### PR TITLE
feat(starship): add bundled footer presets

### DIFF
--- a/.changeset/brave-stars-glow.md
+++ b/.changeset/brave-stars-glow.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-starship": minor
+---
+
+Add four bundled Pi-native footer presets with menu browsing, live preview, optional TOML customization, confirmed atomic application, and built-in recovery.

--- a/docs/plans/archived/2026-08-08_pi-starship-presets-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-starship-presets-plan.md
@@ -37,14 +37,14 @@ lifecycle, or non-TUI behavior.
   presets must not alter startup defaults or config normalization.
 - Import the preset catalog only through the already lazy `commands.ts` path. Opening ordinary Pi
   sessions must not eagerly load preset documents or Pi TUI Kit UI beyond current behavior.
-- Add a seventh **Presets** row to the main menu and one shallow preset action screen. Stable IDs drive
-  selection; labels are presentation only. Exact raw-document equality identifies a currently applied
-  preset, which is shown textually and disabled from redundant application. Any manual byte change is
-  treated as custom configuration.
-- Generalize the current restore/edit review helper around explicit replacement metadata rather than
-  a restore boolean. A preset selection produces a validated draft and adaptive live preview with
-  **Apply preset…**, **Customize before applying**, and **Choose another preset** outcomes. Customizing
-  opens the existing editor with the preset document and then returns to the standard preview flow.
+- Add a seventh **Presets** row to the main menu and one shallow, extension-owned live picker using
+  Kit's published custom-interaction lifecycle. Stable IDs drive selection; labels are presentation
+  only. Exact raw-document equality identifies a currently applied preset, which is shown textually
+  and disabled from redundant application. Any manual byte change is treated as custom configuration.
+- Keep an independent in-memory preview slot in the runtime footer. Cursor changes synchronously
+  replace only that render input and never alter the authoritative loaded settings or collector
+  requirements. Enter reuses the named destructive confirmation and atomic apply path; `e` opens the
+  existing editor with the selected document and returns to its standard review flow.
 - Applying a preset is a complete-document replacement, not a TOML overlay. The confirmation must name
   the selected preset and state that custom settings, unknown fields, and comments will be removed and
   that no post-success backup is kept. Save, apply, concurrent-file protection, and rollback continue
@@ -172,14 +172,40 @@ lifecycle, or non-TUI behavior.
 - [x] Re-run package and repository checks, packaging, RPC smoke, and semantic convention audit; final
       evidence is recorded below.
 
+## Live cursor preview follow-up
+
+The approved follow-up replaces the static preset action screen with a specialized, lifecycle-owned
+picker. Its cursor is the temporary footer state: opening the picker and every Up/Down/Page/Home/End
+move previews the selected complete preset in memory against the current immutable runtime snapshot.
+Enter starts the existing destructive confirmation and atomic save/apply protocol; `e` preserves
+**Customize before applying**. Escape/Back, Ctrl+C, external disposal, session replacement, shutdown,
+confirmation cancellation, validation failure, and apply failure clear the temporary preview and leave
+the previous document/effective footer intact. Preview updates are synchronous latest-selection-wins
+assignments, so no debounce or asynchronous generation race is introduced.
+
+- [x] Add focused red TUI tests for initial and cursor live preview, zero writes during browsing,
+      Enter-to-confirm/apply, `e` customization, active-row disabling, and preview restoration across
+      Back, Ctrl+C, disposal, replacement, and shutdown; the initial run failed on absent preview calls
+      and the old multi-step preview interaction, then the focused set passed with 2,544 root tests.
+- [x] Add an extension-owned picker through the already-published Kit custom-interaction API and a
+      separate runtime preview slot; focused runtime coverage proves selection changes only the footer
+      render input, creates no settings file, and Back restores the built-in footer.
+- [x] Reuse the existing confirmation/save/apply/rollback protocol for direct Enter and preserve the
+      editor/recovery path on `e`; focused confirmation cancellation, apply, customization, invalid
+      draft, width, disposal, and shutdown tests pass.
+- [x] Update README/help/plan evidence, run package/root checks, pack and RPC smoke, repeat the semantic
+      convention audit, archive this plan, commit, and push the PR update; final root verification passed
+      2,547 tests, packaging included 79 files, and RPC help advertised live preset preview without
+      creating settings.
+
 ## Completion Checklist
 
 - [x] `/starship` presents seven shallow, goal-oriented actions and a 13-item preset screen with
       visible current state, font requirements, Back, Escape, and Ctrl+C behavior.
 - [x] Font-safe and Nerd Font-dependent choices are clearly marked; all 13 documents validate cleanly
       and render within supported widths without enabling undocumented collectors or network work.
-- [x] Selecting a preset never mutates disk or runtime before preview and confirmation; users can apply,
-      customize first, choose another, or cancel without ambiguous side effects.
+- [x] Browsing presets never mutates disk or authoritative runtime state; users can live-preview,
+      confirm apply, customize first, choose another, or cancel without ambiguous side effects.
 - [x] Complete-document replacement is disclosed, confirmed, serialized, atomic, generation-safe, and
       rollback-capable; malformed/current/concurrent documents follow the documented recovery rules.
 - [x] Built-in defaults, Restore, custom TOML, menu/direct command routes, non-TUI protocol behavior,
@@ -224,3 +250,12 @@ lifecycle, or non-TUI behavior.
   exited successfully on stdin close, and did not create `pi-starship.toml`. The Kit TUI harness covered
   the paged 13-item list at 20, 40, and 80 columns; a real Nerd Font visual smoke remains unverified
   because repository execution policy forbids opening a TUI.
+- Live-picker follow-up evidence: cursor changes synchronously publish an independent preview slot;
+  Back, Ctrl+C, confirmation cancellation, disposal, session replacement, shutdown, invalid drafts,
+  and failed apply paths clear it without persistence. Direct Enter reuses destructive confirmation and
+  atomic apply, while `e` reuses the editor/review path. Callback-injected navigation and hints are
+  covered. Final package check and root `npm run check` passed with 2,547 tests; Changesets still reports
+  only `@narumitw/pi-starship` 0.50.0. `just pack starship` passed with 79 files at 82.4 kB packed /
+  309.2 kB unpacked, including `src/command-preset-picker.ts`. The final RPC smoke advertised
+  `live-preview presets` and created no settings file. Re-audit found no convention deviation; the
+  prohibited real-terminal/Nerd Font visual path remains the only unverified presentation path.

--- a/docs/plans/archived/2026-08-08_pi-starship-presets-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-starship-presets-plan.md
@@ -2,9 +2,10 @@
 
 ## Goal
 
-Add four bundled, Pi-native footer presets to `@narumitw/pi-starship` and let TUI users browse,
-preview, optionally customize, confirm, and atomically apply one from the existing `/starship` menu
-without weakening custom TOML, recovery, lifecycle, or non-TUI behavior.
+Add Pi-native adaptations of every style listed by Starship 1.26.0's `preset --list`, plus a Minimal
+preset, to `@narumitw/pi-starship`. Let TUI users browse, preview, optionally customize, confirm, and
+atomically apply one from the existing `/starship` menu without weakening custom TOML, recovery,
+lifecycle, or non-TUI behavior.
 
 ## Context
 
@@ -15,9 +16,11 @@ without weakening custom TOML, recovery, lifecycle, or non-TUI behavior.
   draft validation, atomic publication, concurrent-file protection, and runtime-apply rollback.
 - The existing **Restore built-in…** action is documented recovery behavior and remains visible. The
   preset list therefore contains only non-default alternatives.
-- Starship currently publishes presets such as Bracketed Segments, Nerd Font Symbols, Pastel
-  Powerline, and Tokyo Night. pi-starship supports only its own modules and format semantics, so the
-  bundled documents will be Pi-specific adaptations rather than compatibility copies.
+- Starship 1.26.0 publishes 12 presets: Bracketed Segments, Catppuccin Powerline, Gruvbox Rainbow,
+  Jetpack, Nerd Font Symbols, No Empty Icons, No Nerd Font, No Runtime Versions, Pastel Powerline,
+  Plain Text Symbols, Pure, and Tokyo Night. pi-starship supports its own modules and format semantics,
+  so the bundled documents are Pi-specific adaptations of their colors and layouts rather than module
+  compatibility copies.
 - Applicable guidance already reviewed: `docs/extension-conventions.md`,
   `docs/extension-settings.md`, Pi TUI/menu lifecycle requirements, and the repository TDD boundary.
   Touched MUST areas are command/menu behavior, custom TUI width and cancellation, settings
@@ -46,19 +49,18 @@ without weakening custom TOML, recovery, lifecycle, or non-TUI behavior.
   the selected preset and state that custom settings, unknown fields, and comments will be removed and
   that no post-success backup is kept. Save, apply, concurrent-file protection, and rollback continue
   through the existing config APIs.
-- Initial catalog:
-  - `minimal`: font-safe `$model`, `$directory`, `$git_branch`, and `$activity` layout.
-  - `bracketed`: font-safe bracketed presentation of the balanced Pi/Git default information.
-  - `nerd-font-symbols`: balanced default information with Nerd Font module symbols.
-  - `tokyo-night`: a one-line, palette-backed Powerline treatment of Pi model/thinking, directory,
-    Git, activity, context, and time, explicitly requiring a Nerd Font.
+- Catalog: the Pi-specific `minimal` option plus stable IDs matching all 12 names emitted by
+  `starship preset --list`. Bracketed, semantic modifier, Jetpack, and Pure adaptations are font-safe;
+  Catppuccin, Gruvbox, Pastel, Tokyo Night, and Nerd Font Symbols explicitly require a Nerd Font.
+  Every document chooses only local Pi and Git snapshot modules while preserving the source preset's
+  color, separator, typography, and layout treatment.
 - None of the initial presets enables GitHub PR queries, cloud/deployment readers, or optional
   command-backed workspace collectors. Preset previews remain synchronous consumers of the current
   immutable runtime snapshot.
 
 ## Non-Goals
 
-- Read or execute Starship's own preset command, binary, schema, or `starship.toml`.
+- Read or execute Starship's preset command, binary, schema, or `starship.toml` at extension runtime.
 - Claim complete compatibility with upstream preset TOML or copy unsupported Starship modules.
 - Add a `/starship preset` textual route, project scope, environment override, automatic migration,
   remote/community preset download, preset composition, or TOML merge engine.
@@ -70,8 +72,8 @@ without weakening custom TOML, recovery, lifecycle, or non-TUI behavior.
 
 ## Assumptions
 
-- Unless revised before execution, the approved v1 catalog is Minimal, Bracketed, Nerd Font Symbols,
-  and Tokyo Night as specified above.
+- The development reference is the local Starship 1.26.0 output from `starship preset --list` and
+  `starship preset <name>`; runtime behavior remains independent of the Starship binary.
 - Presets are complete starting points. Expert preservation is provided by **Customize before
   applying**, not by silently merging a preset into an existing document.
 
@@ -112,11 +114,11 @@ without weakening custom TOML, recovery, lifecycle, or non-TUI behavior.
       requirements are explicit, exact raw matching recognizes only unchanged preset documents, and
       no preset reaches network or optional command-backed modules; verify the focused tests execute
       and fail for missing preset behavior before implementation.
-- [x] Add `packages/pi-starship/src/presets/` catalog and four bounded document modules implementing the
+- [x] Add `packages/pi-starship/src/presets/` catalog and bounded document modules implementing the
       approved module/layout contracts; verify the focused catalog/config tests pass and source files
       remain below 1,000 lines.
 - [x] Add focused red menu tests in `packages/pi-starship/test/command-ux.test.ts` and
-      `packages/pi-starship/test/commands.test.ts` for the seventh **Presets** row, one-level four-item
+      `packages/pi-starship/test/commands.test.ts` for the seventh **Presets** row, one-level preset
       list, descriptions and Nerd Font warnings, exact `Currently applied` disabled state, active
       preset configuration presentation, Back/focus restoration, and no startup/file/runtime side
       effects; verify they fail on the existing six-row menu for the intended reason.
@@ -153,13 +155,29 @@ without weakening custom TOML, recovery, lifecycle, or non-TUI behavior.
       documentation, and release gates; verify every applicable MUST has test/review/smoke evidence and
       record any accepted deviation.
 
+## Starship 1.26 catalog expansion
+
+- [x] Capture `starship preset --list` and each `starship preset <name>` development output; verified
+      the 12 upstream names and reviewed every emitted palette, format, separator, symbol policy, and
+      typography treatment.
+- [x] Extend the public catalog test to require all 12 upstream IDs plus Minimal; verified the red
+      state reported the nine missing IDs and the former `bracketed` ID.
+- [x] Add bounded Pi-native preset documents and action handlers for the complete catalog; verified
+      every document parses without diagnostics, renders Pi-native information, uses only local Pi/Git
+      modules, and declares its Nerd Font requirement.
+- [x] Exercise the 13-item menu viewport and final-item navigation at 20, 40, and 80 columns; verified
+      stable selection, active-item disabling, scrolling, and font-warning presentation.
+- [x] Update README catalog and Starship attribution to explain the 1.26.0 color/layout reference and
+      Pi-owned module selection.
+- [x] Re-run package and repository checks, packaging, RPC smoke, and semantic convention audit; final
+      evidence is recorded below.
+
 ## Completion Checklist
 
-- [x] `/starship` presents seven shallow, goal-oriented actions and a four-item preset screen with
+- [x] `/starship` presents seven shallow, goal-oriented actions and a 13-item preset screen with
       visible current state, font requirements, Back, Escape, and Ctrl+C behavior.
-- [x] Minimal and Bracketed are font-safe; Nerd Font Symbols and Tokyo Night are clearly marked; all
-      four documents validate cleanly and render within supported widths without enabling undocumented
-      collectors or network work.
+- [x] Font-safe and Nerd Font-dependent choices are clearly marked; all 13 documents validate cleanly
+      and render within supported widths without enabling undocumented collectors or network work.
 - [x] Selecting a preset never mutates disk or runtime before preview and confirmation; users can apply,
       customize first, choose another, or cancel without ambiguous side effects.
 - [x] Complete-document replacement is disclosed, confirmed, serialized, atomic, generation-safe, and
@@ -171,17 +189,18 @@ without weakening custom TOML, recovery, lifecycle, or non-TUI behavior.
 
 ## Execution Evidence
 
-- Completed 2026-08-08 on `feat/pi-starship-presets` after rebasing onto `origin/main` at
-  `1156ee7`. The four preset documents validate without diagnostics and remain under the lazy command
-  import boundary.
+- Initial four-preset implementation completed 2026-08-08 on `feat/pi-starship-presets` after
+  rebasing onto `origin/main` at `1156ee7`; the later Starship 1.26 catalog expansion retains the same
+  lazy command import boundary.
 - TDD evidence: the catalog test first failed with an empty preset list, and the menu test first failed
   on the existing six-row menu and `Custom configuration` state. Focused config, menu, interaction,
   rendering, failure-recovery, and lifecycle tests then passed.
 - `npm run check --workspace @narumitw/pi-starship` passed. The compiled package test set passed before
   the final root gate; `npm run check` passed with 2,542 tests after the final rebase and help-text
   update.
-- `just pack starship` passed with 69 files, including all five `src/presets/` modules. Changeset status
-  reports the intended independent minor bump to `@narumitw/pi-starship` 0.50.0.
+- Initial `just pack starship` passed with 69 files and Changeset status reported the intended
+  independent minor bump to `@narumitw/pi-starship` 0.50.0. Final expansion packaging evidence is
+  recorded below.
 - A real Pi 0.84.1 RPC smoke loaded only `packages/pi-starship/src/index.ts`, discovered `/starship`,
   returned the updated `/starship help` notification, exited successfully, and left the temporary
   agent directory without `pi-starship.toml`. TUI behavior was exercised through the local async Kit
@@ -193,3 +212,15 @@ without weakening custom TOML, recovery, lifecycle, or non-TUI behavior.
   complete-document replacement is previewed and confirmed; existing invalid-file, atomic publication,
   concurrent-file preservation, runtime rollback, lazy loading, and missing-file semantics remain in
   force. No accepted convention deviation remains; only real Nerd Font appearance is unverified.
+- Follow-up expansion evidence: Starship 1.26.0 reported all 12 expected IDs, and all emitted documents
+  were reviewed as development references. The 13 Pi documents validate without diagnostics, render
+  expected Pi/Git information, and limit reachability to local core modules. The TDD catalog red state
+  named the nine missing upstream styles and obsolete `bracketed` ID before implementation.
+- Final `npm run check --workspace @narumitw/pi-starship` and root `npm run check` passed; the root gate
+  completed 2,542 tests. `npm run changeset:status` still reports only the intended minor bump to
+  `@narumitw/pi-starship` 0.50.0. Final `just pack starship` passed with 78 files, including all 14
+  `src/presets/` modules, at 81.1 kB packed / 301.5 kB unpacked.
+- Final Pi RPC smoke loaded only `src/index.ts`, discovered `/starship`, observed preset-aware help,
+  exited successfully on stdin close, and did not create `pi-starship.toml`. The Kit TUI harness covered
+  the paged 13-item list at 20, 40, and 80 columns; a real Nerd Font visual smoke remains unverified
+  because repository execution policy forbids opening a TUI.

--- a/docs/plans/archived/2026-08-08_pi-starship-presets-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-starship-presets-plan.md
@@ -1,0 +1,195 @@
+# pi-starship presets plan
+
+## Goal
+
+Add four bundled, Pi-native footer presets to `@narumitw/pi-starship` and let TUI users browse,
+preview, optionally customize, confirm, and atomically apply one from the existing `/starship` menu
+without weakening custom TOML, recovery, lifecycle, or non-TUI behavior.
+
+## Context
+
+- `packages/pi-starship/src/commands.ts` currently exposes a six-item, current-state main menu and one
+  transactional edit/preview/confirm pipeline. Presets should reuse that pipeline rather than add a
+  second persistence protocol.
+- `packages/pi-starship/src/config.ts` owns side-effect-free missing-file loading, TOML normalization,
+  draft validation, atomic publication, concurrent-file protection, and runtime-apply rollback.
+- The existing **Restore built-in…** action is documented recovery behavior and remains visible. The
+  preset list therefore contains only non-default alternatives.
+- Starship currently publishes presets such as Bracketed Segments, Nerd Font Symbols, Pastel
+  Powerline, and Tokyo Night. pi-starship supports only its own modules and format semantics, so the
+  bundled documents will be Pi-specific adaptations rather than compatibility copies.
+- Applicable guidance already reviewed: `docs/extension-conventions.md`,
+  `docs/extension-settings.md`, Pi TUI/menu lifecycle requirements, and the repository TDD boundary.
+  Touched MUST areas are command/menu behavior, custom TUI width and cancellation, settings
+  publication and rollback, session replacement/shutdown, deterministic tests, documentation,
+  release intent, package inspection, and the root check.
+
+## Architecture
+
+- Add a lazy command-side preset catalog under `packages/pi-starship/src/presets/`. Each entry owns a
+  stable ID, English label, concise description, Nerd Font requirement, and complete raw TOML
+  document. Keep each substantial declarative document in its own module so no source file crosses the
+  repository's 1,000-line limit.
+- Keep `BUILT_IN_CONFIG` and `BUILT_IN_EXAMPLE` authoritative for missing-file defaults and recovery;
+  presets must not alter startup defaults or config normalization.
+- Import the preset catalog only through the already lazy `commands.ts` path. Opening ordinary Pi
+  sessions must not eagerly load preset documents or Pi TUI Kit UI beyond current behavior.
+- Add a seventh **Presets** row to the main menu and one shallow preset action screen. Stable IDs drive
+  selection; labels are presentation only. Exact raw-document equality identifies a currently applied
+  preset, which is shown textually and disabled from redundant application. Any manual byte change is
+  treated as custom configuration.
+- Generalize the current restore/edit review helper around explicit replacement metadata rather than
+  a restore boolean. A preset selection produces a validated draft and adaptive live preview with
+  **Apply preset…**, **Customize before applying**, and **Choose another preset** outcomes. Customizing
+  opens the existing editor with the preset document and then returns to the standard preview flow.
+- Applying a preset is a complete-document replacement, not a TOML overlay. The confirmation must name
+  the selected preset and state that custom settings, unknown fields, and comments will be removed and
+  that no post-success backup is kept. Save, apply, concurrent-file protection, and rollback continue
+  through the existing config APIs.
+- Initial catalog:
+  - `minimal`: font-safe `$model`, `$directory`, `$git_branch`, and `$activity` layout.
+  - `bracketed`: font-safe bracketed presentation of the balanced Pi/Git default information.
+  - `nerd-font-symbols`: balanced default information with Nerd Font module symbols.
+  - `tokyo-night`: a one-line, palette-backed Powerline treatment of Pi model/thinking, directory,
+    Git, activity, context, and time, explicitly requiring a Nerd Font.
+- None of the initial presets enables GitHub PR queries, cloud/deployment readers, or optional
+  command-backed workspace collectors. Preset previews remain synchronous consumers of the current
+  immutable runtime snapshot.
+
+## Non-Goals
+
+- Read or execute Starship's own preset command, binary, schema, or `starship.toml`.
+- Claim complete compatibility with upstream preset TOML or copy unsupported Starship modules.
+- Add a `/starship preset` textual route, project scope, environment override, automatic migration,
+  remote/community preset download, preset composition, or TOML merge engine.
+- Remove **Customize footer**, **Restore built-in…**, or any established `settings`, `status`, and
+  `help` route.
+- Detect whether the terminal actually has a Nerd Font; requirements remain explicit text and preview
+  evidence.
+- Introduce a Basic/Advanced submenu or more than the one preset-list navigation level.
+
+## Assumptions
+
+- Unless revised before execution, the approved v1 catalog is Minimal, Bracketed, Nerd Font Symbols,
+  and Tokyo Night as specified above.
+- Presets are complete starting points. Expert preservation is provided by **Customize before
+  applying**, not by silently merging a preset into an existing document.
+
+## Risks
+
+- **Destructive replacement:** a preset could erase hand-written TOML or forward-compatible fields.
+  Mitigation: preview first, use explicit replacement copy, require confirmation, and retain existing
+  atomic rollback behavior.
+- **Misleading active state:** normalized configs may be equivalent while source documents differ.
+  Mitigation: claim `Currently applied` only for exact raw-document equality; otherwise show custom.
+- **Font failure:** private-use glyphs render as boxes without a Nerd Font. Mitigation: mark affected
+  rows and preview screens with `Requires Nerd Font`; keep two font-safe choices and non-color labels.
+- **Narrow-terminal overflow:** Powerline glyphs and long confirmation text can become unusable.
+  Mitigation: reuse adaptive preview and Kit wrapping, and test constrained widths/heights and resize.
+- **Lifecycle race:** session replacement or shutdown can occur while a preset preview, editor, or
+  confirmation is open. Mitigation: retain the command owner signal, dispose every custom component,
+  and revalidate ownership after each await before save/apply/UI continuation.
+- **Startup regression:** large bundled documents could enter the eager extension graph. Mitigation:
+  keep the catalog under the lazy command implementation and retain source-entry/import tests.
+- **Upstream resemblance and attribution:** themed documents may derive colors or ideas from Starship
+  presets. Mitigation: adapt to Pi semantics, describe them as inspired, and retain/update `NOTICES.md`
+  where source material is reused.
+
+## Rollback / Recovery
+
+- The on-disk schema and path remain unchanged. Reverting the feature leaves any applied preset as
+  ordinary valid `pi-starship.toml`, still editable through `/starship settings`.
+- **Restore built-in…** remains the deterministic recovery path for every preset.
+- Cancel, Back, Escape, Ctrl+C, disposal, replacement, validation failure, confirmation rejection, and
+  save failure leave the previous file and runtime unchanged.
+- Runtime-apply failure restores the previous file/effective config through the current identity-aware
+  rollback path; a concurrent newer file is preserved and reported instead of overwritten.
+
+## Plan
+
+- [x] Add focused red tests in `packages/pi-starship/test/config.test.ts` for the public preset catalog:
+      every stable ID is unique, every complete document validates without diagnostics, font
+      requirements are explicit, exact raw matching recognizes only unchanged preset documents, and
+      no preset reaches network or optional command-backed modules; verify the focused tests execute
+      and fail for missing preset behavior before implementation.
+- [x] Add `packages/pi-starship/src/presets/` catalog and four bounded document modules implementing the
+      approved module/layout contracts; verify the focused catalog/config tests pass and source files
+      remain below 1,000 lines.
+- [x] Add focused red menu tests in `packages/pi-starship/test/command-ux.test.ts` and
+      `packages/pi-starship/test/commands.test.ts` for the seventh **Presets** row, one-level four-item
+      list, descriptions and Nerd Font warnings, exact `Currently applied` disabled state, active
+      preset configuration presentation, Back/focus restoration, and no startup/file/runtime side
+      effects; verify they fail on the existing six-row menu for the intended reason.
+- [x] Extend the declarative `defineMenu` flow in `packages/pi-starship/src/commands.ts` with stable
+      catalog-driven preset actions and current-state presentation while preserving all existing menu
+      items and direct routes; verify the focused main/preset menu tests pass at 20, 40, and 80 columns.
+- [x] Add focused red interaction tests for selection preview, **Choose another preset**, preview
+      Escape, **Customize before applying**, editor cancellation, final confirmation copy, successful
+      first save, replacement of a custom/malformed document, and immediate runtime application;
+      assert every pre-confirmation exit performs zero saves and zero applies.
+- [x] Generalize the existing preview/apply workflow and connect preset selection to validation,
+      preview, optional editing, confirmation, atomic save, and immediate apply; verify the interaction
+      tests pass without duplicating persistence or rollback code.
+- [x] Add failure and lifecycle regressions covering preset validation/render failure, warning display,
+      write/rename failure, runtime-apply rollback, concurrent replacement, retry, external disposal,
+      session replacement, and shutdown after each await boundary; verify the previous valid file and
+      effective footer survive every unsuccessful path and no stale continuation publishes UI/state.
+- [x] Re-audit non-TUI and compatibility behavior so no new textual subcommand is accepted, RPC no-arg
+      help remains observable without opening custom TUI, print/JSON stay protocol-safe, existing
+      completions remain `settings|status|help`, and lazy source-entry behavior is unchanged; verify
+      existing route, lifecycle, and source-entry tests plus focused regressions pass.
+- [x] Update `packages/pi-starship/README.md` with the preset catalog, font prerequisites, exact
+      replacement/customize/recovery semantics, menu navigation, package layout, and Starship-inspired
+      wording; update `NOTICES.md` only if implementation reuses upstream preset material, and add a
+      minor Changeset for `@narumitw/pi-starship`; verify Biome and `npm run changeset:status` accept the
+      documentation and release intent.
+- [x] Run `npm run typecheck --workspace @narumitw/pi-starship`, the compiled pi-starship test set,
+      `npm run check`, `just pack starship`, and a local Pi TUI/RPC smoke that previews, cancels, applies,
+      and restores a preset from a temporary agent directory; record exact evidence and any unverified
+      platform/font path before completion.
+- [x] Audit the final diff against `docs/extension-conventions.md` and
+      `docs/extension-settings.md`, including command modes, width, cancellation, disposal, session
+      ownership, settings ordering/failure recovery, invalid-file protection, atomic publication,
+      documentation, and release gates; verify every applicable MUST has test/review/smoke evidence and
+      record any accepted deviation.
+
+## Completion Checklist
+
+- [x] `/starship` presents seven shallow, goal-oriented actions and a four-item preset screen with
+      visible current state, font requirements, Back, Escape, and Ctrl+C behavior.
+- [x] Minimal and Bracketed are font-safe; Nerd Font Symbols and Tokyo Night are clearly marked; all
+      four documents validate cleanly and render within supported widths without enabling undocumented
+      collectors or network work.
+- [x] Selecting a preset never mutates disk or runtime before preview and confirmation; users can apply,
+      customize first, choose another, or cancel without ambiguous side effects.
+- [x] Complete-document replacement is disclosed, confirmed, serialized, atomic, generation-safe, and
+      rollback-capable; malformed/current/concurrent documents follow the documented recovery rules.
+- [x] Built-in defaults, Restore, custom TOML, menu/direct command routes, non-TUI protocol behavior,
+      lazy command loading, lifecycle cleanup, and unknown-field behavior remain compatible and tested.
+- [x] README, attribution review, minor Changeset, focused tests, package typecheck, local TUI/RPC smoke,
+      `npm run check`, and `just pack starship` pass with recorded evidence.
+
+## Execution Evidence
+
+- Completed 2026-08-08 on `feat/pi-starship-presets` after rebasing onto `origin/main` at
+  `1156ee7`. The four preset documents validate without diagnostics and remain under the lazy command
+  import boundary.
+- TDD evidence: the catalog test first failed with an empty preset list, and the menu test first failed
+  on the existing six-row menu and `Custom configuration` state. Focused config, menu, interaction,
+  rendering, failure-recovery, and lifecycle tests then passed.
+- `npm run check --workspace @narumitw/pi-starship` passed. The compiled package test set passed before
+  the final root gate; `npm run check` passed with 2,542 tests after the final rebase and help-text
+  update.
+- `just pack starship` passed with 69 files, including all five `src/presets/` modules. Changeset status
+  reports the intended independent minor bump to `@narumitw/pi-starship` 0.50.0.
+- A real Pi 0.84.1 RPC smoke loaded only `packages/pi-starship/src/index.ts`, discovered `/starship`,
+  returned the updated `/starship help` notification, exited successfully, and left the temporary
+  agent directory without `pi-starship.toml`. TUI behavior was exercised through the local async Kit
+  harness at 20, 40, and 80 columns; an interactive real-terminal/Nerd Font visual smoke was not run
+  because repository execution policy forbids opening a TUI.
+- Semantic audit covered `docs/extension-conventions.md`, `docs/extension-settings.md`, and Pi's full
+  `extensions.md`, `tui.md`, `packages.md`, and `rpc.md`: direct routes/modes are preserved; preset
+  selection is TUI-only; cancellation, disposal, replacement, and shutdown are generation-safe;
+  complete-document replacement is previewed and confirmed; existing invalid-file, atomic publication,
+  concurrent-file preservation, runtime rollback, lazy loading, and missing-file semantics remain in
+  force. No accepted convention deviation remains; only real Nerd Font appearance is unverified.

--- a/packages/pi-starship/NOTICES.md
+++ b/packages/pi-starship/NOTICES.md
@@ -1,7 +1,8 @@
 # Notices
 
-pi-starship's format and style behavior is based in part on Starship. It uses the `yaml`
-package to parse kubeconfig and OpenStack metadata as inert local data.
+pi-starship's format, style behavior, bundled preset ideas, and Tokyo Night preset palette are based
+in part on Starship. It uses the `yaml` package to parse kubeconfig and OpenStack metadata as inert
+local data.
 
 ## yaml
 

--- a/packages/pi-starship/NOTICES.md
+++ b/packages/pi-starship/NOTICES.md
@@ -1,8 +1,9 @@
 # Notices
 
-pi-starship's format, style behavior, bundled preset ideas, and Tokyo Night preset palette are based
-in part on Starship. It uses the `yaml` package to parse kubeconfig and OpenStack metadata as inert
-local data.
+pi-starship's format, style behavior, and bundled preset color and layout treatments are based in
+part on the preset documents emitted by Starship 1.26.0. The preset modules and TOML are adapted to
+Pi's native runtime snapshots. pi-starship uses the `yaml` package to parse kubeconfig and OpenStack
+metadata as inert local data.
 
 ## yaml
 

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -17,8 +17,8 @@ A native Pi footer configured with Starship-style TOML. It parses and renders fo
 - Width-aware `$fill` alignment for native multiline left/right layouts.
 - Footer rendering is pure: no subprocess, network, filesystem, timer, or environment work runs from `render()`.
 - Multiline output wraps to the terminal width instead of truncating.
-- Goal-oriented `/starship` menu with footer explanation, searchable module inspection,
-  configuration health, transactional preview, and recovery.
+- Goal-oriented `/starship` menu with four bundled presets, footer explanation, searchable module
+  inspection, configuration health, transactional preview, and recovery.
 
 ## 📦 Install
 
@@ -64,9 +64,9 @@ on the next `session_start`, including `/reload` and session replacement. Editor
 cancellation, component disposal, invalid drafts, write failures, and runtime application failures
 preserve the previous file and effective footer.
 
-The shallow main menu also exposes **Explain footer**, **Modules**, **Configuration**, **Help**, and
-**Restore built-in…**. Explain footer uses the current immutable runtime snapshot to list each
-currently showing non-empty module once with its rendered value and description; it starts no new
+The shallow main menu also exposes **Presets**, **Explain footer**, **Modules**, **Configuration**,
+**Help**, and **Restore built-in…**. Explain footer uses the current immutable runtime snapshot to list
+each currently showing non-empty module once with its rendered value and description; it starts no new
 collection work. Modules opens a bounded searchable inspector for every registered module. Its
 textual states distinguish **Showing**, **Empty**, **Disabled**, **Not in format**, and
 **Unavailable** only when the current footer cannot provide an inspection snapshot. Module detail
@@ -75,11 +75,40 @@ variables, style fields, display rules, and the known reason for absent output. 
 read-only and never create or update the settings document.
 
 Configuration combines state, source, path, health, and diagnostics. A healthy missing file is shown
-as **Built-in defaults**, while **Built-in fallback** is reserved for read or parse errors. Restore is
-disabled when no settings document exists or the exact built-in document is already saved. For a
-custom or invalid document, Restore previews the result and warns that the complete document,
+as **Built-in defaults**, an exact bundled document is shown as its named preset, and **Built-in
+fallback** is reserved for read or parse errors. Restore is disabled when no settings document exists
+or the exact built-in document is already saved. For a custom or invalid document, Restore previews
+the result and warns that the complete document,
 including custom settings, unknown fields, and comments, will be replaced without a post-success
 backup before asking for confirmation.
+
+### 🎛️ Presets
+
+Choose **Presets** from `/starship` to browse four complete Pi-native starting points:
+
+| Preset | Layout | Font requirement |
+| --- | --- | --- |
+| **Minimal** | Model, directory, Git branch, and activity | Standard Unicode |
+| **Bracketed** | Balanced Pi and Git information in font-safe bracketed segments | Standard Unicode |
+| **Nerd Font Symbols** | The balanced default layout with icon-rich module symbols | Nerd Font |
+| **Tokyo Night** | One-line Tokyo Night palette with independent Powerline segments | Nerd Font |
+
+Selecting a preset opens the same adaptive live preview used by manual settings. From there, choose
+**Apply _name_ preset…**, **Customize before applying**, or **Choose another preset**. Customization
+starts the TOML editor with the complete preset document and previews the edited result before any
+save. Escape returns to the preset list, while Ctrl+C closes the complete workflow.
+
+Presets are complete documents, not overlays. Applying one replaces `pi-starship.toml`, including
+custom settings, unknown fields, and comments, only after a separate confirmation; no post-success
+backup is kept. Cancellation, disposal, validation failure, write failure, and runtime-apply failure
+retain the previous valid document and effective footer. Exact unedited matches are shown as
+**Currently applied** and cannot be redundantly selected; editing any byte makes the document custom
+again. **Restore built-in…** remains the deterministic recovery path.
+
+The bundled presets use only pi-starship's local Pi and Git snapshot modules. They do not enable the
+GitHub PR query, cloud/deployment readers, or optional command-backed workspace collectors. Their
+visual ideas are inspired by Starship presets but their TOML and module choices are specific to Pi.
+There is no `/starship preset` textual route and no remote preset download.
 
 ### 📝 Example
 
@@ -593,10 +622,11 @@ Package's explicitly documented Cargo lookup is the only ancestor walk and is ca
 | `/starship status` | Show config source/path and diagnostics |
 | `/starship help` | Show command and configuration help |
 
-The standard main menu keeps six goals on one level: **Customize footer**, **Explain footer**,
-**Modules**, **Configuration**, **Help**, and **Restore built-in…**. It shows whether the footer uses
-built-in defaults, a saved built-in document, a custom document, or an error-driven fallback,
-together with the current health. Explain and Modules are menu-only read paths; they do not add
+The standard main menu keeps seven goals on one level: **Customize footer**, **Presets**,
+**Explain footer**, **Modules**, **Configuration**, **Help**, and **Restore built-in…**. It shows whether
+the footer uses built-in defaults, a saved built-in document, a named preset, a custom document, or an
+error-driven fallback,
+together with the current health. Presets, Explain, and Modules are menu-only paths; they do not add
 textual subcommands or change RPC, print, or JSON protocols. Restore remains last and unavailable
 when there is no document to replace.
 
@@ -635,6 +665,7 @@ Keep `extension_status` last in the catalog so arbitrary third-party statuses fo
 - `src/usage.ts` — native-aligned session usage and cache aggregation.
 - `src/command-contract.ts` — lightweight command routes and completions loaded at startup.
 - `src/commands.ts` — lazily loaded menu, preview/confirmation flow, diagnostics, and compatibility routes.
+- `src/presets/` — bundled complete TOML documents and stable preset metadata.
 - `src/command-inspector.ts` — adaptive Explain and searchable read-only module inspection surfaces.
 - `src/command-preview.ts` — adaptive, scrollable, keybinding-aware preview action surface.
 - `src/config.ts` — TOML loading, draft validation, defaults, atomic persistence, and rollback.

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -17,8 +17,9 @@ A native Pi footer configured with Starship-style TOML. It parses and renders fo
 - Width-aware `$fill` alignment for native multiline left/right layouts.
 - Footer rendering is pure: no subprocess, network, filesystem, timer, or environment work runs from `render()`.
 - Multiline output wraps to the terminal width instead of truncating.
-- Goal-oriented `/starship` menu with four bundled presets, footer explanation, searchable module
-  inspection, configuration health, transactional preview, and recovery.
+- Goal-oriented `/starship` menu with every Starship 1.26 preset style plus a Pi-native Minimal
+  preset, footer explanation, searchable module inspection, configuration health, transactional
+  preview, and recovery.
 
 ## 📦 Install
 
@@ -84,14 +85,26 @@ backup before asking for confirmation.
 
 ### 🎛️ Presets
 
-Choose **Presets** from `/starship` to browse four complete Pi-native starting points:
+Choose **Presets** from `/starship` to browse complete Pi-native starting points. The catalog adapts
+all styles listed by `starship preset --list` in Starship 1.26.0, plus a Pi-specific Minimal option.
+Colors, separators, typography, and layout follow the named Starship preset; modules are deliberately
+selected for Pi's model, thinking, workspace, Git, activity, context, and time snapshots.
 
-| Preset | Layout | Font requirement |
+| Preset | Adapted visual treatment | Font requirement |
 | --- | --- | --- |
-| **Minimal** | Model, directory, Git branch, and activity | Standard Unicode |
-| **Bracketed** | Balanced Pi and Git information in font-safe bracketed segments | Standard Unicode |
-| **Nerd Font Symbols** | The balanced default layout with icon-rich module symbols | Nerd Font |
-| **Tokyo Night** | One-line Tokyo Night palette with independent Powerline segments | Nerd Font |
+| **Minimal** | Compact Pi essentials | Standard Unicode |
+| **Bracketed Segments** | Balanced Pi and Git information in brackets | Standard Unicode |
+| **Catppuccin Powerline** | Connected Catppuccin Mocha blocks; other Catppuccin palettes remain in the document for customization | Nerd Font |
+| **Gruvbox Rainbow** | Warm Gruvbox connected segments | Nerd Font |
+| **Jetpack** | Airy geometric activity/context and workspace columns joined by fill | Standard Unicode |
+| **Nerd Font Symbols** | Balanced default layout with icon-rich symbols | Nerd Font |
+| **No Empty Icons** | Conditional text labels that cannot appear without their values | Standard Unicode |
+| **No Nerd Font** | Portable Unicode symbols without private-use glyphs | Standard Unicode |
+| **No Runtime Versions** | Presence indicators without model or thinking details | Standard Unicode |
+| **Pastel Powerline** | Connected magenta, coral, orange, blue, teal, and navy blocks | Nerd Font |
+| **Plain Text Symbols** | Plain words replace pictograms | Standard Unicode |
+| **Pure Preset** | Clean two-line workspace and session context | Standard Unicode |
+| **Tokyo Night** | Connected cool blue Tokyo Night blocks | Nerd Font |
 
 Selecting a preset opens the same adaptive live preview used by manual settings. From there, choose
 **Apply _name_ preset…**, **Customize before applying**, or **Choose another preset**. Customization
@@ -106,9 +119,10 @@ retain the previous valid document and effective footer. Exact unedited matches 
 again. **Restore built-in…** remains the deterministic recovery path.
 
 The bundled presets use only pi-starship's local Pi and Git snapshot modules. They do not enable the
-GitHub PR query, cloud/deployment readers, or optional command-backed workspace collectors. Their
-visual ideas are inspired by Starship presets but their TOML and module choices are specific to Pi.
-There is no `/starship preset` textual route and no remote preset download.
+GitHub PR query, cloud/deployment readers, or optional command-backed workspace collectors. They are
+Pi-native adaptations of the color and format treatments emitted by Starship 1.26.0; they do not copy
+Starship's module selections because Pi exposes different runtime information. There is no
+`/starship preset` textual route and no remote preset download.
 
 ### 📝 Example
 

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -106,17 +106,19 @@ selected for Pi's model, thinking, workspace, Git, activity, context, and time s
 | **Pure Preset** | Clean two-line workspace and session context | Standard Unicode |
 | **Tokyo Night** | Connected cool blue Tokyo Night blocks | Nerd Font |
 
-Selecting a preset opens the same adaptive live preview used by manual settings. From there, choose
-**Apply _name_ preset…**, **Customize before applying**, or **Choose another preset**. Customization
-starts the TOML editor with the complete preset document and previews the edited result before any
-save. Escape returns to the preset list, while Ctrl+C closes the complete workflow.
+The preset cursor is a live footer preview. Opening the picker and moving with Up/Down, Page Up/Down,
+Home, or End temporarily renders the selected preset in the actual footer without writing settings or
+starting new collectors. Press Enter to start the named preset's replacement confirmation, or press
+`e` to customize the selected complete TOML document before its normal editor preview and
+confirmation. Escape returns to the main menu, while Ctrl+C closes the complete workflow; both restore
+the previously effective footer.
 
 Presets are complete documents, not overlays. Applying one replaces `pi-starship.toml`, including
 custom settings, unknown fields, and comments, only after a separate confirmation; no post-success
-backup is kept. Cancellation, disposal, validation failure, write failure, and runtime-apply failure
-retain the previous valid document and effective footer. Exact unedited matches are shown as
-**Currently applied** and cannot be redundantly selected; editing any byte makes the document custom
-again. **Restore built-in…** remains the deterministic recovery path.
+backup is kept. Cursor movement, confirmation cancellation, disposal, validation failure, write
+failure, and runtime-apply failure retain the previous valid document and effective footer. Exact
+unedited matches are shown as **Currently applied** and cannot be redundantly selected; editing any
+byte makes the document custom again. **Restore built-in…** remains the deterministic recovery path.
 
 The bundled presets use only pi-starship's local Pi and Git snapshot modules. They do not enable the
 GitHub PR query, cloud/deployment readers, or optional command-backed workspace collectors. They are
@@ -679,6 +681,7 @@ Keep `extension_status` last in the catalog so arbitrary third-party statuses fo
 - `src/usage.ts` — native-aligned session usage and cache aggregation.
 - `src/command-contract.ts` — lightweight command routes and completions loaded at startup.
 - `src/commands.ts` — lazily loaded menu, preview/confirmation flow, diagnostics, and compatibility routes.
+- `src/command-preset-picker.ts` — lifecycle-owned preset cursor and temporary footer-preview UI.
 - `src/presets/` — bundled complete TOML documents and stable preset metadata.
 - `src/command-inspector.ts` — adaptive Explain and searchable read-only module inspection surfaces.
 - `src/command-preview.ts` — adaptive, scrollable, keybinding-aware preview action surface.

--- a/packages/pi-starship/src/command-preset-picker.ts
+++ b/packages/pi-starship/src/command-preset-picker.ts
@@ -1,0 +1,203 @@
+import { stripVTControlCharacters } from "node:util";
+import {
+	DynamicBorder,
+	type ExtensionCommandContext,
+	type KeybindingsManager,
+} from "@earendil-works/pi-coding-agent";
+import {
+	Container,
+	Key,
+	matchesKey,
+	type SelectItem,
+	SelectList,
+	Text,
+} from "@earendil-works/pi-tui";
+import { runCustomInteraction } from "@narumitw/pi-tui-kit";
+import type { StarshipPreset } from "./presets/catalog.js";
+
+export type PresetPickerResult =
+	| { kind: "apply"; presetId: StarshipPreset["id"] }
+	| { kind: "customize"; presetId: StarshipPreset["id"] }
+	| { kind: "back" }
+	| { kind: "close" };
+
+export interface PresetPickerOptions {
+	presets: readonly StarshipPreset[];
+	activePresetId?: StarshipPreset["id"];
+	initialPresetId?: StarshipPreset["id"];
+	signal: AbortSignal;
+	isCurrent(): boolean;
+	preview(preset: StarshipPreset): void;
+}
+
+export async function showPresetPicker(
+	ctx: ExtensionCommandContext,
+	options: PresetPickerOptions,
+): Promise<PresetPickerResult> {
+	const items: SelectItem[] = options.presets.map((preset) => ({
+		value: preset.id,
+		label: `${preset.id === options.activePresetId ? "[-] " : ""}${preset.label}`,
+		description:
+			preset.id === options.activePresetId
+				? `Currently applied · ${preset.description}`
+				: preset.description,
+	}));
+	const initialIndex = Math.max(
+		0,
+		options.presets.findIndex(
+			(preset) => preset.id === (options.initialPresetId ?? options.activePresetId),
+		),
+	);
+	const result = await runCustomInteraction<PresetPickerResult>(ctx, {
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+		create({ tui, theme, keybindings, complete }) {
+			const container = new Container();
+			const topBorder = new DynamicBorder((text: string) => theme.fg("accent", text));
+			const bottomBorder = new DynamicBorder((text: string) => theme.fg("accent", text));
+			const title = new Text("", 1, 0);
+			const detail = new Text("", 1, 0);
+			const hint = new Text("", 1, 0);
+			const viewportSize = Math.min(items.length, 10);
+			const list = new SelectList(items, viewportSize, {
+				selectedPrefix: (text) => theme.fg("accent", text),
+				selectedText: (text) => theme.fg("accent", text),
+				description: (text) => theme.fg("muted", text),
+				scrollInfo: (text) => theme.fg("dim", text),
+				noMatch: (text) => theme.fg("warning", text),
+			});
+			const selectedPreset = () => {
+				const id = list.getSelectedItem()?.value;
+				return options.presets.find((preset) => preset.id === id);
+			};
+			const updateSelectedText = () => {
+				const preset = selectedPreset();
+				if (!preset) return;
+				detail.setText(
+					theme.fg(
+						"muted",
+						`Selected: ${preset.label} · ${preset.requiresNerdFont ? "requires Nerd Font" : "font-safe"}`,
+					),
+				);
+			};
+			const previewSelected = () => {
+				const preset = selectedPreset();
+				if (!preset) return;
+				updateSelectedText();
+				options.preview(preset);
+			};
+			const updateThemedText = () => {
+				const current =
+					options.presets.find((preset) => preset.id === options.activePresetId)?.label ??
+					"Custom configuration";
+				title.setText(theme.fg("accent", theme.bold(`Presets · current: ${current}`)));
+				hint.setText(theme.fg("dim", pickerHint(keybindings)));
+			};
+
+			let selectedIndex = initialIndex;
+			const select = (index: number) => {
+				if (items.length === 0) return;
+				selectedIndex = Math.max(0, Math.min(index, items.length - 1));
+				list.setSelectedIndex(selectedIndex);
+				previewSelected();
+			};
+			const move = (delta: number) => {
+				if (items.length === 0) return;
+				select((selectedIndex + delta + items.length) % items.length);
+			};
+			const applySelected = () => {
+				const preset = selectedPreset();
+				if (preset && preset.id !== options.activePresetId) {
+					complete({ kind: "apply", presetId: preset.id });
+				}
+			};
+			list.setSelectedIndex(initialIndex);
+			container.addChild(topBorder);
+			container.addChild(title);
+			container.addChild(list);
+			container.addChild(detail);
+			container.addChild(hint);
+			container.addChild(bottomBorder);
+			updateThemedText();
+			previewSelected();
+
+			return {
+				render: (width: number) => container.render(width),
+				invalidate() {
+					container.invalidate();
+					updateThemedText();
+					updateSelectedText();
+				},
+				handleInput(data: string) {
+					if (matchesKey(data, Key.ctrl("c"))) {
+						complete({ kind: "close" });
+					} else if (keybindings.matches(data, "tui.select.cancel")) {
+						complete({ kind: "back" });
+					} else if (keybindings.matches(data, "tui.select.up")) {
+						move(-1);
+					} else if (keybindings.matches(data, "tui.select.down")) {
+						move(1);
+					} else if (keybindings.matches(data, "tui.select.pageUp")) {
+						select(selectedIndex - Math.max(1, viewportSize));
+					} else if (keybindings.matches(data, "tui.select.pageDown")) {
+						select(selectedIndex + Math.max(1, viewportSize));
+					} else if (matchesKey(data, Key.home)) {
+						select(0);
+					} else if (matchesKey(data, Key.end)) {
+						select(items.length - 1);
+					} else if (data === "e" || data === "E") {
+						const preset = selectedPreset();
+						if (preset) complete({ kind: "customize", presetId: preset.id });
+					} else if (keybindings.matches(data, "tui.select.confirm")) {
+						applySelected();
+					}
+					tui.requestRender();
+				},
+			};
+		},
+	});
+	return result.kind === "completed" ? result.value : { kind: "close" };
+}
+
+function pickerHint(keybindings: Pick<KeybindingsManager, "getKeys">): string {
+	const up = bindingText(keybindings, "tui.select.up");
+	const down = bindingText(keybindings, "tui.select.down");
+	const confirm = bindingText(keybindings, "tui.select.confirm");
+	const cancel = bindingText(keybindings, "tui.select.cancel", "ctrl+c");
+	const pageUp = bindingText(keybindings, "tui.select.pageUp");
+	const pageDown = bindingText(keybindings, "tui.select.pageDown");
+	return [
+		...(up || down ? [`${[up, down].filter(Boolean).join("/")} live preview`] : []),
+		...(confirm ? [`${confirm} apply`] : []),
+		"e customize",
+		...(cancel ? [`${cancel} back`] : []),
+		"ctrl+c close",
+		...(pageUp || pageDown ? [`${[pageUp, pageDown].filter(Boolean).join("/")} page preview`] : []),
+	].join(" • ");
+}
+
+function bindingText(
+	keybindings: Pick<KeybindingsManager, "getKeys">,
+	binding: Parameters<KeybindingsManager["getKeys"]>[0],
+	excluded?: string,
+): string {
+	return keybindings
+		.getKeys(binding)
+		.filter((key) => key !== excluded)
+		.map((key) => {
+			if (key === "up") return "↑";
+			if (key === "down") return "↓";
+			if (key === "escape") return "esc";
+			if (key === "return") return "enter";
+			return safeDisplayText(key);
+		})
+		.join("/");
+}
+
+function safeDisplayText(value: string): string {
+	return Array.from(stripVTControlCharacters(value), (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		const control = codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+		return control ? "" : character;
+	}).join("");
+}

--- a/packages/pi-starship/src/commands.ts
+++ b/packages/pi-starship/src/commands.ts
@@ -12,9 +12,16 @@ import {
 	validateConfigDocument,
 } from "./config.js";
 import { inspectUnavailableModules, type StatuslineInspection } from "./modules/inspection.js";
+import {
+	getStarshipPreset,
+	presetForDocument,
+	STARSHIP_PRESETS,
+	type StarshipPreset,
+} from "./presets/catalog.js";
 
 const MAIN_ACTIONS = {
 	customize: "customize",
+	presets: "presets",
 	explain: "explain",
 	modules: "modules",
 	configuration: "configuration",
@@ -48,6 +55,11 @@ interface WorkflowOwner {
 	signal: AbortSignal;
 	isCurrent(): boolean;
 }
+
+type ReviewIntent =
+	| { kind: "customize" }
+	| { kind: "restore" }
+	| { kind: "preset"; preset: StarshipPreset };
 
 export function registerStarshipCommand(pi: ExtensionAPI, options: StarshipCommandOptions) {
 	pi.registerCommand("starship", {
@@ -100,8 +112,14 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 		signal: fallbackController.signal,
 		isCurrent: () => !fallbackController.signal.aborted,
 	};
-	type Screen = "main" | "modules" | "configuration" | "help";
-	type Action = "customize" | "explain" | "restore";
+	type Screen = "main" | "presets" | "modules" | "configuration" | "help";
+	type Action = "customize" | "explain" | "restore" | StarshipPreset["id"];
+	const runPresetAction = async (preset: StarshipPreset) => {
+		const result = await applyPreset(ctx, options, preset);
+		return result === "applied" || result === "close"
+			? { kind: "close" as const }
+			: { kind: "stay" as const };
+	};
 	const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
 		start: "main",
 		screens: {
@@ -118,6 +136,12 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 							label: "Customize footer",
 							description: `${presentation.state} · preview before applying`,
 							action: "customize",
+						},
+						{
+							id: MAIN_ACTIONS.presets,
+							label: "Presets",
+							description: "Browse bundled footer starting points",
+							to: "presets",
 						},
 						{
 							id: MAIN_ACTIONS.explain,
@@ -152,6 +176,25 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 						},
 					],
 					hint: "close",
+				};
+			},
+			presets: () => {
+				const active = presetForDocument(options.getLoaded().rawDocument);
+				return {
+					kind: "actions",
+					title: "Presets",
+					lines: ["Choose a complete footer starting point to preview."],
+					items: STARSHIP_PRESETS.map((preset) => ({
+						id: preset.id,
+						label: preset.label,
+						description:
+							active?.id === preset.id
+								? `Currently applied · ${preset.description}`
+								: preset.description,
+						disabled: active?.id === preset.id,
+						action: preset.id,
+					})),
+					hint: "back",
 				};
 			},
 			modules: () => {
@@ -202,6 +245,7 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 				title: "pi-starship help",
 				lines: [
 					"Customize footer opens the TOML editor, then previews and confirms before saving.",
+					"Presets previews complete bundled starting points before replacing the settings document.",
 					"Explain footer breaks down the modules currently showing from the existing snapshot.",
 					"Modules searches every supported module and explains its current read-only state.",
 					"Configuration explains state, source, path, and warnings without changing the footer.",
@@ -221,6 +265,10 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 				if (!isCurrentOwner(owner)) return { kind: "stay" };
 				return result?.kind === "back" ? { kind: "stay" } : { kind: "close" };
 			},
+			minimal: async () => runPresetAction(getStarshipPreset("minimal")),
+			bracketed: async () => runPresetAction(getStarshipPreset("bracketed")),
+			"nerd-font-symbols": async () => runPresetAction(getStarshipPreset("nerd-font-symbols")),
+			"tokyo-night": async () => runPresetAction(getStarshipPreset("tokyo-night")),
 			restore: async () => {
 				const presentation = configurationPresentation(options.getLoaded());
 				if (presentation.restoreDisabled) {
@@ -279,9 +327,50 @@ async function editSettings(
 			return "cancel";
 		}
 
-		const result = await reviewAndApply(ctx, options, validated, "Footer preview", false, owner);
+		const result = await reviewAndApply(ctx, options, validated, { kind: "customize" }, owner);
 		if (result === "edit") continue;
 		return result;
+	}
+}
+
+async function applyPreset(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+	preset: StarshipPreset,
+): Promise<"applied" | "cancel" | "close"> {
+	const owner = workflowOwner(options);
+	if (!isCurrentOwner(owner)) return "cancel";
+	let draft = preset.rawDocument;
+	while (true) {
+		let validated: LoadedStarshipConfig;
+		try {
+			validated = (options.validate ?? validateConfigDocument)(options.settingsPath, draft);
+		} catch (error) {
+			ctx.ui.notify(`Preset draft is invalid: ${safeText(formatError(error))}`, "error");
+			const action = await showPreviewActionMenu(
+				ctx,
+				"Preset needs attention",
+				() => [safeText(formatError(error)), "The current footer has not changed."],
+				[
+					{ value: PREVIEW_ACTIONS.edit, label: "Continue editing" },
+					{ value: PREVIEW_ACTIONS.cancel, label: "Choose another preset" },
+				],
+				owner.signal,
+			);
+			if (!isCurrentOwner(owner)) return "cancel";
+			if (action?.kind === "closed") return "close";
+			if (selectedPreviewAction(action) !== PREVIEW_ACTIONS.edit) return "cancel";
+			const edited = await ctx.ui.editor(`Customize ${preset.label} preset`, draft);
+			if (!isCurrentOwner(owner) || edited === undefined) return "cancel";
+			draft = edited;
+			continue;
+		}
+
+		const result = await reviewAndApply(ctx, options, validated, { kind: "preset", preset }, owner);
+		if (result !== "edit") return result;
+		const edited = await ctx.ui.editor(`Customize ${preset.label} preset`, draft);
+		if (!isCurrentOwner(owner) || edited === undefined) return "cancel";
+		draft = edited;
 	}
 }
 
@@ -295,7 +384,7 @@ async function restoreBuiltIn(
 		options.settingsPath,
 		BUILT_IN_EXAMPLE,
 	);
-	const result = await reviewAndApply(ctx, options, validated, "Restore preview", true, owner);
+	const result = await reviewAndApply(ctx, options, validated, { kind: "restore" }, owner);
 	return result === "edit" ? "cancel" : result;
 }
 
@@ -303,27 +392,32 @@ async function reviewAndApply(
 	ctx: ExtensionCommandContext,
 	options: StarshipCommandOptions,
 	validated: LoadedStarshipConfig,
-	title: string,
-	restore: boolean,
+	intent: ReviewIntent,
 	owner: WorkflowOwner,
 ): Promise<"applied" | "edit" | "cancel" | "close"> {
 	while (true) {
 		const selection = await showPreviewActionMenu(
 			ctx,
-			title,
-			(width) =>
-				restore
-					? restorePreviewBody(ctx, options, validated, width)
-					: previewBody(ctx, options, validated, width),
+			reviewTitle(intent),
+			(width) => reviewPreviewBody(ctx, options, validated, width, intent),
 			[
-				{
-					value: PREVIEW_ACTIONS.continue,
-					label: restore ? "Replace with built-in…" : "Apply changes…",
-				},
-				...(restore ? [] : [{ value: PREVIEW_ACTIONS.edit, label: "Continue editing" }]),
+				{ value: PREVIEW_ACTIONS.continue, label: continueLabel(intent) },
+				...(intent.kind === "restore"
+					? []
+					: [
+							{
+								value: PREVIEW_ACTIONS.edit,
+								label: intent.kind === "preset" ? "Customize before applying" : "Continue editing",
+							},
+						]),
 				{
 					value: PREVIEW_ACTIONS.cancel,
-					label: restore ? "Cancel" : "Discard draft",
+					label:
+						intent.kind === "restore"
+							? "Cancel"
+							: intent.kind === "preset"
+								? "Choose another preset"
+								: "Discard draft",
 				},
 			],
 			owner.signal,
@@ -335,10 +429,8 @@ async function reviewAndApply(
 		if (selected !== PREVIEW_ACTIONS.continue) return "cancel";
 
 		const confirmed = await ctx.ui.confirm(
-			restore ? "Restore built-in footer?" : "Apply footer changes?",
-			restore
-				? `Replace ${safeText(options.settingsPath)} entirely with the built-in configuration? All custom settings, unknown fields, and comments will be removed. No backup is kept after success.`
-				: "Save this configuration and apply it immediately?",
+			confirmationTitle(intent),
+			confirmationMessage(options.settingsPath, intent),
 		);
 		if (!isCurrentOwner(owner)) return "cancel";
 		if (!confirmed) continue;
@@ -373,13 +465,59 @@ async function reviewAndApply(
 			saved.diagnostics.length > 0
 				? ` (${saved.diagnostics.length} warning${saved.diagnostics.length === 1 ? "" : "s"})`
 				: "";
-		ctx.ui.notify(
-			restore
-				? `Built-in footer restored and applied${warningSuffix}.`
-				: `Footer settings saved and applied${warningSuffix}.`,
-			"info",
-		);
+		ctx.ui.notify(`${successMessage(intent)}${warningSuffix}.`, "info");
 		return "applied";
+	}
+}
+
+function reviewTitle(intent: ReviewIntent): string {
+	switch (intent.kind) {
+		case "customize":
+			return "Footer preview";
+		case "restore":
+			return "Restore preview";
+		case "preset":
+			return `${intent.preset.label} preset preview`;
+	}
+}
+
+function continueLabel(intent: ReviewIntent): string {
+	switch (intent.kind) {
+		case "customize":
+			return "Apply changes…";
+		case "restore":
+			return "Replace with built-in…";
+		case "preset":
+			return `Apply ${intent.preset.label} preset…`;
+	}
+}
+
+function confirmationTitle(intent: ReviewIntent): string {
+	switch (intent.kind) {
+		case "customize":
+			return "Apply footer changes?";
+		case "restore":
+			return "Restore built-in footer?";
+		case "preset":
+			return `Apply ${intent.preset.label} preset?`;
+	}
+}
+
+function confirmationMessage(settingsPath: string, intent: ReviewIntent): string {
+	if (intent.kind === "customize") return "Save this configuration and apply it immediately?";
+	const replacement =
+		intent.kind === "restore" ? "the built-in configuration" : `the ${intent.preset.label} preset`;
+	return `Replace ${safeText(settingsPath)} entirely with ${replacement}? All custom settings, unknown fields, and comments will be removed. No backup is kept after success.`;
+}
+
+function successMessage(intent: ReviewIntent): string {
+	switch (intent.kind) {
+		case "customize":
+			return "Footer settings saved and applied";
+		case "restore":
+			return "Built-in footer restored and applied";
+		case "preset":
+			return `${intent.preset.label} preset saved and applied`;
 	}
 }
 
@@ -417,6 +555,28 @@ function restorePreviousConfiguration(
 	} catch (error) {
 		return error;
 	}
+}
+
+function reviewPreviewBody(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+	loaded: LoadedStarshipConfig,
+	width: number,
+	intent: ReviewIntent,
+): string[] {
+	if (intent.kind === "restore") return restorePreviewBody(ctx, options, loaded, width);
+	if (intent.kind === "customize") return previewBody(ctx, options, loaded, width);
+	const current = configurationPresentation(options.getLoaded());
+	return [
+		`Preset: ${intent.preset.label}`,
+		`Requirement: ${intent.preset.requiresNerdFont ? "Nerd Font" : "No special font"}`,
+		`Current: ${current.state}`,
+		`Path: ${safeText(options.settingsPath)}`,
+		"Applying replaces the entire settings document, including custom settings, unknown fields, and comments.",
+		"No backup is kept after a successful apply.",
+		"",
+		...previewBody(ctx, options, loaded, width),
+	];
 }
 
 function restorePreviewBody(
@@ -490,20 +650,25 @@ function configurationPresentation(loaded: LoadedStarshipConfig): ConfigurationP
 		loaded.rawDocument === undefined &&
 		loaded.diagnostics.length === 0;
 	const savedBuiltIn = loaded.source === "user" && loaded.rawDocument === BUILT_IN_EXAMPLE;
+	const activePreset = presetForDocument(loaded.rawDocument);
 	const fallback = loaded.source === "built-in" && loaded.diagnostics.length > 0;
 	return {
 		state: healthyMissing
 			? "Built-in defaults"
 			: savedBuiltIn
 				? "Saved built-in configuration"
-				: fallback
-					? "Built-in fallback"
-					: "Custom configuration",
+				: activePreset
+					? `${activePreset.label} preset`
+					: fallback
+						? "Built-in fallback"
+						: "Custom configuration",
 		source: healthyMissing
 			? "No settings file"
-			: loaded.source === "user"
-				? "User file"
-				: "Built-in fallback",
+			: activePreset
+				? "Bundled preset"
+				: loaded.source === "user"
+					? "User file"
+					: "Built-in fallback",
 		health: configurationHealth(loaded),
 		restoreDisabled: healthyMissing || savedBuiltIn,
 		restoreDescription: healthyMissing
@@ -544,7 +709,7 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 	if (!canNotify(ctx)) return;
 	ctx.ui.notify(
 		[
-			"/starship — customize, explain, or inspect the footer in TUI mode",
+			"/starship — customize, choose presets, explain, or inspect the footer in TUI mode",
 			"/starship settings — customize, preview, and apply TOML",
 			"/starship status — show source, path, and warnings",
 			"/starship help — show this help",

--- a/packages/pi-starship/src/commands.ts
+++ b/packages/pi-starship/src/commands.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-c
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import { completeStarshipArguments, STARSHIP_SUBCOMMANDS } from "./command-contract.js";
 import { showFooterExplanation } from "./command-inspector.js";
+import { showPresetPicker } from "./command-preset-picker.js";
 import { type PreviewMenuResult, showPreviewActionMenu } from "./command-preview.js";
 import {
 	atomicRestoreConfigDocument,
@@ -39,6 +40,7 @@ export interface StarshipCommandOptions {
 	getLoaded(): LoadedStarshipConfig;
 	getInspection?(): StatuslineInspection | undefined;
 	apply(loaded: LoadedStarshipConfig, ctx: ExtensionCommandContext): void;
+	preview?(loaded: LoadedStarshipConfig | undefined, ctx: ExtensionCommandContext): void;
 	settingsPath: string;
 	renderPreview?(
 		loaded: LoadedStarshipConfig,
@@ -112,14 +114,8 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 		signal: fallbackController.signal,
 		isCurrent: () => !fallbackController.signal.aborted,
 	};
-	type Screen = "main" | "presets" | "modules" | "configuration" | "help";
-	type Action = "customize" | "explain" | "restore" | StarshipPreset["id"];
-	const runPresetAction = async (preset: StarshipPreset) => {
-		const result = await applyPreset(ctx, options, preset);
-		return result === "applied" || result === "close"
-			? { kind: "close" as const }
-			: { kind: "stay" as const };
-	};
+	type Screen = "main" | "modules" | "configuration" | "help";
+	type Action = "customize" | "presets" | "explain" | "restore";
 	const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
 		start: "main",
 		screens: {
@@ -140,8 +136,8 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 						{
 							id: MAIN_ACTIONS.presets,
 							label: "Presets",
-							description: "Browse bundled footer starting points",
-							to: "presets",
+							description: "Browse and live-preview bundled footer starting points",
+							action: "presets",
 						},
 						{
 							id: MAIN_ACTIONS.explain,
@@ -176,25 +172,6 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 						},
 					],
 					hint: "close",
-				};
-			},
-			presets: () => {
-				const active = presetForDocument(options.getLoaded().rawDocument);
-				return {
-					kind: "actions",
-					title: "Presets",
-					lines: ["Choose a complete footer starting point to preview."],
-					items: STARSHIP_PRESETS.map((preset) => ({
-						id: preset.id,
-						label: preset.label,
-						description:
-							active?.id === preset.id
-								? `Currently applied · ${preset.description}`
-								: preset.description,
-						disabled: active?.id === preset.id,
-						action: preset.id,
-					})),
-					hint: "back",
 				};
 			},
 			modules: () => {
@@ -245,7 +222,7 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 				title: "pi-starship help",
 				lines: [
 					"Customize footer opens the TOML editor, then previews and confirms before saving.",
-					"Presets previews complete bundled starting points before replacing the settings document.",
+					"Presets live-previews the cursor in the footer; Enter confirms apply and e customizes first.",
 					"Explain footer breaks down the modules currently showing from the existing snapshot.",
 					"Modules searches every supported module and explains its current read-only state.",
 					"Configuration explains state, source, path, and warnings without changing the footer.",
@@ -265,20 +242,10 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 				if (!isCurrentOwner(owner)) return { kind: "stay" };
 				return result?.kind === "back" ? { kind: "stay" } : { kind: "close" };
 			},
-			minimal: async () => runPresetAction(getStarshipPreset("minimal")),
-			"bracketed-segments": async () => runPresetAction(getStarshipPreset("bracketed-segments")),
-			"catppuccin-powerline": async () =>
-				runPresetAction(getStarshipPreset("catppuccin-powerline")),
-			"gruvbox-rainbow": async () => runPresetAction(getStarshipPreset("gruvbox-rainbow")),
-			jetpack: async () => runPresetAction(getStarshipPreset("jetpack")),
-			"nerd-font-symbols": async () => runPresetAction(getStarshipPreset("nerd-font-symbols")),
-			"no-empty-icons": async () => runPresetAction(getStarshipPreset("no-empty-icons")),
-			"no-nerd-font": async () => runPresetAction(getStarshipPreset("no-nerd-font")),
-			"no-runtime-versions": async () => runPresetAction(getStarshipPreset("no-runtime-versions")),
-			"pastel-powerline": async () => runPresetAction(getStarshipPreset("pastel-powerline")),
-			"plain-text-symbols": async () => runPresetAction(getStarshipPreset("plain-text-symbols")),
-			"pure-preset": async () => runPresetAction(getStarshipPreset("pure-preset")),
-			"tokyo-night": async () => runPresetAction(getStarshipPreset("tokyo-night")),
+			presets: async () => {
+				const result = await choosePreset(ctx, options, owner);
+				return result === "applied" || result === "close" ? { kind: "close" } : { kind: "stay" };
+			},
 			restore: async () => {
 				const presentation = configurationPresentation(options.getLoaded());
 				if (presentation.restoreDisabled) {
@@ -343,14 +310,62 @@ async function editSettings(
 	}
 }
 
+async function choosePreset(
+	ctx: ExtensionCommandContext,
+	options: StarshipCommandOptions,
+	owner: WorkflowOwner,
+): Promise<"applied" | "cancel" | "close"> {
+	const activePreset = presetForDocument(options.getLoaded().rawDocument);
+	const selection = await showPresetPicker(ctx, {
+		presets: STARSHIP_PRESETS,
+		activePresetId: activePreset?.id,
+		initialPresetId: activePreset?.id ?? STARSHIP_PRESETS[0]?.id,
+		signal: owner.signal,
+		isCurrent: owner.isCurrent,
+		preview(preset) {
+			const loaded = (options.validate ?? validateConfigDocument)(
+				options.settingsPath,
+				preset.rawDocument,
+			);
+			options.preview?.(loaded, ctx);
+		},
+	});
+	if (!isCurrentOwner(owner)) {
+		options.preview?.(undefined, ctx);
+		return "cancel";
+	}
+	if (selection.kind === "back" || selection.kind === "close") {
+		options.preview?.(undefined, ctx);
+		return selection.kind === "close" ? "close" : "cancel";
+	}
+
+	const preset = getStarshipPreset(selection.presetId);
+	try {
+		return await applyPreset(
+			ctx,
+			options,
+			preset,
+			selection.kind === "customize" ? "customize" : "confirm",
+		);
+	} finally {
+		options.preview?.(undefined, ctx);
+	}
+}
+
 async function applyPreset(
 	ctx: ExtensionCommandContext,
 	options: StarshipCommandOptions,
 	preset: StarshipPreset,
+	start: "review" | "confirm" | "customize" = "review",
 ): Promise<"applied" | "cancel" | "close"> {
 	const owner = workflowOwner(options);
 	if (!isCurrentOwner(owner)) return "cancel";
 	let draft = preset.rawDocument;
+	if (start === "customize") {
+		const edited = await ctx.ui.editor(`Customize ${preset.label} preset`, draft);
+		if (!isCurrentOwner(owner) || edited === undefined) return "cancel";
+		draft = edited;
+	}
 	while (true) {
 		let validated: LoadedStarshipConfig;
 		try {
@@ -376,7 +391,14 @@ async function applyPreset(
 			continue;
 		}
 
-		const result = await reviewAndApply(ctx, options, validated, { kind: "preset", preset }, owner);
+		const result = await reviewAndApply(
+			ctx,
+			options,
+			validated,
+			{ kind: "preset", preset },
+			owner,
+			start === "confirm",
+		);
 		if (result !== "edit") return result;
 		const edited = await ctx.ui.editor(`Customize ${preset.label} preset`, draft);
 		if (!isCurrentOwner(owner) || edited === undefined) return "cancel";
@@ -404,46 +426,56 @@ async function reviewAndApply(
 	validated: LoadedStarshipConfig,
 	intent: ReviewIntent,
 	owner: WorkflowOwner,
+	skipReview = false,
 ): Promise<"applied" | "edit" | "cancel" | "close"> {
+	let reviewRequired = !skipReview;
 	while (true) {
-		const selection = await showPreviewActionMenu(
-			ctx,
-			reviewTitle(intent),
-			(width) => reviewPreviewBody(ctx, options, validated, width, intent),
-			[
-				{ value: PREVIEW_ACTIONS.continue, label: continueLabel(intent) },
-				...(intent.kind === "restore"
-					? []
-					: [
-							{
-								value: PREVIEW_ACTIONS.edit,
-								label: intent.kind === "preset" ? "Customize before applying" : "Continue editing",
-							},
-						]),
-				{
-					value: PREVIEW_ACTIONS.cancel,
-					label:
-						intent.kind === "restore"
-							? "Cancel"
-							: intent.kind === "preset"
-								? "Choose another preset"
-								: "Discard draft",
-				},
-			],
-			owner.signal,
-		);
-		if (!isCurrentOwner(owner)) return "cancel";
-		if (selection?.kind === "closed") return "close";
-		const selected = selectedPreviewAction(selection);
-		if (selected === PREVIEW_ACTIONS.edit) return "edit";
-		if (selected !== PREVIEW_ACTIONS.continue) return "cancel";
+		const directAttempt = !reviewRequired;
+		if (reviewRequired) {
+			const selection = await showPreviewActionMenu(
+				ctx,
+				reviewTitle(intent),
+				(width) => reviewPreviewBody(ctx, options, validated, width, intent),
+				[
+					{ value: PREVIEW_ACTIONS.continue, label: continueLabel(intent) },
+					...(intent.kind === "restore"
+						? []
+						: [
+								{
+									value: PREVIEW_ACTIONS.edit,
+									label:
+										intent.kind === "preset" ? "Customize before applying" : "Continue editing",
+								},
+							]),
+					{
+						value: PREVIEW_ACTIONS.cancel,
+						label:
+							intent.kind === "restore"
+								? "Cancel"
+								: intent.kind === "preset"
+									? "Choose another preset"
+									: "Discard draft",
+					},
+				],
+				owner.signal,
+			);
+			if (!isCurrentOwner(owner)) return "cancel";
+			if (selection?.kind === "closed") return "close";
+			const selected = selectedPreviewAction(selection);
+			if (selected === PREVIEW_ACTIONS.edit) return "edit";
+			if (selected !== PREVIEW_ACTIONS.continue) return "cancel";
+		}
+		reviewRequired = true;
 
 		const confirmed = await ctx.ui.confirm(
 			confirmationTitle(intent),
 			confirmationMessage(options.settingsPath, intent),
 		);
 		if (!isCurrentOwner(owner)) return "cancel";
-		if (!confirmed) continue;
+		if (!confirmed) {
+			if (directAttempt) return "cancel";
+			continue;
+		}
 
 		const save = options.save ?? atomicSaveConfigDocument;
 		const previous = options.getLoaded();
@@ -455,6 +487,7 @@ async function reviewAndApply(
 				`Footer settings were not saved: ${safeText(formatError(error))}. The previous footer remains active.`,
 				"error",
 			);
+			if (directAttempt) return "cancel";
 			continue;
 		}
 
@@ -468,6 +501,7 @@ async function reviewAndApply(
 					: `Footer settings could not be applied: ${safeText(formatError(error))}. The previous configuration was restored.`,
 				"error",
 			);
+			if (directAttempt) return "cancel";
 			continue;
 		}
 
@@ -719,7 +753,7 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
 	if (!canNotify(ctx)) return;
 	ctx.ui.notify(
 		[
-			"/starship — customize, choose presets, explain, or inspect the footer in TUI mode",
+			"/starship — customize, live-preview presets, explain, or inspect the footer in TUI mode",
 			"/starship settings — customize, preview, and apply TOML",
 			"/starship status — show source, path, and warnings",
 			"/starship help — show this help",

--- a/packages/pi-starship/src/commands.ts
+++ b/packages/pi-starship/src/commands.ts
@@ -266,8 +266,18 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 				return result?.kind === "back" ? { kind: "stay" } : { kind: "close" };
 			},
 			minimal: async () => runPresetAction(getStarshipPreset("minimal")),
-			bracketed: async () => runPresetAction(getStarshipPreset("bracketed")),
+			"bracketed-segments": async () => runPresetAction(getStarshipPreset("bracketed-segments")),
+			"catppuccin-powerline": async () =>
+				runPresetAction(getStarshipPreset("catppuccin-powerline")),
+			"gruvbox-rainbow": async () => runPresetAction(getStarshipPreset("gruvbox-rainbow")),
+			jetpack: async () => runPresetAction(getStarshipPreset("jetpack")),
 			"nerd-font-symbols": async () => runPresetAction(getStarshipPreset("nerd-font-symbols")),
+			"no-empty-icons": async () => runPresetAction(getStarshipPreset("no-empty-icons")),
+			"no-nerd-font": async () => runPresetAction(getStarshipPreset("no-nerd-font")),
+			"no-runtime-versions": async () => runPresetAction(getStarshipPreset("no-runtime-versions")),
+			"pastel-powerline": async () => runPresetAction(getStarshipPreset("pastel-powerline")),
+			"plain-text-symbols": async () => runPresetAction(getStarshipPreset("plain-text-symbols")),
+			"pure-preset": async () => runPresetAction(getStarshipPreset("pure-preset")),
 			"tokyo-night": async () => runPresetAction(getStarshipPreset("tokyo-night")),
 			restore: async () => {
 				const presentation = configurationPresentation(options.getLoaded());

--- a/packages/pi-starship/src/pi-starship.ts
+++ b/packages/pi-starship/src/pi-starship.ts
@@ -85,6 +85,7 @@ interface PiStarshipOptions {
 
 export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions = {}) {
 	let loaded: LoadedStarshipConfig | undefined;
+	let previewLoaded: LoadedStarshipConfig | undefined;
 	const runtime: RuntimeState = {
 		activeTools: new Map(),
 		isStreaming: false,
@@ -252,6 +253,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 	const installFooter = (ctx: ExtensionContext) => {
 		const generation = ++sessionGeneration;
 		sessionOwner = ctx.sessionManager;
+		previewLoaded = undefined;
 		menuController.abort(new DOMException("Starship session context replaced", "AbortError"));
 		menuController = new AbortController();
 		const target: RefreshTarget = { cwd: ctx.cwd, generation, sessionManager: ctx.sessionManager };
@@ -328,10 +330,11 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 				invalidate() {},
 				render(width: number): string[] {
 					runtime.footerWidth = width;
-					if (!loaded) return [];
+					const current = previewLoaded ?? loaded;
+					if (!current) return [];
 					const snapshot = runtimeSnapshot(ctx, footerData, runtime);
 					return wrapFormattedStatusline(
-						renderStatusline(loaded.config, snapshot, width).ansi,
+						renderStatusline(current.config, snapshot, width).ansi,
 						width,
 					);
 				},
@@ -360,6 +363,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 			if (sessionOwner !== ctx.sessionManager) {
 				throw new Error("Starship session context was replaced");
 			}
+			previewLoaded = undefined;
 			loaded = next;
 			const target = activeTarget;
 			if (target) {
@@ -368,6 +372,11 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 				requestRefresh(target);
 				requestGithubPr(target);
 			}
+			refresh();
+		},
+		preview(next, ctx) {
+			if (sessionOwner !== ctx.sessionManager) return;
+			previewLoaded = next;
 			refresh();
 		},
 		renderPreview(preview, width) {
@@ -405,6 +414,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (sessionOwner !== ctx.sessionManager) return;
 		sessionOwner = undefined;
+		previewLoaded = undefined;
 		sessionGeneration += 1;
 		menuController.abort(new DOMException("Starship session shut down", "AbortError"));
 		activeTarget = undefined;

--- a/packages/pi-starship/src/presets/bracketed-segments.ts
+++ b/packages/pi-starship/src/presets/bracketed-segments.ts
@@ -1,4 +1,4 @@
-export const BRACKETED_PRESET = String.raw`# Font-safe bracketed segments inspired by Starship.
+export const BRACKETED_SEGMENTS_PRESET = String.raw`# Font-safe bracketed segments inspired by Starship.
 format = "$brand$model$thinking$directory$git_branch$git_status$activity$context$time"
 
 [brand]

--- a/packages/pi-starship/src/presets/bracketed.ts
+++ b/packages/pi-starship/src/presets/bracketed.ts
@@ -1,0 +1,45 @@
+export const BRACKETED_PRESET = String.raw`# Font-safe bracketed segments inspired by Starship.
+format = "$brand$model$thinking$directory$git_branch$git_status$activity$context$time"
+
+[brand]
+format = '[\[$symbol\]]($style) '
+style = "bold white"
+
+[model]
+format = '[\[$symbol $model\]]($style) '
+symbol = "AI"
+style = "bold blue"
+
+[thinking]
+format = '[\[$symbol $level\]]($style) '
+symbol = "think"
+style = "bold purple"
+
+[directory]
+format = '[\[$symbol $path\]]($style) '
+symbol = "dir"
+style = "cyan bold"
+
+[git_branch]
+format = '[\[$symbol $branch\]]($style) '
+symbol = "git"
+style = "bold purple"
+
+[git_status]
+format = '[\[$all_status( $ahead_behind)\]]($style) '
+style = "red bold"
+
+[activity]
+format = '[\[$text\]]($style) '
+symbol = "run"
+style = "bold yellow"
+
+[context]
+format = '[\[$symbol $percentage\]]($style) '
+symbol = "ctx"
+
+[time]
+format = '[\[$time\]]($style)'
+symbol = ""
+style = "bold yellow"
+`;

--- a/packages/pi-starship/src/presets/catalog.ts
+++ b/packages/pi-starship/src/presets/catalog.ts
@@ -1,10 +1,32 @@
-import { BRACKETED_PRESET } from "./bracketed.js";
+import { BRACKETED_SEGMENTS_PRESET } from "./bracketed-segments.js";
+import { CATPPUCCIN_POWERLINE_PRESET } from "./catppuccin-powerline.js";
+import { GRUVBOX_RAINBOW_PRESET } from "./gruvbox-rainbow.js";
+import { JETPACK_PRESET } from "./jetpack.js";
 import { MINIMAL_PRESET } from "./minimal.js";
 import { NERD_FONT_SYMBOLS_PRESET } from "./nerd-font-symbols.js";
+import { NO_EMPTY_ICONS_PRESET } from "./no-empty-icons.js";
+import { NO_NERD_FONT_PRESET } from "./no-nerd-font.js";
+import { NO_RUNTIME_VERSIONS_PRESET } from "./no-runtime-versions.js";
+import { PASTEL_POWERLINE_PRESET } from "./pastel-powerline.js";
+import { PLAIN_TEXT_SYMBOLS_PRESET } from "./plain-text-symbols.js";
+import { PURE_PRESET } from "./pure-preset.js";
 import { TOKYO_NIGHT_PRESET } from "./tokyo-night.js";
 
 export interface StarshipPreset {
-	id: "minimal" | "bracketed" | "nerd-font-symbols" | "tokyo-night";
+	id:
+		| "minimal"
+		| "bracketed-segments"
+		| "catppuccin-powerline"
+		| "gruvbox-rainbow"
+		| "jetpack"
+		| "nerd-font-symbols"
+		| "no-empty-icons"
+		| "no-nerd-font"
+		| "no-runtime-versions"
+		| "pastel-powerline"
+		| "plain-text-symbols"
+		| "pure-preset"
+		| "tokyo-night";
 	label: string;
 	description: string;
 	requiresNerdFont: boolean;
@@ -15,16 +37,37 @@ export const STARSHIP_PRESETS = [
 	{
 		id: "minimal",
 		label: "Minimal",
-		description: "Model, directory, branch, and activity · font-safe",
+		description: "Compact Pi essentials · font-safe",
 		requiresNerdFont: false,
 		rawDocument: MINIMAL_PRESET,
 	},
 	{
-		id: "bracketed",
-		label: "Bracketed",
+		id: "bracketed-segments",
+		label: "Bracketed Segments",
 		description: "Balanced Pi and Git details in brackets · font-safe",
 		requiresNerdFont: false,
-		rawDocument: BRACKETED_PRESET,
+		rawDocument: BRACKETED_SEGMENTS_PRESET,
+	},
+	{
+		id: "catppuccin-powerline",
+		label: "Catppuccin Powerline",
+		description: "Mocha connected color blocks · requires Nerd Font",
+		requiresNerdFont: true,
+		rawDocument: CATPPUCCIN_POWERLINE_PRESET,
+	},
+	{
+		id: "gruvbox-rainbow",
+		label: "Gruvbox Rainbow",
+		description: "Warm Gruvbox connected segments · requires Nerd Font",
+		requiresNerdFont: true,
+		rawDocument: GRUVBOX_RAINBOW_PRESET,
+	},
+	{
+		id: "jetpack",
+		label: "Jetpack",
+		description: "Airy geometric left/right layout · font-safe",
+		requiresNerdFont: false,
+		rawDocument: JETPACK_PRESET,
 	},
 	{
 		id: "nerd-font-symbols",
@@ -34,9 +77,51 @@ export const STARSHIP_PRESETS = [
 		rawDocument: NERD_FONT_SYMBOLS_PRESET,
 	},
 	{
+		id: "no-empty-icons",
+		label: "No Empty Icons",
+		description: "Conditional labels never appear without values · font-safe",
+		requiresNerdFont: false,
+		rawDocument: NO_EMPTY_ICONS_PRESET,
+	},
+	{
+		id: "no-nerd-font",
+		label: "No Nerd Font",
+		description: "Portable Unicode symbols without private-use glyphs · font-safe",
+		requiresNerdFont: false,
+		rawDocument: NO_NERD_FONT_PRESET,
+	},
+	{
+		id: "no-runtime-versions",
+		label: "No Runtime Versions",
+		description: "Presence indicators without model or thinking details · font-safe",
+		requiresNerdFont: false,
+		rawDocument: NO_RUNTIME_VERSIONS_PRESET,
+	},
+	{
+		id: "pastel-powerline",
+		label: "Pastel Powerline",
+		description: "Pastel connected color blocks · requires Nerd Font",
+		requiresNerdFont: true,
+		rawDocument: PASTEL_POWERLINE_PRESET,
+	},
+	{
+		id: "plain-text-symbols",
+		label: "Plain Text Symbols",
+		description: "Plain words replace pictograms · font-safe",
+		requiresNerdFont: false,
+		rawDocument: PLAIN_TEXT_SYMBOLS_PRESET,
+	},
+	{
+		id: "pure-preset",
+		label: "Pure Preset",
+		description: "Clean two-line workspace and session context · font-safe",
+		requiresNerdFont: false,
+		rawDocument: PURE_PRESET,
+	},
+	{
 		id: "tokyo-night",
 		label: "Tokyo Night",
-		description: "Palette-backed Powerline segments · requires Nerd Font",
+		description: "Cool connected color blocks · requires Nerd Font",
 		requiresNerdFont: true,
 		rawDocument: TOKYO_NIGHT_PRESET,
 	},

--- a/packages/pi-starship/src/presets/catalog.ts
+++ b/packages/pi-starship/src/presets/catalog.ts
@@ -1,0 +1,53 @@
+import { BRACKETED_PRESET } from "./bracketed.js";
+import { MINIMAL_PRESET } from "./minimal.js";
+import { NERD_FONT_SYMBOLS_PRESET } from "./nerd-font-symbols.js";
+import { TOKYO_NIGHT_PRESET } from "./tokyo-night.js";
+
+export interface StarshipPreset {
+	id: "minimal" | "bracketed" | "nerd-font-symbols" | "tokyo-night";
+	label: string;
+	description: string;
+	requiresNerdFont: boolean;
+	rawDocument: string;
+}
+
+export const STARSHIP_PRESETS = [
+	{
+		id: "minimal",
+		label: "Minimal",
+		description: "Model, directory, branch, and activity · font-safe",
+		requiresNerdFont: false,
+		rawDocument: MINIMAL_PRESET,
+	},
+	{
+		id: "bracketed",
+		label: "Bracketed",
+		description: "Balanced Pi and Git details in brackets · font-safe",
+		requiresNerdFont: false,
+		rawDocument: BRACKETED_PRESET,
+	},
+	{
+		id: "nerd-font-symbols",
+		label: "Nerd Font Symbols",
+		description: "Balanced default layout with icon-rich symbols · requires Nerd Font",
+		requiresNerdFont: true,
+		rawDocument: NERD_FONT_SYMBOLS_PRESET,
+	},
+	{
+		id: "tokyo-night",
+		label: "Tokyo Night",
+		description: "Palette-backed Powerline segments · requires Nerd Font",
+		requiresNerdFont: true,
+		rawDocument: TOKYO_NIGHT_PRESET,
+	},
+] as const satisfies readonly StarshipPreset[];
+
+export function getStarshipPreset(id: StarshipPreset["id"]): StarshipPreset {
+	const preset = STARSHIP_PRESETS.find((candidate) => candidate.id === id);
+	if (!preset) throw new Error(`Unknown pi-starship preset: ${id}`);
+	return preset;
+}
+
+export function presetForDocument(rawDocument: string | undefined): StarshipPreset | undefined {
+	return STARSHIP_PRESETS.find((preset) => preset.rawDocument === rawDocument);
+}

--- a/packages/pi-starship/src/presets/catppuccin-powerline.ts
+++ b/packages/pi-starship/src/presets/catppuccin-powerline.ts
@@ -1,0 +1,90 @@
+export const CATPPUCCIN_POWERLINE_PRESET = `# Pi-native adaptation of Starship's Catppuccin Powerline preset.
+format = "[](red)$brand$model[](bg:peach fg:red)$directory[](bg:yellow fg:peach)$git_branch$git_status[](fg:yellow bg:green)$thinking$activity[](fg:green bg:sapphire)$context[](fg:sapphire bg:lavender)$time[](fg:lavender)"
+palette = "catppuccin_mocha"
+
+[brand]
+format = "[ $symbol ]($style)"
+symbol = ""
+style = "fg:crust bg:red bold"
+
+[model]
+format = "[$model ]($style)"
+symbol = ""
+style = "fg:crust bg:red bold"
+
+[directory]
+format = "[ $path ]($style)"
+symbol = ""
+style = "fg:crust bg:peach bold"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[git_branch]
+format = "[ $symbol $branch ]($style)"
+symbol = ""
+style = "fg:crust bg:yellow bold"
+
+[git_status]
+format = "[$all_status$ahead_behind ]($style)"
+style = "fg:crust bg:yellow bold"
+
+[thinking]
+format = "[ $symbol $level ]($style)"
+symbol = "󰔟"
+style = "fg:crust bg:green bold"
+
+[activity]
+format = "[ $text ]($style)"
+symbol = "󰑮"
+style = "fg:crust bg:green bold"
+
+[context]
+format = "[ $symbol $percentage ](fg:crust bg:sapphire bold)"
+symbol = "󰍛"
+
+[[context.display]]
+threshold = 0
+style = "sapphire"
+hidden = false
+
+[time]
+format = "[  $time ]($style)"
+symbol = ""
+style = "fg:crust bg:lavender bold"
+
+[palettes.catppuccin_mocha]
+red = "#f38ba8"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+sapphire = "#74c7ec"
+lavender = "#b4befe"
+crust = "#11111b"
+
+[palettes.catppuccin_frappe]
+red = "#e78284"
+peach = "#ef9f76"
+yellow = "#e5c890"
+green = "#a6d189"
+sapphire = "#85c1dc"
+lavender = "#babbf1"
+crust = "#232634"
+
+[palettes.catppuccin_latte]
+red = "#d20f39"
+peach = "#fe640b"
+yellow = "#df8e1d"
+green = "#40a02b"
+sapphire = "#209fb5"
+lavender = "#7287fd"
+crust = "#dce0e8"
+
+[palettes.catppuccin_macchiato]
+red = "#ed8796"
+peach = "#f5a97f"
+yellow = "#eed49f"
+green = "#a6da95"
+sapphire = "#7dc4e4"
+lavender = "#b7bdf8"
+crust = "#181926"
+`;

--- a/packages/pi-starship/src/presets/gruvbox-rainbow.ts
+++ b/packages/pi-starship/src/presets/gruvbox-rainbow.ts
@@ -1,0 +1,66 @@
+export const GRUVBOX_RAINBOW_PRESET = `# Pi-native adaptation of Starship's Gruvbox Rainbow preset.
+format = "[](color_orange)$brand$model[](bg:color_yellow fg:color_orange)$directory[](fg:color_yellow bg:color_aqua)$git_branch$git_status[](fg:color_aqua bg:color_blue)$thinking$activity[](fg:color_blue bg:color_bg3)$context[](fg:color_bg3 bg:color_bg1)$time[](fg:color_bg1)"
+palette = "gruvbox_dark"
+
+[palettes.gruvbox_dark]
+color_fg0 = "#fbf1c7"
+color_bg1 = "#3c3836"
+color_bg3 = "#665c54"
+color_blue = "#458588"
+color_aqua = "#689d6a"
+color_green = "#98971a"
+color_orange = "#d65d0e"
+color_purple = "#b16286"
+color_red = "#cc241d"
+color_yellow = "#d79921"
+
+[brand]
+format = "[ $symbol ]($style)"
+symbol = ""
+style = "fg:color_fg0 bg:color_orange bold"
+
+[model]
+format = "[$model ]($style)"
+symbol = ""
+style = "fg:color_fg0 bg:color_orange bold"
+
+[directory]
+format = "[ $path ]($style)"
+symbol = ""
+style = "fg:color_fg0 bg:color_yellow bold"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[git_branch]
+format = "[ $symbol $branch ]($style)"
+symbol = ""
+style = "fg:color_fg0 bg:color_aqua bold"
+
+[git_status]
+format = "[$all_status$ahead_behind ]($style)"
+style = "fg:color_fg0 bg:color_aqua bold"
+
+[thinking]
+format = "[ $symbol $level ]($style)"
+symbol = "󰔟"
+style = "fg:color_fg0 bg:color_blue bold"
+
+[activity]
+format = "[ $text ]($style)"
+symbol = "󰑮"
+style = "fg:color_fg0 bg:color_blue bold"
+
+[context]
+format = "[ $symbol $percentage ](fg:color_fg0 bg:color_bg3 bold)"
+symbol = "󰍛"
+
+[[context.display]]
+threshold = 0
+style = "color_bg3"
+hidden = false
+
+[time]
+format = "[  $time ]($style)"
+symbol = ""
+style = "fg:color_fg0 bg:color_bg1 bold"
+`;

--- a/packages/pi-starship/src/presets/jetpack.ts
+++ b/packages/pi-starship/src/presets/jetpack.ts
@@ -1,0 +1,51 @@
+export const JETPACK_PRESET = `# Pi-native adaptation of Starship's Jetpack preset.
+# Left-side session activity and right-side workspace context meet at $fill.
+format = "$activity$context$fill$directory$git_branch$git_state$git_status$time"
+
+[activity]
+format = "[◄ $text ]($style)"
+symbol = ""
+style = "italic white"
+
+[context]
+format = "[◯ $percentage]($style) "
+symbol = ""
+
+[[context.display]]
+threshold = 0
+style = "bold purple"
+hidden = false
+
+[fill]
+symbol = " "
+style = "none"
+
+[directory]
+format = "[$path]($style) "
+symbol = ""
+style = "italic blue"
+truncation_length = 2
+truncation_symbol = "□ "
+home_symbol = "⌂"
+
+[git_branch]
+format = "[$symbol$branch]($style)"
+symbol = "△ "
+style = "italic bright-blue"
+truncation_length = 11
+truncation_symbol = "⋯"
+
+[git_state]
+format = "([⎪$state $progress_current/$progress_total⎥]($style))"
+symbol = ""
+style = "italic bright-purple"
+
+[git_status]
+format = "([⎪$all_status$ahead_behind⎥]($style))"
+style = "bold italic bright-blue"
+
+[time]
+format = "[ $time]($style)"
+symbol = ""
+style = "italic dimmed white"
+`;

--- a/packages/pi-starship/src/presets/minimal.ts
+++ b/packages/pi-starship/src/presets/minimal.ts
@@ -1,0 +1,23 @@
+export const MINIMAL_PRESET = `# A compact, font-safe Pi footer.
+format = "$model$directory$git_branch$activity"
+
+[model]
+format = "[$model]($style) "
+symbol = ""
+style = "bold blue"
+
+[directory]
+format = "[$path]($style) "
+symbol = ""
+style = "cyan bold"
+
+[git_branch]
+format = "[git:$branch]($style) "
+symbol = ""
+style = "bold purple"
+
+[activity]
+format = "[$text]($style)"
+symbol = "*"
+style = "bold yellow"
+`;

--- a/packages/pi-starship/src/presets/nerd-font-symbols.ts
+++ b/packages/pi-starship/src/presets/nerd-font-symbols.ts
@@ -1,0 +1,27 @@
+export const NERD_FONT_SYMBOLS_PRESET = `# Balanced Pi footer with Nerd Font symbols.
+format = "$brand$model$thinking$directory$git_branch$git_status$activity$context$time"
+
+[brand]
+symbol = ""
+
+[model]
+symbol = "󰚩"
+
+[thinking]
+symbol = "󰔟"
+
+[directory]
+symbol = "󰉋"
+
+[git_branch]
+symbol = ""
+
+[activity]
+symbol = "󰑮"
+
+[context]
+symbol = "󰍛"
+
+[time]
+symbol = ""
+`;

--- a/packages/pi-starship/src/presets/no-empty-icons.ts
+++ b/packages/pi-starship/src/presets/no-empty-icons.ts
@@ -1,0 +1,47 @@
+export const NO_EMPTY_ICONS_PRESET = `# Pi-native adaptation of Starship's No Empty Icons preset.
+# Each label lives inside the same conditional group as its value.
+format = "$model$thinking$directory$git_branch$git_status$activity$context$time"
+
+[model]
+format = "([model $model]($style) )"
+symbol = ""
+style = "bold blue"
+
+[thinking]
+format = "([thinking $level]($style) )"
+symbol = ""
+style = "bold purple"
+
+[directory]
+format = "([in $path]($style) )"
+symbol = ""
+style = "cyan bold"
+
+[git_branch]
+format = "([on $branch]($style) )"
+symbol = ""
+style = "bold purple"
+
+[git_status]
+format = "([$all_status$ahead_behind]($style) )"
+style = "red bold"
+
+[activity]
+format = "([while $text]($style) )"
+symbol = ""
+style = "bold yellow"
+
+[context]
+format = "([using $percentage context]($style) )"
+symbol = ""
+
+[[context.display]]
+threshold = 0
+style = "bold green"
+hidden = false
+
+[time]
+format = "([at $time]($style))"
+symbol = ""
+style = "bold yellow"
+`;

--- a/packages/pi-starship/src/presets/no-nerd-font.ts
+++ b/packages/pi-starship/src/presets/no-nerd-font.ts
@@ -1,0 +1,51 @@
+export const NO_NERD_FONT_PRESET = `# Pi-native adaptation of Starship's No Nerd Font preset.
+format = "$brand$model$thinking$directory$git_branch$git_status$activity$context$time"
+
+[brand]
+format = "[$symbol]($style) "
+symbol = "✦"
+style = "bold white"
+
+[model]
+format = "[$symbol $model]($style) "
+symbol = "◆"
+style = "bold blue"
+
+[thinking]
+format = "[$symbol $level]($style) "
+symbol = "◇"
+style = "bold purple"
+
+[directory]
+format = "[$symbol $path]($style) "
+symbol = "⌂"
+style = "cyan bold"
+
+[git_branch]
+format = "[$symbol $branch]($style) "
+symbol = "⎇"
+style = "bold purple"
+
+[git_status]
+format = "[$all_status( $ahead_behind)]($style) "
+style = "red bold"
+
+[activity]
+format = "[$text]($style) "
+symbol = "●"
+style = "bold yellow"
+
+[context]
+format = "[$symbol $percentage]($style) "
+symbol = "◌"
+
+[[context.display]]
+threshold = 0
+style = "bold green"
+hidden = false
+
+[time]
+format = "[$symbol $time]($style)"
+symbol = "◴"
+style = "bold yellow"
+`;

--- a/packages/pi-starship/src/presets/no-runtime-versions.ts
+++ b/packages/pi-starship/src/presets/no-runtime-versions.ts
@@ -1,0 +1,52 @@
+export const NO_RUNTIME_VERSIONS_PRESET = `# Pi-native adaptation of Starship's No Runtime Versions preset.
+# Model and thinking modules retain presence symbols while hiding version-like details.
+format = "$brand$model$thinking$directory$git_branch$git_status$activity$context$time"
+
+[brand]
+format = "[$symbol]($style) "
+symbol = "π"
+style = "bold white"
+
+[model]
+format = "[$symbol]($style) "
+symbol = "AI"
+style = "bold blue"
+
+[thinking]
+format = "[$symbol]($style) "
+symbol = "think"
+style = "bold purple"
+
+[directory]
+format = "[$path]($style) "
+symbol = ""
+style = "cyan bold"
+
+[git_branch]
+format = "[$symbol$branch]($style) "
+symbol = "git:"
+style = "bold purple"
+
+[git_status]
+format = "[$all_status( $ahead_behind)]($style) "
+style = "red bold"
+
+[activity]
+format = "[$symbol]($style) "
+symbol = "run"
+style = "bold yellow"
+
+[context]
+format = "[$percentage]($style) "
+symbol = ""
+
+[[context.display]]
+threshold = 0
+style = "bold green"
+hidden = false
+
+[time]
+format = "[$time]($style)"
+symbol = ""
+style = "bold yellow"
+`;

--- a/packages/pi-starship/src/presets/pastel-powerline.ts
+++ b/packages/pi-starship/src/presets/pastel-powerline.ts
@@ -1,0 +1,53 @@
+export const PASTEL_POWERLINE_PRESET = `# Pi-native adaptation of Starship's Pastel Powerline preset.
+format = "[](#9A348E)$brand$model[](bg:#DA627D fg:#9A348E)$directory[](fg:#DA627D bg:#FCA17D)$git_branch$git_status[](fg:#FCA17D bg:#86BBD8)$thinking$activity[](fg:#86BBD8 bg:#06969A)$context[](fg:#06969A bg:#33658A)$time[](fg:#33658A)"
+
+[brand]
+format = "[ $symbol ]($style)"
+symbol = ""
+style = "fg:#ffffff bg:#9A348E bold"
+
+[model]
+format = "[$model ]($style)"
+symbol = ""
+style = "fg:#ffffff bg:#9A348E bold"
+
+[directory]
+format = "[ $path ]($style)"
+symbol = ""
+style = "fg:#ffffff bg:#DA627D bold"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[git_branch]
+format = "[ $symbol $branch ]($style)"
+symbol = ""
+style = "fg:#1f1f1f bg:#FCA17D bold"
+
+[git_status]
+format = "[$all_status$ahead_behind ]($style)"
+style = "fg:#1f1f1f bg:#FCA17D bold"
+
+[thinking]
+format = "[ $symbol $level ]($style)"
+symbol = "󰔟"
+style = "fg:#1f1f1f bg:#86BBD8 bold"
+
+[activity]
+format = "[ $text ]($style)"
+symbol = "󰑮"
+style = "fg:#1f1f1f bg:#86BBD8 bold"
+
+[context]
+format = "[ $symbol $percentage ](fg:#ffffff bg:#06969A bold)"
+symbol = "󰍛"
+
+[[context.display]]
+threshold = 0
+style = "#06969A"
+hidden = false
+
+[time]
+format = "[ ♥ $time ]($style)"
+symbol = ""
+style = "fg:#ffffff bg:#33658A bold"
+`;

--- a/packages/pi-starship/src/presets/plain-text-symbols.ts
+++ b/packages/pi-starship/src/presets/plain-text-symbols.ts
@@ -1,0 +1,52 @@
+export const PLAIN_TEXT_SYMBOLS_PRESET = `# Pi-native adaptation of Starship's Plain Text Symbols preset.
+format = "$brand$model$thinking$directory$git_branch$git_status$activity$context$time"
+
+[brand]
+format = "[$symbol]($style) "
+symbol = "pi"
+style = "bold white"
+
+[model]
+format = "[$symbol $model]($style) "
+symbol = "model"
+style = "bold blue"
+
+[thinking]
+format = "[$symbol $level]($style) "
+symbol = "thinking"
+style = "bold purple"
+
+[directory]
+format = "[$symbol $path]($style) "
+symbol = "dir"
+style = "cyan bold"
+
+[git_branch]
+format = "[$symbol $branch]($style) "
+symbol = "git"
+style = "bold purple"
+truncation_symbol = "..."
+
+[git_status]
+format = "[$all_status( $ahead_behind)]($style) "
+style = "red bold"
+
+[activity]
+format = "[$text]($style) "
+symbol = "active"
+style = "bold yellow"
+
+[context]
+format = "[$symbol $percentage]($style) "
+symbol = "context"
+
+[[context.display]]
+threshold = 0
+style = "bold green"
+hidden = false
+
+[time]
+format = "[$symbol $time]($style)"
+symbol = "time"
+style = "bold yellow"
+`;

--- a/packages/pi-starship/src/presets/pure-preset.ts
+++ b/packages/pi-starship/src/presets/pure-preset.ts
@@ -1,0 +1,55 @@
+export const PURE_PRESET = `# Pi-native adaptation of Starship's Pure preset.
+format = "$directory$git_branch$git_state$git_status$activity\\n$model$thinking$context$fill$time"
+
+[directory]
+format = "[$path]($style) "
+symbol = ""
+style = "blue"
+
+[git_branch]
+format = "[$branch]($style) "
+symbol = ""
+style = "bright-black"
+
+[git_state]
+format = '([($state( $progress_current/$progress_total))]($style) )'
+symbol = ""
+style = "bright-black"
+
+[git_status]
+format = "[(*$all_status)](218) [$ahead_behind]($style) "
+style = "cyan"
+
+[activity]
+format = "[$text]($style) "
+symbol = ""
+style = "yellow"
+
+[model]
+format = "[$model]($style) "
+symbol = ""
+style = "bright-black"
+
+[thinking]
+format = "[$level]($style) "
+symbol = ""
+style = "bright-black"
+
+[context]
+format = "[$percentage]($style)"
+symbol = ""
+
+[[context.display]]
+threshold = 0
+style = "bright-black"
+hidden = false
+
+[fill]
+symbol = " "
+style = "none"
+
+[time]
+format = "[$time]($style)"
+symbol = ""
+style = "bright-black"
+`;

--- a/packages/pi-starship/src/presets/tokyo-night.ts
+++ b/packages/pi-starship/src/presets/tokyo-night.ts
@@ -1,0 +1,65 @@
+export const TOKYO_NIGHT_PRESET = `# A Pi-native Tokyo Night treatment using Nerd Font Powerline glyphs.
+format = "$brand$model$thinking$directory$git_branch$git_status$activity$context$fill$time"
+palette = "tokyo_night"
+
+[palettes.tokyo_night]
+base = "#1a1b26"
+blue = "#7aa2f7"
+cyan = "#7dcfff"
+green = "#9ece6a"
+orange = "#ff9e64"
+purple = "#bb9af7"
+red = "#f7768e"
+
+[brand]
+format = "[](blue)[ $symbol ]($style)[](blue) "
+symbol = ""
+style = "fg:base bg:blue bold"
+
+[model]
+format = "[](purple)[ $symbol $model ]($style)[](purple) "
+symbol = "󰚩"
+style = "fg:base bg:purple bold"
+
+[thinking]
+format = "[](cyan)[ $symbol $level ]($style)[](cyan) "
+symbol = "󰔟"
+style = "fg:base bg:cyan bold"
+
+[directory]
+format = "[](blue)[ $symbol $path ]($style)[](blue) "
+symbol = "󰉋"
+style = "fg:base bg:blue bold"
+
+[git_branch]
+format = "[](orange)[ $symbol $branch ]($style)"
+symbol = ""
+style = "fg:base bg:orange bold"
+
+[git_status]
+format = "[$all_status( $ahead_behind) ]($style)[](orange) "
+style = "fg:base bg:orange bold"
+
+[activity]
+format = "[](green)[ $text ]($style)[](green) "
+symbol = "󰑮"
+style = "fg:base bg:green bold"
+
+[context]
+format = "[]($style)[ $symbol $percentage ](fg:base bg:green bold)[](green) "
+symbol = "󰍛"
+
+[[context.display]]
+threshold = 0
+style = "green"
+hidden = false
+
+[fill]
+symbol = " "
+style = "none"
+
+[time]
+format = "[](blue)[ $symbol $time ]($style)[](blue)"
+symbol = ""
+style = "fg:base bg:blue bold"
+`;

--- a/packages/pi-starship/src/presets/tokyo-night.ts
+++ b/packages/pi-starship/src/presets/tokyo-night.ts
@@ -1,65 +1,53 @@
-export const TOKYO_NIGHT_PRESET = `# A Pi-native Tokyo Night treatment using Nerd Font Powerline glyphs.
-format = "$brand$model$thinking$directory$git_branch$git_status$activity$context$fill$time"
-palette = "tokyo_night"
-
-[palettes.tokyo_night]
-base = "#1a1b26"
-blue = "#7aa2f7"
-cyan = "#7dcfff"
-green = "#9ece6a"
-orange = "#ff9e64"
-purple = "#bb9af7"
-red = "#f7768e"
+export const TOKYO_NIGHT_PRESET = `# Pi-native adaptation of Starship's Tokyo Night preset.
+format = "[░▒▓](#a3aed2)$brand$model[](bg:#769ff0 fg:#a3aed2)$directory[](fg:#769ff0 bg:#394260)$git_branch$git_status[](fg:#394260 bg:#212736)$thinking$activity[](fg:#212736 bg:#1d2230)$context$time[](fg:#1d2230)"
 
 [brand]
-format = "[](blue)[ $symbol ]($style)[](blue) "
+format = "[ $symbol ]($style)"
 symbol = ""
-style = "fg:base bg:blue bold"
+style = "fg:#090c0c bg:#a3aed2 bold"
 
 [model]
-format = "[](purple)[ $symbol $model ]($style)[](purple) "
-symbol = "󰚩"
-style = "fg:base bg:purple bold"
-
-[thinking]
-format = "[](cyan)[ $symbol $level ]($style)[](cyan) "
-symbol = "󰔟"
-style = "fg:base bg:cyan bold"
+format = "[$model ]($style)"
+symbol = ""
+style = "fg:#090c0c bg:#a3aed2 bold"
 
 [directory]
-format = "[](blue)[ $symbol $path ]($style)[](blue) "
-symbol = "󰉋"
-style = "fg:base bg:blue bold"
+format = "[ $path ]($style)"
+symbol = ""
+style = "fg:#e3e5e5 bg:#769ff0 bold"
+truncation_length = 3
+truncation_symbol = "…/"
 
 [git_branch]
-format = "[](orange)[ $symbol $branch ]($style)"
+format = "[ $symbol $branch ]($style)"
 symbol = ""
-style = "fg:base bg:orange bold"
+style = "fg:#769ff0 bg:#394260 bold"
 
 [git_status]
-format = "[$all_status( $ahead_behind) ]($style)[](orange) "
-style = "fg:base bg:orange bold"
+format = "[$all_status$ahead_behind ]($style)"
+style = "fg:#769ff0 bg:#394260 bold"
+
+[thinking]
+format = "[ $symbol $level ]($style)"
+symbol = "󰔟"
+style = "fg:#769ff0 bg:#212736 bold"
 
 [activity]
-format = "[](green)[ $text ]($style)[](green) "
+format = "[ $text ]($style)"
 symbol = "󰑮"
-style = "fg:base bg:green bold"
+style = "fg:#769ff0 bg:#212736 bold"
 
 [context]
-format = "[]($style)[ $symbol $percentage ](fg:base bg:green bold)[](green) "
+format = "[ $symbol $percentage ](fg:#a0a9cb bg:#1d2230 bold)"
 symbol = "󰍛"
 
 [[context.display]]
 threshold = 0
-style = "green"
+style = "#1d2230"
 hidden = false
 
-[fill]
-symbol = " "
-style = "none"
-
 [time]
-format = "[](blue)[ $symbol $time ]($style)[](blue)"
-symbol = ""
-style = "fg:base bg:blue bold"
+format = "[ $time ]($style)"
+symbol = ""
+style = "fg:#a0a9cb bg:#1d2230 bold"
 `;

--- a/packages/pi-starship/test/command-inspection.test.ts
+++ b/packages/pi-starship/test/command-inspection.test.ts
@@ -78,6 +78,7 @@ test("/starship adds Explain footer and Modules without adding direct routes", a
 	await tui.waitForOpen();
 	const frame = tui.render().join("\n");
 	assert.match(frame, /Customize footer/u);
+	assert.match(frame, /Presets/u);
 	assert.match(frame, /Explain footer/u);
 	assert.match(frame, /Modules/u);
 	assert.match(frame, /Configuration/u);
@@ -102,6 +103,7 @@ test("Explain footer is adaptive and lists only currently showing modules", asyn
 		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 		const running = mock.commands.get("starship")?.handler("", context.ctx);
 		await tui.waitForOpen();
+		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
@@ -146,6 +148,7 @@ test("Explain footer has an explicit empty state", async () => {
 	const running = mock.commands.get("starship")?.handler("", context.ctx);
 	await tui.waitForOpen();
 	tui.press("tui.select.down");
+	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
 	await tui.waitForOpen();
 	assert.match(tui.render().join("\n"), /No modules are currently showing/u);
@@ -168,6 +171,7 @@ test("Modules is searchable, adaptive, terminal-safe, and restores search after 
 		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 		const running = mock.commands.get("starship")?.handler("", context.ctx);
 		await tui.waitForOpen();
+		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
@@ -230,6 +234,7 @@ test("Modules searches non-rendered module metadata", async () => {
 	await tui.waitForOpen();
 	tui.press("tui.select.down");
 	tui.press("tui.select.down");
+	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
 	await tui.waitForOpen();
 	tui.setFocused(true);
@@ -256,6 +261,7 @@ test("external module-browser disposal releases the component without writing se
 		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 		const running = Promise.resolve(mock.commands.get("starship")?.handler("", context.ctx));
 		await tui.waitForOpen();
+		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
@@ -293,6 +299,7 @@ test("Modules honors injected keybindings and distinguishes Back from Close", as
 	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 	const running = mock.commands.get("starship")?.handler("", context.ctx);
 	await tui.waitForOpen();
+	tui.send("j");
 	tui.send("j");
 	tui.send("j");
 	tui.send("y");

--- a/packages/pi-starship/test/command-lifecycle.test.ts
+++ b/packages/pi-starship/test/command-lifecycle.test.ts
@@ -184,6 +184,93 @@ test("session shutdown disposes an open settings preview before returning", asyn
 	}
 });
 
+test("preset cursor preview swaps only the in-memory footer and Back restores it", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-live-preset-footer-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		const mock = createMockPi();
+		(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () =>
+			gitResult();
+		piStarship(mock.pi);
+		const tui = createTuiHarness({ width: 50, rows: 16 });
+		const context = createMockContext({ mode: "tui", custom: tui.custom });
+		await emit(mock.events, "session_start", {}, context.ctx);
+		const footer = (context.footer as FooterFactory)(
+			{ requestRender() {} },
+			{},
+			{
+				getGitBranch: () => null,
+				getExtensionStatuses: () => new Map(),
+				onBranchChange: () => () => undefined,
+			},
+		);
+		assert.match(footer.render(80).join("\n"), /π/u);
+
+		const command = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.doesNotMatch(footer.render(80).join("\n"), /π/u);
+		assert.equal(existsSync(join(root, "pi-starship.toml")), false);
+
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(footer.render(80).join("\n"), /π/u);
+		tui.press("ctrl+c");
+		await command;
+		footer.dispose();
+		await emit(mock.events, "session_shutdown", {}, context.ctx);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("session replacement clears an open preset footer preview before returning", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-replace-preset-preview-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		const mock = createMockPi();
+		(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () =>
+			gitResult();
+		piStarship(mock.pi);
+		const tui = createTuiHarness({ width: 50, rows: 16 });
+		const oldContext = createMockContext({ mode: "tui", custom: tui.custom });
+		await emit(mock.events, "session_start", {}, oldContext.ctx);
+		const oldFooter = (oldContext.footer as FooterFactory)(
+			{ requestRender() {} },
+			{},
+			{
+				getGitBranch: () => null,
+				getExtensionStatuses: () => new Map(),
+				onBranchChange: () => () => undefined,
+			},
+		);
+		const command = mock.commands.get("starship")?.handler("", oldContext.ctx);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.doesNotMatch(oldFooter.render(80).join("\n"), /π/u);
+
+		const newContext = createMockContext({ mode: "tui", cwd: "/work/replacement" });
+		await emit(mock.events, "session_start", {}, newContext.ctx);
+		await command;
+		assert.match(oldFooter.render(80).join("\n"), /π/u);
+		assert.equal(existsSync(join(root, "pi-starship.toml")), false);
+		oldFooter.dispose();
+		await emit(mock.events, "session_shutdown", {}, newContext.ctx);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("session shutdown disposes an open preset preview without saving", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-shutdown-preset-preview-"));
 	const previous = process.env.PI_CODING_AGENT_DIR;
@@ -205,9 +292,7 @@ test("session shutdown disposes an open preset preview without saving", async ()
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
-		tui.press("tui.select.confirm");
-		await tui.waitForOpen();
-		assert.match(tui.render().join("\n"), /Minimal preset preview/u);
+		assert.match(tui.render().join("\n"), /Presets · current:/u);
 		await emit(mock.events, "session_shutdown", {}, context.ctx);
 		await flushAsync();
 		try {
@@ -232,6 +317,16 @@ async function emit(
 ) {
 	for (const handler of events.get(name) ?? []) await handler(...args);
 }
+
+type FooterFactory = (
+	tui: { requestRender(): void },
+	theme: unknown,
+	data: {
+		getGitBranch(): string | null;
+		getExtensionStatuses(): ReadonlyMap<string, string>;
+		onBranchChange(callback: () => void): () => void;
+	},
+) => { render(width: number): string[]; dispose(): void };
 
 type ExecResult = { stdout: string; stderr: string; code: number; killed: boolean };
 

--- a/packages/pi-starship/test/command-lifecycle.test.ts
+++ b/packages/pi-starship/test/command-lifecycle.test.ts
@@ -82,6 +82,7 @@ test("session replacement disposes an open module browser before returning", asy
 		await tui.waitForOpen();
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
+		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		await emit(mock.events, "session_start", {}, newContext.ctx);
@@ -120,6 +121,7 @@ test("session shutdown disposes an open module browser before returning", async 
 			settled = true;
 		});
 		await tui.waitForOpen();
+		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
@@ -165,6 +167,47 @@ test("session shutdown disposes an open settings preview before returning", asyn
 			settled = true;
 		});
 		await tui.waitForOpen();
+		await emit(mock.events, "session_shutdown", {}, context.ctx);
+		await flushAsync();
+		try {
+			assert.equal(settled, true);
+			assert.equal(tui.isOpen, false);
+		} finally {
+			if (!settled) tui.dispose();
+			await command;
+		}
+		assert.equal(existsSync(join(root, "pi-starship.toml")), false);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("session shutdown disposes an open preset preview without saving", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-shutdown-preset-preview-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		const mock = createMockPi();
+		(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () =>
+			gitResult();
+		piStarship(mock.pi);
+		const tui = createTuiHarness({ width: 50, rows: 16 });
+		const context = createMockContext({ mode: "tui", custom: tui.custom });
+		await emit(mock.events, "session_start", {}, context.ctx);
+		let settled = false;
+		const command = Promise.resolve(mock.commands.get("starship")?.handler("", context.ctx));
+		void command.then(() => {
+			settled = true;
+		});
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Minimal preset preview/u);
 		await emit(mock.events, "session_shutdown", {}, context.ctx);
 		await flushAsync();
 		try {

--- a/packages/pi-starship/test/command-ux.test.ts
+++ b/packages/pi-starship/test/command-ux.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -9,6 +9,7 @@ import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerStarshipCommand } from "../src/commands.js";
 import { BUILT_IN_EXAMPLE, loadStarshipConfig } from "../src/config.js";
+import { STARSHIP_PRESETS } from "../src/presets/catalog.js";
 
 test("/starship distinguishes built-in defaults, saved built-in, custom, and fallback states", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-state-"));
@@ -64,6 +65,233 @@ test("/starship distinguishes built-in defaults, saved built-in, custom, and fal
 	}
 });
 
+test("Presets stays shallow, identifies the exact active document, and restores focus", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-presets-"));
+	const path = join(root, "pi-starship.toml");
+	const minimal = STARSHIP_PRESETS[0];
+	assert.ok(minimal);
+	writeFileSync(path, minimal.rawDocument);
+	try {
+		const mock = createMockPi();
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loadStarshipConfig(path),
+			apply() {},
+			settingsPath: path,
+		});
+		const tui = createTuiHarness({ width: 40, rows: 18 });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Minimal preset · Healthy/u);
+		tui.press("tui.select.down");
+		assert.match(tui.render().join("\n"), /→ Presets/u);
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		for (const dimensions of [
+			{ width: 20, rows: 8 },
+			{ width: 40, rows: 18 },
+			{ width: 80, rows: 24 },
+		]) {
+			const frame = tui.resize(dimensions);
+			assert.ok(frame.every((line) => visibleWidth(line) <= dimensions.width));
+		}
+		const full = tui.render().join("\n");
+		assert.match(full, /Minimal/u);
+		assert.match(full, /Bracketed/u);
+		assert.match(full, /Nerd Font Symbols/u);
+		assert.match(full, /Tokyo Night/u);
+		assert.match(full, /Currently applied/u);
+		tui.press("tui.select.confirm");
+		await flushAsyncWork();
+		assert.match(tui.render().join("\n"), /^Presets/mu);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		assert.match(tui.render().join("\n"), /requires Nerd Font/u);
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /→ Presets/u);
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(readFileSync(path, "utf8"), minimal.rawDocument);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("preset preview cancellation is inert and confirmed apply replaces atomically", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preset-apply-"));
+	const path = join(root, "pi-starship.toml");
+	const original = "format = 'custom'\nfuture = true\n";
+	writeFileSync(path, original);
+	try {
+		const mock = createMockPi();
+		let applied = 0;
+		let confirmation = "";
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loadStarshipConfig(path),
+			apply() {
+				applied += 1;
+			},
+			settingsPath: path,
+			renderPreview: (loaded) => [loaded.config.format],
+		});
+
+		const cancelledTui = createTuiHarness({ width: 50, rows: 16 });
+		const cancelledContext = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: cancelledTui.custom,
+			confirm: async () => true,
+		});
+		const cancelled = mock.commands.get("starship")?.handler("", cancelledContext.ctx);
+		await cancelledTui.waitForOpen();
+		cancelledTui.press("tui.select.down");
+		cancelledTui.press("tui.select.confirm");
+		await cancelledTui.waitForOpen();
+		cancelledTui.press("tui.select.confirm");
+		await cancelledTui.waitForOpen();
+		assert.match(cancelledTui.render().join("\n"), /Minimal preset preview/u);
+		assert.match(cancelledTui.render().join("\n"), /Apply Minimal preset…/u);
+		assert.match(cancelledTui.render().join("\n"), /Customize before applying/u);
+		assert.match(cancelledTui.render().join("\n"), /Choose another preset/u);
+		cancelledTui.press("tui.select.cancel");
+		await cancelledTui.waitForOpen();
+		assert.match(cancelledTui.render().join("\n"), /Presets/u);
+		cancelledTui.press("ctrl+c");
+		await cancelled;
+		assert.equal(readFileSync(path, "utf8"), original);
+		assert.equal(applied, 0);
+
+		const appliedTui = createTuiHarness({ width: 50, rows: 16 });
+		const appliedContext = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: appliedTui.custom,
+			confirm: async (_title: string, message: string) => {
+				confirmation = message;
+				return true;
+			},
+		});
+		const running = mock.commands.get("starship")?.handler("", appliedContext.ctx);
+		await appliedTui.waitForOpen();
+		appliedTui.press("tui.select.down");
+		appliedTui.press("tui.select.confirm");
+		await appliedTui.waitForOpen();
+		appliedTui.press("tui.select.confirm");
+		await appliedTui.waitForOpen();
+		appliedTui.press("tui.select.confirm");
+		await running;
+		assert.equal(readFileSync(path, "utf8"), STARSHIP_PRESETS[0]?.rawDocument);
+		assert.equal(applied, 1);
+		assert.match(confirmation, /Minimal/u);
+		assert.match(confirmation, /custom settings, unknown fields, and comments will be removed/iu);
+		assert.match(confirmation, /No backup is kept after success/u);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Customize before applying starts from the preset and saves the edited document", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preset-customize-"));
+	const path = join(root, "pi-starship.toml");
+	const bracketed = STARSHIP_PRESETS[1];
+	assert.ok(bracketed);
+	try {
+		const mock = createMockPi();
+		let editorDraft = "";
+		let applied = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loadStarshipConfig(path),
+			apply() {
+				applied += 1;
+			},
+			settingsPath: path,
+			renderPreview: (loaded) => [loaded.config.format],
+		});
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			editor: async (_title: string, draft: string) => {
+				editorDraft = draft;
+				return `${draft}# personalized\n`;
+			},
+			confirm: async () => true,
+		});
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.equal(editorDraft, bracketed.rawDocument);
+		assert.match(tui.render().join("\n"), /Bracketed preset preview/u);
+		tui.press("tui.select.confirm");
+		await running;
+		assert.equal(readFileSync(path, "utf8"), `${bracketed.rawDocument}# personalized\n`);
+		assert.equal(applied, 1);
+		assert.match(
+			context.notifications.at(-1)?.message ?? "",
+			/Bracketed preset saved and applied/u,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("an invalid customized preset returns to preset recovery without changing the footer", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preset-invalid-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mock = createMockPi();
+		let applied = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loadStarshipConfig(path),
+			apply() {
+				applied += 1;
+			},
+			settingsPath: path,
+		});
+		const tui = createTuiHarness({ width: 50, rows: 16 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			editor: async () => "format = [",
+		});
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const errorFrame = tui.render().join("\n");
+		assert.match(errorFrame, /Preset needs attention/u);
+		assert.match(errorFrame, /Continue editing/u);
+		assert.match(errorFrame, /Choose another preset/u);
+		assert.match(context.notifications.at(-1)?.message ?? "", /Preset draft is invalid/u);
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Presets/u);
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(existsSync(path), false);
+		assert.equal(applied, 0);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("Configuration combines state, source, path, health, and diagnostics", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-configuration-"));
 	const path = join(root, "pi-starship.toml");
@@ -79,7 +307,7 @@ test("Configuration combines state, source, path, health, and diagnostics", asyn
 		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 		const running = mock.commands.get("starship")?.handler("", context.ctx);
 		await tui.waitForOpen();
-		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+		for (let index = 0; index < 4; index += 1) tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		const frame = tui.render().join("\n");
@@ -119,7 +347,7 @@ test("healthy missing settings disable restore without creating a document", asy
 		});
 		const running = mock.commands.get("starship")?.handler("", context.ctx);
 		await tui.waitForOpen();
-		for (let index = 0; index < 5; index += 1) tui.press("tui.select.down");
+		for (let index = 0; index < 6; index += 1) tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Already using defaults · no file to replace/u);

--- a/packages/pi-starship/test/command-ux.test.ts
+++ b/packages/pi-starship/test/command-ux.test.ts
@@ -8,7 +8,7 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerStarshipCommand } from "../src/commands.js";
-import { BUILT_IN_EXAMPLE, loadStarshipConfig } from "../src/config.js";
+import { BUILT_IN_EXAMPLE, type LoadedStarshipConfig, loadStarshipConfig } from "../src/config.js";
 import { STARSHIP_PRESETS } from "../src/presets/catalog.js";
 
 test("/starship distinguishes built-in defaults, saved built-in, custom, and fallback states", async () => {
@@ -73,11 +73,16 @@ test("Presets stays shallow, identifies the exact active document, and restores 
 	writeFileSync(path, minimal.rawDocument);
 	try {
 		const mock = createMockPi();
-		registerStarshipCommand(mock.pi, {
+		const previewed: Array<string | undefined> = [];
+		const commandOptions = {
 			getLoaded: () => loadStarshipConfig(path),
 			apply() {},
+			preview(next: LoadedStarshipConfig | undefined) {
+				previewed.push(next && presetForRawDocument(next.rawDocument));
+			},
 			settingsPath: path,
-		});
+		};
+		registerStarshipCommand(mock.pi, commandOptions);
 		const tui = createTuiHarness({ width: 40, rows: 18 });
 		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 		const running = mock.commands.get("starship")?.handler("", context.ctx);
@@ -102,9 +107,10 @@ test("Presets stays shallow, identifies the exact active document, and restores 
 		assert.match(full, /Nerd Font Symbols/u);
 		assert.match(full, /Currently applied/u);
 		assert.match(full, /\(1\/13\)/u);
+		assert.deepEqual(previewed, ["minimal"]);
 		tui.press("tui.select.confirm");
 		await flushAsyncWork();
-		assert.match(tui.render().join("\n"), /^Presets/mu);
+		assert.match(tui.render().join("\n"), /Presets · current:/u);
 		for (let index = 0; index < STARSHIP_PRESETS.length - 1; index += 1) {
 			tui.press("tui.select.down");
 		}
@@ -112,12 +118,51 @@ test("Presets stays shallow, identifies the exact active document, and restores 
 		assert.match(lastPreset, /Tokyo Night/u);
 		assert.match(lastPreset, /requires Nerd Font/u);
 		assert.match(lastPreset, /\(13\/13\)/u);
+		assert.equal(previewed.at(-1), "tokyo-night");
 		tui.press("tui.select.cancel");
 		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /→ Presets/u);
 		tui.press("ctrl+c");
 		await running;
 		assert.equal(readFileSync(path, "utf8"), minimal.rawDocument);
+		assert.equal(previewed.at(-1), undefined);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("live preset preview restores on Ctrl+C and external disposal", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preset-preview-exit-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		for (const exit of ["close", "dispose"] as const) {
+			const mock = createMockPi();
+			const previewed: Array<string | undefined> = [];
+			const commandOptions = {
+				getLoaded: () => loadStarshipConfig(path),
+				apply() {
+					assert.fail("Browsing presets must not apply settings");
+				},
+				preview(next: LoadedStarshipConfig | undefined) {
+					previewed.push(next && presetForRawDocument(next.rawDocument));
+				},
+				settingsPath: path,
+			};
+			registerStarshipCommand(mock.pi, commandOptions);
+			const tui = createTuiHarness({ width: 50, rows: 16 });
+			const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+			const running = mock.commands.get("starship")?.handler("", context.ctx);
+			await tui.waitForOpen();
+			tui.press("tui.select.down");
+			tui.press("tui.select.confirm");
+			await tui.waitForOpen();
+			assert.equal(previewed.at(-1), "minimal");
+			if (exit === "close") tui.press("ctrl+c");
+			else tui.dispose();
+			await running;
+			assert.equal(previewed.at(-1), undefined, exit);
+			assert.equal(existsSync(path), false, exit);
+		}
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -132,40 +177,44 @@ test("preset preview cancellation is inert and confirmed apply replaces atomical
 		const mock = createMockPi();
 		let applied = 0;
 		let confirmation = "";
-		registerStarshipCommand(mock.pi, {
+		const previewed: Array<string | undefined> = [];
+		const commandOptions = {
 			getLoaded: () => loadStarshipConfig(path),
 			apply() {
 				applied += 1;
 			},
+			preview(next: LoadedStarshipConfig | undefined) {
+				previewed.push(next && presetForRawDocument(next.rawDocument));
+			},
 			settingsPath: path,
-			renderPreview: (loaded) => [loaded.config.format],
-		});
+			renderPreview: (loaded: LoadedStarshipConfig) => [loaded.config.format],
+		};
+		registerStarshipCommand(mock.pi, commandOptions);
 
 		const cancelledTui = createTuiHarness({ width: 50, rows: 16 });
 		const cancelledContext = createMockContext({
 			mode: "tui",
 			hasUI: true,
 			custom: cancelledTui.custom,
-			confirm: async () => true,
+			confirm: async () => false,
 		});
 		const cancelled = mock.commands.get("starship")?.handler("", cancelledContext.ctx);
 		await cancelledTui.waitForOpen();
 		cancelledTui.press("tui.select.down");
 		cancelledTui.press("tui.select.confirm");
 		await cancelledTui.waitForOpen();
+		assert.equal(previewed.at(-1), "minimal");
 		cancelledTui.press("tui.select.confirm");
 		await cancelledTui.waitForOpen();
-		assert.match(cancelledTui.render().join("\n"), /Minimal preset preview/u);
-		assert.match(cancelledTui.render().join("\n"), /Apply Minimal preset…/u);
-		assert.match(cancelledTui.render().join("\n"), /Customize before applying/u);
-		assert.match(cancelledTui.render().join("\n"), /Choose another preset/u);
-		cancelledTui.press("tui.select.cancel");
-		await cancelledTui.waitForOpen();
-		assert.match(cancelledTui.render().join("\n"), /Presets/u);
+		assert.equal(readFileSync(path, "utf8"), original);
+		assert.equal(applied, 0);
+		assert.equal(previewed.at(-1), undefined);
+		assert.match(cancelledTui.render().join("\n"), /→ Presets/u);
 		cancelledTui.press("ctrl+c");
 		await cancelled;
 		assert.equal(readFileSync(path, "utf8"), original);
 		assert.equal(applied, 0);
+		assert.equal(previewed.at(-1), undefined);
 
 		const appliedTui = createTuiHarness({ width: 50, rows: 16 });
 		const appliedContext = createMockContext({
@@ -183,14 +232,60 @@ test("preset preview cancellation is inert and confirmed apply replaces atomical
 		appliedTui.press("tui.select.confirm");
 		await appliedTui.waitForOpen();
 		appliedTui.press("tui.select.confirm");
-		await appliedTui.waitForOpen();
-		appliedTui.press("tui.select.confirm");
 		await running;
 		assert.equal(readFileSync(path, "utf8"), STARSHIP_PRESETS[0]?.rawDocument);
 		assert.equal(applied, 1);
 		assert.match(confirmation, /Minimal/u);
 		assert.match(confirmation, /custom settings, unknown fields, and comments will be removed/iu);
 		assert.match(confirmation, /No backup is kept after success/u);
+		assert.equal(previewed.at(-1), undefined);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("failed direct preset apply clears the preview and preserves the previous footer", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-command-preset-failed-apply-"));
+	const path = join(root, "pi-starship.toml");
+	const original = "format = 'custom'\n";
+	writeFileSync(path, original);
+	try {
+		const previewed: Array<string | undefined> = [];
+		const mock = createMockPi();
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loadStarshipConfig(path),
+			apply() {
+				assert.fail("Failed save must not apply settings");
+			},
+			preview(next: LoadedStarshipConfig | undefined) {
+				previewed.push(next && presetForRawDocument(next.rawDocument));
+			},
+			save() {
+				throw new Error("publish failed");
+			},
+			settingsPath: path,
+		});
+		const tui = createTuiHarness({ width: 50, rows: 16 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			confirm: async () => true,
+		});
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.equal(previewed.at(-1), "minimal");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.equal(previewed.at(-1), undefined);
+		assert.equal(readFileSync(path, "utf8"), original);
+		assert.match(context.notifications.at(-1)?.message ?? "", /publish failed/u);
+		assert.match(tui.render().join("\n"), /→ Presets/u);
+		tui.press("ctrl+c");
+		await running;
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -230,10 +325,7 @@ test("Customize before applying starts from the preset and saves the edited docu
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		tui.press("tui.select.down");
-		tui.press("tui.select.confirm");
-		await tui.waitForOpen();
-		tui.press("tui.select.down");
-		tui.press("tui.select.confirm");
+		tui.send("e");
 		await tui.waitForOpen();
 		assert.equal(editorDraft, bracketed.rawDocument);
 		assert.match(tui.render().join("\n"), /Bracketed Segments preset preview/u);
@@ -275,10 +367,7 @@ test("an invalid customized preset returns to preset recovery without changing t
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
-		tui.press("tui.select.confirm");
-		await tui.waitForOpen();
-		tui.press("tui.select.down");
-		tui.press("tui.select.confirm");
+		tui.send("e");
 		await tui.waitForOpen();
 		const errorFrame = tui.render().join("\n");
 		assert.match(errorFrame, /Preset needs attention/u);
@@ -404,6 +493,57 @@ test("preview remains operable across terminal sizes and dynamic resize", async 
 		assert.match(tui.render().join("\n"), /Continue editing/u);
 		tui.press("tui.select.down");
 		assert.match(tui.render().join("\n"), /Discard draft/u);
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("preset picker uses injected navigation bindings and exposes their hints", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-preset-picker-keys-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const mapping: Record<string, string> = {
+			"tui.select.up": "k",
+			"tui.select.down": "j",
+			"tui.select.pageUp": "u",
+			"tui.select.pageDown": "d",
+			"tui.select.confirm": "y",
+			"tui.select.cancel": "q",
+		};
+		const keybindings: Pick<KeybindingsManager, "matches" | "getKeys"> = {
+			matches: (data, binding) => data === mapping[binding],
+			getKeys: (binding) => (mapping[binding] ? [mapping[binding] as never] : []),
+		};
+		const previewed: Array<string | undefined> = [];
+		const mock = createMockPi();
+		const commandOptions = {
+			getLoaded: () => loadStarshipConfig(path),
+			apply() {},
+			preview(next: LoadedStarshipConfig | undefined) {
+				previewed.push(next && presetForRawDocument(next.rawDocument));
+			},
+			settingsPath: path,
+		};
+		registerStarshipCommand(mock.pi, commandOptions);
+		const tui = createTuiHarness({ width: 50, rows: 16, keybindings });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		tui.send("j");
+		tui.send("y");
+		await tui.waitForOpen();
+		const frame = tui.render().join("\n");
+		assert.match(frame, /k\/j live preview/u);
+		assert.match(frame, /y apply/u);
+		assert.match(frame, /q\s+back/u);
+		tui.send("j");
+		assert.equal(previewed.at(-1), "bracketed-segments");
+		tui.send("q");
+		await tui.waitForOpen();
+		assert.equal(previewed.at(-1), undefined);
 		tui.press("ctrl+c");
 		await running;
 		assert.equal(existsSync(path), false);
@@ -584,6 +724,10 @@ test("external preview disposal cancels without saving", async () => {
 		rmSync(root, { recursive: true, force: true });
 	}
 });
+
+function presetForRawDocument(rawDocument: string | undefined): string | undefined {
+	return STARSHIP_PRESETS.find((preset) => preset.rawDocument === rawDocument)?.id;
+}
 
 async function flushAsyncWork() {
 	await new Promise<void>((resolve) => setImmediate(resolve));

--- a/packages/pi-starship/test/command-ux.test.ts
+++ b/packages/pi-starship/test/command-ux.test.ts
@@ -97,16 +97,21 @@ test("Presets stays shallow, identifies the exact active document, and restores 
 		}
 		const full = tui.render().join("\n");
 		assert.match(full, /Minimal/u);
-		assert.match(full, /Bracketed/u);
+		assert.match(full, /Bracketed Segments/u);
+		assert.match(full, /Catppuccin Powerline/u);
 		assert.match(full, /Nerd Font Symbols/u);
-		assert.match(full, /Tokyo Night/u);
 		assert.match(full, /Currently applied/u);
+		assert.match(full, /\(1\/13\)/u);
 		tui.press("tui.select.confirm");
 		await flushAsyncWork();
 		assert.match(tui.render().join("\n"), /^Presets/mu);
-		tui.press("tui.select.down");
-		tui.press("tui.select.down");
-		assert.match(tui.render().join("\n"), /requires Nerd Font/u);
+		for (let index = 0; index < STARSHIP_PRESETS.length - 1; index += 1) {
+			tui.press("tui.select.down");
+		}
+		const lastPreset = tui.render().join("\n");
+		assert.match(lastPreset, /Tokyo Night/u);
+		assert.match(lastPreset, /requires Nerd Font/u);
+		assert.match(lastPreset, /\(13\/13\)/u);
 		tui.press("tui.select.cancel");
 		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /→ Presets/u);
@@ -231,14 +236,14 @@ test("Customize before applying starts from the preset and saves the edited docu
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		assert.equal(editorDraft, bracketed.rawDocument);
-		assert.match(tui.render().join("\n"), /Bracketed preset preview/u);
+		assert.match(tui.render().join("\n"), /Bracketed Segments preset preview/u);
 		tui.press("tui.select.confirm");
 		await running;
 		assert.equal(readFileSync(path, "utf8"), `${bracketed.rawDocument}# personalized\n`);
 		assert.equal(applied, 1);
 		assert.match(
 			context.notifications.at(-1)?.message ?? "",
-			/Bracketed preset saved and applied/u,
+			/Bracketed Segments preset saved and applied/u,
 		);
 	} finally {
 		rmSync(root, { recursive: true, force: true });

--- a/packages/pi-starship/test/commands.test.ts
+++ b/packages/pi-starship/test/commands.test.ts
@@ -61,6 +61,7 @@ test("/starship keeps direct routes and opens a stateful narrow TUI menu", async
 	assert.match(screen, /Saved built-in configuration/u);
 	assert.match(screen, /Healthy/u);
 	assert.match(screen, /Customize footer/u);
+	assert.match(screen, /Presets/u);
 	assert.match(screen, /Configuration/u);
 	assert.match(screen, /Help/u);
 	assert.match(screen, /Restore built-in…/u);
@@ -98,6 +99,7 @@ test("Explain consumes the current snapshot without starting collection work", a
 
 		const running = mock.commands.get("starship")?.handler("", context.ctx);
 		await tui.waitForOpen();
+		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
@@ -623,7 +625,8 @@ test("main and Configuration menus expose current state and a clear Back path", 
 		mode: "tui",
 		hasUI: true,
 		custom: async (factory: unknown) => {
-			const inputs = call === 0 ? ["\u001b[B", "\u001b[B", "\u001b[B", "\r"] : ["\u001b"];
+			const inputs =
+				call === 0 ? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"] : ["\u001b"];
 			const driven = driveCustomSelector(factory, inputs, 26);
 			screens[call++] = driven.renders.flat().join("\n");
 			assert.ok(driven.renders.flat().every((line) => visibleWidth(line) <= 26));
@@ -663,7 +666,9 @@ test("Restore previews, confirms, and atomically applies the built-in footer", a
 			hasUI: true,
 			custom: async (factory: unknown) => {
 				const inputs =
-					call === 0 ? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"] : ["\r"];
+					call === 0
+						? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"]
+						: ["\r"];
 				const driven = driveCustomSelector(factory, inputs, 32);
 				if (call === 1) restorePreview = driven.renders.flat().join("\n");
 				call += 1;
@@ -718,7 +723,7 @@ test("Restore recovers a malformed settings document", async () => {
 			custom: async (factory: unknown) => {
 				const inputs =
 					call++ === 0
-						? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"]
+						? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"]
 						: ["\r"];
 				return driveCustomSelector(factory, inputs, 60).result;
 			},
@@ -835,7 +840,7 @@ test("restore preview cancellation preserves exact settings and runtime in a nar
 		});
 		const running = mock.commands.get("starship")?.handler("", context.ctx);
 		await tui.waitForOpen();
-		for (let index = 0; index < 5; index += 1) tui.press("tui.select.down");
+		for (let index = 0; index < 6; index += 1) tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		const preview = tui.render();

--- a/packages/pi-starship/test/config.test.ts
+++ b/packages/pi-starship/test/config.test.ts
@@ -28,12 +28,32 @@ import { presetForDocument, STARSHIP_PRESETS } from "../src/presets/catalog.js";
 test("bundled presets are distinct, valid, and limited to local core modules", () => {
 	assert.deepEqual(
 		STARSHIP_PRESETS.map((preset) => preset.id),
-		["minimal", "bracketed", "nerd-font-symbols", "tokyo-night"],
+		[
+			"minimal",
+			"bracketed-segments",
+			"catppuccin-powerline",
+			"gruvbox-rainbow",
+			"jetpack",
+			"nerd-font-symbols",
+			"no-empty-icons",
+			"no-nerd-font",
+			"no-runtime-versions",
+			"pastel-powerline",
+			"plain-text-symbols",
+			"pure-preset",
+			"tokyo-night",
+		],
 	);
 	assert.equal(new Set(STARSHIP_PRESETS.map((preset) => preset.id)).size, STARSHIP_PRESETS.length);
 	assert.deepEqual(
-		STARSHIP_PRESETS.map((preset) => preset.requiresNerdFont),
-		[false, false, true, true],
+		STARSHIP_PRESETS.filter((preset) => preset.requiresNerdFont).map((preset) => preset.id),
+		[
+			"catppuccin-powerline",
+			"gruvbox-rainbow",
+			"nerd-font-symbols",
+			"pastel-powerline",
+			"tokyo-night",
+		],
 	);
 
 	const allowedModules = new Set([
@@ -42,6 +62,7 @@ test("bundled presets are distinct, valid, and limited to local core modules", (
 		"thinking",
 		"directory",
 		"git_branch",
+		"git_state",
 		"git_status",
 		"activity",
 		"context",

--- a/packages/pi-starship/test/config.test.ts
+++ b/packages/pi-starship/test/config.test.ts
@@ -22,6 +22,45 @@ import {
 	settingsFilePath,
 	validateConfigDocument,
 } from "../src/config.js";
+import { reachableModuleRequirements } from "../src/modules/index.js";
+import { presetForDocument, STARSHIP_PRESETS } from "../src/presets/catalog.js";
+
+test("bundled presets are distinct, valid, and limited to local core modules", () => {
+	assert.deepEqual(
+		STARSHIP_PRESETS.map((preset) => preset.id),
+		["minimal", "bracketed", "nerd-font-symbols", "tokyo-night"],
+	);
+	assert.equal(new Set(STARSHIP_PRESETS.map((preset) => preset.id)).size, STARSHIP_PRESETS.length);
+	assert.deepEqual(
+		STARSHIP_PRESETS.map((preset) => preset.requiresNerdFont),
+		[false, false, true, true],
+	);
+
+	const allowedModules = new Set([
+		"brand",
+		"model",
+		"thinking",
+		"directory",
+		"git_branch",
+		"git_status",
+		"activity",
+		"context",
+		"time",
+		"fill",
+	]);
+	for (const preset of STARSHIP_PRESETS) {
+		const loaded = validateConfigDocument(`/presets/${preset.id}.toml`, preset.rawDocument);
+		assert.deepEqual(loaded.diagnostics, [], preset.id);
+		assert.ok(preset.label.length > 0, preset.id);
+		assert.ok(preset.description.length > 0, preset.id);
+		for (const name of reachableModuleRequirements(loaded.config).keys()) {
+			assert.equal(allowedModules.has(name), true, `${preset.id}: ${name}`);
+		}
+		assert.equal(presetForDocument(preset.rawDocument)?.id, preset.id);
+		assert.equal(presetForDocument(`${preset.rawDocument}\n`), undefined);
+	}
+	assert.equal(presetForDocument(undefined), undefined);
+});
 
 test("config path uses the agent directory and missing settings use built-in defaults", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-config-"));

--- a/packages/pi-starship/test/modules.test.ts
+++ b/packages/pi-starship/test/modules.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { sep } from "node:path";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { BUILT_IN_CONFIG } from "../src/config.js";
+import { BUILT_IN_CONFIG, validateConfigDocument } from "../src/config.js";
 import { parseFormat } from "../src/format/formatter.js";
 import {
 	formatCount,
@@ -11,6 +11,7 @@ import {
 	type StarshipRuntimeSnapshot,
 	shortenModel,
 } from "../src/modules/index.js";
+import { STARSHIP_PRESETS } from "../src/presets/catalog.js";
 
 const ESC = String.fromCharCode(27);
 const LINK = "\x1b]8;;https://github.com/o/r/pull/123\x07#123\x1b]8;;\x07";
@@ -83,6 +84,24 @@ function fixture(overrides: Partial<StarshipRuntimeSnapshot> = {}): StarshipRunt
 		...overrides,
 	};
 }
+
+test("bundled presets render their promised Pi-native information", () => {
+	const plainById = new Map(
+		STARSHIP_PRESETS.map((preset) => {
+			const loaded = validateConfigDocument(`/presets/${preset.id}.toml`, preset.rawDocument);
+			return [preset.id, stripAnsi(renderStatusline(loaded.config, fixture(), 80).ansi)];
+		}),
+	);
+	assert.match(plainById.get("minimal") ?? "", /sonnet-4.*pi-extensions.*feature.*read/u);
+	assert.doesNotMatch(plainById.get("minimal") ?? "", /π|75\.0%|09:05/u);
+	assert.match(plainById.get("bracketed") ?? "", /\[π\].*\[AI sonnet-4\].*\[09:05\]/u);
+	assert.match(plainById.get("nerd-font-symbols") ?? "", /.*󰚩.*󰉋.*.*/u);
+	assert.match(plainById.get("tokyo-night") ?? "", /.*.*󰚩.*󰉋.*.*󰑮.*󰍛.*/u);
+	for (const [id, rendered] of plainById) {
+		assert.ok(rendered.length > 0, id);
+		assert.doesNotMatch(rendered, /undefined|\$[a-z_]+/u, id);
+	}
+});
 
 test("built-in root renders exactly the reachable nine module categories without backgrounds", () => {
 	const rendered = renderStatusline(BUILT_IN_CONFIG, fixture());

--- a/packages/pi-starship/test/modules.test.ts
+++ b/packages/pi-starship/test/modules.test.ts
@@ -94,9 +94,25 @@ test("bundled presets render their promised Pi-native information", () => {
 	);
 	assert.match(plainById.get("minimal") ?? "", /sonnet-4.*pi-extensions.*feature.*read/u);
 	assert.doesNotMatch(plainById.get("minimal") ?? "", /π|75\.0%|09:05/u);
-	assert.match(plainById.get("bracketed") ?? "", /\[π\].*\[AI sonnet-4\].*\[09:05\]/u);
+	assert.match(plainById.get("bracketed-segments") ?? "", /\[π\].*\[AI sonnet-4\].*\[09:05\]/u);
+	assert.match(plainById.get("catppuccin-powerline") ?? "", /.*.*sonnet-4.*.*/u);
+	assert.match(plainById.get("gruvbox-rainbow") ?? "", /.*.*sonnet-4.*.*/u);
+	assert.match(plainById.get("jetpack") ?? "", /◄.*read.*◯ 75\.0%.*pi-extensions.*△ feature/u);
 	assert.match(plainById.get("nerd-font-symbols") ?? "", /.*󰚩.*󰉋.*.*/u);
-	assert.match(plainById.get("tokyo-night") ?? "", /.*.*󰚩.*󰉋.*.*󰑮.*󰍛.*/u);
+	assert.match(plainById.get("no-empty-icons") ?? "", /model sonnet-4.*in \/work\/pi-extensions/u);
+	assert.match(
+		plainById.get("no-nerd-font") ?? "",
+		/✦.*◆ sonnet-4.*⌂ \/work\/pi-extensions.*◴ 09:05/u,
+	);
+	assert.doesNotMatch(plainById.get("no-runtime-versions") ?? "", /sonnet-4|high/u);
+	assert.match(plainById.get("no-runtime-versions") ?? "", /π.*AI.*think.*pi-extensions/u);
+	assert.match(plainById.get("pastel-powerline") ?? "", /.*.*sonnet-4.*.*/u);
+	assert.match(
+		plainById.get("plain-text-symbols") ?? "",
+		/pi.*model sonnet-4.*dir \/work\/pi-extensions.*git feature/u,
+	);
+	assert.match(plainById.get("pure-preset") ?? "", /pi-extensions feature.*\nsonnet-4 high/u);
+	assert.match(plainById.get("tokyo-night") ?? "", /░▒▓.*.*sonnet-4.*.*.*󰑮.*󰍛.*/u);
 	for (const [id, rendered] of plainById) {
 		assert.ok(rendered.length > 0, id);
 		assert.doesNotMatch(rendered, /undefined|\$[a-z_]+/u, id);


### PR DESCRIPTION
## Summary

- add Pi-native adaptations of all 12 preset styles emitted by Starship 1.26.0, plus a Minimal preset
- preserve each preset's color/layout treatment while choosing only local Pi and Git snapshot modules
- add a shallow `/starship` preset browser with exact active-state detection, adaptive paging/preview, optional TOML customization, explicit replacement confirmation, and existing atomic rollback
- preserve built-in recovery and direct/non-TUI routes; document font requirements, adaptation semantics, attribution, and minor release intent

## Verification

- TDD catalog red state identified the nine missing upstream styles and obsolete `bracketed` ID
- `npm run check --workspace @narumitw/pi-starship`
- `npm run check` (2,542 tests)
- deterministic 13-item TUI catalog and rendering coverage at 20, 40, and 80 columns
- `npm run changeset:status` (only `@narumitw/pi-starship` minor to 0.50.0)
- `just pack starship` (78 files, 81.1 kB packed / 301.5 kB unpacked)
- Pi 0.84.1 RPC source-entry/help smoke with a side-effect-free temporary agent directory

A real-terminal Nerd Font visual smoke was not run; preset rendering and glyph content are covered deterministically. No npm publish, visibility, tag, or release workflow action was performed.
