### PR TITLE
feat(plan-mode): configure handoff and export defaults

### DIFF
--- a/docs/plans/archived/2026-08-03_plan-mode-handoff-export-defaults-plan.md
+++ b/docs/plans/archived/2026-08-03_plan-mode-handoff-export-defaults-plan.md
@@ -1,0 +1,96 @@
+# Plan mode handoff and export defaults plan
+
+## Goal
+
+Let users choose how long an accepted plan continues guiding implementation and configure the default
+Plan export destination. Keep the current retained-plan behavior and `PLAN.md` export destination as
+backward-compatible defaults.
+
+## Context
+
+- The approved Settings redesign keeps four goal-oriented rows on one level: **Plan thinking**,
+  **Plan tools**, **After Implement**, and **Export destination**.
+- **After Implement** offers **Keep plan active**, **Use plan for handoff only**, and **Clear after
+  first implementation run**. The Implement menu previews the effective result before the user
+  confirms it.
+- **Export destination** is used only when an export omits its path. Explicit `/plan export <path>`
+  input remains authoritative, and export never overwrites an existing target.
+- Settings saves are immediate and atomic. Retention changes apply to the next Implement action;
+  export-destination changes apply to the next export.
+- `extensions/pi-plan-mode/src/plan-mode.ts` is already near the 1,000-line boundary, so lifecycle
+  work must move into a responsibility-focused module rather than growing that file.
+
+## Architecture
+
+- Extend `PlanModeSettings` with `implementationPlanRetention` and optional
+  `defaultPlanExportPath`. Missing fields resolve to `keep` and `PLAN.md`; resetting the export
+  destination removes its override.
+- Capture the effective retention policy in each active implementation state. Legacy retained state
+  without the field restores as `keep`, and later global Settings changes cannot alter an existing
+  implementation.
+- Add an implementation-retention coordinator outside `plan-mode.ts` that binds cleanup to one
+  implementation ID and lifecycle phase. **Use plan for handoff only** must preserve the complete
+  plan through the first implementation context assembly before clearing retained status/context.
+  **Clear after first implementation run** clears only after that implementation's fully settled run,
+  not after an older queued run settles.
+- Resolve an omitted export path from Settings at action time against the current `ctx.cwd`. Pass the
+  same effective default and resolved preview through ready, saved, and active menus instead of
+  duplicating `PLAN.md` placeholders.
+- Keep the Settings screen flat. The retention row uses three user-facing result labels; the export
+  row opens one input screen that shows the configured and currently resolved destination. Empty
+  submission resets to `PLAN.md`; Escape returns without saving.
+
+## Non-Goals
+
+- No automatic export on Implement, project-scoped setting, environment-variable override,
+  `/plan settings` route, overwrite option, or change to explicit export-path precedence.
+- No retroactive retention-policy change for an implementation already in progress.
+- No basic/advanced Settings sections or extra confirmation dialog after the outcome is previewed in
+  the Implement menu.
+
+## Risks
+
+- Clearing retained state too early can cause the context hook to remove the only implementation
+  handoff. The lifecycle contract must prove that the first implementation request still contains the
+  complete plan.
+- A queued implementation can overlap settlement from an older run. Cleanup must be armed by the
+  matching implementation run and guarded by implementation ID, session generation, replacement,
+  and supersession.
+- Relative export defaults vary by working directory. Every export screen must show the current
+  resolved preview, and notifications must report the actual written path.
+- Long or control-bearing path text can corrupt or overflow terminal output. Validation,
+  sanitization, wrapping, truncation detail, and raw action identity require separate tests.
+
+## Rollback / Recovery
+
+- Omitting both new fields restores the exact current behavior, so reverting runtime/UI support does
+  not require a data migration. Unknown fields remain preserved by older-compatible writes.
+- Failed settings publication keeps the previous displayed, in-memory, and on-disk values. Failed
+  implementation delivery restores the previous ready or saved state and never performs automatic
+  cleanup. Failed or cancelled export keeps plan state and the existing target unchanged.
+- `/plan exit` remains the explicit recovery route for any retained active implementation.
+
+## Plan
+
+- [x] Verify Pi's implementation-request event ordering and encode the first-context/settled-run contract in focused lifecycle tests; evidence: Pi 0.83.0 documents `context` before each LLM call and `agent_settled` after retries/compaction/queues, and the new lifecycle suite first failed before retention support, then passed exact-handoff and older-settlement guards.
+- [x] Add failing settings tests for both new fields, missing-field defaults, strict enum/path validation, reset semantics, latest-document patching, legacy canonical promotion, unknown-field preservation, abort, atomic failure, and ordered concurrent saves; evidence: the first compile failed on the absent exports, fields, and patch surface before implementation.
+- [x] Implement the settings schema and persistence patches in `extensions/pi-plan-mode/src/settings.ts`, preserving side-effect-free reads and existing concurrency guarantees; evidence: 12 focused settings tests passed, including three repeated deterministic concurrency runs.
+- [x] Add failing Settings-menu tests for the four flat goal-oriented rows, three retention outcomes, export-path input and resolved preview, empty reset, Escape cancellation, cursor/focus restoration, rollback, invalid read-only state, RPC adaptation, terminal controls, long paths, and narrow widths; evidence: focused tests failed against the old two-row screen before implementation.
+- [x] Implement the approved flat Settings experience in `extensions/pi-plan-mode/src/settings-menu.ts`, with immediate atomic feedback and no retroactive change to current implementation state; evidence: 9 TUI/RPC Settings tests passed, including active-state capture and immediate next-export integration.
+- [x] Add failing implementation-flow tests for effective-policy previews and the `keep`, handoff-only, and first-run policies across ready and saved plans, send failure, busy queued handoff, retries/settlement, resume, fork, compaction, session replacement, supersession, and manual `/plan exit`; evidence: preview and lifecycle tests failed before menu/coordinator integration, then passed alongside existing send-failure, fork, compaction, and replacement suites.
+- [x] Extract a responsibility-focused implementation-retention coordinator and integrate captured per-implementation policy into state restore, context transformation, status cleanup, and Implement menus; evidence: `implementation-retention.ts` owns matching/arming and all active source files are at or below 1,000 lines (`plan-mode.ts`: 992).
+- [x] Add failing export tests proving configured defaults across ready, saved, and active plans in TUI, RPC, print, and JSON modes, including explicit-path precedence, relative/absolute resolution, `@` compatibility, empty reset, existing file/directory/symlink refusal, cancellation, long/control-bearing display, and consistent placeholders/previews; evidence: three configured-default export tests failed before settings-aware routing, then passed with the existing refusal/cancellation matrix.
+- [x] Implement one settings-aware export-default resolver and thread its effective path/preview through direct routes and all export menus without changing overwrite or ready-plan exit semantics; evidence: `plan-export-controller.ts` and shared `plan-export-screen.ts` drive direct and menu paths, with 18 export tests passing.
+- [x] Update `extensions/pi-plan-mode/README.md` with user-facing labels, defaults, application timing, JSON values, resolved-path behavior, retention/compaction trade-offs, explicit-route precedence, failure recovery, and supported modes; evidence: README behavior and JSON values match focused tests and the RPC smoke.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`, including command modes, settings concurrency, lifecycle revalidation after every await, context ownership, cancellation/disposal/replacement/shutdown, path safety, and the source-file size boundary; evidence: no product deviation accepted, no package metadata changed, and a separate deterministic gate-fixture fix removed a pre-existing 5 ms timing race in `pi-btw` tests.
+
+## Completion Checklist
+
+- [x] Focused settings, Settings-menu, implementation lifecycle, restore/compaction, export, command-mode, and responsive TUI/RPC tests pass without timing-based waits (160 focused tests).
+- [x] Missing new fields preserve `keep` plus `PLAN.md`, legacy sessions restore safely, unknown settings fields survive every save, and current active implementations ignore later global retention changes (focused settings and retention tests).
+- [x] Every active source file is at or below 1,000 lines (`plan-mode.ts` is 992; no justification needed).
+- [x] `npm test` passes (2,309/2,309 tests).
+- [x] `npm run check` passes (Biome, boundaries, workspace typechecks, and 2,309 tests).
+- [x] `just pack plan-mode` succeeds; inspected 27 files including README and all new `src` modules.
+- [x] A real non-interactive RPC smoke verified the four Settings rows, handoff-only preview, `smoke/PLAN.md` resolution, and active-plan cleanup under isolated temporary agent/session directories.
+- [x] Every task and completion check has evidence; archive destination was checked before moving this file to `docs/plans/archived/`.

--- a/extensions/pi-btw/test/settings.test.ts
+++ b/extensions/pi-btw/test/settings.test.ts
@@ -177,21 +177,27 @@ test("btw settings atomic publication failure preserves the previous document", 
 
 test("btw settings serialize rapid updates in invocation order and recover after failure", async () => {
 	await withTempSettings(async (settingsPath) => {
-		let releaseFirst: (() => void) | undefined;
+		let releaseFirst!: () => void;
+		let markFirstReached!: () => void;
+		const firstReached = new Promise<void>((resolve) => {
+			markFirstReached = resolve;
+		});
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
 		const first = updateBtwSettings(
 			{ thinkingLevel: "low" },
 			{
 				settingsPath,
-				beforeRename: () =>
-					new Promise<void>((resolve) => {
-						releaseFirst = resolve;
-					}),
+				beforeRename: async () => {
+					markFirstReached();
+					await firstGate;
+				},
 			},
 		);
 		const second = updateBtwSettings({ thinkingLevel: "medium" }, { settingsPath });
 		const coordinatedRead = readBtwSettings(settingsPath);
-		await new Promise((resolve) => setTimeout(resolve, 5));
-		assert.ok(releaseFirst);
+		await firstReached;
 		releaseFirst();
 		await Promise.all([first, second]);
 		assert.deepEqual(await coordinatedRead, {

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -16,7 +16,8 @@ Pi core intentionally does not ship a built-in plan mode; this package provides 
 - Injects Codex-like Plan mode instructions: explore first, ask decision questions for high-impact ambiguity, do not mutate files, and finalize only when decision-complete.
 - Adds required `plan_mode_question` and `plan_mode_complete` tools for structured questions and completion.
 - Presents the complete plan and prompts you to implement, export it to a chosen Markdown file, save it for later, stay in Plan mode, or exit and discard it.
-- Exports ready, saved, or active implementation plans with `/plan export [path]` without overwriting existing paths; exporting a ready plan completes and exits Plan mode.
+- Exports ready, saved, or active implementation plans with `/plan export [path]` without overwriting existing paths; the omitted-path destination is configurable, and exporting a ready plan completes and exits Plan mode.
+- Lets each accepted plan remain active, serve only as the first implementation handoff, or clear after the first implementation run; the current retained-plan behavior remains the default.
 - Keeps legacy `<proposed_plan>` responses compatible without advertising XML as the primary workflow.
 - Shows Plan mode state in Pi's statusline as `plan active`, `plan ready`, `plan saved`, or `plan implementing`; `@narumitw/pi-statusline` adds the default `📝` icon unless configured otherwise.
 - Persists Plan mode, one session-local saved plan, and active implementation state so resume and compaction retain the exact accepted plan.
@@ -87,9 +88,11 @@ export also leaves Plan mode; saved and active implementation exports retain the
 `show`, `save`, `export`, and `implement` fail closed when no applicable plan is stored; `finalize`
 requires active Plan mode.
 
-`/plan export` creates `PLAN.md` in Pi's current working directory. Supply a path to choose another
-location; relative paths resolve from that directory, absolute paths remain absolute, and missing
-parent directories are created. Export never overwrites an existing file, directory, or symbolic
+`/plan export` uses the configured **Export destination**, which defaults to `PLAN.md`. Supply a path
+to override that default for one export. Relative paths resolve from the command's current `ctx.cwd`
+at export time, absolute paths remain absolute, a leading `@` is accepted for Pi path compatibility,
+and missing parent directories are created. Explicit `/plan export <path>` input always wins over the
+setting. Export never overwrites an existing file, directory, or symbolic
 link: choose another path or remove the existing target first. A successful export adds one trailing
 newline but otherwise preserves the accepted Markdown exactly. After a ready plan is written, Plan
 mode ends, its tools and thinking level are restored, and the ready state is cleared without starting
@@ -99,8 +102,9 @@ through its normal file-reading tools. Export is an explicit user-requested file
 model-initiated Plan-mode writes remain blocked.
 
 In TUI and RPC, **Export plan…** opens a single-line path input from every ready, saved, or active
-plan menu. Submit an empty value to use `PLAN.md`, or enter a relative or absolute custom path. A
-failed TUI export retains the draft for correction; RPC reopens its input dialog. Escape returns to
+plan menu. The input shows both the configured value and its currently resolved path. Submit an empty
+value to use the configured destination, or enter a relative or absolute one-off path. A failed TUI
+export retains the draft for correction; RPC reopens its input dialog. Escape returns to
 the owning menu without writing a file. A successful ready-plan export closes the menu and ends Plan
 mode; saved and active implementation menus close without changing their stored state.
 
@@ -122,7 +126,7 @@ A complete Plan mode answer should appear only after the agent has resolved disc
 
 Legacy sessions and models may still submit one non-empty `<proposed_plan>` block with tags on their own lines. That compatibility path remains accepted, but it is not the primary workflow. Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and produce a warning.
 
-After completion, `/plan` opens the ready actions when interactive UI is available. Choosing implementation—or running `/plan implement`—disables Plan mode, restores full tool access, and starts an implementation turn with the stored plan. Choosing **Export plan…** asks for a destination, writes the plan, restores normal tools and thinking, and leaves Plan mode without starting a model turn. Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session before leaving Plan mode.
+After completion, `/plan` opens the ready actions when interactive UI is available. Before confirmation, every Implement menu previews how long the plan will remain active. Choosing implementation—or running `/plan implement`—disables Plan mode, restores full tool access, captures the current **After Implement** policy on that implementation, and starts an implementation turn with the stored plan. Choosing **Export plan…** asks for a destination, writes the plan, restores normal tools and thinking, and leaves Plan mode without starting a model turn. Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session before leaving Plan mode.
 
 A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session. It does not expire automatically, cross into a new session, or participate in ordinary model context. Open `/plan` to Show, Implement, Export, open Settings, or Clear it; `/plan show`, `/plan implement`, `/plan export [path]`, and `/plan exit`/`off` provide the same direct routes in TUI and RPC. Implementation checks the selected model and authentication before consuming the saved plan. Starting another workflow with `/plan start`, `/plan <prompt>`, or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten. Resuming that session with `--plan` moves the saved plan back to ready Plan mode. Cancellation or failed implementation preflight leaves it unchanged.
 
@@ -137,16 +141,16 @@ These modes reject saved-plan display and implementation before changing state b
 neither printable custom-message output nor acknowledged extension-triggered turns; resume the
 session in TUI or RPC to show or implement it.
 
-Once implemented, the exact accepted plan remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary. Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away. This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed.
+With the default **Keep plan active** policy, the exact accepted plan remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary. Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away. This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed. **Use plan for handoff only** clears retained state immediately after the first implementation request receives the complete plan. **Clear after first implementation run** keeps the plan through that run, including retries, compaction retries, and queued continuation, then clears it at `agent_settled`. Cleanup is bound to the matching implementation, so an older run settling cannot clear a newer handoff.
 
-While implementation is active, `/plan show` displays the accepted plan. Interactive `/plan` offers Show, Export plan…, Settings, Start a new plan, and Clear; `/plan exit` and `/plan off` are the direct clear routes. Starting a new Plan-mode workflow or implementing a replacement plan supersedes the previous active plan. The extension deliberately does not infer completion from assistant prose or agent settlement, so clear the active plan when the implementation no longer applies. Choosing Stay before implementation keeps the plan ready. Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives. For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable. Before saving or implementation, exit/off discards the ready plan and removes its completion result from later non-Plan model context.
+While implementation is active, `/plan show` displays the accepted plan. Interactive `/plan` offers Show, Export plan…, Settings, Start a new plan, and Clear; `/plan exit` and `/plan off` are the direct clear routes. Settings changes never alter the policy already captured by the active implementation. Automatic cleanup has the same observable result as clearing: its active status and future injected plan context disappear, while the implementation request that triggered cleanup still receives the complete plan. Starting a new Plan-mode workflow or implementing a replacement plan supersedes the previous active plan. The extension deliberately does not infer completion from assistant prose or agent settlement, so clear the active plan when the implementation no longer applies. Choosing Stay before implementation keeps the plan ready. Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives. For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable. Before saving or implementation, exit/off discards the ready plan and removes its completion result from later non-Plan model context.
 
 While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines. With `@narumitw/pi-statusline`, this appears in the extension status area:
 
 - `plan active`: Plan mode is enabled and still gathering context or drafting a plan.
 - `plan ready`: A completed plan is stored until you implement it, export it, save it, continue planning, or exit Plan mode.
 - `plan saved`: One completed plan is stored outside model context in the current session until you implement or clear it.
-- `plan implementing`: The exact accepted plan remains active until you clear or supersede it.
+- `plan implementing`: The exact accepted plan is currently retained under its captured **After Implement** policy.
 
 You can also exit directly. Before implementation, direct exit discards the latest proposed plan; while a plan is saved, it clears that saved plan. During implementation, it removes both the original implementation handoff and the extension's canonical active-plan block from later model calls; an earlier Pi-generated compaction summary may still describe prior work:
 
@@ -156,12 +160,14 @@ You can also exit directly. Before implementation, direct exit discards the late
 
 ## ⚙️ Settings
 
-Open **Settings** from an inactive `/plan` menu to edit the global default tools and Plan thinking level. You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually; `safeSubcommands` remains JSON-only. The file is optional, is read at session start, and is created only after an explicit Settings save or manual edit.
+Open **Settings** from an inactive `/plan` menu to edit one flat group of four workflow choices: **Plan thinking**, **Plan tools**, **After Implement**, and **Export destination**. You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually; `safeSubcommands` remains JSON-only. The file is optional, is read at session start, and is created only after an explicit Settings save or manual edit.
 
 ```json
 {
   "thinkingLevel": "inherit",
   "defaultPlanTools": ["read", "bash", "grep", "find", "ls"],
+  "implementationPlanRetention": "keep",
+  "defaultPlanExportPath": "PLAN.md",
   "safeSubcommands": {
     "git": ["status", "log", "rev-parse", "blame"],
     "gh": ["pr view", "pr list", "issue view", "issue list"]
@@ -176,6 +182,18 @@ Open **Settings** from an inactive `/plan` menu to edit the global default tools
 Tool names must be non-empty strings; duplicates are removed in first-seen order. Unknown, unavailable, and Plan-mode-blocked names are ignored when tools are activated. Settings retains configured unavailable names and shows them as unavailable; resetting to automatic removes the entire override. A tool registered after Plan mode is already active is not added automatically; exit and start a new Plan workflow to apply another set. Non-built-in tools named in this global setting are an explicit user-risk opt-in, just like selecting them in the pre-start workflow selector. Plan mode does not interpret their arguments or actions: enabling one trusts the whole effective tool. Pi resolves tools by name, so if an extension overrides a built-in name, the effective extension tool is selected instead. An effective tool named `bash` remains subject to the limited-shell policy regardless of its source metadata.
 
 A selection accepted through **Choose tools, then start…** or `/plan tools` is stored in that Pi session and takes precedence over `defaultPlanTools` when the session resumes. The global setting remains the baseline for fresh sessions and sessions without an explicit selection. Settings saves immediately, but the saved tools and thinking level apply only when a later Plan workflow starts; they never mutate a workflow already in progress.
+
+### After Implement
+
+`implementationPlanRetention` controls the result of the next Implement action. Omit it or use `keep` for **Keep plan active**, the backward-compatible behavior that retains and reinjects the exact plan until `/plan exit` or supersession. Use `clear-on-start` for **Use plan for handoff only**: the first matching implementation request receives the complete plan, then retained state clears before later requests. Use `clear-after-first-run` to retain the plan until that implementation's first fully settled run ends. A resumed cleanup policy re-arms against the first context in the replacement session. Failed handoff delivery restores the ready or saved plan and does not run automatic cleanup.
+
+Changing this setting applies to the next Implement action only. Each active implementation stores its effective policy, so a later Settings save cannot shorten or extend an implementation already in progress. `/plan exit` remains available under every policy.
+
+### Export destination
+
+`defaultPlanExportPath` controls only exports that omit a path. Omit it—or submit an empty value in Settings—to use `PLAN.md`. The value must be a non-empty string of at most 4,096 characters without terminal control characters or NUL. Relative values are resolved against the current working directory at export time; the Settings detail and every export input preview the concrete resolved destination. An explicit `/plan export <path>` is a one-off override and does not edit Settings. Saving a new destination affects the next export immediately, including export of a currently active implementation.
+
+The existing no-overwrite, cancellation, and atomic Plan-state behavior is unchanged. A failed save rolls the row back to its previous value; a failed or cancelled export preserves the plan and target. Long previews wrap or truncate to the available terminal width without changing the raw path used by the action.
 
 ### Safe shell subcommands
 
@@ -224,7 +242,7 @@ Plan mode inherits Pi's current thinking level by default. Set `thinkingLevel` t
 
 Settings saves are serialized in invocation order inside one Pi process. Each save re-reads the latest valid document, preserves unknown top-level fields and unedited `safeSubcommands`, then publishes through a same-directory temporary file and rename. A missing file stays absent until an explicit save. Invalid JSON, invalid values, oversized content, non-regular files, and read failures make Settings read-only; the existing bytes and previous effective settings remain. This in-process queue is not a cross-process lock, so concurrent separate Pi processes can still race.
 
-Invalid settings produce a warning and fall back to inherited thinking plus the available safe-built-in tool defaults. Compatibility: a valid legacy `plan-mode.json` remains readable with a warning and is never modified automatically. If Settings is explicitly saved while only that legacy file exists, the extension creates canonical `pi-plan-mode.json` from the complete legacy document, applies the selected change, preserves unknown fields, and leaves the legacy file untouched. If both files exist, the canonical filename takes precedence.
+Invalid settings produce a warning and fall back to inherited thinking, available safe-built-in tool defaults, `keep`, and `PLAN.md`. Compatibility: a valid legacy `plan-mode.json` remains readable with a warning and is never modified automatically. If Settings is explicitly saved while only that legacy file exists, the extension creates canonical `pi-plan-mode.json` from the complete legacy document, applies the selected change, preserves unknown fields, and leaves the legacy file untouched. If both files exist, the canonical filename takes precedence.
 
 ## 🧠 Codex-like behavior
 
@@ -235,7 +253,7 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 - The agent should use `plan_mode_question` for important non-discoverable preferences or tradeoffs before finalizing.
 - The agent completes with a standalone `plan_mode_complete` tool call instead of relying on semantic prose detection.
 - `update_plan` checklist use is blocked while Plan mode is active.
-- The implementation boundary is explicit: Plan mode restores tools before saving or starting implementation, saving keeps the plan outside ordinary model context, choosing implementation immediately triggers a normal agent turn with full tool access, and the accepted plan remains active across compaction until exit/off or a replacement workflow clears it.
+- The implementation boundary is explicit: Plan mode restores tools before saving or starting implementation, saving keeps the plan outside ordinary model context, choosing implementation immediately triggers a normal agent turn with full tool access, and the accepted plan follows the captured `keep`, `clear-on-start`, or `clear-after-first-run` lifecycle.
 - Pi extension safety is approximated with tool classification and fail-closed filtering for every effective tool named `bash`; other non-built-in tools remain user-selected at user risk because Pi does not expose standardized tool mutability metadata.
 - Unlike native Codex, this extension uses a terminating Pi tool plus an `agent_settled` ready flow; Pi cannot provide sandbox-level enforcement.
 

--- a/extensions/pi-plan-mode/src/active-implementation-menu.ts
+++ b/extensions/pi-plan-mode/src/active-implementation-menu.ts
@@ -1,8 +1,10 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { type PlanExportDestinationProvider, planExportInputScreen } from "./plan-export-screen.js";
 
 interface ActiveImplementationMenuOptions {
 	statusText: string;
+	getExportDestination: PlanExportDestinationProvider;
 	signal: AbortSignal;
 	isCurrent(): boolean;
 	show(): void;
@@ -34,14 +36,7 @@ export async function showActiveImplementationMenu(
 				],
 				hint: "close",
 			}),
-			export: () => ({
-				kind: "input",
-				title: "Export plan",
-				lines: ["Existing paths are never overwritten."],
-				placeholder: "PLAN.md",
-				action: "export",
-				hint: "back",
-			}),
+			export: () => planExportInputScreen(options.getExportDestination),
 		},
 		actions: {
 			show: async () => {

--- a/extensions/pi-plan-mode/src/implementation-retention.ts
+++ b/extensions/pi-plan-mode/src/implementation-retention.ts
@@ -1,0 +1,122 @@
+import {
+	injectActiveImplementationContext,
+	isEmptyAssistantMessage,
+	messageContainsExactPlanModeImplementationHandoff,
+	messageContainsInactivePlanModeArtifact,
+	messageContainsLegacyPlanModeContextArtifact,
+	messageContainsPlanModeImplementationContextArtifact,
+	messageContainsPlanModeImplementationHandoff,
+	stripPlanModeCompletionCallsFromMessage,
+	stripProposedPlanBlocksFromMessage,
+} from "./message-transform.js";
+import type { ImplementationPlanRetention } from "./settings.js";
+import type { ActiveImplementationPlan, PlanModeState } from "./state.js";
+
+export function retentionLabel(retention: ImplementationPlanRetention) {
+	return {
+		keep: "Keep plan active",
+		"clear-on-start": "Use plan for handoff only",
+		"clear-after-first-run": "Clear after first implementation run",
+	}[retention];
+}
+
+export function implementationRetentionPreview(retention: ImplementationPlanRetention) {
+	return {
+		keep: "After Implement: Keep plan active until /plan exit.",
+		"clear-on-start":
+			"After Implement: Use the plan for the implementation handoff only, then clear it.",
+		"clear-after-first-run": "After Implement: Clear after the first implementation run settles.",
+	}[retention];
+}
+
+export interface ImplementationContextResult {
+	messages: unknown[];
+	clearActiveImplementationId?: string;
+}
+
+export interface ImplementationRetentionCoordinator {
+	restore(activeImplementation: ActiveImplementationPlan | undefined): void;
+	transformContext(messages: unknown[], state: PlanModeState): ImplementationContextResult;
+	implementationSettled(
+		activeImplementation: ActiveImplementationPlan | undefined,
+	): string | undefined;
+	reset(): void;
+}
+
+export function createImplementationRetentionCoordinator(): ImplementationRetentionCoordinator {
+	let implementationWithDeliveredContext: string | undefined;
+	let restoredImplementationAwaitingContext: string | undefined;
+
+	return {
+		restore(activeImplementation) {
+			restoredImplementationAwaitingContext =
+				activeImplementation && activeImplementation.retention !== "keep"
+					? activeImplementation.id
+					: undefined;
+		},
+		transformContext(messages, state) {
+			const messagesWithoutPlanContext = messages.filter(
+				(message) =>
+					!messageContainsLegacyPlanModeContextArtifact(message) &&
+					!messageContainsPlanModeImplementationContextArtifact(message),
+			);
+			if (state.enabled) {
+				return {
+					messages: messagesWithoutPlanContext.filter(
+						(message) => !messageContainsPlanModeImplementationHandoff(message),
+					),
+				};
+			}
+
+			const activeImplementation = state.activeImplementation;
+			const inactiveMessages = activeImplementation
+				? messagesWithoutPlanContext
+				: messagesWithoutPlanContext.filter(
+						(message) => !messageContainsPlanModeImplementationHandoff(message),
+					);
+			const filteredMessages = inactiveMessages
+				.filter((message) => !messageContainsInactivePlanModeArtifact(message))
+				.map(stripProposedPlanBlocksFromMessage)
+				.map(stripPlanModeCompletionCallsFromMessage)
+				.filter((message) => !isEmptyAssistantMessage(message));
+			if (!activeImplementation) return { messages: filteredMessages };
+
+			const contextualMessages = injectActiveImplementationContext(
+				filteredMessages,
+				activeImplementation,
+			);
+			// A busy /plan implement queues its handoff behind an older run. Do not arm cleanup
+			// until that exact handoff reaches context; a restored session has no older run to drain.
+			const deliveredCurrentHandoff =
+				restoredImplementationAwaitingContext === activeImplementation.id ||
+				filteredMessages.some((message) =>
+					messageContainsExactPlanModeImplementationHandoff(message, activeImplementation.plan),
+				);
+			if (!deliveredCurrentHandoff) return { messages: contextualMessages };
+			restoredImplementationAwaitingContext = undefined;
+
+			if (activeImplementation.retention === "clear-after-first-run") {
+				implementationWithDeliveredContext = activeImplementation.id;
+			}
+			return {
+				messages: contextualMessages,
+				clearActiveImplementationId:
+					activeImplementation.retention === "clear-on-start" ? activeImplementation.id : undefined,
+			};
+		},
+		implementationSettled(activeImplementation) {
+			if (
+				activeImplementation?.retention !== "clear-after-first-run" ||
+				implementationWithDeliveredContext !== activeImplementation.id
+			) {
+				return undefined;
+			}
+			implementationWithDeliveredContext = undefined;
+			return activeImplementation.id;
+		},
+		reset() {
+			implementationWithDeliveredContext = undefined;
+			restoredImplementationAwaitingContext = undefined;
+		},
+	};
+}

--- a/extensions/pi-plan-mode/src/message-transform.ts
+++ b/extensions/pi-plan-mode/src/message-transform.ts
@@ -128,7 +128,7 @@ export function messageContainsPlanModeImplementationHandoff(message: unknown) {
 	);
 }
 
-function messageContainsExactPlanModeImplementationHandoff(message: unknown, plan: string) {
+export function messageContainsExactPlanModeImplementationHandoff(message: unknown, plan: string) {
 	const candidate = unwrapSessionMessage(message);
 	if (candidate.role !== "user") return false;
 	return (

--- a/extensions/pi-plan-mode/src/plan-action-menus.ts
+++ b/extensions/pi-plan-mode/src/plan-action-menus.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { type PlanExportDestinationProvider, planExportInputScreen } from "./plan-export-screen.js";
 
 interface MenuLifecycle {
 	signal: AbortSignal;
@@ -9,6 +10,8 @@ interface MenuLifecycle {
 interface PlanMenuOptions extends MenuLifecycle {
 	statusText: string;
 	hasReadyPlan: boolean;
+	implementationOutcome(): string;
+	getExportDestination: PlanExportDestinationProvider;
 	show(): void;
 	finalize(): void;
 	implement(): void | Promise<void>;
@@ -27,7 +30,10 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 			main: () => ({
 				kind: "actions",
 				title: "Plan mode",
-				lines: [options.statusText],
+				lines: [
+					options.statusText,
+					...(options.hasReadyPlan ? [options.implementationOutcome()] : []),
+				],
 				items: options.hasReadyPlan
 					? [
 							{ id: "show", label: "Show latest proposed plan", action: "show" },
@@ -44,14 +50,7 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 						],
 				hint: "close",
 			}),
-			export: () => ({
-				kind: "input",
-				title: "Export plan",
-				lines: ["Existing paths are never overwritten."],
-				placeholder: "PLAN.md",
-				action: "export",
-				hint: "back",
-			}),
+			export: () => planExportInputScreen(options.getExportDestination),
 		},
 		actions: {
 			show: async () => {
@@ -90,6 +89,8 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 }
 
 interface ReadyPlanMenuOptions extends MenuLifecycle {
+	implementationOutcome(): string;
+	getExportDestination: PlanExportDestinationProvider;
 	implement(): void | Promise<void>;
 	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	save(): void;
@@ -106,6 +107,7 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 			ready: () => ({
 				kind: "actions",
 				title: "Proposed plan ready. What next?",
+				lines: [options.implementationOutcome()],
 				items: [
 					{ id: "implement", label: "Implement this plan", action: "implement" },
 					{ id: "export", label: "Export plan…", to: "export" },
@@ -115,14 +117,7 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 				],
 				hint: "close",
 			}),
-			export: () => ({
-				kind: "input",
-				title: "Export plan",
-				lines: ["Existing paths are never overwritten."],
-				placeholder: "PLAN.md",
-				action: "export",
-				hint: "back",
-			}),
+			export: () => planExportInputScreen(options.getExportDestination),
 		},
 		actions: {
 			implement: async () => {

--- a/extensions/pi-plan-mode/src/plan-export-controller.ts
+++ b/extensions/pi-plan-mode/src/plan-export-controller.ts
@@ -1,0 +1,38 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { exportStoredPlan, planExportDestination } from "./plan-export.js";
+import { configuredPlanExportPath, type PlanModeSettings } from "./settings.js";
+import type { PlanModeState } from "./state.js";
+
+interface PlanExportControllerOptions {
+	getState(): PlanModeState;
+	getSettings(): PlanModeSettings;
+	finishReady(ctx: ExtensionContext): void;
+}
+
+export function createPlanExportController(options: PlanExportControllerOptions) {
+	return {
+		export(
+			path: string | undefined,
+			ctx: ExtensionContext,
+			signal: AbortSignal,
+			isCurrent: () => boolean,
+		) {
+			const state = options.getState();
+			return exportStoredPlan(
+				state,
+				path,
+				ctx,
+				{
+					signal,
+					isCurrent,
+					getState: options.getState,
+					finishReady: () => options.finishReady(ctx),
+				},
+				configuredPlanExportPath(options.getSettings()),
+			);
+		},
+		getDestination(ctx: ExtensionContext) {
+			return planExportDestination(configuredPlanExportPath(options.getSettings()), ctx.cwd);
+		},
+	};
+}

--- a/extensions/pi-plan-mode/src/plan-export-screen.ts
+++ b/extensions/pi-plan-mode/src/plan-export-screen.ts
@@ -1,0 +1,19 @@
+import type { PlanExportDestination } from "./plan-export.js";
+
+export type PlanExportDestinationProvider = () => PlanExportDestination;
+
+export function planExportInputScreen(getDestination: PlanExportDestinationProvider) {
+	const destination = getDestination();
+	return {
+		kind: "input" as const,
+		title: "Export plan",
+		lines: [
+			"Existing paths are never overwritten.",
+			`Default: ${destination.configuredPath}`,
+			`Resolves to: ${destination.resolvedPath}`,
+		],
+		placeholder: destination.configuredPath,
+		action: "export" as const,
+		hint: "back" as const,
+	};
+}

--- a/extensions/pi-plan-mode/src/plan-export.ts
+++ b/extensions/pi-plan-mode/src/plan-export.ts
@@ -2,12 +2,18 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { type ExtensionContext, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_PLAN_EXPORT_PATH } from "./settings.js";
 import type { PlanModeState } from "./state.js";
 
-export const DEFAULT_PLAN_EXPORT_PATH = "PLAN.md";
+export { DEFAULT_PLAN_EXPORT_PATH };
 
 export interface PlanExportResult {
 	path: string;
+}
+
+export interface PlanExportDestination {
+	configuredPath: string;
+	resolvedPath: string;
 }
 
 export interface PlanExportLifecycle {
@@ -22,6 +28,7 @@ export async function exportStoredPlan(
 	requestedPath: string | undefined,
 	ctx: ExtensionContext,
 	lifecycle?: PlanExportLifecycle,
+	defaultPath = DEFAULT_PLAN_EXPORT_PATH,
 ) {
 	const plan =
 		(state.enabled ? state.latestPlan : undefined)?.trim() ??
@@ -41,7 +48,14 @@ export async function exportStoredPlan(
 		(lifecycle.isCurrent() && (!lifecycle.getState || lifecycle.getState() === state));
 	let result: PlanExportResult;
 	try {
-		result = await exportPlanToFile(plan, requestedPath, ctx.cwd, lifecycle?.signal, isCurrent);
+		result = await exportPlanToFile(
+			plan,
+			requestedPath,
+			ctx.cwd,
+			lifecycle?.signal,
+			isCurrent,
+			defaultPath,
+		);
 	} catch (error: unknown) {
 		if (lifecycle?.signal.aborted || !isCurrent()) return false;
 		if (!ctx.hasUI) throw error;
@@ -65,8 +79,9 @@ export async function exportPlanToFile(
 	cwd: string,
 	signal?: AbortSignal,
 	isCurrent: () => boolean = () => true,
+	defaultPath = DEFAULT_PLAN_EXPORT_PATH,
 ): Promise<PlanExportResult> {
-	const path = resolvePlanExportPath(requestedPath, cwd);
+	const path = resolvePlanExportPath(requestedPath, cwd, defaultPath);
 	await withFileMutationQueue(path, async () => {
 		throwIfCancelled(signal, isCurrent);
 		await mkdir(dirname(path), { recursive: true });
@@ -85,8 +100,19 @@ export async function exportPlanToFile(
 	return { path };
 }
 
-export function resolvePlanExportPath(requestedPath: string | undefined, cwd: string) {
-	const rawPath = requestedPath?.trim() || DEFAULT_PLAN_EXPORT_PATH;
+export function planExportDestination(defaultPath: string, cwd: string): PlanExportDestination {
+	return {
+		configuredPath: safeNotification(defaultPath),
+		resolvedPath: safeNotification(resolvePlanExportPath(undefined, cwd, defaultPath)),
+	};
+}
+
+export function resolvePlanExportPath(
+	requestedPath: string | undefined,
+	cwd: string,
+	defaultPath = DEFAULT_PLAN_EXPORT_PATH,
+) {
+	const rawPath = requestedPath?.trim() || defaultPath;
 	const normalizedPath = rawPath.startsWith("@") ? rawPath.slice(1) : rawPath;
 	if (!normalizedPath.trim()) throw new Error("Plan export path must not be empty.");
 	if (normalizedPath.includes("\0")) {

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -15,20 +15,12 @@ import {
 	setPlanThinkingLevel,
 } from "./extension-runtime.js";
 import {
-	injectActiveImplementationContext,
-	invalidPlanMessage,
-	isEmptyAssistantMessage,
-	latestAssistantText,
-	messageContainsInactivePlanModeArtifact,
-	messageContainsLegacyPlanModeContextArtifact,
-	messageContainsPlanModeImplementationContextArtifact,
-	messageContainsPlanModeImplementationHandoff,
-	parseProposedPlan,
-	stripPlanModeCompletionCallsFromMessage,
-	stripProposedPlanBlocksFromMessage,
-} from "./message-transform.js";
+	createImplementationRetentionCoordinator,
+	implementationRetentionPreview,
+} from "./implementation-retention.js";
+import { invalidPlanMessage, latestAssistantText, parseProposedPlan } from "./message-transform.js";
 import { showPlanModeMenu, showReadyPlanMenu } from "./plan-action-menus.js";
-import { exportStoredPlan } from "./plan-export.js";
+import { createPlanExportController } from "./plan-export-controller.js";
 import { showPlanLaunchMenu } from "./plan-launch-menu.js";
 import {
 	clearPlanModeUi,
@@ -52,6 +44,7 @@ import {
 } from "./saved-plan-preflight.js";
 import {
 	awaitPlanModeSettingsWrites,
+	configuredImplementationPlanRetention,
 	configuredThinkingLevel,
 	type PlanModeSettings,
 	readPlanModeSettings,
@@ -94,7 +87,13 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let menuGeneration = 0;
 	let workflowGeneration = 0;
 	let menuController = new AbortController();
+	const implementationRetention = createImplementationRetentionCoordinator();
 	const persistState = () => pi.appendEntry<PlanModeState>(STATE_ENTRY_TYPE, state);
+	const planExports = createPlanExportController({
+		getState: () => state,
+		getSettings: () => settings,
+		finishReady: (ctx) => exitPlanMode(ctx),
+	});
 
 	pi.registerFlag("plan", {
 		description: "Start in Codex-like Plan mode",
@@ -207,12 +206,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			const exportMatch = /^export(?:\s+([\s\S]+))?$/iu.exec(prompt);
 			if (exportMatch) {
 				const lifecycle = captureMenuLifecycle();
-				await exportStoredPlan(
-					state,
-					exportMatch[1],
-					ctx,
-					exportOwner(ctx, lifecycle.signal, lifecycle.isCurrent),
-				);
+				await planExports.export(exportMatch[1], ctx, lifecycle.signal, lifecycle.isCurrent);
 				return;
 			}
 			if (command === "exit" || command === "off") {
@@ -275,8 +269,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		menuController.abort(new DOMException("Plan-mode session replaced", "AbortError"));
 		menuController = new AbortController();
 		readyPresentationIntent = undefined;
+		implementationRetention.reset();
 		settings = { thinkingLevel: "inherit" };
 		restoreState(ctx);
+		implementationRetention.restore(state.activeImplementation);
 		const loadedSettings = await (dependencies.readSettings?.() ?? readPlanModeSettings());
 		if (generation !== menuGeneration || menuController.signal.aborted) return;
 		if (loadedSettings.kind === "loaded") settings = loadedSettings.settings;
@@ -323,6 +319,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		menuGeneration += 1;
 		menuController.abort(new DOMException("Plan-mode session shut down", "AbortError"));
 		readyPresentationIntent = undefined;
+		implementationRetention.reset();
 		await awaitPlanModeSettingsWrites(dependencies.settingsPath);
 		captureManualThinkingLevel();
 		persistState();
@@ -367,33 +364,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 	});
 
-	pi.on("context", async (event) => {
-		const messagesWithoutPlanContext = event.messages.filter(
-			(message: unknown) =>
-				!messageContainsLegacyPlanModeContextArtifact(message) &&
-				!messageContainsPlanModeImplementationContextArtifact(message),
-		);
-		if (state.enabled) {
-			return {
-				messages: messagesWithoutPlanContext.filter(
-					(message: unknown) => !messageContainsPlanModeImplementationHandoff(message),
-				),
-			};
+	pi.on("context", async (event, ctx) => {
+		const result = implementationRetention.transformContext(event.messages, state);
+		if (result.clearActiveImplementationId) {
+			clearActiveImplementation(result.clearActiveImplementationId, ctx);
 		}
-		const inactiveMessages = state.activeImplementation
-			? messagesWithoutPlanContext
-			: messagesWithoutPlanContext.filter(
-					(message: unknown) => !messageContainsPlanModeImplementationHandoff(message),
-				);
-		const messages = inactiveMessages
-			.filter((message: unknown) => !messageContainsInactivePlanModeArtifact(message))
-			.map(stripProposedPlanBlocksFromMessage)
-			.map(stripPlanModeCompletionCallsFromMessage)
-			.filter((message: unknown) => !isEmptyAssistantMessage(message));
-		const contextualMessages = state.activeImplementation
-			? injectActiveImplementationContext(messages, state.activeImplementation)
-			: messages;
-		return { messages: contextualMessages as typeof event.messages };
+		return { messages: result.messages as typeof event.messages };
 	});
 
 	pi.on("before_agent_start", (event, ctx) => {
@@ -432,6 +408,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	onAgentSettled(pi, async (_event, ctx) => {
+		const settledImplementationId = implementationRetention.implementationSettled(
+			state.activeImplementation,
+		);
+		if (settledImplementationId) clearActiveImplementation(settledImplementationId, ctx);
+
 		const intent = readyPresentationIntent;
 		if (!intent || !readyPresentationIsCurrent(intent)) return;
 		if (!ctx.isIdle() || ctx.hasPendingMessages()) return;
@@ -646,6 +627,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				plan,
 				source,
 				startedAt: Date.now(),
+				retention: configuredImplementationPlanRetention(settings),
 			},
 			manualThinkingLevel: undefined,
 		};
@@ -672,6 +654,15 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			persistState();
 			updateUi(ctx);
 		}
+	}
+
+	function clearActiveImplementation(id: string, ctx: ExtensionContext) {
+		if (state.activeImplementation?.id !== id) return false;
+		workflowGeneration += 1;
+		state = { ...state, activeImplementation: undefined };
+		persistState();
+		updateUi(ctx);
+		return true;
 	}
 
 	async function showLaunchMenu(ctx: ExtensionContext, initialScreen: "main" | "tools" = "main") {
@@ -723,11 +714,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		const lifecycle = captureMenuLifecycle();
 		await showActiveImplementationMenu(ctx, {
 			statusText: planStatusText(),
+			getExportDestination: () => planExports.getDestination(ctx),
 			signal: lifecycle.signal,
 			isCurrent: lifecycle.isCurrent,
 			show: () => showStoredPlan(pi, ctx, state),
-			exportPlan: (path, signal) =>
-				exportStoredPlan(state, path, ctx, exportOwner(ctx, signal, lifecycle.isCurrent)),
+			exportPlan: (path, signal) => planExports.export(path, ctx, signal, lifecycle.isCurrent),
 			settings: (signal) => showSettings(ctx, signal, lifecycle.isCurrent),
 			startNew: () => {
 				enterPlanMode(ctx);
@@ -744,12 +735,13 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		const lifecycle = captureMenuLifecycle();
 		await showSavedPlanMenu(ctx, {
 			statusText: planStatusText(),
+			implementationOutcome,
+			getExportDestination: () => planExports.getDestination(ctx),
 			signal: lifecycle.signal,
 			isCurrent: lifecycle.isCurrent,
 			show: () => showStoredPlan(pi, ctx, state),
 			implement: () => startImplementation(ctx),
-			exportPlan: (path, signal) =>
-				exportStoredPlan(state, path, ctx, exportOwner(ctx, signal, lifecycle.isCurrent)),
+			exportPlan: (path, signal) => planExports.export(path, ctx, signal, lifecycle.isCurrent),
 			settings: (signal) => showSettings(ctx, signal, lifecycle.isCurrent),
 			clear: () => {
 				exitPlanMode(ctx);
@@ -767,12 +759,13 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		await showPlanModeMenu(ctx, {
 			statusText: planStatusText(),
 			hasReadyPlan: state.latestPlan !== undefined,
+			implementationOutcome,
+			getExportDestination: () => planExports.getDestination(ctx),
 			...lifecycle,
 			show: () => showStoredPlan(pi, ctx, state),
 			finalize: () => requestFinalPlan(ctx),
 			implement: () => startImplementation(ctx),
-			exportPlan: (path, signal) =>
-				exportStoredPlan(state, path, ctx, exportOwner(ctx, signal, lifecycle.isCurrent)),
+			exportPlan: (path, signal) => planExports.export(path, ctx, signal, lifecycle.isCurrent),
 			save: () => savePlanForLater(ctx),
 			stay: () => updateUi(ctx),
 			exit: () => {
@@ -786,9 +779,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		const lifecycle = captureMenuLifecycle();
 		await showReadyPlanMenu(ctx, {
 			...lifecycle,
+			implementationOutcome,
+			getExportDestination: () => planExports.getDestination(ctx),
 			implement: () => startImplementation(ctx),
-			exportPlan: (path, signal) =>
-				exportStoredPlan(state, path, ctx, exportOwner(ctx, signal, lifecycle.isCurrent)),
+			exportPlan: (path, signal) => planExports.export(path, ctx, signal, lifecycle.isCurrent),
 			save: () => savePlanForLater(ctx),
 			stay: () => undefined,
 			exit: () => {
@@ -816,10 +810,6 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				: {}),
 		});
 		return result.kind === "closed" && "reason" in result && result.reason === "close";
-	}
-
-	function exportOwner(ctx: ExtensionContext, signal: AbortSignal, isCurrent: () => boolean) {
-		return { signal, isCurrent, getState: () => state, finishReady: () => exitPlanMode(ctx) };
 	}
 
 	function captureMenuLifecycle() {
@@ -971,6 +961,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	function planStatusText() {
 		return formatPlanModeStatusText(state, formatToolSummary);
+	}
+
+	function implementationOutcome() {
+		return implementationRetentionPreview(configuredImplementationPlanRetention(settings));
 	}
 
 	function formatToolSummary() {

--- a/extensions/pi-plan-mode/src/saved-plan-menu.ts
+++ b/extensions/pi-plan-mode/src/saved-plan-menu.ts
@@ -1,8 +1,11 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { type PlanExportDestinationProvider, planExportInputScreen } from "./plan-export-screen.js";
 
 interface SavedPlanMenuOptions {
 	statusText: string;
+	implementationOutcome(): string;
+	getExportDestination: PlanExportDestinationProvider;
 	signal: AbortSignal;
 	isCurrent(): boolean;
 	show(): void;
@@ -26,7 +29,7 @@ export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPla
 			saved: () => ({
 				kind: "actions",
 				title: "Saved plan",
-				lines: [options.statusText],
+				lines: [options.statusText, options.implementationOutcome()],
 				items: [
 					{ id: "show", label: "Show saved plan", action: "show" },
 					{ id: "implement", label: "Implement saved plan", action: "implement" },
@@ -36,14 +39,7 @@ export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPla
 				],
 				hint: "close",
 			}),
-			export: () => ({
-				kind: "input",
-				title: "Export plan",
-				lines: ["Existing paths are never overwritten."],
-				placeholder: "PLAN.md",
-				action: "export",
-				hint: "back",
-			}),
+			export: () => planExportInputScreen(options.getExportDestination),
 		},
 		actions: {
 			show: async () => {

--- a/extensions/pi-plan-mode/src/settings-menu.ts
+++ b/extensions/pi-plan-mode/src/settings-menu.ts
@@ -1,8 +1,13 @@
 import type { ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
 import { defineMenu, type RunMenuResult, runMenu } from "@narumitw/pi-tui-kit";
 import { PLAN_MODE_COMPLETE_TOOL_NAME } from "./completion-tool.js";
+import { retentionLabel } from "./implementation-retention.js";
+import { planExportDestination } from "./plan-export.js";
 import { PLAN_MODE_QUESTION_TOOL_NAME } from "./question-tool.js";
 import {
+	configuredImplementationPlanRetention,
+	configuredPlanExportPath,
+	IMPLEMENTATION_PLAN_RETENTIONS,
 	PLAN_MODE_THINKING_LEVELS,
 	type PlanModeSettings,
 	type PlanModeSettingsLoadResult,
@@ -36,8 +41,15 @@ export interface PlanModeSettingsMenuOptions {
 	onSaved(settings: PlanModeSettings): void;
 }
 
-type Screen = "settings" | "tools";
-type Action = "set-thinking" | "open-tools" | "toggle-tool" | "reset-tools";
+type Screen = "settings" | "tools" | "export";
+type Action =
+	| "set-thinking"
+	| "open-tools"
+	| "toggle-tool"
+	| "reset-tools"
+	| "set-retention"
+	| "open-export"
+	| "set-export";
 
 export async function showPlanModeSettings(
 	ctx: ExtensionContext,
@@ -81,7 +93,7 @@ export async function showPlanModeSettings(
 							items: [
 								{
 									id: "thinkingLevel",
-									label: "Thinking level",
+									label: "Plan thinking",
 									description: "Set the thinking level when the next Plan workflow starts.",
 									currentValue: state.settings.thinkingLevel,
 									values: PLAN_MODE_THINKING_LEVELS,
@@ -89,11 +101,28 @@ export async function showPlanModeSettings(
 								},
 								{
 									id: "defaultPlanTools",
-									label: "Default tools",
+									label: "Plan tools",
 									description:
 										"Choose persistent defaults; a launch-time selection still overrides them for that session.",
 									currentValue: defaultToolsValue(state.settings.defaultPlanTools),
 									action: "open-tools",
+								},
+								{
+									id: "implementationPlanRetention",
+									label: "After Implement",
+									description: "Choose how long the accepted plan keeps guiding implementation.",
+									currentValue: retentionLabel(
+										configuredImplementationPlanRetention(state.settings),
+									),
+									values: IMPLEMENTATION_PLAN_RETENTIONS.map(retentionLabel),
+									action: "set-retention",
+								},
+								{
+									id: "defaultPlanExportPath",
+									label: "Export destination",
+									description: "Set the destination used when an export omits its path.",
+									currentValue: safeTerminalText(configuredPlanExportPath(state.settings)),
+									action: "open-export",
 								},
 							],
 						},
@@ -117,6 +146,22 @@ export async function showPlanModeSettings(
 				],
 				hint: "back",
 			}),
+			export: ({ state }) => {
+				const configured = configuredPlanExportPath(state.settings);
+				const destination = planExportDestination(configured, ctx.cwd);
+				return {
+					kind: "input",
+					title: "Export destination",
+					lines: [
+						`Configured: ${destination.configuredPath}`,
+						`Resolves here to: ${destination.resolvedPath}`,
+						"Submit an empty value to reset to PLAN.md. Changes affect the next export.",
+					],
+					placeholder: configured,
+					action: "set-export",
+					hint: "back",
+				};
+			},
 		},
 		actions: {
 			"set-thinking": async ({ ctx: actionCtx, value, signal }) => {
@@ -133,6 +178,29 @@ export async function showPlanModeSettings(
 				);
 			},
 			"open-tools": async () => ({ kind: "to", screen: "tools" }),
+			"set-retention": async ({ ctx: actionCtx, value, signal }) => {
+				const implementationPlanRetention = retentionFromLabel(value);
+				if (!implementationPlanRetention) return { kind: "rejected" };
+				return savePatch(
+					actionCtx,
+					{ implementationPlanRetention },
+					signal,
+					`After Implement: ${retentionLabel(implementationPlanRetention)}. Applies to the next Implement action.`,
+				);
+			},
+			"open-export": async () => ({ kind: "to", screen: "export" }),
+			"set-export": async ({ ctx: actionCtx, value, signal }) => {
+				const defaultPlanExportPath = value?.trim() || null;
+				const result = await savePatch(
+					actionCtx,
+					{ defaultPlanExportPath },
+					signal,
+					defaultPlanExportPath
+						? `Default Plan export destination: ${safeTerminalText(defaultPlanExportPath)}.`
+						: "Default Plan export destination reset to PLAN.md.",
+				);
+				return result.kind === "stay" ? { kind: "to", screen: "settings" } : result;
+			},
 			"toggle-tool": async ({ ctx: actionCtx, state, itemId, selected, signal }) => {
 				const tool = tools.find((candidate) => candidate.name === itemId);
 				if (!tool || !canSelectToolInPlanMode(tool)) return { kind: "rejected" };
@@ -197,7 +265,7 @@ export async function showPlanModeSettings(
 function settingsLines(settingsPath: string, notice: string | undefined) {
 	return [
 		`User settings · ${safeTerminalText(settingsPath)}`,
-		"Saved changes apply to the next Plan workflow.",
+		"Plan defaults apply to the next workflow; handoff and export choices apply to their next action.",
 		...(notice ? [safeTerminalText(notice)] : []),
 	];
 }
@@ -213,6 +281,10 @@ function invalidScreen(settingsPath: string, state: SettingsMenuState) {
 		],
 		hint: "back" as const,
 	};
+}
+
+function retentionFromLabel(value: string | undefined) {
+	return IMPLEMENTATION_PLAN_RETENTIONS.find((retention) => retentionLabel(retention) === value);
 }
 
 function defaultToolsValue(configured: string[] | undefined) {

--- a/extensions/pi-plan-mode/src/settings.ts
+++ b/extensions/pi-plan-mode/src/settings.ts
@@ -24,17 +24,29 @@ export const PLAN_MODE_THINKING_LEVELS = [
 	"xhigh",
 	"max",
 ] as const;
+export const IMPLEMENTATION_PLAN_RETENTIONS = [
+	"keep",
+	"clear-on-start",
+	"clear-after-first-run",
+] as const;
+export const DEFAULT_PLAN_EXPORT_PATH = "PLAN.md";
+const MAX_PLAN_EXPORT_PATH_LENGTH = 4096;
 
 export type PlanModeThinkingLevel = (typeof PLAN_MODE_THINKING_LEVELS)[number];
+export type ImplementationPlanRetention = (typeof IMPLEMENTATION_PLAN_RETENTIONS)[number];
 export type PlanModeFixedThinkingLevel = Exclude<PlanModeThinkingLevel, "inherit">;
 export interface PlanModeSettings {
 	thinkingLevel: PlanModeThinkingLevel;
 	defaultPlanTools?: string[];
+	implementationPlanRetention?: ImplementationPlanRetention;
+	defaultPlanExportPath?: string;
 	safeSubcommands?: SafeSubcommands;
 }
 export interface PlanModeSettingsPatch {
 	thinkingLevel?: PlanModeThinkingLevel;
 	defaultPlanTools?: readonly string[] | null;
+	implementationPlanRetention?: ImplementationPlanRetention;
+	defaultPlanExportPath?: string | null;
 }
 export interface UpdatePlanModeSettingsOptions {
 	settingsPath?: string;
@@ -79,6 +91,25 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 		if (!defaultPlanTools) return undefined;
 		settings.defaultPlanTools = defaultPlanTools;
 	}
+	if (Object.hasOwn(value, "implementationPlanRetention")) {
+		const implementationPlanRetention = Reflect.get(value, "implementationPlanRetention");
+		if (
+			!IMPLEMENTATION_PLAN_RETENTIONS.includes(
+				implementationPlanRetention as ImplementationPlanRetention,
+			)
+		) {
+			return undefined;
+		}
+		settings.implementationPlanRetention =
+			implementationPlanRetention as ImplementationPlanRetention;
+	}
+	if (Object.hasOwn(value, "defaultPlanExportPath")) {
+		const defaultPlanExportPath = normalizePlanExportPath(
+			Reflect.get(value, "defaultPlanExportPath"),
+		);
+		if (!defaultPlanExportPath) return undefined;
+		settings.defaultPlanExportPath = defaultPlanExportPath;
+	}
 	if (Object.hasOwn(value, "safeSubcommands")) {
 		const safeSubcommands = normalizeSafeSubcommands(Reflect.get(value, "safeSubcommands"));
 		if (!safeSubcommands) return undefined;
@@ -95,6 +126,23 @@ function normalizeToolNames(value: unknown) {
 		return undefined;
 	}
 	return Array.from(new Set(value));
+}
+
+function normalizePlanExportPath(value: unknown) {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim();
+	if (
+		!normalized ||
+		normalized.length > MAX_PLAN_EXPORT_PATH_LENGTH ||
+		!/[^@\s]/u.test(normalized) ||
+		[...normalized].some((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+		})
+	) {
+		return undefined;
+	}
+	return normalized;
 }
 
 function normalizeSafeSubcommands(value: unknown): SafeSubcommands | undefined {
@@ -171,6 +219,13 @@ export function updatePlanModeSettings(
 		if (patch.defaultPlanTools === null) delete updated.defaultPlanTools;
 		else if (patch.defaultPlanTools !== undefined) {
 			updated.defaultPlanTools = [...patch.defaultPlanTools];
+		}
+		if (patch.implementationPlanRetention !== undefined) {
+			updated.implementationPlanRetention = patch.implementationPlanRetention;
+		}
+		if (patch.defaultPlanExportPath === null) delete updated.defaultPlanExportPath;
+		else if (patch.defaultPlanExportPath !== undefined) {
+			updated.defaultPlanExportPath = patch.defaultPlanExportPath;
 		}
 		const settings = normalizePlanModeSettings(updated);
 		if (!settings) throw invalidSettingsError(settingsPath, "invalid settings shape");
@@ -338,4 +393,14 @@ export function configuredThinkingLevel(
 	settings: PlanModeSettings,
 ): PlanModeFixedThinkingLevel | undefined {
 	return settings.thinkingLevel === "inherit" ? undefined : settings.thinkingLevel;
+}
+
+export function configuredImplementationPlanRetention(
+	settings: PlanModeSettings,
+): ImplementationPlanRetention {
+	return settings.implementationPlanRetention ?? "keep";
+}
+
+export function configuredPlanExportPath(settings: PlanModeSettings) {
+	return settings.defaultPlanExportPath ?? DEFAULT_PLAN_EXPORT_PATH;
 }

--- a/extensions/pi-plan-mode/src/state.ts
+++ b/extensions/pi-plan-mode/src/state.ts
@@ -3,7 +3,12 @@ import {
 	PLAN_MODE_COMPLETE_TOOL_NAME,
 	planFromCompletionDetails,
 } from "./completion-tool.js";
-import { PLAN_MODE_THINKING_LEVELS, type PlanModeFixedThinkingLevel } from "./settings.js";
+import {
+	IMPLEMENTATION_PLAN_RETENTIONS,
+	type ImplementationPlanRetention,
+	PLAN_MODE_THINKING_LEVELS,
+	type PlanModeFixedThinkingLevel,
+} from "./settings.js";
 
 export type PlanCompletionSource = typeof PLAN_MODE_COMPLETE_TOOL_NAME | "legacy_proposed_plan";
 
@@ -12,6 +17,7 @@ export interface ActiveImplementationPlan {
 	plan: string;
 	source: PlanCompletionSource;
 	startedAt: number;
+	retention?: ImplementationPlanRetention;
 }
 
 export interface SavedPlan {
@@ -111,7 +117,12 @@ function normalizeActiveImplementation(value: unknown): ActiveImplementationPlan
 			? value.startedAt
 			: undefined;
 	if (!id || !source || !normalized.ok || startedAt === undefined) return undefined;
-	return { id, plan: normalized.plan, source, startedAt };
+	const retention = IMPLEMENTATION_PLAN_RETENTIONS.includes(
+		value.retention as ImplementationPlanRetention,
+	)
+		? (value.retention as ImplementationPlanRetention)
+		: "keep";
+	return { id, plan: normalized.plan, source, startedAt, retention };
 }
 
 function normalizePersistedPlan(value: unknown) {

--- a/extensions/pi-plan-mode/test/implementation-retention.test.ts
+++ b/extensions/pi-plan-mode/test/implementation-retention.test.ts
@@ -1,0 +1,316 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import planMode from "../src/plan-mode.js";
+import type { ImplementationPlanRetention } from "../src/settings.js";
+import { restorePlanModeState } from "../src/state.js";
+
+const PLAN = "# Retained plan\n\n1. Keep the complete handoff.";
+const STATE_ENTRY_TYPE = "plan-mode-state";
+
+function stateEntry(data: Record<string, unknown>) {
+	return { type: "custom", customType: STATE_ENTRY_TYPE, data };
+}
+
+function latestState(mock: ReturnType<typeof createMockPi>) {
+	return mock.entries.at(-1)?.data as {
+		activeImplementation?: {
+			id: string;
+			plan: string;
+			retention?: ImplementationPlanRetention;
+		};
+	};
+}
+
+async function beginImplementation(
+	retention: ImplementationPlanRetention,
+	options: { idle?: boolean } = {},
+) {
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: {
+				thinkingLevel: "inherit" as const,
+				implementationPlanRetention: retention,
+			},
+		}),
+	});
+	const context = createMockContext({ isIdle: () => options.idle ?? true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as
+		| ((...args: unknown[]) => Promise<unknown>)
+		| undefined;
+	assert.ok(complete);
+	await complete("complete", { plan: PLAN }, undefined, undefined, context.ctx);
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	return { mock, context, handoff: mock.sentUserMessages.at(-1)?.text ?? "" };
+}
+
+test("active implementation state captures retention and legacy state restores as keep", () => {
+	const legacy = restorePlanModeState(
+		[
+			stateEntry({
+				enabled: false,
+				awaitingAction: false,
+				activeImplementation: {
+					id: "legacy-implementation",
+					plan: PLAN,
+					source: "plan_mode_complete",
+					startedAt: 42,
+				},
+			}),
+		],
+		STATE_ENTRY_TYPE,
+	);
+	assert.equal(legacy.activeImplementation?.retention, "keep");
+
+	const explicit = restorePlanModeState(
+		[
+			stateEntry({
+				enabled: false,
+				awaitingAction: false,
+				activeImplementation: {
+					id: "implementation-1",
+					plan: PLAN,
+					source: "plan_mode_complete",
+					startedAt: 42,
+					retention: "clear-after-first-run",
+				},
+			}),
+		],
+		STATE_ENTRY_TYPE,
+	);
+	assert.equal(explicit.activeImplementation?.retention, "clear-after-first-run");
+});
+
+test("keep leaves the accepted plan active after context and settlement", async () => {
+	const { mock, context, handoff } = await beginImplementation("keep");
+	assert.equal(latestState(mock).activeImplementation?.retention, "keep");
+	const transformed = (await mock.events.get("context")?.[0]?.(
+		{ messages: [{ role: "user", content: handoff }] },
+		context.ctx,
+	)) as { messages: Array<{ content?: unknown }> };
+	assert.match(JSON.stringify(transformed.messages), /Retained plan/);
+	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+	assert.equal(latestState(mock).activeImplementation?.retention, "keep");
+	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+});
+
+test("handoff-only waits for the exact queued handoff, preserves its first context, then clears", async () => {
+	const { mock, context, handoff } = await beginImplementation("clear-on-start", { idle: false });
+	const contextHook = mock.events.get("context")?.[0];
+	assert.ok(contextHook);
+
+	await contextHook({ messages: [{ role: "user", content: "Older queued work" }] }, context.ctx);
+	assert.equal(latestState(mock).activeImplementation?.retention, "clear-on-start");
+
+	const firstImplementationContext = (await contextHook(
+		{ messages: [{ role: "user", content: handoff }] },
+		context.ctx,
+	)) as { messages: unknown[] };
+	assert.match(JSON.stringify(firstImplementationContext.messages), /Retained plan/);
+	assert.equal(latestState(mock).activeImplementation, undefined);
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+
+	const later = (await contextHook(
+		{ messages: [{ role: "user", content: handoff }] },
+		context.ctx,
+	)) as { messages: unknown[] };
+	assert.doesNotMatch(JSON.stringify(later.messages), /Retained plan/);
+});
+
+test("first-run ignores older settlement and clears only after its handoff context settles", async () => {
+	const { mock, context, handoff } = await beginImplementation("clear-after-first-run", {
+		idle: false,
+	});
+	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+	assert.equal(latestState(mock).activeImplementation?.retention, "clear-after-first-run");
+
+	const contextHook = mock.events.get("context")?.[0];
+	assert.ok(contextHook);
+	const firstImplementationContext = (await contextHook(
+		{ messages: [{ role: "user", content: handoff }] },
+		context.ctx,
+	)) as { messages: unknown[] };
+	assert.match(JSON.stringify(firstImplementationContext.messages), /Retained plan/);
+	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+	await mock.events.get("agent_end")?.[0]?.({ messages: [] }, context.ctx);
+	assert.equal(latestState(mock).activeImplementation?.retention, "clear-after-first-run");
+
+	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+	assert.equal(latestState(mock).activeImplementation, undefined);
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+});
+
+test("an armed older implementation cannot clear a superseding implementation", async () => {
+	const { mock, context, handoff } = await beginImplementation("clear-after-first-run");
+	const contextHook = mock.events.get("context")?.[0];
+	assert.ok(contextHook);
+	await contextHook({ messages: [{ role: "user", content: handoff }] }, context.ctx);
+	const firstId = latestState(mock).activeImplementation?.id;
+
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as
+		| ((...args: unknown[]) => Promise<unknown>)
+		| undefined;
+	assert.ok(complete);
+	await complete("replacement", { plan: "# Replacement plan" }, undefined, undefined, context.ctx);
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	const secondId = latestState(mock).activeImplementation?.id;
+	assert.notEqual(secondId, firstId);
+
+	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+	assert.equal(latestState(mock).activeImplementation?.id, secondId);
+	const secondHandoff = mock.sentUserMessages.at(-1)?.text ?? "";
+	await contextHook({ messages: [{ role: "user", content: secondHandoff }] }, context.ctx);
+	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+	assert.equal(latestState(mock).activeImplementation, undefined);
+});
+
+test("Implement menus preview each configured retention outcome before confirmation", async () => {
+	for (const [retention, preview] of [
+		["keep", "Keep plan active until /plan exit"],
+		["clear-on-start", "Use the plan for the implementation handoff only"],
+		["clear-after-first-run", "Clear after the first implementation run settles"],
+	] as const) {
+		let menuTitle = "";
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi, {
+			readSettings: async () => ({
+				kind: "loaded" as const,
+				settings: {
+					thinkingLevel: "inherit" as const,
+					implementationPlanRetention: retention,
+				},
+			}),
+		});
+		const context = createMockContext({
+			hasUI: true,
+			select: async (title: string) => {
+				menuTitle = title;
+				return "Stay in Plan mode";
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as
+			| ((...args: unknown[]) => Promise<unknown>)
+			| undefined;
+		assert.ok(complete);
+		await complete("complete", { plan: PLAN }, undefined, undefined, context.ctx);
+		await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		assert.match(menuTitle, new RegExp(preview.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "i"));
+	}
+});
+
+test("changing Settings does not retroactively change an active implementation", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-plan-retention-settings-"));
+	const settingsPath = join(directory, "pi-plan-mode.json");
+	try {
+		const mock = createMockPi({ activeTools: ["read", "edit"] });
+		planMode(mock.pi, {
+			settingsPath,
+			readSettings: async () => ({
+				kind: "loaded" as const,
+				settings: {
+					thinkingLevel: "inherit" as const,
+					implementationPlanRetention: "keep" as const,
+				},
+			}),
+		});
+		let openedSettings = false;
+		let changedSetting = false;
+		const context = createMockContext({
+			hasUI: true,
+			select: async (_title: string, options: string[]) => {
+				if (options.includes("Settings")) {
+					if (openedSettings) return undefined;
+					openedSettings = true;
+					return "Settings";
+				}
+				if (changedSetting) return undefined;
+				changedSetting = true;
+				return options.find((option) => option.startsWith("After Implement"));
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as
+			| ((...args: unknown[]) => Promise<unknown>)
+			| undefined;
+		assert.ok(complete);
+		await complete("complete", { plan: PLAN }, undefined, undefined, context.ctx);
+		await mock.commands.get("plan")?.handler("implement", context.ctx);
+		assert.equal(latestState(mock).activeImplementation?.retention, "keep");
+
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.equal(
+			(
+				JSON.parse(await readFile(settingsPath, "utf8")) as {
+					implementationPlanRetention?: string;
+				}
+			).implementationPlanRetention,
+			"clear-on-start",
+		);
+		assert.equal(latestState(mock).activeImplementation?.retention, "keep");
+		const handoff = mock.sentUserMessages.at(-1)?.text ?? "";
+		await mock.events.get("context")?.[0]?.(
+			{ messages: [{ role: "user", content: handoff }] },
+			context.ctx,
+		);
+		await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		assert.equal(latestState(mock).activeImplementation?.retention, "keep");
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("restored cleanup policies re-arm safely in the replacement session", async () => {
+	for (const retention of ["clear-on-start", "clear-after-first-run"] as const) {
+		const restoredEntry = stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			activeImplementation: {
+				id: `restored-${retention}`,
+				plan: PLAN,
+				source: "plan_mode_complete",
+				startedAt: 42,
+				retention,
+			},
+		});
+		const mock = createMockPi({ activeTools: ["read", "edit"] });
+		planMode(mock.pi);
+		const context = createMockContext({
+			sessionManager: {
+				getBranch: () => [restoredEntry],
+				getEntries: () => [restoredEntry],
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({ reason: "resume" }, context.ctx);
+		const transformed = (await mock.events.get("context")?.[0]?.(
+			{ messages: [{ role: "user", content: "Continue after resume" }] },
+			context.ctx,
+		)) as { messages: unknown[] };
+		assert.match(JSON.stringify(transformed.messages), /Retained plan/);
+		if (retention === "clear-after-first-run") {
+			assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+			await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		}
+		assert.equal(latestState(mock).activeImplementation, undefined);
+		assert.equal(context.statuses.get("plan-mode"), undefined);
+	}
+});
+
+test("manual exit clears every retention policy before its automatic boundary", async () => {
+	for (const retention of ["keep", "clear-on-start", "clear-after-first-run"] as const) {
+		const { mock, context } = await beginImplementation(retention);
+		await mock.commands.get("plan")?.handler("exit", context.ctx);
+		assert.equal(latestState(mock).activeImplementation, undefined);
+		assert.equal(context.statuses.get("plan-mode"), undefined);
+	}
+});

--- a/extensions/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/extensions/pi-plan-mode/test/issue-471-repro.test.ts
@@ -58,7 +58,7 @@ test("active implementation state restores independently from Plan mode", () => 
 		STATE_ENTRY_TYPE,
 	);
 
-	assert.deepEqual(restored.activeImplementation, activeImplementation);
+	assert.deepEqual(restored.activeImplementation, { ...activeImplementation, retention: "keep" });
 	assert.deepEqual(restored.selectedToolNames, ["read"]);
 	assert.equal(restored.latestPlan, undefined);
 	assert.equal(restored.awaitingAction, false);

--- a/extensions/pi-plan-mode/test/plan-export.test.ts
+++ b/extensions/pi-plan-mode/test/plan-export.test.ts
@@ -88,6 +88,102 @@ test("ready plan export ends Plan mode without triggering a model turn", async (
 	});
 });
 
+test("configured export defaults resolve at action time and explicit paths still win", async () => {
+	await withTempDirectory(async (directory) => {
+		for (const { command, expectedPath } of [
+			{ command: "export", expectedPath: join(directory, "plans", "default.md") },
+			{ command: "export explicit.md", expectedPath: join(directory, "explicit.md") },
+		]) {
+			const mock = createMockPi({ activeTools: ["read"] });
+			planMode(mock.pi, {
+				readSettings: async () => ({
+					kind: "loaded" as const,
+					settings: {
+						thinkingLevel: "inherit" as const,
+						defaultPlanExportPath: "@plans/default.md",
+					},
+				}),
+			});
+			const context = createMockContext({ cwd: directory, hasUI: true });
+			await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+			await mock.commands.get("plan")?.handler("start", context.ctx);
+			await completePlan(mock, context.ctx);
+			await mock.commands.get("plan")?.handler(command, context.ctx);
+			assert.equal(await readFile(expectedPath, "utf8"), `${PLAN}\n`);
+		}
+	});
+});
+
+test("relative configured defaults resolve against the command context cwd", async () => {
+	await withTempDirectory(async (directory) => {
+		const planningDirectory = join(directory, "planning");
+		const exportDirectory = join(directory, "implementation");
+		await mkdir(planningDirectory);
+		await mkdir(exportDirectory);
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi, {
+			readSettings: async () => ({
+				kind: "loaded" as const,
+				settings: {
+					thinkingLevel: "inherit" as const,
+					defaultPlanExportPath: "plans/default.md",
+				},
+			}),
+		});
+		const planningContext = createMockContext({ cwd: planningDirectory, hasUI: true });
+		await mock.events.get("session_start")?.[0]?.({}, planningContext.ctx);
+		await mock.commands.get("plan")?.handler("start", planningContext.ctx);
+		await completePlan(mock, planningContext.ctx);
+
+		const exportContext = createMockContext({ cwd: exportDirectory, hasUI: true });
+		await mock.commands.get("plan")?.handler("export", exportContext.ctx);
+		assert.equal(await readFile(join(exportDirectory, "plans", "default.md"), "utf8"), `${PLAN}\n`);
+		await assert.rejects(readFile(join(planningDirectory, "plans", "default.md"), "utf8"));
+	});
+});
+
+test("an active Settings save changes the next export without changing active state", async () => {
+	await withTempDirectory(async (directory) => {
+		const settingsPath = join(directory, "pi-plan-mode.json");
+		const mock = createMockPi({ activeTools: ["read", "edit"] });
+		planMode(mock.pi, {
+			settingsPath,
+			readSettings: async () => ({
+				kind: "loaded" as const,
+				settings: { thinkingLevel: "inherit" as const },
+			}),
+		});
+		let openedSettings = false;
+		let changedExport = false;
+		const context = createMockContext({
+			cwd: directory,
+			mode: "tui",
+			hasUI: true,
+			select: async (_title: string, options: string[]) => {
+				if (options.includes("Settings")) {
+					if (openedSettings) return undefined;
+					openedSettings = true;
+					return "Settings";
+				}
+				if (changedExport) return undefined;
+				changedExport = true;
+				return options.find((option) => option.startsWith("Export destination"));
+			},
+			input: async () => "next/export.md",
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await completePlan(mock, context.ctx);
+		await mock.commands.get("plan")?.handler("implement", context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+
+		await mock.commands.get("plan")?.handler("export", context.ctx);
+		assert.equal(await readFile(join(directory, "next", "export.md"), "utf8"), `${PLAN}\n`);
+		assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+	});
+});
+
 test("ready plan export supports custom relative and absolute paths", async () => {
 	await withTempDirectory(async (directory) => {
 		for (const { requestedPath, expectedPath } of [
@@ -224,7 +320,7 @@ test("plan export refuses an existing symbolic link", {
 	});
 });
 
-test("plan export supports saved and active plans in print and JSON modes", async () => {
+test("configured export defaults support saved and active plans in print and JSON modes", async () => {
 	for (const scenario of [
 		{
 			mode: "print",
@@ -253,7 +349,15 @@ test("plan export supports saved and active plans in print and JSON modes", asyn
 		await withTempDirectory(async (directory) => {
 			const entry = stateEntry(scenario.data);
 			const mock = createMockPi({ activeTools: ["read", "edit"] });
-			planMode(mock.pi);
+			planMode(mock.pi, {
+				readSettings: async () => ({
+					kind: "loaded" as const,
+					settings: {
+						thinkingLevel: "inherit" as const,
+						defaultPlanExportPath: `${scenario.mode}-default.md`,
+					},
+				}),
+			});
 			const context = createMockContext({
 				cwd: directory,
 				mode: scenario.mode,
@@ -265,9 +369,12 @@ test("plan export supports saved and active plans in print and JSON modes", asyn
 			});
 			await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 
-			await mock.commands.get("plan")?.handler("export exported.md", context.ctx);
+			await mock.commands.get("plan")?.handler("export", context.ctx);
 
-			assert.equal(await readFile(join(directory, "exported.md"), "utf8"), `${PLAN}\n`);
+			assert.equal(
+				await readFile(join(directory, `${scenario.mode}-default.md`), "utf8"),
+				`${PLAN}\n`,
+			);
 			assert.equal(context.statuses.get("plan-mode"), scenario.status);
 			assert.equal(mock.entries.length, 0);
 			assert.equal(mock.sentUserMessages.length, 0);
@@ -312,21 +419,31 @@ test("plan export fails observably without a plan or on an existing path in no-U
 	});
 });
 
-test("completion and management TUI menus accept an export path", async () => {
+test("completion and management TUI menus preview and use the configured export default", async () => {
 	for (const scenario of ["automatic-ready", "manual-ready", "saved", "active"] as const) {
 		await withTempDirectory(async (directory) => {
-			const expectedPath = scenario === "automatic-ready" ? "PLAN.md" : `${scenario}-export.md`;
+			const expectedPath = "configured/default-plan.md";
 			const mock = createMockPi({ activeTools: ["read", "edit"] });
-			planMode(mock.pi);
+			planMode(mock.pi, {
+				readSettings: async () => ({
+					kind: "loaded" as const,
+					settings: {
+						thinkingLevel: "inherit" as const,
+						defaultPlanExportPath: expectedPath,
+					},
+				}),
+			});
 			const custom = async (factory: unknown) => {
 				const harness = createCustomSelectorHarness(factory);
 				if (!harness.isFocusable) {
 					chooseExportMenu(harness);
 					return harness.resultPromise;
 				}
-				assert.match(harness.render().join("\n"), /Export plan.*PLAN\.md/is);
+				const exportFrame = harness.render().join("\n");
+				assert.match(exportFrame, /Export plan/is);
+				assert.match(exportFrame, /configured\/default-plan\.md/i);
+				assert.match(exportFrame, /Resolves to:/i);
 				harness.setFocused(true);
-				if (scenario !== "automatic-ready") harness.handleInput(expectedPath);
 				harness.handleInput("tui.input.submit");
 				await harness.waitForPending();
 				return harness.resultPromise;
@@ -415,10 +532,18 @@ function selectedMenuLabel(lines: readonly string[]) {
 		: "";
 }
 
-test("RPC export menu accepts a custom path", async () => {
+test("RPC export menu exposes and uses the configured default", async () => {
 	await withTempDirectory(async (directory) => {
 		const mock = createMockPi({ activeTools: ["read"] });
-		planMode(mock.pi);
+		planMode(mock.pi, {
+			readSettings: async () => ({
+				kind: "loaded" as const,
+				settings: {
+					thinkingLevel: "inherit" as const,
+					defaultPlanExportPath: "rpc-default.md",
+				},
+			}),
+		});
 		let inputCalls = 0;
 		const context = createMockContext({
 			cwd: directory,
@@ -431,8 +556,9 @@ test("RPC export menu accepts a custom path", async () => {
 			input: async (title: string, placeholder?: string) => {
 				inputCalls += 1;
 				assert.match(title, /Export plan/i);
-				assert.equal(placeholder, "PLAN.md");
-				return "rpc-export.md";
+				assert.match(title, /Resolves to:.*rpc-default\.md/is);
+				assert.equal(placeholder, "rpc-default.md");
+				return "";
 			},
 		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
@@ -442,7 +568,7 @@ test("RPC export menu accepts a custom path", async () => {
 		await mock.commands.get("plan")?.handler("", context.ctx);
 
 		assert.equal(inputCalls, 1);
-		assert.equal(await readFile(join(directory, "rpc-export.md"), "utf8"), `${PLAN}\n`);
+		assert.equal(await readFile(join(directory, "rpc-default.md"), "utf8"), `${PLAN}\n`);
 		assert.equal(context.statuses.get("plan-mode"), undefined);
 	});
 });

--- a/extensions/pi-plan-mode/test/saved-plan.test.ts
+++ b/extensions/pi-plan-mode/test/saved-plan.test.ts
@@ -86,7 +86,7 @@ test("saved Plan state restores from the active branch and rejects malformed val
 		],
 		STATE_ENTRY_TYPE,
 	) as ReturnType<typeof restorePlanModeState> & { savedPlan?: unknown };
-	assert.deepEqual(mixed.activeImplementation, activeImplementation);
+	assert.deepEqual(mixed.activeImplementation, { ...activeImplementation, retention: "keep" });
 	assert.equal(mixed.savedPlan, undefined);
 });
 
@@ -164,7 +164,8 @@ test("automatic and manual ready menus expose Save for later", async () => {
 		planMode(mock.pi);
 		const context = createMockContext({
 			hasUI: true,
-			select: async (_title: string, options: string[]) => {
+			select: async (title: string, options: string[]) => {
+				assert.match(title, /After Implement: Keep plan active until \/plan exit/i);
 				assert.deepEqual(
 					options.filter((option) => option !== "Close"),
 					automatic
@@ -219,7 +220,8 @@ test("saved Plan management can show, implement, clear, or cancel", async () => 
 				getBranch: () => [savedEntry],
 				getEntries: () => [savedEntry],
 			},
-			select: async (_title: string, options: string[]) => {
+			select: async (title: string, options: string[]) => {
+				assert.match(title, /After Implement: Keep plan active until \/plan exit/i);
 				assert.deepEqual(
 					options.filter((option) => option !== "Close"),
 					[

--- a/extensions/pi-plan-mode/test/settings-menu.test.ts
+++ b/extensions/pi-plan-mode/test/settings-menu.test.ts
@@ -22,7 +22,12 @@ async function withSettingsMenu(
 	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-settings-menu-"));
 	const settingsPath = join(directory, "pi-plan-mode.json");
 	const tui = createTuiHarness({ width: 72, rows: 24 });
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const context = createMockContext({
+		cwd: directory,
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+	});
 	const saved: PlanModeSettings[] = [];
 	try {
 		await run({ settingsPath, tui, ctx: context.ctx, notifications: context.notifications, saved });
@@ -47,14 +52,16 @@ function menuOptions(
 	};
 }
 
-test("Plan settings show thinking and default tools without materializing a missing file", async () => {
+test("Plan settings show four flat workflow rows without materializing a missing file", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
 		const frame = tui.render().join("\n");
 		assert.match(frame, /Plan Mode Settings/);
-		assert.match(frame, /Thinking level\s+inherit/);
-		assert.match(frame, /Default tools\s+Automatic safe built-ins/);
+		assert.match(frame, /Plan thinking\s+inherit/);
+		assert.match(frame, /Plan tools\s+Automatic safe built-ins/);
+		assert.match(frame, /After Implement\s+Keep plan active/);
+		assert.match(frame, /Export destination\s+PLAN\.md/);
 		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
 		await assert.rejects(access(settingsPath));
 
@@ -78,7 +85,7 @@ test("Plan settings save thinking immediately for the next workflow", async () =
 			"off",
 		);
 		assert.equal(saved.at(-1)?.thinkingLevel, "off");
-		assert.match(tui.render().join("\n"), /Thinking level\s+off/);
+		assert.match(tui.render().join("\n"), /Plan thinking\s+off/);
 		tui.press("ctrl+c");
 		await running;
 	});
@@ -113,7 +120,7 @@ test("Default tools distinguish automatic, explicit empty, user risk, blocked ro
 		tui.press("tui.select.cancel");
 		await tui.waitForPending();
 		await tui.waitForOpen();
-		assert.match(tui.render().join("\n"), /Default tools\s+Required tools only/);
+		assert.match(tui.render().join("\n"), /Plan tools\s+Required tools only/);
 
 		// Reopen and choose the pinned reset action after the three tool rows.
 		tui.press("tui.select.confirm");
@@ -158,6 +165,82 @@ test("Default tools retain configured names that are unavailable in the current 
 	});
 });
 
+test("After Implement cycles outcomes and export destination saves, previews, resets, and cancels", async () => {
+	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
+		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.implementationPlanRetention, "clear-on-start");
+		assert.match(tui.render().join("\n"), /After Implement\s+Use plan for handoff only/);
+
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		const frame = tui.render().join("\n");
+		assert.match(frame, /Export destination/i);
+		assert.match(frame, /PLAN\.md/);
+		assert.match(
+			frame,
+			new RegExp(
+				settingsPath
+					.replace("pi-plan-mode.json", "PLAN.md")
+					.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"),
+			),
+		);
+		tui.type("docs/PLAN.md");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.defaultPlanExportPath, "docs/PLAN.md");
+		assert.match(tui.render().join("\n"), /Export destination\s+docs\/PLAN\.md/);
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.defaultPlanExportPath, undefined);
+		assert.match(tui.render().join("\n"), /Export destination\s+PLAN\.md/);
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.type("cancelled.md");
+		tui.press("tui.select.cancel");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.defaultPlanExportPath, undefined);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("long export previews stay within narrow terminal widths", async () => {
+	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
+		const longPath = `plans/${"nested-".repeat(16)}PLAN.md`;
+		await writeFile(settingsPath, JSON.stringify({ defaultPlanExportPath: longPath }));
+		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
+		await tui.waitForOpen();
+		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /nested-/);
+		assert.ok(tui.render(26).every((line) => visibleWidth(line) <= 26));
+		tui.press("tui.select.cancel");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
 test("Invalid Plan settings are read-only and save failures roll back displayed values", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, notifications, saved }) => {
 		await writeFile(settingsPath, "{mock-sensitive-token");
@@ -169,6 +252,15 @@ test("Invalid Plan settings are read-only and save failures roll back displayed 
 		tui.press("ctrl+c");
 		await running;
 		assert.equal(await readFile(settingsPath, "utf8"), "{mock-sensitive-token");
+
+		await writeFile(settingsPath, '{"defaultPlanExportPath":"bad\\u001bpath"}');
+		running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
+		await tui.waitForOpen();
+		const controlInvalid = tui.render().join("\n");
+		assert.match(controlInvalid, /Read only/);
+		assert.doesNotMatch(controlInvalid, /bad.*path/is);
+		tui.press("ctrl+c");
+		await running;
 
 		await rm(settingsPath);
 		running = showPlanModeSettings(
@@ -183,7 +275,7 @@ test("Invalid Plan settings are read-only and save failures roll back displayed 
 		tui.press("tui.select.confirm");
 		await tui.waitForPending();
 		await tui.waitForOpen();
-		assert.match(tui.render().join("\n"), /Thinking level\s+inherit/);
+		assert.match(tui.render().join("\n"), /Plan thinking\s+inherit/);
 		const message = notifications.at(-1)?.message ?? "";
 		assert.match(message, /previous value remains/i);
 		assert.equal(
@@ -198,11 +290,72 @@ test("Invalid Plan settings are read-only and save failures roll back displayed 
 	});
 });
 
-test("Plan settings adapt to RPC and disposal aborts an in-flight save", async () => {
+test("RPC Settings changes retention and export destination with the same flat navigation", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-settings-rpc-"));
+	const settingsPath = join(directory, "pi-plan-mode.json");
+	try {
+		const rpc = createRpcHarness([
+			{
+				kind: "select",
+				options: [
+					"Plan thinking (inherit)",
+					"Plan tools (Automatic safe built-ins)",
+					"After Implement (Keep plan active)",
+					"Export destination (PLAN.md)",
+					"Back",
+				],
+				response: "After Implement (Keep plan active)",
+			},
+			{
+				kind: "select",
+				options: [
+					"Plan thinking (inherit)",
+					"Plan tools (Automatic safe built-ins)",
+					"After Implement (Use plan for handoff only)",
+					"Export destination (PLAN.md)",
+					"Back",
+				],
+				response: "Export destination (PLAN.md)",
+			},
+			{
+				kind: "input",
+				placeholder: "PLAN.md",
+				response: "rpc/PLAN.md",
+			},
+			{
+				kind: "select",
+				options: [
+					"Plan thinking (inherit)",
+					"Plan tools (Automatic safe built-ins)",
+					"After Implement (Use plan for handoff only)",
+					"Export destination (rpc/PLAN.md)",
+					"Back",
+				],
+				response: undefined,
+			},
+		]);
+		const context = createMockContext({ cwd: directory, mode: "rpc", hasUI: true, ...rpc.ui });
+		const saved: PlanModeSettings[] = [];
+		await showPlanModeSettings(context.ctx, menuOptions(settingsPath, saved));
+		rpc.assertConsumed();
+		assert.equal(saved.at(-1)?.implementationPlanRetention, "clear-on-start");
+		assert.equal(saved.at(-1)?.defaultPlanExportPath, "rpc/PLAN.md");
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("Plan settings adapt to RPC cancellation and disposal aborts an in-flight save", async () => {
 	const rpc = createRpcHarness([
 		{
 			kind: "select",
-			options: ["Thinking level (inherit)", "Default tools (Automatic safe built-ins)", "Back"],
+			options: [
+				"Plan thinking (inherit)",
+				"Plan tools (Automatic safe built-ins)",
+				"After Implement (Keep plan active)",
+				"Export destination (PLAN.md)",
+				"Back",
+			],
 			response: undefined,
 		},
 	]);

--- a/extensions/pi-plan-mode/test/settings.test.ts
+++ b/extensions/pi-plan-mode/test/settings.test.ts
@@ -14,6 +14,8 @@ import { join } from "node:path";
 import test from "node:test";
 import {
 	awaitPlanModeSettingsWrites,
+	configuredImplementationPlanRetention,
+	configuredPlanExportPath,
 	normalizePlanModeSettings,
 	readPlanModeSettings,
 	updatePlanModeSettings,
@@ -74,6 +76,47 @@ test("Plan-mode settings normalize default tool names strictly", async () => {
 		});
 	} finally {
 		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("Plan-mode settings validate implementation retention and export defaults", () => {
+	for (const implementationPlanRetention of [
+		"keep",
+		"clear-on-start",
+		"clear-after-first-run",
+	] as const) {
+		const normalized = normalizePlanModeSettings({ implementationPlanRetention });
+		assert.ok(normalized);
+		assert.equal(normalized.implementationPlanRetention, implementationPlanRetention);
+		assert.equal(configuredImplementationPlanRetention(normalized), implementationPlanRetention);
+	}
+	assert.equal(
+		normalizePlanModeSettings({ implementationPlanRetention: "clear-eventually" }),
+		undefined,
+	);
+
+	assert.deepEqual(normalizePlanModeSettings({ defaultPlanExportPath: "docs/PLAN.md" }), {
+		thinkingLevel: "inherit",
+		defaultPlanExportPath: "docs/PLAN.md",
+	});
+	const normalizedPath = normalizePlanModeSettings({
+		defaultPlanExportPath: " docs/PLAN.md ",
+	});
+	assert.ok(normalizedPath);
+	assert.equal(configuredPlanExportPath(normalizedPath), "docs/PLAN.md");
+	const defaults = normalizePlanModeSettings({});
+	assert.ok(defaults);
+	assert.equal(configuredImplementationPlanRetention(defaults), "keep");
+	assert.equal(configuredPlanExportPath(defaults), "PLAN.md");
+	for (const defaultPlanExportPath of [
+		"",
+		"   ",
+		"bad\0path",
+		"bad\u001bpath",
+		"x".repeat(4097),
+		42,
+	]) {
+		assert.equal(normalizePlanModeSettings({ defaultPlanExportPath }), undefined);
 	}
 });
 
@@ -166,11 +209,46 @@ test("Plan-mode settings updates create only on explicit save and preserve unkno
 	}
 });
 
+test("Plan-mode settings patch retention and export fields from the latest document", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-settings-new-fields-"));
+	const settingsPath = join(directory, "pi-plan-mode.json");
+	try {
+		await writeFile(
+			settingsPath,
+			'{"thinkingLevel":"low","future":{"kept":true},"defaultPlanExportPath":"old.md"}\n',
+		);
+		await updatePlanModeSettings(
+			{
+				implementationPlanRetention: "clear-after-first-run",
+				defaultPlanExportPath: "docs/PLAN.md",
+			},
+			{ settingsPath },
+		);
+		await updatePlanModeSettings({ defaultPlanExportPath: null }, { settingsPath });
+
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			thinkingLevel: "low",
+			future: { kept: true },
+			implementationPlanRetention: "clear-after-first-run",
+		});
+		assert.deepEqual(await readPlanModeSettings(settingsPath), {
+			kind: "loaded",
+			settings: {
+				thinkingLevel: "low",
+				implementationPlanRetention: "clear-after-first-run",
+			},
+		});
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
 test("Plan-mode settings explicit save promotes valid legacy content without modifying it", async () => {
 	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-settings-promote-"));
 	const settingsPath = join(directory, "pi-plan-mode.json");
 	const legacySettingsPath = join(directory, "plan-mode.json");
-	const legacy = '{"thinkingLevel":"low","defaultPlanTools":["read"],"future":{"kept":true}}\n';
+	const legacy =
+		'{"thinkingLevel":"low","defaultPlanTools":["read"],"implementationPlanRetention":"clear-on-start","defaultPlanExportPath":"plans/PLAN.md","future":{"kept":true}}\n';
 	try {
 		await writeFile(legacySettingsPath, legacy);
 		await updatePlanModeSettings({ thinkingLevel: "high" }, { settingsPath, legacySettingsPath });
@@ -179,6 +257,8 @@ test("Plan-mode settings explicit save promotes valid legacy content without mod
 		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
 			thinkingLevel: "high",
 			defaultPlanTools: ["read"],
+			implementationPlanRetention: "clear-on-start",
+			defaultPlanExportPath: "plans/PLAN.md",
 			future: { kept: true },
 		});
 	} finally {
@@ -269,14 +349,28 @@ test("Plan-mode settings serialize updates, coordinate reads, and recover after 
 				},
 			},
 		);
-		const second = updatePlanModeSettings({ thinkingLevel: "medium" }, { settingsPath });
+		const second = updatePlanModeSettings(
+			{
+				thinkingLevel: "medium",
+				implementationPlanRetention: "clear-after-first-run",
+			},
+			{ settingsPath },
+		);
+		const third = updatePlanModeSettings(
+			{ defaultPlanExportPath: "ordered/PLAN.md" },
+			{ settingsPath },
+		);
 		const coordinatedRead = readPlanModeSettings(settingsPath);
 		await firstReached;
 		releaseFirst();
-		await Promise.all([first, second]);
+		await Promise.all([first, second, third]);
 		assert.deepEqual(await coordinatedRead, {
 			kind: "loaded",
-			settings: { thinkingLevel: "medium" },
+			settings: {
+				thinkingLevel: "medium",
+				implementationPlanRetention: "clear-after-first-run",
+				defaultPlanExportPath: "ordered/PLAN.md",
+			},
 		});
 
 		await assert.rejects(
@@ -291,10 +385,11 @@ test("Plan-mode settings serialize updates, coordinate reads, and recover after 
 		);
 		await updatePlanModeSettings({ thinkingLevel: "max" }, { settingsPath });
 		await awaitPlanModeSettingsWrites(settingsPath);
-		assert.equal(
-			(JSON.parse(await readFile(settingsPath, "utf8")) as { thinkingLevel: string }).thinkingLevel,
-			"max",
-		);
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			thinkingLevel: "max",
+			implementationPlanRetention: "clear-after-first-run",
+			defaultPlanExportPath: "ordered/PLAN.md",
+		});
 	} finally {
 		releaseFirst();
 		await rm(directory, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- add flat **After Implement** and **Export destination** rows to Plan Mode Settings
- capture `keep`, handoff-only, or first-settled-run retention per implementation, with matching context/settlement lifecycle guards
- apply configurable export defaults across ready, saved, and active plans while preserving explicit path precedence and no-overwrite behavior
- document the settings, timing, compatibility, and compaction trade-offs
- replace a pre-existing 5 ms `pi-btw` settings-test delay with a deterministic gate so the repository check is stable under parallel load

## Verification

- 160 focused `pi-plan-mode` tests
- `npm test` (2,309 tests)
- `npm run check`
- `just pack plan-mode` (27 files inspected)
- isolated real RPC smoke: four Settings rows, retention preview, configured default export, and active-plan cleanup

## Notes

- Read and audited `docs/extension-conventions.md` and `docs/extension-settings.md`.
- No package metadata, dependency range, version, publish, or visibility changes.
- Completed plan archived at `docs/plans/archived/2026-08-03_plan-mode-handoff-export-defaults-plan.md`.
