### PR TITLE
feat(tui-kit): add live choice interactions

### DIFF
--- a/.changeset/calm-moons-preview.md
+++ b/.changeset/calm-moons-preview.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add a standalone live-choice interaction, shared choice-selection behavior, and generic interaction-hint formatting.

--- a/docs/plans/archived/2026-08-08_pi-tui-kit-live-choice-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-tui-kit-live-choice-plan.md
@@ -1,0 +1,74 @@
+# Pi TUI Kit live choice plan
+
+## Goal
+
+Add a reusable standalone live-choice interaction, a shared internal selection controller, and a
+public interaction-hint formatter to `@narumitw/pi-tui-kit`, while keeping preview state,
+persistence, confirmation, rollback, and session ownership in consuming extensions.
+
+## Architecture
+
+- `runLiveChoice()` owns TUI/RPC adaptation, injected-key navigation, typed interaction outcomes,
+  custom shortcut dispatch, disposal, and pending preview-callback draining.
+- A package-internal selection controller owns stable-ID selection, wrapping single-step movement,
+  clamped paging, Home/End behavior, and empty-list safety for both declarative choice screens and
+  standalone live choices.
+- `formatInteractionHints()` owns keybinding lookup, key-name normalization, terminal sanitization,
+  exclusions, and de-duplication. It does not own product wording.
+- Existing declarative `choice` screens remain side-effect-free. `pi-starship` and `pi-statusline`
+  migrations are deferred until the new Kit API is published, as required by the repository release
+  boundary.
+
+## Non-Goals
+
+- Move extension-owned preview snapshots, save/apply logic, rollback, collectors, or session
+  generations into the Kit.
+- Change existing declarative `ChoiceScreen` cursor semantics or public menu behavior.
+- Publish the package or migrate a consumer in this branch.
+
+## Plan
+
+- [x] Record the existing Pi TUI Kit focused-test baseline and map the touched custom-interaction,
+      TUI, RPC, public-API, documentation, and package verification rules; the compiled package suite
+      passed 147 tests before implementation. Applicable MUST rules: TUI-only `custom()`, bounded and
+      sanitized rendering, injected keybindings, cancellation/disposal/draining, stale-context
+      revalidation, deterministic tests, CI gate, Changeset release intent, package smoke, and no
+      consumer adoption before the Kit API is published.
+- [x] Add failing public-contract tests for `formatInteractionHints()` covering injected bindings,
+      aliases, control sanitization, exclusions, and de-duplication; TypeScript initially failed on
+      the missing export, then the focused test passed 2 tests.
+- [x] Add selection characterization coverage, extract the internal stable-ID selection controller,
+      and make the existing choice component use it without behavior changes; existing code already
+      satisfied the corrected wrap/page/Home/End/empty-list contract, and all 38 focused screen
+      component tests passed after extraction.
+- [x] Add failing `runLiveChoice()` TUI tests for initial/cursor preview, wrap/page/Home/End movement,
+      current and disabled rows, confirmation, custom shortcuts, Back/Close, bounded sanitized
+      rendering, callback draining, cancellation, disposal, stale ownership, and errors; the initial
+      compile failed on the missing API and the completed focused live-choice suite passed.
+- [x] Add failing `runLiveChoice()` RPC and unsupported-mode tests proving deterministic ordinary
+      selection without live preview or shortcut execution, disabled-row handling, stale ownership,
+      and typed unsupported/error outcomes; all 9 focused live-choice tests passed across TUI, RPC,
+      unsupported, stale, disposal, callback-draining, and error paths.
+- [x] Export and document all three APIs, update API compatibility metadata and package release
+      intent, and verify README type examples with package typechecking and build; API version 9,
+      public root export smoke, package check/build, context type tests, README usage types, and the
+      Kit-only minor Changeset all passed.
+- [x] Audit the final diff against `docs/extension-conventions.md`: `runLiveChoice()` guards TUI
+      custom UI by mode, uses injected navigation, inherits width-safe sanitized choice rendering,
+      aborts and drains previews on every exit, blocks stale cursor callbacks, and revalidates after
+      awaited previews; RPC is signal-aware and deterministic; graph evidence found no production
+      consumer adoption; boundary checks and the Kit-only Changeset passed. No deviation accepted.
+
+## Completion Checklist
+
+- [x] The final root suite passed all 2,562 tests, including the complete compiled Pi TUI Kit suite.
+- [x] `npm run check` passed after temporarily moving the pre-existing untracked `dev/` directory
+      outside the worktree so Biome would not inspect those unrelated local runtime files; `dev/` was
+      restored unchanged immediately afterward.
+- [x] `just pack tui-kit` succeeds; the final dry-run contained 57 declared files (48.8 kB packed,
+      222.2 kB unpacked), including built JavaScript/declarations, README, license, and manifest.
+- [x] The completed plan is archived at
+      `docs/plans/archived/2026-08-08_pi-tui-kit-live-choice-plan.md` with all evidence recorded.
+- [x] Final status/diff inspection found only the Kit implementation, tests, README, roadmap
+      alignment, Changeset, and this plan; the pre-existing untracked `dev/` directory remains
+      present and untouched.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -1,14 +1,14 @@
 # Pi TUI Kit Roadmap
 
-- **Status:** Current evidence-qualified sequence complete through Pi 0.84.1; future capabilities
-  require new evidence and an approved plan
+- **Status:** Source API 9 live-choice capability is complete and verified; publication and
+  post-publication consumer migrations remain gated
 - **Audience:** Pi TUI Kit maintainers and extension authors
 - **Planning horizon:** The reviewed Pi 0.84.1 capability baseline; no delivery dates are committed
-- **Repository source:** Menu API version 8 with standalone confirmation, explanatory disabled
-  action rows, read-only browse, lifecycle-safe custom interactions, adaptive review, distinct root
-  Back/Close results, and a supported `/testing` subpath
-- **Published status:** Derive the current release from the npm badge, registry, and package manifest;
-  this roadmap does not pin a transient package version
+- **Repository source:** API version 9 adds standalone live choice, generic interaction hints, and
+  shared choice selection behavior to the API-8 confirmation, browse, custom-interaction, adaptive
+  review, distinct Back/Close, disabled-action, and `/testing` foundations
+- **Published status:** API 8 is published; API 9 must publish independently before any consumer
+  raises its compatibility floor
 - **Migration evidence:** Maintained package/consumer tests and the stable PR references in the
   decision log below
 
@@ -38,23 +38,31 @@ handling.
   and domain actions.
 - Centralize custom-component cancellation, disposal, stale-owner classification, and pending-work
   draining without absorbing the specialized component or its domain result.
+- Provide a bounded live-choice lifecycle shell when cursor selection is the reusable interaction,
+  while keeping preview snapshots, rollback, persistence, and final apply policy consumer-owned.
+- Keep injected-key hint formatting and stable-ID selection behavior consistent without making
+  declarative choice screens side-effecting.
 - Keep package source imports from Pi private `dist/*` paths at zero through every roadmap phase.
 
 ## Current State
 
 The maintained package exposes eight declarative screen kinds: `actions`, `detail`, `browse`,
-`choice`, `settings`, `input`, `review`, and `multiSelect`. It also exposes:
+`choice`, `settings`, `input`, `review`, and `multiSelect`. Source API 9 also exposes:
 
 - `runTask()` for abort-aware work with a TUI loader;
 - `runConfirmation()` for distinct Confirmed, Back, Close, Stale, Unsupported, and Error outcomes;
+- `runLiveChoice()` for initial and cursor preview callbacks, typed selection/shortcut/exit outcomes,
+  lifecycle draining, and deterministic ordinary RPC selection;
+- `formatInteractionHints()` for sanitized injected bindings and literal shortcuts;
 - `runCustomInteraction()` for lifecycle ownership around one extension-owned specialized
   component; and
 - a supported `/testing` subpath for semantic TUI driving and strict RPC scripts.
 
-Published menu API version 8 includes distinct root Back/Close results, adaptive review, read-only
-browse, custom-interaction lifecycle handling, standalone confirmation, and explanatory disabled
-action rows. The internal interaction driver owns shared semantic action coordination once for both
-modes while adapters retain TUI component and RPC dialog cadence.
+Published API 8 includes distinct root Back/Close results, adaptive review, read-only browse,
+custom-interaction lifecycle handling, standalone confirmation, and explanatory disabled action
+rows. Source API 9 adds live choice and hint formatting without changing declarative `choice`
+cursor semantics. The internal interaction driver owns shared semantic action coordination once for
+both modes while adapters retain TUI component and RPC dialog cadence.
 
 Representative migrations prove the shipped boundaries: Usage uses `runTask()`; Stamp uses
 validated input; Image Drop composes input, review, and confirmation; Starship uses read-only browse;
@@ -68,11 +76,14 @@ dialog inventory likewise admitted no new API: one-off values use Pi primitives,
 authentication sequences remain domain transactions, boolean confirmation stays direct unless richer
 outcomes are required, and multi-line editing remains extension-owned.
 
-The Pi 0.84.1 review found no additional Kit capability to admit or shipped screen to retire.
-Action-bearing and live async catalogs, live previews, reorderable lists, forms, and editors still
-lack two compatible consumer contracts or the required public Pi lifecycle surface. Public `Input`,
-`SelectList`, `SettingsList`, and `ScrollView` remain useful low-level building blocks but do not own
-the Kit's cross-mode, cancellation, navigation, rollback, or stale-owner policy.
+The original Pi 0.84.1 review found no additional Kit capability to admit or shipped screen to
+retire. Subsequent Starship preset work converged with Statusline's palette picker on a bounded live
+choice contract: initial/cursor preview, Enter confirmation, Back/Close distinction, owner
+cancellation, and consumer-owned snapshot restoration. Optional shortcut dispatch covers Starship's
+customize route without absorbing its save/apply transaction. Action-bearing async catalogs,
+reorderable lists, forms, and editors remain unqualified. Public `Input`, `SelectList`,
+`SettingsList`, and `ScrollView` remain useful low-level building blocks but do not own the Kit's
+cross-mode, cancellation, navigation, rollback, or stale-owner policy.
 
 Production and experimental consumers continue to use the Kit alongside direct Pi dialogs. Raw
 consumer and dialog counts are intentionally not pinned because they change independently of roadmap
@@ -117,9 +128,9 @@ requiring each extension to rebuild a TUI/RPC host.
 
 ### Evidence-Controlled Expansion
 
-Qualify standalone confirmation, deferred selection, and future screen patterns against compatible
-consumers. Keep wizards, editors, action-bearing catalogs, and previews specialized until their
-lifecycle contracts actually converge.
+Qualify standalone interactions and future screen patterns against compatible consumers. Keep
+wizards, editors, action-bearing catalogs, and preview workflows specialized until their lifecycle
+contracts converge; use live choice only for the now-proven bounded cursor-selection contract.
 
 ### Runtime Locality Without Speculative Layers
 
@@ -243,9 +254,10 @@ contract.
 - [x] Action-bearing and live async catalogs remain specialized: Recall's scoped searchable actions
   and File Context's asynchronous file/revision/diff workflow do not share an interaction or
   transaction contract. No compatible tree workflow was found.
-- [x] Live previews and reorderable lists remain specialized: Statusline's cursor-driven palette
-  preview and immediate-save segment ordering do not match Starship's edit/validate/preview/confirm
-  transaction. Setup and authentication forms remain domain-owned under the direct-dialog decision.
+- [x] At the Phase-5 review gate, live previews and reorderable lists remained specialized because
+  Statusline's palette picker and Starship's then-current transaction had not yet converged. Later
+  Starship preset evidence supersedes only the bounded live-choice part of this decision in Phase 6;
+  reorder and transaction policy remain extension-owned.
 - [x] Multi-line editor remains deferred after the latest Pi 0.84.1 review confirmed that
   `ctx.ui.editor()` still has no `AbortSignal`; reconsider only when Pi exposes an abort-aware
   cross-mode editor contract.
@@ -255,6 +267,34 @@ contract.
 
 **Outcome:** The kit continues to grow only where evidence supports durable leverage and removes local
 abstractions when Pi provides a better stable owner.
+
+### Phase 6: Bounded Live Choice
+
+**Status:** Source complete and verified as API 9; publication and consumer adoption remain gated.
+
+**Milestones:**
+
+- [x] Statusline palette selection and Starship preset selection demonstrate a compatible bounded
+  contract: initial and cursor preview, injected navigation, Enter confirmation, Back/Close,
+  stale-owner protection, and consumer-owned restoration and persistence.
+- [x] Source API 9 exposes `runLiveChoice()` with current/disabled rows, optional shortcuts, synchronous
+  preview immediacy, latest-selection coalescing for pending async previews, cancellation/disposal
+  draining, typed terminal outcomes, and ordinary signal-aware RPC selection without preview effects.
+- [x] One internal stable-ID selection controller owns wrap, paging, Home/End, and empty-list behavior
+  for declarative and live choices without making declarative cursor movement side-effecting.
+- [x] `formatInteractionHints()` owns injected-binding lookup, aliases, control sanitization,
+  exclusions, de-duplication, literal shortcuts, and separator policy; existing Kit menu and browse
+  hints consume it.
+- [x] API-root type tests, TUI/RPC/lifecycle coverage, the repository gate, and dry-run package
+  inspection verify the source contract and Kit-only release intent.
+- [ ] Publish API 9 through the independent Changesets release before raising a consumer's Kit floor.
+- [ ] After publication, migrate Statusline and Starship in independently reviewable consumer changes
+  that remove local selection/hint loops while preserving preview snapshots, rollback, settings,
+  confirmation, collectors, and session-generation ownership.
+
+**Outcome:** The source contract concentrates reusable cursor-selection and lifecycle policy. Once
+published and proven by both consumers, live preview pickers can delete duplicate interaction code
+without turning the Kit into a preview-state or transaction owner.
 
 ## Technical Health
 
@@ -268,9 +308,9 @@ abstractions when Pi provides a better stable owner.
   behavior matrix proves better locality and deletes coordination.
 - Maintain deterministic model, component, runtime, package-root usage, and README tests for every
   public contract.
-- Maintain a TUI/RPC behavior matrix across all declarative screens covering success, rejection, user
-  cancellation, component disposal, owner abort, `isCurrent()` failure, action failure, session
-  replacement, and shutdown.
+- Maintain a TUI/RPC behavior matrix across all declarative screens and standalone live choice
+  covering success, rejection, user cancellation, component disposal, owner abort, `isCurrent()`
+  failure, callback/action failure, session replacement, and shutdown.
 - Keep terminal sanitization and cell-aware width checks at the final display boundary while passing
   raw IDs and values separately.
 - Revalidate mutable state after every await before publishing UI or in-memory state.
@@ -300,6 +340,11 @@ abstractions when Pi provides a better stable owner.
 - **Consumer capability loss:** a standard flow may erase preview, rollback, selection restoration, or
   three-way cancellation. Mitigation: compare behavioral contracts before migration and preserve
   specialized flows on a no-go result.
+- **Preview continuation races:** a slow preview may finish after a newer cursor, owner replacement, or
+  exit. Mitigation: keep one drained latest-selection queue, abort through the interaction signal,
+  revalidate generation after awaits, and require consumers to honor the callback signal.
+- **Premature consumer adoption:** source API 9 is not yet a published compatibility floor.
+  Mitigation: publish the Kit-only Changeset first, then migrate consumers in later PRs.
 
 ## Success Metrics
 
@@ -317,9 +362,11 @@ abstractions when Pi provides a better stable owner.
 | Standalone confirmation | Image Drop locally distinguished confirm, Back, and Close; boolean dialogs collapsed cancellation intent | Published API 8 includes the API-7 confirmation contract preserving Confirmed, Back, Close, Stale, Unsupported, and Error without owning side effects | Phase 4 published and proven through Image Drop and Analytics |
 | Deferred multi-select transaction ownership | Pi Sync and Subagents both used Kit multi-select with extension-local drafts | Keep transactions extension-owned unless consumers converge on Save/Discard cadence, review, persistence, conflict recovery, and interactive RPC semantics | Phase 4 qualification complete; maintained Kit and consumer tests plus source/README contract review |
 | Direct-dialog admission pressure | Remaining calls mixed one-off prompts, domain transactions, boolean confirmations, and editors | Admit APIs from compatible lifecycle evidence, never raw call volume; reuse published confirmation only where richer outcomes are required | Phase 5 inventory complete; active-source recount, owner classification, and repository gate |
-| Specialized interaction pressure | Action-bearing and async catalogs, previews, reorderable lists, forms, and editors have incompatible or single-consumer contracts | Keep each specialized until two consumers prove compatible reusable policy | Phase 5 complete against maintained consumers; re-open on new evidence |
+| Specialized interaction pressure | Action-bearing and async catalogs, reorderable lists, forms, editors, and preview workflows beyond bounded choice have incompatible or single-consumer contracts | Keep each specialized until two consumers prove compatible reusable policy | Phase 5 baseline plus Phase 6 bounded-live-choice exception; re-open on new evidence |
 | Public Pi replacement pressure | Pi 0.84.1 exposes useful low-level TUI primitives but no equivalent Kit cross-mode composite | Retire a Kit screen when a stable public Pi owner provides the complete contract | Phase 5 review complete; re-run after Pi dependency upgrades |
 | Disabled action presentation | Disabled action rows could hide their state or truncate labels ambiguously | Published API 8 presents sanitized reasons and ellipsis-safe labels across TUI/RPC while keeping actions inert and raw identities stable | Phase 4 published; registry package, maintained component/runtime tests, and archived implementation plan |
+| Bounded live-choice ownership | Statusline and Starship repeated cursor navigation, preview dispatch, key hints, and exit handling | Source API 9 owns selection and lifecycle mechanics while consumers retain preview state, rollback, persistence, and final apply | Phase 6 source-complete; Kit TUI/RPC/lifecycle tests, repository gate, package dry run, and post-publication proof migrations |
+| Interaction-hint consistency | Kit and specialized pickers repeated binding lookup, aliases, exclusions, and sanitization | Source API 9 exposes one formatter and uses it for Kit menu, browse, and live-choice hints | Phase 6 source-complete; formatter and rendering tests |
 | Regression gate | Repository CI-equivalent gate at each capability change | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
@@ -336,8 +383,8 @@ and adoption rather than calendar output.
 - Adding a general wizard or form merely to reduce Stamp or Image Drop screen definitions; their
   validation and publication semantics differ.
 - Adding a multi-line editor while Pi lacks an abort-aware RPC editor contract.
-- Building an action-bearing catalog, tree, transcript, live-preview, or reorder framework without
-  compatible consumer evidence.
+- Building an action-bearing catalog, tree, transcript, general preview-state framework, or reorder
+  framework; bounded live choice does not own preview state or transactions.
 - Reducing direct dialog counts as an end in itself.
 - Committing to delivery dates, speculative package versions, or implementation scope without a
   focused approved plan.
@@ -376,4 +423,5 @@ and adoption rather than calendar output.
 | 2026-08-08 | Complete standalone-confirmation proof through Analytics. | Analytics raised only its Kit floor, retained deletion and committed-clear policy, made TUI Ctrl+C close the dashboard, and proved TUI/RPC Back, Close, stale, error, replacement, and cleanup-warning behavior; focused tests, package checks, dry-run packaging, isolated Pi load, and the repository gate passed. |
 | 2026-08-08 | Close deferred multi-select qualification without a new Kit transaction API. | Pi Sync requires a separate exact review, optional privacy acknowledgement, conflict-checked atomic publication, and read-only RPC; Subagents uses pinned in-screen Save/Discard, unavailable-tool preservation, synchronous settings publication, and RPC status. Existing Kit mechanics are reusable, but the transaction contracts do not converge. Immediate-save Chrome DevTools, Firecrawl, Google GenAI, and Plan-mode selectors remained unchanged and passed focused verification. |
 | 2026-08-08 | Classify remaining direct dialogs without admitting a new API. | One-off choices and values fit Pi's direct primitives; setup/auth sequences retain extension-owned drafts, secrets, validation, and publication; boolean confirmations use direct dialogs when all dismissals mean no and can adopt published `runConfirmation()` when richer outcomes are proven; multi-line editors remain deferred pending abort-aware RPC support. Raw call volume is not an admission criterion. |
-| 2026-08-08 | Complete Phase 5 capability and public-export review against Pi 0.84.1 without admitting or retiring an API. | Recall, File Context, Statusline, and Starship demonstrate incompatible specialized catalog, preview, reorder, and transaction contracts; no maintained tree pair exists; Pi's editor remains non-abort-aware; and its public TUI controls remain lower-level than the Kit's cross-mode lifecycle contracts. Reassess after a Pi dependency upgrade or two compatible consumers provide new evidence. |
+| 2026-08-08 | Complete Phase 5 capability and public-export review against Pi 0.84.1 without admitting or retiring an API. | Recall, File Context, Statusline, and Starship then demonstrated incompatible specialized catalog, preview, reorder, and transaction contracts; no maintained tree pair exists; Pi's editor remains non-abort-aware; and its public TUI controls remain lower-level than the Kit's cross-mode lifecycle contracts. Reassess after a Pi dependency upgrade or two compatible consumers provide new evidence. |
+| 2026-08-08 | Admit source API 9 bounded live choice after Starship preset selection converged with Statusline palette selection. | `runLiveChoice()` owns injected navigation, typed exits, optional shortcuts, RPC downgrade, stale checks, coalescing, disposal, and draining; a shared internal controller and public hint formatter remove repeated interaction mechanics. Preview snapshots, rollback, persistence, confirmation, and final apply remain consumer-owned. Publication must precede separate proof migrations. |

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -212,7 +212,7 @@ try {
     initialItemId: activePresetId,
     navigationLabel: "live preview",
     confirmLabel: "apply",
-    shortcuts: [{ id: "customize", keys: ["e", "E"], label: "customize" }],
+    shortcuts: [{ id: "customize", keys: ["e", "shift+e"], label: "customize" }],
     signal: currentSessionSignal(),
     isCurrent: () => generation === currentGeneration(),
     onSelectionChange: ({ item, signal }) => {
@@ -228,7 +228,9 @@ else if (choice?.kind === "shortcut") await customizePreset(choice.itemId);
 ```
 
 TUI calls `onSelectionChange` for the initial cursor and later focused rows, including disabled rows;
-only confirmation and shortcuts are blocked for a disabled row. Synchronous previews run immediately.
+only confirmation and shortcuts are blocked for a disabled row. Shortcut keys use Pi `KeyId` values;
+keys that conflict with current standard choice controls are omitted from shortcut hints and dispatch.
+Synchronous previews run immediately.
 While an asynchronous preview is pending, newer cursor changes coalesce to the latest row. Completion,
 Back, Close, owner cancellation, external disposal, and errors abort the callback signal and drain
 owned preview work before returning. The callback must honor that signal. The caller still owns its

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -8,8 +8,8 @@ Reusable navigation helpers and typed, declarative interaction flows for indepen
 [`@earendil-works/pi-tui`](https://www.npmjs.com/package/@earendil-works/pi-tui). The initial
 high-level API lets extensions describe menu screens and domain actions while this package owns
 standard rendering, navigation, mode adaptation, cancellation, and lifecycle behavior. It also
-provides a standalone task runner for abort-aware work with a cancellable bordered loader composed
-from public Pi TUI primitives.
+provides standalone task, confirmation, and live-choice interactions plus lifecycle ownership for
+specialized custom components.
 
 ## 📦 Install
 
@@ -190,8 +190,72 @@ replacement, external TUI disposal, and failures remain distinct `stale` or `err
 owns only this interaction lifecycle—the caller performs every confirmed side effect and must abort
 its owner signal on replacement or shutdown.
 
+For a choice whose cursor drives an extension-owned preview, use `runLiveChoice()` instead of making
+a declarative `choice` screen side-effecting:
+
+```ts
+import { runLiveChoice } from "@narumitw/pi-tui-kit";
+
+const previousPreview = capturePreview();
+let choice;
+try {
+  choice = await runLiveChoice(ctx, {
+    title: "Preset",
+    items: presets.map((preset) => ({
+      id: preset.id,
+      label: preset.label,
+      description: preset.description,
+      disabled: !preset.available,
+      disabledReason: preset.available ? undefined : "Required font is unavailable",
+    })),
+    currentItemId: activePresetId,
+    initialItemId: activePresetId,
+    navigationLabel: "live preview",
+    confirmLabel: "apply",
+    shortcuts: [{ id: "customize", keys: ["e", "E"], label: "customize" }],
+    signal: currentSessionSignal(),
+    isCurrent: () => generation === currentGeneration(),
+    onSelectionChange: ({ item, signal }) => {
+      if (!signal.aborted) previewPreset(item.id);
+    },
+  });
+} finally {
+  restorePreview(previousPreview);
+}
+
+if (choice?.kind === "selected") await saveAndApplyPreset(choice.itemId);
+else if (choice?.kind === "shortcut") await customizePreset(choice.itemId);
+```
+
+TUI calls `onSelectionChange` for the initial cursor and later focused rows, including disabled rows;
+only confirmation and shortcuts are blocked for a disabled row. Synchronous previews run immediately.
+While an asynchronous preview is pending, newer cursor changes coalesce to the latest row. Completion,
+Back, Close, owner cancellation, external disposal, and errors abort the callback signal and drain
+owned preview work before returning. The callback must honor that signal. The caller still owns its
+preview snapshot, rollback, persistence, confirmation, and final apply policy.
+
+RPC deliberately degrades to a signal-aware ordinary selector: it never runs live previews or custom
+shortcuts, disabled rows remain inert, and cancellation follows the requested Back/Close hint. Print
+and JSON return `unsupported`. Results distinguish `selected`, `shortcut`, `closed`, `stale`,
+`unsupported`, and `error`.
+
+`formatInteractionHints()` is available for other specialized components. Pass the callback-injected
+keybindings plus binding-backed or literal-key hint groups; the formatter normalizes arrows,
+Enter/Escape names, sanitizes controls, applies exclusions, de-duplicates keys, and supports a custom
+separator.
+
+```ts
+import { formatInteractionHints } from "@narumitw/pi-tui-kit";
+
+const hint = formatInteractionHints(keybindings, [
+  { bindings: ["tui.select.up", "tui.select.down"], label: "preview" },
+  { bindings: ["tui.select.confirm"], label: "apply" },
+  { keys: ["e"], label: "customize" },
+]);
+```
+
 For a specialized custom component that does not belong in the declarative screen union, use
-`runCustomInteraction()`. It supplies an interaction-owned signal, classifies owner replacement and
+`runCustomInteraction()`.  It supplies an interaction-owned signal, classifies owner replacement and
 external component disposal as stale, disposes exactly once, and drains optional `waitForPending()`
 work before returning. The consumer still owns the component, its Back/Close value, and every domain
 side effect. Async factories and pending work must honor the supplied signal; the helper drains them
@@ -290,8 +354,9 @@ const profileScreen = {
 };
 ```
 
-Keep live previews, preview rollback, persistence, and confirmation policy in the consuming extension;
-a specialized UI remains appropriate when cursor movement itself has side effects.
+Keep preview snapshots, rollback, persistence, and confirmation policy in the consuming extension.
+Use standalone `runLiveChoice()` when its list-and-shortcut contract fits; keep a fully specialized UI
+local only when cursor behavior needs more than that contract.
 
 Browse screens are read-only and invoke no action. TUI fuzzy-searches each sanitized label, textual
 `statusText`, description, and optional non-rendered `searchText`. Enter opens an adaptive scrolling
@@ -484,7 +549,8 @@ cross-mode and lifecycle contract shared by multiple extensions.
 The library owns:
 
 - standalone task-mode adaptation, cancellation, stale checks, error routing, and draining;
-- lifecycle ownership, disposal, and pending-work draining around specialized custom interactions;
+- lifecycle ownership, disposal, and pending-work draining around live-choice and specialized custom
+  interactions;
 - width-safe standard rendering and injected keybindings;
 - screen-stack navigation, Back/Close semantics, and per-screen cursor memory;
 - serial settings and multi-select updates, optimistic rollback, and pending-update draining;
@@ -500,8 +566,8 @@ The consuming extension still owns:
 - transactional persistence and preservation of unknown settings fields;
 - confirmations and product-specific copy;
 - session generation and shutdown policy supplied through `isCurrent()`;
-- multi-line editors, secret inputs, live side-effecting previews, multi-field forms, or other
-  specialized custom TUI.
+- preview snapshots, rollback and persistence, multi-line editors, secret inputs, multi-field forms,
+  or other specialized custom TUI.
 
 Keep specialized UI local rather than adding package hooks that expose Pi TUI internals.
 
@@ -579,6 +645,10 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `runTask()` — runs typed abort-aware work with a cancellable TUI loader and direct non-TUI fallback.
 - `runConfirmation()` — preserves Confirmed, Back, Close, Stale, Unsupported, and Error for one
   standalone confirmation without owning the confirmed side effect.
+- `runLiveChoice()` — adapts a live-preview choice to TUI and ordinary RPC selection while preserving
+  typed selection, shortcut, Back, Close, Stale, Unsupported, and Error outcomes.
+- `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and
+  literal shortcut keys for specialized interaction hints.
 - `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending
   work draining, and typed results around one extension-owned custom TUI component.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
@@ -586,10 +656,10 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - exported screen, item, action, transition, runtime option, `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
   strict scripts, and their public testing types; it is not re-exported from the production root.
-- `PI_EXTENSION_MENU_API_VERSION` — current declarative API version (`8`). Version 8 adds disabled
-  action reasons and adaptive action-label columns; version-7 definitions remain valid on the
-  version-8 runtime. Version 7 added `runConfirmation()`, and version 6 added the read-only `browse`
-  screen and `runCustomInteraction()`.
+- `PI_EXTENSION_MENU_API_VERSION` — current API version (`9`). Version 9 adds `runLiveChoice()` and
+  `formatInteractionHints()` while version-8 menu definitions remain valid. Version 8 added disabled
+  action reasons and adaptive action-label columns, version 7 added `runConfirmation()`, and version
+  6 added the read-only `browse` screen and `runCustomInteraction()`.
 
 ## 🗂️ Package layout
 
@@ -598,6 +668,8 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `src/testing/` — supported TUI/RPC test drivers exported only through the `/testing` subpath
 - `src/task.ts` — standalone and menu-shared task lifecycle orchestration
 - `src/confirmation.ts` — standalone confirmation mode adaptation and lifecycle results
+- `src/live-choice.ts` — standalone live-choice TUI/RPC adaptation and preview-work ownership
+- `src/interaction-hints.ts` — injected-key and literal-shortcut hint formatting
 - `src/custom-interaction.ts` — lifecycle ownership for specialized public custom components
 - `dist/` — generated ESM and declarations included in the npm package
 - `test/` — contract, renderer, navigation, lifecycle, and public testing-entrypoint coverage

--- a/packages/pi-tui-kit/src/components/browse.ts
+++ b/packages/pi-tui-kit/src/components/browse.ts
@@ -9,6 +9,7 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
+import { formatInteractionHints } from "../interaction-hints.js";
 import type { MenuBrowseItem } from "../types.js";
 import type { BrowseOptions, MenuKeybindings, MenuScreenComponent } from "./contracts.js";
 import { handleSearchInput, safeMenuText } from "./rendering.js";
@@ -398,50 +399,38 @@ function boundedLines(lines: readonly string[], width: number, rows: number) {
 }
 
 function browseHint(keybindings: MenuKeybindings, destination: "back" | "close") {
-	const up = bindingText(keybindings, "tui.select.up");
-	const down = bindingText(keybindings, "tui.select.down");
-	const confirm = bindingText(keybindings, "tui.select.confirm");
-	const cancel = bindingText(keybindings, "tui.select.cancel", "ctrl+c");
-	return [
-		"type to search",
-		...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
-		...(confirm ? [`${confirm} details`] : []),
-		...(cancel ? [`${cancel} ${destination}`] : []),
-		...(destination === "back" ? ["ctrl+c close"] : []),
-	].join(" · ");
+	const controls = formatInteractionHints(
+		keybindings,
+		[
+			{ bindings: ["tui.select.up", "tui.select.down"], label: "navigate" },
+			{ bindings: ["tui.select.confirm"], label: "details" },
+			{
+				bindings: ["tui.select.cancel"],
+				excludeKeys: ["ctrl+c"],
+				label: destination,
+			},
+			...(destination === "back" ? [{ keys: ["ctrl+c"], label: "close" }] : []),
+		],
+		{ separator: "·" },
+	);
+	return ["type to search", controls].filter(Boolean).join(" · ");
 }
 
 function detailHint(keybindings: MenuKeybindings) {
-	const up = bindingText(keybindings, "tui.select.up");
-	const down = bindingText(keybindings, "tui.select.down");
-	const pageUp = bindingText(keybindings, "tui.select.pageUp");
-	const pageDown = bindingText(keybindings, "tui.select.pageDown");
-	const cancel = bindingText(keybindings, "tui.select.cancel", "ctrl+c");
-	return [
-		...(up || down ? [`${[up, down].filter(Boolean).join("/")} scroll`] : []),
-		...(pageUp || pageDown ? [`${[pageUp, pageDown].filter(Boolean).join("/")} page`] : []),
-		...(cancel ? [`${cancel} back`] : []),
-		"ctrl+c close",
-	].join(" · ");
-}
-
-function bindingText(
-	keybindings: MenuKeybindings,
-	binding: Parameters<MenuKeybindings["getKeys"]>[0],
-	excluded?: string,
-) {
-	return keybindings
-		.getKeys(binding)
-		.filter((key) => key !== excluded)
-		.map((key) => {
-			if (key === "up") return "↑";
-			if (key === "down") return "↓";
-			if (key === "escape") return "esc";
-			if (key === "enter" || key === "return") return "enter";
-			return safeMenuText(key);
-		})
-		.filter(Boolean)
-		.join("/");
+	return formatInteractionHints(
+		keybindings,
+		[
+			{ bindings: ["tui.select.up", "tui.select.down"], label: "scroll" },
+			{ bindings: ["tui.select.pageUp", "tui.select.pageDown"], label: "page" },
+			{
+				bindings: ["tui.select.cancel"],
+				excludeKeys: ["ctrl+c"],
+				label: "back",
+			},
+			{ keys: ["ctrl+c"], label: "close" },
+		],
+		{ separator: "·" },
+	);
 }
 
 function safeBrowseText(value: unknown) {

--- a/packages/pi-tui-kit/src/components/contracts.ts
+++ b/packages/pi-tui-kit/src/components/contracts.ts
@@ -68,6 +68,8 @@ export interface MenuScreenComponentOptions<ScreenId extends string, ActionId ex
 	onInputSubmit?(change: MenuInputSubmit): Promise<MenuChangeResponse<ScreenId>>;
 	onTransition?(transition: MenuTransition<ScreenId>): void;
 	onError?(error: unknown): void;
+	/** Internal standalone-interaction hint override. Declarative screens do not set this. */
+	interactionHint?: string;
 	onDispose?(): void;
 }
 

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -33,6 +33,7 @@ import {
 	safeMenuText,
 } from "./rendering.js";
 import { createReviewComponent, type ReviewOptions } from "./review.js";
+import { SelectionController } from "./selection-controller.js";
 
 export { browseDialogLabel, browseDialogPages } from "./browse.js";
 export type {
@@ -190,33 +191,26 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 	});
 	const viewportSize = Math.min(items.length, options.screen.viewportSize ?? 10);
 	const list = new SelectList(items, viewportSize, selectTheme(options.theme));
-	const initialId = items.some((item) => item.value === options.selectedItemId)
-		? options.selectedItemId
-		: items[0]?.value;
-	let selectedItemId = initialId;
-	setInitialSelection(list, items, initialId);
-	const select = (index: number) => {
-		if (items.length === 0) return;
-		const selectedIndex = Math.max(0, Math.min(index, items.length - 1));
-		list.setSelectedIndex(selectedIndex);
-		selectedItemId = items[selectedIndex]?.value;
-		if (selectedItemId) options.onSelectionChange?.(selectedItemId);
+	const selection = new SelectionController(options.screen.items, options.selectedItemId);
+	setInitialSelection(list, items, selection.selectedItem?.id);
+	const syncSelection = () => {
+		const item = selection.selectedItem;
+		if (!item) return;
+		list.setSelectedIndex(selection.selectedIndex);
+		options.onSelectionChange?.(item.id);
 	};
 	const move = (delta: number) => {
-		if (items.length === 0) return;
-		const index = items.findIndex((item) => item.value === selectedItemId);
-		select((index + delta + items.length) % items.length);
+		if (selection.move(delta)) syncSelection();
 	};
-	const activate = (itemId: string | undefined) => {
-		if (!itemId) return;
-		const item = options.screen.items.find((candidate) => candidate.id === itemId);
-		if (!item?.disabled) options.onEvent({ kind: "activate", itemId });
+	const activate = () => {
+		const item = selection.selectedItem;
+		if (item && !item.disabled) options.onEvent({ kind: "activate", itemId: item.id });
 	};
 	let disposed = false;
 	return {
 		render(width) {
 			const safeWidth = Math.max(1, width);
-			const selected = options.screen.items.find((item) => item.id === selectedItemId);
+			const selected = selection.selectedItem;
 			const details = [
 				...(selected?.disabledReason
 					? [`Unavailable: ${safeMenuText(selected.disabledReason)}`]
@@ -251,7 +245,8 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 				...wrapTextWithAnsi(
 					options.theme.fg(
 						"dim",
-						menuHint(options.keybindings, options.screen.hint ?? "back", "select"),
+						options.interactionHint ??
+							menuHint(options.keybindings, options.screen.hint ?? "back", "select"),
 					),
 					safeWidth,
 				),
@@ -271,15 +266,15 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 			} else if (options.keybindings.matches(data, "tui.select.up")) move(-1);
 			else if (options.keybindings.matches(data, "tui.select.down")) move(1);
 			else if (options.keybindings.matches(data, "tui.select.pageUp")) {
-				const index = items.findIndex((item) => item.value === selectedItemId);
-				select(index - Math.max(1, viewportSize));
+				if (selection.page(-1, viewportSize)) syncSelection();
 			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
-				const index = items.findIndex((item) => item.value === selectedItemId);
-				select(index + Math.max(1, viewportSize));
-			} else if (matchesKey(data, Key.home)) select(0);
-			else if (matchesKey(data, Key.end)) select(items.length - 1);
-			else if (options.keybindings.matches(data, "tui.select.confirm") || data === " ") {
-				activate(selectedItemId);
+				if (selection.page(1, viewportSize)) syncSelection();
+			} else if (matchesKey(data, Key.home)) {
+				if (selection.first()) syncSelection();
+			} else if (matchesKey(data, Key.end)) {
+				if (selection.last()) syncSelection();
+			} else if (options.keybindings.matches(data, "tui.select.confirm") || data === " ") {
+				activate();
 			}
 			options.tui.requestRender();
 		},

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -1,6 +1,10 @@
 import { type Input, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { formatInteractionHints } from "../interaction-hints.js";
+import { replaceTerminalControls, safeMenuText } from "../text.js";
 import type { ActionMenuItem } from "../types.js";
-import type { MenuBinding, MenuKeybindings, MenuScreenComponentOptions } from "./contracts.js";
+import type { MenuKeybindings, MenuScreenComponentOptions } from "./contracts.js";
+
+export { safeMenuText } from "../text.js";
 
 export function actionMenuItemPresentation(item: ActionMenuItem<string, string>): {
 	label: string;
@@ -58,45 +62,20 @@ export function menuHint(
 	destination: "back" | "close",
 	confirmAction: string,
 ) {
-	const up = bindingText(keybindings, "tui.select.up");
-	const down = bindingText(keybindings, "tui.select.down");
-	const confirm = bindingText(keybindings, "tui.select.confirm");
-	const cancel = bindingText(keybindings, "tui.select.cancel", "ctrl+c");
-	return [
-		...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
-		...(confirm && confirmAction ? [`${confirm} ${confirmAction}`] : []),
-		...(cancel ? [`${cancel} ${destination}`] : []),
-		...(destination === "back" ? ["ctrl+c close"] : []),
-	].join(" • ");
-}
-
-function bindingText(keybindings: MenuKeybindings, binding: MenuBinding, excluded?: string) {
-	return keybindings
-		.getKeys(binding)
-		.filter((key) => key !== excluded)
-		.map((key) => {
-			if (key === "up") return "↑";
-			if (key === "down") return "↓";
-			if (key === "escape") return "esc";
-			return safeMenuText(key);
-		})
-		.filter(Boolean)
-		.join("/");
-}
-
-export function safeMenuText(value: unknown) {
-	return replaceTerminalControls(value).replace(/\s+/gu, " ").trim();
+	return formatInteractionHints(keybindings, [
+		{ bindings: ["tui.select.up", "tui.select.down"], label: "navigate" },
+		...(confirmAction ? [{ bindings: ["tui.select.confirm"] as const, label: confirmAction }] : []),
+		{
+			bindings: ["tui.select.cancel"],
+			excludeKeys: ["ctrl+c"],
+			label: destination,
+		},
+		...(destination === "back" ? [{ keys: ["ctrl+c"], label: "close" }] : []),
+	]);
 }
 
 export function handleSearchInput(input: Input, data: string) {
 	input.handleInput(data);
 	const value = replaceTerminalControls(input.getValue());
 	if (value !== input.getValue()) input.setValue(value);
-}
-
-export function replaceTerminalControls(value: unknown) {
-	return Array.from(String(value), (character) => {
-		const codePoint = character.codePointAt(0) ?? 0;
-		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
-	}).join("");
 }

--- a/packages/pi-tui-kit/src/components/selection-controller.ts
+++ b/packages/pi-tui-kit/src/components/selection-controller.ts
@@ -1,0 +1,48 @@
+interface SelectionItem {
+	id: string;
+}
+
+/** Package-internal stable-ID selection movement shared by choice interactions. */
+export class SelectionController<Item extends SelectionItem> {
+	readonly items: readonly Item[];
+	#selectedIndex: number;
+
+	constructor(items: readonly Item[], initialItemId?: string) {
+		this.items = items;
+		const initialIndex = initialItemId ? items.findIndex((item) => item.id === initialItemId) : -1;
+		this.#selectedIndex = items.length === 0 ? -1 : Math.max(0, initialIndex);
+	}
+
+	get selectedIndex(): number {
+		return this.#selectedIndex;
+	}
+
+	get selectedItem(): Item | undefined {
+		return this.items[this.#selectedIndex];
+	}
+
+	select(index: number): Item | undefined {
+		if (this.items.length === 0) return undefined;
+		this.#selectedIndex = Math.max(0, Math.min(index, this.items.length - 1));
+		return this.selectedItem;
+	}
+
+	move(delta: number): Item | undefined {
+		if (this.items.length === 0) return undefined;
+		this.#selectedIndex =
+			(((this.#selectedIndex + delta) % this.items.length) + this.items.length) % this.items.length;
+		return this.selectedItem;
+	}
+
+	page(delta: number, viewportSize: number): Item | undefined {
+		return this.select(this.#selectedIndex + delta * Math.max(1, viewportSize));
+	}
+
+	first(): Item | undefined {
+		return this.select(0);
+	}
+
+	last(): Item | undefined {
+		return this.select(this.items.length - 1);
+	}
+}

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -10,6 +10,20 @@ export {
 	type RunCustomInteractionResult,
 	runCustomInteraction,
 } from "./custom-interaction.js";
+export {
+	type FormatInteractionHintsOptions,
+	formatInteractionHints,
+	type InteractionHint,
+	type InteractionKeybindings,
+} from "./interaction-hints.js";
+export {
+	type LiveChoiceItem,
+	type LiveChoiceSelectionContext,
+	type LiveChoiceShortcut,
+	type RunLiveChoiceOptions,
+	type RunLiveChoiceResult,
+	runLiveChoice,
+} from "./live-choice.js";
 export { defineMenu, resolveMenuScreen } from "./model.js";
 export { createMenuNavigator, type MenuNavigator } from "./navigator.js";
 export { type RunMenuOptions, type RunMenuResult, runMenu } from "./runtime.js";
@@ -42,4 +56,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 8;
+export const PI_EXTENSION_MENU_API_VERSION = 9;

--- a/packages/pi-tui-kit/src/interaction-hints.ts
+++ b/packages/pi-tui-kit/src/interaction-hints.ts
@@ -1,0 +1,54 @@
+import { safeMenuText } from "./text.js";
+
+export interface InteractionKeybindings<Binding extends string = string> {
+	getKeys(binding: Binding): readonly string[];
+}
+
+export interface InteractionHint<Binding extends string = string> {
+	bindings?: readonly Binding[];
+	keys?: readonly string[];
+	excludeKeys?: readonly string[];
+	label: string;
+}
+
+export interface FormatInteractionHintsOptions {
+	separator?: string;
+}
+
+/** Format width-neutral interaction hints from Pi keybindings and literal shortcut keys. */
+export function formatInteractionHints<Binding extends string>(
+	keybindings: InteractionKeybindings<Binding>,
+	hints: readonly InteractionHint<Binding>[],
+	options: FormatInteractionHintsOptions = {},
+): string {
+	const separator = safeMenuText(options.separator ?? "•") || "•";
+	return hints
+		.map((hint) => formatHint(keybindings, hint))
+		.filter(Boolean)
+		.join(` ${separator} `);
+}
+
+function formatHint<Binding extends string>(
+	keybindings: InteractionKeybindings<Binding>,
+	hint: InteractionHint<Binding>,
+): string {
+	const excluded = new Set((hint.excludeKeys ?? []).map(normalizeKey).filter(Boolean));
+	const keys = [
+		...(hint.bindings ?? []).flatMap((binding) => keybindings.getKeys(binding)),
+		...(hint.keys ?? []),
+	]
+		.map(normalizeKey)
+		.filter((key) => key && !excluded.has(key));
+	const uniqueKeys = [...new Set(keys)];
+	const label = safeMenuText(hint.label);
+	return uniqueKeys.length > 0 && label ? `${uniqueKeys.join("/")} ${label}` : "";
+}
+
+function normalizeKey(value: string): string {
+	const key = safeMenuText(value).toLowerCase();
+	if (key === "up") return "↑";
+	if (key === "down") return "↓";
+	if (key === "return") return "enter";
+	if (key === "escape") return "esc";
+	return key;
+}

--- a/packages/pi-tui-kit/src/live-choice.ts
+++ b/packages/pi-tui-kit/src/live-choice.ts
@@ -1,12 +1,11 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { Key, matchesKey } from "@earendil-works/pi-tui";
+import { Key, type KeyId, matchesKey } from "@earendil-works/pi-tui";
 import { createMenuScreenComponent, safeMenuText } from "./components/index.js";
 import { runCustomInteraction } from "./custom-interaction.js";
 import { formatInteractionHints } from "./interaction-hints.js";
 import type { MenuCloseReason, MenuContext } from "./types.js";
 
 type ExtensionMode = MenuContext["mode"];
-type MatchableKey = Parameters<typeof matchesKey>[1];
 
 export interface LiveChoiceItem<ItemId extends string = string> {
 	id: ItemId;
@@ -19,7 +18,7 @@ export interface LiveChoiceItem<ItemId extends string = string> {
 
 export interface LiveChoiceShortcut<ShortcutId extends string = string> {
 	id: ShortcutId;
-	keys: readonly string[];
+	keys: readonly KeyId[];
 	label: string;
 }
 
@@ -110,6 +109,7 @@ async function runTuiLiveChoice<
 		onError: (currentCtx, error) => reportLiveChoiceError(currentCtx, options, error),
 		create: ({ tui, theme, keybindings, signal, complete }) => {
 			let focusedItemId = selectedItemId;
+			const shortcuts = availableShortcuts(options.shortcuts, keybindings);
 			const previews = createPreviewQueue(ctx, options, signal, () =>
 				complete({ kind: "previewFailed" }),
 			);
@@ -128,7 +128,7 @@ async function runTuiLiveChoice<
 				tui,
 				theme,
 				keybindings,
-				interactionHint: liveChoiceHint(keybindings, options),
+				interactionHint: liveChoiceHint(keybindings, options, shortcuts),
 				onSelectionChange: (itemId) => {
 					focusedItemId = itemId as Item["id"];
 					const item = findItem(options.items, focusedItemId);
@@ -156,7 +156,7 @@ async function runTuiLiveChoice<
 					const item = findItem(options.items, focusedItemId);
 					const shortcut =
 						item && !item.disabled && !isStandardChoiceInput(data, keybindings)
-							? findShortcut(options.shortcuts, data)
+							? findShortcut(shortcuts, data)
 							: undefined;
 					if (item && shortcut) {
 						complete({ kind: "shortcut", shortcutId: shortcut.id, itemId: item.id });
@@ -304,6 +304,7 @@ function liveChoiceHint<Item extends LiveChoiceItem, ShortcutId extends string>(
 		getKeys(binding: string): readonly string[];
 	},
 	options: RunLiveChoiceOptions<Item, ShortcutId, MenuContext>,
+	shortcuts: readonly LiveChoiceShortcut<ShortcutId>[],
 ): string {
 	return formatInteractionHints(keybindings, [
 		{
@@ -311,7 +312,7 @@ function liveChoiceHint<Item extends LiveChoiceItem, ShortcutId extends string>(
 			label: options.navigationLabel ?? "preview",
 		},
 		{ bindings: ["tui.select.confirm"], label: options.confirmLabel ?? "select" },
-		...(options.shortcuts ?? []).map((shortcut) => ({
+		...shortcuts.map((shortcut) => ({
 			keys: shortcut.keys,
 			label: shortcut.label,
 		})),
@@ -345,13 +346,56 @@ function isStandardChoiceInput(
 	);
 }
 
-function findShortcut<ShortcutId extends string>(
+const STANDARD_CHOICE_BINDINGS = [
+	"tui.select.cancel",
+	"tui.select.up",
+	"tui.select.down",
+	"tui.select.pageUp",
+	"tui.select.pageDown",
+	"tui.select.confirm",
+] as const;
+
+function availableShortcuts<ShortcutId extends string>(
 	shortcuts: readonly LiveChoiceShortcut<ShortcutId>[] | undefined,
+	keybindings: { getKeys(binding: string): readonly string[] },
+): readonly LiveChoiceShortcut<ShortcutId>[] {
+	const unavailableKeys = new Set(
+		[
+			"ctrl+c",
+			"home",
+			"end",
+			"space",
+			...STANDARD_CHOICE_BINDINGS.flatMap((binding) => keybindings.getKeys(binding)),
+		].map(canonicalKeyId),
+	);
+	const available: LiveChoiceShortcut<ShortcutId>[] = [];
+	for (const shortcut of shortcuts ?? []) {
+		const keys = shortcut.keys.filter((key) => {
+			const canonical = canonicalKeyId(key);
+			if (unavailableKeys.has(canonical)) return false;
+			unavailableKeys.add(canonical);
+			return true;
+		});
+		if (keys.length > 0) available.push({ ...shortcut, keys });
+	}
+	return available;
+}
+
+function canonicalKeyId(key: string): string {
+	const parts = key.toLowerCase().split("+");
+	const base = parts.at(-1) ?? "";
+	const canonicalBase = base === "esc" ? "escape" : base === "return" ? "enter" : base;
+	const modifiers = ["ctrl", "shift", "alt", "super"].filter((modifier) =>
+		parts.includes(modifier),
+	);
+	return [...modifiers, canonicalBase].join("+");
+}
+
+function findShortcut<ShortcutId extends string>(
+	shortcuts: readonly LiveChoiceShortcut<ShortcutId>[],
 	data: string,
 ): LiveChoiceShortcut<ShortcutId> | undefined {
-	return shortcuts?.find((shortcut) =>
-		shortcut.keys.some((key) => matchesKey(data, key as MatchableKey)),
-	);
+	return shortcuts.find((shortcut) => shortcut.keys.some((key) => matchesKey(data, key)));
 }
 
 function initialItemId<

--- a/packages/pi-tui-kit/src/live-choice.ts
+++ b/packages/pi-tui-kit/src/live-choice.ts
@@ -1,0 +1,497 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { Key, matchesKey } from "@earendil-works/pi-tui";
+import { createMenuScreenComponent, safeMenuText } from "./components/index.js";
+import { runCustomInteraction } from "./custom-interaction.js";
+import { formatInteractionHints } from "./interaction-hints.js";
+import type { MenuCloseReason, MenuContext } from "./types.js";
+
+type ExtensionMode = MenuContext["mode"];
+type MatchableKey = Parameters<typeof matchesKey>[1];
+
+export interface LiveChoiceItem<ItemId extends string = string> {
+	id: ItemId;
+	label: string;
+	description?: string;
+	details?: readonly string[];
+	disabled?: boolean;
+	disabledReason?: string;
+}
+
+export interface LiveChoiceShortcut<ShortcutId extends string = string> {
+	id: ShortcutId;
+	keys: readonly string[];
+	label: string;
+}
+
+export interface LiveChoiceSelectionContext<
+	Item extends LiveChoiceItem,
+	Context extends MenuContext = ExtensionCommandContext,
+> {
+	ctx: Context;
+	item: Item;
+	signal: AbortSignal;
+}
+
+export interface RunLiveChoiceOptions<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string = never,
+	Context extends MenuContext = ExtensionCommandContext,
+> {
+	title: string;
+	lines?: readonly string[];
+	items: readonly Item[];
+	currentItemId?: Item["id"];
+	initialItemId?: Item["id"];
+	viewportSize?: number;
+	hint?: MenuCloseReason;
+	navigationLabel?: string;
+	confirmLabel?: string;
+	shortcuts?: readonly LiveChoiceShortcut<ShortcutId>[];
+	onSelectionChange?(context: LiveChoiceSelectionContext<Item, Context>): void | Promise<void>;
+	signal?: AbortSignal;
+	isCurrent?(): boolean;
+	onError?(ctx: Context, error: unknown): void | Promise<void>;
+	onUnsupportedMode?(ctx: Context, mode: ExtensionMode): void | Promise<void>;
+}
+
+export type RunLiveChoiceResult<
+	ItemId extends string = string,
+	ShortcutId extends string = string,
+> =
+	| { kind: "selected"; itemId: ItemId }
+	| { kind: "shortcut"; shortcutId: ShortcutId; itemId: ItemId }
+	| { kind: "closed"; reason: MenuCloseReason }
+	| { kind: "stale" }
+	| { kind: "unsupported"; mode: ExtensionMode }
+	| { kind: "error"; error: unknown };
+
+type LiveChoiceValue<ItemId extends string, ShortcutId extends string> =
+	| { kind: "selected"; itemId: ItemId }
+	| { kind: "shortcut"; shortcutId: ShortcutId; itemId: ItemId }
+	| { kind: "closed"; reason: MenuCloseReason }
+	| { kind: "previewFailed" };
+
+/** Run a standalone choice interaction whose cursor can drive consumer-owned live previews. */
+export async function runLiveChoice<
+	const Item extends LiveChoiceItem,
+	ShortcutId extends string = never,
+	Context extends MenuContext = ExtensionCommandContext,
+>(
+	ctx: Context,
+	options: RunLiveChoiceOptions<Item, ShortcutId, Context>,
+): Promise<RunLiveChoiceResult<Item["id"], ShortcutId>> {
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	const validationError = validateOptions(options);
+	if (validationError) return liveChoiceError(ctx, options, validationError);
+	if (ctx.mode === "tui" && ctx.hasUI) return runTuiLiveChoice(ctx, options);
+	if (ctx.mode === "rpc" && ctx.hasUI) return runRpcLiveChoice(ctx, options);
+
+	try {
+		await options.onUnsupportedMode?.(ctx, ctx.mode);
+	} catch (error) {
+		return liveChoiceError(ctx, options, error);
+	}
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	return { kind: "unsupported", mode: ctx.mode };
+}
+
+async function runTuiLiveChoice<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(
+	ctx: Context,
+	options: RunLiveChoiceOptions<Item, ShortcutId, Context>,
+): Promise<RunLiveChoiceResult<Item["id"], ShortcutId>> {
+	const selectedItemId = initialItemId(options);
+	const result = await runCustomInteraction<LiveChoiceValue<Item["id"], ShortcutId>, Context>(ctx, {
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+		onError: (currentCtx, error) => reportLiveChoiceError(currentCtx, options, error),
+		create: ({ tui, theme, keybindings, signal, complete }) => {
+			let focusedItemId = selectedItemId;
+			const previews = createPreviewQueue(ctx, options, signal, () =>
+				complete({ kind: "previewFailed" }),
+			);
+			const component = createMenuScreenComponent<"liveChoice", "select">({
+				screen: {
+					kind: "choice",
+					title: options.title,
+					lines: options.lines,
+					items: options.items,
+					action: "select",
+					currentItemId: options.currentItemId,
+					viewportSize: options.viewportSize,
+					hint: options.hint ?? "back",
+				},
+				selectedItemId,
+				tui,
+				theme,
+				keybindings,
+				interactionHint: liveChoiceHint(keybindings, options),
+				onSelectionChange: (itemId) => {
+					focusedItemId = itemId as Item["id"];
+					const item = findItem(options.items, focusedItemId);
+					if (item) previews.enqueue(item);
+				},
+				onEvent: (event) => {
+					if (event.kind === "activate") {
+						complete({ kind: "selected", itemId: event.itemId as Item["id"] });
+						return;
+					}
+					complete({ kind: "closed", reason: event.kind });
+				},
+			});
+			const initialItem = findItem(options.items, focusedItemId);
+			if (initialItem) previews.enqueue(initialItem);
+
+			return {
+				render: (width) => component.render(width),
+				invalidate: () => component.invalidate(),
+				handleInput(data) {
+					if (!isCurrent(options)) {
+						complete({ kind: "previewFailed" });
+						return;
+					}
+					const item = findItem(options.items, focusedItemId);
+					const shortcut =
+						item && !item.disabled && !isStandardChoiceInput(data, keybindings)
+							? findShortcut(options.shortcuts, data)
+							: undefined;
+					if (item && shortcut) {
+						complete({ kind: "shortcut", shortcutId: shortcut.id, itemId: item.id });
+						return;
+					}
+					component.handleInput(data);
+				},
+				async waitForPending() {
+					await component.waitForPending();
+					await previews.waitForPending();
+				},
+				dispose() {
+					previews.dispose();
+					component.dispose?.();
+				},
+			};
+		},
+	});
+	if (result.kind === "completed" && result.value.kind !== "previewFailed") return result.value;
+	if (result.kind === "completed") {
+		return liveChoiceError(ctx, options, new Error("Live choice preview failed"));
+	}
+	return result;
+}
+
+async function runRpcLiveChoice<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(
+	ctx: Context,
+	options: RunLiveChoiceOptions<Item, ShortcutId, Context>,
+): Promise<RunLiveChoiceResult<Item["id"], ShortcutId>> {
+	const rows = rpcRows(options);
+	while (true) {
+		let selection: string | undefined;
+		try {
+			selection = await uiFor(ctx).select(
+				[options.title, ...(options.lines ?? [])].map(safeMenuText).filter(Boolean).join("\n"),
+				rows.map((row) => row.label),
+				{ signal: options.signal },
+			);
+		} catch (error) {
+			return liveChoiceError(ctx, options, error);
+		}
+		if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+		if (selection === undefined) return { kind: "closed", reason: options.hint ?? "back" };
+		const row = rows.find((candidate) => candidate.label === selection);
+		if (!row) {
+			return liveChoiceError(
+				ctx,
+				options,
+				new Error("Live choice dialog returned an option that was not offered"),
+			);
+		}
+		if (row.kind === "exit") return { kind: "closed", reason: options.hint ?? "back" };
+		if (!row.item.disabled) return { kind: "selected", itemId: row.item.id };
+	}
+}
+
+function createPreviewQueue<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(
+	ctx: Context,
+	options: RunLiveChoiceOptions<Item, ShortcutId, Context>,
+	signal: AbortSignal,
+	fail: () => void,
+) {
+	let queued: Item | undefined;
+	let running = false;
+	let disposed = false;
+	let failure: unknown;
+	let pending = Promise.resolve();
+	const start = () => {
+		if (running || disposed || signal.aborted || !options.onSelectionChange) return;
+		if (!isCurrent(options)) {
+			queued = undefined;
+			fail();
+			return;
+		}
+		running = true;
+		pending = (async () => {
+			try {
+				while (queued && !disposed && !signal.aborted) {
+					if (!isCurrent(options)) {
+						queued = undefined;
+						fail();
+						return;
+					}
+					const item = queued;
+					queued = undefined;
+					const result = options.onSelectionChange?.({ ctx, item, signal });
+					if (isPromiseLike(result)) await result;
+					if (!isCurrent(options)) {
+						queued = undefined;
+						fail();
+						return;
+					}
+				}
+			} catch (error) {
+				if (signal.aborted || disposed) return;
+				failure = error;
+				queued = undefined;
+				fail();
+			} finally {
+				running = false;
+				if (queued) start();
+			}
+		})();
+	};
+	return {
+		enqueue(item: Item) {
+			if (disposed || signal.aborted || !options.onSelectionChange) return;
+			if (!isCurrent(options)) {
+				fail();
+				return;
+			}
+			queued = item;
+			start();
+		},
+		async waitForPending() {
+			while (running) await pending;
+			if (failure !== undefined) throw failure;
+		},
+		dispose() {
+			disposed = true;
+			queued = undefined;
+		},
+	};
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"then" in value &&
+		typeof value.then === "function"
+	);
+}
+
+function liveChoiceHint<Item extends LiveChoiceItem, ShortcutId extends string>(
+	keybindings: {
+		getKeys(binding: string): readonly string[];
+	},
+	options: RunLiveChoiceOptions<Item, ShortcutId, MenuContext>,
+): string {
+	return formatInteractionHints(keybindings, [
+		{
+			bindings: ["tui.select.up", "tui.select.down"],
+			label: options.navigationLabel ?? "preview",
+		},
+		{ bindings: ["tui.select.confirm"], label: options.confirmLabel ?? "select" },
+		...(options.shortcuts ?? []).map((shortcut) => ({
+			keys: shortcut.keys,
+			label: shortcut.label,
+		})),
+		{
+			bindings: ["tui.select.cancel"],
+			excludeKeys: ["ctrl+c"],
+			label: options.hint ?? "back",
+		},
+		{ keys: ["ctrl+c"], label: "close" },
+		{ bindings: ["tui.select.pageUp", "tui.select.pageDown"], label: "page" },
+	]);
+}
+
+function isStandardChoiceInput(
+	data: string,
+	keybindings: { matches(data: string, binding: string): boolean },
+): boolean {
+	return (
+		matchesKey(data, Key.ctrl("c")) ||
+		matchesKey(data, Key.home) ||
+		matchesKey(data, Key.end) ||
+		data === " " ||
+		[
+			"tui.select.cancel",
+			"tui.select.up",
+			"tui.select.down",
+			"tui.select.pageUp",
+			"tui.select.pageDown",
+			"tui.select.confirm",
+		].some((binding) => keybindings.matches(data, binding))
+	);
+}
+
+function findShortcut<ShortcutId extends string>(
+	shortcuts: readonly LiveChoiceShortcut<ShortcutId>[] | undefined,
+	data: string,
+): LiveChoiceShortcut<ShortcutId> | undefined {
+	return shortcuts?.find((shortcut) =>
+		shortcut.keys.some((key) => matchesKey(data, key as MatchableKey)),
+	);
+}
+
+function initialItemId<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(options: RunLiveChoiceOptions<Item, ShortcutId, Context>): Item["id"] | undefined {
+	for (const id of [options.initialItemId, options.currentItemId]) {
+		if (id !== undefined && findItem(options.items, id)) return id;
+	}
+	return options.items[0]?.id;
+}
+
+function findItem<Item extends LiveChoiceItem>(
+	items: readonly Item[],
+	itemId: string | undefined,
+): Item | undefined {
+	return items.find((item) => item.id === itemId);
+}
+
+type RpcRow<Item extends LiveChoiceItem> =
+	| { kind: "item"; label: string; item: Item }
+	| { kind: "exit"; label: string };
+
+function rpcRows<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(options: RunLiveChoiceOptions<Item, ShortcutId, Context>): readonly RpcRow<Item>[] {
+	const used = new Set<string>();
+	const rows: RpcRow<Item>[] = options.items.map((item) => {
+		const states = [
+			item.id === options.currentItemId ? "current" : undefined,
+			item.disabled
+				? `unavailable${item.disabledReason ? `: ${safeMenuText(item.disabledReason)}` : ""}`
+				: undefined,
+			item.description ? safeMenuText(item.description) : undefined,
+		].filter((value): value is string => Boolean(value));
+		const label = `${item.disabled ? "[-] " : ""}${safeMenuText(item.label)}${
+			states.length > 0 ? ` — ${states.join(" · ")}` : ""
+		}`;
+		return { kind: "item", label: uniqueLabel(label, used), item };
+	});
+	rows.push({
+		kind: "exit",
+		label: uniqueLabel(options.hint === "close" ? "Close" : "← Back", used),
+	});
+	return rows;
+}
+
+function uniqueLabel(label: string, used: Set<string>): string {
+	const base = label || "Choice";
+	if (!used.has(base)) {
+		used.add(base);
+		return base;
+	}
+	let suffix = 2;
+	while (used.has(`${base} [${suffix}]`)) suffix += 1;
+	const unique = `${base} [${suffix}]`;
+	used.add(unique);
+	return unique;
+}
+
+function validateOptions<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(options: RunLiveChoiceOptions<Item, ShortcutId, Context>): Error | undefined {
+	if (
+		options.viewportSize !== undefined &&
+		(!Number.isInteger(options.viewportSize) || options.viewportSize <= 0)
+	) {
+		return new Error("Live choice viewportSize must be a positive integer");
+	}
+	const itemIds = new Set<string>();
+	for (const item of options.items) {
+		if (!item.id.trim()) return new Error("Live choice item ids must not be blank");
+		if (itemIds.has(item.id)) return new Error(`Duplicate live choice item id: ${item.id}`);
+		itemIds.add(item.id);
+	}
+	const shortcutIds = new Set<string>();
+	for (const shortcut of options.shortcuts ?? []) {
+		if (!shortcut.id.trim()) return new Error("Live choice shortcut ids must not be blank");
+		if (shortcutIds.has(shortcut.id)) {
+			return new Error(`Duplicate live choice shortcut id: ${shortcut.id}`);
+		}
+		if (shortcut.keys.length === 0) {
+			return new Error(`Live choice shortcut ${shortcut.id} must declare at least one key`);
+		}
+		shortcutIds.add(shortcut.id);
+	}
+	return undefined;
+}
+
+async function liveChoiceError<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(
+	ctx: Context,
+	options: RunLiveChoiceOptions<Item, ShortcutId, Context>,
+	error: unknown,
+): Promise<RunLiveChoiceResult<Item["id"], ShortcutId>> {
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	await reportLiveChoiceError(ctx, options, error);
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	return { kind: "error", error };
+}
+
+async function reportLiveChoiceError<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(ctx: Context, options: RunLiveChoiceOptions<Item, ShortcutId, Context>, error: unknown) {
+	let reported = false;
+	if (options.onError) {
+		try {
+			await options.onError(ctx, error);
+			reported = true;
+		} catch {
+			// Fall through to Pi's notifier when a custom reporter is unavailable.
+		}
+	}
+	if (reported || !ctx.hasUI || !isCurrent(options) || options.signal?.aborted) return;
+	const message = error instanceof Error ? error.message : String(error);
+	try {
+		uiFor(ctx).notify(`Live choice failed: ${safeMenuText(message)}`, "error");
+	} catch {
+		// Error reporting must not change the typed result.
+	}
+}
+
+function isCurrent<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(options: RunLiveChoiceOptions<Item, ShortcutId, Context>) {
+	return options.isCurrent?.() ?? true;
+}
+
+function uiFor(ctx: MenuContext): ExtensionCommandContext["ui"] {
+	return ctx.ui as ExtensionCommandContext["ui"];
+}

--- a/packages/pi-tui-kit/src/text.ts
+++ b/packages/pi-tui-kit/src/text.ts
@@ -1,0 +1,10 @@
+export function safeMenuText(value: unknown) {
+	return replaceTerminalControls(value).replace(/\s+/gu, " ").trim();
+}
+
+export function replaceTerminalControls(value: unknown) {
+	return Array.from(String(value), (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+	}).join("");
+}

--- a/packages/pi-tui-kit/test/context-usage.ts
+++ b/packages/pi-tui-kit/test/context-usage.ts
@@ -200,6 +200,19 @@ const commandLiveChoice: Promise<RunLiveChoiceResult<"one", never>> = runLiveCho
 );
 void commandLiveChoice;
 
+void runLiveChoice(commandContext, {
+	title: "Invalid shortcut",
+	items: [{ id: "one", label: "One" }],
+	shortcuts: [
+		{
+			id: "invalid",
+			// @ts-expect-error Live-choice shortcuts accept Pi KeyId values, not uppercase aliases.
+			keys: ["E"],
+			label: "invalid",
+		},
+	],
+});
+
 void runLiveChoice(lifecycleContext, {
 	title: "Lifecycle choice",
 	items: [{ id: "one", label: "One" }],

--- a/packages/pi-tui-kit/test/context-usage.ts
+++ b/packages/pi-tui-kit/test/context-usage.ts
@@ -7,10 +7,12 @@ import {
 	type ReviewScreen,
 	type RunConfirmationResult,
 	type RunCustomInteractionResult,
+	type RunLiveChoiceResult,
 	type RunMenuResult,
 	type RunTaskResult,
 	runConfirmation,
 	runCustomInteraction,
+	runLiveChoice,
 	runMenu,
 	runTask,
 } from "../src/index.js";
@@ -186,6 +188,26 @@ void runCustomInteraction(lifecycleContext, {
 		// @ts-expect-error Lifecycle custom interactions must not gain command-only session methods.
 		handleInput: () => void ctx.waitForIdle(),
 	}),
+});
+
+const commandLiveChoice: Promise<RunLiveChoiceResult<"one", never>> = runLiveChoice(
+	commandContext,
+	{
+		title: "Command choice",
+		items: [{ id: "one", label: "One" }],
+		onSelectionChange: async ({ ctx }) => ctx.waitForIdle(),
+	},
+);
+void commandLiveChoice;
+
+void runLiveChoice(lifecycleContext, {
+	title: "Lifecycle choice",
+	items: [{ id: "one", label: "One" }],
+	onSelectionChange: async ({ ctx }) => {
+		ctx.isIdle();
+		// @ts-expect-error Lifecycle live choices must not gain command-only session methods.
+		await ctx.waitForIdle();
+	},
 });
 
 void runTask(lifecycleContext, {

--- a/packages/pi-tui-kit/test/interaction-hints.test.ts
+++ b/packages/pi-tui-kit/test/interaction-hints.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatInteractionHints } from "../src/index.js";
+
+const keybindings = {
+	getKeys(binding: string): readonly string[] {
+		const keys: Record<string, readonly string[]> = {
+			"tui.select.up": ["up", "k", "up"],
+			"tui.select.down": ["down", "j"],
+			"tui.select.confirm": ["return", "enter"],
+			"tui.select.cancel": ["escape", "ctrl+c", "escape"],
+		};
+		return keys[binding] ?? [];
+	},
+};
+
+test("formatInteractionHints formats injected bindings, literal shortcuts, and safe labels", () => {
+	const result = formatInteractionHints(keybindings, [
+		{
+			bindings: ["tui.select.up", "tui.select.down"],
+			label: "live\u0007 preview",
+		},
+		{ bindings: ["tui.select.confirm"], label: "apply" },
+		{
+			bindings: ["tui.select.cancel"],
+			excludeKeys: ["ctrl+c"],
+			label: "back",
+		},
+		{ keys: ["e", "e"], label: "customize" },
+		{ keys: ["ctrl+c"], label: "close" },
+	]);
+
+	assert.equal(
+		result,
+		"↑/k/↓/j live preview • enter apply • esc back • e customize • ctrl+c close",
+	);
+	assert.equal(result.includes("\u001b"), false);
+	assert.equal(result.includes("\u0007"), false);
+});
+
+test("formatInteractionHints supports a sanitized custom separator", () => {
+	assert.equal(
+		formatInteractionHints(
+			keybindings,
+			[
+				{ keys: ["x"], label: "first" },
+				{ keys: ["y"], label: "second" },
+			],
+			{ separator: "\u0007·" },
+		),
+		"x first · y second",
+	);
+});
+
+test("formatInteractionHints omits empty key and label groups", () => {
+	assert.equal(
+		formatInteractionHints(keybindings, [
+			{ bindings: ["tui.select.pageUp"], label: "page" },
+			{ keys: ["\u0007"], label: "unsafe" },
+			{ keys: ["x"], label: "\u0007" },
+		]),
+		"",
+	);
+});

--- a/packages/pi-tui-kit/test/live-choice.test.ts
+++ b/packages/pi-tui-kit/test/live-choice.test.ts
@@ -1,0 +1,371 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { stripVTControlCharacters } from "node:util";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createMockContext } from "../../../test/support.js";
+import { runLiveChoice } from "../src/index.js";
+import { createRpcHarness, createTuiHarness } from "../src/testing/index.js";
+
+const choices = [
+	{
+		id: "minimal",
+		label: "Minimal",
+		description: "Small output",
+		details: ["Model and branch"],
+	},
+	{
+		id: "blocked",
+		label: "Blocked\u001b[31m",
+		description: "Unavailable profile",
+		disabled: true,
+		disabledReason: "Missing\u0007 font",
+	},
+	{
+		id: "full",
+		label: "Full",
+		description: "Everything",
+		details: ["Model, tokens, tools, and time"],
+	},
+] as const;
+
+test("runLiveChoice previews initial and cursor choices and dispatches enabled shortcuts", async () => {
+	const previews: string[] = [];
+	const tui = createTuiHarness({ width: 32, rows: 20 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(context.ctx, {
+		title: "Preset\u001b[2J picker",
+		lines: ["Choose with a live preview."],
+		items: choices,
+		currentItemId: "minimal",
+		initialItemId: "blocked",
+		shortcuts: [{ id: "customize", keys: ["e", "E"], label: "customize" }],
+		onSelectionChange: ({ item }) => {
+			previews.push(item.id);
+		},
+	});
+	await tui.waitForOpen();
+	await Promise.resolve();
+	const frame = tui.render();
+	const plain = stripVTControlCharacters(frame.join("\n"));
+	assert.match(plain, /Minimal.*✓ current/u);
+	assert.match(plain, /Blocked/u);
+	assert.match(plain, /Unavailable: Missing font/u);
+	assert.equal(frame.join("\n").includes("\u001b[2J"), false);
+	for (const line of frame) assert.ok(visibleWidth(line) <= 32);
+	assert.deepEqual(previews, ["blocked"]);
+
+	tui.press("tui.select.confirm");
+	assert.equal(tui.isOpen, true);
+	tui.type("e");
+	assert.equal(tui.isOpen, true);
+	tui.press("tui.select.down");
+	await Promise.resolve();
+	tui.type("e");
+	assert.deepEqual(await running, {
+		kind: "shortcut",
+		shortcutId: "customize",
+		itemId: "full",
+	});
+	assert.deepEqual(previews, ["blocked", "full"]);
+});
+
+test("runLiveChoice shares wrapping, clamped paging, Home, and End selection semantics", async () => {
+	const previews: string[] = [];
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(context.ctx, {
+		title: "Preset",
+		items: choices,
+		initialItemId: "minimal",
+		viewportSize: 2,
+		onSelectionChange: ({ item }) => {
+			previews.push(item.id);
+		},
+	});
+	await tui.waitForOpen();
+	for (const input of [
+		"tui.select.up",
+		"tui.select.down",
+		"tui.select.pageDown",
+		"tui.select.pageDown",
+		"home",
+		"end",
+	] as const) {
+		tui.press(input);
+		await Promise.resolve();
+	}
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "selected", itemId: "full" });
+	assert.deepEqual(previews, ["minimal", "full", "minimal", "full", "full", "minimal", "full"]);
+});
+
+test("runLiveChoice preserves Back, Close, stale ownership, and external disposal", async () => {
+	async function drive(exit: "tui.select.cancel" | "ctrl+c") {
+		const tui = createTuiHarness();
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = runLiveChoice(context.ctx, { title: "Preset", items: choices });
+		await tui.waitForOpen();
+		tui.press(exit);
+		return running;
+	}
+	assert.deepEqual(await drive("tui.select.cancel"), { kind: "closed", reason: "back" });
+	assert.deepEqual(await drive("ctrl+c"), { kind: "closed", reason: "close" });
+
+	const owner = new AbortController();
+	const staleTui = createTuiHarness();
+	const staleContext = createMockContext({ mode: "tui", hasUI: true, custom: staleTui.custom });
+	const stale = runLiveChoice(staleContext.ctx, {
+		title: "Preset",
+		items: choices,
+		signal: owner.signal,
+	});
+	await staleTui.waitForOpen();
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await stale, { kind: "stale" });
+
+	const disposedTui = createTuiHarness();
+	const disposedContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: disposedTui.custom,
+	});
+	const disposed = runLiveChoice(disposedContext.ctx, { title: "Preset", items: choices });
+	await disposedTui.waitForOpen();
+	disposedTui.dispose();
+	assert.deepEqual(await disposed, { kind: "stale" });
+});
+
+test("runLiveChoice blocks cursor previews after generation ownership becomes stale", async () => {
+	let current = true;
+	const previews: string[] = [];
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(context.ctx, {
+		title: "Preset",
+		items: choices,
+		isCurrent: () => current,
+		onSelectionChange: ({ item }) => {
+			previews.push(item.id);
+		},
+	});
+	await tui.waitForOpen();
+	current = false;
+	tui.press("tui.select.down");
+	tui.press("ctrl+c");
+	assert.deepEqual(await running, { kind: "stale" });
+	assert.deepEqual(previews, ["minimal"]);
+});
+
+test("runLiveChoice revalidates generation ownership after an awaited preview", async () => {
+	let current = true;
+	let release: () => void = () => undefined;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(context.ctx, {
+		title: "Preset",
+		items: choices,
+		isCurrent: () => current,
+		onSelectionChange: async () => gate,
+	});
+	await tui.waitForOpen();
+	current = false;
+	release();
+	assert.deepEqual(await running, { kind: "stale" });
+});
+
+test("runLiveChoice aborts and drains preview work while coalescing queued cursor changes", async () => {
+	let release: () => void = () => undefined;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const started: string[] = [];
+	let previewSignal: AbortSignal | undefined;
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(context.ctx, {
+		title: "Preset",
+		items: choices,
+		onSelectionChange: async ({ item, signal }) => {
+			started.push(item.id);
+			previewSignal = signal;
+			await gate;
+		},
+	});
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.cancel");
+	let settled = false;
+	void running.then(() => {
+		settled = true;
+	});
+	await Promise.resolve();
+	assert.equal(settled, false);
+	assert.equal(previewSignal?.aborted, true);
+	release();
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+	assert.deepEqual(started, ["minimal"]);
+});
+
+test("runLiveChoice reports current preview failures without leaking stale failures", async () => {
+	const failure = new Error("Preview failed");
+	let reported: unknown;
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	assert.deepEqual(
+		await runLiveChoice(context.ctx, {
+			title: "Preset",
+			items: choices,
+			onSelectionChange: () => {
+				throw failure;
+			},
+			onError: (_ctx, error) => {
+				reported = error;
+			},
+		}),
+		{ kind: "error", error: failure },
+	);
+	assert.equal(reported, failure);
+});
+
+test("runLiveChoice degrades RPC to ordinary selection without preview or shortcuts", async () => {
+	let previews = 0;
+	const rpc = createRpcHarness([
+		{
+			kind: "select",
+			options: [
+				"Minimal — current · Small output",
+				"[-] Blocked [31m — unavailable: Missing font · Unavailable profile",
+				"Full — Everything",
+				"← Back",
+			],
+			response: "Full — Everything",
+		},
+	]);
+	const base = createMockContext({ mode: "rpc", hasUI: true }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const context = { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+	const result = await runLiveChoice(context, {
+		title: "Preset",
+		items: choices,
+		currentItemId: "minimal",
+		shortcuts: [{ id: "customize", keys: ["e"], label: "customize" }],
+		onSelectionChange: () => {
+			previews += 1;
+		},
+	});
+	assert.deepEqual(result, { kind: "selected", itemId: "full" });
+	assert.equal(previews, 0);
+	rpc.assertConsumed();
+});
+
+test("runLiveChoice keeps disabled RPC rows inert and preserves deterministic Back", async () => {
+	const options = [
+		"Minimal — current · Small output",
+		"[-] Blocked [31m — unavailable: Missing font · Unavailable profile",
+		"Full — Everything",
+		"← Back",
+	];
+	const rpc = createRpcHarness([
+		{ kind: "select", options, response: options[1] },
+		{ kind: "select", options, response: "← Back" },
+	]);
+	const base = createMockContext({ mode: "rpc", hasUI: true }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const context = { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+	assert.deepEqual(
+		await runLiveChoice(context, {
+			title: "Preset",
+			items: choices,
+			currentItemId: "minimal",
+		}),
+		{ kind: "closed", reason: "back" },
+	);
+	rpc.assertConsumed();
+});
+
+test("runLiveChoice gives stale ownership precedence over preview and RPC failures", async () => {
+	const failure = new Error("Late preview failed");
+	const owner = new AbortController();
+	let release: () => void = () => undefined;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let reports = 0;
+	const tui = createTuiHarness();
+	const tuiContext = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(tuiContext.ctx, {
+		title: "Preset",
+		items: choices,
+		signal: owner.signal,
+		onSelectionChange: async () => {
+			await gate;
+			throw failure;
+		},
+		onError: () => {
+			reports += 1;
+		},
+	});
+	await tui.waitForOpen();
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	release();
+	assert.deepEqual(await running, { kind: "stale" });
+	assert.equal(reports, 0);
+
+	const rpcOwner = new AbortController();
+	const rpc = createRpcHarness([{ kind: "select", waitForAbort: true }]);
+	const base = createMockContext({ mode: "rpc", hasUI: true }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const rpcContext = { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+	const rpcRunning = runLiveChoice(rpcContext, {
+		title: "Preset",
+		items: choices,
+		signal: rpcOwner.signal,
+	});
+	await rpc.waitForCall();
+	rpcOwner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await rpcRunning, { kind: "stale" });
+	rpc.assertConsumed();
+});
+
+test("runLiveChoice reports unsupported modes and unsupported callback failures", async () => {
+	const printContext = createMockContext({ mode: "print", hasUI: false });
+	let unsupportedMode = "";
+	assert.deepEqual(
+		await runLiveChoice(printContext.ctx, {
+			title: "Preset",
+			items: choices,
+			onUnsupportedMode: (_ctx, mode) => {
+				unsupportedMode = mode;
+			},
+		}),
+		{ kind: "unsupported", mode: "print" },
+	);
+	assert.equal(unsupportedMode, "print");
+
+	const failure = new Error("Fallback failed");
+	let reported: unknown;
+	assert.deepEqual(
+		await runLiveChoice(printContext.ctx, {
+			title: "Preset",
+			items: choices,
+			onUnsupportedMode: () => {
+				throw failure;
+			},
+			onError: (_ctx, error) => {
+				reported = error;
+			},
+		}),
+		{ kind: "error", error: failure },
+	);
+	assert.equal(reported, failure);
+});

--- a/packages/pi-tui-kit/test/live-choice.test.ts
+++ b/packages/pi-tui-kit/test/live-choice.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { stripVTControlCharacters } from "node:util";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { type KeyId, matchesKey, visibleWidth } from "@earendil-works/pi-tui";
 import { createMockContext } from "../../../test/support.js";
 import { runLiveChoice } from "../src/index.js";
 import { createRpcHarness, createTuiHarness } from "../src/testing/index.js";
@@ -38,7 +38,7 @@ test("runLiveChoice previews initial and cursor choices and dispatches enabled s
 		items: choices,
 		currentItemId: "minimal",
 		initialItemId: "blocked",
-		shortcuts: [{ id: "customize", keys: ["e", "E"], label: "customize" }],
+		shortcuts: [{ id: "customize", keys: ["e", "shift+e"], label: "customize" }],
 		onSelectionChange: ({ item }) => {
 			previews.push(item.id);
 		},
@@ -60,13 +60,52 @@ test("runLiveChoice previews initial and cursor choices and dispatches enabled s
 	assert.equal(tui.isOpen, true);
 	tui.press("tui.select.down");
 	await Promise.resolve();
-	tui.type("e");
+	tui.type("E");
 	assert.deepEqual(await running, {
 		kind: "shortcut",
 		shortcutId: "customize",
 		itemId: "full",
 	});
 	assert.deepEqual(previews, ["blocked", "full"]);
+});
+
+test("runLiveChoice omits shortcuts that conflict with remapped standard controls", async () => {
+	const bindingKeys = (binding: string): KeyId[] => {
+		switch (binding) {
+			case "tui.select.up":
+				return ["up"];
+			case "tui.select.down":
+				return ["e"];
+			case "tui.select.pageUp":
+				return ["pageUp"];
+			case "tui.select.pageDown":
+				return ["pageDown"];
+			case "tui.select.confirm":
+				return ["enter"];
+			case "tui.select.cancel":
+				return ["escape", "ctrl+c"];
+			default:
+				return [];
+		}
+	};
+	const tui = createTuiHarness({
+		keybindings: {
+			getKeys: (binding) => bindingKeys(binding),
+			matches: (data, binding) => bindingKeys(binding).some((key) => matchesKey(data, key)),
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(context.ctx, {
+		title: "Preset",
+		items: [choices[0], choices[2]],
+		shortcuts: [{ id: "customize", keys: ["e", "return"], label: "customize" }],
+	});
+	await tui.waitForOpen();
+	assert.doesNotMatch(tui.render().join("\n"), /customize/u);
+
+	tui.type("e");
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "selected", itemId: "full" });
 });
 
 test("runLiveChoice shares wrapping, clamped paging, Home, and End selection semantics", async () => {

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -38,8 +38,8 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("package exposes declarative API version 8", () => {
-	assert.equal(PI_EXTENSION_MENU_API_VERSION, 8);
+test("package exposes API version 9", () => {
+	assert.equal(PI_EXTENSION_MENU_API_VERSION, 9);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/readme-usage.ts
+++ b/packages/pi-tui-kit/test/readme-usage.ts
@@ -2,11 +2,14 @@ import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
 	type BrowseScreen,
 	defineMenu,
+	formatInteractionHints,
 	type InputScreen,
 	type MenuCloseReason,
 	type MultiSelectScreen,
 	type ReviewScreen,
+	type RunLiveChoiceResult,
 	runCustomInteraction,
+	runLiveChoice,
 	runMenu,
 } from "../src/index.js";
 import { createRpcHarness, createTuiHarness } from "../src/testing/index.js";
@@ -156,14 +159,45 @@ export function showSpecializedView(ctx: ExtensionCommandContext, generation: nu
 	return runCustomInteraction<{ kind: "back" | "close" }>(ctx, {
 		signal: currentSessionSignal(),
 		isCurrent: () => generation === currentGeneration(),
-		create: ({ keybindings, signal, complete }) => ({
-			render: () => [signal.aborted ? "Closing…" : "Specialized view"],
-			invalidate() {},
-			handleInput(data) {
-				if (keybindings.matches(data, "tui.select.cancel")) complete({ kind: "back" });
-			},
-		}),
+		create: ({ keybindings, signal, complete }) => {
+			const hint = formatInteractionHints(keybindings, [
+				{ bindings: ["tui.select.up", "tui.select.down"], label: "navigate" },
+				{ keys: ["e"], label: "edit" },
+			]);
+			return {
+				render: () => [signal.aborted ? "Closing…" : `Specialized view · ${hint}`],
+				invalidate() {},
+				handleInput(data: string) {
+					if (keybindings.matches(data, "tui.select.cancel")) complete({ kind: "back" });
+				},
+			};
+		},
 	});
+}
+
+export async function choosePreset(ctx: ExtensionCommandContext, generation: number) {
+	const previousPreview = "minimal";
+	let preview = previousPreview;
+	let result: RunLiveChoiceResult<"minimal" | "full", "customize"> | undefined;
+	try {
+		result = await runLiveChoice(ctx, {
+			title: "Preset",
+			items: [
+				{ id: "minimal", label: "Minimal" },
+				{ id: "full", label: "Full" },
+			],
+			currentItemId: "minimal",
+			shortcuts: [{ id: "customize", keys: ["e"], label: "customize" }],
+			signal: currentSessionSignal(),
+			isCurrent: () => generation === currentGeneration(),
+			onSelectionChange: ({ item, signal }) => {
+				if (!signal.aborted) preview = item.id;
+			},
+		});
+	} finally {
+		preview = previousPreview;
+	}
+	return { result, preview };
 }
 
 export async function driveMenuWithSupportedTuiHarness() {

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -309,6 +309,41 @@ test("choice screens page through a bounded viewport and sanitize all displayed 
 	assert.ok(harness.component.render(24).every((line) => visibleWidth(line) <= 24));
 });
 
+test("choice selection wraps single steps, clamps jumps, and handles empty lists", () => {
+	const items = Array.from({ length: 6 }, (_, index) => ({
+		id: `choice-${index}`,
+		label: `Choice ${index}`,
+	}));
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "choice",
+		title: "Selection movement",
+		items,
+		action: "choose",
+		viewportSize: 2,
+	};
+	const harness = componentHarness(screen, { selectedItemId: "choice-0" });
+	harness.component.handleInput("k");
+	harness.component.handleInput("l");
+	harness.component.handleInput("j");
+	harness.component.handleInput("u");
+	harness.component.handleInput("\u001b[F");
+	harness.component.handleInput("l");
+	harness.component.handleInput("\u001b[H");
+	harness.component.handleInput("l");
+	assert.deepEqual(harness.events, [
+		{ kind: "activate", itemId: "choice-5" },
+		{ kind: "activate", itemId: "choice-5" },
+		{ kind: "activate", itemId: "choice-0" },
+	]);
+
+	const empty = componentHarness({ ...screen, items: [] });
+	for (const input of ["k", "j", "u", "d", "\u001b[H", "\u001b[F", "l"]) {
+		empty.component.handleInput(input);
+	}
+	assert.deepEqual(empty.selectionChanges, []);
+	assert.deepEqual(empty.events, []);
+});
+
 test("theme invalidation rebuilds themed title content", () => {
 	let accent = "first";
 	const harness = componentHarness(actionScreen, {

--- a/packages/pi-tui-kit/test/testing-exports.test.ts
+++ b/packages/pi-tui-kit/test/testing-exports.test.ts
@@ -11,9 +11,11 @@ test("built package roots resolve separate production and testing exports", asyn
 	const testingSpecifier = "@narumitw/pi-tui-kit/testing";
 	const production = await import(productionSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 8);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 9);
+	assert.equal(typeof production.formatInteractionHints, "function");
 	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");
+	assert.equal(typeof production.runLiveChoice, "function");
 	assert.equal("createTuiHarness" in production, false);
 	assert.equal("createRpcHarness" in production, false);
 	assert.deepEqual(Object.keys(testing).sort(), ["createRpcHarness", "createTuiHarness"]);
@@ -26,7 +28,7 @@ test("built package roots resolve separate production and testing exports", asyn
 		path.join(fixture, "usage.ts"),
 		`import { PI_EXTENSION_MENU_API_VERSION } from "@narumitw/pi-tui-kit";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 8 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const version: 9 = PI_EXTENSION_MENU_API_VERSION;\n` +
 			`void version;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
 	);
 	writeFileSync(


### PR DESCRIPTION
## Summary

- add `runLiveChoice()` with live cursor callbacks, typed exits and shortcuts, lifecycle-safe draining, and deterministic RPC selection fallback
- share stable-ID choice navigation through an internal selection controller and expose reusable `formatInteractionHints()` formatting
- document source API 9, archive the implementation plan, update the Pi TUI Kit roadmap, and add Kit-only minor release intent

## Verification

- `npm run check` — 2,562 tests passed
- `npm run check --workspace @narumitw/pi-tui-kit`
- `just pack tui-kit` — 57 files, 48.8 kB packed / 222.2 kB unpacked
- signed commit verified by the commit's SSH `gpgsig`

## Release boundary

This PR changes only `@narumitw/pi-tui-kit`. Pi Statusline and Pi Starship migrations remain separate post-publication changes so consumers do not raise their compatibility floor before API 9 is published.
