### PR TITLE
chore: simplify Just recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Run commands from the repository root unless noted otherwise.
 - Run all active tests: `npm test`
 - Format with Biome: `npm run format` or `just format`
 - Typecheck all workspaces: `npm run typecheck`
-- Preview an extension package: `just pack <unscoped-name>`; preview the library with `just pack-tui-kit`
+- Preview any package: `just pack <unscoped-name>`
 - Try a local extension without installing: `just try <unscoped-name>`
 - Inspect available recipes before adding or documenting workflow commands: `just --list`
 
@@ -52,7 +52,7 @@ Run commands from the repository root unless noted otherwise.
 
 - Active extension tests live under `packages/<package>/test/*.test.ts` and run with `npm test`; archived tests under `deprecated/` are excluded.
 - Use `npm run check` as the CI-equivalent local gate; it runs Biome, boundary checks, workspace typechecks, and tests.
-- For package metadata or publishing changes, also run `just pack <unscoped-name>` (or the library's dedicated pack recipe) and inspect the tarball contents.
+- For package metadata or publishing changes, also run `just pack <unscoped-name>` and inspect the tarball contents.
 - For Pi runtime behavior, prefer `just try <unscoped-name>` or the equivalent explicit `pi -e` path before publishing.
 
 ## Publishing and release safety
@@ -61,7 +61,7 @@ Run commands from the repository root unless noted otherwise.
 - Every publishable package versions independently through Changesets. A pull request that changes published package behavior must add release intent with `npm run changeset`; repository-only documentation, tests, tooling, and path migrations may omit it.
 - Publishable experimental packages use the same Changesets version-PR and publishing workflow as stable packages; preserve their experimental warning in user-facing documentation and runtime behavior.
 - `just npm-public <package>` only changes visibility for an existing package. If a brand-new scoped package still returns 404, its first approved publication must use `npm publish --workspace <package> --access public`.
-- The `publish.yml` workflow creates or updates an independent version PR, then publishes merged versions with package-specific tags and GitHub releases. `just publish-all` is recovery-only and still requires explicit approval.
+- The `publish.yml` workflow creates or updates an independent version PR, then publishes merged versions with package-specific tags and GitHub releases. Initial publication remains a manually approved exception.
 - Publish a new `pi-tui-kit` API before raising a consumer's reviewed compatibility floor; do not release an unpublished Kit API and its first consumer together.
 
 ## Git and PR guidance

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ just pack goal
 just try file-context
 just pack file-context
 
-# Libraries have dedicated pack recipes
-just pack-tui-kit
+# Libraries use the same generic pack recipe
+just pack tui-kit
 ```
 
 Run `just --list` to see all development, install, pack, and release recipes. Pull requests that
@@ -203,8 +203,8 @@ and the lockfile. Merging it publishes the new versions with npm provenance and 
 package-specific tags and GitHub releases such as `@narumitw/pi-goal@0.50.0`.
 
 Repository-only documentation, tests, tooling, and path migrations may omit a changeset. Use
-`npm run changeset:status` to inspect pending releases. `just publish-all` is recovery-only and still
-requires explicit publication approval.
+`npm run changeset:status` to inspect pending releases. Versioning and publication run through the
+release workflow; initial publication remains the manually approved exception described above.
 
 `@narumitw/pi-tui-kit` remains independently versioned. Publish a new Kit API before raising an
 extension's compatibility floor to consume it; do not release an unpublished Kit API and its first

--- a/docs/plans/2026-07-30_pi-goal-blocked-proposal-review-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-blocked-proposal-review-plan.md
@@ -125,7 +125,7 @@ The Phase 4 admission record must resolve these before implementation:
       match the admitted consumer and deterministic tests.
 - [ ] Audit cancellation, proposal disposal, replacement, shutdown, every post-`await` state use,
       settings mutation ordering, and public contract compatibility; run focused tests, the pi-goal
-      workspace check and runtime smoke, root `npm test`, root `npm run check`, `just pack-goal`, the
+      workspace check and runtime smoke, root `npm test`, root `npm run check`, `just pack goal`, the
       admitted consumer smoke/dry run, and `git diff --check` before handoff.
 
 ## Completion Checklist

--- a/docs/plans/2026-07-30_pi-goal-continuation-lease-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-continuation-lease-plan.md
@@ -142,7 +142,7 @@ The Phase 4 admission record must resolve these before implementation:
       replacement, shutdown, settings rollback, and every timer/event continuation against both
       extension guides.
 - [ ] Run focused deterministic tests, the pi-goal workspace check and runtime smoke, root `npm test`,
-      root `npm run check`, `just pack-goal`, the admitted consumer check/dry run and runtime smoke,
+      root `npm run check`, `just pack goal`, the admitted consumer check/dry run and runtime smoke,
       plus `git diff --check`; record lease cleanup and no-listener equivalence evidence before
       handoff.
 

--- a/docs/plans/2026-07-30_pi-goal-cross-extension-access-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-cross-extension-access-plan.md
@@ -115,7 +115,7 @@ continues to report the manual settings path.
       replacement, and shutdown against `docs/extension-conventions.md` and
       `docs/extension-settings.md`; run `npm run check --workspace @narumitw/pi-goal`,
       `npm run test:runtime --workspace @narumitw/pi-goal`, root `npm test`, root `npm run check`,
-      `just pack-goal`, and `git diff --check`, recording any unverified runtime path before handoff.
+      `just pack goal`, and `git diff --check`, recording any unverified runtime path before handoff.
 
 ## Completion Checklist
 

--- a/docs/plans/2026-07-30_pi-goal-supervisor-resume-rpc-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-supervisor-resume-rpc-plan.md
@@ -127,7 +127,7 @@ wording, and tests without widening the objective. Deferral does not block the c
       tracking, settings behavior, and any explicit guidance deferral; verify examples match tests.
 - [ ] Audit user cancellation, prompt disposal, session replacement, shutdown, post-`await` state,
       settings downgrade, and tool-visibility rollback against both extension guides; run the
-      workspace check and runtime smoke, root `npm test`, root `npm run check`, `just pack-goal`, and
+      workspace check and runtime smoke, root `npm test`, root `npm run check`, `just pack goal`, and
       `git diff --check`, recording any live supervisor path that remains unverified for Phase 4.
 
 ## Completion Checklist

--- a/docs/plans/2026-07-30_pi-goal-transition-provenance-plan.md
+++ b/docs/plans/2026-07-30_pi-goal-transition-provenance-plan.md
@@ -124,7 +124,7 @@ code changes.
       documentation examples match exported TypeScript types and deterministic tests.
 - [ ] Audit every stopped-state writer, post-`await` rollback, session reload, queue transition, and
       settings snapshot against the roadmap and extension conventions; run the pi-goal workspace
-      check and runtime smoke, root `npm test`, root `npm run check`, `just pack-goal`, and
+      check and runtime smoke, root `npm test`, root `npm run check`, `just pack goal`, and
       `git diff --check`, recording the transition-matrix evidence in the completed plan.
 
 ## Completion Checklist

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -276,7 +276,7 @@ abstractions when Pi provides a better stable owner.
   raw IDs and values separately.
 - Revalidate mutable state after every await before publishing UI or in-memory state.
 - For each public package change, run the package check, root `npm run check`, deterministic runtime
-  smokes, and `just pack-tui-kit`; inspect all exported production and testing entry points.
+  smokes, and `just pack tui-kit`; inspect all exported production and testing entry points.
 
 ## Risks and Dependencies
 

--- a/justfile
+++ b/justfile
@@ -66,17 +66,17 @@ npm-public package="@narumitw/pi-goal":
     npm access set status=public {{quote(package)}}
     npm view {{quote(package)}} version
 
-_validate-extension-name name:
-    @[[ {{quote(name)}} =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || { printf 'invalid extension name: %s\n' {{quote(name)}} >&2; exit 2; }
+_validate-package-name name:
+    @[[ {{quote(name)}} =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || { printf 'invalid package name: %s\n' {{quote(name)}} >&2; exit 2; }
 
 # Preview the package that npm would publish
 # Usage: just pack subagents
-pack name: (_validate-extension-name name)
-    name={{quote(name)}}; package_json="./packages/pi-$name/package.json"; [[ -f "$package_json" ]] || { echo "extension package not found for: $name" >&2; exit 2; }; package="$(node -p "require(process.argv[1]).name" "$package_json")"; npm --workspace "$package" pack --dry-run
+pack name: (_validate-package-name name)
+    name={{quote(name)}}; package_json="./packages/pi-$name/package.json"; [[ -f "$package_json" ]] || { echo "package not found for: $name" >&2; exit 2; }; package="$(node -p "require(process.argv[1]).name" "$package_json")"; npm --workspace "$package" pack --dry-run
 
-# Try a package from this working tree as a temporary pi package
+# Try an extension package from this working tree as a temporary pi package
 # Usage: just try subagents
-try name: (_validate-extension-name name)
+try name: (_validate-package-name name)
     name={{quote(name)}}; extension_dir="./packages/pi-$name"; [[ -d "$extension_dir" ]] || { echo "extension package not found for: $name" >&2; exit 2; }; package_json="$extension_dir/package.json"; package="$(node -p "require(process.argv[1]).name" "$package_json")"; npm --workspace "$package" run build --if-present; pi -e "$extension_dir"
 
 # Start Pi with the commonly used extensions loaded from this working tree
@@ -104,7 +104,7 @@ try-all:
 
 # Install a package through pi, falling back to the local workspace if unpublished
 # Usage: just install subagents
-install name: (_validate-extension-name name)
+install name: (_validate-package-name name)
     name={{quote(name)}}; extension_dir="./packages/pi-$name"; package_json="$extension_dir/package.json"; [[ -f "$package_json" ]] || { echo "extension package not found for: $name" >&2; exit 2; }; package="$(node -p "require(process.argv[1]).name" "$package_json")"; if npm view "$package" version >/dev/null 2>&1; then pi install "npm:$package"; else echo "$package is not published; installing local workspace package instead."; pi install "$extension_dir"; fi
 
 # Add release intent for independently versioned packages
@@ -114,226 +114,3 @@ changeset:
 # Show the pending independent release plan
 changeset-status:
     npm run changeset:status
-
-# Apply pending changesets to package versions, changelogs, and the lockfile
-version-packages:
-    npm run version-packages
-
-# Recovery publication for every local package version not already on npm
-# Requires explicit approval before use.
-publish-all:
-    npm run check
-    npm run publish-packages
-
-# Preview individual packages that npm would publish
-pack-tui-kit:
-    npm --workspace @narumitw/pi-tui-kit pack --dry-run
-
-pack-btw:
-    just pack btw
-
-pack-caffeinate:
-    just pack caffeinate
-
-pack-chrome-devtools:
-    just pack chrome-devtools
-
-pack-codex-compact:
-    just pack codex-compact
-
-pack-accounts:
-    just pack accounts
-
-pack-analytics:
-    just pack analytics
-
-pack-usage:
-    just pack usage
-
-pack-firecrawl:
-    just pack firecrawl
-
-pack-github-pr:
-    just pack github-pr
-
-pack-google-genai:
-    just pack google-genai
-
-pack-goal:
-    just pack goal
-
-pack-image-drop:
-    just pack image-drop
-
-pack-jupyter:
-    just pack jupyter
-
-pack-langfuse:
-    just pack langfuse
-
-pack-lsp:
-    just pack lsp
-
-pack-plan-mode:
-    just pack plan-mode
-
-pack-recall:
-    just pack recall
-
-pack-stamp:
-    just pack stamp
-
-pack-starship:
-    just pack starship
-
-pack-statusline:
-    just pack statusline
-
-pack-sync:
-    just pack sync
-
-pack-subagents:
-    just pack subagents
-
-pack-webui:
-    just pack webui
-
-pack-worktree:
-    just pack worktree
-
-# Try individual packages from this working tree as temporary pi packages
-try-btw:
-    just try btw
-
-try-caffeinate:
-    just try caffeinate
-
-try-chrome-devtools:
-    just try chrome-devtools
-
-try-codex-compact:
-    just try codex-compact
-
-try-accounts:
-    just try accounts
-
-try-analytics:
-    just try analytics
-
-try-usage:
-    just try usage
-
-try-firecrawl:
-    just try firecrawl
-
-try-github-pr:
-    just try github-pr
-
-try-google-genai:
-    just try google-genai
-
-try-goal:
-    just try goal
-
-try-image-drop:
-    just try image-drop
-
-try-jupyter:
-    just try jupyter
-
-try-langfuse:
-    just try langfuse
-
-try-lsp:
-    just try lsp
-
-try-plan-mode:
-    just try plan-mode
-
-try-recall:
-    just try recall
-
-try-stamp:
-    just try stamp
-
-try-starship:
-    just try starship
-
-try-statusline:
-    just try statusline
-
-try-sync:
-    just try sync
-
-try-subagents:
-    just try subagents
-
-try-webui:
-    just try webui
-
-try-worktree:
-    just try worktree
-
-# Install individual packages through pi
-install-btw:
-    just install btw
-
-install-caffeinate:
-    just install caffeinate
-
-install-chrome-devtools:
-    just install chrome-devtools
-
-install-accounts:
-    just install accounts
-
-install-analytics:
-    just install analytics
-
-install-usage:
-    just install usage
-
-install-firecrawl:
-    just install firecrawl
-
-install-github-pr:
-    just install github-pr
-
-install-google-genai:
-    just install google-genai
-
-install-goal:
-    just install goal
-
-install-image-drop:
-    just install image-drop
-
-install-jupyter:
-    just install jupyter
-
-install-langfuse:
-    just install langfuse
-
-install-lsp:
-    just install lsp
-
-install-plan-mode:
-    just install plan-mode
-
-install-stamp:
-    just install stamp
-
-install-statusline:
-    just install statusline
-
-install-sync:
-    just install sync
-
-install-subagents:
-    just install subagents
-
-install-webui:
-    just install webui
-
-install-worktree:
-    just install worktree

--- a/packages/pi-worktree/README.md
+++ b/packages/pi-worktree/README.md
@@ -36,7 +36,7 @@ pi -e npm:@narumitw/pi-worktree
 Try this package locally from the repository root:
 
 ```bash
-just try-worktree
+just try worktree
 # or: pi -e ./packages/pi-worktree
 ```
 

--- a/test/repository-scripts.test.ts
+++ b/test/repository-scripts.test.ts
@@ -132,8 +132,9 @@ test("Changesets config keeps every package independently versioned", () => {
 	assert.equal(config.baseBranch, "main");
 	assert.equal(config.bumpVersionsWithWorkspaceProtocolOnly, true);
 	assert.match(justfile, /^changeset:/m);
-	assert.match(justfile, /^publish-all:/m);
-	assert.doesNotMatch(justfile, /^publish-(?!all:)[a-z]|^publish name:|^bump /m);
+	assert.match(justfile, /^changeset-status:/m);
+	assert.doesNotMatch(justfile, /^version-packages:|^publish-|^bump /m);
+	assert.doesNotMatch(justfile, /^(?:(?:pack|install)-[a-z0-9]|try-(?!all:)[a-z0-9])/m);
 	assert.equal(existsSync(path.join(repositoryRoot, ".github/workflows/bump-version.yml")), false);
 	assert.equal(existsSync(path.join(repositoryRoot, ".github/workflows/release.yml")), false);
 });


### PR DESCRIPTION
## Summary

- replace package-specific pack, try, and install aliases with parameterized recipes
- keep release versioning and publication in the Changesets workflow while documenting manual first publication
- update repository guidance, active plans, and tests for the generic commands

## Testing

- `npm run check` (2,421 tests passed)
- `just pack tui-kit`
- `git diff --check`

No changeset is required because this only changes repository tooling and documentation.