### PR TITLE
fix(chrome-devtools): reuse owned explicit-port browser

### DIFF
--- a/packages/pi-chrome-devtools/src/browser-manager.ts
+++ b/packages/pi-chrome-devtools/src/browser-manager.ts
@@ -71,10 +71,7 @@ function normalizePathForComparison(value: string) {
 
 export async function ensureDevToolsEndpoint(waitMs = DEFAULT_ENDPOINT_WAIT_MS) {
 	if (extensionsConfigured()) {
-		const generation = state.sessionGeneration;
-		const signal = state.sessionController.signal;
-		await validateExtensionLaunchMode(generation, signal);
-		throwIfBrowserLaunchCancelled(generation, signal);
+		validateExtensionLaunchMode();
 		await ensureManagedBrowserLaunched(waitMs);
 		return;
 	}
@@ -99,7 +96,7 @@ export async function ensureDevToolsEndpoint(waitMs = DEFAULT_ENDPOINT_WAIT_MS) 
 	}
 }
 
-async function validateExtensionLaunchMode(generation: number, signal: AbortSignal) {
+function validateExtensionLaunchMode() {
 	if (!isLocalDevToolsHost(state.host)) {
 		throw new DevToolsEndpointError(
 			"Unpacked extensions require a local extension-owned managed browser; remote CDP endpoints cannot be modified.",
@@ -115,6 +112,32 @@ async function validateExtensionLaunchMode(generation: number, signal: AbortSign
 			"Unpacked extensions require browser.executablePath for Chrome for Testing or Chromium in pi-chrome-devtools.json.",
 		);
 	}
+}
+
+async function ensureManagedBrowserLaunched(waitMs: number) {
+	if (state.launchPromise) return state.launchPromise;
+	if (state.managedBrowser && !state.managedBrowser.exited && state.managedBrowser.ready) return;
+	const generation = state.sessionGeneration;
+	const signal = state.sessionController.signal;
+	throwIfBrowserLaunchCancelled(generation, signal);
+
+	const launchPromise = prepareManagedBrowserLaunch(waitMs, generation, signal);
+	const wrappedPromise = launchPromise.finally(() => {
+		if (state.launchPromise === wrappedPromise) state.launchPromise = undefined;
+	});
+	state.launchPromise = wrappedPromise;
+	return wrappedPromise;
+}
+
+async function prepareManagedBrowserLaunch(
+	waitMs: number,
+	generation: number,
+	signal: AbortSignal,
+) {
+	if (state.managedBrowser) {
+		await shutdownManagedBrowser(state.managedBrowser, { awaitLaunch: false });
+		throwIfBrowserLaunchCancelled(generation, signal);
+	}
 	if (state.portConfigured) {
 		const available = await browserManagerOperations.isPortAvailable(state.host, state.port);
 		throwIfBrowserLaunchCancelled(generation, signal);
@@ -124,24 +147,7 @@ async function validateExtensionLaunchMode(generation: number, signal: AbortSign
 			);
 		}
 	}
-}
-
-async function ensureManagedBrowserLaunched(waitMs: number) {
-	if (state.launchPromise) return state.launchPromise;
-	if (state.managedBrowser && !state.managedBrowser.exited && state.managedBrowser.ready) return;
-	if (state.managedBrowser) {
-		await shutdownManagedBrowser(state.managedBrowser, { awaitLaunch: false });
-	}
-	const generation = state.sessionGeneration;
-	const signal = state.sessionController.signal;
-	throwIfBrowserLaunchCancelled(generation, signal);
-
-	const launchPromise = launchManagedBrowser(waitMs, generation, signal);
-	const wrappedPromise = launchPromise.finally(() => {
-		if (state.launchPromise === wrappedPromise) state.launchPromise = undefined;
-	});
-	state.launchPromise = wrappedPromise;
-	return wrappedPromise;
+	return launchManagedBrowser(waitMs, generation, signal);
 }
 
 async function launchManagedBrowser(waitMs: number, generation: number, signal: AbortSignal) {

--- a/packages/pi-chrome-devtools/test/managed-browser.test.ts
+++ b/packages/pi-chrome-devtools/test/managed-browser.test.ts
@@ -48,7 +48,12 @@ function resetRuntime(overrides: Partial<typeof state> = {}) {
 	});
 }
 
-function successfulOperations(options: { portAvailable?: boolean } = {}) {
+function successfulOperations(
+	options: {
+		portAvailable?: boolean | (() => boolean);
+		fetch?: (input: string) => Promise<Response>;
+	} = {},
+) {
 	const child = new FakeChildProcess();
 	const calls = {
 		spawn: [] as Array<{ executable: string; args: string[]; shell: boolean | undefined }>,
@@ -64,7 +69,9 @@ function successfulOperations(options: { portAvailable?: boolean } = {}) {
 			calls.rm.push(target);
 		},
 		fetch: async (input) => {
-			calls.fetch.push(String(input));
+			const url = String(input);
+			calls.fetch.push(url);
+			if (options.fetch) return options.fetch(url);
 			return new Response(JSON.stringify({ Browser: "Chrome/149" }), {
 				status: 200,
 				headers: { "content-type": "application/json" },
@@ -74,7 +81,10 @@ function successfulOperations(options: { portAvailable?: boolean } = {}) {
 			calls.version.push(executable);
 			return "Google Chrome for Testing 149.0.0.0";
 		},
-		isPortAvailable: async () => options.portAvailable ?? true,
+		isPortAvailable: async () =>
+			typeof options.portAvailable === "function"
+				? options.portAvailable()
+				: (options.portAvailable ?? true),
 		sleep: async () => undefined,
 		spawn: (executable, args, spawnOptions) => {
 			calls.spawn.push({ executable, args, shell: spawnOptions.shell });
@@ -176,6 +186,63 @@ test("extension launch rejects remote, disabled, missing, unsupported, and occup
 		assert.equal(occupied.calls.spawn.length, 0);
 	} finally {
 		occupied.restore();
+	}
+});
+
+test("a ready extension browser on an explicit port is reused without rechecking its port", async () => {
+	resetRuntime({ portConfigured: true });
+	let portChecks = 0;
+	const { calls, restore } = successfulOperations({
+		portAvailable: () => {
+			portChecks += 1;
+			return portChecks === 1;
+		},
+	});
+	try {
+		await ensureDevToolsEndpoint();
+		await ensureDevToolsEndpoint();
+		assert.equal(portChecks, 1);
+		assert.equal(calls.spawn.length, 1);
+	} finally {
+		await shutdownManagedBrowser();
+		restore();
+	}
+});
+
+test("an in-flight extension launch owns its explicit port for concurrent callers", async () => {
+	resetRuntime({ portConfigured: true });
+	let portChecks = 0;
+	let signalReadinessStarted: (() => void) | undefined;
+	const readinessStarted = new Promise<void>((resolve) => {
+		signalReadinessStarted = resolve;
+	});
+	let releaseReadiness: (() => void) | undefined;
+	const readinessBlocked = new Promise<void>((resolve) => {
+		releaseReadiness = resolve;
+	});
+	const { calls, restore } = successfulOperations({
+		portAvailable: () => {
+			portChecks += 1;
+			return portChecks === 1;
+		},
+		fetch: async () => {
+			signalReadinessStarted?.();
+			await readinessBlocked;
+			return new Response(JSON.stringify({ Browser: "Chrome/149" }), { status: 200 });
+		},
+	});
+	try {
+		const first = ensureDevToolsEndpoint();
+		await readinessStarted;
+		const launches = Promise.all([first, ensureDevToolsEndpoint()]);
+		releaseReadiness?.();
+		await launches;
+		assert.equal(portChecks, 1);
+		assert.equal(calls.spawn.length, 1);
+	} finally {
+		releaseReadiness?.();
+		await shutdownManagedBrowser();
+		restore();
 	}
 });
 


### PR DESCRIPTION
## Summary

- check explicit-port availability only when starting a new managed browser
- publish launch ownership before awaited preparation so concurrent callers reuse in-flight work
- cover ready and concurrent explicit-port browser reuse with regression tests

Follow-up to #620. Addresses the resolved review finding in https://github.com/narumiruna/pi-extensions/pull/620#discussion_r3738118771.

## Verification

- `npm run check` (2,520 tests passed)