### PR TITLE
feat(file-context): add cwd content search

### DIFF
--- a/.changeset/calm-books-search.md
+++ b/.changeset/calm-books-search.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": minor
+---
+
+Add cancellable cwd content search with highlighted result cards, case and fuzzy toggles, and matched-line preview navigation.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -44,6 +44,7 @@
 - Sanitize terminal escapes before path splitting or truncation; OSC payloads can contain `/` and otherwise change path-component semantics before final-sink sanitization.
 - `wrapTextWithAnsi` trims whitespace at word-wrap boundaries; use cell-aware hard wrapping or horizontal scrolling for exact code/text previews.
 - A custom component embedding `Input` or `Editor` must implement `Focusable` and forward `focused`. Sanitize pasted input after handling but before rendering/filtering so the child retains its own cursor escapes.
+- Pi can remove `ctx.ui.custom()` components during session reset without invoking their `done()` callback or `dispose()`. Retain active components and explicitly dispose and settle them from session replacement and shutdown hooks.
 - Pi's public `SelectList.handleInput()` reads global keybindings, while `ctx.ui.select()` maps both Escape and Ctrl+C to `undefined`. Wrappers needing injected keys or distinct Back/Close outcomes must dispatch those keys themselves.
 - `Editor.getText()` retains large pastes as markers; use `getExpandedText()` when moving a draft outside that editor.
 - Tests constructing `BorderedLoader` must initialize a theme and dispose the loader harness so its animation timer cannot keep Node alive.

--- a/docs/plans/archived/2026-08-08_pi-file-context-content-search-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-file-context-content-search-plan.md
@@ -22,7 +22,7 @@ Add an approved content-search mode to `pi-file-context`: `Ctrl+F` switches from
 - [x] Added focused explorer tests for `Ctrl+F`, result cards/highlighting, `Alt+C`, `Alt+F`, matched-line preview entry, preserved search state on `Escape`, width safety, cancellation, disposal, and stale opens; initial `npm test` failed because `FileQuoteExplorer.dispose()` was absent.
 - [x] Implemented the approved screen through `content-search-session.ts`, `content-search-ui.ts`, and `file-context-explorer.ts`; the explorer remains below 1,000 lines and all focused package tests pass.
 - [x] Updated `packages/pi-file-context/README.md` and added `.changeset/calm-books-search.md` with a minor release; documentation matches the tested keyboard, lifecycle, and limit behavior.
-- [x] Ran the 39 focused `pi-file-context` tests and package check, then `npm run check`; the final CI-equivalent gate passed all 2,559 tests.
+- [x] Ran the 42 focused `pi-file-context` tests and package check, then `npm run check`; the final CI-equivalent gate passed all 2,562 tests.
 - [x] Ran `just pack file-context` and inspected all 11 expected published files; a non-interactive offline Pi load smoke exited successfully. The live custom-TUI path was not opened because repository execution policy forbids interactive TUI commands; deterministic component tests exercise that path.
 
 ## Completion Checklist
@@ -32,6 +32,6 @@ Add an approved content-search mode to `pi-file-context`: `Ctrl+F` switches from
 - [x] Explorer tests prove selected path/line cards, distant-match context, terminal sanitization, IME focus forwarding, navigation, and width bounds.
 - [x] Explorer tests prove matched-line preview entry and restoration of the content query, result selection, and scroll position on `Escape`.
 - [x] Abort-aware discovery/read/Git paths plus cancellation, disposal, stale-open, session-owner, and shutdown guards prevent stale publication and release owned work.
-- [x] The final 2,559-test repository gate covers existing file search, `Tab` references, Git views, quote injection, and non-TUI rejection; focused tests also cover content-result `Tab`.
+- [x] The final 2,562-test repository gate covers existing file search, `Tab` references, Git views, quote injection, and non-TUI rejection; focused tests also cover content-result `Tab`.
 - [x] Audited `docs/extension-conventions.md` custom-TUI and lifecycle MUST rules: TUI guards remain, lines are bounded, theme/input invalidation and IME focus are forwarded, every owned async path is abortable and stale-guarded, and deterministic tests cover cancellation/disposal. No settings guide applies because no setting is persisted.
 - [x] `.changeset/calm-books-search.md` reports a minor bump to 0.50.0; `npm run check`, `just pack file-context`, `npm run changeset:status`, non-interactive Pi load smoke, and `git diff --check` pass.

--- a/docs/plans/archived/2026-08-08_pi-file-context-content-search-plan.md
+++ b/docs/plans/archived/2026-08-08_pi-file-context-content-search-plan.md
@@ -1,0 +1,37 @@
+# Pi File Context content search plan
+
+## Goal
+
+Add an approved content-search mode to `pi-file-context`: `Ctrl+F` switches from the existing file-name picker to cwd file contents, literal case-insensitive search is the default, `Alt+C` and `Alt+F` toggle case-sensitive and fuzzy matching, result cards highlight matches, and `Enter` opens the existing line-range preview at the matched line.
+
+## Architecture
+
+- Keep filesystem discovery and safe bounded reads owned by `file-context.ts`.
+- Add a focused content-search module that scans discovered files with cancellation, bounded results, match ranges, and skipped-file reporting.
+- Keep navigation and rendering in `FileQuoteExplorer`, preserving file-name search, whole-file references, Git detail flows, pending quotes, and non-TUI behavior.
+- Treat content searching, file opening, cancellation, component disposal, session replacement, and shutdown as separate lifecycle paths.
+
+## Non-Goals
+
+- Character-range attachment, persistent search settings, mouse selection, external search-process dependencies, or changing the established `@` trigger.
+
+## Plan
+
+- [x] Added focused literal, case-sensitive, fuzzy, bounded, and cancellation tests in `packages/pi-file-context/test/content-search.test.ts` plus abort-aware read coverage; initial `npm test` failed because `content-search.js` and `LoadOptions.signal` were absent.
+- [x] Implemented `packages/pi-file-context/src/content-search.ts` and abort-aware safe reads; focused matcher, Unicode-range, and filesystem tests pass.
+- [x] Added focused explorer tests for `Ctrl+F`, result cards/highlighting, `Alt+C`, `Alt+F`, matched-line preview entry, preserved search state on `Escape`, width safety, cancellation, disposal, and stale opens; initial `npm test` failed because `FileQuoteExplorer.dispose()` was absent.
+- [x] Implemented the approved screen through `content-search-session.ts`, `content-search-ui.ts`, and `file-context-explorer.ts`; the explorer remains below 1,000 lines and all focused package tests pass.
+- [x] Updated `packages/pi-file-context/README.md` and added `.changeset/calm-books-search.md` with a minor release; documentation matches the tested keyboard, lifecycle, and limit behavior.
+- [x] Ran the 39 focused `pi-file-context` tests and package check, then `npm run check`; the final CI-equivalent gate passed all 2,559 tests.
+- [x] Ran `just pack file-context` and inspected all 11 expected published files; a non-interactive offline Pi load smoke exited successfully. The live custom-TUI path was not opened because repository execution policy forbids interactive TUI commands; deterministic component tests exercise that path.
+
+## Completion Checklist
+
+- [x] `content-search.test.ts` proves default `this is` matches both example files case-insensitively while `thisis` has no literal result.
+- [x] Matcher and explorer tests prove fuzzy `thisis` matching plus visible `Alt+C` case and `Alt+F` fuzzy states.
+- [x] Explorer tests prove selected path/line cards, distant-match context, terminal sanitization, IME focus forwarding, navigation, and width bounds.
+- [x] Explorer tests prove matched-line preview entry and restoration of the content query, result selection, and scroll position on `Escape`.
+- [x] Abort-aware discovery/read/Git paths plus cancellation, disposal, stale-open, session-owner, and shutdown guards prevent stale publication and release owned work.
+- [x] The final 2,559-test repository gate covers existing file search, `Tab` references, Git views, quote injection, and non-TUI rejection; focused tests also cover content-result `Tab`.
+- [x] Audited `docs/extension-conventions.md` custom-TUI and lifecycle MUST rules: TUI guards remain, lines are bounded, theme/input invalidation and IME focus are forwarded, every owned async path is abortable and stale-guarded, and deterministic tests cover cancellation/disposal. No settings guide applies because no setting is persisted.
+- [x] `.changeset/calm-books-search.md` reports a minor bump to 0.50.0; `npm run check`, `just pack file-context`, `npm run changeset:status`, non-interactive Pi load smoke, and `git diff --check` pass.

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -13,7 +13,8 @@ Browse project files inside Pi, preview text, select a line range, and attach th
 
 - Opens the file explorer when `@` is typed at a word boundary in Pi's normal editor.
 - Provides `/file-context` as a discoverable fallback when another extension owns the editor.
-- Fuzzy-searches project files with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
+- Fuzzy-searches project file names with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
+- Switches with `Ctrl+F` to cancellable cwd content search with highlighted result cards, literal case-insensitive matching by default, and visible case-sensitive and fuzzy toggles.
 - Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
 - Selects a contiguous line range or changed hunk without using the system clipboard and shows a deterministic token estimate before attachment.
 - Discloses current-line blame and bounded file history, opens a validated commit/branch/tag version, and attaches explicit Git diff hunks.
@@ -43,14 +44,14 @@ pi -e ./packages/pi-file-context
 ## 🚀 Quick start
 
 1. Type `@` at the start of a word in Pi's editor. If another custom editor is active, run `/file-context` instead.
-2. Type to fuzzy-search files in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
-3. In the preview, move to the first line and press `Space` to anchor the selection.
-4. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
-5. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.
-6. Repeat from `@` to attach more ranges from the same or different files.
-7. Write the question and submit normally. All pending quotes are attached in selection order and then cleared together.
+2. Type to fuzzy-search file names in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
+3. Press `Ctrl+F` to switch between file-name and content search. Content search is literal and case-insensitive by default; `Alt+C` toggles case sensitivity and `Alt+F` toggles ordered fuzzy matching. The current states remain visible above the results.
+4. In content results, use `Up`/`Down` to choose a highlighted path-and-line card. Press `Tab` for a whole-file reference or `Enter` to preview the file at that line. `Escape` from the preview restores the query, result selection, and scroll position.
+5. In the preview, press `Space` to anchor the selection. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
+6. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.
+7. Repeat from `@` to attach more ranges from the same or different files, then write the question and submit normally. All pending quotes are attached in selection order and then cleared together.
 
-`Escape` returns from a preview to the file list; from the file list it cancels without changing the draft. `Ctrl+C` cancels from either view.
+`Escape` returns from a preview to its originating file-name or content results; from either search screen it cancels without changing the draft. `Ctrl+C` cancels from every view.
 
 The agent receives an explicit block similar to:
 
@@ -78,8 +79,9 @@ RPC receives an observable warning. JSON and print modes do not enter custom UI.
 - File paths and symlink targets are checked against the real project root before reading.
 - Preview files are limited to 1 MB and NUL-containing files are treated as binary.
 - Discovery is limited to 5,000 files and skips symlinks.
-- File-search queries are limited to 256 characters before candidate scoring.
-- Terminal control characters are escaped before file names, Git refs, authors, summaries, or file contents are rendered.
+- File-name and content-search queries are limited to 256 characters. Content search returns at most 100 cards and reports truncation and unreadable, oversized, or binary files as skipped.
+- Content search uses the same 5,000-file, 1 MB-per-file, real-project-path, and no-symlink boundaries as preview loading. Superseded searches and file opens are cancelled.
+- Terminal control characters are escaped before file names, Git refs, authors, summaries, search context, or file contents are rendered.
 - Git is invoked read-only without a shell, pager, external diff, or text conversion; commands time out after 5 seconds and output is bounded to 1.1 MB.
 - Revision names are resolved to a commit before file loading. Historical files remain subject to the 1 MB and binary guards.
 - Blame shows the author name but not author email. Commit summaries and diffs can still contain sensitive project text; inspect selections before attachment.
@@ -93,19 +95,27 @@ RPC receives an observable warning. JSON and print modes do not enter custom UI.
 - Pending quotes do not survive `/reload`, session replacement, or shutdown.
 - The `@` trigger is not installed when another extension already owns the custom editor; `/file-context` remains available.
 - File discovery uses a small built-in ignore list rather than `.gitignore` semantics.
+- Content search scans discovered files natively and sequentially; large projects or queries with no matches may take longer than indexed or external search tools.
+- Fuzzy content search matches query characters in order on one line; it is not semantic search and does not cross line boundaries.
 - Git integration degrades to the original filesystem-only workflow outside a repository or when Git metadata cannot be read.
 - File history is limited to the 20 most recent commits. Untracked files have status and provenance but no HEAD diff hunk until Git tracks them.
 
 ## 🗂️ Package layout
 
 ```text
-src/index.ts                 Thin Pi entrypoint
+src/index.ts                   Thin Pi entrypoint
 src/file-context.ts            Lifecycle, filesystem boundaries, quote injection
 src/file-context-explorer.ts   File list, Git detail views, and line-range TUI
-src/file-search.ts             Bounded native fuzzy matching and relevance ranking
+src/content-search.ts          Bounded literal and fuzzy content matching
+src/content-search-session.ts  Search input, toggles, navigation, and cancellation
+src/content-search-ui.ts       Width-safe result cards and highlighted context
+src/file-search.ts             Bounded native fuzzy file-name ranking
 src/git-context.ts             Bounded read-only Git status, diff, blame, history, revisions
 
-test/file-context.test.ts      Filesystem, prompt, lifecycle, and TUI tests
+test/content-search.test.ts     Content matcher behavior and limits
+test/content-search-ui.test.ts  Content interaction, rendering, and lifecycle tests
+test/file-context.test.ts       Filesystem, prompt, lifecycle, and explorer tests
+test/git-context.test.ts        Git repository behavior and parser tests
 ```
 
 ## 🔎 Keywords

--- a/packages/pi-file-context/src/content-search-session.ts
+++ b/packages/pi-file-context/src/content-search-session.ts
@@ -1,0 +1,209 @@
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import { Input, Key, matchesKey, type TUI, visibleWidth } from "@earendil-works/pi-tui";
+import { type ContentSearchMatch, searchProjectContents } from "./content-search.js";
+import { contentSearchCardCapacity, renderContentSearchScreen } from "./content-search-ui.js";
+import type { LoadedProjectTextFile } from "./file-context.js";
+
+interface ContentSearchSessionOptions {
+	tui: TUI;
+	theme: Theme;
+	keybindings: KeybindingsManager;
+	files: readonly string[];
+	cwd?: string;
+	loadFile: (path: string, signal?: AbortSignal) => Promise<LoadedProjectTextFile>;
+	onPreview: (match: ContentSearchMatch) => void;
+	onReference: (path: string) => void;
+	onSwitchFiles: () => void;
+	onCancel: () => void;
+}
+
+export class ContentSearchSession {
+	private readonly input = new Input();
+	private matches: ContentSearchMatch[] = [];
+	private selectedIndex = 0;
+	private scrollOffset = 0;
+	private caseSensitive = false;
+	private fuzzy = false;
+	private truncated = false;
+	private skippedFiles = 0;
+	private loading = false;
+	private request = 0;
+	private controller: AbortController | undefined;
+	private error: string | undefined;
+	private disposed = false;
+
+	constructor(private readonly options: ContentSearchSessionOptions) {}
+
+	set focused(value: boolean) {
+		this.input.focused = value;
+	}
+
+	activate(): void {
+		this.disposed = false;
+		if (this.input.getValue().trim()) this.startSearch();
+	}
+
+	deactivate(): void {
+		this.focused = false;
+		this.cancelSearch();
+	}
+
+	render(width: number, availableRows: number, opening: boolean, externalError?: string): string[] {
+		const capacity = contentSearchCardCapacity(availableRows);
+		this.keepSelectionVisible(capacity);
+		const queryLabel = this.options.theme.fg("muted", "Search: ");
+		const queryWidth = Math.max(1, width - visibleWidth(queryLabel));
+		const queryLine = `${queryLabel}${this.input.render(queryWidth)[0] ?? ""}`;
+		return renderContentSearchScreen({
+			theme: this.options.theme,
+			width,
+			availableRows,
+			queryLine,
+			query: this.input.getValue(),
+			cwd: this.options.cwd,
+			matches: this.matches,
+			selectedIndex: this.selectedIndex,
+			scrollOffset: this.scrollOffset,
+			caseSensitive: this.caseSensitive,
+			fuzzy: this.fuzzy,
+			loading: this.loading,
+			opening,
+			truncated: this.truncated,
+			skippedFiles: this.skippedFiles,
+			error: externalError ?? this.error,
+		});
+	}
+
+	handleInput(data: string): void {
+		if (this.disposed) return;
+		if (matchesKey(data, Key.ctrl("f"))) {
+			this.options.onSwitchFiles();
+			return;
+		}
+		if (matchesKey(data, Key.escape)) {
+			this.options.onCancel();
+			return;
+		}
+		if (matchesKey(data, Key.alt("c"))) {
+			this.caseSensitive = !this.caseSensitive;
+			this.startSearch();
+			return;
+		}
+		if (matchesKey(data, Key.alt("f"))) {
+			this.fuzzy = !this.fuzzy;
+			this.startSearch();
+			return;
+		}
+		if (this.options.keybindings.matches(data, "tui.select.up")) {
+			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+			return;
+		}
+		if (this.options.keybindings.matches(data, "tui.select.down")) {
+			this.selectedIndex = Math.min(Math.max(0, this.matches.length - 1), this.selectedIndex + 1);
+			return;
+		}
+		if (this.options.keybindings.matches(data, "tui.select.pageUp")) {
+			this.selectedIndex = Math.max(0, this.selectedIndex - 10);
+			return;
+		}
+		if (this.options.keybindings.matches(data, "tui.select.pageDown")) {
+			this.selectedIndex = Math.min(Math.max(0, this.matches.length - 1), this.selectedIndex + 10);
+			return;
+		}
+		if (this.options.keybindings.matches(data, "tui.select.confirm")) {
+			const match = this.matches[this.selectedIndex];
+			if (match) this.options.onPreview(match);
+			return;
+		}
+		if (this.options.keybindings.matches(data, "tui.input.tab")) {
+			const match = this.matches[this.selectedIndex];
+			if (match) this.options.onReference(match.path);
+			return;
+		}
+
+		const previousQuery = this.input.getValue();
+		this.input.handleInput(data);
+		if (this.input.getValue() !== previousQuery) this.startSearch();
+	}
+
+	invalidate(): void {
+		this.input.invalidate();
+	}
+
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.cancelSearch();
+	}
+
+	private startSearch(): void {
+		this.cancelSearch();
+		const query = this.input.getValue();
+		this.matches = [];
+		this.selectedIndex = 0;
+		this.scrollOffset = 0;
+		this.truncated = false;
+		this.skippedFiles = 0;
+		this.error = undefined;
+		if (!query.trim()) return;
+
+		const request = this.request;
+		const controller = new AbortController();
+		this.controller = controller;
+		this.loading = true;
+		void searchProjectContents(this.options.files, this.options.loadFile, query, {
+			caseSensitive: this.caseSensitive,
+			fuzzy: this.fuzzy,
+			signal: controller.signal,
+		})
+			.then((result) => {
+				if (!this.isCurrent(request, controller)) return;
+				this.matches = result.matches;
+				this.truncated = result.truncated;
+				this.skippedFiles = result.skippedFiles;
+			})
+			.catch((error: unknown) => {
+				if (this.isCurrent(request, controller) && !isAbortError(error)) {
+					this.error = formatError(error);
+				}
+			})
+			.finally(() => {
+				if (request === this.request) {
+					this.loading = false;
+					this.controller = undefined;
+				}
+				if (!this.disposed) this.options.tui.requestRender();
+			});
+	}
+
+	private cancelSearch(): void {
+		this.request += 1;
+		this.controller?.abort();
+		this.controller = undefined;
+		this.loading = false;
+	}
+
+	private isCurrent(request: number, controller: AbortController): boolean {
+		return (
+			!this.disposed &&
+			request === this.request &&
+			this.controller === controller &&
+			!controller.signal.aborted
+		);
+	}
+
+	private keepSelectionVisible(capacity: number): void {
+		if (this.selectedIndex < this.scrollOffset) this.scrollOffset = this.selectedIndex;
+		if (this.selectedIndex >= this.scrollOffset + capacity) {
+			this.scrollOffset = this.selectedIndex - capacity + 1;
+		}
+	}
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-file-context/src/content-search-ui.ts
+++ b/packages/pi-file-context/src/content-search-ui.ts
@@ -1,0 +1,172 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { ContentMatchRange, ContentSearchMatch } from "./content-search.js";
+
+export const CONTENT_SEARCH_CARD_ROWS = 3;
+
+interface ContentSearchScreenOptions {
+	theme: Theme;
+	width: number;
+	availableRows: number;
+	queryLine: string;
+	query: string;
+	cwd?: string;
+	matches: readonly ContentSearchMatch[];
+	selectedIndex: number;
+	scrollOffset: number;
+	caseSensitive: boolean;
+	fuzzy: boolean;
+	loading: boolean;
+	opening: boolean;
+	truncated: boolean;
+	skippedFiles: number;
+	error?: string;
+}
+
+export function contentSearchCardCapacity(availableRows: number): number {
+	return Math.max(1, Math.floor((availableRows - 4) / CONTENT_SEARCH_CARD_ROWS));
+}
+
+export function renderContentSearchScreen(options: ContentSearchScreenOptions): string[] {
+	const { theme, width, availableRows } = options;
+	const capacity = contentSearchCardCapacity(availableRows);
+	const cwdLabel = options.cwd ? ` · cwd: ${escapeTerminalControls(options.cwd)}` : "";
+	const title = theme.fg("accent", theme.bold(`File Context · Content Search${cwdLabel}`));
+	const modes = theme.fg(
+		"muted",
+		`Case: ${options.caseSensitive ? "on" : "off"} · Fuzzy: ${options.fuzzy ? "on" : "off"} · Alt+C case · Alt+F fuzzy`,
+	);
+	const body: string[] = [];
+
+	if (options.error) {
+		body.push(theme.fg("error", `  Search failed: ${escapeTerminalControls(options.error)}`));
+	} else if (options.loading) {
+		body.push(theme.fg("warning", "  Searching…"));
+	} else if (!options.query.trim()) {
+		body.push(theme.fg("muted", "  Type text to search project contents"));
+	} else if (options.matches.length === 0) {
+		body.push(
+			theme.fg(
+				"muted",
+				`  No matches for "${escapeTerminalControls(options.query)}"${options.fuzzy ? "" : " · Alt+F enables fuzzy matching"}`,
+			),
+		);
+	} else {
+		const visible = options.matches.slice(options.scrollOffset, options.scrollOffset + capacity);
+		for (let visibleIndex = 0; visibleIndex < visible.length; visibleIndex += 1) {
+			const index = options.scrollOffset + visibleIndex;
+			const match = visible[visibleIndex];
+			if (match) {
+				body.push(...renderContentSearchCard(match, index === options.selectedIndex, width, theme));
+			}
+		}
+	}
+
+	const count = `${options.matches.length}${options.truncated ? "+" : ""} matches`;
+	const skipped = options.skippedFiles > 0 ? ` · ${options.skippedFiles} skipped` : "";
+	const action = options.opening
+		? "Opening…"
+		: `${count}${skipped} · ↑↓ navigate · Enter preview · Tab reference · Ctrl+F files · Esc cancel`;
+	return fitRows(
+		[
+			truncateToWidth(title, width, ""),
+			truncateToWidth(options.queryLine, width, ""),
+			truncateToWidth(modes, width, ""),
+			...body.map((line) => truncateToWidth(line, width, "")),
+			truncateToWidth(theme.fg(options.opening ? "warning" : "muted", action), width, ""),
+		],
+		availableRows,
+	);
+}
+
+export function highlightContentRanges(
+	line: string,
+	ranges: readonly ContentMatchRange[],
+	theme: Theme,
+): string {
+	let result = "";
+	let index = 0;
+	for (const range of ranges) {
+		const start = Math.max(index, Math.min(line.length, range.start));
+		const end = Math.max(start, Math.min(line.length, range.end));
+		result += escapeTerminalControls(line.slice(index, start));
+		result += theme.fg("warning", theme.bold(escapeTerminalControls(line.slice(start, end))));
+		index = end;
+	}
+	return result + escapeTerminalControls(line.slice(index));
+}
+
+function renderContentSearchCard(
+	match: ContentSearchMatch,
+	selected: boolean,
+	width: number,
+	theme: Theme,
+): string[] {
+	if (width < 8) {
+		return [
+			truncateToWidth(`${selected ? ">" : " "}${escapeTerminalControls(match.path)}`, width, ""),
+		];
+	}
+	const prefix = selected ? theme.fg("accent", "> ") : "  ";
+	const cardWidth = Math.max(4, width - visibleWidth(prefix));
+	const innerWidth = Math.max(1, cardWidth - 2);
+	const borderColor = selected ? "borderAccent" : "borderMuted";
+	const border = (text: string) => theme.fg(borderColor, text);
+	const rawTitle = ` ${escapeTerminalControls(match.path)} · L${match.lineNumber} `;
+	const title = truncateToWidth(rawTitle, innerWidth, "");
+	const titleFill = "─".repeat(Math.max(0, innerWidth - visibleWidth(title)));
+	const context = clipMatchContext(match, Math.max(1, innerWidth - 1));
+	const highlighted = highlightContentRanges(context.line, context.ranges, theme);
+	const content = truncateToWidth(` ${highlighted}`, innerWidth, "");
+	const contentFill = " ".repeat(Math.max(0, innerWidth - visibleWidth(content)));
+	const contentLine = `${border("│")}${content}${contentFill}${border("│")}`;
+	return [
+		`${prefix}${border("╭")}${title}${border(`${titleFill}╮`)}`,
+		`${" ".repeat(visibleWidth(prefix))}${selected ? theme.bg("selectedBg", contentLine) : contentLine}`,
+		`${" ".repeat(visibleWidth(prefix))}${border(`╰${"─".repeat(innerWidth)}╯`)}`,
+	];
+}
+
+function clipMatchContext(
+	match: ContentSearchMatch,
+	maxCharacters: number,
+): { line: string; ranges: ContentMatchRange[] } {
+	const firstStart = match.ranges[0]?.start ?? 0;
+	const lastEnd = match.ranges.at(-1)?.end ?? firstStart;
+	const matchSpan = Math.max(1, lastEnd - firstStart);
+	const before = Math.max(0, Math.floor((maxCharacters - Math.min(matchSpan, maxCharacters)) / 3));
+	const rawStart = Math.max(0, firstStart - before);
+	const prefix = rawStart > 0 ? "…" : "";
+	const availableRawCharacters = Math.max(1, maxCharacters - prefix.length - 1);
+	let rawEnd = Math.min(match.line.length, rawStart + availableRawCharacters);
+	if (rawEnd < lastEnd) rawEnd = Math.min(match.line.length, lastEnd);
+	const suffix = rawEnd < match.line.length ? "…" : "";
+	const line = `${prefix}${match.line.slice(rawStart, rawEnd)}${suffix}`;
+	const ranges = match.ranges.flatMap((range): ContentMatchRange[] => {
+		const start = Math.max(rawStart, range.start);
+		const end = Math.min(rawEnd, range.end);
+		return end > start
+			? [{ start: prefix.length + start - rawStart, end: prefix.length + end - rawStart }]
+			: [];
+	});
+	return { line, ranges };
+}
+
+function fitRows(lines: string[], height: number): string[] {
+	if (lines.length <= height) return lines;
+	if (height <= 1) return lines.slice(0, 1);
+	return [...lines.slice(0, height - 1), lines.at(-1) ?? ""];
+}
+
+function escapeTerminalControls(text: string): string {
+	return [...text]
+		.map((character) => {
+			if (character === "\t") return "    ";
+			const code = character.charCodeAt(0);
+			if (code <= 31 || (code >= 127 && code <= 159)) {
+				return `\\x${code.toString(16).padStart(2, "0")}`;
+			}
+			return character;
+		})
+		.join("");
+}

--- a/packages/pi-file-context/src/content-search.ts
+++ b/packages/pi-file-context/src/content-search.ts
@@ -1,0 +1,180 @@
+const MAX_CONTENT_QUERY_LENGTH = 256;
+const DEFAULT_MAX_RESULTS = 100;
+
+export interface ContentMatchRange {
+	start: number;
+	end: number;
+}
+
+export interface ContentSearchMatch {
+	path: string;
+	lineNumber: number;
+	line: string;
+	ranges: ContentMatchRange[];
+	fuzzy: boolean;
+}
+
+export interface ContentSearchResult {
+	matches: ContentSearchMatch[];
+	truncated: boolean;
+	skippedFiles: number;
+}
+
+export interface ContentSearchOptions {
+	caseSensitive?: boolean;
+	fuzzy?: boolean;
+	maxResults?: number;
+	signal?: AbortSignal;
+}
+
+interface SearchableTextFile {
+	path: string;
+	lines: readonly string[];
+}
+
+type IndexedCharacter = { start: number; end: number; comparable: string };
+
+type LoadSearchableFile = (path: string, signal?: AbortSignal) => Promise<SearchableTextFile>;
+
+export async function searchProjectContents(
+	files: readonly string[],
+	loadFile: LoadSearchableFile,
+	query: string,
+	options: ContentSearchOptions = {},
+): Promise<ContentSearchResult> {
+	const signal = options.signal;
+	signal?.throwIfAborted();
+	if (!query.trim() || query.length > MAX_CONTENT_QUERY_LENGTH) {
+		return { matches: [], truncated: false, skippedFiles: 0 };
+	}
+
+	const maxResults = Math.max(1, options.maxResults ?? DEFAULT_MAX_RESULTS);
+	const caseSensitive = options.caseSensitive ?? false;
+	const literalExpression = new RegExp(escapeRegExp(query), caseSensitive ? "g" : "gi");
+	const fuzzyQuery = options.fuzzy ? indexedCharacters(query, caseSensitive) : [];
+	const matches: ContentSearchMatch[] = [];
+	let truncated = false;
+	let skippedFiles = 0;
+
+	for (const path of files) {
+		signal?.throwIfAborted();
+		let file: SearchableTextFile;
+		try {
+			file = await loadFile(path, signal);
+		} catch (error: unknown) {
+			if (isAbortError(error) || signal?.aborted) throw error;
+			skippedFiles += 1;
+			continue;
+		}
+		signal?.throwIfAborted();
+
+		for (let lineIndex = 0; lineIndex < file.lines.length; lineIndex += 1) {
+			const line = file.lines[lineIndex] ?? "";
+			const literalRanges = findLiteralRanges(line, literalExpression);
+			if (literalRanges.length > 0) {
+				for (const range of literalRanges) {
+					if (matches.length < maxResults) {
+						matches.push({
+							path: file.path,
+							lineNumber: lineIndex + 1,
+							line,
+							ranges: [range],
+							fuzzy: false,
+						});
+					} else {
+						truncated = true;
+					}
+				}
+				continue;
+			}
+
+			if (!options.fuzzy) continue;
+			const fuzzyRanges = findSubsequenceRanges(line, fuzzyQuery, caseSensitive);
+			if (!fuzzyRanges) continue;
+			if (matches.length < maxResults) {
+				matches.push({
+					path: file.path,
+					lineNumber: lineIndex + 1,
+					line,
+					ranges: fuzzyRanges,
+					fuzzy: true,
+				});
+			} else {
+				truncated = true;
+			}
+		}
+	}
+
+	return { matches, truncated, skippedFiles };
+}
+
+function findLiteralRanges(line: string, expression: RegExp): ContentMatchRange[] {
+	const ranges: ContentMatchRange[] = [];
+	expression.lastIndex = 0;
+	for (let match = expression.exec(line); match; match = expression.exec(line)) {
+		const start = match.index;
+		ranges.push({ start, end: start + match[0].length });
+	}
+	return ranges;
+}
+
+function findSubsequenceRanges(
+	line: string,
+	queryCharacters: readonly IndexedCharacter[],
+	caseSensitive: boolean,
+): ContentMatchRange[] | undefined {
+	const lineCharacters = indexedCharacters(line, caseSensitive);
+	const positions: Array<{ start: number; end: number }> = [];
+	let queryIndex = 0;
+	for (
+		let lineIndex = 0;
+		lineIndex < lineCharacters.length && queryIndex < queryCharacters.length;
+		lineIndex += 1
+	) {
+		const lineCharacter = lineCharacters[lineIndex];
+		const queryCharacter = queryCharacters[queryIndex];
+		if (
+			!lineCharacter ||
+			!queryCharacter ||
+			lineCharacter.comparable !== queryCharacter.comparable
+		) {
+			continue;
+		}
+		positions.push({ start: lineCharacter.start, end: lineCharacter.end });
+		queryIndex += 1;
+	}
+	if (queryIndex !== queryCharacters.length) return undefined;
+
+	const ranges: ContentMatchRange[] = [];
+	for (const position of positions) {
+		const previous = ranges.at(-1);
+		if (previous?.end === position.start) previous.end = position.end;
+		else ranges.push(position);
+	}
+	return ranges;
+}
+
+function indexedCharacters(value: string, caseSensitive: boolean): IndexedCharacter[] {
+	const characters: IndexedCharacter[] = [];
+	for (let start = 0; start < value.length; ) {
+		const codePoint = value.codePointAt(start);
+		if (codePoint === undefined) break;
+		const character = String.fromCodePoint(codePoint);
+		const end = start + character.length;
+		characters.push({
+			start,
+			end,
+			comparable: caseSensitive ? character : character.toLowerCase(),
+		});
+		start = end;
+	}
+	return characters;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
+}

--- a/packages/pi-file-context/src/content-search.ts
+++ b/packages/pi-file-context/src/content-search.ts
@@ -72,18 +72,16 @@ export async function searchProjectContents(
 			const line = file.lines[lineIndex] ?? "";
 			const literalRanges = findLiteralRanges(line, literalExpression);
 			if (literalRanges.length > 0) {
-				for (const range of literalRanges) {
-					if (matches.length < maxResults) {
-						matches.push({
-							path: file.path,
-							lineNumber: lineIndex + 1,
-							line,
-							ranges: [range],
-							fuzzy: false,
-						});
-					} else {
-						truncated = true;
-					}
+				if (matches.length < maxResults) {
+					matches.push({
+						path: file.path,
+						lineNumber: lineIndex + 1,
+						line,
+						ranges: literalRanges,
+						fuzzy: false,
+					});
+				} else {
+					truncated = true;
 				}
 				continue;
 			}

--- a/packages/pi-file-context/src/file-context-explorer.ts
+++ b/packages/pi-file-context/src/file-context-explorer.ts
@@ -9,6 +9,9 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
+import type { ContentSearchMatch } from "./content-search.js";
+import { ContentSearchSession } from "./content-search-session.js";
+import { highlightContentRanges } from "./content-search-ui.js";
 import {
 	createFileQuote,
 	createFileQuoteSnapshot,
@@ -39,19 +42,23 @@ interface FileQuoteExplorerOptions {
 	theme: Theme;
 	keybindings: KeybindingsManager;
 	files: readonly string[];
-	loadFile: (path: string) => Promise<LoadedProjectTextFile>;
+	cwd?: string;
+	loadFile: (path: string, signal?: AbortSignal) => Promise<LoadedProjectTextFile>;
 	gitContext?: GitContext;
 	done: (result: FileQuoteExplorerResult | undefined) => void;
 }
 
 export class FileQuoteExplorer implements Component, Focusable {
 	private readonly search = new Input();
+	private readonly contentSearch: ContentSearchSession;
 	private readonly revisionInput = new Input();
 	private readonly fileSearch: ProjectFileSearch;
 	private filteredFiles: string[];
 	private selectedFileIndex = 0;
 	private fileScrollOffset = 0;
-	private mode: "files" | "preview" | "history" | "revision" | "diff" = "files";
+	private mode: "files" | "contents" | "preview" | "history" | "revision" | "diff" = "files";
+	private previewReturnMode: "files" | "contents" = "files";
+	private activeContentMatch: ContentSearchMatch | undefined;
 	private loadedFile: LoadedProjectTextFile | undefined;
 	private loadedGit: GitFileContext | undefined;
 	private previewCursor = 0;
@@ -65,14 +72,36 @@ export class FileQuoteExplorer implements Component, Focusable {
 	private diffHunkIndex = 0;
 	private diffScrollOffset = 0;
 	private detailRequest = 0;
+	private detailController: AbortController | undefined;
+	private openRequest = 0;
+	private openController: AbortController | undefined;
 	private loading = false;
 	private error: string | undefined;
 	private finished = false;
+	private disposed = false;
 	private isFocused = false;
 
 	constructor(private readonly options: FileQuoteExplorerOptions) {
 		this.fileSearch = new ProjectFileSearch(options.files);
 		this.filteredFiles = [...options.files];
+		this.contentSearch = new ContentSearchSession({
+			tui: options.tui,
+			theme: options.theme,
+			keybindings: options.keybindings,
+			files: options.files,
+			cwd: options.cwd,
+			loadFile: options.loadFile,
+			onPreview: (match) => {
+				void this.openFile(match.path, {
+					returnMode: "contents",
+					cursorIndex: match.lineNumber - 1,
+					match,
+				});
+			},
+			onReference: (path) => this.finish({ kind: "reference", path }),
+			onSwitchFiles: () => this.showFileSearch(),
+			onCancel: () => this.finish(undefined),
+		});
 	}
 
 	get focused(): boolean {
@@ -82,12 +111,14 @@ export class FileQuoteExplorer implements Component, Focusable {
 	set focused(value: boolean) {
 		this.isFocused = value;
 		this.search.focused = value && this.mode === "files";
+		this.contentSearch.focused = value && this.mode === "contents";
 		this.revisionInput.focused = value && this.mode === "revision";
 	}
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
 		if (this.mode === "files") return this.renderFileList(safeWidth);
+		if (this.mode === "contents") return this.renderContentSearch(safeWidth);
 		if (this.mode === "history") return this.renderHistory(safeWidth);
 		if (this.mode === "revision") return this.renderRevisionInput(safeWidth);
 		if (this.mode === "diff") return this.renderDiff(safeWidth);
@@ -95,12 +126,13 @@ export class FileQuoteExplorer implements Component, Focusable {
 	}
 
 	handleInput(data: string): void {
-		if (this.finished) return;
+		if (this.finished || this.disposed) return;
 		if (matchesKey(data, Key.ctrl("c"))) {
 			this.finish(undefined);
 			return;
 		}
 		if (this.mode === "files") this.handleFileInput(data);
+		else if (this.mode === "contents") this.handleContentInput(data);
 		else if (this.mode === "history") this.handleHistoryInput(data);
 		else if (this.mode === "revision") this.handleRevisionInput(data);
 		else if (this.mode === "diff") this.handleDiffInput(data);
@@ -110,7 +142,16 @@ export class FileQuoteExplorer implements Component, Focusable {
 
 	invalidate(): void {
 		this.search.invalidate();
+		this.contentSearch.invalidate();
 		this.revisionInput.invalidate();
+	}
+
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.contentSearch.dispose();
+		this.cancelOpenRequest();
+		this.cancelDetailRequest();
 	}
 
 	private renderFileList(width: number): string[] {
@@ -159,7 +200,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 					)
 				: this.options.theme.fg(
 						"muted",
-						`${this.filteredFiles.length} files · ↑↓ navigate · Enter preview · Tab reference · Esc cancel`,
+						`${this.filteredFiles.length} files · ↑↓ navigate · Enter preview · Tab reference · Ctrl+F contents · Esc cancel`,
 					);
 		return fitRows(
 			[
@@ -170,6 +211,11 @@ export class FileQuoteExplorer implements Component, Focusable {
 			],
 			availableRows,
 		);
+	}
+
+	private renderContentSearch(width: number): string[] {
+		const availableRows = Math.max(1, this.options.tui.terminal.rows - RESERVED_APP_ROWS);
+		return this.contentSearch.render(width, availableRows, this.loading, this.error);
 	}
 
 	private renderPreview(width: number): string[] {
@@ -196,7 +242,16 @@ export class FileQuoteExplorer implements Component, Focusable {
 			const cursor = index === this.previewCursor ? ">" : " ";
 			const marker = changedLines.has(index + 1) ? "+" : deletedAtLines.has(index + 1) ? "-" : " ";
 			const number = String(index + 1).padStart(digits, " ");
-			const line = `${cursor}${marker}${number} │ ${escapeTerminalControls(rawLine)}`;
+			const contentMatch =
+				this.activeContentMatch?.path === loadedFile.path &&
+				this.activeContentMatch.lineNumber === index + 1 &&
+				this.activeContentMatch.line === rawLine
+					? this.activeContentMatch
+					: undefined;
+			const content = contentMatch
+				? highlightContentRanges(rawLine, contentMatch.ranges, this.options.theme)
+				: escapeTerminalControls(rawLine);
+			const line = `${cursor}${marker}${number} │ ${content}`;
 			const styled = selected
 				? this.options.theme.bg("selectedBg", this.options.theme.fg("text", line))
 				: index === this.previewCursor
@@ -215,7 +270,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 		const estimatedTokens = Math.max(1, Math.ceil(Buffer.byteLength(selectedText, "utf8") / 4));
 		const footer = this.error
 			? this.options.theme.fg("error", escapeTerminalControls(this.error))
-			: `~${estimatedTokens} tokens · Enter attach ${selecting} · Space anchor · ↑↓ extend · [] hunks · b blame · h history · r revision · d diff · Esc files`;
+			: `~${estimatedTokens} tokens · Enter attach ${selecting} · Space anchor · ↑↓ extend · [] hunks · b blame · h history · r revision · d diff · Esc ${this.previewReturnMode === "contents" ? "content results" : "files"}`;
 		const project = this.options.gitContext?.project;
 		const gitLabel = this.loadedRevision
 			? `${escapeTerminalControls(this.loadedRevision.revision)}@${this.loadedRevision.commit.slice(0, 12)} · historical`
@@ -350,6 +405,10 @@ export class FileQuoteExplorer implements Component, Focusable {
 	}
 
 	private handleFileInput(data: string): void {
+		if (matchesKey(data, Key.ctrl("f"))) {
+			this.showContentSearch();
+			return;
+		}
 		if (matchesKey(data, Key.escape)) {
 			this.finish(undefined);
 			return;
@@ -399,19 +458,27 @@ export class FileQuoteExplorer implements Component, Focusable {
 		}
 	}
 
+	private handleContentInput(data: string): void {
+		this.cancelOpenRequest();
+		this.error = undefined;
+		this.contentSearch.handleInput(data);
+	}
+
 	private handlePreviewInput(data: string): void {
 		const loadedFile = this.loadedFile;
 		if (!loadedFile) return;
 		const lines = loadedFile.lines;
 		if (matchesKey(data, Key.escape)) {
 			this.cancelDetailRequest();
-			this.mode = "files";
+			this.cancelOpenRequest();
+			this.mode = this.previewReturnMode;
 			this.loadedFile = undefined;
 			this.loadedGit = undefined;
 			this.loadedRevision = undefined;
 			this.previewAnchor = undefined;
 			this.blame = undefined;
-			this.search.focused = this.isFocused;
+			this.search.focused = this.isFocused && this.mode === "files";
+			this.contentSearch.focused = this.isFocused && this.mode === "contents";
 			return;
 		}
 		if (data === " ") {
@@ -612,14 +679,15 @@ export class FileQuoteExplorer implements Component, Focusable {
 			this.error = "Git revision browsing is unavailable";
 			return;
 		}
-		const request = this.beginDetailRequest();
+		const { request, signal } = this.beginDetailRequest();
 		this.error = undefined;
 		this.options.tui.requestRender();
 		try {
-			const loadedRevision = await gitContext.loadRevision(path, revision, historicalPath);
+			const loadedRevision = await gitContext.loadRevision(path, revision, historicalPath, signal);
 			if (this.finished || request !== this.detailRequest) return;
 			this.loadedRevision = loadedRevision;
 			this.loadedFile = { path: loadedRevision.path, lines: loadedRevision.lines };
+			this.activeContentMatch = undefined;
 			this.previewCursor = 0;
 			this.previewAnchor = undefined;
 			this.previewScrollOffset = 0;
@@ -627,10 +695,9 @@ export class FileQuoteExplorer implements Component, Focusable {
 			this.mode = "preview";
 			this.revisionInput.focused = false;
 		} catch (error: unknown) {
-			if (request === this.detailRequest) this.error = formatError(error);
+			if (request === this.detailRequest && !isAbortError(error)) this.error = formatError(error);
 		} finally {
-			if (request === this.detailRequest) this.loading = false;
-			this.options.tui.requestRender();
+			this.finishDetailRequest(request);
 		}
 	}
 
@@ -641,12 +708,17 @@ export class FileQuoteExplorer implements Component, Focusable {
 			this.error = "Git blame is unavailable";
 			return;
 		}
-		const request = this.beginDetailRequest();
+		const { request, signal } = this.beginDetailRequest();
 		const requestedLine = this.previewCursor + 1;
 		this.error = undefined;
 		this.options.tui.requestRender();
 		try {
-			const blame = await gitContext.getBlame(path, requestedLine, this.loadedRevision?.commit);
+			const blame = await gitContext.getBlame(
+				path,
+				requestedLine,
+				this.loadedRevision?.commit,
+				signal,
+			);
 			if (
 				this.finished ||
 				request !== this.detailRequest ||
@@ -658,10 +730,9 @@ export class FileQuoteExplorer implements Component, Focusable {
 			this.blame = blame;
 			if (!blame) this.error = "No blame information for this line";
 		} catch (error: unknown) {
-			if (request === this.detailRequest) this.error = formatError(error);
+			if (request === this.detailRequest && !isAbortError(error)) this.error = formatError(error);
 		} finally {
-			if (request === this.detailRequest) this.loading = false;
-			this.options.tui.requestRender();
+			this.finishDetailRequest(request);
 		}
 	}
 
@@ -672,51 +743,72 @@ export class FileQuoteExplorer implements Component, Focusable {
 			this.error = "Git history is unavailable";
 			return;
 		}
-		const request = this.beginDetailRequest();
+		const { request, signal } = this.beginDetailRequest();
 		this.error = undefined;
 		this.options.tui.requestRender();
 		try {
-			const history = await gitContext.getHistory(path);
+			const history = await gitContext.getHistory(path, signal);
 			if (this.finished || request !== this.detailRequest || this.mode !== "preview") return;
 			this.history = history;
 			this.historyIndex = 0;
 			this.mode = "history";
 		} catch (error: unknown) {
-			if (request === this.detailRequest) this.error = formatError(error);
+			if (request === this.detailRequest && !isAbortError(error)) this.error = formatError(error);
 		} finally {
-			if (request === this.detailRequest) this.loading = false;
-			this.options.tui.requestRender();
+			this.finishDetailRequest(request);
 		}
 	}
 
-	private async openFile(path: string): Promise<void> {
+	private async openFile(
+		path: string,
+		options: {
+			returnMode?: "files" | "contents";
+			cursorIndex?: number;
+			match?: ContentSearchMatch;
+		} = {},
+	): Promise<void> {
+		this.cancelOpenRequest();
+		const request = this.openRequest;
+		const controller = new AbortController();
+		this.openController = controller;
 		this.loading = true;
 		this.error = undefined;
 		this.options.tui.requestRender();
 		try {
 			const [loadedFile, loadedGit] = await Promise.all([
-				this.options.loadFile(path),
-				this.options.gitContext?.getFileContext(path),
+				this.options.loadFile(path, controller.signal),
+				this.options.gitContext?.getFileContext(path, controller.signal),
 			]);
-			if (this.finished) return;
+			if (!this.isCurrentOpenRequest(request, controller)) return;
 			this.loadedFile = loadedFile;
 			this.loadedGit = loadedGit;
 			this.loadedRevision = undefined;
 			this.mode = "preview";
-			this.previewCursor = 0;
+			this.previewReturnMode = options.returnMode ?? "files";
+			this.activeContentMatch = options.match;
+			this.previewCursor = Math.max(
+				0,
+				Math.min(Math.max(0, loadedFile.lines.length - 1), options.cursorIndex ?? 0),
+			);
 			this.previewAnchor = undefined;
-			this.previewScrollOffset = 0;
+			this.previewScrollOffset = Math.max(0, this.previewCursor - 1);
 			this.hunkIndex = -1;
 			this.blame = undefined;
 			this.history = [];
 			this.detailRequest += 1;
 			this.error = undefined;
 			this.search.focused = false;
+			this.contentSearch.focused = false;
 		} catch (error: unknown) {
-			this.error = formatError(error);
+			if (this.isCurrentOpenRequest(request, controller) && !isAbortError(error)) {
+				this.error = formatError(error);
+			}
 		} finally {
-			this.loading = false;
-			this.options.tui.requestRender();
+			if (request === this.openRequest) {
+				this.loading = false;
+				this.openController = undefined;
+			}
+			if (!this.finished && !this.disposed) this.options.tui.requestRender();
 		}
 	}
 
@@ -742,14 +834,61 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.error = undefined;
 	}
 
-	private beginDetailRequest(): number {
-		const request = ++this.detailRequest;
+	private showContentSearch(): void {
+		this.cancelOpenRequest();
+		this.mode = "contents";
+		this.search.focused = false;
+		this.contentSearch.activate();
+		this.contentSearch.focused = this.isFocused;
+		this.error = undefined;
+	}
+
+	private showFileSearch(): void {
+		this.contentSearch.deactivate();
+		this.cancelOpenRequest();
+		this.mode = "files";
+		this.search.focused = this.isFocused;
+		this.error = undefined;
+	}
+
+	private cancelOpenRequest(): void {
+		this.openRequest += 1;
+		this.openController?.abort();
+		this.openController = undefined;
+		this.loading = false;
+	}
+
+	private isCurrentOpenRequest(request: number, controller: AbortController): boolean {
+		return (
+			!this.finished &&
+			!this.disposed &&
+			request === this.openRequest &&
+			this.openController === controller &&
+			!controller.signal.aborted
+		);
+	}
+
+	private beginDetailRequest(): { request: number; signal: AbortSignal } {
+		this.cancelDetailRequest();
+		const request = this.detailRequest;
+		const controller = new AbortController();
+		this.detailController = controller;
 		this.loading = true;
-		return request;
+		return { request, signal: controller.signal };
+	}
+
+	private finishDetailRequest(request: number): void {
+		if (request === this.detailRequest) {
+			this.loading = false;
+			this.detailController = undefined;
+		}
+		if (!this.finished && !this.disposed) this.options.tui.requestRender();
 	}
 
 	private cancelDetailRequest(): void {
 		this.detailRequest += 1;
+		this.detailController?.abort();
+		this.detailController = undefined;
 		this.loading = false;
 	}
 
@@ -762,6 +901,9 @@ export class FileQuoteExplorer implements Component, Focusable {
 
 	private finish(result: FileQuoteExplorerResult | undefined): void {
 		this.finished = true;
+		this.contentSearch.dispose();
+		this.cancelOpenRequest();
+		this.cancelDetailRequest();
 		this.options.done(result);
 	}
 
@@ -812,6 +954,10 @@ function escapeTerminalControls(text: string): string {
 function formatHistoryDate(authorTime: number): string {
 	const date = new Date(authorTime * 1_000);
 	return Number.isFinite(date.getTime()) ? date.toISOString().slice(0, 10) : "unknown-date";
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
 }
 
 function formatError(error: unknown): string {

--- a/packages/pi-file-context/src/file-context-explorer.ts
+++ b/packages/pi-file-context/src/file-context-explorer.ts
@@ -152,6 +152,10 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.contentSearch.dispose();
 		this.cancelOpenRequest();
 		this.cancelDetailRequest();
+		if (!this.finished) {
+			this.finished = true;
+			this.options.done(undefined);
+		}
 	}
 
 	private renderFileList(width: number): string[] {

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -68,6 +68,11 @@ interface LoadOptions {
 	signal?: AbortSignal;
 }
 
+interface ActiveExplorer {
+	controller: AbortController;
+	component?: FileQuoteExplorer;
+}
+
 export async function discoverProjectFiles(
 	root: string,
 	options: DiscoveryOptions = {},
@@ -301,7 +306,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 	let installedEditorFactory: unknown;
 	let activeSessionManager: unknown;
 	let sessionGeneration = 0;
-	const explorerControllers = new Set<AbortController>();
+	const activeExplorers = new Set<ActiveExplorer>();
 
 	const clearPending = (ctx: ExtensionContext) => {
 		pendingQuotes = [];
@@ -334,8 +339,11 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		owner === activeSessionManager && generation === sessionGeneration;
 
 	const cancelExplorers = () => {
-		for (const controller of explorerControllers) controller.abort();
-		explorerControllers.clear();
+		for (const explorer of activeExplorers) {
+			explorer.controller.abort();
+			explorer.component?.dispose();
+		}
+		activeExplorers.clear();
 	};
 
 	const openExplorer = async (ctx: ExtensionContext): Promise<void> => {
@@ -345,8 +353,9 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		}
 		const owner = ctx.sessionManager;
 		const generation = sessionGeneration;
-		const controller = new AbortController();
-		explorerControllers.add(controller);
+		const activeExplorer: ActiveExplorer = { controller: new AbortController() };
+		const { controller } = activeExplorer;
+		activeExplorers.add(activeExplorer);
 		try {
 			const [files, gitContext] = await Promise.all([
 				discoverProjectFiles(ctx.cwd, { signal: controller.signal }),
@@ -358,8 +367,8 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 				return;
 			}
 			const result = await ctx.ui.custom<FileQuoteExplorerResult | undefined>(
-				(tui, theme, keybindings, done) =>
-					new FileQuoteExplorer({
+				(tui, theme, keybindings, done) => {
+					const component = new FileQuoteExplorer({
 						tui,
 						theme,
 						keybindings,
@@ -368,7 +377,11 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 						loadFile: (path, signal) => loadProjectTextFile(ctx.cwd, path, { signal }),
 						gitContext,
 						done,
-					}),
+					});
+					activeExplorer.component = component;
+					if (controller.signal.aborted) component.dispose();
+					return component;
+				},
 			);
 			if (!isCurrentSession(owner, generation) || controller.signal.aborted) return;
 			if (result?.kind === "quote") appendPending(result.quote, ctx);
@@ -389,7 +402,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 				// The session may have been replaced while the picker was open.
 			}
 		} finally {
-			explorerControllers.delete(controller);
+			activeExplorers.delete(activeExplorer);
 		}
 	};
 

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -59,11 +59,13 @@ export interface LoadedProjectTextFile {
 
 interface DiscoveryOptions {
 	maxFiles?: number;
+	signal?: AbortSignal;
 }
 
 interface LoadOptions {
 	maxBytes?: number;
 	beforeOpen?: () => Promise<void>;
+	signal?: AbortSignal;
 }
 
 export async function discoverProjectFiles(
@@ -72,13 +74,17 @@ export async function discoverProjectFiles(
 ): Promise<string[]> {
 	const maxFiles = Math.max(1, options.maxFiles ?? DEFAULT_MAX_FILES);
 	const files: string[] = [];
+	options.signal?.throwIfAborted();
 
 	async function walk(directory: string, prefix: string): Promise<void> {
+		options.signal?.throwIfAborted();
 		if (files.length >= maxFiles) return;
 		const entries = (await readdir(directory, { withFileTypes: true })).sort((left, right) =>
 			compareStrings(left.name, right.name),
 		);
+		options.signal?.throwIfAborted();
 		for (const entry of entries) {
+			options.signal?.throwIfAborted();
 			if (files.length >= maxFiles) return;
 			if (IGNORED_DIRECTORIES.has(entry.name) || entry.isSymbolicLink()) continue;
 			const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
@@ -91,7 +97,10 @@ export async function discoverProjectFiles(
 		}
 	}
 
-	await walk(await realpath(root), "");
+	const canonicalRoot = await realpath(root);
+	options.signal?.throwIfAborted();
+	await walk(canonicalRoot, "");
+	options.signal?.throwIfAborted();
 	return files.sort(compareStrings);
 }
 
@@ -100,8 +109,10 @@ export async function loadProjectTextFile(
 	projectPath: string,
 	options: LoadOptions = {},
 ): Promise<LoadedProjectTextFile> {
+	options.signal?.throwIfAborted();
 	if (!projectPath || isAbsolute(projectPath)) throw new Error("File path is outside the project");
 	const canonicalRoot = await realpath(root);
+	options.signal?.throwIfAborted();
 	const candidate = resolve(canonicalRoot, projectPath);
 	if (!isInside(canonicalRoot, candidate)) throw new Error("File path is outside the project");
 
@@ -111,13 +122,16 @@ export async function loadProjectTextFile(
 	} catch (error: unknown) {
 		throw new Error(`Cannot open ${projectPath}: ${formatError(error)}`);
 	}
+	options.signal?.throwIfAborted();
 	if (!isInside(canonicalRoot, canonicalFile)) throw new Error("File path is outside the project");
 	const info = await lstat(canonicalFile);
+	options.signal?.throwIfAborted();
 	if (!info.isFile()) throw new Error(`${projectPath} is not a regular file`);
 
 	const maxBytes = Math.max(1, options.maxBytes ?? DEFAULT_MAX_BYTES);
 	if (info.size > maxBytes) throw new Error(`${projectPath} exceeds ${maxBytes} bytes`);
 	await options.beforeOpen?.();
+	options.signal?.throwIfAborted();
 	let file: Awaited<ReturnType<typeof open>>;
 	try {
 		file = await open(
@@ -128,7 +142,9 @@ export async function loadProjectTextFile(
 		throw new Error(`Cannot safely open ${projectPath}: ${formatError(error)}`);
 	}
 	try {
+		options.signal?.throwIfAborted();
 		const openedInfo = await file.stat();
+		options.signal?.throwIfAborted();
 		if (!openedInfo.isFile()) throw new Error(`${projectPath} is not a regular file`);
 		if (openedInfo.dev !== info.dev || openedInfo.ino !== info.ino) {
 			throw new Error(`${projectPath} changed while it was being opened safely`);
@@ -137,7 +153,9 @@ export async function loadProjectTextFile(
 		const buffer = Buffer.alloc(maxBytes + 1);
 		let offset = 0;
 		while (offset < buffer.length) {
+			options.signal?.throwIfAborted();
 			const { bytesRead } = await file.read(buffer, offset, buffer.length - offset, offset);
+			options.signal?.throwIfAborted();
 			if (bytesRead === 0) break;
 			offset += bytesRead;
 		}
@@ -283,6 +301,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 	let installedEditorFactory: unknown;
 	let activeSessionManager: unknown;
 	let sessionGeneration = 0;
+	const explorerControllers = new Set<AbortController>();
 
 	const clearPending = (ctx: ExtensionContext) => {
 		pendingQuotes = [];
@@ -314,6 +333,11 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 	const isCurrentSession = (owner: unknown, generation: number) =>
 		owner === activeSessionManager && generation === sessionGeneration;
 
+	const cancelExplorers = () => {
+		for (const controller of explorerControllers) controller.abort();
+		explorerControllers.clear();
+	};
+
 	const openExplorer = async (ctx: ExtensionContext): Promise<void> => {
 		if (ctx.mode !== "tui") {
 			rejectCommand(ctx, "File Context requires Pi's interactive TUI.");
@@ -321,11 +345,14 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		}
 		const owner = ctx.sessionManager;
 		const generation = sessionGeneration;
+		const controller = new AbortController();
+		explorerControllers.add(controller);
 		try {
 			const [files, gitContext] = await Promise.all([
-				discoverProjectFiles(ctx.cwd),
-				createGitContext(ctx.cwd),
+				discoverProjectFiles(ctx.cwd, { signal: controller.signal }),
+				createGitContext(ctx.cwd, controller.signal),
 			]);
+			if (!isCurrentSession(owner, generation) || controller.signal.aborted) return;
 			if (files.length === 0) {
 				ctx.ui.notify("File Context found no project files.", "warning");
 				return;
@@ -337,23 +364,32 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 						theme,
 						keybindings,
 						files,
-						loadFile: (path) => loadProjectTextFile(ctx.cwd, path),
+						cwd: ctx.cwd,
+						loadFile: (path, signal) => loadProjectTextFile(ctx.cwd, path, { signal }),
 						gitContext,
 						done,
 					}),
 			);
-			if (!isCurrentSession(owner, generation)) return;
+			if (!isCurrentSession(owner, generation) || controller.signal.aborted) return;
 			if (result?.kind === "quote") appendPending(result.quote, ctx);
 			else if (result?.kind === "reference") {
 				ctx.ui.pasteToEditor(formatFileReference(result.path));
 			}
 		} catch (error: unknown) {
-			if (!isCurrentSession(owner, generation)) return;
+			if (
+				!isCurrentSession(owner, generation) ||
+				controller.signal.aborted ||
+				isAbortError(error)
+			) {
+				return;
+			}
 			try {
 				ctx.ui.notify(`File Context failed: ${formatError(error)}`, "error");
 			} catch {
 				// The session may have been replaced while the picker was open.
 			}
+		} finally {
+			explorerControllers.delete(controller);
 		}
 	};
 
@@ -370,6 +406,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
+		cancelExplorers();
 		activeSessionManager = ctx.sessionManager;
 		sessionGeneration += 1;
 		clearPending(ctx);
@@ -407,6 +444,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (ctx.sessionManager !== activeSessionManager) return;
+		cancelExplorers();
 		clearPending(ctx);
 		if (installedEditorFactory && ctx.mode === "tui") {
 			if (ctx.ui.getEditorComponent() === installedEditorFactory)
@@ -483,6 +521,10 @@ function rejectCommand(ctx: ExtensionContext, message: string): void {
 		return;
 	}
 	throw new Error(message);
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
 }
 
 function formatError(error: unknown): string {

--- a/packages/pi-file-context/src/git-context.ts
+++ b/packages/pi-file-context/src/git-context.ts
@@ -73,15 +73,17 @@ export class GitContext {
 		readonly statuses: ReadonlyMap<string, GitFileStatus>,
 	) {}
 
-	async getFileContext(projectPath: string): Promise<GitFileContext> {
+	async getFileContext(projectPath: string, signal?: AbortSignal): Promise<GitFileContext> {
 		this.assertProjectPath(projectPath);
 		const [blobResult, diffResult] = await Promise.all([
-			this.run(["rev-parse", "--verify", `HEAD:${this.repositoryPath(projectPath)}`], true),
+			this.run(["rev-parse", "--verify", `HEAD:${this.repositoryPath(projectPath)}`], true, signal),
 			this.run(
 				["diff", "--no-ext-diff", "--no-textconv", "--unified=3", "HEAD", "--", projectPath],
 				true,
+				signal,
 			),
 		]);
+		signal?.throwIfAborted();
 		return {
 			status: this.statuses.get(projectPath),
 			blob: blobResult.ok ? blobResult.stdout.trim() || undefined : undefined,
@@ -93,6 +95,7 @@ export class GitContext {
 		projectPath: string,
 		line: number,
 		revision?: string,
+		signal?: AbortSignal,
 	): Promise<GitBlameInfo | undefined> {
 		this.assertProjectPath(projectPath);
 		if (!Number.isSafeInteger(line) || line < 1) throw new Error("Blame line must be positive");
@@ -109,12 +112,14 @@ export class GitContext {
 				projectPath,
 			],
 			true,
+			signal,
 		);
+		signal?.throwIfAborted();
 		if (!result.ok) return undefined;
 		return parseBlame(result.stdout);
 	}
 
-	async getHistory(projectPath: string): Promise<GitHistoryEntry[]> {
+	async getHistory(projectPath: string, signal?: AbortSignal): Promise<GitHistoryEntry[]> {
 		this.assertProjectPath(projectPath);
 		const result = await this.run(
 			[
@@ -128,7 +133,9 @@ export class GitContext {
 				projectPath,
 			],
 			true,
+			signal,
 		);
+		signal?.throwIfAborted();
 		return result.ok ? parseHistory(result.stdout) : [];
 	}
 
@@ -136,6 +143,7 @@ export class GitContext {
 		projectPath: string,
 		revision: string,
 		historicalPath?: string,
+		signal?: AbortSignal,
 	): Promise<GitRevisionFile> {
 		this.assertProjectPath(projectPath);
 		const normalizedRevision = revision.trim();
@@ -145,18 +153,21 @@ export class GitContext {
 		const resolved = await this.run(
 			["rev-parse", "--verify", "--end-of-options", `${normalizedRevision}^{commit}`],
 			true,
+			signal,
 		);
 		if (!resolved.ok || !/^[0-9a-f]{40}$/i.test(resolved.stdout.trim())) {
 			throw new Error(`Unknown Git revision: ${normalizedRevision}`);
 		}
+		signal?.throwIfAborted();
 		const commit = resolved.stdout.trim().toLowerCase();
 		const repositoryPath = historicalPath
 			? this.assertRepositoryPath(historicalPath)
 			: this.repositoryPath(projectPath);
 		const [contentsResult, blobResult] = await Promise.all([
-			this.run(["show", `${commit}:${repositoryPath}`], true),
-			this.run(["rev-parse", "--verify", `${commit}:${repositoryPath}`], true),
+			this.run(["show", `${commit}:${repositoryPath}`], true, signal),
+			this.run(["rev-parse", "--verify", `${commit}:${repositoryPath}`], true, signal),
 		]);
+		signal?.throwIfAborted();
 		if (!contentsResult.ok) {
 			throw new Error(`${projectPath} does not exist at ${normalizedRevision}`);
 		}
@@ -175,8 +186,12 @@ export class GitContext {
 		};
 	}
 
-	private async run(args: string[], allowFailure = false): Promise<GitResult> {
-		return runGit(this.projectRoot, args, allowFailure);
+	private async run(
+		args: string[],
+		allowFailure = false,
+		signal?: AbortSignal,
+	): Promise<GitResult> {
+		return runGit(this.projectRoot, args, allowFailure, signal);
 	}
 
 	private repositoryPath(projectPath: string): string {
@@ -208,16 +223,26 @@ export class GitContext {
 	}
 }
 
-export async function createGitContext(root: string): Promise<GitContext | undefined> {
+export async function createGitContext(
+	root: string,
+	signal?: AbortSignal,
+): Promise<GitContext | undefined> {
+	signal?.throwIfAborted();
 	const projectRoot = await realpath(root);
-	const repositoryResult = await runGit(projectRoot, ["rev-parse", "--show-toplevel"], true);
+	signal?.throwIfAborted();
+	const repositoryResult = await runGit(
+		projectRoot,
+		["rev-parse", "--show-toplevel"],
+		true,
+		signal,
+	);
 	if (!repositoryResult.ok) return undefined;
 	const repositoryRoot = stripLineEnding(repositoryResult.stdout);
 	if (!repositoryRoot) return undefined;
 	const [prefixResult, headResult, branchResult, statusResult] = await Promise.all([
-		runGit(projectRoot, ["rev-parse", "--show-prefix"], true),
-		runGit(projectRoot, ["rev-parse", "--verify", "HEAD"], true),
-		runGit(projectRoot, ["symbolic-ref", "--quiet", "--short", "HEAD"], true),
+		runGit(projectRoot, ["rev-parse", "--show-prefix"], true, signal),
+		runGit(projectRoot, ["rev-parse", "--verify", "HEAD"], true, signal),
+		runGit(projectRoot, ["symbolic-ref", "--quiet", "--short", "HEAD"], true, signal),
 		runGit(
 			projectRoot,
 			[
@@ -232,8 +257,10 @@ export async function createGitContext(root: string): Promise<GitContext | undef
 				".",
 			],
 			true,
+			signal,
 		),
 	]);
+	signal?.throwIfAborted();
 	const head = headResult.ok ? headResult.stdout.trim().toLowerCase() : "unborn";
 	const branch = branchResult.ok
 		? branchResult.stdout.trim()
@@ -260,7 +287,12 @@ interface GitResult {
 	stdout: string;
 }
 
-async function runGit(cwd: string, args: string[], allowFailure: boolean): Promise<GitResult> {
+async function runGit(
+	cwd: string,
+	args: string[],
+	allowFailure: boolean,
+	signal?: AbortSignal,
+): Promise<GitResult> {
 	try {
 		const { stdout } = await execFileAsync(
 			"git",
@@ -270,6 +302,7 @@ async function runGit(cwd: string, args: string[], allowFailure: boolean): Promi
 				encoding: "utf8",
 				timeout: GIT_TIMEOUT_MS,
 				maxBuffer: GIT_MAX_BUFFER,
+				signal,
 				env: {
 					...process.env,
 					GIT_OPTIONAL_LOCKS: "0",
@@ -280,6 +313,7 @@ async function runGit(cwd: string, args: string[], allowFailure: boolean): Promi
 		);
 		return { ok: true, stdout };
 	} catch (error: unknown) {
+		if (signal?.aborted) throw error;
 		if (allowFailure) return { ok: false, stdout: "" };
 		throw error;
 	}

--- a/packages/pi-file-context/test/content-search-ui.test.ts
+++ b/packages/pi-file-context/test/content-search-ui.test.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
+import { FileQuoteExplorer } from "../src/file-context-explorer.js";
+
+const CTRL_F = "\u0006";
+const ALT_C = "\u001bc";
+const ALT_F = "\u001bf";
+const ESCAPE = "\u001b";
+
+function createHarness(
+	loadFile: (
+		path: string,
+		signal?: AbortSignal,
+	) => Promise<{ path: string; lines: string[] }> = async (path) => ({ path, lines: [] }),
+) {
+	const foreground: Array<{ color: string; text: string }> = [];
+	const backgrounds: Array<{ color: string; text: string }> = [];
+	let result: unknown = "pending";
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 18 }, requestRender() {} } as never,
+		theme: {
+			fg(color: string, text: string) {
+				foreground.push({ color, text });
+				return text;
+			},
+			bg(color: string, text: string) {
+				backgrounds.push({ color, text });
+				return text;
+			},
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return (
+					(data === "up" && key === "tui.select.up") ||
+					(data === "down" && key === "tui.select.down") ||
+					(data === "enter" && key === "tui.select.confirm") ||
+					(data === "tab" && key === "tui.input.tab")
+				);
+			},
+		} as never,
+		files: ["a.txt", "b.txt"],
+		loadFile,
+		done: (value) => {
+			result = value;
+		},
+	});
+	return { explorer, foreground, backgrounds, getResult: () => result };
+}
+
+async function flushAsyncWork(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+test("content result cards highlight literal matches and open preview at the selected match", async () => {
+	const loads: string[] = [];
+	const { explorer, foreground, backgrounds } = createHarness(async (path) => {
+		loads.push(path);
+		return path === "a.txt"
+			? { path, lines: ["Hi narumi, this is your book."] }
+			: { path, lines: ["This is a tree."] };
+	});
+	explorer.focused = true;
+	assert.ok(explorer.render(100).some((line) => line.includes("Ctrl+F contents")));
+	explorer.handleInput(CTRL_F);
+	explorer.handleInput("this is");
+	await flushAsyncWork();
+
+	const resultRows = explorer.render(48);
+	assert.ok(resultRows.some((line) => line.includes("Content Search")));
+	assert.ok(resultRows.some((line) => line.includes("Case: off") && line.includes("Fuzzy: off")));
+	assert.ok(resultRows.some((line) => line.includes("a.txt") && line.includes("L1")));
+	assert.ok(resultRows.some((line) => line.includes("b.txt") && line.includes("L1")));
+	assert.ok(foreground.some(({ color, text }) => color === "warning" && text === "this is"));
+	assert.ok(foreground.some(({ color, text }) => color === "warning" && text === "This is"));
+	assert.ok(backgrounds.some(({ color }) => color === "selectedBg"));
+	assert.ok(resultRows.every((line) => visibleWidth(line) <= 48));
+
+	explorer.handleInput("down");
+	explorer.handleInput("enter");
+	await flushAsyncWork();
+	const previewRows = explorer.render(48);
+	assert.ok(previewRows.some((line) => line.includes("b.txt")));
+	assert.ok(previewRows.some((line) => line.includes("> 1") && line.includes("This is a tree.")));
+
+	explorer.handleInput(ESCAPE);
+	const restoredRows = explorer.render(48);
+	assert.ok(restoredRows.some((line) => line.includes("Content Search")));
+	assert.ok(restoredRows.some((line) => line.includes("this is")));
+	explorer.handleInput("enter");
+	await flushAsyncWork();
+	assert.deepEqual(loads.slice(-2), ["b.txt", "b.txt"]);
+});
+
+test("content result cards keep a distant match visible within narrow context", async () => {
+	const { explorer } = createHarness(async (path) => ({
+		path,
+		lines: [path === "a.txt" ? `${"x".repeat(80)}needle tail` : "no match"],
+	}));
+	explorer.handleInput(CTRL_F);
+	explorer.handleInput("needle");
+	await flushAsyncWork();
+
+	const rows = explorer.render(32);
+	assert.ok(rows.some((line) => line.includes("needle tail")));
+	assert.ok(rows.every((line) => visibleWidth(line) <= 32));
+});
+
+test("content search forwards focus for IME and sanitizes matched terminal controls", async () => {
+	const { explorer } = createHarness(async (path) => ({
+		path,
+		lines: [path === "a.txt" ? "before \u001b[31mthis is after" : "no match"],
+	}));
+	explorer.focused = true;
+	explorer.handleInput(CTRL_F);
+	assert.ok(explorer.render(48).some((line) => line.includes(CURSOR_MARKER)));
+	explorer.handleInput("this is");
+	await flushAsyncWork();
+
+	const rows = explorer.render(48);
+	assert.ok(rows.every((line) => !line.includes("\u001b[31m")));
+	assert.ok(rows.some((line) => line.includes("\\x1b[31mthis is")));
+});
+
+test("content search toggles case sensitivity and fuzzy matching with visible state", async () => {
+	const load = async (path: string) =>
+		path === "a.txt"
+			? { path, lines: ["Hi narumi, this is your book."] }
+			: { path, lines: ["This is a tree."] };
+	const caseHarness = createHarness(load);
+	caseHarness.explorer.handleInput(CTRL_F);
+	caseHarness.explorer.handleInput("this is");
+	caseHarness.explorer.handleInput(ALT_C);
+	await flushAsyncWork();
+	let rows = caseHarness.explorer.render(60);
+	assert.ok(rows.some((line) => line.includes("Case: on")));
+	assert.ok(rows.some((line) => line.includes("a.txt")));
+	assert.ok(rows.every((line) => !line.includes("b.txt")));
+
+	const fuzzyHarness = createHarness(load);
+	fuzzyHarness.explorer.handleInput(CTRL_F);
+	fuzzyHarness.explorer.handleInput("thisis");
+	await flushAsyncWork();
+	rows = fuzzyHarness.explorer.render(60);
+	assert.ok(rows.some((line) => line.includes('No matches for "thisis"')));
+	fuzzyHarness.explorer.handleInput(ALT_F);
+	await flushAsyncWork();
+	rows = fuzzyHarness.explorer.render(60);
+	assert.ok(rows.some((line) => line.includes("Fuzzy: on")));
+	assert.ok(rows.some((line) => line.includes("a.txt")));
+	assert.ok(rows.some((line) => line.includes("b.txt")));
+});
+
+test("content results keep file-open failures actionable", async () => {
+	let calls = 0;
+	const { explorer } = createHarness(async (path) => {
+		calls += 1;
+		if (calls > 2) throw new Error("cannot open selected file");
+		return { path, lines: ["needle"] };
+	});
+	explorer.handleInput(CTRL_F);
+	explorer.handleInput("needle");
+	await flushAsyncWork();
+	explorer.handleInput("enter");
+	await flushAsyncWork();
+	assert.ok(explorer.render(60).some((line) => line.includes("cannot open selected file")));
+	explorer.handleInput("x");
+	await flushAsyncWork();
+	assert.ok(explorer.render(60).every((line) => !line.includes("cannot open selected file")));
+});
+
+test("content results preserve whole-file references and cancel without a selection", async () => {
+	const referenceHarness = createHarness(async (path) => ({ path, lines: ["needle"] }));
+	referenceHarness.explorer.handleInput(CTRL_F);
+	referenceHarness.explorer.handleInput("needle");
+	await flushAsyncWork();
+	referenceHarness.explorer.handleInput("tab");
+	assert.deepEqual(referenceHarness.getResult(), { kind: "reference", path: "a.txt" });
+
+	const cancelHarness = createHarness();
+	cancelHarness.explorer.handleInput(CTRL_F);
+	cancelHarness.explorer.handleInput(ESCAPE);
+	assert.equal(cancelHarness.getResult(), undefined);
+});
+
+test("content search cancellation and disposal reject stale async results", async () => {
+	let resolveSearch: ((file: { path: string; lines: string[] }) => void) | undefined;
+	let searchSignal: AbortSignal | undefined;
+	const pendingSearch = new Promise<{ path: string; lines: string[] }>((resolve) => {
+		resolveSearch = resolve;
+	});
+	const disposedHarness = createHarness(async (path, signal) => {
+		searchSignal = signal;
+		if (path === "a.txt") return pendingSearch;
+		return { path, lines: [] };
+	});
+	disposedHarness.explorer.handleInput(CTRL_F);
+	disposedHarness.explorer.handleInput("needle");
+	await Promise.resolve();
+	disposedHarness.explorer.dispose();
+	assert.equal(searchSignal?.aborted, true);
+	resolveSearch?.({ path: "a.txt", lines: ["needle"] });
+	await flushAsyncWork();
+	assert.ok(disposedHarness.explorer.render(60).every((line) => !line.includes("a.txt · L1")));
+
+	let resolveOpen: ((file: { path: string; lines: string[] }) => void) | undefined;
+	let openSignal: AbortSignal | undefined;
+	let calls = 0;
+	const staleOpenHarness = createHarness(async (path, signal) => {
+		calls += 1;
+		if (calls === 3) {
+			openSignal = signal;
+			return new Promise((resolve) => {
+				resolveOpen = resolve;
+			});
+		}
+		return { path, lines: ["needle"] };
+	});
+	staleOpenHarness.explorer.handleInput(CTRL_F);
+	staleOpenHarness.explorer.handleInput("needle");
+	await flushAsyncWork();
+	staleOpenHarness.explorer.handleInput("enter");
+	staleOpenHarness.explorer.handleInput("x");
+	assert.equal(openSignal?.aborted, true);
+	resolveOpen?.({ path: "a.txt", lines: ["needle"] });
+	await flushAsyncWork();
+	assert.ok(staleOpenHarness.explorer.render(60).some((line) => line.includes("Content Search")));
+});

--- a/packages/pi-file-context/test/content-search.test.ts
+++ b/packages/pi-file-context/test/content-search.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { searchProjectContents } from "../src/content-search.js";
+
+const files = new Map([
+	["a.txt", ["Hi narumi, this is your book."]],
+	["b.txt", ["This is a tree."]],
+	["c.txt", ["Nothing to see here."]],
+]);
+
+const loadFile = async (path: string) => ({ path, lines: files.get(path) ?? [] });
+
+test("content search defaults to literal case-insensitive matching with exact ranges", async () => {
+	const result = await searchProjectContents([...files.keys()], loadFile, "this is");
+
+	assert.deepEqual(
+		result.matches.map(({ path, lineNumber, ranges }) => ({ path, lineNumber, ranges })),
+		[
+			{ path: "a.txt", lineNumber: 1, ranges: [{ start: 11, end: 18 }] },
+			{ path: "b.txt", lineNumber: 1, ranges: [{ start: 0, end: 7 }] },
+		],
+	);
+	assert.equal(result.truncated, false);
+	assert.equal(result.skippedFiles, 0);
+	assert.equal(
+		(await searchProjectContents([...files.keys()], loadFile, "thisis")).matches.length,
+		0,
+	);
+});
+
+test("content search independently toggles case-sensitive and fuzzy matching", async () => {
+	const caseSensitive = await searchProjectContents([...files.keys()], loadFile, "this is", {
+		caseSensitive: true,
+	});
+	assert.deepEqual(
+		caseSensitive.matches.map((match) => match.path),
+		["a.txt"],
+	);
+
+	const fuzzy = await searchProjectContents([...files.keys()], loadFile, "thisis", { fuzzy: true });
+	assert.deepEqual(
+		fuzzy.matches.map((match) => match.path),
+		["a.txt", "b.txt"],
+	);
+	for (const match of fuzzy.matches) {
+		const matchedCharacters = match.ranges
+			.map((range) => match.line.slice(range.start, range.end))
+			.join("")
+			.toLowerCase();
+		assert.equal(matchedCharacters, "thisis");
+	}
+});
+
+test("case-insensitive content ranges stay aligned with Unicode source text", async () => {
+	const result = await searchProjectContents(
+		["unicode.txt"],
+		async (path) => ({ path, lines: ["İx marker"] }),
+		"x",
+	);
+	assert.deepEqual(result.matches[0]?.ranges, [{ start: 1, end: 2 }]);
+	assert.equal(result.matches[0]?.line.slice(1, 2), "x");
+});
+
+test("content search bounds results, reports skipped files, and honors cancellation", async () => {
+	const projectFiles = ["first.txt", "binary.bin", "second.txt", "third.txt"];
+	const bounded = await searchProjectContents(
+		projectFiles,
+		async (path) => {
+			if (path === "binary.bin") throw new Error("binary");
+			return { path, lines: [`${path}: needle`] };
+		},
+		"needle",
+		{ maxResults: 2 },
+	);
+	assert.deepEqual(
+		bounded.matches.map((match) => match.path),
+		["first.txt", "second.txt"],
+	);
+	assert.equal(bounded.truncated, true);
+	assert.equal(bounded.skippedFiles, 1);
+
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		searchProjectContents([...files.keys()], loadFile, "this", { signal: controller.signal }),
+		(error: unknown) => error instanceof Error && error.name === "AbortError",
+	);
+});

--- a/packages/pi-file-context/test/content-search.test.ts
+++ b/packages/pi-file-context/test/content-search.test.ts
@@ -28,6 +28,30 @@ test("content search defaults to literal case-insensitive matching with exact ra
 	);
 });
 
+test("content search combines same-line literal ranges into one bounded result", async () => {
+	const result = await searchProjectContents(
+		["repeated.txt"],
+		async (path) => ({ path, lines: ["needle then needle", "later needle"] }),
+		"needle",
+		{ maxResults: 2 },
+	);
+
+	assert.deepEqual(
+		result.matches.map(({ lineNumber, ranges }) => ({ lineNumber, ranges })),
+		[
+			{
+				lineNumber: 1,
+				ranges: [
+					{ start: 0, end: 6 },
+					{ start: 12, end: 18 },
+				],
+			},
+			{ lineNumber: 2, ranges: [{ start: 6, end: 12 }] },
+		],
+	);
+	assert.equal(result.truncated, false);
+});
+
 test("content search independently toggles case-sensitive and fuzzy matching", async () => {
 	const caseSensitive = await searchProjectContents([...files.keys()], loadFile, "this is", {
 		caseSensitive: true,

--- a/packages/pi-file-context/test/file-context-lifecycle.test.ts
+++ b/packages/pi-file-context/test/file-context-lifecycle.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import fileQuoteExtension from "../src/file-context.js";
+
+test("disposes and settles an active explorer on session replacement", async () => {
+	await assertExplorerLifecycleCancellation("session_start");
+});
+
+test("disposes and settles an active explorer on session shutdown", async () => {
+	await assertExplorerLifecycleCancellation("session_shutdown");
+});
+
+async function assertExplorerLifecycleCancellation(
+	event: "session_start" | "session_shutdown",
+): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-file-context-lifecycle-test-"));
+	try {
+		await writeFile(join(root, "example.txt"), "needle\n");
+		const mock = createMockPi();
+		fileQuoteExtension(mock.pi);
+		let markReady!: () => void;
+		const ready = new Promise<void>((resolve) => {
+			markReady = resolve;
+		});
+		let disposed = false;
+		const oldManager = { getSessionId: () => "old" };
+		const newManager = { getSessionId: () => "new" };
+		const makeContext = (sessionManager: object, custom?: (factory: unknown) => Promise<unknown>) =>
+			createMockContext({
+				mode: "tui",
+				hasUI: true,
+				cwd: root,
+				sessionManager,
+				ui: {
+					theme: { fg: (_color: string, text: string) => text },
+					notify() {},
+					setWidget() {},
+					setEditorComponent() {},
+					getEditorComponent: () => undefined,
+					custom: custom ?? (async () => undefined),
+					pasteToEditor() {},
+				},
+			});
+		const oldContext = makeContext(
+			oldManager,
+			(factory) =>
+				new Promise((resolve) => {
+					const component = (
+						factory as (...args: unknown[]) => {
+							dispose(): void;
+						}
+					)(
+						{ terminal: { rows: 18 }, requestRender() {} },
+						{
+							fg: (_color: string, text: string) => text,
+							bg: (_color: string, text: string) => text,
+							bold: (text: string) => text,
+						},
+						{ matches: () => false },
+						resolve,
+					);
+					const dispose = component.dispose.bind(component);
+					component.dispose = () => {
+						disposed = true;
+						dispose();
+					};
+					markReady();
+				}),
+		);
+		const newContext = makeContext(newManager);
+		await mock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
+		let settled = false;
+		const command = Promise.resolve(
+			mock.commands.get("file-context")?.handler("", oldContext.ctx),
+		).then(() => {
+			settled = true;
+		});
+		await ready;
+
+		if (event === "session_start") {
+			await mock.events.get(event)?.[0]?.({}, newContext.ctx);
+		} else {
+			await mock.events.get(event)?.[0]?.({}, oldContext.ctx);
+		}
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.equal(disposed, true);
+		assert.equal(settled, true);
+		await command;
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -38,6 +38,12 @@ test("discovers bounded project text candidates without traversing ignored direc
 
 		assert.deepEqual(await discoverProjectFiles(root), ["README.md", "src/main.ts"]);
 		assert.deepEqual(await discoverProjectFiles(root, { maxFiles: 1 }), ["README.md"]);
+		const controller = new AbortController();
+		controller.abort();
+		await assert.rejects(
+			discoverProjectFiles(root, { signal: controller.signal }),
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
 	});
 });
 
@@ -61,6 +67,19 @@ test("loads only bounded regular text files inside the project", async () => {
 		await assert.rejects(
 			loadProjectTextFile(root, "large.txt", { maxBytes: 16 }),
 			/exceeds 16 bytes/,
+		);
+	});
+});
+
+test("cancels bounded project text reads before opening a file", async () => {
+	await withTempProject(async (root) => {
+		await writeFile(join(root, "safe.ts"), "inside\n");
+		const controller = new AbortController();
+		controller.abort();
+
+		await assert.rejects(
+			loadProjectTextFile(root, "safe.ts", { signal: controller.signal }),
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
 		);
 	});
 });


### PR DESCRIPTION
## Summary

- add a `Ctrl+F` cwd content-search mode with highlighted path/line result cards
- support case-sensitive and fuzzy toggles, matched-line preview navigation, and whole-file references
- cancel stale file, Git, and search work across input changes, disposal, session replacement, and shutdown
- document the workflow and add a minor changeset for `@narumitw/pi-file-context`

## Testing

- `npm run check` (2,559 tests passed)
- 39 focused `pi-file-context` tests
- `just pack file-context`
- `npm run changeset:status`
- `./node_modules/.bin/pi --offline --no-extensions -e ./packages/pi-file-context --list-models file-context`
- signed commit pre-commit checks: Biome and workspace typechecks

Live interactive TUI smoke was not run because repository execution policy forbids interactive TUI commands; deterministic component tests cover the custom TUI flow.
