### PR TITLE
feat(btw): add side-thread steering

### DIFF
--- a/.changeset/tidy-moles-steer.md
+++ b/.changeset/tidy-moles-steer.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-btw": patch
 ---
 
-Queue Pi-style steering questions while a side-thread answer is running and process them one at a time without touching the main conversation.
+Queue Pi-style steering questions while a side-thread answer is running, process them one at a time without touching the main conversation, and report malformed side-model responses without hanging the side UI.

--- a/.changeset/tidy-moles-steer.md
+++ b/.changeset/tidy-moles-steer.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": patch
+---
+
+Queue Pi-style steering questions while a side-thread answer is running and process them one at a time without touching the main conversation.

--- a/docs/plans/archived/2026-08-09_pi-btw-side-thread-steering-plan.md
+++ b/docs/plans/archived/2026-08-09_pi-btw-side-thread-steering-plan.md
@@ -1,0 +1,66 @@
+## Goal
+
+Let users submit Pi-style steering questions while a pi-btw side-thread answer is running, then answer those questions inside the same ephemeral side thread without writing to the main conversation or editor.
+
+## Context
+
+Pi labels messages submitted during streaming as `Steering` and, by default, delivers them one at a time after the current assistant turn finishes.
+
+pi-btw currently replaces its composer with a read-only `BtwAnsweringView` until the side-model request completes.
+
+A pi-btw side turn is one provider request without tools, so its equivalent steering boundary is the completion of the current side-model response.
+
+## Architecture
+
+`runBtwThread` will own an in-memory FIFO steering queue for the current invocation.
+
+`BtwAnsweringView` will keep an editable composer visible while answering, submit non-empty text into that queue, and render bounded `Steering: …` status rows using terminal-safe text.
+
+After the active response succeeds or fails, `runBtwThread` will process the oldest queued question before reopening the idle composer.
+
+Each queued question will receive its own response before the next queued question is delivered, matching Pi's default `one-at-a-time` steering mode.
+
+The existing side-thread thinking control will remain active while answering, and a queued question will use the active side-thread thinking level when its turn begins.
+
+## Non-Goals
+
+- Do not call `pi.sendUserMessage()`, append session entries, or add steering content to the main conversation.
+- Do not change Bring to main behavior.
+- Do not add follow-up delivery or an `all` steering mode in this change.
+- Do not persist the ephemeral steering queue across closing, reload, or session replacement.
+- Do not inject text into an already-running provider request.
+
+## Risks
+
+- Answer completion, submission, cancellation, and component disposal can race unless queue ownership and terminal completion are single-settlement.
+- A growing queue or editor can hide the transcript or exceed short-terminal bounds unless the bottom area is explicitly budgeted.
+- New input must preserve IME focus propagation, large-paste expansion, configured thinking shortcuts, transcript scrolling, and terminal-control sanitization.
+- Cancelling the side thread must abort the active request and discard its local draft and queue without reopening another component.
+
+## Plan
+
+- [x] Add focused failing loop tests in `packages/pi-btw/test/side-thread.test.ts` proving FIFO one-at-a-time delivery, processing before the idle composer reopens, continuation after a displayed side-model error, and no main-session mutation.
+  Evidence: the initial focused run failed because the answering view and injected ask path did not yet accept steering controls.
+- [x] Add focused failing `BtwAnsweringView` tests proving Enter queues expanded editor text as `Steering`, empty submissions stay local with a warning, multiple queued rows remain ordered, and the configured thinking shortcut affects the next queued turn.
+  Evidence: the new component tests failed at compile time before the answering composer and focus contract existed.
+- [x] Add focused failing lifecycle and layout tests proving Ctrl+C and disposal abort once, late completion cannot process discarded steering, focus reaches the embedded editor, terminal controls are escaped, and every rendered line and short-terminal layout stays bounded.
+  Evidence: focused tests cover queued-message discard after abort, single cancellation, IME cursor rendering, sanitized bounded output, and short terminals.
+- [x] Update `packages/pi-btw/src/btw.ts` so `runBtwThread` owns and drains a side-thread-only FIFO queue before showing the normal composer; verify with the focused loop tests.
+  Evidence: FIFO, error continuation, thinking-level timing, composer ordering, cancellation, and untouched branch assertions pass.
+- [x] Update `packages/pi-btw/src/transcript-pager.ts` so the answering state includes an IME-capable editor, `Steering: …` queue feedback, compact overflow/status hints, scrolling, thinking control, and deterministic cancellation; verify with the focused component tests.
+  Evidence: all 83 focused side-thread tests and all 133 pi-btw tests pass.
+- [x] Update `packages/pi-btw/README.md` to document side-thread steering, one-at-a-time delivery, error and cancellation behavior, and the fact that nothing is sent to the main conversation.
+- [x] Add a patch changeset for `@narumitw/pi-btw` because the published extension gains observable behavior.
+  Evidence: `npx changeset status --verbose` includes `.changeset/tidy-moles-steer.md` in the pi-btw patch bump.
+- [x] Audit the final diff against `docs/extension-conventions.md`, especially asynchronous UI cancellation, disposal, stale context after awaits, session replacement, terminal safety, and custom-component width/focus rules.
+  Evidence: the queue is invocation-local, active custom UI remains single-owner, Ctrl+C and disposal settle once, stale notification handling remains guarded, raw messages are sanitized only at display, and both editor containers implement and forward `Focusable`.
+- [x] Run `npm test -- packages/pi-btw/test/side-thread.test.ts`, `npm run check --workspace @narumitw/pi-btw`, and `npm run check`; record exact evidence in this plan.
+  Evidence: the focused file passed 83 tests, the package check passed Biome and TypeScript, and the root gate passed 231 files with 2,637 tests plus boundaries and all workspace typechecks.
+
+## Completion Checklist
+
+- [x] Enter during `Answering…` visibly queues a side-thread `Steering` question without interrupting the active provider request.
+- [x] Queued questions are answered FIFO and one at a time before the idle composer reopens.
+- [x] Steering questions, answers, drafts, and queue state remain absent from the main Pi conversation and editor.
+- [x] Thinking changes, transcript scrolling, large pastes, IME focus, narrow widths, errors, Ctrl+C, disposal, and session replacement retain deterministic behavior.
+- [x] README, patch changeset, focused tests, package checks, root CI-equivalent checks, package preview, load smoke, and the semantic convention audit are complete.

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -13,6 +13,7 @@ Use it when you want to ask a temporary question, inspect context, or get a shor
 - Answers side questions in a dedicated, scrollable full-screen UI.
 - Keeps mouse-drag copying stable while the main agent continues running in the background.
 - Supports follow-up questions in the same ephemeral side thread.
+- Queues Pi-style `Steering` questions while an answer is running and processes them one at a time.
 - Optionally brings the latest answer, a question-to-end suffix, an exact line range, or the entire side thread into the main editor.
 - Uses the current session branch as context.
 - Uses Pi's current model or an independent model selected in `pi-btw.json`.
@@ -74,10 +75,16 @@ invocation. The side-thread header shows its current thinking level. Press Pi's 
 supported by the side-thread model; every later question uses the displayed level until it is
 changed again. By default, each shortcut change is also written to `pi-btw.json` for the next
 invocation. Turn **Remember thinking level changes** off in Settings to keep changes local to the
-current side thread. Neither path changes the main session's thinking level. While a response is
-running, the transcript stays visible above a compact `Answering…` status.
-The footer shows `PgUp`/`PgDn` only when history can scroll; press `Ctrl+C` to cancel an
-in-progress answer or leave the side thread.
+current side thread. Neither path changes the main session's thinking level.
+While a response is running, the transcript and composer remain visible above an `Answering…`
+status.
+Type another question and press `Enter` to queue it as `Steering`; queued questions are shown in
+submission order and answered one at a time after the active response completes.
+A queued question uses the side thread's thinking level when its turn begins.
+A failed active response is shown in the transcript and does not discard later steering questions.
+The footer shows `PgUp`/`PgDn` only when history can scroll; press `Ctrl+C` to cancel the active
+response and discard the ephemeral side-thread draft and steering queue.
+Steering remains entirely inside pi-btw and never appends to the main conversation or editor.
 
 After at least one successful answer, press `Ctrl+R` to bring selected context to the main
 editor. The scope menu shows the size of the latest question and answer and the entire side

--- a/packages/pi-btw/src/btw.ts
+++ b/packages/pi-btw/src/btw.ts
@@ -341,6 +341,12 @@ export type BtwThreadResult = { kind: "closed" };
 
 type BtwThreadThinkingControl = Omit<BtwThinkingControl, "keybindings">;
 
+interface BtwThreadSteeringControl {
+	questions: readonly string[];
+	submit: (question: string) => void;
+	thinking: BtwThreadThinkingControl;
+}
+
 type BtwBringToMainChoice =
 	| BtwThreadResult
 	| {
@@ -382,41 +388,42 @@ export async function runBtwThread({
 	const thread = createSideThread(buildConversationContext(ctx.sessionManager.getBranch()));
 	const thinkingLevels = getSupportedThinkingLevels(selected.model);
 	const pendingWrites = new Set<Promise<void>>();
+	const steeringQuestions: string[] = [];
 	let activeThinkingLevel = clampThinkingLevel(selected.model, thinkingLevel);
 	let pendingQuestion = initialQuestion;
 	let composerDraft: string | undefined;
+	const createThinkingControl = (): BtwThreadThinkingControl => ({
+		level: activeThinkingLevel,
+		levels: thinkingLevels,
+		onChange: (level) => {
+			if (!thinkingLevels.includes(level)) return;
+			activeThinkingLevel = level;
+			if (!rememberThinkingLevelChanges) return;
+			let write!: Promise<void>;
+			write = Promise.resolve()
+				.then(() => persistThinkingLevel(level))
+				.then(() => undefined)
+				.catch((error: unknown) => {
+					notifySafely(
+						ctx,
+						`Thinking level changed to ${level}, but could not be remembered in pi-btw.json: ${formatError(error)}`,
+						"warning",
+					);
+				})
+				.finally(() => pendingWrites.delete(write));
+			pendingWrites.add(write);
+		},
+	});
 
 	try {
 		while (true) {
 			if (!pendingQuestion) {
-				const thinking: BtwThreadThinkingControl = {
-					level: activeThinkingLevel,
-					levels: thinkingLevels,
-					onChange: (level) => {
-						if (!thinkingLevels.includes(level)) return;
-						activeThinkingLevel = level;
-						if (!rememberThinkingLevelChanges) return;
-						let write!: Promise<void>;
-						write = Promise.resolve()
-							.then(() => persistThinkingLevel(level))
-							.then(() => undefined)
-							.catch((error: unknown) => {
-								notifySafely(
-									ctx,
-									`Thinking level changed to ${level}, but could not be remembered in pi-btw.json: ${formatError(error)}`,
-									"warning",
-								);
-							})
-							.finally(() => pendingWrites.delete(write));
-						pendingWrites.add(write);
-					},
-				};
 				const action = await interact(
 					thread,
 					thread.turns.length > 0,
 					ctx,
 					composerDraft,
-					thinking,
+					createThinkingControl(),
 				);
 				if (action.kind === "close") return { kind: "closed" };
 				if (action.kind === "bringToMain") {
@@ -435,7 +442,11 @@ export async function runBtwThread({
 				pendingQuestion = action.question;
 			}
 
-			const result = await ask(thread, pendingQuestion, selected, activeThinkingLevel, ctx);
+			const result = await ask(thread, pendingQuestion, selected, activeThinkingLevel, ctx, {
+				questions: steeringQuestions,
+				submit: (question) => steeringQuestions.push(question),
+				thinking: createThinkingControl(),
+			});
 			if (result.kind === "aborted") {
 				notifySafely(ctx, "Cancelled", "info");
 				return { kind: "closed" };
@@ -448,7 +459,7 @@ export async function runBtwThread({
 				});
 			}
 
-			pendingQuestion = undefined;
+			pendingQuestion = steeringQuestions.shift();
 		}
 	} finally {
 		await Promise.allSettled([...pendingWrites]);
@@ -771,9 +782,10 @@ async function askThreadQuestion(
 	selected: ResolvedBtwModel,
 	thinkingLevel: BtwThinkingLevel,
 	ctx: ExtensionCommandContext,
+	steering: BtwThreadSteeringControl,
 ) {
 	return ctx.ui.custom<Awaited<ReturnType<typeof completeSideThreadTurn>>>(
-		(tui, theme, _keybindings, done) => {
+		(tui, theme, keybindings, done) => {
 			let settled = false;
 			const view = new BtwAnsweringView(
 				tui,
@@ -786,6 +798,13 @@ async function askThreadQuestion(
 					done({ kind: "aborted" });
 				},
 				thinkingLevel,
+				{
+					steering: {
+						questions: steering.questions,
+						onSubmit: steering.submit,
+						thinking: { ...steering.thinking, keybindings },
+					},
+				},
 			);
 			completeSideThreadTurn({
 				thread,

--- a/packages/pi-btw/src/side-thread.ts
+++ b/packages/pi-btw/src/side-thread.ts
@@ -103,26 +103,30 @@ export async function completeSideThreadTurn({
 	completeSimple,
 }: CompleteSideThreadTurnOptions): Promise<CompleteSideThreadTurnResult> {
 	if (signal?.aborted) return { kind: "aborted" };
-	let response: AssistantMessage;
 	try {
-		response = await completeSimple(
+		const response = await completeSimple(
 			model,
 			{ systemPrompt: SYSTEM_PROMPT, messages: buildSideThreadMessages(thread, question) },
 			buildStreamOptions(auth, thinkingLevel, signal),
 		);
+		if (signal?.aborted || response?.stopReason === "aborted") return { kind: "aborted" };
+		if (!isAssistantMessage(response)) {
+			return { kind: "error", message: "The side model returned a malformed response." };
+		}
+		if (response.stopReason === "error") {
+			return {
+				kind: "error",
+				message: response.errorMessage ?? "The side model returned an error.",
+			};
+		}
+
+		const answer = extractAssistantText(response) || "No response received.";
+		thread.turns.push({ kind: "answered", question, answer, response });
+		return { kind: "answered", response, answer };
 	} catch (error: unknown) {
 		if (signal?.aborted) return { kind: "aborted" };
 		return { kind: "error", message: formatError(error) };
 	}
-
-	if (signal?.aborted || response.stopReason === "aborted") return { kind: "aborted" };
-	if (response.stopReason === "error") {
-		return { kind: "error", message: response.errorMessage ?? "The side model returned an error." };
-	}
-
-	const answer = extractAssistantText(response) || "No response received.";
-	thread.turns.push({ kind: "answered", question, answer, response });
-	return { kind: "answered", response, answer };
 }
 
 export interface CompleteSideQuestionOptions {
@@ -156,10 +160,26 @@ export async function completeSideQuestion({
 
 export function extractAssistantText(response: AssistantMessage): string {
 	return response.content
-		.filter((content): content is { type: "text"; text: string } => content.type === "text")
+		.filter(
+			(content): content is { type: "text"; text: string } =>
+				content !== null &&
+				typeof content === "object" &&
+				content.type === "text" &&
+				typeof content.text === "string",
+		)
 		.map((content) => content.text)
 		.join("\n")
 		.trim();
+}
+
+function isAssistantMessage(value: unknown): value is AssistantMessage {
+	if (value === null || typeof value !== "object") return false;
+	const candidate = value as Partial<AssistantMessage>;
+	return (
+		candidate.role === "assistant" &&
+		Array.isArray(candidate.content) &&
+		typeof candidate.stopReason === "string"
+	);
 }
 
 export function buildUserPrompt(question: string, conversationContext: string): string {

--- a/packages/pi-btw/src/transcript-pager.ts
+++ b/packages/pi-btw/src/transcript-pager.ts
@@ -11,6 +11,7 @@ import {
 	CURSOR_MARKER,
 	Editor,
 	type EditorTheme,
+	type Focusable,
 	Key,
 	Loader,
 	Markdown,
@@ -23,6 +24,7 @@ import type { BtwThinkingLevel, SideThreadTurn } from "./side-thread.js";
 import { sanitizeSingleLine } from "./text.js";
 
 const TRANSCRIPT_CHROME_LINES = 2;
+const MAX_STEERING_DISPLAY_LINES = 3;
 const OSC133_MARKERS = ["\u001b]133;A\u0007", "\u001b]133;B\u0007", "\u001b]133;C\u0007"];
 // Pi renders a spacer above the custom component and a two-line built-in footer below it.
 const RESERVED_APP_LINES = 3;
@@ -39,7 +41,15 @@ export interface BtwThinkingControl {
 	onChange: (level: BtwThinkingLevel) => void;
 }
 
-export class BtwTranscriptPager implements Component {
+export interface BtwAnsweringViewOptions {
+	steering?: {
+		questions: readonly string[];
+		onSubmit: (question: string) => void;
+		thinking?: BtwThinkingControl;
+	};
+}
+
+export class BtwTranscriptPager implements Component, Focusable {
 	private readonly transcriptComponents: Component[];
 	private readonly editor: Editor;
 	private readonly canBringToMain: boolean;
@@ -242,15 +252,19 @@ export class BtwTranscriptPager implements Component {
 	}
 }
 
-export class BtwAnsweringView implements Component {
+export class BtwAnsweringView implements Component, Focusable {
 	private readonly transcriptComponents: Component[];
 	private readonly loader: Loader;
+	private readonly editor: Editor | undefined;
 	private readonly controller = new AbortController();
 	private scrollOffset = 0;
 	private lastContentLineCount = 0;
 	private lastViewportHeight = 1;
 	private followBottom = true;
+	private warning: string | undefined;
 	private finished = false;
+	private isFocused = false;
+	private thinkingLevel: BtwThinkingLevel | undefined;
 
 	constructor(
 		private readonly tui: TUI,
@@ -258,15 +272,51 @@ export class BtwAnsweringView implements Component {
 		turns: readonly SideThreadTurn[],
 		pendingQuestion: string,
 		private readonly onCancel: () => void,
-		private readonly thinkingLevel?: BtwThinkingLevel,
+		thinkingLevel?: BtwThinkingLevel,
+		private readonly options: BtwAnsweringViewOptions = {},
 	) {
 		this.transcriptComponents = buildTranscriptComponents(turns, this.theme, pendingQuestion);
+		this.thinkingLevel = options.steering?.thinking?.level ?? thinkingLevel;
 		this.loader = new Loader(
 			this.tui,
 			(text) => this.theme.fg("accent", text),
 			(text) => this.theme.fg("muted", text),
 			"Answering…",
 		);
+		if (options.steering) {
+			const editorTheme: EditorTheme = {
+				borderColor: (text) => this.theme.fg("accent", text),
+				selectList: {
+					selectedPrefix: (text) => this.theme.fg("accent", text),
+					selectedText: (text) => this.theme.fg("accent", text),
+					description: (text) => this.theme.fg("muted", text),
+					scrollInfo: (text) => this.theme.fg("dim", text),
+					noMatch: (text) => this.theme.fg("warning", text),
+				},
+			};
+			this.editor = new Editor(this.tui, editorTheme);
+			this.editor.onChange = () => {
+				this.warning = undefined;
+			};
+			this.editor.onSubmit = (text) => {
+				const question = text.trim();
+				if (!question) {
+					this.warning = "Question cannot be empty";
+					return;
+				}
+				options.steering?.onSubmit(question);
+				this.warning = undefined;
+			};
+		}
+	}
+
+	get focused(): boolean {
+		return this.isFocused;
+	}
+
+	set focused(value: boolean) {
+		this.isFocused = value;
+		if (this.editor) this.editor.focused = value;
 	}
 
 	get signal(): AbortSignal {
@@ -276,21 +326,35 @@ export class BtwAnsweringView implements Component {
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
 		const availableRows = Math.max(1, this.tui.terminal.rows - RESERVED_APP_LINES);
-		const viewportHeight = Math.max(0, availableRows - TRANSCRIPT_CHROME_LINES);
+		const editorLines = this.editor?.render(safeWidth) ?? [];
+		const steeringCapacity = Math.max(
+			0,
+			availableRows - editorLines.length - TRANSCRIPT_CHROME_LINES,
+		);
+		const steeringLines = renderSteeringLines(
+			this.options.steering?.questions ?? [],
+			safeWidth,
+			this.theme,
+			Math.min(MAX_STEERING_DISPLAY_LINES, steeringCapacity),
+		);
+		const viewportHeight = Math.max(
+			0,
+			availableRows - editorLines.length - TRANSCRIPT_CHROME_LINES - steeringLines.length,
+		);
 		const contentLines = renderTranscriptLines(this.transcriptComponents, safeWidth);
 		this.lastContentLineCount = contentLines.length;
 		this.lastViewportHeight = viewportHeight;
 		if (this.followBottom) this.scrollOffset = this.getMaxScrollOffset();
 		this.clampScrollOffset();
-		const cancelHint = safeWidth < 28 ? "Ctrl+C" : "Ctrl+C cancel";
-		const loaderWidth = Math.max(1, safeWidth - visibleWidth(cancelHint) - 3);
-		const loaderLine = this.loader.render(loaderWidth).at(-1) ?? "Answering…";
-		const lines = [
+
+		return fitComposerLayout(
 			renderSideThreadHeader(safeWidth, this.theme, this.thinkingLevel),
-			...contentLines.slice(this.scrollOffset, this.scrollOffset + viewportHeight),
-			truncateToWidth(`${loaderLine} • ${this.theme.fg("muted", cancelHint)}`, safeWidth),
-		];
-		return fitWithFixedHeader(lines, availableRows);
+			contentLines.slice(this.scrollOffset, this.scrollOffset + viewportHeight),
+			this.renderFooter(safeWidth),
+			editorLines,
+			availableRows,
+			steeringLines,
+		);
 	}
 
 	handleInput(data: string): void {
@@ -302,21 +366,43 @@ export class BtwAnsweringView implements Component {
 			this.onCancel();
 			return;
 		}
+		const thinking = this.options.steering?.thinking;
+		if (
+			thinking &&
+			thinking.levels.length > 1 &&
+			thinking.keybindings.matches(data, "app.thinking.cycle")
+		) {
+			const currentIndex = thinking.levels.indexOf(this.thinkingLevel ?? thinking.level);
+			const nextLevel = thinking.levels[(currentIndex + 1) % thinking.levels.length];
+			if (nextLevel) {
+				this.thinkingLevel = nextLevel;
+				thinking.onChange(nextLevel);
+				this.warning = undefined;
+				this.tui.requestRender();
+			}
+			return;
+		}
 		if (matchesKey(data, Key.pageUp)) {
 			const previousOffset = this.scrollOffset;
 			this.scrollBy(-this.lastViewportHeight);
 			if (this.scrollOffset < previousOffset) this.followBottom = false;
 			this.tui.requestRender();
-		} else if (matchesKey(data, Key.pageDown)) {
+			return;
+		}
+		if (matchesKey(data, Key.pageDown)) {
 			this.scrollBy(this.lastViewportHeight);
 			this.followBottom = this.scrollOffset >= this.getMaxScrollOffset();
 			this.tui.requestRender();
+			return;
 		}
+		this.editor?.handleInput(data);
+		this.tui.requestRender();
 	}
 
 	invalidate(): void {
 		for (const component of this.transcriptComponents) component.invalidate();
 		this.loader.invalidate();
+		this.editor?.invalidate();
 	}
 
 	finish(): void {
@@ -334,6 +420,26 @@ export class BtwAnsweringView implements Component {
 		this.loader.stop();
 		this.controller.abort();
 		this.onCancel();
+	}
+
+	private renderFooter(width: number): string {
+		if (this.warning) {
+			const warning = width < 32 ? "Empty • Ctrl+C" : `${this.warning} • Ctrl+C cancel`;
+			return truncateToWidth(this.theme.fg("warning", warning), width);
+		}
+		const baseHint = this.editor ? "Enter steer • Ctrl+C cancel" : "Ctrl+C cancel";
+		const thinking = this.options.steering?.thinking;
+		const cycleHint =
+			thinking && thinking.levels.length > 1 && this.thinkingLevel
+				? ` • thinking ${this.thinkingLevel} • ${thinkingKeyLabel(thinking.keybindings)} cycle`
+				: "";
+		const scrollHint = this.getMaxScrollOffset() > 0 ? " • PgUp/PgDn history" : "";
+		const hints = `${baseHint}${cycleHint}${scrollHint}`;
+		const compactHints = this.editor ? "Enter • Ctrl+C" : "Ctrl+C";
+		const selectedHints = visibleWidth(hints) <= width ? hints : compactHints;
+		const loaderWidth = Math.max(1, width - visibleWidth(selectedHints) - 3);
+		const loaderLine = this.loader.render(loaderWidth).at(-1) ?? "Answering…";
+		return truncateToWidth(`${loaderLine} • ${this.theme.fg("muted", selectedHints)}`, width);
 	}
 
 	private scrollBy(delta: number): void {
@@ -439,8 +545,9 @@ function fitComposerLayout(
 	footer: string,
 	editorLines: string[],
 	availableRows: number,
+	statusLines: string[] = [],
 ): string[] {
-	const lines = [header, ...contentLines, footer, ...editorLines];
+	const lines = [header, ...contentLines, ...statusLines, footer, ...editorLines];
 	if (lines.length <= availableRows) return lines;
 	if (availableRows <= 1) return [header];
 	const editorBudget = Math.max(0, availableRows - 2);
@@ -456,10 +563,42 @@ function fitEditorLines(editorLines: string[], budget: number): string[] {
 	return editorLines.slice(start, start + budget);
 }
 
-function fitWithFixedHeader(lines: string[], availableRows: number): string[] {
-	if (lines.length <= availableRows) return lines;
-	if (availableRows <= 1) return lines.slice(0, 1);
-	return [lines[0] ?? "", ...lines.slice(lines.length - availableRows + 1)];
+function renderSteeringLines(
+	questions: readonly string[],
+	width: number,
+	theme: Theme,
+	maxLines: number,
+): string[] {
+	if (questions.length === 0 || maxLines <= 0) return [];
+	const formatQuestion = (question: string) =>
+		sanitizeSingleLine(question) || "(non-printing message)";
+	if (maxLines === 1 && questions.length > 1) {
+		return [
+			truncateToWidth(
+				theme.fg(
+					"dim",
+					`Steering (+${questions.length - 1} more): ${formatQuestion(questions[0] ?? "")}`,
+				),
+				width,
+			),
+		];
+	}
+	const hasOverflow = questions.length > maxLines;
+	const questionLimit = hasOverflow ? Math.max(1, maxLines - 1) : maxLines;
+	const lines = questions
+		.slice(0, questionLimit)
+		.map((question) =>
+			truncateToWidth(theme.fg("dim", `Steering: ${formatQuestion(question)}`), width),
+		);
+	if (hasOverflow) {
+		lines.push(
+			truncateToWidth(
+				theme.fg("dim", `Steering: … +${questions.length - questionLimit} more`),
+				width,
+			),
+		);
+	}
+	return lines;
 }
 
 function stripShellIntegrationMarkers(line: string): string {

--- a/packages/pi-btw/test/side-thread.test.ts
+++ b/packages/pi-btw/test/side-thread.test.ts
@@ -2506,3 +2506,257 @@ test("transcript composer submits typed questions by default and only Ctrl+C clo
 
 	assert.deepEqual(actions, [{ kind: "submit", question: "qf" }, { kind: "close" }]);
 });
+
+test("side-thread steering drains queued questions one at a time before reopening the composer", async () => {
+	const branch = [{ type: "message", message: { role: "user", content: "main" } }];
+	const questions: string[] = [];
+	const thinkingLevels: string[] = [];
+	let interactions = 0;
+	const result = await runBtwThread({
+		initialQuestion: "Q1",
+		selected: {
+			model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+			auth: { apiKey: "key" },
+		},
+		thinkingLevel: "low",
+		ctx: {
+			ui: { notify() {} },
+			sessionManager: { getBranch: () => branch },
+		} as never,
+		dependencies: {
+			ask: (async (
+				thread: SideThread,
+				question: string,
+				_selected: ResolvedBtwModel,
+				thinkingLevel: string,
+				_ctx: unknown,
+				steering: {
+					submit(question: string): void;
+					thinking: { onChange(level: "high"): void };
+				},
+			) => {
+				questions.push(question);
+				thinkingLevels.push(thinkingLevel);
+				if (question === "Q1") {
+					steering.submit("Q2");
+					steering.submit("Q3");
+					steering.thinking.onChange("high");
+				}
+				const assistant = response(`A${questions.length}`);
+				thread.turns.push({
+					kind: "answered",
+					question,
+					answer: `A${questions.length}`,
+					response: assistant,
+				});
+				return {
+					kind: "answered",
+					response: assistant,
+					answer: `A${questions.length}`,
+				};
+			}) as never,
+			interact: async () => {
+				interactions += 1;
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(result, { kind: "closed" });
+	assert.deepEqual(questions, ["Q1", "Q2", "Q3"]);
+	assert.deepEqual(thinkingLevels, ["low", "high", "high"]);
+	assert.equal(interactions, 1);
+	assert.deepEqual(branch, [{ type: "message", message: { role: "user", content: "main" } }]);
+});
+
+test("side-thread steering continues after the active answer fails", async () => {
+	const asked: string[] = [];
+	let interactions = 0;
+	const result = await runBtwThread({
+		initialQuestion: "Q1",
+		selected: {
+			model: { provider: "test", id: "side" } as Model<Api>,
+			auth: { apiKey: "key" },
+		},
+		thinkingLevel: "off",
+		ctx: {
+			ui: { notify() {} },
+			sessionManager: { getBranch: () => [] },
+		} as never,
+		dependencies: {
+			ask: (async (
+				thread: SideThread,
+				question: string,
+				_selected: ResolvedBtwModel,
+				_level: string,
+				_ctx: unknown,
+				steering: { submit(question: string): void },
+			) => {
+				asked.push(question);
+				if (question === "Q1") {
+					steering.submit("recover with Q2");
+					return { kind: "error", message: "first answer failed" };
+				}
+				const assistant = response("recovered");
+				thread.turns.push({
+					kind: "answered",
+					question,
+					answer: "recovered",
+					response: assistant,
+				});
+				return { kind: "answered", response: assistant, answer: "recovered" };
+			}) as never,
+			interact: async () => {
+				interactions += 1;
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(result, { kind: "closed" });
+	assert.deepEqual(asked, ["Q1", "recover with Q2"]);
+	assert.equal(interactions, 1);
+});
+
+test("cancelling an active answer discards its side-thread steering queue", async () => {
+	const asked: string[] = [];
+	let interactions = 0;
+	const result = await runBtwThread({
+		initialQuestion: "Q1",
+		selected: {
+			model: { provider: "test", id: "side" } as Model<Api>,
+			auth: { apiKey: "key" },
+		},
+		thinkingLevel: "off",
+		ctx: {
+			ui: { notify() {} },
+			sessionManager: { getBranch: () => [] },
+		} as never,
+		dependencies: {
+			ask: (async (
+				_thread: SideThread,
+				question: string,
+				_selected: ResolvedBtwModel,
+				_level: string,
+				_ctx: unknown,
+				steering: { submit(question: string): void },
+			) => {
+				asked.push(question);
+				steering.submit("must be discarded");
+				return { kind: "aborted" };
+			}) as never,
+			interact: async () => {
+				interactions += 1;
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.deepEqual(result, { kind: "closed" });
+	assert.deepEqual(asked, ["Q1"]);
+	assert.equal(interactions, 0);
+});
+
+test("answering view accepts Pi-style steering while preserving IME focus and expanded paste", () => {
+	initTheme("dark");
+	const queued: string[] = [];
+	const changes: string[] = [];
+	const tui = { terminal: { rows: 24 }, requestRender() {} };
+	const theme = {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	};
+	const view = new BtwAnsweringView(
+		tui as never,
+		theme as never,
+		[],
+		"Current question",
+		() => undefined,
+		"low",
+		{
+			steering: {
+				questions: queued,
+				onSubmit: (question) => queued.push(question),
+				thinking: {
+					level: "low",
+					levels: ["low", "high"],
+					keybindings: keybindings({ "app.thinking.cycle": "t" }) as never,
+					onChange: (level) => changes.push(level),
+				},
+			},
+		},
+	);
+	try {
+		view.focused = true;
+		assert.equal(view.render(80).join("\n").includes(CURSOR_MARKER), true);
+		const pasted = "steering paste ".repeat(100);
+		view.handleInput(`\u001b[200~${pasted}\u001b[201~`);
+		view.handleInput("\r");
+		view.handleInput("second steering");
+		view.handleInput("\r");
+		view.handleInput("t");
+
+		assert.deepEqual(queued, [pasted.trim(), "second steering"]);
+		assert.deepEqual(changes, ["high"]);
+		const rendered = view.render(100).join("\n");
+		assert.match(rendered, /Steering: steering paste/);
+		assert.ok(rendered.indexOf("steering paste") < rendered.indexOf("second steering"));
+		assert.match(rendered, /Answering….*Enter steer.*Ctrl\+C cancel/);
+		assert.match(rendered, /thinking high/i);
+	} finally {
+		view.dispose();
+	}
+});
+
+test("answering steering rejects blank questions and bounds unsafe queue display", () => {
+	initTheme("dark");
+	const queued = [
+		"first\u001b]52;c;ZXZpbA==\u0007 steering",
+		"second steering",
+		"third steering",
+		"fourth steering",
+	];
+	let cancelled = 0;
+	const tui = { terminal: { rows: 9 }, requestRender() {} };
+	const theme = {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	};
+	const view = new BtwAnsweringView(
+		tui as never,
+		theme as never,
+		[],
+		"Current question",
+		() => {
+			cancelled += 1;
+		},
+		"off",
+		{
+			steering: {
+				questions: queued,
+				onSubmit: (question) => queued.push(question),
+			},
+		},
+	);
+	view.focused = true;
+	view.handleInput("   ");
+	view.handleInput("\r");
+	const rendered = view.render(28);
+	assert.match(rendered.join("\n"), /cannot be empty|Empty/i);
+	assert.equal(rendered.join("\n").includes("\u001b]52"), false);
+	assert.match(rendered.join("\n"), /more/i);
+	assert.ok(rendered.every((line) => visibleWidth(line) <= 28));
+	assert.ok(rendered.length <= tui.terminal.rows - 3);
+	view.handleInput("\u0003");
+	view.dispose();
+	assert.equal(cancelled, 1);
+	assert.equal(view.signal.aborted, true);
+});

--- a/packages/pi-btw/test/side-thread.test.ts
+++ b/packages/pi-btw/test/side-thread.test.ts
@@ -31,6 +31,7 @@ import {
 	buildSideThreadMessages,
 	completeSideThreadTurn,
 	createSideThread,
+	extractAssistantText,
 	type SideThread,
 } from "../src/side-thread.js";
 import {
@@ -219,6 +220,34 @@ test("side thread discards a late successful response after cancellation", async
 
 	assert.deepEqual(await pending, { kind: "aborted" });
 	assert.deepEqual(thread.turns, []);
+});
+
+test("side thread turns malformed provider responses into visible errors", async () => {
+	for (const malformed of [null, { ...response("answer"), content: undefined }]) {
+		const thread = createSideThread("context");
+		const result = await completeSideThreadTurn({
+			thread,
+			question: "handle malformed response",
+			model: { provider: "test", id: "side" } as Model<Api>,
+			auth: { apiKey: "key" },
+			thinkingLevel: "off",
+			completeSimple: async () => malformed as never,
+		});
+
+		assert.equal(result.kind, "error");
+		assert.match(result.kind === "error" ? result.message : "", /malformed response/i);
+		assert.deepEqual(thread.turns, []);
+	}
+});
+
+test("assistant text extraction ignores malformed content blocks", () => {
+	assert.equal(
+		extractAssistantText({
+			...response("unused"),
+			content: [null, { type: "text", text: 42 }, { type: "text", text: "valid answer" }],
+		} as never),
+		"valid answer",
+	);
 });
 
 test("side thread does not record aborted completions", async () => {


### PR DESCRIPTION
## Summary

- keep the pi-btw composer available while a side answer is running and show queued `Steering` prompts
- drain side-thread steering prompts FIFO and one at a time before reopening the idle composer
- preserve local thinking-level changes, continue after side-model errors, and discard the ephemeral queue on cancellation
- keep all steering state out of the main Pi conversation and editor
- reject malformed provider responses as visible side-thread errors instead of leaving the side UI pending
- document the behavior and add a pi-btw patch changeset

## Verification

- `npx vitest run packages/pi-btw/test/side-thread.test.ts` — 85 tests passed
- `npx vitest run packages/pi-btw/test` — 135 tests passed
- `npm run check --workspace @narumitw/pi-btw`
- `npm run check` — 231 files and 2,639 tests passed, with boundaries and workspace typechecks
- `npm run pack:btw -- --json` — 12 expected package files
- `pi -e ./packages/pi-btw --list-models` — extension load smoke passed

## Convention and hardening audit

Reviewed the changed command loop and custom TUI against `docs/extension-conventions.md` and the reachable input, UI-state, async-lifecycle, and provider-boundary cases.

The queue remains invocation-local, cancellation and disposal settle once, stale notifications stay guarded, terminal input is sanitized at display, and both editor containers forward `Focusable` for IME support.

Malformed top-level provider responses now become deterministic error turns, malformed content blocks cannot crash text extraction, and the steering queue can continue after the error.

No deviations or intentionally unverified required paths remain.
