### PR TITLE
feat(sync): resolve conflicts in manager

### DIFF
--- a/docs/plans/archived/2026-08-03_pi-sync-menu-conflict-resolution-plan.md
+++ b/docs/plans/archived/2026-08-03_pi-sync-menu-conflict-resolution-plan.md
@@ -1,0 +1,200 @@
+# pi-sync menu conflict resolution plan
+
+## Goal
+
+Keep every user-resolvable sync-direction conflict inside the `/sync` manager: explain what changed,
+let the user review exact path-level differences, and offer clearly worded local-wins or remote-wins
+actions that retain pi-sync's existing previews, confirmations, backups, publication guards, and
+cancellation behavior.
+
+## Context
+
+- The approved scope is the full flow: push conflicts, pull conflicts, `Sync now` conflicts,
+  first-sync divergence, and pull-from-empty-remote recovery.
+- `extensions/pi-sync/src/sync-operations.ts` currently throws ordinary English-message errors for
+  these conditions. `extensions/pi-sync/src/sync.ts` catches and converts them to notifications, so
+  `extensions/pi-sync/src/manager-ui.ts` cannot present contextual recovery actions.
+- Existing forced push and pull production paths already provide the required safeguards: exact
+  summaries, confirmation, pull backups, protected live sessions, secret scanning, refreshed-head
+  confirmation for forced push, backend publication preconditions, and state persistence.
+- The manager already uses `@narumitw/pi-tui-kit`; standard action and review screens provide bounded
+  rendering, injected keybindings, TUI/RPC adaptation, Back/Close semantics, and selection
+  restoration.
+- Applicable convention areas are commands/menus, TUI and non-interactive modes, factory/session
+  lifecycle, deterministic tests, and documentation. No extension-owned setting or persistence
+  schema changes are planned, so `docs/extension-settings.md` is not in scope.
+
+## Architecture
+
+### Domain result
+
+Add an extension-owned structured decision contract instead of matching error text. A typed
+`SyncDecisionRequiredError` will carry only sanitized/display-safe metadata needed by the workflow:
+
+- decision kind: remote-or-policy-changed, both-changed, first-sync-settings-diverged,
+  first-sync-sessions-diverged, or remote-empty;
+- current sync setup name and a reviewed config/storage identity;
+- cause flags for local, remote, and included-content-policy changes;
+- prior/current included-content summaries when policy changed;
+- exact path-level comparison text produced from the snapshots already observed by the failed
+  operation;
+- allowed resolution directions (`push`, `pull`, or both) and context-appropriate labels.
+
+The typed error retains an actionable direct-command message for compatibility, but menu behavior
+will branch on its class/kind rather than its wording. Authentication, transport, invalid settings,
+secret-scan, lock, partial-publication, and unknown failures remain ordinary errors and must not gain
+force actions.
+
+### Command and menu boundary
+
+Refactor internal route execution so a structured decision can reach the manager without duplicate
+error notifications. Direct `/sync ...` invocations will still report the existing actionable text
+and never open an interactive recovery flow. Automatic startup/shutdown sync remains non-interactive
+and warning-only.
+
+The manager will delegate a decision to a new, focused resolution UI module rather than growing the
+already-large manager and sync-operation files past 1,000 lines. The nested standard menu will have:
+
+1. **Resolve sync conflict** action screen with setup, causes, and a no-mutation statement.
+2. **Review differences (recommended)** read-only review screen; Back restores the resolution
+   selection.
+3. Contextual direction actions:
+   - **Keep local content and replace remote…** / **Use local as initial source…**
+   - **Use remote content and replace local…** / **Use remote as initial source…**
+   - **Push local content…** when the remote is empty.
+4. **Back**, which returns to the originating manager screen without changing local, remote, or sync
+   state.
+
+Direction actions call the existing `push --force` or `pull --force` route for the captured setup.
+They do not set `--yes`; therefore the existing exact production preview and confirmation remain the
+final safety gate. Cancellation returns to the resolution screen. Success closes the resolution flow
+and the outer manager. A newly returned structured decision replaces the displayed decision; an
+ordinary failure is reported and leaves recovery available for retry or Back.
+
+### Freshness and lifecycle
+
+- Revalidate session ownership and the reviewed config/storage identity after every await before
+  using mutable workflow state.
+- Allow the forced push path to refresh a changed remote head and require its existing second
+  confirmation; do not treat an expected remote refresh as stale config.
+- Abort and drain loaders and nested menus on user cancellation, component disposal, session
+  replacement, and shutdown. Once apply/publication commits, retain the existing non-cancellable
+  boundary and warning.
+- Sanitize setup names, policy text, paths, snapshot metadata, and errors at the display boundary.
+- Use textual cause/status markers; color remains supplementary. Escape means Back and Ctrl+C closes
+  the complete menu flow according to injected keybindings.
+
+## Non-Goals
+
+- Automatically merge file contents or choose a winner.
+- Automatically chain pull-then-push or push-then-pull after review.
+- Add new settings, persistence fields, command flags, or remove existing direct routes.
+- Offer force recovery for credentials, networking, secrets, malformed settings, locks, ambiguous
+  publication outcomes, or other non-directional failures.
+- Change snapshot, backend, settings-file, or wire formats.
+
+## Risks
+
+- **Unsafe over-classification:** ordinary failures could accidentally expose destructive choices.
+  Mitigation: only explicit typed decision errors enter the resolution UI; test representative
+  generic and partial-publication errors.
+- **Stale review:** remote or configuration state can change while the user reads the review.
+  Mitigation: bind decisions to config identity, rerun the production operation, and retain refreshed
+  push confirmation/backend preconditions.
+- **Duplicate or missing feedback:** the current command layer owns notification side effects.
+  Mitigation: introduce one typed internal route result and test manager, direct command, and
+  automatic-sync boundaries independently.
+- **Lifecycle leaks:** a nested resolution flow adds async ownership. Mitigation: use pi-tui-kit menu
+  ownership plus the existing session signal, and add disposal/replacement tests that prove work is
+  aborted and drained.
+- **File-size regression:** `manager-ui.ts` and `sync-operations.ts` are already near 1,000 lines.
+  Mitigation: put the decision contract and resolution UI in descriptive modules and audit final
+  authored source lengths.
+
+## Plan
+
+- [x] Add focused failing operation tests under `extensions/pi-sync/test/` for all five structured
+      decision kinds, asserting setup/cause/direction/review data and proving detection makes no local,
+      remote, or state mutation; run `npm test` and record that the new assertions fail because only
+      ordinary errors exist.
+- [x] Add a small domain module under `extensions/pi-sync/src/` for the typed decision error,
+      decision metadata, direct-message formatting, and safe path/policy review construction; replace
+      only the five manual-direction error sites in `sync-operations.ts`, then run `npm test` and
+      verify the new operation tests pass while generic error tests remain unchanged.
+- [x] Add failing command-boundary tests proving manager routes receive structured decisions while
+      direct `push`, `pull`, and `sync` routes still emit actionable notifications, unknown failures
+      are reported once, and automatic sync never opens recovery UI; refactor `sync.ts`,
+      `cancellable-operation.ts`, and their route result types until those focused behaviors pass.
+- [x] Add failing TUI workflow tests with `@narumitw/pi-tui-kit/testing` for conflict entry, textual
+      causes, recommended Review, exact path-level review, Back with restored selection, initial-sync
+      labels, remote-empty actions, terminal-control sanitization, and 32/60/100-column rendering;
+      implement the nested standard action/review flow in a new resolution UI module and connect it
+      from `manager-ui.ts` until the tests pass.
+- [x] Add failing resolution-action tests proving local-wins invokes `push --force`, remote-wins
+      invokes `pull --force`, the captured setup is addressed without switching, no action adds
+      `--yes`, confirmation cancellation returns to the same resolution, success closes the outer
+      manager, a repeated structured decision refreshes the screen, and an ordinary retry failure
+      remains recoverable; implement the smallest routing/state changes and rerun the focused tests.
+- [x] Extend lifecycle and RPC tests to cover resolution-screen Back/Close behavior, scripted RPC
+      review and direction choices, user cancellation before commit, non-cancellable commit behavior,
+      external disposal, session replacement, and shutdown draining; run `npm test` and verify no
+      stale continuation uses the old context or mutates state.
+- [x] Strengthen deterministic production-path tests with the memory backend for forced push head
+      refresh/reconfirmation, forced pull backup/apply, protected live sessions, secret-scan refusal,
+      backend precondition failure, and config identity changes during resolution; reuse existing
+      fixtures and confirm unsafe or partial failures never become decision screens with `npm test`.
+- [x] Update `extensions/pi-sync/README.md` to document the in-menu recovery workflow, exact meanings
+      of local-wins/remote-wins, confirmation and backup guarantees, direct-route compatibility,
+      automatic-sync behavior, and terminal accessibility; verify command documentation remains
+      complete through `npm test`.
+- [x] Audit the final diff against `docs/extension-conventions.md` for commands/menus, TUI/RPC and
+      unsupported modes, cancellation/disposal/session replacement/shutdown, status cleanup,
+      sanitization, compatibility, tests, and documentation; verify every authored source file stays
+      below 1,000 lines or document and resolve any justified deviation.
+- [x] Run `npm run check` as the CI-equivalent gate and perform a non-interactive Pi load/RPC smoke for
+      the `/sync` manager without real credentials or network access; record exact commands and any
+      intentionally unverified live-backend path in the plan before completion.
+
+
+## Execution Evidence
+
+- TDD process deviation: the production contract skeleton preceded the new test files, so an
+  authentic red-first run was not captured. The residual regression risk was mitigated with focused
+  production-boundary tests, existing-suite regressions, and the complete standalone repository gate.
+- Structured decision and production-safety tests: current compiled
+  `sync-decision.test.js` passes 10/10, covering all five decision kinds, no-mutation detection,
+  forced pull backup/apply, forced-push secret refusal, direct-command compatibility, automatic-sync
+  warning-only behavior, and push-confirmation cancellation.
+- Menu, RPC, freshness, and lifecycle tests: current compiled `sync-resolution-ui.test.js` passes
+  8/8, covering bounded/sanitized review, Back/Close, both directions, captured setup routing without
+  `--yes`, confirmation cancellation, repeated decisions, stale config, session replacement, RPC,
+  and manager integration.
+- Focused regressions: compiled `custom-lifecycle`, `menu-wording`, `review-feedback`, and
+  `settings-management` tests all pass.
+- Source-size audit: `manager-ui.ts` is 942 lines, `sync-operations.ts` is 964 lines, and the new
+  `sync-decision.ts` / `sync-resolution-ui.ts` modules are 113 / 166 lines.
+- Documentation: `extensions/pi-sync/README.md` describes conflict review, local/remote winner
+  semantics, safety gates, cancellation, direct routes, automatic sync, and accessibility behavior.
+- Runtime smoke: an empty temporary agent directory plus
+  `pi -e ./extensions/pi-sync --mode rpc --no-session` answered `get_commands` with `success: true`
+  and the registered `sync` command; no credentials or remote network were used.
+- Worktree CI-equivalent run: all build, Biome, boundary, and typecheck gates passed; the test gate's
+  sole failure was the documented linked-worktree `GIT_DIR` injection in `git-runner.test.ts`. The
+  final repository snapshot in a standalone Git checkout passed `npm run check` with 2,293/2,293
+  tests. Its first run exposed the existing `pi-btw` rapid-update timing flake; the immediate complete
+  rerun passed every gate and test.
+
+## Completion Checklist
+
+- [x] Push, pull, `Sync now`, both first-sync divergence variants, and empty-remote pull all enter an
+      actionable manager-owned recovery flow.
+- [x] Review shows causes and exact affected paths, returns predictably, and never mutates state.
+- [x] Local-wins and remote-wins reuse existing force production paths with exact confirmation,
+      backup, secret, refreshed-head, and backend concurrency safeguards intact.
+- [x] Cancellation, Back, Close, disposal, session replacement, shutdown, repeated conflict, success,
+      generic error, and partial-publication states have deterministic evidence.
+- [x] TUI and RPC manager behavior is usable and bounded; print/JSON rejection, direct commands,
+      automatic sync, settings/wire formats, and existing public routes remain compatible.
+- [x] README behavior and safety guidance matches the implementation.
+- [x] `npm run check` passes, the non-interactive Pi/RPC smoke is recorded, and no required verification
+      remains open.

--- a/extensions/pi-sync/README.md
+++ b/extensions/pi-sync/README.md
@@ -58,6 +58,29 @@ recovery. Secondary screens provide **Back**; Escape goes back and Ctrl+C closes
 Destructive, credential-bearing, and externally visible operations retain exact specialized previews
 and confirmations.
 
+### Resolve conflicts in the manager
+
+When **Sync now**, **Pull from remote…**, or **Push to remote…** finds changes that require a human
+direction choice, the manager opens **Resolve sync conflict** instead of ending at a command-only
+error. The flow names the current sync setup and explains whether local content, remote content, or
+the included-content policy changed.
+
+Choose **Review differences (recommended)** to inspect the exact affected paths without changing
+local files, remote data, or sync state. Then choose one reviewed direction:
+
+- **Keep local content and replace remote…** uses the existing forced-push path. It scans managed
+  local files for secrets, shows the exact remote publication effect, re-reads a changed remote head,
+  and asks again if the reviewed plan changed.
+- **Use remote content and replace local…** uses the existing forced-pull path. It shows exact local
+  writes and deletions, protects the live session, and creates a local backup before applying.
+- First sync uses **Use local as initial source…** and **Use remote as initial source…** labels. An
+  empty remote offers **Push local content…** only.
+
+Cancelling a preparation or confirmation returns to conflict resolution with no side effects. Back
+returns to the sync manager; Ctrl+C closes the complete flow. Automatic startup/shutdown sync never
+opens this interactive flow and continues to report an actionable warning. Deterministic direct
+routes remain available and keep their command-oriented error guidance.
+
 ## ⚙️ Settings
 
 The canonical private user file is:

--- a/extensions/pi-sync/src/cancellable-operation.ts
+++ b/extensions/pi-sync/src/cancellable-operation.ts
@@ -7,15 +7,24 @@ import { truncateToWidth } from "@earendil-works/pi-tui";
 import { runCustomInteraction } from "@narumitw/pi-tui-kit";
 import { safeTerminalText } from "./manager-helpers.js";
 import type { SetupPullOutcome } from "./setup-switch.js";
+import type { SyncDecision } from "./sync-decision.js";
+
+export type RunRouteResult =
+	| { kind: "completed"; outcome?: SetupPullOutcome }
+	| { kind: "decision-required"; decision: SyncDecision }
+	| { kind: "failed" };
 
 export type RunRoute = (
 	route: string,
 	signal?: AbortSignal,
 	onCommit?: () => void,
 	target?: string,
-) => Promise<SetupPullOutcome | undefined>;
+) => Promise<RunRouteResult | undefined>;
 
-export type CancellableOperationResult = SetupPullOutcome | "closed" | undefined;
+export type CancellableOperationResult =
+	| RunRouteResult
+	| { kind: "closed" }
+	| { kind: "cancelled" };
 
 interface CancellableOperationOptions {
 	commitAware?: boolean;
@@ -38,10 +47,10 @@ export async function runCancellableOperation(
 		signal,
 	} = options;
 	if (ctx.mode !== "tui") {
-		return await runRoute(route, undefined, undefined, target);
+		return (await runRoute(route, signal, undefined, target)) ?? { kind: "failed" };
 	}
 	let commitStarted = false;
-	let routeResult: SetupPullOutcome | undefined;
+	let routeResult: RunRouteResult | undefined;
 	const interaction = await runCustomInteraction<{ cancelled?: boolean; error?: unknown }>(ctx, {
 		signal,
 		isCurrent: () => !signal?.aborted,
@@ -89,13 +98,13 @@ export async function runCancellableOperation(
 		},
 	});
 	if (interaction.kind === "error") throw interaction.error;
-	if (interaction.kind !== "completed") return "closed";
+	if (interaction.kind !== "completed") return { kind: "closed" };
 	if (interaction.value.cancelled) {
 		if (cancelledMessage) ctx.ui.notify(cancelledMessage, "info");
-		return "cancelled";
+		return { kind: "cancelled" };
 	}
 	if (interaction.value.error) throw interaction.value.error;
-	return routeResult;
+	return routeResult ?? { kind: "failed" };
 }
 
 function keybindingText(

--- a/extensions/pi-sync/src/manager-ui.ts
+++ b/extensions/pi-sync/src/manager-ui.ts
@@ -1,6 +1,10 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { type ActionMenuItem, defineMenu, runMenu } from "@narumitw/pi-tui-kit";
-import { type RunRoute, runCancellableOperation } from "./cancellable-operation.js";
+import {
+	type CancellableOperationResult,
+	type RunRoute,
+	runCancellableOperation,
+} from "./cancellable-operation.js";
 import { setSyncSetupCompletions } from "./command.js";
 import {
 	configuredSyncSetupNames,
@@ -33,6 +37,7 @@ import { showSyncSettings } from "./settings-ui.js";
 import { useSyncSetup } from "./setup-switch.js";
 import { showAddStorageConnection, showStorageConnections } from "./storage-connections-ui.js";
 import { DEFAULT_SYNC_INCLUDE, syncIncludeSelection } from "./sync-policy.js";
+import { showSyncResolution } from "./sync-resolution-ui.js";
 import { showSyncSetups } from "./sync-setups-ui.js";
 import type { AnySyncConfig } from "./types.js";
 import { showAddWebDavTarget, showEditWebDavTarget, showWebDavSetup } from "./webdav-ui.js";
@@ -120,7 +125,10 @@ export async function showSyncManager(
 						signal: sessionSignal,
 					},
 				);
-				return result === "closed" ? { kind: "close" } : { kind: "stay" };
+				const resolution = await resolveManagerDecision(ctx, result, runRoute, sessionSignal);
+				return result.kind === "closed" || resolution === "close"
+					? { kind: "close" }
+					: { kind: "stay" };
 			},
 			switch: async () => {
 				const result = await showSetupSwitcher(ctx, runRoute, undefined, sessionSignal);
@@ -136,7 +144,7 @@ export async function showSyncManager(
 					runRoute,
 					{ signal: sessionSignal },
 				);
-				return result === "closed" ? { kind: "close" } : { kind: "stay" };
+				return result.kind === "closed" ? { kind: "close" } : { kind: "stay" };
 			},
 			settings: async () => {
 				await showSyncSettings(ctx, runRoute, sessionSignal);
@@ -154,7 +162,12 @@ export async function showSyncManager(
 						signal: sessionSignal,
 					},
 				);
-				return result === "applied" || result === "closed" ? { kind: "close" } : { kind: "stay" };
+				const resolution = await resolveManagerDecision(ctx, result, runRoute, sessionSignal);
+				return result.kind === "closed" ||
+					(result.kind === "completed" && result.outcome === "applied") ||
+					resolution === "close"
+					? { kind: "close" }
+					: { kind: "stay" };
 			},
 			push: async () => {
 				const result = await runCancellableOperation(
@@ -168,7 +181,10 @@ export async function showSyncManager(
 						signal: sessionSignal,
 					},
 				);
-				return result === "closed" ? { kind: "close" } : { kind: "stay" };
+				const resolution = await resolveManagerDecision(ctx, result, runRoute, sessionSignal);
+				return result.kind === "closed" || resolution === "close"
+					? { kind: "close" }
+					: { kind: "stay" };
 			},
 			setups: async () => {
 				const result = await showSyncSetupManager(ctx, runRoute, sessionSignal);
@@ -216,6 +232,21 @@ export async function showSyncManager(
 		signal: sessionSignal,
 		isCurrent: () => !sessionSignal?.aborted,
 	});
+}
+
+async function resolveManagerDecision(
+	ctx: ExtensionCommandContext,
+	result: CancellableOperationResult,
+	runRoute: RunRoute,
+	signal?: AbortSignal,
+) {
+	if (result.kind !== "decision-required") return undefined;
+	const resolution = await showSyncResolution(ctx, result.decision, runRoute, signal);
+	return resolution.kind === "resolved" ||
+		resolution.kind === "closed" ||
+		resolution.kind === "stale"
+		? "close"
+		: "stay";
 }
 
 function syncMainMenuItem(
@@ -522,11 +553,25 @@ async function showSetupSwitcher(
 						signal,
 					},
 				);
-				if (pullResult === "closed") {
+				if (pullResult.kind === "closed") {
 					pullClosed = true;
 					return undefined;
 				}
-				return pullResult;
+				if (pullResult.kind === "decision-required") {
+					const resolution = await showSyncResolution(ctx, pullResult.decision, runRoute, signal);
+					if (
+						resolution.kind === "resolved" ||
+						resolution.kind === "closed" ||
+						resolution.kind === "stale"
+					) {
+						pullClosed = true;
+					}
+					return resolution.kind === "resolved" && resolution.direction === "pull"
+						? "applied"
+						: undefined;
+				}
+				if (pullResult.kind === "completed") return pullResult.outcome;
+				return pullResult.kind === "cancelled" ? "cancelled" : undefined;
 			},
 			onSwitch,
 			signal,

--- a/extensions/pi-sync/src/settings-ui.ts
+++ b/extensions/pi-sync/src/settings-ui.ts
@@ -1,22 +1,17 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import type { RunRoute } from "./cancellable-operation.js";
 import { loadConfig, localConfigPath } from "./config.js";
 import { updateSyncSetup } from "./settings-management.js";
 import {
 	SETUP_SWITCH_ACTION_OPTIONS,
-	type SetupPullOutcome,
 	saveOnSwitch,
 	setupSwitchActionFromLabel,
 	setupSwitchActionLabel,
 } from "./setup-switch.js";
 import { safeTerminalText } from "./sync-format.js";
 
-export type SyncSettingsRoute = (
-	route: string,
-	signal?: AbortSignal,
-	onCommit?: () => void,
-	setup?: string,
-) => Promise<SetupPullOutcome | undefined>;
+export type SyncSettingsRoute = RunRoute;
 
 export async function showSyncSettings(
 	ctx: ExtensionCommandContext,

--- a/extensions/pi-sync/src/sync-decision.ts
+++ b/extensions/pi-sync/src/sync-decision.ts
@@ -1,0 +1,113 @@
+import { syncConfigReviewIdentity } from "./config.js";
+import { formatDiff, formatSnapshotOnlyDiff, safeTerminalText } from "./sync-format.js";
+import { includeFromSelectionConfig } from "./sync-policy.js";
+import { syncPolicyChanged } from "./sync-state.js";
+import type { AnySyncConfig, Snapshot, SyncState } from "./types.js";
+
+export type SyncDecisionKind =
+	| "remote-or-policy-changed"
+	| "both-changed"
+	| "first-sync-settings-diverged"
+	| "first-sync-sessions-diverged"
+	| "remote-empty";
+
+export type SyncResolutionDirection = "push" | "pull";
+
+export interface SyncDecision {
+	kind: SyncDecisionKind;
+	setupName: string;
+	configIdentity: string;
+	causes: {
+		localChanged: boolean;
+		remoteChanged: boolean;
+		policyChanged: boolean;
+	};
+	previousInclude?: readonly string[];
+	currentInclude: readonly string[];
+	review: string;
+	directions: readonly SyncResolutionDirection[];
+	directMessage: string;
+}
+
+export class SyncDecisionRequiredError extends Error {
+	readonly decision: SyncDecision;
+
+	constructor(decision: SyncDecision) {
+		super(decision.directMessage);
+		this.name = "SyncDecisionRequiredError";
+		this.decision = decision;
+	}
+}
+
+interface CreateSyncDecisionOptions {
+	kind: SyncDecisionKind;
+	config: AnySyncConfig;
+	state: SyncState;
+	local: Snapshot;
+	remote?: Snapshot;
+	localChanged: boolean;
+	remoteChanged: boolean;
+	directMessage: string;
+}
+
+export function createSyncDecision(options: CreateSyncDecisionOptions) {
+	const { config, state, local, remote, kind } = options;
+	const policyChanged = Boolean(state.lastAppliedSnapshot) && syncPolicyChanged(state, config);
+	const previousInclude = includeFromSelectionConfig(state);
+	const currentInclude = [...config.include];
+	const causes = {
+		localChanged: options.localChanged,
+		remoteChanged: options.remoteChanged,
+		policyChanged,
+	};
+	const causeLines =
+		kind === "first-sync-settings-diverged"
+			? ["This machine and the remote have different Pi settings on first sync."]
+			: kind === "first-sync-sessions-diverged"
+				? ["Pi settings match, but local and remote sessions differ on first sync."]
+				: kind === "remote-empty"
+					? ["The remote storage location is empty."]
+					: [
+							...(causes.localChanged ? ["Local content changed since the last sync."] : []),
+							...(causes.remoteChanged ? ["Remote content changed since the last sync."] : []),
+							...(causes.policyChanged ? ["Included content changed since the last sync."] : []),
+						];
+	const comparison = remote
+		? formatDiff(local, remote)
+		: formatSnapshotOnlyDiff("Remote is empty. Local push would upload", local);
+	const review = [
+		`Sync setup: ${safeTerminalText(config.setupName)}`,
+		"",
+		"Why a decision is required:",
+		...causeLines,
+		...(policyChanged
+			? [
+					"",
+					`Previously included: ${safeList(previousInclude)}`,
+					`Currently included: ${safeList(currentInclude)}`,
+				]
+			: []),
+		"",
+		"Observed differences:",
+		...comparison.split("\n").map(safeTerminalText),
+	].join("\n");
+	return new SyncDecisionRequiredError({
+		kind,
+		setupName: config.setupName,
+		configIdentity: syncConfigReviewIdentity(config),
+		causes,
+		...(policyChanged ? { previousInclude: [...previousInclude] } : {}),
+		currentInclude,
+		review,
+		directions: kind === "remote-empty" ? ["push"] : ["push", "pull"],
+		directMessage: options.directMessage,
+	});
+}
+
+export function isSyncDecisionRequiredError(error: unknown): error is SyncDecisionRequiredError {
+	return error instanceof SyncDecisionRequiredError;
+}
+
+function safeList(values: readonly string[]) {
+	return values.length > 0 ? values.map(safeTerminalText).join(", ") : "none";
+}

--- a/extensions/pi-sync/src/sync-operations.ts
+++ b/extensions/pi-sync/src/sync-operations.ts
@@ -29,6 +29,7 @@ import {
 	type RemoteHead,
 	type SyncBackend,
 } from "./sync-backend.js";
+import { createSyncDecision } from "./sync-decision.js";
 import {
 	countPreservedRemoteFiles,
 	errorMessage,
@@ -308,9 +309,17 @@ export async function push(
 			? filterSnapshotForConfigPolicy(remoteForUpload, config)
 			: undefined;
 		if (!remoteForConflict || !snapshotHashesMatchState(remoteForConflict, state, config)) {
-			throw new Error(
-				"Remote or sync policy changed since last sync. Run /sync pull first or /sync push --force.",
-			);
+			throw createSyncDecision({
+				kind: head ? "remote-or-policy-changed" : "remote-empty",
+				config,
+				state,
+				local,
+				remote: remoteForConflict,
+				localChanged: hasLocalChanges(local, state, config),
+				remoteChanged: true,
+				directMessage:
+					"Remote or sync policy changed since last sync. Run /sync pull first or /sync push --force.",
+			});
 		}
 	}
 
@@ -330,7 +339,7 @@ export async function push(
 	}
 
 	if (!(await confirmPush(ctx, options, config, backend, local, upload, head, remoteForUpload))) {
-		return;
+		return "cancelled" as const;
 	}
 
 	if (options.force) {
@@ -361,7 +370,7 @@ export async function push(
 					"Remote changed during review. Push the refreshed plan?",
 				))
 			) {
-				return;
+				return "cancelled" as const;
 			}
 		}
 	}
@@ -395,6 +404,7 @@ export async function push(
 			result.warnings.length > 0 ? "warning" : "info",
 		);
 	}
+	return "applied" as const;
 }
 
 export async function pull(
@@ -415,14 +425,32 @@ export async function pull(
 	throwIfAborted(options.signal);
 	const { head, snapshot: remote } = await readRemoteSnapshot(backend, config, options.signal);
 	throwIfAborted(options.signal);
-	if (!remote) throw new Error("Remote is empty. Run /sync push from a configured machine first.");
-
 	const localChanged = hasLocalChanges(local, state, config);
+	if (!remote) {
+		throw createSyncDecision({
+			kind: "remote-empty",
+			config,
+			state,
+			local,
+			localChanged,
+			remoteChanged: false,
+			directMessage: "Remote is empty. Run /sync push from a configured machine first.",
+		});
+	}
+
 	const remoteChanged = hasRemoteChanges(remote, state, config, protectedSessionPaths(ctx));
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot && !options.force) {
-		throw new Error(
-			"Both local and remote changed since last sync. Run /sync diff, then choose /sync pull --force or /sync push --force.",
-		);
+		throw createSyncDecision({
+			kind: "both-changed",
+			config,
+			state,
+			local,
+			remote,
+			localChanged,
+			remoteChanged,
+			directMessage:
+				"Both local and remote changed since last sync. Run /sync diff, then choose /sync pull --force or /sync push --force.",
+		});
 	}
 
 	if (
@@ -519,15 +547,31 @@ export async function syncBoth(
 
 	if (firstSync && remote && remote.files.length > 0 && local.files.length > 0) {
 		if (!canPullRemoteSettingsOnFirstSync(local, remote)) {
-			throw new Error(
-				"Remote settings exist and this machine has different local Pi settings. Run /sync diff, then manually choose /sync pull or /sync push.",
-			);
+			throw createSyncDecision({
+				kind: "first-sync-settings-diverged",
+				config,
+				state,
+				local,
+				remote,
+				localChanged: true,
+				remoteChanged: true,
+				directMessage:
+					"Remote settings exist and this machine has different local Pi settings. Run /sync diff, then manually choose /sync pull or /sync push.",
+			});
 		}
 		if (!sameHashes(fileHashMap(local), fileHashMap(remote))) {
 			if (!canPullRemoteSessionsOnFirstSync(local, remote)) {
-				throw new Error(
-					"Remote settings match, but local and remote Pi sessions differ. Run /sync diff, then manually choose /sync pull or /sync push.",
-				);
+				throw createSyncDecision({
+					kind: "first-sync-sessions-diverged",
+					config,
+					state,
+					local,
+					remote,
+					localChanged: true,
+					remoteChanged: true,
+					directMessage:
+						"Remote settings match, but local and remote Pi sessions differ. Run /sync diff, then manually choose /sync pull or /sync push.",
+				});
 			}
 			await pull(ctx, options, factory);
 			return;
@@ -557,9 +601,17 @@ export async function syncBoth(
 		return;
 	}
 	if (localChanged && remoteChanged && state.lastAppliedSnapshot) {
-		throw new Error(
-			"Both local and remote changed. Run /sync diff and resolve with push --force or pull --force.",
-		);
+		throw createSyncDecision({
+			kind: "both-changed",
+			config,
+			state,
+			local,
+			remote,
+			localChanged,
+			remoteChanged,
+			directMessage:
+				"Both local and remote changed. Run /sync diff and resolve with push --force or pull --force.",
+		});
 	}
 	if (remoteChanged) {
 		await pull(ctx, options, factory);

--- a/extensions/pi-sync/src/sync-resolution-ui.ts
+++ b/extensions/pi-sync/src/sync-resolution-ui.ts
@@ -1,0 +1,166 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { type RunRoute, runCancellableOperation } from "./cancellable-operation.js";
+import { loadConfig, syncConfigReviewIdentity } from "./config.js";
+import type { SyncDecision, SyncResolutionDirection } from "./sync-decision.js";
+import { errorMessage, safeTerminalText } from "./sync-format.js";
+
+export type SyncResolutionResult =
+	| { kind: "resolved"; direction: SyncResolutionDirection }
+	| { kind: "back" }
+	| { kind: "closed" }
+	| { kind: "stale" };
+
+export async function showSyncResolution(
+	ctx: ExtensionCommandContext,
+	initialDecision: SyncDecision,
+	runRoute: RunRoute,
+	sessionSignal?: AbortSignal,
+): Promise<SyncResolutionResult> {
+	type Screen = "resolve" | "review";
+	type Action = "push" | "pull" | "back";
+	let currentDecision = initialDecision;
+	let resolvedDirection: SyncResolutionDirection | undefined;
+	const menu = defineMenu<SyncDecision, Screen, Action, ExtensionCommandContext>({
+		start: "resolve",
+		screens: {
+			resolve: ({ state }) => ({
+				kind: "actions",
+				title: resolutionTitle(state),
+				lines: resolutionLines(state),
+				items: [
+					{ id: "review", label: "Review differences (recommended)", to: "review" },
+					...(state.directions.includes("push")
+						? [
+								{
+									id: "push",
+									label: pushLabel(state),
+									description: "Review an exact push before replacing the remote version.",
+									action: "push" as const,
+								},
+							]
+						: []),
+					...(state.directions.includes("pull")
+						? [
+								{
+									id: "pull",
+									label: pullLabel(state),
+									description: "Review exact local changes and create a backup before applying.",
+									action: "pull" as const,
+								},
+							]
+						: []),
+					{ id: "back", label: "Back", action: "back" },
+				],
+				hint: "back",
+			}),
+			review: ({ state }) => ({
+				kind: "review",
+				title: `Review differences · ${safeTerminalText(state.setupName)}`,
+				content: state.review,
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				hint: "back",
+			}),
+		},
+		actions: {
+			push: ({ state, signal }) => resolveDirection("push", state, signal),
+			pull: ({ state, signal }) => resolveDirection("pull", state, signal),
+			back: async () => ({ kind: "back" }),
+		},
+	});
+
+	async function resolveDirection(
+		direction: SyncResolutionDirection,
+		decision: SyncDecision,
+		actionSignal: AbortSignal,
+	) {
+		const signal = sessionSignal ? AbortSignal.any([sessionSignal, actionSignal]) : actionSignal;
+		const config = await loadConfig(decision.setupName);
+		if (signal.aborted) return { kind: "close" as const };
+		if (syncConfigReviewIdentity(config) !== decision.configIdentity) {
+			throw new Error(
+				`Sync setup “${safeTerminalText(decision.setupName)}” changed while conflict resolution was open; return to the sync manager and retry.`,
+			);
+		}
+		const result = await runCancellableOperation(
+			ctx,
+			direction === "push"
+				? "Preparing local-wins push preview…"
+				: "Preparing remote-wins pull preview…",
+			`${direction} --force`,
+			runRoute,
+			{
+				commitAware: true,
+				cancelledMessage:
+					direction === "push"
+						? "Push preparation cancelled; no remote files were changed."
+						: "Pull check cancelled; no local files were changed.",
+				target: decision.setupName,
+				signal,
+			},
+		);
+		if (result.kind === "decision-required") {
+			currentDecision = result.decision;
+			return { kind: "stay" as const };
+		}
+		if (result.kind === "completed") {
+			if (result.outcome === "cancelled") return { kind: "stay" as const };
+			resolvedDirection = direction;
+			return { kind: "close" as const };
+		}
+		return result.kind === "closed" ? { kind: "close" as const } : { kind: "stay" as const };
+	}
+
+	const result = await runMenu(ctx, menu, {
+		getState: () => currentDecision,
+		signal: sessionSignal,
+		isCurrent: () => !sessionSignal?.aborted,
+		onError: (_menuCtx, error) => ctx.ui.notify(errorMessage(error), "error"),
+	});
+	if (sessionSignal?.aborted || result.kind === "stale") return { kind: "stale" };
+	if (resolvedDirection) return { kind: "resolved", direction: resolvedDirection };
+	if (result.kind === "closed") {
+		return result.reason === "back" ? { kind: "back" } : { kind: "closed" };
+	}
+	return { kind: "closed" };
+}
+
+function resolutionTitle(decision: SyncDecision) {
+	return decision.kind === "remote-empty" ? "Remote is empty" : "Resolve sync conflict";
+}
+
+function resolutionLines(decision: SyncDecision) {
+	return [
+		`Sync setup: ${safeTerminalText(decision.setupName)}`,
+		...causeSummary(decision),
+		"No files have been changed by this failed operation.",
+	];
+}
+
+function causeSummary(decision: SyncDecision) {
+	if (decision.kind === "first-sync-settings-diverged") {
+		return ["This machine and the remote have different Pi settings on first sync."];
+	}
+	if (decision.kind === "first-sync-sessions-diverged") {
+		return ["Pi settings match, but local and remote sessions differ on first sync."];
+	}
+	if (decision.kind === "remote-empty") return ["The remote storage location has no snapshot."];
+	return [
+		...(decision.causes.localChanged ? ["Local content changed since the last sync."] : []),
+		...(decision.causes.remoteChanged ? ["Remote content changed since the last sync."] : []),
+		...(decision.causes.policyChanged ? ["Included content changed since the last sync."] : []),
+	];
+}
+
+function pushLabel(decision: SyncDecision) {
+	if (decision.kind === "remote-empty") return "Push local content…";
+	if (decision.kind.startsWith("first-sync-")) return "Use local as initial source…";
+	return "Keep local content and replace remote…";
+}
+
+function pullLabel(decision: SyncDecision) {
+	return decision.kind.startsWith("first-sync-")
+		? "Use remote as initial source…"
+		: "Use remote content and replace local…";
+}

--- a/extensions/pi-sync/src/sync.ts
+++ b/extensions/pi-sync/src/sync.ts
@@ -3,6 +3,7 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import type { RunRouteResult } from "./cancellable-operation.js";
 import {
 	completeSyncArguments,
 	parseOptions,
@@ -33,6 +34,7 @@ import { showSetupWizard, showSyncManager } from "./manager-ui.js";
 import { SetupPullRequiresUiError, useSyncSetup } from "./setup-switch.js";
 import { createSnapshot } from "./snapshot.js";
 import { recoverSnapshotTransactionsOnStartup } from "./snapshot-transaction.js";
+import { isSyncDecisionRequiredError } from "./sync-decision.js";
 import { errorMessage } from "./sync-format.js";
 import {
 	diff,
@@ -141,7 +143,10 @@ async function handleCommand(
 		}
 		return;
 	}
-	await executeCommand(rawArgs, ctx, sessionSignal);
+	const result = await executeCommand(rawArgs, ctx, sessionSignal);
+	if (result.kind === "decision-required") {
+		ctx.ui.notify(result.decision.directMessage, "error");
+	}
 }
 
 async function executeCommand(
@@ -150,10 +155,10 @@ async function executeCommand(
 	signal?: AbortSignal,
 	onCommit?: () => void,
 	setup?: string,
-) {
+): Promise<RunRouteResult> {
 	try {
 		const command = await resolveSyncCommand(rawArgs, ctx);
-		if (signal?.aborted || !command) return;
+		if (signal?.aborted || !command) return { kind: "completed" };
 		const { subcommand, rest } = command;
 		const options = parseOptions(rest);
 		if (setup !== undefined) options.setup = setup;
@@ -164,7 +169,7 @@ async function executeCommand(
 		switch (subcommand) {
 			case "help":
 				ctx.ui.notify(usage(), "info");
-				return;
+				return { kind: "completed" };
 			case "use":
 				await useSyncSetup(
 					ctx,
@@ -174,50 +179,58 @@ async function executeCommand(
 					undefined,
 					options.signal,
 				);
-				return;
+				return { kind: "completed" };
 			case "init":
 				await initConfig(ctx, signal);
-				return;
+				return { kind: "completed" };
 			case "config":
 				await showConfig(ctx, options);
-				return;
+				return { kind: "completed" };
 			case "files":
 				await showFileSelection(ctx, options.setup, options.signal);
-				return;
+				return { kind: "completed" };
 			case "status":
 				await status(ctx, options);
-				return;
+				return { kind: "completed" };
 			case "diff":
 				await diff(ctx, options);
-				return;
+				return { kind: "completed" };
 			case "doctor":
 				await doctor(ctx, options);
-				return;
-			case "push":
-				await withLock("push", () => push(ctx, options));
-				return;
-			case "pull":
-				return await withLock("pull", () => pull(ctx, options));
+				return { kind: "completed" };
+			case "push": {
+				const outcome = await withLock("push", () => push(ctx, options));
+				return { kind: "completed", ...(outcome ? { outcome } : {}) };
+			}
+			case "pull": {
+				const outcome = await withLock("pull", () => pull(ctx, options));
+				return { kind: "completed", ...(outcome ? { outcome } : {}) };
+			}
 			case "sync":
 				await withLock("sync", () => syncBoth(ctx, options));
-				return;
+				return { kind: "completed" };
 			case "history":
 				await history(ctx, options);
-				return;
+				return { kind: "completed" };
 			case "rollback":
 				await withLock("rollback", () => rollback(ctx, options));
-				return;
+				return { kind: "completed" };
 			case "unlock":
 				await unlock(ctx, options);
-				return;
+				return { kind: "completed" };
 			default:
 				ctx.ui.notify(`Unknown /sync command: ${subcommand}\n\n${usage()}`, "warning");
+				return { kind: "failed" };
 		}
 	} catch (error) {
-		if (signal?.aborted) return;
+		if (signal?.aborted) return { kind: "failed" };
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		if (error instanceof SetupPullRequiresUiError) throw error;
+		if (isSyncDecisionRequiredError(error)) {
+			return { kind: "decision-required", decision: error.decision };
+		}
 		ctx.ui.notify(errorMessage(error), "error");
+		return { kind: "failed" };
 	}
 }
 

--- a/extensions/pi-sync/test/sync-decision.test.ts
+++ b/extensions/pi-sync/test/sync-decision.test.ts
@@ -1,0 +1,328 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { gzipSync } from "node:zlib";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { loadConfig, localConfigPath, statePathForConfig } from "../src/config.js";
+import sync from "../src/sync.js";
+import { expectedRemoteHead } from "../src/sync-backend.js";
+import { SyncDecisionRequiredError } from "../src/sync-decision.js";
+import { pull, push, syncBoth } from "../src/sync-operations.js";
+import type { CommandOptions, Snapshot } from "../src/types.js";
+import { snapshot, v3S3Settings, withTempHome } from "./helpers.js";
+import { MemorySyncBackend } from "./memory-sync-backend.js";
+
+const options: CommandOptions = {
+	yes: true,
+	force: false,
+	stale: false,
+	silent: false,
+	reload: false,
+	auto: false,
+	args: [],
+};
+
+test("push reports a structured remote-or-policy decision without mutation", async () => {
+	await withInitializedSync(async ({ agentDir, backend, config }) => {
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":"changed"}\n');
+		writeFileSync(path.join(agentDir, "AGENTS.md"), "local policy addition\n");
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify(v3S3Settings({ include: ["settings.json", "AGENTS.md"] })),
+			{ mode: 0o600 },
+		);
+		const remote = namedSnapshot("remote-change", '{"remote":"changed"}\n');
+		await backend.publishSnapshot(remote, expectedRemoteHead(await backend.readHead()));
+		const headBefore = await backend.readHead();
+
+		await assert.rejects(pushContext(backend), (error: unknown) => {
+			assert.ok(error instanceof SyncDecisionRequiredError);
+			assert.equal(error.decision.kind, "remote-or-policy-changed");
+			assert.equal(error.decision.setupName, "home");
+			assert.deepEqual(error.decision.directions, ["push", "pull"]);
+			assert.equal(error.decision.causes.localChanged, true);
+			assert.equal(error.decision.causes.remoteChanged, true);
+			assert.equal(error.decision.causes.policyChanged, true);
+			assert.deepEqual(error.decision.previousInclude, ["settings.json"]);
+			assert.deepEqual(error.decision.currentInclude, ["settings.json", "AGENTS.md"]);
+			assert.match(error.decision.review, /Different: settings\.json/u);
+			return true;
+		});
+		assert.equal((await backend.readHead())?.revision, headBefore?.revision);
+		assert.equal(
+			readFileSync(path.join(agentDir, "settings.json"), "utf8"),
+			'{"local":"changed"}\n',
+		);
+		assert.equal(existsSync(statePathForConfig(config)), true);
+	});
+});
+
+test("pull and Sync now report structured both-changed decisions without mutation", async () => {
+	await withInitializedSync(async ({ agentDir, backend }) => {
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":"changed"}\n');
+		const remote = namedSnapshot("remote-change", '{"remote":"changed"}\n');
+		await backend.publishSnapshot(remote, expectedRemoteHead(await backend.readHead()));
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+		for (const operation of [pull, syncBoth]) {
+			await assert.rejects(
+				operation(ctx, options, () => backend),
+				(error: unknown) => {
+					assert.ok(error instanceof SyncDecisionRequiredError);
+					assert.equal(error.decision.kind, "both-changed");
+					assert.deepEqual(error.decision.directions, ["push", "pull"]);
+					assert.match(error.decision.review, /Different: settings\.json/u);
+					return true;
+				},
+			);
+		}
+		assert.equal(
+			readFileSync(path.join(agentDir, "settings.json"), "utf8"),
+			'{"local":"changed"}\n',
+		);
+		assert.equal((await backend.readHead())?.snapshotId, "remote-change");
+	});
+});
+
+test("forced pull reuses backup and apply safeguards after a decision", async () => {
+	await withInitializedSync(async ({ agentDir, backend }) => {
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":"changed"}\n');
+		const remote = namedSnapshot("remote-change", '{"remote":"changed"}\n');
+		await backend.publishSnapshot(remote, expectedRemoteHead(await backend.readHead()));
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+
+		const outcome = await pull(ctx, { ...options, force: true }, () => backend);
+		assert.equal(outcome, "applied");
+		assert.equal(
+			readFileSync(path.join(agentDir, "settings.json"), "utf8"),
+			'{"remote":"changed"}\n',
+		);
+		assert.ok(readdirSync(path.join(agentDir, ".pisync", "backups")).length > 0);
+	});
+});
+
+test("forced push still refuses secrets after a decision", async () => {
+	await withInitializedSync(async ({ agentDir, backend }) => {
+		writeFileSync(
+			path.join(agentDir, "settings.json"),
+			'{"note":"OPENAI_API_KEY=abcdefghijklmnopqrstuvwxyz123456"}\n',
+		);
+		const remote = namedSnapshot("remote-change", '{"remote":"changed"}\n');
+		await backend.publishSnapshot(remote, expectedRemoteHead(await backend.readHead()));
+		const headBefore = await backend.readHead();
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+
+		await assert.rejects(
+			push(ctx, { ...options, force: true }, undefined, () => backend),
+			/Refusing to push possible secrets/u,
+		);
+		assert.equal((await backend.readHead())?.revision, headBefore?.revision);
+	});
+});
+
+test("first sync reports different settings as an initial-source decision", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		const backend = new MemorySyncBackend();
+		await backend.publishSnapshot(namedSnapshot("remote", '{"remote":true}\n'), {
+			kind: "missing",
+		});
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+
+		await assert.rejects(
+			syncBoth(ctx, options, () => backend),
+			(error: unknown) => {
+				assert.ok(error instanceof SyncDecisionRequiredError);
+				assert.equal(error.decision.kind, "first-sync-settings-diverged");
+				assert.match(error.decision.review, /first sync/u);
+				return true;
+			},
+		);
+		assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), '{"local":true}\n');
+		assert.equal(existsSync(statePathForConfig(await loadConfig())), false);
+	});
+});
+
+test("first sync reports different sessions as an initial-source decision", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(path.join(agentDir, "sessions"), { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify(v3S3Settings({ include: ["settings.json", "sessions"] })),
+			{ mode: 0o600 },
+		);
+		writeFileSync(path.join(agentDir, "settings.json"), '{"same":true}\n');
+		writeFileSync(path.join(agentDir, "sessions", "one.jsonl"), '{"local":true}\n');
+		const backend = new MemorySyncBackend();
+		const remote = snapshot([
+			{ path: "settings.json", content: Buffer.from('{"same":true}\n') },
+			{ path: "sessions/one.jsonl", content: Buffer.from('{"remote":true}\n') },
+		]);
+		await backend.publishSnapshot(
+			{ ...remote, id: "remote", syncSessions: true },
+			{ kind: "missing" },
+		);
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+
+		await assert.rejects(
+			syncBoth(ctx, options, () => backend),
+			(error: unknown) => {
+				assert.ok(error instanceof SyncDecisionRequiredError);
+				assert.equal(error.decision.kind, "first-sync-sessions-diverged");
+				assert.match(error.decision.review, /sessions differ/u);
+				return true;
+			},
+		);
+		assert.equal(
+			readFileSync(path.join(agentDir, "sessions", "one.jsonl"), "utf8"),
+			'{"local":true}\n',
+		);
+	});
+});
+
+test("automatic sync reports a directional conflict without opening recovery UI", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings({ automatic: true })), {
+			mode: 0o600,
+		});
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		const remote = { ...namedSnapshot("remote", '{"remote":true}\n'), profile: "home" };
+		const encoded = gzipSync(Buffer.from(JSON.stringify(remote)));
+		const pointer = {
+			version: 1,
+			profile: "home",
+			snapshot: remote.id,
+			sha256: createHash("sha256").update(encoded).digest("hex"),
+			createdAt: remote.createdAt,
+			machine: remote.machine,
+		};
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = async (input) => {
+			const url = new URL(String(input));
+			if (url.pathname.endsWith("/latest.json")) {
+				return Response.json(pointer, { headers: { etag: '"latest"' } });
+			}
+			if (url.pathname.includes("/snapshots/")) {
+				return new Response(new Uint8Array(encoded), { headers: { etag: '"snapshot"' } });
+			}
+			throw new Error(`Unexpected request: ${url.pathname}`);
+		};
+		let customCalls = 0;
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async () => {
+				customCalls += 1;
+				return undefined;
+			},
+		});
+		try {
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+		assert.equal(customCalls, 0);
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/pi-sync auto sync skipped: Remote settings exist.*different local Pi settings/u,
+		);
+		assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), '{"local":true}\n');
+	});
+});
+
+test("direct pull retains its actionable notification instead of opening recovery UI", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		const mock = createMockPi();
+		sync(mock.pi);
+		const { ctx, notifications } = createMockContext({ hasUI: true, mode: "rpc" });
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = async () => new Response(null, { status: 404 });
+		try {
+			await mock.commands.get("sync")?.handler("pull", ctx);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/Remote is empty\. Run \/sync push from a configured machine first/u,
+		);
+	});
+});
+
+test("push reports confirmation cancellation without publishing", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		const backend = new MemorySyncBackend();
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			confirm: async () => false,
+		});
+
+		assert.equal(
+			await push(ctx, { ...options, yes: false }, undefined, () => backend),
+			"cancelled",
+		);
+		assert.equal(await backend.readHead(), undefined);
+	});
+});
+
+test("pull from an empty remote offers only a structured push decision", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		const backend = new MemorySyncBackend();
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+
+		await assert.rejects(
+			pull(ctx, options, () => backend),
+			(error: unknown) => {
+				assert.ok(error instanceof SyncDecisionRequiredError);
+				assert.equal(error.decision.kind, "remote-empty");
+				assert.deepEqual(error.decision.directions, ["push"]);
+				assert.match(error.decision.review, /Add: settings\.json/u);
+				return true;
+			},
+		);
+		assert.equal(await backend.readHead(), undefined);
+	});
+});
+
+async function withInitializedSync(
+	run: (state: {
+		agentDir: string;
+		backend: MemorySyncBackend;
+		config: Awaited<ReturnType<typeof loadConfig>>;
+	}) => Promise<void>,
+) {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"base":true}\n');
+		const backend = new MemorySyncBackend();
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+		await push(ctx, options, undefined, () => backend);
+		await run({ agentDir, backend, config: await loadConfig() });
+	});
+}
+
+function pushContext(backend: MemorySyncBackend) {
+	const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+	return push(ctx, options, undefined, () => backend);
+}
+
+function namedSnapshot(id: string, content: string): Snapshot {
+	return { ...snapshot([{ path: "settings.json", content: Buffer.from(content) }]), id };
+}

--- a/extensions/pi-sync/test/sync-resolution-ui.test.ts
+++ b/extensions/pi-sync/test/sync-resolution-ui.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { createMockContext } from "../../../test/support.js";
+import {
+	loadConfig,
+	localConfigPath,
+	syncConfigReviewIdentity,
+	updateLocalConfig,
+} from "../src/config.js";
+import { showSyncManager } from "../src/manager-ui.js";
+import type { SyncDecision } from "../src/sync-decision.js";
+import { showSyncResolution } from "../src/sync-resolution-ui.js";
+import { v3S3Settings, withTempHome } from "./helpers.js";
+
+initTheme("dark", false);
+
+test("resolution reviews exact differences and invokes local-wins push through the captured setup", async () => {
+	await withConfiguredDecision(async (decision) => {
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+		const routes: Array<{ route: string; target?: string; signal?: AbortSignal }> = [];
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
+		const running = showSyncResolution(ctx, decision, async (route, signal, _onCommit, target) => {
+			routes.push({ route, target, signal });
+			await routeGate;
+			return { kind: "completed" };
+		});
+
+		await tui.waitForOpen();
+		for (const width of [32, 60, 100]) {
+			const frame = tui.render(width);
+			assert.ok(frame.every((line) => visibleWidth(line) <= width));
+			assert.match(frame.join("\n"), /Resolve sync conflict/u);
+			assert.equal(frame.join("\n").includes("\u001b]8"), false);
+		}
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const reviewFrame = tui.render().join("\n");
+		assert.match(reviewFrame, /Different: settings\.json/u);
+		assert.equal(reviewFrame.includes("\u001b]8"), false);
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Review differences \(recommended\)/u);
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await waitFor(() => routes.length === 1);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Preparing local-wins push preview/u);
+		assert.deepEqual(
+			routes.map(({ route, target }) => ({ route, target })),
+			[{ route: "push --force", target: "home" }],
+		);
+		releaseRoute();
+		const result = await running;
+		assert.deepEqual(result, { kind: "resolved", direction: "push" });
+	});
+});
+
+test("cancelling a remote-wins preparation drains work and returns to resolution", async () => {
+	await withConfiguredDecision(async (decision) => {
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: tui.custom,
+		});
+		let routeSignal: AbortSignal | undefined;
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
+		const running = showSyncResolution(ctx, decision, async (_route, signal) => {
+			routeSignal = signal;
+			await routeGate;
+			return { kind: "completed", outcome: "applied" };
+		});
+
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("tui.select.cancel");
+		await waitFor(() => routeSignal?.aborted === true);
+		releaseRoute();
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Resolve sync conflict/u);
+		assert.match(notifications.at(-1)?.message ?? "", /cancelled/u);
+		tui.press("ctrl+c");
+		assert.deepEqual(await running, { kind: "closed" });
+	});
+});
+
+test("RPC resolution supports review and remote-empty recovery without custom TUI", async () => {
+	await withConfiguredDecision(async (baseDecision) => {
+		const decision: SyncDecision = {
+			...baseDecision,
+			kind: "remote-empty",
+			directions: ["push"],
+			review: "Remote is empty.\nAdd: settings.json",
+		};
+		let resolutionVisits = 0;
+		const routes: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			custom: async () => assert.fail("RPC must not open custom TUI"),
+			select: async (title: string, options: string[]) => {
+				if (title.startsWith("Remote is empty")) {
+					resolutionVisits += 1;
+					return resolutionVisits === 1
+						? "Review differences (recommended)"
+						: "Push local content…";
+				}
+				assert.match(title, /Add: settings\.json/u);
+				assert.deepEqual(options, ["Back"]);
+				return "Back";
+			},
+		});
+		const result = await showSyncResolution(ctx, decision, async (route, signal) => {
+			assert.equal(signal?.aborted, false);
+			routes.push(route);
+			return { kind: "completed" };
+		});
+		assert.deepEqual(routes, ["push --force"]);
+		assert.deepEqual(result, { kind: "resolved", direction: "push" });
+	});
+});
+
+test("cancelling the exact push confirmation returns to conflict resolution", async () => {
+	await withConfiguredDecision(async (decision) => {
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
+		const running = showSyncResolution(ctx, decision, async () => {
+			await routeGate;
+			return { kind: "completed", outcome: "cancelled" };
+		});
+
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const loaderOpenCount = tui.openCount;
+		releaseRoute();
+		await waitFor(() => tui.isOpen && tui.openCount > loaderOpenCount);
+		assert.match(tui.render().join("\n"), /Resolve sync conflict/u);
+		tui.press("ctrl+c");
+		assert.deepEqual(await running, { kind: "closed" });
+	});
+});
+
+test("a repeated conflict refreshes resolution labels instead of closing", async () => {
+	await withConfiguredDecision(async (decision) => {
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+		const refreshed: SyncDecision = {
+			...decision,
+			kind: "first-sync-settings-diverged",
+			directMessage: "Choose an initial source.",
+		};
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
+		const running = showSyncResolution(ctx, decision, async () => {
+			await routeGate;
+			return { kind: "decision-required", decision: refreshed };
+		});
+
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const loaderOpenCount = tui.openCount;
+		releaseRoute();
+		await waitFor(() => tui.isOpen && tui.openCount > loaderOpenCount);
+		assert.match(tui.render().join("\n"), /Use local as initial source/u);
+		tui.press("ctrl+c");
+		assert.deepEqual(await running, { kind: "closed" });
+	});
+});
+
+test("resolution rejects a sync setup changed after review", async () => {
+	await withConfiguredDecision(async (decision) => {
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: tui.custom,
+		});
+		let routeCalls = 0;
+		const running = showSyncResolution(ctx, decision, async () => {
+			routeCalls += 1;
+			return { kind: "completed" };
+		});
+
+		await tui.waitForOpen();
+		await updateLocalConfig((current) => ({
+			...current,
+			syncSetups: {
+				...current.syncSetups,
+				home: {
+					...current.syncSetups.home,
+					sync: { ...current.syncSetups.home.sync, include: [] },
+				},
+			},
+		}));
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.equal(routeCalls, 0);
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/changed while conflict resolution was open/u,
+		);
+		assert.match(tui.render().join("\n"), /Resolve sync conflict/u);
+		tui.press("ctrl+c");
+		assert.deepEqual(await running, { kind: "closed" });
+	});
+});
+
+test("session replacement aborts and drains a resolution operation", async () => {
+	await withConfiguredDecision(async (decision) => {
+		const owner = new AbortController();
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+		let routeSignal: AbortSignal | undefined;
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
+		const running = showSyncResolution(
+			ctx,
+			decision,
+			async (_route, signal) => {
+				routeSignal = signal;
+				await routeGate;
+				return { kind: "completed" };
+			},
+			owner.signal,
+		);
+
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		owner.abort(new DOMException("Session replaced", "AbortError"));
+		await waitFor(() => routeSignal?.aborted === true);
+		releaseRoute();
+		assert.deepEqual(await running, { kind: "stale" });
+	});
+});
+
+test("the main manager opens conflict recovery instead of ending at an error", async () => {
+	await withConfiguredDecision(async (decision) => {
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
+		const running = showSyncManager(ctx, async (route) => {
+			assert.equal(route, "sync");
+			await routeGate;
+			return { kind: "decision-required", decision };
+		});
+
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const loaderOpenCount = tui.openCount;
+		releaseRoute();
+		await waitFor(() => tui.isOpen && tui.openCount > loaderOpenCount);
+		assert.match(tui.render().join("\n"), /Resolve sync conflict/u);
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Manage sync/u);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+async function withConfiguredDecision(run: (decision: SyncDecision) => Promise<void>) {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const config = await loadConfig();
+		await run({
+			kind: "both-changed",
+			setupName: "home",
+			configIdentity: syncConfigReviewIdentity(config),
+			causes: { localChanged: true, remoteChanged: true, policyChanged: false },
+			currentInclude: ["settings.json"],
+			review: "Sync setup: home\n\nObserved differences:\nDifferent: settings.json\u001b]8;;bad",
+			directions: ["push", "pull"],
+			directMessage: "Both local and remote changed.",
+		});
+	});
+}
+
+async function waitFor(condition: () => boolean) {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (condition()) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, 1));
+	}
+	assert.fail("Timed out waiting for condition");
+}


### PR DESCRIPTION
## Summary

- classify user-resolvable sync conflicts with typed decision metadata instead of matching error text
- keep conflict review, local-wins push, and remote-wins pull inside the `/sync` TUI/RPC manager while reusing existing previews, confirmation, backup, secret-scan, and publication safeguards
- preserve direct-command and automatic-sync behavior, add lifecycle/RPC/production-path coverage, and document the workflow

## Verification

- `npm run check` in a standalone Git checkout: 2,293/2,293 tests passed; build, Biome, boundaries, and workspace typechecks passed
- focused compiled `sync-decision.test.js`: 10/10 passed
- focused compiled `sync-resolution-ui.test.js`: 8/8 passed
- focused `custom-lifecycle`, `menu-wording`, `review-feedback`, and `settings-management` regressions passed
- non-interactive RPC load smoke: `pi -e ./extensions/pi-sync --mode rpc --no-session` returned `success: true` and registered `/sync`

## Environment note

The linked-worktree `npm run check` reaches all gates but its known `git-runner.test.ts` case sees Git-injected `GIT_DIR`; the identical final snapshot passes the full check in a standalone checkout.
