### PR TITLE
feat(sync): make included content portable

### DIFF
--- a/.changeset/fresh-paths-sync.md
+++ b/.changeset/fresh-paths-sync.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Make included-content intent portable across snapshots, add reviewed remote-policy adoption, pause sync on explicit policy divergence, and allow safe custom paths that exist only remotely.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,12 @@ jobs:
 
       - name: Install dependencies with latest Pi packages
         run: |
-          node scripts/set-pi-version.mjs latest
-          npm install --no-save
-          expected_version="$(npm view @earendil-works/pi-coding-agent version)"
+          expected_version="$(npm view @earendil-works/pi-coding-agent@latest version --prefer-online)"
+          node scripts/set-pi-version.mjs "$expected_version"
+          npm install --no-save --prefer-online
           installed_version="$(node -p "require('./node_modules/@earendil-works/pi-coding-agent/package.json').version")"
           cli_version="$(node_modules/.bin/pi --version)"
+          printf 'Expected Pi: %s\nInstalled Pi: %s\nPi CLI: %s\n' "$expected_version" "$installed_version" "$cli_version"
           test "$installed_version" = "$expected_version"
           test "$cli_version" = "$expected_version"
 

--- a/docs/adr/pi-sync-portable-selection-policy.md
+++ b/docs/adr/pi-sync-portable-selection-policy.md
@@ -1,0 +1,104 @@
+# ADR: pi-sync portable included-content policy
+
+## Status
+
+Accepted. The policy is implemented by pi-sync snapshots, orchestration, and Settings review.
+
+## Context
+
+A sync setup's `sync.include` is local because `pi-sync.json` also owns private storage credentials
+and machine-specific behavior. That made a new environment unable to discover a selected custom path
+when the path existed only remotely. Inferring intent from snapshot files is insufficient: a selected
+path may currently be absent, and a snapshot may preserve files that its publisher did not select.
+
+Syncing `pi-sync.json`, hard-coding another extension's filenames, or automatically selecting every
+safe-looking remote file would respectively expose credentials, create cross-extension coupling, or
+turn an incomplete denylist into policy.
+
+## Decision
+
+### Portable policy
+
+Each new immutable `Snapshot` carries an additive credential-free field:
+
+```ts
+selection: {
+  version: 1;
+  include: string[];
+}
+```
+
+The include list uses the same normalization and safety rules as local `sync.include`. It contains no
+setup name, storage location, credentials, automatic-sync preference, or switch behavior. Selection
+intent is separate from `files`, so selected-but-missing paths remain portable.
+
+S3 and WebDAV include the field in their integrity-checked gzip snapshot. Their latest pointer also
+carries a validated projection so Status stays lightweight. Git includes it in the strict publication
+manifest, which binds it to the commit and supplies its head projection. Adoption always re-reads the
+immutable snapshot and rejects a projection mismatch. New readers accept old snapshots and Git
+manifests without `selection`. Invalid versions, extra fields, unsafe paths, duplicates, and overlaps
+fail before settings or synced files change.
+
+### Divergence behavior
+
+Orchestration compares an explicit remote policy with the current local setup before applying remote
+content. Ordinary sync, automatic startup/shutdown sync, and pull—including forced pull—pause on a
+difference. Status names the difference and lists local-only and remote-only selections.
+
+A force push is the explicit keep-local publication path. Its confirmation says that the local
+selection will replace the differing remote policy; preserved unmanaged remote files remain subject
+to the existing preservation rules.
+
+Read-only diff remains available and labels policy state. A legacy snapshot without policy preserves
+prior sync behavior because no authoritative remote intent exists.
+
+### Review and adoption
+
+Settings exposes **Remote included content**. For a differing explicit policy it offers:
+
+- **Adopt remote included content** — revalidate the reviewed remote head, then save only local
+  `sync.include` through the existing cross-process lock, expected-storage/include checks, unknown
+  field preservation, and atomic publication;
+- **Keep local included content** — make no change and explain that a reviewed force push publishes
+  that choice;
+- **Review paths** — show exact remote-only, local-only, and ordered selections; and
+- **Cancel** — make no change.
+
+Adopting `sessions` requires the existing privacy acknowledgement. Adoption never pulls files,
+writes sync state, or starts another network operation. The user reviews Sync now separately.
+Cancellation, component disposal, session replacement, shutdown, a changed remote head, and a
+concurrent settings edit all preserve the last valid local selection.
+
+For old snapshots, Settings offers a clearly labeled read-only partial discovery from safe file roots.
+It cannot be adopted as authoritative policy because preserved files and selected-but-missing paths
+cannot be distinguished. Users can copy needed paths through **Add custom path…**.
+
+## Consequences
+
+### Positive
+
+- New environments can discover and adopt custom remote-only paths such as a TOML configuration
+  without syncing private settings or knowing which extension owns the path.
+- Selection conflicts are explicit and cannot silently expand automatic synchronization.
+- The snapshot remains self-describing even when selected paths are temporarily absent.
+- Backend transport stays extension-neutral; selection policy remains orchestration-owned.
+
+### Negative
+
+- Remote-policy review reads the active immutable snapshot; Status relies on the validated head
+  projection and cannot partially discover legacy paths.
+- Keep-local remains unresolved until the user publishes with a reviewed force push.
+- Legacy discovery is necessarily incomplete and cannot reconstruct exact intent.
+- Git publications containing `selection` require a reader that understands the additive manifest
+  field; newer pi-sync remains backward-compatible with older Git publications, but an older strict
+  Git reader may reject newer manifests.
+
+## Verification
+
+- Policy and legacy discovery: `packages/pi-sync/test/portable-selection.test.ts`.
+- Snapshot intent and codec validation: `sync-snapshot.test.ts` and `snapshot-codec.test.ts`.
+- Backend round trips: shared backend contract tests and Git backend tests.
+- Divergence, automatic no-mutation, pull pause, and reviewed keep-local push:
+  `sync-decision.test.ts`.
+- Adoption, session acknowledgement, legacy review, stale remote/local rejection, and disposal:
+  `remote-selection-ui.test.ts`.

--- a/docs/adr/pi-sync-portable-selection-policy.md
+++ b/docs/adr/pi-sync-portable-selection-policy.md
@@ -36,8 +36,8 @@ S3 and WebDAV include the field in their integrity-checked gzip snapshot. Their 
 carries a validated projection so Status stays lightweight. Git includes it in the strict publication
 manifest, which binds it to the commit and supplies its head projection. Adoption always re-reads the
 immutable snapshot and rejects a projection mismatch. New readers accept old snapshots and Git
-manifests without `selection`. Invalid versions, extra fields, unsafe paths, duplicates, and overlaps
-fail before settings or synced files change.
+manifests without `selection`. Invalid versions, extra fields, unsafe paths, oversized collections,
+duplicates, and overlaps fail before settings or synced files change.
 
 ### Divergence behavior
 

--- a/docs/plans/archived/2026-08-07_pi-sync-portable-selection-policy-plan.md
+++ b/docs/plans/archived/2026-08-07_pi-sync-portable-selection-policy-plan.md
@@ -1,0 +1,62 @@
+# pi-sync portable selection policy plan
+
+## Goal
+
+Make included-content intent portable across environments without syncing private credentials, and
+require an explicit reviewed choice before a differing remote selection can affect local settings or
+content synchronization.
+
+## Architecture
+
+- Store an optional versioned `selection` policy in each immutable snapshot, separate from the files
+  that happened to exist when the snapshot was created. New snapshots always publish the normalized
+  local `sync.include`; old snapshots without policy remain readable.
+- Keep `pi-sync.json` local and private. The remote policy contains only safe agent-relative include
+  paths and no storage connection, credentials, automatic-sync, or setup names.
+- Compare local and remote policy in orchestration. Automatic and ordinary synchronization pause on
+  explicit divergence; a force push is the reviewed “keep local” publication path, while pulls require
+  local adoption first.
+- Add a remote-selection review under Settings with Adopt remote, Keep local, Review paths, and Cancel.
+  Adoption updates only local settings through the existing locked, stale-checked, atomic mutation
+  protocol and never starts a pull.
+- For old snapshots, derive a clearly labeled partial discovery list from remote file roots without
+  treating it as authoritative policy.
+
+## Non-Goals
+
+- Do not sync `pi-sync.json`, credentials, automatic-sync settings, setup names, or backend details.
+- Do not hard-code `pi-starship.toml` or coordinate with another extension package.
+- Do not add silent remote-policy adoption or automatically pull files after adopting a policy.
+
+## Plan
+
+- [x] Add snapshot selection schema, normalization, and backward-compatible S3/WebDAV/Git wire handling; focused codec, Git, and all four backend contract suites pass with policy round trips and malformed-policy rejection.
+- [x] Add backend-neutral policy comparison and old-snapshot path discovery; `portable-selection.test.ts` proves exact divergence, selected-but-missing intent, head/snapshot revalidation, and safe partial discovery.
+- [x] Make status report policy state and make sync/pull pause before mutation on explicit divergence while force push remains the reviewed keep-local path; `sync-decision.test.ts` proves manual/automatic no-mutation and exact force-push review.
+- [x] Add the Settings remote-policy review/adoption flow with Adopt remote, Keep local, Review paths, and Cancel; `remote-selection-ui.test.ts` and `settings-management.test.ts` prove session acknowledgement, stale remote/local rejection, disposal/replacement, discoverability, and save-without-pull behavior.
+- [x] Record the accepted architecture in `docs/adr/pi-sync-portable-selection-policy.md`, update the package README and patch Changeset, then verify 2,380 tests through `npm run check`, Changesets status, and the 49-file `just pack sync` dry run.
+
+## Risks
+
+- Git snapshots use a strict manifest rather than the gzip codec, so selection metadata must be
+  integrity-bound in that manifest without rejecting old manifests.
+- Remote policy is untrusted input. Invalid versions, paths, duplicates, and overlaps must fail closed
+  before settings or synced files change.
+- A remote head can change during review. Adoption must re-read and verify the reviewed head and must
+  also reject concurrent local settings changes.
+
+## Rollback / Recovery
+
+The snapshot field is additive and optional. Older pi-sync versions ignore it on S3/WebDAV, while
+new pi-sync readers continue to accept Git manifests without the field. An older strict Git reader may
+reject a newer manifest containing selection; recover by using the current reader or restoring a
+pre-feature Git publication. Local adoption is an ordinary atomic settings edit and can be reversed
+in the Included Content editor.
+
+## Completion Checklist
+
+- [x] New snapshots preserve selected paths even when those paths have no current file; covered by snapshot and backend contract tests.
+- [x] A new environment can review and adopt valid remote included content without copying private settings or mutating synced files; covered by remote-selection UI tests.
+- [x] Divergent or malformed remote policy cannot be silently applied by startup, shutdown, sync, or pull flows; cancellation and lifecycle replacement have no side effects in focused and full-suite coverage.
+- [x] Old snapshots remain readable and offer only clearly labeled partial discovery; covered by codec/backend compatibility and legacy discovery tests.
+- [x] The final diff passes the extension/settings semantic audit, `npm run check`, Changesets status, package dry run, and `git diff --check`; archive this completed plan under `docs/plans/archived/`.

--- a/docs/plans/archived/2026-08-07_pi-sync-remote-only-custom-path-plan.md
+++ b/docs/plans/archived/2026-08-07_pi-sync-remote-only-custom-path-plan.md
@@ -1,0 +1,20 @@
+# pi-sync remote-only custom path plan
+
+## Goal
+
+Allow the Included Content editor to add a safe agent-relative file or directory that does not yet
+exist locally, so a new environment can pull custom content already present in remote snapshots.
+
+## Plan
+
+- [x] Add a focused `packages/pi-sync/test/sync.test.ts` regression proving a remote-only custom path can be added, reviewed, and saved without creating the local file; the focused test initially failed with `1 !== 3` because no add-path action existed.
+- [x] Update `packages/pi-sync/src/file-selection.ts` with a generic Add custom path action that validates the entered path, keeps edits draft-only, and revalidates cancellation/session ownership after input; focused result: 18/18 tests passed.
+- [x] Document remote-only custom paths in `packages/pi-sync/README.md` and add `.changeset/fresh-paths-sync.md` as a patch Changeset for `@narumitw/pi-sync`.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`; `npm run check` passed all 2,366 tests, Changesets reports the pi-sync patch, and `just pack sync` contains the updated source and README.
+
+## Completion Checklist
+
+- [x] A missing local custom path can be entered from TUI, appears selected in the draft, and is persisted only after reviewed Save; covered by the focused absent-path test.
+- [x] Invalid, duplicate, overlapping, cancelled, disposed, replaced-session, and failed-save paths preserve the existing settings behavior; covered by new unsafe/replacement tests, existing policy validation, draft-disposal, concurrent-save, and full-suite coverage.
+- [x] No extension-specific filename or cross-extension dependency is introduced; the action accepts generic validated agent-relative paths.
+- [x] All plan tasks have evidence and the completed plan is archived as `docs/plans/archived/2026-08-07_pi-sync-remote-only-custom-path-plan.md`.

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -13,7 +13,7 @@
 - One ordered `sync.include` list for Pi roots, safe agent-relative paths, and the privacy-sensitive `sessions` root.
 - Portable, credential-free snapshot selection with explicit cross-environment review and adoption.
 - Atomic private settings writes that preserve unknown fields and reject stale concurrent edits.
-- Fail-closed validation for missing references, mixed backend fields, duplicate remote locations, unsafe paths, malformed credentials, and credential-bearing Git URLs.
+- Fail-closed validation for missing references, mixed backend fields, duplicate remote locations, unsafe or oversized selection policies, malformed credentials, and credential-bearing Git URLs.
 
 ## 📦 Install
 

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -11,6 +11,7 @@
 - Immutable snapshots, secret scanning, local locks, conflict checks, pull backups, transactional apply, and recovery journals.
 - Exact reviewed storage paths that do not change when a local sync setup is renamed.
 - One ordered `sync.include` list for Pi roots, safe agent-relative paths, and the privacy-sensitive `sessions` root.
+- Portable, credential-free snapshot selection with explicit cross-environment review and adoption.
 - Atomic private settings writes that preserve unknown fields and reject stale concurrent edits.
 - Fail-closed validation for missing references, mixed backend fields, duplicate remote locations, unsafe paths, malformed credentials, and credential-bearing Git URLs.
 
@@ -63,7 +64,9 @@ and confirmations.
 When **Sync now**, **Pull from remote…**, or **Push to remote…** finds changes that require a human
 direction choice, the manager opens **Resolve sync conflict** instead of ending at a command-only
 error. The flow names the current sync setup and explains whether local content, remote content, or
-the included-content policy changed.
+the included-content policy changed. If the active remote snapshot explicitly selects different
+content, automatic sync and pulls pause until you adopt the remote policy in Settings or publish the
+local policy with a reviewed force push.
 
 Choose **Review differences (recommended)** to inspect the exact affected paths without changing
 local files, remote data, or sync state. Then choose one reviewed direction:
@@ -193,10 +196,27 @@ Safe agent-relative custom files or directories may also be included. Absolute p
 An empty array is valid. It means no useful transfer is selected: **Sync now** reports the condition and does not claim that the setup is up to date. Unselected content remains unmanaged locally and is preserved when republishing existing remote snapshots.
 
 The Included Content editor is a standard bounded multi-select backed by one in-memory draft. Toggles
-never write settings. Leaving the editor opens an exact Include/Exclude review with **Save changes**,
+never write settings. **Add custom path…** accepts a safe agent-relative file or directory even when
+it does not exist locally yet, allowing a new environment to select content that exists only in the
+remote snapshot. Leaving the editor opens an exact Include/Exclude review with **Save changes**,
 **Discard changes**, and **Continue editing**; only reviewed Save publishes, while Continue preserves
 the draft and Discard/cancellation preserves the settings bytes. RPC remains a read-only summary with
 the manual `sync.include` path.
+
+Every new snapshot stores the normalized included-content selection separately from the files that
+happened to exist. This preserves selected-but-missing paths without syncing `pi-sync.json`, storage
+credentials, automatic-sync preferences, or setup names. **Settings → Remote included content** reads
+the active snapshot and offers **Adopt remote included content**, **Keep local included content**,
+**Review paths**, and **Cancel** when local and remote selections differ. Adoption revalidates the
+remote head, saves local settings atomically, and does not pull files or write sync state; review
+**Sync now** separately. A reviewed force push keeps local selection and explicitly replaces the
+remote policy while preserving eligible unmanaged remote files.
+
+Automatic sync and pull, including forced pull, pause on an explicit remote-policy difference rather
+than silently expanding local scope. Status reports matches and exact local-only/remote-only paths.
+Old snapshots remain readable. Because they have no authoritative selection, pi-sync offers only a
+clearly labeled read-only partial discovery from safe remote file roots; selected-but-missing and
+preserved-unmanaged intent cannot be reconstructed. Use **Add custom path…** for any needed path.
 
 Adding `sessions` requires a privacy acknowledgement in interactive flows. Session JSONL can contain prompts, tool output, file paths, images, and secrets. Automatic apply protects the currently open session file; restart Pi or resume a pulled session to use newly synchronized conversations.
 
@@ -290,6 +310,8 @@ packages/pi-sync/
 │   ├── storage-connections-ui.ts
 │   ├── sync-setups-ui.ts
 │   ├── file-selection.ts
+│   ├── remote-selection-ui.ts
+│   ├── remote-snapshot.ts
 │   ├── sync-operations.ts
 │   ├── sync-backend.ts
 │   ├── backend-factory.ts      # lazy selected-backend loader

--- a/packages/pi-sync/src/file-selection.ts
+++ b/packages/pi-sync/src/file-selection.ts
@@ -6,12 +6,14 @@ import { updateSyncSetup } from "./settings-management.js";
 import {
 	BUILT_IN_SYNC_ROOTS,
 	isSafeCustomIncludePath,
+	normalizeSyncInclude,
 	syncIncludeSelection,
 } from "./sync-policy.js";
 
 const BUILT_IN_PREFIX = "builtin:";
 const CUSTOM_PREFIX = "custom:";
 const SESSIONS_ID = "sessions";
+const ADD_CUSTOM_ID = "add-custom";
 
 interface SelectionDraft {
 	builtIns: Set<string>;
@@ -107,7 +109,7 @@ async function showDraftEditor(
 	customCandidates: string[],
 	signal?: AbortSignal,
 ) {
-	const menu = defineMenu<undefined, "editor", "toggle", ExtensionCommandContext>({
+	const menu = defineMenu<undefined, "editor", "toggle" | "addCustom", ExtensionCommandContext>({
 		start: "editor",
 		screens: {
 			editor: () => ({
@@ -139,6 +141,15 @@ async function showDraftEditor(
 					},
 				],
 				action: "toggle",
+				actions: [
+					{
+						id: ADD_CUSTOM_ID,
+						label: "Add custom path…",
+						description:
+							"Include an agent-relative file or directory even when it exists only remotely.",
+						action: "addCustom",
+					},
+				],
 				hint: "close",
 				doneLabel: "Review changes",
 			}),
@@ -146,6 +157,45 @@ async function showDraftEditor(
 		actions: {
 			toggle: async ({ itemId, selected }) => {
 				updateDraft(draft, itemId, selected === true);
+				return { kind: "stay" };
+			},
+			addCustom: async ({ ctx: actionCtx, signal: actionSignal }) => {
+				const entered = await actionCtx.ui.input(
+					"Add included content",
+					"Agent-relative path, for example custom.toml or snippets",
+					{ signal: actionSignal },
+				);
+				if (actionSignal.aborted) return { kind: "stay" };
+				const requested = entered?.trim();
+				if (!requested) return { kind: "stay" };
+				const existing = customCandidates.find(
+					(candidate) => candidate.toLowerCase() === requested.toLowerCase(),
+				);
+				const relativePath = existing ?? requested;
+				if (draft.custom.has(relativePath)) return { kind: "stay" };
+				try {
+					if (!isSafeCustomIncludePath(relativePath)) {
+						throw new Error("Enter a safe agent-relative file or directory path.");
+					}
+					normalizeSyncInclude([
+						...draft.builtIns,
+						...draft.custom,
+						...(draft.sessions ? ["sessions"] : []),
+						relativePath,
+					]);
+				} catch (error) {
+					if (actionSignal.aborted) return { kind: "stay" };
+					actionCtx.ui.notify(
+						`Could not add included content: ${safeTerminalText(error instanceof Error ? error.message : String(error))}`,
+						"error",
+					);
+					return { kind: "stay" };
+				}
+				if (!existing) {
+					customCandidates.push(relativePath);
+					customCandidates.sort((left, right) => left.localeCompare(right));
+				}
+				draft.custom.add(relativePath);
 				return { kind: "stay" };
 			},
 		},

--- a/packages/pi-sync/src/git-backend.ts
+++ b/packages/pi-sync/src/git-backend.ts
@@ -140,6 +140,7 @@ export class GitSyncBackend implements SyncBackend {
 			...(manifest.snapshotSyncSessions === undefined
 				? {}
 				: { syncSessions: manifest.snapshotSyncSessions }),
+			...(manifest.selection === undefined ? {} : { selection: manifest.selection }),
 			files,
 		};
 		validateGitSnapshot(snapshot, manifest, this.config.destination.namespace);
@@ -174,6 +175,7 @@ export class GitSyncBackend implements SyncBackend {
 			...(snapshot.syncSessions === undefined
 				? {}
 				: { snapshotSyncSessions: snapshot.syncSessions }),
+			...(snapshot.selection === undefined ? {} : { selection: snapshot.selection }),
 			files: files.map(({ path: filePath, sha256: fileSha, size }) => ({
 				path: filePath,
 				sha256: fileSha,
@@ -688,6 +690,7 @@ function remoteHead(sha: string, manifest: GitManifest, identity: string): Remot
 		createdAt: manifest.createdAt,
 		machine: manifest.machine,
 		syncSessions: manifest.syncSessions,
+		...(manifest.selection === undefined ? {} : { selection: manifest.selection }),
 	};
 }
 

--- a/packages/pi-sync/src/git-storage.ts
+++ b/packages/pi-sync/src/git-storage.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import type { Snapshot } from "./types.js";
+import { portableSnapshotSelection, snapshotSelectionInclude } from "./sync-policy.js";
+import type { Snapshot, SnapshotSelection } from "./types.js";
 
 export const GIT_MANIFEST_VERSION = 2;
 export const MAX_GIT_MANIFEST_BYTES = 1024 * 1024;
@@ -23,6 +24,7 @@ export interface GitManifest {
 	profile: string;
 	syncSessions: boolean;
 	snapshotSyncSessions?: boolean;
+	selection?: SnapshotSelection;
 	files: GitManifestFile[];
 }
 
@@ -81,11 +83,13 @@ export function requireGitManifest(value: unknown): GitManifest {
 			"profile",
 			"syncSessions",
 			...(manifest.snapshotSyncSessions === undefined ? [] : ["snapshotSyncSessions"]),
+			...(manifest.selection === undefined ? [] : ["selection"]),
 			"files",
 		])
 	) {
 		throw new Error("Git publication manifest is malformed.");
 	}
+	if (manifest.selection !== undefined) portableSnapshotSelection(manifest.selection);
 	let total = 0;
 	const paths = new Set<string>();
 	for (const rawFile of manifest.files) {
@@ -126,6 +130,12 @@ export function validateGitSnapshot(snapshot: Snapshot, manifest: GitManifest, n
 		snapshot.profile !== manifest.profile ||
 		snapshot.syncSessions !== manifest.snapshotSyncSessions ||
 		syncSessions !== manifest.syncSessions ||
+		!sameOptionalInclude(
+			snapshotSelectionInclude(snapshot),
+			manifest.selection === undefined
+				? undefined
+				: portableSnapshotSelection(manifest.selection).include,
+		) ||
 		prepared.length !== manifest.files.length ||
 		prepared.some((file, index) => {
 			const expected = manifest.files[index];
@@ -142,6 +152,7 @@ export function validateGitSnapshot(snapshot: Snapshot, manifest: GitManifest, n
 }
 
 export function prepareGitSnapshot(snapshot: Snapshot, namespace: string) {
+	snapshotSelectionInclude(snapshot);
 	if (
 		snapshot.version !== SNAPSHOT_VERSION ||
 		typeof snapshot.id !== "string" ||
@@ -240,6 +251,11 @@ export function validateGitPublicationTree(
 		}
 	}
 	return manifest.files.map((file) => byPath.get(filePath(file.path)) as GitTreeEntry);
+}
+
+function sameOptionalInclude(left: string[] | undefined, right: string[] | undefined) {
+	if (!left || !right) return left === right;
+	return left.length === right.length && left.every((item, index) => item === right[index]);
 }
 
 function isSafeSnapshotPath(value: unknown): value is string {

--- a/packages/pi-sync/src/remote-selection-ui.ts
+++ b/packages/pi-sync/src/remote-selection-ui.ts
@@ -1,0 +1,279 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { createSyncBackend, type SyncBackendFactory } from "./backend-factory.js";
+import { loadConfig, loadPartialConfig } from "./config.js";
+import { readSnapshotForHead } from "./remote-snapshot.js";
+import { updateSyncSetup } from "./settings-management.js";
+import type { RemoteHead, SyncBackend } from "./sync-backend.js";
+import { errorMessage, safeTerminalText } from "./sync-format.js";
+import {
+	inspectRemoteSelection,
+	type RemoteSelectionState,
+	sameSyncInclude,
+} from "./sync-policy.js";
+import type { AnySyncConfig } from "./types.js";
+
+const STATUS_KEY = "sync";
+
+export async function showRemoteSelectionReview(
+	ctx: ExtensionCommandContext,
+	setupName?: string,
+	signal?: AbortSignal,
+	factory: SyncBackendFactory = createSyncBackend,
+) {
+	try {
+		const config = await loadConfig(setupName);
+		if (signal?.aborted) return;
+		const storageReview = await loadPartialConfig(config.setupName);
+		if (signal?.aborted) return;
+		ctx.ui.setStatus(STATUS_KEY, `checking remote selection for ${config.setupName}`);
+		const backend = await factory(config);
+		if (signal?.aborted) return;
+		const head = await backend.readHead(signal);
+		if (signal?.aborted) return;
+		if (!head) {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			ctx.ui.notify("Remote storage has no snapshot or included-content policy yet.", "info");
+			return;
+		}
+		const snapshot = await readSnapshotForHead(backend, head, signal);
+		if (signal?.aborted) return;
+		const state = inspectRemoteSelection(config.include, snapshot);
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+
+		if (ctx.mode !== "tui") {
+			ctx.ui.notify(
+				formatRemoteSelectionSummary(config, state),
+				state.kind === "different" ? "warning" : "info",
+			);
+			return;
+		}
+		if (state.kind === "same") {
+			ctx.ui.notify("Remote included content already matches this sync setup.", "info");
+			return;
+		}
+		if (state.kind === "legacy") {
+			await showLegacyDiscovery(ctx, config, state.discovered, signal);
+			return;
+		}
+		await showSelectionDifference(ctx, config, storageReview, backend, head, state, signal);
+	} catch (error) {
+		if (signal?.aborted) return;
+		ctx.ui.notify(`Could not review remote included content: ${errorMessage(error)}`, "error");
+	} finally {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	}
+}
+
+async function showSelectionDifference(
+	ctx: ExtensionCommandContext,
+	config: AnySyncConfig,
+	storageReview: Awaited<ReturnType<typeof loadPartialConfig>>,
+	backend: SyncBackend,
+	reviewedHead: RemoteHead,
+	state: Extract<RemoteSelectionState, { kind: "different" }>,
+	sessionSignal?: AbortSignal,
+) {
+	type Screen = "choice" | "review";
+	type Action = "adopt" | "keep" | "cancel";
+	const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "actions",
+				title: `Remote included content · ${safeTerminalText(config.setupName)}`,
+				lines: [
+					"The remote selection differs from this local sync setup.",
+					"No settings or files have been changed.",
+				],
+				items: [
+					{
+						id: "adopt",
+						label: "Adopt remote included content",
+						description: "Save the reviewed remote paths locally without pulling files.",
+						action: "adopt",
+					},
+					{
+						id: "keep",
+						label: "Keep local included content",
+						description: "Make no settings change; a reviewed force push can publish it later.",
+						action: "keep",
+					},
+					{
+						id: "review",
+						label: "Review paths",
+						description: "Compare exact local-only and remote-only selection paths.",
+						to: "review",
+					},
+					{ id: "cancel", label: "Cancel", action: "cancel" },
+				],
+				hint: "close",
+			}),
+			review: () => ({
+				kind: "review",
+				title: `Review remote included content · ${safeTerminalText(config.setupName)}`,
+				content: formatSelectionDifference(config.include, state),
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				hint: "back",
+			}),
+		},
+		actions: {
+			adopt: async ({ signal: actionSignal }) => {
+				const signal = sessionSignal
+					? AbortSignal.any([sessionSignal, actionSignal])
+					: actionSignal;
+				try {
+					if (!config.include.includes("sessions") && state.include.includes("sessions")) {
+						const acknowledged = await ctx.ui.confirm(
+							"Adopt session conversations?",
+							"Session JSONL may contain prompts, tool output, file paths, images, and secrets. This saves the selection only; it does not pull files.",
+							{ signal },
+						);
+						if (signal.aborted) return { kind: "close" as const };
+						if (!acknowledged) return { kind: "stay" as const };
+					}
+					if (signal.aborted) return { kind: "close" as const };
+					const currentHead = await backend.readHead(signal);
+					if (signal.aborted) return { kind: "close" as const };
+					if (!currentHead || !backend.sameRevision(reviewedHead.revision, currentHead.revision)) {
+						throw new Error(
+							"Remote changed while the included-content review was open; reopen it.",
+						);
+					}
+					const currentSnapshot = await readSnapshotForHead(backend, currentHead, signal);
+					if (signal.aborted) return { kind: "close" as const };
+					const currentState = inspectRemoteSelection(config.include, currentSnapshot);
+					if (
+						currentState.kind === "legacy" ||
+						!sameSyncInclude(currentState.include, state.include)
+					) {
+						throw new Error(
+							"Remote included content changed while the review was open; reopen it.",
+						);
+					}
+					await updateSyncSetup(
+						config.setupName,
+						(setup) => ({
+							...setup,
+							sync: { ...setup.sync, include: [...state.include] },
+						}),
+						{
+							expectedStorage: storageReview,
+							expectedInclude: config.include,
+							signal,
+						},
+					);
+					if (signal.aborted) return { kind: "close" as const };
+					ctx.ui.notify(
+						`Saved remote included content for sync setup “${safeTerminalText(config.setupName)}”. No files were pulled; review Sync now separately.`,
+						"info",
+					);
+					return { kind: "close" as const };
+				} catch (error) {
+					if (signal.aborted) return { kind: "close" as const };
+					ctx.ui.notify(`Could not adopt remote included content: ${errorMessage(error)}`, "error");
+					return { kind: "close" as const };
+				}
+			},
+			keep: async () => {
+				ctx.ui.notify(
+					"Kept local included content. No settings or files changed; use a reviewed force push to publish the local selection.",
+					"info",
+				);
+				return { kind: "close" };
+			},
+			cancel: async () => ({ kind: "close" }),
+		},
+	});
+	await runMenu(ctx, menu, {
+		getState: () => undefined,
+		signal: sessionSignal,
+		isCurrent: () => !sessionSignal?.aborted,
+	});
+}
+
+async function showLegacyDiscovery(
+	ctx: ExtensionCommandContext,
+	config: AnySyncConfig,
+	discovered: string[],
+	signal?: AbortSignal,
+) {
+	const menu = defineMenu<undefined, "choice" | "review", "back", ExtensionCommandContext>({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "actions",
+				title: `Remote included content · ${safeTerminalText(config.setupName)}`,
+				lines: [
+					"This legacy snapshot has no portable included-content policy.",
+					"Discovered paths are partial and read-only; preserved files may not have been selected.",
+				],
+				items: [
+					{ id: "review", label: "Review discovered paths", to: "review" },
+					{ id: "back", label: "Back", action: "back" },
+				],
+				hint: "close",
+			}),
+			review: () => ({
+				kind: "review",
+				title: "Partial discovery from legacy snapshot",
+				content: [
+					"Partial discovery only — not an authoritative selection.",
+					"",
+					...(discovered.length > 0
+						? discovered.map((item) => `Discovered: ${safeTerminalText(item)}`)
+						: ["No safe paths were discovered."]),
+					"",
+					"Use Add custom path… in the local Included Content editor if needed.",
+				].join("\n"),
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				hint: "back",
+			}),
+		},
+		actions: { back: async () => ({ kind: "close" }) },
+	});
+	await runMenu(ctx, menu, {
+		getState: () => undefined,
+		signal,
+		isCurrent: () => !signal?.aborted,
+	});
+}
+
+function formatSelectionDifference(
+	localInclude: readonly string[],
+	state: Extract<RemoteSelectionState, { kind: "different" }>,
+) {
+	return [
+		"Remote-only selection:",
+		...(state.remoteOnly.length > 0
+			? state.remoteOnly.map((item) => `+ ${safeTerminalText(item)}`)
+			: ["(none)"]),
+		"",
+		"Local-only selection:",
+		...(state.localOnly.length > 0
+			? state.localOnly.map((item) => `- ${safeTerminalText(item)}`)
+			: ["(none)"]),
+		"",
+		`Remote order: ${state.include.map(safeTerminalText).join(", ") || "none"}`,
+		`Local order: ${localInclude.map(safeTerminalText).join(", ") || "none"}`,
+		"",
+		"Adopting saves settings only and does not pull files.",
+	].join("\n");
+}
+
+function formatRemoteSelectionSummary(config: AnySyncConfig, state: RemoteSelectionState) {
+	if (state.kind === "same") {
+		return `Remote included content for “${safeTerminalText(config.setupName)}” matches local settings.`;
+	}
+	if (state.kind === "legacy") {
+		return `Remote snapshot for “${safeTerminalText(config.setupName)}” has no portable included-content policy; ${state.discovered.length} safe path${state.discovered.length === 1 ? " was" : "s were"} discovered, but the result is partial and read-only.`;
+	}
+	return [
+		`Remote included content for “${safeTerminalText(config.setupName)}” differs from local settings.`,
+		`Remote-only: ${state.remoteOnly.map(safeTerminalText).join(", ") || "none"}`,
+		`Local-only: ${state.localOnly.map(safeTerminalText).join(", ") || "none"}`,
+		"Use TUI Settings to review or adopt it; RPC is read-only.",
+	].join("\n");
+}

--- a/packages/pi-sync/src/remote-snapshot.ts
+++ b/packages/pi-sync/src/remote-snapshot.ts
@@ -1,0 +1,59 @@
+import type { RemoteHead, SyncBackend } from "./sync-backend.js";
+import { safeTerminalText } from "./sync-format.js";
+import {
+	inspectRemoteSelection,
+	RemoteSelectionMismatchError,
+	type RemoteSelectionState,
+	sameSyncInclude,
+	snapshotSelectionInclude,
+} from "./sync-policy.js";
+import type { AnySyncConfig, Snapshot } from "./types.js";
+
+export async function readSnapshotForHead(
+	backend: SyncBackend,
+	head: RemoteHead,
+	signal?: AbortSignal,
+) {
+	const snapshot = await backend.readSnapshot(head.snapshotRef, signal);
+	if (signal?.aborted) {
+		throw signal.reason instanceof Error
+			? signal.reason
+			: new DOMException("The operation was aborted", "AbortError");
+	}
+	if (snapshot.id !== head.snapshotId) {
+		throw new Error(
+			`Remote head ${head.snapshotId} resolved to unexpected snapshot ${snapshot.id}.`,
+		);
+	}
+	if (head.selection) {
+		const snapshotInclude = snapshotSelectionInclude(snapshot);
+		if (!snapshotInclude || !sameSyncInclude(head.selection.include, snapshotInclude)) {
+			throw new Error("Remote head selection does not match its immutable snapshot.");
+		}
+	}
+	return snapshot;
+}
+
+export function requireCompatibleRemoteSelection(config: AnySyncConfig, snapshot: Snapshot) {
+	const state = inspectRemoteSelection(config.include, snapshot);
+	if (state.kind === "different") {
+		throw new RemoteSelectionMismatchError(config.include, state.include);
+	}
+}
+
+export function formatRemoteSelectionStatus(state: RemoteSelectionState | undefined) {
+	if (!state) return "remote included content: unavailable (remote is empty)";
+	if (state.kind === "same") return "remote included content: matches this setup";
+	if (state.kind === "legacy") {
+		return `remote included content: unavailable in legacy snapshot (${state.discovered.length} path${state.discovered.length === 1 ? "" : "s"} discovered, partial)`;
+	}
+	return [
+		"remote included content: differs from this setup",
+		`remote-only selection: ${safeList(state.remoteOnly)}`,
+		`local-only selection: ${safeList(state.localOnly)}`,
+	].join("\n");
+}
+
+function safeList(values: readonly string[]) {
+	return values.length > 0 ? values.map(safeTerminalText).join(", ") : "none";
+}

--- a/packages/pi-sync/src/s3-backend.ts
+++ b/packages/pi-sync/src/s3-backend.ts
@@ -14,6 +14,7 @@ import {
 	SyncBackendConflictError,
 	SyncBackendPublicationOutcomeUnknownError,
 } from "./sync-backend.js";
+import { portableSnapshotSelection } from "./sync-policy.js";
 import type { LatestPointer, RemoteObject, ResolvedS3Backend, Snapshot } from "./types.js";
 
 const VERSION = 1;
@@ -274,6 +275,7 @@ export function pointerFor(
 		syncSessions:
 			snapshot.syncSessions === true ||
 			snapshot.files.some((file) => file.path.startsWith("sessions/")),
+		...(snapshot.selection === undefined ? {} : { selection: snapshot.selection }),
 	};
 }
 
@@ -330,6 +332,7 @@ function remoteHead(pointer: LatestPointer, identity: string, etag?: string): Re
 		createdAt: pointer.createdAt,
 		machine: pointer.machine,
 		syncSessions: pointer.syncSessions === true,
+		...(pointer.selection === undefined ? {} : { selection: pointer.selection }),
 	};
 }
 
@@ -377,6 +380,7 @@ function requirePointer(
 	) {
 		throw new Error(message);
 	}
+	if (value.selection !== undefined) portableSnapshotSelection(value.selection);
 	return value;
 }
 

--- a/packages/pi-sync/src/settings-ui.ts
+++ b/packages/pi-sync/src/settings-ui.ts
@@ -25,7 +25,7 @@ export async function showSyncSettings(
 	const initial = await loadConfig();
 	if (signal?.aborted) return;
 	const setupName = initial.setupName;
-	type Action = "automatic" | "on-switch" | "include";
+	type Action = "automatic" | "on-switch" | "include" | "remote-include";
 	const menu = defineMenu<
 		Awaited<ReturnType<typeof loadConfig>>,
 		"settings",
@@ -64,6 +64,14 @@ export async function showSyncSettings(
 						description: `${state.include.length} selected path${state.include.length === 1 ? "" : "s"}. Opens the reviewed content-selection draft.`,
 						currentValue: "Open editor",
 						action: "include",
+					},
+					{
+						id: "remoteInclude",
+						label: "Remote included content",
+						description:
+							"Compare portable remote selection, then adopt it or keep local settings without pulling files.",
+						currentValue: "Review",
+						action: "remote-include",
 					},
 				],
 			}),
@@ -113,6 +121,13 @@ export async function showSyncSettings(
 				const editorSignal = signal ? AbortSignal.any([signal, actionSignal]) : actionSignal;
 				await runRoute("files", editorSignal, undefined, setupName);
 				return editorSignal.aborted ? { kind: "rejected" } : { kind: "stay" };
+			},
+			"remote-include": async ({ signal: actionSignal }) => {
+				const reviewSignal = signal ? AbortSignal.any([signal, actionSignal]) : actionSignal;
+				const { showRemoteSelectionReview } = await import("./remote-selection-ui.js");
+				if (reviewSignal.aborted) return { kind: "rejected" };
+				await showRemoteSelectionReview(ctx, setupName, reviewSignal);
+				return reviewSignal.aborted ? { kind: "rejected" } : { kind: "stay" };
 			},
 		},
 	});

--- a/packages/pi-sync/src/snapshot-codec.ts
+++ b/packages/pi-sync/src/snapshot-codec.ts
@@ -2,6 +2,7 @@ import { Readable, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
 import { createGunzip, gzip } from "node:zlib";
+import { snapshotSelectionInclude } from "./sync-policy.js";
 import type { Snapshot } from "./types.js";
 
 const VERSION = 1;
@@ -9,6 +10,7 @@ const MAX_DECOMPRESSED_SNAPSHOT_BYTES = 512 * 1024 * 1024;
 const gzipAsync = promisify(gzip);
 
 export async function encodeSnapshot(snapshot: Snapshot) {
+	snapshotSelectionInclude(snapshot);
 	return gzipAsync(Buffer.from(JSON.stringify(snapshot), "utf8"));
 }
 
@@ -37,6 +39,7 @@ export async function decodeSnapshot(
 	if (parsed.version !== VERSION || !Array.isArray(parsed.files)) {
 		throw new Error("Unsupported snapshot format.");
 	}
+	snapshotSelectionInclude(parsed);
 	return parsed;
 }
 

--- a/packages/pi-sync/src/snapshot.ts
+++ b/packages/pi-sync/src/snapshot.ts
@@ -18,6 +18,8 @@ import {
 	normalizeExtraFiles,
 	normalizeSyncFiles,
 	type SyncSelectionConfig,
+	selectionForSnapshot,
+	snapshotSelectionInclude,
 	syncIncludeSelection,
 } from "./sync-policy.js";
 import type { Snapshot, SnapshotFile, SnapshotOptions } from "./types.js";
@@ -74,6 +76,8 @@ function snapshotsMatch(left: Snapshot, right: Snapshot) {
 	const leftHashes = new Map(left.files.map((file) => [file.path, file.sha256]));
 	const rightHashes = new Map(right.files.map((file) => [file.path, file.sha256]));
 	return (
+		left.syncSessions === right.syncSessions &&
+		sameOptionalInclude(snapshotSelectionInclude(left), snapshotSelectionInclude(right)) &&
 		leftHashes.size === rightHashes.size &&
 		[...leftHashes].every(([filePath, hash]) => rightHashes.get(filePath) === hash)
 	);
@@ -109,6 +113,7 @@ export async function createSnapshot(
 		machine: os.hostname(),
 		profile,
 		syncSessions,
+		selection: selectionForSnapshot(include),
 		files,
 	};
 }
@@ -249,7 +254,11 @@ export function snapshotTarget(root: string, relativePath: string, configuredSes
 }
 
 export function snapshotIncludesSessions(snapshot: Snapshot) {
-	return snapshot.syncSessions === true || snapshot.files.some((file) => isSessionPath(file.path));
+	return (
+		snapshot.syncSessions === true ||
+		snapshotSelectionInclude(snapshot)?.includes("sessions") === true ||
+		snapshot.files.some((file) => isSessionPath(file.path))
+	);
 }
 
 export function filterSnapshotForConfigPolicy(
@@ -262,6 +271,7 @@ export function filterSnapshotForConfigPolicy(
 	const filtered = {
 		...snapshot,
 		syncSessions: include.includes("sessions") ? snapshot.syncSessions : false,
+		selection: selectionForSnapshot(include),
 		files: canonicalizeSnapshotFilesForConfig(snapshot.files, config, includePaths),
 	};
 	if (!options.regenerateId || snapshotsMatch(snapshot, filtered)) return filtered;
@@ -319,13 +329,21 @@ function isPreferredExtraCandidate(
 
 export function snapshotWithoutSessions(snapshot: Snapshot) {
 	const files = snapshot.files.filter((file) => !isSessionPath(file.path));
-	if (files.length === snapshot.files.length && snapshot.syncSessions !== true) return snapshot;
+	const include = snapshotSelectionInclude(snapshot)?.filter((item) => item !== "sessions");
+	if (
+		files.length === snapshot.files.length &&
+		snapshot.syncSessions !== true &&
+		include?.length === snapshot.selection?.include.length
+	) {
+		return snapshot;
+	}
 	return {
 		...snapshot,
 		id: snapshotId(),
 		createdAt: new Date().toISOString(),
 		machine: os.hostname(),
 		syncSessions: false,
+		...(include ? { selection: selectionForSnapshot(include) } : {}),
 		files,
 	};
 }
@@ -387,14 +405,27 @@ export function mergeRemoteSessionFiles(local: Snapshot, remote: Snapshot) {
 		return isSessionFilePath(normalized) && isSafeSnapshotPath(file.path);
 	});
 	if (remoteSessions.length === 0 && !snapshotIncludesSessions(remote)) return local;
+	const localInclude = snapshotSelectionInclude(local);
 	return {
 		...local,
 		id: snapshotId(),
 		createdAt: new Date().toISOString(),
 		machine: os.hostname(),
 		syncSessions: true,
+		...(localInclude
+			? {
+					selection: selectionForSnapshot(
+						localInclude.includes("sessions") ? localInclude : [...localInclude, "sessions"],
+					),
+				}
+			: {}),
 		files: [...local.files.filter((file) => !isSessionPath(file.path)), ...remoteSessions].sort(
 			(left, right) => left.path.localeCompare(right.path),
 		),
 	};
+}
+
+function sameOptionalInclude(left: string[] | undefined, right: string[] | undefined) {
+	if (!left || !right) return left === right;
+	return left.length === right.length && left.every((item, index) => item === right[index]);
 }

--- a/packages/pi-sync/src/sync-backend.ts
+++ b/packages/pi-sync/src/sync-backend.ts
@@ -1,4 +1,4 @@
-import type { Snapshot } from "./types.js";
+import type { Snapshot, SnapshotSelection } from "./types.js";
 
 export type PublicationCapability =
 	| "read-check-write-verify"
@@ -15,6 +15,8 @@ export interface RemoteHead {
 	createdAt: string;
 	machine: string;
 	syncSessions: boolean;
+	/** Validated lightweight projection; revalidate it against the immutable snapshot before adoption. */
+	selection?: SnapshotSelection;
 }
 
 export interface RemoteHistoryEntry {

--- a/packages/pi-sync/src/sync-format.ts
+++ b/packages/pi-sync/src/sync-format.ts
@@ -1,5 +1,6 @@
 import { agentDir } from "./config.js";
 import type { PublicationCapability, RemoteHead } from "./sync-backend.js";
+import { inspectRemoteSelection } from "./sync-policy.js";
 import { fileHashMap } from "./sync-state.js";
 import type { CommonSyncConfig, Snapshot } from "./types.js";
 
@@ -50,6 +51,11 @@ export function formatPushSummary(
 		`Sessions: ${upload.syncSessions ? "included — may contain private conversations" : "not included"}`,
 		head ? `Remote latest: ${head.snapshotId}` : "Remote latest: empty",
 		"Publication effect: the backend's active head will reference the new immutable snapshot.",
+		...(remote && inspectRemoteSelection(config.include, remote).kind === "different"
+			? [
+					"Included-content policy effect: replace the differing remote selection with this setup's local selection.",
+				]
+			: []),
 		formatPublicationPreview(remote, upload),
 		preservedRemoteFileCount > 0
 			? `Possible secrets in locally managed files were scanned before this prompt; ${preservedRemoteFileCount} preserved remote file(s) were not rescanned.`

--- a/packages/pi-sync/src/sync-operations.ts
+++ b/packages/pi-sync/src/sync-operations.ts
@@ -12,6 +12,11 @@ import {
 } from "./config.js";
 import { inspectLock, isLockGuardHeld, isStaleLock, withLock } from "./lock.js";
 import {
+	formatRemoteSelectionStatus,
+	readSnapshotForHead,
+	requireCompatibleRemoteSelection,
+} from "./remote-snapshot.js";
+import {
 	createSnapshot,
 	filterSnapshotForConfigPolicy,
 	mergeRemotePreservedFiles,
@@ -41,6 +46,7 @@ import {
 	publicationCapabilityDescription,
 	safeTerminalText,
 } from "./sync-format.js";
+import { inspectRemoteSelection, RemoteSelectionMismatchError } from "./sync-policy.js";
 import {
 	canPullRemoteSessionsOnFirstSync,
 	canPullRemoteSettingsOnFirstSync,
@@ -124,6 +130,9 @@ export async function status(
 	throwIfAborted(options.signal);
 	const head = await backend.readHead(options.signal);
 	throwIfAborted(options.signal);
+	const selectionState = head
+		? inspectRemoteSelection(config.include, { selection: head.selection, files: [] })
+		: undefined;
 	const localChanged = hasLocalChanges(local, state, config);
 
 	const remoteText = head
@@ -143,12 +152,15 @@ export async function status(
 			`included content: ${config.include.join(", ") || "none"}`,
 			`sessions: ${config.include.includes("sessions") ? "included" : "excluded"}`,
 			remoteText,
+			formatRemoteSelectionStatus(selectionState),
 			`local files: ${local.files.length}`,
 			`local changed since last sync: ${localChanged ? "yes" : "no"}`,
 			`remote changed since last sync: ${remoteChanged ? "yes" : "no"}`,
 			...warnings,
 		].join("\n"),
-		localChanged || remoteChanged || warnings.length > 0 ? "warning" : "info",
+		localChanged || remoteChanged || selectionState?.kind === "different" || warnings.length > 0
+			? "warning"
+			: "info",
 	);
 }
 
@@ -166,7 +178,12 @@ export async function diff(
 		snapshotOptionsForContext(ctx, config),
 	);
 	throwIfAborted(options.signal);
-	const { snapshot: remote } = await readRemoteSnapshot(backend, config, options.signal);
+	const { snapshot: remote, selectionState } = await readRemoteSnapshot(
+		backend,
+		config,
+		options.signal,
+		{ allowSelectionDifference: true },
+	);
 	throwIfAborted(options.signal);
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 
@@ -177,9 +194,10 @@ export async function diff(
 		`storage location: ${safeTerminalText(backend.destination)}`,
 		`included content: ${config.include.join(", ") || "none"}`,
 		`sessions: ${config.include.includes("sessions") ? "included" : "excluded"}`,
+		formatRemoteSelectionStatus(selectionState),
 		...warnings,
 	].join("\n");
-	const level = warnings.length > 0 ? "warning" : "info";
+	const level = warnings.length > 0 || selectionState?.kind === "different" ? "warning" : "info";
 	if (!remote) {
 		ctx.ui.notify(
 			`${header}\n\n${formatSnapshotOnlyDiff("Remote is empty. Local push would upload", local)}`,
@@ -299,6 +317,9 @@ export async function push(
 		state,
 		options.signal,
 	);
+	if (remoteForUpload && !options.force) {
+		requireCompatibleRemoteSelection(config, remoteForUpload);
+	}
 	if (
 		remoteChangedSinceState(head, state, config, (left, right) =>
 			backend.sameRevision(left, right),
@@ -886,16 +907,20 @@ async function readRemoteSnapshot(
 	backend: SyncBackend,
 	config: AnySyncConfig,
 	signal?: AbortSignal,
+	options: { allowSelectionDifference?: boolean } = {},
 ) {
 	const head = await backend.readHead(signal);
-	if (!head) return { head: undefined, snapshot: undefined };
-	const snapshot = await backend.readSnapshot(head.snapshotRef, signal);
-	if (snapshot.id !== head.snapshotId) {
-		throw new Error(
-			`Remote head ${head.snapshotId} resolved to unexpected snapshot ${snapshot.id}.`,
-		);
+	if (!head) return { head: undefined, snapshot: undefined, selectionState: undefined };
+	const snapshot = await readSnapshotForHead(backend, head, signal);
+	const selectionState = inspectRemoteSelection(config.include, snapshot);
+	if (!options.allowSelectionDifference && selectionState.kind === "different") {
+		throw new RemoteSelectionMismatchError(config.include, selectionState.include);
 	}
-	return { head, snapshot: filterSnapshotForConfigPolicy(snapshot, config) };
+	return {
+		head,
+		snapshot: filterSnapshotForConfigPolicy(snapshot, config),
+		selectionState,
+	};
 }
 
 async function confirmPush(

--- a/packages/pi-sync/src/sync-operations.ts
+++ b/packages/pi-sync/src/sync-operations.ts
@@ -317,6 +317,15 @@ export async function push(
 		state,
 		options.signal,
 	);
+	if (
+		!options.force &&
+		!remoteForUpload &&
+		head?.selection &&
+		inspectRemoteSelection(config.include, { selection: head.selection, files: [] }).kind ===
+			"different"
+	) {
+		remoteForUpload = await readSnapshotForHead(backend, head, options.signal);
+	}
 	if (remoteForUpload && !options.force) {
 		requireCompatibleRemoteSelection(config, remoteForUpload);
 	}

--- a/packages/pi-sync/src/sync-policy.ts
+++ b/packages/pi-sync/src/sync-policy.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { isDeniedPath, toPosix } from "./paths.js";
+import type { Snapshot, SnapshotSelection } from "./types.js";
 
 export const BUILT_IN_SYNC_ROOTS = [
 	"settings.json",
@@ -15,6 +16,7 @@ export const BUILT_IN_SYNC_ROOTS = [
 
 export const DEFAULT_SYNC_INCLUDE = [...BUILT_IN_SYNC_ROOTS] as const;
 export type BuiltInSyncFile = (typeof BUILT_IN_SYNC_ROOTS)[number];
+const SNAPSHOT_SELECTION_VERSION = 1;
 
 const BUILT_IN_BY_LOWER = new Map<string, BuiltInSyncFile>(
 	BUILT_IN_SYNC_ROOTS.map((fileName) => [fileName.toLowerCase(), fileName]),
@@ -87,6 +89,138 @@ function validateAgentRelativeInclude(value: string) {
 			`Invalid pi-sync settings: use the canonical ${topLevel} root instead of a nested sync.include path.`,
 		);
 	}
+}
+
+export function portableSnapshotSelection(value: unknown): SnapshotSelection {
+	const selection = value as Partial<SnapshotSelection> | null;
+	if (
+		!selection ||
+		typeof selection !== "object" ||
+		Array.isArray(selection) ||
+		selection.version !== SNAPSHOT_SELECTION_VERSION ||
+		!Object.hasOwn(selection, "include") ||
+		Object.keys(selection).some((key) => key !== "version" && key !== "include")
+	) {
+		throw new Error("Invalid snapshot selection policy.");
+	}
+	return {
+		version: SNAPSHOT_SELECTION_VERSION,
+		include: normalizeSyncInclude(selection.include),
+	};
+}
+
+export function snapshotSelectionInclude(snapshot: Pick<Snapshot, "selection">) {
+	return snapshot.selection === undefined
+		? undefined
+		: portableSnapshotSelection(snapshot.selection).include;
+}
+
+export function selectionForSnapshot(include: unknown): SnapshotSelection {
+	return { version: SNAPSHOT_SELECTION_VERSION, include: normalizeSyncInclude(include) };
+}
+
+export function sameSyncInclude(left: unknown, right: unknown) {
+	const normalizedLeft = normalizeSyncInclude(left);
+	const normalizedRight = normalizeSyncInclude(right);
+	return (
+		normalizedLeft.length === normalizedRight.length &&
+		normalizedLeft.every((item, index) => item === normalizedRight[index])
+	);
+}
+
+export function compareSyncInclude(local: unknown, remote: unknown) {
+	const localInclude = normalizeSyncInclude(local);
+	const remoteInclude = normalizeSyncInclude(remote);
+	const localSet = new Set(localInclude);
+	const remoteSet = new Set(remoteInclude);
+	return {
+		same: sameSyncInclude(localInclude, remoteInclude),
+		remoteOnly: remoteInclude.filter((item) => !localSet.has(item)),
+		localOnly: localInclude.filter((item) => !remoteSet.has(item)),
+	};
+}
+
+export type RemoteSelectionState =
+	| { kind: "legacy"; discovered: string[] }
+	| { kind: "same"; include: string[] }
+	| {
+			kind: "different";
+			include: string[];
+			remoteOnly: string[];
+			localOnly: string[];
+	  };
+
+export function inspectRemoteSelection(
+	localInclude: unknown,
+	snapshot: Pick<Snapshot, "selection" | "files">,
+): RemoteSelectionState {
+	const remoteInclude = snapshotSelectionInclude(snapshot);
+	if (!remoteInclude) {
+		return { kind: "legacy", discovered: discoverLegacySnapshotInclude(snapshot) };
+	}
+	const comparison = compareSyncInclude(localInclude, remoteInclude);
+	return comparison.same
+		? { kind: "same", include: remoteInclude }
+		: { kind: "different", include: remoteInclude, ...comparison };
+}
+
+export class RemoteSelectionMismatchError extends Error {
+	readonly localInclude: string[];
+	readonly remoteInclude: string[];
+
+	constructor(localInclude: unknown, remoteInclude: unknown) {
+		const local = normalizeSyncInclude(localInclude);
+		const remote = normalizeSyncInclude(remoteInclude);
+		super(
+			"Remote included content differs from this sync setup. Review Remote included content in /sync Settings, or use a reviewed force push to keep local selection.",
+		);
+		this.name = "RemoteSelectionMismatchError";
+		this.localInclude = local;
+		this.remoteInclude = remote;
+	}
+}
+
+export function discoverLegacySnapshotInclude(snapshot: Pick<Snapshot, "files">) {
+	const builtIns = new Set<BuiltInSyncFile>();
+	const custom = new Set<string>();
+	let sessions = false;
+	for (const file of snapshot.files) {
+		const normalized = toPosix(file.path);
+		if (
+			!normalized ||
+			file.path.includes("\\") ||
+			normalized.length > 4096 ||
+			normalized.startsWith("../") ||
+			path.posix.isAbsolute(normalized) ||
+			path.posix.normalize(normalized) !== normalized ||
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: Ignore unsafe legacy paths.
+			/[\u0000-\u001f\u007f-\u009f]/u.test(normalized) ||
+			isDeniedPath(normalized)
+		) {
+			continue;
+		}
+		const [topLevel, ...rest] = normalized.split("/");
+		if (!topLevel) continue;
+		if (topLevel === "sessions" && rest.length > 0) {
+			sessions = true;
+			continue;
+		}
+		const builtIn = BUILT_IN_BY_LOWER.get(topLevel.toLowerCase());
+		if (
+			builtIn &&
+			((TOP_LEVEL_DIRS.has(builtIn) && rest.length > 0) ||
+				(!TOP_LEVEL_DIRS.has(builtIn) && rest.length === 0))
+		) {
+			builtIns.add(builtIn);
+			continue;
+		}
+		if (isSafeCustomIncludePath(topLevel)) custom.add(topLevel);
+	}
+	return [
+		...BUILT_IN_SYNC_ROOTS.filter((item) => builtIns.has(item)),
+		...[...custom].sort((left, right) => left.localeCompare(right)),
+		...(sessions ? ["sessions"] : []),
+	];
 }
 
 export function syncIncludeSelection(value: unknown) {

--- a/packages/pi-sync/src/sync-policy.ts
+++ b/packages/pi-sync/src/sync-policy.ts
@@ -17,6 +17,14 @@ export const BUILT_IN_SYNC_ROOTS = [
 export const DEFAULT_SYNC_INCLUDE = [...BUILT_IN_SYNC_ROOTS] as const;
 export type BuiltInSyncFile = (typeof BUILT_IN_SYNC_ROOTS)[number];
 const SNAPSHOT_SELECTION_VERSION = 1;
+const MAX_SYNC_INCLUDE_ITEMS = 1_024;
+const MAX_SYNC_INCLUDE_PATH_BYTES = 4_096;
+const MAX_SYNC_INCLUDE_TOTAL_BYTES = 256 * 1_024;
+
+interface IncludePathNode {
+	selected?: string;
+	children: Map<string, IncludePathNode>;
+}
 
 const BUILT_IN_BY_LOWER = new Map<string, BuiltInSyncFile>(
 	BUILT_IN_SYNC_ROOTS.map((fileName) => [fileName.toLowerCase(), fileName]),
@@ -36,11 +44,30 @@ export function normalizeSyncInclude(value: unknown): string[] {
 	if (!Array.isArray(value)) {
 		throw new Error("Invalid pi-sync settings: sync.include must be an array.");
 	}
+	if (value.length > MAX_SYNC_INCLUDE_ITEMS) {
+		throw new Error(
+			`Invalid pi-sync settings: sync.include has too many items; limit: ${MAX_SYNC_INCLUDE_ITEMS}.`,
+		);
+	}
 	const result: string[] = [];
 	const seen = new Set<string>();
+	const pathRoot: IncludePathNode = { children: new Map() };
+	let totalBytes = 0;
 	for (const item of value) {
 		if (typeof item !== "string") {
 			throw new Error("Invalid pi-sync settings: sync.include items must be strings.");
+		}
+		const itemBytes = Buffer.byteLength(item, "utf8");
+		if (itemBytes > MAX_SYNC_INCLUDE_PATH_BYTES) {
+			throw new Error(
+				`Invalid pi-sync settings: sync.include item is too long; limit: ${MAX_SYNC_INCLUDE_PATH_BYTES} bytes.`,
+			);
+		}
+		totalBytes += itemBytes;
+		if (totalBytes > MAX_SYNC_INCLUDE_TOTAL_BYTES) {
+			throw new Error(
+				`Invalid pi-sync settings: sync.include is too large; limit: ${MAX_SYNC_INCLUDE_TOTAL_BYTES} bytes.`,
+			);
 		}
 		const trimmed = item.trim();
 		const builtIn = BUILT_IN_BY_LOWER.get(trimmed.toLowerCase());
@@ -50,17 +77,32 @@ export function normalizeSyncInclude(value: unknown): string[] {
 		if (seen.has(identity)) {
 			throw new Error(`Invalid pi-sync settings: duplicate sync.include item: ${item}`);
 		}
-		for (const previous of seen) {
-			if (identity.startsWith(`${previous}/`) || previous.startsWith(`${identity}/`)) {
-				throw new Error(
-					`Invalid pi-sync settings: overlapping sync.include items are ambiguous: ${item}`,
-				);
-			}
-		}
+		addIncludePath(pathRoot, identity, item);
 		seen.add(identity);
 		result.push(normalized);
 	}
 	return result;
+}
+
+function addIncludePath(root: IncludePathNode, identity: string, source: string) {
+	let node = root;
+	for (const segment of identity.split("/")) {
+		if (node.selected !== undefined) throwOverlappingInclude(source);
+		let child = node.children.get(segment);
+		if (!child) {
+			child = { children: new Map() };
+			node.children.set(segment, child);
+		}
+		node = child;
+	}
+	if (node.children.size > 0) throwOverlappingInclude(source);
+	node.selected = identity;
+}
+
+function throwOverlappingInclude(item: string): never {
+	throw new Error(
+		`Invalid pi-sync settings: overlapping sync.include items are ambiguous: ${item}`,
+	);
 }
 
 function validateAgentRelativeInclude(value: string) {

--- a/packages/pi-sync/src/types.ts
+++ b/packages/pi-sync/src/types.ts
@@ -193,6 +193,11 @@ export interface SnapshotFile {
 	sha256: string;
 }
 
+export interface SnapshotSelection {
+	version: 1;
+	include: string[];
+}
+
 export interface Snapshot {
 	version: number;
 	id: string;
@@ -201,6 +206,8 @@ export interface Snapshot {
 	/** Backend-scoped remote identity retained in the snapshot wire format. */
 	profile: string;
 	syncSessions?: boolean;
+	/** Portable, credential-free included-content intent. Absent on legacy snapshots. */
+	selection?: SnapshotSelection;
 	files: SnapshotFile[];
 }
 
@@ -212,6 +219,8 @@ export interface LatestPointer {
 	createdAt: string;
 	machine: string;
 	syncSessions?: boolean;
+	/** Lightweight projection; the immutable snapshot remains authoritative. */
+	selection?: SnapshotSelection;
 }
 
 export interface RemoteObject<T> {

--- a/packages/pi-sync/src/webdav-backend.ts
+++ b/packages/pi-sync/src/webdav-backend.ts
@@ -11,6 +11,7 @@ import {
 	SyncBackendConflictError,
 	SyncBackendPublicationOutcomeUnknownError,
 } from "./sync-backend.js";
+import { portableSnapshotSelection } from "./sync-policy.js";
 import type { LatestPointer, RemoteObject, ResolvedWebDavBackend, Snapshot } from "./types.js";
 import { WebDavClient, WebDavHttpError, WebDavPreconditionError } from "./webdav-client.js";
 
@@ -427,6 +428,7 @@ function pointerFor(
 		syncSessions:
 			snapshot.syncSessions === true ||
 			snapshot.files.some((file) => file.path.startsWith("sessions/")),
+		...(snapshot.selection === undefined ? {} : { selection: snapshot.selection }),
 	};
 }
 
@@ -438,6 +440,7 @@ function remoteHead(pointer: LatestPointer, identity: string, etag?: string): Re
 		createdAt: pointer.createdAt,
 		machine: pointer.machine,
 		syncSessions: pointer.syncSessions === true,
+		...(pointer.selection === undefined ? {} : { selection: pointer.selection }),
 	};
 }
 
@@ -503,6 +506,7 @@ function requirePointer(value: LatestPointer | undefined, expectedProfile: strin
 	) {
 		throw new Error("Remote latest pointer is malformed.");
 	}
+	if (value.selection !== undefined) portableSnapshotSelection(value.selection);
 	return value;
 }
 

--- a/packages/pi-sync/test/backend-contract-suite.ts
+++ b/packages/pi-sync/test/backend-contract-suite.ts
@@ -21,9 +21,16 @@ export function registerSyncBackendContractSuite(name: string, create: BackendFa
 			assert.ok(backend.destination);
 			assert.equal(await backend.readHead(), undefined);
 
-			const first = snapshot([{ path: "settings.json", content: Buffer.from("first") }]);
+			const first = {
+				...snapshot([{ path: "settings.json", content: Buffer.from("first") }]),
+				selection: {
+					version: 1 as const,
+					include: ["settings.json", "remote-only.toml"],
+				},
+			};
 			const firstResult = await backend.publishSnapshot(first, expectedRemoteHead(undefined));
 			assert.equal(firstResult.head.snapshotId, first.id);
+			assert.deepEqual(firstResult.head.selection, first.selection);
 			assert.match(firstResult.head.revision, /\S/);
 			assert.equal(
 				backend.sameRevision(firstResult.head.revision, firstResult.head.revision),

--- a/packages/pi-sync/test/git-backend.test.ts
+++ b/packages/pi-sync/test/git-backend.test.ts
@@ -29,11 +29,17 @@ test("Git backend publishes lease-protected commits and preserves repeated-conte
 			cacheRoot: path.join(fixture.root, "cache"),
 			allowLocalRemotes: true,
 		});
-		const content = snapshot([
-			{ path: "settings.json", content: Buffer.from("one") },
-			{ path: "keybindings.json", content: Buffer.from("shared") },
-			{ path: "copies/keybindings.json", content: Buffer.from("shared") },
-		]);
+		const content = {
+			...snapshot([
+				{ path: "settings.json", content: Buffer.from("one") },
+				{ path: "keybindings.json", content: Buffer.from("shared") },
+				{ path: "copies/keybindings.json", content: Buffer.from("shared") },
+			]),
+			selection: {
+				version: 1 as const,
+				include: ["settings.json", "keybindings.json", "copies", "missing.toml"],
+			},
+		};
 		const first = await backend.publishSnapshot(content, { kind: "missing" });
 		assert.match(
 			first.head.revision,

--- a/packages/pi-sync/test/memory-sync-backend.ts
+++ b/packages/pi-sync/test/memory-sync-backend.ts
@@ -32,7 +32,7 @@ export class MemorySyncBackend implements SyncBackend {
 
 	async readHead(signal?: AbortSignal) {
 		throwIfAborted(signal);
-		return this.head ? { ...this.head } : undefined;
+		return this.head ? structuredClone(this.head) : undefined;
 	}
 
 	async readSnapshot(reference: string, signal?: AbortSignal) {
@@ -62,6 +62,9 @@ export class MemorySyncBackend implements SyncBackend {
 			createdAt: snapshot.createdAt,
 			machine: snapshot.machine,
 			syncSessions: snapshot.syncSessions === true,
+			...(snapshot.selection === undefined
+				? {}
+				: { selection: structuredClone(snapshot.selection) }),
 		};
 		this.history = [
 			...this.history.filter((entry) => entry.snapshotRef !== snapshot.id),
@@ -79,7 +82,7 @@ export class MemorySyncBackend implements SyncBackend {
 				"Memory publication committed, but verification failed.",
 			);
 		}
-		return { head: { ...this.head }, warnings: [] };
+		return { head: structuredClone(this.head), warnings: [] };
 	}
 
 	async listHistory(signal?: AbortSignal) {

--- a/packages/pi-sync/test/portable-selection.test.ts
+++ b/packages/pi-sync/test/portable-selection.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readSnapshotForHead } from "../src/remote-snapshot.js";
+import {
+	compareSyncInclude,
+	discoverLegacySnapshotInclude,
+	snapshotSelectionInclude,
+} from "../src/sync-policy.js";
+import { snapshot } from "./helpers.js";
+import { MemorySyncBackend } from "./memory-sync-backend.js";
+
+test("portable selection comparison preserves exact selected-but-missing intent", () => {
+	const remote = {
+		...snapshot([]),
+		selection: {
+			version: 1 as const,
+			include: ["settings.json", "pi-starship.toml", "sessions"],
+		},
+	};
+	assert.deepEqual(snapshotSelectionInclude(remote), [
+		"settings.json",
+		"pi-starship.toml",
+		"sessions",
+	]);
+	assert.deepEqual(compareSyncInclude(["settings.json", "AGENTS.md"], remote.selection.include), {
+		same: false,
+		remoteOnly: ["pi-starship.toml", "sessions"],
+		localOnly: ["AGENTS.md"],
+	});
+});
+
+test("remote head selection is revalidated against the immutable snapshot", async () => {
+	const backend = new MemorySyncBackend();
+	const selected = {
+		...snapshot([]),
+		selection: { version: 1 as const, include: ["settings.json"] },
+	};
+	const { head } = await backend.publishSnapshot(selected, { kind: "missing" });
+	await assert.rejects(
+		readSnapshotForHead(backend, {
+			...head,
+			selection: { version: 1, include: ["models.json"] },
+		}),
+		/selection does not match/i,
+	);
+});
+
+test("legacy snapshot discovery is safe, partial, and rooted", () => {
+	const legacy = snapshot([
+		{ path: "settings.json", content: Buffer.from("settings") },
+		{ path: "skills/demo.md", content: Buffer.from("skill") },
+		{ path: "pi-starship.toml", content: Buffer.from("starship") },
+		{ path: "snippets/nested/example.md", content: Buffer.from("snippet") },
+		{ path: "sessions/project/session.jsonl", content: Buffer.from("session") },
+		{ path: ".env", content: Buffer.from("secret") },
+		{ path: "unsafe\\nested.txt", content: Buffer.from("unsafe") },
+		{ path: `control-${String.fromCharCode(27)}.txt`, content: Buffer.from("unsafe") },
+	]);
+	assert.deepEqual(discoverLegacySnapshotInclude(legacy), [
+		"settings.json",
+		"skills",
+		"pi-starship.toml",
+		"snippets",
+		"sessions",
+	]);
+});

--- a/packages/pi-sync/test/portable-selection.test.ts
+++ b/packages/pi-sync/test/portable-selection.test.ts
@@ -29,6 +29,36 @@ test("portable selection comparison preserves exact selected-but-missing intent"
 	});
 });
 
+test("portable selection rejects policies that exceed bounded collection and path sizes", () => {
+	assert.throws(
+		() =>
+			snapshotSelectionInclude({
+				selection: {
+					version: 1,
+					include: Array.from({ length: 1_025 }, (_, index) => `path-${index}`),
+				},
+			}),
+		/too many|limit/i,
+	);
+	assert.throws(
+		() =>
+			snapshotSelectionInclude({
+				selection: { version: 1, include: ["x".repeat(4_097)] },
+			}),
+		/too long|limit/i,
+	);
+	assert.throws(
+		() =>
+			snapshotSelectionInclude({
+				selection: {
+					version: 1,
+					include: Array.from({ length: 1_024 }, (_, index) => `path-${index}-${"x".repeat(250)}`),
+				},
+			}),
+		/too large|limit/i,
+	);
+});
+
 test("remote head selection is revalidated against the immutable snapshot", async () => {
 	const backend = new MemorySyncBackend();
 	const selected = {

--- a/packages/pi-sync/test/remote-selection-ui.test.ts
+++ b/packages/pi-sync/test/remote-selection-ui.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import {
+	loadConfig,
+	localConfigPath,
+	readLocalConfigObject,
+	statePathForConfig,
+	updateLocalConfig,
+} from "../src/config.js";
+import { showRemoteSelectionReview } from "../src/remote-selection-ui.js";
+import { expectedRemoteHead } from "../src/sync-backend.js";
+import { snapshot, v3S3Settings, withTempHome } from "./helpers.js";
+import { MemorySyncBackend } from "./memory-sync-backend.js";
+
+initTheme("dark", false);
+
+test("remote selection review adopts policy only after session acknowledgement", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const backend = new MemorySyncBackend();
+		await publishSelection(backend, ["settings.json", "pi-starship.toml", "sessions"]);
+		let confirmations = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			confirm: async () => {
+				confirmations += 1;
+				return true;
+			},
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 100);
+				assert.match(harness.render().join("\n"), /Adopt remote included content/u);
+				harness.handleInput("tui.select.confirm");
+				await harness.waitForPending();
+				return harness.result;
+			},
+		});
+
+		await showRemoteSelectionReview(ctx, "home", undefined, () => backend);
+
+		assert.equal(confirmations, 1);
+		assert.deepEqual((await readLocalConfigObject())?.syncSetups.home.sync.include, [
+			"settings.json",
+			"pi-starship.toml",
+			"sessions",
+		]);
+		assert.equal(existsSync(path.join(agentDir, "pi-starship.toml")), false);
+		assert.equal(existsSync(statePathForConfig(await loadConfig())), false);
+		assert.match(notifications.at(-1)?.message ?? "", /No files were pulled/u);
+	});
+});
+
+test("remote selection review keeps local policy without changing settings", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const before = Buffer.from(`${JSON.stringify(v3S3Settings())}\n`);
+		writeFileSync(localConfigPath(), before, { mode: 0o600 });
+		const backend = new MemorySyncBackend();
+		await publishSelection(backend, ["settings.json", "pi-starship.toml"]);
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 100);
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+				await harness.waitForPending();
+				return harness.result;
+			},
+		});
+
+		await showRemoteSelectionReview(ctx, "home", undefined, () => backend);
+
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+		assert.match(notifications.at(-1)?.message ?? "", /Kept local.*force push/i);
+	});
+});
+
+test("legacy remote selection offers read-only partial discovery", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const before = Buffer.from(`${JSON.stringify(v3S3Settings())}\n`);
+		writeFileSync(localConfigPath(), before, { mode: 0o600 });
+		const backend = new MemorySyncBackend();
+		await backend.publishSnapshot(
+			{
+				...snapshot([
+					{ path: "settings.json", content: Buffer.from("settings") },
+					{ path: "pi-starship.toml", content: Buffer.from("starship") },
+				]),
+				id: "legacy",
+			},
+			{ kind: "missing" },
+		);
+		const rendered: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				harness.handleInput("tui.select.confirm");
+				await harness.waitForPending();
+				rendered.push(harness.render().join("\n"));
+				harness.dispose();
+				return harness.result;
+			},
+		});
+
+		await showRemoteSelectionReview(ctx, "home", undefined, () => backend);
+
+		assert.match(rendered.join("\n"), /partial.*pi-starship\.toml/is);
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+	});
+});
+
+test("remote selection adoption rejects a changed remote head and preserves settings", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const before = Buffer.from(`${JSON.stringify(v3S3Settings())}\n`);
+		writeFileSync(localConfigPath(), before, { mode: 0o600 });
+		const backend = new MemorySyncBackend();
+		await publishSelection(backend, ["settings.json", "pi-starship.toml", "sessions"]);
+		const controller = new AbortController();
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			confirm: async () => {
+				await publishSelection(backend, ["settings.json", "models.json"]);
+				return true;
+			},
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 100);
+				harness.handleInput("tui.select.confirm");
+				await harness.waitForPending();
+				return harness.result;
+			},
+		});
+
+		await showRemoteSelectionReview(ctx, "home", controller.signal, () => backend);
+
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+		assert.match(notifications.at(-1)?.message ?? "", /Remote changed while.*open/i);
+	});
+});
+
+test("remote selection adoption rejects a concurrent local include change", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const backend = new MutatingReadBackend(async () => {
+			await updateLocalConfig((settings) => ({
+				...settings,
+				syncSetups: {
+					...settings.syncSetups,
+					home: {
+						...settings.syncSetups.home,
+						sync: { ...settings.syncSetups.home.sync, include: ["models.json"] },
+					},
+				},
+			}));
+		});
+		await publishSelection(backend, ["settings.json", "pi-starship.toml"]);
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 100);
+				harness.handleInput("tui.select.confirm");
+				await harness.waitForPending();
+				return harness.result;
+			},
+		});
+
+		await showRemoteSelectionReview(ctx, "home", undefined, () => backend);
+
+		assert.deepEqual((await readLocalConfigObject())?.syncSetups.home.sync.include, [
+			"models.json",
+		]);
+		assert.match(notifications.at(-1)?.message ?? "", /included content changed.*reopen/i);
+	});
+});
+
+test("remote selection review disposes on session replacement without side effects", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const before = Buffer.from(`${JSON.stringify(v3S3Settings())}\n`);
+		writeFileSync(localConfigPath(), before, { mode: 0o600 });
+		const backend = new MemorySyncBackend();
+		await publishSelection(backend, ["settings.json", "pi-starship.toml"]);
+		const controller = new AbortController();
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				controller.abort(new DOMException("Session replaced", "AbortError"));
+				harness.dispose();
+				return harness.result;
+			},
+		});
+
+		await showRemoteSelectionReview(ctx, "home", controller.signal, () => backend);
+
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+		assert.deepEqual(notifications, []);
+	});
+});
+
+class MutatingReadBackend extends MemorySyncBackend {
+	private snapshotReads = 0;
+
+	constructor(private readonly mutate: () => Promise<void>) {
+		super();
+	}
+
+	override async readSnapshot(reference: string, signal?: AbortSignal) {
+		this.snapshotReads += 1;
+		if (this.snapshotReads === 2) await this.mutate();
+		return super.readSnapshot(reference, signal);
+	}
+}
+
+async function publishSelection(backend: MemorySyncBackend, include: string[]) {
+	return backend.publishSnapshot(
+		{
+			...snapshot([]),
+			id: `selection-${include.length}`,
+			selection: { version: 1, include },
+		},
+		expectedRemoteHead(await backend.readHead()),
+	);
+}

--- a/packages/pi-sync/test/settings-management.test.ts
+++ b/packages/pi-sync/test/settings-management.test.ts
@@ -539,6 +539,31 @@ test("an aborted settings mutation waiting on the cross-process lock never publi
 	});
 });
 
+test("settings UI exposes separate local and remote included-content reviews", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const before = Buffer.from(`${JSON.stringify(v3S3Settings())}\n`);
+		writeFileSync(localConfigPath(), before, { mode: 0o600 });
+		let rendered = "";
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 100);
+				rendered = harness.render().join("\n");
+				harness.handleInput("tui.select.cancel");
+				return harness.result;
+			},
+		});
+
+		await showSyncSettings(ctx, async () => undefined);
+
+		assert.match(rendered, /Included content/u);
+		assert.match(rendered, /Remote included content/u);
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+	});
+});
+
 test("settings UI disposes on session replacement without mutating settings", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });

--- a/packages/pi-sync/test/snapshot-codec.test.ts
+++ b/packages/pi-sync/test/snapshot-codec.test.ts
@@ -1,8 +1,25 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { gzipSync } from "node:zlib";
-import { decodeSnapshot } from "../src/snapshot-codec.js";
+import { decodeSnapshot, encodeSnapshot } from "../src/snapshot-codec.js";
 import { snapshot } from "./helpers.js";
+
+test("snapshot codec preserves portable selection intent and rejects malformed policy", async () => {
+	const selected = {
+		...snapshot([]),
+		selection: { version: 1 as const, include: ["settings.json", "pi-starship.toml"] },
+	};
+	assert.deepEqual(await decodeSnapshot(await encodeSnapshot(selected)), selected);
+
+	const malformed = {
+		...snapshot([]),
+		selection: { version: 1, include: ["../auth.json"] },
+	};
+	await assert.rejects(
+		decodeSnapshot(gzipSync(Buffer.from(JSON.stringify(malformed)))),
+		/selection|sync\.include|safe agent-relative/i,
+	);
+});
 
 test("snapshot decoding bounds decompressed output and honors cancellation", async () => {
 	const encoded = gzipSync(

--- a/packages/pi-sync/test/sync-decision.test.ts
+++ b/packages/pi-sync/test/sync-decision.test.ts
@@ -9,7 +9,8 @@ import { loadConfig, localConfigPath, statePathForConfig } from "../src/config.j
 import sync from "../src/sync.js";
 import { expectedRemoteHead } from "../src/sync-backend.js";
 import { SyncDecisionRequiredError } from "../src/sync-decision.js";
-import { pull, push, syncBoth } from "../src/sync-operations.js";
+import { pull, push, status, syncBoth } from "../src/sync-operations.js";
+import { RemoteSelectionMismatchError } from "../src/sync-policy.js";
 import type { CommandOptions, Snapshot } from "../src/types.js";
 import { snapshot, v3S3Settings, withTempHome } from "./helpers.js";
 import { MemorySyncBackend } from "./memory-sync-backend.js";
@@ -23,6 +24,83 @@ const options: CommandOptions = {
 	auto: false,
 	args: [],
 };
+
+test("sync and pull pause without mutation when remote included content differs", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		const backend = new MemorySyncBackend();
+		const remote = {
+			...snapshot([
+				{ path: "settings.json", content: Buffer.from('{"remote":true}\n') },
+				{ path: "pi-starship.toml", content: Buffer.from("remote-only\n") },
+			]),
+			id: "remote-selection",
+			selection: {
+				version: 1 as const,
+				include: ["settings.json", "pi-starship.toml"],
+			},
+		};
+		await backend.publishSnapshot(remote, { kind: "missing" });
+		const { ctx, notifications } = createMockContext({ hasUI: true, mode: "tui" });
+
+		for (const operation of [
+			() => syncBoth(ctx, { ...options, auto: true }, () => backend),
+			() => pull(ctx, { ...options, force: true }, () => backend),
+		]) {
+			await assert.rejects(operation(), RemoteSelectionMismatchError);
+		}
+		await status(ctx, options, () => backend);
+		assert.match(notifications.at(-1)?.message ?? "", /remote included content: differs/i);
+		assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), '{"local":true}\n');
+		assert.equal(existsSync(path.join(agentDir, "pi-starship.toml")), false);
+		assert.equal(existsSync(statePathForConfig(await loadConfig())), false);
+	});
+});
+
+test("reviewed force push keeps local selection and preserves remote unmanaged files", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		writeFileSync(path.join(agentDir, "settings.json"), '{"local":true}\n');
+		const backend = new MemorySyncBackend();
+		await backend.publishSnapshot(
+			{
+				...snapshot([
+					{ path: "settings.json", content: Buffer.from('{"remote":true}\n') },
+					{ path: "pi-starship.toml", content: Buffer.from("preserved\n") },
+				]),
+				id: "remote-selection",
+				selection: {
+					version: 1,
+					include: ["settings.json", "pi-starship.toml"],
+				},
+			},
+			{ kind: "missing" },
+		);
+		const reviews: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			confirm: async (_title: string, message: string) => {
+				reviews.push(message);
+				return true;
+			},
+		});
+
+		await push(ctx, { ...options, yes: false, force: true }, undefined, () => backend);
+		const head = await backend.readHead();
+		assert.ok(head);
+		const published = await backend.readSnapshot(head.snapshotRef);
+		assert.deepEqual(published.selection, { version: 1, include: ["settings.json"] });
+		assert.match(reviews.join("\n"), /replace the differing remote selection/i);
+		assert.deepEqual(published.files.map((file) => file.path).sort(), [
+			"pi-starship.toml",
+			"settings.json",
+		]);
+	});
+});
 
 test("push reports a structured remote-or-policy decision without mutation", async () => {
 	await withInitializedSync(async ({ agentDir, backend, config }) => {

--- a/packages/pi-sync/test/sync-decision.test.ts
+++ b/packages/pi-sync/test/sync-decision.test.ts
@@ -5,7 +5,12 @@ import path from "node:path";
 import test from "node:test";
 import { gzipSync } from "node:zlib";
 import { createMockContext, createMockPi } from "../../../test/support.js";
-import { loadConfig, localConfigPath, statePathForConfig } from "../src/config.js";
+import {
+	loadConfig,
+	localConfigPath,
+	statePathForConfig,
+	writeStateForConfig,
+} from "../src/config.js";
 import sync from "../src/sync.js";
 import { expectedRemoteHead } from "../src/sync-backend.js";
 import { SyncDecisionRequiredError } from "../src/sync-decision.js";
@@ -56,6 +61,47 @@ test("sync and pull pause without mutation when remote included content differs"
 		assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), '{"local":true}\n');
 		assert.equal(existsSync(path.join(agentDir, "pi-starship.toml")), false);
 		assert.equal(existsSync(statePathForConfig(await loadConfig())), false);
+	});
+});
+
+test("ordinary push checks a differing head policy even when legacy state matches its snapshot", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const base = Buffer.from('{"base":true}\n');
+		writeFileSync(path.join(agentDir, "settings.json"), base);
+		const backend = new MemorySyncBackend();
+		const remote = {
+			...snapshot([
+				{ path: "settings.json", content: base },
+				{ path: "pi-starship.toml", content: Buffer.from("remote-only\n") },
+			]),
+			id: "remote-selection",
+			selection: {
+				version: 1 as const,
+				include: ["settings.json", "pi-starship.toml"],
+			},
+		};
+		const published = await backend.publishSnapshot(remote, { kind: "missing" });
+		const config = await loadConfig();
+		await writeStateForConfig(config, {
+			version: 1,
+			profile: config.snapshotIdentity,
+			lastAppliedSnapshot: remote.id,
+			lastRemoteRevision: published.head.revision,
+			lastFileHashes: { "settings.json": remote.files[0]?.sha256 ?? "" },
+			include: ["settings.json"],
+		});
+		writeFileSync(path.join(agentDir, "settings.json"), '{"changed":true}\n');
+		const headBefore = await backend.readHead();
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+
+		await assert.rejects(
+			push(ctx, options, undefined, () => backend),
+			RemoteSelectionMismatchError,
+		);
+		assert.equal((await backend.readHead())?.revision, headBefore?.revision);
+		assert.deepEqual((await backend.readSnapshot(remote.id)).selection, remote.selection);
 	});
 });
 

--- a/packages/pi-sync/test/sync-snapshot.test.ts
+++ b/packages/pi-sync/test/sync-snapshot.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
+import { createSnapshot } from "../src/snapshot.js";
 import { applySnapshot } from "../src/snapshot-apply.js";
 import {
 	addTopLevelCaseVariantDeletes,
@@ -15,6 +16,24 @@ import {
 import { snapshot, withTempHome } from "./helpers.js";
 
 initTheme("dark", false);
+
+test("snapshot preserves selected paths that are currently missing", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(path.join(agentDir, "settings.json"), "{}\n");
+		const created = await createSnapshot("home", {
+			include: ["settings.json", "pi-starship.toml"],
+		});
+		assert.deepEqual(created.selection, {
+			version: 1,
+			include: ["settings.json", "pi-starship.toml"],
+		});
+		assert.deepEqual(
+			created.files.map((file) => file.path),
+			["settings.json"],
+		);
+	});
+});
 
 test("snapshot collection includes session jsonl files only when enabled", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-sync-collect-"));

--- a/packages/pi-sync/test/sync-storage.test.ts
+++ b/packages/pi-sync/test/sync-storage.test.ts
@@ -303,10 +303,12 @@ test("snapshotWithoutSessions clears session opt-in even when no session files e
 	const source = {
 		...snapshot([{ path: "settings.json", content: Buffer.from("{}") }]),
 		syncSessions: true,
+		selection: { version: 1 as const, include: ["settings.json", "sessions"] },
 	};
 	const filtered = snapshotWithoutSessions(source);
 
 	assert.equal(filtered.syncSessions, false);
+	assert.deepEqual(filtered.selection, { version: 1, include: ["settings.json"] });
 	assert.notEqual(filtered.id, source.id);
 	assert.deepEqual(
 		filtered.files.map((file) => file.path),

--- a/packages/pi-sync/test/sync.test.ts
+++ b/packages/pi-sync/test/sync.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
@@ -185,8 +185,126 @@ test("included-content TUI lists built-in and custom paths exactly once", async 
 		});
 		await showFileSelection(ctx, "home");
 		assert.equal(customCalls, 1);
-		assert.deepEqual(labels, [...BUILT_IN_SYNC_ROOTS, "custom.json", "sessions"]);
+		assert.deepEqual(labels, [
+			...BUILT_IN_SYNC_ROOTS,
+			"custom.json",
+			"sessions",
+			"Add custom path…",
+		]);
 		assert.deepEqual(readFileSync(localConfigPath()), before);
+	});
+});
+
+test("included-content TUI adds and saves a custom path that is absent locally", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const remoteOnlyPath = "remote-only.toml";
+		let screen = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => remoteOnlyPath,
+			custom: async (factory: unknown) => {
+				screen += 1;
+				const harness = createCustomSelectorHarness(factory, 100);
+				if (screen === 1) {
+					for (let index = 0; index < 32; index += 1) {
+						if (selectedMultiSelectLabel(harness.render()) === "Add custom path…") break;
+						harness.handleInput("tui.select.down");
+					}
+					assert.equal(selectedMultiSelectLabel(harness.render()), "Add custom path…");
+					harness.handleInput("tui.select.confirm");
+					await Promise.resolve();
+				} else if (screen === 2) {
+					assert.match(harness.render().join("\n"), /\[x\] remote-only\.toml/u);
+					harness.handleInput("tui.select.cancel");
+				} else {
+					harness.handleInput("tui.select.confirm");
+				}
+				return harness.result;
+			},
+		});
+
+		await showFileSelection(ctx, "home");
+
+		assert.equal(screen, 3);
+		assert.equal(existsSync(path.join(agentDir, remoteOnlyPath)), false);
+		assert.deepEqual((await readLocalConfigObject())?.syncSetups.home.sync.include, [
+			"settings.json",
+			remoteOnlyPath,
+		]);
+		assert.match(notifications.at(-1)?.message ?? "", /Saved included content/u);
+	});
+});
+
+test("included-content TUI rejects an unsafe absent custom path without changing settings", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const before = Buffer.from(`${JSON.stringify(v3S3Settings())}\n`);
+		writeFileSync(localConfigPath(), before, { mode: 0o600 });
+		let screen = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => "../outside.toml",
+			custom: async (factory: unknown) => {
+				screen += 1;
+				const harness = createCustomSelectorHarness(factory, 100);
+				if (screen === 1) {
+					for (let index = 0; index < BUILT_IN_SYNC_ROOTS.length + 1; index += 1) {
+						harness.handleInput("tui.select.down");
+					}
+					assert.equal(selectedMultiSelectLabel(harness.render()), "Add custom path…");
+					harness.handleInput("tui.select.confirm");
+					await Promise.resolve();
+				} else {
+					harness.handleInput("tui.select.cancel");
+				}
+				return harness.result;
+			},
+		});
+
+		await showFileSelection(ctx, "home");
+
+		assert.equal(screen, 2);
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+		assert.match(notifications.at(-1)?.message ?? "", /safe agent-relative/u);
+	});
+});
+
+test("included-content custom-path input stops on session replacement", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const before = Buffer.from(`${JSON.stringify(v3S3Settings())}\n`);
+		writeFileSync(localConfigPath(), before, { mode: 0o600 });
+		const controller = new AbortController();
+		let screen = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => {
+				controller.abort(new DOMException("Session replaced", "AbortError"));
+				return "remote-only.toml";
+			},
+			custom: async (factory: unknown) => {
+				screen += 1;
+				const harness = createCustomSelectorHarness(factory, 100);
+				for (let index = 0; index < BUILT_IN_SYNC_ROOTS.length + 1; index += 1) {
+					harness.handleInput("tui.select.down");
+				}
+				assert.equal(selectedMultiSelectLabel(harness.render()), "Add custom path…");
+				harness.handleInput("tui.select.confirm");
+				await Promise.resolve();
+				return harness.result;
+			},
+		});
+
+		await showFileSelection(ctx, "home", controller.signal);
+
+		assert.equal(screen, 1);
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+		assert.deepEqual(notifications, []);
 	});
 });
 


### PR DESCRIPTION
## Summary

- persist credential-free included-content intent in pi-sync snapshots and validated backend head projections, including selected paths that are currently missing
- add an explicit Settings review flow to compare, inspect, and adopt remote included content while pausing pull/automatic sync on policy divergence
- allow safe remote-only custom paths, preserve legacy snapshot compatibility with read-only partial discovery, and document the policy in an ADR

## Verification

- `npm run check` (2,380 tests passed)
- `just pack sync`
- pre-commit Biome and workspace typechecks

## Compatibility

Older snapshots remain readable. Newer readers accept older Git manifests, while older strict Git readers may reject new manifests containing the additive selection field.
