### PR TITLE
docs: simplify repository guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,6 @@ Run commands from the repository root unless a command says otherwise.
 - Add root workspace scripts or recipes when users need them.
 - Use `@narumitw/pi-tui-kit` for new standard action, detail, settings, and multi-select menus.
 - Keep domain state, persistence, confirmations, and specialized UI inside the owning extension.
-- Write extension READMEs in English.
 - Preserve each README's emoji title, npm badge, Pi badge, license badge, standard emoji sections, and `## 🗂️ Package layout`.
 - Keep standalone experimental extensions under `packages/` with `"piExtension": { "lifecycle": "experimental" }`.
 - Show a user-facing warning for experimental extensions and features.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,83 +1,125 @@
 # Repository Guidelines
 
-- Keep documents and conversations concise and clear.
+## Documentation and communication
+
+- Keep documents and conversations concise, clear, and accurate.
 - Explain things simply enough for a child to understand.
+- Write one sentence per line in prose.
 
-## Project structure
+## Repository structure
 
-- This is a Node/TypeScript monorepo for independently installable Pi extensions, reusable publishable libraries, and published experimental packages.
-- All active package source lives under `packages/<package>/src/`; each package owns its manifest, README, license, and TypeScript config. Extension manifests declare `piExtension.lifecycle` as `stable` or `experimental`; reusable libraries omit it.
-- `deprecated/` contains reference packages excluded from active workspace checks.
-- Root config owns shared tooling: `package.json`, `package-lock.json`, `biome.json`, `tsconfig.json`, `justfile`, and `.github/workflows/*`.
-- Do not edit `node_modules/`, read it for external API types and usage; don't guess.
-- Keep published contents aligned with each manifest's `files` list and `pi.extensions` entry.
-- Keep executable plans current under `docs/plans/` and archive them only after every task and completion check has evidence, as defined by `docs/plans/README.md`.
+- This Node.js and TypeScript monorepo contains Pi extensions and reusable libraries.
+- Keep active package source under `packages/<package>/src/`.
+- Each package owns its manifest, README, license, and TypeScript configuration.
+- Set each extension's `piExtension.lifecycle` to `stable` or `experimental`.
+- Omit `piExtension` from reusable libraries.
+- Keep deprecated reference packages under `deprecated/`, which active checks exclude.
+- Root files such as `package.json`, `package-lock.json`, `biome.json`, `tsconfig.json`, `justfile`, and `.github/workflows/*` own shared tooling.
+- Never edit `node_modules/`.
+- Read `node_modules/` to confirm external API types and usage instead of guessing.
+- Keep published files aligned with each manifest's `files` list and `pi.extensions` entry.
+- Keep plans current under `docs/plans/` and follow `docs/plans/README.md` before archiving them.
 
 ## Commands
 
-Run commands from the repository root unless noted otherwise.
+Run commands from the repository root unless a command says otherwise.
 
-- Install dependencies: `npm install`
-- Full CI-equivalent verification: `npm run check` or `just check`
-- Run all active tests: `npm test`
-- Format with Biome: `npm run format` or `just format`
-- Typecheck all workspaces: `npm run typecheck`
-- Preview any package: `just pack <unscoped-name>`
-- Try a local extension without installing: `just try <unscoped-name>`
-- Inspect available recipes before adding or documenting workflow commands: `just --list`
+- Run `npm install` to install dependencies.
+- Run `npm run check` or `just check` for the CI-equivalent verification gate.
+- Run `npm test` to execute all active tests.
+- Run `npm run format` or `just format` to format with Biome.
+- Run `npm run typecheck` to typecheck every workspace.
+- Run `just pack <unscoped-name>` to preview a package.
+- Run `just try <unscoped-name>` to test a local extension in Pi.
+- Run `just --list` before adding or documenting a workflow command.
 
-## Code style
+## Code and package rules
 
-- Root TypeScript uses `module`/`moduleResolution: NodeNext`, `target: ES2022`, `strict: true`, and `noEmit: true`; publishable libraries emit through package-owned build configuration.
-- Biome is authoritative: tabs, 100-column line width, double quotes, semicolons, and recommended lint rules.
-- Keep extension packages small. Add dependencies only when they solve a current extension need.
-- When a Pi core package provides the required function, use that function.
-- Check `node_modules` for external API types; don't guess.
-- Never remove or downgrade code to fix type errors from outdated dependencies; upgrade the dependency instead.
-- Treat each extension package as independently installable and semantically self-contained. Do not import or depend on another extension package, and do not hard-code assumptions about another extension’s package or tool names, argument schemas or actions, settings, event channels, installation state, version, or runtime behavior, whether repository-owned or external. Keep policy in the extension that owns the affected behavior. Share capabilities only through Pi’s public, extension-neutral APIs or reusable non-extension libraries that do not coordinate specific extensions. Consume shared Pi surfaces only generically, without extension-specific branching, and ensure the extension remains functional when all other extensions are absent.
-- Every active extension package exposes Pi through a thin `src/index.ts` default-export forwarding entrypoint, and its `package.json` declares exactly `"pi": { "extensions": ["./src/index.ts"] }`; keep implementation in descriptive modules. Publishable libraries emit JavaScript and declarations and must not declare `pi.extensions` or `piExtension`. Run `npm run check:boundaries` to enforce these boundaries.
-- Production extensions include source in `pi.extensions`, publish `files`, and root workspace-aware scripts/recipes when users need them. New standard action/detail/settings/multi-select menus should use `@narumitw/pi-tui-kit`; keep domain state, persistence, confirmations, and specialized UI extension-owned.
-- Write extension READMEs in English; preserve the emoji title, npm/Pi/license badges, standard emoji section headings, and `## 🗂️ Package layout` during readability passes.
-- Standalone experimental extension packages live under `packages/`, declare `"piExtension": { "lifecycle": "experimental" }`, show a user-facing warning, remain covered by root checks, and participate in publishing unless marked `private`. An opt-in experimental feature may remain inside a stable package only when its default behavior stays compatible, configuration explicitly gates it, and enabling it shows a warning.
-- Source files over 1,000 lines require decomposition along responsibility boundaries or a documented justification. Generated, vendored, migration, snapshot, and primarily declarative files may justify remaining intact; do not split them mechanically.
+- Root TypeScript uses NodeNext modules, ES2022, strict mode, and no emit.
+- Publishable libraries emit through their own build configuration.
+- Biome requires tabs, double quotes, semicolons, a 100-column line width, and recommended lint rules.
+- Keep extension packages small.
+- Add dependencies only for current package needs.
+- Use a Pi core function when Pi already provides the required behavior.
+- Upgrade an outdated dependency instead of hiding its type errors by removing or downgrading code.
+- Keep every extension independently installable and functional by itself.
+- Do not import or depend on another extension package.
+- Do not assume another extension's names, schemas, settings, events, installation state, version, or behavior.
+- Keep policy in the extension that owns the affected behavior.
+- Share code only through Pi's public extension-neutral APIs or reusable non-extension libraries.
+- Do not make reusable libraries coordinate specific extensions.
+- Consume shared Pi APIs without extension-specific branches.
+- Give every active extension a thin `src/index.ts` default-export forwarder.
+- Declare exactly `"pi": { "extensions": ["./src/index.ts"] }` in every active extension manifest.
+- Keep extension implementation in descriptively named modules.
+- Publish reusable libraries as JavaScript with declarations and without `pi.extensions` or `piExtension`.
+- Run `npm run check:boundaries` to verify package boundaries.
+- List every stable extension entrypoint in the root `package.json` under `pi.extensions`.
+- Do not list experimental extension entrypoints in the root `package.json` under `pi.extensions`.
+- Add root workspace scripts or recipes when users need them.
+- Use `@narumitw/pi-tui-kit` for new standard action, detail, settings, and multi-select menus.
+- Keep domain state, persistence, confirmations, and specialized UI inside the owning extension.
+- Write extension READMEs in English.
+- Preserve each README's emoji title, npm badge, Pi badge, license badge, standard emoji sections, and `## 🗂️ Package layout`.
+- Keep standalone experimental extensions under `packages/` with `"piExtension": { "lifecycle": "experimental" }`.
+- Show a user-facing warning for experimental extensions and features.
+- Keep experimental packages in root checks and publishing unless they are private.
+- Gate an experimental feature inside a stable package with explicit configuration and compatible default behavior.
+- Split source files over 1,000 lines by clear responsibilities or document why they must stay intact.
+- Do not mechanically split generated, vendored, migration, snapshot, or mainly declarative files.
 
 ## Extension change gates
 
-- Before planning or editing an extension's package, lifecycle, command, menu, custom TUI, settings, status, documentation, or verification behavior, read `docs/extension-conventions.md` completely. Do not defer this reading until review.
-- When extension-owned settings are touched—including loading, persistence, validation, precedence, migration, commands, or UI—also read `docs/extension-settings.md` completely before planning or editing.
-- Before implementation, identify the touched areas and map them to the applicable **MUST** rules and named verification methods.
-- For every asynchronous UI or lifecycle flow, audit user cancellation, component disposal, session replacement, and shutdown separately. Cancel or release every owned task. After each `await`, revalidate any session, generation, context, or mutable state the continuation will use.
-- Treat settings reads and writes as one concurrency protocol; audit ordering, failure recovery, stale reads, invalid-file protection, unknown-field preservation, and atomic publication together.
-- Before completion, audit the final diff against the guides' touched-area and verification checklists. Passing `npm run check` does not replace this semantic audit.
-- When review reveals a convention failure, audit the whole pull-request diff for the same failure class before replying or pushing.
-- In the handoff, name the guides read, touched areas audited, checks and smokes run, and any accepted deviation or unverified path.
+- Read `docs/extension-conventions.md` completely before planning or editing any extension.
+- This gate covers package metadata, lifecycle, commands, menus, custom TUI, settings, status, documentation, and verification behavior.
+- Also read `docs/extension-settings.md` completely before changing extension-owned settings.
+- This settings gate covers loading, persistence, validation, precedence, migration, commands, and UI.
+- Before implementation, map every touched area to its applicable **MUST** rules and verification methods.
+- Audit user cancellation, component disposal, session replacement, and shutdown for every asynchronous UI or lifecycle flow.
+- Cancel or release every task owned by the flow.
+- Revalidate stale sessions, generations, contexts, and mutable state after each `await`.
+- Treat settings reads and writes as one concurrency protocol.
+- Audit settings ordering, failure recovery, stale reads, invalid-file protection, unknown-field preservation, and atomic publication together.
+- Audit the final diff against the guides' touched-area and verification checklists.
+- Do not use a passing `npm run check` as a substitute for the semantic audit.
+- When review finds one convention failure, inspect the whole pull-request diff for the same failure class.
+- Name the guides, audits, checks, smokes, deviations, and unverified paths in the handoff.
 
 ## Testing and verification
 
-- Active extension tests live under `packages/<package>/test/*.test.ts` and run with `npm test`; archived tests under `deprecated/` are excluded.
-- Use `npm run check` as the CI-equivalent local gate; it runs Biome, boundary checks, workspace typechecks, and tests.
-- For package metadata or publishing changes, also run `just pack <unscoped-name>` and inspect the tarball contents.
-- For Pi runtime behavior, prefer `just try <unscoped-name>` or the equivalent explicit `pi -e` path before publishing.
+- Keep active tests under `packages/<package>/test/*.test.ts` and run them with `npm test`.
+- Keep archived tests under `deprecated/` and outside active checks.
+- Use `npm run check` as the CI-equivalent gate for Biome, boundaries, typechecks, and tests.
+- Run `just pack <unscoped-name>` and inspect the tarball after package metadata or publishing changes.
+- Run `just try <unscoped-name>` or an equivalent `pi -e` command for Pi runtime behavior when practical.
 
 ## Publishing and release safety
 
-- Require explicit user approval before publishing, changing npm visibility, creating version tags, or dispatching release workflows.
-- Every publishable package versions independently through Changesets. A pull request that changes published package behavior must add release intent with `npm run changeset`; repository-only documentation, tests, tooling, and path migrations may omit it.
-- Publishable experimental packages use the same Changesets version-PR and publishing workflow as stable packages; preserve their experimental warning in user-facing documentation and runtime behavior.
-- `just npm-public <package>` only changes visibility for an existing package. If a brand-new scoped package still returns 404, its first approved publication must use `npm publish --workspace <package> --access public`.
-- The `publish.yml` workflow creates or updates an independent version PR, then publishes merged versions with package-specific tags and GitHub releases. Initial publication remains a manually approved exception.
-- Publish a new `pi-tui-kit` API before raising a consumer's reviewed compatibility floor; do not release an unpublished Kit API and its first consumer together.
+- Get explicit user approval before publishing, changing npm visibility, creating version tags, or dispatching release workflows.
+- Version every publishable package independently through Changesets.
+- Add a changeset when a pull request changes published package behavior.
+- Repository-only documentation, tests, tooling, and path migrations may omit a changeset.
+- Release experimental packages through the same Changesets workflow as stable packages.
+- Preserve experimental warnings in documentation and runtime behavior.
+- Use `just npm-public <package>` only to change the visibility of an existing package.
+- Use `npm publish --workspace <package> --access public` for the first approved publication of a new scoped package that still returns 404.
+- Treat initial publication as a manually approved exception.
+- Let `publish.yml` manage the version pull request, package tags, publications, and GitHub releases.
+- Publish a new `pi-tui-kit` API before raising a consumer's compatibility floor.
+- Do not release an unpublished Kit API together with its first consumer.
 
-## Git and PR guidance
+## Git and pull requests
 
-- Before drafting or creating a commit, inspect the selected diff and keep one coherent intent; split unrelated changes.
-- Use `<type>[scope][!]: <description>` grounded in the diff. Prefer `feat`, `fix`, `refactor`, or `docs`; omit scope, body, and footers unless useful.
-- When committing, stage only intended paths, recheck the index, reject empty commits, then verify and report the commit ID and remaining changes.
-- For PRs or handoff notes, include the commands run and any publish/visibility checks performed.
+- Inspect the selected diff and keep each commit focused on one intent.
+- Use `<type>[scope][!]: <description>` based on the actual diff.
+- Prefer `feat`, `fix`, `refactor`, or `docs`, and omit unused scope, body, or footers.
+- Stage only intended paths, recheck the index, reject empty commits, and report the commit ID and remaining changes.
+- Include checks and publish or visibility evidence in pull-request or handoff notes.
 
 ## MEMORY.md
 
-- `MEMORY.md` is not auto-loaded. Check it before non-trivial debugging or design work when prior project context may matter.
-- Keep entries short and reusable.
-- `MEMORY.md` must use `## GOTCHA` and `## TASTE` sections.
-- After a non-trivial error or discovery, add one concise entry if it will help future work.
+- `MEMORY.md` is not loaded automatically.
+- Read it at the start of repository work and let current evidence override it.
+- Keep entries short, reusable, and verified.
+- Use exactly `## GOTCHA`, `## TASTE`, and `## CONVENTIONS` as its top-level sections.
+- Add a note only when a verified discovery will help future work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,6 @@
 - Never edit `node_modules/`.
 - Read `node_modules/` to confirm external API types and usage instead of guessing.
 - Keep published files aligned with each manifest's `files` list and `pi.extensions` entry.
-- Keep plans current under `docs/plans/` and follow `docs/plans/README.md` before archiving them.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- Rewrite the root AGENTS.md with shorter and clearer language.
- Keep each prose sentence on its own line.
- Clarify repository, package, verification, release, and memory rules.

## Testing

- `npm run check`

## Release

- No changeset is needed because this is repository-only documentation.