### PR TITLE
fix(analytics): preserve write timeout reason

### DIFF
--- a/.changeset/calm-timeouts-surface.md
+++ b/.changeset/calm-timeouts-surface.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-analytics": patch
+---
+
+Preserve analytics write timeout errors when Node wraps aborted filesystem operations.

--- a/packages/pi-analytics/src/storage/files.ts
+++ b/packages/pi-analytics/src/storage/files.ts
@@ -406,6 +406,16 @@ async function withDeadline<T>(
 	);
 	try {
 		return await operation(controller.signal);
+	} catch (error) {
+		if (
+			controller.signal.aborted &&
+			error instanceof Error &&
+			error.name === "AbortError" &&
+			error.cause === controller.signal.reason
+		) {
+			throw controller.signal.reason;
+		}
+		throw error;
 	} finally {
 		clearTimeout(timer);
 		callerSignal?.removeEventListener("abort", callerAbort);

--- a/packages/pi-analytics/test/files.test.ts
+++ b/packages/pi-analytics/test/files.test.ts
@@ -171,7 +171,16 @@ test("a stalled append receives the bounded write cancellation signal", async (t
 		writeTimeoutMs: 10,
 		async beforeAppend(_generation, signal) {
 			await new Promise<void>((_resolve, reject) => {
-				signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+				signal.addEventListener(
+					"abort",
+					() =>
+						reject(
+							Object.assign(new Error("The operation was aborted", { cause: signal.reason }), {
+								name: "AbortError",
+							}),
+						),
+					{ once: true },
+				);
 			});
 		},
 	});


### PR DESCRIPTION
## Summary

- unwrap Node filesystem `AbortError` values caused by the analytics deadline signal
- preserve the original `TimeoutError` so stalled writes report `Analytics write timed out`
- cover Node's wrapped abort behavior with a deterministic regression test
- add a patch changeset for `@narumitw/pi-analytics`

Fixes the CI failure in [run 31194315175](https://github.com/narumiruna/pi-extensions/actions/runs/31194315175/job/92918663143).

## Verification

- `node --test "$(realpath node_modules/.cache/pi-extensions-test/packages/pi-analytics/test/files.test.js)"`
- `npm run check --workspace @narumitw/pi-analytics`
- `npm run changeset:status`
- `npm run check`