### PR TITLE
fix(btw): support runtime-scoped custom providers

### DIFF
--- a/extensions/pi-btw/src/btw.ts
+++ b/extensions/pi-btw/src/btw.ts
@@ -40,6 +40,7 @@ import {
 import {
 	BTW_THINKING_LEVELS,
 	type BtwThinkingLevel,
+	type CompleteSimpleFunction,
 	completeSideThreadTurn,
 	createSideThread,
 	type SideQuestionAuth,
@@ -66,7 +67,6 @@ export {
 	type BtwThinkingLevel,
 	buildUserPrompt,
 	completeSideQuestion,
-	loadCompleteSimple,
 } from "./side-thread.js";
 export { sanitizeSingleLine } from "./text.js";
 
@@ -81,6 +81,18 @@ type BtwModelRegistry = Pick<
 	ExtensionCommandContext["modelRegistry"],
 	"find" | "getApiKeyAndHeaders"
 >;
+
+type BtwProviderRegistry = Pick<ExtensionCommandContext["modelRegistry"], "getProvider">;
+
+export function createModelRegistryCompleteSimple(
+	modelRegistry: BtwProviderRegistry,
+): CompleteSimpleFunction {
+	return async (model, context, options) => {
+		const provider = modelRegistry.getProvider(model.provider);
+		if (!provider) throw new Error(`No provider registered for model provider: ${model.provider}`);
+		return provider.streamSimple(model, context, options).result();
+	};
+}
 
 interface ResolveBtwModelOptions {
 	settings: BtwSettings;
@@ -777,6 +789,7 @@ async function askThreadQuestion(
 				thinkingLevel,
 				auth: selected.auth,
 				signal: view.signal,
+				completeSimple: createModelRegistryCompleteSimple(ctx.modelRegistry),
 			}).then((result) => {
 				if (settled) return;
 				settled = true;

--- a/extensions/pi-btw/src/side-thread.ts
+++ b/extensions/pi-btw/src/side-thread.ts
@@ -33,36 +33,6 @@ export type CompleteSimpleFunction = <TApi extends Api>(
 	options?: SimpleStreamOptions,
 ) => Promise<AssistantMessage>;
 
-type ModuleImporter = (moduleId: string) => Promise<unknown>;
-
-function hasCompleteSimple(value: unknown): value is { completeSimple: CompleteSimpleFunction } {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		typeof Reflect.get(value, "completeSimple") === "function"
-	);
-}
-
-export async function loadCompleteSimple(
-	importModule: ModuleImporter = (moduleId) => import(moduleId),
-): Promise<CompleteSimpleFunction> {
-	let importError: unknown;
-	for (const moduleId of ["@earendil-works/pi-ai/compat", "@earendil-works/pi-ai"]) {
-		try {
-			const module = await importModule(moduleId);
-			if (hasCompleteSimple(module)) return module.completeSimple;
-		} catch (error: unknown) {
-			importError = error;
-		}
-	}
-
-	throw new Error("@earendil-works/pi-ai does not export completeSimple", {
-		cause: importError,
-	});
-}
-
-const defaultCompleteSimple = await loadCompleteSimple();
-
 export type SideThreadTurn =
 	| {
 			kind: "answered";
@@ -115,7 +85,7 @@ export interface CompleteSideThreadTurnOptions {
 	thinkingLevel: BtwThinkingLevel;
 	auth: SideQuestionAuth;
 	signal?: AbortSignal;
-	completeSimple?: CompleteSimpleFunction;
+	completeSimple: CompleteSimpleFunction;
 }
 
 export type CompleteSideThreadTurnResult =
@@ -130,7 +100,7 @@ export async function completeSideThreadTurn({
 	thinkingLevel,
 	auth,
 	signal,
-	completeSimple = defaultCompleteSimple,
+	completeSimple,
 }: CompleteSideThreadTurnOptions): Promise<CompleteSideThreadTurnResult> {
 	if (signal?.aborted) return { kind: "aborted" };
 	let response: AssistantMessage;
@@ -162,7 +132,7 @@ export interface CompleteSideQuestionOptions {
 	thinkingLevel: BtwThinkingLevel;
 	auth: SideQuestionAuth;
 	signal?: AbortSignal;
-	completeSimple?: CompleteSimpleFunction;
+	completeSimple: CompleteSimpleFunction;
 }
 
 export async function completeSideQuestion({
@@ -172,7 +142,7 @@ export async function completeSideQuestion({
 	thinkingLevel,
 	auth,
 	signal,
-	completeSimple = defaultCompleteSimple,
+	completeSimple,
 }: CompleteSideQuestionOptions): Promise<AssistantMessage> {
 	return completeSimple(
 		model,

--- a/extensions/pi-btw/test/btw.test.ts
+++ b/extensions/pi-btw/test/btw.test.ts
@@ -11,7 +11,6 @@ import btw, {
 	buildUserPrompt,
 	completeSideQuestion,
 	loadBtwThinkingLevel,
-	loadCompleteSimple,
 	normalizeBtwSettings,
 	parseBtwModelReference,
 	readBtwSettings,
@@ -29,41 +28,6 @@ async function withTempSettings(run: (settingsPath: string) => Promise<void>): P
 		await rm(directory, { recursive: true, force: true });
 	}
 }
-
-test("loadCompleteSimple prefers compat and falls back to the root module", async () => {
-	const compatCompleteSimple = async () => ({ source: "compat" });
-	const rootCompleteSimple = async () => ({ source: "root" });
-	const preferredImports: string[] = [];
-	const preferred = await loadCompleteSimple(async (moduleId) => {
-		preferredImports.push(moduleId);
-		return moduleId.endsWith("/compat")
-			? { completeSimple: compatCompleteSimple }
-			: { completeSimple: rootCompleteSimple };
-	});
-
-	assert.equal(preferred, compatCompleteSimple);
-	assert.deepEqual(preferredImports, ["@earendil-works/pi-ai/compat"]);
-
-	const fallbackImports: string[] = [];
-	const fallback = await loadCompleteSimple(async (moduleId) => {
-		fallbackImports.push(moduleId);
-		if (moduleId.endsWith("/compat")) throw new Error("missing compat export");
-		return { completeSimple: rootCompleteSimple };
-	});
-
-	assert.equal(fallback, rootCompleteSimple);
-	assert.deepEqual(fallbackImports, ["@earendil-works/pi-ai/compat", "@earendil-works/pi-ai"]);
-});
-
-test("loadCompleteSimple reports when neither module exports completeSimple", async () => {
-	await assert.rejects(
-		loadCompleteSimple(async (moduleId) => {
-			if (moduleId.endsWith("/compat")) throw new Error("missing compat export");
-			return {};
-		}),
-		/@earendil-works\/pi-ai does not export completeSimple/,
-	);
-});
 
 test("normalizeBtwSettings accepts optional model and thinking level", () => {
 	assert.deepEqual(normalizeBtwSettings({}), {});

--- a/extensions/pi-btw/test/side-thread.test.ts
+++ b/extensions/pi-btw/test/side-thread.test.ts
@@ -692,6 +692,74 @@ test("bring-to-main scope menu propagates Ctrl+C as a side-thread close", async 
 	assert.deepEqual(result, { kind: "closed" });
 });
 
+test("side-thread sends custom APIs through Pi core's effective provider", async () => {
+	initTheme("dark");
+	const model = {
+		provider: "synthetic-provider",
+		id: "synthetic-model",
+		api: "synthetic-custom-api",
+		reasoning: false,
+	} as Model<Api>;
+	const selected: ResolvedBtwModel = {
+		model,
+		auth: { apiKey: "synthetic-key", headers: { "x-test": "yes" } },
+	};
+	const providerReads: string[] = [];
+	const streamCalls: Array<{
+		model: Model<Api>;
+		context: Context;
+		options?: SimpleStreamOptions;
+	}> = [];
+	let customCalls = 0;
+	const ctx = {
+		ui: {
+			notify() {},
+			custom: async (factory: (...args: never[]) => unknown) => {
+				customCalls += 1;
+				if (customCalls > 1) return { kind: "close" };
+				return new Promise((resolve) => {
+					factory(
+						{ terminal: { rows: 24 }, requestRender() {} } as never,
+						{
+							fg: (_color: string, text: string) => text,
+							bold: (text: string) => text,
+						} as never,
+						{} as never,
+						resolve as never,
+					);
+				});
+			},
+		},
+		modelRegistry: {
+			getProvider(provider: string) {
+				providerReads.push(provider);
+				return {
+					streamSimple(capturedModel: Model<Api>, context: Context, options?: SimpleStreamOptions) {
+						streamCalls.push({ model: capturedModel, context, options });
+						return { result: async () => response("scoped answer") } as never;
+					},
+				};
+			},
+		},
+		sessionManager: { getBranch: () => [] },
+	} as never;
+
+	assert.deepEqual(
+		await runBtwThread({
+			initialQuestion: "Can the scoped provider answer?",
+			selected,
+			thinkingLevel: "off",
+			ctx,
+		}),
+		{ kind: "closed" },
+	);
+	assert.deepEqual(providerReads, ["synthetic-provider"]);
+	assert.equal(streamCalls.length, 1);
+	assert.equal(streamCalls[0]?.model, model);
+	assert.equal(streamCalls[0]?.options?.apiKey, "synthetic-key");
+	assert.deepEqual(streamCalls[0]?.options?.headers, { "x-test": "yes" });
+});
+
 test("side-thread command loop opens the composer before the first question", async () => {
 	const ctx = {
 		ui: { notify() {} },


### PR DESCRIPTION
## Summary

- route `/btw` side-question completions through the effective provider exposed by `ctx.modelRegistry`
- remove the global legacy compat dispatcher from the production side-thread path
- add a deterministic custom-API regression test that requires no external provider package or network access

## Why

Custom providers register `streamSimple` within their owning Pi runtime. The legacy global compat dispatcher only knows globally registered APIs, so it rejected runtime-scoped custom API names before the provider stream could run.

## Verification

- `npm run check --workspace @narumitw/pi-btw`
- `npm run check` in a normal clone: 2430/2430 tests passed
- synthetic custom provider regression test, with `pi-commandcode-provider` absent

Closes #576