### PR TITLE
feat(pi-tui-kit): explain disabled action rows

### DIFF
--- a/.changeset/gentle-actions-explain.md
+++ b/.changeset/gentle-actions-explain.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add disabled reasons and adaptive, ellipsis-safe labels for action rows in TUI and RPC menus.

--- a/docs/plans/archived/2026-08-08_pi-tui-kit-disabled-action-presentation-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-tui-kit-disabled-action-presentation-plan.md
@@ -67,8 +67,8 @@ existing navigation, and the guarantee that disabled actions never execute.
       public `disabledReason` contract, sanitized cross-mode formatting, adaptive public `SelectList`
       layout, and ellipsis-based truncation; focused component and runtime tests pass.
 - [x] Run the complete `@narumitw/pi-tui-kit` test and typecheck surface after the focused tests;
-      package check passed and all 139 Kit tests passed, including action, choice, multi-select,
-      navigation, sanitization, width, and built-export contracts.
+      package check passed and all 147 Kit tests passed after rebasing, including action, choice,
+      confirmation, multi-select, navigation, sanitization, width, and built-export contracts.
 - [x] Update `packages/pi-tui-kit/README.md` with disabled action behavior and an example, then bump
       `PI_EXTENSION_MENU_API_VERSION` in `packages/pi-tui-kit/src/index.ts` to 8 and document version
       compatibility; source and built-export type fixtures pass with literal version 8 after rebasing
@@ -76,9 +76,15 @@ existing navigation, and the guarantee that disabled actions never execute.
 - [x] Add `.changeset/gentle-actions-explain.md` as a minor Changeset for
       `@narumitw/pi-tui-kit`; `npm run changeset:status` reports the planned `0.50.0` release.
 - [x] Run `npm run check:boundaries`, `npm run check`, and `just pack tui-kit`; boundaries passed,
-      the CI-equivalent gate passed all 2,458 tests on the latest `origin/main`, and the 47-file dry-run
-      tarball contains built JavaScript/declarations, README, license, and package metadata without
-      tests or authored source.
+      the CI-equivalent gate passed all 2,491 tests on the rebased `origin/main`, and the 49-file
+      dry-run tarball contains built JavaScript/declarations, README, license, and package metadata
+      without tests or authored source.
+- [x] Resolve both PR review findings with red-green regression evidence: selected disabled reasons
+      now remain visible when action descriptions collapse at narrow widths, and multi-select action
+      rows now use cell-aware ellipsis truncation instead of ambiguous fragments.
+- [x] Rebase over the independently merged standalone-confirmation API, retain its exports/docs/tests,
+      and advance this feature to declarative API version 8; all conflicts are resolved and the
+      combined package checks pass.
 - [x] Audit the final diff against `docs/extension-conventions.md` for the touched reusable-library,
       TUI, documentation, testing, and publishing rules; public Pi TUI primitives, width/sanitization
       contracts, minor release intent, package contents, and consumer independence conform with no

--- a/docs/plans/archived/2026-08-08_pi-tui-kit-disabled-action-presentation-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-tui-kit-disabled-action-presentation-plan.md
@@ -1,0 +1,115 @@
+# Pi TUI Kit disabled action presentation
+
+## Goal
+
+Make disabled action rows consistently understandable and width-safe in Pi TUI Kit without forcing
+consumers to append status text such as `(unavailable)` to action labels. Preserve raw item identity,
+existing navigation, and the guarantee that disabled actions never execute.
+
+## Context
+
+- `ActionMenuItem` currently accepts `disabled` but not `disabledReason`.
+- TUI action screens pass labels and descriptions directly to Pi's public `SelectList`. Its default
+  primary column is capped near 32 cells and silently truncates longer labels, which can produce
+  fragments such as `(una` even when the terminal has room for both columns.
+- Action-screen rendering blocks disabled activation but does not render a textual disabled state.
+  RPC action rows have the same presentation gap. `ActionMenuItem` is also used for action rows inside
+  multi-select screens, so the public contract must behave consistently in both owners.
+- Choice and multi-select toggle rows already establish the Kit convention of `[-]`, `unavailable`,
+  and an optional reason.
+
+## Architecture
+
+- Extend the public `ActionMenuItem` contract with optional `disabledReason`, scoped to action rows
+  rather than all `MenuItemBase` consumers.
+- Keep consumer-provided labels semantic and stable. The Kit will derive presentation-only disabled
+  markers and descriptions after sanitization:
+  - TUI: prefix a disabled row with `[-]`; when `disabledReason` is supplied, combine
+    `Unavailable: reason` with any existing description. Keep an existing description unchanged when
+    no separate reason is supplied.
+  - RPC: when `disabledReason` is supplied, include the disabled state and reason in the unique dialog
+    label because RPC selectors have no native disabled-row presentation. Preserve the existing label
+    for legacy disabled definitions without a reason so exact RPC scripts remain compatible.
+- Configure the public Pi `SelectList` layout for action screens so the primary column adapts to the
+  rendered labels. Preserve description space when both columns fit; when they do not, prioritize a
+  recognizable action label and use a cell-aware ellipsis instead of silent partial text.
+- Apply the disabled-action contract to both top-level `actions` screens and `multiSelect.actions`.
+  Existing interaction guards remain the authority that prevents activation.
+- Treat this as declarative menu API version 8 and a backward-compatible minor release of
+  `@narumitw/pi-tui-kit`. Version-7 definitions remain valid; version 7 was assigned to the
+  independently merged standalone-confirmation API before this branch rebased.
+
+## Non-Goals
+
+- Do not change choice, settings, browse, review, input, or multi-select toggle semantics.
+- Do not add wrapping action rows or a new custom list primitive when Pi's public `SelectList` layout
+  hooks are sufficient.
+- Do not modify `pi-usage` or raise any consumer's Kit dependency floor in this change. Consumers may
+  adopt the published API only after the Kit release is available.
+- Do not change action IDs, action dispatch, screen transitions, cursor restoration, or Back/Close
+  behavior.
+
+## Plan
+
+- [x] Add focused failing contracts in `packages/pi-tui-kit/test/screen-components.test.ts` for a
+      long disabled action label with an existing description and sanitized `disabledReason`; initial
+      `tsc -p tsconfig.test.json` failed because `disabledReason` was absent, and the passing contracts
+      cover widths 1, 24, 40, 41, 80, and 120 plus inert activation.
+- [x] Add focused failing runtime contracts in `packages/pi-tui-kit/test/runtime.test.ts` for RPC
+      disabled action rows; the passing contract verifies the unavailable reason, inert selection,
+      recovery through Close, and raw target identity.
+- [x] Add focused failing multi-select coverage in
+      `packages/pi-tui-kit/test/screen-components.test.ts` and `packages/pi-tui-kit/test/runtime.test.ts`
+      for disabled `multiSelect.actions`; the passing contracts preserve toggle semantics and verify
+      sanitized marker/reason presentation plus inert TUI/RPC activation.
+- [x] Update `packages/pi-tui-kit/src/types.ts`, the action and multi-select component adapters under
+      `packages/pi-tui-kit/src/components/`, and `packages/pi-tui-kit/src/runtime.ts` to implement the
+      public `disabledReason` contract, sanitized cross-mode formatting, adaptive public `SelectList`
+      layout, and ellipsis-based truncation; focused component and runtime tests pass.
+- [x] Run the complete `@narumitw/pi-tui-kit` test and typecheck surface after the focused tests;
+      package check passed and all 139 Kit tests passed, including action, choice, multi-select,
+      navigation, sanitization, width, and built-export contracts.
+- [x] Update `packages/pi-tui-kit/README.md` with disabled action behavior and an example, then bump
+      `PI_EXTENSION_MENU_API_VERSION` in `packages/pi-tui-kit/src/index.ts` to 8 and document version
+      compatibility; source and built-export type fixtures pass with literal version 8 after rebasing
+      over the independently merged version-7 confirmation API.
+- [x] Add `.changeset/gentle-actions-explain.md` as a minor Changeset for
+      `@narumitw/pi-tui-kit`; `npm run changeset:status` reports the planned `0.50.0` release.
+- [x] Run `npm run check:boundaries`, `npm run check`, and `just pack tui-kit`; boundaries passed,
+      the CI-equivalent gate passed all 2,458 tests on the latest `origin/main`, and the 47-file dry-run
+      tarball contains built JavaScript/declarations, README, license, and package metadata without
+      tests or authored source.
+- [x] Audit the final diff against `docs/extension-conventions.md` for the touched reusable-library,
+      TUI, documentation, testing, and publishing rules; public Pi TUI primitives, width/sanitization
+      contracts, minor release intent, package contents, and consumer independence conform with no
+      accepted deviations or skipped applicable smokes. Settings and lifecycle rules are not touched.
+
+## Risks
+
+- Growing the primary column too aggressively could hide useful descriptions. Width tests cover
+  narrow, boundary, and wide layouts and assert both label recognition and description visibility
+  where both fit. Full-suite regressions established that a generic `Unavailable` description must
+  not displace existing copy and that reason-less RPC labels must remain exact for pre-version-8
+  consumers.
+- RPC cannot truly disable a selector row. It must clearly label the row and safely reject selection
+  without invoking domain code or trapping the user.
+- `ActionMenuItem` also powers multi-select action rows; implementing only top-level action rendering
+  would create an inconsistent public API.
+
+## Completion Checklist
+
+- [x] Disabled top-level and multi-select action rows expose a sanitized textual state in TUI and,
+      when a reason is supplied, the state and reason in RPC; focused component/runtime contracts
+      cover both owners while legacy reason-less RPC labels remain compatible.
+- [x] Disabled action rows remain focusable/explainable but cannot invoke navigation, close, or domain
+      actions; existing interaction guards and cross-mode inert-selection tests verify the boundary.
+- [x] Long action labels no longer end in ambiguous fragments when space is available, and unavoidable
+      truncation uses an ellipsis while every rendered line remains within widths 1 through 120 in
+      focused boundary cases.
+- [x] Existing action descriptions, selection memory, transitions, cancellation, and Back/Close
+      behavior remain compatible; the full suite includes the recovered Starship description case.
+- [x] API version 8, README, declaration output, minor Changeset, package contents, and repository
+      checks agree with the shipped public behavior after rebasing over the version-7 confirmation
+      API.
+- [x] No consumer adopts the API before the corresponding Kit release is published; the final source
+      diff is confined to Pi TUI Kit, its tests/docs, release intent, and this plan.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -238,10 +238,11 @@ content after invalidation, and bound rendered output to the supplied terminal w
 the screen's Back/Close hint; `Ctrl+C` closes the menu.
 
 Disabled action rows stay visible and focusable for context but never navigate, close, or invoke a
-domain action. Set `disabledReason` to explain why. TUI prefixes the semantic label with `[-]`, shows
-a supplied unavailable reason beside any existing description, and adapts the primary column to
-available width; unavoidable label truncation uses an ellipsis. When a reason is supplied, RPC adds
-the unavailable state and reason to its selector label; legacy disabled rows without a reason keep
+domain action. Set `disabledReason` to explain why. TUI prefixes the semantic label with `[-]`, keeps
+a supplied unavailable reason visible below the selected row at every width, and adapts the primary
+column to available width; unavoidable action-label truncation uses an ellipsis. When a reason is
+supplied, RPC adds the unavailable state and reason to its selector label; legacy disabled rows
+without a reason keep
 their existing RPC label. This contract also applies to action rows under `multiSelect.actions`.
 
 ```ts

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -217,8 +217,8 @@ const result = await runCustomInteraction<{ kind: "back" | "close" }>(ctx, {
 
 `defineMenu()` supports eight standard screen kinds:
 
-- **`actions`** — navigation targets, domain actions, close rows, and optional cancellable busy
-  labels.
+- **`actions`** — navigation targets, domain actions, close rows, optional cancellable busy labels,
+  adaptive long-label columns, and disabled explanations.
 - **`detail`** — read-only wrapped text with Back or Close behavior.
 - **`browse`** — a read-only searchable catalog with textual status, adaptive list/detail views,
   stable selection restoration, and paginated RPC details.
@@ -236,6 +236,24 @@ const result = await runCustomInteraction<{ kind: "back" | "close" }>(ctx, {
 All standard TUI screens use Pi's injected keybindings, sanitize display text, rebuild themed
 content after invalidation, and bound rendered output to the supplied terminal width. Escape follows
 the screen's Back/Close hint; `Ctrl+C` closes the menu.
+
+Disabled action rows stay visible and focusable for context but never navigate, close, or invoke a
+domain action. Set `disabledReason` to explain why. TUI prefixes the semantic label with `[-]`, shows
+a supplied unavailable reason beside any existing description, and adapts the primary column to
+available width; unavoidable label truncation uses an ellipsis. When a reason is supplied, RPC adds
+the unavailable state and reason to its selector label; legacy disabled rows without a reason keep
+their existing RPC label. This contract also applies to action rows under `multiSelect.actions`.
+
+```ts
+const resetAction = {
+  id: "redeem-reset",
+  label: "Redeem usage limit reset…",
+  description: "Current Codex account",
+  disabled: availableResetCount === 0,
+  disabledReason: availableResetCount === 0 ? "No resets available" : undefined,
+  action: "redeemReset" as const,
+};
+```
 
 Choice screens are for bounded static alternatives rather than actions that run while the cursor
 moves. `currentItemId` adds the textual current marker; `initialItemId` controls the first cursor when
@@ -567,10 +585,10 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - exported screen, item, action, transition, runtime option, `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
   strict scripts, and their public testing types; it is not re-exported from the production root.
-- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`7`). Version 7 adds
-  `runConfirmation()`; version-6 definitions remain valid on the version-7 runtime, including
-  read-only browse, custom-interaction lifecycle ownership, adaptive review, and mandatory Back/Close
-  reasons.
+- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`8`). Version 8 adds disabled
+  action reasons and adaptive action-label columns; version-7 definitions remain valid on the
+  version-8 runtime. Version 7 added `runConfirmation()`, and version 6 added the read-only `browse`
+  screen and `runCustomInteraction()`.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -26,6 +26,7 @@ import { createInputComponent, type InputOptions } from "./input.js";
 import { createMultiSelectComponent } from "./multi-select.js";
 import {
 	actionMenuItemPresentation,
+	actionMenuUnavailableDescription,
 	handleSearchInput,
 	menuHint,
 	renderFrame,
@@ -127,6 +128,12 @@ function createActionsComponent<ScreenId extends string, ActionId extends string
 		(itemId) => {
 			const source = options.screen.items.find((candidate) => candidate.id === itemId);
 			if (!source?.disabled) options.onEvent({ kind: "activate", itemId });
+		},
+		(itemId) => {
+			const source = options.screen.items.find((candidate) => candidate.id === itemId);
+			if (!source) return [];
+			const unavailable = actionMenuUnavailableDescription(source);
+			return unavailable ? [unavailable] : [];
 		},
 	);
 }
@@ -533,6 +540,7 @@ function commonListComponent<ScreenId extends string, ActionId extends string>(
 	lines: readonly string[],
 	destination: "back" | "close",
 	onActivate: (itemId: string) => void,
+	selectedDetails?: (itemId: string) => readonly string[],
 ): MenuScreenComponent {
 	const initialIndex = Math.max(
 		0,
@@ -551,14 +559,21 @@ function commonListComponent<ScreenId extends string, ActionId extends string>(
 	};
 	return {
 		render(width) {
-			return renderFrame(
-				options.screen.title,
-				lines,
-				list.render(Math.max(1, width)),
-				destination,
-				width,
-				options,
-			);
+			const safeWidth = Math.max(1, width);
+			const selectedId = items[selectedIndex]?.value;
+			const details = selectedId ? (selectedDetails?.(selectedId) ?? []) : [];
+			const content = [
+				...list.render(safeWidth),
+				...(details.length > 0
+					? [
+							"",
+							...details.flatMap((detail) =>
+								wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(detail)), safeWidth),
+							),
+						]
+					: []),
+			];
+			return renderFrame(options.screen.title, lines, content, destination, width, options);
 		},
 		invalidate() {
 			list.invalidate();

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -24,7 +24,13 @@ import type {
 import { DynamicBorder } from "./dynamic-border.js";
 import { createInputComponent, type InputOptions } from "./input.js";
 import { createMultiSelectComponent } from "./multi-select.js";
-import { handleSearchInput, menuHint, renderFrame, safeMenuText } from "./rendering.js";
+import {
+	actionMenuItemPresentation,
+	handleSearchInput,
+	menuHint,
+	renderFrame,
+	safeMenuText,
+} from "./rendering.js";
 import { createReviewComponent, type ReviewOptions } from "./review.js";
 
 export { browseDialogLabel, browseDialogPages } from "./browse.js";
@@ -36,7 +42,7 @@ export type {
 	MenuScreenEvent,
 	MenuSettingChange,
 } from "./contracts.js";
-export { safeMenuText } from "./rendering.js";
+export { actionMenuDialogLabel, safeMenuText } from "./rendering.js";
 export { reviewDialogPages } from "./review.js";
 
 export function createMenuScreenComponent<ScreenId extends string, ActionId extends string>(
@@ -102,10 +108,15 @@ function createActionsComponent<ScreenId extends string, ActionId extends string
 ): MenuScreenComponent {
 	const items: SelectItem[] = options.screen.items.map((item) => ({
 		value: item.id,
-		label: safeMenuText(item.label),
-		description: item.description ? safeMenuText(item.description) : undefined,
+		...actionMenuItemPresentation(item),
 	}));
-	const list = new SelectList(items, Math.min(items.length, 10), selectTheme(options.theme));
+	const widestPrimary = Math.max(1, ...items.map((item) => visibleWidth(item.label))) + 2;
+	const list = new SelectList(items, Math.min(items.length, 10), selectTheme(options.theme), {
+		minPrimaryColumnWidth: Math.min(32, widestPrimary),
+		maxPrimaryColumnWidth: widestPrimary,
+		truncatePrimary: ({ text, maxWidth }) =>
+			truncateToWidth(text, maxWidth, maxWidth > 1 ? "…" : ""),
+	});
 	setInitialSelection(list, items, options.selectedItemId);
 	return commonListComponent(
 		options,

--- a/packages/pi-tui-kit/src/components/multi-select.ts
+++ b/packages/pi-tui-kit/src/components/multi-select.ts
@@ -8,7 +8,12 @@ import {
 } from "@earendil-works/pi-tui";
 import type { ActionMenuItem, MenuMultiSelectItem } from "../types.js";
 import type { MenuChangeResponse, MenuScreenComponent, MultiSelectOptions } from "./contracts.js";
-import { handleSearchInput, renderFrame, safeMenuText } from "./rendering.js";
+import {
+	actionMenuItemPresentation,
+	handleSearchInput,
+	renderFrame,
+	safeMenuText,
+} from "./rendering.js";
 
 type ToggleRow = { kind: "toggle"; item: MenuMultiSelectItem };
 type ActionRow<ScreenId extends string, ActionId extends string> = {
@@ -151,12 +156,12 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 				const index = viewportStart + offset;
 				const isSelected = index === selectedIndex;
 				const prefix = isSelected ? "› " : "  ";
-				const marker =
-					row.kind === "toggle"
-						? `${row.item.disabled ? "[-]" : selected.get(row.item.id) ? "[x]" : "[ ]"} `
-						: "";
-				const unavailable = row.item.disabled ? " (unavailable)" : "";
-				const label = `${prefix}${marker}${safeMenuText(row.item.label)}${unavailable}`;
+				const label =
+					row.kind === "action"
+						? `${prefix}${actionMenuItemPresentation(row.item).label}`
+						: `${prefix}${
+								row.item.disabled ? "[-]" : selected.get(row.item.id) ? "[x]" : "[ ]"
+							} ${safeMenuText(row.item.label)}${row.item.disabled ? " (unavailable)" : ""}`;
 				if (isSelected) return options.theme.fg("accent", label);
 				return row.item.disabled ? options.theme.fg("dim", label) : label;
 			});
@@ -165,14 +170,18 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 			}
 			const row = selectedRow();
 			const descriptions = row
-				? [
-						row.item.description,
-						row.kind === "toggle" && row.item.disabled
-							? row.item.disabledReason
-								? `Unavailable: ${row.item.disabledReason}`
-								: "Unavailable"
-							: undefined,
-					].filter((value): value is string => Boolean(value))
+				? row.kind === "action"
+					? [actionMenuItemPresentation(row.item).description].filter((value): value is string =>
+							Boolean(value),
+						)
+					: [
+							row.item.description,
+							row.item.disabled
+								? row.item.disabledReason
+									? `Unavailable: ${row.item.disabledReason}`
+									: "Unavailable"
+								: undefined,
+						].filter((value): value is string => Boolean(value))
 				: [];
 			if (descriptions.length > 0) {
 				rowContent.push(

--- a/packages/pi-tui-kit/src/components/multi-select.ts
+++ b/packages/pi-tui-kit/src/components/multi-select.ts
@@ -4,12 +4,14 @@ import {
 	Input,
 	Key,
 	matchesKey,
+	truncateToWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import type { ActionMenuItem, MenuMultiSelectItem } from "../types.js";
 import type { MenuChangeResponse, MenuScreenComponent, MultiSelectOptions } from "./contracts.js";
 import {
 	actionMenuItemPresentation,
+	actionMenuUnavailableDescription,
 	handleSearchInput,
 	renderFrame,
 	safeMenuText,
@@ -162,8 +164,12 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 						: `${prefix}${
 								row.item.disabled ? "[-]" : selected.get(row.item.id) ? "[x]" : "[ ]"
 							} ${safeMenuText(row.item.label)}${row.item.disabled ? " (unavailable)" : ""}`;
-				if (isSelected) return options.theme.fg("accent", label);
-				return row.item.disabled ? options.theme.fg("dim", label) : label;
+				const boundedLabel =
+					row.kind === "action"
+						? truncateToWidth(label, safeWidth, safeWidth > 1 ? "…" : "")
+						: label;
+				if (isSelected) return options.theme.fg("accent", boundedLabel);
+				return row.item.disabled ? options.theme.fg("dim", boundedLabel) : boundedLabel;
 			});
 			if (viewportSize < rows.length) {
 				rowContent.push(options.theme.fg("dim", `  (${selectedIndex + 1}/${rows.length})`));
@@ -171,9 +177,10 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 			const row = selectedRow();
 			const descriptions = row
 				? row.kind === "action"
-					? [actionMenuItemPresentation(row.item).description].filter((value): value is string =>
-							Boolean(value),
-						)
+					? [
+							actionMenuUnavailableDescription(row.item),
+							actionMenuItemPresentation(row.item).description,
+						].filter((value): value is string => Boolean(value))
 					: [
 							row.item.description,
 							row.item.disabled

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -1,5 +1,29 @@
 import { type Input, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type { ActionMenuItem } from "../types.js";
 import type { MenuBinding, MenuKeybindings, MenuScreenComponentOptions } from "./contracts.js";
+
+export function actionMenuItemPresentation(item: ActionMenuItem<string, string>): {
+	label: string;
+	description?: string;
+} {
+	const label = safeMenuText(item.label);
+	const description = item.description ? safeMenuText(item.description) : undefined;
+	if (!item.disabled) return { label, description };
+	const reason = safeMenuText(item.disabledReason ?? "");
+	return {
+		label: `[-] ${label}`,
+		description:
+			[reason ? `Unavailable: ${reason}` : undefined, description].filter(Boolean).join(" · ") ||
+			undefined,
+	};
+}
+
+export function actionMenuDialogLabel(item: ActionMenuItem<string, string>): string {
+	const label = safeMenuText(item.label);
+	const reason = safeMenuText(item.disabledReason ?? "");
+	if (!item.disabled || !reason) return label;
+	return `[-] ${label} (unavailable: ${reason})`;
+}
 
 export function renderFrame<ScreenId extends string, ActionId extends string>(
 	title: string,

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -8,14 +8,15 @@ export function actionMenuItemPresentation(item: ActionMenuItem<string, string>)
 } {
 	const label = safeMenuText(item.label);
 	const description = item.description ? safeMenuText(item.description) : undefined;
-	if (!item.disabled) return { label, description };
+	return { label: item.disabled ? `[-] ${label}` : label, description };
+}
+
+export function actionMenuUnavailableDescription(
+	item: ActionMenuItem<string, string>,
+): string | undefined {
+	if (!item.disabled) return undefined;
 	const reason = safeMenuText(item.disabledReason ?? "");
-	return {
-		label: `[-] ${label}`,
-		description:
-			[reason ? `Unavailable: ${reason}` : undefined, description].filter(Boolean).join(" · ") ||
-			undefined,
-	};
+	return reason ? `Unavailable: ${reason}` : undefined;
 }
 
 export function actionMenuDialogLabel(item: ActionMenuItem<string, string>): string {

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -42,4 +42,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 7;
+export const PI_EXTENSION_MENU_API_VERSION = 8;

--- a/packages/pi-tui-kit/src/runtime.ts
+++ b/packages/pi-tui-kit/src/runtime.ts
@@ -1,5 +1,6 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
+	actionMenuDialogLabel,
 	browseDialogLabel,
 	browseDialogPages,
 	createMenuScreenComponent,
@@ -461,7 +462,7 @@ function dialogRows<ScreenId extends string, ActionId extends string>(
 		rows = screen.items.map((item) => ({
 			kind: "interaction",
 			interaction: { kind: "activate", itemId: item.id },
-			label: safeMenuText(item.label),
+			label: actionMenuDialogLabel(item),
 		}));
 	} else if (screen.kind === "settings") {
 		rows = [
@@ -516,7 +517,7 @@ function dialogRows<ScreenId extends string, ActionId extends string>(
 			...(screen.actions ?? []).map((item) => ({
 				kind: "interaction" as const,
 				interaction: { kind: "activate" as const, itemId: item.id },
-				label: safeMenuText(item.label),
+				label: actionMenuDialogLabel(item),
 			})),
 			{ kind: "exit", label: dialogExitChoice(screen) },
 		];

--- a/packages/pi-tui-kit/src/types.ts
+++ b/packages/pi-tui-kit/src/types.ts
@@ -44,10 +44,19 @@ interface MenuItemBase {
 	disabled?: boolean;
 }
 
+type ActionMenuItemBase = MenuItemBase & {
+	disabledReason?: string;
+};
+
 export type ActionMenuItem<ScreenId extends string, ActionId extends string> =
-	| (MenuItemBase & { to: ScreenId; action?: never; close?: never })
-	| (MenuItemBase & { action: ActionId; to?: never; close?: never; busyLabel?: string })
-	| (MenuItemBase & { close: true; to?: never; action?: never });
+	| (ActionMenuItemBase & { to: ScreenId; action?: never; close?: never })
+	| (ActionMenuItemBase & {
+			action: ActionId;
+			to?: never;
+			close?: never;
+			busyLabel?: string;
+	  })
+	| (ActionMenuItemBase & { close: true; to?: never; action?: never });
 
 export interface ActionsScreen<ScreenId extends string, ActionId extends string> {
 	kind: "actions";

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -38,8 +38,8 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("package exposes declarative API version 7", () => {
-	assert.equal(PI_EXTENSION_MENU_API_VERSION, 7);
+test("package exposes declarative API version 8", () => {
+	assert.equal(PI_EXTENSION_MENU_API_VERSION, 8);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/runtime.test.ts
+++ b/packages/pi-tui-kit/test/runtime.test.ts
@@ -853,6 +853,57 @@ test("choice RPC preserves duplicate-label identity and keeps disabled rows iner
 	assert.equal(selectCalls, 2);
 });
 
+test("RPC explains disabled action rows and never invokes their targets", async () => {
+	let selectCalls = 0;
+	let invoked = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (_title: string, choices: string[]) => {
+			selectCalls += 1;
+			if (selectCalls === 1) {
+				assert.match(choices[0] ?? "", /^\[-\].*unavailable: Policy blocks it/i);
+				return choices[0];
+			}
+			return choices.at(-1);
+		},
+	});
+	const definition = defineMenu<undefined, "main", "run">({
+		start: "main",
+		screens: {
+			main: () => ({
+				kind: "actions",
+				title: "Actions",
+				items: [
+					{
+						id: "blocked-raw",
+						label: "Blocked action",
+						disabled: true,
+						disabledReason: "Policy\u0007 blocks it",
+						action: "run",
+					},
+					{ id: "close", label: "Close", close: true },
+				],
+				hint: "close",
+			}),
+		},
+		actions: {
+			run: async ({ itemId }) => {
+				assert.equal(itemId, "blocked-raw");
+				invoked += 1;
+				return { kind: "stay" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, definition, { getState: () => undefined }), {
+		kind: "closed",
+		reason: "close",
+	});
+	assert.equal(invoked, 0);
+	assert.equal(selectCalls, 2);
+});
+
 test("searchable multi-select TUI dispatches the filtered raw item id", async () => {
 	const invoked: string[] = [];
 	const context = createMockContext({
@@ -1037,6 +1088,58 @@ test("RPC exposes disabled multi-select reasons and never invokes toggle actions
 		reason: "back",
 	});
 	assert.equal(toggles, 0);
+	assert.equal(selectCalls, 2);
+});
+
+test("RPC explains disabled multi-select action rows and keeps them inert", async () => {
+	let selectCalls = 0;
+	let invoked = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (_title: string, choices: string[]) => {
+			selectCalls += 1;
+			if (selectCalls === 1) {
+				assert.match(choices[0] ?? "", /^\[-\].*unavailable: Policy blocks bulk changes/i);
+				return choices[0];
+			}
+			return choices.at(-1);
+		},
+	});
+	const definition = defineMenu<undefined, "tools", "toggle" | "bulk">({
+		start: "tools",
+		screens: {
+			tools: () => ({
+				kind: "multiSelect",
+				title: "Tools",
+				items: [],
+				action: "toggle",
+				actions: [
+					{
+						id: "blocked-bulk-raw",
+						label: "Enable all",
+						disabled: true,
+						disabledReason: "Policy blocks bulk changes",
+						action: "bulk",
+					},
+				],
+			}),
+		},
+		actions: {
+			toggle: async () => ({ kind: "stay" }),
+			bulk: async ({ itemId }) => {
+				assert.equal(itemId, "blocked-bulk-raw");
+				invoked += 1;
+				return { kind: "stay" };
+			},
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, definition, { getState: () => undefined }), {
+		kind: "closed",
+		reason: "back",
+	});
+	assert.equal(invoked, 0);
 	assert.equal(selectCalls, 2);
 });
 

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -202,11 +202,13 @@ test("disabled action rows keep long labels readable and explain why they are un
 	}
 	const wide = plainRender(harness.component, 120).join("\n");
 	assert.match(wide, new RegExp(`→ \\[-\\] ${label}`));
-	assert.match(wide, /Unavailable: No resets available · Current OAuth account/);
+	assert.match(wide, /Current OAuth account/);
+	assert.match(wide, /Unavailable: No resets available/);
 	assert.equal(wide.includes("\u0007"), false);
 
-	const narrow = plainRender(harness.component, 24);
-	assert.match(narrow.join("\n"), /→ \[-\].*…/);
+	const narrow = plainRender(harness.component, 24).join("\n");
+	assert.match(narrow, /→ \[-\].*…/);
+	assert.match(narrow, /Unavailable: No resets\s+available/);
 	harness.component.handleInput("l");
 	assert.deepEqual(harness.events, []);
 });
@@ -698,6 +700,8 @@ test("disabled multi-select action rows show their reason and remain inert", asy
 	for (const width of [1, 20, 80]) {
 		assert.ok(plainRender(harness.component, width).every((line) => visibleWidth(line) <= width));
 	}
+	const narrowAction = plainRender(harness.component, 20).find((line) => line.includes("[-]"));
+	assert.ok(narrowAction?.endsWith("…"));
 	const rendered = plainRender(harness.component, 80).join("\n");
 	assert.match(rendered, /› \[-\] Enable all available tools/);
 	assert.match(rendered, /Unavailable: Policy blocks this action/);

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -180,6 +180,37 @@ test("action screens honor injected navigation and distinguish Back from Ctrl+C 
 	assert.deepEqual(close.events, [{ kind: "close" }]);
 });
 
+test("disabled action rows keep long labels readable and explain why they are unavailable", () => {
+	const label = "Redeem usage limit reset for the current account…";
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "actions",
+		title: "Usage",
+		items: [
+			{
+				id: "run",
+				label,
+				description: "Current OAuth account",
+				disabled: true,
+				disabledReason: "No resets\u0007 available",
+				action: "run",
+			},
+		],
+	};
+	const harness = componentHarness(screen, { plainTheme: true });
+	for (const width of [1, 24, 40, 41, 80, 120]) {
+		assert.ok(plainRender(harness.component, width).every((line) => visibleWidth(line) <= width));
+	}
+	const wide = plainRender(harness.component, 120).join("\n");
+	assert.match(wide, new RegExp(`→ \\[-\\] ${label}`));
+	assert.match(wide, /Unavailable: No resets available · Current OAuth account/);
+	assert.equal(wide.includes("\u0007"), false);
+
+	const narrow = plainRender(harness.component, 24);
+	assert.match(narrow.join("\n"), /→ \[-\].*…/);
+	harness.component.handleInput("l");
+	assert.deepEqual(harness.events, []);
+});
+
 test("static lists use callback keybindings when they differ from the global manager", () => {
 	const actions = componentHarness(actionScreen, {
 		selectedItemId: "run",
@@ -644,6 +675,37 @@ test("multi-select supports explicit bulk action rows", async () => {
 	harness.component.handleInput("l");
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	assert.deepEqual(harness.events, [{ kind: "activate", itemId: "all" }]);
+});
+
+test("disabled multi-select action rows show their reason and remain inert", async () => {
+	const harness = componentHarness(
+		{
+			...multiSelectScreen,
+			items: [],
+			actions: [
+				{
+					id: "all",
+					label: "Enable all available tools",
+					description: "Bulk action",
+					disabled: true,
+					disabledReason: "Policy\u0007 blocks this action",
+					action: "run",
+				},
+			],
+		},
+		{ plainTheme: true },
+	);
+	for (const width of [1, 20, 80]) {
+		assert.ok(plainRender(harness.component, width).every((line) => visibleWidth(line) <= width));
+	}
+	const rendered = plainRender(harness.component, 80).join("\n");
+	assert.match(rendered, /› \[-\] Enable all available tools/);
+	assert.match(rendered, /Unavailable: Policy blocks this action/);
+	assert.match(rendered, /Bulk action/);
+	assert.equal(rendered.includes("\u0007"), false);
+	harness.component.handleInput("l");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.deepEqual(harness.events, []);
 });
 
 test("bounded multi-select keeps first, middle, last, and paged selections visible", () => {

--- a/packages/pi-tui-kit/test/testing-exports.test.ts
+++ b/packages/pi-tui-kit/test/testing-exports.test.ts
@@ -11,7 +11,7 @@ test("built package roots resolve separate production and testing exports", asyn
 	const testingSpecifier = "@narumitw/pi-tui-kit/testing";
 	const production = await import(productionSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 7);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 8);
 	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");
 	assert.equal("createTuiHarness" in production, false);
@@ -26,7 +26,7 @@ test("built package roots resolve separate production and testing exports", asyn
 		path.join(fixture, "usage.ts"),
 		`import { PI_EXTENSION_MENU_API_VERSION } from "@narumitw/pi-tui-kit";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 7 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const version: 8 = PI_EXTENSION_MENU_API_VERSION;\n` +
 			`void version;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
 	);
 	writeFileSync(


### PR DESCRIPTION
## Summary

- add optional `disabledReason` support to action rows in action and multi-select screens
- render disabled TUI actions with textual markers, selected-row explanations at every width, adaptive label columns, and ellipsis-safe truncation
- expose supplied disabled reasons in RPC while preserving legacy reason-less RPC labels
- integrate with the merged standalone-confirmation API and advance the declarative menu API to version 8
- add a minor Changeset for `@narumitw/pi-tui-kit`

## Verification

- `npm run check` — 2,491 tests passed on the rebased `origin/main`
- complete Pi TUI Kit package suite — 147 tests passed
- `npm run check:boundaries`
- `npm run changeset:status` — plans `@narumitw/pi-tui-kit` 0.50.0
- `just pack tui-kit` — inspected 49-file dry-run tarball
- focused TUI/RPC action, multi-select, Starship, and pi-usage compatibility tests

## Review follow-up

- keep selected disabled reasons visible when narrow action layouts suppress the description column
- use cell-aware ellipsis truncation for long `multiSelect.actions` rows

## Convention audit

Read and audited `docs/extension-conventions.md` for reusable-library packaging, TUI width/sanitization, documentation, tests, and release intent. No settings or lifecycle behavior changed. No consumer adopts the API before the Kit release is published, and no applicable checks or smokes were skipped.
