### PR TITLE
feat(tui-kit): add standalone confirmation

### DIFF
--- a/.changeset/bright-confirmations-return.md
+++ b/.changeset/bright-confirmations-return.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add `runConfirmation()` with distinct Confirmed, Back, Close, Stale, Unsupported, and Error outcomes across TUI and RPC adapters.

--- a/docs/plans/2026-08-08_pi-tui-kit-standalone-confirmation-plan.md
+++ b/docs/plans/2026-08-08_pi-tui-kit-standalone-confirmation-plan.md
@@ -1,0 +1,113 @@
+# Pi TUI Kit Standalone Confirmation Plan
+
+## Goal
+
+Add and publish a bounded standalone confirmation contract that preserves Confirmed, Back, Close,
+Stale, Unsupported, and Error outcomes across Pi modes, then prove it through Image Drop and
+Analytics without moving either extension's domain side effects into Pi TUI Kit.
+
+## Context
+
+- Image Drop already implements `confirmed | cancelled | close` locally so Escape returns to its
+  menu while Ctrl+C closes the whole flow.
+- Analytics currently uses boolean `ctx.ui.confirm()` inside its Kit menu; cancellation stays on the
+  privacy screen, but the boolean contract cannot preserve a TUI Ctrl+C request to close the whole
+  dashboard.
+- Pi RPC confirmation cancellation collapses to `false`; a deterministic Kit `select()` adaptation
+  can preserve explicit Confirm/Cancel choices and map protocol cancellation to Back, while RPC
+  cannot claim a separate Ctrl+C Close event the protocol does not expose.
+- Repository policy requires publishing the Kit API before either consumer raises its compatibility
+  floor. Publication, tags, visibility, and release workflow dispatch remain separately approval
+  gated.
+
+## Architecture
+
+- Add `runConfirmation()` as a standalone Kit helper, not a ninth declarative menu screen.
+- Return `confirmed`, `closed` with the existing `back | close` reason, `stale`, `unsupported`, or
+  `error`; keep all domain mutation after a `confirmed` result in the consumer.
+- In TUI mode, compose the existing standard actions renderer under `runCustomInteraction()` so the
+  Kit reuses width safety, injected theme/keybindings, Ctrl+C handling, disposal, owner cancellation,
+  stale classification, and pending-work draining.
+- In RPC mode, issue one signal-aware `select()` with explicit Confirm and Cancel rows. Explicit
+  Cancel and protocol cancellation map to Back; the adapter does not invent a Close signal.
+- In print/JSON modes, return Unsupported after the optional callback. Revalidate owner state after
+  every await and classify callback/UI failures without publishing stale feedback.
+- Keep title, message, labels, session signal/generation, and every confirmed side effect
+  consumer-owned.
+
+## Non-Goals
+
+- Do not add a generic modal framework, confirmation payload, timeout policy, danger styling, domain
+  action callback, or new declarative screen kind.
+- Do not change ordinary `ctx.ui.confirm()` behavior or existing menu Back/Close behavior.
+- Do not publish or raise a consumer dependency floor without separate explicit approval.
+
+## Risks
+
+- Reusing a standard actions renderer could accidentally expose menu-only behavior. Mitigation:
+  exercise only semantic activate/Back/Close events and keep the helper's public result independent
+  of component internals.
+- RPC cannot distinguish client cancellation reasons. Mitigation: document and test deterministic
+  cancellation-to-Back behavior instead of claiming false parity.
+- A confirmation result could win a race against session replacement. Mitigation: owner abort and
+  `isCurrent()` checks take precedence after every await and before returning a user result.
+- Consumer migrations could appear valid through workspace hoisting before the API exists on npm.
+  Mitigation: keep them in a post-publication step and verify the registry package first.
+
+## Rollback / Recovery
+
+- Before publication, revert the helper, tests, docs, API-version change, and changeset together.
+- After publication, retain the additive Kit API and revert each consumer migration independently;
+  do not lower unrelated consumer compatibility floors automatically.
+
+## Plan
+
+- [x] Add focused `packages/pi-tui-kit/test/confirmation.test.ts` contract tests that initially fail
+      because `runConfirmation()` is absent, covering TUI Confirm/Cancel/Escape/Ctrl+C, RPC
+      Confirm/Cancel/protocol cancellation, terminal sanitization and width, stale owner abort,
+      external disposal, unsupported modes, callback/UI errors, and stale-error suppression. Evidence:
+      package typecheck first failed on the absent export, then the focused compiled Node test passed
+      8/8 after the implementation.
+- [x] Implement `packages/pi-tui-kit/src/confirmation.ts`, export its public options/result types and
+      `runConfirmation()` from `src/index.ts`, and raise the menu API literal to 7. Evidence: package
+      check/typecheck/build passed, generated declarations expose the generic context contract, and all
+      143 Pi TUI Kit tests passed including export and context-usage checks.
+- [x] Update `packages/pi-tui-kit/README.md` with ownership and exact TUI/RPC/non-interactive
+      semantics, add a minor Kit changeset, and update the roadmap's source-complete status without
+      marking the proof milestone complete. Evidence: Changesets resolves Kit to an independent
+      0.50.0 minor; `just pack tui-kit` listed 49 intended files including production/testing roots and
+      `dist/confirmation.{js,d.ts}`; package Biome/typecheck/build and cold RPC import passed.
+- [x] Audit the source-complete diff against `docs/extension-conventions.md`, Pi `extensions.md`,
+      `tui.md`, `rpc.md`, and `packages.md`, including cancellation, component disposal, session
+      replacement, shutdown, post-await revalidation, public-root imports, and zero private `dist/*`
+      imports. Evidence: focused tests cover all named lifecycle paths, await/guard review found owner
+      revalidation at every continuation, and source searches found zero private `dist/*` references
+      and zero coding-agent runtime value imports.
+- [x] Run `npm run check` and the deterministic Kit runtime benchmark/smoke. Evidence: the repository
+      gate passed 2,448/2,448 tests; the five-run benchmark kept `codingAgentLoaded: false` in import,
+      actions, review, and task scenarios (121.04 ms median cold import), and a built RPC confirmation
+      smoke returned `confirmed` through API version 7.
+- [ ] Obtain explicit user approval to publish the new Kit version, then execute and verify the
+      repository's approved release workflow or publication path. Do not infer this approval from the
+      implementation approval.
+- [ ] After the release is visible on npm, migrate Image Drop in a separate bounded change, raise only
+      its reviewed Kit floor, preserve link-rotation Confirm/Back/Close/stale behavior, add its own
+      changeset, and verify focused tests, pack contents, Pi runtime smoke, and `npm run check`.
+- [ ] After the release is visible on npm, migrate Analytics in a separate bounded change, raise only
+      its reviewed Kit floor, preserve side-effect-free Back and committed-clear behavior while making
+      TUI Ctrl+C close the dashboard, add its own changeset, and verify TUI/RPC/stale/error tests, pack
+      contents, Pi runtime smoke, and `npm run check`.
+- [ ] Re-run the two-consumer behavior matrix, mark the roadmap milestone complete with publication
+      and migration evidence, run the final repository gate, and archive this fully checked plan.
+
+## Completion Checklist
+
+- [ ] The published root API exposes one documented standalone confirmation contract with no private
+      Pi imports or consumer domain payloads.
+- [x] Maintained tests prove Confirmed, Back, Close, Stale, Unsupported, and Error, including TUI/RPC
+      limitations, pre-abort, owner abort, external disposal, and stale-error suppression.
+- [ ] Image Drop and Analytics consume the published API through independently reviewable migrations
+      without capability, persistence, cancellation, or non-TUI regressions.
+- [ ] Package dry runs, runtime smokes, the benchmark, and `npm run check` pass for the final state.
+- [ ] The roadmap records stable release/adoption evidence and this plan is archived only after every
+      item above is complete.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -4,8 +4,9 @@
 - **Audience:** Pi TUI Kit maintainers and extension authors
 - **Planning horizon:** The next evidence-qualified capability sequence; no delivery dates are
   committed
-- **Repository source:** Menu API version 6 with read-only browse, lifecycle-safe custom
-  interactions, adaptive review, distinct root Back/Close results, and a supported `/testing` subpath
+- **Repository source:** Menu API version 7 with standalone confirmation, read-only browse,
+  lifecycle-safe custom interactions, adaptive review, distinct root Back/Close results, and a
+  supported `/testing` subpath
 - **Published status:** Derive the current release from the npm badge, registry, and package manifest;
   this roadmap does not pin a transient package version
 - **Migration evidence:** Maintained package/consumer tests and the stable PR references in the
@@ -54,9 +55,10 @@ The package also exposes `runTask()` for abort-aware work with a TUI loader and
 `runCustomInteraction()` for lifecycle ownership around one extension-owned specialized component.
 Published menu API version 6 identifies runtimes that add read-only searchable browse and custom
 interaction lifecycle handling while retaining version-5 adaptive review and distinct root
-Back/Close behavior. The package's separate supported `/testing` subpath provides semantic TUI
-driving and strict RPC scripts without exporting raw components; Stamp and Image Drop completed
-representative adoption before publication.
+Back/Close behavior. Repository source version 7 adds standalone confirmation with deterministic RPC
+Back behavior; publication and Image Drop/Analytics proof migrations remain gated. The package's
+separate supported `/testing` subpath provides semantic TUI driving and strict RPC scripts without
+exporting raw components; Stamp and Image Drop completed representative adoption before publication.
 
 Production and experimental consumers use the Kit alongside direct Pi dialogs. Raw consumer and
 dialog counts are intentionally not pinned here because they change independently of roadmap
@@ -213,8 +215,8 @@ contracts without private component knowledge.
 ### Phase 4: Qualified Shared Flows and Runtime Locality
 
 **Status:** In progress. The internal interaction driver, read-only browse, and custom-interaction
-lifecycle helper are complete; standalone confirmation and deferred multi-select remain independently
-gated follow-ups.
+lifecycle helper are complete. Standalone confirmation is source-complete pending publication and
+Image Drop/Analytics proof migrations; deferred multi-select remains independently gated.
 
 **Milestones:**
 
@@ -315,6 +317,7 @@ abstractions when Pi provides a better stable owner.
 | Runtime action/lifecycle ownership | TUI and RPC formerly coordinated screen actions in separate branches | One internal driver now owns shared semantic action policy; adapters retain presentation lifecycle | Phase 4 source-complete; maintained all-screen matrix plus source diff |
 | Read-only catalog disclosure | Searchable catalogs were specialized | Menu API 6 browse owns bounded cross-mode list/detail presentation without domain actions | Phase 4 published; package matrix and Pi Starship adoption |
 | Specialized custom lifecycle | Consumers repeated cancellation, disposal, stale-owner, and draining logic | `runCustomInteraction()` owns the shared lifecycle shell while components and domain results remain local | Phase 4 published; package tests and Pi Sync adoption |
+| Standalone confirmation | Image Drop locally distinguished confirm, Back, and Close; boolean dialogs collapsed cancellation intent | Source API 7 preserves Confirmed, Back, Close, Stale, Unsupported, and Error without owning side effects | Phase 4 source-complete; publication and Image Drop/Analytics proof migrations pending |
 | Regression gate | Repository CI-equivalent gate at each capability change | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
@@ -364,3 +367,4 @@ and adoption rather than calendar output.
 | 2026-08-01 | Admit the internal semantic interaction driver after the Phase 4 deletion gate. | A seven-screen TUI/RPC matrix proves compatible raw payloads, transitions, errors, cancellation, disposal, and stale ownership; one internal owner replaces mode-specific action resolution without changing exports or API version 5. |
 | 2026-08-02 | Publish menu API 6 with read-only browse, injected static-list keybindings, and `runCustomInteraction()` through PR #520. | Bounded list/detail disclosure and specialized-component lifecycle policy became reusable while catalog data, domain actions, Back/Close values, and side effects stayed consumer-owned. |
 | 2026-08-02 | Adopt API-v6 capabilities in Pi Starship and Pi Sync through PR #522. | Starship Modules now uses browse and Sync custom UI uses the lifecycle helper; both consumers raised only their own compatibility floors and retained domain, settings, cancellation, and non-TUI policy. |
+| 2026-08-08 | Implement source menu API 7 with standalone confirmation; keep publication and proof migrations gated. | Image Drop and Analytics demonstrate compatible Confirm/Back/Close needs. TUI reuses the standard actions renderer and custom-interaction lifecycle shell; RPC cancellation maps deterministically to Back because Pi exposes no separate RPC Ctrl+C dialog result. |

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -161,6 +161,35 @@ if (result.kind === "completed") ctx.ui.notify("Refreshed", "info");
 A task must honor its supplied signal. The runner aborts and drains owned work before returning; it
 does not hide an uncooperative task behind an arbitrary timeout.
 
+For a confirmation nested inside a larger flow, use `runConfirmation()` when Escape must return to
+the caller while Ctrl+C closes the whole TUI interaction:
+
+```ts
+import { runConfirmation } from "@narumitw/pi-tui-kit";
+
+const confirmation = await runConfirmation(ctx, {
+  title: "Delete local data?",
+  message: "This cannot be undone.",
+  confirmLabel: "Delete",
+  cancelLabel: "Keep data",
+  signal: currentSessionSignal(),
+  isCurrent: () => generation === currentGeneration(),
+  onError: (_ctx, error) => ctx.ui.notify(formatError(error), "error"),
+});
+
+if (confirmation.kind === "confirmed") await deleteDomainData();
+else if (confirmation.kind === "closed" && confirmation.reason === "close") return;
+```
+
+TUI confirmation uses the standard bounded actions presentation: selecting the cancel row or pressing
+Escape returns `{ kind: "closed", reason: "back" }`, while Ctrl+C returns the same result with reason
+`"close"`. RPC uses one signal-aware `select()` request with explicit confirm and cancel rows;
+explicit cancel and protocol cancellation deterministically map to Back because Pi RPC does not expose
+a separate Ctrl+C dialog outcome. Print and JSON return `unsupported`. Owner abort, session
+replacement, external TUI disposal, and failures remain distinct `stale` or `error` results. The Kit
+owns only this interaction lifecycle—the caller performs every confirmed side effect and must abort
+its owner signal on replacement or shutdown.
+
 For a specialized custom component that does not belong in the declarative screen union, use
 `runCustomInteraction()`. It supplies an interaction-owned signal, classifies owner replacement and
 external component disposal as stale, disposes exactly once, and drains optional `waitForPending()`
@@ -529,6 +558,8 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `defineMenu()` — validates and returns a typed menu definition.
 - `runMenu()` — runs the definition in the current Pi mode and preserves root Back versus Close.
 - `runTask()` — runs typed abort-aware work with a cancellable TUI loader and direct non-TUI fallback.
+- `runConfirmation()` — preserves Confirmed, Back, Close, Stale, Unsupported, and Error for one
+  standalone confirmation without owning the confirmed side effect.
 - `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending
   work draining, and typed results around one extension-owned custom TUI component.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
@@ -536,9 +567,10 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - exported screen, item, action, transition, runtime option, `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
   strict scripts, and their public testing types; it is not re-exported from the production root.
-- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`6`). Version 6 adds the
-  read-only `browse` screen and `runCustomInteraction()`; version-5 definitions remain valid on the
-  version-6 runtime, including adaptive review and mandatory Back/Close reasons.
+- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`7`). Version 7 adds
+  `runConfirmation()`; version-6 definitions remain valid on the version-7 runtime, including
+  read-only browse, custom-interaction lifecycle ownership, adaptive review, and mandatory Back/Close
+  reasons.
 
 ## 🗂️ Package layout
 
@@ -546,6 +578,7 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `src/components/` — internal TUI input, review, list, settings, and rendering adapters
 - `src/testing/` — supported TUI/RPC test drivers exported only through the `/testing` subpath
 - `src/task.ts` — standalone and menu-shared task lifecycle orchestration
+- `src/confirmation.ts` — standalone confirmation mode adaptation and lifecycle results
 - `src/custom-interaction.ts` — lifecycle ownership for specialized public custom components
 - `dist/` — generated ESM and declarations included in the npm package
 - `test/` — contract, renderer, navigation, lifecycle, and public testing-entrypoint coverage

--- a/packages/pi-tui-kit/src/confirmation.ts
+++ b/packages/pi-tui-kit/src/confirmation.ts
@@ -1,0 +1,174 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { createMenuScreenComponent, safeMenuText } from "./components/index.js";
+import { runCustomInteraction } from "./custom-interaction.js";
+import type { MenuCloseReason, MenuContext } from "./types.js";
+
+type ExtensionMode = MenuContext["mode"];
+type ConfirmationValue = "confirmed" | MenuCloseReason;
+type ConfirmationAction = "confirm" | "back";
+
+export interface RunConfirmationOptions<Context extends MenuContext = ExtensionCommandContext> {
+	title: string;
+	message: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	signal?: AbortSignal;
+	isCurrent?(): boolean;
+	onError?(ctx: Context, error: unknown): void | Promise<void>;
+	onUnsupportedMode?(ctx: Context, mode: ExtensionMode): void | Promise<void>;
+}
+
+export type RunConfirmationResult =
+	| { kind: "confirmed" }
+	| { kind: "closed"; reason: MenuCloseReason }
+	| { kind: "stale" }
+	| { kind: "unsupported"; mode: ExtensionMode }
+	| { kind: "error"; error: unknown };
+
+interface ConfirmationPrompt {
+	title: string;
+	lines: readonly string[];
+	confirmLabel: string;
+	cancelLabel: string;
+}
+
+/** Run one standalone confirmation without absorbing the caller's confirmed side effect. */
+export async function runConfirmation<Context extends MenuContext = ExtensionCommandContext>(
+	ctx: Context,
+	options: RunConfirmationOptions<Context>,
+): Promise<RunConfirmationResult> {
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	const prompt = normalizePrompt(options);
+	if (ctx.mode === "tui" && ctx.hasUI) return runTuiConfirmation(ctx, options, prompt);
+	if (ctx.mode === "rpc" && ctx.hasUI) return runRpcConfirmation(ctx, options, prompt);
+
+	try {
+		await options.onUnsupportedMode?.(ctx, ctx.mode);
+	} catch (error) {
+		return confirmationError(ctx, options, error);
+	}
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	return { kind: "unsupported", mode: ctx.mode };
+}
+
+async function runTuiConfirmation<Context extends MenuContext>(
+	ctx: Context,
+	options: RunConfirmationOptions<Context>,
+	prompt: ConfirmationPrompt,
+): Promise<RunConfirmationResult> {
+	const result = await runCustomInteraction<ConfirmationValue, Context>(ctx, {
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+		onError: (currentCtx, error) => reportConfirmationError(currentCtx, options, error),
+		create: ({ tui, theme, keybindings, complete }) =>
+			createMenuScreenComponent<"confirmation", ConfirmationAction>({
+				screen: {
+					kind: "actions",
+					title: prompt.title,
+					lines: prompt.lines,
+					items: [
+						{ id: "confirm", label: prompt.confirmLabel, action: "confirm" },
+						{ id: "back", label: prompt.cancelLabel, action: "back" },
+					],
+					hint: "back",
+				},
+				selectedItemId: "confirm",
+				tui,
+				theme,
+				keybindings,
+				onEvent: (event) => {
+					if (event.kind === "activate") {
+						complete(event.itemId === "confirm" ? "confirmed" : "back");
+						return;
+					}
+					complete(event.kind);
+				},
+			}),
+	});
+	if (result.kind === "completed") {
+		return result.value === "confirmed"
+			? { kind: "confirmed" }
+			: { kind: "closed", reason: result.value };
+	}
+	return result;
+}
+
+async function runRpcConfirmation<Context extends MenuContext>(
+	ctx: Context,
+	options: RunConfirmationOptions<Context>,
+	prompt: ConfirmationPrompt,
+): Promise<RunConfirmationResult> {
+	let selection: string | undefined;
+	try {
+		selection = await uiFor(ctx).select(
+			[prompt.title, ...prompt.lines].join("\n"),
+			[prompt.confirmLabel, prompt.cancelLabel],
+			{ signal: options.signal },
+		);
+	} catch (error) {
+		return confirmationError(ctx, options, error);
+	}
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	if (selection === prompt.confirmLabel) return { kind: "confirmed" };
+	if (selection === undefined || selection === prompt.cancelLabel) {
+		return { kind: "closed", reason: "back" };
+	}
+	return confirmationError(
+		ctx,
+		options,
+		new Error("Confirmation dialog returned an option that was not offered"),
+	);
+}
+
+function normalizePrompt<Context extends MenuContext>(
+	options: RunConfirmationOptions<Context>,
+): ConfirmationPrompt {
+	const title = safeMenuText(options.title) || "Confirm";
+	const lines = options.message.split(/\r?\n/u).map(safeMenuText);
+	const confirmLabel = safeMenuText(options.confirmLabel ?? "Confirm") || "Confirm";
+	let cancelLabel = safeMenuText(options.cancelLabel ?? "Cancel") || "Cancel";
+	if (cancelLabel === confirmLabel) cancelLabel = `${cancelLabel} [2]`;
+	return { title, lines, confirmLabel, cancelLabel };
+}
+
+async function confirmationError<Context extends MenuContext>(
+	ctx: Context,
+	options: RunConfirmationOptions<Context>,
+	error: unknown,
+): Promise<RunConfirmationResult> {
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	await reportConfirmationError(ctx, options, error);
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	return { kind: "error", error };
+}
+
+async function reportConfirmationError<Context extends MenuContext>(
+	ctx: Context,
+	options: RunConfirmationOptions<Context>,
+	error: unknown,
+): Promise<void> {
+	let reported = false;
+	if (options.onError) {
+		try {
+			await options.onError(ctx, error);
+			reported = true;
+		} catch {
+			// Fall through to Pi's notifier when a custom reporter is unavailable.
+		}
+	}
+	if (reported || !ctx.hasUI || !isCurrent(options) || options.signal?.aborted) return;
+	const message = error instanceof Error ? error.message : String(error);
+	try {
+		uiFor(ctx).notify(`Confirmation failed: ${safeMenuText(message)}`, "error");
+	} catch {
+		// Error reporting must not change the typed result.
+	}
+}
+
+function isCurrent<Context extends MenuContext>(options: RunConfirmationOptions<Context>) {
+	return options.isCurrent?.() ?? true;
+}
+
+function uiFor(ctx: MenuContext): ExtensionCommandContext["ui"] {
+	return ctx.ui as ExtensionCommandContext["ui"];
+}

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -1,4 +1,9 @@
 export {
+	type RunConfirmationOptions,
+	type RunConfirmationResult,
+	runConfirmation,
+} from "./confirmation.js";
+export {
 	type CustomInteractionComponent,
 	type CustomInteractionContext,
 	type RunCustomInteractionOptions,
@@ -37,4 +42,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 6;
+export const PI_EXTENSION_MENU_API_VERSION = 7;

--- a/packages/pi-tui-kit/test/confirmation.test.ts
+++ b/packages/pi-tui-kit/test/confirmation.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { stripVTControlCharacters } from "node:util";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createMockContext } from "../../../test/support.js";
+import { runConfirmation } from "../src/index.js";
+import { createRpcHarness, createTuiHarness } from "../src/testing/index.js";
+
+const prompt = {
+	title: "Delete local data?",
+	message: "This cannot be undone.",
+};
+
+test("runConfirmation preserves TUI Confirm, Cancel, Back, and Close intent", async () => {
+	async function drive(input: "confirm" | "cancel-row" | "tui.select.cancel" | "ctrl+c") {
+		const tui = createTuiHarness({ width: 48, rows: 20 });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = runConfirmation(context.ctx, prompt);
+		await tui.waitForOpen();
+		if (input === "cancel-row") {
+			tui.press("tui.select.down");
+			tui.press("tui.select.confirm");
+		} else if (input === "confirm") {
+			tui.press("tui.select.confirm");
+		} else {
+			tui.press(input);
+		}
+		return running;
+	}
+
+	assert.deepEqual(await drive("confirm"), { kind: "confirmed" });
+	assert.deepEqual(await drive("cancel-row"), { kind: "closed", reason: "back" });
+	assert.deepEqual(await drive("tui.select.cancel"), { kind: "closed", reason: "back" });
+	assert.deepEqual(await drive("ctrl+c"), { kind: "closed", reason: "close" });
+});
+
+test("runConfirmation sanitizes and bounds its TUI frame", async () => {
+	const tui = createTuiHarness({ width: 24, rows: 20 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runConfirmation(context.ctx, {
+		title: "Delete\u001b[31m data?",
+		message: "First line\n\nSecond\u0007 line with a long explanation",
+		confirmLabel: "Apply\u001b[2J",
+		cancelLabel: "Keep current data",
+	});
+	await tui.waitForOpen();
+	const frame = tui.render();
+	const plain = stripVTControlCharacters(frame.join("\n"));
+	assert.equal(plain.includes("\u001b"), false);
+	assert.equal(plain.includes("\u0007"), false);
+	assert.match(plain, /Delete.*data\?/u);
+	assert.match(plain, /First line/u);
+	assert.match(plain, /Second.*line/u);
+	for (const line of frame) assert.ok(visibleWidth(line) <= 24);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});
+
+test("runConfirmation uses deterministic RPC select semantics", async () => {
+	async function drive(response: "Proceed" | "Keep" | undefined) {
+		const rpc = createRpcHarness([
+			{
+				kind: "select",
+				title: "Rotate link?\nCurrent link will stop working.\n\nOpen clients must reconnect.",
+				options: ["Proceed", "Keep"],
+				response,
+			},
+		]);
+		const base = createMockContext({ mode: "rpc", hasUI: true }).ctx as unknown as {
+			ui: Record<string, unknown>;
+			[key: string]: unknown;
+		};
+		const ctx = { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+		const result = await runConfirmation(ctx, {
+			title: "Rotate link?",
+			message: "Current link will stop working.\n\nOpen clients must reconnect.",
+			confirmLabel: "Proceed",
+			cancelLabel: "Keep",
+		});
+		rpc.assertConsumed();
+		return result;
+	}
+
+	assert.deepEqual(await drive("Proceed"), { kind: "confirmed" });
+	assert.deepEqual(await drive("Keep"), { kind: "closed", reason: "back" });
+	assert.deepEqual(await drive(undefined), { kind: "closed", reason: "back" });
+});
+
+test("runConfirmation gives stale ownership precedence in TUI and RPC", async () => {
+	const tuiOwner = new AbortController();
+	const tui = createTuiHarness();
+	const tuiContext = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const tuiRunning = runConfirmation(tuiContext.ctx, { ...prompt, signal: tuiOwner.signal });
+	await tui.waitForOpen();
+	tuiOwner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await tuiRunning, { kind: "stale" });
+
+	const rpcOwner = new AbortController();
+	const rpc = createRpcHarness([{ kind: "select", waitForAbort: true }]);
+	const base = createMockContext({ mode: "rpc", hasUI: true }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const rpcContext = { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+	const rpcRunning = runConfirmation(rpcContext, { ...prompt, signal: rpcOwner.signal });
+	await rpc.waitForCall();
+	rpcOwner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await rpcRunning, { kind: "stale" });
+	rpc.assertConsumed();
+});
+
+test("runConfirmation classifies external TUI disposal as stale", async () => {
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runConfirmation(context.ctx, prompt);
+	await tui.waitForOpen();
+	tui.dispose();
+	assert.deepEqual(await running, { kind: "stale" });
+});
+
+test("runConfirmation reports unsupported modes and callback failures", async () => {
+	let unsupportedMode = "";
+	const printContext = createMockContext({ mode: "print", hasUI: false });
+	assert.deepEqual(
+		await runConfirmation(printContext.ctx, {
+			...prompt,
+			onUnsupportedMode: (_ctx, mode) => {
+				unsupportedMode = mode;
+			},
+		}),
+		{ kind: "unsupported", mode: "print" },
+	);
+	assert.equal(unsupportedMode, "print");
+
+	const failure = new Error("Unsupported reporter failed");
+	let reported: unknown;
+	assert.deepEqual(
+		await runConfirmation(printContext.ctx, {
+			...prompt,
+			onUnsupportedMode: () => {
+				throw failure;
+			},
+			onError: (_ctx, error) => {
+				reported = error;
+			},
+		}),
+		{ kind: "error", error: failure },
+	);
+	assert.equal(reported, failure);
+});
+
+test("runConfirmation reports current UI errors and suppresses stale feedback", async () => {
+	const failure = new Error("Dialog failed");
+	let reports = 0;
+	const report = (_ctx: unknown, error: unknown) => {
+		reports += 1;
+		assert.equal(error, failure);
+	};
+	const currentRpc = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			throw failure;
+		},
+	});
+	assert.deepEqual(await runConfirmation(currentRpc.ctx, { ...prompt, onError: report }), {
+		kind: "error",
+		error: failure,
+	});
+	const currentTui = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async () => {
+			throw failure;
+		},
+	});
+	assert.deepEqual(await runConfirmation(currentTui.ctx, { ...prompt, onError: report }), {
+		kind: "error",
+		error: failure,
+	});
+
+	let isCurrent = true;
+	let release: () => void = () => undefined;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const stale = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			await gate;
+			throw failure;
+		},
+	});
+	const running = runConfirmation(stale.ctx, {
+		...prompt,
+		isCurrent: () => isCurrent,
+		onError: () => {
+			reports += 1;
+		},
+	});
+	isCurrent = false;
+	release();
+	assert.deepEqual(await running, { kind: "stale" });
+	assert.equal(reports, 2);
+});
+
+test("runConfirmation rejects stale ownership before opening any UI", async () => {
+	const owner = new AbortController();
+	owner.abort(new DOMException("Session shut down", "AbortError"));
+	let uiCalls = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async () => {
+			uiCalls += 1;
+		},
+	});
+	assert.deepEqual(await runConfirmation(context.ctx, { ...prompt, signal: owner.signal }), {
+		kind: "stale",
+	});
+	assert.equal(uiCalls, 0);
+});

--- a/packages/pi-tui-kit/test/context-usage.ts
+++ b/packages/pi-tui-kit/test/context-usage.ts
@@ -5,9 +5,11 @@ import {
 	type InputScreen,
 	type MenuCloseReason,
 	type ReviewScreen,
+	type RunConfirmationResult,
 	type RunCustomInteractionResult,
 	type RunMenuResult,
 	type RunTaskResult,
+	runConfirmation,
 	runCustomInteraction,
 	runMenu,
 	runTask,
@@ -147,6 +149,23 @@ const commandTask: Promise<RunTaskResult<number>> = runTask(commandContext, {
 	},
 });
 void commandTask;
+
+const commandConfirmation: Promise<RunConfirmationResult> = runConfirmation(commandContext, {
+	title: "Confirm command",
+	message: "Continue?",
+	onUnsupportedMode: async (ctx) => ctx.waitForIdle(),
+});
+void commandConfirmation;
+
+void runConfirmation(lifecycleContext, {
+	title: "Confirm lifecycle",
+	message: "Continue?",
+	onUnsupportedMode: async (ctx) => {
+		ctx.isIdle();
+		// @ts-expect-error Lifecycle confirmations must not gain command-only session methods.
+		await ctx.waitForIdle();
+	},
+});
 
 const commandInteraction: Promise<RunCustomInteractionResult<string>> = runCustomInteraction(
 	commandContext,

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -38,8 +38,8 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("browse uses declarative API version 6", () => {
-	assert.equal(PI_EXTENSION_MENU_API_VERSION, 6);
+test("package exposes declarative API version 7", () => {
+	assert.equal(PI_EXTENSION_MENU_API_VERSION, 7);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/testing-exports.test.ts
+++ b/packages/pi-tui-kit/test/testing-exports.test.ts
@@ -11,7 +11,8 @@ test("built package roots resolve separate production and testing exports", asyn
 	const testingSpecifier = "@narumitw/pi-tui-kit/testing";
 	const production = await import(productionSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 6);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 7);
+	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");
 	assert.equal("createTuiHarness" in production, false);
 	assert.equal("createRpcHarness" in production, false);
@@ -25,7 +26,7 @@ test("built package roots resolve separate production and testing exports", asyn
 		path.join(fixture, "usage.ts"),
 		`import { PI_EXTENSION_MENU_API_VERSION } from "@narumitw/pi-tui-kit";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 6 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const version: 7 = PI_EXTENSION_MENU_API_VERSION;\n` +
 			`void version;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
 	);
 	writeFileSync(


### PR DESCRIPTION
## Summary

- add `runConfirmation()` with typed Confirmed, Back, Close, Stale, Unsupported, and Error outcomes
- preserve TUI Escape/Ctrl+C intent and define deterministic RPC cancellation-to-Back behavior
- document API version 7, lifecycle ownership, and consumer migration gates
- add focused TUI/RPC/lifecycle tests and a minor `@narumitw/pi-tui-kit` changeset

## Verification

- `npm run check` (2,462 tests passed)
- `just pack tui-kit` (49 intended files, including confirmation JS/declarations)
- five-run TUI Kit runtime benchmark (`codingAgentLoaded: false`; 121.04 ms median cold import)
- built RPC confirmation smoke (API 7; one select call; confirmed result)

## Release sequence

This PR publishes only the source and release intent. After merge, the approved Changesets workflow should create/update the version PR for `@narumitw/pi-tui-kit` 0.50.0. Image Drop and Analytics migrations remain separate post-publication changes.
