### PR TITLE
feat(pi-goal): add friendly token budget input

### DIFF
--- a/docs/plans/2026-08-04_pi-goal-friendly-token-budget-input-plan.md
+++ b/docs/plans/2026-08-04_pi-goal-friendly-token-budget-input-plan.md
@@ -1,0 +1,160 @@
+# Pi Goal friendly token-budget input plan
+
+## Goal
+
+Make the TUI path for starting a Goal with a token budget understandable without requiring users to
+remember compact-number syntax, while preserving exact custom input, safe cancellation, the existing
+increase-and-resume safeguards, and all direct-command and persisted-state compatibility.
+
+## Context
+
+The current **Start with token budget…** path collects the objective first, then opens a generic
+`Token budget` input with only `100k` as a placeholder. The UI does not explain accepted formats,
+cumulative-token semantics, one-call overshoot, the independent automatic-work response limit, or
+that this is not a dollar-cost cap. Invalid input reopens the generic prompt without retaining the
+entered draft, and cancelling the budget prompt closes the manager.
+
+`parseTokenBudget()` currently accepts positive safe values written as full numbers or
+case-insensitive decimal `k`/`m` forms, including `300000`, `300k`, `2.5k`, and `1.5m`. The direct
+`/goal --tokens` route, goal persistence format, budget accounting, one-call overshoot behavior, and
+automatic-work limit are existing public contracts.
+
+The proposed start flow is:
+
+1. Choose `25k`, `100k` (suggested), `300k`, or **Set a custom budget…**.
+2. Show the cumulative-token, overshoot, cost, and current automatic-work-limit context.
+3. For custom input, keep invalid drafts available for correction and show concrete examples.
+4. Open the objective editor with the selected budget visible; submitting starts the Goal, while
+   cancellation returns without creating or replacing a Goal.
+
+The secondary **Increase budget and resume…** path should reuse the clearer custom-input language,
+show current budget and usage, preserve its exact confirmation, and continue rejecting stale goal
+state after asynchronous dialogs.
+
+## Architecture
+
+- Keep workflow ownership in `extensions/pi-goal/src/menu.ts`; use declarative
+  `@narumitw/pi-tui-kit` action/input screens rather than adding a bespoke component. The published
+  input-screen API begins at `@narumitw/pi-tui-kit` 0.46.0, so pi-goal must raise its reviewed
+  compatibility floor from 0.40.0 to 0.46.0 and update the root lockfile.
+- Hold selected start-budget values and custom-input drafts only in the current manager invocation.
+  Do not persist or apply a budget until `GoalCommandController.startGoal()` accepts the objective.
+- Return rejected custom-input actions to the same input screen so the kit preserves the TUI draft;
+  return Escape to the budget chooser and Ctrl+C to close the manager.
+- Read the effective `continuationLimits.automaticTurns` when rendering budget context so finite and
+  Unlimited automatic work are distinguished without coupling the two limits.
+- Keep `parseTokenBudget()` as the canonical parser and retain its accepted syntax and numeric
+  normalization. Do not add a second parser for presets or TUI input.
+- Keep `GoalCommandController` responsible for replacement confirmation, activation rollback,
+  persistence, and prompt delivery. Extend success feedback only with the selected token-budget
+  state; do not duplicate activation logic in the menu.
+- Revalidate manager generation, active-goal identity, current usage, component disposal, session
+  replacement, and shutdown after each asynchronous editor/input/confirmation boundary before
+  starting, replacing, increasing, or resuming a Goal.
+
+## Non-Goals
+
+- Do not add a dollar-cost cap, provider-balance query, or cost estimate.
+- Do not change token accounting, budget exhaustion, overshoot, response-cap, or no-progress logic.
+- Do not change the unbudgeted **Start a goal…** path or add a redundant **No budget** row.
+- Do not change `/goal --tokens`, parser syntax, stored Goal/settings schemas, or unknown-field
+  preservation.
+- Do not introduce a custom TUI component when the kit's action and input screens satisfy the flow.
+
+## Assumptions
+
+- `100k` remains a suggestion rather than a default because an ordinary Goal has no token budget.
+- The initial preset proposal is `25k`, `100k`, and `300k`; no usage telemetry currently validates
+  task-size labels or conversion impact.
+- Supported responsive verification remains the package's established 40-, 80-, and 120-column TUI
+  harness widths. Pi terminal UI has no Web ARIA surface, so accessibility evidence is textual
+  hierarchy, non-color-only meaning, keyboard operation, focus/IME forwarding, and bounded output.
+
+## Unknowns
+
+- None. The implementation goal explicitly approved the plan's `25k` / `100k` / `300k` presets,
+  budget-before-objective order, and objective-submit-as-Apply behavior.
+
+## Risks
+
+- Presets can imply unsupported cost or task-duration guarantees; use neutral ceiling language and
+  state that token usage is cumulative, may overshoot by one model call, and is not a dollar cap.
+- Moving budget selection before objective entry changes TUI ordering; keep direct routes unchanged
+  and test Back/Escape behavior so the change does not strand or silently discard applied state.
+- Menu-owned drafts can become stale while dialogs are open; reuse the existing generation and
+  active-goal guards and test replacement/disposal races.
+- Long helper text can overflow narrow terminals; rely on kit wrapping and verify every rendered line
+  by terminal-cell width at 40, 80, and 120 columns.
+
+## Plan
+
+- [x] Obtain explicit approval for the `25k` / `100k` / `300k` presets, budget-before-objective flow,
+      and objective-submit-as-Apply behavior; the active implementation goal approved the plan and
+      the resolved decision is recorded under Unknowns.
+- [x] Add red-first interaction tests in `extensions/pi-goal/test/menu.test.ts` for the start-budget
+      chooser, exact preset labels/context, custom-input examples, accepted compact/full formats,
+      invalid-draft retention, Back/Escape/Ctrl+C, objective cancellation, and successful start;
+      the initial focused run failed on the missing chooser/custom guidance, and the updated focused
+      menu suite passes 28/28 tests.
+- [x] Refactor the start-budget route in `extensions/pi-goal/src/menu.ts` into shallow declarative
+      chooser and custom-input screens with menu-owned draft state; preset and custom integration
+      tests prove exact normalized budgets apply only after objective submission and cancellation
+      leaves Goal state unchanged.
+- [x] Extend `extensions/pi-goal/test/menu.test.ts` with finite/Unlimited automatic-work context,
+      manager/session disposal, replacement during an awaited dialog, and 40/80/120-column
+      keyboard/focus rendering cases; the focused TUI harness passes without overflow, lost draft, or
+      stale mutation.
+- [x] Update the increase-and-resume input path in `extensions/pi-goal/src/menu.ts` to show current
+      budget, current usage, accepted-format examples, and the exact required lower bound while
+      retaining its existing preview confirmation; focused tests pass for confirmation,
+      cancellation, invalid/lower values, exact non-round usage, replacement, changed usage,
+      immediate resume, and the maximum-safe-integer disabled state.
+- [x] Update start feedback in `extensions/pi-goal/src/commands.ts` only as needed to report the exact
+      selected cumulative token budget alongside the finite or Unlimited automatic-work state;
+      focused command tests pass for budgeted and no-budget starts, while existing rollback coverage
+      remains in the package suite.
+- [x] Preserve parser and direct-route compatibility in `extensions/pi-goal/src/command.ts` and its
+      tests, adding representative assertions for `300000`, `300k`, `2.5k`, and `1.5m`; focused tests
+      pass for those forms plus malformed, zero, negative, non-finite, and unsafe values.
+- [x] Raise `extensions/pi-goal/package.json`'s `@narumitw/pi-tui-kit` floor to published version
+      `^0.46.0` and update `package-lock.json`; pinned npm 12.0.2 under Node 22 changed only the intended
+      nested dependency, package checks pass, and `just pack goal` contains the declared source,
+      README, manifest, and notices.
+- [x] Update `extensions/pi-goal/README.md` with presets, custom syntax examples, cumulative-token and
+      one-call-overshoot semantics, independent automatic-work limits, cancellation/navigation, and
+      the cost-cap distinction; reviewed labels and direct routes match production.
+- [x] Audit the completed diff against `docs/extension-conventions.md` and
+      `docs/extension-settings.md` for TUI bounds, keyboard/focus/IME behavior, asynchronous
+      lifecycle guards, cancellation, runtime rollback, compatibility, and documentation; the menu
+      uses published kit 0.46 input screens, revalidates menu/queue/goal/usage/status ownership after
+      awaits, retains existing command rollback, and has no accepted convention deviation.
+- [ ] Run `npm run check --workspace @narumitw/pi-goal`, all compiled pi-goal tests,
+      `npm run test:runtime --workspace @narumitw/pi-goal`, and root `npm run check`; if the known
+      linked-worktree-only pi-sync Git-environment fixture recurs, rerun the exact commit in a normal
+      clone and retain both results as evidence.
+- [ ] Commit the bounded implementation on `feat/pi-goal-friendly-token-budget-input`, push the new
+      branch, and open a PR against `main`; verify the PR points to the pushed commit, has no unresolved
+      review threads introduced by the change, and all required GitHub checks pass.
+
+## Completion Checklist
+
+- [x] The start-budget chooser exposes exactly three approved presets, one custom route, and Back,
+      with no redundant no-budget option; focused menu assertions prove the exact action list.
+- [x] Custom input explains accepted syntax, preserves invalid drafts, and normalizes through the
+      existing parser without changing its public contract; parser and TUI draft tests pass.
+- [x] The UI distinguishes cumulative token budget, possible one-call overshoot, automatic response
+      cap, and dollar cost in every decision-relevant screen; finite and Unlimited tests pass.
+- [x] Preset/custom selection remains provisional until objective submission; cancellation,
+      disposal, replacement, and shutdown have no unintended side effects in lifecycle tests.
+- [x] Increase-and-resume preserves current state, exact preview/confirmation, stale-state rejection,
+      failure rollback, and immediate success feedback; focused and existing delivery tests pass.
+- [x] TUI output is bounded and readable at 40, 80, and 120 columns; arrows, Enter, Escape, Ctrl+C,
+      focus restoration, and IME forwarding remain operable without color-only meaning in the TUI
+      harness and published kit component contract.
+- [x] Direct `/goal --tokens`, unbudgeted starts, parser syntax, persisted data, settings unknown
+      fields, and existing token-accounting semantics remain backward compatible; all 295 compiled
+      pi-goal tests pass.
+- [ ] README behavior, focused tests, package/runtime checks, root CI-equivalent verification, pushed
+      PR state, and GitHub checks all match the final implementation.
+- [ ] After every item above has evidence, archive this plan under `docs/plans/archived/` without
+      overwriting an existing file and report the archived path.

--- a/docs/plans/archived/2026-08-04_pi-goal-friendly-token-budget-input-plan.md
+++ b/docs/plans/archived/2026-08-04_pi-goal-friendly-token-budget-input-plan.md
@@ -128,13 +128,16 @@ state after asynchronous dialogs.
       lifecycle guards, cancellation, runtime rollback, compatibility, and documentation; the menu
       uses published kit 0.46 input screens, revalidates menu/queue/goal/usage/status ownership after
       awaits, retains existing command rollback, and has no accepted convention deviation.
-- [ ] Run `npm run check --workspace @narumitw/pi-goal`, all compiled pi-goal tests,
-      `npm run test:runtime --workspace @narumitw/pi-goal`, and root `npm run check`; if the known
-      linked-worktree-only pi-sync Git-environment fixture recurs, rerun the exact commit in a normal
-      clone and retain both results as evidence.
-- [ ] Commit the bounded implementation on `feat/pi-goal-friendly-token-budget-input`, push the new
-      branch, and open a PR against `main`; verify the PR points to the pushed commit, has no unresolved
-      review threads introduced by the change, and all required GitHub checks pass.
+- [x] Run `npm run check --workspace @narumitw/pi-goal`, all compiled pi-goal tests,
+      `npm run test:runtime --workspace @narumitw/pi-goal`, and root `npm run check`; package checks,
+      295 pi-goal tests, and the runtime smoke passed. The linked-worktree root run reproduced the
+      known pi-sync Git-environment fixture failure (2,407/2,408), while exact commit
+      `a9f090149d0ea88a035a96fb3fb374fc61a7f6e9` passed all 2,408 tests in a clean normal clone under
+      Node 22 and pinned npm 12.0.2.
+- [x] Commit the bounded implementation on `feat/pi-goal-friendly-token-budget-input`, push the new
+      branch, and open a PR against `main`; PR #553 is open and mergeable at exact pushed commit
+      `a9f090149d0ea88a035a96fb3fb374fc61a7f6e9`, has zero review threads, and CI plus all CodeQL checks
+      pass.
 
 ## Completion Checklist
 
@@ -154,7 +157,8 @@ state after asynchronous dialogs.
 - [x] Direct `/goal --tokens`, unbudgeted starts, parser syntax, persisted data, settings unknown
       fields, and existing token-accounting semantics remain backward compatible; all 295 compiled
       pi-goal tests pass.
-- [ ] README behavior, focused tests, package/runtime checks, root CI-equivalent verification, pushed
-      PR state, and GitHub checks all match the final implementation.
-- [ ] After every item above has evidence, archive this plan under `docs/plans/archived/` without
-      overwriting an existing file and report the archived path.
+- [x] README behavior, focused tests, package/runtime checks, root CI-equivalent verification, pushed
+      PR state, and GitHub checks all match the final implementation and PR #553.
+- [x] After every item above has evidence, archive this plan under `docs/plans/archived/` without
+      overwriting an existing file; archived as
+      `docs/plans/archived/2026-08-04_pi-goal-friendly-token-budget-input-plan.md`.

--- a/extensions/pi-goal/README.md
+++ b/extensions/pi-goal/README.md
@@ -136,9 +136,12 @@ Tool visibility is a baseline, not ownership of Pi's global active-tool list. Pl
   A hard-cap pause opens **Review and continue…**, which states that objective, cumulative usage,
   active time, and queue are preserved and previews that Continue resets the counter to zero and
   allows up to one more configured epoch. **Change automatic-work limit…** opens that setting while
-  leaving the goal paused; Back and Escape make no change. Status, Settings, Help, queue management,
-  invalid-settings guidance, Clear, and Close remain shallow, labeled routes. Arrow keys navigate,
-  Enter selects, Escape goes Back, and Ctrl+C closes the full flow.
+  leaving the goal paused; Back and Escape make no change. **Start with token budget…** first offers
+  `25k`, a suggested `100k`, `300k`, and **Set a custom budget…**, then collects the objective with
+  the selected budget still visible. Custom input accepts examples such as `300000`, `300k`, `2.5k`,
+  and `1.5m`; invalid input retains its draft for correction. Status, Settings, Help, queue
+  management, invalid-settings guidance, Clear, and Close remain shallow, labeled routes. Arrow keys
+  navigate, Enter selects or submits, Escape goes Back, and Ctrl+C closes the full flow.
 - In RPC mode, bare `/goal` and `/goal status` report the current summary through an observable notification without opening terminal UI. Pi exposes no extension-command output channel in print or JSON mode, so those routes reject with an explicit unsupported-mode error instead of misreporting stderr as status output.
 - Menu-driven Replace, Clear, Prioritize, Skip, and Drop last actions preview the exact affected goals and require confirmation. Existing direct routes remain immediate for compatibility and automation.
 - `/goal <goal_to_complete>` starts goal mode. If another unfinished goal exists, Pi asks for confirmation before replacing it with a new active goal and resetting its usage counters. Failed kickoff delivery clears a new goal or restores the prior goal; a previously active goal is restored as paused.
@@ -187,6 +190,14 @@ Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed 
 - `queue off` — retained ordered goals are frozen because `experimental.goals` is disabled.
 
 ## 💰 Token budgets and elapsed time
+
+The TUI budget chooser describes token budgets as cumulative Goal usage, warns that the final model
+call may exceed the chosen value, and keeps the independent automatic-work response limit visible.
+It is not a dollar-cost cap. Choosing a preset or entering a custom value remains provisional until
+the objective is submitted; cancelling the chooser, custom input, or objective editor creates no
+Goal. **Increase budget and resume…** shows the exact current budget and usage, requires a new total
+above current usage, previews the new total plus automatic-work epoch, and resumes only after
+confirmation. If the goal or its usage changes while that dialog is open, no change is applied.
 
 For each persisted assistant message, `pi-goal` uses finite, non-negative `usage.totalTokens` when available. For compatibility with older or partial records, it otherwise sums finite, non-negative `input + output + cacheRead + cacheWrite`. It does not add `reasoning` because reasoning is already part of output, or `cacheWrite1h` because that is a subset of cache writes. Goal usage is the current branch's cumulative assistant total minus the baseline captured when the goal started, clamped at zero after branch rewinds.
 

--- a/extensions/pi-goal/package.json
+++ b/extensions/pi-goal/package.json
@@ -30,7 +30,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"typebox": "^1.3.9"
 	},
 	"peerDependencies": {

--- a/extensions/pi-goal/src/commands.ts
+++ b/extensions/pi-goal/src/commands.ts
@@ -1,4 +1,4 @@
-import { checkpointGoalActiveTime, currentTokenTotal } from "./accounting.js";
+import { checkpointGoalActiveTime, currentTokenTotal, formatTokenCount } from "./accounting.js";
 import { validateObjective } from "./command.js";
 import { safeGoalMenuText } from "./menu.js";
 import type { ActiveGoal } from "./persistence.js";
@@ -46,7 +46,9 @@ export class GoalCommandController {
 		ctx: StatusContext,
 		onActivated?: (goal: ActiveGoal) => void,
 		isActivationCurrent?: (goal: ActiveGoal) => boolean,
+		isRequestCurrent?: () => boolean,
 	) {
+		if (isRequestCurrent && !isRequestCurrent()) return;
 		const validationError = validateObjective(objective);
 		if (validationError) {
 			ctx.ui.notify(validationError, "warning");
@@ -76,6 +78,7 @@ export class GoalCommandController {
 				ctx.ui.notify(`Goal kept: ${existingGoal.text}`, "info");
 				return;
 			}
+			if (isRequestCurrent && !isRequestCurrent()) return;
 			if (
 				goalQueueIdentity(
 					this.runtime.activeGoal,
@@ -90,6 +93,7 @@ export class GoalCommandController {
 
 		// Unlock lazy visibility only for a real activation. In always mode, a
 		// missing tool means another policy or allowlist intentionally removed it.
+		if (isRequestCurrent && !isRequestCurrent()) return;
 		const goalToolVisibilityBeforeActivation = this.runtime.snapshotGoalToolVisibility();
 		try {
 			this.runtime.prepareGoalToolsForActivation(ctx);
@@ -121,7 +125,7 @@ export class GoalCommandController {
 			startedGoal.id,
 			buildGoalPrompt(startedGoal),
 			true,
-			() => isActivationCurrent?.(startedGoal) ?? true,
+			() => (isRequestCurrent?.() ?? true) && (isActivationCurrent?.(startedGoal) ?? true),
 		);
 		if (isActivationCurrent && !isActivationCurrent(startedGoal)) return;
 		if (!sent) {
@@ -163,6 +167,10 @@ export class GoalCommandController {
 		const automaticLimit = this.runtime.settings.continuationLimits.automaticTurns;
 		ctx.ui.notify(
 			`${existingGoal ? "Goal replaced" : "Goal started"}: ${objective}. ${
+				startedGoal.tokenBudget === undefined
+					? ""
+					: `Token budget: ${formatTokenCount(startedGoal.tokenBudget)} cumulative; the final model call may exceed it. `
+			}${
 				automaticLimit === null
 					? "Automatic work is Unlimited; tool loops may consume substantial tokens and provider cost. Open /goal to monitor."
 					: `Automatic work pauses after ${automaticLimit} responses; open /goal to monitor progress.`

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -175,7 +175,7 @@ export async function showGoalManager(
 		owner.menuController === undefined ||
 		(generation === owner.menuGeneration && !owner.menuController.signal.aborted);
 	let displayedGoal: ActiveGoal | undefined;
-	let startBudgetQueueIdentity: string | undefined;
+	let startBudgetQueueIdentity = currentGoalQueueIdentity(runtime);
 	let displayedBudgetGoal: ActiveGoal | undefined;
 	let displayedBudgetValue: number | undefined;
 	let displayedBudgetUsage: number | undefined;
@@ -190,7 +190,7 @@ export async function showGoalManager(
 				refreshGoalMenuState(runtime, ctx);
 				const state = buildGoalMenuState(runtime);
 				displayedGoal = runtime.activeGoal;
-				startBudgetQueueIdentity = undefined;
+				startBudgetQueueIdentity = currentGoalQueueIdentity(runtime);
 				return {
 					kind: "actions",
 					title: "Goal",
@@ -200,7 +200,6 @@ export async function showGoalManager(
 				};
 			},
 			"start-budget": () => {
-				startBudgetQueueIdentity ??= currentGoalQueueIdentity(runtime);
 				return {
 					kind: "actions",
 					title: "Choose token budget",
@@ -641,7 +640,7 @@ async function startBudgetedGoal(
 	ctx: ExtensionCommandContext,
 	budget: number,
 	automaticLimit: number | null,
-	expectedQueueIdentity: string | undefined,
+	expectedQueueIdentity: string,
 	signal: AbortSignal,
 	isMenuCurrent: () => boolean,
 	cancelTransition: "stay" | "back",
@@ -780,10 +779,10 @@ function currentGoalQueueIdentity(runtime: GoalMenuRuntimeView) {
 
 function requireCurrentStartBudgetQueue(
 	runtime: GoalMenuRuntimeView,
-	expectedIdentity: string | undefined,
+	expectedIdentity: string,
 	ctx: ExtensionCommandContext,
 ) {
-	if (expectedIdentity !== undefined && currentGoalQueueIdentity(runtime) === expectedIdentity) {
+	if (currentGoalQueueIdentity(runtime) === expectedIdentity) {
 		return true;
 	}
 	ctx.ui.notify(

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -1,6 +1,6 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { type ActionMenuItem, defineMenu, runMenu } from "@narumitw/pi-tui-kit";
-import { formatDuration } from "./accounting.js";
+import { formatTokenCount as formatCompactTokenCount, formatDuration } from "./accounting.js";
 import { parseTokenBudget } from "./command.js";
 import type { GoalCommandController } from "./commands.js";
 import type { ActiveGoal, PendingQueueAction } from "./persistence.js";
@@ -49,15 +49,24 @@ export interface GoalMenuState {
 }
 
 type ShowSettings = (ctx: ExtensionCommandContext, target?: "automatic") => Promise<void>;
-type GoalMenuScreen = "main" | "safety" | "queue" | "status" | "help";
+type GoalMenuScreen =
+	| "main"
+	| "start-budget"
+	| "start-custom-budget"
+	| "increase-budget"
+	| "safety"
+	| "queue"
+	| "status"
+	| "help";
 type GoalMenuAction =
 	| "start"
-	| "start-budget"
+	| "start-with-budget"
+	| "start-with-custom-budget"
+	| "submit-increase-budget"
 	| "pause"
 	| "resume"
 	| "safety-resume"
 	| "safety-settings"
-	| "increase-budget"
 	| "edit"
 	| "replace"
 	| "settings"
@@ -166,6 +175,11 @@ export async function showGoalManager(
 		owner.menuController === undefined ||
 		(generation === owner.menuGeneration && !owner.menuController.signal.aborted);
 	let displayedGoal: ActiveGoal | undefined;
+	let startBudgetQueueIdentity: string | undefined;
+	let displayedBudgetGoal: ActiveGoal | undefined;
+	let displayedBudgetValue: number | undefined;
+	let displayedBudgetUsage: number | undefined;
+	let displayedBudgetStatus: ActiveGoal["status"] | undefined;
 	let displayedQueueHead: ActiveGoal | undefined;
 	let displayedQueueFirst: ActiveGoal | undefined;
 	let displayedQueueLast: ActiveGoal | undefined;
@@ -176,12 +190,85 @@ export async function showGoalManager(
 				refreshGoalMenuState(runtime, ctx);
 				const state = buildGoalMenuState(runtime);
 				displayedGoal = runtime.activeGoal;
+				startBudgetQueueIdentity = undefined;
 				return {
 					kind: "actions",
 					title: "Goal",
 					lines: state.title.split("\n").slice(1),
 					items: state.actions.map(goalMainMenuItem),
 					hint: "close",
+				};
+			},
+			"start-budget": () => {
+				startBudgetQueueIdentity ??= currentGoalQueueIdentity(runtime);
+				return {
+					kind: "actions",
+					title: "Choose token budget",
+					lines: tokenBudgetGuidance(runtime.settings.continuationLimits.automaticTurns),
+					items: [
+						{
+							id: "25k",
+							label: "25k — Lower token ceiling",
+							description: "Set the cumulative token limit to 25k.",
+							action: "start-with-budget",
+						},
+						{
+							id: "100k",
+							label: "100k — Suggested",
+							description: "Set the cumulative token limit to 100k.",
+							action: "start-with-budget",
+						},
+						{
+							id: "300k",
+							label: "300k — Higher token ceiling",
+							description: "Set the cumulative token limit to 300k.",
+							action: "start-with-budget",
+						},
+						{
+							id: "custom",
+							label: "Set a custom budget…",
+							description: "Enter an exact cumulative token limit.",
+							to: "start-custom-budget",
+						},
+						{ id: "back", label: "Back", action: "back" },
+					],
+					hint: "back",
+				};
+			},
+			"start-custom-budget": () => ({
+				kind: "input",
+				title: "Custom token budget",
+				lines: customTokenBudgetGuidance(runtime.settings.continuationLimits.automaticTurns),
+				placeholder: "100k",
+				action: "start-with-custom-budget",
+				hint: "back",
+			}),
+			"increase-budget": () => {
+				const goal = runtime.activeGoal;
+				displayedBudgetGoal = goal;
+				displayedBudgetValue = goal?.tokenBudget;
+				displayedBudgetUsage = goal?.tokensUsed;
+				displayedBudgetStatus = goal?.status;
+				if (goal && goal.tokensUsed >= Number.MAX_SAFE_INTEGER) {
+					return {
+						kind: "detail",
+						title: "Increase token budget unavailable",
+						lines: [
+							`Current usage: ${formatBudgetDecisionValue(goal.tokensUsed)}`,
+							"No larger safe whole-number token budget is available. Progress remains saved; choose Back and clear or replace the goal when ready.",
+						],
+						hint: "back",
+					};
+				}
+				return {
+					kind: "input",
+					title: "Increase token budget",
+					lines: goal
+						? increaseTokenBudgetGuidance(goal, runtime.settings.continuationLimits.automaticTurns)
+						: ["The budget-limited goal is no longer available. Return to the Goal menu."],
+					placeholder: goal ? suggestedIncreasedBudget(goal) : "300k",
+					action: "submit-increase-budget",
+					hint: "back",
 				};
 			},
 			safety: () => {
@@ -283,8 +370,91 @@ export async function showGoalManager(
 				await startFromMenu(commands, ctx);
 				return { kind: "close" };
 			},
-			"start-budget": async () => {
-				await startFromMenu(commands, ctx, true);
+			"start-with-budget": async ({ itemId, signal }) => {
+				const budget = parseTokenBudget(itemId);
+				if (budget === undefined) return { kind: "rejected" };
+				return startBudgetedGoal(
+					runtime,
+					commands,
+					ctx,
+					budget,
+					runtime.settings.continuationLimits.automaticTurns,
+					startBudgetQueueIdentity,
+					signal,
+					isMenuCurrent,
+					"stay",
+				);
+			},
+			"start-with-custom-budget": async ({ value, signal }) => {
+				const budget = parseTokenBudget(value ?? "");
+				if (budget === undefined) {
+					ctx.ui.notify(
+						"Enter a positive token amount, for example 25k, 300k, or 1.5m.",
+						"warning",
+					);
+					return { kind: "rejected" };
+				}
+				return startBudgetedGoal(
+					runtime,
+					commands,
+					ctx,
+					budget,
+					runtime.settings.continuationLimits.automaticTurns,
+					startBudgetQueueIdentity,
+					signal,
+					isMenuCurrent,
+					"back",
+				);
+			},
+			"submit-increase-budget": async ({ value, signal }) => {
+				const goal = displayedBudgetGoal;
+				const budget = parseTokenBudget(value ?? "");
+				if (budget === undefined) {
+					ctx.ui.notify(
+						"Enter a positive token amount, for example 300k, 1.5m, or 300000.",
+						"warning",
+					);
+					return { kind: "rejected" };
+				}
+				if (
+					!goal ||
+					!requireCurrentBudgetPreview(
+						runtime,
+						goal,
+						displayedBudgetValue,
+						displayedBudgetUsage,
+						displayedBudgetStatus,
+						ctx,
+					)
+				) {
+					return { kind: "close" };
+				}
+				if (budget <= goal.tokensUsed) {
+					ctx.ui.notify(
+						`Enter a new cumulative total greater than current usage (${formatCompactTokenCount(goal.tokensUsed)}).`,
+						"warning",
+					);
+					return { kind: "rejected" };
+				}
+				const confirmed = await ctx.ui.confirm(
+					"Increase goal budget?",
+					increaseBudgetPreview(goal, budget, runtime.settings.continuationLimits.automaticTurns),
+				);
+				if (signal.aborted || !isMenuCurrent()) return { kind: "close" };
+				if (!confirmed) return { kind: "rejected" };
+				if (
+					!requireCurrentBudgetPreview(
+						runtime,
+						goal,
+						displayedBudgetValue,
+						displayedBudgetUsage,
+						displayedBudgetStatus,
+						ctx,
+					)
+				) {
+					return { kind: "close" };
+				}
+				await commands.editGoal(goal.text, budget, ctx);
 				return { kind: "close" };
 			},
 			pause: async () => {
@@ -317,13 +487,6 @@ export async function showGoalManager(
 				if (!isMenuCurrent()) return { kind: "close" };
 				if (!requireCurrentMenuGoal(runtime, expectedGoal, ctx)) return { kind: "stay" };
 				return { kind: "stay" };
-			},
-			"increase-budget": async () => {
-				if (!displayedGoal || !requireCurrentMenuGoal(runtime, displayedGoal, ctx)) {
-					return { kind: "stay" };
-				}
-				await increaseBudget(runtime, commands, ctx);
-				return { kind: "close" };
 			},
 			edit: async () => {
 				if (!displayedGoal || !requireCurrentMenuGoal(runtime, displayedGoal, ctx)) {
@@ -422,6 +585,12 @@ export async function showGoalManager(
 
 function goalMainMenuItem(label: string): ActionMenuItem<GoalMenuScreen, GoalMenuAction> {
 	if (label === GOAL_MENU_ACTIONS.status) return { id: "status", label, to: "status" as const };
+	if (label === GOAL_MENU_ACTIONS.startBudget) {
+		return { id: "start-budget", label, to: "start-budget" as const };
+	}
+	if (label === GOAL_MENU_ACTIONS.increaseBudget) {
+		return { id: "increase-budget", label, to: "increase-budget" as const };
+	}
 	if (label === GOAL_MENU_ACTIONS.reviewSafety) {
 		return { id: "review-safety", label, to: "safety" as const };
 	}
@@ -430,10 +599,8 @@ function goalMainMenuItem(label: string): ActionMenuItem<GoalMenuScreen, GoalMen
 	if (label === GOAL_MENU_ACTIONS.close) return { id: "close", label, close: true as const };
 	const actions = new Map<string, GoalMenuAction>([
 		[GOAL_MENU_ACTIONS.start, "start"],
-		[GOAL_MENU_ACTIONS.startBudget, "start-budget"],
 		[GOAL_MENU_ACTIONS.pause, "pause"],
 		[GOAL_MENU_ACTIONS.resume, "resume"],
-		[GOAL_MENU_ACTIONS.increaseBudget, "increase-budget"],
 		[GOAL_MENU_ACTIONS.edit, "edit"],
 		[GOAL_MENU_ACTIONS.replace, "replace"],
 		[GOAL_MENU_ACTIONS.settings, "settings"],
@@ -462,16 +629,108 @@ export function safeGoalMenuText(value: string, maxCharacters = 120) {
 		: `${characters.slice(0, maxCharacters).join("")}…`;
 }
 
-async function startFromMenu(
-	commands: GoalCommandController,
-	ctx: ExtensionCommandContext,
-	withBudget = false,
-) {
+async function startFromMenu(commands: GoalCommandController, ctx: ExtensionCommandContext) {
 	const objective = (await ctx.ui.editor("Goal objective", ""))?.trim();
 	if (!objective) return;
-	const tokenBudget = withBudget ? await askTokenBudget(ctx) : undefined;
-	if (withBudget && tokenBudget === undefined) return;
-	await commands.startGoal(objective, tokenBudget, ctx);
+	await commands.startGoal(objective, undefined, ctx);
+}
+
+async function startBudgetedGoal(
+	runtime: GoalMenuRuntimeView,
+	commands: GoalCommandController,
+	ctx: ExtensionCommandContext,
+	budget: number,
+	automaticLimit: number | null,
+	expectedQueueIdentity: string | undefined,
+	signal: AbortSignal,
+	isMenuCurrent: () => boolean,
+	cancelTransition: "stay" | "back",
+) {
+	if (!requireCurrentStartBudgetQueue(runtime, expectedQueueIdentity, ctx)) {
+		return { kind: "rejected" as const };
+	}
+	const objective = (
+		await ctx.ui.editor(
+			`Goal objective · Token budget ${formatCompactTokenCount(budget)} · ${automaticLimit === null ? "Automatic Unlimited" : `Automatic limit ${automaticLimit}`}`,
+			"",
+		)
+	)?.trim();
+	if (signal.aborted || !isMenuCurrent()) return { kind: "close" as const };
+	if (!objective) return { kind: cancelTransition } as const;
+	if (!requireCurrentStartBudgetQueue(runtime, expectedQueueIdentity, ctx)) {
+		return { kind: "rejected" as const };
+	}
+	await commands.startGoal(
+		objective,
+		budget,
+		ctx,
+		undefined,
+		() => !signal.aborted && isMenuCurrent(),
+		() => !signal.aborted && isMenuCurrent(),
+	);
+	return { kind: "close" as const };
+}
+
+function tokenBudgetGuidance(automaticLimit: number | null) {
+	return [
+		"Set the maximum cumulative token usage for this goal.",
+		"The final model call may exceed the limit; this is not a dollar-cost cap.",
+		automaticBudgetGuidance(automaticLimit),
+	];
+}
+
+function customTokenBudgetGuidance(automaticLimit: number | null) {
+	return [
+		"Enter the maximum cumulative token usage for this goal.",
+		"Examples: 25k, 300k, 1.5m, or 300000.",
+		"The final model call may exceed this value; this is not a dollar-cost cap.",
+		automaticBudgetGuidance(automaticLimit),
+	];
+}
+
+function automaticBudgetGuidance(automaticLimit: number | null) {
+	return automaticLimit === null
+		? "Automatic work has no response-count cap."
+		: `Automatic work will also pause after ${automaticLimit} responses.`;
+}
+
+function increaseTokenBudgetGuidance(goal: ActiveGoal, automaticLimit: number | null) {
+	return [
+		`Current budget: ${formatBudgetDecisionValue(goal.tokenBudget ?? 0)}`,
+		`Current usage: ${formatBudgetDecisionValue(goal.tokensUsed)}`,
+		`Enter a new cumulative total greater than ${formatBudgetDecisionValue(goal.tokensUsed)}.`,
+		"Examples: 300k, 1.5m, or 300000.",
+		"The final model call may exceed the limit; this is not a dollar-cost cap.",
+		automaticBudgetGuidance(automaticLimit),
+	];
+}
+
+function suggestedIncreasedBudget(goal: ActiveGoal) {
+	const floor = Math.max(goal.tokensUsed, goal.tokenBudget ?? 0);
+	for (const suggestion of [25_000, 100_000, 300_000, 500_000, 1_000_000]) {
+		if (suggestion > floor) return formatCompactTokenCount(suggestion);
+	}
+	return formatCompactTokenCount(
+		Math.min(Number.MAX_SAFE_INTEGER, Math.max(Math.floor(floor) + 1, Math.ceil(floor * 2))),
+	);
+}
+
+function formatBudgetDecisionValue(value: number) {
+	const compact = formatCompactTokenCount(value);
+	if (value < 1_000 || value % 1_000 === 0) return compact;
+	return `${compact} (${formatInteger(value)} tokens)`;
+}
+
+function increaseBudgetPreview(goal: ActiveGoal, budget: number, automaticLimit: number | null) {
+	return [
+		`Goal: ${safeGoalMenuText(goal.text, 4_000)}`,
+		`Budget: ${formatCompactTokenCount(goal.tokenBudget ?? 0)} → ${formatCompactTokenCount(budget)}`,
+		`Current usage: ${formatCompactTokenCount(goal.tokensUsed)}`,
+		automaticLimit === null
+			? "Automatic work: Unlimited after resume"
+			: `Automatic work: up to ${automaticLimit} more responses after resume`,
+		"The goal will resume immediately.",
+	].join("\n");
 }
 
 async function editFromMenu(
@@ -494,42 +753,6 @@ async function editFromMenu(
 	await commands.editGoal(objective, undefined, ctx);
 }
 
-async function increaseBudget(
-	runtime: GoalMenuRuntimeView,
-	commands: GoalCommandController,
-	ctx: ExtensionCommandContext,
-) {
-	const goal = runtime.activeGoal;
-	if (!goal) return;
-	const budget = await askTokenBudget(ctx, goal.tokenBudget);
-	if (budget === undefined || !requireCurrentMenuGoal(runtime, goal, ctx)) return;
-	if (budget <= goal.tokensUsed) {
-		ctx.ui.notify(
-			`Token budget must be greater than current usage (${formatTokenCount(goal.tokensUsed)}).`,
-			"warning",
-		);
-		return;
-	}
-	const confirmed = await ctx.ui.confirm(
-		"Increase goal budget?",
-		`Goal: ${safeGoalMenuText(goal.text, 4_000)}\n\nBudget: ${formatTokenCount(goal.tokenBudget ?? 0)} → ${formatTokenCount(budget)}\nCurrent usage: ${formatTokenCount(goal.tokensUsed)}\n\nThe goal will resume immediately.`,
-	);
-	if (!confirmed || !requireCurrentMenuGoal(runtime, goal, ctx)) return;
-	await commands.editGoal(goal.text, budget, ctx);
-}
-
-async function askTokenBudget(ctx: ExtensionCommandContext, current?: number) {
-	const raw = await ctx.ui.input(
-		"Token budget",
-		current === undefined ? "100k" : formatTokenCount(current),
-	);
-	if (raw === undefined) return undefined;
-	const budget = parseTokenBudget(raw);
-	if (budget === undefined)
-		ctx.ui.notify(`Invalid token budget: ${safeGoalMenuText(raw)}`, "warning");
-	return budget;
-}
-
 async function confirmClear(runtime: GoalMenuRuntimeView, ctx: ExtensionCommandContext) {
 	const goals = [runtime.activeGoal, ...runtime.queuedGoals].filter(
 		(goal): goal is ActiveGoal => goal !== undefined,
@@ -549,6 +772,49 @@ async function confirmClear(runtime: GoalMenuRuntimeView, ctx: ExtensionCommandC
 			.map((summary, index) => `${index + 1}. ${summary}`)
 			.join("\n")}\n\nThis cannot be undone.`,
 	);
+}
+
+function currentGoalQueueIdentity(runtime: GoalMenuRuntimeView) {
+	return goalQueueIdentity(runtime.activeGoal, runtime.queuedGoals, runtime.pendingQueueAction);
+}
+
+function requireCurrentStartBudgetQueue(
+	runtime: GoalMenuRuntimeView,
+	expectedIdentity: string | undefined,
+	ctx: ExtensionCommandContext,
+) {
+	if (expectedIdentity !== undefined && currentGoalQueueIdentity(runtime) === expectedIdentity) {
+		return true;
+	}
+	ctx.ui.notify(
+		"The goal queue changed while the token budget flow was open. Reopen /goal and try again.",
+		"warning",
+	);
+	return false;
+}
+
+function requireCurrentBudgetPreview(
+	runtime: GoalMenuRuntimeView,
+	expectedGoal: ActiveGoal,
+	expectedBudget: number | undefined,
+	expectedUsage: number | undefined,
+	expectedStatus: ActiveGoal["status"] | undefined,
+	ctx: ExtensionCommandContext,
+) {
+	const current = runtime.activeGoal;
+	if (
+		current?.id === expectedGoal.id &&
+		current.tokenBudget === expectedBudget &&
+		current.tokensUsed === expectedUsage &&
+		current.status === expectedStatus
+	) {
+		return true;
+	}
+	ctx.ui.notify(
+		"The goal changed or its usage changed while the budget dialog was open. Reopen /goal and try again.",
+		"warning",
+	);
+	return false;
 }
 
 function requireCurrentQueueHead(

--- a/extensions/pi-goal/test/goal.test.ts
+++ b/extensions/pi-goal/test/goal.test.ts
@@ -1602,9 +1602,15 @@ test("legacy active-time state migrates without counting offline or reload time"
 
 test("parseTokenBudget and format helpers use compact units", () => {
 	assert.equal(parseTokenBudget("250"), 250);
+	assert.equal(parseTokenBudget("300000"), 300_000);
+	assert.equal(parseTokenBudget("300k"), 300_000);
 	assert.equal(parseTokenBudget("2.5k"), 2500);
+	assert.equal(parseTokenBudget("1.5m"), 1_500_000);
 	assert.equal(parseTokenBudget("0"), undefined);
 	assert.equal(parseTokenBudget("0.1"), undefined);
+	assert.equal(parseTokenBudget("-1"), undefined);
+	assert.equal(parseTokenBudget("Infinity"), undefined);
+	assert.equal(parseTokenBudget("many"), undefined);
 	assert.equal(parseTokenBudget("9007199254740992"), undefined);
 	assert.equal(parseTokenBudget(String(Number.MAX_SAFE_INTEGER)), Number.MAX_SAFE_INTEGER);
 	assert.equal(formatTokenCount(1500), "1.5k");
@@ -1663,6 +1669,17 @@ test("goal start feedback exposes the default cap and explicit Unlimited mode", 
 		/automatic work pauses after 25 responses/i,
 	);
 	assert.match(capped.notifications.at(-1)?.message ?? "", /open \/goal to monitor/i);
+	assert.doesNotMatch(capped.notifications.at(-1)?.message ?? "", /Token budget:/i);
+
+	const budgeted = await startGoalForTest({}, "--tokens 100k budgeted objective");
+	assert.match(
+		budgeted.notifications.at(-1)?.message ?? "",
+		/Token budget: 100k cumulative.*final model call may exceed/is,
+	);
+	assert.match(
+		budgeted.notifications.at(-1)?.message ?? "",
+		/automatic work pauses after 25 responses/i,
+	);
 
 	const unlimited = await startGoalForTest({}, "unbounded objective", UNLIMITED_SETTINGS_PATH);
 	assert.match(unlimited.notifications.at(-1)?.message ?? "", /automatic work is Unlimited/i);

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -96,6 +96,182 @@ test("buildGoalMenuState prioritizes actions for empty, active, stopped, budget,
 	]);
 });
 
+test("start with token budget offers presets before collecting the objective", async () => {
+	for (const automaticLimit of [25, null] as const) {
+		const state = runtime();
+		state.settings.continuationLimits.automaticTurns = automaticLimit;
+		const tracked = commands();
+		const selections = [GOAL_MENU_ACTIONS.startBudget, "100k — Suggested"];
+		let chooserTitle = "";
+		let chooserOptions: string[] = [];
+		let editorTitle = "";
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async (title: string, options: string[]) => {
+				if (/Choose token budget/i.test(title)) {
+					chooserTitle = title;
+					chooserOptions = options;
+				}
+				return selections.shift();
+			},
+			editor: async (title: string) => {
+				editorTitle = title;
+				return "ship the release";
+			},
+		});
+
+		await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+		assert.deepEqual(chooserOptions, [
+			"25k — Lower token ceiling",
+			"100k — Suggested",
+			"300k — Higher token ceiling",
+			"Set a custom budget…",
+			"Back",
+		]);
+		assert.match(chooserTitle, /maximum cumulative token usage/i);
+		assert.match(chooserTitle, /final model call may exceed/i);
+		assert.match(chooserTitle, /not a dollar-cost cap/i);
+		assert.match(
+			chooserTitle,
+			automaticLimit === null
+				? /automatic work has no response-count cap/i
+				: /automatic work will also pause after 25 responses/i,
+		);
+		assert.match(editorTitle, /Goal objective.*Token budget 100k/i);
+		assert.match(
+			editorTitle,
+			automaticLimit === null ? /Automatic Unlimited/i : /Automatic limit 25/i,
+		);
+		assert.equal(tracked.calls[0]?.name, "startGoal");
+		assert.deepEqual(tracked.calls[0]?.args.slice(0, 2), ["ship the release", 100_000]);
+	}
+});
+
+test("custom start budget explains formats and uses the canonical parser", async () => {
+	const state = runtime();
+	const tracked = commands();
+	const selections = [GOAL_MENU_ACTIONS.startBudget, "Set a custom budget…"];
+	const entered = ["not-a-budget", "1.5m"];
+	let inputTitle = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => selections.shift(),
+		input: async (title: string) => {
+			inputTitle = title;
+			return entered.shift();
+		},
+		editor: async () => "custom-budget objective",
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+	assert.match(inputTitle, /maximum cumulative token usage/i);
+	assert.match(inputTitle, /Examples: 25k, 300k, 1\.5m, or 300000/i);
+	assert.match(context.notifications[0]?.message ?? "", /positive token amount.*25k.*300k.*1\.5m/i);
+	assert.equal(tracked.calls[0]?.name, "startGoal");
+	assert.deepEqual(tracked.calls[0]?.args.slice(0, 2), ["custom-budget objective", 1_500_000]);
+});
+
+test("budgeted start cancellation and stale menu ownership have no side effects", async () => {
+	for (const scenario of ["objective-cancel", "goal-replaced", "menu-disposed"] as const) {
+		const state = runtime();
+		const tracked = commands();
+		const selections = [GOAL_MENU_ACTIONS.startBudget, "25k — Lower token ceiling"];
+		const menuController = new AbortController();
+		if (scenario === "menu-disposed") {
+			Object.assign(state, { menuGeneration: 1, menuController });
+		}
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async () => selections.shift(),
+			editor: async () => {
+				if (scenario === "goal-replaced") {
+					state.activeGoal = createGoal("replacement objective", undefined, 0);
+				}
+				if (scenario === "menu-disposed") menuController.abort();
+				return scenario === "objective-cancel" ? undefined : "new objective";
+			},
+		});
+
+		await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+		assert.equal(tracked.calls.length, 0);
+		if (scenario === "goal-replaced") {
+			assert.match(context.notifications.at(-1)?.message ?? "", /goal queue changed.*reopen/i);
+		}
+	}
+});
+
+test("custom budget input retains invalid drafts and stays responsive", async () => {
+	const state = runtime();
+	const tracked = commands();
+	const tui = createTuiHarness({ width: 80, rows: 30 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+
+	try {
+		const running = showGoalManager(
+			state,
+			tracked.controller as never,
+			context.ctx,
+			async () => undefined,
+		);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		for (const width of [40, 80, 120]) {
+			const lines = tui.render(width);
+			const frame = lines.join(" ").replace(/\s+/gu, " ");
+			assert.ok(lines.every((line) => visibleWidth(line) <= width));
+			assert.match(frame, /Choose token budget/i);
+			assert.match(frame, /25k — Lower token ceiling/i);
+			assert.match(frame, /100k — Suggested/i);
+			assert.match(frame, /300k — Higher token ceiling/i);
+			assert.match(frame, /Set a custom budget…/i);
+			assert.match(frame, /Back/i);
+		}
+
+		for (let index = 0; index < 3; index++) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(tui.isFocusable, true);
+		for (const width of [40, 80, 120]) {
+			const lines = tui.render(width);
+			const frame = lines.join(" ").replace(/\s+/gu, " ");
+			assert.ok(lines.every((line) => visibleWidth(line) <= width));
+			assert.match(frame, /Custom token budget/i);
+			assert.match(frame, /Examples: 25k, 300k, 1\.5m, or 300000/i);
+		}
+		tui.type("invalid");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		assert.match(tui.render().join(" "), /invalid/i);
+		assert.match(context.notifications.at(-1)?.message ?? "", /positive token amount/i);
+		tui.press("tui.select.cancel");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join(" "), /Choose token budget/i);
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join(" "), /Custom token budget/i);
+		tui.press("tui.select.cancel");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(tracked.calls.length, 0);
+	} finally {
+		tui.dispose();
+	}
+});
+
 test("hard-cap pause names the cause and prioritizes review over immediate resume", () => {
 	const goal = transitionGoal(createGoal("preserve this objective", undefined, 0), "paused");
 	goal.automaticModelTurns = 25;
@@ -371,24 +547,140 @@ test("clear preview includes a pending priority objective", async () => {
 	assert.equal(tracked.calls.length, 0);
 });
 
+test("increase budget input shows current usage and confirms the exact resume effect", async () => {
+	const goal = transitionGoal(createGoal("increase safely", 100_000, 0), "budget_limited");
+	goal.tokensUsed = 108_000;
+	const state = runtime(goal);
+	const tracked = commands();
+	const selections = [GOAL_MENU_ACTIONS.increaseBudget];
+	let inputTitle = "";
+	let confirmation = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => selections.shift(),
+		input: async (title: string) => {
+			inputTitle = title;
+			return "300k";
+		},
+		confirm: async (_title: string, message: string) => {
+			confirmation = message;
+			return true;
+		},
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+	assert.match(inputTitle, /Current budget: 100k/i);
+	assert.match(inputTitle, /Current usage: 108k/i);
+	assert.match(inputTitle, /new cumulative total greater than 108k/i);
+	assert.match(inputTitle, /Examples: 300k, 1\.5m, or 300000/i);
+	assert.match(confirmation, /Budget: 100k → 300k/i);
+	assert.match(confirmation, /Current usage: 108k/i);
+	assert.match(confirmation, /Automatic work: up to 25 more responses after resume/i);
+	assert.match(confirmation, /resume immediately/i);
+	assert.equal(tracked.calls[0]?.name, "editGoal");
+	assert.deepEqual(tracked.calls[0]?.args.slice(0, 2), ["increase safely", 300_000]);
+});
+
+test("increase budget validation and confirmation cancellation preserve the stopped goal", async () => {
+	for (const scenario of ["invalid-total", "confirmation-cancel"] as const) {
+		const goal = transitionGoal(createGoal("keep stopped", 100_000, 0), "budget_limited");
+		goal.tokensUsed = 108_000;
+		const state = runtime(goal);
+		const tracked = commands();
+		const entered = scenario === "invalid-total" ? ["100k", undefined] : ["300k", undefined];
+		const selections = [GOAL_MENU_ACTIONS.increaseBudget, GOAL_MENU_ACTIONS.close];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async () => selections.shift(),
+			input: async () => entered.shift(),
+			confirm: async () => false,
+		});
+
+		await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+		assert.equal(tracked.calls.length, 0);
+		assert.equal(state.activeGoal, goal);
+		assert.equal(state.activeGoal?.status, "budget_limited");
+		if (scenario === "invalid-total") {
+			assert.match(context.notifications[0]?.message ?? "", /greater than current usage.*108k/i);
+		}
+	}
+});
+
+test("increase budget becomes read-only when no larger safe integer exists", async () => {
+	const goal = transitionGoal(
+		createGoal("maximum safe budget", Number.MAX_SAFE_INTEGER, 0),
+		"budget_limited",
+	);
+	goal.tokensUsed = Number.MAX_SAFE_INTEGER;
+	const state = runtime(goal);
+	const tracked = commands();
+	let title = "";
+	const selections = [GOAL_MENU_ACTIONS.increaseBudget, undefined, GOAL_MENU_ACTIONS.close];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async (receivedTitle: string) => {
+			if (/Increase token budget unavailable/i.test(receivedTitle)) title = receivedTitle;
+			return selections.shift();
+		},
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+	assert.match(title, /Increase token budget unavailable/i);
+	assert.match(title, /No larger safe whole-number token budget/i);
+	assert.equal(tracked.calls.length, 0);
+});
+
+test("increase budget rejects goal state that changes while confirmation is open", async () => {
+	for (const changed of ["usage", "status"] as const) {
+		const goal = transitionGoal(createGoal("changing state", 100_000, 0), "budget_limited");
+		goal.tokensUsed = 108_000;
+		const state = runtime(goal);
+		const tracked = commands();
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async () => GOAL_MENU_ACTIONS.increaseBudget,
+			input: async () => "300k",
+			confirm: async () => {
+				if (changed === "usage") goal.tokensUsed = 109_000;
+				else goal.status = "paused";
+				return true;
+			},
+		});
+
+		await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+		assert.equal(tracked.calls.length, 0);
+		assert.match(context.notifications.at(-1)?.message ?? "", /goal changed|usage changed/i);
+		assert.match(context.notifications.at(-1)?.message ?? "", /reopen/i);
+	}
+});
+
 test("menu preserves exact token values in status and budget input", async () => {
 	const goal = transitionGoal(createGoal("precise budget", 10_500, 0), "budget_limited");
 	goal.tokensUsed = 10_499;
 	const state = runtime(goal);
 	assert.match(buildGoalMenuState(state).title, /10499\/10500/);
-	let placeholder = "";
+	let inputTitle = "";
 	const tracked = commands();
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
 		select: async () => GOAL_MENU_ACTIONS.increaseBudget,
-		input: async (_title: string, value: string) => {
-			placeholder = value;
+		input: async (title: string) => {
+			inputTitle = title;
 			return undefined;
 		},
 	});
 	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
-	assert.equal(placeholder, "10500");
+	assert.match(inputTitle, /Current budget: 10\.5k \(10,500 tokens\)/i);
+	assert.match(inputTitle, /Current usage: 10\.5k \(10,499 tokens\)/i);
 	assert.equal(tracked.calls.length, 0);
 });
 

--- a/extensions/pi-goal/test/menu.test.ts
+++ b/extensions/pi-goal/test/menu.test.ts
@@ -206,6 +206,35 @@ test("budgeted start cancellation and stale menu ownership have no side effects"
 	}
 });
 
+test("budgeted start rejects a queue that changes before the budget chooser opens", async () => {
+	const state = runtime();
+	const tracked = commands();
+	let editorOpened = false;
+	let selectionCount = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => {
+			selectionCount++;
+			if (selectionCount === 1) {
+				state.activeGoal = createGoal("new current goal", undefined, 0);
+				return GOAL_MENU_ACTIONS.startBudget;
+			}
+			return selectionCount === 2 ? "25k — Lower token ceiling" : undefined;
+		},
+		editor: async () => {
+			editorOpened = true;
+			return "must not start";
+		},
+	});
+
+	await showGoalManager(state, tracked.controller as never, context.ctx, async () => undefined);
+
+	assert.equal(editorOpened, false);
+	assert.equal(tracked.calls.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /goal queue changed.*reopen/i);
+});
+
 test("custom budget input retains invalid drafts and stays responsive", async () => {
 	const state = runtime();
 	const tracked = commands();

--- a/package-lock.json
+++ b/package-lock.json
@@ -344,7 +344,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
@@ -360,9 +360,9 @@
 			}
 		},
 		"extensions/pi-goal/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",


### PR DESCRIPTION
## Summary

- add 25k, suggested 100k, and 300k presets before collecting a budgeted Goal objective
- add draft-preserving custom budget input with accepted-format, overshoot, cost-cap, and automatic-work guidance
- harden increase-and-resume previews against stale goal, usage, and status changes
- report selected cumulative budgets in start feedback and document the complete TUI workflow
- raise pi-goal's published pi-tui-kit compatibility floor to 0.46.0 for declarative input screens

## Verification

- `npm run check --workspace @narumitw/pi-goal`
- 295 compiled pi-goal tests
- `npm run test:runtime --workspace @narumitw/pi-goal`
- `just pack goal`
- `npm run check` in a normal clone at `a9f090149d0ea88a035a96fb3fb374fc61a7f6e9` (2,408 tests)

The linked-worktree root run reproduced the known pi-sync Git-environment fixture failure; the exact commit passed the full gate in a normal clone.
