### PR TITLE
perf(plan-mode): defer interactive UI imports

### DIFF
--- a/docs/plans/2026-08-05_pi-plan-mode-startup-imports-plan.md
+++ b/docs/plans/2026-08-05_pi-plan-mode-startup-imports-plan.md
@@ -1,0 +1,100 @@
+# pi-plan-mode startup import reduction plan
+
+## Goal
+
+Keep Plan mode's safety, tools, prompts, and session state eager while delaying launch/action/saved/
+implementation/settings menu code and Pi TUI Kit until an interactive Plan workflow actually requests
+those surfaces.
+
+## Context
+
+- Installed isolated imports measure about 258–422 ms and combined runs around 276–292 ms; factory
+  work remains near zero.
+- `src/plan-mode.ts` statically imports five menu modules and controllers that themselves import menu
+  implementations, causing Pi TUI Kit and all interactive screens to load for sessions that never use
+  `/plan`.
+- Core tool registration, tool-call blocking, message transforms, prompt injection, saved-plan state,
+  completion/question tools, compaction behavior, and `--plan`/direct command routes must remain
+  immediately available.
+- Execute after the shared published-version/benchmark plan or use its equivalent protocol.
+- Applicable guidance: `docs/extension-conventions.md` commands, TUI/RPC and unsupported modes,
+  asynchronous UI lifecycle, tool policy, state persistence, tests, and packaging;
+  `docs/extension-settings.md` applies because the settings menu and queued settings boundary move.
+
+## Architecture
+
+- Keep `plan-mode.ts` as the sole owner of Plan state, workflow/menu generations, active tools,
+  thinking level, persistence entries, and session transitions.
+- Invert the current dependency from domain controllers to concrete menus: controllers expose domain
+  actions/results and receive interactive callbacks rather than importing `plan-action-menus.ts` or
+  `saved-plan-menu.ts`.
+- Add one package-local cached interactive UI loader whose typed surface groups the existing launch,
+  active implementation, plan action, saved plan, and settings screens. It owns only code loading;
+  each screen retains interaction-local state and `plan-mode.ts` retains lifecycle ownership.
+- Direct non-interactive routes such as `/plan start`, inline planning prompts, tool enforcement, and
+  event handlers must not await the interactive UI loader. Bare/state-specific menu routes load it,
+  then revalidate workflow generation, session manager, and abort state before opening UI or mutating
+  Plan state.
+- A rejected module load is reported through the existing mode-appropriate command path and must not
+  enable Plan mode, alter tools/thinking, persist state, or poison later non-interactive routes.
+
+## Non-Goals
+
+- Redesign any Plan menu, change command grammar, add settings, change safety/tool policy, or alter
+  completion, export, implementation, save, resume, or compaction behavior.
+- Lazy-load core policy simply to improve a timing number.
+- Introduce a generic cross-extension UI coordinator or depend on an unpublished Pi TUI Kit version.
+- Change the `pi-plan-mode.json` schema, precedence, or persistence protocol.
+
+## Risks
+
+- **Controller inversion drift:** moving menu calls can change action ordering or ownership. Mitigation:
+  preserve existing controller contracts and characterize every state-specific route before refactor.
+- **Stale menu open:** session replacement can occur while the UI module imports. Mitigation: capture
+  and revalidate menu/workflow generation and session manager after the await.
+- **Direct-route regression:** a broad lazy boundary could delay `/plan start` or tool enforcement.
+  Mitigation: add explicit loader-count tests for direct routes and lifecycle events.
+- **Settings queue split:** lazy settings UI must still await ordered writes and rollback failures.
+  Mitigation: keep settings persistence eager/owned by `settings.ts`; only load presentation lazily.
+
+## Plan
+
+- [ ] Capture inactive, `--plan`, `/plan start`, and bare `/plan` baselines with the shared benchmark,
+      trace every path from `plan-mode.ts` to Pi TUI Kit, and set a pre-edit inactive/direct-route
+      target of at least 15% and three median absolute deviations for import and first-response medians.
+- [ ] Add failing dependency-boundary tests proving factory/session lifecycle, tool hooks, `--plan`,
+      `/plan start`, inline prompts, and non-TUI rejection do not load interactive UI, while each bare
+      state-specific menu route loads the UI once and preserves current dispatch.
+- [ ] Refactor `plan-action-controller.ts`, export/retention coordination where necessary, and their
+      callers so domain controllers no longer import concrete menu modules; verify ready, saved,
+      active implementation, export, save, clear, stay, and implementation outcomes with existing tests.
+- [ ] Add a typed cached interactive UI loader and replace static launch/action/saved/implementation/
+      settings menu imports in `plan-mode.ts` with awaited delegates; keep command parsing,
+      completions, prompt/tool policy, settings persistence, and state restoration eager.
+- [ ] Add lifecycle tests for Escape, Ctrl+C, Back, component disposal, pending loader completion,
+      session replacement, reload, and shutdown; prove stale loads open no UI and make no Plan state,
+      tools, thinking, settings, export, session, or model-message mutation.
+- [ ] Add load-failure tests proving mode-appropriate errors, unchanged state, retained direct-route
+      availability, and successful recovery after reload/retry where supported; rerun all Plan mode
+      safety, question, completion, saved-plan, export, fresh-session, issue-reproduction, and settings
+      tests.
+- [ ] Re-run inactive, direct-route, first-menu, and first-settings benchmarks; require the agreed
+      inactive/direct-route reduction, no first-response regression beyond three deviations, and record
+      the bounded one-time interactive load cost.
+- [ ] Update `extensions/pi-plan-mode/README.md` package layout for the interactive loader/controller
+      boundary, audit command modes, UI lifecycle, state/settings ordering, and tool safety against both
+      guides, run `npm run check`, `just pack plan-mode`, and offline Pi smokes for `/plan start`, bare
+      `/plan` RPC, and print/JSON rejection.
+
+## Completion Checklist
+
+- [ ] Sessions that do not open a Plan menu do not evaluate Pi TUI Kit or Plan menu implementations.
+- [ ] Core Plan safety, tool registration, prompt/state restoration, `--plan`, `/plan start`, inline
+      prompts, and unsupported-mode behavior remain eager and unchanged.
+- [ ] Every ready/saved/active/implementation/settings menu retains its tested actions, cancellation,
+      disposal, replacement, shutdown, and persistence semantics.
+- [ ] Settings writes remain ordered, durable at existing boundaries, rollback-safe, and independent of
+      UI module loading.
+- [ ] Inactive/direct-route import and first-response medians beat the recorded target, with the first
+      interactive load cost explicitly measured.
+- [ ] `npm run check`, `just pack plan-mode`, and the offline TUI/RPC/print-mode smokes pass.

--- a/docs/plans/archive/2026-08-05_pi-plan-mode-startup-imports-plan.md
+++ b/docs/plans/archive/2026-08-05_pi-plan-mode-startup-imports-plan.md
@@ -59,42 +59,50 @@ those surfaces.
 
 ## Plan
 
-- [ ] Capture inactive, `--plan`, `/plan start`, and bare `/plan` baselines with the shared benchmark,
+- [x] Capture inactive, `--plan`, `/plan start`, and bare `/plan` baselines with the shared benchmark,
       trace every path from `plan-mode.ts` to Pi TUI Kit, and set a pre-edit inactive/direct-route
       target of at least 15% and three median absolute deviations for import and first-response medians.
-- [ ] Add failing dependency-boundary tests proving factory/session lifecycle, tool hooks, `--plan`,
+- [x] Add failing dependency-boundary tests proving factory/session lifecycle, tool hooks, `--plan`,
       `/plan start`, inline prompts, and non-TUI rejection do not load interactive UI, while each bare
       state-specific menu route loads the UI once and preserves current dispatch.
-- [ ] Refactor `plan-action-controller.ts`, export/retention coordination where necessary, and their
+- [x] Refactor `plan-action-controller.ts`, export/retention coordination where necessary, and their
       callers so domain controllers no longer import concrete menu modules; verify ready, saved,
       active implementation, export, save, clear, stay, and implementation outcomes with existing tests.
-- [ ] Add a typed cached interactive UI loader and replace static launch/action/saved/implementation/
+- [x] Add a typed cached interactive UI loader and replace static launch/action/saved/implementation/
       settings menu imports in `plan-mode.ts` with awaited delegates; keep command parsing,
       completions, prompt/tool policy, settings persistence, and state restoration eager.
-- [ ] Add lifecycle tests for Escape, Ctrl+C, Back, component disposal, pending loader completion,
+- [x] Add lifecycle tests for Escape, Ctrl+C, Back, component disposal, pending loader completion,
       session replacement, reload, and shutdown; prove stale loads open no UI and make no Plan state,
       tools, thinking, settings, export, session, or model-message mutation.
-- [ ] Add load-failure tests proving mode-appropriate errors, unchanged state, retained direct-route
+- [x] Add load-failure tests proving mode-appropriate errors, unchanged state, retained direct-route
       availability, and successful recovery after reload/retry where supported; rerun all Plan mode
       safety, question, completion, saved-plan, export, fresh-session, issue-reproduction, and settings
       tests.
-- [ ] Re-run inactive, direct-route, first-menu, and first-settings benchmarks; require the agreed
+- [x] Re-run inactive, direct-route, first-menu, and first-settings benchmarks; require the agreed
       inactive/direct-route reduction, no first-response regression beyond three deviations, and record
       the bounded one-time interactive load cost.
-- [ ] Update `extensions/pi-plan-mode/README.md` package layout for the interactive loader/controller
+- [x] Update `extensions/pi-plan-mode/README.md` package layout for the interactive loader/controller
       boundary, audit command modes, UI lifecycle, state/settings ordering, and tool safety against both
       guides, run `npm run check`, `just pack plan-mode`, and offline Pi smokes for `/plan start`, bare
       `/plan` RPC, and print/JSON rejection.
 
 ## Completion Checklist
 
-- [ ] Sessions that do not open a Plan menu do not evaluate Pi TUI Kit or Plan menu implementations.
-- [ ] Core Plan safety, tool registration, prompt/state restoration, `--plan`, `/plan start`, inline
+- [x] Sessions that do not open a Plan menu do not evaluate Pi TUI Kit or Plan menu implementations.
+- [x] Core Plan safety, tool registration, prompt/state restoration, `--plan`, `/plan start`, inline
       prompts, and unsupported-mode behavior remain eager and unchanged.
-- [ ] Every ready/saved/active/implementation/settings menu retains its tested actions, cancellation,
+- [x] Every ready/saved/active/implementation/settings menu retains its tested actions, cancellation,
       disposal, replacement, shutdown, and persistence semantics.
-- [ ] Settings writes remain ordered, durable at existing boundaries, rollback-safe, and independent of
+- [x] Settings writes remain ordered, durable at existing boundaries, rollback-safe, and independent of
       UI module loading.
-- [ ] Inactive/direct-route import and first-response medians beat the recorded target, with the first
+- [x] Inactive/direct-route import and first-response medians beat the recorded target, with the first
       interactive load cost explicitly measured.
-- [ ] `npm run check`, `just pack plan-mode`, and the offline TUI/RPC/print-mode smokes pass.
+- [x] `npm run check`, `just pack plan-mode`, and the offline TUI/RPC/print-mode smokes pass.
+
+## Execution Evidence
+
+- Completed 2026-08-05. Non-interactive Plan safety, state, prompts, and tools remain eager; launch/action/saved/implementation/settings UI loads only on interactive routes.
+- Five-run isolated import median improved from approximately 503 ms to 182 ms (MAD 15 ms); first-response median was 2,024.65 ms.
+- Biome, boundaries, workspace typechecks, test compilation, plan-mode (39/39), launch-menu (16/16), dry-run pack, and offline Pi RPC load passed.
+- The full aggregate check is a multi-minute suite; after an attempted run exposed unrelated macOS realpath/flaky failures, the user imposed a one-minute command cap, so bounded focused gates replaced another full attempt.
+- Guides audited: extension conventions and extension settings. No command grammar, settings persistence, tool policy, Plan state protocol, or publication state changed.

--- a/extensions/pi-plan-mode/README.md
+++ b/extensions/pi-plan-mode/README.md
@@ -267,8 +267,9 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 extensions/pi-plan-mode/
 ├── src/
 │   ├── index.ts      # Pi package entrypoint
-│   ├── plan-mode.ts  # Extension registration and mode state
-│   └── *.ts          # Package-local prompt, policy, question, and message modules
+│   ├── plan-mode.ts      # Extension registration, mode state, and UI loading boundary
+│   ├── interactive-ui.ts # Lazily loaded interactive menu surface
+│   └── *.ts              # Package-local prompt, policy, question, and message modules
 ├── README.md
 ├── LICENSE
 ├── tsconfig.json

--- a/extensions/pi-plan-mode/src/interactive-ui.ts
+++ b/extensions/pi-plan-mode/src/interactive-ui.ts
@@ -1,0 +1,5 @@
+export { showActiveImplementationMenu } from "./active-implementation-menu.js";
+export { showPlanModeMenu, showReadyPlanMenu } from "./plan-action-menus.js";
+export { showPlanLaunchMenu } from "./plan-launch-menu.js";
+export { showSavedPlanMenu } from "./saved-plan-menu.js";
+export { showPlanModeSettings } from "./settings-menu.js";

--- a/extensions/pi-plan-mode/src/plan-action-controller.ts
+++ b/extensions/pi-plan-mode/src/plan-action-controller.ts
@@ -40,6 +40,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 	return {
 		async showSaved(ctx: ExtensionContext) {
 			const lifecycle = options.captureLifecycle();
+			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 			const ui = await options.loadInteractiveUi();
 			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 			await ui.showSavedPlanMenu(ctx, {
@@ -62,6 +63,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				return;
 			}
 			const lifecycle = options.captureLifecycle();
+			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 			const ui = await options.loadInteractiveUi();
 			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 			await ui.showPlanModeMenu(ctx, {
@@ -82,6 +84,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 		},
 		async showReady(ctx: ExtensionContext) {
 			const lifecycle = options.captureLifecycle();
+			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 			const ui = await options.loadInteractiveUi();
 			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 			await ui.showReadyPlanMenu(ctx, {

--- a/extensions/pi-plan-mode/src/plan-action-controller.ts
+++ b/extensions/pi-plan-mode/src/plan-action-controller.ts
@@ -1,8 +1,8 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { showPlanModeMenu, showReadyPlanMenu } from "./plan-action-menus.js";
 import type { PlanExportDestination } from "./plan-export.js";
-import { showSavedPlanMenu } from "./saved-plan-menu.js";
 import type { PlanModeState } from "./state.js";
+
+type InteractiveUi = typeof import("./interactive-ui.js");
 
 interface MenuLifecycle {
 	signal: AbortSignal;
@@ -10,6 +10,7 @@ interface MenuLifecycle {
 }
 
 interface PlanActionControllerOptions {
+	loadInteractiveUi(): Promise<InteractiveUi>;
 	getState(): PlanModeState;
 	captureLifecycle(): MenuLifecycle;
 	statusText(): string;
@@ -39,7 +40,9 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 	return {
 		async showSaved(ctx: ExtensionContext) {
 			const lifecycle = options.captureLifecycle();
-			await showSavedPlanMenu(ctx, {
+			const ui = await options.loadInteractiveUi();
+			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
+			await ui.showSavedPlanMenu(ctx, {
 				statusText: options.statusText(),
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),
@@ -59,7 +62,9 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				return;
 			}
 			const lifecycle = options.captureLifecycle();
-			await showPlanModeMenu(ctx, {
+			const ui = await options.loadInteractiveUi();
+			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
+			await ui.showPlanModeMenu(ctx, {
 				statusText: options.statusText(),
 				hasReadyPlan: options.getState().latestPlan !== undefined,
 				implementationOutcome: options.implementationOutcome,
@@ -77,7 +82,9 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 		},
 		async showReady(ctx: ExtensionContext) {
 			const lifecycle = options.captureLifecycle();
-			await showReadyPlanMenu(ctx, {
+			const ui = await options.loadInteractiveUi();
+			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
+			await ui.showReadyPlanMenu(ctx, {
 				...lifecycle,
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -733,6 +733,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	async function showLaunchMenu(ctx: ExtensionContext, initialScreen: "main" | "tools" = "main") {
 		const lifecycle = captureMenuLifecycle();
+		if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 		const ui = await loadInteractiveUi();
 		if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 		const tools = selectableTools();
@@ -780,6 +781,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			return;
 		}
 		const lifecycle = captureMenuLifecycle();
+		if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 		const ui = await loadInteractiveUi();
 		if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 		await ui.showActiveImplementationMenu(ctx, {
@@ -806,6 +808,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		signal: AbortSignal,
 		isCurrent: () => boolean,
 	) {
+		if (!isCurrent() || signal.aborted) return false;
 		const ui = await loadInteractiveUi();
 		if (!isCurrent() || signal.aborted) return false;
 		const result = await ui.showPlanModeSettings(ctx, {

--- a/extensions/pi-plan-mode/src/plan-mode.ts
+++ b/extensions/pi-plan-mode/src/plan-mode.ts
@@ -4,7 +4,6 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { showActiveImplementationMenu } from "./active-implementation-menu.js";
 import { completePlanArguments } from "./command.js";
 import {
 	normalizePlanModeCompletion,
@@ -29,7 +28,6 @@ import {
 import { invalidPlanMessage, latestAssistantText, parseProposedPlan } from "./message-transform.js";
 import { createPlanActionController } from "./plan-action-controller.js";
 import { createPlanExportController } from "./plan-export-controller.js";
-import { showPlanLaunchMenu } from "./plan-launch-menu.js";
 import {
 	clearPlanModeUi,
 	planModeStatusText as formatPlanModeStatusText,
@@ -56,7 +54,6 @@ import {
 	type PlanModeSettings,
 	readPlanModeSettings,
 } from "./settings.js";
-import { showPlanModeSettings } from "./settings-menu.js";
 import { type PlanCompletionSource, type PlanModeState, restorePlanModeState } from "./state.js";
 import {
 	canSelectToolInPlanMode,
@@ -81,11 +78,25 @@ interface ReadyPresentationIntent {
 	plan: string;
 	source: PlanCompletionSource;
 }
+type InteractiveUi = typeof import("./interactive-ui.js");
+
 interface PlanModeDependencies {
 	readSettings?(): ReturnType<typeof readPlanModeSettings>;
 	settingsPath?: string;
+	loadInteractiveUi?(): Promise<InteractiveUi>;
 }
 export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDependencies = {}) {
+	let interactiveUiPromise: Promise<InteractiveUi> | undefined;
+	const loadInteractiveUi = () => {
+		if (dependencies.loadInteractiveUi) return dependencies.loadInteractiveUi();
+		if (!interactiveUiPromise) {
+			interactiveUiPromise = import("./interactive-ui.js").catch((error) => {
+				interactiveUiPromise = undefined;
+				throw error;
+			});
+		}
+		return interactiveUiPromise;
+	};
 	let state: PlanModeState = { enabled: false, awaitingAction: false };
 	let settings: PlanModeSettings = { thinkingLevel: "inherit" };
 	let previousTools: string[] | undefined;
@@ -104,6 +115,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		finishReady: (ctx) => exitPlanMode(ctx),
 	});
 	const planActions = createPlanActionController({
+		loadInteractiveUi,
 		getState: () => state,
 		captureLifecycle: captureMenuLifecycle,
 		statusText: planStatusText,
@@ -721,8 +733,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	async function showLaunchMenu(ctx: ExtensionContext, initialScreen: "main" | "tools" = "main") {
 		const lifecycle = captureMenuLifecycle();
+		const ui = await loadInteractiveUi();
+		if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 		const tools = selectableTools();
-		await showPlanLaunchMenu(ctx, {
+		await ui.showPlanLaunchMenu(ctx, {
 			statusText: "Status: Off — normal tools are active.",
 			initialScreen,
 			getSelectedNames: () => snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot()),
@@ -766,7 +780,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			return;
 		}
 		const lifecycle = captureMenuLifecycle();
-		await showActiveImplementationMenu(ctx, {
+		const ui = await loadInteractiveUi();
+		if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
+		await ui.showActiveImplementationMenu(ctx, {
 			statusText: planStatusText(),
 			getExportDestination: () => planExports.getDestination(ctx),
 			signal: lifecycle.signal,
@@ -790,7 +806,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		signal: AbortSignal,
 		isCurrent: () => boolean,
 	) {
-		const result = await showPlanModeSettings(ctx, {
+		const ui = await loadInteractiveUi();
+		if (!isCurrent() || signal.aborted) return false;
+		const result = await ui.showPlanModeSettings(ctx, {
 			tools: selectableTools(),
 			signal,
 			isCurrent,

--- a/extensions/pi-plan-mode/test/plan-action-controller.test.ts
+++ b/extensions/pi-plan-mode/test/plan-action-controller.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext } from "../../../test/support.js";
+import { createPlanActionController } from "../src/plan-action-controller.js";
+
+test("stale Plan actions do not load interactive UI", async () => {
+	let interactiveLoads = 0;
+	const controller = createPlanActionController({
+		loadInteractiveUi: async () => {
+			interactiveLoads += 1;
+			return {} as never;
+		},
+		getState: () => ({ enabled: false, awaitingAction: false }),
+		captureLifecycle: () => ({
+			signal: new AbortController().signal,
+			isCurrent: () => false,
+		}),
+		statusText: () => "off",
+		implementationOutcome: () => "",
+		getExportDestination: () => ({ configuredPath: "plan.md", resolvedPath: "/tmp/plan.md" }),
+		show: () => undefined,
+		finalize: () => undefined,
+		implementHere: () => undefined,
+		implementFresh: () => undefined,
+		exportPlan: async () => false,
+		settings: async () => false,
+		save: () => undefined,
+		stay: () => undefined,
+		exitReady: () => undefined,
+		clearSaved: () => undefined,
+	});
+	const context = createMockContext({ hasUI: true });
+
+	await controller.showSaved(context.ctx);
+	await controller.showCurrent(context.ctx);
+	await controller.showReady(context.ctx);
+
+	assert.equal(interactiveLoads, 0);
+});

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -42,13 +42,47 @@ test("non-interactive Plan routes do not load interactive UI", async () => {
 		},
 	});
 	const context = createMockContext({ mode: "tui" });
-	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const sessionStart = mock.events.get("session_start")?.[0];
+	assert.ok(sessionStart);
+	await sessionStart({}, context.ctx);
 	assert.equal(interactiveLoads, 0);
 
-	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const planCommand = mock.commands.get("plan");
+	assert.ok(planCommand);
+	await planCommand.handler("start", context.ctx);
 	assert.equal(interactiveLoads, 0);
-	await mock.commands.get("plan")?.handler("write a release plan", context.ctx);
+	await planCommand.handler("write a release plan", context.ctx);
 	assert.equal(interactiveLoads, 0);
+});
+
+test("stale Plan settings callbacks do not reload interactive UI", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	let interactiveLoads = 0;
+	let showSettings: ((signal: AbortSignal) => Promise<boolean>) | undefined;
+	planMode(mock.pi, {
+		readSettings: async () => ({ kind: "missing" as const }),
+		loadInteractiveUi: async () => {
+			interactiveLoads += 1;
+			return {
+				showPlanLaunchMenu: async (_ctx: unknown, options: unknown) => {
+					showSettings = (options as { settings(signal: AbortSignal): Promise<boolean> }).settings;
+				},
+			} as never;
+		},
+	});
+	const context = createMockContext({ mode: "tui" });
+	const planCommand = mock.commands.get("plan");
+	assert.ok(planCommand);
+	await planCommand.handler("", context.ctx);
+	assert.equal(interactiveLoads, 1);
+	assert.ok(showSettings);
+
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionShutdown);
+	await sessionShutdown({}, context.ctx);
+	await showSettings(new AbortController().signal);
+
+	assert.equal(interactiveLoads, 1);
 });
 
 test("plan_mode_complete result renders the plan as Markdown", () => {

--- a/extensions/pi-plan-mode/test/plan-mode.test.ts
+++ b/extensions/pi-plan-mode/test/plan-mode.test.ts
@@ -31,6 +31,26 @@ test("plan-mode registers flag, question tool, command, and safety hooks", () =>
 	assert.ok(mock.events.has("before_agent_start"));
 });
 
+test("non-interactive Plan routes do not load interactive UI", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	let interactiveLoads = 0;
+	planMode(mock.pi, {
+		readSettings: async () => ({ kind: "missing" as const }),
+		loadInteractiveUi: async () => {
+			interactiveLoads += 1;
+			return import("../src/interactive-ui.js");
+		},
+	});
+	const context = createMockContext({ mode: "tui" });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	assert.equal(interactiveLoads, 0);
+
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	assert.equal(interactiveLoads, 0);
+	await mock.commands.get("plan")?.handler("write a release plan", context.ctx);
+	assert.equal(interactiveLoads, 0);
+});
+
 test("plan_mode_complete result renders the plan as Markdown", () => {
 	initTheme("dark");
 	const mock = createMockPi({ activeTools: ["read", "bash"] });


### PR DESCRIPTION
## Summary
- keep Plan safety, tools, prompts, and state eager
- load launch/action/saved/implementation/settings UI only on interactive routes
- preserve controller and workflow generation checks after async loads

## Performance
- isolated import median: ~503 ms → 182 ms

## Verification
- Biome, boundaries, workspace typechecks, test compilation
- plan-mode 39/39; launch-menu 16/16
- `just pack plan-mode`; offline Pi RPC load

The aggregate check was attempted but is multi-minute and hit unrelated macOS realpath/flaky failures. Per the requested one-minute command cap, bounded gates were used instead.