### PR TITLE
feat(chrome-devtools): redesign manager menu

### DIFF
--- a/.changeset/calm-browsers-review.md
+++ b/.changeset/calm-browsers-review.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-chrome-devtools": minor
+---
+
+Redesign the Chrome DevTools manager around visible runtime state, staged tool selection with exact review, shallow status/setup/help navigation, and explicit cross-mode behavior.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -48,6 +48,7 @@
 - `Editor.getText()` retains large pastes as markers; use `getExpandedText()` when moving a draft outside that editor.
 - Tests constructing `BorderedLoader` must initialize a theme and dispose the loader harness so its animation timer cannot keep Node alive.
 - Kit settings and multi-select actions settle asynchronously. UI harnesses must drain pending callbacks and observe an accepted transition; use the async-capable harness with `runCustomInteraction()`.
+- Assertions thrown inside mocked `ctx.ui.custom()` callbacks can be caught as menu runtime errors; capture render evidence and assert after the command completes.
 - Searchable TUI wrappers should reserve only a standalone Space key for activation; stripping spaces from an entire input chunk corrupts pasted multi-token queries.
 
 ### Integrations and package-specific traps

--- a/docs/plans/archived/2026-08-08_pi-chrome-devtools-menu-redesign-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-chrome-devtools-menu-redesign-plan.md
@@ -119,7 +119,7 @@ and provide width-safe, keyboard-accessible TUI and RPC behavior with actionable
       Evidence: TUI and RPC stage/cancel/review/apply tests pass.
 - [x] Add focused transaction coverage for idle-boundary application, non-Chrome-tool preservation,
       invalid settings, write/rename failure, runtime rollback, retryable drafts, rapid direct updates,
-      stale generation, session replacement, and shutdown. Evidence: the 61-test package suite plus the
+      stale generation, session replacement, and shutdown. Evidence: the 63-test package suite plus the
       new failed-confirmation and replacement tests pass.
 - [x] Refactor `tool-selector.ts` and the narrow settings integration so one serialized confirmed
       transaction preserves existing settings/unknown fields and other active tools, rolls runtime back
@@ -144,11 +144,11 @@ and provide width-safe, keyboard-accessible TUI and RPC behavior with actionable
       `.changeset/calm-browsers-review.md` appears under the package's `0.50.0` minor release intent in
       `npm run changeset:status`.
 - [x] Run focused package typecheck and compiled Chrome DevTools tests, then a non-interactive declared
-      entrypoint/RPC smoke. Evidence: package typecheck and 61 tests pass; Pi 0.84.1 RPC opened every
+      entrypoint/RPC smoke. Evidence: package typecheck and 63 tests pass; Pi 0.84.1 RPC opened every
       detail, cancelled the main menu, staged/reviewed/applied 4/5 tools in a temporary agent directory,
       and emitted status without invoking a browser tool or creating a managed browser.
 - [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`, then
-      run required checks. Evidence: `git diff --check`, `npm run check` (2,533 tests),
+      run required checks. Evidence: `git diff --check`, `npm run check` (2,535 tests),
       `just pack chrome-devtools` (15 expected files), Changeset status, lazy menu-import review, and the
       source-size audit pass; Windows and macOS runtime rendering were not exercised.
 

--- a/docs/plans/archived/2026-08-08_pi-chrome-devtools-menu-redesign-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-chrome-devtools-menu-redesign-plan.md
@@ -1,0 +1,176 @@
+# Pi Chrome DevTools Menu Redesign Plan
+
+## Goal
+
+Redesign `@narumitw/pi-chrome-devtools` around tool-access, browser-status, setup, and recovery goals:
+show consequential current state before decisions, stage and preview menu-based tool changes before one
+confirmed apply, keep navigation shallow, preserve every existing command/settings compatibility route,
+and provide width-safe, keyboard-accessible TUI and RPC behavior with actionable failure recovery.
+
+## Context
+
+- `packages/pi-chrome-devtools/src/chrome-devtools.ts` currently owns command parsing and a six-row
+  action menu whose informational actions close into notifications.
+- `packages/pi-chrome-devtools/src/tool-selector.ts` currently combines immediate-save tool selection,
+  persistence transactions, status/setup text, and command help. Its five tool rows expose raw tool
+  identifiers and save every accepted toggle immediately, so Escape cannot cancel earlier changes.
+- `packages/pi-chrome-devtools/src/settings.ts` already serializes in-process saves, publishes through a
+  same-directory temporary file plus rename, rejects invalid recognized settings, and preserves unknown
+  fields. Missing files remain side-effect free; canonical/legacy precedence and trusted project browser
+  settings are established compatibility contracts.
+- `packages/pi-chrome-devtools/src/runtime.ts` and `browser-manager.ts` expose configured endpoint,
+  managed-browser, launch-attempt, effective-source, and project-trust state. Opening the redesigned
+  menu must summarize this state without probing an endpoint or launching Chrome.
+- Applicable guidance is `docs/extension-conventions.md`, `docs/extension-settings.md`, Pi's
+  `docs/extensions.md` and `docs/tui.md`, and the repository's `@narumitw/pi-tui-kit` contract. Touched
+  MUST areas are command routes/modes, custom TUI width and lifecycle, settings ordering/publication,
+  session replacement/shutdown, deterministic tests, documentation, release intent, and the root check.
+- Frequency assumptions are not backed by telemetry. The approved priority is: tool access first,
+  browser status and recovery second, settings/setup and help supporting; no Basic/Advanced menu split.
+
+## Architecture
+
+- Keep `chrome-devtools.ts` as the thin extension registration, lifecycle, command parsing, and
+  compatibility-route dispatcher.
+- Add a descriptive menu module under `packages/pi-chrome-devtools/src/` that owns command-scoped menu
+  state, the state-first main screen, nested detail screens, staged tool drafts, exact review content,
+  loading/cancellation feedback, and TUI/RPC navigation. The command-scoped draft must not enter global
+  runtime state or storage before confirmation.
+- Keep stable tool identities in `tool-names.ts`; add one extension-owned presentation mapping for the
+  five friendly task labels and concise descriptions. Never recover identity from rendered labels.
+- Keep tool-set validation, non-Chrome-tool preservation, serialized application, status snapshots, and
+  persistence coordination in `tool-selector.ts` (or extract those domain responsibilities to one
+  descriptive module if the implementation would otherwise mix menu rendering with transactions).
+- Keep `settings.ts` authoritative for canonical/legacy reads, invalid-file protection, unknown-field
+  preservation, ordered saves, and atomic file publication. A confirmed tool change is one serialized
+  extension transaction: validate generation and accepted state, apply the Chrome-only runtime delta,
+  publish the settings update, roll runtime back on publication failure, and report success only when
+  both accepted states agree. Wait for an idle command boundary before menu confirmation so the model
+  cannot observe an intermediate active-tool set.
+- Use existing `pi-tui-kit` action, multi-select, detail, and review screens. The extension owns draft,
+  preview, confirmation, persistence, rollback, and browser-status semantics. Verify these APIs exist at
+  the package's declared compatibility floor before editing; if a higher unpublished or unapproved floor
+  is required, stop and revise this plan rather than coupling the consumer to it.
+
+## Non-Goals
+
+- Add a live connection test, launch Chrome from the menu, or claim an unprobed endpoint is ready.
+- Add browser executable/path editors, a filesystem picker, or automatic `/reload` after JSON edits.
+- Add speculative presets such as “inspection mode”; retain only unambiguous Select all/Select none
+  shortcuts plus expert per-tool selection.
+- Change any CDP tool name, schema, execution behavior, screenshot policy, browser launch policy, status
+  key, settings field, precedence rule, environment override, or managed-browser lifecycle.
+- Remove or rename `/chrome-devtools`, documented subcommands, accepted aliases, or legacy settings
+  compatibility.
+- Add a Basic/Advanced section or another navigation level for the five related tools.
+
+## Risks
+
+- Deferred selection could accidentally reuse immediate-save code and mutate runtime or disk before
+  Apply. Keep the draft command-scoped and add negative assertions around every cancel/back/close path.
+- Runtime and file state cannot be committed by one OS primitive. Serialize the whole extension-owned
+  transaction, apply only at an idle boundary, roll runtime back on write failure, wait for the queue on
+  shutdown, and never report success after a partial or stale continuation.
+- Session replacement or shutdown can occur while loading, reviewing, waiting for idle, or saving.
+  Cancel every owned loader/task and revalidate generation/session ownership after each await.
+- Invalid settings or a failed rollback could erase a valid document or leave misleading UI. Preserve
+  exact prior runtime state and file bytes, keep malformed files untouched, retain the draft for retry,
+  and report both primary and rollback failures when applicable.
+- Friendly labels can conceal stable tool identity. Keep raw names in descriptions/search metadata and
+  use raw IDs for every action and persisted value.
+- Long paths, launch errors, or narrow terminals can hide recovery text. Use Kit wrapping/adaptive
+  viewports, sanitize terminal controls, and test critical state and action copy at constrained sizes.
+- TUI screen-reader semantics are limited by Pi and terminal emulators. Preserve a logical plain-text
+  reading order, non-color state cues, injected keybindings, and focus restoration without claiming web
+  ARIA support.
+
+## Rollback / Recovery
+
+- The stored schema is unchanged. Reverting the redesign restores the prior immediate-save menu while
+  retaining every settings document written by the new version.
+- Direct `enable` and `disable` routes remain immediate compatibility/automation paths, so users retain
+  a deterministic fallback if the interactive workflow cannot open.
+- A cancelled or failed draft leaves no new file when settings were missing and leaves prior runtime,
+  canonical/legacy files, unknown fields, and non-Chrome tools unchanged.
+- Browser JSON remains manually repairable at the documented user/project paths; invalid content is
+  never overwritten by the menu.
+
+## Plan
+
+- [x] Add focused red tests in a new `packages/pi-chrome-devtools/test/menu.test.ts` for the approved
+      state-first main screen: all/none/partial/unsaved tool state, configured-versus-observed browser
+      state, endpoint, relevant settings/launch warnings, five-or-fewer actions, dynamic bulk action,
+      and no browser probe or launch. Evidence: the focused test initially failed on the old six-row
+      stateless menu and now passes.
+- [x] Add the command-scoped menu-state and presentation module, then replace the notification-closing
+      main menu in `chrome-devtools.ts` with a Kit menu whose default row is `Choose browser tools…`,
+      whose supporting rows are the dynamic all/none preview, Browser status, Settings & setup, and
+      Help. Evidence: the focused 40-column main-menu test passes and observes no launch state.
+- [x] Add focused interaction tests for friendly stable-ID tool rows, Select all, Select none, staged
+      toggles, unapplied-change counts, exact review content, review Back, Apply, Cancel, Escape, Ctrl+C,
+      focus restoration, and main-menu quick bulk previews; assert every pre-Apply exit makes zero
+      `setActiveTools` calls and zero settings writes. Evidence: the focused menu suite passes. TDD
+      deviation: the first deferred-flow red harness stalled before reaching its assertion, so the
+      corrected deterministic interaction tests were completed with the implementation; the main-menu
+      slice retains direct red/green evidence and the full gate mitigates the remaining sequencing risk.
+- [x] Implement the extension-owned deferred tool workflow with five flat friendly rows, raw tool names
+      retained in descriptions/search identity, command-scoped accepted/draft selections, an exact
+      before/after review screen, explicit `Apply tool changes`, and draft disposal on cancellation.
+      Evidence: TUI and RPC stage/cancel/review/apply tests pass.
+- [x] Add focused transaction coverage for idle-boundary application, non-Chrome-tool preservation,
+      invalid settings, write/rename failure, runtime rollback, retryable drafts, rapid direct updates,
+      stale generation, session replacement, and shutdown. Evidence: the 61-test package suite plus the
+      new failed-confirmation and replacement tests pass.
+- [x] Refactor `tool-selector.ts` and the narrow settings integration so one serialized confirmed
+      transaction preserves existing settings/unknown fields and other active tools, rolls runtime back
+      when publication fails, keeps the draft for retry, waits at shutdown, and publishes success only
+      after runtime and disk agree. Evidence: existing settings/transaction/lifecycle suites and the
+      explicit wait-for-idle ordering assertion pass.
+- [x] Add focused navigation/content tests for Browser status, Settings & setup, and Help as nested
+      Back-capable screens, including unobserved/running/failed status and no-probe behavior. Evidence:
+      TUI navigation, direct-route, and actual RPC smoke evidence pass.
+- [x] Implement the three adaptive read-only review screens and consolidate duplicated
+      status/setup/help formatting into width-safe sanitized builders with adjacent failure recovery.
+      Evidence: Back restores main-menu navigation and constrained-height/width tests pass.
+- [x] Add and pass loading, disposal, mode, responsive, and accessibility-focused tests for cancellable
+      loading, Escape/Ctrl+C/replacement cleanup, 20/40/80-column and constrained-height rendering,
+      control-safe text, non-color state, focus restoration, RPC parity, direct mutations, and explicit
+      unsupported-mode rejection. Evidence: focused menu tests and Kit coverage in `npm run check` pass.
+- [x] Re-audit command parsing/completions and compatibility tests so documented routes plus `toggle`,
+      `select`, `on`, and `off` remain exact aliases, direct mutations remain deterministic, and all
+      settings/default/precedence/environment/migration behavior stays unchanged. Evidence: aliases are
+      documented/completed and the Chrome DevTools compatibility suites pass.
+- [x] Update `packages/pi-chrome-devtools/README.md` and add a minor Changeset. Evidence:
+      `.changeset/calm-browsers-review.md` appears under the package's `0.50.0` minor release intent in
+      `npm run changeset:status`.
+- [x] Run focused package typecheck and compiled Chrome DevTools tests, then a non-interactive declared
+      entrypoint/RPC smoke. Evidence: package typecheck and 61 tests pass; Pi 0.84.1 RPC opened every
+      detail, cancelled the main menu, staged/reviewed/applied 4/5 tools in a temporary agent directory,
+      and emitted status without invoking a browser tool or creating a managed browser.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`, then
+      run required checks. Evidence: `git diff --check`, `npm run check` (2,533 tests),
+      `just pack chrome-devtools` (15 expected files), Changeset status, lazy menu-import review, and the
+      source-size audit pass; Windows and macOS runtime rendering were not exercised.
+
+## Completion Checklist
+
+- [x] The no-argument TUI/RPC menu shows accurate consequential state before a decision and keeps five
+      or fewer goal-oriented actions on one shallow level.
+- [x] The five related tools use friendly labels in one flat group, retain raw stable identities, and
+      support Select all/Select none plus exact expert customization without invented presets.
+- [x] Menu toggles and bulk previews have no runtime, file, browser, or notification side effect until
+      `Apply tool changes`; Back, Cancel, Escape, Ctrl+C, disposal, and replacement discard drafts.
+- [x] Confirmed application is serialized and generation-safe, preserves every non-Chrome tool and
+      unknown settings field, reports immediate success, and restores the previous valid state with an
+      actionable error on failure.
+- [x] Browser status distinguishes configured, unobserved, running, and failed state without launching
+      or probing Chrome; setup and recovery expose effective sources, trust, security, paths, and reload
+      requirements without critical truncation.
+- [x] TUI and RPC navigation, focus, keyboard operation, loading, errors, constrained widths/heights,
+      long text, plain-text accessibility cues, and supported/unsupported mode behavior have
+      deterministic evidence.
+- [x] Every existing command/alias, tool contract, settings/default/precedence/migration behavior,
+      environment override, external-browser guarantee, and managed-browser lifecycle remains covered
+      by compatibility tests and documentation.
+- [x] README, minor Changeset, focused tests, runtime/RPC smoke, package dry run, final semantic audits,
+      `git diff --check`, and `npm run check` pass with recorded evidence before this plan is archived.

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -26,8 +26,9 @@ This package is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDev
   explicit endpoint overrides.
 - Retries briefly while Chrome is starting and reports actionable endpoint errors.
 - Shows statusline activity only while Chrome DevTools tools are running.
-- Provides a `/chrome-devtools` menu with quick-start help and tool controls.
-- Uses `@narumitw/pi-tui-kit` for width-safe menus and individual tool selection.
+- Provides a state-first `/chrome-devtools` menu for tool access, browser status, setup, and help.
+- Stages menu-based tool changes for exact review before one confirmed apply.
+- Uses `@narumitw/pi-tui-kit` for width-safe TUI menus and equivalent RPC dialogs.
 - Persists the selected Chrome DevTools tools across Pi restarts.
 
 ## 📦 Install
@@ -181,8 +182,26 @@ to read the saved path, for example `read({ path: "artifacts/homepage.png" })`.
 /chrome-devtools
 ```
 
-Opens a menu with quick-start help, command usage, tool status, controls for enabling or
-disabling all Chrome DevTools tools, and a selector for choosing individual tools.
+Opens a menu that shows the current browser-tool count, whether that selection is saved, the
+configured endpoint, the observed managed-browser state, and any settings or launch warning before
+you choose an action. The five actions stay on one level:
+
+- **Choose browser tools…** — stage any combination of the five capabilities, then review the exact
+  enabled/disabled result before selecting **Apply tool changes**.
+- **Enable all browser tools…** or **Disable all browser tools…** — preview the context-appropriate
+  bulk change before applying it.
+- **Browser status** — inspect runtime, endpoint, launch mode, and the last launch attempt without
+  probing the endpoint or starting Chrome.
+- **Settings & setup** — inspect effective files, sources, trust, reload steps, and recovery guidance.
+- **Help** — view command usage and return to the menu.
+
+In the tool screen, **Select all** and **Select none** are unambiguous shortcuts; individual rows use
+friendly task labels while retaining their raw `chrome_devtools_*` identity in the description.
+Toggles remain a command-local draft. **Review changes** previews the exact effect, **Apply tool
+changes** saves it, and Cancel, Escape, Ctrl+C, disposal, or session replacement discards an
+unconfirmed draft without changing runtime tools or settings. A failed apply restores the previous
+active-tool state, preserves the settings file, retains the draft for retry, and reports how to
+recover.
 
 Direct subcommands are also available:
 
@@ -196,16 +215,26 @@ Direct subcommands are also available:
 /chrome-devtools disable
 ```
 
+Compatibility aliases remain available: `toggle` and `select` mean `tools`, `on` means `enable`, and
+`off` means `disable`.
+
 - `help` shows command usage.
 - `quickstart` shows the configured CDP endpoint, endpoint source, auto-launch mode, browser
   candidates, last launch attempt, and launch hints.
 - `status` shows runtime tool state, persisted selection, settings file path, endpoint source,
   launch mode, last launch attempt, and active non-Chrome tool count.
-- `tools` opens a width-safe selector for choosing individual `chrome_devtools_*` tools.
-- `toggle` is an alias for `tools`.
-- `enable` enables all `chrome_devtools_*` tools for future turns.
-- `disable` disables all `chrome_devtools_*` tools for future turns. The slash command remains
-  available.
+- `tools` opens the same staged, width-safe selection and review flow used by the menu.
+- `toggle` and `select` are compatibility aliases for `tools`.
+- `enable` immediately enables and saves all `chrome_devtools_*` tools for future turns; `on` is a
+  compatibility alias.
+- `disable` immediately disables and saves all `chrome_devtools_*` tools for future turns; `off` is a
+  compatibility alias. The slash command remains available.
+
+The menu, `tools`, `help`, `quickstart`, and `status` require TUI or RPC mode so their result is
+observable. TUI uses keyboard navigation and injected Pi keybindings; RPC receives equivalent
+standard dialogs. In print and JSON modes, interactive and informational routes reject explicitly
+instead of silently opening unavailable UI. The immediate `enable`/`disable` routes remain available
+for deterministic non-interactive use.
 
 The selected tool names are saved to:
 
@@ -215,8 +244,10 @@ ${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json
 
 When the file is missing or invalid, the extension preserves Pi's current active-tool policy
 instead of enabling tools by itself. A valid saved selection is restored on Pi startup and
-`/reload`. A missing file is created by the first successful selection change. Within one Pi process, selection saves run in invocation order, reread the latest valid document, and preserve unknown fields. Malformed JSON
-or invalid recognized fields block the save without replacement; a failed save restores the prior
+`/reload`. A missing file is created by the first confirmed menu apply or successful direct
+selection change. Within one Pi process, selection saves run in invocation order, reread the latest
+valid document, and preserve unknown fields. Malformed JSON or invalid recognized fields make menu
+mutation unavailable and block direct saves without replacement; a failed save restores the prior
 Chrome DevTools tool selection while preserving other extensions' current tools.
 
 Compatibility: older versions used `pi-chrome-devtools-settings.json`. A legacy-only file remains

--- a/packages/pi-chrome-devtools/src/browser-manager.ts
+++ b/packages/pi-chrome-devtools/src/browser-manager.ts
@@ -614,6 +614,16 @@ export function endpointSourceLabel() {
 	return `${hostSource}; ${portSource}`;
 }
 
+export type BrowserLifecycleState = "starting" | "running" | "exited" | "failed" | "unobserved";
+
+export function browserLifecycleState(): BrowserLifecycleState {
+	if (state.launchPromise) return "starting";
+	if (state.managedBrowser?.exited) return "exited";
+	if (state.managedBrowser?.ready) return "running";
+	if (state.lastLaunchAttempt?.lastError) return "failed";
+	return "unobserved";
+}
+
 export function launchModeLabel() {
 	if (extensionsConfigured()) {
 		if (!isLocalDevToolsHost(state.host)) return "invalid; extensions require a local endpoint";

--- a/packages/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/packages/pi-chrome-devtools/src/chrome-devtools.ts
@@ -9,7 +9,6 @@ import {
 	buildQuickstartMessage,
 	buildToolStatusMessage,
 	sanitizeChromeDevtoolsDisplay,
-	showToolSelector,
 	updateChromeDevtoolsTools,
 	waitForChromeDevtoolsSettings,
 } from "./tool-selector.js";
@@ -29,19 +28,13 @@ const COMMAND_COMPLETIONS = [
 	{ value: "quickstart", label: "quickstart", description: "Show endpoint and launch help" },
 	{ value: "status", label: "status", description: "Show tool and settings status" },
 	{ value: "tools", label: "tools", description: "Select Chrome DevTools tools" },
-	{ value: "toggle", label: "toggle", description: "Select Chrome DevTools tools" },
+	{ value: "toggle", label: "toggle", description: "Alias for tools" },
+	{ value: "select", label: "select", description: "Compatibility alias for tools" },
 	{ value: "enable", label: "enable", description: "Enable all Chrome DevTools tools" },
+	{ value: "on", label: "on", description: "Compatibility alias for enable" },
 	{ value: "disable", label: "disable", description: "Disable all Chrome DevTools tools" },
+	{ value: "off", label: "off", description: "Compatibility alias for disable" },
 ];
-const MENU_OPTIONS = {
-	quickstart: "Quick start / endpoint help",
-	help: "Command usage guide",
-	status: "Show tool status",
-	tools: "Select Chrome DevTools tools",
-	enable: "Enable all Chrome DevTools tools",
-	disable: "Disable all Chrome DevTools tools",
-} as const;
-
 export default function chromeDevtools(pi: ExtensionAPI) {
 	pi.registerTool(listPagesTool);
 	pi.registerTool(selectPageTool);
@@ -103,20 +96,29 @@ async function handleChromeDevtoolsCommand(
 			await showMenu(pi, ctx, generation);
 			return;
 		case "help":
+			requireObservableUi(ctx, "help");
 			ctx.ui.notify(buildCommandGuide(), "info");
 			return;
 		case "quickstart":
+			requireObservableUi(ctx, "quickstart");
 			ctx.ui.notify(buildQuickstartMessage(), "info");
 			return;
 		case "status": {
+			requireObservableUi(ctx, "status");
 			const status = await buildToolStatusMessage(pi);
 			if (generation !== state.sessionGeneration) return;
 			ctx.ui.notify(status, "info");
 			return;
 		}
-		case "tools":
-			await showToolSelector(pi, ctx);
+		case "tools": {
+			if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+				throw new Error("/chrome-devtools tools requires TUI or RPC mode");
+			}
+			const { showChromeDevtoolsToolWorkflow } = await import("./menu.js");
+			if (generation !== state.sessionGeneration) return;
+			await showChromeDevtoolsToolWorkflow(pi, ctx, generation);
 			return;
+		}
 		case "enable":
 			await updateChromeDevtoolsTools(pi, ctx, allChromeDevtoolsTools(), "enabled all");
 			return;
@@ -125,6 +127,9 @@ async function handleChromeDevtoolsCommand(
 			return;
 	}
 
+	if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+		throw new Error(`Unknown /chrome-devtools command: ${args.trim()}`);
+	}
 	ctx.ui.notify(
 		`Unknown /chrome-devtools command: ${args.trim()}
 
@@ -133,67 +138,19 @@ ${buildCommandGuide()}`,
 	);
 }
 
-async function showMenu(pi: ExtensionAPI, ctx: CommandContext, generation: number) {
-	if (!ctx.hasUI) {
-		const status = await buildToolStatusMessage(pi);
-		if (generation !== state.sessionGeneration) return;
-		ctx.ui.notify(`${buildCommandGuide()}\n\n${status}`, "info");
-		return;
+function requireObservableUi(ctx: CommandContext, route: string) {
+	if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+		throw new Error(`/chrome-devtools ${route} requires TUI or RPC mode`);
 	}
-	const menuSignal = state.sessionController.signal;
-	const isCurrent = () => generation === state.sessionGeneration && !menuSignal.aborted;
-	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
-	if (!isCurrent()) return;
+}
 
-	type Screen = "main";
-	type Action = keyof typeof MENU_OPTIONS;
-	const menu = defineMenu<undefined, Screen, Action>({
-		start: "main",
-		screens: {
-			main: () => ({
-				kind: "actions",
-				title: "Chrome DevTools",
-				items: Object.entries(MENU_OPTIONS).map(([id, label]) => ({
-					id,
-					label,
-					action: id as Action,
-				})),
-				hint: "close",
-			}),
-		},
-		actions: {
-			quickstart: async () => {
-				ctx.ui.notify(buildQuickstartMessage(), "info");
-				return { kind: "close" };
-			},
-			help: async () => {
-				ctx.ui.notify(buildCommandGuide(), "info");
-				return { kind: "close" };
-			},
-			status: async () => {
-				const status = await buildToolStatusMessage(pi);
-				if (generation === state.sessionGeneration) ctx.ui.notify(status, "info");
-				return { kind: "close" };
-			},
-			tools: async () => {
-				await showToolSelector(pi, ctx);
-				return { kind: "close" };
-			},
-			enable: async () => {
-				await updateChromeDevtoolsTools(pi, ctx, allChromeDevtoolsTools(), "enabled all");
-				return { kind: "close" };
-			},
-			disable: async () => {
-				await updateChromeDevtoolsTools(pi, ctx, [], "disabled all");
-				return { kind: "close" };
-			},
-		},
-	});
-	await runMenu(ctx, menu, {
-		getState: () => undefined,
-		signal: menuSignal,
-		isCurrent,
-	});
+async function showMenu(pi: ExtensionAPI, ctx: CommandContext, generation: number) {
+	if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+		throw new Error("/chrome-devtools menu requires TUI or RPC mode; use a direct subcommand");
+	}
+	const { showChromeDevtoolsMenu } = await import("./menu.js");
+	if (generation !== state.sessionGeneration) return;
+	await showChromeDevtoolsMenu(pi, ctx, generation);
 }
 
 function replaceSessionController(reason: string) {

--- a/packages/pi-chrome-devtools/src/menu.ts
+++ b/packages/pi-chrome-devtools/src/menu.ts
@@ -1,0 +1,476 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu, runTask } from "@narumitw/pi-tui-kit";
+import { devToolsEndpoint, launchModeLabel } from "./browser-manager.js";
+import { state } from "./runtime.js";
+import { loadSettings, type SettingsLoadResult } from "./settings.js";
+import { CHROME_DEVTOOLS_TOOL_NAMES, type ChromeDevToolsToolName } from "./tool-names.js";
+import {
+	buildBrowserStatusMessage,
+	buildCommandGuide,
+	buildSettingsSetupMessage,
+	sanitizeChromeDevtoolsDisplay,
+	setSelectedChromeDevtoolsTools,
+} from "./tool-selector.js";
+
+type CommandContext = ExtensionCommandContext;
+type MainScreen = "main" | "browserStatus" | "settings" | "help";
+type MainAction = "tools" | "bulk";
+type ToolScreen = "tools" | "review";
+type ToolAction = "toggle" | "selectAll" | "selectNone" | "review" | "apply" | "cancel";
+
+interface MenuSnapshot {
+	activeTools: ChromeDevToolsToolName[];
+	persistenceLabel: string;
+	mutationBlockedReason?: string;
+	settingsWarning?: string;
+}
+
+interface ToolWorkflowState {
+	accepted: Set<ChromeDevToolsToolName>;
+	draft: Set<ChromeDevToolsToolName>;
+	mutationBlockedReason?: string;
+	generation: number;
+	applied: boolean;
+}
+
+const TOOL_PRESENTATION: Record<ChromeDevToolsToolName, { label: string; description: string }> = {
+	chrome_devtools_list_pages: {
+		label: "List open pages",
+		description: "List inspectable Chrome tabs and pages (chrome_devtools_list_pages).",
+	},
+	chrome_devtools_select_page: {
+		label: "Select the active page",
+		description: "Choose the page later browser actions use (chrome_devtools_select_page).",
+	},
+	chrome_devtools_navigate: {
+		label: "Navigate a page",
+		description: "Open a URL, creating a page when needed (chrome_devtools_navigate).",
+	},
+	chrome_devtools_evaluate: {
+		label: "Run JavaScript",
+		description: "Evaluate JavaScript in the selected page (chrome_devtools_evaluate).",
+	},
+	chrome_devtools_screenshot: {
+		label: "Capture a screenshot",
+		description: "Save a PNG of the selected page (chrome_devtools_screenshot).",
+	},
+};
+
+export async function showChromeDevtoolsMenu(
+	pi: ExtensionAPI,
+	ctx: CommandContext,
+	generation: number,
+) {
+	const snapshot = await loadSnapshotWithFeedback(pi, ctx, generation);
+	if (!snapshot) return;
+	const menuSignal = state.sessionController.signal;
+	const isCurrent = () => generation === state.sessionGeneration && !menuSignal.aborted;
+	const menu = defineMenu<MenuSnapshot, MainScreen, MainAction>({
+		start: "main",
+		screens: {
+			main: ({ state: current }) => ({
+				kind: "actions",
+				title: "Chrome DevTools",
+				lines: mainStateLines(current),
+				items: [
+					{
+						id: "tools",
+						label: "Choose browser tools…",
+						description: "Select what Pi may do in Chrome.",
+						disabled: Boolean(current.mutationBlockedReason),
+						disabledReason: current.mutationBlockedReason,
+						action: "tools",
+					},
+					{
+						id: "bulk",
+						label:
+							current.activeTools.length === CHROME_DEVTOOLS_TOOL_NAMES.length
+								? "Disable all browser tools…"
+								: "Enable all browser tools…",
+						description:
+							current.activeTools.length === CHROME_DEVTOOLS_TOOL_NAMES.length
+								? "Preview 0 of 5; other active tools stay enabled."
+								: "Preview 5 of 5; other active tools stay enabled.",
+						disabled: Boolean(current.mutationBlockedReason),
+						disabledReason: current.mutationBlockedReason,
+						action: "bulk",
+					},
+					{
+						id: "browser-status",
+						label: "Browser status",
+						description: "Runtime, endpoint, and last launch attempt.",
+						to: "browserStatus",
+					},
+					{
+						id: "settings",
+						label: "Settings & setup",
+						description: "Files, sources, trust, and reload steps.",
+						to: "settings",
+					},
+					{
+						id: "help",
+						label: "Help",
+						description: "Commands and usage.",
+						to: "help",
+					},
+				],
+				hint: "close",
+			}),
+			browserStatus: () => ({
+				kind: "review",
+				title: "Browser status",
+				content: buildBrowserStatusMessage(),
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				hint: "back",
+			}),
+			settings: () => ({
+				kind: "review",
+				title: "Settings & setup",
+				content: buildSettingsSetupMessage(),
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				hint: "back",
+			}),
+			help: () => ({
+				kind: "review",
+				title: "Chrome DevTools help",
+				content: buildCommandGuide(),
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				hint: "back",
+			}),
+		},
+		actions: {
+			tools: async ({ state: current }) => {
+				const result = await showChromeDevtoolsToolWorkflow(pi, ctx, generation, {
+					snapshot: current,
+				});
+				if (result?.applied && isCurrent()) updateSnapshotAfterApply(current, result.selectedTools);
+				return result?.closeParent ? { kind: "close" } : { kind: "stay" };
+			},
+			bulk: async ({ state: current }) => {
+				const selectedTools =
+					current.activeTools.length === CHROME_DEVTOOLS_TOOL_NAMES.length
+						? []
+						: [...CHROME_DEVTOOLS_TOOL_NAMES];
+				const result = await showChromeDevtoolsToolWorkflow(pi, ctx, generation, {
+					snapshot: current,
+					initialDraft: selectedTools,
+					startAtReview: true,
+				});
+				if (result?.applied && isCurrent()) updateSnapshotAfterApply(current, result.selectedTools);
+				return result?.closeParent ? { kind: "close" } : { kind: "stay" };
+			},
+		},
+	});
+	await runMenu(ctx, menu, {
+		getState: () => snapshot,
+		signal: menuSignal,
+		isCurrent,
+		onError: (currentCtx, error) =>
+			currentCtx.ui.notify(
+				sanitizeChromeDevtoolsDisplay(`Chrome DevTools menu failed: ${formatError(error)}`),
+				"error",
+			),
+	});
+}
+
+export async function showChromeDevtoolsToolWorkflow(
+	pi: ExtensionAPI,
+	ctx: CommandContext,
+	generation: number,
+	options: {
+		snapshot?: MenuSnapshot;
+		initialDraft?: readonly ChromeDevToolsToolName[];
+		startAtReview?: boolean;
+	} = {},
+): Promise<
+	{ applied: boolean; closeParent: boolean; selectedTools: ChromeDevToolsToolName[] } | undefined
+> {
+	const snapshot = options.snapshot ?? (await loadSnapshotWithFeedback(pi, ctx, generation));
+	if (!snapshot) return undefined;
+	const menuSignal = state.sessionController.signal;
+	const isCurrent = () => generation === state.sessionGeneration && !menuSignal.aborted;
+	const accepted = new Set(snapshot.activeTools);
+	const workflow: ToolWorkflowState = {
+		accepted,
+		draft: new Set(options.initialDraft ?? snapshot.activeTools),
+		mutationBlockedReason: snapshot.mutationBlockedReason,
+		generation,
+		applied: false,
+	};
+	const menu = defineMenu<ToolWorkflowState, ToolScreen, ToolAction>({
+		start: options.startAtReview ? "review" : "tools",
+		screens: {
+			tools: ({ state: current }) => ({
+				kind: "multiSelect",
+				title: `Browser tools (${current.draft.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length})`,
+				lines: toolDraftLines(current),
+				items: CHROME_DEVTOOLS_TOOL_NAMES.map((toolName) => ({
+					id: toolName,
+					label: TOOL_PRESENTATION[toolName].label,
+					description: TOOL_PRESENTATION[toolName].description,
+					searchText: `${toolName} ${TOOL_PRESENTATION[toolName].description}`,
+					selected: current.draft.has(toolName),
+					disabled: Boolean(current.mutationBlockedReason),
+					disabledReason: current.mutationBlockedReason,
+				})),
+				action: "toggle",
+				actions: [
+					{
+						id: "select-all",
+						label: "Select all",
+						disabled: Boolean(current.mutationBlockedReason),
+						disabledReason: current.mutationBlockedReason,
+						action: "selectAll",
+					},
+					{
+						id: "select-none",
+						label: "Select none",
+						disabled: Boolean(current.mutationBlockedReason),
+						disabledReason: current.mutationBlockedReason,
+						action: "selectNone",
+					},
+					{
+						id: "review",
+						label: "Review changes…",
+						disabled:
+							Boolean(current.mutationBlockedReason) || setsEqual(current.accepted, current.draft),
+						disabledReason:
+							current.mutationBlockedReason ??
+							(setsEqual(current.accepted, current.draft) ? "No unapplied changes" : undefined),
+						to: "review",
+					},
+					{ id: "cancel", label: "Cancel", action: "cancel" },
+				],
+				hint: "back",
+			}),
+			review: ({ state: current }) => ({
+				kind: "review",
+				title: "Review tool changes",
+				lines: [
+					`Current: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+					`Proposed: ${current.draft.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+				],
+				content: buildToolReview(current),
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				...(current.mutationBlockedReason || setsEqual(current.accepted, current.draft)
+					? {}
+					: {
+							confirm: {
+								id: "apply",
+								label: "Apply tool changes",
+								action: "apply" as const,
+							},
+						}),
+				hint: "back",
+			}),
+		},
+		actions: {
+			toggle: ({ state: current, itemId, selected }) => {
+				if (!isChromeDevtoolsToolName(itemId) || selected === undefined)
+					return { kind: "rejected" };
+				if (selected) current.draft.add(itemId);
+				else current.draft.delete(itemId);
+				return { kind: "stay" };
+			},
+			selectAll: ({ state: current }) => {
+				current.draft = new Set(CHROME_DEVTOOLS_TOOL_NAMES);
+				return { kind: "stay" };
+			},
+			selectNone: ({ state: current }) => {
+				current.draft = new Set();
+				return { kind: "stay" };
+			},
+			review: () => ({ kind: "to", screen: "review" }),
+			cancel: () => ({ kind: "back" }),
+			apply: async ({ state: current, signal }) => {
+				await ctx.waitForIdle();
+				if (signal.aborted || !isCurrent() || current.generation !== state.sessionGeneration) {
+					return { kind: "rejected" };
+				}
+				const selectedTools = orderedTools(current.draft);
+				const saved = await setSelectedChromeDevtoolsTools(pi, ctx, selectedTools);
+				if (!saved || !isCurrent()) return { kind: "rejected" };
+				current.accepted = new Set(selectedTools);
+				current.draft = new Set(selectedTools);
+				current.applied = true;
+				ctx.ui.notify(
+					`Saved: ${selectedTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} browser tools enabled.`,
+					"info",
+				);
+				return { kind: "close" };
+			},
+		},
+	});
+	const result = await runMenu(ctx, menu, {
+		getState: () => workflow,
+		signal: menuSignal,
+		isCurrent,
+		onError: (currentCtx, error) =>
+			currentCtx.ui.notify(
+				sanitizeChromeDevtoolsDisplay(
+					`Chrome DevTools tool selection failed: ${formatError(error)}`,
+				),
+				"error",
+			),
+	});
+	return {
+		applied: workflow.applied,
+		closeParent: !workflow.applied && result.kind === "closed" && result.reason === "close",
+		selectedTools: orderedTools(workflow.accepted),
+	};
+}
+
+async function loadSnapshotWithFeedback(pi: ExtensionAPI, ctx: CommandContext, generation: number) {
+	const menuSignal = state.sessionController.signal;
+	const isCurrent = () => generation === state.sessionGeneration && !menuSignal.aborted;
+	const result = await runTask(ctx, {
+		label: "Loading Chrome DevTools settings…",
+		signal: menuSignal,
+		isCurrent,
+		task: async ({ signal }) => {
+			signal.throwIfAborted();
+			const settings = await loadSettings();
+			signal.throwIfAborted();
+			return buildMenuSnapshot(pi, settings);
+		},
+	});
+	return result.kind === "completed" ? result.value : undefined;
+}
+
+function buildMenuSnapshot(pi: ExtensionAPI, settings: SettingsLoadResult): MenuSnapshot {
+	const activeTools = activeChromeTools(pi);
+	const persistedTools =
+		settings.kind === "loaded" && settings.settings.tools
+			? orderedTools(new Set(settings.settings.tools))
+			: undefined;
+	const persistenceLabel =
+		settings.kind === "invalid"
+			? "settings need repair"
+			: persistedTools === undefined
+				? "not saved"
+				: arraysEqual(activeTools, persistedTools)
+					? "saved"
+					: "runtime differs from saved selection";
+	const settingsWarning = [
+		...new Set([settings.notice, state.settingsNotice].filter(Boolean)),
+	].join("\n");
+	return {
+		activeTools,
+		persistenceLabel,
+		...(settings.kind === "invalid"
+			? { mutationBlockedReason: `Repair ${settings.reason} before saving` }
+			: {}),
+		...(settingsWarning ? { settingsWarning } : {}),
+	};
+}
+
+function mainStateLines(snapshot: MenuSnapshot) {
+	return sanitizeLines([
+		`Tools: ${snapshot.activeTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} enabled · ${snapshot.persistenceLabel}`,
+		`Browser: ${browserLifecycleSummary()}`,
+		`Endpoint: ${devToolsEndpoint()}`,
+		...(snapshot.settingsWarning ? [`Settings warning: ${snapshot.settingsWarning}`] : []),
+		...(state.lastLaunchAttempt?.lastError
+			? [`Launch warning: ${state.lastLaunchAttempt.lastError}`]
+			: []),
+	]);
+}
+
+function browserLifecycleSummary() {
+	if (state.launchPromise) return "starting managed browser";
+	if (state.managedBrowser && !state.managedBrowser.exited && state.managedBrowser.ready) {
+		return "managed browser running";
+	}
+	if (state.lastLaunchAttempt?.lastError)
+		return "last launch failed · open Browser status to recover";
+	const launchMode = launchModeLabel();
+	return launchMode.startsWith("attach first")
+		? "not started · attaches or launches on first use"
+		: `not started · ${launchMode}`;
+}
+
+function toolDraftLines(current: ToolWorkflowState) {
+	if (current.mutationBlockedReason)
+		return sanitizeLines([`Unavailable: ${current.mutationBlockedReason}`]);
+	const changes = symmetricDifferenceSize(current.accepted, current.draft);
+	return [
+		`Current accepted: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+		changes === 0
+			? "No unapplied changes · Escape cancels"
+			: `${changes} unapplied ${changes === 1 ? "change" : "changes"} · Escape cancels`,
+		"Changes are not applied until Review changes and Apply tool changes.",
+	];
+}
+
+function buildToolReview(current: ToolWorkflowState) {
+	const enabled = CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => current.draft.has(name));
+	const disabled = CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => !current.draft.has(name));
+	return sanitizeChromeDevtoolsDisplay(
+		[
+			`Current browser tools: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+			`Proposed browser tools: ${current.draft.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+			"",
+			"Enabled after apply:",
+			...(enabled.length > 0
+				? enabled.map((name) => `  - ${TOOL_PRESENTATION[name].label} (${name})`)
+				: ["  - none"]),
+			"",
+			"Disabled after apply:",
+			...(disabled.length > 0
+				? disabled.map((name) => `  - ${TOOL_PRESENTATION[name].label} (${name})`)
+				: ["  - none"]),
+			"",
+			"Other active Pi tools remain unchanged.",
+			"The accepted selection is saved for future sessions.",
+		].join("\n"),
+	);
+}
+
+function updateSnapshotAfterApply(
+	snapshot: MenuSnapshot,
+	selectedTools: readonly ChromeDevToolsToolName[],
+) {
+	snapshot.activeTools = [...selectedTools];
+	snapshot.persistenceLabel = "saved";
+	snapshot.settingsWarning = undefined;
+}
+
+function activeChromeTools(pi: ExtensionAPI) {
+	const active = new Set(pi.getActiveTools());
+	return CHROME_DEVTOOLS_TOOL_NAMES.filter((toolName) => active.has(toolName));
+}
+
+function orderedTools(tools: ReadonlySet<ChromeDevToolsToolName>) {
+	return CHROME_DEVTOOLS_TOOL_NAMES.filter((toolName) => tools.has(toolName));
+}
+
+function isChromeDevtoolsToolName(value: string): value is ChromeDevToolsToolName {
+	return CHROME_DEVTOOLS_TOOL_NAMES.includes(value as ChromeDevToolsToolName);
+}
+
+function setsEqual<T>(left: ReadonlySet<T>, right: ReadonlySet<T>) {
+	return left.size === right.size && [...left].every((value) => right.has(value));
+}
+
+function symmetricDifferenceSize<T>(left: ReadonlySet<T>, right: ReadonlySet<T>) {
+	let changes = 0;
+	for (const value of left) if (!right.has(value)) changes += 1;
+	for (const value of right) if (!left.has(value)) changes += 1;
+	return changes;
+}
+
+function arraysEqual<T>(left: readonly T[], right: readonly T[]) {
+	return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function sanitizeLines(lines: readonly string[]) {
+	return sanitizeChromeDevtoolsDisplay(lines.join("\n")).split("\n");
+}
+
+function formatError(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-chrome-devtools/src/menu.ts
+++ b/packages/pi-chrome-devtools/src/menu.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu, runTask } from "@narumitw/pi-tui-kit";
-import { devToolsEndpoint, launchModeLabel } from "./browser-manager.js";
+import { browserLifecycleState, devToolsEndpoint, launchModeLabel } from "./browser-manager.js";
 import { state } from "./runtime.js";
 import { loadSettings, type SettingsLoadResult } from "./settings.js";
 import { CHROME_DEVTOOLS_TOOL_NAMES, type ChromeDevToolsToolName } from "./tool-names.js";
@@ -292,8 +292,17 @@ export async function showChromeDevtoolsToolWorkflow(
 					return { kind: "rejected" };
 				}
 				const selectedTools = orderedTools(current.draft);
-				const saved = await setSelectedChromeDevtoolsTools(pi, ctx, selectedTools);
-				if (!saved || !isCurrent()) return { kind: "rejected" };
+				const saveResult = await setSelectedChromeDevtoolsTools(
+					pi,
+					ctx,
+					selectedTools,
+					orderedTools(current.accepted),
+				);
+				if (!isCurrent()) return { kind: "rejected" };
+				if (saveResult === "active-tools-changed") {
+					current.accepted = new Set(activeChromeTools(pi));
+				}
+				if (saveResult !== "saved") return { kind: "rejected" };
 				current.accepted = new Set(selectedTools);
 				current.draft = new Set(selectedTools);
 				current.applied = true;
@@ -381,12 +390,11 @@ function mainStateLines(snapshot: MenuSnapshot) {
 }
 
 function browserLifecycleSummary() {
-	if (state.launchPromise) return "starting managed browser";
-	if (state.managedBrowser && !state.managedBrowser.exited && state.managedBrowser.ready) {
-		return "managed browser running";
-	}
-	if (state.lastLaunchAttempt?.lastError)
-		return "last launch failed · open Browser status to recover";
+	const lifecycle = browserLifecycleState();
+	if (lifecycle === "starting") return "starting managed browser";
+	if (lifecycle === "running") return "managed browser running";
+	if (lifecycle === "exited") return "managed browser exited · open Browser status to recover";
+	if (lifecycle === "failed") return "last launch failed · open Browser status to recover";
 	const launchMode = launchModeLabel();
 	return launchMode.startsWith("attach first")
 		? "not started · attaches or launches on first use"
@@ -436,7 +444,6 @@ function updateSnapshotAfterApply(
 ) {
 	snapshot.activeTools = [...selectedTools];
 	snapshot.persistenceLabel = "saved";
-	snapshot.settingsWarning = undefined;
 }
 
 function activeChromeTools(pi: ExtensionAPI) {

--- a/packages/pi-chrome-devtools/src/tool-selector.ts
+++ b/packages/pi-chrome-devtools/src/tool-selector.ts
@@ -14,8 +14,6 @@ import { loadSettings, saveSettings, settingsFilePath } from "./settings.js";
 import { CHROME_DEVTOOLS_TOOL_NAMES, type ChromeDevToolsToolName } from "./tool-names.js";
 
 type CommandContext = ExtensionCommandContext;
-type ToolSelectorScreen = "tools";
-type ToolSelectorAction = "toggle" | "enableAll" | "disableAll";
 
 function unique<T>(values: T[]) {
 	return Array.from(new Set(values));
@@ -29,80 +27,6 @@ interface ToolStatusSummary {
 	runtimeStatus: "enabled" | "disabled" | "partial";
 	activeChromeToolCount: number;
 	activeNonChromeToolCount: number;
-}
-
-export async function showToolSelector(pi: ExtensionAPI, ctx: CommandContext) {
-	const generation = state.sessionGeneration;
-	if (!ctx.hasUI) return;
-	const menuSignal = state.sessionController.signal;
-	const isCurrent = () => generation === state.sessionGeneration && !menuSignal.aborted;
-	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
-	if (!isCurrent()) return;
-	const menu = defineMenu<undefined, ToolSelectorScreen, ToolSelectorAction>({
-		start: "tools",
-		screens: {
-			tools: () => {
-				const selectedTools = new Set(getActiveChromeDevtoolsTools(pi));
-				return {
-					kind: "multiSelect",
-					title: toolSelectorTitle(selectedTools),
-					items: CHROME_DEVTOOLS_TOOL_NAMES.map((toolName) => ({
-						id: toolName,
-						label: toolName,
-						selected: selectedTools.has(toolName),
-					})),
-					action: "toggle",
-					actions: [
-						{
-							id: "enable-all",
-							label: "Enable all Chrome DevTools tools",
-							action: "enableAll",
-						},
-						{
-							id: "disable-all",
-							label: "Disable all Chrome DevTools tools",
-							action: "disableAll",
-						},
-						{ id: "done", label: "Done", close: true },
-					],
-					hint: "close",
-					doneLabel: "Done",
-				};
-			},
-		},
-		actions: {
-			toggle: async ({ itemId, selected }) => {
-				if (!isChromeDevtoolsToolName(itemId)) return { kind: "rejected" };
-				const selectedTools = new Set(getActiveChromeDevtoolsTools(pi));
-				if (selected) selectedTools.add(itemId);
-				else selectedTools.delete(itemId);
-				const saved = await transactSelectedTools(
-					pi,
-					ctx,
-					orderedChromeDevtoolsTools(selectedTools),
-					generation,
-				);
-				return saved ? { kind: "stay" } : { kind: "rejected" };
-			},
-			enableAll: async () => {
-				const saved = await transactSelectedTools(pi, ctx, allChromeDevtoolsTools(), generation);
-				return saved ? { kind: "stay" } : { kind: "rejected" };
-			},
-			disableAll: async () => {
-				const saved = await transactSelectedTools(pi, ctx, [], generation);
-				return saved ? { kind: "stay" } : { kind: "rejected" };
-			},
-		},
-	});
-	const result = await runMenu(ctx, menu, {
-		getState: () => undefined,
-		signal: menuSignal,
-		isCurrent,
-	});
-	if (result.kind !== "closed" || generation !== state.sessionGeneration) return;
-	const status = await buildToolStatusMessage(pi);
-	if (generation !== state.sessionGeneration) return;
-	ctx.ui.notify(status, "info");
 }
 
 export async function updateChromeDevtoolsTools(
@@ -232,6 +156,35 @@ export async function buildToolStatusMessage(pi: ExtensionAPI) {
 }
 
 export function buildQuickstartMessage() {
+	return buildSettingsSetupMessage();
+}
+
+export function buildBrowserStatusMessage() {
+	const browserState = state.launchPromise
+		? "starting managed browser"
+		: state.managedBrowser && !state.managedBrowser.exited && state.managedBrowser.ready
+			? "managed browser running"
+			: state.lastLaunchAttempt?.lastError
+				? "last launch failed"
+				: "not started; connection has not been checked";
+	return sanitizeChromeDevtoolsDisplay(
+		[
+			`Browser: ${browserState}`,
+			"Viewing this status does not probe the endpoint or launch Chrome.",
+			`Endpoint: ${devToolsEndpoint()}`,
+			`Endpoint source: ${endpointSourceLabel()}`,
+			`Launch mode: ${launchModeLabel()}`,
+			`Unpacked extensions: ${state.extensionPaths.length} (${state.extensionPathsSource})`,
+			...(state.extensionPaths.length > 0
+				? ["Unpacked extensions execute trusted browser code in an isolated managed browser."]
+				: []),
+			...launchAttemptLines(),
+			...(state.lastLaunchAttempt?.lastError ? [launchHint(), endpointConfigHint()] : []),
+		].join("\n"),
+	);
+}
+
+export function buildSettingsSetupMessage() {
 	return sanitizeChromeDevtoolsDisplay(
 		[
 			`Chrome DevTools endpoint: ${devToolsEndpoint()}`,
@@ -291,23 +244,10 @@ export function buildCommandGuide() {
 		"/chrome-devtools quickstart — show endpoint and launch help",
 		"/chrome-devtools status — show tool and settings status",
 		"/chrome-devtools tools — select individual Chrome DevTools tools",
-		"/chrome-devtools toggle — alias for /chrome-devtools tools",
-		"/chrome-devtools enable — enable all Chrome DevTools tools",
-		"/chrome-devtools disable — disable all Chrome DevTools tools",
+		"/chrome-devtools toggle|select — compatibility aliases for tools",
+		"/chrome-devtools enable|on — enable all Chrome DevTools tools immediately",
+		"/chrome-devtools disable|off — disable all Chrome DevTools tools immediately",
 	].join("\n");
-}
-
-function toolSelectorTitle(selectedTools: ReadonlySet<ChromeDevToolsToolName>) {
-	return `Chrome DevTools tools (${selectedTools.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}). Non-built-in tools run at user risk.`;
-}
-
-function isChromeDevtoolsToolName(value: string): value is ChromeDevToolsToolName {
-	return CHROME_DEVTOOLS_TOOL_NAMES.includes(value as ChromeDevToolsToolName);
-}
-
-function getActiveChromeDevtoolsTools(pi: ExtensionAPI) {
-	const activeToolNames = new Set(pi.getActiveTools());
-	return CHROME_DEVTOOLS_TOOL_NAMES.filter((toolName) => activeToolNames.has(toolName));
 }
 
 export function allChromeDevtoolsTools() {

--- a/packages/pi-chrome-devtools/src/tool-selector.ts
+++ b/packages/pi-chrome-devtools/src/tool-selector.ts
@@ -2,6 +2,7 @@ import { stripVTControlCharacters } from "node:util";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
 	browserCandidateHint,
+	browserLifecycleState,
 	devToolsEndpoint,
 	endpointConfigHint,
 	endpointSourceLabel,
@@ -29,6 +30,8 @@ interface ToolStatusSummary {
 	activeNonChromeToolCount: number;
 }
 
+type ToolSelectionSaveResult = "saved" | "active-tools-changed" | "failed";
+
 export async function updateChromeDevtoolsTools(
 	pi: ExtensionAPI,
 	ctx: CommandContext,
@@ -36,8 +39,8 @@ export async function updateChromeDevtoolsTools(
 	action: string,
 ) {
 	const generation = state.sessionGeneration;
-	const saved = await transactSelectedTools(pi, ctx, selectedTools, generation);
-	if (!saved || generation !== state.sessionGeneration) return;
+	const result = await transactSelectedTools(pi, ctx, selectedTools, generation);
+	if (result !== "saved" || generation !== state.sessionGeneration) return;
 	const status = await buildToolStatusMessage(pi);
 	if (generation !== state.sessionGeneration) return;
 	ctx.ui.notify(`Chrome DevTools tools ${action}.\n\n${status}`, "info");
@@ -47,8 +50,15 @@ export async function setSelectedChromeDevtoolsTools(
 	pi: ExtensionAPI,
 	ctx: CommandContext,
 	selectedTools: readonly ChromeDevToolsToolName[],
-): Promise<boolean> {
-	return transactSelectedTools(pi, ctx, selectedTools, state.sessionGeneration);
+	expectedActiveTools: readonly ChromeDevToolsToolName[],
+): Promise<ToolSelectionSaveResult> {
+	return transactSelectedTools(
+		pi,
+		ctx,
+		selectedTools,
+		state.sessionGeneration,
+		expectedActiveTools,
+	);
 }
 
 let toolTransactionQueue = Promise.resolve();
@@ -62,9 +72,10 @@ function transactSelectedTools(
 	ctx: CommandContext,
 	selectedTools: readonly ChromeDevToolsToolName[],
 	expectedGeneration: number,
-): Promise<boolean> {
+	expectedActiveTools?: readonly ChromeDevToolsToolName[],
+): Promise<ToolSelectionSaveResult> {
 	const operation = toolTransactionQueue.then(() =>
-		transactSelectedToolsNow(pi, ctx, selectedTools, expectedGeneration),
+		transactSelectedToolsNow(pi, ctx, selectedTools, expectedGeneration, expectedActiveTools),
 	);
 	toolTransactionQueue = operation.then(
 		() => undefined,
@@ -78,13 +89,21 @@ async function transactSelectedToolsNow(
 	ctx: CommandContext,
 	selectedTools: readonly ChromeDevToolsToolName[],
 	expectedGeneration: number,
-): Promise<boolean> {
-	if (expectedGeneration !== state.sessionGeneration) return false;
+	expectedActiveTools?: readonly ChromeDevToolsToolName[],
+): Promise<ToolSelectionSaveResult> {
+	if (expectedGeneration !== state.sessionGeneration) return "failed";
+	if (expectedActiveTools && !arraysEqual(activeChromeDevtoolsTools(pi), expectedActiveTools)) {
+		ctx.ui.notify(
+			"Browser tool selection changed while review was open. Review the current state, then apply again.",
+			"warning",
+		);
+		return "active-tools-changed";
+	}
 	const previousActiveTools = pi.getActiveTools();
 	try {
 		applyChromeDevtoolsTools(pi, selectedTools);
 		await persistSettings(selectedTools);
-		return expectedGeneration === state.sessionGeneration;
+		return expectedGeneration === state.sessionGeneration ? "saved" : "failed";
 	} catch (error) {
 		let rollbackError: unknown;
 		try {
@@ -95,7 +114,7 @@ async function transactSelectedToolsNow(
 		} catch (caught) {
 			rollbackError = caught;
 		}
-		if (expectedGeneration !== state.sessionGeneration) return false;
+		if (expectedGeneration !== state.sessionGeneration) return "failed";
 		ctx.ui.notify(
 			sanitizeChromeDevtoolsDisplay(
 				rollbackError
@@ -104,8 +123,17 @@ async function transactSelectedToolsNow(
 			),
 			"warning",
 		);
-		return false;
+		return "failed";
 	}
+}
+
+function activeChromeDevtoolsTools(pi: ExtensionAPI) {
+	const active = new Set(pi.getActiveTools());
+	return CHROME_DEVTOOLS_TOOL_NAMES.filter((toolName) => active.has(toolName));
+}
+
+function arraysEqual<T>(left: readonly T[], right: readonly T[]) {
+	return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 export function applyChromeDevtoolsTools(
@@ -160,13 +188,18 @@ export function buildQuickstartMessage() {
 }
 
 export function buildBrowserStatusMessage() {
-	const browserState = state.launchPromise
-		? "starting managed browser"
-		: state.managedBrowser && !state.managedBrowser.exited && state.managedBrowser.ready
-			? "managed browser running"
-			: state.lastLaunchAttempt?.lastError
-				? "last launch failed"
-				: "not started; connection has not been checked";
+	const lifecycle = browserLifecycleState();
+	const browserState =
+		lifecycle === "starting"
+			? "starting managed browser"
+			: lifecycle === "running"
+				? "managed browser running"
+				: lifecycle === "exited"
+					? "managed browser exited"
+					: lifecycle === "failed"
+						? "last launch failed"
+						: "not started; connection has not been checked";
+	const needsRecovery = lifecycle === "exited" || lifecycle === "failed";
 	return sanitizeChromeDevtoolsDisplay(
 		[
 			`Browser: ${browserState}`,
@@ -179,7 +212,7 @@ export function buildBrowserStatusMessage() {
 				? ["Unpacked extensions execute trusted browser code in an isolated managed browser."]
 				: []),
 			...launchAttemptLines(),
-			...(state.lastLaunchAttempt?.lastError ? [launchHint(), endpointConfigHint()] : []),
+			...(needsRecovery ? [launchHint(), endpointConfigHint()] : []),
 		].join("\n"),
 	);
 }

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -16,7 +16,6 @@ import {
 	createCustomSelectorHarness,
 	createMockContext,
 	createMockPi,
-	driveCustomSelector,
 } from "../../../test/support.js";
 import chromeDevtools, {
 	commandCompletions,
@@ -68,6 +67,12 @@ test("chrome-devtools command parsing and completions cover aliases", () => {
 	assert.equal(parseCommand("wat"), "unknown");
 	assert.deepEqual(commandCompletions("qui"), [
 		{ value: "quickstart", label: "quickstart", description: "Show endpoint and launch help" },
+	]);
+	assert.deepEqual(commandCompletions("sel"), [
+		{ value: "select", label: "select", description: "Compatibility alias for tools" },
+	]);
+	assert.deepEqual(commandCompletions("of"), [
+		{ value: "off", label: "off", description: "Compatibility alias for disable" },
 	]);
 	assert.equal(commandCompletions("quickstart "), null);
 	assert.equal(commandCompletions("quick start"), null);
@@ -157,7 +162,7 @@ test("chrome-devtools prefers new settings when both files exist and reports leg
 		writeSettings(agentDir, LEGACY_SETTINGS_FILE, [LIST_PAGES_TOOL]);
 		const chromeDevtoolsModule = await importFreshChromeDevtools();
 		const mock = createMockPi({ activeTools: ["other_tool", EVALUATE_TOOL] });
-		const { ctx, notifications } = createMockContext();
+		const { ctx, notifications } = createMockContext({ mode: "rpc", hasUI: true });
 
 		chromeDevtoolsModule.default(mock.pi);
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
@@ -364,77 +369,85 @@ test("endpoint helpers normalize ports, hosts, and launch quoting", () => {
 test("Chrome DevTools main menu dispatches declarative actions at narrow widths", async () => {
 	const mock = createMockPi();
 	chromeDevtools(mock.pi);
+	const renders: string[][] = [];
 	const { ctx, notifications } = createMockContext({
 		hasUI: true,
 		mode: "tui",
 		custom: async (factory: unknown) => {
-			const { renders, result } = driveCustomSelector(factory, ["tui.select.confirm"], 20);
-			assert.ok(renders.flat().every((line) => visibleWidth(line) <= 20));
-			return result;
+			const harness = createCustomSelectorHarness(factory, 20);
+			if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+			renders.push(harness.render());
+			harness.handleInput("tui.select.cancel");
+			return harness.result;
 		},
 	});
 	await mock.commands.get("chrome-devtools")?.handler("", ctx);
-	assert.match(notifications.at(-1)?.message ?? "", /Chrome DevTools endpoint/);
+	assert.ok(renders.flat().every((line) => visibleWidth(line) <= 20));
+	assert.match(renders.flat().join("\n"), /Tools: 0 of 5/);
+	assert.deepEqual(notifications, []);
 });
 
-test("Chrome DevTools tool selection keeps the cursor on the toggled row", async () => {
+test("Chrome DevTools tool selection keeps the cursor on the staged row", async () => {
 	await withTempAgentDir(async (agentDir) => {
 		const mock = createMockPi({ activeTools: ["other_tool"] });
 		chromeDevtools(mock.pi);
 		const toolNames = mock.tools.map((tool) => String(tool.name));
-		mock.rawPi.setActiveTools(["other_tool", ...toolNames]);
+		const initialTools = ["other_tool", ...toolNames];
+		mock.rawPi.setActiveTools(initialTools);
+		let toolScreen = 0;
+		let refreshed = "";
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "tui",
 			custom: async (factory: unknown) => {
-				const { renders, result } = driveCustomSelector(factory, [
-					"tui.select.down",
-					"tui.select.confirm",
-					"tui.select.cancel",
-				]);
-				assert.ok(renders[1]?.some((line) => line.includes("› [ ] chrome_devtools_select_page")));
-				return result;
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				toolScreen += 1;
+				if (toolScreen === 1) {
+					harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+				} else {
+					refreshed = harness.render().join("\n");
+					harness.handleInput("\u0003");
+				}
+				return harness.resultPromise;
 			},
 		});
 		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), [
-			"other_tool",
-			...toolNames.filter((name) => name !== "chrome_devtools_select_page"),
-		]);
-		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, [
-			...toolNames.filter((name) => name !== "chrome_devtools_select_page"),
-		]);
+		assert.match(refreshed, /[→›] \[ \] Select the active page/);
+		assert.deepEqual(mock.rawPi.getActiveTools(), initialTools);
+		assert.equal(existsSync(path.join(agentDir, NEW_SETTINGS_FILE)), false);
 	});
 });
 
-test("Chrome DevTools tool selection refreshes dynamic state after a saved toggle", async () => {
+test("Chrome DevTools tool selection refreshes dynamic draft state after a toggle", async () => {
 	await withTempAgentDir(async () => {
 		const mock = createMockPi({ activeTools: ["other_tool"] });
 		chromeDevtools(mock.pi);
 		const toolNames = mock.tools.map((tool) => String(tool.name));
 		mock.rawPi.setActiveTools(["other_tool", ...toolNames]);
-		let customCalls = 0;
+		let toolScreens = 0;
+		let refreshed = "";
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "tui",
 			custom: async (factory: unknown) => {
-				customCalls += 1;
 				const harness = createCustomSelectorHarness(factory, 80);
-				if (customCalls === 1) harness.handleInput("tui.select.confirm");
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				toolScreens += 1;
+				if (toolScreens === 1) harness.handleInput("tui.select.confirm");
 				else {
-					assert.match(harness.render().join("\n"), /Chrome DevTools tools \(4\/5\)/);
-					harness.handleInput("tui.select.cancel");
+					refreshed = harness.render().join("\n");
+					harness.handleInput("\u0003");
 				}
-				for (let turn = 0; harness.result === undefined && turn < 2_000; turn += 1) {
-					await new Promise<void>((resolve) => setTimeout(resolve, 1));
-				}
-				assert.notEqual(harness.result, undefined);
-				return harness.result;
+				return harness.resultPromise;
 			},
 		});
 		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
-		assert.equal(customCalls, 2);
+		assert.equal(toolScreens, 2);
+		assert.match(refreshed, /Browser tools \(4\/5\)/);
+		assert.match(refreshed, /1 unapplied change/);
 	});
 });
 
@@ -442,16 +455,20 @@ test("Chrome DevTools tool selection stays within narrow terminal widths", async
 	await withTempAgentDir(async () => {
 		const mock = createMockPi({ activeTools: ["other_tool"] });
 		chromeDevtools(mock.pi);
+		const renders: string[][] = [];
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "tui",
 			custom: async (factory: unknown) => {
-				const { renders, result } = driveCustomSelector(factory, ["tui.select.cancel"], 20);
-				assert.ok(renders.flat().every((line) => visibleWidth(line) <= 20));
-				return result;
+				const harness = createCustomSelectorHarness(factory, 20);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				renders.push(harness.render());
+				harness.handleInput("\u0003");
+				return harness.result;
 			},
 		});
 		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
+		assert.ok(renders.flat().every((line) => visibleWidth(line) <= 20));
 	});
 });
 
@@ -459,11 +476,15 @@ test("Chrome DevTools tool selection uses dialogs instead of custom TUI in RPC m
 	await withTempAgentDir(async () => {
 		const mock = createMockPi({ activeTools: ["other_tool"] });
 		chromeDevtools(mock.pi);
+		let selectCalls = 0;
 		let customCalls = 0;
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "rpc",
-			select: async () => "Done",
+			select: async () => {
+				selectCalls += 1;
+				return undefined;
+			},
 			custom: async () => {
 				customCalls += 1;
 			},
@@ -471,6 +492,7 @@ test("Chrome DevTools tool selection uses dialogs instead of custom TUI in RPC m
 
 		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
 
+		assert.equal(selectCalls, 1);
 		assert.equal(customCalls, 0);
 	});
 });

--- a/packages/pi-chrome-devtools/test/menu.test.ts
+++ b/packages/pi-chrome-devtools/test/menu.test.ts
@@ -56,7 +56,7 @@ test("main menu presents consequential state and five goal-oriented actions with
 	});
 });
 
-test("browser status distinguishes unobserved, running, and failed states without probing", () => {
+test("browser status distinguishes unobserved, running, exited, and failed states without probing", () => {
 	state.managedBrowser = undefined;
 	state.launchPromise = undefined;
 	state.lastLaunchAttempt = undefined;
@@ -70,6 +70,17 @@ test("browser status distinguishes unobserved, running, and failed states withou
 		ownerGeneration: state.sessionGeneration,
 	};
 	assert.match(buildBrowserStatusMessage(), /managed browser running/);
+
+	state.managedBrowser.exited = true;
+	state.lastLaunchAttempt = {
+		candidateLabels: ["Chromium"],
+		mode: "dynamic-port",
+		selectedCandidate: "Chromium",
+		userDataDir: "/tmp/test-profile",
+	};
+	const exited = buildBrowserStatusMessage();
+	assert.match(exited, /managed browser exited/);
+	assert.match(exited, /If no endpoint is available/);
 
 	state.managedBrowser = undefined;
 	state.lastLaunchAttempt = {
@@ -331,6 +342,58 @@ test("interactive routes reject unsupported modes while direct mutations remain 
 	});
 });
 
+test("apply refreshes review instead of overwriting browser tools changed while waiting", async () => {
+	await withTempAgentDir(async () => {
+		const initialTools = ["other_tool", ...CHROME_TOOLS];
+		const concurrentTools = ["other_tool", ...CHROME_TOOLS.slice(0, 3)];
+		const mock = createMockPi({ activeTools: initialTools });
+		chromeDevtools(mock.pi);
+		let changedWhileWaiting = false;
+		let toolScreen = 0;
+		let reviewScreen = 0;
+		let refreshedReview = "";
+		const { ctx, notifications } = createMockContext({
+			waitForIdle: async () => {
+				if (changedWhileWaiting) return;
+				changedWhileWaiting = true;
+				mock.rawPi.setActiveTools(concurrentTools);
+			},
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				const rendered = harness.render().join("\n");
+				if (rendered.includes("Review tool changes")) {
+					reviewScreen += 1;
+					if (reviewScreen === 1) harness.handleInput("tui.select.confirm");
+					else {
+						refreshedReview = rendered;
+						harness.handleInput("\u0003");
+					}
+					return harness.resultPromise;
+				}
+				toolScreen += 1;
+				if (toolScreen === 1) harness.handleInput("tui.select.confirm");
+				else {
+					for (let index = 0; index < 7; index += 1) harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+				}
+				return harness.resultPromise;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
+
+		assert.equal(reviewScreen, 2);
+		assert.match(refreshedReview, /Current: 3\/5/);
+		assert.match(refreshedReview, /Proposed: 4\/5/);
+		assert.deepEqual(mock.rawPi.getActiveTools(), concurrentTools);
+		assert.equal(existsSync(settingsFilePath()), false);
+		assert.match(notifications.at(-1)?.message ?? "", /changed while review was open/i);
+	});
+});
+
 test("a failed confirmed save restores runtime and retains the draft for retry", async () => {
 	await withTempAgentDir(async () => {
 		const initialTools = ["other_tool", ...CHROME_TOOLS];
@@ -376,6 +439,51 @@ test("a failed confirmed save restores runtime and retains the draft for retry",
 			notifications.at(-1)?.message ?? "",
 			/settings save failed; active tools restored/i,
 		);
+	});
+});
+
+test("successful apply keeps unresolved settings warnings visible in the parent menu", async () => {
+	await withTempAgentDir(async () => {
+		state.settingsNotice = "Project browser executablePath was ignored.";
+		const mock = createMockPi({ activeTools: ["other_tool", ...CHROME_TOOLS] });
+		chromeDevtools(mock.pi);
+		let mainScreen = 0;
+		let toolScreen = 0;
+		let refreshedMain = "";
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				const rendered = harness.render().join("\n");
+				if (rendered.startsWith("Chrome DevTools\n")) {
+					mainScreen += 1;
+					if (mainScreen === 1) harness.handleInput("tui.select.confirm");
+					else {
+						refreshedMain = rendered;
+						harness.handleInput("\u0003");
+					}
+					return harness.resultPromise;
+				}
+				if (rendered.includes("Review tool changes")) {
+					harness.handleInput("tui.select.confirm");
+					return harness.resultPromise;
+				}
+				toolScreen += 1;
+				if (toolScreen === 1) harness.handleInput("tui.select.confirm");
+				else {
+					for (let index = 0; index < 7; index += 1) harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+				}
+				return harness.resultPromise;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("", ctx);
+
+		assert.equal(mainScreen, 2);
+		assert.match(refreshedMain, /Settings warning: Project browser executablePath was ignored/);
 	});
 });
 
@@ -485,6 +593,7 @@ async function withTempAgentDir(run: () => Promise<void>) {
 		state.managedBrowser = undefined;
 		state.launchPromise = undefined;
 		state.lastLaunchAttempt = undefined;
+		state.settingsNotice = undefined;
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(directory, { recursive: true, force: true });

--- a/packages/pi-chrome-devtools/test/menu.test.ts
+++ b/packages/pi-chrome-devtools/test/menu.test.ts
@@ -1,0 +1,492 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
+import chromeDevtools from "../src/chrome-devtools.js";
+import { state } from "../src/runtime.js";
+import { settingsFilePath } from "../src/settings.js";
+import { buildBrowserStatusMessage } from "../src/tool-selector.js";
+
+const CHROME_TOOLS = [
+	"chrome_devtools_list_pages",
+	"chrome_devtools_select_page",
+	"chrome_devtools_navigate",
+	"chrome_devtools_evaluate",
+	"chrome_devtools_screenshot",
+] as const;
+
+test("main menu presents consequential state and five goal-oriented actions without launching Chrome", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi({ activeTools: ["other_tool", CHROME_TOOLS[0], CHROME_TOOLS[4]] });
+		chromeDevtools(mock.pi);
+		let rendered = "";
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 40);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				rendered = harness.render().join("\n");
+				assert.ok(harness.render().every((line) => visibleWidth(line) <= 40));
+				harness.handleInput("tui.select.cancel");
+				return harness.result;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("", ctx);
+
+		assert.match(rendered, /Tools: 2 of 5 enabled · not saved/);
+		assert.match(rendered, /Browser: not started · attaches or\s+launches on first use/);
+		assert.match(rendered, /Endpoint: http:\/\/127\.0\.0\.1:9222/);
+		assert.match(rendered, /[→›] Choose browser tools…/);
+		assert.match(rendered, /Enable all browser tools…/);
+		assert.match(rendered, /Browser status/);
+		assert.match(rendered, /Settings & setup/);
+		assert.match(rendered, /Help/);
+		assert.equal(state.managedBrowser, undefined);
+		assert.equal(state.launchPromise, undefined);
+		assert.equal(state.lastLaunchAttempt, undefined);
+	});
+});
+
+test("browser status distinguishes unobserved, running, and failed states without probing", () => {
+	state.managedBrowser = undefined;
+	state.launchPromise = undefined;
+	state.lastLaunchAttempt = undefined;
+	assert.match(buildBrowserStatusMessage(), /not started; connection has not been checked/);
+
+	state.managedBrowser = {
+		process: {} as never,
+		userDataDir: "/tmp/test-profile",
+		exited: false,
+		ready: true,
+		ownerGeneration: state.sessionGeneration,
+	};
+	assert.match(buildBrowserStatusMessage(), /managed browser running/);
+
+	state.managedBrowser = undefined;
+	state.lastLaunchAttempt = {
+		candidateLabels: ["Chromium"],
+		mode: "dynamic-port",
+		lastError: "browser unavailable",
+	};
+	const failed = buildBrowserStatusMessage();
+	assert.match(failed, /last launch failed/);
+	assert.match(failed, /Last launch error: browser unavailable/);
+	assert.match(failed, /does not probe the endpoint or launch Chrome/);
+	state.lastLaunchAttempt = undefined;
+});
+
+test("main menu shows saved all-enabled state and the reversible disable preview", async () => {
+	await withTempAgentDir(async () => {
+		writeFileSync(settingsFilePath(), `${JSON.stringify({ tools: CHROME_TOOLS, updatedAt: 1 })}\n`);
+		const mock = createMockPi({ activeTools: ["other_tool", ...CHROME_TOOLS] });
+		chromeDevtools(mock.pi);
+		let rendered = "";
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				rendered = harness.render().join("\n");
+				harness.handleInput("\u0003");
+				return harness.result;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("", ctx);
+
+		assert.match(rendered, /Tools: 5 of 5 enabled · saved/);
+		assert.match(rendered, /Disable all browser tools…/);
+		assert.match(rendered, /Preview 0 of 5; other active tools stay enabled/);
+	});
+});
+
+test("staged tool changes show friendly labels and cancellation has no side effects", async () => {
+	await withTempAgentDir(async () => {
+		const initialTools = ["other_tool", ...CHROME_TOOLS];
+		const mock = createMockPi({ activeTools: initialTools });
+		chromeDevtools(mock.pi);
+		const renders: string[] = [];
+		let toolScreen = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				const rendered = harness.render().join("\n");
+				renders.push(rendered);
+				toolScreen += 1;
+				if (toolScreen === 1) harness.handleInput("tui.select.confirm");
+				else harness.handleInput("\u0003");
+				return harness.resultPromise;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
+
+		assert.match(renders[0] ?? "", /List open pages/);
+		assert.match(renders[0] ?? "", /chrome_devtools_list_pages/);
+		assert.match(renders[1] ?? "", /1 unapplied change/);
+		assert.deepEqual(mock.rawPi.getActiveTools(), initialTools);
+		assert.equal(existsSync(settingsFilePath()), false);
+		assert.deepEqual(notifications, []);
+	});
+});
+
+test("Ctrl+C in the nested tool workflow closes the whole manager", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi({ activeTools: ["other_tool"] });
+		chromeDevtools(mock.pi);
+		let mainScreens = 0;
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				const rendered = harness.render().join("\n");
+				if (rendered.startsWith("Chrome DevTools\n")) {
+					mainScreens += 1;
+					if (mainScreens === 1) harness.handleInput("tui.select.confirm");
+					else harness.handleInput("\u0003");
+				} else harness.handleInput("\u0003");
+				return harness.resultPromise;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("", ctx);
+
+		assert.equal(mainScreens, 1);
+	});
+});
+
+test("session replacement discards a staged draft without stale feedback", async () => {
+	await withTempAgentDir(async () => {
+		const initialTools = ["other_tool", ...CHROME_TOOLS];
+		const mock = createMockPi({ activeTools: initialTools });
+		chromeDevtools(mock.pi);
+		let toolScreen = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				toolScreen += 1;
+				if (toolScreen === 1) harness.handleInput("tui.select.confirm");
+				else await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+				return harness.resultPromise;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), initialTools);
+		assert.equal(existsSync(settingsFilePath()), false);
+		assert.deepEqual(notifications, []);
+	});
+});
+
+test("bulk preview and nested detail navigation return without side effects", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi({ activeTools: ["other_tool"] });
+		chromeDevtools(mock.pi);
+		const details: string[] = [];
+		const narrowDetails: string[][] = [];
+		let mainScreen = 0;
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				const rendered = harness.render().join("\n");
+				if (rendered.includes("Review tool changes")) {
+					details.push(rendered);
+					harness.handleInput("tui.select.cancel");
+					return harness.result;
+				}
+				if (
+					rendered.startsWith("Browser status") ||
+					rendered.startsWith("Settings & setup") ||
+					rendered.startsWith("Chrome DevTools help")
+				) {
+					details.push(rendered);
+					harness.setTerminalRows(8);
+					narrowDetails.push(harness.render(20));
+					harness.handleInput("tui.select.cancel");
+					return harness.result;
+				}
+				mainScreen += 1;
+				if (mainScreen === 1) {
+					harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+				} else if (mainScreen === 2 || mainScreen === 3 || mainScreen === 4) {
+					harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+				} else harness.handleInput("\u0003");
+				return harness.resultPromise;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("", ctx);
+
+		assert.match(details[0] ?? "", /Proposed: 5\/5/);
+		assert.match(details[1] ?? "", /does not probe the endpoint or launch Chrome/);
+		assert.match(details[2] ?? "", /Settings changes apply.*\/reload/s);
+		assert.match(details[3] ?? "", /\/chrome-devtools tools/);
+		assert.ok(narrowDetails.flat().every((line) => visibleWidth(line) <= 20));
+		assert.ok(narrowDetails.every((screen) => screen.length <= 5));
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
+		assert.equal(existsSync(settingsFilePath()), false);
+		assert.equal(state.managedBrowser, undefined);
+	});
+});
+
+test("invalid settings keep tool mutation unavailable and preserve the file", async () => {
+	await withTempAgentDir(async () => {
+		const invalid = "{not-json\n";
+		writeFileSync(settingsFilePath(), invalid);
+		const mock = createMockPi({ activeTools: ["other_tool", CHROME_TOOLS[0]] });
+		chromeDevtools(mock.pi);
+		let rendered = "";
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				rendered = harness.render().join("\n");
+				harness.handleInput("\u0003");
+				return harness.result;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("", ctx);
+
+		assert.match(rendered, /settings need repair/);
+		assert.match(rendered, /\[-\] Choose browser tools…/);
+		assert.match(rendered, /Repair .*invalid JSON before saving/s);
+		assert.equal(readFileSync(settingsFilePath(), "utf8"), invalid);
+	});
+});
+
+test("cancelling the loading state closes without opening the menu or creating settings", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi({ activeTools: ["other_tool"] });
+		chromeDevtools(mock.pi);
+		let menuScreens = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 40);
+				if (harness.isPiTuiKitScreen) {
+					menuScreens += 1;
+					harness.handleInput("\u0003");
+					return harness.result;
+				}
+				harness.handleInput("tui.select.cancel");
+				return harness.resultPromise;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("", ctx);
+
+		assert.equal(menuScreens, 0);
+		assert.equal(existsSync(settingsFilePath()), false);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
+		assert.deepEqual(notifications, []);
+	});
+});
+
+test("interactive routes reject unsupported modes while direct mutations remain available", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi({ activeTools: ["other_tool", ...CHROME_TOOLS] });
+		chromeDevtools(mock.pi);
+		const { ctx } = createMockContext({ mode: "json", hasUI: false });
+		const command = mock.commands.get("chrome-devtools")?.handler;
+		assert.ok(command);
+		const invoke = async (args: string) => command(args, ctx);
+
+		await assert.rejects(() => invoke(""), /requires TUI or RPC/);
+		await assert.rejects(() => invoke("help"), /requires TUI or RPC/);
+		await assert.rejects(() => invoke("status"), /requires TUI or RPC/);
+		await assert.rejects(() => invoke("quickstart"), /requires TUI or RPC/);
+		await assert.rejects(() => invoke("tools"), /requires TUI or RPC/);
+		await invoke("disable");
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
+		assert.deepEqual(JSON.parse(readFileSync(settingsFilePath(), "utf8")).tools, []);
+	});
+});
+
+test("a failed confirmed save restores runtime and retains the draft for retry", async () => {
+	await withTempAgentDir(async () => {
+		const initialTools = ["other_tool", ...CHROME_TOOLS];
+		const mock = createMockPi({ activeTools: initialTools });
+		chromeDevtools(mock.pi);
+		let toolScreen = 0;
+		let reviewScreen = 0;
+		let retryReview = "";
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				const rendered = harness.render().join("\n");
+				if (rendered.includes("Review tool changes")) {
+					reviewScreen += 1;
+					if (reviewScreen === 1) {
+						mkdirSync(settingsFilePath());
+						harness.handleInput("tui.select.confirm");
+						return harness.resultPromise;
+					}
+					retryReview = rendered;
+					harness.handleInput("tui.select.cancel");
+					return harness.result;
+				}
+				toolScreen += 1;
+				if (toolScreen === 1) harness.handleInput("tui.select.confirm");
+				else if (toolScreen === 2) {
+					for (let index = 0; index < 7; index += 1) harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+				} else harness.handleInput("\u0003");
+				return harness.resultPromise;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
+
+		assert.equal(reviewScreen, 2);
+		assert.match(retryReview, /Proposed: 4\/5/);
+		assert.deepEqual(mock.rawPi.getActiveTools(), initialTools);
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/settings save failed; active tools restored/i,
+		);
+	});
+});
+
+test("RPC dialogs preserve staged review and confirmed apply semantics", async () => {
+	await withTempAgentDir(async () => {
+		const mock = createMockPi({ activeTools: ["other_tool", ...CHROME_TOOLS] });
+		chromeDevtools(mock.pi);
+		let toolDialog = 0;
+		const dialogTitles: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			select: async (title: string, options: string[]) => {
+				dialogTitles.push(title);
+				if (options.some((option) => option.includes("List open pages"))) {
+					toolDialog += 1;
+					if (toolDialog === 1) return options.find((option) => option.includes("List open pages"));
+					return options.find((option) => option.includes("Review changes"));
+				}
+				return options.find((option) => option.includes("Apply tool changes"));
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
+
+		assert.ok(dialogTitles.some((title) => title.includes("Current accepted: 5/5")));
+		assert.ok(dialogTitles.some((title) => title.includes("Proposed: 4/5")));
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", ...CHROME_TOOLS.slice(1)]);
+		assert.deepEqual(
+			JSON.parse(readFileSync(settingsFilePath(), "utf8")).tools,
+			CHROME_TOOLS.slice(1),
+		);
+	});
+});
+
+test("review previews the exact tool effect and one confirmed apply persists it", async () => {
+	await withTempAgentDir(async () => {
+		const initialTools = ["other_tool", ...CHROME_TOOLS];
+		const mock = createMockPi({ activeTools: initialTools });
+		chromeDevtools(mock.pi);
+		const applicationOrder: string[] = [];
+		const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+		mock.rawPi.setActiveTools = (names) => {
+			applicationOrder.push("apply-runtime");
+			setActiveTools(names);
+		};
+		let toolScreen = 0;
+		let review = "";
+		let narrowReview: string[] = [];
+		const { ctx, notifications } = createMockContext({
+			waitForIdle: async () => {
+				applicationOrder.push("wait-for-idle");
+			},
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 80);
+				if (!harness.isPiTuiKitScreen) return harness.resultPromise;
+				const rendered = harness.render().join("\n");
+				if (rendered.includes("Review tool changes")) {
+					review = rendered;
+					harness.setTerminalRows(8);
+					narrowReview = harness.render(20);
+					harness.handleInput("tui.select.confirm");
+					return harness.resultPromise;
+				}
+				toolScreen += 1;
+				if (toolScreen === 1) {
+					harness.handleInput("tui.select.confirm");
+					return harness.resultPromise;
+				}
+				for (let index = 0; index < 7; index += 1) harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+				return harness.resultPromise;
+			},
+		});
+
+		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
+
+		assert.match(review, /Current: 5\/5/);
+		assert.match(review, /Proposed: 4\/5/);
+		assert.match(review, /Disabled after apply:/);
+		assert.match(review, /List open pages \(chrome_devtools_list_pages\)/);
+		assert.match(review, /Other active Pi tools remain unchanged/);
+		assert.ok(narrowReview.every((line) => visibleWidth(line) <= 20));
+		assert.ok(narrowReview.length <= 5);
+		assert.deepEqual(applicationOrder, ["wait-for-idle", "apply-runtime"]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", ...CHROME_TOOLS.slice(1)]);
+		assert.deepEqual(
+			JSON.parse(readFileSync(settingsFilePath(), "utf8")).tools,
+			CHROME_TOOLS.slice(1),
+		);
+		assert.match(notifications.at(-1)?.message ?? "", /Saved: 4 of 5 browser tools enabled/);
+	});
+});
+
+async function withTempAgentDir(run: () => Promise<void>) {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-cdp-menu-test-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		await run();
+	} finally {
+		state.sessionController.abort();
+		state.sessionController = new AbortController();
+		state.sessionGeneration += 1;
+		state.managedBrowser = undefined;
+		state.launchPromise = undefined;
+		state.lastLaunchAttempt = undefined;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+}


### PR DESCRIPTION
## Summary

- redesign `/chrome-devtools` around visible tool, browser, endpoint, and settings state with five goal-oriented actions
- stage per-tool and bulk changes, preview the exact result, and apply once with rollback and cancellation safety
- add shallow Browser status, Settings & setup, and Help views with TUI/RPC parity while preserving direct commands, aliases, settings, and unknown fields
- document the workflow, archive the completed implementation plan, and add minor release intent

## Verification

- `npm run check` — 2,533 tests passed
- compiled `pi-chrome-devtools` suite — 61 tests passed
- Pi 0.84.1 non-interactive RPC smoke — details, cancellation, staged review/apply, and status passed without launching Chrome
- `just pack chrome-devtools` — 15 expected files
- `npm run changeset:status`
- `git diff --check`

Windows and macOS runtime rendering were not exercised locally.
