### PR TITLE
feat: adopt standalone confirmation in consumers

### DIFF
--- a/.changeset/calm-images-confirm.md
+++ b/.changeset/calm-images-confirm.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-image-drop": patch
+---
+
+Use Pi TUI Kit's published standalone confirmation for lifecycle-owned link rotation while preserving Image Drop's Confirm, Back, Close, stale-session, and link-mutation behavior.

--- a/.changeset/warm-analytics-confirm.md
+++ b/.changeset/warm-analytics-confirm.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-analytics": patch
+---
+
+Use Pi TUI Kit's published standalone confirmation for analytics deletion so Back remains side-effect free, TUI Ctrl+C closes the dashboard, and stale or failed confirmation cannot clear data.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -17,6 +17,7 @@
 - npm 12 returns `npm pack --workspaces --dry-run --json` as an object keyed by workspace name rather than the single-package array shape; normalize with `Object.values()` before auditing all tarballs.
 - `npm audit fix --force` can replace every workspace's exact Pi devDependency with a vulnerable older caret range; restore all workspace manifests and the lockfile, then use targeted patched upgrades or overrides instead.
 - A consumer cannot safely adopt an unpublished `pi-tui-kit` API in the same PR: clean `npm ci` resolves its semver dependency from the registry. Publish the Kit API before raising the consumer's reviewed compatibility floor; do not use local paths that break independent packaging.
+- After raising one consumer's Kit floor, npm 12 can update the lock while leaving the old nested package on disk; run a root `npm install` and verify the resolved consumer package version before typechecking.
 - Pi maintains separate managed npm roots for user and project packages; dependency deduplication is guaranteed only within one install root, not across scopes.
 - A `pi-tui-kit` runtime import of the `pi-coding-agent` root can evaluate a second repository-resolved agent runtime and add over a second. Keep Kit production JavaScript on public `pi-tui` primitives with coding-agent type-only, and lazy-load command menus until consumers require that published Kit boundary.
 - Official Pi can misresolve static `@earendil-works/pi-ai/api/*` imports beneath its compatibility alias. Prefer root exports; otherwise use a variable-specifier dynamic import.

--- a/docs/plans/archived/2026-08-08_pi-tui-kit-deferred-multi-select-qualification-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-tui-kit-deferred-multi-select-qualification-plan.md
@@ -1,0 +1,56 @@
+# Pi TUI Kit Deferred Multi-Select Qualification Plan
+
+## Goal
+
+Close the Phase 4 deferred multi-select gate with maintained consumer evidence: either admit one
+shared Kit-owned deferred transaction contract, or record a bounded no-go that keeps each draft and
+persistence workflow extension-owned without changing immediate-save consumers.
+
+## Context
+
+Pi Sync and Subagents both render Kit `multiSelect` screens but own materially different transaction
+flows. Pi Sync uses a TUI-only draft followed by a separate exact review, optional privacy
+acknowledgement, and conflict-checked atomic publication; RPC is intentionally read-only. Subagents
+keeps Save and Discard actions in the searchable tool screen, preserves unavailable configured tools,
+and writes user settings only on Save; RPC intentionally reports status instead of opening the
+manager. Existing Kit multi-select already owns cross-mode toggles, rejected optimistic rollback,
+action rows, disposal, and stale-owner behavior.
+
+Immediate-save selectors in Chrome DevTools, Firecrawl, deprecated Google GenAI, and Plan mode persist
+each accepted toggle and must not be converted to deferred drafts as part of this qualification.
+
+## Non-Goals
+
+- Add a new public Kit screen, transaction coordinator, settings API, or menu API version.
+- Expand Pi Sync or Subagents command-mode support.
+- Change any consumer persistence, confirmation, conflict, rollback, or session-ownership policy.
+- Change immediate-save selectors.
+
+## Plan
+
+- [x] Characterize Pi Sync and Subagents draft, Save, Discard/cancel, rejection, RPC, disposal, and
+      session-replacement behavior from maintained source, READMEs, and focused tests; the roadmap
+      records that their review, publication, recovery, and RPC contracts do not converge.
+- [x] Verify existing Kit multi-select coverage owns only reusable interaction semantics—toggle
+      dispatch, optimistic rejection rollback, action rows, RPC adaptation, cancellation, disposal,
+      and stale ownership—without owning consumer drafts or publication; Kit runtime/component tests
+      passed in the 194-test focused run.
+- [x] Verify Pi Sync and Subagents focused tests pass for their current extension-owned workflows;
+      both complete test files passed in the 194-test focused run.
+- [x] Verify Chrome DevTools, Firecrawl, Google GenAI, and Plan mode retain immediate-save behavior;
+      active consumer files passed in the 194-test focused run, all 31 deprecated Google GenAI tests
+      passed through an isolated temporary compile, and the selector source diff was empty.
+- [x] Update `docs/roadmaps/pi-tui-kit-roadmap.md` so Phase 4 and both deferred-flow milestones reflect
+      the evidence-backed no-go without claiming a new Kit API.
+- [x] Run `npm run check` and `git diff --check`; the 2,495-test repository gate passed, the diff
+      check was clean, the touched-source private-import search was empty, and qualification-consumer
+      package/source diffs were empty.
+
+## Completion Checklist
+
+- [x] The roadmap states that deferred multi-select remains extension-owned, with Pi Sync/Subagents
+      rationale and explicit RPC boundaries.
+- [x] Immediate-save consumers are explicitly unchanged and supported by focused verification.
+- [x] No package manifest, production source, lockfile, or changeset was added for this docs-only
+      qualification beyond the already-present standalone-confirmation work in the worktree.
+- [x] Every plan item has evidence; archive this completed plan under `docs/plans/archived/`.

--- a/docs/plans/archived/2026-08-08_pi-tui-kit-direct-dialog-qualification-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-tui-kit-direct-dialog-qualification-plan.md
@@ -1,0 +1,68 @@
+# Pi TUI Kit Direct Dialog Qualification Plan
+
+## Goal
+
+Complete the first Phase 5 evidence gate by recounting active extension calls to Pi's direct
+`select`, `confirm`, `input`, and `editor` dialogs and classifying them by compatible lifecycle
+contract rather than treating call volume as pressure for new Kit APIs.
+
+## Context
+
+The post-confirmation-migration source baseline contains 101 direct dialog call sites across 11
+active extension packages: 36 `select`, 39 `confirm`, 17 `input`, and 9 `editor`. Pi Sync owns 48 of
+those sites inside storage/setup/synchronization workflows; Pi Goal owns 18 inside goal and settings
+workflows. The remaining sites are distributed across Accounts, Chat, Langfuse, Plan mode, Recall,
+Starship, Statusline, Subagents, and Worktree.
+
+This inventory is qualification evidence, not a durable metric target. The roadmap should record the
+contract classes and admission decisions without pinning transient counts.
+
+## Non-Goals
+
+- Reduce direct dialog counts as an end in itself.
+- Change extension behavior, command modes, settings, persistence, or package metadata.
+- Add a new Kit screen or raise the menu API version.
+- Migrate isolated prompts without two compatible consumers and a demonstrated lifecycle seam.
+- Reconsider action-bearing catalogs, forms, or public Pi export replacement in this gate.
+
+## Qualification Decision
+
+| Contract class | Recounted owners | Decision and boundary |
+| --- | --- | --- |
+| Sequential domain setup and authentication | 49 sites: Accounts 3, Chat 3, Langfuse 3, Sync 36, Worktree 4 | Keep extension-owned. These flows coordinate partial drafts, secret handling, validation, remote state, exact previews, and publication. Consumers retain their signal/generation checks and revalidate mutable state after awaits. |
+| One-off bounded choice or value | 4 sites: Goal 1, Plan mode 1, Recall 2 | Keep Pi direct primitives. Repository conventions already prefer `ctx.ui.select()` for a one-off small choice; these calls do not justify a menu/session abstraction. |
+| Boolean domain confirmation | 39 sites: Accounts 2, Chat 3, Goal 11, Recall 1, Starship 1, Subagents 5, Sync 12, Worktree 4 | Keep direct where every dismissal intentionally means “do not proceed.” Use the already-published `runConfirmation()` only in a consumer-specific migration that needs distinct Back/Close, stale, unsupported, or error outcomes; no new API is needed. Side effects and current-state revalidation remain local. |
+| Multi-line editor | 9 sites: Goal 6, Plan mode 1, Starship 1, Statusline 1 | Remain direct and deferred from Kit until Pi exposes an abort-aware cross-mode editor contract. Draft validation, preview, persistence, and rollback remain extension-owned. |
+
+The four classes cover all 101 active-source sites exactly once. No compatible pair demonstrates a
+missing Kit contract. Existing Kit choice, input, review, confirmation, task, and custom-interaction
+contracts remain available for bounded consumer migrations when their stronger semantics are needed.
+
+## Plan
+
+- [x] Verify the exact active-source inventory and package/method distribution after the completed
+      confirmation migrations; a literal active-source scan found 101 sites across 11 packages: 36
+      `select`, 39 `confirm`, 17 `input`, and 9 `editor`.
+- [x] Classify every owning workflow into one-off direct primitives, domain setup/auth sequences,
+      boolean domain confirmations, or multi-line editors; the qualification table covers all 101
+      sites exactly once and admits no new Kit candidate.
+- [x] Audit cancellation, disposal, session replacement, shutdown, post-await ownership, RPC, and
+      side-effect ownership for each contract class. Representative source confirms setup flows own
+      signal/generation checks and publication, boolean callers own post-confirm revalidation,
+      one-off choices use Pi's cross-mode primitive, and editor flows retain draft/persistence policy.
+- [x] Update `docs/roadmaps/pi-tui-kit-roadmap.md` to check off the direct-dialog milestone and record
+      the resulting admission/deferral decisions without preserving transient raw counts.
+- [x] Run `npm run check`, `git diff --check`, and a source-diff audit; the 2,495-test repository gate
+      passed, the diff check and Kit private-import search were clean, and every inventoried owner
+      package had an empty qualification diff.
+
+## Completion Checklist
+
+- [x] Every direct dialog owner is represented by one lifecycle-contract class.
+- [x] Future candidates name the missing evidence or existing public Kit contract; no speculative API
+      was admitted from count alone.
+- [x] The roadmap remains consistent with its evidence-before-abstraction and editor deferral
+      principles.
+- [x] No package manifest, production source, lockfile, or changeset was added for this docs-only gate
+      beyond the already-present standalone-confirmation work in the worktree.
+- [x] Every task has evidence; archive this completed plan under `docs/plans/archived/`.

--- a/docs/plans/archived/2026-08-08_pi-tui-kit-standalone-confirmation-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-tui-kit-standalone-confirmation-plan.md
@@ -87,27 +87,41 @@ Analytics without moving either extension's domain side effects into Pi TUI Kit.
       gate passed 2,448/2,448 tests; the five-run benchmark kept `codingAgentLoaded: false` in import,
       actions, review, and task scenarios (121.04 ms median cold import), and a built RPC confirmation
       smoke returned `confirmed` through API version 7.
-- [ ] Obtain explicit user approval to publish the new Kit version, then execute and verify the
-      repository's approved release workflow or publication path. Do not infer this approval from the
-      implementation approval.
-- [ ] After the release is visible on npm, migrate Image Drop in a separate bounded change, raise only
+- [x] Obtain explicit user approval to publish the new Kit version, then execute and verify the
+      repository's approved release workflow or publication path. Evidence: npm registry `latest`
+      resolves to `0.51.0`, the packed registry artifact exports menu API 8 and `runConfirmation()`,
+      and GitHub release `@narumitw/pi-tui-kit@0.51.0` was published on 2026-08-07.
+- [x] After the release is visible on npm, migrate Image Drop in a separate bounded change, raise only
       its reviewed Kit floor, preserve link-rotation Confirm/Back/Close/stale behavior, add its own
       changeset, and verify focused tests, pack contents, Pi runtime smoke, and `npm run check`.
-- [ ] After the release is visible on npm, migrate Analytics in a separate bounded change, raise only
+      Evidence: Image Drop now requires Kit `^0.51.0`, deleted its local confirmation component, and
+      passes current session ownership to `runConfirmation()` while retaining link mutation locally;
+      45 focused menu/lifecycle tests, the package check, 25-file dry-run package, isolated Pi load,
+      Changesets status, and the 2,492-test repository gate passed.
+- [x] After the release is visible on npm, migrate Analytics in a separate bounded change, raise only
       its reviewed Kit floor, preserve side-effect-free Back and committed-clear behavior while making
       TUI Ctrl+C close the dashboard, add its own changeset, and verify TUI/RPC/stale/error tests, pack
-      contents, Pi runtime smoke, and `npm run check`.
-- [ ] Re-run the two-consumer behavior matrix, mark the roadmap milestone complete with publication
+      contents, Pi runtime smoke, and `npm run check`. Evidence: Analytics now requires Kit `^0.51.0`
+      and dynamically injects `runConfirmation()` into its dashboard; 14 focused menu tests cover
+      TUI/RPC, Back, Close, stale ownership, error, committed-clear cancellation, and replacement,
+      while the package check, 14-file dry-run package, isolated Pi load, and Changesets status passed.
+- [x] Re-run the two-consumer behavior matrix, mark the roadmap milestone complete with publication
       and migration evidence, run the final repository gate, and archive this fully checked plan.
+      Evidence: 59 combined Image Drop/Analytics focused tests and all 2,495 repository tests passed;
+      the roadmap records both migrations and the completed standalone-confirmation milestone.
 
 ## Completion Checklist
 
-- [ ] The published root API exposes one documented standalone confirmation contract with no private
-      Pi imports or consumer domain payloads.
+- [x] The published root API exposes one documented standalone confirmation contract with no private
+      Pi imports or consumer domain payloads. Evidence: the `0.51.0` registry artifact exports
+      `runConfirmation()` and its built confirmation module through menu API 8.
 - [x] Maintained tests prove Confirmed, Back, Close, Stale, Unsupported, and Error, including TUI/RPC
       limitations, pre-abort, owner abort, external disposal, and stale-error suppression.
-- [ ] Image Drop and Analytics consume the published API through independently reviewable migrations
-      without capability, persistence, cancellation, or non-TUI regressions.
-- [ ] Package dry runs, runtime smokes, the benchmark, and `npm run check` pass for the final state.
-- [ ] The roadmap records stable release/adoption evidence and this plan is archived only after every
+- [x] Image Drop and Analytics consume the published API through independently reviewable migrations
+      without capability, persistence, cancellation, or non-TUI regressions. Evidence: each package
+      raises only its own Kit floor and has a separate patch Changeset and focused proof coverage.
+- [x] Package dry runs, runtime smokes, the benchmark, and `npm run check` pass for the final state.
+      Evidence: source-complete Kit benchmark evidence remains recorded above; both consumer package
+      checks, dry runs, isolated Pi loads, the 59-test matrix, and the 2,495-test root gate passed.
+- [x] The roadmap records stable release/adoption evidence and this plan is archived only after every
       item above is complete.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -4,9 +4,9 @@
 - **Audience:** Pi TUI Kit maintainers and extension authors
 - **Planning horizon:** The next evidence-qualified capability sequence; no delivery dates are
   committed
-- **Repository source:** Menu API version 7 with standalone confirmation, read-only browse,
-  lifecycle-safe custom interactions, adaptive review, distinct root Back/Close results, and a
-  supported `/testing` subpath
+- **Repository source:** Menu API version 8 with standalone confirmation, explanatory disabled
+  action rows, read-only browse, lifecycle-safe custom interactions, adaptive review, distinct root
+  Back/Close results, and a supported `/testing` subpath
 - **Published status:** Derive the current release from the npm badge, registry, and package manifest;
   this roadmap does not pin a transient package version
 - **Migration evidence:** Maintained package/consumer tests and the stable PR references in the
@@ -26,6 +26,8 @@ handling.
   Close without extension-local sentinels.
 - Make bounded review screens adapt safely to terminal height while retaining deterministic RPC
   pagination and fixed-size compatibility.
+- Make disabled action rows understandable and width-safe across TUI and RPC without changing raw
+  identity, navigation, or the guarantee that disabled actions never execute.
 - Publish a supported consumer test host that exercises real TUI and RPC adapters, then remove the
   equivalent generic orchestration added to repository-level test support by the first adopters.
 - Admit new public flows only when compatible consumer evidence proves reusable interaction and
@@ -53,12 +55,20 @@ The maintained package exposes eight declarative screen kinds:
 
 The package also exposes `runTask()` for abort-aware work with a TUI loader and
 `runCustomInteraction()` for lifecycle ownership around one extension-owned specialized component.
-Published menu API version 6 identifies runtimes that add read-only searchable browse and custom
-interaction lifecycle handling while retaining version-5 adaptive review and distinct root
-Back/Close behavior. Repository source version 7 adds standalone confirmation with deterministic RPC
-Back behavior; publication and Image Drop/Analytics proof migrations remain gated. The package's
-separate supported `/testing` subpath provides semantic TUI driving and strict RPC scripts without
-exporting raw components; Stamp and Image Drop completed representative adoption before publication.
+Published menu API version 8 adds the version-7 standalone confirmation contract with deterministic
+RPC Back behavior, then adds explanatory disabled action rows with sanitized, width-safe TUI/RPC
+presentation. It retains version-6 read-only searchable browse and custom-interaction lifecycle
+handling plus version-5 adaptive review and distinct root Back/Close behavior. Image Drop and
+Analytics have adopted the published confirmation contract through independent proof migrations. A
+subsequent deferred multi-select qualification admitted no new Kit transaction API: Pi Sync retains
+its reviewed, conflict-checked TUI draft and read-only RPC summary, while Subagents retains its
+in-screen tool draft and RPC status boundary. Immediate-save selectors remain unchanged. The first
+Phase 5 inventory then classified every remaining direct dialog by lifecycle contract and found no
+missing shared Kit API: one-off primitives, domain setup/auth sequences, boolean confirmations, and
+multi-line editors retain their existing owners. The package's separate supported `/testing` subpath
+provides semantic TUI driving and strict RPC scripts
+without exporting raw components; Stamp and Image Drop completed representative adoption before
+publication.
 
 Production and experimental consumers use the Kit alongside direct Pi dialogs. Raw consumer and
 dialog counts are intentionally not pinned here because they change independently of roadmap
@@ -214,9 +224,10 @@ contracts without private component knowledge.
 
 ### Phase 4: Qualified Shared Flows and Runtime Locality
 
-**Status:** In progress. The internal interaction driver, read-only browse, and custom-interaction
-lifecycle helper are complete. Standalone confirmation is source-complete pending publication and
-Image Drop/Analytics proof migrations; deferred multi-select remains independently gated.
+**Status:** Complete. The internal interaction driver, read-only browse, custom-interaction
+lifecycle helper, standalone confirmation, and explanatory disabled action presentation are published
+through API 8. Image Drop and Analytics completed confirmation proof migrations. Deferred
+multi-select completed its qualification as a bounded no-go for a new Kit transaction API.
 
 **Milestones:**
 
@@ -233,28 +244,41 @@ Image Drop/Analytics proof migrations; deferred multi-select remains independent
 - [x] Pi Starship and Pi Sync completed bounded API-v6 adoption: Modules uses browse, custom Sync UI
   uses the lifecycle helper, and both retain their prior domain, settings, cancellation, and non-TUI
   contracts.
-- [ ] Standalone confirmation either proves confirmed, Back, Close, Stale, Unsupported, and Error
-  through Image Drop plus a second compatible consumer, or remains deferred with the missing shared
-  contract recorded.
-- [ ] Deferred or batched multi-select either proves common draft, Save, Discard, rejection, and RPC
-  semantics through Pi Sync and Subagents, or remains extension-owned.
-- [ ] Immediate-save multi-select behavior remains unchanged for Chrome DevTools, Firecrawl,
-  Google GenAI, and Plan mode during any deferred-flow work.
+- [x] Published API 8 adds explanatory disabled action rows to top-level actions and multi-select
+  actions. Sanitized reasons, adaptive ellipsis-safe labels, inert activation, raw identity, and
+  legacy reason-less RPC labels are covered across TUI and RPC.
+- [x] Standalone confirmation proves Confirmed, Back, Close, Stale, Unsupported, and Error through
+  Image Drop and Analytics. Both consumers raised only their published Kit floor, retained domain
+  side effects, and passed focused TUI/RPC/lifecycle tests, package checks, dry-run packaging,
+  isolated Pi loads, and the repository gate.
+- [x] Deferred or batched multi-select remains extension-owned after Pi Sync and Subagents failed the
+  common-transaction gate. They share Kit toggle, rejection rollback, action-row, cancellation,
+  disposal, and stale-owner mechanics, but not Save/Discard cadence, review and confirmation policy,
+  persistence, conflict recovery, or interactive RPC support.
+- [x] Immediate-save multi-select behavior remains unchanged for Chrome DevTools, Firecrawl,
+  Google GenAI, and Plan mode. Focused maintained tests verified each accepted toggle still persists
+  immediately, and qualification introduced no selector source changes.
 
 **Outcome:** Repeated lifecycle and read-only disclosure policy moves behind bounded public or
 internal seams without absorbing consumer transactions or creating a universal UI framework.
 
 ### Phase 5: Evidence-Based Evolution
 
+**Status:** In progress. The post-migration direct-dialog inventory is classified; remaining pattern
+and public-Pi replacement reviews are independently gated.
+
 **Milestones:**
 
-- Remaining direct dialogs are recounted after completed migrations and reclassified by compatible
-  lifecycle contract rather than raw call volume.
-- Action-bearing or live async catalogs, trees, live previews, reorderable lists, and forms have
+- [x] Remaining direct dialogs were recounted after completed migrations and reclassified into
+  one-off bounded choices/values, domain setup/auth sequences, boolean domain confirmations, and
+  multi-line editors. Call volume admitted no new API: direct primitives remain preferred for
+  one-offs, setup transactions remain extension-owned, richer confirmation needs use the published
+  helper through consumer-specific migrations, and editors remain deferred.
+- [ ] Action-bearing or live async catalogs, trees, live previews, reorderable lists, and forms have
   explicit admission or deferral decisions based on compatible workflows.
-- Multi-line editor remains deferred until Pi exposes an abort-aware cross-mode editor contract.
-- Shipped screens are reviewed against newer public Pi exports and retired when an equivalent stable
-  public primitive or composite becomes available.
+- [ ] Multi-line editor remains deferred until Pi exposes an abort-aware cross-mode editor contract.
+- [ ] Shipped screens are reviewed against newer public Pi exports and retired when an equivalent
+  stable public primitive or composite becomes available.
 
 **Outcome:** The kit continues to grow only where evidence supports durable leverage and removes local
 abstractions when Pi provides a better stable owner.
@@ -317,7 +341,10 @@ abstractions when Pi provides a better stable owner.
 | Runtime action/lifecycle ownership | TUI and RPC formerly coordinated screen actions in separate branches | One internal driver now owns shared semantic action policy; adapters retain presentation lifecycle | Phase 4 source-complete; maintained all-screen matrix plus source diff |
 | Read-only catalog disclosure | Searchable catalogs were specialized | Menu API 6 browse owns bounded cross-mode list/detail presentation without domain actions | Phase 4 published; package matrix and Pi Starship adoption |
 | Specialized custom lifecycle | Consumers repeated cancellation, disposal, stale-owner, and draining logic | `runCustomInteraction()` owns the shared lifecycle shell while components and domain results remain local | Phase 4 published; package tests and Pi Sync adoption |
-| Standalone confirmation | Image Drop locally distinguished confirm, Back, and Close; boolean dialogs collapsed cancellation intent | Source API 7 preserves Confirmed, Back, Close, Stale, Unsupported, and Error without owning side effects | Phase 4 source-complete; publication and Image Drop/Analytics proof migrations pending |
+| Standalone confirmation | Image Drop locally distinguished confirm, Back, and Close; boolean dialogs collapsed cancellation intent | Published API 8 includes the API-7 confirmation contract preserving Confirmed, Back, Close, Stale, Unsupported, and Error without owning side effects | Phase 4 published and proven through Image Drop and Analytics |
+| Deferred multi-select transaction ownership | Pi Sync and Subagents both used Kit multi-select with extension-local drafts | Keep transactions extension-owned unless consumers converge on Save/Discard cadence, review, persistence, conflict recovery, and interactive RPC semantics | Phase 4 qualification complete; maintained Kit and consumer tests plus source/README contract review |
+| Direct-dialog admission pressure | Remaining calls mixed one-off prompts, domain transactions, boolean confirmations, and editors | Admit APIs from compatible lifecycle evidence, never raw call volume; reuse published confirmation only where richer outcomes are required | Phase 5 inventory complete; active-source recount, owner classification, and repository gate |
+| Disabled action presentation | Disabled action rows could hide their state or truncate labels ambiguously | Published API 8 presents sanitized reasons and ellipsis-safe labels across TUI/RPC while keeping actions inert and raw identities stable | Phase 4 published; registry package, maintained component/runtime tests, and archived implementation plan |
 | Regression gate | Repository CI-equivalent gate at each capability change | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
@@ -368,3 +395,9 @@ and adoption rather than calendar output.
 | 2026-08-02 | Publish menu API 6 with read-only browse, injected static-list keybindings, and `runCustomInteraction()` through PR #520. | Bounded list/detail disclosure and specialized-component lifecycle policy became reusable while catalog data, domain actions, Back/Close values, and side effects stayed consumer-owned. |
 | 2026-08-02 | Adopt API-v6 capabilities in Pi Starship and Pi Sync through PR #522. | Starship Modules now uses browse and Sync custom UI uses the lifecycle helper; both consumers raised only their own compatibility floors and retained domain, settings, cancellation, and non-TUI policy. |
 | 2026-08-08 | Implement source menu API 7 with standalone confirmation; keep publication and proof migrations gated. | Image Drop and Analytics demonstrate compatible Confirm/Back/Close needs. TUI reuses the standard actions renderer and custom-interaction lifecycle shell; RPC cancellation maps deterministically to Back because Pi exposes no separate RPC Ctrl+C dialog result. |
+| 2026-08-08 | Advance repository source to menu API 8 with explanatory disabled action rows. | Top-level and multi-select actions now share sanitized disabled reasons, adaptive ellipsis-safe TUI labels, deterministic RPC presentation, and inert activation without changing raw identity or legacy reason-less RPC labels. Publication and consumer floor changes remain separate gates. |
+| 2026-08-08 | Publish menu API 8 through the registry release tagged `@narumitw/pi-tui-kit@0.51.0`. | The registry package and GitHub release expose `runConfirmation()`, the API-8 literal, and disabled action presentation; consumer proof migrations remain independently reviewable follow-ups. |
+| 2026-08-08 | Migrate Image Drop link rotation to the published standalone confirmation contract. | Image Drop raised only its Kit floor, removed its local confirmation component, passed session ownership into the helper, and retained link invalidation and startup error policy locally; focused tests, package checks, dry-run packaging, isolated Pi load, and the repository gate passed. |
+| 2026-08-08 | Complete standalone-confirmation proof through Analytics. | Analytics raised only its Kit floor, retained deletion and committed-clear policy, made TUI Ctrl+C close the dashboard, and proved TUI/RPC Back, Close, stale, error, replacement, and cleanup-warning behavior; focused tests, package checks, dry-run packaging, isolated Pi load, and the repository gate passed. |
+| 2026-08-08 | Close deferred multi-select qualification without a new Kit transaction API. | Pi Sync requires a separate exact review, optional privacy acknowledgement, conflict-checked atomic publication, and read-only RPC; Subagents uses pinned in-screen Save/Discard, unavailable-tool preservation, synchronous settings publication, and RPC status. Existing Kit mechanics are reusable, but the transaction contracts do not converge. Immediate-save Chrome DevTools, Firecrawl, Google GenAI, and Plan-mode selectors remained unchanged and passed focused verification. |
+| 2026-08-08 | Classify remaining direct dialogs without admitting a new API. | One-off choices and values fit Pi's direct primitives; setup/auth sequences retain extension-owned drafts, secrets, validation, and publication; boolean confirmations use direct dialogs when all dismissals mean no and can adopt published `runConfirmation()` when richer outcomes are proven; multi-line editors remain deferred pending abort-aware RPC support. Raw call volume is not an admission criterion. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7713,7 +7713,7 @@
 			"version": "0.49.5",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1"
+				"@narumitw/pi-tui-kit": "^0.51.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",
@@ -7723,28 +7723,6 @@
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*"
-			}
-		},
-		"packages/pi-analytics/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.49.3",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
-			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
-			"license": "MIT",
-			"dependencies": {
-				"highlight.js": "11.11.1"
-			},
-			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-analytics/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"packages/pi-btw": {
@@ -8070,7 +8048,7 @@
 			"version": "0.49.3",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1",
+				"@narumitw/pi-tui-kit": "^0.51.0",
 				"@radix-ui/colors": "3.0.0",
 				"@radix-ui/react-icons": "1.3.2",
 				"@radix-ui/themes": "3.3.0",
@@ -8095,28 +8073,6 @@
 				"@earendil-works/pi-ai": "*",
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-image-drop/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.49.3",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
-			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
-			"license": "MIT",
-			"dependencies": {
-				"highlight.js": "11.11.1"
-			},
-			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-image-drop/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"packages/pi-langfuse": {

--- a/packages/pi-analytics/README.md
+++ b/packages/pi-analytics/README.md
@@ -96,7 +96,7 @@ Pi exposes HTTP responses and final assistant failures, not every provider-SDK t
 
 The command accepts no arguments. TUI mode uses the full dashboard; RPC mode adapts the same standard screens to dialogs. Print and JSON modes reject the interactive command observably instead of writing ad hoc protocol output.
 
-The root menu contains Change time range, Skills, Tools, Provider reliability, Response cycles, Data & privacy, and Close. Skills and Tools are searchable browse views with details and model breakdowns. Escape goes Back from nested screens and closes the root. Ctrl+C closes the menu. Cancelling data deletion has no side effects.
+The root menu contains Change time range, Skills, Tools, Provider reliability, Response cycles, Data & privacy, and Close. Skills and Tools are searchable browse views with details and model breakdowns. Escape goes Back from nested screens and closes the root. Ctrl+C closes the menu. Data deletion uses Pi TUI Kit's standalone confirmation: Back keeps the dashboard open, Ctrl+C closes it in TUI mode, and cancellation never clears data.
 
 ## 🔐 Local data and privacy
 

--- a/packages/pi-analytics/package.json
+++ b/packages/pi-analytics/package.json
@@ -32,7 +32,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1"
+		"@narumitw/pi-tui-kit": "^0.51.0"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*"

--- a/packages/pi-analytics/src/menu.ts
+++ b/packages/pi-analytics/src/menu.ts
@@ -28,6 +28,11 @@ export interface AnalyticsMenuState {
 	result: AnalyticsLoadResult;
 }
 
+export interface AnalyticsMenuOptions {
+	runConfirmation: typeof import("@narumitw/pi-tui-kit")["runConfirmation"];
+	isCurrent(): boolean;
+}
+
 type Screen = "main" | "range" | "skills" | "tools" | "reliability" | "responses" | "privacy";
 type Action = "setRange" | "clearData";
 
@@ -38,7 +43,11 @@ const RANGE_LABELS: Record<TimeRangeId, string> = {
 	all: "All time",
 };
 
-export function createAnalyticsMenu(source: AnalyticsMenuDataSource, now: () => number = Date.now) {
+export function createAnalyticsMenu(
+	source: AnalyticsMenuDataSource,
+	now: () => number = Date.now,
+	options?: AnalyticsMenuOptions,
+) {
 	let rangeId: TimeRangeId = "7d";
 	let cachedState: AnalyticsMenuState | undefined;
 	const loadState = async (signal: AbortSignal): Promise<AnalyticsMenuState> => {
@@ -119,27 +128,45 @@ export function createAnalyticsMenu(source: AnalyticsMenuDataSource, now: () => 
 			},
 			clearData: async ({ ctx, state, signal }) => {
 				if (state.result.kind !== "ready") return { kind: "stay" };
+				if (!options) throw new Error("Analytics confirmation is unavailable");
 				const count = state.result.snapshot.overview.responseCycles;
-				const confirmed = await ctx.ui.confirm(
-					"Delete analytics data?",
-					`This will clear all local analytics history from:\n\n${safeDisplayText(state.path)}\n\nThe selected range currently shows ${count} response cycles. Other running Pi processes may add new records afterward.`,
-					{ signal },
-				);
-				if (!confirmed || signal.aborted) return { kind: "stay" };
+				const confirmation = await options.runConfirmation(ctx, {
+					title: "Delete analytics data?",
+					message: `This will clear all local analytics history from:\n\n${safeDisplayText(state.path)}\n\nThe selected range currently shows ${count} response cycles. Other running Pi processes may add new records afterward.`,
+					confirmLabel: "Delete data",
+					cancelLabel: "Keep data",
+					signal,
+					isCurrent: options.isCurrent,
+					// Keep the dashboard's existing domain-level error route as the only notifier.
+					onError: () => undefined,
+				});
+				if (signal.aborted || !options.isCurrent()) return { kind: "close" };
+				if (confirmation.kind === "closed") {
+					return confirmation.reason === "close" ? { kind: "close" } : { kind: "stay" };
+				}
+				if (confirmation.kind === "stale") return { kind: "close" };
+				if (confirmation.kind === "unsupported") {
+					throw new Error(`Analytics confirmation is unavailable in ${confirmation.mode} mode`);
+				}
+				if (confirmation.kind === "error") throw confirmation.error;
+
 				const result = await source.clearAll(signal);
 				cachedState = undefined;
-				try {
-					ctx.ui.notify("Cleared local analytics data.", "info");
-					if (result.cleanupIncomplete) {
-						ctx.ui.notify(
-							"Some obsolete analytics files are still in use. Stop other Pi processes and clear again to remove them.",
-							"warning",
-						);
+				const isCurrent = options.isCurrent();
+				if (isCurrent) {
+					try {
+						ctx.ui.notify("Cleared local analytics data.", "info");
+						if (result.cleanupIncomplete) {
+							ctx.ui.notify(
+								"Some obsolete analytics files are still in use. Stop other Pi processes and clear again to remove them.",
+								"warning",
+							);
+						}
+					} catch {
+						// The host can dispose the current UI after the ownership check.
 					}
-				} catch {
-					// Session replacement can invalidate the UI after the generation switch.
 				}
-				return signal.aborted ? { kind: "close" } : { kind: "to", screen: "main" };
+				return signal.aborted || !isCurrent ? { kind: "close" } : { kind: "to", screen: "main" };
 			},
 		},
 	};
@@ -158,9 +185,12 @@ export async function showAnalyticsMenu(
 	source: AnalyticsMenuDataSource,
 	options: { signal: AbortSignal; isCurrent: () => boolean },
 ): Promise<void> {
-	const { runMenu, runTask } = await import("@narumitw/pi-tui-kit");
+	const { runConfirmation, runMenu, runTask } = await import("@narumitw/pi-tui-kit");
 	if (options.signal.aborted || !options.isCurrent()) return;
-	const controller = createAnalyticsMenu(source);
+	const controller = createAnalyticsMenu(source, Date.now, {
+		runConfirmation,
+		isCurrent: options.isCurrent,
+	});
 	const loading = await runTask(ctx, {
 		label: "Loading local analytics…",
 		signal: options.signal,

--- a/packages/pi-analytics/test/menu.test.ts
+++ b/packages/pi-analytics/test/menu.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { resolveMenuScreen, runMenu } from "@narumitw/pi-tui-kit";
+import { resolveMenuScreen, runConfirmation, runMenu } from "@narumitw/pi-tui-kit";
 import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { createMockContext } from "../../../test/support.js";
 import {
@@ -14,6 +14,8 @@ import {
 import type { AnalyticsSnapshot } from "../src/storage/queries.js";
 
 initTheme("dark", false);
+
+const confirmationOptions = { runConfirmation, isCurrent: () => true };
 
 const snapshot: AnalyticsSnapshot = {
 	overview: {
@@ -90,6 +92,17 @@ async function state(
 	controller: ReturnType<typeof createAnalyticsMenu>,
 ): Promise<AnalyticsMenuState> {
 	return controller.getState({ signal: new AbortController().signal });
+}
+
+function withRpcUi(
+	context: ReturnType<typeof createMockContext>,
+	rpc: ReturnType<typeof createRpcHarness>,
+) {
+	const base = context.ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	return { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
 }
 
 test("dashboard exposes seven primary rows and concise settled metrics", async () => {
@@ -201,35 +214,108 @@ test("clear cancellation is side-effect free and confirmation clears committed r
 				return { cleanupIncomplete: false };
 			},
 		}),
+		Date.now,
+		confirmationOptions,
 	);
 	const current = await state(controller);
-	let confirmation = "";
-	const cancelled = createMockContext({
-		hasUI: true,
-		mode: "rpc",
-		confirm: async (_title: string, message: string) => {
-			confirmation = message;
-			return false;
-		},
-	});
+	const cancelledRpc = createRpcHarness([{ kind: "select", response: undefined }]);
+	const cancelled = createMockContext({ hasUI: true, mode: "rpc" });
 	await controller.menu.actions.clearData({
-		ctx: cancelled.ctx,
+		ctx: withRpcUi(cancelled, cancelledRpc),
 		state: current,
 		signal: new AbortController().signal,
 		itemId: "clear",
 	});
+	cancelledRpc.assertConsumed();
 	assert.equal(clears, 0);
-	assert.match(confirmation, /clear all local analytics history/i);
-	assert.match(confirmation, /selected range currently shows 83 response cycles/i);
-	const confirmed = createMockContext({ hasUI: true, mode: "rpc", confirm: async () => true });
+	assert.match(cancelledRpc.dialogs[0]?.title ?? "", /clear all local analytics history/i);
+	assert.match(
+		cancelledRpc.dialogs[0]?.title ?? "",
+		/selected range currently shows 83 response cycles/i,
+	);
+
+	const confirmedRpc = createRpcHarness([{ kind: "select", response: "Delete data" }]);
+	const confirmed = createMockContext({ hasUI: true, mode: "rpc" });
 	await controller.menu.actions.clearData({
-		ctx: confirmed.ctx,
+		ctx: withRpcUi(confirmed, confirmedRpc),
 		state: current,
 		signal: new AbortController().signal,
 		itemId: "clear",
 	});
+	confirmedRpc.assertConsumed();
 	assert.equal(clears, 1);
 	assert.match(confirmed.notifications[0]?.message ?? "", /Cleared local analytics data/);
+});
+
+test("TUI Ctrl+C closes the dashboard from clear confirmation without deleting data", async () => {
+	let clears = 0;
+	const controller = createAnalyticsMenu(
+		source({
+			async clearAll() {
+				clears += 1;
+				return { cleanupIncomplete: false };
+			},
+		}),
+		Date.now,
+		confirmationOptions,
+	);
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	const context = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+	const clearing = controller.menu.actions.clearData({
+		ctx: context.ctx,
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "clear",
+	});
+	await tui.waitForOpen();
+	tui.press("ctrl+c");
+	assert.deepEqual(await clearing, { kind: "close" });
+	assert.equal(clears, 0);
+});
+
+test("stale and failed clear confirmations never delete analytics", async () => {
+	let clears = 0;
+	const analyticsSource = source({
+		async clearAll() {
+			clears += 1;
+			return { cleanupIncomplete: false };
+		},
+	});
+	const stale = createAnalyticsMenu(analyticsSource, Date.now, {
+		runConfirmation,
+		isCurrent: () => false,
+	});
+	const staleContext = createMockContext({ hasUI: true, mode: "rpc" });
+	assert.deepEqual(
+		await stale.menu.actions.clearData({
+			ctx: staleContext.ctx,
+			state: await state(stale),
+			signal: new AbortController().signal,
+			itemId: "clear",
+		}),
+		{ kind: "close" },
+	);
+
+	const failed = createAnalyticsMenu(analyticsSource, Date.now, confirmationOptions);
+	const failedContext = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		select: async () => {
+			throw new Error("confirmation transport failed");
+		},
+	});
+	await assert.rejects(
+		Promise.resolve(
+			failed.menu.actions.clearData({
+				ctx: failedContext.ctx,
+				state: await state(failed),
+				signal: new AbortController().signal,
+				itemId: "clear",
+			}),
+		),
+		/confirmation transport failed/u,
+	);
+	assert.equal(clears, 0);
 });
 
 test("clear reports obsolete files that could not be removed", async () => {
@@ -239,20 +325,28 @@ test("clear reports obsolete files that could not be removed", async () => {
 				return { cleanupIncomplete: true };
 			},
 		}),
+		Date.now,
+		confirmationOptions,
 	);
 	const current = await state(controller);
-	const confirmed = createMockContext({ hasUI: true, mode: "rpc", confirm: async () => true });
+	const rpc = createRpcHarness([{ kind: "select", response: "Delete data" }]);
+	const confirmed = createMockContext({ hasUI: true, mode: "rpc" });
 	await controller.menu.actions.clearData({
-		ctx: confirmed.ctx,
+		ctx: withRpcUi(confirmed, rpc),
 		state: current,
 		signal: new AbortController().signal,
 		itemId: "clear",
 	});
+	rpc.assertConsumed();
 	assert.match(confirmed.notifications[0]?.message ?? "", /Cleared local analytics data/);
 	assert.match(confirmed.notifications[1]?.message ?? "", /still in use/);
 });
 
 test("clear completion remains visible when cancellation races after confirmation", async () => {
+	let startedClear!: () => void;
+	const started = new Promise<void>((resolve) => {
+		startedClear = resolve;
+	});
 	let release!: () => void;
 	const blocked = new Promise<void>((resolve) => {
 		release = resolve;
@@ -260,25 +354,67 @@ test("clear completion remains visible when cancellation races after confirmatio
 	const controller = createAnalyticsMenu(
 		source({
 			async clearAll() {
+				startedClear();
 				await blocked;
 				return { cleanupIncomplete: false };
 			},
 		}),
+		Date.now,
+		confirmationOptions,
 	);
 	const current = await state(controller);
-	const confirmed = createMockContext({ hasUI: true, mode: "rpc", confirm: async () => true });
+	const rpc = createRpcHarness([{ kind: "select", response: "Delete data" }]);
+	const confirmed = createMockContext({ hasUI: true, mode: "rpc" });
 	const owner = new AbortController();
 	const clearing = controller.menu.actions.clearData({
-		ctx: confirmed.ctx,
+		ctx: withRpcUi(confirmed, rpc),
 		state: current,
 		signal: owner.signal,
 		itemId: "clear",
 	});
-	await Promise.resolve();
+	await started;
 	owner.abort();
 	release();
 	assert.deepEqual(await clearing, { kind: "close" });
+	rpc.assertConsumed();
 	assert.match(confirmed.notifications[0]?.message ?? "", /Cleared local analytics data/);
+});
+
+test("session replacement after committed clear suppresses stale UI publication", async () => {
+	let startedClear!: () => void;
+	const started = new Promise<void>((resolve) => {
+		startedClear = resolve;
+	});
+	let release!: () => void;
+	const blocked = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let current = true;
+	const controller = createAnalyticsMenu(
+		source({
+			async clearAll() {
+				startedClear();
+				await blocked;
+				return { cleanupIncomplete: false };
+			},
+		}),
+		Date.now,
+		{ runConfirmation, isCurrent: () => current },
+	);
+	const rpc = createRpcHarness([{ kind: "select", response: "Delete data" }]);
+	const context = createMockContext({ hasUI: true, mode: "rpc" });
+	const clearing = controller.menu.actions.clearData({
+		ctx: withRpcUi(context, rpc),
+		state: await state(controller),
+		signal: new AbortController().signal,
+		itemId: "clear",
+	});
+	await started;
+	current = false;
+	release();
+	assert.deepEqual(await clearing, { kind: "close" });
+	rpc.assertConsumed();
+	assert.equal(context.notifications.length, 0);
 });
 
 test("empty and unavailable states remain actionable", async () => {

--- a/packages/pi-image-drop/README.md
+++ b/packages/pi-image-drop/README.md
@@ -61,8 +61,9 @@ service state, then offers:
 Use the configured navigation and confirmation keys. Escape returns from a standard subview or closes
 the main menu; Ctrl+C closes from any menu level. Status, settings, limits, and help share one
 lifecycle-owned navigation flow. Resource-limit entry and save review use standard declarative
-screens with rejected-draft retention and exact bounded content; cancellable loaders and link-rotation
-three-way confirmation remain specialized. `/image-drop` accepts no arguments. The interactive menu is unavailable
+screens with rejected-draft retention and exact bounded content. Cancellable loaders remain
+extension-owned; link rotation uses Pi TUI Kit's standalone Confirm/Back/Close contract while Image
+Drop retains ownership of link invalidation. `/image-drop` accepts no arguments. The interactive menu is unavailable
 in RPC, JSON, and print modes and rejects those invocations before starting the service; manual
 settings remain available through the JSON file below.
 
@@ -165,8 +166,8 @@ Then open the unchanged `http://127.0.0.1:45678/...` link locally. Image Drop do
 src/index.ts            Pi package entrypoint
 src/image-drop.ts       extension registration and command orchestration
 src/runtime.ts          Pi lifecycle, lazy capabilities, and message orchestration
-src/interactive-ui.ts   lazily loaded menu adapter and Pi TUI Kit boundary
-src/menu.ts             limit input/review projections, menu-state helpers, loader, and confirmation
+src/interactive-ui.ts   lazy menu and standalone-confirmation Pi TUI Kit boundary
+src/menu.ts             limit input/review projections, menu-state helpers, and loader
 src/format.ts           lightweight byte formatting shared by runtime and menus
 src/batch.ts            in-memory draft and sent-history state machine
 src/images.ts           bounded queue with codecs loaded on first image processing

--- a/packages/pi-image-drop/package.json
+++ b/packages/pi-image-drop/package.json
@@ -34,7 +34,7 @@
 		"typecheck": "npm run check:web && tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1",
+		"@narumitw/pi-tui-kit": "^0.51.0",
 		"@radix-ui/colors": "3.0.0",
 		"@radix-ui/react-icons": "1.3.2",
 		"@radix-ui/themes": "3.3.0",

--- a/packages/pi-image-drop/src/interactive-ui.ts
+++ b/packages/pi-image-drop/src/interactive-ui.ts
@@ -1,4 +1,4 @@
-export { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+export { defineMenu, runConfirmation, runMenu } from "@narumitw/pi-tui-kit";
 export {
 	createLimitInputScreen,
 	createLimitReviewScreen,
@@ -9,7 +9,6 @@ export {
 	limitSettingsPatch,
 	menuSummary,
 	runImageDropMenuLoad,
-	showImageDropConfirmDialog,
 	usesSafeLimits,
 	validateLimitInput,
 } from "./menu.js";

--- a/packages/pi-image-drop/src/menu.ts
+++ b/packages/pi-image-drop/src/menu.ts
@@ -1,15 +1,5 @@
-import {
-	BorderedLoader,
-	type ExtensionCommandContext,
-	type ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
-import {
-	Key,
-	matchesKey,
-	SelectList,
-	truncateToWidth,
-	wrapTextWithAnsi,
-} from "@earendil-works/pi-tui";
+import { BorderedLoader, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { Key, matchesKey } from "@earendil-works/pi-tui";
 import type { PublicBatchState, PublicHistoryState } from "./batch.js";
 import { formatBytes } from "./format.js";
 import { DEFAULT_SETTINGS, HARD_LIMITS, type ImageDropSettings } from "./settings.js";
@@ -272,62 +262,6 @@ export function runImageDropMenuLoad<T>(
 			dispose() {
 				taskAbort.abort();
 				loader.dispose();
-			},
-		};
-	});
-}
-
-export type ConfirmDialogResult = "confirmed" | "cancelled" | "close";
-
-/** Specialized three-way confirmation retained to distinguish Escape from Ctrl+C. */
-export function showImageDropConfirmDialog(
-	ctx: ExtensionContext,
-	title: string,
-	message: string,
-): Promise<ConfirmDialogResult> {
-	return showConfirmScreen(ctx, title, message.split(/\r?\n/));
-}
-
-function showConfirmScreen(
-	ctx: ExtensionContext,
-	title: string,
-	lines: readonly string[],
-): Promise<ConfirmDialogResult> {
-	return ctx.ui.custom<ConfirmDialogResult>((tui, theme, keybindings, done) => {
-		const list = new SelectList(
-			[
-				{ value: "confirmed", label: "Confirm" },
-				{ value: "cancelled", label: "Cancel" },
-			],
-			2,
-			{
-				selectedPrefix: (text) => theme.fg("accent", text),
-				selectedText: (text) => theme.fg("accent", text),
-				description: (text) => theme.fg("muted", text),
-				scrollInfo: (text) => theme.fg("dim", text),
-				noMatch: (text) => theme.fg("warning", text),
-			},
-		);
-		list.onSelect = (item) => done(item.value as "confirmed" | "cancelled");
-		list.onCancel = () => done("cancelled");
-		return {
-			render(width: number): string[] {
-				const safeWidth = Math.max(1, width);
-				return [
-					...wrapTextWithAnsi(theme.fg("accent", theme.bold(safeMenuText(title))), safeWidth),
-					...lines.flatMap((line) =>
-						wrapTextWithAnsi(theme.fg("muted", safeMenuText(line)), safeWidth),
-					),
-					"",
-					...list.render(safeWidth),
-				].map((line) => truncateToWidth(line, safeWidth));
-			},
-			invalidate: () => list.invalidate(),
-			handleInput(data: string) {
-				if (matchesKey(data, Key.ctrl("c"))) done("close");
-				else if (keybindings.matches(data, "tui.select.cancel")) done("cancelled");
-				else list.handleInput(data);
-				tui.requestRender();
 			},
 		};
 	});

--- a/packages/pi-image-drop/src/runtime.ts
+++ b/packages/pi-image-drop/src/runtime.ts
@@ -7,16 +7,15 @@ import type {
 	InputEvent,
 	InputEventResult,
 } from "@earendil-works/pi-coding-agent";
-import type { MenuActionResult } from "@narumitw/pi-tui-kit";
+import type {
+	MenuActionResult,
+	RunConfirmationOptions,
+	RunConfirmationResult,
+} from "@narumitw/pi-tui-kit";
 import { BatchError, BatchStore, digestImages, type ProcessedImage } from "./batch.js";
 import { formatBytes } from "./format.js";
 import type { ImageProcessor } from "./images.js";
-import type {
-	ConfirmDialogResult,
-	ImageDropLimitsMenuState,
-	LimitSettingAction,
-	MenuLoadResult,
-} from "./menu.js";
+import type { ImageDropLimitsMenuState, LimitSettingAction, MenuLoadResult } from "./menu.js";
 import { readEffectivePiImageSettings } from "./pi-settings.js";
 import type { ImageDropServer, ImageDropServerOptions } from "./server.js";
 import {
@@ -65,7 +64,10 @@ export interface RuntimeDependencies {
 		label: string,
 		task: (signal: AbortSignal) => Promise<T>,
 	): Promise<MenuLoadResult<T>>;
-	showConfirm(ctx: ExtensionContext, title: string, message: string): Promise<ConfirmDialogResult>;
+	showConfirm(
+		ctx: ExtensionContext,
+		options: RunConfirmationOptions<ExtensionContext>,
+	): Promise<RunConfirmationResult>;
 	updateSettings: typeof updateSettings;
 	settingsFilePath: typeof settingsFilePath;
 }
@@ -78,8 +80,8 @@ const DEFAULT_DEPENDENCIES: RuntimeDependencies = {
 	loadInteractiveUi: loadDefaultInteractiveUi,
 	loadStatus: async (ctx, label, task) =>
 		(await loadDefaultInteractiveUi()).runImageDropMenuLoad(ctx, label, task),
-	showConfirm: async (ctx, title, message) =>
-		(await loadDefaultInteractiveUi()).showImageDropConfirmDialog(ctx, title, message),
+	showConfirm: async (ctx, options) =>
+		(await loadDefaultInteractiveUi()).runConfirmation(ctx, options),
 	updateSettings,
 	settingsFilePath,
 };
@@ -817,16 +819,27 @@ export class ImageDropRuntime {
 			throw new Error("the Pi session changed while opening Image Drop");
 		}
 		if (confirmRotation && server.hasUnusedLink?.()) {
-			const confirmation = await this.dependencies.showConfirm(
-				ctx,
-				"Create a new staging link?",
-				"The previous unused Image Drop link will stop working.",
-			);
-			if (generation !== this.generation || this.closed) {
+			const confirmation = await this.dependencies.showConfirm(ctx, {
+				title: "Create a new staging link?",
+				message: "The previous unused Image Drop link will stop working.",
+				signal: this.sessionAbort.signal,
+				isCurrent: () => this.isCurrentMenu(generation),
+				// Preserve Image Drop's domain-level startup error instead of notifying twice.
+				onError: () => undefined,
+			});
+			if (!this.isCurrentMenu(generation)) {
 				throw new Error("the Pi session changed while opening Image Drop");
 			}
-			if (confirmation === "close") return "closed";
-			if (confirmation !== "confirmed") return "cancelled";
+			if (confirmation.kind === "closed") {
+				return confirmation.reason === "close" ? "closed" : "cancelled";
+			}
+			if (confirmation.kind === "stale") {
+				throw new Error("the Pi session changed while opening Image Drop");
+			}
+			if (confirmation.kind === "unsupported") {
+				throw new Error(`Image Drop confirmation is unavailable in ${confirmation.mode} mode`);
+			}
+			if (confirmation.kind === "error") throw confirmation.error;
 		}
 		const link = server.issueLink();
 		if (this.batch?.publicState().phase === "empty") {

--- a/packages/pi-image-drop/test/lifecycle.test.ts
+++ b/packages/pi-image-drop/test/lifecycle.test.ts
@@ -2,13 +2,17 @@
 // verify ordering across menu, browser processing, message attachment, replacement, and shutdown.
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { RunConfirmationOptions, RunConfirmationResult } from "@narumitw/pi-tui-kit";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { digestImages, type ProcessedImage } from "../src/batch.js";
-import type { ConfirmDialogResult, ImageDropLimitsMenuState } from "../src/menu.js";
+import type { ImageDropLimitsMenuState } from "../src/menu.js";
 import { ImageDropRuntime } from "../src/runtime.js";
 import type { ImageDropServerOptions } from "../src/server.js";
 import { DEFAULT_SETTINGS, type ImageDropSettings } from "../src/settings.js";
+
+type ConfirmDialogResult = "confirmed" | "cancelled" | "close";
 
 const PNG = Buffer.from("processed-png");
 const PROCESSED: ProcessedImage = {
@@ -58,12 +62,14 @@ function createHarness(
 		>;
 		confirm?: () => Promise<boolean>;
 		custom?: ReturnType<typeof createTuiHarness>["custom"];
+		usePublishedConfirmation?: boolean;
 		input?: (render?: string) => Promise<string | undefined>;
 		confirmDialog?: () => Promise<ConfirmDialogResult>;
 		inputDialog?: () => Promise<
 			{ kind: "submitted"; value: string } | { kind: "cancelled" } | { kind: "closed" }
 		>;
 		onConfirm?: (title: string, message: string) => void;
+		onConfirmationOptions?: (options: RunConfirmationOptions<ExtensionContext>) => void;
 		onStatus?: (lines: readonly string[]) => void;
 		onLimits?: (state: ImageDropLimitsMenuState) => void;
 		onSave?: (settings: Partial<ImageDropSettings>) => Promise<void>;
@@ -130,11 +136,25 @@ function createHarness(
 				return { kind: "error", error };
 			}
 		},
-		showConfirm: async (_ctx, title, message) => {
-			options.onConfirm?.(title, message);
-			if (options.confirmDialog) return options.confirmDialog();
-			return ((await options.confirm?.()) ?? true) ? "confirmed" : "cancelled";
-		},
+		...(options.usePublishedConfirmation
+			? {}
+			: {
+					showConfirm: async (
+						_ctx: ExtensionContext,
+						confirmationOptions: RunConfirmationOptions<ExtensionContext>,
+					): Promise<RunConfirmationResult> => {
+						options.onConfirm?.(confirmationOptions.title, confirmationOptions.message);
+						options.onConfirmationOptions?.(confirmationOptions);
+						const result = options.confirmDialog
+							? await options.confirmDialog()
+							: ((await options.confirm?.()) ?? true)
+								? "confirmed"
+								: "cancelled";
+						return result === "confirmed"
+							? { kind: "confirmed" }
+							: { kind: "closed", reason: result === "close" ? "close" : "back" };
+					},
+				}),
 		updateSettings: options.onSave ?? (async () => undefined),
 		settingsFilePath: () => "/agent/pi-image-drop.json",
 	});
@@ -759,6 +779,65 @@ test("session replacement during a limit save suppresses stale state and UI publ
 		harness.context.notifications.some((notice) => /resource limits saved/iu.test(notice.message)),
 		false,
 	);
+});
+
+test("link rotation passes current session ownership into confirmation", async () => {
+	let received: RunConfirmationOptions<ExtensionContext> | undefined;
+	const harness = createHarness({
+		menuActions: ["open", "open", "close"],
+		confirmDialog: async () => "cancelled",
+		onConfirmationOptions: (options) => {
+			received = options;
+		},
+	});
+	await emit(harness.mock, "session_start", {}, harness.context.ctx);
+	await harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx);
+	await harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx);
+
+	assert.equal(received?.title, "Create a new staging link?");
+	assert.equal(received?.message, "The previous unused Image Drop link will stop working.");
+	assert.equal(received?.signal?.aborted, false);
+	assert.equal(received?.isCurrent?.(), true);
+
+	await emit(harness.mock, "session_shutdown", {}, harness.context.ctx);
+	assert.equal(received?.signal?.aborted, true);
+	assert.equal(received?.isCurrent?.(), false);
+});
+
+test("published confirmation preserves Back and Close during link rotation", async () => {
+	async function drive(exit: "tui.select.cancel" | "ctrl+c") {
+		const tui = createTuiHarness({ width: 80, rows: 24 });
+		const harness = createHarness({ custom: tui.custom, usePublishedConfirmation: true });
+		await emit(harness.mock, "session_start", {}, harness.context.ctx);
+
+		const first = Promise.resolve(
+			harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx),
+		);
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await first;
+
+		const second = Promise.resolve(
+			harness.mock.commands.get("image-drop")?.handler("", harness.context.ctx),
+		);
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.press(exit);
+		if (exit === "tui.select.cancel") {
+			await tui.waitForPending();
+			await tui.waitForOpen();
+			tui.press("ctrl+c");
+		}
+		await second;
+		return harness;
+	}
+
+	const back = await drive("tui.select.cancel");
+	assert.equal(back.context.notifications.length, 1);
+	const close = await drive("ctrl+c");
+	assert.equal(close.context.notifications.length, 1);
 });
 
 test("Ctrl+C closes Image Drop from limit dialogs and link rotation", async () => {

--- a/packages/pi-image-drop/test/menu.test.ts
+++ b/packages/pi-image-drop/test/menu.test.ts
@@ -10,7 +10,6 @@ import {
 	menuSummary,
 	runImageDropMenuLoad,
 	safeMenuText,
-	showImageDropConfirmDialog,
 	validateLimitInput,
 } from "../src/menu.js";
 import { DEFAULT_SETTINGS } from "../src/settings.js";
@@ -121,17 +120,4 @@ test("Ctrl+C aborts loader work before closing its UI", async () => {
 	assert.equal(result.kind, "closed");
 	assert.equal(abortedBeforeClose, true);
 	assert.equal(tui.isOpen, false);
-});
-
-test("specialized confirmation distinguishes cancellation from closing Image Drop", async () => {
-	async function drive(key: "tui.select.cancel" | "ctrl+c") {
-		const tui = createTuiHarness({ width: 80, rows: 24 });
-		const context = createMockContext({ mode: "tui", custom: tui.custom });
-		const running = showImageDropConfirmDialog(context.ctx, "Save?", "Review");
-		await tui.waitForOpen();
-		tui.press(key);
-		return running;
-	}
-	assert.equal(await drive("ctrl+c"), "close");
-	assert.equal(await drive("tui.select.cancel"), "cancelled");
 });


### PR DESCRIPTION
## Summary

- migrate Image Drop link rotation and Analytics data deletion to the published Pi TUI Kit `runConfirmation()` contract
- preserve Confirm/Back/Close, committed side effects, stale-session suppression, and domain-owned error policy with focused TUI/RPC/lifecycle coverage
- raise only the two consumer compatibility floors to `^0.51.0`, add independent patch Changesets, and close the related roadmap qualification gates without adding another Kit API

## Verification

- `npm run check` — 2,495 tests passed
- `npm --workspace @narumitw/pi-image-drop run check`
- `npm --workspace @narumitw/pi-analytics run check`
- 59 combined focused Image Drop/Analytics tests
- `just pack image-drop` and `just pack analytics`; inspected intended tarball contents
- isolated Pi entrypoint load smokes for Image Drop and Analytics
- `npm run changeset:status`
- `git diff --check`

## Audit

Read `docs/extension-conventions.md` and `docs/extension-settings.md` (no settings behavior changed). Audited user cancellation, component disposal, session replacement, shutdown, and every post-await ownership check. No private Pi `dist/*` imports or accepted behavior deviations remain. No package publication or visibility change was performed.
