### PR TITLE
fix: exclude deprecated sources from Biome checks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,7 @@
 	"files": {
 		"includes": [
 			"**",
+			"!deprecated",
 			"!package-lock.json",
 			"!packages/pi-image-drop/src/web/{app.js,state.js,styles.css}",
 			"!packages/pi-webui/src/web/{app.css,app.js,image-drag.js,markdown.js,state.js,transcript.js}"


### PR DESCRIPTION
## Summary

- exclude the archived `deprecated/` tree from root Biome checks
- align lint coverage with the repository policy that deprecated packages are reference-only and excluded from active workspace checks

## Verification

- `npm run check` (2,491 tests passed)
- commit pre-check: `npm run biome:check && npm run typecheck`