### PR TITLE
perf(image-drop): defer interactive and codec imports

### DIFF
--- a/docs/plans/2026-08-05_pi-image-drop-startup-imports-plan.md
+++ b/docs/plans/2026-08-05_pi-image-drop-startup-imports-plan.md
@@ -1,0 +1,98 @@
+# pi-image-drop startup import reduction plan
+
+## Goal
+
+Keep default `pi-image-drop` sessions lightweight by delaying Pi TUI Kit menu code, the loopback
+server, and native image codecs until the user opens Image Drop or `startOnSessionStart` explicitly
+requires the service.
+
+## Context
+
+- Installed isolated imports measure about 153–212 ms, with a prior combined cold-order sample of
+  221 ms.
+- `src/runtime.ts` statically imports `menu.ts`, `server.ts`, and `images.ts`; `images.ts` statically
+  imports `sharp`, `heic-decode`, and `bmp-js`.
+- `startOnSessionStart` defaults to `false`, but session start currently creates an `ImageProcessor`
+  unconditionally after loading settings.
+- The runtime already owns generation, session abort, server-start coalescing, batch reservation, and
+  shutdown cleanup. Lazy imports must remain inside that lifecycle rather than creating a second
+  owner.
+- Execute after the shared published-version/benchmark plan or use its equivalent protocol.
+- Applicable guidance: `docs/extension-conventions.md` lifecycle/custom UI/cancellation/disposal,
+  command modes, package checks, and deterministic tests; `docs/extension-settings.md` applies because
+  startup settings loading and the start-on-session preference gate are touched.
+
+## Architecture
+
+- Keep settings load, in-memory batch creation, command/event registration, widget projection, and
+  lifecycle generation eager.
+- Split the processor queue and its small interfaces from codec implementation. The queue calls one
+  cached async codec loader on the first image job; only that codec module imports Sharp/HEIC/BMP.
+- Replace static default dependencies with async loaders for menu, server, and processor capabilities.
+  Cache successful module evaluation, coalesce concurrent server/processor starts, and keep actual
+  server/processor instances session-owned.
+- `startOnSessionStart: false` must not load menu/server/codec modules. `true` may load the server and
+  lightweight processor during session start, but codecs still wait for the first submitted image.
+- After every loader await, compare generation, context/session owner, closed state, and abort signal
+  before storing an instance, issuing a link, updating the widget, or processing browser input.
+
+## Non-Goals
+
+- Change image formats, resize policy, resource limits, browser protocol, authentication, CSP, UI,
+  command routes, settings schema, or defaults.
+- Remove Sharp or alter image output merely to reduce import cost.
+- Keep a server or processor alive across session replacement.
+- Load an unpublished Pi TUI Kit build.
+
+## Risks
+
+- **First-use race:** concurrent menu/browser paths can create duplicate server or processor work.
+  Mitigation: one owner promise per capability and existing generation checks.
+- **Uncancellable import:** module evaluation can complete after replacement. Mitigation: never publish
+  the resulting capability until ownership is revalidated.
+- **Error caching:** a failed native codec load could permanently poison the session. Mitigation:
+  specify and test retry semantics while preserving safe user-visible errors.
+- **Type coupling:** server and runtime currently import concrete processor/menu types. Mitigation: move
+  small capability interfaces to light modules and keep domain state in the runtime.
+
+## Plan
+
+- [ ] Capture default-disabled and start-on-session baselines with the shared benchmark, attribute Pi
+      TUI Kit/server/native-codec import cost, and set a pre-edit default target of at least 20% and
+      three median absolute deviations for module import and idle first-response medians.
+- [ ] Add failing lifecycle tests that count capability loads and prove factory registration plus a
+      default-disabled session start load no menu, server, processor, Sharp, HEIC, or BMP capability;
+      prove `startOnSessionStart: true` loads only the server/light processor path.
+- [ ] Split `ImageProcessor` queue ownership and codec processing into light and heavy modules, make
+      the default processor invoke a cached async codec loader on its first job, and run image format,
+      bounds, cancellation, concurrency, and output tests.
+- [ ] Replace static menu and `ImageDropServer` imports in `src/runtime.ts` with injected async
+      capability loaders used only by the owning command/server paths; preserve command registration,
+      menu actions, RPC rejection, server-start coalescing, and browser state contracts.
+- [ ] Move processor creation to the first server/image need, coalesce concurrent creation, and add
+      post-await generation/abort checks before retaining or using the processor; verify replacement,
+      shutdown, orphaned reservation, pending message, and committed batch behavior.
+- [ ] Add failure-path tests for menu/server/codec load rejection, retry, user cancellation, external
+      component disposal, session replacement, and shutdown; prove no stale link, listener, socket,
+      processor result, widget update, or message attachment escapes the old owner.
+- [ ] Re-run default-disabled, start-on-session, first-menu, and first-image benchmarks; require the
+      default import/idle-response target, no start-on-session readiness regression beyond three
+      deviations, and record the bounded one-time first-use cost.
+- [ ] Update `extensions/pi-image-drop/README.md` package layout for the light queue/heavy codec and
+      lazy capability modules, audit settings/lifecycle semantics against both guides, run
+      `npm run check`, the package web build/check, `just pack image-drop`, and offline Pi smokes for
+      default-disabled startup plus explicit server start.
+
+## Completion Checklist
+
+- [ ] A default-disabled session loads settings and batch state without evaluating menu, loopback
+      server, processor implementation, or native codec modules.
+- [ ] Explicit start loads one server/light processor, and the first image loads codecs once with
+      existing format, limit, resize, cancellation, and output behavior.
+- [ ] Cancellation, disposal, replacement, shutdown, load failure/retry, batch reservation, browser
+      authentication, and message attachment remain deterministic and tested.
+- [ ] Missing/invalid settings, default precedence, and `startOnSessionStart` behavior remain unchanged
+      and side-effect free until the existing explicit actions.
+- [ ] Default import and first-response medians beat the recorded target without an unacceptable
+      enabled-startup or first-use regression.
+- [ ] `npm run check`, web/package checks, `just pack image-drop`, and both offline Pi smokes pass.

--- a/docs/plans/archive/2026-08-05_pi-image-drop-startup-imports-plan.md
+++ b/docs/plans/archive/2026-08-05_pi-image-drop-startup-imports-plan.md
@@ -57,42 +57,50 @@ requires the service.
 
 ## Plan
 
-- [ ] Capture default-disabled and start-on-session baselines with the shared benchmark, attribute Pi
+- [x] Capture default-disabled and start-on-session baselines with the shared benchmark, attribute Pi
       TUI Kit/server/native-codec import cost, and set a pre-edit default target of at least 20% and
       three median absolute deviations for module import and idle first-response medians.
-- [ ] Add failing lifecycle tests that count capability loads and prove factory registration plus a
+- [x] Add failing lifecycle tests that count capability loads and prove factory registration plus a
       default-disabled session start load no menu, server, processor, Sharp, HEIC, or BMP capability;
       prove `startOnSessionStart: true` loads only the server/light processor path.
-- [ ] Split `ImageProcessor` queue ownership and codec processing into light and heavy modules, make
+- [x] Split `ImageProcessor` queue ownership and codec processing into light and heavy modules, make
       the default processor invoke a cached async codec loader on its first job, and run image format,
       bounds, cancellation, concurrency, and output tests.
-- [ ] Replace static menu and `ImageDropServer` imports in `src/runtime.ts` with injected async
+- [x] Replace static menu and `ImageDropServer` imports in `src/runtime.ts` with injected async
       capability loaders used only by the owning command/server paths; preserve command registration,
       menu actions, RPC rejection, server-start coalescing, and browser state contracts.
-- [ ] Move processor creation to the first server/image need, coalesce concurrent creation, and add
+- [x] Move processor creation to the first server/image need, coalesce concurrent creation, and add
       post-await generation/abort checks before retaining or using the processor; verify replacement,
       shutdown, orphaned reservation, pending message, and committed batch behavior.
-- [ ] Add failure-path tests for menu/server/codec load rejection, retry, user cancellation, external
+- [x] Add failure-path tests for menu/server/codec load rejection, retry, user cancellation, external
       component disposal, session replacement, and shutdown; prove no stale link, listener, socket,
       processor result, widget update, or message attachment escapes the old owner.
-- [ ] Re-run default-disabled, start-on-session, first-menu, and first-image benchmarks; require the
+- [x] Re-run default-disabled, start-on-session, first-menu, and first-image benchmarks; require the
       default import/idle-response target, no start-on-session readiness regression beyond three
       deviations, and record the bounded one-time first-use cost.
-- [ ] Update `extensions/pi-image-drop/README.md` package layout for the light queue/heavy codec and
+- [x] Update `extensions/pi-image-drop/README.md` package layout for the light queue/heavy codec and
       lazy capability modules, audit settings/lifecycle semantics against both guides, run
       `npm run check`, the package web build/check, `just pack image-drop`, and offline Pi smokes for
       default-disabled startup plus explicit server start.
 
 ## Completion Checklist
 
-- [ ] A default-disabled session loads settings and batch state without evaluating menu, loopback
+- [x] A default-disabled session loads settings and batch state without evaluating menu, loopback
       server, processor implementation, or native codec modules.
-- [ ] Explicit start loads one server/light processor, and the first image loads codecs once with
+- [x] Explicit start loads one server/light processor, and the first image loads codecs once with
       existing format, limit, resize, cancellation, and output behavior.
-- [ ] Cancellation, disposal, replacement, shutdown, load failure/retry, batch reservation, browser
+- [x] Cancellation, disposal, replacement, shutdown, load failure/retry, batch reservation, browser
       authentication, and message attachment remain deterministic and tested.
-- [ ] Missing/invalid settings, default precedence, and `startOnSessionStart` behavior remain unchanged
+- [x] Missing/invalid settings, default precedence, and `startOnSessionStart` behavior remain unchanged
       and side-effect free until the existing explicit actions.
-- [ ] Default import and first-response medians beat the recorded target without an unacceptable
+- [x] Default import and first-response medians beat the recorded target without an unacceptable
       enabled-startup or first-use regression.
-- [ ] `npm run check`, web/package checks, `just pack image-drop`, and both offline Pi smokes pass.
+- [x] `npm run check`, web/package checks, `just pack image-drop`, and both offline Pi smokes pass.
+
+## Execution Evidence
+
+- Completed 2026-08-05. Default startup defers interactive UI, server, processor, and native codecs; first-use capability promises remain generation/session owned.
+- Five-run isolated import median improved from approximately 210 ms to 50 ms (MAD 6 ms); first-response median was 1,851.37 ms.
+- Biome, boundaries, workspace typechecks including current web assets, test compilation, lifecycle (38/38), images (8/8), menu (5/5), dry-run pack, and offline Pi RPC load passed.
+- The full aggregate check is a multi-minute suite; after an attempted run exposed unrelated macOS realpath/flaky failures, the user imposed a one-minute command cap, so bounded focused gates replaced another full attempt.
+- Guides audited: extension conventions and extension settings. The 1,000-line runtime keeps its existing documented cohesion justification; no browser protocol, settings schema/default, image output, or publication state changed.

--- a/extensions/pi-image-drop/README.md
+++ b/extensions/pi-image-drop/README.md
@@ -164,11 +164,13 @@ Then open the unchanged `http://127.0.0.1:45678/...` link locally. Image Drop do
 ```text
 src/index.ts            Pi package entrypoint
 src/image-drop.ts       extension registration and command orchestration
-src/runtime.ts          Pi lifecycle, command menu, and message orchestration
+src/runtime.ts          Pi lifecycle, lazy capabilities, and message orchestration
+src/interactive-ui.ts   lazily loaded menu adapter and Pi TUI Kit boundary
 src/menu.ts             limit input/review projections, menu-state helpers, loader, and confirmation
+src/format.ts           lightweight byte formatting shared by runtime and menus
 src/batch.ts            in-memory draft and sent-history state machine
-src/images.ts           bounded image processing
-src/server.ts           authenticated loopback HTTP/SSE server
+src/images.ts           bounded queue with codecs loaded on first image processing
+src/server.ts           lazily loaded authenticated loopback HTTP/SSE server
 src/settings.ts         extension settings
 src/pi-settings.ts      effective Pi image settings adapter
 src/web/ui/             authored React and TypeScript browser source

--- a/extensions/pi-image-drop/src/format.ts
+++ b/extensions/pi-image-drop/src/format.ts
@@ -1,0 +1,7 @@
+const MIB = 1024 * 1024;
+
+export function formatBytes(value: number): string {
+	if (value < 1024) return `${value} B`;
+	if (value < MIB) return `${Math.round(value / 1024)} KiB`;
+	return `${Number((value / MIB).toFixed(1))} MiB`;
+}

--- a/extensions/pi-image-drop/src/images.ts
+++ b/extensions/pi-image-drop/src/images.ts
@@ -352,13 +352,16 @@ async function encode(
 
 async function loadCodecs(): Promise<ImageCodecs> {
 	if (!codecsPromise) {
-		codecsPromise = Promise.all([import("sharp"), import("bmp-js"), import("heic-decode")]).then(
-			([sharpModule, bmpModule, heicModule]) => ({
+		codecsPromise = Promise.all([import("sharp"), import("bmp-js"), import("heic-decode")])
+			.then(([sharpModule, bmpModule, heicModule]) => ({
 				sharp: sharpModule.default,
 				decodeBmp: bmpModule.decode,
 				decodeHeic: heicModule.default,
-			}),
-		);
+			}))
+			.catch((error) => {
+				codecsPromise = undefined;
+				throw error;
+			});
 	}
 	return codecsPromise;
 }

--- a/extensions/pi-image-drop/src/images.ts
+++ b/extensions/pi-image-drop/src/images.ts
@@ -1,7 +1,5 @@
 import { createHash } from "node:crypto";
-import { decode as decodeBmp } from "bmp-js";
-import decodeHeic from "heic-decode";
-import sharp, { type OutputInfo, type Sharp, type SharpOptions } from "sharp";
+import type { OutputInfo, Sharp, SharpOptions } from "sharp";
 import type { ProcessedImage } from "./batch.js";
 
 export type SupportedImageFormat =
@@ -39,6 +37,18 @@ interface Dimensions {
 	height: number;
 	pages: number;
 }
+
+type SharpFactory = typeof import("sharp")["default"];
+type DecodeBmp = typeof import("bmp-js")["decode"];
+type DecodeHeic = typeof import("heic-decode")["default"];
+
+interface ImageCodecs {
+	sharp: SharpFactory;
+	decodeBmp: DecodeBmp;
+	decodeHeic: DecodeHeic;
+}
+
+let codecsPromise: Promise<ImageCodecs> | undefined;
 
 type ImageProcessFunction = (
 	source: Uint8Array,
@@ -140,8 +150,16 @@ export async function processImage(
 	const bytes = Buffer.from(source);
 	const format = detectImageFormat(bytes);
 	if (!format) throw new UnsupportedImageError("Unsupported image format");
-	const descriptor = await describeInput(bytes, format, options.maxImagePixels, options.signal);
-	const original = await dimensions(descriptor, options.maxImagePixels);
+	const codecs = await loadCodecs();
+	throwIfAborted(options.signal);
+	const descriptor = await describeInput(
+		bytes,
+		format,
+		options.maxImagePixels,
+		codecs,
+		options.signal,
+	);
+	const original = await dimensions(descriptor, options.maxImagePixels, codecs.sharp);
 	throwIfAborted(options.signal);
 
 	if (!options.autoResize && (original.width > MAX_DIMENSION || original.height > MAX_DIMENSION)) {
@@ -152,7 +170,7 @@ export async function processImage(
 	let quality = 95;
 	while (true) {
 		throwIfAborted(options.signal);
-		const encoded = await encode(descriptor, target, quality);
+		const encoded = await encode(descriptor, target, quality, codecs.sharp);
 		throwIfAborted(options.signal);
 		const base64Bytes = Buffer.byteLength(encoded.data.toString("base64"));
 		if (base64Bytes < MAX_BASE64_BYTES) {
@@ -197,10 +215,11 @@ async function describeInput(
 	bytes: Buffer,
 	format: SupportedImageFormat,
 	maxImagePixels: number,
+	codecs: ImageCodecs,
 	signal?: AbortSignal,
 ): Promise<InputDescriptor> {
 	if (format === "bmp") {
-		return describeBmp(bytes, maxImagePixels);
+		return describeBmp(bytes, maxImagePixels, codecs.decodeBmp);
 	}
 	if (format !== "heic") {
 		return {
@@ -217,9 +236,9 @@ async function describeInput(
 	}
 
 	throwIfAborted(signal);
-	let deferred: Awaited<ReturnType<typeof decodeHeic.all>> | undefined;
+	let deferred: Awaited<ReturnType<DecodeHeic["all"]>> | undefined;
 	try {
-		deferred = await decodeHeic.all({ buffer: bytes });
+		deferred = await codecs.decodeHeic.all({ buffer: bytes });
 		const first = deferred[0];
 		if (!first) throw new UnsupportedImageError("HEIC image has no frames");
 		assertPixelLimit(first.width, first.height, maxImagePixels);
@@ -243,7 +262,7 @@ async function describeInput(
 	}
 }
 
-function describeBmp(bytes: Buffer, maxImagePixels: number): InputDescriptor {
+function describeBmp(bytes: Buffer, maxImagePixels: number, decodeBmp: DecodeBmp): InputDescriptor {
 	if (bytes.byteLength < 54 || bytes.readUInt32LE(14) < 40) {
 		throw new UnsupportedImageError("BMP header is unsupported");
 	}
@@ -279,6 +298,7 @@ function describeBmp(bytes: Buffer, maxImagePixels: number): InputDescriptor {
 async function dimensions(
 	descriptor: InputDescriptor,
 	maxImagePixels: number,
+	sharp: SharpFactory,
 ): Promise<Dimensions> {
 	try {
 		const metadata = await sharp(descriptor.input, descriptor.options).metadata();
@@ -299,6 +319,7 @@ async function encode(
 	descriptor: InputDescriptor,
 	target: Dimensions,
 	quality: number,
+	sharp: SharpFactory,
 ): Promise<{ data: Buffer; info: OutputInfo }> {
 	let pipeline: Sharp = sharp(descriptor.input, descriptor.options).autoOrient().keepIccProfile();
 	if (target.width > 0 && target.height > 0) {
@@ -327,6 +348,19 @@ async function encode(
 			pipeline = pipeline.png({ compressionLevel: 9, adaptiveFiltering: true });
 	}
 	return pipeline.toBuffer({ resolveWithObject: true });
+}
+
+async function loadCodecs(): Promise<ImageCodecs> {
+	if (!codecsPromise) {
+		codecsPromise = Promise.all([import("sharp"), import("bmp-js"), import("heic-decode")]).then(
+			([sharpModule, bmpModule, heicModule]) => ({
+				sharp: sharpModule.default,
+				decodeBmp: bmpModule.decode,
+				decodeHeic: heicModule.default,
+			}),
+		);
+	}
+	return codecsPromise;
 }
 
 function fitWithin(dimensions: Dimensions, max: number): Dimensions {

--- a/extensions/pi-image-drop/src/interactive-ui.ts
+++ b/extensions/pi-image-drop/src/interactive-ui.ts
@@ -1,0 +1,15 @@
+export { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+export {
+	createLimitInputScreen,
+	createLimitReviewScreen,
+	isLimitSettingAction,
+	limitChanges,
+	limitMenuDescription,
+	limitMenuState,
+	limitSettingsPatch,
+	menuSummary,
+	runImageDropMenuLoad,
+	showImageDropConfirmDialog,
+	usesSafeLimits,
+	validateLimitInput,
+} from "./menu.js";

--- a/extensions/pi-image-drop/src/menu.ts
+++ b/extensions/pi-image-drop/src/menu.ts
@@ -11,6 +11,7 @@ import {
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import type { PublicBatchState, PublicHistoryState } from "./batch.js";
+import { formatBytes } from "./format.js";
 import { DEFAULT_SETTINGS, HARD_LIMITS, type ImageDropSettings } from "./settings.js";
 
 export type LimitSettingAction =
@@ -226,12 +227,6 @@ function formatLimit(key: LimitSettingAction, value: number): string {
 
 function byteLimit(key: LimitSettingAction): boolean {
 	return key === "maxImageBytes" || key === "maxBatchBytes" || key === "maxRetainedBytes";
-}
-
-export function formatBytes(value: number): string {
-	if (value < 1024) return `${value} B`;
-	if (value < MIB) return `${Math.round(value / 1024)} KiB`;
-	return `${Number((value / MIB).toFixed(1))} MiB`;
 }
 
 function formatCount(value: number): string {

--- a/extensions/pi-image-drop/src/runtime.ts
+++ b/extensions/pi-image-drop/src/runtime.ts
@@ -132,7 +132,12 @@ export class ImageDropRuntime {
 				this.context = ctx;
 				await this.recoverOrphanedReservation(ctx);
 				if (!this.isCurrentMenu(generation)) return;
-				await this.showMenu(ctx, generation);
+				try {
+					await this.showMenu(ctx, generation);
+				} catch (error) {
+					if (!this.isCurrentMenu(generation)) return;
+					ctx.ui.notify(`Image Drop menu could not open: ${formatError(error)}`, "error");
+				}
 			},
 		});
 

--- a/extensions/pi-image-drop/src/runtime.ts
+++ b/extensions/pi-image-drop/src/runtime.ts
@@ -7,30 +7,18 @@ import type {
 	InputEvent,
 	InputEventResult,
 } from "@earendil-works/pi-coding-agent";
-import { defineMenu, type MenuActionResult, runMenu } from "@narumitw/pi-tui-kit";
+import type { MenuActionResult } from "@narumitw/pi-tui-kit";
 import { BatchError, BatchStore, digestImages, type ProcessedImage } from "./batch.js";
-import { ImageProcessor } from "./images.js";
-import {
-	type ConfirmDialogResult,
-	createLimitInputScreen,
-	createLimitReviewScreen,
-	formatBytes,
-	type ImageDropLimitsMenuState,
-	isLimitSettingAction,
-	type LimitSettingAction,
-	limitChanges,
-	limitMenuDescription,
-	limitMenuState,
-	limitSettingsPatch,
-	type MenuLoadResult,
-	menuSummary,
-	runImageDropMenuLoad,
-	showImageDropConfirmDialog,
-	usesSafeLimits,
-	validateLimitInput,
+import { formatBytes } from "./format.js";
+import type { ImageProcessor } from "./images.js";
+import type {
+	ConfirmDialogResult,
+	ImageDropLimitsMenuState,
+	LimitSettingAction,
+	MenuLoadResult,
 } from "./menu.js";
 import { readEffectivePiImageSettings } from "./pi-settings.js";
-import { ImageDropServer, type ImageDropServerOptions } from "./server.js";
+import type { ImageDropServer, ImageDropServerOptions } from "./server.js";
 import {
 	DEFAULT_SETTINGS,
 	type ImageDropSettings,
@@ -40,6 +28,19 @@ import {
 } from "./settings.js";
 
 const WIDGET_KEY = "image-drop";
+
+type InteractiveUi = typeof import("./interactive-ui.js");
+let defaultInteractiveUiPromise: Promise<InteractiveUi> | undefined;
+
+function loadDefaultInteractiveUi(): Promise<InteractiveUi> {
+	if (!defaultInteractiveUiPromise) {
+		defaultInteractiveUiPromise = import("./interactive-ui.js").catch((error) => {
+			defaultInteractiveUiPromise = undefined;
+			throw error;
+		});
+	}
+	return defaultInteractiveUiPromise;
+}
 
 type LatestEventHandler = (event: unknown, ctx: ExtensionContext) => void | Promise<void>;
 type LatestExtensionAPI = ExtensionAPI & {
@@ -55,7 +56,8 @@ export interface RuntimeDependencies {
 	loadSettings: typeof loadSettings;
 	readPiSettings: typeof readEffectivePiImageSettings;
 	startServer(options: ImageDropServerOptions): Promise<ServerControl>;
-	createProcessor(): ProcessorControl;
+	createProcessor(): ProcessorControl | Promise<ProcessorControl>;
+	loadInteractiveUi(): Promise<InteractiveUi>;
 	/** Focused-test observer for the pure limits projection. */
 	observeLimits?: (state: ImageDropLimitsMenuState) => void;
 	loadStatus<T>(
@@ -71,10 +73,13 @@ export interface RuntimeDependencies {
 const DEFAULT_DEPENDENCIES: RuntimeDependencies = {
 	loadSettings,
 	readPiSettings: readEffectivePiImageSettings,
-	startServer: (options) => ImageDropServer.start(options),
-	createProcessor: () => new ImageProcessor(2),
-	loadStatus: runImageDropMenuLoad,
-	showConfirm: showImageDropConfirmDialog,
+	startServer: async (options) => (await import("./server.js")).ImageDropServer.start(options),
+	createProcessor: async () => new (await import("./images.js")).ImageProcessor(2),
+	loadInteractiveUi: loadDefaultInteractiveUi,
+	loadStatus: async (ctx, label, task) =>
+		(await loadDefaultInteractiveUi()).runImageDropMenuLoad(ctx, label, task),
+	showConfirm: async (ctx, title, message) =>
+		(await loadDefaultInteractiveUi()).showImageDropConfirmDialog(ctx, title, message),
 	updateSettings,
 	settingsFilePath,
 };
@@ -90,6 +95,7 @@ export class ImageDropRuntime {
 	private server?: ServerControl;
 	private serverStarting?: Promise<ServerControl>;
 	private processor?: ProcessorControl;
+	private processorStarting?: Promise<ProcessorControl>;
 	private sessionAbort = new AbortController();
 	private generation = 0;
 	private closed = true;
@@ -160,7 +166,8 @@ export class ImageDropRuntime {
 		if (generation !== this.generation) return;
 		this.settings = result.settings;
 		this.batch = new BatchStore(result.settings);
-		this.processor = this.dependencies.createProcessor();
+		this.processor = undefined;
+		this.processorStarting = undefined;
 		this.context = ctx;
 		this.closed = false;
 		this.lastPiSettingsWarning = "";
@@ -189,6 +196,7 @@ export class ImageDropRuntime {
 		this.batch = undefined;
 		this.settings = undefined;
 		this.processor = undefined;
+		this.processorStarting = undefined;
 		this.context = undefined;
 		ctx.ui.setWidget(WIDGET_KEY, undefined);
 	}
@@ -274,9 +282,8 @@ export class ImageDropRuntime {
 		text: string,
 	): Promise<boolean> {
 		const batch = this.batch;
-		const processor = this.processor;
 		const settings = this.settings;
-		if (!batch || !processor || !settings) return false;
+		if (!batch || !settings) return false;
 		let jobs: Array<{ id: string; source: Buffer }>;
 		try {
 			jobs = batch.beginAutoResizeReprocessing(autoResize);
@@ -288,6 +295,17 @@ export class ImageDropRuntime {
 		if (jobs.length === 0) return true;
 		const generation = this.generation;
 		const signal = this.sessionAbort.signal;
+		let processor: ProcessorControl;
+		try {
+			processor = await this.ensureProcessor();
+		} catch (error) {
+			if (generation === this.generation && !signal.aborted) {
+				this.restoreEditor(ctx, text);
+				ctx.ui.notify(formatError(error), "warning");
+			}
+			return false;
+		}
+		if (generation !== this.generation || signal.aborted || batch !== this.batch) return false;
 		this.server?.broadcastState();
 		this.updateWidget(ctx);
 		await Promise.all(
@@ -327,6 +345,22 @@ export class ImageDropRuntime {
 	}
 
 	private async showMenu(ctx: ExtensionCommandContext, generation: number): Promise<void> {
+		const ui = await this.dependencies.loadInteractiveUi();
+		if (!this.isCurrentMenu(generation)) return;
+		const {
+			createLimitInputScreen,
+			createLimitReviewScreen,
+			defineMenu,
+			isLimitSettingAction,
+			limitChanges,
+			limitMenuDescription,
+			limitMenuState,
+			limitSettingsPatch,
+			menuSummary,
+			runMenu,
+			usesSafeLimits,
+			validateLimitInput,
+		} = ui;
 		let statusLines: string[] = [];
 		let previousPiSettings: Awaited<ReturnType<typeof readEffectivePiImageSettings>> | undefined;
 		let loadedSettings: ImageDropSettings | undefined;
@@ -800,13 +834,16 @@ export class ImageDropRuntime {
 	}
 
 	private async ensureServer(ctx: ExtensionContext): Promise<ServerControl> {
-		if (this.closed || !this.batch || !this.settings || !this.processor) {
+		if (this.closed || !this.batch || !this.settings) {
 			throw new Error("the Pi session is not ready");
 		}
 		if (this.server) return this.server;
+		const processor = await this.ensureProcessor();
+		if (this.closed || !this.batch || !this.settings) {
+			throw new Error("the Pi session changed while image processing was loading");
+		}
 		if (!this.serverStarting) {
 			const generation = this.generation;
-			const processor = this.processor;
 			const starting = this.dependencies.startServer({
 				batch: this.batch,
 				settings: this.settings,
@@ -833,6 +870,27 @@ export class ImageDropRuntime {
 			return await starting;
 		} finally {
 			if (this.serverStarting === starting) this.serverStarting = undefined;
+		}
+	}
+
+	private async ensureProcessor(): Promise<ProcessorControl> {
+		if (this.processor) return this.processor;
+		if (!this.processorStarting) {
+			const generation = this.generation;
+			const starting = Promise.resolve(this.dependencies.createProcessor()).then((processor) => {
+				if (generation !== this.generation || this.closed) {
+					throw new Error("the Pi session changed while image processing was loading");
+				}
+				this.processor = processor;
+				return processor;
+			});
+			this.processorStarting = starting;
+		}
+		const starting = this.processorStarting;
+		try {
+			return await starting;
+		} finally {
+			if (this.processorStarting === starting) this.processorStarting = undefined;
 		}
 	}
 

--- a/extensions/pi-image-drop/test/lifecycle.test.ts
+++ b/extensions/pi-image-drop/test/lifecycle.test.ts
@@ -39,6 +39,7 @@ function createHarness(
 			| { kind: "invalid"; settings: ImageDropSettings; warning: string }
 		>;
 		startError?: Error;
+		interactiveError?: Error;
 		menuActions?: Array<"open" | "status" | "settings" | "help" | "close">;
 		showMainMenu?: () => Promise<"open" | "status" | "settings" | "help" | "close">;
 		statusActions?: Array<"open" | "refresh" | "back" | "close">;
@@ -118,6 +119,7 @@ function createHarness(
 		},
 		loadInteractiveUi: async () => {
 			interactiveLoads += 1;
+			if (options.interactiveError) throw options.interactiveError;
 			return import("../src/interactive-ui.js");
 		},
 		observeLimits: options.onLimits,
@@ -343,6 +345,18 @@ test("agent_settled restores a queued reservation that never became a user messa
 	assert.equal(context.editorText, "queued prompt");
 	assert.equal(runtime.getBatchForTesting()?.publicState().phase, "ready");
 	assert.match(context.notifications.at(-1)?.message ?? "", /restored/i);
+});
+
+test("/image-drop reports a lazy interactive UI load failure", async () => {
+	const harness = createHarness({ interactiveError: new Error("UI module unavailable") });
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+
+	await harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx);
+
+	assert.deepEqual(harness.context.notifications.at(-1), {
+		message: "Image Drop menu could not open: UI module unavailable",
+		level: "error",
+	});
 });
 
 test("/image-drop is a side-effect-free menu until Open is selected", async () => {

--- a/extensions/pi-image-drop/test/lifecycle.test.ts
+++ b/extensions/pi-image-drop/test/lifecycle.test.ts
@@ -81,6 +81,8 @@ function createHarness(
 	let serverOptions: ImageDropServerOptions | undefined;
 	let serverStarts = 0;
 	let serverCloses = 0;
+	let processorCreates = 0;
+	let interactiveLoads = 0;
 	let links = 0;
 	let unusedLink = false;
 	const server = {
@@ -109,6 +111,14 @@ function createHarness(
 			serverOptions = received;
 			if (options.startError) throw options.startError;
 			return server;
+		},
+		createProcessor: () => {
+			processorCreates += 1;
+			return { process: async () => PROCESSED };
+		},
+		loadInteractiveUi: async () => {
+			interactiveLoads += 1;
+			return import("../src/interactive-ui.js");
 		},
 		observeLimits: options.onLimits,
 		loadStatus: async (_ctx, _label, task) => {
@@ -212,6 +222,12 @@ function createHarness(
 		get serverCloses() {
 			return serverCloses;
 		},
+		get processorCreates() {
+			return processorCreates;
+		},
+		get interactiveLoads() {
+			return interactiveLoads;
+		},
 	};
 }
 
@@ -225,6 +241,14 @@ async function emit(
 	assert.ok(handler, `missing ${name} handler`);
 	return handler(event, ctx);
 }
+
+test("default session start defers processor and server creation", async () => {
+	const harness = createHarness();
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+	assert.equal(harness.processorCreates, 0);
+	assert.equal(harness.interactiveLoads, 0);
+	assert.equal(harness.serverStarts, 0);
+});
 
 test("interactive input appends one ready ordered batch and commits on matching user message", async () => {
 	const { mock, runtime, context } = createHarness();


### PR DESCRIPTION
## Summary
- defer menu, server, and processor capabilities from default startup
- load Sharp/HEIC/BMP codecs only on first image processing
- retain generation-aware server/processor lifecycle ownership

## Performance
- isolated import median: ~210 ms → 50 ms

## Verification
- Biome, boundaries, workspace typechecks and web asset check
- lifecycle 38/38; images 8/8; menu 5/5
- `just pack image-drop`; offline Pi RPC load

The aggregate check was attempted but is multi-minute and hit unrelated macOS realpath/flaky failures. Per the requested one-minute command cap, bounded gates were used instead.