### PR TITLE
test: stabilize suite across temporary path aliases

### DIFF
--- a/docs/plans/archived/2026-08-05_test-suite-portability-plan.md
+++ b/docs/plans/archived/2026-08-05_test-suite-portability-plan.md
@@ -1,0 +1,20 @@
+# Test suite portability fixes
+
+## Goal
+
+Make the complete `npm test` suite pass when the host exposes a non-canonical temporary-directory alias and when TUI content wraps at the configured test width.
+
+## Plan
+
+- [x] Canonicalize the temporary-directory environment for the compiled test process in `scripts/run-tests.mjs`; focused pi-subagents path and workspace tests passed with the canonical temp environment.
+- [x] Make the pi-btw and pi-plan-mode assertions inspect a sufficiently wide render rather than depending on incidental wrapping from a long host temp path; both focused menu test files passed.
+- [x] Render the pi-worktree colliding labels wide enough to inspect their distinguishing suffixes and drain the asynchronous choice action before the custom harness returns; the focused colliding-label switch test passed.
+- [x] Isolate the pi-github-pr branch-change lifecycle test from unrelated filesystem watcher notifications surfaced by the full run; its focused lifecycle test passed five consecutive runs.
+- [x] Run the complete repository test suite and `npm run check`; `npm test` passed 2,427 tests and `npm run check` passed. The semantic audit found only test harness/assertion changes: no extension runtime, settings persistence, command surface, or package behavior changed.
+
+## Completion Checklist
+
+- [x] All 12 originally failing tests pass in the focused eight-file run after the final pi-worktree assertion fix.
+- [x] `npm test` passes: 2,427 tests, 0 failures.
+- [x] `npm run check` passes: formatting/lint, boundaries, typechecks, and all 2,427 tests.
+- [x] The completed plan is archived under `docs/plans/archived/`.

--- a/extensions/pi-btw/test/menu.test.ts
+++ b/extensions/pi-btw/test/menu.test.ts
@@ -243,7 +243,7 @@ test("btw menu exposes malformed settings as read-only", async () => {
 		});
 		await openSettings(tui);
 		assert.match(tui.render().join("\n"), /Read only/);
-		assert.match(tui.render().join("\n"), /Fix .*pi-btw\.json before\s+saving/);
+		assert.match(tui.render(240).join("\n"), /Fix .*pi-btw\.json before saving/);
 		tui.press("ctrl+c");
 		assert.equal(await running, "closed");
 		assert.equal(await readFile(settingsPath, "utf8"), "{broken");

--- a/extensions/pi-github-pr/test/github-pr.test.ts
+++ b/extensions/pi-github-pr/test/github-pr.test.ts
@@ -724,21 +724,22 @@ test("branch changes abort an in-flight periodic refresh", async () => {
 	writeFileSync(headPath, "ref: refs/heads/feature\n");
 
 	const periodicPrView = deferred<ExecResult>();
-	let prViews = 0;
+	const sessionSignal = new AbortController().signal;
 	let periodicSignal: AbortSignal | undefined;
 	const mock = createMockPi();
 	installExec(mock, async (command, args, options) => {
 		if (command === "git") return textResult(".git/HEAD\n");
 		if (args[0] === "pr") {
-			prViews += 1;
-			if (prViews === 1) return okResult(samplePr);
-			periodicSignal = options?.signal;
-			return periodicPrView.promise;
+			if (options?.signal && options.signal !== sessionSignal) {
+				periodicSignal = options.signal;
+				return periodicPrView.promise;
+			}
+			return okResult(samplePr);
 		}
 		return okResult(sampleCounts);
 	});
 	githubPr(mock.pi, { refreshIntervalMs: 20 });
-	const context = createMockContext({ cwd: root });
+	const context = createMockContext({ cwd: root, signal: sessionSignal });
 	const sessionStart = mock.events.get("session_start")?.[0];
 	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
 	assert.ok(sessionStart);
@@ -746,7 +747,7 @@ test("branch changes abort an in-flight periodic refresh", async () => {
 
 	try {
 		await sessionStart({}, context.ctx);
-		await waitFor(() => prViews === 2, "periodic refresh starts");
+		await waitFor(() => periodicSignal !== undefined, "periodic refresh starts");
 		assert.ok(periodicSignal, "periodic refresh receives a session-owned abort signal");
 		assert.equal(periodicSignal.aborted, false);
 

--- a/extensions/pi-plan-mode/test/settings-menu.test.ts
+++ b/extensions/pi-plan-mode/test/settings-menu.test.ts
@@ -185,7 +185,7 @@ test("After Implement cycles outcomes and export destination saves, previews, re
 		assert.match(frame, /Export destination/i);
 		assert.match(frame, /PLAN\.md/);
 		assert.match(
-			frame,
+			tui.render(240).join("\n"),
 			new RegExp(
 				settingsPath
 					.replace("pi-plan-mode.json", "PLAN.md")

--- a/extensions/pi-worktree/test/command.test.ts
+++ b/extensions/pi-worktree/test/command.test.ts
@@ -946,10 +946,11 @@ test("switch choices use unique ordinals when sanitized worktree labels collide"
 				harness.handleInput("tui.select.down");
 				harness.handleInput("tui.select.confirm");
 			} else {
-				assert.match(harness.render().join("\n"), /1\..*wt-.*same/);
-				assert.match(harness.render().join("\n"), /2\..*wt-same/);
+				assert.match(harness.render(240).join("\n"), /1\..*wt-.*same/);
+				assert.match(harness.render(240).join("\n"), /2\..*wt-same/);
 				harness.handleInput("tui.select.down");
 				harness.handleInput("tui.select.confirm");
+				await harness.waitForPending();
 			}
 			return harness.result;
 		},
@@ -966,7 +967,7 @@ test("switch choices use unique ordinals when sanitized worktree labels collide"
 	try {
 		await mock.commands.get("worktree")?.handler("", context.ctx);
 		assert.equal(customCalls, 2);
-		assert.equal(switchedCwd, second);
+		assert.equal(switchedCwd, second, JSON.stringify(context.notifications));
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -2,6 +2,7 @@
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -38,7 +39,13 @@ if (testFiles.length === 0) {
 	process.exit(1);
 }
 
-run(process.execPath, ["--test", ...testFiles]);
+const canonicalTempDir = fs.realpathSync(os.tmpdir());
+run(process.execPath, ["--test", ...testFiles], {
+	...process.env,
+	TMPDIR: canonicalTempDir,
+	TMP: canonicalTempDir,
+	TEMP: canonicalTempDir,
+});
 
 function activeExtensionDirectories(directory = path.join(root, "extensions")) {
 	const directories = [];
@@ -70,8 +77,8 @@ function runNpm(args) {
 	run(command, commandArgs);
 }
 
-function run(command, args) {
-	const result = spawnSync(command, args, { cwd: root, stdio: "inherit" });
+function run(command, args, env = process.env) {
+	const result = spawnSync(command, args, { cwd: root, stdio: "inherit", env });
 	if (result.error) {
 		console.error(result.error.message);
 		process.exit(1);


### PR DESCRIPTION
## Summary

- canonicalize the temporary-directory environment used by compiled tests
- make TUI assertions independent of host path length and drain the async worktree choice
- isolate the GitHub PR lifecycle test from unrelated filesystem watcher notifications

## Verification

- `npm test` (2,427 passed)
- `npm run check`
- focused GitHub PR lifecycle test passed five consecutive runs