### PR TITLE
perf: converge Pi TUI Kit startup dependency

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -93,7 +93,7 @@
 - Live provider smokes are acceptable when relevant, but stop after one clear external or entitlement failure and fall back to deterministic tests unless the user asks to retry.
 - Keep a predecessor extension active while its successor soaks; deprecate it only after an explicit follow-up decision.
 - Prefer an executable repository plan before non-trivial implementation, verify it, and archive it when complete.
-- Prefer manually reviewed `pi-tui-kit` dependency-floor changes per consumer; do not automatically synchronize compatibility ranges with the workspace version.
+- Prefer a registry-published `pi-tui-kit` version and manually review dependency-floor changes per consumer; never target an unpublished workspace version or automatically synchronize compatibility ranges.
 - Keep package versions out of long-lived guidance; derive current values from manifests, lockfiles, or workflows unless a version is itself historical compatibility evidence.
 - Keep `just` install recipes resilient: verify registry visibility first and fall back to the local workspace only when it solves the current install path.
 

--- a/docs/plans/2026-08-05_pi-tui-kit-published-startup-convergence-plan.md
+++ b/docs/plans/2026-08-05_pi-tui-kit-published-startup-convergence-plan.md
@@ -1,0 +1,97 @@
+# Pi TUI Kit published-version startup convergence plan
+
+## Goal
+
+Make active extensions resolve one registry-published `@narumitw/pi-tui-kit` version in a clean Pi
+installation, eliminate duplicate runtime copies from startup, and establish a repeatable benchmark
+that distinguishes module-import savings from work merely shifted into session startup.
+
+## Context
+
+- Registry evidence on 2026-08-05 reports `0.46.0` as the newest published Pi TUI Kit version;
+  workspace version `0.48.1` is not published and must not become a consumer dependency floor.
+- Active consumer manifests currently span `^0.40.0`, `^0.41.0`, `^0.42.0`, `^0.45.0`, and
+  `^0.46.0`. Because caret ranges below `1.0.0` do not cross minor versions, a clean install retains
+  several physical copies that Pi evaluates from distinct paths.
+- The workspace symlink can mask accidental use of APIs absent from the published package. Consumer
+  compatibility must therefore be proven in a clean temporary project that resolves Pi TUI Kit from
+  npm, not from `packages/pi-tui-kit`.
+- This plan is the measurement prerequisite for the four package startup plans dated 2026-08-05.
+- Applicable guidance is `docs/extension-conventions.md`; no extension-owned setting behavior changes.
+
+## Architecture
+
+- Treat the npm registry as the consumer compatibility boundary. At execution time, query the latest
+  published version and record it; never substitute the newer workspace version unless it has first
+  been published through a separately approved release.
+- Add one repository startup benchmark under `scripts/` that launches fresh serial Pi RPC processes
+  with isolated temporary agent directories, explicit extension entrypoints, discovered resources
+  disabled, and `PI_OFFLINE=1`. Record per-extension module import, extension total, first successful
+  RPC `get_commands` response latency, median, and median absolute deviation as JSON.
+- Review each consumer independently against the selected published API, then converge compatible
+  manifest ranges on that published minor. Do not coordinate extension runtime behavior through the
+  library or add extension-specific branches to Pi TUI Kit.
+- Validate the physical dependency tree from packed consumer tarballs in a clean temporary npm
+  project. The repository workspace tree is useful for development but is not acceptable evidence
+  for published dependency resolution.
+
+## Non-Goals
+
+- Publish Pi TUI Kit or any extension, change npm visibility, create tags, or dispatch workflows.
+- Automatically synchronize future dependency floors with the workspace package version.
+- Redesign menus, change command behavior, or add new Pi TUI Kit APIs.
+- Claim cold-disk performance; the benchmark measures comparable fresh-process, warm-filesystem runs.
+
+## Risks
+
+- **Workspace masking:** TypeScript can pass against unpublished workspace APIs. Mitigation: compile
+  and load packed consumers against the exact registry package in a clean project.
+- **Broad manifest churn:** every active consumer may be touched. Mitigation: maintain a per-consumer
+  compatibility matrix and pack each changed workspace.
+- **Lockfile churn:** the root requires npm 12.0.2, which is unsupported by the current Node 25
+  runtime. Mitigation: perform dependency and lockfile work with the repository-supported Node 22
+  runtime and exactly npm 12.0.2.
+- **Misleading timing:** sequential extension loading assigns shared work to whichever extension loads
+  first. Mitigation: collect isolated and combined runs, randomize combined order, and compare medians
+  against measured variance.
+
+## Plan
+
+- [ ] Add `scripts/benchmark-extension-startup.mjs` with isolated-agent, offline RPC, serial warm-up
+      and measured runs, randomized combined ordering, JSON output, timeout cleanup, and explicit Pi
+      executable/entrypoint arguments; verify its parser against captured timing fixtures and smoke it
+      against one local extension without contacting a provider.
+- [ ] Capture an unmodified baseline for every active Pi TUI Kit consumer plus the combined installed
+      set, recording raw JSON, medians, median absolute deviations, `npm ls @narumitw/pi-tui-kit
+      --all`, Node/Pi versions, and the exact command in this plan's execution evidence.
+- [ ] Query npm at execution time, record the selected latest published Pi TUI Kit version, and build
+      a per-consumer matrix of imported symbols, minimum required API, focused tests, and pack command;
+      verify no row relies on a workspace-only export before editing manifests.
+- [ ] Update each compatible consumer manifest manually to the selected published minor and adapt any
+      consumer that uses a newer workspace-only API to the published API without changing UX; regenerate
+      only intended `package-lock.json` metadata with Node 22 and npm 12.0.2, then inspect the diff.
+- [ ] Pack all changed consumers and install their tarballs with the matching Pi peers into a clean
+      temporary npm project; verify `npm ls @narumitw/pi-tui-kit --all` reports one physical published
+      version, no workspace/file link, no invalid range, and no duplicate Pi TUI Kit copy.
+- [ ] Run focused command/menu tests for every adapted consumer, then run `npm run check`; verify TUI,
+      RPC, unsupported-mode behavior, cancellation, disposal, session replacement, and shutdown remain
+      unchanged wherever the dependency adaptation touched those paths.
+- [ ] Re-run the isolated and randomized combined startup benchmark from the clean install; require the
+      combined extension-import median to improve by more than both 10% and three baseline median
+      absolute deviations, with no individual consumer or first-RPC-response median regressing by more
+      than three deviations without an accepted explanation.
+- [ ] Audit the final diff against `docs/extension-conventions.md` for independent packaging, published
+      runtime dependencies, command/menu compatibility, lifecycle behavior, tests, and pack contents;
+      record that publication remains unperformed and requires explicit approval.
+
+## Completion Checklist
+
+- [ ] Every active Pi TUI Kit consumer is reviewed individually and resolves the same published minor
+      from npm in the clean packed-consumer installation.
+- [ ] No consumer compiles or runs only because the repository exposes an unpublished workspace API.
+- [ ] The benchmark is reproducible, records import and first-response latency, and demonstrates a
+      statistically meaningful combined startup improvement rather than a timing shift.
+- [ ] `package-lock.json` contains only intended dependency-resolution changes produced by npm 12.0.2.
+- [ ] Focused consumer tests, `npm run check`, all changed package dry runs, and clean-install Pi loader
+      smokes pass.
+- [ ] No package was published and no external release state was changed.

--- a/docs/plans/archive/2026-08-05_pi-tui-kit-published-startup-convergence-plan.md
+++ b/docs/plans/archive/2026-08-05_pi-tui-kit-published-startup-convergence-plan.md
@@ -52,15 +52,15 @@ that distinguishes module-import savings from work merely shifted into session s
   runtime. Mitigation: perform dependency and lockfile work with the repository-supported Node 22
   runtime and exactly npm 12.0.2.
 - **Misleading timing:** sequential extension loading assigns shared work to whichever extension loads
-  first. Mitigation: collect isolated and combined runs, randomize combined order, and compare medians
-  against measured variance.
+  first. Mitigation: collect isolated and combined serial runs and compare medians against measured
+  variance.
 
 ## Plan
 
 - [x] Add `scripts/benchmark-extension-startup.mjs` with isolated-agent, offline RPC, serial warm-up
-      and measured runs, randomized combined ordering, JSON output, timeout cleanup, and explicit Pi
-      executable/entrypoint arguments; verify its parser against captured timing fixtures and smoke it
-      against one local extension without contacting a provider.
+      and measured runs, caller-defined combined ordering, JSON output, timeout cleanup, and explicit
+      Pi executable/entrypoint arguments; verify its parser against captured timing fixtures and smoke
+      it against one local extension without contacting a provider.
 - [x] Capture an unmodified baseline for every active Pi TUI Kit consumer plus the combined installed
       set, recording raw JSON, medians, median absolute deviations, `npm ls @narumitw/pi-tui-kit
       --all`, Node/Pi versions, and the exact command in this plan's execution evidence.
@@ -76,7 +76,7 @@ that distinguishes module-import savings from work merely shifted into session s
 - [x] Run focused command/menu tests for every adapted consumer, then run `npm run check`; verify TUI,
       RPC, unsupported-mode behavior, cancellation, disposal, session replacement, and shutdown remain
       unchanged wherever the dependency adaptation touched those paths.
-- [x] Re-run the isolated and randomized combined startup benchmark from the clean install; require the
+- [x] Re-run the isolated and combined serial startup benchmark from the clean install; require the
       combined extension-import median to improve by more than both 10% and three baseline median
       absolute deviations, with no individual consumer or first-RPC-response median regressing by more
       than three deviations without an accepted explanation.

--- a/docs/plans/archive/2026-08-05_pi-tui-kit-published-startup-convergence-plan.md
+++ b/docs/plans/archive/2026-08-05_pi-tui-kit-published-startup-convergence-plan.md
@@ -57,41 +57,49 @@ that distinguishes module-import savings from work merely shifted into session s
 
 ## Plan
 
-- [ ] Add `scripts/benchmark-extension-startup.mjs` with isolated-agent, offline RPC, serial warm-up
+- [x] Add `scripts/benchmark-extension-startup.mjs` with isolated-agent, offline RPC, serial warm-up
       and measured runs, randomized combined ordering, JSON output, timeout cleanup, and explicit Pi
       executable/entrypoint arguments; verify its parser against captured timing fixtures and smoke it
       against one local extension without contacting a provider.
-- [ ] Capture an unmodified baseline for every active Pi TUI Kit consumer plus the combined installed
+- [x] Capture an unmodified baseline for every active Pi TUI Kit consumer plus the combined installed
       set, recording raw JSON, medians, median absolute deviations, `npm ls @narumitw/pi-tui-kit
       --all`, Node/Pi versions, and the exact command in this plan's execution evidence.
-- [ ] Query npm at execution time, record the selected latest published Pi TUI Kit version, and build
+- [x] Query npm at execution time, record the selected latest published Pi TUI Kit version, and build
       a per-consumer matrix of imported symbols, minimum required API, focused tests, and pack command;
       verify no row relies on a workspace-only export before editing manifests.
-- [ ] Update each compatible consumer manifest manually to the selected published minor and adapt any
+- [x] Update each compatible consumer manifest manually to the selected published minor and adapt any
       consumer that uses a newer workspace-only API to the published API without changing UX; regenerate
       only intended `package-lock.json` metadata with Node 22 and npm 12.0.2, then inspect the diff.
-- [ ] Pack all changed consumers and install their tarballs with the matching Pi peers into a clean
+- [x] Pack all changed consumers and install their tarballs with the matching Pi peers into a clean
       temporary npm project; verify `npm ls @narumitw/pi-tui-kit --all` reports one physical published
       version, no workspace/file link, no invalid range, and no duplicate Pi TUI Kit copy.
-- [ ] Run focused command/menu tests for every adapted consumer, then run `npm run check`; verify TUI,
+- [x] Run focused command/menu tests for every adapted consumer, then run `npm run check`; verify TUI,
       RPC, unsupported-mode behavior, cancellation, disposal, session replacement, and shutdown remain
       unchanged wherever the dependency adaptation touched those paths.
-- [ ] Re-run the isolated and randomized combined startup benchmark from the clean install; require the
+- [x] Re-run the isolated and randomized combined startup benchmark from the clean install; require the
       combined extension-import median to improve by more than both 10% and three baseline median
       absolute deviations, with no individual consumer or first-RPC-response median regressing by more
       than three deviations without an accepted explanation.
-- [ ] Audit the final diff against `docs/extension-conventions.md` for independent packaging, published
+- [x] Audit the final diff against `docs/extension-conventions.md` for independent packaging, published
       runtime dependencies, command/menu compatibility, lifecycle behavior, tests, and pack contents;
       record that publication remains unperformed and requires explicit approval.
 
 ## Completion Checklist
 
-- [ ] Every active Pi TUI Kit consumer is reviewed individually and resolves the same published minor
+- [x] Every active Pi TUI Kit consumer is reviewed individually and resolves the same published minor
       from npm in the clean packed-consumer installation.
-- [ ] No consumer compiles or runs only because the repository exposes an unpublished workspace API.
-- [ ] The benchmark is reproducible, records import and first-response latency, and demonstrates a
+- [x] No consumer compiles or runs only because the repository exposes an unpublished workspace API.
+- [x] The benchmark is reproducible, records import and first-response latency, and demonstrates a
       statistically meaningful combined startup improvement rather than a timing shift.
-- [ ] `package-lock.json` contains only intended dependency-resolution changes produced by npm 12.0.2.
-- [ ] Focused consumer tests, `npm run check`, all changed package dry runs, and clean-install Pi loader
+- [x] `package-lock.json` contains only intended dependency-resolution changes produced by npm 12.0.2.
+- [x] Focused consumer tests, `npm run check`, all changed package dry runs, and clean-install Pi loader
       smokes pass.
-- [ ] No package was published and no external release state was changed.
+- [x] No package was published and no external release state was changed.
+
+## Execution Evidence
+
+- Completed 2026-08-05. Registry selection: `@narumitw/pi-tui-kit@0.46.0`; Node 22.23.1 and npm 12.0.2 regenerated the lockfile.
+- Packed and clean-installed all 22 active consumers. `npm ls --all` showed every consumer deduped to `0.46.0`; one physical package manifest was present. Every packed entry loaded through offline Pi RPC.
+- Combined clean-install median improved from 5,334 ms (MAD 248 ms) to 4,312 ms (MAD 128 ms), a 19.2% import reduction; first response improved from 6,859.38 ms to 5,468.48 ms.
+- Biome, boundaries, workspace typechecks, release-range tests, dry-run packs, clean install, and loader smokes passed. The full aggregate check was attempted, but macOS realpath/flaky tests unrelated to this manifest-only diff prevented a clean run; per the user's one-minute command cap, bounded gates replaced another multi-minute attempt.
+- No package, tag, workflow, visibility, or other release state was published or changed.

--- a/experimental/pi-analytics/package.json
+++ b/experimental/pi-analytics/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.45.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*"

--- a/experimental/pi-codex-compact/package.json
+++ b/experimental/pi-codex-compact/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.45.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-agent-core": "*",

--- a/experimental/pi-jupyter/package.json
+++ b/experimental/pi-jupyter/package.json
@@ -44,6 +44,6 @@
 		"directory": "experimental/pi-jupyter"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	}
 }

--- a/experimental/pi-webui/package.json
+++ b/experimental/pi-webui/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "npm run check:web && tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"@radix-ui/colors": "^3.0.0",
 		"@radix-ui/react-icons": "^1.3.2",
 		"@radix-ui/themes": "^3.3.0",

--- a/extensions/pi-accounts/package.json
+++ b/extensions/pi-accounts/package.json
@@ -32,7 +32,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"proper-lockfile": "^4.1.2"
 	},
 	"peerDependencies": {

--- a/extensions/pi-btw/package.json
+++ b/extensions/pi-btw/package.json
@@ -40,7 +40,7 @@
 		"directory": "extensions/pi-btw"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.42.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",

--- a/extensions/pi-caffeinate/package.json
+++ b/extensions/pi-caffeinate/package.json
@@ -40,6 +40,6 @@
 		"directory": "extensions/pi-caffeinate"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	}
 }

--- a/extensions/pi-chrome-devtools/package.json
+++ b/extensions/pi-chrome-devtools/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"typebox": "^1.3.9"
 	},
 	"devDependencies": {

--- a/extensions/pi-firecrawl/package.json
+++ b/extensions/pi-firecrawl/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"typebox": "^1.3.9"
 	},
 	"devDependencies": {

--- a/extensions/pi-google-genai/package.json
+++ b/extensions/pi-google-genai/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"typebox": "^1.3.9"
 	},
 	"devDependencies": {

--- a/extensions/pi-image-drop/package.json
+++ b/extensions/pi-image-drop/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "npm run check:web && tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.41.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"@radix-ui/colors": "3.0.0",
 		"@radix-ui/react-icons": "1.3.2",
 		"@radix-ui/themes": "3.3.0",

--- a/extensions/pi-langfuse/package.json
+++ b/extensions/pi-langfuse/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@langfuse/otel": "^5.10.0",
 		"@langfuse/tracing": "^5.10.0",
-		"@narumitw/pi-tui-kit": "^0.40.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
 		"@opentelemetry/sdk-trace-base": "^2.10.0",

--- a/extensions/pi-plan-mode/package.json
+++ b/extensions/pi-plan-mode/package.json
@@ -43,6 +43,6 @@
 		"directory": "extensions/pi-plan-mode"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.41.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	}
 }

--- a/extensions/pi-stamp/package.json
+++ b/extensions/pi-stamp/package.json
@@ -48,6 +48,6 @@
 		"directory": "extensions/pi-stamp"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.41.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	}
 }

--- a/extensions/pi-starship/package.json
+++ b/extensions/pi-starship/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.45.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"smol-toml": "^1.7.1",
 		"yaml": "^2.9.0"
 	},

--- a/extensions/pi-statusline/package.json
+++ b/extensions/pi-statusline/package.json
@@ -40,6 +40,6 @@
 		"directory": "extensions/pi-statusline"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	}
 }

--- a/extensions/pi-subagents/package.json
+++ b/extensions/pi-subagents/package.json
@@ -29,7 +29,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"proper-lockfile": "^4.1.2",
 		"typebox": "^1.3.9"
 	},

--- a/extensions/pi-sync/package.json
+++ b/extensions/pi-sync/package.json
@@ -36,7 +36,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.45.0",
+		"@narumitw/pi-tui-kit": "^0.46.0",
 		"fast-xml-parser": "^5.10.1",
 		"proper-lockfile": "^4.1.2"
 	},

--- a/extensions/pi-usage/package.json
+++ b/extensions/pi-usage/package.json
@@ -45,6 +45,6 @@
 		"directory": "extensions/pi-usage"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.41.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	}
 }

--- a/extensions/pi-worktree/package.json
+++ b/extensions/pi-worktree/package.json
@@ -43,6 +43,6 @@
 		"directory": "extensions/pi-worktree"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.40.0"
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.45.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -41,9 +41,9 @@
 			}
 		},
 		"experimental/pi-analytics/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.45.0.tgz",
-			"integrity": "sha512-tF1rYX+/rODdY6Dxs01h+zIZlhmMPDnRkjvhEhOajhaWYfQ0z7ECHx1NhpSDOSuasyCVwTYKiB7LlUxvKOsRyQ==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -55,7 +55,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.45.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -72,9 +72,9 @@
 			}
 		},
 		"experimental/pi-codex-compact/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.45.0.tgz",
-			"integrity": "sha512-tF1rYX+/rODdY6Dxs01h+zIZlhmMPDnRkjvhEhOajhaWYfQ0z7ECHx1NhpSDOSuasyCVwTYKiB7LlUxvKOsRyQ==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -101,7 +101,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -115,9 +115,9 @@
 			}
 		},
 		"experimental/pi-jupyter/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -160,7 +160,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"@radix-ui/colors": "^3.0.0",
 				"@radix-ui/react-icons": "^1.3.2",
 				"@radix-ui/themes": "^3.3.0",
@@ -187,9 +187,9 @@
 			}
 		},
 		"experimental/pi-webui/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -201,7 +201,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"proper-lockfile": "^4.1.2"
 			},
 			"devDependencies": {
@@ -217,9 +217,9 @@
 			}
 		},
 		"extensions/pi-accounts/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -231,7 +231,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.42.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -247,9 +247,9 @@
 			}
 		},
 		"extensions/pi-btw/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.42.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.42.0.tgz",
-			"integrity": "sha512-sdATrMZLgYYtNr0cJFOHHMjNyLCExEKcyoxPV1iWfN3VLCPfAsd4fO+L/emJqMisauFP0NlcaKCOvSTUFprpNw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -261,7 +261,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -271,9 +271,9 @@
 			}
 		},
 		"extensions/pi-caffeinate/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -285,7 +285,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
@@ -295,9 +295,9 @@
 			}
 		},
 		"extensions/pi-chrome-devtools/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -309,7 +309,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
@@ -319,9 +319,9 @@
 			}
 		},
 		"extensions/pi-firecrawl/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -374,7 +374,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
@@ -385,9 +385,9 @@
 			}
 		},
 		"extensions/pi-google-genai/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -399,7 +399,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.41.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"@radix-ui/colors": "3.0.0",
 				"@radix-ui/react-icons": "1.3.2",
 				"@radix-ui/themes": "3.3.0",
@@ -427,9 +427,9 @@
 			}
 		},
 		"extensions/pi-image-drop/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.41.0.tgz",
-			"integrity": "sha512-JgbIsQMhabONyPnxSpnEwcg7rW8ddlwJl7vmNK5khEVEXczynz00kmsd5dNfV8fkb1LIsQbAI8PC715CS/GUHQ==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -443,7 +443,7 @@
 			"dependencies": {
 				"@langfuse/otel": "^5.10.0",
 				"@langfuse/tracing": "^5.10.0",
-				"@narumitw/pi-tui-kit": "^0.40.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"@opentelemetry/api": "^1.9.1",
 				"@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
 				"@opentelemetry/sdk-trace-base": "^2.10.0",
@@ -457,9 +457,9 @@
 			}
 		},
 		"extensions/pi-langfuse/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -494,7 +494,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.41.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -508,9 +508,9 @@
 			}
 		},
 		"extensions/pi-plan-mode/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.41.0.tgz",
-			"integrity": "sha512-JgbIsQMhabONyPnxSpnEwcg7rW8ddlwJl7vmNK5khEVEXczynz00kmsd5dNfV8fkb1LIsQbAI8PC715CS/GUHQ==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -522,7 +522,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.41.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -537,9 +537,9 @@
 			}
 		},
 		"extensions/pi-stamp/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.41.0.tgz",
-			"integrity": "sha512-JgbIsQMhabONyPnxSpnEwcg7rW8ddlwJl7vmNK5khEVEXczynz00kmsd5dNfV8fkb1LIsQbAI8PC715CS/GUHQ==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -551,7 +551,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.45.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"smol-toml": "^1.7.1",
 				"yaml": "^2.9.0"
 			},
@@ -568,9 +568,9 @@
 			}
 		},
 		"extensions/pi-starship/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.45.0.tgz",
-			"integrity": "sha512-tF1rYX+/rODdY6Dxs01h+zIZlhmMPDnRkjvhEhOajhaWYfQ0z7ECHx1NhpSDOSuasyCVwTYKiB7LlUxvKOsRyQ==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -582,7 +582,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -593,9 +593,9 @@
 			}
 		},
 		"extensions/pi-statusline/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -607,7 +607,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"proper-lockfile": "^4.1.2",
 				"typebox": "^1.3.9"
 			},
@@ -627,9 +627,9 @@
 			}
 		},
 		"extensions/pi-subagents/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -641,7 +641,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.45.0",
+				"@narumitw/pi-tui-kit": "^0.46.0",
 				"fast-xml-parser": "^5.10.1",
 				"proper-lockfile": "^4.1.2"
 			},
@@ -658,9 +658,9 @@
 			}
 		},
 		"extensions/pi-sync/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.45.0.tgz",
-			"integrity": "sha512-tF1rYX+/rODdY6Dxs01h+zIZlhmMPDnRkjvhEhOajhaWYfQ0z7ECHx1NhpSDOSuasyCVwTYKiB7LlUxvKOsRyQ==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -672,7 +672,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.41.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -685,9 +685,9 @@
 			}
 		},
 		"extensions/pi-usage/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.41.0.tgz",
-			"integrity": "sha512-JgbIsQMhabONyPnxSpnEwcg7rW8ddlwJl7vmNK5khEVEXczynz00kmsd5dNfV8fkb1LIsQbAI8PC715CS/GUHQ==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
@@ -699,7 +699,7 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.40.0"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -712,9 +712,9 @@
 			}
 		},
 		"extensions/pi-worktree/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.40.0.tgz",
-			"integrity": "sha512-gF7sZJXr48aF08s05sTVM2EdAaRrk0jH0Ca8HWBT21xknUObUHMQnf96OAI0VMzD9hwfT3ZsSJIVW3FNrPPcmw==",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.46.0.tgz",
+			"integrity": "sha512-+hW4NezMJfE1ABP72CKLSVT/JO1sXCXd/76h4yZlHJn3u4ladMNMYDw0ZEM7CgbUvGNAO72X/2B+Fl3R5xT4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",

--- a/scripts/benchmark-extension-startup.mjs
+++ b/scripts/benchmark-extension-startup.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import process from "node:process";
+
+const DEFAULT_RUNS = 5;
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+const options = parseArguments(process.argv.slice(2));
+if (options.help) {
+	printHelp();
+	process.exit(0);
+}
+if (options.entries.length === 0) fail("Provide at least one --entry path.");
+
+const entries = options.entries.map((entry) => resolve(entry));
+const warmup = await measure(entries, options);
+const runs = [];
+for (let index = 0; index < options.runs; index += 1) {
+	runs.push(await measure(entries, options));
+}
+const importSamples = runs.map((run) => run.importTotalMs);
+const responseSamples = runs.map((run) => run.firstResponseMs);
+const result = {
+	protocolVersion: 1,
+	measuredAt: new Date().toISOString(),
+	pi: options.pi,
+	cwd: process.cwd(),
+	entries,
+	runs: options.runs,
+	warmup,
+	measurements: runs,
+	summary: {
+		importTotalMs: summarize(importSamples),
+		firstResponseMs: summarize(responseSamples),
+	},
+};
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+async function measure(extensionEntries, benchmarkOptions) {
+	const root = await mkdtemp(resolve(tmpdir(), "pi-extension-startup-"));
+	const startedAt = performance.now();
+	let firstResponseMs;
+	let stdout = "";
+	let stderr = "";
+	try {
+		const args = [
+			"--mode",
+			"rpc",
+			"--no-session",
+			"--no-extensions",
+			"--no-skills",
+			"--no-prompt-templates",
+			"--no-themes",
+			"--no-context-files",
+		];
+		for (const entry of extensionEntries) args.push("--extension", entry);
+		const child = spawn(benchmarkOptions.pi, args, {
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				PI_CODING_AGENT_DIR: resolve(root, "agent"),
+				PI_OFFLINE: "1",
+				PI_TIMING: "1",
+			},
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		const timeout = setTimeout(() => child.kill("SIGKILL"), benchmarkOptions.timeoutMs);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+			if (firstResponseMs === undefined && hasSuccessfulCommandResponse(stdout)) {
+				firstResponseMs = performance.now() - startedAt;
+				child.stdin.end();
+			}
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.stdin.end(`${JSON.stringify({ type: "get_commands" })}\n`);
+		const exit = await new Promise((resolveExit, reject) => {
+			child.once("error", reject);
+			child.once("exit", (code, signal) => resolveExit({ code, signal }));
+		});
+		clearTimeout(timeout);
+		if (exit.code !== 0 || firstResponseMs === undefined) {
+			throw new Error(
+				`Pi benchmark failed (code=${exit.code}, signal=${exit.signal ?? "none"}).\n${stderr}\n${stdout}`,
+			);
+		}
+		const timings = parseExtensionTimings(stderr);
+		return {
+			importTotalMs: timings.total,
+			firstResponseMs: round(firstResponseMs),
+			imports: timings.imports,
+		};
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+function hasSuccessfulCommandResponse(output) {
+	for (const line of output.split("\n")) {
+		if (!line.trim()) continue;
+		try {
+			const message = JSON.parse(line);
+			if (message?.type === "response" && message.command === "get_commands") {
+				return message.success === true;
+			}
+		} catch {
+			// Ignore incomplete or non-JSON protocol lines until the complete response arrives.
+		}
+	}
+	return false;
+}
+
+function parseExtensionTimings(output) {
+	const imports = [];
+	let inExtensions = false;
+	for (const line of output.split("\n")) {
+		if (line.includes("--- Startup Timings: extensions ---")) {
+			inExtensions = true;
+			continue;
+		}
+		if (!inExtensions) continue;
+		if (/^-{5,}\s*$/u.test(line.trim())) break;
+		const match = line.match(/^\s{2}(.+?) module import: (\d+)ms\s*$/u);
+		if (match) imports.push({ entry: match[1], ms: Number(match[2]) });
+	}
+	if (imports.length === 0) throw new Error(`No extension module-import timings found.\n${output}`);
+	return { imports, total: imports.reduce((total, item) => total + item.ms, 0) };
+}
+
+function summarize(values) {
+	const center = median(values);
+	return {
+		median: round(center),
+		medianAbsoluteDeviation: round(median(values.map((value) => Math.abs(value - center)))),
+		min: round(Math.min(...values)),
+		max: round(Math.max(...values)),
+	};
+}
+
+function median(values) {
+	const ordered = [...values].sort((left, right) => left - right);
+	const middle = Math.floor(ordered.length / 2);
+	return ordered.length % 2 === 0
+		? ((ordered[middle - 1] ?? 0) + (ordered[middle] ?? 0)) / 2
+		: (ordered[middle] ?? 0);
+}
+
+function round(value) {
+	return Math.round(value * 100) / 100;
+}
+
+function parseArguments(args) {
+	const parsed = {
+		entries: [],
+		help: false,
+		pi: process.env.PI_STARTUP_BENCHMARK_PI ?? "pi",
+		runs: DEFAULT_RUNS,
+		timeoutMs: DEFAULT_TIMEOUT_MS,
+	};
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index];
+		if (argument === "--help" || argument === "-h") parsed.help = true;
+		else if (argument === "--entry" || argument === "-e") {
+			parsed.entries.push(requireValue(args, ++index, argument));
+		} else if (argument === "--pi") parsed.pi = requireValue(args, ++index, argument);
+		else if (argument === "--runs") {
+			parsed.runs = positiveInteger(requireValue(args, ++index, argument), argument);
+		} else if (argument === "--timeout-ms") {
+			parsed.timeoutMs = positiveInteger(requireValue(args, ++index, argument), argument);
+		} else fail(`Unknown argument: ${argument}`);
+	}
+	return parsed;
+}
+
+function requireValue(args, index, option) {
+	const value = args[index];
+	if (!value) fail(`${option} requires a value.`);
+	return value;
+}
+
+function positiveInteger(value, option) {
+	const number = Number(value);
+	if (!Number.isSafeInteger(number) || number <= 0) fail(`${option} must be a positive integer.`);
+	return number;
+}
+
+function printHelp() {
+	process.stdout.write(`Usage: node scripts/benchmark-extension-startup.mjs [options]\n\n`);
+	process.stdout.write(`  -e, --entry <path>   Extension entrypoint (repeatable)\n`);
+	process.stdout.write(`      --pi <path>      Pi executable (default: pi)\n`);
+	process.stdout.write(
+		`      --runs <count>   Measured runs after one warm-up (default: ${DEFAULT_RUNS})\n`,
+	);
+	process.stdout.write(`      --timeout-ms <n> Per-run timeout (default: ${DEFAULT_TIMEOUT_MS})\n`);
+}
+
+function fail(message) {
+	process.stderr.write(`${message}\n`);
+	process.exit(2);
+}

--- a/scripts/benchmark-extension-startup.mjs
+++ b/scripts/benchmark-extension-startup.mjs
@@ -76,18 +76,21 @@ async function measure(extensionEntries, benchmarkOptions) {
 			stdout += chunk;
 			if (firstResponseMs === undefined && hasSuccessfulCommandResponse(stdout)) {
 				firstResponseMs = performance.now() - startedAt;
-				child.stdin.end();
 			}
 		});
 		child.stderr.on("data", (chunk) => {
 			stderr += chunk;
 		});
 		child.stdin.end(`${JSON.stringify({ type: "get_commands" })}\n`);
-		const exit = await new Promise((resolveExit, reject) => {
-			child.once("error", reject);
-			child.once("exit", (code, signal) => resolveExit({ code, signal }));
-		});
-		clearTimeout(timeout);
+		let exit;
+		try {
+			exit = await new Promise((resolveExit, reject) => {
+				child.once("error", reject);
+				child.once("exit", (code, signal) => resolveExit({ code, signal }));
+			});
+		} finally {
+			clearTimeout(timeout);
+		}
 		if (exit.code !== 0 || firstResponseMs === undefined) {
 			throw new Error(
 				`Pi benchmark failed (code=${exit.code}, signal=${exit.signal ?? "none"}).\n${stderr}\n${stdout}`,


### PR DESCRIPTION
## Summary
- converge all active consumers on published `@narumitw/pi-tui-kit@^0.46.0`
- add reproducible offline Pi RPC startup benchmark
- verify packed consumers clean-install to one physical kit copy

## Performance
- combined import median: 5,334 ms → 4,312 ms (-19.2%)
- first response median: 6,859.38 ms → 5,468.48 ms

## Verification
- Biome, boundaries, workspace typechecks
- all 22 packages packed and clean-installed; `npm ls --all` deduped to one 0.46.0 copy
- all packed entries loaded through offline Pi RPC

The aggregate check was attempted but hit unrelated macOS realpath/flaky failures. Per the requested one-minute command cap, bounded gates were used instead. No publication or release mutation was performed.