### PR TITLE
feat(chat): add experimental peer-to-peer developer chat

### DIFF
--- a/.changeset/fuzzy-chats-connect.md
+++ b/.changeset/fuzzy-chats-connect.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-chat": minor
+---
+
+Add the experimental Pi Chat extension for ephemeral DHT-discovered peer-to-peer developer chat.

--- a/docs/plans/archived/2026-08-07_pi-chat-persistent-room-dock-plan.md
+++ b/docs/plans/archived/2026-08-07_pi-chat-persistent-room-dock-plan.md
@@ -1,0 +1,69 @@
+# Pi Chat persistent room dock plan
+
+## Goal
+
+Make a joined Pi Chat room persistently visible while the normal Pi editor remains the default input target, and make the dedicated chat composer unmistakable without adding a global shortcut or unsupported mouse interaction.
+
+## Context
+
+The final design keeps `/chat` menu-first. A joined room gains an adaptive dock above the Pi editor, and the connected menu's first action opens a clearly labeled full custom composer. Existing direct join routes, settings, identity data, unknown fields, privacy modes, and session-owned networking remain compatible. A compact floating composer was implemented and deterministically tested, then rejected during user acceptance as harder to use and replaced with the prior full-view presentation.
+
+## Architecture
+
+- `widget.ts` owns responsive read-only dock rendering and keeps legacy `count`, `latest`, and `off` modes intact while adding `dock`.
+- `chat-view.ts` owns the focused full custom composer, explicit input-target labeling, responsive transcript viewport, and externally retained draft.
+- `chat-session.ts` publishes whether the composer is open so the dock always reports the real input target.
+- `pi-chat.ts` owns session-scoped draft state, first-use display choice, full custom-view invocation, and lifecycle cleanup.
+- `menu.ts` keeps `/chat` menu-first and presents Reply as the first connected action while preserving the existing shallow controls.
+- `settings.ts` accepts the additive `dock` value and preserves old documents and unknown fields.
+
+## Non-Goals
+
+- Generic mouse hit-testing or Pi core changes.
+- A global keyboard shortcut or new focus command.
+- Auto-rejoin, persistent chat history, offline delivery, delivery receipts, or model-context integration.
+- A permanently focused or transcript-obscuring side overlay.
+
+## Risks
+
+- The dock consumes terminal rows; rendering must collapse predictably at low height and narrow width.
+- Overlay focus or disposal could leak across session replacement; every continuation must revalidate ownership and cleanup must retain no task or stale draft.
+- Showing multiple messages is a privacy change; only the new `dock` mode may do so, and legacy modes must retain their existing disclosure level.
+- A send attempted with no direct peer must retain the draft without creating a misleading delivered state.
+
+## Plan
+
+- [x] Add failing settings and first-use tests for additive `dock` support, legacy mode compatibility, atomic display/identity persistence, cancellation, and unknown-field preservation; focused run failed in three intended assertions (`dock` rejected/missing and cancelled selection still joined).
+- [x] Implement `dock` settings normalization and first-use display selection in `settings.ts` and `pi-chat.ts`; focused settings/lifecycle run passed 10 tests.
+- [x] Add failing dock rendering tests for joining, empty, connected, degraded, input-target, privacy modes, message limits, CJK/control sanitization, and representative widths/heights; focused run failed in the intended missing dock and composer-state assertions.
+- [x] Implement the adaptive persistent dock in `widget.ts` plus composer-open snapshot state in `chat-session.ts`; focused widget/session run passed 11 tests.
+- [x] Add failing composer tests for explicit target labels, retained drafts, successful clearing, zero-peer preservation, Escape/disposal focus release, IME forwarding, and narrow/low layouts; focused runs failed for the missing target label, retained draft, and view state.
+- [x] Implement the responsive full custom composer and session-owned draft integration in `chat-view.ts` and `pi-chat.ts`; focused component and custom-view lifecycle tests pass. A later red/green acceptance correction proved and removed compact overlay options while preserving the composer behavior.
+- [x] Update the connected menu's primary label/state presentation while keeping `/chat` menu-first and all existing controls/routes; menu tests failed before the change and now pass.
+- [x] Open the full chat composer immediately after a confirmed public-room join from either the menu or `/chat #slug`. A later red/green hardening pass found that closing the join menu aborted the already-started transport; startup signals are now released after startup, while cancellation during startup still tears down partial resources.
+- [x] Update `packages/pi-chat/README.md` for the dock, first-use display choice, composer workflow, no mouse/shortcut claim, responsive/privacy behavior, and one-extension local launch command; package formatting passes.
+- [x] Audit async cancellation, disposal, session replacement, shutdown, settings ordering/rollback, privacy disclosure, and narrow-terminal behavior against `docs/extension-conventions.md` and `docs/extension-settings.md`; no accepted convention deviation. The composer subscription disposes, session ownership is revalidated after awaits, drafts clear with room lifecycle, settings publish once after confirmation, and legacy privacy modes retain disclosure semantics.
+- [x] Run focused package tests repeatedly, `npm run check`, `just pack chat`, Changesets status, and a local Pi entrypoint smoke; evidence is recorded below.
+
+## Completion Checklist
+
+- [x] A joined room remains visible in every non-hidden display mode and `dock` shows bounded recent messages without obscuring the Pi transcript.
+- [x] The dock and composer always state whether input targets Pi/LLM or the room without relying on color.
+- [x] `/chat` remains the no-argument manager; Reply is first when connected; direct join routes remain compatible.
+- [x] Chat drafts survive closing/reopening and zero-peer attempts, clear only after a successful broadcast, and clear on confirmed leave/session shutdown.
+- [x] Existing `count`, `latest`, and `off` settings retain disclosure semantics; old documents and unknown fields remain valid.
+- [x] Joining, cancellation, errors, partial connectivity, responsive layouts, IME/focus, lifecycle cleanup, and destructive confirmations have deterministic evidence.
+- [x] Documentation and package contents match shipped behavior.
+- [x] Repository CI-equivalent verification is green and the completed plan is archived.
+
+## Execution Evidence
+
+- Red/green cycles: settings/first-use failed in 3 intended assertions before implementation; dock/composer state failed in 3 intended assertions; composer behavior failed in 2 intended assertions; menu behavior failed in 3 intended assertions. The public-join follow-up failed in 3 intended assertions: menu and direct routes did not open chat, and aborting the completed join action left two peers permanently undiscoverable. All focused cycles ended green.
+- Focused package suite: the original 41 tests passed three consecutive runs; the final 42-test suite, including the public-join signal regression, also passes (`node --test` over every compiled `packages/pi-chat/test/*.test.js`).
+- Package checks: `npm run check --workspace @narumitw/pi-chat` passed Biome and TypeScript.
+- Full repository: final `npm run check` passed in a temporary clean clone with 2,424 tests. The linked worktree's root Biome phase cannot include user-owned untracked `test1/` and `test2/`; those identity directories were read only for the authorized two-client smoke and were not modified or staged.
+- Package smoke: `just pack chat` passed with 15 expected files, 27.1 kB packed and 94.1 kB unpacked.
+- Release intent: `npm run changeset:status` reports `@narumitw/pi-chat` minor to `0.1.0`.
+- Entrypoint smoke: `pi -e ./packages/pi-chat --list-models` loaded successfully and returned 8 model lines.
+- Real public-DHT smoke: the two distinct identities from `test1/` and `test2/` joined `#pi` after the first join action's signal was aborted, converged to one authenticated peer each, and delivered one message end to end.
+- Manual interactive composer and mouse behavior were not exercised because the agent harness cannot open an interactive TUI. Component, Pi-context, absence-of-overlay-options, focus, IME, disposal, width, height, and lifecycle harnesses cover the supported extension path; the design intentionally claims no mouse interaction.

--- a/docs/plans/archived/2026-08-07_pi-chat-session-restore-plan.md
+++ b/docs/plans/archived/2026-08-07_pi-chat-session-restore-plan.md
@@ -1,0 +1,73 @@
+# Pi Chat session restore plan
+
+## Goal
+
+Restore the previously remembered room and input surface when Pi starts, while making `/chat` goal-oriented and preserving explicit safety for private bearer invites, destructive leave, compatibility, and settings failure recovery.
+
+## Context
+
+Pi Chat currently persists identity and display preferences but deliberately disconnects and forgets its room on every shutdown. The approved redesign removes the repeated `/chat` → join → `/chat` → reply workflow. Public rooms become remembered after their existing risk confirmation; private rooms remain one-time unless the user explicitly chooses to store the bearer invite. Runtime support remains one active room, while the additive settings shape leaves room for future multi-room support.
+
+## Architecture
+
+- `settings.ts` owns a bounded additive `resume` document containing a room catalog, active room id, and `chat`/`pi` surface. It validates stored room material by reconstructing descriptors, preserves unknown top-level and nested fields, serializes writes, and publishes atomically with private permissions.
+- `pi-chat.ts` separates explicit leave-and-forget from lifecycle disconnect, persists successful joins and user-selected surfaces, runs one generation-owned restore task on `session_start`, and retains the prior valid file/runtime state on publication failure.
+- `menu.ts` keeps related actions flat, prioritizes public join when empty, shows remembered/restoring/error state where decisions are made, and places destructive leave-and-forget last.
+- `chat-view.ts` reports intentional user return separately from host disposal so shutdown cannot overwrite a remembered `chat` surface with `pi`.
+- Public direct routes remain compatible; transcript, peers, and drafts remain ephemeral.
+
+## Non-Goals
+
+- Simultaneous multi-room networking or UI.
+- Persisted transcript, messages, peer lists, unread counts, or drafts.
+- Offline delivery, automatic infinite reconnect, cross-process room coordination, mouse interaction, or new textual subcommands.
+
+## Risks
+
+- Automatically restoring a remembered room creates network activity at startup; only previously confirmed and successfully persisted rooms may restore.
+- A stored private invite is a bearer secret; persistence requires an explicit concrete warning and `Join and remember` choice.
+- Session replacement or shutdown can race restore, persistence, or custom UI creation; every continuation must revalidate generation and all owned tasks must abort and drain.
+- Navigation state and shutdown disposal are different events; only intentional user return may change the remembered surface to `pi`.
+- Multiple Pi processes sharing one agent directory remain last-successful-writer-wins, matching the existing documented in-process settings ordering scope.
+
+## Rollback / Recovery
+
+- Old files without `resume` remain valid and produce no startup network activity.
+- Restore failures keep the remembered room and expose retry/forget recovery without rewriting settings.
+- A failed join-state publication tears down the candidate room and leaves the prior valid document unchanged.
+- Explicit leave clears remembered state atomically before disconnecting; publication failure leaves the current room connected and remembered.
+- Private `Join once` never writes room material.
+
+## Plan
+
+- [x] Add failing settings tests for public/private remembered rooms, active-room consistency, bounded catalogs, legacy documents, nested unknown-field preservation, field removal, invalid-file protection, ordered writes, and private permissions; TypeScript first failed on the missing model/API, then all 9 focused settings tests passed with the additive `resume` model and mutation protocol.
+- [x] Add failing chat-view tests that distinguish intentional Escape/Ctrl+C return from host disposal and remain focus/IME/width safe; TypeScript failed on the missing callback, then all 6 component tests passed with `onReturnToPi` emitted only by user close.
+- [x] Add failing lifecycle tests for successful public persistence, direct/menu auto-open, private join-once versus join-and-remember previews, publication rollback, leave-and-forget rollback, and unchanged direct-route compatibility; focused failures covered missing persistence/restore and rollback injection, and the final 14 lifecycle tests pass.
+- [x] Add failing startup tests for no saved room, remembered `chat` and `pi` surfaces, waiting peers, restore failure/retry, invalid settings, session replacement, shutdown cancellation, and no stale UI; the generation-owned restore flow now aborts/drains network, persistence, and composer work, and focused lifecycle/widget tests pass.
+- [x] Update menu tests and `menu.ts` so disconnected users see public join first, connected state and restart behavior are visible, destructive leave-and-forget is last, and recovery remains shallow with clear Back/Cancel/Close behavior; all 5 focused menu tests pass.
+- [x] Update `packages/pi-chat/README.md` with restart behavior, concrete public/private persistence semantics, the additive example, recovery states, lifecycle behavior, compatibility, and ephemeral-data boundaries; package formatting passes.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md` for cancellation, disposal, session replacement, shutdown, write ordering/failure recovery, invalid-file protection, unknown-field preservation, privacy disclosure, TUI focus, and responsive rendering; all owned restore/composer/persistence tasks abort and drain, every post-await continuation revalidates ownership, and no convention deviation was accepted. Cross-process settings remain explicitly last-successful-writer-wins, matching the existing documented scope.
+- [x] Run the full focused Pi Chat suite repeatedly, a two-identity public-DHT restore smoke, `npm run check` in a clean clone, `just pack chat`, Changesets status, and the Pi entrypoint smoke; exact evidence is recorded below.
+
+## Completion Checklist
+
+- [x] Restarting Pi restores a remembered public room without user commands and opens chat only when the last intentional surface was chat.
+- [x] Private invites are persisted only after an explicit bearer-secret preview; Join once and cancellation perform no room-state write.
+- [x] Old settings and unknown fields remain valid; invalid or failed writes preserve the previous file and effective runtime state.
+- [x] Restore loading, waiting, success, degraded, error, retry, disabled/empty, cancellation, replacement, and shutdown states have deterministic evidence.
+- [x] `/chat` remains menu-first with compatible direct routes, goal-prioritized flat actions, visible consequential state, and destructive actions last.
+- [x] Keyboard focus, IME, non-color text cues, narrow/low layouts, Back/Cancel/Close, and disposal behavior remain covered.
+- [x] Documentation and packed package contents match the final behavior.
+- [x] Repository CI-equivalent verification is green and this completed plan is archived.
+
+## Execution Evidence
+
+- TDD: settings first failed at TypeScript on the missing resume model/API; surface restoration failed by timeout; startup restoration and rollback tests failed on missing persistence/behavior before implementation. Each slice ended green.
+- Focused package suite: all 57 Pi Chat tests passed three consecutive final runs, including settings, menus, public/private persistence, restore/retry, replacement, stale shutdown, owner abort, responsive composer/dock, local DHT, and separate-process DHT coverage.
+- Package gate: `npm run check --workspace @narumitw/pi-chat` passed Biome and TypeScript.
+- Repository gate: final `npm run check` passed in a temporary clean clone with 2,439 tests.
+- Real public-DHT restore smoke: two distinct read-only identities from `test1/` and `test2/` restored the same saved public room through extension `session_start`, automatically opened two composers, converged to one authenticated peer each, and delivered a message end to end. User-owned identity directories were not modified or staged.
+- Package smoke: `just pack chat` passed with 15 expected files, 30.9 kB packed and 111.7 kB unpacked.
+- Release intent: `npm run changeset:status` reports `@narumitw/pi-chat` minor to `0.1.0` through `.changeset/fuzzy-chats-connect.md`.
+- Entrypoint smoke: `pi -e ./packages/pi-chat --list-models` loaded successfully and returned 8 model lines.
+- Manual physical TUI and cross-NAT startup restore were not available. Component, Pi-context, lifecycle, local public-DHT, width/height, focus, IME, cancellation, disposal, and clean-clone harnesses cover the supported path; no mouse or native screen-reader API is claimed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1827,6 +1827,23 @@
 				}
 			}
 		},
+		"node_modules/@hyperswarm/secret-stream": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@hyperswarm/secret-stream/-/secret-stream-6.9.1.tgz",
+			"integrity": "sha512-xb0S5y3YJwBakD77JOGBHlBxdp63mHClZoXBYoLv+9wH8e054ESKlmQptWqjJK5dv5VMUIVYOJB4MaOpB0JdGw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.1.0",
+				"hypercore-crypto": "^3.3.1",
+				"noise-curve-ed": "^2.0.1",
+				"noise-handshake": "^4.0.0",
+				"sodium-secretstream": "^1.1.0",
+				"sodium-universal": "^5.0.0",
+				"streamx": "^2.14.0",
+				"timeout-refresh": "^2.0.0",
+				"unslab": "^1.3.0"
+			}
+		},
 		"node_modules/@img/colour": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -2498,6 +2515,10 @@
 		},
 		"node_modules/@narumitw/pi-caffeinate": {
 			"resolved": "packages/pi-caffeinate",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-chat": {
+			"resolved": "packages/pi-chat",
 			"link": true
 		},
 		"node_modules/@narumitw/pi-chrome-devtools": {
@@ -4967,6 +4988,15 @@
 				"node": ">=16.20.0"
 			}
 		},
+		"node_modules/adaptive-timeout": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/adaptive-timeout/-/adaptive-timeout-1.0.1.tgz",
+			"integrity": "sha512-+seGiBtHqbnyZ0Quq/ZGxxwP66153WBABawa07/QeyuPFzbduPBjiGQAyCiriiLDzt3dkbMBskSlfqtRwblK8Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"xache": "^1.2.1"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -5038,6 +5068,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -5046,6 +5090,175 @@
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/bare-addon-resolve": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+			"integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-module-resolve": "^1.10.0",
+				"bare-semver": "^1.0.0"
+			},
+			"peerDependencies": {
+				"bare-url": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-url": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-ansi-escapes": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+			"integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-stream": "^2.6.5"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-assert": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+			"integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-inspect": "^3.1.2"
+			}
+		},
+		"node_modules/bare-events": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+			"integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"bare-abort-controller": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-fs": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
+			"integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4",
+				"bare-url": "^2.2.2",
+				"fast-fifo": "^1.3.2"
+			},
+			"engines": {
+				"bare": ">=1.28.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-inspect": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+			"integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-ansi-escapes": "^2.1.0",
+				"bare-type": "^1.0.0"
+			},
+			"engines": {
+				"bare": ">=1.18.0"
+			}
+		},
+		"node_modules/bare-module-resolve": {
+			"version": "1.12.4",
+			"resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+			"integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-semver": "^1.0.0"
+			},
+			"peerDependencies": {
+				"bare-url": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-url": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+			"integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/bare-semver": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+			"integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/bare-stream": {
+			"version": "2.13.3",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+			"integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.8.1",
+				"streamx": "^2.25.0",
+				"teex": "^1.0.1"
+			},
+			"peerDependencies": {
+				"bare-abort-controller": "*",
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+			"integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"bare": ">=1.2.0"
+			}
+		},
+		"node_modules/bare-url": {
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.7.tgz",
+			"integrity": "sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-path": "^3.0.0"
 			}
 		},
 		"node_modules/base64-js": {
@@ -5092,11 +5305,46 @@
 				"node": "*"
 			}
 		},
+		"node_modules/bits-to-bytes": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/bits-to-bytes/-/bits-to-bytes-1.3.0.tgz",
+			"integrity": "sha512-OJoHTpFXS9bXHBCekGTByf3MqM8CGblBDIduKQeeVVeiU9dDWywSSirXIBYGgg3d1zbVuvnMa1vD4r6PA0kOKg==",
+			"license": "ISC",
+			"dependencies": {
+				"b4a": "^1.5.0"
+			}
+		},
+		"node_modules/blind-relay": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/blind-relay/-/blind-relay-1.6.1.tgz",
+			"integrity": "sha512-38YmKCl/m9NcTkwueBbcGIt9Zx3IT/Q9Nsluu6C5Gur6PqfE0zWPhPwCzia1hri/g0ICYxrqkgLtEaoWD5WeSQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"bare-events": "^2.2.0",
+				"bits-to-bytes": "^1.3.0",
+				"compact-encoding": "^3.0.0",
+				"compact-encoding-bitfield": "^1.0.0",
+				"protomux": "^3.5.1",
+				"sodium-universal": "^5.0.0",
+				"streamx": "^2.15.1"
+			}
+		},
 		"node_modules/bmp-js": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
 			"integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
 			"license": "MIT"
+		},
+		"node_modules/bogon": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/bogon/-/bogon-1.3.0.tgz",
+			"integrity": "sha512-04tu0G/v0f2HPuQlSfhO635WwHDBCaITJ490rhxH9ttUlgPqOirZVKV02YB6NvPf5VkmbqJCm3bnZwrPk/eDSg==",
+			"license": "MIT",
+			"dependencies": {
+				"compact-encoding": "^3.0.0",
+				"compact-encoding-net": "^1.2.0"
+			}
 		},
 		"node_modules/bowser": {
 			"version": "2.14.1",
@@ -5163,6 +5411,33 @@
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
 			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
 			"license": "MIT"
+		},
+		"node_modules/compact-encoding": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.3.0.tgz",
+			"integrity": "sha512-e64XyzlBvTRJ3iScuU/U2w25Dglkm7fhrRbrGaHIwuTlNnzjRKMaQBCVl7mJRvZg7wI5a9wX1IVTXCuaAANNkw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.3.0"
+			}
+		},
+		"node_modules/compact-encoding-bitfield": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/compact-encoding-bitfield/-/compact-encoding-bitfield-1.1.0.tgz",
+			"integrity": "sha512-F6wliSKHi50BsBStmnsRJAzJgYSIYzdfSe3M0oHj4uQ1RcctJK/NQVD7wF51bj/DBMne2i5gUxrGUFkNZQns5w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"compact-encoding": "^3.0.0"
+			}
+		},
+		"node_modules/compact-encoding-net": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/compact-encoding-net/-/compact-encoding-net-1.3.0.tgz",
+			"integrity": "sha512-HIYjL3aMiSENApR691aMLngXt6rkTHb9HUkEukcx3YwIZpoMUVXHXyjBzoo9kVwC7KakooBA1RRWb46Cu6qtAQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"compact-encoding": "^3.0.0"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -5238,6 +5513,26 @@
 			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
 			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
 			"license": "MIT"
+		},
+		"node_modules/dht-rpc": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-6.27.0.tgz",
+			"integrity": "sha512-NsfgRlFDQnkA2+H+hJXMPLmBOn/TSIIc0cRMV8q42M4xc1uAXWtpvIIQsONF5tYcYC6px0bslrUGideN1h4S4A==",
+			"license": "MIT",
+			"dependencies": {
+				"adaptive-timeout": "^1.0.1",
+				"b4a": "^1.6.1",
+				"bare-events": "^2.2.0",
+				"compact-encoding": "^3.0.0",
+				"compact-encoding-net": "^1.2.0",
+				"fast-fifo": "^1.1.0",
+				"kademlia-routing-table": "^1.0.1",
+				"nat-sampler": "^1.0.1",
+				"sodium-universal": "^5.0.0",
+				"streamx": "^2.13.2",
+				"time-ordered-set": "^2.0.0",
+				"udx-native": "^1.5.3"
+			}
 		},
 		"node_modules/diff": {
 			"version": "8.0.4",
@@ -5342,6 +5637,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/events-universal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.7.0"
+			}
+		},
 		"node_modules/extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5354,6 +5658,12 @@
 			"resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
 			"integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
@@ -5530,6 +5840,21 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/generate-object-property": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz",
+			"integrity": "sha512-KwuURPyqn2Mz8DdV29pJwQu0Y7tcsbkULr82eeOcY/ZllFK6I9Wm8dsRByIu7CKWlFi9BdW1b3mcXMp/kQBQsw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-property": "^1.0.0"
+			}
+		},
+		"node_modules/generate-string": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/generate-string/-/generate-string-1.0.1.tgz",
+			"integrity": "sha512-IfTY0dKZM43ACyGvXkbG7De7WY7MxTS5VO6Juhe8oJKpCmrYYXoqp/cJMskkpi0k9H8wuXq0H+eI898/BCqvXg==",
+			"license": "MIT"
 		},
 		"node_modules/get-east-asian-width": {
 			"version": "1.6.0",
@@ -5748,6 +6073,94 @@
 				"url": "https://github.com/sponsors/typicode"
 			}
 		},
+		"node_modules/hypercore-crypto": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.7.0.tgz",
+			"integrity": "sha512-SWxobptQf2V/+ZLCCDRTXqFzGfTPIkNIuDyLKXpEMfcpJ1/ec94N9aWgylHcWOHmRt14ng/KR7z0BugebWHK9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.6",
+				"compact-encoding": "^3.0.0",
+				"sodium-universal": "^5.0.0"
+			}
+		},
+		"node_modules/hypercore-id-encoding": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/hypercore-id-encoding/-/hypercore-id-encoding-1.3.0.tgz",
+			"integrity": "sha512-W6sHdGo5h7LXEsoWfKf/KfuROZmZRQDlGqJF2EPHW+noCK66Vvr0+zE6cL0vqQi18s0kQPeN7Sq3QyR0Ytc2VQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.5.3",
+				"z32": "^1.0.0"
+			}
+		},
+		"node_modules/hyperdht": {
+			"version": "6.33.0",
+			"resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.33.0.tgz",
+			"integrity": "sha512-veSvVKptjPTu2di3q5IWI62ZDFzEmTj1QSTAkiXW/cg0+lgMUlwfVWB4dX+WI14xNb54vogVIjA/Ph3KiVuRJQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@hyperswarm/secret-stream": "^6.6.2",
+				"b4a": "^1.3.1",
+				"bare-events": "^2.2.0",
+				"blind-relay": "^1.3.0",
+				"bogon": "^1.0.0",
+				"compact-encoding": "^3.0.0",
+				"dht-rpc": "^6.15.1",
+				"hypercore-crypto": "^3.3.0",
+				"hypercore-id-encoding": "^1.2.0",
+				"hyperdht-address": "^1.0.1",
+				"noise-curve-ed": "^2.0.0",
+				"noise-handshake": "^4.0.0",
+				"record-cache": "^1.1.1",
+				"safety-catch": "^1.0.1",
+				"signal-promise": "^1.0.3",
+				"sodium-universal": "^5.0.1",
+				"streamx": "^2.16.1",
+				"unslab": "^1.3.0",
+				"xache": "^1.1.0"
+			},
+			"bin": {
+				"hyperdht": "bin.js"
+			}
+		},
+		"node_modules/hyperdht-address": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/hyperdht-address/-/hyperdht-address-1.1.1.tgz",
+			"integrity": "sha512-Mu/+7SW2cwvHxMXswa5mOrhrS5BJyntViAuB25k8d8wNtA8eAPs4LaIq6TwN1SS/KQY02h1r+gM8cQeN/k360w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"compact-encoding": "^3.0.0",
+				"hyperschema": "^1.20.1"
+			}
+		},
+		"node_modules/hyperschema": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.22.0.tgz",
+			"integrity": "sha512-h4D00e+tVyT4cDcb68p7ioaQxphBN5UOtiZVQv6RDPdtaKHLdngUWVoG/PL+RJvw/AS/OdZpiReGpLhx9pDHWg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-fs": "^4.0.1",
+				"compact-encoding": "^3.0.0",
+				"generate-object-property": "^2.0.0",
+				"generate-string": "^1.0.1"
+			}
+		},
+		"node_modules/hyperswarm": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.17.0.tgz",
+			"integrity": "sha512-oe86sK961Ueg7rvDN/veFwG8xH+Iv6vObPhGDkPJcDVxk/NduW41ZhAcVDnHzRbm7S0eLU7WaDUvehOYoKSpRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.3.1",
+				"bare-events": "^2.2.0",
+				"hyperdht": "^6.21.0",
+				"safety-catch": "^1.0.2",
+				"shuffled-priority-queue": "^2.1.0",
+				"streamx": "^2.22.1",
+				"unslab": "^1.3.0"
+			}
+		},
 		"node_modules/iconv-lite": {
 			"version": "0.7.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
@@ -5807,6 +6220,12 @@
 			"engines": {
 				"node": ">=0.12.0"
 			}
+		},
+		"node_modules/is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+			"license": "MIT"
 		},
 		"node_modules/is-subdir": {
 			"version": "1.2.0",
@@ -5940,6 +6359,15 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/kademlia-routing-table": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/kademlia-routing-table/-/kademlia-routing-table-1.0.6.tgz",
+			"integrity": "sha512-Ve6jwIlUCYvUzBnXnzVRHDZCFgXURW9gmF3r7n05kZs/2rNbLHXwGdcq0qIaSwdmJCvtosgR4JensnVU65hzNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bare-events": "^2.2.0"
+			}
+		},
 		"node_modules/libheif-js": {
 			"version": "1.19.8",
 			"resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.19.8.tgz",
@@ -6066,6 +6494,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/nanoassert": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+			"integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+			"license": "ISC"
+		},
+		"node_modules/nat-sampler": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/nat-sampler/-/nat-sampler-1.0.1.tgz",
+			"integrity": "sha512-yQvyNN7xbqR8crTKk3U8gRgpcV1Az+vfCEijiHu9oHHsnIl8n3x+yXNHl42M6L3czGynAVoOT9TqBfS87gDdcw==",
+			"license": "MIT"
+		},
 		"node_modules/node-domexception": {
 			"name": "@profoundlogic/node-domexception",
 			"version": "1.0.2",
@@ -6091,6 +6531,28 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/noise-curve-ed": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/noise-curve-ed/-/noise-curve-ed-2.1.0.tgz",
+			"integrity": "sha512-zAzJx+VwZM3w6EA1hTmDhJfvAnCeBQn/1FAeZ0LtGxCcCtlAK/uJXQVF/eDVUOaAZ286lHlx77WJ+qj9SmsRRg==",
+			"license": "ISC",
+			"dependencies": {
+				"b4a": "^1.1.0",
+				"nanoassert": "^2.0.0",
+				"sodium-universal": "^5.0.0"
+			}
+		},
+		"node_modules/noise-handshake": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/noise-handshake/-/noise-handshake-4.2.0.tgz",
+			"integrity": "sha512-9O/VTNX/E2/AToyMTTDU0J/4WhaXMTdqc2DHs9vf+snoZ0cenSBq0dNYTVV1snYYEkmo6QeRrYMxtqtoYnY+LA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.1.0",
+				"nanoassert": "^2.0.0",
+				"sodium-universal": "^5.0.0"
 			}
 		},
 		"node_modules/npm-check-updates": {
@@ -6382,6 +6844,19 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/protomux": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/protomux/-/protomux-3.11.0.tgz",
+			"integrity": "sha512-Ze43XaNHbL6zQ/zJwVYvue7Aj8pDB1HNnISsrFhAur3291Y+Iu2fMhOpySD73J/32BoBIUYrhl07lJsBR/fUVA==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.3.1",
+				"compact-encoding": "^3.0.0",
+				"queue-tick": "^1.0.0",
+				"safety-catch": "^1.0.1",
+				"unslab": "^1.3.0"
+			}
+		},
 		"node_modules/quansync": {
 			"version": "0.2.11",
 			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -6418,6 +6893,12 @@
 					"url": "https://feross.org/support"
 				}
 			],
+			"license": "MIT"
+		},
+		"node_modules/queue-tick": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+			"integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
 			"license": "MIT"
 		},
 		"node_modules/radix-ui": {
@@ -6627,6 +7108,27 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/record-cache": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
+			"integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.3.1"
+			}
+		},
+		"node_modules/require-addon": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+			"integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-addon-resolve": "^1.3.0"
+			},
+			"engines": {
+				"bare": ">=1.10.0"
+			}
+		},
 		"node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -6708,6 +7210,12 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/safety-catch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.3.tgz",
+			"integrity": "sha512-Zq+J1TefpoEq/HTUabo0YXX5MNvttjWYODGohgPBO2jfko8Wqx3JYMgE823szDFVamdH5PlpByvfiWScTdSYDA==",
 			"license": "MIT"
 		},
 		"node_modules/scheduler": {
@@ -6800,11 +7308,26 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/shuffled-priority-queue": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/shuffled-priority-queue/-/shuffled-priority-queue-2.1.0.tgz",
+			"integrity": "sha512-xhdh7fHyMsr0m/w2kDfRJuBFRS96b9l8ZPNWGaQ+PMvnUnZ/Eh+gJJ9NsHBd7P9k0399WYlCLzsy18EaMfyadA==",
+			"license": "MIT",
+			"dependencies": {
+				"unordered-set": "^2.0.1"
+			}
+		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"license": "ISC"
+		},
+		"node_modules/signal-promise": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/signal-promise/-/signal-promise-1.0.3.tgz",
+			"integrity": "sha512-WBgv0UnIq2C+Aeh0/n+IRpP6967eIx9WpynTUoiW3isPpfe1zu2LJzyfXdo9Tgef8yR/sGjcMvoUXD7EYdiz+g==",
+			"license": "MIT"
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -6826,6 +7349,47 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/cyyynthia"
+			}
+		},
+		"node_modules/sodium-native": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+			"integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
+			"license": "MIT",
+			"dependencies": {
+				"bare-assert": "^1.2.0",
+				"require-addon": "^1.1.0",
+				"which-runtime": "^1.2.1"
+			},
+			"engines": {
+				"bare": ">=1.16.0"
+			}
+		},
+		"node_modules/sodium-secretstream": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/sodium-secretstream/-/sodium-secretstream-1.2.0.tgz",
+			"integrity": "sha512-q/DbraNFXm1KfCiiZvapmz5UC3OlpirYFIvBK2MhGaOFSb3gRyk8OXTi17UI9SGfshQNCpsVvlopogbzZNyW6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.1.1",
+				"sodium-universal": "^5.0.0"
+			}
+		},
+		"node_modules/sodium-universal": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-5.0.1.tgz",
+			"integrity": "sha512-rv+aH+tnKB5H0MAc2UadHShLMslpJsc4wjdnHRtiSIEYpOetCgu8MS4ExQRia+GL/MK3uuCyZPeEsi+J3h+Q+Q==",
+			"license": "MIT",
+			"dependencies": {
+				"sodium-native": "^5.0.1"
+			},
+			"peerDependencies": {
+				"sodium-javascript": "~0.8.0"
+			},
+			"peerDependenciesMeta": {
+				"sodium-javascript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/spawndamnit": {
@@ -6858,6 +7422,17 @@
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/streamx": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+			"integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+			"license": "MIT",
+			"dependencies": {
+				"events-universal": "^1.0.0",
+				"fast-fifo": "^1.3.2",
+				"text-decoder": "^1.1.0"
+			}
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
@@ -6897,6 +7472,15 @@
 				"anynum": "^1.0.1"
 			}
 		},
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+			"license": "MIT",
+			"dependencies": {
+				"streamx": "^2.12.5"
+			}
+		},
 		"node_modules/term-size": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -6909,6 +7493,27 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/text-decoder": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+			"integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.4"
+			}
+		},
+		"node_modules/time-ordered-set": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/time-ordered-set/-/time-ordered-set-2.0.1.tgz",
+			"integrity": "sha512-VJEKmgSN2UiOLB8BpN8Sh2b9LGMHTP5OPrQRpnKjvOheOyzk0mufbjzjKTIG2gO4A+Y+vDJ+0TcLbpUmMLsg8A==",
+			"license": "MIT"
+		},
+		"node_modules/timeout-refresh": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-2.0.1.tgz",
+			"integrity": "sha512-SVqEcMZBsZF9mA78rjzCrYrUs37LMJk3ShZ851ygZYW1cMeIjs9mL57KO6Iv5mmjSQnOe/29/VAfGXo+oRCiVw==",
+			"license": "MIT"
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -6978,6 +7583,21 @@
 				"@typescript/typescript-win32-x64": "7.0.2"
 			}
 		},
+		"node_modules/udx-native": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.21.0.tgz",
+			"integrity": "sha512-54GMSqSJyc+NLALQLGWpkxQcTYmW/MNU5aYugrv+FR+f2nb7kfUJlstKBiaIM4iYg71b9VSxHrA1g8vBA9HPTw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.5.0",
+				"bare-events": "^2.2.0",
+				"require-addon": "^1.1.0",
+				"streamx": "^2.22.0"
+			},
+			"engines": {
+				"bare": ">=1.17.4"
+			}
+		},
 		"node_modules/undici": {
 			"version": "8.9.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
@@ -7003,6 +7623,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/unordered-set": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz",
+			"integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==",
+			"license": "MIT"
+		},
+		"node_modules/unslab": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/unslab/-/unslab-1.3.0.tgz",
+			"integrity": "sha512-YATkfKAFj47kTzmiQrWXMyRvaVrHsW6MEALa4bm+FhiA2YG4oira+Z3DXN6LrYOYn2Y8eO94Lwl9DOHjs1FpoQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.6"
 			}
 		},
 		"node_modules/use-callback-ref": {
@@ -7074,6 +7709,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/which-runtime": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+			"integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/ws": {
 			"version": "8.21.1",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
@@ -7095,6 +7736,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/xache": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/xache/-/xache-1.3.0.tgz",
+			"integrity": "sha512-ekAknjLTiyXJcuezqwa/cOMfFenVVY2toL4J7D3AfTn7UEDYb8JSgRnv3CK8khF7u38XZ4NjS1MXEw4RwqJ4oA==",
+			"license": "MIT"
 		},
 		"node_modules/xml-naming": {
 			"version": "0.3.0",
@@ -7124,6 +7771,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/z32": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/z32/-/z32-1.1.0.tgz",
+			"integrity": "sha512-1WUHy+VS6d0HPNspDxvLssBbeQjXMjSnpv0vH82vRAUfg847NmX3OXozp/hRP5jPhxBbrVzrgvAt+UsGNzRFQQ==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.5.3"
 			}
 		},
 		"node_modules/zod": {
@@ -7218,6 +7874,27 @@
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*"
+			}
+		},
+		"packages/pi-chat": {
+			"name": "@narumitw/pi-chat",
+			"version": "0.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.49.1",
+				"hyperdht": "6.33.0",
+				"hyperswarm": "4.17.0"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.5.7",
+				"@earendil-works/pi-coding-agent": "0.84.1",
+				"@earendil-works/pi-tui": "0.84.1",
+				"@types/node": "26.1.2",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"packages/pi-chrome-devtools": {

--- a/packages/pi-chat/LICENSE
+++ b/packages/pi-chat/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-chat/README.md
+++ b/packages/pi-chat/README.md
@@ -1,0 +1,293 @@
+# 💬 Pi Chat — Experimental P2P Developer Chat for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-chat)](https://www.npmjs.com/package/@narumitw/pi-chat) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+> [!WARNING]
+> Pi Chat is experimental. Its protocol, identity format, networking behavior, and interaction flow
+> may change between releases. It is not an anonymous or reliable messaging service.
+
+`@narumitw/pi-chat` adds an ephemeral peer-to-peer chat room beside your Pi coding workflow. It uses
+Hyperswarm and HyperDHT to discover peers and opens encrypted Noise streams directly between them.
+Chat messages remain separate from Pi sessions, prompts, model context, repositories, and agent
+output.
+
+## ✨ Features
+
+- Creates random private rooms shared through bearer invite codes.
+- Joins guessable public rooms by lowercase slug.
+- Shows every nickname with a stable public-key fingerprint such as
+  `Mika~7K2P-9D4M-HQ3T`.
+- Keeps an adaptive joined-room dock visible above the Pi editor with explicit input-target status.
+- Opens a focused, scrollable full-size chat composer with multiline IME support.
+- Preserves chat drafts when returning to Pi or when no direct peer can accept a message.
+- Restores a remembered room and the last intentional chat/Pi surface when Pi restarts.
+- Uses authenticated direct streams and an invite-derived private-room handshake.
+- Limits peers, frames, messages, transcript entries, reconnect work, and per-peer message rates.
+- Keeps identity settings local with private permissions and atomic publication.
+- Cleans up discovery, sockets, timers, status, and widgets on leave, reload, session replacement,
+  or shutdown.
+
+## 📦 Install
+
+Install persistently after the package is published:
+
+```bash
+pi install npm:@narumitw/pi-chat
+```
+
+Try from npm without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-chat
+```
+
+Try the extension from a local checkout:
+
+```bash
+pi --no-extensions --no-skills --no-session -e ./packages/pi-chat
+```
+
+Load the package only once per Pi process. Repeating `-e ./packages/pi-chat` creates duplicate
+extension instances and suffixed commands such as `/chat:1` and `/chat:2`.
+
+Pi extensions execute with your user permissions. Review source before installing third-party
+packages.
+
+## 🚀 Quick start
+
+Run:
+
+```text
+/chat
+```
+
+Then choose one of these actions:
+
+- **Join public room** accepts a lowercase slug such as `pi-dev`, remembers it after the public-room
+  warning is confirmed, and opens the chat composer.
+- **Join with invite** accepts a private-room invite, then offers **Join and remember**, **Join once**,
+  or **Cancel** before networking starts.
+- **Create private room** generates a random `pichat:v1:…` bearer invite and uses the same explicit
+  persistence choice.
+
+The first join asks for a nickname and joined-room display mode, then previews the generated
+identity fingerprint and display choice before one atomic save. Pi Chat does not read your OS
+username, Git identity, cwd, repository, or Pi session to fill these values. Cancelling creates
+neither identity settings nor network activity.
+
+A successful remembered join stores the room and `chat` surface atomically. On the next Pi start,
+Pi Chat reconnects and reopens the full composer without another command. If you intentionally press
+Escape or Ctrl+C to return to Pi, it remembers the `pi` surface instead: the next start reconnects in
+the background and leaves the Pi editor focused.
+
+While connected, `/chat` opens the state-aware manager. **Open chat in <room>** is selected first,
+followed by participants, private invite, settings, status, help, and **Leave and forget room** last.
+The persistent dock continues showing room state while the normal Pi editor targets Pi/LLM.
+
+Inside the dedicated chat composer:
+
+- The header says `CHAT INPUT → <room>` so the destination is never color-only.
+- `Enter` sends the current message.
+- Pi's configured newline key inserts a newline in the composer.
+- `PageUp` and `PageDown` scroll transcript history.
+- `Escape` or `Ctrl+C` returns to Pi/LLM without leaving the room or discarding the chat draft.
+
+The composer retains the draft when no authenticated direct peer is available or a broadcast reaches
+zero peers. A successful local message reports how many authenticated direct peers accepted the
+broadcast. A disconnect race can still record an attempted message as **not delivered**; Pi Chat
+never claims delivery receipts or offline retry.
+
+## 💬 Commands
+
+| Command | Modes | Description |
+| --- | --- | --- |
+| `/chat` | TUI | Open the state-aware Pi Chat manager. |
+| `/chat <pichat:v1:invite>` | TUI | Choose private persistence, join, and open chat. |
+| `/chat #<public-slug>` | TUI | Review the warning, join, and open the chat composer directly. |
+
+RPC, print, and JSON modes reject the command before starting networking or custom TUI work.
+Unknown and trailing arguments are rejected instead of ignored.
+
+## 🪪 Identity and nicknames
+
+The display format is:
+
+```text
+nickname~7K2P-9D4M-HQ3T
+```
+
+The nickname is editable. The 12-character identity tag is the first 60 bits of the SHA-256 digest
+of the authenticated DHT public key, encoded with Crockford Base32 and grouped `4-4-4`. The complete
+public key remains the protocol identity. If short tags collide in one room, the UI can extend them;
+the short tag is never an authorization boundary.
+
+A fingerprint establishes continuity for one pseudonymous key. It does **not** prove a person's
+real-world identity, prevent a user from creating many identities, or recover trust after the local
+identity is reset or lost.
+
+Nicknames are NFKC-normalized, trimmed, and limited to 24 grapheme clusters. Terminal, C0/C1, and
+bidirectional control characters are rejected. Remote display text is sanitized again before
+wrapping or rendering.
+
+## ⚙️ Settings
+
+Pi Chat uses this user-owned file:
+
+```text
+<getAgentDir()>/pi-chat.json
+```
+
+The usual location is `~/.pi/agent/pi-chat.json`. Pi Chat does not add environment variables or read
+project-local settings because the identity material is user-owned and secret.
+
+Example with a remembered public room:
+
+```json
+{
+  "nickname": "Mika",
+  "identitySeed": "base64url-encoded-private-seed",
+  "widgetMode": "count",
+  "resume": {
+    "rooms": [
+      {
+        "id": "derived-room-id",
+        "kind": "public",
+        "slug": "pi-dev"
+      }
+    ],
+    "activeRoomId": "derived-room-id",
+    "surface": "chat"
+  }
+}
+```
+
+`resume.rooms` is a bounded catalog designed to permit future multi-room expansion. This release
+connects only `activeRoomId`. `surface` is `chat` when the user last kept the composer open and `pi`
+after an intentional return to Pi/LLM. Transcripts, drafts, peers, and unread counts are never stored.
+
+`widgetMode` accepts:
+
+- `dock`: room and input-target status plus up to three recent messages, adapting to terminal height.
+- `latest`: the existing single-message preview.
+- `count`: room, direct-peer, and unread status only, without message text.
+- `off`: hides the persistent widget.
+
+New identities choose a mode before confirmation, with **Room dock** listed first. Existing settings
+retain their stored mode; an older document without `widgetMode` continues to default to `count`, so
+an upgrade does not expose message text unexpectedly.
+
+Public rooms are remembered only after their existing risk confirmation. A private room is remembered
+only when **Join and remember** is selected; this stores its bearer invite in `pi-chat.json`.
+**Join once** stores no room material, and Cancel starts neither persistence nor networking. An older
+file without `resume` remains disconnected until the next confirmed remembered join.
+
+The identity seed and stored private invites are redacted from UI, notifications, status, and errors.
+On POSIX, settings are published with `0600` permissions. A missing file is a side-effect-free read;
+it is created only after an explicit first-use confirmation or settings change. Saves are ordered
+within one Pi process, preserve unknown top-level and nested resume fields, and use a same-directory
+temporary file plus rename. Malformed, invalid, symlinked, non-regular, invalid UTF-8, or oversized
+files fail closed and remain unchanged.
+
+**Reset identity** previews the old and candidate fingerprints and requires confirmation. Resetting
+changes your fingerprint everywhere, forgets startup restore, and leaves the active room.
+
+## 🌐 Network and protocol behavior
+
+Pi Chat uses one versioned 32-byte discovery topic per room:
+
+- A private topic and handshake key are domain-separated from a random 32-byte invite secret.
+- A public topic is deterministically derived from the public room slug.
+
+Each peer announces and looks up the topic through HyperDHT. Hyperswarm establishes authenticated,
+encrypted Noise streams. The application handshake binds the room proof, nickname, and both peer
+public keys. Messages are sent only across authenticated direct connections; they are not forwarded
+as multi-hop messages. A bounded peer-list exchange asks Hyperswarm to complete a small direct mesh.
+
+The implementation limits a room to 16 direct peers, messages to 4 KiB, protocol frames to 16 KiB,
+and the local transcript to 256 entries. There is no authoritative room membership count, global
+ordering, server history, delivery receipt, or offline delivery. The UI therefore reports only
+**direct peers**.
+
+Hyperswarm's default DHT depends on public bootstrap infrastructure. “P2P” does not mean
+infrastructure-free. NAT, UDP blocking, enterprise firewalls, bootstrap availability, or peer churn
+can prevent connectivity. Pi Chat performs bounded early refresh and reconnect work but cannot
+promise a connection on every network.
+
+## 🔒 Privacy, security, and recovery
+
+- Noise encrypts direct transport, but DHT infrastructure and direct peers may observe IP addresses,
+  timing, and topic participation metadata. Pi Chat does not provide anonymity.
+- Anyone holding a private invite can join. There is no member revocation in the initial protocol;
+  create a new room after an invite leak.
+- Public slugs are guessable. Anyone may join, record, or repost public-room content.
+- A local session mute reduces immediate abuse but does not stop Sybil identities.
+- Remote peers can save or copy messages. Leaving or clearing the local transcript cannot withdraw
+  copies from their devices.
+- Pi Chat never sends cwd, repository data, Git remotes, Pi sessions, prompts, models, files, or agent
+  output unless a user manually types that information into chat.
+- Chat messages never call Pi message APIs and never enter model context or the main transcript.
+- Deleting `pi-chat.json` loses identity continuity and produces a new fingerprint on the next
+  confirmed join.
+
+If an ordinary join fails, Pi Chat tears down partially opened discovery and sockets and preserves
+the previous valid settings. If startup restore fails, the remembered room is kept and `/chat` shows
+Retry, Join another room, and Forget recovery actions instead of retrying forever. Invalid settings
+must be fixed manually before a save can proceed.
+
+Reloading, replacing the Pi session, or shutting down still releases every session-owned network and
+UI resource. A new TUI session then restores the remembered room. Explicit **Leave and forget room**
+atomically removes resume state before disconnecting; if that save fails, the room stays connected
+and remembered with an actionable error.
+
+## 🧪 Experimental limitations
+
+The first release intentionally omits:
+
+- simultaneous multi-room connections or UI;
+- persistent or synchronized history;
+- offline messages and delivery receipts;
+- files, images, reactions, replies, editing, or deletion;
+- administrator roles, global bans, or identity recovery;
+- browser, mobile, RPC, print, or JSON chat clients;
+- large-room gossip pubsub and product-owned relay infrastructure;
+- automatic transfer of chat content into the Pi editor, transcript, or model context.
+
+The joined room uses a persistent read-only widget while the normal Pi view is active. Selecting
+**Reply in <room>** temporarily opens the full custom chat view instead of a small floating window.
+Closing it returns to Pi and the dock without leaving the room. The dock and composer reduce message
+rows before hiding room, connectivity, or input-target status.
+
+Pi's public extension widget API does not provide generic mouse hit-testing, so the dock is not
+clickable and Pi Chat registers no global shortcut. `/chat` remains the menu-first entrypoint.
+
+## 🗂️ Package layout
+
+```text
+packages/pi-chat/
+├── src/
+│   ├── index.ts
+│   ├── pi-chat.ts
+│   ├── chat-session.ts
+│   ├── network.ts
+│   ├── protocol.ts
+│   ├── identity.ts
+│   ├── settings.ts
+│   ├── menu.ts
+│   ├── chat-view.ts
+│   ├── widget.ts
+│   └── text.ts
+├── test/
+├── README.md
+├── LICENSE
+├── package.json
+└── tsconfig.json
+```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, peer-to-peer chat, P2P developer chat, Hyperswarm, HyperDHT, terminal
+chat, TypeScript Pi package.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/packages/pi-chat/package.json
+++ b/packages/pi-chat/package.json
@@ -1,0 +1,55 @@
+{
+	"name": "@narumitw/pi-chat",
+	"version": "0.0.0",
+	"description": "Experimental peer-to-peer chat extension for Pi.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"chat",
+		"p2p",
+		"dht"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"piExtension": {
+		"lifecycle": "experimental"
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.49.1",
+		"hyperdht": "6.33.0",
+		"hyperswarm": "4.17.0"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.7",
+		"@earendil-works/pi-coding-agent": "0.84.1",
+		"@earendil-works/pi-tui": "0.84.1",
+		"@types/node": "26.1.2",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "packages/pi-chat"
+	}
+}

--- a/packages/pi-chat/src/chat-session.ts
+++ b/packages/pi-chat/src/chat-session.ts
@@ -1,0 +1,436 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import type { ChatIdentity } from "./identity.js";
+import { formatIdentityLabel, normalizeNickname, uniqueIdentityTags } from "./identity.js";
+import {
+	createChatMessage,
+	createHello,
+	PeerRateLimiter,
+	type ProtocolMessage,
+	type RoomDescriptor,
+	verifyHello,
+} from "./protocol.js";
+
+const MAX_TRANSCRIPT = 256;
+const MAX_SEEN_MESSAGES = 1024;
+const MAX_PROTOCOL_VIOLATIONS = 3;
+
+export interface TransportPeer {
+	publicKey: Buffer;
+	send(message: ProtocolMessage): void;
+	close(): void;
+}
+
+export interface ChatTransportListener {
+	onPeer(peer: TransportPeer): void;
+	onMessage(peer: TransportPeer, message: ProtocolMessage): void;
+	onDisconnect(peer: TransportPeer): void;
+	onError(error: Error): void;
+}
+
+export interface ChatTransport {
+	start(listener: ChatTransportListener, signal?: AbortSignal): Promise<void>;
+	connectPeer?(publicKey: Buffer): void;
+	stop(): Promise<void>;
+}
+
+export interface TranscriptEntry {
+	id: string;
+	author: "local" | "remote";
+	label: string;
+	publicKey: string;
+	text: string;
+	sentAt: number;
+	delivery?: "broadcast" | "not-delivered";
+	deliveredTo?: number;
+}
+
+export interface ParticipantSnapshot {
+	publicKey: string;
+	label: string;
+	nickname: string;
+	muted: boolean;
+}
+
+export interface ChatSnapshot {
+	state: "connecting" | "connected" | "degraded" | "disconnected";
+	room: RoomDescriptor;
+	localLabel: string;
+	peers: ParticipantSnapshot[];
+	transcript: TranscriptEntry[];
+	unread: number;
+	composerOpen: boolean;
+	lastError?: string;
+}
+
+export interface ChatSessionOptions {
+	room: RoomDescriptor;
+	identity: ChatIdentity;
+	nickname: string;
+	transport: ChatTransport;
+	now?: () => number;
+	onChange?: (snapshot: ChatSnapshot) => void;
+}
+
+interface PeerState {
+	peer: TransportPeer;
+	authenticated: boolean;
+	nickname?: string;
+	muted: boolean;
+	violations: number;
+	limiter: PeerRateLimiter;
+}
+
+export class ChatSession {
+	private readonly room: RoomDescriptor;
+	private readonly identity: ChatIdentity;
+	private nickname: string;
+	private readonly transport: ChatTransport;
+	private readonly now: () => number;
+	private readonly onChange?: (snapshot: ChatSnapshot) => void;
+	private readonly peers = new Map<string, PeerState>();
+	private readonly transcript: TranscriptEntry[] = [];
+	private readonly seen = new Set<string>();
+	private readonly seenOrder: string[] = [];
+	private readonly listeners = new Set<(snapshot: ChatSnapshot) => void>();
+	private state: ChatSnapshot["state"] = "disconnected";
+	private unread = 0;
+	private viewOpen = false;
+	private lastError: string | undefined;
+	private generation = 0;
+	private leavePromise: Promise<void> | undefined;
+
+	constructor(options: ChatSessionOptions) {
+		const nickname = normalizeNickname(options.nickname);
+		if (!nickname) throw new Error("Pi Chat nickname is invalid.");
+		this.room = options.room;
+		this.identity = options.identity;
+		this.nickname = nickname;
+		this.transport = options.transport;
+		this.now = options.now ?? Date.now;
+		this.onChange = options.onChange;
+	}
+
+	async start(signal?: AbortSignal): Promise<void> {
+		if (this.state !== "disconnected" || this.leavePromise) {
+			throw new Error("Pi Chat session has already started.");
+		}
+		const owner = ++this.generation;
+		this.state = "connecting";
+		this.emit();
+		try {
+			await this.transport.start(
+				{
+					onPeer: (peer) => this.onPeer(owner, peer),
+					onMessage: (peer, message) => this.onMessage(owner, peer, message),
+					onDisconnect: (peer) => this.onDisconnect(owner, peer),
+					onError: (error) => this.onError(owner, error),
+				},
+				signal,
+			);
+			signal?.throwIfAborted();
+			if (owner !== this.generation) return;
+			this.state = "connected";
+			this.emit();
+		} catch (error) {
+			if (owner === this.generation) {
+				this.state = "disconnected";
+				this.lastError = safeError(error);
+				this.emit();
+			}
+			await this.transport.stop().catch(() => undefined);
+			throw error;
+		}
+	}
+
+	send(text: string): { id: string; deliveredTo: number } {
+		if (this.state !== "connected" && this.state !== "degraded") {
+			throw new Error("Pi Chat is not connected.");
+		}
+		const id = randomUUID();
+		const message = createChatMessage(text, this.now(), id);
+		let deliveredTo = 0;
+		for (const state of this.peers.values()) {
+			if (!state.authenticated || state.muted) continue;
+			try {
+				state.peer.send(message);
+				deliveredTo += 1;
+			} catch {
+				state.violations += 1;
+			}
+		}
+		this.pushTranscript({
+			id,
+			author: "local",
+			label: formatIdentityLabel(this.nickname, this.identity.publicKey),
+			publicKey: this.identity.publicKey.toString("hex"),
+			text,
+			sentAt: message.sentAt,
+			delivery: deliveredTo > 0 ? "broadcast" : "not-delivered",
+			deliveredTo,
+		});
+		this.emit();
+		return { id, deliveredTo };
+	}
+
+	updateNickname(value: string): void {
+		const nickname = normalizeNickname(value);
+		if (!nickname) throw new Error("Pi Chat nickname is invalid.");
+		this.nickname = nickname;
+		for (const state of this.peers.values()) {
+			if (!state.authenticated) continue;
+			try {
+				state.peer.send({ v: 1, type: "nickname-update", nickname });
+			} catch {
+				state.violations += 1;
+			}
+		}
+		this.emit();
+	}
+
+	mute(publicKey: Uint8Array): void {
+		const state = this.peers.get(keyId(publicKey));
+		if (!state) return;
+		state.muted = true;
+		this.emit();
+	}
+
+	toggleMute(publicKey: Uint8Array): boolean | undefined {
+		const state = this.peers.get(keyId(publicKey));
+		if (!state?.authenticated) return undefined;
+		state.muted = !state.muted;
+		this.emit();
+		return state.muted;
+	}
+
+	subscribe(listener: (snapshot: ChatSnapshot) => void): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	setViewOpen(open: boolean): void {
+		if (this.viewOpen === open) return;
+		this.viewOpen = open;
+		if (open) this.unread = 0;
+		this.emit();
+	}
+
+	leave(): Promise<void> {
+		if (this.leavePromise) return this.leavePromise;
+		this.leavePromise = this.leaveOwned();
+		return this.leavePromise;
+	}
+
+	snapshot(): ChatSnapshot {
+		const authenticated: Array<[string, PeerState, string]> = [];
+		for (const [publicKey, value] of this.peers) {
+			if (value.authenticated && value.nickname) {
+				authenticated.push([publicKey, value, value.nickname]);
+			}
+		}
+		const tags = uniqueIdentityTags([
+			this.identity.publicKey,
+			...authenticated.map(([, value]) => value.peer.publicKey),
+		]);
+		const localKey = this.identity.publicKey.toString("hex");
+		const peers = authenticated
+			.map(([publicKey, value, nickname]) => ({
+				publicKey,
+				nickname,
+				label: `${nickname}~${tags.get(publicKey) ?? formatIdentityLabel(nickname, value.peer.publicKey).split("~").at(-1)}`,
+				muted: value.muted,
+			}))
+			.sort((left, right) => left.label.localeCompare(right.label));
+		return {
+			state: this.state,
+			room: this.room,
+			localLabel: `${this.nickname}~${tags.get(localKey) ?? formatIdentityLabel(this.nickname, this.identity.publicKey).split("~").at(-1)}`,
+			peers,
+			transcript: this.transcript.map((entry) => {
+				const tag = tags.get(entry.publicKey);
+				const nickname = entry.label.split("~", 1)[0] ?? entry.label;
+				return { ...entry, label: tag ? `${nickname}~${tag}` : entry.label };
+			}),
+			unread: this.unread,
+			composerOpen: this.viewOpen,
+			...(this.lastError ? { lastError: this.lastError } : {}),
+		};
+	}
+
+	private onPeer(owner: number, peer: TransportPeer): void {
+		if (owner !== this.generation || this.state === "disconnected") {
+			peer.close();
+			return;
+		}
+		const id = keyId(peer.publicKey);
+		const previous = this.peers.get(id);
+		if (previous && previous.peer !== peer) previous.peer.close();
+		const state: PeerState = {
+			peer,
+			authenticated: false,
+			muted: previous?.muted ?? false,
+			violations: 0,
+			limiter: new PeerRateLimiter({ burst: 3, refillPerSecond: 1, now: this.now }),
+		};
+		this.peers.set(id, state);
+		try {
+			peer.send(
+				createHello(
+					this.room,
+					this.nickname,
+					this.identity.publicKey,
+					peer.publicKey,
+					randomBytes(16),
+				),
+			);
+		} catch {
+			peer.close();
+			this.peers.delete(id);
+		}
+	}
+
+	private onMessage(owner: number, peer: TransportPeer, message: ProtocolMessage): void {
+		if (owner !== this.generation) return;
+		const id = keyId(peer.publicKey);
+		const state = this.peers.get(id);
+		if (!state || state.peer !== peer) return;
+		if (!state.authenticated) {
+			const hello = verifyHello(message, this.room, peer.publicKey, this.identity.publicKey);
+			if (!hello) {
+				this.violate(id, state);
+				return;
+			}
+			state.authenticated = true;
+			state.nickname = hello.nickname;
+			const knownPeers = [...this.peers.values()]
+				.filter((candidate) => candidate !== state && candidate.authenticated)
+				.map((candidate) => candidate.peer.publicKey.toString("hex"));
+			if (knownPeers.length > 0) {
+				state.peer.send({ v: 1, type: "peer-list", publicKeys: knownPeers.slice(0, 16) });
+			}
+			for (const candidate of this.peers.values()) {
+				if (candidate !== state && candidate.authenticated) {
+					candidate.peer.send({ v: 1, type: "peer-list", publicKeys: [id] });
+				}
+			}
+			this.emit();
+			return;
+		}
+		if (message.type === "hello") return;
+		if (message.type === "peer-list") {
+			for (const publicKey of message.publicKeys) {
+				if (publicKey !== this.identity.publicKey.toString("hex") && !this.peers.has(publicKey)) {
+					this.transport.connectPeer?.(Buffer.from(publicKey, "hex"));
+				}
+			}
+			return;
+		}
+		if (message.type === "goodbye") {
+			this.peers.delete(id);
+			peer.close();
+			this.emit();
+			return;
+		}
+		if (message.type === "nickname-update") {
+			const nickname = normalizeNickname(message.nickname);
+			if (!nickname) this.violate(id, state);
+			else {
+				state.nickname = nickname;
+				this.emit();
+			}
+			return;
+		}
+		if (message.type !== "chat" || state.muted) return;
+		if (!state.limiter.accept()) {
+			this.violate(id, state);
+			return;
+		}
+		const seenId = `${id}:${message.id}`;
+		if (this.seen.has(seenId)) return;
+		this.remember(seenId);
+		this.pushTranscript({
+			id: message.id,
+			author: "remote",
+			label: formatIdentityLabel(state.nickname ?? "peer", peer.publicKey),
+			publicKey: id,
+			text: message.text,
+			sentAt: message.sentAt,
+		});
+		if (!this.viewOpen) this.unread += 1;
+		this.emit();
+	}
+
+	private onDisconnect(owner: number, peer: TransportPeer): void {
+		if (owner !== this.generation) return;
+		const id = keyId(peer.publicKey);
+		if (this.peers.get(id)?.peer === peer) {
+			this.peers.delete(id);
+			this.emit();
+		}
+	}
+
+	private onError(owner: number, error: Error): void {
+		if (owner !== this.generation) return;
+		this.state = "degraded";
+		this.lastError = safeError(error);
+		this.emit();
+	}
+
+	private violate(id: string, state: PeerState): void {
+		state.violations += 1;
+		if (state.violations > MAX_PROTOCOL_VIOLATIONS) {
+			state.peer.close();
+			this.peers.delete(id);
+			this.emit();
+		}
+	}
+
+	private remember(id: string): void {
+		this.seen.add(id);
+		this.seenOrder.push(id);
+		if (this.seenOrder.length > MAX_SEEN_MESSAGES) {
+			const removed = this.seenOrder.shift();
+			if (removed) this.seen.delete(removed);
+		}
+	}
+
+	private pushTranscript(entry: TranscriptEntry): void {
+		this.transcript.push(entry);
+		if (this.transcript.length > MAX_TRANSCRIPT) this.transcript.shift();
+	}
+
+	private async leaveOwned(): Promise<void> {
+		this.generation += 1;
+		for (const state of this.peers.values()) {
+			if (state.authenticated) {
+				try {
+					state.peer.send({ v: 1, type: "goodbye" });
+				} catch {
+					// Best-effort departure notice.
+				}
+			}
+			state.peer.close();
+		}
+		this.peers.clear();
+		await this.transport.stop().catch((error) => {
+			this.lastError = safeError(error);
+		});
+		this.state = "disconnected";
+		this.unread = 0;
+		this.transcript.length = 0;
+		this.emit();
+	}
+
+	private emit(): void {
+		const snapshot = this.snapshot();
+		this.onChange?.(snapshot);
+		for (const listener of this.listeners) listener(snapshot);
+	}
+}
+
+function keyId(publicKey: Uint8Array): string {
+	return Buffer.from(publicKey).toString("hex");
+}
+
+function safeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-chat/src/chat-view.ts
+++ b/packages/pi-chat/src/chat-view.ts
@@ -1,0 +1,256 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import {
+	type Component,
+	Editor,
+	type EditorTheme,
+	type Focusable,
+	Key,
+	matchesKey,
+	sliceByColumn,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import type { ChatSnapshot } from "./chat-session.js";
+import { sanitizeChatText, sanitizeSingleLine } from "./text.js";
+
+export interface ChatViewOptions {
+	tui: TUI;
+	theme: Theme;
+	getSnapshot(): ChatSnapshot;
+	send(text: string): { id: string; deliveredTo: number };
+	initialDraft?: string;
+	onDraftChange?(text: string): void;
+	setViewOpen(open: boolean): void;
+	subscribe?(listener: () => void): () => void;
+	signal?: AbortSignal;
+	onReturnToPi(): void;
+	onClose(): void;
+}
+
+export class ChatView implements Component, Focusable {
+	private readonly editor: Editor;
+	private readonly tui: TUI;
+	private readonly theme: Theme;
+	private readonly options: ChatViewOptions;
+	private scrollOffset = 0;
+	private lastContentRows = 0;
+	private lastViewportRows = 1;
+	private followBottom = true;
+	private messageStatus: { kind: "success" | "warning"; text: string } | undefined;
+	private finished = false;
+	private _focused = false;
+	private readonly unsubscribe: () => void;
+	private removeAbort = () => {};
+
+	constructor(options: ChatViewOptions) {
+		this.options = options;
+		this.tui = options.tui;
+		this.theme = options.theme;
+		const editorTheme: EditorTheme = {
+			borderColor: (text) => this.theme.fg("accent", text),
+			selectList: {
+				selectedPrefix: (text) => this.theme.fg("accent", text),
+				selectedText: (text) => this.theme.fg("accent", text),
+				description: (text) => this.theme.fg("muted", text),
+				scrollInfo: (text) => this.theme.fg("dim", text),
+				noMatch: (text) => this.theme.fg("warning", text),
+			},
+		};
+		this.editor = new Editor(this.tui, editorTheme);
+		if (options.initialDraft) this.editor.setText(options.initialDraft);
+		this.unsubscribe = options.subscribe?.(() => this.tui.requestRender()) ?? (() => undefined);
+		this.editor.onChange = () => {
+			this.messageStatus = undefined;
+			this.options.onDraftChange?.(this.editor.getExpandedText());
+		};
+		this.editor.onSubmit = (text) => {
+			const message = text.trim();
+			if (!message) {
+				this.messageStatus = { kind: "warning", text: "Message cannot be empty" };
+				this.tui.requestRender();
+				return;
+			}
+			if (this.options.getSnapshot().peers.length === 0) {
+				this.editor.setText(text);
+				this.messageStatus = {
+					kind: "warning",
+					text: "No direct peers — message kept. Wait for connection or Esc to return.",
+				};
+				this.tui.requestRender();
+				return;
+			}
+			try {
+				const result = this.options.send(message);
+				if (result.deliveredTo === 0) {
+					this.editor.setText(text);
+					this.messageStatus = {
+						kind: "warning",
+						text: "No direct peers accepted it — message kept for retry.",
+					};
+				} else {
+					this.editor.setText("");
+					this.followBottom = true;
+					this.messageStatus = {
+						kind: "success",
+						text: `Sent to ${result.deliveredTo} direct peer${result.deliveredTo === 1 ? "" : "s"}`,
+					};
+				}
+			} catch (error) {
+				this.editor.setText(text);
+				this.messageStatus = { kind: "warning", text: safeDisplayError(error) };
+			}
+			this.tui.requestRender();
+		};
+		this.options.setViewOpen(true);
+		if (options.signal) {
+			const abort = () => this.finish(false, true);
+			options.signal.addEventListener("abort", abort, { once: true });
+			this.removeAbort = () => options.signal?.removeEventListener("abort", abort);
+			if (options.signal.aborted) abort();
+		}
+	}
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	set focused(value: boolean) {
+		this._focused = value;
+		this.editor.focused = value;
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const snapshot = this.options.getSnapshot();
+		const editorLines = this.editor.render(safeWidth);
+		const availableRows = Math.max(3, Math.min(16, Math.floor(this.tui.terminal.rows * 0.75)));
+		const viewportRows = Math.max(0, availableRows - editorLines.length - 2);
+		const content = renderTranscript(snapshot, safeWidth, this.theme);
+		this.lastContentRows = content.length;
+		this.lastViewportRows = viewportRows;
+		if (this.followBottom) this.scrollOffset = this.maxScroll();
+		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, this.maxScroll()));
+		const peerCount = snapshot.peers.length;
+		const header = truncateToWidth(
+			this.theme.fg(
+				"accent",
+				this.theme.bold(
+					`CHAT INPUT → ${sanitizeSingleLine(snapshot.room.label)} · ${peerCount === 0 ? "waiting for peers" : `${peerCount} direct peer${peerCount === 1 ? "" : "s"}`}`,
+				),
+			),
+			safeWidth,
+		);
+		const footer = truncateToWidth(
+			this.theme.fg(
+				this.messageStatus?.kind === "warning"
+					? "warning"
+					: this.messageStatus?.kind === "success"
+						? "success"
+						: "dim",
+				this.messageStatus?.text ??
+					"Enter sends · configured newline key inserts a line · Esc returns to Pi/LLM",
+			),
+			safeWidth,
+		);
+		const lines = [
+			header,
+			...content.slice(this.scrollOffset, this.scrollOffset + viewportRows),
+			footer,
+			...editorLines,
+		];
+		return lines.slice(-availableRows).map((line) => truncateToWidth(line, safeWidth));
+	}
+
+	handleInput(data: string): void {
+		if (this.finished) return;
+		if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+			this.close();
+			return;
+		}
+		if (matchesKey(data, Key.pageUp)) {
+			this.scrollOffset = Math.max(0, this.scrollOffset - this.lastViewportRows);
+			this.followBottom = false;
+			this.tui.requestRender();
+			return;
+		}
+		if (matchesKey(data, Key.pageDown)) {
+			this.scrollOffset = Math.min(this.maxScroll(), this.scrollOffset + this.lastViewportRows);
+			this.followBottom = this.scrollOffset === this.maxScroll();
+			this.tui.requestRender();
+			return;
+		}
+		this.editor.handleInput(data);
+		this.tui.requestRender();
+	}
+
+	invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	dispose(): void {
+		this.finish(false, false);
+	}
+
+	private maxScroll(): number {
+		return Math.max(0, this.lastContentRows - this.lastViewportRows);
+	}
+
+	private close(): void {
+		this.finish(true, true);
+	}
+
+	private finish(returnedToPi: boolean, closeHost: boolean): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.removeAbort();
+		this.removeAbort = () => {};
+		this.unsubscribe();
+		this.options.setViewOpen(false);
+		if (returnedToPi) this.options.onReturnToPi();
+		if (closeHost) this.options.onClose();
+	}
+}
+
+function renderTranscript(snapshot: ChatSnapshot, width: number, theme: Theme): string[] {
+	if (snapshot.transcript.length === 0) {
+		const empty =
+			snapshot.peers.length === 0
+				? "You are alone; waiting for peers."
+				: "No messages yet. Start the conversation below.";
+		return wrapTextWithAnsi(theme.fg("muted", empty), width);
+	}
+	const lines: string[] = [];
+	for (const entry of snapshot.transcript) {
+		const label = sanitizeSingleLine(entry.label);
+		const delivery =
+			entry.author === "local" && entry.delivery === "not-delivered"
+				? " · not delivered"
+				: entry.author === "local" && entry.deliveredTo !== undefined
+					? ` · broadcast to ${entry.deliveredTo}`
+					: "";
+		lines.push(...wrapTextWithAnsi(theme.fg("accent", `${label}${delivery}`), width));
+		for (const rawLine of sanitizeChatText(entry.text).split("\n")) {
+			for (const line of hardWrapExact(rawLine, Math.max(1, width - 2))) {
+				lines.push(truncateToWidth(`  ${line}`, width));
+			}
+		}
+	}
+	return lines;
+}
+
+function hardWrapExact(value: string, width: number): string[] {
+	if (!value) return [" "];
+	const columns = visibleWidth(value);
+	const lines: string[] = [];
+	for (let column = 0; column < columns; column += width) {
+		lines.push(sliceByColumn(value, column, width));
+	}
+	return lines.length > 0 ? lines : [" "];
+}
+
+function safeDisplayError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return sanitizeSingleLine(message).slice(0, 200);
+}

--- a/packages/pi-chat/src/external.d.ts
+++ b/packages/pi-chat/src/external.d.ts
@@ -1,0 +1,69 @@
+declare module "hyperdht" {
+	export interface HyperDhtKeyPair {
+		publicKey: Buffer;
+		secretKey: Buffer;
+	}
+
+	interface HyperDhtConstructor {
+		keyPair(seed?: Uint8Array): HyperDhtKeyPair;
+	}
+
+	const HyperDHT: HyperDhtConstructor;
+	export default HyperDHT;
+}
+
+declare module "hyperswarm" {
+	import type { Duplex } from "node:stream";
+	import type { HyperDhtKeyPair } from "hyperdht";
+
+	export interface PeerInfo {
+		publicKey: Buffer;
+		topics: Buffer[];
+		ban(value?: boolean): void;
+	}
+
+	export interface PeerDiscovery {
+		flushed(): Promise<void>;
+		destroy(): Promise<void>;
+		refresh(options?: { client?: boolean; server?: boolean; limit?: number }): Promise<void>;
+	}
+
+	export interface HyperswarmOptions {
+		keyPair?: HyperDhtKeyPair;
+		seed?: Uint8Array;
+		maxPeers?: number;
+		firewall?: (remotePublicKey: Buffer) => boolean;
+		dht?: unknown;
+		bootstrap?: unknown[];
+	}
+
+	export default class Hyperswarm {
+		constructor(options?: HyperswarmOptions);
+		connections: Set<Duplex>;
+		connecting: number;
+		on(event: "connection", listener: (socket: Duplex, info: PeerInfo) => void): this;
+		on(event: "update", listener: () => void): this;
+		on(event: "error", listener: (error: Error) => void): this;
+		join(
+			topic: Buffer,
+			options?: { client?: boolean; server?: boolean; limit?: number },
+		): PeerDiscovery;
+		joinPeer(publicKey: Buffer): void;
+		leavePeer(publicKey: Buffer): void;
+		flush(): Promise<void>;
+		destroy(options?: { force?: boolean }): Promise<void>;
+	}
+}
+
+declare module "hyperdht/testnet.js" {
+	interface Testnet {
+		nodes: unknown[];
+		bootstrap: unknown[];
+		createNode(options?: Record<string, unknown>): unknown;
+		destroy(): Promise<void>;
+	}
+	export default function createTestnet(
+		size?: number,
+		options?: Record<string, unknown>,
+	): Promise<Testnet>;
+}

--- a/packages/pi-chat/src/identity.ts
+++ b/packages/pi-chat/src/identity.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import HyperDHT from "hyperdht";
+
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const MAX_NICKNAME_GRAPHEMES = 24;
+const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+
+export interface ChatIdentity {
+	seed: string;
+	publicKey: Buffer;
+	secretKey: Buffer;
+	tag: string;
+}
+
+export function normalizeNickname(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.normalize("NFKC").trim();
+	if (!normalized || /\p{Cc}/u.test(normalized) || BIDI_CONTROLS.test(normalized)) return undefined;
+	const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+	if (Array.from(segmenter.segment(normalized)).length > MAX_NICKNAME_GRAPHEMES) return undefined;
+	return normalized;
+}
+
+export function createIdentity(seed: Uint8Array): ChatIdentity {
+	if (seed.byteLength !== 32) throw new Error("Pi Chat identity seed must be exactly 32-byte.");
+	const stableSeed = Buffer.from(seed);
+	const keyPair = HyperDHT.keyPair(stableSeed);
+	return {
+		seed: stableSeed.toString("base64url"),
+		publicKey: Buffer.from(keyPair.publicKey),
+		secretKey: Buffer.from(keyPair.secretKey),
+		tag: identityTag(keyPair.publicKey),
+	};
+}
+
+export function identityTag(publicKey: Uint8Array, characters = 12): string {
+	if (characters < 12 || characters > 52) throw new Error("Identity tags use 12 to 52 characters.");
+	const digest = createHash("sha256").update(publicKey).digest();
+	let bits = 0;
+	let bitCount = 0;
+	let raw = "";
+	for (const byte of digest) {
+		bits = (bits << 8) | byte;
+		bitCount += 8;
+		while (bitCount >= 5 && raw.length < characters) {
+			bitCount -= 5;
+			raw += CROCKFORD[(bits >>> bitCount) & 31];
+			bits &= (1 << bitCount) - 1;
+		}
+		if (raw.length === characters) break;
+	}
+	return raw.match(/.{1,4}/gu)?.join("-") ?? raw;
+}
+
+export function formatIdentityLabel(
+	nickname: string,
+	publicKey: Uint8Array,
+	characters = 12,
+): string {
+	return `${nickname}~${identityTag(publicKey, characters)}`;
+}
+
+export function uniqueIdentityTags(publicKeys: readonly Uint8Array[]): Map<string, string> {
+	const fullKeys = publicKeys.map((key) => Buffer.from(key).toString("hex"));
+	const result = new Map<string, string>();
+	for (let length = 12; length <= 52; length += 4) {
+		const grouped = new Map<string, string[]>();
+		for (const [index, publicKey] of publicKeys.entries()) {
+			const tag = identityTag(publicKey, length);
+			const fullKey = fullKeys[index] ?? Buffer.from(publicKey).toString("hex");
+			grouped.set(tag, [...(grouped.get(tag) ?? []), fullKey]);
+		}
+		for (const [tag, keys] of grouped) {
+			const onlyKey = keys.length === 1 ? keys[0] : undefined;
+			if (onlyKey && !result.has(onlyKey)) result.set(onlyKey, tag);
+		}
+		if (result.size === publicKeys.length) break;
+	}
+	return result;
+}

--- a/packages/pi-chat/src/index.ts
+++ b/packages/pi-chat/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./pi-chat.js";

--- a/packages/pi-chat/src/menu.ts
+++ b/packages/pi-chat/src/menu.ts
@@ -1,0 +1,490 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { MenuDefinition } from "@narumitw/pi-tui-kit";
+import type { ChatSnapshot } from "./chat-session.js";
+import { normalizeNickname } from "./identity.js";
+import { createPublicRoom, parseInvite, type RoomDescriptor } from "./protocol.js";
+import { type ChatSettings, descriptorFromRememberedRoom, type WidgetMode } from "./settings.js";
+import { sanitizeSingleLine } from "./text.js";
+
+export interface JoinRoomOptions {
+	remember: boolean;
+}
+
+export interface ChatMenuSource {
+	settingsPath: string;
+	getSettings(): ChatSettings;
+	getSnapshot(): ChatSnapshot | undefined;
+	getRestoreError(): string | undefined;
+	createPrivateRoom(): RoomDescriptor;
+	joinRoom(
+		room: RoomDescriptor,
+		ctx: ExtensionCommandContext,
+		signal: AbortSignal,
+		options?: JoinRoomOptions,
+	): Promise<boolean>;
+	openChat(ctx: ExtensionCommandContext): Promise<void>;
+	retryRememberedRoom(ctx: ExtensionCommandContext, signal: AbortSignal): Promise<void>;
+	forgetRememberedRoom(signal: AbortSignal): Promise<void>;
+	leaveRoom(signal: AbortSignal): Promise<void>;
+	toggleMute(publicKey: string): boolean | undefined;
+	updateNickname(value: string, signal: AbortSignal): Promise<void>;
+	updateWidgetMode(value: WidgetMode, signal: AbortSignal): Promise<void>;
+	getIdentityResetPreview(): { current: string; next: string };
+	resetIdentity(signal: AbortSignal): Promise<void>;
+}
+
+interface ChatMenuState {
+	settings: ChatSettings;
+	snapshot?: ChatSnapshot;
+	pendingRoom?: RoomDescriptor;
+	restoreError?: string;
+}
+
+type Screen =
+	| "main"
+	| "invite"
+	| "joinInvite"
+	| "joinPublic"
+	| "joinAnother"
+	| "participants"
+	| "settings"
+	| "changeNickname"
+	| "widget"
+	| "resetIdentity"
+	| "leave"
+	| "forget"
+	| "status"
+	| "help";
+type Action =
+	| "createPrivate"
+	| "joinPending"
+	| "joinInvite"
+	| "joinPublic"
+	| "retry"
+	| "forget"
+	| "open"
+	| "leave"
+	| "toggleMute"
+	| "changeNickname"
+	| "setWidget"
+	| "resetIdentity";
+
+export function createChatMenu(source: ChatMenuSource) {
+	let pendingRoom: RoomDescriptor | undefined;
+	const getState = async (): Promise<ChatMenuState> => ({
+		settings: source.getSettings(),
+		snapshot: source.getSnapshot(),
+		pendingRoom,
+		...(source.getRestoreError() ? { restoreError: source.getRestoreError() } : {}),
+	});
+	const menu: MenuDefinition<ChatMenuState, Screen, Action> = {
+		start: "main",
+		screens: {
+			main: ({ state }) => mainScreen(state),
+			invite: ({ state }) => {
+				const room = state.pendingRoom ?? state.snapshot?.room;
+				return {
+					kind: "review",
+					title: "Private room invite",
+					lines: [
+						"Anyone with this bearer invite can join.",
+						"After confirmation, choose whether to save it privately for restart restore.",
+					],
+					content: room?.invite ?? "Invite is unavailable.",
+					format: { kind: "text" },
+					viewportSize: "adaptive",
+					...(state.pendingRoom
+						? {
+								confirm: {
+									id: "join-private",
+									label: "Join private room",
+									action: "joinPending" as const,
+								},
+							}
+						: {}),
+					hint: "back",
+				};
+			},
+			joinInvite: () => ({
+				kind: "input",
+				title: "Join with invite",
+				lines: [
+					"Paste a pichat:v1 invite. It grants access to the private room.",
+					"You will choose Join and remember, Join once, or Cancel before networking starts.",
+				],
+				placeholder: "pichat:v1:…",
+				action: "joinInvite",
+				hint: "back",
+			}),
+			joinPublic: () => ({
+				kind: "input",
+				title: "Join public room",
+				lines: ["Use a lowercase room slug. Public rooms are guessable and open to anyone."],
+				placeholder: "pi-dev",
+				action: "joinPublic",
+				hint: "back",
+			}),
+			joinAnother: () => ({
+				kind: "actions",
+				title: "Join another room",
+				lines: ["A successfully remembered join replaces the room restored at startup."],
+				items: [
+					{ id: "public", label: "Join public room", to: "joinPublic" },
+					{ id: "invite", label: "Join with invite", to: "joinInvite" },
+					{ id: "create", label: "Create private room", action: "createPrivate" },
+				],
+				hint: "back",
+			}),
+			participants: ({ state }) => ({
+				kind: "choice",
+				title: "Direct participants",
+				lines: state.snapshot?.peers.length
+					? ["Select a peer to toggle local mute. Full public keys are shown in details."]
+					: ["No authenticated direct peers are connected."],
+				items:
+					state.snapshot?.peers.map((peer) => ({
+						id: peer.publicKey,
+						label: sanitizeSingleLine(peer.label),
+						description: peer.muted ? "Muted locally" : "Receiving messages",
+						details: [peer.publicKey],
+					})) ?? [],
+				action: "toggleMute",
+				viewportSize: 10,
+				hint: "back",
+			}),
+			settings: ({ state }) => ({
+				kind: "actions",
+				title: "Pi Chat settings",
+				lines: [
+					`Nickname: ${sanitizeSingleLine(state.settings.nickname ?? "not set")}`,
+					`Joined room display: ${state.settings.widgetMode ?? "count"}`,
+					`Restart: ${restartDescription(state.settings)}`,
+					`User settings · ${sanitizeSingleLine(source.settingsPath)}`,
+				],
+				items: [
+					{ id: "nickname", label: "Change nickname", to: "changeNickname" },
+					{ id: "widget", label: "Joined room display", to: "widget" },
+					{ id: "reset", label: "Reset identity…", to: "resetIdentity" },
+				],
+				hint: "back",
+			}),
+			changeNickname: () => ({
+				kind: "input",
+				title: "Change nickname",
+				lines: ["The immutable fingerprint remains attached to the new nickname."],
+				placeholder: "Mika",
+				action: "changeNickname",
+				hint: "back",
+			}),
+			widget: ({ state }) => ({
+				kind: "choice",
+				title: "Joined room display",
+				lines: ["Choose how much room content remains visible above the Pi editor."],
+				items: [
+					{
+						id: "dock",
+						label: "Room dock",
+						description: "Status, input target, and up to three recent messages",
+					},
+					{ id: "latest", label: "Latest message", description: "Show one recent message" },
+					{ id: "count", label: "Status only", description: "Hide message text" },
+					{ id: "off", label: "Hidden", description: "Show no persistent room widget" },
+				],
+				action: "setWidget",
+				currentItemId: state.settings.widgetMode ?? "count",
+				initialItemId: state.settings.widgetMode ?? "count",
+				hint: "back",
+			}),
+			resetIdentity: () => {
+				const preview = source.getIdentityResetPreview();
+				return {
+					kind: "review",
+					title: "Reset Pi Chat identity?",
+					lines: [
+						`Current: ${preview.current}`,
+						`New: ${preview.next}`,
+						"Resetting changes your fingerprint, forgets startup restore, and leaves the room.",
+					],
+					content: "This cannot restore trust or blocked state associated with the old public key.",
+					format: { kind: "text" },
+					confirm: { id: "reset", label: "Reset identity", action: "resetIdentity" },
+					hint: "back",
+				};
+			},
+			leave: ({ state }) => {
+				const forgetsCurrent = state.settings.resume?.activeRoomId === state.snapshot?.room.id;
+				return {
+					kind: "review",
+					title: forgetsCurrent ? "Leave and forget room?" : "Leave room?",
+					lines: [
+						`Room: ${sanitizeSingleLine(state.snapshot?.room.label ?? "unknown")}`,
+						forgetsCurrent
+							? "Leaving disconnects peers, clears this transcript, and disables startup restore."
+							: "Leaving disconnects peers and clears this ephemeral transcript.",
+					],
+					content: "Messages already received by other peers cannot be withdrawn.",
+					format: { kind: "text" },
+					confirm: {
+						id: "leave",
+						label: forgetsCurrent ? "Leave and forget room" : "Leave room",
+						action: "leave",
+					},
+					hint: "back",
+				};
+			},
+			forget: ({ state }) => {
+				const room = rememberedRoom(state.settings);
+				return {
+					kind: "review",
+					title: "Forget saved room?",
+					lines: [
+						`Room: ${sanitizeSingleLine(room?.label ?? "unknown")}`,
+						"Pi Chat will not reconnect to this room at startup.",
+					],
+					content: "This does not withdraw messages already received by peers.",
+					format: { kind: "text" },
+					confirm: { id: "forget", label: "Forget saved room", action: "forget" },
+					hint: "back",
+				};
+			},
+			status: ({ state }) => ({
+				kind: "detail",
+				title: "Pi Chat status",
+				lines: state.snapshot
+					? [
+							`State: ${state.snapshot.state}`,
+							`Room: ${sanitizeSingleLine(state.snapshot.room.label)}`,
+							`Identity: ${sanitizeSingleLine(state.snapshot.localLabel)}`,
+							`Direct peers: ${state.snapshot.peers.length}`,
+							`Unread: ${state.snapshot.unread}`,
+							`Restart: ${restartDescription(state.settings)}`,
+							...(state.snapshot.lastError
+								? [`Attention: ${sanitizeSingleLine(state.snapshot.lastError)}`]
+								: []),
+						]
+					: [
+							"State: disconnected",
+							`Restart: ${restartDescription(state.settings)}`,
+							...(state.restoreError
+								? [`Attention: ${sanitizeSingleLine(state.restoreError)}`]
+								: []),
+							`Settings: ${sanitizeSingleLine(source.settingsPath)}`,
+						],
+				hint: "back",
+			}),
+			help: () => ({
+				kind: "detail",
+				title: "Pi Chat help",
+				lines: [
+					"Pi Chat is experimental and TUI-only.",
+					"Chat stays outside Pi sessions, prompts, model context, and repository files.",
+					"Private invites are bearer secrets. Public rooms are guessable.",
+					"Noise encrypts direct streams, but peers and DHT infrastructure may observe network metadata.",
+					"There is no offline delivery, authoritative room count, or message withdrawal.",
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			createPrivate: () => {
+				pendingRoom = source.createPrivateRoom();
+				return { kind: "to", screen: "invite" };
+			},
+			joinPending: async ({ ctx, signal }) => {
+				if (!pendingRoom) return { kind: "rejected", error: new Error("Invite is unavailable") };
+				if (!(await source.joinRoom(pendingRoom, ctx, signal)) || signal.aborted) {
+					return { kind: "stay" };
+				}
+				await source.openChat(ctx);
+				return { kind: "close" };
+			},
+			joinInvite: async ({ ctx, signal, value }) => {
+				let room: RoomDescriptor;
+				try {
+					room = parseInvite(value ?? "");
+				} catch (error) {
+					return { kind: "rejected", error };
+				}
+				if (!(await source.joinRoom(room, ctx, signal)) || signal.aborted) return { kind: "stay" };
+				await source.openChat(ctx);
+				return { kind: "close" };
+			},
+			joinPublic: async ({ ctx, signal, value }) => {
+				let room: RoomDescriptor;
+				try {
+					room = createPublicRoom((value ?? "").replace(/^#/u, ""));
+				} catch (error) {
+					return { kind: "rejected", error };
+				}
+				const confirmed = await ctx.ui.confirm(
+					"Join public room?",
+					"Anyone can join or record it. DHT and direct peers may observe network metadata.",
+					{ signal },
+				);
+				if (!confirmed || signal.aborted) return { kind: "stay" };
+				if (!(await source.joinRoom(room, ctx, signal, { remember: true })) || signal.aborted) {
+					return { kind: "stay" };
+				}
+				await source.openChat(ctx);
+				return { kind: "close" };
+			},
+			retry: async ({ ctx, signal }) => {
+				await source.retryRememberedRoom(ctx, signal);
+				return { kind: "close" };
+			},
+			forget: async ({ signal }) => {
+				await source.forgetRememberedRoom(signal);
+				return { kind: "to", screen: "main" };
+			},
+			open: async ({ ctx }) => {
+				await source.openChat(ctx);
+				return { kind: "close" };
+			},
+			leave: async ({ signal }) => {
+				await source.leaveRoom(signal);
+				return { kind: "to", screen: "main" };
+			},
+			toggleMute: ({ itemId }) => {
+				const muted = source.toggleMute(itemId);
+				return muted === undefined
+					? { kind: "rejected", error: new Error("Peer is no longer connected") }
+					: { kind: "to", screen: "participants" };
+			},
+			changeNickname: async ({ signal, value }) => {
+				const nickname = normalizeNickname(value);
+				if (!nickname) return { kind: "rejected", error: new Error("Nickname is invalid") };
+				await source.updateNickname(nickname, signal);
+				return { kind: "to", screen: "settings" };
+			},
+			setWidget: async ({ signal, itemId }) => {
+				if (itemId !== "dock" && itemId !== "count" && itemId !== "latest" && itemId !== "off") {
+					return { kind: "rejected", error: new Error("Widget mode is invalid") };
+				}
+				await source.updateWidgetMode(itemId, signal);
+				return { kind: "to", screen: "settings" };
+			},
+			resetIdentity: async ({ signal }) => {
+				await source.resetIdentity(signal);
+				return { kind: "to", screen: "settings" };
+			},
+		},
+	};
+	return { menu, getState };
+}
+
+export async function showChatMenu(
+	ctx: ExtensionCommandContext,
+	source: ChatMenuSource,
+	ownership: { signal: AbortSignal; isCurrent: () => boolean },
+): Promise<void> {
+	const { runMenu } = await import("@narumitw/pi-tui-kit");
+	if (ownership.signal.aborted || !ownership.isCurrent()) return;
+	const controller = createChatMenu(source);
+	await runMenu(ctx, controller.menu, {
+		getState: controller.getState,
+		signal: ownership.signal,
+		isCurrent: ownership.isCurrent,
+		onError: (_ctx, error) => {
+			if (ownership.isCurrent() && !ownership.signal.aborted) {
+				ctx.ui.notify(`Pi Chat failed: ${sanitizeSingleLine(safeError(error))}`, "error");
+			}
+		},
+	});
+}
+
+function mainScreen(state: ChatMenuState) {
+	const remembered = rememberedRoom(state.settings);
+	if (!state.snapshot || state.snapshot.state === "disconnected") {
+		if (remembered) {
+			return {
+				kind: "actions" as const,
+				title: state.restoreError
+					? `Pi Chat · could not restore ${sanitizeSingleLine(remembered.label)}`
+					: `Pi Chat · ${sanitizeSingleLine(remembered.label)} remembered`,
+				lines: [
+					state.restoreError
+						? `Attention: ${sanitizeSingleLine(state.restoreError)}`
+						: "Disconnected. This room is configured to reconnect at startup.",
+					`Restart surface: ${state.settings.resume?.surface === "chat" ? "open chat" : "Pi/LLM"}`,
+				],
+				items: [
+					{ id: "retry", label: `Retry ${remembered.label}`, action: "retry" as const },
+					{ id: "another", label: "Join another room", to: "joinAnother" as const },
+					{ id: "forget", label: `Forget ${remembered.label}…`, to: "forget" as const },
+					{ id: "settings", label: "Settings", to: "settings" as const },
+					{ id: "status", label: "Status", to: "status" as const },
+					{ id: "help", label: "Help", to: "help" as const },
+				],
+				hint: "close" as const,
+			};
+		}
+		return {
+			kind: "actions" as const,
+			title: "Pi Chat · disconnected",
+			lines: ["Experimental peer-to-peer chat. Messages never enter model context."],
+			items: [
+				{ id: "public", label: "Join public room", to: "joinPublic" as const },
+				{ id: "invite", label: "Join with invite", to: "joinInvite" as const },
+				{ id: "create", label: "Create private room", action: "createPrivate" as const },
+				{ id: "settings", label: "Settings", to: "settings" as const },
+				{ id: "status", label: "Status", to: "status" as const },
+				{ id: "help", label: "Help", to: "help" as const },
+			],
+			hint: "close" as const,
+		};
+	}
+	const restoresCurrent = remembered?.id === state.snapshot.room.id;
+	return {
+		kind: "actions" as const,
+		title: `Pi Chat · ${sanitizeSingleLine(state.snapshot.room.label)}`,
+		lines: [
+			`${state.snapshot.state} · ${state.snapshot.peers.length} direct peers · ${state.snapshot.unread} unread`,
+			`Current input: ${state.snapshot.composerOpen ? state.snapshot.room.label : "Pi/LLM"}`,
+			restoresCurrent
+				? `Restart: restore this room and ${state.settings.resume?.surface === "chat" ? "open chat" : "stay in Pi/LLM"}`
+				: "Restart: this room will not reconnect",
+			state.snapshot.localLabel,
+		],
+		items: [
+			{
+				id: "open",
+				label: `Open chat in ${sanitizeSingleLine(state.snapshot.room.label)}`,
+				action: "open" as const,
+			},
+			{ id: "participants", label: "Show participants", to: "participants" as const },
+			...(state.snapshot.room.invite
+				? [{ id: "invite", label: "Show room invite", to: "invite" as const }]
+				: []),
+			{ id: "settings", label: "Settings", to: "settings" as const },
+			{ id: "status", label: "Status", to: "status" as const },
+			{ id: "help", label: "Help", to: "help" as const },
+			{
+				id: "leave",
+				label: restoresCurrent ? "Leave and forget room…" : "Leave room…",
+				to: "leave" as const,
+			},
+		],
+		hint: "close" as const,
+	};
+}
+
+function rememberedRoom(settings: ChatSettings): RoomDescriptor | undefined {
+	const resume = settings.resume;
+	const remembered = resume?.rooms.find(({ id }) => id === resume.activeRoomId);
+	if (!remembered) return undefined;
+	try {
+		return descriptorFromRememberedRoom(remembered);
+	} catch {
+		return undefined;
+	}
+}
+
+function restartDescription(settings: ChatSettings): string {
+	const room = rememberedRoom(settings);
+	if (!room) return "no room remembered";
+	return `${room.label} · ${settings.resume?.surface === "chat" ? "open chat" : "stay in Pi/LLM"}`;
+}
+
+function safeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-chat/src/network.ts
+++ b/packages/pi-chat/src/network.ts
@@ -1,0 +1,201 @@
+import type { Duplex } from "node:stream";
+import Hyperswarm, { type PeerDiscovery, type PeerInfo } from "hyperswarm";
+import type { ChatTransport, ChatTransportListener, TransportPeer } from "./chat-session.js";
+import type { ChatIdentity } from "./identity.js";
+import {
+	encodeFrame,
+	FrameDecoder,
+	type ProtocolMessage,
+	type RoomDescriptor,
+} from "./protocol.js";
+
+export interface HyperswarmTransportOptions {
+	room: RoomDescriptor;
+	identity: ChatIdentity;
+	maxPeers?: number;
+	dht?: unknown;
+	bootstrap?: unknown[];
+}
+
+interface ActiveConnection {
+	socket: Duplex;
+	peer: TransportPeer;
+}
+
+export class HyperswarmTransport implements ChatTransport {
+	private readonly options: HyperswarmTransportOptions;
+	private swarm: Hyperswarm | undefined;
+	private discovery: PeerDiscovery | undefined;
+	private listener: ChatTransportListener | undefined;
+	private readonly connections = new Map<Duplex, ActiveConnection>();
+	private readonly directPeers = new Map<string, Buffer>();
+	private readonly refreshTimers = new Set<NodeJS.Timeout>();
+	private stopPromise: Promise<void> | undefined;
+
+	constructor(options: HyperswarmTransportOptions) {
+		this.options = options;
+	}
+
+	get connectionCount(): number {
+		return this.connections.size;
+	}
+
+	async start(listener: ChatTransportListener, signal?: AbortSignal): Promise<void> {
+		if (this.swarm) throw new Error("Hyperswarm transport has already started.");
+		const startupSignal = signal
+			? AbortSignal.any([signal, AbortSignal.timeout(15_000)])
+			: AbortSignal.timeout(15_000);
+		startupSignal.throwIfAborted();
+		this.listener = listener;
+		const swarm = new Hyperswarm({
+			keyPair: {
+				publicKey: this.options.identity.publicKey,
+				secretKey: this.options.identity.secretKey,
+			},
+			maxPeers: this.options.maxPeers ?? 16,
+			...(this.options.dht ? { dht: this.options.dht } : {}),
+			...(this.options.bootstrap ? { bootstrap: this.options.bootstrap } : {}),
+		});
+		this.swarm = swarm;
+		swarm.on("connection", (socket, info) => this.accept(socket, info));
+		swarm.on("error", (error) => this.listener?.onError(safeNetworkError(error)));
+		try {
+			const discovery = swarm.join(this.options.room.topic, {
+				server: true,
+				client: true,
+				limit: this.options.maxPeers ?? 16,
+			});
+			this.discovery = discovery;
+			await raceAbort(discovery.flushed(), startupSignal);
+			startupSignal.throwIfAborted();
+			this.scheduleEarlyRefreshes(discovery);
+		} catch (error) {
+			await this.stop();
+			throw error;
+		}
+	}
+
+	connectPeer(publicKey: Buffer): void {
+		if (!this.swarm || publicKey.length !== 32 || this.directPeers.size >= 16) return;
+		const id = publicKey.toString("hex");
+		if (id === this.options.identity.publicKey.toString("hex") || this.directPeers.has(id)) return;
+		this.directPeers.set(id, Buffer.from(publicKey));
+		this.swarm.joinPeer(publicKey);
+	}
+
+	stop(): Promise<void> {
+		if (this.stopPromise) return this.stopPromise;
+		this.stopPromise = this.stopOwned();
+		return this.stopPromise;
+	}
+
+	private scheduleEarlyRefreshes(discovery: PeerDiscovery): void {
+		const delays = [250, 750, 1_500, 3_000, 6_000, 12_000];
+		const schedule = (index: number): void => {
+			const delayMs = delays[index];
+			if (delayMs === undefined || this.discovery !== discovery) return;
+			const timer = setTimeout(() => {
+				this.refreshTimers.delete(timer);
+				if (this.discovery !== discovery) return;
+				void discovery
+					.refresh()
+					.catch(() => undefined)
+					.finally(() => {
+						if (this.discovery === discovery) schedule(index + 1);
+					});
+			}, delayMs);
+			this.refreshTimers.add(timer);
+		};
+		schedule(0);
+	}
+
+	private accept(socket: Duplex, info: PeerInfo): void {
+		if (!this.swarm || !this.listener) {
+			socket.destroy();
+			return;
+		}
+		const decoder = new FrameDecoder();
+		let closed = false;
+		const peer: TransportPeer = {
+			publicKey: Buffer.from(info.publicKey),
+			send(message: ProtocolMessage) {
+				if (closed || socket.destroyed) throw new Error("Peer connection is closed.");
+				const accepted = socket.write(encodeFrame(message));
+				if (!accepted && socket.destroyed) throw new Error("Peer connection rejected the message.");
+			},
+			close() {
+				if (closed) return;
+				closed = true;
+				socket.destroy();
+			},
+		};
+		this.connections.set(socket, { socket, peer });
+		this.listener.onPeer(peer);
+		socket.on("data", (chunk: unknown) => {
+			if (closed || !this.listener) return;
+			try {
+				const bytes =
+					typeof chunk === "string"
+						? Buffer.from(chunk)
+						: Buffer.isBuffer(chunk)
+							? chunk
+							: Buffer.from(chunk as Uint8Array);
+				for (const message of decoder.push(bytes)) this.listener.onMessage(peer, message);
+			} catch {
+				closed = true;
+				socket.destroy();
+				this.listener?.onError(new Error("Pi Chat rejected invalid peer protocol data."));
+			}
+		});
+		const disconnected = () => {
+			if (!this.connections.delete(socket)) return;
+			closed = true;
+			this.listener?.onDisconnect(peer);
+		};
+		socket.once("close", disconnected);
+		socket.once("error", (error) => {
+			this.listener?.onError(safeNetworkError(error));
+			disconnected();
+		});
+	}
+
+	private async stopOwned(): Promise<void> {
+		for (const timer of this.refreshTimers) clearTimeout(timer);
+		this.refreshTimers.clear();
+		const discovery = this.discovery;
+		this.discovery = undefined;
+		if (discovery) await discovery.destroy().catch(() => undefined);
+		for (const { socket } of this.connections.values()) socket.destroy();
+		this.connections.clear();
+		const swarm = this.swarm;
+		if (swarm) {
+			for (const publicKey of this.directPeers.values()) swarm.leavePeer(publicKey);
+		}
+		this.directPeers.clear();
+		this.swarm = undefined;
+		this.listener = undefined;
+		if (swarm) await swarm.destroy().catch(() => undefined);
+	}
+}
+
+async function raceAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return operation;
+	signal.throwIfAborted();
+	let remove = () => {};
+	const aborted = new Promise<never>((_resolve, reject) => {
+		const onAbort = () => reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+		signal.addEventListener("abort", onAbort, { once: true });
+		remove = () => signal.removeEventListener("abort", onAbort);
+	});
+	try {
+		return await Promise.race([operation, aborted]);
+	} finally {
+		remove();
+	}
+}
+
+function safeNetworkError(error: unknown): Error {
+	const code =
+		error instanceof Error && "code" in error ? String(Reflect.get(error, "code")) : "error";
+	return new Error(`Pi Chat network ${code}.`);
+}

--- a/packages/pi-chat/src/pi-chat.ts
+++ b/packages/pi-chat/src/pi-chat.ts
@@ -1,0 +1,647 @@
+import { randomBytes as nodeRandomBytes } from "node:crypto";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import type { ChatSnapshot, ChatTransport } from "./chat-session.js";
+import { ChatSession } from "./chat-session.js";
+import { ChatView } from "./chat-view.js";
+import { type ChatIdentity, createIdentity, formatIdentityLabel } from "./identity.js";
+import { type ChatMenuSource, type JoinRoomOptions, showChatMenu } from "./menu.js";
+import { HyperswarmTransport, type HyperswarmTransportOptions } from "./network.js";
+import {
+	createPrivateRoom,
+	createPublicRoom,
+	parseInvite,
+	type RoomDescriptor,
+} from "./protocol.js";
+import {
+	awaitChatSettingsWrites,
+	type ChatSettings,
+	chatSettingsPath,
+	descriptorFromRememberedRoom,
+	readChatSettings,
+	rememberedRoomFromDescriptor,
+	updateChatSettings as updateChatSettingsFile,
+	type WidgetMode,
+} from "./settings.js";
+import { sanitizeSingleLine } from "./text.js";
+import { renderChatWidget } from "./widget.js";
+
+const CHAT_UI_KEY = "chat";
+const EXPERIMENTAL_WARNING =
+	"Pi Chat is experimental. Peer identity, networking, and interaction behavior may change.";
+const USAGE = "Usage: /chat, /chat <pichat:v1:invite>, or /chat #<public-slug>";
+const PRIVATE_ROOM_OPTIONS = [
+	"Join and remember — Save the bearer invite privately and restore this room",
+	"Join once — Do not save the bearer invite",
+	"Cancel",
+] as const;
+const DISPLAY_OPTIONS: ReadonlyArray<{ label: string; mode: WidgetMode }> = [
+	{
+		label: "Room dock — Show up to three recent messages above the Pi editor",
+		mode: "dock",
+	},
+	{ label: "Latest message — Show one recent message above the Pi editor", mode: "latest" },
+	{ label: "Status only — Hide message text", mode: "count" },
+	{ label: "Hidden — Show no persistent room widget", mode: "off" },
+];
+
+export interface PiChatDependencies {
+	settingsPath: string;
+	randomBytes(size: number): Buffer;
+	createTransport(options: HyperswarmTransportOptions): ChatTransport;
+	updateSettings: typeof updateChatSettingsFile;
+}
+
+export function createPiChatExtension(
+	dependencies: Partial<PiChatDependencies> = {},
+): (pi: ExtensionAPI) => void {
+	const deps: PiChatDependencies = {
+		settingsPath: dependencies.settingsPath ?? chatSettingsPath(),
+		randomBytes: dependencies.randomBytes ?? nodeRandomBytes,
+		createTransport:
+			dependencies.createTransport ?? ((options) => new HyperswarmTransport(options)),
+		updateSettings: dependencies.updateSettings ?? updateChatSettingsFile,
+	};
+	const updateChatSettings = deps.updateSettings;
+
+	return function piChatExtension(pi: ExtensionAPI): void {
+		let generation = 0;
+		let controller = new AbortController();
+		let activeSessionManager: unknown;
+		let activeContext: ExtensionContext | undefined;
+		let settings: ChatSettings = {};
+		let chatSession: ChatSession | undefined;
+		let latestSnapshot: ChatSnapshot | undefined;
+		let chatDraft = "";
+		let restoreError: string | undefined;
+		let restoringRoomId: string | undefined;
+		const ownedTasks = new Set<Promise<unknown>>();
+		let widgetRender: (() => void) | undefined;
+		let widgetInstalled = false;
+
+		const isCurrent = (owner: unknown, ownerGeneration: number) =>
+			activeSessionManager === owner &&
+			generation === ownerGeneration &&
+			!controller.signal.aborted;
+
+		const trackTask = <T>(task: Promise<T>): Promise<T> => {
+			ownedTasks.add(task);
+			void task.then(
+				() => ownedTasks.delete(task),
+				() => ownedTasks.delete(task),
+			);
+			return task;
+		};
+
+		const drainOwnedTasks = async (): Promise<void> => {
+			while (ownedTasks.size > 0) await Promise.allSettled([...ownedTasks]);
+		};
+
+		const clearUi = (ctx: ExtensionContext): void => {
+			try {
+				ctx.ui.setWidget(CHAT_UI_KEY, undefined);
+				ctx.ui.setStatus(CHAT_UI_KEY, undefined);
+			} catch {
+				// Session replacement may invalidate an old UI immediately.
+			}
+			widgetRender = undefined;
+			widgetInstalled = false;
+		};
+
+		const updateUi = (ctx: ExtensionContext, snapshot?: ChatSnapshot): void => {
+			if (ctx.sessionManager !== activeSessionManager) return;
+			latestSnapshot = snapshot;
+			try {
+				ctx.ui.setStatus(
+					CHAT_UI_KEY,
+					snapshot?.state === "connecting"
+						? restoringRoomId === snapshot.room.id
+							? `chat: restoring ${sanitizeSingleLine(snapshot.room.label)}`
+							: "chat: joining"
+						: snapshot?.state === "degraded"
+							? "chat: reconnecting"
+							: undefined,
+				);
+				const mode = settings.widgetMode ?? "count";
+				if (
+					ctx.mode !== "tui" ||
+					!snapshot ||
+					snapshot.state === "disconnected" ||
+					mode === "off"
+				) {
+					ctx.ui.setWidget(CHAT_UI_KEY, undefined);
+					widgetInstalled = false;
+					widgetRender = undefined;
+					return;
+				}
+				if (!widgetInstalled) {
+					ctx.ui.setWidget(CHAT_UI_KEY, (tui, theme) => {
+						const requestRender = () => tui.requestRender();
+						widgetRender = requestRender;
+						return {
+							render: (width: number) =>
+								latestSnapshot
+									? renderChatWidget(
+											latestSnapshot,
+											settings.widgetMode ?? "count",
+											width,
+											theme,
+											tui.terminal.rows,
+										)
+									: [],
+							invalidate() {},
+							dispose() {
+								if (widgetRender === requestRender) widgetRender = undefined;
+							},
+						};
+					});
+					widgetInstalled = true;
+				}
+				widgetRender?.();
+			} catch {
+				// UI updates are best-effort after replacement.
+			}
+		};
+
+		const disconnectRoom = async (): Promise<void> => {
+			const owned = chatSession;
+			chatSession = undefined;
+			latestSnapshot = undefined;
+			chatDraft = "";
+			if (owned) await owned.leave();
+			if (activeContext) clearUi(activeContext);
+		};
+
+		const ensureIdentity = async (
+			ctx: ExtensionContext,
+			signal: AbortSignal,
+			owner: unknown,
+			ownerGeneration: number,
+		): Promise<ChatIdentity | undefined> => {
+			let nickname = settings.nickname;
+			if (!nickname) {
+				const entered = await ctx.ui.input(
+					"Choose a Pi Chat nickname",
+					"Visible to room peers; no OS or Git identity is used",
+					{ signal },
+				);
+				if (!isCurrent(owner, ownerGeneration) || signal.aborted || !entered) return undefined;
+				nickname = entered;
+			}
+			let seed = settings.identitySeed;
+			let widgetMode = settings.widgetMode;
+			if (!seed) {
+				const candidate = createIdentity(deps.randomBytes(32));
+				if (!widgetMode) {
+					const selected = await ctx.ui.select(
+						"Joined room display",
+						DISPLAY_OPTIONS.map(({ label }) => label),
+						{ signal },
+					);
+					if (!selected || !isCurrent(owner, ownerGeneration) || signal.aborted) return undefined;
+					widgetMode = DISPLAY_OPTIONS.find(({ label }) => label === selected)?.mode;
+					if (!widgetMode) return undefined;
+				}
+				const display =
+					DISPLAY_OPTIONS.find(({ mode }) => mode === widgetMode)?.label ?? widgetMode;
+				const confirmed = await ctx.ui.confirm(
+					"Create Pi Chat identity?",
+					`${formatIdentityLabel(nickname, candidate.publicKey)}\nDisplay: ${display}\nThis pseudonymous fingerprint is not real-world identity verification.`,
+					{ signal },
+				);
+				if (!confirmed || !isCurrent(owner, ownerGeneration) || signal.aborted) return undefined;
+				seed = candidate.seed;
+			}
+			if (
+				nickname !== settings.nickname ||
+				seed !== settings.identitySeed ||
+				widgetMode !== settings.widgetMode
+			) {
+				const updated = await updateChatSettings(
+					{
+						nickname,
+						identitySeed: seed,
+						...(widgetMode ? { widgetMode } : {}),
+					},
+					{ settingsPath: deps.settingsPath, signal },
+				);
+				if (!isCurrent(owner, ownerGeneration)) return undefined;
+				settings = updated;
+			}
+			return createIdentity(Buffer.from(seed, "base64url"));
+		};
+
+		const joinRoom = async (
+			room: RoomDescriptor,
+			ctx: ExtensionContext,
+			signal: AbortSignal,
+			options?: JoinRoomOptions,
+		): Promise<boolean> => {
+			if (chatSession && latestSnapshot?.state !== "disconnected") {
+				throw new Error("Leave the current Pi Chat room before joining another.");
+			}
+			const owner = ctx.sessionManager;
+			const ownerGeneration = generation;
+			if (!isCurrent(owner, ownerGeneration)) throw new Error("Pi Chat session is stale.");
+			let remember = options?.remember ?? false;
+			if (room.kind === "private" && options === undefined) {
+				const selected = await ctx.ui.select(
+					"Private bearer invite — restore this room after restarting Pi?",
+					[...PRIVATE_ROOM_OPTIONS],
+					{ signal },
+				);
+				if (
+					!selected ||
+					selected === PRIVATE_ROOM_OPTIONS[2] ||
+					!isCurrent(owner, ownerGeneration) ||
+					signal.aborted
+				) {
+					return false;
+				}
+				remember = selected === PRIVATE_ROOM_OPTIONS[0];
+			}
+			const identity = await ensureIdentity(ctx, signal, owner, ownerGeneration);
+			if (!identity || !isCurrent(owner, ownerGeneration) || signal.aborted) return false;
+			const nickname = settings.nickname;
+			if (!nickname) throw new Error("Pi Chat nickname is unavailable.");
+			const transport = deps.createTransport({ room, identity, maxPeers: 16 });
+			const session = new ChatSession({
+				room,
+				identity,
+				nickname,
+				transport,
+				onChange: (snapshot) => {
+					if (chatSession !== session || !isCurrent(owner, ownerGeneration)) return;
+					updateUi(ctx, snapshot);
+				},
+			});
+			chatSession = session;
+			ctx.ui.setStatus(CHAT_UI_KEY, "chat: joining");
+			try {
+				await session.start(AbortSignal.any([signal, controller.signal]));
+				if (!isCurrent(owner, ownerGeneration) || chatSession !== session) {
+					await session.leave();
+					return false;
+				}
+				if (remember) {
+					const rememberedRoom = rememberedRoomFromDescriptor(room);
+					const next = await updateChatSettings(
+						{
+							resume: {
+								rooms: [rememberedRoom],
+								activeRoomId: rememberedRoom.id,
+								surface: "chat",
+							},
+						},
+						{ settingsPath: deps.settingsPath, signal },
+					);
+					if (!isCurrent(owner, ownerGeneration) || chatSession !== session) {
+						await session.leave();
+						return false;
+					}
+					settings = next;
+				}
+				restoreError = undefined;
+				latestSnapshot = session.snapshot();
+				updateUi(ctx, latestSnapshot);
+				return true;
+			} catch (error) {
+				if (chatSession === session) chatSession = undefined;
+				await session.leave();
+				clearUi(ctx);
+				if (!signal.aborted && isCurrent(owner, ownerGeneration)) throw error;
+				return false;
+			}
+		};
+
+		const updateRememberedSurface = async (
+			surface: "chat" | "pi",
+			ctx: ExtensionContext,
+			owner: unknown,
+			ownerGeneration: number,
+			session: ChatSession,
+		): Promise<void> => {
+			const resume = settings.resume;
+			if (
+				!resume ||
+				resume.activeRoomId !== session.snapshot().room.id ||
+				resume.surface === surface
+			) {
+				return;
+			}
+			try {
+				const next = await updateChatSettings(
+					{ resume: { ...resume, surface } },
+					{ settingsPath: deps.settingsPath, signal: controller.signal },
+				);
+				if (isCurrent(owner, ownerGeneration) && chatSession === session) settings = next;
+			} catch (error) {
+				if (isCurrent(owner, ownerGeneration) && chatSession === session) {
+					notifySafely(
+						ctx,
+						`Pi Chat could not save the restart view: ${sanitizeSingleLine(error instanceof Error ? error.message : String(error))}.`,
+						"error",
+					);
+				}
+			}
+		};
+
+		const openChat = async (ctx: ExtensionContext): Promise<void> => {
+			const session = chatSession;
+			if (!session || session.snapshot().state === "disconnected") {
+				throw new Error("Join a Pi Chat room first.");
+			}
+			const owner = ctx.sessionManager;
+			const ownerGeneration = generation;
+			const ownerSignal = controller.signal;
+			await updateRememberedSurface("chat", ctx, owner, ownerGeneration, session);
+			if (!isCurrent(owner, ownerGeneration) || chatSession !== session) return;
+			await ctx.ui.custom<void>(
+				(tui, theme, _keybindings, done) =>
+					new ChatView({
+						tui,
+						theme,
+						getSnapshot: () => session.snapshot(),
+						send: (text) => session.send(text),
+						initialDraft: chatDraft,
+						onDraftChange: (text) => {
+							if (isCurrent(owner, ownerGeneration) && chatSession === session) chatDraft = text;
+						},
+						setViewOpen: (open) => session.setViewOpen(open),
+						subscribe: (listener) => session.subscribe(listener),
+						signal: ownerSignal,
+						onReturnToPi: () => {
+							void trackTask(updateRememberedSurface("pi", ctx, owner, ownerGeneration, session));
+						},
+						onClose: () => done(undefined),
+					}),
+			);
+			if (isCurrent(owner, ownerGeneration) && chatSession === session)
+				updateUi(ctx, session.snapshot());
+		};
+
+		const restoreRememberedRoom = async (
+			ctx: ExtensionContext,
+			ownerGeneration: number,
+			signal: AbortSignal = controller.signal,
+		): Promise<void> => {
+			const resume = settings.resume;
+			if (!resume || !settings.nickname || !settings.identitySeed || ctx.mode !== "tui") return;
+			const remembered = resume.rooms.find(({ id }) => id === resume.activeRoomId);
+			if (!remembered || !isCurrent(ctx.sessionManager, ownerGeneration)) return;
+			let room: RoomDescriptor;
+			try {
+				room = descriptorFromRememberedRoom(remembered);
+			} catch {
+				notifySafely(ctx, "Pi Chat could not restore the saved room; fix pi-chat.json.", "error");
+				return;
+			}
+			restoreError = undefined;
+			restoringRoomId = room.id;
+			try {
+				ctx.ui.setStatus(CHAT_UI_KEY, `chat: restoring ${sanitizeSingleLine(room.label)}`);
+				const joined = await joinRoom(room, ctx, signal, { remember: false });
+				if (!joined || signal.aborted || !isCurrent(ctx.sessionManager, ownerGeneration)) return;
+				if (resume.surface === "chat") await openChat(ctx);
+			} catch (error) {
+				if (isCurrent(ctx.sessionManager, ownerGeneration)) {
+					restoreError = sanitizeSingleLine(error instanceof Error ? error.message : String(error));
+					ctx.ui.setStatus(CHAT_UI_KEY, "chat: restore failed");
+					notifySafely(
+						ctx,
+						`Pi Chat could not restore ${sanitizeSingleLine(room.label)}: ${restoreError}. Use /chat to retry or forget it.`,
+						"error",
+					);
+				}
+			} finally {
+				if (restoringRoomId === room.id) restoringRoomId = undefined;
+			}
+		};
+
+		const menuSource = (ctx: ExtensionCommandContext): ChatMenuSource => {
+			const resetIdentity = createIdentity(deps.randomBytes(32));
+			const owner = ctx.sessionManager;
+			const ownerGeneration = generation;
+			const ownsMenu = () => isCurrent(owner, ownerGeneration);
+			return {
+				settingsPath: deps.settingsPath,
+				getSettings: () => settings,
+				getSnapshot: () => chatSession?.snapshot(),
+				getRestoreError: () => restoreError,
+				createPrivateRoom: () => createPrivateRoom(deps.randomBytes(32)),
+				joinRoom,
+				openChat: async (commandCtx) => {
+					if (ownsMenu()) await openChat(commandCtx);
+				},
+				retryRememberedRoom: async (commandCtx, signal) => {
+					if (!ownsMenu() || signal.aborted) return;
+					await restoreRememberedRoom(
+						commandCtx,
+						ownerGeneration,
+						AbortSignal.any([signal, controller.signal]),
+					);
+					if (restoreError) throw new Error(restoreError);
+				},
+				forgetRememberedRoom: async (signal) => {
+					if (!ownsMenu()) return;
+					if (settings.resume) {
+						const next = await updateChatSettings(
+							{ resume: null },
+							{ settingsPath: deps.settingsPath, signal },
+						);
+						if (!ownsMenu()) return;
+						settings = next;
+					}
+					restoreError = undefined;
+					clearUi(ctx);
+				},
+				leaveRoom: async (signal) => {
+					if (!ownsMenu()) return;
+					const currentRoomId = chatSession?.snapshot().room.id;
+					if (settings.resume && settings.resume.activeRoomId === currentRoomId) {
+						const next = await updateChatSettings(
+							{ resume: null },
+							{ settingsPath: deps.settingsPath, signal },
+						);
+						if (!ownsMenu()) return;
+						settings = next;
+					}
+					restoreError = undefined;
+					await disconnectRoom();
+				},
+				toggleMute(publicKey) {
+					if (!ownsMenu() || !/^[0-9a-f]{64}$/u.test(publicKey)) return undefined;
+					const muted = chatSession?.toggleMute(Buffer.from(publicKey, "hex"));
+					if (chatSession) updateUi(ctx, chatSession.snapshot());
+					return muted;
+				},
+				async updateNickname(value, signal) {
+					const previous = settings;
+					const next = await updateChatSettings(
+						{ nickname: value },
+						{ settingsPath: deps.settingsPath, signal },
+					);
+					if (!ownsMenu()) return;
+					settings = next;
+					try {
+						chatSession?.updateNickname(value);
+					} catch (error) {
+						settings = previous;
+						throw error;
+					}
+					if (chatSession) updateUi(ctx, chatSession.snapshot());
+				},
+				async updateWidgetMode(value, signal) {
+					const next = await updateChatSettings(
+						{ widgetMode: value },
+						{ settingsPath: deps.settingsPath, signal },
+					);
+					if (!ownsMenu()) return;
+					settings = next;
+					updateUi(ctx, chatSession?.snapshot());
+				},
+				getIdentityResetPreview: () => {
+					const current = settings.identitySeed
+						? formatIdentityLabel(
+								settings.nickname ?? "anonymous",
+								createIdentity(Buffer.from(settings.identitySeed, "base64url")).publicKey,
+							)
+						: "not created";
+					return {
+						current,
+						next: formatIdentityLabel(settings.nickname ?? "anonymous", resetIdentity.publicKey),
+					};
+				},
+				async resetIdentity(signal) {
+					const next = await updateChatSettings(
+						{ identitySeed: resetIdentity.seed, resume: null },
+						{ settingsPath: deps.settingsPath, signal },
+					);
+					if (!ownsMenu()) return;
+					settings = next;
+					await disconnectRoom();
+				},
+			};
+		};
+
+		pi.registerCommand("chat", {
+			description: "Open experimental peer-to-peer developer chat",
+			handler: async (args, ctx) => {
+				if (ctx.mode !== "tui") throw new Error("Pi Chat requires Pi TUI mode.");
+				const owner = ctx.sessionManager;
+				const ownerGeneration = generation;
+				if (!isCurrent(owner, ownerGeneration)) throw new Error("Pi Chat session is stale.");
+				const input = args.trim();
+				if (!input) {
+					await showChatMenu(ctx, menuSource(ctx), {
+						signal: controller.signal,
+						isCurrent: () => isCurrent(owner, ownerGeneration),
+					});
+					return;
+				}
+				if (/\s/u.test(input)) {
+					notifySafely(ctx, USAGE, "warning");
+					return;
+				}
+				let room: RoomDescriptor;
+				let openAfterJoin = false;
+				if (input.startsWith("pichat:")) {
+					openAfterJoin = true;
+					try {
+						room = parseInvite(input);
+					} catch {
+						notifySafely(ctx, USAGE, "warning");
+						return;
+					}
+				} else if (input.startsWith("#")) {
+					openAfterJoin = true;
+					try {
+						room = createPublicRoom(input.slice(1));
+					} catch {
+						notifySafely(ctx, USAGE, "warning");
+						return;
+					}
+					const confirmed = await ctx.ui.confirm(
+						"Join public room?",
+						"Anyone can join or record it. DHT and direct peers may observe network metadata.",
+						{ signal: controller.signal },
+					);
+					if (!confirmed || !isCurrent(owner, ownerGeneration)) return;
+				} else {
+					notifySafely(ctx, USAGE, "warning");
+					return;
+				}
+				const joined = await joinRoom(
+					room,
+					ctx,
+					controller.signal,
+					room.kind === "public" ? { remember: true } : undefined,
+				);
+				if (
+					joined &&
+					openAfterJoin &&
+					!controller.signal.aborted &&
+					isCurrent(owner, ownerGeneration)
+				) {
+					await openChat(ctx);
+				}
+			},
+		});
+
+		pi.on("session_start", async (_event, ctx) => {
+			controller.abort(new DOMException("Pi Chat session replaced", "AbortError"));
+			await disconnectRoom();
+			await drainOwnedTasks();
+			controller = new AbortController();
+			generation += 1;
+			activeSessionManager = ctx.sessionManager;
+			activeContext = ctx;
+			restoreError = undefined;
+			clearUi(ctx);
+			const ownerGeneration = generation;
+			const loaded = await readChatSettings(deps.settingsPath);
+			if (generation !== ownerGeneration || activeSessionManager !== ctx.sessionManager) return;
+			if (loaded.kind === "loaded") settings = loaded.settings;
+			else if (loaded.kind === "missing") settings = {};
+			else {
+				settings = {};
+				notifySafely(ctx, "Pi Chat settings are invalid; fix the file before saving.", "error");
+			}
+			if (ctx.hasUI) notifySafely(ctx, EXPERIMENTAL_WARNING, "warning");
+			if (settings.resume && ctx.mode === "tui") {
+				void trackTask(restoreRememberedRoom(ctx, ownerGeneration));
+			}
+		});
+
+		pi.on("session_shutdown", async (_event, ctx) => {
+			const owner = ctx.sessionManager;
+			if (owner !== activeSessionManager) return;
+			controller.abort(new DOMException("Pi Chat session shut down", "AbortError"));
+			const shutdownGeneration = ++generation;
+			await disconnectRoom();
+			await drainOwnedTasks();
+			await awaitChatSettingsWrites(deps.settingsPath);
+			if (activeSessionManager !== owner || generation !== shutdownGeneration) return;
+			clearUi(ctx);
+			activeSessionManager = undefined;
+			activeContext = undefined;
+		});
+	};
+}
+
+function notifySafely(
+	ctx: ExtensionContext,
+	message: string,
+	level: "info" | "warning" | "error",
+): void {
+	try {
+		ctx.ui.notify(sanitizeSingleLine(message), level);
+	} catch {
+		// Stale UI errors must not escape lifecycle cleanup.
+	}
+}
+
+export default createPiChatExtension();

--- a/packages/pi-chat/src/protocol.ts
+++ b/packages/pi-chat/src/protocol.ts
@@ -1,0 +1,337 @@
+import { createHash, createHmac, hkdfSync, timingSafeEqual } from "node:crypto";
+import { normalizeNickname } from "./identity.js";
+
+export const PROTOCOL_VERSION = 1;
+export const MAX_FRAME_BYTES = 16 * 1024;
+export const MAX_MESSAGE_BYTES = 4 * 1024;
+const PUBLIC_SLUG = /^[a-z0-9][a-z0-9-]{0,47}$/u;
+
+export interface RoomDescriptor {
+	kind: "private" | "public";
+	label: string;
+	id: string;
+	topic: Buffer;
+	key: Buffer;
+	invite?: string;
+}
+
+export interface HelloMessage {
+	v: 1;
+	type: "hello";
+	roomId: string;
+	nonce: string;
+	nickname: string;
+	proof: string;
+}
+
+export interface ChatMessage {
+	v: 1;
+	type: "chat";
+	text: string;
+	sentAt: number;
+	id: string;
+}
+
+export interface PresenceMessage {
+	v: 1;
+	type: "nickname-update" | "goodbye" | "ping" | "pong";
+	nickname?: string;
+}
+
+export interface PeerListMessage {
+	v: 1;
+	type: "peer-list";
+	publicKeys: string[];
+}
+
+export type ProtocolMessage = HelloMessage | ChatMessage | PresenceMessage | PeerListMessage;
+
+export function createPrivateRoom(secret: Uint8Array): RoomDescriptor {
+	if (secret.byteLength !== 32) throw new Error("Private room secrets must be 32 bytes.");
+	const bytes = Buffer.from(secret);
+	const topic = domainHash("pi-chat/discovery/private/v1", bytes);
+	return {
+		kind: "private",
+		label: `private ${shortRoomId(topic)}`,
+		id: topic.toString("base64url"),
+		topic,
+		key: deriveRoomKey(bytes),
+		invite: `pichat:v1:${bytes.toString("base64url")}`,
+	};
+}
+
+export function parseInvite(value: string): RoomDescriptor {
+	const match = /^pichat:v1:([A-Za-z0-9_-]{43})$/u.exec(value.trim());
+	const encodedSecret = match?.[1];
+	if (!encodedSecret) throw new Error("This is not a valid Pi Chat invite.");
+	const secret = Buffer.from(encodedSecret, "base64url");
+	if (secret.length !== 32) throw new Error("This is not a valid Pi Chat invite.");
+	return createPrivateRoom(secret);
+}
+
+export function createPublicRoom(slug: string): RoomDescriptor {
+	if (!PUBLIC_SLUG.test(slug)) {
+		throw new Error("A public room slug must use lowercase letters, numbers, or hyphens.");
+	}
+	const material = Buffer.from(`pi-chat/public/v1:${slug}`, "utf8");
+	const topic = createHash("sha256").update(material).digest();
+	return {
+		kind: "public",
+		label: `#${slug}`,
+		id: topic.toString("base64url"),
+		topic,
+		key: deriveRoomKey(material),
+	};
+}
+
+export function createHello(
+	room: RoomDescriptor,
+	nicknameValue: string,
+	senderPublicKey: Uint8Array,
+	receiverPublicKey: Uint8Array,
+	nonceBytes: Uint8Array,
+): HelloMessage {
+	const nickname = normalizeNickname(nicknameValue);
+	if (!nickname) throw new Error("Nickname is invalid.");
+	if (senderPublicKey.byteLength !== 32 || receiverPublicKey.byteLength !== 32) {
+		throw new Error("Peer public keys must be 32 bytes.");
+	}
+	if (nonceBytes.byteLength !== 16) throw new Error("Handshake nonces must be 16 bytes.");
+	const nonce = Buffer.from(nonceBytes).toString("base64url");
+	return {
+		v: 1,
+		type: "hello",
+		roomId: room.id,
+		nonce,
+		nickname,
+		proof: helloProof(room, nickname, senderPublicKey, receiverPublicKey, nonce),
+	};
+}
+
+export function verifyHello(
+	value: unknown,
+	room: RoomDescriptor,
+	senderPublicKey: Uint8Array,
+	receiverPublicKey: Uint8Array,
+): HelloMessage | undefined {
+	if (!isRecord(value) || value.v !== 1 || value.type !== "hello") return undefined;
+	if (
+		value.roomId !== room.id ||
+		typeof value.nonce !== "string" ||
+		typeof value.proof !== "string"
+	) {
+		return undefined;
+	}
+	const nickname = normalizeNickname(value.nickname);
+	if (!nickname || !/^[A-Za-z0-9_-]{22}$/u.test(value.nonce)) return undefined;
+	const expected = helloProof(room, nickname, senderPublicKey, receiverPublicKey, value.nonce);
+	const actualBytes = Buffer.from(value.proof, "base64url");
+	const expectedBytes = Buffer.from(expected, "base64url");
+	if (actualBytes.length !== expectedBytes.length || !timingSafeEqual(actualBytes, expectedBytes)) {
+		return undefined;
+	}
+	return {
+		v: 1,
+		type: "hello",
+		roomId: room.id,
+		nonce: value.nonce,
+		nickname,
+		proof: value.proof,
+	};
+}
+
+export function createChatMessage(text: string, sentAt: number, id: string): ChatMessage {
+	if (!text || Buffer.byteLength(text, "utf8") > MAX_MESSAGE_BYTES) {
+		throw new Error("Chat message is empty or too large.");
+	}
+	if (!Number.isSafeInteger(sentAt) || sentAt < 0) throw new Error("Message timestamp is invalid.");
+	if (!validId(id)) throw new Error("Message id is invalid.");
+	return { v: 1, type: "chat", text, sentAt, id };
+}
+
+export function parseProtocolMessage(value: unknown): ProtocolMessage | undefined {
+	if (!isRecord(value) || value.v !== 1 || typeof value.type !== "string") return undefined;
+	if (value.type === "chat") {
+		if (
+			typeof value.text !== "string" ||
+			!value.text ||
+			Buffer.byteLength(value.text, "utf8") > MAX_MESSAGE_BYTES ||
+			!Number.isSafeInteger(value.sentAt) ||
+			(value.sentAt as number) < 0 ||
+			!validId(value.id)
+		) {
+			return undefined;
+		}
+		return {
+			v: 1,
+			type: "chat",
+			text: value.text,
+			sentAt: value.sentAt as number,
+			id: value.id as string,
+		};
+	}
+	if (value.type === "hello") {
+		if (
+			typeof value.roomId !== "string" ||
+			typeof value.nonce !== "string" ||
+			typeof value.proof !== "string" ||
+			!normalizeNickname(value.nickname)
+		) {
+			return undefined;
+		}
+		return value as unknown as HelloMessage;
+	}
+	if (value.type === "nickname-update") {
+		const nickname = normalizeNickname(value.nickname);
+		return nickname ? { v: 1, type: "nickname-update", nickname } : undefined;
+	}
+	if (value.type === "peer-list") {
+		if (
+			!Array.isArray(value.publicKeys) ||
+			value.publicKeys.length > 16 ||
+			!value.publicKeys.every((key) => typeof key === "string" && /^[0-9a-f]{64}$/u.test(key))
+		) {
+			return undefined;
+		}
+		return { v: 1, type: "peer-list", publicKeys: [...new Set(value.publicKeys)] };
+	}
+	if (value.type === "goodbye" || value.type === "ping" || value.type === "pong") {
+		return { v: 1, type: value.type };
+	}
+	return undefined;
+}
+
+export function encodeFrame(message: ProtocolMessage): Buffer {
+	const payload = Buffer.from(JSON.stringify(message), "utf8");
+	if (payload.length > MAX_FRAME_BYTES) throw new Error("Protocol frame exceeds the size limit.");
+	const header = Buffer.allocUnsafe(4);
+	header.writeUInt32BE(payload.length);
+	return Buffer.concat([header, payload]);
+}
+
+export class FrameDecoder {
+	private buffer = Buffer.alloc(0);
+
+	push(chunk: Uint8Array): ProtocolMessage[] {
+		if (chunk.byteLength === 0) return [];
+		const incoming = Buffer.from(chunk);
+		const messages: ProtocolMessage[] = [];
+		let offset = 0;
+		while (offset < incoming.length) {
+			if (this.buffer.length < 4) {
+				const headerBytes = Math.min(4 - this.buffer.length, incoming.length - offset);
+				this.buffer = Buffer.concat([this.buffer, incoming.subarray(offset, offset + headerBytes)]);
+				offset += headerBytes;
+				if (this.buffer.length < 4) break;
+			}
+			const length = this.buffer.readUInt32BE(0);
+			if (length > MAX_FRAME_BYTES) {
+				this.buffer = Buffer.alloc(0);
+				throw new Error("Protocol frame exceeds the size limit.");
+			}
+			const frameBytes = length + 4;
+			if (this.buffer.length < frameBytes) {
+				const payloadBytes = Math.min(frameBytes - this.buffer.length, incoming.length - offset);
+				this.buffer = Buffer.concat([
+					this.buffer,
+					incoming.subarray(offset, offset + payloadBytes),
+				]);
+				offset += payloadBytes;
+				if (this.buffer.length < frameBytes) break;
+			}
+			const payload = this.buffer.subarray(4, frameBytes);
+			this.buffer = Buffer.alloc(0);
+			let text: string;
+			try {
+				text = new TextDecoder("utf-8", { fatal: true }).decode(payload);
+			} catch {
+				throw new Error("Protocol frame contains invalid UTF-8.");
+			}
+			let value: unknown;
+			try {
+				value = JSON.parse(text) as unknown;
+			} catch {
+				throw new Error("Protocol frame contains invalid JSON.");
+			}
+			const parsed = parseProtocolMessage(value);
+			if (!parsed) throw new Error("Protocol frame has an invalid message shape.");
+			messages.push(parsed);
+		}
+		return messages;
+	}
+}
+
+export class PeerRateLimiter {
+	private tokens: number;
+	private lastRefill: number;
+	private readonly burst: number;
+	private readonly refillPerSecond: number;
+	private readonly now: () => number;
+
+	constructor(options: { burst: number; refillPerSecond: number; now?: () => number }) {
+		if (options.burst <= 0 || options.refillPerSecond <= 0) {
+			throw new Error("Rate limiter values must be positive.");
+		}
+		this.burst = options.burst;
+		this.tokens = options.burst;
+		this.refillPerSecond = options.refillPerSecond;
+		this.now = options.now ?? Date.now;
+		this.lastRefill = this.now();
+	}
+
+	accept(): boolean {
+		const current = this.now();
+		const elapsed = Math.max(0, current - this.lastRefill);
+		this.lastRefill = current;
+		this.tokens = Math.min(this.burst, this.tokens + (elapsed / 1000) * this.refillPerSecond);
+		if (this.tokens < 1) return false;
+		this.tokens -= 1;
+		return true;
+	}
+}
+
+function deriveRoomKey(material: Uint8Array): Buffer {
+	return Buffer.from(
+		hkdfSync("sha256", material, Buffer.from("pi-chat/v1"), Buffer.from("room-handshake"), 32),
+	);
+}
+
+function domainHash(domain: string, material: Uint8Array): Buffer {
+	return createHash("sha256")
+		.update(domain)
+		.update(Buffer.from([0]))
+		.update(material)
+		.digest();
+}
+
+function shortRoomId(topic: Uint8Array): string {
+	return Buffer.from(topic).subarray(0, 5).toString("base64url");
+}
+
+function helloProof(
+	room: RoomDescriptor,
+	nickname: string,
+	senderPublicKey: Uint8Array,
+	receiverPublicKey: Uint8Array,
+	nonce: string,
+): string {
+	const canonical = JSON.stringify([
+		PROTOCOL_VERSION,
+		room.id,
+		nonce,
+		nickname,
+		Buffer.from(senderPublicKey).toString("hex"),
+		Buffer.from(receiverPublicKey).toString("hex"),
+	]);
+	return createHmac("sha256", room.key).update(canonical).digest("base64url");
+}
+
+function validId(value: unknown): value is string {
+	return (
+		typeof value === "string" && value.length > 0 && value.length <= 64 && !/\p{Cc}/u.test(value)
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/pi-chat/src/settings.ts
+++ b/packages/pi-chat/src/settings.ts
@@ -1,0 +1,334 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, lstat, mkdir, open, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { normalizeNickname } from "./identity.js";
+import { createPublicRoom, parseInvite, type RoomDescriptor } from "./protocol.js";
+
+export const CHAT_SETTINGS_FILE = "pi-chat.json";
+const MAX_SETTINGS_BYTES = 64 * 1024;
+export type WidgetMode = "dock" | "count" | "latest" | "off";
+
+export type RememberedRoom =
+	| { id: string; kind: "public"; slug: string }
+	| { id: string; kind: "private"; invite: string };
+
+export interface ChatResumeSettings {
+	rooms: RememberedRoom[];
+	activeRoomId: string;
+	surface: "chat" | "pi";
+}
+
+export interface ChatSettings {
+	nickname?: string;
+	identitySeed?: string;
+	widgetMode?: WidgetMode;
+	resume?: ChatResumeSettings;
+}
+
+export type ChatSettingsPatch = Partial<Omit<ChatSettings, "resume">> & {
+	resume?: ChatResumeSettings | null;
+};
+
+export type ChatSettingsLoadResult =
+	| { kind: "missing" }
+	| { kind: "invalid"; reason: string }
+	| { kind: "loaded"; settings: ChatSettings };
+
+export interface UpdateChatSettingsOptions {
+	settingsPath?: string;
+	signal?: AbortSignal;
+	beforeRename?: (temporaryPath: string, settingsPath: string) => Promise<void>;
+	setPrivateMode?: (path: string) => Promise<void>;
+}
+
+type SettingsDocument = Record<string, unknown>;
+const queues = new Map<string, Promise<void>>();
+
+export function chatSettingsPath(): string {
+	return join(getAgentDir(), CHAT_SETTINGS_FILE);
+}
+
+export function normalizeChatSettings(value: unknown): ChatSettings | undefined {
+	if (!isRecord(value)) return undefined;
+	const settings: ChatSettings = {};
+	if (Object.hasOwn(value, "nickname")) {
+		const nickname = normalizeNickname(value.nickname);
+		if (!nickname) return undefined;
+		settings.nickname = nickname;
+	}
+	if (Object.hasOwn(value, "identitySeed")) {
+		if (typeof value.identitySeed !== "string" || !validSeed(value.identitySeed)) return undefined;
+		settings.identitySeed = value.identitySeed;
+	}
+	if (Object.hasOwn(value, "widgetMode")) {
+		if (
+			value.widgetMode !== "dock" &&
+			value.widgetMode !== "count" &&
+			value.widgetMode !== "latest" &&
+			value.widgetMode !== "off"
+		) {
+			return undefined;
+		}
+		settings.widgetMode = value.widgetMode;
+	}
+	if (Object.hasOwn(value, "resume")) {
+		const resume = normalizeResumeSettings(value.resume);
+		if (!resume || !settings.nickname || !settings.identitySeed) return undefined;
+		settings.resume = resume;
+	}
+	return settings;
+}
+
+export async function readChatSettings(
+	settingsPath = chatSettingsPath(),
+): Promise<ChatSettingsLoadResult> {
+	await queues.get(settingsPath);
+	try {
+		const contents = await readSettings(settingsPath);
+		try {
+			const settings = normalizeChatSettings(JSON.parse(contents) as unknown);
+			return settings
+				? { kind: "loaded", settings }
+				: { kind: "invalid", reason: `${settingsPath}: invalid settings shape` };
+		} catch {
+			return { kind: "invalid", reason: `${settingsPath}: invalid JSON` };
+		}
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") return { kind: "missing" };
+		return { kind: "invalid", reason: `${settingsPath}: ${safeError(error)}` };
+	}
+}
+
+export function updateChatSettings(
+	patch: ChatSettingsPatch,
+	options: UpdateChatSettingsOptions = {},
+): Promise<ChatSettings> {
+	const settingsPath = options.settingsPath ?? chatSettingsPath();
+	return enqueue(settingsPath, async () => {
+		options.signal?.throwIfAborted();
+		const current = await readDocumentForUpdate(settingsPath);
+		const updated: SettingsDocument = { ...current, ...patch };
+		if (Object.hasOwn(patch, "resume")) {
+			if (patch.resume === null) delete updated.resume;
+			else if (patch.resume === undefined) {
+				if (Object.hasOwn(current, "resume")) updated.resume = current.resume;
+				else delete updated.resume;
+			} else updated.resume = mergeResumeDocument(current.resume, patch.resume);
+		}
+		const settings = normalizeChatSettings(updated);
+		if (!settings) throw new Error(`Pi Chat settings at ${settingsPath} have an invalid shape.`);
+		await publish(settingsPath, updated, options);
+		return settings;
+	});
+}
+
+export function rememberedRoomFromDescriptor(room: RoomDescriptor): RememberedRoom {
+	if (room.kind === "public") {
+		const slug = room.label.startsWith("#") ? room.label.slice(1) : room.label;
+		const reconstructed = createPublicRoom(slug);
+		if (reconstructed.id !== room.id) throw new Error("Public room descriptor is inconsistent.");
+		return { id: room.id, kind: "public", slug };
+	}
+	if (!room.invite || parseInvite(room.invite).id !== room.id) {
+		throw new Error("Private room descriptor is inconsistent.");
+	}
+	return { id: room.id, kind: "private", invite: room.invite };
+}
+
+export function descriptorFromRememberedRoom(room: RememberedRoom): RoomDescriptor {
+	const descriptor =
+		room.kind === "public" ? createPublicRoom(room.slug) : parseInvite(room.invite);
+	if (descriptor.id !== room.id) throw new Error("Remembered room is inconsistent.");
+	return descriptor;
+}
+
+export async function awaitChatSettingsWrites(settingsPath = chatSettingsPath()): Promise<void> {
+	await queues.get(settingsPath);
+}
+
+function enqueue<T>(path: string, operation: () => Promise<T>): Promise<T> {
+	const previous = queues.get(path) ?? Promise.resolve();
+	const result = previous.then(operation, operation);
+	const settled = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	queues.set(path, settled);
+	void settled.finally(() => {
+		if (queues.get(path) === settled) queues.delete(path);
+	});
+	return result;
+}
+
+async function readDocumentForUpdate(path: string): Promise<SettingsDocument> {
+	let contents: string;
+	try {
+		contents = await readSettings(path);
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") return {};
+		throw new Error(`Pi Chat settings at ${path} are invalid: ${safeError(error)}`);
+	}
+	let value: unknown;
+	try {
+		value = JSON.parse(contents) as unknown;
+	} catch {
+		throw new Error(`Pi Chat settings at ${path} are invalid: invalid JSON`);
+	}
+	if (!isRecord(value) || !normalizeChatSettings(value)) {
+		throw new Error(`Pi Chat settings at ${path} are invalid: invalid settings shape`);
+	}
+	return value;
+}
+
+async function readSettings(path: string): Promise<string> {
+	const pathStats = await lstat(path);
+	if (pathStats.isSymbolicLink() || !pathStats.isFile()) {
+		throw new Error("settings path is not a regular file");
+	}
+	const noFollow = constants.O_NOFOLLOW ?? 0;
+	const handle = await open(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | noFollow);
+	try {
+		const stats = await handle.stat();
+		if (!stats.isFile() || stats.dev !== pathStats.dev || stats.ino !== pathStats.ino) {
+			throw new Error("settings path changed while opening");
+		}
+		if (stats.size > MAX_SETTINGS_BYTES) {
+			throw new Error(`settings file exceeds ${MAX_SETTINGS_BYTES} bytes`);
+		}
+		const buffer = Buffer.alloc(MAX_SETTINGS_BYTES + 1);
+		let offset = 0;
+		while (offset < buffer.length) {
+			const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+			if (bytesRead === 0) break;
+			offset += bytesRead;
+		}
+		if (offset > MAX_SETTINGS_BYTES)
+			throw new Error(`settings file exceeds ${MAX_SETTINGS_BYTES} bytes`);
+		try {
+			return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+				buffer.subarray(0, offset),
+			);
+		} catch {
+			throw new Error("settings file is not valid UTF-8");
+		}
+	} finally {
+		await handle.close();
+	}
+}
+
+async function publish(
+	path: string,
+	document: SettingsDocument,
+	options: UpdateChatSettingsOptions,
+): Promise<void> {
+	options.signal?.throwIfAborted();
+	const contents = `${JSON.stringify(document, null, 2)}\n`;
+	if (Buffer.byteLength(contents) > MAX_SETTINGS_BYTES) {
+		throw new Error(`Pi Chat settings document exceeds ${MAX_SETTINGS_BYTES} bytes.`);
+	}
+	const directory = dirname(path);
+	await mkdir(directory, { recursive: true });
+	const temporaryPath = join(directory, `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+	try {
+		await writeFile(temporaryPath, contents, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: 0o600,
+			signal: options.signal,
+		});
+		await options.beforeRename?.(temporaryPath, path);
+		options.signal?.throwIfAborted();
+		if (process.platform !== "win32") {
+			await (options.setPrivateMode ?? ((target) => chmod(target, 0o600)))(temporaryPath);
+			options.signal?.throwIfAborted();
+		}
+		await rename(temporaryPath, path);
+	} catch (error) {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+		throw error;
+	}
+}
+
+function normalizeResumeSettings(value: unknown): ChatResumeSettings | undefined {
+	if (!isRecord(value) || !Array.isArray(value.rooms)) return undefined;
+	if (value.rooms.length === 0 || value.rooms.length > 16) return undefined;
+	if (typeof value.activeRoomId !== "string") return undefined;
+	if (value.surface !== "chat" && value.surface !== "pi") return undefined;
+	const rooms: RememberedRoom[] = [];
+	const ids = new Set<string>();
+	for (const candidate of value.rooms) {
+		const room = normalizeRememberedRoom(candidate);
+		if (!room || ids.has(room.id)) return undefined;
+		ids.add(room.id);
+		rooms.push(room);
+	}
+	if (!ids.has(value.activeRoomId)) return undefined;
+	return { rooms, activeRoomId: value.activeRoomId, surface: value.surface };
+}
+
+function normalizeRememberedRoom(value: unknown): RememberedRoom | undefined {
+	if (!isRecord(value) || typeof value.id !== "string") return undefined;
+	try {
+		if (
+			value.kind === "public" &&
+			typeof value.slug === "string" &&
+			!Object.hasOwn(value, "invite")
+		) {
+			const room = createPublicRoom(value.slug);
+			return room.id === value.id ? { id: room.id, kind: "public", slug: value.slug } : undefined;
+		}
+		if (
+			value.kind === "private" &&
+			typeof value.invite === "string" &&
+			!Object.hasOwn(value, "slug")
+		) {
+			const room = parseInvite(value.invite);
+			return room.id === value.id
+				? { id: room.id, kind: "private", invite: value.invite }
+				: undefined;
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
+}
+
+function mergeResumeDocument(current: unknown, next: ChatResumeSettings): SettingsDocument {
+	const currentResume = isRecord(current) ? current : {};
+	const existingRooms = new Map<string, SettingsDocument>();
+	if (Array.isArray(currentResume.rooms)) {
+		for (const candidate of currentResume.rooms) {
+			if (isRecord(candidate) && typeof candidate.id === "string") {
+				existingRooms.set(candidate.id, candidate);
+			}
+		}
+	}
+	return {
+		...currentResume,
+		rooms: next.rooms.map((room) => ({ ...existingRooms.get(room.id), ...room })),
+		activeRoomId: next.activeRoomId,
+		surface: next.surface,
+	};
+}
+
+function validSeed(value: string): boolean {
+	try {
+		return /^[A-Za-z0-9_-]{43}$/u.test(value) && Buffer.from(value, "base64url").length === 32;
+	} catch {
+		return false;
+	}
+}
+
+function isRecord(value: unknown): value is SettingsDocument {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function safeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-chat/src/text.ts
+++ b/packages/pi-chat/src/text.ts
@@ -1,0 +1,73 @@
+const REPLACEMENT = "�";
+
+export function sanitizeChatText(value: string): string {
+	const normalized = value.replace(/\r\n?/gu, "\n");
+	let result = "";
+	for (let index = 0; index < normalized.length; index += 1) {
+		const code = normalized.charCodeAt(index);
+		if (code === 0x1b) {
+			index = escapeSequenceEnd(normalized, index);
+			result += REPLACEMENT;
+			continue;
+		}
+		const point = normalized.codePointAt(index) ?? code;
+		if (isBidiControl(point) || isUnsafeControl(point)) {
+			result += REPLACEMENT;
+			continue;
+		}
+		if (code === 0x09) {
+			result += "    ";
+			continue;
+		}
+		result += String.fromCodePoint(point);
+		if (point > 0xffff) index += 1;
+	}
+	return result;
+}
+
+export function sanitizeSingleLine(value: string): string {
+	return sanitizeChatText(value).replace(/\n+/gu, " ");
+}
+
+function escapeSequenceEnd(value: string, start: number): number {
+	const introducer = value.charCodeAt(start + 1);
+	if (introducer === 0x5d) {
+		for (let index = start + 2; index < value.length; index += 1) {
+			const code = value.charCodeAt(index);
+			if (code === 0x07) return index;
+			if (code === 0x1b && value.charCodeAt(index + 1) === 0x5c) return index + 1;
+		}
+		return value.length - 1;
+	}
+	if (introducer === 0x50) {
+		for (let index = start + 2; index < value.length; index += 1) {
+			if (value.charCodeAt(index) === 0x1b && value.charCodeAt(index + 1) === 0x5c) {
+				return index + 1;
+			}
+		}
+		return value.length - 1;
+	}
+	if (introducer === 0x5b) {
+		for (let index = start + 2; index < value.length; index += 1) {
+			const code = value.charCodeAt(index);
+			if (code >= 0x40 && code <= 0x7e) return index;
+		}
+		return value.length - 1;
+	}
+	return Math.min(start + 1, value.length - 1);
+}
+
+function isUnsafeControl(point: number): boolean {
+	if (point === 0x0a || point === 0x09) return false;
+	return point <= 0x1f || (point >= 0x7f && point <= 0x9f);
+}
+
+function isBidiControl(point: number): boolean {
+	return (
+		point === 0x061c ||
+		point === 0x200e ||
+		point === 0x200f ||
+		(point >= 0x202a && point <= 0x202e) ||
+		(point >= 0x2066 && point <= 0x2069)
+	);
+}

--- a/packages/pi-chat/src/widget.ts
+++ b/packages/pi-chat/src/widget.ts
@@ -1,0 +1,87 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { ChatSnapshot, TranscriptEntry } from "./chat-session.js";
+import type { WidgetMode } from "./settings.js";
+import { sanitizeChatText, sanitizeSingleLine } from "./text.js";
+
+export function renderChatWidget(
+	snapshot: ChatSnapshot,
+	mode: WidgetMode,
+	width: number,
+	theme: Theme,
+	terminalRows = 24,
+): string[] {
+	if (mode === "off" || snapshot.state === "disconnected") return [];
+	const safeWidth = Math.max(1, width);
+	if (mode === "dock") return renderRoomDock(snapshot, safeWidth, terminalRows, theme);
+
+	const peers = snapshot.peers.length;
+	const presence = peers === 0 ? "alone" : `${peers} direct peer${peers === 1 ? "" : "s"}`;
+	const unread = snapshot.unread > 0 ? `${snapshot.unread} unread · ` : "";
+	const attention = snapshot.state === "degraded" ? " · reconnecting" : "";
+	const header = truncateToWidth(
+		theme.fg(
+			snapshot.state === "degraded" ? "warning" : "accent",
+			`chat · ${unread}${presence}${attention}`,
+		),
+		safeWidth,
+	);
+	const roomHint = truncateToWidth(
+		theme.fg("dim", `${sanitizeSingleLine(snapshot.room.label)} · /chat to open`),
+		safeWidth,
+	);
+	if (mode !== "latest") return [header, roomHint];
+	const latest = snapshot.transcript.at(-1);
+	if (!latest) return [header, roomHint];
+	return [header, roomHint, renderMessagePreview(latest, safeWidth, theme, false)];
+}
+
+function renderRoomDock(
+	snapshot: ChatSnapshot,
+	width: number,
+	terminalRows: number,
+	theme: Theme,
+): string[] {
+	const peers = snapshot.peers.length;
+	const peerText = `${peers} direct peer${peers === 1 ? "" : "s"}`;
+	const stateText =
+		snapshot.state === "connecting"
+			? "joining…"
+			: snapshot.state === "degraded"
+				? `reconnecting · ${peerText}`
+				: peers === 0
+					? "waiting for peers"
+					: peerText;
+	const unread = snapshot.unread > 0 ? ` · ${snapshot.unread} unread` : "";
+	const roomTitle = `ROOM ${sanitizeSingleLine(snapshot.room.label)}`;
+	const status = `${stateText}${unread}`;
+	const color = snapshot.state === "degraded" ? "warning" : "accent";
+	const combinedHeader = `${roomTitle} · ${status}`;
+	const header =
+		visibleWidth(combinedHeader) <= width
+			? [theme.fg(color, combinedHeader)]
+			: [
+					truncateToWidth(theme.fg(color, roomTitle), width),
+					truncateToWidth(theme.fg(color, status), width),
+				];
+	const previewCount = terminalRows < 10 ? 0 : terminalRows < 18 ? 1 : terminalRows < 26 ? 2 : 3;
+	const previews = (previewCount === 0 ? [] : snapshot.transcript.slice(-previewCount)).map(
+		(entry) => renderMessagePreview(entry, width, theme, true),
+	);
+	const target = snapshot.composerOpen
+		? `Input → CHAT ${sanitizeSingleLine(snapshot.room.label)} · Esc returns to Pi/LLM`
+		: "Input → Pi/LLM · /chat then Enter to reply";
+	return [...header, ...previews, truncateToWidth(theme.fg("dim", target), width)];
+}
+
+function renderMessagePreview(
+	entry: TranscriptEntry,
+	width: number,
+	theme: Theme,
+	includeIdentity = false,
+): string {
+	const preview = sanitizeChatText(entry.text).replace(/\n+/gu, " ");
+	const label = sanitizeSingleLine(entry.label);
+	const author = includeIdentity ? label || "peer" : label.split("~", 1)[0] || "peer";
+	return truncateToWidth(theme.fg("muted", `${author}: ${preview}`), width);
+}

--- a/packages/pi-chat/test/chat-session.test.ts
+++ b/packages/pi-chat/test/chat-session.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ChatSession, type ChatTransport, type TransportPeer } from "../src/chat-session.js";
+import { createIdentity } from "../src/identity.js";
+import { createPrivateRoom, type ProtocolMessage } from "../src/protocol.js";
+
+class FakePeer implements TransportPeer {
+	readonly sent: ProtocolMessage[] = [];
+	closed = false;
+	constructor(readonly publicKey: Buffer) {}
+	send(message: ProtocolMessage): void {
+		if (!this.closed) this.sent.push(message);
+	}
+	close(): void {
+		this.closed = true;
+	}
+}
+
+class FakeTransport implements ChatTransport {
+	private listener:
+		| {
+				onPeer(peer: TransportPeer): void;
+				onMessage(peer: TransportPeer, message: ProtocolMessage): void;
+				onDisconnect(peer: TransportPeer): void;
+				onError(error: Error): void;
+		  }
+		| undefined;
+	started = false;
+	stopped = false;
+	start(listener: NonNullable<FakeTransport["listener"]>): Promise<void> {
+		this.listener = listener;
+		this.started = true;
+		return Promise.resolve();
+	}
+	stop(): Promise<void> {
+		this.stopped = true;
+		return Promise.resolve();
+	}
+	connect(peer: FakePeer): void {
+		this.listener?.onPeer(peer);
+	}
+	receive(peer: FakePeer, message: ProtocolMessage): void {
+		this.listener?.onMessage(peer, message);
+	}
+	disconnect(peer: FakePeer): void {
+		this.listener?.onDisconnect(peer);
+	}
+}
+
+function fixture() {
+	const room = createPrivateRoom(Buffer.alloc(32, 9));
+	const identity = createIdentity(Buffer.alloc(32, 1));
+	const remote = createIdentity(Buffer.alloc(32, 2));
+	const transport = new FakeTransport();
+	const session = new ChatSession({ room, identity, nickname: "Mika", transport, now: () => 100 });
+	return { room, identity, remote, transport, session };
+}
+
+test("authenticates a direct peer before exposing presence or chat", async () => {
+	const { room, identity, remote, transport, session } = fixture();
+	await session.start();
+	const peer = new FakePeer(remote.publicKey);
+	transport.connect(peer);
+	assert.equal(peer.sent[0]?.type, "hello");
+	assert.equal(session.snapshot().peers.length, 0);
+	transport.receive(
+		peer,
+		peerHello(room, "Other", remote.publicKey, identity.publicKey, Buffer.alloc(16, 4)),
+	);
+	assert.equal(session.snapshot().peers[0]?.label.startsWith("Other~"), true);
+});
+
+test("broadcasts only to authenticated unmuted peers and reports zero-peer delivery honestly", async () => {
+	const { room, identity, remote, transport, session } = fixture();
+	await session.start();
+	assert.equal(session.send("alone").deliveredTo, 0);
+	assert.equal(session.snapshot().transcript.at(-1)?.delivery, "not-delivered");
+	const peer = new FakePeer(remote.publicKey);
+	transport.connect(peer);
+	transport.receive(peer, peerHello(room, "Other", remote.publicKey, identity.publicKey));
+	const result = session.send("hello");
+	assert.equal(result.deliveredTo, 1);
+	assert.equal(peer.sent.at(-1)?.type, "chat");
+	session.mute(remote.publicKey);
+	assert.equal(session.send("muted").deliveredTo, 0);
+});
+
+test("publishes composer focus so persistent UI reports the real input target", async () => {
+	const { session } = fixture();
+	await session.start();
+	assert.equal((session.snapshot() as { composerOpen?: boolean }).composerOpen, false);
+	session.setViewOpen(true);
+	assert.equal((session.snapshot() as { composerOpen?: boolean }).composerOpen, true);
+	session.setViewOpen(false);
+	assert.equal((session.snapshot() as { composerOpen?: boolean }).composerOpen, false);
+});
+
+test("tracks unread remote messages, deduplicates ids, and bounds transcript", async () => {
+	const { room, identity, remote, transport, session } = fixture();
+	await session.start();
+	const peer = new FakePeer(remote.publicKey);
+	transport.connect(peer);
+	transport.receive(peer, peerHello(room, "Other", remote.publicKey, identity.publicKey));
+	session.setViewOpen(false);
+	const message = { v: 1, type: "chat", text: "hi", sentAt: 1, id: "same" } as const;
+	transport.receive(peer, message);
+	transport.receive(peer, message);
+	assert.equal(session.snapshot().unread, 1);
+	assert.equal(session.snapshot().transcript.filter((entry) => entry.text === "hi").length, 1);
+	for (let index = 0; index < 300; index += 1) session.send(`local ${index}`);
+	assert.equal(session.snapshot().transcript.length, 256);
+	session.setViewOpen(true);
+	assert.equal(session.snapshot().unread, 0);
+});
+
+test("nickname updates retain peer identity and hostile protocol abuse closes the peer", async () => {
+	const { room, identity, remote, transport, session } = fixture();
+	await session.start();
+	const peer = new FakePeer(remote.publicKey);
+	transport.connect(peer);
+	transport.receive(peer, peerHello(room, "Other", remote.publicKey, identity.publicKey));
+	transport.receive(peer, { v: 1, type: "nickname-update", nickname: "Renamed" });
+	assert.match(session.snapshot().peers[0]?.label ?? "", /^Renamed~/u);
+	for (let index = 0; index < 7; index += 1) {
+		transport.receive(peer, { v: 1, type: "chat", text: "flood", sentAt: 1, id: `f${index}` });
+	}
+	assert.equal(peer.closed, true);
+});
+
+test("leave is idempotent and ignores late transport continuations", async () => {
+	const { remote, transport, session } = fixture();
+	await session.start();
+	const peer = new FakePeer(remote.publicKey);
+	transport.connect(peer);
+	await Promise.all([session.leave(), session.leave()]);
+	transport.connect(new FakePeer(Buffer.alloc(32, 8)));
+	assert.equal(transport.stopped, true);
+	assert.equal(session.snapshot().state, "disconnected");
+	assert.equal(session.snapshot().peers.length, 0);
+});
+
+function peerHello(
+	room: ReturnType<typeof createPrivateRoom>,
+	nickname: string,
+	sender: Buffer,
+	receiver: Buffer,
+	nonce = Buffer.alloc(16, 3),
+) {
+	return importHello(room, nickname, sender, receiver, nonce);
+}
+
+import { createHello as importHello } from "../src/protocol.js";

--- a/packages/pi-chat/test/chat-view.test.ts
+++ b/packages/pi-chat/test/chat-view.test.ts
@@ -1,0 +1,281 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { ChatSnapshot } from "../src/chat-session.js";
+import { ChatView } from "../src/chat-view.js";
+import { createPrivateRoom } from "../src/protocol.js";
+import { sanitizeChatText, sanitizeSingleLine } from "../src/text.js";
+import { renderChatWidget } from "../src/widget.js";
+
+const room = createPrivateRoom(Buffer.alloc(32, 4));
+
+function snapshot(overrides: Partial<ChatSnapshot> = {}): ChatSnapshot {
+	return {
+		state: "connected",
+		room,
+		localLabel: "Me~AAAA-BBBB-CCCC",
+		peers: [],
+		transcript: [],
+		unread: 0,
+		composerOpen: false,
+		...overrides,
+	};
+}
+
+const theme = {
+	fg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+};
+
+test("sanitizes terminal and bidi controls before line handling", () => {
+	const hostile = "safe\u001b]8;;https://evil\u0007link\u001b]8;;\u0007\nred\u001b[31m!\u202e";
+	const rendered = sanitizeChatText(hostile);
+	assert.equal(rendered.includes("\u001b"), false);
+	assert.equal(rendered.includes("\u0007"), false);
+	assert.equal(rendered.includes("\u202e"), false);
+	assert.equal(rendered.includes("\n"), true);
+	assert.equal(sanitizeSingleLine("a\nb\u001b[2J"), "a b�");
+});
+
+test("privacy-safe widget hides message text by default and bounds every line", () => {
+	const state = snapshot({
+		unread: 2,
+		peers: [{ publicKey: "1", label: "Other~AAAA-BBBB-CCCC", nickname: "Other", muted: false }],
+		transcript: [
+			{
+				id: "1",
+				author: "remote",
+				label: "Other~AAAA-BBBB-CCCC",
+				publicKey: "1",
+				text: "private message",
+				sentAt: 1,
+			},
+		],
+	});
+	const count = renderChatWidget(state, "count", 28, theme as never);
+	assert.equal(count.join("\n").includes("private message"), false);
+	assert.match(count.join("\n"), /2 unread/u);
+	const latest = renderChatWidget(state, "latest", 28, theme as never);
+	assert.match(latest.join("\n"), /private message/u);
+	assert.equal(
+		latest.every((line) => visibleWidth(line) <= 28),
+		true,
+	);
+	assert.deepEqual(renderChatWidget(state, "off", 28, theme as never), []);
+});
+
+test("room dock keeps status, bounded recent messages, and the real input target visible", () => {
+	const transcript = ["old", "one", "two", "three"].map((text, index) => ({
+		id: String(index),
+		author: "remote" as const,
+		label: `開發者${index}~AAAA-BBBB-CCCC`,
+		publicKey: String(index),
+		text: `${text}\u001b[2J`,
+		sentAt: index,
+	}));
+	const renderDock = (state: ChatSnapshot, width: number, rows: number) =>
+		(
+			renderChatWidget as unknown as (
+				snapshot: ChatSnapshot,
+				mode: "dock",
+				width: number,
+				theme: unknown,
+				rows: number,
+			) => string[]
+		)(state, "dock", width, theme, rows);
+	const state = snapshot({
+		peers: [{ publicKey: "1", label: "Other~AAAA-BBBB-CCCC", nickname: "Other", muted: false }],
+		transcript,
+	});
+	const wide = renderDock(state, 64, 30);
+	assert.match(wide[0] ?? "", /ROOM.*private/u);
+	assert.doesNotMatch(wide.join("\n"), /old/u);
+	assert.match(wide.join("\n"), /one/u);
+	assert.match(wide.join("\n"), /three/u);
+	assert.match(wide.at(-1) ?? "", /Input → Pi\/LLM/u);
+	assert.equal(wide.join("\n").includes("\u001b[2J"), false);
+
+	const composing = renderDock({ ...state, composerOpen: true } as ChatSnapshot, 40, 18);
+	assert.match(composing.at(-1) ?? "", /Input → CHAT/u);
+	assert.equal(
+		composing.every((line) => visibleWidth(line) <= 40),
+		true,
+	);
+	const low = renderDock(state, 20, 8);
+	assert.equal(low.length <= 3, true);
+	assert.equal(
+		low.every((line) => visibleWidth(line) <= 20),
+		true,
+	);
+	for (const width of [20, 40, 60, 80, 100, 160]) {
+		for (const rows of [8, 18, 30]) {
+			const rendered = renderDock(state, width, rows);
+			assert.equal(
+				rendered.every((line) => visibleWidth(line) <= width),
+				true,
+				`${width}x${rows}`,
+			);
+		}
+	}
+});
+
+test("room dock distinguishes joining, waiting, and degraded partial connectivity", () => {
+	const joining = renderChatWidget(
+		snapshot({ state: "connecting" }),
+		"dock" as never,
+		48,
+		theme as never,
+	);
+	assert.match(joining.join("\n"), /joining/u);
+	const waiting = renderChatWidget(snapshot(), "dock" as never, 48, theme as never);
+	assert.match(waiting.join("\n"), /waiting for peers/u);
+	const degraded = renderChatWidget(
+		snapshot({
+			state: "degraded",
+			peers: [{ publicKey: "1", label: "Other~AAAA", nickname: "Other", muted: false }],
+		}),
+		"dock" as never,
+		48,
+		theme as never,
+	);
+	assert.match(degraded.join("\n"), /reconnecting[\s\S]*1 direct peer/u);
+});
+
+test("chat composer makes its target explicit, preserves failed drafts, and clears successful sends", () => {
+	let current = snapshot();
+	let deliveredTo = 0;
+	let sendError: Error | undefined;
+	const sent: string[] = [];
+	const drafts: string[] = [];
+	const viewStates: boolean[] = [];
+	let closed = 0;
+	let returnedToPi = 0;
+	let renders = 0;
+	let subscription: (() => void) | undefined;
+	let unsubscribed = 0;
+	const view = new ChatView({
+		tui: { terminal: { rows: 30 }, requestRender: () => renders++ } as never,
+		theme: theme as never,
+		getSnapshot: () => current,
+		send: (text) => {
+			if (sendError) throw sendError;
+			sent.push(text);
+			return { id: "sent", deliveredTo };
+		},
+		initialDraft: "",
+		onDraftChange: (text) => drafts.push(text),
+		setViewOpen: (open) => viewStates.push(open),
+		subscribe: (listener) => {
+			subscription = listener;
+			return () => unsubscribed++;
+		},
+		onReturnToPi: () => returnedToPi++,
+		onClose: () => closed++,
+	});
+	view.focused = true;
+	assert.equal(view.focused, true);
+	subscription?.();
+	assert.match(view.render(48).join("\n"), /CHAT INPUT → private/u);
+	view.handleInput("hello");
+	view.handleInput("\r");
+	assert.deepEqual(sent, []);
+	assert.equal(drafts.at(-1), "hello");
+	assert.match(view.render(48).join("\n"), /message kept/i);
+
+	current = snapshot({
+		peers: [{ publicKey: "1", label: "開發者~AAAA-BBBB-CCCC", nickname: "開發者", muted: false }],
+		transcript: [
+			{
+				id: "1",
+				author: "remote",
+				label: "開發者~AAAA-BBBB-CCCC",
+				publicKey: "1",
+				text: `  code\n    indented\n${"long ".repeat(30)}`,
+				sentAt: 1,
+			},
+		],
+	});
+	view.handleInput("\r");
+	assert.deepEqual(sent, ["hello"]);
+	assert.equal(drafts.at(-1), "hello");
+	assert.match(view.render(48).join("\n"), /message kept/i);
+	sendError = new Error("Message is too large");
+	view.handleInput("\r");
+	assert.deepEqual(sent, ["hello"]);
+	assert.equal(drafts.at(-1), "hello");
+	assert.match(view.render(48).join("\n"), /too large/i);
+	sendError = undefined;
+	deliveredTo = 1;
+	view.handleInput("\r");
+	assert.deepEqual(sent, ["hello", "hello"]);
+	assert.equal(drafts.at(-1), "");
+
+	view.handleInput("保留草稿");
+	const narrow = view.render(24);
+	assert.equal(
+		narrow.every((line) => visibleWidth(line) <= 24),
+		true,
+	);
+	assert.equal(
+		narrow.some((line) => line.includes("    code")),
+		true,
+	);
+	view.handleInput("\u001b");
+	assert.equal(drafts.at(-1), "保留草稿");
+	assert.equal(closed, 1);
+	assert.equal(returnedToPi, 1);
+	assert.deepEqual(viewStates, [true, false]);
+	assert.equal(unsubscribed, 1);
+	assert.ok(renders > 0);
+});
+
+test("owner abort closes the composer without recording a user return", () => {
+	const controller = new AbortController();
+	const viewStates: boolean[] = [];
+	let returnedToPi = 0;
+	let closed = 0;
+	const view = new ChatView({
+		tui: { terminal: { rows: 20 }, requestRender() {} } as never,
+		theme: theme as never,
+		getSnapshot: () => snapshot(),
+		send: () => ({ id: "sent", deliveredTo: 0 }),
+		setViewOpen: (open) => viewStates.push(open),
+		signal: controller.signal,
+		onReturnToPi: () => returnedToPi++,
+		onClose: () => closed++,
+	});
+	controller.abort(new DOMException("Session replaced", "AbortError"));
+	view.dispose();
+	assert.deepEqual(viewStates, [true, false]);
+	assert.equal(returnedToPi, 0);
+	assert.equal(closed, 1);
+});
+
+test("chat composer restores retained drafts and host disposal does not record a user return", () => {
+	let draft = "之前的草稿";
+	let returnedToPi = 0;
+	const view = new ChatView({
+		tui: { terminal: { rows: 8 }, requestRender() {} } as never,
+		theme: theme as never,
+		getSnapshot: () => snapshot(),
+		send: () => ({ id: "sent", deliveredTo: 0 }),
+		initialDraft: draft,
+		onDraftChange: (text) => {
+			draft = text;
+		},
+		setViewOpen() {},
+		onReturnToPi: () => returnedToPi++,
+		onClose() {},
+	});
+	view.focused = true;
+	const lines = view.render(20);
+	assert.match(lines.join("\n"), /之前的草稿/u);
+	assert.equal(lines.length <= 6, true);
+	assert.equal(
+		lines.every((line) => visibleWidth(line) <= 20),
+		true,
+	);
+	view.dispose();
+	assert.equal(draft, "之前的草稿");
+	assert.equal(returnedToPi, 0);
+});

--- a/packages/pi-chat/test/identity.test.ts
+++ b/packages/pi-chat/test/identity.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	createIdentity,
+	formatIdentityLabel,
+	identityTag,
+	normalizeNickname,
+} from "../src/identity.js";
+
+const SEED = Buffer.from("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "hex");
+
+test("normalizes safe Unicode nicknames and rejects terminal or bidi controls", () => {
+	assert.equal(normalizeNickname("  Ｍｉｋａ  "), "Mika");
+	assert.equal(normalizeNickname("開發者👩🏽‍💻"), "開發者👩🏽‍💻");
+	assert.equal(normalizeNickname("a".repeat(25)), undefined);
+	assert.equal(normalizeNickname("bad\nname"), undefined);
+	assert.equal(normalizeNickname("bad\u001b[31m"), undefined);
+	assert.equal(normalizeNickname("left\u202eright"), undefined);
+});
+
+test("derives a stable human-readable tag from a public key", () => {
+	const publicKey = Buffer.alloc(32, 0xa5);
+	const first = identityTag(publicKey);
+	assert.match(first, /^[0-9A-HJKMNP-TV-Z]{4}(?:-[0-9A-HJKMNP-TV-Z]{4}){2}$/u);
+	assert.equal(identityTag(publicKey), first);
+	assert.notEqual(identityTag(Buffer.alloc(32, 0xa6)), first);
+	assert.equal(formatIdentityLabel("Mika", publicKey), `Mika~${first}`);
+});
+
+test("creates deterministic DHT identity material from a 32-byte seed", () => {
+	const first = createIdentity(SEED);
+	const second = createIdentity(SEED);
+	assert.equal(first.seed, SEED.toString("base64url"));
+	assert.equal(first.publicKey.length, 32);
+	assert.deepEqual(first.publicKey, second.publicKey);
+	assert.equal(first.tag, second.tag);
+	assert.throws(() => createIdentity(Buffer.alloc(31)), /32-byte/u);
+});

--- a/packages/pi-chat/test/menu.test.ts
+++ b/packages/pi-chat/test/menu.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext } from "../../../test/support.js";
+import { type ChatMenuSource, createChatMenu } from "../src/menu.js";
+import { createPrivateRoom } from "../src/protocol.js";
+
+function source(overrides: Partial<ChatMenuSource> = {}): ChatMenuSource {
+	return {
+		settingsPath: "/agent/pi-chat.json",
+		getSettings: () => ({ nickname: "Mika", widgetMode: "count" }),
+		getSnapshot: () => undefined,
+		getRestoreError: () => undefined,
+		createPrivateRoom: () => createPrivateRoom(Buffer.alloc(32, 1)),
+		joinRoom: async () => true,
+		openChat: async () => undefined,
+		retryRememberedRoom: async () => undefined,
+		forgetRememberedRoom: async () => undefined,
+		leaveRoom: async () => undefined,
+		toggleMute: () => undefined,
+		updateNickname: async () => undefined,
+		updateWidgetMode: async () => undefined,
+		getIdentityResetPreview: () => ({ current: "Mika~OLD", next: "Mika~NEW" }),
+		resetIdentity: async () => undefined,
+		...overrides,
+	};
+}
+
+const actionContext = (ctx: unknown, value?: string, itemId = "") =>
+	({
+		ctx,
+		state: {},
+		signal: new AbortController().signal,
+		itemId,
+		value,
+	}) as never;
+
+test("manager keeps disconnected and connected primary actions shallow", async () => {
+	const disconnected = createChatMenu(source());
+	const disconnectedState = await disconnected.getState();
+	const first = disconnected.menu.screens.main({ state: disconnectedState });
+	assert.equal(first.kind, "actions");
+	if (first.kind === "actions") {
+		assert.deepEqual(
+			first.items.map(({ label }) => label),
+			["Join public room", "Join with invite", "Create private room", "Settings", "Status", "Help"],
+		);
+	}
+	const connected = createChatMenu(
+		source({
+			getSnapshot: () => ({
+				state: "connected",
+				room: createPrivateRoom(Buffer.alloc(32, 1)),
+				localLabel: "Mika~AAAA-BBBB-CCCC",
+				peers: [],
+				transcript: [],
+				unread: 0,
+				composerOpen: false,
+			}),
+		}),
+	);
+	const state = await connected.getState();
+	const connectedScreen = connected.menu.screens.main({ state });
+	assert.equal(connectedScreen.kind, "actions");
+	if (connectedScreen.kind === "actions") {
+		assert.equal(connectedScreen.items.length, 7);
+		assert.match(connectedScreen.items[0]?.label ?? "", /^Open chat in private/u);
+		assert.match(connectedScreen.items.at(-1)?.label ?? "", /^Leave room/u);
+		assert.match(connectedScreen.lines?.join("\n") ?? "", /Current input: Pi\/LLM/u);
+		assert.match(connectedScreen.lines?.join("\n") ?? "", /Restart: this room will not reconnect/u);
+	}
+	const inviteScreen = connected.menu.screens.invite({ state });
+	assert.equal(inviteScreen.kind, "review");
+	if (inviteScreen.kind === "review") assert.match(inviteScreen.content, /^pichat:v1:/u);
+});
+
+test("invite and public input actions validate payloads and successful joins open chat", async () => {
+	const joined: string[] = [];
+	let opened = 0;
+	const controller = createChatMenu(
+		source({
+			joinRoom: async (room) => {
+				joined.push(room.label);
+				return true;
+			},
+			openChat: async () => {
+				opened += 1;
+			},
+		}),
+	);
+	const ctx = createMockContext({ hasUI: true, mode: "tui", confirm: async () => true });
+	const invite = createPrivateRoom(Buffer.alloc(32, 8)).invite;
+	assert.ok(invite);
+	assert.deepEqual(await controller.menu.actions.joinInvite(actionContext(ctx.ctx, invite)), {
+		kind: "close",
+	});
+	assert.deepEqual(await controller.menu.actions.joinPublic(actionContext(ctx.ctx, "pi-dev")), {
+		kind: "close",
+	});
+	assert.deepEqual(joined, [createPrivateRoom(Buffer.alloc(32, 8)).label, "#pi-dev"]);
+	assert.equal(opened, 2);
+	const rejected = await controller.menu.actions.joinInvite(actionContext(ctx.ctx, "bad"));
+	assert.equal(rejected?.kind, "rejected");
+	const cancelled = createChatMenu(
+		source({
+			joinRoom: async () => {
+				throw new Error("cancelled public join must not start");
+			},
+			openChat: async () => {
+				throw new Error("cancelled public join must not open chat");
+			},
+		}),
+	);
+	const cancelContext = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		confirm: async () => false,
+	});
+	assert.deepEqual(
+		await cancelled.menu.actions.joinPublic(actionContext(cancelContext.ctx, "pi-dev")),
+		{ kind: "stay" },
+	);
+});
+
+test("remembered restore failures expose shallow retry, replacement, and forget recovery", async () => {
+	const room = createPrivateRoom(Buffer.alloc(32, 3));
+	const controller = createChatMenu(
+		source({
+			getSettings: () => ({
+				resume: {
+					rooms: [{ id: room.id, kind: "private", invite: room.invite ?? "" }],
+					activeRoomId: room.id,
+					surface: "chat",
+				},
+			}),
+			getRestoreError: () => "network unavailable",
+		}),
+	);
+	const state = await controller.getState();
+	const screen = controller.menu.screens.main({ state });
+	assert.equal(screen.kind, "actions");
+	if (screen.kind === "actions") {
+		assert.match(screen.title, /could not restore/u);
+		assert.match(screen.lines?.join("\n") ?? "", /network unavailable/u);
+		assert.deepEqual(
+			screen.items.map(({ label }) => label),
+			[
+				`Retry ${room.label}`,
+				"Join another room",
+				`Forget ${room.label}…`,
+				"Settings",
+				"Status",
+				"Help",
+			],
+		);
+	}
+	const replacement = controller.menu.screens.joinAnother({ state });
+	assert.equal(replacement.kind, "actions");
+	if (replacement.kind === "actions") {
+		assert.deepEqual(
+			replacement.items.map(({ label }) => label),
+			["Join public room", "Join with invite", "Create private room"],
+		);
+	}
+});
+
+test("joined room display keeps four compatible choices in one flat group", async () => {
+	const controller = createChatMenu(source({ getSettings: () => ({ widgetMode: "dock" }) }));
+	const state = await controller.getState();
+	const screen = controller.menu.screens.widget({ state });
+	assert.equal(screen.kind, "choice");
+	if (screen.kind === "choice") {
+		assert.deepEqual(
+			screen.items.map(({ label }) => label),
+			["Room dock", "Latest message", "Status only", "Hidden"],
+		);
+		assert.equal(screen.currentItemId, "dock");
+	}
+});
+
+test("leaving, widget settings, and identity reset require explicit actions", async () => {
+	let left = 0;
+	let reset = 0;
+	let mode = "";
+	let toggled = "";
+	const controller = createChatMenu(
+		source({
+			leaveRoom: async () => void left++,
+			resetIdentity: async () => void reset++,
+			toggleMute: (publicKey) => {
+				toggled = publicKey;
+				return true;
+			},
+			updateWidgetMode: async (value) => {
+				mode = value;
+			},
+		}),
+	);
+	const ctx = createMockContext({ hasUI: true, mode: "tui" });
+	await controller.menu.actions.leave(actionContext(ctx.ctx));
+	await controller.menu.actions.setWidget(actionContext(ctx.ctx, undefined, "dock"));
+	await controller.menu.actions.resetIdentity(actionContext(ctx.ctx));
+	await controller.menu.actions.toggleMute(actionContext(ctx.ctx, undefined, "ab".repeat(32)));
+	assert.equal(left, 1);
+	assert.equal(mode, "dock");
+	assert.equal(reset, 1);
+	assert.equal(toggled, "ab".repeat(32));
+});

--- a/packages/pi-chat/test/network-peer-fixture.ts
+++ b/packages/pi-chat/test/network-peer-fixture.ts
@@ -1,0 +1,52 @@
+import { ChatSession } from "../src/chat-session.js";
+import { createIdentity } from "../src/identity.js";
+import { HyperswarmTransport } from "../src/network.js";
+import { createPrivateRoom } from "../src/protocol.js";
+
+const [bootstrapJson, seedText, secretText] = process.argv.slice(2);
+if (!bootstrapJson || !seedText || !secretText)
+	throw new Error("Missing network peer fixture args");
+const bootstrap = JSON.parse(Buffer.from(bootstrapJson, "base64url").toString("utf8")) as unknown[];
+const seed = Number.parseInt(seedText, 10);
+const secret = Buffer.from(secretText, "base64url");
+const identity = createIdentity(Buffer.alloc(32, seed));
+const room = createPrivateRoom(secret);
+const transport = new HyperswarmTransport({ room, identity, bootstrap, maxPeers: 8 });
+const session = new ChatSession({
+	room,
+	identity,
+	nickname: `Process${seed}`,
+	transport,
+	onChange: (snapshot) => {
+		process.send?.({
+			kind: "snapshot",
+			peers: snapshot.peers.length,
+			texts: snapshot.transcript.map(({ text }) => text),
+		});
+	},
+});
+
+process.on("message", (message: unknown) => {
+	if (!message || typeof message !== "object") return;
+	const command = Reflect.get(message, "command");
+	if (command === "send") {
+		const text = Reflect.get(message, "text");
+		if (typeof text === "string") process.send?.({ kind: "sent", ...session.send(text) });
+		return;
+	}
+	if (command === "stop") {
+		void session.leave().finally(() => process.exit(0));
+	}
+});
+
+try {
+	await session.start();
+	process.send?.({ kind: "ready" });
+} catch (error) {
+	process.send?.({
+		kind: "error",
+		message: error instanceof Error ? error.message : String(error),
+	});
+	await session.leave();
+	process.exit(1);
+}

--- a/packages/pi-chat/test/network.test.ts
+++ b/packages/pi-chat/test/network.test.ts
@@ -128,14 +128,14 @@ test("a completed startup releases its caller signal without leaving the room", 
 	}
 });
 
-test("three separate Node processes converge through a local DHT bootstrap", {
+test("two separate Node processes connect through a local DHT bootstrap", {
 	timeout: 80_000,
 }, async () => {
 	const testnet = await createTestnet(3);
 	const secret = Buffer.alloc(32, 77);
 	const bootstrapArg = Buffer.from(JSON.stringify(testnet.bootstrap)).toString("base64url");
 	const fixturePath = fileURLToPath(new URL("./network-peer-fixture.js", import.meta.url));
-	const children = Array.from({ length: 3 }, (_, index) =>
+	const children = Array.from({ length: 2 }, (_, index) =>
 		fork(fixturePath, [bootstrapArg, String(index + 1), secret.toString("base64url")], {
 			execArgv: [],
 			stdio: ["ignore", "ignore", "pipe", "ipc"],
@@ -166,7 +166,7 @@ test("three separate Node processes converge through a local DHT bootstrap", {
 				children.every((child) =>
 					messages
 						.get(child)
-						?.some((message) => message.kind === "snapshot" && message.peers === 2),
+						?.some((message) => message.kind === "snapshot" && message.peers === 1),
 				),
 			() => childDetails(children, messages, errors),
 			27_000,

--- a/packages/pi-chat/test/network.test.ts
+++ b/packages/pi-chat/test/network.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { type ChildProcess, fork } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import createTestnet from "hyperdht/testnet.js";
+import { ChatSession } from "../src/chat-session.js";
+import { createIdentity } from "../src/identity.js";
+import { HyperswarmTransport } from "../src/network.js";
+import { createPrivateRoom, createPublicRoom } from "../src/protocol.js";
+
+test("three local DHT peers discover, authenticate, exchange, and fully stop", {
+	timeout: 20_000,
+}, async () => {
+	const testnet = await createTestnet(3);
+	const room = createPrivateRoom(Buffer.alloc(32, 42));
+	const sessions = Array.from({ length: 3 }, (_, index) => {
+		const identity = createIdentity(Buffer.alloc(32, index + 1));
+		const transport = new HyperswarmTransport({
+			room,
+			identity,
+			dht: testnet.createNode({ firewalled: false }),
+			maxPeers: 8,
+		});
+		return {
+			transport,
+			session: new ChatSession({
+				room,
+				identity,
+				nickname: `Dev${index + 1}`,
+				transport,
+			}),
+		};
+	});
+	try {
+		await Promise.all(sessions.map(({ session }) => session.start()));
+		await waitFor(
+			() => sessions.every(({ session }) => session.snapshot().peers.length === 2),
+			() =>
+				sessions
+					.map(({ session, transport }) => {
+						const snapshot = session.snapshot();
+						return `${snapshot.state}:${snapshot.peers.length}:${transport.connectionCount}:${snapshot.lastError ?? "ok"}`;
+					})
+					.join(","),
+		);
+		const sender = sessions[0];
+		assert.ok(sender);
+		assert.equal(sender.session.send("hello mesh").deliveredTo, 2);
+		await waitFor(() =>
+			sessions
+				.slice(1)
+				.every(({ session }) =>
+					session.snapshot().transcript.some((entry) => entry.text === "hello mesh"),
+				),
+		);
+	} finally {
+		await Promise.allSettled(sessions.map(({ session }) => session.leave()));
+		await testnet.destroy();
+	}
+	assert.equal(
+		sessions.every(({ transport }) => transport.connectionCount === 0),
+		true,
+	);
+});
+
+test("early discovery retries recover after initial DHT lookups miss peers", {
+	timeout: 20_000,
+}, async () => {
+	const testnet = await createTestnet(3);
+	const room = createPublicRoom("retry-room");
+	const sessions = Array.from({ length: 2 }, (_, index) => {
+		const identity = createIdentity(Buffer.alloc(32, index + 11));
+		const dht = suppressPeerResults(testnet.createNode({ firewalled: false }), 3);
+		const transport = new HyperswarmTransport({ room, identity, dht, maxPeers: 8 });
+		return new ChatSession({
+			room,
+			identity,
+			nickname: `Retry${index + 1}`,
+			transport,
+		});
+	});
+	try {
+		await Promise.all(sessions.map((session) => session.start()));
+		await waitFor(
+			() => sessions.every((session) => session.snapshot().peers.length === 1),
+			() => sessions.map((session) => session.snapshot().peers.length).join(","),
+			8_000,
+		);
+	} finally {
+		await Promise.allSettled(sessions.map((session) => session.leave()));
+		await testnet.destroy();
+	}
+});
+
+test("a completed startup releases its caller signal without leaving the room", {
+	timeout: 15_000,
+}, async () => {
+	const testnet = await createTestnet(3);
+	const room = createPublicRoom("released-startup-signal");
+	const controller = new AbortController();
+	const sessions = Array.from({ length: 2 }, (_, index) => {
+		const identity = createIdentity(Buffer.alloc(32, index + 21));
+		const transport = new HyperswarmTransport({
+			room,
+			identity,
+			dht: testnet.createNode({ firewalled: false }),
+			maxPeers: 8,
+		});
+		return new ChatSession({
+			room,
+			identity,
+			nickname: `Owner${index + 1}`,
+			transport,
+		});
+	});
+	try {
+		await sessions[0]?.start(controller.signal);
+		controller.abort(new DOMException("Menu closed", "AbortError"));
+		await sessions[1]?.start();
+		await waitFor(
+			() => sessions.every((session) => session.snapshot().peers.length === 1),
+			() => sessions.map((session) => session.snapshot().peers.length).join(","),
+			5_000,
+		);
+	} finally {
+		await Promise.allSettled(sessions.map((session) => session.leave()));
+		await testnet.destroy();
+	}
+});
+
+test("three separate Node processes converge through a local DHT bootstrap", {
+	timeout: 45_000,
+}, async () => {
+	const testnet = await createTestnet(3);
+	const secret = Buffer.alloc(32, 77);
+	const bootstrapArg = Buffer.from(JSON.stringify(testnet.bootstrap)).toString("base64url");
+	const fixturePath = fileURLToPath(new URL("./network-peer-fixture.js", import.meta.url));
+	const children = Array.from({ length: 3 }, (_, index) =>
+		fork(fixturePath, [bootstrapArg, String(index + 1), secret.toString("base64url")], {
+			execArgv: [],
+			stdio: ["ignore", "ignore", "pipe", "ipc"],
+		}),
+	);
+	const messages = new Map<ChildProcess, Array<Record<string, unknown>>>();
+	const errors = new Map<ChildProcess, string>();
+	for (const child of children) {
+		messages.set(child, []);
+		child.on("message", (message: unknown) => {
+			if (message && typeof message === "object") {
+				messages.get(child)?.push(message as Record<string, unknown>);
+			}
+		});
+		child.stderr?.on("data", (chunk) => {
+			errors.set(child, `${errors.get(child) ?? ""}${String(chunk)}`);
+		});
+	}
+	try {
+		await waitFor(
+			() =>
+				children.every((child) =>
+					messages
+						.get(child)
+						?.some((message) => message.kind === "snapshot" && message.peers === 2),
+				),
+			() => childDetails(children, messages, errors),
+			27_000,
+		);
+		children[0]?.send({ command: "send", text: "cross-process hello" });
+		await waitFor(
+			() =>
+				children
+					.slice(1)
+					.every((child) =>
+						messages
+							.get(child)
+							?.some(
+								(message) =>
+									Array.isArray(message.texts) && message.texts.includes("cross-process hello"),
+							),
+					),
+			() => childDetails(children, messages, errors),
+			10_000,
+		);
+	} finally {
+		for (const child of children) {
+			if (child.connected) child.send({ command: "stop" });
+		}
+		await Promise.all(children.map((child) => waitForExit(child)));
+		await testnet.destroy();
+	}
+});
+
+interface AnnounceResult {
+	peers: unknown[];
+	[key: string]: unknown;
+}
+
+interface AnnounceQuery extends AsyncIterable<AnnounceResult> {
+	readonly closestNodes: unknown;
+	destroy(): void;
+}
+
+interface DhtWithAnnounce {
+	announce(...args: unknown[]): AnnounceQuery;
+}
+
+function suppressPeerResults(value: unknown, callsToSuppress: number): unknown {
+	const dht = value as DhtWithAnnounce;
+	const announce = dht.announce.bind(dht);
+	let calls = 0;
+	dht.announce = (...args: unknown[]): AnnounceQuery => {
+		const query = announce(...args);
+		calls += 1;
+		if (calls > callsToSuppress) return query;
+		return {
+			get closestNodes() {
+				return query.closestNodes;
+			},
+			destroy: () => query.destroy(),
+			async *[Symbol.asyncIterator]() {
+				for await (const result of query) yield { ...result, peers: [] };
+			},
+		};
+	};
+	return dht;
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	detail: () => string = () => "",
+	timeoutMs = 10_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) {
+			throw new Error(`Timed out waiting for local DHT mesh (${detail()})`);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}
+
+function childDetails(
+	children: readonly ChildProcess[],
+	messages: ReadonlyMap<ChildProcess, Array<Record<string, unknown>>>,
+	errors: ReadonlyMap<ChildProcess, string>,
+): string {
+	return children
+		.map((child) => {
+			const latest = messages.get(child)?.at(-1);
+			return `${child.exitCode ?? "running"}:${JSON.stringify(latest)}:${errors.get(child) ?? ""}`;
+		})
+		.join(" | ");
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null) return;
+	let timeout: NodeJS.Timeout | undefined;
+	try {
+		await Promise.race([
+			new Promise<void>((resolve) => child.once("exit", () => resolve())),
+			new Promise<void>((resolve) => {
+				timeout = setTimeout(() => {
+					child.kill("SIGKILL");
+					resolve();
+				}, 5_000);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}

--- a/packages/pi-chat/test/network.test.ts
+++ b/packages/pi-chat/test/network.test.ts
@@ -129,7 +129,7 @@ test("a completed startup releases its caller signal without leaving the room", 
 });
 
 test("three separate Node processes converge through a local DHT bootstrap", {
-	timeout: 45_000,
+	timeout: 80_000,
 }, async () => {
 	const testnet = await createTestnet(3);
 	const secret = Buffer.alloc(32, 77);
@@ -155,6 +155,12 @@ test("three separate Node processes converge through a local DHT bootstrap", {
 		});
 	}
 	try {
+		await waitFor(
+			() =>
+				children.every((child) => messages.get(child)?.some((message) => message.kind === "ready")),
+			() => childDetails(children, messages, errors),
+			35_000,
+		);
 		await waitFor(
 			() =>
 				children.every((child) =>

--- a/packages/pi-chat/test/pi-chat.test.ts
+++ b/packages/pi-chat/test/pi-chat.test.ts
@@ -1,0 +1,761 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
+import type { ChatTransport } from "../src/chat-session.js";
+import { createPiChatExtension } from "../src/pi-chat.js";
+import { createPrivateRoom, createPublicRoom } from "../src/protocol.js";
+import { updateChatSettings } from "../src/settings.js";
+
+class IdleTransport implements ChatTransport {
+	started = 0;
+	stopped = 0;
+	async start(
+		_listener: Parameters<ChatTransport["start"]>[0],
+		_signal?: AbortSignal,
+	): Promise<void> {
+		this.started += 1;
+	}
+	async stop(): Promise<void> {
+		if (this.stopped === 0) this.stopped = 1;
+	}
+}
+
+class FailingTransport extends IdleTransport {
+	override async start(): Promise<void> {
+		this.started += 1;
+		throw new Error("bootstrap unavailable");
+	}
+}
+
+class DelayedStopTransport extends IdleTransport {
+	stopStarted = false;
+	private releaseStop: (() => void) | undefined;
+	override async stop(): Promise<void> {
+		this.stopStarted = true;
+		await new Promise<void>((resolve) => {
+			this.releaseStop = resolve;
+		});
+		await super.stop();
+	}
+	finishStop(): void {
+		this.releaseStop?.();
+	}
+}
+
+class DelayedTransport extends IdleTransport {
+	override async start(
+		_listener: Parameters<ChatTransport["start"]>[0],
+		signal?: AbortSignal,
+	): Promise<void> {
+		this.started += 1;
+		await new Promise<void>((_resolve, reject) => {
+			if (!signal) return reject(new Error("missing owner signal"));
+			const abort = () => reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+			signal.addEventListener("abort", abort, { once: true });
+			if (signal.aborted) abort();
+		});
+	}
+}
+
+async function emit(
+	mock: ReturnType<typeof createMockPi>,
+	name: string,
+	event: unknown,
+	ctx: unknown,
+): Promise<void> {
+	for (const handler of mock.events.get(name) ?? []) await handler(event, ctx);
+}
+
+async function waitFor(
+	predicate: () => boolean | Promise<boolean>,
+	timeoutMs = 1_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!(await predicate())) {
+		if (Date.now() >= deadline) throw new Error("Timed out waiting for Pi Chat state");
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+async function fixture(run: (path: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-chat-extension-"));
+	try {
+		await run(join(root, "pi-chat.json"));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("registers /chat, warns each UI session, and does not create settings at startup", async () => {
+	await fixture(async (settingsPath) => {
+		const mock = createMockPi();
+		createPiChatExtension({ settingsPath })(mock.pi);
+		assert.ok(mock.commands.has("chat"));
+		const ctx = createMockContext({ hasUI: true, mode: "tui" });
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		assert.match(ctx.notifications[0]?.message ?? "", /experimental/i);
+		await assert.rejects(readFile(settingsPath), { code: "ENOENT" });
+	});
+});
+
+test("invalid settings block startup restore and remain unchanged", async () => {
+	await fixture(async (settingsPath) => {
+		const contents = "{invalid-restore";
+		await writeFile(settingsPath, contents, "utf8");
+		const transport = new IdleTransport();
+		const mock = createMockPi();
+		createPiChatExtension({ settingsPath, createTransport: () => transport })(mock.pi);
+		const ctx = createMockContext({ hasUI: true, mode: "tui" });
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		assert.equal(transport.started, 0);
+		assert.match(
+			ctx.notifications.map(({ message }) => message).join("\n"),
+			/settings are invalid/u,
+		);
+		assert.equal(await readFile(settingsPath, "utf8"), contents);
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+	});
+});
+
+test("rejects unsupported modes and malformed direct arguments before starting networking", async () => {
+	await fixture(async (settingsPath) => {
+		const transports: IdleTransport[] = [];
+		const mock = createMockPi();
+		createPiChatExtension({
+			settingsPath,
+			createTransport: () => {
+				const transport = new IdleTransport();
+				transports.push(transport);
+				return transport;
+			},
+		})(mock.pi);
+		const command = mock.commands.get("chat");
+		assert.ok(command);
+		for (const mode of ["rpc", "print", "json"] as const) {
+			const ctx = createMockContext({ hasUI: mode === "rpc", mode });
+			await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+			await assert.rejects(Promise.resolve(command?.handler("#pi-dev", ctx.ctx)), /TUI mode/u);
+		}
+		const tui = createMockContext({ hasUI: true, mode: "tui" });
+		await emit(mock, "session_start", { reason: "startup" }, tui.ctx);
+		await command?.handler("unexpected trailing words", tui.ctx);
+		assert.match(tui.notifications.at(-1)?.message ?? "", /Usage: \/chat/u);
+		assert.equal(transports.length, 0);
+	});
+});
+
+test("direct public join creates identity only after confirmation and shutdown cleans UI/network", async () => {
+	await fixture(async (settingsPath) => {
+		const transport = new IdleTransport();
+		const mock = createMockPi();
+		createPiChatExtension({
+			settingsPath,
+			randomBytes: (size) => Buffer.alloc(size, 7),
+			createTransport: () => transport,
+		})(mock.pi);
+		const sessionManager = { getSessionId: () => "s", getBranch: () => [], getEntries: () => [] };
+		const selected: string[][] = [];
+		const confirmations: string[] = [];
+		let opened = 0;
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			sessionManager,
+			input: async () => "Mika",
+			select: async (_title: string, options: string[]) => {
+				selected.push(options);
+				return options.find((option) => /Room dock/u.test(option));
+			},
+			confirm: async (_title: string, message: string) => {
+				confirmations.push(message);
+				return true;
+			},
+			custom: async (factory: unknown) => {
+				opened += 1;
+				let done = false;
+				const component = (
+					factory as (
+						tui: unknown,
+						theme: unknown,
+						keybindings: unknown,
+						done: () => void,
+					) => { handleInput(data: string): void }
+				)(
+					{ terminal: { rows: 24 }, requestRender() {} },
+					{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
+					{},
+					() => {
+						done = true;
+					},
+				);
+				component.handleInput("\u001b");
+				assert.equal(done, true);
+				return undefined;
+			},
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await mock.commands.get("chat")?.handler("#pi-dev", ctx.ctx);
+		assert.equal(transport.started, 1);
+		assert.equal(opened, 1);
+		const saved = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.equal(saved.nickname, "Mika");
+		assert.equal(typeof saved.identitySeed, "string");
+		assert.equal(saved.widgetMode, "dock");
+		const room = createPublicRoom("pi-dev");
+		assert.deepEqual(saved.resume, {
+			rooms: [{ id: room.id, kind: "public", slug: "pi-dev" }],
+			activeRoomId: room.id,
+			surface: "chat",
+		});
+		assert.equal(selected.length, 1);
+		assert.match(confirmations.at(-1) ?? "", /Display: Room dock/u);
+		assert.deepEqual(
+			selected[0]?.map((option) => option.split(" — ", 1)[0]),
+			["Room dock", "Latest message", "Status only", "Hidden"],
+		);
+		assert.ok(ctx.widgets.has("chat"));
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+		assert.equal(transport.stopped, 1);
+		assert.equal(ctx.widgets.get("chat"), undefined);
+		assert.equal(ctx.statuses.get("chat"), undefined);
+	});
+});
+
+test("private direct joins remember only after explicit bearer-secret consent", async () => {
+	const cases = [
+		{ choice: "Join and remember", joined: true, remembered: true },
+		{ choice: "Join once", joined: true, remembered: false },
+		{ choice: "Cancel", joined: false, remembered: false },
+		{ choice: undefined, joined: false, remembered: false },
+	] as const;
+	for (const scenario of cases) {
+		await fixture(async (settingsPath) => {
+			await updateChatSettings(
+				{
+					nickname: "Mika",
+					identitySeed: Buffer.alloc(32, 8).toString("base64url"),
+					widgetMode: "count",
+				},
+				{ settingsPath },
+			);
+			const before = await readFile(settingsPath, "utf8");
+			const room = createPrivateRoom(Buffer.alloc(32, 19));
+			const transport = new IdleTransport();
+			let opened = 0;
+			const mock = createMockPi();
+			createPiChatExtension({ settingsPath, createTransport: () => transport })(mock.pi);
+			const ctx = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async (title: string, options: string[]) => {
+					assert.match(title, /Private bearer invite.*restore this room/u);
+					assert.deepEqual(
+						options.map((option) => option.split(" — ", 1)[0]),
+						["Join and remember", "Join once", "Cancel"],
+					);
+					return scenario.choice
+						? options.find((option) => option.startsWith(scenario.choice))
+						: undefined;
+				},
+				custom: async () => {
+					opened += 1;
+					return undefined;
+				},
+			});
+			await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+			await mock.commands.get("chat")?.handler(room.invite ?? "", ctx.ctx);
+			assert.equal(transport.started, scenario.joined ? 1 : 0);
+			assert.equal(opened, scenario.joined ? 1 : 0);
+			const after = await readFile(settingsPath, "utf8");
+			if (!scenario.joined || !scenario.remembered) assert.equal(after, before);
+			else {
+				const saved = JSON.parse(after) as Record<string, unknown>;
+				assert.deepEqual(saved.resume, {
+					rooms: [{ id: room.id, kind: "private", invite: room.invite }],
+					activeRoomId: room.id,
+					surface: "chat",
+				});
+			}
+			await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+		});
+	}
+});
+
+test("failed resume publication rolls back a newly joined room and preserves settings", async () => {
+	await fixture(async (settingsPath) => {
+		await updateChatSettings(
+			{
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 10).toString("base64url"),
+				widgetMode: "count",
+			},
+			{ settingsPath },
+		);
+		const before = await readFile(settingsPath, "utf8");
+		const transport = new IdleTransport();
+		const mock = createMockPi();
+		createPiChatExtension({
+			settingsPath,
+			createTransport: () => transport,
+			updateSettings: async (patch, options) => {
+				if (Object.hasOwn(patch, "resume")) throw new Error("resume disk full");
+				return updateChatSettings(patch, options);
+			},
+		})(mock.pi);
+		const ctx = createMockContext({ hasUI: true, mode: "tui", confirm: async () => true });
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await assert.rejects(
+			Promise.resolve(mock.commands.get("chat")?.handler("#pi-dev", ctx.ctx)),
+			/resume disk full/u,
+		);
+		assert.equal(transport.started, 1);
+		assert.equal(transport.stopped, 1);
+		assert.equal(await readFile(settingsPath, "utf8"), before);
+		assert.equal(ctx.widgets.get("chat"), undefined);
+	});
+});
+
+test("leave-and-forget clears resume before disconnect and rolls back on save failure", async () => {
+	for (const failClear of [false, true]) {
+		await fixture(async (settingsPath) => {
+			await updateChatSettings(
+				{
+					nickname: "Mika",
+					identitySeed: Buffer.alloc(32, 11).toString("base64url"),
+					widgetMode: "count",
+				},
+				{ settingsPath },
+			);
+			const transport = new IdleTransport();
+			let leaveAttempted = false;
+			const mock = createMockPi();
+			createPiChatExtension({
+				settingsPath,
+				createTransport: () => transport,
+				updateSettings: async (patch, options) => {
+					if (failClear && patch.resume === null) throw new Error("cannot forget room");
+					return updateChatSettings(patch, options);
+				},
+			})(mock.pi);
+			const ctx = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				confirm: async () => true,
+				custom: async (factory: unknown) => {
+					const harness = createCustomSelectorHarness(factory);
+					if (!harness.isPiTuiKitScreen) {
+						harness.handleInput("tui.select.cancel");
+						return harness.result;
+					}
+					const rendered = harness.render().join("\n");
+					if (/Leave and forget room\?/u.test(rendered)) {
+						if (leaveAttempted) {
+							harness.handleInput("\u0003");
+							return harness.result;
+						}
+						leaveAttempted = true;
+						harness.handleInput("tui.select.confirm");
+						await harness.waitForPending();
+						if (failClear && harness.result === undefined) harness.handleInput("\u0003");
+						return harness.result;
+					}
+					if (leaveAttempted) {
+						harness.handleInput("\u0003");
+						return harness.result;
+					}
+					for (let index = 0; index < 10; index += 1) {
+						if (harness.render().some((line) => /[→›].*Leave/u.test(line))) break;
+						harness.handleInput("tui.select.down");
+					}
+					harness.handleInput("tui.select.confirm");
+					await harness.waitForPending();
+					return harness.result;
+				},
+			});
+			await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+			const command = mock.commands.get("chat");
+			await command?.handler("#pi-dev", ctx.ctx);
+			await command?.handler("", ctx.ctx);
+			const document = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+			const stoppedBeforeShutdown = transport.stopped;
+			const lastNotification = ctx.notifications.at(-1)?.message ?? "";
+			await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+			assert.equal(Object.hasOwn(document, "resume"), failClear);
+			assert.equal(stoppedBeforeShutdown, failClear ? 0 : 1);
+			if (failClear) assert.match(lastNotification, /cannot forget room/u);
+		});
+	}
+});
+
+test("session start restores a remembered room and only reopens the remembered chat surface", async () => {
+	for (const surface of ["chat", "pi"] as const) {
+		await fixture(async (settingsPath) => {
+			const room = createPublicRoom(`restore-${surface}`);
+			await updateChatSettings(
+				{
+					nickname: "Mika",
+					identitySeed: Buffer.alloc(32, 6).toString("base64url"),
+					widgetMode: "dock",
+					resume: {
+						rooms: [{ id: room.id, kind: "public", slug: `restore-${surface}` }],
+						activeRoomId: room.id,
+						surface,
+					},
+				},
+				{ settingsPath },
+			);
+			const transport = new IdleTransport();
+			let opened = 0;
+			const mock = createMockPi();
+			createPiChatExtension({ settingsPath, createTransport: () => transport })(mock.pi);
+			const ctx = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				custom: async () => {
+					opened += 1;
+					return undefined;
+				},
+			});
+			await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+			await waitFor(() => transport.started === 1);
+			await waitFor(() => opened === (surface === "chat" ? 1 : 0));
+			assert.ok(ctx.widgets.has("chat"));
+			await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+			assert.equal(transport.stopped, 1);
+			const saved = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+			assert.equal(Reflect.get(saved.resume as object, "surface"), surface);
+		});
+	}
+});
+
+test("remembered private rooms restore without repeating bearer-secret consent", async () => {
+	await fixture(async (settingsPath) => {
+		const room = createPrivateRoom(Buffer.alloc(32, 22));
+		await updateChatSettings(
+			{
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 16).toString("base64url"),
+				widgetMode: "count",
+				resume: {
+					rooms: [{ id: room.id, kind: "private", invite: room.invite ?? "" }],
+					activeRoomId: room.id,
+					surface: "pi",
+				},
+			},
+			{ settingsPath },
+		);
+		const transport = new IdleTransport();
+		let selections = 0;
+		const mock = createMockPi();
+		createPiChatExtension({ settingsPath, createTransport: () => transport })(mock.pi);
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => {
+				selections += 1;
+				return undefined;
+			},
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await waitFor(() => transport.started === 1);
+		assert.equal(selections, 0);
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+	});
+});
+
+test("failed startup restore keeps its room and the menu retry opens chat", async () => {
+	await fixture(async (settingsPath) => {
+		const room = createPublicRoom("retry-saved");
+		await updateChatSettings(
+			{
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 12).toString("base64url"),
+				widgetMode: "dock",
+				resume: {
+					rooms: [{ id: room.id, kind: "public", slug: "retry-saved" }],
+					activeRoomId: room.id,
+					surface: "chat",
+				},
+			},
+			{ settingsPath },
+		);
+		const before = await readFile(settingsPath, "utf8");
+		const failed = new FailingTransport();
+		const recovered = new IdleTransport();
+		let transportIndex = 0;
+		let opened = 0;
+		const mock = createMockPi();
+		createPiChatExtension({
+			settingsPath,
+			createTransport: () => (transportIndex++ === 0 ? failed : recovered),
+		})(mock.pi);
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (_title: string, options: string[]) =>
+				options.find((option) => /Retry/u.test(option)),
+			custom: async () => {
+				opened += 1;
+				return undefined;
+			},
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await waitFor(() =>
+			ctx.notifications.some(({ message }) => /bootstrap unavailable/u.test(message)),
+		);
+		assert.equal(failed.started, 1);
+		assert.equal(failed.stopped, 1);
+		assert.equal(ctx.statuses.get("chat"), "chat: restore failed");
+		assert.equal(await readFile(settingsPath, "utf8"), before);
+		await mock.commands.get("chat")?.handler("", ctx.ctx);
+		assert.equal(recovered.started, 1);
+		assert.equal(opened, 1);
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+	});
+});
+
+test("session replacement aborts and drains a pending room restore without stale UI", async () => {
+	await fixture(async (settingsPath) => {
+		const room = createPublicRoom("replace-restore");
+		await updateChatSettings(
+			{
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 14).toString("base64url"),
+				widgetMode: "dock",
+				resume: {
+					rooms: [{ id: room.id, kind: "public", slug: "replace-restore" }],
+					activeRoomId: room.id,
+					surface: "pi",
+				},
+			},
+			{ settingsPath },
+		);
+		const delayed = new DelayedTransport();
+		const mock = createMockPi();
+		createPiChatExtension({ settingsPath, createTransport: () => delayed })(mock.pi);
+		const first = createMockContext({ hasUI: true, mode: "tui" });
+		await emit(mock, "session_start", { reason: "startup" }, first.ctx);
+		await waitFor(() => delayed.started === 1);
+		assert.equal(first.statuses.get("chat"), "chat: restoring #replace-restore");
+		const second = createMockContext({ hasUI: true, mode: "rpc" });
+		await emit(mock, "session_start", { reason: "switch" }, second.ctx);
+		assert.equal(delayed.stopped, 1);
+		assert.equal(first.widgets.get("chat"), undefined);
+		assert.equal(first.statuses.get("chat"), undefined);
+		assert.equal(
+			first.notifications.some(({ message }) => /could not restore/u.test(message)),
+			false,
+		);
+		await emit(mock, "session_shutdown", { reason: "quit" }, second.ctx);
+	});
+});
+
+test("shutdown aborts an automatically reopened composer and drains restore ownership", async () => {
+	await fixture(async (settingsPath) => {
+		const room = createPublicRoom("shutdown-restore");
+		await updateChatSettings(
+			{
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 15).toString("base64url"),
+				widgetMode: "dock",
+				resume: {
+					rooms: [{ id: room.id, kind: "public", slug: "shutdown-restore" }],
+					activeRoomId: room.id,
+					surface: "chat",
+				},
+			},
+			{ settingsPath },
+		);
+		const transport = new IdleTransport();
+		let opened = 0;
+		const mock = createMockPi();
+		createPiChatExtension({ settingsPath, createTransport: () => transport })(mock.pi);
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				opened += 1;
+				return createCustomSelectorHarness(factory).resultPromise;
+			},
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await waitFor(() => opened === 1);
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+		assert.equal(transport.stopped, 1);
+		assert.equal(ctx.widgets.get("chat"), undefined);
+		assert.equal(ctx.statuses.get("chat"), undefined);
+	});
+});
+
+test("a slow stale shutdown cannot clear replacement-session ownership", async () => {
+	await fixture(async (settingsPath) => {
+		await updateChatSettings(
+			{
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 17).toString("base64url"),
+				widgetMode: "count",
+			},
+			{ settingsPath },
+		);
+		const transport = new DelayedStopTransport();
+		const room = createPrivateRoom(Buffer.alloc(32, 23));
+		const mock = createMockPi();
+		createPiChatExtension({ settingsPath, createTransport: () => transport })(mock.pi);
+		const first = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (_title: string, options: string[]) =>
+				options.find((option) => option.startsWith("Join once")),
+			custom: async () => undefined,
+		});
+		await emit(mock, "session_start", { reason: "startup" }, first.ctx);
+		await mock.commands.get("chat")?.handler(room.invite ?? "", first.ctx);
+		const shutdown = emit(mock, "session_shutdown", { reason: "quit" }, first.ctx);
+		await waitFor(() => transport.stopStarted);
+		const second = createMockContext({ hasUI: true, mode: "tui" });
+		await emit(mock, "session_start", { reason: "switch" }, second.ctx);
+		transport.finishStop();
+		await shutdown;
+		await mock.commands.get("chat")?.handler("bad", second.ctx);
+		assert.match(second.notifications.at(-1)?.message ?? "", /Usage: \/chat/u);
+		await emit(mock, "session_shutdown", { reason: "quit" }, second.ctx);
+	});
+});
+
+test("legacy identity settings without a display mode remain status-only without a new prompt", async () => {
+	await fixture(async (settingsPath) => {
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				nickname: "Legacy",
+				identitySeed: Buffer.alloc(32, 5).toString("base64url"),
+				future: { keep: true },
+			}),
+			{ mode: 0o600 },
+		);
+		const transport = new IdleTransport();
+		const mock = createMockPi();
+		createPiChatExtension({ settingsPath, createTransport: () => transport })(mock.pi);
+		let selections = 0;
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			confirm: async () => true,
+			select: async () => {
+				selections += 1;
+				return undefined;
+			},
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory);
+				harness.handleInput("tui.select.cancel");
+				return harness.result;
+			},
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await mock.commands.get("chat")?.handler("#pi-dev", ctx.ctx);
+		assert.equal(transport.started, 1);
+		assert.equal(selections, 0);
+		const saved = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.equal(saved.widgetMode, undefined);
+		assert.deepEqual(saved.future, { keep: true });
+		const widgetFactory = ctx.widgets.get("chat") as
+			| ((tui: unknown, theme: unknown) => { render(width: number): string[] })
+			| undefined;
+		assert.ok(widgetFactory);
+		const widget = widgetFactory(
+			{ terminal: { rows: 24 }, requestRender() {} },
+			{ fg: (_color: string, text: string) => text },
+		);
+		assert.match(widget.render(80).join("\n"), /^chat ·/u);
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+	});
+});
+
+test("connected manager opens a full custom composer and retains its draft", async () => {
+	await fixture(async (settingsPath) => {
+		const transport = new IdleTransport();
+		const customOptions: unknown[] = [];
+		const renderedViews: string[][] = [];
+		let opens = 0;
+		const mock = createMockPi();
+		createPiChatExtension({
+			settingsPath,
+			randomBytes: (size) => Buffer.alloc(size, 9),
+			createTransport: () => transport,
+		})(mock.pi);
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => "Mika",
+			confirm: async () => true,
+			select: async (_title: string, options: string[]) =>
+				options.find((option) => /Room dock|Reply in|Open chat/u.test(option)),
+			custom: async (factory: unknown, options?: unknown) => {
+				customOptions.push(options);
+				let done = false;
+				const component = (
+					factory as (
+						tui: unknown,
+						theme: unknown,
+						keybindings: unknown,
+						done: () => void,
+					) => { render(width: number): string[]; handleInput(data: string): void }
+				)(
+					{ terminal: { rows: 24 }, requestRender() {} },
+					{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
+					{},
+					() => {
+						done = true;
+					},
+				);
+				renderedViews.push(component.render(60));
+				if (opens === 0) component.handleInput("retained draft");
+				opens += 1;
+				component.handleInput("\u001b");
+				assert.equal(done, true);
+				return undefined;
+			},
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		const command = mock.commands.get("chat");
+		await command?.handler("#pi-dev", ctx.ctx);
+		await command?.handler("", ctx.ctx);
+		await command?.handler("", ctx.ctx);
+		assert.equal(opens, 3);
+		assert.match(renderedViews[0]?.join("\n") ?? "", /CHAT INPUT/u);
+		assert.match(renderedViews[1]?.join("\n") ?? "", /retained draft/u);
+		assert.deepEqual(customOptions, [undefined, undefined, undefined]);
+		await waitFor(async () => {
+			const saved = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+			return Reflect.get(saved.resume as object, "surface") === "pi";
+		});
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+	});
+});
+
+test("cancelled first-use identity has no persistence or network side effects", async () => {
+	await fixture(async (settingsPath) => {
+		const transport = new IdleTransport();
+		const mock = createMockPi();
+		createPiChatExtension({ settingsPath, createTransport: () => transport })(mock.pi);
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => "Mika",
+			select: async () => undefined,
+			confirm: async () => true,
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await mock.commands.get("chat")?.handler("#pi-dev", ctx.ctx);
+		assert.equal(transport.started, 0);
+		await assert.rejects(readFile(settingsPath), { code: "ENOENT" });
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+	});
+});

--- a/packages/pi-chat/test/protocol.test.ts
+++ b/packages/pi-chat/test/protocol.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import test from "node:test";
+import {
+	createChatMessage,
+	createHello,
+	createPrivateRoom,
+	createPublicRoom,
+	encodeFrame,
+	FrameDecoder,
+	MAX_FRAME_BYTES,
+	MAX_MESSAGE_BYTES,
+	PeerRateLimiter,
+	parseInvite,
+	parseProtocolMessage,
+	verifyHello,
+} from "../src/protocol.js";
+
+const alice = Buffer.alloc(32, 1);
+const bob = Buffer.alloc(32, 2);
+
+test("private invites round-trip while public slugs are normalized and bounded", () => {
+	const secret = Buffer.alloc(32, 9);
+	const room = createPrivateRoom(secret);
+	assert.equal(room.invite, `pichat:v1:${secret.toString("base64url")}`);
+	assert.deepEqual(parseInvite(room.invite), room);
+	assert.equal(createPublicRoom("pi-dev").label, "#pi-dev");
+	assert.throws(() => createPublicRoom("Pi Dev"), /public room slug/u);
+	assert.throws(() => parseInvite("pichat:v2:nope"), /valid Pi Chat invite/u);
+});
+
+test("private hello proves room possession and binds both authenticated peer keys", () => {
+	const room = createPrivateRoom(Buffer.alloc(32, 5));
+	const hello = createHello(room, "Mika", alice, bob, Buffer.alloc(16, 3));
+	assert.equal(verifyHello(hello, room, alice, bob)?.nickname, "Mika");
+	assert.equal(verifyHello(hello, room, bob, alice), undefined);
+	assert.equal(verifyHello(hello, createPrivateRoom(Buffer.alloc(32, 6)), alice, bob), undefined);
+});
+
+test("length-prefixed decoder handles chunks and rejects oversized frames before buffering them", () => {
+	const message = createChatMessage("hello", 10, "id-1");
+	const encoded = encodeFrame(message);
+	const decoder = new FrameDecoder();
+	assert.deepEqual(decoder.push(encoded.subarray(0, 2)), []);
+	assert.deepEqual(decoder.push(encoded.subarray(2, 7)), []);
+	assert.deepEqual(decoder.push(encoded.subarray(7)), [message]);
+
+	const oversized = Buffer.alloc(4);
+	oversized.writeUInt32BE(MAX_FRAME_BYTES + 1);
+	assert.throws(() => new FrameDecoder().push(oversized), /exceeds/u);
+});
+
+test("decoder accepts multiple valid frames coalesced beyond one frame's size limit", () => {
+	const messages = Array.from({ length: 5 }, (_, index) =>
+		createChatMessage("x".repeat(MAX_MESSAGE_BYTES), 10 + index, `coalesced-${index}`),
+	);
+	const coalesced = Buffer.concat(messages.map((message) => encodeFrame(message)));
+	assert.ok(coalesced.length > MAX_FRAME_BYTES + 4);
+	assert.deepEqual(new FrameDecoder().push(coalesced), messages);
+});
+
+test("decoder rejects invalid UTF-8 before JSON parsing", () => {
+	const frame = Buffer.from([0, 0, 0, 1, 0xff]);
+	assert.throws(() => new FrameDecoder().push(frame), /UTF-8/u);
+});
+
+test("chat parsing bounds text and rejects unknown or malformed payloads", () => {
+	assert.deepEqual(parseProtocolMessage(createChatMessage("hello", 10, "id-1")), {
+		v: 1,
+		type: "chat",
+		text: "hello",
+		sentAt: 10,
+		id: "id-1",
+	});
+	assert.throws(() => createChatMessage("x".repeat(MAX_MESSAGE_BYTES + 1), 1, "id"), /too large/u);
+	assert.equal(parseProtocolMessage({ v: 1, type: "admin", text: "oops" }), undefined);
+	assert.equal(parseProtocolMessage({ v: 2, type: "chat", text: "oops" }), undefined);
+});
+
+test("per-peer limiter permits a burst and refills without unbounded state", () => {
+	let now = 0;
+	const limiter = new PeerRateLimiter({ burst: 2, refillPerSecond: 1, now: () => now });
+	assert.equal(limiter.accept(), true);
+	assert.equal(limiter.accept(), true);
+	assert.equal(limiter.accept(), false);
+	now = 1000;
+	assert.equal(limiter.accept(), true);
+	assert.equal(limiter.accept(), false);
+});
+
+test("protocol rejects arbitrary random bytes without echoing input", () => {
+	for (let index = 0; index < 50; index += 1) {
+		const bytes = randomBytes(index);
+		const decoder = new FrameDecoder();
+		try {
+			decoder.push(bytes);
+		} catch (error) {
+			assert.doesNotMatch(String(error), new RegExp(bytes.toString("hex"), "u"));
+		}
+	}
+});

--- a/packages/pi-chat/test/settings.test.ts
+++ b/packages/pi-chat/test/settings.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { chmod, lstat, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createPrivateRoom, createPublicRoom } from "../src/protocol.js";
+import {
+	CHAT_SETTINGS_FILE,
+	type ChatResumeSettings,
+	readChatSettings,
+	updateChatSettings,
+} from "../src/settings.js";
+
+async function withSettings(run: (path: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-chat-settings-"));
+	try {
+		await run(join(root, "nested", CHAT_SETTINGS_FILE));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("missing settings are side-effect free", async () => {
+	await withSettings(async (path) => {
+		assert.deepEqual(await readChatSettings(path), { kind: "missing" });
+		await assert.rejects(lstat(path), { code: "ENOENT" });
+	});
+});
+
+test("explicit saves are private, ordered, and preserve unknown fields", async () => {
+	await withSettings(async (path) => {
+		await updateChatSettings({ nickname: "Mika", widgetMode: "count" }, { settingsPath: path });
+		await writeFile(
+			path,
+			JSON.stringify({ nickname: "Mika", widgetMode: "count", future: { keep: true } }),
+			{ mode: 0o600 },
+		);
+		const first = updateChatSettings({ nickname: "One" }, { settingsPath: path });
+		const second = updateChatSettings(
+			{ nickname: "Two", widgetMode: "dock" },
+			{ settingsPath: path },
+		);
+		await Promise.all([first, second]);
+		const document = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+		assert.deepEqual(document.future, { keep: true });
+		assert.equal(document.nickname, "Two");
+		assert.equal(document.widgetMode, "dock");
+		if (process.platform !== "win32") assert.equal((await lstat(path)).mode & 0o777, 0o600);
+	});
+});
+
+test("remembered public and private rooms round-trip through a bounded active catalog", async () => {
+	await withSettings(async (path) => {
+		const publicRoom = createPublicRoom("pi-dev");
+		const privateRoom = createPrivateRoom(Buffer.alloc(32, 13));
+		const resume: ChatResumeSettings = {
+			rooms: [
+				{ id: publicRoom.id, kind: "public", slug: "pi-dev" },
+				{ id: privateRoom.id, kind: "private", invite: privateRoom.invite ?? "" },
+			],
+			activeRoomId: privateRoom.id,
+			surface: "chat",
+		};
+		await updateChatSettings(
+			{ nickname: "Mika", identitySeed: Buffer.alloc(32, 4).toString("base64url"), resume },
+			{ settingsPath: path },
+		);
+		const loaded = await readChatSettings(path);
+		assert.equal(loaded.kind, "loaded");
+		if (loaded.kind === "loaded") assert.deepEqual(loaded.settings.resume, resume);
+		if (process.platform !== "win32") assert.equal((await lstat(path)).mode & 0o777, 0o600);
+	});
+});
+
+test("resume updates preserve nested unknown fields and explicit clearing removes only resume", async () => {
+	await withSettings(async (path) => {
+		const room = createPublicRoom("pi-dev");
+		await updateChatSettings({ nickname: "Mika" }, { settingsPath: path });
+		await writeFile(
+			path,
+			JSON.stringify({
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 4).toString("base64url"),
+				future: { keep: true },
+				resume: {
+					rooms: [{ id: room.id, kind: "public", slug: "pi-dev", roomFuture: 1 }],
+					activeRoomId: room.id,
+					surface: "chat",
+					resumeFuture: { keep: true },
+				},
+			}),
+			{ mode: 0o600 },
+		);
+		await updateChatSettings(
+			{
+				resume: {
+					rooms: [{ id: room.id, kind: "public", slug: "pi-dev" }],
+					activeRoomId: room.id,
+					surface: "pi",
+				},
+			},
+			{ settingsPath: path },
+		);
+		const updated = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+		assert.deepEqual(updated.future, { keep: true });
+		assert.deepEqual(Reflect.get(updated.resume as object, "resumeFuture"), { keep: true });
+		const rooms = Reflect.get(updated.resume as object, "rooms") as Array<Record<string, unknown>>;
+		assert.equal(rooms[0]?.roomFuture, 1);
+		await updateChatSettings({ resume: null }, { settingsPath: path });
+		const cleared = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+		assert.equal(Object.hasOwn(cleared, "resume"), false);
+		assert.deepEqual(cleared.future, { keep: true });
+	});
+});
+
+test("resume validation rejects inconsistent, duplicate, and excessive room catalogs", async () => {
+	await withSettings(async (path) => {
+		const room = createPublicRoom("pi-dev");
+		await updateChatSettings({ nickname: "Mika" }, { settingsPath: path });
+		const invalidResumeValues = [
+			{ rooms: [], activeRoomId: room.id, surface: "chat" },
+			{
+				rooms: [{ id: "wrong", kind: "public", slug: "pi-dev" }],
+				activeRoomId: "wrong",
+				surface: "chat",
+			},
+			{
+				rooms: [
+					{ id: room.id, kind: "public", slug: "pi-dev" },
+					{ id: room.id, kind: "public", slug: "pi-dev" },
+				],
+				activeRoomId: room.id,
+				surface: "chat",
+			},
+			{
+				rooms: Array.from({ length: 17 }, (_, index) => {
+					const value = createPublicRoom(`room-${index}`);
+					return { id: value.id, kind: "public", slug: `room-${index}` };
+				}),
+				activeRoomId: createPublicRoom("room-0").id,
+				surface: "pi",
+			},
+		];
+		for (const resume of invalidResumeValues) {
+			await writeFile(
+				path,
+				JSON.stringify({
+					nickname: "Mika",
+					identitySeed: Buffer.alloc(32, 4).toString("base64url"),
+					resume,
+				}),
+				{ mode: 0o600 },
+			);
+			assert.equal((await readChatSettings(path)).kind, "invalid");
+		}
+		await writeFile(
+			path,
+			JSON.stringify({
+				nickname: "Mika",
+				resume: {
+					rooms: [{ id: room.id, kind: "public", slug: "pi-dev" }],
+					activeRoomId: room.id,
+					surface: "chat",
+				},
+			}),
+			{ mode: 0o600 },
+		);
+		assert.equal((await readChatSettings(path)).kind, "invalid");
+	});
+});
+
+test("identity creation is explicit and preserved by preference updates", async () => {
+	await withSettings(async (path) => {
+		const settings = await updateChatSettings(
+			{ nickname: "Mika", identitySeed: Buffer.alloc(32, 7).toString("base64url") },
+			{ settingsPath: path },
+		);
+		assert.equal(settings.identitySeed, Buffer.alloc(32, 7).toString("base64url"));
+		await updateChatSettings({ widgetMode: "off" }, { settingsPath: path });
+		const loaded = await readChatSettings(path);
+		assert.equal(loaded.kind, "loaded");
+		if (loaded.kind === "loaded") {
+			assert.equal(loaded.settings.identitySeed, settings.identitySeed);
+			assert.equal(loaded.settings.widgetMode, "off");
+		}
+	});
+});
+
+test("malformed, invalid, symlinked, and oversized settings fail closed", async () => {
+	await withSettings(async (path) => {
+		await updateChatSettings({ nickname: "Mika" }, { settingsPath: path });
+		for (const contents of ["{secret-marker", '{"nickname":"bad\\nname"}']) {
+			await writeFile(path, contents, "utf8");
+			const loaded = await readChatSettings(path);
+			assert.equal(loaded.kind, "invalid");
+			assert.doesNotMatch(loaded.kind === "invalid" ? loaded.reason : "", /secret-marker/u);
+			await assert.rejects(updateChatSettings({ widgetMode: "off" }, { settingsPath: path }));
+			assert.equal(await readFile(path, "utf8"), contents);
+		}
+		await writeFile(path, Buffer.alloc(70 * 1024));
+		assert.equal((await readChatSettings(path)).kind, "invalid");
+	});
+});
+
+test("invalid UTF-8 and symlink paths fail closed without exposing file bytes", async () => {
+	await withSettings(async (path) => {
+		await updateChatSettings({ nickname: "Mika" }, { settingsPath: path });
+		const invalidUtf8 = Buffer.from([0xff, 0xfe, 0xfd]);
+		await writeFile(path, invalidUtf8);
+		const invalid = await readChatSettings(path);
+		assert.equal(invalid.kind, "invalid");
+		assert.match(invalid.kind === "invalid" ? invalid.reason : "", /UTF-8/u);
+		assert.deepEqual(await readFile(path), invalidUtf8);
+
+		if (process.platform !== "win32") {
+			const target = `${path}.target`;
+			await writeFile(target, '{"nickname":"Secret"}', { mode: 0o600 });
+			await rm(path);
+			await symlink(target, path);
+			const linked = await readChatSettings(path);
+			assert.equal(linked.kind, "invalid");
+			await assert.rejects(updateChatSettings({ widgetMode: "off" }, { settingsPath: path }));
+			assert.equal(await readFile(target, "utf8"), '{"nickname":"Secret"}');
+		}
+	});
+});
+
+test("publication failure and abort preserve the previous valid document", async () => {
+	await withSettings(async (path) => {
+		await updateChatSettings({ nickname: "Mika" }, { settingsPath: path });
+		const before = await readFile(path, "utf8");
+		await assert.rejects(
+			updateChatSettings(
+				{ nickname: "Other" },
+				{ settingsPath: path, beforeRename: async () => Promise.reject(new Error("stop")) },
+			),
+			/stop/u,
+		);
+		assert.equal(await readFile(path, "utf8"), before);
+		if (process.platform !== "win32") {
+			await assert.rejects(
+				updateChatSettings(
+					{ nickname: "Other" },
+					{
+						settingsPath: path,
+						setPrivateMode: async () => Promise.reject(new Error("chmod failed")),
+					},
+				),
+				/chmod failed/u,
+			);
+			assert.equal(await readFile(path, "utf8"), before);
+		}
+		await chmod(path, 0o600);
+	});
+});

--- a/packages/pi-chat/tsconfig.json
+++ b/packages/pi-chat/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- add the experimental `@narumitw/pi-chat` extension for ephemeral DHT-discovered peer-to-peer developer chat
- support private bearer invites and public room slugs over HyperDHT/Hyperswarm with Noise-encrypted direct peer streams
- identify participants with a custom nickname plus a stable public-key fingerprint such as `Mika~7K2P-9D4M-HQ3T`
- keep joined rooms visible through an adaptive privacy-selectable room dock while `/chat` remains the menu-first manager
- open a responsive full-size custom composer with explicit `CHAT INPUT → room` labeling, retained drafts, zero-peer protection, and no unsupported mouse or global-shortcut claim
- remember confirmed public rooms and explicitly approved private bearer invites, then restore the active room and last intentional chat/Pi surface on TUI session start
- expose shallow retry/join-another/forget recovery, keep destructive leave-and-forget last, and retain all direct command routes
- add bounded messaging, peer limits, local mute controls, terminal sanitization, atomic private settings, lifecycle cleanup, documentation, tests, and initial `0.1.0` Changeset intent
- archive the completed implementation plans under `docs/plans/archived/`

## Verification

- `npm run check` in a clean clone — 2,439 tests passed
- focused Pi Chat suite — all 57 tests passed in three consecutive final runs
- real public-DHT restore smoke with two independent local identities — both session starts restored and opened the saved room, converged to one authenticated peer each, and delivered one message end to end
- `npm run check --workspace @narumitw/pi-chat` — Biome and TypeScript passed
- `just pack chat` — dry-run tarball contains the expected 15 files (30.9 kB packed, 111.7 kB unpacked)
- `npm run changeset:status` — reports `@narumitw/pi-chat` minor to `0.1.0`
- `pi -e ./packages/pi-chat --list-models` — extension entrypoint loads successfully

## Notes

- audited against `docs/extension-conventions.md` and `docs/extension-settings.md`
- deterministic coverage includes legacy settings, nested unknown-field preservation, public/private persistence choices, atomic rollback, startup restore/retry, stale shutdown, session replacement, composer disposal/focus/IME, and local/separate-process DHT behavior
- transcript, drafts, peer lists, and unread counts remain ephemeral; this release still runs one active room while the bounded room catalog leaves a migration path for future multi-room support
- a physical cross-NAT restore and manual interactive TUI smoke were not available; the archived plans record these limitations
