### PR TITLE
chore: harden dependency update workflow

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,13 +12,29 @@ check:
 format:
     npm run format
 
-# Update, install, rebuild, and verify dependencies across all npm workspaces
-update:
-    npx npm-check-updates --workspaces --root -u
-    npm install
+_require-pinned-npm:
+    @package_manager="$(node -p 'require("./package.json").packageManager')"; [[ "$package_manager" == npm@* ]] || { printf 'unsupported packageManager: %s\n' "$package_manager" >&2; exit 2; }; expected="${package_manager#npm@}"; actual="$(npm --version)"; [[ "$actual" == "$expected" ]] || { printf 'npm %s is required, but npm %s is active; switch to a supported Node runtime and install %s\n' "$expected" "$actual" "$package_manager" >&2; exit 2; }
+
+_require-clean-worktree:
+    @[[ -z "$(git status --porcelain)" ]] || { printf 'dependency updates require a clean worktree; commit or stash changes first\n' >&2; exit 2; }
+
+# Update dependency manifests and regenerate the lockfile without trusting the current install
+update-lock: _require-pinned-npm _require-clean-worktree
+    npm exec -- npm-check-updates --workspaces --root -u
+    npm install --package-lock-only
+
+# Verify dependency updates from the exact clean lockfile installation
+verify-update: _require-pinned-npm
+    npm ci
     # Rebuild generated web assets only in workspaces that provide build:web
     npm --workspaces --if-present run build:web
     npm run check
+    npm pack --workspaces --dry-run
+
+# Update, clean-install, rebuild, test, and pack all npm workspaces
+update:
+    just update-lock
+    just verify-update
 
 # Install pre-commit hooks
 hooks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@earendil-works/pi-tui": "0.83.0",
 				"@types/node": "^26.1.2",
-				"npm-check-updates": "22.2.9",
+				"npm-check-updates": "23.0.1",
 				"typebox": "^1.3.10",
 				"typescript": "^7.0.2"
 			}
@@ -5804,9 +5804,9 @@
 			}
 		},
 		"node_modules/npm-check-updates": {
-			"version": "22.2.9",
-			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.9.tgz",
-			"integrity": "sha512-DVeZ0KirHfliSsHuR2o7cHE+tW439sVHfJjF6cGWeDiY0Wyl3BI/jS4zV0eixtcMOquFbcF1Su/FsxOvk5MoYA==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-23.0.1.tgz",
+			"integrity": "sha512-e4hu3Rq4waj7SnhzvqAc5UG557mfP5e3JIFFQd7Fg3RiRkJl8yR90NFoZ1GSWUT3S/QacJndJb+7dLQBPeH+iA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -5814,7 +5814,7 @@
 				"npm-check-updates": "build/cli.js"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0",
 				"npm": ">=10.0.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@earendil-works/pi-tui": "0.83.0",
 				"@types/node": "^26.1.2",
+				"npm-check-updates": "22.2.9",
 				"typebox": "^1.3.10",
 				"typescript": "^7.0.2"
 			}
@@ -5800,6 +5801,21 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/npm-check-updates": {
+			"version": "22.2.9",
+			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.9.tgz",
+			"integrity": "sha512-DVeZ0KirHfliSsHuR2o7cHE+tW439sVHfJjF6cGWeDiY0Wyl3BI/jS4zV0eixtcMOquFbcF1Su/FsxOvk5MoYA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"ncu": "build/cli.js",
+				"npm-check-updates": "build/cli.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+				"npm": ">=10.0.0"
 			}
 		},
 		"node_modules/openai": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@earendil-works/pi-tui": "0.83.0",
 		"@types/node": "^26.1.2",
+		"npm-check-updates": "22.2.9",
 		"typebox": "^1.3.10",
 		"typescript": "^7.0.2"
 	},

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@earendil-works/pi-tui": "0.83.0",
 		"@types/node": "^26.1.2",
-		"npm-check-updates": "22.2.9",
+		"npm-check-updates": "23.0.1",
 		"typebox": "^1.3.10",
 		"typescript": "^7.0.2"
 	},

--- a/test/repository-scripts.test.ts
+++ b/test/repository-scripts.test.ts
@@ -188,6 +188,33 @@ test("latest-Pi setup updates library, production, and experimental workspaces",
 	}
 });
 
+test("dependency updates pin tooling and verify a clean lockfile installation", () => {
+	const manifest = JSON.parse(readFileSync(path.join(repositoryRoot, "package.json"), "utf8"));
+	assert.match(manifest.packageManager, /^npm@\d/u);
+	assert.match(manifest.devDependencies["npm-check-updates"], /^\d+\.\d+\.\d+$/u);
+
+	const justfile = readFileSync(path.join(repositoryRoot, "justfile"), "utf8");
+	const pinnedNpm = justfile.indexOf("_require-pinned-npm:");
+	const cleanWorktree = justfile.indexOf("_require-clean-worktree:");
+	const updateLock = justfile.indexOf("update-lock:");
+	const updateNcu = justfile.indexOf("npm exec -- npm-check-updates", updateLock);
+	const generateLock = justfile.indexOf("npm install --package-lock-only", updateNcu);
+	const verifyUpdate = justfile.indexOf("verify-update:");
+	const cleanInstall = justfile.indexOf("npm ci", verifyUpdate);
+	const checks = justfile.indexOf("npm run check", cleanInstall);
+	const pack = justfile.indexOf("npm pack --workspaces --dry-run", checks);
+
+	assert.ok(pinnedNpm >= 0, "dependency updates must verify packageManager");
+	assert.ok(cleanWorktree > pinnedNpm, "dependency updates must reject a dirty worktree");
+	assert.ok(updateLock > cleanWorktree, "update-lock must follow its preflights");
+	assert.ok(updateNcu > updateLock, "update-lock must use the pinned npm-check-updates binary");
+	assert.ok(generateLock > updateNcu, "update-lock must regenerate package-lock.json");
+	assert.ok(verifyUpdate > generateLock, "verification must be independently rerunnable");
+	assert.ok(cleanInstall > verifyUpdate, "verification must start from npm ci");
+	assert.ok(checks > cleanInstall, "checks must run against the clean install");
+	assert.ok(pack > checks, "workspace pack smokes must run after checks");
+});
+
 test("release workflows install the repository-pinned npm before lockfile or registry work", () => {
 	for (const workflowPath of [
 		".github/workflows/bump-version.yml",


### PR DESCRIPTION
## Summary

- split dependency mutation (`just update-lock`) from clean verification (`just verify-update`)
- enforce the repository-pinned npm version and require a clean worktree before updates
- pin `npm-check-updates`, regenerate the lockfile without trusting the current install, then verify through `npm ci`
- add full workspace pack dry-runs after checks and repository coverage for the workflow contract

## Verification

- `fnm exec --using=24.15.0 -- just update`
  - npm 12.0.2
  - 2,428 tests passed
  - 26 workspace pack dry-runs passed
- mismatched npm preflight exits with an actionable error
- dirty-worktree preflight exits before changing dependency files
- `git diff --check`
