### PR TITLE
fix(goal): abort current turn on stale tool-call block

### DIFF
--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -799,6 +799,10 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 			clearStaleGoalToolCallBlock();
 			return;
 		}
+		// A blocked tool result would normally trigger another model call. Abort the
+		// current turn so a tool-seeking model cannot create an unbounded loop that
+		// burns provider quota while the goal is stopped.
+		abortCurrentTurn(ctx);
 		return {
 			block: true,
 			reason: "Blocked stale /goal tool call after the goal stopped or was interrupted.",


### PR DESCRIPTION
## Summary

A blocked tool result still triggers the next model call in pi-agent-core (`shouldTerminateToolBatch` requires `result.terminate === true`, which the `block: true` path never sets). When a goal pauses after an interruption, a tool-seeking model can loop on the same blocked tool call indefinitely, burning provider quota until the account hits its usage limit.

The `budget_limited` wrap-up path already calls `abortCurrentTurn` before blocking for exactly this reason. This PR applies the same abort to the stale-goal tool-call block.

## Status: speculative fix

I have **not reproduced the original loop** to confirm this fully breaks it. The issue is not reliably reproducible (requires a goal to pause mid-run while the agent loop is active and the model to keep requesting tools).

What I have verified:
- `npm run typecheck` clean (whole workspace)
- `test/goal-runtime-smoke.mjs` passes

What I have not verified:
- a successful reproduction → fix → no loop

Filed #544 with the full analysis.

## The change

```diff
   if (!runtime.activeGoal || !blocksStaleGoalToolCalls(runtime.activeGoal.status)) {
       clearStaleGoalToolCallBlock();
       return;
   }
+  // A blocked tool result would normally trigger another model call. Abort the
+  // current turn so a tool-seeking model cannot create an unbounded loop that
+  // burns provider quota while the goal is stopped.
+  abortCurrentTurn(ctx);
   return {
       block: true,
       reason: "Blocked stale /goal tool call after the goal stopped or was interrupted.",
   };
```

Mirrors the existing budget-path abort a few lines above in the same handler.

## Note on the deeper root cause

The real fix is likely in pi-agent-core: a blocked `immediate` result should be treated as terminal in `shouldTerminateToolBatch` (or the `block: true` path should set a terminate flag). That would protect every extension, not just pi-goal. This PR is a pi-goal-side mitigation only.

## Related
- Fixes #544
- Relates to #115, #338