### PR TITLE
feat(pi-goal): restore automatic work safety limit

### DIFF
--- a/docs/plans/2026-08-04_pi-goal-automatic-work-limit-ux-plan.md
+++ b/docs/plans/2026-08-04_pi-goal-automatic-work-limit-ux-plan.md
@@ -1,0 +1,129 @@
+# pi-goal automatic-work limit UX plan
+
+## Goal
+
+Restore `pi-goal`'s default `automaticTurns` limit to 25 and make that safety boundary visible
+before, during, and after automatic work. When the limit pauses a goal, explain why, preserve all
+work, and give users an explicit, cancellable path to review and continue.
+
+## Context
+
+The prior built-in default was `automaticTurns: null` (`Unlimited`), and the manager/status line did
+not consistently expose why a goal paused. Interactive TUI users need a safe default and clear
+recovery; long-running and expert users still need custom or Unlimited operation; CLI/RPC and
+existing configuration users need stable commands, schemas, and stored values.
+
+Feature priority for this change:
+
+- **Primary:** start, monitor automatic-work progress, understand a safety pause, and continue.
+- **Secondary:** inspect details and change the automatic-work limit.
+- **Advanced:** custom limits and explicit Unlimited operation.
+- **Destructive:** existing replace, clear, skip, and drop actions; behavior is unchanged.
+- **Compatibility-only:** direct command aliases, RPC transitions, persisted schema, and managed-run
+  status enums; behavior and wire shapes remain compatible.
+
+## Architecture
+
+- `settings.ts` owns the built-in default and strict normalization. Omitted `automaticTurns` uses 25;
+  explicit finite values and `null` remain authoritative; malformed values keep the file invalid.
+- `runtime.ts` and existing accounting/safety state remain the source of truth for response count and
+  pause cause. Enforcement occurs before another normal response can start.
+- `menu.ts` presents count/limit and a safety-recovery screen. Back is side-effect free; Continue
+  uses the existing generation-guarded resume/reset protocol.
+- `settings-ui.ts` keeps all five settings in one flat group. It offers default 25, a custom finite
+  limit, and explicitly confirmed Unlimited operation.
+- Direct `/goal resume`, queue, token-budget, and RPC workflows retain their existing contracts while
+  notifications, summaries, and status text expose the automatic-work state.
+
+## Non-Goals
+
+- Add a dollar-cost cap or claim that 25 responses corresponds to a fixed provider charge.
+- Change token-budget accounting, no-progress policy, queue semantics, tool policy, or managed-RPC
+  status values.
+- Add basic/advanced navigation or migrate an explicitly stored `null` to 25.
+- Publish, change npm visibility, tag a release, or dispatch a release workflow.
+
+## Assumptions and accepted clarifications
+
+- Explicit persisted `null` remains Unlimited because historical generated and intentional values
+  cannot be distinguished safely.
+- Malformed explicit limits remain invalid instead of silently normalizing to 25, preserving the
+  repository's invalid-file protection.
+- The TUI renders from a synchronized runtime snapshot, so there is no separate asynchronous loading
+  screen. Loading-state acceptance is satisfied by immediate snapshot rendering and stale/disposed
+  continuation guards.
+- Continue is the applying action after a concrete recovery preview and does not add a redundant
+  generic yes/no prompt.
+
+## Rollback / Recovery
+
+The persisted schema remains `number | null`; rollback requires no data conversion. Save or runtime
+apply failure retains the previous valid file and in-memory settings, keeps the goal recoverable, and
+reports an actionable error.
+
+## Plan
+
+- [x] Add red tests for the omitted default and explicit finite/`null` compatibility, then update
+  `extensions/pi-goal/src/settings.ts` to restore 25. Evidence: focused tests initially failed with
+  `null !== 25` and now pass 5/5; malformed values remain invalid and unknown-field save coverage
+  passes.
+- [x] Add interaction tests and update `extensions/pi-goal/src/settings-ui.ts` for the flat
+  **Automatic-work limit** control, default/custom/Unlimited choices, explicit Unlimited warning,
+  lower-live-limit preview, atomic rollback, direct recovery entry, cancellation, goal replacement,
+  and menu disposal. Evidence: settings UI tests pass 30/30.
+- [x] Add manager tests and update `extensions/pi-goal/src/menu.ts` for empty, active, Unlimited,
+  hard-cap-paused, queue/partial, budget, and ordinary stopped states. Evidence: hard-cap recovery
+  previews preserved objective/usage/time/queue, Back has no side effects, Continue is bound to the
+  previewed goal, and Change limit returns to the still-paused recovery state; menu tests pass 20/20.
+- [x] Update `extensions/pi-goal/src/commands.ts`, `goal.ts`, and `runtime.ts` so start, resume,
+  restored-session, summary, pause notification, and statusline surfaces use consistent automatic
+  work terminology and finite/Unlimited state. Evidence: direct resume reports the pending reset to
+  0/25 and preserved usage; default and Unlimited starts are covered; restored 25/25 work pauses
+  before provider delivery.
+- [x] Preserve enforcement across tool loops, retry boundaries, compaction, aborted turns, and
+  session restoration. Evidence: the existing lifecycle matrix plus updated hard-cap tests and
+  `goal-runtime-smoke.mjs` pass; all 286 pi-goal tests pass.
+- [x] Verify responsive and accessibility behavior at 40, 80, and 120 columns. Evidence: public TUI
+  harness tests prove every rendered line stays within width, critical cause/effect/action text stays
+  visible, keyboard Enter/Escape navigation returns focus to the prior route, and states/actions are
+  text-labeled rather than color-only.
+- [x] Update `extensions/pi-goal/README.md` with default 25, explicit-null compatibility, manager and
+  recovery behavior, statusline examples, restoration behavior, and the distinction between a
+  response cap, token budget, estimated Pi cost, and a provider billing cap.
+- [x] Audit the diff against `docs/extension-conventions.md` and `docs/extension-settings.md` for
+  command/menu/status/settings/lifecycle rules, unknown-field preservation, atomic publication,
+  stale-session guards, cancellation, disposal, session replacement, and shutdown. Evidence: scoped
+  tests cover rollback and stale/disposed continuations; no convention deviation remains.
+- [x] Run package verification. Evidence: `npm run check --workspace @narumitw/pi-goal`,
+  `npm run test:runtime --workspace @narumitw/pi-goal`, and `just pack goal` pass; the dry-run tarball
+  contains README, LICENSE, package manifest, all `src` files, and `src/index.ts`, with no test or
+  temporary files.
+- [x] Run repository verification. Evidence: all 286 pi-goal tests pass in the active worktree; full
+  `npm run check` passes in `/tmp/pi-goal-automatic-work-limit-check`, a normal local clone with the
+  exact extension patch. The linked worktree itself exposes Git's internal `GIT_DIR` to one unrelated
+  pi-sync alias test, so the normal-clone run provides the CI-equivalent repository evidence.
+- [ ] Commit the bounded change, push `feat/pi-goal-automatic-work-limit-ux`, open a GitHub pull
+  request, verify its head/base/state, then record the PR URL and archive this completed plan.
+
+## Completion Checklist
+
+- [x] Fresh and omitted configuration uses 25; explicit numbers and `null` retain meaning; unknown
+  configuration fields survive writes; malformed files remain protected and read-only.
+- [x] Empty, active, stopped, and detailed status surfaces expose the finite boundary/progress or
+  explicit Unlimited state wherever it affects a decision.
+- [x] At 25/25 no further normal model response starts, including after tools, retry/compaction
+  recovery, and restoration.
+- [x] A hard-cap pause names the cause, confirms progress/usage/time/queue preservation, and previews
+  that Continue grants one more configured epoch.
+- [x] Back/Escape, cancelled confirmations, failed saves, replaced goals, and disposed sessions have
+  no unintended settings or goal mutations.
+- [x] Guided Continue and direct `/goal resume` preserve compatibility, reset only the safety epoch
+  at prompt start, and provide concrete feedback.
+- [x] Custom finite and confirmed Unlimited choices remain in one flat five-control settings group;
+  lowering a reached active limit previews and, only after confirmation, applies the immediate pause.
+- [x] Primary flows are keyboard-operable and readable at 40, 80, and 120 columns without hidden
+  critical text, ambiguous truncation, color-only meaning, or overflow.
+- [x] README behavior and cost terminology match the implementation.
+- [x] Focused/package/runtime/pack checks and the normal-clone full repository gate pass.
+- [ ] The pull request is open, points from `feat/pi-goal-automatic-work-limit-ux` to the repository's
+  default branch, includes verification evidence, and contains the archived completed plan.

--- a/docs/plans/archived/2026-08-04_pi-goal-automatic-work-limit-ux-plan.md
+++ b/docs/plans/archived/2026-08-04_pi-goal-automatic-work-limit-ux-plan.md
@@ -102,8 +102,9 @@ reports an actionable error.
   `npm run check` passes in `/tmp/pi-goal-automatic-work-limit-check`, a normal local clone with the
   exact extension patch. The linked worktree itself exposes Git's internal `GIT_DIR` to one unrelated
   pi-sync alias test, so the normal-clone run provides the CI-equivalent repository evidence.
-- [ ] Commit the bounded change, push `feat/pi-goal-automatic-work-limit-ux`, open a GitHub pull
-  request, verify its head/base/state, then record the PR URL and archive this completed plan.
+- [x] Commit the bounded change, push `feat/pi-goal-automatic-work-limit-ux`, and open GitHub pull
+  request [#552](https://github.com/narumiruna/pi-extensions/pull/552). Evidence: PR is OPEN,
+  non-draft, MERGEABLE, and targets `main` from the requested branch; CI is queued.
 
 ## Completion Checklist
 
@@ -125,5 +126,5 @@ reports an actionable error.
   critical text, ambiguous truncation, color-only meaning, or overflow.
 - [x] README behavior and cost terminology match the implementation.
 - [x] Focused/package/runtime/pack checks and the normal-clone full repository gate pass.
-- [ ] The pull request is open, points from `feat/pi-goal-automatic-work-limit-ux` to the repository's
-  default branch, includes verification evidence, and contains the archived completed plan.
+- [x] Pull request #552 is open from `feat/pi-goal-automatic-work-limit-ux` to `main`, includes the
+  verification evidence, and will contain this archived completed plan after the final push.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -15,7 +15,7 @@ Goal mode uses Codex-like persistence instructions and sends guarded continuatio
 - Keeps direct goal management available through `/goal` subcommands: `status`, `pause`, `resume`, `clear`, and `edit`.
 - Exposes only one top-level command: `/goal`, including when ordered goals are enabled.
 - Optionally adds ordered-goal operations through `/goal add`, `prioritize`, `drop-last`, and `skip`, while accepting `push`, `unshift`, `pop`, and `shift` as hidden compatibility aliases.
-- Leaves automatic response count unlimited by default; set `continuationLimits.automaticTurns` to a positive whole number when an authoritative response cap is wanted.
+- Pauses automatic work after 25 Goal-owned model responses by default, preserves progress, and provides a guided review-and-continue flow; custom finite limits and confirmed Unlimited mode remain available.
 - Pauses after three consecutive empty or normalized-identical tool-free automatic runs, while distinct short output and tool activity reset the repeat detector.
 - Supports optional token budgets such as `/goal --tokens 100k <goal>`, using provider-reported total-token accounting with a cache-inclusive compatibility fallback.
 - Tracks distinct `active`, `paused`, `blocked`, `usage_limited`, `budget_limited`, and `complete` states.
@@ -70,7 +70,7 @@ built-in defaults without creating the file:
     "enabled": false
   },
   "continuationLimits": {
-    "automaticTurns": null,
+    "automaticTurns": 25,
     "noProgressTurns": 3
   }
 }
@@ -80,7 +80,7 @@ Use `/goal` → **Settings…** in the TUI to create or update the file interact
 and edit it directly. The standard Settings screen keeps all five controls on one level in task
 order; the two safety limits open standard choice screens:
 
-- **Automatic work** shows **Unlimited** or an exact **≤_N_** response cap. Choose **Unlimited** directly, or choose **Set a maximum…** and enter a safe whole number greater than zero.
+- **Automatic-work limit** shows the exact response limit or **Unlimited**. Choose **25 responses (default)**, **Set a custom limit…**, or **Unlimited…**. Unlimited requires confirmation that tool loops may continue consuming tokens and provider cost without a response-count cap.
 - **No-progress guard** shows **_N_ runs** or **Off**. Choose the default threshold, **Off**, or **Set threshold…** and enter a safe whole number greater than zero.
 - **Goal tools** controls whether terminal Goal tools are always visible or appear after the first goal.
 - **Ordered goal queue** controls the experimental ordered-goal workflows.
@@ -99,7 +99,7 @@ Custom number inputs reject zero, negative numbers, decimals, text, and unsafe i
 
 `continuationLimits` controls the runaway guards:
 
-- `automaticTurns` accepts a positive safe integer or `null` and defaults to `null` (unlimited). When configured, it counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries. The user-triggered kickoff, resume, edit, and ordinary user runs are not charged. At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted. Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work. Set this field to `null` to remove the authoritative hard bound.
+- `automaticTurns` accepts a positive safe integer or `null` and defaults to `25`. It counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries. The user-triggered kickoff, resume, edit, and ordinary user runs are not charged. At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted before a 26th normal response starts. Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work. Set this field explicitly to `null` to opt into Unlimited mode; existing explicit `null` values remain compatible.
 - `noProgressTurns` is a positive safe integer and defaults to `3`. At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercasing, control-character removal, and whitespace collapse. Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent. Consecutive empty or identical tool-free outputs increment the repeat count. Different non-empty output starts a new run at one, and any attempted tool call resets it. Set this field to `null` to disable only this heuristic.
 
 Settings are reread at Pi startup, session replacement, and `/reload`; direct external file edits are not watched live, while changes made through the Goal menu apply immediately. A missing file remains absent and uses the built-in defaults. The first successful settings change creates the file atomically; later saves preserve unknown fields.
@@ -130,9 +130,13 @@ Tool visibility is a baseline, not ownership of Pi's global active-tool list. Pl
 ```
 
 - In the TUI, `/goal` opens a standard state-aware manager. Its first action follows the current
-  state: start when empty, pause when active, resume when stopped, or increase the budget when
-  exhausted. An active goal shows automatic-response state as **_used_ automatic responses ·
-  Unlimited** or **_used_/_limit_ automatic responses**. Status, Settings, Help, queue management,
+  state: start when empty, pause when active, review a reached automatic-work limit, resume for other
+  stopped states, or increase an exhausted token budget. Active and paused views show **Automatic
+  work: _used_ of _limit_ responses** with the remaining count, or explicitly show **Unlimited**.
+  A hard-cap pause opens **Review and continue…**, which states that objective, cumulative usage,
+  active time, and queue are preserved and previews that Continue resets the counter to zero and
+  allows up to one more configured epoch. **Change automatic-work limit…** opens that setting while
+  leaving the goal paused; Back and Escape make no change. Status, Settings, Help, queue management,
   invalid-settings guidance, Clear, and Close remain shallow, labeled routes. Arrow keys navigate,
   Enter selects, Escape goes Back, and Ctrl+C closes the full flow.
 - In RPC mode, bare `/goal` and `/goal status` report the current summary through an observable notification without opening terminal UI. Pi exposes no extension-command output channel in print or JSON mode, so those routes reject with an explicit unsupported-mode error instead of misreporting stderr as status output.
@@ -141,7 +145,7 @@ Tool visibility is a baseline, not ownership of Pi's global active-tool list. Pl
 - `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget. `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
 - `/goal edit <goal_to_complete>` updates the existing goal objective without resetting usage counters. A successful active edit rotates the stale-turn guard and starts a fresh safety epoch. Paused, blocked, and usage-limited goals stay stopped and retain their safety state until resume. A budget-limited goal reactivates only when `edit --tokens` raises its budget above current usage. Failed prompt delivery restores the exact previous safety counters/cause; it restores a budget-limited goal or restores and pauses a previously active goal.
 - `/goal pause` stops prompt injection and auto-continuation, aborts the current turn, and keeps the goal for later resume. Only active goals can be paused.
-- `/goal resume` resumes a paused, blocked, usage-limited, or budget-limited goal when its token budget allows it, rotates the stale-turn guard id, resets the automatic-response/repeat safety epoch, clears a safety-pause cause, and queues a resume prompt so work continues. If prompt delivery fails, the original stopped state, guard id, counters, fingerprint, and cause are restored.
+- `/goal resume` resumes a paused, blocked, usage-limited, or budget-limited goal when its token budget allows it, rotates the stale-turn guard id, resets the automatic-response/repeat safety epoch when the queued resume prompt starts, clears a safety-pause cause, and reports the new finite epoch or explicit Unlimited state. Objective, cumulative usage, elapsed time, and queue are preserved. If prompt delivery fails, the original stopped state, guard id, counters, fingerprint, and cause are restored.
 - `/goal clear` clears the current goal or the entire ordered queue, status, pending continuation/transition, and legacy persisted state for the current working directory without aborting unrelated in-flight work.
 
 With `experimental.goals: true`:
@@ -159,7 +163,7 @@ Goal objectives are limited to 4,000 characters. Put longer instructions in a fi
 
 ## 🔁 Session and reload behavior
 
-Goal state is stored as Pi session state, similar to Codex's thread-owned goals. `/reload` and reopening the same Pi session can restore that session's unfinished goal. With `"after-first-goal"`, that unfinished restore marks the tools unlocked in the new extension runtime, but it does not widen an active-tool set already restricted by an earlier lifecycle handler; an active goal instead restores as paused when either terminal tool is missing. If no unfinished goal remains, a fresh runtime starts locked again. Active elapsed time is checkpointed before shutdown and restarted after reload, so offline and stopped wall-clock time is excluded. Automatic-response counts, repeat fingerprints, and safety-pause causes persist across reload and compaction. A direct non-`/goal` user/RPC input resets the safety epoch only while the goal is active and reclassifies the in-flight run as manual; extension input and messages sent while stopped do not reset it. Starting a new Pi session in the same working directory does not inherit the old goal.
+Goal state is stored as Pi session state, similar to Codex's thread-owned goals. `/reload` and reopening the same Pi session can restore that session's unfinished goal. An active restored goal already at or above its finite automatic-work limit pauses before another provider request and reports that progress is saved; use `/goal` to review and continue. With `"after-first-goal"`, an unfinished restore marks the tools unlocked in the new extension runtime, but it does not widen an active-tool set already restricted by an earlier lifecycle handler; an active goal instead restores as paused when either terminal tool is missing. If no unfinished goal remains, a fresh runtime starts locked again. Active elapsed time is checkpointed before shutdown and restarted after reload, so offline and stopped wall-clock time is excluded. Automatic-response counts, repeat fingerprints, and safety-pause causes persist across reload and compaction. A direct non-`/goal` user/RPC input resets the safety epoch only while the goal is active and reclassifies the in-flight run as manual; extension input and messages sent while stopped do not reset it. Starting a new Pi session in the same working directory does not inherit the old goal.
 
 Ordered queues use the same canonical `goal-state` session entry as single goals. Every item owns independent usage and safety state. Shelving, priority displacement, automatic advancement, and later reactivation preserve that item's epoch rather than granting more automatic work. The legacy `{ goal }` shape remains valid, and missing safety fields normalize to zero/defaults. Queue fields are written only when needed. Sessions created by the former standalone `pi-goals` experiment can migrate their last `goals-state` array and pending `unshift` intent when the branch has never written a canonical `goal-state`; any canonical entry, including an explicit clear, takes precedence so old plural state cannot be resurrected.
 
@@ -171,12 +175,14 @@ Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed 
 
 `pi-goal` writes compact plain status strings for statusline extensions. `@narumitw/pi-statusline` adds the default `🎯` icon unless configured otherwise:
 
-- `active 3m` — an active goal without a token budget; elapsed time counts only periods when its status is active.
-- `active 18k/100k` — an active goal with token usage and budget.
-- `paused` — the user paused/interrupted the goal, terminal tools disappeared, or a `continuation_limit`/`no_progress` safety breaker stopped automatic work. Bare `/goal` shows the fixed safety reason and counters.
-- `blocked` — progress requires user or external action, or a terminal non-usage error stopped work.
-- `usage` — the provider or account usage limit stopped work.
-- `budget 100k/100k` — the user-configured token budget was reached; auto-continuation stops.
+- `active 3m · automatic 12/25` — an active goal without a token budget; elapsed time counts only periods when its status is active.
+- `active 18k/100k · automatic 12/25` — an active goal with token usage and budget.
+- `active 3m · automatic Unlimited` — explicit Unlimited automatic work.
+- `paused · automatic limit 25/25` — the automatic-work limit paused the goal; `/goal` opens the recovery preview.
+- `paused · automatic 12/25` — another pause reason stopped work while preserving the finite epoch.
+- `blocked · automatic 12/25` — progress requires user or external action, or a terminal non-usage error stopped work.
+- `usage · automatic 12/25` — the provider or account usage limit stopped work.
+- `budget 100k/100k · automatic 12/25` — the user-configured token budget was reached; auto-continuation stops.
 - `complete` — shown briefly after `goal_complete` succeeds.
 - `queue off` — retained ordered goals are frozen because `experimental.goals` is disabled.
 
@@ -186,7 +192,7 @@ For each persisted assistant message, `pi-goal` uses finite, non-negative `usage
 
 Provider usage becomes authoritative only when an assistant message finishes, so a budget can overshoot by one model call. When completed tool activity first exposes exhaustion, the goal transitions once to `budget_limited`, cancels continuation, and queues one bounded custom wrap-up instruction before the next model call. The instruction permits only a concise progress/results/blockers summary; a substantive tool attempt is blocked and aborts the remaining wrap-up. A rejected `goal_complete` also terminates the wrap-up, while accepted completion still requires existing evidence that proves every requirement—budget exhaustion itself never means completion. If exhaustion is first visible at `agent_end` and no turn remains, the extension stops without creating another model turn.
 
-When configured, the automatic-response cap is a call-count boundary, not a fixed cost ceiling: context size, cache pricing, output length, and provider rates vary, and the final capped response is still retained. No default automatic-response cap or token budget is imposed. For stricter spend control, configure `automaticTurns` and/or use `/goal --tokens`.
+The default 25-response automatic-work limit is a response-count boundary, not a fixed cost ceiling: context size, cache pricing, output length, and provider rates vary, and the final capped response is still retained. Pi derives displayed cost estimates from provider-reported token usage and local model pricing; pi-goal does not query a billing balance or enforce a dollar cap. For tighter token control, choose a smaller `automaticTurns` value and/or use `/goal --tokens`; choosing Unlimited removes only the response-count boundary.
 
 Elapsed time is accumulated only while status is `active`. Pause, blocked, usage-limited, budget-limited, shutdown, and offline periods do not increase it. Legacy session entries are migrated by preserving their accumulated seconds and starting a fresh active clock when loaded.
 

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -80,7 +80,7 @@ Use `/goal` → **Settings…** in the TUI to create or update the file interact
 and edit it directly. The standard Settings screen keeps all five controls on one level in task
 order; the two safety limits open standard choice screens:
 
-- **Automatic-work limit** shows the exact response limit or **Unlimited**. Choose **25 responses (default)**, **Set a custom limit…**, or **Unlimited…**. Unlimited requires confirmation that tool loops may continue consuming tokens and provider cost without a response-count cap.
+- **Automatic-work limit** shows the exact response limit or **Unlimited**. Choose **Set response limit…** to edit the current finite value (or the built-in default of 25 when switching from Unlimited), or choose **Unlimited…**. Unlimited requires confirmation that tool loops may continue consuming tokens and provider cost without a response-count cap.
 - **No-progress guard** shows **_N_ runs** or **Off**. Choose the default threshold, **Off**, or **Set threshold…** and enter a safe whole number greater than zero.
 - **Goal tools** controls whether terminal Goal tools are always visible or appear after the first goal.
 - **Ordered goal queue** controls the experimental ordered-goal workflows.

--- a/extensions/pi-goal/src/commands.ts
+++ b/extensions/pi-goal/src/commands.ts
@@ -160,9 +160,14 @@ export class GoalCommandController {
 		) {
 			return;
 		}
+		const automaticLimit = this.runtime.settings.continuationLimits.automaticTurns;
 		ctx.ui.notify(
-			existingGoal ? `Goal replaced: ${objective}` : `Goal started: ${objective}`,
-			"info",
+			`${existingGoal ? "Goal replaced" : "Goal started"}: ${objective}. ${
+				automaticLimit === null
+					? "Automatic work is Unlimited; tool loops may consume substantial tokens and provider cost. Open /goal to monitor."
+					: `Automatic work pauses after ${automaticLimit} responses; open /goal to monitor progress.`
+			}`,
+			automaticLimit === null ? "warning" : "info",
 		);
 	}
 
@@ -474,9 +479,14 @@ export class GoalCommandController {
 			}
 			return;
 		}
+		const automaticLimit = this.runtime.settings.continuationLimits.automaticTurns;
 		ctx.ui.notify(
-			`Goal resumed from ${stoppedStatusLabel(stoppedStatus)}: ${resumedGoal.text}`,
-			"info",
+			`Goal resumed from ${stoppedStatusLabel(stoppedStatus)}: ${resumedGoal.text}. ${
+				automaticLimit === null
+					? "Automatic work remains Unlimited; goal progress and cumulative usage are preserved."
+					: `The automatic-work counter will reset to 0 of ${automaticLimit} when the resumed prompt starts; goal progress and cumulative usage are preserved.`
+			}`,
+			automaticLimit === null ? "warning" : "info",
 		);
 	}
 
@@ -602,6 +612,7 @@ export class GoalCommandController {
 				this.runtime.settings.experimental.goals,
 				this.runtime.queueFrozen,
 				this.runtime.pendingQueueAction,
+				this.runtime.settings.continuationLimits.automaticTurns,
 			),
 		);
 	}

--- a/extensions/pi-goal/src/goal.ts
+++ b/extensions/pi-goal/src/goal.ts
@@ -413,9 +413,10 @@ function registerGoalRuntime(pi: ExtensionAPI, options: GoalOptions = {}) {
 				return;
 			}
 			if (result.kind === "show" && args.trim() === "") {
-				await showGoalManager(runtime, commands, ctx, (menuCtx) =>
+				await showGoalManager(runtime, commands, ctx, (menuCtx, target) =>
 					showGoalSettings(runtime, menuCtx, {
 						settingsPath: options.settingsPath,
+						initialScreen: target,
 						onQueueUnfrozen: async (settingsCtx) => {
 							await commands.resumeQueueAfterUnfreeze(settingsCtx);
 						},

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -108,7 +108,7 @@ export function buildGoalMenuState(runtime: GoalMenuRuntimeView): GoalMenuState 
 				"No goal is currently set",
 				automaticTurnLimit === null
 					? "Automatic work is configured as Unlimited."
-					: `Automatic work pauses after ${automaticTurnLimit} responses by default.`,
+					: `Automatic work is configured to pause after ${automaticTurnLimit} responses.`,
 			].join("\n");
 
 	if (runtime.queueFrozen || runtime.pendingQueueAction) {
@@ -621,7 +621,7 @@ function automaticPauseSummary(used: number, limit: number | null) {
 		return `Goal paused after ${used} responses at its previous safety limit. Current limit: Unlimited.`;
 	}
 	if (used < limit) {
-		return `Goal paused after ${used} responses. Current automatic-work limit: ${limit}.`;
+		return `Goal paused after ${used} responses at its previous safety limit. Current automatic-work limit: ${limit}.`;
 	}
 	return `Goal reached its ${used}-of-${limit} safety limit.`;
 }

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -12,6 +12,7 @@ export const GOAL_MENU_ACTIONS = {
 	startBudget: "Start with token budget…",
 	pause: "Pause goal",
 	resume: "Resume goal",
+	reviewSafety: "Review and continue…",
 	increaseBudget: "Increase budget and resume…",
 	edit: "Edit goal…",
 	replace: "Replace goal…",
@@ -47,13 +48,15 @@ export interface GoalMenuState {
 	actions: string[];
 }
 
-type ShowSettings = (ctx: ExtensionCommandContext) => Promise<void>;
-type GoalMenuScreen = "main" | "queue" | "status" | "help";
+type ShowSettings = (ctx: ExtensionCommandContext, target?: "automatic") => Promise<void>;
+type GoalMenuScreen = "main" | "safety" | "queue" | "status" | "help";
 type GoalMenuAction =
 	| "start"
 	| "start-budget"
 	| "pause"
 	| "resume"
+	| "safety-resume"
+	| "safety-settings"
 	| "increase-budget"
 	| "edit"
 	| "replace"
@@ -68,28 +71,45 @@ type GoalMenuAction =
 export function buildGoalMenuState(runtime: GoalMenuRuntimeView): GoalMenuState {
 	const goal = runtime.activeGoal;
 	const queueCount = runtime.queuedGoals.length;
+	const pausedByAutomaticLimit =
+		goal?.status === "paused" && goal.safetyPauseCause === "continuation_limit";
 	const state = runtime.queueFrozen
 		? "Queue frozen"
 		: runtime.pendingQueueAction
 			? "Waiting for Pi to settle"
-			: displayStatus(goal?.status);
+			: pausedByAutomaticLimit
+				? "Paused — automatic-work limit reached"
+				: displayStatus(goal?.status);
 	const automaticTurnLimit = runtime.settings.continuationLimits.automaticTurns;
+	const used = goal?.automaticModelTurns ?? 0;
 	const automaticResponses =
 		automaticTurnLimit === null
-			? `${goal?.automaticModelTurns ?? 0} automatic responses · Unlimited`
-			: `${goal?.automaticModelTurns ?? 0}/${automaticTurnLimit} automatic responses`;
-	const details = goal
-		? [
-				goal.tokenBudget === undefined
-					? formatDuration(goal.timeUsedSeconds)
-					: `${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`,
-				automaticResponses,
-				...(queueCount > 0 ? [`${queueCount} queued`] : []),
-			].join(" · ")
-		: "No goal is currently set";
+			? `Automatic work: ${used} responses · Unlimited`
+			: `Automatic work: ${used} of ${automaticTurnLimit} responses${
+					used < automaticTurnLimit ? ` · ${automaticTurnLimit - used} remaining` : ""
+				}`;
 	const title = goal
-		? `Goal · ${state}\n${safeGoalMenuText(goal.text)}\n${details}`
-		: `Goal · ${state}\n${details}`;
+		? [
+				`Goal · ${state}`,
+				safeGoalMenuText(goal.text),
+				`Usage: ${
+					goal.tokenBudget === undefined
+						? formatDuration(goal.timeUsedSeconds)
+						: `${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`
+				}`,
+				automaticResponses,
+				...(pausedByAutomaticLimit
+					? ["Progress is saved. Review the safety limit before continuing."]
+					: []),
+				...(queueCount > 0 ? [`Queue: ${queueCount} queued`] : []),
+			].join("\n")
+		: [
+				`Goal · ${state}`,
+				"No goal is currently set",
+				automaticTurnLimit === null
+					? "Automatic work is configured as Unlimited."
+					: `Automatic work pauses after ${automaticTurnLimit} responses by default.`,
+			].join("\n");
 
 	if (runtime.queueFrozen || runtime.pendingQueueAction) {
 		return {
@@ -111,6 +131,8 @@ export function buildGoalMenuState(runtime: GoalMenuRuntimeView): GoalMenuState 
 		actions.push(GOAL_MENU_ACTIONS.pause);
 	} else if (goal.status === "budget_limited") {
 		actions.push(GOAL_MENU_ACTIONS.increaseBudget);
+	} else if (pausedByAutomaticLimit) {
+		actions.push(GOAL_MENU_ACTIONS.reviewSafety);
 	} else {
 		actions.push(GOAL_MENU_ACTIONS.resume);
 	}
@@ -140,6 +162,9 @@ export async function showGoalManager(
 	const owner = runtime as GoalRuntime;
 	const generation = owner.menuGeneration;
 	const ownerSignal = owner.menuController?.signal;
+	const isMenuCurrent = () =>
+		owner.menuController === undefined ||
+		(generation === owner.menuGeneration && !owner.menuController.signal.aborted);
 	let displayedGoal: ActiveGoal | undefined;
 	let displayedQueueHead: ActiveGoal | undefined;
 	let displayedQueueFirst: ActiveGoal | undefined;
@@ -157,6 +182,47 @@ export async function showGoalManager(
 					lines: state.title.split("\n").slice(1),
 					items: state.actions.map(goalMainMenuItem),
 					hint: "close",
+				};
+			},
+			safety: () => {
+				const goal = runtime.activeGoal;
+				displayedGoal = goal;
+				const limit = runtime.settings.continuationLimits.automaticTurns;
+				const used = goal?.automaticModelTurns ?? 0;
+				const queueCount = runtime.queuedGoals.length;
+				return {
+					kind: "actions",
+					title: "Automatic work paused",
+					lines: goal
+						? [
+								automaticPauseSummary(used, limit),
+								`${safeGoalMenuText(goal.text)} is preserved.`,
+								`${formatInteger(goal.tokensUsed)} cumulative tokens and ${formatDuration(goal.timeUsedSeconds)} active time are preserved.`,
+								`The objective, usage, and ${queueCount} queued ${queueCount === 1 ? "goal is" : "goals are"} preserved.`,
+								limit === null
+									? "Continuing resets the counter to 0 and resumes with Unlimited automatic work."
+									: `Continuing resets the counter to 0 and allows up to ${limit} more automatic model responses.`,
+							]
+						: ["The paused goal is no longer available. Return to the Goal menu."],
+					items: goal
+						? [
+								{
+									id: "continue",
+									label:
+										limit === null
+											? "Continue — Unlimited"
+											: `Continue — up to ${limit} more responses`,
+									action: "safety-resume" as const,
+								},
+								{
+									id: "settings",
+									label: "Change automatic-work limit…",
+									action: "safety-settings" as const,
+								},
+								{ id: "back", label: "Back", action: "back" as const },
+							]
+						: [{ id: "back", label: "Back", action: "back" as const }],
+					hint: "back",
 				};
 			},
 			queue: () => {
@@ -200,6 +266,7 @@ export async function showGoalManager(
 							runtime.settings.experimental.goals,
 							runtime.queueFrozen,
 							runtime.pendingQueueAction,
+							runtime.settings.continuationLimits.automaticTurns,
 						).split("\n")
 					: ["No goal is currently set."],
 				hint: "back",
@@ -233,6 +300,23 @@ export async function showGoalManager(
 				}
 				await commands.resumeGoal(ctx);
 				return { kind: "close" };
+			},
+			"safety-resume": async () => {
+				if (!displayedGoal || !requireCurrentMenuGoal(runtime, displayedGoal, ctx)) {
+					return { kind: "stay" };
+				}
+				await commands.resumeGoal(ctx);
+				return { kind: "close" };
+			},
+			"safety-settings": async () => {
+				if (!displayedGoal || !requireCurrentMenuGoal(runtime, displayedGoal, ctx)) {
+					return { kind: "stay" };
+				}
+				const expectedGoal = displayedGoal;
+				await showSettings(ctx, "automatic");
+				if (!isMenuCurrent()) return { kind: "close" };
+				if (!requireCurrentMenuGoal(runtime, expectedGoal, ctx)) return { kind: "stay" };
+				return { kind: "stay" };
 			},
 			"increase-budget": async () => {
 				if (!displayedGoal || !requireCurrentMenuGoal(runtime, displayedGoal, ctx)) {
@@ -332,14 +416,15 @@ export async function showGoalManager(
 	await runMenu(ctx, menu, {
 		getState: () => undefined,
 		signal: ownerSignal,
-		isCurrent: () =>
-			owner.menuController === undefined ||
-			(generation === owner.menuGeneration && !owner.menuController.signal.aborted),
+		isCurrent: isMenuCurrent,
 	});
 }
 
 function goalMainMenuItem(label: string): ActionMenuItem<GoalMenuScreen, GoalMenuAction> {
 	if (label === GOAL_MENU_ACTIONS.status) return { id: "status", label, to: "status" as const };
+	if (label === GOAL_MENU_ACTIONS.reviewSafety) {
+		return { id: "review-safety", label, to: "safety" as const };
+	}
 	if (label === GOAL_MENU_ACTIONS.queue) return { id: "queue", label, to: "queue" as const };
 	if (label === GOAL_MENU_ACTIONS.help) return { id: "help", label, to: "help" as const };
 	if (label === GOAL_MENU_ACTIONS.close) return { id: "close", label, close: true as const };
@@ -525,6 +610,20 @@ function displayStatus(status?: ActiveGoal["status"]) {
 
 function formatTokenCount(tokens: number) {
 	return String(tokens);
+}
+
+function formatInteger(value: number) {
+	return value.toLocaleString("en-US", { maximumFractionDigits: 0 });
+}
+
+function automaticPauseSummary(used: number, limit: number | null) {
+	if (limit === null) {
+		return `Goal paused after ${used} responses at its previous safety limit. Current limit: Unlimited.`;
+	}
+	if (used < limit) {
+		return `Goal paused after ${used} responses. Current automatic-work limit: ${limit}.`;
+	}
+	return `Goal reached its ${used}-of-${limit} safety limit.`;
 }
 
 function isTerminalControl(character: string) {

--- a/extensions/pi-goal/src/runtime.ts
+++ b/extensions/pi-goal/src/runtime.ts
@@ -360,7 +360,10 @@ export class GoalRuntime {
 
 	updateStatus(ctx: StatusContext, goal: ActiveGoal) {
 		this.clearCompletionStatusTimer();
-		ctx.ui.setStatus(STATUS_KEY, formatStatus(goal));
+		ctx.ui.setStatus(
+			STATUS_KEY,
+			formatStatus(goal, this.settings.continuationLimits.automaticTurns),
+		);
 	}
 
 	blockStaleGoalToolCalls() {
@@ -528,9 +531,10 @@ export class GoalRuntime {
 			abortCurrentTurn(ctx);
 		}
 		this.activeGoal = transitionGoal({ ...goal, safetyPauseCause: cause }, "paused");
+		const automaticLimit = this.settings.continuationLimits.automaticTurns;
 		const count =
 			cause === "continuation_limit"
-				? `${this.activeGoal.automaticModelTurns} automatic model responses`
+				? `${this.activeGoal.automaticModelTurns} of ${automaticLimit ?? "Unlimited"} automatic model responses`
 				: `no progress across ${this.activeGoal.toolFreeRepeatCount} automatic runs`;
 		this.setTerminalReason(
 			this.activeGoal.id,
@@ -539,7 +543,9 @@ export class GoalRuntime {
 		this.persistGoal(this.activeGoal);
 		this.updateStatus(ctx, this.activeGoal);
 		ctx.ui.notify(
-			`Goal paused: ${count}; ${formatTokenCount(this.activeGoal.tokensUsed)} cumulative tokens. Run /goal resume to continue.`,
+			cause === "continuation_limit"
+				? `Automatic-work limit reached: ${this.activeGoal.automaticModelTurns} of ${automaticLimit} responses. Goal progress is saved with ${formatTokenCount(this.activeGoal.tokensUsed)} cumulative tokens. Open /goal to review and continue.`
+				: `Goal paused: ${count}; ${formatTokenCount(this.activeGoal.tokensUsed)} cumulative tokens. Open /goal to review and continue.`,
 			"warning",
 		);
 		return true;
@@ -1071,16 +1077,32 @@ export function incrementGoal(goal: ActiveGoal): ActiveGoal {
 	return { ...goal, iteration: goal.iteration + 1, updatedAt: Date.now() };
 }
 
-export function formatStatus(goal: ActiveGoal | undefined) {
+export function formatStatus(
+	goal: ActiveGoal | undefined,
+	automaticTurnLimit: number | null = DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns,
+) {
 	if (!goal) return undefined;
 	if (goal.status === "complete") return "complete";
-	if (goal.status === "queued") return "queued";
-	if (goal.status === "paused") return "paused";
-	if (goal.status === "blocked") return "blocked";
-	if (goal.status === "usage_limited") return "usage";
-	if (goal.status === "budget_limited") return `budget ${formatBudget(goal)}`;
-	if (goal.tokenBudget !== undefined) return `active ${formatBudget(goal)}`;
-	return `active ${formatDuration(goal.timeUsedSeconds)}`;
+	const automatic =
+		automaticTurnLimit === null
+			? "automatic Unlimited"
+			: `automatic ${goal.automaticModelTurns}/${automaticTurnLimit}`;
+	if (goal.status === "queued") return `queued · ${automatic}`;
+	if (goal.status === "paused" && goal.safetyPauseCause === "continuation_limit") {
+		if (automaticTurnLimit === null) {
+			return `paused · previous automatic limit at ${goal.automaticModelTurns}`;
+		}
+		if (goal.automaticModelTurns < automaticTurnLimit) {
+			return `paused · automatic ${goal.automaticModelTurns}/${automaticTurnLimit}`;
+		}
+		return `paused · automatic limit ${goal.automaticModelTurns}/${automaticTurnLimit}`;
+	}
+	if (goal.status === "paused") return `paused · ${automatic}`;
+	if (goal.status === "blocked") return `blocked · ${automatic}`;
+	if (goal.status === "usage_limited") return `usage · ${automatic}`;
+	if (goal.status === "budget_limited") return `budget ${formatBudget(goal)} · ${automatic}`;
+	if (goal.tokenBudget !== undefined) return `active ${formatBudget(goal)} · ${automatic}`;
+	return `active ${formatDuration(goal.timeUsedSeconds)} · ${automatic}`;
 }
 
 export function formatBudget(goal: ActiveGoal) {
@@ -1093,18 +1115,23 @@ export function goalSummary(
 	experimentalGoals = false,
 	queueFrozen = false,
 	pendingAction?: PendingQueueAction,
+	automaticTurnLimit: number | null = DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns,
 ) {
 	const summary = [
 		`Goal: ${goal.text}`,
 		`Status: ${queueFrozen ? "queue off" : goal.status}`,
 		`Iteration: ${goal.iteration}`,
-		`Automatic model responses: ${goal.automaticModelTurns}`,
+		automaticTurnLimit === null
+			? `Automatic work: ${goal.automaticModelTurns} responses · Unlimited`
+			: `Automatic work: ${goal.automaticModelTurns} of ${automaticTurnLimit} responses`,
 		`Active elapsed: ${formatDuration(goal.timeUsedSeconds)}`,
 		`Tokens: ${goal.tokenBudget === undefined ? formatTokenCount(goal.tokensUsed) : formatBudget(goal)}`,
 	];
 	if (goal.safetyPauseCause) {
 		summary.push(
-			`Safety pause: ${goal.safetyPauseCause === "continuation_limit" ? "automatic response limit" : "no progress"}`,
+			goal.safetyPauseCause === "continuation_limit"
+				? `Safety pause: automatic-work limit reached (${goal.automaticModelTurns} of ${automaticTurnLimit ?? "Unlimited"} responses). Progress is saved; open /goal to review and continue.`
+				: "Safety pause: no progress. Progress is saved; open /goal to review and continue.",
 		);
 	}
 	if (experimentalGoals || queuedGoals.length > 0 || queueFrozen || pendingAction) {

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -12,6 +12,7 @@ import {
 
 interface GoalSettingsUiOptions {
 	settingsPath?: string;
+	initialScreen?: "settings" | "automatic";
 	save?: (settings: GoalSettings, settingsPath: string) => void;
 	onQueueUnfrozen?: (ctx: ExtensionCommandContext) => Promise<void>;
 }
@@ -33,6 +34,8 @@ export async function showGoalSettings(
 		return;
 	}
 	const generation = runtime.menuGeneration;
+	const isMenuCurrent = () =>
+		generation === runtime.menuGeneration && !runtime.menuController.signal.aborted;
 	const invalid = runtime.settingsLoadIssue?.kind === "invalid";
 	const previewGoalIds = new Map<LimitField, string | null>();
 	type Screen = "settings" | "automatic" | "no-progress" | "invalid";
@@ -45,7 +48,7 @@ export async function showGoalSettings(
 		| "set-queue"
 		| "set-rpc";
 	const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
-		start: invalid ? "invalid" : "settings",
+		start: invalid ? "invalid" : (options.initialScreen ?? "settings"),
 		screens: {
 			settings: () => ({
 				kind: "settings",
@@ -54,8 +57,8 @@ export async function showGoalSettings(
 				items: [
 					{
 						id: "automaticTurns",
-						label: "Automatic work",
-						description: "Choose whether Goal can continue without a response-count cap.",
+						label: "Automatic-work limit",
+						description: "Pause automatic Goal work after a visible number of model responses.",
 						currentValue: formatAutomaticSettingValue(
 							runtime.settings.continuationLimits.automaticTurns,
 						),
@@ -104,7 +107,7 @@ export async function showGoalSettings(
 				title: "Pi Goal Settings · Read only",
 				lines: [
 					`Invalid settings file. Pi-goal is using built-in defaults. Fix ${safeTerminalText(settingsPath)} and run /reload. The file will not be overwritten.`,
-					`Automatic work: ${formatAutomaticWork(runtime.settings.continuationLimits.automaticTurns)}`,
+					`Automatic-work limit: ${formatAutomaticWork(runtime.settings.continuationLimits.automaticTurns)}`,
 					`No-progress guard: ${formatNoProgressProtection(runtime.settings.continuationLimits.noProgressTurns)}`,
 					`Goal tools: ${visibilityLabel(runtime.settings.toolVisibility)}`,
 					`Ordered goal queue: ${runtime.settings.experimental.goals ? "Experimental" : "Off"}`,
@@ -131,6 +134,7 @@ export async function showGoalSettings(
 					"automaticTurns",
 					itemId,
 					previewGoalIds.get("automaticTurns") ?? null,
+					isMenuCurrent,
 				),
 			"choose-no-progress": async ({ itemId }) =>
 				applyLimitChoice(
@@ -141,6 +145,7 @@ export async function showGoalSettings(
 					"noProgressTurns",
 					itemId,
 					previewGoalIds.get("noProgressTurns") ?? null,
+					isMenuCurrent,
 				),
 			"set-visibility": async ({ value }) => {
 				const nextVisibility = value === "Always" ? "always" : "after-first-goal";
@@ -210,8 +215,7 @@ export async function showGoalSettings(
 	await runMenu(ctx, menu, {
 		getState: () => undefined,
 		signal: runtime.menuController.signal,
-		isCurrent: () =>
-			generation === runtime.menuGeneration && !runtime.menuController.signal.aborted,
+		isCurrent: isMenuCurrent,
 	});
 }
 
@@ -224,7 +228,7 @@ function limitChoiceScreen(
 	const goal = runtime.activeGoal;
 	return {
 		kind: "actions" as const,
-		title: field === "automaticTurns" ? "Automatic work" : "No-progress guard",
+		title: field === "automaticTurns" ? "Automatic-work limit" : "No-progress guard",
 		lines: [
 			field === "automaticTurns"
 				? `Current: ${formatAutomaticWork(value)}`
@@ -259,13 +263,19 @@ function limitChoices(
 				: automaticTurnsUsed === undefined
 					? `Remove the current ${value}-response cap. Goal work will have no response-count cap; other configured stop conditions remain.`
 					: `Remove the current ${value}-response cap. The active goal has used ${automaticTurnsUsed} responses; other configured stop conditions remain.`;
+		const defaultLimit = DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns;
 		return [
-			{ value: "unlimited", label: "Unlimited (default)", description: unlimitedDescription },
+			{
+				value: "default",
+				label: `${defaultLimit} responses (default)`,
+				description: `Pause after ${defaultLimit} Goal-owned automatic model responses.`,
+			},
 			{
 				value: "custom",
-				label: "Set a maximum…",
-				description: "Pause after a whole number of Goal-owned automatic responses.",
+				label: "Set a custom limit…",
+				description: "Choose a whole-number response limit for each automatic-work epoch.",
 			},
+			{ value: "unlimited", label: "Unlimited…", description: unlimitedDescription },
 		];
 	}
 	const defaultLimit = DEFAULT_GOAL_SETTINGS.continuationLimits.noProgressTurns;
@@ -296,8 +306,9 @@ async function applyLimitChoice(
 	field: LimitField,
 	itemId: string,
 	activeGoalId: string | null,
+	isCurrent: () => boolean,
 ) {
-	if (!isLimitSelection(itemId)) return { kind: "rejected" as const };
+	if (!isCurrent() || !isLimitSelection(itemId)) return { kind: "rejected" as const };
 	if ((runtime.activeGoal?.id ?? null) !== activeGoalId) {
 		ctx.ui.notify(
 			"The active goal changed while the safety setting was open. No settings were changed.",
@@ -306,7 +317,8 @@ async function applyLimitChoice(
 		return { kind: "rejected" as const };
 	}
 	const previous = runtime.settings.continuationLimits[field];
-	const limit = await resolveLimitSelection(field, itemId, previous, ctx);
+	const limit = await resolveLimitSelection(field, itemId, previous, ctx, isCurrent);
+	if (!isCurrent()) return { kind: "rejected" as const };
 	if (limit === undefined || limit === previous) return { kind: "back" as const };
 	if ((runtime.activeGoal?.id ?? null) !== activeGoalId) {
 		ctx.ui.notify(
@@ -316,7 +328,7 @@ async function applyLimitChoice(
 		return { kind: "rejected" as const };
 	}
 	const confirmation = await confirmLowerActiveLimit(runtime, ctx, field, limit);
-	if (!confirmation.apply) return { kind: "rejected" as const };
+	if (!isCurrent() || !confirmation.apply) return { kind: "rejected" as const };
 	if (confirmation.goalId !== undefined && runtime.activeGoal?.id !== confirmation.goalId) {
 		ctx.ui.notify(
 			"The active goal changed while confirming the limit. No settings were changed.",
@@ -354,6 +366,9 @@ export function applyGoalSettings(
 		const abortOwnedRun = activeGoalId !== undefined && runtime.agentRunGoalId === activeGoalId;
 		const pausedByAutomaticLimit = runtime.enforceAutomaticTurnLimit(ctx, abortOwnedRun);
 		if (!pausedByAutomaticLimit) runtime.enforceNoProgressLimit(ctx, abortOwnedRun);
+		if (runtime.activeGoal && !runtime.queueFrozen) {
+			runtime.updateStatus(ctx, runtime.activeGoal);
+		}
 	} catch (error) {
 		const rollbackErrors: unknown[] = [];
 		try {
@@ -399,10 +414,19 @@ async function resolveLimitSelection(
 	selection: LimitSelection,
 	previous: number | null,
 	ctx: ExtensionCommandContext,
+	isCurrent: () => boolean,
 ): Promise<number | null | undefined> {
-	if (selection === "unlimited" || selection === "off") return null;
+	if (selection === "off") return null;
+	if (selection === "unlimited") {
+		if (previous === null) return null;
+		const confirmed = await ctx.ui.confirm(
+			"Allow Unlimited automatic work?",
+			"Tool loops can continue without a response-count limit and may consume substantial tokens and provider cost. Completion, manual pause, blockers, provider limits, and the no-progress guard still apply.",
+		);
+		return isCurrent() && confirmed ? null : undefined;
+	}
 	if (selection === "default") {
-		return DEFAULT_GOAL_SETTINGS.continuationLimits.noProgressTurns;
+		return DEFAULT_GOAL_SETTINGS.continuationLimits[field];
 	}
 	while (true) {
 		const raw = await ctx.ui.input(
@@ -411,7 +435,7 @@ async function resolveLimitSelection(
 				: "Repeated-run threshold (whole number greater than 0)",
 			previous === null ? "Positive whole number" : String(previous),
 		);
-		if (raw === undefined) return undefined;
+		if (!isCurrent() || raw === undefined) return undefined;
 		const parsed = parseGoalLimit(raw);
 		if (parsed !== undefined) return parsed;
 		ctx.ui.notify(
@@ -550,7 +574,7 @@ function withLimit(settings: GoalSettings, field: LimitField, value: number | nu
 }
 
 function formatAutomaticSettingValue(value: number | null) {
-	return value === null ? "Unlimited" : `≤${value}`;
+	return value === null ? "Unlimited" : `${value} responses`;
 }
 
 function formatNoProgressSettingValue(value: number | null) {
@@ -569,7 +593,7 @@ function formatNoProgressProtection(value: number | null) {
 
 function formatLimitSuccess(field: LimitField, value: number | null) {
 	return field === "automaticTurns"
-		? `Automatic work: ${formatAutomaticWork(value)}.`
+		? `Automatic-work limit: ${formatAutomaticWork(value)}.`
 		: `No-progress guard: ${formatNoProgressProtection(value)}.`;
 }
 

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -233,6 +233,11 @@ function limitChoiceScreen(
 			field === "automaticTurns"
 				? `Current: ${formatAutomaticWork(value)}`
 				: `Current: ${formatNoProgressProtection(value)}`,
+			...(field === "automaticTurns"
+				? [
+						`Set a whole-number response limit for each automatic-work epoch. Default: ${DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns}.`,
+					]
+				: []),
 			...(goal
 				? [
 						field === "automaticTurns"
@@ -263,17 +268,11 @@ function limitChoices(
 				: automaticTurnsUsed === undefined
 					? `Remove the current ${value}-response cap. Goal work will have no response-count cap; other configured stop conditions remain.`
 					: `Remove the current ${value}-response cap. The active goal has used ${automaticTurnsUsed} responses; other configured stop conditions remain.`;
-		const defaultLimit = DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns;
 		return [
 			{
-				value: "default",
-				label: `${defaultLimit} responses (default)`,
-				description: `Pause after ${defaultLimit} Goal-owned automatic model responses.`,
-			},
-			{
 				value: "custom",
-				label: "Set a custom limit…",
-				description: "Choose a whole-number response limit for each automatic-work epoch.",
+				label: "Set response limit…",
+				description: `Choose a whole-number response limit for each automatic-work epoch. Default: ${DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns}.`,
 			},
 			{ value: "unlimited", label: "Unlimited…", description: unlimitedDescription },
 		];
@@ -429,12 +428,16 @@ async function resolveLimitSelection(
 		return DEFAULT_GOAL_SETTINGS.continuationLimits[field];
 	}
 	while (true) {
-		const raw = await ctx.ui.input(
+		const raw =
 			field === "automaticTurns"
-				? "Maximum automatic responses (whole number greater than 0)"
-				: "Repeated-run threshold (whole number greater than 0)",
-			previous === null ? "Positive whole number" : String(previous),
-		);
+				? await ctx.ui.editor(
+						`Automatic-work response limit (whole number greater than 0) · Default: ${DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns}`,
+						String(previous ?? DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns),
+					)
+				: await ctx.ui.input(
+						"Repeated-run threshold (whole number greater than 0)",
+						previous === null ? "Positive whole number" : String(previous),
+					);
 		if (!isCurrent() || raw === undefined) return undefined;
 		const parsed = parseGoalLimit(raw);
 		if (parsed !== undefined) return parsed;

--- a/extensions/pi-goal/src/settings.ts
+++ b/extensions/pi-goal/src/settings.ts
@@ -27,7 +27,7 @@ export const DEFAULT_GOAL_SETTINGS: GoalSettings = {
 	toolVisibility: "always",
 	experimental: { goals: false },
 	rpc: { enabled: false },
-	continuationLimits: { automaticTurns: null, noProgressTurns: 3 },
+	continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
 };
 
 export type GoalSettingsLoadResult =

--- a/extensions/pi-goal/test/goal-queue.test.ts
+++ b/extensions/pi-goal/test/goal-queue.test.ts
@@ -722,7 +722,7 @@ test("restored exhausted queued heads remain budget-limited without a kickoff pr
 
 	assert.equal(restored.mock.sentUserMessages.length, 0);
 	assert.equal(stateGoals(restored.mock)[0]?.status, "budget_limited");
-	assert.equal(restored.statuses.get("goal"), "budget 10/10");
+	assert.equal(restored.statuses.get("goal"), "budget 10/10 · automatic 0/25");
 });
 
 test("pending priority survives reload after the displaced head completes", async () => {
@@ -1400,7 +1400,7 @@ test("disabled settings freeze retained queues without losing state", async () =
 	const restored = await createHarness({
 		sessionManager: { getBranch: () => restoredBranch, getEntries: () => restoredBranch },
 	});
-	assert.equal(restored.statuses.get("goal"), "active 0s");
+	assert.equal(restored.statuses.get("goal"), "active 0s · automatic 0/25");
 	assert.deepEqual(
 		stateGoals(restored.mock).map(({ text }) => text),
 		["head", "later"],

--- a/extensions/pi-goal/test/goal-run-protocol.test.ts
+++ b/extensions/pi-goal/test/goal-run-protocol.test.ts
@@ -400,7 +400,7 @@ test("cancel during the first active event prevents kickoff delivery", async () 
 	);
 	assert.equal(mock.sentUserMessages.length, 0);
 	assert.equal(lastPersistedGoal(mock)?.status, "paused");
-	assert.equal(context.statuses.get("goal"), "paused");
+	assert.equal(context.statuses.get("goal"), "paused · automatic 0/25");
 });
 
 test("unknown, stale, and manual runs cannot be cancelled", async () => {

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -43,6 +43,7 @@ const INVALID_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "invalid.json");
 const MISSING_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "missing.json");
 const LOW_LIMITS_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "low-limits.json");
 const ONE_TURN_LIMIT_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "one-turn-limit.json");
+const UNLIMITED_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "unlimited.json");
 writeFileSync(ALWAYS_SETTINGS_PATH, '{"toolVisibility":"always"}\n');
 writeFileSync(LAZY_SETTINGS_PATH, '{"toolVisibility":"after-first-goal"}\n');
 writeFileSync(INVALID_SETTINGS_PATH, '{"toolVisibility":"sometimes"}\n');
@@ -53,6 +54,10 @@ writeFileSync(
 writeFileSync(
 	ONE_TURN_LIMIT_SETTINGS_PATH,
 	'{"continuationLimits":{"automaticTurns":1,"noProgressTurns":null}}\n',
+);
+writeFileSync(
+	UNLIMITED_SETTINGS_PATH,
+	'{"continuationLimits":{"automaticTurns":null,"noProgressTurns":3}}\n',
 );
 after(() => rmSync(GOAL_SETTINGS_DIRECTORY, { recursive: true, force: true }));
 
@@ -1513,19 +1518,18 @@ test("session reload pauses an active goal already at the automatic response lim
 		tokensUsed: 5,
 		timeUsedSeconds: 4,
 		baselineTokens: 0,
-		automaticModelTurns: 3,
+		automaticModelTurns: 25,
 		toolFreeRepeatCount: 0,
 	};
-	const restored = restoreStoredGoalForTest(
-		sessionGoal,
-		[],
-		"always",
-		{},
-		LOW_LIMITS_SETTINGS_PATH,
-	);
+	const restored = restoreStoredGoalForTest(sessionGoal);
 	assert.equal(lastGoalStatus(restored.mock), "paused");
 	assert.equal(requireLastGoal(restored.mock).safetyPauseCause, "continuation_limit");
 	assert.equal(restored.mock.sentUserMessages.length, 0);
+	assert.match(
+		restored.notifications.at(-1)?.message ?? "",
+		/automatic-work limit reached.*25 of 25/i,
+	);
+	assert.match(restored.notifications.at(-1)?.message ?? "", /progress is saved/i);
 });
 
 test("session reload pauses an active goal already at the no-progress limit", () => {
@@ -1625,13 +1629,45 @@ test("formatStatus reports active, stopped, budget-limited, complete, and empty 
 		toolFreeRepeatCount: 0,
 	} as const;
 
-	assert.equal(formatStatus(undefined), undefined);
-	assert.equal(formatStatus(activeGoal), "active 500/2k");
-	assert.equal(formatStatus({ ...activeGoal, status: "paused" }), "paused");
-	assert.equal(formatStatus({ ...activeGoal, status: "blocked" }), "blocked");
-	assert.equal(formatStatus({ ...activeGoal, status: "usage_limited" }), "usage");
-	assert.equal(formatStatus({ ...activeGoal, status: "budget_limited" }), "budget 500/2k");
-	assert.equal(formatStatus({ ...activeGoal, status: "complete" }), "complete");
+	assert.equal(formatStatus(undefined, 25), undefined);
+	assert.equal(formatStatus(activeGoal, 25), "active 500/2k · automatic 0/25");
+	assert.equal(
+		formatStatus(
+			{
+				...activeGoal,
+				status: "paused",
+				automaticModelTurns: 25,
+				safetyPauseCause: "continuation_limit",
+			},
+			25,
+		),
+		"paused · automatic limit 25/25",
+	);
+	assert.equal(formatStatus({ ...activeGoal, status: "blocked" }, 25), "blocked · automatic 0/25");
+	assert.equal(
+		formatStatus({ ...activeGoal, status: "usage_limited" }, 25),
+		"usage · automatic 0/25",
+	);
+	assert.equal(
+		formatStatus({ ...activeGoal, status: "budget_limited" }, 25),
+		"budget 500/2k · automatic 0/25",
+	);
+	assert.equal(formatStatus(activeGoal, null), "active 500/2k · automatic Unlimited");
+	assert.equal(formatStatus({ ...activeGoal, status: "complete" }, 25), "complete");
+});
+
+test("goal start feedback exposes the default cap and explicit Unlimited mode", async () => {
+	const capped = await startGoalForTest();
+	assert.match(
+		capped.notifications.at(-1)?.message ?? "",
+		/automatic work pauses after 25 responses/i,
+	);
+	assert.match(capped.notifications.at(-1)?.message ?? "", /open \/goal to monitor/i);
+
+	const unlimited = await startGoalForTest({}, "unbounded objective", UNLIMITED_SETTINGS_PATH);
+	assert.match(unlimited.notifications.at(-1)?.message ?? "", /automatic work is Unlimited/i);
+	assert.match(unlimited.notifications.at(-1)?.message ?? "", /provider cost/i);
+	assert.equal(unlimited.notifications.at(-1)?.level, "warning");
 });
 
 test("buildGoalSystemPrompt escapes objective XML and includes goal_id guard rules", () => {
@@ -2048,7 +2084,7 @@ test("goal_blocked requires a current active goal and strict blocker evidence", 
 	assert.equal(accepted.terminate, true);
 	assert.match(accepted.content?.[0]?.text ?? "", /goal blocked/i);
 	assert.equal(lastGoalStatus(blocked.mock), "blocked");
-	assert.equal(blocked.statuses.get("goal"), "blocked");
+	assert.equal(blocked.statuses.get("goal"), "blocked · automatic 0/25");
 	assert.match(blocked.notifications.at(-1)?.message ?? "", /goal blocked/i);
 	assert.deepEqual(
 		blocked.mock.events.get("tool_call")?.[0]?.(
@@ -2093,7 +2129,7 @@ test("session persistence restores stopped states with resumable command hints",
 		["budget_limited", "budget 5/10"],
 	] as const) {
 		const restored = restoreGoalForTest(status);
-		assert.equal(restored.statuses.get("goal"), statusline);
+		assert.equal(restored.statuses.get("goal"), `${statusline} · automatic 0/25`);
 
 		await restored.mock.commands.get("goal")?.handler("", restored.ctx);
 		assert.match(restored.notifications.at(-1)?.message ?? "", new RegExp(`Status: ${status}`));
@@ -2111,7 +2147,12 @@ test("resume safely reactivates every resumable stopped status and rotates goal_
 		const resumed = requireLastGoal(restored.mock);
 		assert.equal(resumed.status, "active", `${status} should resume`);
 		assert.notEqual(resumed.id, beforeResume.id);
-		assert.equal(restored.statuses.get("goal"), "active 5/10");
+		assert.equal(restored.statuses.get("goal"), "active 5/10 · automatic 0/25");
+		assert.match(restored.notifications.at(-1)?.message ?? "", /counter.*0 of 25/i);
+		assert.match(
+			restored.notifications.at(-1)?.message ?? "",
+			/progress and cumulative usage are preserved/i,
+		);
 		assert.equal(restored.mock.sentUserMessages.length, 1);
 		assert.match(restored.mock.sentUserMessages[0]?.text ?? "", /explicitly resumed/i);
 		assert.equal(
@@ -2365,7 +2406,7 @@ test("failed resume delivery restores the stopped state and original goal_id", a
 
 	assert.equal(lastGoalStatus(restored.mock), "blocked");
 	assert.equal(requireLastGoal(restored.mock).id, restored.sessionGoal.id);
-	assert.equal(restored.statuses.get("goal"), "blocked");
+	assert.equal(restored.statuses.get("goal"), "blocked · automatic 0/25");
 	assert.equal(restored.mock.sentUserMessages.length, 0);
 	assert.match(restored.notifications.at(-1)?.message ?? "", /runtime became busy/i);
 	assert.deepEqual(
@@ -2528,10 +2569,9 @@ test("pause remains active-only for new stopped statuses", async () => {
 		const restored = restoreGoalForTest(status);
 		await restored.mock.commands.get("goal")?.handler("pause", restored.ctx);
 		assert.match(restored.notifications.at(-1)?.message ?? "", /only active goals can be paused/i);
-		assert.equal(
-			restored.statuses.get("goal"),
-			status === "usage_limited" ? "usage" : status === "budget_limited" ? "budget 5/10" : status,
-		);
+		const label =
+			status === "usage_limited" ? "usage" : status === "budget_limited" ? "budget 5/10" : status;
+		assert.equal(restored.statuses.get("goal"), `${label} · automatic 0/25`);
 	}
 });
 
@@ -2679,15 +2719,15 @@ test("automatic turn_end hard cap pauses a tool loop before another normal respo
 	assert.equal(aborts, 1);
 	assert.equal(
 		capped.notifications.filter((notice) =>
-			/Goal paused: 3 automatic model responses/i.test(notice.message),
+			/Automatic-work limit reached: 3 of 3 responses/i.test(notice.message),
 		).length,
 		1,
 	);
 	await capped.mock.commands.get("goal")?.handler("", capped.ctx);
-	assert.match(capped.notifications.at(-1)?.message ?? "", /Automatic model responses: 3/i);
+	assert.match(capped.notifications.at(-1)?.message ?? "", /Automatic work: 3 of 3 responses/i);
 	assert.match(
 		capped.notifications.at(-1)?.message ?? "",
-		/Safety pause: automatic response limit/i,
+		/Safety pause: automatic-work limit reached/i,
 	);
 	capped.mock.events.get("turn_end")?.[0]?.(
 		{ message: { role: "assistant", stopReason: "aborted", content: [] }, toolResults: [] },
@@ -3432,7 +3472,7 @@ test("pause aborts the current turn, blocks stale tools, and persists paused sta
 
 	assert.equal(pauseAborts, 1);
 	assert.equal(lastGoalStatus(paused.mock), "paused");
-	assert.equal(paused.statuses.get("goal"), "paused");
+	assert.equal(paused.statuses.get("goal"), "paused · automatic 0/25");
 	assert.deepEqual(
 		paused.mock.events.get("input")?.[0]?.(
 			{ source: "extension", text: staleContinuation },
@@ -3612,7 +3652,7 @@ test("tool_execution_end enforces budget once and injects one bounded wrap-up", 
 
 	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
 	assert.equal(requireLastGoal(budgeted.mock).tokensUsed, 12);
-	assert.equal(budgeted.statuses.get("goal"), "budget 12/10");
+	assert.equal(budgeted.statuses.get("goal"), "budget 12/10 · automatic 0/25");
 	assert.equal(budgeted.mock.sentMessages.length, 1);
 	const wrapUp = budgeted.mock.sentMessages[0];
 	assert.ok(wrapUp);

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -49,12 +49,17 @@ function commands() {
 test("buildGoalMenuState prioritizes actions for empty, active, stopped, budget, and frozen states", () => {
 	const empty = runtime();
 	empty.settings.experimental.goals = true;
-	assert.match(buildGoalMenuState(empty).title, /automatic work pauses after 25 responses/i);
+	assert.match(buildGoalMenuState(empty).title, /configured to pause after 25 responses/i);
 	assert.deepEqual(buildGoalMenuState(empty).actions.slice(0, 2), [
 		GOAL_MENU_ACTIONS.start,
 		GOAL_MENU_ACTIONS.startBudget,
 	]);
 	assert.equal(buildGoalMenuState(empty).actions.includes(GOAL_MENU_ACTIONS.queue), false);
+
+	const customEmpty = runtime();
+	customEmpty.settings.continuationLimits.automaticTurns = 40;
+	assert.match(buildGoalMenuState(customEmpty).title, /configured to pause after 40 responses/i);
+	assert.doesNotMatch(buildGoalMenuState(customEmpty).title, /by default/i);
 
 	const active = createGoal("ship the release", 100, 0);
 	active.tokensUsed = 20;
@@ -173,43 +178,50 @@ test("hard-cap recovery applies Continue only to the previewed goal", async () =
 });
 
 test("hard-cap recovery can open the automatic-work setting and remain paused", async () => {
-	const goal = transitionGoal(createGoal("paused objective", undefined, 0), "paused");
-	goal.automaticModelTurns = 25;
-	goal.safetyPauseCause = "continuation_limit";
-	const state = runtime(goal);
-	const tracked = commands();
-	const selections = [
-		"Review and continue…",
-		"Change automatic-work limit…",
-		"Back",
-		GOAL_MENU_ACTIONS.close,
-	];
-	const targets: Array<string | undefined> = [];
-	const recoveryFrames: string[] = [];
-	const context = createMockContext({
-		mode: "tui",
-		hasUI: true,
-		select: async (title: string) => {
-			if (/Automatic work paused/i.test(title)) recoveryFrames.push(title);
-			return selections.shift();
-		},
-	});
+	for (const updatedLimit of [40, null] as const) {
+		const goal = transitionGoal(createGoal("paused objective", undefined, 0), "paused");
+		goal.automaticModelTurns = 25;
+		goal.safetyPauseCause = "continuation_limit";
+		const state = runtime(goal);
+		const tracked = commands();
+		const selections = [
+			"Review and continue…",
+			"Change automatic-work limit…",
+			"Back",
+			GOAL_MENU_ACTIONS.close,
+		];
+		const targets: Array<string | undefined> = [];
+		const recoveryFrames: string[] = [];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async (title: string) => {
+				if (/Automatic work paused/i.test(title)) recoveryFrames.push(title);
+				return selections.shift();
+			},
+		});
 
-	await showGoalManager(
-		state,
-		tracked.controller as never,
-		context.ctx,
-		async (_ctx, target?: string) => {
-			targets.push(target);
-			state.settings.continuationLimits.automaticTurns = null;
-		},
-	);
+		await showGoalManager(
+			state,
+			tracked.controller as never,
+			context.ctx,
+			async (_ctx, target?: string) => {
+				targets.push(target);
+				state.settings.continuationLimits.automaticTurns = updatedLimit;
+			},
+		);
 
-	assert.deepEqual(targets, ["automatic"]);
-	assert.match(recoveryFrames.at(-1) ?? "", /Current limit: Unlimited/i);
-	assert.doesNotMatch(recoveryFrames.at(-1) ?? "", /of-Unlimited safety limit/i);
-	assert.equal(state.activeGoal?.status, "paused");
-	assert.equal(tracked.calls.length, 0);
+		assert.deepEqual(targets, ["automatic"]);
+		const updatedFrame = recoveryFrames.at(-1) ?? "";
+		assert.match(updatedFrame, /paused after 25 responses at its previous safety limit/i);
+		assert.match(
+			updatedFrame,
+			updatedLimit === null ? /Current limit: Unlimited/i : /Current automatic-work limit: 40/i,
+		);
+		assert.doesNotMatch(updatedFrame, /of-(?:40|Unlimited) safety limit/i);
+		assert.equal(state.activeGoal?.status, "paused");
+		assert.equal(tracked.calls.length, 0);
+	}
 });
 
 test("hard-cap recovery remains readable and keyboard-operable at supported widths", async () => {

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { createMockContext } from "../../../test/support.js";
 import {
 	buildGoalMenuState,
@@ -47,6 +49,7 @@ function commands() {
 test("buildGoalMenuState prioritizes actions for empty, active, stopped, budget, and frozen states", () => {
 	const empty = runtime();
 	empty.settings.experimental.goals = true;
+	assert.match(buildGoalMenuState(empty).title, /automatic work pauses after 25 responses/i);
 	assert.deepEqual(buildGoalMenuState(empty).actions.slice(0, 2), [
 		GOAL_MENU_ACTIONS.start,
 		GOAL_MENU_ACTIONS.startBudget,
@@ -56,14 +59,17 @@ test("buildGoalMenuState prioritizes actions for empty, active, stopped, budget,
 	const active = createGoal("ship the release", 100, 0);
 	active.tokensUsed = 20;
 	active.automaticModelTurns = 12;
-	const unlimited = runtime(active);
-	assert.equal(buildGoalMenuState(unlimited).actions[0], GOAL_MENU_ACTIONS.pause);
-	assert.match(buildGoalMenuState(unlimited).title, /Active.*20\/100/is);
-	assert.match(buildGoalMenuState(unlimited).title, /12 automatic responses.*Unlimited/is);
-
 	const capped = runtime(active);
-	capped.settings.continuationLimits.automaticTurns = 25;
-	assert.match(buildGoalMenuState(capped).title, /12\/25 automatic responses/is);
+	assert.equal(buildGoalMenuState(capped).actions[0], GOAL_MENU_ACTIONS.pause);
+	assert.match(buildGoalMenuState(capped).title, /Active.*Usage: 20\/100/is);
+	assert.match(
+		buildGoalMenuState(capped).title,
+		/Automatic work: 12 of 25 responses.*13 remaining/is,
+	);
+
+	const unlimited = runtime(active);
+	unlimited.settings.continuationLimits.automaticTurns = null;
+	assert.match(buildGoalMenuState(unlimited).title, /Automatic work: 12 responses.*Unlimited/is);
 
 	for (const status of ["paused", "blocked", "usage_limited"] as const) {
 		const stopped = runtime(transitionGoal(active, status));
@@ -83,6 +89,182 @@ test("buildGoalMenuState prioritizes actions for empty, active, stopped, budget,
 		GOAL_MENU_ACTIONS.clear,
 		GOAL_MENU_ACTIONS.close,
 	]);
+});
+
+test("hard-cap pause names the cause and prioritizes review over immediate resume", () => {
+	const goal = transitionGoal(createGoal("preserve this objective", undefined, 0), "paused");
+	goal.automaticModelTurns = 25;
+	goal.tokensUsed = 12_345;
+	goal.timeUsedSeconds = 90;
+	goal.safetyPauseCause = "continuation_limit";
+	const state = buildGoalMenuState(runtime(goal));
+
+	assert.match(state.title, /Paused — automatic-work limit reached/i);
+	assert.match(state.title, /Automatic work: 25 of 25 responses/i);
+	assert.match(state.title, /Progress is saved/i);
+	assert.equal(state.actions[0], "Review and continue…");
+	assert.equal(state.actions.includes(GOAL_MENU_ACTIONS.resume), false);
+});
+
+test("hard-cap recovery previews the next epoch and Back has no side effects", async () => {
+	const goal = transitionGoal(createGoal("preserve this objective", undefined, 0), "paused");
+	goal.automaticModelTurns = 25;
+	goal.tokensUsed = 12_345;
+	goal.timeUsedSeconds = 90;
+	goal.safetyPauseCause = "continuation_limit";
+	const state = runtime(goal);
+	state.queuedGoals.push(createGoal("queued objective", undefined, 0));
+	const tracked = commands();
+	const selections = ["Review and continue…", "Back", GOAL_MENU_ACTIONS.close];
+	let recoveryRender = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async (title: string) => {
+			if (/Automatic work paused/i.test(title)) recoveryRender = title;
+			return selections.shift();
+		},
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+	assert.match(recoveryRender, /25-of-25 safety limit/i);
+	assert.match(recoveryRender, /12,345 cumulative tokens/i);
+	assert.match(recoveryRender, /1m active time/i);
+	assert.match(recoveryRender, /objective, usage, and 1 queued goal is preserved/i);
+	assert.match(recoveryRender, /resets the counter to 0.*up to 25 more/is);
+	assert.equal(tracked.calls.length, 0);
+	assert.equal(state.activeGoal, goal);
+});
+
+test("hard-cap recovery applies Continue only to the previewed goal", async () => {
+	for (const replaceBeforeContinue of [false, true]) {
+		const goal = transitionGoal(createGoal("previewed objective", undefined, 0), "paused");
+		goal.automaticModelTurns = 25;
+		goal.safetyPauseCause = "continuation_limit";
+		const state = runtime(goal);
+		const tracked = commands();
+		const selections = ["Review and continue…", "Continue — up to 25 more responses"];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async () => {
+				const selection = selections.shift();
+				if (selection?.startsWith("Continue") && replaceBeforeContinue) {
+					state.activeGoal = transitionGoal(
+						createGoal("replacement objective", undefined, 0),
+						"paused",
+					);
+				}
+				return selection;
+			},
+		});
+
+		await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+		assert.equal(
+			tracked.calls.filter((call) => call.name === "resumeGoal").length,
+			replaceBeforeContinue ? 0 : 1,
+		);
+		if (replaceBeforeContinue) {
+			assert.match(context.notifications.at(-1)?.message ?? "", /active goal changed.*reopen/i);
+		}
+	}
+});
+
+test("hard-cap recovery can open the automatic-work setting and remain paused", async () => {
+	const goal = transitionGoal(createGoal("paused objective", undefined, 0), "paused");
+	goal.automaticModelTurns = 25;
+	goal.safetyPauseCause = "continuation_limit";
+	const state = runtime(goal);
+	const tracked = commands();
+	const selections = [
+		"Review and continue…",
+		"Change automatic-work limit…",
+		"Back",
+		GOAL_MENU_ACTIONS.close,
+	];
+	const targets: Array<string | undefined> = [];
+	const recoveryFrames: string[] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async (title: string) => {
+			if (/Automatic work paused/i.test(title)) recoveryFrames.push(title);
+			return selections.shift();
+		},
+	});
+
+	await showGoalManager(
+		state,
+		tracked.controller as never,
+		context.ctx,
+		async (_ctx, target?: string) => {
+			targets.push(target);
+			state.settings.continuationLimits.automaticTurns = null;
+		},
+	);
+
+	assert.deepEqual(targets, ["automatic"]);
+	assert.match(recoveryFrames.at(-1) ?? "", /Current limit: Unlimited/i);
+	assert.doesNotMatch(recoveryFrames.at(-1) ?? "", /of-Unlimited safety limit/i);
+	assert.equal(state.activeGoal?.status, "paused");
+	assert.equal(tracked.calls.length, 0);
+});
+
+test("hard-cap recovery remains readable and keyboard-operable at supported widths", async () => {
+	const goal = transitionGoal(
+		createGoal(`long objective ${"with preserved detail ".repeat(12)}`, undefined, 0),
+		"paused",
+	);
+	goal.automaticModelTurns = 25;
+	goal.tokensUsed = 12_345;
+	goal.safetyPauseCause = "continuation_limit";
+	const state = runtime(goal);
+	const tracked = commands();
+	const tui = createTuiHarness({ width: 80, rows: 40 });
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+	});
+
+	try {
+		const running = showGoalManager(
+			state,
+			tracked.controller as never,
+			context.ctx,
+			async () => undefined,
+		);
+		await tui.waitForOpen();
+		for (const width of [40, 80, 120]) {
+			const lines = tui.render(width);
+			assert.ok(lines.every((line) => visibleWidth(line) <= width));
+			assert.match(lines.join(" ").replace(/\s+/gu, " "), /Review and continue…/i);
+		}
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		for (const width of [40, 80, 120]) {
+			const lines = tui.render(width);
+			const frame = lines.join(" ").replace(/\s+/gu, " ");
+			assert.ok(lines.every((line) => visibleWidth(line) <= width));
+			assert.match(frame, /Automatic work paused/i);
+			assert.match(frame, /25-of-25 safety limit/i);
+			assert.match(frame, /Continue — up to 25 more responses/i);
+			assert.match(frame, /Back/i);
+		}
+
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(tui.render().join(" "), /Review and continue…/i);
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(tracked.calls.length, 0);
+	} finally {
+		tui.dispose();
+	}
 });
 
 test("safeGoalMenuText strips terminal controls and bounds untrusted previews", () => {

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -464,32 +464,39 @@ test("automatic-work settings can open directly from the safety recovery flow", 
 	});
 
 	assert.match(title, /Automatic-work limit/i);
-	assert.deepEqual(options, ["25 responses (default)", "Set a custom limit…", "Unlimited…"]);
+	assert.deepEqual(options, ["Set response limit…", "Unlimited…"]);
 });
 
-test("automatic-work choices restore the default, support custom limits, and preview Unlimited", async () => {
+test("automatic-work finite limit editor starts from the current value or built-in default", async () => {
 	for (const scenario of [
 		{
 			initial: null,
-			choice: "25 responses (default)",
+			prefill: "25",
+			entered: "25",
 			expected: 25,
 		},
 		{
-			initial: 25,
-			choice: "Set a custom limit…",
-			input: "40",
+			initial: 50,
+			prefill: "50",
+			entered: "40",
 			expected: 40,
 		},
 	] as const) {
 		const state = runtime();
 		state.settings.continuationLimits.automaticTurns = scenario.initial;
 		let saved: GoalSettings | undefined;
-		const selections = ["Automatic-work limit", scenario.choice, undefined];
+		let editorTitle = "";
+		let editorPrefill = "";
+		const selections = ["Automatic-work limit", "Set response limit…", undefined];
 		const context = createMockContext({
 			hasUI: true,
 			mode: "tui",
 			select: async () => selections.shift(),
-			input: async () => ("input" in scenario ? scenario.input : undefined),
+			editor: async (title: string, prefill: string) => {
+				editorTitle = title;
+				editorPrefill = prefill;
+				return scenario.entered;
+			},
 		});
 
 		await showGoalSettings(state, context.ctx, {
@@ -499,9 +506,34 @@ test("automatic-work choices restore the default, support custom limits, and pre
 			},
 		});
 
+		assert.match(editorTitle, /default: 25/i);
+		assert.equal(editorPrefill, scenario.prefill);
 		assert.equal(saved?.continuationLimits.automaticTurns, scenario.expected);
 		assert.equal(state.settings.continuationLimits.automaticTurns, scenario.expected);
 	}
+});
+
+test("cancelling the automatic-work finite limit editor changes nothing", async () => {
+	const state = runtime();
+	state.settings.continuationLimits.automaticTurns = 50;
+	let saves = 0;
+	const selections = ["Automatic-work limit", "Set response limit…", undefined];
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		select: async () => selections.shift(),
+		editor: async () => undefined,
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			saves++;
+		},
+	});
+
+	assert.equal(saves, 0);
+	assert.equal(state.settings.continuationLimits.automaticTurns, 50);
 });
 
 test("Unlimited automatic work requires a concrete confirmation and cancellation changes nothing", async () => {
@@ -541,12 +573,12 @@ test("lowering a reached automatic-work limit previews the immediate pause", asy
 		state.activeGoal.automaticModelTurns = 25;
 		let preview = "";
 		let saves = 0;
-		const selections = ["Automatic-work limit", "Set a custom limit…", undefined];
+		const selections = ["Automatic-work limit", "Set response limit…", undefined];
 		const context = createMockContext({
 			hasUI: true,
 			mode: "tui",
 			select: async () => selections.shift(),
-			input: async () => "20",
+			editor: async () => "20",
 			confirm: async (_title: string, message: string) => {
 				preview = message;
 				return confirmed;
@@ -569,12 +601,12 @@ test("lowering a reached automatic-work limit previews the immediate pause", asy
 
 test("automatic-work save failure preserves the previous valid setting", async () => {
 	const state = runtime();
-	const selections = ["Automatic-work limit", "Set a custom limit…", undefined];
+	const selections = ["Automatic-work limit", "Set response limit…", undefined];
 	const context = createMockContext({
 		hasUI: true,
 		mode: "tui",
 		select: async () => selections.shift(),
-		input: async () => "40",
+		editor: async () => "40",
 	});
 
 	await showGoalSettings(state, context.ctx, {
@@ -612,9 +644,10 @@ test("automatic-work settings stay readable and keyboard-operable at supported w
 			const lines = tui.render(width);
 			const frame = lines.join(" ").replace(/\s+/gu, " ");
 			assert.ok(lines.every((line) => visibleWidth(line) <= width));
-			assert.match(frame, /25 responses \(default\)/i);
-			assert.match(frame, /Set a custom limit…/i);
+			assert.match(frame, /Set response limit…/i);
+			assert.match(frame, /Default: 25/i);
 			assert.match(frame, /Unlimited…/i);
+			assert.doesNotMatch(frame, /25 responses \(default\)/i);
 		}
 		tui.press("tui.select.cancel");
 		await tui.waitForOpen();
@@ -629,12 +662,12 @@ test("automatic-work settings stay readable and keyboard-operable at supported w
 test("automatic-work editing stops without side effects when its menu is disposed", async () => {
 	const state = runtime();
 	let saves = 0;
-	const selections = ["Automatic-work limit", "Set a custom limit…", undefined];
+	const selections = ["Automatic-work limit", "Set response limit…", undefined];
 	const context = createMockContext({
 		hasUI: true,
 		mode: "tui",
 		select: async () => selections.shift(),
-		input: async () => {
+		editor: async () => {
 			state.closeMenuSession();
 			return "10";
 		},
@@ -655,12 +688,12 @@ test("automatic-work editing rejects a replacement active goal without saving", 
 	const state = runtime();
 	state.activeGoal = createGoal("original", undefined, 0);
 	let saves = 0;
-	const selections = ["Automatic-work limit", "Set a custom limit…", undefined];
+	const selections = ["Automatic-work limit", "Set response limit…", undefined];
 	const context = createMockContext({
 		hasUI: true,
 		mode: "tui",
 		select: async () => selections.shift(),
-		input: async () => {
+		editor: async () => {
 			state.activeGoal = createGoal("replacement", undefined, 0);
 			return "10";
 		},

--- a/extensions/pi-goal/test/settings-ui.test.ts
+++ b/extensions/pi-goal/test/settings-ui.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { GoalCommandController } from "../src/commands.js";
 import { createGoal, GoalRuntime } from "../src/runtime.js";
@@ -434,12 +436,246 @@ test("standard settings keep all five controls on one level", async () => {
 	await showGoalSettings(state, context.ctx, { settingsPath: "/tmp/pi-goal.json" });
 	assert.match(title, /Pi Goal Settings/);
 	assert.deepEqual(options, [
-		"Automatic work",
+		"Automatic-work limit",
 		"No-progress guard",
 		"Goal tools",
 		"Ordered goal queue",
 		"Managed run RPC",
 	]);
+});
+
+test("automatic-work settings can open directly from the safety recovery flow", async () => {
+	const state = runtime();
+	let title = "";
+	let options: string[] = [];
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		select: async (receivedTitle: string, receivedOptions: string[]) => {
+			title = receivedTitle;
+			options = receivedOptions;
+			return undefined;
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		initialScreen: "automatic",
+	});
+
+	assert.match(title, /Automatic-work limit/i);
+	assert.deepEqual(options, ["25 responses (default)", "Set a custom limit…", "Unlimited…"]);
+});
+
+test("automatic-work choices restore the default, support custom limits, and preview Unlimited", async () => {
+	for (const scenario of [
+		{
+			initial: null,
+			choice: "25 responses (default)",
+			expected: 25,
+		},
+		{
+			initial: 25,
+			choice: "Set a custom limit…",
+			input: "40",
+			expected: 40,
+		},
+	] as const) {
+		const state = runtime();
+		state.settings.continuationLimits.automaticTurns = scenario.initial;
+		let saved: GoalSettings | undefined;
+		const selections = ["Automatic-work limit", scenario.choice, undefined];
+		const context = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+			input: async () => ("input" in scenario ? scenario.input : undefined),
+		});
+
+		await showGoalSettings(state, context.ctx, {
+			settingsPath: "/tmp/pi-goal.json",
+			save(settings) {
+				saved = structuredClone(settings);
+			},
+		});
+
+		assert.equal(saved?.continuationLimits.automaticTurns, scenario.expected);
+		assert.equal(state.settings.continuationLimits.automaticTurns, scenario.expected);
+	}
+});
+
+test("Unlimited automatic work requires a concrete confirmation and cancellation changes nothing", async () => {
+	for (const confirmed of [false, true]) {
+		const state = runtime();
+		let confirmation = "";
+		let saves = 0;
+		const selections = ["Automatic-work limit", "Unlimited…", undefined];
+		const context = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+			confirm: async (_title: string, message: string) => {
+				confirmation = message;
+				return confirmed;
+			},
+		});
+
+		await showGoalSettings(state, context.ctx, {
+			settingsPath: "/tmp/pi-goal.json",
+			save() {
+				saves++;
+			},
+		});
+
+		assert.match(confirmation, /tool loops can continue.*without a response-count limit/i);
+		assert.equal(saves, confirmed ? 1 : 0);
+		assert.equal(state.settings.continuationLimits.automaticTurns, confirmed ? null : 25);
+	}
+});
+
+test("lowering a reached automatic-work limit previews the immediate pause", async () => {
+	for (const confirmed of [false, true]) {
+		const state = runtime();
+		state.settings.continuationLimits.automaticTurns = 40;
+		state.activeGoal = createGoal("active objective", undefined, 0);
+		state.activeGoal.automaticModelTurns = 25;
+		let preview = "";
+		let saves = 0;
+		const selections = ["Automatic-work limit", "Set a custom limit…", undefined];
+		const context = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+			input: async () => "20",
+			confirm: async (_title: string, message: string) => {
+				preview = message;
+				return confirmed;
+			},
+		});
+
+		await showGoalSettings(state, context.ctx, {
+			settingsPath: "/tmp/pi-goal.json",
+			save() {
+				saves++;
+			},
+		});
+
+		assert.match(preview, /already used 25.*limit to 20.*pause.*without deleting progress/is);
+		assert.equal(saves, confirmed ? 1 : 0);
+		assert.equal(state.settings.continuationLimits.automaticTurns, confirmed ? 20 : 40);
+		assert.equal(state.activeGoal?.status, confirmed ? "paused" : "active");
+	}
+});
+
+test("automatic-work save failure preserves the previous valid setting", async () => {
+	const state = runtime();
+	const selections = ["Automatic-work limit", "Set a custom limit…", undefined];
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		select: async () => selections.shift(),
+		input: async () => "40",
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			throw new Error("disk full");
+		},
+	});
+
+	assert.equal(state.settings.continuationLimits.automaticTurns, 25);
+	assert.match(context.notifications.at(-1)?.message ?? "", /previous value remains/i);
+});
+
+test("automatic-work settings stay readable and keyboard-operable at supported widths", async () => {
+	const state = runtime();
+	const tui = createTuiHarness({ width: 80, rows: 30 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+
+	try {
+		const running = showGoalSettings(state, context.ctx, {
+			settingsPath: "/tmp/pi-goal.json",
+			save() {},
+		});
+		await tui.waitForOpen();
+		for (const width of [40, 80, 120]) {
+			const lines = tui.render(width);
+			assert.ok(lines.every((line) => visibleWidth(line) <= width));
+			assert.match(lines.join(" "), /Automatic-work limit/i);
+		}
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		for (const width of [40, 80, 120]) {
+			const lines = tui.render(width);
+			const frame = lines.join(" ").replace(/\s+/gu, " ");
+			assert.ok(lines.every((line) => visibleWidth(line) <= width));
+			assert.match(frame, /25 responses \(default\)/i);
+			assert.match(frame, /Set a custom limit…/i);
+			assert.match(frame, /Unlimited…/i);
+		}
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(tui.render().join(" "), /Automatic-work limit/i);
+		tui.press("ctrl+c");
+		await running;
+	} finally {
+		tui.dispose();
+	}
+});
+
+test("automatic-work editing stops without side effects when its menu is disposed", async () => {
+	const state = runtime();
+	let saves = 0;
+	const selections = ["Automatic-work limit", "Set a custom limit…", undefined];
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		select: async () => selections.shift(),
+		input: async () => {
+			state.closeMenuSession();
+			return "10";
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			saves++;
+		},
+	});
+
+	assert.equal(saves, 0);
+	assert.equal(state.settings.continuationLimits.automaticTurns, 25);
+});
+
+test("automatic-work editing rejects a replacement active goal without saving", async () => {
+	const state = runtime();
+	state.activeGoal = createGoal("original", undefined, 0);
+	let saves = 0;
+	const selections = ["Automatic-work limit", "Set a custom limit…", undefined];
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		select: async () => selections.shift(),
+		input: async () => {
+			state.activeGoal = createGoal("replacement", undefined, 0);
+			return "10";
+		},
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			saves++;
+		},
+	});
+
+	assert.equal(saves, 0);
+	assert.equal(state.settings.continuationLimits.automaticTurns, 25);
+	assert.match(context.notifications.at(-1)?.message ?? "", /active goal changed/i);
 });
 
 test("Managed run RPC setting defaults off and saves immediately", async () => {
@@ -545,7 +781,7 @@ test("invalid settings use a standard read-only detail screen", async () => {
 	await showGoalSettings(state, context.ctx, { settingsPath: "/tmp/pi-goal.json" });
 	assert.match(title, /Read only/i);
 	assert.match(title, /Invalid settings file/i);
-	assert.match(title, /Automatic work: Unlimited/i);
+	assert.match(title, /Automatic-work limit: Up to 25 responses/i);
 	assert.match(title, /Managed run RPC: Off/i);
 });
 

--- a/extensions/pi-goal/test/settings.test.ts
+++ b/extensions/pi-goal/test/settings.test.ts
@@ -14,7 +14,7 @@ import {
 const DEFAULT_GOAL_SETTINGS_DOCUMENT = `${JSON.stringify(DEFAULT_GOAL_SETTINGS, null, 2)}\n`;
 
 test("normalizeGoalSettings applies defaults and accepts bounded continuation limits", () => {
-	assert.equal(DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns, null);
+	assert.equal(DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns, 25);
 	assert.deepEqual(DEFAULT_GOAL_SETTINGS.rpc, { enabled: false });
 	assert.deepEqual(normalizeGoalSettings({}), DEFAULT_GOAL_SETTINGS);
 	assert.deepEqual(normalizeGoalSettings({ futureOption: true }), DEFAULT_GOAL_SETTINGS);
@@ -49,7 +49,7 @@ test("normalizeGoalSettings applies defaults and accepts bounded continuation li
 	});
 	assert.deepEqual(normalizeGoalSettings({ continuationLimits: { noProgressTurns: 2 } }), {
 		...DEFAULT_GOAL_SETTINGS,
-		continuationLimits: { automaticTurns: null, noProgressTurns: 2 },
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 2 },
 	});
 	assert.deepEqual(
 		normalizeGoalSettings({
@@ -176,7 +176,7 @@ test("readGoalSettings distinguishes missing, loaded, malformed, and unreadable 
 			toolVisibility: "after-first-goal",
 			experimental: { goals: true },
 			rpc: { enabled: false },
-			continuationLimits: { automaticTurns: null, noProgressTurns: 3 },
+			continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
 		},
 	});
 


### PR DESCRIPTION
## Summary

- restore the built-in automatic-work limit to 25 responses while preserving explicit finite and `null` settings
- expose automatic-work progress in the manager, summaries, notifications, and statusline
- add a guided hard-cap recovery flow with preserved-state details, a concrete Continue preview, and direct limit editing
- require confirmation for Unlimited mode and retain atomic rollback, stale-session, and cancellation safeguards
- update user documentation, responsive TUI coverage, and lifecycle compatibility tests

Related context: #338.

## Verification

- `npm run check --workspace @narumitw/pi-goal`
- all 286 compiled `pi-goal` tests
- `npm run test:runtime --workspace @narumitw/pi-goal`
- `just pack goal` (dry-run contents inspected)
- `npm run check` in a normal local clone (2,399 tests passed; formatter, boundaries, workspace typechecks, and tests)
