### PR TITLE
feat(subagents): add RPC transport and execution controls

### DIFF
--- a/.changeset/quick-subagents-flow.md
+++ b/.changeset/quick-subagents-flow.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-subagents": minor
 ---
 
-Add persistent RPC and automatic detached transports, execution profiles and per-agent defaults, bounded runtime telemetry, spawn idempotency, context preview, and opt-in structured completion metadata.
+Add persistent RPC and automatic detached transports, execution profiles and per-agent defaults, main-agent-selected retained and per-follow-up work deadlines with abort-then-summary recovery, bounded runtime telemetry, spawn idempotency, context preview, and opt-in structured completion metadata.

--- a/.changeset/quick-subagents-flow.md
+++ b/.changeset/quick-subagents-flow.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Add persistent RPC and automatic detached transports, execution profiles and per-agent defaults, bounded runtime telemetry, spawn idempotency, context preview, and opt-in structured completion metadata.

--- a/docs/implementation-notes/pi-subagents-rpc-v1.md
+++ b/docs/implementation-notes/pi-subagents-rpc-v1.md
@@ -13,7 +13,7 @@ Extension-owned progress, run inspection, and completion metadata may include th
   "protocol": "pi-subagents:v1",
   "agentId": "sa_…",
   "transport": "rpc",
-  "phase": "starting | ready | accepted | running | retrying | compacting | settled | failed | interrupted",
+  "phase": "starting | ready | accepted | running | finalizing | retrying | compacting | settled | failed | interrupted",
   "timing": {},
   "provider": "…",
   "model": "…",
@@ -48,7 +48,15 @@ A successful prompt response means accepted, not completed.
 
 Abort and timeout send the Pi RPC `abort` command and wait for settlement within a bounded grace period.
 
-A child that does not settle is terminated and cannot be reused.
+After a work timeout settles, the transport sends one bounded finalization prompt that requests only a summary of already gathered evidence and explicitly forbids further tool use.
+
+Pi RPC does not currently replace an existing child session's active tool set for one turn, so the finalization deadline and abort path remain authoritative if the model disregards that instruction.
+
+The finalization turn has a separate model-work deadline of at most 45 seconds, followed only by bounded abort and process-cleanup grace, and never replays the timed-out task.
+
+Explicit parent interruption does not start finalization.
+
+A child that does not settle after work or finalization abort is terminated and cannot be reused.
 
 An accepted or ambiguously accepted task is never replayed automatically.
 
@@ -66,7 +74,9 @@ Child extensions stay disabled to prevent recursive `pi-subagents` loading and d
 
 Custom or extension tools fail before RPC child creation with a subprocess recommendation.
 
-The selected cwd, project-trust decision, role prompt, model, thinking level, context, mailbox input, timeout, recursion depth, and output bounds retain their existing owners.
+The selected cwd, project-trust decision, role prompt, model, thinking level, context, mailbox input, work timeout, recursion depth, and output bounds retain their existing owners.
+
+`subagent_spawn.timeoutMs` is retained as the agent default, while `subagent_send.timeoutMs` overrides only one follow-up turn.
 
 RPC session-file persistence stays disabled because `AgentPersistence` owns sanitized logical recovery records.
 

--- a/docs/implementation-notes/pi-subagents-rpc-v1.md
+++ b/docs/implementation-notes/pi-subagents-rpc-v1.md
@@ -1,0 +1,121 @@
+# pi-subagents RPC v1
+
+`pi-subagents:v1` is the extension-owned transport and metadata contract layered over Pi's built-in RPC JSONL protocol.
+
+It does not add commands to Pi RPC or alter Pi command and event payloads.
+
+## Envelope
+
+Extension-owned progress, run inspection, and completion metadata may include these bounded fields:
+
+```json
+{
+  "protocol": "pi-subagents:v1",
+  "agentId": "sa_…",
+  "transport": "rpc",
+  "phase": "starting | ready | accepted | running | retrying | compacting | settled | failed | interrupted",
+  "timing": {},
+  "provider": "…",
+  "model": "…",
+  "thinkingLevel": "medium",
+  "usage": {}
+}
+```
+
+Fields are additive and optional within v1.
+
+A breaking lifecycle or envelope change requires another protocol identifier.
+
+Raw prompts, chain-of-thought, credentials, headers, environment values, full stderr, and raw tool arguments never enter the envelope.
+
+## Lifecycle
+
+One retained `agentId` lazily owns at most one RPC child.
+
+The child starts through the exact loaded Pi package with `--mode rpc --no-session --no-extensions`.
+
+A correlated `get_state` response is the readiness handshake.
+
+The task timeout begins only after readiness.
+
+The transport subscribes before sending `prompt`.
+
+A successful prompt response means accepted, not completed.
+
+`agent_end` is a low-level run boundary and cannot complete a retained turn.
+
+`agent_settled` is the authoritative completion boundary after retries, compaction, and queued continuations settle.
+
+Abort and timeout send the Pi RPC `abort` command and wait for settlement within a bounded grace period.
+
+A child that does not settle is terminated and cannot be reused.
+
+An accepted or ambiguously accepted task is never replayed automatically.
+
+Process exit marks the turn failed or interrupted with bounded partial evidence.
+
+Release, expiry, close, session replacement, reload, and shutdown abort owned work and terminate the process group until captured streams close.
+
+Extension UI requests fail closed in v1.
+
+## Resources and tools
+
+RPC v1 supports Pi built-in tools only.
+
+Child extensions stay disabled to prevent recursive `pi-subagents` loading and duplicate extension side effects.
+
+Custom or extension tools fail before RPC child creation with a subprocess recommendation.
+
+The selected cwd, project-trust decision, role prompt, model, thinking level, context, mailbox input, timeout, recursion depth, and output bounds retain their existing owners.
+
+RPC session-file persistence stays disabled because `AgentPersistence` owns sanitized logical recovery records.
+
+A restored record starts no process until an explicit follow-up arrives.
+
+Its first new RPC turn seeds bounded sanitized parent context and logical history exactly once.
+
+## Automatic selection
+
+`stateful.transport: "auto"` selects exactly one transport before child creation.
+
+Read-only built-in tool sets select `in-process` for the lowest startup overhead.
+
+Write-capable built-in tool sets select `rpc` for a persistent separate process.
+
+Extension or custom tools select the existing fresh `subprocess` path.
+
+The selection remains fixed for the retained agent's current runtime lifetime.
+
+A restored inert record is preflighted again on its first explicit follow-up.
+
+No startup or post-acceptance failure triggers automatic fallback.
+
+## Execution profiles
+
+Fast, Balanced, and Deep are explicit atomic patches to built-in agent thinking defaults.
+
+They do not change models, tools, timeouts, transport, completion delivery, or parent context.
+
+Fast uses low for scout, planner, worker aliases, and medium for reviewer.
+
+Balanced uses low for scout and medium for planner, reviewer, and worker aliases.
+
+Deep uses medium for scout and high for planner, reviewer, and worker aliases.
+
+No profile selects `max`.
+
+Explicit tool-call values remain authoritative.
+
+## Measurement
+
+Run `just benchmark-subagents` for serial offline startup and retained state-command measurements.
+
+The benchmark makes no provider request and therefore measures transport overhead rather than model quality or latency.
+
+A provider-backed smoke is optional and must stop after one clear external quota, credential, or entitlement failure.
+
+A seven-sample isolated-agent run on 2026-08-09 recorded 27.728 ms median deterministic fresh subprocess turn overhead with 0.782 ms MAD, 0.073 ms first retained RPC turn with 0.006 ms MAD, 0.037 ms retained RPC follow-up with 0.004 ms MAD, 445.631 ms real Pi RPC readiness with 9.765 ms MAD, 0.893 ms retained real Pi RPC `get_state` with 0.036 ms MAD, 3.759 ms in-process session creation with 0.198 ms MAD, and 0.001 ms retained in-process state access with 0.000 ms MAD.
+
+The deterministic turn measurements use a fake Pi while the readiness and SDK measurements use an isolated real Pi installation without credentials.
+
+The measurement supports retained transports as startup-overhead improvements without claiming provider-turn latency or quality.

--- a/docs/plans/archived/2026-08-09_pi-subagents-fluency-improvement-plan.md
+++ b/docs/plans/archived/2026-08-09_pi-subagents-fluency-improvement-plan.md
@@ -1,0 +1,224 @@
+# Pi Subagents Fluency Improvement Plan
+
+## Goal
+
+Make `pi-subagents` feel faster, easier to control, and easier to diagnose without weakening its trust, cancellation, persistence, or process-cleanup guarantees.
+
+Add an opt-in persistent RPC transport, deterministic automatic transport selection, previewable execution profiles, bounded performance diagnostics, spawn idempotency, context-size guidance, and an opt-in structured completion contract.
+
+Keep existing subprocess, in-process, tool, state, completion-delivery, and settings behavior compatible unless the user explicitly selects a new option.
+
+## Context
+
+- Stateful execution currently supports a fresh `subprocess` turn or one retained `in-process` `AgentSession` per `agentId`.
+- Fresh subprocess turns preserve process isolation but repeatedly pay Pi startup and logical-history reconstruction costs.
+- In-process turns preserve native child history and reduce startup cost but share the parent process and reject extension or custom tools.
+- Pi exposes a persistent JSONL RPC mode with correlated commands, streamed events, `abort`, state and usage inspection, and `agent_settled` as the true idle boundary.
+- Pi exports RPC types and `RpcClient` from its root package, but the stock client does not satisfy this package's exact CLI resolution, bounded stderr, readiness, process-group termination, and no-ad-hoc-output requirements.
+- `stateful.transport` currently accepts only `subprocess` and `in-process`, defaults to `subprocess`, and is captured when the session runtime starts.
+- Completion delivery already supports `next-turn` and `auto-resume`, but transport choice and completion delivery are configured separately and are not presented as a responsiveness workflow.
+- Agent settings already accept `model`, `thinkingLevel`, and `timeoutMs`, while the interactive agent editor currently exposes only tool permissions.
+- The model-facing spawn guidance already asks the root to select the lowest sufficient thinking level, but built-in agents intentionally have no fixed thinking defaults.
+- Mailbox send already supports a deduplication key, while `subagent_spawn` can still duplicate work if an accepted request is retried.
+- Context selection supports `none`, `all`, `summary`, recent user turns, and exact source IDs, but callers cannot inspect the expected byte and turn footprint before spawning.
+- `subagent_inspect` safely exposes status and diagnostics without launching work, but it does not report queue, startup, readiness, first-activity, settled, or delivery timing.
+
+## Architecture
+
+### RPC contract
+
+- Name the extension-owned RPC adapter contract `pi-subagents:v1`.
+- Keep Pi's built-in RPC command and event JSON unchanged, and place the `pi-subagents:v1` identifier only in extension-owned normalized progress, inspection, completion metadata, diagnostics, and tests.
+- Treat additive optional fields as compatible within v1, and require a new protocol identifier for a breaking envelope or lifecycle change.
+- Use public Pi root-exported RPC types where they are semantically sufficient, but keep child spawning, framing, correlation, stderr capture, readiness, abort, and termination in a package-owned adapter.
+- Reuse the package's bounded strict-LF `JsonLineDecoder` instead of Node `readline`.
+- Resolve the exact loaded Pi CLI through `resolvePiInvocation()` rather than PATH or a fixed `node dist/cli.js` assumption.
+- Start one lazy `pi --mode rpc --no-session` child per active retained agent and retain it across follow-up turns.
+- Complete a readiness handshake with a correlated `get_state` response before accepting a task into the RPC child and before starting the task timeout.
+- Subscribe to events before sending `prompt`, treat a successful prompt response as acceptance only, and wait for `agent_settled` rather than `agent_end` before finalizing the turn.
+- Never replay a prompt after its acceptance is uncertain or confirmed, because a replay could duplicate writes.
+- Launch the first RPC version with extensions disabled and an explicit built-in tool allow-list so recursive `pi-subagents` loading cannot occur.
+- Reject unsupported custom or extension tools before child creation with an actionable transport recommendation.
+- Preserve cwd, project trust, recursion-depth environment, model, thinking, role prompt, context, timeout, output bounds, redaction, and private-text behavior across transports.
+- Capture authoritative effective model and thinking state after readiness, and derive per-turn usage only from validated non-negative RPC event or session-stat deltas without inventing missing values.
+- Keep RPC session persistence disabled because `AgentPersistence` remains the owner of bounded, sanitized retained records.
+- Restore an inert retained record by starting a fresh RPC child only when the next explicit turn begins, seeding its sanitized logical context and history once.
+
+### Lifecycle and progress
+
+- Extend `SubagentTransport` with optional normalized progress and capability inspection rather than exposing raw Pi RPC events to tools or persistence.
+- Keep progress ephemeral and bounded so high-frequency stream events do not trigger settings writes or retained-state publication.
+- Record only non-secret timing and state metadata such as queue wait, transport start, readiness, prompt acceptance, first activity, settled, completion delivery, effective model and thinking, bounded usage, and context-window estimates.
+- Key every RPC child, temporary prompt, decoder, listener, timer, and process group by the retained `agentId` and owning session generation.
+- Revalidate abort and session generation after every asynchronous discovery, prompt-file, spawn, readiness, command, settlement, and cleanup boundary.
+- Make `release()` and `shutdown()` idempotent, abort active work, close stdin, signal the POSIX process group until streams close, escalate after grace, remove temporary files, and aggregate cleanup failures.
+- Fail extension UI requests closed in v1 instead of allowing a detached headless child to wait indefinitely for an unavailable dialog.
+
+### Transport selection
+
+- Add explicit `rpc` and `auto` values without changing the default `subprocess` value in the first release.
+- Implement `auto` as a preflight-only composite that selects one transport before child creation and retains that selection for the agent's current runtime lifetime.
+- Do not fall back to another transport after child creation or prompt acceptance.
+- Define and document one deterministic capability matrix before implementing `auto`, including tool kind, requested model, loaded public SDK support, CLI availability, process-isolation requirement, and trust/resource parity.
+- Keep persisted agent records transport-neutral, and re-run automatic preflight after a restored inert record receives an explicit follow-up.
+- Expose configured and effective transport separately in status and per-run inspection.
+
+### Settings and experience
+
+- Preserve `subprocess`, `next-turn`, inherited model, absent per-agent thinking override, and `context: none` as compatibility defaults.
+- Present transport, completion delivery, per-agent execution defaults, and context guidance as previewable advanced choices rather than silently changing behavior.
+- Add `Fast`, `Balanced`, and `Deep` as named, atomic setting patches with an exact preview and confirmation, not as a hidden precedence layer.
+- Keep built-in profiles provider-neutral, never select `max`, never widen parent context from `none` without explicit confirmation, and let explicit tool-call arguments remain authoritative.
+- Finalize the exact profile patch matrix from baseline evidence and user-visible trade-offs before implementation, with the current low/medium/high task guidance as the starting proposal.
+- Expose per-agent model, thinking, timeout, and reset-to-inherited controls in the existing agent settings flow while preserving unavailable configured values and unknown JSON fields.
+- Apply immediately only settings whose current runtime already supports safe live application, and label transport or retained-runtime changes as requiring `/reload`.
+- Never reload automatically while retained agents exist.
+- Keep the main manager's primary workflow and Current agents actions prominent, and place transport, profiles, timings, and expert overrides under shallow progressive disclosure.
+
+### Reliability and result efficiency
+
+- Add an optional `idempotencyKey` to `subagent_spawn` with session-owned semantics matching the existing mailbox key bound.
+- Hash the canonical spawn request and return the existing retained `agentId` for the same key and same request while rejecting key reuse with different inputs.
+- Perform idempotency lookup before project-agent confirmation, worktree creation, child allocation, or any other side effect.
+- Release the spawn key when the retained record is closed and preserve it across session reload while the record remains retained.
+- Add a side-effect-free context preview projection that reports selected turns, source count, UTF-8 bytes, and truncation without returning context text.
+- Keep `context: all` explicit and warn through descriptions or previews when `summary` or a bounded recent-turn selection would avoid unnecessary context transfer.
+- Prototype an opt-in structured completion result with versioned fields for summary, evidence, changes, verification, and risks.
+- Preserve bounded raw final text as a fallback when a model does not produce a valid structured result, and do not make structured output the default until provider and agent compatibility is proven.
+
+## Non-Goals
+
+- Do not replace the current blocking `subagent` or `subagent_consult` subprocess path with RPC in the first implementation phase.
+- Do not expose raw chain-of-thought, raw RPC events, prompt contents, credentials, headers, environment values, full stderr, or full tool arguments through progress or diagnostics.
+- Do not claim that RPC or process isolation is a filesystem, network, credential, or workspace sandbox.
+- Do not allow automatic transport fallback after startup or accepted work.
+- Do not add task-string heuristics, a classifier model call, or fixed provider-specific model aliases.
+- Do not make live steering of an already running retained turn part of `pi-subagents:v1`; existing `subagent_send` and mailbox semantics remain unchanged.
+- Do not change completion batching, auto-resume wake suppression, detached capacity defaults, trust policy, worktree policy, or blocking parallel semantics except where additive diagnostics are required.
+- Do not publish, tag, or dispatch a release without separate explicit approval.
+
+## Assumptions
+
+- `pi-subagents:v1` identifies the extension-owned adapter and metadata contract layered over Pi's existing RPC protocol rather than replacing Pi's command vocabulary.
+- One retained agent owns at most one persistent RPC child at a time.
+- RPC v1 supports only the built-in Pi tools that can be selected safely without loading child extensions.
+- The existing transport-neutral persisted logical history remains the recovery source after parent restart or RPC child loss.
+- A profile is an explicit settings patch that users can inspect, cancel, and later customize.
+- Performance acceptance should be based on reproducible measurements rather than an invented absolute latency promise.
+
+## Unknowns
+
+- The exact `auto` routing matrix needs a pre-implementation decision after capability probes establish RPC and in-process parity for tools, resources, trust, models, and thinking levels.
+- The exact Fast, Balanced, and Deep patch values need product approval after their latency, cost, and quality consequences are visible.
+- The structured completion prototype may show that prompt-only JSON is too unreliable for a public schema, in which case the feature remains experimental or is omitted.
+- A real-provider benchmark may be unavailable because of credentials, quota, or entitlement, so deterministic process and protocol benchmarks must remain sufficient for correctness and relative transport overhead.
+
+## Risks
+
+- A persistent RPC child can leak processes, listeners, streams, or temporary files if cancellation and shutdown ownership are incomplete.
+- A successful prompt response can be mistaken for completion and cause premature delivery unless every path waits for `agent_settled`.
+- Automatic fallback or replay can duplicate write side effects.
+- Loading extensions in an RPC child can recursively load `pi-subagents` and widen the approved tool surface.
+- Sixteen retained agents can imply sixteen resident child processes, so lazy startup, active limits, idle expiry, and deterministic release are required.
+- Timing diagnostics can become a covert content or path channel if labels or raw event data are retained.
+- Profile saves can erase manual or future settings unless writes use the existing latest-document lock, unknown-field preservation, validation, and atomic rename protocol.
+- A spawn idempotency key can return the wrong agent unless the canonical request hash includes every behavior-affecting field and rejects mismatches.
+- Context preview can create false precision because byte size is not provider token count, so it must label bytes and turns rather than promise token cost.
+- Adding `rpc` or `auto` to settings makes those files invalid to older releases until the value is changed back to `subprocess` or `in-process`.
+
+## Rollback / Recovery
+
+- Keep `stateful.transport: "subprocess"` as the documented rollback path and unchanged default.
+- Keep persisted retained records transport-neutral so switching away from RPC does not require state migration.
+- Mark a crashed RPC turn failed or interrupted with bounded partial evidence, dispose the child, and require an explicit later follow-up instead of replaying the accepted task.
+- If `auto` preflight cannot prove a safe route, fail before launch with the exact unsupported capability and a suggested explicit transport.
+- Preserve the previous effective settings and file when profile or execution-default persistence fails.
+- Before downgrading to a release that does not recognize `rpc` or `auto`, require changing the transport setting to `subprocess` and reloading Pi.
+- Keep every behavior slice in a focused changeset so a release can revert RPC, automatic routing, profiles, or result contracts independently.
+
+## Plan
+
+### Phase 0: Baseline and contracts
+
+- [x] Add a reproducible transport benchmark under `scripts/` that measures fresh subprocess startup, RPC readiness, first turn, retained follow-up, in-process creation, and retained follow-up; record medians and dispersion without provider secrets, and verify the script against a deterministic fake Pi plus an optional real Pi smoke.
+- [x] Write the `pi-subagents:v1` normalized envelope and lifecycle contract in an implementation note, including readiness, request correlation, accepted-versus-settled semantics, progress bounds, extension UI failure, crash behavior, and compatibility rules; verify it against installed Pi RPC docs and root-exported types.
+- [x] Probe RPC parity for exact CLI resolution, cwd, trust flags, model and `:<thinking>` resolution, built-in tools, role prompts, context seeding, retries, compaction, abort, and final output; record unsupported capabilities before selecting the v1 boundary.
+- [x] Decide and document the deterministic `auto` routing matrix and the exact previewable profile patch matrix; obtain user approval for any default or precedence change before implementation.
+
+### Phase 1: Persistent RPC transport
+
+- [x] Add failing protocol-driver tests using a test-owned `PI_PACKAGE_DIR` and fake `package.json#bin.pi` for strict LF framing, split UTF-8, `U+2028` and `U+2029`, oversized and malformed lines, correlated responses, bounded stderr, process exit, and readiness; verify the tests fail before `rpc-transport.ts` exists.
+- [x] Implement a package-owned RPC driver using `resolvePiInvocation()`, `JsonLineDecoder`, public Pi root RPC types, bounded command correlation, and a `get_state` readiness handshake; verify no deep Pi import, PATH fallback, fixed Node CLI, stdout logging, or unbounded stderr remains.
+- [x] Add failing lifecycle tests for abort before spawn, abort during readiness, timeout after readiness, `agent_end` followed by retry or compaction, authoritative `agent_settled`, crash before and after prompt acceptance, stdin failure, extension UI request, and no automatic replay.
+- [x] Implement `RpcTransport` with one lazy child per retained `agentId`, native multi-turn history, authoritative effective model and thinking state, validated per-turn usage deltas, bounded final and partial output, `pi-subagents:v1` progress, and exact task timeout semantics; verify a two-turn child receives the second task without duplicated logical history.
+- [x] Reuse agent discovery and safe resource assembly so RPC launch preserves model, thinking, tools, cwd, trust, recursion depth, role prompt, parent context, mailbox input, private-text redaction, and output limits; verify unsupported tools fail before child creation.
+- [x] Implement idempotent release and shutdown with unsubscribe, abort, stdin close, process-group TERM/KILL escalation, descendant-stream closure, temporary-file cleanup, partial-start cleanup, and aggregated errors; verify close, subtree close, expiry, clear, session replacement, reload, and shutdown.
+- [x] Extend `SubagentTransportKind`, settings validation, runtime status, inspection, rendering, help, and README with opt-in `rpc`; verify malformed settings remain protected, unknown fields survive, and the default remains `subprocess`.
+- [x] Add a minor Changeset for the opt-in RPC transport and run focused tests, package typecheck, root boundary checks, `just pack subagents`, and an offline real Pi RPC loader smoke before continuing.
+
+### Phase 2: Automatic routing and responsiveness setup
+
+- [x] Add capability-probe tests and an `AutoTransport` composite that selects exactly one transport before child creation, caches that choice for the retained runtime, reports the reason, and never performs post-start fallback.
+- [x] Add `auto` settings validation, configured-versus-effective status, per-run transport inspection, mixed-runtime cleanup, restored-record re-preflight, and actionable unsupported-capability errors; verify old transport values and persisted records remain compatible.
+- [x] Add an Advanced settings transport screen with current and configured values, concrete isolation and tool trade-offs, preview, cancellation, serialized save, failure rollback, and reload-only application while retained agents are protected.
+- [x] Add a responsiveness setup screen that previews `in-process` or `auto`, `auto-resume`, and explicit thinking guidance as separate choices rather than silently enabling them; verify cancellation is read-only and each selected patch preserves unrelated settings.
+- [x] Re-run the transport benchmark and record whether RPC and automatic routing reduce measured follow-up overhead; do not recommend or default a route whose measured behavior does not improve its stated use case.
+
+### Phase 3: Execution profiles and observability
+
+- [x] Add failing settings tests for previewable Fast, Balanced, and Deep patches, explicit-call precedence, reset-to-inherited behavior, unavailable model preservation, unknown-field preservation, concurrent edits, invalid-file refusal, and rollback after persistence or runtime-application failure.
+- [x] Add per-agent execution settings for model, thinking level, timeout, and reset alongside the existing tool editor, using Pi TUI Kit standard screens and the session model catalog without hard-coded provider aliases.
+- [x] Implement named profiles as atomic visible patches over owned settings, preserve `context: none` unless explicitly approved, keep `max` manual-only, and show latency, quality, and cost trade-offs before confirmation.
+- [x] Add normalized ephemeral transport progress to the registry and Current agents view with queue position, phase, elapsed time, and effective transport while keeping raw model text and event payloads out of persistence.
+- [x] Extend `subagent_inspect get_run`, `status`, and `diagnose` with bounded current-session timing, protocol, effective transport, effective model and thinking, validated usage, capability checks, and failure phase; verify inspection stays side-effect-free and never launches a child.
+- [x] Add deterministic timing tests with an injected clock for queue wait, startup, readiness, acceptance, first activity, settlement, completion batching, and auto-resume delivery while preserving the existing settled-completion snapshot ordering.
+- [x] Update README and help with profiles, precedence, timing definitions, measurement limits, and the distinction between transport isolation and sandboxing; add a separate minor Changeset if this phase ships independently.
+
+### Phase 4: Duplicate prevention, context guidance, and completion contracts
+
+- [x] Add failing schema, registry, persistence, worktree, project-confirmation, reload, close, and mismatch tests for `subagent_spawn.idempotencyKey`, including same-key same-request reuse and same-key different-request rejection before side effects.
+- [x] Implement canonical spawn hashing and retained-key lookup without exposing task or context content, preserve optional fields through current state storage when downgrade tests permit it, and release the key when the retained record closes.
+- [x] Add a side-effect-free context preview projection to `subagent_inspect` or another existing safe surface, returning only mode, turns, source count, bytes, and truncation; verify private text, raw entries, and selected content never appear.
+- [x] Add context-size metadata to spawn result details and settings/profile previews, and document that byte counts are not provider token estimates.
+- [x] Prototype a versioned structured completion format with summary, evidence, changes, verification, and risks; test valid, partial, malformed, oversized, private, and plain-text fallback outputs across built-in and custom agents.
+- [x] Ship structured completion only as an explicit opt-in after the prototype passes provider-compatibility review, otherwise record the rejection and keep bounded text as the sole stable contract.
+- [x] Update tool descriptions, renderers, README, compatibility notes, and a separate minor Changeset for shipped public schema or completion behavior.
+
+### Phase 5: Final verification and handoff
+
+- [x] Audit every changed asynchronous flow for user cancellation, abort during creation, stale session generation after each `await`, component disposal, session replacement, shutdown, child crash, retry, expiry, and exactly-once cleanup; record the audit by owning module.
+- [x] Audit every settings read and write for defaults, precedence, malformed and invalid files, latest-document locking, unknown-field preservation, ordered saves, stale confirmation, atomic publication, rollback, reload semantics, and older-version downgrade guidance.
+- [x] Audit terminal and model-facing boundaries so paths, tasks, model IDs, RPC errors, stderr, context metadata, progress, and structured results are bounded, redacted, and sanitized before display.
+- [x] Run all focused `pi-subagents` tests, `npm test`, `npm run check`, `git diff --check`, and `just pack subagents`; record exact passing evidence and inspect the tarball for intended source, README, manifest, license, and Changesets only.
+- [x] Run a real local `pi -e ./packages/pi-subagents` smoke covering opt-in RPC spawn, two-turn reuse, interrupt, close, session shutdown, automatic routing inspection, profile cancellation and save, and completion delivery; stop after one clear provider or entitlement failure and retain deterministic evidence for unverified live paths.
+- [x] Run an independent review against `docs/extension-conventions.md`, `docs/extension-settings.md`, Pi RPC documentation, package `AGENTS.md`, public API compatibility, and the final diff; resolve every material finding or document an explicitly accepted deviation.
+- [x] Move durable protocol and mechanism facts to `docs/implementation-notes/` or an ADR, update the README for user behavior, check every plan item with evidence, and archive this plan only after no required work remains.
+
+## Execution evidence
+
+- The package gate passed with 18 files and 224 tests after the final hardening changes.
+- The full repository test suite passed with 235 files and 2,658 tests.
+- The full `VITEST_MAX_WORKERS=4 npm run check` gate passed with root Biome, boundaries, all workspace type checks, 235 test files, and 2,658 tests; the worker cap avoids local process-start deadline contention without reducing test coverage.
+- `just benchmark-subagents 7` passed with deterministic fake-turn and isolated real Pi measurements recorded in `docs/implementation-notes/pi-subagents-rpc-v1.md`.
+- `just pack subagents` produced a 56-file dry-run tarball containing only the manifest, README, license, and published source.
+- The offline real Pi RPC loader returned a correlated successful `get_state` response without provider access.
+- Live provider smokes passed RPC spawn and two-turn reuse, idle-root completion delivery, interrupt, inspection, close, automatic in-process selection, structured completion, and active-child session-shutdown cleanup.
+- An automated real Pi TUI smoke cancelled a Balanced profile confirmation without a write and then saved the same profile successfully.
+- The lifecycle audit covered `stateful.ts`, `stateful-lifecycle.ts`, `rpc-transport.ts`, `in-process-transport.ts`, `auto-transport.ts`, `completion-delivery.ts`, `workspace.ts`, `config-ui.ts`, `execution-ui.ts`, and `transport-ui.ts`.
+- The settings audit covered malformed-file refusal, latest-document locking, unknown-field preservation, atomic publication, stale confirmation checks, reload-only transport application, retained-agent protection, and downgrade guidance.
+- The terminal and model-boundary audit covered RPC framing and stderr, model and tool names, task and completion text, context metadata, telemetry, structured results, paths, and temporary role prompts.
+- No publication, tag, visibility change, or release workflow was performed.
+
+## Completion Checklist
+
+- [x] `pi-subagents:v1` is documented, bounded, versioned, and implemented without changing Pi's underlying RPC wire vocabulary.
+- [x] RPC retains one child per active retained agent, uses readiness and `agent_settled`, never replays accepted work, and cleans every owned process, stream, listener, timer, and temporary file.
+- [x] Existing subprocess and in-process behavior remains available, and the default remains unchanged unless separately approved from benchmark evidence.
+- [x] Automatic routing is deterministic, preflight-only, inspectable, and incapable of silently widening tools or retrying side effects.
+- [x] Profiles and execution settings are previewable, cancelable, provider-neutral, precedence-safe, concurrency-safe, and recoverable after failure.
+- [x] Timing and progress diagnostics identify queue, startup, readiness, execution, settlement, and delivery delays without exposing private content or launching inspection work.
+- [x] Spawn retries can be deduplicated before confirmation, worktree creation, or child launch, while mismatched key reuse fails clearly.
+- [x] Context guidance reports bounded bytes and turns without claiming provider token precision or revealing selected text.
+- [x] Structured completion either passes the opt-in compatibility gate with bounded fallback behavior or is explicitly rejected without weakening the existing text contract.
+- [x] Cancellation, disposal, session replacement, shutdown, settings concurrency, trust, terminal safety, packaging, runtime smokes, and CI-equivalent checks all have recorded evidence.
+- [x] Every shipped behavior change has an appropriate Changeset, downgrade instructions are documented, and no publication occurred without explicit approval.

--- a/docs/plans/archived/2026-08-09_pi-subagents-graceful-timeout-plan.md
+++ b/docs/plans/archived/2026-08-09_pi-subagents-graceful-timeout-plan.md
@@ -1,0 +1,66 @@
+# Pi Subagents Graceful Timeout Plan
+
+## Goal
+
+Let the main agent choose a bounded work timeout for every subagent turn and turn elapsed work deadlines into an abort-then-summarize flow with a separate hard-bounded finalization phase.
+
+## Architecture
+
+- Treat public `timeoutMs` as the work deadline selected by the main agent.
+- On a work timeout, abort the active run, wait for authoritative settlement, and request a concise summary of only evidence already gathered.
+- Bound finalization independently so an ignored abort, stuck provider, or failed summary cannot block the parent indefinitely.
+- Preserve explicit user interruption semantics: user aborts stop immediately and do not launch a summary turn.
+- Keep retained spawn timeouts as per-agent defaults and allow `subagent_send.timeoutMs` to override one follow-up turn.
+- Keep subprocess finalization tool-less and bounded; RPC and in-process transports reuse their retained child context after successful abort settlement.
+
+## Non-Goals
+
+- Do not make finalization unbounded.
+- Do not automatically retry or replay the timed-out task.
+- Do not infer task difficulty from task text.
+- Do not change the existing default timeout when the main agent omits `timeoutMs`.
+
+## Risks
+
+- A summary turn can itself hang, so it needs a hard finalization deadline and process/session cleanup.
+- A retained summary prompt can still attempt tools because current child APIs cannot replace one turn's active tool set; the prompt prohibits tool use, while the separate deadline and abort path remain authoritative.
+- Spawn idempotency must include the retained timeout because it changes execution behavior.
+- Timeout summaries must remain bounded, sanitized, private-text-safe, and accurately labeled as partial evidence.
+
+## Rollback / Recovery
+
+- Keep the timeout exit code and failed retained-agent state so callers can still distinguish work deadline expiry.
+- If abort does not settle or summary finalization fails, return bounded partial evidence and release the unusable child.
+- The existing default timeout and explicit user-abort behavior remain the compatibility rollback path.
+
+## Plan
+
+- [x] Add failing focused tests for main-agent timeout selection on spawn and follow-up turns, including idempotency and persistence; the initial focused run failed in six intended assertions before implementation.
+- [x] Add failing focused tests for abort-then-summary behavior and hard-bounded finalization in subprocess, RPC, and in-process transports; the initial focused run failed before summary recovery existed.
+- [x] Implement retained timeout storage and per-follow-up overrides across tool schemas, registry state, persistence, inspection, hashing, and transport resolution.
+- [x] Implement bounded timeout finalization prompts and subprocess summary recovery without task replay or tool access.
+- [x] Implement RPC and in-process abort-settle-summary state transitions with a separate finalization timeout and deterministic cleanup.
+- [x] Update model-facing guidance, README, protocol note, renderers, and result metadata to explain work deadlines and summary finalization.
+- [x] Update the existing minor Changeset for the published timeout behavior.
+- [x] Audit cancellation, stale session generation, shutdown, settings, output bounds, private text, terminal rendering, idempotency, and retained-tool limitations against `docs/extension-conventions.md` and `docs/extension-settings.md`.
+- [x] Run focused tests, package checks, root `npm run check`, `git diff --check`, and `just pack subagents`; all passed.
+- [x] Run independent bounded reviews of subprocess, retained timeout selection, RPC/in-process cleanup, and explicit-abort races; resolve every reported finding and finish with no remaining finding.
+
+## Execution Evidence
+
+- `npm run check --workspace @narumitw/pi-subagents` passed Biome and TypeScript checks.
+- The focused package suite passed 18 files and 231 tests before the final root run.
+- `VITEST_MAX_WORKERS=4 npm run check` passed Biome, package boundaries, every workspace typecheck, 235 test files, and 2,666 tests.
+- `git diff --check` passed.
+- `just pack subagents` produced and inspected a 60-file dry-run tarball containing the manifest, README, license, and published source, including the new timeout modules.
+- Independent reviewers found and prompted fixes for pre-close subprocess finalization, unbounded process/RPC cleanup, abort-to-prompt races, and an unbounded RPC prompt client; the final focused re-review reported no findings.
+
+## Completion Checklist
+
+- [x] Main-agent calls can set a work timeout for blocking, consultation, spawn, and individual retained follow-up turns.
+- [x] Work timeout aborts first and returns a bounded summary when finalization succeeds.
+- [x] Finalization always has a finite model-work deadline plus bounded abort and cleanup grace.
+- [x] Explicit user interruption never starts timeout finalization.
+- [x] Timeout selection, idempotency, persistence, inspection, documentation, and tests agree.
+- [x] Required verification and package inspection pass.
+- [x] The completed plan is ready to archive.

--- a/justfile
+++ b/justfile
@@ -75,6 +75,10 @@ try name: (_validate-package-name name)
     npm --workspace {{ quote("@narumitw/pi-" + name) }} run build --if-present
     pi -e {{ quote("./packages/pi-" + name) }}
 
+# Measure offline pi-subagents transport startup and retained-command overhead
+benchmark-subagents samples="7":
+    node scripts/benchmark-pi-subagents-transports.mjs --samples {{ quote(samples) }}
+
 # Start Pi with the commonly used extensions loaded from this working tree
 # PI_TIMING reports startup timing for local extension development
 dev:

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -760,6 +760,7 @@ packages/pi-subagents/
 │   ├── consult.ts                # Synchronous read-only consultation tool
 │   ├── consult-policy.ts         # Enforced read-only tool intersection
 │   ├── cwd-policy.ts             # Canonical target and saved-trust resolution
+│   ├── prompt-resources.ts       # Core-selected SYSTEM and APPEND_SYSTEM resources
 │   ├── safe-text.ts              # Shared byte/line/path sanitization
 │   ├── stateful.ts               # Detached lifecycle registration and dispatch
 │   ├── rpc-transport.ts          # Persistent strict-JSONL Pi RPC child transport

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -15,15 +15,17 @@ Use it to split independent research, planning, implementation, and review work 
 - Lets users set a blocking parallel call's maximum worker count from 1 through 64 while keeping four-at-a-time execution.
 - Registers detached stateful lifecycle tools by default; completion can stay queued for the next turn or opt into an idle root synthesis turn.
 - Supports an opt-in public-SDK `in-process` stateful transport with one reusable child `AgentSession` per `agentId`.
+- Supports an opt-in persistent `rpc` transport with one isolated Pi RPC process per active retained agent and `pi-subagents:v1` lifecycle metadata.
+- Supports deterministic opt-in `auto` routing: read-only built-ins use in-process, write-capable built-ins use RPC, and custom tools use the compatibility subprocess path.
 - Supports built-in `scout`, `planner`, `reviewer`, and `worker` agents.
 - Loads custom user agents from `~/.pi/agent/agents/*.md`.
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
 - Provides a current-session-first `/subagents` manager, direct `settings|status|help` routes, and compatibility aliases for agent tools and retained agents.
-- Supports trust-aware per-task `cwd` policies, hard subprocess `timeoutMs`, task-selected `thinkingLevel`, abort propagation, and streaming progress.
+- Supports trust-aware per-task `cwd` policies, hard `timeoutMs`, task-selected `thinkingLevel`, abort propagation, bounded progress and timing telemetry, and explicit Fast, Balanced, or Deep thinking profiles.
 - Renders all seven tools with Pi-native compact/expanded transcript rows; long-running blocking and consultation calls show bounded live activity.
 - Bounds JSON lines, captured messages, stderr, final output, chain substitution, and fan-in context.
 - Enforces a recursion-depth guard and deterministic process-group termination.
-- Provides addressable stateful agents with follow-up, consolidated mailbox/management actions, context selection, and persistence.
+- Provides addressable stateful agents with follow-up, consolidated mailbox/management actions, idempotent spawn retries, context selection and preview, opt-in structured completion metadata, and persistence.
 - Publishes transient runtime status through Pi's generic extension status API while subagents are running.
 - Returns complete bounded worker output in tool details and a concise result for the main agent.
 
@@ -108,7 +110,9 @@ Common controls:
 
 - `cwd` — choose a launch directory subject to the user-owned trust-aware target policy described below.
 - `timeoutMs` — set a hard subprocess timeout.
-- `thinkingLevel` — request `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` thinking for the spawned Pi process or in-process child.
+- `thinkingLevel` — request `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` thinking for the spawned Pi process or retained child.
+- `idempotencyKey` — make an exact `subagent_spawn` retry return the existing retained `agentId`; reuse with different parameters fails before confirmation, worktree creation, or child launch.
+- `resultFormat` — keep bounded text by default or request the opt-in `structured-v1` summary/evidence/changes/verification/risks contract with text fallback.
 
 For `subagent_spawn`, the root agent selects the lowest thinking level sufficient for the delegated task. This is a tool-argument decision made from the task already in context; `pi-subagents` does not run a string heuristic or an extra classifier model call.
 
@@ -218,8 +222,9 @@ A blocking fan-out is reserved for output that must be synthesized before the ro
 | `list_agents` | Optional `agentScope` (default `user`) and `limit` (default 32, maximum 100) | Bounded agent metadata and omission counts |
 | `get_agent` | Required `agent`; optional `agentScope` | One resolved definition, safe source path, configured tools, and consultation-effective tools; never the system prompt |
 | `list_runs` | Optional `includeClosed` and `limit` (default 50, maximum 100) | Metadata-only retained-run summaries and unread counts |
-| `get_run` | Required `agentId` | Safe `cwd`, current-task/error summaries, thinking level, policy, history count, and unread count |
+| `get_run` | Required `agentId` | Safe `cwd`, current-task/error summaries, thinking level, context footprint, protocol, effective transport, bounded timing/usage telemetry, structured result when valid, policy, history count, and unread count |
 | `list_models` | Optional `limit` (default 50, maximum 100) | Session-scoped models, or the already-loaded available snapshot |
+| `preview_context` | Optional `context` and `contextEntryIds` | Selected mode, user turns, source count, UTF-8 bytes, and truncation without returning context text |
 | `status` | No additional fields | Effective workflow, runtime counts/transport, detached limit values, completion delivery, consultation resources, and configured/runtime settings with per-field sources |
 | `diagnose` | No additional fields | Structured `pass`, `warning`, and `fail` checks; failed checks are report data rather than a tool error |
 
@@ -349,12 +354,18 @@ A detached agent additionally needs a concrete isolation or specialization benef
 
 Auto-resume is best-effort because Pi's custom-message API is fire-and-forget. Session-generation checks, shutdown cleanup, batching, and the in-flight wake guard prevent stale or duplicate scheduling pressure, but they do not make completion delivery durable across process exit.
 
-The default `subprocess` transport preserves compatibility: each turn starts a fresh isolated `pi --mode json -p --no-session` child and receives sanitized, bounded history. Set `transport` to `in-process` to retain one public Pi SDK `AgentSession` per stateful `agentId`, avoiding repeated process startup while preserving native child history in memory.
+The default `subprocess` transport preserves compatibility: each turn starts a fresh isolated `pi --mode json -p --no-session` child and receives sanitized, bounded history.
+Set `transport` to `in-process` to retain one public Pi SDK `AgentSession` per stateful `agentId`, avoiding repeated process startup while preserving native child history in memory.
+Set it to `rpc` to retain one `pi --mode rpc --no-session --no-extensions` process per active retained agent, preserving native child history with a separate process boundary.
+Set it to `auto` for deterministic preflight selection: read-only built-in tools use in-process, write-capable built-in tools use RPC, and extension/custom tools use subprocess.
+Automatic selection never falls back after child creation or prompt acceptance.
 
 Run `/subagents` in TUI mode to open the standard primary manager.
 It leads with the current delegation workflow, human-readable async completion behavior, consultation/delegation target policies, consultation-resource policy, parallel-worker limit, and active/retained counts.
 **Change delegation**, **Current agents**, and **Settings** cover the common workflows.
-Agent permissions, **Maximum parallel workers**, **Detached agent limits**, transport/runtime details, source, and settings path remain under **Advanced settings**.
+Agent permissions, **Maximum parallel workers**, **Detached agent limits**, **Performance and execution**, transport/runtime details, source, and settings path remain under **Advanced settings**.
+**Performance and execution** provides responsiveness guidance, transport previews, Fast/Balanced/Deep thinking profiles, and per-agent model/thinking/timeout defaults.
+Profiles are explicit atomic thinking patches, preserve model/tool/timeout/context settings, never select `max`, and can be customized afterward.
 The parallel-worker input rejects invalid values without discarding the draft and applies a successful save immediately.
 The detached-limit screen edits retained capacity, active-turn concurrency, direct children, tree depth, and stored-record capacity.
 Detached-limit saves are durable immediately but apply to the runtime after `/reload` or the next Pi session.
@@ -371,7 +382,7 @@ The direct routes remain predictable: `/subagents settings` changes both target 
   },
   "stateful": {
     "enabled": true,
-    "transport": "in-process",
+    "transport": "auto",
     "completionDelivery": "auto-resume",
     "maxAgents": 16,
     "maxActiveTurns": 4,
@@ -416,7 +427,7 @@ This avoids lifecycle-driven tool-schema churn and preserves a stable provider p
 
 | Tool | Purpose |
 | --- | --- |
-| `subagent_spawn` | Start detached work with an optional task-selected thinking level, return an opaque `agentId` immediately, and deliver completion asynchronously. |
+| `subagent_spawn` | Start detached work with optional task-selected thinking, exact-retry `idempotencyKey`, and `text` or `structured-v1` result format; return an opaque `agentId` immediately and deliver completion asynchronously. |
 | `subagent_send` | Send follow-up work and trigger a new turn on a reusable agent; shared-workspace write conflicts are guarded unless explicitly overridden. |
 | `subagent_manage` | Use `action: "list"` to inspect agents, `"interrupt"` to retain an agent after aborting active work, or `"close"` to release it; interrupt/close accept optional `subtree`. |
 | `subagent_mailbox` | Use `action: "send"` for queue-only messages that do not start a turn, or `"read"` to read and optionally acknowledge unread messages. |
@@ -472,6 +483,23 @@ A spawn can request a thinking level explicitly:
 
 The requested level is stored with the stateful agent and remains in effect for all follow-ups and after persisted restore. `subagent_send` does not provide a per-turn thinking override; create a new agent when a later task needs a different level.
 
+An exact retry can use a bounded session-owned idempotency key:
+
+```json
+{
+  "agent": "worker",
+  "task": "Implement the approved change",
+  "idempotencyKey": "approved-change-1"
+}
+```
+
+The same key and canonical request returns the existing retained `agentId` without another confirmation, worktree, or child.
+Reusing the key with different behavior-affecting parameters fails.
+Closing the retained record releases the key.
+
+Set `resultFormat: "structured-v1"` to ask for versioned `summary`, `evidence`, `changes`, `verification`, and `risks` fields.
+Valid structured data appears in completion and inspection details, while the bounded final text remains authoritative fallback when the model returns malformed or ordinary text.
+
 `subagent_spawn.context` accepts:
 
 - `"none"` (default) — no parent conversation.
@@ -479,21 +507,31 @@ The requested level is stored with the stateful agent and remains in effect for 
 - `"summary"` — a bounded earlier-context checkpoint plus recent messages verbatim.
 - A positive number — the most recent N user turns and related assistant text.
 
-Use `contextEntryIds` to select exact session entries. Supplying IDs without `context` implies `context: "all"`; an explicit `context: "none"` still disables parent context. Stable source IDs are retained so repeated follow-ups do not need to duplicate parent context.
+Use `contextEntryIds` to select exact session entries.
+Supplying IDs without `context` implies `context: "all"`; an explicit `context: "none"` still disables parent context.
+Stable source IDs are retained so repeated follow-ups do not need to duplicate parent context.
+Use `subagent_inspect` with `action: "preview_context"` to inspect selected turns, source count, UTF-8 bytes, and truncation before spawning without returning the context text.
+The byte count is not a provider token estimate.
 
 Reasoning, tool results, custom transport messages, and non-text parts are excluded. Text inside `<private>...</private>` and lines containing `[subagent-private]` are omitted before context, mailbox content, or history is persisted.
 
 Stateful execution uses a transport boundary:
 
-- `subprocess` is the default compatibility and rollback path.
+- `subprocess` is the default compatibility and rollback path and starts a fresh child for every turn.
 - `in-process` uses only public Pi SDK APIs: `createAgentSessionServices()`, `createAgentSessionFromServices()`, `SessionManager.inMemory()`, and normal session lifecycle methods. It isolates conversation/tool selection, not memory or crashes; child failures share the parent Node.js process.
-- Child resource loading sets `noExtensions: true`, preventing recursive `pi-subagents` loading and duplicate extension side effects while retaining trust-eligible context/skill resources and the selected agent prompt. Both transports receive the same resolved target-trust boolean: subprocess children get explicit `--approve`/`--no-approve`, and in-process children set the same `SettingsManager.projectTrusted` value.
+- `rpc` uses strict bounded JSONL over one lazy child process per active retained agent. A `get_state` response proves readiness, prompt response means accepted only, and `agent_settled` is the completion boundary after retry or compaction.
+- `auto` selects one transport before launch and retains the choice for that agent's runtime lifetime. It never retries through another transport after startup or accepted work.
+- In-process and RPC child resource loading disables extensions to prevent recursive `pi-subagents` loading and duplicate extension side effects while retaining trust-eligible context/skill resources and the selected agent prompt. The compatibility subprocess path retains its recursion-depth guard and configured tool behavior. Transports receive the same resolved target-trust boolean through their public SDK or explicit CLI trust controls.
 - Agent model strings use Pi core's CLI resolver, including provider/model patterns, fuzzy matching, custom provider model IDs, and `:<thinking>` suffixes. Thinking level and built-in tool allow-list overrides are applied when the child is created. Parent model/thinking changes are snapshotted for subsequently created children; an existing child keeps its own session configuration.
-- Extension/custom tool names are rejected in-process with an actionable recommendation to use `subprocess`; permissions are never silently widened.
-- Timeout, parent abort, close, expiry, and session shutdown abort/dispose owned child sessions. A child that does not settle after abort grace is discarded rather than reused.
+- Extension/custom tool names are rejected by in-process and RPC v1 before child creation; automatic mode selects `subprocess` for them, and permissions are never silently widened.
+- Timeout, parent abort, close, expiry, and session shutdown abort/dispose owned child sessions or process groups. A child that does not settle after abort grace is discarded rather than reused.
+- RPC progress uses `pi-subagents:v1` metadata and reports only bounded phase, queue, timing, effective model/thinking, and validated usage fields; it never exposes raw prompts, reasoning, credentials, environment values, or full RPC events.
+- A successful RPC prompt response is never treated as completion, and accepted or ambiguously accepted work is never replayed automatically.
 - In-process startup failures do not silently retry through subprocesses, preventing duplicate side effects. If the loaded Pi core lacks public `createAgentSessionServices()`, `createAgentSessionFromServices()`, or `resolveCliModel()` support, startup fails with an actionable instruction to select `stateful.transport: "subprocess"`.
 
-No private Pi imports, runtime casts, or `ExtensionAPI` monkey-patching are used. Approval policy, sandbox profile, provider-header hooks, extension state, global scheduling, and parent/child transcript switching are not inherited or provided by the in-process transport.
+No private Pi imports, runtime casts, or `ExtensionAPI` monkey-patching are used.
+The package uses public Pi root RPC types but owns exact CLI resolution, bounded framing, readiness, stderr, cancellation, and process-group cleanup because the stock client does not provide those package-specific guarantees.
+Approval policy, sandbox profile, provider-header hooks, extension state, global scheduling, and parent/child transcript switching are not inherited or provided by in-process or RPC transport.
 
 Write-capable agents share the workspace by default. Concurrent write-capable starts in the same cwd are rejected unless `allowConcurrentWrites` is explicitly set. Classification is intentionally conservative: an agent with `bash`, `write`, or `edit` is write-capable even when its task prompt says “read only,” because prompt wording is not a filesystem sandbox. Prefer one detached agent when asynchronous work can be combined. If concurrent work is genuinely required, use the blocking batch only when synchronous outputs justify making the root unavailable, explicitly accept safe detached overlap with `allowConcurrentWrites`, or use isolated worktrees when repository isolation is needed.
 
@@ -502,6 +540,9 @@ Set `workspaceMode: "worktree"` to opt into a disposable detached Git worktree; 
 ## 📜 Compatibility and failure contract
 
 Existing accepted `subagent` payload shapes remain unchanged.
+`subagent_spawn` adds optional `idempotencyKey` and `resultFormat` fields without changing omitted behavior.
+Older releases do not recognize `stateful.transport: "rpc"` or `"auto"`; change the value to `"subprocess"` and reload before downgrading.
+Retained records remain transport-neutral, and older readers ignore the additive idempotency and context-footprint fields while the state version remains compatible.
 The `tasks` schema now advertises the absolute 64-item safety bound, while the effective `blocking.maxParallelTasks` value may be lower.
 The intentional compatibility change is that an external target without saved trust is rejected by the new default `cwdPolicy.delegation: "trusted-targets"`; set the user-owned policy to `"anywhere"` to restore the preceding target flexibility.
 
@@ -531,12 +572,24 @@ Built-in agents are available without setup and can be overridden by user or pro
 
 The built-in `reviewer` does not run tests, builds, benchmarks, or formatters. It recommends additional verification commands for the main agent to run instead. Custom agents can override this behavior.
 
-Built-in agents inherit the active/default Pi model instead of forcing a provider-specific model alias, which keeps subprocesses usable across different Pi setups.
+Built-in agents inherit the active/default Pi model instead of forcing a provider-specific model alias, which keeps every transport usable across different Pi setups.
+Built-ins also have no fixed thinking override until a caller, frontmatter, per-agent setting, or execution profile selects one.
+
+The optional profiles apply these provider-neutral thinking defaults:
+
+| Profile | `scout` | `planner` | `reviewer` | `worker` and aliases |
+| --- | --- | --- | --- | --- |
+| Fast | `low` | `low` | `medium` | `low` |
+| Balanced | `low` | `medium` | `medium` | `medium` |
+| Deep | `medium` | `high` | `high` | `high` |
+
+Profiles preserve model, timeout, tools, transport, completion delivery, and parent-context behavior.
 
 ## ⚙️ Configure agent tools
 
 Open `/subagents`, choose **Advanced settings**, then **Agent tool permissions** in an interactive
-Pi session to edit the tools each subagent may use. The standard bounded multi-select keeps a
+Pi session to edit the tools each subagent may use.
+Choose **Performance and execution** → **Agent execution defaults** to edit provider-neutral inherited model patterns, thinking levels, and timeouts without changing tools. The standard bounded multi-select keeps a
 one-save draft: toggles do not write until **Save changes**, Escape leaves the draft without writing,
 and unavailable configured tool names remain visible and preserved. In TUI mode, type to fuzzy-search
 tool names and availability metadata; Save and Discard remain pinned below the matches. These are user
@@ -643,7 +696,11 @@ For `subagent_spawn`, the root agent should choose the lowest sufficient level:
 
 Blocking thinking precedence is: task/chain step/aggregator `thinkingLevel` → top-level `thinkingLevel` → agent default from config or frontmatter → Pi subprocess default.
 
-Stateful spawn precedence is: `subagent_spawn.thinkingLevel` → agent default from config or frontmatter → transport fallback. The subprocess transport then uses spawned Pi model/default resolution. The in-process transport delegates configured model parsing to the loaded Pi core and uses its model thinking suffix before the parent thinking snapshot captured when the child is created. An explicit spawn value is retained for the agent lifecycle and wins over all of those fallbacks.
+Stateful spawn precedence is: `subagent_spawn.thinkingLevel` → agent default from settings or frontmatter → model suffix → transport fallback.
+Subprocess uses spawned Pi model/default resolution.
+In-process delegates configured model parsing to loaded Pi core and then uses the parent thinking snapshot captured at child creation.
+RPC passes the selected CLI model and thinking controls before its readiness handshake and reports the effective state returned by Pi.
+An explicit spawn value is retained for the agent lifecycle and wins over every fallback.
 
 Omit `thinkingLevel` to preserve existing behavior. Reported stateful details show the requested level, not a guarantee of the provider's effective value. Pi still owns model capability clamping; `pi-subagents` does not duplicate capability detection.
 
@@ -658,6 +715,18 @@ The child event protocol limits each JSON line to 256 KiB. Captured output uses 
 Truncated text includes a `truncated by pi-subagents` marker and details expose `truncated: true`. Inspection and consultation model-facing content also stops at 2,000 lines, whichever limit is reached first. `PI_SUBAGENT_MAX_DEPTH` controls nested delegation depth and defaults to 1; child processes receive `PI_SUBAGENT_DEPTH` automatically.
 
 ## 📡 Runtime status
+
+Run the offline transport benchmark from the repository root when comparing startup overhead:
+
+```bash
+just benchmark-subagents
+```
+
+It reports serial median and median absolute deviation for deterministic fake fresh-subprocess and retained-RPC turns plus isolated real Pi RPC readiness, retained commands, in-process session creation, and retained in-process state access without making a provider request.
+Queue time starts when the registry accepts work, transport startup starts when execution begins, RPC readiness comes from `get_state`, RPC acceptance comes from the correlated `prompt` response, first activity comes from a bounded lifecycle event, settlement comes from `agent_settled`, and delivery is recorded after the parent accepts the completion message.
+Subprocess and in-process timing fields use the nearest public lifecycle boundary and may be coarser than RPC.
+Timing and progress are current-session diagnostics and are not persisted.
+The benchmark measures transport overhead rather than model latency or output quality.
 
 While the `subagent` tool is running, `pi-subagents` publishes compact activity status with `ctx.ui.setStatus("subagents", "...")`. Any statusline extension that reads Pi's generic extension status API can display it; no package-to-package dependency is required.
 
@@ -693,6 +762,12 @@ packages/pi-subagents/
 │   ├── cwd-policy.ts             # Canonical target and saved-trust resolution
 │   ├── safe-text.ts              # Shared byte/line/path sanitization
 │   ├── stateful.ts               # Detached lifecycle registration and dispatch
+│   ├── rpc-transport.ts          # Persistent strict-JSONL Pi RPC child transport
+│   ├── auto-transport.ts         # Deterministic preflight transport routing
+│   ├── transport-types.ts        # Bounded pi-subagents:v1 progress and telemetry contract
+│   ├── completion-delivery.ts    # Completion batching and optional idle-root wake
+│   ├── execution-profiles.ts     # Provider-neutral thinking profile patches
+│   ├── execution-ui.ts           # Profile and per-agent execution settings screens
 │   ├── stateful-guidance.ts      # Detached model-facing workflow guidance
 │   ├── stateful-lifecycle.ts     # Runtime disposal and spawn ownership guards
 │   ├── stateful-limit-ui.ts      # Detached capacity settings and recovery previews

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -21,7 +21,7 @@ Use it to split independent research, planning, implementation, and review work 
 - Loads custom user agents from `~/.pi/agent/agents/*.md`.
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
 - Provides a current-session-first `/subagents` manager, direct `settings|status|help` routes, and compatibility aliases for agent tools and retained agents.
-- Supports trust-aware per-task `cwd` policies, hard `timeoutMs`, task-selected `thinkingLevel`, abort propagation, bounded progress and timing telemetry, and explicit Fast, Balanced, or Deep thinking profiles.
+- Supports trust-aware per-task `cwd` policies, task-selected `timeoutMs` work deadlines and `thinkingLevel`, abort-then-summary timeout recovery, bounded progress and timing telemetry, and explicit Fast, Balanced, or Deep thinking profiles.
 - Renders all seven tools with Pi-native compact/expanded transcript rows; long-running blocking and consultation calls show bounded live activity.
 - Bounds JSON lines, captured messages, stderr, final output, chain substitution, and fan-in context.
 - Enforces a recursion-depth guard and deterministic process-group termination.
@@ -109,12 +109,12 @@ Execution modes:
 Common controls:
 
 - `cwd` — choose a launch directory subject to the user-owned trust-aware target policy described below.
-- `timeoutMs` — set a hard subprocess timeout.
+- `timeoutMs` — choose the work deadline for the task difficulty; expiry aborts active work and starts one separately hard-bounded summary attempt.
 - `thinkingLevel` — request `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` thinking for the spawned Pi process or retained child.
 - `idempotencyKey` — make an exact `subagent_spawn` retry return the existing retained `agentId`; reuse with different parameters fails before confirmation, worktree creation, or child launch.
 - `resultFormat` — keep bounded text by default or request the opt-in `structured-v1` summary/evidence/changes/verification/risks contract with text fallback.
 
-For `subagent_spawn`, the root agent selects the lowest thinking level sufficient for the delegated task. This is a tool-argument decision made from the task already in context; `pi-subagents` does not run a string heuristic or an extra classifier model call.
+For `subagent_spawn`, the root agent selects the lowest thinking level and shortest realistic work deadline sufficient for the delegated task. These are tool-argument decisions made from the task already in context; `pi-subagents` does not run a string heuristic or an extra classifier model call.
 
 ## 🔐 Working-directory trust policy
 
@@ -266,7 +266,7 @@ Extensions remain disabled for all three values. Pi core owns system-prompt sour
 
 Both settings are user-owned in `~/.pi/agent/pi-subagents.json`; projects cannot override them. `cwdPolicy.consultation: "current-workspace"` rejects every canonical external target before agent discovery or launch even when that target is saved-trusted. This is not a path sandbox: read-only tools can still read an explicitly requested accessible absolute path.
 
-Result details report the canonical safe cwd, current/external boundary, bounded target-trust decision/source/warning, requested and effective tools/resources, downgrade reason, agent/model/thinking/timeout metadata, and the facts that extensions, session persistence, and retained-agent state are disabled. They never dump prompt contents or the full trust store. Nested model usage is returned through Pi's usage field, so footer, `/session`, and RPC totals include consultation cost. Validation, disallowed targets, and launch failures throw. Failures after model launch preserve bounded partial evidence and usage while the finalized Pi tool result is marked as an error. Abort, timeout, session replacement, and shutdown use the existing process-tree termination and temporary-file cleanup path.
+Result details report the canonical safe cwd, current/external boundary, bounded target-trust decision/source/warning, requested and effective tools/resources, downgrade reason, agent/model/thinking/timeout metadata, and the facts that extensions, session persistence, and retained-agent state are disabled. They never dump prompt contents or the full trust store. Nested model usage is returned through Pi's usage field, so footer, `/session`, and RPC totals include consultation cost. Validation, disallowed targets, and launch failures throw. Failures after model launch preserve bounded partial evidence and usage while the finalized Pi tool result is marked as an error. Explicit abort, session replacement, and shutdown use the existing process-tree termination and temporary-file cleanup path; a work timeout additionally makes one separately bounded, tool-less summary attempt after abort.
 
 ## 🚀 Blocking batch examples
 
@@ -427,8 +427,8 @@ This avoids lifecycle-driven tool-schema churn and preserves a stable provider p
 
 | Tool | Purpose |
 | --- | --- |
-| `subagent_spawn` | Start detached work with optional task-selected thinking, exact-retry `idempotencyKey`, and `text` or `structured-v1` result format; return an opaque `agentId` immediately and deliver completion asynchronously. |
-| `subagent_send` | Send follow-up work and trigger a new turn on a reusable agent; shared-workspace write conflicts are guarded unless explicitly overridden. |
+| `subagent_spawn` | Start detached work with optional task-selected thinking and retained timeout, exact-retry `idempotencyKey`, and `text` or `structured-v1` result format; return an opaque `agentId` immediately and deliver completion asynchronously. |
+| `subagent_send` | Send follow-up work with an optional one-turn timeout override and trigger a new turn on a reusable agent; shared-workspace write conflicts are guarded unless explicitly overridden. |
 | `subagent_manage` | Use `action: "list"` to inspect agents, `"interrupt"` to retain an agent after aborting active work, or `"close"` to release it; interrupt/close accept optional `subtree`. |
 | `subagent_mailbox` | Use `action: "send"` for queue-only messages that do not start a turn, or `"read"` to read and optionally acknowledge unread messages. |
 
@@ -481,7 +481,7 @@ A spawn can request a thinking level explicitly:
 }
 ```
 
-The requested level is stored with the stateful agent and remains in effect for all follow-ups and after persisted restore. `subagent_send` does not provide a per-turn thinking override; create a new agent when a later task needs a different level.
+The requested level and spawn `timeoutMs` are stored with the stateful agent and remain in effect for all follow-ups and after persisted restore. `subagent_send.timeoutMs` can override only that follow-up's work deadline. `subagent_send` does not provide a per-turn thinking override; create a new agent when a later task needs a different level.
 
 An exact retry can use a bounded session-owned idempotency key:
 
@@ -556,7 +556,7 @@ The intentional compatibility change is that an external target without saved tr
 An aggregator whose `agent` or `task` is empty or whitespace-only is treated as absent, so successful
 parallel outputs remain available instead of being replaced by a malformed fan-in failure.
 
-Timeout precedence remains: task/step/aggregator → call → agent setting → `PI_SUBAGENT_TIMEOUT_MS` → 600000 ms. Blocking thinking precedence remains: task/step/aggregator → call → agent setting → child default. Stateful spawn thinking precedence is: `subagent_spawn.thinkingLevel` → agent setting → transport fallback. Project-agent resolution and confirmation behavior is unchanged after target preflight. Blocking and retained result/inspection details add bounded target boundary and effective trust metadata.
+Blocking timeout precedence remains: task/step/aggregator → call → agent setting → `PI_SUBAGENT_TIMEOUT_MS` → 600000 ms. Stateful timeout precedence is: `subagent_send.timeoutMs` for one follow-up → retained `subagent_spawn.timeoutMs` → agent setting → `PI_SUBAGENT_TIMEOUT_MS` → 600000 ms. Blocking thinking precedence remains: task/step/aggregator → call → agent setting → child default. Stateful spawn thinking precedence is: `subagent_spawn.thinkingLevel` → agent setting → transport fallback. Project-agent resolution and confirmation behavior is unchanged after target preflight. Blocking and retained result/inspection details add bounded target boundary and effective trust metadata.
 
 ## 🤖 Built-in agents
 
@@ -672,14 +672,16 @@ argument skips that confirmation dialog, but it does not bypass the project trus
 
 ## ⏱️ Runtime limits and thinking levels
 
-Each subprocess has a hard timeout to avoid runaway workers.
+Every turn has a main-agent-selectable work deadline plus an extension-owned hard-bounded finalization deadline.
 
 - Set `blocking.maxParallelTasks` in `~/.pi/agent/pi-subagents.json`, or use `/subagents` → **Advanced settings** → **Maximum parallel workers**, to allow 1 through 64 worker tasks in one blocking parallel call.
 - The worker-count limit defaults to 8 and does not change the fixed four-at-a-time execution concurrency.
-- Set `timeoutMs` on the top-level call to apply a default for all jobs.
+- Set `timeoutMs` on the top-level blocking call to apply a work deadline to all jobs.
 - Set `timeoutMs` on a task, chain step, or aggregator to override it locally.
+- Set `subagent_spawn.timeoutMs` as the retained work deadline, or `subagent_send.timeoutMs` to override one follow-up turn.
+- Choose the shortest realistic deadline for the task difficulty; split an oversized task instead of extending its deadline merely to compensate for broad scope.
 - Valid timeout values range from 1 to 2,147,483,647 milliseconds, matching the runtime timer limit.
-- If omitted, the default is `PI_SUBAGENT_TIMEOUT_MS`, or `600000` milliseconds (10 minutes) when unset.
+- If omitted, the default is the retained or agent setting, then `PI_SUBAGENT_TIMEOUT_MS`, or `600000` milliseconds (10 minutes) when unset.
 
 Set `thinkingLevel` to request one of Pi's supported levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Blocking subprocess calls pass the resolved value through `--thinking <level>`.
 
@@ -704,7 +706,7 @@ An explicit spawn value is retained for the agent lifecycle and wins over every 
 
 Omit `thinkingLevel` to preserve existing behavior. Reported stateful details show the requested level, not a guarantee of the provider's effective value. Pi still owns model capability clamping; `pi-subagents` does not duplicate capability detection.
 
-On timeout, the extension sends process-group `SIGTERM`, escalates to `SIGKILL` after a five-second grace period if the process has not actually closed, and returns partial bounded messages or stderr collected so far. Parent abort uses the same cleanup path and preserves a structured result.
+When the work deadline expires, the extension aborts the active run first. After authoritative settlement it makes one concise summary attempt over already gathered evidence, without replaying the timed-out task. The summary attempt has its own extension-owned model-work deadline of at most 45 seconds, followed only by bounded abort and process-cleanup grace. Fresh subprocess summaries run with no tools or project resources. Retained RPC and in-process summaries reuse their child context and are explicitly instructed not to call tools; the current child APIs do not support replacing an existing session's tool set for one turn, so their separate deadline and abort path remain the enforcement boundary. If abort does not settle or finalization fails, the extension terminates or discards the child and returns bounded partial evidence. Explicit parent or user abort stops immediately and never starts timeout finalization.
 
 The child event protocol limits each JSON line to 256 KiB. Captured output uses these defaults:
 
@@ -764,6 +766,8 @@ packages/pi-subagents/
 │   ├── safe-text.ts              # Shared byte/line/path sanitization
 │   ├── stateful.ts               # Detached lifecycle registration and dispatch
 │   ├── rpc-transport.ts          # Persistent strict-JSONL Pi RPC child transport
+│   ├── rpc-timeout-finalization.ts # RPC abort-settle-summary recovery
+│   ├── rpc-transport-metadata.ts # RPC result policy and bounded metadata helpers
 │   ├── auto-transport.ts         # Deterministic preflight transport routing
 │   ├── transport-types.ts        # Bounded pi-subagents:v1 progress and telemetry contract
 │   ├── completion-delivery.ts    # Completion batching and optional idle-root wake
@@ -771,6 +775,7 @@ packages/pi-subagents/
 │   ├── execution-ui.ts           # Profile and per-agent execution settings screens
 │   ├── stateful-guidance.ts      # Detached model-facing workflow guidance
 │   ├── stateful-lifecycle.ts     # Runtime disposal and spawn ownership guards
+│   ├── timeout-finalization.ts   # Abort-time bounded summary prompts and deadlines
 │   ├── stateful-limit-ui.ts      # Detached capacity settings and recovery previews
 │   ├── stateful-limits.ts        # Shared detached defaults, labels, and validation
 │   ├── stateful-safety.ts        # Project-agent and shared-write safety checks

--- a/packages/pi-subagents/src/agents.ts
+++ b/packages/pi-subagents/src/agents.ts
@@ -37,7 +37,7 @@ export interface SubagentAgentConfig {
 	timeoutMs?: number | null;
 }
 
-export type SubagentTransportKind = "subprocess" | "in-process";
+export type SubagentTransportKind = "subprocess" | "in-process" | "rpc" | "auto";
 
 export type CompletionDelivery = "next-turn" | "auto-resume";
 

--- a/packages/pi-subagents/src/auto-transport.ts
+++ b/packages/pi-subagents/src/auto-transport.ts
@@ -1,0 +1,113 @@
+import { discoverAgents, type SubagentSettings } from "./agents.js";
+import type { ManagedAgent, TurnOutcome } from "./registry.js";
+import { isWriteCapable } from "./stateful-safety.js";
+import type { SubagentTransport } from "./transport.js";
+import type {
+	EffectiveSubagentTransportKind,
+	TransportProgressCallback,
+} from "./transport-types.js";
+
+const BUILT_IN_TOOL_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+
+export interface AutoTransportOptions {
+	subprocess: SubagentTransport;
+	inProcess: SubagentTransport;
+	rpc: SubagentTransport;
+	getSettings?: () => SubagentSettings | undefined;
+}
+
+export interface AutoTransportSelection {
+	kind: EffectiveSubagentTransportKind;
+	reason: string;
+}
+
+export class AutoTransport implements SubagentTransport {
+	readonly kind = "auto" as const;
+	private readonly selections = new Map<string, AutoTransportSelection>();
+
+	constructor(private readonly options: AutoTransportOptions) {}
+
+	async runTurn(
+		agent: ManagedAgent,
+		task: string,
+		signal: AbortSignal,
+		onProgress?: TransportProgressCallback,
+	): Promise<TurnOutcome> {
+		const selection = this.selections.get(agent.id) ?? this.select(agent);
+		this.selections.set(agent.id, selection);
+		const transport = this.transport(selection.kind);
+		const outcome = await transport.runTurn(agent, task, signal, (progress) =>
+			onProgress?.({ ...progress, selectionReason: selection.reason }),
+		);
+		return {
+			...outcome,
+			telemetry: outcome.telemetry
+				? { ...outcome.telemetry, selectionReason: selection.reason }
+				: outcome.telemetry,
+		};
+	}
+
+	async release(agent: ManagedAgent): Promise<void> {
+		const selection = this.selections.get(agent.id);
+		this.selections.delete(agent.id);
+		if (selection) await this.transport(selection.kind).release?.(agent);
+	}
+
+	async shutdown(): Promise<void> {
+		this.selections.clear();
+		const transports = [this.options.subprocess, this.options.inProcess, this.options.rpc];
+		const results = await Promise.allSettled(transports.map((transport) => transport.shutdown?.()));
+		const failures = results.flatMap((result) =>
+			result.status === "rejected" ? [result.reason] : [],
+		);
+		if (failures.length > 0) {
+			throw new AggregateError(
+				failures,
+				`Failed to shut down ${failures.length} auto transport(s)`,
+			);
+		}
+	}
+
+	selectionFor(agentId: string): AutoTransportSelection | undefined {
+		const selection = this.selections.get(agentId);
+		return selection ? { ...selection } : undefined;
+	}
+
+	private select(agent: ManagedAgent): AutoTransportSelection {
+		const settings = this.options.getSettings?.();
+		const config = discoverAgents(agent.cwd, agent.agentScope ?? "user", settings).agents.find(
+			(candidate) => candidate.name === agent.agent,
+		);
+		if (!config) {
+			throw new Error(`Automatic transport cannot resolve subagent ${agent.agent}`);
+		}
+		const unsupported = (config.tools ?? []).filter((tool) => !BUILT_IN_TOOL_NAMES.has(tool));
+		if (unsupported.length > 0) {
+			return {
+				kind: "subprocess",
+				reason: `extension/custom tools require subprocess: ${unsupported.join(", ")}`,
+			};
+		}
+		if (isWriteCapable(config.tools)) {
+			return {
+				kind: "rpc",
+				reason: "write-capable built-in tools use a persistent isolated process",
+			};
+		}
+		return {
+			kind: "in-process",
+			reason: "read-only built-in tools use the lowest-overhead public SDK session",
+		};
+	}
+
+	private transport(kind: EffectiveSubagentTransportKind): SubagentTransport {
+		switch (kind) {
+			case "subprocess":
+				return this.options.subprocess;
+			case "in-process":
+				return this.options.inProcess;
+			case "rpc":
+				return this.options.rpc;
+		}
+	}
+}

--- a/packages/pi-subagents/src/completion-delivery.ts
+++ b/packages/pi-subagents/src/completion-delivery.ts
@@ -1,0 +1,251 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { CompletionDelivery } from "./agents.js";
+import { redactPrivateText } from "./context.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import type { AgentTurnCompletion, ManagedAgent } from "./registry.js";
+import { safeTerminalText } from "./safe-text.js";
+import { PI_SUBAGENTS_RPC_PROTOCOL } from "./transport-types.js";
+
+const MAX_TOOL_MESSAGE_BYTES = 2 * 1024;
+const MAX_COMPLETION_ERROR_BYTES = 512;
+const MAX_COMPLETIONS_PER_MESSAGE = 16;
+const COMPLETION_BATCH_DELAY_MS = 10;
+
+interface CompletionMetadata {
+	protocol: typeof PI_SUBAGENTS_RPC_PROTOCOL;
+	agentId: string;
+	agent: string;
+	state: string;
+	transport?: string;
+	structuredResult?: ManagedAgent["structuredResult"];
+}
+
+interface CompletionMessage {
+	customType: "pi-subagent-completion";
+	content: string;
+	display: true;
+	details:
+		| CompletionMetadata
+		| {
+				completionCount: number;
+				completions: CompletionMetadata[];
+		  };
+}
+
+type CompletionContext = Pick<ExtensionContext, "hasPendingMessages" | "isIdle">;
+type CompletionPi = Pick<ExtensionAPI, "sendMessage">;
+
+export interface CompletionDeliveryBrokerOptions {
+	onDeliveryError?: (error: unknown) => void;
+	onDelivered?: (completions: readonly AgentTurnCompletion[], deliveredAt: number) => void;
+	now?: () => number;
+}
+
+/** Owns bounded completion batching and at most one idle-root wake for one parent session. */
+export class CompletionDeliveryBroker {
+	private pending: AgentTurnCompletion[] = [];
+	private flushTimer?: NodeJS.Timeout;
+	private wakeInFlight = false;
+	private closed = false;
+
+	constructor(
+		private readonly pi: CompletionPi,
+		private readonly ctx: CompletionContext,
+		private delivery: CompletionDelivery,
+		private readonly options: CompletionDeliveryBrokerOptions = {},
+	) {}
+
+	enqueue(completion: AgentTurnCompletion): void {
+		if (this.closed) return;
+		this.pending.push(completion);
+		this.scheduleFlush();
+	}
+
+	setDelivery(value: CompletionDelivery): void {
+		this.delivery = value;
+		this.scheduleFlush();
+	}
+
+	onParentTurnStart(): void {
+		this.wakeInFlight = false;
+		this.scheduleFlush();
+	}
+
+	onParentSettled(): void {
+		this.wakeInFlight = false;
+		this.scheduleFlush();
+	}
+
+	flush(): void {
+		if (this.closed || this.pending.length === 0) return;
+		if (this.flushTimer) clearTimeout(this.flushTimer);
+		this.flushTimer = undefined;
+		if (this.delivery === "auto-resume" && !this.isRootIdle()) return;
+
+		const completions = this.pending.splice(0);
+		const batches = chunkCompletions(completions);
+		let canWake = this.shouldWakeRoot();
+		for (let index = 0; index < batches.length; index++) {
+			const triggerTurn = canWake && index === batches.length - 1;
+			const message = buildCompletionMessage(batches[index]);
+			if (triggerTurn) this.wakeInFlight = true;
+			try {
+				this.pi.sendMessage(message, { deliverAs: "steer", triggerTurn });
+				this.notifyDelivered(batches[index]);
+			} catch (primaryError) {
+				if (triggerTurn) this.wakeInFlight = false;
+				canWake = false;
+				try {
+					this.pi.sendMessage(message, { deliverAs: "nextTurn", triggerTurn: false });
+					this.notifyDelivered(batches[index]);
+				} catch (fallbackError) {
+					this.pending = [...batches.slice(index).flat(), ...this.pending];
+					try {
+						this.options.onDeliveryError?.(
+							new AggregateError(
+								[primaryError, fallbackError],
+								"Detached subagent completion delivery failed",
+							),
+						);
+					} catch {
+						// Delivery retention must survive a failing observer.
+					}
+					return;
+				}
+			}
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+		if (this.flushTimer) clearTimeout(this.flushTimer);
+		this.flushTimer = undefined;
+		this.pending = [];
+	}
+
+	private scheduleFlush(): void {
+		if (this.closed || this.pending.length === 0 || this.flushTimer) return;
+		this.flushTimer = setTimeout(() => {
+			this.flushTimer = undefined;
+			this.flush();
+		}, COMPLETION_BATCH_DELAY_MS);
+	}
+
+	private notifyDelivered(completions: readonly AgentTurnCompletion[]): void {
+		try {
+			this.options.onDelivered?.(completions, (this.options.now ?? Date.now)());
+		} catch {
+			// Delivery already succeeded, so observer failures cannot requeue it.
+		}
+	}
+
+	private isRootIdle(): boolean {
+		try {
+			return this.ctx.isIdle();
+		} catch {
+			return false;
+		}
+	}
+
+	private shouldWakeRoot(): boolean {
+		if (this.delivery !== "auto-resume" || this.wakeInFlight) return false;
+		try {
+			return !this.ctx.hasPendingMessages();
+		} catch {
+			return false;
+		}
+	}
+}
+
+function chunkCompletions(completions: AgentTurnCompletion[]): AgentTurnCompletion[][] {
+	const batches: AgentTurnCompletion[][] = [];
+	for (let index = 0; index < completions.length; index += MAX_COMPLETIONS_PER_MESSAGE) {
+		batches.push(completions.slice(index, index + MAX_COMPLETIONS_PER_MESSAGE));
+	}
+	return batches;
+}
+
+function buildCompletionMessage(completions: AgentTurnCompletion[]): CompletionMessage {
+	if (completions.length === 1) {
+		const completion = completions[0];
+		return {
+			customType: "pi-subagent-completion",
+			content: buildDetachedCompletionMessage(completion),
+			display: true,
+			details: completionMetadata(completion),
+		};
+	}
+	const content = truncateUtf8(
+		[
+			"Message Type: SUBAGENT_COMPLETION_BATCH",
+			`Protocol: ${PI_SUBAGENTS_RPC_PROTOCOL}`,
+			`Completion Count: ${completions.length}`,
+			...completions.flatMap((completion, index) => [
+				"",
+				`--- Completion ${index + 1} of ${completions.length} ---`,
+				buildDetachedCompletionMessage(completion),
+			]),
+		].join("\n"),
+		DEFAULT_MAX_CONTEXT_BYTES,
+	).text;
+	return {
+		customType: "pi-subagent-completion",
+		content,
+		display: true,
+		details: {
+			completionCount: completions.length,
+			completions: completions.map(completionMetadata),
+		},
+	};
+}
+
+function completionMetadata(completion: AgentTurnCompletion): CompletionMetadata {
+	return {
+		protocol: PI_SUBAGENTS_RPC_PROTOCOL,
+		agentId: completion.agent.id,
+		agent: completion.agent.agent,
+		state: completion.agent.state,
+		...(completion.agent.telemetry?.transport
+			? { transport: completion.agent.telemetry.transport }
+			: {}),
+		...(completion.agent.structuredResult
+			? { structuredResult: completion.agent.structuredResult }
+			: {}),
+	};
+}
+
+export function buildDetachedCompletionMessage(completion: AgentTurnCompletion): string {
+	const task = sanitizeCompletionLine(completion.task, 256) || "(unknown task)";
+	const agentName = sanitizeCompletionLine(completion.agent.agent, 128) || "(unknown agent)";
+	const output = safeTerminalText(redactPrivateText(completion.output));
+	const error = completion.error
+		? truncateUtf8(
+				safeTerminalText(redactPrivateText(completion.error)),
+				MAX_COMPLETION_ERROR_BYTES,
+			).text
+		: "";
+	return truncateUtf8(
+		[
+			"Message Type: SUBAGENT_COMPLETION",
+			`Protocol: ${PI_SUBAGENTS_RPC_PROTOCOL}`,
+			`Agent ID: ${completion.agent.id}`,
+			`Agent: ${agentName}`,
+			`Task: ${task}`,
+			`State: ${completion.agent.state}`,
+			...(error.trim() ? ["Error:", error] : []),
+			"Payload:",
+			output.trim() ? output : "(no output)",
+		].join("\n"),
+		MAX_TOOL_MESSAGE_BYTES,
+	).text;
+}
+
+function sanitizeCompletionLine(value: string, maxBytes: number): string {
+	return (
+		truncateUtf8(redactPrivateText(value), maxBytes)
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: Strip untrusted terminal controls.
+			.text.replace(/[\u0000-\u001f\u007f]+/g, " ")
+			.replace(/\s+/g, " ")
+			.trim()
+	);
+}

--- a/packages/pi-subagents/src/config-status.ts
+++ b/packages/pi-subagents/src/config-status.ts
@@ -1,0 +1,221 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type {
+	CompletionDelivery,
+	ConsultationCwdPolicy,
+	ConsultResourcePolicy,
+	DelegationCwdPolicy,
+} from "./agents.js";
+import type { SubagentSettingsRuntime } from "./config-ui.js";
+import { safeTerminalLine as safeTerminalText } from "./safe-text.js";
+import {
+	type DelegationWorkflow,
+	inspectBlockingParallelLimitSettings,
+	inspectCompletionDeliverySettings,
+	inspectConsultResourceSettings,
+	inspectCwdPolicySettings,
+	inspectDelegationWorkflowSettings,
+	inspectStatefulLimitSettings,
+	inspectStatefulTransportSettings,
+} from "./settings.js";
+import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
+import {
+	formatConfiguredDetachedLimitDivergence,
+	formatConfiguredDetachedLimits,
+	formatDetachedLimitSummary,
+} from "./stateful-limit-ui.js";
+import { STATEFUL_LIMIT_DEFINITIONS } from "./stateful-limits.js";
+import { workflowLabel } from "./workflow-ui.js";
+
+export function showSubagentStatus(
+	ctx: ExtensionCommandContext,
+	runtime: SubagentSettingsRuntime,
+): void {
+	if (ctx.mode !== "tui" && !ctx.hasUI) return;
+	const snapshot = inspectCompletionDeliverySettings();
+	ctx.ui.notify(
+		formatStatus(runtime.getRuntimeStatus(), snapshot, runtime),
+		snapshot.error ? "warning" : "info",
+	);
+}
+
+export function showSubagentHelp(
+	ctx: ExtensionCommandContext,
+	runtime: SubagentSettingsRuntime,
+): void {
+	if (ctx.mode !== "tui" && !ctx.hasUI) return;
+	ctx.ui.notify(helpLines(runtime).join("\n"), "info");
+}
+
+export function statusLines(runtime: SubagentSettingsRuntime): string[] {
+	const snapshot = inspectCompletionDeliverySettings();
+	return formatStatus(runtime.getRuntimeStatus(), snapshot, runtime).split("\n");
+}
+
+export function helpLines(runtime: SubagentSettingsRuntime): string[] {
+	const snapshot = inspectCompletionDeliverySettings();
+	const cwdPolicy = inspectCwdPolicySettings();
+	const parallelLimit = inspectBlockingParallelLimitSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
+	const transport = inspectStatefulTransportSettings();
+	return [
+		"/subagents — choose delegation workflow, manage current agents, and configure agent tools",
+		"/subagents settings — configure target locations, trusted resources, and async completion",
+		"/subagents status — show current-session and user-setting values",
+		"/subagents help — show this help",
+		"Target policies control startup directories and resources, not filesystem access or sandboxing.",
+		"Manage saved folder trust with Pi /trust and restart Pi after changing it.",
+		`Runtime consultation target: ${consultationCwdLabel(runtime.getConsultationCwdPolicy())}`,
+		`Configured consultation target: ${consultationCwdLabel(cwdPolicy.consultation.value)} (${cwdPolicy.consultation.source})`,
+		`Runtime delegation target: ${delegationCwdLabel(runtime.getDelegationCwdPolicy())}`,
+		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} (${cwdPolicy.delegation.source})`,
+		`Maximum parallel workers: ${runtime.getMaxParallelTasks()} per blocking call`,
+		`Configured parallel limit: ${parallelLimit.value} (${parallelLimit.source})`,
+		`Detached limits: ${formatDetachedLimitSummary(runtime.getRuntimeStatus())}`,
+		`Configured transport: ${transport.value} (${transport.source})`,
+		...(detachedLimits.values
+			? [`Configured detached limits: ${formatConfiguredDetachedLimits(detachedLimits.values)}`]
+			: ["Configured detached limits: unavailable; repair user settings"]),
+		"Detached limits and transport apply after /reload; clear retained agents first if their work must not be interrupted.",
+		`User settings: ${safeTerminalText(snapshot.path)}`,
+	];
+}
+
+export function formatManagerSummary(
+	runtime: SubagentSettingsRuntime,
+	status: StatefulSubagentRuntimeStatus,
+	configured: ReturnType<typeof inspectDelegationWorkflowSettings>,
+): string {
+	const current = currentWorkflow(runtime, status);
+	const cwdPolicy = inspectCwdPolicySettings();
+	const consult = inspectConsultResourceSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
+	const transport = inspectStatefulTransportSettings();
+	const detachedDivergence = detachedLimits.values
+		? formatConfiguredDetachedLimitDivergence(status, detachedLimits.values)
+		: undefined;
+	return [
+		`Delegation: ${workflowLabel(current)}`,
+		`Completion: ${completionLabel(status.completionDelivery)}`,
+		`Consult target: ${consultationCwdLabel(runtime.getConsultationCwdPolicy())}`,
+		`Delegation target: ${delegationCwdLabel(runtime.getDelegationCwdPolicy())}`,
+		`Consult resources: ${consultResourceLabel(runtime.getConsultResourcePolicy())}`,
+		`Parallel workers: max ${runtime.getMaxParallelTasks()} per blocking call`,
+		`Detached limits: ${formatDetachedLimitSummary(status)}`,
+		`Transport: ${status.transport}`,
+		`Configured transport: ${transport.value} · ${transport.source}`,
+		`Configured consult target: ${consultationCwdLabel(cwdPolicy.consultation.value)} · ${cwdPolicy.consultation.source}`,
+		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} · ${cwdPolicy.delegation.source}`,
+		`Configured consult resources: ${consultResourceLabel(consult.value)} · ${consult.source}`,
+		`Settings: ${safeTerminalText(cwdPolicy.path)}`,
+		`Agents: ${status.activeAgents} active · ${status.retainedAgents} retained`,
+		...(detachedDivergence ? [detachedDivergence] : []),
+		...(configured.value !== current
+			? [`Configured after reload: ${workflowLabel(configured.value)}`]
+			: []),
+		...(configured.error || detachedLimits.error
+			? ["Settings need repair; open Advanced settings for details."]
+			: []),
+	].join("\n");
+}
+
+function formatStatus(
+	status: StatefulSubagentRuntimeStatus,
+	snapshot: ReturnType<typeof inspectCompletionDeliverySettings>,
+	runtime?: SubagentSettingsRuntime,
+): string {
+	const configuredWorkflow = inspectDelegationWorkflowSettings();
+	const consult = inspectConsultResourceSettings();
+	const cwdPolicy = inspectCwdPolicySettings();
+	const parallelLimit = inspectBlockingParallelLimitSettings();
+	const detachedLimits = inspectStatefulLimitSettings();
+	const transport = inspectStatefulTransportSettings();
+	const current = runtime ? currentWorkflow(runtime, status) : configuredWorkflow.value;
+	return [
+		"Current session",
+		`  Delegation: ${workflowLabel(current)}`,
+		`  Async runtime: ${status.initialized ? "initialized" : status.enabled ? "not initialized" : "disabled"}`,
+		`  Transport: ${status.transport}`,
+		`  Configured transport: ${transport.value} (${transport.source})`,
+		`  Completion: ${completionLabel(status.completionDelivery)}`,
+		`  Consultation target: ${consultationCwdLabel(runtime?.getConsultationCwdPolicy() ?? cwdPolicy.consultation.value)}`,
+		`  Delegation target: ${delegationCwdLabel(runtime?.getDelegationCwdPolicy() ?? cwdPolicy.delegation.value)}`,
+		`  Consultation resources: ${consultResourceLabel(runtime?.getConsultResourcePolicy() ?? consult.value)}`,
+		`  Maximum parallel workers: ${runtime?.getMaxParallelTasks() ?? parallelLimit.value} per blocking call`,
+		`  Detached limits: ${formatDetachedLimitSummary(status)}`,
+		`  Agents: ${status.activeAgents} active, ${status.retainedAgents} retained`,
+		"User settings",
+		`  Delegation source: ${configuredWorkflow.source}`,
+		`  Configured delegation: ${workflowLabel(configuredWorkflow.value)}`,
+		`  Completion source: ${snapshot.source}`,
+		`  Configured completion: ${completionLabel(snapshot.value)}`,
+		`  Configured parallel limit: ${parallelLimit.value}`,
+		`  Parallel limit source: ${parallelLimit.source}`,
+		...(detachedLimits.values
+			? STATEFUL_LIMIT_DEFINITIONS.map((definition) => {
+					const configured = detachedLimits.values?.[definition.field];
+					return `  Configured ${definition.label.toLowerCase()}: ${configured?.value} (${configured?.source})`;
+				})
+			: ["  Configured detached limits: unavailable"]),
+		`  Configured consultation target: ${consultationCwdLabel(cwdPolicy.consultation.value)}`,
+		`  Consultation target source: ${cwdPolicy.consultation.source}`,
+		`  Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)}`,
+		`  Delegation target source: ${cwdPolicy.delegation.source}`,
+		`  Configured consultation resources: ${consultResourceLabel(consult.value)}`,
+		`  Consultation resource source: ${consult.source}`,
+		`  Path: ${safeTerminalText(snapshot.path)}`,
+		configuredWorkflow.error ||
+		snapshot.error ||
+		cwdPolicy.error ||
+		parallelLimit.error ||
+		detachedLimits.error ||
+		transport.error
+			? `  Warning: ${safeTerminalText(configuredWorkflow.error ?? snapshot.error ?? cwdPolicy.error ?? parallelLimit.error ?? detachedLimits.error ?? transport.error ?? "invalid settings")}`
+			: "  Warning: none",
+		configuredWorkflow.value !== current
+			? "Configured delegation differs from this session. Run /reload to apply it."
+			: "Manual file changes require /reload.",
+	].join("\n");
+}
+
+export function currentWorkflow(
+	runtime: SubagentSettingsRuntime,
+	status: StatefulSubagentRuntimeStatus,
+): DelegationWorkflow {
+	const blocking = runtime.getBlockingEnabled();
+	if (blocking && status.enabled) return "all";
+	if (status.enabled) return "async-only";
+	if (blocking) return "blocking-only";
+	return "disabled";
+}
+
+export function completionLabel(value: CompletionDelivery): string {
+	return value === "auto-resume" ? "Resume automatically when finished" : "Wait until my next turn";
+}
+
+export function consultationCwdLabel(value: ConsultationCwdPolicy): string {
+	return value === "current-workspace"
+		? "Current workspace only"
+		: "Anywhere · untrusted targets inherit nothing";
+}
+
+export function delegationCwdLabel(value: DelegationCwdPolicy): string {
+	switch (value) {
+		case "trusted-targets":
+			return "Current or saved-trusted folders";
+		case "current-workspace":
+			return "Current workspace only";
+		case "anywhere":
+			return "Anywhere · normal Pi permissions";
+	}
+}
+
+export function consultResourceLabel(value: ConsultResourcePolicy): string {
+	switch (value) {
+		case "project-context":
+			return "Project context only";
+		case "none":
+			return "No inherited resources";
+		case "all":
+			return "All trusted resources";
+	}
+}

--- a/packages/pi-subagents/src/config-ui.ts
+++ b/packages/pi-subagents/src/config-ui.ts
@@ -7,6 +7,32 @@ import {
 	discoverAgents,
 } from "./agents.js";
 import {
+	completionLabel,
+	consultationCwdLabel,
+	consultResourceLabel,
+	currentWorkflow,
+	delegationCwdLabel,
+	formatManagerSummary,
+	helpLines,
+	showSubagentHelp,
+	showSubagentStatus,
+	statusLines,
+} from "./config-status.js";
+import {
+	applyAgentModel,
+	applyAgentThinking,
+	applyAgentTimeout,
+	applyExecutionProfileFromUi,
+	executionAgentPickerScreen,
+	executionAgentScreen,
+	executionModelInputScreen,
+	executionModelScreen,
+	executionProfileScreen,
+	executionThinkingScreen,
+	executionTimeoutInputScreen,
+	resetAgentExecution,
+} from "./execution-ui.js";
+import {
 	applyBlockingParallelLimitSetting,
 	blockingParallelLimitScreen,
 } from "./parallel-limit-ui.js";
@@ -20,7 +46,6 @@ import {
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
 	inspectDelegationWorkflowSettings,
-	inspectStatefulLimitSettings,
 	readSubagentSettings,
 	sameToolSet,
 	uniqueToolNames,
@@ -33,18 +58,17 @@ import {
 import { formatStatefulAgentLine, type StatefulSubagentRuntimeStatus } from "./stateful.js";
 import {
 	applyStatefulLimitSetting,
-	formatConfiguredDetachedLimitDivergence,
-	formatConfiguredDetachedLimits,
 	formatDetachedLimitSummary,
 	formatEmptyStatefulRuntime,
 	statefulLimitInputScreen,
 	statefulLimitListScreen,
 } from "./stateful-limit-ui.js";
+import { isStatefulLimitField, type StatefulLimitField } from "./stateful-limits.js";
 import {
-	isStatefulLimitField,
-	STATEFUL_LIMIT_DEFINITIONS,
-	type StatefulLimitField,
-} from "./stateful-limits.js";
+	applyTransportSetting,
+	responsivenessSetupScreen,
+	transportSettingsScreen,
+} from "./transport-ui.js";
 import { showWorkflowPreview, workflowLabel } from "./workflow-ui.js";
 
 const SUBCOMMANDS = [
@@ -160,6 +184,7 @@ async function showSubagentManager(
 	if (!isCurrent()) return;
 	let availableAgents = discoverAgents(ctx.cwd, "user", readSubagentSettings() ?? {}).agents;
 	let toolDraft: ToolDraft | undefined;
+	let selectedExecutionAgent: (typeof availableAgents)[number] | undefined;
 	let selectedStatefulLimit: StatefulLimitField = "maxAgents";
 	type Screen =
 		| "main"
@@ -167,6 +192,16 @@ async function showSubagentManager(
 		| "agents"
 		| "settings"
 		| "advanced"
+		| "performance"
+		| "responsiveness"
+		| "transport"
+		| "execution-profiles"
+		| "execution-agent-picker"
+		| "execution-agent"
+		| "execution-thinking"
+		| "execution-model"
+		| "execution-model-input"
+		| "execution-timeout"
 		| "parallel-limit"
 		| "stateful-limits"
 		| "stateful-limit-input"
@@ -177,6 +212,13 @@ async function showSubagentManager(
 	type Action =
 		| "set-workflow"
 		| "clear-agents"
+		| "set-transport"
+		| "apply-execution-profile"
+		| "pick-execution-agent"
+		| "set-agent-thinking"
+		| "set-agent-model"
+		| "set-agent-timeout"
+		| "reset-agent-execution"
 		| "set-parallel-limit"
 		| "pick-stateful-limit"
 		| "set-stateful-limit"
@@ -333,11 +375,48 @@ async function showSubagentManager(
 							description: formatDetachedLimitSummary(runtime.getRuntimeStatus()),
 							to: "stateful-limits",
 						},
+						{
+							id: "performance",
+							label: "Performance and execution",
+							description: "Transport, responsiveness, profiles, and agent defaults",
+							to: "performance",
+						},
 						{ id: "back", label: "Back", action: "back" },
 					],
 					hint: "back",
 				};
 			},
+			performance: () => ({
+				kind: "actions",
+				title: "Performance and Execution",
+				items: [
+					{
+						id: "responsiveness",
+						label: "Responsiveness setup",
+						description: "Preview automatic retained transport and completion guidance",
+						to: "responsiveness",
+					},
+					{ id: "transport", label: "Detached transport", to: "transport" },
+					{ id: "profiles", label: "Execution profiles", to: "execution-profiles" },
+					{
+						id: "agents",
+						label: "Agent execution defaults",
+						description: "Model, thinking level, and timeout",
+						to: "execution-agent-picker",
+					},
+					{ id: "back", label: "Back", action: "back" },
+				],
+				hint: "back",
+			}),
+			responsiveness: () => responsivenessSetupScreen(runtime),
+			transport: () => transportSettingsScreen(runtime),
+			"execution-profiles": () => executionProfileScreen(),
+			"execution-agent-picker": () => executionAgentPickerScreen(availableAgents),
+			"execution-agent": () => executionAgentScreen(selectedExecutionAgent),
+			"execution-thinking": () => executionThinkingScreen(selectedExecutionAgent),
+			"execution-model": () => executionModelScreen(selectedExecutionAgent, ctx),
+			"execution-model-input": () => executionModelInputScreen(selectedExecutionAgent),
+			"execution-timeout": () => executionTimeoutInputScreen(selectedExecutionAgent),
 			"parallel-limit": () => blockingParallelLimitScreen(runtime),
 			"stateful-limits": () => statefulLimitListScreen(runtime),
 			"stateful-limit-input": () => statefulLimitInputScreen(selectedStatefulLimit, runtime),
@@ -487,6 +566,29 @@ async function showSubagentManager(
 				);
 				return { kind: "stay" };
 			},
+			"set-transport": async ({ itemId, signal }) =>
+				applyTransportSetting(itemId, ctx, runtime, signal, isCurrent),
+			"apply-execution-profile": async ({ itemId, signal }) =>
+				applyExecutionProfileFromUi(itemId, ctx, signal, isCurrent),
+			"pick-execution-agent": async ({ itemId }) => {
+				selectedExecutionAgent = availableAgents.find((agent) => agent.name === itemId);
+				return selectedExecutionAgent
+					? { kind: "to", screen: "execution-agent" as const }
+					: { kind: "rejected" as const };
+			},
+			"set-agent-thinking": async ({ value }) =>
+				applyAgentThinking(selectedExecutionAgent, value, ctx),
+			"set-agent-model": async ({ itemId, value }) => {
+				const selected = value ?? (itemId.startsWith("model:") ? itemId.slice(6) : undefined);
+				return applyAgentModel(
+					selectedExecutionAgent,
+					selected === "__inherited__" ? undefined : selected,
+					ctx,
+				);
+			},
+			"set-agent-timeout": async ({ value }) =>
+				applyAgentTimeout(selectedExecutionAgent, value, ctx),
+			"reset-agent-execution": async () => resetAgentExecution(selectedExecutionAgent, ctx),
 			"set-parallel-limit": async ({ value }) =>
 				applyBlockingParallelLimitSetting(value, ctx, runtime),
 			"pick-stateful-limit": async ({ itemId }) => {
@@ -784,188 +886,8 @@ function blockReloadWithRetainedAgents(
 	return true;
 }
 
-function showSubagentStatus(ctx: ExtensionCommandContext, runtime: SubagentSettingsRuntime) {
-	if (ctx.mode !== "tui" && !ctx.hasUI) return;
-	const snapshot = inspectCompletionDeliverySettings();
-	ctx.ui.notify(
-		formatStatus(runtime.getRuntimeStatus(), snapshot, runtime),
-		snapshot.error ? "warning" : "info",
-	);
-}
-
-function showSubagentHelp(ctx: ExtensionCommandContext, runtime: SubagentSettingsRuntime) {
-	if (ctx.mode !== "tui" && !ctx.hasUI) return;
-	ctx.ui.notify(helpLines(runtime).join("\n"), "info");
-}
-
-function statusLines(runtime: SubagentSettingsRuntime): string[] {
-	const snapshot = inspectCompletionDeliverySettings();
-	return formatStatus(runtime.getRuntimeStatus(), snapshot, runtime).split("\n");
-}
-
-function helpLines(runtime: SubagentSettingsRuntime): string[] {
-	const snapshot = inspectCompletionDeliverySettings();
-	const cwdPolicy = inspectCwdPolicySettings();
-	const parallelLimit = inspectBlockingParallelLimitSettings();
-	const detachedLimits = inspectStatefulLimitSettings();
-	return [
-		"/subagents — choose delegation workflow, manage current agents, and configure agent tools",
-		"/subagents settings — configure target locations, trusted resources, and async completion",
-		"/subagents status — show current-session and user-setting values",
-		"/subagents help — show this help",
-		"Target policies control startup directories and resources, not filesystem access or sandboxing.",
-		"Manage saved folder trust with Pi /trust and restart Pi after changing it.",
-		`Runtime consultation target: ${consultationCwdLabel(runtime.getConsultationCwdPolicy())}`,
-		`Configured consultation target: ${consultationCwdLabel(cwdPolicy.consultation.value)} (${cwdPolicy.consultation.source})`,
-		`Runtime delegation target: ${delegationCwdLabel(runtime.getDelegationCwdPolicy())}`,
-		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} (${cwdPolicy.delegation.source})`,
-		`Maximum parallel workers: ${runtime.getMaxParallelTasks()} per blocking call`,
-		`Configured parallel limit: ${parallelLimit.value} (${parallelLimit.source})`,
-		`Detached limits: ${formatDetachedLimitSummary(runtime.getRuntimeStatus())}`,
-		...(detachedLimits.values
-			? [`Configured detached limits: ${formatConfiguredDetachedLimits(detachedLimits.values)}`]
-			: ["Configured detached limits: unavailable; repair user settings"]),
-		"Detached limits apply after /reload; clear retained agents first if their work must not be interrupted.",
-		`User settings: ${safeTerminalText(snapshot.path)}`,
-	];
-}
-
-function formatManagerSummary(
-	runtime: SubagentSettingsRuntime,
-	status: StatefulSubagentRuntimeStatus,
-	configured: ReturnType<typeof inspectDelegationWorkflowSettings>,
-): string {
-	const current = currentWorkflow(runtime, status);
-	const cwdPolicy = inspectCwdPolicySettings();
-	const consult = inspectConsultResourceSettings();
-	const detachedLimits = inspectStatefulLimitSettings();
-	const detachedDivergence = detachedLimits.values
-		? formatConfiguredDetachedLimitDivergence(status, detachedLimits.values)
-		: undefined;
-	return [
-		`Delegation: ${workflowLabel(current)}`,
-		`Completion: ${completionLabel(status.completionDelivery)}`,
-		`Consult target: ${consultationCwdLabel(runtime.getConsultationCwdPolicy())}`,
-		`Delegation target: ${delegationCwdLabel(runtime.getDelegationCwdPolicy())}`,
-		`Consult resources: ${consultResourceLabel(runtime.getConsultResourcePolicy())}`,
-		`Parallel workers: max ${runtime.getMaxParallelTasks()} per blocking call`,
-		`Detached limits: ${formatDetachedLimitSummary(status)}`,
-		`Configured consult target: ${consultationCwdLabel(cwdPolicy.consultation.value)} · ${cwdPolicy.consultation.source}`,
-		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} · ${cwdPolicy.delegation.source}`,
-		`Configured consult resources: ${consultResourceLabel(consult.value)} · ${consult.source}`,
-		`Settings: ${safeTerminalText(cwdPolicy.path)}`,
-		`Agents: ${status.activeAgents} active · ${status.retainedAgents} retained`,
-		...(detachedDivergence ? [detachedDivergence] : []),
-		...(configured.value !== current
-			? [`Configured after reload: ${workflowLabel(configured.value)}`]
-			: []),
-		...(configured.error || detachedLimits.error
-			? ["Settings need repair; open Advanced settings for details."]
-			: []),
-	].join("\n");
-}
-
-function formatStatus(
-	status: StatefulSubagentRuntimeStatus,
-	snapshot: ReturnType<typeof inspectCompletionDeliverySettings>,
-	runtime?: SubagentSettingsRuntime,
-): string {
-	const configuredWorkflow = inspectDelegationWorkflowSettings();
-	const consult = inspectConsultResourceSettings();
-	const cwdPolicy = inspectCwdPolicySettings();
-	const parallelLimit = inspectBlockingParallelLimitSettings();
-	const detachedLimits = inspectStatefulLimitSettings();
-	const current = runtime ? currentWorkflow(runtime, status) : configuredWorkflow.value;
-	return [
-		"Current session",
-		`  Delegation: ${workflowLabel(current)}`,
-		`  Async runtime: ${status.initialized ? "initialized" : status.enabled ? "not initialized" : "disabled"}`,
-		`  Transport: ${status.transport}`,
-		`  Completion: ${completionLabel(status.completionDelivery)}`,
-		`  Consultation target: ${consultationCwdLabel(runtime?.getConsultationCwdPolicy() ?? cwdPolicy.consultation.value)}`,
-		`  Delegation target: ${delegationCwdLabel(runtime?.getDelegationCwdPolicy() ?? cwdPolicy.delegation.value)}`,
-		`  Consultation resources: ${consultResourceLabel(runtime?.getConsultResourcePolicy() ?? consult.value)}`,
-		`  Maximum parallel workers: ${runtime?.getMaxParallelTasks() ?? parallelLimit.value} per blocking call`,
-		`  Detached limits: ${formatDetachedLimitSummary(status)}`,
-		`  Agents: ${status.activeAgents} active, ${status.retainedAgents} retained`,
-		"User settings",
-		`  Delegation source: ${configuredWorkflow.source}`,
-		`  Configured delegation: ${workflowLabel(configuredWorkflow.value)}`,
-		`  Completion source: ${snapshot.source}`,
-		`  Configured completion: ${completionLabel(snapshot.value)}`,
-		`  Configured parallel limit: ${parallelLimit.value}`,
-		`  Parallel limit source: ${parallelLimit.source}`,
-		...(detachedLimits.values
-			? STATEFUL_LIMIT_DEFINITIONS.map((definition) => {
-					const configured = detachedLimits.values?.[definition.field];
-					return `  Configured ${definition.label.toLowerCase()}: ${configured?.value} (${configured?.source})`;
-				})
-			: ["  Configured detached limits: unavailable"]),
-		`  Configured consultation target: ${consultationCwdLabel(cwdPolicy.consultation.value)}`,
-		`  Consultation target source: ${cwdPolicy.consultation.source}`,
-		`  Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)}`,
-		`  Delegation target source: ${cwdPolicy.delegation.source}`,
-		`  Configured consultation resources: ${consultResourceLabel(consult.value)}`,
-		`  Consultation resource source: ${consult.source}`,
-		`  Path: ${safeTerminalText(snapshot.path)}`,
-		configuredWorkflow.error ||
-		snapshot.error ||
-		cwdPolicy.error ||
-		parallelLimit.error ||
-		detachedLimits.error
-			? `  Warning: ${safeTerminalText(configuredWorkflow.error ?? snapshot.error ?? cwdPolicy.error ?? parallelLimit.error ?? detachedLimits.error ?? "invalid settings")}`
-			: "  Warning: none",
-		configuredWorkflow.value !== current
-			? "Configured delegation differs from this session. Run /reload to apply it."
-			: "Manual file changes require /reload.",
-	].join("\n");
-}
-
-function currentWorkflow(
-	runtime: SubagentSettingsRuntime,
-	status: StatefulSubagentRuntimeStatus,
-): DelegationWorkflow {
-	const blocking = runtime.getBlockingEnabled();
-	if (blocking && status.enabled) return "all";
-	if (status.enabled) return "async-only";
-	if (blocking) return "blocking-only";
-	return "disabled";
-}
-
 function isWorkflow(value: string): value is Exclude<DelegationWorkflow, "disabled"> {
 	return value === "all" || value === "async-only" || value === "blocking-only";
-}
-
-function completionLabel(value: CompletionDelivery): string {
-	return value === "auto-resume" ? "Resume automatically when finished" : "Wait until my next turn";
-}
-
-function consultationCwdLabel(value: ConsultationCwdPolicy): string {
-	return value === "current-workspace"
-		? "Current workspace only"
-		: "Anywhere · untrusted targets inherit nothing";
-}
-
-function delegationCwdLabel(value: DelegationCwdPolicy): string {
-	switch (value) {
-		case "trusted-targets":
-			return "Current or saved-trusted folders";
-		case "current-workspace":
-			return "Current workspace only";
-		case "anywhere":
-			return "Anywhere · normal Pi permissions";
-	}
-}
-
-function consultResourceLabel(value: ConsultResourcePolicy): string {
-	switch (value) {
-		case "project-context":
-			return "Project context only";
-		case "none":
-			return "No inherited resources";
-		case "all":
-			return "All trusted resources";
-	}
 }
 
 function formatError(error: unknown): string {

--- a/packages/pi-subagents/src/consult-resources.ts
+++ b/packages/pi-subagents/src/consult-resources.ts
@@ -1,11 +1,6 @@
-import {
-	DefaultResourceLoader,
-	getAgentDir,
-	SettingsManager,
-} from "@earendil-works/pi-coding-agent";
 import type { ConsultResourcePolicy } from "./agents.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
-import { assertPiPromptSourcesAreReadableFiles } from "./prompt-source-safety.js";
+import { resolvePiPromptResources } from "./prompt-resources.js";
 import type { ChildLaunchPolicy } from "./runner.js";
 
 const MINIMAL_CONSULT_SYSTEM_PROMPT =
@@ -31,30 +26,12 @@ export async function resolveConsultResourceLaunchPolicy(
 		};
 	}
 
-	const agentDir = getAgentDir();
-	assertPiPromptSourcesAreReadableFiles(cwd, agentDir, projectTrusted, [
-		"SYSTEM.md",
-		"APPEND_SYSTEM.md",
-	]);
-	const loader = new DefaultResourceLoader({
-		cwd,
-		agentDir,
-		settingsManager: SettingsManager.inMemory({}, { projectTrusted }),
-		noExtensions: true,
-		noSkills: true,
-		noPromptTemplates: true,
-		noThemes: true,
-		noContextFiles: true,
-	});
-	await loader.reload();
-
-	const discoveredSystemPrompt = loader.getSystemPrompt();
+	const resources = await resolvePiPromptResources(cwd, projectTrusted);
+	const discoveredSystemPrompt = resources.systemPrompt;
 	const baseSystemPrompt = discoveredSystemPrompt
 		? truncateUtf8(discoveredSystemPrompt, DEFAULT_MAX_CONTEXT_BYTES).text
 		: undefined;
-	const appendSystemPromptPaths = loader
-		.getAppendSystemPromptSources()
-		.map((source) => source.path);
+	const appendSystemPromptPaths = resources.appendSystemPromptPaths;
 	const shared = {
 		disableExtensions: true,
 		disableContextFiles: !projectTrusted,

--- a/packages/pi-subagents/src/consult.ts
+++ b/packages/pi-subagents/src/consult.ts
@@ -61,7 +61,14 @@ export const SubagentConsultParams = Type.Object(
 		agentScope: Type.Optional(ConsultScopeSchema),
 		confirmProjectAgents: Type.Optional(Type.Boolean({ default: true })),
 		cwd: Type.Optional(Type.String({ minLength: 1 })),
-		timeoutMs: Type.Optional(Type.Number({ minimum: 1, maximum: MAX_SUBAGENT_TIMEOUT_MS })),
+		timeoutMs: Type.Optional(
+			Type.Number({
+				minimum: 1,
+				maximum: MAX_SUBAGENT_TIMEOUT_MS,
+				description:
+					"Work deadline selected for the consultation difficulty. On expiry, Pi aborts the work and makes one separately bounded summary attempt.",
+			}),
+		),
 		thinkingLevel: Type.Optional(ConsultThinkingSchema),
 	},
 	{ additionalProperties: false },
@@ -191,6 +198,7 @@ export function registerSubagentConsult(
 		promptSnippet: "Consult one constrained read-only subagent and wait for its answer",
 		promptGuidelines: [
 			"Use subagent_consult for bounded reconnaissance, planning, or review whose result is required in the current turn.",
+			"Set subagent_consult timeoutMs to the shortest realistic work deadline for the task difficulty; split oversized consultations instead of extending the deadline merely to compensate for broad scope.",
 			"Implementation-shaped tasks remain read-only and can return only analysis or instructions.",
 		],
 		parameters: SubagentConsultParams,

--- a/packages/pi-subagents/src/create-stateful-transport.ts
+++ b/packages/pi-subagents/src/create-stateful-transport.ts
@@ -1,0 +1,55 @@
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { discoverAgents, type SubagentSettings, type SubagentTransportKind } from "./agents.js";
+import { AutoTransport } from "./auto-transport.js";
+import {
+	type ChildSessionFactory,
+	InProcessTransport,
+	type ParentRuntimeSnapshot,
+} from "./in-process-transport.js";
+import { RpcTransport } from "./rpc-transport.js";
+import { SubprocessTransport } from "./subprocess-transport.js";
+import type { SubagentTransport } from "./transport.js";
+
+export interface CreateStatefulTransportOptions {
+	kind: SubagentTransportKind;
+	modelRegistry: ModelRegistry;
+	getParentRuntime(): ParentRuntimeSnapshot;
+	getSettings(): SubagentSettings | undefined;
+	createInProcessSession?: ChildSessionFactory;
+}
+
+export function createStatefulTransport(
+	options: CreateStatefulTransportOptions,
+): SubagentTransport {
+	const subprocess = () => new SubprocessTransport({ getSettings: options.getSettings });
+	const inProcess = () =>
+		new InProcessTransport({
+			modelRegistry: options.modelRegistry,
+			getParentRuntime: options.getParentRuntime,
+			createSession: options.createInProcessSession,
+			discoverAgent: (agent) =>
+				discoverAgents(agent.cwd, agent.agentScope ?? "user", options.getSettings()).agents.find(
+					(candidate) => candidate.name === agent.agent,
+				),
+		});
+	const rpc = () =>
+		new RpcTransport({
+			getSettings: options.getSettings,
+			getParentRuntime: options.getParentRuntime,
+		});
+	switch (options.kind) {
+		case "subprocess":
+			return subprocess();
+		case "in-process":
+			return inProcess();
+		case "rpc":
+			return rpc();
+		case "auto":
+			return new AutoTransport({
+				subprocess: subprocess(),
+				inProcess: inProcess(),
+				rpc: rpc(),
+				getSettings: options.getSettings,
+			});
+	}
+}

--- a/packages/pi-subagents/src/execution-profiles.ts
+++ b/packages/pi-subagents/src/execution-profiles.ts
@@ -1,0 +1,95 @@
+import type { SubagentThinkingLevel } from "./agents.js";
+import { readSubagentSettings, updateAgentSettingsPatch } from "./settings.js";
+
+export const EXECUTION_PROFILES = ["fast", "balanced", "deep"] as const;
+export type ExecutionProfile = (typeof EXECUTION_PROFILES)[number];
+
+const PROFILE_AGENT_ORDER = [
+	"scout",
+	"planner",
+	"reviewer",
+	"worker",
+	"general",
+	"general-purpose",
+] as const;
+
+type ProfileAgent = (typeof PROFILE_AGENT_ORDER)[number];
+
+export const EXECUTION_PROFILE_THINKING: Record<
+	ExecutionProfile,
+	Record<ProfileAgent, SubagentThinkingLevel>
+> = {
+	fast: {
+		scout: "low",
+		planner: "low",
+		reviewer: "medium",
+		worker: "low",
+		general: "low",
+		"general-purpose": "low",
+	},
+	balanced: {
+		scout: "low",
+		planner: "medium",
+		reviewer: "medium",
+		worker: "medium",
+		general: "medium",
+		"general-purpose": "medium",
+	},
+	deep: {
+		scout: "medium",
+		planner: "high",
+		reviewer: "high",
+		worker: "high",
+		general: "high",
+		"general-purpose": "high",
+	},
+};
+
+export function executionProfileLabel(profile: ExecutionProfile): string {
+	switch (profile) {
+		case "fast":
+			return "Fast";
+		case "balanced":
+			return "Balanced";
+		case "deep":
+			return "Deep";
+	}
+}
+
+export function executionProfileDescription(profile: ExecutionProfile): string {
+	switch (profile) {
+		case "fast":
+			return "Prefer low thinking for bounded work and medium for review.";
+		case "balanced":
+			return "Use low for scouting and medium for planning, review, and implementation.";
+		case "deep":
+			return "Use medium scouting and high thinking for planning, review, and implementation.";
+	}
+}
+
+export function executionProfilePreview(profile: ExecutionProfile): string[] {
+	const values = EXECUTION_PROFILE_THINKING[profile];
+	return PROFILE_AGENT_ORDER.map((agent) => `${agent}: ${values[agent]}`);
+}
+
+export function inspectExecutionProfile(): ExecutionProfile | "custom" {
+	const configured = readSubagentSettings()?.agents ?? {};
+	for (const profile of EXECUTION_PROFILES) {
+		const expected = EXECUTION_PROFILE_THINKING[profile];
+		if (
+			PROFILE_AGENT_ORDER.every((agent) => configured[agent]?.thinkingLevel === expected[agent])
+		) {
+			return profile;
+		}
+	}
+	return "custom";
+}
+
+export function applyExecutionProfile(profile: ExecutionProfile): void {
+	const values = EXECUTION_PROFILE_THINKING[profile];
+	updateAgentSettingsPatch(
+		Object.fromEntries(
+			PROFILE_AGENT_ORDER.map((agent) => [agent, { thinkingLevel: values[agent] }]),
+		),
+	);
+}

--- a/packages/pi-subagents/src/execution-ui.ts
+++ b/packages/pi-subagents/src/execution-ui.ts
@@ -1,0 +1,320 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { AgentConfig, SubagentThinkingLevel } from "./agents.js";
+import {
+	applyExecutionProfile,
+	EXECUTION_PROFILES,
+	type ExecutionProfile,
+	executionProfileDescription,
+	executionProfileLabel,
+	executionProfilePreview,
+	inspectExecutionProfile,
+} from "./execution-profiles.js";
+import { MAX_SUBAGENT_TIMEOUT_MS } from "./limits.js";
+import { safeTerminalLine as safeTerminalText } from "./safe-text.js";
+import { readSubagentSettings, updateAgentSettingsPatch } from "./settings.js";
+
+export function executionProfileScreen() {
+	const current = inspectExecutionProfile();
+	return {
+		kind: "actions" as const,
+		title: "Execution Profiles",
+		lines: [
+			`Current built-in mapping: ${current === "custom" ? "Custom or inherited" : executionProfileLabel(current)}`,
+			"Profiles change only built-in agent thinking defaults.",
+			"Models, timeouts, tools, transport, context, and explicit tool-call values are preserved.",
+		],
+		items: [
+			...EXECUTION_PROFILES.map((profile) => ({
+				id: profile,
+				label: executionProfileLabel(profile),
+				description: executionProfileDescription(profile),
+				action: "apply-execution-profile" as const,
+			})),
+			{ id: "back", label: "Back", action: "back" as const },
+		],
+		hint: "back" as const,
+	};
+}
+
+export async function applyExecutionProfileFromUi(
+	profileValue: string,
+	ctx: ExtensionCommandContext,
+	signal: AbortSignal,
+	isCurrent: () => boolean,
+) {
+	if (!EXECUTION_PROFILES.includes(profileValue as ExecutionProfile)) {
+		return { kind: "rejected" as const };
+	}
+	const profile = profileValue as ExecutionProfile;
+	const before = executionSettingsFingerprint();
+	const confirmed = await ctx.ui.confirm(
+		`Apply ${executionProfileLabel(profile)} profile?`,
+		[
+			executionProfileDescription(profile),
+			...executionProfilePreview(profile),
+			"Existing model, timeout, and tool overrides remain unchanged.",
+		].join("\n"),
+		{ signal },
+	);
+	if (signal.aborted || !isCurrent()) return { kind: "close" as const };
+	if (!confirmed) return { kind: "rejected" as const };
+	if (before !== executionSettingsFingerprint()) {
+		ctx.ui.notify("Agent execution settings changed while confirming; review again.", "warning");
+		return { kind: "rejected" as const };
+	}
+	try {
+		applyExecutionProfile(profile);
+		ctx.ui.notify(`Applied ${executionProfileLabel(profile)} profile.`, "info");
+		return { kind: "stay" as const };
+	} catch (error) {
+		ctx.ui.notify(`Execution profile was not saved: ${formatError(error)}`, "error");
+		return { kind: "rejected" as const };
+	}
+}
+
+export function executionAgentPickerScreen(agents: readonly AgentConfig[]) {
+	const configured = readSubagentSettings()?.agents ?? {};
+	return {
+		kind: "actions" as const,
+		title: "Agent Execution Defaults",
+		lines: ["Choose an agent to edit its inherited model, thinking, or timeout."],
+		items: [
+			...agents.map((agent) => {
+				const value = configured[agent.name];
+				return {
+					id: agent.name,
+					label: safeTerminalText(agent.name),
+					description: safeTerminalText(
+						`${agent.source} · model ${value?.model ?? agent.model ?? "inherited"} · thinking ${value?.thinkingLevel ?? agent.thinkingLevel ?? "inherited"} · timeout ${value?.timeoutMs ?? agent.timeoutMs ?? "inherited"}`,
+					),
+					action: "pick-execution-agent" as const,
+				};
+			}),
+			{ id: "back", label: "Back", action: "back" as const },
+		],
+		hint: "back" as const,
+	};
+}
+
+export function executionAgentScreen(agent: AgentConfig | undefined) {
+	if (!agent) {
+		return {
+			kind: "actions" as const,
+			title: "Agent Execution Defaults",
+			lines: ["No agent selected."],
+			items: [{ id: "back", label: "Back", action: "back" as const }],
+			hint: "back" as const,
+		};
+	}
+	const configured = readSubagentSettings()?.agents?.[agent.name];
+	return {
+		kind: "actions" as const,
+		title: `${safeTerminalText(agent.name)} execution`,
+		lines: [
+			`Model: ${safeTerminalText(configured?.model ?? agent.model ?? "inherited")}`,
+			`Thinking: ${configured?.thinkingLevel ?? agent.thinkingLevel ?? "inherited"}`,
+			`Timeout: ${configured?.timeoutMs ?? agent.timeoutMs ?? "inherited"}`,
+			"Explicit tool-call values remain authoritative.",
+		],
+		items: [
+			{ id: "thinking", label: "Thinking level", to: "execution-thinking" as const },
+			{ id: "model", label: "Model", to: "execution-model" as const },
+			{ id: "timeout", label: "Timeout", to: "execution-timeout" as const },
+			{
+				id: "reset",
+				label: "Reset execution defaults",
+				description: "Restore frontmatter or Pi inheritance without changing tools",
+				action: "reset-agent-execution" as const,
+			},
+			{ id: "back", label: "Back", action: "back" as const },
+		],
+		hint: "back" as const,
+	};
+}
+
+export function executionThinkingScreen(agent: AgentConfig | undefined) {
+	const configured = agent ? readSubagentSettings()?.agents?.[agent.name] : undefined;
+	return {
+		kind: "settings" as const,
+		title: agent ? `${safeTerminalText(agent.name)} thinking` : "Agent thinking",
+		items: agent
+			? [
+					{
+						id: "thinking",
+						label: "Default thinking level",
+						description: "Explicit spawn or blocking call values still win.",
+						currentValue: configured?.thinkingLevel ?? agent.thinkingLevel ?? "Inherited",
+						values: ["Inherited", "off", "minimal", "low", "medium", "high", "xhigh", "max"],
+						action: "set-agent-thinking" as const,
+					},
+				]
+			: [],
+		hint: "back" as const,
+	};
+}
+
+export function executionModelScreen(agent: AgentConfig | undefined, ctx: ExtensionCommandContext) {
+	const configured = agent ? readSubagentSettings()?.agents?.[agent.name] : undefined;
+	const models = ctx.modelRegistry
+		.getAvailable()
+		.map((model) => `${model.provider}/${model.id}`)
+		.sort((left, right) => left.localeCompare(right))
+		.slice(0, 100);
+	return {
+		kind: "actions" as const,
+		title: agent ? `${safeTerminalText(agent.name)} model` : "Agent model",
+		lines: [
+			`Current: ${safeTerminalText(configured?.model ?? agent?.model ?? "inherited")}`,
+			"Choose a session-available model or enter a custom Pi model pattern.",
+		],
+		items: agent
+			? [
+					{
+						id: "model:__inherited__",
+						label: "Inherited",
+						description: "Use frontmatter or active Pi model resolution",
+						action: "set-agent-model" as const,
+					},
+					...models.map((model) => ({
+						id: `model:${model}`,
+						label: safeTerminalText(model),
+						action: "set-agent-model" as const,
+					})),
+					{
+						id: "custom",
+						label: "Custom model pattern",
+						description: "Enter provider/model, a model pattern, or an optional :thinking suffix",
+						to: "execution-model-input" as const,
+					},
+					{ id: "back", label: "Back", action: "back" as const },
+				]
+			: [],
+		hint: "back" as const,
+	};
+}
+
+export function executionModelInputScreen(agent: AgentConfig | undefined) {
+	const configured = agent ? readSubagentSettings()?.agents?.[agent.name] : undefined;
+	return {
+		kind: "input" as const,
+		title: agent ? `${safeTerminalText(agent.name)} model` : "Agent model",
+		lines: [
+			`Current: ${safeTerminalText(configured?.model ?? agent?.model ?? "inherited")}`,
+			"Enter a Pi CLI model pattern, including an optional :thinking suffix.",
+			"Use Reset execution defaults to restore inheritance.",
+		],
+		placeholder: "provider/model or model pattern",
+		action: "set-agent-model" as const,
+		hint: "back" as const,
+	};
+}
+
+export function executionTimeoutInputScreen(agent: AgentConfig | undefined) {
+	const configured = agent ? readSubagentSettings()?.agents?.[agent.name] : undefined;
+	return {
+		kind: "input" as const,
+		title: agent ? `${safeTerminalText(agent.name)} timeout` : "Agent timeout",
+		lines: [
+			`Current: ${configured?.timeoutMs ?? agent?.timeoutMs ?? "inherited"}`,
+			`Allowed: 1-${MAX_SUBAGENT_TIMEOUT_MS} milliseconds.`,
+			"Use Reset execution defaults to restore inheritance.",
+		],
+		placeholder: "Timeout in milliseconds",
+		action: "set-agent-timeout" as const,
+		hint: "back" as const,
+	};
+}
+
+export function applyAgentThinking(
+	agent: AgentConfig | undefined,
+	value: string | undefined,
+	ctx: ExtensionCommandContext,
+) {
+	if (!agent) return { kind: "rejected" as const };
+	const thinkingLevel = value === "Inherited" ? undefined : (value as SubagentThinkingLevel);
+	if (
+		thinkingLevel !== undefined &&
+		!["off", "minimal", "low", "medium", "high", "xhigh", "max"].includes(thinkingLevel)
+	) {
+		return { kind: "rejected" as const };
+	}
+	return saveAgentPatch(agent.name, { thinkingLevel }, ctx, "thinking level");
+}
+
+export function applyAgentModel(
+	agent: AgentConfig | undefined,
+	value: string | undefined,
+	ctx: ExtensionCommandContext,
+) {
+	if (!agent) return { kind: "rejected" as const };
+	if (value === undefined) return saveAgentPatch(agent.name, { model: undefined }, ctx, "model");
+	const model = value.trim();
+	if (!model || Buffer.byteLength(model, "utf8") > 1_024 || hasTerminalControl(model)) {
+		ctx.ui.notify("Model must contain 1-1024 UTF-8 bytes on one line.", "warning");
+		return { kind: "rejected" as const };
+	}
+	return saveAgentPatch(agent.name, { model }, ctx, "model");
+}
+
+export function applyAgentTimeout(
+	agent: AgentConfig | undefined,
+	value: string | undefined,
+	ctx: ExtensionCommandContext,
+) {
+	if (!agent) return { kind: "rejected" as const };
+	const normalized = value?.trim() ?? "";
+	if (!/^\d+$/u.test(normalized)) {
+		ctx.ui.notify("Timeout must be a whole number of milliseconds.", "warning");
+		return { kind: "rejected" as const };
+	}
+	const timeoutMs = Number(normalized);
+	if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_SUBAGENT_TIMEOUT_MS) {
+		ctx.ui.notify(`Timeout must be between 1 and ${MAX_SUBAGENT_TIMEOUT_MS}.`, "warning");
+		return { kind: "rejected" as const };
+	}
+	return saveAgentPatch(agent.name, { timeoutMs }, ctx, "timeout");
+}
+
+export function resetAgentExecution(agent: AgentConfig | undefined, ctx: ExtensionCommandContext) {
+	if (!agent) return { kind: "rejected" as const };
+	return saveAgentPatch(
+		agent.name,
+		{ model: undefined, thinkingLevel: undefined, timeoutMs: undefined },
+		ctx,
+		"execution defaults",
+	);
+}
+
+function saveAgentPatch(
+	name: string,
+	patch: Parameters<typeof updateAgentSettingsPatch>[0][string],
+	ctx: ExtensionCommandContext,
+	label: string,
+) {
+	try {
+		updateAgentSettingsPatch({ [name]: patch });
+		ctx.ui.notify(`${safeTerminalText(name)} ${label} saved.`, "info");
+		return { kind: "back" as const };
+	} catch (error) {
+		ctx.ui.notify(
+			`${safeTerminalText(name)} ${label} was not saved: ${formatError(error)}`,
+			"error",
+		);
+		return { kind: "rejected" as const };
+	}
+}
+
+function hasTerminalControl(value: string): boolean {
+	return [...value].some((character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+	});
+}
+
+function executionSettingsFingerprint(): string {
+	return JSON.stringify(readSubagentSettings()?.agents ?? {});
+}
+
+function formatError(error: unknown): string {
+	return safeTerminalText(error instanceof Error ? error.message : String(error));
+}

--- a/packages/pi-subagents/src/in-process-transport.ts
+++ b/packages/pi-subagents/src/in-process-transport.ts
@@ -13,8 +13,11 @@ import { resolveDefaultSubagentTimeoutMs } from "./execution.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
 import { assertPiPromptSourcesAreReadableFiles } from "./prompt-source-safety.js";
 import type { AgentTurn, ManagedAgent, TurnOutcome } from "./registry.js";
+import { appendResultInstruction } from "./result-contract.js";
+import { safeTerminalLine } from "./safe-text.js";
 import { readSubagentSettings } from "./settings.js";
 import type { SubagentTransport } from "./transport.js";
+import type { TransportProgressCallback, TransportTelemetry } from "./transport-types.js";
 
 const BUILT_IN_TOOL_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"]);
 const DEFAULT_ABORT_GRACE_MS = 5_000;
@@ -57,6 +60,9 @@ export interface ParentRuntimeSnapshot {
 export interface ChildSession {
 	readonly sessionId: string;
 	readonly messages: readonly unknown[];
+	readonly provider?: string;
+	readonly model?: string;
+	readonly thinkingLevel?: SubagentThinkingLevel;
 	prompt(text: string): Promise<void>;
 	subscribe(listener: (event: unknown) => void): () => void;
 	abort(): Promise<void>;
@@ -118,37 +124,87 @@ export class InProcessTransport implements SubagentTransport {
 		this.abortGraceMs = options.abortGraceMs ?? DEFAULT_ABORT_GRACE_MS;
 	}
 
-	async runTurn(agent: ManagedAgent, task: string, signal: AbortSignal): Promise<TurnOutcome> {
-		if (signal.aborted) return interruptedOutcome("");
+	async runTurn(
+		agent: ManagedAgent,
+		task: string,
+		signal: AbortSignal,
+		onProgress?: TransportProgressCallback,
+	): Promise<TurnOutcome> {
+		const startedAt = Date.now();
+		let telemetry: TransportTelemetry = {
+			transport: "in-process",
+			phase: "starting",
+			updatedAt: startedAt,
+			timing: { startedAt, transportStartedAt: startedAt },
+		};
+		const publish = (patch: Partial<TransportTelemetry>) => {
+			telemetry = {
+				...telemetry,
+				...patch,
+				timing: { ...telemetry.timing, ...patch.timing },
+				updatedAt: Date.now(),
+			};
+			onProgress?.({ ...telemetry, timing: { ...telemetry.timing } });
+		};
+		publish({});
+		if (signal.aborted) {
+			publish({ phase: "interrupted", failurePhase: "starting" });
+			return { ...interruptedOutcome(""), telemetry };
+		}
 		const agentConfig = this.discoverAgent(agent);
 		if (!agentConfig) {
-			return { output: "", exitCode: 1, error: `Unknown subagent: ${agent.agent}` };
+			publish({ phase: "failed", failurePhase: "starting" });
+			return {
+				output: "",
+				exitCode: 1,
+				error: `Unknown subagent: ${agent.agent}`,
+				telemetry,
+			};
 		}
 		let tools: string[] | undefined;
 		try {
 			tools = validateInProcessTools(agentConfig.tools);
 		} catch (error) {
-			return { output: "", exitCode: 1, error: errorMessage(error) };
+			publish({ phase: "failed", failurePhase: "starting" });
+			return { output: "", exitCode: 1, error: errorMessage(error), telemetry };
 		}
 		let record: ChildSessionRecord;
 		try {
 			record = await this.getOrCreate(agent, agentConfig, tools);
 		} catch (error) {
-			return { output: "", exitCode: 1, error: errorMessage(error) };
+			publish({ phase: "failed", failurePhase: "starting" });
+			return { output: "", exitCode: 1, error: errorMessage(error), telemetry };
 		}
-		if (signal.aborted) return interruptedOutcome("");
+		publish({
+			phase: "ready",
+			provider: record.session.provider,
+			model: record.session.model,
+			thinkingLevel: record.session.thinkingLevel,
+			timing: { readyAt: Date.now() },
+		});
+		if (signal.aborted) {
+			await this.releaseById(agent.id).catch(() => undefined);
+			publish({ phase: "interrupted", failurePhase: "ready" });
+			return { ...interruptedOutcome(""), telemetry };
+		}
 		const prompt = buildCurrentTurnPrompt(agent, task);
 		const timeoutMs = agentConfig.timeoutMs ?? this.defaultTimeoutMs;
 		const startingMessageCount = record.session.messages.length;
 		record.lastOutput = "";
+		publish({ phase: "running", timing: { promptAcceptedAt: Date.now() } });
 		const settlement = await this.runPrompt(record, prompt, signal, timeoutMs);
 		const final = latestAssistant(record.session.messages.slice(startingMessageCount));
 		const output = truncateUtf8(final.output || record.lastOutput, DEFAULT_MAX_OUTPUT_BYTES);
 		const truncated = output.truncated || agent.contextTruncated;
 		const policy = inProcessPolicy(agentConfig, agent);
+		const settledAt = Date.now();
 
 		switch (settlement.kind) {
 			case "completed":
+				publish({
+					phase: final.stopReason === "error" ? "failed" : "settled",
+					timing: { settledAt },
+				});
 				if (final.stopReason === "error") {
 					return {
 						output: output.text,
@@ -156,13 +212,16 @@ export class InProcessTransport implements SubagentTransport {
 						truncated,
 						error: final.error || "In-process subagent returned an error",
 						policy,
+						telemetry,
 					};
 				}
 				if (final.stopReason === "aborted") {
+					publish({ phase: "interrupted", failurePhase: "running" });
 					return {
 						...interruptedOutcome(output.text),
 						truncated,
 						policy,
+						telemetry,
 					};
 				}
 				return {
@@ -170,28 +229,35 @@ export class InProcessTransport implements SubagentTransport {
 					exitCode: 0,
 					truncated,
 					policy,
+					telemetry,
 				};
 			case "failed":
+				publish({ phase: "failed", failurePhase: "running", timing: { settledAt } });
 				return {
 					output: output.text,
 					exitCode: 1,
 					truncated,
 					error: errorMessage(settlement.error),
 					policy,
+					telemetry,
 				};
 			case "timeout":
+				publish({ phase: "failed", failurePhase: "running", timing: { settledAt } });
 				return {
 					output: output.text,
 					exitCode: 124,
 					truncated,
 					error: `In-process subagent timed out after ${timeoutMs}ms`,
 					policy,
+					telemetry,
 				};
 			case "aborted":
+				publish({ phase: "interrupted", failurePhase: "running", timing: { settledAt } });
 				return {
 					...interruptedOutcome(output.text),
 					truncated,
 					policy,
+					telemetry,
 				};
 		}
 	}
@@ -290,10 +356,11 @@ export class InProcessTransport implements SubagentTransport {
 		signal: AbortSignal,
 		timeoutMs: number,
 	): Promise<PromptSettlement> {
+		if (signal.aborted) return { kind: "aborted" };
 		let timeout: NodeJS.Timeout | undefined;
 		let abortHandler: (() => void) | undefined;
-		const promptSettlement: Promise<PromptSettlement> = record.session
-			.prompt(prompt)
+		const promptSettlement: Promise<PromptSettlement> = Promise.resolve()
+			.then(() => record.session.prompt(prompt))
 			.then(() => ({ kind: "completed" as const }))
 			.catch((error: unknown) => ({ kind: "failed" as const, error }));
 		const timeoutSettlement = new Promise<PromptSettlement>((resolve) => {
@@ -302,6 +369,7 @@ export class InProcessTransport implements SubagentTransport {
 		const abortSettlement = new Promise<PromptSettlement>((resolve) => {
 			abortHandler = () => resolve({ kind: "aborted" });
 			signal.addEventListener("abort", abortHandler, { once: true });
+			if (signal.aborted) abortHandler();
 		});
 		const settlement = await Promise.race([promptSettlement, timeoutSettlement, abortSettlement]);
 		if (timeout) clearTimeout(timeout);
@@ -331,7 +399,7 @@ export function validateInProcessTools(tools: string[] | undefined): string[] | 
 	const unsupported = unique.filter((tool) => !BUILT_IN_TOOL_NAMES.has(tool));
 	if (unsupported.length > 0) {
 		throw new Error(
-			`In-process subagents cannot load extension/custom tools: ${unsupported.join(", ")}. Use stateful.transport "subprocess" for this agent.`,
+			`In-process subagents cannot load extension/custom tools: ${unsupported.map((tool) => safeTerminalLine(tool, 256)).join(", ")}. Use stateful.transport "subprocess" for this agent.`,
 		);
 	}
 	return unique;
@@ -391,6 +459,15 @@ export async function createSdkChildSession(
 		},
 		get messages() {
 			return session.messages;
+		},
+		get provider() {
+			return session.model?.provider;
+		},
+		get model() {
+			return session.model?.id;
+		},
+		get thinkingLevel() {
+			return session.thinkingLevel;
 		},
 		prompt: (text) => session.prompt(text),
 		subscribe: (listener) => session.subscribe((event) => listener(event)),
@@ -556,7 +633,7 @@ export function seedChildSessionManager(
 	}
 }
 
-function buildCurrentTurnPrompt(agent: ManagedAgent, task: string): string {
+export function buildCurrentTurnPrompt(agent: ManagedAgent, task: string): string {
 	const ids = new Set(agent.currentMailboxMessageIds ?? []);
 	const messages = agent.mailbox
 		.filter((message) => ids.has(message.id))
@@ -564,9 +641,12 @@ function buildCurrentTurnPrompt(agent: ManagedAgent, task: string): string {
 		.map((message) => `From ${message.senderId}: ${redactPrivateText(message.content)}`)
 		.join("\n");
 	return truncateUtf8(
-		messages
-			? `${redactPrivateText(task)}\n\nMailbox messages:\n${messages}`
-			: redactPrivateText(task),
+		appendResultInstruction(
+			messages
+				? `${redactPrivateText(task)}\n\nMailbox messages:\n${messages}`
+				: redactPrivateText(task),
+			agent.resultFormat,
+		),
 		DEFAULT_MAX_CONTEXT_BYTES,
 	).text;
 }

--- a/packages/pi-subagents/src/in-process-transport.ts
+++ b/packages/pi-subagents/src/in-process-transport.ts
@@ -11,7 +11,7 @@ import { type AgentConfig, discoverAgents, type SubagentThinkingLevel } from "./
 import { redactPrivateText } from "./context.js";
 import { resolveDefaultSubagentTimeoutMs } from "./execution.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
-import { assertPiPromptSourcesAreReadableFiles } from "./prompt-source-safety.js";
+import { resolvePiPromptResources } from "./prompt-resources.js";
 import type { AgentTurn, ManagedAgent, TurnOutcome } from "./registry.js";
 import { appendResultInstruction } from "./result-contract.js";
 import { safeTerminalLine } from "./safe-text.js";
@@ -568,7 +568,7 @@ async function prepareInProcessServices(
 	agentSystemPrompt: string,
 	projectTrusted: boolean,
 ): Promise<{ services: AgentSessionServices; support: CoreSessionSupport }> {
-	assertPiPromptSourcesAreReadableFiles(cwd, agentDir, projectTrusted, ["SYSTEM.md"]);
+	const promptResources = await resolvePiPromptResources(cwd, projectTrusted, agentDir);
 	const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
 	const support = await loadCoreSessionSupport();
 	if (!support) throw unsupportedInProcessCoreError();
@@ -578,7 +578,10 @@ async function prepareInProcessServices(
 		settingsManager,
 		resourceLoaderOptions: {
 			noExtensions: true,
-			appendSystemPrompt: agentSystemPrompt.trim() ? [agentSystemPrompt] : [],
+			appendSystemPrompt: [
+				...promptResources.appendSystemPromptPaths,
+				...(agentSystemPrompt.trim() ? [agentSystemPrompt] : []),
+			],
 		},
 	});
 	return { services, support };

--- a/packages/pi-subagents/src/in-process-transport.ts
+++ b/packages/pi-subagents/src/in-process-transport.ts
@@ -16,6 +16,10 @@ import type { AgentTurn, ManagedAgent, TurnOutcome } from "./registry.js";
 import { appendResultInstruction } from "./result-contract.js";
 import { safeTerminalLine } from "./safe-text.js";
 import { readSubagentSettings } from "./settings.js";
+import {
+	buildTimeoutFinalizationPrompt,
+	resolveTimeoutFinalizationMs,
+} from "./timeout-finalization.js";
 import type { SubagentTransport } from "./transport.js";
 import type { TransportProgressCallback, TransportTelemetry } from "./transport-types.js";
 
@@ -89,6 +93,7 @@ export interface InProcessTransportOptions {
 	discoverAgent?: (agent: ManagedAgent) => AgentConfig | undefined;
 	defaultTimeoutMs?: number;
 	abortGraceMs?: number;
+	timeoutFinalizationMs?: number;
 }
 
 interface ChildSessionRecord {
@@ -188,7 +193,8 @@ export class InProcessTransport implements SubagentTransport {
 			return { ...interruptedOutcome(""), telemetry };
 		}
 		const prompt = buildCurrentTurnPrompt(agent, task);
-		const timeoutMs = agentConfig.timeoutMs ?? this.defaultTimeoutMs;
+		const timeoutMs =
+			agent.currentTimeoutMs ?? agent.timeoutMs ?? agentConfig.timeoutMs ?? this.defaultTimeoutMs;
 		const startingMessageCount = record.session.messages.length;
 		record.lastOutput = "";
 		publish({ phase: "running", timing: { promptAcceptedAt: Date.now() } });
@@ -241,16 +247,53 @@ export class InProcessTransport implements SubagentTransport {
 					policy,
 					telemetry,
 				};
-			case "timeout":
-				publish({ phase: "failed", failurePhase: "running", timing: { settledAt } });
+			case "timeout": {
+				let finalizedOutput = output.text;
+				let finalizationError: string | undefined;
+				if (!signal.aborted && this.sessions.get(agent.id) === record) {
+					publish({ phase: "finalizing", failurePhase: "running" });
+					const summaryStart = record.session.messages.length;
+					record.lastOutput = "";
+					const summarySettlement = await this.runPrompt(
+						record,
+						buildTimeoutFinalizationPrompt({
+							task,
+							partialOutput: output.text,
+							resultFormat: agent.resultFormat,
+						}),
+						signal,
+						resolveTimeoutFinalizationMs(timeoutMs, this.options.timeoutFinalizationMs),
+					);
+					const summary = latestAssistant(record.session.messages.slice(summaryStart));
+					const boundedSummary = truncateUtf8(
+						summary.output || record.lastOutput,
+						DEFAULT_MAX_OUTPUT_BYTES,
+					);
+					if (
+						summarySettlement.kind === "completed" &&
+						summary.stopReason !== "error" &&
+						boundedSummary.text.trim()
+					) {
+						finalizedOutput = boundedSummary.text;
+					} else {
+						finalizationError =
+							summarySettlement.kind === "failed"
+								? errorMessage(summarySettlement.error)
+								: `timeout summary ${summarySettlement.kind}`;
+					}
+				}
+				publish({ phase: "failed", failurePhase: "running", timing: { settledAt: Date.now() } });
 				return {
-					output: output.text,
+					output: finalizedOutput,
 					exitCode: 124,
 					truncated,
-					error: `In-process subagent timed out after ${timeoutMs}ms`,
+					error: [`In-process subagent timed out after ${timeoutMs}ms`, finalizationError]
+						.filter(Boolean)
+						.join("; "),
 					policy,
 					telemetry,
 				};
+			}
 			case "aborted":
 				publish({ phase: "interrupted", failurePhase: "running", timing: { settledAt } });
 				return {
@@ -360,7 +403,10 @@ export class InProcessTransport implements SubagentTransport {
 		let timeout: NodeJS.Timeout | undefined;
 		let abortHandler: (() => void) | undefined;
 		const promptSettlement: Promise<PromptSettlement> = Promise.resolve()
-			.then(() => record.session.prompt(prompt))
+			.then(() => {
+				if (signal.aborted) throw new Error("In-process subagent prompt aborted before start");
+				return record.session.prompt(prompt);
+			})
 			.then(() => ({ kind: "completed" as const }))
 			.catch((error: unknown) => ({ kind: "failed" as const, error }));
 		const timeoutSettlement = new Promise<PromptSettlement>((resolve) => {
@@ -375,8 +421,10 @@ export class InProcessTransport implements SubagentTransport {
 		if (timeout) clearTimeout(timeout);
 		if (abortHandler) signal.removeEventListener("abort", abortHandler);
 		if (settlement.kind === "timeout" || settlement.kind === "aborted") {
-			await settleWithin(record.session.abort(), this.abortGraceMs);
-			const settledAfterAbort = await completesWithin(promptSettlement, this.abortGraceMs);
+			const [, settledAfterAbort] = await Promise.all([
+				settleWithin(record.session.abort(), this.abortGraceMs),
+				completesWithin(promptSettlement, this.abortGraceMs),
+			]);
 			if (!settledAfterAbort) this.discardRecord(record);
 		}
 		return settlement;

--- a/packages/pi-subagents/src/inspect-render.ts
+++ b/packages/pi-subagents/src/inspect-render.ts
@@ -157,10 +157,11 @@ function formatRun(run: Record<string, unknown>, theme: Theme, expanded: boolean
 	];
 	if (expanded) {
 		const thinking = stringValue(run.thinkingLevel);
+		const timeout = numberValue(run.currentTimeoutMs) || numberValue(run.timeoutMs);
 		const task = safeBlock(run.currentTask, "", 2 * 1024).trim();
 		const error = safeBlock(run.error, "", 2 * 1024).trim();
 		lines.push(
-			`  ${theme.fg("dim", `${numberValue(run.historyCount)} history · ${thinking ? `thinking:${safeLine(thinking, "", 128)} · ` : ""}${numberValue(run.children)} children`)}`,
+			`  ${theme.fg("dim", `${numberValue(run.historyCount)} history · ${thinking ? `thinking:${safeLine(thinking, "", 128)} · ` : ""}${timeout ? `timeout:${timeout}ms · ` : ""}${numberValue(run.children)} children`)}`,
 		);
 		const context = recordValue(run.context);
 		const telemetry = recordValue(run.telemetry);

--- a/packages/pi-subagents/src/inspect-render.ts
+++ b/packages/pi-subagents/src/inspect-render.ts
@@ -84,6 +84,17 @@ function renderAction(
 				formatModel,
 				stringValue(details.source),
 			);
+		case "preview_context": {
+			const preview = recordValue(details.preview);
+			if (!preview) return undefined;
+			return [
+				`${statusBadge(theme, "completed")} · context ${theme.fg("accent", safeLine(preview.mode, "none", 128))}`,
+				theme.fg(
+					"dim",
+					`${numberValue(preview.turns)} turns · ${numberValue(preview.sourceCount)} sources · ${numberValue(preview.bytes)} bytes${preview.truncated === true ? " · truncated" : ""}`,
+				),
+			].join("\n");
+		}
 		case "status":
 			return renderStatus(details, expanded, theme);
 		case "diagnose":
@@ -151,6 +162,18 @@ function formatRun(run: Record<string, unknown>, theme: Theme, expanded: boolean
 		lines.push(
 			`  ${theme.fg("dim", `${numberValue(run.historyCount)} history · ${thinking ? `thinking:${safeLine(thinking, "", 128)} · ` : ""}${numberValue(run.children)} children`)}`,
 		);
+		const context = recordValue(run.context);
+		const telemetry = recordValue(run.telemetry);
+		if (context) {
+			lines.push(
+				`  ${theme.fg("dim", `context: ${numberValue(context.turns)} turns · ${numberValue(context.sources)} sources · ${numberValue(context.bytes)} bytes${context.truncated === true ? " · truncated" : ""}`)}`,
+			);
+		}
+		if (telemetry) {
+			lines.push(
+				`  ${theme.fg("dim", `transport: ${safeLine(telemetry.transport, "unknown", 128)} · phase:${safeLine(telemetry.phase, "unknown", 128)}${stringValue(telemetry.protocol) ? ` · ${safeLine(telemetry.protocol, "", 128)}` : ""}`)}`,
+			);
+		}
 		if (task) lines.push(`  ${theme.fg("dim", `task: ${task}`)}`);
 		if (error) lines.push(`  ${theme.fg("error", `error: ${error}`)}`);
 	}

--- a/packages/pi-subagents/src/inspect.ts
+++ b/packages/pi-subagents/src/inspect.ts
@@ -14,7 +14,10 @@ import {
 	discoverAgents,
 } from "./agents.js";
 import { resolveConsultTools } from "./consult-policy.js";
+import { buildContextSnapshot, type ContextMode } from "./context.js";
 import { renderInspectCall, renderInspectResult } from "./inspect-render.js";
+import { DEFAULT_MAX_CONTEXT_BYTES } from "./limits.js";
+import { resolvePiInvocation } from "./pi-invocation.js";
 import type { AgentRunInspectionDetail, AgentRunInspectionSummary } from "./registry.js";
 import { boundedPrivateText, boundText, safeDisplayPath, safeTerminalLine } from "./safe-text.js";
 import {
@@ -24,6 +27,7 @@ import {
 	inspectCwdPolicySettings,
 	inspectDelegationWorkflowSettings,
 	inspectStatefulLimitSettings,
+	inspectStatefulTransportSettings,
 	inspectSubagentSettings,
 	resolveDelegationWorkflow,
 } from "./settings.js";
@@ -35,6 +39,7 @@ const INSPECT_ACTIONS = [
 	"list_runs",
 	"get_run",
 	"list_models",
+	"preview_context",
 	"status",
 	"diagnose",
 ] as const;
@@ -45,6 +50,10 @@ const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
 });
 
 const LimitSchema = Type.Number({ minimum: 1, maximum: 100, multipleOf: 1 });
+const ContextModeSchema = Type.Union([
+	StringEnum(["none", "all", "summary"] as const),
+	Type.Number({ minimum: 1, multipleOf: 1 }),
+]);
 const MAX_DETAILS_LIST_BYTES = 40 * 1024;
 
 export const SubagentInspectParams = Type.Object(
@@ -55,6 +64,8 @@ export const SubagentInspectParams = Type.Object(
 		agentScope: Type.Optional(AgentScopeSchema),
 		limit: Type.Optional(LimitSchema),
 		includeClosed: Type.Optional(Type.Boolean({ default: false })),
+		context: Type.Optional(ContextModeSchema),
+		contextEntryIds: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
 	},
 	{ additionalProperties: false },
 );
@@ -83,6 +94,7 @@ type ValidatedInspectOperation =
 	| { action: "list_runs"; includeClosed: boolean; limit: number }
 	| { action: "get_run"; agentId: string }
 	| { action: "list_models"; limit: number }
+	| { action: "preview_context"; context: ContextMode; contextEntryIds?: string[] }
 	| { action: "status" }
 	| { action: "diagnose" };
 
@@ -122,6 +134,7 @@ export function validateInspectParams(params: unknown): ValidatedInspectOperatio
 		list_runs: ["action", "includeClosed", "limit"],
 		get_run: ["action", "agentId"],
 		list_models: ["action", "limit"],
+		preview_context: ["action", "context", "contextEntryIds"],
 		status: ["action"],
 		diagnose: ["action"],
 	};
@@ -153,6 +166,15 @@ export function validateInspectParams(params: unknown): ValidatedInspectOperatio
 	}
 	if (action === "list_models") {
 		return { action, limit: optionalLimit(values.limit, 50) };
+	}
+	if (action === "preview_context") {
+		const context = optionalContextMode(values.context);
+		const contextEntryIds = optionalStringArray(values.contextEntryIds, "contextEntryIds");
+		return {
+			action,
+			context: values.context === undefined && contextEntryIds ? "all" : context,
+			...(contextEntryIds ? { contextEntryIds } : {}),
+		};
 	}
 	return { action };
 }
@@ -210,6 +232,24 @@ async function executeSubagentInspect(
 	if (operation.action === "list_models") {
 		return inspectResult({ action: operation.action, ...projectModels(ctx, operation.limit) });
 	}
+	if (operation.action === "preview_context") {
+		const snapshot = buildContextSnapshot(
+			ctx.sessionManager.getBranch(),
+			operation.context,
+			DEFAULT_MAX_CONTEXT_BYTES,
+			operation.contextEntryIds,
+		);
+		return inspectResult({
+			action: operation.action,
+			preview: {
+				mode: operation.context,
+				turns: snapshot.turns,
+				sourceCount: snapshot.sourceIds.length,
+				bytes: Buffer.byteLength(snapshot.text, "utf8"),
+				truncated: snapshot.truncated,
+			},
+		});
+	}
 	if (operation.action === "status") {
 		return inspectResult({ action: operation.action, status: projectStatus(runtime) });
 	}
@@ -218,6 +258,8 @@ async function executeSubagentInspect(
 	const userDiscovery = discoverAgents(ctx.cwd, "user", settings.settings);
 	const modelCount = availableModelCount(ctx);
 	const runtimeStatus = runtime.getRuntimeStatus();
+	const rpcCapability = inspectRpcCapability();
+	const inProcessCapability = await inspectInProcessCapability();
 	const checks = [
 		{
 			name: "settings",
@@ -246,6 +288,20 @@ async function executeSubagentInspect(
 			message: runtimeStatus.initialized
 				? "Stateful runtime initialized."
 				: "Stateful runtime not initialized.",
+		},
+		{
+			name: "in-process-sdk",
+			status: inProcessCapability.error ? "fail" : "pass",
+			message: inProcessCapability.error
+				? boundedPrivateText(inProcessCapability.error, 2 * 1024)
+				: "Required public Pi in-process session APIs are available.",
+		},
+		{
+			name: "rpc-cli",
+			status: rpcCapability.error ? "fail" : "pass",
+			message: rpcCapability.error
+				? boundedPrivateText(rpcCapability.error, 2 * 1024)
+				: "The exact loaded Pi CLI is available for persistent RPC transport.",
 		},
 		{
 			name: "consultation",
@@ -308,6 +364,15 @@ function projectRun(run: AgentRunInspectionDetail, ctx: ExtensionContext): Recor
 		cwd: safeDisplayPath(run.cwd, ctx.cwd),
 		workspaceMode: run.workspaceMode ?? "shared",
 		thinkingLevel: run.thinkingLevel,
+		context: {
+			turns: run.contextTurns ?? 0,
+			sources: run.contextSources ?? 0,
+			bytes: run.contextBytes ?? 0,
+			truncated: run.contextTruncated === true,
+		},
+		resultFormat: run.resultFormat ?? "text",
+		structuredResult: run.structuredResult,
+		telemetry: run.telemetry,
 		currentTask: run.currentTask ? boundedPrivateText(run.currentTask, 2 * 1024) : undefined,
 		error: run.error ? boundedPrivateText(run.error, 2 * 1024) : undefined,
 		target: run.target
@@ -370,6 +435,7 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 	const completion = inspectCompletionDeliverySettings();
 	const parallelLimit = inspectBlockingParallelLimitSettings();
 	const detachedLimits = inspectStatefulLimitSettings();
+	const transport = inspectStatefulTransportSettings();
 	const configuredDetachedLimits = detachedLimits.values
 		? Object.fromEntries(
 				Object.entries(detachedLimits.values).map(([field, snapshot]) => [field, snapshot.value]),
@@ -386,6 +452,8 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 		configuredWorkflowSource: configured.source,
 		stateful,
 		statefulLimits: stateful.limits,
+		configuredTransport: transport.value,
+		configuredTransportSource: transport.source,
 		configuredStatefulLimits: configuredDetachedLimits,
 		configuredStatefulLimitSources: configuredDetachedLimitSources,
 		configuredCompletionDelivery: completion.value,
@@ -409,7 +477,8 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 			cwdPolicy.error ||
 			completion.error ||
 			parallelLimit.error ||
-			detachedLimits.error
+			detachedLimits.error ||
+			transport.error
 				? boundedPrivateText(
 						configured.error ??
 							resources.error ??
@@ -417,11 +486,38 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 							completion.error ??
 							parallelLimit.error ??
 							detachedLimits.error ??
+							transport.error ??
 							"",
 						2 * 1024,
 					)
 				: undefined,
 	};
+}
+
+async function inspectInProcessCapability(): Promise<{ error?: string }> {
+	try {
+		const moduleSpecifier = "@earendil-works/pi-coding-agent";
+		const core = await import(moduleSpecifier);
+		for (const name of [
+			"createAgentSessionServices",
+			"createAgentSessionFromServices",
+			"resolveCliModel",
+		] as const) {
+			if (typeof core[name] !== "function") return { error: `Pi core does not export ${name}()` };
+		}
+		return {};
+	} catch (error) {
+		return { error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function inspectRpcCapability(): { error?: string } {
+	try {
+		resolvePiInvocation(["--mode", "rpc", "--no-session"]);
+		return {};
+	} catch (error) {
+		return { error: error instanceof Error ? error.message : String(error) };
+	}
 }
 
 function availableModelCount(ctx: ExtensionContext): number {
@@ -480,6 +576,24 @@ function requiredString(value: unknown, action: string, field: string): string {
 		throw new Error(`subagent_inspect action "${action}" requires ${field}`);
 	}
 	return value;
+}
+
+function optionalContextMode(value: unknown): ContextMode {
+	if (value === undefined) return "none";
+	if (value === "none" || value === "all" || value === "summary") return value;
+	if (typeof value === "number" && Number.isSafeInteger(value) && value >= 1) return value;
+	throw new Error("subagent_inspect context must be none, all, summary, or a positive integer");
+}
+
+function optionalStringArray(value: unknown, field: string): string[] | undefined {
+	if (value === undefined) return undefined;
+	if (
+		!Array.isArray(value) ||
+		!value.every((item) => typeof item === "string" && item.length > 0)
+	) {
+		throw new Error(`subagent_inspect ${field} must be an array of non-empty strings`);
+	}
+	return [...value];
 }
 
 function optionalLimit(value: unknown, defaultValue: number): number {

--- a/packages/pi-subagents/src/inspect.ts
+++ b/packages/pi-subagents/src/inspect.ts
@@ -364,6 +364,8 @@ function projectRun(run: AgentRunInspectionDetail, ctx: ExtensionContext): Recor
 		cwd: safeDisplayPath(run.cwd, ctx.cwd),
 		workspaceMode: run.workspaceMode ?? "shared",
 		thinkingLevel: run.thinkingLevel,
+		timeoutMs: run.timeoutMs,
+		currentTimeoutMs: run.currentTimeoutMs,
 		context: {
 			turns: run.contextTurns ?? 0,
 			sources: run.contextSources ?? 0,

--- a/packages/pi-subagents/src/params.ts
+++ b/packages/pi-subagents/src/params.ts
@@ -5,7 +5,7 @@ import { MAX_CONFIGURABLE_PARALLEL_TASKS, MAX_SUBAGENT_TIMEOUT_MS } from "./limi
 
 const TimeoutMs = Type.Number({
 	description:
-		"Hard timeout in milliseconds for each subagent subprocess. Defaults to PI_SUBAGENT_TIMEOUT_MS or 600000.",
+		"Work deadline in milliseconds selected for the task difficulty. On expiry, Pi aborts the work and makes one separately bounded summary attempt. Defaults to PI_SUBAGENT_TIMEOUT_MS or 600000.",
 	minimum: 1,
 	maximum: MAX_SUBAGENT_TIMEOUT_MS,
 });

--- a/packages/pi-subagents/src/persistence.ts
+++ b/packages/pi-subagents/src/persistence.ts
@@ -6,6 +6,7 @@ import { projectAgentRecords } from "./agent-projection.js";
 import { isThinkingLevel } from "./agents.js";
 import { redactPrivateText } from "./context.js";
 import type { ManagedAgent } from "./registry.js";
+import { SUBAGENT_RESULT_FORMATS } from "./result-contract.js";
 import { resolveStatefulLimits } from "./stateful-limits.js";
 
 const STATE_VERSION = 2;
@@ -119,6 +120,8 @@ function sanitizeAgent(agent: ManagedAgent): ManagedAgent {
 		state: "idle",
 		currentTask: undefined,
 		currentMailboxMessageIds: undefined,
+		telemetry: undefined,
+		structuredResult: undefined,
 		context: agent.context ? redactPrivateText(agent.context) : undefined,
 		error: agent.error ? redactPrivateText(agent.error) : undefined,
 		history: agent.history.map((turn) => ({
@@ -148,6 +151,15 @@ function isStoredState(value: unknown): value is StoredState {
 			Number.isFinite(record.updatedAt) &&
 			(record.parentId === undefined || typeof record.parentId === "string") &&
 			(record.thinkingLevel === undefined || isThinkingLevel(record.thinkingLevel)) &&
+			(record.contextTurns === undefined || isNonNegativeInteger(record.contextTurns)) &&
+			(record.contextBytes === undefined || isNonNegativeInteger(record.contextBytes)) &&
+			(record.spawnIdempotencyKey === undefined ||
+				(typeof record.spawnIdempotencyKey === "string" &&
+					record.spawnIdempotencyKey.length > 0 &&
+					record.spawnIdempotencyKey.length <= 256)) &&
+			(record.spawnRequestHash === undefined || isSha256(record.spawnRequestHash)) &&
+			(record.resultFormat === undefined ||
+				SUBAGENT_RESULT_FORMATS.includes(record.resultFormat)) &&
 			(record.workspaceMode === undefined || record.workspaceMode === "worktree") &&
 			(record.target === undefined || isTargetPolicyAudit(record.target)) &&
 			(record.children === undefined ||
@@ -159,6 +171,14 @@ function isStoredState(value: unknown): value is StoredState {
 				(Array.isArray(record.mailbox) && record.mailbox.every(isMailboxMessage)))
 		);
 	});
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isSha256(value: unknown): value is string {
+	return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value);
 }
 
 function isTargetPolicyAudit(value: unknown): boolean {

--- a/packages/pi-subagents/src/persistence.ts
+++ b/packages/pi-subagents/src/persistence.ts
@@ -5,6 +5,7 @@ import { getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-ag
 import { projectAgentRecords } from "./agent-projection.js";
 import { isThinkingLevel } from "./agents.js";
 import { redactPrivateText } from "./context.js";
+import { MAX_SUBAGENT_TIMEOUT_MS } from "./limits.js";
 import type { ManagedAgent } from "./registry.js";
 import { SUBAGENT_RESULT_FORMATS } from "./result-contract.js";
 import { resolveStatefulLimits } from "./stateful-limits.js";
@@ -119,6 +120,7 @@ function sanitizeAgent(agent: ManagedAgent): ManagedAgent {
 		})),
 		state: "idle",
 		currentTask: undefined,
+		currentTimeoutMs: undefined,
 		currentMailboxMessageIds: undefined,
 		telemetry: undefined,
 		structuredResult: undefined,
@@ -151,6 +153,7 @@ function isStoredState(value: unknown): value is StoredState {
 			Number.isFinite(record.updatedAt) &&
 			(record.parentId === undefined || typeof record.parentId === "string") &&
 			(record.thinkingLevel === undefined || isThinkingLevel(record.thinkingLevel)) &&
+			(record.timeoutMs === undefined || isTurnTimeout(record.timeoutMs)) &&
 			(record.contextTurns === undefined || isNonNegativeInteger(record.contextTurns)) &&
 			(record.contextBytes === undefined || isNonNegativeInteger(record.contextBytes)) &&
 			(record.spawnIdempotencyKey === undefined ||
@@ -175,6 +178,15 @@ function isStoredState(value: unknown): value is StoredState {
 
 function isNonNegativeInteger(value: unknown): value is number {
 	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isTurnTimeout(value: unknown): value is number {
+	return (
+		typeof value === "number" &&
+		Number.isSafeInteger(value) &&
+		value >= 1 &&
+		value <= MAX_SUBAGENT_TIMEOUT_MS
+	);
 }
 
 function isSha256(value: unknown): value is string {

--- a/packages/pi-subagents/src/prompt-resources.ts
+++ b/packages/pi-subagents/src/prompt-resources.ts
@@ -1,0 +1,38 @@
+import {
+	DefaultResourceLoader,
+	getAgentDir,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { assertPiPromptSourcesAreReadableFiles } from "./prompt-source-safety.js";
+
+export interface PiPromptResources {
+	systemPrompt?: string;
+	appendSystemPromptPaths: string[];
+}
+
+/** Resolve Pi-owned prompt files without loading target packages, extensions, or settings. */
+export async function resolvePiPromptResources(
+	cwd: string,
+	projectTrusted: boolean,
+	agentDir = getAgentDir(),
+): Promise<PiPromptResources> {
+	assertPiPromptSourcesAreReadableFiles(cwd, agentDir, projectTrusted, [
+		"SYSTEM.md",
+		"APPEND_SYSTEM.md",
+	]);
+	const loader = new DefaultResourceLoader({
+		cwd,
+		agentDir,
+		settingsManager: SettingsManager.inMemory({}, { projectTrusted }),
+		noExtensions: true,
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+	});
+	await loader.reload();
+	return {
+		systemPrompt: loader.getSystemPrompt(),
+		appendSystemPromptPaths: loader.getAppendSystemPromptSources().map((source) => source.path),
+	};
+}

--- a/packages/pi-subagents/src/registry-types.ts
+++ b/packages/pi-subagents/src/registry-types.ts
@@ -44,6 +44,8 @@ export interface ManagedAgent {
 	cwd: string;
 	agentScope?: "user" | "project" | "both";
 	thinkingLevel?: SubagentThinkingLevel;
+	timeoutMs?: number;
+	currentTimeoutMs?: number;
 	currentTask?: string;
 	history: AgentTurn[];
 	error?: string;
@@ -77,6 +79,8 @@ export interface AgentRunInspectionSummary {
 export interface AgentRunInspectionDetail extends AgentRunInspectionSummary {
 	cwd: string;
 	thinkingLevel?: SubagentThinkingLevel;
+	timeoutMs?: number;
+	currentTimeoutMs?: number;
 	currentTask?: string;
 	error?: string;
 	workspaceMode?: "worktree";

--- a/packages/pi-subagents/src/registry-types.ts
+++ b/packages/pi-subagents/src/registry-types.ts
@@ -1,0 +1,131 @@
+import type { SubagentThinkingLevel } from "./agents.js";
+import type { TargetPolicyAudit } from "./cwd-policy.js";
+import type { StructuredSubagentResult, SubagentResultFormat } from "./result-contract.js";
+import type { TransportTelemetry } from "./transport-types.js";
+
+export type AgentLifecycleState =
+	| "starting"
+	| "running"
+	| "idle"
+	| "completed"
+	| "interrupted"
+	| "failed"
+	| "closed";
+
+export interface AgentTurn {
+	task: string;
+	output: string;
+	startedAt: number;
+	completedAt: number;
+	exitCode: number;
+	truncated?: boolean;
+}
+
+export interface AgentMailboxMessage {
+	id: string;
+	senderId: string;
+	recipientId: string;
+	content: string;
+	createdAt: number;
+	readAt?: number;
+	deduplicationKey?: string;
+}
+
+export interface ManagedAgent {
+	id: string;
+	agent: string;
+	parentId?: string;
+	rootId: string;
+	depth: number;
+	children: string[];
+	state: AgentLifecycleState;
+	createdAt: number;
+	updatedAt: number;
+	cwd: string;
+	agentScope?: "user" | "project" | "both";
+	thinkingLevel?: SubagentThinkingLevel;
+	currentTask?: string;
+	history: AgentTurn[];
+	error?: string;
+	context?: string;
+	contextSourceIds?: string[];
+	contextTruncated?: boolean;
+	contextTurns?: number;
+	contextBytes?: number;
+	workspaceMode?: "worktree";
+	spawnIdempotencyKey?: string;
+	spawnRequestHash?: string;
+	resultFormat?: SubagentResultFormat;
+	structuredResult?: StructuredSubagentResult;
+	telemetry?: TransportTelemetry;
+	target?: TargetPolicyAudit;
+	policy?: { inherited: string[]; overridden: string[]; unsupported: string[] };
+	mailbox: AgentMailboxMessage[];
+	currentMailboxMessageIds?: string[];
+}
+
+export interface AgentRunInspectionSummary {
+	id: string;
+	agent: string;
+	state: AgentLifecycleState;
+	createdAt: number;
+	updatedAt: number;
+	historyCount: number;
+	unreadMessages: number;
+}
+
+export interface AgentRunInspectionDetail extends AgentRunInspectionSummary {
+	cwd: string;
+	thinkingLevel?: SubagentThinkingLevel;
+	currentTask?: string;
+	error?: string;
+	workspaceMode?: "worktree";
+	contextTurns?: number;
+	contextBytes?: number;
+	contextSources?: number;
+	contextTruncated?: boolean;
+	resultFormat?: SubagentResultFormat;
+	target?: TargetPolicyAudit;
+	policy?: { inherited: string[]; overridden: string[]; unsupported: string[] };
+	structuredResult?: StructuredSubagentResult;
+	telemetry?: TransportTelemetry;
+}
+
+export interface AgentInspectionCounts {
+	activeAgents: number;
+	retainedAgents: number;
+}
+
+export interface TurnOutcome {
+	output: string;
+	exitCode: number;
+	aborted?: boolean;
+	truncated?: boolean;
+	error?: string;
+	policy?: ManagedAgent["policy"];
+	structuredResult?: StructuredSubagentResult;
+	telemetry?: TransportTelemetry;
+}
+
+export interface AgentTurnCompletion {
+	agent: ManagedAgent;
+	task: string;
+	output: string;
+	error?: string;
+}
+
+export interface AgentRegistryOptions {
+	maxAgents?: number;
+	maxActiveTurns?: number;
+	maxHistoryTurns?: number;
+	maxDepth?: number;
+	maxChildrenPerAgent?: number;
+	maxMailboxMessages?: number;
+	maxMailboxMessageBytes?: number;
+	maxTaskBytes?: number;
+	maxTurnOutputBytes?: number;
+	idleTtlMs?: number;
+	now?: () => number;
+	onChange?: (agents: ManagedAgent[]) => void | Promise<void>;
+	onTurnComplete?: (completion: AgentTurnCompletion) => void | Promise<void>;
+}

--- a/packages/pi-subagents/src/registry.ts
+++ b/packages/pi-subagents/src/registry.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "node:crypto";
 import { projectAgentRecords } from "./agent-projection.js";
 import type { SubagentThinkingLevel } from "./agents.js";
 import type { TargetPolicyAudit } from "./cwd-policy.js";
-import { DEFAULT_MAX_CONTEXT_BYTES, DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
+import {
+	DEFAULT_MAX_CONTEXT_BYTES,
+	DEFAULT_MAX_OUTPUT_BYTES,
+	MAX_SUBAGENT_TIMEOUT_MS,
+	truncateUtf8,
+} from "./limits.js";
 import type {
 	AgentInspectionCounts,
 	AgentMailboxMessage,
@@ -35,6 +40,13 @@ function positiveInteger(value: number, label: string): number {
 function nonNegativeInteger(value: number, label: string): number {
 	if (!Number.isSafeInteger(value) || value < 0) {
 		throw new Error(`${label} must be a non-negative safe integer`);
+	}
+	return value;
+}
+
+function validateTurnTimeout(value: number): number {
+	if (!Number.isSafeInteger(value) || value < 1 || value > MAX_SUBAGENT_TIMEOUT_MS) {
+		throw new Error(`Subagent timeoutMs must be between 1 and ${MAX_SUBAGENT_TIMEOUT_MS}`);
 	}
 	return value;
 }
@@ -141,6 +153,7 @@ export class AgentRegistry {
 				rootId,
 				depth,
 				currentTask: undefined,
+				currentTimeoutMs: undefined,
 				currentMailboxMessageIds: undefined,
 				children: [],
 				contextSourceIds: [...(record.contextSourceIds ?? [])],
@@ -163,6 +176,7 @@ export class AgentRegistry {
 		cwd: string;
 		agentScope?: "user" | "project" | "both";
 		thinkingLevel?: SubagentThinkingLevel;
+		timeoutMs?: number;
 		parentId?: string;
 		context?: string;
 		contextSourceIds?: string[];
@@ -176,6 +190,7 @@ export class AgentRegistry {
 		target?: TargetPolicyAudit;
 	}): Promise<ManagedAgent> {
 		if (!input.task.trim()) throw new Error("Subagent tasks cannot be empty");
+		if (input.timeoutMs !== undefined) validateTurnTimeout(input.timeoutMs);
 		const existing = this.findBySpawnIdempotencyKey(
 			input.spawnIdempotencyKey,
 			input.spawnRequestHash,
@@ -216,6 +231,8 @@ export class AgentRegistry {
 			cwd: input.cwd,
 			agentScope: input.agentScope,
 			thinkingLevel: input.thinkingLevel,
+			timeoutMs: input.timeoutMs,
+			currentTimeoutMs: input.timeoutMs,
 			currentTask: task,
 			history: [],
 			mailbox: [],
@@ -257,8 +274,13 @@ export class AgentRegistry {
 		return this.copy(existing);
 	}
 
-	async followUp(id: string, task: string): Promise<ManagedAgent> {
+	async followUp(
+		id: string,
+		task: string,
+		options: { timeoutMs?: number } = {},
+	): Promise<ManagedAgent> {
 		if (!task.trim()) throw new Error("Subagent tasks cannot be empty");
+		if (options.timeoutMs !== undefined) validateTurnTimeout(options.timeoutMs);
 		const boundedTask = truncateUtf8(task, this.maxTaskBytes).text;
 		const agent = this.require(id);
 		if (!["idle", "completed", "interrupted", "failed"].includes(agent.state)) {
@@ -268,7 +290,7 @@ export class AgentRegistry {
 		const readAt = this.now();
 		for (const message of unread) message.readAt = readAt;
 		agent.currentMailboxMessageIds = unread.map((message) => message.id);
-		this.startTurn(agent, boundedTask);
+		this.startTurn(agent, boundedTask, options.timeoutMs);
 		return this.copy(agent);
 	}
 
@@ -367,6 +389,7 @@ export class AgentRegistry {
 				const [entry] = this.queue.splice(index, 1);
 				agent.state = "interrupted";
 				agent.currentTask = undefined;
+				agent.currentTimeoutMs = undefined;
 				agent.currentMailboxMessageIds = undefined;
 				agent.updatedAt = this.now();
 				const completion: AgentTurnCompletion = {
@@ -430,6 +453,7 @@ export class AgentRegistry {
 			if (parent) parent.children = parent.children.filter((childId) => childId !== id);
 		}
 		agent.currentTask = undefined;
+		agent.currentTimeoutMs = undefined;
 		agent.currentMailboxMessageIds = undefined;
 		let releaseError: unknown;
 		try {
@@ -460,6 +484,7 @@ export class AgentRegistry {
 		for (const entry of this.queue.splice(0)) {
 			entry.agent.state = "idle";
 			entry.agent.currentTask = undefined;
+			entry.agent.currentTimeoutMs = undefined;
 			entry.agent.currentMailboxMessageIds = undefined;
 			entry.resolve(entry.agent);
 			this.running.delete(entry.agent.id);
@@ -470,6 +495,7 @@ export class AgentRegistry {
 			if (agent.state !== "closed") {
 				agent.state = "idle";
 				agent.currentTask = undefined;
+				agent.currentTimeoutMs = undefined;
 				agent.currentMailboxMessageIds = undefined;
 			}
 		}
@@ -507,6 +533,8 @@ export class AgentRegistry {
 			...this.inspectSummary(agent),
 			cwd: agent.cwd,
 			thinkingLevel: agent.thinkingLevel,
+			timeoutMs: agent.timeoutMs,
+			currentTimeoutMs: agent.currentTimeoutMs,
 			currentTask: agent.currentTask,
 			error: agent.error,
 			workspaceMode: agent.workspaceMode,
@@ -566,10 +594,11 @@ export class AgentRegistry {
 		return removed.length;
 	}
 
-	private startTurn(agent: ManagedAgent, task: string): void {
+	private startTurn(agent: ManagedAgent, task: string, timeoutMs?: number): void {
 		agent.state = "starting";
 		agent.error = undefined;
 		agent.currentTask = task;
+		agent.currentTimeoutMs = timeoutMs ?? agent.timeoutMs;
 		agent.structuredResult = undefined;
 		agent.updatedAt = this.now();
 		agent.telemetry = {
@@ -705,6 +734,7 @@ export class AgentRegistry {
 					}
 				}
 				agent.currentTask = undefined;
+				agent.currentTimeoutMs = undefined;
 				agent.currentMailboxMessageIds = undefined;
 				agent.updatedAt = this.now();
 				this.controllers.delete(agent.id);

--- a/packages/pi-subagents/src/registry.ts
+++ b/packages/pi-subagents/src/registry.ts
@@ -3,121 +3,27 @@ import { projectAgentRecords } from "./agent-projection.js";
 import type { SubagentThinkingLevel } from "./agents.js";
 import type { TargetPolicyAudit } from "./cwd-policy.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
+import type {
+	AgentInspectionCounts,
+	AgentMailboxMessage,
+	AgentRegistryOptions,
+	AgentRunInspectionDetail,
+	AgentRunInspectionSummary,
+	AgentTurnCompletion,
+	ManagedAgent,
+} from "./registry-types.js";
+import {
+	parseStructuredSubagentResult,
+	type StructuredSubagentResult,
+	type SubagentResultFormat,
+} from "./result-contract.js";
 import { resolveStatefulLimits } from "./stateful-limits.js";
 import { type AgentTurnRunner, normalizeTransport, type SubagentTransport } from "./transport.js";
+import type { TransportTelemetry } from "./transport-types.js";
 
 const DEFAULT_STATEFUL_LIMITS = resolveStatefulLimits();
 
-export type AgentLifecycleState =
-	| "starting"
-	| "running"
-	| "idle"
-	| "completed"
-	| "interrupted"
-	| "failed"
-	| "closed";
-
-export interface AgentTurn {
-	task: string;
-	output: string;
-	startedAt: number;
-	completedAt: number;
-	exitCode: number;
-	truncated?: boolean;
-}
-
-export interface AgentMailboxMessage {
-	id: string;
-	senderId: string;
-	recipientId: string;
-	content: string;
-	createdAt: number;
-	readAt?: number;
-	deduplicationKey?: string;
-}
-
-export interface ManagedAgent {
-	id: string;
-	agent: string;
-	parentId?: string;
-	rootId: string;
-	depth: number;
-	children: string[];
-	state: AgentLifecycleState;
-	createdAt: number;
-	updatedAt: number;
-	cwd: string;
-	agentScope?: "user" | "project" | "both";
-	thinkingLevel?: SubagentThinkingLevel;
-	currentTask?: string;
-	history: AgentTurn[];
-	error?: string;
-	context?: string;
-	contextSourceIds?: string[];
-	contextTruncated?: boolean;
-	workspaceMode?: "worktree";
-	target?: TargetPolicyAudit;
-	policy?: { inherited: string[]; overridden: string[]; unsupported: string[] };
-	mailbox: AgentMailboxMessage[];
-	currentMailboxMessageIds?: string[];
-}
-
-export interface AgentRunInspectionSummary {
-	id: string;
-	agent: string;
-	state: AgentLifecycleState;
-	createdAt: number;
-	updatedAt: number;
-	historyCount: number;
-	unreadMessages: number;
-}
-
-export interface AgentRunInspectionDetail extends AgentRunInspectionSummary {
-	cwd: string;
-	thinkingLevel?: SubagentThinkingLevel;
-	currentTask?: string;
-	error?: string;
-	workspaceMode?: "worktree";
-	target?: TargetPolicyAudit;
-	policy?: { inherited: string[]; overridden: string[]; unsupported: string[] };
-}
-
-export interface AgentInspectionCounts {
-	activeAgents: number;
-	retainedAgents: number;
-}
-
-export interface TurnOutcome {
-	output: string;
-	exitCode: number;
-	aborted?: boolean;
-	truncated?: boolean;
-	error?: string;
-	policy?: ManagedAgent["policy"];
-}
-
-export interface AgentTurnCompletion {
-	agent: ManagedAgent;
-	task: string;
-	output: string;
-	error?: string;
-}
-
-export interface AgentRegistryOptions {
-	maxAgents?: number;
-	maxActiveTurns?: number;
-	maxHistoryTurns?: number;
-	maxDepth?: number;
-	maxChildrenPerAgent?: number;
-	maxMailboxMessages?: number;
-	maxMailboxMessageBytes?: number;
-	maxTaskBytes?: number;
-	maxTurnOutputBytes?: number;
-	idleTtlMs?: number;
-	now?: () => number;
-	onChange?: (agents: ManagedAgent[]) => void | Promise<void>;
-	onTurnComplete?: (completion: AgentTurnCompletion) => void | Promise<void>;
-}
+export type * from "./registry-types.js";
 
 function positiveInteger(value: number, label: string): number {
 	if (!Number.isSafeInteger(value) || value < 1) {
@@ -261,10 +167,20 @@ export class AgentRegistry {
 		context?: string;
 		contextSourceIds?: string[];
 		contextTruncated?: boolean;
+		contextTurns?: number;
+		contextBytes?: number;
 		workspaceMode?: "worktree";
+		spawnIdempotencyKey?: string;
+		spawnRequestHash?: string;
+		resultFormat?: SubagentResultFormat;
 		target?: TargetPolicyAudit;
 	}): Promise<ManagedAgent> {
 		if (!input.task.trim()) throw new Error("Subagent tasks cannot be empty");
+		const existing = this.findBySpawnIdempotencyKey(
+			input.spawnIdempotencyKey,
+			input.spawnRequestHash,
+		);
+		if (existing) return existing;
 		const task = truncateUtf8(input.task, this.maxTaskBytes).text;
 		const expired = this.evictExpired();
 		let expiryReleaseError: unknown;
@@ -306,7 +222,12 @@ export class AgentRegistry {
 			context: input.context,
 			contextSourceIds: input.contextSourceIds,
 			contextTruncated: input.contextTruncated,
+			contextTurns: input.contextTurns,
+			contextBytes: input.contextBytes,
 			workspaceMode: input.workspaceMode,
+			spawnIdempotencyKey: input.spawnIdempotencyKey,
+			spawnRequestHash: input.spawnRequestHash,
+			resultFormat: input.resultFormat,
 			target: input.target,
 		};
 		this.agents.set(record.id, record);
@@ -317,6 +238,23 @@ export class AgentRegistry {
 		await this.changed();
 		this.startTurn(record, task);
 		return this.copy(record);
+	}
+
+	findBySpawnIdempotencyKey(
+		key: string | undefined,
+		requestHash: string | undefined,
+	): ManagedAgent | undefined {
+		if (!key) return undefined;
+		const existing = [...this.agents.values()].find(
+			(agent) => agent.state !== "closed" && agent.spawnIdempotencyKey === key,
+		);
+		if (!existing) return undefined;
+		if (!requestHash || existing.spawnRequestHash !== requestHash) {
+			throw new Error(
+				"The subagent_spawn idempotencyKey was already used with different parameters",
+			);
+		}
+		return this.copy(existing);
 	}
 
 	async followUp(id: string, task: string): Promise<ManagedAgent> {
@@ -572,6 +510,11 @@ export class AgentRegistry {
 			currentTask: agent.currentTask,
 			error: agent.error,
 			workspaceMode: agent.workspaceMode,
+			contextTurns: agent.contextTurns,
+			contextBytes: agent.contextBytes,
+			contextSources: agent.contextSourceIds?.length,
+			contextTruncated: agent.contextTruncated,
+			resultFormat: agent.resultFormat,
 			target: agent.target ? { ...agent.target, trust: { ...agent.target.trust } } : undefined,
 			policy: agent.policy
 				? {
@@ -580,6 +523,10 @@ export class AgentRegistry {
 						unsupported: [...agent.policy.unsupported],
 					}
 				: undefined,
+			structuredResult: agent.structuredResult
+				? copyStructuredResult(agent.structuredResult)
+				: undefined,
+			telemetry: agent.telemetry ? copyTelemetry(agent.telemetry) : undefined,
 		};
 	}
 
@@ -594,6 +541,16 @@ export class AgentRegistry {
 	get(id: string): ManagedAgent | undefined {
 		const agent = this.agents.get(id);
 		return agent ? this.copy(agent) : undefined;
+	}
+
+	markCompletionDelivered(id: string, deliveredAt: number): void {
+		const agent = this.agents.get(id);
+		if (!agent?.telemetry) return;
+		agent.telemetry = {
+			...agent.telemetry,
+			updatedAt: deliveredAt,
+			timing: { ...agent.telemetry.timing, completionDeliveredAt: deliveredAt },
+		};
 	}
 
 	async sweepExpired(): Promise<number> {
@@ -613,13 +570,21 @@ export class AgentRegistry {
 		agent.state = "starting";
 		agent.error = undefined;
 		agent.currentTask = task;
+		agent.structuredResult = undefined;
 		agent.updatedAt = this.now();
+		agent.telemetry = {
+			phase: "queued",
+			queuePosition: this.queue.length + 1,
+			updatedAt: agent.updatedAt,
+			timing: { queuedAt: agent.updatedAt },
+		};
 		let resolveQueued!: (agent: ManagedAgent) => void;
 		const completion = new Promise<ManagedAgent>((resolve) => {
 			resolveQueued = resolve;
 		});
 		this.running.set(agent.id, completion);
 		this.queue.push({ agent, task, resolve: resolveQueued });
+		this.updateQueuePositions();
 		void this.changed();
 		this.pumpQueue();
 	}
@@ -629,6 +594,7 @@ export class AgentRegistry {
 			const next = this.queue.shift();
 			if (!next) return;
 			this.runQueuedTurn(next.agent, next.task, next.resolve);
+			this.updateQueuePositions();
 		}
 	}
 
@@ -647,7 +613,16 @@ export class AgentRegistry {
 		let completionOutput = "";
 		let completionError: string | undefined;
 		void this.transport
-			.runTurn(this.copy(agent), task, controller.signal)
+			.runTurn(this.copy(agent), task, controller.signal, (progress) => {
+				agent.telemetry = {
+					...progress,
+					queuePosition: undefined,
+					timing: {
+						queuedAt: agent.telemetry?.timing.queuedAt,
+						...progress.timing,
+					},
+				};
+			})
 			.then(async (outcome) => {
 				const output = truncateUtf8(outcome.output, this.maxTurnOutputBytes).text;
 				const error = outcome.error
@@ -669,6 +644,20 @@ export class AgentRegistry {
 						: "failed";
 				agent.error = error;
 				agent.policy = outcome.policy;
+				agent.telemetry = outcome.telemetry
+					? {
+							...outcome.telemetry,
+							timing: {
+								queuedAt: agent.telemetry?.timing.queuedAt,
+								...outcome.telemetry.timing,
+							},
+						}
+					: agent.telemetry;
+				agent.structuredResult =
+					outcome.structuredResult ??
+					(agent.resultFormat === "structured-v1"
+						? parseStructuredSubagentResult(output)
+						: undefined);
 				completionOutput = output;
 				completionError = error;
 				completionContent = output || error || `${agent.id} ${agent.state}`;
@@ -688,6 +677,16 @@ export class AgentRegistry {
 					exitCode: controller.signal.aborted ? 130 : 1,
 				});
 				agent.history = agent.history.slice(-this.maxHistoryTurns);
+				agent.telemetry = {
+					...(agent.telemetry ?? {
+						phase: "failed",
+						updatedAt: this.now(),
+						timing: { queuedAt: startedAt },
+					}),
+					phase: controller.signal.aborted ? "interrupted" : "failed",
+					failurePhase: agent.telemetry?.phase ?? "running",
+					updatedAt: this.now(),
+				};
 				completionError = agent.error;
 				completionContent = agent.error;
 				return agent;
@@ -715,6 +714,17 @@ export class AgentRegistry {
 				await this.notifyTurnComplete(turnCompletion);
 				await this.changed();
 			});
+	}
+
+	private updateQueuePositions(): void {
+		for (const [index, entry] of this.queue.entries()) {
+			if (!entry.agent.telemetry) continue;
+			entry.agent.telemetry = {
+				...entry.agent.telemetry,
+				queuePosition: index + 1,
+				updatedAt: this.now(),
+			};
+		}
 	}
 
 	private enqueueMessage(
@@ -872,6 +882,28 @@ export class AgentRegistry {
 						unsupported: [...agent.policy.unsupported],
 					}
 				: undefined,
+			structuredResult: agent.structuredResult
+				? copyStructuredResult(agent.structuredResult)
+				: undefined,
+			telemetry: agent.telemetry ? copyTelemetry(agent.telemetry) : undefined,
 		};
 	}
+}
+
+function copyStructuredResult(value: StructuredSubagentResult): StructuredSubagentResult {
+	return {
+		...value,
+		evidence: [...value.evidence],
+		changes: [...value.changes],
+		verification: [...value.verification],
+		risks: [...value.risks],
+	};
+}
+
+function copyTelemetry(value: TransportTelemetry): TransportTelemetry {
+	return {
+		...value,
+		timing: { ...value.timing },
+		usage: value.usage ? { ...value.usage } : undefined,
+	};
 }

--- a/packages/pi-subagents/src/result-contract.ts
+++ b/packages/pi-subagents/src/result-contract.ts
@@ -1,0 +1,85 @@
+import { redactPrivateText } from "./context.js";
+import { DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
+
+export const SUBAGENT_RESULT_FORMATS = ["text", "structured-v1"] as const;
+export type SubagentResultFormat = (typeof SUBAGENT_RESULT_FORMATS)[number];
+
+export interface StructuredSubagentResult {
+	version: "pi-subagents:result:v1";
+	summary: string;
+	evidence: string[];
+	changes: string[];
+	verification: string[];
+	risks: string[];
+}
+
+const MAX_FIELD_BYTES = 8 * 1024;
+const MAX_ITEMS = 50;
+
+export function structuredResultInstruction(format: SubagentResultFormat | undefined): string {
+	if (format !== "structured-v1") return "";
+	return [
+		"Return the final answer as one JSON object and no surrounding prose.",
+		'Use exactly version "pi-subagents:result:v1" and fields summary, evidence, changes, verification, and risks.',
+		"summary must be a string and the other fields must be arrays of strings.",
+	].join(" ");
+}
+
+export function appendResultInstruction(
+	prompt: string,
+	format: SubagentResultFormat | undefined,
+	maxBytes = DEFAULT_MAX_OUTPUT_BYTES,
+): string {
+	const instruction = structuredResultInstruction(format);
+	if (!instruction) return prompt;
+	const suffix = `\n\nResult contract:\n${instruction}`;
+	const suffixBytes = Buffer.byteLength(suffix, "utf8");
+	const boundedPrompt = truncateUtf8(prompt, Math.max(0, maxBytes - suffixBytes)).text;
+	return `${boundedPrompt}${suffix}`;
+}
+
+export function parseStructuredSubagentResult(text: string): StructuredSubagentResult | undefined {
+	if (Buffer.byteLength(text, "utf8") > DEFAULT_MAX_OUTPUT_BYTES) return undefined;
+	const source = unwrapJsonFence(text).trim();
+	if (!source.startsWith("{") || !source.endsWith("}")) return undefined;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(source);
+	} catch {
+		return undefined;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+	const value = parsed as Record<string, unknown>;
+	if (value.version !== "pi-subagents:result:v1" || typeof value.summary !== "string") {
+		return undefined;
+	}
+	const evidence = stringArray(value.evidence);
+	const changes = stringArray(value.changes);
+	const verification = stringArray(value.verification);
+	const risks = stringArray(value.risks);
+	if (!evidence || !changes || !verification || !risks) return undefined;
+	return {
+		version: "pi-subagents:result:v1",
+		summary: bounded(value.summary),
+		evidence,
+		changes,
+		verification,
+		risks,
+	};
+}
+
+function stringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || value.length > MAX_ITEMS) return undefined;
+	if (!value.every((item) => typeof item === "string")) return undefined;
+	return value.map((item) => bounded(item));
+}
+
+function bounded(value: string): string {
+	return truncateUtf8(redactPrivateText(value), MAX_FIELD_BYTES).text;
+}
+
+function unwrapJsonFence(value: string): string {
+	const trimmed = value.trim();
+	const match = /^```(?:json)?\s*\n([\s\S]*?)\n```$/iu.exec(trimmed);
+	return match?.[1] ?? trimmed;
+}

--- a/packages/pi-subagents/src/rpc-timeout-finalization.ts
+++ b/packages/pi-subagents/src/rpc-timeout-finalization.ts
@@ -1,0 +1,196 @@
+import { DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
+import type { SubagentResultFormat } from "./result-contract.js";
+import {
+	buildTimeoutFinalizationPrompt,
+	resolveTimeoutFinalizationMs,
+} from "./timeout-finalization.js";
+
+interface RpcTimeoutFinalizationClient {
+	prompt(message: string, timeoutMs?: number): Promise<void>;
+	abort(): Promise<void>;
+	onEvent(listener: (event: unknown) => void): () => void;
+	onClose(listener: (error: Error) => void): () => void;
+}
+
+interface RpcSummaryCapture {
+	output: string;
+	partial: string;
+	stopReason?: string;
+	error?: string;
+}
+
+export interface RpcTimeoutFinalizationOptions {
+	client: RpcTimeoutFinalizationClient;
+	task: string;
+	partialOutput: string;
+	resultFormat?: SubagentResultFormat;
+	signal: AbortSignal;
+	workTimeoutMs: number;
+	finalizationTimeoutMs?: number;
+	abortGraceMs: number;
+	resetCapture(): void;
+	getCapture(): RpcSummaryCapture;
+	release(): Promise<void>;
+}
+
+export interface RpcTimeoutFinalizationResult {
+	output: string;
+	truncated: boolean;
+	error?: string;
+}
+
+export async function finalizeTimedOutRpcTurn(
+	options: RpcTimeoutFinalizationOptions,
+): Promise<RpcTimeoutFinalizationResult> {
+	options.resetCapture();
+	let settleResolve!: () => void;
+	let settleReject!: (error: Error) => void;
+	const settled = new Promise<void>((resolve, reject) => {
+		settleResolve = resolve;
+		settleReject = reject;
+	});
+	void settled.catch(() => undefined);
+	const unsubscribeEvent = options.client.onEvent((event) => {
+		if (eventType(event) === "agent_settled") settleResolve();
+	});
+	const unsubscribeClose = options.client.onClose(settleReject);
+	let error: string | undefined;
+	try {
+		const finalizationMs = resolveTimeoutFinalizationMs(
+			options.workTimeoutMs,
+			options.finalizationTimeoutMs,
+		);
+		const deadline = Date.now() + finalizationMs;
+		await raceWithAbort(
+			() =>
+				options.client.prompt(
+					buildTimeoutFinalizationPrompt({
+						task: options.task,
+						partialOutput: options.partialOutput,
+						resultFormat: options.resultFormat,
+					}),
+					remainingMs(deadline),
+				),
+			options.signal,
+			remainingMs(deadline),
+		);
+		const settlement = await waitForSettlement(settled, options.signal, remainingMs(deadline));
+		if (settlement !== "settled") {
+			const [abortCompleted, stopped] = await Promise.all([
+				settlesWithin(options.client.abort(), options.abortGraceMs),
+				settlesWithin(settled, options.abortGraceMs),
+			]);
+			if (!stopped) await boundedRelease(options);
+			error = [
+				`timeout summary ${settlement}`,
+				abortCompleted ? undefined : "summary abort command did not settle",
+			]
+				.filter(Boolean)
+				.join("; ");
+		}
+	} catch (caught) {
+		error = boundedError(caught);
+		await boundedRelease(options);
+	} finally {
+		unsubscribeEvent();
+		unsubscribeClose();
+	}
+	const capture = options.getCapture();
+	const output = truncateUtf8(capture.output || capture.partial, DEFAULT_MAX_OUTPUT_BYTES);
+	if (!error && (capture.stopReason === "error" || !output.text.trim())) {
+		error = capture.error || "Timeout summary produced no final text";
+	}
+	return { output: output.text, truncated: output.truncated, error };
+}
+
+function eventType(value: unknown): string | undefined {
+	return value &&
+		typeof value === "object" &&
+		typeof (value as { type?: unknown }).type === "string"
+		? ((value as { type: string }).type ?? undefined)
+		: undefined;
+}
+
+function remainingMs(deadline: number): number {
+	return Math.max(1, deadline - Date.now());
+}
+
+async function raceWithAbort<T>(
+	start: () => Promise<T>,
+	signal: AbortSignal,
+	timeoutMs: number,
+): Promise<T> {
+	if (signal.aborted) throw abortError();
+	let onAbort: (() => void) | undefined;
+	let timer: NodeJS.Timeout | undefined;
+	const aborted = new Promise<never>((_resolve, reject) => {
+		onAbort = () => reject(abortError());
+		signal.addEventListener("abort", onAbort, { once: true });
+		if (signal.aborted) onAbort();
+	});
+	const timedOut = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => reject(new Error("RPC timeout summary prompt timed out")), timeoutMs);
+	});
+	try {
+		return await Promise.race([start(), aborted, timedOut]);
+	} finally {
+		if (timer) clearTimeout(timer);
+		if (onAbort) signal.removeEventListener("abort", onAbort);
+	}
+}
+
+async function waitForSettlement(
+	settled: Promise<void>,
+	signal: AbortSignal,
+	timeoutMs: number,
+): Promise<"settled" | "aborted" | "timeout"> {
+	if (signal.aborted) return "aborted";
+	let timer: NodeJS.Timeout | undefined;
+	let onAbort: (() => void) | undefined;
+	try {
+		return await Promise.race([
+			settled.then(() => "settled" as const),
+			new Promise<"aborted">((resolve) => {
+				onAbort = () => resolve("aborted");
+				signal.addEventListener("abort", onAbort, { once: true });
+			}),
+			new Promise<"timeout">((resolve) => {
+				timer = setTimeout(() => resolve("timeout"), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+		if (onAbort) signal.removeEventListener("abort", onAbort);
+	}
+}
+
+async function boundedRelease(options: RpcTimeoutFinalizationOptions): Promise<boolean> {
+	return settlesWithin(options.release(), options.abortGraceMs + 1_000);
+}
+
+async function settlesWithin(settled: Promise<void>, timeoutMs: number): Promise<boolean> {
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			settled.then(
+				() => true,
+				() => true,
+			),
+			new Promise<boolean>((resolve) => {
+				timer = setTimeout(() => resolve(false), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+function abortError(): Error {
+	const error = new Error("RPC timeout summary aborted");
+	error.name = "AbortError";
+	return error;
+}
+
+function boundedError(error: unknown): string {
+	return truncateUtf8(error instanceof Error ? error.message : String(error), 16 * 1024).text;
+}

--- a/packages/pi-subagents/src/rpc-transport-metadata.ts
+++ b/packages/pi-subagents/src/rpc-transport-metadata.ts
@@ -1,0 +1,65 @@
+import type { AgentConfig, SubagentThinkingLevel } from "./agents.js";
+import { DEFAULT_MAX_OUTPUT_BYTES } from "./limits.js";
+import type { ManagedAgent, TurnOutcome } from "./registry.js";
+import { boundedPrivateText } from "./safe-text.js";
+import type { TransportTelemetry } from "./transport-types.js";
+
+export function modelIdentity(value: unknown): { provider?: string; model?: string } {
+	if (!value || typeof value !== "object") return {};
+	const model = value as Record<string, unknown>;
+	return {
+		provider:
+			typeof model.provider === "string" ? boundedPrivateText(model.provider, 256) : undefined,
+		model: typeof model.id === "string" ? boundedPrivateText(model.id, 256) : undefined,
+	};
+}
+
+export function normalizeThinking(value: unknown): SubagentThinkingLevel | undefined {
+	return typeof value === "string" &&
+		["off", "minimal", "low", "medium", "high", "xhigh", "max"].includes(value)
+		? (value as SubagentThinkingLevel)
+		: undefined;
+}
+
+export function rpcPolicy(
+	config: AgentConfig,
+	agent: ManagedAgent,
+): NonNullable<TurnOutcome["policy"]> {
+	return {
+		inherited: ["environment", "cwdResources"],
+		overridden: [
+			"cwd",
+			"extensions",
+			...(config.model ? ["model"] : []),
+			...(agent.thinkingLevel || config.thinkingLevel ? ["thinkingLevel"] : []),
+			...(config.tools ? ["tools"] : []),
+		],
+		unsupported: ["approvalPolicy", "sandboxProfile", "providerHeaders", "extensionState"],
+	};
+}
+
+export function interruptedRpcOutcome(
+	output: string,
+	telemetry: TransportTelemetry,
+	failurePhase: TransportTelemetry["phase"],
+): TurnOutcome {
+	return {
+		output,
+		exitCode: 130,
+		aborted: true,
+		error: "RPC subagent was aborted",
+		telemetry: {
+			...telemetry,
+			phase: "interrupted",
+			failurePhase,
+			updatedAt: Date.now(),
+		},
+	};
+}
+
+export function boundedError(error: unknown): string {
+	return boundedPrivateText(
+		error instanceof Error ? error.message : String(error),
+		DEFAULT_MAX_OUTPUT_BYTES,
+	);
+}

--- a/packages/pi-subagents/src/rpc-transport.ts
+++ b/packages/pi-subagents/src/rpc-transport.ts
@@ -1,0 +1,977 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { RpcSessionState } from "@earendil-works/pi-coding-agent";
+import {
+	type AgentConfig,
+	discoverAgents,
+	type SubagentSettings,
+	type SubagentThinkingLevel,
+} from "./agents.js";
+import {
+	buildCurrentTurnPrompt,
+	type ParentRuntimeSnapshot,
+	validateInProcessTools,
+} from "./in-process-transport.js";
+import {
+	appendBounded,
+	DEFAULT_MAX_OUTPUT_BYTES,
+	DEFAULT_MAX_STDERR_BYTES,
+	truncateUtf8,
+} from "./limits.js";
+import { type PiInvocation, resolvePiInvocation } from "./pi-invocation.js";
+import { JsonLineDecoder } from "./protocol.js";
+import type { ManagedAgent, TurnOutcome } from "./registry.js";
+import { terminateProcess } from "./runner.js";
+import { boundedPrivateText, safeTerminalText } from "./safe-text.js";
+import { readSubagentSettings } from "./settings.js";
+import { buildStatefulTurnPrompt, resolveStatefulTurnTimeout } from "./stateful-prompt.js";
+import type { SubagentTransport } from "./transport.js";
+import {
+	emptyTransportUsage,
+	PI_SUBAGENTS_RPC_PROTOCOL,
+	type TransportProgressCallback,
+	type TransportTelemetry,
+	type TransportUsage,
+} from "./transport-types.js";
+
+const COMMAND_TIMEOUT_MS = 30_000;
+const STARTUP_TIMEOUT_MS = 30_000;
+const ABORT_GRACE_MS = 5_000;
+const BUILT_IN_TOOL_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+
+interface RpcCommandInput {
+	type: string;
+	[key: string]: unknown;
+}
+
+interface RpcResponse {
+	id?: string;
+	type: "response";
+	command: string;
+	success: boolean;
+	data?: unknown;
+	error?: string;
+}
+
+interface PendingRequest {
+	command: string;
+	resolve(value: RpcResponse): void;
+	reject(error: Error): void;
+	timer: NodeJS.Timeout;
+}
+
+export interface RpcProtocolClientOptions {
+	cwd: string;
+	args: string[];
+	env?: NodeJS.ProcessEnv;
+	startupTimeoutMs?: number;
+	commandTimeoutMs?: number;
+	abortTimeoutMs?: number;
+	terminationGraceMs?: number;
+	invocation?: PiInvocation;
+}
+
+export interface RpcProtocolSnapshot {
+	state: RpcSessionState;
+	stderr: string;
+	malformedLines: number;
+	oversizedLines: number;
+}
+
+export class RpcProtocolClient {
+	private process?: ChildProcess;
+	private processClosed = false;
+	private decoder?: JsonLineDecoder;
+	private readonly pending = new Map<string, PendingRequest>();
+	private readonly listeners = new Set<(event: unknown) => void>();
+	private readonly closeListeners = new Set<(error: Error) => void>();
+	private nextRequestId = 0;
+	private stderr = "";
+	private malformedLines = 0;
+	private oversizedLines = 0;
+	private closedError?: Error;
+	private closePromise?: Promise<void>;
+	private cleanupTermination?: () => void;
+
+	constructor(private readonly options: RpcProtocolClientOptions) {}
+
+	async start(signal?: AbortSignal): Promise<RpcProtocolSnapshot> {
+		if (this.process) throw new Error("RPC subagent client already started");
+		if (signal?.aborted) throw abortError("RPC subagent start aborted");
+		const invocation = this.options.invocation
+			? {
+					command: this.options.invocation.command,
+					args: [...this.options.invocation.args, ...this.options.args],
+				}
+			: resolvePiInvocation(this.options.args);
+		const proc = spawn(invocation.command, invocation.args, {
+			cwd: this.options.cwd,
+			detached: process.platform !== "win32",
+			shell: false,
+			stdio: ["pipe", "pipe", "pipe"],
+			env: { ...process.env, ...this.options.env },
+		});
+		this.process = proc;
+		this.processClosed = false;
+		this.decoder = new JsonLineDecoder({
+			onValue: (value) => this.handleValue(value),
+			onMalformed: () => {
+				this.malformedLines++;
+				this.fail(new Error("RPC subagent emitted malformed JSONL"));
+			},
+			onOversized: () => {
+				this.oversizedLines++;
+				this.fail(new Error("RPC subagent emitted an oversized JSONL record"));
+			},
+		});
+		proc.stdout?.on("data", (chunk) => this.decoder?.push(chunk));
+		proc.stdin?.on("error", (error) => this.fail(errorMessage("RPC stdin failed", error)));
+		proc.stderr?.on("data", (chunk) => {
+			this.stderr = appendBounded(
+				this.stderr,
+				Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk),
+				DEFAULT_MAX_STDERR_BYTES,
+			).text;
+		});
+		proc.stdin?.on("error", (error) => this.fail(errorMessage("RPC stdin failed", error)));
+		proc.once("error", (error) => this.fail(errorMessage("RPC process failed", error)));
+		proc.once("close", (code, childSignal) => {
+			this.processClosed = true;
+			this.decoder?.finish();
+			this.fail(
+				new Error(
+					`RPC subagent exited (code=${code ?? "null"}, signal=${childSignal ?? "null"})${this.stderr ? `: ${safeTerminalText(this.stderr)}` : ""}`,
+				),
+			);
+		});
+		try {
+			await waitForSpawn(proc, signal, this.options.startupTimeoutMs ?? STARTUP_TIMEOUT_MS);
+			if (signal?.aborted) throw abortError("RPC subagent start aborted");
+			const state = await raceWithAbort(
+				this.requestData<RpcSessionState>(
+					{ type: "get_state" },
+					this.options.startupTimeoutMs ?? STARTUP_TIMEOUT_MS,
+				),
+				signal,
+				"RPC subagent readiness aborted",
+			);
+			return {
+				state,
+				stderr: this.stderr,
+				malformedLines: this.malformedLines,
+				oversizedLines: this.oversizedLines,
+			};
+		} catch (error) {
+			await this.stop();
+			throw error;
+		}
+	}
+
+	onEvent(listener: (event: unknown) => void): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	onClose(listener: (error: Error) => void): () => void {
+		this.closeListeners.add(listener);
+		return () => this.closeListeners.delete(listener);
+	}
+
+	async prompt(message: string, timeoutMs?: number): Promise<void> {
+		await this.request({ type: "prompt", message }, timeoutMs);
+	}
+
+	async abort(): Promise<void> {
+		await this.request(
+			{ type: "abort" },
+			this.options.abortTimeoutMs ?? Math.min(COMMAND_TIMEOUT_MS, ABORT_GRACE_MS),
+		);
+	}
+
+	async getState(): Promise<RpcSessionState> {
+		return this.requestData<RpcSessionState>({ type: "get_state" });
+	}
+
+	getStderr(): string {
+		return this.stderr;
+	}
+
+	async stop(): Promise<void> {
+		if (this.closePromise) return this.closePromise;
+		const proc = this.process;
+		if (!proc) return;
+		if (this.processClosed) {
+			this.cleanupTermination?.();
+			this.cleanupTermination = undefined;
+			this.process = undefined;
+			this.rejectPending(this.closedError ?? new Error("RPC subagent process already exited"));
+			this.listeners.clear();
+			this.closeListeners.clear();
+			return;
+		}
+		this.closePromise = new Promise<void>((resolve) => {
+			let settled = false;
+			let timer: NodeJS.Timeout | undefined;
+			const finish = () => {
+				if (settled) return;
+				settled = true;
+				if (timer) clearTimeout(timer);
+				this.cleanupTermination?.();
+				this.cleanupTermination = undefined;
+				resolve();
+			};
+			proc.once("close", finish);
+			try {
+				proc.stdin?.end();
+			} catch {
+				// Termination below remains authoritative.
+			}
+			const graceMs = this.options.terminationGraceMs ?? ABORT_GRACE_MS;
+			this.cleanupTermination?.();
+			this.cleanupTermination = terminateProcess(proc, graceMs);
+			timer = setTimeout(finish, graceMs + 1_000);
+			timer.unref();
+		});
+		await this.closePromise;
+		this.process = undefined;
+		this.rejectPending(new Error("RPC subagent client stopped"));
+		this.listeners.clear();
+		this.closeListeners.clear();
+	}
+
+	private async requestData<T>(
+		command: RpcCommandInput,
+		timeoutMs = this.options.commandTimeoutMs ?? COMMAND_TIMEOUT_MS,
+	): Promise<T> {
+		const response = await this.request(command, timeoutMs);
+		return response.data as T;
+	}
+
+	private request(
+		command: RpcCommandInput,
+		timeoutMs = this.options.commandTimeoutMs ?? COMMAND_TIMEOUT_MS,
+	): Promise<RpcResponse> {
+		const proc = this.process;
+		if (!proc?.stdin || proc.stdin.destroyed || !proc.stdin.writable) {
+			return Promise.reject(this.closedError ?? new Error("RPC subagent stdin is unavailable"));
+		}
+		const id = `psa_${++this.nextRequestId}`;
+		return new Promise<RpcResponse>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(rpcTimeoutError(`RPC ${command.type} response timed out after ${timeoutMs}ms`));
+			}, timeoutMs);
+			timer.unref();
+			this.pending.set(id, { command: command.type, resolve, reject, timer });
+			try {
+				proc.stdin?.write(`${JSON.stringify({ ...command, id })}\n`, (error) => {
+					if (!error) return;
+					this.fail(errorMessage("RPC stdin write failed", error));
+				});
+			} catch (error) {
+				this.pending.delete(id);
+				clearTimeout(timer);
+				reject(error instanceof Error ? error : new Error(String(error)));
+			}
+		}).then((response) => {
+			if (!response.success) throw new Error(response.error || `RPC ${command.type} failed`);
+			return response;
+		});
+	}
+
+	private handleValue(value: unknown): void {
+		if (!value || typeof value !== "object" || Array.isArray(value)) return;
+		const event = value as Record<string, unknown>;
+		if (event.type === "response" && typeof event.id === "string") {
+			const pending = this.pending.get(event.id);
+			if (!pending) return;
+			if (typeof event.command !== "string" || event.command !== pending.command) {
+				this.fail(
+					new Error(`RPC response command mismatch for ${event.id}: expected ${pending.command}`),
+				);
+				return;
+			}
+			this.pending.delete(event.id);
+			clearTimeout(pending.timer);
+			pending.resolve(event as unknown as RpcResponse);
+			return;
+		}
+		if (event.type === "extension_ui_request" && typeof event.id === "string") {
+			this.writeFireAndForget({
+				type: "extension_ui_response",
+				id: event.id,
+				cancelled: true,
+			});
+		}
+		for (const listener of this.listeners) listener(value);
+	}
+
+	private writeFireAndForget(value: Record<string, unknown>): void {
+		try {
+			this.process?.stdin?.write(`${JSON.stringify(value)}\n`);
+		} catch {
+			// Process failure will be reported through close/error handling.
+		}
+	}
+
+	private fail(error: Error): void {
+		if (this.closedError) return;
+		this.closedError = error;
+		this.rejectPending(error);
+		for (const listener of this.closeListeners) listener(error);
+		if (this.process && !this.closePromise) {
+			this.cleanupTermination = terminateProcess(
+				this.process,
+				this.options.terminationGraceMs ?? ABORT_GRACE_MS,
+			);
+		}
+	}
+
+	private rejectPending(error: Error): void {
+		for (const pending of this.pending.values()) {
+			clearTimeout(pending.timer);
+			pending.reject(error);
+		}
+		this.pending.clear();
+	}
+}
+
+export interface RpcTransportOptions {
+	getSettings?: () => SubagentSettings | undefined;
+	getParentRuntime: () => ParentRuntimeSnapshot;
+	createClient?: (options: RpcProtocolClientOptions) => RpcProtocolClient;
+	defaultTimeoutMs?: number;
+	abortGraceMs?: number;
+}
+
+interface RpcChildRecord {
+	client: RpcProtocolClient;
+	state: RpcSessionState;
+	started: boolean;
+	temporaryPrompt?: { dir: string; filePath: string };
+}
+
+interface TurnCapture {
+	output: string;
+	partial: string;
+	stopReason?: string;
+	error?: string;
+	provider?: string;
+	model?: string;
+	usage: TransportUsage;
+	firstActivityAt?: number;
+}
+
+export class RpcTransport implements SubagentTransport {
+	readonly kind = "rpc" as const;
+	private readonly children = new Map<string, RpcChildRecord>();
+	private readonly createClient: (options: RpcProtocolClientOptions) => RpcProtocolClient;
+
+	constructor(private readonly options: RpcTransportOptions) {
+		this.createClient =
+			options.createClient ?? ((clientOptions) => new RpcProtocolClient(clientOptions));
+	}
+
+	async runTurn(
+		agent: ManagedAgent,
+		task: string,
+		signal: AbortSignal,
+		onProgress?: TransportProgressCallback,
+	): Promise<TurnOutcome> {
+		const startedAt = Date.now();
+		let telemetry: TransportTelemetry = {
+			transport: "rpc",
+			protocol: PI_SUBAGENTS_RPC_PROTOCOL,
+			phase: "starting",
+			updatedAt: startedAt,
+			timing: { startedAt, transportStartedAt: startedAt },
+		};
+		const publish = (patch: Partial<TransportTelemetry>) => {
+			telemetry = {
+				...telemetry,
+				...patch,
+				timing: { ...telemetry.timing, ...patch.timing },
+				usage: patch.usage ? { ...patch.usage } : telemetry.usage,
+				updatedAt: Date.now(),
+			};
+			onProgress?.({
+				...telemetry,
+				timing: { ...telemetry.timing },
+				usage: telemetry.usage ? { ...telemetry.usage } : undefined,
+			});
+		};
+		publish({});
+		if (signal.aborted) return interruptedRpcOutcome("", telemetry, "starting");
+		const settings = this.options.getSettings ? this.options.getSettings() : readSubagentSettings();
+		const agentConfig = discoverAgents(agent.cwd, agent.agentScope ?? "user", settings).agents.find(
+			(candidate) => candidate.name === agent.agent,
+		);
+		if (!agentConfig) {
+			publish({ phase: "failed", failurePhase: "starting" });
+			return { output: "", exitCode: 1, error: `Unknown subagent: ${agent.agent}`, telemetry };
+		}
+		try {
+			validateRpcTools(agentConfig.tools);
+		} catch (error) {
+			publish({ phase: "failed", failurePhase: "starting" });
+			return { output: "", exitCode: 1, error: boundedError(error), telemetry };
+		}
+		let child: RpcChildRecord;
+		try {
+			child = await this.getOrCreate(agent, agentConfig, signal);
+		} catch (error) {
+			publish({ phase: signal.aborted ? "interrupted" : "failed", failurePhase: "starting" });
+			return {
+				output: "",
+				exitCode: signal.aborted ? 130 : 1,
+				aborted: signal.aborted,
+				error: boundedError(error),
+				telemetry,
+			};
+		}
+		const stateModel = modelIdentity(child.state.model);
+		publish({
+			phase: "ready",
+			provider: stateModel.provider,
+			model: stateModel.model,
+			thinkingLevel: normalizeThinking(child.state.thinkingLevel),
+			timing: { readyAt: Date.now() },
+		});
+		if (signal.aborted) {
+			await this.releaseById(agent.id).catch(() => undefined);
+			return interruptedRpcOutcome("", telemetry, "ready");
+		}
+		const capture: TurnCapture = { output: "", partial: "", usage: emptyTransportUsage() };
+		let settledResolve!: () => void;
+		let settledReject!: (error: Error) => void;
+		const settled = new Promise<void>((resolve, reject) => {
+			settledResolve = resolve;
+			settledReject = reject;
+		});
+		void settled.catch(() => undefined);
+		const unsubscribeEvent = child.client.onEvent((event) => {
+			captureRpcEvent(event, capture);
+			if (!capture.firstActivityAt && isActivityEvent(event)) {
+				capture.firstActivityAt = Date.now();
+				publish({ phase: "running", timing: { firstActivityAt: capture.firstActivityAt } });
+			}
+			const type = eventType(event);
+			if (type === "auto_retry_start") publish({ phase: "retrying" });
+			if (type === "compaction_start" || type === "summarization_retry_attempt_start") {
+				publish({ phase: "compacting" });
+			}
+			if (type === "agent_settled") settledResolve();
+		});
+		const unsubscribeClose = child.client.onClose(settledReject);
+		const prompt = child.started
+			? buildCurrentTurnPrompt(agent, task)
+			: buildStatefulTurnPrompt(agent, task).text;
+		const timeoutMs =
+			agentConfig.timeoutMs ??
+			this.options.defaultTimeoutMs ??
+			resolveStatefulTurnTimeout(agentConfig);
+		let accepted = false;
+		const deadline = Date.now() + timeoutMs;
+		try {
+			await raceWithAbort(
+				child.client.prompt(prompt, remainingMs(deadline)),
+				signal,
+				"RPC subagent prompt acceptance aborted",
+			);
+			accepted = true;
+			child.started = true;
+			publish({ phase: "accepted", timing: { promptAcceptedAt: Date.now() } });
+			const settlement = await waitForTurnSettlement(settled, signal, remainingMs(deadline));
+			if (settlement !== "settled") {
+				await child.client.abort().catch(() => undefined);
+				const stopped = await settlesWithin(settled, this.options.abortGraceMs ?? ABORT_GRACE_MS);
+				if (!stopped) await this.releaseById(agent.id);
+				const output = truncateUtf8(capture.output || capture.partial, DEFAULT_MAX_OUTPUT_BYTES);
+				publish({
+					phase: settlement === "aborted" ? "interrupted" : "failed",
+					failurePhase: "running",
+					timing: { settledAt: Date.now() },
+					usage: capture.usage,
+				});
+				return {
+					output: output.text,
+					exitCode: settlement === "aborted" ? 130 : 124,
+					aborted: settlement === "aborted",
+					truncated: output.truncated || agent.contextTruncated,
+					error:
+						settlement === "aborted"
+							? "RPC subagent was aborted"
+							: `RPC subagent timed out after ${timeoutMs}ms`,
+					policy: rpcPolicy(agentConfig, agent),
+					telemetry,
+				};
+			}
+			const output = truncateUtf8(capture.output || capture.partial, DEFAULT_MAX_OUTPUT_BYTES);
+			const failed = capture.stopReason === "error" || !output.text.trim();
+			publish({
+				phase: failed ? "failed" : "settled",
+				failurePhase: failed ? "running" : undefined,
+				timing: { settledAt: Date.now() },
+				provider: capture.provider ?? telemetry.provider,
+				model: capture.model ?? telemetry.model,
+				usage: capture.usage,
+			});
+			return {
+				output: output.text,
+				exitCode: failed ? 1 : 0,
+				truncated: output.truncated || agent.contextTruncated,
+				error: failed ? capture.error || "RPC subagent completed without final text" : undefined,
+				policy: rpcPolicy(agentConfig, agent),
+				telemetry,
+			};
+		} catch (error) {
+			await this.releaseById(agent.id).catch(() => undefined);
+			const timedOut = isTimeoutError(error);
+			publish({
+				phase: signal.aborted ? "interrupted" : "failed",
+				failurePhase: accepted ? "running" : "ready",
+				timing: { settledAt: Date.now() },
+			});
+			return {
+				output: truncateUtf8(capture.output || capture.partial, DEFAULT_MAX_OUTPUT_BYTES).text,
+				exitCode: signal.aborted ? 130 : timedOut ? 124 : 1,
+				aborted: signal.aborted,
+				error: timedOut ? `RPC subagent timed out after ${timeoutMs}ms` : boundedError(error),
+				policy: rpcPolicy(agentConfig, agent),
+				telemetry,
+			};
+		} finally {
+			unsubscribeEvent();
+			unsubscribeClose();
+		}
+	}
+
+	async release(agent: ManagedAgent): Promise<void> {
+		await this.releaseById(agent.id);
+	}
+
+	async shutdown(): Promise<void> {
+		const results = await Promise.allSettled(
+			[...this.children.keys()].map((agentId) => this.releaseById(agentId)),
+		);
+		const failures = results.flatMap((result) =>
+			result.status === "rejected" ? [result.reason] : [],
+		);
+		if (failures.length > 0) {
+			throw new AggregateError(failures, `Failed to release ${failures.length} RPC subagent(s)`);
+		}
+	}
+
+	private async getOrCreate(
+		agent: ManagedAgent,
+		agentConfig: AgentConfig,
+		signal: AbortSignal,
+	): Promise<RpcChildRecord> {
+		const existing = this.children.get(agent.id);
+		if (existing) return existing;
+		const temporaryPrompt = agentConfig.systemPrompt.trim()
+			? await writeRolePrompt(agentConfig.name, agentConfig.systemPrompt)
+			: undefined;
+		if (signal.aborted) {
+			cleanupRolePrompt(temporaryPrompt);
+			throw abortError("RPC subagent start aborted");
+		}
+		const client = this.createClient({
+			cwd: agent.cwd,
+			abortTimeoutMs: this.options.abortGraceMs ?? ABORT_GRACE_MS,
+			terminationGraceMs: this.options.abortGraceMs ?? ABORT_GRACE_MS,
+			args: buildRpcArgs(
+				agent,
+				agentConfig,
+				this.options.getParentRuntime(),
+				temporaryPrompt?.filePath,
+			),
+			env: {
+				PI_SUBAGENT_DEPTH: String(
+					(Number.parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) || 0) + 1,
+				),
+				PI_SUBAGENT_RPC_PROTOCOL: PI_SUBAGENTS_RPC_PROTOCOL,
+			},
+		});
+		try {
+			const snapshot = await client.start(signal);
+			const record: RpcChildRecord = {
+				client,
+				state: snapshot.state,
+				started: false,
+				temporaryPrompt,
+			};
+			if (signal.aborted) {
+				await client.stop();
+				cleanupRolePrompt(temporaryPrompt);
+				throw abortError("RPC subagent start aborted");
+			}
+			this.children.set(agent.id, record);
+			return record;
+		} catch (error) {
+			await client.stop().catch(() => undefined);
+			cleanupRolePrompt(temporaryPrompt);
+			throw error;
+		}
+	}
+
+	private async releaseById(agentId: string): Promise<void> {
+		const child = this.children.get(agentId);
+		if (!child) return;
+		this.children.delete(agentId);
+		try {
+			await child.client.abort().catch(() => undefined);
+			await child.client.stop();
+		} finally {
+			cleanupRolePrompt(child.temporaryPrompt);
+		}
+	}
+}
+
+export function validateRpcTools(tools: string[] | undefined): string[] | undefined {
+	const validated = validateInProcessTools(tools);
+	if (validated?.some((tool) => !BUILT_IN_TOOL_NAMES.has(tool))) {
+		throw new Error("RPC subagents support only built-in Pi tools in pi-subagents:v1");
+	}
+	return validated;
+}
+
+export function buildRpcArgs(
+	agent: ManagedAgent,
+	agentConfig: AgentConfig,
+	parentRuntime: ParentRuntimeSnapshot,
+	rolePromptPath?: string,
+): string[] {
+	const args = ["--mode", "rpc", "--no-session", "--no-extensions"];
+	const model =
+		agentConfig.model ??
+		(parentRuntime.model ? `${parentRuntime.model.provider}/${parentRuntime.model.id}` : undefined);
+	if (model) args.push("--model", model);
+	const modelSelectsThinking = agentConfig.model
+		? /:(?:off|minimal|low|medium|high|xhigh|max)$/u.test(agentConfig.model.trim())
+		: false;
+	const thinking =
+		agent.thinkingLevel ??
+		agentConfig.thinkingLevel ??
+		(modelSelectsThinking ? undefined : parentRuntime.thinkingLevel);
+	if (thinking) args.push("--thinking", thinking);
+	if (agent.target?.trust.projectTrusted ?? false) args.push("--approve");
+	else args.push("--no-approve");
+	if (Array.isArray(agentConfig.tools)) {
+		if (agentConfig.tools.length > 0) args.push("--tools", agentConfig.tools.join(","));
+		else args.push("--no-tools");
+	}
+	if (rolePromptPath) args.push("--append-system-prompt", rolePromptPath);
+	return args;
+}
+
+function captureRpcEvent(event: unknown, capture: TurnCapture): void {
+	if (!event || typeof event !== "object" || Array.isArray(event)) return;
+	const value = event as Record<string, unknown>;
+	if (value.type === "message_update") {
+		const delta = value.assistantMessageEvent;
+		if (delta && typeof delta === "object") {
+			const update = delta as Record<string, unknown>;
+			if (update.type === "text_delta" && typeof update.delta === "string") {
+				capture.partial = truncateUtf8(
+					`${capture.partial}${update.delta}`,
+					DEFAULT_MAX_OUTPUT_BYTES,
+				).text;
+			}
+		}
+	}
+	if (value.type !== "message_end") return;
+	const message = value.message;
+	if (!message || typeof message !== "object" || Array.isArray(message)) return;
+	const candidate = message as Record<string, unknown>;
+	if (candidate.role !== "assistant") return;
+	capture.output = truncateUtf8(
+		assistantText(candidate.content) || capture.partial,
+		DEFAULT_MAX_OUTPUT_BYTES,
+	).text;
+	capture.partial = capture.output;
+	capture.stopReason = typeof candidate.stopReason === "string" ? candidate.stopReason : undefined;
+	capture.error =
+		typeof candidate.errorMessage === "string"
+			? boundedPrivateText(candidate.errorMessage, 4 * 1024)
+			: undefined;
+	capture.provider =
+		typeof candidate.provider === "string"
+			? boundedPrivateText(candidate.provider, 256)
+			: undefined;
+	const responseModel =
+		typeof candidate.responseModel === "string"
+			? candidate.responseModel
+			: typeof candidate.model === "string"
+				? candidate.model
+				: undefined;
+	capture.model = responseModel ? boundedPrivateText(responseModel, 256) : undefined;
+	capture.usage.turns++;
+	addUsage(capture.usage, candidate.usage);
+}
+
+function addUsage(target: TransportUsage, value: unknown): void {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return;
+	const usage = value as Record<string, unknown>;
+	target.input += safeNonNegative(usage.input);
+	target.output += safeNonNegative(usage.output);
+	target.cacheRead += safeNonNegative(usage.cacheRead);
+	target.cacheWrite += safeNonNegative(usage.cacheWrite);
+	const reportedTotal = safeNonNegative(usage.totalTokens);
+	target.totalTokens +=
+		reportedTotal ||
+		safeNonNegative(usage.input) +
+			safeNonNegative(usage.output) +
+			safeNonNegative(usage.cacheRead) +
+			safeNonNegative(usage.cacheWrite);
+	const cost = usage.cost;
+	if (cost && typeof cost === "object" && !Array.isArray(cost)) {
+		target.cost += safeNonNegative((cost as Record<string, unknown>).total);
+	}
+}
+
+function safeNonNegative(value: unknown): number {
+	return typeof value === "number" &&
+		Number.isFinite(value) &&
+		value >= 0 &&
+		value <= Number.MAX_SAFE_INTEGER
+		? value
+		: 0;
+}
+
+function assistantText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (!Array.isArray(value)) return "";
+	return value
+		.flatMap((part) => {
+			if (!part || typeof part !== "object" || Array.isArray(part)) return [];
+			const item = part as Record<string, unknown>;
+			return item.type === "text" && typeof item.text === "string" ? [item.text] : [];
+		})
+		.join("\n");
+}
+
+function eventType(value: unknown): string | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const type = (value as Record<string, unknown>).type;
+	return typeof type === "string" ? type : undefined;
+}
+
+function isActivityEvent(value: unknown): boolean {
+	return [
+		"message_start",
+		"message_update",
+		"message_end",
+		"tool_execution_start",
+		"tool_execution_update",
+		"auto_retry_start",
+		"compaction_start",
+	].includes(eventType(value) ?? "");
+}
+
+function modelIdentity(value: unknown): { provider?: string; model?: string } {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	const model = value as Record<string, unknown>;
+	return {
+		provider:
+			typeof model.provider === "string" ? boundedPrivateText(model.provider, 256) : undefined,
+		model: typeof model.id === "string" ? boundedPrivateText(model.id, 256) : undefined,
+	};
+}
+
+function normalizeThinking(value: unknown): SubagentThinkingLevel | undefined {
+	return ["off", "minimal", "low", "medium", "high", "xhigh", "max"].includes(String(value))
+		? (value as SubagentThinkingLevel)
+		: undefined;
+}
+
+function rpcPolicy(
+	agentConfig: AgentConfig,
+	agent: ManagedAgent,
+): NonNullable<TurnOutcome["policy"]> {
+	return {
+		inherited: ["environment", "cwdResources"],
+		overridden: [
+			"cwd",
+			"extensions",
+			...(agentConfig.model ? ["model"] : []),
+			...(agent.thinkingLevel || agentConfig.thinkingLevel ? ["thinkingLevel"] : []),
+			...(agentConfig.tools ? ["tools"] : []),
+		],
+		unsupported: ["approvalPolicy", "sandboxProfile", "providerHeaders", "extensionState"],
+	};
+}
+
+async function writeRolePrompt(
+	agentName: string,
+	prompt: string,
+): Promise<{ dir: string; filePath: string }> {
+	const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "pi-subagent-rpc-"));
+	const safeName = agentName.replace(/[^\w.-]+/gu, "_");
+	const filePath = path.join(dir, `prompt-${safeName}.md`);
+	await fs.promises.writeFile(filePath, prompt, {
+		encoding: "utf8",
+		mode: 0o600,
+	});
+	return { dir, filePath };
+}
+
+function cleanupRolePrompt(value: { dir: string; filePath: string } | undefined): void {
+	if (!value) return;
+	try {
+		fs.rmSync(value.dir, { recursive: true, force: true });
+	} catch {
+		// Best-effort cleanup is repeated when the owning runtime shuts down.
+	}
+}
+
+function waitForSpawn(
+	proc: ChildProcess,
+	signal: AbortSignal | undefined,
+	timeoutMs: number,
+): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		let settled = false;
+		const finish = (error?: Error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			proc.off("spawn", onSpawn);
+			proc.off("error", onError);
+			signal?.removeEventListener("abort", onAbort);
+			if (error) reject(error);
+			else resolve();
+		};
+		const onSpawn = () => finish();
+		const onError = (error: Error) => finish(error);
+		const onAbort = () => finish(abortError("RPC subagent start aborted"));
+		const timer = setTimeout(
+			() => finish(new Error(`RPC subagent start timed out after ${timeoutMs}ms`)),
+			timeoutMs,
+		);
+		timer.unref();
+		proc.once("spawn", onSpawn);
+		proc.once("error", onError);
+		signal?.addEventListener("abort", onAbort, { once: true });
+		if (signal?.aborted) onAbort();
+	});
+}
+
+async function raceWithAbort<T>(
+	promise: Promise<T>,
+	signal: AbortSignal | undefined,
+	message: string,
+): Promise<T> {
+	if (!signal) return promise;
+	if (signal.aborted) throw abortError(message);
+	let onAbort: (() => void) | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_resolve, reject) => {
+				onAbort = () => reject(abortError(message));
+				signal.addEventListener("abort", onAbort, { once: true });
+				if (signal.aborted) onAbort();
+			}),
+		]);
+	} finally {
+		if (onAbort) signal.removeEventListener("abort", onAbort);
+	}
+}
+
+function waitForTurnSettlement(
+	settled: Promise<void>,
+	signal: AbortSignal,
+	timeoutMs: number,
+): Promise<"settled" | "aborted" | "timeout"> {
+	if (signal.aborted) return Promise.resolve("aborted");
+	return new Promise((resolve, reject) => {
+		let finished = false;
+		const finish = (value: "settled" | "aborted" | "timeout", error?: unknown) => {
+			if (finished) return;
+			finished = true;
+			clearTimeout(timer);
+			signal.removeEventListener("abort", onAbort);
+			if (error) reject(error);
+			else resolve(value);
+		};
+		const onAbort = () => finish("aborted");
+		const timer = setTimeout(() => finish("timeout"), timeoutMs);
+		timer.unref();
+		signal.addEventListener("abort", onAbort, { once: true });
+		if (signal.aborted) onAbort();
+		settled.then(
+			() => finish("settled"),
+			(error) => finish("settled", error),
+		);
+	});
+}
+
+async function settlesWithin(settled: Promise<void>, timeoutMs: number): Promise<boolean> {
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			settled.then(
+				() => true,
+				() => true,
+			),
+			new Promise<boolean>((resolve) => {
+				timer = setTimeout(() => resolve(false), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+function remainingMs(deadline: number): number {
+	return Math.max(1, deadline - Date.now());
+}
+
+function rpcTimeoutError(message: string): Error {
+	const error = new Error(message);
+	error.name = "RpcTimeoutError";
+	return error;
+}
+
+function isTimeoutError(error: unknown): boolean {
+	return error instanceof Error && error.name === "RpcTimeoutError";
+}
+
+function interruptedRpcOutcome(
+	output: string,
+	telemetry: TransportTelemetry,
+	failurePhase: TransportTelemetry["phase"],
+): TurnOutcome {
+	return {
+		output,
+		exitCode: 130,
+		aborted: true,
+		error: "RPC subagent was aborted",
+		telemetry: {
+			...telemetry,
+			phase: "interrupted",
+			failurePhase,
+			updatedAt: Date.now(),
+		},
+	};
+}
+
+function abortError(message: string): Error {
+	const error = new Error(message);
+	error.name = "AbortError";
+	return error;
+}
+
+function boundedError(error: unknown): string {
+	return boundedPrivateText(
+		error instanceof Error ? error.message : String(error),
+		DEFAULT_MAX_OUTPUT_BYTES,
+	);
+}
+
+function errorMessage(prefix: string, error: Error): Error {
+	return new Error(`${prefix}: ${error.message}`);
+}

--- a/packages/pi-subagents/src/rpc-transport.ts
+++ b/packages/pi-subagents/src/rpc-transport.ts
@@ -21,6 +21,7 @@ import {
 	truncateUtf8,
 } from "./limits.js";
 import { type PiInvocation, resolvePiInvocation } from "./pi-invocation.js";
+import { resolvePiPromptResources } from "./prompt-resources.js";
 import { JsonLineDecoder } from "./protocol.js";
 import type { ManagedAgent, TurnOutcome } from "./registry.js";
 import { terminateProcess } from "./runner.js";
@@ -135,7 +136,6 @@ export class RpcProtocolClient {
 				DEFAULT_MAX_STDERR_BYTES,
 			).text;
 		});
-		proc.stdin?.on("error", (error) => this.fail(errorMessage("RPC stdin failed", error)));
 		proc.once("error", (error) => this.fail(errorMessage("RPC process failed", error)));
 		proc.once("close", (code, childSignal) => {
 			this.processClosed = true;
@@ -213,11 +213,9 @@ export class RpcProtocolClient {
 		}
 		this.closePromise = new Promise<void>((resolve) => {
 			let settled = false;
-			let timer: NodeJS.Timeout | undefined;
 			const finish = () => {
 				if (settled) return;
 				settled = true;
-				if (timer) clearTimeout(timer);
 				this.cleanupTermination?.();
 				this.cleanupTermination = undefined;
 				resolve();
@@ -231,8 +229,6 @@ export class RpcProtocolClient {
 			const graceMs = this.options.terminationGraceMs ?? ABORT_GRACE_MS;
 			this.cleanupTermination?.();
 			this.cleanupTermination = terminateProcess(proc, graceMs);
-			timer = setTimeout(finish, graceMs + 1_000);
-			timer.unref();
 		});
 		await this.closePromise;
 		this.process = undefined;
@@ -342,6 +338,7 @@ export interface RpcTransportOptions {
 	getSettings?: () => SubagentSettings | undefined;
 	getParentRuntime: () => ParentRuntimeSnapshot;
 	createClient?: (options: RpcProtocolClientOptions) => RpcProtocolClient;
+	resolvePromptResources?: typeof resolvePiPromptResources;
 	defaultTimeoutMs?: number;
 	abortGraceMs?: number;
 }
@@ -571,7 +568,15 @@ export class RpcTransport implements SubagentTransport {
 	): Promise<RpcChildRecord> {
 		const existing = this.children.get(agent.id);
 		if (existing) return existing;
-		const temporaryPrompt = agentConfig.systemPrompt.trim()
+		const hasRolePrompt = agentConfig.systemPrompt.trim().length > 0;
+		const resources = hasRolePrompt
+			? await (this.options.resolvePromptResources ?? resolvePiPromptResources)(
+					agent.cwd,
+					agent.target?.trust.projectTrusted ?? false,
+				)
+			: { appendSystemPromptPaths: [] };
+		if (signal.aborted) throw abortError("RPC subagent start aborted");
+		const temporaryPrompt = hasRolePrompt
 			? await writeRolePrompt(agentConfig.name, agentConfig.systemPrompt)
 			: undefined;
 		if (signal.aborted) {
@@ -587,6 +592,7 @@ export class RpcTransport implements SubagentTransport {
 				agentConfig,
 				this.options.getParentRuntime(),
 				temporaryPrompt?.filePath,
+				resources.appendSystemPromptPaths,
 			),
 			env: {
 				PI_SUBAGENT_DEPTH: String(
@@ -643,6 +649,7 @@ export function buildRpcArgs(
 	agentConfig: AgentConfig,
 	parentRuntime: ParentRuntimeSnapshot,
 	rolePromptPath?: string,
+	appendSystemPromptPaths: readonly string[] = [],
 ): string[] {
 	const args = ["--mode", "rpc", "--no-session", "--no-extensions"];
 	const model =
@@ -662,6 +669,9 @@ export function buildRpcArgs(
 	if (Array.isArray(agentConfig.tools)) {
 		if (agentConfig.tools.length > 0) args.push("--tools", agentConfig.tools.join(","));
 		else args.push("--no-tools");
+	}
+	for (const promptPath of appendSystemPromptPaths) {
+		args.push("--append-system-prompt", promptPath);
 	}
 	if (rolePromptPath) args.push("--append-system-prompt", rolePromptPath);
 	return args;

--- a/packages/pi-subagents/src/rpc-transport.ts
+++ b/packages/pi-subagents/src/rpc-transport.ts
@@ -3,12 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { RpcSessionState } from "@earendil-works/pi-coding-agent";
-import {
-	type AgentConfig,
-	discoverAgents,
-	type SubagentSettings,
-	type SubagentThinkingLevel,
-} from "./agents.js";
+import { type AgentConfig, discoverAgents, type SubagentSettings } from "./agents.js";
 import {
 	buildCurrentTurnPrompt,
 	type ParentRuntimeSnapshot,
@@ -24,6 +19,14 @@ import { type PiInvocation, resolvePiInvocation } from "./pi-invocation.js";
 import { resolvePiPromptResources } from "./prompt-resources.js";
 import { JsonLineDecoder } from "./protocol.js";
 import type { ManagedAgent, TurnOutcome } from "./registry.js";
+import { finalizeTimedOutRpcTurn } from "./rpc-timeout-finalization.js";
+import {
+	boundedError,
+	interruptedRpcOutcome,
+	modelIdentity,
+	normalizeThinking,
+	rpcPolicy,
+} from "./rpc-transport-metadata.js";
 import { terminateProcess } from "./runner.js";
 import { boundedPrivateText, safeTerminalText } from "./safe-text.js";
 import { readSubagentSettings } from "./settings.js";
@@ -213,9 +216,12 @@ export class RpcProtocolClient {
 		}
 		this.closePromise = new Promise<void>((resolve) => {
 			let settled = false;
+			let terminationDeadline: NodeJS.Timeout | undefined;
 			const finish = () => {
 				if (settled) return;
 				settled = true;
+				if (terminationDeadline) clearTimeout(terminationDeadline);
+				proc.off("close", finish);
 				this.cleanupTermination?.();
 				this.cleanupTermination = undefined;
 				resolve();
@@ -229,6 +235,12 @@ export class RpcProtocolClient {
 			const graceMs = this.options.terminationGraceMs ?? ABORT_GRACE_MS;
 			this.cleanupTermination?.();
 			this.cleanupTermination = terminateProcess(proc, graceMs);
+			terminationDeadline = setTimeout(() => {
+				proc.stdin?.destroy();
+				proc.stdout?.destroy();
+				proc.stderr?.destroy();
+				finish();
+			}, graceMs + 1_000);
 		});
 		await this.closePromise;
 		this.process = undefined;
@@ -341,6 +353,7 @@ export interface RpcTransportOptions {
 	resolvePromptResources?: typeof resolvePiPromptResources;
 	defaultTimeoutMs?: number;
 	abortGraceMs?: number;
+	timeoutFinalizationMs?: number;
 }
 
 interface RpcChildRecord {
@@ -466,6 +479,8 @@ export class RpcTransport implements SubagentTransport {
 			? buildCurrentTurnPrompt(agent, task)
 			: buildStatefulTurnPrompt(agent, task).text;
 		const timeoutMs =
+			agent.currentTimeoutMs ??
+			agent.timeoutMs ??
 			agentConfig.timeoutMs ??
 			this.options.defaultTimeoutMs ??
 			resolveStatefulTurnTimeout(agentConfig);
@@ -482,25 +497,65 @@ export class RpcTransport implements SubagentTransport {
 			publish({ phase: "accepted", timing: { promptAcceptedAt: Date.now() } });
 			const settlement = await waitForTurnSettlement(settled, signal, remainingMs(deadline));
 			if (settlement !== "settled") {
-				await child.client.abort().catch(() => undefined);
-				const stopped = await settlesWithin(settled, this.options.abortGraceMs ?? ABORT_GRACE_MS);
-				if (!stopped) await this.releaseById(agent.id);
-				const output = truncateUtf8(capture.output || capture.partial, DEFAULT_MAX_OUTPUT_BYTES);
+				const [, stopped] = await Promise.all([
+					child.client.abort().catch(() => undefined),
+					settlesWithin(settled, this.options.abortGraceMs ?? ABORT_GRACE_MS),
+				]);
+				const partial = truncateUtf8(capture.output || capture.partial, DEFAULT_MAX_OUTPUT_BYTES);
+				if (settlement === "aborted" || !stopped || signal.aborted) {
+					if (!stopped) await this.releaseById(agent.id);
+					publish({
+						phase: settlement === "aborted" ? "interrupted" : "failed",
+						failurePhase: "running",
+						timing: { settledAt: Date.now() },
+						usage: capture.usage,
+					});
+					return {
+						output: partial.text,
+						exitCode: settlement === "aborted" ? 130 : 124,
+						aborted: settlement === "aborted",
+						truncated: partial.truncated || agent.contextTruncated,
+						error:
+							settlement === "aborted"
+								? "RPC subagent was aborted"
+								: `RPC subagent timed out after ${timeoutMs}ms; abort did not settle`,
+						policy: rpcPolicy(agentConfig, agent),
+						telemetry,
+					};
+				}
+
+				publish({ phase: "finalizing", failurePhase: "running" });
+				const summary = await finalizeTimedOutRpcTurn({
+					client: child.client,
+					task,
+					partialOutput: partial.text,
+					resultFormat: agent.resultFormat,
+					signal,
+					workTimeoutMs: timeoutMs,
+					finalizationTimeoutMs: this.options.timeoutFinalizationMs,
+					abortGraceMs: this.options.abortGraceMs ?? ABORT_GRACE_MS,
+					resetCapture() {
+						capture.output = "";
+						capture.partial = "";
+						capture.stopReason = undefined;
+						capture.error = undefined;
+					},
+					getCapture: () => capture,
+					release: () => this.releaseById(agent.id),
+				});
 				publish({
-					phase: settlement === "aborted" ? "interrupted" : "failed",
+					phase: "failed",
 					failurePhase: "running",
 					timing: { settledAt: Date.now() },
 					usage: capture.usage,
 				});
 				return {
-					output: output.text,
-					exitCode: settlement === "aborted" ? 130 : 124,
-					aborted: settlement === "aborted",
-					truncated: output.truncated || agent.contextTruncated,
-					error:
-						settlement === "aborted"
-							? "RPC subagent was aborted"
-							: `RPC subagent timed out after ${timeoutMs}ms`,
+					output: summary.error ? partial.text : summary.output,
+					exitCode: 124,
+					truncated: partial.truncated || summary.truncated || agent.contextTruncated,
+					error: [`RPC subagent timed out after ${timeoutMs}ms`, summary.error]
+						.filter(Boolean)
+						.join("; "),
 					policy: rpcPolicy(agentConfig, agent),
 					telemetry,
 				};
@@ -781,39 +836,6 @@ function isActivityEvent(value: unknown): boolean {
 	].includes(eventType(value) ?? "");
 }
 
-function modelIdentity(value: unknown): { provider?: string; model?: string } {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-	const model = value as Record<string, unknown>;
-	return {
-		provider:
-			typeof model.provider === "string" ? boundedPrivateText(model.provider, 256) : undefined,
-		model: typeof model.id === "string" ? boundedPrivateText(model.id, 256) : undefined,
-	};
-}
-
-function normalizeThinking(value: unknown): SubagentThinkingLevel | undefined {
-	return ["off", "minimal", "low", "medium", "high", "xhigh", "max"].includes(String(value))
-		? (value as SubagentThinkingLevel)
-		: undefined;
-}
-
-function rpcPolicy(
-	agentConfig: AgentConfig,
-	agent: ManagedAgent,
-): NonNullable<TurnOutcome["policy"]> {
-	return {
-		inherited: ["environment", "cwdResources"],
-		overridden: [
-			"cwd",
-			"extensions",
-			...(agentConfig.model ? ["model"] : []),
-			...(agent.thinkingLevel || agentConfig.thinkingLevel ? ["thinkingLevel"] : []),
-			...(agentConfig.tools ? ["tools"] : []),
-		],
-		unsupported: ["approvalPolicy", "sandboxProfile", "providerHeaders", "extensionState"],
-	};
-}
-
 async function writeRolePrompt(
 	agentName: string,
 	prompt: string,
@@ -950,36 +972,10 @@ function isTimeoutError(error: unknown): boolean {
 	return error instanceof Error && error.name === "RpcTimeoutError";
 }
 
-function interruptedRpcOutcome(
-	output: string,
-	telemetry: TransportTelemetry,
-	failurePhase: TransportTelemetry["phase"],
-): TurnOutcome {
-	return {
-		output,
-		exitCode: 130,
-		aborted: true,
-		error: "RPC subagent was aborted",
-		telemetry: {
-			...telemetry,
-			phase: "interrupted",
-			failurePhase,
-			updatedAt: Date.now(),
-		},
-	};
-}
-
 function abortError(message: string): Error {
 	const error = new Error(message);
 	error.name = "AbortError";
 	return error;
-}
-
-function boundedError(error: unknown): string {
-	return boundedPrivateText(
-		error instanceof Error ? error.message : String(error),
-		DEFAULT_MAX_OUTPUT_BYTES,
-	);
 }
 
 function errorMessage(prefix: string, error: Error): Error {

--- a/packages/pi-subagents/src/runner.ts
+++ b/packages/pi-subagents/src/runner.ts
@@ -18,6 +18,11 @@ import {
 } from "./limits.js";
 import { resolvePiInvocation } from "./pi-invocation.js";
 import { JsonLineDecoder } from "./protocol.js";
+import type { SubagentResultFormat } from "./result-contract.js";
+import {
+	buildTimeoutFinalizationPrompt,
+	resolveTimeoutFinalizationMs,
+} from "./timeout-finalization.js";
 
 export const KILL_GRACE_MS = 5000;
 
@@ -58,6 +63,24 @@ function addUsageValue(current: number, addition: number): number {
 	return Math.min(MAX_USAGE_VALUE, current + addition);
 }
 
+function mergeUsageStats(target: UsageStats, addition: UsageStats): void {
+	for (const key of ["input", "output", "cacheRead", "cacheWrite", "cost", "turns"] as const) {
+		target[key] = addUsageValue(target[key], addition[key]);
+	}
+	for (const key of [
+		"costInput",
+		"costOutput",
+		"costCacheRead",
+		"costCacheWrite",
+		"totalTokens",
+	] as const) {
+		if (addition[key] !== undefined) {
+			target[key] = addUsageValue(target[key] ?? 0, addition[key]);
+		}
+	}
+	target.contextTokens = addition.contextTokens || target.contextTokens;
+}
+
 export interface SingleResult {
 	agent: string;
 	agentSource: AgentSource | "unknown";
@@ -76,6 +99,9 @@ export interface SingleResult {
 	errorMessage?: string;
 	step?: number;
 	finalOutput?: string;
+	partialOutput?: string;
+	timeoutSummary?: string;
+	timeoutSummaryError?: string;
 	timedOut?: boolean;
 	timeoutMs?: number;
 	aborted?: boolean;
@@ -131,9 +157,19 @@ export function isResultError(result: SingleResult): boolean {
 export function formatResultFailure(result: SingleResult): string {
 	const error = result.errorMessage || result.stderr.trim();
 	const output = getResultFinalOutput(result);
-	const combined =
-		error && output ? `${error}\n\nPartial output:\n${output}` : error || output || "(no output)";
-	return truncateUtf8(combined, DEFAULT_MAX_CONTEXT_BYTES).text;
+	const sections = [error];
+	if (result.timeoutSummary) sections.push(`Timed-out work summary:\n${result.timeoutSummary}`);
+	else if (output) sections.push(`Partial output:\n${output}`);
+	if (result.partialOutput && result.partialOutput !== output) {
+		sections.push(`Partial output before finalization:\n${result.partialOutput}`);
+	}
+	if (result.timeoutSummaryError) {
+		sections.push(`Summary finalization failed: ${result.timeoutSummaryError}`);
+	}
+	return truncateUtf8(
+		sections.filter(Boolean).join("\n\n") || "(no output)",
+		DEFAULT_MAX_CONTEXT_BYTES,
+	).text;
 }
 
 function boundMessageText(
@@ -405,6 +441,12 @@ export interface ChildLaunchPolicy {
 	projectTrust?: boolean;
 	baseSystemPrompt?: string;
 	appendSystemPromptPaths?: string[];
+	/** Internal timeout recovery control; omitted means enabled. */
+	finalizeOnTimeout?: boolean;
+	/** Internal hard deadline for the summary attempt. */
+	timeoutFinalizationMs?: number;
+	/** Optional stateful result contract retained during timeout finalization. */
+	timeoutResultFormat?: SubagentResultFormat;
 }
 
 export async function runSingleAgent(
@@ -584,11 +626,13 @@ export async function runSingleAgent(
 			let settled = false;
 			let cleanupTermination: (() => void) | undefined;
 			let timeout: NodeJS.Timeout | undefined;
+			let terminationDeadline: NodeJS.Timeout | undefined;
 			let abortHandler: (() => void) | undefined;
 			const finish = (code: number) => {
 				if (settled) return;
 				settled = true;
 				if (timeout) clearTimeout(timeout);
+				if (terminationDeadline) clearTimeout(terminationDeadline);
 				cleanupTermination?.();
 				if (signal && abortHandler) signal.removeEventListener("abort", abortHandler);
 				resolve(code);
@@ -732,6 +776,17 @@ export async function runSingleAgent(
 					currentResult.truncated = true;
 				},
 			});
+			const beginTermination = (exitCode: number) => {
+				if (cleanupTermination || settled) return;
+				cleanupTermination = terminateProcess(proc);
+				terminationDeadline = setTimeout(() => {
+					decoder.finish();
+					proc.stdin?.destroy();
+					proc.stdout?.destroy();
+					proc.stderr?.destroy();
+					finish(exitCode);
+				}, KILL_GRACE_MS + 1_000);
+			};
 
 			timeout = setTimeout(() => {
 				timedOut = true;
@@ -746,7 +801,7 @@ export async function runSingleAgent(
 				currentResult.stderr = bounded.text;
 				currentResult.truncated ||= bounded.truncated;
 				emitUpdate();
-				cleanupTermination = terminateProcess(proc);
+				beginTermination(124);
 			}, timeoutMs);
 			timeout.unref();
 
@@ -768,7 +823,7 @@ export async function runSingleAgent(
 				finish(timedOut ? 124 : wasAborted ? 130 : (code ?? 0));
 			});
 			proc.on("error", (error) => {
-				currentResult.launchFailed = true;
+				currentResult.launchFailed = currentResult.processStarted ? undefined : true;
 				const message = setErrorMessage(error.message);
 				const bounded = appendBounded(
 					currentResult.stderr,
@@ -777,7 +832,8 @@ export async function runSingleAgent(
 				);
 				currentResult.stderr = bounded.text;
 				currentResult.truncated ||= bounded.truncated;
-				finish(1);
+				if (currentResult.processStarted) beginTermination(1);
+				else finish(1);
 			});
 
 			if (signal) {
@@ -787,7 +843,7 @@ export async function runSingleAgent(
 					currentResult.aborted = true;
 					currentResult.stopReason = "aborted";
 					setErrorMessage("Subagent was aborted");
-					cleanupTermination = terminateProcess(proc);
+					beginTermination(130);
 				};
 				if (signal.aborted) abortHandler();
 				else signal.addEventListener("abort", abortHandler, { once: true });
@@ -798,6 +854,52 @@ export async function runSingleAgent(
 		const final = truncateUtf8(selectedAssistantOutput(), DEFAULT_MAX_OUTPUT_BYTES);
 		currentResult.finalOutput = final.text;
 		currentResult.truncated ||= final.truncated;
+		if (timedOut && launchPolicy?.finalizeOnTimeout !== false && !signal?.aborted) {
+			currentResult.partialOutput = currentResult.finalOutput || undefined;
+			const finalizationMs = resolveTimeoutFinalizationMs(
+				timeoutMs,
+				launchPolicy?.timeoutFinalizationMs,
+			);
+			const summary = await runSingleAgent(
+				defaultCwd,
+				agents,
+				agentName,
+				buildTimeoutFinalizationPrompt({
+					task,
+					partialOutput: currentResult.partialOutput,
+					recentActivity: currentResult.recentActivity,
+					resultFormat: launchPolicy?.timeoutResultFormat,
+				}),
+				cwd,
+				step,
+				signal,
+				thinkingLevel,
+				finalizationMs,
+				undefined,
+				makeDetails,
+				invocationOverride,
+				{
+					...launchPolicy,
+					tools: [],
+					disableExtensions: true,
+					disableSkills: true,
+					disablePromptTemplates: true,
+					disableContextFiles: true,
+					appendSystemPromptPaths: undefined,
+					finalizeOnTimeout: false,
+				},
+			);
+			mergeUsageStats(currentResult.usage, summary.usage);
+			const summaryOutput = getResultFinalOutput(summary).trim();
+			if (summary.exitCode === 0 && summaryOutput) {
+				currentResult.timeoutSummary = summaryOutput;
+				currentResult.finalOutput = summaryOutput;
+			} else {
+				currentResult.timeoutSummaryError =
+					summary.errorMessage || summary.stderr.trim() || "Summary produced no final text";
+			}
+			currentResult.truncated ||= summary.truncated;
+		}
 		if (
 			currentResult.exitCode === 0 &&
 			currentResult.stopReason !== "error" &&

--- a/packages/pi-subagents/src/settings.ts
+++ b/packages/pi-subagents/src/settings.ts
@@ -16,6 +16,7 @@ import {
 	type SubagentAgentConfig,
 	type SubagentSettings,
 	type SubagentThinkingLevel,
+	type SubagentTransportKind,
 } from "./agents.js";
 import {
 	DEFAULT_MAX_PARALLEL_TASKS,
@@ -123,7 +124,12 @@ export function normalizeSubagentSettings(value: unknown): SubagentSettings | un
 		if (!isPlainObject(value.stateful)) return undefined;
 		const runtime: NonNullable<SubagentSettings["stateful"]> = {};
 		if (hasOwn(value.stateful, "transport")) {
-			if (value.stateful.transport !== "subprocess" && value.stateful.transport !== "in-process") {
+			if (
+				value.stateful.transport !== "subprocess" &&
+				value.stateful.transport !== "in-process" &&
+				value.stateful.transport !== "rpc" &&
+				value.stateful.transport !== "auto"
+			) {
 				return undefined;
 			}
 			runtime.transport = value.stateful.transport;
@@ -290,6 +296,13 @@ export interface DelegationWorkflowSettingsSnapshot {
 export interface CompletionDeliverySettingsSnapshot {
 	path: string;
 	value: CompletionDelivery;
+	source: "default" | "user settings";
+	error?: string;
+}
+
+export interface StatefulTransportSettingsSnapshot {
+	path: string;
+	value: SubagentTransportKind;
 	source: "default" | "user settings";
 	error?: string;
 }
@@ -492,6 +505,25 @@ export function inspectCompletionDeliverySettings(): CompletionDeliverySettingsS
 	};
 }
 
+export function inspectStatefulTransportSettings(): StatefulTransportSettingsSnapshot {
+	const inspected = inspectSubagentSettingsDocument();
+	if (!inspected.raw || !inspected.settings) {
+		return {
+			path: inspected.path,
+			value: "subprocess",
+			source: "default",
+			...(inspected.error ? { error: inspected.error } : {}),
+		};
+	}
+	const explicit =
+		isPlainObject(inspected.raw.stateful) && hasOwn(inspected.raw.stateful, "transport");
+	return {
+		path: inspected.path,
+		value: inspected.settings.stateful?.transport ?? "subprocess",
+		source: explicit ? "user settings" : "default",
+	};
+}
+
 export function resolveBlockingMaxParallelTasks(settings?: SubagentSettings): number {
 	return settings?.blocking?.maxParallelTasks ?? DEFAULT_MAX_PARALLEL_TASKS;
 }
@@ -563,6 +595,27 @@ export function updateDelegationWorkflowSetting(
 					...(stateful ?? {}),
 					enabled: value !== "blocking-only",
 				},
+			},
+			update.replaceCanonical,
+		);
+	});
+}
+
+export function updateStatefulTransportSetting(value: SubagentTransportKind): void {
+	if (!["subprocess", "in-process", "rpc", "auto"].includes(value)) {
+		throw new Error(`Unsupported stateful transport: ${value}`);
+	}
+	withSettingsMutationLock(() => {
+		const update = readSettingsObjectForUpdate();
+		const raw = update.document;
+		const stateful = raw.stateful;
+		if (stateful !== undefined && !isPlainObject(stateful)) {
+			throw new Error(`Cannot update invalid ${SETTINGS_FILE} stateful settings`);
+		}
+		writeSettingsObjectUnlocked(
+			{
+				...raw,
+				stateful: { ...(stateful ?? {}), transport: value },
 			},
 			update.replaceCanonical,
 		);
@@ -692,7 +745,18 @@ export function updateCwdPolicySetting(
 	});
 }
 
+export type AgentSettingsPatch = {
+	tools?: string[] | undefined;
+	model?: string | null | undefined;
+	thinkingLevel?: SubagentThinkingLevel | null | undefined;
+	timeoutMs?: number | null | undefined;
+};
+
 export function updateAgentToolsSetting(name: string, tools: string[] | undefined): void {
+	updateAgentSettingsPatch({ [name]: { tools } });
+}
+
+export function updateAgentSettingsPatch(patches: Record<string, AgentSettingsPatch>): void {
 	withSettingsMutationLock(() => {
 		const update = readSettingsObjectForUpdate();
 		const raw = update.document;
@@ -701,24 +765,41 @@ export function updateAgentToolsSetting(name: string, tools: string[] | undefine
 			throw new Error(`Cannot update invalid ${SETTINGS_FILE} agent settings`);
 		}
 		const agents = { ...(rawAgents ?? {}) };
-		const rawAgent = hasOwn(agents, name) ? agents[name] : undefined;
-		if (rawAgent !== undefined && !isPlainObject(rawAgent)) {
-			throw new Error(`Cannot update invalid ${SETTINGS_FILE} settings for ${name}`);
-		}
-		const agent = { ...(rawAgent ?? {}) };
-		if (tools === undefined) delete agent.tools;
-		else agent.tools = tools;
-		if (Object.keys(agent).length > 0) {
-			Object.defineProperty(agents, name, {
-				value: agent,
-				enumerable: true,
-				configurable: true,
-				writable: true,
-			});
-		} else {
-			delete agents[name];
+		for (const [name, patch] of Object.entries(patches)) {
+			const rawAgent = hasOwn(agents, name) ? agents[name] : undefined;
+			if (rawAgent !== undefined && !isPlainObject(rawAgent)) {
+				throw new Error(`Cannot update invalid ${SETTINGS_FILE} settings for ${name}`);
+			}
+			const agent = { ...(rawAgent ?? {}) };
+			for (const field of ["tools", "model", "thinkingLevel", "timeoutMs"] as const) {
+				if (!hasOwn(patch, field)) continue;
+				const value = patch[field];
+				if (value === undefined) delete agent[field];
+				else
+					Object.defineProperty(agent, field, {
+						value,
+						enumerable: true,
+						configurable: true,
+						writable: true,
+					});
+			}
+			if (Object.keys(agent).length > 0) {
+				Object.defineProperty(agents, name, {
+					value: agent,
+					enumerable: true,
+					configurable: true,
+					writable: true,
+				});
+			} else {
+				delete agents[name];
+			}
 		}
 
+		const normalized = normalizeSubagentSettings({
+			...raw,
+			...(Object.keys(agents).length > 0 ? { agents } : {}),
+		});
+		if (!normalized) throw new Error(`Cannot update invalid ${SETTINGS_FILE} agent settings`);
 		const updated = { ...raw };
 		if (Object.keys(agents).length > 0) updated.agents = agents;
 		else delete updated.agents;

--- a/packages/pi-subagents/src/spawn-idempotency.ts
+++ b/packages/pi-subagents/src/spawn-idempotency.ts
@@ -1,0 +1,50 @@
+import { createHash } from "node:crypto";
+import type { AgentScope, SubagentThinkingLevel } from "./agents.js";
+import type { SubagentResultFormat } from "./result-contract.js";
+
+export const MAX_SPAWN_IDEMPOTENCY_KEY_LENGTH = 256;
+
+export interface CanonicalSpawnRequest {
+	agent: string;
+	task: string;
+	cwd: string;
+	agentScope: AgentScope;
+	thinkingLevel?: SubagentThinkingLevel;
+	parentId?: string;
+	context?: string;
+	contextSourceIds: readonly string[];
+	workspaceMode: "shared" | "worktree";
+	allowConcurrentWrites: boolean;
+	resultFormat: SubagentResultFormat;
+}
+
+export function hashSpawnRequest(request: CanonicalSpawnRequest): string {
+	return createHash("sha256")
+		.update(
+			JSON.stringify({
+				agent: request.agent,
+				task: request.task,
+				cwd: request.cwd,
+				agentScope: request.agentScope,
+				thinkingLevel: request.thinkingLevel ?? null,
+				parentId: request.parentId ?? null,
+				contextHash: request.context
+					? createHash("sha256").update(request.context).digest("hex")
+					: null,
+				contextSourceIds: [...request.contextSourceIds],
+				workspaceMode: request.workspaceMode,
+				allowConcurrentWrites: request.allowConcurrentWrites,
+				resultFormat: request.resultFormat,
+			}),
+		)
+		.digest("hex");
+}
+
+export function assertSpawnIdempotencyKey(value: string | undefined): void {
+	if (value === undefined) return;
+	if (!value || value.length > MAX_SPAWN_IDEMPOTENCY_KEY_LENGTH) {
+		throw new Error(
+			`subagent_spawn idempotencyKey must contain 1-${MAX_SPAWN_IDEMPOTENCY_KEY_LENGTH} characters`,
+		);
+	}
+}

--- a/packages/pi-subagents/src/spawn-idempotency.ts
+++ b/packages/pi-subagents/src/spawn-idempotency.ts
@@ -10,6 +10,7 @@ export interface CanonicalSpawnRequest {
 	cwd: string;
 	agentScope: AgentScope;
 	thinkingLevel?: SubagentThinkingLevel;
+	timeoutMs?: number;
 	parentId?: string;
 	context?: string;
 	contextSourceIds: readonly string[];
@@ -27,6 +28,7 @@ export function hashSpawnRequest(request: CanonicalSpawnRequest): string {
 				cwd: request.cwd,
 				agentScope: request.agentScope,
 				thinkingLevel: request.thinkingLevel ?? null,
+				...(request.timeoutMs === undefined ? {} : { timeoutMs: request.timeoutMs }),
 				parentId: request.parentId ?? null,
 				contextHash: request.context
 					? createHash("sha256").update(request.context).digest("hex")

--- a/packages/pi-subagents/src/stateful-guidance.ts
+++ b/packages/pi-subagents/src/stateful-guidance.ts
@@ -19,6 +19,7 @@ export function createSpawnPromptGuidelines(
 	return [
 		"Do not use subagent_spawn for simple or critical-path work that the main agent can perform directly.",
 		"Set subagent_spawn thinkingLevel to the lowest sufficient thinking level for the delegated task: use off or minimal for extraction, formatting, or mechanical work; low for straightforward bounded work; medium for ordinary multi-step research or implementation; high for complex debugging, design, review, or cross-file analysis; xhigh for highly ambiguous, cross-system, or high-risk analysis; and max only for the hardest tasks when quality clearly outweighs latency and cost. Omit subagent_spawn thinkingLevel only to preserve the agent or child default.",
+		"Set subagent_spawn timeoutMs to the shortest realistic work deadline for the task difficulty; split oversized tasks instead of extending the deadline merely to compensate for broad scope. Omit timeoutMs only to preserve the retained agent or configured default.",
 		deliveryGuidance,
 		"Use a single subagent_spawn only for a concrete bounded subtask that can run independently and has an isolation or specialization benefit such as independent review, bounded context/output, a distinct model/tool profile, or workspace isolation.",
 		...(blockingEnabled

--- a/packages/pi-subagents/src/stateful-lifecycle.ts
+++ b/packages/pi-subagents/src/stateful-lifecycle.ts
@@ -19,13 +19,38 @@ export async function disposeStatefulRuntime(
 	return errors;
 }
 
+export async function waitForOwnedSpawn<T>(
+	promise: Promise<T>,
+	signal: AbortSignal | undefined,
+): Promise<T> {
+	if (!signal) return promise;
+	if (signal.aborted) throw ownedSpawnAbortError();
+	let abortHandler: (() => void) | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_resolve, reject) => {
+				abortHandler = () => reject(ownedSpawnAbortError());
+				signal.addEventListener("abort", abortHandler, { once: true });
+				if (signal.aborted) abortHandler();
+			}),
+		]);
+	} finally {
+		if (abortHandler) signal.removeEventListener("abort", abortHandler);
+	}
+}
+
 export function assertCurrentSpawn(
 	signal: AbortSignal | undefined,
 	generation: number,
 	currentGeneration: number,
 ): void {
 	if (!signal?.aborted && generation === currentGeneration) return;
+	throw ownedSpawnAbortError();
+}
+
+function ownedSpawnAbortError(): Error {
 	const error = new Error("Subagent spawn owner was replaced or aborted");
 	error.name = "AbortError";
-	throw error;
+	return error;
 }

--- a/packages/pi-subagents/src/stateful-prompt.ts
+++ b/packages/pi-subagents/src/stateful-prompt.ts
@@ -3,9 +3,13 @@ import { redactPrivateText } from "./context.js";
 import { resolveDefaultSubagentTimeoutMs } from "./execution.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
 import type { ManagedAgent } from "./registry.js";
+import { appendResultInstruction } from "./result-contract.js";
 
 export function buildStatefulTurnPrompt(
-	record: Pick<ManagedAgent, "context" | "history" | "mailbox" | "currentMailboxMessageIds">,
+	record: Pick<
+		ManagedAgent,
+		"context" | "history" | "mailbox" | "currentMailboxMessageIds" | "resultFormat"
+	>,
 	task: string,
 	maxBytes = DEFAULT_MAX_CONTEXT_BYTES,
 ): { text: string; truncated: boolean } {
@@ -30,7 +34,7 @@ export function buildStatefulTurnPrompt(
 	]
 		.filter(Boolean)
 		.join("\n\n---\n\n");
-	return truncateUtf8(context, maxBytes);
+	return truncateUtf8(appendResultInstruction(context, record.resultFormat, maxBytes), maxBytes);
 }
 
 export function resolveStatefulTurnTimeout(

--- a/packages/pi-subagents/src/stateful-render.ts
+++ b/packages/pi-subagents/src/stateful-render.ts
@@ -43,6 +43,7 @@ function renderStatefulCall(tool: StatefulRenderTool, args: Record<string, unkno
 			safeLine(args.workspaceMode, "shared", 64),
 		];
 		if (typeof args.thinkingLevel === "string") metadata.push(`thinking:${args.thinkingLevel}`);
+		if (typeof args.timeoutMs === "number") metadata.push(`timeout:${args.timeoutMs}ms`);
 		return new Text(
 			[
 				toolHeader(theme, "subagent_spawn", args.agent, metadata),
@@ -53,9 +54,11 @@ function renderStatefulCall(tool: StatefulRenderTool, args: Record<string, unkno
 		);
 	}
 	if (tool === "send") {
+		const metadata = ["follow-up"];
+		if (typeof args.timeoutMs === "number") metadata.push(`timeout:${args.timeoutMs}ms`);
 		return new Text(
 			[
-				toolHeader(theme, "subagent_send", args.agentId, ["follow-up"]),
+				toolHeader(theme, "subagent_send", args.agentId, metadata),
 				`  ${theme.fg("dim", safeLine(args.task, "...", 2 * 1024))}`,
 			].join("\n"),
 			0,
@@ -112,12 +115,22 @@ function renderAgentResult(
 		`${statusBadge(theme, lifecycleStatus(state))} · ${theme.fg("accent", safeLine(agent.id, "agent", 256))} · ${theme.fg("toolOutput", safeLine(agent.agent, "subagent", 256))} · ${theme.fg("muted", state)}`,
 	];
 	const thinking = stringValue(agent.thinkingLevel);
+	const timeout =
+		typeof agent.currentTimeoutMs === "number"
+			? agent.currentTimeoutMs
+			: typeof agent.timeoutMs === "number"
+				? agent.timeoutMs
+				: 0;
 	const unread = typeof agent.unreadMessages === "number" ? agent.unreadMessages : 0;
-	if (thinking || unread > 0) {
+	if (thinking || timeout || unread > 0) {
 		lines.push(
 			theme.fg(
 				"dim",
-				[thinking && `thinking:${safeLine(thinking, "", 128)}`, unread > 0 && `unread:${unread}`]
+				[
+					thinking && `thinking:${safeLine(thinking, "", 128)}`,
+					timeout && `timeout:${timeout}ms`,
+					unread > 0 && `unread:${unread}`,
+				]
 					.filter(Boolean)
 					.join(" · "),
 			),

--- a/packages/pi-subagents/src/stateful.ts
+++ b/packages/pi-subagents/src/stateful.ts
@@ -1,10 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { StringEnum } from "@earendil-works/pi-ai";
-import {
-	defineTool,
-	type ExtensionAPI,
-	type ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
+import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import {
 	type AgentScope,
@@ -13,32 +9,40 @@ import {
 	isThinkingLevel,
 	type SubagentRuntimeSettings,
 	type SubagentSettings,
+	type SubagentTransportKind,
 	THINKING_LEVELS,
 } from "./agents.js";
+import { CompletionDeliveryBroker } from "./completion-delivery.js";
 import { buildContextSnapshot, type ContextMode, redactPrivateText } from "./context.js";
+import { createStatefulTransport } from "./create-stateful-transport.js";
 import {
 	assertDelegationTargetAllowed,
 	resolveSubagentTarget,
 	targetPolicyAudit,
 } from "./cwd-policy.js";
 import { assertSubagentDepthAllowed } from "./execution.js";
-import {
-	type ChildSessionFactory,
-	InProcessTransport,
-	type ParentRuntimeSnapshot,
-} from "./in-process-transport.js";
+import type { ChildSessionFactory, ParentRuntimeSnapshot } from "./in-process-transport.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
 import { AgentPersistence } from "./persistence.js";
 import {
 	AgentRegistry,
 	type AgentRunInspectionDetail,
 	type AgentRunInspectionSummary,
-	type AgentTurnCompletion,
 	type ManagedAgent,
 } from "./registry.js";
+import { SUBAGENT_RESULT_FORMATS, type SubagentResultFormat } from "./result-contract.js";
 import { DEFAULT_DELEGATION_CWD_POLICY, readSubagentSettings } from "./settings.js";
+import {
+	assertSpawnIdempotencyKey,
+	hashSpawnRequest,
+	MAX_SPAWN_IDEMPOTENCY_KEY_LENGTH,
+} from "./spawn-idempotency.js";
 import { createSpawnPromptGuidelines } from "./stateful-guidance.js";
-import { assertCurrentSpawn, disposeStatefulRuntime } from "./stateful-lifecycle.js";
+import {
+	assertCurrentSpawn,
+	disposeStatefulRuntime,
+	waitForOwnedSpawn,
+} from "./stateful-lifecycle.js";
 import { resolveStatefulLimits, type StatefulLimits } from "./stateful-limits.js";
 import { createStatefulToolRenderer } from "./stateful-render.js";
 import {
@@ -59,7 +63,6 @@ import {
 	validateMailboxParams,
 	validateManageParams,
 } from "./stateful-tool-params.js";
-import { SubprocessTransport } from "./subprocess-transport.js";
 import { WorkspaceManager } from "./workspace.js";
 
 const ContextModeSchema = Type.Union([
@@ -76,9 +79,6 @@ const StatefulThinkingLevelSchema = StringEnum(THINKING_LEVELS, {
 		"Optional requested Pi thinking level selected for this task difficulty; retained for every turn of the spawned agent.",
 });
 const MAX_TOOL_MESSAGE_BYTES = 2 * 1024;
-const MAX_COMPLETION_ERROR_BYTES = 512;
-const MAX_COMPLETIONS_PER_MESSAGE = 16;
-const COMPLETION_BATCH_DELAY_MS = 10;
 
 export interface StatefulSubagentDependencies {
 	blockingEnabled?: boolean;
@@ -91,7 +91,7 @@ export interface StatefulSubagentDependencies {
 export interface StatefulSubagentRuntimeStatus {
 	enabled: boolean;
 	initialized: boolean;
-	transport: "subprocess" | "in-process";
+	transport: SubagentTransportKind;
 	completionDelivery: CompletionDelivery;
 	limits: StatefulLimits;
 	activeAgents: number;
@@ -138,6 +138,10 @@ export function registerStatefulSubagents(
 	const workspaceManager = dependencies.workspaceManager ?? new WorkspaceManager();
 	const isolatedAgents = new Map<string, string>();
 	const seenMessageIds = new Set<string>();
+	const pendingIdempotentSpawns = new Map<
+		string,
+		{ requestHash: string; promise: Promise<ManagedAgent> }
+	>();
 	const parentRuntime: ParentRuntimeSnapshot = { model: undefined, thinkingLevel: "off" };
 	const getCurrentSettings = () =>
 		dependencies.getSettings ? dependencies.getSettings() : readSubagentSettings();
@@ -207,12 +211,6 @@ export function registerStatefulSubagents(
 		if (!registry) throw new Error("Stateful subagents are not initialized for this session");
 		return registry;
 	};
-	const requireAgent = (agentId: string) => {
-		const agent = requireRegistry().get(agentId);
-		if (!agent) throw new Error(`Unknown subagent: ${agentId}`);
-		return agent;
-	};
-
 	pi.on("session_start", async (_event, ctx) => {
 		const generation = ++runtimeGeneration;
 		completionBroker?.close();
@@ -224,6 +222,7 @@ export function registerStatefulSubagents(
 		persistence = undefined;
 		isolatedAgents.clear();
 		seenMessageIds.clear();
+		pendingIdempotentSpawns.clear();
 		const initialize = async () => {
 			const cleanupErrors = await disposeStatefulRuntime(previousRegistry, workspaceManager);
 			if (generation !== runtimeGeneration) return;
@@ -245,28 +244,28 @@ export function registerStatefulSubagents(
 				retentionDays: sessionSettings.retentionDays,
 				maxStoredAgents: nextLimits.maxStoredAgents,
 			});
+			let nextRegistry: AgentRegistry;
 			const sessionBroker = new CompletionDeliveryBroker(pi, ctx, completionDelivery, {
 				onDeliveryError: (error) => {
 					if (!ctx.hasUI) return;
 					const reason = error instanceof Error ? error.message : String(error);
 					ctx.ui.notify(`Subagent completion delivery failed: ${reason}`, "warning");
 				},
+				onDelivered: (completions, deliveredAt) => {
+					if (generation !== runtimeGeneration) return;
+					for (const completion of completions) {
+						nextRegistry.markCompletionDelivered(completion.agent.id, deliveredAt);
+					}
+				},
 			});
-			const transport =
-				transportKind === "in-process"
-					? new InProcessTransport({
-							modelRegistry: ctx.modelRegistry,
-							getParentRuntime: () => ({ ...parentRuntime }),
-							createSession: dependencies.createInProcessSession,
-							discoverAgent: (agent) =>
-								discoverAgents(
-									agent.cwd,
-									agent.agentScope ?? "user",
-									getCurrentSettings(),
-								).agents.find((candidate) => candidate.name === agent.agent),
-						})
-					: new SubprocessTransport({ getSettings: getCurrentSettings });
-			const nextRegistry = new AgentRegistry(transport, {
+			const transport = createStatefulTransport({
+				kind: transportKind,
+				modelRegistry: ctx.modelRegistry,
+				getParentRuntime: () => ({ ...parentRuntime }),
+				getSettings: getCurrentSettings,
+				createInProcessSession: dependencies.createInProcessSession,
+			});
+			nextRegistry = new AgentRegistry(transport, {
 				maxAgents: nextLimits.maxAgents,
 				maxActiveTurns: nextLimits.maxActiveTurns,
 				maxDepth: nextLimits.maxDepth,
@@ -372,6 +371,7 @@ export function registerStatefulSubagents(
 		persistence = undefined;
 		isolatedAgents.clear();
 		seenMessageIds.clear();
+		pendingIdempotentSpawns.clear();
 		const shutdown = async () => {
 			const errors = await disposeStatefulRuntime(previousRegistry, workspaceManager);
 			if (errors.length > 0 && ctx.hasUI) {
@@ -411,11 +411,25 @@ export function registerStatefulSubagents(
 					description: "Use the shared workspace or an opt-in disposable Git worktree.",
 				}),
 			),
+			idempotencyKey: Type.Optional(
+				Type.String({
+					minLength: 1,
+					maxLength: MAX_SPAWN_IDEMPOTENCY_KEY_LENGTH,
+					description: "Reuse the same retained agent for an exact accepted spawn retry.",
+				}),
+			),
+			resultFormat: Type.Optional(
+				StringEnum(SUBAGENT_RESULT_FORMATS, {
+					description: "Use text (default) or the opt-in structured-v1 completion contract.",
+				}),
+			),
 		}),
 		...createStatefulToolRenderer("spawn"),
 		async execute(_id, params, signal, _update, ctx) {
 			const scope = (params.agentScope ?? "user") as AgentScope;
+			const resultFormat = (params.resultFormat ?? "text") as SubagentResultFormat;
 			assertSubagentDepthAllowed();
+			assertSpawnIdempotencyKey(params.idempotencyKey);
 			const generation = runtimeGeneration;
 			const currentSettings = getCurrentSettings();
 			const target = resolveSubagentTarget({
@@ -428,22 +442,6 @@ export function registerStatefulSubagents(
 				currentSettings?.cwdPolicy?.delegation ?? DEFAULT_DELEGATION_CWD_POLICY,
 			);
 			const cwd = target.cwd;
-			await confirmProjectAgent(
-				params.agent,
-				scope,
-				params.confirmProjectAgents ?? true,
-				ctx,
-				cwd,
-				currentSettings,
-			);
-			assertCurrentSpawn(signal, generation, runtimeGeneration);
-			const ownedRegistry = requireRegistry();
-			const resolvedAgent = discoverAgents(cwd, scope, currentSettings).agents.find(
-				(agent) => agent.name === params.agent,
-			);
-			if (params.workspaceMode === "worktree" && resolvedAgent?.source === "project") {
-				throw new Error("Project-local subagent definitions cannot run in a detached worktree");
-			}
 			const mode = resolveSpawnContextMode(params.context, params.contextEntryIds);
 			const snapshot = buildContextSnapshot(
 				ctx.sessionManager.getBranch(),
@@ -451,59 +449,129 @@ export function registerStatefulSubagents(
 				DEFAULT_MAX_CONTEXT_BYTES,
 				params.contextEntryIds,
 			);
-			const requestedCwd = cwd;
-			if ((params.workspaceMode ?? "shared") === "shared" && !params.allowConcurrentWrites) {
-				assertNoSharedWriteConflict(
-					ownedRegistry,
+			if ((scope === "project" || scope === "both") && !ctx.isProjectTrusted()) {
+				throw new Error("Project-local subagent definitions require a trusted project");
+			}
+			const requestHash = hashSpawnRequest({
+				agent: params.agent,
+				task: params.task,
+				cwd,
+				agentScope: scope,
+				thinkingLevel: params.thinkingLevel,
+				parentId: params.parentId,
+				context: snapshot.text || undefined,
+				contextSourceIds: snapshot.sourceIds,
+				workspaceMode: params.workspaceMode ?? "shared",
+				allowConcurrentWrites: params.allowConcurrentWrites ?? false,
+				resultFormat,
+			});
+			const ownedRegistry = requireRegistry();
+			const retained = ownedRegistry.findBySpawnIdempotencyKey(params.idempotencyKey, requestHash);
+			if (retained) return result(retained, `Reused ${retained.agent} as ${retained.id}.`);
+			const pending = params.idempotencyKey
+				? pendingIdempotentSpawns.get(params.idempotencyKey)
+				: undefined;
+			if (pending) {
+				if (pending.requestHash !== requestHash) {
+					throw new Error("The subagent_spawn idempotencyKey is pending with different parameters");
+				}
+				const agent = await waitForOwnedSpawn(pending.promise, signal);
+				assertCurrentSpawn(signal, generation, runtimeGeneration);
+				return result(agent, `Reused ${agent.agent} as ${agent.id}.`);
+			}
+			let resolvePending: ((agent: ManagedAgent) => void) | undefined;
+			let rejectPending: ((error: unknown) => void) | undefined;
+			if (params.idempotencyKey) {
+				const promise = new Promise<ManagedAgent>((resolve, reject) => {
+					resolvePending = resolve;
+					rejectPending = reject;
+				});
+				void promise.catch(() => undefined);
+				pendingIdempotentSpawns.set(params.idempotencyKey, { requestHash, promise });
+			}
+			try {
+				await confirmProjectAgent(
 					params.agent,
-					requestedCwd,
 					scope,
+					params.confirmProjectAgents ?? true,
+					ctx,
+					cwd,
 					currentSettings,
 				);
-			}
-			const workspaceOwner = `pending-${randomUUID()}`;
-			const workspace =
-				params.workspaceMode === "worktree"
-					? await workspaceManager.create(workspaceOwner, requestedCwd)
-					: undefined;
-			try {
 				assertCurrentSpawn(signal, generation, runtimeGeneration);
-			} catch (error) {
-				if (workspace) await workspaceManager.cleanup(workspaceOwner);
-				throw error;
-			}
-			const targetSnapshot = targetPolicyAudit(target);
-			let agent: ManagedAgent | undefined;
-			try {
-				agent = await ownedRegistry.spawn({
-					agent: params.agent,
-					task: params.task,
-					cwd: workspace?.path ?? requestedCwd,
-					agentScope: scope,
-					thinkingLevel: params.thinkingLevel,
-					parentId: params.parentId,
-					context: snapshot.text || undefined,
-					contextSourceIds: snapshot.sourceIds,
-					contextTruncated: snapshot.truncated,
-					workspaceMode: workspace ? "worktree" : undefined,
-					target: targetSnapshot,
-				});
+				const resolvedAgent = discoverAgents(cwd, scope, currentSettings).agents.find(
+					(agent) => agent.name === params.agent,
+				);
+				if (params.workspaceMode === "worktree" && resolvedAgent?.source === "project") {
+					throw new Error("Project-local subagent definitions cannot run in a detached worktree");
+				}
+				const requestedCwd = cwd;
+				if ((params.workspaceMode ?? "shared") === "shared" && !params.allowConcurrentWrites) {
+					assertNoSharedWriteConflict(
+						ownedRegistry,
+						params.agent,
+						requestedCwd,
+						scope,
+						currentSettings,
+					);
+				}
+				const workspaceOwner = `pending-${randomUUID()}`;
+				const workspace =
+					params.workspaceMode === "worktree"
+						? await workspaceManager.create(workspaceOwner, requestedCwd)
+						: undefined;
+				try {
+					assertCurrentSpawn(signal, generation, runtimeGeneration);
+				} catch (error) {
+					if (workspace) await workspaceManager.cleanup(workspaceOwner);
+					throw error;
+				}
+				const targetSnapshot = targetPolicyAudit(target);
+				let agent: ManagedAgent | undefined;
+				try {
+					agent = await ownedRegistry.spawn({
+						agent: params.agent,
+						task: params.task,
+						cwd: workspace?.path ?? requestedCwd,
+						agentScope: scope,
+						thinkingLevel: params.thinkingLevel,
+						parentId: params.parentId,
+						context: snapshot.text || undefined,
+						contextSourceIds: snapshot.sourceIds,
+						contextTruncated: snapshot.truncated,
+						contextTurns: snapshot.turns,
+						contextBytes: Buffer.byteLength(snapshot.text, "utf8"),
+						workspaceMode: workspace ? "worktree" : undefined,
+						spawnIdempotencyKey: params.idempotencyKey,
+						spawnRequestHash: params.idempotencyKey ? requestHash : undefined,
+						resultFormat: resultFormat === "text" ? undefined : resultFormat,
+						target: targetSnapshot,
+					});
+					assertCurrentSpawn(signal, generation, runtimeGeneration);
+				} catch (error) {
+					if (agent) await ownedRegistry.closeTree(agent.id).catch(() => undefined);
+					if (workspace) await workspaceManager.cleanup(workspaceOwner);
+					throw error;
+				}
+				if (!agent) throw new Error("Subagent spawn completed without a retained agent");
+				if (workspace && agent.cwd === workspace.path) isolatedAgents.set(agent.id, workspaceOwner);
+				else if (workspace) await workspaceManager.cleanup(workspaceOwner);
 				assertCurrentSpawn(signal, generation, runtimeGeneration);
+				resolvePending?.(agent);
+				const deliveryNote =
+					completionDelivery === "auto-resume"
+						? "If no useful local work remains, briefly tell the user what was launched and end the response; auto-resume will request synthesis after completion."
+						: "End the response without the result only when the current response does not depend on it; next-turn delivery will not wake an idle root.";
+				return result(
+					agent,
+					`Spawned ${agent.agent} as ${agent.id}. Do useful non-overlapping work immediately. ${deliveryNote} Do not poll for progress.`,
+				);
 			} catch (error) {
-				if (agent) await ownedRegistry.closeTree(agent.id).catch(() => undefined);
-				if (workspace) await workspaceManager.cleanup(workspaceOwner);
+				rejectPending?.(error);
 				throw error;
+			} finally {
+				if (params.idempotencyKey) pendingIdempotentSpawns.delete(params.idempotencyKey);
 			}
-			if (!agent) throw new Error("Subagent spawn completed without a retained agent");
-			if (workspace) isolatedAgents.set(agent.id, workspaceOwner);
-			const deliveryNote =
-				completionDelivery === "auto-resume"
-					? "If no useful local work remains, briefly tell the user what was launched and end the response; auto-resume will request synthesis after completion."
-					: "End the response without the result only when the current response does not depend on it; next-turn delivery will not wake an idle root.";
-			return result(
-				agent,
-				`Spawned ${agent.agent} as ${agent.id}. Do useful non-overlapping work immediately. ${deliveryNote} Do not poll for progress.`,
-			);
 		},
 	});
 	refreshSpawnToolRegistration = () => {
@@ -563,10 +631,17 @@ export function registerStatefulSubagents(
 		promptSnippet: "List or control retained detached subagents",
 		parameters: ManageParamsSchema,
 		...createStatefulToolRenderer("manage"),
-		async execute(_id, params): Promise<StatefulActionToolResult> {
+		async execute(_id, params, signal): Promise<StatefulActionToolResult> {
+			const generation = runtimeGeneration;
+			const ownedRegistry = requireRegistry();
+			const ownedAgent = (agentId: string): ManagedAgent => {
+				const value = ownedRegistry.get(agentId);
+				if (!value) throw new Error(`Unknown subagent: ${agentId}`);
+				return value;
+			};
 			const operation = validateManageParams(params);
 			if (operation.action === "list") {
-				const agents = requireRegistry().list(operation.includeClosed);
+				const agents = ownedRegistry.list(operation.includeClosed);
 				return {
 					content: [
 						{
@@ -580,46 +655,51 @@ export function registerStatefulSubagents(
 			const agentId = operation.agentId;
 			if (operation.action === "interrupt") {
 				if (operation.subtree) {
-					const agents = await requireRegistry().interruptTree(agentId);
+					const agents = await ownedRegistry.interruptTree(agentId);
+					assertCurrentSpawn(signal, generation, runtimeGeneration);
 					return {
 						content: [{ type: "text", text: `Interrupted ${agents.length} active agent(s).` }],
 						details: {
-							agent: summarizeAgent(requireAgent(agentId)),
+							agent: summarizeAgent(ownedAgent(agentId)),
 							agents: agents.map(summarizeAgent),
 						},
 					};
 				}
-				const agent = await requireRegistry().interrupt(agentId);
+				const agent = await ownedRegistry.interrupt(agentId);
+				assertCurrentSpawn(signal, generation, runtimeGeneration);
 				return result(agent, `Interrupted ${agent.id}; it remains reusable.`);
 			}
-			const existing = requireRegistry().get(agentId);
+			const existing = ownedRegistry.get(agentId);
 			if (existing?.state === "closed" && !operation.subtree) {
 				const pendingOwner = isolatedAgents.get(existing.id);
 				if (pendingOwner) await workspaceManager.cleanup(pendingOwner);
+				assertCurrentSpawn(signal, generation, runtimeGeneration);
 				isolatedAgents.delete(existing.id);
 				return result(existing, `Closed ${existing.id}.`);
 			}
 			if (operation.subtree) {
 				let agents: ManagedAgent[];
 				try {
-					agents = await requireRegistry().closeTree(agentId);
+					agents = await ownedRegistry.closeTree(agentId);
 				} finally {
-					await cleanupClosedWorkspaces(requireRegistry(), isolatedAgents, workspaceManager);
+					await cleanupClosedWorkspaces(ownedRegistry, isolatedAgents, workspaceManager);
 				}
+				assertCurrentSpawn(signal, generation, runtimeGeneration);
 				return {
 					content: [{ type: "text", text: `Closed ${agents.length} agent(s).` }],
 					details: {
-						agent: summarizeAgent(requireAgent(agentId)),
+						agent: summarizeAgent(ownedAgent(agentId)),
 						agents: agents.map(summarizeAgent),
 					},
 				};
 			}
 			let agent: ManagedAgent;
 			try {
-				agent = await requireRegistry().close(agentId);
+				agent = await ownedRegistry.close(agentId);
 			} finally {
-				await cleanupClosedWorkspaces(requireRegistry(), isolatedAgents, workspaceManager);
+				await cleanupClosedWorkspaces(ownedRegistry, isolatedAgents, workspaceManager);
 			}
+			assertCurrentSpawn(signal, generation, runtimeGeneration);
 			return result(agent, `Closed ${agent.id}.`);
 		},
 	});
@@ -632,25 +712,29 @@ export function registerStatefulSubagents(
 		promptSnippet: "Send or read queue-only detached-subagent mailbox messages",
 		parameters: MailboxParamsSchema,
 		...createStatefulToolRenderer("mailbox"),
-		async execute(_id, params): Promise<StatefulActionToolResult> {
+		async execute(_id, params, signal): Promise<StatefulActionToolResult> {
+			const generation = runtimeGeneration;
+			const ownedRegistry = requireRegistry();
 			const operation = validateMailboxParams(params);
 			if (operation.action === "send") {
-				const message = await requireRegistry().sendMessage(
+				const message = await ownedRegistry.sendMessage(
 					operation.agentId,
 					operation.message,
 					operation.senderId,
 					operation.deduplicationKey,
 				);
+				assertCurrentSpawn(signal, generation, runtimeGeneration);
 				return {
 					content: [{ type: "text", text: `Queued ${message.id} for ${message.recipientId}.` }],
 					details: { message },
 				};
 			}
-			const messages = await requireRegistry().readMessages(
+			const messages = await ownedRegistry.readMessages(
 				operation.agentId,
 				operation.acknowledge,
 				operation.limit,
 			);
+			assertCurrentSpawn(signal, generation, runtimeGeneration);
 			const summaries = messages.map((message) => ({
 				...message,
 				content: truncateUtf8(message.content, MAX_TOOL_MESSAGE_BYTES).text,
@@ -696,7 +780,10 @@ export function formatStatefulAgentLine(agent: ManagedAgent): string {
 	const unread = agent.mailbox.filter((message) => !message.readAt).length;
 	const indent = "  ".repeat(agent.depth);
 	const thinking = agent.thinkingLevel ? ` thinking:${agent.thinkingLevel}` : "";
-	return `${indent}${sanitizeStatusLine(agent.id, 128)} ${sanitizeStatusLine(agent.agent, 128)} ${agent.state} ${elapsedSeconds}s${thinking} unread:${unread} [${actions}]${task}`;
+	const transport = agent.telemetry?.transport ? ` transport:${agent.telemetry.transport}` : "";
+	const phase = agent.telemetry?.phase ? ` phase:${agent.telemetry.phase}` : "";
+	const queued = agent.telemetry?.queuePosition ? ` queue:${agent.telemetry.queuePosition}` : "";
+	return `${indent}${sanitizeStatusLine(agent.id, 128)} ${sanitizeStatusLine(agent.agent, 128)} ${agent.state} ${elapsedSeconds}s${thinking}${transport}${phase}${queued} unread:${unread} [${actions}]${task}`;
 }
 
 function sanitizeStatusLine(value: string, maxLength: number): string {
@@ -733,226 +820,19 @@ function summarizeAgent(agent: ManagedAgent) {
 			: undefined,
 		historyCount: agent.history.length,
 		unreadMessages: agent.mailbox.filter((message) => !message.readAt).length,
+		context: {
+			turns: agent.contextTurns ?? 0,
+			sources: agent.contextSourceIds?.length ?? 0,
+			bytes: agent.contextBytes ?? 0,
+			truncated: agent.contextTruncated === true,
+		},
+		resultFormat: agent.resultFormat ?? "text",
+		structuredResult: agent.structuredResult,
+		telemetry: agent.telemetry,
 		error: agent.error ? truncateUtf8(agent.error, MAX_TOOL_MESSAGE_BYTES).text : undefined,
 		target: agent.target,
 		policy: agent.policy,
 	};
-}
-
-interface CompletionMetadata {
-	agentId: string;
-	agent: string;
-	state: string;
-}
-
-interface CompletionMessage {
-	customType: "pi-subagent-completion";
-	content: string;
-	display: true;
-	details:
-		| CompletionMetadata
-		| {
-				completionCount: number;
-				completions: CompletionMetadata[];
-		  };
-}
-
-type CompletionContext = Pick<ExtensionContext, "hasPendingMessages" | "isIdle">;
-type CompletionPi = Pick<ExtensionAPI, "sendMessage">;
-
-export interface CompletionDeliveryBrokerOptions {
-	onDeliveryError?: (error: unknown) => void;
-}
-
-/**
- * Coalesces detached completions so one bounded notification batch starts at
- * most one root synthesis turn. The broker belongs to one parent session and
- * must be closed when that session is replaced or shut down.
- */
-export class CompletionDeliveryBroker {
-	private pending: AgentTurnCompletion[] = [];
-	private flushTimer?: NodeJS.Timeout;
-	private wakeInFlight = false;
-	private closed = false;
-
-	constructor(
-		private readonly pi: CompletionPi,
-		private readonly ctx: CompletionContext,
-		private delivery: CompletionDelivery,
-		private readonly options: CompletionDeliveryBrokerOptions = {},
-	) {}
-
-	enqueue(completion: AgentTurnCompletion): void {
-		if (this.closed) return;
-		this.pending.push(completion);
-		this.scheduleFlush();
-	}
-
-	setDelivery(value: CompletionDelivery): void {
-		this.delivery = value;
-		this.scheduleFlush();
-	}
-
-	onParentTurnStart(): void {
-		this.wakeInFlight = false;
-		this.scheduleFlush();
-	}
-
-	onParentSettled(): void {
-		this.wakeInFlight = false;
-		this.scheduleFlush();
-	}
-
-	flush(): void {
-		if (this.closed || this.pending.length === 0) return;
-		if (this.flushTimer) clearTimeout(this.flushTimer);
-		this.flushTimer = undefined;
-		if (this.delivery === "auto-resume" && !this.isRootIdle()) return;
-
-		const completions = this.pending.splice(0);
-		const batches = chunkCompletions(completions);
-		let canWake = this.shouldWakeRoot();
-		for (let index = 0; index < batches.length; index++) {
-			const triggerTurn = canWake && index === batches.length - 1;
-			const message = buildCompletionMessage(batches[index]);
-			if (triggerTurn) this.wakeInFlight = true;
-			try {
-				this.pi.sendMessage(message, { deliverAs: "steer", triggerTurn });
-			} catch (primaryError) {
-				if (triggerTurn) this.wakeInFlight = false;
-				canWake = false;
-				try {
-					this.pi.sendMessage(message, { deliverAs: "nextTurn", triggerTurn: false });
-				} catch (fallbackError) {
-					this.pending = [...batches.slice(index).flat(), ...this.pending];
-					try {
-						this.options.onDeliveryError?.(
-							new AggregateError(
-								[primaryError, fallbackError],
-								"Detached subagent completion delivery failed",
-							),
-						);
-					} catch {
-						// Delivery retention must survive a failing observer.
-					}
-					return;
-				}
-			}
-		}
-	}
-
-	close(): void {
-		this.closed = true;
-		if (this.flushTimer) clearTimeout(this.flushTimer);
-		this.flushTimer = undefined;
-		this.pending = [];
-	}
-
-	private scheduleFlush(): void {
-		if (this.closed || this.pending.length === 0 || this.flushTimer) return;
-		this.flushTimer = setTimeout(() => {
-			this.flushTimer = undefined;
-			this.flush();
-		}, COMPLETION_BATCH_DELAY_MS);
-	}
-
-	private isRootIdle(): boolean {
-		try {
-			return this.ctx.isIdle();
-		} catch {
-			return false;
-		}
-	}
-
-	private shouldWakeRoot(): boolean {
-		if (this.delivery !== "auto-resume" || this.wakeInFlight) return false;
-		try {
-			return !this.ctx.hasPendingMessages();
-		} catch {
-			return false;
-		}
-	}
-}
-
-function chunkCompletions(completions: AgentTurnCompletion[]): AgentTurnCompletion[][] {
-	const batches: AgentTurnCompletion[][] = [];
-	for (let index = 0; index < completions.length; index += MAX_COMPLETIONS_PER_MESSAGE) {
-		batches.push(completions.slice(index, index + MAX_COMPLETIONS_PER_MESSAGE));
-	}
-	return batches;
-}
-
-function buildCompletionMessage(completions: AgentTurnCompletion[]): CompletionMessage {
-	if (completions.length === 1) {
-		const completion = completions[0];
-		return {
-			customType: "pi-subagent-completion",
-			content: buildDetachedCompletionMessage(completion),
-			display: true,
-			details: completionMetadata(completion),
-		};
-	}
-	const content = truncateUtf8(
-		[
-			"Message Type: SUBAGENT_COMPLETION_BATCH",
-			`Completion Count: ${completions.length}`,
-			...completions.flatMap((completion, index) => [
-				"",
-				`--- Completion ${index + 1} of ${completions.length} ---`,
-				buildDetachedCompletionMessage(completion),
-			]),
-		].join("\n"),
-		DEFAULT_MAX_CONTEXT_BYTES,
-	).text;
-	return {
-		customType: "pi-subagent-completion",
-		content,
-		display: true,
-		details: {
-			completionCount: completions.length,
-			completions: completions.map(completionMetadata),
-		},
-	};
-}
-
-function completionMetadata(completion: AgentTurnCompletion): CompletionMetadata {
-	return {
-		agentId: completion.agent.id,
-		agent: completion.agent.agent,
-		state: completion.agent.state,
-	};
-}
-
-export function buildDetachedCompletionMessage(completion: AgentTurnCompletion): string {
-	const task = sanitizeCompletionLine(completion.task, 256) || "(unknown task)";
-	const agentName = sanitizeCompletionLine(completion.agent.agent, 128) || "(unknown agent)";
-	const output = redactPrivateText(completion.output);
-	const error = completion.error
-		? truncateUtf8(redactPrivateText(completion.error), MAX_COMPLETION_ERROR_BYTES).text
-		: "";
-	return truncateUtf8(
-		[
-			"Message Type: SUBAGENT_COMPLETION",
-			`Agent ID: ${completion.agent.id}`,
-			`Agent: ${agentName}`,
-			`Task: ${task}`,
-			`State: ${completion.agent.state}`,
-			...(error.trim() ? ["Error:", error] : []),
-			"Payload:",
-			output.trim() ? output : "(no output)",
-		].join("\n"),
-		MAX_TOOL_MESSAGE_BYTES,
-	).text;
-}
-
-function sanitizeCompletionLine(value: string, maxBytes: number): string {
-	return (
-		truncateUtf8(redactPrivateText(value), maxBytes)
-			// biome-ignore lint/suspicious/noControlCharactersInRegex: Strip untrusted terminal controls.
-			.text.replace(/[\u0000-\u001f\u007f]+/g, " ")
-			.replace(/\s+/g, " ")
-			.trim()
-	);
 }
 
 async function cleanupClosedWorkspaces(
@@ -979,8 +859,8 @@ function result(agent: ManagedAgent, text: string) {
 }
 
 export function resolveStatefulTransportKind(
-	value: "subprocess" | "in-process" | undefined,
-): "subprocess" | "in-process" {
+	value: SubagentTransportKind | undefined,
+): SubagentTransportKind {
 	return value ?? "subprocess";
 }
 
@@ -994,6 +874,10 @@ function normalizeRuntimeThinkingLevel(value: string): ParentRuntimeSnapshot["th
 	return isThinkingLevel(value) ? value : "off";
 }
 
+export {
+	buildDetachedCompletionMessage,
+	CompletionDeliveryBroker,
+} from "./completion-delivery.js";
 export {
 	buildStatefulTurnPrompt,
 	resolveStatefulTurnTimeout,

--- a/packages/pi-subagents/src/stateful.ts
+++ b/packages/pi-subagents/src/stateful.ts
@@ -138,10 +138,12 @@ export function registerStatefulSubagents(
 	const workspaceManager = dependencies.workspaceManager ?? new WorkspaceManager();
 	const isolatedAgents = new Map<string, string>();
 	const seenMessageIds = new Set<string>();
-	const pendingIdempotentSpawns = new Map<
-		string,
-		{ requestHash: string; promise: Promise<ManagedAgent> }
-	>();
+	type PendingIdempotentSpawn = {
+		generation: number;
+		requestHash: string;
+		promise: Promise<ManagedAgent>;
+	};
+	const pendingIdempotentSpawns = new Map<string, PendingIdempotentSpawn>();
 	const parentRuntime: ParentRuntimeSnapshot = { model: undefined, thinkingLevel: "off" };
 	const getCurrentSettings = () =>
 		dependencies.getSettings ? dependencies.getSettings() : readSubagentSettings();
@@ -468,9 +470,18 @@ export function registerStatefulSubagents(
 			const ownedRegistry = requireRegistry();
 			const retained = ownedRegistry.findBySpawnIdempotencyKey(params.idempotencyKey, requestHash);
 			if (retained) return result(retained, `Reused ${retained.agent} as ${retained.id}.`);
-			const pending = params.idempotencyKey
+			const foundPending = params.idempotencyKey
 				? pendingIdempotentSpawns.get(params.idempotencyKey)
 				: undefined;
+			if (
+				params.idempotencyKey &&
+				foundPending &&
+				foundPending.generation !== generation &&
+				pendingIdempotentSpawns.get(params.idempotencyKey) === foundPending
+			) {
+				pendingIdempotentSpawns.delete(params.idempotencyKey);
+			}
+			const pending = foundPending?.generation === generation ? foundPending : undefined;
 			if (pending) {
 				if (pending.requestHash !== requestHash) {
 					throw new Error("The subagent_spawn idempotencyKey is pending with different parameters");
@@ -481,13 +492,15 @@ export function registerStatefulSubagents(
 			}
 			let resolvePending: ((agent: ManagedAgent) => void) | undefined;
 			let rejectPending: ((error: unknown) => void) | undefined;
+			let ownedPending: PendingIdempotentSpawn | undefined;
 			if (params.idempotencyKey) {
 				const promise = new Promise<ManagedAgent>((resolve, reject) => {
 					resolvePending = resolve;
 					rejectPending = reject;
 				});
 				void promise.catch(() => undefined);
-				pendingIdempotentSpawns.set(params.idempotencyKey, { requestHash, promise });
+				ownedPending = { generation, requestHash, promise };
+				pendingIdempotentSpawns.set(params.idempotencyKey, ownedPending);
 			}
 			try {
 				await confirmProjectAgent(
@@ -570,7 +583,13 @@ export function registerStatefulSubagents(
 				rejectPending?.(error);
 				throw error;
 			} finally {
-				if (params.idempotencyKey) pendingIdempotentSpawns.delete(params.idempotencyKey);
+				if (
+					params.idempotencyKey &&
+					ownedPending &&
+					pendingIdempotentSpawns.get(params.idempotencyKey) === ownedPending
+				) {
+					pendingIdempotentSpawns.delete(params.idempotencyKey);
+				}
 			}
 		},
 	});

--- a/packages/pi-subagents/src/stateful.ts
+++ b/packages/pi-subagents/src/stateful.ts
@@ -22,7 +22,7 @@ import {
 } from "./cwd-policy.js";
 import { assertSubagentDepthAllowed } from "./execution.js";
 import type { ChildSessionFactory, ParentRuntimeSnapshot } from "./in-process-transport.js";
-import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, MAX_SUBAGENT_TIMEOUT_MS, truncateUtf8 } from "./limits.js";
 import { AgentPersistence } from "./persistence.js";
 import {
 	AgentRegistry,
@@ -77,6 +77,12 @@ const ScopeSchema = StringEnum(["user", "project", "both"] as const, {
 const StatefulThinkingLevelSchema = StringEnum(THINKING_LEVELS, {
 	description:
 		"Optional requested Pi thinking level selected for this task difficulty; retained for every turn of the spawned agent.",
+});
+const StatefulTimeoutSchema = Type.Integer({
+	minimum: 1,
+	maximum: MAX_SUBAGENT_TIMEOUT_MS,
+	description:
+		"Work deadline in milliseconds selected for the task difficulty. On expiry, Pi aborts the work and makes one separately bounded summary attempt. Retained as the agent default.",
 });
 const MAX_TOOL_MESSAGE_BYTES = 2 * 1024;
 
@@ -386,7 +392,7 @@ export function registerStatefulSubagents(
 	});
 
 	const baseSpawnDescription = () =>
-		`Start an addressable background subagent with an optional thinking level chosen for the task difficulty, return immediately with an agentId, and receive its completion asynchronously. Detached capacity: ${runtimeLimits.maxAgents} retained agents, ${runtimeLimits.maxActiveTurns} active turns, ${runtimeLimits.maxChildrenPerAgent} direct children per agent, and depth ${runtimeLimits.maxDepth}. Working-directory target policy: ${dependencies.getSettings?.()?.cwdPolicy?.delegation ?? DEFAULT_DELEGATION_CWD_POLICY}. This controls launch targets and protected project resources, not filesystem access or sandboxing.`;
+		`Start an addressable background subagent with an optional thinking level and timeout chosen for the task difficulty, return immediately with an agentId, and receive its completion asynchronously. Detached capacity: ${runtimeLimits.maxAgents} retained agents, ${runtimeLimits.maxActiveTurns} active turns, ${runtimeLimits.maxChildrenPerAgent} direct children per agent, and depth ${runtimeLimits.maxDepth}. Working-directory target policy: ${dependencies.getSettings?.()?.cwdPolicy?.delegation ?? DEFAULT_DELEGATION_CWD_POLICY}. This controls launch targets and protected project resources, not filesystem access or sandboxing.`;
 	const spawnTool = defineTool({
 		name: "subagent_spawn",
 		label: "Spawn Subagent",
@@ -397,6 +403,7 @@ export function registerStatefulSubagents(
 			agent: Type.String({ minLength: 1 }),
 			task: Type.String({ minLength: 1, maxLength: DEFAULT_MAX_CONTEXT_BYTES }),
 			thinkingLevel: Type.Optional(StatefulThinkingLevelSchema),
+			timeoutMs: Type.Optional(StatefulTimeoutSchema),
 			cwd: Type.Optional(Type.String()),
 			agentScope: Type.Optional(ScopeSchema),
 			confirmProjectAgents: Type.Optional(Type.Boolean({ default: true })),
@@ -460,6 +467,7 @@ export function registerStatefulSubagents(
 				cwd,
 				agentScope: scope,
 				thinkingLevel: params.thinkingLevel,
+				timeoutMs: params.timeoutMs,
 				parentId: params.parentId,
 				context: snapshot.text || undefined,
 				contextSourceIds: snapshot.sourceIds,
@@ -548,6 +556,7 @@ export function registerStatefulSubagents(
 						cwd: workspace?.path ?? requestedCwd,
 						agentScope: scope,
 						thinkingLevel: params.thinkingLevel,
+						timeoutMs: params.timeoutMs,
 						parentId: params.parentId,
 						context: snapshot.text || undefined,
 						contextSourceIds: snapshot.sourceIds,
@@ -609,6 +618,14 @@ export function registerStatefulSubagents(
 		parameters: Type.Object({
 			agentId: Type.String(),
 			task: Type.String({ minLength: 1, maxLength: DEFAULT_MAX_CONTEXT_BYTES }),
+			timeoutMs: Type.Optional(
+				Type.Integer({
+					minimum: 1,
+					maximum: MAX_SUBAGENT_TIMEOUT_MS,
+					description:
+						"Optional work deadline for this follow-up turn. On expiry, Pi aborts the work and makes one separately bounded summary attempt.",
+				}),
+			),
 			allowConcurrentWrites: Type.Optional(
 				Type.Boolean({ description: "Override the shared-workspace write conflict guard." }),
 			),
@@ -636,7 +653,9 @@ export function registerStatefulSubagents(
 				isolatedAgents.has(existing.id),
 				currentSettings,
 			);
-			const agent = await ownedRegistry.followUp(params.agentId, params.task);
+			const agent = await ownedRegistry.followUp(params.agentId, params.task, {
+				timeoutMs: params.timeoutMs,
+			});
 			assertCurrentSpawn(signal, generation, runtimeGeneration);
 			return result(agent, `Started follow-up for ${agent.id}.`);
 		},
@@ -799,10 +818,12 @@ export function formatStatefulAgentLine(agent: ManagedAgent): string {
 	const unread = agent.mailbox.filter((message) => !message.readAt).length;
 	const indent = "  ".repeat(agent.depth);
 	const thinking = agent.thinkingLevel ? ` thinking:${agent.thinkingLevel}` : "";
+	const timeout = agent.currentTimeoutMs ?? agent.timeoutMs;
+	const timeoutText = timeout ? ` timeout:${timeout}ms` : "";
 	const transport = agent.telemetry?.transport ? ` transport:${agent.telemetry.transport}` : "";
 	const phase = agent.telemetry?.phase ? ` phase:${agent.telemetry.phase}` : "";
 	const queued = agent.telemetry?.queuePosition ? ` queue:${agent.telemetry.queuePosition}` : "";
-	return `${indent}${sanitizeStatusLine(agent.id, 128)} ${sanitizeStatusLine(agent.agent, 128)} ${agent.state} ${elapsedSeconds}s${thinking}${transport}${phase}${queued} unread:${unread} [${actions}]${task}`;
+	return `${indent}${sanitizeStatusLine(agent.id, 128)} ${sanitizeStatusLine(agent.agent, 128)} ${agent.state} ${elapsedSeconds}s${thinking}${timeoutText}${transport}${phase}${queued} unread:${unread} [${actions}]${task}`;
 }
 
 function sanitizeStatusLine(value: string, maxLength: number): string {
@@ -834,6 +855,8 @@ function summarizeAgent(agent: ManagedAgent) {
 		cwd: agent.cwd,
 		workspaceMode: agent.workspaceMode ?? "shared",
 		thinkingLevel: agent.thinkingLevel,
+		timeoutMs: agent.timeoutMs,
+		currentTimeoutMs: agent.currentTimeoutMs,
 		currentTask: agent.currentTask
 			? truncateUtf8(agent.currentTask, MAX_TOOL_MESSAGE_BYTES).text
 			: undefined,

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -185,6 +185,7 @@ function registerBlockingSubagent(
 		"For parallel subagent calls, omit the aggregator key entirely unless a fan-in step is required; do not send null, empty strings, or an empty object for unused optional fields.",
 		'Do not use subagent with project-local agents unless the user explicitly wants project agents or sets agentScope to "project" or "both"; keep confirmation enabled for untrusted repositories.',
 		"When using subagent, write self-contained tasks with file paths, context, expected output, and whether the subagent may edit files.",
+		"Set subagent timeoutMs to the shortest realistic work deadline for the task difficulty, just as thinkingLevel should match reasoning difficulty; split oversized tasks instead of extending the deadline merely to compensate for broad scope. On expiry, Pi aborts the work and makes one separately bounded summary attempt.",
 	];
 	const definition: ToolDefinition<typeof SubagentParams, SubagentDetails> = {
 		name: "subagent",

--- a/packages/pi-subagents/src/subprocess-transport.ts
+++ b/packages/pi-subagents/src/subprocess-transport.ts
@@ -4,6 +4,7 @@ import {
 	type SubagentSettings,
 	type SubagentThinkingLevel,
 } from "./agents.js";
+import { resolvePiPromptResources } from "./prompt-resources.js";
 import type { ManagedAgent, TurnOutcome } from "./registry.js";
 import { getResultFinalOutput, runSingleAgent, type SubagentDetails } from "./runner.js";
 import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.js";
@@ -45,6 +46,12 @@ export class SubprocessTransport implements SubagentTransport {
 		const discovery = discoverAgents(record.cwd, record.agentScope ?? "user", settings);
 		const agent = discovery.agents.find((candidate) => candidate.name === record.agent);
 		const boundedTask = buildStatefulTurnPrompt(record, task);
+		const projectTrust =
+			record.target?.trust.projectTrusted ??
+			(record.agentScope === "project" || record.agentScope === "both");
+		const promptResources = agent?.systemPrompt.trim()
+			? await resolvePiPromptResources(record.cwd, projectTrust)
+			: undefined;
 		const makeDetails = (results: SubagentDetails["results"]): SubagentDetails => ({
 			mode: "single",
 			agentScope: record.agentScope ?? "user",
@@ -65,9 +72,8 @@ export class SubprocessTransport implements SubagentTransport {
 			makeDetails,
 			undefined,
 			{
-				projectTrust:
-					record.target?.trust.projectTrusted ??
-					(record.agentScope === "project" || record.agentScope === "both"),
+				projectTrust,
+				appendSystemPromptPaths: promptResources?.appendSystemPromptPaths,
 			},
 		);
 		const settledAt = Date.now();

--- a/packages/pi-subagents/src/subprocess-transport.ts
+++ b/packages/pi-subagents/src/subprocess-transport.ts
@@ -67,13 +67,14 @@ export class SubprocessTransport implements SubagentTransport {
 			undefined,
 			signal,
 			resolveStatefulSubprocessThinkingLevel(discovery.agents, record),
-			resolveStatefulTurnTimeout(agent),
+			record.currentTimeoutMs ?? record.timeoutMs ?? resolveStatefulTurnTimeout(agent),
 			undefined,
 			makeDetails,
 			undefined,
 			{
 				projectTrust,
 				appendSystemPromptPaths: promptResources?.appendSystemPromptPaths,
+				timeoutResultFormat: record.resultFormat,
 			},
 		);
 		const settledAt = Date.now();

--- a/packages/pi-subagents/src/subprocess-transport.ts
+++ b/packages/pi-subagents/src/subprocess-transport.ts
@@ -9,6 +9,7 @@ import { getResultFinalOutput, runSingleAgent, type SubagentDetails } from "./ru
 import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.js";
 import { buildStatefulTurnPrompt, resolveStatefulTurnTimeout } from "./stateful-prompt.js";
 import type { SubagentTransport } from "./transport.js";
+import type { TransportProgressCallback, TransportTelemetry } from "./transport-types.js";
 
 export function resolveStatefulSubprocessThinkingLevel(
 	agents: readonly Pick<AgentConfig, "name" | "thinkingLevel">[],
@@ -26,7 +27,20 @@ export class SubprocessTransport implements SubagentTransport {
 
 	constructor(private readonly options: SubprocessTransportOptions = {}) {}
 
-	async runTurn(record: ManagedAgent, task: string, signal: AbortSignal): Promise<TurnOutcome> {
+	async runTurn(
+		record: ManagedAgent,
+		task: string,
+		signal: AbortSignal,
+		onProgress?: TransportProgressCallback,
+	): Promise<TurnOutcome> {
+		const startedAt = Date.now();
+		const starting: TransportTelemetry = {
+			transport: "subprocess",
+			phase: "starting",
+			updatedAt: startedAt,
+			timing: { startedAt, transportStartedAt: startedAt },
+		};
+		onProgress?.(starting);
 		const settings = this.options.getSettings ? this.options.getSettings() : readSubagentSettings();
 		const discovery = discoverAgents(record.cwd, record.agentScope ?? "user", settings);
 		const agent = discovery.agents.find((candidate) => candidate.name === record.agent);
@@ -56,6 +70,32 @@ export class SubprocessTransport implements SubagentTransport {
 					(record.agentScope === "project" || record.agentScope === "both"),
 			},
 		);
+		const settledAt = Date.now();
+		const telemetry: TransportTelemetry = {
+			...starting,
+			phase: single.aborted ? "interrupted" : single.exitCode === 0 ? "settled" : "failed",
+			failurePhase: single.exitCode === 0 ? undefined : "running",
+			updatedAt: settledAt,
+			timing: {
+				...starting.timing,
+				promptAcceptedAt: single.processStarted ? startedAt : undefined,
+				firstActivityAt: single.messages.length > 0 ? settledAt : undefined,
+				settledAt,
+			},
+			provider: single.actualProvider,
+			model: single.actualModel ?? single.model,
+			thinkingLevel: single.thinkingLevel,
+			usage: {
+				input: single.usage.input,
+				output: single.usage.output,
+				cacheRead: single.usage.cacheRead,
+				cacheWrite: single.usage.cacheWrite,
+				totalTokens: single.usage.totalTokens ?? 0,
+				cost: single.usage.cost,
+				turns: single.usage.turns,
+			},
+		};
+		onProgress?.(telemetry);
 		return {
 			output: getResultFinalOutput(single),
 			exitCode: single.exitCode,
@@ -63,6 +103,7 @@ export class SubprocessTransport implements SubagentTransport {
 			truncated: single.truncated || boundedTask.truncated,
 			error: single.errorMessage || single.stderr || undefined,
 			policy: single.policy,
+			telemetry,
 		};
 	}
 }

--- a/packages/pi-subagents/src/timeout-finalization.ts
+++ b/packages/pi-subagents/src/timeout-finalization.ts
@@ -1,0 +1,48 @@
+import { redactPrivateText } from "./context.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import { appendResultInstruction, type SubagentResultFormat } from "./result-contract.js";
+import type { RecentActivityItem } from "./runner.js";
+
+export const DEFAULT_TIMEOUT_FINALIZATION_MS = 45_000;
+
+export interface TimeoutFinalizationEvidence {
+	task: string;
+	partialOutput?: string;
+	recentActivity?: readonly RecentActivityItem[];
+	resultFormat?: SubagentResultFormat;
+}
+
+export function resolveTimeoutFinalizationMs(workTimeoutMs: number, override?: number): number {
+	const requested = override ?? Math.min(workTimeoutMs, DEFAULT_TIMEOUT_FINALIZATION_MS);
+	if (!Number.isFinite(requested) || requested < 1) {
+		throw new Error("Timeout finalization deadline must be a positive finite number");
+	}
+	return Math.min(Math.floor(requested), DEFAULT_TIMEOUT_FINALIZATION_MS);
+}
+
+export function buildTimeoutFinalizationPrompt(
+	evidence: TimeoutFinalizationEvidence,
+	maxBytes = DEFAULT_MAX_CONTEXT_BYTES,
+): string {
+	const activity = (evidence.recentActivity ?? [])
+		.slice(-10)
+		.map((item) =>
+			item.type === "text"
+				? `- Assistant note: ${redactPrivateText(item.text)}`
+				: `- Tool activity: ${redactPrivateText(item.name)}`,
+		)
+		.join("\n");
+	const prompt = [
+		"Work deadline expired and the active work was aborted.",
+		"Do not continue investigating, call tools, modify files, or retry the original task.",
+		"Return a concise summary of only verified findings and completed evidence already available.",
+		"Explicitly label unfinished or unverified areas.",
+		`Original task:\n${redactPrivateText(evidence.task)}`,
+		evidence.partialOutput
+			? `Partial assistant output:\n${redactPrivateText(evidence.partialOutput)}`
+			: "Partial assistant output: (none)",
+		activity ? `Recent bounded activity:\n${activity}` : "Recent bounded activity: (none)",
+	].join("\n\n");
+	return truncateUtf8(appendResultInstruction(prompt, evidence.resultFormat, maxBytes), maxBytes)
+		.text;
+}

--- a/packages/pi-subagents/src/transport-types.ts
+++ b/packages/pi-subagents/src/transport-types.ts
@@ -1,0 +1,67 @@
+import type { SubagentThinkingLevel } from "./agents.js";
+
+export const PI_SUBAGENTS_RPC_PROTOCOL = "pi-subagents:v1" as const;
+
+export type EffectiveSubagentTransportKind = "subprocess" | "in-process" | "rpc";
+
+export type TransportProgressPhase =
+	| "queued"
+	| "starting"
+	| "ready"
+	| "accepted"
+	| "running"
+	| "retrying"
+	| "compacting"
+	| "settled"
+	| "failed"
+	| "interrupted";
+
+export interface TransportUsage {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	totalTokens: number;
+	cost: number;
+	turns: number;
+}
+
+export interface TransportTiming {
+	queuedAt?: number;
+	startedAt?: number;
+	transportStartedAt?: number;
+	readyAt?: number;
+	promptAcceptedAt?: number;
+	firstActivityAt?: number;
+	settledAt?: number;
+	completionDeliveredAt?: number;
+}
+
+export interface TransportTelemetry {
+	transport?: EffectiveSubagentTransportKind;
+	selectionReason?: string;
+	protocol?: typeof PI_SUBAGENTS_RPC_PROTOCOL;
+	phase: TransportProgressPhase;
+	queuePosition?: number;
+	updatedAt: number;
+	timing: TransportTiming;
+	provider?: string;
+	model?: string;
+	thinkingLevel?: SubagentThinkingLevel;
+	usage?: TransportUsage;
+	failurePhase?: TransportProgressPhase;
+}
+
+export type TransportProgressCallback = (progress: TransportTelemetry) => void;
+
+export function emptyTransportUsage(): TransportUsage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: 0,
+		turns: 0,
+	};
+}

--- a/packages/pi-subagents/src/transport-types.ts
+++ b/packages/pi-subagents/src/transport-types.ts
@@ -10,6 +10,7 @@ export type TransportProgressPhase =
 	| "ready"
 	| "accepted"
 	| "running"
+	| "finalizing"
 	| "retrying"
 	| "compacting"
 	| "settled"

--- a/packages/pi-subagents/src/transport-ui.ts
+++ b/packages/pi-subagents/src/transport-ui.ts
@@ -1,0 +1,169 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { SubagentTransportKind } from "./agents.js";
+import { safeTerminalLine as safeTerminalText } from "./safe-text.js";
+import { inspectStatefulTransportSettings, updateStatefulTransportSetting } from "./settings.js";
+import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
+
+const TRANSPORT_OPTIONS: Array<{
+	value: SubagentTransportKind;
+	label: string;
+	description: string;
+}> = [
+	{
+		value: "subprocess",
+		label: "Fresh subprocess",
+		description: "Compatibility path with a fresh isolated Pi process for every turn.",
+	},
+	{
+		value: "in-process",
+		label: "In process",
+		description:
+			"Lowest follow-up overhead for built-in tools, with shared memory and crash boundary.",
+	},
+	{
+		value: "rpc",
+		label: "Persistent RPC process",
+		description: "Retain native history in one isolated Pi process per active retained agent.",
+	},
+	{
+		value: "auto",
+		label: "Automatic",
+		description:
+			"Read-only built-ins use in-process, write-capable built-ins use RPC, and custom tools use subprocess.",
+	},
+];
+
+export interface TransportUiRuntime {
+	getRuntimeStatus(): StatefulSubagentRuntimeStatus;
+}
+
+export function transportSettingsScreen(runtime: TransportUiRuntime) {
+	const configured = inspectStatefulTransportSettings();
+	const current = runtime.getRuntimeStatus();
+	return {
+		kind: "actions" as const,
+		title: configured.error ? "Detached Transport · Read only" : "Detached Transport",
+		lines: [
+			`Current session: ${transportLabel(current.transport)}`,
+			`Configured after reload: ${transportLabel(configured.value)} (${configured.source})`,
+			"Transport isolation is not a filesystem or network sandbox.",
+			"RPC v1 disables child extensions and supports built-in Pi tools only.",
+			...(configured.error
+				? [
+						`Settings cannot be edited: ${safeTerminalText(configured.error)}`,
+						`Repair ${safeTerminalText(configured.path)} and retry.`,
+					]
+				: []),
+		],
+		items: [
+			...(configured.error
+				? []
+				: TRANSPORT_OPTIONS.map((option) => ({
+						id: option.value,
+						label: option.label,
+						description: option.description,
+						action: "set-transport" as const,
+					}))),
+			{ id: "back", label: "Back", action: "back" as const },
+		],
+		hint: "back" as const,
+	};
+}
+
+export async function applyTransportSetting(
+	value: string,
+	ctx: ExtensionCommandContext,
+	runtime: TransportUiRuntime,
+	signal: AbortSignal,
+	isCurrent: () => boolean,
+) {
+	if (!isTransport(value)) return { kind: "rejected" as const };
+	const before = inspectStatefulTransportSettings();
+	if (before.error) return { kind: "rejected" as const };
+	if (value === before.value) return { kind: "stay" as const };
+	const status = runtime.getRuntimeStatus();
+	if (status.retainedAgents > 0) {
+		ctx.ui.notify(
+			`Cannot change transport while ${status.retainedAgents} detached agent${status.retainedAgents === 1 ? " is" : "s are"} retained. Clear Current agents first.`,
+			"warning",
+		);
+		return { kind: "rejected" as const };
+	}
+	const option = TRANSPORT_OPTIONS.find((candidate) => candidate.value === value);
+	const confirmed = await ctx.ui.confirm(
+		`Use ${transportLabel(value)} after reload?`,
+		`${option?.description ?? ""}\n\nThis saves the setting but does not reload Pi automatically.`,
+		{ signal },
+	);
+	if (signal.aborted || !isCurrent()) return { kind: "close" as const };
+	if (!confirmed) return { kind: "rejected" as const };
+	const after = inspectStatefulTransportSettings();
+	if (after.error || after.value !== before.value || after.source !== before.source) {
+		ctx.ui.notify("Transport settings changed while confirming; review again.", "warning");
+		return { kind: "rejected" as const };
+	}
+	if (runtime.getRuntimeStatus().retainedAgents > 0) {
+		ctx.ui.notify(
+			"Detached agents appeared while confirming; clear them before changing transport.",
+			"warning",
+		);
+		return { kind: "rejected" as const };
+	}
+	try {
+		updateStatefulTransportSetting(value);
+		ctx.ui.notify(`Saved ${transportLabel(value)}. Run /reload when ready.`, "info");
+		return { kind: "stay" as const };
+	} catch (error) {
+		ctx.ui.notify(
+			`Transport was not saved; the previous setting remains: ${safeTerminalText(error instanceof Error ? error.message : String(error))}`,
+			"error",
+		);
+		return { kind: "rejected" as const };
+	}
+}
+
+export function responsivenessSetupScreen(runtime: TransportUiRuntime) {
+	const current = runtime.getRuntimeStatus();
+	const configured = inspectStatefulTransportSettings();
+	return {
+		kind: "actions" as const,
+		title: "Responsiveness Setup",
+		lines: [
+			`Current transport: ${transportLabel(current.transport)}`,
+			`Configured transport: ${transportLabel(configured.value)}`,
+			"Transport, completion delivery, and thinking defaults are separate explicit choices.",
+			"Use Automatic to reduce retained follow-up startup while keeping custom-tool compatibility.",
+		],
+		items: [
+			{
+				id: "auto",
+				label: "Preview Automatic transport",
+				description: "Choose a deterministic transport before each retained agent starts",
+				action: "set-transport" as const,
+			},
+			{ id: "transport", label: "Compare all transports", to: "transport" as const },
+			{
+				id: "completion",
+				label: "Completion delivery",
+				description: "Choose separately whether an idle root resumes for synthesis",
+				to: "settings" as const,
+			},
+			{
+				id: "thinking",
+				label: "Thinking profiles",
+				description: "Preview explicit Fast, Balanced, or Deep per-agent defaults",
+				to: "execution-profiles" as const,
+			},
+			{ id: "back", label: "Back", action: "back" as const },
+		],
+		hint: "back" as const,
+	};
+}
+
+export function transportLabel(value: SubagentTransportKind): string {
+	return TRANSPORT_OPTIONS.find((option) => option.value === value)?.label ?? value;
+}
+
+function isTransport(value: string): value is SubagentTransportKind {
+	return ["subprocess", "in-process", "rpc", "auto"].includes(value);
+}

--- a/packages/pi-subagents/src/transport.ts
+++ b/packages/pi-subagents/src/transport.ts
@@ -1,8 +1,14 @@
 import type { ManagedAgent, TurnOutcome } from "./registry.js";
+import type { TransportProgressCallback } from "./transport-types.js";
 
 export interface SubagentTransport {
-	readonly kind: "subprocess" | "in-process" | "fake";
-	runTurn(agent: ManagedAgent, task: string, signal: AbortSignal): Promise<TurnOutcome>;
+	readonly kind: "subprocess" | "in-process" | "rpc" | "auto" | "fake";
+	runTurn(
+		agent: ManagedAgent,
+		task: string,
+		signal: AbortSignal,
+		onProgress?: TransportProgressCallback,
+	): Promise<TurnOutcome>;
 	release?(agent: ManagedAgent): Promise<void>;
 	shutdown?(): Promise<void>;
 }
@@ -11,6 +17,7 @@ export type AgentTurnRunner = (
 	agent: ManagedAgent,
 	task: string,
 	signal: AbortSignal,
+	onProgress?: TransportProgressCallback,
 ) => Promise<TurnOutcome>;
 
 export class FunctionTransport implements SubagentTransport {
@@ -18,8 +25,13 @@ export class FunctionTransport implements SubagentTransport {
 
 	constructor(private readonly runner: AgentTurnRunner) {}
 
-	runTurn(agent: ManagedAgent, task: string, signal: AbortSignal): Promise<TurnOutcome> {
-		return this.runner(agent, task, signal);
+	runTurn(
+		agent: ManagedAgent,
+		task: string,
+		signal: AbortSignal,
+		onProgress?: TransportProgressCallback,
+	): Promise<TurnOutcome> {
+		return this.runner(agent, task, signal, onProgress);
 	}
 }
 

--- a/packages/pi-subagents/src/workspace.ts
+++ b/packages/pi-subagents/src/workspace.ts
@@ -19,10 +19,11 @@ export class WorkspaceManager {
 
 	async create(ownerId: string, cwd: string): Promise<IsolatedWorkspace> {
 		if (this.owned.has(ownerId)) throw new Error(`Workspace owner already exists: ${ownerId}`);
-		const resolvedCwd = path.resolve(cwd);
-		const repositoryRoot = (
+		const resolvedCwd = await fs.promises.realpath(path.resolve(cwd));
+		const reportedRepositoryRoot = (
 			await execFileAsync("git", ["-C", resolvedCwd, "rev-parse", "--show-toplevel"])
 		).stdout.trim();
+		const repositoryRoot = await fs.promises.realpath(reportedRepositoryRoot);
 		const relativeCwd = path.relative(repositoryRoot, resolvedCwd);
 		if (relativeCwd.startsWith("..") || path.isAbsolute(relativeCwd)) {
 			throw new Error("Subagent cwd is outside the Git repository");

--- a/packages/pi-subagents/test/auto-transport.test.ts
+++ b/packages/pi-subagents/test/auto-transport.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import type { SubagentSettings } from "../src/agents.js";
+import { AutoTransport } from "../src/auto-transport.js";
+import type { ManagedAgent, TurnOutcome } from "../src/registry.js";
+import type { SubagentTransport } from "../src/transport.js";
+
+class FakeTransport implements SubagentTransport {
+	readonly calls: string[] = [];
+	readonly releases: string[] = [];
+	shutdowns = 0;
+
+	constructor(readonly kind: "subprocess" | "in-process" | "rpc") {}
+
+	async runTurn(agent: ManagedAgent): Promise<TurnOutcome> {
+		this.calls.push(agent.id);
+		return {
+			output: this.kind,
+			exitCode: 0,
+			telemetry: {
+				transport: this.kind,
+				phase: "settled",
+				updatedAt: Date.now(),
+				timing: {},
+			},
+		};
+	}
+
+	async release(agent: ManagedAgent): Promise<void> {
+		this.releases.push(agent.id);
+	}
+
+	async shutdown(): Promise<void> {
+		this.shutdowns++;
+	}
+}
+
+function agent(id: string, name: string): ManagedAgent {
+	return {
+		id,
+		agent: name,
+		rootId: id,
+		depth: 0,
+		children: [],
+		state: "running",
+		createdAt: 1,
+		updatedAt: 1,
+		cwd: process.cwd(),
+		history: [],
+		mailbox: [],
+	};
+}
+
+test("AutoTransport deterministically routes before launch and retains the selection", async () => {
+	const subprocess = new FakeTransport("subprocess");
+	const inProcess = new FakeTransport("in-process");
+	const rpc = new FakeTransport("rpc");
+	let settings: SubagentSettings | undefined;
+	const transport = new AutoTransport({
+		subprocess,
+		inProcess,
+		rpc,
+		getSettings: () => settings,
+	});
+	const planner = agent("planner-id", "planner");
+	const worker = agent("worker-id", "worker");
+	const planned = await transport.runTurn(planner, "plan", new AbortController().signal);
+	assert.equal(planned.output, "in-process");
+	assert.match(planned.telemetry?.selectionReason ?? "", /read-only/i);
+	const worked = await transport.runTurn(worker, "work", new AbortController().signal);
+	assert.equal(worked.output, "rpc");
+	assert.match(worked.telemetry?.selectionReason ?? "", /write-capable/i);
+	settings = { agents: { worker: { tools: ["custom_tool"] } } };
+	await transport.runTurn(worker, "follow-up", new AbortController().signal);
+	assert.equal(rpc.calls.length, 2, "existing retained selection must not change mid-runtime");
+	const custom = agent("custom-id", "worker");
+	const customResult = await transport.runTurn(custom, "custom", new AbortController().signal);
+	assert.equal(customResult.output, "subprocess");
+	assert.match(customResult.telemetry?.selectionReason ?? "", /custom tools/i);
+	await transport.release?.(planner);
+	await transport.release?.(worker);
+	await transport.release?.(custom);
+	assert.deepEqual(inProcess.releases, ["planner-id"]);
+	assert.deepEqual(rpc.releases, ["worker-id"]);
+	assert.deepEqual(subprocess.releases, ["custom-id"]);
+	await transport.shutdown();
+	assert.deepEqual([subprocess.shutdowns, inProcess.shutdowns, rpc.shutdowns], [1, 1, 1]);
+});

--- a/packages/pi-subagents/test/completion-delivery.test.ts
+++ b/packages/pi-subagents/test/completion-delivery.test.ts
@@ -34,6 +34,21 @@ function deliveryHarness(options: { idle?: boolean; pending?: boolean } = {}) {
 	return { pi, ctx, sent };
 }
 
+test("completion delivery reports one deterministic delivery timestamp after success", () => {
+	const harness = deliveryHarness();
+	const delivered: Array<{ ids: string[]; at: number }> = [];
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "next-turn", {
+		now: () => 1234,
+		onDelivered: (completions, at) => {
+			delivered.push({ ids: completions.map((value) => value.agent.id), at });
+		},
+	});
+	broker.enqueue(completion("sa_timed"));
+	broker.flush();
+	assert.deepEqual(delivered, [{ ids: ["sa_timed"], at: 1234 }]);
+	broker.close();
+});
+
 test("next-turn completion delivery never wakes an idle root", () => {
 	const harness = deliveryHarness();
 	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "next-turn");
@@ -45,6 +60,7 @@ test("next-turn completion delivery never wakes an idle root", () => {
 	assert.equal(harness.sent[0]?.message.customType, "pi-subagent-completion");
 	assert.match(String(harness.sent[0]?.message.content), /Agent ID: sa_one/);
 	assert.deepEqual(harness.sent[0]?.message.details, {
+		protocol: "pi-subagents:v1",
 		agentId: "sa_one",
 		agent: "scout",
 		state: "completed",
@@ -67,8 +83,18 @@ test("auto-resume batches simultaneous completions into one root synthesis turn"
 	assert.deepEqual(harness.sent[0]?.message.details, {
 		completionCount: 2,
 		completions: [
-			{ agentId: "sa_one", agent: "scout", state: "completed" },
-			{ agentId: "sa_two", agent: "scout", state: "completed" },
+			{
+				protocol: "pi-subagents:v1",
+				agentId: "sa_one",
+				agent: "scout",
+				state: "completed",
+			},
+			{
+				protocol: "pi-subagents:v1",
+				agentId: "sa_two",
+				agent: "scout",
+				state: "completed",
+			},
 		],
 	});
 	broker.close();

--- a/packages/pi-subagents/test/consult.test.ts
+++ b/packages/pi-subagents/test/consult.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { ProjectTrustStore } from "@earendil-works/pi-coding-agent";
@@ -483,7 +483,7 @@ test("subagent_consult follows Pi core prompt precedence without loading project
 			await execute(instance.tool, { agent: "worker", task: "inspect" }, trusted);
 			assert.equal(instance.requests[0].launchPolicy.baseSystemPrompt, "project system");
 			assert.deepEqual(instance.requests[0].launchPolicy.appendSystemPromptPaths, [
-				path.join(workspace, ".pi", "APPEND_SYSTEM.md"),
+				realpathSync(path.join(workspace, ".pi", "APPEND_SYSTEM.md")),
 			]);
 			assert.match(instance.requests[0].agent.systemPrompt, /read-only consultation/i);
 		}

--- a/packages/pi-subagents/test/cwd-policy.test.ts
+++ b/packages/pi-subagents/test/cwd-policy.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { ProjectTrustStore } from "@earendil-works/pi-coding-agent";
@@ -31,7 +31,7 @@ test("resolves relative descendants with current-session trust", () => {
 			currentProjectTrusted: true,
 			agentDir: value.agentDir,
 		});
-		assert.equal(resolved.cwd, value.child);
+		assert.equal(resolved.cwd, realpathSync(value.child));
 		assert.equal(resolved.boundary, "current-workspace");
 		assert.equal(resolved.trust.kind, "session-trusted");
 		assert.equal(resolved.trust.projectTrusted, true);
@@ -56,7 +56,7 @@ test("uses nearest saved external trust decision", () => {
 		});
 		assert.equal(denied.boundary, "external");
 		assert.equal(denied.trust.kind, "saved-denied");
-		assert.equal(denied.trust.sourcePath, value.external);
+		assert.equal(denied.trust.sourcePath, realpathSync(value.external));
 		assert.equal(denied.trust.projectTrusted, false);
 
 		store.set(value.external, true);
@@ -113,7 +113,7 @@ test("canonicalizes symlinks before workspace and trust classification", () => {
 			currentProjectTrusted: false,
 			agentDir: value.agentDir,
 		});
-		assert.equal(resolved.cwd, value.external);
+		assert.equal(resolved.cwd, realpathSync(value.external));
 		assert.equal(resolved.boundary, "external");
 		assert.equal(resolved.trust.kind, "saved-trusted");
 	} finally {

--- a/packages/pi-subagents/test/execution-ui.test.ts
+++ b/packages/pi-subagents/test/execution-ui.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	applyAgentModel,
+	applyAgentThinking,
+	applyAgentTimeout,
+	applyExecutionProfileFromUi,
+	executionAgentScreen,
+	executionModelScreen,
+	executionProfileScreen,
+	resetAgentExecution,
+} from "../src/execution-ui.js";
+import { updateAgentSettingsPatch } from "../src/settings.js";
+import { resolveStatefulLimits } from "../src/stateful-limits.js";
+import { applyTransportSetting, transportSettingsScreen } from "../src/transport-ui.js";
+
+function withAgentDir(run: (directory: string) => Promise<void>): Promise<void> {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-execution-ui-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	return run(directory).finally(() => {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(directory, { recursive: true, force: true });
+	});
+}
+
+function runtime(retainedAgents = 0) {
+	return {
+		getRuntimeStatus: () => ({
+			enabled: true,
+			initialized: true,
+			transport: "subprocess" as const,
+			completionDelivery: "next-turn" as const,
+			limits: resolveStatefulLimits(),
+			activeAgents: 0,
+			retainedAgents,
+		}),
+	};
+}
+
+test("execution profile preview cancels without a write and applies one atomic patch", async () => {
+	await withAgentDir(async (directory) => {
+		const cancelled = createMockContext({ confirm: async () => false });
+		const rejected = await applyExecutionProfileFromUi(
+			"balanced",
+			cancelled.ctx,
+			new AbortController().signal,
+			() => true,
+		);
+		assert.equal(rejected.kind, "rejected");
+		assert.equal(existsSync(path.join(directory, "pi-subagents.json")), false);
+
+		updateAgentSettingsPatch({ backend: { model: "unavailable/model", tools: ["bash"] } });
+		const accepted = createMockContext({ confirm: async () => true });
+		const applied = await applyExecutionProfileFromUi(
+			"balanced",
+			accepted.ctx,
+			new AbortController().signal,
+			() => true,
+		);
+		assert.equal(applied.kind, "stay");
+		const saved = JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8"));
+		assert.equal(saved.agents.scout.thinkingLevel, "low");
+		assert.equal(saved.agents.reviewer.thinkingLevel, "medium");
+		assert.equal(saved.agents.general.thinkingLevel, "medium");
+		assert.equal(saved.agents.backend.thinkingLevel, undefined);
+		assert.equal(saved.agents.backend.model, "unavailable/model");
+		assert.deepEqual(saved.agents.backend.tools, ["bash"]);
+		assert.match(JSON.stringify(executionProfileScreen()), /Fast.*Balanced.*Deep/);
+		assert.match(
+			JSON.stringify(
+				executionAgentScreen({
+					name: "scout",
+					description: "scout",
+					systemPrompt: "",
+					source: "built-in",
+					filePath: "built-in:scout",
+				}),
+			),
+			/model.*Thinking level.*Timeout/i,
+		);
+		const catalogContext = createMockContext({
+			modelRegistry: { getAvailable: () => [{ provider: "fake", id: "model" }] },
+		});
+		assert.match(
+			JSON.stringify(
+				executionModelScreen(
+					{
+						name: "scout",
+						description: "scout",
+						systemPrompt: "",
+						source: "built-in",
+						filePath: "built-in:scout",
+					},
+					catalogContext.ctx,
+				),
+			),
+			/fake\/model/,
+		);
+	});
+});
+
+test("per-agent execution controls validate, preserve tools, and reset inheritance", async () => {
+	await withAgentDir(async (directory) => {
+		const context = createMockContext();
+		const agent = {
+			name: "scout",
+			description: "scout",
+			tools: ["read"],
+			systemPrompt: "",
+			source: "built-in" as const,
+			filePath: "built-in:scout",
+		};
+		updateAgentSettingsPatch({ scout: { tools: ["read"] } });
+		assert.equal(applyAgentThinking(agent, "high", context.ctx).kind, "back");
+		assert.equal(applyAgentModel(agent, "provider/model", context.ctx).kind, "back");
+		assert.equal(applyAgentTimeout(agent, "1234", context.ctx).kind, "back");
+		assert.equal(applyAgentTimeout(agent, "0", context.ctx).kind, "rejected");
+		let saved = JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8"));
+		assert.equal(saved.agents.scout.thinkingLevel, "high");
+		assert.equal(saved.agents.scout.model, "provider/model");
+		assert.equal(saved.agents.scout.timeoutMs, 1234);
+		assert.equal(resetAgentExecution(agent, context.ctx).kind, "back");
+		saved = JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8"));
+		assert.deepEqual(saved.agents.scout, { tools: ["read"] });
+	});
+});
+
+test("transport setting previews, protects retained agents, and applies after reload", async () => {
+	await withAgentDir(async (directory) => {
+		const blocked = createMockContext({ confirm: async () => true });
+		const blockedResult = await applyTransportSetting(
+			"rpc",
+			blocked.ctx,
+			runtime(1),
+			new AbortController().signal,
+			() => true,
+		);
+		assert.equal(blockedResult.kind, "rejected");
+		assert.match(blocked.notifications.at(-1)?.message ?? "", /retained/i);
+		assert.equal(existsSync(path.join(directory, "pi-subagents.json")), false);
+
+		const accepted = createMockContext({ confirm: async () => true });
+		const result = await applyTransportSetting(
+			"auto",
+			accepted.ctx,
+			runtime(),
+			new AbortController().signal,
+			() => true,
+		);
+		assert.equal(result.kind, "stay");
+		const saved = JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8"));
+		assert.equal(saved.stateful.transport, "auto");
+		assert.match(accepted.notifications.at(-1)?.message ?? "", /reload/i);
+		assert.match(JSON.stringify(transportSettingsScreen(runtime())), /Persistent RPC process/);
+	});
+});

--- a/packages/pi-subagents/test/in-process-transport.test.ts
+++ b/packages/pi-subagents/test/in-process-transport.test.ts
@@ -504,10 +504,14 @@ test("child resource loader excludes extensions while retaining the agent prompt
 	const cwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-sdk-cwd-"));
 	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-sdk-agent-"));
 	writeFileSync(path.join(cwd, "AGENTS.md"), "Trusted child context.");
+	writeFileSync(path.join(agentDir, "APPEND_SYSTEM.md"), "Global append prompt.");
 	const services = await createInProcessServices(cwd, agentDir, "Agent role prompt.", true);
 	assert.equal(services.settingsManager.isProjectTrusted(), true);
 	assert.deepEqual(services.resourceLoader.getExtensions().extensions, []);
-	assert.deepEqual(services.resourceLoader.getAppendSystemPrompt(), ["Agent role prompt."]);
+	assert.deepEqual(services.resourceLoader.getAppendSystemPrompt(), [
+		"Global append prompt.",
+		"Agent role prompt.",
+	]);
 	assert.equal(
 		services.resourceLoader.getAgentsFiles().agentsFiles.at(-1)?.content,
 		"Trusted child context.",
@@ -519,6 +523,8 @@ test("untrusted in-process resource loading never reads project settings", async
 	const cwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-untrusted-cwd-"));
 	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-untrusted-agent-"));
 	mkdirSync(path.join(cwd, ".pi"));
+	writeFileSync(path.join(agentDir, "APPEND_SYSTEM.md"), "Global append prompt.");
+	writeFileSync(path.join(cwd, ".pi", "APPEND_SYSTEM.md"), "SECRET_PROJECT_APPEND");
 	writeFileSync(
 		path.join(cwd, ".pi", "settings.json"),
 		'{"SECRET_UNTRUSTED_PROJECT_SETTINGS":"unterminated',
@@ -528,6 +534,11 @@ test("untrusted in-process resource loading never reads project settings", async
 		assert.equal(services.settingsManager.isProjectTrusted(), false);
 		assert.deepEqual(services.settingsManager.getProjectSettings(), {});
 		assert.deepEqual(services.settingsManager.drainErrors(), []);
+		assert.deepEqual(services.resourceLoader.getAppendSystemPrompt(), [
+			"Global append prompt.",
+			"Agent role prompt.",
+		]);
+		assert.doesNotMatch(services.resourceLoader.getAppendSystemPrompt().join("\n"), /SECRET/);
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 		rmSync(agentDir, { recursive: true, force: true });

--- a/packages/pi-subagents/test/in-process-transport.test.ts
+++ b/packages/pi-subagents/test/in-process-transport.test.ts
@@ -284,16 +284,19 @@ test("InProcessTransport disposes a child when event subscription fails during c
 	assert.deepEqual(child.prompts, []);
 });
 
-test("InProcessTransport times out by aborting, remains releasable, and disposes exactly once", async () => {
-	const child = new FakeChildSession(true);
-	const transport = transportWithFactory(async () => child, { timeoutMs: 5 });
-	const agent = managedAgent();
+test("InProcessTransport aborts timed-out work, summarizes it, and remains releasable", async () => {
+	const child = new FakeChildSession(1);
+	const transport = transportWithFactory(async () => child, { timeoutMs: 1_000 });
+	const agent = managedAgent({ timeoutMs: 500, currentTimeoutMs: 20 });
 
 	const result = await transport.runTurn(agent, "slow", new AbortController().signal);
 	assert.equal(result.exitCode, 124);
 	assert.equal(result.aborted, undefined);
 	assert.match(result.error ?? "", /timed out/);
 	assert.equal(child.aborts, 1);
+	assert.equal(child.prompts.length, 2);
+	assert.match(child.prompts[1], /Work deadline expired/);
+	assert.match(result.output, /done:.*Work deadline expired/s);
 
 	await transport.release?.(agent);
 	await transport.release?.(agent);

--- a/packages/pi-subagents/test/inspect.test.ts
+++ b/packages/pi-subagents/test/inspect.test.ts
@@ -74,6 +74,7 @@ test("subagent_inspect registers one strict Google-compatible action schema", as
 		"list_runs",
 		"get_run",
 		"list_models",
+		"preview_context",
 		"status",
 		"diagnose",
 	]);
@@ -88,6 +89,18 @@ test("subagent_inspect registers one strict Google-compatible action schema", as
 	await assert.rejects(
 		() => execute(tool, { action: "list_models", limit: 101 }),
 		/between 1 and 100/,
+	);
+	const preview = await execute(tool, { action: "preview_context", context: "none" });
+	assert.deepEqual(preview.details.preview, {
+		mode: "none",
+		turns: 0,
+		sourceCount: 0,
+		bytes: 0,
+		truncated: false,
+	});
+	await assert.rejects(
+		() => execute(tool, { action: "preview_context", context: 0 }),
+		/positive integer/,
 	);
 });
 
@@ -169,6 +182,28 @@ test("subagent_inspect returns metadata-only run summaries", async () => {
 			},
 		},
 		policy: { inherited: ["environment"], overridden: [], unsupported: [] },
+		contextTurns: 2,
+		contextBytes: 128,
+		contextSources: 3,
+		contextTruncated: false,
+		resultFormat: "structured-v1",
+		structuredResult: {
+			version: "pi-subagents:result:v1",
+			summary: "done",
+			evidence: [],
+			changes: [],
+			verification: [],
+			risks: [],
+		},
+		telemetry: {
+			protocol: "pi-subagents:v1",
+			transport: "rpc",
+			phase: "settled",
+			updatedAt: 3,
+			timing: { queuedAt: 1, readyAt: 2, settledAt: 3 },
+			model: "model-one",
+			thinkingLevel: "high",
+		},
 	};
 	const mock = createMockPi();
 	registerSubagentInspect(mock.pi, runtime({ runs: [summary], detail }));
@@ -183,6 +218,15 @@ test("subagent_inspect returns metadata-only run summaries", async () => {
 		(got.details.run as { target: { trust: { kind: string } } }).target.trust.kind,
 		"saved-trusted",
 	);
+	const projected = got.details.run as {
+		context: { turns: number; bytes: number; sources: number };
+		telemetry: { protocol: string; transport: string };
+		structuredResult: { summary: string };
+	};
+	assert.deepEqual(projected.context, { turns: 2, sources: 3, bytes: 128, truncated: false });
+	assert.equal(projected.telemetry.protocol, "pi-subagents:v1");
+	assert.equal(projected.telemetry.transport, "rpc");
+	assert.equal(projected.structuredResult.summary, "done");
 	await assert.rejects(
 		() => execute(tool, { action: "get_run", agentId: "missing" }),
 		/Unknown retained run/,

--- a/packages/pi-subagents/test/orchestration.test.ts
+++ b/packages/pi-subagents/test/orchestration.test.ts
@@ -994,6 +994,114 @@ test("stateful worktree spawn revalidates session ownership and cleans stale wor
 	}
 });
 
+test("stale idempotent spawn cleanup cannot delete a replacement session attempt", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-idempotent-replacement-"));
+	const agentDir = path.join(root, "agent-home");
+	const workspace = path.join(root, "workspace");
+	mkdirSync(agentDir);
+	mkdirSync(workspace);
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	let createCalls = 0;
+	const createResolvers: Array<
+		(value: { mode: "worktree"; path: string; rootPath: string; repositoryRoot: string }) => void
+	> = [];
+	const workspaceManager = {
+		create: async () => {
+			createCalls++;
+			if (createCalls > 2) throw new Error("duplicate worktree creation");
+			return await new Promise<{
+				mode: "worktree";
+				path: string;
+				rootPath: string;
+				repositoryRoot: string;
+			}>((resolve) => createResolvers.push(resolve));
+		},
+		async cleanup() {},
+		async cleanupAll() {},
+	} as unknown as WorkspaceManager;
+	try {
+		const mock = createMockPi();
+		registerStatefulSubagents(mock.pi, {
+			settings: { transport: "in-process" },
+			workspaceManager,
+			createInProcessSession: async () => {
+				const messages: unknown[] = [];
+				return {
+					sessionId: "idempotent-replacement",
+					messages,
+					prompt: async () => {
+						messages.push({
+							role: "assistant",
+							content: [{ type: "text", text: "done" }],
+							stopReason: "stop",
+						});
+					},
+					subscribe: () => () => undefined,
+					abort: async () => undefined,
+					dispose: () => undefined,
+					getActiveToolNames: () => ["read", "grep", "find", "ls", "bash"],
+				};
+			},
+		});
+		const firstContext = createMockContext({ cwd: workspace, isProjectTrusted: () => true });
+		await mock.events.get("session_start")?.[0]?.({}, firstContext.ctx);
+		const spawn = mock.tools.find((tool) => tool.name === "subagent_spawn") as {
+			execute: (...args: unknown[]) => Promise<unknown>;
+		};
+		const spawnParams = {
+			agent: "scout",
+			task: "same request",
+			workspaceMode: "worktree" as const,
+			idempotencyKey: "replacement-key",
+		};
+		const first = spawn.execute("first", spawnParams, undefined, undefined, firstContext.ctx);
+		while (createCalls < 1) await new Promise<void>((resolve) => setImmediate(resolve));
+
+		const replacementContext = createMockContext({ cwd: workspace, isProjectTrusted: () => true });
+		await mock.events.get("session_start")?.[0]?.({}, replacementContext.ctx);
+		const second = spawn.execute(
+			"second",
+			spawnParams,
+			undefined,
+			undefined,
+			replacementContext.ctx,
+		) as Promise<{ details: { agent: { id: string } } }>;
+		while (createCalls < 2) await new Promise<void>((resolve) => setImmediate(resolve));
+
+		createResolvers[0]?.({
+			mode: "worktree",
+			path: path.join(root, "first-worktree"),
+			rootPath: path.join(root, "first-worktree"),
+			repositoryRoot: workspace,
+		});
+		await assert.rejects(first, (error) => error instanceof Error && error.name === "AbortError");
+
+		const third = spawn.execute(
+			"third",
+			spawnParams,
+			undefined,
+			undefined,
+			replacementContext.ctx,
+		) as Promise<{ details: { agent: { id: string } } }>;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		assert.equal(createCalls, 2, "the retry must join the replacement session's pending spawn");
+		createResolvers[1]?.({
+			mode: "worktree",
+			path: path.join(root, "second-worktree"),
+			rootPath: path.join(root, "second-worktree"),
+			repositoryRoot: workspace,
+		});
+		const [secondResult, thirdResult] = await Promise.all([second, third]);
+		assert.equal(thirdResult.details.agent.id, secondResult.details.agent.id);
+		await mock.events.get("session_shutdown")?.[0]?.({}, replacementContext.ctx);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("stateful clear and session replacement serialize active-child cleanup before the new runtime", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-runtime-replacement-"));
 	const agentDir = path.join(root, "agent-home");
@@ -1093,7 +1201,12 @@ test("stateful subprocess uses the retained resolved trust decision", async () =
 		}),
 	);
 	const previousPackageDir = process.env.PI_PACKAGE_DIR;
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const agentDir = path.join(root, "agent-home");
+	mkdirSync(agentDir);
+	writeFileSync(path.join(agentDir, "APPEND_SYSTEM.md"), "global append");
 	process.env.PI_PACKAGE_DIR = root;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
 	try {
 		const transport = new SubprocessTransport({
 			getSettings: () => ({ agents: { scout: { tools: [] } } }),
@@ -1120,10 +1233,14 @@ test("stateful subprocess uses the retained resolved trust decision", async () =
 			assert.equal(outcome.exitCode, 0);
 			assert.match(outcome.output, new RegExp(expected));
 			assert.match(outcome.output, /--no-tools/);
+			assert.match(outcome.output, /--append-system-prompt/);
+			assert.match(outcome.output, /APPEND_SYSTEM\.md/);
 		}
 	} finally {
 		if (previousPackageDir === undefined) delete process.env.PI_PACKAGE_DIR;
 		else process.env.PI_PACKAGE_DIR = previousPackageDir;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(root, { recursive: true, force: true });
 	}
 });

--- a/packages/pi-subagents/test/orchestration.test.ts
+++ b/packages/pi-subagents/test/orchestration.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { ProjectTrustStore } from "@earendil-works/pi-coding-agent";
@@ -18,6 +26,7 @@ import {
 	resolveSpawnContextMode,
 	resolveStatefulTransportKind,
 } from "../src/stateful.js";
+import { waitForOwnedSpawn } from "../src/stateful-lifecycle.js";
 import { resolveStatefulLimits } from "../src/stateful-limits.js";
 import {
 	resolveStatefulSubprocessThinkingLevel,
@@ -114,6 +123,14 @@ test("stateful agent lines escape terminal controls from retained agent data", (
 	assert.doesNotMatch(line, /[\u0000-\u001f\u007f-\u009f]/u);
 	assert.match(line, /scout.*linked/);
 	assert.match(line, /first line second line/);
+});
+
+test("pending idempotent spawn waits honor caller cancellation", async () => {
+	const controller = new AbortController();
+	const pending = new Promise<never>(() => undefined);
+	const waiting = waitForOwnedSpawn(pending, controller.signal);
+	controller.abort();
+	await assert.rejects(waiting, (error) => error instanceof Error && error.name === "AbortError");
 });
 
 test("selected context entries imply all mode only when context mode is omitted", () => {
@@ -436,12 +453,17 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			description: string;
 			execute: (...args: unknown[]) => Promise<unknown>;
 			parameters: {
-				properties?: Record<string, { description?: string; enum?: string[] }>;
+				properties?: Record<string, { description?: string; enum?: string[]; maxLength?: number }>;
 			};
 			promptGuidelines: string[];
 		};
 		const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 		assert.deepEqual(spawnTool.parameters.properties?.thinkingLevel?.enum, thinkingLevels);
+		assert.equal(spawnTool.parameters.properties?.idempotencyKey?.maxLength, 256);
+		assert.deepEqual(spawnTool.parameters.properties?.resultFormat?.enum, [
+			"text",
+			"structured-v1",
+		]);
 		assert.match(
 			spawnTool.parameters.properties?.thinkingLevel?.description ?? "",
 			/task difficulty/i,
@@ -595,6 +617,8 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 	let delegation: "trusted-targets" | "anywhere" = "trusted-targets";
 	const created: ManagedAgent[] = [];
 	const createdTools: Array<string[] | undefined> = [];
+	let workspaceCreates = 0;
+	let projectConfirmations = 0;
 	try {
 		const mock = createMockPi();
 		const controller = registerStatefulSubagents(mock.pi, {
@@ -605,6 +629,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 			}),
 			workspaceManager: {
 				async create() {
+					workspaceCreates++;
 					return {
 						mode: "worktree" as const,
 						path: generated,
@@ -636,7 +661,15 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 				};
 			},
 		});
-		const context = createMockContext({ cwd: workspace, isProjectTrusted: () => true });
+		const context = createMockContext({
+			cwd: workspace,
+			hasUI: true,
+			isProjectTrusted: () => true,
+			confirm: async () => {
+				projectConfirmations++;
+				return true;
+			},
+		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		const spawn = mock.tools.find((tool) => tool.name === "subagent_spawn") as
 			| { execute: (...args: unknown[]) => Promise<unknown> }
@@ -667,7 +700,54 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 		assert.deepEqual(createdTools[0], []);
 		assert.equal(created[0]?.target?.trust.kind, "saved-trusted");
 		assert.equal(created[0]?.target?.trust.projectTrusted, true);
-		assert.equal(controller.listAgents()[0]?.target?.cwd, external);
+		assert.equal(controller.listAgents()[0]?.target?.cwd, realpathSync(external));
+
+		const idempotentFirst = (await spawn.execute(
+			"idempotent-1",
+			{
+				agent: "scout",
+				task: "idempotent inspect",
+				cwd: external,
+				idempotencyKey: "inspect-external",
+				resultFormat: "structured-v1",
+			},
+			undefined,
+			undefined,
+			context.ctx,
+		)) as { details: { agent: { id: string; context: { bytes: number } } } };
+		const idempotentSecond = (await spawn.execute(
+			"idempotent-2",
+			{
+				agent: "scout",
+				task: "idempotent inspect",
+				cwd: external,
+				idempotencyKey: "inspect-external",
+				resultFormat: "structured-v1",
+			},
+			undefined,
+			undefined,
+			context.ctx,
+		)) as { details: { agent: { id: string } } };
+		assert.equal(idempotentSecond.details.agent.id, idempotentFirst.details.agent.id);
+		assert.equal(idempotentFirst.details.agent.context.bytes, 0);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		assert.equal(created.length, 2);
+		await assert.rejects(
+			() =>
+				spawn.execute(
+					"idempotent-mismatch",
+					{
+						agent: "scout",
+						task: "different task",
+						cwd: external,
+						idempotencyKey: "inspect-external",
+					},
+					undefined,
+					undefined,
+					context.ctx,
+				),
+			/different parameters/,
+		);
 
 		new ProjectTrustStore(agentDir).set(external, false);
 		delegation = "anywhere";
@@ -679,8 +759,8 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 			context.ctx,
 		);
 		await new Promise<void>((resolve) => setImmediate(resolve));
-		assert.equal(created[1]?.target?.trust.kind, "saved-denied");
-		assert.equal(created[1]?.target?.trust.projectTrusted, false);
+		assert.equal(created[2]?.target?.trust.kind, "saved-denied");
+		assert.equal(created[2]?.target?.trust.projectTrusted, false);
 
 		await spawn.execute(
 			"worktree",
@@ -690,12 +770,86 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 			context.ctx,
 		);
 		await new Promise<void>((resolve) => setImmediate(resolve));
-		assert.equal(created[2]?.cwd, generated);
-		assert.equal(created[2]?.workspaceMode, "worktree");
-		assert.equal(created[2]?.target?.cwd, workspace);
-		assert.equal(created[2]?.target?.boundary, "current-workspace");
-		assert.equal(created[2]?.target?.trust.kind, "session-trusted");
-		assert.equal(created[2]?.target?.trust.projectTrusted, true);
+		assert.equal(created[3]?.cwd, generated);
+		assert.equal(created[3]?.workspaceMode, "worktree");
+		assert.equal(created[3]?.target?.cwd, realpathSync(workspace));
+		assert.equal(created[3]?.target?.boundary, "current-workspace");
+		assert.equal(created[3]?.target?.trust.kind, "session-trusted");
+		assert.equal(created[3]?.target?.trust.projectTrusted, true);
+		assert.equal(workspaceCreates, 1);
+		mkdirSync(path.join(workspace, ".pi", "agents"), { recursive: true });
+		writeFileSync(
+			path.join(workspace, ".pi", "agents", "project-reviewer.md"),
+			"---\nname: project-reviewer\ndescription: Project reviewer\ntools: []\n---\nReview.",
+		);
+		const projectFirst = (await spawn.execute(
+			"project-idempotent-1",
+			{
+				agent: "project-reviewer",
+				task: "review once",
+				agentScope: "project",
+				idempotencyKey: "project-review",
+			},
+			undefined,
+			undefined,
+			context.ctx,
+		)) as { details: { agent: { id: string } } };
+		const projectSecond = (await spawn.execute(
+			"project-idempotent-2",
+			{
+				agent: "project-reviewer",
+				task: "review once",
+				agentScope: "project",
+				idempotencyKey: "project-review",
+			},
+			undefined,
+			undefined,
+			context.ctx,
+		)) as { details: { agent: { id: string } } };
+		assert.equal(projectSecond.details.agent.id, projectFirst.details.agent.id);
+		assert.equal(projectConfirmations, 1, "exact retry must not confirm project agents twice");
+		await assert.rejects(
+			spawn.execute(
+				"project-idempotent-mismatch",
+				{
+					agent: "project-reviewer",
+					task: "different review",
+					agentScope: "project",
+					idempotencyKey: "project-review",
+				},
+				undefined,
+				undefined,
+				context.ctx,
+			),
+			/different parameters/,
+		);
+		assert.equal(projectConfirmations, 1, "mismatch must fail before project confirmation");
+		const isolatedFirst = (await spawn.execute(
+			"worktree-idempotent-1",
+			{
+				agent: "scout",
+				task: "isolated exact retry",
+				workspaceMode: "worktree",
+				idempotencyKey: "isolated-retry",
+			},
+			undefined,
+			undefined,
+			context.ctx,
+		)) as { details: { agent: { id: string } } };
+		const isolatedSecond = (await spawn.execute(
+			"worktree-idempotent-2",
+			{
+				agent: "scout",
+				task: "isolated exact retry",
+				workspaceMode: "worktree",
+				idempotencyKey: "isolated-retry",
+			},
+			undefined,
+			undefined,
+			context.ctx,
+		)) as { details: { agent: { id: string } } };
+		assert.equal(isolatedSecond.details.agent.id, isolatedFirst.details.agent.id);
+		assert.equal(workspaceCreates, 2, "exact retry must not create another worktree");
 		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
@@ -990,6 +1144,8 @@ test("stateful subprocess thinking uses spawn override before the agent default"
 test("stateful settings validate transport, completion delivery, and bounded runtime options", () => {
 	assert.equal(resolveStatefulTransportKind(undefined), "subprocess");
 	assert.equal(resolveStatefulTransportKind("in-process"), "in-process");
+	assert.equal(resolveStatefulTransportKind("rpc"), "rpc");
+	assert.equal(resolveStatefulTransportKind("auto"), "auto");
 	assert.equal(resolveCompletionDelivery(undefined), "next-turn");
 	assert.equal(resolveCompletionDelivery("auto-resume"), "auto-resume");
 	assert.deepEqual(
@@ -1021,6 +1177,12 @@ test("stateful settings validate transport, completion delivery, and bounded run
 	);
 	assert.deepEqual(normalizeSubagentSettings({ stateful: { transport: "subprocess" } }), {
 		stateful: { transport: "subprocess" },
+	});
+	assert.deepEqual(normalizeSubagentSettings({ stateful: { transport: "rpc" } }), {
+		stateful: { transport: "rpc" },
+	});
+	assert.deepEqual(normalizeSubagentSettings({ stateful: { transport: "auto" } }), {
+		stateful: { transport: "auto" },
 	});
 	assert.equal(normalizeSubagentSettings({ stateful: { transport: "native" } }), undefined);
 	assert.equal(

--- a/packages/pi-subagents/test/orchestration.test.ts
+++ b/packages/pi-subagents/test/orchestration.test.ts
@@ -191,6 +191,7 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			name: string;
 			description: string;
 			promptGuidelines: string[];
+			parameters: { properties?: Record<string, { description?: string; maximum?: number }> };
 		};
 		controller.setAgentCatalog(
 			'Available agent definitions\n- api-reviewer [source: user; agentScope: "user"] — Reviews APIs',
@@ -214,11 +215,18 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		assert.match(refreshedRegistration?.promptGuidelines?.join("\n") ?? "", /auto-resume/);
 		controller.setCompletionDelivery("next-turn");
 		assert.equal(spawn.name, "subagent_spawn");
+		assert.match(spawn.parameters.properties?.timeoutMs?.description ?? "", /work deadline/i);
+		assert.match(spawn.promptGuidelines.join("\n"), /timeoutMs.*task difficulty/i);
 
 		const send = mock.tools.find((tool) => tool.name === "subagent_send") as {
 			description: string;
 			promptSnippet?: string;
+			parameters: { properties?: Record<string, { description?: string; maximum?: number }> };
 		};
+		assert.match(
+			send.parameters.properties?.timeoutMs?.description ?? "",
+			/work deadline.*follow-up/i,
+		);
 		const manage = mock.tools.find((tool) => tool.name === "subagent_manage") as {
 			description: string;
 			parameters: { properties?: Record<string, { description?: string; enum?: string[] }> };

--- a/packages/pi-subagents/test/pi-invocation.test.ts
+++ b/packages/pi-subagents/test/pi-invocation.test.ts
@@ -64,7 +64,7 @@ test("Pi invocation ignores an existing non-Pi host and selects the loaded core 
 
 		assert.deepEqual(resolvePiInvocation(["--mode", "json"], runtime), {
 			command: process.execPath,
-			args: [cliPath, "--mode", "json"],
+			args: [realpathSync(cliPath), "--mode", "json"],
 		});
 	});
 });
@@ -177,7 +177,7 @@ test("Pi invocation treats a Node executable named pi as a script runtime", () =
 				packageDir: root,
 				runtimeKind: "node",
 			}),
-			{ command: executable, args: [cliPath, "--mode", "json"] },
+			{ command: executable, args: [realpathSync(cliPath), "--mode", "json"] },
 		);
 	});
 });

--- a/packages/pi-subagents/test/registry.test.ts
+++ b/packages/pi-subagents/test/registry.test.ts
@@ -25,6 +25,65 @@ function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 	};
 }
 
+test("AgentRegistry retains spawn idempotency only until close", async () => {
+	const registry = new AgentRegistry(async () => ({ output: "done", exitCode: 0 }));
+	const first = await registry.spawn({
+		agent: "scout",
+		task: "first",
+		cwd: process.cwd(),
+		spawnIdempotencyKey: "key",
+		spawnRequestHash: "hash",
+	});
+	assert.equal(registry.findBySpawnIdempotencyKey("key", "hash")?.id, first.id);
+	assert.throws(() => registry.findBySpawnIdempotencyKey("key", "different"), /different/);
+	await registry.close(first.id);
+	assert.equal(registry.findBySpawnIdempotencyKey("key", "hash"), undefined);
+	const replacement = await registry.spawn({
+		agent: "scout",
+		task: "different after close",
+		cwd: process.cwd(),
+		spawnIdempotencyKey: "key",
+		spawnRequestHash: "different",
+	});
+	assert.notEqual(replacement.id, first.id);
+});
+
+test("AgentRegistry preserves queue and transport timing without persisting progress callbacks", async () => {
+	let now = 10;
+	const registry = new AgentRegistry(
+		async (_agent, _task, _signal, onProgress) => {
+			onProgress?.({
+				transport: "rpc",
+				protocol: "pi-subagents:v1",
+				phase: "ready",
+				updatedAt: 20,
+				timing: { startedAt: 15, readyAt: 20 },
+			});
+			return {
+				output: "done",
+				exitCode: 0,
+				telemetry: {
+					transport: "rpc",
+					protocol: "pi-subagents:v1",
+					phase: "settled",
+					updatedAt: 30,
+					timing: { startedAt: 15, readyAt: 20, settledAt: 30 },
+				},
+			};
+		},
+		{ now: () => now++ },
+	);
+	const spawned = await registry.spawn({ agent: "scout", task: "timed", cwd: process.cwd() });
+	await registry.wait(spawned.id, 100);
+	const telemetry = registry.getInspection(spawned.id)?.telemetry;
+	assert.equal(telemetry?.transport, "rpc");
+	assert.equal(telemetry?.timing.queuedAt, 12);
+	assert.equal(telemetry?.timing.readyAt, 20);
+	assert.equal(telemetry?.timing.settledAt, 30);
+	registry.markCompletionDelivered(spawned.id, 40);
+	assert.equal(registry.getInspection(spawned.id)?.telemetry?.timing.completionDeliveredAt, 40);
+});
+
 test("AgentRegistry exposes metadata-only inspection snapshots", async () => {
 	let finish!: (value: { output: string; exitCode: number; error?: string }) => void;
 	const registry = new AgentRegistry(
@@ -69,6 +128,45 @@ test("AgentRegistry exposes metadata-only inspection snapshots", async () => {
 	assert.equal(completed?.historyCount, 1);
 	assert.equal(completed?.error, "private error");
 	assert.doesNotMatch(JSON.stringify(completed), /history output|mailbox content|parent context/);
+});
+
+test("AgentRegistry deduplicates exact spawn retries before another transport turn", async () => {
+	let turns = 0;
+	const registry = new AgentRegistry(async () => {
+		turns++;
+		return {
+			output: JSON.stringify({
+				version: "pi-subagents:result:v1",
+				summary: "done",
+				evidence: ["src/a.ts"],
+				changes: [],
+				verification: ["test"],
+				risks: [],
+			}),
+			exitCode: 0,
+		};
+	});
+	const input = {
+		agent: "scout",
+		task: "inspect",
+		cwd: process.cwd(),
+		spawnIdempotencyKey: "request-1",
+		spawnRequestHash: "a".repeat(64),
+		resultFormat: "structured-v1" as const,
+	};
+	const first = await registry.spawn(input);
+	const repeated = await registry.spawn(input);
+	assert.equal(repeated.id, first.id);
+	await registry.wait(first.id, 100);
+	assert.equal(turns, 1);
+	assert.equal(registry.getInspection(first.id)?.structuredResult?.summary, "done");
+	await assert.rejects(
+		() => registry.spawn({ ...input, spawnRequestHash: "b".repeat(64) }),
+		/different parameters/,
+	);
+	await registry.close(first.id);
+	const afterClose = await registry.spawn(input);
+	assert.notEqual(afterClose.id, first.id);
 });
 
 test("AgentRegistry rejects invalid capacity and wait bounds", async () => {
@@ -700,6 +798,26 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 	await persistence.save([
 		record({
 			thinkingLevel: "high",
+			spawnIdempotencyKey: "persisted-request",
+			spawnRequestHash: "a".repeat(64),
+			resultFormat: "structured-v1",
+			contextTurns: 2,
+			contextBytes: 128,
+			telemetry: {
+				protocol: "pi-subagents:v1",
+				transport: "rpc",
+				phase: "settled",
+				updatedAt: 2,
+				timing: { settledAt: 2 },
+			},
+			structuredResult: {
+				version: "pi-subagents:result:v1",
+				summary: "ephemeral",
+				evidence: [],
+				changes: [],
+				verification: [],
+				risks: [],
+			},
 			target: {
 				cwd: process.cwd(),
 				boundary: "external",
@@ -729,9 +847,17 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 	const raw = readFileSync(persistence.filePath, "utf8");
 	assert.doesNotMatch(raw, /secret|hidden/);
 	assert.match(raw, /visible/);
+	assert.doesNotMatch(raw, /telemetry|ephemeral|structuredResult/);
 	const restoredState = persistence.load()[0];
 	assert.equal(restoredState?.state, "idle");
 	assert.equal(restoredState?.thinkingLevel, "high");
+	assert.equal(restoredState?.spawnIdempotencyKey, "persisted-request");
+	assert.equal(restoredState?.spawnRequestHash, "a".repeat(64));
+	assert.equal(restoredState?.resultFormat, "structured-v1");
+	assert.equal(restoredState?.contextTurns, 2);
+	assert.equal(restoredState?.contextBytes, 128);
+	assert.equal(restoredState?.telemetry, undefined);
+	assert.equal(restoredState?.structuredResult, undefined);
 	assert.equal(restoredState?.target?.trust.kind, "saved-trusted");
 	assert.equal(restoredState?.target?.trust.projectTrusted, true);
 	assert.equal(restoredState?.mailbox[0]?.content, "[private content omitted]visible");

--- a/packages/pi-subagents/test/registry.test.ts
+++ b/packages/pi-subagents/test/registry.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -6,6 +7,7 @@ import { test } from "vitest";
 import { projectAgentRecords } from "../src/agent-projection.js";
 import { AgentPersistence } from "../src/persistence.js";
 import { AgentRegistry, type ManagedAgent } from "../src/registry.js";
+import { hashSpawnRequest } from "../src/spawn-idempotency.js";
 import { buildDetachedCompletionMessage } from "../src/stateful.js";
 
 function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
@@ -24,6 +26,41 @@ function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 		...overrides,
 	};
 }
+
+test("spawn idempotency includes the retained timeout budget", () => {
+	const request = {
+		agent: "scout",
+		task: "inspect",
+		cwd: process.cwd(),
+		agentScope: "user" as const,
+		thinkingLevel: "low" as const,
+		timeoutMs: 1_000,
+		contextSourceIds: [],
+		workspaceMode: "shared" as const,
+		allowConcurrentWrites: false,
+		resultFormat: "text" as const,
+	};
+	assert.notEqual(hashSpawnRequest(request), hashSpawnRequest({ ...request, timeoutMs: 2_000 }));
+	const { timeoutMs: _omitted, ...withoutTimeout } = request;
+	const legacyHash = createHash("sha256")
+		.update(
+			JSON.stringify({
+				agent: withoutTimeout.agent,
+				task: withoutTimeout.task,
+				cwd: withoutTimeout.cwd,
+				agentScope: withoutTimeout.agentScope,
+				thinkingLevel: withoutTimeout.thinkingLevel,
+				parentId: null,
+				contextHash: null,
+				contextSourceIds: [],
+				workspaceMode: "shared",
+				allowConcurrentWrites: false,
+				resultFormat: "text",
+			}),
+		)
+		.digest("hex");
+	assert.equal(hashSpawnRequest(withoutTimeout), legacyHash);
+});
 
 test("AgentRegistry retains spawn idempotency only until close", async () => {
 	const registry = new AgentRegistry(async () => ({ output: "done", exitCode: 0 }));
@@ -259,10 +296,18 @@ test("AgentRegistry supports follow-up, wait timeout, interrupt/reuse, limits, a
 	await assert.rejects(() => registry.close(first.id), /already closed/);
 });
 
-test("AgentRegistry retains an explicit spawn thinking level across follow-ups and copies", async () => {
-	const observed: Array<string | undefined> = [];
+test("AgentRegistry retains explicit execution defaults and applies one-turn timeout overrides", async () => {
+	const observed: Array<{
+		thinkingLevel?: string;
+		timeoutMs?: number;
+		currentTimeoutMs?: number;
+	}> = [];
 	const registry = new AgentRegistry(async (agent) => {
-		observed.push(agent.thinkingLevel);
+		observed.push({
+			thinkingLevel: agent.thinkingLevel,
+			timeoutMs: agent.timeoutMs,
+			currentTimeoutMs: agent.currentTimeoutMs,
+		});
 		return { output: "done", exitCode: 0 };
 	});
 	const spawned = await registry.spawn({
@@ -270,14 +315,24 @@ test("AgentRegistry retains an explicit spawn thinking level across follow-ups a
 		task: "first",
 		cwd: process.cwd(),
 		thinkingLevel: "high",
+		timeoutMs: 111,
 	});
 	assert.equal(spawned.thinkingLevel, "high");
+	assert.equal(spawned.timeoutMs, 111);
 	await registry.wait(spawned.id, 100);
-	const followUp = await registry.followUp(spawned.id, "second");
-	assert.equal(followUp.thinkingLevel, "high");
+	const overridden = await registry.followUp(spawned.id, "second", { timeoutMs: 222 });
+	assert.equal(overridden.thinkingLevel, "high");
+	assert.equal(overridden.timeoutMs, 111);
+	assert.equal(overridden.currentTimeoutMs, 222);
 	await registry.wait(spawned.id, 100);
-	assert.deepEqual(observed, ["high", "high"]);
-	assert.equal(registry.get(spawned.id)?.thinkingLevel, "high");
+	await registry.followUp(spawned.id, "third");
+	await registry.wait(spawned.id, 100);
+	assert.deepEqual(observed, [
+		{ thinkingLevel: "high", timeoutMs: 111, currentTimeoutMs: 111 },
+		{ thinkingLevel: "high", timeoutMs: 111, currentTimeoutMs: 222 },
+		{ thinkingLevel: "high", timeoutMs: 111, currentTimeoutMs: 111 },
+	]);
+	assert.equal(registry.get(spawned.id)?.currentTimeoutMs, undefined);
 });
 
 test("AgentRegistry runs lifecycle operations through a transport contract", async () => {
@@ -798,6 +853,8 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 	await persistence.save([
 		record({
 			thinkingLevel: "high",
+			timeoutMs: 1234,
+			currentTimeoutMs: 4321,
 			spawnIdempotencyKey: "persisted-request",
 			spawnRequestHash: "a".repeat(64),
 			resultFormat: "structured-v1",
@@ -851,6 +908,8 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 	const restoredState = persistence.load()[0];
 	assert.equal(restoredState?.state, "idle");
 	assert.equal(restoredState?.thinkingLevel, "high");
+	assert.equal(restoredState?.timeoutMs, 1234);
+	assert.equal(restoredState?.currentTimeoutMs, undefined);
 	assert.equal(restoredState?.spawnIdempotencyKey, "persisted-request");
 	assert.equal(restoredState?.spawnRequestHash, "a".repeat(64));
 	assert.equal(restoredState?.resultFormat, "structured-v1");

--- a/packages/pi-subagents/test/result-contract.test.ts
+++ b/packages/pi-subagents/test/result-contract.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { appendResultInstruction, parseStructuredSubagentResult } from "../src/result-contract.js";
+
+test("structured result contract validates versioned fields and redacts private text", () => {
+	const parsed = parseStructuredSubagentResult(
+		JSON.stringify({
+			version: "pi-subagents:result:v1",
+			summary: "safe <private>secret</private>",
+			evidence: ["src/a.ts"],
+			changes: ["changed"],
+			verification: ["npm test"],
+			risks: [],
+		}),
+	);
+	assert.deepEqual(parsed, {
+		version: "pi-subagents:result:v1",
+		summary: "safe [private content omitted]",
+		evidence: ["src/a.ts"],
+		changes: ["changed"],
+		verification: ["npm test"],
+		risks: [],
+	});
+	assert.equal(parseStructuredSubagentResult('{"summary":"missing version"}'), undefined);
+	assert.equal(
+		parseStructuredSubagentResult(
+			'{"version":"pi-subagents:result:v1","summary":"partial","evidence":[]}',
+		),
+		undefined,
+	);
+	assert.equal(parseStructuredSubagentResult("{malformed"), undefined);
+	assert.equal(parseStructuredSubagentResult("plain text"), undefined);
+	const fenced = parseStructuredSubagentResult(
+		'```json\n{"version":"pi-subagents:result:v1","summary":"fenced","evidence":[],"changes":[],"verification":[],"risks":[]}\n```',
+	);
+	assert.equal(fenced?.summary, "fenced");
+});
+
+test("structured result instruction is opt-in and bounded", () => {
+	assert.equal(appendResultInstruction("task", "text"), "task");
+	const structured = appendResultInstruction("task", "structured-v1");
+	assert.match(structured, /pi-subagents:result:v1/);
+	assert.ok(Buffer.byteLength(structured, "utf8") <= 50 * 1024);
+	const oversized = appendResultInstruction("x".repeat(100 * 1024), "structured-v1");
+	assert.match(oversized, /pi-subagents:result:v1/);
+	assert.ok(Buffer.byteLength(oversized, "utf8") <= 50 * 1024);
+	assert.equal(parseStructuredSubagentResult("x".repeat(50 * 1024 + 1)), undefined);
+});

--- a/packages/pi-subagents/test/rpc-transport.test.ts
+++ b/packages/pi-subagents/test/rpc-transport.test.ts
@@ -1,0 +1,383 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "vitest";
+import type { ManagedAgent } from "../src/registry.js";
+import { buildRpcArgs, RpcProtocolClient, RpcTransport } from "../src/rpc-transport.js";
+import { PI_SUBAGENTS_RPC_PROTOCOL } from "../src/transport-types.js";
+
+function fixtureScript(root: string): string {
+	const filePath = path.join(root, "fake-rpc.mjs");
+	writeFileSync(
+		filePath,
+		[
+			'import { StringDecoder } from "node:string_decoder";',
+			"const decoder=new StringDecoder('utf8');let buffer='';let turns=0;let pendingPrompt;",
+			"const send=(value)=>process.stdout.write(JSON.stringify(value)+'\\n');",
+			"const finishPrompt=()=>{const command=pendingPrompt;pendingPrompt=undefined;send({id:command.id,type:'response',command:'prompt',success:true});send({type:'agent_start'});send({type:'message_update',assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'turn '+turns}});send({type:'agent_end',messages:[],willRetry:false});send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'turn '+turns}],provider:'fake',model:'rpc-model',usage:{input:turns,output:2,cacheRead:0,cacheWrite:0,totalTokens:turns+2,cost:{total:0}},stopReason:'stop'}});send({type:'agent_settled'});};const handle=(line)=>{const command=JSON.parse(line);",
+			"if(command.type==='get_state'){send({id:command.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'rpc-model'},thinkingLevel:'medium',isStreaming:false,isCompacting:false,steeringMode:'one-at-a-time',followUpMode:'one-at-a-time',sessionId:'fake-session',autoCompactionEnabled:true,messageCount:turns*2,pendingMessageCount:0}});return;}",
+			"if(command.type==='abort'){send({id:command.id,type:'response',command:'abort',success:true});send({type:'agent_settled'});return;}",
+			"if(command.type==='extension_ui_response'){if(command.id==='ui-'+turns&&command.cancelled===true)finishPrompt();return;}",
+			"if(command.type==='prompt'){turns++;pendingPrompt=command;send({type:'extension_ui_request',id:'ui-'+turns,method:'confirm',title:'must cancel'});return;}",
+			"};",
+			"process.stdin.on('data',(chunk)=>{buffer+=decoder.write(chunk);while(true){const index=buffer.indexOf('\\n');if(index<0)break;let line=buffer.slice(0,index);buffer=buffer.slice(index+1);if(line.endsWith('\\r'))line=line.slice(0,-1);if(line)handle(line);}});",
+		].join(""),
+	);
+	return filePath;
+}
+
+function managedAgent(): ManagedAgent {
+	const now = Date.now();
+	return {
+		id: "sa_rpc",
+		agent: "planner",
+		rootId: "sa_rpc",
+		depth: 0,
+		children: [],
+		state: "running",
+		createdAt: now,
+		updatedAt: now,
+		cwd: process.cwd(),
+		history: [],
+		mailbox: [],
+		target: {
+			cwd: process.cwd(),
+			boundary: "current-workspace",
+			trust: { kind: "session-trusted", projectTrusted: true },
+		},
+	};
+}
+
+test("RPC launch arguments preserve model, thinking, tools, trust, and role policy", () => {
+	const args = buildRpcArgs(
+		{ ...managedAgent(), thinkingLevel: "high" },
+		{
+			name: "planner",
+			description: "plan",
+			model: "provider/model:low",
+			tools: ["read", "find"],
+			systemPrompt: "plan",
+			source: "built-in",
+			filePath: "built-in:planner",
+		},
+		{ model: undefined, thinkingLevel: "medium" },
+		"/tmp/role.md",
+	);
+	assert.deepEqual(args, [
+		"--mode",
+		"rpc",
+		"--no-session",
+		"--no-extensions",
+		"--model",
+		"provider/model:low",
+		"--thinking",
+		"high",
+		"--approve",
+		"--tools",
+		"read,find",
+		"--append-system-prompt",
+		"/tmp/role.md",
+	]);
+	const inheritedThinking = buildRpcArgs(
+		managedAgent(),
+		{
+			name: "planner",
+			description: "plan",
+			model: "provider/model",
+			tools: [],
+			systemPrompt: "",
+			source: "built-in",
+			filePath: "built-in:planner",
+		},
+		{ model: undefined, thinkingLevel: "medium" },
+	);
+	assert.deepEqual(inheritedThinking.slice(4, 10), [
+		"--model",
+		"provider/model",
+		"--thinking",
+		"medium",
+		"--approve",
+		"--no-tools",
+	]);
+});
+
+test("RpcProtocolClient uses strict JSONL and the get_state readiness handshake", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-client-"));
+	try {
+		const script = fixtureScript(root);
+		const client = new RpcProtocolClient({
+			cwd: root,
+			args: [],
+			invocation: { command: process.execPath, args: [script] },
+		});
+		const snapshot = await client.start();
+		assert.equal(snapshot.state.sessionId, "fake-session");
+		assert.equal(snapshot.state.thinkingLevel, "medium");
+		const events: string[] = [];
+		const unsubscribe = client.onEvent((event) => {
+			if (event && typeof event === "object" && "type" in event) {
+				events.push(String((event as { type?: unknown }).type));
+			}
+		});
+		const settled = new Promise<void>((resolve) => {
+			const stop = client.onEvent((event) => {
+				if ((event as { type?: string }).type === "agent_settled") {
+					stop();
+					resolve();
+				}
+			});
+		});
+		await client.prompt("hello\u2028world\u2029again");
+		await settled;
+		assert.ok(events.includes("message_update"));
+		assert.ok(events.includes("agent_settled"));
+		unsubscribe();
+		await client.stop();
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("RpcTransport retains one child across turns and reports pi-subagents:v1 telemetry", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-transport-"));
+	try {
+		const script = fixtureScript(root);
+		let creations = 0;
+		let rolePromptPath: string | undefined;
+		const transport = new RpcTransport({
+			getParentRuntime: () => ({ model: undefined, thinkingLevel: "medium" }),
+			createClient: (options) => {
+				creations++;
+				const roleIndex = options.args.indexOf("--append-system-prompt");
+				if (roleIndex >= 0) rolePromptPath = options.args[roleIndex + 1];
+				return new RpcProtocolClient({
+					...options,
+					invocation: { command: process.execPath, args: [script] },
+				});
+			},
+		});
+		const agent = { ...managedAgent(), cwd: root };
+		const first = await transport.runTurn(agent, "first", new AbortController().signal);
+		assert.equal(first.output, "turn 1");
+		assert.equal(first.exitCode, 0);
+		assert.equal(first.telemetry?.protocol, PI_SUBAGENTS_RPC_PROTOCOL);
+		assert.equal(first.telemetry?.model, "rpc-model");
+		assert.equal(first.telemetry?.usage?.input, 1);
+		assert.ok(rolePromptPath && existsSync(rolePromptPath));
+		const second = await transport.runTurn(
+			{
+				...agent,
+				history: [{ task: "first", output: "turn 1", startedAt: 1, completedAt: 2, exitCode: 0 }],
+			},
+			"second",
+			new AbortController().signal,
+		);
+		assert.equal(second.output, "turn 2");
+		assert.equal(creations, 1);
+		await transport.release?.(agent);
+		assert.equal(rolePromptPath ? existsSync(rolePromptPath) : true, false);
+		await transport.release?.(agent);
+		await transport.shutdown();
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("RpcProtocolClient aborts readiness and rejects malformed protocol records", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-invalid-"));
+	try {
+		const hanging = path.join(root, "hanging.mjs");
+		writeFileSync(hanging, "process.stdin.resume();setInterval(()=>{},1000).unref();");
+		const controller = new AbortController();
+		const client = new RpcProtocolClient({
+			cwd: root,
+			args: [],
+			startupTimeoutMs: 5_000,
+			terminationGraceMs: 10,
+			invocation: { command: process.execPath, args: [hanging] },
+		});
+		const pending = client.start(controller.signal);
+		setTimeout(() => controller.abort(), 20);
+		await assert.rejects(pending, (error) => error instanceof Error && error.name === "AbortError");
+
+		const malformed = path.join(root, "malformed.mjs");
+		writeFileSync(
+			malformed,
+			"process.stderr.write('x'.repeat(32*1024));process.stdin.once('data',()=>process.stdout.write('{not-json\\n'));process.stdin.resume();",
+		);
+		const malformedClient = new RpcProtocolClient({
+			cwd: root,
+			args: [],
+			startupTimeoutMs: 5_000,
+			terminationGraceMs: 10,
+			invocation: { command: process.execPath, args: [malformed] },
+		});
+		await assert.rejects(() => malformedClient.start(), /malformed JSONL/);
+		assert.ok(Buffer.byteLength(malformedClient.getStderr(), "utf8") <= 16 * 1024);
+
+		const mismatched = path.join(root, "mismatched.mjs");
+		writeFileSync(
+			mismatched,
+			"let b='';process.stdin.on('data',chunk=>{b+=chunk;const i=b.indexOf('\\n');if(i<0)return;const c=JSON.parse(b.slice(0,i));process.stdout.write(JSON.stringify({id:c.id,type:'response',command:'prompt',success:true})+'\\n')});",
+		);
+		const mismatchedClient = new RpcProtocolClient({
+			cwd: root,
+			args: [],
+			startupTimeoutMs: 5_000,
+			terminationGraceMs: 10,
+			invocation: { command: process.execPath, args: [mismatched] },
+		});
+		await assert.rejects(() => mismatchedClient.start(), /response command mismatch/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("RpcTransport waits for agent_settled after agent_end and times out without replay", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-settled-"));
+	try {
+		const delayed = path.join(root, "delayed.mjs");
+		writeFileSync(
+			delayed,
+			[
+				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');",
+				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
+				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
+				"if(c.type==='prompt'){send({id:c.id,type:'response',command:'prompt',success:true});send({type:'agent_end',messages:[],willRetry:true});setTimeout(()=>{send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'after retry'}],provider:'fake',model:'model',usage:{},stopReason:'stop'}});send({type:'agent_settled'});},30);}",
+				"if(c.type==='abort'){send({id:c.id,type:'response',command:'abort',success:true});send({type:'agent_settled'});}",
+				"}});",
+			].join(""),
+		);
+		const transport = new RpcTransport({
+			getParentRuntime: () => ({ model: undefined, thinkingLevel: "low" }),
+			abortGraceMs: 10,
+			createClient: (options) =>
+				new RpcProtocolClient({
+					...options,
+					terminationGraceMs: 10,
+					invocation: { command: process.execPath, args: [delayed] },
+				}),
+		});
+		const started = Date.now();
+		const result = await transport.runTurn(
+			{ ...managedAgent(), cwd: root },
+			"retry",
+			new AbortController().signal,
+		);
+		assert.equal(result.output, "after retry");
+		assert.ok(Date.now() - started >= 20, "agent_end must not settle the turn");
+		await transport.shutdown();
+
+		const hanging = path.join(root, "turn-hang.mjs");
+		writeFileSync(
+			hanging,
+			[
+				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');let prompts=0;",
+				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
+				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
+				"if(c.type==='prompt'){prompts++;send({id:c.id,type:'response',command:'prompt',success:true});send({type:'agent_end',messages:[],willRetry:false});}",
+				"if(c.type==='abort')send({id:c.id,type:'response',command:'abort',success:true});",
+				"}});",
+			].join(""),
+		);
+		const timeoutTransport = new RpcTransport({
+			getParentRuntime: () => ({ model: undefined, thinkingLevel: "low" }),
+			defaultTimeoutMs: 20,
+			abortGraceMs: 10,
+			createClient: (options) =>
+				new RpcProtocolClient({
+					...options,
+					terminationGraceMs: 10,
+					invocation: { command: process.execPath, args: [hanging] },
+				}),
+		});
+		const timedOut = await timeoutTransport.runTurn(
+			{ ...managedAgent(), cwd: root },
+			"hang",
+			new AbortController().signal,
+		);
+		assert.equal(timedOut.exitCode, 124);
+		assert.match(timedOut.error ?? "", /timed out/);
+		assert.equal(timedOut.telemetry?.failurePhase, "running");
+		await timeoutTransport.shutdown();
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("RPC prompt acceptance timeout discards the child without replay", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-accept-timeout-"));
+	try {
+		const script = path.join(root, "accept-timeout.mjs");
+		const marker = path.join(root, "prompts.log");
+		writeFileSync(
+			script,
+			[
+				'import { appendFileSync } from "node:fs";',
+				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');",
+				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
+				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
+				`if(c.type==='prompt')appendFileSync(${JSON.stringify(marker)},'prompt\\n');`,
+				"if(c.type==='abort')send({id:c.id,type:'response',command:'abort',success:true});",
+				"}});",
+			].join(""),
+		);
+		const transport = new RpcTransport({
+			getParentRuntime: () => ({ model: undefined, thinkingLevel: "low" }),
+			defaultTimeoutMs: 20,
+			abortGraceMs: 10,
+			createClient: (options) =>
+				new RpcProtocolClient({
+					...options,
+					terminationGraceMs: 10,
+					invocation: { command: process.execPath, args: [script] },
+				}),
+		});
+		const result = await transport.runTurn(
+			{ ...managedAgent(), cwd: root },
+			"ambiguous",
+			new AbortController().signal,
+		);
+		assert.equal(result.exitCode, 124);
+		assert.match(result.error ?? "", /timed out/);
+		assert.equal(readFileSync(marker, "utf8"), "prompt\n");
+		await transport.shutdown();
+
+		const crashScript = path.join(root, "crash-after-accept.mjs");
+		const crashMarker = path.join(root, "crash-prompts.log");
+		writeFileSync(
+			crashScript,
+			[
+				'import { appendFileSync } from "node:fs";',
+				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');",
+				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
+				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
+				`if(c.type==='prompt'){appendFileSync(${JSON.stringify(crashMarker)},'prompt\\n');send({id:c.id,type:'response',command:'prompt',success:true});setImmediate(()=>process.exit(7));}`,
+				"}});",
+			].join(""),
+		);
+		const crashTransport = new RpcTransport({
+			getParentRuntime: () => ({ model: undefined, thinkingLevel: "low" }),
+			defaultTimeoutMs: 100,
+			abortGraceMs: 10,
+			createClient: (options) =>
+				new RpcProtocolClient({
+					...options,
+					terminationGraceMs: 10,
+					invocation: { command: process.execPath, args: [crashScript] },
+				}),
+		});
+		const crashed = await crashTransport.runTurn(
+			{ ...managedAgent(), cwd: root },
+			"accepted then crash",
+			new AbortController().signal,
+		);
+		assert.equal(crashed.exitCode, 1);
+		assert.match(crashed.error ?? "", /exited/);
+		assert.equal(readFileSync(crashMarker, "utf8"), "prompt\n");
+		await crashTransport.shutdown();
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-subagents/test/rpc-transport.test.ts
+++ b/packages/pi-subagents/test/rpc-transport.test.ts
@@ -4,8 +4,68 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "vitest";
 import type { ManagedAgent } from "../src/registry.js";
+import { finalizeTimedOutRpcTurn } from "../src/rpc-timeout-finalization.js";
 import { buildRpcArgs, RpcProtocolClient, RpcTransport } from "../src/rpc-transport.js";
 import { PI_SUBAGENTS_RPC_PROTOCOL } from "../src/transport-types.js";
+
+test("RPC timeout finalization never prompts after an explicit parent abort", async () => {
+	const controller = new AbortController();
+	controller.abort();
+	let prompts = 0;
+	let releases = 0;
+	const result = await finalizeTimedOutRpcTurn({
+		client: {
+			async prompt() {
+				prompts++;
+			},
+			async abort() {},
+			onEvent: () => () => undefined,
+			onClose: () => () => undefined,
+		},
+		task: "review",
+		partialOutput: "partial",
+		signal: controller.signal,
+		workTimeoutMs: 100,
+		abortGraceMs: 10,
+		resetCapture() {},
+		getCapture: () => ({ output: "", partial: "" }),
+		async release() {
+			releases++;
+		},
+	});
+	assert.equal(prompts, 0);
+	assert.equal(releases, 1);
+	assert.match(result.error ?? "", /aborted/i);
+});
+
+test("RPC timeout finalization bounds a prompt client that ignores its deadline", async () => {
+	let releases = 0;
+	const started = Date.now();
+	const result = await finalizeTimedOutRpcTurn({
+		client: {
+			async prompt() {
+				await new Promise<void>(() => undefined);
+			},
+			async abort() {},
+			onEvent: () => () => undefined,
+			onClose: () => () => undefined,
+		},
+		task: "review",
+		partialOutput: "partial",
+		signal: new AbortController().signal,
+		workTimeoutMs: 100,
+		finalizationTimeoutMs: 10,
+		abortGraceMs: 10,
+		resetCapture() {},
+		getCapture: () => ({ output: "", partial: "" }),
+		async release() {
+			releases++;
+		},
+	});
+	assert.equal(releases, 1);
+	assert.match(result.error ?? "", /prompt timed out/i);
+	assert.ok(Date.now() - started < 500, "prompt finalization must remain hard-bounded");
+});
 
 function fixtureScript(root: string): string {
 	const filePath = path.join(root, "fake-rpc.mjs");
@@ -169,7 +229,7 @@ test("RpcProtocolClient uses strict JSONL and the get_state readiness handshake"
 	}
 });
 
-test("RpcProtocolClient waits for inherited descendant streams to close", async () => {
+test("RpcProtocolClient gives inherited descendant streams bounded cleanup grace", async () => {
 	if (process.platform === "win32") return;
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-descendant-"));
 	let descendantPid: number | undefined;
@@ -199,12 +259,16 @@ test("RpcProtocolClient waits for inherited descendant streams to close", async 
 		assert.equal(Number.isSafeInteger(descendantPid), true);
 		const stopping = client.stop();
 		assert.equal(
-			await settlesWithin(stopping, 1_100),
+			await settlesWithin(stopping, 100),
 			false,
-			"stop must not resolve while a descendant retains captured streams",
+			"stop must allow captured streams a cleanup grace period",
+		);
+		assert.equal(
+			await settlesWithin(stopping, 1_500),
+			true,
+			"stop must hard-bound cleanup when a detached descendant retains captured streams",
 		);
 		process.kill(-descendantPid, "SIGKILL");
-		await stopping;
 	} finally {
 		if (descendantPid) {
 			try {
@@ -387,6 +451,48 @@ test("RpcTransport waits for agent_settled after agent_end and times out without
 		assert.match(timedOut.error ?? "", /timed out/);
 		assert.equal(timedOut.telemetry?.failurePhase, "running");
 		await timeoutTransport.shutdown();
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("RPC timeout aborts the work turn and requests a bounded summary after settlement", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-timeout-summary-"));
+	try {
+		const script = path.join(root, "timeout-summary.mjs");
+		writeFileSync(
+			script,
+			[
+				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');let prompts=0;",
+				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
+				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
+				"if(c.type==='prompt'){prompts++;send({id:c.id,type:'response',command:'prompt',success:true});if(prompts===1){send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'PARTIAL_RPC'}],provider:'fake',model:'model',usage:{},stopReason:'toolUse'}});}else{send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'SUMMARY_RPC'}],provider:'fake',model:'model',usage:{},stopReason:'stop'}});send({type:'agent_settled'});}}",
+				"if(c.type==='abort'){send({id:c.id,type:'response',command:'abort',success:true});send({type:'agent_settled'});}",
+				"}});",
+			].join(""),
+		);
+		const transport = new RpcTransport({
+			getParentRuntime: () => ({ model: undefined, thinkingLevel: "low" }),
+			defaultTimeoutMs: 1_000,
+			abortGraceMs: 20,
+			timeoutFinalizationMs: 100,
+			createClient: (options) =>
+				new RpcProtocolClient({
+					...options,
+					terminationGraceMs: 10,
+					invocation: { command: process.execPath, args: [script] },
+				}),
+		});
+		const result = await transport.runTurn(
+			{ ...managedAgent(), cwd: root, currentTimeoutMs: 30 },
+			"review",
+			new AbortController().signal,
+		);
+		assert.equal(result.exitCode, 124);
+		assert.match(result.error ?? "", /timed out/);
+		assert.equal(result.output, "SUMMARY_RPC");
+		assert.equal(result.telemetry?.phase, "failed");
+		await transport.shutdown();
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/packages/pi-subagents/test/rpc-transport.test.ts
+++ b/packages/pi-subagents/test/rpc-transport.test.ts
@@ -27,6 +27,31 @@ function fixtureScript(root: string): string {
 	return filePath;
 }
 
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			promise.then(
+				() => true,
+				() => true,
+			),
+			new Promise<boolean>((resolve) => {
+				timer = setTimeout(() => resolve(false), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+async function waitForFile(filePath: string, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!existsSync(filePath)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${filePath}`);
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+	}
+}
+
 function managedAgent(): ManagedAgent {
 	const now = Date.now();
 	return {
@@ -63,6 +88,7 @@ test("RPC launch arguments preserve model, thinking, tools, trust, and role poli
 		},
 		{ model: undefined, thinkingLevel: "medium" },
 		"/tmp/role.md",
+		["/tmp/global-append.md", "/tmp/project-append.md"],
 	);
 	assert.deepEqual(args, [
 		"--mode",
@@ -76,6 +102,10 @@ test("RPC launch arguments preserve model, thinking, tools, trust, and role poli
 		"--approve",
 		"--tools",
 		"read,find",
+		"--append-system-prompt",
+		"/tmp/global-append.md",
+		"--append-system-prompt",
+		"/tmp/project-append.md",
 		"--append-system-prompt",
 		"/tmp/role.md",
 	]);
@@ -139,17 +169,72 @@ test("RpcProtocolClient uses strict JSONL and the get_state readiness handshake"
 	}
 });
 
+test("RpcProtocolClient waits for inherited descendant streams to close", async () => {
+	if (process.platform === "win32") return;
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-descendant-"));
+	let descendantPid: number | undefined;
+	try {
+		const marker = path.join(root, "descendant.pid");
+		const script = path.join(root, "descendant-rpc.mjs");
+		writeFileSync(
+			script,
+			[
+				'import { spawn } from "node:child_process";',
+				'import { writeFileSync } from "node:fs";',
+				"let buffer='';const send=value=>process.stdout.write(JSON.stringify(value)+'\\n');",
+				"process.stdin.on('data',chunk=>{buffer+=chunk;let index;while((index=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,index);buffer=buffer.slice(index+1);if(!line)continue;const command=JSON.parse(line);if(command.type!=='get_state')continue;",
+				`const child=spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{detached:true,stdio:['ignore','inherit','inherit']});child.unref();writeFileSync(${JSON.stringify(marker)},String(child.pid));`,
+				"send({id:command.id,type:'response',command:'get_state',success:true,data:{thinkingLevel:'low',sessionId:'descendant'}});setTimeout(()=>process.exit(0),20);}});",
+			].join(""),
+		);
+		const client = new RpcProtocolClient({
+			cwd: root,
+			args: [],
+			terminationGraceMs: 10,
+			invocation: { command: process.execPath, args: [script] },
+		});
+		await client.start();
+		await waitForFile(marker);
+		descendantPid = Number(readFileSync(marker, "utf8"));
+		assert.equal(Number.isSafeInteger(descendantPid), true);
+		const stopping = client.stop();
+		assert.equal(
+			await settlesWithin(stopping, 1_100),
+			false,
+			"stop must not resolve while a descendant retains captured streams",
+		);
+		process.kill(-descendantPid, "SIGKILL");
+		await stopping;
+	} finally {
+		if (descendantPid) {
+			try {
+				process.kill(-descendantPid, "SIGKILL");
+			} catch {
+				// The descendant was already reaped.
+			}
+		}
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("RpcTransport retains one child across turns and reports pi-subagents:v1 telemetry", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-transport-"));
 	try {
 		const script = fixtureScript(root);
 		let creations = 0;
 		let rolePromptPath: string | undefined;
+		const resourceRequests: Array<{ cwd: string; trusted: boolean }> = [];
 		const transport = new RpcTransport({
 			getParentRuntime: () => ({ model: undefined, thinkingLevel: "medium" }),
+			resolvePromptResources: async (cwd, trusted) => {
+				resourceRequests.push({ cwd, trusted });
+				return {
+					appendSystemPromptPaths: ["/tmp/global-append.md", "/tmp/project-append.md"],
+				};
+			},
 			createClient: (options) => {
 				creations++;
-				const roleIndex = options.args.indexOf("--append-system-prompt");
+				const roleIndex = options.args.lastIndexOf("--append-system-prompt");
 				if (roleIndex >= 0) rolePromptPath = options.args[roleIndex + 1];
 				return new RpcProtocolClient({
 					...options,
@@ -164,6 +249,7 @@ test("RpcTransport retains one child across turns and reports pi-subagents:v1 te
 		assert.equal(first.telemetry?.protocol, PI_SUBAGENTS_RPC_PROTOCOL);
 		assert.equal(first.telemetry?.model, "rpc-model");
 		assert.equal(first.telemetry?.usage?.input, 1);
+		assert.deepEqual(resourceRequests, [{ cwd: root, trusted: true }]);
 		assert.ok(rolePromptPath && existsSync(rolePromptPath));
 		const second = await transport.runTurn(
 			{

--- a/packages/pi-subagents/test/runner-render.test.ts
+++ b/packages/pi-subagents/test/runner-render.test.ts
@@ -355,6 +355,89 @@ test("runSingleAgent preserves partial output on mid-stream abort and handles pr
 	);
 	assert.equal(beforeStart.aborted, true);
 	assert.equal(beforeStart.exitCode, 130);
+	assert.equal(beforeStart.timeoutSummary, undefined);
+});
+
+test("runSingleAgent aborts timed-out work and returns a hard-bounded tool-less summary", async () => {
+	const script = [
+		"const args=process.argv.slice(1);",
+		"const task=args.at(-1)??'';",
+		"if(task.includes('Work deadline expired')){",
+		"const isolated=['--no-tools','--no-extensions','--no-skills','--no-prompt-templates','--no-context-files'].every(flag=>args.includes(flag));",
+		"const summary={role:'assistant',content:[{type:'text',text:isolated?'SUMMARY_FROM_PARTIAL':'UNSAFE_SUMMARY'}],stopReason:'stop',timestamp:Date.now()};",
+		"process.stdout.write(JSON.stringify({type:'message_end',message:summary})+'\\n');",
+		"}else{",
+		"const partial={role:'assistant',content:[{type:'text',text:'PARTIAL_EVIDENCE'}],timestamp:Date.now()};",
+		"process.stdout.write(JSON.stringify({type:'message_end',message:partial})+'\\n');",
+		"setInterval(()=>{},1000);",
+		"}",
+	].join("");
+	const result = await runSingleAgent(
+		process.cwd(),
+		[
+			{
+				name: "test",
+				description: "test",
+				tools: ["read", "bash"],
+				systemPrompt: "",
+				source: "built-in",
+				filePath: "built-in:test",
+			},
+		],
+		"test",
+		"inspect",
+		undefined,
+		undefined,
+		undefined,
+		"low",
+		30,
+		undefined,
+		(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
+		{ command: process.execPath, argsPrefix: ["-e", script, "--"] },
+		{ timeoutFinalizationMs: 200 },
+	);
+	assert.equal(result.exitCode, 124);
+	assert.equal(result.timedOut, true);
+	assert.equal(result.partialOutput, "PARTIAL_EVIDENCE");
+	assert.equal(result.timeoutSummary, "SUMMARY_FROM_PARTIAL");
+	assert.equal(result.finalOutput, "SUMMARY_FROM_PARTIAL");
+	assert.equal(result.timeoutSummaryError, undefined);
+});
+
+test("runSingleAgent hard-bounds timeout summary finalization", async () => {
+	const script = [
+		"const args=process.argv.slice(1);const task=args.at(-1)??'';",
+		"if(!task.includes('Work deadline expired')){const partial={role:'assistant',content:[{type:'text',text:'PARTIAL_ONLY'}],timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message:partial})+'\\n');}",
+		"setInterval(()=>{},1000);",
+	].join("");
+	const started = Date.now();
+	const result = await runSingleAgent(
+		process.cwd(),
+		[
+			{
+				name: "test",
+				description: "test",
+				systemPrompt: "",
+				source: "built-in",
+				filePath: "built-in:test",
+			},
+		],
+		"test",
+		"inspect",
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		100,
+		undefined,
+		(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
+		{ command: process.execPath, argsPrefix: ["-e", script, "--"] },
+		{ timeoutFinalizationMs: 30 },
+	);
+	assert.equal(result.exitCode, 124);
+	assert.equal(result.finalOutput, "PARTIAL_ONLY");
+	assert.match(result.timeoutSummaryError ?? "", /timed out/i);
+	assert.ok(Date.now() - started < 1_000, "summary finalization must remain hard-bounded");
 });
 
 test("runSingleAgent preserves final text beyond its history budget and rejects empty final output", async () => {

--- a/packages/pi-subagents/test/runner-render.test.ts
+++ b/packages/pi-subagents/test/runner-render.test.ts
@@ -390,7 +390,7 @@ test("runSingleAgent aborts timed-out work and returns a hard-bounded tool-less 
 		undefined,
 		undefined,
 		"low",
-		30,
+		150,
 		undefined,
 		(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
 		{ command: process.execPath, argsPrefix: ["-e", script, "--"] },

--- a/packages/pi-subagents/test/settings.test.ts
+++ b/packages/pi-subagents/test/settings.test.ts
@@ -4,18 +4,26 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "vitest";
 import {
+	applyExecutionProfile,
+	executionProfilePreview,
+	inspectExecutionProfile,
+} from "../src/execution-profiles.js";
+import {
 	consumeSubagentSettingsNotice,
 	inspectBlockingParallelLimitSettings,
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
 	inspectStatefulLimitSettings,
+	inspectStatefulTransportSettings,
 	inspectSubagentSettings,
 	normalizeSubagentSettings,
 	readSubagentSettings,
+	updateAgentSettingsPatch,
 	updateBlockingMaxParallelTasksSetting,
 	updateConsultResourceSetting,
 	updateCwdPolicySetting,
 	updateStatefulLimitSetting,
+	updateStatefulTransportSetting,
 } from "../src/settings.js";
 import { resolveStatefulLimits } from "../src/stateful-limits.js";
 
@@ -32,6 +40,57 @@ function withAgentDir(run: (directory: string) => void): void {
 		rmSync(directory, { recursive: true, force: true });
 	}
 }
+
+test("stateful RPC and automatic transports are opt-in and preserve unknown settings", () => {
+	withAgentDir((directory) => {
+		assert.deepEqual(normalizeSubagentSettings({ stateful: { transport: "rpc" } }), {
+			stateful: { transport: "rpc" },
+		});
+		assert.deepEqual(normalizeSubagentSettings({ stateful: { transport: "auto" } }), {
+			stateful: { transport: "auto" },
+		});
+		assert.equal(inspectStatefulTransportSettings().value, "subprocess");
+		writeFileSync(
+			path.join(directory, "pi-subagents.json"),
+			'{"future":{"kept":true},"stateful":{"completionDelivery":"auto-resume"}}\n',
+		);
+		updateStatefulTransportSetting("rpc");
+		assert.deepEqual(JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8")), {
+			future: { kept: true },
+			stateful: { completionDelivery: "auto-resume", transport: "rpc" },
+		});
+		assert.deepEqual(inspectStatefulTransportSettings(), {
+			path: path.join(directory, "pi-subagents.json"),
+			value: "rpc",
+			source: "user settings",
+		});
+	});
+});
+
+test("execution profiles patch only thinking defaults and keep other agent fields", () => {
+	withAgentDir((directory) => {
+		writeFileSync(
+			path.join(directory, "pi-subagents.json"),
+			'{"agents":{"scout":{"model":"provider/model","tools":["read"]}},"future":true}\n',
+		);
+		applyExecutionProfile("balanced");
+		assert.equal(inspectExecutionProfile(), "balanced");
+		assert.match(executionProfilePreview("deep").join("\n"), /reviewer: high/);
+		const saved = JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8"));
+		assert.equal(saved.future, true);
+		assert.equal(saved.agents.scout.model, "provider/model");
+		assert.deepEqual(saved.agents.scout.tools, ["read"]);
+		assert.equal(saved.agents.scout.thinkingLevel, "low");
+		updateAgentSettingsPatch({
+			scout: { model: undefined, thinkingLevel: "high", timeoutMs: 1234 },
+		});
+		const updated = readSubagentSettings();
+		assert.equal(updated?.agents?.scout?.model, undefined);
+		assert.equal(updated?.agents?.scout?.thinkingLevel, "high");
+		assert.equal(updated?.agents?.scout?.timeoutMs, 1234);
+		assert.equal(inspectExecutionProfile(), "custom");
+	});
+});
 
 test("consult resources normalize strictly and default without creating settings", () => {
 	withAgentDir((directory) => {

--- a/packages/pi-subagents/test/subagents.test.ts
+++ b/packages/pi-subagents/test/subagents.test.ts
@@ -7,6 +7,7 @@ import fs, {
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
+	realpathSync,
 	rmSync,
 	symlinkSync,
 	unlinkSync,
@@ -2868,7 +2869,7 @@ test("blocking delegation preflights every target and passes explicit saved trus
 		);
 		assert.match(accepted.content?.[0]?.text ?? "", /--approve/);
 		assert.equal(accepted.details?.results[0]?.target?.trust.kind, "saved-trusted");
-		assert.equal(accepted.details?.results[0]?.target?.cwd, external);
+		assert.equal(accepted.details?.results[0]?.target?.cwd, realpathSync(external));
 
 		rmSync(marker, { force: true });
 		writeFileSync(

--- a/scripts/benchmark-pi-subagents-transports.mjs
+++ b/scripts/benchmark-pi-subagents-transports.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { rmSync } from "node:fs";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import {
+	createAgentSessionFromServices,
+	createAgentSessionServices,
+	getPackageDir,
+	SessionManager,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+const samples = parseSamples(process.argv.slice(2));
+const cli = await resolvePiCli();
+const benchmarkAgentDir = await mkdtemp(path.join(os.tmpdir(), "pi-subagents-benchmark-agent-"));
+const cleanupAgentDir = () => rmSync(benchmarkAgentDir, { recursive: true, force: true });
+process.once("exit", cleanupAgentDir);
+const fakePi = await writeFakePi(benchmarkAgentDir);
+const fakeFreshSubprocessTurn = [];
+const fakeRpcFirstTurn = [];
+const fakeRpcRetainedFollowUp = [];
+const freshRpcReadiness = [];
+const retainedRpcCommand = [];
+const inProcessCreate = [];
+const retainedInProcessState = [];
+
+for (let index = 0; index < samples; index++) {
+	const subprocessStarted = performance.now();
+	await runFakeSubprocessTurn(fakePi, benchmarkAgentDir);
+	fakeFreshSubprocessTurn.push(performance.now() - subprocessStarted);
+	const fakeClient = await startRpc(
+		{ command: process.execPath, args: [fakePi] },
+		benchmarkAgentDir,
+	);
+	let settled = fakeClient.waitFor("agent_settled");
+	let turnStarted = performance.now();
+	await fakeClient.request("prompt", { message: "first" });
+	await settled;
+	fakeRpcFirstTurn.push(performance.now() - turnStarted);
+	settled = fakeClient.waitFor("agent_settled");
+	turnStarted = performance.now();
+	await fakeClient.request("prompt", { message: "follow-up" });
+	await settled;
+	fakeRpcRetainedFollowUp.push(performance.now() - turnStarted);
+	await fakeClient.stop();
+}
+
+for (let index = 0; index < samples; index++) {
+	const started = performance.now();
+	const client = await startRpc(cli, benchmarkAgentDir);
+	freshRpcReadiness.push(performance.now() - started);
+	const retainedStarted = performance.now();
+	await client.request("get_state");
+	retainedRpcCommand.push(performance.now() - retainedStarted);
+	await client.stop();
+}
+
+for (let index = 0; index < samples; index++) {
+	const sdkStarted = performance.now();
+	const services = await createAgentSessionServices({
+		cwd: process.cwd(),
+		agentDir: benchmarkAgentDir,
+		settingsManager: SettingsManager.inMemory({}),
+		resourceLoaderOptions: { noExtensions: true, noSkills: true, noPromptTemplates: true },
+	});
+	const created = await createAgentSessionFromServices({
+		services,
+		sessionManager: SessionManager.inMemory(process.cwd()),
+	});
+	inProcessCreate.push(performance.now() - sdkStarted);
+	const stateStarted = performance.now();
+	void created.session.model;
+	void created.session.thinkingLevel;
+	retainedInProcessState.push(performance.now() - stateStarted);
+	created.session.dispose();
+}
+
+process.stdout.write(
+	`${JSON.stringify(
+		{
+			benchmark: "pi-subagents-transport-overhead:v1",
+			samples,
+			note: "Deterministic fake-turn and isolated real Pi startup/readiness overhead only; no provider request is made.",
+			fakeFreshSubprocessTurnMs: stats(fakeFreshSubprocessTurn),
+			fakeRpcFirstTurnMs: stats(fakeRpcFirstTurn),
+			fakeRpcRetainedFollowUpMs: stats(fakeRpcRetainedFollowUp),
+			freshRpcReadinessMs: stats(freshRpcReadiness),
+			retainedRpcCommandMs: stats(retainedRpcCommand),
+			inProcessSessionCreateMs: stats(inProcessCreate),
+			retainedInProcessStateReadMs: stats(retainedInProcessState),
+		},
+		null,
+		2,
+	)}\n`,
+);
+process.off("exit", cleanupAgentDir);
+cleanupAgentDir();
+
+function parseSamples(args) {
+	const index = args.indexOf("--samples");
+	const raw = index >= 0 ? args[index + 1] : "7";
+	const value = Number(raw);
+	if (!Number.isSafeInteger(value) || value < 1 || value > 100) {
+		throw new Error("--samples must be an integer between 1 and 100");
+	}
+	return value;
+}
+
+async function resolvePiCli() {
+	const packageDir = getPackageDir();
+	const manifest = JSON.parse(await readFile(path.join(packageDir, "package.json"), "utf8"));
+	const declared = manifest?.bin?.pi;
+	if (typeof declared !== "string" || !declared) throw new Error("Pi package has no bin.pi");
+	return { command: process.execPath, args: [path.resolve(packageDir, declared)] };
+}
+
+async function writeFakePi(directory) {
+	const filePath = path.join(directory, "fake-pi.mjs");
+	await writeFile(
+		filePath,
+		[
+			'import readline from "node:readline";',
+			"const mode=process.argv[process.argv.indexOf('--mode')+1];",
+			"const send=value=>process.stdout.write(JSON.stringify(value)+'\\n');",
+			"if(mode==='json'){send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'done'}]}});process.exit(0);}",
+			"const input=readline.createInterface({input:process.stdin,crlfDelay:Infinity});",
+			"input.on('line',line=>{const command=JSON.parse(line);",
+			"if(command.type==='get_state'){send({id:command.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'fake'}});return;}",
+			"if(command.type==='prompt'){send({id:command.id,type:'response',command:'prompt',success:true});send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'done'}]}});send({type:'agent_settled'});return;}",
+			"});",
+		].join(""),
+		{ mode: 0o700 },
+	);
+	return filePath;
+}
+
+async function runFakeSubprocessTurn(fakePi, agentDir) {
+	const proc = spawn(
+		process.execPath,
+		[fakePi, "--mode", "json", "-p", "--no-session", "benchmark"],
+		{
+			cwd: process.cwd(),
+			stdio: ["ignore", "pipe", "pipe"],
+			shell: false,
+			env: { ...process.env, PI_CODING_AGENT_DIR: agentDir },
+		},
+	);
+	let stderr = "";
+	proc.stderr.on("data", (chunk) => {
+		stderr = `${stderr}${chunk.toString("utf8")}`.slice(-16 * 1024);
+	});
+	await new Promise((resolve, reject) => {
+		proc.once("error", reject);
+		proc.once("close", (code, signal) => {
+			if (code === 0) resolve();
+			else reject(new Error(`Fake subprocess failed (code=${code}, signal=${signal}): ${stderr}`));
+		});
+	});
+}
+
+async function startRpc(invocation, agentDir) {
+	const proc = spawn(
+		invocation.command,
+		[
+			...invocation.args,
+			"--mode",
+			"rpc",
+			"--no-session",
+			"--no-extensions",
+			"--no-skills",
+			"--no-prompt-templates",
+			"--no-context-files",
+			"--no-approve",
+		],
+		{
+			cwd: process.cwd(),
+			stdio: ["pipe", "pipe", "pipe"],
+			shell: false,
+			env: { ...process.env, PI_CODING_AGENT_DIR: agentDir },
+		},
+	);
+	let buffer = "";
+	let nextId = 0;
+	const pending = new Map();
+	const eventWaiters = new Map();
+	let stderr = "";
+	proc.stdout.on("data", (chunk) => {
+		buffer += chunk.toString("utf8");
+		while (true) {
+			const newline = buffer.indexOf("\n");
+			if (newline < 0) break;
+			let line = buffer.slice(0, newline);
+			buffer = buffer.slice(newline + 1);
+			if (line.endsWith("\r")) line = line.slice(0, -1);
+			if (!line) continue;
+			const value = JSON.parse(line);
+			if (value.type === "response" && typeof value.id === "string") {
+				const request = pending.get(value.id);
+				if (request) {
+					pending.delete(value.id);
+					value.success ? request.resolve(value) : request.reject(new Error(value.error));
+				}
+			} else if (typeof value.type === "string") {
+				const waiters = eventWaiters.get(value.type);
+				const waiter = waiters?.shift();
+				if (waiter) waiter.resolve(value);
+				if (waiters?.length === 0) eventWaiters.delete(value.type);
+			}
+		}
+	});
+	proc.stderr.on("data", (chunk) => {
+		stderr = `${stderr}${chunk.toString("utf8")}`.slice(-16 * 1024);
+	});
+	const rejectPending = (error) => {
+		for (const request of pending.values()) request.reject(error);
+		pending.clear();
+		for (const waiters of eventWaiters.values()) {
+			for (const waiter of waiters) waiter.reject(error);
+		}
+		eventWaiters.clear();
+	};
+	proc.once("error", (error) => rejectPending(error));
+	proc.once("close", (code, signal) =>
+		rejectPending(
+			new Error(
+				`RPC benchmark process exited (code=${code ?? "null"}, signal=${signal ?? "null"}): ${stderr}`,
+			),
+		),
+	);
+	const request = (type, payload = {}) =>
+		new Promise((resolve, reject) => {
+			const id = `benchmark_${++nextId}`;
+			const timer = setTimeout(() => {
+				pending.delete(id);
+				reject(new Error(`RPC ${type} timed out: ${stderr}`));
+			}, 30_000);
+			pending.set(id, {
+				resolve: (value) => {
+					clearTimeout(timer);
+					resolve(value);
+				},
+				reject: (error) => {
+					clearTimeout(timer);
+					reject(error);
+				},
+			});
+			proc.stdin.write(`${JSON.stringify({ id, type, ...payload })}\n`);
+		});
+	const waitFor = (type) =>
+		new Promise((resolve, reject) => {
+			const waiters = eventWaiters.get(type) ?? [];
+			let entry;
+			const timer = setTimeout(() => {
+				const remaining = (eventWaiters.get(type) ?? []).filter((value) => value !== entry);
+				if (remaining.length > 0) eventWaiters.set(type, remaining);
+				else eventWaiters.delete(type);
+				reject(new Error(`RPC ${type} event timed out: ${stderr}`));
+			}, 30_000);
+			entry = {
+				resolve: (value) => {
+					clearTimeout(timer);
+					resolve(value);
+				},
+				reject: (error) => {
+					clearTimeout(timer);
+					reject(error);
+				},
+			};
+			waiters.push(entry);
+			eventWaiters.set(type, waiters);
+		});
+	const stop = async () => {
+		if (proc.exitCode !== null || proc.signalCode !== null) return;
+		proc.stdin.end();
+		proc.kill("SIGTERM");
+		let timer;
+		try {
+			await Promise.race([
+				new Promise((resolve) => proc.once("close", resolve)),
+				new Promise((resolve) => {
+					timer = setTimeout(() => {
+						proc.kill("SIGKILL");
+						resolve();
+					}, 1_000);
+				}),
+			]);
+		} finally {
+			if (timer) clearTimeout(timer);
+		}
+	};
+	try {
+		await request("get_state");
+		return { request, waitFor, stop };
+	} catch (error) {
+		await stop();
+		throw error;
+	}
+}
+
+function stats(values) {
+	const sorted = [...values].sort((left, right) => left - right);
+	const median = quantile(sorted, 0.5);
+	const deviations = sorted
+		.map((value) => Math.abs(value - median))
+		.sort((left, right) => left - right);
+	return {
+		median: round(median),
+		mad: round(quantile(deviations, 0.5)),
+		min: round(sorted[0]),
+		max: round(sorted.at(-1)),
+	};
+}
+
+function quantile(sorted, value) {
+	const index = (sorted.length - 1) * value;
+	const lower = Math.floor(index);
+	const upper = Math.ceil(index);
+	if (lower === upper) return sorted[lower];
+	return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
+}
+
+function round(value) {
+	return Number(value.toFixed(3));
+}

--- a/scripts/benchmark-pi-subagents-transports.mjs
+++ b/scripts/benchmark-pi-subagents-transports.mjs
@@ -178,6 +178,7 @@ async function startRpc(invocation, agentDir) {
 		],
 		{
 			cwd: process.cwd(),
+			detached: process.platform !== "win32",
 			stdio: ["pipe", "pipe", "pipe"],
 			shell: false,
 			env: { ...process.env, PI_CODING_AGENT_DIR: agentDir },
@@ -188,6 +189,7 @@ async function startRpc(invocation, agentDir) {
 	const pending = new Map();
 	const eventWaiters = new Map();
 	let stderr = "";
+	let closed = false;
 	proc.stdout.on("data", (chunk) => {
 		buffer += chunk.toString("utf8");
 		while (true) {
@@ -224,13 +226,14 @@ async function startRpc(invocation, agentDir) {
 		eventWaiters.clear();
 	};
 	proc.once("error", (error) => rejectPending(error));
-	proc.once("close", (code, signal) =>
+	proc.once("close", (code, signal) => {
+		closed = true;
 		rejectPending(
 			new Error(
 				`RPC benchmark process exited (code=${code ?? "null"}, signal=${signal ?? "null"}): ${stderr}`,
 			),
-		),
-	);
+		);
+	});
 	const request = (type, payload = {}) =>
 		new Promise((resolve, reject) => {
 			const id = `benchmark_${++nextId}`;
@@ -273,23 +276,35 @@ async function startRpc(invocation, agentDir) {
 			waiters.push(entry);
 			eventWaiters.set(type, waiters);
 		});
-	const stop = async () => {
-		if (proc.exitCode !== null || proc.signalCode !== null) return;
-		proc.stdin.end();
-		proc.kill("SIGTERM");
-		let timer;
+	const signalGroup = (signal) => {
+		if (process.platform !== "win32" && proc.pid) {
+			try {
+				process.kill(-proc.pid, signal);
+				return;
+			} catch {
+				// Fall back to the immediate process below.
+			}
+		}
 		try {
-			await Promise.race([
-				new Promise((resolve) => proc.once("close", resolve)),
-				new Promise((resolve) => {
-					timer = setTimeout(() => {
-						proc.kill("SIGKILL");
-						resolve();
-					}, 1_000);
-				}),
-			]);
+			proc.kill(signal);
+		} catch {
+			// The process may already be closed.
+		}
+	};
+	const stop = async () => {
+		if (closed) return;
+		proc.stdin.end();
+		signalGroup("SIGTERM");
+		const escalation = setTimeout(() => {
+			if (!closed) signalGroup("SIGKILL");
+		}, 1_000);
+		try {
+			await new Promise((resolve) => {
+				if (closed) resolve();
+				else proc.once("close", resolve);
+			});
 		} finally {
-			if (timer) clearTimeout(timer);
+			clearTimeout(escalation);
 		}
 	};
 	try {


### PR DESCRIPTION
## Summary

- add opt-in persistent `rpc` and deterministic `auto` retained-agent transports while keeping `subprocess` as the default
- add Fast/Balanced/Deep profiles, per-agent model/thinking/timeout controls, bounded progress diagnostics, spawn idempotency, context preview, and opt-in structured results
- add a reproducible transport benchmark, protocol note, archived executable plan, README guidance, and a minor Changeset

## Safety and compatibility

- use exact loaded Pi CLI resolution, strict bounded JSONL, `get_state` readiness, authoritative `agent_settled`, and no replay after possible prompt acceptance
- preserve trust, tool, model, thinking, context, persistence, worktree, and completion-delivery boundaries
- keep RPC/auto/profile/structured behavior opt-in and document downgrade to `subprocess`
- audit cancellation, stale sessions, shutdown, process groups, temporary files, settings locking, malformed files, terminal input, and private text against `docs/extension-conventions.md` and `docs/extension-settings.md`

## Verification

- `VITEST_MAX_WORKERS=4 npm run check` — 235 files and 2,658 tests passed; the worker cap avoids local process-start contention without excluding tests
- `npm run check --workspace @narumitw/pi-subagents` — passed
- focused pi-subagents suite — 18 files and 224 tests passed
- `just benchmark-subagents 7` — passed; medians and MAD recorded in `docs/implementation-notes/pi-subagents-rpc-v1.md`
- `just pack subagents` — inspected 56-file dry-run tarball containing the manifest, README, license, and published source
- offline real Pi RPC loader — correlated `get_state` passed without provider access
- live Pi smokes — RPC spawn, two-turn reuse, idle-root completion, interrupt, inspect, close, auto routing, structured result, and active-child shutdown passed
- real Pi TUI smoke — profile cancellation made no write, then Balanced save passed
- `git diff --check` — passed

No package publication, visibility change, tag, or release workflow was performed.
