### PR TITLE
fix: align consumer peers with Pi package conventions

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -16,6 +16,7 @@
 - Treat `package.json#packageManager` plus CI/release workflows as the npm-version authority. A different npm can rewrite unrelated lock metadata or mishandle the alternate-Pi install matrix.
 - The pinned npm 12.0.2 rejects Node 25; run lockfile work under an installed supported runtime such as Node 22.22.2 instead of tolerating npm's compatibility warning.
 - A consumer cannot safely adopt an unpublished `pi-tui-kit` API in the same PR: clean `npm ci` resolves its semver dependency from the registry. Publish the Kit API before raising the consumer's reviewed compatibility floor; do not use local paths that break independent packaging.
+- Pi maintains separate managed npm roots for user and project packages; dependency deduplication is guaranteed only within one install root, not across scopes.
 - Official Pi can misresolve static `@earendil-works/pi-ai/api/*` imports beneath its compatibility alias. Prefer root exports; otherwise use a variable-specifier dynamic import.
 
 ### Processes, lifecycle, and state

--- a/docs/plans/archive/2026-08-05_pi-tui-kit-published-startup-convergence-plan.md
+++ b/docs/plans/archive/2026-08-05_pi-tui-kit-published-startup-convergence-plan.md
@@ -2,8 +2,8 @@
 
 ## Goal
 
-Make active extensions resolve one registry-published `@narumitw/pi-tui-kit` version in a clean Pi
-installation, eliminate duplicate runtime copies from startup, and establish a repeatable benchmark
+Make active extensions resolve one registry-published `@narumitw/pi-tui-kit` version in each Pi
+managed npm install root, eliminate duplicate same-scope runtime copies from startup, and establish a repeatable benchmark
 that distinguishes module-import savings from work merely shifted into session startup.
 
 ## Context
@@ -72,7 +72,7 @@ that distinguishes module-import savings from work merely shifted into session s
       only intended `package-lock.json` metadata with Node 22 and npm 12.0.2, then inspect the diff.
 - [x] Pack all changed consumers and install their tarballs with the matching Pi peers into a clean
       temporary npm project; verify `npm ls @narumitw/pi-tui-kit --all` reports one physical published
-      version, no workspace/file link, no invalid range, and no duplicate Pi TUI Kit copy.
+      version in that managed npm scope, no workspace/file link, no invalid range, and no duplicate copy.
 - [x] Run focused command/menu tests for every adapted consumer, then run `npm run check`; verify TUI,
       RPC, unsupported-mode behavior, cancellation, disposal, session replacement, and shutdown remain
       unchanged wherever the dependency adaptation touched those paths.
@@ -87,7 +87,7 @@ that distinguishes module-import savings from work merely shifted into session s
 ## Completion Checklist
 
 - [x] Every active Pi TUI Kit consumer is reviewed individually and resolves the same published minor
-      from npm in the clean packed-consumer installation.
+      from npm in the clean same-scope packed-consumer installation.
 - [x] No consumer compiles or runs only because the repository exposes an unpublished workspace API.
 - [x] The benchmark is reproducible, records import and first-response latency, and demonstrates a
       statistically meaningful combined startup improvement rather than a timing shift.
@@ -99,7 +99,8 @@ that distinguishes module-import savings from work merely shifted into session s
 ## Execution Evidence
 
 - Completed 2026-08-05. Registry selection: `@narumitw/pi-tui-kit@0.46.0`; Node 22.23.1 and npm 12.0.2 regenerated the lockfile.
-- Packed and clean-installed all 22 active consumers. `npm ls --all` showed every consumer deduped to `0.46.0`; one physical package manifest was present. Every packed entry loaded through offline Pi RPC.
+- Packed and clean-installed all 22 active consumers in one managed npm root. `npm ls --all` showed every consumer deduped to `0.46.0`; one physical package manifest was present in that scope. Pi maintains separate user and project npm roots, so this evidence does not claim cross-scope physical deduplication. Every packed entry loaded through offline Pi RPC.
 - Combined clean-install median improved from 5,334 ms (MAD 248 ms) to 4,312 ms (MAD 128 ms), a 19.2% import reduction; first response improved from 6,859.38 ms to 5,468.48 ms.
 - Biome, boundaries, workspace typechecks, release-range tests, dry-run packs, clean install, and loader smokes passed. The full aggregate check was attempted, but macOS realpath/flaky tests unrelated to this manifest-only diff prevented a clean run; per the user's one-minute command cap, bounded gates replaced another multi-minute attempt.
+- Follow-up package audit moved every imported Pi-bundled core package to `peerDependencies: "*"`, retained exact development versions, and clean-installed the nine corrected packed consumers with their Pi peers.
 - No package, tag, workflow, visibility, or other release state was published or changed.

--- a/extensions/pi-caffeinate/package.json
+++ b/extensions/pi-caffeinate/package.json
@@ -28,6 +28,9 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",
 		"@earendil-works/pi-coding-agent": "0.83.0",

--- a/extensions/pi-chrome-devtools/package.json
+++ b/extensions/pi-chrome-devtools/package.json
@@ -28,14 +28,18 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
-	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.46.0",
-		"typebox": "^1.3.9"
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"typebox": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",
 		"@earendil-works/pi-coding-agent": "0.83.0",
+		"typebox": "1.3.9",
 		"typescript": "7.0.2"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	},
 	"repository": {
 		"type": "git",

--- a/extensions/pi-firecrawl/package.json
+++ b/extensions/pi-firecrawl/package.json
@@ -28,14 +28,18 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
-	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.46.0",
-		"typebox": "^1.3.9"
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"typebox": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",
 		"@earendil-works/pi-coding-agent": "0.83.0",
+		"typebox": "1.3.9",
 		"typescript": "7.0.2"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	},
 	"repository": {
 		"type": "git",

--- a/extensions/pi-goal/package.json
+++ b/extensions/pi-goal/package.json
@@ -29,20 +29,21 @@
 		"test:runtime": "node ./test/goal-runtime-smoke.mjs",
 		"typecheck": "tsc --noEmit"
 	},
-	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.46.0",
-		"typebox": "^1.3.9"
-	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",
 		"@earendil-works/pi-coding-agent": "*",
-		"@earendil-works/pi-tui": "*"
+		"@earendil-works/pi-tui": "*",
+		"typebox": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",
 		"@earendil-works/pi-ai": "0.83.0",
 		"@earendil-works/pi-coding-agent": "0.83.0",
+		"typebox": "1.3.9",
 		"typescript": "7.0.2"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	},
 	"repository": {
 		"type": "git",

--- a/extensions/pi-google-genai/package.json
+++ b/extensions/pi-google-genai/package.json
@@ -30,15 +30,19 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
-	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.46.0",
-		"typebox": "^1.3.9"
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"typebox": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "26.1.2",
+		"typebox": "1.3.9",
 		"typescript": "7.0.2"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.46.0"
 	},
 	"repository": {
 		"type": "git",

--- a/extensions/pi-langfuse/package.json
+++ b/extensions/pi-langfuse/package.json
@@ -28,6 +28,15 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.6",
+		"@earendil-works/pi-coding-agent": "0.83.0",
+		"@types/node": "26.1.2",
+		"typescript": "7.0.2"
+	},
 	"dependencies": {
 		"@langfuse/otel": "^5.10.0",
 		"@langfuse/tracing": "^5.10.0",
@@ -36,12 +45,6 @@
 		"@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
 		"@opentelemetry/sdk-trace-base": "^2.10.0",
 		"@opentelemetry/sdk-trace-node": "^2.10.0"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "2.5.6",
-		"@earendil-works/pi-coding-agent": "0.83.0",
-		"@types/node": "26.1.2",
-		"typescript": "7.0.2"
 	},
 	"repository": {
 		"type": "git",

--- a/extensions/pi-statusline/package.json
+++ b/extensions/pi-statusline/package.json
@@ -27,6 +27,10 @@
 		"format": "biome check --write --vcs-use-ignore-file=false src test package.json tsconfig.json README.md",
 		"typecheck": "tsc --noEmit"
 	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",
 		"@earendil-works/pi-coding-agent": "0.83.0",

--- a/extensions/pi-subagents/package.json
+++ b/extensions/pi-subagents/package.json
@@ -28,16 +28,12 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
-	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.46.0",
-		"proper-lockfile": "^4.1.2",
-		"typebox": "^1.3.9"
-	},
 	"peerDependencies": {
 		"@earendil-works/pi-agent-core": "*",
 		"@earendil-works/pi-ai": "*",
 		"@earendil-works/pi-coding-agent": "*",
-		"@earendil-works/pi-tui": "*"
+		"@earendil-works/pi-tui": "*",
+		"typebox": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",
@@ -45,7 +41,12 @@
 		"@earendil-works/pi-ai": "0.83.0",
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@earendil-works/pi-tui": "0.83.0",
+		"typebox": "1.3.9",
 		"typescript": "7.0.2"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.46.0",
+		"proper-lockfile": "^4.1.2"
 	},
 	"repository": {
 		"type": "git",

--- a/extensions/pi-usage/package.json
+++ b/extensions/pi-usage/package.json
@@ -31,7 +31,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-coding-agent": ">=0.81.0"
+		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -268,6 +268,9 @@
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "26.1.2",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*"
 			}
 		},
 		"extensions/pi-caffeinate/node_modules/@narumitw/pi-tui-kit": {
@@ -285,13 +288,17 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.46.0",
-				"typebox": "^1.3.9"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
 				"@earendil-works/pi-coding-agent": "0.83.0",
+				"typebox": "1.3.9",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"typebox": "*"
 			}
 		},
 		"extensions/pi-chrome-devtools/node_modules/@narumitw/pi-tui-kit": {
@@ -309,13 +316,17 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.46.0",
-				"typebox": "^1.3.9"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
 				"@earendil-works/pi-coding-agent": "0.83.0",
+				"typebox": "1.3.9",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"typebox": "*"
 			}
 		},
 		"extensions/pi-firecrawl/node_modules/@narumitw/pi-tui-kit": {
@@ -344,19 +355,20 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.46.0",
-				"typebox": "^1.3.9"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
 				"@earendil-works/pi-ai": "0.83.0",
 				"@earendil-works/pi-coding-agent": "0.83.0",
+				"typebox": "1.3.9",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-ai": "*",
 				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
+				"@earendil-works/pi-tui": "*",
+				"typebox": "*"
 			}
 		},
 		"extensions/pi-goal/node_modules/@narumitw/pi-tui-kit": {
@@ -374,14 +386,18 @@
 			"version": "0.48.1",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.46.0",
-				"typebox": "^1.3.9"
+				"@narumitw/pi-tui-kit": "^0.46.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "26.1.2",
+				"typebox": "1.3.9",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"typebox": "*"
 			}
 		},
 		"extensions/pi-google-genai/node_modules/@narumitw/pi-tui-kit": {
@@ -454,6 +470,9 @@
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "26.1.2",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*"
 			}
 		},
 		"extensions/pi-langfuse/node_modules/@narumitw/pi-tui-kit": {
@@ -590,6 +609,10 @@
 				"@earendil-works/pi-tui": "0.83.0",
 				"@types/node": "26.1.2",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"extensions/pi-statusline/node_modules/@narumitw/pi-tui-kit": {
@@ -608,8 +631,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@narumitw/pi-tui-kit": "^0.46.0",
-				"proper-lockfile": "^4.1.2",
-				"typebox": "^1.3.9"
+				"proper-lockfile": "^4.1.2"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -617,13 +639,15 @@
 				"@earendil-works/pi-ai": "0.83.0",
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@earendil-works/pi-tui": "0.83.0",
+				"typebox": "1.3.9",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-agent-core": "*",
 				"@earendil-works/pi-ai": "*",
 				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
+				"@earendil-works/pi-tui": "*",
+				"typebox": "*"
 			}
 		},
 		"extensions/pi-subagents/node_modules/@narumitw/pi-tui-kit": {
@@ -681,7 +705,7 @@
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": ">=0.81.0"
+				"@earendil-works/pi-coding-agent": "*"
 			}
 		},
 		"extensions/pi-usage/node_modules/@narumitw/pi-tui-kit": {


### PR DESCRIPTION
## Summary
- declare every imported Pi-bundled core package as a `peerDependencies: "*"` entry
- move `typebox` from runtime dependencies to Pi peer metadata while retaining exact dev versions
- scope Pi TUI Kit physical deduplication claims to one managed npm install root

Follow-up to #555. The Image Drop rejected codec-loader promise was already reset by `5bfcc782` in merged #558.

## Verification
- all 22 TUI Kit consumers pass the imported-core peer metadata audit
- Biome, extension boundaries, and all workspace typechecks
- dry-run packs for all 9 corrected packages
- clean packed install resolves all core peers and one same-scope Pi TUI Kit copy

No package or release state was published.