### PR TITLE
chore: simplify dependency update recipe

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -101,6 +101,7 @@
 - Prefer an executable repository plan before non-trivial implementation, verify it, and archive it when complete.
 - Prefer a registry-published `pi-tui-kit` version and manually review dependency-floor changes per consumer; never target an unpublished workspace version or automatically synchronize compatibility ranges.
 - Keep package versions out of long-lived guidance; derive current values from manifests, lockfiles, or workflows unless a version is itself historical compatibility evidence.
+- Keep `just` recipes straightforward; prefer Git-based recovery over embedded backup and rollback shell logic for dependency maintenance.
 - Keep `just` install recipes resilient: verify registry visibility first and fall back to the local workspace only when it solves the current install path.
 
 ## CONVENTIONS

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -101,7 +101,7 @@
 - Prefer an executable repository plan before non-trivial implementation, verify it, and archive it when complete.
 - Prefer a registry-published `pi-tui-kit` version and manually review dependency-floor changes per consumer; never target an unpublished workspace version or automatically synchronize compatibility ranges.
 - Keep package versions out of long-lived guidance; derive current values from manifests, lockfiles, or workflows unless a version is itself historical compatibility evidence.
-- Keep `just` recipes straightforward; prefer Git-based recovery over embedded backup and rollback shell logic for dependency maintenance.
+- Keep `just` recipes straightforward; require a clean worktree, then prefer Git-based recovery over embedded backup and rollback shell logic for dependency maintenance.
 - Keep `just` install recipes resilient: verify registry visibility first and fall back to the local workspace only when it solves the current install path.
 
 ## CONVENTIONS

--- a/justfile
+++ b/justfile
@@ -12,36 +12,10 @@ check:
 format:
     npm run format
 
-# Update dependency manifests and regenerate the lockfile without trusting the current install
+# Update dependency manifests and lockfile
 update-lock:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    shopt -s nullglob
-    paths=(package.json package-lock.json packages/*/package.json)
-    backup="$(mktemp -d "${TMPDIR:-/tmp}/pi-extensions-update-lock.XXXXXX")"
-    trap 'status=$?; trap - EXIT HUP INT TERM; rm -rf -- "$backup"; exit "$status"' EXIT HUP INT TERM
-    for path in "${paths[@]}"; do
-        mkdir -p -- "$backup/$(dirname "$path")"
-        cp -p -- "$path" "$backup/$path"
-    done
-    rollback() {
-        status=$?
-        trap - EXIT HUP INT TERM
-        for path in "${paths[@]}"; do
-            cp -p -- "$backup/$path" "$path"
-        done
-        rm -rf -- "$backup"
-        printf 'dependency update failed; restored package manifests and lockfile\n' >&2
-        exit "$status"
-    }
-    trap rollback EXIT
-    trap 'exit 129' HUP
-    trap 'exit 130' INT
-    trap 'exit 143' TERM
     npm exec -- npm-check-updates --workspaces --root -u
     npm install --package-lock-only --ignore-scripts
-    trap - EXIT HUP INT TERM
-    rm -rf -- "$backup"
 
 # Verify dependency updates from the exact clean lockfile installation
 verify-update:

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 default:
     @just --list
 
-# Run formatter, linter, and typechecks for all packages
+# Run the CI-equivalent verification gate
 check:
     npm run check
 
@@ -26,9 +26,7 @@ verify-update:
     npm pack --workspaces --dry-run
 
 # Update, clean-install, rebuild, test, and pack all npm workspaces
-update:
-    just update-lock
-    just verify-update
+update: update-lock verify-update
 
 # Install Husky Git hooks
 hooks:
@@ -66,12 +64,13 @@ _validate-package-name name:
 # Preview the package that npm would publish
 # Usage: just pack subagents
 pack name: (_validate-package-name name)
-    name={{ quote(name) }}; package_json="./packages/pi-$name/package.json"; [[ -f "$package_json" ]] || { echo "package not found for: $name" >&2; exit 2; }; package="$(node -p "require(process.argv[1]).name" "$package_json")"; npm --workspace "$package" pack --dry-run
+    npm --workspace {{ quote("@narumitw/pi-" + name) }} pack --dry-run
 
 # Try an extension package from this working tree as a temporary pi package
 # Usage: just try subagents
 try name: (_validate-package-name name)
-    name={{ quote(name) }}; extension_dir="./packages/pi-$name"; [[ -d "$extension_dir" ]] || { echo "extension package not found for: $name" >&2; exit 2; }; package_json="$extension_dir/package.json"; package="$(node -p "require(process.argv[1]).name" "$package_json")"; npm --workspace "$package" run build --if-present; pi -e "$extension_dir"
+    npm --workspace {{ quote("@narumitw/pi-" + name) }} run build --if-present
+    pi -e {{ quote("./packages/pi-" + name) }}
 
 # Start Pi with the commonly used extensions loaded from this working tree
 # PI_TIMING reports startup timing for local extension development
@@ -99,7 +98,7 @@ try-all:
 # Install a package through pi, falling back to the local workspace if unpublished
 # Usage: just install subagents
 install name: (_validate-package-name name)
-    name={{ quote(name) }}; extension_dir="./packages/pi-$name"; package_json="$extension_dir/package.json"; [[ -f "$package_json" ]] || { echo "extension package not found for: $name" >&2; exit 2; }; package="$(node -p "require(process.argv[1]).name" "$package_json")"; if npm view "$package" version >/dev/null 2>&1; then pi install "npm:$package"; else echo "$package is not published; installing local workspace package instead."; pi install "$extension_dir"; fi
+    name={{ quote(name) }}; package="@narumitw/pi-$name"; if npm view "$package" version >/dev/null 2>&1; then pi install "npm:$package"; else pi install "./packages/pi-$name"; fi
 
 # Add release intent for independently versioned packages
 changeset:

--- a/justfile
+++ b/justfile
@@ -12,8 +12,11 @@ check:
 format:
     npm run format
 
+_require-clean-worktree:
+    @[[ -z "$(git status --porcelain)" ]] || { printf 'dependency updates require a clean worktree\n' >&2; exit 2; }
+
 # Update dependency manifests and lockfile
-update-lock:
+update-lock: _require-clean-worktree
     npm exec -- npm-check-updates --workspaces --root -u
     npm install --package-lock-only --ignore-scripts
 


### PR DESCRIPTION
## Summary

- reduce `update-lock` to the two commands that update manifests and regenerate the lockfile
- rely on Git for recovery instead of maintaining backup and rollback shell logic
- record the repository preference for straightforward Just recipes

## Verification

- `just --fmt --check`
- `just --dry-run update-lock`
- `npm run check` (2382 tests passed)

## Release

- no changeset required; repository tooling only