### PR TITLE
fix(analytics): tolerate transient write stalls

### DIFF
--- a/.changeset/calm-writers-wait.md
+++ b/.changeset/calm-writers-wait.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-analytics": patch
+---
+
+Allow local analytics writes more time to complete during transient filesystem stalls.

--- a/packages/pi-analytics/src/storage/files.ts
+++ b/packages/pi-analytics/src/storage/files.ts
@@ -24,7 +24,7 @@ import {
 
 const GENERATION_PATTERN =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
-const DEFAULT_WRITE_TIMEOUT_MS = 500;
+const DEFAULT_WRITE_TIMEOUT_MS = 5_000;
 const YIELD_EVERY_RECORDS = 100;
 
 export interface ClearAnalyticsResult {

--- a/packages/pi-analytics/test/files.test.ts
+++ b/packages/pi-analytics/test/files.test.ts
@@ -87,6 +87,20 @@ test("independent writers lazily append private frames without cross-process loc
 	}
 });
 
+test("the default write deadline tolerates a transient local filesystem stall", async (t) => {
+	const root = await fixture(t);
+	const files = new AnalyticsRunFiles(root, {
+		async beforeAppend() {
+			await new Promise((resolve) => setTimeout(resolve, 750));
+		},
+	});
+	await files.append(run("delayed"));
+	assert.deepEqual(
+		(await collect(files)).map(({ id }) => id),
+		["delayed"],
+	);
+});
+
 test("reader ignores only a crash-truncated final frame and rejects completed corruption", async (t) => {
 	const root = await fixture(t);
 	const files = new AnalyticsRunFiles(root);


### PR DESCRIPTION
## Summary

- increase the default local analytics write deadline from 500 ms to 5 seconds so transient filesystem stalls do not drop runs
- retain caller/lifecycle cancellation and the explicitly tested bounded timeout path
- add a patch changeset for `@narumitw/pi-analytics`

## Verification

- regression test failed before the fix with `TimeoutError: Analytics write timed out`
- focused deadline and cancellation tests pass
- `npm run check` — 2,421 tests passed in a normal clone
- `npm run check --workspace @narumitw/pi-analytics`
- `npm run changeset:status`
- `just pack analytics`

## Context

Resolves the flaky analytics write seen in [workflow run 31111093815](https://github.com/narumiruna/pi-extensions/actions/runs/31111093815/job/92649098337).
