### PR TITLE
feat(chat): add signed gossip and room discovery

### DIFF
--- a/.changeset/bright-rooms-gossip.md
+++ b/.changeset/bright-rooms-gossip.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-chat": minor
+---
+
+Replace full-mesh chat with signed, duplicate-suppressing gossip and add an estimated P2P public-room browser.

--- a/docs/plans/archived/2026-08-07_pi-chat-gossip-pubsub-plan.md
+++ b/docs/plans/archived/2026-08-07_pi-chat-gossip-pubsub-plan.md
@@ -1,0 +1,235 @@
+# Pi Chat gossip/pubsub and public-room directory plan
+
+## Goal
+
+Replace Pi Chat's 16-peer full mesh with a bounded, signed P2P gossip/pubsub overlay that supports
+approximately 256 active participants per room with at most 8 direct neighbors per client, prevents
+duplicate local display and forwarding while a message remains in the bounded deduplication window,
+and adds a best-effort public-room browser sorted by estimated active participants.
+
+## Context
+
+- Room discovery currently joins one deterministic HyperDHT topic, then `peer-list` messages attempt
+  to complete a full mesh capped at 16 direct peers.
+- Chat messages currently trust the authenticated immediate connection. Forwarding them would lose
+  author identity unless each origin signs an immutable event envelope.
+- Current duplicate tracking keys messages by the immediate peer, so the same forwarded event arriving
+  through different neighbors would not deduplicate correctly.
+- HyperDHT cannot enumerate unknown room topics. The approved public directory therefore uses a
+  separate bounded gossip overlay and must say “discovered” and “estimated,” never complete or
+  authoritative.
+- Existing settings store public slugs and private invite secrets rather than transport internals, so
+  no settings schema change is required. Existing `/chat`, `/chat #slug`, and private-invite command
+  shapes remain supported.
+- Applicable convention areas are package/runtime dependencies, command and Kit-menu behavior,
+  bounded protocol output, TUI-only mode handling, asynchronous network ownership, session
+  replacement and shutdown, deterministic tests, documentation, packaging, and Changesets. The v2
+  discovery domains also require a narrow settings migration, so `docs/extension-settings.md` applies
+  to side-effect-free load normalization, invalid-file protection, unknown-field preservation, and
+  atomic publication; precedence and settings UI remain unchanged.
+
+## Architecture
+
+### Room overlay and transport
+
+- Keep one Hyperswarm room topic but let Hyperswarm maintain at most 8 authenticated direct neighbors;
+  remove application behavior that calls `joinPeer()` to complete a mesh.
+- Retain the room-secret handshake before accepting any gossip event. Refresh discovery on a bounded
+  schedule so churn can heal the sparse overlay.
+- Model local connectivity separately from room membership: snapshots expose direct-neighbor count and
+  a bounded active-participant catalog rather than treating every participant as a direct peer.
+
+### Signed gossip events
+
+- Introduce a versioned immutable event envelope for chat and presence with room id, origin public key,
+  event id, issued time, payload, and an Ed25519 detached signature from the existing HyperDHT identity
+  keypair. Hop budget is mutable forwarding metadata and is excluded from the signed canonical body.
+- Verify shape, byte limits, room id, clock window, signature, hop budget, immediate-neighbor rate
+  limits, and origin limits before accepting an event.
+- Deduplicate on `originPublicKey:eventId`. Record locally created events before broadcasting; for a
+  newly accepted remote event, update local state once and forward once to authenticated neighbors
+  other than the ingress connection with a decremented hop budget.
+- Bound deduplication by both capacity and local expiry. This provides at-most-once local display and
+  forwarding only inside that window; it does not claim global exactly-once delivery.
+- Use signed online, heartbeat, nickname, and leaving presence events. Expire participants after a
+  bounded heartbeat timeout, cap the catalog at 256 remote origins, and keep local mute keyed by event
+  origin. Muted content is not displayed but may still be forwarded so one user's local preference
+  does not partition the overlay.
+- Report a local send as relayed to direct neighbors, not delivered to the room. Preserve best-effort
+  semantics, no history replay, and no delivery receipt.
+
+### Protocol compatibility
+
+- Move wire messages and discovery domains to protocol v2 so old full-mesh clients do not silently
+  mix with the gossip overlay.
+- Continue accepting existing `pichat:v1:<secret>` command and remembered-invite input, deriving the
+  v2 private room from the same secret. Emit `pichat:v2` for newly created private invites and document
+  that old clients cannot interoperate with the v2 overlay.
+- Public settings continue storing the slug; restore derives the v2 public topic. Unknown settings
+  fields and existing restart behavior remain unchanged.
+
+### Public-room directory
+
+- Add a separate versioned global directory gossip topic. A joined public room owns one room-scoped
+  pseudonymous announcer so directory traffic does not expose the stable chat identity across rooms.
+- Directory presence records contain a validated public slug, scoped origin key, event id, issued time,
+  and signature. Peers deduplicate and forward bounded current records; heartbeat expiry produces an
+  estimated count of unique scoped origins per slug.
+- Bound the directory by room count, active records, frame size, hop budget, request frequency, and
+  collection time. When any bound truncates results, return a partial marker for the UI.
+- A disconnected browser uses an ephemeral identity and temporary swarm. A joined public-room browser
+  may reuse its owned directory node. Browser cancellation, menu disposal, join failure, leave,
+  session replacement, and shutdown stop every owned discovery, socket, timer, and task.
+- Normalize results deterministically by estimated participant count descending, then slug ascending.
+
+### Menu and state flows
+
+- Add **Browse public rooms** before manual **Join public room** in disconnected and replacement menus.
+  The browse screen shows estimated counts and explicit discovered/partial wording.
+- Loading is cancellable. Empty results retain Refresh and manual-entry recovery; failures retain Retry
+  and manual-entry recovery without discarding a valid previous catalog.
+- Selecting a discovered room reuses the existing public-room warning, remembered join, and composer
+  opening. Cancellation has no settings or room-network side effects.
+- Update status, participants, widget, and composer copy to distinguish active participants, direct
+  neighbors, and “relayed to neighbors.”
+
+## Tech Stack
+
+- Continue using TypeScript, Hyperswarm, HyperDHT, Pi's extension APIs, and
+  `@narumitw/pi-tui-kit`.
+- Add `sodium-universal` as a direct runtime dependency for detached Ed25519 signatures compatible
+  with HyperDHT keypairs; do not rely on its current transitive installation.
+- Use Node's test runner and local `hyperdht/testnet.js` for deterministic multi-peer overlay smokes.
+
+## Non-Goals
+
+- No central registry, product-owned relay, offline delivery, persistent history, global ordering,
+  delivery receipts, or exactly-once guarantee.
+- No claim that the directory lists every public room or that estimated participant counts resist
+  Sybil identities.
+- No unbounded room, directory, deduplication, transcript, retry, queue, or peer catalog.
+- No interoperability between old v1 full-mesh clients and the new v2 wire overlay beyond accepting
+  old invite text and stored secrets as v2 inputs.
+- No RPC, print, JSON, browser, or mobile chat client.
+
+## Risks
+
+- Sparse gossip can partition temporarily or lose events during churn; bounded discovery refresh,
+  multiple neighbors, hop budget, and local DHT testnets mitigate but do not eliminate this.
+- A valid member can replay old signed events, create Sybil identities, or flood valid signatures;
+  clock windows, expiry, per-neighbor/per-origin rate limits, bounded catalogs, and documented
+  best-effort behavior limit impact.
+- Global directory gossip can expose public room participation metadata. Room-scoped pseudonyms reduce
+  cross-room linkability but do not provide anonymity from DHT infrastructure or direct neighbors.
+- A v2 topic/domain change intentionally separates upgraded and old clients. README and Changeset must
+  make this experimental protocol break explicit while preserving old invite parsing and settings
+  restoration.
+- Eight neighbors and the chosen hop budget may not cover every 256-node topology. The local testnet
+  smoke proves representative propagation and duplicate suppression, not universal delivery.
+
+## Rollback / Recovery
+
+- The implementation remains one package release and introduces no persistent data migration. A code
+  rollback restores the previous full-mesh runtime; stored public slugs and private secrets remain
+  readable.
+- If v2 join or directory startup fails, stop partial resources, retain the prior valid settings, and
+  expose the existing retry/join-another/forget recovery paths.
+- If browsing fails, keep the active chat session unchanged and offer Retry or manual slug entry.
+
+## Plan
+
+- [x] Add identity-level signature tests and a failing canonical-event test in
+      `packages/pi-chat/test/identity.test.ts` and `protocol.test.ts` proving valid Ed25519 envelopes
+      verify while payload mutation, wrong room, wrong origin, malformed signatures, and oversized
+      payloads fail. Evidence: the initial `npm test` compile failed on the intentionally missing
+      signature/event exports.
+- [x] Add `sodium-universal` to `packages/pi-chat/package.json`, regenerate `package-lock.json` with
+      npm 12.0.2, and implement canonical detached signing/verification in `src/identity.ts` and
+      `src/protocol.ts`. Evidence: workspace typecheck and 13 focused identity/protocol tests passed.
+- [x] Add failing `chat-session` tests for multi-path duplicate arrival, local-send loopback,
+      forwarding excluding ingress, hop exhaustion, invalid signature rejection, bounded expiry,
+      per-neighbor/per-origin rate limits, mute-by-origin, presence expiry, and a 256-member catalog.
+      Evidence: the test compile initially failed on the absent gossip snapshot and relay contracts.
+- [x] Refactor `src/chat-session.ts` into bounded event-deduplication, presence, and forwarding
+      responsibilities without leaving any source file over 1,000 lines. Evidence: 10 focused session
+      tests pass and snapshots distinguish active participants from direct neighbors.
+- [x] Add transport tests showing at most 8 direct neighbors, no application-driven full-mesh
+      `joinPeer()` calls, bounded discovery refresh, sparse-overlay recovery, and idempotent stop.
+      Evidence: the transport contract no longer exposes `connectPeer`, limits clamp at 8, and local
+      DHT recovery/cleanup coverage compiles against the sparse contract.
+- [x] Update `src/network.ts` and protocol peer-discovery behavior to maintain the 8-neighbor sparse
+      room overlay and protocol-v2 domains, while accepting v1 invite text as v2 input. Evidence:
+      focused protocol tests and workspace typecheck pass; network smokes remain in the final suite.
+- [x] Normalize stored v1 public/private room ids to v2 in memory without load-time writes, and preserve
+      unknown room/resume fields when an explicit resume save publishes v2 ids. Evidence: the focused
+      migration test verifies byte-for-byte side-effect-free load, both room kinds, active-id mapping,
+      unknown-field retention, and atomic settings publication.
+- [x] Add failing directory unit tests for slug validation, signed room-scoped presence, multi-path
+      deduplication, heartbeat expiry, catalog/frame/hop/request bounds, partial-result marking,
+      count-descending/slug-ascending sorting, and abort cleanup. Evidence: compilation first failed on
+      the absent directory module and its contract.
+- [x] Implement the directory state machine and Hyperswarm adapter in descriptive modules under
+      `packages/pi-chat/src/`, including ephemeral browsing and room-scoped advertising. Evidence: 6
+      directory tests pass, including abort cleanup and a two-advertiser local DHT smoke.
+- [x] Add failing `menu.test.ts` cases for browse ordering, approximate labels, loading cancellation,
+      empty results, partial results, retry after failure, manual-entry recovery, selected-room warning,
+      and selected-room join. Evidence: test compilation initially failed on the absent source and
+      menu routes.
+- [x] Extend `src/menu.ts` through `@narumitw/pi-tui-kit` with Browse, Refresh/Retry, and manual recovery
+      while preserving all established command routes and TUI-only rejection. Evidence: 7 focused
+      menu tests pass and the disconnected root has exactly seven rows.
+- [x] Add failing `pi-chat.test.ts` lifecycle cases for advertiser startup only after a successful
+      public join, no advertiser for private rooms, browse cancellation, failed join cleanup, leave,
+      session replacement, shutdown, and stale continuation suppression. Evidence: focused coverage
+      asserts public/private ownership and temporary browse cleanup alongside existing replacement,
+      failed-join, and shutdown cases.
+- [x] Wire directory ownership and gossip session state through `src/pi-chat.ts`, revalidating session,
+      generation, context, and mutable owner after every await. Evidence: 18 focused extension tests
+      pass with injected directory ownership and no stale UI/network continuation.
+- [x] Update chat view, widget, status, and participant tests and implementation to say active
+      participants, direct neighbors, and relayed-to-neighbors. Evidence: 7 focused view/widget tests
+      pass with width bounds, focus, cancellation, disposal, and draft retention intact.
+- [x] Extend the local DHT integration fixture to propagate one signed chat event across at least one
+      non-origin intermediate peer, deliver it once after duplicate paths, converge representative
+      presence/count state, and fully stop all processes. Evidence: the 10-peer test finds a non-neighbor,
+      relays through the sparse overlay exactly once at every transcript, enforces 8 connections, and
+      passes with complete cleanup; all 76 Pi Chat tests pass.
+- [x] Update `packages/pi-chat/README.md` with the discovered-room workflow, sorting, approximate-count
+      caveat, 256-participant/8-neighbor bounds, v2 invite compatibility, signed deduplication window,
+      metadata/Sybil risks, lifecycle, and delivery limitations. Evidence: documented commands and the
+      package layout match the final source and preserve all standard README sections.
+- [x] Add a minor Changeset for `@narumitw/pi-chat`, run `npm run format`, `npm run check`, and
+      `just pack chat`, inspect that the tarball contains the declared source/README/license and the
+      direct signature dependency resolves, then run the local Pi load smoke. Evidence: all 2,461 root
+      tests and CI-equivalent checks passed; the 17-file tarball includes both directory modules;
+      Changesets reports a minor bump; offline Pi source loading exited 0.
+- [x] Audit the final diff against `docs/extension-conventions.md` and
+      `docs/extension-settings.md` for dependency metadata, command compatibility/modes, bounded
+      protocol data, cancellation, component disposal, failed startup, side-effect-free migration,
+      session replacement, shutdown, independent packaging, deterministic tests, docs, and release
+      intent. Accepted deviations: discovery/counts are explicitly approximate and sparse gossip is
+      best-effort rather than exactly-once/global delivery. Unverified path: no live public-bootstrap
+      interoperability smoke; deterministic local HyperDHT testnets cover room and directory overlays.
+
+## Completion Checklist
+
+- [x] A representative sparse local overlay forwards a valid signed chat event through an intermediate
+      peer, and each client displays and forwards `originPublicKey:eventId` at most once inside the
+      bounded deduplication window.
+- [x] Invalid, replay-window-expired, oversized, over-hop, over-rate, wrong-room, and bad-signature
+      events cannot enter transcript/presence state or propagate.
+- [x] Each room client maintains no more than 8 direct neighbors while the bounded active-participant
+      catalog supports approximately 256 identities and expires stale presence.
+- [x] `/chat` in TUI browses currently discovered public rooms sorted by estimated participants
+      descending and slug ascending, clearly marks approximate/partial results, and retains retry plus
+      manual-entry recovery.
+- [x] Selecting a discovered room reuses the public warning and remembered join; `/chat`, `/chat
+      #slug`, old/new private invite input, startup restore, cancellation, and unsupported-mode behavior
+      remain covered.
+- [x] Public advertising and temporary browsing release every owned discovery, socket, timer, and task
+      on success, cancellation, disposal, failed join, leave, replacement, and shutdown.
+- [x] UI and README distinguish active participants, direct neighbors, and relay acceptance without
+      claiming complete discovery, authoritative counts, room-wide delivery, global ordering, or
+      exactly-once semantics.
+- [x] Pi Chat focused tests, representative local DHT smokes, workspace typecheck, `npm run check`,
+      package inspection, local Pi load, Changeset, and convention audit all have recorded evidence.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7883,7 +7883,8 @@
 			"dependencies": {
 				"@narumitw/pi-tui-kit": "^0.49.1",
 				"hyperdht": "6.33.0",
-				"hyperswarm": "4.17.0"
+				"hyperswarm": "4.17.0",
+				"sodium-universal": "5.0.1"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",

--- a/packages/pi-chat/README.md
+++ b/packages/pi-chat/README.md
@@ -14,15 +14,19 @@ output.
 ## ✨ Features
 
 - Creates random private rooms shared through bearer invite codes.
-- Joins guessable public rooms by lowercase slug.
+- Browses currently discovered public rooms by estimated active participants, or joins a known
+  lowercase slug directly.
 - Shows every nickname with a stable public-key fingerprint such as
   `Mika~7K2P-9D4M-HQ3T`.
+- Relays signed chat and presence events through a sparse P2P gossip overlay and suppresses duplicate
+  display and forwarding inside a bounded deduplication window.
 - Keeps an adaptive joined-room dock visible above the Pi editor with explicit input-target status.
 - Opens a focused, scrollable full-size chat composer with multiline IME support.
-- Preserves chat drafts when returning to Pi or when no direct peer can accept a message.
+- Preserves chat drafts when returning to Pi or when no direct neighbor can accept a message.
 - Restores a remembered room and the last intentional chat/Pi surface when Pi restarts.
-- Uses authenticated direct streams and an invite-derived private-room handshake.
-- Limits peers, frames, messages, transcript entries, reconnect work, and per-peer message rates.
+- Uses authenticated direct streams, origin signatures, and an invite-derived private-room handshake.
+- Limits neighbors, participants, frames, messages, hops, catalogs, transcript entries, reconnect
+  work, and per-neighbor/per-origin message rates.
 - Keeps identity settings local with private permissions and atomic publication.
 - Cleans up discovery, sockets, timers, status, and widgets on leave, reload, session replacement,
   or shutdown.
@@ -63,12 +67,14 @@ Run:
 
 Then choose one of these actions:
 
+- **Browse public rooms** queries a best-effort P2P directory, sorts discovered rooms by estimated
+  active participants and then slug, and keeps Refresh plus manual slug entry available.
 - **Join public room** accepts a lowercase slug such as `pi-dev`, remembers it after the public-room
   warning is confirmed, and opens the chat composer.
 - **Join with invite** accepts a private-room invite, then offers **Join and remember**, **Join once**,
   or **Cancel** before networking starts.
-- **Create private room** generates a random `pichat:v1:…` bearer invite and uses the same explicit
-  persistence choice.
+- **Create private room** generates a random `pichat:v2:…` bearer invite and uses the same explicit
+  persistence choice. Existing `pichat:v1` invite text remains accepted as v2 room input.
 
 The first join asks for a nickname and joined-room display mode, then previews the generated
 identity fingerprint and display choice before one atomic save. Pi Chat does not read your OS
@@ -92,17 +98,18 @@ Inside the dedicated chat composer:
 - `PageUp` and `PageDown` scroll transcript history.
 - `Escape` or `Ctrl+C` returns to Pi/LLM without leaving the room or discarding the chat draft.
 
-The composer retains the draft when no authenticated direct peer is available or a broadcast reaches
-zero peers. A successful local message reports how many authenticated direct peers accepted the
-broadcast. A disconnect race can still record an attempted message as **not delivered**; Pi Chat
-never claims delivery receipts or offline retry.
+The composer retains the draft when no authenticated direct neighbor is available or a relay reaches
+zero neighbors. A successful local message reports how many direct neighbors accepted the first
+relay; it does not claim room-wide delivery. Signed events may arrive over multiple paths, but each
+client displays and forwards one `originPublicKey:eventId` only once while it remains in the bounded
+deduplication window. Pi Chat never claims exactly-once delivery, delivery receipts, or offline retry.
 
 ## 💬 Commands
 
 | Command | Modes | Description |
 | --- | --- | --- |
 | `/chat` | TUI | Open the state-aware Pi Chat manager. |
-| `/chat <pichat:v1:invite>` | TUI | Choose private persistence, join, and open chat. |
+| `/chat <pichat:v1-or-v2:invite>` | TUI | Choose private persistence, join, and open chat. |
 | `/chat #<public-slug>` | TUI | Review the warning, join, and open the chat composer directly. |
 
 RPC, print, and JSON modes reject the command before starting networking or custom TUI work.
@@ -179,7 +186,9 @@ an upgrade does not expose message text unexpectedly.
 Public rooms are remembered only after their existing risk confirmation. A private room is remembered
 only when **Join and remember** is selected; this stores its bearer invite in `pi-chat.json`.
 **Join once** stores no room material, and Cancel starts neither persistence nor networking. An older
-file without `resume` remains disconnected until the next confirmed remembered join.
+file without `resume` remains disconnected until the next confirmed remembered join. Stored v1 public
+or private room ids are normalized to v2 in memory without rewriting the file during load; the next
+explicit resume save publishes v2 ids while preserving unknown room and resume fields.
 
 The identity seed and stored private invites are redacted from UI, notifications, status, and errors.
 On POSIX, settings are published with `0600` permissions. A missing file is a side-effect-free read;
@@ -193,25 +202,41 @@ changes your fingerprint everywhere, forgets startup restore, and leaves the act
 
 ## 🌐 Network and protocol behavior
 
-Pi Chat uses one versioned 32-byte discovery topic per room:
+Pi Chat protocol v2 uses one versioned 32-byte discovery topic per room:
 
 - A private topic and handshake key are domain-separated from a random 32-byte invite secret.
 - A public topic is deterministically derived from the public room slug.
+- A separate global topic carries only bounded public-room directory presence.
 
-Each peer announces and looks up the topic through HyperDHT. Hyperswarm establishes authenticated,
-encrypted Noise streams. The application handshake binds the room proof, nickname, and both peer
-public keys. Messages are sent only across authenticated direct connections; they are not forwarded
-as multi-hop messages. A bounded peer-list exchange asks Hyperswarm to complete a small direct mesh.
+Each peer announces and looks up its topics through HyperDHT. Hyperswarm establishes authenticated,
+encrypted Noise streams. The room handshake binds the room proof, nickname, and both neighbor public
+keys. Each client keeps at most **8 direct neighbors** instead of completing a full mesh.
 
-The implementation limits a room to 16 direct peers, messages to 4 KiB, protocol frames to 16 KiB,
-and the local transcript to 256 entries. There is no authoritative room membership count, global
-ordering, server history, delivery receipt, or offline delivery. The UI therefore reports only
-**direct peers**.
+Chat and presence payloads carry the room id, origin public key, event id, issued time, content, and an
+Ed25519 signature from the origin identity. A mutable hop budget is decremented at each relay. After
+validation, the first copy updates local state and is forwarded to authenticated neighbors other than
+the ingress connection; later copies with the same `originPublicKey:eventId` are dropped. Deduplication,
+rate-limit, participant, and presence state are all bounded and expire locally.
+
+The active-participant catalog supports up to **256 remote identities** and expires presence that has
+not refreshed for 90 seconds. This is an approximate local view: sparse-overlay partitions, churn,
+clock differences, and Sybil identities can change it. Messages are limited to 4 KiB, protocol frames
+to 16 KiB, gossip to 8 hops, and the local transcript to 256 entries.
+
+Public-room browsing uses signed room-scoped pseudonyms so honest clients do not expose one stable chat
+identity across directory rooms. Directory nodes gossip bounded recent presence and browsers sort
+unique scoped origins by estimated count descending, then slug ascending. Results can be empty,
+stale, or partial; HyperDHT cannot enumerate every unknown topic, so the UI never calls the list or
+count authoritative.
+
+`pichat:v1` invite text and stored v1 secrets are accepted and mapped to a v2 private room. Newly
+created invites use `pichat:v2`. Protocol-v1 full-mesh clients do not interoperate with the v2 gossip
+overlay.
 
 Hyperswarm's default DHT depends on public bootstrap infrastructure. “P2P” does not mean
-infrastructure-free. NAT, UDP blocking, enterprise firewalls, bootstrap availability, or peer churn
-can prevent connectivity. Pi Chat performs bounded early refresh and reconnect work but cannot
-promise a connection on every network.
+infrastructure-free. NAT, UDP blocking, enterprise firewalls, bootstrap availability, peer churn, or
+a partitioned sparse overlay can prevent connectivity or delivery. Pi Chat performs bounded refresh
+and reconnect work but cannot promise a connection or room-wide delivery.
 
 ## 🔒 Privacy, security, and recovery
 
@@ -220,7 +245,8 @@ promise a connection on every network.
 - Anyone holding a private invite can join. There is no member revocation in the initial protocol;
   create a new room after an invite leak.
 - Public slugs are guessable. Anyone may join, record, or repost public-room content.
-- A local session mute reduces immediate abuse but does not stop Sybil identities.
+- A local session mute hides one signed origin while still forwarding valid events so a local
+  preference does not partition the room. It does not stop Sybil identities.
 - Remote peers can save or copy messages. Leaving or clearing the local transcript cannot withdraw
   copies from their devices.
 - Pi Chat never sends cwd, repository data, Git remotes, Pi sessions, prompts, models, files, or agent
@@ -241,15 +267,16 @@ and remembered with an actionable error.
 
 ## 🧪 Experimental limitations
 
-The first release intentionally omits:
+The current experimental release intentionally omits:
 
 - simultaneous multi-room connections or UI;
 - persistent or synchronized history;
-- offline messages and delivery receipts;
+- offline messages, delivery receipts, exactly-once delivery, or global ordering;
 - files, images, reactions, replies, editing, or deletion;
-- administrator roles, global bans, or identity recovery;
+- administrator roles, global bans, Sybil resistance, or identity recovery;
 - browser, mobile, RPC, print, or JSON chat clients;
-- large-room gossip pubsub and product-owned relay infrastructure;
+- authoritative room enumeration/counts or product-owned relay infrastructure;
+- more than 256 tracked remote participants or 8 direct neighbors per client;
 - automatic transfer of chat content into the Pi editor, transcript, or model context.
 
 The joined room uses a persistent read-only widget while the normal Pi view is active. Selecting
@@ -269,6 +296,8 @@ packages/pi-chat/
 │   ├── pi-chat.ts
 │   ├── chat-session.ts
 │   ├── network.ts
+│   ├── public-room-directory.ts
+│   ├── directory-network.ts
 │   ├── protocol.ts
 │   ├── identity.ts
 │   ├── settings.ts

--- a/packages/pi-chat/package.json
+++ b/packages/pi-chat/package.json
@@ -34,7 +34,8 @@
 	"dependencies": {
 		"@narumitw/pi-tui-kit": "^0.49.1",
 		"hyperdht": "6.33.0",
-		"hyperswarm": "4.17.0"
+		"hyperswarm": "4.17.0",
+		"sodium-universal": "5.0.1"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*",

--- a/packages/pi-chat/src/chat-session.ts
+++ b/packages/pi-chat/src/chat-session.ts
@@ -7,6 +7,7 @@ import {
 	createHello,
 	createPresenceEvent,
 	type GossipMessage,
+	MAX_EVENT_AGE_MS,
 	PeerRateLimiter,
 	type PresenceEvent,
 	type ProtocolMessage,
@@ -103,6 +104,11 @@ interface OriginLimiterState {
 	lastSeen: number;
 }
 
+interface ParticipantVersionState {
+	issuedAt: number;
+	id: string;
+}
+
 export class ChatSession {
 	private readonly room: RoomDescriptor;
 	private readonly identity: ChatIdentity;
@@ -117,6 +123,7 @@ export class ChatSession {
 	private readonly seen = new Map<string, number>();
 	private readonly seenOrder: Array<{ key: string; expiresAt: number }> = [];
 	private readonly originLimiters = new Map<string, OriginLimiterState>();
+	private readonly participantVersions = new Map<string, ParticipantVersionState>();
 	private readonly listeners = new Set<(snapshot: ChatSnapshot) => void>();
 	private state: ChatSnapshot["state"] = "disconnected";
 	private unread = 0;
@@ -360,15 +367,17 @@ export class ChatSession {
 		}
 		if (!this.acceptOrigin(event.origin)) return;
 		this.remember(key);
-		this.applyEvent(event);
+		if (!this.applyEvent(event)) return;
 		if (message.hops > 1) {
 			this.broadcast(createGossipMessage(event, message.hops - 1), state.peer);
 		}
 	}
 
-	private applyEvent(event: RoomEvent): void {
+	private applyEvent(event: RoomEvent): boolean {
 		const publicKey = Buffer.from(event.origin, "hex");
+		const participantStateIsNew = this.acceptParticipantVersion(event);
 		if (event.kind === "presence") {
+			if (!participantStateIsNew) return false;
 			if (event.status === "leaving") {
 				this.participants.delete(event.origin);
 				this.originLimiters.delete(event.origin);
@@ -376,9 +385,11 @@ export class ChatSession {
 				this.upsertParticipant(event.origin, publicKey, event.nickname, this.now());
 			}
 			this.emit();
-			return;
+			return true;
 		}
-		this.upsertParticipant(event.origin, publicKey, event.nickname, this.now());
+		if (participantStateIsNew) {
+			this.upsertParticipant(event.origin, publicKey, event.nickname, this.now());
+		}
 		if (!this.mutedOrigins.has(event.origin)) {
 			this.pushTranscript({
 				id: event.id,
@@ -391,6 +402,36 @@ export class ChatSession {
 			if (!this.viewOpen) this.unread += 1;
 		}
 		this.emit();
+		return true;
+	}
+
+	private acceptParticipantVersion(event: RoomEvent): boolean {
+		this.pruneParticipantVersions();
+		const existing = this.participantVersions.get(event.origin);
+		if (existing && compareEventVersion(existing, event) >= 0) return false;
+		if (!existing && this.participantVersions.size >= MAX_SEEN_MESSAGES) {
+			let oldestOrigin: string | undefined;
+			let oldestVersion: ParticipantVersionState | undefined;
+			for (const [origin, candidate] of this.participantVersions) {
+				if (!oldestVersion || compareEventVersion(candidate, oldestVersion) < 0) {
+					oldestOrigin = origin;
+					oldestVersion = candidate;
+				}
+			}
+			if (oldestOrigin) this.participantVersions.delete(oldestOrigin);
+		}
+		this.participantVersions.set(event.origin, {
+			issuedAt: event.issuedAt,
+			id: event.id,
+		});
+		return true;
+	}
+
+	private pruneParticipantVersions(): void {
+		const oldest = this.now() - MAX_EVENT_AGE_MS;
+		for (const [origin, version] of this.participantVersions) {
+			if (version.issuedAt < oldest) this.participantVersions.delete(origin);
+		}
 	}
 
 	private onDisconnect(owner: number, peer: TransportPeer): void {
@@ -481,6 +522,7 @@ export class ChatSession {
 	}
 
 	private pruneParticipants(): void {
+		this.pruneParticipantVersions();
 		const oldest = this.now() - PARTICIPANT_TTL_MS;
 		for (const [id, participant] of this.participants) {
 			if (participant.lastSeen < oldest) {
@@ -576,6 +618,7 @@ export class ChatSession {
 		this.peers.clear();
 		this.participants.clear();
 		this.originLimiters.clear();
+		this.participantVersions.clear();
 		this.seen.clear();
 		this.seenOrder.length = 0;
 		await this.transport.stop().catch((error) => {
@@ -596,6 +639,13 @@ export class ChatSession {
 
 function eventKey(event: RoomEvent): string {
 	return `${event.origin}:${event.id}`;
+}
+
+function compareEventVersion(
+	left: Pick<RoomEvent, "issuedAt" | "id">,
+	right: Pick<RoomEvent, "issuedAt" | "id">,
+): number {
+	return left.issuedAt - right.issuedAt || left.id.localeCompare(right.id);
 }
 
 function keyId(publicKey: Uint8Array): string {

--- a/packages/pi-chat/src/chat-session.ts
+++ b/packages/pi-chat/src/chat-session.ts
@@ -2,17 +2,28 @@ import { randomBytes, randomUUID } from "node:crypto";
 import type { ChatIdentity } from "./identity.js";
 import { formatIdentityLabel, normalizeNickname, uniqueIdentityTags } from "./identity.js";
 import {
-	createChatMessage,
+	createChatEvent,
+	createGossipMessage,
 	createHello,
+	createPresenceEvent,
+	type GossipMessage,
 	PeerRateLimiter,
+	type PresenceEvent,
 	type ProtocolMessage,
 	type RoomDescriptor,
+	type RoomEvent,
 	verifyHello,
+	verifyRoomEvent,
 } from "./protocol.js";
 
 const MAX_TRANSCRIPT = 256;
-const MAX_SEEN_MESSAGES = 1024;
+const MAX_SEEN_MESSAGES = 8_192;
+const SEEN_MESSAGE_TTL_MS = 10 * 60_000;
 const MAX_PROTOCOL_VIOLATIONS = 3;
+const MAX_PARTICIPANTS = 256;
+const PARTICIPANT_TTL_MS = 90_000;
+const PRESENCE_HEARTBEAT_MS = 30_000;
+const MAX_ORIGIN_LIMITERS = 512;
 
 export interface TransportPeer {
 	publicKey: Buffer;
@@ -29,7 +40,6 @@ export interface ChatTransportListener {
 
 export interface ChatTransport {
 	start(listener: ChatTransportListener, signal?: AbortSignal): Promise<void>;
-	connectPeer?(publicKey: Buffer): void;
 	stop(): Promise<void>;
 }
 
@@ -40,8 +50,8 @@ export interface TranscriptEntry {
 	publicKey: string;
 	text: string;
 	sentAt: number;
-	delivery?: "broadcast" | "not-delivered";
-	deliveredTo?: number;
+	delivery?: "relayed" | "not-relayed";
+	relayedTo?: number;
 }
 
 export interface ParticipantSnapshot {
@@ -55,7 +65,9 @@ export interface ChatSnapshot {
 	state: "connecting" | "connected" | "degraded" | "disconnected";
 	room: RoomDescriptor;
 	localLabel: string;
-	peers: ParticipantSnapshot[];
+	participants: ParticipantSnapshot[];
+	directNeighbors: number;
+	participantCatalogFull: boolean;
 	transcript: TranscriptEntry[];
 	unread: number;
 	composerOpen: boolean;
@@ -75,9 +87,20 @@ interface PeerState {
 	peer: TransportPeer;
 	authenticated: boolean;
 	nickname?: string;
-	muted: boolean;
 	violations: number;
 	limiter: PeerRateLimiter;
+}
+
+interface ParticipantState {
+	publicKey: Buffer;
+	nickname: string;
+	muted: boolean;
+	lastSeen: number;
+}
+
+interface OriginLimiterState {
+	limiter: PeerRateLimiter;
+	lastSeen: number;
 }
 
 export class ChatSession {
@@ -88,9 +111,12 @@ export class ChatSession {
 	private readonly now: () => number;
 	private readonly onChange?: (snapshot: ChatSnapshot) => void;
 	private readonly peers = new Map<string, PeerState>();
+	private readonly participants = new Map<string, ParticipantState>();
+	private readonly mutedOrigins = new Set<string>();
 	private readonly transcript: TranscriptEntry[] = [];
-	private readonly seen = new Set<string>();
-	private readonly seenOrder: string[] = [];
+	private readonly seen = new Map<string, number>();
+	private readonly seenOrder: Array<{ key: string; expiresAt: number }> = [];
+	private readonly originLimiters = new Map<string, OriginLimiterState>();
 	private readonly listeners = new Set<(snapshot: ChatSnapshot) => void>();
 	private state: ChatSnapshot["state"] = "disconnected";
 	private unread = 0;
@@ -98,6 +124,9 @@ export class ChatSession {
 	private lastError: string | undefined;
 	private generation = 0;
 	private leavePromise: Promise<void> | undefined;
+	private heartbeatTimer: NodeJS.Timeout | undefined;
+	private currentPresence: PresenceEvent | undefined;
+	private participantCatalogFull = false;
 
 	constructor(options: ChatSessionOptions) {
 		const nickname = normalizeNickname(options.nickname);
@@ -130,6 +159,7 @@ export class ChatSession {
 			signal?.throwIfAborted();
 			if (owner !== this.generation) return;
 			this.state = "connected";
+			this.startHeartbeat(owner);
 			this.emit();
 		} catch (error) {
 			if (owner === this.generation) {
@@ -142,64 +172,58 @@ export class ChatSession {
 		}
 	}
 
-	send(text: string): { id: string; deliveredTo: number } {
+	send(text: string): { id: string; relayedTo: number } {
 		if (this.state !== "connected" && this.state !== "degraded") {
 			throw new Error("Pi Chat is not connected.");
 		}
 		const id = randomUUID();
-		const message = createChatMessage(text, this.now(), id);
-		let deliveredTo = 0;
-		for (const state of this.peers.values()) {
-			if (!state.authenticated || state.muted) continue;
-			try {
-				state.peer.send(message);
-				deliveredTo += 1;
-			} catch {
-				state.violations += 1;
-			}
-		}
+		const event = createChatEvent(this.room, this.identity, this.nickname, text, this.now(), id);
+		this.remember(eventKey(event));
+		const relayedTo = this.broadcast(createGossipMessage(event));
 		this.pushTranscript({
 			id,
 			author: "local",
 			label: formatIdentityLabel(this.nickname, this.identity.publicKey),
 			publicKey: this.identity.publicKey.toString("hex"),
 			text,
-			sentAt: message.sentAt,
-			delivery: deliveredTo > 0 ? "broadcast" : "not-delivered",
-			deliveredTo,
+			sentAt: event.issuedAt,
+			delivery: relayedTo > 0 ? "relayed" : "not-relayed",
+			relayedTo,
 		});
 		this.emit();
-		return { id, deliveredTo };
+		return { id, relayedTo };
 	}
 
 	updateNickname(value: string): void {
 		const nickname = normalizeNickname(value);
 		if (!nickname) throw new Error("Pi Chat nickname is invalid.");
 		this.nickname = nickname;
-		for (const state of this.peers.values()) {
-			if (!state.authenticated) continue;
-			try {
-				state.peer.send({ v: 1, type: "nickname-update", nickname });
-			} catch {
-				state.violations += 1;
-			}
-		}
+		this.publishPresence("online");
 		this.emit();
 	}
 
 	mute(publicKey: Uint8Array): void {
-		const state = this.peers.get(keyId(publicKey));
-		if (!state) return;
-		state.muted = true;
+		const id = keyId(publicKey);
+		if (!this.participants.has(id)) return;
+		this.mutedOrigins.add(id);
+		const participant = this.participants.get(id);
+		if (participant) participant.muted = true;
 		this.emit();
 	}
 
 	toggleMute(publicKey: Uint8Array): boolean | undefined {
-		const state = this.peers.get(keyId(publicKey));
-		if (!state?.authenticated) return undefined;
-		state.muted = !state.muted;
+		const id = keyId(publicKey);
+		const participant = this.participants.get(id);
+		if (!participant) return undefined;
+		if (this.mutedOrigins.has(id)) {
+			this.mutedOrigins.delete(id);
+			participant.muted = false;
+		} else {
+			this.mutedOrigins.add(id);
+			participant.muted = true;
+		}
 		this.emit();
-		return state.muted;
+		return participant.muted;
 	}
 
 	subscribe(listener: (snapshot: ChatSnapshot) => void): () => void {
@@ -221,22 +245,18 @@ export class ChatSession {
 	}
 
 	snapshot(): ChatSnapshot {
-		const authenticated: Array<[string, PeerState, string]> = [];
-		for (const [publicKey, value] of this.peers) {
-			if (value.authenticated && value.nickname) {
-				authenticated.push([publicKey, value, value.nickname]);
-			}
-		}
+		this.pruneParticipants();
+		const active = [...this.participants.entries()];
 		const tags = uniqueIdentityTags([
 			this.identity.publicKey,
-			...authenticated.map(([, value]) => value.peer.publicKey),
+			...active.map(([, value]) => value.publicKey),
 		]);
 		const localKey = this.identity.publicKey.toString("hex");
-		const peers = authenticated
-			.map(([publicKey, value, nickname]) => ({
+		const participants = active
+			.map(([publicKey, value]) => ({
 				publicKey,
-				nickname,
-				label: `${nickname}~${tags.get(publicKey) ?? formatIdentityLabel(nickname, value.peer.publicKey).split("~").at(-1)}`,
+				nickname: value.nickname,
+				label: `${value.nickname}~${tags.get(publicKey) ?? formatIdentityLabel(value.nickname, value.publicKey).split("~").at(-1)}`,
 				muted: value.muted,
 			}))
 			.sort((left, right) => left.label.localeCompare(right.label));
@@ -244,7 +264,9 @@ export class ChatSession {
 			state: this.state,
 			room: this.room,
 			localLabel: `${this.nickname}~${tags.get(localKey) ?? formatIdentityLabel(this.nickname, this.identity.publicKey).split("~").at(-1)}`,
-			peers,
+			participants,
+			directNeighbors: [...this.peers.values()].filter(({ authenticated }) => authenticated).length,
+			participantCatalogFull: this.participantCatalogFull,
 			transcript: this.transcript.map((entry) => {
 				const tag = tags.get(entry.publicKey);
 				const nickname = entry.label.split("~", 1)[0] ?? entry.label;
@@ -262,14 +284,18 @@ export class ChatSession {
 			return;
 		}
 		const id = keyId(peer.publicKey);
+		if (id === this.identity.publicKey.toString("hex")) {
+			peer.close();
+			return;
+		}
 		const previous = this.peers.get(id);
 		if (previous && previous.peer !== peer) previous.peer.close();
 		const state: PeerState = {
 			peer,
 			authenticated: false,
-			muted: previous?.muted ?? false,
+			nickname: previous?.nickname,
 			violations: 0,
-			limiter: new PeerRateLimiter({ burst: 3, refillPerSecond: 1, now: this.now }),
+			limiter: new PeerRateLimiter({ burst: 12, refillPerSecond: 4, now: this.now }),
 		};
 		this.peers.set(id, state);
 		try {
@@ -301,61 +327,69 @@ export class ChatSession {
 			}
 			state.authenticated = true;
 			state.nickname = hello.nickname;
-			const knownPeers = [...this.peers.values()]
-				.filter((candidate) => candidate !== state && candidate.authenticated)
-				.map((candidate) => candidate.peer.publicKey.toString("hex"));
-			if (knownPeers.length > 0) {
-				state.peer.send({ v: 1, type: "peer-list", publicKeys: knownPeers.slice(0, 16) });
-			}
-			for (const candidate of this.peers.values()) {
-				if (candidate !== state && candidate.authenticated) {
-					candidate.peer.send({ v: 1, type: "peer-list", publicKeys: [id] });
-				}
-			}
+			this.upsertParticipant(id, peer.publicKey, hello.nickname, this.now());
+			this.sendPresenceTo(state.peer);
 			this.emit();
 			return;
 		}
 		if (message.type === "hello") return;
-		if (message.type === "peer-list") {
-			for (const publicKey of message.publicKeys) {
-				if (publicKey !== this.identity.publicKey.toString("hex") && !this.peers.has(publicKey)) {
-					this.transport.connectPeer?.(Buffer.from(publicKey, "hex"));
-				}
-			}
-			return;
-		}
 		if (message.type === "goodbye") {
 			this.peers.delete(id);
 			peer.close();
 			this.emit();
 			return;
 		}
-		if (message.type === "nickname-update") {
-			const nickname = normalizeNickname(message.nickname);
-			if (!nickname) this.violate(id, state);
-			else {
-				state.nickname = nickname;
-				this.emit();
-			}
-			return;
-		}
-		if (message.type !== "chat" || state.muted) return;
-		if (!state.limiter.accept()) {
+		if (message.type !== "gossip") {
 			this.violate(id, state);
 			return;
 		}
-		const seenId = `${id}:${message.id}`;
-		if (this.seen.has(seenId)) return;
-		this.remember(seenId);
-		this.pushTranscript({
-			id: message.id,
-			author: "remote",
-			label: formatIdentityLabel(state.nickname ?? "peer", peer.publicKey),
-			publicKey: id,
-			text: message.text,
-			sentAt: message.sentAt,
-		});
-		if (!this.viewOpen) this.unread += 1;
+		this.onGossip(id, state, message);
+	}
+
+	private onGossip(peerId: string, state: PeerState, message: GossipMessage): void {
+		const event = message.event;
+		const key = eventKey(event);
+		if (event.origin === this.identity.publicKey.toString("hex") || this.hasSeen(key)) return;
+		if (!state.limiter.accept()) {
+			this.violate(peerId, state);
+			return;
+		}
+		if (!verifyRoomEvent(event, this.room, this.now())) {
+			this.violate(peerId, state);
+			return;
+		}
+		if (!this.acceptOrigin(event.origin)) return;
+		this.remember(key);
+		this.applyEvent(event);
+		if (message.hops > 1) {
+			this.broadcast(createGossipMessage(event, message.hops - 1), state.peer);
+		}
+	}
+
+	private applyEvent(event: RoomEvent): void {
+		const publicKey = Buffer.from(event.origin, "hex");
+		if (event.kind === "presence") {
+			if (event.status === "leaving") {
+				this.participants.delete(event.origin);
+				this.originLimiters.delete(event.origin);
+			} else {
+				this.upsertParticipant(event.origin, publicKey, event.nickname, this.now());
+			}
+			this.emit();
+			return;
+		}
+		this.upsertParticipant(event.origin, publicKey, event.nickname, this.now());
+		if (!this.mutedOrigins.has(event.origin)) {
+			this.pushTranscript({
+				id: event.id,
+				author: "remote",
+				label: formatIdentityLabel(event.nickname, publicKey),
+				publicKey: event.origin,
+				text: event.text,
+				sentAt: event.issuedAt,
+			});
+			if (!this.viewOpen) this.unread += 1;
+		}
 		this.emit();
 	}
 
@@ -375,21 +409,147 @@ export class ChatSession {
 		this.emit();
 	}
 
+	private startHeartbeat(owner: number): void {
+		this.heartbeatTimer = setInterval(() => {
+			if (owner !== this.generation || this.state === "disconnected") return;
+			this.publishPresence("online");
+			this.pruneParticipants();
+			this.emit();
+		}, PRESENCE_HEARTBEAT_MS);
+		this.heartbeatTimer.unref();
+	}
+
+	private publishPresence(status: "online" | "leaving"): void {
+		const event = this.newPresence(status);
+		this.broadcast(createGossipMessage(event));
+	}
+
+	private sendPresenceTo(peer: TransportPeer): void {
+		const event = this.currentPresence ?? this.newPresence("online");
+		try {
+			peer.send(createGossipMessage(event));
+		} catch {
+			// The transport will publish disconnect state.
+		}
+	}
+
+	private newPresence(status: "online" | "leaving"): PresenceEvent {
+		const event = createPresenceEvent(
+			this.room,
+			this.identity,
+			this.nickname,
+			status,
+			this.now(),
+			randomUUID(),
+		);
+		this.currentPresence = status === "online" ? event : undefined;
+		this.remember(eventKey(event));
+		return event;
+	}
+
+	private broadcast(message: GossipMessage, exclude?: TransportPeer): number {
+		let relayedTo = 0;
+		for (const state of this.peers.values()) {
+			if (!state.authenticated || state.peer === exclude) continue;
+			try {
+				state.peer.send(message);
+				relayedTo += 1;
+			} catch {
+				state.violations += 1;
+			}
+		}
+		return relayedTo;
+	}
+
+	private upsertParticipant(
+		id: string,
+		publicKey: Buffer,
+		nickname: string,
+		lastSeen: number,
+	): void {
+		const existing = this.participants.get(id);
+		if (!existing && this.participants.size >= MAX_PARTICIPANTS) {
+			this.participantCatalogFull = true;
+			return;
+		}
+		this.participants.set(id, {
+			publicKey: Buffer.from(publicKey),
+			nickname,
+			muted: this.mutedOrigins.has(id),
+			lastSeen,
+		});
+	}
+
+	private pruneParticipants(): void {
+		const oldest = this.now() - PARTICIPANT_TTL_MS;
+		for (const [id, participant] of this.participants) {
+			if (participant.lastSeen < oldest) {
+				this.participants.delete(id);
+				this.originLimiters.delete(id);
+			}
+		}
+		if (this.participants.size < MAX_PARTICIPANTS) this.participantCatalogFull = false;
+	}
+
+	private acceptOrigin(origin: string): boolean {
+		const current = this.now();
+		let state = this.originLimiters.get(origin);
+		if (!state) {
+			if (this.originLimiters.size >= MAX_ORIGIN_LIMITERS) {
+				let oldestKey: string | undefined;
+				let oldest = Number.POSITIVE_INFINITY;
+				for (const [key, candidate] of this.originLimiters) {
+					if (candidate.lastSeen < oldest) {
+						oldest = candidate.lastSeen;
+						oldestKey = key;
+					}
+				}
+				if (oldestKey) this.originLimiters.delete(oldestKey);
+			}
+			state = {
+				limiter: new PeerRateLimiter({ burst: 6, refillPerSecond: 1, now: this.now }),
+				lastSeen: current,
+			};
+			this.originLimiters.set(origin, state);
+		}
+		state.lastSeen = current;
+		return state.limiter.accept();
+	}
+
+	private hasSeen(key: string): boolean {
+		this.pruneSeen();
+		return this.seen.has(key);
+	}
+
+	private remember(key: string): void {
+		this.pruneSeen();
+		const expiresAt = this.now() + SEEN_MESSAGE_TTL_MS;
+		this.seen.set(key, expiresAt);
+		this.seenOrder.push({ key, expiresAt });
+		while (this.seen.size > MAX_SEEN_MESSAGES) {
+			const removed = this.seenOrder.shift();
+			if (removed && this.seen.get(removed.key) === removed.expiresAt) {
+				this.seen.delete(removed.key);
+			}
+		}
+	}
+
+	private pruneSeen(): void {
+		const current = this.now();
+		while (this.seenOrder[0] && this.seenOrder[0].expiresAt <= current) {
+			const removed = this.seenOrder.shift();
+			if (removed && this.seen.get(removed.key) === removed.expiresAt) {
+				this.seen.delete(removed.key);
+			}
+		}
+	}
+
 	private violate(id: string, state: PeerState): void {
 		state.violations += 1;
 		if (state.violations > MAX_PROTOCOL_VIOLATIONS) {
 			state.peer.close();
 			this.peers.delete(id);
 			this.emit();
-		}
-	}
-
-	private remember(id: string): void {
-		this.seen.add(id);
-		this.seenOrder.push(id);
-		if (this.seenOrder.length > MAX_SEEN_MESSAGES) {
-			const removed = this.seenOrder.shift();
-			if (removed) this.seen.delete(removed);
 		}
 	}
 
@@ -400,10 +560,13 @@ export class ChatSession {
 
 	private async leaveOwned(): Promise<void> {
 		this.generation += 1;
+		if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+		this.heartbeatTimer = undefined;
+		if (this.state !== "disconnected") this.publishPresence("leaving");
 		for (const state of this.peers.values()) {
 			if (state.authenticated) {
 				try {
-					state.peer.send({ v: 1, type: "goodbye" });
+					state.peer.send({ v: 2, type: "goodbye" });
 				} catch {
 					// Best-effort departure notice.
 				}
@@ -411,6 +574,10 @@ export class ChatSession {
 			state.peer.close();
 		}
 		this.peers.clear();
+		this.participants.clear();
+		this.originLimiters.clear();
+		this.seen.clear();
+		this.seenOrder.length = 0;
 		await this.transport.stop().catch((error) => {
 			this.lastError = safeError(error);
 		});
@@ -425,6 +592,10 @@ export class ChatSession {
 		this.onChange?.(snapshot);
 		for (const listener of this.listeners) listener(snapshot);
 	}
+}
+
+function eventKey(event: RoomEvent): string {
+	return `${event.origin}:${event.id}`;
 }
 
 function keyId(publicKey: Uint8Array): string {

--- a/packages/pi-chat/src/chat-view.ts
+++ b/packages/pi-chat/src/chat-view.ts
@@ -19,7 +19,7 @@ export interface ChatViewOptions {
 	tui: TUI;
 	theme: Theme;
 	getSnapshot(): ChatSnapshot;
-	send(text: string): { id: string; deliveredTo: number };
+	send(text: string): { id: string; relayedTo: number };
 	initialDraft?: string;
 	onDraftChange?(text: string): void;
 	setViewOpen(open: boolean): void;
@@ -72,29 +72,29 @@ export class ChatView implements Component, Focusable {
 				this.tui.requestRender();
 				return;
 			}
-			if (this.options.getSnapshot().peers.length === 0) {
+			if (this.options.getSnapshot().directNeighbors === 0) {
 				this.editor.setText(text);
 				this.messageStatus = {
 					kind: "warning",
-					text: "No direct peers — message kept. Wait for connection or Esc to return.",
+					text: "No direct neighbors — message kept. Wait for connection or Esc to return.",
 				};
 				this.tui.requestRender();
 				return;
 			}
 			try {
 				const result = this.options.send(message);
-				if (result.deliveredTo === 0) {
+				if (result.relayedTo === 0) {
 					this.editor.setText(text);
 					this.messageStatus = {
 						kind: "warning",
-						text: "No direct peers accepted it — message kept for retry.",
+						text: "No direct neighbors accepted it — message kept for retry.",
 					};
 				} else {
 					this.editor.setText("");
 					this.followBottom = true;
 					this.messageStatus = {
 						kind: "success",
-						text: `Sent to ${result.deliveredTo} direct peer${result.deliveredTo === 1 ? "" : "s"}`,
+						text: `Relayed to ${result.relayedTo} direct neighbor${result.relayedTo === 1 ? "" : "s"}`,
 					};
 				}
 			} catch (error) {
@@ -132,12 +132,12 @@ export class ChatView implements Component, Focusable {
 		this.lastViewportRows = viewportRows;
 		if (this.followBottom) this.scrollOffset = this.maxScroll();
 		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, this.maxScroll()));
-		const peerCount = snapshot.peers.length;
+		const participantCount = snapshot.participants.length;
 		const header = truncateToWidth(
 			this.theme.fg(
 				"accent",
 				this.theme.bold(
-					`CHAT INPUT → ${sanitizeSingleLine(snapshot.room.label)} · ${peerCount === 0 ? "waiting for peers" : `${peerCount} direct peer${peerCount === 1 ? "" : "s"}`}`,
+					`CHAT INPUT → ${sanitizeSingleLine(snapshot.room.label)} · ${participantCount} active · ${snapshot.directNeighbors} direct neighbor${snapshot.directNeighbors === 1 ? "" : "s"}`,
 				),
 			),
 			safeWidth,
@@ -216,8 +216,8 @@ export class ChatView implements Component, Focusable {
 function renderTranscript(snapshot: ChatSnapshot, width: number, theme: Theme): string[] {
 	if (snapshot.transcript.length === 0) {
 		const empty =
-			snapshot.peers.length === 0
-				? "You are alone; waiting for peers."
+			snapshot.participants.length === 0
+				? "No other active participants discovered yet."
 				: "No messages yet. Start the conversation below.";
 		return wrapTextWithAnsi(theme.fg("muted", empty), width);
 	}
@@ -225,10 +225,10 @@ function renderTranscript(snapshot: ChatSnapshot, width: number, theme: Theme): 
 	for (const entry of snapshot.transcript) {
 		const label = sanitizeSingleLine(entry.label);
 		const delivery =
-			entry.author === "local" && entry.delivery === "not-delivered"
-				? " · not delivered"
-				: entry.author === "local" && entry.deliveredTo !== undefined
-					? ` · broadcast to ${entry.deliveredTo}`
+			entry.author === "local" && entry.delivery === "not-relayed"
+				? " · not relayed"
+				: entry.author === "local" && entry.relayedTo !== undefined
+					? ` · relayed to ${entry.relayedTo}`
 					: "";
 		lines.push(...wrapTextWithAnsi(theme.fg("accent", `${label}${delivery}`), width));
 		for (const rawLine of sanitizeChatText(entry.text).split("\n")) {

--- a/packages/pi-chat/src/directory-network.ts
+++ b/packages/pi-chat/src/directory-network.ts
@@ -1,0 +1,416 @@
+import { randomUUID } from "node:crypto";
+import type { Duplex } from "node:stream";
+import Hyperswarm, { type PeerDiscovery, type PeerInfo } from "hyperswarm";
+import type { ChatIdentity } from "./identity.js";
+import { MAX_DIRECT_NEIGHBORS } from "./network.js";
+import { PeerRateLimiter } from "./protocol.js";
+import {
+	createDirectoryPresence,
+	createDirectoryWireMessage,
+	DirectoryCatalog,
+	DirectoryFrameDecoder,
+	type DirectoryWireMessage,
+	encodeDirectoryFrame,
+	PUBLIC_ROOM_DIRECTORY_TOPIC,
+	type PublicRoomBrowseResult,
+} from "./public-room-directory.js";
+
+const DIRECTORY_HEARTBEAT_MS = 30_000;
+const DIRECTORY_BROWSE_MS = 1_200;
+const MAX_SYNC_RECORDS = 256;
+
+export interface DirectoryPeer {
+	publicKey: Buffer;
+	send(message: DirectoryWireMessage): void;
+	close(): void;
+}
+
+export interface DirectoryTransportListener {
+	onPeer(peer: DirectoryPeer): void;
+	onMessage(peer: DirectoryPeer, message: DirectoryWireMessage): void;
+	onDisconnect(peer: DirectoryPeer): void;
+	onError(error: Error): void;
+}
+
+export interface DirectoryTransport {
+	start(listener: DirectoryTransportListener, signal?: AbortSignal): Promise<void>;
+	refresh(signal?: AbortSignal): Promise<void>;
+	stop(): Promise<void>;
+}
+
+export interface PublicRoomDirectory {
+	start(signal?: AbortSignal): Promise<void>;
+	browse(signal: AbortSignal, collectionMs?: number): Promise<PublicRoomBrowseResult>;
+	stop(): Promise<void>;
+}
+
+export interface PublicRoomDirectorySessionOptions {
+	identity: ChatIdentity;
+	transport: DirectoryTransport;
+	advertisedSlug?: string;
+	now?: () => number;
+	createId?: () => string;
+}
+
+interface DirectoryPeerState {
+	peer: DirectoryPeer;
+	limiter: PeerRateLimiter;
+	violations: number;
+}
+
+export class PublicRoomDirectorySession implements PublicRoomDirectory {
+	private readonly identity: ChatIdentity;
+	private readonly transport: DirectoryTransport;
+	private readonly advertisedSlug?: string;
+	private readonly now: () => number;
+	private readonly createId: () => string;
+	private readonly catalog: DirectoryCatalog;
+	private readonly peers = new Map<string, DirectoryPeerState>();
+	private started = false;
+	private startPromise: Promise<void> | undefined;
+	private stopPromise: Promise<void> | undefined;
+	private transportStopPromise: Promise<void> | undefined;
+	private heartbeatTimer: NodeJS.Timeout | undefined;
+	private generation = 0;
+
+	constructor(options: PublicRoomDirectorySessionOptions) {
+		this.identity = options.identity;
+		this.transport = options.transport;
+		this.advertisedSlug = options.advertisedSlug;
+		this.now = options.now ?? Date.now;
+		this.createId = options.createId ?? randomUUID;
+		this.catalog = new DirectoryCatalog({ now: this.now });
+	}
+
+	start(signal?: AbortSignal): Promise<void> {
+		if (this.startPromise) return this.startPromise;
+		if (this.stopPromise) throw new Error("Public room directory has already stopped.");
+		this.startPromise = this.startOwned(signal);
+		return this.startPromise;
+	}
+
+	async browse(
+		signal: AbortSignal,
+		collectionMs = DIRECTORY_BROWSE_MS,
+	): Promise<PublicRoomBrowseResult> {
+		const temporary = !this.started && !this.advertisedSlug;
+		try {
+			await this.start(signal);
+			signal.throwIfAborted();
+			await this.transport.refresh(signal);
+			await abortableDelay(Math.max(0, collectionMs), signal);
+			signal.throwIfAborted();
+			return this.catalog.snapshot();
+		} finally {
+			if (temporary) await this.stop();
+		}
+	}
+
+	stop(): Promise<void> {
+		if (this.stopPromise) return this.stopPromise;
+		this.stopPromise = this.stopOwned();
+		return this.stopPromise;
+	}
+
+	private async startOwned(signal?: AbortSignal): Promise<void> {
+		const owner = ++this.generation;
+		this.started = true;
+		try {
+			await this.transport.start(
+				{
+					onPeer: (peer) => this.onPeer(owner, peer),
+					onMessage: (peer, message) => this.onMessage(owner, peer, message),
+					onDisconnect: (peer) => this.onDisconnect(owner, peer),
+					onError: () => this.catalog.markPartial(),
+				},
+				signal,
+			);
+			signal?.throwIfAborted();
+			if (owner !== this.generation) return;
+			if (this.advertisedSlug) this.publish("online");
+			this.heartbeatTimer = setInterval(() => {
+				if (owner === this.generation && this.started && this.advertisedSlug) {
+					this.publish("online");
+				}
+			}, DIRECTORY_HEARTBEAT_MS);
+			this.heartbeatTimer.unref();
+		} catch (error) {
+			this.started = false;
+			await this.stopTransport();
+			throw error;
+		}
+	}
+
+	private onPeer(owner: number, peer: DirectoryPeer): void {
+		if (owner !== this.generation || !this.started) {
+			peer.close();
+			return;
+		}
+		const id = peer.publicKey.toString("hex");
+		const previous = this.peers.get(id);
+		if (previous && previous.peer !== peer) previous.peer.close();
+		this.peers.set(id, {
+			peer,
+			limiter: new PeerRateLimiter({ burst: MAX_SYNC_RECORDS, refillPerSecond: 16, now: this.now }),
+			violations: 0,
+		});
+		const events = this.catalog.currentEvents();
+		const partial = events.length > MAX_SYNC_RECORDS || this.catalog.snapshot().partial;
+		if (events.length > MAX_SYNC_RECORDS) this.catalog.markPartial();
+		for (const [index, event] of events.slice(0, MAX_SYNC_RECORDS).entries()) {
+			try {
+				peer.send(createDirectoryWireMessage(event, undefined, partial && index === 0));
+			} catch {
+				break;
+			}
+		}
+	}
+
+	private onMessage(owner: number, peer: DirectoryPeer, message: DirectoryWireMessage): void {
+		if (owner !== this.generation || !this.started) return;
+		const state = this.peers.get(peer.publicKey.toString("hex"));
+		if (!state || state.peer !== peer) return;
+		if (!state.limiter.accept()) {
+			this.violate(state);
+			return;
+		}
+		if (message.partial) this.catalog.markPartial();
+		if (!this.catalog.accept(message.event)) {
+			return;
+		}
+		if (message.hops > 1) {
+			this.broadcast(
+				createDirectoryWireMessage(message.event, message.hops - 1, message.partial),
+				peer,
+			);
+		}
+	}
+
+	private onDisconnect(owner: number, peer: DirectoryPeer): void {
+		if (owner !== this.generation) return;
+		const id = peer.publicKey.toString("hex");
+		if (this.peers.get(id)?.peer === peer) this.peers.delete(id);
+	}
+
+	private publish(status: "online" | "leaving"): void {
+		if (!this.advertisedSlug) return;
+		const event = createDirectoryPresence(
+			this.identity,
+			this.advertisedSlug,
+			status,
+			this.now(),
+			this.createId(),
+		);
+		this.catalog.accept(event);
+		this.broadcast(createDirectoryWireMessage(event));
+	}
+
+	private broadcast(message: DirectoryWireMessage, exclude?: DirectoryPeer): void {
+		for (const state of this.peers.values()) {
+			if (state.peer === exclude) continue;
+			try {
+				state.peer.send(message);
+			} catch {
+				state.violations += 1;
+			}
+		}
+	}
+
+	private violate(state: DirectoryPeerState): void {
+		state.violations += 1;
+		if (state.violations > 3) {
+			state.peer.close();
+			this.peers.delete(state.peer.publicKey.toString("hex"));
+		}
+	}
+
+	private async stopOwned(): Promise<void> {
+		this.generation += 1;
+		if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+		this.heartbeatTimer = undefined;
+		if (this.started && this.advertisedSlug) this.publish("leaving");
+		this.started = false;
+		for (const state of this.peers.values()) state.peer.close();
+		this.peers.clear();
+		await this.stopTransport();
+	}
+
+	private stopTransport(): Promise<void> {
+		if (!this.transportStopPromise) {
+			this.transportStopPromise = this.transport.stop().catch(() => undefined);
+		}
+		return this.transportStopPromise;
+	}
+}
+
+export interface HyperswarmDirectoryTransportOptions {
+	identity: ChatIdentity;
+	dht?: unknown;
+	bootstrap?: unknown[];
+}
+
+interface ActiveConnection {
+	socket: Duplex;
+	peer: DirectoryPeer;
+}
+
+export class HyperswarmDirectoryTransport implements DirectoryTransport {
+	private readonly options: HyperswarmDirectoryTransportOptions;
+	private swarm: Hyperswarm | undefined;
+	private discovery: PeerDiscovery | undefined;
+	private listener: DirectoryTransportListener | undefined;
+	private readonly connections = new Map<Duplex, ActiveConnection>();
+	private stopPromise: Promise<void> | undefined;
+
+	constructor(options: HyperswarmDirectoryTransportOptions) {
+		this.options = options;
+	}
+
+	async start(listener: DirectoryTransportListener, signal?: AbortSignal): Promise<void> {
+		if (this.swarm) throw new Error("Public room directory transport has already started.");
+		const startupSignal = signal
+			? AbortSignal.any([signal, AbortSignal.timeout(15_000)])
+			: AbortSignal.timeout(15_000);
+		startupSignal.throwIfAborted();
+		this.listener = listener;
+		const swarm = new Hyperswarm({
+			keyPair: {
+				publicKey: this.options.identity.publicKey,
+				secretKey: this.options.identity.secretKey,
+			},
+			maxPeers: MAX_DIRECT_NEIGHBORS,
+			...(this.options.dht ? { dht: this.options.dht } : {}),
+			...(this.options.bootstrap ? { bootstrap: this.options.bootstrap } : {}),
+		});
+		this.swarm = swarm;
+		swarm.on("connection", (socket, info) => this.accept(socket, info));
+		swarm.on("error", (error) => this.listener?.onError(safeNetworkError(error)));
+		try {
+			this.discovery = swarm.join(PUBLIC_ROOM_DIRECTORY_TOPIC, {
+				server: true,
+				client: true,
+				limit: MAX_DIRECT_NEIGHBORS,
+			});
+			await raceAbort(this.discovery.flushed(), startupSignal);
+			startupSignal.throwIfAborted();
+		} catch (error) {
+			await this.stop();
+			throw error;
+		}
+	}
+
+	async refresh(signal?: AbortSignal): Promise<void> {
+		if (!this.discovery) throw new Error("Public room directory is not running.");
+		await raceAbort(
+			this.discovery.refresh({ server: true, client: true, limit: MAX_DIRECT_NEIGHBORS }),
+			signal,
+		);
+	}
+
+	stop(): Promise<void> {
+		if (this.stopPromise) return this.stopPromise;
+		this.stopPromise = this.stopOwned();
+		return this.stopPromise;
+	}
+
+	private accept(socket: Duplex, info: PeerInfo): void {
+		if (!this.swarm || !this.listener || this.connections.size >= MAX_DIRECT_NEIGHBORS) {
+			socket.destroy();
+			return;
+		}
+		const decoder = new DirectoryFrameDecoder();
+		let closed = false;
+		const peer: DirectoryPeer = {
+			publicKey: Buffer.from(info.publicKey),
+			send(message) {
+				if (closed || socket.destroyed) throw new Error("Directory peer connection is closed.");
+				const accepted = socket.write(encodeDirectoryFrame(message));
+				if (!accepted && socket.destroyed) {
+					throw new Error("Directory peer connection rejected the message.");
+				}
+			},
+			close() {
+				if (closed) return;
+				closed = true;
+				socket.destroy();
+			},
+		};
+		this.connections.set(socket, { socket, peer });
+		this.listener.onPeer(peer);
+		socket.on("data", (chunk: unknown) => {
+			if (closed || !this.listener) return;
+			try {
+				const bytes =
+					typeof chunk === "string"
+						? Buffer.from(chunk)
+						: Buffer.isBuffer(chunk)
+							? chunk
+							: Buffer.from(chunk as Uint8Array);
+				for (const message of decoder.push(bytes)) this.listener.onMessage(peer, message);
+			} catch {
+				closed = true;
+				socket.destroy();
+				this.listener?.onError(new Error("Pi Chat rejected invalid directory protocol data."));
+			}
+		});
+		const disconnected = () => {
+			if (!this.connections.delete(socket)) return;
+			closed = true;
+			this.listener?.onDisconnect(peer);
+		};
+		socket.once("close", disconnected);
+		socket.once("error", (error) => {
+			this.listener?.onError(safeNetworkError(error));
+			disconnected();
+		});
+	}
+
+	private async stopOwned(): Promise<void> {
+		const discovery = this.discovery;
+		this.discovery = undefined;
+		if (discovery) await discovery.destroy().catch(() => undefined);
+		for (const { socket } of this.connections.values()) socket.destroy();
+		this.connections.clear();
+		const swarm = this.swarm;
+		this.swarm = undefined;
+		this.listener = undefined;
+		if (swarm) await swarm.destroy().catch(() => undefined);
+	}
+}
+
+async function abortableDelay(milliseconds: number, signal: AbortSignal): Promise<void> {
+	signal.throwIfAborted();
+	await new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(done, milliseconds);
+		const abort = () => done(signal.reason ?? new DOMException("Aborted", "AbortError"));
+		function done(error?: unknown): void {
+			clearTimeout(timer);
+			signal.removeEventListener("abort", abort);
+			if (error) reject(error);
+			else resolve();
+		}
+		signal.addEventListener("abort", abort, { once: true });
+	});
+}
+
+async function raceAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return operation;
+	signal.throwIfAborted();
+	let remove = () => {};
+	const aborted = new Promise<never>((_resolve, reject) => {
+		const onAbort = () => reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+		signal.addEventListener("abort", onAbort, { once: true });
+		remove = () => signal.removeEventListener("abort", onAbort);
+	});
+	try {
+		return await Promise.race([operation, aborted]);
+	} finally {
+		remove();
+	}
+}
+
+function safeNetworkError(error: unknown): Error {
+	const code =
+		error instanceof Error && "code" in error ? String(Reflect.get(error, "code")) : "error";
+	return new Error(`Pi Chat directory network ${code}.`);
+}

--- a/packages/pi-chat/src/external.d.ts
+++ b/packages/pi-chat/src/external.d.ts
@@ -1,3 +1,17 @@
+declare module "sodium-universal" {
+	interface SodiumUniversal {
+		crypto_sign_BYTES: number;
+		crypto_sign_detached(signature: Uint8Array, message: Uint8Array, secretKey: Uint8Array): void;
+		crypto_sign_verify_detached(
+			signature: Uint8Array,
+			message: Uint8Array,
+			publicKey: Uint8Array,
+		): boolean;
+	}
+	const sodium: SodiumUniversal;
+	export default sodium;
+}
+
 declare module "hyperdht" {
 	export interface HyperDhtKeyPair {
 		publicKey: Buffer;

--- a/packages/pi-chat/src/identity.ts
+++ b/packages/pi-chat/src/identity.ts
@@ -1,5 +1,6 @@
-import { createHash } from "node:crypto";
+import { createHash, hkdfSync } from "node:crypto";
 import HyperDHT from "hyperdht";
+import sodium from "sodium-universal";
 
 const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 const MAX_NICKNAME_GRAPHEMES = 24;
@@ -31,6 +32,45 @@ export function createIdentity(seed: Uint8Array): ChatIdentity {
 		secretKey: Buffer.from(keyPair.secretKey),
 		tag: identityTag(keyPair.publicKey),
 	};
+}
+
+export function deriveScopedIdentity(identity: ChatIdentity, scope: string): ChatIdentity {
+	if (!scope || Buffer.byteLength(scope, "utf8") > 256) {
+		throw new Error("Pi Chat identity scope is invalid.");
+	}
+	const seed = Buffer.from(identity.seed, "base64url");
+	return createIdentity(
+		Buffer.from(
+			hkdfSync(
+				"sha256",
+				seed,
+				Buffer.from("pi-chat/scoped-identity/v2", "utf8"),
+				Buffer.from(scope, "utf8"),
+				32,
+			),
+		),
+	);
+}
+
+export function signIdentityPayload(identity: ChatIdentity, payload: Uint8Array): string {
+	const signature = Buffer.alloc(sodium.crypto_sign_BYTES);
+	sodium.crypto_sign_detached(signature, payload, identity.secretKey);
+	return signature.toString("base64url");
+}
+
+export function verifyIdentityPayload(
+	publicKey: Uint8Array,
+	payload: Uint8Array,
+	signatureValue: string,
+): boolean {
+	if (publicKey.byteLength !== 32 || !/^[A-Za-z0-9_-]{86}$/u.test(signatureValue)) return false;
+	const signature = Buffer.from(signatureValue, "base64url");
+	if (signature.byteLength !== sodium.crypto_sign_BYTES) return false;
+	try {
+		return sodium.crypto_sign_verify_detached(signature, payload, publicKey);
+	} catch {
+		return false;
+	}
 }
 
 export function identityTag(publicKey: Uint8Array, characters = 12): string {

--- a/packages/pi-chat/src/menu.ts
+++ b/packages/pi-chat/src/menu.ts
@@ -3,6 +3,7 @@ import type { MenuDefinition } from "@narumitw/pi-tui-kit";
 import type { ChatSnapshot } from "./chat-session.js";
 import { normalizeNickname } from "./identity.js";
 import { createPublicRoom, parseInvite, type RoomDescriptor } from "./protocol.js";
+import { type PublicRoomBrowseResult, sortDirectoryRooms } from "./public-room-directory.js";
 import { type ChatSettings, descriptorFromRememberedRoom, type WidgetMode } from "./settings.js";
 import { sanitizeSingleLine } from "./text.js";
 
@@ -16,6 +17,7 @@ export interface ChatMenuSource {
 	getSnapshot(): ChatSnapshot | undefined;
 	getRestoreError(): string | undefined;
 	createPrivateRoom(): RoomDescriptor;
+	browsePublicRooms(signal: AbortSignal): Promise<PublicRoomBrowseResult>;
 	joinRoom(
 		room: RoomDescriptor,
 		ctx: ExtensionCommandContext,
@@ -38,6 +40,8 @@ interface ChatMenuState {
 	snapshot?: ChatSnapshot;
 	pendingRoom?: RoomDescriptor;
 	restoreError?: string;
+	directoryResult?: PublicRoomBrowseResult;
+	directoryError?: string;
 }
 
 type Screen =
@@ -45,6 +49,7 @@ type Screen =
 	| "invite"
 	| "joinInvite"
 	| "joinPublic"
+	| "publicRooms"
 	| "joinAnother"
 	| "participants"
 	| "settings"
@@ -60,6 +65,8 @@ type Action =
 	| "joinPending"
 	| "joinInvite"
 	| "joinPublic"
+	| "browse"
+	| "selectPublicRoom"
 	| "retry"
 	| "forget"
 	| "open"
@@ -71,12 +78,48 @@ type Action =
 
 export function createChatMenu(source: ChatMenuSource) {
 	let pendingRoom: RoomDescriptor | undefined;
+	let directoryResult: PublicRoomBrowseResult | undefined;
+	let directoryError: string | undefined;
 	const getState = async (): Promise<ChatMenuState> => ({
 		settings: source.getSettings(),
 		snapshot: source.getSnapshot(),
 		pendingRoom,
 		...(source.getRestoreError() ? { restoreError: source.getRestoreError() } : {}),
+		...(directoryResult ? { directoryResult } : {}),
+		...(directoryError ? { directoryError } : {}),
 	});
+	const browseRooms = async (signal: AbortSignal) => {
+		try {
+			const result = await source.browsePublicRooms(signal);
+			if (signal.aborted) return { kind: "stay" as const };
+			directoryResult = { ...result, rooms: sortDirectoryRooms(result.rooms) };
+			directoryError = undefined;
+		} catch (error) {
+			if (signal.aborted) return { kind: "stay" as const };
+			directoryResult = undefined;
+			directoryError = sanitizeSingleLine(error instanceof Error ? error.message : String(error));
+		}
+		return { kind: "to" as const, screen: "publicRooms" as const };
+	};
+	const joinPublic = async (slug: string, ctx: ExtensionCommandContext, signal: AbortSignal) => {
+		let room: RoomDescriptor;
+		try {
+			room = createPublicRoom(slug.replace(/^#/u, ""));
+		} catch (error) {
+			return { kind: "rejected" as const, error };
+		}
+		const confirmed = await ctx.ui.confirm(
+			"Join public room?",
+			"Anyone can join or record it. DHT and direct peers may observe network metadata.",
+			{ signal },
+		);
+		if (!confirmed || signal.aborted) return { kind: "stay" as const };
+		if (!(await source.joinRoom(room, ctx, signal, { remember: true })) || signal.aborted) {
+			return { kind: "stay" as const };
+		}
+		await source.openChat(ctx);
+		return { kind: "close" as const };
+	};
 	const menu: MenuDefinition<ChatMenuState, Screen, Action> = {
 		start: "main",
 		screens: {
@@ -109,10 +152,10 @@ export function createChatMenu(source: ChatMenuSource) {
 				kind: "input",
 				title: "Join with invite",
 				lines: [
-					"Paste a pichat:v1 invite. It grants access to the private room.",
+					"Paste a pichat:v1 or pichat:v2 invite. It grants access to the private room.",
 					"You will choose Join and remember, Join once, or Cancel before networking starts.",
 				],
-				placeholder: "pichat:v1:…",
+				placeholder: "pichat:v2:…",
 				action: "joinInvite",
 				hint: "back",
 			}),
@@ -124,11 +167,59 @@ export function createChatMenu(source: ChatMenuSource) {
 				action: "joinPublic",
 				hint: "back",
 			}),
+			publicRooms: ({ state }) => {
+				const rooms = state.directoryResult?.rooms ?? [];
+				const lines = state.directoryError
+					? [
+							`Discovery failed: ${sanitizeSingleLine(state.directoryError)}`,
+							"Retry or enter a known public room slug.",
+						]
+					: rooms.length === 0
+						? ["No active public rooms were discovered. Counts are best-effort estimates."]
+						: [
+								state.directoryResult?.partial
+									? "Estimated active participants · partial discovered results."
+									: "Estimated active participants · currently discovered results.",
+								"Select a room to review the public-room warning before joining.",
+							];
+				return {
+					kind: "choice",
+					title: "Public rooms",
+					lines,
+					items: [
+						...rooms.map((room) => ({
+							id: `room:${room.slug}`,
+							label: `#${room.slug}`,
+							description: `~${room.estimatedParticipants} active`,
+							details: ["Estimated from recent signed P2P directory presence."],
+						})),
+						{
+							id: "route:refresh",
+							label: state.directoryError ? "Retry discovery" : "Refresh discovery",
+							description: "Query the P2P directory again",
+						},
+						{
+							id: "route:manual",
+							label: "Enter room slug",
+							description: "Join a known public room manually",
+						},
+					],
+					action: "selectPublicRoom",
+					viewportSize: 10,
+					hint: "back",
+				};
+			},
 			joinAnother: () => ({
 				kind: "actions",
 				title: "Join another room",
 				lines: ["A successfully remembered join replaces the room restored at startup."],
 				items: [
+					{
+						id: "browse",
+						label: "Browse public rooms",
+						action: "browse",
+						busyLabel: "Discovering rooms",
+					},
 					{ id: "public", label: "Join public room", to: "joinPublic" },
 					{ id: "invite", label: "Join with invite", to: "joinInvite" },
 					{ id: "create", label: "Create private room", action: "createPrivate" },
@@ -137,12 +228,12 @@ export function createChatMenu(source: ChatMenuSource) {
 			}),
 			participants: ({ state }) => ({
 				kind: "choice",
-				title: "Direct participants",
-				lines: state.snapshot?.peers.length
-					? ["Select a peer to toggle local mute. Full public keys are shown in details."]
-					: ["No authenticated direct peers are connected."],
+				title: "Active participants",
+				lines: state.snapshot?.participants.length
+					? ["Select an origin to toggle local mute. Full public keys are shown in details."]
+					: ["No other active participants are currently discovered."],
 				items:
-					state.snapshot?.peers.map((peer) => ({
+					state.snapshot?.participants.map((peer) => ({
 						id: peer.publicKey,
 						label: sanitizeSingleLine(peer.label),
 						description: peer.muted ? "Muted locally" : "Receiving messages",
@@ -255,7 +346,8 @@ export function createChatMenu(source: ChatMenuSource) {
 							`State: ${state.snapshot.state}`,
 							`Room: ${sanitizeSingleLine(state.snapshot.room.label)}`,
 							`Identity: ${sanitizeSingleLine(state.snapshot.localLabel)}`,
-							`Direct peers: ${state.snapshot.peers.length}`,
+							`Active participants: ${state.snapshot.participants.length}`,
+							`Direct neighbors: ${state.snapshot.directNeighbors}`,
 							`Unread: ${state.snapshot.unread}`,
 							`Restart: ${restartDescription(state.settings)}`,
 							...(state.snapshot.lastError
@@ -280,7 +372,8 @@ export function createChatMenu(source: ChatMenuSource) {
 					"Chat stays outside Pi sessions, prompts, model context, and repository files.",
 					"Private invites are bearer secrets. Public rooms are guessable.",
 					"Noise encrypts direct streams, but peers and DHT infrastructure may observe network metadata.",
-					"There is no offline delivery, authoritative room count, or message withdrawal.",
+					"Public-room discovery and participant counts are approximate P2P observations.",
+					"There is no offline delivery, global ordering, delivery receipt, or message withdrawal.",
 				],
 				hint: "back",
 			}),
@@ -309,24 +402,15 @@ export function createChatMenu(source: ChatMenuSource) {
 				await source.openChat(ctx);
 				return { kind: "close" };
 			},
-			joinPublic: async ({ ctx, signal, value }) => {
-				let room: RoomDescriptor;
-				try {
-					room = createPublicRoom((value ?? "").replace(/^#/u, ""));
-				} catch (error) {
-					return { kind: "rejected", error };
+			joinPublic: ({ ctx, signal, value }) => joinPublic(value ?? "", ctx, signal),
+			browse: ({ signal }) => browseRooms(signal),
+			selectPublicRoom: async ({ ctx, signal, itemId }) => {
+				if (itemId === "route:refresh") return browseRooms(signal);
+				if (itemId === "route:manual") return { kind: "to", screen: "joinPublic" };
+				if (!itemId.startsWith("room:")) {
+					return { kind: "rejected", error: new Error("Public room selection is invalid") };
 				}
-				const confirmed = await ctx.ui.confirm(
-					"Join public room?",
-					"Anyone can join or record it. DHT and direct peers may observe network metadata.",
-					{ signal },
-				);
-				if (!confirmed || signal.aborted) return { kind: "stay" };
-				if (!(await source.joinRoom(room, ctx, signal, { remember: true })) || signal.aborted) {
-					return { kind: "stay" };
-				}
-				await source.openChat(ctx);
-				return { kind: "close" };
+				return joinPublic(itemId.slice("room:".length), ctx, signal);
 			},
 			retry: async ({ ctx, signal }) => {
 				await source.retryRememberedRoom(ctx, signal);
@@ -423,6 +507,12 @@ function mainScreen(state: ChatMenuState) {
 			title: "Pi Chat · disconnected",
 			lines: ["Experimental peer-to-peer chat. Messages never enter model context."],
 			items: [
+				{
+					id: "browse",
+					label: "Browse public rooms",
+					action: "browse" as const,
+					busyLabel: "Discovering rooms",
+				},
 				{ id: "public", label: "Join public room", to: "joinPublic" as const },
 				{ id: "invite", label: "Join with invite", to: "joinInvite" as const },
 				{ id: "create", label: "Create private room", action: "createPrivate" as const },
@@ -438,7 +528,7 @@ function mainScreen(state: ChatMenuState) {
 		kind: "actions" as const,
 		title: `Pi Chat · ${sanitizeSingleLine(state.snapshot.room.label)}`,
 		lines: [
-			`${state.snapshot.state} · ${state.snapshot.peers.length} direct peers · ${state.snapshot.unread} unread`,
+			`${state.snapshot.state} · ${state.snapshot.participants.length} active · ${state.snapshot.directNeighbors} direct neighbors · ${state.snapshot.unread} unread`,
 			`Current input: ${state.snapshot.composerOpen ? state.snapshot.room.label : "Pi/LLM"}`,
 			restoresCurrent
 				? `Restart: restore this room and ${state.settings.resume?.surface === "chat" ? "open chat" : "stay in Pi/LLM"}`
@@ -451,7 +541,7 @@ function mainScreen(state: ChatMenuState) {
 				label: `Open chat in ${sanitizeSingleLine(state.snapshot.room.label)}`,
 				action: "open" as const,
 			},
-			{ id: "participants", label: "Show participants", to: "participants" as const },
+			{ id: "participants", label: "Show active participants", to: "participants" as const },
 			...(state.snapshot.room.invite
 				? [{ id: "invite", label: "Show room invite", to: "invite" as const }]
 				: []),

--- a/packages/pi-chat/src/network.ts
+++ b/packages/pi-chat/src/network.ts
@@ -22,13 +22,19 @@ interface ActiveConnection {
 	peer: TransportPeer;
 }
 
+export const MAX_DIRECT_NEIGHBORS = 8;
+
+export function directNeighborLimit(requested?: number): number {
+	if (!Number.isSafeInteger(requested) || (requested ?? 0) <= 0) return MAX_DIRECT_NEIGHBORS;
+	return Math.min(requested ?? MAX_DIRECT_NEIGHBORS, MAX_DIRECT_NEIGHBORS);
+}
+
 export class HyperswarmTransport implements ChatTransport {
 	private readonly options: HyperswarmTransportOptions;
 	private swarm: Hyperswarm | undefined;
 	private discovery: PeerDiscovery | undefined;
 	private listener: ChatTransportListener | undefined;
 	private readonly connections = new Map<Duplex, ActiveConnection>();
-	private readonly directPeers = new Map<string, Buffer>();
 	private readonly refreshTimers = new Set<NodeJS.Timeout>();
 	private stopPromise: Promise<void> | undefined;
 
@@ -40,6 +46,10 @@ export class HyperswarmTransport implements ChatTransport {
 		return this.connections.size;
 	}
 
+	get connectedPeerKeys(): string[] {
+		return [...this.connections.values()].map(({ peer }) => peer.publicKey.toString("hex")).sort();
+	}
+
 	async start(listener: ChatTransportListener, signal?: AbortSignal): Promise<void> {
 		if (this.swarm) throw new Error("Hyperswarm transport has already started.");
 		const startupSignal = signal
@@ -47,12 +57,13 @@ export class HyperswarmTransport implements ChatTransport {
 			: AbortSignal.timeout(15_000);
 		startupSignal.throwIfAborted();
 		this.listener = listener;
+		const maxPeers = directNeighborLimit(this.options.maxPeers);
 		const swarm = new Hyperswarm({
 			keyPair: {
 				publicKey: this.options.identity.publicKey,
 				secretKey: this.options.identity.secretKey,
 			},
-			maxPeers: this.options.maxPeers ?? 16,
+			maxPeers,
 			...(this.options.dht ? { dht: this.options.dht } : {}),
 			...(this.options.bootstrap ? { bootstrap: this.options.bootstrap } : {}),
 		});
@@ -63,7 +74,7 @@ export class HyperswarmTransport implements ChatTransport {
 			const discovery = swarm.join(this.options.room.topic, {
 				server: true,
 				client: true,
-				limit: this.options.maxPeers ?? 16,
+				limit: maxPeers,
 			});
 			this.discovery = discovery;
 			await raceAbort(discovery.flushed(), startupSignal);
@@ -73,14 +84,6 @@ export class HyperswarmTransport implements ChatTransport {
 			await this.stop();
 			throw error;
 		}
-	}
-
-	connectPeer(publicKey: Buffer): void {
-		if (!this.swarm || publicKey.length !== 32 || this.directPeers.size >= 16) return;
-		const id = publicKey.toString("hex");
-		if (id === this.options.identity.publicKey.toString("hex") || this.directPeers.has(id)) return;
-		this.directPeers.set(id, Buffer.from(publicKey));
-		this.swarm.joinPeer(publicKey);
 	}
 
 	stop(): Promise<void> {
@@ -110,7 +113,7 @@ export class HyperswarmTransport implements ChatTransport {
 	}
 
 	private accept(socket: Duplex, info: PeerInfo): void {
-		if (!this.swarm || !this.listener) {
+		if (!this.swarm || !this.listener || this.connections.size >= MAX_DIRECT_NEIGHBORS) {
 			socket.destroy();
 			return;
 		}
@@ -168,10 +171,6 @@ export class HyperswarmTransport implements ChatTransport {
 		for (const { socket } of this.connections.values()) socket.destroy();
 		this.connections.clear();
 		const swarm = this.swarm;
-		if (swarm) {
-			for (const publicKey of this.directPeers.values()) swarm.leavePeer(publicKey);
-		}
-		this.directPeers.clear();
 		this.swarm = undefined;
 		this.listener = undefined;
 		if (swarm) await swarm.destroy().catch(() => undefined);

--- a/packages/pi-chat/src/pi-chat.ts
+++ b/packages/pi-chat/src/pi-chat.ts
@@ -7,9 +7,23 @@ import type {
 import type { ChatSnapshot, ChatTransport } from "./chat-session.js";
 import { ChatSession } from "./chat-session.js";
 import { ChatView } from "./chat-view.js";
-import { type ChatIdentity, createIdentity, formatIdentityLabel } from "./identity.js";
+import {
+	HyperswarmDirectoryTransport,
+	type PublicRoomDirectory,
+	PublicRoomDirectorySession,
+} from "./directory-network.js";
+import {
+	type ChatIdentity,
+	createIdentity,
+	deriveScopedIdentity,
+	formatIdentityLabel,
+} from "./identity.js";
 import { type ChatMenuSource, type JoinRoomOptions, showChatMenu } from "./menu.js";
-import { HyperswarmTransport, type HyperswarmTransportOptions } from "./network.js";
+import {
+	HyperswarmTransport,
+	type HyperswarmTransportOptions,
+	MAX_DIRECT_NEIGHBORS,
+} from "./network.js";
 import {
 	createPrivateRoom,
 	createPublicRoom,
@@ -32,7 +46,7 @@ import { renderChatWidget } from "./widget.js";
 const CHAT_UI_KEY = "chat";
 const EXPERIMENTAL_WARNING =
 	"Pi Chat is experimental. Peer identity, networking, and interaction behavior may change.";
-const USAGE = "Usage: /chat, /chat <pichat:v1:invite>, or /chat #<public-slug>";
+const USAGE = "Usage: /chat, /chat <pichat:v1-or-v2:invite>, or /chat #<public-slug>";
 const PRIVATE_ROOM_OPTIONS = [
 	"Join and remember — Save the bearer invite privately and restore this room",
 	"Join once — Do not save the bearer invite",
@@ -48,10 +62,16 @@ const DISPLAY_OPTIONS: ReadonlyArray<{ label: string; mode: WidgetMode }> = [
 	{ label: "Hidden — Show no persistent room widget", mode: "off" },
 ];
 
+export interface PiChatDirectoryOptions {
+	identity: ChatIdentity;
+	advertisedSlug?: string;
+}
+
 export interface PiChatDependencies {
 	settingsPath: string;
 	randomBytes(size: number): Buffer;
 	createTransport(options: HyperswarmTransportOptions): ChatTransport;
+	createDirectory(options: PiChatDirectoryOptions): PublicRoomDirectory;
 	updateSettings: typeof updateChatSettingsFile;
 }
 
@@ -63,6 +83,13 @@ export function createPiChatExtension(
 		randomBytes: dependencies.randomBytes ?? nodeRandomBytes,
 		createTransport:
 			dependencies.createTransport ?? ((options) => new HyperswarmTransport(options)),
+		createDirectory:
+			dependencies.createDirectory ??
+			((options) =>
+				new PublicRoomDirectorySession({
+					...options,
+					transport: new HyperswarmDirectoryTransport({ identity: options.identity }),
+				})),
 		updateSettings: dependencies.updateSettings ?? updateChatSettingsFile,
 	};
 	const updateChatSettings = deps.updateSettings;
@@ -74,6 +101,7 @@ export function createPiChatExtension(
 		let activeContext: ExtensionContext | undefined;
 		let settings: ChatSettings = {};
 		let chatSession: ChatSession | undefined;
+		let roomDirectory: PublicRoomDirectory | undefined;
 		let latestSnapshot: ChatSnapshot | undefined;
 		let chatDraft = "";
 		let restoreError: string | undefined;
@@ -168,10 +196,12 @@ export function createPiChatExtension(
 
 		const disconnectRoom = async (): Promise<void> => {
 			const owned = chatSession;
+			const ownedDirectory = roomDirectory;
 			chatSession = undefined;
+			roomDirectory = undefined;
 			latestSnapshot = undefined;
 			chatDraft = "";
-			if (owned) await owned.leave();
+			await Promise.allSettled([owned?.leave(), ownedDirectory?.stop()]);
 			if (activeContext) clearUi(activeContext);
 		};
 
@@ -234,6 +264,41 @@ export function createPiChatExtension(
 			return createIdentity(Buffer.from(seed, "base64url"));
 		};
 
+		const startPublicRoomDirectory = (
+			room: RoomDescriptor,
+			identity: ChatIdentity,
+			ctx: ExtensionContext,
+			owner: unknown,
+			ownerGeneration: number,
+		): void => {
+			if (room.kind !== "public" || !room.slug) return;
+			const directory = deps.createDirectory({
+				identity: deriveScopedIdentity(identity, `directory:#${room.slug}`),
+				advertisedSlug: room.slug,
+			});
+			roomDirectory = directory;
+			void trackTask(
+				directory.start(controller.signal).catch(async (error) => {
+					const ownsDirectory = roomDirectory === directory;
+					if (ownsDirectory) roomDirectory = undefined;
+					await directory.stop();
+					if (
+						ownsDirectory &&
+						isCurrent(owner, ownerGeneration) &&
+						chatSession?.snapshot().room.id === room.id
+					) {
+						notifySafely(
+							ctx,
+							`Pi Chat public-room discovery is unavailable: ${sanitizeSingleLine(
+								error instanceof Error ? error.message : String(error),
+							)}. Chat remains connected.`,
+							"warning",
+						);
+					}
+				}),
+			);
+		};
+
 		const joinRoom = async (
 			room: RoomDescriptor,
 			ctx: ExtensionContext,
@@ -267,7 +332,11 @@ export function createPiChatExtension(
 			if (!identity || !isCurrent(owner, ownerGeneration) || signal.aborted) return false;
 			const nickname = settings.nickname;
 			if (!nickname) throw new Error("Pi Chat nickname is unavailable.");
-			const transport = deps.createTransport({ room, identity, maxPeers: 16 });
+			const transport = deps.createTransport({
+				room,
+				identity,
+				maxPeers: MAX_DIRECT_NEIGHBORS,
+			});
 			const session = new ChatSession({
 				room,
 				identity,
@@ -307,6 +376,7 @@ export function createPiChatExtension(
 				restoreError = undefined;
 				latestSnapshot = session.snapshot();
 				updateUi(ctx, latestSnapshot);
+				startPublicRoomDirectory(room, identity, ctx, owner, ownerGeneration);
 				return true;
 			} catch (error) {
 				if (chatSession === session) chatSession = undefined;
@@ -432,6 +502,24 @@ export function createPiChatExtension(
 				getSnapshot: () => chatSession?.snapshot(),
 				getRestoreError: () => restoreError,
 				createPrivateRoom: () => createPrivateRoom(deps.randomBytes(32)),
+				browsePublicRooms: async (signal) => {
+					if (!ownsMenu()) throw new Error("Pi Chat session is stale.");
+					const activeDirectory = roomDirectory;
+					const directory =
+						activeDirectory ??
+						deps.createDirectory({ identity: createIdentity(deps.randomBytes(32)) });
+					const temporary = activeDirectory ? undefined : directory;
+					const browseSignal = AbortSignal.any([signal, controller.signal]);
+					try {
+						const result = await directory.browse(browseSignal);
+						if (!ownsMenu() || browseSignal.aborted) {
+							throw browseSignal.reason ?? new DOMException("Aborted", "AbortError");
+						}
+						return result;
+					} finally {
+						if (temporary) await temporary.stop();
+					}
+				},
 				joinRoom,
 				openChat: async (commandCtx) => {
 					if (ownsMenu()) await openChat(commandCtx);

--- a/packages/pi-chat/src/protocol.ts
+++ b/packages/pi-chat/src/protocol.ts
@@ -1,10 +1,16 @@
 import { createHash, createHmac, hkdfSync, timingSafeEqual } from "node:crypto";
-import { normalizeNickname } from "./identity.js";
+import type { ChatIdentity } from "./identity.js";
+import { normalizeNickname, signIdentityPayload, verifyIdentityPayload } from "./identity.js";
 
-export const PROTOCOL_VERSION = 1;
+export const PROTOCOL_VERSION = 2;
 export const MAX_FRAME_BYTES = 16 * 1024;
 export const MAX_MESSAGE_BYTES = 4 * 1024;
+export const MAX_GOSSIP_HOPS = 8;
+export const MAX_EVENT_AGE_MS = 5 * 60_000;
+const MAX_EVENT_FUTURE_MS = 60_000;
 const PUBLIC_SLUG = /^[a-z0-9][a-z0-9-]{0,47}$/u;
+const PUBLIC_KEY = /^[0-9a-f]{64}$/u;
+const SIGNATURE = /^[A-Za-z0-9_-]{86}$/u;
 
 export interface RoomDescriptor {
 	kind: "private" | "public";
@@ -13,10 +19,11 @@ export interface RoomDescriptor {
 	topic: Buffer;
 	key: Buffer;
 	invite?: string;
+	slug?: string;
 }
 
 export interface HelloMessage {
-	v: 1;
+	v: 2;
 	type: "hello";
 	roomId: string;
 	nonce: string;
@@ -24,44 +31,63 @@ export interface HelloMessage {
 	proof: string;
 }
 
-export interface ChatMessage {
-	v: 1;
-	type: "chat";
-	text: string;
-	sentAt: number;
+export interface ChatEvent {
+	v: 2;
+	kind: "chat";
+	roomId: string;
+	origin: string;
 	id: string;
+	issuedAt: number;
+	nickname: string;
+	text: string;
+	signature: string;
 }
 
-export interface PresenceMessage {
-	v: 1;
-	type: "nickname-update" | "goodbye" | "ping" | "pong";
-	nickname?: string;
+export interface PresenceEvent {
+	v: 2;
+	kind: "presence";
+	roomId: string;
+	origin: string;
+	id: string;
+	issuedAt: number;
+	nickname: string;
+	status: "online" | "leaving";
+	signature: string;
 }
 
-export interface PeerListMessage {
-	v: 1;
-	type: "peer-list";
-	publicKeys: string[];
+export type RoomEvent = ChatEvent | PresenceEvent;
+type UnsignedRoomEvent = Omit<ChatEvent, "signature"> | Omit<PresenceEvent, "signature">;
+
+export interface GossipMessage {
+	v: 2;
+	type: "gossip";
+	event: RoomEvent;
+	hops: number;
 }
 
-export type ProtocolMessage = HelloMessage | ChatMessage | PresenceMessage | PeerListMessage;
+export interface GoodbyeMessage {
+	v: 2;
+	type: "goodbye";
+}
+
+export type ProtocolMessage = HelloMessage | GossipMessage | GoodbyeMessage;
 
 export function createPrivateRoom(secret: Uint8Array): RoomDescriptor {
 	if (secret.byteLength !== 32) throw new Error("Private room secrets must be 32 bytes.");
 	const bytes = Buffer.from(secret);
-	const topic = domainHash("pi-chat/discovery/private/v1", bytes);
+	const topic = domainHash("pi-chat/discovery/private/v2", bytes);
 	return {
 		kind: "private",
 		label: `private ${shortRoomId(topic)}`,
 		id: topic.toString("base64url"),
 		topic,
 		key: deriveRoomKey(bytes),
-		invite: `pichat:v1:${bytes.toString("base64url")}`,
+		invite: `pichat:v2:${bytes.toString("base64url")}`,
 	};
 }
 
 export function parseInvite(value: string): RoomDescriptor {
-	const match = /^pichat:v1:([A-Za-z0-9_-]{43})$/u.exec(value.trim());
+	const match = /^pichat:v[12]:([A-Za-z0-9_-]{43})$/u.exec(value.trim());
 	const encodedSecret = match?.[1];
 	if (!encodedSecret) throw new Error("This is not a valid Pi Chat invite.");
 	const secret = Buffer.from(encodedSecret, "base64url");
@@ -73,7 +99,7 @@ export function createPublicRoom(slug: string): RoomDescriptor {
 	if (!PUBLIC_SLUG.test(slug)) {
 		throw new Error("A public room slug must use lowercase letters, numbers, or hyphens.");
 	}
-	const material = Buffer.from(`pi-chat/public/v1:${slug}`, "utf8");
+	const material = Buffer.from(`pi-chat/public/v2:${slug}`, "utf8");
 	const topic = createHash("sha256").update(material).digest();
 	return {
 		kind: "public",
@@ -81,7 +107,26 @@ export function createPublicRoom(slug: string): RoomDescriptor {
 		id: topic.toString("base64url"),
 		topic,
 		key: deriveRoomKey(material),
+		slug,
 	};
+}
+
+export function legacyRoomId(room: RoomDescriptor): string | undefined {
+	if (room.kind === "public" && room.slug) {
+		return createHash("sha256")
+			.update(Buffer.from(`pi-chat/public/v1:${room.slug}`, "utf8"))
+			.digest("base64url");
+	}
+	const encodedSecret = /^pichat:v[12]:([A-Za-z0-9_-]{43})$/u.exec(room.invite ?? "")?.[1];
+	if (!encodedSecret) return undefined;
+	const secret = Buffer.from(encodedSecret, "base64url");
+	return secret.length === 32
+		? domainHash("pi-chat/discovery/private/v1", secret).toString("base64url")
+		: undefined;
+}
+
+export function isCompatibleRoomId(room: RoomDescriptor, id: string): boolean {
+	return room.id === id || legacyRoomId(room) === id;
 }
 
 export function createHello(
@@ -99,7 +144,7 @@ export function createHello(
 	if (nonceBytes.byteLength !== 16) throw new Error("Handshake nonces must be 16 bytes.");
 	const nonce = Buffer.from(nonceBytes).toString("base64url");
 	return {
-		v: 1,
+		v: 2,
 		type: "hello",
 		roomId: room.id,
 		nonce,
@@ -114,7 +159,7 @@ export function verifyHello(
 	senderPublicKey: Uint8Array,
 	receiverPublicKey: Uint8Array,
 ): HelloMessage | undefined {
-	if (!isRecord(value) || value.v !== 1 || value.type !== "hello") return undefined;
+	if (!isRecord(value) || value.v !== 2 || value.type !== "hello") return undefined;
 	if (
 		value.roomId !== room.id ||
 		typeof value.nonce !== "string" ||
@@ -131,7 +176,7 @@ export function verifyHello(
 		return undefined;
 	}
 	return {
-		v: 1,
+		v: 2,
 		type: "hello",
 		roomId: room.id,
 		nonce: value.nonce,
@@ -140,37 +185,95 @@ export function verifyHello(
 	};
 }
 
-export function createChatMessage(text: string, sentAt: number, id: string): ChatMessage {
+export function createChatEvent(
+	room: RoomDescriptor,
+	identity: ChatIdentity,
+	nicknameValue: string,
+	text: string,
+	issuedAt: number,
+	id: string,
+): ChatEvent {
+	const nickname = normalizeNickname(nicknameValue);
+	if (!nickname) throw new Error("Nickname is invalid.");
 	if (!text || Buffer.byteLength(text, "utf8") > MAX_MESSAGE_BYTES) {
 		throw new Error("Chat message is empty or too large.");
 	}
-	if (!Number.isSafeInteger(sentAt) || sentAt < 0) throw new Error("Message timestamp is invalid.");
-	if (!validId(id)) throw new Error("Message id is invalid.");
-	return { v: 1, type: "chat", text, sentAt, id };
+	validateEventFields(issuedAt, id);
+	const unsigned: Omit<ChatEvent, "signature"> = {
+		v: 2,
+		kind: "chat",
+		roomId: room.id,
+		origin: identity.publicKey.toString("hex"),
+		id,
+		issuedAt,
+		nickname,
+		text,
+	};
+	return { ...unsigned, signature: signIdentityPayload(identity, canonicalEvent(unsigned)) };
+}
+
+export function createPresenceEvent(
+	room: RoomDescriptor,
+	identity: ChatIdentity,
+	nicknameValue: string,
+	status: PresenceEvent["status"],
+	issuedAt: number,
+	id: string,
+): PresenceEvent {
+	const nickname = normalizeNickname(nicknameValue);
+	if (!nickname) throw new Error("Nickname is invalid.");
+	if (status !== "online" && status !== "leaving") throw new Error("Presence state is invalid.");
+	validateEventFields(issuedAt, id);
+	const unsigned: Omit<PresenceEvent, "signature"> = {
+		v: 2,
+		kind: "presence",
+		roomId: room.id,
+		origin: identity.publicKey.toString("hex"),
+		id,
+		issuedAt,
+		nickname,
+		status,
+	};
+	return { ...unsigned, signature: signIdentityPayload(identity, canonicalEvent(unsigned)) };
+}
+
+export function createGossipMessage(
+	event: RoomEvent,
+	hops: number = MAX_GOSSIP_HOPS,
+): GossipMessage {
+	if (!Number.isSafeInteger(hops) || hops < 1 || hops > MAX_GOSSIP_HOPS) {
+		throw new Error("Gossip hop budget is invalid.");
+	}
+	return { v: 2, type: "gossip", event, hops };
+}
+
+export function verifyRoomEvent(event: RoomEvent, room: RoomDescriptor, now = Date.now()): boolean {
+	const parsed = parseRoomEvent(event);
+	if (!parsed || parsed.roomId !== room.id) return false;
+	if (parsed.issuedAt < now - MAX_EVENT_AGE_MS || parsed.issuedAt > now + MAX_EVENT_FUTURE_MS) {
+		return false;
+	}
+	return verifyIdentityPayload(
+		Buffer.from(parsed.origin, "hex"),
+		canonicalEvent(withoutSignature(parsed)),
+		parsed.signature,
+	);
 }
 
 export function parseProtocolMessage(value: unknown): ProtocolMessage | undefined {
-	if (!isRecord(value) || value.v !== 1 || typeof value.type !== "string") return undefined;
-	if (value.type === "chat") {
+	if (!isRecord(value) || typeof value.type !== "string") return undefined;
+	if (value.v === 2 && value.type === "gossip") {
 		if (
-			typeof value.text !== "string" ||
-			!value.text ||
-			Buffer.byteLength(value.text, "utf8") > MAX_MESSAGE_BYTES ||
-			!Number.isSafeInteger(value.sentAt) ||
-			(value.sentAt as number) < 0 ||
-			!validId(value.id)
+			!Number.isSafeInteger(value.hops) ||
+			(value.hops as number) < 1 ||
+			(value.hops as number) > MAX_GOSSIP_HOPS
 		) {
 			return undefined;
 		}
-		return {
-			v: 1,
-			type: "chat",
-			text: value.text,
-			sentAt: value.sentAt as number,
-			id: value.id as string,
-		};
+		const event = parseRoomEvent(value.event);
+		return event ? { v: 2, type: "gossip", event, hops: value.hops as number } : undefined;
 	}
-	if (value.type === "hello") {
+	if (value.v === 2 && value.type === "hello") {
 		if (
 			typeof value.roomId !== "string" ||
 			typeof value.nonce !== "string" ||
@@ -181,23 +284,7 @@ export function parseProtocolMessage(value: unknown): ProtocolMessage | undefine
 		}
 		return value as unknown as HelloMessage;
 	}
-	if (value.type === "nickname-update") {
-		const nickname = normalizeNickname(value.nickname);
-		return nickname ? { v: 1, type: "nickname-update", nickname } : undefined;
-	}
-	if (value.type === "peer-list") {
-		if (
-			!Array.isArray(value.publicKeys) ||
-			value.publicKeys.length > 16 ||
-			!value.publicKeys.every((key) => typeof key === "string" && /^[0-9a-f]{64}$/u.test(key))
-		) {
-			return undefined;
-		}
-		return { v: 1, type: "peer-list", publicKeys: [...new Set(value.publicKeys)] };
-	}
-	if (value.type === "goodbye" || value.type === "ping" || value.type === "pong") {
-		return { v: 1, type: value.type };
-	}
+	if (value.v === 2 && value.type === "goodbye") return { v: 2, type: "goodbye" };
 	return undefined;
 }
 
@@ -290,9 +377,90 @@ export class PeerRateLimiter {
 	}
 }
 
+function parseRoomEvent(value: unknown): RoomEvent | undefined {
+	if (!isRecord(value) || value.v !== 2 || (value.kind !== "chat" && value.kind !== "presence")) {
+		return undefined;
+	}
+	const nickname = normalizeNickname(value.nickname);
+	if (
+		typeof value.roomId !== "string" ||
+		!PUBLIC_KEY.test(String(value.origin)) ||
+		!validId(value.id) ||
+		!Number.isSafeInteger(value.issuedAt) ||
+		(value.issuedAt as number) < 0 ||
+		!nickname ||
+		typeof value.signature !== "string" ||
+		!SIGNATURE.test(value.signature)
+	) {
+		return undefined;
+	}
+	const common = {
+		v: 2 as const,
+		roomId: value.roomId,
+		origin: value.origin as string,
+		id: value.id,
+		issuedAt: value.issuedAt as number,
+		nickname,
+		signature: value.signature,
+	};
+	if (value.kind === "chat") {
+		if (
+			typeof value.text !== "string" ||
+			!value.text ||
+			Buffer.byteLength(value.text, "utf8") > MAX_MESSAGE_BYTES
+		) {
+			return undefined;
+		}
+		return { ...common, kind: "chat", text: value.text };
+	}
+	if (value.status !== "online" && value.status !== "leaving") return undefined;
+	return { ...common, kind: "presence", status: value.status };
+}
+
+function canonicalEvent(event: UnsignedRoomEvent): Buffer {
+	const payload =
+		event.kind === "chat"
+			? [
+					2,
+					"chat",
+					event.roomId,
+					event.origin,
+					event.id,
+					event.issuedAt,
+					event.nickname,
+					event.text,
+				]
+			: [
+					2,
+					"presence",
+					event.roomId,
+					event.origin,
+					event.id,
+					event.issuedAt,
+					event.nickname,
+					event.status,
+				];
+	return Buffer.from(JSON.stringify(payload), "utf8");
+}
+
+function withoutSignature(event: RoomEvent): UnsignedRoomEvent {
+	if (event.kind === "chat") {
+		const { signature: _signature, ...unsigned } = event;
+		return unsigned;
+	}
+	const { signature: _signature, ...unsigned } = event;
+	return unsigned;
+}
+
+function validateEventFields(issuedAt: number, id: string): void {
+	if (!Number.isSafeInteger(issuedAt) || issuedAt < 0)
+		throw new Error("Message timestamp is invalid.");
+	if (!validId(id)) throw new Error("Message id is invalid.");
+}
+
 function deriveRoomKey(material: Uint8Array): Buffer {
 	return Buffer.from(
-		hkdfSync("sha256", material, Buffer.from("pi-chat/v1"), Buffer.from("room-handshake"), 32),
+		hkdfSync("sha256", material, Buffer.from("pi-chat/v2"), Buffer.from("room-handshake"), 32),
 	);
 }
 

--- a/packages/pi-chat/src/public-room-directory.ts
+++ b/packages/pi-chat/src/public-room-directory.ts
@@ -90,16 +90,20 @@ export class DirectoryCatalog {
 		) {
 			return false;
 		}
-		if (event.status === "leaving") {
-			this.records.delete(event.origin);
-			return true;
-		}
 		if (!existing && this.records.size >= this.maxRecords) {
 			this.truncated = true;
 			return false;
 		}
-		const knownSlugs = new Set([...this.records.values()].map(({ slug }) => slug));
-		if (!knownSlugs.has(event.slug) && knownSlugs.size >= this.maxRooms) {
+		const knownSlugs = new Set(
+			[...this.records.values()]
+				.filter(({ status }) => status === "online")
+				.map(({ slug }) => slug),
+		);
+		if (
+			event.status === "online" &&
+			!knownSlugs.has(event.slug) &&
+			knownSlugs.size >= this.maxRooms
+		) {
 			this.truncated = true;
 			return false;
 		}
@@ -111,7 +115,9 @@ export class DirectoryCatalog {
 		this.prune();
 		const counts = new Map<string, number>();
 		for (const event of this.records.values()) {
-			counts.set(event.slug, (counts.get(event.slug) ?? 0) + 1);
+			if (event.status === "online") {
+				counts.set(event.slug, (counts.get(event.slug) ?? 0) + 1);
+			}
 		}
 		return {
 			rooms: sortDirectoryRooms(
@@ -133,9 +139,10 @@ export class DirectoryCatalog {
 	}
 
 	private prune(): void {
-		const oldest = this.now() - DIRECTORY_RECORD_TTL_MS;
+		const now = this.now();
 		for (const [origin, event] of this.records) {
-			if (event.issuedAt < oldest) this.records.delete(origin);
+			const ttl = event.status === "leaving" ? MAX_EVENT_AGE_MS : DIRECTORY_RECORD_TTL_MS;
+			if (event.issuedAt < now - ttl) this.records.delete(origin);
 		}
 		this.pruneSeen();
 	}

--- a/packages/pi-chat/src/public-room-directory.ts
+++ b/packages/pi-chat/src/public-room-directory.ts
@@ -1,0 +1,379 @@
+import { createHash } from "node:crypto";
+import type { ChatIdentity } from "./identity.js";
+import { signIdentityPayload, verifyIdentityPayload } from "./identity.js";
+import {
+	createPublicRoom,
+	MAX_EVENT_AGE_MS,
+	MAX_FRAME_BYTES,
+	MAX_GOSSIP_HOPS,
+} from "./protocol.js";
+
+const MAX_EVENT_FUTURE_MS = 60_000;
+const DIRECTORY_RECORD_TTL_MS = 90_000;
+const MAX_DIRECTORY_RECORDS = 4_096;
+const MAX_DIRECTORY_ROOMS = 512;
+const MAX_DIRECTORY_SEEN = 16_384;
+const DIRECTORY_SEEN_TTL_MS = 10 * 60_000;
+const PUBLIC_KEY = /^[0-9a-f]{64}$/u;
+const SIGNATURE = /^[A-Za-z0-9_-]{86}$/u;
+
+export const PUBLIC_ROOM_DIRECTORY_TOPIC = createHash("sha256")
+	.update("pi-chat/public-room-directory/v2", "utf8")
+	.digest();
+
+export interface DirectoryPresence {
+	v: 2;
+	kind: "directory-presence";
+	slug: string;
+	origin: string;
+	id: string;
+	issuedAt: number;
+	status: "online" | "leaving";
+	signature: string;
+}
+
+export interface DirectoryWireMessage {
+	v: 2;
+	type: "directory";
+	event: DirectoryPresence;
+	hops: number;
+	partial?: true;
+}
+
+export interface PublicRoomListing {
+	slug: string;
+	estimatedParticipants: number;
+}
+
+export interface PublicRoomBrowseResult {
+	rooms: PublicRoomListing[];
+	partial: boolean;
+}
+
+export interface DirectoryCatalogOptions {
+	now?: () => number;
+	maxRecords?: number;
+	maxRooms?: number;
+}
+
+interface SeenRecord {
+	key: string;
+	expiresAt: number;
+}
+
+export class DirectoryCatalog {
+	private readonly now: () => number;
+	private readonly maxRecords: number;
+	private readonly maxRooms: number;
+	private readonly records = new Map<string, DirectoryPresence>();
+	private readonly seen = new Map<string, number>();
+	private readonly seenOrder: SeenRecord[] = [];
+	private truncated = false;
+
+	constructor(options: DirectoryCatalogOptions = {}) {
+		this.now = options.now ?? Date.now;
+		this.maxRecords = positiveBound(options.maxRecords, MAX_DIRECTORY_RECORDS);
+		this.maxRooms = positiveBound(options.maxRooms, MAX_DIRECTORY_ROOMS);
+	}
+
+	accept(event: DirectoryPresence): boolean {
+		const now = this.now();
+		if (!verifyDirectoryPresence(event, now)) return false;
+		const seenKey = `${event.origin}:${event.id}`;
+		if (this.hasSeen(seenKey)) return false;
+		this.remember(seenKey);
+		const existing = this.records.get(event.origin);
+		if (
+			existing &&
+			(existing.issuedAt > event.issuedAt ||
+				(existing.issuedAt === event.issuedAt && existing.id.localeCompare(event.id) >= 0))
+		) {
+			return false;
+		}
+		if (event.status === "leaving") {
+			this.records.delete(event.origin);
+			return true;
+		}
+		if (!existing && this.records.size >= this.maxRecords) {
+			this.truncated = true;
+			return false;
+		}
+		const knownSlugs = new Set([...this.records.values()].map(({ slug }) => slug));
+		if (!knownSlugs.has(event.slug) && knownSlugs.size >= this.maxRooms) {
+			this.truncated = true;
+			return false;
+		}
+		this.records.set(event.origin, event);
+		return true;
+	}
+
+	snapshot(): PublicRoomBrowseResult {
+		this.prune();
+		const counts = new Map<string, number>();
+		for (const event of this.records.values()) {
+			counts.set(event.slug, (counts.get(event.slug) ?? 0) + 1);
+		}
+		return {
+			rooms: sortDirectoryRooms(
+				[...counts].map(([slug, estimatedParticipants]) => ({ slug, estimatedParticipants })),
+			),
+			partial: this.truncated,
+		};
+	}
+
+	currentEvents(): DirectoryPresence[] {
+		this.prune();
+		return [...this.records.values()].sort(
+			(left, right) => right.issuedAt - left.issuedAt || left.origin.localeCompare(right.origin),
+		);
+	}
+
+	markPartial(): void {
+		this.truncated = true;
+	}
+
+	private prune(): void {
+		const oldest = this.now() - DIRECTORY_RECORD_TTL_MS;
+		for (const [origin, event] of this.records) {
+			if (event.issuedAt < oldest) this.records.delete(origin);
+		}
+		this.pruneSeen();
+	}
+
+	private hasSeen(key: string): boolean {
+		this.pruneSeen();
+		return this.seen.has(key);
+	}
+
+	private remember(key: string): void {
+		const expiresAt = this.now() + DIRECTORY_SEEN_TTL_MS;
+		this.seen.set(key, expiresAt);
+		this.seenOrder.push({ key, expiresAt });
+		while (this.seen.size > MAX_DIRECTORY_SEEN) {
+			const removed = this.seenOrder.shift();
+			if (removed && this.seen.get(removed.key) === removed.expiresAt) {
+				this.seen.delete(removed.key);
+			}
+		}
+	}
+
+	private pruneSeen(): void {
+		const now = this.now();
+		while (this.seenOrder[0] && this.seenOrder[0].expiresAt <= now) {
+			const removed = this.seenOrder.shift();
+			if (removed && this.seen.get(removed.key) === removed.expiresAt) {
+				this.seen.delete(removed.key);
+			}
+		}
+	}
+}
+
+export function createDirectoryPresence(
+	identity: ChatIdentity,
+	slugValue: string,
+	status: DirectoryPresence["status"],
+	issuedAt: number,
+	id: string,
+): DirectoryPresence {
+	const slug = validatedSlug(slugValue);
+	if (!slug) throw new Error("A public room slug must use lowercase letters, numbers, or hyphens.");
+	if (status !== "online" && status !== "leaving") {
+		throw new Error("Directory presence state is invalid.");
+	}
+	if (!Number.isSafeInteger(issuedAt) || issuedAt < 0) {
+		throw new Error("Directory presence timestamp is invalid.");
+	}
+	if (!validId(id)) throw new Error("Directory presence id is invalid.");
+	const unsigned: Omit<DirectoryPresence, "signature"> = {
+		v: 2,
+		kind: "directory-presence",
+		slug,
+		origin: identity.publicKey.toString("hex"),
+		id,
+		issuedAt,
+		status,
+	};
+	return {
+		...unsigned,
+		signature: signIdentityPayload(identity, canonicalDirectoryPresence(unsigned)),
+	};
+}
+
+export function verifyDirectoryPresence(value: DirectoryPresence, now = Date.now()): boolean {
+	const event = parseDirectoryPresence(value);
+	if (!event) return false;
+	if (event.issuedAt < now - MAX_EVENT_AGE_MS || event.issuedAt > now + MAX_EVENT_FUTURE_MS) {
+		return false;
+	}
+	const { signature, ...unsigned } = event;
+	return verifyIdentityPayload(
+		Buffer.from(event.origin, "hex"),
+		canonicalDirectoryPresence(unsigned),
+		signature,
+	);
+}
+
+export function createDirectoryWireMessage(
+	event: DirectoryPresence,
+	hops = MAX_GOSSIP_HOPS,
+	partial = false,
+): DirectoryWireMessage {
+	if (!Number.isSafeInteger(hops) || hops < 1 || hops > MAX_GOSSIP_HOPS) {
+		throw new Error("Directory gossip hop budget is invalid.");
+	}
+	return { v: 2, type: "directory", event, hops, ...(partial ? { partial: true as const } : {}) };
+}
+
+export function parseDirectoryWireMessage(value: unknown): DirectoryWireMessage | undefined {
+	if (
+		!isRecord(value) ||
+		value.v !== 2 ||
+		value.type !== "directory" ||
+		!Number.isSafeInteger(value.hops) ||
+		(value.hops as number) < 1 ||
+		(value.hops as number) > MAX_GOSSIP_HOPS
+	) {
+		return undefined;
+	}
+	if (value.partial !== undefined && value.partial !== true) return undefined;
+	const event = parseDirectoryPresence(value.event);
+	return event
+		? {
+				v: 2,
+				type: "directory",
+				event,
+				hops: value.hops as number,
+				...(value.partial === true ? { partial: true as const } : {}),
+			}
+		: undefined;
+}
+
+export function encodeDirectoryFrame(message: DirectoryWireMessage): Buffer {
+	const payload = Buffer.from(JSON.stringify(message), "utf8");
+	if (payload.length > MAX_FRAME_BYTES) throw new Error("Directory frame exceeds the size limit.");
+	const header = Buffer.allocUnsafe(4);
+	header.writeUInt32BE(payload.length);
+	return Buffer.concat([header, payload]);
+}
+
+export class DirectoryFrameDecoder {
+	private buffer = Buffer.alloc(0);
+
+	push(chunk: Uint8Array): DirectoryWireMessage[] {
+		if (chunk.byteLength === 0) return [];
+		const incoming = Buffer.from(chunk);
+		const messages: DirectoryWireMessage[] = [];
+		let offset = 0;
+		while (offset < incoming.length) {
+			if (this.buffer.length < 4) {
+				const headerBytes = Math.min(4 - this.buffer.length, incoming.length - offset);
+				this.buffer = Buffer.concat([this.buffer, incoming.subarray(offset, offset + headerBytes)]);
+				offset += headerBytes;
+				if (this.buffer.length < 4) break;
+			}
+			const length = this.buffer.readUInt32BE(0);
+			if (length > MAX_FRAME_BYTES) {
+				this.buffer = Buffer.alloc(0);
+				throw new Error("Directory frame exceeds the size limit.");
+			}
+			const frameBytes = length + 4;
+			if (this.buffer.length < frameBytes) {
+				const payloadBytes = Math.min(frameBytes - this.buffer.length, incoming.length - offset);
+				this.buffer = Buffer.concat([
+					this.buffer,
+					incoming.subarray(offset, offset + payloadBytes),
+				]);
+				offset += payloadBytes;
+				if (this.buffer.length < frameBytes) break;
+			}
+			const payload = this.buffer.subarray(4, frameBytes);
+			this.buffer = Buffer.alloc(0);
+			let value: unknown;
+			try {
+				value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(payload)) as unknown;
+			} catch {
+				throw new Error("Directory frame is not valid UTF-8 JSON.");
+			}
+			const parsed = parseDirectoryWireMessage(value);
+			if (!parsed) throw new Error("Directory frame has an invalid message shape.");
+			messages.push(parsed);
+		}
+		return messages;
+	}
+}
+
+export function sortDirectoryRooms(rooms: readonly PublicRoomListing[]): PublicRoomListing[] {
+	return [...rooms].sort(
+		(left, right) =>
+			right.estimatedParticipants - left.estimatedParticipants ||
+			left.slug.localeCompare(right.slug),
+	);
+}
+
+function parseDirectoryPresence(value: unknown): DirectoryPresence | undefined {
+	if (
+		!isRecord(value) ||
+		value.v !== 2 ||
+		value.kind !== "directory-presence" ||
+		!validatedSlug(value.slug) ||
+		!PUBLIC_KEY.test(String(value.origin)) ||
+		!validId(value.id) ||
+		!Number.isSafeInteger(value.issuedAt) ||
+		(value.issuedAt as number) < 0 ||
+		(value.status !== "online" && value.status !== "leaving") ||
+		typeof value.signature !== "string" ||
+		!SIGNATURE.test(value.signature)
+	) {
+		return undefined;
+	}
+	return {
+		v: 2,
+		kind: "directory-presence",
+		slug: value.slug as string,
+		origin: value.origin as string,
+		id: value.id,
+		issuedAt: value.issuedAt as number,
+		status: value.status,
+		signature: value.signature,
+	};
+}
+
+function canonicalDirectoryPresence(event: Omit<DirectoryPresence, "signature">): Buffer {
+	return Buffer.from(
+		JSON.stringify([
+			2,
+			"directory-presence",
+			event.slug,
+			event.origin,
+			event.id,
+			event.issuedAt,
+			event.status,
+		]),
+		"utf8",
+	);
+}
+
+function validatedSlug(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	try {
+		return createPublicRoom(value).slug;
+	} catch {
+		return undefined;
+	}
+}
+
+function positiveBound(value: number | undefined, fallback: number): number {
+	return Number.isSafeInteger(value) && (value ?? 0) > 0
+		? Math.min(value ?? fallback, fallback)
+		: fallback;
+}
+
+function validId(value: unknown): value is string {
+	return (
+		typeof value === "string" && value.length > 0 && value.length <= 64 && !/\p{Cc}/u.test(value)
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/pi-chat/src/settings.ts
+++ b/packages/pi-chat/src/settings.ts
@@ -4,7 +4,12 @@ import { chmod, lstat, mkdir, open, rename, rm, writeFile } from "node:fs/promis
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { normalizeNickname } from "./identity.js";
-import { createPublicRoom, parseInvite, type RoomDescriptor } from "./protocol.js";
+import {
+	createPublicRoom,
+	isCompatibleRoomId,
+	parseInvite,
+	type RoomDescriptor,
+} from "./protocol.js";
 
 export const CHAT_SETTINGS_FILE = "pi-chat.json";
 const MAX_SETTINGS_BYTES = 64 * 1024;
@@ -258,14 +263,21 @@ function normalizeResumeSettings(value: unknown): ChatResumeSettings | undefined
 	if (value.surface !== "chat" && value.surface !== "pi") return undefined;
 	const rooms: RememberedRoom[] = [];
 	const ids = new Set<string>();
+	let activeRoomId: string | undefined;
 	for (const candidate of value.rooms) {
 		const room = normalizeRememberedRoom(candidate);
 		if (!room || ids.has(room.id)) return undefined;
 		ids.add(room.id);
 		rooms.push(room);
+		if (
+			isRecord(candidate) &&
+			(candidate.id === value.activeRoomId || room.id === value.activeRoomId)
+		) {
+			activeRoomId = room.id;
+		}
 	}
-	if (!ids.has(value.activeRoomId)) return undefined;
-	return { rooms, activeRoomId: value.activeRoomId, surface: value.surface };
+	if (!activeRoomId || !ids.has(activeRoomId)) return undefined;
+	return { rooms, activeRoomId, surface: value.surface };
 }
 
 function normalizeRememberedRoom(value: unknown): RememberedRoom | undefined {
@@ -277,7 +289,9 @@ function normalizeRememberedRoom(value: unknown): RememberedRoom | undefined {
 			!Object.hasOwn(value, "invite")
 		) {
 			const room = createPublicRoom(value.slug);
-			return room.id === value.id ? { id: room.id, kind: "public", slug: value.slug } : undefined;
+			return isCompatibleRoomId(room, value.id)
+				? { id: room.id, kind: "public", slug: value.slug }
+				: undefined;
 		}
 		if (
 			value.kind === "private" &&
@@ -285,7 +299,7 @@ function normalizeRememberedRoom(value: unknown): RememberedRoom | undefined {
 			!Object.hasOwn(value, "slug")
 		) {
 			const room = parseInvite(value.invite);
-			return room.id === value.id
+			return isCompatibleRoomId(room, value.id)
 				? { id: room.id, kind: "private", invite: value.invite }
 				: undefined;
 		}
@@ -300,9 +314,8 @@ function mergeResumeDocument(current: unknown, next: ChatResumeSettings): Settin
 	const existingRooms = new Map<string, SettingsDocument>();
 	if (Array.isArray(currentResume.rooms)) {
 		for (const candidate of currentResume.rooms) {
-			if (isRecord(candidate) && typeof candidate.id === "string") {
-				existingRooms.set(candidate.id, candidate);
-			}
+			const normalized = normalizeRememberedRoom(candidate);
+			if (normalized && isRecord(candidate)) existingRooms.set(normalized.id, candidate);
 		}
 	}
 	return {

--- a/packages/pi-chat/src/widget.ts
+++ b/packages/pi-chat/src/widget.ts
@@ -15,8 +15,8 @@ export function renderChatWidget(
 	const safeWidth = Math.max(1, width);
 	if (mode === "dock") return renderRoomDock(snapshot, safeWidth, terminalRows, theme);
 
-	const peers = snapshot.peers.length;
-	const presence = peers === 0 ? "alone" : `${peers} direct peer${peers === 1 ? "" : "s"}`;
+	const participants = snapshot.participants.length;
+	const presence = `${participants} active · ${snapshot.directNeighbors} direct neighbor${snapshot.directNeighbors === 1 ? "" : "s"}`;
 	const unread = snapshot.unread > 0 ? `${snapshot.unread} unread · ` : "";
 	const attention = snapshot.state === "degraded" ? " · reconnecting" : "";
 	const header = truncateToWidth(
@@ -42,16 +42,15 @@ function renderRoomDock(
 	terminalRows: number,
 	theme: Theme,
 ): string[] {
-	const peers = snapshot.peers.length;
-	const peerText = `${peers} direct peer${peers === 1 ? "" : "s"}`;
+	const participantText = `${snapshot.participants.length} active · ${snapshot.directNeighbors} direct neighbor${snapshot.directNeighbors === 1 ? "" : "s"}`;
 	const stateText =
 		snapshot.state === "connecting"
 			? "joining…"
 			: snapshot.state === "degraded"
-				? `reconnecting · ${peerText}`
-				: peers === 0
-					? "waiting for peers"
-					: peerText;
+				? `reconnecting · ${participantText}`
+				: snapshot.directNeighbors === 0
+					? "waiting for neighbors"
+					: participantText;
 	const unread = snapshot.unread > 0 ? ` · ${snapshot.unread} unread` : "";
 	const roomTitle = `ROOM ${sanitizeSingleLine(snapshot.room.label)}`;
 	const status = `${stateText}${unread}`;

--- a/packages/pi-chat/test/chat-session.test.ts
+++ b/packages/pi-chat/test/chat-session.test.ts
@@ -209,6 +209,85 @@ test("bounds accepted events per signed origin before transcript and forwarding"
 	assert.equal(sentChat(second.peer, "origin-6"), undefined);
 });
 
+test("ignores stale presence updates after a newer departure", async () => {
+	const { room, identity, transport, session } = fixture();
+	await session.start();
+	const remote = authenticate(room, identity, transport, 2, "Current");
+	const leaving = createPresenceEvent(room, remote.identity, "Current", "leaving", 100_000, "z");
+	const delayedByTime = createPresenceEvent(
+		room,
+		remote.identity,
+		"Old Name",
+		"online",
+		99_999,
+		"delayed-time",
+	);
+	const delayedById = createPresenceEvent(
+		room,
+		remote.identity,
+		"Other Old Name",
+		"online",
+		100_000,
+		"a",
+	);
+
+	transport.receive(remote.peer, createGossipMessage(leaving));
+	transport.receive(remote.peer, createGossipMessage(delayedByTime));
+	transport.receive(remote.peer, createGossipMessage(delayedById));
+
+	assert.equal(session.snapshot().participants.length, 0);
+});
+
+test("keeps the newest nickname when presence heartbeats arrive out of order", async () => {
+	const { room, identity, transport, session } = fixture();
+	await session.start();
+	const remote = authenticate(room, identity, transport, 2, "Initial");
+	const current = createPresenceEvent(room, remote.identity, "Current", "online", 100_000, "z");
+	const delayedByTime = createPresenceEvent(
+		room,
+		remote.identity,
+		"Old By Time",
+		"online",
+		99_999,
+		"delayed-time",
+	);
+	const delayedById = createPresenceEvent(
+		room,
+		remote.identity,
+		"Old By Id",
+		"online",
+		100_000,
+		"a",
+	);
+
+	transport.receive(remote.peer, createGossipMessage(current));
+	transport.receive(remote.peer, createGossipMessage(delayedByTime));
+	transport.receive(remote.peer, createGossipMessage(delayedById));
+
+	assert.equal(session.snapshot().participants[0]?.nickname, "Current");
+});
+
+test("does not restore presence when delayed chat predates a departure", async () => {
+	const { room, identity, transport, session } = fixture();
+	await session.start();
+	const remote = authenticate(room, identity, transport, 2, "Current");
+	const leaving = createPresenceEvent(room, remote.identity, "Current", "leaving", 100_000, "left");
+	const delayedChat = createChatEvent(
+		room,
+		remote.identity,
+		"Old Name",
+		"sent before leaving",
+		99_999,
+		"delayed-chat",
+	);
+
+	transport.receive(remote.peer, createGossipMessage(leaving));
+	transport.receive(remote.peer, createGossipMessage(delayedChat));
+
+	assert.equal(session.snapshot().participants.length, 0);
+	assert.equal(session.snapshot().transcript.at(-1)?.text, "sent before leaving");
+});
+
 test("mutes display by signed origin while continuing to forward its events", async () => {
 	const { room, identity, transport, session } = fixture();
 	await session.start();

--- a/packages/pi-chat/test/chat-session.test.ts
+++ b/packages/pi-chat/test/chat-session.test.ts
@@ -1,8 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { ChatSession, type ChatTransport, type TransportPeer } from "../src/chat-session.js";
-import { createIdentity } from "../src/identity.js";
-import { createPrivateRoom, type ProtocolMessage } from "../src/protocol.js";
+import { type ChatIdentity, createIdentity } from "../src/identity.js";
+import {
+	createChatEvent,
+	createGossipMessage,
+	createHello,
+	createPresenceEvent,
+	createPrivateRoom,
+	type GossipMessage,
+	type ProtocolMessage,
+	type RoomDescriptor,
+} from "../src/protocol.js";
 
 class FakePeer implements TransportPeer {
 	readonly sent: ProtocolMessage[] = [];
@@ -48,105 +57,206 @@ class FakeTransport implements ChatTransport {
 }
 
 function fixture() {
+	let now = 100_000;
 	const room = createPrivateRoom(Buffer.alloc(32, 9));
 	const identity = createIdentity(Buffer.alloc(32, 1));
-	const remote = createIdentity(Buffer.alloc(32, 2));
 	const transport = new FakeTransport();
-	const session = new ChatSession({ room, identity, nickname: "Mika", transport, now: () => 100 });
-	return { room, identity, remote, transport, session };
+	const session = new ChatSession({
+		room,
+		identity,
+		nickname: "Mika",
+		transport,
+		now: () => now,
+	});
+	return {
+		room,
+		identity,
+		transport,
+		session,
+		setNow(value: number) {
+			now = value;
+		},
+	};
 }
 
-test("authenticates a direct peer before exposing presence or chat", async () => {
-	const { room, identity, remote, transport, session } = fixture();
+function authenticate(
+	room: RoomDescriptor,
+	local: ChatIdentity,
+	transport: FakeTransport,
+	seed: number,
+	nickname = `Peer${seed}`,
+): { identity: ChatIdentity; peer: FakePeer } {
+	const seedBytes = Buffer.alloc(32);
+	seedBytes.writeUInt32BE(seed);
+	const identity = createIdentity(seedBytes);
+	const peer = new FakePeer(identity.publicKey);
+	transport.connect(peer);
+	transport.receive(
+		peer,
+		createHello(room, nickname, identity.publicKey, local.publicKey, Buffer.alloc(16, seed)),
+	);
+	return { identity, peer };
+}
+
+function sentChat(peer: FakePeer, id: string): GossipMessage | undefined {
+	const message = peer.sent.find(
+		(candidate) =>
+			candidate.type === "gossip" && candidate.event.kind === "chat" && candidate.event.id === id,
+	);
+	return message?.type === "gossip" ? message : undefined;
+}
+
+test("authenticates direct neighbors before exposing their active presence", async () => {
+	const { room, identity, transport, session } = fixture();
 	await session.start();
+	const remote = createIdentity(Buffer.alloc(32, 2));
 	const peer = new FakePeer(remote.publicKey);
 	transport.connect(peer);
 	assert.equal(peer.sent[0]?.type, "hello");
-	assert.equal(session.snapshot().peers.length, 0);
+	assert.equal(session.snapshot().participants.length, 0);
 	transport.receive(
 		peer,
-		peerHello(room, "Other", remote.publicKey, identity.publicKey, Buffer.alloc(16, 4)),
+		createHello(room, "Other", remote.publicKey, identity.publicKey, Buffer.alloc(16, 4)),
 	);
-	assert.equal(session.snapshot().peers[0]?.label.startsWith("Other~"), true);
+	assert.equal(session.snapshot().participants[0]?.label.startsWith("Other~"), true);
+	assert.equal(session.snapshot().directNeighbors, 1);
 });
 
-test("broadcasts only to authenticated unmuted peers and reports zero-peer delivery honestly", async () => {
-	const { room, identity, remote, transport, session } = fixture();
+test("relays a signed event once across duplicate paths and never sends it back to ingress", async () => {
+	const { room, identity, transport, session } = fixture();
 	await session.start();
-	assert.equal(session.send("alone").deliveredTo, 0);
-	assert.equal(session.snapshot().transcript.at(-1)?.delivery, "not-delivered");
-	const peer = new FakePeer(remote.publicKey);
-	transport.connect(peer);
-	transport.receive(peer, peerHello(room, "Other", remote.publicKey, identity.publicKey));
-	const result = session.send("hello");
-	assert.equal(result.deliveredTo, 1);
-	assert.equal(peer.sent.at(-1)?.type, "chat");
-	session.mute(remote.publicKey);
-	assert.equal(session.send("muted").deliveredTo, 0);
+	const first = authenticate(room, identity, transport, 2);
+	const second = authenticate(room, identity, transport, 3);
+	const origin = createIdentity(Buffer.alloc(32, 4));
+	const event = createChatEvent(room, origin, "Origin", "hello gossip", 100_000, "same");
+
+	transport.receive(first.peer, createGossipMessage(event, 4));
+	transport.receive(second.peer, createGossipMessage(event, 4));
+	assert.equal(
+		session.snapshot().transcript.filter((entry) => entry.text === "hello gossip").length,
+		1,
+	);
+	assert.equal(sentChat(first.peer, "same"), undefined);
+	assert.equal(sentChat(second.peer, "same")?.type, "gossip");
+	if (sentChat(second.peer, "same")?.type === "gossip") {
+		assert.equal(sentChat(second.peer, "same")?.hops, 3);
+	}
 });
 
-test("publishes composer focus so persistent UI reports the real input target", async () => {
+test("records local events before relay so loopback cannot duplicate the transcript", async () => {
+	const { room, identity, transport, session } = fixture();
+	await session.start();
+	const neighbor = authenticate(room, identity, transport, 2);
+	const result = session.send("local gossip");
+	assert.equal(result.relayedTo, 1);
+	const relayed = neighbor.peer.sent.find(
+		(message) => message.type === "gossip" && message.event.kind === "chat",
+	);
+	assert.equal(relayed?.type, "gossip");
+	if (relayed?.type === "gossip") transport.receive(neighbor.peer, relayed);
+	assert.equal(
+		session.snapshot().transcript.filter((entry) => entry.text === "local gossip").length,
+		1,
+	);
+	assert.equal(session.snapshot().transcript.at(-1)?.delivery, "relayed");
+});
+
+test("accepts an exhausted-hop event locally without forwarding it", async () => {
+	const { room, identity, transport, session } = fixture();
+	await session.start();
+	const first = authenticate(room, identity, transport, 2);
+	const second = authenticate(room, identity, transport, 3);
+	const origin = createIdentity(Buffer.alloc(32, 4));
+	const event = createChatEvent(room, origin, "Origin", "last hop", 100_000, "last-hop");
+	transport.receive(first.peer, createGossipMessage(event, 1));
+	assert.equal(session.snapshot().transcript.at(-1)?.text, "last hop");
+	assert.equal(sentChat(second.peer, "last-hop"), undefined);
+});
+
+test("rejects invalid, stale, and over-rate events before state or forwarding", async () => {
+	const { room, identity, transport, session, setNow } = fixture();
+	await session.start();
+	const first = authenticate(room, identity, transport, 2);
+	const second = authenticate(room, identity, transport, 3);
+	const origin = createIdentity(Buffer.alloc(32, 4));
+	const valid = createChatEvent(room, origin, "Origin", "valid", 100_000, "valid");
+	transport.receive(first.peer, createGossipMessage({ ...valid, text: "tampered" }, 4));
+	setNow(1_000_000);
+	transport.receive(first.peer, createGossipMessage(valid, 4));
+	assert.equal(session.snapshot().transcript.length, 0);
+	assert.equal(sentChat(second.peer, "valid"), undefined);
+});
+
+test("bounds accepted events per signed origin before transcript and forwarding", async () => {
+	const { room, identity, transport, session } = fixture();
+	await session.start();
+	const first = authenticate(room, identity, transport, 2);
+	const second = authenticate(room, identity, transport, 3);
+	const origin = createIdentity(Buffer.alloc(32, 4));
+	for (let index = 0; index < 7; index += 1) {
+		const event = createChatEvent(
+			room,
+			origin,
+			"Origin",
+			`message ${index}`,
+			100_000,
+			`origin-${index}`,
+		);
+		transport.receive(first.peer, createGossipMessage(event));
+	}
+	assert.equal(session.snapshot().transcript.length, 6);
+	assert.equal(sentChat(second.peer, "origin-5")?.type, "gossip");
+	assert.equal(sentChat(second.peer, "origin-6"), undefined);
+});
+
+test("mutes display by signed origin while continuing to forward its events", async () => {
+	const { room, identity, transport, session } = fixture();
+	await session.start();
+	const first = authenticate(room, identity, transport, 2);
+	const second = authenticate(room, identity, transport, 3);
+	const origin = createIdentity(Buffer.alloc(32, 4));
+	const presence = createPresenceEvent(room, origin, "Origin", "online", 100_000, "presence");
+	transport.receive(first.peer, createGossipMessage(presence));
+	assert.equal(session.toggleMute(origin.publicKey), true);
+	const chat = createChatEvent(room, origin, "Origin", "muted", 100_000, "muted");
+	transport.receive(first.peer, createGossipMessage(chat));
+	assert.equal(
+		session.snapshot().transcript.some((entry) => entry.text === "muted"),
+		false,
+	);
+	assert.equal(sentChat(second.peer, "muted")?.type, "gossip");
+});
+
+test("expires stale presence and bounds the active participant catalog at 256", async () => {
+	const { room, identity, transport, session, setNow } = fixture();
+	await session.start();
+	for (let index = 2; index < 262; index += 1) {
+		authenticate(room, identity, transport, index);
+	}
+	assert.equal(session.snapshot().participants.length, 256);
+	assert.equal(session.snapshot().participantCatalogFull, true);
+	setNow(300_001);
+	assert.equal(session.snapshot().participants.length, 0);
+});
+
+test("publishes composer focus and clears unread when the view opens", async () => {
 	const { session } = fixture();
 	await session.start();
-	assert.equal((session.snapshot() as { composerOpen?: boolean }).composerOpen, false);
+	assert.equal(session.snapshot().composerOpen, false);
 	session.setViewOpen(true);
-	assert.equal((session.snapshot() as { composerOpen?: boolean }).composerOpen, true);
+	assert.equal(session.snapshot().composerOpen, true);
 	session.setViewOpen(false);
-	assert.equal((session.snapshot() as { composerOpen?: boolean }).composerOpen, false);
-});
-
-test("tracks unread remote messages, deduplicates ids, and bounds transcript", async () => {
-	const { room, identity, remote, transport, session } = fixture();
-	await session.start();
-	const peer = new FakePeer(remote.publicKey);
-	transport.connect(peer);
-	transport.receive(peer, peerHello(room, "Other", remote.publicKey, identity.publicKey));
-	session.setViewOpen(false);
-	const message = { v: 1, type: "chat", text: "hi", sentAt: 1, id: "same" } as const;
-	transport.receive(peer, message);
-	transport.receive(peer, message);
-	assert.equal(session.snapshot().unread, 1);
-	assert.equal(session.snapshot().transcript.filter((entry) => entry.text === "hi").length, 1);
-	for (let index = 0; index < 300; index += 1) session.send(`local ${index}`);
-	assert.equal(session.snapshot().transcript.length, 256);
-	session.setViewOpen(true);
-	assert.equal(session.snapshot().unread, 0);
-});
-
-test("nickname updates retain peer identity and hostile protocol abuse closes the peer", async () => {
-	const { room, identity, remote, transport, session } = fixture();
-	await session.start();
-	const peer = new FakePeer(remote.publicKey);
-	transport.connect(peer);
-	transport.receive(peer, peerHello(room, "Other", remote.publicKey, identity.publicKey));
-	transport.receive(peer, { v: 1, type: "nickname-update", nickname: "Renamed" });
-	assert.match(session.snapshot().peers[0]?.label ?? "", /^Renamed~/u);
-	for (let index = 0; index < 7; index += 1) {
-		transport.receive(peer, { v: 1, type: "chat", text: "flood", sentAt: 1, id: `f${index}` });
-	}
-	assert.equal(peer.closed, true);
+	assert.equal(session.snapshot().composerOpen, false);
 });
 
 test("leave is idempotent and ignores late transport continuations", async () => {
-	const { remote, transport, session } = fixture();
+	const { transport, session } = fixture();
 	await session.start();
-	const peer = new FakePeer(remote.publicKey);
+	const peer = new FakePeer(createIdentity(Buffer.alloc(32, 2)).publicKey);
 	transport.connect(peer);
 	await Promise.all([session.leave(), session.leave()]);
 	transport.connect(new FakePeer(Buffer.alloc(32, 8)));
 	assert.equal(transport.stopped, true);
 	assert.equal(session.snapshot().state, "disconnected");
-	assert.equal(session.snapshot().peers.length, 0);
+	assert.equal(session.snapshot().participants.length, 0);
 });
-
-function peerHello(
-	room: ReturnType<typeof createPrivateRoom>,
-	nickname: string,
-	sender: Buffer,
-	receiver: Buffer,
-	nonce = Buffer.alloc(16, 3),
-) {
-	return importHello(room, nickname, sender, receiver, nonce);
-}
-
-import { createHello as importHello } from "../src/protocol.js";

--- a/packages/pi-chat/test/chat-view.test.ts
+++ b/packages/pi-chat/test/chat-view.test.ts
@@ -14,7 +14,9 @@ function snapshot(overrides: Partial<ChatSnapshot> = {}): ChatSnapshot {
 		state: "connected",
 		room,
 		localLabel: "Me~AAAA-BBBB-CCCC",
-		peers: [],
+		participants: [],
+		directNeighbors: 0,
+		participantCatalogFull: false,
 		transcript: [],
 		unread: 0,
 		composerOpen: false,
@@ -40,7 +42,10 @@ test("sanitizes terminal and bidi controls before line handling", () => {
 test("privacy-safe widget hides message text by default and bounds every line", () => {
 	const state = snapshot({
 		unread: 2,
-		peers: [{ publicKey: "1", label: "Other~AAAA-BBBB-CCCC", nickname: "Other", muted: false }],
+		participants: [
+			{ publicKey: "1", label: "Other~AAAA-BBBB-CCCC", nickname: "Other", muted: false },
+		],
+		directNeighbors: 1,
 		transcript: [
 			{
 				id: "1",
@@ -84,7 +89,10 @@ test("room dock keeps status, bounded recent messages, and the real input target
 			) => string[]
 		)(state, "dock", width, theme, rows);
 	const state = snapshot({
-		peers: [{ publicKey: "1", label: "Other~AAAA-BBBB-CCCC", nickname: "Other", muted: false }],
+		participants: [
+			{ publicKey: "1", label: "Other~AAAA-BBBB-CCCC", nickname: "Other", muted: false },
+		],
+		directNeighbors: 1,
 		transcript,
 	});
 	const wide = renderDock(state, 64, 30);
@@ -128,22 +136,23 @@ test("room dock distinguishes joining, waiting, and degraded partial connectivit
 	);
 	assert.match(joining.join("\n"), /joining/u);
 	const waiting = renderChatWidget(snapshot(), "dock" as never, 48, theme as never);
-	assert.match(waiting.join("\n"), /waiting for peers/u);
+	assert.match(waiting.join("\n"), /waiting for neighbors/u);
 	const degraded = renderChatWidget(
 		snapshot({
 			state: "degraded",
-			peers: [{ publicKey: "1", label: "Other~AAAA", nickname: "Other", muted: false }],
+			participants: [{ publicKey: "1", label: "Other~AAAA", nickname: "Other", muted: false }],
+			directNeighbors: 1,
 		}),
 		"dock" as never,
 		48,
 		theme as never,
 	);
-	assert.match(degraded.join("\n"), /reconnecting[\s\S]*1 direct peer/u);
+	assert.match(degraded.join("\n"), /reconnecting[\s\S]*1 direct neighbor/u);
 });
 
 test("chat composer makes its target explicit, preserves failed drafts, and clears successful sends", () => {
 	let current = snapshot();
-	let deliveredTo = 0;
+	let relayedTo = 0;
 	let sendError: Error | undefined;
 	const sent: string[] = [];
 	const drafts: string[] = [];
@@ -160,7 +169,7 @@ test("chat composer makes its target explicit, preserves failed drafts, and clea
 		send: (text) => {
 			if (sendError) throw sendError;
 			sent.push(text);
-			return { id: "sent", deliveredTo };
+			return { id: "sent", relayedTo };
 		},
 		initialDraft: "",
 		onDraftChange: (text) => drafts.push(text),
@@ -180,10 +189,13 @@ test("chat composer makes its target explicit, preserves failed drafts, and clea
 	view.handleInput("\r");
 	assert.deepEqual(sent, []);
 	assert.equal(drafts.at(-1), "hello");
-	assert.match(view.render(48).join("\n"), /message kept/i);
+	assert.match(view.render(48).join("\n"), /message kep/i);
 
 	current = snapshot({
-		peers: [{ publicKey: "1", label: "開發者~AAAA-BBBB-CCCC", nickname: "開發者", muted: false }],
+		participants: [
+			{ publicKey: "1", label: "開發者~AAAA-BBBB-CCCC", nickname: "開發者", muted: false },
+		],
+		directNeighbors: 1,
 		transcript: [
 			{
 				id: "1",
@@ -198,14 +210,14 @@ test("chat composer makes its target explicit, preserves failed drafts, and clea
 	view.handleInput("\r");
 	assert.deepEqual(sent, ["hello"]);
 	assert.equal(drafts.at(-1), "hello");
-	assert.match(view.render(48).join("\n"), /message kept/i);
+	assert.match(view.render(48).join("\n"), /message kep/i);
 	sendError = new Error("Message is too large");
 	view.handleInput("\r");
 	assert.deepEqual(sent, ["hello"]);
 	assert.equal(drafts.at(-1), "hello");
 	assert.match(view.render(48).join("\n"), /too large/i);
 	sendError = undefined;
-	deliveredTo = 1;
+	relayedTo = 1;
 	view.handleInput("\r");
 	assert.deepEqual(sent, ["hello", "hello"]);
 	assert.equal(drafts.at(-1), "");
@@ -238,7 +250,7 @@ test("owner abort closes the composer without recording a user return", () => {
 		tui: { terminal: { rows: 20 }, requestRender() {} } as never,
 		theme: theme as never,
 		getSnapshot: () => snapshot(),
-		send: () => ({ id: "sent", deliveredTo: 0 }),
+		send: () => ({ id: "sent", relayedTo: 0 }),
 		setViewOpen: (open) => viewStates.push(open),
 		signal: controller.signal,
 		onReturnToPi: () => returnedToPi++,
@@ -258,7 +270,7 @@ test("chat composer restores retained drafts and host disposal does not record a
 		tui: { terminal: { rows: 8 }, requestRender() {} } as never,
 		theme: theme as never,
 		getSnapshot: () => snapshot(),
-		send: () => ({ id: "sent", deliveredTo: 0 }),
+		send: () => ({ id: "sent", relayedTo: 0 }),
 		initialDraft: draft,
 		onDraftChange: (text) => {
 			draft = text;

--- a/packages/pi-chat/test/directory.test.ts
+++ b/packages/pi-chat/test/directory.test.ts
@@ -114,6 +114,28 @@ test("catalog applies signed leaving records, expires heartbeats, and marks boun
 	assert.deepEqual(catalog.snapshot().rooms, []);
 });
 
+test("catalog retains departure ordering against delayed online records", () => {
+	const catalog = new DirectoryCatalog({ now: () => 10_002 });
+	const identity = scoped(1, "pi-dev");
+	const initial = createDirectoryPresence(identity, "pi-dev", "online", 10_000, "initial");
+	const leaving = createDirectoryPresence(identity, "pi-dev", "leaving", 10_002, "z");
+	const delayedByTime = createDirectoryPresence(
+		identity,
+		"pi-dev",
+		"online",
+		10_001,
+		"delayed-time",
+	);
+	const delayedById = createDirectoryPresence(identity, "pi-dev", "online", 10_002, "a");
+
+	assert.equal(catalog.accept(initial), true);
+	assert.equal(catalog.accept(leaving), true);
+	assert.equal(catalog.accept(delayedByTime), false);
+	assert.equal(catalog.accept(delayedById), false);
+	assert.deepEqual(catalog.snapshot().rooms, []);
+	assert.deepEqual(catalog.currentEvents(), [leaving]);
+});
+
 test("sort helper is deterministic and does not mutate caller state", () => {
 	const rooms = [
 		{ slug: "zeta", estimatedParticipants: 1 },

--- a/packages/pi-chat/test/directory.test.ts
+++ b/packages/pi-chat/test/directory.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import createTestnet from "hyperdht/testnet.js";
+import {
+	type DirectoryTransport,
+	type DirectoryTransportListener,
+	HyperswarmDirectoryTransport,
+	PublicRoomDirectorySession,
+} from "../src/directory-network.js";
+import { createIdentity, deriveScopedIdentity } from "../src/identity.js";
+import { MAX_FRAME_BYTES, MAX_GOSSIP_HOPS } from "../src/protocol.js";
+import {
+	createDirectoryPresence,
+	createDirectoryWireMessage,
+	DirectoryCatalog,
+	DirectoryFrameDecoder,
+	encodeDirectoryFrame,
+	parseDirectoryWireMessage,
+	sortDirectoryRooms,
+	verifyDirectoryPresence,
+} from "../src/public-room-directory.js";
+
+function scoped(seed: number, slug: string) {
+	return deriveScopedIdentity(createIdentity(Buffer.alloc(32, seed)), `directory:#${slug}`);
+}
+
+class IdleDirectoryTransport implements DirectoryTransport {
+	listener: DirectoryTransportListener | undefined;
+	started = 0;
+	refreshed = 0;
+	stopped = 0;
+	async start(listener: DirectoryTransportListener): Promise<void> {
+		this.listener = listener;
+		this.started += 1;
+	}
+	async refresh(): Promise<void> {
+		this.refreshed += 1;
+	}
+	async stop(): Promise<void> {
+		this.stopped += 1;
+	}
+}
+
+test("directory presence is room-scoped, signed, and mutation resistant", () => {
+	const identity = scoped(1, "pi-dev");
+	const event = createDirectoryPresence(identity, "pi-dev", "online", 10_000, "event-1");
+	assert.equal(verifyDirectoryPresence(event, 10_000), true);
+	assert.equal(verifyDirectoryPresence({ ...event, slug: "other" }, 10_000), false);
+	assert.equal(verifyDirectoryPresence({ ...event, origin: "00".repeat(32) }, 10_000), false);
+	assert.equal(verifyDirectoryPresence(event, 1_000_000), false);
+	assert.throws(
+		() => createDirectoryPresence(identity, "Invalid Room", "online", 1, "bad"),
+		/public room slug/u,
+	);
+});
+
+test("directory frames bound hops and payload bytes before buffering", () => {
+	const event = createDirectoryPresence(scoped(1, "pi-dev"), "pi-dev", "online", 10_000, "wire");
+	const message = createDirectoryWireMessage(event);
+	const encoded = encodeDirectoryFrame(message);
+	const decoder = new DirectoryFrameDecoder();
+	assert.deepEqual(decoder.push(encoded.subarray(0, 3)), []);
+	assert.deepEqual(decoder.push(encoded.subarray(3)), [message]);
+	assert.equal(parseDirectoryWireMessage({ ...message, hops: 0 }), undefined);
+	assert.equal(parseDirectoryWireMessage({ ...message, partial: false }), undefined);
+	assert.equal(parseDirectoryWireMessage({ ...message, hops: MAX_GOSSIP_HOPS + 1 }), undefined);
+	const oversized = Buffer.alloc(4);
+	oversized.writeUInt32BE(MAX_FRAME_BYTES + 1);
+	assert.throws(() => new DirectoryFrameDecoder().push(oversized), /exceeds/u);
+});
+
+test("catalog deduplicates origins and sorts count descending then slug ascending", () => {
+	const catalog = new DirectoryCatalog({ now: () => 10_000 });
+	const first = createDirectoryPresence(scoped(1, "pi-dev"), "pi-dev", "online", 10_000, "a");
+	const duplicate = { ...first };
+	const second = createDirectoryPresence(scoped(2, "pi-dev"), "pi-dev", "online", 10_000, "b");
+	const alpha = createDirectoryPresence(scoped(3, "alpha"), "alpha", "online", 10_000, "c");
+	const beta = createDirectoryPresence(scoped(4, "beta"), "beta", "online", 10_000, "d");
+	assert.equal(catalog.accept(first), true);
+	assert.equal(catalog.accept(duplicate), false);
+	assert.equal(catalog.accept(second), true);
+	assert.equal(catalog.accept(beta), true);
+	assert.equal(catalog.accept(alpha), true);
+	assert.deepEqual(catalog.snapshot().rooms, [
+		{ slug: "pi-dev", estimatedParticipants: 2 },
+		{ slug: "alpha", estimatedParticipants: 1 },
+		{ slug: "beta", estimatedParticipants: 1 },
+	]);
+});
+
+test("catalog applies signed leaving records, expires heartbeats, and marks bounded results partial", () => {
+	let now = 10_000;
+	const catalog = new DirectoryCatalog({ now: () => now, maxRecords: 2 });
+	const firstIdentity = scoped(1, "one");
+	assert.equal(
+		catalog.accept(createDirectoryPresence(firstIdentity, "one", "online", now, "one-online")),
+		true,
+	);
+	assert.equal(
+		catalog.accept(createDirectoryPresence(scoped(2, "two"), "two", "online", now, "two")),
+		true,
+	);
+	assert.equal(
+		catalog.accept(createDirectoryPresence(scoped(3, "three"), "three", "online", now, "three")),
+		false,
+	);
+	assert.equal(catalog.snapshot().partial, true);
+	assert.equal(
+		catalog.accept(createDirectoryPresence(firstIdentity, "one", "leaving", now + 1, "one-left")),
+		true,
+	);
+	assert.deepEqual(catalog.snapshot().rooms, [{ slug: "two", estimatedParticipants: 1 }]);
+	now += 100_000;
+	assert.deepEqual(catalog.snapshot().rooms, []);
+});
+
+test("sort helper is deterministic and does not mutate caller state", () => {
+	const rooms = [
+		{ slug: "zeta", estimatedParticipants: 1 },
+		{ slug: "alpha", estimatedParticipants: 1 },
+		{ slug: "busy", estimatedParticipants: 9 },
+	];
+	assert.deepEqual(sortDirectoryRooms(rooms), [rooms[2], rooms[1], rooms[0]]);
+	assert.equal(rooms[0]?.slug, "zeta");
+});
+
+test("temporary browsing aborts and stops every owned directory resource", async () => {
+	const transport = new IdleDirectoryTransport();
+	const directory = new PublicRoomDirectorySession({
+		identity: createIdentity(Buffer.alloc(32, 8)),
+		transport,
+	});
+	const controller = new AbortController();
+	const browsing = directory.browse(controller.signal, 60_000);
+	controller.abort(new DOMException("Menu disposed", "AbortError"));
+	await assert.rejects(browsing, /Menu disposed/u);
+	assert.equal(transport.started, 1);
+	assert.equal(transport.stopped, 1);
+});
+
+test("local DHT directory discovers two scoped advertisers and fully stops", {
+	timeout: 20_000,
+}, async () => {
+	const testnet = await createTestnet(4);
+	const makeDirectory = (seed: number, slug?: string) => {
+		const identity = slug ? scoped(seed, slug) : createIdentity(Buffer.alloc(32, seed));
+		return new PublicRoomDirectorySession({
+			identity,
+			...(slug ? { advertisedSlug: slug } : {}),
+			transport: new HyperswarmDirectoryTransport({
+				identity,
+				dht: testnet.createNode({ firewalled: false }),
+			}),
+		});
+	};
+	const first = makeDirectory(10, "pi-dev");
+	const second = makeDirectory(11, "pi-dev");
+	const browser = makeDirectory(12);
+	try {
+		await Promise.all([first.start(), second.start()]);
+		const result = await browser.browse(new AbortController().signal, 1_500);
+		assert.deepEqual(result.rooms, [{ slug: "pi-dev", estimatedParticipants: 2 }]);
+	} finally {
+		await Promise.allSettled([first.stop(), second.stop(), browser.stop()]);
+		await testnet.destroy();
+	}
+});

--- a/packages/pi-chat/test/identity.test.ts
+++ b/packages/pi-chat/test/identity.test.ts
@@ -2,9 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
 	createIdentity,
+	deriveScopedIdentity,
 	formatIdentityLabel,
 	identityTag,
 	normalizeNickname,
+	signIdentityPayload,
+	verifyIdentityPayload,
 } from "../src/identity.js";
 
 const SEED = Buffer.from("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "hex");
@@ -35,4 +38,20 @@ test("creates deterministic DHT identity material from a 32-byte seed", () => {
 	assert.deepEqual(first.publicKey, second.publicKey);
 	assert.equal(first.tag, second.tag);
 	assert.throws(() => createIdentity(Buffer.alloc(31)), /32-byte/u);
+});
+
+test("signs immutable payloads and derives unlinkable stable scoped identities", () => {
+	const identity = createIdentity(SEED);
+	const payload = Buffer.from("pi-chat signed payload", "utf8");
+	const signature = signIdentityPayload(identity, payload);
+	assert.equal(verifyIdentityPayload(identity.publicKey, payload, signature), true);
+	assert.equal(verifyIdentityPayload(identity.publicKey, Buffer.from("mutated"), signature), false);
+	assert.equal(verifyIdentityPayload(Buffer.alloc(32, 9), payload, signature), false);
+
+	const first = deriveScopedIdentity(identity, "directory:#pi-dev");
+	const repeated = deriveScopedIdentity(identity, "directory:#pi-dev");
+	const other = deriveScopedIdentity(identity, "directory:#typescript");
+	assert.deepEqual(first.publicKey, repeated.publicKey);
+	assert.notDeepEqual(first.publicKey, identity.publicKey);
+	assert.notDeepEqual(first.publicKey, other.publicKey);
 });

--- a/packages/pi-chat/test/menu.test.ts
+++ b/packages/pi-chat/test/menu.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { createMockContext } from "../../../test/support.js";
 import { type ChatMenuSource, createChatMenu } from "../src/menu.js";
 import { createPrivateRoom } from "../src/protocol.js";
+import type { PublicRoomBrowseResult } from "../src/public-room-directory.js";
 
 function source(overrides: Partial<ChatMenuSource> = {}): ChatMenuSource {
 	return {
@@ -11,6 +12,7 @@ function source(overrides: Partial<ChatMenuSource> = {}): ChatMenuSource {
 		getSnapshot: () => undefined,
 		getRestoreError: () => undefined,
 		createPrivateRoom: () => createPrivateRoom(Buffer.alloc(32, 1)),
+		browsePublicRooms: async (): Promise<PublicRoomBrowseResult> => ({ rooms: [], partial: false }),
 		joinRoom: async () => true,
 		openChat: async () => undefined,
 		retryRememberedRoom: async () => undefined,
@@ -42,7 +44,15 @@ test("manager keeps disconnected and connected primary actions shallow", async (
 	if (first.kind === "actions") {
 		assert.deepEqual(
 			first.items.map(({ label }) => label),
-			["Join public room", "Join with invite", "Create private room", "Settings", "Status", "Help"],
+			[
+				"Browse public rooms",
+				"Join public room",
+				"Join with invite",
+				"Create private room",
+				"Settings",
+				"Status",
+				"Help",
+			],
 		);
 	}
 	const connected = createChatMenu(
@@ -51,7 +61,9 @@ test("manager keeps disconnected and connected primary actions shallow", async (
 				state: "connected",
 				room: createPrivateRoom(Buffer.alloc(32, 1)),
 				localLabel: "Mika~AAAA-BBBB-CCCC",
-				peers: [],
+				participants: [],
+				directNeighbors: 0,
+				participantCatalogFull: false,
 				transcript: [],
 				unread: 0,
 				composerOpen: false,
@@ -70,7 +82,94 @@ test("manager keeps disconnected and connected primary actions shallow", async (
 	}
 	const inviteScreen = connected.menu.screens.invite({ state });
 	assert.equal(inviteScreen.kind, "review");
-	if (inviteScreen.kind === "review") assert.match(inviteScreen.content, /^pichat:v1:/u);
+	if (inviteScreen.kind === "review") assert.match(inviteScreen.content, /^pichat:v2:/u);
+});
+
+test("public-room browser sorts estimates, marks partial results, and joins a selected room", async () => {
+	const joined: string[] = [];
+	let opened = 0;
+	const controller = createChatMenu(
+		source({
+			browsePublicRooms: async () => ({
+				rooms: [
+					{ slug: "quiet", estimatedParticipants: 1 },
+					{ slug: "busy", estimatedParticipants: 9 },
+					{ slug: "alpha", estimatedParticipants: 1 },
+				],
+				partial: true,
+			}),
+			joinRoom: async (room) => {
+				joined.push(room.label);
+				return true;
+			},
+			openChat: async () => void opened++,
+		}),
+	);
+	const ctx = createMockContext({ hasUI: true, mode: "tui", confirm: async () => true });
+	assert.deepEqual(await controller.menu.actions.browse(actionContext(ctx.ctx)), {
+		kind: "to",
+		screen: "publicRooms",
+	});
+	const screen = controller.menu.screens.publicRooms({ state: await controller.getState() });
+	assert.equal(screen.kind, "choice");
+	if (screen.kind === "choice") {
+		assert.match(screen.lines?.join("\n") ?? "", /estimated.*partial/iu);
+		assert.deepEqual(
+			screen.items.slice(0, 3).map(({ label }) => label),
+			["#busy", "#alpha", "#quiet"],
+		);
+		assert.deepEqual(
+			screen.items.slice(0, 3).map(({ description }) => description),
+			["~9 active", "~1 active", "~1 active"],
+		);
+	}
+	assert.deepEqual(
+		await controller.menu.actions.selectPublicRoom(actionContext(ctx.ctx, undefined, "room:busy")),
+		{ kind: "close" },
+	);
+	assert.deepEqual(joined, ["#busy"]);
+	assert.equal(opened, 1);
+});
+
+test("public-room browser keeps retry and manual recovery for empty and failed discovery", async () => {
+	let attempts = 0;
+	const controller = createChatMenu(
+		source({
+			browsePublicRooms: async () => {
+				attempts += 1;
+				if (attempts === 1) throw new Error("directory unavailable");
+				return { rooms: [], partial: false };
+			},
+		}),
+	);
+	const ctx = createMockContext({ hasUI: true, mode: "tui" });
+	assert.equal((await controller.menu.actions.browse(actionContext(ctx.ctx)))?.kind, "to");
+	let screen = controller.menu.screens.publicRooms({ state: await controller.getState() });
+	assert.equal(screen.kind, "choice");
+	if (screen.kind === "choice") {
+		assert.match(screen.lines?.join("\n") ?? "", /directory unavailable/u);
+		assert.deepEqual(
+			screen.items.map(({ label }) => label),
+			["Retry discovery", "Enter room slug"],
+		);
+	}
+	assert.equal(
+		(
+			await controller.menu.actions.selectPublicRoom(
+				actionContext(ctx.ctx, undefined, "route:refresh"),
+			)
+		)?.kind,
+		"to",
+	);
+	screen = controller.menu.screens.publicRooms({ state: await controller.getState() });
+	if (screen.kind === "choice")
+		assert.match(screen.lines?.join("\n") ?? "", /No active public rooms/u);
+	assert.deepEqual(
+		await controller.menu.actions.selectPublicRoom(
+			actionContext(ctx.ctx, undefined, "route:manual"),
+		),
+		{ kind: "to", screen: "joinPublic" },
+	);
 });
 
 test("invite and public input actions validate payloads and successful joins open chat", async () => {
@@ -158,7 +257,7 @@ test("remembered restore failures expose shallow retry, replacement, and forget 
 	if (replacement.kind === "actions") {
 		assert.deepEqual(
 			replacement.items.map(({ label }) => label),
-			["Join public room", "Join with invite", "Create private room"],
+			["Browse public rooms", "Join public room", "Join with invite", "Create private room"],
 		);
 	}
 });

--- a/packages/pi-chat/test/network-peer-fixture.ts
+++ b/packages/pi-chat/test/network-peer-fixture.ts
@@ -20,7 +20,7 @@ const session = new ChatSession({
 	onChange: (snapshot) => {
 		process.send?.({
 			kind: "snapshot",
-			peers: snapshot.peers.length,
+			peers: snapshot.participants.length,
 			texts: snapshot.transcript.map(({ text }) => text),
 		});
 	},

--- a/packages/pi-chat/test/network.test.ts
+++ b/packages/pi-chat/test/network.test.ts
@@ -5,8 +5,16 @@ import { fileURLToPath } from "node:url";
 import createTestnet from "hyperdht/testnet.js";
 import { ChatSession } from "../src/chat-session.js";
 import { createIdentity } from "../src/identity.js";
-import { HyperswarmTransport } from "../src/network.js";
+import { directNeighborLimit, HyperswarmTransport, MAX_DIRECT_NEIGHBORS } from "../src/network.js";
 import { createPrivateRoom, createPublicRoom } from "../src/protocol.js";
+
+test("room overlays clamp every requested direct-neighbor limit to eight", () => {
+	assert.equal(MAX_DIRECT_NEIGHBORS, 8);
+	assert.equal(directNeighborLimit(), 8);
+	assert.equal(directNeighborLimit(4), 4);
+	assert.equal(directNeighborLimit(64), 8);
+	assert.equal(directNeighborLimit(-1), 8);
+});
 
 test("three local DHT peers discover, authenticate, exchange, and fully stop", {
 	timeout: 20_000,
@@ -34,23 +42,23 @@ test("three local DHT peers discover, authenticate, exchange, and fully stop", {
 	try {
 		await Promise.all(sessions.map(({ session }) => session.start()));
 		await waitFor(
-			() => sessions.every(({ session }) => session.snapshot().peers.length === 2),
+			() => sessions.every(({ session }) => session.snapshot().participants.length === 2),
 			() =>
 				sessions
 					.map(({ session, transport }) => {
 						const snapshot = session.snapshot();
-						return `${snapshot.state}:${snapshot.peers.length}:${transport.connectionCount}:${snapshot.lastError ?? "ok"}`;
+						return `${snapshot.state}:${snapshot.participants.length}:${transport.connectionCount}:${snapshot.lastError ?? "ok"}`;
 					})
 					.join(","),
 		);
 		const sender = sessions[0];
 		assert.ok(sender);
-		assert.equal(sender.session.send("hello mesh").deliveredTo, 2);
+		assert.equal(sender.session.send("hello gossip").relayedTo, 2);
 		await waitFor(() =>
 			sessions
 				.slice(1)
 				.every(({ session }) =>
-					session.snapshot().transcript.some((entry) => entry.text === "hello mesh"),
+					session.snapshot().transcript.some((entry) => entry.text === "hello gossip"),
 				),
 		);
 	} finally {
@@ -61,6 +69,81 @@ test("three local DHT peers discover, authenticate, exchange, and fully stop", {
 		sessions.every(({ transport }) => transport.connectionCount === 0),
 		true,
 	);
+});
+
+test("ten-peer sparse overlay relays once through a non-origin intermediate", {
+	timeout: 35_000,
+}, async () => {
+	const testnet = await createTestnet(4);
+	const room = createPublicRoom("sparse-gossip");
+	const sessions = Array.from({ length: 10 }, (_, index) => {
+		const identity = createIdentity(Buffer.alloc(32, index + 31));
+		const transport = new HyperswarmTransport({
+			room,
+			identity,
+			dht: testnet.createNode({ firewalled: false }),
+			maxPeers: 64,
+		});
+		return {
+			identity,
+			transport,
+			session: new ChatSession({
+				room,
+				identity,
+				nickname: `Sparse${index + 1}`,
+				transport,
+			}),
+		};
+	});
+	try {
+		await Promise.all(sessions.map(({ session }) => session.start()));
+		await waitFor(
+			() => sessions.every(({ session }) => session.snapshot().participants.length === 9),
+			() =>
+				sessions
+					.map(
+						({ session, transport }) =>
+							`${session.snapshot().participants.length}/${transport.connectionCount}`,
+					)
+					.join(","),
+			20_000,
+		);
+		assert.equal(
+			sessions.every(({ transport }) => transport.connectionCount <= 8),
+			true,
+		);
+		const sender = sessions[0];
+		assert.ok(sender);
+		const indirect = sessions
+			.slice(1)
+			.find(
+				({ identity }) =>
+					!sender.transport.connectedPeerKeys.includes(identity.publicKey.toString("hex")),
+			);
+		assert.ok(indirect, "the sender must have at least one non-neighbor in a ten-peer room");
+		sender.session.send("through sparse overlay");
+		await waitFor(
+			() =>
+				indirect.session
+					.snapshot()
+					.transcript.filter(({ text }) => text === "through sparse overlay").length === 1,
+			() =>
+				`${sender.transport.connectionCount}:${indirect.transport.connectionCount}:${indirect.session.snapshot().transcript.length}`,
+			8_000,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		assert.equal(
+			sessions.every(
+				({ session }) =>
+					session.snapshot().transcript.filter(({ text }) => text === "through sparse overlay")
+						.length === 1,
+			),
+			true,
+		);
+	} finally {
+		await Promise.allSettled(sessions.map(({ session }) => session.leave()));
+		await testnet.destroy();
+	}
 });
 
 test("early discovery retries recover after initial DHT lookups miss peers", {
@@ -82,8 +165,8 @@ test("early discovery retries recover after initial DHT lookups miss peers", {
 	try {
 		await Promise.all(sessions.map((session) => session.start()));
 		await waitFor(
-			() => sessions.every((session) => session.snapshot().peers.length === 1),
-			() => sessions.map((session) => session.snapshot().peers.length).join(","),
+			() => sessions.every((session) => session.snapshot().participants.length === 1),
+			() => sessions.map((session) => session.snapshot().participants.length).join(","),
 			8_000,
 		);
 	} finally {
@@ -118,8 +201,8 @@ test("a completed startup releases its caller signal without leaving the room", 
 		controller.abort(new DOMException("Menu closed", "AbortError"));
 		await sessions[1]?.start();
 		await waitFor(
-			() => sessions.every((session) => session.snapshot().peers.length === 1),
-			() => sessions.map((session) => session.snapshot().peers.length).join(","),
+			() => sessions.every((session) => session.snapshot().participants.length === 1),
+			() => sessions.map((session) => session.snapshot().participants.length).join(","),
 			5_000,
 		);
 	} finally {

--- a/packages/pi-chat/test/pi-chat.test.ts
+++ b/packages/pi-chat/test/pi-chat.test.ts
@@ -9,9 +9,46 @@ import {
 	createMockPi,
 } from "../../../test/support.js";
 import type { ChatTransport } from "../src/chat-session.js";
-import { createPiChatExtension } from "../src/pi-chat.js";
+import type { PublicRoomDirectory } from "../src/directory-network.js";
+import {
+	createPiChatExtension as createProductionPiChatExtension,
+	type PiChatDependencies,
+} from "../src/pi-chat.js";
 import { createPrivateRoom, createPublicRoom } from "../src/protocol.js";
+import type { PublicRoomBrowseResult } from "../src/public-room-directory.js";
 import { updateChatSettings } from "../src/settings.js";
+
+class IdleDirectory implements PublicRoomDirectory {
+	started = 0;
+	browsed = 0;
+	stopped = 0;
+	result: PublicRoomBrowseResult = { rooms: [], partial: false };
+	async start(): Promise<void> {
+		this.started += 1;
+	}
+	async browse(signal: AbortSignal): Promise<PublicRoomBrowseResult> {
+		this.browsed += 1;
+		signal.throwIfAborted();
+		return this.result;
+	}
+	async stop(): Promise<void> {
+		if (this.stopped === 0) this.stopped = 1;
+	}
+}
+
+function createPiChatExtension(dependencies: Partial<PiChatDependencies> = {}) {
+	return createProductionPiChatExtension({
+		...dependencies,
+		createDirectory: dependencies.createDirectory ?? (() => new IdleDirectory()),
+	});
+}
+
+class FailingDirectory extends IdleDirectory {
+	override async start(): Promise<void> {
+		this.started += 1;
+		throw new Error("directory bootstrap unavailable");
+	}
+}
 
 class IdleTransport implements ChatTransport {
 	started = 0;
@@ -225,6 +262,146 @@ test("direct public join creates identity only after confirmation and shutdown c
 		assert.equal(transport.stopped, 1);
 		assert.equal(ctx.widgets.get("chat"), undefined);
 		assert.equal(ctx.statuses.get("chat"), undefined);
+	});
+});
+
+test("public joins own a scoped directory advertiser while private joins do not", async () => {
+	await fixture(async (settingsPath) => {
+		await updateChatSettings(
+			{
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 18).toString("base64url"),
+				widgetMode: "count",
+			},
+			{ settingsPath },
+		);
+		const directory = new IdleDirectory();
+		const advertised: Array<string | undefined> = [];
+		const mock = createMockPi();
+		createPiChatExtension({
+			settingsPath,
+			createTransport: () => new IdleTransport(),
+			createDirectory: (options) => {
+				advertised.push(options.advertisedSlug);
+				return directory;
+			},
+		})(mock.pi);
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			confirm: async () => true,
+			custom: async () => undefined,
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await mock.commands.get("chat")?.handler("#pi-dev", ctx.ctx);
+		await waitFor(() => directory.started === 1);
+		assert.deepEqual(advertised, ["pi-dev"]);
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+		assert.equal(directory.stopped, 1);
+	});
+
+	await fixture(async (settingsPath) => {
+		await updateChatSettings(
+			{
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 19).toString("base64url"),
+				widgetMode: "count",
+			},
+			{ settingsPath },
+		);
+		let directories = 0;
+		const mock = createMockPi();
+		createPiChatExtension({
+			settingsPath,
+			createTransport: () => new IdleTransport(),
+			createDirectory: () => {
+				directories += 1;
+				return new IdleDirectory();
+			},
+		})(mock.pi);
+		const room = createPrivateRoom(Buffer.alloc(32, 20));
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (_title: string, options: string[]) =>
+				options.find((option) => option.startsWith("Join once")),
+			custom: async () => undefined,
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await mock.commands.get("chat")?.handler(room.invite ?? "", ctx.ctx);
+		assert.equal(directories, 0);
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+	});
+});
+
+test("directory startup failure cleans its resource without disconnecting public chat", async () => {
+	await fixture(async (settingsPath) => {
+		await updateChatSettings(
+			{
+				nickname: "Mika",
+				identitySeed: Buffer.alloc(32, 27).toString("base64url"),
+				widgetMode: "count",
+			},
+			{ settingsPath },
+		);
+		const transport = new IdleTransport();
+		const directory = new FailingDirectory();
+		const mock = createMockPi();
+		createPiChatExtension({
+			settingsPath,
+			createTransport: () => transport,
+			createDirectory: () => directory,
+		})(mock.pi);
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			confirm: async () => true,
+			custom: async () => undefined,
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await mock.commands.get("chat")?.handler("#pi-dev", ctx.ctx);
+		await waitFor(() =>
+			ctx.notifications.some(({ message }) => /directory bootstrap unavailable/u.test(message)),
+		);
+		assert.equal(directory.stopped, 1);
+		assert.equal(transport.stopped, 0);
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
+		assert.equal(transport.stopped, 1);
+	});
+});
+
+test("disconnected room browsing stops its temporary directory after the menu closes", async () => {
+	await fixture(async (settingsPath) => {
+		const directory = new IdleDirectory();
+		directory.result = {
+			rooms: [{ slug: "pi-dev", estimatedParticipants: 2 }],
+			partial: false,
+		};
+		const mock = createMockPi();
+		createPiChatExtension({ settingsPath, createDirectory: () => directory })(mock.pi);
+		let mainOpened = false;
+		const ctx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory);
+				if (!harness.isPiTuiKitScreen) return harness.result;
+				const rendered = harness.render().join("\n");
+				if (!mainOpened && /Browse public rooms/u.test(rendered)) {
+					mainOpened = true;
+					harness.handleInput("tui.select.confirm");
+					await harness.waitForPending();
+					return harness.result;
+				}
+				harness.handleInput("\u0003");
+				return harness.result;
+			},
+		});
+		await emit(mock, "session_start", { reason: "startup" }, ctx.ctx);
+		await mock.commands.get("chat")?.handler("", ctx.ctx);
+		assert.equal(directory.browsed, 1);
+		assert.equal(directory.stopped, 1);
+		await emit(mock, "session_shutdown", { reason: "quit" }, ctx.ctx);
 	});
 });
 

--- a/packages/pi-chat/test/protocol.test.ts
+++ b/packages/pi-chat/test/protocol.test.ts
@@ -1,32 +1,38 @@
 import assert from "node:assert/strict";
 import { randomBytes } from "node:crypto";
 import test from "node:test";
+import { createIdentity } from "../src/identity.js";
 import {
-	createChatMessage,
+	createChatEvent,
+	createGossipMessage,
 	createHello,
+	createPresenceEvent,
 	createPrivateRoom,
 	createPublicRoom,
 	encodeFrame,
 	FrameDecoder,
 	MAX_FRAME_BYTES,
+	MAX_GOSSIP_HOPS,
 	MAX_MESSAGE_BYTES,
 	PeerRateLimiter,
 	parseInvite,
 	parseProtocolMessage,
 	verifyHello,
+	verifyRoomEvent,
 } from "../src/protocol.js";
 
 const alice = Buffer.alloc(32, 1);
 const bob = Buffer.alloc(32, 2);
 
-test("private invites round-trip while public slugs are normalized and bounded", () => {
+test("v2 private invites round-trip while v1 inputs migrate to the v2 room", () => {
 	const secret = Buffer.alloc(32, 9);
 	const room = createPrivateRoom(secret);
-	assert.equal(room.invite, `pichat:v1:${secret.toString("base64url")}`);
+	assert.equal(room.invite, `pichat:v2:${secret.toString("base64url")}`);
 	assert.deepEqual(parseInvite(room.invite), room);
+	assert.deepEqual(parseInvite(`pichat:v1:${secret.toString("base64url")}`), room);
 	assert.equal(createPublicRoom("pi-dev").label, "#pi-dev");
 	assert.throws(() => createPublicRoom("Pi Dev"), /public room slug/u);
-	assert.throws(() => parseInvite("pichat:v2:nope"), /valid Pi Chat invite/u);
+	assert.throws(() => parseInvite("pichat:v3:nope"), /valid Pi Chat invite/u);
 });
 
 test("private hello proves room possession and binds both authenticated peer keys", () => {
@@ -38,7 +44,9 @@ test("private hello proves room possession and binds both authenticated peer key
 });
 
 test("length-prefixed decoder handles chunks and rejects oversized frames before buffering them", () => {
-	const message = createChatMessage("hello", 10, "id-1");
+	const room = createPublicRoom("pi-dev");
+	const identity = createIdentity(Buffer.alloc(32, 7));
+	const message = createGossipMessage(createChatEvent(room, identity, "Mika", "hello", 10, "id-1"));
 	const encoded = encodeFrame(message);
 	const decoder = new FrameDecoder();
 	assert.deepEqual(decoder.push(encoded.subarray(0, 2)), []);
@@ -51,8 +59,19 @@ test("length-prefixed decoder handles chunks and rejects oversized frames before
 });
 
 test("decoder accepts multiple valid frames coalesced beyond one frame's size limit", () => {
+	const room = createPublicRoom("coalesced");
+	const identity = createIdentity(Buffer.alloc(32, 8));
 	const messages = Array.from({ length: 5 }, (_, index) =>
-		createChatMessage("x".repeat(MAX_MESSAGE_BYTES), 10 + index, `coalesced-${index}`),
+		createGossipMessage(
+			createChatEvent(
+				room,
+				identity,
+				"Mika",
+				"x".repeat(MAX_MESSAGE_BYTES),
+				10 + index,
+				`coalesced-${index}`,
+			),
+		),
 	);
 	const coalesced = Buffer.concat(messages.map((message) => encodeFrame(message)));
 	assert.ok(coalesced.length > MAX_FRAME_BYTES + 4);
@@ -64,17 +83,35 @@ test("decoder rejects invalid UTF-8 before JSON parsing", () => {
 	assert.throws(() => new FrameDecoder().push(frame), /UTF-8/u);
 });
 
-test("chat parsing bounds text and rejects unknown or malformed payloads", () => {
-	assert.deepEqual(parseProtocolMessage(createChatMessage("hello", 10, "id-1")), {
-		v: 1,
-		type: "chat",
-		text: "hello",
-		sentAt: 10,
-		id: "id-1",
-	});
-	assert.throws(() => createChatMessage("x".repeat(MAX_MESSAGE_BYTES + 1), 1, "id"), /too large/u);
-	assert.equal(parseProtocolMessage({ v: 1, type: "admin", text: "oops" }), undefined);
-	assert.equal(parseProtocolMessage({ v: 2, type: "chat", text: "oops" }), undefined);
+test("signed room events reject mutation, wrong rooms, stale clocks, and invalid hop budgets", () => {
+	const room = createPublicRoom("pi-dev");
+	const otherRoom = createPublicRoom("other");
+	const identity = createIdentity(Buffer.alloc(32, 7));
+	const event = createChatEvent(room, identity, "Mika", "hello", 10_000, "id-1");
+	assert.equal(verifyRoomEvent(event, room, 10_000), true);
+	assert.equal(verifyRoomEvent(event, otherRoom, 10_000), false);
+	assert.equal(verifyRoomEvent({ ...event, text: "mutated" }, room, 10_000), false);
+	assert.equal(verifyRoomEvent(event, room, 1_000_000), false);
+	assert.throws(
+		() => createChatEvent(room, identity, "Mika", "x".repeat(MAX_MESSAGE_BYTES + 1), 1, "id"),
+		/too large/u,
+	);
+	assert.equal(createGossipMessage(event).hops, MAX_GOSSIP_HOPS);
+	assert.equal(parseProtocolMessage({ ...createGossipMessage(event), hops: 0 }), undefined);
+	assert.equal(
+		parseProtocolMessage({ ...createGossipMessage(event), hops: MAX_GOSSIP_HOPS + 1 }),
+		undefined,
+	);
+	assert.equal(parseProtocolMessage({ v: 1, type: "gossip", event, hops: 1 }), undefined);
+});
+
+test("presence events authenticate nickname and state", () => {
+	const room = createPublicRoom("presence");
+	const identity = createIdentity(Buffer.alloc(32, 6));
+	const event = createPresenceEvent(room, identity, "Mika", "online", 100, "presence-1");
+	assert.equal(verifyRoomEvent(event, room, 100), true);
+	assert.equal(parseProtocolMessage(createGossipMessage(event))?.type, "gossip");
+	assert.equal(verifyRoomEvent({ ...event, nickname: "Mallory" }, room, 100), false);
 });
 
 test("per-peer limiter permits a burst and refills without unbounded state", () => {

--- a/packages/pi-chat/test/settings.test.ts
+++ b/packages/pi-chat/test/settings.test.ts
@@ -3,7 +3,7 @@ import { chmod, lstat, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { createPrivateRoom, createPublicRoom } from "../src/protocol.js";
+import { createPrivateRoom, createPublicRoom, legacyRoomId } from "../src/protocol.js";
 import {
 	CHAT_SETTINGS_FILE,
 	type ChatResumeSettings,
@@ -110,6 +110,66 @@ test("resume updates preserve nested unknown fields and explicit clearing remove
 		const cleared = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
 		assert.equal(Object.hasOwn(cleared, "resume"), false);
 		assert.deepEqual(cleared.future, { keep: true });
+	});
+});
+
+test("v1 room ids and invites migrate in memory without side effects and preserve unknown fields", async () => {
+	await withSettings(async (path) => {
+		const publicRoom = createPublicRoom("legacy-public");
+		const privateRoom = createPrivateRoom(Buffer.alloc(32, 24));
+		const publicLegacyId = legacyRoomId(publicRoom);
+		const privateLegacyId = legacyRoomId(privateRoom);
+		assert.ok(publicLegacyId);
+		assert.ok(privateLegacyId);
+		const v1Invite = (privateRoom.invite ?? "").replace("pichat:v2:", "pichat:v1:");
+		const document = {
+			nickname: "Legacy",
+			identitySeed: Buffer.alloc(32, 25).toString("base64url"),
+			resume: {
+				rooms: [
+					{
+						id: publicLegacyId,
+						kind: "public",
+						slug: "legacy-public",
+						roomFuture: "keep-public",
+					},
+					{
+						id: privateLegacyId,
+						kind: "private",
+						invite: v1Invite,
+						roomFuture: "keep-private",
+					},
+				],
+				activeRoomId: privateLegacyId,
+				surface: "pi",
+				resumeFuture: true,
+			},
+		};
+		await updateChatSettings({ nickname: "Legacy" }, { settingsPath: path });
+		await writeFile(path, JSON.stringify(document), { mode: 0o600 });
+		const before = await readFile(path, "utf8");
+		const loaded = await readChatSettings(path);
+		assert.equal(loaded.kind, "loaded");
+		if (loaded.kind !== "loaded" || !loaded.settings.resume) return;
+		assert.deepEqual(
+			loaded.settings.resume.rooms.map(({ id }) => id),
+			[publicRoom.id, privateRoom.id],
+		);
+		assert.equal(loaded.settings.resume.activeRoomId, privateRoom.id);
+		assert.equal(await readFile(path, "utf8"), before);
+
+		await updateChatSettings({ resume: loaded.settings.resume }, { settingsPath: path });
+		const migrated = JSON.parse(await readFile(path, "utf8")) as {
+			resume: { rooms: Array<Record<string, unknown>>; resumeFuture: boolean };
+		};
+		assert.deepEqual(
+			migrated.resume.rooms.map(({ id, roomFuture }) => ({ id, roomFuture })),
+			[
+				{ id: publicRoom.id, roomFuture: "keep-public" },
+				{ id: privateRoom.id, roomFuture: "keep-private" },
+			],
+		);
+		assert.equal(migrated.resume.resumeFuture, true);
 	});
 });
 


### PR DESCRIPTION
## Summary

- replace Pi Chat's full mesh with signed protocol-v2 gossip, bounded duplicate suppression, an 8-neighbor overlay, and an approximately 256-participant catalog
- add a P2P public-room directory with estimated participant counts sorted by count and slug, plus retry/manual recovery
- preserve v1 invite and stored-room inputs through side-effect-free v2 normalization, and document delivery, privacy, Sybil, and compatibility limits

## Verification

- `npm run check` — passed (2,461 tests plus Biome, boundaries, and workspace typechecks)
- `just pack chat` — passed; inspected 17-file dry-run tarball
- `PI_OFFLINE=1 pi --no-extensions --no-skills --no-session -e ./packages/pi-chat --list-models __pi_chat_smoke_no_match` — passed
- `npx changeset status` — reports a minor bump for `@narumitw/pi-chat`

## Compatibility

Protocol-v1 full-mesh clients do not interoperate with the v2 gossip overlay. Existing `pichat:v1` invite text and stored v1 room ids remain accepted and are normalized to v2 without a load-time write.
