### PR TITLE
perf(pi-accounts): lazy-load account menu

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -17,6 +17,7 @@
 - The pinned npm 12.0.2 rejects Node 25; run lockfile work under an installed supported runtime such as Node 22.22.2 instead of tolerating npm's compatibility warning.
 - A consumer cannot safely adopt an unpublished `pi-tui-kit` API in the same PR: clean `npm ci` resolves its semver dependency from the registry. Publish the Kit API before raising the consumer's reviewed compatibility floor; do not use local paths that break independent packaging.
 - Pi maintains separate managed npm roots for user and project packages; dependency deduplication is guaranteed only within one install root, not across scopes.
+- A static `pi-tui-kit` import in a source-loaded extension can evaluate a second repository-resolved Pi/TUI runtime and add over a second to startup. Lazy-load command-only menus and revalidate session ownership after the import.
 - Official Pi can misresolve static `@earendil-works/pi-ai/api/*` imports beneath its compatibility alias. Prefer root exports; otherwise use a variable-specifier dynamic import.
 
 ### Processes, lifecycle, and state

--- a/extensions/pi-accounts/src/accounts.ts
+++ b/extensions/pi-accounts/src/accounts.ts
@@ -3,7 +3,6 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import {
 	AccountStore,
 	consumeMigrationNotice,
@@ -254,6 +253,8 @@ async function showAccountsMenu(
 		ctx.ui.notify("/accounts requires interactive UI (TUI or RPC mode).", "error");
 		return;
 	}
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!owner.isCurrent()) return;
 	let selectedProviderId: AccountProviderId | undefined;
 	type State = {
 		states: Map<AccountProviderId, ProviderMenuState>;


### PR DESCRIPTION
## Summary

- defer `pi-tui-kit` evaluation until the interactive `/accounts` command is used
- revalidate menu session ownership after the lazy import
- document the source-loaded extension startup pitfall in `MEMORY.md`

## Performance

Isolated warm-filesystem startup benchmark (`5` measured runs):

- extension import median: `1435 ms` → `42 ms`
- first RPC response median: `2568.97 ms` → `1341.48 ms`
- direct `PI_TIMING=1 pi -ne -e extensions/pi-accounts/` smoke: about `63 ms` module import

## Verification

- `npm run check --workspace @narumitw/pi-accounts`
- focused `pi-accounts` tests: 46 passed
- `npm run check:boundaries`
- `npm run pack:accounts -- --json`
- `PI_TIMING=1 pi -ne -e extensions/pi-accounts/`
- `npm run check` (completed with 14 unrelated existing/environment-sensitive failures outside `pi-accounts`, mainly macOS `/var` realpath and timing/terminal-width fixtures)
