### PR TITLE
fix(pi-chrome-devtools): keep auto-launch alive under elevated Windows terminals

### DIFF
--- a/.changeset/chrome-devtools-do-not-de-elevate.md
+++ b/.changeset/chrome-devtools-do-not-de-elevate.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-chrome-devtools": patch
+---
+
+Pass `--do-not-de-elevate` when auto-launching the managed browser so Chrome no longer relaunches de-elevated and exits when Pi runs in an elevated Windows terminal, which the launch watchdog misread as "Auto-launched browser exited before DevTools became available."

--- a/packages/pi-chrome-devtools/src/browser-manager.ts
+++ b/packages/pi-chrome-devtools/src/browser-manager.ts
@@ -121,6 +121,10 @@ async function launchBrowserCandidate(candidate: BrowserCandidate, waitMs: numbe
 		const args = [
 			`--remote-debugging-port=${portArgument}`,
 			`--user-data-dir=${userDataDir}`,
+			// Chrome 120+ de-elevates when launched from an elevated process on Windows: the
+			// spawned process relaunches a de-elevated child and exits immediately, which the
+			// exit watchdog misreads as a failed launch. No-op in non-elevated contexts.
+			"--do-not-de-elevate",
 			"--no-first-run",
 			"--no-default-browser-check",
 			"about:blank",


### PR DESCRIPTION
## Problem

On Windows, when Pi runs in a terminal started **as Administrator**, every `chrome_devtools_*` call fails with:

```
Unable to auto-launch a Chromium-family browser for Chrome DevTools.
Last error: Auto-launched browser exited before DevTools became available.
```

and an orphaned Chrome window stuck at `about:blank` is left open, plus a leaked temp profile dir per attempt.

## Root cause

Since Chrome 120, chrome.exe launched from an elevated process *de-elevates*: the spawned process relaunches a de-elevated child and **exits immediately**. `browser-manager.ts` listens for `exit` on the spawned child and marks the managed browser as exited, so `readManagedBrowserPort` / `waitForDevToolsEndpoint` throw — even though the de-elevated child does start and would have served the DevTools endpoint (the leftover `about:blank` window is that child).

## Change

- Add Chrome's `--do-not-de-elevate` switch to the managed-browser launch args. This is the switch Chrome itself appends when relaunching, and it is a no-op in non-elevated contexts and on other platforms.
- Changeset: `@narumitw/pi-chrome-devtools` patch.

## Verification

Windows 11, Chrome 151, elevated pwsh:

- **Before:** spawned process exits ~immediately; auto-launch fails with the error above; orphaned `about:blank` window + leaked `pi-chrome-devtools-profile-*` temp dirs.
- **After (flag added):** spawned process stays alive, `DevToolsActivePort` is written, endpoint reachable; `list_pages` / `navigate` / `evaluate` / `screenshot` all work. Patched the installed extension locally the same way and used it as the daily driver.
- Non-elevated launch behavior unchanged.