### PR TITLE
chore(release): add pi-btw provider fix changeset

### DIFF
--- a/.changeset/runtime-provider-streams.md
+++ b/.changeset/runtime-provider-streams.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": patch
+---
+
+Route side-question completions through Pi's effective runtime provider so custom provider APIs work.


### PR DESCRIPTION
## Summary

- add the missing patch release intent for the runtime-scoped custom-provider fix merged in #579
- select only `@narumitw/pi-btw`, advancing it from 0.49.5 to 0.49.6
- leave publication to the Changesets Version PR workflow after this metadata lands on `main`

## SemVer rationale

This is a backward-compatible bug fix to the extension entrypoint: side-question completions now use Pi's effective runtime provider. The package's advertised `src/index.ts` surface remains unchanged, so a patch bump is appropriate.

## Verification

- `npm run changeset:status` — selects only `@narumitw/pi-btw@0.49.6` as patch
- `npm pack --workspace @narumitw/pi-btw --dry-run --json`
- `npm run check` — 2,420 tests passed
- npm registry verification — `@narumitw/pi-btw@0.49.5` is current; 0.49.6 is available

No package was published, no Version PR was merged, and no release workflow was dispatched.