### PR TITLE
feat(recall): add fuzzy saved-message search

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -15,6 +15,7 @@
 - Tests compiled under root `node_modules/.cache` resolve Pi packages from the root, not a source workspace. Keep imported Pi packages as root devDependencies so the alternate-Pi matrix installs matching copies.
 - Treat `package.json#packageManager` plus CI/release workflows as the npm-version authority. A different npm can rewrite unrelated lock metadata or mishandle the alternate-Pi install matrix.
 - The pinned npm 12.0.2 rejects Node 25; run lockfile work under an installed supported runtime such as Node 22.22.2 instead of tolerating npm's compatibility warning.
+- A consumer cannot safely adopt an unpublished `pi-tui-kit` API in the same PR: clean `npm ci` resolves its semver dependency from the registry. Publish the Kit API before raising the consumer's reviewed compatibility floor; do not use local paths that break independent packaging.
 - Official Pi can misresolve static `@earendil-works/pi-ai/api/*` imports beneath its compatibility alias. Prefer root exports; otherwise use a variable-specifier dynamic import.
 
 ### Processes, lifecycle, and state

--- a/docs/plans/archived/2026-08-04_pi-recall-fuzzy-search-plan.md
+++ b/docs/plans/archived/2026-08-04_pi-recall-fuzzy-search-plan.md
@@ -1,0 +1,36 @@
+# Pi Recall fuzzy search implementation plan
+
+## Goal
+
+Add visible, transient TUI fuzzy search to Pi Recall's scoped saved-message picker without changing RPC, storage, command, or quote semantics.
+
+## Architecture
+
+- Keep `ScopedRecallPicker` extension-owned because it combines scope switching with saved-message selection.
+- Use Pi TUI's public `Input` and `fuzzyFilter` over message text, role, and optional session name.
+- Apply scope filtering before search; retain the scope total separately from the current match count.
+- Carry the transient query through picker results so one `/recall` interaction can restore it after selected-message navigation.
+- Keep Pi TUI Kit unchanged: it already consumes Pi TUI's generic fuzzy primitive, while pi-file-context's typo/path scorer remains domain-specific.
+
+## Non-Goals
+
+No typo-edit-distance matching, RPC search, persistent query, settings, storage/schema changes, package metadata changes, publication, tag, merge, or release.
+
+## Plan
+
+- [x] Add focused failing picker tests for visible search, content/role/session matching, relevance order, scope-before-search behavior, match counts, empty/no-match/overlong states, safe pasted controls and spaces, selection restoration, query persistence, focus forwarding, disposal, and narrow-width rendering. Evidence: the focused compile failed because `initialQuery` was absent from the picker contract.
+- [x] Implement bounded `Input`-driven fuzzy filtering in `experimental/pi-recall/src/picker.ts`; verify focused picker tests pass. Evidence: focused picker suite passes 9/9.
+- [x] Add a failing menu-flow test for same-interaction query restoration and fresh-flow reset; implement the smallest state handoff in `experimental/pi-recall/src/menu.ts` while preserving RPC behavior. Evidence: the new menu test first reopened with an empty Search row, then passed after the query handoff; menu suite passes 8/8 and the existing RPC scope/list test remains green.
+- [x] Update `experimental/pi-recall/README.md`; verify package typechecking and Biome. Evidence: README documents fields, semantics, reset/limit behavior, and RPC; `npm run check --workspace @narumitw/pi-recall` passes.
+- [x] Run focused Pi Recall tests, `npm run check:boundaries`, full `npm run check`, and `just pack recall`; inspect dry-run contents. Evidence: Pi Recall passes 35/35 focused tests; boundary validation passes for 1 library and 25 active extensions; a clean normal clone under CI's Node 24/npm 11 path with latest Pi passes all 2,344 root tests and gates; dry-run pack contains only the 9 manifest-allowed files and leaves no tarball.
+- [x] Audit the final diff against `docs/extension-conventions.md` for custom TUI rendering, focus, input sanitization, cancellation/disposal, TUI/RPC behavior, documentation, tests, and package boundaries; settings guidance remains inapplicable. Evidence: search is TUI-only and visibly labeled; lines are tested width-safe; `Focusable`, invalidation, control replacement, disposal, Back/Close, lifecycle ownership, and unchanged RPC are covered; no settings, metadata, storage, or dependency boundary changed.
+- [x] Mark all evidence complete and archive this plan at `docs/plans/archived/2026-08-04_pi-recall-fuzzy-search-plan.md` without changing the earlier archived implementation plan. Evidence: all plan and completion items are checked before the archive move.
+
+## Completion Checklist
+
+- [x] Body, role, and session-name queries filter and relevance-rank only records in the active scope using standard Pi fuzzy semantics; non-searchable local metadata is covered.
+- [x] Scope totals, active match counts, empty/no-match/overlong states, and all keyboard hints are visible and width-safe.
+- [x] Query, selected ID, and prior-selection restoration behave correctly across filtering, scope changes, and same-flow navigation; a new flow resets to an empty query and Current cwd.
+- [x] Controls are removed from query input, spaces support multiple tokens, overlong queries do not run matching, and disposal/focus semantics satisfy Pi's custom TUI contract.
+- [x] Escape/Ctrl+C, RPC dialogs, JSONL storage, editor drafts, command behavior, and quote format remain unchanged.
+- [x] Focused tests, package checks, boundaries, root CI-equivalent checks, and package dry run pass.

--- a/experimental/pi-recall/README.md
+++ b/experimental/pi-recall/README.md
@@ -12,6 +12,7 @@
 - Saves any eligible user or assistant text message from the current active session branch—not only the latest message.
 - Recalls saved messages across sessions using **Current cwd**, **All**, or **Current session** scope.
 - Cycles TUI scope with `Tab` and `Shift+Tab`, with the active scope and result count always visible.
+- Fuzzy-searches saved message text, role, and session name inside the active TUI scope.
 - Previews the complete saved text before use.
 - Inserts an XML-marked quote at the TUI editor cursor without submitting it automatically.
 - Stores versioned JSONL locally with cross-process locking, private permissions, and atomic replacement.
@@ -42,7 +43,7 @@ pi -e ./experimental/pi-recall
 1. Run `/recall`.
 2. Choose **Save a message** and select a text user or assistant message from the active branch.
 3. In any later session, run `/recall` and choose **Recall a saved message**.
-4. In TUI mode, press `Tab` or `Shift+Tab` to change scope. RPC mode asks for scope explicitly.
+4. In TUI mode, type to fuzzy-search or press `Tab` / `Shift+Tab` to change scope. RPC mode asks for scope explicitly.
 5. Preview the message or choose **Quote into draft**.
 6. Add your question or instruction, then submit the draft normally.
 
@@ -68,11 +69,19 @@ Print and JSON modes reject `/recall` before opening an interactive flow. TUI an
 
 ## 🧭 Recall scopes
 
-- **Current cwd** — saved messages whose normalized absolute source cwd matches the current cwd. This is the default each time the picker opens.
+- **Current cwd** — saved messages whose normalized absolute source cwd matches the current cwd. This is the default for each new `/recall` interaction.
 - **All** — every valid record in the current Pi agent directory.
 - **Current session** — records whose source session ID exactly matches the current session.
 
-Scope applies only when recalling already saved messages. The save picker intentionally reads only `ctx.sessionManager.getBranch()` from the current session and never scans other session files. TUI scope switching keeps the selected saved record when it remains visible in the new scope; otherwise it selects the newest visible record.
+Scope applies only when recalling already saved messages. The save picker intentionally reads only `ctx.sessionManager.getBranch()` from the current session and never scans other session files. TUI scope switching keeps the selected saved record when it remains visible in the new scope; otherwise it selects the first fuzzy-ranked result or the newest result when the query is empty.
+
+## 🔍 TUI fuzzy search
+
+The TUI picker has a visible `Search:` input. It matches complete saved message text, the `user` or `assistant` role, and the optional session name after scope filtering. Matching is case-insensitive and requires every whitespace- or slash-separated token as an ordered subsequence. It ranks closer matches first but does not perform typo-edit-distance correction.
+
+The query and selection survive scope changes and selected-message navigation during one `/recall` interaction. A new `/recall` starts with an empty query and **Current cwd**. Queries are limited to 256 UTF-16 code units; an overlong query shows an error and runs no matching. Terminal controls are replaced before matching or display, while ordinary spaces remain available for multi-token queries.
+
+RPC continues to show the complete scoped list through explicit dialogs and does not simulate a hidden fuzzy query. Message timestamps, cwd, session IDs, entry IDs, and local paths are not searchable.
 
 ## 🔒 Storage, privacy, and recovery
 
@@ -108,11 +117,11 @@ Terminal controls are removed from labels, previews, metadata, and errors before
 
 ## 🚧 Experimental limitations
 
-- No tags, text search, editing, reordering, import/export, automatic expiry, or automatic context injection.
+- No tags, saved-query persistence, editing, reordering, import/export, automatic expiry, or automatic context injection.
 - No cross-session transcript browser: only previously saved records can be recalled across sessions.
 - Text only; images and tool payloads are deliberately omitted.
 - The custom TUI picker is keyboard-operated. RPC uses sequential dialogs.
-- Scope preference is not persisted; every new picker starts at **Current cwd**.
+- Scope and search preferences are not persisted; every new `/recall` interaction starts at **Current cwd** with an empty query.
 
 ## 🗂️ Package layout
 

--- a/experimental/pi-recall/src/menu.ts
+++ b/experimental/pi-recall/src/menu.ts
@@ -52,6 +52,7 @@ export function createRecallMenu(
 	let selectedRecordId: string | undefined;
 	let selectedScope: RecallScope = "cwd";
 	let pickerSelectedId: string | undefined;
+	let pickerQuery = "";
 
 	const getState = async ({ signal }: { signal: AbortSignal }): Promise<RecallMenuState> => {
 		try {
@@ -175,9 +176,23 @@ export function createRecallMenu(
 			chooseSaved: async ({ ctx, state, signal }) => {
 				const result =
 					ctx.mode === "tui"
-						? await chooseSavedInTui(ctx, state, signal, ownership, selectedScope, pickerSelectedId)
+						? await chooseSavedInTui(
+								ctx,
+								state,
+								signal,
+								ownership,
+								selectedScope,
+								pickerSelectedId,
+								pickerQuery,
+							)
 						: await chooseSavedInRpc(ctx, state, signal, selectedScope);
-				if (!result || result.kind === "back") return { kind: "stay" };
+				if (!result) return { kind: "stay" };
+				if (ctx.mode === "tui") {
+					selectedScope = result.scope;
+					pickerQuery = result.query ?? pickerQuery;
+					if ("selectedId" in result) pickerSelectedId = result.selectedId;
+				}
+				if (result.kind === "back") return { kind: "stay" };
 				if (result.kind === "close") return { kind: "close" };
 				selectedScope = result.scope;
 				pickerSelectedId = result.recordId;
@@ -294,6 +309,7 @@ async function chooseSavedInTui(
 	ownership: { isCurrent?: () => boolean },
 	initialScope: RecallScope,
 	initialSelectedId: string | undefined,
+	initialQuery: string,
 ): Promise<ScopedRecallPickerResult | undefined> {
 	const interaction = await runCustomInteraction<ScopedRecallPickerResult>(ctx, {
 		signal,
@@ -307,6 +323,7 @@ async function chooseSavedInTui(
 				current: state.current,
 				initialScope,
 				initialSelectedId,
+				initialQuery,
 				complete,
 			}),
 	});

--- a/experimental/pi-recall/src/picker.ts
+++ b/experimental/pi-recall/src/picker.ts
@@ -1,5 +1,15 @@
 import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
-import { type Component, Key, matchesKey, type TUI, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+	type Component,
+	type Focusable,
+	fuzzyFilter,
+	Input,
+	Key,
+	matchesKey,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 import {
 	filterRecallMessages,
 	messagePreview,
@@ -14,11 +24,12 @@ const SCOPE_LABELS: Record<RecallScope, string> = {
 	cwd: "Current cwd",
 	session: "Current session",
 };
+const MAX_SEARCH_QUERY_LENGTH = 256;
 
 export type ScopedRecallPickerResult =
-	| { kind: "selected"; recordId: string; scope: RecallScope }
-	| { kind: "back"; scope: RecallScope; selectedId?: string }
-	| { kind: "close"; scope: RecallScope; selectedId?: string };
+	| { kind: "selected"; recordId: string; scope: RecallScope; query?: string }
+	| { kind: "back"; scope: RecallScope; selectedId?: string; query?: string }
+	| { kind: "close"; scope: RecallScope; selectedId?: string; query?: string };
 
 interface ScopedRecallPickerOptions {
 	tui: TUI;
@@ -28,30 +39,46 @@ interface ScopedRecallPickerOptions {
 	current: RecallScopeContext;
 	initialScope?: RecallScope;
 	initialSelectedId?: string;
+	initialQuery?: string;
 	complete: (result: ScopedRecallPickerResult) => void;
 }
 
-export class ScopedRecallPicker implements Component {
+export class ScopedRecallPicker implements Component, Focusable {
+	private readonly searchInput = new Input();
 	private scope: RecallScope;
 	private selectedId: string | undefined;
+	private restoreSelectedId: string | undefined;
+	private records: RecallMessageRecord[];
 	private scrollOffset = 0;
 	private disposed = false;
 	private completed = false;
+	private isFocused = false;
 
 	constructor(private readonly options: ScopedRecallPickerOptions) {
 		this.scope = options.initialScope ?? "cwd";
-		const records = this.filteredRecords();
-		this.selectedId = records.some(({ id }) => id === options.initialSelectedId)
+		this.searchInput.setValue(replaceTerminalControls(options.initialQuery ?? ""));
+		this.searchInput.focused = false;
+		this.records = this.searchRecords(this.scopedRecords());
+		this.selectedId = this.records.some(({ id }) => id === options.initialSelectedId)
 			? options.initialSelectedId
-			: records[0]?.id;
+			: this.records[0]?.id;
+	}
+
+	get focused(): boolean {
+		return this.isFocused;
+	}
+
+	set focused(value: boolean) {
+		this.isFocused = value;
+		this.searchInput.focused = value && !this.disposed;
 	}
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const records = this.filteredRecords();
-		const listHeight = Math.max(1, Math.floor(this.options.tui.terminal.rows) - 7);
-		this.keepSelectionVisible(records, listHeight);
-		const visible = records.slice(this.scrollOffset, this.scrollOffset + listHeight);
+		const scopedRecords = this.scopedRecords();
+		const listHeight = Math.max(1, Math.floor(this.options.tui.terminal.rows) - 8);
+		this.keepSelectionVisible(this.records, listHeight);
+		const visible = this.records.slice(this.scrollOffset, this.scrollOffset + listHeight);
 		const rows = visible.map((record) => {
 			const selected = record.id === this.selectedId;
 			const role = record.role === "assistant" ? "assistant" : "user";
@@ -65,7 +92,29 @@ export class ScopedRecallPicker implements Component {
 				? this.options.theme.fg("accent", truncateToWidth(line, safeWidth, "…"))
 				: truncateToWidth(line, safeWidth, "…");
 		});
-		const scopeLine = `Scope: ${SCOPE_LABELS[this.scope]} (${records.length}) · Tab change scope`;
+		const query = this.query();
+		const activeQuery = query.trim().length > 0;
+		const matchCount = activeQuery
+			? ` · ${this.records.length} ${this.records.length === 1 ? "match" : "matches"}`
+			: "";
+		const scopeLine = `Scope: ${SCOPE_LABELS[this.scope]} (${scopedRecords.length})${matchCount} · Tab change scope`;
+		const searchLabel = this.options.theme.fg("muted", "Search: ");
+		const searchWidth = Math.max(1, safeWidth - visibleWidth(searchLabel));
+		const searchLine = `${searchLabel}${this.searchInput.render(searchWidth)[0] ?? ""}`;
+		const emptyRows =
+			scopedRecords.length === 0
+				? [this.options.theme.fg("dim", "  No saved messages in this scope")]
+				: [
+						...(this.queryTooLong()
+							? [
+									this.options.theme.fg(
+										"error",
+										`  Search query is too long (maximum ${MAX_SEARCH_QUERY_LENGTH} characters)`,
+									),
+								]
+							: []),
+						this.options.theme.fg("dim", "  No matching saved messages"),
+					];
 		return [
 			truncateToWidth(
 				this.options.theme.fg("accent", this.options.theme.bold("Pi Recall")),
@@ -73,20 +122,13 @@ export class ScopedRecallPicker implements Component {
 				"",
 			),
 			truncateToWidth(this.options.theme.fg("muted", scopeLine), safeWidth, ""),
+			truncateToWidth(searchLine, safeWidth, ""),
 			"",
-			...(rows.length > 0
-				? rows
-				: [
-						truncateToWidth(
-							this.options.theme.fg("dim", "  No saved messages in this scope"),
-							safeWidth,
-							"",
-						),
-					]),
+			...(rows.length > 0 ? rows : emptyRows),
 			truncateToWidth(
 				this.options.theme.fg(
 					"dim",
-					"↑↓ navigate · Enter select · Tab/Shift+Tab scope · Esc back · Ctrl+C close",
+					"Type to search · ↑↓ navigate · Enter select · Tab/Shift+Tab scope · Esc back · Ctrl+C close",
 				),
 				safeWidth,
 				"",
@@ -97,7 +139,12 @@ export class ScopedRecallPicker implements Component {
 	handleInput(data: string): void {
 		if (this.disposed || this.completed) return;
 		if (matchesKey(data, Key.ctrl("c"))) {
-			this.finish({ kind: "close", scope: this.scope, selectedId: this.selectedId });
+			this.finish({
+				kind: "close",
+				scope: this.scope,
+				selectedId: this.selectedId,
+				query: this.query(),
+			});
 			return;
 		}
 		if (matchesKey(data, Key.shift("tab"))) {
@@ -105,63 +152,109 @@ export class ScopedRecallPicker implements Component {
 		} else if (matchesKey(data, Key.tab)) {
 			this.cycleScope(1);
 		} else if (this.options.keybindings.matches(data, "tui.select.cancel")) {
-			this.finish({ kind: "back", scope: this.scope, selectedId: this.selectedId });
+			this.finish({
+				kind: "back",
+				scope: this.scope,
+				selectedId: this.selectedId,
+				query: this.query(),
+			});
 			return;
 		} else if (this.options.keybindings.matches(data, "tui.select.up")) {
 			this.move(-1);
 		} else if (this.options.keybindings.matches(data, "tui.select.down")) {
 			this.move(1);
 		} else if (this.options.keybindings.matches(data, "tui.select.pageUp")) {
-			this.move(-Math.max(1, Math.floor(this.options.tui.terminal.rows) - 7));
+			this.move(-Math.max(1, Math.floor(this.options.tui.terminal.rows) - 8));
 		} else if (this.options.keybindings.matches(data, "tui.select.pageDown")) {
-			this.move(Math.max(1, Math.floor(this.options.tui.terminal.rows) - 7));
+			this.move(Math.max(1, Math.floor(this.options.tui.terminal.rows) - 8));
 		} else if (matchesKey(data, Key.home)) {
 			this.selectAt(0);
 		} else if (matchesKey(data, Key.end)) {
-			this.selectAt(this.filteredRecords().length - 1);
+			this.selectAt(this.records.length - 1);
 		} else if (this.options.keybindings.matches(data, "tui.select.confirm")) {
 			if (this.selectedId) {
-				this.finish({ kind: "selected", recordId: this.selectedId, scope: this.scope });
+				this.finish({
+					kind: "selected",
+					recordId: this.selectedId,
+					scope: this.scope,
+					query: this.query(),
+				});
 				return;
 			}
+		} else {
+			const previousQuery = this.query();
+			this.searchInput.handleInput(data);
+			const safeQuery = replaceTerminalControls(this.searchInput.getValue());
+			if (safeQuery !== this.searchInput.getValue()) this.searchInput.setValue(safeQuery);
+			if (safeQuery !== previousQuery) this.applySearch();
 		}
 		this.options.tui.requestRender();
 	}
 
-	invalidate(): void {}
+	invalidate(): void {
+		this.searchInput.invalidate();
+	}
 
 	dispose(): void {
 		this.disposed = true;
+		this.isFocused = false;
+		this.searchInput.focused = false;
 	}
 
-	private filteredRecords(): RecallMessageRecord[] {
+	private scopedRecords(): RecallMessageRecord[] {
 		return filterRecallMessages(this.options.records, this.scope, this.options.current).reverse();
+	}
+
+	private searchRecords(records: readonly RecallMessageRecord[]): RecallMessageRecord[] {
+		const query = this.query();
+		if (this.queryTooLong()) return [];
+		if (!query.trim()) return [...records];
+		return fuzzyFilter([...records], query, searchRecordText);
+	}
+
+	private applySearch(): void {
+		const previouslySelectedId = this.selectedId;
+		this.records = this.searchRecords(this.scopedRecords());
+		const restoreIndex = this.records.findIndex(({ id }) => id === this.restoreSelectedId);
+		const previousIndex = this.records.findIndex(({ id }) => id === previouslySelectedId);
+		if (restoreIndex >= 0) {
+			this.selectedId = this.records[restoreIndex]?.id;
+			this.restoreSelectedId = undefined;
+		} else if (previousIndex >= 0) {
+			this.selectedId = this.records[previousIndex]?.id;
+		} else {
+			if (previouslySelectedId) this.restoreSelectedId ??= previouslySelectedId;
+			this.selectedId = this.records[0]?.id;
+		}
+		this.scrollOffset = 0;
 	}
 
 	private cycleScope(delta: number): void {
 		const index = SCOPE_ORDER.indexOf(this.scope);
 		this.scope = SCOPE_ORDER[(index + delta + SCOPE_ORDER.length) % SCOPE_ORDER.length] ?? "cwd";
-		const records = this.filteredRecords();
-		if (!records.some(({ id }) => id === this.selectedId)) this.selectedId = records[0]?.id;
+		this.records = this.searchRecords(this.scopedRecords());
+		if (!this.records.some(({ id }) => id === this.selectedId)) {
+			this.selectedId = this.records[0]?.id;
+		}
 		this.scrollOffset = 0;
 	}
 
 	private move(delta: number): void {
-		const records = this.filteredRecords();
-		if (records.length === 0) return;
+		if (this.records.length === 0) return;
 		const current = Math.max(
 			0,
-			records.findIndex(({ id }) => id === this.selectedId),
+			this.records.findIndex(({ id }) => id === this.selectedId),
 		);
-		const next = Math.max(0, Math.min(records.length - 1, current + delta));
-		this.selectedId = records[next]?.id;
+		const next = Math.max(0, Math.min(this.records.length - 1, current + delta));
+		this.selectedId = this.records[next]?.id;
+		this.restoreSelectedId = undefined;
 	}
 
 	private selectAt(index: number): void {
-		const records = this.filteredRecords();
-		if (records.length === 0) return;
-		const bounded = Math.max(0, Math.min(records.length - 1, index));
-		this.selectedId = records[bounded]?.id;
+		if (this.records.length === 0) return;
+		const bounded = Math.max(0, Math.min(this.records.length - 1, index));
+		this.selectedId = this.records[bounded]?.id;
+		this.restoreSelectedId = undefined;
 	}
 
 	private keepSelectionVisible(records: readonly RecallMessageRecord[], height: number): void {
@@ -178,11 +271,36 @@ export class ScopedRecallPicker implements Component {
 		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, records.length - height));
 	}
 
+	private query(): string {
+		return this.searchInput.getValue();
+	}
+
+	private queryTooLong(): boolean {
+		return this.query().length > MAX_SEARCH_QUERY_LENGTH;
+	}
+
 	private finish(result: ScopedRecallPickerResult): void {
 		if (this.completed) return;
 		this.completed = true;
 		this.options.complete(result);
 	}
+}
+
+function searchRecordText(record: RecallMessageRecord): string {
+	return [
+		sanitizeTerminalText(record.text),
+		record.role,
+		record.source.sessionName ? sanitizeTerminalText(record.source.sessionName) : "",
+	]
+		.filter(Boolean)
+		.join(" ");
+}
+
+function replaceTerminalControls(value: string): string {
+	return Array.from(value, (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+	}).join("");
 }
 
 export function sanitizeTerminalText(value: string): string {

--- a/experimental/pi-recall/test/menu.test.ts
+++ b/experimental/pi-recall/test/menu.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { stripVTControlCharacters } from "node:util";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { resolveMenuScreen, runMenu } from "@narumitw/pi-tui-kit";
 import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
@@ -162,6 +163,59 @@ test("TUI saved picker is lifecycle-owned and returns the Tab-selected scope", a
 	tui.press("tui.select.confirm");
 	assert.deepEqual(await choosing, { kind: "to", screen: "selected" });
 	assert.equal(tui.isOpen, false);
+});
+
+test("TUI query survives picker re-entry in one Recall flow and resets in a fresh flow", async () => {
+	const data = source();
+	const base = createMockContext({ hasUI: true, mode: "tui" }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const controller = createRecallMenu(data);
+
+	const firstTui = createTuiHarness({ width: 72, rows: 18 });
+	const first = controller.menu.actions.chooseSaved({
+		ctx: { ...base, ui: { ...base.ui, custom: firstTui.custom } } as never,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "recall",
+	});
+	await firstTui.waitForOpen();
+	firstTui.type("saved-a");
+	assert.match(stripVTControlCharacters(firstTui.render().join("\n")), /1 match/);
+	firstTui.press("tui.select.confirm");
+	assert.deepEqual(await first, { kind: "to", screen: "selected" });
+
+	const reopenedTui = createTuiHarness({ width: 72, rows: 18 });
+	const reopened = controller.menu.actions.chooseSaved({
+		ctx: { ...base, ui: { ...base.ui, custom: reopenedTui.custom } } as never,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "recall",
+	});
+	await reopenedTui.waitForOpen();
+	const reopenedSearch = stripVTControlCharacters(reopenedTui.render().join("\n"))
+		.split("\n")
+		.find((line) => line.startsWith("Search:"));
+	assert.match(reopenedSearch ?? "", /saved-a/);
+	reopenedTui.press("tui.select.cancel");
+	assert.deepEqual(await reopened, { kind: "stay" });
+
+	const fresh = createRecallMenu(data);
+	const freshTui = createTuiHarness({ width: 72, rows: 18 });
+	const freshChoosing = fresh.menu.actions.chooseSaved({
+		ctx: { ...base, ui: { ...base.ui, custom: freshTui.custom } } as never,
+		state: await state(fresh),
+		signal: new AbortController().signal,
+		itemId: "recall",
+	});
+	await freshTui.waitForOpen();
+	const freshSearch = stripVTControlCharacters(freshTui.render().join("\n"))
+		.split("\n")
+		.find((line) => line.startsWith("Search:"));
+	assert.doesNotMatch(freshSearch ?? "", /saved-a/);
+	freshTui.press("tui.select.cancel");
+	assert.deepEqual(await freshChoosing, { kind: "stay" });
 });
 
 test("preview is exact, quote appends to the draft without sending, and delete requires review action", async () => {

--- a/experimental/pi-recall/test/picker.test.ts
+++ b/experimental/pi-recall/test/picker.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { stripVTControlCharacters } from "node:util";
+import { CURSOR_MARKER, type Focusable, visibleWidth } from "@earendil-works/pi-tui";
 import type { RecallMessageRecord } from "../src/messages.js";
 import { ScopedRecallPicker } from "../src/picker.js";
 
@@ -22,11 +23,19 @@ function saved(id: string, sessionId: string, cwd: string, text: string): Recall
 	};
 }
 
-function createPicker(records: RecallMessageRecord[]) {
+function createPicker(
+	records: RecallMessageRecord[],
+	options: {
+		initialScope?: "all" | "cwd" | "session";
+		initialSelectedId?: string;
+		initialQuery?: string;
+		rows?: number;
+	} = {},
+) {
 	let result: unknown;
 	let renders = 0;
 	const picker = new ScopedRecallPicker({
-		tui: { terminal: { rows: 12 }, requestRender: () => renders++ } as never,
+		tui: { terminal: { rows: options.rows ?? 12 }, requestRender: () => renders++ } as never,
 		theme: {
 			fg: (_color: string, text: string) => text,
 			bold: (text: string) => text,
@@ -44,7 +53,9 @@ function createPicker(records: RecallMessageRecord[]) {
 		} as never,
 		records,
 		current: { sessionId: "current", cwd: "/work/project" },
-		initialScope: "cwd",
+		initialScope: options.initialScope ?? "cwd",
+		initialSelectedId: options.initialSelectedId,
+		initialQuery: options.initialQuery,
 		complete: (value) => {
 			result = value;
 		},
@@ -81,6 +92,7 @@ test("preserves a selected saved id across scope changes when still visible", ()
 		kind: "selected",
 		recordId: "one",
 		scope: "all",
+		query: "",
 	});
 });
 
@@ -97,6 +109,7 @@ test("falls back to the first newest record when selection leaves the scope", ()
 		kind: "selected",
 		recordId: "one",
 		scope: "session",
+		query: "",
 	});
 });
 
@@ -104,10 +117,15 @@ test("escape returns to the menu while ctrl+c closes the whole Recall flow", () 
 	const records = [saved("one", "current", "/work/project", "one")];
 	const back = createPicker(records);
 	back.picker.handleInput("escape");
-	assert.deepEqual(back.result(), { kind: "back", scope: "cwd", selectedId: "one" });
+	assert.deepEqual(back.result(), { kind: "back", scope: "cwd", selectedId: "one", query: "" });
 	const close = createPicker(records);
 	close.picker.handleInput("\u0003");
-	assert.deepEqual(close.result(), { kind: "close", scope: "cwd", selectedId: "one" });
+	assert.deepEqual(close.result(), {
+		kind: "close",
+		scope: "cwd",
+		selectedId: "one",
+		query: "",
+	});
 });
 
 test("empty scopes remain switchable and rendered output is sanitized and width-safe", () => {
@@ -126,4 +144,111 @@ test("empty scopes remain switchable and rendered output is sanitized and width-
 	picker.dispose();
 	picker.handleInput("\t");
 	assert.match(picker.render(24).join("\n"), /Scope: All \(1\)/);
+});
+
+test("fuzzy-searches message text, role, and session name with relevance ordering", () => {
+	const direct = saved("one", "current", "/work/project", "alpha release");
+	direct.source.sessionName = "Planning Room";
+	const later = saved("two", "other", "/work/project", "prefix alpha notes");
+	later.source.sessionName = "Other Room";
+
+	const content = createPicker([direct, later]);
+	assert.ok(
+		content.picker.render(100).join("\n").indexOf("prefix alpha") <
+			content.picker.render(100).join("\n").indexOf("alpha release"),
+	);
+	content.picker.handleInput("alpha");
+	const ranked = content.picker.render(100).join("\n");
+	assert.ok(ranked.indexOf("alpha release") < ranked.indexOf("prefix alpha"));
+
+	const role = createPicker([direct, later]);
+	role.picker.handleInput("user");
+	assert.match(role.picker.render(100).join("\n"), /alpha release/);
+	assert.doesNotMatch(role.picker.render(100).join("\n"), /prefix alpha/);
+
+	const session = createPicker([direct, later]);
+	session.picker.handleInput("plnng room");
+	assert.match(session.picker.render(100).join("\n"), /Planning Room/);
+	assert.doesNotMatch(session.picker.render(100).join("\n"), /Other Room/);
+
+	const hiddenMetadata = createPicker([direct, later]);
+	hiddenMetadata.picker.handleInput("work project");
+	assert.match(hiddenMetadata.picker.render(100).join("\n"), /No matching saved messages/);
+});
+
+test("applies scope before search and distinguishes totals, matches, and empty states", () => {
+	const noMatch = createPicker([
+		saved("one", "current", "/work/project", "local note"),
+		saved("two", "other", "/other", "remote needle"),
+	]);
+	noMatch.picker.handleInput("needle");
+	let rendered = noMatch.picker.render(80).join("\n");
+	assert.match(rendered, /Scope: Current cwd \(1\).*0 matches/);
+	assert.match(rendered, /No matching saved messages/);
+	noMatch.picker.handleInput("enter");
+	assert.equal(noMatch.result(), undefined);
+	noMatch.picker.handleInput("\t");
+	rendered = noMatch.picker.render(80).join("\n");
+	assert.match(rendered, /Scope: All \(2\).*1 match/);
+	assert.match(rendered, /remote needle/);
+
+	const empty = createPicker([saved("three", "other", "/other", "elsewhere")]);
+	assert.match(empty.picker.render(80).join("\n"), /No saved messages in this scope/);
+});
+
+test("preserves query spaces, removes pasted controls, bounds queries, and forwards focus", () => {
+	const record = saved("one", "current", "/work/project", "bar foo 📖");
+	const { picker } = createPicker([record]);
+	const focusable = picker as ScopedRecallPicker & Focusable;
+	focusable.focused = true;
+	assert.equal(picker.render(80).join("\n").includes(CURSOR_MARKER), true);
+	focusable.focused = false;
+	picker.handleInput("\u001b[200~foo \u0007\u009dbar\u009c\u001b[201~");
+	const rendered = picker.render(80).join("\n");
+	assert.match(rendered, /bar foo/);
+	assert.equal(rendered.includes("\u0007"), false);
+	assert.equal(rendered.includes("\u009d"), false);
+	assert.equal(rendered.includes("\u009c"), false);
+	for (const width of [1, 2, 8, 20, 80]) {
+		assert.ok(picker.render(width).every((line) => visibleWidth(line) <= width));
+	}
+
+	const overlong = createPicker([record]);
+	overlong.picker.handleInput("a".repeat(257));
+	assert.match(overlong.picker.render(80).join("\n"), /Search query is too long.*256/);
+	assert.match(overlong.picker.render(80).join("\n"), /No matching saved messages/);
+
+	const beforeDispose = picker.render(80);
+	picker.dispose();
+	assert.equal(picker.render(80).join("\n").includes(CURSOR_MARKER), false);
+	picker.handleInput("ignored");
+	assert.deepEqual(picker.render(80), beforeDispose);
+});
+
+test("restores selection after broadening and carries query through scope and completion", () => {
+	const records = [
+		saved("one", "current", "/work/project", "alpha"),
+		saved("two", "other", "/work/project", "zulu"),
+	];
+	const restored = createPicker(records, { initialSelectedId: "one" });
+	restored.picker.handleInput("z");
+	restored.picker.handleInput("\u007f");
+	restored.picker.handleInput("enter");
+	assert.deepEqual(restored.result(), {
+		kind: "selected",
+		recordId: "one",
+		scope: "cwd",
+		query: "",
+	});
+
+	const carried = createPicker(records, { initialQuery: "alpha" });
+	assert.match(stripVTControlCharacters(carried.picker.render(80).join("\n")), /Search: .*alpha/);
+	carried.picker.handleInput("\t");
+	carried.picker.handleInput("enter");
+	assert.deepEqual(carried.result(), {
+		kind: "selected",
+		recordId: "one",
+		scope: "all",
+		query: "alpha",
+	});
 });


### PR DESCRIPTION
## Summary

- add a visible TUI fuzzy-search input for saved message text, role, and session name
- filter within the active recall scope while preserving scope totals, query state, and stable selection restoration
- bound and sanitize search input, expose no-match/overlong states, and keep RPC selection unchanged
- reuse Pi TUI's standard `fuzzyFilter` instead of adding an unreleased Pi TUI Kit API

## Testing

- Pi Recall focused tests: 35 passed
- `npm run check --workspace @narumitw/pi-recall`
- `npm run check:boundaries`
- `npm run check` in a clean normal clone with CI's Node/npm/latest-Pi path: 2,344 tests passed
- `just pack recall` (9 expected files)
