### PR TITLE
fix(pi-chrome-devtools): keep elevated Windows launch managed

### DIFF
--- a/packages/pi-chrome-devtools/src/browser-manager.ts
+++ b/packages/pi-chrome-devtools/src/browser-manager.ts
@@ -121,10 +121,10 @@ async function launchBrowserCandidate(candidate: BrowserCandidate, waitMs: numbe
 		const args = [
 			`--remote-debugging-port=${portArgument}`,
 			`--user-data-dir=${userDataDir}`,
-			// Chrome 120+ de-elevates when launched from an elevated process on Windows: the
+			// Chrome 138+ de-elevates when launched from an elevated process on Windows: the
 			// spawned process relaunches a de-elevated child and exits immediately, which the
-			// exit watchdog misreads as a failed launch. No-op in non-elevated contexts.
-			"--do-not-de-elevate",
+			// exit watchdog misreads as a failed launch.
+			...(process.platform === "win32" ? ["--do-not-de-elevate"] : []),
 			"--no-first-run",
 			"--no-default-browser-check",
 			"about:blank",


### PR DESCRIPTION
## Summary

- pass `--do-not-de-elevate` only on Windows, where Chromium auto-de-elevation applies
- correct the adjacent Chromium version note from Chrome 120+ to Chrome 138+

This is a follow-up to #599. Its merged changeset already owns the release intent.

## Verification

- `npm run check --workspace @narumitw/pi-chrome-devtools`
- `npm run check` in a clean clone: 2,363 tests passed