### PR TITLE
feat(subagents): expose detached agent limits

### DIFF
--- a/.changeset/bright-otters-scale.md
+++ b/.changeset/bright-otters-scale.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Add interactive detached-agent capacity, concurrency, depth, child, and persistence limit settings.

--- a/docs/plans/archived/2026-08-09_pi-subagents-detached-limit-settings-plan.md
+++ b/docs/plans/archived/2026-08-09_pi-subagents-detached-limit-settings-plan.md
@@ -1,0 +1,73 @@
+# Expand pi-subagents detached limit settings
+
+## Goal
+
+Let users edit the existing detached-subagent capacity and concurrency limits from `/subagents` instead of requiring manual JSON changes.
+
+Expose `stateful.maxAgents`, `stateful.maxActiveTurns`, `stateful.maxChildrenPerAgent`, `stateful.maxDepth`, and `stateful.maxStoredAgents` while preserving their current defaults and accepted values.
+
+## Context
+
+The runtime already reads all five fields from `~/.pi/agent/pi-subagents.json`.
+
+Only `blocking.maxParallelTasks` currently has an interactive numeric editor.
+
+The detached registry and persistence layer capture these five limits during extension startup, so changing them safely requires a later `/reload` or session restart.
+
+Lowering `maxAgents`, `maxDepth`, or `maxStoredAgents` below current retained state can prevent some records from being restored after reload and therefore needs a clear preview and confirmation.
+
+## Architecture
+
+- Keep `settings.ts` as the owner of validation, inspection, source reporting, and atomic user-setting updates.
+- Centralize the five defaults and effective-value resolution so `AgentRegistry`, `AgentPersistence`, status output, inspection output, and the editor cannot drift.
+- Add **Detached agent limits** under `/subagents` → **Advanced settings** and keep the existing **Maximum parallel workers** route unchanged.
+- Put the five related settings on one action screen, with one numeric input screen per field and current-session versus configured values shown before editing.
+- Save each accepted value immediately, but do not mutate the live registry or automatically reload; report that the value applies after `/reload` so users can make several edits before one restart.
+- Keep the numeric editor and destructive-lowering preview in a dedicated module so `config-ui.ts` remains below the repository's 1,000-line review threshold.
+- Expose current and configured detached limits through `/subagents status`, `/subagents help`, manager summaries, and `subagent_inspect status` for TUI and non-TUI observability.
+
+## Non-Goals
+
+- Do not make the fixed blocking execution concurrency of four configurable in this change.
+- Do not change blocking single, chain, parallel, aggregator, or detached scheduling semantics.
+- Do not add arbitrary presets or narrow the currently accepted safe-integer domains.
+- Do not expose mailbox, byte, timeout, retention-day, or idle-TTL settings as agent-count controls.
+- Do not add project-scoped settings or new environment variables.
+- Do not automatically close, evict, interrupt, or reload retained agents after a save.
+
+## Assumptions
+
+- “More quantity options” means exposing the five existing detached-agent limits, not introducing additional resource limits.
+- Numeric inputs are preferable to fixed value cycles because the existing settings accept user-selected safe integers and no evidence supports a smaller preset list.
+- `maxDepth` continues to accept zero, while the other four fields continue to require positive safe integers.
+- Cross-field combinations remain valid as they are today; for example, `maxActiveTurns` may exceed `maxAgents`, although the smaller live capacity remains the effective practical bound.
+
+## Risks
+
+- Duplicate defaults could make the UI report a value different from the registry or persistence layer, so all consumers must use one resolver.
+- Lower values can reduce restored capacity, so the editor must identify affected retained agents before saving and cancellation must leave the file unchanged.
+- A manual file change can make configured values differ from the current startup snapshot, so every screen must label current and configured values separately.
+- A malformed or concurrently changed settings file could otherwise be overwritten, so every write must reuse the existing mutation lock, latest-document read, unknown-field preservation, and atomic rename protocol.
+- Reloading while detached agents are retained can interrupt work, so the editor must never reload automatically and must direct users to Current agents before a deliberate reload.
+
+## Plan
+
+- [x] Add a shared detached-limit definition and resolver for the five fields, their defaults, labels, descriptions, and validation domains; `stateful-limits.ts`, registry, persistence, runtime tests, and session-refresh tests use the same resolved values.
+- [x] Add structured inspection and a field-specific updater in `packages/pi-subagents/src/settings.ts`; settings tests verify side-effect-free defaults, unknown-field preservation, invalid-file protection, legacy seeding, expected-tuple rejection, and canonical publication races.
+- [x] Extend `StatefulSubagentRuntimeStatus` and `subagent_inspect status` with current and configured limits plus per-field sources; inspect and renderer tests verify structured and TUI-visible output.
+- [x] Add `packages/pi-subagents/src/stateful-limit-ui.ts` with five validated numeric input flows; manager tests verify every label and 64-cell rendering.
+- [x] Wire the new screen into `/subagents` → **Advanced settings** without moving the existing parallel-limit route; tests cover Escape, Ctrl+C, invalid input, session replacement, shutdown, and stale confirmation snapshots.
+- [x] Implement startup-only save behavior with reload messaging; tests save multiple values while the current runtime remains unchanged and verify later session starts refresh the limits.
+- [x] Add ancestry-aware lowering previews for `maxAgents`, `maxDepth`, and `maxStoredAgents`; tests cover exact projected counts, cancellation, changed snapshots, session replacement, and settings-write failure.
+- [x] Update manager summary, status, help, spawn guidance, structured inspection, and inspect rendering with effective and configured capacity information.
+- [x] Update `packages/pi-subagents/README.md` and add `.changeset/bright-otters-scale.md` with a minor release intent.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`; independent review passed after lifecycle-order, configured-divergence, renderer, and field-specific preview fixes.
+
+## Completion Checklist
+
+- [x] `npm run check --workspace @narumitw/pi-subagents` passed, and all 14 pi-subagents test files passed with 205 tests.
+- [x] `VITEST_MAX_WORKERS=4 npm run check` passed Biome, boundaries, all workspace typechecks, 230 test files, and 2,623 tests.
+- [x] `just pack subagents` passed and the 44-file dry-run tarball contains the new modules, README, manifest, source, and license.
+- [x] A real `pi -e ./packages/pi-subagents` pseudo-TTY smoke loaded the extension; enhanced-keyboard automation could not traverse the menu, so the accepted deterministic harness fallback covers successful multi-save, cancellation, reload messaging, stale sessions, and narrow widths.
+- [x] Independent review returned PASS after all correctness, lifecycle, settings, compatibility, UX, and evidence findings were resolved.
+- [x] Archive this plan under `docs/plans/archived/` after every task and completion check has evidence.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -220,7 +220,7 @@ A blocking fan-out is reserved for output that must be synthesized before the ro
 | `list_runs` | Optional `includeClosed` and `limit` (default 50, maximum 100) | Metadata-only retained-run summaries and unread counts |
 | `get_run` | Required `agentId` | Safe `cwd`, current-task/error summaries, thinking level, policy, history count, and unread count |
 | `list_models` | Optional `limit` (default 50, maximum 100) | Session-scoped models, or the already-loaded available snapshot |
-| `status` | No additional fields | Effective workflow, runtime counts/transport, completion delivery, consultation resources, and configured/runtime cwd policies with per-field sources |
+| `status` | No additional fields | Effective workflow, runtime counts/transport, detached limit values, completion delivery, consultation resources, and configured/runtime settings with per-field sources |
 | `diagnose` | No additional fields | Structured `pass`, `warning`, and `fail` checks; failed checks are report data rather than a tool error |
 
 The schema rejects fields that do not belong to the selected action. Explicit `project` or `both` scope fails before project-agent discovery unless Pi already trusts the project. Run inspection never returns history output, stored context, or mailbox content; unread counts come from a metadata-only snapshot and do not acknowledge messages. Paths beneath the Pi agent directory use `~`, project paths are workspace-relative, model objects are projected through an allow-list, and model-facing text is bounded to 50 KiB or 2,000 lines.
@@ -354,8 +354,10 @@ The default `subprocess` transport preserves compatibility: each turn starts a f
 Run `/subagents` in TUI mode to open the standard primary manager.
 It leads with the current delegation workflow, human-readable async completion behavior, consultation/delegation target policies, consultation-resource policy, parallel-worker limit, and active/retained counts.
 **Change delegation**, **Current agents**, and **Settings** cover the common workflows.
-Agent permissions, the **Maximum parallel workers** input, transport/runtime details, source, and settings path remain under **Advanced settings**.
-The maximum-worker input rejects invalid values without discarding the draft and applies a successful save immediately.
+Agent permissions, **Maximum parallel workers**, **Detached agent limits**, transport/runtime details, source, and settings path remain under **Advanced settings**.
+The parallel-worker input rejects invalid values without discarding the draft and applies a successful save immediately.
+The detached-limit screen edits retained capacity, active-turn concurrency, direct children, tree depth, and stored-record capacity.
+Detached-limit saves are durable immediately but apply to the runtime after `/reload` or the next Pi session.
 Escape returns from a nested screen to a newly refreshed manager, while Ctrl+C closes the full flow.
 Exact workflow/reload and project-agent safety confirmations remain extension-owned because they guard live agent and trust-boundary policy rather than ordinary navigation.
 
@@ -399,6 +401,13 @@ Editors and older extension versions do not participate in that lock, so avoid m
 `blocking.maxParallelTasks` defaults to `8` and accepts positive integers from `1` through `64`.
 It limits worker tasks in one blocking parallel call, while execution still starts at most four workers at once and treats an optional aggregator separately.
 `stateful.enabled` also defaults to `true`; its existing `false` value remains the blocking-only workflow.
+The detached defaults are `maxAgents: 16`, `maxActiveTurns: 4`, `maxChildrenPerAgent: 8`, `maxDepth: 3`, and `maxStoredAgents: 50`.
+`maxDepth` accepts zero or a positive safe integer, while the other four detached limits accept positive safe integers.
+Use `/subagents` → **Advanced settings** → **Detached agent limits** to edit them without replacing unknown JSON fields.
+The screen shows current-session and configured values separately because changes apply after `/reload`.
+It never reloads automatically, because reload can interrupt retained detached work.
+Lowering retained, depth, or stored capacity shows a projected recovery warning when current records would be omitted.
+Restored parents that already exceed a lowered `maxChildrenPerAgent` remain available, but they cannot gain another child until they fall below the configured limit.
 `cwdPolicy.consultation` defaults to `"anywhere"`, `cwdPolicy.delegation` defaults to `"trusted-targets"`, and `consult.resources` defaults to `"project-context"`.
 The Settings UI applies a saved change immediately to subsequent launches and refreshes the affected tool descriptions; manual edits take effect on session start or `/reload`.
 The UI explicitly states that target/trust settings are not filesystem sandboxing and directs trust changes to Pi `/trust`.
@@ -430,7 +439,12 @@ The action schemas are flat for provider compatibility and reject parameters tha
 }
 ```
 
-Use the **Current agents** action in `/subagents` to inspect the indented agent tree, lifecycle state, unread count, and available actions, or to confirm clearing retained agents. Active turns are FIFO-limited by `maxActiveTurns`; excess retained work remains in `starting` state until a slot is available. `maxAgents` separately bounds running, queued, and idle records. `parentId` creates a bounded child relationship; subtree interrupt and close operate child-first.
+Use the **Current agents** action in `/subagents` to inspect the indented agent tree, lifecycle state, unread count, and available actions, or to confirm clearing retained agents.
+Active turns are FIFO-limited by `maxActiveTurns`; excess retained work remains in `starting` state until a slot is available.
+`maxAgents` separately bounds running, queued, and idle records.
+`maxChildrenPerAgent` bounds direct children, while `maxDepth` counts nested levels below a depth-zero root.
+`maxStoredAgents` bounds sanitized records persisted per session and does not increase live runtime capacity.
+`parentId` creates a bounded child relationship; subtree interrupt and close operate child-first.
 
 ### Migrating from the previous seven-tool lifecycle surface
 
@@ -659,7 +673,12 @@ The runner explicitly reports policy continuity in result details:
 
 Treat project-local agent prompts like executable project configuration: only enable them in trusted repositories. Stateful project agents require Pi's project trust; interactive use also keeps confirmation enabled by default.
 
-Stateful records are stored as versioned mode-0600 JSON under `~/.pi/agent/pi-subagents-state/` (or the configured Pi agent directory). Records contain sanitized logical history, never process IDs or credentials. Corrupt or unsupported state is quarantined, restored agents are always inert `idle` records, and no prior side effect is automatically resumed. Retention and count limits are configurable. Downgrading is safe: older extension versions ignore this separate state directory; clear **Current agents** from `/subagents` before downgrade if the histories should be removed.
+Stateful records are stored as versioned mode-0600 JSON under `~/.pi/agent/pi-subagents-state/` (or the configured Pi agent directory).
+Records contain sanitized logical history, never process IDs or credentials.
+Corrupt or unsupported state is quarantined, restored agents are always inert `idle` records, and no prior side effect is automatically resumed.
+Count projection keeps complete ancestor chains together when stored or restored limits omit older trees.
+Retention and count limits are configurable.
+Downgrading is safe: older extension versions ignore this separate state directory; clear **Current agents** from `/subagents` before downgrade if the histories should be removed.
 
 ## 🗂️ Package layout
 
@@ -676,6 +695,8 @@ packages/pi-subagents/
 │   ├── stateful.ts               # Detached lifecycle registration and dispatch
 │   ├── stateful-guidance.ts      # Detached model-facing workflow guidance
 │   ├── stateful-lifecycle.ts     # Runtime disposal and spawn ownership guards
+│   ├── stateful-limit-ui.ts      # Detached capacity settings and recovery previews
+│   ├── stateful-limits.ts        # Shared detached defaults, labels, and validation
 │   ├── stateful-safety.ts        # Project-agent and shared-write safety checks
 │   ├── stateful-tool-params.ts   # Consolidated action schemas and validation
 │   └── *.ts                      # Package-local discovery, execution, rendering, and settings modules

--- a/packages/pi-subagents/src/agent-projection.ts
+++ b/packages/pi-subagents/src/agent-projection.ts
@@ -1,0 +1,53 @@
+import type { ManagedAgent } from "./registry.js";
+
+export interface AgentProjectionLimits {
+	maxAgents: number;
+	maxDepth?: number;
+}
+
+/**
+ * Select the newest restorable agent trees without orphaning child records.
+ *
+ * Complete ancestor chains are selected together, then returned in their original
+ * order so persistence and restore behavior stay deterministic.
+ */
+export function projectAgentRecords(
+	agents: readonly ManagedAgent[],
+	limits: AgentProjectionLimits,
+): ManagedAgent[] {
+	const byId = new Map(agents.map((agent) => [agent.id, agent]));
+	const selected = new Set<string>();
+	const maxDepth = limits.maxDepth ?? Number.MAX_SAFE_INTEGER;
+	const newestFirst = agents
+		.map((agent, index) => ({ agent, index }))
+		.sort(
+			(left, right) => right.agent.updatedAt - left.agent.updatedAt || right.index - left.index,
+		);
+
+	for (const { agent } of newestFirst) {
+		const chain = ancestorChain(agent, byId);
+		if (!chain || chain.length - 1 > maxDepth) continue;
+		const missing = chain.filter((candidate) => !selected.has(candidate.id));
+		if (selected.size + missing.length > limits.maxAgents) continue;
+		for (const candidate of missing) selected.add(candidate.id);
+	}
+
+	return agents.filter((agent) => selected.has(agent.id));
+}
+
+function ancestorChain(
+	agent: ManagedAgent,
+	byId: ReadonlyMap<string, ManagedAgent>,
+): ManagedAgent[] | undefined {
+	const chain: ManagedAgent[] = [];
+	const seen = new Set<string>();
+	let current: ManagedAgent | undefined = agent;
+	while (current) {
+		if (seen.has(current.id)) return undefined;
+		seen.add(current.id);
+		chain.unshift(current);
+		if (!current.parentId) return chain;
+		current = byId.get(current.parentId);
+	}
+	return undefined;
+}

--- a/packages/pi-subagents/src/config-ui.ts
+++ b/packages/pi-subagents/src/config-ui.ts
@@ -11,6 +11,7 @@ import {
 	blockingParallelLimitScreen,
 } from "./parallel-limit-ui.js";
 import type { ManagedAgent } from "./registry.js";
+import { safeTerminalLine as safeTerminalText } from "./safe-text.js";
 import {
 	type DelegationWorkflow,
 	hasOwn,
@@ -19,6 +20,7 @@ import {
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
 	inspectDelegationWorkflowSettings,
+	inspectStatefulLimitSettings,
 	readSubagentSettings,
 	sameToolSet,
 	uniqueToolNames,
@@ -29,6 +31,21 @@ import {
 	updateDelegationWorkflowSetting,
 } from "./settings.js";
 import { formatStatefulAgentLine, type StatefulSubagentRuntimeStatus } from "./stateful.js";
+import {
+	applyStatefulLimitSetting,
+	formatConfiguredDetachedLimitDivergence,
+	formatConfiguredDetachedLimits,
+	formatDetachedLimitSummary,
+	formatEmptyStatefulRuntime,
+	statefulLimitInputScreen,
+	statefulLimitListScreen,
+} from "./stateful-limit-ui.js";
+import {
+	isStatefulLimitField,
+	STATEFUL_LIMIT_DEFINITIONS,
+	type StatefulLimitField,
+} from "./stateful-limits.js";
+import { showWorkflowPreview, workflowLabel } from "./workflow-ui.js";
 
 const SUBCOMMANDS = [
 	{ value: "settings", label: "settings", description: "Configure subagent user settings" },
@@ -54,7 +71,7 @@ export interface SubagentSettingsRuntime {
 	clearAgents(): Promise<number>;
 }
 
-interface MenuOwner {
+export interface SubagentMenuOwner {
 	generation: number;
 	controller: AbortController;
 }
@@ -68,8 +85,8 @@ interface ToolDraft {
 	selected: Set<string>;
 }
 
-export function registerSubagentConfigCommand(pi: ExtensionAPI, runtime: SubagentSettingsRuntime) {
-	const owner: MenuOwner = { generation: 0, controller: new AbortController() };
+export function registerSubagentConfigLifecycle(pi: ExtensionAPI): SubagentMenuOwner {
+	const owner: SubagentMenuOwner = { generation: 0, controller: new AbortController() };
 	pi.on("session_start", () => {
 		owner.generation += 1;
 		owner.controller.abort(new DOMException("Subagent session replaced", "AbortError"));
@@ -79,13 +96,21 @@ export function registerSubagentConfigCommand(pi: ExtensionAPI, runtime: Subagen
 		owner.generation += 1;
 		owner.controller.abort(new DOMException("Subagent session shut down", "AbortError"));
 	});
+	return owner;
+}
+
+export function registerSubagentConfigCommand(
+	pi: ExtensionAPI,
+	runtime: SubagentSettingsRuntime,
+	owner = registerSubagentConfigLifecycle(pi),
+) {
 	registerSubagentPrimaryCommand(pi, runtime, owner);
 }
 
 function registerSubagentPrimaryCommand(
 	pi: ExtensionAPI,
 	runtime: SubagentSettingsRuntime,
-	owner: MenuOwner,
+	owner: SubagentMenuOwner,
 ) {
 	pi.registerCommand("subagents", {
 		description: "Manage current-session subagents and user settings",
@@ -123,7 +148,7 @@ async function showSubagentManager(
 	pi: ExtensionAPI,
 	ctx: ExtensionCommandContext,
 	runtime: SubagentSettingsRuntime,
-	owner: MenuOwner,
+	owner: SubagentMenuOwner,
 ) {
 	if (ctx.mode !== "tui") {
 		showSubagentStatus(ctx, runtime);
@@ -135,6 +160,7 @@ async function showSubagentManager(
 	if (!isCurrent()) return;
 	let availableAgents = discoverAgents(ctx.cwd, "user", readSubagentSettings() ?? {}).agents;
 	let toolDraft: ToolDraft | undefined;
+	let selectedStatefulLimit: StatefulLimitField = "maxAgents";
 	type Screen =
 		| "main"
 		| "workflow"
@@ -142,6 +168,8 @@ async function showSubagentManager(
 		| "settings"
 		| "advanced"
 		| "parallel-limit"
+		| "stateful-limits"
+		| "stateful-limit-input"
 		| "status"
 		| "help"
 		| "agent-picker"
@@ -150,6 +178,8 @@ async function showSubagentManager(
 		| "set-workflow"
 		| "clear-agents"
 		| "set-parallel-limit"
+		| "pick-stateful-limit"
+		| "set-stateful-limit"
 		| "set-completion"
 		| "set-consult-resources"
 		| "set-consultation-cwd"
@@ -249,7 +279,9 @@ async function showSubagentManager(
 				return {
 					kind: "actions",
 					title: "Current-session Subagents",
-					lines: agents.length ? agents.map(formatStatefulAgentLine) : [formatEmptyRuntime(status)],
+					lines: agents.length
+						? agents.map(formatStatefulAgentLine)
+						: [formatEmptyStatefulRuntime(status)],
 					items: [
 						...(agents.length > 0
 							? [
@@ -295,12 +327,20 @@ async function showSubagentManager(
 								? `Repair ${safeTerminalText(limit.path)} before editing this setting`
 								: undefined,
 						},
+						{
+							id: "stateful-limits",
+							label: "Detached agent limits",
+							description: formatDetachedLimitSummary(runtime.getRuntimeStatus()),
+							to: "stateful-limits",
+						},
 						{ id: "back", label: "Back", action: "back" },
 					],
 					hint: "back",
 				};
 			},
 			"parallel-limit": () => blockingParallelLimitScreen(runtime),
+			"stateful-limits": () => statefulLimitListScreen(runtime),
+			"stateful-limit-input": () => statefulLimitInputScreen(selectedStatefulLimit, runtime),
 			status: () => ({
 				kind: "detail",
 				title: "Subagent runtime details",
@@ -374,7 +414,7 @@ async function showSubagentManager(
 			}),
 		},
 		actions: {
-			"set-workflow": async ({ itemId }) => {
+			"set-workflow": async ({ itemId, signal }) => {
 				if (!isWorkflow(itemId)) return { kind: "rejected" };
 				const snapshot = inspectDelegationWorkflowSettings();
 				if (snapshot.error) return { kind: "rejected" };
@@ -387,9 +427,10 @@ async function showSubagentManager(
 				if (requiresReload && blockReloadWithRetainedAgents(ctx, runtime)) {
 					return { kind: "rejected" };
 				}
-				if (!(await showWorkflowPreview(ctx, active, itemId, requiresReload))) {
-					return { kind: "rejected" };
+				if (!(await showWorkflowPreview(ctx, active, itemId, requiresReload, signal))) {
+					return signal.aborted || !isCurrent() ? { kind: "close" } : { kind: "rejected" };
 				}
+				if (signal.aborted || !isCurrent()) return { kind: "close" };
 				if (requiresReload && blockReloadWithRetainedAgents(ctx, runtime)) {
 					return { kind: "rejected" };
 				}
@@ -416,15 +457,30 @@ async function showSubagentManager(
 				await ctx.reload();
 				return { kind: "close" };
 			},
-			"clear-agents": async () => {
+			"clear-agents": async ({ signal }) => {
 				const agents = runtime.listAgents();
 				if (agents.length === 0) return { kind: "stay" };
 				const confirmed = await ctx.ui.confirm(
 					"Clear current-session subagents?",
 					`Close and delete ${agents.length} retained agent${agents.length === 1 ? "" : "s"}?`,
+					{ signal },
 				);
+				if (signal.aborted || !isCurrent()) return { kind: "close" };
 				if (!confirmed) return { kind: "rejected" };
+				if (
+					runtime
+						.listAgents()
+						.map((agent) => agent.id)
+						.join("\0") !== agents.map((agent) => agent.id).join("\0")
+				) {
+					ctx.ui.notify(
+						"Detached agents changed while confirming; review the list again.",
+						"warning",
+					);
+					return { kind: "rejected" };
+				}
 				const cleared = await runtime.clearAgents();
+				if (signal.aborted || !isCurrent()) return { kind: "close" };
 				ctx.ui.notify(
 					`Cleared ${cleared} current-session subagent${cleared === 1 ? "" : "s"}.`,
 					"info",
@@ -433,6 +489,16 @@ async function showSubagentManager(
 			},
 			"set-parallel-limit": async ({ value }) =>
 				applyBlockingParallelLimitSetting(value, ctx, runtime),
+			"pick-stateful-limit": async ({ itemId }) => {
+				if (!isStatefulLimitField(itemId)) return { kind: "rejected" };
+				selectedStatefulLimit = itemId;
+				return { kind: "to", screen: "stateful-limit-input" };
+			},
+			"set-stateful-limit": async ({ value, signal }) =>
+				applyStatefulLimitSetting(selectedStatefulLimit, value, ctx, runtime, {
+					signal,
+					isCurrent,
+				}),
 			"set-completion": async ({ value }) => applyCompletionSetting(value, ctx, runtime),
 			"set-consult-resources": async ({ value }) =>
 				applyConsultResourceSetting(value, ctx, runtime),
@@ -516,7 +582,7 @@ async function showSubagentManager(
 async function showSubagentSettings(
 	ctx: ExtensionCommandContext,
 	runtime: SubagentSettingsRuntime,
-	owner: MenuOwner,
+	owner: SubagentMenuOwner,
 ) {
 	const snapshot = inspectConsultResourceSettings();
 	if (ctx.mode !== "tui") {
@@ -718,28 +784,6 @@ function blockReloadWithRetainedAgents(
 	return true;
 }
 
-async function showWorkflowPreview(
-	ctx: ExtensionCommandContext,
-	current: DelegationWorkflow,
-	next: DelegationWorkflow,
-	requiresReload: boolean,
-): Promise<boolean> {
-	const changes = workflowEffects(current, next);
-	return ctx.ui.confirm(
-		requiresReload ? "Save delegation change and reload?" : "Save delegation change?",
-		[
-			`Current: ${workflowLabel(current)}`,
-			`New: ${workflowLabel(next)}`,
-			"",
-			"Effect:",
-			...(changes.length > 0 ? changes : ["Keep the current registered tools"]).map(
-				(effect) => `- ${effect}`,
-			),
-			`- ${requiresReload ? "Reload the extension to apply this tool surface" : "No reload is needed because the active tools already match"}`,
-		].join("\n"),
-	);
-}
-
 function showSubagentStatus(ctx: ExtensionCommandContext, runtime: SubagentSettingsRuntime) {
 	if (ctx.mode !== "tui" && !ctx.hasUI) return;
 	const snapshot = inspectCompletionDeliverySettings();
@@ -763,6 +807,7 @@ function helpLines(runtime: SubagentSettingsRuntime): string[] {
 	const snapshot = inspectCompletionDeliverySettings();
 	const cwdPolicy = inspectCwdPolicySettings();
 	const parallelLimit = inspectBlockingParallelLimitSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
 	return [
 		"/subagents — choose delegation workflow, manage current agents, and configure agent tools",
 		"/subagents settings — configure target locations, trusted resources, and async completion",
@@ -776,6 +821,11 @@ function helpLines(runtime: SubagentSettingsRuntime): string[] {
 		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} (${cwdPolicy.delegation.source})`,
 		`Maximum parallel workers: ${runtime.getMaxParallelTasks()} per blocking call`,
 		`Configured parallel limit: ${parallelLimit.value} (${parallelLimit.source})`,
+		`Detached limits: ${formatDetachedLimitSummary(runtime.getRuntimeStatus())}`,
+		...(detachedLimits.values
+			? [`Configured detached limits: ${formatConfiguredDetachedLimits(detachedLimits.values)}`]
+			: ["Configured detached limits: unavailable; repair user settings"]),
+		"Detached limits apply after /reload; clear retained agents first if their work must not be interrupted.",
 		`User settings: ${safeTerminalText(snapshot.path)}`,
 	];
 }
@@ -788,6 +838,10 @@ function formatManagerSummary(
 	const current = currentWorkflow(runtime, status);
 	const cwdPolicy = inspectCwdPolicySettings();
 	const consult = inspectConsultResourceSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
+	const detachedDivergence = detachedLimits.values
+		? formatConfiguredDetachedLimitDivergence(status, detachedLimits.values)
+		: undefined;
 	return [
 		`Delegation: ${workflowLabel(current)}`,
 		`Completion: ${completionLabel(status.completionDelivery)}`,
@@ -795,15 +849,19 @@ function formatManagerSummary(
 		`Delegation target: ${delegationCwdLabel(runtime.getDelegationCwdPolicy())}`,
 		`Consult resources: ${consultResourceLabel(runtime.getConsultResourcePolicy())}`,
 		`Parallel workers: max ${runtime.getMaxParallelTasks()} per blocking call`,
+		`Detached limits: ${formatDetachedLimitSummary(status)}`,
 		`Configured consult target: ${consultationCwdLabel(cwdPolicy.consultation.value)} · ${cwdPolicy.consultation.source}`,
 		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} · ${cwdPolicy.delegation.source}`,
 		`Configured consult resources: ${consultResourceLabel(consult.value)} · ${consult.source}`,
 		`Settings: ${safeTerminalText(cwdPolicy.path)}`,
 		`Agents: ${status.activeAgents} active · ${status.retainedAgents} retained`,
+		...(detachedDivergence ? [detachedDivergence] : []),
 		...(configured.value !== current
 			? [`Configured after reload: ${workflowLabel(configured.value)}`]
 			: []),
-		...(configured.error ? ["Settings need repair; open Advanced settings for details."] : []),
+		...(configured.error || detachedLimits.error
+			? ["Settings need repair; open Advanced settings for details."]
+			: []),
 	].join("\n");
 }
 
@@ -816,6 +874,7 @@ function formatStatus(
 	const consult = inspectConsultResourceSettings();
 	const cwdPolicy = inspectCwdPolicySettings();
 	const parallelLimit = inspectBlockingParallelLimitSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
 	const current = runtime ? currentWorkflow(runtime, status) : configuredWorkflow.value;
 	return [
 		"Current session",
@@ -827,6 +886,7 @@ function formatStatus(
 		`  Delegation target: ${delegationCwdLabel(runtime?.getDelegationCwdPolicy() ?? cwdPolicy.delegation.value)}`,
 		`  Consultation resources: ${consultResourceLabel(runtime?.getConsultResourcePolicy() ?? consult.value)}`,
 		`  Maximum parallel workers: ${runtime?.getMaxParallelTasks() ?? parallelLimit.value} per blocking call`,
+		`  Detached limits: ${formatDetachedLimitSummary(status)}`,
 		`  Agents: ${status.activeAgents} active, ${status.retainedAgents} retained`,
 		"User settings",
 		`  Delegation source: ${configuredWorkflow.source}`,
@@ -835,6 +895,12 @@ function formatStatus(
 		`  Configured completion: ${completionLabel(snapshot.value)}`,
 		`  Configured parallel limit: ${parallelLimit.value}`,
 		`  Parallel limit source: ${parallelLimit.source}`,
+		...(detachedLimits.values
+			? STATEFUL_LIMIT_DEFINITIONS.map((definition) => {
+					const configured = detachedLimits.values?.[definition.field];
+					return `  Configured ${definition.label.toLowerCase()}: ${configured?.value} (${configured?.source})`;
+				})
+			: ["  Configured detached limits: unavailable"]),
 		`  Configured consultation target: ${consultationCwdLabel(cwdPolicy.consultation.value)}`,
 		`  Consultation target source: ${cwdPolicy.consultation.source}`,
 		`  Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)}`,
@@ -842,19 +908,17 @@ function formatStatus(
 		`  Configured consultation resources: ${consultResourceLabel(consult.value)}`,
 		`  Consultation resource source: ${consult.source}`,
 		`  Path: ${safeTerminalText(snapshot.path)}`,
-		configuredWorkflow.error || snapshot.error || cwdPolicy.error || parallelLimit.error
-			? `  Warning: ${safeTerminalText(configuredWorkflow.error ?? snapshot.error ?? cwdPolicy.error ?? parallelLimit.error ?? "invalid settings")}`
+		configuredWorkflow.error ||
+		snapshot.error ||
+		cwdPolicy.error ||
+		parallelLimit.error ||
+		detachedLimits.error
+			? `  Warning: ${safeTerminalText(configuredWorkflow.error ?? snapshot.error ?? cwdPolicy.error ?? parallelLimit.error ?? detachedLimits.error ?? "invalid settings")}`
 			: "  Warning: none",
 		configuredWorkflow.value !== current
 			? "Configured delegation differs from this session. Run /reload to apply it."
 			: "Manual file changes require /reload.",
 	].join("\n");
-}
-
-function formatEmptyRuntime(status: StatefulSubagentRuntimeStatus): string {
-	if (!status.enabled) return "Stateful subagents are disabled in user settings.";
-	if (!status.initialized) return "Stateful subagents are not initialized for this session.";
-	return "No current-session subagents.";
 }
 
 function currentWorkflow(
@@ -870,19 +934,6 @@ function currentWorkflow(
 
 function isWorkflow(value: string): value is Exclude<DelegationWorkflow, "disabled"> {
 	return value === "all" || value === "async-only" || value === "blocking-only";
-}
-
-function workflowLabel(value: DelegationWorkflow): string {
-	switch (value) {
-		case "all":
-			return "All delegation methods";
-		case "async-only":
-			return "Async only";
-		case "blocking-only":
-			return "Blocking only";
-		case "disabled":
-			return "Delegation disabled";
-	}
 }
 
 function completionLabel(value: CompletionDelivery): string {
@@ -915,33 +966,6 @@ function consultResourceLabel(value: ConsultResourcePolicy): string {
 		case "all":
 			return "All trusted resources";
 	}
-}
-
-function workflowEffects(current: DelegationWorkflow, next: DelegationWorkflow): string[] {
-	const blockingEnabled = (value: DelegationWorkflow) =>
-		value === "all" || value === "blocking-only";
-	const asyncEnabled = (value: DelegationWorkflow) => value === "all" || value === "async-only";
-	const effects: string[] = [];
-	if (blockingEnabled(current) !== blockingEnabled(next)) {
-		effects.push(
-			blockingEnabled(next)
-				? "Add blocking `subagent` and read-only `subagent_consult`"
-				: "Remove blocking `subagent` and read-only `subagent_consult`",
-		);
-	}
-	if (asyncEnabled(current) !== asyncEnabled(next)) {
-		effects.push(
-			asyncEnabled(next)
-				? "Add reusable async lifecycle tools"
-				: "Remove reusable async lifecycle tools",
-		);
-	}
-	return effects;
-}
-
-function safeTerminalText(value: string): string {
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: Escape untrusted terminal controls.
-	return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, "?");
 }
 
 function formatError(error: unknown): string {

--- a/packages/pi-subagents/src/inspect-render.ts
+++ b/packages/pi-subagents/src/inspect-render.ts
@@ -181,11 +181,15 @@ function renderStatus(
 	const status = recordValue(details.status);
 	const stateful = recordValue(status?.stateful);
 	if (!status || !stateful) return undefined;
+	const currentLimits = recordValue(status.statefulLimits) ?? recordValue(stateful.limits);
 	const lines = [
 		`${statusBadge(theme, "completed")} · runtime status`,
 		`${theme.fg("muted", "workflow: ")}${theme.fg("accent", safeLine(status.workflow, "unknown", 128))} · ${numberValue(stateful.activeAgents)} active · ${numberValue(stateful.retainedAgents)} retained`,
 		`${theme.fg("muted", "stateful: ")}${stateful.initialized === true ? "initialized" : "not initialized"} · resources: ${safeLine(status.consultResources, "unknown", 128)}`,
 	];
+	if (currentLimits) {
+		lines.push(`${theme.fg("muted", "limits: ")}${formatDetachedLimits(currentLimits)}`);
+	}
 	if (expanded) {
 		const delivery = stringValue(stateful.completionDelivery);
 		const transport = stringValue(stateful.transport);
@@ -202,8 +206,31 @@ function renderStatus(
 				),
 			);
 		}
+		const configured = recordValue(status.configuredStatefulLimits);
+		const sources = recordValue(status.configuredStatefulLimitSources);
+		if (configured) {
+			lines.push(theme.fg("dim", `configured: ${formatDetachedLimits(configured, sources)}`));
+		}
 	} else lines.push(expansionHint());
 	return lines.join("\n");
+}
+
+function formatDetachedLimits(
+	limits: Record<string, unknown>,
+	sources?: Record<string, unknown>,
+): string {
+	return [
+		["agents", "maxAgents"],
+		["active", "maxActiveTurns"],
+		["children", "maxChildrenPerAgent"],
+		["depth", "maxDepth"],
+		["stored", "maxStoredAgents"],
+	]
+		.map(([label, field]) => {
+			const source = stringValue(sources?.[field]);
+			return `${label}:${numberValue(limits[field])}${source ? ` (${safeLine(source, "", 64)})` : ""}`;
+		})
+		.join(" · ");
 }
 
 function renderDiagnose(details: Record<string, unknown>, expanded: boolean, theme: Theme): string {

--- a/packages/pi-subagents/src/inspect.ts
+++ b/packages/pi-subagents/src/inspect.ts
@@ -23,6 +23,7 @@ import {
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
 	inspectDelegationWorkflowSettings,
+	inspectStatefulLimitSettings,
 	inspectSubagentSettings,
 	resolveDelegationWorkflow,
 } from "./settings.js";
@@ -368,11 +369,25 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 	const cwdPolicy = inspectCwdPolicySettings();
 	const completion = inspectCompletionDeliverySettings();
 	const parallelLimit = inspectBlockingParallelLimitSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
+	const configuredDetachedLimits = detachedLimits.values
+		? Object.fromEntries(
+				Object.entries(detachedLimits.values).map(([field, snapshot]) => [field, snapshot.value]),
+			)
+		: undefined;
+	const configuredDetachedLimitSources = detachedLimits.values
+		? Object.fromEntries(
+				Object.entries(detachedLimits.values).map(([field, snapshot]) => [field, snapshot.source]),
+			)
+		: undefined;
 	return {
 		workflow,
 		configuredWorkflow: configured.value,
 		configuredWorkflowSource: configured.source,
 		stateful,
+		statefulLimits: stateful.limits,
+		configuredStatefulLimits: configuredDetachedLimits,
+		configuredStatefulLimitSources: configuredDetachedLimitSources,
 		configuredCompletionDelivery: completion.value,
 		configuredCompletionDeliverySource: completion.source,
 		maxParallelTasks: runtime.getMaxParallelTasks(),
@@ -393,13 +408,15 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 			resources.error ||
 			cwdPolicy.error ||
 			completion.error ||
-			parallelLimit.error
+			parallelLimit.error ||
+			detachedLimits.error
 				? boundedPrivateText(
 						configured.error ??
 							resources.error ??
 							cwdPolicy.error ??
 							completion.error ??
 							parallelLimit.error ??
+							detachedLimits.error ??
 							"",
 						2 * 1024,
 					)

--- a/packages/pi-subagents/src/persistence.ts
+++ b/packages/pi-subagents/src/persistence.ts
@@ -2,11 +2,14 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { projectAgentRecords } from "./agent-projection.js";
 import { isThinkingLevel } from "./agents.js";
 import { redactPrivateText } from "./context.js";
 import type { ManagedAgent } from "./registry.js";
+import { resolveStatefulLimits } from "./stateful-limits.js";
 
 const STATE_VERSION = 2;
+const DEFAULT_STATEFUL_LIMITS = resolveStatefulLimits();
 const MAX_STATE_BYTES = 1024 * 1024;
 
 interface StoredState {
@@ -35,7 +38,7 @@ export class AgentPersistence {
 		if (!Number.isFinite(retentionMs)) {
 			throw new Error("Subagent retentionDays is too large");
 		}
-		const maxStoredAgents = options.maxStoredAgents ?? 50;
+		const maxStoredAgents = options.maxStoredAgents ?? DEFAULT_STATEFUL_LIMITS.maxStoredAgents;
 		if (!Number.isSafeInteger(maxStoredAgents) || maxStoredAgents < 1) {
 			throw new Error("Subagent maxStoredAgents must be a positive safe integer");
 		}
@@ -54,10 +57,10 @@ export class AgentPersistence {
 			const parsed = JSON.parse(fs.readFileSync(this.filePath, "utf8")) as unknown;
 			if (!isStoredState(parsed)) throw new Error("unsupported or malformed state");
 			const cutoff = Date.now() - this.retentionMs;
-			return parsed.agents
-				.filter((agent) => agent.updatedAt >= cutoff && agent.state !== "closed")
-				.slice(-this.maxStoredAgents)
-				.map(sanitizeAgent);
+			return projectAgentRecords(
+				parsed.agents.filter((agent) => agent.updatedAt >= cutoff && agent.state !== "closed"),
+				{ maxAgents: this.maxStoredAgents },
+			).map(sanitizeAgent);
 		} catch {
 			this.quarantine();
 			return [];
@@ -69,7 +72,9 @@ export class AgentPersistence {
 		const eligible = agents.filter(
 			(agent) => agent.state !== "closed" && agent.updatedAt >= cutoff,
 		);
-		const records = selectAgentsForPersistence(eligible, this.maxStoredAgents).map(sanitizeAgent);
+		const records = projectAgentRecords(eligible, {
+			maxAgents: this.maxStoredAgents,
+		}).map(sanitizeAgent);
 		const state: StoredState = { version: STATE_VERSION, updatedAt: Date.now(), agents: records };
 		let content = `${JSON.stringify(state, null, "\t")}\n`;
 		while (Buffer.byteLength(content, "utf8") > MAX_STATE_BYTES && state.agents.length > 0) {
@@ -98,30 +103,6 @@ export class AgentPersistence {
 			// A concurrent process may already have moved or removed it.
 		}
 	}
-}
-
-function selectAgentsForPersistence(
-	agents: readonly ManagedAgent[],
-	maxAgents: number,
-): ManagedAgent[] {
-	const byId = new Map(agents.map((agent) => [agent.id, agent]));
-	const selected = new Map<string, ManagedAgent>();
-	const newestFirst = [...agents].sort((left, right) => right.updatedAt - left.updatedAt);
-	for (const agent of newestFirst) {
-		const chain: ManagedAgent[] = [];
-		let current: ManagedAgent | undefined = agent;
-		const seen = new Set<string>();
-		while (current && !seen.has(current.id)) {
-			seen.add(current.id);
-			chain.unshift(current);
-			current = current.parentId ? byId.get(current.parentId) : undefined;
-		}
-		if (current || (agent.parentId && chain[0].parentId)) continue;
-		const missing = chain.filter((candidate) => !selected.has(candidate.id));
-		if (selected.size + missing.length > maxAgents) continue;
-		for (const candidate of missing) selected.set(candidate.id, candidate);
-	}
-	return agents.filter((agent) => selected.has(agent.id));
 }
 
 function sanitizeAgent(agent: ManagedAgent): ManagedAgent {

--- a/packages/pi-subagents/src/registry.ts
+++ b/packages/pi-subagents/src/registry.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
+import { projectAgentRecords } from "./agent-projection.js";
 import type { SubagentThinkingLevel } from "./agents.js";
 import type { TargetPolicyAudit } from "./cwd-policy.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
+import { resolveStatefulLimits } from "./stateful-limits.js";
 import { type AgentTurnRunner, normalizeTransport, type SubagentTransport } from "./transport.js";
+
+const DEFAULT_STATEFUL_LIMITS = resolveStatefulLimits();
 
 export type AgentLifecycleState =
 	| "starting"
@@ -163,12 +167,21 @@ export class AgentRegistry {
 		private readonly options: AgentRegistryOptions = {},
 	) {
 		this.transport = normalizeTransport(transport);
-		this.maxAgents = positiveInteger(options.maxAgents ?? 16, "maxAgents");
-		this.maxActiveTurns = positiveInteger(options.maxActiveTurns ?? 4, "maxActiveTurns");
+		this.maxAgents = positiveInteger(
+			options.maxAgents ?? DEFAULT_STATEFUL_LIMITS.maxAgents,
+			"maxAgents",
+		);
+		this.maxActiveTurns = positiveInteger(
+			options.maxActiveTurns ?? DEFAULT_STATEFUL_LIMITS.maxActiveTurns,
+			"maxActiveTurns",
+		);
 		this.maxHistoryTurns = positiveInteger(options.maxHistoryTurns ?? 20, "maxHistoryTurns");
-		this.maxDepth = nonNegativeInteger(options.maxDepth ?? 3, "maxDepth");
+		this.maxDepth = nonNegativeInteger(
+			options.maxDepth ?? DEFAULT_STATEFUL_LIMITS.maxDepth,
+			"maxDepth",
+		);
 		this.maxChildrenPerAgent = positiveInteger(
-			options.maxChildrenPerAgent ?? 8,
+			options.maxChildrenPerAgent ?? DEFAULT_STATEFUL_LIMITS.maxChildrenPerAgent,
 			"maxChildrenPerAgent",
 		);
 		this.maxMailboxMessages = positiveInteger(
@@ -193,10 +206,10 @@ export class AgentRegistry {
 
 	restore(records: readonly ManagedAgent[]): void {
 		const candidates = new Map(
-			records
-				.slice(-this.maxAgents)
-				.filter((record) => record.id && record.state !== "closed")
-				.map((record) => [record.id, record]),
+			projectAgentRecords(
+				records.filter((record) => record.id && record.state !== "closed"),
+				{ maxAgents: this.maxAgents, maxDepth: this.maxDepth },
+			).map((record) => [record.id, record]),
 		);
 		for (const record of candidates.values()) {
 			if (record.parentId && !candidates.has(record.parentId)) continue;

--- a/packages/pi-subagents/src/settings.ts
+++ b/packages/pi-subagents/src/settings.ts
@@ -22,6 +22,14 @@ import {
 	MAX_CONFIGURABLE_PARALLEL_TASKS,
 	MAX_SUBAGENT_TIMEOUT_MS,
 } from "./limits.js";
+import {
+	isValidStatefulLimit,
+	resolveStatefulLimits,
+	STATEFUL_LIMIT_FIELDS,
+	type StatefulLimitField,
+	type StatefulLimits,
+	statefulLimitDefinition,
+} from "./stateful-limits.js";
 
 export function hasOwn(obj: object, key: PropertyKey): boolean {
 	return Object.hasOwn(obj, key);
@@ -41,10 +49,6 @@ function isPositiveNumber(value: unknown): value is number {
 
 function isPositiveInteger(value: unknown): value is number {
 	return isPositiveNumber(value) && Number.isSafeInteger(value);
-}
-
-function isNonNegativeInteger(value: unknown): value is number {
-	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
 export function normalizeAgentSettings(value: unknown): SubagentAgentConfig | undefined {
@@ -133,23 +137,17 @@ export function normalizeSubagentSettings(value: unknown): SubagentSettings | un
 			}
 			runtime.completionDelivery = value.stateful.completionDelivery;
 		}
-		for (const key of [
-			"maxAgents",
-			"maxActiveTurns",
-			"maxChildrenPerAgent",
-			"maxMailboxMessages",
-			"maxMailboxMessageBytes",
-			"idleTtlMs",
-			"maxStoredAgents",
-		] as const) {
+		for (const key of STATEFUL_LIMIT_FIELDS) {
+			if (hasOwn(value.stateful, key)) {
+				if (!isValidStatefulLimit(key, value.stateful[key])) return undefined;
+				runtime[key] = value.stateful[key];
+			}
+		}
+		for (const key of ["maxMailboxMessages", "maxMailboxMessageBytes", "idleTtlMs"] as const) {
 			if (hasOwn(value.stateful, key)) {
 				if (!isPositiveInteger(value.stateful[key])) return undefined;
 				runtime[key] = value.stateful[key];
 			}
-		}
-		if (hasOwn(value.stateful, "maxDepth")) {
-			if (!isNonNegativeInteger(value.stateful.maxDepth)) return undefined;
-			runtime.maxDepth = value.stateful.maxDepth;
 		}
 		if (hasOwn(value.stateful, "retentionDays")) {
 			if (!isPositiveNumber(value.stateful.retentionDays)) return undefined;
@@ -300,6 +298,18 @@ export interface BlockingParallelLimitSettingsSnapshot {
 	path: string;
 	value: number;
 	source: "default" | "user settings";
+	error?: string;
+}
+
+export interface StatefulLimitFieldSnapshot {
+	value: number;
+	source: "default" | "user settings";
+}
+
+export interface StatefulLimitSettingsSnapshot {
+	path: string;
+	writePath: string;
+	values?: Record<StatefulLimitField, StatefulLimitFieldSnapshot>;
 	error?: string;
 }
 
@@ -505,6 +515,29 @@ export function inspectBlockingParallelLimitSettings(): BlockingParallelLimitSet
 	};
 }
 
+export function inspectStatefulLimitSettings(): StatefulLimitSettingsSnapshot {
+	const inspected = inspectSubagentSettingsDocument();
+	const writePath = subagentSettingsFilePath();
+	if (inspected.error) {
+		return { path: inspected.path, writePath, error: inspected.error };
+	}
+	const resolved = resolveStatefulLimits(inspected.settings?.stateful);
+	const rawStateful = isPlainObject(inspected.raw?.stateful) ? inspected.raw.stateful : undefined;
+	return {
+		path: inspected.path,
+		writePath,
+		values: Object.fromEntries(
+			STATEFUL_LIMIT_FIELDS.map((field) => [
+				field,
+				{
+					value: resolved[field],
+					source: rawStateful && hasOwn(rawStateful, field) ? "user settings" : "default",
+				},
+			]),
+		) as unknown as Record<StatefulLimitField, StatefulLimitFieldSnapshot>,
+	};
+}
+
 export function updateDelegationWorkflowSetting(
 	value: Exclude<DelegationWorkflow, "disabled">,
 ): void {
@@ -577,6 +610,38 @@ export function updateBlockingMaxParallelTasksSetting(value: number): void {
 					...(blocking ?? {}),
 					maxParallelTasks: value,
 				},
+			},
+			update.replaceCanonical,
+		);
+	});
+}
+
+export function updateStatefulLimitSetting(
+	field: StatefulLimitField,
+	value: number,
+	expected?: StatefulLimits,
+): void {
+	if (!isValidStatefulLimit(field, value)) {
+		throw new Error(
+			`${field} must be a safe integer greater than or equal to ${statefulLimitDefinition(field).minimum}`,
+		);
+	}
+	withSettingsMutationLock(() => {
+		const update = readSettingsObjectForUpdate();
+		const raw = update.document;
+		const stateful = raw.stateful;
+		if (stateful !== undefined && !isPlainObject(stateful)) {
+			throw new Error(`Cannot update invalid ${SETTINGS_FILE} stateful settings`);
+		}
+		const normalized = normalizeSubagentSettings(raw);
+		if (!normalized) throw new Error(`Cannot update invalid ${SETTINGS_FILE}`);
+		if (expected && !sameStatefulLimits(resolveStatefulLimits(normalized.stateful), expected)) {
+			throw new Error("Detached limit settings changed; reopen settings and retry");
+		}
+		writeSettingsObjectUnlocked(
+			{
+				...raw,
+				stateful: { ...(stateful ?? {}), [field]: value },
 			},
 			update.replaceCanonical,
 		);
@@ -726,6 +791,10 @@ function withSettingsMutationLock<T>(mutate: () => T): T {
 	} finally {
 		release();
 	}
+}
+
+function sameStatefulLimits(left: StatefulLimits, right: StatefulLimits): boolean {
+	return STATEFUL_LIMIT_FIELDS.every((field) => left[field] === right[field]);
 }
 
 function pathEntryExists(filePath: string): boolean {

--- a/packages/pi-subagents/src/stateful-limit-ui.ts
+++ b/packages/pi-subagents/src/stateful-limit-ui.ts
@@ -1,0 +1,246 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { projectAgentRecords } from "./agent-projection.js";
+import type { ManagedAgent } from "./registry.js";
+import { safeTerminalLine as safeTerminalText } from "./safe-text.js";
+import { inspectStatefulLimitSettings, updateStatefulLimitSetting } from "./settings.js";
+import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
+import {
+	isValidStatefulLimit,
+	resolveStatefulLimits,
+	STATEFUL_LIMIT_DEFINITIONS,
+	type StatefulLimitField,
+	type StatefulLimits,
+	statefulLimitDefinition,
+} from "./stateful-limits.js";
+
+export interface StatefulLimitRuntime {
+	getRuntimeStatus(): StatefulSubagentRuntimeStatus;
+	listAgents(includeClosed?: boolean): ManagedAgent[];
+}
+
+export interface StatefulLimitApplyOptions {
+	signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+export function statefulLimitListScreen(runtime: StatefulLimitRuntime) {
+	const inspected = inspectStatefulLimitSettings();
+	const current = runtime.getRuntimeStatus().limits;
+	return {
+		kind: "actions" as const,
+		title: "Detached Agent Limits",
+		lines: [
+			"These limits apply after /reload or the next Pi session.",
+			"Reloading can interrupt retained detached work.",
+			...(inspected.error
+				? [
+						`Settings cannot be edited: ${safeTerminalText(inspected.error)}`,
+						`Repair ${safeTerminalText(inspected.path)} and retry.`,
+					]
+				: []),
+		],
+		items: [
+			...(inspected.values
+				? STATEFUL_LIMIT_DEFINITIONS.map((definition) => {
+						const configured = inspected.values?.[definition.field];
+						return {
+							id: definition.field,
+							label: definition.label,
+							description: `Current ${current[definition.field]} · configured ${configured?.value ?? "unavailable"} (${configured?.source ?? "unknown"})`,
+							action: "pick-stateful-limit" as const,
+						};
+					})
+				: []),
+			{ id: "back", label: "Back", action: "back" as const },
+		],
+		hint: "back" as const,
+	};
+}
+
+export function statefulLimitInputScreen(field: StatefulLimitField, runtime: StatefulLimitRuntime) {
+	const definition = statefulLimitDefinition(field);
+	const inspected = inspectStatefulLimitSettings();
+	const configured = inspected.values?.[field];
+	return {
+		kind: "input" as const,
+		title: definition.label,
+		lines: [
+			definition.description,
+			`Current session: ${runtime.getRuntimeStatus().limits[field]}`,
+			`Configured after reload: ${configured?.value ?? "unavailable"} (${configured?.source ?? "unknown"})`,
+			`Allowed: whole numbers ${definition.minimum === 0 ? "0 or greater" : "1 or greater"}`,
+			`Read from: ${safeTerminalText(inspected.path)}`,
+			...(inspected.writePath !== inspected.path
+				? [`Saves to: ${safeTerminalText(inspected.writePath)}`]
+				: []),
+		],
+		placeholder: "Enter a whole number",
+		action: "set-stateful-limit" as const,
+		hint: "back" as const,
+	};
+}
+
+export async function applyStatefulLimitSetting(
+	field: StatefulLimitField,
+	value: string | undefined,
+	ctx: ExtensionCommandContext,
+	runtime: StatefulLimitRuntime,
+	options: StatefulLimitApplyOptions,
+) {
+	const next = parseStatefulLimit(field, value);
+	if (next === undefined) {
+		notifyValidationError(field, ctx);
+		return { kind: "rejected" as const };
+	}
+	const inspected = inspectStatefulLimitSettings();
+	if (inspected.error || !inspected.values) {
+		if (options.isCurrent() && !options.signal.aborted) {
+			ctx.ui.notify(
+				`Subagent settings cannot be edited: ${safeTerminalText(inspected.error ?? "settings are unavailable")}`,
+				"error",
+			);
+		}
+		return { kind: "rejected" as const };
+	}
+	const expected = configuredValues(inspected.values);
+	if (next === expected[field]) return { kind: "back" as const };
+
+	const beforeAgents = runtime.listAgents();
+	const affectedBefore = projectedRemovedAgentIds(beforeAgents, expected, {
+		...expected,
+		[field]: next,
+	});
+	if (affectedBefore.length > 0) {
+		const confirmed = await ctx.ui.confirm(
+			`Lower ${statefulLimitDefinition(field).label}?`,
+			[
+				`This configured value would omit ${affectedBefore.length} currently retained agent record${affectedBefore.length === 1 ? "" : "s"} from projected recovery after reload.`,
+				"No agent is closed now, and this menu will not reload Pi.",
+				"A later state rewrite can make omitted records unavailable for recovery.",
+			].join("\n\n"),
+			{ signal: options.signal },
+		);
+		if (options.signal.aborted || !options.isCurrent()) return { kind: "close" as const };
+		if (!confirmed) return { kind: "rejected" as const };
+		const affectedAfter = projectedRemovedAgentIds(runtime.listAgents(), expected, {
+			...expected,
+			[field]: next,
+		});
+		if (!sameIds(affectedBefore, affectedAfter)) {
+			ctx.ui.notify("Detached agents changed while confirming; review the limit again.", "warning");
+			return { kind: "rejected" as const };
+		}
+	}
+
+	if (options.signal.aborted || !options.isCurrent()) return { kind: "close" as const };
+	try {
+		updateStatefulLimitSetting(field, next, expected);
+	} catch (error) {
+		if (options.isCurrent() && !options.signal.aborted) {
+			ctx.ui.notify(
+				`Detached limit was not saved; the previous setting is unchanged: ${formatError(error)}`,
+				"error",
+			);
+		}
+		return { kind: "rejected" as const };
+	}
+	if (options.signal.aborted || !options.isCurrent()) return { kind: "close" as const };
+	ctx.ui.notify(
+		`Saved ${statefulLimitDefinition(field).label.toLowerCase()}: ${next}. Applies after /reload; clear retained agents before reloading if their work must not be interrupted.`,
+		"info",
+	);
+	return { kind: "back" as const };
+}
+
+export function formatDetachedLimitSummary(status: StatefulSubagentRuntimeStatus): string {
+	return [
+		`${status.limits.maxAgents} retained`,
+		`${status.limits.maxActiveTurns} active turns`,
+		`${status.limits.maxChildrenPerAgent} children`,
+		`depth ${status.limits.maxDepth}`,
+		`${status.limits.maxStoredAgents} stored`,
+	].join(" · ");
+}
+
+export function formatConfiguredDetachedLimitDivergence(
+	status: StatefulSubagentRuntimeStatus,
+	values: NonNullable<ReturnType<typeof inspectStatefulLimitSettings>["values"]>,
+): string | undefined {
+	const changed = STATEFUL_LIMIT_DEFINITIONS.flatMap((definition) => {
+		const configured = values[definition.field].value;
+		return configured === status.limits[definition.field]
+			? []
+			: [`${definition.label.toLowerCase()} ${configured}`];
+	});
+	return changed.length > 0 ? `Configured after reload: ${changed.join(" · ")}` : undefined;
+}
+
+export function formatConfiguredDetachedLimits(
+	values: NonNullable<ReturnType<typeof inspectStatefulLimitSettings>["values"]>,
+): string {
+	return STATEFUL_LIMIT_DEFINITIONS.map((definition) => {
+		const snapshot = values[definition.field];
+		return `${definition.label.toLowerCase()} ${snapshot.value} (${snapshot.source})`;
+	}).join(" · ");
+}
+
+export function formatEmptyStatefulRuntime(status: StatefulSubagentRuntimeStatus): string {
+	if (!status.enabled) return "Stateful subagents are disabled in user settings.";
+	if (!status.initialized) return "Stateful subagents are not initialized for this session.";
+	return "No current-session subagents.";
+}
+
+function parseStatefulLimit(
+	field: StatefulLimitField,
+	value: string | undefined,
+): number | undefined {
+	const normalized = value?.trim() ?? "";
+	if (!/^\d+$/u.test(normalized)) return undefined;
+	const parsed = Number(normalized);
+	return isValidStatefulLimit(field, parsed) ? parsed : undefined;
+}
+
+function notifyValidationError(field: StatefulLimitField, ctx: ExtensionCommandContext): void {
+	const definition = statefulLimitDefinition(field);
+	ctx.ui.notify(
+		`${definition.label} must be a safe whole number ${definition.minimum === 0 ? "0 or greater" : "1 or greater"}.`,
+		"warning",
+	);
+}
+
+function configuredValues(
+	values: NonNullable<ReturnType<typeof inspectStatefulLimitSettings>["values"]>,
+): StatefulLimits {
+	return resolveStatefulLimits(
+		Object.fromEntries(Object.entries(values).map(([field, snapshot]) => [field, snapshot.value])),
+	);
+}
+
+function projectedRemovedAgentIds(
+	agents: readonly ManagedAgent[],
+	current: StatefulLimits,
+	next: StatefulLimits,
+): string[] {
+	const restorable = agents.filter(
+		(agent) => agent.state !== "closed" && agent.workspaceMode !== "worktree",
+	);
+	const before = projectForReload(restorable, current);
+	const afterIds = new Set(projectForReload(restorable, next).map((agent) => agent.id));
+	return before.filter((agent) => !afterIds.has(agent.id)).map((agent) => agent.id);
+}
+
+function projectForReload(agents: readonly ManagedAgent[], limits: StatefulLimits): ManagedAgent[] {
+	const stored = projectAgentRecords(agents, { maxAgents: limits.maxStoredAgents });
+	return projectAgentRecords(stored, {
+		maxAgents: limits.maxAgents,
+		maxDepth: limits.maxDepth,
+	});
+}
+
+function sameIds(left: readonly string[], right: readonly string[]): boolean {
+	return left.length === right.length && left.every((id, index) => id === right[index]);
+}
+
+function formatError(error: unknown): string {
+	return safeTerminalText(error instanceof Error ? error.message : String(error));
+}

--- a/packages/pi-subagents/src/stateful-limits.ts
+++ b/packages/pi-subagents/src/stateful-limits.ts
@@ -1,0 +1,96 @@
+import type { SubagentRuntimeSettings } from "./agents.js";
+
+export const STATEFUL_LIMIT_FIELDS = [
+	"maxAgents",
+	"maxActiveTurns",
+	"maxChildrenPerAgent",
+	"maxDepth",
+	"maxStoredAgents",
+] as const;
+
+export type StatefulLimitField = (typeof STATEFUL_LIMIT_FIELDS)[number];
+
+export interface StatefulLimits {
+	maxAgents: number;
+	maxActiveTurns: number;
+	maxChildrenPerAgent: number;
+	maxDepth: number;
+	maxStoredAgents: number;
+}
+
+export interface StatefulLimitDefinition {
+	field: StatefulLimitField;
+	label: string;
+	description: string;
+	defaultValue: number;
+	minimum: number;
+}
+
+export const STATEFUL_LIMIT_DEFINITIONS: readonly StatefulLimitDefinition[] = [
+	{
+		field: "maxAgents",
+		label: "Retained agents",
+		description: "Running, queued, and reusable idle detached agents",
+		defaultValue: 16,
+		minimum: 1,
+	},
+	{
+		field: "maxActiveTurns",
+		label: "Active turns",
+		description: "Detached agent turns that may run at the same time",
+		defaultValue: 4,
+		minimum: 1,
+	},
+	{
+		field: "maxChildrenPerAgent",
+		label: "Children per agent",
+		description: "Direct child agents retained beneath one parent",
+		defaultValue: 8,
+		minimum: 1,
+	},
+	{
+		field: "maxDepth",
+		label: "Agent tree depth",
+		description: "Nested child levels below a root agent",
+		defaultValue: 3,
+		minimum: 0,
+	},
+	{
+		field: "maxStoredAgents",
+		label: "Stored agents",
+		description: "Detached agent records kept per session on disk",
+		defaultValue: 50,
+		minimum: 1,
+	},
+];
+
+const definitionsByField = new Map(
+	STATEFUL_LIMIT_DEFINITIONS.map((definition) => [definition.field, definition]),
+);
+
+export function statefulLimitDefinition(field: StatefulLimitField): StatefulLimitDefinition {
+	const definition = definitionsByField.get(field);
+	if (!definition) throw new Error(`Unknown stateful limit: ${field}`);
+	return definition;
+}
+
+export function isStatefulLimitField(value: string): value is StatefulLimitField {
+	return (STATEFUL_LIMIT_FIELDS as readonly string[]).includes(value);
+}
+
+export function isValidStatefulLimit(field: StatefulLimitField, value: unknown): value is number {
+	return (
+		typeof value === "number" &&
+		Number.isSafeInteger(value) &&
+		value >= statefulLimitDefinition(field).minimum
+	);
+}
+
+export function resolveStatefulLimits(settings?: SubagentRuntimeSettings): StatefulLimits {
+	return Object.fromEntries(
+		STATEFUL_LIMIT_DEFINITIONS.map((definition) => [
+			definition.field,
+			settings?.[definition.field] ?? definition.defaultValue,
+		]),
+	) as unknown as StatefulLimits;
+}

--- a/packages/pi-subagents/src/stateful.ts
+++ b/packages/pi-subagents/src/stateful.ts
@@ -39,6 +39,7 @@ import {
 import { DEFAULT_DELEGATION_CWD_POLICY, readSubagentSettings } from "./settings.js";
 import { createSpawnPromptGuidelines } from "./stateful-guidance.js";
 import { assertCurrentSpawn, disposeStatefulRuntime } from "./stateful-lifecycle.js";
+import { resolveStatefulLimits, type StatefulLimits } from "./stateful-limits.js";
 import { createStatefulToolRenderer } from "./stateful-render.js";
 import {
 	assertFollowUpWriteAllowed,
@@ -92,6 +93,7 @@ export interface StatefulSubagentRuntimeStatus {
 	initialized: boolean;
 	transport: "subprocess" | "in-process";
 	completionDelivery: CompletionDelivery;
+	limits: StatefulLimits;
 	activeAgents: number;
 	retainedAgents: number;
 }
@@ -124,6 +126,7 @@ export function registerStatefulSubagents(
 	const enabled = settings.enabled !== false;
 	const transportKind = resolveStatefulTransportKind(settings.transport);
 	let completionDelivery = resolveCompletionDelivery(settings.completionDelivery);
+	let runtimeLimits = resolveStatefulLimits(settings);
 	let agentCatalog = "";
 	let completionBroker: CompletionDeliveryBroker | undefined;
 	let refreshSpawnToolRegistration: (() => void) | undefined;
@@ -138,6 +141,8 @@ export function registerStatefulSubagents(
 	const parentRuntime: ParentRuntimeSnapshot = { model: undefined, thinkingLevel: "off" };
 	const getCurrentSettings = () =>
 		dependencies.getSettings ? dependencies.getSettings() : readSubagentSettings();
+	const getCurrentStatefulSettings = () =>
+		dependencies.getSettings ? (dependencies.getSettings()?.stateful ?? {}) : settings;
 
 	const clearAgents = async (): Promise<number> => {
 		const generation = runtimeGeneration;
@@ -181,6 +186,7 @@ export function registerStatefulSubagents(
 				initialized: registry !== undefined,
 				transport: transportKind,
 				completionDelivery,
+				limits: { ...runtimeLimits },
 				...counts,
 			};
 		},
@@ -229,13 +235,15 @@ export function registerStatefulSubagents(
 			}
 			parentRuntime.model = ctx.model;
 			parentRuntime.thinkingLevel = normalizeRuntimeThinkingLevel(pi.getThinkingLevel());
+			const sessionSettings = getCurrentStatefulSettings();
+			const nextLimits = resolveStatefulLimits(sessionSettings);
 			const owner =
 				ctx.sessionManager.getSessionId?.() ??
 				ctx.sessionManager.getSessionFile?.() ??
 				`ephemeral:${ctx.cwd}`;
 			const sessionPersistence = new AgentPersistence(owner, {
-				retentionDays: settings.retentionDays,
-				maxStoredAgents: settings.maxStoredAgents,
+				retentionDays: sessionSettings.retentionDays,
+				maxStoredAgents: nextLimits.maxStoredAgents,
 			});
 			const sessionBroker = new CompletionDeliveryBroker(pi, ctx, completionDelivery, {
 				onDeliveryError: (error) => {
@@ -259,13 +267,13 @@ export function registerStatefulSubagents(
 						})
 					: new SubprocessTransport({ getSettings: getCurrentSettings });
 			const nextRegistry = new AgentRegistry(transport, {
-				maxAgents: settings.maxAgents,
-				maxActiveTurns: settings.maxActiveTurns,
-				maxDepth: settings.maxDepth,
-				maxChildrenPerAgent: settings.maxChildrenPerAgent,
-				maxMailboxMessages: settings.maxMailboxMessages,
-				maxMailboxMessageBytes: settings.maxMailboxMessageBytes,
-				idleTtlMs: settings.idleTtlMs,
+				maxAgents: nextLimits.maxAgents,
+				maxActiveTurns: nextLimits.maxActiveTurns,
+				maxDepth: nextLimits.maxDepth,
+				maxChildrenPerAgent: nextLimits.maxChildrenPerAgent,
+				maxMailboxMessages: sessionSettings.maxMailboxMessages,
+				maxMailboxMessageBytes: sessionSettings.maxMailboxMessageBytes,
+				idleTtlMs: sessionSettings.idleTtlMs,
 				onChange: async (agents) => {
 					await sessionPersistence.save(agents);
 					if (generation !== runtimeGeneration) return;
@@ -317,7 +325,12 @@ export function registerStatefulSubagents(
 			registry = nextRegistry;
 			persistence = sessionPersistence;
 			completionBroker = sessionBroker;
-			const sweepEveryMs = Math.max(1_000, Math.min(settings.idleTtlMs ?? 60 * 60 * 1000, 60_000));
+			runtimeLimits = nextLimits;
+			refreshSpawnToolRegistration?.();
+			const sweepEveryMs = Math.max(
+				1_000,
+				Math.min(sessionSettings.idleTtlMs ?? 60 * 60 * 1000, 60_000),
+			);
 			sweepTimer = setInterval(() => {
 				void nextRegistry.sweepExpired().catch((error: unknown) => {
 					if (!ctx.hasUI || generation !== runtimeGeneration) return;
@@ -371,7 +384,7 @@ export function registerStatefulSubagents(
 	});
 
 	const baseSpawnDescription = () =>
-		`Start an addressable background subagent with an optional thinking level chosen for the task difficulty, return immediately with an agentId, and receive its completion asynchronously. Working-directory target policy: ${dependencies.getSettings?.()?.cwdPolicy?.delegation ?? DEFAULT_DELEGATION_CWD_POLICY}. This controls launch targets and protected project resources, not filesystem access or sandboxing.`;
+		`Start an addressable background subagent with an optional thinking level chosen for the task difficulty, return immediately with an agentId, and receive its completion asynchronously. Detached capacity: ${runtimeLimits.maxAgents} retained agents, ${runtimeLimits.maxActiveTurns} active turns, ${runtimeLimits.maxChildrenPerAgent} direct children per agent, and depth ${runtimeLimits.maxDepth}. Working-directory target policy: ${dependencies.getSettings?.()?.cwdPolicy?.delegation ?? DEFAULT_DELEGATION_CWD_POLICY}. This controls launch targets and protected project resources, not filesystem access or sandboxing.`;
 	const spawnTool = defineTool({
 		name: "subagent_spawn",
 		label: "Spawn Subagent",

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -25,7 +25,7 @@ import {
 	formatAgentCatalog,
 	type SubagentSettings,
 } from "./agents.js";
-import { registerSubagentConfigCommand } from "./config-ui.js";
+import { registerSubagentConfigCommand, registerSubagentConfigLifecycle } from "./config-ui.js";
 import { registerSubagentConsult } from "./consult.js";
 import { executeSubagent } from "./execution.js";
 import { registerSubagentInspect } from "./inspect.js";
@@ -45,6 +45,7 @@ import {
 import { registerStatefulSubagents } from "./stateful.js";
 
 export default function (pi: ExtensionAPI) {
+	const configOwner = registerSubagentConfigLifecycle(pi);
 	const settings = readSubagentSettings();
 	let currentSettings: SubagentSettings | undefined = settings;
 	let currentCatalog = "";
@@ -102,57 +103,61 @@ export default function (pi: ExtensionAPI) {
 			getSettings: () => currentSettings,
 		});
 	}
-	registerSubagentConfigCommand(pi, {
-		...statefulRuntime,
-		getBlockingEnabled,
-		getMaxParallelTasks,
-		getConsultResourcePolicy,
-		getConsultationCwdPolicy,
-		getDelegationCwdPolicy,
-		setMaxParallelTasks(value: number) {
-			const previousSettings = currentSettings;
-			currentSettings = {
-				...(currentSettings ?? {}),
-				blocking: { ...(currentSettings?.blocking ?? {}), maxParallelTasks: value },
-			};
-			try {
-				refreshBlockingCatalog(currentCatalog);
-			} catch (applyError) {
-				currentSettings = previousSettings;
+	registerSubagentConfigCommand(
+		pi,
+		{
+			...statefulRuntime,
+			getBlockingEnabled,
+			getMaxParallelTasks,
+			getConsultResourcePolicy,
+			getConsultationCwdPolicy,
+			getDelegationCwdPolicy,
+			setMaxParallelTasks(value: number) {
+				const previousSettings = currentSettings;
+				currentSettings = {
+					...(currentSettings ?? {}),
+					blocking: { ...(currentSettings?.blocking ?? {}), maxParallelTasks: value },
+				};
 				try {
 					refreshBlockingCatalog(currentCatalog);
-				} catch (rollbackError) {
-					throw new AggregateError(
-						[applyError, rollbackError],
-						"Failed to apply and roll back the parallel-worker limit",
-					);
+				} catch (applyError) {
+					currentSettings = previousSettings;
+					try {
+						refreshBlockingCatalog(currentCatalog);
+					} catch (rollbackError) {
+						throw new AggregateError(
+							[applyError, rollbackError],
+							"Failed to apply and roll back the parallel-worker limit",
+						);
+					}
+					throw applyError;
 				}
-				throw applyError;
-			}
+			},
+			setConsultResourcePolicy(value: ConsultResourcePolicy) {
+				currentSettings = {
+					...(currentSettings ?? {}),
+					consult: { ...(currentSettings?.consult ?? {}), resources: value },
+				};
+				refreshConsultCatalog(currentCatalog);
+			},
+			setConsultationCwdPolicy(value: ConsultationCwdPolicy) {
+				currentSettings = {
+					...(currentSettings ?? {}),
+					cwdPolicy: { ...(currentSettings?.cwdPolicy ?? {}), consultation: value },
+				};
+				refreshConsultCatalog(currentCatalog);
+			},
+			setDelegationCwdPolicy(value: DelegationCwdPolicy) {
+				currentSettings = {
+					...(currentSettings ?? {}),
+					cwdPolicy: { ...(currentSettings?.cwdPolicy ?? {}), delegation: value },
+				};
+				refreshBlockingCatalog(currentCatalog);
+				statefulRuntime.refreshSettingsGuidance();
+			},
 		},
-		setConsultResourcePolicy(value: ConsultResourcePolicy) {
-			currentSettings = {
-				...(currentSettings ?? {}),
-				consult: { ...(currentSettings?.consult ?? {}), resources: value },
-			};
-			refreshConsultCatalog(currentCatalog);
-		},
-		setConsultationCwdPolicy(value: ConsultationCwdPolicy) {
-			currentSettings = {
-				...(currentSettings ?? {}),
-				cwdPolicy: { ...(currentSettings?.cwdPolicy ?? {}), consultation: value },
-			};
-			refreshConsultCatalog(currentCatalog);
-		},
-		setDelegationCwdPolicy(value: DelegationCwdPolicy) {
-			currentSettings = {
-				...(currentSettings ?? {}),
-				cwdPolicy: { ...(currentSettings?.cwdPolicy ?? {}), delegation: value },
-			};
-			refreshBlockingCatalog(currentCatalog);
-			statefulRuntime.refreshSettingsGuidance();
-		},
-	});
+		configOwner,
+	);
 }
 
 function registerBlockingSubagent(
@@ -232,6 +237,7 @@ export {
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
 	inspectDelegationWorkflowSettings,
+	inspectStatefulLimitSettings,
 	inspectSubagentSettings,
 	normalizeAgentSettings,
 	normalizeSubagentSettings,
@@ -248,4 +254,5 @@ export {
 	updateConsultResourceSetting,
 	updateCwdPolicySetting,
 	updateDelegationWorkflowSetting,
+	updateStatefulLimitSetting,
 } from "./settings.js";

--- a/packages/pi-subagents/src/workflow-ui.ts
+++ b/packages/pi-subagents/src/workflow-ui.ts
@@ -1,0 +1,61 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { DelegationWorkflow } from "./settings.js";
+
+export async function showWorkflowPreview(
+	ctx: ExtensionCommandContext,
+	current: DelegationWorkflow,
+	next: DelegationWorkflow,
+	requiresReload: boolean,
+	signal: AbortSignal,
+): Promise<boolean> {
+	const changes = workflowEffects(current, next);
+	return ctx.ui.confirm(
+		requiresReload ? "Save delegation change and reload?" : "Save delegation change?",
+		[
+			`Current: ${workflowLabel(current)}`,
+			`New: ${workflowLabel(next)}`,
+			"",
+			"Effect:",
+			...(changes.length > 0 ? changes : ["Keep the current registered tools"]).map(
+				(effect) => `- ${effect}`,
+			),
+			`- ${requiresReload ? "Reload the extension to apply this tool surface" : "No reload is needed because the active tools already match"}`,
+		].join("\n"),
+		{ signal },
+	);
+}
+
+export function workflowLabel(value: DelegationWorkflow): string {
+	switch (value) {
+		case "all":
+			return "All delegation methods";
+		case "async-only":
+			return "Async only";
+		case "blocking-only":
+			return "Blocking only";
+		case "disabled":
+			return "Delegation disabled";
+	}
+}
+
+function workflowEffects(current: DelegationWorkflow, next: DelegationWorkflow): string[] {
+	const blockingEnabled = (value: DelegationWorkflow) =>
+		value === "all" || value === "blocking-only";
+	const asyncEnabled = (value: DelegationWorkflow) => value === "all" || value === "async-only";
+	const effects: string[] = [];
+	if (blockingEnabled(current) !== blockingEnabled(next)) {
+		effects.push(
+			blockingEnabled(next)
+				? "Add blocking `subagent` and read-only `subagent_consult`"
+				: "Remove blocking `subagent` and read-only `subagent_consult`",
+		);
+	}
+	if (asyncEnabled(current) !== asyncEnabled(next)) {
+		effects.push(
+			asyncEnabled(next)
+				? "Add reusable async lifecycle tools"
+				: "Remove reusable async lifecycle tools",
+		);
+	}
+	return effects;
+}

--- a/packages/pi-subagents/test/in-process-transport.test.ts
+++ b/packages/pi-subagents/test/in-process-transport.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../src/in-process-transport.js";
 import type { ManagedAgent } from "../src/registry.js";
 import { registerStatefulSubagents } from "../src/stateful.js";
+import { resolveStatefulLimits } from "../src/stateful-limits.js";
 import { type IsolatedWorkspace, WorkspaceManager } from "../src/workspace.js";
 
 function managedAgent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
@@ -624,6 +625,7 @@ test("registered detached spawn auto-resumes without exposing a wait tool", asyn
 			initialized: true,
 			transport: "in-process",
 			completionDelivery: "auto-resume",
+			limits: resolveStatefulLimits(),
 			activeAgents: 1,
 			retainedAgents: 1,
 		});
@@ -643,6 +645,7 @@ test("registered detached spawn auto-resumes without exposing a wait tool", asyn
 			initialized: true,
 			transport: "in-process",
 			completionDelivery: "auto-resume",
+			limits: resolveStatefulLimits(),
 			activeAgents: 0,
 			retainedAgents: 1,
 		});

--- a/packages/pi-subagents/test/inspect.test.ts
+++ b/packages/pi-subagents/test/inspect.test.ts
@@ -6,6 +6,7 @@ import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerSubagentInspect } from "../src/inspect.js";
 import type { AgentRunInspectionDetail, AgentRunInspectionSummary } from "../src/registry.js";
+import { resolveStatefulLimits } from "../src/stateful-limits.js";
 
 function runtime(
 	options: {
@@ -26,6 +27,7 @@ function runtime(
 			initialized: true,
 			transport: "subprocess" as const,
 			completionDelivery: "next-turn" as const,
+			limits: resolveStatefulLimits(),
 			activeAgents: 1,
 			retainedAgents: 2,
 		}),
@@ -262,6 +264,15 @@ test("subagent_inspect uses scoped model snapshots and structured diagnostics wi
 	assert.equal(statusDetails.maxParallelTasks, 8);
 	assert.equal(statusDetails.configuredMaxParallelTasks, 8);
 	assert.equal(statusDetails.configuredMaxParallelTasksSource, "default");
+	assert.deepEqual(statusDetails.statefulLimits, resolveStatefulLimits());
+	assert.deepEqual(statusDetails.configuredStatefulLimits, resolveStatefulLimits());
+	assert.deepEqual(statusDetails.configuredStatefulLimitSources, {
+		maxAgents: "default",
+		maxActiveTurns: "default",
+		maxChildrenPerAgent: "default",
+		maxDepth: "default",
+		maxStoredAgents: "default",
+	});
 	assert.doesNotMatch(JSON.stringify(status), /trust\.json/);
 
 	const diagnosed = await execute(tool, { action: "diagnose" }, ctx);

--- a/packages/pi-subagents/test/orchestration.test.ts
+++ b/packages/pi-subagents/test/orchestration.test.ts
@@ -18,6 +18,7 @@ import {
 	resolveSpawnContextMode,
 	resolveStatefulTransportKind,
 } from "../src/stateful.js";
+import { resolveStatefulLimits } from "../src/stateful-limits.js";
 import {
 	resolveStatefulSubprocessThinkingLevel,
 	SubprocessTransport,
@@ -135,6 +136,7 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			initialized: false,
 			transport: "subprocess",
 			completionDelivery: "next-turn",
+			limits: resolveStatefulLimits(),
 			activeAgents: 0,
 			retainedAgents: 0,
 		});
@@ -164,6 +166,7 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			initialized: true,
 			transport: "subprocess",
 			completionDelivery: "next-turn",
+			limits: resolveStatefulLimits(),
 			activeAgents: 0,
 			retainedAgents: 0,
 		});
@@ -534,6 +537,7 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			initialized: false,
 			transport: "subprocess",
 			completionDelivery: "next-turn",
+			limits: resolveStatefulLimits(),
 			activeAgents: 0,
 			retainedAgents: 0,
 		});
@@ -564,6 +568,7 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			initialized: false,
 			transport: "subprocess",
 			completionDelivery: "next-turn",
+			limits: resolveStatefulLimits(),
 			activeAgents: 0,
 			retainedAgents: 0,
 		});

--- a/packages/pi-subagents/test/registry.test.ts
+++ b/packages/pi-subagents/test/registry.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "vitest";
+import { projectAgentRecords } from "../src/agent-projection.js";
 import { AgentPersistence } from "../src/persistence.js";
 import { AgentRegistry, type ManagedAgent } from "../src/registry.js";
 import { buildDetachedCompletionMessage } from "../src/stateful.js";
@@ -645,6 +646,34 @@ test("AgentRegistry keeps lifecycle usable when persistence callbacks fail", asy
 	});
 	const agent = await registry.spawn({ agent: "scout", task: "done", cwd: process.cwd() });
 	assert.equal((await registry.wait(agent.id, 100)).agent.state, "completed");
+});
+
+test("agent record projection preserves ancestry with deterministic count and depth limits", () => {
+	const root = record({ id: "root", rootId: "root", updatedAt: 1 });
+	const child = record({
+		id: "child",
+		rootId: "root",
+		parentId: "root",
+		depth: 1,
+		updatedAt: 5,
+	});
+	const other = record({ id: "other", rootId: "other", updatedAt: 4 });
+	const cycleA = record({ id: "cycle-a", parentId: "cycle-b", updatedAt: 8 });
+	const cycleB = record({ id: "cycle-b", parentId: "cycle-a", updatedAt: 7 });
+	const records = [child, root, other, cycleA, cycleB];
+
+	assert.deepEqual(
+		projectAgentRecords(records, { maxAgents: 2 }).map((agent) => agent.id),
+		["child", "root"],
+	);
+	assert.deepEqual(
+		projectAgentRecords(records, { maxAgents: 1 }).map((agent) => agent.id),
+		["other"],
+	);
+	assert.deepEqual(
+		projectAgentRecords(records, { maxAgents: 2, maxDepth: 0 }).map((agent) => agent.id),
+		["root", "other"],
+	);
 });
 
 test("AgentRegistry restores valid records inertly and rejects cyclic hierarchy", () => {

--- a/packages/pi-subagents/test/settings.test.ts
+++ b/packages/pi-subagents/test/settings.test.ts
@@ -8,13 +8,16 @@ import {
 	inspectBlockingParallelLimitSettings,
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
+	inspectStatefulLimitSettings,
 	inspectSubagentSettings,
 	normalizeSubagentSettings,
 	readSubagentSettings,
 	updateBlockingMaxParallelTasksSetting,
 	updateConsultResourceSetting,
 	updateCwdPolicySetting,
+	updateStatefulLimitSetting,
 } from "../src/settings.js";
+import { resolveStatefulLimits } from "../src/stateful-limits.js";
 
 function withAgentDir(run: (directory: string) => void): void {
 	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-settings-"));
@@ -82,6 +85,102 @@ test("blocking parallel limit normalizes, inspects, and updates safely", () => {
 		writeFileSync(defaultSnapshot.path, "{ malformed");
 		assert.throws(() => updateBlockingMaxParallelTasksSetting(4), /malformed/i);
 		assert.equal(readFileSync(defaultSnapshot.path, "utf8"), "{ malformed");
+	});
+});
+
+test("detached limits normalize, inspect, and update with per-field sources", () => {
+	withAgentDir((directory) => {
+		const defaults = resolveStatefulLimits();
+		assert.deepEqual(
+			normalizeSubagentSettings({
+				stateful: {
+					maxAgents: 3,
+					maxActiveTurns: 2,
+					maxChildrenPerAgent: 4,
+					maxDepth: 0,
+					maxStoredAgents: 7,
+				},
+			}),
+			{
+				stateful: {
+					maxAgents: 3,
+					maxActiveTurns: 2,
+					maxChildrenPerAgent: 4,
+					maxDepth: 0,
+					maxStoredAgents: 7,
+				},
+			},
+		);
+		for (const invalid of [
+			{ maxAgents: 0 },
+			{ maxActiveTurns: 1.5 },
+			{ maxChildrenPerAgent: -1 },
+			{ maxDepth: -1 },
+			{ maxStoredAgents: Number.MAX_SAFE_INTEGER + 1 },
+		]) {
+			assert.equal(normalizeSubagentSettings({ stateful: invalid }), undefined);
+		}
+
+		const missing = inspectStatefulLimitSettings();
+		assert.equal(missing.path, path.join(directory, "pi-subagents.json"));
+		assert.equal(missing.writePath, missing.path);
+		assert.deepEqual(
+			Object.fromEntries(
+				Object.entries(missing.values ?? {}).map(([field, snapshot]) => [field, snapshot.value]),
+			),
+			defaults,
+		);
+		assert.ok(Object.values(missing.values ?? {}).every((value) => value.source === "default"));
+		assert.throws(() => readFileSync(missing.path, "utf8"), /ENOENT/);
+
+		writeFileSync(
+			missing.path,
+			JSON.stringify({ future: true, stateful: { futureStateful: "keep", maxAgents: 6 } }),
+		);
+		const before = inspectStatefulLimitSettings();
+		assert.equal(before.values?.maxAgents.value, 6);
+		assert.equal(before.values?.maxAgents.source, "user settings");
+		assert.equal(before.values?.maxDepth.source, "default");
+		updateStatefulLimitSetting("maxDepth", 2, {
+			...defaults,
+			maxAgents: 6,
+		});
+		assert.deepEqual(JSON.parse(readFileSync(missing.path, "utf8")), {
+			future: true,
+			stateful: { futureStateful: "keep", maxAgents: 6, maxDepth: 2 },
+		});
+		assert.throws(
+			() => updateStatefulLimitSetting("maxActiveTurns", 3, defaults),
+			/changed.*reopen/i,
+		);
+		assert.throws(() => updateStatefulLimitSetting("maxDepth", -1), /greater than or equal to 0/i);
+
+		writeFileSync(missing.path, "{ malformed");
+		const invalid = inspectStatefulLimitSettings();
+		assert.equal(invalid.values, undefined);
+		assert.match(invalid.error ?? "", /malformed/i);
+		assert.throws(() => updateStatefulLimitSetting("maxAgents", 4), /malformed/i);
+		assert.equal(readFileSync(missing.path, "utf8"), "{ malformed");
+	});
+});
+
+test("detached limit updates seed the canonical file from legacy settings", () => {
+	withAgentDir((directory) => {
+		const legacyPath = path.join(directory, "pi-subagents-config.json");
+		const canonicalPath = path.join(directory, "pi-subagents.json");
+		const legacy = { future: true, stateful: { maxAgents: 5, futureStateful: "keep" } };
+		writeFileSync(legacyPath, JSON.stringify(legacy));
+
+		const inspected = inspectStatefulLimitSettings();
+		assert.equal(inspected.path, legacyPath);
+		assert.equal(inspected.writePath, canonicalPath);
+		updateStatefulLimitSetting("maxActiveTurns", 2);
+
+		assert.deepEqual(JSON.parse(readFileSync(canonicalPath, "utf8")), {
+			...legacy,
+			stateful: { ...legacy.stateful, maxActiveTurns: 2 },
+		});
+		assert.deepEqual(JSON.parse(readFileSync(legacyPath, "utf8")), legacy);
 	});
 });
 

--- a/packages/pi-subagents/test/subagents.test.ts
+++ b/packages/pi-subagents/test/subagents.test.ts
@@ -37,6 +37,8 @@ import { registerSubagentConfigCommand, type SubagentSettingsRuntime } from "../
 import { hasUsableAggregator } from "../src/params.js";
 import type { ManagedAgent } from "../src/registry.js";
 import { consumeSubagentSettingsNotice } from "../src/settings.js";
+import { applyStatefulLimitSetting } from "../src/stateful-limit-ui.js";
+import { resolveStatefulLimits } from "../src/stateful-limits.js";
 import subagents, {
 	buildPiArgs,
 	formatTokens,
@@ -54,6 +56,7 @@ import subagents, {
 	updateBlockingMaxParallelTasksSetting,
 	updateCompletionDeliverySetting,
 	updateDelegationWorkflowSetting,
+	updateStatefulLimitSetting,
 } from "../src/subagents.js";
 
 initTheme("dark", false);
@@ -428,6 +431,7 @@ test("agent tool drafts preserve settings across searchable save, discard, and E
 				initialized: true,
 				transport: "subprocess",
 				completionDelivery: "next-turn",
+				limits: resolveStatefulLimits(),
 				activeAgents: 0,
 				retainedAgents: 0,
 			}),
@@ -706,6 +710,66 @@ test("configured workflow differences reload from the active tool surface", asyn
 	}
 });
 
+test("config lifecycle aborts pending confirmations before stateful session handlers", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-config-lifecycle-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const command = mock.commands.get("subagents");
+		assert.ok(command);
+		const exercise = async (event: "session_start" | "session_shutdown") => {
+			let call = 0;
+			let observedSignal: AbortSignal | undefined;
+			let markStarted: (() => void) | undefined;
+			const started = new Promise<void>((resolve) => {
+				markStarted = resolve;
+			});
+			const context = createMockContext({
+				mode: "tui",
+				hasUI: true,
+				confirm: async (_title: string, _message: string, options?: { signal?: AbortSignal }) => {
+					observedSignal = options?.signal;
+					markStarted?.();
+					return new Promise<boolean>((resolve) => {
+						if (observedSignal?.aborted) resolve(false);
+						else observedSignal?.addEventListener("abort", () => resolve(false), { once: true });
+					});
+				},
+				custom: async (factory: unknown) => {
+					const harness = createCustomSelectorHarness(factory, 60);
+					if (call === 0) {
+						harness.handleInput("tui.select.confirm");
+					} else {
+						harness.handleInput("tui.select.down");
+						harness.handleInput("tui.select.confirm");
+						await harness.waitForPending();
+					}
+					call++;
+					return harness.result;
+				},
+			});
+			const commandRun = command.handler("", context.ctx);
+			await started;
+			assert.equal(observedSignal?.aborted, false);
+			const handlers = mock.events.get(event) ?? [];
+			assert.ok(handlers.length > 1);
+			await handlers[0]?.({}, context.ctx);
+			assert.equal(observedSignal?.aborted, true);
+			await commandRun;
+			assert.equal(existsSync(path.join(directory, "pi-subagents.json")), false);
+		};
+
+		await exercise("session_start");
+		await exercise("session_shutdown");
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
 test("delegation workflow blocks reload while detached agents are retained", async () => {
 	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-workflow-retained-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -732,6 +796,7 @@ test("delegation workflow blocks reload while detached agents are retained", asy
 				initialized: true,
 				transport: "subprocess",
 				completionDelivery: "next-turn",
+				limits: resolveStatefulLimits(),
 				activeAgents: 1,
 				retainedAgents: 2,
 			}),
@@ -848,6 +913,7 @@ test("current-session manager excludes already closed agent records", async () =
 				initialized: true,
 				transport: "subprocess",
 				completionDelivery: "next-turn",
+				limits: resolveStatefulLimits(),
 				activeAgents: 0,
 				retainedAgents: 0,
 			}),
@@ -1137,6 +1203,335 @@ test("advanced settings validates, saves, and immediately applies the blocking p
 		assert.match(invalidContext.notifications.at(-1)?.message ?? "", /whole number from 1 to 64/i);
 		assert.equal(readFileSync(settingsPath, "utf8"), savedDocument);
 	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("detached-limit UI saves several startup limits without mutating the current runtime", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-detached-limit-ui-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({ future: true, stateful: { futureStateful: "keep" } }),
+		);
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const command = mock.commands.get("subagents");
+		assert.ok(command);
+		let call = 0;
+		const frames: string[] = [];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 64);
+				const frame = stripVTControlCharacters(harness.render().join("\n"));
+				frames.push(frame);
+				if (call === 0 || call === 1) {
+					for (let index = 0; index < 3; index++) harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+				} else if (call === 2) {
+					assert.match(frame, /Detached Agent Limits/);
+					assert.match(frame, /Retained agents.*Current 16.*configured 16/s);
+					for (const label of [
+						"Active turns",
+						"Children per agent",
+						"Agent tree depth",
+						"Stored agents",
+					]) {
+						assert.match(frame, new RegExp(label));
+					}
+					harness.handleInput("tui.select.confirm");
+				} else if (call === 3) {
+					assert.match(frame, /Current session: 16/);
+					harness.setFocused(true);
+					harness.handleInput("20");
+					harness.handleInput("tui.input.submit");
+					await harness.waitForPending();
+				} else if (call === 4) {
+					assert.match(frame, /Retained agents.*Current 16.*configured 20/s);
+					harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+				} else if (call === 5) {
+					assert.match(frame, /Current session: 4/);
+					harness.setFocused(true);
+					harness.handleInput("6");
+					harness.handleInput("tui.input.submit");
+					await harness.waitForPending();
+				} else if (call === 6) {
+					assert.match(frame, /Retained agents.*Current 16.*configured 20/s);
+					assert.match(frame, /Active turns.*Current 4.*configured 6/s);
+					harness.handleInput("tui.select.cancel");
+				} else if (call === 7) {
+					assert.match(frame, /Advanced Subagent Settings/);
+					harness.handleInput("tui.select.cancel");
+				} else {
+					assert.match(frame, /Configured after reload: retained agents 20.*active turns 6/s);
+					harness.handleInput("\u0003");
+				}
+				call++;
+				return harness.result;
+			},
+		});
+		await command.handler("", context.ctx);
+		assert.equal(call, 9, frames.join("\n---\n"));
+		assert.ok(
+			frames.flatMap((frame) => frame.split("\n")).every((line) => visibleWidth(line) <= 64),
+		);
+		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+			future: true,
+			stateful: { futureStateful: "keep", maxAgents: 20, maxActiveTurns: 6 },
+		});
+		assert.match(context.notifications.at(-1)?.message ?? "", /applies after \/reload/i);
+
+		await command.handler("status", context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /detached limits: 16 retained/i);
+		assert.match(context.notifications.at(-1)?.message ?? "", /configured retained agents: 20/i);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("detached-limit lowering cancellation and stale previews leave settings unchanged", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-detached-preview-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const controller = new AbortController();
+		const agents: ManagedAgent[] = [
+			{
+				id: "older",
+				agent: "scout",
+				rootId: "older",
+				depth: 0,
+				children: [],
+				state: "idle",
+				createdAt: 1,
+				updatedAt: 1,
+				cwd: process.cwd(),
+				history: [],
+				mailbox: [],
+			},
+			{
+				id: "newer",
+				agent: "reviewer",
+				rootId: "newer",
+				depth: 0,
+				children: [],
+				state: "idle",
+				createdAt: 2,
+				updatedAt: 2,
+				cwd: process.cwd(),
+				history: [],
+				mailbox: [],
+			},
+		];
+		const runtime = {
+			getRuntimeStatus: () => ({
+				enabled: true,
+				initialized: true,
+				transport: "subprocess" as const,
+				completionDelivery: "next-turn" as const,
+				limits: resolveStatefulLimits(),
+				activeAgents: 0,
+				retainedAgents: agents.length,
+			}),
+			listAgents: () => [...agents],
+		};
+		const invalid = createMockContext({ mode: "tui", hasUI: true });
+		assert.deepEqual(
+			await applyStatefulLimitSetting("maxDepth", "-1", invalid.ctx, runtime, {
+				signal: controller.signal,
+				isCurrent: () => true,
+			}),
+			{ kind: "rejected" },
+		);
+		assert.match(invalid.notifications.at(-1)?.message ?? "", /whole number.*0 or greater/i);
+		assert.equal(existsSync(path.join(directory, "pi-subagents.json")), false);
+
+		let preview = "";
+		const cancelled = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			confirm: async (_title: string, message: string) => {
+				preview = message;
+				return false;
+			},
+		});
+		assert.deepEqual(
+			await applyStatefulLimitSetting("maxAgents", "1", cancelled.ctx, runtime, {
+				signal: controller.signal,
+				isCurrent: () => true,
+			}),
+			{ kind: "rejected" },
+		);
+		assert.match(preview, /omit 1 currently retained agent record/i);
+		assert.equal(existsSync(path.join(directory, "pi-subagents.json")), false);
+
+		const stale = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			confirm: async () => {
+				agents.push({ ...agents[0], id: "changed", rootId: "changed", updatedAt: 3 });
+				return true;
+			},
+		});
+		assert.deepEqual(
+			await applyStatefulLimitSetting("maxAgents", "1", stale.ctx, runtime, {
+				signal: controller.signal,
+				isCurrent: () => true,
+			}),
+			{ kind: "rejected" },
+		);
+		assert.match(stale.notifications.at(-1)?.message ?? "", /agents changed.*review/i);
+		assert.equal(existsSync(path.join(directory, "pi-subagents.json")), false);
+
+		const replacedController = new AbortController();
+		let current = true;
+		const replaced = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			confirm: async () => {
+				current = false;
+				replacedController.abort();
+				return true;
+			},
+		});
+		assert.deepEqual(
+			await applyStatefulLimitSetting("maxAgents", "1", replaced.ctx, runtime, {
+				signal: replacedController.signal,
+				isCurrent: () => current,
+			}),
+			{ kind: "close" },
+		);
+		assert.equal(existsSync(path.join(directory, "pi-subagents.json")), false);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("detached-limit previews depth and stored-record reductions", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-detached-preview-fields-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const root: ManagedAgent = {
+			id: "root",
+			agent: "scout",
+			rootId: "root",
+			depth: 0,
+			children: ["child"],
+			state: "idle",
+			createdAt: 1,
+			updatedAt: 1,
+			cwd: process.cwd(),
+			history: [],
+			mailbox: [],
+		};
+		const child: ManagedAgent = {
+			...root,
+			id: "child",
+			rootId: "root",
+			parentId: "root",
+			depth: 1,
+			children: [],
+			updatedAt: 3,
+		};
+		const other: ManagedAgent = {
+			...root,
+			id: "other",
+			rootId: "other",
+			children: [],
+			updatedAt: 2,
+		};
+		for (const [field, value, agents] of [
+			["maxDepth", "0", [root, child]],
+			["maxStoredAgents", "1", [root, other]],
+		] as const) {
+			let preview = "";
+			const context = createMockContext({
+				mode: "tui",
+				hasUI: true,
+				confirm: async (_title: string, message: string) => {
+					preview = message;
+					return false;
+				},
+			});
+			const runtime = {
+				getRuntimeStatus: () => ({
+					enabled: true,
+					initialized: true,
+					transport: "subprocess" as const,
+					completionDelivery: "next-turn" as const,
+					limits: resolveStatefulLimits(),
+					activeAgents: 0,
+					retainedAgents: agents.length,
+				}),
+				listAgents: () => [...agents],
+			};
+			assert.deepEqual(
+				await applyStatefulLimitSetting(field, value, context.ctx, runtime, {
+					signal: new AbortController().signal,
+					isCurrent: () => true,
+				}),
+				{ kind: "rejected" },
+			);
+			assert.match(preview, /omit 1 currently retained agent record/i);
+			assert.equal(existsSync(path.join(directory, "pi-subagents.json")), false);
+		}
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("detached-limit save failure preserves the previous configured value", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-detached-save-failure-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	const settingsPath = path.join(directory, "pi-subagents.json");
+	writeFileSync(settingsPath, "{}\n");
+	const originalRenameSync = fs.renameSync;
+	try {
+		fs.renameSync = (() => {
+			throw new Error("rename unavailable");
+		}) as typeof fs.renameSync;
+		syncBuiltinESMExports();
+		const context = createMockContext({ mode: "tui", hasUI: true });
+		const runtime = {
+			getRuntimeStatus: () => ({
+				enabled: true,
+				initialized: true,
+				transport: "subprocess" as const,
+				completionDelivery: "next-turn" as const,
+				limits: resolveStatefulLimits(),
+				activeAgents: 0,
+				retainedAgents: 0,
+			}),
+			listAgents: () => [],
+		};
+		assert.deepEqual(
+			await applyStatefulLimitSetting("maxAgents", "20", context.ctx, runtime, {
+				signal: new AbortController().signal,
+				isCurrent: () => true,
+			}),
+			{ kind: "rejected" },
+		);
+		assert.equal(readFileSync(settingsPath, "utf8"), "{}\n");
+		assert.match(context.notifications.at(-1)?.message ?? "", /not saved.*unchanged/i);
+	} finally {
+		fs.renameSync = originalRenameSync;
+		syncBuiltinESMExports();
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(directory, { recursive: true, force: true });
@@ -1719,6 +2114,61 @@ test("formatAgentCatalog advertises scope variants deterministically and within 
 	}
 });
 
+test("session start refreshes detached limits and retains the last valid snapshot after read errors", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-session-limits-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({
+				stateful: {
+					maxAgents: 3,
+					maxActiveTurns: 2,
+					maxChildrenPerAgent: 4,
+					maxDepth: 1,
+					maxStoredAgents: 6,
+				},
+			}),
+		);
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const context = createMockContext();
+		const start = async () => {
+			for (const handler of mock.events.get("session_start") ?? []) {
+				await handler({}, context.ctx);
+			}
+			return String(
+				mock.tools.filter((tool) => tool.name === "subagent_spawn").at(-1)?.description ?? "",
+			);
+		};
+
+		assert.match(await start(), /3 retained agents, 2 active turns, 4 direct children.*depth 1/i);
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({
+				stateful: {
+					maxAgents: 7,
+					maxActiveTurns: 5,
+					maxChildrenPerAgent: 6,
+					maxDepth: 2,
+					maxStoredAgents: 9,
+				},
+			}),
+		);
+		assert.match(await start(), /7 retained agents, 5 active turns, 6 direct children.*depth 2/i);
+
+		writeFileSync(settingsPath, "{ malformed");
+		assert.match(await start(), /7 retained agents, 5 active turns, 6 direct children.*depth 2/i);
+		assert.match(context.notifications.at(-1)?.message ?? "", /malformed|invalid/i);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
 test("session start refreshes every agent catalog and gates project metadata on trust", async () => {
 	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-catalog-user-"));
 	const trustedCwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-catalog-trusted-"));
@@ -1910,7 +2360,7 @@ test("subagent status separates runtime cwd policy from manual configured edits"
 	}
 });
 
-test("subagent settings read legacy files and save to the canonical package filename", () => {
+test("subagent settings read legacy files and save to the canonical package filename", async () => {
 	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-migration-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = directory;
@@ -1946,7 +2396,9 @@ test("subagent settings read legacy files and save to the canonical package file
 			futureOption: true,
 		});
 		const migrationContext = createMockContext();
-		migrationMock.events.get("session_start")?.[0]?.({}, migrationContext.ctx);
+		for (const handler of migrationMock.events.get("session_start") ?? []) {
+			await handler({}, migrationContext.ctx);
+		}
 		assert.match(migrationContext.notifications[0]?.message ?? "", /using legacy/i);
 
 		writeFileSync(legacyPath, JSON.stringify({ agents: { scout: { tools: ["bash"] } } }));
@@ -1988,7 +2440,9 @@ test("subagent settings read legacy files and save to the canonical package file
 		const ignoredMock = createMockPi();
 		subagents(ignoredMock.pi);
 		const ignoredContext = createMockContext();
-		ignoredMock.events.get("session_start")?.[0]?.({}, ignoredContext.ctx);
+		for (const handler of ignoredMock.events.get("session_start") ?? []) {
+			await handler({}, ignoredContext.ctx);
+		}
 		assert.match(ignoredContext.notifications[0]?.message ?? "", /ignored/i);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
@@ -2115,6 +2569,7 @@ test("legacy-seeded updates preserve canonical settings created before publicati
 		["completion delivery", () => updateCompletionDeliverySetting("next-turn")],
 		["delegation workflow", () => updateDelegationWorkflowSetting("async-only")],
 		["blocking parallel limit", () => updateBlockingMaxParallelTasksSetting(4)],
+		["detached limit", () => updateStatefulLimitSetting("maxAgents", 4)],
 		["agent tools", () => updateAgentToolsSetting("scout", ["read"])],
 	] as const;
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;

--- a/packages/pi-subagents/test/tool-rendering.test.ts
+++ b/packages/pi-subagents/test/tool-rendering.test.ts
@@ -337,10 +337,42 @@ test("inspect renderer summarizes every action instead of dumping collapsed JSON
 				status: {
 					workflow: "all",
 					consultResources: "project-context",
-					stateful: { initialized: true, activeAgents: 1, retainedAgents: 2 },
+					stateful: {
+						initialized: true,
+						activeAgents: 1,
+						retainedAgents: 2,
+						limits: {
+							maxAgents: 16,
+							maxActiveTurns: 4,
+							maxChildrenPerAgent: 8,
+							maxDepth: 3,
+							maxStoredAgents: 50,
+						},
+					},
+					statefulLimits: {
+						maxAgents: 16,
+						maxActiveTurns: 4,
+						maxChildrenPerAgent: 8,
+						maxDepth: 3,
+						maxStoredAgents: 50,
+					},
+					configuredStatefulLimits: {
+						maxAgents: 20,
+						maxActiveTurns: 4,
+						maxChildrenPerAgent: 8,
+						maxDepth: 3,
+						maxStoredAgents: 50,
+					},
+					configuredStatefulLimitSources: {
+						maxAgents: "user settings",
+						maxActiveTurns: "default",
+						maxChildrenPerAgent: "default",
+						maxDepth: "default",
+						maxStoredAgents: "default",
+					},
 				},
 			},
-			expected: /workflow: all.*1 active.*2 retained/is,
+			expected: /workflow: all.*1 active.*2 retained.*limits:.*agents:16.*stored:50/is,
 		},
 		{
 			args: { action: "diagnose" },
@@ -367,6 +399,21 @@ test("inspect renderer summarizes every action instead of dumping collapsed JSON
 		assert.match(text, fixture.expected);
 		assert.doesNotMatch(text, /^\s*\{/u);
 	}
+
+	const statusFixture = cases.find((fixture) => fixture.args.action === "status");
+	assert.ok(statusFixture);
+	const expandedStatus = withoutSgr(
+		renderResult(
+			tool,
+			statusFixture.args,
+			{
+				content: [{ type: "text", text: JSON.stringify(statusFixture.details) }],
+				details: statusFixture.details,
+			},
+			{ expanded: true, isPartial: false },
+		).join("\n"),
+	);
+	assert.match(expandedStatus, /configured:.*agents:20 \(user settings\).*active:4 \(default\)/is);
 });
 
 test("detached lifecycle renderers summarize calls and action-specific results", () => {


### PR DESCRIPTION
## Summary

- Add `/subagents` → **Advanced settings** → **Detached agent limits** editors for retained agents, active turns, direct children, tree depth, and stored records.
- Keep these startup-owned values reload-based while showing current and configured values in the manager, status, help, spawn guidance, structured inspection, and TUI rendering.
- Preserve unknown settings fields, reject stale or invalid writes, cancel pending confirmations before session cleanup, and preview records that lower limits would omit.
- Share defaults and ancestry-aware projection across settings, runtime startup, registry restore, persistence, and recovery previews.
- Document reload and lowering behavior, archive the completed plan, and add a minor Changeset.

## Verification

- `npm run check --workspace @narumitw/pi-subagents`
- `TMPDIR=/private/tmp npx vitest run packages/pi-subagents/test` — 14 files and 205 tests passed.
- `VITEST_MAX_WORKERS=4 npm run check` — 230 files and 2,623 tests passed with Biome, boundaries, and all workspace typechecks.
- `just pack subagents` — 44 expected files inspected.
- `pi -e ./packages/pi-subagents` — extension loading smoke passed in a pseudo-TTY.
- Deterministic TUI harness coverage passed for multi-setting saves, cancellation, stale sessions, narrow widths, reload messaging, lowering previews, and save failures.
- Independent final review passed with no remaining findings.

## Notes

- Blocking parallel execution concurrency remains fixed at four and is outside this change.
- Detached-limit saves apply after `/reload` or the next Pi session and never reload or close agents automatically.
