### PR TITLE
feat(recall): delete messages from fuzzy picker

### DIFF
--- a/docs/plans/archived/2026-08-04_pi-recall-direct-delete-plan.md
+++ b/docs/plans/archived/2026-08-04_pi-recall-direct-delete-plan.md
@@ -1,0 +1,36 @@
+# Pi Recall direct-delete implementation plan
+
+## Goal
+
+Let TUI users delete the selected saved message from Pi Recall's fuzzy picker with the configured `app.session.delete` shortcut (Ctrl+D by default), confirm the exact destructive action, and return to the same scope and query without changing RPC, storage, quote, or existing selected-message workflows.
+
+## Architecture
+
+- Keep search, scope, and selection in `ScopedRecallPicker`; emit a typed delete request containing the selected record and nearest surviving selection.
+- Keep mutation ownership in `createRecallMenu`: close the picker, show Pi's standard confirmation, run the existing abort-aware atomic store deletion under a non-cancellable post-confirmation loader, then reopen a fresh picker.
+- Revalidate session ownership after every awaited picker, confirmation, and deletion operation. Preserve the previous in-memory list on failure; remove only the confirmed ID after a successful or already-absent result.
+- Continue using the existing JSONL lock and atomic replacement protocol without schema or migration changes.
+
+## Non-Goals
+
+No batch deletion, plain-Delete override, new command arguments, RPC fuzzy shortcuts, storage changes, settings, package metadata, publication, or release.
+
+## Plan
+
+- [x] Add focused failing picker tests for the configurable direct-delete shortcut, visible responsive hint, nearest-selection handoff, empty/no-match behavior, and preservation of plain Delete search input. Evidence: the focused picker suite failed on the missing `ctrl+d delete` hint before implementation.
+- [x] Implement the typed picker delete request and responsive text hints in `experimental/pi-recall/src/picker.ts`; verify focused picker tests pass. Evidence: focused picker suite passes 11/11.
+- [x] Add focused failing menu tests for previewed confirmation, cancellation without mutation, atomic success with scope/query/neighbor restoration, actionable failure recovery, already-removed records, and lifecycle cancellation; verify the intended red state. Evidence: four direct-delete menu tests failed because the picker result went directly to the selected-message screen without confirmation, mutation, progress, or re-entry; lifecycle coverage remains part of the implementation slice.
+- [x] Implement the TUI-only confirm/delete/reopen loop in `experimental/pi-recall/src/menu.ts`, including non-cancellable post-confirmation progress, ownership checks after awaits, and immediate textual feedback; verify focused menu and lifecycle tests pass. Evidence: focused menu suite passes 13/13, including success, cancellation, failure, concurrent removal, progress, and session-abort cases.
+- [x] Update `experimental/pi-recall/README.md` for the Ctrl+D workflow, confirmation, context preservation, failure behavior, and unchanged RPC/existing delete route. Evidence: package Biome and typecheck pass with the documented behavior.
+- [x] Run Pi Recall focused tests, package check, `npm run check:boundaries`, full `npm run check`, and `just pack recall`; inspect dry-run contents. Evidence: Pi Recall passes 42/42 tests; package check and boundaries pass; a normal verification clone with signing disabled passes the full 2,385-test root gate (the linked worktree run reproduced the documented injected-Git/signing failures); dry-run pack contains only the nine manifest-allowed files and leaves no tarball.
+- [x] Audit the final diff against `docs/extension-conventions.md` for destructive confirmation, custom TUI width/focus/input behavior, async cancellation/disposal/session replacement, mutation safety, mode compatibility, documentation, and named verification methods. Evidence: confirmation and cancellation remain explicit; rendered lines, focus forwarding, raw Delete compatibility, progress ownership, post-await guards, locked atomic mutation, TUI-only shortcut, unchanged RPC, and documentation are covered. `docs/extension-settings.md` remains inapplicable because no settings changed.
+
+## Completion Checklist
+
+- [x] Ctrl+D (or the user's configured `app.session.delete` binding) requests deletion only when a saved result is selected; plain Delete remains search editing input.
+- [x] Confirmation identifies the exact record and consequence; cancelling is side-effect free and restores picker scope, query, selection, and focus.
+- [x] Confirmed deletion is atomic, displays progress, remains non-cancellable after application starts, and returns to the same filtered list with a stable neighboring selection and updated counts.
+- [x] Failure keeps the previous valid list and presents an actionable error; an already-removed record is reconciled without reporting false success.
+- [x] Empty, no-match, overlong-query, narrow-width, terminal-control, disposal, replacement, and shutdown paths are safe and observable where applicable.
+- [x] Existing Enter/Preview/Quote/Delete, Escape/Ctrl+C, scope switching, RPC, JSONL schema, unknown fields, command surface, and quote behavior remain compatible.
+- [x] Focused tests, package checks, boundaries, root CI-equivalent checks, and package dry run pass with evidence recorded above.

--- a/experimental/pi-recall/README.md
+++ b/experimental/pi-recall/README.md
@@ -13,6 +13,7 @@
 - Recalls saved messages across sessions using **Current cwd**, **All**, or **Current session** scope.
 - Cycles TUI scope with `Tab` and `Shift+Tab`, with the active scope and result count always visible.
 - Fuzzy-searches saved message text, role, and session name inside the active TUI scope.
+- Deletes the selected TUI result with `Ctrl+D` after confirmation, then restores the same scope and query.
 - Previews the complete saved text before use.
 - Inserts an XML-marked quote at the TUI editor cursor without submitting it automatically.
 - Stores versioned JSONL locally with cross-process locking, private permissions, and atomic replacement.
@@ -44,8 +45,9 @@ pi -e ./experimental/pi-recall
 2. Choose **Save a message** and select a text user or assistant message from the active branch.
 3. In any later session, run `/recall` and choose **Recall a saved message**.
 4. In TUI mode, type to fuzzy-search or press `Tab` / `Shift+Tab` to change scope. RPC mode asks for scope explicitly.
-5. Preview the message or choose **Quote into draft**.
-6. Add your question or instruction, then submit the draft normally.
+5. Press `Enter` to open the selected message, or press `Ctrl+D` to review and confirm its deletion directly from the TUI picker.
+6. Preview the message or choose **Quote into draft**.
+7. Add your question or instruction, then submit the draft normally.
 
 A quoted draft uses this form:
 
@@ -81,7 +83,9 @@ The TUI picker has a visible `Search:` input. It matches complete saved message 
 
 The query and selection survive scope changes and selected-message navigation during one `/recall` interaction. A new `/recall` starts with an empty query and **Current cwd**. Queries are limited to 256 UTF-16 code units; an overlong query shows an error and runs no matching. Terminal controls are replaced before matching or display, while ordinary spaces remain available for multi-token queries.
 
-RPC continues to show the complete scoped list through explicit dialogs and does not simulate a hidden fuzzy query. Message timestamps, cwd, session IDs, entry IDs, and local paths are not searchable.
+`Ctrl+D`—or the configured `app.session.delete` binding—opens a confirmation identifying the selected record and showing a bounded preview. Cancellation returns to the unchanged picker. After confirmation, Pi Recall shows non-cancellable deletion progress, applies the existing locked atomic JSONL mutation, and returns to the same scope and query with a neighboring result selected. A failure keeps the previous list visible and reports how to retry; a record concurrently removed elsewhere is reconciled as already absent. Plain `Delete` remains available for forward editing in the search input. The existing `Enter` → **Delete…** route remains available when a complete saved-text review is preferred.
+
+RPC continues to show the complete scoped list through explicit dialogs and does not simulate a hidden fuzzy query or terminal shortcut. Message timestamps, cwd, session IDs, entry IDs, and local paths are not searchable.
 
 ## 🔒 Storage, privacy, and recovery
 
@@ -117,7 +121,7 @@ Terminal controls are removed from labels, previews, metadata, and errors before
 
 ## 🚧 Experimental limitations
 
-- No tags, saved-query persistence, editing, reordering, import/export, automatic expiry, or automatic context injection.
+- No tags, saved-query persistence, message editing, reordering, batch deletion, import/export, automatic expiry, or automatic context injection.
 - No cross-session transcript browser: only previously saved records can be recalled across sessions.
 - Text only; images and tool payloads are deliberately omitted.
 - The custom TUI picker is keyboard-operated. RPC uses sequential dialogs.

--- a/experimental/pi-recall/src/menu.ts
+++ b/experimental/pi-recall/src/menu.ts
@@ -1,5 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runCustomInteraction, runMenu } from "@narumitw/pi-tui-kit";
+import { defineMenu, runCustomInteraction, runMenu, runTask } from "@narumitw/pi-tui-kit";
 import {
 	candidateIdentity,
 	filterRecallMessages,
@@ -174,25 +174,78 @@ export function createRecallMenu(
 					: { kind: "to", screen: "main" };
 			},
 			chooseSaved: async ({ ctx, state, signal }) => {
-				const result =
-					ctx.mode === "tui"
-						? await chooseSavedInTui(
-								ctx,
-								state,
-								signal,
-								ownership,
-								selectedScope,
-								pickerSelectedId,
-								pickerQuery,
-							)
-						: await chooseSavedInRpc(ctx, state, signal, selectedScope);
-				if (!result) return { kind: "stay" };
 				if (ctx.mode === "tui") {
-					selectedScope = result.scope;
-					pickerQuery = result.query ?? pickerQuery;
-					if ("selectedId" in result) pickerSelectedId = result.selectedId;
+					let availableRecords = [...state.records];
+					while (!signal.aborted && isCurrent(ownership)) {
+						const result = await chooseSavedInTui(
+							ctx,
+							{ ...state, records: availableRecords },
+							signal,
+							ownership,
+							selectedScope,
+							pickerSelectedId,
+							pickerQuery,
+						);
+						if (signal.aborted || !isCurrent(ownership)) return { kind: "close" };
+						if (!result) return { kind: "stay" };
+						selectedScope = result.scope;
+						pickerQuery = result.query ?? pickerQuery;
+						if ("selectedId" in result) pickerSelectedId = result.selectedId;
+						if (result.kind === "back") return { kind: "stay" };
+						if (result.kind === "close") return { kind: "close" };
+						if (result.kind === "delete") {
+							pickerSelectedId = result.recordId;
+							const record = availableRecords.find(({ id }) => id === result.recordId);
+							if (!record) {
+								pickerSelectedId = result.nextSelectedId;
+								continue;
+							}
+							const confirmed = await ctx.ui.confirm(
+								"Delete saved message?",
+								deleteConfirmationMessage(record),
+								{ signal },
+							);
+							if (signal.aborted || !isCurrent(ownership)) return { kind: "close" };
+							if (!confirmed) continue;
+							const deletion = await runTask(ctx, {
+								label: "Deleting saved message…",
+								signal,
+								isCurrent: () => isCurrent(ownership),
+								cancellable: false,
+								task: ({ signal: taskSignal }) => source.delete(record.id, taskSignal),
+								onError: (currentCtx, error) => {
+									safeNotify(
+										currentCtx,
+										`Couldn't delete saved message: ${safeErrorMessage(error)}. Retry or check Status.`,
+										"error",
+									);
+								},
+							});
+							if (signal.aborted || !isCurrent(ownership) || deletion.kind === "stale") {
+								return { kind: "close" };
+							}
+							if (deletion.kind === "cancelled" || deletion.kind === "error") continue;
+							availableRecords = availableRecords.filter(({ id }) => id !== record.id);
+							pickerSelectedId = result.nextSelectedId;
+							safeNotify(
+								ctx,
+								deletion.value
+									? "Deleted saved message from Pi Recall."
+									: "Saved message was already removed; refreshed Pi Recall.",
+								deletion.value ? "info" : "warning",
+							);
+							continue;
+						}
+						pickerSelectedId = result.recordId;
+						selectedRecordId = result.recordId;
+						return { kind: "to", screen: "selected" };
+					}
+					return { kind: "close" };
 				}
-				if (result.kind === "back") return { kind: "stay" };
+
+				const result = await chooseSavedInRpc(ctx, state, signal, selectedScope);
+				if (signal.aborted || !isCurrent(ownership)) return { kind: "close" };
+				if (!result || result.kind === "back") return { kind: "stay" };
 				if (result.kind === "close") return { kind: "close" };
 				selectedScope = result.scope;
 				pickerSelectedId = result.recordId;
@@ -368,6 +421,16 @@ async function chooseSavedInRpc(
 	return record
 		? { kind: "selected" as const, recordId: record.id, scope }
 		: { kind: "back", scope };
+}
+
+function deleteConfirmationMessage(record: RecallMessageRecord): string {
+	return [
+		...sourceLines(record),
+		"",
+		`Message preview: ${sanitizeTerminalText(messagePreview(record.text, 400))}`,
+		"",
+		"Delete this entire saved message? This cannot be undone from Pi Recall.",
+	].join("\n");
 }
 
 function sourceLines(record: RecallMessageRecord): string[] {

--- a/experimental/pi-recall/src/picker.ts
+++ b/experimental/pi-recall/src/picker.ts
@@ -28,6 +28,13 @@ const MAX_SEARCH_QUERY_LENGTH = 256;
 
 export type ScopedRecallPickerResult =
 	| { kind: "selected"; recordId: string; scope: RecallScope; query?: string }
+	| {
+			kind: "delete";
+			recordId: string;
+			nextSelectedId?: string;
+			scope: RecallScope;
+			query?: string;
+	  }
 	| { kind: "back"; scope: RecallScope; selectedId?: string; query?: string }
 	| { kind: "close"; scope: RecallScope; selectedId?: string; query?: string };
 
@@ -125,14 +132,7 @@ export class ScopedRecallPicker implements Component, Focusable {
 			truncateToWidth(searchLine, safeWidth, ""),
 			"",
 			...(rows.length > 0 ? rows : emptyRows),
-			truncateToWidth(
-				this.options.theme.fg(
-					"dim",
-					"Type to search · ↑↓ navigate · Enter select · Tab/Shift+Tab scope · Esc back · Ctrl+C close",
-				),
-				safeWidth,
-				"",
-			),
+			...this.footerLines(safeWidth),
 		].map((line) => truncateToWidth(line, safeWidth, ""));
 	}
 
@@ -145,6 +145,10 @@ export class ScopedRecallPicker implements Component, Focusable {
 				selectedId: this.selectedId,
 				query: this.query(),
 			});
+			return;
+		}
+		if (this.options.keybindings.matches(data, "app.session.delete")) {
+			this.requestDelete();
 			return;
 		}
 		if (matchesKey(data, Key.shift("tab"))) {
@@ -237,6 +241,35 @@ export class ScopedRecallPicker implements Component, Focusable {
 			this.selectedId = this.records[0]?.id;
 		}
 		this.scrollOffset = 0;
+	}
+
+	private requestDelete(): void {
+		if (!this.selectedId) return;
+		const selectedIndex = this.records.findIndex(({ id }) => id === this.selectedId);
+		if (selectedIndex < 0) return;
+		const nextSelectedId =
+			this.records[selectedIndex + 1]?.id ?? this.records[selectedIndex - 1]?.id;
+		this.finish({
+			kind: "delete",
+			recordId: this.selectedId,
+			...(nextSelectedId ? { nextSelectedId } : {}),
+			scope: this.scope,
+			query: this.query(),
+		});
+	}
+
+	private footerLines(width: number): string[] {
+		const deleteKey = this.options.keybindings.getKeys("app.session.delete")[0];
+		const deleteHint = deleteKey ? `${deleteKey} delete` : "";
+		const primary = [deleteHint, "Enter open", "↑↓ navigate"].filter(Boolean).join(" · ");
+		const navigation = "Tab/Shift+Tab scope · Esc back · Ctrl+C close";
+		if (width < 32) {
+			return [this.options.theme.fg("dim", primary), this.options.theme.fg("dim", navigation)];
+		}
+		return [
+			this.options.theme.fg("dim", `Type to search · ${primary}`),
+			this.options.theme.fg("dim", navigation),
+		];
 	}
 
 	private move(delta: number): void {

--- a/experimental/pi-recall/test/menu.test.ts
+++ b/experimental/pi-recall/test/menu.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { stripVTControlCharacters } from "node:util";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { Key, type KeyId, matchesKey, visibleWidth } from "@earendil-works/pi-tui";
 import { resolveMenuScreen, runMenu } from "@narumitw/pi-tui-kit";
 import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { createMockContext } from "../../../test/support.js";
@@ -69,6 +69,45 @@ function source(
 
 async function state(controller: ReturnType<typeof createRecallMenu>) {
 	return controller.getState({ signal: new AbortController().signal });
+}
+
+function recallPickerKeybindings() {
+	return {
+		matches(data: string, binding: string) {
+			const keys: Record<string, KeyId> = {
+				"app.session.delete": Key.ctrl("d"),
+				"tui.select.up": Key.up,
+				"tui.select.down": Key.down,
+				"tui.select.pageUp": Key.pageUp,
+				"tui.select.pageDown": Key.pageDown,
+				"tui.select.confirm": Key.enter,
+				"tui.select.cancel": Key.escape,
+			};
+			const expected = keys[binding];
+			return (
+				(expected !== undefined && matchesKey(data, expected)) ||
+				(binding === "tui.select.cancel" && matchesKey(data, Key.ctrl("c")))
+			);
+		},
+		getKeys(binding: string) {
+			return binding === "app.session.delete" ? ["ctrl+d"] : [];
+		},
+	};
+}
+
+async function waitForOpenCount(
+	tui: ReturnType<typeof createTuiHarness>,
+	count: number,
+	running: Promise<unknown> | unknown,
+) {
+	for (let turn = 0; tui.openCount < count && turn < 100; turn += 1) {
+		const settled = await Promise.race([
+			Promise.resolve(running).then(() => true),
+			new Promise<false>((resolve) => setImmediate(() => resolve(false))),
+		]);
+		if (settled) break;
+	}
+	assert.equal(tui.openCount, count);
 }
 
 test("main menu keeps five primary rows and save choice marks duplicate source unavailable", async () => {
@@ -216,6 +255,217 @@ test("TUI query survives picker re-entry in one Recall flow and resets in a fres
 	assert.doesNotMatch(freshSearch ?? "", /saved-a/);
 	freshTui.press("tui.select.cancel");
 	assert.deepEqual(await freshChoosing, { kind: "stay" });
+});
+
+test("TUI direct delete confirms the selected message, shows progress, and restores picker context", async () => {
+	const current = record("saved-current");
+	const other = record("saved-other", "other-entry");
+	other.source = { ...other.source, sessionId: "other-session", cwd: "/other" };
+	const data = source([current, other]);
+	const originalDelete = data.delete.bind(data);
+	let deleteStarted!: () => void;
+	let releaseDelete!: () => void;
+	const started = new Promise<void>((resolve) => {
+		deleteStarted = resolve;
+	});
+	const release = new Promise<void>((resolve) => {
+		releaseDelete = resolve;
+	});
+	data.delete = async (id) => {
+		deleteStarted();
+		await release;
+		return originalDelete(id);
+	};
+	let confirmation: { title: string; message: string } | undefined;
+	const tui = createTuiHarness({
+		width: 72,
+		rows: 18,
+		keybindings: recallPickerKeybindings() as never,
+	});
+	const base = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		confirm: async (title: string, message: string) => {
+			confirmation = { title, message };
+			return true;
+		},
+	}).ctx as unknown as { ui: Record<string, unknown>; [key: string]: unknown };
+	const controller = createRecallMenu(data);
+	const choosing = controller.menu.actions.chooseSaved({
+		ctx: { ...base, ui: { ...base.ui, custom: tui.custom } } as never,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "recall",
+	});
+	await tui.waitForOpen();
+	tui.send("\t");
+	tui.press("tui.select.up");
+	tui.type("saved");
+	tui.send("\u0004");
+	await waitForOpenCount(tui, 2, choosing);
+	await started;
+	try {
+		assert.match(confirmation?.title ?? "", /Delete saved message/);
+		assert.match(confirmation?.message ?? "", /saved text saved-other/);
+		assert.match(tui.render().join("\n"), /Deleting saved message/);
+	} finally {
+		releaseDelete();
+	}
+	await waitForOpenCount(tui, 3, choosing);
+	const restored = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(restored, /Scope: All \(1\).*1 match/);
+	assert.match(restored, /Search: .*saved/);
+	assert.match(restored, /saved text saved-cur…/);
+	assert.equal(
+		data.records.some(({ id }) => id === "saved-other"),
+		false,
+	);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await choosing, { kind: "stay" });
+});
+
+test("cancelling direct delete is side-effect free and restores query and selection", async () => {
+	const data = source();
+	let deleteCalls = 0;
+	data.delete = async () => {
+		deleteCalls += 1;
+		return true;
+	};
+	const tui = createTuiHarness({
+		width: 72,
+		rows: 18,
+		keybindings: recallPickerKeybindings() as never,
+	});
+	const base = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		confirm: async () => false,
+	}).ctx as unknown as { ui: Record<string, unknown>; [key: string]: unknown };
+	const controller = createRecallMenu(data);
+	const choosing = controller.menu.actions.chooseSaved({
+		ctx: { ...base, ui: { ...base.ui, custom: tui.custom } } as never,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "recall",
+	});
+	await tui.waitForOpen();
+	tui.type("saved-a");
+	tui.send("\u0004");
+	await waitForOpenCount(tui, 2, choosing);
+	const restored = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(restored, /Search: .*saved-a/);
+	assert.match(restored, /> assistant .*saved text saved-a/);
+	assert.equal(deleteCalls, 0);
+	assert.equal(data.records.length, 1);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await choosing, { kind: "stay" });
+});
+
+test("direct delete failure preserves the record and reports an actionable error", async () => {
+	const data = source();
+	let releaseDelete!: () => void;
+	const release = new Promise<void>((resolve) => {
+		releaseDelete = resolve;
+	});
+	data.delete = async () => {
+		await release;
+		throw new Error("lock unavailable");
+	};
+	const tui = createTuiHarness({
+		width: 72,
+		rows: 18,
+		keybindings: recallPickerKeybindings() as never,
+	});
+	const mock = createMockContext({ hasUI: true, mode: "tui", confirm: async () => true });
+	const base = mock.ctx as unknown as { ui: Record<string, unknown>; [key: string]: unknown };
+	const controller = createRecallMenu(data);
+	const choosing = controller.menu.actions.chooseSaved({
+		ctx: { ...base, ui: { ...base.ui, custom: tui.custom } } as never,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "recall",
+	});
+	await tui.waitForOpen();
+	tui.send("\u0004");
+	await waitForOpenCount(tui, 2, choosing);
+	releaseDelete();
+	await waitForOpenCount(tui, 3, choosing);
+	assert.equal(data.records.length, 1);
+	assert.match(tui.render().join("\n"), /saved text saved-a/);
+	assert.match(mock.notifications.at(-1)?.message ?? "", /Couldn.t delete.*lock unavailable/i);
+	tui.press("tui.select.cancel");
+	await choosing;
+});
+
+test("session cancellation aborts in-flight direct delete without stale success UI", async () => {
+	const data = source();
+	let deleteStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		deleteStarted = resolve;
+	});
+	data.delete = async (_id, signal) => {
+		deleteStarted();
+		await new Promise<void>((_resolve, reject) => {
+			if (signal?.aborted) return reject(signal.reason);
+			signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+		});
+		return true;
+	};
+	const owner = new AbortController();
+	const tui = createTuiHarness({
+		width: 72,
+		rows: 18,
+		keybindings: recallPickerKeybindings() as never,
+	});
+	const mock = createMockContext({ hasUI: true, mode: "tui", confirm: async () => true });
+	const base = mock.ctx as unknown as { ui: Record<string, unknown>; [key: string]: unknown };
+	const controller = createRecallMenu(data, { isCurrent: () => !owner.signal.aborted });
+	const choosing = controller.menu.actions.chooseSaved({
+		ctx: { ...base, ui: { ...base.ui, custom: tui.custom } } as never,
+		state: await state(controller),
+		signal: owner.signal,
+		itemId: "recall",
+	});
+	await tui.waitForOpen();
+	tui.send("\u0004");
+	await waitForOpenCount(tui, 2, choosing);
+	await started;
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await choosing, { kind: "close" });
+	assert.equal(data.records.length, 1);
+	assert.equal(
+		mock.notifications.some(({ message }) => /Deleted saved message/.test(message)),
+		false,
+	);
+});
+
+test("direct delete reconciles a record already removed by another process", async () => {
+	const data = source();
+	data.delete = async () => {
+		data.records = [];
+		return false;
+	};
+	const tui = createTuiHarness({
+		width: 72,
+		rows: 18,
+		keybindings: recallPickerKeybindings() as never,
+	});
+	const mock = createMockContext({ hasUI: true, mode: "tui", confirm: async () => true });
+	const base = mock.ctx as unknown as { ui: Record<string, unknown>; [key: string]: unknown };
+	const controller = createRecallMenu(data);
+	const choosing = controller.menu.actions.chooseSaved({
+		ctx: { ...base, ui: { ...base.ui, custom: tui.custom } } as never,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "recall",
+	});
+	await tui.waitForOpen();
+	tui.send("\u0004");
+	await waitForOpenCount(tui, 3, choosing);
+	assert.match(tui.render().join("\n"), /No saved messages in this scope/);
+	assert.match(mock.notifications.at(-1)?.message ?? "", /already removed/i);
+	tui.press("tui.select.cancel");
+	await choosing;
 });
 
 test("preview is exact, quote appends to the draft without sending, and delete requires review action", async () => {

--- a/experimental/pi-recall/test/picker.test.ts
+++ b/experimental/pi-recall/test/picker.test.ts
@@ -46,10 +46,11 @@ function createPicker(
 					(data === "up" && key === "tui.select.up") ||
 					(data === "down" && key === "tui.select.down") ||
 					(data === "enter" && key === "tui.select.confirm") ||
-					(data === "escape" && key === "tui.select.cancel")
+					(data === "escape" && key === "tui.select.cancel") ||
+					(data === "\u0004" && key === "app.session.delete")
 				);
 			},
-			getKeys: () => [],
+			getKeys: (key: string) => (key === "app.session.delete" ? ["ctrl+d"] : []),
 		} as never,
 		records,
 		current: { sessionId: "current", cwd: "/work/project" },
@@ -223,6 +224,35 @@ test("preserves query spaces, removes pasted controls, bounds queries, and forwa
 	assert.equal(picker.render(80).join("\n").includes(CURSOR_MARKER), false);
 	picker.handleInput("ignored");
 	assert.deepEqual(picker.render(80), beforeDispose);
+});
+
+test("requests direct deletion with the selected record and nearest surviving result", () => {
+	const content = createPicker([
+		saved("one", "current", "/work/project", "first saved message"),
+		saved("two", "current", "/work/project", "second saved message"),
+	]);
+	content.picker.handleInput("down");
+	assert.match(content.picker.render(20).join("\n"), /ctrl\+d delete/i);
+	content.picker.handleInput("\u0004");
+	assert.deepEqual(content.result(), {
+		kind: "delete",
+		recordId: "one",
+		nextSelectedId: "two",
+		scope: "cwd",
+		query: "",
+	});
+});
+
+test("does not request deletion without a match and leaves plain Delete to search input", () => {
+	const noMatch = createPicker([saved("one", "current", "/work/project", "alpha")], {
+		initialQuery: "zulu",
+	});
+	noMatch.picker.handleInput("\u0004");
+	assert.equal(noMatch.result(), undefined);
+
+	const editing = createPicker([saved("one", "current", "/work/project", "alpha")]);
+	editing.picker.handleInput("\u001b[3~");
+	assert.equal(editing.result(), undefined);
 });
 
 test("restores selection after broadening and carries query through scope and completion", () => {


### PR DESCRIPTION
## Summary

- add a configurable Ctrl+D delete action to the Pi Recall fuzzy picker
- confirm the selected message with a bounded preview before applying the atomic deletion
- restore scope, query, and neighboring selection after deletion while preserving existing RPC and detail-screen flows
- document the workflow and cover success, cancellation, failure, concurrency, lifecycle, focus, and responsive states

## Verification

- `npm run check --workspace @narumitw/pi-recall`
- Pi Recall focused tests: 42/42 passed
- `npm run check:boundaries`
- `npm run check` in a normal verification clone: 2,385/2,385 tests passed
- `just pack recall` (9 expected files)
