### PR TITLE
perf(pi-tui-kit): avoid coding-agent runtime import

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -17,7 +17,7 @@
 - The pinned npm 12.0.2 rejects Node 25; run lockfile work under an installed supported runtime such as Node 22.22.2 instead of tolerating npm's compatibility warning.
 - A consumer cannot safely adopt an unpublished `pi-tui-kit` API in the same PR: clean `npm ci` resolves its semver dependency from the registry. Publish the Kit API before raising the consumer's reviewed compatibility floor; do not use local paths that break independent packaging.
 - Pi maintains separate managed npm roots for user and project packages; dependency deduplication is guaranteed only within one install root, not across scopes.
-- A static `pi-tui-kit` import in a source-loaded extension can evaluate a second repository-resolved Pi/TUI runtime and add over a second to startup. Lazy-load command-only menus and revalidate session ownership after the import.
+- A `pi-tui-kit` runtime import of the `pi-coding-agent` root can evaluate a second repository-resolved agent runtime and add over a second. Keep Kit production JavaScript on public `pi-tui` primitives with coding-agent type-only, and lazy-load command menus until consumers require that published Kit boundary.
 - Official Pi can misresolve static `@earendil-works/pi-ai/api/*` imports beneath its compatibility alias. Prefer root exports; otherwise use a variable-specifier dynamic import.
 
 ### Processes, lifecycle, and state

--- a/docs/plans/archived/2026-08-05_pi-tui-kit-runtime-import-performance-plan.md
+++ b/docs/plans/archived/2026-08-05_pi-tui-kit-runtime-import-performance-plan.md
@@ -1,0 +1,158 @@
+# Pi TUI Kit runtime-import performance plan
+
+## Goal
+
+Reduce `@narumitw/pi-tui-kit` cold import and first-interaction latency by removing its production
+runtime dependency on the heavyweight `@earendil-works/pi-coding-agent` root barrel, while preserving
+all public APIs, menu behavior, syntax-colored review output, task cancellation, disposal, and
+cross-mode lifecycle results.
+
+## Context
+
+- Fresh-process measurements on 2026-08-05 put the Kit root import around 1.1–1.5 seconds, closely
+  matching the 1.1–2.3 second `pi-coding-agent` root import; `pi-tui` alone measured about 50–120 ms.
+- A disposable built-output experiment replacing the three coding-agent runtime imports reduced the
+  Kit import median to about 64 ms. This is directional evidence, not completion evidence.
+- The production graph reaches coding-agent values through:
+  - `packages/pi-tui-kit/src/task.ts` for `BorderedLoader`;
+  - `packages/pi-tui-kit/src/components/index.ts` for `DynamicBorder`; and
+  - `packages/pi-tui-kit/src/components/review.ts` for `getLanguageFromPath()` and `highlightCode()`.
+- `packages/pi-tui-kit/src/index.ts` re-exports `runTask()` and `runMenu()`, so ESM evaluates those
+  branches when the package root is imported. Extension-level lazy loading avoids startup cost but
+  currently relocates the same pause to the first command.
+
+## Architecture
+
+- Keep `@earendil-works/pi-coding-agent` as a peer/dev dependency for public TypeScript context types,
+  but require every production JavaScript dependency on it to be erased as type-only.
+- Keep `@earendil-works/pi-tui` as the only Pi runtime package used by Kit internals.
+- Own the small presentation composites needed by Kit:
+  - an internal width-aware border component built on the public `Component` contract; and
+  - an internal task-loader composite built from public `pi-tui` primitives, the callback-injected
+    theme/keybindings, and the existing `runTask()` ownership controller.
+- Own review syntax formatting at the review adapter boundary. Use a direct, declared lightweight
+  highlighter dependency and the callback-injected theme; do not deep-import Pi `dist/*`, load the
+  coding-agent root dynamically, or add a consumer-supplied highlighting hook.
+- Preserve the package root and `/testing` exports. This is an internal performance refactor, not a
+  menu API-version change.
+
+## Non-Goals
+
+- Remove extension-level lazy imports added by PR #562.
+- Add new public subpaths, menu screens, loader options, or highlighting configuration.
+- Change review language coverage, ANSI sanitization, exact text wrapping, cancellation keys, or
+  TUI/RPC behavior.
+- Publish the package, bump consumer compatibility floors, or modify extension packages; release and
+  consumer adoption require separate approval and sequencing.
+- Optimize unrelated `pi-goal`, `pi-starship`, or Pi core startup work.
+
+## Assumptions
+
+- Existing code-review syntax coloring is observable behavior and must be characterized before the
+  coding-agent helper is replaced.
+- A direct all-language highlighter is acceptable only if same-host measurements meet the import and
+  first-interaction targets; otherwise a core-plus-registered-languages adapter must preserve the
+  currently mapped language set.
+- Dependency changes will use the root-declared `npm@12.0.2` under a supported Node runtime; the
+  currently active npm 11 installation is not authoritative for lockfile work.
+
+## Risks
+
+- **Behavior drift in highlighting:** a new adapter could change language aliases, token colors, or
+  invalid-language fallback. Mitigate with red-first characterization covering mapped paths,
+  explicit languages, unknown languages, multiline code, and themed token output.
+- **Loader lifecycle drift:** replacing `BorderedLoader` could lose cancellation, animation disposal,
+  or injected keybindings. Mitigate with existing `runTask()` lifecycle tests plus focused first-frame,
+  cancel, external-disposal, owner-abort, non-cancellable, and timer-drain assertions.
+- **Timing moved rather than removed:** a fast root import could hide a slow first review/task render.
+  Mitigate by benchmarking cold import, first menu frame, and first task frame in fresh serial
+  processes.
+- **Flaky performance gates:** absolute timing differs by host and cache state. Keep deterministic
+  dependency-graph assertions in tests and use same-host serial medians plus relative improvement as
+  PR evidence rather than a wall-clock CI assertion.
+- **Dependency/package growth:** an all-language highlighter may increase install size. Record packed
+  size and import latency before selecting it; prefer the smallest implementation that preserves the
+  current language contract and meets the latency target.
+
+## Rollback / Recovery
+
+The change is independently revertible because it does not alter public types, data, settings, or
+consumer manifests. If behavior or import targets fail, revert the internal border, task-loader, and
+highlighter changes together and retain PR #562's lazy-loading mitigation. Do not publish until the
+package dry run and clean-install smoke pass.
+
+## Plan
+
+- [x] Add `scripts/benchmark-tui-kit-runtime.mjs` and capture a fresh-process baseline covering the
+  built package root import, first actions-menu frame, first code-review frame, and first `runTask()`
+  frame. Evidence: Node 22.23.1, five serial runs after warm-up: import 1321.34 ms median/39.23 ms
+  MAD; actions first frame 1421.05/68.34 ms; review 1286.95/43.73 ms; task 1285.97/54.19 ms. Every
+  scenario resolved coding-agent runtime URLs. The dry-run tarball was 37,576 bytes packed and
+  178,374 bytes unpacked across 41 files.
+- [x] Add red-first Kit behavior tests for callback-injected task cancellation and review syntax
+  theming, and use the fresh-process resolver benchmark as the outside-TDD production-graph red gate.
+  Evidence: the focused task test failed because the injected key did not abort; the focused review
+  test failed because syntax colors came from coding-agent's global theme. Existing and added tests
+  cover borders, first frame, cancellation, non-cancellable mode, disposal/draining, inferred and
+  explicit languages, unknown fallback, and syntax tokens. Distribution output remains outside the
+  TDD test boundary and is verified by build inspection.
+- [x] Under Node 22.23.1, use root-pinned `npm@12.0.2` for the dependency/lock change and evaluate
+  `highlight.js` all-language import versus core-plus-current-language registration. Evidence: five
+  all-language imports measured 97–208 ms; mapped core registration measured 40–47 ms but dropped
+  arbitrary explicit-language coverage. The all-language adapter was selected to preserve the public
+  review contract and the final benchmark exceeded the 70% target.
+- [x] Add internal border and task-loader modules under `packages/pi-tui-kit/src/components/`, update
+  `components/index.ts` and `task.ts` to use only public `pi-tui` runtime primitives and injected
+  theme/keybindings. Evidence: focused task/component tests pass, including user cancellation,
+  non-cancellable input, owner abort, external disposal, first-frame borders/hint, and task draining;
+  the loader stops its animation idempotently on every completion/disposal path.
+- [x] Add the direct `highlight.js` adapter and declared dependency, update `components/review.ts` to
+  use it without Pi private paths, and preserve mapped plus arbitrary explicit languages. Evidence:
+  focused review tests pass for inferred TypeScript tokens, explicit Brainfuck/entity decoding,
+  unknown fallback, sanitization, wrapping, diff/text rendering, adaptive/fixed TUI, and RPC pages.
+- [x] Build and inspect the package distribution. Evidence: `rg` finds zero coding-agent or Pi
+  private `dist/*` imports in built JavaScript; declarations retain type-only coding-agent imports;
+  root exports remain the same seven names, `/testing` remains the same two names, and menu API stays
+  version 6.
+- [x] Update `packages/pi-tui-kit/README.md` and the Technical Health section of
+  `docs/roadmaps/pi-tui-kit-roadmap.md` with the runtime dependency boundary and benchmark method,
+  without documenting transient package versions or promising publication.
+- [x] Re-run the fresh-process benchmark against the final built output. Evidence: same-host Node
+  22.23.1 medians improved from 1321.34 to 177.09 ms for import (86.6%), 1421.05 to 243.20 ms for
+  actions (82.9%), 1286.95 to 349.87 ms for review (72.8%), and 1285.97 to 361.73 ms for task
+  (71.9%). No measured interaction exceeded 425 ms and all resolver traces excluded coding-agent.
+- [x] Run the package, focused, repository, and package-distribution gates. Evidence:
+  `npm run check --workspace @narumitw/pi-tui-kit` passed; compiled Kit tests passed 135/135; focused
+  Kit-consumer loader tests passed 38/38; Biome, boundaries, and all typechecks passed within
+  `npm run check`. The final full run passed 2421/2424 tests: the existing Jupyter FIFO timing
+  assertion passed on focused rerun, while the existing BTW path-wrap and GitHub PR periodic-refresh
+  timing failures reproduced; all three failing packages have zero diff. `just pack-tui-kit` passed (47 files, 40.9 kB packed,
+  188.8 kB unpacked), and a clean Node 22/npm 12 tarball install resolved both entrypoints and one
+  deduplicated `highlight.js@10.7.3`; the final dry run remained 47 files, 40.9 kB packed, and
+  188.9 kB unpacked.
+- [x] Audit the final diff against `docs/tui.md`, `docs/extension-conventions.md`, the Pi TUI Kit
+  roadmap, lifecycle paths, and dependency/version policy. Evidence: callback keybindings drive user
+  cancellation; every loader completion/disposal path idempotently stops animation; owner abort and
+  stale continuations remain covered; built JavaScript uses only public Pi TUI runtime APIs; npm 12
+  generated the lock change; and the real Pi RPC load smoke exposed Kit API 6 in 367 ms. No accepted
+  convention deviation, unverified required path, release, or publication remains.
+
+## Completion Checklist
+
+- [x] Built production JavaScript has zero runtime imports of
+  `@earendil-works/pi-coding-agent` and zero Pi private `dist/*` imports.
+- [x] Public root and `/testing` exports, TypeScript contracts, and
+  `PI_EXTENSION_MENU_API_VERSION` are unchanged.
+- [x] Review code highlighting preserves current mapped-language, theme, fallback, sanitization,
+  wrapping, and pagination behavior.
+- [x] `runTask()` preserves completion, user cancellation, external disposal, owner abort/staleness,
+  errors, non-cancellable mode, and complete loader/timer cleanup.
+- [x] Same-host fresh-process evidence shows at least 70% median improvement for cold import and first
+  interaction, rather than merely shifting the coding-agent pause.
+- [x] Package check, focused tests, full `npm run check`, and `just pack-tui-kit` passed as described
+  above; the three unrelated full-suite failures have focused reproduction evidence.
+- [x] No extension, consumer compatibility floor, package version, publication, tag, visibility, or
+  release workflow was changed.
+- [x] Archived at
+  `docs/plans/archived/2026-08-05_pi-tui-kit-runtime-import-performance-plan.md` after confirming no
+  existing archive file would be overwritten.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -261,6 +261,9 @@ abstractions when Pi provides a better stable owner.
 
 - Keep TypeScript strict, NodeNext-compatible, and built as published JavaScript plus declarations.
 - Keep Pi private `dist/*` imports at zero and package-root consumer imports as the supported boundary.
+- Keep production JavaScript imports from `@earendil-works/pi-coding-agent` at zero; use it only for
+  erased public types, compose runtime UI from public `pi-tui` primitives and callback-owned theme and
+  keybindings, and verify cold import plus first interaction with the serial runtime benchmark.
 - Keep the demonstrated runtime/interaction ownership boundary: adapters own presentation cadence
   and the interaction driver owns semantic action coordination. Recombine or split only when a new
   behavior matrix proves better locality and deletes coordination.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1685,15 +1685,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
-			"version": "10.7.3",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
@@ -5745,6 +5736,15 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6471,6 +6471,9 @@
 			"name": "@narumitw/pi-tui-kit",
 			"version": "0.49.0",
 			"license": "MIT",
+			"dependencies": {
+				"highlight.js": "10.7.3"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -8,7 +8,8 @@ Reusable navigation helpers and typed, declarative interaction flows for indepen
 [`@earendil-works/pi-tui`](https://www.npmjs.com/package/@earendil-works/pi-tui). The initial
 high-level API lets extensions describe menu screens and domain actions while this package owns
 standard rendering, navigation, mode adaptation, cancellation, and lifecycle behavior. It also
-provides a standalone task runner for abort-aware work that needs Pi's cancellable TUI loader.
+provides a standalone task runner for abort-aware work with a cancellable bordered loader composed
+from public Pi TUI primitives.
 
 ## 📦 Install
 
@@ -33,6 +34,25 @@ Compatibility ranges are consumer-owned. Review each extension against the APIs 
 its tested minimum; do not automatically synchronize every consumer range with the current workspace
 package version during a shared release bump. In this monorepo, declare the dependency in the
 consuming package so local hoisting cannot hide an incompatible or missing published dependency.
+
+## ⚡ Runtime performance
+
+The Kit's production JavaScript imports Pi TUI at runtime but keeps Pi Coding Agent imports type-only.
+This prevents a source-loaded extension from evaluating a second heavyweight coding-agent runtime
+when its menu first opens. Borders and task loaders compose public Pi TUI primitives with the theme
+and keybindings supplied by the active UI callback; review syntax coloring uses the Kit's declared
+highlighter dependency and the same callback theme.
+
+Repository maintainers can measure cold package import, first actions/review frame, and first task
+frame in fresh serial processes:
+
+```bash
+npm run build --workspace @narumitw/pi-tui-kit
+node scripts/benchmark-tui-kit-runtime.mjs --runs 5
+```
+
+The benchmark reports medians, median absolute deviations, and resolved package URLs so a fast import
+cannot hide the same dependency cost in the first interaction.
 
 ## 🚀 Example
 
@@ -118,9 +138,10 @@ menu. RPC preserves each adapter's existing transition: a generic cancelled sele
 while input and review cancellation follow their declared hint. Owner replacement remains `stale`
 and takes precedence over any racing Close event.
 
-For abort-aware work outside a menu, use `runTask()`. TUI mode shows Pi's cancellable bordered
-loader; RPC, print, and JSON execute the same task directly. User cancellation, owner replacement,
-external component disposal, errors, and successful completion remain distinct typed results.
+For abort-aware work outside a menu, use `runTask()`. TUI mode shows the Kit's Pi-styled cancellable
+bordered loader; RPC, print, and JSON execute the same task directly. User cancellation, owner
+replacement, external component disposal, errors, and successful completion remain distinct typed
+results.
 
 ```ts
 import { runTask } from "@narumitw/pi-tui-kit";

--- a/packages/pi-tui-kit/package.json
+++ b/packages/pi-tui-kit/package.json
@@ -51,5 +51,8 @@
 		"type": "git",
 		"url": "https://github.com/narumiruna/pi-extensions",
 		"directory": "packages/pi-tui-kit"
+	},
+	"dependencies": {
+		"highlight.js": "10.7.3"
 	}
 }

--- a/packages/pi-tui-kit/src/components/dynamic-border.ts
+++ b/packages/pi-tui-kit/src/components/dynamic-border.ts
@@ -1,0 +1,12 @@
+import type { Component } from "@earendil-works/pi-tui";
+
+/** Width-aware border that uses only Pi TUI's public component contract. */
+export class DynamicBorder implements Component {
+	constructor(private readonly color: (text: string) => string = (text) => text) {}
+
+	invalidate() {}
+
+	render(width: number): string[] {
+		return [this.color("─".repeat(Math.max(1, width)))];
+	}
+}

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -1,4 +1,4 @@
-import { DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
 	type Focusable,
 	fuzzyFilter,
@@ -21,6 +21,7 @@ import type {
 	MenuScreenComponentOptions,
 	MultiSelectOptions,
 } from "./contracts.js";
+import { DynamicBorder } from "./dynamic-border.js";
 import { createInputComponent, type InputOptions } from "./input.js";
 import { createMultiSelectComponent } from "./multi-select.js";
 import { handleSearchInput, menuHint, renderFrame, safeMenuText } from "./rendering.js";

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -1,5 +1,4 @@
 import { stripVTControlCharacters } from "node:util";
-import { getLanguageFromPath, highlightCode } from "@earendil-works/pi-coding-agent";
 import {
 	Key,
 	matchesKey,
@@ -14,6 +13,7 @@ import type {
 	MenuScreenComponentOptions,
 } from "./contracts.js";
 import { menuHint, renderFrame, safeMenuText } from "./rendering.js";
+import { getLanguageFromPath, highlightCode } from "./syntax-highlighting.js";
 
 const DEFAULT_REVIEW_VIEWPORT_SIZE = 14;
 const RPC_REVIEW_VIEWPORT_SIZE = 8;
@@ -304,9 +304,7 @@ function formatReviewLines<ActionId extends string>(
 	if (format.kind === "code") {
 		const language =
 			format.language ?? (format.filePath ? getLanguageFromPath(format.filePath) : undefined);
-		return segments.map(({ text }) =>
-			theme.fg("mdCodeBlock", highlightCode(text, language)[0] ?? text),
-		);
+		return segments.map(({ text }) => highlightCode(text, language, theme));
 	}
 	if (format.kind === "diff") {
 		return segments.map(({ source, text }) => {

--- a/packages/pi-tui-kit/src/components/syntax-highlighting.ts
+++ b/packages/pi-tui-kit/src/components/syntax-highlighting.ts
@@ -1,0 +1,216 @@
+import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
+import hljs from "highlight.js";
+
+export type SyntaxTheme = Pick<Theme, "fg" | "bold"> & Partial<Pick<Theme, "italic" | "underline">>;
+
+type Formatter = (text: string) => string;
+
+const LANGUAGE_BY_EXTENSION: Readonly<Record<string, string>> = {
+	ts: "typescript",
+	tsx: "typescript",
+	js: "javascript",
+	jsx: "javascript",
+	mjs: "javascript",
+	cjs: "javascript",
+	py: "python",
+	rb: "ruby",
+	rs: "rust",
+	go: "go",
+	java: "java",
+	kt: "kotlin",
+	swift: "swift",
+	c: "c",
+	h: "c",
+	cpp: "cpp",
+	cc: "cpp",
+	cxx: "cpp",
+	hpp: "cpp",
+	cs: "csharp",
+	php: "php",
+	sh: "bash",
+	bash: "bash",
+	zsh: "bash",
+	fish: "fish",
+	ps1: "powershell",
+	sql: "sql",
+	html: "html",
+	htm: "html",
+	css: "css",
+	scss: "scss",
+	sass: "sass",
+	less: "less",
+	json: "json",
+	yaml: "yaml",
+	yml: "yaml",
+	toml: "toml",
+	xml: "xml",
+	md: "markdown",
+	markdown: "markdown",
+	dockerfile: "dockerfile",
+	makefile: "makefile",
+	cmake: "cmake",
+	lua: "lua",
+	perl: "perl",
+	r: "r",
+	scala: "scala",
+	clj: "clojure",
+	ex: "elixir",
+	exs: "elixir",
+	erl: "erlang",
+	hs: "haskell",
+	ml: "ocaml",
+	vim: "vim",
+	graphql: "graphql",
+	proto: "protobuf",
+	tf: "hcl",
+	hcl: "hcl",
+};
+
+const SCOPE_COLORS: Readonly<Record<string, ThemeColor>> = {
+	keyword: "syntaxKeyword",
+	built_in: "syntaxType",
+	literal: "syntaxNumber",
+	number: "syntaxNumber",
+	regexp: "syntaxString",
+	string: "syntaxString",
+	comment: "syntaxComment",
+	doctag: "syntaxComment",
+	meta: "muted",
+	function: "syntaxFunction",
+	title: "syntaxFunction",
+	class: "syntaxType",
+	type: "syntaxType",
+	tag: "syntaxPunctuation",
+	name: "syntaxKeyword",
+	attr: "syntaxVariable",
+	variable: "syntaxVariable",
+	params: "syntaxVariable",
+	operator: "syntaxOperator",
+	punctuation: "syntaxPunctuation",
+	addition: "toolDiffAdded",
+	deletion: "toolDiffRemoved",
+};
+
+export function getLanguageFromPath(filePath: string): string | undefined {
+	const extension = filePath.split(".").pop()?.toLowerCase();
+	return extension ? LANGUAGE_BY_EXTENSION[extension] : undefined;
+}
+
+export function highlightCode(
+	code: string,
+	language: string | undefined,
+	theme: SyntaxTheme,
+): string {
+	if (!language || !hljs.getLanguage(language)) {
+		return theme.fg("mdCodeBlock", theme.fg("mdCodeBlock", code));
+	}
+	try {
+		const html = hljs.highlight(code, { language, ignoreIllegals: true }).value;
+		return theme.fg("mdCodeBlock", renderHighlightedHtml(html, syntaxFormatters(theme)));
+	} catch {
+		return theme.fg("mdCodeBlock", code);
+	}
+}
+
+function syntaxFormatters(theme: SyntaxTheme): Readonly<Record<string, Formatter>> {
+	const formatters: Record<string, Formatter> = {};
+	for (const [scope, color] of Object.entries(SCOPE_COLORS)) {
+		formatters[scope] = (text) => theme.fg(color, text);
+	}
+	formatters.emphasis = (text) => theme.italic?.(text) ?? text;
+	formatters.strong = (text) => theme.bold(text);
+	formatters.link = (text) => theme.underline?.(text) ?? text;
+	return formatters;
+}
+
+function renderHighlightedHtml(
+	html: string,
+	formatters: Readonly<Record<string, Formatter>>,
+): string {
+	let output = "";
+	let textBuffer = "";
+	const scopes: Array<string | undefined> = [];
+	const flush = () => {
+		if (!textBuffer) return;
+		output += activeFormatter(scopes, formatters)?.(textBuffer) ?? textBuffer;
+		textBuffer = "";
+	};
+
+	for (let index = 0; index < html.length; ) {
+		if (html.startsWith("<span", index)) {
+			const tagEnd = html.indexOf(">", index + 5);
+			if (tagEnd >= 0) {
+				flush();
+				scopes.push(scopeFromTag(html.slice(index, tagEnd + 1)));
+				index = tagEnd + 1;
+				continue;
+			}
+		}
+		if (html.startsWith("</span>", index)) {
+			flush();
+			scopes.pop();
+			index += "</span>".length;
+			continue;
+		}
+		if (html[index] === "&") {
+			const entityEnd = html.indexOf(";", index + 1);
+			if (entityEnd >= 0) {
+				const decoded = decodeEntity(html.slice(index + 1, entityEnd));
+				if (decoded !== undefined) {
+					textBuffer += decoded;
+					index = entityEnd + 1;
+					continue;
+				}
+			}
+		}
+		textBuffer += html[index];
+		index += 1;
+	}
+	flush();
+	return output;
+}
+
+function scopeFromTag(tag: string): string | undefined {
+	const classValue = /\sclass\s*=\s*(?:"([^"]*)"|'([^']*)')/u.exec(tag)?.slice(1).find(Boolean);
+	return classValue
+		?.split(/\s+/u)
+		.find((className) => className.startsWith("hljs-"))
+		?.slice("hljs-".length);
+}
+
+function activeFormatter(
+	scopes: readonly (string | undefined)[],
+	formatters: Readonly<Record<string, Formatter>>,
+): Formatter | undefined {
+	for (let index = scopes.length - 1; index >= 0; index -= 1) {
+		const scope = scopes[index];
+		if (!scope) continue;
+		const exact = formatters[scope];
+		if (exact) return exact;
+		const prefix = scope.split(/[.-]/u)[0];
+		if (prefix && formatters[prefix]) return formatters[prefix];
+	}
+	return undefined;
+}
+
+function decodeEntity(entity: string): string | undefined {
+	const named: Readonly<Record<string, string>> = {
+		amp: "&",
+		apos: "'",
+		gt: ">",
+		lt: "<",
+		quot: '"',
+	};
+	if (named[entity] !== undefined) return named[entity];
+	const radix = entity.startsWith("#x") || entity.startsWith("#X") ? 16 : 10;
+	const digits =
+		entity.startsWith("#x") || entity.startsWith("#X") ? entity.slice(2) : entity.slice(1);
+	if (!entity.startsWith("#") || !digits) return undefined;
+	const codePoint = Number.parseInt(digits, radix);
+	if (!Number.isSafeInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return undefined;
+	try {
+		return String.fromCodePoint(codePoint);
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/pi-tui-kit/src/components/task-loader.ts
+++ b/packages/pi-tui-kit/src/components/task-loader.ts
@@ -1,0 +1,76 @@
+import { Container, Key, Loader, matchesKey, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
+import type { MenuKeybindings } from "./contracts.js";
+import { DynamicBorder } from "./dynamic-border.js";
+
+interface TaskLoaderTheme {
+	fg(color: "accent" | "border" | "dim" | "muted", text: string): string;
+}
+
+/** Cancellable loader composed from public Pi TUI primitives and callback-owned inputs. */
+export class TaskLoader extends Container {
+	private readonly loader: Loader;
+	private readonly cancellable: boolean;
+	private disposed = false;
+	onAbort?: () => void;
+
+	constructor(
+		tui: TUI,
+		theme: TaskLoaderTheme,
+		private readonly keybindings: MenuKeybindings,
+		message: string,
+		options: { cancellable?: boolean } = {},
+	) {
+		super();
+		this.cancellable = options.cancellable ?? true;
+		const cancelHint = this.cancellable ? cancelKeyText(keybindings) : undefined;
+		const borderColor = (text: string) => theme.fg("border", text);
+		this.addChild(new DynamicBorder(borderColor));
+		this.loader = new Loader(
+			tui,
+			(text) => theme.fg("accent", text),
+			(text) => theme.fg("muted", text),
+			message,
+		);
+		this.addChild(this.loader);
+		if (cancelHint !== undefined) {
+			this.addChild(new Spacer(1));
+			this.addChild(new Text(theme.fg("dim", cancelHint) + theme.fg("muted", " cancel"), 1, 0));
+		}
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder(borderColor));
+	}
+
+	handleInput(data: string): void {
+		if (this.disposed || !this.cancellable) return;
+		const matches = this.keybindings.matches;
+		const cancelled =
+			typeof matches === "function"
+				? matches.call(this.keybindings, data, "tui.select.cancel")
+				: matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"));
+		if (cancelled) this.onAbort?.();
+	}
+
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.loader.stop();
+	}
+}
+
+function cancelKeyText(keybindings: MenuKeybindings): string {
+	const getKeys = keybindings.getKeys;
+	const keys =
+		typeof getKeys === "function"
+			? getKeys.call(keybindings, "tui.select.cancel")
+			: ["escape", "ctrl+c"];
+	return keys.map(displayKey).join("/");
+}
+
+function displayKey(key: string): string {
+	return key
+		.split("+")
+		.map((part) =>
+			process.platform === "darwin" && part.toLowerCase() === "alt" ? "option" : part,
+		)
+		.join("+");
+}

--- a/packages/pi-tui-kit/src/task.ts
+++ b/packages/pi-tui-kit/src/task.ts
@@ -1,5 +1,6 @@
-import { BorderedLoader, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { safeMenuText } from "./components/rendering.js";
+import { TaskLoader } from "./components/task-loader.js";
 import type { MenuContext } from "./types.js";
 
 export type RunTaskResult<Value> =
@@ -61,8 +62,8 @@ async function runTuiTask<Value, Context extends MenuContext>(
 
 	try {
 		customResult = await uiFor(ctx).custom<RunTaskResult<Value> | undefined>(
-			(tui, theme, _keybindings, done) => {
-				const loader = new BorderedLoader(tui, theme, safeMenuText(options.label), {
+			(tui, theme, keybindings, done) => {
+				const loader = new TaskLoader(tui, theme, keybindings, safeMenuText(options.label), {
 					cancellable: options.cancellable ?? true,
 				});
 				let loaderDisposed = false;

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -236,6 +236,48 @@ test("review formats code and diffs through theme-aware display paths", () => {
 	assert.match(rendered, /accent:@@ header/);
 });
 
+test("code review uses the injected theme for inferred syntax tokens and safe fallback", () => {
+	const inferred = reviewComponentHarness(
+		{
+			...reviewScreen,
+			content: "const answer: number = 42;",
+			format: { kind: "code", filePath: "answer.ts" },
+			confirm: undefined,
+		},
+		true,
+	);
+	const highlighted = inferred.component.render(80).join("\n");
+	assert.match(highlighted, /syntaxKeyword:const/u);
+	assert.match(highlighted, /syntaxType:number/u);
+	assert.match(highlighted, /syntaxNumber:42/u);
+
+	const explicit = reviewComponentHarness(
+		{
+			...reviewScreen,
+			content: "++>---",
+			format: { kind: "code", language: "brainfuck" },
+			confirm: undefined,
+		},
+		true,
+	);
+	const explicitlyHighlighted = explicit.component.render(80).join("\n");
+	assert.match(explicitlyHighlighted, /\+\+>/u);
+	assert.match(explicitlyHighlighted, /syntaxNumber:-/u);
+
+	const unknown = reviewComponentHarness(
+		{
+			...reviewScreen,
+			content: "plain value",
+			format: { kind: "code", language: "not-a-language" },
+			confirm: undefined,
+		},
+		true,
+	);
+	const fallback = unknown.component.render(80).join("\n");
+	assert.match(fallback, /mdCodeBlock:mdCodeBlock:plain value/u);
+	assert.doesNotMatch(fallback, /syntax(?:Keyword|Type|Number):/u);
+});
+
 test("TUI adaptive review reads live host rows and invokes its raw confirmation action", async () => {
 	const invoked: string[] = [];
 	const frameHeights: number[] = [];

--- a/packages/pi-tui-kit/test/task.test.ts
+++ b/packages/pi-tui-kit/test/task.test.ts
@@ -77,6 +77,81 @@ test("runTask user cancellation aborts and drains the task before returning", as
 	assert.equal(settled, true);
 });
 
+test("runTask uses callback-injected cancellation keys and renders their hint", async () => {
+	let abortedAfterInjectedKey = false;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 40, {
+				matches: (data, binding) => binding === "tui.select.cancel" && data === "x",
+				getKeys: (binding) => (binding === "tui.select.cancel" ? ["x"] : []),
+			});
+			const frame = harness.render();
+			assert.equal(frame[0], "─".repeat(40));
+			assert.equal(frame.at(-1), "─".repeat(40));
+			assert.match(frame.join("\n"), /x cancel/u);
+			harness.handleInput("x");
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			abortedAfterInjectedKey = taskSignal?.aborted ?? false;
+			if (!abortedAfterInjectedKey) {
+				harness.dispose();
+				return undefined;
+			}
+			return harness.resultPromise;
+		},
+	});
+	let taskSignal: AbortSignal | undefined;
+
+	const result = await runTask(context.ctx, {
+		label: "Loading",
+		task: async ({ signal }) => {
+			taskSignal = signal;
+			await new Promise<void>((resolve) => {
+				if (signal.aborted) resolve();
+				else signal.addEventListener("abort", () => resolve(), { once: true });
+			});
+			return "late";
+		},
+	});
+
+	assert.equal(abortedAfterInjectedKey, true);
+	assert.deepEqual(result, { kind: "cancelled" });
+});
+
+test("runTask non-cancellable mode ignores cancel input and hides the hint", async () => {
+	let releaseTask: (() => void) | undefined;
+	const taskGate = new Promise<void>((resolve) => {
+		releaseTask = resolve;
+	});
+	let taskSignal: AbortSignal | undefined;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 40);
+			assert.doesNotMatch(harness.render().join("\n"), /cancel/iu);
+			harness.handleInput("tui.select.cancel");
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			assert.equal(taskSignal?.aborted, false);
+			releaseTask?.();
+			return harness.resultPromise;
+		},
+	});
+
+	const result = await runTask(context.ctx, {
+		label: "Loading",
+		cancellable: false,
+		task: async ({ signal }) => {
+			taskSignal = signal;
+			await taskGate;
+			return "done";
+		},
+	});
+
+	assert.deepEqual(result, { kind: "completed", value: "done" });
+});
+
 test("runTask owner abort is stale and drains before closing TUI", async () => {
 	const owner = new AbortController();
 	let reportStarted: (() => void) | undefined;

--- a/scripts/benchmark-tui-kit-runtime.mjs
+++ b/scripts/benchmark-tui-kit-runtime.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_RUNS = 5;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const SCENARIOS = ["import", "actions", "review", "task"];
+
+const options = parseArguments(process.argv.slice(2));
+if (options.worker) {
+	await runWorker(options.worker);
+} else if (options.help) {
+	printHelp();
+} else {
+	const warmup = {};
+	const measurements = {};
+	for (const scenario of SCENARIOS) {
+		warmup[scenario] = await measure(scenario, options.timeoutMs);
+		measurements[scenario] = [];
+		for (let index = 0; index < options.runs; index += 1) {
+			measurements[scenario].push(await measure(scenario, options.timeoutMs));
+		}
+	}
+	const summary = Object.fromEntries(
+		SCENARIOS.map((scenario) => [
+			scenario,
+			{
+				importMs: summarize(measurements[scenario].map((result) => result.importMs)),
+				firstFrameMs: summarize(
+					measurements[scenario]
+						.map((result) => result.firstFrameMs)
+						.filter((value) => value !== undefined),
+				),
+				codingAgentLoaded: measurements[scenario].some((result) => result.codingAgentLoaded),
+			},
+		]),
+	);
+	process.stdout.write(
+		`${JSON.stringify(
+			{
+				protocolVersion: 1,
+				measuredAt: new Date().toISOString(),
+				node: process.version,
+				cwd: process.cwd(),
+				runs: options.runs,
+				warmup,
+				measurements,
+				summary,
+			},
+			null,
+			2,
+		)}\n`,
+	);
+}
+
+async function runWorker(scenario) {
+	if (!SCENARIOS.includes(scenario)) fail(`Unknown worker scenario: ${scenario}`);
+	const loadedUrls = [];
+	const { registerHooks } = await import("node:module");
+	registerHooks({
+		resolve(specifier, context, nextResolve) {
+			const result = nextResolve(specifier, context);
+			loadedUrls.push(result.url);
+			return result;
+		},
+	});
+
+	const startedAt = performance.now();
+	const kit = await import("@narumitw/pi-tui-kit");
+	const importMs = performance.now() - startedAt;
+	const kitLoadedCodingAgent = loadedUrls.some((url) =>
+		url.includes("/@earendil-works/pi-coding-agent/"),
+	);
+	if (kitLoadedCodingAgent) {
+		const { initTheme } = await import("@earendil-works/pi-coding-agent");
+		initTheme("dark", false);
+	}
+	let firstFrameMs;
+	if (scenario === "actions") {
+		firstFrameMs = await runMenuFrame(kit, startedAt, {
+			kind: "actions",
+			title: "Benchmark actions",
+			items: [{ id: "close", label: "Close", close: true }],
+			hint: "close",
+		});
+	} else if (scenario === "review") {
+		firstFrameMs = await runMenuFrame(kit, startedAt, {
+			kind: "review",
+			title: "Benchmark review",
+			content: "const answer: number = 42;",
+			format: { kind: "code", filePath: "benchmark.ts" },
+			hint: "close",
+		});
+	} else if (scenario === "task") {
+		const context = benchmarkContext(
+			(elapsed) => {
+				firstFrameMs ??= elapsed;
+			},
+			startedAt,
+			false,
+		);
+		const result = await kit.runTask(context, {
+			label: "Benchmark task",
+			task: async () => "done",
+		});
+		if (result.kind !== "completed") {
+			throw new Error(
+				`Unexpected task result: ${result.kind}${result.kind === "error" ? `: ${result.error?.stack ?? result.error}` : ""}`,
+			);
+		}
+	}
+
+	const packageUrls = [...new Set(loadedUrls)]
+		.filter((url) => /\/(?:node_modules|packages)\//u.test(url))
+		.sort();
+	process.stdout.write(
+		`${JSON.stringify({
+			scenario,
+			importMs: round(importMs),
+			firstFrameMs: firstFrameMs === undefined ? undefined : round(firstFrameMs),
+			codingAgentLoaded: packageUrls.some((url) =>
+				url.includes("/@earendil-works/pi-coding-agent/"),
+			),
+			packageUrls,
+		})}\n`,
+	);
+}
+
+async function runMenuFrame(kit, startedAt, screen) {
+	let firstFrameMs;
+	const context = benchmarkContext((elapsed) => {
+		firstFrameMs ??= elapsed;
+	}, startedAt);
+	const menu = kit.defineMenu({
+		start: "main",
+		screens: { main: () => screen },
+		actions: { unused: async () => ({ kind: "close" }) },
+	});
+	const result = await kit.runMenu(context, menu, { getState: () => undefined });
+	if (result.kind !== "closed") throw new Error(`Unexpected menu result: ${result.kind}`);
+	if (firstFrameMs === undefined) throw new Error("Menu did not render a frame");
+	return firstFrameMs;
+}
+
+function benchmarkContext(onFirstFrame, startedAt, closeAfterFirstFrame = true) {
+	const theme = {
+		fg: (_color, text) => text,
+		bold: (text) => text,
+		italic: (text) => text,
+		underline: (text) => text,
+	};
+	const keybindings = {
+		matches(data, binding) {
+			return binding === "tui.select.cancel" && data === "\u001b";
+		},
+		getKeys(binding) {
+			return binding === "tui.select.cancel" ? ["escape", "ctrl+c"] : [];
+		},
+	};
+	const tui = { terminal: { rows: 24 }, requestRender() {} };
+	return {
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			theme,
+			notify() {},
+			async custom(factory) {
+				let resolveResult;
+				const resultPromise = new Promise((resolve) => {
+					resolveResult = resolve;
+				});
+				const component = factory(tui, theme, keybindings, resolveResult);
+				component.render(80);
+				onFirstFrame(performance.now() - startedAt);
+				if (closeAfterFirstFrame) resolveResult(undefined);
+				const result = await resultPromise;
+				component.dispose?.();
+				return result;
+			},
+		},
+	};
+}
+
+async function measure(scenario, timeoutMs) {
+	const child = spawn(process.execPath, [fileURLToPath(import.meta.url), "--worker", scenario], {
+		cwd: process.cwd(),
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	let stdout = "";
+	let stderr = "";
+	child.stdout.setEncoding("utf8");
+	child.stderr.setEncoding("utf8");
+	child.stdout.on("data", (chunk) => {
+		stdout += chunk;
+	});
+	child.stderr.on("data", (chunk) => {
+		stderr += chunk;
+	});
+	const timeout = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+	const exit = await new Promise((resolve, reject) => {
+		child.once("error", reject);
+		child.once("exit", (code, signal) => resolve({ code, signal }));
+	});
+	clearTimeout(timeout);
+	if (exit.code !== 0) {
+		throw new Error(
+			`Benchmark worker failed (scenario=${scenario}, code=${exit.code}, signal=${exit.signal ?? "none"}).\n${stderr}\n${stdout}`,
+		);
+	}
+	return JSON.parse(stdout.trim());
+}
+
+function summarize(values) {
+	if (values.length === 0) return undefined;
+	const center = median(values);
+	return {
+		median: round(center),
+		medianAbsoluteDeviation: round(median(values.map((value) => Math.abs(value - center)))),
+		min: round(Math.min(...values)),
+		max: round(Math.max(...values)),
+	};
+}
+
+function median(values) {
+	const ordered = [...values].sort((left, right) => left - right);
+	const middle = Math.floor(ordered.length / 2);
+	return ordered.length % 2 === 0
+		? ((ordered[middle - 1] ?? 0) + (ordered[middle] ?? 0)) / 2
+		: (ordered[middle] ?? 0);
+}
+
+function round(value) {
+	return Math.round(value * 100) / 100;
+}
+
+function parseArguments(args) {
+	const parsed = {
+		help: false,
+		runs: DEFAULT_RUNS,
+		timeoutMs: DEFAULT_TIMEOUT_MS,
+		worker: undefined,
+	};
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index];
+		if (argument === "--help" || argument === "-h") parsed.help = true;
+		else if (argument === "--runs") {
+			parsed.runs = positiveInteger(requireValue(args, ++index, argument), argument);
+		} else if (argument === "--timeout-ms") {
+			parsed.timeoutMs = positiveInteger(requireValue(args, ++index, argument), argument);
+		} else if (argument === "--worker") parsed.worker = requireValue(args, ++index, argument);
+		else fail(`Unknown argument: ${argument}`);
+	}
+	return parsed;
+}
+
+function requireValue(args, index, option) {
+	const value = args[index];
+	if (!value) fail(`${option} requires a value.`);
+	return value;
+}
+
+function positiveInteger(value, option) {
+	const number = Number(value);
+	if (!Number.isSafeInteger(number) || number <= 0) fail(`${option} must be a positive integer.`);
+	return number;
+}
+
+function printHelp() {
+	process.stdout.write("Usage: node scripts/benchmark-tui-kit-runtime.mjs [options]\n\n");
+	process.stdout.write(
+		`  --runs <count>       Measured runs after warm-up (default: ${DEFAULT_RUNS})\n`,
+	);
+	process.stdout.write(
+		`  --timeout-ms <n>     Per-worker timeout (default: ${DEFAULT_TIMEOUT_MS})\n`,
+	);
+}
+
+function fail(message) {
+	process.stderr.write(`${message}\n`);
+	process.exit(2);
+}


### PR DESCRIPTION
## Summary

- remove all production JavaScript imports of the `@earendil-works/pi-coding-agent` root from Pi TUI Kit
- compose the border and cancellable task loader from public `pi-tui` primitives and callback-owned theme/keybindings
- preserve review syntax highlighting with a direct `highlight.js` adapter and coding-agent type-only imports
- add a fresh-process benchmark that measures cold import plus first actions, review, and task frames
- document and archive the runtime dependency/performance plan

## Performance

Five fresh serial runs after warm-up on Node 22.23.1:

| Scenario | Before median | After median | Improvement |
| --- | ---: | ---: | ---: |
| Root import | 1321.34 ms | 177.09 ms | 86.6% |
| First actions frame | 1421.05 ms | 243.20 ms | 82.9% |
| First review frame | 1286.95 ms | 349.87 ms | 72.8% |
| First task frame | 1285.97 ms | 361.73 ms | 71.9% |

All final resolver traces exclude `pi-coding-agent`; no measured first interaction exceeded 425 ms.

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit` — passed
- compiled Pi TUI Kit tests — 135/135 passed
- focused Analytics/Usage loader consumer tests — 38/38 passed
- exact old/new highlighting parity smoke — TypeScript, Python, Brainfuck, and unknown-language fallback matched
- `just pack-tui-kit` — passed; 47 files, 40.9 kB packed, 188.9 kB unpacked
- clean Node 22/npm 12 tarball install — both public entrypoints resolved with one deduplicated `highlight.js@10.7.3`
- real Pi RPC load smoke — Kit API 6 command loaded; extension module import 367 ms
- `npm run check` — Biome, boundaries, and all workspace typechecks passed; tests passed 2421/2424
  - Jupyter FIFO timing failed in the parallel run and passed focused rerun
  - the existing BTW terminal path-wrap assertion and GitHub PR periodic-refresh timing assertion reproduced focused
  - all three failing packages have zero diff in this PR

No package version, consumer compatibility floor, publication, tag, or release workflow was changed.
