### PR TITLE
feat(recall): add experimental saved message extension

### DIFF
--- a/docs/plans/archived/2026-08-04_pi-recall-plan.md
+++ b/docs/plans/archived/2026-08-04_pi-recall-plan.md
@@ -1,0 +1,39 @@
+# Experimental Pi Recall implementation plan
+
+## Goal
+
+Add `experimental/pi-recall` (`@narumitw/pi-recall`, `/recall`) so users can save a text user or assistant message from the active session branch, then preview, quote, or delete it across sessions through All, Current cwd, and Current session scopes.
+
+## Architecture
+
+- Store versioned `recall_message` records in `getAgentDir()/pi-recall.jsonl`.
+- Keep only raw text plus bounded source metadata; never inject saved content into model context automatically.
+- Serialize cross-process read-modify-write operations with `proper-lockfile`, cancellable extension-owned retry, private temporary files, and atomic replacement.
+- Use Pi TUI Kit standard screens for the manager, save choice, selected actions, reviews, status, and help. Use `runCustomInteraction()` only for the TUI scoped picker; RPC receives explicit scope and message dialogs.
+- Own every interaction with a per-session generation and `AbortController`; abort and drain on reload, replacement, fork, and shutdown.
+
+## Non-goals
+
+No tags, text search, editing, import/export, automatic expiry, automatic context injection, cross-session transcript reading, settings, tools, or publication.
+
+## Plan
+
+- [x] Add failing focused tests for text extraction, source identity, scope filtering, previews, and XML-safe quote formatting; red: `tsc -p tsconfig.test.json` could not resolve `src/messages.js`; green: focused Node test passed 5/5.
+- [x] Add failing focused tests for JSONL validation, limits, private regular-file checks, abort-aware cross-process locking, atomic save/delete, unknown-field preservation, malformed/newer/symlink/interrupted-write protection, and concurrent store instances; red: `tsc -p tsconfig.test.json` could not resolve `src/store.js`, and the later generated-ID collision test failed before its guard; green: focused store suite passed 8/8.
+- [x] Add failing TUI/RPC tests for `/recall`, standard menu flows, save, preview, quote, confirmed delete, cancellation, empty/error states, argument rejection, and unsupported modes; red: `src/menu.js` was absent; green: menu suite passed 7/7.
+- [x] Add failing scoped-picker tests for Current cwd default, Tab/Shift+Tab scope cycling, counts, stable selection, Back/Close, narrow widths, terminal-control sanitization, disposal, and owner replacement; red: `src/picker.js` was absent; green: picker suite passed 5/5, with owner cancellation also covered by the menu/lifecycle suites.
+- [x] Add failing lifecycle tests for startup warning, replacement while a menu or lock wait is active, shutdown, post-publication staleness, and no stale UI/context access; red: `createRecallExtension` did not exist; green: lifecycle suite passed 5/5 and the store lock-abort test passed.
+- [x] Add the thin entrypoint, package manifest, TypeScript config, MIT license, and English README with experimental warning, standard badges/headings, exact behavior, privacy, limits, deletion semantics, and package layout; package check and boundary validator passed.
+- [x] With Node 22.22.2 and npm 12.0.2, add Pi TUI Kit/proper-lockfile dependencies, update the workspace lockfile, and add root `pack:recall`, `pack-recall`, and `try-recall` helpers; npm version was verified through the pinned `npm@12.0.2` invocation and `just --list` exposes both aliases.
+- [x] Run focused tests, package typecheck, `npm run check:boundaries`, `npm run check`, `just pack recall`, inspect packed files, and run a non-interactive RPC load smoke that observes the warning and `/recall` command; evidence: 30/30 focused tests, all workspace typechecks, Biome over 711 files, 25-extension boundary pass, and 2,339/2,339 root tests passed in an isolated normal clone (avoiding linked-worktree Git injection and real user settings). Dry-run tarball contained only 9 allowed files. RPC `get_commands` observed the experimental warning and registered `recall`.
+- [x] Audit the final diff against `docs/extension-conventions.md` for experimental package, entrypoint, command modes, custom TUI lifecycle, file mutation, documentation, tests, pack, and runtime loading. All applicable MUST rules are covered; `docs/extension-settings.md` is not applicable because Pi Recall has no settings. No accepted product deviation remains.
+
+## Completion Checklist
+
+- [x] A non-latest text user/assistant message on the active branch can be saved; abandoned branches and unsupported/empty/oversized content are excluded without mutation.
+- [x] Saved messages survive sessions and filter correctly by normalized cwd or exact session ID; TUI scope switching preserves a still-visible saved ID.
+- [x] Preview is exact, quote only edits the draft and excludes local identifiers, and confirmed deletion removes the canonical record while cancellation is byte-for-byte inert.
+- [x] Concurrent processes do not lose updates or leave locks; invalid, newer, oversized, symlinked, or interrupted storage remains protected.
+- [x] TUI/RPC, narrow/untrusted content, disposal, replacement, shutdown, print/JSON rejection, and experimental warning behavior are covered.
+- [x] Root checks, package dry run, and non-interactive Pi load smoke pass.
+- [x] Plan evidence is complete and this file is archived under `docs/plans/archived/`.

--- a/experimental/pi-recall/LICENSE
+++ b/experimental/pi-recall/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/experimental/pi-recall/README.md
+++ b/experimental/pi-recall/README.md
@@ -1,0 +1,146 @@
+# 🧠 Pi Recall — Saved Messages for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-recall)](https://www.npmjs.com/package/@narumitw/pi-recall) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+> [!WARNING]
+> Pi Recall is experimental. Its storage format and interaction flow may change between releases.
+
+`@narumitw/pi-recall` saves selected text messages from the active Pi session branch and lets you preview or quote them in another session. Saved content remains local until you explicitly insert a quote into a draft and submit it.
+
+## ✨ Features
+
+- Saves any eligible user or assistant text message from the current active session branch—not only the latest message.
+- Recalls saved messages across sessions using **Current cwd**, **All**, or **Current session** scope.
+- Cycles TUI scope with `Tab` and `Shift+Tab`, with the active scope and result count always visible.
+- Previews the complete saved text before use.
+- Inserts an XML-marked quote at the TUI editor cursor without submitting it automatically.
+- Stores versioned JSONL locally with cross-process locking, private permissions, and atomic replacement.
+- Fails closed when storage is malformed, unsupported, oversized, symlinked, or not a regular file.
+
+## 📦 Install
+
+Install persistently from npm:
+
+```bash
+pi install npm:@narumitw/pi-recall
+```
+
+Try from npm without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-recall
+```
+
+Try this package from a local checkout:
+
+```bash
+pi -e ./experimental/pi-recall
+```
+
+## 🚀 Quick start
+
+1. Run `/recall`.
+2. Choose **Save a message** and select a text user or assistant message from the active branch.
+3. In any later session, run `/recall` and choose **Recall a saved message**.
+4. In TUI mode, press `Tab` or `Shift+Tab` to change scope. RPC mode asks for scope explicitly.
+5. Preview the message or choose **Quote into draft**.
+6. Add your question or instruction, then submit the draft normally.
+
+A quoted draft uses this form:
+
+```xml
+<recalled_message role="assistant" message_timestamp="2026-08-04T12:34:56.000Z">
+Original message text
+</recalled_message>
+
+The user intentionally recalled and quoted the saved message above.
+```
+
+The quote sent to the editor omits cwd, session IDs, entry IDs, session files, and other local paths.
+
+## 💬 Commands
+
+| Command | Modes | Description |
+| --- | --- | --- |
+| `/recall` | TUI, RPC | Open the Pi Recall manager. Arguments are rejected. |
+
+Print and JSON modes reject `/recall` before opening an interactive flow. TUI and RPC expose the same save, preview, quote, delete, status, and help capabilities; RPC uses explicit dialogs instead of terminal shortcuts. In RPC, quoting emits Pi's `set_editor_text` extension UI request.
+
+## 🧭 Recall scopes
+
+- **Current cwd** — saved messages whose normalized absolute source cwd matches the current cwd. This is the default each time the picker opens.
+- **All** — every valid record in the current Pi agent directory.
+- **Current session** — records whose source session ID exactly matches the current session.
+
+Scope applies only when recalling already saved messages. The save picker intentionally reads only `ctx.sessionManager.getBranch()` from the current session and never scans other session files. TUI scope switching keeps the selected saved record when it remains visible in the new scope; otherwise it selects the newest visible record.
+
+## 🔒 Storage, privacy, and recovery
+
+The canonical user file is:
+
+```text
+~/.pi/agent/pi-recall.jsonl
+```
+
+Pi's configured agent directory replaces `~/.pi/agent` when applicable. Each line is one active versioned `recall_message` record. Records contain the text, role, saved time, original message time, source cwd, source session ID, source entry ID, and optional session name. This provenance is shown locally but is excluded from generated quote payloads except for role and original message time.
+
+Pi Recall does not create settings, session custom entries, tools, background processes, watchers, or automatic model context. It reads storage only when `/recall` needs it.
+
+Save and delete operations acquire one cross-process lock, reread canonical storage under that lock, and publish a complete JSONL replacement through a unique same-directory `0600` temporary file. Lock waiting is abort-aware. The canonical file is required to be a regular non-symlink file and is kept at `0600`.
+
+Malformed JSON, duplicate IDs, unknown record types or versions, invalid records, symlinks, and limit violations make storage read-only. Fix or move the reported file, then reopen `/recall`; Pi Recall never overwrites invalid storage. Unknown fields on otherwise valid version-1 records survive later rewrites.
+
+Deleting a message removes it from canonical `pi-recall.jsonl`. It is not secure erasure of filesystem blocks, backups, snapshots, temporary copies left by an operating-system failure, or content already quoted into a session.
+
+## 📝 Message semantics and limits
+
+- Eligible sources are `message` entries with role `user` or `assistant` on the active branch.
+- User strings and text blocks are kept; multiple text blocks are joined in source order with newlines.
+- Thinking, tool calls, tool results, images/base64, custom messages, image-only messages, empty text, and abandoned branches are not saved.
+- Markdown, indentation, Unicode, and original line breaks are preserved. Oversized messages are excluded rather than truncated.
+- A source message can be saved only once for the same source session ID and entry ID.
+- At most 200 messages may be saved.
+- One message text may contain at most 50,000 UTF-8 bytes.
+- Canonical JSONL may contain at most 12 MiB.
+- Records are never evicted automatically.
+
+Terminal controls are removed from labels, previews, metadata, and errors before display. Full review content is passed through Pi TUI Kit's sanitized review renderer. The raw stored text is not modified merely for display.
+
+## 🚧 Experimental limitations
+
+- No tags, text search, editing, reordering, import/export, automatic expiry, or automatic context injection.
+- No cross-session transcript browser: only previously saved records can be recalled across sessions.
+- Text only; images and tool payloads are deliberately omitted.
+- The custom TUI picker is keyboard-operated. RPC uses sequential dialogs.
+- Scope preference is not persisted; every new picker starts at **Current cwd**.
+
+## 🗂️ Package layout
+
+```text
+experimental/pi-recall/
+├── src/
+│   ├── index.ts       # Thin Pi package entrypoint
+│   ├── menu.ts        # Standard manager screens and TUI/RPC flow
+│   ├── messages.ts    # Text extraction, scope filtering, previews, and quote format
+│   ├── picker.ts      # Scoped TUI saved-message picker
+│   ├── recall.ts      # Command registration and session lifecycle ownership
+│   └── store.ts       # Locked, validated, atomic JSONL storage
+├── test/
+│   ├── menu.test.ts
+│   ├── messages.test.ts
+│   ├── picker.test.ts
+│   ├── recall.test.ts
+│   └── store.test.ts
+├── README.md
+├── LICENSE
+├── package.json
+└── tsconfig.json
+```
+
+## 🔎 Keywords
+
+Pi extension, saved messages, message recall, cross-session context, quote manager, JSONL, terminal UI.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/experimental/pi-recall/package.json
+++ b/experimental/pi-recall/package.json
@@ -30,7 +30,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.47.1",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"proper-lockfile": "^4.1.2"
 	},
 	"peerDependencies": {

--- a/experimental/pi-recall/package.json
+++ b/experimental/pi-recall/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@narumitw/pi-recall",
+	"version": "0.47.1",
+	"description": "Experimental Pi extension for saving and recalling messages across sessions.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"messages",
+		"recall",
+		"context",
+		"quote"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.47.1",
+		"proper-lockfile": "^4.1.2"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.6",
+		"@earendil-works/pi-coding-agent": "0.83.0",
+		"@earendil-works/pi-tui": "0.83.0",
+		"@types/node": "26.1.2",
+		"@types/proper-lockfile": "^4.1.4",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "experimental/pi-recall"
+	}
+}

--- a/experimental/pi-recall/src/index.ts
+++ b/experimental/pi-recall/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./recall.js";

--- a/experimental/pi-recall/src/menu.ts
+++ b/experimental/pi-recall/src/menu.ts
@@ -1,0 +1,384 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runCustomInteraction, runMenu } from "@narumitw/pi-tui-kit";
+import {
+	candidateIdentity,
+	filterRecallMessages,
+	formatRecallQuote,
+	type MessageCandidate,
+	messagePreview,
+	type RecallMessageRecord,
+	type RecallScope,
+	type RecallScopeContext,
+} from "./messages.js";
+import {
+	ScopedRecallPicker,
+	type ScopedRecallPickerResult,
+	sanitizeTerminalText,
+} from "./picker.js";
+import { MAX_RECALL_FILE_BYTES, MAX_RECALL_RECORDS, type RecallStoreSnapshot } from "./store.js";
+
+export interface RecallMenuSource {
+	path: string;
+	current: RecallScopeContext;
+	candidates: readonly MessageCandidate[];
+	load(signal?: AbortSignal): Promise<RecallStoreSnapshot>;
+	save(candidate: MessageCandidate, signal?: AbortSignal): Promise<RecallMessageRecord>;
+	delete(id: string, signal?: AbortSignal): Promise<boolean>;
+}
+
+interface RecallMenuState {
+	path: string;
+	current: RecallScopeContext;
+	candidates: readonly MessageCandidate[];
+	records: readonly RecallMessageRecord[];
+	bytes: number;
+	error?: string;
+	selected?: RecallMessageRecord;
+}
+
+type Screen = "main" | "save" | "selected" | "preview" | "delete" | "status" | "help";
+type Action = "saveMessage" | "chooseSaved" | "quote" | "deleteMessage";
+
+const SCOPE_LABELS: Record<RecallScope, string> = {
+	cwd: "Current cwd",
+	all: "All",
+	session: "Current session",
+};
+
+export function createRecallMenu(
+	source: RecallMenuSource,
+	ownership: { isCurrent?: () => boolean } = {},
+) {
+	let selectedRecordId: string | undefined;
+	let selectedScope: RecallScope = "cwd";
+	let pickerSelectedId: string | undefined;
+
+	const getState = async ({ signal }: { signal: AbortSignal }): Promise<RecallMenuState> => {
+		try {
+			const snapshot = await source.load(signal);
+			return {
+				path: source.path,
+				current: source.current,
+				candidates: source.candidates,
+				records: snapshot.records,
+				bytes: snapshot.bytes,
+				selected: snapshot.records.find(({ id }) => id === selectedRecordId),
+			};
+		} catch (error) {
+			return {
+				path: source.path,
+				current: source.current,
+				candidates: source.candidates,
+				records: [],
+				bytes: 0,
+				error: safeErrorMessage(error),
+			};
+		}
+	};
+
+	const menu = defineMenu<RecallMenuState, Screen, Action>({
+		start: "main",
+		screens: {
+			main: ({ state }) => ({
+				kind: "actions",
+				title: `Pi Recall · ${state.records.length} saved`,
+				lines: state.error
+					? [`Storage unavailable: ${state.error}`, "Existing storage remains read-only."]
+					: state.records.length === 0
+						? ["No saved messages yet."]
+						: undefined,
+				items: [
+					{ id: "save", label: "Save a message", to: "save", disabled: Boolean(state.error) },
+					{
+						id: "recall",
+						label: "Recall a saved message",
+						action: "chooseSaved",
+						disabled: Boolean(state.error),
+					},
+					{ id: "status", label: "Status", to: "status" },
+					{ id: "help", label: "Help", to: "help" },
+					{ id: "close", label: "Close", close: true },
+				],
+				hint: "close",
+			}),
+			save: ({ state }) => saveScreen(state),
+			selected: ({ state }) => selectedScreen(state),
+			preview: ({ state }) => ({
+				kind: "review",
+				title: "Saved message preview",
+				lines: state.selected
+					? sourceLines(state.selected)
+					: ["The saved message is no longer available."],
+				content: state.selected?.text ?? "",
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				hint: "back",
+			}),
+			delete: ({ state }) => ({
+				kind: "review",
+				title: "Delete saved message?",
+				lines: state.selected
+					? [
+							...sourceLines(state.selected),
+							"This removes the record from canonical JSONL but is not secure filesystem erasure.",
+						]
+					: ["The saved message is no longer available."],
+				content: state.selected?.text ?? "",
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				...(state.selected
+					? {
+							confirm: {
+								id: "delete-confirm",
+								label: "Delete saved message",
+								action: "deleteMessage" as const,
+							},
+						}
+					: {}),
+				hint: "back",
+			}),
+			status: ({ state }) => ({
+				kind: "detail",
+				title: "Pi Recall status",
+				lines: [
+					`Storage: ${state.path}`,
+					`Saved messages: ${state.records.length} / ${MAX_RECALL_RECORDS}`,
+					`Storage bytes: ${state.bytes} / ${MAX_RECALL_FILE_BYTES}`,
+					`State: ${state.error ? `read-only · ${state.error}` : "ready"}`,
+				],
+				hint: "back",
+			}),
+			help: () => ({
+				kind: "detail",
+				title: "Pi Recall help",
+				lines: [
+					"Save captures one text user or assistant message from the active session branch.",
+					"Recall defaults to Current cwd. In TUI, Tab and Shift+Tab change scope.",
+					"Quote inserts an XML-marked excerpt into the draft and never submits it automatically.",
+					"Saved content stays local until you submit a quoted draft.",
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			saveMessage: async ({ ctx, state, signal, itemId }) => {
+				const candidate = state.candidates.find(({ entryId }) => entryId === itemId);
+				if (!candidate) return { kind: "rejected", error: new Error("Message is unavailable") };
+				await source.save(candidate, signal);
+				if (!signal.aborted && isCurrent(ownership)) {
+					safeNotify(ctx, "Saved message to Pi Recall.", "info");
+				}
+				return signal.aborted || !isCurrent(ownership)
+					? { kind: "close" }
+					: { kind: "to", screen: "main" };
+			},
+			chooseSaved: async ({ ctx, state, signal }) => {
+				const result =
+					ctx.mode === "tui"
+						? await chooseSavedInTui(ctx, state, signal, ownership, selectedScope, pickerSelectedId)
+						: await chooseSavedInRpc(ctx, state, signal, selectedScope);
+				if (!result || result.kind === "back") return { kind: "stay" };
+				if (result.kind === "close") return { kind: "close" };
+				selectedScope = result.scope;
+				pickerSelectedId = result.recordId;
+				selectedRecordId = result.recordId;
+				return { kind: "to", screen: "selected" };
+			},
+			quote: ({ ctx, state }) => {
+				if (!state.selected)
+					return { kind: "rejected", error: new Error("Saved message is unavailable") };
+				ctx.ui.pasteToEditor(formatRecallQuote(state.selected));
+				return { kind: "close" };
+			},
+			deleteMessage: async ({ ctx, state, signal }) => {
+				if (!state.selected) return { kind: "back" };
+				const deleted = await source.delete(state.selected.id, signal);
+				if (deleted && !signal.aborted && isCurrent(ownership)) {
+					safeNotify(ctx, "Deleted saved message from Pi Recall.", "info");
+				}
+				selectedRecordId = undefined;
+				pickerSelectedId = undefined;
+				return signal.aborted || !isCurrent(ownership)
+					? { kind: "close" }
+					: { kind: "to", screen: "main" };
+			},
+		},
+	});
+
+	return {
+		menu,
+		getState,
+		selectRecordForTest(id: string) {
+			selectedRecordId = id;
+		},
+	};
+}
+
+export async function showRecallMenu(
+	ctx: ExtensionCommandContext,
+	source: RecallMenuSource,
+	ownership: { signal: AbortSignal; isCurrent: () => boolean },
+): Promise<void> {
+	const controller = createRecallMenu(source, ownership);
+	await runMenu(ctx, controller.menu, {
+		getState: controller.getState,
+		signal: ownership.signal,
+		isCurrent: ownership.isCurrent,
+		onError: (_ctx, error) => {
+			if (ownership.isCurrent() && !ownership.signal.aborted) {
+				safeNotify(ctx, `Pi Recall failed: ${safeErrorMessage(error)}`, "error");
+			}
+		},
+	});
+}
+
+function saveScreen(state: RecallMenuState) {
+	const saved = new Set(
+		state.records.map((record) =>
+			candidateIdentity(record.source.sessionId, record.source.entryId),
+		),
+	);
+	return {
+		kind: "choice" as const,
+		title: "Save a message",
+		lines:
+			state.candidates.length === 0
+				? ["No eligible text user or assistant messages are on the active branch."]
+				: ["Choose one message from the active session branch."],
+		items: state.candidates.map((candidate) => {
+			const duplicate = saved.has(candidateIdentity(candidate.source.sessionId, candidate.entryId));
+			return {
+				id: candidate.entryId,
+				label: `${candidate.role} · ${new Date(candidate.messageTimestamp).toISOString()}`,
+				description: sanitizeTerminalText(messagePreview(candidate.text)),
+				details: [sanitizeTerminalText(messagePreview(candidate.text, 200))],
+				...(duplicate ? { disabled: true, disabledReason: "This message is already saved" } : {}),
+			};
+		}),
+		action: "saveMessage" as const,
+		viewportSize: 10,
+		hint: "back" as const,
+	};
+}
+
+function selectedScreen(state: RecallMenuState) {
+	return {
+		kind: "actions" as const,
+		title: "Saved message",
+		lines: state.selected
+			? [
+					...sourceLines(state.selected),
+					sanitizeTerminalText(messagePreview(state.selected.text, 200)),
+				]
+			: ["The saved message is no longer available."],
+		items: state.selected
+			? [
+					{ id: "preview", label: "Preview", to: "preview" as const },
+					{ id: "quote", label: "Quote into draft", action: "quote" as const },
+					{ id: "delete", label: "Delete…", to: "delete" as const },
+					{
+						id: "back-to-saved",
+						label: "Back to saved messages",
+						action: "chooseSaved" as const,
+					},
+				]
+			: [{ id: "back-to-saved", label: "Back to saved messages", action: "chooseSaved" as const }],
+		hint: "back" as const,
+	};
+}
+
+async function chooseSavedInTui(
+	ctx: ExtensionCommandContext,
+	state: RecallMenuState,
+	signal: AbortSignal,
+	ownership: { isCurrent?: () => boolean },
+	initialScope: RecallScope,
+	initialSelectedId: string | undefined,
+): Promise<ScopedRecallPickerResult | undefined> {
+	const interaction = await runCustomInteraction<ScopedRecallPickerResult>(ctx, {
+		signal,
+		isCurrent: () => isCurrent(ownership),
+		create: ({ tui, theme, keybindings, complete }) =>
+			new ScopedRecallPicker({
+				tui,
+				theme,
+				keybindings,
+				records: state.records,
+				current: state.current,
+				initialScope,
+				initialSelectedId,
+				complete,
+			}),
+	});
+	return interaction.kind === "completed" ? interaction.value : undefined;
+}
+
+async function chooseSavedInRpc(
+	ctx: ExtensionCommandContext,
+	state: RecallMenuState,
+	signal: AbortSignal,
+	initialScope: RecallScope,
+): Promise<ScopedRecallPickerResult | undefined> {
+	const scopeOptions = ["Current cwd", "All", "Current session", "Back"];
+	const initialLabel = SCOPE_LABELS[initialScope];
+	const orderedOptions = [
+		initialLabel,
+		...scopeOptions.filter((option) => option !== initialLabel),
+	];
+	const selectedScopeLabel = await ctx.ui.select("Choose scope", orderedOptions, { signal });
+	if (signal.aborted) return undefined;
+	if (!selectedScopeLabel || selectedScopeLabel === "Back") {
+		return { kind: "back", scope: initialScope };
+	}
+	const scope = Object.entries(SCOPE_LABELS).find(
+		([, label]) => label === selectedScopeLabel,
+	)?.[0] as RecallScope | undefined;
+	if (!scope) return { kind: "back", scope: initialScope };
+	const records = filterRecallMessages(state.records, scope, state.current).reverse();
+	if (records.length === 0) {
+		safeNotify(ctx, `No saved messages in ${SCOPE_LABELS[scope]}.`, "info");
+		return { kind: "back", scope };
+	}
+	const labels = records.map(
+		(record, index) =>
+			`${index + 1}. ${record.role} · ${new Date(record.source.messageTimestamp).toISOString()} · ${sanitizeTerminalText(messagePreview(record.text, 72))}`,
+	);
+	const choice = await ctx.ui.select("Choose saved message", [...labels, "Back"], { signal });
+	if (signal.aborted) return undefined;
+	if (!choice || choice === "Back") return { kind: "back", scope };
+	const index = labels.indexOf(choice);
+	const record = records[index];
+	return record
+		? { kind: "selected" as const, recordId: record.id, scope }
+		: { kind: "back", scope };
+}
+
+function sourceLines(record: RecallMessageRecord): string[] {
+	return [
+		`Role: ${record.role}`,
+		`Message time: ${new Date(record.source.messageTimestamp).toISOString()}`,
+		`Saved: ${record.savedAt}`,
+		`Session: ${sanitizeTerminalText(record.source.sessionName ?? "unnamed")}`,
+		`Source cwd: ${sanitizeTerminalText(record.source.cwd)}`,
+	];
+}
+
+function isCurrent(ownership: { isCurrent?: () => boolean }): boolean {
+	return ownership.isCurrent?.() ?? true;
+}
+
+function safeNotify(
+	ctx: ExtensionCommandContext,
+	message: string,
+	level: "info" | "warning" | "error",
+): void {
+	try {
+		ctx.ui.notify(sanitizeTerminalText(message), level);
+	} catch {
+		// A replaced session can invalidate its UI after a committed storage operation.
+	}
+}
+
+function safeErrorMessage(error: unknown): string {
+	return sanitizeTerminalText(error instanceof Error ? error.message : String(error));
+}

--- a/experimental/pi-recall/src/messages.ts
+++ b/experimental/pi-recall/src/messages.ts
@@ -1,0 +1,133 @@
+import path from "node:path";
+
+export const MAX_MESSAGE_TEXT_BYTES = 50_000;
+
+export type RecallRole = "user" | "assistant";
+export type RecallScope = "all" | "cwd" | "session";
+
+export interface RecallSourceContext {
+	sessionId: string;
+	sessionName?: string;
+	cwd: string;
+}
+
+export interface MessageCandidate {
+	entryId: string;
+	role: RecallRole;
+	text: string;
+	messageTimestamp: number;
+	source: RecallSourceContext;
+}
+
+export interface RecallMessageRecord {
+	type: "recall_message";
+	version: 1;
+	id: string;
+	savedAt: string;
+	source: {
+		sessionId: string;
+		entryId: string;
+		sessionName?: string;
+		cwd: string;
+		messageTimestamp: number;
+		[key: string]: unknown;
+	};
+	role: RecallRole;
+	text: string;
+	[key: string]: unknown;
+}
+
+export interface RecallScopeContext {
+	sessionId: string;
+	cwd: string;
+}
+
+export function extractMessageCandidates(
+	entries: readonly unknown[],
+	source: RecallSourceContext,
+): MessageCandidate[] {
+	const candidates: MessageCandidate[] = [];
+	for (const value of entries) {
+		if (!isRecord(value) || value.type !== "message" || typeof value.id !== "string") continue;
+		const message = value.message;
+		if (!isRecord(message) || (message.role !== "user" && message.role !== "assistant")) continue;
+		if (typeof message.timestamp !== "number" || !isValidTimestamp(message.timestamp)) {
+			continue;
+		}
+		const text = textFromMessageContent(message.content);
+		if (!text.trim() || Buffer.byteLength(text, "utf8") > MAX_MESSAGE_TEXT_BYTES) continue;
+		candidates.push({
+			entryId: value.id,
+			role: message.role,
+			text,
+			messageTimestamp: message.timestamp,
+			source,
+		});
+	}
+	return candidates.reverse();
+}
+
+export function filterRecallMessages(
+	records: readonly RecallMessageRecord[],
+	scope: RecallScope,
+	current: RecallScopeContext,
+	platform: NodeJS.Platform = process.platform,
+): RecallMessageRecord[] {
+	if (scope === "all") return [...records];
+	if (scope === "session") {
+		return records.filter((record) => record.source.sessionId === current.sessionId);
+	}
+	const currentCwd = normalizeCwd(current.cwd, platform);
+	return records.filter((record) => normalizeCwd(record.source.cwd, platform) === currentCwd);
+}
+
+export function normalizeCwd(value: string, platform: NodeJS.Platform | "win32"): string {
+	if (platform === "win32") return path.win32.resolve(value).toLowerCase();
+	return path.resolve(value);
+}
+
+export function messagePreview(text: string, maximumCharacters = 80): string {
+	const normalized = text.trim().replace(/\s+/gu, " ");
+	const characters = [...normalized];
+	if (characters.length <= maximumCharacters) return normalized;
+	if (maximumCharacters <= 1) return "…";
+	return `${characters.slice(0, maximumCharacters - 1).join("")}…`;
+}
+
+export function formatRecallQuote(record: RecallMessageRecord): string {
+	const timestamp = new Date(record.source.messageTimestamp).toISOString();
+	return `<recalled_message role="${record.role}" message_timestamp="${escapeXml(timestamp)}">\n${escapeXml(record.text)}\n</recalled_message>\n\nThe user intentionally recalled and quoted the saved message above.\n\n`;
+}
+
+export function candidateIdentity(sessionId: string, entryId: string): string {
+	return `${sessionId}\u0000${entryId}`;
+}
+
+function textFromMessageContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.flatMap((block) =>
+			isRecord(block) && block.type === "text" && typeof block.text === "string"
+				? [block.text]
+				: [],
+		)
+		.join("\n");
+}
+
+export function isValidTimestamp(value: number): boolean {
+	return value >= 0 && Number.isFinite(value) && !Number.isNaN(new Date(value).getTime());
+}
+
+function escapeXml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&apos;");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/experimental/pi-recall/src/picker.ts
+++ b/experimental/pi-recall/src/picker.ts
@@ -1,0 +1,222 @@
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import { type Component, Key, matchesKey, type TUI, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+	filterRecallMessages,
+	messagePreview,
+	type RecallMessageRecord,
+	type RecallScope,
+	type RecallScopeContext,
+} from "./messages.js";
+
+const SCOPE_ORDER: readonly RecallScope[] = ["cwd", "all", "session"];
+const SCOPE_LABELS: Record<RecallScope, string> = {
+	all: "All",
+	cwd: "Current cwd",
+	session: "Current session",
+};
+
+export type ScopedRecallPickerResult =
+	| { kind: "selected"; recordId: string; scope: RecallScope }
+	| { kind: "back"; scope: RecallScope; selectedId?: string }
+	| { kind: "close"; scope: RecallScope; selectedId?: string };
+
+interface ScopedRecallPickerOptions {
+	tui: TUI;
+	theme: Theme;
+	keybindings: KeybindingsManager;
+	records: readonly RecallMessageRecord[];
+	current: RecallScopeContext;
+	initialScope?: RecallScope;
+	initialSelectedId?: string;
+	complete: (result: ScopedRecallPickerResult) => void;
+}
+
+export class ScopedRecallPicker implements Component {
+	private scope: RecallScope;
+	private selectedId: string | undefined;
+	private scrollOffset = 0;
+	private disposed = false;
+	private completed = false;
+
+	constructor(private readonly options: ScopedRecallPickerOptions) {
+		this.scope = options.initialScope ?? "cwd";
+		const records = this.filteredRecords();
+		this.selectedId = records.some(({ id }) => id === options.initialSelectedId)
+			? options.initialSelectedId
+			: records[0]?.id;
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const records = this.filteredRecords();
+		const listHeight = Math.max(1, Math.floor(this.options.tui.terminal.rows) - 7);
+		this.keepSelectionVisible(records, listHeight);
+		const visible = records.slice(this.scrollOffset, this.scrollOffset + listHeight);
+		const rows = visible.map((record) => {
+			const selected = record.id === this.selectedId;
+			const role = record.role === "assistant" ? "assistant" : "user";
+			const timestamp = new Date(record.source.messageTimestamp).toISOString();
+			const session = record.source.sessionName
+				? ` · ${sanitizeTerminalText(record.source.sessionName)}`
+				: "";
+			const preview = sanitizeTerminalText(messagePreview(record.text, 72));
+			const line = `${selected ? ">" : " "} ${role} · ${timestamp}${session} · ${preview}`;
+			return selected
+				? this.options.theme.fg("accent", truncateToWidth(line, safeWidth, "…"))
+				: truncateToWidth(line, safeWidth, "…");
+		});
+		const scopeLine = `Scope: ${SCOPE_LABELS[this.scope]} (${records.length}) · Tab change scope`;
+		return [
+			truncateToWidth(
+				this.options.theme.fg("accent", this.options.theme.bold("Pi Recall")),
+				safeWidth,
+				"",
+			),
+			truncateToWidth(this.options.theme.fg("muted", scopeLine), safeWidth, ""),
+			"",
+			...(rows.length > 0
+				? rows
+				: [
+						truncateToWidth(
+							this.options.theme.fg("dim", "  No saved messages in this scope"),
+							safeWidth,
+							"",
+						),
+					]),
+			truncateToWidth(
+				this.options.theme.fg(
+					"dim",
+					"↑↓ navigate · Enter select · Tab/Shift+Tab scope · Esc back · Ctrl+C close",
+				),
+				safeWidth,
+				"",
+			),
+		].map((line) => truncateToWidth(line, safeWidth, ""));
+	}
+
+	handleInput(data: string): void {
+		if (this.disposed || this.completed) return;
+		if (matchesKey(data, Key.ctrl("c"))) {
+			this.finish({ kind: "close", scope: this.scope, selectedId: this.selectedId });
+			return;
+		}
+		if (matchesKey(data, Key.shift("tab"))) {
+			this.cycleScope(-1);
+		} else if (matchesKey(data, Key.tab)) {
+			this.cycleScope(1);
+		} else if (this.options.keybindings.matches(data, "tui.select.cancel")) {
+			this.finish({ kind: "back", scope: this.scope, selectedId: this.selectedId });
+			return;
+		} else if (this.options.keybindings.matches(data, "tui.select.up")) {
+			this.move(-1);
+		} else if (this.options.keybindings.matches(data, "tui.select.down")) {
+			this.move(1);
+		} else if (this.options.keybindings.matches(data, "tui.select.pageUp")) {
+			this.move(-Math.max(1, Math.floor(this.options.tui.terminal.rows) - 7));
+		} else if (this.options.keybindings.matches(data, "tui.select.pageDown")) {
+			this.move(Math.max(1, Math.floor(this.options.tui.terminal.rows) - 7));
+		} else if (matchesKey(data, Key.home)) {
+			this.selectAt(0);
+		} else if (matchesKey(data, Key.end)) {
+			this.selectAt(this.filteredRecords().length - 1);
+		} else if (this.options.keybindings.matches(data, "tui.select.confirm")) {
+			if (this.selectedId) {
+				this.finish({ kind: "selected", recordId: this.selectedId, scope: this.scope });
+				return;
+			}
+		}
+		this.options.tui.requestRender();
+	}
+
+	invalidate(): void {}
+
+	dispose(): void {
+		this.disposed = true;
+	}
+
+	private filteredRecords(): RecallMessageRecord[] {
+		return filterRecallMessages(this.options.records, this.scope, this.options.current).reverse();
+	}
+
+	private cycleScope(delta: number): void {
+		const index = SCOPE_ORDER.indexOf(this.scope);
+		this.scope = SCOPE_ORDER[(index + delta + SCOPE_ORDER.length) % SCOPE_ORDER.length] ?? "cwd";
+		const records = this.filteredRecords();
+		if (!records.some(({ id }) => id === this.selectedId)) this.selectedId = records[0]?.id;
+		this.scrollOffset = 0;
+	}
+
+	private move(delta: number): void {
+		const records = this.filteredRecords();
+		if (records.length === 0) return;
+		const current = Math.max(
+			0,
+			records.findIndex(({ id }) => id === this.selectedId),
+		);
+		const next = Math.max(0, Math.min(records.length - 1, current + delta));
+		this.selectedId = records[next]?.id;
+	}
+
+	private selectAt(index: number): void {
+		const records = this.filteredRecords();
+		if (records.length === 0) return;
+		const bounded = Math.max(0, Math.min(records.length - 1, index));
+		this.selectedId = records[bounded]?.id;
+	}
+
+	private keepSelectionVisible(records: readonly RecallMessageRecord[], height: number): void {
+		if (records.length === 0) {
+			this.scrollOffset = 0;
+			return;
+		}
+		const index = Math.max(
+			0,
+			records.findIndex(({ id }) => id === this.selectedId),
+		);
+		if (index < this.scrollOffset) this.scrollOffset = index;
+		if (index >= this.scrollOffset + height) this.scrollOffset = index - height + 1;
+		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, records.length - height));
+	}
+
+	private finish(result: ScopedRecallPickerResult): void {
+		if (this.completed) return;
+		this.completed = true;
+		this.options.complete(result);
+	}
+}
+
+export function sanitizeTerminalText(value: string): string {
+	let safe = "";
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code === 0x1b) {
+			const introducer = value[index + 1];
+			if (introducer === "]") {
+				index += 2;
+				while (index < value.length) {
+					const current = value.charCodeAt(index);
+					if (current === 0x07) break;
+					if (current === 0x1b && value[index + 1] === "\\") {
+						index += 1;
+						break;
+					}
+					index += 1;
+				}
+				continue;
+			}
+			if (introducer === "[") {
+				index += 2;
+				while (index < value.length) {
+					const current = value.charCodeAt(index);
+					if (current >= 0x40 && current <= 0x7e) break;
+					index += 1;
+				}
+				continue;
+			}
+			continue;
+		}
+		if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) safe += " ";
+		else safe += value[index];
+	}
+	return safe.replace(/\s+/gu, " ").trim();
+}

--- a/experimental/pi-recall/src/recall.ts
+++ b/experimental/pi-recall/src/recall.ts
@@ -1,0 +1,109 @@
+import { join } from "node:path";
+import {
+	type ExtensionAPI,
+	type ExtensionContext,
+	getAgentDir,
+} from "@earendil-works/pi-coding-agent";
+import { type RecallMenuSource, showRecallMenu } from "./menu.js";
+import { extractMessageCandidates, normalizeCwd } from "./messages.js";
+import { RecallStore } from "./store.js";
+
+const EXPERIMENTAL_WARNING =
+	"Pi Recall is experimental; its storage format and interaction flow may change.";
+
+interface RecallDependencies {
+	getAgentDir(): string;
+	createStore(path: string): RecallStore;
+}
+
+export function createRecallExtension(
+	dependencies: Partial<RecallDependencies> = {},
+): (pi: ExtensionAPI) => void {
+	const deps: RecallDependencies = {
+		getAgentDir: dependencies.getAgentDir ?? getAgentDir,
+		createStore: dependencies.createStore ?? ((path) => new RecallStore(path)),
+	};
+
+	return function recallExtension(pi: ExtensionAPI): void {
+		let generation = 0;
+		let sessionController = new AbortController();
+		let activeSessionManager: unknown;
+
+		pi.registerCommand("recall", {
+			description: "Save and recall messages across Pi sessions",
+			handler: async (args, ctx) => {
+				if (args.trim()) {
+					rejectCommand(ctx, "Usage: /recall");
+					return;
+				}
+				if (ctx.mode !== "tui" && ctx.mode !== "rpc") {
+					throw new Error("/recall requires Pi TUI or RPC mode.");
+				}
+				const owner = ctx.sessionManager;
+				const ownerGeneration = generation;
+				const controller = sessionController;
+				const isCurrent = () =>
+					activeSessionManager === owner &&
+					generation === ownerGeneration &&
+					!controller.signal.aborted;
+				if (!isCurrent()) throw new Error("Pi Recall session is no longer active.");
+
+				const sessionId = ctx.sessionManager.getSessionId();
+				const cwd = normalizeCwd(ctx.cwd, process.platform);
+				const sessionName = ctx.sessionManager.getSessionName();
+				const candidates = extractMessageCandidates(ctx.sessionManager.getBranch(), {
+					sessionId,
+					...(sessionName ? { sessionName } : {}),
+					cwd,
+				});
+				const store = deps.createStore(join(deps.getAgentDir(), "pi-recall.jsonl"));
+				const source: RecallMenuSource = {
+					path: store.path,
+					current: { sessionId, cwd },
+					candidates,
+					load: (signal) => store.load(signal),
+					save: (candidate, signal) => store.save(candidate, signal),
+					delete: (id, signal) => store.delete(id, signal),
+				};
+				await showRecallMenu(ctx, source, { signal: controller.signal, isCurrent });
+			},
+		});
+
+		pi.on("session_start", (_event, ctx) => {
+			sessionController.abort(new DOMException("Pi Recall session replaced", "AbortError"));
+			sessionController = new AbortController();
+			generation += 1;
+			activeSessionManager = ctx.sessionManager;
+			if (ctx.hasUI) safeNotify(ctx, EXPERIMENTAL_WARNING, "warning");
+		});
+
+		pi.on("session_shutdown", (_event, ctx) => {
+			if (ctx.sessionManager !== activeSessionManager) return;
+			sessionController.abort(new DOMException("Pi Recall session shut down", "AbortError"));
+			activeSessionManager = undefined;
+			generation += 1;
+		});
+	};
+}
+
+function rejectCommand(ctx: ExtensionContext, message: string): void {
+	if (ctx.hasUI) {
+		safeNotify(ctx, message, "warning");
+		return;
+	}
+	throw new Error(message);
+}
+
+function safeNotify(
+	ctx: ExtensionContext,
+	message: string,
+	level: "info" | "warning" | "error",
+): void {
+	try {
+		ctx.ui.notify(message, level);
+	} catch {
+		// Session replacement can invalidate an old UI immediately.
+	}
+}
+
+export default createRecallExtension();

--- a/experimental/pi-recall/src/store.ts
+++ b/experimental/pi-recall/src/store.ts
@@ -1,0 +1,391 @@
+import { randomUUID } from "node:crypto";
+import {
+	mkdir as mkdirCallback,
+	mkdirSync,
+	realpath as realpathCallback,
+	realpathSync,
+	rmdir as rmdirCallback,
+	rmdirSync,
+	stat as statCallback,
+	statSync,
+	utimes as utimesCallback,
+	utimesSync,
+} from "node:fs";
+import { chmod, constants, lstat, mkdir, open, rename, rm } from "node:fs/promises";
+import { dirname, isAbsolute } from "node:path";
+import lockfile from "proper-lockfile";
+import {
+	candidateIdentity,
+	isValidTimestamp,
+	MAX_MESSAGE_TEXT_BYTES,
+	type MessageCandidate,
+	type RecallMessageRecord,
+} from "./messages.js";
+
+export const MAX_RECALL_RECORDS = 200;
+export const MAX_RECALL_FILE_BYTES = 12 * 1024 * 1024;
+
+const LOCK_RETRY_MIN_MS = 10;
+const LOCK_RETRY_MAX_MS = 200;
+const LOCK_STALE_MS = 30_000;
+
+const LOCKFILE_FS_ADAPTER = {
+	mkdir: mkdirCallback,
+	mkdirSync,
+	realpath: realpathCallback,
+	realpathSync,
+	rmdir: rmdirCallback,
+	rmdirSync,
+	stat: statCallback,
+	statSync,
+	utimes: utimesCallback,
+	utimesSync,
+};
+
+export class RecallStoreFormatError extends Error {}
+export class RecallStoreLimitError extends Error {}
+export class RecallStoreDuplicateError extends Error {}
+
+export interface RecallStoreSnapshot {
+	path: string;
+	records: RecallMessageRecord[];
+	bytes: number;
+}
+
+interface RecallStoreOptions {
+	now?: () => number;
+	createId?: () => string;
+	beforeRename?: (temporaryPath: string, canonicalPath: string) => Promise<void>;
+}
+
+export class RecallStore {
+	private readonly now: () => number;
+	private readonly createId: () => string;
+	private readonly beforeRename?: RecallStoreOptions["beforeRename"];
+
+	constructor(
+		readonly path: string,
+		options: RecallStoreOptions = {},
+	) {
+		this.now = options.now ?? Date.now;
+		this.createId = options.createId ?? randomUUID;
+		this.beforeRename = options.beforeRename;
+	}
+
+	async load(signal?: AbortSignal): Promise<RecallStoreSnapshot> {
+		throwIfAborted(signal);
+		if (!(await this.fileOrLockExists())) return { path: this.path, records: [], bytes: 0 };
+		return this.withLock(signal, async () => {
+			const contents = await readPrivateRegularFileIfExists(this.path);
+			throwIfAborted(signal);
+			return snapshotFromContents(this.path, contents);
+		});
+	}
+
+	async save(candidate: MessageCandidate, signal?: AbortSignal): Promise<RecallMessageRecord> {
+		await mkdir(dirname(this.path), { recursive: true, mode: 0o700 });
+		return this.withLock(signal, async (checkCompromised) => {
+			const contents = await readPrivateRegularFileIfExists(this.path);
+			const current = snapshotFromContents(this.path, contents).records;
+			const identity = candidateIdentity(candidate.source.sessionId, candidate.entryId);
+			if (
+				current.some(
+					(record) =>
+						candidateIdentity(record.source.sessionId, record.source.entryId) === identity,
+				)
+			) {
+				throw new RecallStoreDuplicateError("This message is already saved in Pi Recall");
+			}
+			if (current.length >= MAX_RECALL_RECORDS) {
+				throw new RecallStoreLimitError(
+					`Pi Recall supports at most ${MAX_RECALL_RECORDS} saved messages`,
+				);
+			}
+			const record = createRecord(candidate, this.createId(), this.now());
+			if (current.some(({ id }) => id === record.id)) {
+				throw new RecallStoreFormatError(`Pi Recall generated duplicate ID ${record.id}`);
+			}
+			const next = serializeRecords([...current, record]);
+			throwIfAborted(signal);
+			checkCompromised();
+			await this.publish(next);
+			checkCompromised();
+			return record;
+		});
+	}
+
+	async delete(id: string, signal?: AbortSignal): Promise<boolean> {
+		await mkdir(dirname(this.path), { recursive: true, mode: 0o700 });
+		return this.withLock(signal, async (checkCompromised) => {
+			const contents = await readPrivateRegularFileIfExists(this.path);
+			const current = snapshotFromContents(this.path, contents).records;
+			const nextRecords = current.filter((record) => record.id !== id);
+			if (nextRecords.length === current.length) return false;
+			const next = serializeRecords(nextRecords);
+			throwIfAborted(signal);
+			checkCompromised();
+			await this.publish(next);
+			checkCompromised();
+			return true;
+		});
+	}
+
+	private async withLock<T>(
+		signal: AbortSignal | undefined,
+		operation: (checkCompromised: () => void) => Promise<T>,
+	): Promise<T> {
+		let compromised: Error | undefined;
+		const release = await acquireLock(this.path, signal, (error) => {
+			compromised = error;
+		});
+		const checkCompromised = () => {
+			if (compromised) throw compromised;
+		};
+		try {
+			throwIfAborted(signal);
+			checkCompromised();
+			return await operation(checkCompromised);
+		} finally {
+			await release().catch(() => undefined);
+		}
+	}
+
+	private async fileOrLockExists(): Promise<boolean> {
+		if (await pathExists(this.path)) return true;
+		if (await pathExists(`${this.path}.lock`)) return true;
+		return pathExists(this.path);
+	}
+
+	private async publish(contents: string): Promise<void> {
+		const temporaryPath = `${this.path}.${randomUUID()}.tmp`;
+		let handle: Awaited<ReturnType<typeof open>> | undefined;
+		try {
+			handle = await open(temporaryPath, "wx", 0o600);
+			await handle.writeFile(contents, "utf8");
+			await handle.sync();
+			await handle.chmod(0o600);
+			await handle.close();
+			handle = undefined;
+			await this.beforeRename?.(temporaryPath, this.path);
+			await rename(temporaryPath, this.path);
+			await chmod(this.path, 0o600);
+		} finally {
+			await handle?.close().catch(() => undefined);
+			await rm(temporaryPath, { force: true }).catch(() => undefined);
+		}
+	}
+}
+
+function createRecord(candidate: MessageCandidate, id: string, now: number): RecallMessageRecord {
+	if (!id.trim()) throw new RecallStoreFormatError("Pi Recall generated an empty record ID");
+	if (!isValidTimestamp(now))
+		throw new RecallStoreFormatError("Pi Recall received an invalid clock");
+	if (
+		!candidate.text.trim() ||
+		Buffer.byteLength(candidate.text, "utf8") > MAX_MESSAGE_TEXT_BYTES ||
+		!nonEmptyString(candidate.entryId) ||
+		!nonEmptyString(candidate.source.sessionId) ||
+		!isAbsolute(candidate.source.cwd) ||
+		!isValidTimestamp(candidate.messageTimestamp)
+	) {
+		throw new RecallStoreFormatError("Pi Recall received an invalid message candidate");
+	}
+	return {
+		type: "recall_message",
+		version: 1,
+		id,
+		savedAt: new Date(now).toISOString(),
+		source: {
+			sessionId: candidate.source.sessionId,
+			entryId: candidate.entryId,
+			...(candidate.source.sessionName ? { sessionName: candidate.source.sessionName } : {}),
+			cwd: candidate.source.cwd,
+			messageTimestamp: candidate.messageTimestamp,
+		},
+		role: candidate.role,
+		text: candidate.text,
+	};
+}
+
+function snapshotFromContents(path: string, contents: string | undefined): RecallStoreSnapshot {
+	if (contents === undefined || contents === "") return { path, records: [], bytes: 0 };
+	const bytes = Buffer.byteLength(contents, "utf8");
+	if (bytes > MAX_RECALL_FILE_BYTES) {
+		throw new RecallStoreLimitError(
+			`Pi Recall storage exceeds ${MAX_RECALL_FILE_BYTES} bytes and is read-only`,
+		);
+	}
+	const lines = contents.endsWith("\n") ? contents.slice(0, -1).split("\n") : contents.split("\n");
+	if (lines.some((line) => line.length === 0)) {
+		throw new RecallStoreFormatError("Pi Recall storage contains an empty JSONL record");
+	}
+	if (lines.length > MAX_RECALL_RECORDS) {
+		throw new RecallStoreLimitError(
+			`Pi Recall storage contains more than the supported at most ${MAX_RECALL_RECORDS} records`,
+		);
+	}
+	const records = lines.map((line, index) => parseRecord(line, index + 1));
+	const ids = new Set<string>();
+	for (const record of records) {
+		if (ids.has(record.id)) {
+			throw new RecallStoreFormatError(`Pi Recall storage contains duplicate ID ${record.id}`);
+		}
+		ids.add(record.id);
+	}
+	return { path, records, bytes };
+}
+
+function parseRecord(line: string, lineNumber: number): RecallMessageRecord {
+	let value: unknown;
+	try {
+		value = JSON.parse(line);
+	} catch {
+		throw new RecallStoreFormatError(`Pi Recall storage has invalid JSON on line ${lineNumber}`);
+	}
+	if (!isRecord(value)) throw invalidRecord(lineNumber);
+	if (value.type !== "recall_message" || value.version !== 1) {
+		throw new RecallStoreFormatError(
+			`Pi Recall storage has an unsupported record type or version on line ${lineNumber}`,
+		);
+	}
+	if (
+		!nonEmptyString(value.id) ||
+		!isIsoTimestamp(value.savedAt) ||
+		(value.role !== "user" && value.role !== "assistant") ||
+		typeof value.text !== "string" ||
+		!value.text.trim() ||
+		Buffer.byteLength(value.text, "utf8") > MAX_MESSAGE_TEXT_BYTES ||
+		!isRecord(value.source) ||
+		!nonEmptyString(value.source.sessionId) ||
+		!nonEmptyString(value.source.entryId) ||
+		(value.source.sessionName !== undefined && typeof value.source.sessionName !== "string") ||
+		!nonEmptyString(value.source.cwd) ||
+		!isAbsolute(value.source.cwd) ||
+		typeof value.source.messageTimestamp !== "number" ||
+		!isValidTimestamp(value.source.messageTimestamp)
+	) {
+		throw invalidRecord(lineNumber);
+	}
+	return value as RecallMessageRecord;
+}
+
+function serializeRecords(records: readonly RecallMessageRecord[]): string {
+	if (records.length > MAX_RECALL_RECORDS) {
+		throw new RecallStoreLimitError(`Pi Recall supports at most ${MAX_RECALL_RECORDS} records`);
+	}
+	const contents =
+		records.length === 0 ? "" : `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+	if (Buffer.byteLength(contents, "utf8") > MAX_RECALL_FILE_BYTES) {
+		throw new RecallStoreLimitError(
+			`Pi Recall storage would exceed ${MAX_RECALL_FILE_BYTES} bytes`,
+		);
+	}
+	return contents;
+}
+
+async function readPrivateRegularFileIfExists(path: string): Promise<string | undefined> {
+	let before: Awaited<ReturnType<typeof lstat>>;
+	try {
+		before = await lstat(path);
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") return undefined;
+		throw error;
+	}
+	if (!before.isFile() || before.isSymbolicLink()) {
+		throw new RecallStoreFormatError(`Pi Recall storage path must be a regular file: ${path}`);
+	}
+	const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+	try {
+		const after = await handle.stat();
+		if (!after.isFile() || before.dev !== after.dev || before.ino !== after.ino) {
+			throw new RecallStoreFormatError(
+				`Pi Recall storage path must be a stable regular file: ${path}`,
+			);
+		}
+		if (after.size > MAX_RECALL_FILE_BYTES) {
+			throw new RecallStoreLimitError(
+				`Pi Recall storage exceeds ${MAX_RECALL_FILE_BYTES} bytes and is read-only`,
+			);
+		}
+		await handle.chmod(0o600);
+		return await handle.readFile("utf8");
+	} finally {
+		await handle.close();
+	}
+}
+
+async function acquireLock(
+	path: string,
+	signal: AbortSignal | undefined,
+	onCompromised: (error: Error) => void,
+): Promise<() => Promise<void>> {
+	let delayMs = LOCK_RETRY_MIN_MS;
+	while (true) {
+		throwIfAborted(signal);
+		try {
+			return await lockfile.lock(path, {
+				fs: LOCKFILE_FS_ADAPTER,
+				realpath: false,
+				retries: 0,
+				stale: LOCK_STALE_MS,
+				onCompromised,
+			});
+		} catch (error) {
+			if (!isNodeError(error) || error.code !== "ELOCKED") throw error;
+			await abortableDelay(delayMs, signal);
+			delayMs = Math.min(LOCK_RETRY_MAX_MS, delayMs * 2);
+		}
+	}
+}
+
+function abortableDelay(milliseconds: number, signal: AbortSignal | undefined): Promise<void> {
+	if (!signal) return new Promise((resolve) => setTimeout(resolve, milliseconds));
+	throwIfAborted(signal);
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			signal.removeEventListener("abort", abort);
+			resolve();
+		}, milliseconds);
+		const abort = () => {
+			clearTimeout(timer);
+			reject(signal.reason ?? new DOMException("Operation aborted", "AbortError"));
+		};
+		signal.addEventListener("abort", abort, { once: true });
+	});
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+	if (signal?.aborted) throw signal.reason ?? new DOMException("Operation aborted", "AbortError");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+	try {
+		await lstat(path);
+		return true;
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+function nonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+	if (typeof value !== "string") return false;
+	const timestamp = Date.parse(value);
+	return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function invalidRecord(line: number): RecallStoreFormatError {
+	return new RecallStoreFormatError(`Pi Recall storage has an invalid record on line ${line}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error;
+}

--- a/experimental/pi-recall/test/menu.test.ts
+++ b/experimental/pi-recall/test/menu.test.ts
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { resolveMenuScreen, runMenu } from "@narumitw/pi-tui-kit";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { createMockContext } from "../../../test/support.js";
+import { createRecallMenu, type RecallMenuSource, showRecallMenu } from "../src/menu.js";
+import type { MessageCandidate, RecallMessageRecord } from "../src/messages.js";
+
+function candidate(entryId: string): MessageCandidate {
+	return {
+		entryId,
+		role: entryId === "user" ? "user" : "assistant",
+		text: `text for ${entryId}`,
+		messageTimestamp: 1_786_000_000_000,
+		source: { sessionId: "session-a", sessionName: "Current", cwd: "/work/project" },
+	};
+}
+
+function record(id = "saved-a", entryId = "assistant"): RecallMessageRecord {
+	return {
+		type: "recall_message",
+		version: 1,
+		id,
+		savedAt: "2026-08-04T12:00:00.000Z",
+		source: {
+			sessionId: "session-a",
+			entryId,
+			sessionName: "Current",
+			cwd: "/work/project",
+			messageTimestamp: 1_786_000_000_000,
+		},
+		role: "assistant",
+		text: `saved text ${id}`,
+	};
+}
+
+function source(
+	initialRecords = [record()],
+): RecallMenuSource & { records: RecallMessageRecord[] } {
+	const value: RecallMenuSource & { records: RecallMessageRecord[] } = {
+		path: "/agent/pi-recall.jsonl",
+		records: [...initialRecords],
+		current: { sessionId: "session-a", cwd: "/work/project" },
+		candidates: [candidate("assistant"), candidate("user")],
+		async load() {
+			return {
+				path: value.path,
+				records: [...value.records],
+				bytes: Buffer.byteLength(value.records.map((item) => JSON.stringify(item)).join("\n")),
+			};
+		},
+		async save(item) {
+			const saved = record(`saved-${value.records.length + 1}`, item.entryId);
+			saved.role = item.role;
+			saved.text = item.text;
+			value.records.push(saved);
+			return saved;
+		},
+		async delete(id) {
+			const previous = value.records.length;
+			value.records = value.records.filter((item) => item.id !== id);
+			return value.records.length < previous;
+		},
+	};
+	return value;
+}
+
+async function state(controller: ReturnType<typeof createRecallMenu>) {
+	return controller.getState({ signal: new AbortController().signal });
+}
+
+test("main menu keeps five primary rows and save choice marks duplicate source unavailable", async () => {
+	const controller = createRecallMenu(source());
+	const current = await state(controller);
+	const main = resolveMenuScreen(controller.menu, "main", current);
+	assert.equal(main.kind, "actions");
+	if (main.kind !== "actions") return;
+	assert.deepEqual(
+		main.items.map(({ label }) => label),
+		["Save a message", "Recall a saved message", "Status", "Help", "Close"],
+	);
+	const save = resolveMenuScreen(controller.menu, "save", current);
+	assert.equal(save.kind, "choice");
+	if (save.kind !== "choice") return;
+	assert.equal(save.items.find(({ id }) => id === "assistant")?.disabled, true);
+	assert.match(
+		save.items.find(({ id }) => id === "assistant")?.disabledReason ?? "",
+		/already saved/i,
+	);
+	assert.equal(save.items.find(({ id }) => id === "user")?.disabled, undefined);
+});
+
+test("save action persists the selected active-branch candidate and returns to main", async () => {
+	const data = source([]);
+	const controller = createRecallMenu(data);
+	const result = await controller.menu.actions.saveMessage({
+		ctx: createMockContext({ hasUI: true, mode: "rpc" }).ctx,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "user",
+	});
+	assert.deepEqual(result, { kind: "to", screen: "main" });
+	assert.equal(data.records[0]?.source.entryId, "user");
+});
+
+test("RPC saved-message selection asks for scope explicitly and opens selected actions", async () => {
+	const data = source();
+	let calls = 0;
+	const mock = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		select: async (_title: string, options: string[]) => {
+			calls += 1;
+			return options[0];
+		},
+	});
+	const controller = createRecallMenu(data);
+	const result = await controller.menu.actions.chooseSaved({
+		ctx: mock.ctx,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "recall",
+	});
+	assert.equal(calls, 2);
+	assert.deepEqual(result, { kind: "to", screen: "selected" });
+	const selected = resolveMenuScreen(controller.menu, "selected", await state(controller));
+	assert.equal(selected.kind, "actions");
+	assert.match(selected.lines?.join("\n") ?? "", /saved text saved-a/);
+});
+
+test("TUI saved picker is lifecycle-owned and returns the Tab-selected scope", async () => {
+	const data = source([
+		record("saved-current"),
+		{
+			...record("saved-other", "other-entry"),
+			source: {
+				...record().source,
+				sessionId: "other-session",
+				cwd: "/other",
+				entryId: "other-entry",
+			},
+		},
+	]);
+	const tui = createTuiHarness({ width: 72, rows: 18 });
+	const base = createMockContext({ hasUI: true, mode: "tui" }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const controller = createRecallMenu(data);
+	const owner = new AbortController();
+	const choosing = controller.menu.actions.chooseSaved({
+		ctx: { ...base, ui: { ...base.ui, custom: tui.custom } } as never,
+		state: await state(controller),
+		signal: owner.signal,
+		itemId: "recall",
+	});
+	await tui.waitForOpen();
+	assert.match(tui.render().join("\n"), /Scope: Current cwd \(1\)/);
+	tui.send("\t");
+	assert.match(tui.render().join("\n"), /Scope: All \(2\)/);
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await choosing, { kind: "to", screen: "selected" });
+	assert.equal(tui.isOpen, false);
+});
+
+test("preview is exact, quote appends to the draft without sending, and delete requires review action", async () => {
+	const data = source();
+	const mock = createMockContext({ hasUI: true, mode: "rpc" });
+	let editorText = "Question: ";
+	const quoteCtx = mock.ctx as unknown as {
+		ui: { pasteToEditor(value: string): void };
+	};
+	quoteCtx.ui.pasteToEditor = (value) => {
+		editorText += value;
+	};
+	const controller = createRecallMenu(data);
+	controller.selectRecordForTest("saved-a");
+	const current = await state(controller);
+	const preview = resolveMenuScreen(controller.menu, "preview", current);
+	assert.equal(preview.kind, "review");
+	if (preview.kind !== "review") return;
+	assert.equal(preview.content, "saved text saved-a");
+	const deletion = resolveMenuScreen(controller.menu, "delete", current);
+	assert.equal(deletion.kind, "review");
+	if (deletion.kind !== "review") return;
+	assert.equal(deletion.confirm?.label, "Delete saved message");
+	const quoteResult = await controller.menu.actions.quote({
+		ctx: quoteCtx as never,
+		state: current,
+		signal: new AbortController().signal,
+		itemId: "quote",
+	});
+	assert.deepEqual(quoteResult, { kind: "close" });
+	assert.match(editorText, /^Question: <recalled_message/);
+	assert.doesNotMatch(editorText, /session-a|\/work\/project/);
+	assert.equal(data.records.length, 1);
+	await controller.menu.actions.deleteMessage({
+		ctx: mock.ctx,
+		state: current,
+		signal: new AbortController().signal,
+		itemId: "delete-confirm",
+	});
+	assert.equal(data.records.length, 0);
+});
+
+test("invalid storage remains visible and disables mutation routes", async () => {
+	const data = source();
+	data.load = async () => {
+		throw new Error("invalid JSON on line 2");
+	};
+	const controller = createRecallMenu(data);
+	const current = await state(controller);
+	const main = resolveMenuScreen(controller.menu, "main", current);
+	assert.match(main.lines?.join("\n") ?? "", /invalid JSON on line 2/);
+	if (main.kind !== "actions") return;
+	assert.equal(main.items[0]?.disabled, true);
+	assert.equal(main.items[1]?.disabled, true);
+	const status = resolveMenuScreen(controller.menu, "status", current);
+	assert.match(status.lines?.join("\n") ?? "", /read-only/i);
+});
+
+test("RPC manager closes without custom TUI and TUI remains width-safe under owner cancellation", async () => {
+	const data = source();
+	const rpc = createRpcHarness([{ kind: "select", response: "Close" }]);
+	const rpcBase = createMockContext({ hasUI: true, mode: "rpc" }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	await showRecallMenu({ ...rpcBase, ui: { ...rpcBase.ui, ...rpc.ui } } as never, data, {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+	});
+	rpc.assertConsumed();
+
+	const controller = createRecallMenu(data);
+	const tui = createTuiHarness({ width: 32, rows: 16 });
+	const owner = new AbortController();
+	const tuiBase = createMockContext({ hasUI: true, mode: "tui" }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const running = runMenu(
+		{ ...tuiBase, ui: { ...tuiBase.ui, custom: tui.custom } } as never,
+		controller.menu,
+		{
+			getState: controller.getState,
+			signal: owner.signal,
+			isCurrent: () => !owner.signal.aborted,
+		},
+	);
+	await tui.waitForOpen();
+	for (const line of tui.render()) assert.ok(visibleWidth(line) <= 32);
+	owner.abort();
+	assert.equal((await running).kind, "stale");
+});

--- a/experimental/pi-recall/test/messages.test.ts
+++ b/experimental/pi-recall/test/messages.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	extractMessageCandidates,
+	filterRecallMessages,
+	formatRecallQuote,
+	MAX_MESSAGE_TEXT_BYTES,
+	messagePreview,
+	normalizeCwd,
+	type RecallMessageRecord,
+} from "../src/messages.js";
+
+const source = { sessionId: "session-a", sessionName: "Named", cwd: "/work/project" };
+
+function record(overrides: Partial<RecallMessageRecord> = {}): RecallMessageRecord {
+	return {
+		type: "recall_message",
+		version: 1,
+		id: "saved-a",
+		savedAt: "2026-08-04T13:00:00.000Z",
+		source: {
+			sessionId: "session-a",
+			entryId: "entry-a",
+			sessionName: "Named",
+			cwd: "/work/project",
+			messageTimestamp: Date.parse("2026-08-04T12:34:56.000Z"),
+		},
+		role: "assistant",
+		text: "answer",
+		...overrides,
+	};
+}
+
+test("extracts active-branch user and assistant text newest first without hidden content", () => {
+	const entries = [
+		{
+			type: "message",
+			id: "user-1",
+			message: {
+				role: "user",
+				content: [
+					{ type: "text", text: "first" },
+					{ type: "image", data: "base64-secret", mimeType: "image/png" },
+					{ type: "text", text: "second" },
+				],
+				timestamp: 100,
+			},
+		},
+		{
+			type: "message",
+			id: "assistant-1",
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "private" },
+					{ type: "text", text: "visible\n  indented" },
+					{ type: "toolCall", id: "call", name: "read", arguments: {} },
+				],
+				timestamp: 200,
+			},
+		},
+		{ type: "message", id: "tool", message: { role: "toolResult", content: [] } },
+		{ type: "custom", id: "custom", data: { text: "not a message" } },
+	];
+
+	assert.deepEqual(extractMessageCandidates(entries, source), [
+		{
+			entryId: "assistant-1",
+			role: "assistant",
+			text: "visible\n  indented",
+			messageTimestamp: 200,
+			source,
+		},
+		{
+			entryId: "user-1",
+			role: "user",
+			text: "first\nsecond",
+			messageTimestamp: 100,
+			source,
+		},
+	]);
+});
+
+test("excludes empty, image-only, non-finite timestamp, and oversized messages", () => {
+	const entries = [
+		{ type: "message", id: "empty", message: { role: "user", content: "  ", timestamp: 1 } },
+		{
+			type: "message",
+			id: "image",
+			message: { role: "user", content: [{ type: "image", data: "x" }], timestamp: 2 },
+		},
+		{
+			type: "message",
+			id: "time",
+			message: { role: "assistant", content: [{ type: "text", text: "x" }], timestamp: NaN },
+		},
+		{
+			type: "message",
+			id: "range",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "x" }],
+				timestamp: Number.MAX_VALUE,
+			},
+		},
+		{
+			type: "message",
+			id: "large",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "界".repeat(MAX_MESSAGE_TEXT_BYTES) }],
+				timestamp: 3,
+			},
+		},
+	];
+	assert.deepEqual(extractMessageCandidates(entries, source), []);
+});
+
+test("scope filtering uses exact session ids and normalized cwd identity", () => {
+	const records = [
+		record(),
+		record({
+			id: "saved-b",
+			source: { ...record().source, sessionId: "session-b", entryId: "entry-b" },
+		}),
+		record({
+			id: "saved-c",
+			source: {
+				...record().source,
+				sessionId: "session-c",
+				cwd: "/other",
+				entryId: "entry-c",
+			},
+		}),
+	];
+	const current = { sessionId: "session-a", cwd: "/work/./project" };
+	assert.deepEqual(
+		filterRecallMessages(records, "all", current).map(({ id }) => id),
+		["saved-a", "saved-b", "saved-c"],
+	);
+	assert.deepEqual(
+		filterRecallMessages(records, "cwd", current).map(({ id }) => id),
+		["saved-a", "saved-b"],
+	);
+	assert.deepEqual(
+		filterRecallMessages(records, "session", current).map(({ id }) => id),
+		["saved-a"],
+	);
+	assert.equal(normalizeCwd("C:\\Work\\Project", "win32"), "c:\\work\\project");
+});
+
+test("formats a bounded preview without mutating Unicode text", () => {
+	assert.equal(messagePreview(" first\nsecond\tline ", 18), "first second line");
+	assert.equal(messagePreview("😀😀😀😀", 3), "😀😀…");
+});
+
+test("formats an XML-safe quote without local source identifiers", () => {
+	const quoted = formatRecallQuote(record({ text: '<tag attr="x">A & B\'s</tag>' }));
+	assert.equal(
+		quoted,
+		'<recalled_message role="assistant" message_timestamp="2026-08-04T12:34:56.000Z">\n&lt;tag attr=&quot;x&quot;&gt;A &amp; B&apos;s&lt;/tag&gt;\n</recalled_message>\n\nThe user intentionally recalled and quoted the saved message above.\n\n',
+	);
+	assert.doesNotMatch(quoted, /session-a|entry-a|work\/project|Named/);
+});

--- a/experimental/pi-recall/test/picker.test.ts
+++ b/experimental/pi-recall/test/picker.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { RecallMessageRecord } from "../src/messages.js";
+import { ScopedRecallPicker } from "../src/picker.js";
+
+function saved(id: string, sessionId: string, cwd: string, text: string): RecallMessageRecord {
+	return {
+		type: "recall_message",
+		version: 1,
+		id,
+		savedAt: "2026-08-04T12:00:00.000Z",
+		source: {
+			sessionId,
+			entryId: `entry-${id}`,
+			sessionName: `Session ${sessionId}`,
+			cwd,
+			messageTimestamp: Date.parse("2026-08-04T11:00:00.000Z"),
+		},
+		role: id === "one" ? "user" : "assistant",
+		text,
+	};
+}
+
+function createPicker(records: RecallMessageRecord[]) {
+	let result: unknown;
+	let renders = 0;
+	const picker = new ScopedRecallPicker({
+		tui: { terminal: { rows: 12 }, requestRender: () => renders++ } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return (
+					(data === "up" && key === "tui.select.up") ||
+					(data === "down" && key === "tui.select.down") ||
+					(data === "enter" && key === "tui.select.confirm") ||
+					(data === "escape" && key === "tui.select.cancel")
+				);
+			},
+			getKeys: () => [],
+		} as never,
+		records,
+		current: { sessionId: "current", cwd: "/work/project" },
+		initialScope: "cwd",
+		complete: (value) => {
+			result = value;
+		},
+	});
+	return { picker, result: () => result, renders: () => renders };
+}
+
+test("defaults to Current cwd and cycles scope forward and backward with visible counts", () => {
+	const { picker, renders } = createPicker([
+		saved("one", "current", "/work/project", "one"),
+		saved("two", "other", "/work/project", "two"),
+		saved("three", "elsewhere", "/other", "three"),
+	]);
+	assert.match(picker.render(80).join("\n"), /Scope: Current cwd \(2\).*Tab change scope/);
+	picker.handleInput("\t");
+	assert.match(picker.render(80).join("\n"), /Scope: All \(3\)/);
+	picker.handleInput("\t");
+	assert.match(picker.render(80).join("\n"), /Scope: Current session \(1\)/);
+	picker.handleInput("\u001b[Z");
+	assert.match(picker.render(80).join("\n"), /Scope: All \(3\)/);
+	assert.equal(renders(), 3);
+});
+
+test("preserves a selected saved id across scope changes when still visible", () => {
+	const { picker, result } = createPicker([
+		saved("one", "current", "/work/project", "one"),
+		saved("two", "other", "/work/project", "two"),
+		saved("three", "elsewhere", "/other", "three"),
+	]);
+	picker.handleInput("down");
+	picker.handleInput("\t");
+	picker.handleInput("enter");
+	assert.deepEqual(result(), {
+		kind: "selected",
+		recordId: "one",
+		scope: "all",
+	});
+});
+
+test("falls back to the first newest record when selection leaves the scope", () => {
+	const { picker, result } = createPicker([
+		saved("one", "current", "/work/project", "one"),
+		saved("two", "other", "/work/project", "two"),
+		saved("three", "elsewhere", "/other", "three"),
+	]);
+	picker.handleInput("\t");
+	picker.handleInput("\t");
+	picker.handleInput("enter");
+	assert.deepEqual(result(), {
+		kind: "selected",
+		recordId: "one",
+		scope: "session",
+	});
+});
+
+test("escape returns to the menu while ctrl+c closes the whole Recall flow", () => {
+	const records = [saved("one", "current", "/work/project", "one")];
+	const back = createPicker(records);
+	back.picker.handleInput("escape");
+	assert.deepEqual(back.result(), { kind: "back", scope: "cwd", selectedId: "one" });
+	const close = createPicker(records);
+	close.picker.handleInput("\u0003");
+	assert.deepEqual(close.result(), { kind: "close", scope: "cwd", selectedId: "one" });
+});
+
+test("empty scopes remain switchable and rendered output is sanitized and width-safe", () => {
+	const { picker } = createPicker([
+		saved("unsafe", "other", "/other", "unsafe\u001b]8;;https://bad\u0007link\u001b[31m"),
+	]);
+	const empty = picker.render(24);
+	assert.match(empty.join("\n"), /No saved messages/);
+	picker.handleInput("\t");
+	const all = picker.render(24);
+	assert.ok(all.every((line) => visibleWidth(line) <= 24));
+	const rendered = all.join("\n");
+	assert.equal(rendered.includes("\u001b]"), false);
+	assert.equal(rendered.includes("\u001b[31m"), false);
+	assert.equal(rendered.includes("https://bad"), false);
+	picker.dispose();
+	picker.handleInput("\t");
+	assert.match(picker.render(24).join("\n"), /Scope: All \(1\)/);
+});

--- a/experimental/pi-recall/test/recall.test.ts
+++ b/experimental/pi-recall/test/recall.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import type { MessageCandidate, RecallMessageRecord } from "../src/messages.js";
+import { createRecallExtension } from "../src/recall.js";
+import type { RecallStore, RecallStoreSnapshot } from "../src/store.js";
+
+function emptyStore(overrides: Partial<RecallStore> = {}): RecallStore {
+	return {
+		path: "/agent/pi-recall.jsonl",
+		async load(): Promise<RecallStoreSnapshot> {
+			return { path: this.path, records: [], bytes: 0 };
+		},
+		async save(candidate: MessageCandidate): Promise<RecallMessageRecord> {
+			return {
+				type: "recall_message",
+				version: 1,
+				id: "saved",
+				savedAt: "2026-08-04T12:00:00.000Z",
+				source: {
+					sessionId: candidate.source.sessionId,
+					entryId: candidate.entryId,
+					cwd: candidate.source.cwd,
+					messageTimestamp: candidate.messageTimestamp,
+				},
+				role: candidate.role,
+				text: candidate.text,
+			};
+		},
+		async delete() {
+			return false;
+		},
+		...overrides,
+	} as RecallStore;
+}
+
+async function emit(
+	mock: ReturnType<typeof createMockPi>,
+	name: string,
+	event: unknown,
+	ctx: unknown,
+): Promise<void> {
+	for (const handler of mock.events.get(name) ?? []) await handler(event, ctx);
+}
+
+test("registers /recall and warns visibly on every started UI session", async () => {
+	const mock = createMockPi();
+	createRecallExtension({ getAgentDir: () => "/agent", createStore: () => emptyStore() })(mock.pi);
+	assert.ok(mock.commands.has("recall"));
+	const first = createMockContext({ hasUI: true, mode: "rpc" });
+	const second = createMockContext({ hasUI: true, mode: "rpc" });
+	await emit(mock, "session_start", { reason: "startup" }, first.ctx);
+	await emit(mock, "session_start", { reason: "new" }, second.ctx);
+	assert.match(first.notifications[0]?.message ?? "", /Pi Recall is experimental/i);
+	assert.match(second.notifications[0]?.message ?? "", /Pi Recall is experimental/i);
+});
+
+test("rejects arguments and print/json modes before opening interactive UI", async () => {
+	const mock = createMockPi();
+	createRecallExtension({ getAgentDir: () => "/agent", createStore: () => emptyStore() })(mock.pi);
+	const command = mock.commands.get("recall");
+	assert.ok(command);
+	const rpc = createMockContext({ hasUI: true, mode: "rpc" });
+	await emit(mock, "session_start", { reason: "startup" }, rpc.ctx);
+	await command?.handler("unexpected", rpc.ctx);
+	assert.match(rpc.notifications.at(-1)?.message ?? "", /Usage: \/recall/);
+	for (const mode of ["print", "json"] as const) {
+		const headless = createMockContext({ hasUI: false, mode });
+		await assert.rejects(
+			Promise.resolve(command?.handler("trailing", headless.ctx)),
+			/Usage: \/recall/,
+		);
+		await assert.rejects(
+			Promise.resolve(command?.handler("", headless.ctx)),
+			/requires Pi TUI or RPC mode/,
+		);
+	}
+});
+
+test("builds save candidates only from the current active branch with normalized source metadata", async () => {
+	let observed: MessageCandidate | undefined;
+	const store = emptyStore({
+		async save(value: MessageCandidate) {
+			observed = value;
+			return emptyStore().save(value);
+		},
+	});
+	const mock = createMockPi();
+	createRecallExtension({ getAgentDir: () => "/agent", createStore: () => store })(mock.pi);
+	let selects = 0;
+	const sessionManager = {
+		getSessionId: () => "session-current",
+		getSessionName: () => "Current work",
+		getBranch: () => [
+			{
+				type: "message",
+				id: "branch-message",
+				message: { role: "user", content: "save me", timestamp: 100 },
+			},
+		],
+	};
+	const ctx = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		cwd: "/work/./project",
+		sessionManager,
+		select: async (_title: string, options: string[]) => {
+			selects += 1;
+			if (selects <= 2) return options[0];
+			return "Close";
+		},
+	});
+	await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+	await mock.commands.get("recall")?.handler("", ctx.ctx);
+	assert.equal(observed?.entryId, "branch-message");
+	assert.equal(observed?.source.sessionId, "session-current");
+	assert.equal(observed?.source.sessionName, "Current work");
+	assert.equal(observed?.source.cwd, "/work/project");
+});
+
+test("session shutdown aborts an in-flight save and suppresses stale success UI", async () => {
+	let saveStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		saveStarted = resolve;
+	});
+	const store = emptyStore({
+		async save(candidate: MessageCandidate, signal?: AbortSignal) {
+			saveStarted();
+			await new Promise<void>((_resolve, reject) => {
+				if (signal?.aborted) return reject(signal.reason);
+				signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+			});
+			return emptyStore().save(candidate);
+		},
+	});
+	const mock = createMockPi();
+	createRecallExtension({ getAgentDir: () => "/agent", createStore: () => store })(mock.pi);
+	const sessionManager = {
+		getSessionId: () => "session",
+		getSessionName: () => undefined,
+		getBranch: () => [
+			{
+				type: "message",
+				id: "message",
+				message: { role: "assistant", content: [{ type: "text", text: "answer" }], timestamp: 1 },
+			},
+		],
+	};
+	let selects = 0;
+	const ctx = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		sessionManager,
+		select: async (_title: string, options: string[]) => (selects++ < 2 ? options[0] : undefined),
+	});
+	await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+	const running = Promise.resolve(mock.commands.get("recall")?.handler("", ctx.ctx));
+	await started;
+	await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+	await running;
+	assert.equal(ctx.notifications.filter(({ message }) => /Saved message/.test(message)).length, 0);
+});
+
+test("a completed publication after replacement does not touch the stale UI", async () => {
+	let release!: () => void;
+	let started!: () => void;
+	const waiting = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const store = emptyStore({
+		async save(candidate: MessageCandidate) {
+			started();
+			await gate;
+			return emptyStore().save(candidate);
+		},
+	});
+	const mock = createMockPi();
+	createRecallExtension({ getAgentDir: () => "/agent", createStore: () => store })(mock.pi);
+	const sessionManager = {
+		getSessionId: () => "session",
+		getSessionName: () => undefined,
+		getBranch: () => [
+			{
+				type: "message",
+				id: "message",
+				message: { role: "user", content: "save", timestamp: 1 },
+			},
+		],
+	};
+	let selects = 0;
+	const first = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		sessionManager,
+		select: async (_title: string, options: string[]) => (selects++ < 2 ? options[0] : undefined),
+	});
+	await emit(mock, "session_start", { reason: "startup" }, first.ctx);
+	const running = mock.commands.get("recall")?.handler("", first.ctx);
+	await waiting;
+	const replacement = createMockContext({ hasUI: true, mode: "rpc" });
+	await emit(mock, "session_start", { reason: "new" }, replacement.ctx);
+	release();
+	await running;
+	assert.equal(
+		first.notifications.filter(({ message }) => /Saved message/.test(message)).length,
+		0,
+	);
+});

--- a/experimental/pi-recall/test/store.test.ts
+++ b/experimental/pi-recall/test/store.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { chmod, lstat, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { MessageCandidate } from "../src/messages.js";
+import { MAX_RECALL_RECORDS, RecallStore, RecallStoreFormatError } from "../src/store.js";
+
+async function withStore(
+	run: (store: RecallStore, filePath: string, root: string) => Promise<void>,
+	options: ConstructorParameters<typeof RecallStore>[1] = {},
+): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-recall-test-"));
+	const filePath = join(root, "pi-recall.jsonl");
+	try {
+		await run(new RecallStore(filePath, options), filePath, root);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+function candidate(entryId: string, text = `message ${entryId}`): MessageCandidate {
+	return {
+		entryId,
+		role: "assistant",
+		text,
+		messageTimestamp: 1_786_000_000_000,
+		source: { sessionId: "session-a", sessionName: "Named", cwd: "/work/project" },
+	};
+}
+
+test("saves versioned records, rejects duplicate source identity, and physically deletes", async () => {
+	let nextId = 0;
+	await withStore(
+		async (store, filePath) => {
+			assert.deepEqual((await store.load()).records, []);
+			const saved = await store.save(candidate("entry-a"));
+			assert.equal(saved.id, "id-1");
+			assert.equal(saved.savedAt, "2026-08-04T12:00:00.000Z");
+			assert.equal((await lstat(filePath)).mode & 0o777, 0o600);
+			await assert.rejects(store.save(candidate("entry-a")), /already saved/i);
+			assert.equal((await store.load()).records.length, 1);
+			assert.equal(await store.delete(saved.id), true);
+			assert.equal(await store.delete(saved.id), false);
+			assert.equal(await readFile(filePath, "utf8"), "");
+		},
+		{
+			now: () => Date.parse("2026-08-04T12:00:00.000Z"),
+			createId: () => `id-${++nextId}`,
+		},
+	);
+});
+
+test("rejects a generated ID collision without corrupting valid storage", async () => {
+	await withStore(
+		async (store, filePath) => {
+			await store.save(candidate("entry-a"));
+			const previous = await readFile(filePath, "utf8");
+			await assert.rejects(store.save(candidate("entry-b")), /duplicate ID/i);
+			assert.equal(await readFile(filePath, "utf8"), previous);
+		},
+		{ createId: () => "same-id" },
+	);
+});
+
+test("serializes concurrent writers from separate store instances without lost updates", async () => {
+	await withStore(async (first, filePath) => {
+		let sequence = 0;
+		const second = new RecallStore(filePath, { createId: () => `second-${++sequence}` });
+		const third = new RecallStore(filePath, { createId: () => `third-${++sequence}` });
+		await Promise.all([
+			first.save(candidate("entry-a")),
+			second.save(candidate("entry-b")),
+			third.save(candidate("entry-c")),
+		]);
+		const records = (await first.load()).records;
+		assert.deepEqual(records.map(({ source }) => source.entryId).sort(), [
+			"entry-a",
+			"entry-b",
+			"entry-c",
+		]);
+		assert.equal(new Set(records.map(({ id }) => id)).size, 3);
+	});
+});
+
+test("preserves unknown fields on valid v1 records during rewrite", async () => {
+	await withStore(async (store, filePath) => {
+		await writeFile(
+			filePath,
+			`${JSON.stringify({
+				type: "recall_message",
+				version: 1,
+				id: "existing",
+				savedAt: "2026-08-04T12:00:00.000Z",
+				source: {
+					sessionId: "other",
+					entryId: "other-entry",
+					cwd: "/other",
+					messageTimestamp: 1,
+					futureSource: true,
+				},
+				role: "user",
+				text: "existing",
+				futureTopLevel: { keep: true },
+			})}\n`,
+		);
+		await store.save(candidate("new-entry"));
+		const raw = (await readFile(filePath, "utf8")).split("\n")[0];
+		const parsed = JSON.parse(raw ?? "{}") as Record<string, unknown>;
+		assert.deepEqual(parsed.futureTopLevel, { keep: true });
+		assert.equal((parsed.source as Record<string, unknown>).futureSource, true);
+	});
+});
+
+test("malformed, newer, duplicate-id, and oversized stores fail closed without mutation", async () => {
+	const invalidValues = [
+		"{broken\n",
+		`${JSON.stringify({ type: "recall_message", version: 2 })}\n`,
+		`${JSON.stringify({
+			type: "recall_message",
+			version: 1,
+			id: "same",
+			savedAt: "2026-08-04T12:00:00.000Z",
+			source: { sessionId: "s", entryId: "a", cwd: "/a", messageTimestamp: 1 },
+			role: "user",
+			text: "a",
+		})}\n${JSON.stringify({
+			type: "recall_message",
+			version: 1,
+			id: "same",
+			savedAt: "2026-08-04T12:00:00.000Z",
+			source: { sessionId: "s", entryId: "b", cwd: "/a", messageTimestamp: 2 },
+			role: "user",
+			text: "b",
+		})}\n`,
+	];
+	for (const value of invalidValues) {
+		await withStore(async (store, filePath) => {
+			await writeFile(filePath, value);
+			await assert.rejects(store.save(candidate("entry")), RecallStoreFormatError);
+			assert.equal(await readFile(filePath, "utf8"), value);
+		});
+	}
+
+	await withStore(async (store, filePath) => {
+		const records = Array.from({ length: MAX_RECALL_RECORDS + 1 }, (_, index) =>
+			JSON.stringify({
+				type: "recall_message",
+				version: 1,
+				id: `id-${index}`,
+				savedAt: "2026-08-04T12:00:00.000Z",
+				source: { sessionId: "s", entryId: `e-${index}`, cwd: "/a", messageTimestamp: 1 },
+				role: "user",
+				text: "x",
+			}),
+		).join("\n");
+		await writeFile(filePath, `${records}\n`);
+		await assert.rejects(store.load(), /at most/i);
+	});
+});
+
+test("rejects symlink storage and leaves its target unchanged", async () => {
+	await withStore(async (store, filePath, root) => {
+		const target = join(root, "target.txt");
+		await writeFile(target, "secret");
+		await symlink(target, filePath);
+		await assert.rejects(store.save(candidate("entry")), /regular file/i);
+		assert.equal(await readFile(target, "utf8"), "secret");
+	});
+});
+
+test("an interrupted publication preserves the previous canonical bytes and cleans temporary files", async () => {
+	let publications = 0;
+	await withStore(
+		async (store, filePath, root) => {
+			await store.save(candidate("entry-a"));
+			const previous = await readFile(filePath, "utf8");
+			await assert.rejects(store.save(candidate("entry-b")), /injected publication failure/);
+			assert.equal(await readFile(filePath, "utf8"), previous);
+			const entries = await import("node:fs/promises").then(({ readdir }) => readdir(root));
+			assert.deepEqual(entries.sort(), ["pi-recall.jsonl"]);
+		},
+		{
+			beforeRename: async () => {
+				publications += 1;
+				if (publications === 2) throw new Error("injected publication failure");
+			},
+		},
+	);
+});
+
+test("aborts a lock wait promptly and releases the winning lock", async () => {
+	await withStore(async (store, filePath) => {
+		await chmod(join(filePath, ".."), 0o700).catch(() => undefined);
+		const lockfile = (await import("proper-lockfile")).default;
+		const release = await lockfile.lock(filePath, { realpath: false, retries: 0 });
+		const controller = new AbortController();
+		const pending = store.save(candidate("entry"), controller.signal);
+		setTimeout(() => controller.abort(), 20);
+		await assert.rejects(pending, /abort/i);
+		await release();
+		await store.save(candidate("entry"));
+		assert.equal((await store.load()).records.length, 1);
+	});
+});

--- a/experimental/pi-recall/tsconfig.json
+++ b/experimental/pi-recall/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -139,6 +139,9 @@ pack-lsp:
 pack-plan-mode:
     just pack plan-mode
 
+pack-recall:
+    just pack recall
+
 pack-stamp:
     just pack stamp
 
@@ -208,6 +211,9 @@ try-lsp:
 
 try-plan-mode:
     just try plan-mode
+
+try-recall:
+    just try recall
 
 try-stamp:
     just try stamp

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
 			"version": "0.47.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.47.1",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"proper-lockfile": "^4.1.2"
 			},
 			"devDependencies": {
@@ -141,6 +141,16 @@
 				"@types/proper-lockfile": "^4.1.4",
 				"typescript": "7.0.2"
 			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
+			}
+		},
+		"experimental/pi-recall/node_modules/@narumitw/pi-tui-kit": {
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
+			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,27 @@
 				"@earendil-works/pi-tui": "*"
 			}
 		},
+		"experimental/pi-recall": {
+			"name": "@narumitw/pi-recall",
+			"version": "0.47.1",
+			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.47.1",
+				"proper-lockfile": "^4.1.2"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.5.6",
+				"@earendil-works/pi-coding-agent": "0.83.0",
+				"@earendil-works/pi-tui": "0.83.0",
+				"@types/node": "26.1.2",
+				"@types/proper-lockfile": "^4.1.4",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
+			}
+		},
 		"experimental/pi-webui": {
 			"name": "@narumitw/pi-webui",
 			"version": "0.47.1",
@@ -2939,6 +2960,10 @@
 		},
 		"node_modules/@narumitw/pi-plan-mode": {
 			"resolved": "extensions/pi-plan-mode",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-recall": {
+			"resolved": "experimental/pi-recall",
 			"link": true
 		},
 		"node_modules/@narumitw/pi-stamp": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"pack:langfuse": "npm --workspace @narumitw/pi-langfuse pack --dry-run",
 		"pack:lsp": "npm --workspace @narumitw/pi-lsp pack --dry-run",
 		"pack:plan-mode": "npm --workspace @narumitw/pi-plan-mode pack --dry-run",
+		"pack:recall": "npm --workspace @narumitw/pi-recall pack --dry-run",
 		"pack:stamp": "npm --workspace @narumitw/pi-stamp pack --dry-run",
 		"pack:starship": "npm --workspace @narumitw/pi-starship pack --dry-run",
 		"pack:statusline": "npm --workspace @narumitw/pi-statusline pack --dry-run",


### PR DESCRIPTION
## Summary

- add the experimental `@narumitw/pi-recall` extension and `/recall` TUI/RPC flow
- save text-only user or assistant messages from the active branch, then filter, preview, quote, or delete them across sessions
- protect the versioned JSONL store with schema validation, private permissions, abort-aware cross-process locking, and atomic replacement
- cover scope navigation, lifecycle replacement, malformed storage, concurrent mutations, packaging, and runtime loading

## Testing

- `npm run check` (2,339 tests passed in an isolated normal clone with a clean agent directory)
- `npm run check --workspace @narumitw/pi-recall`
- focused Pi Recall tests (30 passed)
- `npm run check:boundaries`
- `just pack recall`
- non-interactive RPC load smoke (`get_commands` observed the experimental warning and `/recall` registration)
