### PR TITLE
fix(lsp): use host Pi runtime dependencies

### DIFF
--- a/.changeset/kind-lsps-share.md
+++ b/.changeset/kind-lsps-share.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-lsp": patch
+---
+
+Use Pi's host-provided coding-agent and TypeBox runtimes instead of installing duplicate copies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6940,6 +6940,7 @@
 			"version": "1.3.11",
 			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.11.tgz",
 			"integrity": "sha512-tZGKIS02Opbh4EYMmAEVuXl+y3EQJ9ZlkitLZ1CmFCY4ZOqr/xWR9dDSCFmIjNDICGMWkOqMh6WxGTyRXqcSGQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
@@ -7392,14 +7393,16 @@
 			"name": "@narumitw/pi-lsp",
 			"version": "0.49.3",
 			"license": "MIT",
-			"dependencies": {
-				"typebox": "^1.3.11"
-			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",
 				"@earendil-works/pi-coding-agent": "0.84.1",
 				"@types/node": "26.1.2",
+				"typebox": "1.3.11",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"typebox": "*"
 			}
 		},
 		"packages/pi-plan-mode": {

--- a/packages/pi-lsp/package.json
+++ b/packages/pi-lsp/package.json
@@ -34,13 +34,15 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
-	"dependencies": {
-		"typebox": "^1.3.11"
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"typebox": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.7",
 		"@earendil-works/pi-coding-agent": "0.84.1",
 		"@types/node": "26.1.2",
+		"typebox": "1.3.11",
 		"typescript": "7.0.2"
 	},
 	"repository": {


### PR DESCRIPTION
## Summary

- declare `@earendil-works/pi-coding-agent` and `typebox` as host-provided `peerDependencies` for pi-lsp
- keep exact development versions for typechecking and tests
- remove the duplicate TypeBox runtime dependency
- add a patch Changeset for `@narumitw/pi-lsp`

## Verification

- `npm ci`
- `npm run check` (2,382 tests passed)
- `just pack lsp`
- `npm run changeset:status`
