### PR TITLE
perf: lazy-load extension menus

### DIFF
--- a/docs/plans/2026-08-05_lazy-extension-menu-imports-plan.md
+++ b/docs/plans/2026-08-05_lazy-extension-menu-imports-plan.md
@@ -1,0 +1,89 @@
+# Lazy extension menu imports plan
+
+## Goal
+
+Remove the remaining eager `@narumitw/pi-tui-kit` runtime imports from active source-loaded
+extensions so no command-only menu pays the duplicate repository Pi/TUI runtime cost during startup,
+then publish the change as a separate pull request.
+
+## Context
+
+- Reversing `pi-btw` and `pi-caffeinate` load order moved the roughly 1.6–1.9 second cost to whichever
+  extension loaded first, proving that the combined timing assigns shared eager runtime work to the
+  first importer.
+- `pi-accounts`, `pi-image-drop`, `pi-plan-mode`, `pi-starship`, and `pi-sync` already demonstrate the
+  intended lazy boundary.
+- This change touches command menus and settings UI loading, not settings schemas, persistence,
+  precedence, or public command routes. Applicable guides are `docs/extension-conventions.md` and
+  `docs/extension-settings.md`.
+- The user's existing `justfile` modification is unrelated and must remain unstaged.
+
+## Architecture
+
+- Keep each extension independent. Use extension-owned dynamic imports at the narrowest command/UI
+  boundary rather than a cross-extension coordinator or an unpublished Pi TUI Kit API.
+- Where a dedicated menu module already exists, lazy-load that module from its owning command path.
+  Otherwise import Pi TUI Kit inside the menu operation immediately before its first use.
+- Dynamic imports are not cancellable. Capture each flow's existing generation, owner signal, or
+  controller before importing and revalidate it immediately after every new import await. Never open
+  UI or publish status through a replaced session.
+- Preserve non-TUI rejection/status paths before loading Pi TUI Kit and preserve all existing command,
+  menu, settings, cancellation, disposal, replacement, and shutdown behavior.
+
+## Non-Goals
+
+- Change menu UX, command grammar, settings behavior, dependency ranges, package versions, or release
+  state.
+- Optimize unrelated startup work remaining in `pi-goal`, `pi-starship`, or other package domains.
+- Modify the user's `justfile` work.
+
+## Risks
+
+- **Stale continuation:** a session can be replaced while a dynamic import is pending. Mitigation:
+  revalidate the existing owner immediately after import and cover representative replacement races.
+- **Cost shifting:** fixing only the first extension leaves another eager importer to absorb the shared
+  cost. Mitigation: audit every production `src/` runtime import and require no eagerly reachable Pi
+  TUI Kit import from any active entrypoint.
+- **First-menu regression:** lazy loading moves one-time work to the first menu invocation. Mitigation:
+  retain cached ESM imports and run existing focused command/menu tests in TUI and RPC paths.
+- **Broad verification:** aggregate tests contain known environment-sensitive failures. Mitigation:
+  run all touched-package focused tests and the full repository gate, recording unrelated failures
+  without weakening tests.
+
+## Plan
+
+- [x] Record the eager-import package inventory and representative isolated/order-reversal benchmark
+      evidence; verified 12 production and 5 experimental eager importers, with order reversal moving
+      1.6–1.9 seconds between `pi-btw` and `pi-caffeinate`.
+- [x] Convert production extensions (`pi-btw`, `pi-caffeinate`, `pi-chrome-devtools`, `pi-firecrawl`,
+      `pi-goal`, `pi-google-genai`, `pi-langfuse`, `pi-stamp`, `pi-statusline`, `pi-subagents`,
+      `pi-usage`, and `pi-worktree`) to extension-owned lazy menu imports with post-await ownership
+      checks; all 12 package typechecks passed and their changed command/menu/lifecycle assertions
+      passed in the focused run.
+- [x] Convert experimental extensions (`pi-analytics`, `pi-codex-compact`, `pi-jupyter`, `pi-recall`,
+      and `pi-webui`) to the same lazy boundary while retaining their warning and lifecycle behavior;
+      all 5 package typechecks and changed command/menu/lifecycle assertions passed.
+- [x] Audit the final runtime import graph to prove no active entrypoint eagerly reaches Pi TUI Kit,
+      then rerun isolated and combined startup benchmarks; the `pi-btw` + `pi-caffeinate` median fell
+      from about 1,808 ms to 78 ms, the user's 14-entry set measured a 1,461 ms median versus the
+      observed 3,182 ms, and all 22 Kit consumers loaded without a duplicate-runtime spike.
+- [x] Run Biome, boundary checks, touched-package tests, package dry-run packs, representative local Pi
+      loading, and `npm run check`; Biome, boundaries, 17 packs, all typechecks, and 600 focused tests
+      passed. Three focused and 14 aggregate tests reproduced pre-existing terminal-width, macOS
+      `/var` realpath, FIFO timing, and unrelated lifecycle failures; no changed assertion failed.
+- [ ] Complete and archive this plan, stage only intended files, create focused Conventional Commit(s),
+      push the branch, and open a non-draft pull request against `main` with verification and benchmark
+      evidence.
+
+## Completion Checklist
+
+- [x] No active production or experimental entrypoint eagerly evaluates `@narumitw/pi-tui-kit`.
+- [x] Every new dynamic-import continuation revalidates its owning signal, generation, or session
+      before using mutable state or UI.
+- [x] Existing changed TUI, RPC, non-UI, cancellation, disposal, replacement, shutdown, settings, and
+      command contracts remain covered and passing; unrelated pre-existing failures are recorded.
+- [x] Combined source-loaded startup no longer transfers the duplicate Pi/TUI runtime cost to another
+      extension and improves by more than benchmark variance.
+- [x] Package checks, focused tests, pack smokes, local Pi smoke, and the repository gate have recorded
+      evidence; the 14 unrelated aggregate failures are explicitly reported above.
+- [ ] The pull request contains no `justfile` changes and performs no publication or release mutation.

--- a/docs/plans/archived/2026-08-05_lazy-extension-menu-imports-plan.md
+++ b/docs/plans/archived/2026-08-05_lazy-extension-menu-imports-plan.md
@@ -71,9 +71,9 @@ then publish the change as a separate pull request.
       loading, and `npm run check`; Biome, boundaries, 17 packs, all typechecks, and 600 focused tests
       passed. Three focused and 14 aggregate tests reproduced pre-existing terminal-width, macOS
       `/var` realpath, FIFO timing, and unrelated lifecycle failures; no changed assertion failed.
-- [ ] Complete and archive this plan, stage only intended files, create focused Conventional Commit(s),
-      push the branch, and open a non-draft pull request against `main` with verification and benchmark
-      evidence.
+- [x] Complete and archive this plan, stage only intended files, create focused Conventional Commit(s),
+      push the branch, and open non-draft pull request #562 against `main` with verification and
+      benchmark evidence.
 
 ## Completion Checklist
 
@@ -86,4 +86,5 @@ then publish the change as a separate pull request.
       extension and improves by more than benchmark variance.
 - [x] Package checks, focused tests, pack smokes, local Pi smoke, and the repository gate have recorded
       evidence; the 14 unrelated aggregate failures are explicitly reported above.
-- [ ] The pull request contains no `justfile` changes and performs no publication or release mutation.
+- [x] Pull request #562 contains no `justfile` changes and performed no publication or release
+      mutation.

--- a/experimental/pi-analytics/src/menu.ts
+++ b/experimental/pi-analytics/src/menu.ts
@@ -1,6 +1,6 @@
 import { stripVTControlCharacters } from "node:util";
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu, runTask } from "@narumitw/pi-tui-kit";
+import type { MenuDefinition } from "@narumitw/pi-tui-kit";
 import type { ClearAnalyticsResult } from "./storage/files.js";
 import type {
 	AnalyticsSnapshot,
@@ -50,7 +50,7 @@ export function createAnalyticsMenu(source: AnalyticsMenuDataSource, now: () => 
 	};
 	const getState = ({ signal }: { signal: AbortSignal }): Promise<AnalyticsMenuState> =>
 		loadState(signal);
-	const menu = defineMenu<AnalyticsMenuState, Screen, Action>({
+	const menu: MenuDefinition<AnalyticsMenuState, Screen, Action> = {
 		start: "main",
 		screens: {
 			main: ({ state }) => ({
@@ -142,7 +142,7 @@ export function createAnalyticsMenu(source: AnalyticsMenuDataSource, now: () => 
 				return signal.aborted ? { kind: "close" } : { kind: "to", screen: "main" };
 			},
 		},
-	});
+	};
 	return {
 		menu,
 		getState,
@@ -158,6 +158,8 @@ export async function showAnalyticsMenu(
 	source: AnalyticsMenuDataSource,
 	options: { signal: AbortSignal; isCurrent: () => boolean },
 ): Promise<void> {
+	const { runMenu, runTask } = await import("@narumitw/pi-tui-kit");
+	if (options.signal.aborted || !options.isCurrent()) return;
 	const controller = createAnalyticsMenu(source);
 	const loading = await runTask(ctx, {
 		label: "Loading local analytics…",

--- a/experimental/pi-codex-compact/src/settings-menu.ts
+++ b/experimental/pi-codex-compact/src/settings-menu.ts
@@ -1,5 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import type { MenuDefinition } from "@narumitw/pi-tui-kit";
 import type {
 	CodexCompactSettings,
 	CodexCompactSettingsRuntime,
@@ -63,8 +63,8 @@ async function update(
 export function createCodexCompactMenu(
 	runtime: CodexCompactSettingsRuntime,
 	options: { onCompactRequested?: () => void; status?: CompactMenuStatus } = {},
-) {
-	return defineMenu<CodexCompactSettingsState, Screen, Action, ExtensionCommandContext>({
+): MenuDefinition<CodexCompactSettingsState, Screen, Action, ExtensionCommandContext> {
+	return {
 		start: "main",
 		screens: {
 			main: ({ state }) => ({
@@ -178,7 +178,7 @@ export function createCodexCompactMenu(
 			"set-notify": ({ ctx, value, signal }) =>
 				update(runtime, ctx, { notifyOnFallback: value === "On" }, signal),
 		},
-	});
+	};
 }
 
 export async function showCodexCompactMenu(
@@ -190,6 +190,8 @@ export async function showCodexCompactMenu(
 		ctx.ui.notify(`Edit Codex compaction settings at ${safeText(runtime.get().path)}.`, "info");
 		return;
 	}
+	const { runMenu } = await import("@narumitw/pi-tui-kit");
+	if (owner.signal.aborted || !owner.isCurrent()) return;
 	let compactRequested = false;
 	await runMenu(
 		ctx,

--- a/experimental/pi-jupyter/src/jupyter-preview.ts
+++ b/experimental/pi-jupyter/src/jupyter-preview.ts
@@ -8,7 +8,6 @@ import {
 	type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import type { OverlayHandle, OverlayOptions } from "@earendil-works/pi-tui";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import { type JupyterScrollDirection, registerJupyterCommand } from "./jupyter-command.js";
 import {
 	jupyterHelpLines,
@@ -363,8 +362,14 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 	async function showJupyterMenu(ctx: ExtensionCommandContext): Promise<void> {
 		requireTui(ctx);
 		const generation = sessionGeneration;
+		const menuSignal = menuController.signal;
 		let notebookPaths: string[] = [];
-		const current = () => generation === sessionGeneration && !menuController.signal.aborted;
+		const current = () =>
+			generation === sessionGeneration &&
+			menuController.signal === menuSignal &&
+			!menuSignal.aborted;
+		const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+		if (!current()) return;
 		type Screen = "main" | "picker" | "help";
 		type Action = "open" | "choose" | "focus" | "refresh" | "close" | "pick";
 		const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
@@ -475,7 +480,7 @@ function registerJupyterPreview(pi: ExtensionAPI, dependencies: JupyterPreviewDe
 		});
 		await runMenu(ctx, menu, {
 			getState: () => undefined,
-			signal: menuController.signal,
+			signal: menuSignal,
 			isCurrent: current,
 		});
 	}

--- a/experimental/pi-recall/src/menu.ts
+++ b/experimental/pi-recall/src/menu.ts
@@ -1,5 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runCustomInteraction, runMenu, runTask } from "@narumitw/pi-tui-kit";
+import type { MenuDefinition } from "@narumitw/pi-tui-kit";
 import {
 	candidateIdentity,
 	filterRecallMessages,
@@ -77,7 +77,7 @@ export function createRecallMenu(
 		}
 	};
 
-	const menu = defineMenu<RecallMenuState, Screen, Action>({
+	const menu: MenuDefinition<RecallMenuState, Screen, Action> = {
 		start: "main",
 		screens: {
 			main: ({ state }) => ({
@@ -207,6 +207,8 @@ export function createRecallMenu(
 							);
 							if (signal.aborted || !isCurrent(ownership)) return { kind: "close" };
 							if (!confirmed) continue;
+							const { runTask } = await import("@narumitw/pi-tui-kit");
+							if (signal.aborted || !isCurrent(ownership)) return { kind: "close" };
 							const deletion = await runTask(ctx, {
 								label: "Deleting saved message…",
 								signal,
@@ -271,7 +273,7 @@ export function createRecallMenu(
 					: { kind: "to", screen: "main" };
 			},
 		},
-	});
+	};
 
 	return {
 		menu,
@@ -287,6 +289,8 @@ export async function showRecallMenu(
 	source: RecallMenuSource,
 	ownership: { signal: AbortSignal; isCurrent: () => boolean },
 ): Promise<void> {
+	const { runMenu } = await import("@narumitw/pi-tui-kit");
+	if (ownership.signal.aborted || !ownership.isCurrent()) return;
 	const controller = createRecallMenu(source, ownership);
 	await runMenu(ctx, controller.menu, {
 		getState: controller.getState,
@@ -364,6 +368,8 @@ async function chooseSavedInTui(
 	initialSelectedId: string | undefined,
 	initialQuery: string,
 ): Promise<ScopedRecallPickerResult | undefined> {
+	const { runCustomInteraction } = await import("@narumitw/pi-tui-kit");
+	if (signal.aborted || !isCurrent(ownership)) return undefined;
 	const interaction = await runCustomInteraction<ScopedRecallPickerResult>(ctx, {
 		signal,
 		isCurrent: () => isCurrent(ownership),

--- a/experimental/pi-webui/src/runtime.ts
+++ b/experimental/pi-webui/src/runtime.ts
@@ -6,7 +6,6 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import type { PreparedAttachment } from "./attachments.js";
 import { ConversationProjection, projectBranchMessages } from "./conversation.js";
 import { DEFAULT_IMAGE_LIMITS, type ImageLimits, imageLimits } from "./image-limits.js";
@@ -437,6 +436,10 @@ export class WebUIRuntime {
 		start: "main" | "settings" | "repair",
 	): Promise<void> {
 		const generation = this.generation;
+		const menuSignal = this.sessionAbort.signal;
+		const isCurrent = () => generation === this.generation && !this.closed && !menuSignal.aborted;
+		const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+		if (!isCurrent()) return;
 		type Screen = "main" | "settings" | "repair" | "status" | "help";
 		type Action = "open" | "settings" | "save-startup";
 		const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
@@ -542,8 +545,8 @@ export class WebUIRuntime {
 		});
 		await runMenu(ctx, menu, {
 			getState: () => undefined,
-			signal: this.sessionAbort.signal,
-			isCurrent: () => generation === this.generation && !this.closed,
+			signal: menuSignal,
+			isCurrent,
 		});
 	}
 

--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -12,7 +12,7 @@ import {
 	type Theme,
 } from "@earendil-works/pi-coding-agent";
 import type { Component, TUI } from "@earendil-works/pi-tui";
-import { defineMenu, type MenuContext, type RunMenuResult, runMenu } from "@narumitw/pi-tui-kit";
+import type { MenuContext, RunMenuResult } from "@narumitw/pi-tui-kit";
 import {
 	type BtwBringToMainSegment,
 	type BtwBringToMainSummary,
@@ -600,6 +600,8 @@ async function showBringToMainPreview(
 	draft: string,
 	summary: BtwBringToMainSummary,
 ): Promise<BtwBringToMainPreviewAction> {
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (ctx.signal?.aborted) return { kind: "close" };
 	let confirmed = false;
 	const count = summary.messages === 1 ? "1 message" : `${summary.messages} messages`;
 	const lineCount = summary.lines === 1 ? "1 line" : `${summary.lines} lines`;
@@ -637,6 +639,8 @@ async function showBtwMenu(
 	options: readonly string[],
 	initialValue?: string,
 ): Promise<BtwMenuSelectorAction> {
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (ctx.signal?.aborted) return { kind: "close" };
 	const items = options.map((label, index) => ({ id: `option-${index}`, label }));
 	const initialIndex = initialValue === undefined ? -1 : options.indexOf(initialValue);
 	let selectedValue: string | undefined;

--- a/extensions/pi-btw/src/menu.ts
+++ b/extensions/pi-btw/src/menu.ts
@@ -4,7 +4,7 @@ import type {
 	Theme,
 } from "@earendil-works/pi-coding-agent";
 import type { Component, TUI } from "@earendil-works/pi-tui";
-import { defineMenu, type MenuContext, type RunMenuResult, runMenu } from "@narumitw/pi-tui-kit";
+import type { MenuContext, RunMenuResult } from "@narumitw/pi-tui-kit";
 import {
 	type BtwSettings,
 	btwSettingsPath,
@@ -51,6 +51,8 @@ export async function showBtwCommandMenu(
 	options: ShowBtwCommandMenuOptions,
 ): Promise<BtwCommandMenuResult> {
 	if (ctx.mode !== "tui") return "closed";
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (ctx.signal?.aborted) return "closed";
 	const settingsPath = options.settingsPath ?? btwSettingsPath();
 	const readSettings = options.readSettings ?? readBtwSettings;
 	const updateSettings = options.updateSettings ?? updateBtwSettings;

--- a/extensions/pi-caffeinate/src/caffeinate.ts
+++ b/extensions/pi-caffeinate/src/caffeinate.ts
@@ -5,7 +5,6 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import { startInhibitorProcess, stopInhibitorProcess } from "./inhibitor-process.js";
 import { formatMode, getInhibitorCommand, type InhibitorCommand } from "./inhibitors.js";
 import {
@@ -171,6 +170,10 @@ async function runCaffeinateMenu(ctx: CommandContext, generation: number, start:
 				: `The pi-caffeinate menu requires TUI or RPC mode.\n\n${buildCommandGuide()}\n\n${describeState()}`,
 		);
 	}
+	const menuSignal = state.menuController.signal;
+	const isCurrent = () => generation === state.sessionGeneration && !menuSignal.aborted;
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isCurrent()) return;
 	type Screen = "main" | "mode";
 	type Action = "display" | "sleep" | "status" | "stop" | "help";
 	const menu = defineMenu<undefined, Screen, Action>({
@@ -223,8 +226,8 @@ async function runCaffeinateMenu(ctx: CommandContext, generation: number, start:
 	});
 	await runMenu(ctx, menu, {
 		getState: () => undefined,
-		signal: state.menuController.signal,
-		isCurrent: () => generation === state.sessionGeneration,
+		signal: menuSignal,
+		isCurrent,
 	});
 }
 

--- a/extensions/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/extensions/pi-chrome-devtools/src/chrome-devtools.ts
@@ -1,5 +1,4 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import { shutdownManagedBrowser } from "./browser-manager.js";
 import { state } from "./runtime.js";
 import { loadSettings } from "./settings.js";
@@ -136,6 +135,10 @@ async function showMenu(pi: ExtensionAPI, ctx: CommandContext, generation: numbe
 		ctx.ui.notify(`${buildCommandGuide()}\n\n${status}`, "info");
 		return;
 	}
+	const menuSignal = state.sessionController.signal;
+	const isCurrent = () => generation === state.sessionGeneration && !menuSignal.aborted;
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isCurrent()) return;
 
 	type Screen = "main";
 	type Action = keyof typeof MENU_OPTIONS;
@@ -183,8 +186,8 @@ async function showMenu(pi: ExtensionAPI, ctx: CommandContext, generation: numbe
 	});
 	await runMenu(ctx, menu, {
 		getState: () => undefined,
-		signal: state.sessionController.signal,
-		isCurrent: () => generation === state.sessionGeneration,
+		signal: menuSignal,
+		isCurrent,
 	});
 }
 

--- a/extensions/pi-chrome-devtools/src/tool-selector.ts
+++ b/extensions/pi-chrome-devtools/src/tool-selector.ts
@@ -1,5 +1,4 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import {
 	browserCandidateHint,
 	devToolsEndpoint,
@@ -38,6 +37,10 @@ interface ToolStatusSummary {
 export async function showToolSelector(pi: ExtensionAPI, ctx: CommandContext) {
 	const generation = state.sessionGeneration;
 	if (!ctx.hasUI) return;
+	const menuSignal = state.sessionController.signal;
+	const isCurrent = () => generation === state.sessionGeneration && !menuSignal.aborted;
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isCurrent()) return;
 	const menu = defineMenu<undefined, ToolSelectorScreen, ToolSelectorAction>({
 		start: "tools",
 		screens: {
@@ -96,8 +99,8 @@ export async function showToolSelector(pi: ExtensionAPI, ctx: CommandContext) {
 	});
 	const result = await runMenu(ctx, menu, {
 		getState: () => undefined,
-		signal: state.sessionController.signal,
-		isCurrent: () => generation === state.sessionGeneration,
+		signal: menuSignal,
+		isCurrent,
 	});
 	if (result.kind !== "closed" || generation !== state.sessionGeneration) return;
 	const status = await buildToolStatusMessage(pi);

--- a/extensions/pi-firecrawl/src/firecrawl.ts
+++ b/extensions/pi-firecrawl/src/firecrawl.ts
@@ -1,5 +1,4 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import { hasApiKey } from "./client.js";
 import { cleanupResponseArtifacts, openResponseArtifacts } from "./response-format.js";
 import { loadSettings } from "./settings.js";
@@ -138,6 +137,10 @@ async function showMenu(pi: ExtensionAPI, ctx: CommandContext, generation: numbe
 		ctx.ui.notify(`${buildCommandGuide()}\n\n${status}`, hasApiKey() ? "info" : "warning");
 		return;
 	}
+	const menuSignal = currentFirecrawlSessionSignal();
+	const isCurrent = () => isCurrentFirecrawlSession(generation) && !menuSignal.aborted;
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isCurrent()) return;
 
 	type Screen = "main";
 	type Action = keyof typeof MENU_OPTIONS;
@@ -187,8 +190,8 @@ async function showMenu(pi: ExtensionAPI, ctx: CommandContext, generation: numbe
 	});
 	await runMenu(ctx, menu, {
 		getState: () => undefined,
-		signal: currentFirecrawlSessionSignal(),
-		isCurrent: () => isCurrentFirecrawlSession(generation),
+		signal: menuSignal,
+		isCurrent,
 	});
 }
 

--- a/extensions/pi-firecrawl/src/tool-selector.ts
+++ b/extensions/pi-firecrawl/src/tool-selector.ts
@@ -1,5 +1,4 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import { configuredApiUrl, hasApiKey } from "./client.js";
 import {
 	loadSettings,
@@ -52,6 +51,10 @@ export function recordSettingsNotice(settings: SettingsLoadResult) {
 export async function showToolSelector(pi: ExtensionAPI, ctx: CommandContext) {
 	const generation = sessionGeneration;
 	if (!ctx.hasUI) return;
+	const menuSignal = sessionController.signal;
+	const isCurrent = () => isCurrentFirecrawlSession(generation) && !menuSignal.aborted;
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isCurrent()) return;
 	const menu = defineMenu<undefined, ToolSelectorScreen, ToolSelectorAction>({
 		start: "tools",
 		screens: {
@@ -110,8 +113,8 @@ export async function showToolSelector(pi: ExtensionAPI, ctx: CommandContext) {
 	});
 	const result = await runMenu(ctx, menu, {
 		getState: () => undefined,
-		signal: sessionController.signal,
-		isCurrent: () => isCurrentFirecrawlSession(generation),
+		signal: menuSignal,
+		isCurrent,
 	});
 	if (result.kind !== "closed" || !isCurrentFirecrawlSession(generation)) return;
 	const status = await buildStatusMessage(pi);

--- a/extensions/pi-goal/src/menu.ts
+++ b/extensions/pi-goal/src/menu.ts
@@ -1,5 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { type ActionMenuItem, defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import type { ActionMenuItem } from "@narumitw/pi-tui-kit";
 import { formatTokenCount as formatCompactTokenCount, formatDuration } from "./accounting.js";
 import { parseTokenBudget } from "./command.js";
 import type { GoalCommandController } from "./commands.js";
@@ -174,6 +174,8 @@ export async function showGoalManager(
 	const isMenuCurrent = () =>
 		owner.menuController === undefined ||
 		(generation === owner.menuGeneration && !owner.menuController.signal.aborted);
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isMenuCurrent()) return;
 	let displayedGoal: ActiveGoal | undefined;
 	let startBudgetQueueIdentity = currentGoalQueueIdentity(runtime);
 	let displayedBudgetGoal: ActiveGoal | undefined;

--- a/extensions/pi-goal/src/settings-ui.ts
+++ b/extensions/pi-goal/src/settings-ui.ts
@@ -1,6 +1,5 @@
 import { join } from "node:path";
 import { type ExtensionCommandContext, getAgentDir } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import { checkpointGoalActiveTime } from "./accounting.js";
 import { abortCurrentTurn, type GoalRuntime, STATUS_KEY } from "./runtime.js";
 import {
@@ -36,6 +35,8 @@ export async function showGoalSettings(
 	const generation = runtime.menuGeneration;
 	const isMenuCurrent = () =>
 		generation === runtime.menuGeneration && !runtime.menuController.signal.aborted;
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isMenuCurrent()) return;
 	const invalid = runtime.settingsLoadIssue?.kind === "invalid";
 	const previewGoalIds = new Map<LimitField, string | null>();
 	type Screen = "settings" | "automatic" | "no-progress" | "invalid";

--- a/extensions/pi-google-genai/src/google-genai.ts
+++ b/extensions/pi-google-genai/src/google-genai.ts
@@ -1,5 +1,4 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import {
 	DEFAULT_MODEL,
 	GOOGLE_GENAI_TOOL_NAMES,
@@ -239,6 +238,8 @@ async function selectTools(
 	menuSignal: AbortSignal,
 ) {
 	if (!ctx.hasUI) throw new Error("/google-genai tools requires TUI or RPC mode.");
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (menuSignal.aborted || !isCurrent()) return;
 	type Screen = "tools";
 	type Action = "toggle" | "enableAll" | "disableAll";
 	const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({

--- a/extensions/pi-langfuse/src/langfuse.ts
+++ b/extensions/pi-langfuse/src/langfuse.ts
@@ -3,7 +3,6 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import {
 	DEFAULT_BASE_URL,
 	type LangfuseConfig,
@@ -69,6 +68,10 @@ export function createLangfuseExtension(
 				return;
 			}
 			const menuGeneration = sessionGeneration;
+			const menuSignal = menuController.signal;
+			const isCurrent = () => menuGeneration === sessionGeneration && !menuSignal.aborted;
+			const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+			if (!isCurrent()) return;
 			type Screen = "main";
 			type Action = "flush" | "configure" | "help";
 			const menu = defineMenu<undefined, Screen, Action>({
@@ -154,8 +157,8 @@ export function createLangfuseExtension(
 			});
 			await runMenu(ctx, menu, {
 				getState: () => undefined,
-				signal: menuController.signal,
-				isCurrent: () => menuGeneration === sessionGeneration,
+				signal: menuSignal,
+				isCurrent,
 			});
 		}
 

--- a/extensions/pi-stamp/src/menu.ts
+++ b/extensions/pi-stamp/src/menu.ts
@@ -1,5 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import type { MenuDefinition } from "@narumitw/pi-tui-kit";
 import {
 	canonicalizeLocale,
 	canonicalizeTimeZone,
@@ -33,10 +33,12 @@ export interface StampMenuOwner {
 	isCurrent(): boolean;
 }
 
-export function createStampMenu(runtime: StampSettingsRuntime) {
+export function createStampMenu(
+	runtime: StampSettingsRuntime,
+): MenuDefinition<StampSettingsState, StampScreen, StampAction, ExtensionCommandContext> {
 	let localeEntry = false;
 	let timeZoneEntry = false;
-	return defineMenu<StampSettingsState, StampScreen, StampAction, ExtensionCommandContext>({
+	return {
 		start: "main",
 		screens: {
 			main: ({ state }) => ({
@@ -362,14 +364,16 @@ export function createStampMenu(runtime: StampSettingsRuntime) {
 				return result;
 			},
 		},
-	});
+	};
 }
 
-export function showStampMenu(
+export async function showStampMenu(
 	ctx: ExtensionCommandContext,
 	runtime: StampSettingsRuntime,
 	owner: StampMenuOwner,
 ) {
+	const { runMenu } = await import("@narumitw/pi-tui-kit");
+	if (owner.signal.aborted || !owner.isCurrent()) return { kind: "stale" } as const;
 	return runMenu(ctx, createStampMenu(runtime), {
 		getState: () => runtime.get(),
 		signal: owner.signal,

--- a/extensions/pi-statusline/src/commands.ts
+++ b/extensions/pi-statusline/src/commands.ts
@@ -14,7 +14,6 @@ import {
 	truncateToWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import {
 	INFORMATION_PROFILE_NAMES,
 	INFORMATION_PROFILES,
@@ -125,6 +124,8 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
 		signal: fallbackController.signal,
 		isCurrent: () => !fallbackController.signal.aborted,
 	};
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (owner.signal.aborted || !owner.isCurrent()) return;
 	type Screen = "main" | "advanced" | "information";
 	type Action = "appearance" | "setInformation" | "layout" | "edit" | "status" | "help" | "back";
 	const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({

--- a/extensions/pi-subagents/src/config-ui.ts
+++ b/extensions/pi-subagents/src/config-ui.ts
@@ -1,5 +1,4 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import {
 	type CompletionDelivery,
 	type ConsultationCwdPolicy,
@@ -124,6 +123,9 @@ async function showSubagentManager(
 		return;
 	}
 	const generation = owner.generation;
+	const isCurrent = () => generation === owner.generation && !owner.controller.signal.aborted;
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isCurrent()) return;
 	let availableAgents = discoverAgents(ctx.cwd, "user", readSubagentSettings() ?? {}).agents;
 	let toolDraft: ToolDraft | undefined;
 	type Screen =
@@ -482,7 +484,7 @@ async function showSubagentManager(
 	await runMenu(ctx, menu, {
 		getState: () => undefined,
 		signal: owner.controller.signal,
-		isCurrent: () => generation === owner.generation && !owner.controller.signal.aborted,
+		isCurrent,
 	});
 }
 
@@ -502,6 +504,9 @@ async function showSubagentSettings(
 		return;
 	}
 	const generation = owner.generation;
+	const isCurrent = () => generation === owner.generation && !owner.controller.signal.aborted;
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isCurrent()) return;
 	type SettingsAction =
 		| "set-completion"
 		| "set-consult-resources"
@@ -521,7 +526,7 @@ async function showSubagentSettings(
 	await runMenu(ctx, menu, {
 		getState: () => undefined,
 		signal: owner.controller.signal,
-		isCurrent: () => generation === owner.generation && !owner.controller.signal.aborted,
+		isCurrent,
 	});
 }
 

--- a/extensions/pi-usage/src/usage.ts
+++ b/extensions/pi-usage/src/usage.ts
@@ -3,7 +3,6 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu, runTask } from "@narumitw/pi-tui-kit";
 import {
 	awaitWithDeadline,
 	errorMessage,
@@ -348,6 +347,8 @@ export default function usageExtension(pi: ExtensionAPI) {
 		parentSignal: AbortSignal,
 		operation: (signal: AbortSignal) => Promise<T>,
 	): Promise<T | undefined> => {
+		const { runTask } = await import("@narumitw/pi-tui-kit");
+		if (parentSignal.aborted) return undefined;
 		const result = await runTask(ctx, {
 			label,
 			signal: parentSignal,
@@ -464,6 +465,8 @@ export default function usageExtension(pi: ExtensionAPI) {
 			publishStableCurrent(ctx, stableCurrent);
 			let current = stableCurrent.outcome;
 			let visibleStates: ProviderUsageState[] = [current.state];
+			const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+			if (controller.signal.aborted || statusGeneration !== menuGeneration) return;
 			type Screen = "main" | "providers";
 			type Action = "refresh" | "another" | "all" | "provider";
 			const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({

--- a/extensions/pi-worktree/src/command.ts
+++ b/extensions/pi-worktree/src/command.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import {
 	addWorktree,
 	administrativeHistoryOids,
@@ -84,6 +83,8 @@ export function registerWorktreeCommand(
 				const root = settings.get();
 				const warning = root.warning ? " — settings warning" : "";
 				const owner = getMenuOwner();
+				const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+				if (owner.signal.aborted || !owner.isCurrent()) return;
 				const runFlow = async (flow: () => Promise<void>) => {
 					try {
 						await flow();
@@ -646,6 +647,8 @@ async function selectWorktree(
 		ctx.ui.notify("No eligible worktrees are available for this action.", "info");
 		return undefined;
 	}
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (signal?.aborted || ctx.signal?.aborted) return undefined;
 	let selected: WorktreeRecord | undefined;
 	const menu = defineMenu<undefined, "worktrees", "choose", ExtensionCommandContext>({
 		start: "worktrees",


### PR DESCRIPTION
## Summary

- lazy-load command-only Pi TUI Kit runtime paths in 12 production and 5 experimental extensions
- revalidate each extension's existing session generation, owner signal, or controller after dynamic imports
- preserve synchronous menu-definition helpers with type-only Kit imports where tests and callers need them

## Performance

Source-loaded, warm-filesystem Pi RPC benchmarks:

- `pi-btw` + `pi-caffeinate` import median: about `1808 ms` → `78 ms`
- the reported 14-extension load: `3182 ms` observed → `1461 ms` median (`5` runs, MAD `70 ms`)
- all 22 Pi TUI Kit consumers: `2542 ms` median (`3` runs, MAD `74 ms`), with no extension absorbing the previous duplicate-runtime spike

## Verification

- all 17 touched workspace typechecks passed
- Biome passed for all changed source and plan files
- extension boundary check passed
- 17 package dry-run packs passed and included their declared entrypoints
- focused command/menu/lifecycle run: 600 passed; 3 reproduced unrelated existing terminal-width/macOS realpath failures
- `npm run check`: 2407/2421 tests passed; the same 14 pre-existing environment-sensitive failures remained outside the changed behavior (FIFO timing, terminal-width fixtures, macOS `/var` realpaths, and unrelated lifecycle timing)
- isolated and combined local Pi RPC startup smokes passed

No package was published and no release state was changed.
