### PR TITLE
feat(pi-subagents): add additive delegation capabilities

### DIFF
--- a/.changeset/warm-fleets-coordinate.md
+++ b/.changeset/warm-fleets-coordinate.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Add opt-in FleetView and lifecycle metadata, manager steering, evidence attestations, and a versioned event API with preflight, foreground delegation, cancellation, and capability ceilings.

--- a/docs/plans/archived/2026-08-09_pi-subagents-additive-capabilities-plan.md
+++ b/docs/plans/archived/2026-08-09_pi-subagents-additive-capabilities-plan.md
@@ -1,0 +1,272 @@
+# Additive pi-subagents platform capabilities
+
+## Goal
+
+Add opt-in fleet visibility, manager-based steering, a versioned event API with preflight and structured foreground delegation, session-scoped capability ceilings, optional metadata lifecycle artifacts, and optional child evidence attestations to `@narumitw/pi-subagents` without removing or changing the default behavior of its existing seven tools, command routes, settings, transports, completion-delivery policies, persisted records, or non-TUI modes.
+
+Treat the existing completion broker's bounded burst coalescing as the completion-grouping implementation, preserve its current delivery timing and wake rules, and improve only its tests and documentation unless execution discovers a confirmed defect.
+
+## Context
+
+The current package registers `subagent`, four detached lifecycle tools, `subagent_inspect`, and `subagent_consult`, with workflow settings selecting compatible subsets.
+
+`CompletionDeliveryBroker` already coalesces completions for 10 ms, limits each message to 16 completions, preserves `next-turn` and `auto-resume` delivery semantics, and bounds model-facing content.
+
+The detached registry already exposes sanitized tree, lifecycle, history-count, unread-count, target-trust, and policy metadata suitable for a read-only fleet projection.
+
+The `/subagents` manager currently lists retained agents and supports clearing all agents, but it does not offer per-agent detail, follow-up, mailbox, interrupt, or close actions.
+
+The package has no public event API or package subpath for protocol types.
+
+Blocking and detached launches already share agent discovery, cwd/trust policy, thinking, timeout, tool, process cleanup, and output-bound behavior, but they do not yet expose one canonical side-effect-free launch-contract resolver.
+
+The package state file is private, bounded, versioned, and sanitized, but it is not a documented public lifecycle artifact.
+
+Recent package work added blocking and detached limits, so new settings and manager work must reuse the existing latest-document read, unknown-field preservation, mutation lock, atomic rename, stale-session guard, and current-versus-configured presentation.
+
+The repository comparison found that tintinweb's strongest relevant ideas are fleet visibility and direct lifecycle UX, while Nico Bailon's strongest relevant ideas are preflight, capability ceilings, structured delegation, and public lifecycle metadata.
+
+## Architecture
+
+### Compatibility boundary
+
+- Keep exactly the current seven default model-facing tools and their existing names.
+- Keep every currently accepted tool payload valid, and add only optional fields with old defaults.
+- Keep `/subagents`, `/subagents settings`, `/subagents status`, and `/subagents help` behavior and non-TUI fallbacks.
+- Keep `next-turn` as the completion-delivery default and preserve the exact wake, pending-input, fallback, ordering, and bounded batching rules.
+- Keep subprocess as the detached transport default and retain the in-process opt-in path.
+- Keep the current user settings path, legacy filename precedence, persisted state path, record restoration, and trust revalidation.
+- Introduce no project settings, new environment variables, scheduling, missions, arbitrary workflow scripts, wait tool, or automatic child restart.
+
+### Capability classification and user experience
+
+- **Primary:** Existing delegation workflow selection and Current agents remain the main user routes.
+- **Supporting:** An opt-in, read-only below-editor fleet widget shows bounded active-agent state without taking focus or intercepting terminal keys.
+- **Contextual:** Selecting an agent under Current agents opens details and only the actions valid for its current state.
+- **Advanced:** Public event API diagnostics, capability ceilings, lifecycle artifacts, and evidence attestation remain documented advanced capabilities.
+- **Safety/status:** Trust boundary, write-conflict policy, failed/interrupted state, destructive close scope, persistence errors, and stale-session changes remain visible at the decision point.
+- Do not add a hidden gesture, global terminal-input listener, custom editor, or second manager command.
+
+The fleet widget defaults to off for every existing or absent settings file.
+
+When enabled, the widget renders only active `starting` and `running` agents, at most five rows plus an omission count, a text status word in addition to color, a bounded sanitized task preview, and a `/subagents` hint.
+
+The widget clears when no agent is active, when detached delegation is disabled, on session replacement, on shutdown, and after partial initialization failure.
+
+The Current agents screen keeps the existing clear-all route and adds one selectable row per retained agent.
+
+The per-agent detail screen exposes metadata first, then state-valid actions: send follow-up, queue mailbox message, interrupt, close, and subtree variants when descendants exist.
+
+Manager actions call new extension-owned controller methods directly rather than recursively invoking model tools, and the controller reuses the same registry, trust, write-conflict, workspace-cleanup, and persistence paths as those tools.
+
+Cancellation, invalid input, stale state after any `await`, session replacement, and failed persistence or cleanup leave the previous valid runtime and stored state intact.
+
+### Public event API
+
+Add a versioned `pi-subagents:v1` in-process event protocol with `ready`, request, per-request reply, progress, and cancellation channels.
+
+Publish optional TypeScript constants and DTO types from a side-effect-free `@narumitw/pi-subagents/api` subpath, while keeping raw event names documented so consumers in separate managed npm roots are not forced to import the package.
+
+Register API handlers only for a bound `session_start`, clear them on replacement and shutdown, key all work by the active session manager and generation, and reject requests without a current session.
+
+Version 1 supports:
+
+- `ping` for protocol version and capability discovery.
+- `preflight` for one configured leaf agent without child launch, credential resolution, confirmation, settings mutation, or artifact creation.
+- `delegate` for one foreground ephemeral leaf using package-owned discovery, tools, trust, timeout, cancellation, process cleanup, bounds, and usage accounting.
+- `cancel` for one exact in-flight delegate request.
+- `ceiling.register`, `ceiling.update`, and `ceiling.dispose` for trusted in-process policy providers.
+
+Request IDs identify attempts, duplicate active IDs fail closed, one attempt emits at most one terminal reply, and bounded settled/cancelled identity history prevents late duplicate execution.
+
+The first delegation API version always uses the existing isolated subprocess leaf runner and does not expose blocking parallel, chain, aggregator, retained-agent mutation, mailbox, settings, worktree creation, transport selection, or arbitrary tool grants.
+
+### Launch contract and capability ceilings
+
+Extract one pure launch-contract resolver used by preflight and every newly touched launch path.
+
+The contract projects canonical agent identity/source, scope, canonical cwd and trust decision, model/thinking request, timeout, configured and effective tools, extension/resource flags, transport, evidence policy, applicable ceiling sources, and a stable digest without returning system prompts, credentials, environment values, mailbox content, history output, or raw settings.
+
+A capability ceiling may specify `allowedAgents`, `allowedTools`, and `denyExtensions`.
+
+Multiple active ceilings intersect agent and tool sets and OR `denyExtensions`; an explicit empty list denies that capability, while an omitted field does not restrict it.
+
+No registered ceiling means byte-for-byte equivalent launch decisions to the current behavior.
+
+Ceilings affect future blocking launches, consultations, detached spawns, structured delegations, and detached follow-ups.
+
+A detached agent stores its launch-contract digest and effective capability snapshot.
+
+If a later ceiling would narrow a retained agent's existing contract, its follow-up is rejected with an actionable instruction to create a new compliant agent rather than silently reusing a wider in-process or subprocess history.
+
+Ceiling changes never interrupt an active turn, close a retained agent, rewrite settings, or mutate persisted agent definitions.
+
+Project-agent trust and confirmation, cwd policy, consultation's fixed read-only intersection, and the shared-write guard remain authoritative after ceiling application.
+
+### Evidence attestation
+
+Add an optional `evidence: "attested"` request to blocking task shapes, detached spawn, and structured delegation, with omission preserving current prompts and results.
+
+An opted-in child receives a bounded request for a fenced `subagent-evidence` JSON object containing summary, changed files, commands run, test or validation claims, and residual risks.
+
+The runtime parses and bounds the attestation into result details and retained turn metadata without removing or rewriting the child's ordinary output.
+
+Evidence status is `attested`, `missing`, or `invalid`; it never upgrades a claim to runtime-verified, never runs a host command, and never changes execution success into failure in version 1.
+
+Consultation remains unchanged and does not accept evidence mode.
+
+### Lifecycle artifact
+
+Add optional `stateful.lifecycleArtifacts: "metadata"`, defaulting to off.
+
+When enabled at session start, atomically publish one private mode-0600, versioned, bounded metadata projection per owning session at `getAgentDir()/pi-subagents-artifacts/<ownerHash>.json`.
+
+The projection contains agent IDs, names, parent/root relationships, lifecycle states, timestamps, history and unread counts, workspace mode, trust kind, launch-contract digest, evidence status, and omission counts.
+
+The projection excludes tasks, prompts, outputs, errors, mailbox text, context, credentials, environment values, process IDs, and raw filesystem trust-store content.
+
+Artifact writes share the registry's ordered change publication, retain the previous valid file after failure, and finish or cancel before shutdown returns.
+
+Artifact cleanup reuses `stateful.retentionDays`, removes only expired metadata projections during session startup, and never scans or deletes unrelated files.
+
+Disabling future publication does not silently delete existing artifacts; documentation gives the exact cleanup location and retention behavior.
+
+### Source boundaries
+
+- Move completion delivery and message construction from `stateful.ts` into `completion-delivery.ts` before adding API or presentation behavior.
+- Move Current agents menu screens and actions from `config-ui.ts` into `current-agents-ui.ts` before expanding the manager.
+- Add `launch-contract.ts`, `capability-ceiling.ts`, `public-api.ts`, `lifecycle-artifacts.ts`, `fleet-view.ts`, and `evidence.ts` as separate owners.
+- Keep `src/index.ts` a thin default-export forwarder.
+- Keep every hand-written source file at or below 1,000 lines.
+
+## Non-Goals
+
+- Do not copy Nico Bailon's WorkflowScript, mission, schedule, wait, watchdog, acceptance-gate command execution, or giant management action surface.
+- Do not copy tintinweb's full transcript viewer, global arrow-key capture, custom editor behavior, automatic agent fallback, or default-on project-agent discovery.
+- Do not add a new model-facing tool for preflight, API control, fleet navigation, or artifacts.
+- Do not expose full child transcripts, prompts, context, mailbox content, credentials, headers, or environment values through the widget, API, inspection, or artifacts.
+- Do not make evidence attestation a merge gate or claim that child-reported commands were verified.
+- Do not make lifecycle artifacts a general event log or durable job scheduler.
+- Do not make another repository extension depend on `@narumitw/pi-subagents`.
+- Do not publish, tag, change npm visibility, or dispatch a release workflow without separate explicit approval.
+
+## Assumptions
+
+- Existing users value stable tool names, payload compatibility, current defaults, and the absence of unsolicited background UI more than default-on discovery of the new capabilities.
+- A read-only active-agent summary plus manager-based actions provides the useful part of FleetView without global input conflicts.
+- The event bus is process-local and all participating extensions are already fully trusted code.
+- External consumers may use the documented event strings without importing the optional type subpath because Pi user and project package roots can be separate install scopes.
+- The current completion broker already satisfies the requested completion-grouping capability and needs compatibility hardening rather than a second batching implementation.
+- One minor Changeset can describe the additive package behavior if all phases ship in one pull request; split pull requests should carry their own package changesets.
+
+## Risks
+
+- A broad plan can create an oversized pull request, so each phase must remain independently testable and later phases must not begin while a prior checkpoint is failing.
+- Refactoring `stateful.ts` or `config-ui.ts` can introduce behavior drift before features are added, so the extraction phase must be behavior-only and verified against existing tests and snapshots.
+- Capability ceilings can create confusing retained-agent behavior, so the contract digest and explicit follow-up rejection must prevent silent widening or narrowing.
+- Event API cancellation and session replacement can race with child startup, so generation, exact request identity, owned abort controllers, and settled-history bounds must be reviewed together.
+- A preflight contract can become misleading if execution uses a separate resolver, so preflight and delegate must consume the same immutable resolved contract.
+- Evidence text is untrusted child output, so parsing, byte limits, terminal sanitization, persistence, and API projection must all use one bounded representation.
+- Lifecycle artifacts add local disk data and backup/DLP exposure, so they must default off, remain metadata-only, use private permissions, and document cleanup.
+- A persistent widget can conflict with other extension UI or narrow terminals, so it must use a stable key, never capture input, bound every line, and clear exactly its own slot.
+- Public versioned API mistakes become long-lived compatibility obligations, so v1 must stay narrow and receive an independent API/security review before release.
+- Settings changes can race with manual edits or other Pi processes, so every new field must reuse the existing latest-document, lock, unknown-field, and atomic-rename protocol.
+
+## Rollback / Recovery
+
+- Keep each capability behind an absent-compatible optional field, request option, or session-scoped registration so rollback restores the prior runtime without migrating user data.
+- Disable the fleet widget by removing or setting its user field to off; shutdown and replacement clear the widget immediately.
+- Disable lifecycle publication by removing or setting its user field to off; preserve existing artifact files until the user removes the documented directory.
+- Omit `evidence` to retain old prompts, outputs, and persisted turn behavior; older package versions ignore additive optional metadata.
+- Dispose every registered capability ceiling to restore the unrestricted baseline for future launches; active work is never interrupted by rollback.
+- Preserve `pi-subagents:v1` after publication for the documented compatibility window; a later replacement must use a new versioned channel rather than mutating v1.
+- If a phase cannot pass its focused checkpoint, revert only that phase's files and keep the last passing behavior-only seam or shipped feature.
+- Use Git-based recovery for source and lockfile changes, and do not embed rollback scripts in runtime code.
+
+## Plan
+
+### Phase 1: Freeze compatibility and create safe seams
+
+- [x] Add compatibility tests for the seven default tools, every workflow subset, accepted legacy payloads, `/subagents` routes, absent settings defaults, state v1/v2 restore, and `next-turn`/`auto-resume` message details; verify with `npx vitest run packages/pi-subagents/test` and record the baseline test count in this plan.
+- [x] Extract `CompletionDeliveryBroker`, completion DTOs, bounds, and message builders into `packages/pi-subagents/src/completion-delivery.ts` while preserving existing exports and byte-for-byte test expectations; verify with `npx vitest run packages/pi-subagents/test/completion-delivery.test.ts packages/pi-subagents/test/in-process-transport.test.ts`.
+- [x] Extract Current agents screen formatting and actions from `packages/pi-subagents/src/config-ui.ts` into `packages/pi-subagents/src/current-agents-ui.ts` without changing visible rows or behavior; verify with focused manager tests covering clear-all, Escape, Ctrl+C, stale confirmation, session replacement, RPC fallback, and 40/64/100-column rendering.
+- [x] Extract a pure immutable launch-contract resolver from blocking, consultation, and detached launch preparation into `packages/pi-subagents/src/launch-contract.ts`; verify parity tests compare old and resolved cwd, trust, scope, model, thinking, timeout, tools, resources, and transport for trusted, denied, unsaved, malformed, and worktree targets.
+- [x] Run `npm run check:boundaries`, `npm run typecheck`, and the complete pi-subagents test directory as the Phase 1 checkpoint; keep later phases unchecked until this behavior-only checkpoint passes.
+
+### Phase 2: Add the versioned event API and capability ceilings
+
+- [x] Define bounded v1 request, reply, progress, error, cancellation, preflight-contract, delegation-result, and ceiling DTOs plus stable channel constants in side-effect-free `packages/pi-subagents/src/public-api.ts`; verify compile-time fixtures and runtime validation reject unknown methods, oversized strings, malformed DTOs, duplicate IDs, and unsupported fields.
+- [x] Add a session-scoped ceiling registry in `packages/pi-subagents/src/capability-ceiling.ts` with intersection, OR, empty-list, update, dispose, source-bound, generation, and bounded-audit semantics; verify deterministic tests for multiple providers, stale tokens, replacement, shutdown, and no-provider identity behavior.
+- [x] Apply the resolved ceiling after existing trust/discovery policy and before every future blocking, consultation, detached, follow-up, and public delegation launch; verify no-ceiling parity, agent denial, tool intersection, extension denial, consultation non-widening, project trust, write guard, and retained-contract mismatch tests.
+- [x] Register `pi-subagents:v1` handlers from `session_start` and dispose all handlers and owned work on replacement/shutdown; verify ready ordering, filtered/unbound behavior, current-session ownership, cancellation-before-start, cancellation-during-run, late reply suppression, bounded settled history, and exact-once terminal replies.
+- [x] Implement side-effect-free `preflight` through the shared launch resolver and return only the documented safe projection and digest; verify tests prove no child, prompt file, worktree, state record, settings write, credential resolution, lifecycle artifact, confirmation, mailbox read, or provider refresh occurs.
+- [x] Implement one-leaf foreground `delegate` and exact `cancel` through package-owned discovery, launch policy, subprocess cleanup, bounds, usage, and error semantics; verify success, unknown agent, denied target, timeout, abort, provider failure, partial output, tool restriction, project scope, session replacement, and cleanup failure paths.
+- [x] Add `package.json#exports["./api"]` without changing the canonical Pi extension entrypoint, and add package-boundary tests proving the API subpath has no factory side effects; verify with `npm run check:boundaries` and `npm run pack:subagents -- --json`.
+- [x] Run the full pi-subagents suite, typecheck, boundary check, and a deterministic two-extension event-bus harness as the Phase 2 checkpoint; record request/reply and no-ceiling compatibility evidence before continuing.
+
+### Phase 3: Add optional evidence attestation
+
+- [x] Add the optional Google-compatible `evidence: "attested"` field to blocking single/task/chain/aggregator shapes, detached spawn, and public delegation while leaving consultation and existing required fields unchanged; verify schema snapshots and legacy payload tests.
+- [x] Implement one bounded evidence instruction, fenced JSON parser, validator, status model, and safe projection in `packages/pi-subagents/src/evidence.ts`; verify missing, malformed, oversized, duplicate-fence, unknown-field, terminal-control, private-text, changed-file, command, validation, and residual-risk cases.
+- [x] Thread opted-in evidence through blocking details, public delegation replies, detached launch contracts, retained turn metadata, inspection, persistence, and rendering without removing the original child output or changing exit status; verify state v1/v2 compatibility, old-reader tolerance, truncation, and subprocess/in-process parity.
+- [x] Document that evidence is child attestation rather than host verification and add tests proving `attested`, `missing`, and `invalid` never become `verified` and never run commands or fail an otherwise successful child.
+- [x] Run focused evidence, blocking, registry, persistence, inspect, rendering, and transport tests as the Phase 3 checkpoint; record the unchanged no-evidence output fixtures before continuing.
+
+### Phase 4: Add optional bounded lifecycle artifacts
+
+- [x] Add strict normalization, inspection, status, help, and Advanced settings UI for `stateful.lifecycleArtifacts: "off" | "metadata"`, defaulting to off and applying after reload; verify missing-file side effects, latest-document reads, unknown-field preservation, legacy seeding, malformed-file protection, lock ordering, atomic failure, cancellation, and current/configured divergence.
+- [x] Implement the metadata-only versioned projection and private atomic writer in `packages/pi-subagents/src/lifecycle-artifacts.ts`; verify schema bounds, omission counts, mode `0600`, no secret/task/output/mailbox/context leakage, previous-file retention, ordered writes, and retention cleanup.
+- [x] Attach the writer to one session-owned registry generation and flush or cancel it during clear, replacement, failed initialization, and shutdown; verify stale generations cannot publish after a replacement and writer failure cannot poison registry lifecycle or later writes.
+- [x] Expose only the safe artifact path, version, enabled state, last publication status, and bounded error summary through `/subagents status`, `subagent_inspect status`, and API `ping/preflight`; verify terminal sanitization and non-TUI protocol safety.
+- [x] Run settings, persistence, lifecycle, inspection, API, and artifact tests as the Phase 4 checkpoint; inspect generated fixtures to prove excluded content is absent before continuing.
+
+### Phase 5: Add opt-in fleet visibility and manager steering
+
+- [x] Add strict normalization, inspection, immediate runtime application, and Settings UI for `stateful.fleetView: "off" | "active"`, defaulting to off; verify missing and malformed settings, unknown fields, serialization, rollback after persistence/runtime failure, session replacement, shutdown, and current/configured source reporting.
+- [x] Implement `packages/pi-subagents/src/fleet-view.ts` as a read-only `subagents:fleet` below-editor widget with no terminal listener, at most five active rows, an omission count, text state labels, safe task previews, bounded width, callback theme use, invalidation, and disposal; verify empty, disabled, initializing, starting, running, concurrent, omitted, failed-removal, narrow/wide, CJK, terminal-control, theme-change, RPC, JSON, print, replacement, and shutdown behavior.
+- [x] Extend Current agents to a shallow agent list and detail flow that preserves clear-all and adds state-valid follow-up, queue-message, interrupt, close, and subtree actions; verify labels, discoverability, empty/disabled/partial states, destructive summaries, and no hidden route to a core action.
+- [x] Implement follow-up and mailbox inputs with draft preservation and cancellation, and revalidate generation, selected agent identity, state, descendants, write-conflict policy, and trust after every `await`; verify Esc, Ctrl+C, empty input, invalid state, concurrent completion, changed subtree, stale session, and persistence/cleanup failures leave prior state intact.
+- [x] Exercise the manager and widget with keyboard-only deterministic harnesses and a TUI smoke at supported widths; verify focus remains with Pi's editor outside the manager, no keys are intercepted globally, all lines fit, state is not color-only, and widget cleanup owns only `subagents:fleet`.
+- [x] Run all pi-subagents UI, lifecycle, registry, settings, rendering, and non-TUI tests as the Phase 5 checkpoint; record screenshots or captured rows only as supplemental evidence, not as a substitute for assertions.
+
+### Phase 6: Preserve completion grouping and finish integration
+
+- [x] Audit the existing completion broker against the requested grouping behavior and add regression cases for burst boundaries, ordering, simultaneous failures, chunk overflow, active-root holding, pending input, fallback delivery, synchronous reentrancy, replacement, shutdown, and bounded details; verify old single and batch fixtures remain unchanged.
+- [x] Update `packages/pi-subagents/README.md` and add `packages/pi-subagents/docs/event-api.md` to document defaults, opt-ins, API lifecycle, ceiling semantics, fleet states, evidence limitations, artifact privacy/cleanup, compatibility, non-sandbox boundaries, and completion grouping without removing existing guidance.
+- [x] Update `packages/pi-subagents/package.json#files` for published docs and add a minor Changeset covering additive public behavior; verify the manifest still declares exactly `"pi": { "extensions": ["./src/index.ts"] }` and `piExtension.lifecycle: "stable"`.
+- [x] Audit all touched asynchronous flows for user cancellation, component disposal, session replacement, shutdown, generation revalidation, owned-task release, and stale-context use; verify every owned timer, listener, child, widget, writer, request, and temporary file has a tested cleanup path.
+- [x] Audit all settings reads and writes together for ordering, failure recovery, stale reads, invalid-file protection, unknown-field preservation, atomic publication, legacy precedence, and cross-process lock claims; verify against `docs/extension-settings.md` rather than relying on the root check alone.
+- [x] Audit the final diff against every applicable MUST in `docs/extension-conventions.md`, the package `AGENTS.md`, the substantial-experience proposal criteria, and the no-removal compatibility boundary; record any accepted deviation or unverified path in this plan.
+
+## Execution Evidence
+
+- Baseline before implementation: `npx vitest run packages/pi-subagents/test` passed 14 files and 205 tests.
+- Final package verification: `npx vitest run packages/pi-subagents/test` passed 15 files and 217 tests.
+- Package gate: `npm run check --workspace @narumitw/pi-subagents` passed Biome and TypeScript.
+- Repository gate after rebasing onto current `origin/main`: `VITEST_MAX_WORKERS=4 npm run check` passed build, Biome, boundaries, all workspace typechecks, 232 test files, and 2,651 tests.
+- Package smoke: `npm run pack:subagents -- --json` produced a 55-file dry-run tarball containing `src/public-api.ts` and `docs/event-api.md` with no tests, state, lifecycle artifacts, or credentials.
+- Loader smoke: `PI_CODING_AGENT_DIR=<temp> pi --offline --no-extensions -e ./packages/pi-subagents/src/index.ts --list-models` exited successfully, and the deterministic entrypoint test registered exactly the existing seven unique tools while the API import registered none.
+- TDD evidence: the capability-ceiling test first failed because non-boolean `denyExtensions` was accepted, then passed after strict validation was implemented.
+- Lifecycle and race hardening fixed stale API work starting after session replacement, duplicate terminal replies and settled-history growth, stale artifact publication, no-op ceiling follow-up rejection, FleetView persistence/runtime rollback, in-process extension-flag parity, and unbounded persisted capability/evidence metadata.
+- Convention audits covered `docs/extension-conventions.md`, `docs/extension-settings.md`, cancellation, component/widget disposal, session generation, shutdown, settings locks, latest-document writes, invalid-file protection, unknown fields, atomic rename, terminal sanitization, and package boundaries.
+- UX evidence uses deterministic keyboard-only Pi TUI Kit harnesses and cell-width assertions because this execution environment prohibits opening an interactive TUI; no live interactive layout was claimed.
+- No provider-backed delegation smoke was run because deterministic subprocess, transport, protocol, timeout, abort, failure, and cleanup suites cover the changed path without external cost or entitlement variability.
+- No package publication, version tag, npm visibility change, or release workflow occurred.
+
+## Completion Checklist
+
+- [x] Every Plan checkbox is checked with concise command, test, or inspected-artifact evidence, and no failed or unavailable check is represented as passed.
+- [x] `npx vitest run packages/pi-subagents/test` passes all existing and new package tests with the final count recorded.
+- [x] `npm run check --workspace @narumitw/pi-subagents` passes Biome and package typechecking.
+- [x] `VITEST_MAX_WORKERS=4 npm run check` passes the repository CI-equivalent build, Biome, boundaries, workspace typechecks, and tests without running concurrently with a `pi-tui-kit` build.
+- [x] `npm run pack:subagents -- --json` succeeds, and inspection confirms the tarball contains the API subpath, focused docs, all runtime modules, README, manifest, and license with no test fixture, artifact, credential, or state files.
+- [x] A deterministic extension-loader smoke proves the declared entrypoint still registers the expected default seven-tool surface and that importing `@narumitw/pi-subagents/api` alone registers nothing.
+- [x] Not applicable for a live interactive TUI: the non-interactive agent harness must not open a TUI; deterministic Pi TUI Kit keyboard/render tests cover FleetView, manager navigation/actions/cancellation, completion delivery, widths, and cleanup, while an offline real-Pi loader smoke covers the declared entrypoint.
+- [x] Print, JSON, and RPC mode tests prove the widget and manager never invoke TUI-only components or write ad hoc protocol output, while documented status/API responses remain observable through supported channels.
+- [x] Compatibility tests prove old settings files, absent new settings, legacy settings filenames, state v1/v2 records, old tool payloads, command routes, transports, trust rules, completion messages, and default output remain accepted and behaviorally unchanged.
+- [x] Security and privacy review confirms ceilings cannot widen tools, preflight is side-effect free, public delegation cannot bypass trust or write guards, evidence remains untrusted attestation, terminal text is sanitized, and artifacts exclude sensitive content.
+- [x] UX review confirms FleetView is opt-in and non-intercepting, Current agents remains shallow and keyboard-accessible, cancellation is side-effect free, destructive scope is explicit, status is not color-only, and narrow/CJK rendering is bounded.
+- [x] Public API review confirms v1 methods, bounds, exact-once replies, cancellation, generation ownership, error codes, separate-install guidance, and compatibility commitments are documented and tested.
+- [x] The package Changeset accurately describes additive behavior and no publication, tag, npm visibility change, or release workflow has occurred without separate explicit approval.
+- [x] `git diff --check` passes, the final diff contains only intended package, test, documentation, manifest, lockfile-if-required, Changeset, and synchronized plan changes, and no generated runtime artifacts remain.
+- [x] Move this fully evidenced plan to `docs/plans/archived/2026-08-09_pi-subagents-additive-capabilities-plan.md` only after every completion item passes and no required work remains.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -18,7 +18,9 @@ Use it to split independent research, planning, implementation, and review work 
 - Supports built-in `scout`, `planner`, `reviewer`, and `worker` agents.
 - Loads custom user agents from `~/.pi/agent/agents/*.md`.
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
-- Provides a current-session-first `/subagents` manager, direct `settings|status|help` routes, and compatibility aliases for agent tools and retained agents.
+- Provides a current-session-first `/subagents` manager with per-agent follow-up, mailbox, interrupt, close, and subtree actions.
+- Offers an opt-in read-only active-agent FleetView below the editor without capturing terminal input.
+- Exposes an optional versioned `pi-subagents:v1` event API for preflight, one-leaf foreground delegation, cancellation, and session-scoped capability ceilings.
 - Supports trust-aware per-task `cwd` policies, hard subprocess `timeoutMs`, task-selected `thinkingLevel`, abort propagation, and streaming progress.
 - Renders all seven tools with Pi-native compact/expanded transcript rows; long-running blocking and consultation calls show bounded live activity.
 - Bounds JSON lines, captured messages, stderr, final output, chain substitution, and fan-in context.
@@ -361,7 +363,7 @@ Detached-limit saves are durable immediately but apply to the runtime after `/re
 Escape returns from a nested screen to a newly refreshed manager, while Ctrl+C closes the full flow.
 Exact workflow/reload and project-agent safety confirmations remain extension-owned because they guard live agent and trust-boundary policy rather than ordinary navigation.
 
-The direct routes remain predictable: `/subagents settings` changes both target policies, consultation resources, and completion delivery and applies them immediately, including refreshing model-facing tool guidance; `/subagents status` reports current-session runtime values separately from configured values, per-field sources, and path; `/subagents help` summarizes the single-command interface and the non-sandbox limitation. In RPC mode, bare `/subagents` emits the same bounded status through Pi's notification protocol instead of opening a custom TUI. JSON and print modes do not emit ad hoc command output. Manual edits use `~/.pi/agent/pi-subagents.json` and take effect after reloading Pi:
+The direct routes remain predictable: `/subagents settings` changes target policies, consultation resources, completion delivery, FleetView, and lifecycle-artifact publication; launch and FleetView changes apply immediately, while lifecycle artifacts apply after reload; `/subagents status` reports current-session runtime values separately from configured values, per-field sources, and path; `/subagents help` summarizes the single-command interface and the non-sandbox limitation. In RPC mode, bare `/subagents` emits the same bounded status through Pi's notification protocol instead of opening a custom TUI. JSON and print modes do not emit ad hoc command output. Manual edits use `~/.pi/agent/pi-subagents.json` and take effect after reloading Pi:
 
 ```json
 {
@@ -381,7 +383,9 @@ The direct routes remain predictable: `/subagents settings` changes both target 
     "maxMailboxMessageBytes": 16384,
     "idleTtlMs": 3600000,
     "retentionDays": 30,
-    "maxStoredAgents": 50
+    "maxStoredAgents": 50,
+    "fleetView": "off",
+    "lifecycleArtifacts": "off"
   },
   "cwdPolicy": {
     "consultation": "anywhere",
@@ -439,12 +443,25 @@ The action schemas are flat for provider compatibility and reject parameters tha
 }
 ```
 
-Use the **Current agents** action in `/subagents` to inspect the indented agent tree, lifecycle state, unread count, and available actions, or to confirm clearing retained agents.
+Use the **Current agents** action in `/subagents` to select a retained agent, inspect its lifecycle metadata, send a follow-up, queue a mailbox message, interrupt active work, close resources, apply subtree variants, or confirm clearing all retained agents.
+The manager revalidates the selected agent after prompts and confirmations so cancellation, session replacement, and concurrent lifecycle changes do not apply stale actions.
+Set `stateful.fleetView` to `"active"` for an opt-in read-only widget that shows at most five `STARTING` or `RUNNING` agents plus an omission count below the editor.
+FleetView never captures terminal input, clears its own widget slot when empty or disabled, and does not run in RPC, JSON, or print mode.
 Active turns are FIFO-limited by `maxActiveTurns`; excess retained work remains in `starting` state until a slot is available.
 `maxAgents` separately bounds running, queued, and idle records.
 `maxChildrenPerAgent` bounds direct children, while `maxDepth` counts nested levels below a depth-zero root.
 `maxStoredAgents` bounds sanitized records persisted per session and does not increase live runtime capacity.
 `parentId` creates a bounded child relationship; subtree interrupt and close operate child-first.
+
+### Additive event API, ceilings, evidence, and artifacts
+
+The package now provides a process-local `pi-subagents:v1` event API for trusted extensions without adding another model-facing tool.
+Use `ping` for discovery, `preflight` for a side-effect-free launch contract, `delegate` for one foreground ephemeral subprocess leaf, `cancel` for one exact request, and the ceiling methods to narrow future agent, tool, or extension capabilities.
+No registered ceiling preserves the previous launch policy, while multiple ceilings intersect allow-lists and can never bypass project trust, target policy, consultation read-only tools, or shared-write protection.
+Passing `evidence: "attested"` to blocking work, detached spawn, or public delegation asks the child for bounded structured metadata while preserving ordinary output and execution status.
+Evidence is explicitly unverified and reports only `attested`, `missing`, or `invalid`.
+Set `stateful.lifecycleArtifacts` to `"metadata"` and reload to publish a private bounded status projection without task, prompt, output, error, mailbox, context, credential, environment, or process data.
+See [`docs/event-api.md`](./docs/event-api.md) for channels, DTO behavior, cancellation, ceiling semantics, evidence limits, artifact retention, and cleanup.
 
 ### Migrating from the previous seven-tool lifecycle surface
 
@@ -693,6 +710,12 @@ packages/pi-subagents/
 │   ├── cwd-policy.ts             # Canonical target and saved-trust resolution
 │   ├── safe-text.ts              # Shared byte/line/path sanitization
 │   ├── stateful.ts               # Detached lifecycle registration and dispatch
+│   ├── public-api.ts              # Versioned process-local event protocol and DTOs
+│   ├── launch-contract.ts         # Shared safe preflight and execution projection
+│   ├── capability-ceiling.ts      # Session-scoped least-capability intersections
+│   ├── evidence.ts                # Optional bounded child evidence attestation
+│   ├── fleet-view.ts              # Opt-in read-only active-agent widget
+│   ├── lifecycle-artifacts.ts     # Optional private metadata projection
 │   ├── stateful-guidance.ts      # Detached model-facing workflow guidance
 │   ├── stateful-lifecycle.ts     # Runtime disposal and spawn ownership guards
 │   ├── stateful-limit-ui.ts      # Detached capacity settings and recovery previews
@@ -700,16 +723,19 @@ packages/pi-subagents/
 │   ├── stateful-safety.ts        # Project-agent and shared-write safety checks
 │   ├── stateful-tool-params.ts   # Consolidated action schemas and validation
 │   └── *.ts                      # Package-local discovery, execution, rendering, and settings modules
+├── docs/
+│   └── event-api.md              # Public event API, ceilings, evidence, and artifact contract
 ├── README.md
 ├── LICENSE
 ├── tsconfig.json
 └── package.json
 ```
 
-`index.ts` is the Pi entrypoint and forwards to `subagents.ts`; the other source modules are internal.
+`index.ts` is the Pi entrypoint and forwards to `subagents.ts`.
+`public-api.ts` is also published through the side-effect-free `@narumitw/pi-subagents/api` subpath, while the other source modules remain internal.
 Workflow settings remain backward compatible: older files without `blocking.enabled` receive the seven-tool default, and an absent `blocking.maxParallelTasks` keeps the previous eight-worker limit.
 Existing `stateful.enabled: false` files expose blocking delegation plus inspection/consultation.
-Older package releases ignore and preserve the optional `blocking.maxParallelTasks`, `consult`, and `cwdPolicy` fields.
+Older package releases ignore and preserve the optional `blocking.maxParallelTasks`, `consult`, `cwdPolicy`, `stateful.fleetView`, and `stateful.lifecycleArtifacts` fields.
 The package exposes its Pi extension through `package.json`:
 
 ```json

--- a/packages/pi-subagents/docs/event-api.md
+++ b/packages/pi-subagents/docs/event-api.md
@@ -1,0 +1,131 @@
+# pi-subagents event API v1
+
+`@narumitw/pi-subagents` exposes an optional process-local event API for trusted Pi extensions.
+
+The API does not add a model-facing tool and is not a network server.
+
+Pi user and project packages can live in separate npm roots, so consumers may use the channel strings directly instead of importing this package.
+
+Importing `@narumitw/pi-subagents/api` only provides constants, DTO types, and the explicit registration helper; it does not register the extension or any tool.
+
+## Channels
+
+- Request: `pi-subagents:v1:request`.
+- Reply: `pi-subagents:v1:reply`.
+- Progress: `pi-subagents:v1:progress`.
+- Ready: `pi-subagents:v1:ready`.
+
+A consumer should register its `ready` listener before its own `session_start` work, then send requests only after the session's ready event.
+
+Each request has a bounded `requestId`, a `method`, and an optional `payload`.
+
+Request IDs identify one session-local attempt and must not be reused.
+
+One request ID emits at most one terminal reply.
+
+Duplicate active IDs abort the original attempt and fail closed, while duplicates of settled IDs are ignored.
+
+Session replacement and shutdown abort active delegation, dispose listeners, clear capability ceilings, and suppress late replies from the old generation.
+
+## Methods
+
+### `ping`
+
+`ping` returns the protocol name, supported methods, effective capability ceiling, detached runtime status, FleetView mode, and safe lifecycle-artifact status.
+
+### `preflight`
+
+`preflight` accepts one leaf request with `agent` and optional `cwd`, `agentScope`, `thinkingLevel`, `timeoutMs`, `evidence`, and `confirmProjectAgents`.
+
+It returns the exact safe launch projection used by delegation, including effective tools, trust, transport, ceiling sources, and a stable contract digest.
+
+It does not start a child, resolve credentials, create a prompt file or worktree, mutate settings or retained state, request confirmation, or publish an artifact.
+
+### `delegate`
+
+`delegate` accepts the preflight fields plus a required bounded `task`.
+
+Version 1 always runs one foreground ephemeral subprocess leaf.
+
+It does not expose parallel, chain, aggregator, retained-agent mutation, mailbox, settings, worktree creation, transport selection, or arbitrary tool grants.
+
+A trusted project is still required for project-agent scope, and normal target, trust, confirmation, timeout, process cleanup, output, and usage policies remain authoritative.
+
+Project-agent confirmation defaults to enabled, preflight reports when it is required, and a non-UI caller must set `confirmProjectAgents: false` explicitly in a trusted project rather than bypassing confirmation silently.
+
+A protocol-level `ok: true` means delegation completed as a request; child failures remain explicit in the returned bounded `isError` details.
+
+### `cancel`
+
+`cancel` accepts `{ "targetRequestId": "..." }` and aborts that exact active delegation attempt.
+
+A successful cancel reply reports whether the target was active.
+
+### Capability ceiling methods
+
+`ceiling.register` accepts a bounded `source` and a ceiling object, then returns an opaque session-local token.
+
+`ceiling.update` replaces the ceiling associated with that token.
+
+`ceiling.dispose` removes the token.
+
+A ceiling may contain `allowedAgents`, `allowedTools`, and `denyExtensions`.
+
+Multiple providers intersect the agent and tool lists and OR `denyExtensions`.
+
+An omitted list does not restrict that capability, while an explicit empty list denies all entries.
+
+Ceilings only narrow future launches and never bypass project trust, target policy, consultation's read-only tool set, or detached shared-write protection.
+
+Active turns are not interrupted by a later ceiling update.
+
+A retained agent whose stored launch contract is wider than the current ceiling rejects follow-up and must be replaced with a new compliant agent.
+
+## Example
+
+```typescript
+const requestId = crypto.randomUUID();
+
+const dispose = pi.events.on("pi-subagents:v1:reply", (data) => {
+  const reply = data as { requestId?: string; ok?: boolean; result?: unknown };
+  if (reply.requestId !== requestId) return;
+  console.log(reply);
+  dispose();
+});
+
+pi.events.emit("pi-subagents:v1:request", {
+  requestId,
+  method: "preflight",
+  payload: { agent: "scout", agentScope: "user" },
+});
+```
+
+## Evidence attestation
+
+Passing `evidence: "attested"` asks the child to append one bounded `subagent-evidence` JSON block.
+
+The parsed metadata can report a summary, changed files, commands, validation claims, and residual risks.
+
+The status is `attested`, `missing`, or `invalid` and is never described as verified.
+
+The runtime does not execute commands to validate the child's claims and evidence does not change execution success.
+
+## Lifecycle metadata artifact
+
+Set `stateful.lifecycleArtifacts` to `"metadata"` and reload to publish a private versioned projection at `~/.pi/agent/pi-subagents-artifacts/<ownerHash>.json`.
+
+The artifact contains lifecycle relationships, state, counts, trust kind, contract digest, and evidence status.
+
+It excludes tasks, prompts, outputs, errors, mailbox text, context, credentials, environment values, and process IDs.
+
+Files use mode `0600`, atomic replacement, bounded content, and the configured `stateful.retentionDays` cleanup window.
+
+Turning publication off does not delete an existing artifact immediately.
+
+Remove only the `pi-subagents-artifacts` directory when no Pi session is using it if immediate local cleanup is required.
+
+## Trust boundary
+
+The event bus is process-local, but participating extensions are executable trusted code.
+
+This protocol is a coordination and least-capability boundary, not an operating-system sandbox.

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -15,9 +15,15 @@
 	],
 	"files": [
 		"src",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],
+	"exports": {
+		".": "./src/index.ts",
+		"./api": "./src/public-api.ts",
+		"./*": "./*"
+	},
 	"pi": {
 		"extensions": [
 			"./src/index.ts"

--- a/packages/pi-subagents/src/agents.ts
+++ b/packages/pi-subagents/src/agents.ts
@@ -41,6 +41,9 @@ export type SubagentTransportKind = "subprocess" | "in-process";
 
 export type CompletionDelivery = "next-turn" | "auto-resume";
 
+export type FleetViewMode = "off" | "active";
+export type LifecycleArtifactsMode = "off" | "metadata";
+
 export const CONSULT_RESOURCE_POLICIES = ["project-context", "none", "all"] as const;
 
 export type ConsultResourcePolicy = (typeof CONSULT_RESOURCE_POLICIES)[number];
@@ -82,6 +85,8 @@ export interface SubagentRuntimeSettings {
 	idleTtlMs?: number;
 	retentionDays?: number;
 	maxStoredAgents?: number;
+	fleetView?: FleetViewMode;
+	lifecycleArtifacts?: LifecycleArtifactsMode;
 }
 
 export interface SubagentSettings {

--- a/packages/pi-subagents/src/capability-ceiling.ts
+++ b/packages/pi-subagents/src/capability-ceiling.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from "node:crypto";
+
+export interface CapabilityCeiling {
+	allowedAgents?: string[];
+	allowedTools?: string[];
+	denyExtensions?: boolean;
+}
+
+export interface EffectiveCapabilityCeiling extends CapabilityCeiling {
+	sources: string[];
+}
+
+interface RegisteredCeiling {
+	source: string;
+	ceiling: CapabilityCeiling;
+}
+
+export interface CapabilityCeilingAuditEntry {
+	operation: "register" | "update" | "dispose";
+	source: string;
+	at: number;
+}
+
+const MAX_PROVIDERS = 32;
+const MAX_LIST_ITEMS = 256;
+const MAX_NAME_LENGTH = 256;
+const MAX_AUDIT_ENTRIES = 64;
+
+export class CapabilityCeilingRegistry {
+	private readonly providers = new Map<string, RegisteredCeiling>();
+	private readonly auditEntries: CapabilityCeilingAuditEntry[] = [];
+
+	register(source: string, ceiling: CapabilityCeiling): string {
+		if (this.providers.size >= MAX_PROVIDERS) {
+			throw new Error(`Capability ceiling provider limit reached (${MAX_PROVIDERS})`);
+		}
+		const normalizedSource = normalizeName(source, "Capability ceiling source");
+		const token = randomUUID();
+		this.providers.set(token, { source: normalizedSource, ceiling: normalizeCeiling(ceiling) });
+		this.record("register", normalizedSource);
+		return token;
+	}
+
+	update(token: string, ceiling: CapabilityCeiling): void {
+		const provider = this.providers.get(token);
+		if (!provider) throw new Error("Unknown capability ceiling token");
+		provider.ceiling = normalizeCeiling(ceiling);
+		this.record("update", provider.source);
+	}
+
+	dispose(token: string): boolean {
+		const provider = this.providers.get(token);
+		const disposed = this.providers.delete(token);
+		if (provider && disposed) this.record("dispose", provider.source);
+		return disposed;
+	}
+
+	clear(): void {
+		this.providers.clear();
+		this.auditEntries.length = 0;
+	}
+
+	audit(): CapabilityCeilingAuditEntry[] {
+		return this.auditEntries.map((entry) => ({ ...entry }));
+	}
+
+	resolve(): EffectiveCapabilityCeiling {
+		let allowedAgents: Set<string> | undefined;
+		let allowedTools: Set<string> | undefined;
+		let denyExtensions = false;
+		const sources: string[] = [];
+		for (const provider of this.providers.values()) {
+			sources.push(provider.source);
+			allowedAgents = intersect(allowedAgents, provider.ceiling.allowedAgents);
+			allowedTools = intersect(allowedTools, provider.ceiling.allowedTools);
+			denyExtensions ||= provider.ceiling.denyExtensions === true;
+		}
+		return {
+			...(allowedAgents ? { allowedAgents: [...allowedAgents].sort() } : {}),
+			...(allowedTools ? { allowedTools: [...allowedTools].sort() } : {}),
+			...(denyExtensions ? { denyExtensions: true } : {}),
+			sources: [...new Set(sources)].sort(),
+		};
+	}
+
+	private record(operation: CapabilityCeilingAuditEntry["operation"], source: string): void {
+		this.auditEntries.push({ operation, source, at: Date.now() });
+		if (this.auditEntries.length > MAX_AUDIT_ENTRIES) {
+			this.auditEntries.splice(0, this.auditEntries.length - MAX_AUDIT_ENTRIES);
+		}
+	}
+}
+
+export function applyCapabilityCeiling(
+	agentName: string,
+	configuredTools: readonly string[] | undefined,
+	ceiling: EffectiveCapabilityCeiling,
+): { tools?: string[]; disableExtensions?: boolean } {
+	if (ceiling.allowedAgents && !ceiling.allowedAgents.includes(agentName)) {
+		throw new Error(`Subagent ${agentName} is denied by the active capability ceiling`);
+	}
+	let tools = configuredTools ? [...new Set(configuredTools)] : undefined;
+	if (ceiling.allowedTools) {
+		tools = tools
+			? tools.filter((tool) => ceiling.allowedTools?.includes(tool))
+			: [...ceiling.allowedTools];
+	}
+	return {
+		...(tools ? { tools } : {}),
+		...(ceiling.denyExtensions ? { disableExtensions: true } : {}),
+	};
+}
+
+function normalizeCeiling(value: CapabilityCeiling): CapabilityCeiling {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("Capability ceiling must be an object");
+	}
+	if (
+		Object.keys(value).some(
+			(key) => !["allowedAgents", "allowedTools", "denyExtensions"].includes(key),
+		)
+	) {
+		throw new Error("Capability ceiling contains an unsupported field");
+	}
+	if (value.denyExtensions !== undefined && typeof value.denyExtensions !== "boolean") {
+		throw new Error("denyExtensions must be boolean");
+	}
+	return {
+		...(value.allowedAgents !== undefined
+			? { allowedAgents: normalizeList(value.allowedAgents, "allowedAgents") }
+			: {}),
+		...(value.allowedTools !== undefined
+			? { allowedTools: normalizeList(value.allowedTools, "allowedTools") }
+			: {}),
+		...(value.denyExtensions !== undefined
+			? { denyExtensions: value.denyExtensions === true }
+			: {}),
+	};
+}
+
+function normalizeList(value: unknown, label: string): string[] {
+	if (!Array.isArray(value) || value.length > MAX_LIST_ITEMS) {
+		throw new Error(`${label} must be an array with at most ${MAX_LIST_ITEMS} items`);
+	}
+	return [...new Set(value.map((item) => normalizeName(item, label)))];
+}
+
+function normalizeName(value: unknown, label: string): string {
+	if (typeof value !== "string" || !value.trim() || value.length > MAX_NAME_LENGTH) {
+		throw new Error(
+			`${label} entries must be non-empty strings up to ${MAX_NAME_LENGTH} characters`,
+		);
+	}
+	return value.trim();
+}
+
+function intersect(
+	current: Set<string> | undefined,
+	next: string[] | undefined,
+): Set<string> | undefined {
+	if (next === undefined) return current;
+	const nextSet = new Set(next);
+	return current === undefined
+		? nextSet
+		: new Set([...current].filter((item) => nextSet.has(item)));
+}

--- a/packages/pi-subagents/src/completion-delivery.ts
+++ b/packages/pi-subagents/src/completion-delivery.ts
@@ -1,0 +1,226 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { CompletionDelivery } from "./agents.js";
+import { redactPrivateText } from "./context.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import type { AgentTurnCompletion } from "./registry.js";
+
+const MAX_TOOL_MESSAGE_BYTES = 2 * 1024;
+const MAX_COMPLETION_ERROR_BYTES = 512;
+const MAX_COMPLETIONS_PER_MESSAGE = 16;
+const COMPLETION_BATCH_DELAY_MS = 10;
+
+interface CompletionMetadata {
+	agentId: string;
+	agent: string;
+	state: string;
+}
+
+interface CompletionMessage {
+	customType: "pi-subagent-completion";
+	content: string;
+	display: true;
+	details:
+		| CompletionMetadata
+		| {
+				completionCount: number;
+				completions: CompletionMetadata[];
+		  };
+}
+
+type CompletionContext = Pick<ExtensionContext, "hasPendingMessages" | "isIdle">;
+type CompletionPi = Pick<ExtensionAPI, "sendMessage">;
+
+export interface CompletionDeliveryBrokerOptions {
+	onDeliveryError?: (error: unknown) => void;
+}
+
+/**
+ * Coalesces detached completions so one bounded notification batch starts at
+ * most one root synthesis turn. The broker belongs to one parent session and
+ * must be closed when that session is replaced or shut down.
+ */
+export class CompletionDeliveryBroker {
+	private pending: AgentTurnCompletion[] = [];
+	private flushTimer?: NodeJS.Timeout;
+	private wakeInFlight = false;
+	private closed = false;
+
+	constructor(
+		private readonly pi: CompletionPi,
+		private readonly ctx: CompletionContext,
+		private delivery: CompletionDelivery,
+		private readonly options: CompletionDeliveryBrokerOptions = {},
+	) {}
+
+	enqueue(completion: AgentTurnCompletion): void {
+		if (this.closed) return;
+		this.pending.push(completion);
+		this.scheduleFlush();
+	}
+
+	setDelivery(value: CompletionDelivery): void {
+		this.delivery = value;
+		this.scheduleFlush();
+	}
+
+	onParentTurnStart(): void {
+		this.wakeInFlight = false;
+		this.scheduleFlush();
+	}
+
+	onParentSettled(): void {
+		this.wakeInFlight = false;
+		this.scheduleFlush();
+	}
+
+	flush(): void {
+		if (this.closed || this.pending.length === 0) return;
+		if (this.flushTimer) clearTimeout(this.flushTimer);
+		this.flushTimer = undefined;
+		if (this.delivery === "auto-resume" && !this.isRootIdle()) return;
+
+		const completions = this.pending.splice(0);
+		const batches = chunkCompletions(completions);
+		let canWake = this.shouldWakeRoot();
+		for (let index = 0; index < batches.length; index++) {
+			const triggerTurn = canWake && index === batches.length - 1;
+			const message = buildCompletionMessage(batches[index]);
+			if (triggerTurn) this.wakeInFlight = true;
+			try {
+				this.pi.sendMessage(message, { deliverAs: "steer", triggerTurn });
+			} catch (primaryError) {
+				if (triggerTurn) this.wakeInFlight = false;
+				canWake = false;
+				try {
+					this.pi.sendMessage(message, { deliverAs: "nextTurn", triggerTurn: false });
+				} catch (fallbackError) {
+					this.pending = [...batches.slice(index).flat(), ...this.pending];
+					try {
+						this.options.onDeliveryError?.(
+							new AggregateError(
+								[primaryError, fallbackError],
+								"Detached subagent completion delivery failed",
+							),
+						);
+					} catch {
+						// Delivery retention must survive a failing observer.
+					}
+					return;
+				}
+			}
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+		if (this.flushTimer) clearTimeout(this.flushTimer);
+		this.flushTimer = undefined;
+		this.pending = [];
+	}
+
+	private scheduleFlush(): void {
+		if (this.closed || this.pending.length === 0 || this.flushTimer) return;
+		this.flushTimer = setTimeout(() => {
+			this.flushTimer = undefined;
+			this.flush();
+		}, COMPLETION_BATCH_DELAY_MS);
+	}
+
+	private isRootIdle(): boolean {
+		try {
+			return this.ctx.isIdle();
+		} catch {
+			return false;
+		}
+	}
+
+	private shouldWakeRoot(): boolean {
+		if (this.delivery !== "auto-resume" || this.wakeInFlight) return false;
+		try {
+			return !this.ctx.hasPendingMessages();
+		} catch {
+			return false;
+		}
+	}
+}
+
+function chunkCompletions(completions: AgentTurnCompletion[]): AgentTurnCompletion[][] {
+	const batches: AgentTurnCompletion[][] = [];
+	for (let index = 0; index < completions.length; index += MAX_COMPLETIONS_PER_MESSAGE) {
+		batches.push(completions.slice(index, index + MAX_COMPLETIONS_PER_MESSAGE));
+	}
+	return batches;
+}
+
+function buildCompletionMessage(completions: AgentTurnCompletion[]): CompletionMessage {
+	if (completions.length === 1) {
+		const completion = completions[0];
+		return {
+			customType: "pi-subagent-completion",
+			content: buildDetachedCompletionMessage(completion),
+			display: true,
+			details: completionMetadata(completion),
+		};
+	}
+	const content = truncateUtf8(
+		[
+			"Message Type: SUBAGENT_COMPLETION_BATCH",
+			`Completion Count: ${completions.length}`,
+			...completions.flatMap((completion, index) => [
+				"",
+				`--- Completion ${index + 1} of ${completions.length} ---`,
+				buildDetachedCompletionMessage(completion),
+			]),
+		].join("\n"),
+		DEFAULT_MAX_CONTEXT_BYTES,
+	).text;
+	return {
+		customType: "pi-subagent-completion",
+		content,
+		display: true,
+		details: {
+			completionCount: completions.length,
+			completions: completions.map(completionMetadata),
+		},
+	};
+}
+
+function completionMetadata(completion: AgentTurnCompletion): CompletionMetadata {
+	return {
+		agentId: completion.agent.id,
+		agent: completion.agent.agent,
+		state: completion.agent.state,
+	};
+}
+
+export function buildDetachedCompletionMessage(completion: AgentTurnCompletion): string {
+	const task = sanitizeCompletionLine(completion.task, 256) || "(unknown task)";
+	const agentName = sanitizeCompletionLine(completion.agent.agent, 128) || "(unknown agent)";
+	const output = redactPrivateText(completion.output);
+	const error = completion.error
+		? truncateUtf8(redactPrivateText(completion.error), MAX_COMPLETION_ERROR_BYTES).text
+		: "";
+	return truncateUtf8(
+		[
+			"Message Type: SUBAGENT_COMPLETION",
+			`Agent ID: ${completion.agent.id}`,
+			`Agent: ${agentName}`,
+			`Task: ${task}`,
+			`State: ${completion.agent.state}`,
+			...(error.trim() ? ["Error:", error] : []),
+			"Payload:",
+			output.trim() ? output : "(no output)",
+		].join("\n"),
+		MAX_TOOL_MESSAGE_BYTES,
+	).text;
+}
+
+function sanitizeCompletionLine(value: string, maxBytes: number): string {
+	return (
+		truncateUtf8(redactPrivateText(value), maxBytes)
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: Strip untrusted terminal controls.
+			.text.replace(/[\u0000-\u001f\u007f]+/g, " ")
+			.replace(/\s+/g, " ")
+			.trim()
+	);
+}

--- a/packages/pi-subagents/src/config-status.ts
+++ b/packages/pi-subagents/src/config-status.ts
@@ -1,0 +1,246 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type {
+	CompletionDelivery,
+	ConsultationCwdPolicy,
+	ConsultResourcePolicy,
+	DelegationCwdPolicy,
+	FleetViewMode,
+	LifecycleArtifactsMode,
+} from "./agents.js";
+import type { SubagentSettingsRuntime } from "./config-ui.js";
+import { safeTerminalLine as safeTerminalText } from "./safe-text.js";
+import {
+	type DelegationWorkflow,
+	inspectBlockingParallelLimitSettings,
+	inspectCompletionDeliverySettings,
+	inspectConsultResourceSettings,
+	inspectCwdPolicySettings,
+	inspectDelegationWorkflowSettings,
+	inspectLifecycleArtifactSettings,
+	inspectStatefulLimitSettings,
+} from "./settings.js";
+import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
+import {
+	formatConfiguredDetachedLimitDivergence,
+	formatConfiguredDetachedLimits,
+	formatDetachedLimitSummary,
+} from "./stateful-limit-ui.js";
+import { STATEFUL_LIMIT_DEFINITIONS } from "./stateful-limits.js";
+import { workflowLabel } from "./workflow-ui.js";
+
+export function showSubagentStatus(ctx: ExtensionCommandContext, runtime: SubagentSettingsRuntime) {
+	if (ctx.mode !== "tui" && !ctx.hasUI) return;
+	const snapshot = inspectCompletionDeliverySettings();
+	ctx.ui.notify(
+		formatStatus(runtime.getRuntimeStatus(), snapshot, runtime),
+		snapshot.error ? "warning" : "info",
+	);
+}
+
+export function showSubagentHelp(ctx: ExtensionCommandContext, runtime: SubagentSettingsRuntime) {
+	if (ctx.mode !== "tui" && !ctx.hasUI) return;
+	ctx.ui.notify(helpLines(runtime).join("\n"), "info");
+}
+
+export function statusLines(runtime: SubagentSettingsRuntime): string[] {
+	const snapshot = inspectCompletionDeliverySettings();
+	return formatStatus(runtime.getRuntimeStatus(), snapshot, runtime).split("\n");
+}
+
+export function helpLines(runtime: SubagentSettingsRuntime): string[] {
+	const snapshot = inspectCompletionDeliverySettings();
+	const cwdPolicy = inspectCwdPolicySettings();
+	const parallelLimit = inspectBlockingParallelLimitSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
+	return [
+		"/subagents — choose delegation workflow, manage current agents, and configure agent tools",
+		"/subagents settings — configure target locations, trusted resources, and async completion",
+		"/subagents status — show current-session and user-setting values",
+		"/subagents help — show this help",
+		"Target policies control startup directories and resources, not filesystem access or sandboxing.",
+		"Manage saved folder trust with Pi /trust and restart Pi after changing it.",
+		`Runtime consultation target: ${consultationCwdLabel(runtime.getConsultationCwdPolicy())}`,
+		`Configured consultation target: ${consultationCwdLabel(cwdPolicy.consultation.value)} (${cwdPolicy.consultation.source})`,
+		`Runtime delegation target: ${delegationCwdLabel(runtime.getDelegationCwdPolicy())}`,
+		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} (${cwdPolicy.delegation.source})`,
+		`Maximum parallel workers: ${runtime.getMaxParallelTasks()} per blocking call`,
+		`Configured parallel limit: ${parallelLimit.value} (${parallelLimit.source})`,
+		`Detached limits: ${formatDetachedLimitSummary(runtime.getRuntimeStatus())}`,
+		`FleetView: ${fleetViewLabel(runtime.getFleetView?.() ?? "off")}`,
+		`Lifecycle artifact: ${lifecycleArtifactLabel(inspectLifecycleArtifactSettings().value)} (after reload)`,
+		...(detachedLimits.values
+			? [`Configured detached limits: ${formatConfiguredDetachedLimits(detachedLimits.values)}`]
+			: ["Configured detached limits: unavailable; repair user settings"]),
+		"Detached limits apply after /reload; clear retained agents first if their work must not be interrupted.",
+		`User settings: ${safeTerminalText(snapshot.path)}`,
+	];
+}
+
+export function formatManagerSummary(
+	runtime: SubagentSettingsRuntime,
+	status: StatefulSubagentRuntimeStatus,
+	configured: ReturnType<typeof inspectDelegationWorkflowSettings>,
+): string {
+	const current = currentWorkflow(runtime, status);
+	const cwdPolicy = inspectCwdPolicySettings();
+	const consult = inspectConsultResourceSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
+	const detachedDivergence = detachedLimits.values
+		? formatConfiguredDetachedLimitDivergence(status, detachedLimits.values)
+		: undefined;
+	const lifecycleArtifact = runtime.getLifecycleArtifactStatus?.() ?? {
+		enabled: false,
+		version: 1,
+	};
+	return [
+		`Delegation: ${workflowLabel(current)}`,
+		`Completion: ${completionLabel(status.completionDelivery)}`,
+		`Consult target: ${consultationCwdLabel(runtime.getConsultationCwdPolicy())}`,
+		`Delegation target: ${delegationCwdLabel(runtime.getDelegationCwdPolicy())}`,
+		`Consult resources: ${consultResourceLabel(runtime.getConsultResourcePolicy())}`,
+		`Parallel workers: max ${runtime.getMaxParallelTasks()} per blocking call`,
+		`Detached limits: ${formatDetachedLimitSummary(status)}`,
+		`FleetView: ${fleetViewLabel(runtime.getFleetView?.() ?? "off")}`,
+		`Lifecycle artifact: ${lifecycleArtifact.enabled ? "metadata" : "off"}`,
+		`Configured consult target: ${consultationCwdLabel(cwdPolicy.consultation.value)} · ${cwdPolicy.consultation.source}`,
+		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} · ${cwdPolicy.delegation.source}`,
+		`Configured consult resources: ${consultResourceLabel(consult.value)} · ${consult.source}`,
+		`Settings: ${safeTerminalText(cwdPolicy.path)}`,
+		`Agents: ${status.activeAgents} active · ${status.retainedAgents} retained`,
+		...(detachedDivergence ? [detachedDivergence] : []),
+		...(configured.value !== current
+			? [`Configured after reload: ${workflowLabel(configured.value)}`]
+			: []),
+		...(configured.error || detachedLimits.error
+			? ["Settings need repair; open Advanced settings for details."]
+			: []),
+	].join("\n");
+}
+
+export function formatStatus(
+	status: StatefulSubagentRuntimeStatus,
+	snapshot: ReturnType<typeof inspectCompletionDeliverySettings>,
+	runtime?: SubagentSettingsRuntime,
+): string {
+	const configuredWorkflow = inspectDelegationWorkflowSettings();
+	const consult = inspectConsultResourceSettings();
+	const cwdPolicy = inspectCwdPolicySettings();
+	const parallelLimit = inspectBlockingParallelLimitSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
+	const current = runtime ? currentWorkflow(runtime, status) : configuredWorkflow.value;
+	const fleetView = runtime?.getFleetView?.() ?? "off";
+	const lifecycleArtifact = runtime?.getLifecycleArtifactStatus?.() ?? {
+		enabled: false,
+		version: 1,
+	};
+	return [
+		"Current session",
+		`  Delegation: ${workflowLabel(current)}`,
+		`  Async runtime: ${status.initialized ? "initialized" : status.enabled ? "not initialized" : "disabled"}`,
+		`  Transport: ${status.transport}`,
+		`  Completion: ${completionLabel(status.completionDelivery)}`,
+		`  Consultation target: ${consultationCwdLabel(runtime?.getConsultationCwdPolicy() ?? cwdPolicy.consultation.value)}`,
+		`  Delegation target: ${delegationCwdLabel(runtime?.getDelegationCwdPolicy() ?? cwdPolicy.delegation.value)}`,
+		`  Consultation resources: ${consultResourceLabel(runtime?.getConsultResourcePolicy() ?? consult.value)}`,
+		`  Maximum parallel workers: ${runtime?.getMaxParallelTasks() ?? parallelLimit.value} per blocking call`,
+		`  Detached limits: ${formatDetachedLimitSummary(status)}`,
+		`  FleetView: ${fleetViewLabel(fleetView)}`,
+		`  Lifecycle artifact: ${lifecycleArtifact.enabled ? "metadata" : "off"}`,
+		...(lifecycleArtifact.path
+			? [`  Lifecycle artifact path: ${safeTerminalText(lifecycleArtifact.path)}`]
+			: []),
+		...(lifecycleArtifact.error
+			? [`  Lifecycle artifact warning: ${safeTerminalText(lifecycleArtifact.error)}`]
+			: []),
+		`  Agents: ${status.activeAgents} active, ${status.retainedAgents} retained`,
+		"User settings",
+		`  Delegation source: ${configuredWorkflow.source}`,
+		`  Configured delegation: ${workflowLabel(configuredWorkflow.value)}`,
+		`  Completion source: ${snapshot.source}`,
+		`  Configured completion: ${completionLabel(snapshot.value)}`,
+		`  Configured parallel limit: ${parallelLimit.value}`,
+		`  Parallel limit source: ${parallelLimit.source}`,
+		...(detachedLimits.values
+			? STATEFUL_LIMIT_DEFINITIONS.map((definition) => {
+					const configured = detachedLimits.values?.[definition.field];
+					return `  Configured ${definition.label.toLowerCase()}: ${configured?.value} (${configured?.source})`;
+				})
+			: ["  Configured detached limits: unavailable"]),
+		`  Configured consultation target: ${consultationCwdLabel(cwdPolicy.consultation.value)}`,
+		`  Consultation target source: ${cwdPolicy.consultation.source}`,
+		`  Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)}`,
+		`  Delegation target source: ${cwdPolicy.delegation.source}`,
+		`  Configured consultation resources: ${consultResourceLabel(consult.value)}`,
+		`  Consultation resource source: ${consult.source}`,
+		`  Path: ${safeTerminalText(snapshot.path)}`,
+		configuredWorkflow.error ||
+		snapshot.error ||
+		cwdPolicy.error ||
+		parallelLimit.error ||
+		detachedLimits.error
+			? `  Warning: ${safeTerminalText(configuredWorkflow.error ?? snapshot.error ?? cwdPolicy.error ?? parallelLimit.error ?? detachedLimits.error ?? "invalid settings")}`
+			: "  Warning: none",
+		configuredWorkflow.value !== current
+			? "Configured delegation differs from this session. Run /reload to apply it."
+			: "Manual file changes require /reload.",
+	].join("\n");
+}
+
+export function currentWorkflow(
+	runtime: SubagentSettingsRuntime,
+	status: StatefulSubagentRuntimeStatus,
+): DelegationWorkflow {
+	const blocking = runtime.getBlockingEnabled();
+	if (blocking && status.enabled) return "all";
+	if (status.enabled) return "async-only";
+	if (blocking) return "blocking-only";
+	return "disabled";
+}
+
+export function isWorkflow(value: string): value is Exclude<DelegationWorkflow, "disabled"> {
+	return value === "all" || value === "async-only" || value === "blocking-only";
+}
+
+export function completionLabel(value: CompletionDelivery): string {
+	return value === "auto-resume" ? "Resume automatically when finished" : "Wait until my next turn";
+}
+
+export function fleetViewLabel(value: FleetViewMode): string {
+	return value === "active" ? "Show active agents" : "Off";
+}
+
+export function lifecycleArtifactLabel(value: LifecycleArtifactsMode): string {
+	return value === "metadata" ? "Metadata after reload" : "Off";
+}
+
+export function consultationCwdLabel(value: ConsultationCwdPolicy): string {
+	return value === "current-workspace"
+		? "Current workspace only"
+		: "Anywhere · untrusted targets inherit nothing";
+}
+
+export function delegationCwdLabel(value: DelegationCwdPolicy): string {
+	switch (value) {
+		case "trusted-targets":
+			return "Current or saved-trusted folders";
+		case "current-workspace":
+			return "Current workspace only";
+		case "anywhere":
+			return "Anywhere · normal Pi permissions";
+	}
+}
+
+export function consultResourceLabel(value: ConsultResourcePolicy): string {
+	switch (value) {
+		case "project-context":
+			return "Project context only";
+		case "none":
+			return "No inherited resources";
+		case "all":
+			return "All trusted resources";
+	}
+}
+
+export function formatError(error: unknown): string {
+	return safeTerminalText(error instanceof Error ? error.message : String(error));
+}

--- a/packages/pi-subagents/src/config-ui.ts
+++ b/packages/pi-subagents/src/config-ui.ts
@@ -5,7 +5,26 @@ import {
 	type ConsultResourcePolicy,
 	type DelegationCwdPolicy,
 	discoverAgents,
+	type FleetViewMode,
+	type LifecycleArtifactsMode,
 } from "./agents.js";
+import {
+	completionLabel,
+	consultationCwdLabel,
+	consultResourceLabel,
+	currentWorkflow,
+	delegationCwdLabel,
+	fleetViewLabel,
+	formatError,
+	formatManagerSummary,
+	helpLines,
+	isWorkflow,
+	lifecycleArtifactLabel,
+	showSubagentHelp,
+	showSubagentStatus,
+	statusLines,
+} from "./config-status.js";
+import { currentAgentDetailScreen, currentAgentsScreen } from "./current-agents-ui.js";
 import {
 	applyBlockingParallelLimitSetting,
 	blockingParallelLimitScreen,
@@ -13,14 +32,14 @@ import {
 import type { ManagedAgent } from "./registry.js";
 import { safeTerminalLine as safeTerminalText } from "./safe-text.js";
 import {
-	type DelegationWorkflow,
 	hasOwn,
 	inspectBlockingParallelLimitSettings,
 	inspectCompletionDeliverySettings,
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
 	inspectDelegationWorkflowSettings,
-	inspectStatefulLimitSettings,
+	inspectFleetViewSettings,
+	inspectLifecycleArtifactSettings,
 	readSubagentSettings,
 	sameToolSet,
 	uniqueToolNames,
@@ -29,22 +48,17 @@ import {
 	updateConsultResourceSetting,
 	updateCwdPolicySetting,
 	updateDelegationWorkflowSetting,
+	updateFleetViewSetting,
+	updateLifecycleArtifactSetting,
 } from "./settings.js";
-import { formatStatefulAgentLine, type StatefulSubagentRuntimeStatus } from "./stateful.js";
+import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
 import {
 	applyStatefulLimitSetting,
-	formatConfiguredDetachedLimitDivergence,
-	formatConfiguredDetachedLimits,
 	formatDetachedLimitSummary,
-	formatEmptyStatefulRuntime,
 	statefulLimitInputScreen,
 	statefulLimitListScreen,
 } from "./stateful-limit-ui.js";
-import {
-	isStatefulLimitField,
-	STATEFUL_LIMIT_DEFINITIONS,
-	type StatefulLimitField,
-} from "./stateful-limits.js";
+import { isStatefulLimitField, type StatefulLimitField } from "./stateful-limits.js";
 import { showWorkflowPreview, workflowLabel } from "./workflow-ui.js";
 
 const SUBCOMMANDS = [
@@ -67,7 +81,24 @@ export interface SubagentSettingsRuntime {
 	setConsultationCwdPolicy(value: ConsultationCwdPolicy): void;
 	setDelegationCwdPolicy(value: DelegationCwdPolicy): void;
 	getRuntimeStatus(): StatefulSubagentRuntimeStatus;
+	getFleetView?(): FleetViewMode;
+	getLifecycleArtifactStatus?(): {
+		enabled: boolean;
+		version: number;
+		path?: string;
+		error?: string;
+	};
+	setFleetView?(value: FleetViewMode): void;
 	listAgents(includeClosed?: boolean): ManagedAgent[];
+	followUp?(
+		agentId: string,
+		task: string,
+		ctx: ExtensionCommandContext,
+		signal?: AbortSignal,
+	): Promise<ManagedAgent>;
+	queueMessage?(agentId: string, message: string): Promise<void>;
+	interruptAgent?(agentId: string, subtree?: boolean): Promise<number>;
+	closeAgent?(agentId: string, subtree?: boolean): Promise<number>;
 	clearAgents(): Promise<number>;
 }
 
@@ -160,11 +191,13 @@ async function showSubagentManager(
 	if (!isCurrent()) return;
 	let availableAgents = discoverAgents(ctx.cwd, "user", readSubagentSettings() ?? {}).agents;
 	let toolDraft: ToolDraft | undefined;
+	let selectedAgentId: string | undefined;
 	let selectedStatefulLimit: StatefulLimitField = "maxAgents";
 	type Screen =
 		| "main"
 		| "workflow"
 		| "agents"
+		| "agent-detail"
 		| "settings"
 		| "advanced"
 		| "parallel-limit"
@@ -176,11 +209,20 @@ async function showSubagentManager(
 		| "tool-draft";
 	type Action =
 		| "set-workflow"
+		| "select-agent"
+		| "agent-follow-up"
+		| "agent-queue-message"
+		| "agent-interrupt"
+		| "agent-interrupt-tree"
+		| "agent-close"
+		| "agent-close-tree"
 		| "clear-agents"
 		| "set-parallel-limit"
 		| "pick-stateful-limit"
 		| "set-stateful-limit"
 		| "set-completion"
+		| "set-fleet-view"
+		| "set-lifecycle-artifacts"
 		| "set-consult-resources"
 		| "set-consultation-cwd"
 		| "set-delegation-cwd"
@@ -273,31 +315,8 @@ async function showSubagentManager(
 					hint: "back",
 				};
 			},
-			agents: () => {
-				const agents = runtime.listAgents();
-				const status = runtime.getRuntimeStatus();
-				return {
-					kind: "actions",
-					title: "Current-session Subagents",
-					lines: agents.length
-						? agents.map(formatStatefulAgentLine)
-						: [formatEmptyStatefulRuntime(status)],
-					items: [
-						...(agents.length > 0
-							? [
-									{
-										id: "clear",
-										label: "Clear current-session agents",
-										description: "Close and delete retained agents for this session",
-										action: "clear-agents" as const,
-									},
-								]
-							: []),
-						{ id: "back", label: "Back", action: "back" },
-					],
-					hint: "back",
-				};
-			},
+			agents: () => currentAgentsScreen(runtime),
+			"agent-detail": () => currentAgentDetailScreen(runtime, selectedAgentId),
 			settings: () => subagentSettingsScreen(runtime),
 			advanced: () => {
 				const limit = inspectBlockingParallelLimitSettings();
@@ -457,6 +476,53 @@ async function showSubagentManager(
 				await ctx.reload();
 				return { kind: "close" };
 			},
+			"select-agent": async ({ itemId }) => {
+				if (!runtime.listAgents(true).some((agent) => agent.id === itemId)) {
+					return { kind: "rejected" };
+				}
+				selectedAgentId = itemId;
+				return { kind: "to", screen: "agent-detail" };
+			},
+			"agent-follow-up": async ({ signal }) => {
+				if (!selectedAgentId || !runtime.followUp) return { kind: "rejected" };
+				const task = await ctx.ui.input("Send subagent follow-up", "Describe the next task", {
+					signal,
+				});
+				if (signal.aborted || !isCurrent()) return { kind: "close" };
+				if (!task?.trim()) return { kind: "rejected" };
+				try {
+					await runtime.followUp(selectedAgentId, task, ctx, signal);
+					if (signal.aborted || !isCurrent()) return { kind: "close" };
+					ctx.ui.notify("Subagent follow-up started.", "info");
+					return { kind: "stay" };
+				} catch (error) {
+					ctx.ui.notify(`Follow-up was not started: ${formatError(error)}`, "error");
+					return { kind: "rejected" };
+				}
+			},
+			"agent-queue-message": async ({ signal }) => {
+				if (!selectedAgentId || !runtime.queueMessage) return { kind: "rejected" };
+				const message = await ctx.ui.input("Queue mailbox message", "Message for the subagent", {
+					signal,
+				});
+				if (signal.aborted || !isCurrent()) return { kind: "close" };
+				if (!message?.trim()) return { kind: "rejected" };
+				try {
+					await runtime.queueMessage(selectedAgentId, message);
+					if (signal.aborted || !isCurrent()) return { kind: "close" };
+					ctx.ui.notify("Mailbox message queued.", "info");
+					return { kind: "stay" };
+				} catch (error) {
+					ctx.ui.notify(`Mailbox message was not queued: ${formatError(error)}`, "error");
+					return { kind: "rejected" };
+				}
+			},
+			"agent-interrupt": async () => applyAgentInterrupt(runtime, selectedAgentId, false, ctx),
+			"agent-interrupt-tree": async () => applyAgentInterrupt(runtime, selectedAgentId, true, ctx),
+			"agent-close": async ({ signal }) =>
+				applyAgentClose(runtime, selectedAgentId, false, ctx, signal, isCurrent),
+			"agent-close-tree": async ({ signal }) =>
+				applyAgentClose(runtime, selectedAgentId, true, ctx, signal, isCurrent),
 			"clear-agents": async ({ signal }) => {
 				const agents = runtime.listAgents();
 				if (agents.length === 0) return { kind: "stay" };
@@ -500,6 +566,8 @@ async function showSubagentManager(
 					isCurrent,
 				}),
 			"set-completion": async ({ value }) => applyCompletionSetting(value, ctx, runtime),
+			"set-fleet-view": async ({ value }) => applyFleetViewSetting(value, ctx, runtime),
+			"set-lifecycle-artifacts": async ({ value }) => applyLifecycleArtifactSetting(value, ctx),
 			"set-consult-resources": async ({ value }) =>
 				applyConsultResourceSetting(value, ctx, runtime),
 			"set-consultation-cwd": async ({ value }) => applyConsultationCwdSetting(value, ctx, runtime),
@@ -600,6 +668,8 @@ async function showSubagentSettings(
 	if (!isCurrent()) return;
 	type SettingsAction =
 		| "set-completion"
+		| "set-fleet-view"
+		| "set-lifecycle-artifacts"
 		| "set-consult-resources"
 		| "set-consultation-cwd"
 		| "set-delegation-cwd";
@@ -608,6 +678,8 @@ async function showSubagentSettings(
 		screens: { settings: () => subagentSettingsScreen(runtime) },
 		actions: {
 			"set-completion": async ({ value }) => applyCompletionSetting(value, ctx, runtime),
+			"set-fleet-view": async ({ value }) => applyFleetViewSetting(value, ctx, runtime),
+			"set-lifecycle-artifacts": async ({ value }) => applyLifecycleArtifactSetting(value, ctx),
 			"set-consult-resources": async ({ value }) =>
 				applyConsultResourceSetting(value, ctx, runtime),
 			"set-consultation-cwd": async ({ value }) => applyConsultationCwdSetting(value, ctx, runtime),
@@ -623,9 +695,12 @@ async function showSubagentSettings(
 
 function subagentSettingsScreen(runtime: SubagentSettingsRuntime) {
 	const completion = inspectCompletionDeliverySettings();
+	const fleet = inspectFleetViewSettings();
+	const artifacts = inspectLifecycleArtifactSettings();
 	const consult = inspectConsultResourceSettings();
 	const cwdPolicy = inspectCwdPolicySettings();
-	const error = completion.error ?? consult.error ?? cwdPolicy.error;
+	const error =
+		completion.error ?? fleet.error ?? artifacts.error ?? consult.error ?? cwdPolicy.error;
 	return {
 		kind: "settings" as const,
 		title: error ? "Subagent User Settings · Read only" : "Subagent User Settings",
@@ -679,8 +754,88 @@ function subagentSettingsScreen(runtime: SubagentSettingsRuntime) {
 						values: ["Wait until my next turn", "Resume automatically when finished"],
 						action: "set-completion" as const,
 					},
+					{
+						id: "fleetView",
+						label: "Active-agent FleetView",
+						description: "Show a read-only status widget below the editor without capturing keys.",
+						currentValue: fleetViewLabel(runtime.getFleetView?.() ?? "off"),
+						values: ["Off", "Show active agents"],
+						action: "set-fleet-view" as const,
+					},
+					{
+						id: "lifecycleArtifacts",
+						label: "Lifecycle metadata artifact",
+						description: "Publish bounded metadata after reload; excludes tasks and outputs.",
+						currentValue: lifecycleArtifactLabel(artifacts.value),
+						values: ["Off", "Metadata after reload"],
+						action: "set-lifecycle-artifacts" as const,
+					},
 				],
 	};
+}
+
+async function applyAgentInterrupt(
+	runtime: SubagentSettingsRuntime,
+	agentId: string | undefined,
+	subtree: boolean,
+	ctx: ExtensionCommandContext,
+) {
+	if (!agentId || !runtime.interruptAgent) return { kind: "rejected" as const };
+	try {
+		const count = await runtime.interruptAgent(agentId, subtree);
+		ctx.ui.notify(`Interrupted ${count} active subagent${count === 1 ? "" : "s"}.`, "info");
+		return { kind: "stay" as const };
+	} catch (error) {
+		ctx.ui.notify(`Subagent was not interrupted: ${formatError(error)}`, "error");
+		return { kind: "rejected" as const };
+	}
+}
+
+async function applyAgentClose(
+	runtime: SubagentSettingsRuntime,
+	agentId: string | undefined,
+	subtree: boolean,
+	ctx: ExtensionCommandContext,
+	signal: AbortSignal,
+	isCurrent: () => boolean,
+) {
+	if (!agentId || !runtime.closeAgent) return { kind: "rejected" as const };
+	const before = runtime.listAgents(true).find((agent) => agent.id === agentId);
+	if (!before) return { kind: "rejected" as const };
+	const count = subtree ? countSubtree(runtime.listAgents(true), agentId) : 1;
+	const confirmed = await ctx.ui.confirm(
+		subtree ? "Close subagent subtree?" : "Close subagent?",
+		`Close ${count} retained agent${count === 1 ? "" : "s"} and release owned resources?`,
+		{ signal },
+	);
+	if (signal.aborted || !isCurrent()) return { kind: "close" as const };
+	if (!confirmed) return { kind: "rejected" as const };
+	const current = runtime.listAgents(true).find((agent) => agent.id === agentId);
+	if (!current || current.updatedAt !== before.updatedAt || current.state !== before.state) {
+		ctx.ui.notify("Subagent state changed while confirming; review it again.", "warning");
+		return { kind: "rejected" as const };
+	}
+	try {
+		const closed = await runtime.closeAgent(agentId, subtree);
+		if (signal.aborted || !isCurrent()) return { kind: "close" as const };
+		ctx.ui.notify(`Closed ${closed} subagent${closed === 1 ? "" : "s"}.`, "info");
+		return { kind: "to" as const, screen: "agents" as const };
+	} catch (error) {
+		ctx.ui.notify(`Subagent was not closed: ${formatError(error)}`, "error");
+		return { kind: "rejected" as const };
+	}
+}
+
+function countSubtree(agents: ReturnType<SubagentSettingsRuntime["listAgents"]>, rootId: string) {
+	const byId = new Map(agents.map((agent) => [agent.id, agent]));
+	const seen = new Set<string>();
+	const visit = (id: string) => {
+		if (seen.has(id)) return;
+		seen.add(id);
+		for (const child of byId.get(id)?.children ?? []) visit(child);
+	};
+	visit(rootId);
+	return seen.size;
 }
 
 function applyCompletionSetting(
@@ -699,6 +854,51 @@ function applyCompletionSetting(
 		return { kind: "stay" as const };
 	} catch (error) {
 		ctx.ui.notify(`Subagent settings were not saved: ${formatError(error)}`, "error");
+		return { kind: "rejected" as const };
+	}
+}
+
+function applyFleetViewSetting(
+	value: string | undefined,
+	ctx: ExtensionCommandContext,
+	runtime: SubagentSettingsRuntime,
+) {
+	const previous = runtime.getFleetView?.() ?? "off";
+	const next: FleetViewMode = value === "Show active agents" ? "active" : "off";
+	if (next === previous) return { kind: "stay" as const };
+	let applied = false;
+	try {
+		if (!runtime.setFleetView) throw new Error("FleetView is unavailable in this runtime");
+		runtime.setFleetView(next);
+		applied = true;
+		updateFleetViewSetting(next);
+		ctx.ui.notify(`Saved and applied: ${fleetViewLabel(next)}.`, "info");
+		return { kind: "stay" as const };
+	} catch (error) {
+		if (applied) {
+			try {
+				runtime.setFleetView?.(previous);
+			} catch (rollbackError) {
+				ctx.ui.notify(
+					`FleetView could not be saved or rolled back: ${formatError(new AggregateError([error, rollbackError]))}. Reopen settings before retrying.`,
+					"error",
+				);
+				return { kind: "rejected" as const };
+			}
+		}
+		ctx.ui.notify(`FleetView setting was not applied: ${formatError(error)}`, "error");
+		return { kind: "rejected" as const };
+	}
+}
+
+function applyLifecycleArtifactSetting(value: string | undefined, ctx: ExtensionCommandContext) {
+	const next: LifecycleArtifactsMode = value === "Metadata after reload" ? "metadata" : "off";
+	try {
+		updateLifecycleArtifactSetting(next);
+		ctx.ui.notify(`Saved: ${lifecycleArtifactLabel(next)}. Run /reload to apply.`, "info");
+		return { kind: "stay" as const };
+	} catch (error) {
+		ctx.ui.notify(`Lifecycle artifact setting was not saved: ${formatError(error)}`, "error");
 		return { kind: "rejected" as const };
 	}
 }
@@ -782,192 +982,4 @@ function blockReloadWithRetainedAgents(
 		"warning",
 	);
 	return true;
-}
-
-function showSubagentStatus(ctx: ExtensionCommandContext, runtime: SubagentSettingsRuntime) {
-	if (ctx.mode !== "tui" && !ctx.hasUI) return;
-	const snapshot = inspectCompletionDeliverySettings();
-	ctx.ui.notify(
-		formatStatus(runtime.getRuntimeStatus(), snapshot, runtime),
-		snapshot.error ? "warning" : "info",
-	);
-}
-
-function showSubagentHelp(ctx: ExtensionCommandContext, runtime: SubagentSettingsRuntime) {
-	if (ctx.mode !== "tui" && !ctx.hasUI) return;
-	ctx.ui.notify(helpLines(runtime).join("\n"), "info");
-}
-
-function statusLines(runtime: SubagentSettingsRuntime): string[] {
-	const snapshot = inspectCompletionDeliverySettings();
-	return formatStatus(runtime.getRuntimeStatus(), snapshot, runtime).split("\n");
-}
-
-function helpLines(runtime: SubagentSettingsRuntime): string[] {
-	const snapshot = inspectCompletionDeliverySettings();
-	const cwdPolicy = inspectCwdPolicySettings();
-	const parallelLimit = inspectBlockingParallelLimitSettings();
-	const detachedLimits = inspectStatefulLimitSettings();
-	return [
-		"/subagents — choose delegation workflow, manage current agents, and configure agent tools",
-		"/subagents settings — configure target locations, trusted resources, and async completion",
-		"/subagents status — show current-session and user-setting values",
-		"/subagents help — show this help",
-		"Target policies control startup directories and resources, not filesystem access or sandboxing.",
-		"Manage saved folder trust with Pi /trust and restart Pi after changing it.",
-		`Runtime consultation target: ${consultationCwdLabel(runtime.getConsultationCwdPolicy())}`,
-		`Configured consultation target: ${consultationCwdLabel(cwdPolicy.consultation.value)} (${cwdPolicy.consultation.source})`,
-		`Runtime delegation target: ${delegationCwdLabel(runtime.getDelegationCwdPolicy())}`,
-		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} (${cwdPolicy.delegation.source})`,
-		`Maximum parallel workers: ${runtime.getMaxParallelTasks()} per blocking call`,
-		`Configured parallel limit: ${parallelLimit.value} (${parallelLimit.source})`,
-		`Detached limits: ${formatDetachedLimitSummary(runtime.getRuntimeStatus())}`,
-		...(detachedLimits.values
-			? [`Configured detached limits: ${formatConfiguredDetachedLimits(detachedLimits.values)}`]
-			: ["Configured detached limits: unavailable; repair user settings"]),
-		"Detached limits apply after /reload; clear retained agents first if their work must not be interrupted.",
-		`User settings: ${safeTerminalText(snapshot.path)}`,
-	];
-}
-
-function formatManagerSummary(
-	runtime: SubagentSettingsRuntime,
-	status: StatefulSubagentRuntimeStatus,
-	configured: ReturnType<typeof inspectDelegationWorkflowSettings>,
-): string {
-	const current = currentWorkflow(runtime, status);
-	const cwdPolicy = inspectCwdPolicySettings();
-	const consult = inspectConsultResourceSettings();
-	const detachedLimits = inspectStatefulLimitSettings();
-	const detachedDivergence = detachedLimits.values
-		? formatConfiguredDetachedLimitDivergence(status, detachedLimits.values)
-		: undefined;
-	return [
-		`Delegation: ${workflowLabel(current)}`,
-		`Completion: ${completionLabel(status.completionDelivery)}`,
-		`Consult target: ${consultationCwdLabel(runtime.getConsultationCwdPolicy())}`,
-		`Delegation target: ${delegationCwdLabel(runtime.getDelegationCwdPolicy())}`,
-		`Consult resources: ${consultResourceLabel(runtime.getConsultResourcePolicy())}`,
-		`Parallel workers: max ${runtime.getMaxParallelTasks()} per blocking call`,
-		`Detached limits: ${formatDetachedLimitSummary(status)}`,
-		`Configured consult target: ${consultationCwdLabel(cwdPolicy.consultation.value)} · ${cwdPolicy.consultation.source}`,
-		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} · ${cwdPolicy.delegation.source}`,
-		`Configured consult resources: ${consultResourceLabel(consult.value)} · ${consult.source}`,
-		`Settings: ${safeTerminalText(cwdPolicy.path)}`,
-		`Agents: ${status.activeAgents} active · ${status.retainedAgents} retained`,
-		...(detachedDivergence ? [detachedDivergence] : []),
-		...(configured.value !== current
-			? [`Configured after reload: ${workflowLabel(configured.value)}`]
-			: []),
-		...(configured.error || detachedLimits.error
-			? ["Settings need repair; open Advanced settings for details."]
-			: []),
-	].join("\n");
-}
-
-function formatStatus(
-	status: StatefulSubagentRuntimeStatus,
-	snapshot: ReturnType<typeof inspectCompletionDeliverySettings>,
-	runtime?: SubagentSettingsRuntime,
-): string {
-	const configuredWorkflow = inspectDelegationWorkflowSettings();
-	const consult = inspectConsultResourceSettings();
-	const cwdPolicy = inspectCwdPolicySettings();
-	const parallelLimit = inspectBlockingParallelLimitSettings();
-	const detachedLimits = inspectStatefulLimitSettings();
-	const current = runtime ? currentWorkflow(runtime, status) : configuredWorkflow.value;
-	return [
-		"Current session",
-		`  Delegation: ${workflowLabel(current)}`,
-		`  Async runtime: ${status.initialized ? "initialized" : status.enabled ? "not initialized" : "disabled"}`,
-		`  Transport: ${status.transport}`,
-		`  Completion: ${completionLabel(status.completionDelivery)}`,
-		`  Consultation target: ${consultationCwdLabel(runtime?.getConsultationCwdPolicy() ?? cwdPolicy.consultation.value)}`,
-		`  Delegation target: ${delegationCwdLabel(runtime?.getDelegationCwdPolicy() ?? cwdPolicy.delegation.value)}`,
-		`  Consultation resources: ${consultResourceLabel(runtime?.getConsultResourcePolicy() ?? consult.value)}`,
-		`  Maximum parallel workers: ${runtime?.getMaxParallelTasks() ?? parallelLimit.value} per blocking call`,
-		`  Detached limits: ${formatDetachedLimitSummary(status)}`,
-		`  Agents: ${status.activeAgents} active, ${status.retainedAgents} retained`,
-		"User settings",
-		`  Delegation source: ${configuredWorkflow.source}`,
-		`  Configured delegation: ${workflowLabel(configuredWorkflow.value)}`,
-		`  Completion source: ${snapshot.source}`,
-		`  Configured completion: ${completionLabel(snapshot.value)}`,
-		`  Configured parallel limit: ${parallelLimit.value}`,
-		`  Parallel limit source: ${parallelLimit.source}`,
-		...(detachedLimits.values
-			? STATEFUL_LIMIT_DEFINITIONS.map((definition) => {
-					const configured = detachedLimits.values?.[definition.field];
-					return `  Configured ${definition.label.toLowerCase()}: ${configured?.value} (${configured?.source})`;
-				})
-			: ["  Configured detached limits: unavailable"]),
-		`  Configured consultation target: ${consultationCwdLabel(cwdPolicy.consultation.value)}`,
-		`  Consultation target source: ${cwdPolicy.consultation.source}`,
-		`  Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)}`,
-		`  Delegation target source: ${cwdPolicy.delegation.source}`,
-		`  Configured consultation resources: ${consultResourceLabel(consult.value)}`,
-		`  Consultation resource source: ${consult.source}`,
-		`  Path: ${safeTerminalText(snapshot.path)}`,
-		configuredWorkflow.error ||
-		snapshot.error ||
-		cwdPolicy.error ||
-		parallelLimit.error ||
-		detachedLimits.error
-			? `  Warning: ${safeTerminalText(configuredWorkflow.error ?? snapshot.error ?? cwdPolicy.error ?? parallelLimit.error ?? detachedLimits.error ?? "invalid settings")}`
-			: "  Warning: none",
-		configuredWorkflow.value !== current
-			? "Configured delegation differs from this session. Run /reload to apply it."
-			: "Manual file changes require /reload.",
-	].join("\n");
-}
-
-function currentWorkflow(
-	runtime: SubagentSettingsRuntime,
-	status: StatefulSubagentRuntimeStatus,
-): DelegationWorkflow {
-	const blocking = runtime.getBlockingEnabled();
-	if (blocking && status.enabled) return "all";
-	if (status.enabled) return "async-only";
-	if (blocking) return "blocking-only";
-	return "disabled";
-}
-
-function isWorkflow(value: string): value is Exclude<DelegationWorkflow, "disabled"> {
-	return value === "all" || value === "async-only" || value === "blocking-only";
-}
-
-function completionLabel(value: CompletionDelivery): string {
-	return value === "auto-resume" ? "Resume automatically when finished" : "Wait until my next turn";
-}
-
-function consultationCwdLabel(value: ConsultationCwdPolicy): string {
-	return value === "current-workspace"
-		? "Current workspace only"
-		: "Anywhere · untrusted targets inherit nothing";
-}
-
-function delegationCwdLabel(value: DelegationCwdPolicy): string {
-	switch (value) {
-		case "trusted-targets":
-			return "Current or saved-trusted folders";
-		case "current-workspace":
-			return "Current workspace only";
-		case "anywhere":
-			return "Anywhere · normal Pi permissions";
-	}
-}
-
-function consultResourceLabel(value: ConsultResourcePolicy): string {
-	switch (value) {
-		case "project-context":
-			return "Project context only";
-		case "none":
-			return "No inherited resources";
-		case "all":
-			return "All trusted resources";
-	}
-}
-
-function formatError(error: unknown): string {
-	return safeTerminalText(error instanceof Error ? error.message : String(error));
 }

--- a/packages/pi-subagents/src/config-ui.ts
+++ b/packages/pi-subagents/src/config-ui.ts
@@ -496,6 +496,7 @@ async function showSubagentManager(
 					ctx.ui.notify("Subagent follow-up started.", "info");
 					return { kind: "stay" };
 				} catch (error) {
+					if (signal.aborted || !isCurrent()) return { kind: "close" };
 					ctx.ui.notify(`Follow-up was not started: ${formatError(error)}`, "error");
 					return { kind: "rejected" };
 				}
@@ -513,12 +514,15 @@ async function showSubagentManager(
 					ctx.ui.notify("Mailbox message queued.", "info");
 					return { kind: "stay" };
 				} catch (error) {
+					if (signal.aborted || !isCurrent()) return { kind: "close" };
 					ctx.ui.notify(`Mailbox message was not queued: ${formatError(error)}`, "error");
 					return { kind: "rejected" };
 				}
 			},
-			"agent-interrupt": async () => applyAgentInterrupt(runtime, selectedAgentId, false, ctx),
-			"agent-interrupt-tree": async () => applyAgentInterrupt(runtime, selectedAgentId, true, ctx),
+			"agent-interrupt": async ({ signal }) =>
+				applyAgentInterrupt(runtime, selectedAgentId, false, ctx, signal, isCurrent),
+			"agent-interrupt-tree": async ({ signal }) =>
+				applyAgentInterrupt(runtime, selectedAgentId, true, ctx, signal, isCurrent),
 			"agent-close": async ({ signal }) =>
 				applyAgentClose(runtime, selectedAgentId, false, ctx, signal, isCurrent),
 			"agent-close-tree": async ({ signal }) =>
@@ -779,13 +783,17 @@ async function applyAgentInterrupt(
 	agentId: string | undefined,
 	subtree: boolean,
 	ctx: ExtensionCommandContext,
+	signal: AbortSignal,
+	isCurrent: () => boolean,
 ) {
 	if (!agentId || !runtime.interruptAgent) return { kind: "rejected" as const };
 	try {
 		const count = await runtime.interruptAgent(agentId, subtree);
+		if (signal.aborted || !isCurrent()) return { kind: "close" as const };
 		ctx.ui.notify(`Interrupted ${count} active subagent${count === 1 ? "" : "s"}.`, "info");
 		return { kind: "stay" as const };
 	} catch (error) {
+		if (signal.aborted || !isCurrent()) return { kind: "close" as const };
 		ctx.ui.notify(`Subagent was not interrupted: ${formatError(error)}`, "error");
 		return { kind: "rejected" as const };
 	}
@@ -821,6 +829,7 @@ async function applyAgentClose(
 		ctx.ui.notify(`Closed ${closed} subagent${closed === 1 ? "" : "s"}.`, "info");
 		return { kind: "to" as const, screen: "agents" as const };
 	} catch (error) {
+		if (signal.aborted || !isCurrent()) return { kind: "close" as const };
 		ctx.ui.notify(`Subagent was not closed: ${formatError(error)}`, "error");
 		return { kind: "rejected" as const };
 	}

--- a/packages/pi-subagents/src/consult.ts
+++ b/packages/pi-subagents/src/consult.ts
@@ -19,6 +19,7 @@ import {
 	type SubagentSettings,
 	THINKING_LEVELS,
 } from "./agents.js";
+import type { CapabilityCeilingRegistry } from "./capability-ceiling.js";
 import { resolveConsultTools } from "./consult-policy.js";
 import { renderConsultCall, renderConsultResult } from "./consult-render.js";
 import { resolveConsultResourceLaunchPolicy } from "./consult-resources.js";
@@ -26,8 +27,10 @@ import {
 	assertConsultationTargetAllowed,
 	type ResolvedSubagentTarget,
 	resolveSubagentTarget,
+	targetPolicyAudit,
 } from "./cwd-policy.js";
 import { assertSubagentDepthAllowed, resolveDefaultSubagentTimeoutMs } from "./execution.js";
+import { launchPolicyFromContract, resolveLaunchContract } from "./launch-contract.js";
 import {
 	DEFAULT_MAX_CONTEXT_BYTES,
 	DEFAULT_MAX_STDERR_BYTES,
@@ -88,6 +91,7 @@ export interface RegisterSubagentConsultOptions {
 	runChild?: (request: ConsultChildRequest) => Promise<SingleResult>;
 	invocationOverride?: { command: string; argsPrefix?: string[] };
 	resolveResourceLaunchPolicy?: typeof resolveConsultResourceLaunchPolicy;
+	ceilings?: CapabilityCeilingRegistry;
 }
 
 export interface ConsultProgressActivity {
@@ -150,6 +154,7 @@ export interface ConsultDetails {
 	cancelled?: boolean;
 	isError?: boolean;
 	truncated?: boolean;
+	launchContractDigest?: string;
 }
 
 const READ_ONLY_INSTRUCTION = [
@@ -440,7 +445,7 @@ async function resolveConsultSetup(
 ) {
 	const requestedResourcePolicy = settings?.consult?.resources ?? DEFAULT_CONSULT_RESOURCE_POLICY;
 	const resourcePolicy = target.trust.projectTrusted ? requestedResourcePolicy : "none";
-	const effectiveTools = resolveConsultTools(agent.tools);
+	const readOnlyTools = resolveConsultTools(agent.tools);
 	const projectTrusted = target.trust.projectTrusted;
 	const thinkingLevel = resolveSubagentThinkingLevel([agent], agent.name, operation.thinkingLevel);
 	const timeoutMs = operation.timeoutMs ?? agent.timeoutMs ?? resolveDefaultSubagentTimeoutMs();
@@ -452,7 +457,21 @@ async function resolveConsultSetup(
 	const resolveResources =
 		options.resolveResourceLaunchPolicy ?? resolveConsultResourceLaunchPolicy;
 	const launchPolicy = await resolveResources(resourcePolicy, projectTrusted, target.cwd);
-	launchPolicy.tools = effectiveTools;
+	const contract = resolveLaunchContract({
+		agent: { ...agent, tools: readOnlyTools },
+		agentScope: operation.agentScope,
+		target: targetPolicyAudit(target),
+		thinkingLevel,
+		timeoutMs,
+		transport: "subprocess",
+		disableExtensions: true,
+		disableSkills: launchPolicy.disableSkills,
+		disablePromptTemplates: launchPolicy.disablePromptTemplates,
+		disableContextFiles: launchPolicy.disableContextFiles,
+		ceiling: options.ceilings?.resolve() ?? { sources: [] },
+	});
+	const effectiveTools = contract.effectiveTools ?? readOnlyTools;
+	Object.assign(launchPolicy, launchPolicyFromContract(contract));
 	const childAgent: AgentConfig = {
 		...agent,
 		tools: effectiveTools,
@@ -473,6 +492,7 @@ async function resolveConsultSetup(
 		model: agent.model ? boundedPrivateText(agent.model, 256) : undefined,
 		thinkingLevel,
 		timeoutMs,
+		launchContractDigest: contract.digest,
 		policy: {
 			requestedTools:
 				agent.tools === undefined

--- a/packages/pi-subagents/src/current-agents-ui.ts
+++ b/packages/pi-subagents/src/current-agents-ui.ts
@@ -1,0 +1,147 @@
+import type { ManagedAgent } from "./registry.js";
+import { safeTerminalLine } from "./safe-text.js";
+import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
+import { formatEmptyStatefulRuntime } from "./stateful-limit-ui.js";
+import { formatStatefulAgentLine } from "./stateful-presenter.js";
+
+interface CurrentAgentsRuntime {
+	listAgents(includeClosed?: boolean): ManagedAgent[];
+	getRuntimeStatus(): StatefulSubagentRuntimeStatus;
+}
+
+export function currentAgentsScreen(runtime: CurrentAgentsRuntime) {
+	const agents = runtime.listAgents();
+	const status = runtime.getRuntimeStatus();
+	return {
+		kind: "actions" as const,
+		title: "Current-session Subagents",
+		lines: agents.length ? [] : [formatEmptyStatefulRuntime(status)],
+		items: [
+			...agents.map((agent) => ({
+				id: agent.id,
+				label: safeTerminalLine(`${agent.agent} · ${agent.state}`, 256),
+				description: safeTerminalLine(formatStatefulAgentLine(agent), 512),
+				action: "select-agent" as const,
+			})),
+			...(agents.length > 0
+				? [
+						{
+							id: "clear",
+							label: "Clear current-session agents",
+							description: "Close and delete retained agents for this session",
+							action: "clear-agents" as const,
+						},
+					]
+				: []),
+			{ id: "back", label: "Back", action: "back" as const },
+		],
+		hint: "back" as const,
+	};
+}
+
+export function currentAgentDetailScreen(
+	runtime: CurrentAgentsRuntime,
+	agentId: string | undefined,
+) {
+	const agent = agentId
+		? runtime.listAgents(true).find((entry) => entry.id === agentId)
+		: undefined;
+	if (!agent) {
+		return {
+			kind: "actions" as const,
+			title: "Subagent unavailable",
+			lines: ["The selected subagent is no longer retained."],
+			items: [{ id: "back", label: "Back", action: "back" as const }],
+			hint: "back" as const,
+		};
+	}
+	const running = agent.state === "starting" || agent.state === "running";
+	const reusable = ["idle", "completed", "interrupted", "failed"].includes(agent.state);
+	const hasDescendants = agent.children.length > 0;
+	return {
+		kind: "actions" as const,
+		title: safeTerminalLine(`${agent.agent} · ${agent.id}`, 256),
+		lines: detailLines(agent),
+		items: [
+			...(reusable
+				? [
+						{
+							id: "follow-up",
+							label: "Send follow-up",
+							description: "Start another turn with this retained agent",
+							action: "agent-follow-up" as const,
+						},
+					]
+				: []),
+			...(agent.state !== "closed"
+				? [
+						{
+							id: "queue-message",
+							label: "Queue mailbox message",
+							description: "Store a message without starting a turn",
+							action: "agent-queue-message" as const,
+						},
+					]
+				: []),
+			...(running
+				? [
+						{
+							id: "interrupt",
+							label: "Interrupt active turn",
+							action: "agent-interrupt" as const,
+						},
+					]
+				: []),
+			...(hasDescendants
+				? [
+						{
+							id: "interrupt-tree",
+							label: "Interrupt subtree",
+							description: "Interrupt active work in this agent and its descendants",
+							action: "agent-interrupt-tree" as const,
+						},
+					]
+				: []),
+			...(agent.state !== "closed"
+				? [
+						{
+							id: "close",
+							label: "Close agent",
+							description: hasDescendants
+								? "Close is unavailable until descendants are closed"
+								: "Close the retained agent and release its resources",
+							action: "agent-close" as const,
+							disabled: hasDescendants,
+							disabledReason: hasDescendants ? "Use Close subtree" : undefined,
+						},
+					]
+				: []),
+			...(agent.state !== "closed" && hasDescendants
+				? [
+						{
+							id: "close-tree",
+							label: "Close subtree",
+							description: "Close this agent and every retained descendant",
+							action: "agent-close-tree" as const,
+						},
+					]
+				: []),
+			{ id: "back", label: "Back", action: "back" as const },
+		],
+		hint: "back" as const,
+	};
+}
+
+function detailLines(agent: ManagedAgent): string[] {
+	return [
+		`State: ${agent.state}`,
+		`Agent: ${safeTerminalLine(agent.agent, 256)}`,
+		`ID: ${safeTerminalLine(agent.id, 256)}`,
+		`Depth: ${agent.depth}`,
+		`Children: ${agent.children.length}`,
+		`History turns: ${agent.history.length}`,
+		`Unread messages: ${agent.mailbox.filter((message) => !message.readAt).length}`,
+		`Workspace: ${agent.workspaceMode ?? "shared"}`,
+		...(agent.evidenceStatus ? [`Evidence: ${agent.evidenceStatus} (unverified)`] : []),
+	];
+}

--- a/packages/pi-subagents/src/evidence.ts
+++ b/packages/pi-subagents/src/evidence.ts
@@ -1,0 +1,89 @@
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import { safeTerminalLine } from "./safe-text.js";
+
+export type EvidencePolicy = "attested";
+export type EvidenceStatus = "attested" | "missing" | "invalid";
+
+export interface EvidenceAttestation {
+	status: EvidenceStatus;
+	summary?: string;
+	changedFiles?: string[];
+	commandsRun?: string[];
+	validations?: string[];
+	residualRisks?: string[];
+}
+
+const MAX_FIELD_BYTES = 2 * 1024;
+const MAX_ITEMS = 32;
+const MAX_JSON_BYTES = 16 * 1024;
+const EVIDENCE_BLOCK = /```subagent-evidence\s*\n([\s\S]*?)\n```/gu;
+
+export const EVIDENCE_INSTRUCTION = [
+	"When finished, append exactly one fenced subagent-evidence JSON block.",
+	'Use keys "summary", "changedFiles", "commandsRun", "validations", and "residualRisks".',
+	"Report only what you actually did; this is an unverified attestation.",
+].join(" ");
+
+export function appendEvidenceInstruction(task: string, policy?: EvidencePolicy): string {
+	if (policy !== "attested") return task;
+	const suffix = `\n\n${EVIDENCE_INSTRUCTION}`;
+	const taskBudget = Math.max(0, DEFAULT_MAX_CONTEXT_BYTES - Buffer.byteLength(suffix, "utf8"));
+	return `${truncateUtf8(task, taskBudget).text}${suffix}`;
+}
+
+export function parseEvidenceAttestation(
+	output: string,
+	policy?: EvidencePolicy,
+): EvidenceAttestation | undefined {
+	if (policy !== "attested") return undefined;
+	const matches = [...output.matchAll(EVIDENCE_BLOCK)];
+	if (matches.length === 0) return { status: "missing" };
+	if (matches.length !== 1) return { status: "invalid" };
+	const raw = matches[0]?.[1] ?? "";
+	if (Buffer.byteLength(raw, "utf8") > MAX_JSON_BYTES) return { status: "invalid" };
+	let value: unknown;
+	try {
+		value = JSON.parse(raw);
+	} catch {
+		return { status: "invalid" };
+	}
+	if (!isPlainObject(value)) return { status: "invalid" };
+	const allowed = new Set([
+		"summary",
+		"changedFiles",
+		"commandsRun",
+		"validations",
+		"residualRisks",
+	]);
+	if (Object.keys(value).some((key) => !allowed.has(key))) return { status: "invalid" };
+	if (typeof value.summary !== "string" || !value.summary.trim()) return { status: "invalid" };
+	const changedFiles = boundedStrings(value.changedFiles);
+	const commandsRun = boundedStrings(value.commandsRun);
+	const validations = boundedStrings(value.validations);
+	const residualRisks = boundedStrings(value.residualRisks);
+	if (!changedFiles || !commandsRun || !validations || !residualRisks) {
+		return { status: "invalid" };
+	}
+	return {
+		status: "attested",
+		summary: bound(value.summary),
+		changedFiles,
+		commandsRun,
+		validations,
+		residualRisks,
+	};
+}
+
+function boundedStrings(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || value.length > MAX_ITEMS) return undefined;
+	if (!value.every((item) => typeof item === "string")) return undefined;
+	return value.map((item) => bound(item));
+}
+
+function bound(value: string): string {
+	return safeTerminalLine(value, MAX_FIELD_BYTES);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/pi-subagents/src/execution.ts
+++ b/packages/pi-subagents/src/execution.ts
@@ -7,12 +7,19 @@ import {
 	type SubagentSettings,
 	type SubagentThinkingLevel,
 } from "./agents.js";
+import type { CapabilityCeilingRegistry } from "./capability-ceiling.js";
 import {
 	assertDelegationTargetAllowed,
 	type ResolvedSubagentTarget,
 	resolveSubagentTarget,
 	targetPolicyAudit,
 } from "./cwd-policy.js";
+import {
+	appendEvidenceInstruction,
+	type EvidencePolicy,
+	parseEvidenceAttestation,
+} from "./evidence.js";
+import { launchPolicyFromContract, resolveLaunchContract } from "./launch-contract.js";
 import {
 	DEFAULT_MAX_CONTEXT_BYTES,
 	MAX_BLOCKING_PARALLEL_CONCURRENCY,
@@ -120,6 +127,7 @@ export async function executeSubagent(
 	onUpdate: AgentToolUpdateCallback<SubagentDetails> | undefined,
 	ctx: ExtensionContext,
 	settingsOverride?: SubagentSettings,
+	ceilings?: CapabilityCeilingRegistry,
 ): Promise<AgentToolResult<SubagentDetails> & { isError?: boolean }> {
 	assertSubagentDepthAllowed();
 	const agentScope: AgentScope = params.agentScope ?? "user";
@@ -191,13 +199,50 @@ export async function executeSubagent(
 	const chainTargets = params.chain?.map((step) => resolveTarget(step.cwd)) ?? [];
 	const parallelTargets = params.tasks?.map((task) => resolveTarget(task.cwd)) ?? [];
 	const aggregatorTarget = aggregator ? resolveTarget(aggregator.cwd) : undefined;
-	const attachTarget = (result: SingleResult, target: ResolvedSubagentTarget): SingleResult => {
+	const prepareLaunch = (
+		agentName: string,
+		target: ResolvedSubagentTarget,
+		thinkingLevel: SubagentThinkingLevel | undefined,
+		timeoutMs: number,
+		evidence: EvidencePolicy | undefined,
+	) => {
+		const agent = agents.find((candidate) => candidate.name === agentName);
+		const ceiling = ceilings?.resolve() ?? { sources: [] };
+		if (!agent) {
+			if (ceiling.allowedAgents && !ceiling.allowedAgents.includes(agentName)) {
+				throw new Error(`Subagent ${agentName} is denied by the active capability ceiling`);
+			}
+			return undefined;
+		}
+		return resolveLaunchContract({
+			agent,
+			agentScope,
+			target: targetPolicyAudit(target),
+			thinkingLevel,
+			timeoutMs,
+			transport: "subprocess",
+			evidence,
+			ceiling,
+		});
+	};
+	const attachLaunch = (
+		result: SingleResult,
+		target: ResolvedSubagentTarget,
+		originalTask: string,
+		evidence: EvidencePolicy | undefined,
+		contract: ReturnType<typeof prepareLaunch>,
+	): SingleResult => {
 		result.target = targetPolicyAudit(target);
+		result.task = originalTask;
+		result.evidence = parseEvidenceAttestation(getResultFinalOutput(result), evidence);
+		result.launchContractDigest = contract?.digest;
 		return result;
 	};
-	const launchPolicy = (target: ResolvedSubagentTarget) => ({
-		projectTrust: target.trust.projectTrusted,
-	});
+	const launchPolicy = (
+		contract: ReturnType<typeof prepareLaunch>,
+		target: ResolvedSubagentTarget,
+	) =>
+		contract ? launchPolicyFromContract(contract) : { projectTrust: target.trust.projectTrusted };
 
 	if (agentScope === "project" || agentScope === "both") {
 		const requestedAgentNames = new Set<string>();
@@ -268,23 +313,30 @@ export async function executeSubagent(
 					: undefined;
 
 				const target = chainTargets[i];
-				const result = attachTarget(
+				const thinkingLevel = resolveThinkingLevel(step.agent, step.thinkingLevel);
+				const timeoutMs = resolveTimeoutMs(step.agent, step.timeoutMs);
+				const evidence = step.evidence ?? params.evidence;
+				const contract = prepareLaunch(step.agent, target, thinkingLevel, timeoutMs, evidence);
+				const result = attachLaunch(
 					await runSingleAgent(
 						ctx.cwd,
 						agents,
 						step.agent,
-						taskWithContext,
+						appendEvidenceInstruction(taskWithContext, evidence),
 						target.cwd,
 						i + 1,
 						signal,
-						resolveThinkingLevel(step.agent, step.thinkingLevel),
-						resolveTimeoutMs(step.agent, step.timeoutMs),
+						thinkingLevel,
+						timeoutMs,
 						chainUpdate,
 						makeDetails("chain"),
 						undefined,
-						launchPolicy(target),
+						launchPolicy(contract, target),
 					),
 					target,
+					taskWithContext,
+					evidence,
+					contract,
 				);
 				results.push(result);
 
@@ -396,17 +448,21 @@ export async function executeSubagent(
 				MAX_BLOCKING_PARALLEL_CONCURRENCY,
 				async (t, index) => {
 					const target = parallelTargets[index];
-					const result = attachTarget(
+					const thinkingLevel = resolveThinkingLevel(t.agent, t.thinkingLevel);
+					const timeoutMs = resolveTimeoutMs(t.agent, t.timeoutMs);
+					const evidence = t.evidence ?? params.evidence;
+					const contract = prepareLaunch(t.agent, target, thinkingLevel, timeoutMs, evidence);
+					const result = attachLaunch(
 						await runSingleAgent(
 							ctx.cwd,
 							agents,
 							t.agent,
-							t.task,
+							appendEvidenceInstruction(t.task, evidence),
 							target.cwd,
 							undefined,
 							signal,
-							resolveThinkingLevel(t.agent, t.thinkingLevel),
-							resolveTimeoutMs(t.agent, t.timeoutMs),
+							thinkingLevel,
+							timeoutMs,
 							// Per-task update callback
 							(partial) => {
 								if (partial.details?.results[0]) {
@@ -416,9 +472,12 @@ export async function executeSubagent(
 							},
 							makeDetails("parallel"),
 							undefined,
-							launchPolicy(target),
+							launchPolicy(contract, target),
 						),
 						target,
+						t.task,
+						evidence,
+						contract,
 					);
 					allResults[index] = result;
 					doneCount += 1;
@@ -455,17 +514,27 @@ export async function executeSubagent(
 					DEFAULT_MAX_CONTEXT_BYTES,
 				).text;
 				const target = aggregatorTarget as ResolvedSubagentTarget;
-				aggregatorResult = attachTarget(
+				const thinkingLevel = resolveThinkingLevel(aggregator.agent, aggregator.thinkingLevel);
+				const timeoutMs = resolveTimeoutMs(aggregator.agent, aggregator.timeoutMs);
+				const evidence = aggregator.evidence ?? params.evidence;
+				const contract = prepareLaunch(
+					aggregator.agent,
+					target,
+					thinkingLevel,
+					timeoutMs,
+					evidence,
+				);
+				aggregatorResult = attachLaunch(
 					await runSingleAgent(
 						ctx.cwd,
 						agents,
 						aggregator.agent,
-						aggregatorTask,
+						appendEvidenceInstruction(aggregatorTask, evidence),
 						target.cwd,
 						undefined,
 						signal,
-						resolveThinkingLevel(aggregator.agent, aggregator.thinkingLevel),
-						resolveTimeoutMs(aggregator.agent, aggregator.timeoutMs),
+						thinkingLevel,
+						timeoutMs,
 						(partial) => {
 							status.update(fanInStatus(aggregator.agent));
 							if (onUpdate && partial.details?.results[0]) {
@@ -477,9 +546,12 @@ export async function executeSubagent(
 						},
 						makeDetails("parallel"),
 						undefined,
-						launchPolicy(target),
+						launchPolicy(contract, target),
 					),
 					target,
+					aggregatorTask,
+					evidence,
+					contract,
 				);
 			}
 
@@ -525,23 +597,35 @@ export async function executeSubagent(
 
 		try {
 			const target = singleTarget as ResolvedSubagentTarget;
-			const result = attachTarget(
+			const thinkingLevel = resolveThinkingLevel(params.agent, params.thinkingLevel);
+			const timeoutMs = resolveTimeoutMs(params.agent, params.timeoutMs);
+			const contract = prepareLaunch(
+				params.agent,
+				target,
+				thinkingLevel,
+				timeoutMs,
+				params.evidence,
+			);
+			const result = attachLaunch(
 				await runSingleAgent(
 					ctx.cwd,
 					agents,
 					params.agent,
-					params.task,
+					appendEvidenceInstruction(params.task, params.evidence),
 					target.cwd,
 					undefined,
 					signal,
-					resolveThinkingLevel(params.agent, params.thinkingLevel),
-					resolveTimeoutMs(params.agent, params.timeoutMs),
+					thinkingLevel,
+					timeoutMs,
 					onUpdate,
 					makeDetails("single"),
 					undefined,
-					launchPolicy(target),
+					launchPolicy(contract, target),
 				),
 				target,
+				params.task,
+				params.evidence,
+				contract,
 			);
 			const isError = isResultError(result);
 			if (isError) {

--- a/packages/pi-subagents/src/fleet-view.ts
+++ b/packages/pi-subagents/src/fleet-view.ts
@@ -1,0 +1,51 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, truncateToWidth } from "@earendil-works/pi-tui";
+import type { ManagedAgent } from "./registry.js";
+import { safeTerminalLine } from "./safe-text.js";
+
+export const FLEET_WIDGET_KEY = "subagents:fleet";
+const MAX_FLEET_ROWS = 5;
+
+export function updateFleetWidget(
+	ctx: Pick<ExtensionContext, "mode" | "ui">,
+	enabled: boolean,
+	agents: readonly ManagedAgent[],
+): void {
+	if (ctx.mode !== "tui" || !enabled) {
+		ctx.ui.setWidget(FLEET_WIDGET_KEY, undefined);
+		return;
+	}
+	const active = agents.filter((agent) => agent.state === "starting" || agent.state === "running");
+	if (active.length === 0) {
+		ctx.ui.setWidget(FLEET_WIDGET_KEY, undefined);
+		return;
+	}
+	const snapshot = active.slice(0, MAX_FLEET_ROWS).map((agent) => ({ ...agent }));
+	const omitted = Math.max(0, active.length - snapshot.length);
+	ctx.ui.setWidget(
+		FLEET_WIDGET_KEY,
+		(_tui, theme) => ({
+			render(width: number): string[] {
+				const safeWidth = Math.max(1, width);
+				const lines = [
+					truncateToWidth(theme.bold(theme.fg("accent", "Subagents")), safeWidth, "…"),
+				];
+				for (const agent of snapshot) {
+					const state = agent.state === "starting" ? "STARTING" : "RUNNING";
+					const task = safeLine(agent.currentTask ?? "(no task)");
+					const raw = `${state} ${safeLine(agent.agent)} ${safeLine(agent.id)} — ${task}`;
+					lines.push(truncateToWidth(raw, safeWidth, "…"));
+				}
+				if (omitted > 0) lines.push(truncateToWidth(`… ${omitted} more active`, safeWidth, "…"));
+				lines.push(truncateToWidth("Manage with /subagents", safeWidth, "…"));
+				return lines;
+			},
+			invalidate() {},
+		}),
+		{ placement: "belowEditor" },
+	);
+}
+
+function safeLine(value: string): string {
+	return safeTerminalLine(stripTerminalSequences(value));
+}

--- a/packages/pi-subagents/src/launch-contract.ts
+++ b/packages/pi-subagents/src/launch-contract.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import type { AgentConfig, AgentScope, SubagentThinkingLevel } from "./agents.js";
+import { applyCapabilityCeiling, type EffectiveCapabilityCeiling } from "./capability-ceiling.js";
+import type { TargetPolicyAudit } from "./cwd-policy.js";
+import type { EvidencePolicy } from "./evidence.js";
+import type { ChildLaunchPolicy } from "./runner.js";
+
+export interface LaunchContract {
+	agent: string;
+	agentSource: AgentConfig["source"];
+	agentScope: AgentScope;
+	cwd: string;
+	target: TargetPolicyAudit;
+	model?: string;
+	thinkingLevel?: SubagentThinkingLevel;
+	timeoutMs: number;
+	configuredTools?: string[];
+	effectiveTools?: string[];
+	disableExtensions: boolean;
+	disableSkills: boolean;
+	disablePromptTemplates: boolean;
+	disableContextFiles: boolean;
+	transport: "subprocess" | "in-process";
+	evidence?: EvidencePolicy;
+	ceilingSources: string[];
+	digest: string;
+}
+
+export interface ResolveLaunchContractOptions {
+	agent: AgentConfig;
+	agentScope: AgentScope;
+	target: TargetPolicyAudit;
+	thinkingLevel?: SubagentThinkingLevel;
+	timeoutMs: number;
+	transport: "subprocess" | "in-process";
+	evidence?: EvidencePolicy;
+	disableExtensions?: boolean;
+	disableSkills?: boolean;
+	disablePromptTemplates?: boolean;
+	disableContextFiles?: boolean;
+	ceiling: EffectiveCapabilityCeiling;
+}
+
+export function resolveLaunchContract(options: ResolveLaunchContractOptions): LaunchContract {
+	const constrained = applyCapabilityCeiling(
+		options.agent.name,
+		options.agent.tools,
+		options.ceiling,
+	);
+	const projection = {
+		agent: options.agent.name,
+		agentSource: options.agent.source,
+		agentScope: options.agentScope,
+		cwd: options.target.cwd,
+		target: cloneTarget(options.target),
+		...(options.agent.model ? { model: options.agent.model } : {}),
+		...(options.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
+		timeoutMs: options.timeoutMs,
+		...(options.agent.tools ? { configuredTools: [...options.agent.tools] } : {}),
+		...(constrained.tools ? { effectiveTools: [...constrained.tools] } : {}),
+		disableExtensions: options.disableExtensions === true || constrained.disableExtensions === true,
+		disableSkills: options.disableSkills === true,
+		disablePromptTemplates: options.disablePromptTemplates === true,
+		disableContextFiles: options.disableContextFiles === true,
+		transport: options.transport,
+		...(options.evidence ? { evidence: options.evidence } : {}),
+		ceilingSources: [...options.ceiling.sources],
+	};
+	return { ...projection, digest: digestContract(projection) };
+}
+
+export function launchPolicyFromContract(contract: LaunchContract): ChildLaunchPolicy {
+	return {
+		projectTrust: contract.target.trust.projectTrusted,
+		...(contract.effectiveTools ? { tools: [...contract.effectiveTools] } : {}),
+		...(contract.disableExtensions ? { disableExtensions: true } : {}),
+		...(contract.disableSkills ? { disableSkills: true } : {}),
+		...(contract.disablePromptTemplates ? { disablePromptTemplates: true } : {}),
+		...(contract.disableContextFiles ? { disableContextFiles: true } : {}),
+	};
+}
+
+function digestContract(value: Omit<LaunchContract, "digest">): string {
+	return createHash("sha256").update(stableStringify(value)).digest("hex").slice(0, 24);
+}
+
+function stableStringify(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+	if (value && typeof value === "object") {
+		return `{${Object.entries(value as Record<string, unknown>)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+			.join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+function cloneTarget(target: TargetPolicyAudit): TargetPolicyAudit {
+	return { ...target, trust: { ...target.trust } };
+}

--- a/packages/pi-subagents/src/lifecycle-artifacts.ts
+++ b/packages/pi-subagents/src/lifecycle-artifacts.ts
@@ -1,0 +1,159 @@
+import { createHash, randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import type { ManagedAgent } from "./registry.js";
+import { safeTerminalLine } from "./safe-text.js";
+
+const ARTIFACT_VERSION = 1;
+const MAX_ARTIFACT_BYTES = 256 * 1024;
+const MAX_ARTIFACT_AGENTS = 256;
+
+export interface LifecycleArtifactStatus {
+	enabled: boolean;
+	path?: string;
+	version: number;
+	lastPublishedAt?: number;
+	error?: string;
+}
+
+interface LifecycleArtifact {
+	version: 1;
+	updatedAt: number;
+	agents: Array<{
+		id: string;
+		agent: string;
+		parentId?: string;
+		rootId: string;
+		state: ManagedAgent["state"];
+		createdAt: number;
+		updatedAt: number;
+		historyCount: number;
+		unreadMessages: number;
+		workspaceMode: "shared" | "worktree";
+		trustKind?: string;
+		launchContractDigest?: string;
+		evidenceStatus?: string;
+	}>;
+	omittedAgents: number;
+}
+
+export class LifecycleArtifactWriter {
+	readonly filePath: string;
+	private lastPublishedAt?: number;
+	private error?: string;
+	private closed = false;
+
+	constructor(
+		owner: string,
+		private readonly retentionDays = 30,
+		artifactDir?: string,
+		private readonly isCurrent: () => boolean = () => true,
+	) {
+		if (!Number.isFinite(retentionDays) || retentionDays <= 0) {
+			throw new Error("Lifecycle artifact retentionDays must be positive");
+		}
+		const ownerHash = createHash("sha256").update(owner).digest("hex").slice(0, 24);
+		this.filePath = path.join(
+			artifactDir ?? path.join(getAgentDir(), "pi-subagents-artifacts"),
+			`${ownerHash}.json`,
+		);
+	}
+
+	status(): LifecycleArtifactStatus {
+		return {
+			enabled: !this.closed,
+			path: this.filePath,
+			version: ARTIFACT_VERSION,
+			lastPublishedAt: this.lastPublishedAt,
+			error: this.error,
+		};
+	}
+
+	async publish(agents: readonly ManagedAgent[]): Promise<void> {
+		if (this.closed || !this.isCurrent()) return;
+		const eligible = agents.filter((agent) => agent.state !== "closed");
+		const selected = eligible.slice(-MAX_ARTIFACT_AGENTS);
+		const artifact: LifecycleArtifact = {
+			version: ARTIFACT_VERSION,
+			updatedAt: Date.now(),
+			agents: selected.map((agent) => ({
+				id: agent.id,
+				agent: agent.agent,
+				...(agent.parentId ? { parentId: agent.parentId } : {}),
+				rootId: agent.rootId,
+				state: agent.state,
+				createdAt: agent.createdAt,
+				updatedAt: agent.updatedAt,
+				historyCount: agent.history.length,
+				unreadMessages: agent.mailbox.filter((message) => message.readAt === undefined).length,
+				workspaceMode: agent.workspaceMode ?? "shared",
+				...(agent.target?.trust.kind ? { trustKind: agent.target.trust.kind } : {}),
+				...(agent.launchContractDigest ? { launchContractDigest: agent.launchContractDigest } : {}),
+				...(agent.evidenceStatus ? { evidenceStatus: agent.evidenceStatus } : {}),
+			})),
+			omittedAgents: eligible.length - selected.length,
+		};
+		const content = `${JSON.stringify(artifact, null, "\t")}\n`;
+		if (Buffer.byteLength(content, "utf8") > MAX_ARTIFACT_BYTES) {
+			this.error = "Lifecycle artifact exceeded its size limit";
+			return;
+		}
+		try {
+			let published = false;
+			await fs.promises.mkdir(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+			await withFileMutationQueue(this.filePath, async () => {
+				const temporary = `${this.filePath}.${process.pid}.${randomUUID()}.tmp`;
+				try {
+					await fs.promises.writeFile(temporary, content, { encoding: "utf8", mode: 0o600 });
+					if (this.closed || !this.isCurrent()) return;
+					await fs.promises.rename(temporary, this.filePath);
+					published = true;
+				} finally {
+					await fs.promises.rm(temporary, { force: true }).catch(() => undefined);
+				}
+			});
+			if (!published) return;
+			this.lastPublishedAt = artifact.updatedAt;
+			this.error = undefined;
+		} catch (error) {
+			this.error = safeError(error);
+		}
+	}
+
+	async cleanupExpired(): Promise<void> {
+		const directory = path.dirname(this.filePath);
+		const cutoff = Date.now() - this.retentionDays * 24 * 60 * 60 * 1000;
+		let entries: fs.Dirent[];
+		try {
+			entries = await fs.promises.readdir(directory, { withFileTypes: true });
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			this.error = safeError(error);
+			return;
+		}
+		for (const entry of entries.slice(0, 1024)) {
+			if (this.closed || !this.isCurrent()) return;
+			if (!entry.isFile() || !/^[a-f0-9]{24}\.json$/u.test(entry.name)) continue;
+			const candidate = path.join(directory, entry.name);
+			try {
+				const stat = await fs.promises.stat(candidate);
+				if (stat.mtimeMs < cutoff) await fs.promises.rm(candidate, { force: true });
+			} catch {
+				// A concurrent session may have replaced or removed this projection.
+			}
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+	}
+}
+
+export function disabledLifecycleArtifactStatus(): LifecycleArtifactStatus {
+	return { enabled: false, version: ARTIFACT_VERSION };
+}
+
+function safeError(error: unknown): string {
+	return safeTerminalLine(error instanceof Error ? error.message : String(error), 512);
+}

--- a/packages/pi-subagents/src/params.ts
+++ b/packages/pi-subagents/src/params.ts
@@ -15,12 +15,18 @@ const ThinkingLevelSchema = StringEnum(THINKING_LEVELS, {
 		"Pi thinking level for the subagent process: off, minimal, low, medium, high, xhigh, or max.",
 });
 
+const EvidenceSchema = StringEnum(["attested"] as const, {
+	description:
+		"Ask the child to append bounded, unverified evidence metadata about files, commands, validation, and risks.",
+});
+
 const TaskItem = Type.Object({
 	agent: Type.String({ description: "Name of the agent to invoke" }),
 	task: Type.String({ description: "Task to delegate to the agent" }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
 	timeoutMs: Type.Optional(TimeoutMs),
 	thinkingLevel: Type.Optional(ThinkingLevelSchema),
+	evidence: Type.Optional(EvidenceSchema),
 });
 
 const ChainItem = Type.Object({
@@ -29,6 +35,7 @@ const ChainItem = Type.Object({
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
 	timeoutMs: Type.Optional(TimeoutMs),
 	thinkingLevel: Type.Optional(ThinkingLevelSchema),
+	evidence: Type.Optional(EvidenceSchema),
 });
 
 const AggregatorItem = Type.Object(
@@ -44,6 +51,7 @@ const AggregatorItem = Type.Object(
 		),
 		timeoutMs: Type.Optional(TimeoutMs),
 		thinkingLevel: Type.Optional(ThinkingLevelSchema),
+		evidence: Type.Optional(EvidenceSchema),
 	},
 	{
 		description:
@@ -84,6 +92,7 @@ export const SubagentParams = Type.Object({
 	),
 	timeoutMs: Type.Optional(TimeoutMs),
 	thinkingLevel: Type.Optional(ThinkingLevelSchema),
+	evidence: Type.Optional(EvidenceSchema),
 });
 
 export type SubagentParams = Static<typeof SubagentParams>;

--- a/packages/pi-subagents/src/persistence.ts
+++ b/packages/pi-subagents/src/persistence.ts
@@ -5,6 +5,7 @@ import { getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-ag
 import { projectAgentRecords } from "./agent-projection.js";
 import { isThinkingLevel } from "./agents.js";
 import { redactPrivateText } from "./context.js";
+import type { EvidenceAttestation } from "./evidence.js";
 import type { ManagedAgent } from "./registry.js";
 import { resolveStatefulLimits } from "./stateful-limits.js";
 
@@ -125,7 +126,9 @@ function sanitizeAgent(agent: ManagedAgent): ManagedAgent {
 			...turn,
 			task: redactPrivateText(turn.task),
 			output: redactPrivateText(turn.output),
+			evidence: turn.evidence ? sanitizeEvidence(turn.evidence) : undefined,
 		})),
+		capabilityTools: agent.capabilityTools ? [...agent.capabilityTools] : undefined,
 	};
 }
 
@@ -149,6 +152,19 @@ function isStoredState(value: unknown): value is StoredState {
 			(record.parentId === undefined || typeof record.parentId === "string") &&
 			(record.thinkingLevel === undefined || isThinkingLevel(record.thinkingLevel)) &&
 			(record.workspaceMode === undefined || record.workspaceMode === "worktree") &&
+			(record.evidencePolicy === undefined || record.evidencePolicy === "attested") &&
+			(record.evidenceStatus === undefined ||
+				["attested", "missing", "invalid"].includes(record.evidenceStatus)) &&
+			(record.launchContractDigest === undefined ||
+				(typeof record.launchContractDigest === "string" &&
+					/^[a-f0-9]{24}$/u.test(record.launchContractDigest))) &&
+			(record.capabilityTools === undefined ||
+				(Array.isArray(record.capabilityTools) &&
+					record.capabilityTools.length <= 256 &&
+					record.capabilityTools.every(
+						(tool) => typeof tool === "string" && Buffer.byteLength(tool, "utf8") <= 256,
+					))) &&
+			(record.disableExtensions === undefined || typeof record.disableExtensions === "boolean") &&
 			(record.target === undefined || isTargetPolicyAudit(record.target)) &&
 			(record.children === undefined ||
 				(Array.isArray(record.children) &&
@@ -199,8 +215,43 @@ function isAgentTurn(value: unknown): boolean {
 		typeof turn.completedAt === "number" &&
 		Number.isFinite(turn.completedAt) &&
 		typeof turn.exitCode === "number" &&
-		Number.isFinite(turn.exitCode)
+		Number.isFinite(turn.exitCode) &&
+		(turn.evidence === undefined || isEvidence(turn.evidence))
 	);
+}
+
+function isEvidence(value: unknown): value is EvidenceAttestation {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const evidence = value as Record<string, unknown>;
+	if (!["attested", "missing", "invalid"].includes(String(evidence.status))) return false;
+	if (
+		evidence.summary !== undefined &&
+		(typeof evidence.summary !== "string" || Buffer.byteLength(evidence.summary, "utf8") > 2048)
+	) {
+		return false;
+	}
+	return ["changedFiles", "commandsRun", "validations", "residualRisks"].every((field) => {
+		const fieldValue = evidence[field];
+		return (
+			fieldValue === undefined ||
+			(Array.isArray(fieldValue) &&
+				fieldValue.length <= 32 &&
+				fieldValue.every(
+					(item) => typeof item === "string" && Buffer.byteLength(item, "utf8") <= 2048,
+				))
+		);
+	});
+}
+
+function sanitizeEvidence(evidence: EvidenceAttestation): EvidenceAttestation {
+	return {
+		...evidence,
+		summary: evidence.summary ? redactPrivateText(evidence.summary) : undefined,
+		changedFiles: evidence.changedFiles?.map(redactPrivateText),
+		commandsRun: evidence.commandsRun?.map(redactPrivateText),
+		validations: evidence.validations?.map(redactPrivateText),
+		residualRisks: evidence.residualRisks?.map(redactPrivateText),
+	};
 }
 
 function isMailboxMessage(value: unknown): boolean {

--- a/packages/pi-subagents/src/public-api.ts
+++ b/packages/pi-subagents/src/public-api.ts
@@ -1,0 +1,324 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AgentScope, SubagentThinkingLevel } from "./agents.js";
+import type { CapabilityCeiling, CapabilityCeilingRegistry } from "./capability-ceiling.js";
+import type { EvidencePolicy } from "./evidence.js";
+import type { LaunchContract } from "./launch-contract.js";
+import type { LifecycleArtifactStatus } from "./lifecycle-artifacts.js";
+import { safeTerminalLine } from "./safe-text.js";
+
+export const PI_SUBAGENTS_V1 = "pi-subagents:v1";
+export const PI_SUBAGENTS_V1_REQUEST = `${PI_SUBAGENTS_V1}:request`;
+export const PI_SUBAGENTS_V1_REPLY = `${PI_SUBAGENTS_V1}:reply`;
+export const PI_SUBAGENTS_V1_PROGRESS = `${PI_SUBAGENTS_V1}:progress`;
+export const PI_SUBAGENTS_V1_READY = `${PI_SUBAGENTS_V1}:ready`;
+
+export type PiSubagentsV1Method =
+	| "ping"
+	| "preflight"
+	| "delegate"
+	| "cancel"
+	| "ceiling.register"
+	| "ceiling.update"
+	| "ceiling.dispose";
+
+export interface PiSubagentsV1LeafPayload {
+	agent: string;
+	task?: string;
+	cwd?: string;
+	agentScope?: AgentScope;
+	thinkingLevel?: SubagentThinkingLevel;
+	timeoutMs?: number;
+	evidence?: EvidencePolicy;
+	confirmProjectAgents?: boolean;
+}
+
+export interface PiSubagentsV1PreflightResult extends LaunchContract {
+	projectAgentConfirmationRequired: boolean;
+	lifecycleArtifact: LifecycleArtifactStatus;
+}
+
+export interface PiSubagentsV1CancelPayload {
+	targetRequestId: string;
+}
+
+export interface PiSubagentsV1CeilingRegisterPayload {
+	source: string;
+	ceiling: CapabilityCeiling;
+}
+
+export interface PiSubagentsV1CeilingUpdatePayload {
+	token: string;
+	ceiling: CapabilityCeiling;
+}
+
+export interface PiSubagentsV1CeilingDisposePayload {
+	token: string;
+}
+
+export interface PiSubagentsV1Progress {
+	requestId: string;
+	state: "running";
+}
+
+export interface PiSubagentsV1Ready {
+	protocol: typeof PI_SUBAGENTS_V1;
+}
+
+export interface PiSubagentsV1Request {
+	requestId: string;
+	method: PiSubagentsV1Method;
+	payload?: unknown;
+}
+
+export interface PiSubagentsV1Reply {
+	requestId: string;
+	ok: boolean;
+	result?: unknown;
+	error?: { code: string; message: string };
+}
+
+export interface PublicApiDependencies {
+	preflight(payload: unknown, ctx: ExtensionContext): Promise<unknown> | unknown;
+	delegate(payload: unknown, signal: AbortSignal, ctx: ExtensionContext): Promise<unknown>;
+	status?(): unknown;
+}
+
+const METHODS = new Set<PiSubagentsV1Method>([
+	"ping",
+	"preflight",
+	"delegate",
+	"cancel",
+	"ceiling.register",
+	"ceiling.update",
+	"ceiling.dispose",
+]);
+const MAX_SETTLED_REQUESTS = 1024;
+
+export function registerPiSubagentsV1Api(
+	pi: ExtensionAPI,
+	ceilings: CapabilityCeilingRegistry,
+	dependencies: PublicApiDependencies,
+): void {
+	let generation = 0;
+	let disposeRequest: (() => void) | undefined;
+	let currentContext: ExtensionContext | undefined;
+	const active = new Map<string, AbortController>();
+	const settled = new Set<string>();
+	const settledOrder: string[] = [];
+
+	const rememberSettled = (requestId: string) => {
+		settled.add(requestId);
+		settledOrder.push(requestId);
+		while (settledOrder.length > MAX_SETTLED_REQUESTS) {
+			const removed = settledOrder.shift();
+			if (removed) settled.delete(removed);
+		}
+	};
+	const reply = (value: PiSubagentsV1Reply) => {
+		if (settled.has(value.requestId)) return;
+		rememberSettled(value.requestId);
+		pi.events.emit(PI_SUBAGENTS_V1_REPLY, value);
+	};
+	const fail = (requestId: string, code: string, error: unknown) => {
+		reply({ requestId, ok: false, error: { code, message: safeMessage(error) } });
+	};
+	const reset = () => {
+		generation += 1;
+		disposeRequest?.();
+		disposeRequest = undefined;
+		for (const controller of active.values()) controller.abort();
+		active.clear();
+		settled.clear();
+		settledOrder.length = 0;
+		ceilings.clear();
+		currentContext = undefined;
+	};
+
+	pi.on("session_start", (_event, ctx) => {
+		reset();
+		currentContext = ctx;
+		const boundGeneration = generation;
+		disposeRequest = pi.events.on(PI_SUBAGENTS_V1_REQUEST, (raw) => {
+			const parsed = parseRequest(raw);
+			if (!parsed.ok) {
+				if (parsed.requestId) fail(parsed.requestId, "invalid_request", parsed.error);
+				return;
+			}
+			const request = parsed.request;
+			if (active.has(request.requestId) || settled.has(request.requestId)) {
+				active.get(request.requestId)?.abort();
+				fail(request.requestId, "duplicate_request", "Request ID was already used");
+				return;
+			}
+			if (!currentContext || boundGeneration !== generation) {
+				fail(request.requestId, "no_session", "No current pi-subagents session");
+				return;
+			}
+			if (request.method === "cancel") {
+				try {
+					assertOnlyFields(request.payload, ["targetRequestId"]);
+					const targetRequestId = requiredStringField(request.payload, "targetRequestId");
+					const target = active.get(targetRequestId);
+					if (target) target.abort();
+					reply({
+						requestId: request.requestId,
+						ok: true,
+						result: { cancelled: target !== undefined },
+					});
+				} catch (error) {
+					fail(request.requestId, "invalid_request", error);
+				}
+				return;
+			}
+			const controller = new AbortController();
+			active.set(request.requestId, controller);
+			void Promise.resolve()
+				.then(async () => {
+					if (boundGeneration !== generation || controller.signal.aborted) {
+						throw abortError();
+					}
+					let result: unknown;
+					switch (request.method) {
+						case "ping":
+							if (request.payload !== undefined) {
+								throw new Error("ping does not accept a payload");
+							}
+							result = {
+								protocol: PI_SUBAGENTS_V1,
+								methods: [...METHODS],
+								ceiling: ceilings.resolve(),
+								ceilingAudit: ceilings.audit(),
+								status: dependencies.status?.(),
+							};
+							break;
+						case "preflight":
+							result = await dependencies.preflight(request.payload, ctx);
+							break;
+						case "delegate":
+							pi.events.emit(PI_SUBAGENTS_V1_PROGRESS, {
+								requestId: request.requestId,
+								state: "running",
+							});
+							result = await dependencies.delegate(request.payload, controller.signal, ctx);
+							break;
+						case "ceiling.register": {
+							const payload = requiredObject(request.payload);
+							assertOnlyFields(payload, ["source", "ceiling"]);
+							const source = requiredStringField(payload, "source");
+							const token = ceilings.register(source, requiredCeiling(payload.ceiling));
+							result = { token, ceiling: ceilings.resolve() };
+							break;
+						}
+						case "ceiling.update": {
+							const payload = requiredObject(request.payload);
+							assertOnlyFields(payload, ["token", "ceiling"]);
+							ceilings.update(
+								requiredStringField(payload, "token"),
+								requiredCeiling(payload.ceiling),
+							);
+							result = { ceiling: ceilings.resolve() };
+							break;
+						}
+						case "ceiling.dispose": {
+							const payload = requiredObject(request.payload);
+							assertOnlyFields(payload, ["token"]);
+							result = {
+								disposed: ceilings.dispose(requiredStringField(payload, "token")),
+								ceiling: ceilings.resolve(),
+							};
+							break;
+						}
+						default:
+							throw new Error("Unsupported method");
+					}
+					if (boundGeneration !== generation || controller.signal.aborted) {
+						throw abortError();
+					}
+					reply({ requestId: request.requestId, ok: true, result });
+				})
+				.catch((error) => {
+					if (boundGeneration !== generation) return;
+					fail(
+						request.requestId,
+						controller.signal.aborted ? "cancelled" : "request_failed",
+						error,
+					);
+				})
+				.finally(() => {
+					if (active.get(request.requestId) === controller) {
+						active.delete(request.requestId);
+					}
+					if (boundGeneration === generation && !settled.has(request.requestId)) {
+						rememberSettled(request.requestId);
+					}
+				});
+		});
+		pi.events.emit(PI_SUBAGENTS_V1_READY, { protocol: PI_SUBAGENTS_V1 });
+	});
+
+	pi.on("session_shutdown", () => reset());
+}
+
+function parseRequest(
+	value: unknown,
+): { ok: true; request: PiSubagentsV1Request } | { ok: false; requestId?: string; error: string } {
+	if (!isPlainObject(value)) return { ok: false, error: "Request must be an object" };
+	const requestId = typeof value.requestId === "string" ? value.requestId : undefined;
+	if (!requestId || requestId.length > 128 || !/^[A-Za-z0-9._:-]+$/u.test(requestId)) {
+		return { ok: false, requestId, error: "Invalid requestId" };
+	}
+	if (typeof value.method !== "string" || !METHODS.has(value.method as PiSubagentsV1Method)) {
+		return { ok: false, requestId, error: "Unsupported method" };
+	}
+	if (Object.keys(value).some((key) => !["requestId", "method", "payload"].includes(key))) {
+		return { ok: false, requestId, error: "Unknown request field" };
+	}
+	return {
+		ok: true,
+		request: {
+			requestId,
+			method: value.method as PiSubagentsV1Method,
+			...(Object.hasOwn(value, "payload") ? { payload: value.payload } : {}),
+		},
+	};
+}
+
+function requiredObject(value: unknown): Record<string, unknown> {
+	if (!isPlainObject(value)) throw new Error("Payload must be an object");
+	return value;
+}
+
+function assertOnlyFields(value: unknown, allowed: readonly string[]): void {
+	const object = requiredObject(value);
+	if (Object.keys(object).some((key) => !allowed.includes(key))) {
+		throw new Error("Payload contains an unsupported field");
+	}
+}
+
+function requiredStringField(value: unknown, field: string): string {
+	const object = requiredObject(value);
+	const candidate = object[field];
+	if (typeof candidate !== "string" || !candidate.trim() || candidate.length > 256) {
+		throw new Error(`${field} must be a non-empty bounded string`);
+	}
+	return candidate;
+}
+
+function requiredCeiling(value: unknown): CapabilityCeiling {
+	if (!isPlainObject(value)) throw new Error("ceiling must be an object");
+	return value as CapabilityCeiling;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function safeMessage(value: unknown): string {
+	return safeTerminalLine(value instanceof Error ? value.message : String(value), 1024);
+}
+
+function abortError(): Error {
+	const error = new Error("pi-subagents request was cancelled");
+	error.name = "AbortError";
+	return error;
+}

--- a/packages/pi-subagents/src/public-api.ts
+++ b/packages/pi-subagents/src/public-api.ts
@@ -98,7 +98,7 @@ export function registerPiSubagentsV1Api(
 	pi: ExtensionAPI,
 	ceilings: CapabilityCeilingRegistry,
 	dependencies: PublicApiDependencies,
-): void {
+): () => void {
 	let generation = 0;
 	let disposeRequest: (() => void) | undefined;
 	let currentContext: ExtensionContext | undefined;
@@ -257,6 +257,7 @@ export function registerPiSubagentsV1Api(
 	});
 
 	pi.on("session_shutdown", () => reset());
+	return reset;
 }
 
 function parseRequest(

--- a/packages/pi-subagents/src/registry.ts
+++ b/packages/pi-subagents/src/registry.ts
@@ -2,6 +2,12 @@ import { randomUUID } from "node:crypto";
 import { projectAgentRecords } from "./agent-projection.js";
 import type { SubagentThinkingLevel } from "./agents.js";
 import type { TargetPolicyAudit } from "./cwd-policy.js";
+import {
+	appendEvidenceInstruction,
+	type EvidenceAttestation,
+	type EvidencePolicy,
+	parseEvidenceAttestation,
+} from "./evidence.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
 import { resolveStatefulLimits } from "./stateful-limits.js";
 import { type AgentTurnRunner, normalizeTransport, type SubagentTransport } from "./transport.js";
@@ -24,6 +30,7 @@ export interface AgentTurn {
 	completedAt: number;
 	exitCode: number;
 	truncated?: boolean;
+	evidence?: EvidenceAttestation;
 }
 
 export interface AgentMailboxMessage {
@@ -60,6 +67,11 @@ export interface ManagedAgent {
 	policy?: { inherited: string[]; overridden: string[]; unsupported: string[] };
 	mailbox: AgentMailboxMessage[];
 	currentMailboxMessageIds?: string[];
+	evidencePolicy?: EvidencePolicy;
+	evidenceStatus?: EvidenceAttestation["status"];
+	launchContractDigest?: string;
+	capabilityTools?: string[];
+	disableExtensions?: boolean;
 }
 
 export interface AgentRunInspectionSummary {
@@ -70,6 +82,7 @@ export interface AgentRunInspectionSummary {
 	updatedAt: number;
 	historyCount: number;
 	unreadMessages: number;
+	evidenceStatus?: EvidenceAttestation["status"];
 }
 
 export interface AgentRunInspectionDetail extends AgentRunInspectionSummary {
@@ -80,6 +93,9 @@ export interface AgentRunInspectionDetail extends AgentRunInspectionSummary {
 	workspaceMode?: "worktree";
 	target?: TargetPolicyAudit;
 	policy?: { inherited: string[]; overridden: string[]; unsupported: string[] };
+	launchContractDigest?: string;
+	capabilityTools?: string[];
+	disableExtensions?: boolean;
 }
 
 export interface AgentInspectionCounts {
@@ -94,6 +110,7 @@ export interface TurnOutcome {
 	truncated?: boolean;
 	error?: string;
 	policy?: ManagedAgent["policy"];
+	evidence?: EvidenceAttestation;
 }
 
 export interface AgentTurnCompletion {
@@ -241,7 +258,10 @@ export class AgentRegistry {
 				mailbox: (record.mailbox ?? [])
 					.slice(-this.maxMailboxMessages)
 					.map((message) => ({ ...message, recipientId: record.id })),
-				history: record.history.slice(-this.maxHistoryTurns).map((turn) => ({ ...turn })),
+				history: record.history.slice(-this.maxHistoryTurns).map((turn) => ({
+					...turn,
+					evidence: turn.evidence ? copyEvidence(turn.evidence) : undefined,
+				})),
 			});
 		}
 		for (const agent of this.agents.values()) {
@@ -263,6 +283,10 @@ export class AgentRegistry {
 		contextTruncated?: boolean;
 		workspaceMode?: "worktree";
 		target?: TargetPolicyAudit;
+		evidencePolicy?: EvidencePolicy;
+		launchContractDigest?: string;
+		capabilityTools?: string[];
+		disableExtensions?: boolean;
 	}): Promise<ManagedAgent> {
 		if (!input.task.trim()) throw new Error("Subagent tasks cannot be empty");
 		const task = truncateUtf8(input.task, this.maxTaskBytes).text;
@@ -308,6 +332,10 @@ export class AgentRegistry {
 			contextTruncated: input.contextTruncated,
 			workspaceMode: input.workspaceMode,
 			target: input.target,
+			evidencePolicy: input.evidencePolicy,
+			launchContractDigest: input.launchContractDigest,
+			capabilityTools: input.capabilityTools ? [...input.capabilityTools] : undefined,
+			disableExtensions: input.disableExtensions,
 		};
 		this.agents.set(record.id, record);
 		if (parent) {
@@ -580,6 +608,9 @@ export class AgentRegistry {
 						unsupported: [...agent.policy.unsupported],
 					}
 				: undefined,
+			launchContractDigest: agent.launchContractDigest,
+			capabilityTools: agent.capabilityTools ? [...agent.capabilityTools] : undefined,
+			disableExtensions: agent.disableExtensions,
 		};
 	}
 
@@ -647,7 +678,11 @@ export class AgentRegistry {
 		let completionOutput = "";
 		let completionError: string | undefined;
 		void this.transport
-			.runTurn(this.copy(agent), task, controller.signal)
+			.runTurn(
+				this.copy(agent),
+				appendEvidenceInstruction(task, agent.evidencePolicy),
+				controller.signal,
+			)
 			.then(async (outcome) => {
 				const output = truncateUtf8(outcome.output, this.maxTurnOutputBytes).text;
 				const error = outcome.error
@@ -669,6 +704,10 @@ export class AgentRegistry {
 						: "failed";
 				agent.error = error;
 				agent.policy = outcome.policy;
+				const evidence = outcome.evidence ?? parseEvidenceAttestation(output, agent.evidencePolicy);
+				agent.evidenceStatus = evidence?.status;
+				const latestTurn = agent.history.at(-1);
+				if (latestTurn && evidence) latestTurn.evidence = evidence;
 				completionOutput = output;
 				completionError = error;
 				completionContent = output || error || `${agent.id} ${agent.state}`;
@@ -851,6 +890,7 @@ export class AgentRegistry {
 			updatedAt: agent.updatedAt,
 			historyCount: agent.history.length,
 			unreadMessages,
+			...(agent.evidenceStatus ? { evidenceStatus: agent.evidenceStatus } : {}),
 		};
 	}
 
@@ -862,8 +902,12 @@ export class AgentRegistry {
 			currentMailboxMessageIds: agent.currentMailboxMessageIds
 				? [...agent.currentMailboxMessageIds]
 				: undefined,
-			history: agent.history.map((turn) => ({ ...turn })),
+			history: agent.history.map((turn) => ({
+				...turn,
+				evidence: turn.evidence ? copyEvidence(turn.evidence) : undefined,
+			})),
 			mailbox: agent.mailbox.map((message) => ({ ...message })),
+			capabilityTools: agent.capabilityTools ? [...agent.capabilityTools] : undefined,
 			target: agent.target ? { ...agent.target, trust: { ...agent.target.trust } } : undefined,
 			policy: agent.policy
 				? {
@@ -874,4 +918,14 @@ export class AgentRegistry {
 				: undefined,
 		};
 	}
+}
+
+function copyEvidence(evidence: EvidenceAttestation): EvidenceAttestation {
+	return {
+		...evidence,
+		changedFiles: evidence.changedFiles ? [...evidence.changedFiles] : undefined,
+		commandsRun: evidence.commandsRun ? [...evidence.commandsRun] : undefined,
+		validations: evidence.validations ? [...evidence.validations] : undefined,
+		residualRisks: evidence.residualRisks ? [...evidence.residualRisks] : undefined,
+	};
 }

--- a/packages/pi-subagents/src/runner.ts
+++ b/packages/pi-subagents/src/runner.ts
@@ -7,6 +7,7 @@ import type { Message } from "@earendil-works/pi-ai";
 import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig, AgentScope, AgentSource, SubagentThinkingLevel } from "./agents.js";
 import type { TargetPolicyAudit } from "./cwd-policy.js";
+import type { EvidenceAttestation } from "./evidence.js";
 import {
 	appendBounded,
 	DEFAULT_MAX_CONTEXT_BYTES,
@@ -89,6 +90,8 @@ export interface SingleResult {
 		overridden: string[];
 		unsupported: string[];
 	};
+	evidence?: EvidenceAttestation;
+	launchContractDigest?: string;
 }
 
 export interface SubagentDetails {

--- a/packages/pi-subagents/src/settings.ts
+++ b/packages/pi-subagents/src/settings.ts
@@ -12,7 +12,9 @@ import {
 	type ConsultResourcePolicy,
 	DELEGATION_CWD_POLICIES,
 	type DelegationCwdPolicy,
+	type FleetViewMode,
 	isThinkingLevel,
+	type LifecycleArtifactsMode,
 	type SubagentAgentConfig,
 	type SubagentSettings,
 	type SubagentThinkingLevel,
@@ -157,6 +159,21 @@ export function normalizeSubagentSettings(value: unknown): SubagentSettings | un
 			if (typeof value.stateful.enabled !== "boolean") return undefined;
 			runtime.enabled = value.stateful.enabled;
 		}
+		if (hasOwn(value.stateful, "fleetView")) {
+			if (value.stateful.fleetView !== "off" && value.stateful.fleetView !== "active") {
+				return undefined;
+			}
+			runtime.fleetView = value.stateful.fleetView;
+		}
+		if (hasOwn(value.stateful, "lifecycleArtifacts")) {
+			if (
+				value.stateful.lifecycleArtifacts !== "off" &&
+				value.stateful.lifecycleArtifacts !== "metadata"
+			) {
+				return undefined;
+			}
+			runtime.lifecycleArtifacts = value.stateful.lifecycleArtifacts;
+		}
 		settings.stateful = runtime;
 	}
 	if (hasOwn(value, "consult")) {
@@ -290,6 +307,13 @@ export interface DelegationWorkflowSettingsSnapshot {
 export interface CompletionDeliverySettingsSnapshot {
 	path: string;
 	value: CompletionDelivery;
+	source: "default" | "user settings";
+	error?: string;
+}
+
+export interface StatefulFeatureSettingsSnapshot<T> {
+	path: string;
+	value: T;
 	source: "default" | "user settings";
 	error?: string;
 }
@@ -492,6 +516,36 @@ export function inspectCompletionDeliverySettings(): CompletionDeliverySettingsS
 	};
 }
 
+export function inspectFleetViewSettings(): StatefulFeatureSettingsSnapshot<FleetViewMode> {
+	return inspectStatefulFeature("fleetView", "off");
+}
+
+export function inspectLifecycleArtifactSettings(): StatefulFeatureSettingsSnapshot<LifecycleArtifactsMode> {
+	return inspectStatefulFeature("lifecycleArtifacts", "off");
+}
+
+function inspectStatefulFeature<T extends FleetViewMode | LifecycleArtifactsMode>(
+	field: "fleetView" | "lifecycleArtifacts",
+	defaultValue: T,
+): StatefulFeatureSettingsSnapshot<T> {
+	const inspected = inspectSubagentSettingsDocument();
+	if (!inspected.raw || !inspected.settings) {
+		return {
+			path: inspected.path,
+			value: defaultValue,
+			source: "default",
+			...(inspected.error ? { error: inspected.error } : {}),
+		};
+	}
+	const rawStateful = isPlainObject(inspected.raw.stateful) ? inspected.raw.stateful : undefined;
+	const value = inspected.settings.stateful?.[field] ?? defaultValue;
+	return {
+		path: inspected.path,
+		value: value as T,
+		source: rawStateful && hasOwn(rawStateful, field) ? "user settings" : "default",
+	};
+}
+
 export function resolveBlockingMaxParallelTasks(settings?: SubagentSettings): number {
 	return settings?.blocking?.maxParallelTasks ?? DEFAULT_MAX_PARALLEL_TASKS;
 }
@@ -585,6 +639,36 @@ export function updateCompletionDeliverySetting(value: CompletionDelivery): void
 					completionDelivery: value,
 				},
 			},
+			update.replaceCanonical,
+		);
+	});
+}
+
+export function updateFleetViewSetting(value: FleetViewMode): void {
+	if (value !== "off" && value !== "active") throw new Error("Invalid FleetView setting");
+	updateStatefulFeatureSetting("fleetView", value);
+}
+
+export function updateLifecycleArtifactSetting(value: LifecycleArtifactsMode): void {
+	if (value !== "off" && value !== "metadata") {
+		throw new Error("Invalid lifecycle artifact setting");
+	}
+	updateStatefulFeatureSetting("lifecycleArtifacts", value);
+}
+
+function updateStatefulFeatureSetting(
+	field: "fleetView" | "lifecycleArtifacts",
+	value: FleetViewMode | LifecycleArtifactsMode,
+): void {
+	withSettingsMutationLock(() => {
+		const update = readSettingsObjectForUpdate();
+		const raw = update.document;
+		const stateful = raw.stateful;
+		if (stateful !== undefined && !isPlainObject(stateful)) {
+			throw new Error(`Cannot update invalid ${SETTINGS_FILE} stateful settings`);
+		}
+		writeSettingsObjectUnlocked(
+			{ ...raw, stateful: { ...(stateful ?? {}), [field]: value } },
 			update.replaceCanonical,
 		);
 	});

--- a/packages/pi-subagents/src/stateful-presenter.ts
+++ b/packages/pi-subagents/src/stateful-presenter.ts
@@ -1,0 +1,59 @@
+import { truncateUtf8 } from "./limits.js";
+import type { ManagedAgent } from "./registry.js";
+
+const MAX_TOOL_MESSAGE_BYTES = 2 * 1024;
+
+export function formatStatefulAgentLine(agent: ManagedAgent): string {
+	const elapsedSeconds = Math.max(0, Math.floor((Date.now() - agent.updatedAt) / 1000));
+	const actions =
+		agent.state === "running" || agent.state === "starting"
+			? "interrupt, close"
+			: agent.state === "closed"
+				? "inspect"
+				: "send, close";
+	const task = agent.currentTask ? ` — ${sanitizeStatusLine(agent.currentTask, 80)}` : "";
+	const unread = agent.mailbox.filter((message) => !message.readAt).length;
+	const indent = "  ".repeat(agent.depth);
+	const thinking = agent.thinkingLevel ? ` thinking:${agent.thinkingLevel}` : "";
+	return `${indent}${sanitizeStatusLine(agent.id, 128)} ${sanitizeStatusLine(agent.agent, 128)} ${agent.state} ${elapsedSeconds}s${thinking} unread:${unread} [${actions}]${task}`;
+}
+
+export function summarizeStatefulAgent(agent: ManagedAgent) {
+	return {
+		id: agent.id,
+		agent: agent.agent,
+		parentId: agent.parentId,
+		rootId: agent.rootId,
+		depth: agent.depth,
+		children: [...agent.children],
+		state: agent.state,
+		createdAt: agent.createdAt,
+		updatedAt: agent.updatedAt,
+		cwd: agent.cwd,
+		workspaceMode: agent.workspaceMode ?? "shared",
+		thinkingLevel: agent.thinkingLevel,
+		currentTask: agent.currentTask
+			? truncateUtf8(agent.currentTask, MAX_TOOL_MESSAGE_BYTES).text
+			: undefined,
+		historyCount: agent.history.length,
+		unreadMessages: agent.mailbox.filter((message) => !message.readAt).length,
+		error: agent.error ? truncateUtf8(agent.error, MAX_TOOL_MESSAGE_BYTES).text : undefined,
+		target: agent.target,
+		policy: agent.policy,
+		evidenceStatus: agent.evidenceStatus,
+		launchContractDigest: agent.launchContractDigest,
+		capabilityTools: agent.capabilityTools ? [...agent.capabilityTools] : undefined,
+		disableExtensions: agent.disableExtensions,
+	};
+}
+
+function sanitizeStatusLine(value: string, maxLength: number): string {
+	return (
+		value
+			.slice(0, maxLength)
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: Escape untrusted terminal controls.
+			.replace(/[\u0000-\u001f\u007f-\u009f]/gu, " ")
+			.replace(/\s+/gu, " ")
+			.trim()
+	);
+}

--- a/packages/pi-subagents/src/stateful.ts
+++ b/packages/pi-subagents/src/stateful.ts
@@ -15,31 +15,41 @@ import {
 	type SubagentSettings,
 	THINKING_LEVELS,
 } from "./agents.js";
+import type { CapabilityCeilingRegistry } from "./capability-ceiling.js";
+import { CompletionDeliveryBroker } from "./completion-delivery.js";
 import { buildContextSnapshot, type ContextMode, redactPrivateText } from "./context.js";
 import {
 	assertDelegationTargetAllowed,
 	resolveSubagentTarget,
 	targetPolicyAudit,
 } from "./cwd-policy.js";
-import { assertSubagentDepthAllowed } from "./execution.js";
+import type { EvidencePolicy } from "./evidence.js";
+import { assertSubagentDepthAllowed, resolveDefaultSubagentTimeoutMs } from "./execution.js";
+import { updateFleetWidget } from "./fleet-view.js";
 import {
 	type ChildSessionFactory,
 	InProcessTransport,
 	type ParentRuntimeSnapshot,
 } from "./in-process-transport.js";
+import { resolveLaunchContract } from "./launch-contract.js";
+import {
+	disabledLifecycleArtifactStatus,
+	type LifecycleArtifactStatus,
+	LifecycleArtifactWriter,
+} from "./lifecycle-artifacts.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
 import { AgentPersistence } from "./persistence.js";
 import {
 	AgentRegistry,
 	type AgentRunInspectionDetail,
 	type AgentRunInspectionSummary,
-	type AgentTurnCompletion,
 	type ManagedAgent,
 } from "./registry.js";
 import { DEFAULT_DELEGATION_CWD_POLICY, readSubagentSettings } from "./settings.js";
 import { createSpawnPromptGuidelines } from "./stateful-guidance.js";
 import { assertCurrentSpawn, disposeStatefulRuntime } from "./stateful-lifecycle.js";
 import { resolveStatefulLimits, type StatefulLimits } from "./stateful-limits.js";
+import { formatStatefulAgentLine, summarizeStatefulAgent } from "./stateful-presenter.js";
 import { createStatefulToolRenderer } from "./stateful-render.js";
 import {
 	assertFollowUpWriteAllowed,
@@ -75,10 +85,10 @@ const StatefulThinkingLevelSchema = StringEnum(THINKING_LEVELS, {
 	description:
 		"Optional requested Pi thinking level selected for this task difficulty; retained for every turn of the spawned agent.",
 });
+const EvidenceSchema = StringEnum(["attested"] as const, {
+	description: "Request bounded, unverified child evidence metadata for every turn.",
+});
 const MAX_TOOL_MESSAGE_BYTES = 2 * 1024;
-const MAX_COMPLETION_ERROR_BYTES = 512;
-const MAX_COMPLETIONS_PER_MESSAGE = 16;
-const COMPLETION_BATCH_DELAY_MS = 10;
 
 export interface StatefulSubagentDependencies {
 	blockingEnabled?: boolean;
@@ -86,6 +96,7 @@ export interface StatefulSubagentDependencies {
 	workspaceManager?: WorkspaceManager;
 	settings?: SubagentRuntimeSettings;
 	getSettings?: () => SubagentSettings | undefined;
+	ceilings?: CapabilityCeilingRegistry;
 }
 
 export interface StatefulSubagentRuntimeStatus {
@@ -104,9 +115,21 @@ export interface StatefulSubagentController {
 	setAgentCatalog(value: string): void;
 	refreshSettingsGuidance(): void;
 	getRuntimeStatus(): StatefulSubagentRuntimeStatus;
+	getFleetView(): "off" | "active";
+	getLifecycleArtifactStatus(): LifecycleArtifactStatus;
 	listAgents(includeClosed?: boolean): ManagedAgent[];
 	listRunInspection(includeClosed?: boolean): AgentRunInspectionSummary[];
 	getRunInspection(agentId: string): AgentRunInspectionDetail | undefined;
+	setFleetView(value: "off" | "active"): void;
+	followUp(
+		agentId: string,
+		task: string,
+		ctx: ExtensionContext,
+		signal?: AbortSignal,
+	): Promise<ManagedAgent>;
+	queueMessage(agentId: string, message: string): Promise<void>;
+	interruptAgent(agentId: string, subtree?: boolean): Promise<number>;
+	closeAgent(agentId: string, subtree?: boolean): Promise<number>;
 	clearAgents(): Promise<number>;
 }
 
@@ -126,12 +149,15 @@ export function registerStatefulSubagents(
 	const enabled = settings.enabled !== false;
 	const transportKind = resolveStatefulTransportKind(settings.transport);
 	let completionDelivery = resolveCompletionDelivery(settings.completionDelivery);
+	let fleetView = settings.fleetView ?? "off";
 	let runtimeLimits = resolveStatefulLimits(settings);
 	let agentCatalog = "";
 	let completionBroker: CompletionDeliveryBroker | undefined;
 	let refreshSpawnToolRegistration: (() => void) | undefined;
 	let registry: AgentRegistry | undefined;
 	let persistence: AgentPersistence | undefined;
+	let artifactWriter: LifecycleArtifactWriter | undefined;
+	let activeContext: ExtensionContext | undefined;
 	let sweepTimer: NodeJS.Timeout | undefined;
 	let runtimeGeneration = 0;
 	let runtimeTransition: Promise<void> = Promise.resolve();
@@ -143,6 +169,26 @@ export function registerStatefulSubagents(
 		dependencies.getSettings ? dependencies.getSettings() : readSubagentSettings();
 	const getCurrentStatefulSettings = () =>
 		dependencies.getSettings ? (dependencies.getSettings()?.stateful ?? {}) : settings;
+	const refreshFleet = (agents = registry?.list() ?? []) => {
+		if (activeContext) updateFleetWidget(activeContext, fleetView === "active", agents);
+	};
+	const clearFleetBestEffort = (ctx: Pick<ExtensionContext, "mode" | "ui"> | undefined) => {
+		if (!ctx) return;
+		try {
+			updateFleetWidget(ctx, false, []);
+		} catch {
+			// Widget cleanup must not block session replacement or shutdown.
+		}
+	};
+	const requireRegistry = () => {
+		if (!registry) throw new Error("Stateful subagents are not initialized for this session");
+		return registry;
+	};
+	const requireAgent = (agentId: string) => {
+		const agent = requireRegistry().get(agentId);
+		if (!agent) throw new Error(`Unknown subagent: ${agentId}`);
+		return agent;
+	};
 
 	const clearAgents = async (): Promise<number> => {
 		const generation = runtimeGeneration;
@@ -162,6 +208,101 @@ export function registerStatefulSubagents(
 		runtimeTransition = transition.catch(() => undefined);
 		await transition;
 		return count;
+	};
+	const followUp = async (
+		agentId: string,
+		task: string,
+		ctx: ExtensionContext,
+		signal?: AbortSignal,
+	): Promise<ManagedAgent> => {
+		const generation = runtimeGeneration;
+		const ownedRegistry = requireRegistry();
+		const currentSettings = getCurrentSettings();
+		const existing = ownedRegistry.get(agentId);
+		if (!existing) throw new Error(`Unknown subagent: ${agentId}`);
+		await confirmProjectAgent(
+			existing.agent,
+			existing.agentScope ?? "user",
+			false,
+			ctx,
+			existing.cwd,
+			currentSettings,
+		);
+		assertCurrentSpawn(signal, generation, runtimeGeneration);
+		assertFollowUpWriteAllowed(
+			ownedRegistry,
+			existing,
+			false,
+			isolatedAgents.has(existing.id),
+			currentSettings,
+		);
+		assertRetainedContractCompatible(existing, currentSettings);
+		return ownedRegistry.followUp(agentId, task);
+	};
+	const interruptAgent = async (agentId: string, subtree = false): Promise<number> => {
+		if (subtree) return (await requireRegistry().interruptTree(agentId)).length;
+		await requireRegistry().interrupt(agentId);
+		return 1;
+	};
+	const closeAgent = async (agentId: string, subtree = false): Promise<number> => {
+		const ownedRegistry = requireRegistry();
+		let count = 0;
+		try {
+			if (subtree) count = (await ownedRegistry.closeTree(agentId)).length;
+			else {
+				await ownedRegistry.close(agentId);
+				count = 1;
+			}
+		} finally {
+			await cleanupClosedWorkspaces(ownedRegistry, isolatedAgents, workspaceManager);
+		}
+		return count;
+	};
+	const assertRetainedContractCompatible = (
+		existing: ManagedAgent,
+		currentSettings: SubagentSettings | undefined,
+	) => {
+		const ceiling = dependencies.ceilings?.resolve() ?? { sources: [] };
+		if (ceiling.sources.length === 0) return;
+		const agent = discoverAgents(
+			existing.cwd,
+			existing.agentScope ?? "user",
+			currentSettings,
+		).agents.find((candidate) => candidate.name === existing.agent);
+		if (!agent) throw new Error(`Unknown subagent: ${existing.agent}`);
+		const target =
+			existing.target ??
+			targetPolicyAudit(
+				resolveSubagentTarget({
+					workspace: activeContext?.cwd ?? existing.cwd,
+					requestedCwd: existing.cwd,
+					currentProjectTrusted: activeContext?.isProjectTrusted() ?? false,
+				}),
+			);
+		const contract = resolveLaunchContract({
+			agent,
+			agentScope: existing.agentScope ?? "user",
+			target,
+			thinkingLevel: existing.thinkingLevel ?? agent.thinkingLevel,
+			timeoutMs: agent.timeoutMs ?? resolveDefaultSubagentTimeoutMs(),
+			transport: transportKind,
+			evidence: existing.evidencePolicy,
+			disableExtensions: transportKind === "in-process",
+			ceiling,
+		});
+		const previousTools = existing.capabilityTools ?? agent.tools;
+		const currentTools = contract.effectiveTools;
+		const toolsNarrowed =
+			previousTools === undefined
+				? currentTools !== undefined
+				: currentTools !== undefined && previousTools.some((tool) => !currentTools.includes(tool));
+		const previousDisableExtensions = existing.disableExtensions ?? contract.disableExtensions;
+		const extensionsNarrowed = contract.disableExtensions && !previousDisableExtensions;
+		if (toolsNarrowed || extensionsNarrowed) {
+			throw new Error(
+				"The active capability ceiling narrows this retained agent; create a new compliant agent",
+			);
+		}
 	};
 	const controller: StatefulSubagentController = {
 		getCompletionDelivery() {
@@ -190,6 +331,12 @@ export function registerStatefulSubagents(
 				...counts,
 			};
 		},
+		getFleetView() {
+			return fleetView;
+		},
+		getLifecycleArtifactStatus() {
+			return artifactWriter?.status() ?? disabledLifecycleArtifactStatus();
+		},
 		listAgents(includeClosed = false) {
 			return registry?.list(includeClosed) ?? [];
 		},
@@ -199,22 +346,40 @@ export function registerStatefulSubagents(
 		getRunInspection(agentId) {
 			return registry?.getInspection(agentId);
 		},
+		setFleetView(value) {
+			const previous = fleetView;
+			fleetView = value;
+			try {
+				refreshFleet();
+			} catch (error) {
+				fleetView = previous;
+				try {
+					refreshFleet();
+				} catch (rollbackError) {
+					throw new AggregateError(
+						[error, rollbackError],
+						"Failed to apply and roll back FleetView",
+					);
+				}
+				throw error;
+			}
+		},
+		followUp,
+		async queueMessage(agentId, message) {
+			await requireRegistry().sendMessage(agentId, message);
+		},
+		interruptAgent,
+		closeAgent,
 		clearAgents,
 	};
 	if (!enabled) return controller;
 
-	const requireRegistry = () => {
-		if (!registry) throw new Error("Stateful subagents are not initialized for this session");
-		return registry;
-	};
-	const requireAgent = (agentId: string) => {
-		const agent = requireRegistry().get(agentId);
-		if (!agent) throw new Error(`Unknown subagent: ${agentId}`);
-		return agent;
-	};
-
 	pi.on("session_start", async (_event, ctx) => {
 		const generation = ++runtimeGeneration;
+		clearFleetBestEffort(activeContext);
+		activeContext = ctx;
+		artifactWriter?.close();
+		artifactWriter = undefined;
 		completionBroker?.close();
 		completionBroker = undefined;
 		if (sweepTimer) clearInterval(sweepTimer);
@@ -245,6 +410,20 @@ export function registerStatefulSubagents(
 				retentionDays: sessionSettings.retentionDays,
 				maxStoredAgents: nextLimits.maxStoredAgents,
 			});
+			const sessionArtifactWriter =
+				sessionSettings.lifecycleArtifacts === "metadata"
+					? new LifecycleArtifactWriter(
+							owner,
+							sessionSettings.retentionDays,
+							undefined,
+							() => generation === runtimeGeneration,
+						)
+					: undefined;
+			await sessionArtifactWriter?.cleanupExpired();
+			if (generation !== runtimeGeneration) {
+				sessionArtifactWriter?.close();
+				return;
+			}
 			const sessionBroker = new CompletionDeliveryBroker(pi, ctx, completionDelivery, {
 				onDeliveryError: (error) => {
 					if (!ctx.hasUI) return;
@@ -258,12 +437,16 @@ export function registerStatefulSubagents(
 							modelRegistry: ctx.modelRegistry,
 							getParentRuntime: () => ({ ...parentRuntime }),
 							createSession: dependencies.createInProcessSession,
-							discoverAgent: (agent) =>
-								discoverAgents(
+							discoverAgent: (agent) => {
+								const candidate = discoverAgents(
 									agent.cwd,
 									agent.agentScope ?? "user",
 									getCurrentSettings(),
-								).agents.find((candidate) => candidate.name === agent.agent),
+								).agents.find((entry) => entry.name === agent.agent);
+								return candidate && agent.capabilityTools
+									? { ...candidate, tools: [...agent.capabilityTools] }
+									: candidate;
+							},
 						})
 					: new SubprocessTransport({ getSettings: getCurrentSettings });
 			const nextRegistry = new AgentRegistry(transport, {
@@ -277,6 +460,18 @@ export function registerStatefulSubagents(
 				onChange: async (agents) => {
 					await sessionPersistence.save(agents);
 					if (generation !== runtimeGeneration) return;
+					await sessionArtifactWriter?.publish(agents);
+					if (generation !== runtimeGeneration) return;
+					try {
+						refreshFleet(agents);
+					} catch (error) {
+						fleetView = "off";
+						clearFleetBestEffort(ctx);
+						if (ctx.hasUI) {
+							const reason = error instanceof Error ? error.message : String(error);
+							ctx.ui.notify(`Subagent FleetView was disabled: ${reason}`, "warning");
+						}
+					}
 					for (const agent of agents) {
 						for (const message of agent.mailbox) {
 							if (seenMessageIds.has(message.id)) continue;
@@ -319,14 +514,34 @@ export function registerStatefulSubagents(
 			nextRegistry.restore(restored);
 			if (generation !== runtimeGeneration) {
 				sessionBroker.close();
+				sessionArtifactWriter?.close();
+				await disposeStatefulRuntime(nextRegistry, workspaceManager);
+				return;
+			}
+			await sessionArtifactWriter?.publish(nextRegistry.list());
+			if (generation !== runtimeGeneration) {
+				sessionBroker.close();
+				sessionArtifactWriter?.close();
 				await disposeStatefulRuntime(nextRegistry, workspaceManager);
 				return;
 			}
 			registry = nextRegistry;
 			persistence = sessionPersistence;
+			artifactWriter = sessionArtifactWriter;
 			completionBroker = sessionBroker;
 			runtimeLimits = nextLimits;
+			fleetView = sessionSettings.fleetView ?? fleetView;
 			refreshSpawnToolRegistration?.();
+			try {
+				refreshFleet(nextRegistry.list());
+			} catch (error) {
+				fleetView = "off";
+				clearFleetBestEffort(ctx);
+				if (ctx.hasUI) {
+					const reason = error instanceof Error ? error.message : String(error);
+					ctx.ui.notify(`Subagent FleetView was disabled: ${reason}`, "warning");
+				}
+			}
 			const sweepEveryMs = Math.max(
 				1_000,
 				Math.min(sessionSettings.idleTtlMs ?? 60 * 60 * 1000, 60_000),
@@ -363,6 +578,10 @@ export function registerStatefulSubagents(
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		runtimeGeneration++;
+		clearFleetBestEffort(activeContext);
+		activeContext = undefined;
+		artifactWriter?.close();
+		artifactWriter = undefined;
 		completionBroker?.close();
 		completionBroker = undefined;
 		if (sweepTimer) clearInterval(sweepTimer);
@@ -395,6 +614,7 @@ export function registerStatefulSubagents(
 			agent: Type.String({ minLength: 1 }),
 			task: Type.String({ minLength: 1, maxLength: DEFAULT_MAX_CONTEXT_BYTES }),
 			thinkingLevel: Type.Optional(StatefulThinkingLevelSchema),
+			evidence: Type.Optional(EvidenceSchema),
 			cwd: Type.Optional(Type.String()),
 			agentScope: Type.Optional(ScopeSchema),
 			confirmProjectAgents: Type.Optional(Type.Boolean({ default: true })),
@@ -441,7 +661,8 @@ export function registerStatefulSubagents(
 			const resolvedAgent = discoverAgents(cwd, scope, currentSettings).agents.find(
 				(agent) => agent.name === params.agent,
 			);
-			if (params.workspaceMode === "worktree" && resolvedAgent?.source === "project") {
+			if (!resolvedAgent) throw new Error(`Unknown subagent: ${params.agent}`);
+			if (params.workspaceMode === "worktree" && resolvedAgent.source === "project") {
 				throw new Error("Project-local subagent definitions cannot run in a detached worktree");
 			}
 			const mode = resolveSpawnContextMode(params.context, params.contextEntryIds);
@@ -473,6 +694,17 @@ export function registerStatefulSubagents(
 				throw error;
 			}
 			const targetSnapshot = targetPolicyAudit(target);
+			const contract = resolveLaunchContract({
+				agent: resolvedAgent,
+				agentScope: scope,
+				target: targetSnapshot,
+				thinkingLevel: params.thinkingLevel ?? resolvedAgent.thinkingLevel,
+				timeoutMs: resolvedAgent.timeoutMs ?? resolveDefaultSubagentTimeoutMs(),
+				transport: transportKind,
+				evidence: params.evidence as EvidencePolicy | undefined,
+				disableExtensions: transportKind === "in-process",
+				ceiling: dependencies.ceilings?.resolve() ?? { sources: [] },
+			});
 			let agent: ManagedAgent | undefined;
 			try {
 				agent = await ownedRegistry.spawn({
@@ -487,6 +719,10 @@ export function registerStatefulSubagents(
 					contextTruncated: snapshot.truncated,
 					workspaceMode: workspace ? "worktree" : undefined,
 					target: targetSnapshot,
+					evidencePolicy: params.evidence as EvidencePolicy | undefined,
+					launchContractDigest: contract.digest,
+					capabilityTools: contract.effectiveTools,
+					disableExtensions: contract.disableExtensions,
 				});
 				assertCurrentSpawn(signal, generation, runtimeGeneration);
 			} catch (error) {
@@ -549,6 +785,7 @@ export function registerStatefulSubagents(
 				isolatedAgents.has(existing.id),
 				currentSettings,
 			);
+			assertRetainedContractCompatible(existing, currentSettings);
 			const agent = await ownedRegistry.followUp(params.agentId, params.task);
 			assertCurrentSpawn(signal, generation, runtimeGeneration);
 			return result(agent, `Started follow-up for ${agent.id}.`);
@@ -574,7 +811,7 @@ export function registerStatefulSubagents(
 							text: agents.length ? agents.map(formatLine).join("\n") : "No stateful subagents.",
 						},
 					],
-					details: { agents: agents.map(summarizeAgent) },
+					details: { agents: agents.map(summarizeStatefulAgent) },
 				};
 			}
 			const agentId = operation.agentId;
@@ -584,8 +821,8 @@ export function registerStatefulSubagents(
 					return {
 						content: [{ type: "text", text: `Interrupted ${agents.length} active agent(s).` }],
 						details: {
-							agent: summarizeAgent(requireAgent(agentId)),
-							agents: agents.map(summarizeAgent),
+							agent: summarizeStatefulAgent(requireAgent(agentId)),
+							agents: agents.map(summarizeStatefulAgent),
 						},
 					};
 				}
@@ -609,8 +846,8 @@ export function registerStatefulSubagents(
 				return {
 					content: [{ type: "text", text: `Closed ${agents.length} agent(s).` }],
 					details: {
-						agent: summarizeAgent(requireAgent(agentId)),
-						agents: agents.map(summarizeAgent),
+						agent: summarizeStatefulAgent(requireAgent(agentId)),
+						agents: agents.map(summarizeStatefulAgent),
 					},
 				};
 			}
@@ -684,276 +921,12 @@ export function resolveSpawnContextMode(
 	return normalizeContextMode(value);
 }
 
-export function formatStatefulAgentLine(agent: ManagedAgent): string {
-	const elapsedSeconds = Math.max(0, Math.floor((Date.now() - agent.updatedAt) / 1000));
-	const actions =
-		agent.state === "running" || agent.state === "starting"
-			? "interrupt, close"
-			: agent.state === "closed"
-				? "inspect"
-				: "send, close";
-	const task = agent.currentTask ? ` — ${sanitizeStatusLine(agent.currentTask, 80)}` : "";
-	const unread = agent.mailbox.filter((message) => !message.readAt).length;
-	const indent = "  ".repeat(agent.depth);
-	const thinking = agent.thinkingLevel ? ` thinking:${agent.thinkingLevel}` : "";
-	return `${indent}${sanitizeStatusLine(agent.id, 128)} ${sanitizeStatusLine(agent.agent, 128)} ${agent.state} ${elapsedSeconds}s${thinking} unread:${unread} [${actions}]${task}`;
-}
-
-function sanitizeStatusLine(value: string, maxLength: number): string {
-	return (
-		value
-			.slice(0, maxLength)
-			// biome-ignore lint/suspicious/noControlCharactersInRegex: Escape untrusted terminal controls.
-			.replace(/[\u0000-\u001f\u007f-\u009f]/gu, " ")
-			.replace(/\s+/gu, " ")
-			.trim()
-	);
-}
-
 function formatLine(agent: ManagedAgent): string {
 	return formatStatefulAgentLine(agent);
 }
 
-function summarizeAgent(agent: ManagedAgent) {
-	return {
-		id: agent.id,
-		agent: agent.agent,
-		parentId: agent.parentId,
-		rootId: agent.rootId,
-		depth: agent.depth,
-		children: [...agent.children],
-		state: agent.state,
-		createdAt: agent.createdAt,
-		updatedAt: agent.updatedAt,
-		cwd: agent.cwd,
-		workspaceMode: agent.workspaceMode ?? "shared",
-		thinkingLevel: agent.thinkingLevel,
-		currentTask: agent.currentTask
-			? truncateUtf8(agent.currentTask, MAX_TOOL_MESSAGE_BYTES).text
-			: undefined,
-		historyCount: agent.history.length,
-		unreadMessages: agent.mailbox.filter((message) => !message.readAt).length,
-		error: agent.error ? truncateUtf8(agent.error, MAX_TOOL_MESSAGE_BYTES).text : undefined,
-		target: agent.target,
-		policy: agent.policy,
-	};
-}
-
-interface CompletionMetadata {
-	agentId: string;
-	agent: string;
-	state: string;
-}
-
-interface CompletionMessage {
-	customType: "pi-subagent-completion";
-	content: string;
-	display: true;
-	details:
-		| CompletionMetadata
-		| {
-				completionCount: number;
-				completions: CompletionMetadata[];
-		  };
-}
-
-type CompletionContext = Pick<ExtensionContext, "hasPendingMessages" | "isIdle">;
-type CompletionPi = Pick<ExtensionAPI, "sendMessage">;
-
-export interface CompletionDeliveryBrokerOptions {
-	onDeliveryError?: (error: unknown) => void;
-}
-
-/**
- * Coalesces detached completions so one bounded notification batch starts at
- * most one root synthesis turn. The broker belongs to one parent session and
- * must be closed when that session is replaced or shut down.
- */
-export class CompletionDeliveryBroker {
-	private pending: AgentTurnCompletion[] = [];
-	private flushTimer?: NodeJS.Timeout;
-	private wakeInFlight = false;
-	private closed = false;
-
-	constructor(
-		private readonly pi: CompletionPi,
-		private readonly ctx: CompletionContext,
-		private delivery: CompletionDelivery,
-		private readonly options: CompletionDeliveryBrokerOptions = {},
-	) {}
-
-	enqueue(completion: AgentTurnCompletion): void {
-		if (this.closed) return;
-		this.pending.push(completion);
-		this.scheduleFlush();
-	}
-
-	setDelivery(value: CompletionDelivery): void {
-		this.delivery = value;
-		this.scheduleFlush();
-	}
-
-	onParentTurnStart(): void {
-		this.wakeInFlight = false;
-		this.scheduleFlush();
-	}
-
-	onParentSettled(): void {
-		this.wakeInFlight = false;
-		this.scheduleFlush();
-	}
-
-	flush(): void {
-		if (this.closed || this.pending.length === 0) return;
-		if (this.flushTimer) clearTimeout(this.flushTimer);
-		this.flushTimer = undefined;
-		if (this.delivery === "auto-resume" && !this.isRootIdle()) return;
-
-		const completions = this.pending.splice(0);
-		const batches = chunkCompletions(completions);
-		let canWake = this.shouldWakeRoot();
-		for (let index = 0; index < batches.length; index++) {
-			const triggerTurn = canWake && index === batches.length - 1;
-			const message = buildCompletionMessage(batches[index]);
-			if (triggerTurn) this.wakeInFlight = true;
-			try {
-				this.pi.sendMessage(message, { deliverAs: "steer", triggerTurn });
-			} catch (primaryError) {
-				if (triggerTurn) this.wakeInFlight = false;
-				canWake = false;
-				try {
-					this.pi.sendMessage(message, { deliverAs: "nextTurn", triggerTurn: false });
-				} catch (fallbackError) {
-					this.pending = [...batches.slice(index).flat(), ...this.pending];
-					try {
-						this.options.onDeliveryError?.(
-							new AggregateError(
-								[primaryError, fallbackError],
-								"Detached subagent completion delivery failed",
-							),
-						);
-					} catch {
-						// Delivery retention must survive a failing observer.
-					}
-					return;
-				}
-			}
-		}
-	}
-
-	close(): void {
-		this.closed = true;
-		if (this.flushTimer) clearTimeout(this.flushTimer);
-		this.flushTimer = undefined;
-		this.pending = [];
-	}
-
-	private scheduleFlush(): void {
-		if (this.closed || this.pending.length === 0 || this.flushTimer) return;
-		this.flushTimer = setTimeout(() => {
-			this.flushTimer = undefined;
-			this.flush();
-		}, COMPLETION_BATCH_DELAY_MS);
-	}
-
-	private isRootIdle(): boolean {
-		try {
-			return this.ctx.isIdle();
-		} catch {
-			return false;
-		}
-	}
-
-	private shouldWakeRoot(): boolean {
-		if (this.delivery !== "auto-resume" || this.wakeInFlight) return false;
-		try {
-			return !this.ctx.hasPendingMessages();
-		} catch {
-			return false;
-		}
-	}
-}
-
-function chunkCompletions(completions: AgentTurnCompletion[]): AgentTurnCompletion[][] {
-	const batches: AgentTurnCompletion[][] = [];
-	for (let index = 0; index < completions.length; index += MAX_COMPLETIONS_PER_MESSAGE) {
-		batches.push(completions.slice(index, index + MAX_COMPLETIONS_PER_MESSAGE));
-	}
-	return batches;
-}
-
-function buildCompletionMessage(completions: AgentTurnCompletion[]): CompletionMessage {
-	if (completions.length === 1) {
-		const completion = completions[0];
-		return {
-			customType: "pi-subagent-completion",
-			content: buildDetachedCompletionMessage(completion),
-			display: true,
-			details: completionMetadata(completion),
-		};
-	}
-	const content = truncateUtf8(
-		[
-			"Message Type: SUBAGENT_COMPLETION_BATCH",
-			`Completion Count: ${completions.length}`,
-			...completions.flatMap((completion, index) => [
-				"",
-				`--- Completion ${index + 1} of ${completions.length} ---`,
-				buildDetachedCompletionMessage(completion),
-			]),
-		].join("\n"),
-		DEFAULT_MAX_CONTEXT_BYTES,
-	).text;
-	return {
-		customType: "pi-subagent-completion",
-		content,
-		display: true,
-		details: {
-			completionCount: completions.length,
-			completions: completions.map(completionMetadata),
-		},
-	};
-}
-
-function completionMetadata(completion: AgentTurnCompletion): CompletionMetadata {
-	return {
-		agentId: completion.agent.id,
-		agent: completion.agent.agent,
-		state: completion.agent.state,
-	};
-}
-
-export function buildDetachedCompletionMessage(completion: AgentTurnCompletion): string {
-	const task = sanitizeCompletionLine(completion.task, 256) || "(unknown task)";
-	const agentName = sanitizeCompletionLine(completion.agent.agent, 128) || "(unknown agent)";
-	const output = redactPrivateText(completion.output);
-	const error = completion.error
-		? truncateUtf8(redactPrivateText(completion.error), MAX_COMPLETION_ERROR_BYTES).text
-		: "";
-	return truncateUtf8(
-		[
-			"Message Type: SUBAGENT_COMPLETION",
-			`Agent ID: ${completion.agent.id}`,
-			`Agent: ${agentName}`,
-			`Task: ${task}`,
-			`State: ${completion.agent.state}`,
-			...(error.trim() ? ["Error:", error] : []),
-			"Payload:",
-			output.trim() ? output : "(no output)",
-		].join("\n"),
-		MAX_TOOL_MESSAGE_BYTES,
-	).text;
-}
-
-function sanitizeCompletionLine(value: string, maxBytes: number): string {
-	return (
-		truncateUtf8(redactPrivateText(value), maxBytes)
-			// biome-ignore lint/suspicious/noControlCharactersInRegex: Strip untrusted terminal controls.
-			.text.replace(/[\u0000-\u001f\u007f]+/g, " ")
-			.replace(/\s+/g, " ")
-			.trim()
-	);
-}
+export { buildDetachedCompletionMessage, CompletionDeliveryBroker } from "./completion-delivery.js";
+export { formatStatefulAgentLine } from "./stateful-presenter.js";
 
 async function cleanupClosedWorkspaces(
 	registry: AgentRegistry,
@@ -974,7 +947,7 @@ function appendAgentCatalog(baseDescription: string, catalog: string): string {
 function result(agent: ManagedAgent, text: string) {
 	return {
 		content: [{ type: "text" as const, text }],
-		details: { agent: summarizeAgent(agent) },
+		details: { agent: summarizeStatefulAgent(agent) },
 	};
 }
 

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /**
  * Subagent Tool - Delegate tasks to specialized agents
  *
@@ -15,22 +17,40 @@
 import {
 	CONFIG_DIR_NAME,
 	type ExtensionAPI,
+	type ExtensionContext,
 	type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import {
+	type AgentScope,
 	type ConsultationCwdPolicy,
 	type ConsultResourcePolicy,
 	type DelegationCwdPolicy,
 	discoverAgentCatalog,
+	discoverAgents,
 	formatAgentCatalog,
+	isThinkingLevel,
 	type SubagentSettings,
+	type SubagentThinkingLevel,
 } from "./agents.js";
+import { CapabilityCeilingRegistry } from "./capability-ceiling.js";
 import { registerSubagentConfigCommand, registerSubagentConfigLifecycle } from "./config-ui.js";
 import { registerSubagentConsult } from "./consult.js";
-import { executeSubagent } from "./execution.js";
+import {
+	assertDelegationTargetAllowed,
+	resolveSubagentTarget,
+	targetPolicyAudit,
+} from "./cwd-policy.js";
+import type { EvidencePolicy } from "./evidence.js";
+import { executeSubagent, resolveDefaultSubagentTimeoutMs } from "./execution.js";
 import { registerSubagentInspect } from "./inspect.js";
-import { MAX_BLOCKING_PARALLEL_CONCURRENCY } from "./limits.js";
+import { resolveLaunchContract } from "./launch-contract.js";
+import {
+	DEFAULT_MAX_CONTEXT_BYTES,
+	MAX_BLOCKING_PARALLEL_CONCURRENCY,
+	MAX_SUBAGENT_TIMEOUT_MS,
+} from "./limits.js";
 import { SubagentParams } from "./params.js";
+import { registerPiSubagentsV1Api } from "./public-api.js";
 import { renderSubagentCall, renderSubagentResult } from "./render.js";
 import type { SubagentDetails } from "./runner.js";
 import {
@@ -41,17 +61,19 @@ import {
 	inspectSubagentSettings,
 	readSubagentSettings,
 	resolveBlockingMaxParallelTasks,
+	resolveSubagentThinkingLevel,
 } from "./settings.js";
 import { registerStatefulSubagents } from "./stateful.js";
 
 export default function (pi: ExtensionAPI) {
 	const configOwner = registerSubagentConfigLifecycle(pi);
+	const ceilings = new CapabilityCeilingRegistry();
 	const settings = readSubagentSettings();
 	let currentSettings: SubagentSettings | undefined = settings;
 	let currentCatalog = "";
 	const blockingEnabled = settings?.blocking?.enabled !== false;
 	const refreshBlockingCatalog = blockingEnabled
-		? registerBlockingSubagent(pi, () => currentSettings)
+		? registerBlockingSubagent(pi, () => currentSettings, ceilings)
 		: () => undefined;
 	let refreshStatefulCatalog: (catalog: string) => void = () => undefined;
 	let refreshConsultCatalog: (catalog: string) => void = () => undefined;
@@ -80,8 +102,51 @@ export default function (pi: ExtensionAPI) {
 		blockingEnabled,
 		settings: settings?.stateful,
 		getSettings: () => currentSettings,
+		ceilings,
 	});
 	refreshStatefulCatalog = statefulRuntime.setAgentCatalog;
+	registerPiSubagentsV1Api(pi, ceilings, {
+		preflight: (payload, ctx) => ({
+			...preflightPublicDelegation(payload, ctx, currentSettings, ceilings),
+			lifecycleArtifact: statefulRuntime.getLifecycleArtifactStatus(),
+		}),
+		delegate: async (payload, signal, ctx) => {
+			const request = parsePublicDelegation(payload, true);
+			const requestedAgent = discoverAgents(
+				ctx.cwd,
+				request.agentScope,
+				currentSettings,
+			).agents.find((agent) => agent.name === request.agent);
+			if (requestedAgent?.source === "project" && request.confirmProjectAgents && !ctx.hasUI) {
+				throw new Error(
+					"Project-local subagent confirmation requires UI; set confirmProjectAgents to false explicitly only in a trusted project",
+				);
+			}
+			return executeSubagent(
+				`public:${randomUUID()}`,
+				{
+					agent: request.agent,
+					task: request.task,
+					cwd: request.cwd,
+					agentScope: request.agentScope,
+					thinkingLevel: request.thinkingLevel,
+					timeoutMs: request.timeoutMs,
+					evidence: request.evidence,
+					confirmProjectAgents: request.confirmProjectAgents,
+				},
+				signal,
+				undefined,
+				ctx,
+				currentSettings,
+				ceilings,
+			);
+		},
+		status: () => ({
+			...statefulRuntime.getRuntimeStatus(),
+			fleetView: statefulRuntime.getFleetView(),
+			lifecycleArtifact: statefulRuntime.getLifecycleArtifactStatus(),
+		}),
+	});
 	const getBlockingEnabled = () => blockingEnabled;
 	const getMaxParallelTasks = () => resolveBlockingMaxParallelTasks(currentSettings);
 	const getConsultResourcePolicy = () =>
@@ -101,6 +166,7 @@ export default function (pi: ExtensionAPI) {
 	if (blockingEnabled) {
 		refreshConsultCatalog = registerSubagentConsult(pi, {
 			getSettings: () => currentSettings,
+			ceilings,
 		});
 	}
 	registerSubagentConfigCommand(
@@ -160,9 +226,152 @@ export default function (pi: ExtensionAPI) {
 	);
 }
 
+interface PublicLeafDelegation {
+	agent: string;
+	task: string;
+	cwd?: string;
+	agentScope: AgentScope;
+	thinkingLevel?: SubagentThinkingLevel;
+	timeoutMs?: number;
+	evidence?: EvidencePolicy;
+	confirmProjectAgents: boolean;
+}
+
+function parsePublicDelegation(payload: unknown, requireTask: boolean): PublicLeafDelegation {
+	if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+		throw new Error("Delegation payload must be an object");
+	}
+	const value = payload as Record<string, unknown>;
+	const allowed = new Set([
+		"agent",
+		"task",
+		"cwd",
+		"agentScope",
+		"thinkingLevel",
+		"timeoutMs",
+		"evidence",
+		"confirmProjectAgents",
+	]);
+	if (Object.keys(value).some((key) => !allowed.has(key))) {
+		throw new Error("Delegation payload contains an unsupported field");
+	}
+	if (
+		typeof value.agent !== "string" ||
+		!value.agent.trim() ||
+		value.agent.length > 256 ||
+		value.agent.includes("\0")
+	) {
+		throw new Error("agent must be a non-empty bounded string");
+	}
+	if (
+		requireTask &&
+		(typeof value.task !== "string" ||
+			!value.task.trim() ||
+			Buffer.byteLength(value.task, "utf8") > DEFAULT_MAX_CONTEXT_BYTES)
+	) {
+		throw new Error("task must be a non-empty bounded string");
+	}
+	if (!requireTask && value.task !== undefined) {
+		throw new Error("preflight does not accept task");
+	}
+	if (value.task !== undefined && typeof value.task !== "string") {
+		throw new Error("task must be a string");
+	}
+	if (typeof value.task === "string" && value.task.includes("\0")) {
+		throw new Error("task must not contain NUL bytes");
+	}
+	if (
+		value.cwd !== undefined &&
+		(typeof value.cwd !== "string" ||
+			!value.cwd.trim() ||
+			value.cwd.length > 4096 ||
+			value.cwd.includes("\0"))
+	) {
+		throw new Error("cwd must be a non-empty bounded string");
+	}
+	const scope = value.agentScope ?? "user";
+	if (scope !== "user" && scope !== "project" && scope !== "both") {
+		throw new Error("agentScope must be user, project, or both");
+	}
+	if (value.thinkingLevel !== undefined && !isThinkingLevel(value.thinkingLevel)) {
+		throw new Error("thinkingLevel is invalid");
+	}
+	if (
+		value.timeoutMs !== undefined &&
+		(typeof value.timeoutMs !== "number" ||
+			!Number.isFinite(value.timeoutMs) ||
+			value.timeoutMs < 1 ||
+			value.timeoutMs > MAX_SUBAGENT_TIMEOUT_MS)
+	) {
+		throw new Error("timeoutMs is outside the supported range");
+	}
+	if (value.evidence !== undefined && value.evidence !== "attested") {
+		throw new Error("evidence must be attested when provided");
+	}
+	if (value.confirmProjectAgents !== undefined && typeof value.confirmProjectAgents !== "boolean") {
+		throw new Error("confirmProjectAgents must be boolean");
+	}
+	return {
+		agent: value.agent,
+		task: typeof value.task === "string" ? value.task : "",
+		cwd: value.cwd as string | undefined,
+		agentScope: scope,
+		thinkingLevel: value.thinkingLevel as SubagentThinkingLevel | undefined,
+		timeoutMs: value.timeoutMs as number | undefined,
+		evidence: value.evidence as EvidencePolicy | undefined,
+		confirmProjectAgents: value.confirmProjectAgents !== false,
+	};
+}
+
+function preflightPublicDelegation(
+	payload: unknown,
+	ctx: ExtensionContext,
+	settings: SubagentSettings | undefined,
+	ceilings: CapabilityCeilingRegistry,
+) {
+	const request = parsePublicDelegation(payload, false);
+	if (
+		(request.agentScope === "project" || request.agentScope === "both") &&
+		!ctx.isProjectTrusted()
+	) {
+		throw new Error("Project-local subagent definitions require a trusted project");
+	}
+	const discovery = discoverAgents(ctx.cwd, request.agentScope, settings);
+	const agent = discovery.agents.find((candidate) => candidate.name === request.agent);
+	if (!agent) throw new Error(`Unknown agent: ${request.agent}`);
+	const target = resolveSubagentTarget({
+		workspace: ctx.cwd,
+		requestedCwd: request.cwd,
+		currentProjectTrusted: ctx.isProjectTrusted(),
+	});
+	assertDelegationTargetAllowed(
+		target,
+		settings?.cwdPolicy?.delegation ?? DEFAULT_DELEGATION_CWD_POLICY,
+	);
+	const contract = resolveLaunchContract({
+		agent,
+		agentScope: request.agentScope,
+		target: targetPolicyAudit(target),
+		thinkingLevel: resolveSubagentThinkingLevel(
+			discovery.agents,
+			request.agent,
+			request.thinkingLevel,
+		),
+		timeoutMs: request.timeoutMs ?? agent.timeoutMs ?? resolveDefaultSubagentTimeoutMs(),
+		transport: "subprocess",
+		evidence: request.evidence,
+		ceiling: ceilings.resolve(),
+	});
+	return {
+		...contract,
+		projectAgentConfirmationRequired: agent.source === "project" && request.confirmProjectAgents,
+	};
+}
+
 function registerBlockingSubagent(
 	pi: ExtensionAPI,
 	getSettings: () => SubagentSettings | undefined,
+	ceilings: CapabilityCeilingRegistry,
 ): (catalog: string) => void {
 	let catalog = "";
 	const baseDescription = () =>
@@ -196,7 +405,7 @@ function registerBlockingSubagent(
 		parameters: SubagentParams,
 
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
-			return executeSubagent(toolCallId, params, signal, onUpdate, ctx, getSettings());
+			return executeSubagent(toolCallId, params, signal, onUpdate, ctx, getSettings(), ceilings);
 		},
 
 		renderCall(args, theme) {
@@ -237,6 +446,8 @@ export {
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
 	inspectDelegationWorkflowSettings,
+	inspectFleetViewSettings,
+	inspectLifecycleArtifactSettings,
 	inspectStatefulLimitSettings,
 	inspectSubagentSettings,
 	normalizeAgentSettings,
@@ -254,5 +465,7 @@ export {
 	updateConsultResourceSetting,
 	updateCwdPolicySetting,
 	updateDelegationWorkflowSetting,
+	updateFleetViewSetting,
+	updateLifecycleArtifactSetting,
 	updateStatefulLimitSetting,
 } from "./settings.js";

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -98,6 +98,9 @@ export default function (pi: ExtensionAPI) {
 		refreshConsultCatalog(currentCatalog);
 	});
 
+	let deactivatePublicApi: () => void = () => undefined;
+	// Pi awaits shutdown handlers in registration order, so stop new API work before agent cleanup.
+	pi.on("session_shutdown", () => deactivatePublicApi());
 	const statefulRuntime = registerStatefulSubagents(pi, {
 		blockingEnabled,
 		settings: settings?.stateful,
@@ -105,7 +108,7 @@ export default function (pi: ExtensionAPI) {
 		ceilings,
 	});
 	refreshStatefulCatalog = statefulRuntime.setAgentCatalog;
-	registerPiSubagentsV1Api(pi, ceilings, {
+	deactivatePublicApi = registerPiSubagentsV1Api(pi, ceilings, {
 		preflight: (payload, ctx) => ({
 			...preflightPublicDelegation(payload, ctx, currentSettings, ceilings),
 			lifecycleArtifact: statefulRuntime.getLifecycleArtifactStatus(),

--- a/packages/pi-subagents/src/subprocess-transport.ts
+++ b/packages/pi-subagents/src/subprocess-transport.ts
@@ -54,6 +54,8 @@ export class SubprocessTransport implements SubagentTransport {
 				projectTrust:
 					record.target?.trust.projectTrusted ??
 					(record.agentScope === "project" || record.agentScope === "both"),
+				tools: record.capabilityTools ?? agent?.tools,
+				disableExtensions: record.disableExtensions,
 			},
 		);
 		return {

--- a/packages/pi-subagents/test/additive-capabilities.test.ts
+++ b/packages/pi-subagents/test/additive-capabilities.test.ts
@@ -1,0 +1,397 @@
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, test } from "vitest";
+import { createMockPi } from "../../../test/support.js";
+import { applyCapabilityCeiling, CapabilityCeilingRegistry } from "../src/capability-ceiling.js";
+import { currentAgentDetailScreen } from "../src/current-agents-ui.js";
+import { parseEvidenceAttestation } from "../src/evidence.js";
+import { updateFleetWidget } from "../src/fleet-view.js";
+import { resolveLaunchContract } from "../src/launch-contract.js";
+import { LifecycleArtifactWriter } from "../src/lifecycle-artifacts.js";
+import {
+	PI_SUBAGENTS_V1_READY,
+	PI_SUBAGENTS_V1_REPLY,
+	PI_SUBAGENTS_V1_REQUEST,
+	registerPiSubagentsV1Api,
+} from "../src/public-api.js";
+import type { ManagedAgent } from "../src/registry.js";
+
+function managedAgent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+	return {
+		id: "sa_1",
+		agent: "worker",
+		rootId: "sa_1",
+		depth: 0,
+		children: [],
+		state: "running",
+		createdAt: 1,
+		updatedAt: 2,
+		cwd: "/workspace",
+		currentTask: "inspect\u001b[31m safely",
+		history: [],
+		mailbox: [],
+		...overrides,
+	};
+}
+
+describe("additive pi-subagents capabilities", () => {
+	test("the declared entrypoint registers seven tools while the API import is inert", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "pi-subagents-loader-"));
+		const previous = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = directory;
+		try {
+			const before = createMockPi();
+			await import("../src/public-api.js");
+			assert.equal(before.tools.length, 0);
+			const loaded = createMockPi();
+			const entrypoint = "../src/index.js";
+			const extension = (await import(entrypoint)).default;
+			extension(loaded.pi);
+			assert.deepEqual(
+				loaded.tools.map((tool) => tool.name),
+				[
+					"subagent",
+					"subagent_spawn",
+					"subagent_send",
+					"subagent_manage",
+					"subagent_mailbox",
+					"subagent_inspect",
+					"subagent_consult",
+				],
+			);
+		} finally {
+			if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previous;
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("capability ceilings intersect and never widen tools", () => {
+		const registry = new CapabilityCeilingRegistry();
+		registry.register("policy-a", {
+			allowedAgents: ["worker", "scout"],
+			allowedTools: ["read", "bash"],
+		});
+		registry.register("policy-b", {
+			allowedAgents: ["worker"],
+			allowedTools: ["read"],
+			denyExtensions: true,
+		});
+		const ceiling = registry.resolve();
+		assert.deepEqual(ceiling, {
+			allowedAgents: ["worker"],
+			allowedTools: ["read"],
+			denyExtensions: true,
+			sources: ["policy-a", "policy-b"],
+		});
+		assert.deepEqual(applyCapabilityCeiling("worker", ["read", "write"], ceiling), {
+			tools: ["read"],
+			disableExtensions: true,
+		});
+		assert.throws(() => applyCapabilityCeiling("scout", ["read"], ceiling), /denied/);
+		assert.throws(
+			() => registry.register("invalid", { denyExtensions: "yes" as unknown as boolean }),
+			/boolean/,
+		);
+		const audited = new CapabilityCeilingRegistry();
+		for (let index = 0; index < 40; index++) {
+			const token = audited.register(`policy-${index}`, {});
+			audited.dispose(token);
+		}
+		assert.equal(audited.audit().length, 64);
+		assert.equal(audited.audit().at(-1)?.source, "policy-39");
+		audited.clear();
+		assert.deepEqual(audited.audit(), []);
+	});
+
+	test("launch contracts are stable and project only safe metadata", () => {
+		const options = {
+			agent: {
+				name: "worker",
+				description: "Worker",
+				tools: ["read", "write"],
+				systemPrompt: "secret prompt",
+				source: "built-in" as const,
+				filePath: "built-in:worker",
+			},
+			agentScope: "user" as const,
+			target: {
+				cwd: "/workspace",
+				boundary: "current-workspace" as const,
+				trust: { kind: "session-trusted" as const, projectTrusted: true },
+			},
+			timeoutMs: 1000,
+			transport: "subprocess" as const,
+			evidence: "attested" as const,
+			ceiling: { allowedTools: ["read"], sources: ["parent"] },
+		};
+		const first = resolveLaunchContract(options);
+		const second = resolveLaunchContract(options);
+		assert.equal(first.digest, second.digest);
+		assert.deepEqual(first.effectiveTools, ["read"]);
+		assert.equal(JSON.stringify(first).includes("secret prompt"), false);
+	});
+
+	test("evidence remains a bounded unverified attestation", () => {
+		const output = [
+			"done",
+			"```subagent-evidence",
+			JSON.stringify({
+				summary: "changed safely",
+				changedFiles: ["src/a.ts"],
+				commandsRun: ["npm test"],
+				validations: ["tests passed"],
+				residualRisks: ["none claimed"],
+			}),
+			"```",
+		].join("\n");
+		assert.deepEqual(parseEvidenceAttestation(output, "attested"), {
+			status: "attested",
+			summary: "changed safely",
+			changedFiles: ["src/a.ts"],
+			commandsRun: ["npm test"],
+			validations: ["tests passed"],
+			residualRisks: ["none claimed"],
+		});
+		assert.deepEqual(parseEvidenceAttestation("plain output", "attested"), {
+			status: "missing",
+		});
+		assert.deepEqual(parseEvidenceAttestation(`${output}\n${output}`, "attested"), {
+			status: "invalid",
+		});
+		assert.deepEqual(parseEvidenceAttestation("```subagent-evidence\n{broken}\n```", "attested"), {
+			status: "invalid",
+		});
+		const privateEvidence = parseEvidenceAttestation(
+			`\`\`\`subagent-evidence\n${JSON.stringify({
+				summary: "<private>secret</private> safe\u001b[31m",
+				changedFiles: [],
+				commandsRun: [],
+				validations: [],
+				residualRisks: [],
+			})}\n\`\`\``,
+			"attested",
+		);
+		assert.equal(JSON.stringify(privateEvidence).includes("secret"), false);
+		assert.equal(JSON.stringify(privateEvidence).includes("\u001b"), false);
+		assert.deepEqual(
+			parseEvidenceAttestation(
+				`\`\`\`subagent-evidence\n${" ".repeat(17 * 1024)}\n\`\`\``,
+				"attested",
+			),
+			{ status: "invalid" },
+		);
+		assert.equal(parseEvidenceAttestation(output, undefined), undefined);
+	});
+
+	test("lifecycle artifacts are private metadata without task or output text", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "pi-subagents-artifact-"));
+		const writer = new LifecycleArtifactWriter("session", 30, directory);
+		await writer.publish([
+			managedAgent({
+				currentTask: "PRIVATE task",
+				error: "PRIVATE error",
+				history: [
+					{
+						task: "PRIVATE history",
+						output: "PRIVATE output",
+						startedAt: 1,
+						completedAt: 2,
+						exitCode: 0,
+					},
+				],
+				mailbox: [
+					{
+						id: "m1",
+						senderId: "root",
+						recipientId: "sa_1",
+						content: "PRIVATE mail",
+						createdAt: 1,
+					},
+				],
+			}),
+		]);
+		const content = await readFile(writer.filePath, "utf8");
+		assert.equal(content.includes("PRIVATE"), false);
+		assert.equal(JSON.parse(content).agents[0].historyCount, 1);
+		assert.equal((await stat(writer.filePath)).mode & 0o777, 0o600);
+		const stale = new LifecycleArtifactWriter("stale", 30, directory, () => false);
+		await stale.publish([managedAgent()]);
+		await assert.rejects(() => readFile(stale.filePath, "utf8"), /ENOENT/);
+		const expired = join(directory, `${"b".repeat(24)}.json`);
+		const unrelated = join(directory, "keep.txt");
+		await writeFile(expired, "{}", "utf8");
+		await writeFile(unrelated, "keep", "utf8");
+		await utimes(expired, new Date(0), new Date(0));
+		await writer.cleanupExpired();
+		await assert.rejects(() => readFile(expired, "utf8"), /ENOENT/);
+		assert.equal(await readFile(unrelated, "utf8"), "keep");
+		await rm(directory, { recursive: true, force: true });
+	});
+
+	test("the current-agent detail exposes state-valid steering without hiding subtree cleanup", () => {
+		const parent = managedAgent({
+			state: "completed",
+			children: ["sa_child"],
+			history: [{ task: "done", output: "ok", startedAt: 1, completedAt: 2, exitCode: 0 }],
+		});
+		const screen = currentAgentDetailScreen({ listAgents: () => [parent] } as never, parent.id);
+		const actions = screen.items.map((item) => item.action);
+		assert.ok(actions.includes("agent-follow-up"));
+		assert.ok(actions.includes("agent-queue-message"));
+		assert.ok(actions.includes("agent-interrupt-tree"));
+		assert.ok(actions.includes("agent-close-tree"));
+		assert.equal(screen.items.find((item) => item.action === "agent-close")?.disabled, true);
+	});
+
+	test("FleetView renders bounded text without terminal controls or input listeners", () => {
+		let widget: unknown;
+		const ui = {
+			setWidget(_key: string, content: unknown) {
+				widget = content;
+			},
+		};
+		updateFleetWidget({ mode: "tui", ui } as never, true, [managedAgent()]);
+		assert.equal(typeof widget, "function");
+		const component = (
+			widget as (
+				tui: unknown,
+				theme: { bold(value: string): string; fg(color: string, value: string): string },
+			) => { render(width: number): string[] }
+		)(undefined, {
+			bold: (value: string) => value,
+			fg: (_color: string, value: string) => value,
+		});
+		const lines = component.render(40) as string[];
+		assert.match(lines.join("\n"), /RUNNING worker sa_1/);
+		assert.equal(lines.join("\n").includes("\u001b"), false);
+		assert.ok(lines.every((line) => line.length <= 40));
+		const narrow = component.render(4) as string[];
+		assert.ok(narrow.every((line) => visibleWidth(line) <= 4));
+		updateFleetWidget({ mode: "rpc", ui } as never, true, [managedAgent()]);
+		assert.equal(widget, undefined);
+	});
+
+	test("the v1 event API binds to a session, rejects duplicate IDs, and cancels exact work", async () => {
+		const lifecycle = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
+		const bus = new Map<string, Set<(data: unknown) => void>>();
+		const emitted: Array<{
+			channel: string;
+			data: {
+				requestId?: string;
+				result?: { cancelled?: boolean };
+				error?: { code?: string };
+			};
+		}> = [];
+		const pi = {
+			on(name: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) {
+				lifecycle.set(name, [...(lifecycle.get(name) ?? []), handler]);
+			},
+			events: {
+				on(channel: string, handler: (data: unknown) => void) {
+					const handlers = bus.get(channel) ?? new Set();
+					handlers.add(handler);
+					bus.set(channel, handlers);
+					return () => handlers.delete(handler);
+				},
+				emit(channel: string, data: unknown) {
+					emitted.push({
+						channel,
+						data: data as {
+							requestId?: string;
+							result?: { cancelled?: boolean };
+							error?: { code?: string };
+						},
+					});
+					for (const handler of bus.get(channel) ?? []) handler(data);
+				},
+			},
+		} as unknown as ExtensionAPI;
+		let release!: () => void;
+		registerPiSubagentsV1Api(pi, new CapabilityCeilingRegistry(), {
+			preflight: () => ({ safe: true }),
+			delegate: (_payload, signal) =>
+				new Promise((resolve, reject) => {
+					release = () => resolve({ done: true });
+					signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+				}),
+		});
+		const ctx = {} as ExtensionContext;
+		for (const handler of lifecycle.get("session_start") ?? []) await handler({}, ctx);
+		assert.ok(emitted.some((entry) => entry.channel === PI_SUBAGENTS_V1_READY));
+		pi.events.on(PI_SUBAGENTS_V1_REPLY, (value) => {
+			if ((value as { requestId?: string }).requestId === "reentrant") {
+				pi.events.emit(PI_SUBAGENTS_V1_REQUEST, { requestId: "reentrant", method: "ping" });
+			}
+		});
+		pi.events.emit(PI_SUBAGENTS_V1_REQUEST, { requestId: "reentrant", method: "ping" });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		assert.equal(
+			emitted.filter(
+				(entry) => entry.channel === PI_SUBAGENTS_V1_REPLY && entry.data.requestId === "reentrant",
+			).length,
+			1,
+		);
+		pi.events.emit(PI_SUBAGENTS_V1_REQUEST, {
+			requestId: "work-1",
+			method: "delegate",
+			payload: {},
+		});
+		await Promise.resolve();
+		pi.events.emit(PI_SUBAGENTS_V1_REQUEST, {
+			requestId: "cancel-1",
+			method: "cancel",
+			payload: { targetRequestId: "work-1" },
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const replies = emitted.filter((entry) => entry.channel === PI_SUBAGENTS_V1_REPLY);
+		assert.equal(
+			replies.find((entry) => entry.data.requestId === "cancel-1")?.data.result?.cancelled,
+			true,
+		);
+		assert.equal(
+			replies.find((entry) => entry.data.requestId === "work-1")?.data.error?.code,
+			"cancelled",
+		);
+		const replyCount = emitted.filter(
+			(entry) => entry.channel === PI_SUBAGENTS_V1_REPLY && entry.data.requestId === "cancel-1",
+		).length;
+		pi.events.emit(PI_SUBAGENTS_V1_REQUEST, { requestId: "cancel-1", method: "ping" });
+		assert.equal(
+			emitted.filter(
+				(entry) => entry.channel === PI_SUBAGENTS_V1_REPLY && entry.data.requestId === "cancel-1",
+			).length,
+			replyCount,
+		);
+		pi.events.emit(PI_SUBAGENTS_V1_REQUEST, {
+			requestId: "work-2",
+			method: "delegate",
+			payload: {},
+		});
+		pi.events.emit(PI_SUBAGENTS_V1_REQUEST, { requestId: "work-2", method: "ping" });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const duplicateReplies = emitted.filter(
+			(entry) => entry.channel === PI_SUBAGENTS_V1_REPLY && entry.data.requestId === "work-2",
+		);
+		assert.equal(duplicateReplies.length, 1);
+		assert.equal(duplicateReplies[0]?.data.error?.code, "duplicate_request");
+		pi.events.emit(PI_SUBAGENTS_V1_REQUEST, {
+			requestId: "work-3",
+			method: "delegate",
+			payload: {},
+		});
+		for (const handler of lifecycle.get("session_start") ?? []) await handler({}, ctx);
+		release?.();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		assert.equal(
+			emitted.filter(
+				(entry) => entry.channel === PI_SUBAGENTS_V1_REPLY && entry.data.requestId === "work-3",
+			).length,
+			0,
+		);
+	});
+});

--- a/packages/pi-subagents/test/orchestration.test.ts
+++ b/packages/pi-subagents/test/orchestration.test.ts
@@ -574,6 +574,10 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		});
 		assert.deepEqual(disabledController.listAgents(), []);
 		assert.equal(await disabledController.clearAgents(), 0);
+		await assert.rejects(
+			() => disabledController.queueMessage("missing", "message"),
+			/not initialized/i,
+		);
 	} finally {
 		if (originalDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = originalDir;

--- a/packages/pi-subagents/test/registry.test.ts
+++ b/packages/pi-subagents/test/registry.test.ts
@@ -700,6 +700,11 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 	await persistence.save([
 		record({
 			thinkingLevel: "high",
+			evidencePolicy: "attested",
+			evidenceStatus: "attested",
+			launchContractDigest: "a".repeat(24),
+			capabilityTools: ["read"],
+			disableExtensions: true,
 			target: {
 				cwd: process.cwd(),
 				boundary: "external",
@@ -722,6 +727,14 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 					startedAt: 1,
 					completedAt: 2,
 					exitCode: 0,
+					evidence: {
+						status: "attested",
+						summary: "<private>evidence-secret</private>checked",
+						changedFiles: ["src/a.ts"],
+						commandsRun: [],
+						validations: ["ok"],
+						residualRisks: [],
+					},
 				},
 			],
 		}),
@@ -734,6 +747,9 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 	assert.equal(restoredState?.thinkingLevel, "high");
 	assert.equal(restoredState?.target?.trust.kind, "saved-trusted");
 	assert.equal(restoredState?.target?.trust.projectTrusted, true);
+	assert.deepEqual(restoredState?.capabilityTools, ["read"]);
+	assert.equal(restoredState?.disableExtensions, true);
+	assert.equal(restoredState?.history[0]?.evidence?.summary, "[private content omitted]checked");
 	assert.equal(restoredState?.mailbox[0]?.content, "[private content omitted]visible");
 	const competing = new AgentPersistence("session", { stateDir: dir, maxStoredAgents: 2 });
 	await Promise.all([

--- a/packages/pi-subagents/test/settings.test.ts
+++ b/packages/pi-subagents/test/settings.test.ts
@@ -8,6 +8,8 @@ import {
 	inspectBlockingParallelLimitSettings,
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
+	inspectFleetViewSettings,
+	inspectLifecycleArtifactSettings,
 	inspectStatefulLimitSettings,
 	inspectSubagentSettings,
 	normalizeSubagentSettings,
@@ -15,6 +17,8 @@ import {
 	updateBlockingMaxParallelTasksSetting,
 	updateConsultResourceSetting,
 	updateCwdPolicySetting,
+	updateFleetViewSetting,
+	updateLifecycleArtifactSetting,
 	updateStatefulLimitSetting,
 } from "../src/settings.js";
 import { resolveStatefulLimits } from "../src/stateful-limits.js";
@@ -50,6 +54,47 @@ test("consult resources normalize strictly and default without creating settings
 		assert.equal(inspected.path, path.join(directory, "pi-subagents.json"));
 		assert.equal(readSubagentSettings(), undefined);
 		assert.throws(() => readFileSync(inspected.path, "utf8"), /ENOENT/);
+	});
+});
+
+test("additive fleet and lifecycle settings default off and preserve unknown fields", () => {
+	withAgentDir((directory) => {
+		const configPath = path.join(directory, "pi-subagents.json");
+		assert.deepEqual(normalizeSubagentSettings({ stateful: { fleetView: "active" } }), {
+			stateful: { fleetView: "active" },
+		});
+		assert.deepEqual(normalizeSubagentSettings({ stateful: { lifecycleArtifacts: "metadata" } }), {
+			stateful: { lifecycleArtifacts: "metadata" },
+		});
+		assert.equal(normalizeSubagentSettings({ stateful: { fleetView: "always" } }), undefined);
+		assert.throws(() => updateFleetViewSetting("always" as "active"), /invalid fleetview/i);
+		assert.throws(
+			() => updateLifecycleArtifactSetting("full" as "metadata"),
+			/invalid lifecycle artifact/i,
+		);
+		assert.equal(
+			normalizeSubagentSettings({ stateful: { lifecycleArtifacts: "full" } }),
+			undefined,
+		);
+		assert.deepEqual(inspectFleetViewSettings(), {
+			path: configPath,
+			value: "off",
+			source: "default",
+		});
+		assert.deepEqual(inspectLifecycleArtifactSettings(), {
+			path: configPath,
+			value: "off",
+			source: "default",
+		});
+		writeFileSync(configPath, JSON.stringify({ future: { keep: true }, stateful: { future: 1 } }));
+		updateFleetViewSetting("active");
+		updateLifecycleArtifactSetting("metadata");
+		assert.deepEqual(JSON.parse(readFileSync(configPath, "utf8")), {
+			future: { keep: true },
+			stateful: { future: 1, fleetView: "active", lifecycleArtifacts: "metadata" },
+		});
+		assert.equal(inspectFleetViewSettings().source, "user settings");
+		assert.equal(inspectLifecycleArtifactSettings().source, "user settings");
 	});
 });
 

--- a/packages/pi-subagents/test/subagents.test.ts
+++ b/packages/pi-subagents/test/subagents.test.ts
@@ -301,6 +301,146 @@ test("public preflight returns a side-effect-free launch contract without adding
 	}
 });
 
+test("the event API deactivates before awaited stateful shutdown", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-api-shutdown-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const context = createMockContext({ cwd: directory });
+		const replies: unknown[] = [];
+		mock.eventBus.on(PI_SUBAGENTS_V1_REPLY, (reply) => replies.push(reply));
+		for (const handler of mock.events.get("session_start") ?? []) {
+			await handler({}, context.ctx);
+		}
+		mock.eventBus.emit(PI_SUBAGENTS_V1_REQUEST, {
+			requestId: "before-shutdown",
+			method: "ping",
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		assert.equal(replies.length, 1);
+
+		const shutdownHandlers = mock.events.get("session_shutdown") ?? [];
+		assert.ok(shutdownHandlers.length >= 3);
+		await shutdownHandlers[0]?.({}, context.ctx);
+		const secondShutdown = Promise.resolve(shutdownHandlers[1]?.({}, context.ctx));
+		try {
+			mock.eventBus.emit(PI_SUBAGENTS_V1_REQUEST, {
+				requestId: "during-shutdown",
+				method: "ping",
+			});
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			assert.equal(replies.length, 1, "the public listener must stop before stateful cleanup");
+		} finally {
+			await secondShutdown;
+			for (const handler of shutdownHandlers.slice(2)) await handler({}, context.ctx);
+		}
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("stale interrupt completion never notifies through a replaced menu context", async () => {
+	const agent: ManagedAgent = {
+		id: "running-agent",
+		agent: "worker",
+		rootId: "running-agent",
+		depth: 0,
+		children: [],
+		state: "running",
+		createdAt: 1,
+		updatedAt: 1,
+		cwd: process.cwd(),
+		history: [],
+		mailbox: [],
+	};
+	for (const outcome of ["resolve", "reject"] as const) {
+		const mock = createMockPi();
+		let resolveInterrupt!: (count: number) => void;
+		let rejectInterrupt!: (error: Error) => void;
+		let markStarted!: () => void;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		const interruption = new Promise<number>((resolve, reject) => {
+			resolveInterrupt = resolve;
+			rejectInterrupt = reject;
+		});
+		const runtime: SubagentSettingsRuntime = {
+			getBlockingEnabled: () => true,
+			getMaxParallelTasks: () => 8,
+			getCompletionDelivery: () => "next-turn",
+			getConsultResourcePolicy: () => "project-context",
+			getConsultationCwdPolicy: () => "anywhere",
+			getDelegationCwdPolicy: () => "trusted-targets",
+			setMaxParallelTasks: () => undefined,
+			setCompletionDelivery: () => undefined,
+			setConsultResourcePolicy: () => undefined,
+			setConsultationCwdPolicy: () => undefined,
+			setDelegationCwdPolicy: () => undefined,
+			getRuntimeStatus: () => ({
+				enabled: true,
+				initialized: true,
+				transport: "subprocess",
+				completionDelivery: "next-turn",
+				limits: resolveStatefulLimits(),
+				activeAgents: 1,
+				retainedAgents: 1,
+			}),
+			listAgents: () => [agent],
+			interruptAgent: async () => {
+				markStarted();
+				return interruption;
+			},
+			clearAgents: async () => 0,
+		};
+		registerSubagentConfigCommand(mock.pi, runtime);
+		const command = mock.commands.get("subagents");
+		assert.ok(command);
+		let call = 0;
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 60);
+				const frame = stripVTControlCharacters(harness.render().join("\n"));
+				if (call === 0) {
+					assert.match(frame, /Subagents/);
+					harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+				} else if (call === 1) {
+					assert.match(frame, /Current-session Subagents/);
+					harness.handleInput("tui.select.confirm");
+				} else if (call === 2) {
+					assert.match(frame, /worker · running/);
+					harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+					await harness.waitForPending();
+				} else {
+					harness.handleInput("\u0003");
+				}
+				call++;
+				return harness.result;
+			},
+		});
+		for (const handler of mock.events.get("session_start") ?? []) {
+			await handler({}, context.ctx);
+		}
+		const commandRun = command.handler("", context.ctx);
+		await started;
+		for (const handler of mock.events.get("session_shutdown") ?? []) {
+			await handler({}, context.ctx);
+		}
+		if (outcome === "resolve") resolveInterrupt(1);
+		else rejectInterrupt(new Error("interrupt failed"));
+		await commandRun;
+		assert.deepEqual(context.notifications, [], `${outcome} used a stale UI context`);
+	}
+});
+
 test("bare subagents opens a current-session manager and keeps direct routes predictable", async () => {
 	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-manager-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;

--- a/packages/pi-subagents/test/subagents.test.ts
+++ b/packages/pi-subagents/test/subagents.test.ts
@@ -35,6 +35,7 @@ import {
 } from "../src/agents.js";
 import { registerSubagentConfigCommand, type SubagentSettingsRuntime } from "../src/config-ui.js";
 import { hasUsableAggregator } from "../src/params.js";
+import { PI_SUBAGENTS_V1_REPLY, PI_SUBAGENTS_V1_REQUEST } from "../src/public-api.js";
 import type { ManagedAgent } from "../src/registry.js";
 import { consumeSubagentSettingsNotice } from "../src/settings.js";
 import { applyStatefulLimitSetting } from "../src/stateful-limit-ui.js";
@@ -253,6 +254,46 @@ test("blocking parallel calls honor the configured worker limit", async () => {
 		);
 		assert.equal(raisedResult.details?.results.length, 9);
 		assert.doesNotMatch(raisedResult.content?.[0]?.text ?? "", /too many parallel tasks/i);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("public preflight returns a side-effect-free launch contract without adding tools", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-preflight-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const context = createMockContext({ cwd: directory });
+		const replies: unknown[] = [];
+		mock.eventBus.on(PI_SUBAGENTS_V1_REPLY, (reply) => replies.push(reply));
+		for (const handler of mock.events.get("session_start") ?? []) {
+			await handler({}, context.ctx);
+		}
+		const registrationsBeforePreflight = mock.tools.length;
+		mock.eventBus.emit(PI_SUBAGENTS_V1_REQUEST, {
+			requestId: "preflight-1",
+			method: "preflight",
+			payload: { agent: "scout" },
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		assert.equal(mock.tools.length, registrationsBeforePreflight);
+		assert.equal(new Set(mock.tools.map((tool) => tool.name)).size, 7);
+		assert.equal(mock.sentMessages.length, 0);
+		assert.equal(replies.length, 1);
+		const reply = replies[0] as {
+			ok: boolean;
+			result: { agent: string; transport: string; effectiveTools: string[]; digest: string };
+		};
+		assert.equal(reply.ok, true);
+		assert.equal(reply.result.agent, "scout");
+		assert.equal(reply.result.transport, "subprocess");
+		assert.deepEqual(reply.result.effectiveTools, ["read", "grep", "find", "ls", "bash"]);
+		assert.match(reply.result.digest, /^[a-f0-9]{24}$/u);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
@@ -1763,6 +1804,91 @@ test("subagent settings UI preserves unknown JSON and applies completion deliver
 		});
 		await command.handler("settings", nonTui.ctx);
 		assert.match(nonTui.notifications[0]?.message ?? "", /Edit settings manually/);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("subagent settings UI applies FleetView now and lifecycle metadata after reload", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-additive-settings-ui-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const command = mock.commands.get("subagents");
+		assert.ok(command);
+		let call = 0;
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const down = call++ === 0 ? 4 : 5;
+				return driveCustomSelector(factory, [
+					...Array.from({ length: down }, () => "\u001b[B"),
+					"\r",
+					"\u001b",
+				]).result;
+			},
+		});
+		await command.handler("settings", context.ctx);
+		await command.handler("settings", context.ctx);
+		assert.deepEqual(JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8")), {
+			stateful: { fleetView: "active", lifecycleArtifacts: "metadata" },
+		});
+		assert.match(
+			context.notifications.map((entry) => entry.message).join("\n"),
+			/FleetView.*applied|Show active agents/i,
+		);
+		assert.match(
+			context.notifications.map((entry) => entry.message).join("\n"),
+			/Metadata after reload.*reload/i,
+		);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("FleetView runtime failure leaves settings and effective state unchanged", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fleet-rollback-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(settingsPath, "{}\n");
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const command = mock.commands.get("subagents");
+		assert.ok(command);
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) =>
+				driveCustomSelector(factory, [
+					"\u001b[B",
+					"\u001b[B",
+					"\u001b[B",
+					"\u001b[B",
+					"\r",
+					"\u001b",
+				]).result,
+		});
+		for (const handler of mock.events.get("session_start") ?? []) {
+			await handler({}, context.ctx);
+		}
+		(context.ctx as { ui: { setWidget: () => void } }).ui.setWidget = () => {
+			throw new Error("widget failed");
+		};
+		await command.handler("settings", context.ctx);
+		assert.equal(readFileSync(settingsPath, "utf8"), "{}\n");
+		assert.match(context.notifications.at(-1)?.message ?? "", /not applied.*roll back fleetview/i);
+		for (const handler of mock.events.get("session_shutdown") ?? []) {
+			await handler({}, context.ctx);
+		}
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;


### PR DESCRIPTION
## Summary

- add the versioned `pi-subagents:v1` event API with ping, side-effect-free preflight, one-leaf foreground delegation, exact cancellation, and session-scoped capability ceilings
- add optional evidence attestations and private bounded lifecycle metadata artifacts
- add opt-in non-intercepting FleetView plus per-agent follow-up, mailbox, interrupt, close, and subtree manager actions
- preserve the existing seven-tool surface, defaults, command routes, transports, completion grouping, settings compatibility, and persisted v1/v2 records
- split completion delivery, status presentation, current-agent UI, launch contracts, and stateful presentation into focused modules

## Safety and compatibility

- capability providers intersect allow-lists and cannot widen tools or bypass target trust, project-agent confirmation, consultation read-only policy, or shared-write guards
- request IDs are bounded and exact-once across duplicates, cancellation, reentrancy, session replacement, and shutdown
- FleetView and lifecycle artifacts default off, while evidence remains explicit unverified child attestation
- lifecycle artifacts use private atomic files and exclude tasks, prompts, outputs, errors, mailbox text, context, credentials, environment values, and process IDs
- settings writes preserve unknown fields, reject invalid files, use the existing mutation lock and atomic publication, and roll runtime state back after failures

## Review and hardening

A final diff review found and fixed stale API work starting after session replacement, reentrant duplicate replies, settled-history growth, stale artifact publication, no-op ceiling follow-up rejection, disabled-runtime controller initialization, FleetView lifecycle/rollback failures, in-process contract-flag drift, project-confirmation bypass risk, and unbounded persisted capability/evidence metadata.

No blocking review finding remains.

## Verification

- `npx vitest run packages/pi-subagents/test` — 15 files, 217 tests passed
- `npm run check --workspace @narumitw/pi-subagents` — passed
- `VITEST_MAX_WORKERS=4 npm run check` — 232 files, 2,651 tests passed after rebasing onto current `origin/main`
- `npm run pack:subagents -- --json` — 55 expected files, no tests or runtime state artifacts
- `PI_CODING_AGENT_DIR=<temp> pi --offline --no-extensions -e ./packages/pi-subagents/src/index.ts --list-models` — loader smoke passed
- deterministic Pi TUI Kit keyboard and cell-width tests cover the non-intercepting widget and manager flows because the automation harness does not open an interactive TUI

## Release

- adds `.changeset/warm-fleets-coordinate.md` with a minor bump for `@narumitw/pi-subagents`
- does not publish, tag, change npm visibility, or dispatch a release workflow

## Plan

Completed and archived at `docs/plans/archived/2026-08-09_pi-subagents-additive-capabilities-plan.md`.
