### PR TITLE
feat(chrome-devtools): load unpacked browser extensions

### DIFF
--- a/.changeset/bright-chrome-extensions.md
+++ b/.changeset/bright-chrome-extensions.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-chrome-devtools": minor
+---
+
+Add trusted user and project settings for loading unpacked Chrome extensions into an isolated managed Chrome for Testing or Chromium browser.

--- a/docs/plans/archived/2026-08-07_pi-chrome-devtools-unpacked-extension-plan.md
+++ b/docs/plans/archived/2026-08-07_pi-chrome-devtools-unpacked-extension-plan.md
@@ -108,65 +108,54 @@ settings content.
 
 ## Plan
 
-- [ ] Add failing settings cases under `packages/pi-chrome-devtools/test/` for browser-only user
+- [x] Add failing settings cases under `packages/pi-chrome-devtools/test/` for browser-only user
       documents, omitted defaults, absolute user paths, trusted project relative paths, untrusted
       project suppression, project-array replacement, invalid browser shapes and manifests, global
       tool-save preservation, malformed-file protection, unknown fields, and pending-save/read
-      ordering; verify the focused compiled tests fail because the current loader only accepts the
-      tool-selection schema and has no project precedence.
-- [ ] Refactor `packages/pi-chrome-devtools/src/settings.ts` to normalize independent tool and browser
+      ordering. Evidence: the initial focused compile failed on the absent browser/project contract;
+      the final focused suite passes.
+- [x] Refactor `packages/pi-chrome-devtools/src/settings.ts` to normalize independent tool and browser
       sections, load canonical user plus trusted project settings without creating missing files,
-      resolve paths by scope, preserve both recognized and unknown siblings during atomic global
-      saves, and expose effective values with source metadata; verify the new focused settings suite
-      and all existing legacy/canonical settings tests pass.
-- [ ] Add failing managed-launch cases for extension-configured attach bypass, local auto-launch
-      requirements, supported/unsupported executable classification, deterministic ordered launch
-      arguments, multiple extension paths, occupied explicit ports, partial startup failure,
-      cancellation, repeated shutdown, and unchanged no-extension attach-first behavior; use
-      test-owned temporary manifests and fake process/endpoint operations rather than real user
-      profiles, and confirm each red state fails for the intended missing contract.
-- [ ] Update `packages/pi-chrome-devtools/src/runtime.ts` and
-      `packages/pi-chrome-devtools/src/browser-manager.ts` to apply the session's validated browser
-      configuration, force an owned isolated launch when extensions are requested, pass safe argv
-      entries without a shell, reject unsupported launch modes before spawn, and clean up every
-      partial or cancelled launch; verify the managed-launch tests pass without weakening existing
-      endpoint retry and shutdown behavior.
-- [ ] Extend `packages/pi-chrome-devtools/src/chrome-devtools.ts` and the existing selector/status
-      helpers so `session_start` loads settings with `ctx.cwd` and `ctx.isProjectTrusted()`,
-      post-await continuations revalidate session generation, shutdown waits for settings and browser
-      cleanup, and quick-start/status output reports canonical/project paths, effective browser
-      source, configured unpacked extensions, restart semantics, and actionable Chrome for Testing
-      guidance; verify command tests cover TUI, RPC notification, replacement, and shutdown paths.
-- [ ] Update `packages/pi-chrome-devtools/README.md` with both JSON locations, schema, precedence,
-      relative-path rules, trusted-project and arbitrary-extension-code warnings, supported browser
-      requirements, `/reload` behavior, failure diagnostics, and a current-project example; add a
-      minor Changeset for `@narumitw/pi-chrome-devtools` and verify every documented branch is covered
-      by a deterministic test or the explicit runtime smoke.
-- [ ] Run a bounded runtime smoke with `just try chrome-devtools`, a temporary Manifest V3 fixture,
-      and an explicitly selected Chrome for Testing/Chromium binary: confirm the managed browser
-      exposes the fixture service-worker target, normal page navigation/evaluation/screenshot tools
-      still work, `/reload` closes the old managed browser, and an external CDP browser remains
-      untouched; record the executable product/version and any platform not exercised.
-- [ ] Audit the final diff against the settings, lifecycle, process ownership, cancellation,
-      non-TUI, documentation, and package MUST rules; run the focused compiled tests,
-      `npm run check --workspace @narumitw/pi-chrome-devtools`, root `npm test`, root
-      `npm run check`, `just pack chrome-devtools`, `npm run changeset:status`, and
-      `git diff --check`, leaving any unavailable smoke or accepted deviation open before handoff.
+      resolve paths by scope, preserve recognized and unknown siblings during atomic global saves,
+      and expose effective values with source metadata. Evidence: `settings.test.ts` plus all legacy
+      settings cases pass.
+- [x] Add failing managed-launch cases for extension attach bypass, launch requirements, executable
+      classification, ordered argv, multiple paths, occupied ports, partial failure, cancellation,
+      repeated shutdown, and unchanged attach-first behavior. Evidence: the initial focused compile
+      failed on the absent launch contract; `managed-browser.test.ts` now passes with test-owned fakes.
+- [x] Update `runtime.ts` and `browser-manager.ts` to force an owned isolated launch, use shell-free
+      argv, reject unsupported modes/products before spawn, and clean every partial or cancelled
+      launch. Evidence: focused launch/lifecycle tests and the real-browser smoke pass.
+- [x] Extend session lifecycle and status handling to use `ctx.cwd`, `ctx.isProjectTrusted()`,
+      generation checks, ordered shutdown, source-aware status, restart semantics, and Chrome for
+      Testing guidance. Evidence: TUI/RPC, replacement, shutdown, and display-sanitization tests pass.
+- [x] Update the package README and add a minor Changeset for
+      `@narumitw/pi-chrome-devtools`. Evidence: `.changeset/bright-chrome-extensions.md` resolves to a
+      `0.50.0` minor bump and the package dry run contains the documented README and source files.
+- [x] Run a bounded real-browser smoke with a temporary Manifest V3 fixture and explicit Chrome for
+      Testing binary. Evidence: the non-interactive compiled-source equivalent was used instead of
+      the TUI-opening `just try` command; Chrome for Testing `149.0.7827.55` on `linux/x64` exposed the
+      fixture `background.js` service-worker target, navigation/evaluation/screenshot passed,
+      replacement removed the old process/profile, and a separately running external CDP browser
+      remained reachable. Windows and macOS were not exercised.
+- [x] Audit the final diff and run all required checks. Evidence: focused compiled tests (46), package
+      check, root `npm test` (2,514 tests), root `npm run check` (Biome, boundaries, typechecks, and
+      2,514 tests), package dry run (14 files), Changeset status, and `git diff --check` all pass.
 
 ## Completion Checklist
 
-- [ ] `pi-chrome-devtools.json` can configure a Chrome for Testing/Chromium executable and unpacked
-      extension paths without any new environment variable.
-- [ ] Missing settings preserve current behavior; canonical user and trusted project precedence,
-      path resolution, invalid-file protection, unknown-field preservation, atomic saves, and reload
-      semantics match the README.
-- [ ] Extension-configured sessions use only an extension-owned isolated browser and never silently
+- [x] `pi-chrome-devtools.json` configures Chrome for Testing/Chromium and unpacked extension paths
+      without a new environment variable.
+- [x] Missing settings preserve current behavior; user/project precedence, path resolution,
+      invalid-file protection, unknown-field preservation, atomic saves, and reload semantics match
+      the README.
+- [x] Extension-configured sessions use only an extension-owned isolated browser and never silently
       attach to, mutate, restart, or close an external browser.
-- [ ] Supported browsers load every configured test extension with safe startup argv; unsupported
-      branded browsers and invalid paths fail before a misleading successful result.
-- [ ] Cancellation, partial startup, session replacement, `/reload`, and shutdown release every owned
-      process, retry, status entry, and temporary profile exactly once.
-- [ ] Existing list/select/navigate/evaluate/screenshot behavior and no-extension attach-first startup
+- [x] Supported browsers load configured test extensions with safe startup argv; branded browsers and
+      invalid paths fail before a misleading success.
+- [x] Cancellation, partial startup, replacement, `/reload`, and shutdown release owned processes,
+      retries, status entries, and temporary profiles idempotently.
+- [x] Existing list/select/navigate/evaluate/screenshot behavior and no-extension attach-first startup
       remain backward compatible.
-- [ ] Focused tests, package and root checks, Changeset status, package dry run, Chrome for Testing
-      runtime smoke, final semantic audit, and plan evidence all pass before the plan is archived.
+- [x] Focused tests, package/root checks, Changeset status, package dry run, Chrome for Testing smoke,
+      final semantic audit, and plan evidence pass before archival.

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -20,6 +20,8 @@ This package is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDev
 - Reuses an existing Chrome DevTools Protocol endpoint when one is already available.
 - Lazily auto-launches a Chromium-family browser for missing local endpoints, with Chrome,
   Chromium, Brave, and Edge fallbacks.
+- Loads one or more user-approved unpacked extensions into an isolated managed Chrome for Testing
+  or Chromium browser.
 - Uses a dynamic managed DevTools port by default to avoid port conflicts, while preserving
   explicit endpoint overrides.
 - Retries briefly while Chrome is starting and reports actionable endpoint errors.
@@ -48,51 +50,95 @@ pi -e ./packages/pi-chrome-devtools
 
 ## 🚀 Browser startup
 
-The extension first tries the configured endpoint, defaulting to `127.0.0.1:9222`. If that
-local endpoint is unavailable, it lazily launches an extension-owned Chromium-family browser with
-an isolated temp profile and then retries the CDP request. Existing endpoints are reused and are
-not terminated by the extension.
+Without unpacked extensions, the extension first tries the configured endpoint, defaulting to
+`127.0.0.1:9222`. If that local endpoint is unavailable, it lazily launches an extension-owned
+Chromium-family browser with an isolated temp profile and retries the CDP request. Existing endpoints
+are reused and are never terminated by the extension.
 
 When `PI_CHROME_DEVTOOLS_PORT` is not set, auto-launch uses Chrome's dynamic DevTools port mode
-(`--remote-debugging-port=0`) and reads `DevToolsActivePort` from the temp profile. This avoids
-forcing every Pi session onto port `9222`. If you set `PI_CHROME_DEVTOOLS_PORT` to a valid port
-(`1`-`65535`), the extension uses that explicit port for both attach and auto-launch. Empty or
-invalid port values are ignored and fall back to the default attach-first behavior.
+(`--remote-debugging-port=0`) and reads `DevToolsActivePort` from the temp profile. If you set a valid
+`PI_CHROME_DEVTOOLS_PORT` (`1`-`65535`), the extension uses that explicit port. Empty or invalid values
+fall back to the default attach-first behavior.
 
-When `PI_CHROME_DEVTOOLS_BROWSER` is set, that executable is the only auto-launch candidate; a
-missing or unusable forced browser reports an error instead of falling back. Without that override,
-browser discovery checks platform-specific Chrome, Chromium, Brave, and Microsoft Edge candidates.
-Disable auto-launch to keep the older manual flow:
+### Unpacked extensions
+
+> [!WARNING]
+> An unpacked extension executes privileged browser code. Load only code you trust. Project settings
+> are honored only when Pi reports the project as trusted.
+
+Configure the canonical user file at
+`${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json`:
+
+```json
+{
+  "browser": {
+    "executablePath": "/absolute/path/to/chrome-for-testing",
+    "extensionPaths": [
+      "/absolute/path/to/unpacked-extension-one",
+      "/absolute/path/to/unpacked-extension-two"
+    ]
+  }
+}
+```
+
+Every user-file path must be absolute. Each extension path must resolve to a directory containing a
+valid `manifest.json` and cannot contain a comma because Chrome uses commas to separate multiple
+startup paths. For extension-configured sessions, `executablePath` must identify Chrome for
+Testing or Chromium. Branded Google Chrome is rejected because tested releases can silently ignore
+unpacked-extension startup flags.
+
+A trusted project can replace the user extension list in
+`<workspace>/.pi/pi-chrome-devtools.json`. Relative paths resolve from the workspace (`ctx.cwd`):
+
+```json
+{
+  "browser": {
+    "extensionPaths": ["./extension"]
+  }
+}
+```
+
+Project `extensionPaths` replace, rather than append to, the user array. A project file cannot
+override `browser.executablePath`; browser selection remains machine-owned user configuration.
+Effective precedence is defaults, user settings, trusted project override, then existing explicit
+runtime environment overrides. No new environment variable is required.
+
+When `extensionPaths` is non-empty, the extension skips attach-first behavior and starts an isolated,
+extension-owned managed browser with `--disable-extensions-except` and `--load-extension`. It fails
+before spawning when the endpoint is remote, auto-launch is disabled, an explicit port is occupied,
+the executable is missing, or the browser product is unsupported. It never adds extensions to,
+modifies, restarts, or closes an external browser.
+
+Settings are loaded on session start. After editing JSON, use `/reload` or replace the session; the
+old managed browser is closed before the new configuration is applied. Missing files preserve the
+existing no-extension behavior. Invalid JSON, invalid browser values, and missing manifests are left
+unchanged and ignored with an actionable warning.
+
+### Environment overrides and manual endpoints
+
+`PI_CHROME_DEVTOOLS_BROWSER` remains the explicit runtime executable override. Without unpacked
+extensions, browser discovery still checks platform-specific Chrome, Chromium, Brave, and Microsoft
+Edge candidates. Disable auto-launch to keep the manual flow:
 
 ```bash
 PI_CHROME_DEVTOOLS_AUTO_LAUNCH=0 pi -e ./packages/pi-chrome-devtools
 ```
 
-Force a browser executable or endpoint if needed:
+Force an executable or endpoint if needed:
 
 ```bash
-PI_CHROME_DEVTOOLS_BROWSER=/usr/bin/brave-browser pi -e ./packages/pi-chrome-devtools
+PI_CHROME_DEVTOOLS_BROWSER=/usr/bin/chromium pi -e ./packages/pi-chrome-devtools
 PI_CHROME_DEVTOOLS_HOST=127.0.0.1 PI_CHROME_DEVTOOLS_PORT=9223 pi -e ./packages/pi-chrome-devtools
 ```
 
-Manual launch still works and is required for remote endpoints, opt-out mode, or unsupported WSL
-browser/profile path setups:
+Manual launch remains available when no unpacked extensions are configured:
 
 ```bash
 google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/pi-chrome-devtools
 ```
 
-On macOS:
-
-```bash
-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
-  --remote-debugging-port=9222 \
-  --user-data-dir=/tmp/pi-chrome-devtools
-```
-
-On session shutdown, the extension terminates only browser processes it started itself and
-best-effort removes their temp profiles. It never closes user-started browsers or remote
-endpoints.
+On session shutdown, the extension terminates only browser processes it started and best-effort
+removes their temporary profiles. It never closes user-started browsers or remote endpoints.
 
 ## 🛠️ Pi tools
 

--- a/packages/pi-chrome-devtools/src/browser-manager.ts
+++ b/packages/pi-chrome-devtools/src/browser-manager.ts
@@ -1,6 +1,7 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, execFile, spawn } from "node:child_process";
 import { constants } from "node:fs";
 import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { delimiter, isAbsolute, join, resolve } from "node:path";
 import {
@@ -17,6 +18,45 @@ import {
 	state,
 } from "./runtime.js";
 
+interface BrowserSpawnOptions {
+	shell: false;
+	stdio: "ignore";
+}
+
+export interface BrowserManagerOperations {
+	access(path: string, mode: number): Promise<void>;
+	mkdtemp(prefix: string): Promise<string>;
+	readFile(path: string, encoding: "utf8"): Promise<string>;
+	rm(path: string, options: { recursive: true; force: true }): Promise<void>;
+	fetch(input: string, init?: RequestInit): Promise<Response>;
+	spawn(executable: string, args: string[], options: BrowserSpawnOptions): ChildProcess;
+	inspectBrowserVersion(executable: string, signal: AbortSignal): Promise<string>;
+	isPortAvailable(host: string, port: number): Promise<boolean>;
+	sleep(ms: number, signal?: AbortSignal): Promise<void>;
+}
+
+const DEFAULT_BROWSER_MANAGER_OPERATIONS: BrowserManagerOperations = {
+	access,
+	mkdtemp,
+	readFile,
+	rm: (path, options) => rm(path, options),
+	fetch: (input, init) => fetch(input, init),
+	spawn,
+	inspectBrowserVersion,
+	isPortAvailable,
+	sleep: abortableSleep,
+};
+
+let browserManagerOperations = DEFAULT_BROWSER_MANAGER_OPERATIONS;
+
+export function setBrowserManagerOperationsForTests(overrides: Partial<BrowserManagerOperations>) {
+	const previous = browserManagerOperations;
+	browserManagerOperations = { ...DEFAULT_BROWSER_MANAGER_OPERATIONS, ...overrides };
+	return () => {
+		browserManagerOperations = previous;
+	};
+}
+
 function formatError(error: unknown) {
 	return error instanceof Error ? error.message : String(error);
 }
@@ -30,6 +70,14 @@ function normalizePathForComparison(value: string) {
 }
 
 export async function ensureDevToolsEndpoint(waitMs = DEFAULT_ENDPOINT_WAIT_MS) {
+	if (extensionsConfigured()) {
+		const generation = state.sessionGeneration;
+		const signal = state.sessionController.signal;
+		await validateExtensionLaunchMode(generation, signal);
+		throwIfBrowserLaunchCancelled(generation, signal);
+		await ensureManagedBrowserLaunched(waitMs);
+		return;
+	}
 	if (canAutoLaunchBrowser()) {
 		try {
 			await withEndpointRetry(() => fetchDevToolsJson<unknown>("/json/version"), waitMs);
@@ -51,25 +99,56 @@ export async function ensureDevToolsEndpoint(waitMs = DEFAULT_ENDPOINT_WAIT_MS) 
 	}
 }
 
+async function validateExtensionLaunchMode(generation: number, signal: AbortSignal) {
+	if (!isLocalDevToolsHost(state.host)) {
+		throw new DevToolsEndpointError(
+			"Unpacked extensions require a local extension-owned managed browser; remote CDP endpoints cannot be modified.",
+		);
+	}
+	if (!state.autoLaunchEnabled) {
+		throw new DevToolsEndpointError(
+			"Auto-launch is required for unpacked extensions so Pi can create an isolated managed browser.",
+		);
+	}
+	if (!state.browserExecutable) {
+		throw new DevToolsEndpointError(
+			"Unpacked extensions require browser.executablePath for Chrome for Testing or Chromium in pi-chrome-devtools.json.",
+		);
+	}
+	if (state.portConfigured) {
+		const available = await browserManagerOperations.isPortAvailable(state.host, state.port);
+		throwIfBrowserLaunchCancelled(generation, signal);
+		if (!available) {
+			throw new DevToolsEndpointError(
+				`Cannot launch the extension-owned browser because explicit port ${state.port} is already in use. Choose a free PI_CHROME_DEVTOOLS_PORT or remove the override for a dynamic port.`,
+			);
+		}
+	}
+}
+
 async function ensureManagedBrowserLaunched(waitMs: number) {
 	if (state.launchPromise) return state.launchPromise;
 	if (state.managedBrowser && !state.managedBrowser.exited && state.managedBrowser.ready) return;
 	if (state.managedBrowser) {
 		await shutdownManagedBrowser(state.managedBrowser, { awaitLaunch: false });
 	}
-	throwIfBrowserLaunchCancelled();
+	const generation = state.sessionGeneration;
+	const signal = state.sessionController.signal;
+	throwIfBrowserLaunchCancelled(generation, signal);
 
-	state.launchPromise = launchManagedBrowser(waitMs).finally(() => {
-		state.launchPromise = undefined;
+	const launchPromise = launchManagedBrowser(waitMs, generation, signal);
+	const wrappedPromise = launchPromise.finally(() => {
+		if (state.launchPromise === wrappedPromise) state.launchPromise = undefined;
 	});
-	return state.launchPromise;
+	state.launchPromise = wrappedPromise;
+	return wrappedPromise;
 }
 
-async function launchManagedBrowser(waitMs: number) {
-	throwIfBrowserLaunchCancelled();
+async function launchManagedBrowser(waitMs: number, generation: number, signal: AbortSignal) {
+	throwIfBrowserLaunchCancelled(generation, signal);
 	const candidateDefinitions = browserCandidateDefinitions();
-	const candidates = await resolveBrowserCandidates(candidateDefinitions);
-	throwIfBrowserLaunchCancelled();
+	const candidates = await resolveBrowserCandidates(candidateDefinitions, generation, signal);
+	throwIfBrowserLaunchCancelled(generation, signal);
 	state.lastLaunchAttempt = {
 		candidateLabels: candidateDefinitions.map(formatBrowserCandidateDefinition),
 		mode: state.portConfigured ? "explicit-port" : "dynamic-port",
@@ -81,9 +160,12 @@ async function launchManagedBrowser(waitMs: number) {
 
 	let lastError: unknown;
 	for (const candidate of candidates) {
-		throwIfBrowserLaunchCancelled();
+		throwIfBrowserLaunchCancelled(generation, signal);
 		try {
-			await launchBrowserCandidate(candidate, waitMs);
+			if (extensionsConfigured())
+				await requireSupportedExtensionBrowser(candidate, generation, signal);
+			await launchBrowserCandidate(candidate, waitMs, generation, signal);
+			throwIfBrowserLaunchCancelled(generation, signal);
 			state.lastLaunchAttempt = {
 				...state.lastLaunchAttempt,
 				selectedCandidate: formatBrowserCandidate(candidate),
@@ -91,6 +173,15 @@ async function launchManagedBrowser(waitMs: number) {
 			};
 			return;
 		} catch (error) {
+			try {
+				throwIfBrowserLaunchCancelled(generation, signal);
+			} catch (cancellation) {
+				state.lastLaunchAttempt = {
+					...state.lastLaunchAttempt,
+					lastError: formatError(cancellation),
+				};
+				throw cancellation;
+			}
 			lastError = error;
 			state.lastLaunchAttempt = {
 				...state.lastLaunchAttempt,
@@ -99,6 +190,7 @@ async function launchManagedBrowser(waitMs: number) {
 		}
 	}
 
+	if (lastError instanceof DevToolsEndpointError && extensionsConfigured()) throw lastError;
 	throw new DevToolsEndpointError(
 		[
 			"Unable to auto-launch a Chromium-family browser for Chrome DevTools.",
@@ -112,30 +204,72 @@ async function launchManagedBrowser(waitMs: number) {
 	);
 }
 
-async function launchBrowserCandidate(candidate: BrowserCandidate, waitMs: number) {
-	throwIfBrowserLaunchCancelled();
-	const userDataDir = await mkdtemp(join(tmpdir(), MANAGED_BROWSER_PROFILE_PREFIX));
+async function requireSupportedExtensionBrowser(
+	candidate: BrowserCandidate,
+	generation: number,
+	signal: AbortSignal,
+) {
+	let version: string;
+	try {
+		version = (
+			await browserManagerOperations.inspectBrowserVersion(candidate.resolvedExecutable, signal)
+		).trim();
+	} catch (error) {
+		throwIfBrowserLaunchCancelled(generation, signal);
+		throw new DevToolsEndpointError(
+			`Unable to identify the configured extension browser ${candidate.resolvedExecutable}: ${formatError(error)}. Configure Chrome for Testing or Chromium.`,
+		);
+	}
+	throwIfBrowserLaunchCancelled(generation, signal);
+	const classification = classifyExtensionBrowserVersion(version);
+	if (!classification.supported) {
+		throw new DevToolsEndpointError(
+			`Unsupported browser for unpacked extensions: ${version || "unknown product"}. Configure Chrome for Testing or Chromium; branded Chrome may silently ignore extension startup flags.`,
+		);
+	}
+}
+
+export function classifyExtensionBrowserVersion(version: string): {
+	supported: boolean;
+	product: string;
+} {
+	if (/^(?:Google )?Chrome for Testing\b/i.test(version)) {
+		return { supported: true, product: "Chrome for Testing" };
+	}
+	if (/^Chromium\b/i.test(version)) return { supported: true, product: "Chromium" };
+	const product = version.trim().replace(/\s+\d+(?:\.\d+)*.*$/, "") || "Unknown";
+	return { supported: false, product };
+}
+
+async function launchBrowserCandidate(
+	candidate: BrowserCandidate,
+	waitMs: number,
+	generation: number,
+	signal: AbortSignal,
+) {
+	throwIfBrowserLaunchCancelled(generation, signal);
+	const userDataDir = await browserManagerOperations.mkdtemp(
+		join(tmpdir(), MANAGED_BROWSER_PROFILE_PREFIX),
+	);
 	let managedBrowser: ManagedBrowser | undefined;
 	try {
+		throwIfBrowserLaunchCancelled(generation, signal);
 		const portArgument = state.portConfigured ? String(state.port) : "0";
-		const args = [
-			`--remote-debugging-port=${portArgument}`,
-			`--user-data-dir=${userDataDir}`,
-			// Chrome 138+ de-elevates when launched from an elevated process on Windows: the
-			// spawned process relaunches a de-elevated child and exits immediately, which the
-			// exit watchdog misreads as a failed launch.
-			...(process.platform === "win32" ? ["--do-not-de-elevate"] : []),
-			"--no-first-run",
-			"--no-default-browser-check",
-			"about:blank",
-		];
-		throwIfBrowserLaunchCancelled();
-		const child = spawn(candidate.resolvedExecutable, args, { shell: false, stdio: "ignore" });
+		const args = buildManagedBrowserLaunchArguments(
+			userDataDir,
+			portArgument,
+			state.extensionPaths,
+		);
+		const child = browserManagerOperations.spawn(candidate.resolvedExecutable, args, {
+			shell: false,
+			stdio: "ignore",
+		});
 		const launchedBrowser: ManagedBrowser = {
 			process: child,
 			userDataDir,
 			exited: false,
 			ready: false,
+			ownerGeneration: generation,
 		};
 		managedBrowser = launchedBrowser;
 		state.managedBrowser = launchedBrowser;
@@ -149,19 +283,54 @@ async function launchBrowserCandidate(candidate: BrowserCandidate, waitMs: numbe
 		});
 
 		await waitForBrowserSpawn(child);
+		throwIfBrowserLaunchCancelled(generation, signal);
 		if (state.portConfigured) {
 			launchedBrowser.port = state.port;
 		} else {
-			launchedBrowser.port = await readManagedBrowserPort(userDataDir, launchedBrowser, waitMs);
+			launchedBrowser.port = await readManagedBrowserPort(
+				userDataDir,
+				launchedBrowser,
+				waitMs,
+				generation,
+				signal,
+			);
+			throwIfBrowserLaunchCancelled(generation, signal);
 			state.port = launchedBrowser.port;
 		}
-		await waitForDevToolsEndpoint(waitMs, launchedBrowser);
+		await waitForDevToolsEndpoint(waitMs, launchedBrowser, generation, signal);
+		throwIfBrowserLaunchCancelled(generation, signal);
 		launchedBrowser.ready = true;
 	} catch (error) {
 		if (managedBrowser) await shutdownManagedBrowser(managedBrowser, { awaitLaunch: false });
-		else await rm(userDataDir, { recursive: true, force: true }).catch(() => undefined);
+		else {
+			await browserManagerOperations
+				.rm(userDataDir, { recursive: true, force: true })
+				.catch(() => undefined);
+		}
 		throw error;
 	}
+}
+
+export function buildManagedBrowserLaunchArguments(
+	userDataDir: string,
+	portArgument: string,
+	extensionPaths: readonly string[],
+) {
+	const extensionList = extensionPaths.join(",");
+	return [
+		`--remote-debugging-port=${portArgument}`,
+		`--user-data-dir=${userDataDir}`,
+		...(extensionPaths.length > 0
+			? [`--disable-extensions-except=${extensionList}`, `--load-extension=${extensionList}`]
+			: []),
+		// Chrome 138+ de-elevates when launched from an elevated process on Windows: the
+		// spawned process relaunches a de-elevated child and exits immediately, which the
+		// exit watchdog misreads as a failed launch.
+		...(process.platform === "win32" ? ["--do-not-de-elevate"] : []),
+		"--no-first-run",
+		"--no-default-browser-check",
+		"about:blank",
+	];
 }
 
 function waitForBrowserSpawn(child: ChildProcess) {
@@ -185,20 +354,24 @@ async function readManagedBrowserPort(
 	userDataDir: string,
 	managedBrowser: ManagedBrowser,
 	waitMs: number,
+	generation: number,
+	signal: AbortSignal,
 ) {
 	const activePortFile = join(userDataDir, DEVTOOLS_ACTIVE_PORT_FILE);
 	const deadline = Date.now() + waitMs;
 	while (true) {
 		throwIfManagedBrowserExited(managedBrowser);
-		const text = await readFile(activePortFile, "utf8").catch((error: unknown) => {
-			if (isNodeError(error) && error.code === "ENOENT") return undefined;
-			throw error;
-		});
+		const text = await browserManagerOperations
+			.readFile(activePortFile, "utf8")
+			.catch((error: unknown) => {
+				if (isNodeError(error) && error.code === "ENOENT") return undefined;
+				throw error;
+			});
+		throwIfBrowserLaunchCancelled(generation, signal);
 		const portText = text?.split(/\r?\n/, 1)[0]?.trim();
 		const port = Number(portText);
 		if (Number.isInteger(port) && port > 0) return port;
 
-		throwIfBrowserLaunchCancelled();
 		const remainingMs = deadline - Date.now();
 		if (remainingMs <= 0) {
 			throw new DevToolsEndpointError(
@@ -209,22 +382,28 @@ async function readManagedBrowserPort(
 				].join("\n"),
 			);
 		}
-		await sleep(Math.min(DEFAULT_ENDPOINT_RETRY_MS, remainingMs));
+		await browserManagerOperations.sleep(Math.min(DEFAULT_ENDPOINT_RETRY_MS, remainingMs), signal);
 	}
 }
 
-async function waitForDevToolsEndpoint(waitMs: number, managedBrowser: ManagedBrowser) {
+async function waitForDevToolsEndpoint(
+	waitMs: number,
+	managedBrowser: ManagedBrowser,
+	generation: number,
+	signal: AbortSignal,
+) {
 	const deadline = Date.now() + waitMs;
 	while (true) {
 		throwIfManagedBrowserExited(managedBrowser);
 		try {
-			await fetchDevToolsJson<unknown>("/json/version");
+			await fetchDevToolsJson<unknown>("/json/version", { signal });
+			throwIfBrowserLaunchCancelled(generation, signal);
 			return;
 		} catch (error) {
 			if (!isRetryableEndpointError(error)) throw error;
 		}
 
-		throwIfBrowserLaunchCancelled();
+		throwIfBrowserLaunchCancelled(generation, signal);
 		const remainingMs = deadline - Date.now();
 		if (remainingMs <= 0) {
 			throw new DevToolsEndpointError(
@@ -234,7 +413,7 @@ async function waitForDevToolsEndpoint(waitMs: number, managedBrowser: ManagedBr
 				].join("\n"),
 			);
 		}
-		await sleep(Math.min(DEFAULT_ENDPOINT_RETRY_MS, remainingMs));
+		await browserManagerOperations.sleep(Math.min(DEFAULT_ENDPOINT_RETRY_MS, remainingMs), signal);
 	}
 }
 
@@ -243,9 +422,15 @@ function throwIfManagedBrowserExited(managedBrowser: ManagedBrowser) {
 	throw new DevToolsEndpointError("Auto-launched browser exited before DevTools became available.");
 }
 
-function throwIfBrowserLaunchCancelled() {
-	if (!state.shuttingDown) return;
-	throw new DevToolsEndpointError("Chrome DevTools browser launch cancelled during shutdown.");
+function throwIfBrowserLaunchCancelled(generation: number, signal: AbortSignal) {
+	if (!state.shuttingDown && generation === state.sessionGeneration && !signal.aborted) {
+		return;
+	}
+	throw new DevToolsEndpointError(
+		generation === state.sessionGeneration
+			? "Chrome DevTools browser launch cancelled during shutdown."
+			: "Chrome DevTools browser launch cancelled because the session was replaced.",
+	);
 }
 
 export async function shutdownManagedBrowser(
@@ -258,17 +443,30 @@ export async function shutdownManagedBrowser(
 		managedBrowser = managedBrowser ?? state.managedBrowser;
 	}
 	if (!managedBrowser) return;
-	if (state.managedBrowser === managedBrowser) state.managedBrowser = undefined;
+	if (managedBrowser.cleanupPromise) return managedBrowser.cleanupPromise;
 
+	const cleanup = cleanupManagedBrowser(managedBrowser);
+	managedBrowser.cleanupPromise = cleanup;
+	return cleanup;
+}
+
+async function cleanupManagedBrowser(managedBrowser: ManagedBrowser) {
+	if (state.managedBrowser === managedBrowser) state.managedBrowser = undefined;
 	if (!managedBrowser.exited) {
 		killManagedBrowserProcess(managedBrowser);
-		await waitForManagedBrowserExit(managedBrowser, BROWSER_SHUTDOWN_WAIT_MS).catch(() => {
+		await waitForManagedBrowserExit(managedBrowser, BROWSER_SHUTDOWN_WAIT_MS).catch(async () => {
 			killManagedBrowserProcess(managedBrowser, "SIGKILL");
+			await waitForManagedBrowserExit(managedBrowser, BROWSER_SHUTDOWN_WAIT_MS).catch(
+				() => undefined,
+			);
 		});
 	}
-	await rm(managedBrowser.userDataDir, { recursive: true, force: true }).catch(() => undefined);
-	if (!state.portConfigured && managedBrowser.port === state.port)
+	await browserManagerOperations
+		.rm(managedBrowser.userDataDir, { recursive: true, force: true })
+		.catch(() => undefined);
+	if (!state.portConfigured && managedBrowser.port === state.port) {
 		state.port = state.configuredPort;
+	}
 }
 
 function killManagedBrowserProcess(managedBrowser: ManagedBrowser, signal?: NodeJS.Signals) {
@@ -305,9 +503,10 @@ export async function fetchDevToolsJson<T>(path: string, init?: RequestInit) {
 	const url = `${devToolsEndpoint()}${path}`;
 	let response: Response;
 	try {
-		response = await fetch(url, {
+		const timeoutSignal = AbortSignal.timeout(DEFAULT_HTTP_TIMEOUT_MS);
+		response = await browserManagerOperations.fetch(url, {
 			...init,
-			signal: AbortSignal.timeout(DEFAULT_HTTP_TIMEOUT_MS),
+			signal: init?.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal,
 		});
 	} catch (error) {
 		throw new DevToolsEndpointError(endpointConnectionErrorMessage(error), {
@@ -351,7 +550,7 @@ export async function withEndpointRetry<T>(operation: () => Promise<T>, waitMs: 
 			const remainingMs = deadline - Date.now();
 			if (remainingMs <= 0) throw error;
 
-			await sleep(Math.min(DEFAULT_ENDPOINT_RETRY_MS, remainingMs));
+			await browserManagerOperations.sleep(Math.min(DEFAULT_ENDPOINT_RETRY_MS, remainingMs));
 		}
 	}
 }
@@ -375,6 +574,10 @@ function shouldAutoLaunchAfterEndpointError(error: unknown) {
 
 function canAutoLaunchBrowser() {
 	return state.autoLaunchEnabled && isLocalDevToolsHost(state.host);
+}
+
+function extensionsConfigured() {
+	return state.extensionPaths.length > 0;
 }
 
 function endpointConnectionErrorMessage(error: unknown) {
@@ -406,6 +609,18 @@ export function endpointSourceLabel() {
 }
 
 export function launchModeLabel() {
+	if (extensionsConfigured()) {
+		if (!isLocalDevToolsHost(state.host)) return "invalid; extensions require a local endpoint";
+		if (!state.autoLaunchEnabled) return "invalid; extensions require auto-launch";
+		if (state.managedBrowser && !state.managedBrowser.exited) {
+			return state.portConfigured
+				? "extension-owned browser on explicit port"
+				: "extension-owned browser on dynamic port";
+		}
+		return state.portConfigured
+			? "force extension-owned launch on explicit port"
+			: "force extension-owned launch on dynamic port";
+	}
 	if (!isLocalDevToolsHost(state.host)) return "manual remote endpoint";
 	if (!state.autoLaunchEnabled) return "manual; auto-launch disabled";
 	if (state.managedBrowser && !state.managedBrowser.exited) {
@@ -437,6 +652,9 @@ export function launchAttemptLines() {
 }
 
 export function launchHint() {
+	if (extensionsConfigured()) {
+		return "Configured unpacked extensions force an isolated extension-owned launch; existing CDP browsers are never reused, modified, or closed.";
+	}
 	if (!isLocalDevToolsHost(state.host)) {
 		return `Remote/non-local endpoints are not auto-launched. Start a browser with CDP enabled at ${devToolsEndpoint()}.`;
 	}
@@ -448,6 +666,9 @@ export function launchHint() {
 }
 
 export function browserCandidateHint() {
+	if (extensionsConfigured()) {
+		return "Extension browser requirement: configure Chrome for Testing or Chromium with browser.executablePath; branded Chrome is rejected because it may ignore unpacked-extension flags.";
+	}
 	return `Browser candidates: ${browserCandidateDefinitions()
 		.map((candidate) => candidate.label)
 		.join(", ")}`;
@@ -491,7 +712,14 @@ function browserCandidateDefinitions(): BrowserCandidateDefinition[] {
 function explicitBrowserCandidateDefinition(): BrowserCandidateDefinition[] {
 	if (!state.browserExecutable) return [];
 	return [
-		{ label: "PI_CHROME_DEVTOOLS_BROWSER", executable: state.browserExecutable, source: "env" },
+		{
+			label:
+				state.browserExecutableSource === "environment"
+					? "PI_CHROME_DEVTOOLS_BROWSER"
+					: "browser.executablePath",
+			executable: state.browserExecutable,
+			source: "env",
+		},
 	];
 }
 
@@ -582,10 +810,15 @@ function uniqueBrowserCandidates(candidates: BrowserCandidateDefinition[]) {
 	});
 }
 
-async function resolveBrowserCandidates(definitions: BrowserCandidateDefinition[]) {
+async function resolveBrowserCandidates(
+	definitions: BrowserCandidateDefinition[],
+	generation: number,
+	signal: AbortSignal,
+) {
 	const candidates: BrowserCandidate[] = [];
 	for (const definition of definitions) {
 		const resolvedExecutable = await resolveBrowserExecutable(definition.executable);
+		throwIfBrowserLaunchCancelled(generation, signal);
 		if (!resolvedExecutable) continue;
 		candidates.push({ ...definition, resolvedExecutable });
 	}
@@ -632,7 +865,10 @@ function executableSearchNames(executable: string) {
 
 async function canAccessExecutable(path: string) {
 	try {
-		await access(path, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+		await browserManagerOperations.access(
+			path,
+			process.platform === "win32" ? constants.F_OK : constants.X_OK,
+		);
 		return true;
 	} catch {
 		return false;
@@ -648,6 +884,13 @@ function formatBrowserCandidateDefinition(candidate: BrowserCandidateDefinition)
 }
 
 function noBrowserCandidateMessage(candidateDefinitions: BrowserCandidateDefinition[]) {
+	if (extensionsConfigured()) {
+		return [
+			"Cannot launch unpacked extensions because the configured browser executable was not found or is not executable.",
+			`Tried: ${candidateDefinitions.map(formatBrowserCandidateDefinition).join(", ")}`,
+			"Set browser.executablePath to an executable Chrome for Testing or Chromium binary.",
+		].join("\n");
+	}
 	return [
 		"Cannot auto-launch Chrome DevTools because no Chromium-family browser executable was found.",
 		`Tried: ${candidateDefinitions.map(formatBrowserCandidateDefinition).join(", ")}`,
@@ -659,8 +902,58 @@ export function formatPageListItem(page: DevToolsPage) {
 	return `- ${page.id}: ${page.title || "(untitled)"} ${page.url}`;
 }
 
-function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+function abortableSleep(ms: number, signal?: AbortSignal) {
+	return new Promise<void>((resolveSleep, reject) => {
+		if (signal?.aborted) {
+			reject(signal.reason);
+			return;
+		}
+		const timeout = setTimeout(settleResolve, ms);
+		const onAbort = () => settleReject(signal?.reason);
+		function cleanup() {
+			clearTimeout(timeout);
+			signal?.removeEventListener("abort", onAbort);
+		}
+		function settleResolve() {
+			cleanup();
+			resolveSleep();
+		}
+		function settleReject(reason: unknown) {
+			cleanup();
+			reject(reason);
+		}
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+function inspectBrowserVersion(executable: string, signal: AbortSignal) {
+	return new Promise<string>((resolveVersion, reject) => {
+		execFile(executable, ["--version"], { signal, timeout: 5_000 }, (error, stdout, stderr) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolveVersion(`${stdout}${stderr}`.trim());
+		});
+	});
+}
+
+function isPortAvailable(host: string, port: number) {
+	return new Promise<boolean>((resolveAvailability, reject) => {
+		const server = createServer();
+		const normalizedHost = host.replace(/^\[(.*)]$/, "$1");
+		server.unref();
+		server.once("error", (error: NodeJS.ErrnoException) => {
+			if (error.code === "EADDRINUSE") resolveAvailability(false);
+			else reject(error);
+		});
+		server.listen(port, normalizedHost, () => {
+			server.close((error) => {
+				if (error) reject(error);
+				else resolveAvailability(true);
+			});
+		});
+	});
 }
 
 class DevToolsEndpointError extends Error {

--- a/packages/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/packages/pi-chrome-devtools/src/chrome-devtools.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { shutdownManagedBrowser } from "./browser-manager.js";
-import { state } from "./runtime.js";
+import { applyRuntimeBrowserSettings, state } from "./runtime.js";
 import { loadSettings } from "./settings.js";
 import {
 	allChromeDevtoolsTools,
@@ -8,6 +8,7 @@ import {
 	buildCommandGuide,
 	buildQuickstartMessage,
 	buildToolStatusMessage,
+	sanitizeChromeDevtoolsDisplay,
 	showToolSelector,
 	updateChromeDevtoolsTools,
 	waitForChromeDevtoolsSettings,
@@ -63,16 +64,20 @@ export default function chromeDevtools(pi: ExtensionAPI) {
 		state.shuttingDown = false;
 		state.settingsNotice = undefined;
 		ctx.ui.setStatus(STATUS_KEY, undefined);
-		const settings = await loadSettings();
+		await shutdownManagedBrowser();
 		if (generation !== state.sessionGeneration) return;
+		state.activePageId = undefined;
+		state.lastLaunchAttempt = undefined;
+		const projectTrusted = ctx.isProjectTrusted();
+		const settings = await loadSettings({ cwd: ctx.cwd, projectTrusted });
+		if (generation !== state.sessionGeneration) return;
+		applyRuntimeBrowserSettings(settings.effectiveBrowser, settings.paths, projectTrusted);
 		state.settingsNotice = settings.notice;
-		if (settings.notice) ctx.ui.notify(settings.notice, "warning");
-		if (settings.kind === "loaded") {
-			applyChromeDevtoolsTools(pi, settings.settings.tools);
-			return;
+		for (const warning of settings.warnings) {
+			ctx.ui.notify(sanitizeChromeDevtoolsDisplay(warning), "warning");
 		}
-		if (settings.kind === "invalid") {
-			ctx.ui.notify(`Chrome DevTools settings ignored: ${settings.reason}`, "warning");
+		if (settings.kind === "loaded" && settings.settings.tools) {
+			applyChromeDevtoolsTools(pi, settings.settings.tools);
 		}
 	});
 
@@ -231,4 +236,7 @@ export {
 	selectAllowedRoot,
 } from "./screenshot.js";
 export { normalizeChromeDevtoolsSettings } from "./settings.js";
-export { orderedChromeDevtoolsTools } from "./tool-selector.js";
+export {
+	orderedChromeDevtoolsTools,
+	sanitizeChromeDevtoolsDisplay,
+} from "./tool-selector.js";

--- a/packages/pi-chrome-devtools/src/runtime.ts
+++ b/packages/pi-chrome-devtools/src/runtime.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from "node:child_process";
+import type { EffectiveBrowserSettings } from "./settings.js";
 
 export const DEFAULT_HOST = "127.0.0.1";
 export const DEFAULT_PORT = 9222;
@@ -26,6 +27,12 @@ export interface ChromeDevToolsState {
 	portConfigured: boolean;
 	autoLaunchEnabled: boolean;
 	browserExecutable?: string;
+	extensionPaths: string[];
+	browserExecutableSource: EffectiveBrowserSettings["executablePathSource"];
+	extensionPathsSource: EffectiveBrowserSettings["extensionPathsSource"];
+	settingsFilePath?: string;
+	projectSettingsFilePath?: string;
+	projectSettingsTrusted: boolean;
 	activePageId?: string;
 	managedBrowser?: ManagedBrowser;
 	launchPromise?: Promise<void>;
@@ -42,6 +49,8 @@ export interface ManagedBrowser {
 	port?: number;
 	exited: boolean;
 	ready: boolean;
+	ownerGeneration: number;
+	cleanupPromise?: Promise<void>;
 }
 
 export interface BrowserLaunchAttempt {
@@ -83,7 +92,25 @@ export const state: ChromeDevToolsState = {
 	portConfigured: configuredPortOverride !== undefined,
 	autoLaunchEnabled: process.env.PI_CHROME_DEVTOOLS_AUTO_LAUNCH !== "0",
 	browserExecutable: process.env.PI_CHROME_DEVTOOLS_BROWSER,
+	extensionPaths: [],
+	browserExecutableSource: process.env.PI_CHROME_DEVTOOLS_BROWSER ? "environment" : "default",
+	extensionPathsSource: "default",
+	projectSettingsTrusted: false,
 	shuttingDown: false,
 	sessionGeneration: 0,
 	sessionController: new AbortController(),
 };
+
+export function applyRuntimeBrowserSettings(
+	browser: EffectiveBrowserSettings,
+	paths: { user: string; project?: string },
+	projectTrusted: boolean,
+) {
+	state.browserExecutable = browser.executablePath;
+	state.extensionPaths = [...browser.extensionPaths];
+	state.browserExecutableSource = browser.executablePathSource;
+	state.extensionPathsSource = browser.extensionPathsSource;
+	state.settingsFilePath = paths.user;
+	state.projectSettingsFilePath = paths.project;
+	state.projectSettingsTrusted = projectTrusted;
+}

--- a/packages/pi-chrome-devtools/src/settings.ts
+++ b/packages/pi-chrome-devtools/src/settings.ts
@@ -1,20 +1,82 @@
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { access, lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
-import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import {
+	access,
+	lstat,
+	mkdir,
+	readFile,
+	realpath,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { CONFIG_DIR_NAME, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { CHROME_DEVTOOLS_TOOL_NAMES, type ChromeDevToolsToolName } from "./tool-names.js";
 
 const NEW_SETTINGS_FILE_NAME = "pi-chrome-devtools.json";
 const LEGACY_SETTINGS_FILE_NAME = "pi-chrome-devtools-settings.json";
+
 export interface ChromeDevToolsSettings {
 	tools: ChromeDevToolsToolName[];
 	updatedAt: number;
 }
 
+export type BrowserSettingsSource = "default" | "environment" | "project" | "user";
+
+export interface EffectiveBrowserSettings {
+	executablePath?: string;
+	extensionPaths: string[];
+	executablePathSource: BrowserSettingsSource;
+	extensionPathsSource: BrowserSettingsSource;
+}
+
+export interface ResolvedChromeDevToolsSettings {
+	tools?: ChromeDevToolsToolName[];
+	updatedAt?: number;
+	browser: EffectiveBrowserSettings;
+}
+
+export interface SettingsLoadOptions {
+	cwd?: string;
+	projectTrusted?: boolean;
+}
+
+interface SettingsLoadBase {
+	effectiveBrowser: EffectiveBrowserSettings;
+	paths: { user: string; project?: string };
+	warnings: string[];
+	notice?: string;
+}
+
+export type SettingsLoadResult =
+	| (SettingsLoadBase & { kind: "missing"; settings?: undefined })
+	| (SettingsLoadBase & { kind: "invalid"; reason: string; settings?: undefined })
+	| (SettingsLoadBase & { kind: "loaded"; settings: ResolvedChromeDevToolsSettings });
+
 export interface SettingsFileOperations {
 	write(path: string, data: string): Promise<void>;
 	rename(source: string, destination: string): Promise<void>;
+}
+
+interface NormalizedBrowserSection {
+	executablePath?: string;
+	extensionPaths?: string[];
+}
+
+interface NormalizedSettingsDocument {
+	tools?: ChromeDevToolsToolName[];
+	updatedAt?: number;
+	browser?: NormalizedBrowserSection;
+}
+
+interface SettingsDocumentResult {
+	kind: "missing" | "invalid" | "valid";
+	reason?: string;
+	document?: Record<string, unknown>;
+	normalized?: NormalizedSettingsDocument;
+	warnings: string[];
 }
 
 const DEFAULT_FILE_OPERATIONS: SettingsFileOperations = {
@@ -22,114 +84,284 @@ const DEFAULT_FILE_OPERATIONS: SettingsFileOperations = {
 	rename,
 };
 
-export type SettingsLoadResult =
-	| { kind: "missing"; notice?: string }
-	| { kind: "invalid"; reason: string; notice?: string }
-	| { kind: "loaded"; settings: ChromeDevToolsSettings; notice?: string };
+let settingsSaveQueue = Promise.resolve();
 
-export async function loadSettings(): Promise<SettingsLoadResult> {
+export async function loadSettings(options: SettingsLoadOptions = {}): Promise<SettingsLoadResult> {
 	await settingsSaveQueue;
-	const newPath = settingsFilePath();
-	const newSettings = await readSettingsFile(newPath);
-	if (newSettings.kind !== "missing") {
-		return withLegacyIgnoredNotice(newSettings);
+	const userPath = settingsFilePath();
+	const projectPath = options.cwd ? projectSettingsFilePath(options.cwd) : undefined;
+	const paths = { user: userPath, ...(projectPath ? { project: projectPath } : {}) };
+	const warnings: string[] = [];
+
+	let user = await readSettingsDocument(userPath, "user");
+	const legacyExists = await fileExists(legacySettingsFilePath());
+	if (user.kind !== "missing" && legacyExists) {
+		warnings.push(
+			`Chrome DevTools legacy settings ignored: ${legacySettingsFilePath()} exists, but ${userPath} takes precedence. Delete ${LEGACY_SETTINGS_FILE_NAME} after confirming your settings.`,
+		);
+	}
+	if (user.kind === "missing") {
+		const legacy = await readSettingsDocument(legacySettingsFilePath(), "user");
+		const concurrentlyCreated = await readSettingsDocument(userPath, "user");
+		if (concurrentlyCreated.kind !== "missing") {
+			user = concurrentlyCreated;
+			if (legacy.kind !== "missing") {
+				warnings.push(
+					`Chrome DevTools legacy settings ignored: ${legacySettingsFilePath()} exists, but ${userPath} takes precedence. Delete ${LEGACY_SETTINGS_FILE_NAME} after confirming your settings.`,
+				);
+			}
+		} else if (legacy.kind !== "missing") {
+			user = legacy;
+			if (legacy.kind === "valid") {
+				warnings.push(
+					`Using legacy ${LEGACY_SETTINGS_FILE_NAME}; rename it to ${NEW_SETTINGS_FILE_NAME}. Future saves write ${NEW_SETTINGS_FILE_NAME} without modifying the legacy file.`,
+				);
+			}
+		}
+	}
+	warnings.push(...user.warnings);
+
+	let project: SettingsDocumentResult = { kind: "missing", warnings: [] };
+	if (projectPath && options.projectTrusted) {
+		project = await readSettingsDocument(projectPath, "project", options.cwd);
+		warnings.push(...project.warnings);
 	}
 
-	const legacyPath = legacySettingsFilePath();
-	const legacySettings = await readSettingsFile(legacyPath);
-	const concurrentlyCreatedSettings = await readSettingsFile(newPath);
-	if (concurrentlyCreatedSettings.kind !== "missing") {
-		return withLegacyIgnoredNotice(concurrentlyCreatedSettings);
-	}
-	if (legacySettings.kind === "missing") return { kind: "missing" };
-	if (legacySettings.kind === "invalid") return legacySettings;
+	const effectiveBrowser = resolveEffectiveBrowser(
+		user.normalized?.browser,
+		project.normalized?.browser,
+	);
+	const settings = resolveSettings(user.normalized, project.normalized, effectiveBrowser);
+	const recognized =
+		settings.tools !== undefined ||
+		user.normalized?.browser !== undefined ||
+		project.normalized?.browser !== undefined;
+	const invalidReasons = [user, project]
+		.filter((result) => result.kind === "invalid")
+		.map((result) => result.reason)
+		.filter((reason): reason is string => Boolean(reason));
+	const base = {
+		effectiveBrowser,
+		paths,
+		warnings,
+		...(warnings.length > 0 ? { notice: warnings.join("\n") } : {}),
+	};
 
+	if (recognized) return { ...base, kind: "loaded", settings };
+	if (invalidReasons.length > 0) {
+		return { ...base, kind: "invalid", reason: invalidReasons.join("; ") };
+	}
+	return { ...base, kind: "missing" };
+}
+
+function resolveSettings(
+	user: NormalizedSettingsDocument | undefined,
+	_project: NormalizedSettingsDocument | undefined,
+	browser: EffectiveBrowserSettings,
+): ResolvedChromeDevToolsSettings {
 	return {
-		...legacySettings,
-		notice: `Using legacy ${LEGACY_SETTINGS_FILE_NAME}; rename it to ${NEW_SETTINGS_FILE_NAME}. Future saves write ${NEW_SETTINGS_FILE_NAME} without modifying the legacy file.`,
+		...(user?.tools ? { tools: user.tools, updatedAt: user.updatedAt } : {}),
+		browser,
 	};
 }
 
-interface SettingsDocumentResult {
-	result: SettingsLoadResult;
-	document?: Record<string, unknown>;
+function resolveEffectiveBrowser(
+	user: NormalizedBrowserSection | undefined,
+	project: NormalizedBrowserSection | undefined,
+): EffectiveBrowserSettings {
+	const environmentExecutable = process.env.PI_CHROME_DEVTOOLS_BROWSER;
+	const executablePath = environmentExecutable || user?.executablePath;
+	const extensionPaths = project?.extensionPaths ?? user?.extensionPaths ?? [];
+	return {
+		...(executablePath ? { executablePath } : {}),
+		extensionPaths: [...extensionPaths],
+		executablePathSource: environmentExecutable
+			? "environment"
+			: user?.executablePath
+				? "user"
+				: "default",
+		extensionPathsSource: project?.extensionPaths
+			? "project"
+			: user?.extensionPaths
+				? "user"
+				: "default",
+	};
 }
 
-async function readSettingsDocument(filePath: string): Promise<SettingsDocumentResult> {
+async function readSettingsDocument(
+	filePath: string,
+	scope: "project" | "user",
+	cwd?: string,
+): Promise<SettingsDocumentResult> {
 	let text: string;
 	try {
 		text = await readFile(filePath, "utf8");
 	} catch (error) {
-		if (isNodeError(error) && error.code === "ENOENT") return { result: { kind: "missing" } };
-		return { result: { kind: "invalid", reason: `${filePath}: ${formatError(error)}` } };
+		if (isNodeError(error) && error.code === "ENOENT") return { kind: "missing", warnings: [] };
+		const reason = `${filePath}: ${formatError(error)}`;
+		return { kind: "invalid", reason, warnings: [`Chrome DevTools settings ignored: ${reason}`] };
 	}
 
+	let parsed: unknown;
 	try {
-		const parsed = JSON.parse(text) as unknown;
-		const settings = normalizeChromeDevtoolsSettings(parsed);
-		if (settings) {
-			return {
-				result: { kind: "loaded", settings },
-				document: { ...(parsed as Record<string, unknown>) },
-			};
-		}
-		return {
-			result: {
-				kind: "invalid",
-				reason: `${filePath}: expected tools to be an array of Chrome DevTools tool names`,
-			},
-		};
-	} catch (error) {
-		return { result: { kind: "invalid", reason: `${filePath}: ${formatError(error)}` } };
-	}
-}
-
-async function readSettingsFile(filePath: string): Promise<SettingsLoadResult> {
-	return (await readSettingsDocument(filePath)).result;
-}
-
-async function withLegacyIgnoredNotice(settings: SettingsLoadResult): Promise<SettingsLoadResult> {
-	if (!(await fileExists(legacySettingsFilePath()))) return settings;
-	return {
-		...settings,
-		notice: `Chrome DevTools legacy settings ignored: ${legacySettingsFilePath()} exists, but ${settingsFilePath()} takes precedence. Delete ${LEGACY_SETTINGS_FILE_NAME} after confirming your settings.`,
-	};
-}
-
-async function fileExists(filePath: string) {
-	try {
-		await access(filePath, constants.F_OK);
-		return true;
+		parsed = JSON.parse(text) as unknown;
 	} catch {
-		return false;
+		const reason = `${filePath}: invalid JSON`;
+		return { kind: "invalid", reason, warnings: [`Chrome DevTools settings ignored: ${reason}`] };
+	}
+	if (!isRecord(parsed)) {
+		const reason = `${filePath}: expected a JSON object`;
+		return { kind: "invalid", reason, warnings: [`Chrome DevTools settings ignored: ${reason}`] };
+	}
+
+	const scopeWarnings = projectExecutableWarnings(parsed, scope, filePath);
+	try {
+		const normalized = await normalizeSettingsDocument(parsed, scope, filePath, cwd);
+		return { kind: "valid", document: { ...parsed }, normalized, warnings: scopeWarnings };
+	} catch (error) {
+		const reason = `${filePath}: ${formatError(error)}`;
+		return {
+			kind: "invalid",
+			reason,
+			warnings: [...scopeWarnings, `Chrome DevTools settings ignored: ${reason}`],
+		};
 	}
 }
 
-async function pathEntryExists(filePath: string) {
-	try {
-		await lstat(filePath);
-		return true;
-	} catch (error) {
-		if (isNodeError(error) && error.code === "ENOENT") return false;
-		throw error;
+function projectExecutableWarnings(
+	document: Record<string, unknown>,
+	scope: "project" | "user",
+	filePath: string,
+) {
+	if (
+		scope !== "project" ||
+		!isRecord(document.browser) ||
+		document.browser.executablePath === undefined
+	) {
+		return [];
 	}
+	return [
+		`Chrome DevTools project browser.executablePath ignored in ${filePath}; configure the machine-owned executable in ${settingsFilePath()}.`,
+	];
+}
+
+async function normalizeSettingsDocument(
+	document: Record<string, unknown>,
+	scope: "project" | "user",
+	filePath: string,
+	cwd?: string,
+): Promise<NormalizedSettingsDocument> {
+	const normalized: NormalizedSettingsDocument = {};
+
+	if (scope === "user" && (document.tools !== undefined || document.updatedAt !== undefined)) {
+		const toolSettings = normalizeChromeDevtoolsSettings(document);
+		if (!toolSettings) {
+			throw new Error(
+				"expected tools to be an array of Chrome DevTools tool names with numeric updatedAt",
+			);
+		}
+		normalized.tools = toolSettings.tools;
+		normalized.updatedAt = toolSettings.updatedAt;
+	}
+
+	if (document.browser !== undefined) {
+		if (!isRecord(document.browser)) throw new Error("expected browser to be an object");
+		normalized.browser = await normalizeBrowserSection(document.browser, scope, filePath, cwd);
+	}
+
+	return normalized;
+}
+
+async function normalizeBrowserSection(
+	browser: Record<string, unknown>,
+	scope: "project" | "user",
+	_filePath: string,
+	cwd?: string,
+): Promise<NormalizedBrowserSection> {
+	const normalized: NormalizedBrowserSection = {};
+	if (scope === "user" && browser.executablePath !== undefined) {
+		if (typeof browser.executablePath !== "string" || browser.executablePath.length === 0) {
+			throw new Error("expected browser.executablePath to be a non-empty absolute path");
+		}
+		if (!isAbsolute(browser.executablePath)) {
+			throw new Error("browser.executablePath in user settings must be absolute");
+		}
+		normalized.executablePath = resolve(browser.executablePath);
+	}
+
+	if (browser.extensionPaths !== undefined) {
+		if (
+			!Array.isArray(browser.extensionPaths) ||
+			!browser.extensionPaths.every((entry) => typeof entry === "string" && entry.length > 0)
+		) {
+			throw new Error(`expected ${scope} browser.extensionPaths to be an array of non-empty paths`);
+		}
+		const resolvedPaths: string[] = [];
+		for (const configuredPath of browser.extensionPaths as string[]) {
+			if (scope === "user" && !isAbsolute(configuredPath)) {
+				throw new Error("browser.extensionPaths in user settings must contain only absolute paths");
+			}
+			const absolutePath = isAbsolute(configuredPath)
+				? resolve(configuredPath)
+				: resolve(cwd ?? process.cwd(), configuredPath);
+			resolvedPaths.push(await validateUnpackedExtensionPath(absolutePath));
+		}
+		normalized.extensionPaths = orderedUnique(resolvedPaths);
+	}
+	return normalized;
+}
+
+async function validateUnpackedExtensionPath(extensionPath: string) {
+	let canonicalPath: string;
+	try {
+		canonicalPath = await realpath(extensionPath);
+		const extensionStat = await stat(canonicalPath);
+		if (!extensionStat.isDirectory()) throw new Error("not a directory");
+	} catch (error) {
+		throw new Error(`unpacked extension path ${extensionPath} is invalid: ${formatError(error)}`);
+	}
+
+	const manifestPath = join(canonicalPath, "manifest.json");
+	let manifest: unknown;
+	try {
+		const manifestStat = await lstat(manifestPath);
+		if (!manifestStat.isFile()) throw new Error("not a regular file");
+		manifest = JSON.parse(await readFile(manifestPath, "utf8")) as unknown;
+	} catch (error) {
+		throw new Error(
+			`unpacked extension ${canonicalPath} has invalid manifest.json: ${formatError(error)}`,
+		);
+	}
+	if (canonicalPath.includes(",")) {
+		throw new Error(
+			`unpacked extension path ${canonicalPath} cannot contain a comma because Chrome separates multiple --load-extension paths with commas`,
+		);
+	}
+	if (
+		!isRecord(manifest) ||
+		![2, 3].includes(manifest.manifest_version as number) ||
+		typeof manifest.name !== "string" ||
+		typeof manifest.version !== "string"
+	) {
+		throw new Error(
+			`unpacked extension ${canonicalPath} has invalid manifest.json: expected manifest_version, name, and version`,
+		);
+	}
+	return canonicalPath;
 }
 
 export function normalizeChromeDevtoolsSettings(
 	value: unknown,
 ): ChromeDevToolsSettings | undefined {
-	if (!value || typeof value !== "object") return undefined;
-	const settings = value as { tools?: unknown; updatedAt?: unknown };
-	if (typeof settings.updatedAt !== "number") return undefined;
+	if (!isRecord(value)) return undefined;
+	if (typeof value.updatedAt !== "number" || !Number.isFinite(value.updatedAt)) return undefined;
 
-	if (settings.tools === "enabled") {
-		return { tools: [...CHROME_DEVTOOLS_TOOL_NAMES], updatedAt: settings.updatedAt };
+	if (value.tools === "enabled") {
+		return { tools: [...CHROME_DEVTOOLS_TOOL_NAMES], updatedAt: value.updatedAt };
 	}
-	if (settings.tools === "disabled") return { tools: [], updatedAt: settings.updatedAt };
-
-	if (!Array.isArray(settings.tools)) return undefined;
-	if (!settings.tools.every(isChromeDevtoolsToolName)) return undefined;
-	return { tools: orderedUniqueChromeDevtoolsTools(settings.tools), updatedAt: settings.updatedAt };
+	if (value.tools === "disabled") return { tools: [], updatedAt: value.updatedAt };
+	if (!Array.isArray(value.tools) || !value.tools.every(isChromeDevtoolsToolName)) return undefined;
+	return { tools: orderedUniqueChromeDevtoolsTools(value.tools), updatedAt: value.updatedAt };
 }
 
 function isChromeDevtoolsToolName(value: unknown): value is ChromeDevToolsToolName {
@@ -141,7 +373,9 @@ function orderedUniqueChromeDevtoolsTools(tools: readonly ChromeDevToolsToolName
 	return CHROME_DEVTOOLS_TOOL_NAMES.filter((toolName) => selectedTools.has(toolName));
 }
 
-let settingsSaveQueue = Promise.resolve();
+function orderedUnique(values: readonly string[]) {
+	return [...new Set(values)];
+}
 
 export function saveSettings(
 	settings: ChromeDevToolsSettings,
@@ -157,13 +391,11 @@ async function saveSettingsNow(
 	operations: Partial<SettingsFileOperations>,
 ): Promise<void> {
 	const filePath = settingsFilePath();
-	let current = await readSettingsDocument(filePath);
-	const replaceCanonical = current.result.kind !== "missing";
-	if (!replaceCanonical) current = await readSettingsDocument(legacySettingsFilePath());
-	if (current.result.kind === "invalid") {
-		throw new Error(
-			`Cannot save Chrome DevTools settings until you repair ${current.result.reason}`,
-		);
+	let current = await readSettingsDocument(filePath, "user");
+	const replaceCanonical = current.kind !== "missing";
+	if (!replaceCanonical) current = await readSettingsDocument(legacySettingsFilePath(), "user");
+	if (current.kind === "invalid") {
+		throw new Error(`Cannot save Chrome DevTools settings until you repair ${current.reason}`);
 	}
 	const nextDocument = {
 		...(current.document ?? {}),
@@ -190,15 +422,38 @@ async function saveSettingsNow(
 }
 
 export function settingsFilePath() {
-	return join(agentDir(), NEW_SETTINGS_FILE_NAME);
+	return join(getAgentDir(), NEW_SETTINGS_FILE_NAME);
+}
+
+export function projectSettingsFilePath(cwd: string) {
+	return join(cwd, CONFIG_DIR_NAME, NEW_SETTINGS_FILE_NAME);
 }
 
 function legacySettingsFilePath() {
-	return join(agentDir(), LEGACY_SETTINGS_FILE_NAME);
+	return join(getAgentDir(), LEGACY_SETTINGS_FILE_NAME);
 }
 
-function agentDir() {
-	return getAgentDir();
+async function fileExists(filePath: string) {
+	try {
+		await access(filePath, constants.F_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function pathEntryExists(filePath: string) {
+	try {
+		await lstat(filePath);
+		return true;
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/packages/pi-chrome-devtools/src/tool-selector.ts
+++ b/packages/pi-chrome-devtools/src/tool-selector.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
 	browserCandidateHint,
@@ -18,10 +19,6 @@ type ToolSelectorAction = "toggle" | "enableAll" | "disableAll";
 
 function unique<T>(values: T[]) {
 	return Array.from(new Set(values));
-}
-
-function recordSettingsNotice(settings: { notice?: string }) {
-	if (settings.notice) state.settingsNotice = settings.notice;
 }
 
 function formatError(error: unknown) {
@@ -176,9 +173,11 @@ async function transactSelectedToolsNow(
 		}
 		if (expectedGeneration !== state.sessionGeneration) return false;
 		ctx.ui.notify(
-			rollbackError
-				? `Chrome DevTools settings save failed: ${formatError(error)}; active-tool rollback failed: ${formatError(rollbackError)}`
-				: `Chrome DevTools settings save failed; active tools restored: ${formatError(error)}`,
+			sanitizeChromeDevtoolsDisplay(
+				rollbackError
+					? `Chrome DevTools settings save failed: ${formatError(error)}; active-tool rollback failed: ${formatError(rollbackError)}`
+					: `Chrome DevTools settings save failed; active tools restored: ${formatError(error)}`,
+			),
 			"warning",
 		);
 		return false;
@@ -217,29 +216,71 @@ function getToolStatusSummary(pi: ExtensionAPI): ToolStatusSummary {
 export async function buildToolStatusMessage(pi: ExtensionAPI) {
 	const summary = getToolStatusSummary(pi);
 	const persistedSetting = await persistedSettingLabel();
-	return [
-		`Chrome DevTools tools: ${formatRuntimeStatus(summary)}`,
-		`Persisted selection: ${persistedSetting}`,
-		`Settings file: ${settingsFilePath()}`,
-		...(state.settingsNotice ? [`Settings note: ${state.settingsNotice}`] : []),
-		`Other active tools preserved: ${summary.activeNonChromeToolCount}`,
-		`Endpoint: ${devToolsEndpoint()}`,
-		`Endpoint source: ${endpointSourceLabel()}`,
-		`Launch mode: ${launchModeLabel()}`,
-		...launchAttemptLines(),
-	].join("\n");
+	return sanitizeChromeDevtoolsDisplay(
+		[
+			`Chrome DevTools tools: ${formatRuntimeStatus(summary)}`,
+			`Persisted selection: ${persistedSetting}`,
+			...browserSettingsStatusLines(),
+			...(state.settingsNotice ? [`Settings note: ${state.settingsNotice}`] : []),
+			`Other active tools preserved: ${summary.activeNonChromeToolCount}`,
+			`Endpoint: ${devToolsEndpoint()}`,
+			`Endpoint source: ${endpointSourceLabel()}`,
+			`Launch mode: ${launchModeLabel()}`,
+			...launchAttemptLines(),
+		].join("\n"),
+	);
 }
 
 export function buildQuickstartMessage() {
+	return sanitizeChromeDevtoolsDisplay(
+		[
+			`Chrome DevTools endpoint: ${devToolsEndpoint()}`,
+			`Endpoint source: ${endpointSourceLabel()}`,
+			`Launch mode: ${launchModeLabel()}`,
+			...browserSettingsStatusLines(),
+			launchHint(),
+			browserCandidateHint(),
+			...launchAttemptLines(),
+			endpointConfigHint(),
+		].join("\n"),
+	);
+}
+
+export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_000) {
+	const sanitized = Array.from(stripVTControlCharacters(value), (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		const unsafeControl =
+			(codePoint >= 0 && codePoint <= 8) ||
+			(codePoint >= 11 && codePoint <= 31) ||
+			(codePoint >= 127 && codePoint <= 159);
+		return unsafeControl ? "�" : character;
+	}).join("");
+	if (sanitized.length <= maxCharacters) return sanitized;
+	return `${sanitized.slice(0, Math.max(0, maxCharacters - 1))}…`;
+}
+
+function browserSettingsStatusLines() {
+	const extensionLines =
+		state.extensionPaths.length > 0
+			? state.extensionPaths.map((extensionPath) => `  - ${extensionPath}`)
+			: ["  - none"];
 	return [
-		`Chrome DevTools endpoint: ${devToolsEndpoint()}`,
-		`Endpoint source: ${endpointSourceLabel()}`,
-		`Launch mode: ${launchModeLabel()}`,
-		launchHint(),
-		browserCandidateHint(),
-		...launchAttemptLines(),
-		endpointConfigHint(),
-	].join("\n");
+		`Settings file: ${state.settingsFilePath ?? settingsFilePath()} (user)`,
+		...(state.projectSettingsFilePath
+			? [
+					`Project settings: ${state.projectSettingsFilePath} (${state.projectSettingsTrusted ? "trusted" : "untrusted; ignored"})`,
+				]
+			: []),
+		`Browser executable: ${state.browserExecutable ?? "automatic discovery"} (${state.browserExecutableSource})`,
+		`Unpacked extensions (${state.extensionPathsSource}):`,
+		...extensionLines,
+		"Settings changes apply to a new managed browser after /reload or session replacement.",
+		...(state.extensionPaths.length > 0
+			? [
+					"Unpacked extensions require Chrome for Testing or Chromium and execute trusted browser code.",
+				]
+			: []),
+	];
 }
 
 export function buildCommandGuide() {
@@ -283,8 +324,9 @@ function formatRuntimeStatus(summary: ToolStatusSummary) {
 
 async function persistedSettingLabel() {
 	const settings = await loadSettings();
-	recordSettingsNotice(settings);
-	if (settings.kind === "loaded") return formatPersistedSelection(settings.settings.tools);
+	if (settings.kind === "loaded" && settings.settings.tools) {
+		return formatPersistedSelection(settings.settings.tools);
+	}
 	if (settings.kind === "invalid") {
 		return `none; current active-tool policy preserved (invalid settings ignored: ${settings.reason})`;
 	}

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -30,6 +30,7 @@ import chromeDevtools, {
 	parseConfiguredPort,
 	quoteCommandPart,
 	resolveScreenshotPath,
+	sanitizeChromeDevtoolsDisplay,
 	selectAllowedRoot,
 } from "../src/chrome-devtools.js";
 import { saveSettings } from "../src/settings.js";
@@ -339,6 +340,14 @@ test("chrome-devtools serializes rapid tool saves in invocation order", async ()
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
 		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, []);
 	});
+});
+
+test("status display strips terminal controls and remains bounded", () => {
+	assert.equal(
+		sanitizeChromeDevtoolsDisplay("safe\u001b]8;;https://evil\u0007link\u001b]8;;\u0007"),
+		"safelink",
+	);
+	assert.equal(sanitizeChromeDevtoolsDisplay("12345", 4), "123…");
 });
 
 test("endpoint helpers normalize ports, hosts, and launch quoting", () => {

--- a/packages/pi-chrome-devtools/test/lifecycle.test.ts
+++ b/packages/pi-chrome-devtools/test/lifecycle.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { setBrowserManagerOperationsForTests } from "../src/browser-manager.js";
+import chromeDevtools from "../src/chrome-devtools.js";
+import { state } from "../src/runtime.js";
+import { projectSettingsFilePath, settingsFilePath } from "../src/settings.js";
+
+class LifecycleChild extends EventEmitter {
+	killCalls = 0;
+	kill() {
+		this.killCalls += 1;
+		queueMicrotask(() => this.emit("exit", 0, null));
+		return true;
+	}
+}
+
+async function withFixture(
+	fn: (fixture: {
+		cwdA: string;
+		cwdB: string;
+		extensionA: string;
+		extensionB: string;
+		executable: string;
+	}) => Promise<void>,
+) {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-cdp-lifecycle-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const agentDir = path.join(root, "agent");
+	const cwdA = path.join(root, "project-a");
+	const cwdB = path.join(root, "project-b");
+	const extensionA = path.join(root, "extension-a");
+	const extensionB = path.join(root, "extension-b");
+	const executable = path.join(root, "chrome-for-testing");
+	for (const directory of [agentDir, cwdA, cwdB, extensionA, extensionB]) {
+		mkdirSync(directory, { recursive: true });
+	}
+	for (const [directory, name] of [
+		[extensionA, "A"],
+		[extensionB, "B"],
+	] as const) {
+		writeFileSync(
+			path.join(directory, "manifest.json"),
+			JSON.stringify({ manifest_version: 3, name, version: "1.0.0" }),
+		);
+	}
+	writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+	chmodSync(executable, 0o755);
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		await fn({ cwdA, cwdB, extensionA, extensionB, executable });
+	} finally {
+		state.sessionController.abort();
+		state.sessionGeneration += 1;
+		state.managedBrowser = undefined;
+		state.launchPromise = undefined;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+function writeJson(filePath: string, value: unknown) {
+	mkdirSync(path.dirname(filePath), { recursive: true });
+	writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+test("session_start applies trusted project browser settings and status reports effective sources", async () => {
+	await withFixture(async ({ cwdA, extensionA, extensionB, executable }) => {
+		writeJson(settingsFilePath(), {
+			browser: { executablePath: executable, extensionPaths: [extensionA] },
+		});
+		writeJson(projectSettingsFilePath(cwdA), {
+			browser: { extensionPaths: [path.relative(cwdA, extensionB)] },
+		});
+		const mock = createMockPi();
+		const { ctx, notifications } = createMockContext({
+			cwd: cwdA,
+			mode: "rpc",
+			hasUI: true,
+			isProjectTrusted: () => true,
+		});
+		chromeDevtools(mock.pi);
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await mock.commands.get("chrome-devtools")?.handler("status", ctx);
+
+		assert.deepEqual(state.extensionPaths, [extensionB]);
+		assert.equal(state.browserExecutable, executable);
+		assert.equal(state.extensionPathsSource, "project");
+		const status = notifications.at(-1)?.message ?? "";
+		assert.match(status, new RegExp(`Project settings: .*${path.basename(cwdA)}.*trusted`));
+		assert.match(status, /Unpacked extensions \(project\)/);
+		assert.match(status, /Chrome for Testing or Chromium/);
+		assert.match(status, /after \/reload or session replacement/);
+	});
+});
+
+test("session replacement discards the stale continuation and applies only the latest cwd", async () => {
+	await withFixture(async ({ cwdA, cwdB, extensionA, extensionB, executable }) => {
+		writeJson(settingsFilePath(), { browser: { executablePath: executable } });
+		writeJson(projectSettingsFilePath(cwdA), {
+			browser: { extensionPaths: [path.relative(cwdA, extensionA)] },
+		});
+		writeJson(projectSettingsFilePath(cwdB), {
+			browser: { extensionPaths: [path.relative(cwdB, extensionB)] },
+		});
+		const mock = createMockPi();
+		chromeDevtools(mock.pi);
+		const first = createMockContext({ cwd: cwdA, isProjectTrusted: () => true }).ctx;
+		const second = createMockContext({ cwd: cwdB, isProjectTrusted: () => true }).ctx;
+
+		const firstStart = mock.events.get("session_start")?.[0]?.({}, first);
+		const secondStart = mock.events.get("session_start")?.[0]?.({}, second);
+		await Promise.all([firstStart, secondStart]);
+
+		assert.deepEqual(state.extensionPaths, [extensionB]);
+		assert.equal(state.projectSettingsFilePath, projectSettingsFilePath(cwdB));
+	});
+});
+
+test("session_shutdown clears status and releases an owned browser once", async () => {
+	await withFixture(async () => {
+		const child = new LifecycleChild();
+		const removed: string[] = [];
+		const restore = setBrowserManagerOperationsForTests({
+			rm: async (target) => {
+				removed.push(target);
+			},
+		});
+		state.managedBrowser = {
+			process: child as unknown as ChildProcess,
+			userDataDir: "/tmp/lifecycle-profile",
+			exited: false,
+			ready: true,
+			ownerGeneration: state.sessionGeneration,
+		};
+		const mock = createMockPi();
+		const { ctx, statuses } = createMockContext();
+		chromeDevtools(mock.pi);
+		try {
+			await Promise.all([
+				mock.events.get("session_shutdown")?.[0]?.({}, ctx),
+				mock.events.get("session_shutdown")?.[0]?.({}, ctx),
+			]);
+			assert.equal(child.killCalls, 1);
+			assert.deepEqual(removed, ["/tmp/lifecycle-profile"]);
+			assert.equal(statuses.get("chrome-devtools"), undefined);
+			assert.equal(state.managedBrowser, undefined);
+		} finally {
+			restore();
+		}
+	});
+});

--- a/packages/pi-chrome-devtools/test/managed-browser.test.ts
+++ b/packages/pi-chrome-devtools/test/managed-browser.test.ts
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import {
+	buildManagedBrowserLaunchArguments,
+	classifyExtensionBrowserVersion,
+	ensureDevToolsEndpoint,
+	setBrowserManagerOperationsForTests,
+	shutdownManagedBrowser,
+} from "../src/browser-manager.js";
+import { state } from "../src/runtime.js";
+
+class FakeChildProcess extends EventEmitter {
+	exited = false;
+	killCalls: Array<NodeJS.Signals | undefined> = [];
+
+	kill(signal?: NodeJS.Signals) {
+		this.killCalls.push(signal);
+		if (!this.exited) {
+			this.exited = true;
+			queueMicrotask(() => this.emit("exit", 0, signal ?? null));
+		}
+		return true;
+	}
+}
+
+function resetRuntime(overrides: Partial<typeof state> = {}) {
+	state.sessionController.abort();
+	Object.assign(state, {
+		host: "127.0.0.1",
+		port: 9222,
+		configuredPort: 9222,
+		hostConfigured: false,
+		portConfigured: false,
+		autoLaunchEnabled: true,
+		browserExecutable: "/test/chrome-for-testing",
+		extensionPaths: ["/test/extension-a", "/test/extension-b"],
+		browserExecutableSource: "user",
+		extensionPathsSource: "user",
+		managedBrowser: undefined,
+		launchPromise: undefined,
+		lastLaunchAttempt: undefined,
+		shuttingDown: false,
+		sessionGeneration: state.sessionGeneration + 1,
+		sessionController: new AbortController(),
+		...overrides,
+	});
+}
+
+function successfulOperations(options: { portAvailable?: boolean } = {}) {
+	const child = new FakeChildProcess();
+	const calls = {
+		spawn: [] as Array<{ executable: string; args: string[]; shell: boolean | undefined }>,
+		fetch: [] as string[],
+		rm: [] as string[],
+		version: [] as string[],
+	};
+	const restore = setBrowserManagerOperationsForTests({
+		access: async () => undefined,
+		mkdtemp: async () => "/tmp/test-managed-profile",
+		readFile: async () => "9333\n/devtools/browser/test\n",
+		rm: async (target) => {
+			calls.rm.push(target);
+		},
+		fetch: async (input) => {
+			calls.fetch.push(String(input));
+			return new Response(JSON.stringify({ Browser: "Chrome/149" }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		},
+		inspectBrowserVersion: async (executable) => {
+			calls.version.push(executable);
+			return "Google Chrome for Testing 149.0.0.0";
+		},
+		isPortAvailable: async () => options.portAvailable ?? true,
+		sleep: async () => undefined,
+		spawn: (executable, args, spawnOptions) => {
+			calls.spawn.push({ executable, args, shell: spawnOptions.shell });
+			queueMicrotask(() => child.emit("spawn"));
+			return child as unknown as ChildProcess;
+		},
+	});
+	return { child, calls, restore };
+}
+
+test("managed extension argv is deterministic and keeps multiple paths in shell-free arguments", () => {
+	assert.deepEqual(
+		buildManagedBrowserLaunchArguments("/tmp/profile", "0", [
+			"/extensions/one with spaces",
+			"/extensions/two",
+		]),
+		[
+			"--remote-debugging-port=0",
+			"--user-data-dir=/tmp/profile",
+			"--disable-extensions-except=/extensions/one with spaces,/extensions/two",
+			"--load-extension=/extensions/one with spaces,/extensions/two",
+			...(process.platform === "win32" ? ["--do-not-de-elevate"] : []),
+			"--no-first-run",
+			"--no-default-browser-check",
+			"about:blank",
+		],
+	);
+});
+
+test("browser product classification accepts Chrome for Testing and Chromium only", () => {
+	assert.deepEqual(classifyExtensionBrowserVersion("Google Chrome for Testing 149.0.0.0"), {
+		supported: true,
+		product: "Chrome for Testing",
+	});
+	assert.deepEqual(classifyExtensionBrowserVersion("Chromium 149.0.0.0"), {
+		supported: true,
+		product: "Chromium",
+	});
+	assert.equal(classifyExtensionBrowserVersion("Google Chrome 148.0.0.0").supported, false);
+	assert.equal(classifyExtensionBrowserVersion("Brave Browser 1.0 Chromium 149").supported, false);
+});
+
+test("extension-configured endpoints bypass attach-first and launch an owned browser", async () => {
+	resetRuntime();
+	const { calls, restore } = successfulOperations();
+	try {
+		await ensureDevToolsEndpoint();
+		assert.equal(calls.spawn.length, 1);
+		assert.equal(calls.spawn[0]?.shell, false);
+		assert.equal(calls.fetch.length, 1, "only the post-spawn readiness check should fetch");
+		assert.deepEqual(calls.version, ["/test/chrome-for-testing"]);
+		assert.equal(state.port, 9333);
+		assert.equal(state.managedBrowser?.ready, true);
+	} finally {
+		await shutdownManagedBrowser();
+		restore();
+	}
+});
+
+test("extension launch rejects remote, disabled, missing, unsupported, and occupied modes before spawn", async () => {
+	for (const scenario of [
+		{ overrides: { host: "remote.example" }, pattern: /local.*managed browser/i },
+		{ overrides: { autoLaunchEnabled: false }, pattern: /auto-launch.*required/i },
+		{ overrides: { browserExecutable: undefined }, pattern: /executablePath.*Chrome for Testing/i },
+	] as const) {
+		resetRuntime(scenario.overrides);
+		const { calls, restore } = successfulOperations();
+		try {
+			await assert.rejects(ensureDevToolsEndpoint(), scenario.pattern);
+			assert.equal(calls.spawn.length, 0);
+		} finally {
+			restore();
+		}
+	}
+
+	resetRuntime();
+	const unsupported = successfulOperations();
+	unsupported.restore();
+	const restoreUnsupported = setBrowserManagerOperationsForTests({
+		access: async () => undefined,
+		inspectBrowserVersion: async () => "Google Chrome 148.0.0.0",
+		spawn: (..._args) => {
+			throw new Error("must not spawn");
+		},
+	});
+	try {
+		await assert.rejects(
+			ensureDevToolsEndpoint(),
+			/unsupported.*Google Chrome.*Chrome for Testing/i,
+		);
+	} finally {
+		restoreUnsupported();
+	}
+
+	resetRuntime({ portConfigured: true });
+	const occupied = successfulOperations({ portAvailable: false });
+	try {
+		await assert.rejects(ensureDevToolsEndpoint(), /port 9222.*already in use/i);
+		assert.equal(occupied.calls.spawn.length, 0);
+	} finally {
+		occupied.restore();
+	}
+});
+
+test("a missing configured extension browser fails with Chrome for Testing guidance", async () => {
+	resetRuntime({ browserExecutable: "/missing/chrome-for-testing" });
+	let spawnCalls = 0;
+	const restore = setBrowserManagerOperationsForTests({
+		access: async () => Promise.reject(new Error("missing")),
+		spawn: () => {
+			spawnCalls += 1;
+			return new FakeChildProcess() as unknown as ChildProcess;
+		},
+	});
+	try {
+		await assert.rejects(
+			ensureDevToolsEndpoint(),
+			/not found or is not executable.*Chrome for Testing or Chromium/is,
+		);
+		assert.equal(spawnCalls, 0);
+	} finally {
+		restore();
+	}
+});
+
+test("partial spawn failure removes the owned profile and leaves no managed browser", async () => {
+	resetRuntime();
+	const child = new FakeChildProcess();
+	const removed: string[] = [];
+	const restore = setBrowserManagerOperationsForTests({
+		access: async () => undefined,
+		inspectBrowserVersion: async () => "Chromium 149.0.0.0",
+		isPortAvailable: async () => true,
+		mkdtemp: async () => "/tmp/partial-profile",
+		rm: async (target) => {
+			removed.push(target);
+		},
+		spawn: () => {
+			queueMicrotask(() => child.emit("error", new Error("spawn failed")));
+			return child as unknown as ChildProcess;
+		},
+	});
+	try {
+		await assert.rejects(ensureDevToolsEndpoint(), /spawn failed/);
+		assert.equal(state.managedBrowser, undefined);
+		assert.deepEqual(removed, ["/tmp/partial-profile"]);
+	} finally {
+		restore();
+	}
+});
+
+test("session cancellation after an awaited profile allocation prevents spawn and cleans up", async () => {
+	resetRuntime();
+	let releaseProfile: (() => void) | undefined;
+	const profileAllocated = new Promise<void>((resolve) => {
+		releaseProfile = resolve;
+	});
+	let continueProfile: (() => void) | undefined;
+	const profileBlocked = new Promise<void>((resolve) => {
+		continueProfile = resolve;
+	});
+	let spawnCalls = 0;
+	const removed: string[] = [];
+	const restore = setBrowserManagerOperationsForTests({
+		access: async () => undefined,
+		inspectBrowserVersion: async () => "Chromium 149.0.0.0",
+		isPortAvailable: async () => true,
+		mkdtemp: async () => {
+			releaseProfile?.();
+			await profileBlocked;
+			return "/tmp/cancelled-profile";
+		},
+		rm: async (target) => {
+			removed.push(target);
+		},
+		spawn: () => {
+			spawnCalls += 1;
+			return new FakeChildProcess() as unknown as ChildProcess;
+		},
+	});
+	try {
+		const launch = ensureDevToolsEndpoint();
+		await profileAllocated;
+		state.sessionController.abort();
+		state.sessionGeneration += 1;
+		continueProfile?.();
+		await assert.rejects(launch, /cancelled|replaced/i);
+		assert.equal(spawnCalls, 0);
+		assert.deepEqual(removed, ["/tmp/cancelled-profile"]);
+	} finally {
+		restore();
+	}
+});
+
+test("repeated shutdown kills and removes an owned browser exactly once", async () => {
+	resetRuntime();
+	const { child, calls, restore } = successfulOperations();
+	try {
+		await ensureDevToolsEndpoint();
+		const managed = state.managedBrowser;
+		assert.ok(managed);
+		await Promise.all([shutdownManagedBrowser(managed), shutdownManagedBrowser(managed)]);
+		assert.equal(child.killCalls.length, 1);
+		assert.deepEqual(calls.rm, ["/tmp/test-managed-profile"]);
+	} finally {
+		restore();
+	}
+});
+
+test("no-extension mode preserves attach-first behavior", async () => {
+	resetRuntime({ extensionPaths: [] });
+	const { calls, restore } = successfulOperations();
+	try {
+		await ensureDevToolsEndpoint();
+		assert.equal(calls.fetch.length, 1);
+		assert.equal(calls.spawn.length, 0);
+	} finally {
+		restore();
+	}
+});

--- a/packages/pi-chrome-devtools/test/settings.test.ts
+++ b/packages/pi-chrome-devtools/test/settings.test.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	loadSettings,
+	projectSettingsFilePath,
+	saveSettings,
+	settingsFilePath,
+} from "../src/settings.js";
+
+const LIST_PAGES_TOOL = "chrome_devtools_list_pages";
+
+async function withSettingsFixture(
+	fn: (fixture: {
+		agentDir: string;
+		cwd: string;
+		extensionA: string;
+		extensionB: string;
+		executable: string;
+	}) => Promise<void>,
+) {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-cdp-browser-settings-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const previousBrowser = process.env.PI_CHROME_DEVTOOLS_BROWSER;
+	const agentDir = path.join(root, "agent");
+	const cwd = path.join(root, "project");
+	const extensionA = path.join(root, "extension-a");
+	const extensionB = path.join(root, "extension-b");
+	const executable = path.join(root, "chrome-for-testing");
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(path.join(cwd, ".pi"), { recursive: true });
+	createExtension(extensionA, "extension-a");
+	createExtension(extensionB, "extension-b");
+	writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+	chmodSync(executable, 0o755);
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	delete process.env.PI_CHROME_DEVTOOLS_BROWSER;
+	try {
+		await fn({ agentDir, cwd, extensionA, extensionB, executable });
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		if (previousBrowser === undefined) delete process.env.PI_CHROME_DEVTOOLS_BROWSER;
+		else process.env.PI_CHROME_DEVTOOLS_BROWSER = previousBrowser;
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+function createExtension(directory: string, name: string) {
+	mkdirSync(directory, { recursive: true });
+	writeFileSync(
+		path.join(directory, "manifest.json"),
+		JSON.stringify({ manifest_version: 3, name, version: "1.0.0" }),
+	);
+}
+
+function writeJson(filePath: string, value: unknown) {
+	mkdirSync(path.dirname(filePath), { recursive: true });
+	writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+test("browser-only user settings load without creating or requiring tool settings", async () => {
+	await withSettingsFixture(async ({ cwd, extensionA, executable }) => {
+		writeJson(settingsFilePath(), {
+			browser: { executablePath: executable, extensionPaths: [extensionA] },
+			future: { kept: true },
+		});
+
+		const loaded = await loadSettings({ cwd, projectTrusted: false });
+
+		assert.equal(loaded.kind, "loaded");
+		assert.equal(loaded.settings?.tools, undefined);
+		assert.deepEqual(loaded.effectiveBrowser, {
+			executablePath: executable,
+			extensionPaths: [extensionA],
+			executablePathSource: "user",
+			extensionPathsSource: "user",
+		});
+		assert.deepEqual(loaded.warnings, []);
+	});
+});
+
+test("missing user and project settings are side-effect free defaults", async () => {
+	await withSettingsFixture(async ({ agentDir, cwd }) => {
+		rmSync(agentDir, { recursive: true, force: true });
+		rmSync(path.join(cwd, ".pi"), { recursive: true, force: true });
+
+		const loaded = await loadSettings({ cwd, projectTrusted: true });
+
+		assert.equal(loaded.kind, "missing");
+		assert.deepEqual(loaded.effectiveBrowser.extensionPaths, []);
+		assert.equal(existsSync(settingsFilePath()), false);
+		assert.equal(existsSync(projectSettingsFilePath(cwd)), false);
+	});
+});
+
+test("an explicit empty tool selection remains a loaded global setting", async () => {
+	await withSettingsFixture(async ({ cwd }) => {
+		writeJson(settingsFilePath(), { tools: [], updatedAt: 1 });
+
+		const loaded = await loadSettings({ cwd, projectTrusted: false });
+
+		assert.equal(loaded.kind, "loaded");
+		assert.deepEqual(loaded.settings?.tools, []);
+	});
+});
+
+test("user browser paths must be absolute and point to valid unpacked manifests", async () => {
+	await withSettingsFixture(async ({ cwd, executable }) => {
+		writeJson(settingsFilePath(), {
+			browser: { executablePath: executable, extensionPaths: ["relative-extension"] },
+		});
+		const relative = await loadSettings({ cwd, projectTrusted: false });
+		assert.equal(relative.kind, "invalid");
+		assert.match(relative.warnings.join("\n"), /absolute/i);
+
+		const missingManifest = path.join(path.dirname(executable), "missing-manifest");
+		mkdirSync(missingManifest);
+		writeJson(settingsFilePath(), {
+			browser: { executablePath: executable, extensionPaths: [missingManifest] },
+		});
+		const invalidManifest = await loadSettings({ cwd, projectTrusted: false });
+		assert.equal(invalidManifest.kind, "invalid");
+		assert.match(invalidManifest.warnings.join("\n"), /manifest\.json/i);
+
+		const commaPath = path.join(path.dirname(executable), "extension,with-comma");
+		createExtension(commaPath, "comma");
+		writeJson(settingsFilePath(), {
+			browser: { executablePath: executable, extensionPaths: [commaPath] },
+		});
+		const invalidComma = await loadSettings({ cwd, projectTrusted: false });
+		assert.equal(invalidComma.kind, "invalid");
+		assert.match(invalidComma.warnings.join("\n"), /cannot contain a comma/i);
+	});
+});
+
+test("trusted project extension paths resolve from cwd and replace the user array", async () => {
+	await withSettingsFixture(async ({ cwd, extensionA, extensionB, executable }) => {
+		writeJson(settingsFilePath(), {
+			browser: { executablePath: executable, extensionPaths: [extensionA] },
+		});
+		const relativeExtension = path.relative(cwd, extensionB);
+		writeJson(projectSettingsFilePath(cwd), {
+			browser: { extensionPaths: [relativeExtension] },
+		});
+
+		const loaded = await loadSettings({ cwd, projectTrusted: true });
+
+		assert.equal(loaded.kind, "loaded");
+		assert.deepEqual(loaded.effectiveBrowser.extensionPaths, [extensionB]);
+		assert.equal(loaded.effectiveBrowser.extensionPathsSource, "project");
+		assert.equal(loaded.effectiveBrowser.executablePath, executable);
+		assert.equal(loaded.effectiveBrowser.executablePathSource, "user");
+	});
+});
+
+test("untrusted projects are not read or allowed to override browser settings", async () => {
+	await withSettingsFixture(async ({ cwd, extensionA, executable }) => {
+		writeJson(settingsFilePath(), {
+			browser: { executablePath: executable, extensionPaths: [extensionA] },
+		});
+		writeFileSync(projectSettingsFilePath(cwd), "{ this project file is intentionally invalid");
+
+		const loaded = await loadSettings({ cwd, projectTrusted: false });
+
+		assert.equal(loaded.kind, "loaded");
+		assert.deepEqual(loaded.effectiveBrowser.extensionPaths, [extensionA]);
+		assert.deepEqual(loaded.warnings, []);
+	});
+});
+
+test("project executablePath is ignored while invalid project extension settings are warned", async () => {
+	await withSettingsFixture(async ({ cwd, extensionA, executable }) => {
+		writeJson(settingsFilePath(), {
+			browser: { executablePath: executable, extensionPaths: [extensionA] },
+		});
+		writeJson(projectSettingsFilePath(cwd), {
+			browser: { executablePath: "/project/cannot/override", extensionPaths: [42] },
+		});
+
+		const loaded = await loadSettings({ cwd, projectTrusted: true });
+
+		assert.equal(loaded.effectiveBrowser.executablePath, executable);
+		assert.deepEqual(loaded.effectiveBrowser.extensionPaths, [extensionA]);
+		assert.match(loaded.warnings.join("\n"), /project.*extensionPaths/i);
+		assert.match(loaded.warnings.join("\n"), /executablePath.*ignored/i);
+	});
+});
+
+test("environment browser executable remains the explicit runtime override", async () => {
+	await withSettingsFixture(async ({ cwd, executable }) => {
+		writeJson(settingsFilePath(), { browser: { executablePath: executable } });
+		process.env.PI_CHROME_DEVTOOLS_BROWSER = "chromium-from-environment";
+
+		const loaded = await loadSettings({ cwd, projectTrusted: false });
+
+		assert.equal(loaded.effectiveBrowser.executablePath, "chromium-from-environment");
+		assert.equal(loaded.effectiveBrowser.executablePathSource, "environment");
+	});
+});
+
+test("global tool saves preserve valid browser and unknown sibling fields", async () => {
+	await withSettingsFixture(async ({ extensionA, executable }) => {
+		writeJson(settingsFilePath(), {
+			browser: { executablePath: executable, extensionPaths: [extensionA] },
+			future: { kept: true },
+		});
+
+		await saveSettings({ tools: [LIST_PAGES_TOOL], updatedAt: 2 });
+
+		const saved = JSON.parse(readFileSync(settingsFilePath(), "utf8")) as Record<string, unknown>;
+		assert.deepEqual(saved.browser, {
+			executablePath: executable,
+			extensionPaths: [extensionA],
+		});
+		assert.deepEqual(saved.future, { kept: true });
+		assert.deepEqual(saved.tools, [LIST_PAGES_TOOL]);
+	});
+});
+
+test("pending global saves finish before a dependent settings read", async () => {
+	await withSettingsFixture(async ({ cwd }) => {
+		let releaseWrite: (() => void) | undefined;
+		const writeStarted = new Promise<void>((resolve) => {
+			releaseWrite = resolve;
+		});
+		let unblockWrite: (() => void) | undefined;
+		const writeBlock = new Promise<void>((resolve) => {
+			unblockWrite = resolve;
+		});
+		const save = saveSettings(
+			{ tools: [LIST_PAGES_TOOL], updatedAt: 3 },
+			{
+				write: async (temporaryPath, data) => {
+					writeFileSync(temporaryPath, data);
+					releaseWrite?.();
+					await writeBlock;
+				},
+			},
+		);
+		await writeStarted;
+		let readSettled = false;
+		const read = loadSettings({ cwd, projectTrusted: false }).then((value) => {
+			readSettled = true;
+			return value;
+		});
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+		assert.equal(readSettled, false);
+		unblockWrite?.();
+		await save;
+
+		const loaded = await read;
+		assert.deepEqual(loaded.settings?.tools, [LIST_PAGES_TOOL]);
+	});
+});


### PR DESCRIPTION
## Summary

- add canonical user and trusted project settings for Chrome for Testing/Chromium executables and unpacked extension paths
- force extension-configured sessions into an isolated extension-owned browser with safe startup argv and actionable launch validation
- preserve existing attach-first behavior when no extensions are configured, with lifecycle-safe cleanup, status/help output, documentation, and release intent

Closes #600.

## Verification

- focused compiled Chrome DevTools tests: 46 passed
- `npm run check --workspace @narumitw/pi-chrome-devtools`
- `npm test`: 2,514 passed
- `npm run check`: Biome, boundaries, typechecks, and 2,514 tests passed
- `just pack chrome-devtools`: 14 expected files
- `npm run changeset:status`: minor bump to `0.50.0`
- `git diff --check`
- real-browser smoke on Linux x64 with Chrome for Testing 149.0.7827.55: Manifest V3 service worker, navigation, evaluation, screenshot, replacement cleanup, and external-browser isolation passed

## Notes

- unpacked extensions require Chrome for Testing or Chromium; branded Chrome is rejected because it may silently ignore startup flags
- settings changes apply after `/reload` or session replacement
- the completed implementation plan is archived under `docs/plans/archived/`
