### PR TITLE
fix(btw): stabilize mouse selection in side threads

### DIFF
--- a/.changeset/calm-mice-copy.md
+++ b/.changeset/calm-mice-copy.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": patch
+---
+
+Run side threads in a dedicated full-screen TUI so mouse-drag copying stays stable while the main agent continues producing output in the background.

--- a/docs/plans/archived/2026-08-09_pi-btw-dedicated-fullscreen-plan.md
+++ b/docs/plans/archived/2026-08-09_pi-btw-dedicated-fullscreen-plan.md
@@ -1,0 +1,44 @@
+## Goal
+
+Keep `/btw` mouse text selection stable while the main agent continues running by rendering the side thread in a dedicated alternate-screen TUI and catching the main TUI up after exit.
+
+## Architecture
+
+- Keep the main agent and session running.
+- Suspend only the parent TUI renderer while the side thread is open.
+- Run every side-thread custom component in one extension-owned `TuiAltScreen` with application-owned mouse selection enabled.
+- Proxy the command context so side-thread menus, loaders, transcript views, and notifications use the dedicated TUI while main-editor reads and writes retain their existing owner.
+- Stop and dispose the dedicated TUI before restarting and force-rendering the parent TUI.
+
+## Non-Goals
+
+- Do not pause, abort, or queue the main agent.
+- Do not change side-thread model, transcript, bring-to-main, or settings semantics.
+- Do not add direct clipboard or terminal mouse-protocol handling to pi-btw.
+
+## Risks
+
+- Two TUI instances must never own the terminal concurrently.
+- Cancellation, disposal, synchronous completion, factory errors, and session replacement must restore the parent renderer exactly once.
+- Notifications emitted while the main renderer is suspended must remain visible after returning.
+
+## Plan
+
+- [x] Add focused failing tests for command routing and dedicated-TUI ownership, including cleanup after completion, errors, and disposal.
+  Red evidence: the new suite initially failed because `fullscreen-ui.js` did not exist, command routing reported `0 !== 2`, and the editor-preservation regression reported `main draft` instead of `brought side context`.
+- [x] Add a dedicated fullscreen UI bridge under `packages/pi-btw/src/` and route `runBtwThread` through it.
+  Evidence: all 125 pi-btw tests pass, including real `TuiAltScreen` mouse-mode enable/disable sequences.
+- [x] Update `packages/pi-btw/README.md` and add a patch changeset describing stable mouse selection while main output continues.
+- [x] Audit cancellation, component disposal, session replacement, main-editor preservation, and terminal ownership against `docs/extension-conventions.md`.
+  Evidence: focused tests cover completion, flow errors, stop failures, synchronous and delayed disposal, ordered parent restoration, and bring-to-main editor retention.
+- [x] Run focused pi-btw tests, package typechecking, `npm run check`, and `npm run pack:btw`; inspect the packed file list.
+  Evidence: the root gate passed 2,614 tests, and the 12-file tarball includes `src/fullscreen-ui.ts` with no tests or plan artifacts.
+
+## Completion Checklist
+
+- [x] The main TUI stops before the dedicated TUI starts and restarts only after the dedicated TUI stops.
+- [x] The main agent is never awaited or aborted by `/btw`; command coverage asserts zero `waitForIdle()` calls.
+- [x] All side-thread custom screens share the dedicated TUI and retain keyboard input and application-owned mouse selection.
+- [x] Normal completion, errors, and disposal restore terminal ownership and dispose active components exactly once.
+- [x] Existing side-thread and bring-to-main behavior passes unchanged, including editor text written during the fullscreen flow.
+- [x] Documentation, changeset, CI-equivalent checks, and package preview are complete.

--- a/docs/plans/archived/2026-08-09_pi-btw-fullscreen-hardening-plan.md
+++ b/docs/plans/archived/2026-08-09_pi-btw-fullscreen-hardening-plan.md
@@ -1,0 +1,37 @@
+## Goal
+
+Harden the dedicated `/btw` fullscreen lifecycle so asynchronous custom-component factories cannot strand terminal ownership and returning to the main TUI does not unnecessarily clear scrollback.
+
+## Context
+
+The review target is pull request #652 against `main`.
+The main risk boundary is `packages/pi-btw/src/fullscreen-ui.ts`, which temporarily transfers one terminal between the parent TUI and a side-thread `TuiAltScreen`.
+
+## Risks
+
+- A custom factory can invoke its completion callback before its asynchronous component factory settles.
+- Waiting for that factory can leave the side promise pending and prevent parent-TUI restoration.
+- A forced parent redraw resets `TuiMainScreen` state and emits the clear-scrollback sequence even when the terminal size did not change.
+
+## Plan
+
+- [x] Add focused regression tests for completion before asynchronous factory fulfillment or rejection; verify they fail without timing sleeps.
+  Evidence: the focused suite first left the result pending, then the contract-aligned tests failed because rejection overrode `done` and parent restoration waited for factory fulfillment.
+- [x] Add focused coverage that parent restoration performs a non-forced redraw; verify the current forced-redraw event fails the assertion.
+  Evidence: three restoration tests received `parent.render:true` instead of `parent.renderNow:false` before the fix.
+- [x] Harden custom UI settlement so `done` settles immediately, later rejection cannot override it, and a component created after completion is disposed exactly once.
+  Evidence: the focused suite covers fulfillment, rejection, cancellation, duplicate disposal, and late component creation.
+- [x] Restore the parent with a non-forced synchronous render so stopped-state pending renders cannot suppress catch-up and regular-screen scrollback is preserved.
+  Evidence: all completion and error paths assert `renderNow(false)` after parent restart.
+- [x] Re-review the branch diff for terminal ownership, cancellation, stale state after awaits, cleanup failures, editor preservation, input handling, and same-pattern lifecycle bugs.
+  Evidence: no additional confirmed finding remained after tracing `runBtwFullscreen`, `runBtwThread`, Pi custom-UI semantics, and `TuiAltScreen`/`TuiMainScreen` lifecycle behavior.
+- [x] Run focused pi-btw tests, package checks, the root CI-equivalent gate, and package preview; record evidence.
+  Evidence: 127 pi-btw tests passed; package check passed; the final root gate passed 2,616 tests after one unrelated `pi-worktree` temporary-directory cleanup flake passed on focused retry; the 12-file package preview includes `src/fullscreen-ui.ts` and excludes tests and plans.
+
+## Completion Checklist
+
+- [x] Every tested custom factory outcome settles without leaving the parent TUI stopped.
+- [x] Components created after completion or cancellation are disposed exactly once.
+- [x] Parent restoration catches up without requesting a forced render.
+- [x] Existing mouse selection, notification, editor preservation, error, and disposal behavior remains covered and passing.
+- [x] The branch diff passes formatting, boundaries, typechecking, tests, packaging, and a fresh semantic review.

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -10,7 +10,8 @@ Use it when you want to ask a temporary question, inspect context, or get a shor
 
 - Adds a `/btw` menu for starting a side thread or changing pi-btw settings.
 - Keeps `/btw <question>` as a direct fast path.
-- Answers side questions in a temporary, scrollable UI.
+- Answers side questions in a dedicated, scrollable full-screen UI.
+- Keeps mouse-drag copying stable while the main agent continues running in the background.
 - Supports follow-up questions in the same ephemeral side thread.
 - Optionally brings the latest answer, a question-to-end suffix, an exact line range, or the entire side thread into the main editor.
 - Uses the current session branch as context.
@@ -58,8 +59,13 @@ Examples:
 Running `/btw` alone opens a two-row menu. **Start side thread** is selected first, so pressing
 `Enter` opens an empty ephemeral side thread; **Settings** changes the starting thinking level
 and whether shortcut changes are remembered. `/btw <question>` bypasses this menu, and its answer
-opens above the side-thread editor. A compact `btw · side thread` header stays fixed above the
-content so the ephemeral workspace remains recognizable while scrolling. Messages use Pi's normal
+opens above the side-thread editor. The side thread uses a dedicated full-screen terminal view.
+The main agent continues running in the background, but its screen rendering stays suspended until
+`/btw` closes, so new main-thread output cannot move a mouse selection inside the side thread.
+Drag the primary mouse button across side-thread text to select and copy it through Pi's terminal
+clipboard support. Returning from `/btw` redraws the main view with everything produced while it
+was hidden. A compact `btw · side thread` header stays fixed above the content so the ephemeral
+workspace remains recognizable while scrolling. Messages use Pi's normal
 user and assistant presentation without numbered turns or role labels. Type each question and press
 `Enter`; no follow-up shortcut is required.
 Previous side questions and answers remain available to the model and visible for that

--- a/packages/pi-btw/src/btw.ts
+++ b/packages/pi-btw/src/btw.ts
@@ -25,6 +25,7 @@ import {
 	getAnsweredTurns,
 	summarizeBringToMain,
 } from "./bring-to-main.js";
+import { type RunBtwFullscreen, runBtwFullscreen } from "./fullscreen-ui.js";
 import {
 	type BtwCommandMenuResult,
 	runBtwMenuPreservingEditor,
@@ -213,6 +214,7 @@ export interface BtwExtensionDependencies {
 	loadSettings?: typeof loadSettingsForCommand;
 	resolveModel?: typeof resolveBtwModelWithLoader;
 	runThread?: typeof runBtwThread;
+	runFullscreen?: RunBtwFullscreen;
 }
 
 export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependencies = {}) {
@@ -220,6 +222,7 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 	const loadSettings = dependencies.loadSettings ?? loadSettingsForCommand;
 	const resolveModel = dependencies.resolveModel ?? resolveBtwModelWithLoader;
 	const runThread = dependencies.runThread ?? runBtwThread;
+	const runFullscreen = dependencies.runFullscreen ?? runBtwFullscreen;
 	pi.registerCommand("btw", {
 		description: "Ask a quick side question without adding it to the main conversation",
 		handler: async (args, ctx) => {
@@ -241,13 +244,15 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 				return;
 			}
 
-			await runThread({
-				initialQuestion: question || undefined,
-				selected: resolution.selected,
-				thinkingLevel: settings.thinkingLevel ?? pi.getThinkingLevel(),
-				rememberThinkingLevelChanges: effectiveRememberThinkingLevelChanges(settings),
-				ctx,
-			});
+			await runFullscreen(ctx, (fullscreenCtx) =>
+				runThread({
+					initialQuestion: question || undefined,
+					selected: resolution.selected,
+					thinkingLevel: settings.thinkingLevel ?? pi.getThinkingLevel(),
+					rememberThinkingLevelChanges: effectiveRememberThinkingLevelChanges(settings),
+					ctx: fullscreenCtx,
+				}),
+			);
 		},
 	});
 }

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -1,0 +1,293 @@
+import type {
+	ExtensionCommandContext,
+	KeybindingsManager,
+	Theme,
+} from "@earendil-works/pi-coding-agent";
+import {
+	type Component,
+	type OverlayHandle,
+	type TUI,
+	TuiAltScreen,
+	truncateToWidth,
+} from "@earendil-works/pi-tui";
+import { sanitizeSingleLine } from "./text.js";
+
+type BtwCustomOptions = Parameters<ExtensionCommandContext["ui"]["custom"]>[1];
+type BtwCustomFactory<T> = (
+	tui: TUI,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	done: (result: T) => void,
+) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>;
+
+type BtwFullscreenTui = TUI & { flash?: (message: string, durationMs?: number) => void };
+
+export type BtwFullscreenTuiFactory = (parent: TUI) => BtwFullscreenTui;
+
+export interface BtwFullscreenDependencies {
+	createTui?: BtwFullscreenTuiFactory;
+}
+
+export type RunBtwFullscreen = <T>(
+	ctx: ExtensionCommandContext,
+	run: (ctx: ExtensionCommandContext) => Promise<T>,
+) => Promise<T>;
+
+type FullscreenOutcome<T> = { kind: "completed"; value: T } | { kind: "failed"; error: unknown };
+
+class FullscreenUiDisposedError extends Error {
+	constructor() {
+		super("The dedicated pi-btw UI was disposed.");
+		this.name = "FullscreenUiDisposedError";
+	}
+}
+
+export async function runBtwFullscreen<T>(
+	ctx: ExtensionCommandContext,
+	run: (ctx: ExtensionCommandContext) => Promise<T>,
+	dependencies: BtwFullscreenDependencies = {},
+): Promise<T> {
+	const createTui = dependencies.createTui ?? createBtwFullscreenTui;
+	let liveEditorText = ctx.ui.getEditorText();
+	let restoreEditor = false;
+	const outcome = await ctx.ui.custom<FullscreenOutcome<T>>(
+		(parent, theme, keybindings, done) =>
+			new BtwFullscreenHost(
+				parent,
+				theme,
+				keybindings,
+				ctx,
+				run,
+				(value) => {
+					try {
+						liveEditorText = ctx.ui.getEditorText();
+						restoreEditor = true;
+					} catch {
+						// A replaced session owns a different editor and must not receive stale text.
+					}
+					done(value);
+				},
+				createTui,
+			),
+	);
+	if (restoreEditor) {
+		try {
+			if (ctx.ui.getEditorText() !== liveEditorText) ctx.ui.setEditorText(liveEditorText);
+		} catch {
+			// A replaced session owns a different editor and must not receive stale restoration.
+		}
+	}
+	if (outcome.kind === "failed") throw outcome.error;
+	return outcome.value;
+}
+
+function createBtwFullscreenTui(parent: TUI): BtwFullscreenTui {
+	return new TuiAltScreen(parent.terminal, parent.getShowHardwareCursor(), undefined, {
+		mouse: true,
+	});
+}
+
+class BtwFullscreenHost<T> implements Component {
+	private fullscreen: BtwFullscreenTui | undefined;
+	private cancelActiveCustom: (() => void) | undefined;
+	private started = false;
+	private disposed = false;
+	private finished = false;
+
+	constructor(
+		private readonly parent: TUI,
+		private readonly theme: Theme,
+		private readonly keybindings: KeybindingsManager,
+		private readonly ctx: ExtensionCommandContext,
+		private readonly run: (ctx: ExtensionCommandContext) => Promise<T>,
+		private readonly done: (outcome: FullscreenOutcome<T>) => void,
+		private readonly createTui: BtwFullscreenTuiFactory,
+	) {
+		queueMicrotask(() => void this.start());
+	}
+
+	render(width: number): string[] {
+		return [truncateToWidth(this.theme.fg("muted", "Opening btw side thread…"), width)];
+	}
+
+	invalidate(): void {}
+
+	dispose(): void {
+		if (this.disposed || this.finished) return;
+		this.disposed = true;
+		this.cancelActiveCustom?.();
+	}
+
+	private async start(): Promise<void> {
+		if (this.started || this.finished) return;
+		this.started = true;
+		let outcome: FullscreenOutcome<T>;
+		let parentStopped = false;
+		let fullscreenCreated = false;
+		try {
+			if (this.disposed) throw new FullscreenUiDisposedError();
+			this.parent.stop({ preserveScreen: true });
+			parentStopped = true;
+			if (this.disposed) throw new FullscreenUiDisposedError();
+			this.fullscreen = this.createTui(this.parent);
+			fullscreenCreated = true;
+			this.fullscreen.start();
+			outcome = { kind: "completed", value: await this.run(this.createContext()) };
+		} catch (error) {
+			outcome = { kind: "failed", error };
+		}
+
+		let cleanupError: unknown;
+		try {
+			this.cancelActiveCustom?.();
+		} catch (error) {
+			cleanupError = error;
+		}
+		if (fullscreenCreated) {
+			try {
+				this.fullscreen?.stop({ preserveScreen: true });
+			} catch (error) {
+				cleanupError ??= error;
+			}
+		}
+		if (parentStopped) {
+			try {
+				this.parent.start();
+				this.parent.requestRender(true);
+			} catch (error) {
+				cleanupError ??= error;
+			}
+		}
+		if (cleanupError !== undefined) outcome = { kind: "failed", error: cleanupError };
+		this.finished = true;
+		this.done(outcome);
+	}
+
+	private createContext(): ExtensionCommandContext {
+		const ui = new Proxy(this.ctx.ui, {
+			get: (target, property) => {
+				if (property === "custom") {
+					return <Value>(factory: BtwCustomFactory<Value>, options?: BtwCustomOptions) =>
+						this.showCustom(factory, options);
+				}
+				if (property === "notify") {
+					return (
+						message: string,
+						level?: Parameters<ExtensionCommandContext["ui"]["notify"]>[1],
+					) => {
+						target.notify(message, level);
+						const display = sanitizeSingleLine(message);
+						if (display) this.fullscreen?.flash?.(display);
+					};
+				}
+				const value = Reflect.get(target, property, target) as unknown;
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		});
+		return new Proxy(this.ctx, {
+			get: (target, property) => (property === "ui" ? ui : Reflect.get(target, property, target)),
+		});
+	}
+
+	private showCustom<Value>(
+		factory: BtwCustomFactory<Value>,
+		options?: BtwCustomOptions,
+	): Promise<Value> {
+		const fullscreen = this.fullscreen;
+		if (!fullscreen || this.disposed || this.finished) {
+			return Promise.reject(new FullscreenUiDisposedError());
+		}
+		if (this.cancelActiveCustom) {
+			return Promise.reject(new Error("pi-btw attempted to open overlapping custom UI."));
+		}
+
+		return new Promise<Value>((resolve, reject) => {
+			let component: (Component & { dispose?(): void }) | undefined;
+			let overlay: OverlayHandle | undefined;
+			let mounted = false;
+			let factorySettled = false;
+			let closed = false;
+			let componentDisposed = false;
+			let pendingValue: Value | undefined;
+			let hasPendingValue = false;
+
+			const disposeComponent = () => {
+				if (!component || componentDisposed) return;
+				componentDisposed = true;
+				try {
+					component.dispose?.();
+				} catch {
+					// Cleanup must continue so terminal ownership is restored.
+				}
+			};
+			const unmount = () => {
+				if (overlay) overlay.hide();
+				else if (mounted && component) fullscreen.removeChild(component);
+				if (overlay || mounted) {
+					fullscreen.setFocus(null);
+					fullscreen.requestRender();
+				}
+				disposeComponent();
+			};
+			const complete = () => {
+				if (!factorySettled || !hasPendingValue) return;
+				unmount();
+				this.cancelActiveCustom = undefined;
+				resolve(pendingValue as Value);
+			};
+			const close = (value: Value) => {
+				if (closed) return;
+				closed = true;
+				pendingValue = value;
+				hasPendingValue = true;
+				complete();
+			};
+			const fail = (error: unknown) => {
+				if (closed) return;
+				closed = true;
+				unmount();
+				this.cancelActiveCustom = undefined;
+				reject(error);
+			};
+			this.cancelActiveCustom = () => {
+				if (closed) return;
+				disposeComponent();
+				if (!closed) fail(new FullscreenUiDisposedError());
+			};
+
+			let created: ReturnType<BtwCustomFactory<Value>>;
+			try {
+				created = factory(fullscreen, this.theme, this.keybindings, close);
+			} catch (error) {
+				factorySettled = true;
+				fail(error);
+				return;
+			}
+			Promise.resolve(created)
+				.then((value) => {
+					component = value;
+					factorySettled = true;
+					if (closed) {
+						if (hasPendingValue) complete();
+						else disposeComponent();
+						return;
+					}
+					if (options?.overlay) {
+						const overlayOptions =
+							typeof options.overlayOptions === "function"
+								? options.overlayOptions()
+								: options.overlayOptions;
+						overlay = fullscreen.showOverlay(component, overlayOptions);
+						options.onHandle?.(overlay);
+					} else {
+						fullscreen.clear();
+						fullscreen.addChild(component);
+						mounted = true;
+						fullscreen.setFocus(component);
+						fullscreen.requestRender();
+					}
+				})
+				.catch(fail);
+		});
+	}
+}

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import type {
 	ExtensionCommandContext,
 	KeybindingsManager,
@@ -26,6 +27,7 @@ export type BtwFullscreenTuiFactory = (parent: TUI) => BtwFullscreenTui;
 
 export interface BtwFullscreenDependencies {
 	createTui?: BtwFullscreenTuiFactory;
+	openUrl?: (url: string) => void;
 }
 
 export type RunBtwFullscreen = <T>(
@@ -47,7 +49,9 @@ export async function runBtwFullscreen<T>(
 	run: (ctx: ExtensionCommandContext) => Promise<T>,
 	dependencies: BtwFullscreenDependencies = {},
 ): Promise<T> {
-	const createTui = dependencies.createTui ?? createBtwFullscreenTui;
+	const createTui =
+		dependencies.createTui ??
+		((parent: TUI) => createBtwFullscreenTui(parent, dependencies.openUrl ?? openUrlInBrowser));
 	let liveEditorText = ctx.ui.getEditorText();
 	let restoreEditor = false;
 	const outcome = await ctx.ui.custom<FullscreenOutcome<T>>(
@@ -81,10 +85,24 @@ export async function runBtwFullscreen<T>(
 	return outcome.value;
 }
 
-function createBtwFullscreenTui(parent: TUI): BtwFullscreenTui {
+function createBtwFullscreenTui(parent: TUI, openUrl: (url: string) => void): BtwFullscreenTui {
 	return new TuiAltScreen(parent.terminal, parent.getShowHardwareCursor(), undefined, {
 		mouse: true,
+		openUrl,
 	});
+}
+
+// Pi does not export its browser opener, so mirror its shell-free launcher for this isolated TUI.
+function openUrlInBrowser(target: string): void {
+	const [command, args] =
+		process.platform === "darwin"
+			? ["open", [target]]
+			: process.platform === "win32"
+				? ["rundll32", ["url.dll,FileProtocolHandler", target]]
+				: ["xdg-open", [target]];
+	spawn(command, args, { stdio: "ignore", detached: true })
+		.on("error", () => {})
+		.unref();
 }
 
 class BtwFullscreenHost<T> implements Component {

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -153,7 +153,7 @@ class BtwFullscreenHost<T> implements Component {
 		if (parentStopped) {
 			try {
 				this.parent.start();
-				this.parent.requestRender(true);
+				this.parent.renderNow(false);
 			} catch (error) {
 				cleanupError ??= error;
 			}
@@ -207,6 +207,7 @@ class BtwFullscreenHost<T> implements Component {
 			let mounted = false;
 			let factorySettled = false;
 			let closed = false;
+			let promiseSettled = false;
 			let componentDisposed = false;
 			let pendingValue: Value | undefined;
 			let hasPendingValue = false;
@@ -221,38 +222,62 @@ class BtwFullscreenHost<T> implements Component {
 				}
 			};
 			const unmount = () => {
-				if (overlay) overlay.hide();
-				else if (mounted && component) fullscreen.removeChild(component);
+				let cleanupError: unknown;
+				try {
+					if (overlay) overlay.hide();
+					else if (mounted && component) fullscreen.removeChild(component);
+				} catch (error) {
+					cleanupError = error;
+				}
 				if (overlay || mounted) {
-					fullscreen.setFocus(null);
-					fullscreen.requestRender();
+					try {
+						fullscreen.setFocus(null);
+						fullscreen.requestRender();
+					} catch (error) {
+						cleanupError ??= error;
+					}
 				}
 				disposeComponent();
+				if (cleanupError !== undefined) throw cleanupError;
 			};
 			const complete = () => {
-				if (!factorySettled || !hasPendingValue) return;
-				unmount();
+				if (promiseSettled || !hasPendingValue) return;
+				promiseSettled = true;
 				this.cancelActiveCustom = undefined;
-				resolve(pendingValue as Value);
+				if (!factorySettled) {
+					resolve(pendingValue as Value);
+					return;
+				}
+				try {
+					unmount();
+					resolve(pendingValue as Value);
+				} catch (error) {
+					reject(error);
+				}
 			};
 			const close = (value: Value) => {
-				if (closed) return;
+				if (closed || promiseSettled) return;
 				closed = true;
 				pendingValue = value;
 				hasPendingValue = true;
 				complete();
 			};
 			const fail = (error: unknown) => {
-				if (closed) return;
+				if (promiseSettled) return;
 				closed = true;
-				unmount();
+				promiseSettled = true;
 				this.cancelActiveCustom = undefined;
-				reject(error);
+				try {
+					unmount();
+					reject(error);
+				} catch (cleanupError) {
+					reject(cleanupError);
+				}
 			};
 			this.cancelActiveCustom = () => {
-				if (closed) return;
+				if (promiseSettled) return;
 				disposeComponent();
-				if (!closed) fail(new FullscreenUiDisposedError());
+				if (!promiseSettled) fail(new FullscreenUiDisposedError());
 			};
 
 			let created: ReturnType<BtwCustomFactory<Value>>;
@@ -267,9 +292,12 @@ class BtwFullscreenHost<T> implements Component {
 				.then((value) => {
 					component = value;
 					factorySettled = true;
+					if (promiseSettled) {
+						disposeComponent();
+						return;
+					}
 					if (closed) {
-						if (hasPendingValue) complete();
-						else disposeComponent();
+						complete();
 						return;
 					}
 					if (options?.overlay) {

--- a/packages/pi-btw/test/btw.test.ts
+++ b/packages/pi-btw/test/btw.test.ts
@@ -347,6 +347,7 @@ test("btw command routes no arguments through the menu and preserves direct ques
 		auth: { apiKey: "key" },
 	};
 	const menuCalls: string[] = [];
+	let fullscreenRuns = 0;
 	const threadStarts: Array<{
 		initialQuestion?: string;
 		thinkingLevel: string;
@@ -359,6 +360,10 @@ test("btw command routes no arguments through the menu and preserves direct ques
 		},
 		loadSettings: async () => ({ thinkingLevel: "medium" }),
 		resolveModel: async () => ({ kind: "selected", selected }),
+		runFullscreen: async (ctx, run) => {
+			fullscreenRuns += 1;
+			return run(ctx);
+		},
 		runThread: async (options) => {
 			threadStarts.push({
 				initialQuestion: options.initialQuestion,
@@ -370,12 +375,21 @@ test("btw command routes no arguments through the menu and preserves direct ques
 	});
 	const command = mock.commands.get("btw");
 	assert.ok(command);
-	const interactive = createMockContext({ mode: "tui", hasUI: true });
+	let idleWaits = 0;
+	const interactive = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		waitForIdle: async () => {
+			idleWaits += 1;
+		},
+	});
 
 	await command.handler("", interactive.ctx);
 	await command.handler("direct question", interactive.ctx);
 
 	assert.deepEqual(menuCalls, ["menu"]);
+	assert.equal(fullscreenRuns, 2);
+	assert.equal(idleWaits, 0);
 	assert.deepEqual(threadStarts, [
 		{
 			initialQuestion: undefined,

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { type BtwFullscreenTuiFactory, runBtwFullscreen } from "../src/fullscreen-ui.js";
+
+interface FakeComponent extends Component {
+	dispose(): void;
+}
+
+function createHarness(options: { fullscreenStopError?: Error } = {}) {
+	const events: string[] = [];
+	let outerComponent: FakeComponent | undefined;
+	let outerDone: ((value: unknown) => void) | undefined;
+	let editorText = "main draft";
+	const parent = {
+		mode: "regular",
+		terminal: { rows: 24, columns: 80 },
+		getShowHardwareCursor: () => false,
+		stop: (options?: { preserveScreen?: boolean }) => {
+			events.push(`parent.stop:${String(options?.preserveScreen)}`);
+		},
+		start: () => events.push("parent.start"),
+		requestRender: (force?: boolean) => events.push(`parent.render:${String(force)}`),
+	} as unknown as TUI;
+	let active: Component | undefined;
+	const fullscreen = {
+		mode: "fullscreen",
+		terminal: parent.terminal,
+		children: [] as Component[],
+		clear() {
+			events.push("fullscreen.clear");
+			active = undefined;
+		},
+		addChild(component: Component) {
+			events.push("fullscreen.add");
+			active = component;
+		},
+		removeChild(component: Component) {
+			events.push("fullscreen.remove");
+			if (active === component) active = undefined;
+		},
+		setFocus(component: Component | null) {
+			events.push(component ? "fullscreen.focus" : "fullscreen.unfocus");
+		},
+		start() {
+			events.push("fullscreen.start");
+		},
+		stop(stopOptions?: { preserveScreen?: boolean }) {
+			events.push(`fullscreen.stop:${String(stopOptions?.preserveScreen)}`);
+			if (options.fullscreenStopError) throw options.fullscreenStopError;
+		},
+		requestRender() {
+			events.push("fullscreen.render");
+		},
+		showOverlay() {
+			throw new Error("overlay was not expected");
+		},
+		flash(message: string) {
+			events.push(`fullscreen.flash:${message}`);
+		},
+	} as unknown as TUI;
+	const createTui: BtwFullscreenTuiFactory = () => fullscreen;
+	const notifications: string[] = [];
+	const ctx = {
+		ui: {
+			custom: async (factory: (...args: never[]) => FakeComponent) => {
+				const savedEditorText = editorText;
+				const result = new Promise<unknown>((resolve) => {
+					outerDone = resolve;
+				});
+				outerComponent = factory(
+					parent as never,
+					{
+						fg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					} as never,
+					{} as never,
+					((value: unknown) => outerDone?.(value)) as never,
+				);
+				const value = await result;
+				editorText = savedEditorText;
+				return value;
+			},
+			notify(message: string) {
+				notifications.push(message);
+			},
+			getEditorText: () => editorText,
+			setEditorText: (value: string) => {
+				editorText = value;
+			},
+		},
+	} as never;
+	return {
+		ctx,
+		createTui,
+		events,
+		notifications,
+		get outerComponent() {
+			return outerComponent;
+		},
+		get editorText() {
+			return editorText;
+		},
+	};
+}
+
+function immediateComponent(done: (value: string) => void, events: string[]): FakeComponent {
+	done("side result");
+	return {
+		render: () => ["side"],
+		invalidate() {},
+		dispose() {
+			events.push("component.dispose");
+		},
+	};
+}
+
+test("default fullscreen enables application-owned mouse selection and restores terminal modes", async () => {
+	const writes: string[] = [];
+	let outerDone: ((value: unknown) => void) | undefined;
+	const terminal = {
+		columns: 80,
+		rows: 24,
+		start() {},
+		stop() {},
+		write(data: string) {
+			writes.push(data);
+		},
+		hideCursor() {},
+		showCursor() {},
+	} as never;
+	const parent = {
+		mode: "regular",
+		terminal,
+		getShowHardwareCursor: () => false,
+		stop() {},
+		start() {},
+		requestRender() {},
+	} as unknown as TUI;
+	let editorText = "main draft";
+	const ctx = {
+		ui: {
+			custom: async (factory: (...args: never[]) => FakeComponent) => {
+				const result = new Promise<unknown>((resolve) => {
+					outerDone = resolve;
+				});
+				factory(
+					parent as never,
+					{ fg: (_color: string, text: string) => text } as never,
+					{} as never,
+					((value: unknown) => outerDone?.(value)) as never,
+				);
+				return result;
+			},
+			getEditorText: () => editorText,
+			setEditorText: (value: string) => {
+				editorText = value;
+			},
+		},
+	} as never;
+
+	assert.equal(
+		await runBtwFullscreen(ctx, (fullscreenCtx) =>
+			fullscreenCtx.ui.custom((_tui, _theme, _keys, done) => immediateComponent(done, [])),
+		),
+		"side result",
+	);
+	const output = writes.join("");
+	for (const sequence of ["\u001b[?1049h", "\u001b[?1002h", "\u001b[?1006h"]) {
+		assert.equal(
+			output.includes(sequence),
+			true,
+			`missing enable sequence ${JSON.stringify(sequence)}`,
+		);
+	}
+	for (const sequence of ["\u001b[?1006l", "\u001b[?1002l", "\u001b[?1049l"]) {
+		assert.equal(
+			output.includes(sequence),
+			true,
+			`missing cleanup sequence ${JSON.stringify(sequence)}`,
+		);
+	}
+});
+
+test("dedicated fullscreen owns the terminal while side custom UI runs and restores it afterward", async () => {
+	const harness = createHarness();
+	const result = await runBtwFullscreen(
+		harness.ctx,
+		async (ctx) => {
+			ctx.ui.notify("side notice", "info");
+			assert.equal(ctx.ui.getEditorText(), "main draft");
+			ctx.ui.setEditorText("brought side context");
+			return ctx.ui.custom<string>((tui, _theme, _keys, done) => {
+				assert.equal(tui.mode, "fullscreen");
+				return immediateComponent(done, harness.events);
+			});
+		},
+		{ createTui: harness.createTui },
+	);
+
+	assert.equal(result, "side result");
+	assert.equal(harness.editorText, "brought side context");
+	assert.deepEqual(harness.notifications, ["side notice"]);
+	assert.deepEqual(harness.events, [
+		"parent.stop:true",
+		"fullscreen.start",
+		"fullscreen.flash:side notice",
+		"component.dispose",
+		"fullscreen.stop:true",
+		"parent.start",
+		"parent.render:true",
+	]);
+});
+
+test("dedicated fullscreen restores the parent before propagating a side-flow error", async () => {
+	const harness = createHarness();
+	await assert.rejects(
+		runBtwFullscreen(
+			harness.ctx,
+			async () => {
+				throw new Error("side failed");
+			},
+			{ createTui: harness.createTui },
+		),
+		/side failed/,
+	);
+
+	assert.deepEqual(harness.events, [
+		"parent.stop:true",
+		"fullscreen.start",
+		"fullscreen.stop:true",
+		"parent.start",
+		"parent.render:true",
+	]);
+});
+
+test("a fullscreen stop failure still restarts the parent before it propagates", async () => {
+	const harness = createHarness({ fullscreenStopError: new Error("fullscreen stop failed") });
+	await assert.rejects(
+		runBtwFullscreen(harness.ctx, async () => "done", { createTui: harness.createTui }),
+		/fullscreen stop failed/,
+	);
+
+	assert.deepEqual(harness.events, [
+		"parent.stop:true",
+		"fullscreen.start",
+		"fullscreen.stop:true",
+		"parent.start",
+		"parent.render:true",
+	]);
+});
+
+test("disposing the fullscreen host closes active side UI and restores terminal ownership once", async () => {
+	const harness = createHarness();
+	let closeSide: (() => void) | undefined;
+	const running = runBtwFullscreen(
+		harness.ctx,
+		(ctx) =>
+			ctx.ui.custom<"closed">((_tui, _theme, _keys, done) => {
+				closeSide = () => done("closed");
+				return {
+					render: () => ["waiting"],
+					invalidate() {},
+					dispose() {
+						harness.events.push("component.dispose");
+						closeSide?.();
+					},
+				};
+			}),
+		{ createTui: harness.createTui },
+	);
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.ok(harness.outerComponent);
+	harness.outerComponent.dispose();
+	harness.outerComponent.dispose();
+
+	assert.equal(await running, "closed");
+	assert.equal(harness.events.filter((event) => event === "fullscreen.stop:true").length, 1);
+	assert.equal(harness.events.filter((event) => event === "parent.start").length, 1);
+	assert.equal(harness.events.filter((event) => event === "component.dispose").length, 1);
+});
+
+test("disposal restores the parent and disposes a custom component whose factory settles late", async () => {
+	const harness = createHarness();
+	let releaseFactory: ((component: FakeComponent) => void) | undefined;
+	const running = runBtwFullscreen(
+		harness.ctx,
+		(ctx) =>
+			ctx.ui.custom(
+				(_tui, _theme, _keys, _done) =>
+					new Promise<FakeComponent>((resolve) => {
+						releaseFactory = resolve;
+					}),
+			),
+		{ createTui: harness.createTui },
+	);
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.ok(harness.outerComponent);
+	harness.outerComponent.dispose();
+	await assert.rejects(running, /dedicated pi-btw UI was disposed/i);
+	assert.ok(releaseFactory);
+	releaseFactory({
+		render: () => ["late"],
+		invalidate() {},
+		dispose() {
+			harness.events.push("late-component.dispose");
+		},
+	});
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.equal(harness.events.filter((event) => event === "fullscreen.stop:true").length, 1);
+	assert.equal(harness.events.filter((event) => event === "parent.start").length, 1);
+	assert.equal(harness.events.filter((event) => event === "late-component.dispose").length, 1);
+});

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -20,6 +20,7 @@ function createHarness(options: { fullscreenStopError?: Error } = {}) {
 			events.push(`parent.stop:${String(options?.preserveScreen)}`);
 		},
 		start: () => events.push("parent.start"),
+		renderNow: (force?: boolean) => events.push(`parent.renderNow:${String(force)}`),
 		requestRender: (force?: boolean) => events.push(`parent.render:${String(force)}`),
 	} as unknown as TUI;
 	let active: Component | undefined;
@@ -115,6 +116,10 @@ function immediateComponent(done: (value: string) => void, events: string[]): Fa
 	};
 }
 
+async function flushAsyncWork(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
 test("default fullscreen enables application-owned mouse selection and restores terminal modes", async () => {
 	const writes: string[] = [];
 	let outerDone: ((value: unknown) => void) | undefined;
@@ -135,6 +140,7 @@ test("default fullscreen enables application-owned mouse selection and restores 
 		getShowHardwareCursor: () => false,
 		stop() {},
 		start() {},
+		renderNow() {},
 		requestRender() {},
 	} as unknown as TUI;
 	let editorText = "main draft";
@@ -208,7 +214,7 @@ test("dedicated fullscreen owns the terminal while side custom UI runs and resto
 		"component.dispose",
 		"fullscreen.stop:true",
 		"parent.start",
-		"parent.render:true",
+		"parent.renderNow:false",
 	]);
 });
 
@@ -230,7 +236,7 @@ test("dedicated fullscreen restores the parent before propagating a side-flow er
 		"fullscreen.start",
 		"fullscreen.stop:true",
 		"parent.start",
-		"parent.render:true",
+		"parent.renderNow:false",
 	]);
 });
 
@@ -246,7 +252,7 @@ test("a fullscreen stop failure still restarts the parent before it propagates",
 		"fullscreen.start",
 		"fullscreen.stop:true",
 		"parent.start",
-		"parent.render:true",
+		"parent.renderNow:false",
 	]);
 });
 
@@ -314,4 +320,67 @@ test("disposal restores the parent and disposes a custom component whose factory
 	assert.equal(harness.events.filter((event) => event === "fullscreen.stop:true").length, 1);
 	assert.equal(harness.events.filter((event) => event === "parent.start").length, 1);
 	assert.equal(harness.events.filter((event) => event === "late-component.dispose").length, 1);
+});
+
+test("done wins over a later asynchronous custom factory rejection", async () => {
+	const harness = createHarness();
+	const running = runBtwFullscreen(
+		harness.ctx,
+		(ctx) =>
+			ctx.ui.custom((_tui, _theme, _keys, done) => {
+				done("completed result");
+				return Promise.reject(new Error("factory failed after done"));
+			}),
+		{ createTui: harness.createTui },
+	);
+
+	await flushAsyncWork();
+
+	assert.equal(await running, "completed result");
+	assert.equal(harness.events.filter((event) => event === "fullscreen.stop:true").length, 1);
+	assert.equal(harness.events.filter((event) => event === "parent.start").length, 1);
+});
+
+test("done restores the parent without waiting for an asynchronous custom factory", async () => {
+	const harness = createHarness();
+	let releaseFactory: ((component: FakeComponent) => void) | undefined;
+	const running = runBtwFullscreen(
+		harness.ctx,
+		(ctx) =>
+			ctx.ui.custom((_tui, _theme, _keys, done) => {
+				done("completed result");
+				return new Promise<FakeComponent>((resolve) => {
+					releaseFactory = resolve;
+				});
+			}),
+		{ createTui: harness.createTui },
+	);
+	let observed: unknown = "pending";
+	void running.then(
+		(value) => {
+			observed = value;
+		},
+		(error: unknown) => {
+			observed = error;
+		},
+	);
+
+	await flushAsyncWork();
+	assert.ok(releaseFactory);
+	const restoredBeforeFactorySettled = harness.events.includes("parent.start");
+	releaseFactory({
+		render: () => ["late"],
+		invalidate() {},
+		dispose() {
+			harness.events.push("late-after-done.dispose");
+		},
+	});
+	await flushAsyncWork();
+
+	assert.equal(restoredBeforeFactorySettled, true);
+	assert.equal(observed, "completed result");
+	assert.equal(await running, "completed result");
+	assert.equal(harness.events.filter((event) => event === "fullscreen.stop:true").length, 1);
+	assert.equal(harness.events.filter((event) => event === "parent.start").length, 1);
+	assert.equal(harness.events.filter((event) => event === "late-after-done.dispose").length, 1);
 });

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -188,6 +188,82 @@ test("default fullscreen enables application-owned mouse selection and restores 
 	}
 });
 
+test("default fullscreen activates OSC-8 links through the configured URL opener", async () => {
+	let handleInput: ((data: string) => void) | undefined;
+	const terminal = {
+		columns: 80,
+		rows: 24,
+		start(onInput: (data: string) => void) {
+			handleInput = onInput;
+		},
+		stop() {},
+		write() {},
+		hideCursor() {},
+		showCursor() {},
+	} as never;
+	const parent = {
+		mode: "regular",
+		terminal,
+		getShowHardwareCursor: () => false,
+		stop() {},
+		start() {},
+		renderNow() {},
+		requestRender() {},
+	} as unknown as TUI;
+	let outerDone: ((value: unknown) => void) | undefined;
+	let editorText = "main draft";
+	const ctx = {
+		ui: {
+			custom: async (factory: (...args: never[]) => FakeComponent) => {
+				const result = new Promise<unknown>((resolve) => {
+					outerDone = resolve;
+				});
+				factory(
+					parent as never,
+					{ fg: (_color: string, text: string) => text } as never,
+					{} as never,
+					((value: unknown) => outerDone?.(value)) as never,
+				);
+				return result;
+			},
+			getEditorText: () => editorText,
+			setEditorText: (value: string) => {
+				editorText = value;
+			},
+		},
+	} as never;
+	const url = "https://example.com/docs";
+	const opened: string[] = [];
+	let sideTui: TUI | undefined;
+	let closeSide: (() => void) | undefined;
+	const running = runBtwFullscreen(
+		ctx,
+		(fullscreenCtx) =>
+			fullscreenCtx.ui.custom<"closed">((tui, _theme, _keys, done) => {
+				sideTui = tui;
+				closeSide = () => done("closed");
+				return {
+					render: () => [`\u001b]8;;${url}\u0007documentation\u001b]8;;\u0007`],
+					invalidate() {},
+					dispose() {},
+				};
+			}),
+		{ openUrl: (target: string) => opened.push(target) },
+	);
+	await flushAsyncWork();
+	assert.ok(sideTui);
+	assert.ok(handleInput);
+	assert.ok(closeSide);
+	sideTui.renderNow(true);
+	handleInput("\u001b[<0;1;1M");
+	handleInput("\u001b[<0;1;1m");
+	const openedBeforeClose = [...opened];
+	closeSide();
+
+	assert.equal(await running, "closed");
+	assert.deepEqual(openedBeforeClose, [url]);
+});
+
 test("dedicated fullscreen owns the terminal while side custom UI runs and restores it afterward", async () => {
 	const harness = createHarness();
 	const result = await runBtwFullscreen(


### PR DESCRIPTION
## Summary

- Run `/btw` side threads in a dedicated alternate-screen TUI while main-thread rendering is suspended.
- Keep the main agent running and restore the parent TUI, editor contents, and accumulated output when the side thread closes.
- Harden early custom-UI completion, late factory settlement, cancellation, cleanup failures, and parent redraw behavior.
- Cover terminal ownership, mouse mode, errors, disposal, editor preservation, and scrollback-safe restoration, and add the patch changeset and documentation.

## Testing

- `npm run check` (2,616 tests passed)
- `npm run check --workspace @narumitw/pi-btw`
- `npx vitest run packages/pi-btw/test` (127 tests passed)
- `npm run pack:btw` (12-file packed list inspected)

The first root-gate run encountered an unrelated `pi-worktree` temporary-directory cleanup flake; its focused retry and the full root-gate retry passed.

## Manual verification

- Interactive terminal mouse selection was not run in this non-interactive agent environment.
- Automated coverage verifies the real `TuiAltScreen` mouse enable/disable sequences and parent TUI restoration order.
