### PR TITLE
feat(usage): redeem Codex usage limit resets

### DIFF
--- a/.changeset/fresh-codex-resets.md
+++ b/.changeset/fresh-codex-resets.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add safe redemption of earned OpenAI Codex usage-limit resets for the current matching Pi OAuth account.

--- a/docs/plans/archived/2026-08-07_pi-usage-codex-reset-redemption-plan.md
+++ b/docs/plans/archived/2026-08-07_pi-usage-codex-reset-redemption-plan.md
@@ -1,0 +1,204 @@
+# Pi Usage Codex Reset Redemption Plan
+
+> Approved and executed on `feat/pi-usage-codex-reset-redemption`.
+
+## Goal
+
+Let a Pi user redeem an earned OpenAI Codex usage-limit reset from the existing interactive
+`/usage` flow, using the exact ChatGPT account currently resolved by Pi, with fresh availability,
+an explicit confirmation, idempotent retry behavior, immediate usage refresh, and no new command
+arguments or settings.
+
+## Context
+
+- `pi-usage` already reads `rate_limit_reset_credits.available_count` from
+  `GET https://chatgpt.com/backend-api/wham/usage`, but only displays the count.
+- Codex source at `/home/narumi/workspace/codex` defines the ChatGPT API contract in
+  `codex-rs/backend-client/src/client/rate_limit_resets.rs`:
+  - `GET /wham/rate-limit-reset-credits` returns detailed earned resets.
+  - `POST /wham/rate-limit-reset-credits/consume` accepts `redeem_request_id` and an optional
+    `credit_id`.
+  - consume outcomes are `reset`, `nothing_to_reset`, `no_credit`, and `already_redeemed`.
+- Codex sends both `Authorization` and `chatgpt-account-id`; Pi's stored OpenAI Codex OAuth
+  credential exposes `access` and `accountId`, while Pi's resolved runtime auth exposes the active
+  access token. The mutation must require those identities to match.
+- The current `/usage` command is menu-only in TUI/RPC mode, has no arguments, and owns a five-minute
+  account-fingerprinted cache plus session-scoped cancellation and status refresh.
+- Codebase Memory indexing was attempted twice for both repositories and crashed on a file each time.
+  This proposal therefore uses targeted source reads and literal searches; implementation must verify
+  the cited source contracts directly again if either repository HEAD changes.
+
+## Experience Proposal
+
+### Findings and classification
+
+- Viewing usage and refreshing it remain the primary, read-only flow.
+- Redeeming a reset is a secondary, consequential account mutation: it consumes one earned reset and
+  therefore requires current-account visibility, fresh server state, and confirmation.
+- Selecting among detailed reset credits is progressive disclosure, not a new top-level command.
+- Retry after an uncertain transport failure is a recovery flow and must reuse the same logical
+  redemption request ID.
+
+### Information architecture and states
+
+1. Keep the existing root `Provider usage` screen. When the current provider is `openai-codex`, add
+   `Redeem usage limit reset…` immediately after refresh:
+   - enable it with `You have N … available` when the fresh usage report says `N > 0`;
+   - disable it with `No usage limit resets available` when the report says `0`;
+   - enable it as `Check reset availability` when the summary field is absent;
+   - omit it when Codex is merely a configured, non-current provider, so a mutation can never target
+     a background account.
+2. On activation, resolve and revalidate the current Codex OAuth identity, then load detailed reset
+   credits. Show available credits in expiration order with sanitized backend title/description and
+   local expiration. If the backend reports only a positive count, offer one generic `Full reset`
+   option without a `credit_id`. Show an empty state instead of a picker when fresh availability is
+   zero.
+3. After selection, show the exact reset title, expiry, effect, and current account/provider context.
+   Put `No, go back` before `Yes, use reset` so the safe choice is initially focused in TUI and first
+   in RPC. Back/Escape/cancellation before confirmation sends no POST.
+4. After confirmation, generate one UUID redemption request ID and run the POST under a visible,
+   user-non-cancellable task. Session replacement and shutdown still abort owned work. A retry after
+   a transport/server failure reuses the same UUID and selected `credit_id`; choosing a reset again
+   after leaving the attempt creates a new UUID.
+5. Treat `reset` and `already_redeemed` as success, but distinguish `nothing_to_reset` and
+   `no_credit` without claiming success. In every recognized outcome, invalidate Codex cache/backoff,
+   force-refresh usage for the still-current account, update the report/statusline, and show the
+   refreshed remaining-reset count when available. Unknown or malformed outcomes fail closed.
+6. Keep recovery shallow: a failed attempt offers `Try again` and `Back`; a completed outcome offers
+   `Back to usage` and `Close`. Print/JSON rejection and all existing cross-provider actions remain
+   unchanged.
+
+### Acceptance criteria
+
+- TUI and RPC expose the same labels, order, confirmation, cancellation, result, and retry semantics.
+- Backend text is terminal-sanitized and bounded; opaque credit IDs are never displayed or altered.
+- Loading, zero-count, summary-only, detailed, success, already-redeemed, nothing-to-reset,
+  no-credit, malformed, timeout, cancellation, replacement, and shutdown states are observable and
+  deterministic.
+- No POST occurs after account/model revalidation fails or after pre-confirmation cancellation.
+- Narrow TUI rendering, keyboard focus/order, Escape/Back, and Ctrl+C remain owned by
+  `@narumitw/pi-tui-kit`; critical meaning never depends on color.
+
+## Architecture
+
+- Add a small Codex-reset domain module under `packages/pi-usage/src/` to own endpoint paths, bounded
+  response parsing, reset-option normalization, consume outcomes, and request payloads. Keep the
+  generic authenticated JSON transport separate from provider normalization so read and mutation
+  requests share timeout, abort, response-size, redaction, and error behavior without creating a
+  `usage.ts`/provider import cycle.
+- Add a current-Codex reset-auth resolver that accepts only the official ChatGPT origin, requires a
+  Pi-stored OAuth credential, compares its `access` token with Pi's resolved runtime token, validates
+  `accountId`, and forwards only `Authorization`, `chatgpt-account-id`, and the existing safe user
+  agent. Include the account identifier in the salted fingerprint and redact it from provider errors.
+- Keep reset workflow state local to one `/usage` invocation: selected credit, fresh summary/options,
+  idempotency key, outcome, and retry error. Never persist credentials, credit IDs, or mutation state
+  to disk or session history.
+- Revalidate menu generation, selected model, and auth fingerprint after every await that precedes a
+  display update or mutation. Revalidate once more immediately before POST. A replaced session,
+  changed model/account, disposed component, user cancellation, and shutdown each have separate abort
+  paths.
+- Continue using declarative Pi TUI Kit screens and `runTask()`; use `cancellable: false` only for the
+  confirmed POST, while retaining the parent session signal and stale-owner guard.
+
+## Non-Goals
+
+- No `/usage redeem`, `--redeem`, print/JSON mutation route, automatic redemption, settings, account
+  switching, Codex CLI fallback, or support for custom/proxy origins.
+- No redemption against a configured-but-not-current Codex account and no support for API-key Codex
+  auth; earned resets are a ChatGPT OAuth account feature.
+- No changes to Copilot/OpenRouter semantics, cache TTL, statusline format, package dependencies, Pi
+  TUI Kit API, or deprecated `pi-codex-usage`.
+- No live redemption during tests or smoke verification; deterministic mocked HTTP contracts are the
+  safety boundary.
+
+## Assumptions
+
+- The current Codex backend contract and response codes are intentionally consumable by compatible
+  clients, despite not being documented as a public OpenAI API.
+- A positive summary with unavailable detail rows may be redeemed without `credit_id`, matching the
+  official Codex fallback.
+- The stored OAuth credential is the account-identity authority only after its access token exactly
+  matches Pi's freshly resolved runtime token.
+- This is a new published capability and requires a minor Changeset for `@narumitw/pi-usage`.
+
+## Risks
+
+- The undocumented ChatGPT endpoints may change. Strict parsing, bounded responses, recognized
+  outcome handling, and actionable errors must fail closed without affecting ordinary usage reads.
+- A POST can have an uncertain transport result. Reusing one UUID for in-menu retries prevents
+  duplicate consumption; reopening the flow first refreshes server state instead of blindly retrying.
+- Auth or model selection can change while detail or consume requests are pending. Post-await identity
+  guards and forced post-mutation refresh must prevent stale UI/status publication.
+- Adding the workflow directly to the already-large `usage.ts` would blur provider/network/UI
+  ownership. Keep provider contracts and normalization in dedicated modules and keep every source
+  file below the repository's 1,000-line review threshold.
+
+## Applicable Convention Gates
+
+- Touched areas: existing command/menu behavior, provider auth/network mutation, cache/status state,
+  asynchronous UI/lifecycle, tests, README, and release intent. Settings and package dependencies are
+  not touched.
+- Preserve `/usage` as the only command and reject all arguments and unsupported modes exactly as
+  today; verify every TUI/RPC path and unchanged print/JSON behavior.
+- Use Pi TUI Kit standard screens/tasks, provide explicit destructive confirmation, make cancellation
+  side-effect free before confirmation, and test disposal, replacement, and shutdown independently.
+- Keep credentials on official origins, forward only allowlisted headers, redact errors, bound output,
+  and keep the extension independently installable.
+- Add deterministic tests, run the full CI-equivalent gate, inspect the package dry run, and perform a
+  no-provider-traffic Pi load smoke. No settings-guide review is required unless implementation adds
+  or changes extension-owned settings.
+
+## Plan
+
+- [x] Add focused failing tests in `packages/pi-usage/test/` for Codex reset auth and HTTP contracts:
+  matching/mismatched OAuth identity, official-origin enforcement, exact GET/POST paths and headers,
+  optional `credit_id`, UUID reuse, response-size/error redaction, abort/timeout, normalized detail
+  ordering/sanitization/fallback, and all consume outcomes. Evidence: the first test compile failed on
+  the missing reset exports; the final focused reset suites pass 12/12.
+- [x] Implement the bounded shared JSON request path and Codex reset domain/auth modules under
+  `packages/pi-usage/src/`; focused contract tests pass and existing provider response-bound,
+  cancellation, timeout, and redaction tests remain green.
+- [x] Add focused failing `/usage` menu tests for current-only action visibility, positive/zero/unknown
+  availability, detailed and summary-only selection, safe-default confirmation, cancellation without
+  POST, retry with the same request ID, semantic outcomes, forced report/status refresh, auth/model
+  changes, component disposal, session replacement, and shutdown. Evidence: the menu test compile
+  first failed on the missing dependency seam, and the replacement test then failed until owned work
+  was aborted; final reset-menu coverage passes 7/7.
+- [x] Extend `packages/pi-usage/src/usage.ts` with the approved Pi TUI Kit workflow, post-await
+  generation/account guards, confirmed non-cancellable task, cache/backoff invalidation, and refreshed
+  result state. Existing command/provider tests plus new TUI/RPC and lifecycle tests pass; the file
+  remains below the 1,000-line review threshold.
+- [x] Update `packages/pi-usage/README.md` for eligibility, selection, confirmation, retry, endpoint
+  privacy/security, outcomes, cancellation, and unchanged modes; `.changeset/fresh-codex-resets.md`
+  records a minor release and `npm run changeset:status` resolves it to `0.50.0`.
+- [x] Run focused tests, package check, boundary validation, and full tests. Evidence: package Biome and
+  typecheck pass, boundaries pass for all active packages, focused usage/reset suites pass, the direct
+  `npm test` run passed on the initial base, and after rebasing onto current `origin/main` the final
+  root gate passed all 2,454 tests.
+- [x] Run `npm run check`, `just pack usage`, and a no-provider-traffic Pi RPC load smoke. Evidence:
+  the final CI-equivalent gate passed; the 13-file dry run contains README, license, metadata, and all
+  declared source including `src/codex-resets.ts`, with no tests or tarball left behind; RPC
+  `get_state`/`get_commands` returned two successful responses and exactly one extension-owned
+  `usage` command while an unsupported provider prevented usage traffic.
+- [x] Audit the final diff against `docs/extension-conventions.md` for command compatibility,
+  destructive confirmation, auth/origin safety, TUI/RPC behavior, cancellation/disposal/session
+  replacement/shutdown, stale continuations, status/cache ownership, documentation, release intent,
+  and named verification methods. Evidence: `/usage` remains the sole argument-free interactive
+  route; only matching current OAuth identity reaches POST; safe confirmation, retry identity,
+  bounded/sanitized responses, post-await guards, cache refresh, and every lifecycle path have focused
+  coverage. No settings changed, no convention deviation was accepted, and no live reset was used.
+
+## Completion Checklist
+
+- [x] Only the currently active, official-origin OpenAI Codex ChatGPT OAuth account can redeem a reset;
+  mismatched, API-key, configured-only, changed, or proxy accounts fail before mutation.
+- [x] Fresh reset details, summary fallback, option ordering, exact confirmation, safe cancellation,
+  idempotent retry, and all backend outcomes behave consistently in TUI and RPC.
+- [x] Successful/idempotent redemption invalidates stale Codex state, refreshes the current account,
+  updates the statusline/report, and reports the remaining resets without leaking account data.
+- [x] Existing `/usage` arguments, unsupported modes, read-only providers, all-provider queries,
+  caching, and lifecycle behavior remain compatible.
+- [x] Focused tests, full tests, `npm run check`, boundary validation, package inspection, and the
+  no-traffic Pi load smoke pass with evidence; no live reset was consumed.
+- [x] Every plan item has evidence and the semantic convention audit is complete; archived without
+  overwrite at `docs/plans/archived/2026-08-07_pi-usage-codex-reset-redemption-plan.md`.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -9,6 +9,7 @@
 - Opens one interactive `/usage` menu with current state and next actions.
 - Automatically queries the selected model provider and active runtime account.
 - Supports OpenAI Codex subscription windows, resets, credits, and model-specific buckets.
+- Redeems earned Codex usage-limit resets for the active, matching Pi OAuth account with fresh availability, explicit confirmation, and idempotent retry.
 - Supports GitHub Copilot AI Credits, legacy premium requests, Free chat quota, additional usage, percentage, and reset time.
 - Supports OpenRouter per-key credit limits plus daily, weekly, monthly, and all-time spend.
 - Provides explicit refresh, another-provider, and all-configured-provider actions.
@@ -51,6 +52,7 @@ with these actions:
 
 ```text
 Refresh current usage
+Redeem usage limit reset…   # Current Codex OAuth accounts only
 View another configured provider…
 View all configured providers…
 Close
@@ -62,17 +64,34 @@ and closes the root menu. Print and JSON modes reject `/usage` observably becaus
 interactive flow. The cancellable live-query progress view remains extension-owned because it streams
 provider work and supports in-flight abort rather than presenting a standard menu screen.
 
+For the current OpenAI Codex provider, **Redeem usage limit reset…** checks fresh earned-reset
+details, lets you select a reset when details are available, and shows the exact reset before asking
+for confirmation. **No, go back** is the safe default and cancellation before confirmation sends no
+mutation. After confirmation, the reset operation cannot be cancelled from its progress view; session
+replacement or shutdown still aborts owned work. A transport failure offers **Try again** with the
+same redemption request ID so the backend can treat an uncertain retry idempotently. Successful,
+already-completed, not-needed, and no-credit outcomes are reported separately, then usage and the
+statusline are refreshed for the still-current account.
+
 ## 📋 Provider semantics
 
 ### OpenAI Codex
 
 - Provider ID: `openai-codex`
 - Semantics: ChatGPT consumer subscription limits
-- Source: the Codex usage endpoint using Pi's resolved runtime authorization
+- Source: the Codex usage and earned-reset endpoints using Pi's resolved runtime authorization
 - Displayed data: returned duration-based windows, resets, credits, earned usage-limit resets, and additional model buckets
+- Reset mutation: `POST /wham/rate-limit-reset-credits/consume` with a unique redemption request ID and, when available, the selected opaque credit ID
 - Statusline examples: `codex 59% 5h 61% wk` or `codex spark 100% 5h`
 
 The statusline selects a returned bucket that matches the current Codex model when one is available. Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.
+
+Reset redemption is available only when Codex is the current provider and Pi's freshly resolved access
+token exactly matches its stored OpenAI Codex OAuth credential. `pi-usage` forwards only the bearer
+authorization and matching `chatgpt-account-id` to the official ChatGPT origin. API-key credentials,
+configured-but-not-current Codex accounts, account changes during the flow, and custom/proxy origins
+fail before mutation. Backend-provided titles and descriptions are sanitized for terminal display;
+opaque credit and account IDs are never shown or persisted by the extension.
 
 ### GitHub Copilot
 
@@ -127,7 +146,8 @@ Behavior changes:
 ## 🚧 Limitations
 
 - Only providers with a meaningful usage source and verifiable Pi runtime auth are supported.
-- GitHub Copilot quota uses an undocumented GitHub endpoint that may change without notice.
+- GitHub Copilot quota and OpenAI Codex reset redemption use undocumented provider endpoints that may change without notice.
+- Codex reset redemption requires a current ChatGPT OAuth login created through Pi; Codex API keys cannot redeem earned subscription resets.
 - Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
@@ -141,7 +161,8 @@ packages/pi-usage/
 ├── src/
 │   ├── index.ts       # Pi package entrypoint and helper export barrel
 │   ├── usage.ts       # Menu, cache, and lifecycle orchestration
-│   ├── query.ts       # Runtime auth resolution and provider queries
+│   ├── query.ts       # Runtime auth resolution and bounded provider queries
+│   ├── codex-resets.ts # Codex reset auth, API contracts, and normalization
 │   ├── format.ts      # Provider-aware notifications and statusline text
 │   ├── core.ts        # Cache, concurrency, fingerprint, and redaction helpers
 │   ├── providers/     # Codex, GitHub Copilot, and OpenRouter normalization adapters

--- a/packages/pi-usage/src/codex-resets.ts
+++ b/packages/pi-usage/src/codex-resets.ts
@@ -1,0 +1,308 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { readStoredCredential } from "@earendil-works/pi-coding-agent";
+import { fingerprintResolvedAuth, sanitizeDisplayText } from "./core.js";
+import {
+	AUTH_FINGERPRINT_SALT,
+	adapterForProvider,
+	fetchProviderJson,
+	resolveUsageAuth,
+} from "./query.js";
+import type { ResolvedUsageAuth, UsageReport } from "./types.js";
+
+const CODEX_RESET_CREDITS_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
+const CODEX_RESET_CONSUME_URL = `${CODEX_RESET_CREDITS_URL}/consume`;
+const MAX_RESET_OPTIONS = 32;
+const MAX_CREDIT_ID_CHARS = 1_024;
+
+type StoredCredentialReader = (providerId: string) => unknown;
+
+export type CodexResetOutcomeCode = "reset" | "nothing_to_reset" | "no_credit" | "already_redeemed";
+
+export interface CodexResetOption {
+	creditId?: string;
+	title: string;
+	description: string;
+	expiresAt?: number;
+}
+
+export interface CodexResetAvailability {
+	availableCount: number;
+	options: CodexResetOption[];
+}
+
+export interface CodexResetOutcome {
+	code: CodexResetOutcomeCode;
+	windowsReset: number;
+}
+
+export function codexResetCount(report: UsageReport): number | undefined {
+	const value = report.metrics.find((metric) => metric.id === "reset-credits")?.value;
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+export function codexResetActionDescription(report: UsageReport): string {
+	const count = codexResetCount(report);
+	if (count === undefined) return "Check reset availability.";
+	if (count === 0) return "No usage limit resets available.";
+	return `You have ${count} ${resetLabel(count)} available.`;
+}
+
+export function genericCodexResetOption(): CodexResetOption {
+	return {
+		title: "Full reset",
+		description: "Reset your current usage limits.",
+	};
+}
+
+export function resetOptionExpiration(option: CodexResetOption): string {
+	if (option.expiresAt === undefined) return "Does not expire.";
+	const expiration = new Date(option.expiresAt * 1_000);
+	if (Number.isNaN(expiration.getTime())) return "Expiration unavailable.";
+	return `Expires ${expiration.toLocaleString()}.`;
+}
+
+export function resetConfirmationLines(option: CodexResetOption | undefined): string[] {
+	if (!option) return ["The selected reset is unavailable."];
+	return [
+		option.title,
+		resetOptionExpiration(option),
+		option.description,
+		"This consumes one earned reset for the current OpenAI Codex account.",
+	];
+}
+
+export function formatCodexResetOutcome(
+	outcome: CodexResetOutcome | undefined,
+	remainingCount: number | undefined,
+): string {
+	const remaining =
+		remainingCount === undefined
+			? ""
+			: ` You have ${remainingCount} ${resetLabel(remainingCount)} left.`;
+	if (!outcome) return "You don't have any usage limit resets available.";
+	if (outcome.code === "reset") return `Usage reset.${remaining}`.trim();
+	if (outcome.code === "already_redeemed") {
+		return `Usage reset was already completed.${remaining}`.trim();
+	}
+	if (outcome.code === "nothing_to_reset") {
+		return "Your usage does not need a reset right now.";
+	}
+	return "No usage limit resets are available.";
+}
+
+export function resetLabel(count: number): string {
+	return count === 1 ? "usage limit reset" : "usage limit resets";
+}
+
+export async function resolveCodexResetAuth(
+	ctx: ExtensionContext,
+	salt: Uint8Array = AUTH_FINGERPRINT_SALT,
+	credentialReader: StoredCredentialReader = readStoredCredential,
+): Promise<ResolvedUsageAuth> {
+	const model = ctx.model;
+	if (model?.provider !== "openai-codex") {
+		throw new Error("Usage limit resets require the current model to use OpenAI Codex.");
+	}
+	const expectedModel = `${model.provider}/${model.id}`;
+	const adapter = adapterForProvider("openai-codex");
+	if (!adapter) throw new Error("OpenAI Codex usage support is unavailable.");
+	const auth = await resolveUsageAuth(ctx, adapter, salt, credentialReader);
+	if (`${ctx.model?.provider}/${ctx.model?.id}` !== expectedModel) {
+		throw new Error("The current model changed while resolving Codex reset authentication.");
+	}
+	if (!auth) throw new Error("No runtime credential is configured for OpenAI Codex.");
+
+	const credential = asObject(credentialReader("openai-codex"));
+	if (credential?.type !== "oauth") {
+		throw new Error(
+			"Usage limit resets require the OpenAI Codex OAuth account configured through Pi /login.",
+		);
+	}
+	const storedAccess = asNonemptyString(credential.access);
+	const resolvedAccess = bearerToken(headerValue(auth.headers, "Authorization")) ?? auth.apiKey;
+	if (!storedAccess || !resolvedAccess) {
+		throw new Error("OpenAI Codex OAuth credentials were incomplete.");
+	}
+	if (storedAccess !== resolvedAccess) {
+		throw new Error(
+			"The active OpenAI Codex runtime account does not match Pi's stored OAuth account.",
+		);
+	}
+	const accountId = validHeaderValue(credential.accountId);
+	if (!accountId)
+		throw new Error("The OpenAI Codex OAuth credential did not include a valid account ID.");
+
+	const authorization = `Bearer ${resolvedAccess}`;
+	const headers = {
+		Authorization: authorization,
+		"chatgpt-account-id": accountId,
+	};
+	return {
+		apiKey: resolvedAccess,
+		headers,
+		fingerprint: fingerprintResolvedAuth({ headers }, salt),
+		secrets: [
+			...new Set([...auth.secrets, storedAccess, resolvedAccess, authorization, accountId]),
+		],
+		model: auth.model,
+	};
+}
+
+export async function listCodexResetCredits(
+	auth: ResolvedUsageAuth,
+	signal: AbortSignal,
+	timeoutMs: number,
+): Promise<CodexResetAvailability> {
+	const payload = await fetchProviderJson(
+		CODEX_RESET_CREDITS_URL,
+		auth,
+		signal,
+		timeoutMs,
+		"Codex usage-limit reset endpoint",
+	);
+	return normalizeCodexResetCreditsPayload(payload);
+}
+
+export async function consumeCodexResetCredit(
+	auth: ResolvedUsageAuth,
+	option: CodexResetOption,
+	redeemRequestId: string,
+	signal: AbortSignal,
+	timeoutMs: number,
+): Promise<CodexResetOutcome> {
+	if (!redeemRequestId) throw new Error("Codex reset redemption request ID must not be empty.");
+	const payload = await fetchProviderJson(
+		CODEX_RESET_CONSUME_URL,
+		auth,
+		signal,
+		timeoutMs,
+		"Codex usage-limit reset consume endpoint",
+		{
+			method: "POST",
+			body: {
+				redeem_request_id: redeemRequestId,
+				...(option.creditId ? { credit_id: option.creditId } : {}),
+			},
+		},
+	);
+	const code = payload.code;
+	if (!isCodexResetOutcomeCode(code)) {
+		throw new Error("Codex reset consume endpoint returned an unknown outcome code.");
+	}
+	const windowsReset =
+		payload.windows_reset === undefined ? 0 : nonnegativeInteger(payload.windows_reset);
+	if (windowsReset === undefined) {
+		throw new Error("Codex reset consume endpoint returned an invalid windows_reset value.");
+	}
+	return { code, windowsReset };
+}
+
+export function normalizeCodexResetCreditsPayload(
+	payload: Record<string, unknown>,
+): CodexResetAvailability {
+	const availableCount = nonnegativeInteger(payload.available_count);
+	if (availableCount === undefined) {
+		throw new Error("Codex reset credits response returned an invalid available_count.");
+	}
+	const rawCredits = payload.credits;
+	if (rawCredits !== undefined && !Array.isArray(rawCredits)) {
+		throw new Error("Codex reset credits response returned invalid credits.");
+	}
+
+	const options = (rawCredits ?? [])
+		.map(asObject)
+		.filter((credit): credit is Record<string, unknown> => Boolean(credit))
+		.filter((credit) => credit.status === "available" && credit.reset_type === "codex_rate_limits")
+		.map(normalizeResetOption)
+		.sort(
+			(left, right) =>
+				(left.expiresAt ?? Number.MAX_SAFE_INTEGER) - (right.expiresAt ?? Number.MAX_SAFE_INTEGER),
+		)
+		.slice(0, Math.min(availableCount, MAX_RESET_OPTIONS));
+
+	if (availableCount > 0 && options.length === 0) {
+		options.push(genericCodexResetOption());
+	}
+	return { availableCount, options };
+}
+
+function normalizeResetOption(credit: Record<string, unknown>): CodexResetOption {
+	const creditId = asOpaqueId(credit.id);
+	if (!creditId) throw new Error("Codex reset credits response returned an invalid credit ID.");
+	let expiresAt: number | undefined;
+	if (credit.expires_at !== undefined && credit.expires_at !== null) {
+		if (typeof credit.expires_at !== "string") {
+			throw new Error("Codex reset credits response returned an invalid expiration time.");
+		}
+		const parsed = Date.parse(credit.expires_at);
+		if (!Number.isFinite(parsed)) {
+			throw new Error("Codex reset credits response returned an invalid expiration time.");
+		}
+		expiresAt = Math.floor(parsed / 1_000);
+	}
+	const title = displayString(credit.title) ?? "Full reset";
+	const description = displayString(credit.description) ?? "Reset your current usage limits.";
+	return {
+		creditId,
+		title,
+		description,
+		...(expiresAt === undefined ? {} : { expiresAt }),
+	};
+}
+
+function isCodexResetOutcomeCode(value: unknown): value is CodexResetOutcomeCode {
+	return (
+		value === "reset" ||
+		value === "nothing_to_reset" ||
+		value === "no_credit" ||
+		value === "already_redeemed"
+	);
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function asNonemptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asOpaqueId(value: unknown): string | undefined {
+	if (typeof value !== "string" || value.length === 0 || value.length > MAX_CREDIT_ID_CHARS) {
+		return undefined;
+	}
+	return value;
+}
+
+function displayString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	return sanitizeDisplayText(value, 160) || undefined;
+}
+
+function validHeaderValue(value: unknown): string | undefined {
+	if (typeof value !== "string" || !value || value.length > 512) return undefined;
+	if (/[^\x20-\x7e]/u.test(value)) return undefined;
+	return value;
+}
+
+function nonnegativeInteger(value: unknown): number | undefined {
+	const parsed =
+		typeof value === "number"
+			? value
+			: typeof value === "string" && value.trim()
+				? Number(value)
+				: Number.NaN;
+	if (!Number.isSafeInteger(parsed) || parsed < 0) return undefined;
+	return parsed;
+}
+
+function bearerToken(authorization: string | undefined): string | undefined {
+	return /^Bearer\s+(.+)$/iu.exec(authorization ?? "")?.[1];
+}
+
+function headerValue(headers: Record<string, string>, name: string): string | undefined {
+	return Object.entries(headers).find(
+		([candidate]) => candidate.toLowerCase() === name.toLowerCase(),
+	)?.[1];
+}

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -1,3 +1,15 @@
+export type {
+	CodexResetAvailability,
+	CodexResetOption,
+	CodexResetOutcome,
+	CodexResetOutcomeCode,
+} from "./codex-resets.js";
+export {
+	consumeCodexResetCredit,
+	listCodexResetCredits,
+	normalizeCodexResetCreditsPayload,
+	resolveCodexResetAuth,
+} from "./codex-resets.js";
 export {
 	abortError,
 	awaitWithDeadline,

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -182,12 +182,16 @@ function candidateModels(ctx: ExtensionContext, providerId: string): PiModel[] {
 	return candidates;
 }
 
-async function fetchProviderJson(
+export async function fetchProviderJson(
 	url: string,
 	auth: ResolvedUsageAuth,
 	signal: AbortSignal,
 	timeoutMs: number,
 	description: string,
+	request: {
+		method?: "GET" | "POST";
+		body?: Record<string, unknown>;
+	} = {},
 ): Promise<Record<string, unknown>> {
 	const controller = new AbortController();
 	let timedOut = false;
@@ -201,7 +205,15 @@ async function fetchProviderJson(
 	try {
 		const headers = { ...auth.headers };
 		if (!hasHeader(headers, "User-Agent")) headers["User-Agent"] = "pi-usage";
-		const response = await fetch(url, { headers, signal: controller.signal });
+		if (request.body && !hasHeader(headers, "Content-Type")) {
+			headers["Content-Type"] = "application/json";
+		}
+		const response = await fetch(url, {
+			method: request.method ?? "GET",
+			headers,
+			...(request.body ? { body: JSON.stringify(request.body) } : {}),
+			signal: controller.signal,
+		});
 		if (controller.signal.aborted)
 			throw Object.assign(new Error("Usage query aborted."), { name: "AbortError" });
 		const text = await readBoundedResponse(

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -537,10 +537,7 @@ export default function usageExtension(
 								? [
 										{
 											id: "open-resets",
-											label:
-												codexResetCount(current.state.report) === 0
-													? `${REDEEM_CODEX_RESET} (unavailable)`
-													: REDEEM_CODEX_RESET,
+											label: REDEEM_CODEX_RESET,
 											description: codexResetActionDescription(current.state.report),
 											disabled: codexResetCount(current.state.report) === 0,
 											action: "open-resets" as const,

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -1,8 +1,24 @@
+import { randomUUID } from "node:crypto";
 import type {
 	ExtensionAPI,
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import {
+	type CodexResetAvailability,
+	type CodexResetOption,
+	type CodexResetOutcome,
+	codexResetActionDescription,
+	codexResetCount,
+	consumeCodexResetCredit,
+	formatCodexResetOutcome,
+	genericCodexResetOption,
+	listCodexResetCredits,
+	resetConfirmationLines,
+	resetLabel,
+	resetOptionExpiration,
+	resolveCodexResetAuth,
+} from "./codex-resets.js";
 import {
 	awaitWithDeadline,
 	errorMessage,
@@ -38,6 +54,12 @@ const REFRESH_CURRENT = "Refresh current usage";
 const VIEW_ANOTHER = "View another configured provider…";
 const VIEW_ALL = "View all configured providers…";
 const CLOSE = "Close";
+const REDEEM_CODEX_RESET = "Redeem usage limit reset…";
+
+type UsageExtensionDependencies = {
+	credentialReader?: (providerId: string) => unknown;
+	createRedemptionId?: () => string;
+};
 
 type QueryOutcome = {
 	state: ProviderUsageState;
@@ -50,7 +72,12 @@ type StableCurrent = {
 	model: PiModel | undefined;
 };
 
-export default function usageExtension(pi: ExtensionAPI) {
+export default function usageExtension(
+	pi: ExtensionAPI,
+	dependencies: UsageExtensionDependencies = {},
+) {
+	const credentialReader = dependencies.credentialReader;
+	const createRedemptionId = dependencies.createRedemptionId ?? randomUUID;
 	const cache = new UsageCache(CACHE_TTL_MS);
 	const failureBackoff = new Map<string, { until: number; message: string }>();
 	const latestQueries = new Map<string, number>();
@@ -123,6 +150,16 @@ export default function usageExtension(pi: ExtensionAPI) {
 		if (shouldSchedule && sessionActive) scheduleStatusRefresh(ctx, model);
 	};
 
+	const invalidateProviderState = (providerId: string) => {
+		cache.clearProvider(providerId);
+		for (const key of failureBackoff.keys()) {
+			if (key.startsWith(`${providerId}:`)) failureBackoff.delete(key);
+		}
+		for (const key of latestQueries.keys()) {
+			if (key.startsWith(`${providerId}:`)) latestQueries.delete(key);
+		}
+	};
+
 	const transitionCurrentIdentity = (nextIdentity: string, providerId: string) => {
 		if (!activeCurrentIdentity || activeCurrentIdentity === nextIdentity) {
 			activeCurrentIdentity = nextIdentity;
@@ -130,14 +167,7 @@ export default function usageExtension(pi: ExtensionAPI) {
 		}
 		const previousProviderId = activeCurrentIdentity.split(":", 1)[0] ?? "";
 		for (const id of new Set([previousProviderId, providerId])) {
-			if (!id) continue;
-			cache.clearProvider(id);
-			for (const key of failureBackoff.keys()) {
-				if (key.startsWith(`${id}:`)) failureBackoff.delete(key);
-			}
-			for (const key of latestQueries.keys()) {
-				if (key.startsWith(`${id}:`)) latestQueries.delete(key);
-			}
+			if (id) invalidateProviderState(id);
 		}
 		activeCurrentIdentity = nextIdentity;
 	};
@@ -346,12 +376,14 @@ export default function usageExtension(pi: ExtensionAPI) {
 		label: string,
 		parentSignal: AbortSignal,
 		operation: (signal: AbortSignal) => Promise<T>,
+		cancellable = true,
 	): Promise<T | undefined> => {
 		const { runTask } = await import("@narumitw/pi-tui-kit");
 		if (parentSignal.aborted) return undefined;
 		const result = await runTask(ctx, {
 			label,
 			signal: parentSignal,
+			cancellable,
 			onError: () => undefined,
 			task: ({ signal }) => operation(signal),
 		});
@@ -465,10 +497,33 @@ export default function usageExtension(pi: ExtensionAPI) {
 			publishStableCurrent(ctx, stableCurrent);
 			let current = stableCurrent.outcome;
 			let visibleStates: ProviderUsageState[] = [current.state];
+			let resetAvailability: CodexResetAvailability | undefined;
+			let selectedReset: CodexResetOption | undefined;
+			let resetAuthFingerprint: string | undefined;
+			let resetModelIdentity: string | undefined;
+			let redemptionId: string | undefined;
+			let resetOutcome: CodexResetOutcome | undefined;
+			let resetFailure: string | undefined;
 			const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
 			if (controller.signal.aborted || statusGeneration !== menuGeneration) return;
-			type Screen = "main" | "providers";
-			type Action = "refresh" | "another" | "all" | "provider";
+			type Screen =
+				| "main"
+				| "providers"
+				| "reset-picker"
+				| "reset-confirm"
+				| "reset-result"
+				| "reset-error";
+			type Action =
+				| "refresh"
+				| "another"
+				| "all"
+				| "provider"
+				| "open-resets"
+				| "select-reset"
+				| "cancel-reset"
+				| "consume-reset"
+				| "back-to-usage"
+				| "back-to-resets";
 			const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
 				start: "main",
 				screens: {
@@ -478,6 +533,20 @@ export default function usageExtension(pi: ExtensionAPI) {
 						lines: formatProviderStates(visibleStates).split("\n"),
 						items: [
 							{ id: "refresh", label: REFRESH_CURRENT, action: "refresh" },
+							...(current.state.status === "ready" && current.state.providerId === "openai-codex"
+								? [
+										{
+											id: "open-resets",
+											label:
+												codexResetCount(current.state.report) === 0
+													? `${REDEEM_CODEX_RESET} (unavailable)`
+													: REDEEM_CODEX_RESET,
+											description: codexResetActionDescription(current.state.report),
+											disabled: codexResetCount(current.state.report) === 0,
+											action: "open-resets" as const,
+										},
+									]
+								: []),
 							{ id: "another", label: VIEW_ANOTHER, action: "another" },
 							{ id: "all", label: VIEW_ALL, action: "all" },
 							{ id: "close", label: CLOSE, close: true },
@@ -496,8 +565,219 @@ export default function usageExtension(pi: ExtensionAPI) {
 							})),
 						hint: "back",
 					}),
+					"reset-picker": () => ({
+						kind: "choice",
+						title: "Usage limit resets",
+						lines: [
+							`${resetAvailability?.availableCount ?? 0} ${resetLabel(resetAvailability?.availableCount ?? 0)} available.`,
+						],
+						items: (resetAvailability?.options ?? []).map((option, index) => ({
+							id: `reset-${index}`,
+							label: option.title,
+							description: resetOptionExpiration(option),
+							details: [option.description],
+						})),
+						action: "select-reset",
+						initialItemId: "reset-0",
+						hint: "back",
+					}),
+					"reset-confirm": () => ({
+						kind: "actions",
+						title: "Use this reset?",
+						lines: resetConfirmationLines(selectedReset),
+						items: [
+							{ id: "cancel-reset", label: "No, go back", action: "cancel-reset" },
+							{ id: "consume-reset", label: "Yes, use reset", action: "consume-reset" },
+						],
+						hint: "back",
+					}),
+					"reset-result": () => ({
+						kind: "actions",
+						title: "Usage limit resets",
+						lines: [
+							formatCodexResetOutcome(
+								resetOutcome,
+								current.state.status === "ready"
+									? codexResetCount(current.state.report)
+									: undefined,
+							),
+						],
+						items: [
+							{
+								id: "back-to-usage",
+								label: "Back to usage",
+								action: "back-to-usage",
+							},
+							{ id: "close", label: CLOSE, close: true },
+						],
+						hint: "back",
+					}),
+					"reset-error": () => ({
+						kind: "actions",
+						title: "Usage limit resets",
+						lines: [resetFailure ?? "Couldn't reset usage. Please try again."],
+						items: [
+							{ id: "consume-reset", label: "Try again", action: "consume-reset" },
+							{ id: "back-to-resets", label: "Back", action: "back-to-resets" },
+						],
+						hint: "back",
+					}),
 				},
 				actions: {
+					"open-resets": async () => {
+						const summaryCount =
+							current.state.status === "ready" && current.state.providerId === "openai-codex"
+								? codexResetCount(current.state.report)
+								: undefined;
+						try {
+							const loaded = await runMenuOperation(
+								ctx,
+								"Checking usage limit resets…",
+								controller.signal,
+								async (signal) => {
+									const expectedModel = modelIdentity(ctx.model);
+									const auth = await awaitWithDeadline(
+										resolveCodexResetAuth(ctx, undefined, credentialReader),
+										signal,
+										DEFAULT_TIMEOUT_MS,
+										"resolving current Codex reset authentication",
+									);
+									let availability: CodexResetAvailability;
+									try {
+										availability = await listCodexResetCredits(auth, signal, DEFAULT_TIMEOUT_MS);
+									} catch (error) {
+										if (isAbortError(error) || summaryCount === undefined || summaryCount <= 0) {
+											throw error;
+										}
+										availability = {
+											availableCount: summaryCount,
+											options: [genericCodexResetOption()],
+										};
+									}
+									const revalidated = await awaitWithDeadline(
+										resolveCodexResetAuth(ctx, undefined, credentialReader),
+										signal,
+										DEFAULT_TIMEOUT_MS,
+										"revalidating current Codex reset authentication",
+									);
+									if (
+										modelIdentity(ctx.model) !== expectedModel ||
+										revalidated.fingerprint !== auth.fingerprint
+									) {
+										throw new Error(
+											"The active Codex model or account changed while loading usage limit resets.",
+										);
+									}
+									return { availability, auth, expectedModel };
+								},
+							);
+							if (!loaded) return { kind: "stay" };
+							resetAvailability = loaded.availability;
+							resetAuthFingerprint = loaded.auth.fingerprint;
+							resetModelIdentity = loaded.expectedModel;
+							selectedReset = undefined;
+							redemptionId = undefined;
+							resetOutcome = undefined;
+							resetFailure = undefined;
+							return {
+								kind: "to",
+								screen: loaded.availability.availableCount > 0 ? "reset-picker" : "reset-result",
+							};
+						} catch (error) {
+							if (isAbortError(error) || isStaleExtensionContextError(error)) {
+								return { kind: "stay" };
+							}
+							ctx.ui.notify(`Couldn't load usage limit resets: ${errorMessage(error)}`, "error");
+							return { kind: "stay" };
+						}
+					},
+					"select-reset": ({ itemId }) => {
+						const index = Number(itemId.replace(/^reset-/u, ""));
+						const option = Number.isSafeInteger(index)
+							? resetAvailability?.options[index]
+							: undefined;
+						if (!option) return { kind: "rejected" };
+						selectedReset = option;
+						redemptionId = undefined;
+						resetFailure = undefined;
+						return { kind: "to", screen: "reset-confirm" };
+					},
+					"cancel-reset": () => ({ kind: "back" }),
+					"consume-reset": async () => {
+						if (!selectedReset || !resetAuthFingerprint || !resetModelIdentity) {
+							return { kind: "rejected" };
+						}
+						try {
+							redemptionId ??= createRedemptionId();
+							const attemptId = redemptionId;
+							const option = selectedReset;
+							const expectedFingerprint = resetAuthFingerprint;
+							const expectedModel = resetModelIdentity;
+							const result = await runMenuOperation(
+								ctx,
+								"Resetting your usage…",
+								controller.signal,
+								async (signal) => {
+									const auth = await awaitWithDeadline(
+										resolveCodexResetAuth(ctx, undefined, credentialReader),
+										signal,
+										DEFAULT_TIMEOUT_MS,
+										"revalidating current Codex reset authentication",
+									);
+									if (
+										modelIdentity(ctx.model) !== expectedModel ||
+										auth.fingerprint !== expectedFingerprint
+									) {
+										throw new Error(
+											"The active Codex model or account changed; the reset was not used.",
+										);
+									}
+									const outcome = await consumeCodexResetCredit(
+										auth,
+										option,
+										attemptId,
+										signal,
+										DEFAULT_TIMEOUT_MS,
+									);
+									invalidateProviderState("openai-codex");
+									const model = ctx.model;
+									if (modelIdentity(model) !== expectedModel) return { outcome };
+									const refreshed = await queryCurrentState(ctx, model, true, signal);
+									const stable = await outcomeStillCurrent(
+										ctx,
+										model,
+										menuGeneration,
+										refreshed,
+										signal,
+									);
+									return stable ? { outcome, refreshed, model } : { outcome };
+								},
+								false,
+							);
+							if (!result) return { kind: "close" };
+							resetOutcome = result.outcome;
+							resetFailure = undefined;
+							if (result.refreshed && result.model) {
+								stableCurrent = { outcome: result.refreshed, model: result.model };
+								current = result.refreshed;
+								visibleStates = [current.state];
+								publishStableCurrent(ctx, stableCurrent);
+							}
+							return { kind: "to", screen: "reset-result" };
+						} catch (error) {
+							if (isAbortError(error) || isStaleExtensionContextError(error)) {
+								return { kind: "close" };
+							}
+							resetFailure = `Couldn't reset usage: ${errorMessage(error)}. Try again with the same request.`;
+							return { kind: "to", screen: "reset-error" };
+						}
+					},
+					"back-to-usage": () => ({ kind: "to", screen: "main" }),
+					"back-to-resets": () => {
+						redemptionId = undefined;
+						resetFailure = undefined;
+						return { kind: "to", screen: "reset-picker" };
+					},
 					refresh: async () => {
 						const refreshed = await queryStableCurrent(
 							ctx,
@@ -633,6 +913,11 @@ export default function usageExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
+		statusGeneration += 1;
+		clearStatusTimer();
+		for (const controller of activeControllers) controller.abort();
+		activeControllers.clear();
+		statusController = undefined;
 		sessionActive = true;
 		startStatusRefresh(ctx, ctx.model, false);
 	});

--- a/packages/pi-usage/test/codex-reset-menu.test.ts
+++ b/packages/pi-usage/test/codex-reset-menu.test.ts
@@ -72,7 +72,8 @@ test("zero Codex reset availability is visible and cannot mutate", async (t) => 
 
 	await command.handler("", ctx);
 
-	assert.ok(rootOptions.includes("Redeem usage limit reset… (unavailable)"));
+	assert.ok(rootOptions.includes("Redeem usage limit reset…"));
+	assert.ok(!rootOptions.some((option) => option.includes("(unavailable)")));
 	assert.equal(posts, 0);
 });
 

--- a/packages/pi-usage/test/codex-reset-menu.test.ts
+++ b/packages/pi-usage/test/codex-reset-menu.test.ts
@@ -1,0 +1,435 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import usageExtension from "../src/usage.js";
+
+initTheme("dark", false);
+
+const codexModel = {
+	id: "gpt-5.3-codex",
+	name: "GPT-5.3 Codex",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+};
+
+const credential = (access = "codex-token") => ({
+	type: "oauth",
+	access,
+	refresh: "refresh-token",
+	expires: Date.now() + 60_000,
+	accountId: "account-123",
+});
+
+function usageResponse(resetCount: number): Response {
+	return new Response(
+		JSON.stringify({
+			rate_limit: { primary_window: { used_percent: 80, limit_window_seconds: 18_000 } },
+			rate_limit_reset_credits: { available_count: resetCount },
+		}),
+		{ status: 200 },
+	);
+}
+
+function codexRegistry(activeToken: () => string) {
+	return {
+		getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: activeToken() }),
+		getProviderAuth: async () => ({ auth: { apiKey: activeToken() } }),
+		getAvailable: () => [codexModel],
+		getAll: () => [codexModel],
+		getProviderAuthStatus: () => ({ configured: true }),
+		getProviderDisplayName: (provider: string) => provider,
+	};
+}
+
+test("zero Codex reset availability is visible and cannot mutate", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let posts = 0;
+	globalThis.fetch = async (_input, init) => {
+		if (init?.method === "POST") posts += 1;
+		return usageResponse(0);
+	};
+	let rootOptions: string[] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async (_title: string, options: string[]) => {
+			rootOptions = options;
+			return "Close";
+		},
+		modelRegistry: codexRegistry(() => "codex-token"),
+	});
+
+	await command.handler("", ctx);
+
+	assert.ok(rootOptions.includes("Redeem usage limit reset… (unavailable)"));
+	assert.equal(posts, 0);
+});
+
+test("missing reset summary keeps the current Codex availability check reachable", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let detailRequests = 0;
+	globalThis.fetch = async (input) => {
+		if (String(input).endsWith("/rate-limit-reset-credits")) {
+			detailRequests += 1;
+			return new Response(JSON.stringify({ available_count: 1 }), { status: 200 });
+		}
+		return new Response(
+			JSON.stringify({
+				rate_limit: { primary_window: { used_percent: 20, limit_window_seconds: 18_000 } },
+			}),
+			{ status: 200 },
+		);
+	};
+	const choices: Array<string | undefined> = [
+		"Redeem usage limit reset…",
+		"Full reset",
+		undefined,
+		"Close",
+	];
+	const mock = createMockPi();
+	usageExtension(mock.pi, { credentialReader: () => credential() });
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async () => choices.shift(),
+		modelRegistry: codexRegistry(() => "codex-token"),
+	});
+
+	await command.handler("", ctx);
+
+	assert.equal(detailRequests, 1);
+});
+
+test("Codex reset transport retries reuse the same redemption request ID", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	const bodies: unknown[] = [];
+	let posts = 0;
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		if (url.endsWith("/consume")) {
+			posts += 1;
+			bodies.push(JSON.parse(String(init?.body)));
+			if (posts === 1) return new Response("uncertain", { status: 503 });
+			return new Response(JSON.stringify({ code: "already_redeemed", windows_reset: 0 }), {
+				status: 200,
+			});
+		}
+		if (url.endsWith("/rate-limit-reset-credits")) {
+			return new Response(JSON.stringify({ available_count: 1 }), { status: 200 });
+		}
+		return usageResponse(posts > 0 ? 0 : 1);
+	};
+
+	const choices = [
+		"Redeem usage limit reset…",
+		"Full reset",
+		"Yes, use reset",
+		"Try again",
+		"Close",
+	];
+	const titles: string[] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi, {
+		credentialReader: () => credential(),
+		createRedemptionId: () => "one-logical-attempt",
+	});
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async (title: string) => {
+			titles.push(title);
+			return choices.shift();
+		},
+		modelRegistry: codexRegistry(() => "codex-token"),
+	});
+
+	await command.handler("", ctx);
+
+	assert.equal(posts, 2);
+	assert.deepEqual(bodies, [
+		{ redeem_request_id: "one-logical-attempt" },
+		{ redeem_request_id: "one-logical-attempt" },
+	]);
+	assert.ok(titles.some((title) => /same request/iu.test(title)));
+	assert.match(titles.at(-1) ?? "", /already completed.*0 usage limit resets left/isu);
+});
+
+test("Codex reset revalidates the active account immediately before POST", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let activeToken = "codex-token";
+	let posts = 0;
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		if (init?.method === "POST") posts += 1;
+		if (url.endsWith("/rate-limit-reset-credits")) {
+			return new Response(JSON.stringify({ available_count: 1 }), { status: 200 });
+		}
+		return usageResponse(1);
+	};
+	const choices: Array<string | undefined> = [
+		"Redeem usage limit reset…",
+		"Full reset",
+		"Yes, use reset",
+		"Back",
+		undefined,
+		"Close",
+	];
+	const titles: string[] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi, {
+		credentialReader: () => credential(),
+		createRedemptionId: () => "account-change-attempt",
+	});
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async (title: string) => {
+			titles.push(title);
+			const choice = choices.shift();
+			if (choice === "Yes, use reset") activeToken = "different-account-token";
+			return choice;
+		},
+		modelRegistry: codexRegistry(() => activeToken),
+	});
+
+	await command.handler("", ctx);
+
+	assert.equal(posts, 0);
+	assert.ok(titles.some((title) => /does not match|changed/iu.test(title)));
+});
+
+test("TUI reset confirmation is width-safe and external disposal aborts confirmed work", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let resolveUsage: (response: Response) => void = () => undefined;
+	const pendingUsage = new Promise<Response>((resolve) => {
+		resolveUsage = resolve;
+	});
+	let resolveDetails: (response: Response) => void = () => undefined;
+	const pendingDetails = new Promise<Response>((resolve) => {
+		resolveDetails = resolve;
+	});
+	let postStarted: () => void = () => undefined;
+	const postReady = new Promise<void>((resolve) => {
+		postStarted = resolve;
+	});
+	let postAborted = false;
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		if (url.endsWith("/consume")) {
+			postStarted();
+			return new Promise<Response>((_resolve, reject) => {
+				const abort = () => {
+					postAborted = true;
+					reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+				};
+				if (init?.signal?.aborted) abort();
+				else init?.signal?.addEventListener("abort", abort, { once: true });
+			});
+		}
+		if (url.endsWith("/rate-limit-reset-credits")) return pendingDetails;
+		return pendingUsage;
+	};
+
+	const tui = createTuiHarness({ width: 32, rows: 18 });
+	const mock = createMockPi();
+	usageExtension(mock.pi, {
+		credentialReader: () => credential(),
+		createRedemptionId: () => "disposed-attempt",
+	});
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const base = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		model: codexModel,
+		modelRegistry: codexRegistry(() => "codex-token"),
+	}).ctx as unknown as { ui: Record<string, unknown>; [key: string]: unknown };
+	const ctx = { ...base, ui: { ...base.ui, custom: tui.custom } };
+	const running = command.handler("", ctx as never);
+
+	await tui.waitForOpen();
+	const initialTask = tui.resultPromise;
+	assert.match(tui.render().join("\n"), /Checking current usage/iu);
+	resolveUsage(usageResponse(1));
+	await initialTask;
+
+	await tui.waitForOpen();
+	const rootScreen = tui.resultPromise;
+	assert.match(tui.render(32).join("\n"), /Provider usage/iu);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await rootScreen;
+
+	await tui.waitForOpen();
+	const detailsTask = tui.resultPromise;
+	assert.match(tui.render(32).join("\n"), /Checking usage limit resets/iu);
+	resolveDetails(new Response(JSON.stringify({ available_count: 1 }), { status: 200 }));
+	await detailsTask;
+
+	await tui.waitForOpen();
+	const pickerScreen = tui.resultPromise;
+	assert.match(tui.render(32).join("\n"), /Full reset/iu);
+	tui.press("tui.select.confirm");
+	await pickerScreen;
+
+	await tui.waitForOpen();
+	const confirmationScreen = tui.resultPromise;
+	const confirmation = tui.render(32);
+	assert.match(confirmation.join("\n"), /No, go back/iu);
+	for (const line of confirmation) assert.ok(visibleWidth(line) <= 32);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await confirmationScreen;
+
+	await tui.waitForOpen();
+	assert.match(tui.render(32).join("\n"), /Resetting your usage/iu);
+	await postReady;
+	tui.dispose();
+	await running;
+
+	assert.equal(postAborted, true);
+});
+
+test("session replacement aborts a confirmed Codex reset request", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let postStarted: () => void = () => undefined;
+	const postReady = new Promise<void>((resolve) => {
+		postStarted = resolve;
+	});
+	let finishPost: (response: Response) => void = () => undefined;
+	let postAborted = false;
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		if (url.endsWith("/consume")) {
+			postStarted();
+			return new Promise<Response>((resolve, reject) => {
+				finishPost = resolve;
+				const abort = () => {
+					postAborted = true;
+					reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+				};
+				if (init?.signal?.aborted) abort();
+				else init?.signal?.addEventListener("abort", abort, { once: true });
+			});
+		}
+		if (url.endsWith("/rate-limit-reset-credits")) {
+			return new Response(JSON.stringify({ available_count: 1 }), { status: 200 });
+		}
+		return usageResponse(1);
+	};
+
+	const choices = ["Redeem usage limit reset…", "Full reset", "Yes, use reset"];
+	const mock = createMockPi();
+	usageExtension(mock.pi, {
+		credentialReader: () => credential(),
+		createRedemptionId: () => "replacement-attempt",
+	});
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async () => choices.shift(),
+		modelRegistry: codexRegistry(() => "codex-token"),
+	});
+
+	const pending = command.handler("", ctx);
+	await postReady;
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	if (!postAborted) {
+		finishPost(new Response(JSON.stringify({ code: "reset", windows_reset: 2 }), { status: 200 }));
+	}
+	await pending;
+
+	assert.equal(postAborted, true);
+});
+
+test("session shutdown aborts a confirmed Codex reset request", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let postStarted: () => void = () => undefined;
+	const postReady = new Promise<void>((resolve) => {
+		postStarted = resolve;
+	});
+	let postAborted = false;
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		if (url.endsWith("/consume")) {
+			postStarted();
+			return new Promise<Response>((_resolve, reject) => {
+				const abort = () => {
+					postAborted = true;
+					reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+				};
+				if (init?.signal?.aborted) abort();
+				else init?.signal?.addEventListener("abort", abort, { once: true });
+			});
+		}
+		if (url.endsWith("/rate-limit-reset-credits")) {
+			return new Response(JSON.stringify({ available_count: 1 }), { status: 200 });
+		}
+		return usageResponse(1);
+	};
+
+	const choices = ["Redeem usage limit reset…", "Full reset", "Yes, use reset"];
+	const mock = createMockPi();
+	usageExtension(mock.pi, {
+		credentialReader: () => credential(),
+		createRedemptionId: () => "shutdown-attempt",
+	});
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async () => choices.shift(),
+		modelRegistry: codexRegistry(() => "codex-token"),
+	});
+
+	const pending = command.handler("", ctx);
+	await postReady;
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	await pending;
+
+	assert.equal(postAborted, true);
+});

--- a/packages/pi-usage/test/codex-resets.test.ts
+++ b/packages/pi-usage/test/codex-resets.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMockContext } from "../../../test/support.js";
+import { formatCodexResetOutcome } from "../src/codex-resets.js";
+import {
+	consumeCodexResetCredit,
+	listCodexResetCredits,
+	normalizeCodexResetCreditsPayload,
+	type ResolvedUsageAuth,
+	resolveCodexResetAuth,
+} from "../src/index.js";
+
+const codexModel = {
+	id: "gpt-5.3-codex",
+	name: "GPT-5.3 Codex",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+};
+
+function resolvedAuth(): ResolvedUsageAuth {
+	return {
+		apiKey: "active-token",
+		headers: {
+			Authorization: "Bearer active-token",
+			"chatgpt-account-id": "account-123",
+		},
+		fingerprint: "fingerprint",
+		secrets: ["active-token", "Bearer active-token", "account-123"],
+		model: codexModel as never,
+	};
+}
+
+test("Codex reset auth requires the current matching Pi OAuth account", async () => {
+	const { ctx } = createMockContext({
+		model: codexModel,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "active-token" }),
+			getProviderAuth: async () => ({ auth: { apiKey: "active-token" } }),
+			getAvailable: () => [codexModel],
+			getAll: () => [codexModel],
+		},
+	});
+	const credential = () => ({
+		type: "oauth",
+		access: "active-token",
+		refresh: "refresh-token",
+		expires: Date.now() + 60_000,
+		accountId: "account-123",
+	});
+
+	const auth = await resolveCodexResetAuth(ctx, new Uint8Array(32), credential);
+	assert.deepEqual(auth.headers, {
+		Authorization: "Bearer active-token",
+		"chatgpt-account-id": "account-123",
+	});
+	assert.ok(auth.secrets.includes("account-123"));
+
+	await assert.rejects(
+		() =>
+			resolveCodexResetAuth(ctx, new Uint8Array(32), () => ({
+				...credential(),
+				access: "another-token",
+			})),
+		/does not match/iu,
+	);
+	await assert.rejects(
+		() =>
+			resolveCodexResetAuth(ctx, new Uint8Array(32), () => ({
+				type: "api_key",
+				key: "active-token",
+			})),
+		/OAuth/iu,
+	);
+
+	const { ctx: configuredOnly } = createMockContext({
+		model: { ...codexModel, provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1" },
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: "active-token" } }),
+			getAvailable: () => [codexModel],
+			getAll: () => [codexModel],
+		},
+	});
+	await assert.rejects(
+		() => resolveCodexResetAuth(configuredOnly, new Uint8Array(32), credential),
+		/current.*Codex/iu,
+	);
+});
+
+test("Codex reset details normalize safe available options in expiration order", () => {
+	const availability = normalizeCodexResetCreditsPayload({
+		credits: [
+			{
+				id: "credit-later",
+				reset_type: "codex_rate_limits",
+				status: "available",
+				granted_at: "2026-06-18T00:00:00Z",
+				expires_at: "2026-08-18T00:00:00Z",
+				title: "Later\u001b[31m reset",
+				description: "Reset\nweekly and 5h limits",
+			},
+			{
+				id: "credit-used",
+				reset_type: "codex_rate_limits",
+				status: "redeemed",
+				granted_at: "2026-06-17T00:00:00Z",
+				expires_at: "2026-07-17T00:00:00Z",
+			},
+			{
+				id: "credit-sooner",
+				reset_type: "codex_rate_limits",
+				status: "available",
+				granted_at: "2026-06-17T00:00:00Z",
+				expires_at: "2026-07-17T00:00:00Z",
+			},
+		],
+		available_count: 2,
+		total_earned_count: 4,
+	});
+
+	assert.equal(availability.availableCount, 2);
+	assert.deepEqual(
+		availability.options.map((option) => option.creditId),
+		["credit-sooner", "credit-later"],
+	);
+	assert.equal(availability.options[0]?.title, "Full reset");
+	assert.equal(availability.options[1]?.title, "Later reset");
+	assert.equal(availability.options[1]?.description, "Reset weekly and 5h limits");
+	assert.equal(availability.options[0]?.expiresAt, 1_784_246_400);
+
+	const summaryOnly = normalizeCodexResetCreditsPayload({ available_count: 3 });
+	assert.deepEqual(summaryOnly.options, [
+		{
+			title: "Full reset",
+			description: "Reset your current usage limits.",
+		},
+	]);
+	assert.throws(
+		() => normalizeCodexResetCreditsPayload({ available_count: -1 }),
+		/available_count/iu,
+	);
+});
+
+test("Codex reset outcomes distinguish success, idempotency, and unavailable states", () => {
+	assert.equal(
+		formatCodexResetOutcome({ code: "reset", windowsReset: 2 }, 1),
+		"Usage reset. You have 1 usage limit reset left.",
+	);
+	assert.equal(
+		formatCodexResetOutcome({ code: "already_redeemed", windowsReset: 0 }, 0),
+		"Usage reset was already completed. You have 0 usage limit resets left.",
+	);
+	assert.equal(
+		formatCodexResetOutcome({ code: "nothing_to_reset", windowsReset: 0 }, 2),
+		"Your usage does not need a reset right now.",
+	);
+	assert.equal(
+		formatCodexResetOutcome({ code: "no_credit", windowsReset: 0 }, 0),
+		"No usage limit resets are available.",
+	);
+});
+
+test("Codex reset requests use exact ChatGPT paths, account headers, and payloads", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	const requests: Array<{ url: string; init?: RequestInit }> = [];
+	globalThis.fetch = async (input, init) => {
+		requests.push({ url: String(input), init });
+		if (init?.method === "POST") {
+			return new Response(JSON.stringify({ code: "reset", windows_reset: 2 }), { status: 200 });
+		}
+		return new Response(JSON.stringify({ credits: [], available_count: 0 }), { status: 200 });
+	};
+	const controller = new AbortController();
+
+	const availability = await listCodexResetCredits(resolvedAuth(), controller.signal, 1_000);
+	assert.equal(availability.availableCount, 0);
+	const outcome = await consumeCodexResetCredit(
+		resolvedAuth(),
+		{ creditId: "credit-123", title: "Full reset", description: "Reset limits" },
+		"redeem-123",
+		controller.signal,
+		1_000,
+	);
+	assert.deepEqual(outcome, { code: "reset", windowsReset: 2 });
+
+	assert.equal(requests[0]?.url, "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits");
+	assert.equal(requests[0]?.init?.method, "GET");
+	assert.equal(
+		requests[1]?.url,
+		"https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
+	);
+	assert.equal(requests[1]?.init?.method, "POST");
+	assert.deepEqual(JSON.parse(String(requests[1]?.init?.body)), {
+		redeem_request_id: "redeem-123",
+		credit_id: "credit-123",
+	});
+	const headers = new Headers(requests[1]?.init?.headers);
+	assert.equal(headers.get("authorization"), "Bearer active-token");
+	assert.equal(headers.get("chatgpt-account-id"), "account-123");
+	assert.equal(headers.get("content-type"), "application/json");
+});
+
+test("Codex reset consume recognizes every backend outcome and rejects unknown values", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	for (const code of ["reset", "nothing_to_reset", "no_credit", "already_redeemed"] as const) {
+		globalThis.fetch = async () =>
+			new Response(JSON.stringify({ code, windows_reset: 0 }), { status: 200 });
+		const outcome = await consumeCodexResetCredit(
+			resolvedAuth(),
+			{ title: "Full reset", description: "Reset limits" },
+			"same-logical-attempt",
+			new AbortController().signal,
+			1_000,
+		);
+		assert.equal(outcome.code, code);
+	}
+
+	globalThis.fetch = async () =>
+		new Response(JSON.stringify({ code: "surprise", windows_reset: 0 }), { status: 200 });
+	await assert.rejects(
+		() =>
+			consumeCodexResetCredit(
+				resolvedAuth(),
+				{ title: "Full reset", description: "Reset limits" },
+				"redeem-unknown",
+				new AbortController().signal,
+				1_000,
+			),
+		/outcome|code/iu,
+	);
+});

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -115,6 +115,168 @@ test("/usage automatically queries the current runtime account and shows state p
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
 });
 
+test("current Codex usage can redeem a selected reset and refresh account state", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let usageRequests = 0;
+	const requests: Array<{ url: string; init?: RequestInit }> = [];
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		requests.push({ url, init });
+		if (url.endsWith("/wham/rate-limit-reset-credits/consume")) {
+			return new Response(JSON.stringify({ code: "reset", windows_reset: 2 }), { status: 200 });
+		}
+		if (url.endsWith("/wham/rate-limit-reset-credits")) {
+			return new Response(
+				JSON.stringify({
+					credits: [
+						{
+							id: "credit-123",
+							reset_type: "codex_rate_limits",
+							status: "available",
+							granted_at: "2026-06-17T00:00:00Z",
+							expires_at: "2026-09-17T00:00:00Z",
+							title: "Weekly + 5h reset",
+							description: "Reset both current windows.",
+						},
+					],
+					available_count: 1,
+				}),
+				{ status: 200 },
+			);
+		}
+		usageRequests += 1;
+		return new Response(
+			JSON.stringify({
+				plan_type: "pro",
+				rate_limit: {
+					primary_window: {
+						used_percent: usageRequests === 1 ? 80 : 0,
+						limit_window_seconds: 18_000,
+					},
+				},
+				rate_limit_reset_credits: { available_count: usageRequests === 1 ? 1 : 0 },
+			}),
+			{ status: 200 },
+		);
+	};
+
+	const choices = ["Redeem usage limit reset…", "Weekly + 5h reset", "Yes, use reset", "Close"];
+	const titles: string[] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi, {
+		credentialReader: () => ({
+			type: "oauth",
+			access: "codex-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			accountId: "account-123",
+		}),
+		createRedemptionId: () => "redeem-123",
+	});
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async (title: string, options: string[]) => {
+			titles.push(title);
+			const choice = choices.shift();
+			assert.ok(choice === undefined || options.includes(choice), `${choice} not in ${options}`);
+			return choice;
+		},
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "codex-token" }),
+			getProviderAuth: async () => ({ auth: { apiKey: "codex-token" } }),
+			getAvailable: () => [codexModel],
+			getAll: () => [codexModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	const consume = requests.find((request) => request.url.endsWith("/consume"));
+	assert.ok(consume);
+	assert.deepEqual(JSON.parse(String(consume.init?.body)), {
+		redeem_request_id: "redeem-123",
+		credit_id: "credit-123",
+	});
+	assert.equal(new Headers(consume.init?.headers).get("chatgpt-account-id"), "account-123");
+	assert.ok(usageRequests >= 2);
+	assert.equal(statuses.get("usage"), "codex 100% 5h");
+	assert.match(titles.at(-1) ?? "", /Usage reset.*0 usage limit resets left/isu);
+});
+
+test("Codex reset confirmation defaults to cancellation and sends no mutation", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let postRequests = 0;
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		if (init?.method === "POST") postRequests += 1;
+		if (url.endsWith("/wham/rate-limit-reset-credits")) {
+			return new Response(JSON.stringify({ available_count: 1 }), { status: 200 });
+		}
+		return new Response(
+			JSON.stringify({
+				rate_limit: { primary_window: { used_percent: 80, limit_window_seconds: 18_000 } },
+				rate_limit_reset_credits: { available_count: 1 },
+			}),
+			{ status: 200 },
+		);
+	};
+	const choices: Array<string | undefined> = [
+		"Redeem usage limit reset…",
+		"Full reset",
+		"No, go back",
+		undefined,
+		"Close",
+	];
+	const confirmationOptions: string[][] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi, {
+		credentialReader: () => ({
+			type: "oauth",
+			access: "codex-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			accountId: "account-123",
+		}),
+		createRedemptionId: () => "must-not-be-used",
+	});
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async (title: string, options: string[]) => {
+			if (title.includes("Use this reset?")) confirmationOptions.push(options);
+			return choices.shift();
+		},
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "codex-token" }),
+			getProviderAuth: async () => ({ auth: { apiKey: "codex-token" } }),
+			getAvailable: () => [codexModel],
+			getAll: () => [codexModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.deepEqual(confirmationOptions[0], ["No, go back", "Yes, use reset"]);
+	assert.equal(postRequests, 0);
+});
+
 test("command arguments are rejected instead of becoming a hidden interface", async () => {
 	const mock = createMockPi();
 	usageExtension(mock.pi);


### PR DESCRIPTION
## Summary

- add a bounded Codex reset client for listing and consuming earned usage-limit resets with the current matching Pi OAuth account
- add TUI/RPC selection, safe confirmation, idempotent retry, account revalidation, lifecycle cancellation, and post-redemption usage/status refresh
- document the workflow and security boundaries, add deterministic contract/lifecycle coverage, and record a minor Changeset

## Verification

- `npm run check` — passed on current `origin/main` (2,454 tests)
- `npm run check --workspace @narumitw/pi-usage` — passed
- `npm run check:boundaries` — passed
- `just pack usage` — inspected 13 declared package files; no tarball retained
- Pi RPC load smoke with an unsupported provider — two successful responses and exactly one extension-owned `usage` command; no provider traffic

No live usage-limit reset was consumed during verification.

## Convention audit

Read and audited `docs/extension-conventions.md` for the touched command/menu, auth/network mutation, cache/status, lifecycle, documentation, release, and verification paths. `docs/extension-settings.md` is not applicable because no settings changed. No convention deviation was accepted.
