### PR TITLE
test(chat): serialize cross-process peer startup

### DIFF
--- a/docs/plans/archived/2026-08-08_stabilize-pi-chat-dht-test-plan.md
+++ b/docs/plans/archived/2026-08-08_stabilize-pi-chat-dht-test-plan.md
@@ -1,0 +1,17 @@
+# Stabilize the Pi Chat cross-process DHT test
+
+## Goal
+
+Prevent the cross-process Pi Chat DHT smoke test from racing both peer announcements during a busy CI run.
+
+## Plan
+
+- [x] Update `packages/pi-chat/test/network.test.ts` to launch each child only after the previous child reports readiness, while preserving process cleanup and the cross-process message assertion; five focused Vitest runs passed.
+- [x] Audit the test-only lifecycle against `docs/extension-conventions.md`, including child failure diagnostics and cleanup after partial startup; the child launch now occurs inside the existing `try`/`finally`, and every started child remains tracked for shutdown.
+- [x] Run `npm run check` to prove the CI-equivalent gate passes; all 227 test files and 2,581 tests passed.
+
+## Completion Checklist
+
+- [x] The focused Pi Chat network suite passes repeatedly.
+- [x] The repository CI-equivalent check passes.
+- [x] No changeset is present because the fix changes repository-only test orchestration, not published behavior.

--- a/packages/pi-chat/test/network.test.ts
+++ b/packages/pi-chat/test/network.test.ts
@@ -241,7 +241,7 @@ test("a completed startup releases its caller signal without leaving the room", 
 });
 
 test("two separate Node processes connect through a local DHT bootstrap", {
-	timeout: 80_000,
+	timeout: 90_000,
 }, async () => {
 	const testnet = await createTestnet(3);
 	const secret = Buffer.alloc(32, 77);
@@ -250,15 +250,19 @@ test("two separate Node processes connect through a local DHT bootstrap", {
 		process.cwd(),
 		"node_modules/.cache/pi-extensions-test/packages/pi-chat/test/network-peer-fixture.js",
 	);
-	const children = Array.from({ length: 2 }, (_, index) =>
-		fork(fixturePath, [bootstrapArg, String(index + 1), secret.toString("base64url")], {
-			execArgv: [],
-			stdio: ["ignore", "ignore", "pipe", "ipc"],
-		}),
-	);
+	const children: ChildProcess[] = [];
 	const messages = new Map<ChildProcess, Array<Record<string, unknown>>>();
 	const errors = new Map<ChildProcess, string>();
-	for (const child of children) {
+	const startChild = (index: number): ChildProcess => {
+		const child = fork(
+			fixturePath,
+			[bootstrapArg, String(index + 1), secret.toString("base64url")],
+			{
+				execArgv: [],
+				stdio: ["ignore", "ignore", "pipe", "ipc"],
+			},
+		);
+		children.push(child);
 		messages.set(child, []);
 		child.on("message", (message: unknown) => {
 			if (message && typeof message === "object") {
@@ -268,14 +272,17 @@ test("two separate Node processes connect through a local DHT bootstrap", {
 		child.stderr?.on("data", (chunk) => {
 			errors.set(child, `${errors.get(child) ?? ""}${String(chunk)}`);
 		});
-	}
+		return child;
+	};
 	try {
-		await waitFor(
-			() =>
-				children.every((child) => messages.get(child)?.some((message) => message.kind === "ready")),
-			() => childDetails(children, messages, errors),
-			35_000,
-		);
+		for (let index = 0; index < 2; index += 1) {
+			const child = startChild(index);
+			await waitFor(
+				() => messages.get(child)?.some((message) => message.kind === "ready") === true,
+				() => childDetails(children, messages, errors),
+				20_000,
+			);
+		}
 		await waitFor(
 			() =>
 				children.every((child) =>


### PR DESCRIPTION
## Summary

- launch the cross-process DHT peers one at a time after an observable readiness handshake
- retain partial-startup cleanup coverage and allow time for serialized startup
- archive the verified implementation plan

## Testing

- five consecutive focused `pi-chat` network test runs
- `npm run check` (227 test files, 2,581 tests)

## Context

Fixes the flaky failure observed in https://github.com/narumiruna/pi-extensions/actions/runs/31257344620/job/93102657423.

No changeset is required because this changes test orchestration only.