### PR TITLE
docs(pi-subagents): add delegation intelligence roadmap

### DIFF
--- a/docs/plans/2026-08-10_pi-subagents-adaptive-scheduling-semantic-snapshot-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-adaptive-scheduling-semantic-snapshot-plan.md
@@ -1,0 +1,110 @@
+# Pi Subagents Adaptive Scheduling and Semantic Snapshot Plan
+
+## Goal
+
+Add deterministic dependency-aware scheduling and semantic resource snapshots so `pi-subagents` starts only current, ready, safely independent work, adapts effective concurrency below hard ceilings, detects semantic skew before continuation, and invalidates stale downstream evidence.
+
+Prove value against matched single-agent and orchestration baselines before changing defaults.
+
+## Context
+
+The WorkItem ledger provides authoritative dependencies, artifacts, generations, ownership, acceptance state, and invalidation.
+
+Current retained turns use a FIFO queue bounded by `maxActiveTurns`, while blocking parallel execution starts a fixed maximum of four workers at once.
+
+Current retained state records agent identity and selected runtime controls but does not bind every continuation to immutable identities for agent definition, prompt resources, tool policy, model resolution, repository generation, dependency artifacts, or scheduler policy.
+
+The research notes show that raw agent count is weakly related to quality, that dependency-ready cohesion-aware scheduling can improve quality and cost, and that missing transfers and latent-failure cascade radius can grow with depth.
+
+This phase must keep concurrency limits as safety ceilings and make semantic mismatch visible without storing secrets or full prompts.
+
+## Architecture
+
+A deterministic scheduler will consume immutable WorkItem and ExecutionPlan snapshots and emit explicit decisions with ready, blocked, unsafe, stale, budget-limited, capacity-limited, or selected reasons.
+
+Effective concurrency will be the minimum of configured hard limits, dependency-ready work, safe ownership and workspace capacity, transport capacity, remaining budget, and bounded policy constraints.
+
+The first scheduler will not call another model and will not optimize raw agent count.
+
+Optional critical-path and cohesion hints will affect ordering only when they are explicit or computed by a bounded deterministic adapter.
+
+A versioned semantic snapshot will store allowlisted identities or hashes for agent definition, role prompt, result contract, effective tool and resource policy, resolved model and thinking, transport protocol, cwd trust decision, repository generation, dependency artifacts, workflow generation, and scheduler policy.
+
+Snapshots will never persist credentials, provider headers, environment values, full prompts, raw protected files, or unrestricted absolute paths.
+
+A compatibility evaluator will classify current state as compatible, warning, needs-revalidation, or rejected before a restored or retained turn begins.
+
+Invalidation will propagate through dependency edges and preserve prior evidence while preventing stale acceptance.
+
+Independent verifier evidence will be required only for configured risk classes or WorkItems whose acceptance contract demands it.
+
+## Non-Goals
+
+- Do not maximize worker count, recurse without bounds, or launch every ready task immediately.
+- Do not add a learned scheduler, reinforcement-learning policy, or orchestration reward model in the first implementation.
+- Do not build full static repository dependency analysis or require a repository index for every task.
+- Do not persist raw prompts, source files, credentials, provider headers, secrets, or model reasoning in snapshots.
+- Do not automatically replay stale or invalidated work that may have produced side effects.
+- Do not change default scheduling or semantic-isolation policy before benchmark and soak evidence supports a separate decision.
+
+## Assumptions
+
+- Handoff v2, ExecutionPlan enforcement, typed outcomes, and the WorkItem ledger are complete and stable.
+- Existing concurrency settings remain hard safety limits regardless of scheduler mode.
+- Repository generation can use a bounded truthful identity that distinguishes clean commits, worktrees, and unsupported dirty-state precision.
+- Semantic compatibility rules can begin conservative and become stricter only with evidence.
+
+## Risks
+
+- Adaptive ordering can make runs harder to reproduce if decisions are not deterministic and recorded.
+- Cohesion hints can be wrong and serialize work unnecessarily or allow unsafe overlap.
+- Repository or resource hashing can add startup latency and expose sensitive identities.
+- Benign prompt, model alias, or settings changes can cause excessive revalidation.
+- Strict snapshot enforcement can strand restored work after package upgrades.
+- Benchmark improvements can be caused by extra tokens, models, retries, or budget rather than scheduling.
+- New settings can violate persistence, precedence, rollback, or downgrade expectations.
+
+## Rollback / Recovery
+
+- Keep current FIFO and fixed blocking scheduling as the default and documented rollback path during the first release.
+- Add dependency-aware scheduling and semantic-isolation policy as explicit settings or contracted options with exact previews and downgrade instructions.
+- Treat unknown old snapshots as warning or needs-revalidation rather than silently compatible.
+- Restore stale workflows inertly and require explicit revalidation, replacement, or closure.
+- Preserve prior WorkItem, artifact, and verification evidence when invalidating downstream state.
+- Revert scheduler policy independently from semantic snapshot recording if benchmark value is not demonstrated.
+
+## Plan
+
+- [ ] Characterize FIFO queue order, blocking parallel concurrency, queue telemetry, budget precedence, write-conflict checks, worktree isolation, transport capacity, retained restore, model resolution, agent discovery, prompt resources, and current persistence; verify focused tests pass before scheduling changes.
+- [ ] Define deterministic scheduler inputs, decision reasons, tie-breaking, hard ceilings, critical-path hints, cohesion hints, ownership conflicts, workspace conflicts, transport capacity, budget handling, and starvation bounds; verify the policy never treats configured maximum as a target.
+- [ ] Add failing pure-scheduler tests for dependency readiness, equal-priority determinism, critical path, cohesion grouping, write conflicts, worktree independence, capacity, budget exhaustion, stale inputs, blocked verification, cancellation, fairness, and no-ready-work behavior.
+- [ ] Implement a scheduler module that returns decisions without launching work, then integrate it behind the WorkItem ready queue while preserving legacy FIFO mode and existing hard limits.
+- [ ] Add blocking workflow scheduling only after retained scheduling parity is proven; verify existing explicit parallel input ordering remains stable in results even when launch order differs under the opt-in scheduler.
+- [ ] Define the semantic snapshot schema, allowlist, hash algorithms, path projection, versioning, and compatibility rules for agent definition, prompt resources, tool policy, model resolution, transport protocol, trust, repository, artifacts, workflow, and scheduler.
+- [ ] Add failing snapshot tests for unchanged state, agent prompt change, tool change, model alias re-resolution, resource change, trust change, clean commit change, dirty repository, worktree, artifact supersession, package protocol upgrade, unknown old snapshot, private text, and unsupported resource identity.
+- [ ] Implement bounded snapshot capture before launch and before persistence without reading secrets, storing full prompts, exposing unrestricted paths, or performing unbounded repository scans.
+- [ ] Implement compatibility evaluation before restored or retained continuation with compatible, warning, needs-revalidation, and rejected outcomes plus exact bounded reason codes.
+- [ ] Propagate upstream artifact, repository generation, accepted ExecutionPlan, or semantic-resource invalidation through downstream WorkItems and verifier evidence without automatic replay or evidence deletion.
+- [ ] Add an explicit revalidation operation that can refresh safe read-only evidence or request a new verifier turn, while requiring user or orchestrator approval before repeating side-effecting implementation work.
+- [ ] Add risk-based independent verification policy for contracted implementation, security-sensitive, cross-owner integration, and stale-result acceptance, while allowing low-risk lookups to omit the extra cost.
+- [ ] Add bounded scheduler and snapshot metadata to inspection, diagnostics, completion details, status, and manager views with decision reason, effective concurrency, snapshot compatibility, invalidation count, and verification state.
+- [ ] If user-facing settings are added, implement them through the existing `/subagents` manager with current-versus-configured values, exact preview, cancellation, serialized latest-document save, invalid-file protection, unknown-field preservation, atomic publication, rollback, reload semantics, and non-TUI behavior.
+- [ ] Build a deterministic orchestration simulation suite covering graph width, depth, context pressure, transfer loss, cohesion, stale resources, and injected failures; record transfer coverage, cascade radius, permission precision, delegation fidelity, makespan, tokens, and decision reproducibility.
+- [ ] Run repeated target-framework comparisons against a strong single agent, equal-budget best-of-N, naive parallelism, fixed scheduling, and orchestrator ablation with matched model, tools, context, budgets, and verification; report confidence and limitations rather than one-run wins.
+- [ ] Decide from evidence whether dependency-aware scheduling or stricter semantic isolation should remain experimental, become recommended, or be proposed as a new default; require separate approval for a default change.
+- [ ] Update README, settings and downgrade guidance, help, inspection docs, implementation notes, package layout, and separate Changesets for public scheduler and snapshot behavior.
+- [ ] Audit timers, queues, cancellation, stale generation after every `await`, session replacement, shutdown, restore, settings ordering, hashing bounds, private data, terminal safety, and cleanup against both extension guides.
+- [ ] Run focused tests, `npm test`, `npm run check`, `git diff --check`, `just benchmark-subagents`, and `just pack subagents`; run representative local Pi smokes for scheduling, restore mismatch, revalidation, and shutdown when practical.
+
+## Completion Checklist
+
+- [ ] Scheduler decisions are deterministic, bounded, inspectable, and constrained by existing hard limits.
+- [ ] Effective concurrency is derived from ready safe work and never optimized toward raw agent count.
+- [ ] Legacy FIFO and fixed scheduling remain available until a separately approved default change.
+- [ ] Snapshots contain only allowlisted identities or hashes and no credentials, full prompts, provider headers, or raw private resources.
+- [ ] Restored and retained continuations evaluate semantic compatibility before model work begins.
+- [ ] Stale or invalidated evidence cannot satisfy current acceptance without explicit revalidation.
+- [ ] Potentially side-effecting work is never replayed automatically because of scheduling or snapshot mismatch.
+- [ ] Independent verification is required by risk or contract rather than applied indiscriminately.
+- [ ] Matched benchmark evidence distinguishes scheduler value from extra models, tokens, retries, context, or budget.
+- [ ] Settings, lifecycle, persistence, terminal safety, package checks, smokes, and Changesets pass without publication.

--- a/docs/plans/2026-08-10_pi-subagents-adaptive-scheduling-semantic-snapshot-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-adaptive-scheduling-semantic-snapshot-plan.md
@@ -6,9 +6,21 @@ Add deterministic dependency-aware scheduling and semantic resource snapshots so
 
 Prove value against matched single-agent and orchestration baselines before changing defaults.
 
+## Post-hoc Amendment
+
+This section and every checklist item labelled **Post-hoc addition** were added after the initial plan in commit `07df6d8b`.
+
+**Reason:** The later evidence audit and roadmap review found that matched comparison at the end of scheduler implementation was too late, that readiness is different from deciding whether to delegate, and that initial width and recursion must stay constrained until a small architecture passes an explicit evidence gate.
+
+This plan is now conditional on Gate 4A and does not proceed after **Defer** without a new explicitly approved evaluation.
+
 ## Context
 
 The WorkItem ledger provides authoritative dependencies, artifacts, generations, ownership, acceptance state, and invalidation.
+
+**Post-hoc addition:** Gate 4A provides a recorded **Admit**, **Revise**, or **Defer** decision for the audit-only delegation-admission policy and the fixed two-child, no-grandchild architecture.
+
+**Reason:** The reviewed literature does not support assuming that adaptive subagents beat a strong simpler baseline merely because dependency-ready scheduling is available.
 
 Current retained turns use a FIFO queue bounded by `maxActiveTurns`, while blocking parallel execution starts a fixed maximum of four workers at once.
 
@@ -21,6 +33,10 @@ This phase must keep concurrency limits as safety ceilings and make semantic mis
 ## Architecture
 
 A deterministic scheduler will consume immutable WorkItem and ExecutionPlan snapshots and emit explicit decisions with ready, blocked, unsafe, stale, budget-limited, capacity-limited, or selected reasons.
+
+**Post-hoc addition:** Before allocating children, the scheduler will consume only the Gate 4A-admitted policy and distinguish parent-owned direct work, one child, one child plus independent verification, bounded multi-child work, or insufficient evidence.
+
+**Reason:** A ready queue can determine which declared child task may start but cannot determine whether creating child tasks is beneficial.
 
 Effective concurrency will be the minimum of configured hard limits, dependency-ready work, safe ownership and workspace capacity, transport capacity, remaining budget, and bounded policy constraints.
 
@@ -41,6 +57,7 @@ Independent verifier evidence will be required only for configured risk classes 
 ## Non-Goals
 
 - Do not maximize worker count, recurse without bounds, or launch every ready task immediately.
+- **Post-hoc addition:** Do not exceed Gate 4A's two-mutating-child limit or permit recursive grandchildren until a separate matched evaluation and approval expands those bounds.
 - Do not add a learned scheduler, reinforcement-learning policy, or orchestration reward model in the first implementation.
 - Do not build full static repository dependency analysis or require a repository index for every task.
 - Do not persist raw prompts, source files, credentials, provider headers, secrets, or model reasoning in snapshots.
@@ -50,6 +67,7 @@ Independent verifier evidence will be required only for configured risk classes 
 ## Assumptions
 
 - Handoff v2, ExecutionPlan enforcement, typed outcomes, and the WorkItem ledger are complete and stable.
+- **Post-hoc addition:** Gate 4A has recorded **Admit** or an explicitly approved **Revise** scope, and its task strata, bounds, baseline protocol, and failed criteria are available to this plan.
 - Existing concurrency settings remain hard safety limits regardless of scheduler mode.
 - Repository generation can use a bounded truthful identity that distinguishes clean commits, worktrees, and unsupported dirty-state precision.
 - Semantic compatibility rules can begin conservative and become stricter only with evidence.
@@ -75,9 +93,12 @@ Independent verifier evidence will be required only for configured risk classes 
 
 ## Plan
 
+- [ ] **Post-hoc addition:** Verify Gate 4A recorded **Admit** or an explicitly approved **Revise** scope, copy its task strata, two-child and no-grandchild bounds, matched-baseline protocol, and unresolved limitations into this plan, and stop with no implementation after **Defer**.
 - [ ] Characterize FIFO queue order, blocking parallel concurrency, queue telemetry, budget precedence, write-conflict checks, worktree isolation, transport capacity, retained restore, model resolution, agent discovery, prompt resources, and current persistence; verify focused tests pass before scheduling changes.
 - [ ] Define deterministic scheduler inputs, decision reasons, tie-breaking, hard ceilings, critical-path hints, cohesion hints, ownership conflicts, workspace conflicts, transport capacity, budget handling, and starvation bounds; verify the policy never treats configured maximum as a target.
+- [ ] **Post-hoc addition:** Define the admitted delegation modes and preserve an explicit insufficient-evidence or parent-owned recommendation without making `pi-subagents` own Pi's parent agent loop.
 - [ ] Add failing pure-scheduler tests for dependency readiness, equal-priority determinism, critical path, cohesion grouping, write conflicts, worktree independence, capacity, budget exhaustion, stale inputs, blocked verification, cancellation, fairness, and no-ready-work behavior.
+- [ ] **Post-hoc addition:** Add admission tests proving insufficient benefit launches zero children, one-child and verified-one-child modes do not widen, multi-child mutation never exceeds two, recursive grandchildren are rejected, and cancelled or replaced generations cannot become selected.
 - [ ] Implement a scheduler module that returns decisions without launching work, then integrate it behind the WorkItem ready queue while preserving legacy FIFO mode and existing hard limits.
 - [ ] Add blocking workflow scheduling only after retained scheduling parity is proven; verify existing explicit parallel input ordering remains stable in results even when launch order differs under the opt-in scheduler.
 - [ ] Define the semantic snapshot schema, allowlist, hash algorithms, path projection, versioning, and compatibility rules for agent definition, prompt resources, tool policy, model resolution, transport protocol, trust, repository, artifacts, workflow, and scheduler.
@@ -91,6 +112,7 @@ Independent verifier evidence will be required only for configured risk classes 
 - [ ] If user-facing settings are added, implement them through the existing `/subagents` manager with current-versus-configured values, exact preview, cancellation, serialized latest-document save, invalid-file protection, unknown-field preservation, atomic publication, rollback, reload semantics, and non-TUI behavior.
 - [ ] Build a deterministic orchestration simulation suite covering graph width, depth, context pressure, transfer loss, cohesion, stale resources, and injected failures; record transfer coverage, cascade radius, permission precision, delegation fidelity, makespan, tokens, and decision reproducibility.
 - [ ] Run repeated target-framework comparisons against a strong single agent, equal-budget best-of-N, naive parallelism, fixed scheduling, and orchestrator ablation with matched model, tools, context, budgets, and verification; report confidence and limitations rather than one-run wins.
+- [ ] **Post-hoc addition:** Preserve Gate 4A's paired protocol and report unnecessary delegation, accepted late results, cancellation latency, leaked owned work, stale integration rejection, and task-stratified policy error alongside quality, cost, tokens, and time.
 - [ ] Decide from evidence whether dependency-aware scheduling or stricter semantic isolation should remain experimental, become recommended, or be proposed as a new default; require separate approval for a default change.
 - [ ] Update README, settings and downgrade guidance, help, inspection docs, implementation notes, package layout, and separate Changesets for public scheduler and snapshot behavior.
 - [ ] Audit timers, queues, cancellation, stale generation after every `await`, session replacement, shutdown, restore, settings ordering, hashing bounds, private data, terminal safety, and cleanup against both extension guides.
@@ -107,4 +129,6 @@ Independent verifier evidence will be required only for configured risk classes 
 - [ ] Potentially side-effecting work is never replayed automatically because of scheduling or snapshot mismatch.
 - [ ] Independent verification is required by risk or contract rather than applied indiscriminately.
 - [ ] Matched benchmark evidence distinguishes scheduler value from extra models, tokens, retries, context, or budget.
+- [ ] **Post-hoc addition:** Gate 4A admission evidence exists before implementation, and this phase stays within its admitted task strata, two-mutating-child limit, and no-grandchild boundary unless another approved evaluation expands them.
+- [ ] **Post-hoc addition:** The scheduler can decline delegation without allocating a child and records why a simpler route was selected.
 - [ ] Settings, lifecycle, persistence, terminal safety, package checks, smokes, and Changesets pass without publication.

--- a/docs/plans/2026-08-10_pi-subagents-capability-manifest-execution-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-capability-manifest-execution-plan.md
@@ -6,6 +6,14 @@ Add versioned agent capability manifests and one deterministic transport-neutral
 
 Establish package-specific capability and permission-precision baselines before enforcement is considered.
 
+## Post-hoc Amendment
+
+This section and every checklist item labelled **Post-hoc addition** were added after the initial plan in commit `07df6d8b`.
+
+**Reason:** The later evidence audit and roadmap review found that capability fit alone does not answer whether delegation is worthwhile, and that every plan and future grant must be tied to the task generation that produced it.
+
+Admission remains audit-only in this phase because the reviewed literature does not justify automatic routing or rejection from an unvalidated predictor.
+
 ## Context
 
 `AgentConfig` currently describes agent name, description, tools, model, thinking level, timeout, prompt, source, and file path.
@@ -32,6 +40,10 @@ It will not infer intent from keywords, call another LLM, or override the caller
 
 The plan will distinguish requested, declared, available, effective, overgranted, missing, and unsupported capabilities.
 
+**Post-hoc addition:** The plan will also record the immutable task generation, a bounded benefit hypothesis, and an audit-only admission recommendation of parent-owned direct work, one child, one child plus independent verification, bounded multi-child work, or insufficient evidence.
+
+**Reason:** The roadmap promised to decide when delegation is justified, while the original `ExecutionPlan` only audited which selected agent and transport could perform an already delegated task.
+
 Each transport will consume the same plan projection or prove parity with it rather than independently re-deriving policy.
 
 Audit findings will appear in bounded tool details, retained inspection, diagnostics, and optional local benchmark output without exposing prompts or private context.
@@ -40,6 +52,7 @@ Audit findings will appear in bounded tool details, retained inspection, diagnos
 
 - Do not reject a launch because of capability mismatch in this phase.
 - Do not auto-select another agent, model, transport, workspace, or tool set.
+- **Post-hoc addition:** Do not let the admission recommendation launch, reject, or reroute work before Gate 4A produces paired evidence and a separate approval.
 - Do not add task-string keyword heuristics or a classifier model request.
 - Do not claim path, network, secret, credential, or process sandboxing.
 - Do not add a WorkItem graph, adaptive scheduler, automatic retry, or independent verifier workflow.
@@ -78,12 +91,16 @@ Audit findings will appear in bounded tool details, retained inspection, diagnos
 - [ ] Implement manifest parsing and safe projection in `agents.ts` or a focused capability module while preserving existing agent precedence, prompt loading, settings overrides, and catalog bounds.
 - [ ] Add explicit capability manifests for built-in scout, planner, reviewer, worker, and aliases; verify aliases remain behaviorally compatible and do not claim unimplemented verification or sandbox guarantees.
 - [ ] Define an immutable `ExecutionPlan` with version, task requirements, selected agent and source, manifest fit, requested and effective tools, cwd and trust, resources, workspace, transport, model, thinking, budgets, result contract, overgrant, mismatch, unknowns, and unsupported guarantees.
+- [ ] **Post-hoc addition:** Add immutable task-generation, admission-recommendation, benefit-hypothesis, evidence-sufficiency, and bounded-reason fields without changing the selected agent or launch behavior.
+- [ ] **Post-hoc addition:** Define deterministic admission inputs from explicit context pressure, declared dependencies and cohesion, specialist capability, verification need, budgets, and enforceability while prohibiting task-keyword matching and extra provider calls.
 - [ ] Add failing plan tests for exact match, subset match, unknown manifest, missing capability, excess tools, unsupported network denial, untrusted resources, custom-tool subprocess routing, write-capable RPC routing, read-only in-process routing, and explicit transport overrides.
+- [ ] **Post-hoc addition:** Add audit-only admission tests for explicit decomposability, dense coupling, missing verification, insufficient budget, unknown task requirements, stale generation, and no-benefit evidence; verify recommendations are inspectable and have zero launch side effects.
 - [ ] Implement a deterministic planner that consumes explicit contract requirements and existing policy resolvers without task-keyword matching, additional provider work, side effects, or launch changes.
 - [ ] Introduce one preflight seam before confirmation, worktree creation, child allocation, and provider work, then pass the immutable plan or its exact policy projection to subprocess, in-process, RPC, and automatic transports.
 - [ ] Add parity tests proving every transport applies the plan's effective tools, cwd, trust, resources, workspace, model, thinking, and budgets without post-plan widening or hidden fallback.
 - [ ] Add bounded plan summaries to blocking details, retained records, `subagent_inspect get_run`, status diagnostics, and renderers while omitting prompts, credentials, raw protected paths, private context, and unnecessary capability descriptions.
 - [ ] Add an offline audit benchmark that compares requested versus effective capabilities and tools for representative lookup, review, implementation, multimodal, and unsupported-isolation contracts; record capability coverage, unknown rate, mismatch rate, and permission precision.
+- [ ] **Post-hoc addition:** Extend offline evidence with admission recommendation coverage, insufficient-evidence rate, and unnecessary-delegation labels, but defer quality claims and production routing to Gate 4A's paired target-framework evaluation.
 - [ ] Update README agent-frontmatter documentation, inspection documentation, compatibility guidance, package layout, and a minor Changeset with audit-only semantics and the enforceability matrix.
 - [ ] Audit project trust, source precedence, metadata bounds, terminal sanitization, private text, settings preservation, transport parity, cancellation before launch, and session replacement against the extension guides.
 - [ ] Run focused tests, `npm test`, `npm run check`, `git diff --check`, and `just pack subagents`; inspect the tarball and record baseline audit evidence.
@@ -97,4 +114,5 @@ Audit findings will appear in bounded tool details, retained inspection, diagnos
 - [ ] All transports prove policy parity against the same plan and perform no silent widening or fallback.
 - [ ] Project-authored capability metadata remains behind existing trust and scope controls.
 - [ ] Permission precision and capability coverage have a reproducible package baseline without unsupported targets.
+- [ ] **Post-hoc addition:** Every ExecutionPlan is tied to one task generation and exposes an audit-only admission recommendation whose reasons can be evaluated later without having changed the launch.
 - [ ] Required checks and semantic audits pass, and the package has an appropriate Changeset without publication.

--- a/docs/plans/2026-08-10_pi-subagents-capability-manifest-execution-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-capability-manifest-execution-plan.md
@@ -1,0 +1,100 @@
+# Pi Subagents Capability Manifest and Audit-Only ExecutionPlan Plan
+
+## Goal
+
+Add versioned agent capability manifests and one deterministic transport-neutral `ExecutionPlan` that audits task fit, requested authority, effective policy, overgrant, mismatch, and unsupported guarantees without changing established launch behavior.
+
+Establish package-specific capability and permission-precision baselines before enforcement is considered.
+
+## Context
+
+`AgentConfig` currently describes agent name, description, tools, model, thinking level, timeout, prompt, source, and file path.
+
+Automatic transport selection currently routes custom tools to subprocess, write-capable built-ins to RPC, and read-only built-ins to in-process execution.
+
+That transport decision does not determine whether an agent can satisfy the task's declared objective, evidence, modality, verification, or authority requirements.
+
+The research notes show that keyword routing can fail adversarial intent cases and that subagent managers frequently overgrant workspace access.
+
+This phase must observe fit and overgrant without rejecting legacy definitions or introducing an additional model call.
+
+## Architecture
+
+A versioned optional capability manifest will extend built-in definitions and custom-agent frontmatter with capabilities, modalities, supported result contracts, authority needs, verification roles, and declared constraints.
+
+Absent manifests will mean `unknown`, not unrestricted or incapable.
+
+A new package-owned `ExecutionPlan` will normalize the delegation contract, selected agent definition, tool policy, cwd and trust audit, workspace mode, transport selection, model and thinking selection, budgets, resource policy, and enforceability matrix.
+
+The first matcher will be deterministic and use explicit v2 contract requirements plus manifest identifiers.
+
+It will not infer intent from keywords, call another LLM, or override the caller-selected agent.
+
+The plan will distinguish requested, declared, available, effective, overgranted, missing, and unsupported capabilities.
+
+Each transport will consume the same plan projection or prove parity with it rather than independently re-deriving policy.
+
+Audit findings will appear in bounded tool details, retained inspection, diagnostics, and optional local benchmark output without exposing prompts or private context.
+
+## Non-Goals
+
+- Do not reject a launch because of capability mismatch in this phase.
+- Do not auto-select another agent, model, transport, workspace, or tool set.
+- Do not add task-string keyword heuristics or a classifier model request.
+- Do not claim path, network, secret, credential, or process sandboxing.
+- Do not add a WorkItem graph, adaptive scheduler, automatic retry, or independent verifier workflow.
+- Do not make project-agent metadata available before existing trust and scope checks.
+
+## Assumptions
+
+- Handoff contract v2 is available as the authoritative source of explicit task requirements.
+- Legacy free-text tasks can produce an incomplete audit but cannot prove a capability mismatch.
+- Built-in manifests can be defined by package source, while custom manifests remain optional frontmatter.
+- A capability identifier names a stable behavior or evidence role rather than a cosmetic persona.
+
+## Risks
+
+- Capability taxonomies can become large, subjective, or provider-specific.
+- Unknown manifests can be mistaken for a pass if audit output is not explicit.
+- Agent descriptions and capability identifiers can drift apart.
+- Transport implementations can silently widen policy if they continue re-resolving tools or resources after planning.
+- Audit metadata can leak sensitive paths or reveal project-authored prompt structure.
+- Permission precision can be misleading unless requested scope and actual usage are measured consistently.
+
+## Rollback / Recovery
+
+- Keep all manifest fields optional and preserve existing frontmatter behavior when absent.
+- Keep the caller-selected agent and current launch policy authoritative during audit-only operation.
+- Make `ExecutionPlan` details additive and safe for older persisted records to ignore.
+- Keep transport-specific policy code until parity tests prove the shared plan can replace duplicated derivation.
+- Revert catalog and inspection additions independently if metadata size or provider compatibility is unacceptable.
+
+## Plan
+
+- [ ] Characterize current agent discovery, frontmatter normalization, built-in aliases, catalog bounds, tool overrides, transport selection, trust resolution, workspace selection, and inspection output; verify focused tests pass before manifest changes.
+- [ ] Define a bounded capability vocabulary and versioned manifest schema covering task capabilities, modalities, result contracts, authority needs, verifier roles, and declared limitations; verify each admitted field has at least one current or planned consumer.
+- [ ] Define an enforceability matrix for subprocess, in-process, RPC, automatic transport, worktree, consultation, cwd policy, tools, resources, filesystem paths, network, secrets, credentials, and process isolation; label each entry enforced, advisory, unsupported, or transport-dependent.
+- [ ] Add failing discovery tests for valid manifests, absent manifests, explicit empty capabilities, duplicate identifiers, unknown future fields, malformed values, user/project overrides, untrusted project scope, bounded metadata discovery, and legacy frontmatter.
+- [ ] Implement manifest parsing and safe projection in `agents.ts` or a focused capability module while preserving existing agent precedence, prompt loading, settings overrides, and catalog bounds.
+- [ ] Add explicit capability manifests for built-in scout, planner, reviewer, worker, and aliases; verify aliases remain behaviorally compatible and do not claim unimplemented verification or sandbox guarantees.
+- [ ] Define an immutable `ExecutionPlan` with version, task requirements, selected agent and source, manifest fit, requested and effective tools, cwd and trust, resources, workspace, transport, model, thinking, budgets, result contract, overgrant, mismatch, unknowns, and unsupported guarantees.
+- [ ] Add failing plan tests for exact match, subset match, unknown manifest, missing capability, excess tools, unsupported network denial, untrusted resources, custom-tool subprocess routing, write-capable RPC routing, read-only in-process routing, and explicit transport overrides.
+- [ ] Implement a deterministic planner that consumes explicit contract requirements and existing policy resolvers without task-keyword matching, additional provider work, side effects, or launch changes.
+- [ ] Introduce one preflight seam before confirmation, worktree creation, child allocation, and provider work, then pass the immutable plan or its exact policy projection to subprocess, in-process, RPC, and automatic transports.
+- [ ] Add parity tests proving every transport applies the plan's effective tools, cwd, trust, resources, workspace, model, thinking, and budgets without post-plan widening or hidden fallback.
+- [ ] Add bounded plan summaries to blocking details, retained records, `subagent_inspect get_run`, status diagnostics, and renderers while omitting prompts, credentials, raw protected paths, private context, and unnecessary capability descriptions.
+- [ ] Add an offline audit benchmark that compares requested versus effective capabilities and tools for representative lookup, review, implementation, multimodal, and unsupported-isolation contracts; record capability coverage, unknown rate, mismatch rate, and permission precision.
+- [ ] Update README agent-frontmatter documentation, inspection documentation, compatibility guidance, package layout, and a minor Changeset with audit-only semantics and the enforceability matrix.
+- [ ] Audit project trust, source precedence, metadata bounds, terminal sanitization, private text, settings preservation, transport parity, cancellation before launch, and session replacement against the extension guides.
+- [ ] Run focused tests, `npm test`, `npm run check`, `git diff --check`, and `just pack subagents`; inspect the tarball and record baseline audit evidence.
+
+## Completion Checklist
+
+- [ ] Old built-in and custom agent definitions remain valid without capability metadata.
+- [ ] Every contracted launch produces one deterministic immutable ExecutionPlan before side effects.
+- [ ] Audit-only mode never changes the selected agent or established effective launch policy.
+- [ ] Unknown, missing, overgranted, and unsupported capability states remain distinct in data and rendering.
+- [ ] All transports prove policy parity against the same plan and perform no silent widening or fallback.
+- [ ] Project-authored capability metadata remains behind existing trust and scope controls.
+- [ ] Permission precision and capability coverage have a reproducible package baseline without unsupported targets.
+- [ ] Required checks and semantic audits pass, and the package has an appropriate Changeset without publication.

--- a/docs/plans/2026-08-10_pi-subagents-handoff-contract-v2-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-handoff-contract-v2-plan.md
@@ -1,0 +1,89 @@
+# Pi Subagents Handoff Contract v2 Plan
+
+## Goal
+
+Add one opt-in versioned delegation request and result contract that preserves objectives, authority requests, dependencies, evidence, artifacts, limitations, provenance, and outcome state across blocking, chained, fan-in, detached, persisted, inspected, and rendered subagent flows.
+
+Keep existing free-form text and `structured-v1` behavior compatible when callers omit the new contract.
+
+## Context
+
+The current blocking schema accepts free-form task strings, chain execution substitutes raw previous output into `{previous}`, and fan-in constructs bounded Markdown from worker results.
+
+The current `structured-v1` result is available only as an opt-in stateful completion shape and does not define the request side of delegation.
+
+The repository research notes report that explicit delegation contracts improve evidence sufficiency and reviewability but can increase tokens, wall-clock time, and tool calls.
+
+This phase therefore needs a bounded contract with selectable detail rather than an unconditional verbose default.
+
+## Architecture
+
+`result-contract.ts` will evolve into a delegation-contract boundary or delegate request ownership to a new `delegation-contract.ts` while retaining parsing and compatibility adapters for `structured-v1`.
+
+The request contract will cover version, task identity, objective, non-goals, dependencies, required inputs, requested authority, acceptance criteria, required evidence, and budget references.
+
+The result contract will cover version, status, summary, evidence-backed claims, artifacts, changed paths, verification, limitations, unresolved dependencies, provenance, usage, and truncation.
+
+Contract levels will provide a minimal lookup shape and a full software-change shape without changing the meaning of individual fields.
+
+Structured transfer will remain data rather than proof of enforcement, and requested authority will be labelled advisory until later phases produce an enforceable `ExecutionPlan`.
+
+Validated structured envelopes will be carried in typed details and metadata, while bounded raw output remains the authoritative compatibility fallback for malformed or non-participating agents.
+
+Chain and fan-in will consume structured results when valid and preserve source task, agent, state, evidence, and truncation instead of flattening them into anonymous prose.
+
+## Non-Goals
+
+- Do not enforce capabilities, paths, tools, network access, secrets, or sandbox policy in this phase.
+- Do not automatically choose an agent, model, transport, workspace, or concurrency level.
+- Do not add a WorkItem DAG or persistent artifact store.
+- Do not make the full contract the default for existing payloads.
+- Do not reject ordinary text from agents that were not asked for `structured-v2`.
+- Do not expose raw chain-of-thought, private context, credentials, or unbounded tool output as evidence.
+
+## Risks
+
+- A large nested tool schema can reduce provider compatibility or increase prompt cost.
+- A prompt-only JSON contract can be malformed even when the delegated work is useful.
+- Chain and fan-in compatibility can regress if structured transfer replaces the existing raw fallback.
+- Evidence fields can create false confidence unless claims remain explicitly observed, inferred, or unverified.
+- Contract metadata can leak task text, paths, or private content if bounds and redaction are inconsistent.
+- Adding outcome values before enforcement can tempt callers to treat self-reported completion as verified acceptance.
+
+## Rollback / Recovery
+
+- Keep `text` and `structured-v1` parsers and omitted-field behavior unchanged.
+- Gate `structured-v2` behind an explicit request and retain raw bounded output on parse failure.
+- Keep chain `{previous}` substitution and Markdown fan-in as compatibility fallbacks until structured transfer passes the compatibility gate.
+- Make persisted additions optional and additive so older readers can ignore them.
+- Revert the new public schema and its Changeset independently if provider compatibility is unacceptable.
+
+## Plan
+
+- [ ] Record characterization tests for current text, `structured-v1`, chain `{previous}`, fan-in Markdown, completion metadata, persistence, inspection, and rendering behavior; verify the focused package tests pass before contract changes.
+- [ ] Decide the exact `pi-subagents:delegation:v2` and `pi-subagents:result:v2` field names, contract levels, status vocabulary, size limits, unknown-field policy, and observed/inferred/unverified provenance semantics; verify the decision against the two research notes and existing provider-compatible schema conventions.
+- [ ] Add failing parser and serializer tests for valid minimal and full contracts, malformed JSON, unsupported versions, missing required fields, unknown fields, duplicate identifiers, oversized arrays, oversized strings, terminal controls, private text, and UTF-8 truncation; verify failures precede implementation.
+- [ ] Implement bounded immutable request and result types plus parse, normalize, copy, redact, and compatibility helpers in responsibility-focused modules under `packages/pi-subagents/src/`; verify no source file crosses 1,000 lines.
+- [ ] Add optional contract and `structured-v2` request fields to blocking single, task, chain, aggregator, detached spawn, and follow-up shapes without changing calls that provide only `task`; verify TypeBox schemas remain bounded and provider-compatible.
+- [ ] Append contract instructions through one shared prompt builder across subprocess, in-process, and RPC turns; verify each transport receives semantically identical bounded instructions and no duplicate suffix.
+- [ ] Capture valid `structured-v2` results in blocking `SingleResult`, retained `ManagedAgent`, turn history projection, completion metadata, inspection details, and tool details while keeping bounded raw output available.
+- [ ] Change chain transfer to prefer a validated structured envelope with source and provenance while preserving raw `{previous}` fallback for legacy output; verify mixed v2, v1, text, failed, and truncated sequences.
+- [ ] Change fan-in context to preserve per-result task identity, agent, status, evidence, artifacts, errors, and truncation through a bounded structured projection while preserving the existing Markdown fallback.
+- [ ] Add rendering for contract level, outcome, evidence count, artifacts, verification, limitations, invalid-contract warning, and fallback state without rendering untrusted terminal controls or exceeding width.
+- [ ] Extend persistence validation and copy logic for optional v2 request and result metadata; verify old records restore, new records round-trip, invalid persisted contracts are quarantined or omitted safely, and raw private context is not added.
+- [ ] Update `subagent_inspect` and completion delivery with bounded safe contract metadata while preserving side-effect-free inspection and current completion ordering.
+- [ ] Run a deterministic fake-provider matrix and one bounded live-provider smoke when credentials permit to measure valid-contract rate, prompt bytes, output bytes, tool calls, and latency for minimal versus full contracts; record unsupported numeric targets as baseline data rather than claims.
+- [ ] Update `packages/pi-subagents/README.md`, help, compatibility notes, package layout, and a minor Changeset with exact opt-in behavior, overhead evidence, fallback semantics, and the fact that authority requests are not yet enforcement.
+- [ ] Audit cancellation, timeout finalization, partial output, session replacement, shutdown, redaction, persistence, settings neutrality, and every model-facing or terminal-facing contract path against `docs/extension-conventions.md`.
+- [ ] Run focused tests, `npm test`, `npm run check`, `git diff --check`, and `just pack subagents`; inspect the tarball and record any skipped live-provider path.
+
+## Completion Checklist
+
+- [ ] Existing omitted-field text and `structured-v1` calls have zero unapproved behavior changes.
+- [ ] Every opted-in execution mode can carry the same bounded v2 request and result semantics.
+- [ ] Invalid structured output is visible as invalid or fallback and is never silently presented as valid evidence.
+- [ ] Chain and fan-in preserve source, status, evidence, artifact, and truncation provenance when v2 data is available.
+- [ ] Contract levels expose measured cost and latency tradeoffs without making unsupported performance promises.
+- [ ] Authority fields are documented as requested rather than enforced until the capability-enforcement phase.
+- [ ] Persistence, inspection, completion delivery, rendering, cancellation, timeout, replacement, and shutdown retain their existing safety guarantees.
+- [ ] Every changed behavior has deterministic coverage, required checks pass, and the package contains an appropriate Changeset without publishing.

--- a/docs/plans/2026-08-10_pi-subagents-handoff-contract-v2-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-handoff-contract-v2-plan.md
@@ -6,6 +6,14 @@ Add one opt-in versioned delegation request and result contract that preserves o
 
 Keep existing free-form text and `structured-v1` behavior compatible when callers omit the new contract.
 
+## Post-hoc Amendment
+
+This section and every checklist item labelled **Post-hoc addition** were added after the initial plan in commit `07df6d8b`.
+
+**Reason:** The later evidence audit and roadmap review found that cancellation and replacement safety require immutable task-generation provenance to begin at the request and result boundary rather than being introduced only by a later ledger.
+
+The added generation fields remain descriptive in this phase and do not claim capability revocation or late-result enforcement before their owning phases exist.
+
 ## Context
 
 The current blocking schema accepts free-form task strings, chain execution substitutes raw previous output into `{previous}`, and fan-in constructs bounded Markdown from worker results.
@@ -23,6 +31,10 @@ This phase therefore needs a bounded contract with selectable detail rather than
 The request contract will cover version, task identity, objective, non-goals, dependencies, required inputs, requested authority, acceptance criteria, required evidence, and budget references.
 
 The result contract will cover version, status, summary, evidence-backed claims, artifacts, changed paths, verification, limitations, unresolved dependencies, provenance, usage, and truncation.
+
+**Post-hoc addition:** The executor will attach an immutable task generation and cancellation lineage to the request and stamp the normalized structured result envelope with the generation that produced it rather than trusting a model-supplied value.
+
+**Reason:** Later grant revocation, stale-result quarantine, and integration rejection need one end-to-end identity that cannot be reconstructed safely from timestamps or agent IDs.
 
 Contract levels will provide a minimal lookup shape and a full software-change shape without changing the meaning of individual fields.
 
@@ -62,7 +74,10 @@ Chain and fan-in will consume structured results when valid and preserve source 
 
 - [ ] Record characterization tests for current text, `structured-v1`, chain `{previous}`, fan-in Markdown, completion metadata, persistence, inspection, and rendering behavior; verify the focused package tests pass before contract changes.
 - [ ] Decide the exact `pi-subagents:delegation:v2` and `pi-subagents:result:v2` field names, contract levels, status vocabulary, size limits, unknown-field policy, and observed/inferred/unverified provenance semantics; verify the decision against the two research notes and existing provider-compatible schema conventions.
+- [ ] **Post-hoc addition:** Add bounded executor-owned task-generation and cancellation-lineage fields to the request and normalized result, persistence, inspection, chain, and fan-in projections; verify model output cannot override them, omission preserves legacy behavior, and this phase labels them as provenance rather than enforcement.
+- [ ] **Post-hoc addition:** Reconcile the exact contract decision with the evidence audit and architecture deep dive, recording why generation provenance was added after the initial plan and which late-result guarantees remain deferred.
 - [ ] Add failing parser and serializer tests for valid minimal and full contracts, malformed JSON, unsupported versions, missing required fields, unknown fields, duplicate identifiers, oversized arrays, oversized strings, terminal controls, private text, and UTF-8 truncation; verify failures precede implementation.
+- [ ] **Post-hoc addition:** Add generation tests for echoed identity, mixed-generation chain and fan-in input, cancellation or replacement metadata, persisted round-trip, stale-version parsing, and attempts by model output to forge executor-owned generation fields.
 - [ ] Implement bounded immutable request and result types plus parse, normalize, copy, redact, and compatibility helpers in responsibility-focused modules under `packages/pi-subagents/src/`; verify no source file crosses 1,000 lines.
 - [ ] Add optional contract and `structured-v2` request fields to blocking single, task, chain, aggregator, detached spawn, and follow-up shapes without changing calls that provide only `task`; verify TypeBox schemas remain bounded and provider-compatible.
 - [ ] Append contract instructions through one shared prompt builder across subprocess, in-process, and RPC turns; verify each transport receives semantically identical bounded instructions and no duplicate suffix.
@@ -85,5 +100,6 @@ Chain and fan-in will consume structured results when valid and preserve source 
 - [ ] Chain and fan-in preserve source, status, evidence, artifact, and truncation provenance when v2 data is available.
 - [ ] Contract levels expose measured cost and latency tradeoffs without making unsupported performance promises.
 - [ ] Authority fields are documented as requested rather than enforced until the capability-enforcement phase.
+- [ ] **Post-hoc addition:** Every valid structured result can be attributed to one immutable task generation, and documentation states that Phase 1 records lineage but does not yet revoke authority or reject late work.
 - [ ] Persistence, inspection, completion delivery, rendering, cancellation, timeout, replacement, and shutdown retain their existing safety guarantees.
 - [ ] Every changed behavior has deterministic coverage, required checks pass, and the package contains an appropriate Changeset without publishing.

--- a/docs/plans/2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md
@@ -1,0 +1,104 @@
+# Pi Subagents Minimal Delegation Admission Evaluation Plan
+
+## Post-hoc Origin
+
+This plan was added after commit `07df6d8b` created the initial delegation-intelligence roadmap and its five implementation plans.
+
+**Reason:** A later AlphaXiv evidence audit found no general matched-model, matched-information, matched-budget, matched-harness coding advantage for dynamic subagents, while strong single-agent, equal-budget sampling, naive-team failure, cancellation, and stale-integration evidence required a small falsifiable gate before adaptive orchestration.
+
+This post-hoc plan implements Roadmap Gate 4A only and does not authorize production routing or a default change.
+
+## Goal
+
+Evaluate an audit-only deterministic delegation-admission policy and a minimal fixed delegation architecture before adaptive scheduling is admitted.
+
+Record an explicit **Admit**, **Revise**, or **Defer** decision using paired repeated evidence against credible simpler baselines.
+
+## Context
+
+Handoff v2, capability audit and enforcement, typed outcomes, generation-bound cancellation, and the WorkItem integration ledger are expected to provide the contracts and observations needed for a fair comparison.
+
+The deeper research found that automatic multi-agent systems can lose to a strong single agent or equal-budget self-consistency and that wider teams can increase coordination failure.
+
+The first experiment must therefore isolate admission, bounded parallelism, integration, and verification without recursive delegation or an adaptive learned scheduler.
+
+## Architecture
+
+An audit-only admission evaluator will consume immutable task, capability, dependency, budget, verification, and generation metadata and return one recommendation with bounded reasons.
+
+The recommendation vocabulary will be parent-owned direct work, one child, one child plus independent verification, bounded two-child work, or abstain because evidence is insufficient.
+
+The evaluator will not launch children, override a caller, call another model, inspect hidden reasoning, or infer intent from task keywords.
+
+A benchmark harness will execute comparable arms with the same base model, issue and repository state, hints, tools, context policy, evaluator, aggregate token or dollar ceiling, wall-clock ceiling, retry allowance, and repeated paired seeds.
+
+The minimal multi-child arm will permit at most two concurrent mutating children, prohibit recursive grandchildren, use one integration owner, and use one fresh-context verifier.
+
+Every result will remain tied to its task generation, base state, accepted plan, capability grant, artifact versions, and verification evidence so cancellation and stale-result containment can be scored.
+
+## Non-Goals
+
+- Do not enable automatic production routing or change existing launch defaults.
+- Do not add learned routing, task-keyword heuristics, reward models, or another admission-time model call.
+- Do not test more than two concurrent mutating children or permit recursive grandchildren.
+- Do not claim a universal delegation policy from one model, benchmark, task class, or provider.
+- Do not weaken capability, trust, workspace, cancellation, integration, or verification controls to improve benchmark throughput.
+- Do not publish, tag, or release from this evaluation plan.
+
+## Assumptions
+
+- Roadmap Phases 1 through 4 are complete and stable before this gate executes.
+- The benchmark can represent parent-owned or equivalent strong single-agent work without making `pi-subagents` own Pi's parent agent loop.
+- Provider and evaluator variability can be bounded with repeated paired tasks and preserved per-instance outcomes.
+- A **Defer** result leaves completed contracts, capability audit, typed outcomes, and integration safety useful without admitting Phase 5.
+
+## Unknowns
+
+- Which repository task strata expose enough decomposability, context pressure, specialist value, or independent-verification value to justify delegation remains unknown.
+- The minimum sample size and confidence interval required for an admission decision must be fixed before result inspection.
+- A truthful equal-budget comparison may need both token or dollar and wall-clock ceilings when cached or local worker costs are not directly comparable.
+- The benchmark may need an external harness adapter to represent parent-owned direct execution without coupling that adapter to extension production code.
+
+## Risks
+
+- Harness or prompt differences can be mistaken for delegation value.
+- Equal per-agent limits can accidentally give multi-child arms more total compute.
+- One-run wins can reverse under another seed or task sample.
+- A verifier can add cost while sharing the implementation model's blind spots.
+- Audit recommendations can be overfit to the benchmark even when they do not change production behavior.
+- Cancellation or stale-result tests can appear successful if late workers are ignored but not actually stopped or quarantined.
+
+## Rollback / Recovery
+
+- Keep all admission output offline or audit-only and removable without changing existing execution behavior.
+- Preserve raw paired outcomes and rejected policy variants so the decision can be reproduced without rerunning providers.
+- Record **Defer** when matched execution, sample size, or cost accounting cannot be made truthful.
+- Keep Phase 5 blocked after **Defer** and require a new explicitly approved evaluation plan before another admission attempt.
+- Retain deterministic contract and lifecycle fixtures even when live-provider evidence is unavailable.
+
+## Plan
+
+- [ ] **Post-hoc addition:** Freeze the admission question, task strata, compared arms, primary outcomes, aggregate budgets, stopping rules, minimum sample size, and paired confidence method before observing results; verify the protocol against both deeper research reports.
+- [ ] **Post-hoc addition:** Define the bounded audit-only recommendation and reason schema for parent-owned direct work, one child, one child plus verification, bounded two-child work, and insufficient evidence; verify no recommendation can launch work.
+- [ ] **Post-hoc addition:** Add deterministic policy tests for context pressure, declared independent work, dense coupling, missing verification, unsupported capability, insufficient budget, stale generation, and ambiguous requirements without task-keyword matching or provider calls.
+- [ ] **Post-hoc addition:** Build benchmark adapters for a strong single-agent arm, one-child arm, equal-budget best-of-N arm, naive-parallel arm, fixed two-child arm, and admission-policy-selected arm with one shared model, tool, context, evaluator, retry, token or dollar, and wall-clock protocol.
+- [ ] **Post-hoc addition:** Enforce at most two concurrent mutating children and no recursive grandchildren in every experimental multi-child arm; verify attempted width or depth expansion is rejected before child allocation.
+- [ ] **Post-hoc addition:** Require one integration owner to check task generation, base commit, dependency or read-set versions, accepted-plan identity, scope, patch digest, and evidence before applying experimental artifacts.
+- [ ] **Post-hoc addition:** Run verification in a fresh context against the exact integrated tree and preserve accept, bounded rework, and reject outcomes separately from worker self-reports.
+- [ ] **Post-hoc addition:** Inject cancellation, session replacement, stale dependency, merge conflict, verifier disagreement, transient tool failure, worker crash, timeout, and late completion; measure propagation latency, leaked owned work, stale-result rejection, and accepted late results.
+- [ ] **Post-hoc addition:** Run paired repeated repository tasks and preserve per-instance quality, token, dollar, wall-clock, retry, handoff, conflict, integration, verification, cancellation, and failure outcomes for every arm.
+- [ ] **Post-hoc addition:** Report verified success, verified success per dollar, wall-clock critical path, unnecessary delegation, transfer coverage, conflict and rework rates, permission precision, false completion, stale acceptance, and confidence intervals without selecting only favorable task strata.
+- [ ] **Post-hoc addition:** Record **Admit**, **Revise**, or **Defer** with the admitted task strata, policy bounds, failed criteria, limitations, and exact Phase 5 consequence; require explicit user approval before executing an admitted Phase 5 plan.
+- [ ] **Post-hoc addition:** Update the roadmap, implementation notes, and benchmark guidance with the decision and evidence while keeping provider data bounded, redacted, and free of credentials or private repository content.
+- [ ] **Post-hoc addition:** Run focused deterministic tests, the benchmark's dry-run validation, `npm test`, `npm run check`, `git diff --check`, and `just pack subagents`; record unavailable live-provider evidence without substituting simulation claims.
+
+## Completion Checklist
+
+- [ ] **Post-hoc gate:** Every compared arm uses the same declared model, information, harness, evaluator, aggregate compute ceilings, and paired task sample, or the decision is **Defer**.
+- [ ] **Post-hoc gate:** The first multi-child architecture uses no more than two concurrent mutating children and no recursive grandchildren.
+- [ ] **Post-hoc gate:** Admission remains audit-only and cannot allocate a child or change an established launch.
+- [ ] **Post-hoc gate:** Cancellation and replacement invalidate old generations before signalling workers, and zero old-generation results enter integration or acceptance.
+- [ ] **Post-hoc gate:** Integration and fresh-context verification evaluate the exact current state rather than trusting worker completion prose.
+- [ ] **Post-hoc gate:** Per-instance outcomes and paired uncertainty support the recorded **Admit**, **Revise**, or **Defer** decision.
+- [ ] **Post-hoc gate:** Phase 5 remains blocked unless the decision and subsequent execution receive explicit user approval.
+- [ ] **Post-hoc gate:** Required checks pass, limitations are recorded, and no package is published.

--- a/docs/plans/2026-08-10_pi-subagents-typed-abstention-enforcement-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-typed-abstention-enforcement-plan.md
@@ -1,0 +1,99 @@
+# Pi Subagents Typed Abstention and Capability Enforcement Plan
+
+## Goal
+
+Turn audited capability and authority findings into an explicit opt-in enforcement and recovery protocol that can acknowledge suitable work, reject unsuitable work before side effects, request missing inputs, abstain safely, and avoid blind retries.
+
+Preserve audit-only behavior for legacy and uncontracted calls unless a separate compatibility decision changes the default.
+
+## Context
+
+The capability-manifest phase provides explicit requirements, declared agent capabilities, an enforceability matrix, and one immutable `ExecutionPlan`.
+
+Current lifecycle and result contracts do not distinguish missing context, capability mismatch, unsupported policy, unavailable verification, ambiguous delegation, stale input, or ordinary execution failure.
+
+The research notes report strong recovery for transient tool faults but weak or absent recovery for ambiguous delegation, context pollution, conflicting outputs, and premature action.
+
+A useful enforcement system must therefore classify inability and choose failure-specific recovery rather than map every outcome to failed or retry.
+
+## Architecture
+
+A preflight acknowledgement will evaluate the ExecutionPlan before confirmation, worktree creation, child allocation, or provider work.
+
+The acknowledgement will be either accepted or rejected and will include bounded reason codes, missing requirements, unsupported guarantees, and allowed recovery actions.
+
+Contracted runtime results will use one typed outcome vocabulary including completed, partial, blocked, needs-input, abstained, failed, interrupted, stale, and contract-invalid.
+
+A bounded reason-code registry will distinguish capability, authority, dependency, ambiguity, verification, policy, transport, timeout, cancellation, semantic, and stale-state classes.
+
+Enforcement will apply only to controls proven enforceable through the active transport and runtime.
+
+An explicit request for an unsupported filesystem, network, secret, credential, or process guarantee will fail closed instead of degrading to prompt guidance.
+
+A deterministic recovery policy will map classified outcomes to retry, clarify, supply-input, reroute, replan, revalidate, fallback, or stop.
+
+No policy action will replay accepted or uncertain write-capable work automatically.
+
+## Non-Goals
+
+- Do not enable enforcement for legacy free-text calls by default.
+- Do not claim OS sandboxing or enforce advisory path and network policy through prompts.
+- Do not let an agent self-grant missing capabilities, tools, trust, secrets, or workspace access.
+- Do not add a WorkItem dependency graph or adaptive scheduler in this phase.
+- Do not automatically choose a new worker through a hidden model call.
+- Do not treat self-reported completed status as independent verification.
+
+## Assumptions
+
+- Handoff contract v2 and audit-only ExecutionPlan are implemented and stable.
+- The caller can explicitly request enforcement through a provider-compatible field or contracted mode.
+- The package can reject unsupported guarantees before launch even when it cannot enforce the guarantee itself.
+- Recovery actions can be represented as recommendations before later WorkItem automation consumes them.
+
+## Risks
+
+- Enforcement can reject useful work because manifests or task requirements are incomplete.
+- Too many outcome or reason codes can create inconsistent caller handling.
+- A model can return an invalid abstention payload or falsely claim missing capability.
+- Recovery can duplicate side effects if acceptance and settlement boundaries are confused.
+- Settings or per-call precedence can make enforcement state unclear.
+- Prompt-only scope can be mistaken for enforcement if advisory controls appear beside real controls.
+
+## Rollback / Recovery
+
+- Keep audit-only as the compatibility default and require explicit enforcement for contracted calls.
+- Preserve raw bounded output and existing failed/interrupted states for legacy callers.
+- Fail enforcement closed before side effects when the requested guarantee is unsupported or ambiguous.
+- Disable automated recovery actions independently while retaining typed outcome reporting.
+- Keep current timeout finalization and explicit-abort behavior authoritative, and preserve deterministic timeout checkpoints when that separately planned capability is present at execution time.
+
+## Plan
+
+- [ ] Characterize current preflight, confirmation, worktree creation, registry spawn, transport startup, prompt acceptance, settlement, timeout, abort, completion, and retry boundaries; verify focused tests pass before enforcement changes.
+- [ ] Define the versioned acknowledgement, typed outcome, reason-code, and recovery-action schemas with one owner and bounded forward-compatible parsing; verify every code has a distinct caller action or diagnostic purpose.
+- [ ] Decide the provider-compatible enforcement request and precedence rules for blocking tasks, chain steps, aggregators, detached spawn, and follow-up turns; preserve audit-only omitted behavior and document any setting interaction.
+- [ ] Add failing preflight tests for accepted work, unknown manifest, missing capability, unsupported guarantee, unavailable result contract, trust denial, resource denial, transport mismatch, insufficient workspace isolation, and malformed enforcement request.
+- [ ] Implement acknowledgement before project-agent confirmation, worktree creation, registry insertion, child process or session allocation, and provider work; verify rejected plans produce zero side effects and stable bounded details.
+- [ ] Add failing cross-transport tests for enforceable tool, cwd, trust, resource, workspace, model, result-contract, concurrency, and budget policy; verify subprocess, in-process, RPC, and automatic transport cannot widen the accepted plan.
+- [ ] Implement enforcement for proven controls and fail closed for requested unsupported filesystem, network, secret, credential, approval, sandbox, or provider-header guarantees.
+- [ ] Extend result parsing, registry state, completion metadata, inspection, rendering, and persistence with typed outcomes and reason codes while preserving legacy lifecycle projections.
+- [ ] Add constrained agent instructions for acknowledgement, missing-input requests, limitations, and abstention without allowing model output to override executor-owned policy or preflight facts.
+- [ ] Add malformed, contradictory, oversized, private, and unrecognized abstention tests; verify invalid self-reported outcomes become contract-invalid or ordinary partial output rather than trusted policy decisions.
+- [ ] Define and implement a deterministic recovery classifier that retries only bounded transient pre-acceptance transport or tool failures, recommends clarification for ambiguity, supplies exact missing dependencies, reroutes capability mismatch, revalidates stale state, and stops unsupported guarantees.
+- [ ] Add tests proving ambiguous acceptance, successful prompt acceptance, write-capable partial side effects, available timeout checkpoint or finalization evidence, and stale evidence never trigger automatic replay.
+- [ ] Add parent-facing recovery metadata and guidance to completion delivery and inspection without automatically launching a replacement agent in this phase.
+- [ ] Add an offline failure-injection suite for transient transport, tool, ambiguous delegation, missing context, capability mismatch, conflicting result, invalid contract, premature action, timeout, and stale input; record recovery accuracy and false-retry count.
+- [ ] Update README, tool descriptions, status/help, compatibility and downgrade notes, enforceability matrix, package layout, and a minor Changeset with exact audit-versus-enforce behavior.
+- [ ] Audit settings ordering if any setting is added, project trust, cancellation, stale session generation, partial initialization, settlement, timeout finalization, completion batching, redaction, and repeated cleanup against both extension guides.
+- [ ] Run focused tests, `npm test`, `npm run check`, `git diff --check`, and `just pack subagents`; run one representative local Pi smoke for accept, reject, abstain, and stop behavior when practical.
+
+## Completion Checklist
+
+- [ ] Every enforced launch receives a typed preflight acknowledgement before side effects.
+- [ ] Legacy and uncontracted calls preserve audit-only behavior unless an explicitly approved compatibility change says otherwise.
+- [ ] Enforced, advisory, unsupported, and unknown controls are distinct and truthfully documented.
+- [ ] Typed inability carries enough information for clarification, rerouting, fallback, revalidation, or stop.
+- [ ] No accepted, ambiguously accepted, or potentially side-effecting turn is automatically replayed.
+- [ ] Failure-injection evidence distinguishes transient recovery from semantic and stale-state containment.
+- [ ] All transports enforce the same accepted ExecutionPlan without silent widening or fallback.
+- [ ] Required checks, lifecycle and settings audits, compatibility evidence, and Changeset pass without publication.

--- a/docs/plans/2026-08-10_pi-subagents-typed-abstention-enforcement-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-typed-abstention-enforcement-plan.md
@@ -6,6 +6,14 @@ Turn audited capability and authority findings into an explicit opt-in enforceme
 
 Preserve audit-only behavior for legacy and uncontracted calls unless a separate compatibility decision changes the default.
 
+## Post-hoc Amendment
+
+This section and every checklist item labelled **Post-hoc addition** were added after the initial plan in commit `07df6d8b`.
+
+**Reason:** The later evidence audit and roadmap review found that enforcement without task-version-bound grants and cancellation-generation revocation can leave stale authority active and race late completions into acceptance.
+
+The audit-only delegation-admission recommendation remains non-enforcing until Gate 4A records evidence and a separate approval admits adaptive behavior.
+
 ## Context
 
 The capability-manifest phase provides explicit requirements, declared agent capabilities, an enforceability matrix, and one immutable `ExecutionPlan`.
@@ -28,6 +36,14 @@ A bounded reason-code registry will distinguish capability, authority, dependenc
 
 Enforcement will apply only to controls proven enforceable through the active transport and runtime.
 
+**Post-hoc addition:** Every accepted enforceable plan will issue a bounded grant tied to the task generation and exact `ExecutionPlan` identity with an explicit lifetime and revocation state.
+
+**Reason:** Agent identity or prompt scope alone cannot prove that authority still belongs to the current user request after cancellation, replacement, or re-planning.
+
+**Post-hoc addition:** For contracted generation-aware work, cancellation and session replacement will rotate the generation and revoke grants before signalling workers, and later results from the old generation will be typed stale and barred from recovery or acceptance while legacy omitted-field behavior remains unchanged.
+
+**Reason:** Ignoring a late continuation does not release its authority or prevent detached completion from being mistaken for current evidence.
+
 An explicit request for an unsupported filesystem, network, secret, credential, or process guarantee will fail closed instead of degrading to prompt guidance.
 
 A deterministic recovery policy will map classified outcomes to retry, clarify, supply-input, reroute, replan, revalidate, fallback, or stop.
@@ -41,11 +57,13 @@ No policy action will replay accepted or uncertain write-capable work automatica
 - Do not let an agent self-grant missing capabilities, tools, trust, secrets, or workspace access.
 - Do not add a WorkItem dependency graph or adaptive scheduler in this phase.
 - Do not automatically choose a new worker through a hidden model call.
+- **Post-hoc addition:** Do not enforce the audit-only delegation-admission recommendation or reject work merely because the unvalidated policy prefers parent-owned execution.
 - Do not treat self-reported completed status as independent verification.
 
 ## Assumptions
 
 - Handoff contract v2 and audit-only ExecutionPlan are implemented and stable.
+- **Post-hoc addition:** Their request, result, and plan projections carry one immutable executor-owned task generation that model output cannot override.
 - The caller can explicitly request enforcement through a provider-compatible field or contracted mode.
 - The package can reject unsupported guarantees before launch even when it cannot enforce the guarantee itself.
 - Recovery actions can be represented as recommendations before later WorkItem automation consumes them.
@@ -71,9 +89,12 @@ No policy action will replay accepted or uncertain write-capable work automatica
 
 - [ ] Characterize current preflight, confirmation, worktree creation, registry spawn, transport startup, prompt acceptance, settlement, timeout, abort, completion, and retry boundaries; verify focused tests pass before enforcement changes.
 - [ ] Define the versioned acknowledgement, typed outcome, reason-code, and recovery-action schemas with one owner and bounded forward-compatible parsing; verify every code has a distinct caller action or diagnostic purpose.
+- [ ] **Post-hoc addition:** Define a task-generation-bound capability-grant schema with accepted-plan digest, issued and expiry bounds, revocation reason, and executor-owned state; verify no model-facing field can widen or revive it.
 - [ ] Decide the provider-compatible enforcement request and precedence rules for blocking tasks, chain steps, aggregators, detached spawn, and follow-up turns; preserve audit-only omitted behavior and document any setting interaction.
 - [ ] Add failing preflight tests for accepted work, unknown manifest, missing capability, unsupported guarantee, unavailable result contract, trust denial, resource denial, transport mismatch, insufficient workspace isolation, and malformed enforcement request.
 - [ ] Implement acknowledgement before project-agent confirmation, worktree creation, registry insertion, child process or session allocation, and provider work; verify rejected plans produce zero side effects and stable bounded details.
+- [ ] **Post-hoc addition:** Issue the grant only after acknowledgement, propagate its generation and accepted-plan identity through every transport, and revoke it before delivering cancellation or replacement signals.
+- [ ] **Post-hoc addition:** Add cancellation-race tests covering pre-launch rejection, in-flight tool work, accepted prompt, detached completion, timeout finalization, session replacement, repeated cancellation, and late provider settlement; verify old-generation results are stale and cannot trigger retry, fallback, or acceptance.
 - [ ] Add failing cross-transport tests for enforceable tool, cwd, trust, resource, workspace, model, result-contract, concurrency, and budget policy; verify subprocess, in-process, RPC, and automatic transport cannot widen the accepted plan.
 - [ ] Implement enforcement for proven controls and fail closed for requested unsupported filesystem, network, secret, credential, approval, sandbox, or provider-header guarantees.
 - [ ] Extend result parsing, registry state, completion metadata, inspection, rendering, and persistence with typed outcomes and reason codes while preserving legacy lifecycle projections.
@@ -82,6 +103,7 @@ No policy action will replay accepted or uncertain write-capable work automatica
 - [ ] Define and implement a deterministic recovery classifier that retries only bounded transient pre-acceptance transport or tool failures, recommends clarification for ambiguity, supplies exact missing dependencies, reroutes capability mismatch, revalidates stale state, and stops unsupported guarantees.
 - [ ] Add tests proving ambiguous acceptance, successful prompt acceptance, write-capable partial side effects, available timeout checkpoint or finalization evidence, and stale evidence never trigger automatic replay.
 - [ ] Add parent-facing recovery metadata and guidance to completion delivery and inspection without automatically launching a replacement agent in this phase.
+- [ ] **Post-hoc addition:** Expose bounded grant generation, expiry, and revocation metadata in safe details and inspection while omitting credentials, unrestricted paths, and private policy material.
 - [ ] Add an offline failure-injection suite for transient transport, tool, ambiguous delegation, missing context, capability mismatch, conflicting result, invalid contract, premature action, timeout, and stale input; record recovery accuracy and false-retry count.
 - [ ] Update README, tool descriptions, status/help, compatibility and downgrade notes, enforceability matrix, package layout, and a minor Changeset with exact audit-versus-enforce behavior.
 - [ ] Audit settings ordering if any setting is added, project trust, cancellation, stale session generation, partial initialization, settlement, timeout finalization, completion batching, redaction, and repeated cleanup against both extension guides.
@@ -96,4 +118,5 @@ No policy action will replay accepted or uncertain write-capable work automatica
 - [ ] No accepted, ambiguously accepted, or potentially side-effecting turn is automatically replayed.
 - [ ] Failure-injection evidence distinguishes transient recovery from semantic and stale-state containment.
 - [ ] All transports enforce the same accepted ExecutionPlan without silent widening or fallback.
+- [ ] **Post-hoc addition:** All transports bind enforceable authority to the same task generation and accepted-plan identity, and cancellation or replacement produces zero accepted old-generation completions.
 - [ ] Required checks, lifecycle and settings audits, compatibility evidence, and Changeset pass without publication.

--- a/docs/plans/2026-08-10_pi-subagents-work-item-ledger-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-work-item-ledger-plan.md
@@ -6,6 +6,14 @@ Add a bounded persistent orchestration ledger that owns WorkItem identity, depen
 
 Reject cyclic and invalid explicit workflows before any child starts.
 
+## Post-hoc Amendment
+
+This section and every checklist item labelled **Post-hoc addition** were added after the initial plan in commit `07df6d8b`.
+
+**Reason:** The later evidence audit and roadmap review found that observable artifact versions and Worktree isolation are insufficient unless one integration controller rejects stale premises, while cancellation must rotate generations and quarantine late results before Gate 4A can measure a trustworthy minimal architecture.
+
+The additions make Phase 4 the owner of fail-closed integration and lifecycle provenance without adding adaptive scheduling.
+
 ## Context
 
 `AgentRegistry` currently owns retained agent records, parent relationships, history, mailboxes, a FIFO turn queue, concurrency, persistence callbacks, and subtree lifecycle operations.
@@ -38,6 +46,14 @@ Graph validation will resolve identifiers, bounds, missing dependencies, self-ed
 
 One integration owner and independently contextualized verifier can be represented without allowing multiple completion owners.
 
+**Post-hoc addition:** Within an opted-in managed-integration WorkItem, the integration owner will be the only component allowed to update canonical integration state and will validate task generation, base commit, declared dependency or read-set versions, accepted-plan identity, capability compliance, scope, patch digest, and required evidence before applying an artifact.
+
+**Reason:** Separate worktrees prevent direct overwrites but do not prevent stale assumptions, incompatible interfaces, or late patches from corrupting the assembled result.
+
+**Post-hoc addition:** Cancellation will operate on a WorkItem subtree by rotating affected generations, revoking or observing prior grant revocation, signalling owned work, quarantining later artifacts, and preserving diagnostic provenance without accepting them.
+
+**Reason:** The initial ledger model contained generation and invalidation but did not define the race between cancellation, detached settlement, and integration.
+
 ## Non-Goals
 
 - Do not build a general workflow DSL, distributed scheduler, CI engine, or arbitrary durable job service.
@@ -46,10 +62,12 @@ One integration owner and independently contextualized verifier can be represent
 - Do not persist raw chain-of-thought, credentials, full prompts, unbounded tool output, or arbitrary repository contents.
 - Do not infer repository dependencies through an unbounded mandatory analysis pass.
 - Do not automatically merge worktrees or resolve conflicting edits.
+- **Post-hoc addition:** Do not let any worker, verifier, or late completion update canonical integration state outside the single integration controller for opted-in managed-integration WorkItems, while preserving legacy omitted-field execution behavior.
 
 ## Assumptions
 
 - Handoff v2 provides task and result contracts, and capability enforcement provides acknowledged effective policy.
+- **Post-hoc addition:** Handoff, `ExecutionPlan`, and capability grants share one immutable task generation, and enforcement exposes revocation state before ledger integration begins.
 - Existing persistence can add a separate versioned ledger record or state file without making older retained agent records unreadable.
 - Explicit workflows remain bounded by current task, output, agent, depth, and storage limits.
 - An artifact reference can identify evidence without making the ledger the artifact-content store.
@@ -78,6 +96,7 @@ One integration owner and independently contextualized verifier can be represent
 - [ ] Define WorkItem, workflow, dependency edge, cohesive scope, artifact reference, artifact version, verifier relationship, generation, state, outcome, and invalidation schemas with explicit bounds and one terminal owner.
 - [ ] Map existing agent lifecycle and typed result states to WorkItem transitions, including starting, ready, running, blocked, needs-input, completed, failed, interrupted, stale, invalidated, and closed or archived projections.
 - [ ] Add failing pure-ledger tests for creation, transition legality, monotonic generations, idempotent updates, duplicate identifiers, missing dependencies, self-edges, duplicate edges, cycle detection, terminal immutability, invalidation, and bounded projection.
+- [ ] **Post-hoc addition:** Add cancellation-tree and race tests for generation rotation, grant revocation observation, repeated cancellation, session replacement, detached late result, timeout settlement, quarantined artifacts, inert restore, and zero old-generation acceptance.
 - [ ] Implement a deep `WorkItemLedger` module with deterministic transitions, graph validation, artifact provenance, ready-state calculation, and immutable inspection snapshots without transport or UI dependencies.
 - [ ] Project blocking single, parallel, chain, and fan-in calls into ledger workflows while preserving current execution order, result content, failure behavior, status, and omitted-field compatibility.
 - [ ] Link detached spawn and follow-up turns to optional WorkItems without treating `parentId` as a dependency automatically; verify subtree lifecycle and workflow invalidation remain distinct operations.
@@ -85,11 +104,15 @@ One integration owner and independently contextualized verifier can be represent
 - [ ] Validate every explicit workflow, target, agent, contract, ExecutionPlan, dependency, artifact input, and ownership scope before project-agent confirmation or any child launch; verify an invalid or cyclic graph starts zero children.
 - [ ] Add conservative cohesive-scope and ownership conflict checks using declared paths, artifacts, and integration boundaries without claiming complete static dependency inference.
 - [ ] Add one integration-owner relationship and one verifier relationship whose executable evidence can satisfy acceptance criteria while only the WorkItem transition owner commits completion.
+- [ ] **Post-hoc addition:** Implement an integration admission check that fails closed on stale generation, base commit, declared dependency or read-set versions, accepted-plan identity, revoked capability, scope, patch digest, or missing evidence; verify no rejected artifact mutates canonical integration state.
+- [ ] **Post-hoc addition:** Require the integration controller to apply admitted artifacts in dependency order and record the exact decision inputs, while a fresh-context verifier evaluates only the resulting current state and evidence receipts.
 - [ ] Add artifact invalidation so changed upstream generation, superseded result, failed verification, or ownership conflict marks affected downstream work stale or invalidated transitively without deleting prior evidence.
 - [ ] Add versioned bounded ledger persistence with serialized publication, redaction, corrupt-state quarantine, inert restore, ancestor and dependency closure, count projection, and recovery after partial or repeated cleanup.
 - [ ] Add `subagent_inspect` workflow and WorkItem projections that return metadata, dependencies, artifact identities, state, provenance, transfer coverage, and invalidation without returning raw artifact bodies or acknowledging mailboxes.
 - [ ] Add bounded TUI or existing-manager views for workflow state only if the standard Pi TUI Kit surface can present it without creating another lifecycle owner; verify cancellation, disposal, replacement, and shutdown.
 - [ ] Add failure-injection and graph fixtures that measure missing transfers, cascade radius, delegation fidelity, ownership conflicts, invalidation reach, and zero-launch preflight failures across increasing graph depth.
+- [ ] **Post-hoc addition:** Add a Gate 4A fixture profile limited to two concurrent mutating children with no grandchildren, one integration owner, and one fresh-context verifier; verify attempts to widen or recurse are rejected in the profile before child allocation.
+- [ ] **Post-hoc addition:** Export bounded per-instance generation, integration, verification, cancellation, late-result, handoff, conflict, timing, and usage evidence required by the post-hoc minimal-delegation evaluation plan without adding production admission policy.
 - [ ] Update README, tool schema documentation, persistence and downgrade guidance, package layout, implementation notes, and a minor Changeset for any public workflow surface.
 - [ ] Audit persistence ordering, state ownership, cancellation, session replacement, shutdown, worktree cleanup, settings neutrality, sanitization, output bounds, and all stale continuations against the extension guides.
 - [ ] Run focused tests, `npm test`, `npm run check`, `git diff --check`, and `just pack subagents`; run a local Pi smoke for one valid chain-shaped workflow and one rejected cycle when practical.
@@ -101,6 +124,9 @@ One integration owner and independently contextualized verifier can be represent
 - [ ] Invalid identifiers, dependencies, artifacts, ownership scopes, and cycles launch zero children.
 - [ ] Artifact provenance and generation make missing, superseded, stale, and invalidated transfers observable.
 - [ ] Integration and verification roles can attach evidence without creating multiple completion owners.
+- [ ] **Post-hoc addition:** Only the integration controller can mutate canonical integration state for opted-in managed-integration WorkItems, stale or revoked inputs fail closed before application, and legacy omitted-field execution remains compatible.
+- [ ] **Post-hoc addition:** Cancellation and replacement rotate generations and produce zero accepted late artifacts while preserving bounded diagnostic provenance.
+- [ ] **Post-hoc addition:** The ledger exposes the bounded two-child, no-grandchild experimental evidence required for Gate 4A without admitting adaptive scheduling.
 - [ ] Persisted workflows restore inertly, preserve bounded evidence, and never resume prior side effects automatically.
 - [ ] Inspection remains side-effect-free and excludes raw artifact contents, private context, and credentials.
 - [ ] Required checks, semantic audits, migration evidence, package inspection, and Changeset pass without publication.

--- a/docs/plans/2026-08-10_pi-subagents-work-item-ledger-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-work-item-ledger-plan.md
@@ -1,0 +1,106 @@
+# Pi Subagents WorkItem and Artifact Ledger Plan
+
+## Goal
+
+Add a bounded persistent orchestration ledger that owns WorkItem identity, dependencies, cohesive scope, assignment, artifacts, versions, ownership, acceptance, invalidation, and terminal state while leaving Pi and existing transports responsible for agent execution.
+
+Reject cyclic and invalid explicit workflows before any child starts.
+
+## Context
+
+`AgentRegistry` currently owns retained agent records, parent relationships, history, mailboxes, a FIFO turn queue, concurrency, persistence callbacks, and subtree lifecycle operations.
+
+Blocking orchestration separately owns single, parallel, chain, and fan-in topology without one durable task model.
+
+The research notes show that dependency-aware cohesion can improve quality, latency, and cost, while naive file partitioning can increase cost and coordination risk.
+
+They also show that missing transfers and latent failures can grow sharply with workflow size and depth.
+
+A ledger is required before adaptive scheduling because the scheduler needs authoritative ready state, artifact versions, ownership, and invalidation.
+
+## Architecture
+
+A `WorkItemLedger` will be a package-owned delegation-state module beside `AgentRegistry`, not a replacement for Pi sessions, the model loop, or transport lifecycle.
+
+A WorkItem will contain workflow and task identity, objective reference, dependencies, assigned agent, cohesive scope, requested capabilities, input artifact versions, output artifacts, acceptance criteria, verifier relationship, state, generation, provenance, timing, and terminal outcome.
+
+Artifacts will be bounded metadata references with type, producer, generation, content hash or stable identity, location policy, verification state, and invalidation state.
+
+The ledger will not persist arbitrary artifact bodies or raw model output by default.
+
+Existing modes will project into the ledger first, with single as one node, parallel as independent nodes, chain as sequential dependencies, and fan-in as a node depending on all workers.
+
+Detached parent relationships will remain lifecycle ownership unless an explicit WorkItem dependency links them.
+
+An explicit DAG surface will be admitted only after the internal projection, schema size, provider compatibility, and usability evidence pass.
+
+Graph validation will resolve identifiers, bounds, missing dependencies, self-edges, duplicate edges, cycles, ownership conflicts, and invalid artifact references before launch.
+
+One integration owner and independently contextualized verifier can be represented without allowing multiple completion owners.
+
+## Non-Goals
+
+- Do not build a general workflow DSL, distributed scheduler, CI engine, or arbitrary durable job service.
+- Do not move model turns, tool execution, provider retry, session persistence, compaction, or transport cleanup into the ledger.
+- Do not add adaptive scheduling until the ledger proves deterministic ready and invalidation state.
+- Do not persist raw chain-of-thought, credentials, full prompts, unbounded tool output, or arbitrary repository contents.
+- Do not infer repository dependencies through an unbounded mandatory analysis pass.
+- Do not automatically merge worktrees or resolve conflicting edits.
+
+## Assumptions
+
+- Handoff v2 provides task and result contracts, and capability enforcement provides acknowledged effective policy.
+- Existing persistence can add a separate versioned ledger record or state file without making older retained agent records unreadable.
+- Explicit workflows remain bounded by current task, output, agent, depth, and storage limits.
+- An artifact reference can identify evidence without making the ledger the artifact-content store.
+
+## Risks
+
+- A ledger can duplicate agent history or Pi session state and create two owners for completion.
+- WorkItem and agent lifecycle states can diverge during cancellation, timeout, crash, or restore.
+- Explicit DAG schemas can become too large or difficult for model providers to generate reliably.
+- Dependency and ownership declarations can be wrong even when the graph is acyclic.
+- Persistence migration can strand retained agents or partially written workflows.
+- Artifact hashes and locations can expose sensitive paths or create expensive repository scans.
+
+## Rollback / Recovery
+
+- Introduce ledger projection behind existing modes before exposing an explicit workflow mode.
+- Keep AgentRegistry and existing tool behavior authoritative until ledger parity tests pass.
+- Store ledger data under a separately versioned optional envelope that old readers can ignore.
+- Restore incomplete workflows inertly and require explicit continuation rather than resuming prior side effects.
+- Keep explicit DAG execution opt-in and removable without invalidating ordinary retained agents.
+- Preserve prior evidence when invalidating work so diagnosis does not require replay.
+
+## Plan
+
+- [ ] Characterize current blocking topology, registry queue, parent tree, history, mailbox, persistence, completion, subtree close, worktree ownership, timeout, and restore behavior; verify focused tests pass before ledger changes.
+- [ ] Define WorkItem, workflow, dependency edge, cohesive scope, artifact reference, artifact version, verifier relationship, generation, state, outcome, and invalidation schemas with explicit bounds and one terminal owner.
+- [ ] Map existing agent lifecycle and typed result states to WorkItem transitions, including starting, ready, running, blocked, needs-input, completed, failed, interrupted, stale, invalidated, and closed or archived projections.
+- [ ] Add failing pure-ledger tests for creation, transition legality, monotonic generations, idempotent updates, duplicate identifiers, missing dependencies, self-edges, duplicate edges, cycle detection, terminal immutability, invalidation, and bounded projection.
+- [ ] Implement a deep `WorkItemLedger` module with deterministic transitions, graph validation, artifact provenance, ready-state calculation, and immutable inspection snapshots without transport or UI dependencies.
+- [ ] Project blocking single, parallel, chain, and fan-in calls into ledger workflows while preserving current execution order, result content, failure behavior, status, and omitted-field compatibility.
+- [ ] Link detached spawn and follow-up turns to optional WorkItems without treating `parentId` as a dependency automatically; verify subtree lifecycle and workflow invalidation remain distinct operations.
+- [ ] Add a bounded explicit workflow schema only after a schema compatibility gate decides whether it belongs as a new `subagent` mode or another separately approved surface; record the decision and rejected alternative.
+- [ ] Validate every explicit workflow, target, agent, contract, ExecutionPlan, dependency, artifact input, and ownership scope before project-agent confirmation or any child launch; verify an invalid or cyclic graph starts zero children.
+- [ ] Add conservative cohesive-scope and ownership conflict checks using declared paths, artifacts, and integration boundaries without claiming complete static dependency inference.
+- [ ] Add one integration-owner relationship and one verifier relationship whose executable evidence can satisfy acceptance criteria while only the WorkItem transition owner commits completion.
+- [ ] Add artifact invalidation so changed upstream generation, superseded result, failed verification, or ownership conflict marks affected downstream work stale or invalidated transitively without deleting prior evidence.
+- [ ] Add versioned bounded ledger persistence with serialized publication, redaction, corrupt-state quarantine, inert restore, ancestor and dependency closure, count projection, and recovery after partial or repeated cleanup.
+- [ ] Add `subagent_inspect` workflow and WorkItem projections that return metadata, dependencies, artifact identities, state, provenance, transfer coverage, and invalidation without returning raw artifact bodies or acknowledging mailboxes.
+- [ ] Add bounded TUI or existing-manager views for workflow state only if the standard Pi TUI Kit surface can present it without creating another lifecycle owner; verify cancellation, disposal, replacement, and shutdown.
+- [ ] Add failure-injection and graph fixtures that measure missing transfers, cascade radius, delegation fidelity, ownership conflicts, invalidation reach, and zero-launch preflight failures across increasing graph depth.
+- [ ] Update README, tool schema documentation, persistence and downgrade guidance, package layout, implementation notes, and a minor Changeset for any public workflow surface.
+- [ ] Audit persistence ordering, state ownership, cancellation, session replacement, shutdown, worktree cleanup, settings neutrality, sanitization, output bounds, and all stale continuations against the extension guides.
+- [ ] Run focused tests, `npm test`, `npm run check`, `git diff --check`, and `just pack subagents`; run a local Pi smoke for one valid chain-shaped workflow and one rejected cycle when practical.
+
+## Completion Checklist
+
+- [ ] WorkItem and AgentRegistry responsibilities are distinct and documented with one owner for each state transition.
+- [ ] Existing single, parallel, chain, fan-in, detached, mailbox, and subtree behavior remains compatible by omission.
+- [ ] Invalid identifiers, dependencies, artifacts, ownership scopes, and cycles launch zero children.
+- [ ] Artifact provenance and generation make missing, superseded, stale, and invalidated transfers observable.
+- [ ] Integration and verification roles can attach evidence without creating multiple completion owners.
+- [ ] Persisted workflows restore inertly, preserve bounded evidence, and never resume prior side effects automatically.
+- [ ] Inspection remains side-effect-free and excludes raw artifact contents, private context, and credentials.
+- [ ] Required checks, semantic audits, migration evidence, package inspection, and Changeset pass without publication.

--- a/docs/research/2026-08-10-coding-agent-subagents-architecture-deep-dive.md
+++ b/docs/research/2026-08-10-coding-agent-subagents-architecture-deep-dive.md
@@ -1,0 +1,302 @@
+# Coding-Agent Subagents Architecture Deep Dive
+
+Date: 2026-08-10.
+
+## Scope and evidence labels
+
+This report studies how a coding agent should decide whether to delegate, isolate concurrent work, transfer context, integrate changes, verify results, and stop unsafe or stale work.
+
+The study began with the repository survey and engineering notes dated 2026-08-10 and then used AlphaXiv `discover_papers` to search beyond their cited set.
+
+AlphaXiv `answer_pdf_queries` was used to inspect mechanisms, experiments, ablations, limitations, and contrary results in the selected papers.
+
+`[Direct evidence]` marks a mechanism or result reported by a paper.
+
+`[Cross-paper inference]` marks an architecture conclusion synthesized across papers rather than directly tested as one system.
+
+`[Paper-author interpretation]` marks an explanatory interpretation made by a paper's authors rather than a directly measured result.
+
+`[Coverage gap]` marks a requested concern for which the reviewed evidence remains weak or indirect.
+
+Quantitative findings are reported in the paper's own benchmark setting and should not be treated as directly comparable across different models, tasks, or budgets.
+
+## Executive findings
+
+- `[Cross-paper inference]` Multi-agent execution is not a reliable default because strong single-agent or equal-sample baselines often match or beat automatically designed multi-agent systems at much lower cost.
+- `[Cross-paper inference]` Delegation helps most when work is genuinely decomposable, context exceeds one agent's effective window, or independent verification can cheaply reject a weak first attempt.
+- `[Cross-paper inference]` More workers can reduce success when they create integration conflicts, repeated reasoning, late communication, or excessive context transfer.
+- `[Cross-paper inference]` Worktree isolation prevents accidental file interference but does not by itself prevent logically incompatible patches or stale assumptions.
+- `[Cross-paper inference]` Shared workspaces can outperform worktrees when every read and write is versioned and stale writes are actively rejected, but unprotected shared workspaces perform poorly.
+- `[Cross-paper inference]` Structured task contracts, explicit dependencies, precise ownership boundaries, and machine-checkable artifacts outperform unconstrained peer conversation as coordination primitives.
+- `[Cross-paper inference]` Independent tests and evidence-bound completion gates improve selection and reduce false completion more reliably than self-reported confidence.
+- `[Cross-paper inference]` The smallest defensible architecture is a single-agent-first cascade with at most two concurrent workers, immutable task packets, versioned state, manager-controlled integration, and a fresh-context verifier.
+- `[Cross-paper inference]` The architecture should optimize verified task value per unit of cost and latency rather than agent count, message count, or nominal parallelism.
+
+## Search and selection method
+
+- The search covered dynamic routing, decomposition, context transfer, communication, scheduling, filesystem isolation, integration, verification, permissions, cancellation, retries, stale state, observability, and evaluation.
+- Papers were retained when their PDFs exposed an executable mechanism, a controlled comparison, a quantitative result, or a clearly stated limitation relevant to coding-agent architecture.
+- The reviewed set includes software-engineering benchmarks, general multi-agent benchmarks, long-context delegation studies, concurrency-control systems, permission systems, and orchestration evaluators.
+- The evidence base extends beyond the seed documents with CAID, STORM, CooperBench, SHEPHERD, CoAgent, Claim Plane, Proof-or-Stop, SkillScope, Semantic Snapshot Isolation, Co-Coder, and the single-versus-multi hybrid study.
+- Simulator results and synthetic mechanism probes are treated as lower-external-validity evidence than repository-level tests, and preliminary one-seed studies are labeled accordingly.
+
+## Dynamic delegation policy
+
+- `[Direct evidence]` [Single-agent or Multi-agent Systems? Why Not Both?](https://arxiv.org/abs/2505.18286) found that single-agent and multi-agent systems produced the same pass-or-fail outcome in about 80% of evaluated cases across 15 tasks, seven application types, and nine frameworks.
+- `[Direct evidence]` The same study found much higher multi-agent token use, including 5.05 times prefill and 5.56 times decode tokens on MBPP, 34.66 times and 12.77 times on GSM8K, and 220.22 times and 11.05 times on AIME.
+- `[Direct evidence]` Its difficulty router sent low-rated tasks to a single agent and high-rated tasks to a multi-agent system, producing two percentage points higher accuracy at half the multi-agent cost on a mixed GSM8K and AIME workload.
+- `[Direct evidence]` Its cascade ran a single agent first and escalated only answers that failed a cheap exact checker, reaching 94.5% on HumanEval versus 90.2% for the single agent and 93.3% for the multi-agent system.
+- `[Direct evidence]` The same cascade reached 84.4% on MBPP versus 79.6% and 80.8%, and 71.2% on DS1000 versus 62.9% and 62.3%.
+- `[Direct evidence]` The cascade was reported to improve accuracy by as much as 12% while lowering cost by 20% relative to the multi-agent system, with larger savings in some settings.
+- `[Direct evidence]` The cascade depends on a checker that is both cheap and accurate, so it does not transfer directly to open-ended tasks with ambiguous correctness.
+- `[Direct evidence]` [The Illusion of Multi-Agent Advantage](https://arxiv.org/abs/2606.13003) found that six automatically designed multi-agent systems generally lost to five-sample chain-of-thought self-consistency and sometimes cost up to ten times more.
+- `[Direct evidence]` On SWE-bench Lite with GPT-5, five-sample self-consistency achieved 57.09% for $286.40, while the evaluated multi-agent systems ranged from 27.23% to 55.97% and from $83.50 to $998.20.
+- `[Direct evidence]` On the synthetic, non-coding Synthetic Multi-Hop Financial Reasoning task with GPT-5, DyLAN and MAS-Orchestra improved over self-consistency by 4.3 and 6.0 percentage points while costing about 2.5 and 1.9 times as much.
+- `[Direct evidence]` A hand-designed Synthetic Multi-Hop Financial Reasoning pipeline with a meta-agent, parallel per-investor extractors and calculators, and deterministic aggregation achieved 96.51% at $554.82 versus 56.97% at $478.40 for self-consistency.
+- `[Cross-paper inference]` Delegation admission should require at least one explicit benefit hypothesis such as context relief, separable parallel work, specialist tool access, or independent evidence generation.
+- `[Cross-paper inference]` The default path should remain one agent unless estimated benefit exceeds coordination cost and the task contract exposes a credible verification route.
+
+## Task decomposition and concurrency control
+
+- `[Direct evidence]` [Effective Strategies for Asynchronous SWE Agents](https://arxiv.org/abs/2603.21489) uses a central manager to build a dependency graph, group strongly or circularly dependent work, and dispatch only ready nodes under a maximum-active-worker limit.
+- `[Direct evidence]` The manager dynamically reassigns work after integrations and sends workers structured JSON contracts containing target paths, functions, dependencies, and expected work.
+- `[Direct evidence]` The system improved by as much as 14.7 percentage points on Commit0 and 25.6 percentage points on PaperBench over its single-agent baseline.
+- `[Direct evidence]` Its agent-count ablation was nonmonotonic because Commit0 improved from two to four workers and then declined at eight workers as integration overhead grew.
+- `[Direct evidence]` Wall-clock time did not fall substantially because merges and verification remained sequential and test-gated even when implementation ran in parallel.
+- `[Direct evidence]` [Co-Coder](https://arxiv.org/abs/2606.00953) builds a weighted repository dependency graph, isolates hub files, partitions the graph into communities, and schedules a group only when its dependencies finish.
+- `[Direct evidence]` Co-Coder assigns one owner per group and routes failed tests back only to implicated groups for at most ten repair iterations.
+- `[Direct evidence]` On DevEval, Co-Coder reached 68.1% at 442 seconds and $0.18, compared with 56.8% at 800 seconds and $0.25 for sequential execution.
+- `[Direct evidence]` On CodeProjectEval, Co-Coder reached 34.1% at 1,315 seconds and $0.67, compared with 20.1% at 2,756 seconds and $1.03 for sequential execution.
+- `[Direct evidence]` Across the 16 CodeProjectEval projects with nonzero pass rates, Co-Coder's absolute test-pass improvement over sequential execution correlated with dependency edge density at Pearson 0.65 and Spearman 0.60, with both p-values below 0.05.
+- `[Direct evidence]` Nearly complete coupling collapsed Co-Coder's schedule toward sequential work.
+- `[Direct evidence]` [SWARMRESEARCH](https://arxiv.org/abs/2607.02807) lets a shepherd choose a parent branch and an explorer or optimizer role while changing tree width and depth across waves of four to eight workers.
+- `[Direct evidence]` Its controlled 60-worker-call study beat the best fixed strategy on four of five tasks, while adding a separate Claude orchestrator increased total output tokens by 7.7% relative to the output tokens of the 60 worker calls alone.
+- `[Direct evidence]` The shepherd rarely merged branches and could collapse into repeatedly prescribing one approach, which limits the evidence for reliable synthesis at high width.
+- `[Cross-paper inference]` A coding orchestrator should derive concurrency from a dependency graph and coupling estimate instead of using a fixed worker count.
+- `[Cross-paper inference]` The initial concurrency ceiling should be two mutating workers because the strongest coding studies show benefits at small width and measurable degradation as width grows.
+
+## Context isolation and transfer
+
+- `[Direct evidence]` [Recursive Agent Harnesses](https://arxiv.org/abs/2606.13643) gives each worker a fresh context and isolated workspace, forbids sibling communication, and aggregates structured JSON result files.
+- `[Direct evidence]` On 199 synthetic long-context Oolong tasks, Recursive Agent Harnesses scored 81.36 versus a published Codex baseline of 71.75, a published recursive-language-model baseline of 64.38, and full-context prompting at 59.22.
+- `[Direct evidence]` The Codex result was imported from Cao et al. rather than rerun, although the paper matched its GPT-5 backbone family.
+- `[Direct evidence]` The reported 9.61-point gain interval from 4.2 to 14.8 points bootstraps only the 199 RAH per-instance scores against the fixed 71.75 baseline because the authors did not have Codex per-instance outcomes, so it is not a paired baseline interval.
+- `[Direct evidence]` The study did not instrument exact token or wall-clock cost and did not ablate context isolation, recursion depth, grouping, or spawn policy, so its aggregate gain cannot be attributed causally to context isolation.
+- `[Direct evidence]` [OrchBench](https://arxiv.org/abs/2607.25656) models orchestration as a dependency graph whose edges explicitly choose whether to retain or compress predecessor context.
+- `[Direct evidence]` In OrchBench's deterministic simulator at a 16,000-token context limit, simulated average quality was 0.423 for the modeled single-agent baseline and 0.725 for multi-agent plans.
+- `[Direct evidence]` In the same deterministic simulation at 128,000 tokens, simulated averages narrowed to 0.852 and 0.859, and the modeled single-agent baseline was better on the 10-task, 20-task, and 50-task graph sizes.
+- `[Direct evidence]` The OrchBench appendix reports that simulated multi-agent quality was lower in 82% of model-problem pairs at 128,000 tokens.
+- `[Direct evidence]` Adding one simulator-selected handoff to 20 MultiAgentBench tasks raised real-agent score from 3.754 to 4.150 out of five.
+- `[Direct evidence]` [SHEPHERD](https://arxiv.org/abs/2605.10913) reports exactly zero characters of worker-context inflation from supervisor observation and intervention in a ten-step check.
+- `[Direct evidence]` [Semantic Snapshot Isolation](https://arxiv.org/abs/2608.05412) makes prompt, model, index, tool, resource, and contract versions sticky across retries, resumes, children, and forks.
+- `[Direct evidence]` Semantic Snapshot Isolation validates the union of branch manifests before merge and extends the manifest when an open-world resource is first accessed.
+- `[Direct evidence]` At 128 resource identities and 16 branches, the prototype reported 4.6 microseconds p95 resolution and 88.2 microseconds merge validation.
+- `[Direct evidence]` The paper reproduced semantic read skew, compatibility skew, context escape, and merge skew in a controlled LangGraph and Qdrant setting and blocked all four with its protocol.
+- `[Coverage gap]` Semantic Snapshot Isolation protects semantic resource versions rather than repository writes or external effects, so it cannot replace filesystem concurrency control.
+- `[Cross-paper inference]` Every child should start from an immutable task packet and a pinned semantic manifest instead of inheriting an unbounded parent transcript.
+- `[Cross-paper inference]` Context transfer should contain only dependency outputs, relevant repository slices, constraints, and evidence references because full transcript sharing wastes context and can transfer obsolete assumptions.
+
+## Worker communication
+
+- `[Direct evidence]` [CooperBench](https://arxiv.org/abs/2601.13295) evaluates 652 paired-feature tasks across 12 libraries and four languages, with 77.3% of ground-truth feature pairs containing conflicting solutions.
+- `[Direct evidence]` CooperBench isolates two agents in separate containers and branches, allows real-time SQL-backed messaging, merges their patches, and scores exact unit tests.
+- `[Direct evidence]` Collaboration reduced average success by 30%, and GPT-5 and Claude Sonnet 4.5 agents solved about 25% cooperatively, roughly half their solo rate.
+- `[Direct evidence]` Communication reduced textual conflicts without significantly improving task success because messages were often vague, late, incorrect, or based on commitments that were not followed.
+- `[Direct evidence]` Success was associated with mutually confirmed role division, precise resource or line boundaries, and explicit negotiation.
+- `[Direct evidence]` Scaling a 46-task subset from two to three to four agents reduced success from 68.6% to 46.5% to 30.0%.
+- `[Direct evidence]` [STORM](https://arxiv.org/abs/2605.20563) avoids direct peer messaging and instead uses manager-owned decomposition plus structured intent annotations in code comments.
+- `[Direct evidence]` [MASAI](https://arxiv.org/abs/2406.11638) coordinates five fixed roles through structured inputs and outputs rather than free-form conversations.
+- `[Cross-paper inference]` Workers should communicate through typed artifacts and manager-mediated clarification requests by default, while peer chat should be an admitted exception with a stated coordination purpose.
+- `[Cross-paper inference]` A handoff should identify producer, consumer, base state, changed assumptions, patch or artifact digest, verification evidence, and known limitations.
+
+## Workspace isolation, stale state, and integration
+
+- `[Direct evidence]` The asynchronous SWE-agent system gives every engineer a Git worktree and branch, integrates through one main branch, and asks a conflicting worker to pull the latest main state, resolve, and resubmit.
+- `[Direct evidence]` With Claude Sonnet on PaperBench, worktrees scored 63.3 versus 57.2 for one agent and 55.5 for instruction-only soft isolation.
+- `[Direct evidence]` On Commit0, worktrees scored 59.1 versus 53.1 for one agent and 56.1 for soft isolation.
+- `[Direct evidence]` [STORM](https://arxiv.org/abs/2605.20563) instead uses a shared workspace in which every file has a monotonic version and every read records the complete observed version set.
+- `[Direct evidence]` STORM accepts a write only when the target and all read dependencies remain unchanged, otherwise returning the current target, a unified diff, and the stale dependency versions.
+- `[Direct evidence]` STORM adds a reservation of up to 30 seconds after rejection to prevent workers from repeatedly invalidating each other.
+- `[Direct evidence]` On Commit0 with Claude Sonnet, STORM scored 82.5 macro and 46.2 weighted, compared with 66.4 and 20.7 for one agent and 63.8 and 24.6 for Git worktrees.
+- `[Direct evidence]` On PaperBench with Claude Sonnet, STORM scored 74.1 versus 72.7 for Git worktrees and 68.7 for one agent.
+- `[Direct evidence]` Git worktrees still won on a task whose decomposition aligned with file boundaries, scoring 98.2 on sample-specific-masks versus 72.8 for STORM.
+- `[Direct evidence]` STORM's high-coupling Sonnet stratum scored 70.9 versus 36.3 for worktrees and 59.5 for one agent, although the coupling labels were proxy-derived.
+- `[Direct evidence]` [CoAgent](https://arxiv.org/abs/2606.15376) assigns a transaction order at launch, requires tools to declare read and write footprints plus inverse actions, and gives reads order-filtered values.
+- `[Direct evidence]` CoAgent notifies a higher-order reader when a late lower-order write invalidates its premise, after which the reader judges relevance and selectively repairs.
+- `[Direct evidence]` CoAgent undoes and replays misordered invertible writes and delays non-invertible writes until earlier transactions commit.
+- `[Direct evidence]` In 100 trials over ten contended task pairs, serial execution achieved 98% correctness, naive parallelism 13%, two-phase locking 96%, optimistic concurrency control 93%, and CoAgent 93%.
+- `[Direct evidence]` Relative to serial execution, naive parallelism achieved 1.54 times speed at 1.06 times cost, while CoAgent achieved 1.43 times speed at 1.15 times cost.
+- `[Direct evidence]` CoAgent's five failures came from agents misjudging notification relevance, which exposes an unsafe semantic decision inside an otherwise mechanical protocol.
+- `[Direct evidence]` [Claim Plane](https://arxiv.org/abs/2607.21909) binds a versioned change intent to an exact base commit, declared operations, dependencies, preservation policy, tests, lease, and fencing token.
+- `[Direct evidence]` Claim Plane fails closed on unknown overlap and permits same-file parallel work only for declared disjoint regions followed by final hunk verification.
+- `[Direct evidence]` Its integration applies immutable patch digests in producer-first order and invalidates dependent consumers transitively when a premise changes.
+- `[Direct evidence]` In a preliminary six-pair, one-seed CooperBench study, static Claim Plane passed all six pairs by serializing all six, dynamic Claim Plane passed three pairs before integration and four after integration while serializing three, and naive execution passed two before and three after integration.
+- `[Direct evidence]` The Claim Plane authors state that the sample is too small for comparative performance claims and that its Python-first broker can be bypassed outside enforcement boundaries.
+- `[Cross-paper inference]` Worktrees and versioned premises solve different problems, so mutating workers should receive worktree isolation while their outputs also carry read-set or base-state versions checked at integration.
+- `[Cross-paper inference]` One integration controller should own the canonical branch and reject late patches whose base commit, semantic manifest, dependency output, or acceptance tests have changed.
+- `[Cross-paper inference]` A rejected stale result should be quarantined as evidence for replanning rather than silently rebased or merged.
+
+## Independent verification and completion gates
+
+- `[Direct evidence]` MASAI independently generates a reproduction test, produces five candidate patches, and ranks candidates using the reproduction result.
+- `[Direct evidence]` On SWE-bench Lite with GPT-4o, MASAI resolved 28.33%, localized 75%, cost $1.96 on average, and achieved the 95.33% patch-application rate reported in its main results table.
+- `[Direct evidence]` MASAI's five-candidate oracle reached 35%, a random candidate reached 22.28%, and ranking with the independently generated reproduction test reached 28.33%.
+- `[Direct evidence]` The asynchronous SWE-agent study found that manager review scored 60.2% at 3,689.1 seconds, worker self-verification scored 55.1% at 2,243.9 seconds, and an efficiency-focused prompt scored 54.0% at 1,908.6 seconds.
+- `[Direct evidence]` [Proof-or-Stop](https://arxiv.org/abs/2607.14890) accepts completion evidence only when freshness, completeness, integrity, producer authorization, execution attestation, support, and outcome acceptance all hold.
+- `[Direct evidence]` Proof-or-Stop binds receipts to material, head, story-file, policy, and command-set hashes plus the command, arguments, working directory, exit status, and output digest.
+- `[Direct evidence]` Its done transition requires a full test or build receipt for the current tree, and its merge transition uses compare-and-swap checks for both source and target heads.
+- `[Direct evidence]` Across ten engine scenarios and 18 tamper classes, Proof-or-Stop reported zero false completion states and zero false accepts.
+- `[Direct evidence]` In a 9,240-cell ablation, a naive loop produced 31 visible-pass and hidden-fail amplifications per 1,800 cells, an advisory reviewer produced 14, and the gated protocol produced two.
+- `[Direct evidence]` Bounded reflection retries stop or escalate when their budget expires instead of converting uncertainty into a successful completion state.
+- `[Cross-paper inference]` Verification should run in a fresh context against the exact integrated tree and should consume claims plus evidence rather than the worker's persuasive narrative.
+- `[Cross-paper inference]` Acceptance should require current-tree tests, patch integrity, scope compliance, and a verifier verdict, with no worker permitted to mark its own integrated result complete.
+
+## Least privilege
+
+- `[Direct evidence]` [ClawArena-Team](https://arxiv.org/abs/2606.31174) lets a manager choose each worker's system prompt, model modality, tool subset, path whitelist, foreground or background mode, and new or resumed session.
+- `[Direct evidence]` Every evaluated model in ClawArena-Team had workspace-permission precision below 50%, with granted paths approximately twice the paths actually needed.
+- `[Direct evidence]` Read-only compliance and modality-choice accuracy were each at least 92% for the eleven capable ClawArena-Team models, while tool-permission precision was roughly 70% to 80%.
+- `[Direct evidence]` ClawArena-Team reports that managers retained stale beliefs across staged updates by advancing before rewriting an earlier deliverable or otherwise carrying obsolete state into later work.
+- `[Direct evidence]` This reported failure concerns manager beliefs and deliverable revision rather than demonstrated failure to deliver staged files to active workers.
+- `[Direct evidence]` [SkillScope](https://arxiv.org/abs/2605.05868) constructs a graph of instruction and code actions, removes candidate actions by replay, and patches control flow so an action is reachable only under a task-conditioned condition.
+- `[Direct evidence]` On 200 manually annotated skills, SkillScope reported 94.53% F1 for identifying task-conditioned privilege needs.
+- `[Direct evidence]` Across 68,312 valid real-world skills, SkillScope validated 7,039 as over-privileged and reduced triggered over-privileged action-task instances by 88.56% while preserving all evaluated legitimate tasks.
+- `[Coverage gap]` SkillScope evaluates reusable skills rather than repository-editing subagents, so its results support task-conditioned capabilities but not a specific coding-agent sandbox policy.
+- `[Cross-paper inference]` Every task packet should carry an expiring capability grant for exact repository paths, tools, command classes, network destinations, and external side effects.
+- `[Cross-paper inference]` Capability expansion should require re-admission against the current task version, while unused grants should be measurable as permission-precision failures.
+
+## Cancellation, retries, and lifecycle control
+
+- `[Direct evidence]` SHEPHERD models tasks, effects, and scopes as typed objects and records execution in an immutable Git-like trace.
+- `[Direct evidence]` Its supervisor can inject guidance, hand work to another agent, or discard a stuck worker without adding supervisor text to the worker context.
+- `[Direct evidence]` A scope fork atomically copies agent and environment state, a discard restores the byte-identical parent, reversible effects roll back, compensable effects call handlers, and irreversible effects remain audited.
+- `[Direct evidence]` Fork and revert for a 5.8-gigabyte image took 143 and 147 milliseconds, compared with 725 and 828 milliseconds for Docker commit and 53.5 and 25.9 seconds for a full copy.
+- `[Direct evidence]` SHEPHERD reported about 95% cache hits beginning at two concurrent branches.
+- `[Direct evidence]` On 479 CooperBench pairs with Claude Haiku 4.5 workers, cooperation scored 28.8%, solo execution 57.2%, a Sonnet supervisor 45.3%, and an Opus supervisor 54.7%.
+- `[Direct evidence]` The Opus supervisor closed 91% of the gap between unsupervised cooperation and solo execution, while wall-clock time was 24.18 minutes versus 28.43 minutes for solo execution.
+- `[Direct evidence]` SHEPHERD cannot roll back irreversible external effects and depends on the sandbox backend for several guarantees.
+- `[Direct evidence]` The asynchronous SWE-agent system stops when all work is integrated or a maximum round or iteration limit is reached, and it removes worker worktrees on completion or exhaustion.
+- `[Direct evidence]` Proof-or-Stop distinguishes bounded retry from successful completion and uses current-state receipts to prevent an older passing run from proving a changed tree.
+- `[Coverage gap]` The reviewed coding-agent studies rarely measure cancellation propagation latency, leaked subprocesses, late-result rejection, or partial external-effect compensation under injected failures.
+- `[Cross-paper inference]` Cancellation should form a tree rooted at the user request, and every child result should carry a generation token that makes output from a cancelled or replaced generation inadmissible.
+- `[Cross-paper inference]` Retry policy should distinguish transient tool failure, stale premise, integration conflict, verifier failure, and budget exhaustion because each class requires a different recovery action.
+- `[Cross-paper inference]` A retry should inherit immutable task intent and semantic versions but should not inherit hidden mutable workspace state or an unbounded failed transcript.
+
+## Observability and replay
+
+- `[Direct evidence]` SHEPHERD records task state, effects, scopes, evidence, and supervisory interventions in an immutable trace.
+- `[Direct evidence]` Its local record overhead was 3.1 milliseconds per event, about 5%, while remote recording was 113 milliseconds per event, about 87% and mostly attributable to network cost.
+- `[Direct evidence]` Claim Plane records exact base commits, intent versions, capability leases, fencing tokens, immutable patches, and integration order.
+- `[Direct evidence]` Proof-or-Stop records evidence digests and execution receipts that can be rechecked against the current material state.
+- `[Direct evidence]` ClawArena-Team measures permission selection, forbidden operations, workflow topology, communication behavior, and staged-update handling rather than final success alone.
+- `[Cross-paper inference]` The orchestrator should emit an append-only event stream for admission, dispatch, context manifest, capability grant, tool effect, handoff, stale rejection, cancellation, integration, verification, retry, and terminal state.
+- `[Cross-paper inference]` Every event should include task ID, parent ID, generation, base commit, semantic-manifest digest, capability digest, monotonic timestamp, and causal predecessor IDs.
+- `[Cross-paper inference]` Replay should reconstruct why a worker was admitted, what it knew, what it could touch, which evidence supported integration, and why a result was accepted or rejected.
+
+## Contrary findings and cases where one agent wins
+
+- `[Direct evidence]` On 30 human-annotated MAST software tasks, Gemini 2.5 Pro single-agent outputs passed 24 tasks under the MAST rubric, while the multi-agent comparisons used stored ChatDev and MetaGPT traces supplied by the MAST repository.
+- `[Direct evidence]` Within that comparison, the Gemini single-agent outputs won 15 tasks and lost one against ChatDev traces, while they won 13 and lost none against MetaGPT traces.
+- `[Coverage gap]` This 30-task analysis did not match models or harnesses between conditions and does not report repeated runs, so it is not a controlled same-model estimate of single-agent advantage.
+- `[Direct evidence]` Adding more debate agents often failed to improve accuracy, and summarization damaged weaker models more than concatenation.
+- `[Paper-author interpretation]` The authors of The Illusion of Multi-Agent Advantage interpret their activation patterns and cost results as role redundancy, functional collapse, and architecture bloat that often degenerates into expensive self-consistency.
+- `[Direct evidence]` STORM reported the single agent as the most cost-efficient method across all tested models because it paid no coordination overhead.
+- `[Direct evidence]` CooperBench showed that isolated branches plus communication can still halve success relative to solo work when features interact semantically.
+- `[Direct evidence]` The asynchronous SWE-agent study found that a single-first fallback followed by multi-agent retry largely wasted cost and time, which contrasts with cascades that possess a cheap exact checker.
+- `[Direct evidence]` OrchBench's deterministic simulation found that the modeled multi-agent quality advantage nearly disappeared at a 128,000-token context limit and reversed for the 10-task, 20-task, and 50-task graph sizes.
+- `[Direct evidence]` Co-Coder found that near-complete coupling removes available parallelism and collapses its schedule toward sequential execution.
+- `[Cross-paper inference]` A single agent is favored when the task fits comfortably in context, edits are tightly coupled, correctness is hard to partition, coordination artifacts would exceed useful work, or no independent verifier exists.
+
+## Cross-paper architecture synthesis
+
+- `[Cross-paper inference]` The architecture should contain a router, an orchestrator, at most two initial workers, an integration controller, a capability broker, an evidence store, and a fresh-context verifier.
+- `[Cross-paper inference]` The router should select among direct single-agent execution, single-agent execution with verification, and admitted parallel delegation.
+- `[Cross-paper inference]` The orchestrator should construct a versioned dependency graph over cohesive change units and should serialize units with dense shared assumptions or overlapping ownership.
+- `[Cross-paper inference]` Each mutating worker should receive an isolated worktree, while read-only investigators can share a read-only repository snapshot.
+- `[Cross-paper inference]` Every worker should receive one immutable task packet containing objective, non-goals, base commit, dependency versions, allowed paths, allowed tools, acceptance checks, resource budget, and cancellation generation.
+- `[Cross-paper inference]` Workers should return typed artifacts containing status, patch digest, files touched, assumptions, commands run, evidence digests, unresolved risks, and requested follow-up.
+- `[Cross-paper inference]` The integration controller should be the only component allowed to update the canonical branch and should integrate in dependency order.
+- `[Cross-paper inference]` Integration should fail closed when a patch exceeds scope, its base or semantic manifest is stale, a dependency changed, verification evidence is missing, or the exact patch cannot be reproduced.
+- `[Cross-paper inference]` The verifier should inspect the integrated state independently and should be able to accept, request bounded rework, or reject without changing the implementation itself.
+- `[Cross-paper inference]` The capability broker should issue short-lived, task-version-bound grants and should mediate every mutable repository or external effect that the platform can enforce.
+- `[Cross-paper inference]` Cancellation should invalidate the generation before signalling workers so that late completions cannot race into integration.
+- `[Cross-paper inference]` Observability should be part of correctness because stale-state rejection, permission precision, evidence freshness, and cancellation behavior cannot be evaluated from final patches alone.
+
+## Minimal experimentally testable architecture
+
+This section defines a falsifiable experimental system rather than an implementation sequence.
+
+- The system has one router-orchestrator, no more than two concurrent mutating workers, one integration controller, and one fresh-context verifier.
+- The router first predicts whether direct execution, verified direct execution, or two-worker execution will maximize expected verified success under a fixed cost and latency budget.
+- The orchestrator emits a two-level dependency graph whose nodes have one owner and whose edges name the exact artifact or premise transferred.
+- A worker receives a fresh context, a worktree rooted at an exact commit, a semantic manifest, a scoped capability grant, a deadline, and a cancellation generation.
+- Workers cannot message each other directly in the minimal system and can only return a typed result or request manager-mediated clarification.
+- The integration controller checks base commit, read-set or dependency versions, capability compliance, patch digest, declared file scope, and worker evidence before applying a patch.
+- The verifier receives the objective, acceptance criteria, integrated tree, and evidence receipts without receiving the worker's hidden reasoning or persuasive summary.
+- The verifier can produce only `accept`, `rework` with machine-readable findings, or `reject`, and rework is limited to one retry per node.
+- The lifecycle state machine is `proposed`, `admitted`, `running`, `result_pending`, `integrating`, `verifying`, and one of `accepted`, `rework`, `cancelled`, `stale`, or `failed`.
+- A cancellation increments the task generation, revokes grants, signals live workers, and makes every later result from the old generation ineligible for integration.
+- The experiment forbids recursive grandchildren so that delegation policy, concurrency, and verification effects can be measured without tree-depth confounding.
+- The proposed architecture is supported only if it improves verified success or Pareto efficiency over strong single-agent, equal-budget sampling, naive parallel, and fixed-worktree baselines.
+
+## Evaluation methodology
+
+- `[Direct evidence]` OrchBench reports simulator-to-real quality correlations of Pearson 0.816 with p equal to 0.047 and Spearman 0.771, while simulated time and token estimates did not correlate reliably with real execution.
+- `[Direct evidence]` OrchBench simulation used about 1.3% of real-agent tokens and 10.3% of real-agent wall time in aggregate, but its task decomposition was supplied rather than discovered.
+- `[Direct evidence]` [OrchestraBench](https://arxiv.org/abs/2608.05263) uses 26 aligned and adversarial routing cases and found 23% accuracy for fixed routing, 62% for a flag heuristic, 92% for TF-IDF description matching, and 100% for an LLM router.
+- `[Direct evidence]` OrchestraBench's flag heuristic scored 100% on aligned cases and 0% on adversarial cases, demonstrating that ordinary success cases can hide routing brittleness.
+- `[Direct evidence]` In 30 real Claude Sonnet trials per arithmetic failure mode, tool failure recovered at 100%, ambiguous failure at 30%, and context pollution, conflicting state, and premature success at 0%.
+- `[Direct evidence]` OrchestraBench is a staged single-agent mechanism probe rather than a literal concurrent multi-agent system, so its results motivate failure injection without proving production recovery rates.
+- `[Cross-paper inference]` Evaluation should compare a strong single agent, equal-budget best-of-N or self-consistency, naive parallel workers, fixed worktree workers, and the proposed architecture.
+- `[Cross-paper inference]` All methods should use the same base model, tool set, starting repository state, aggregate token or dollar cap, wall-clock cap, and retry allowance.
+- `[Cross-paper inference]` The task suite should stratify independent edits, moderate coupling, dense coupling, context overflow, staged upstream changes, and injected worker or tool failures.
+- `[Cross-paper inference]` Each condition should use repeated seeds and paired task comparisons with confidence intervals rather than one best run.
+- `[Cross-paper inference]` Primary outcomes should be hidden-test success, accepted-task rate, cost, wall-clock time, and verified success per dollar.
+- `[Cross-paper inference]` Coordination outcomes should include unnecessary delegation, handoff coverage, conflict rate, stale-result rejection, integration rework, duplicate work, and worker-count utilization.
+- `[Cross-paper inference]` Safety outcomes should include permission precision and recall, out-of-scope write attempts, forbidden effects, evidence freshness, false completion, cancellation latency, leaked processes, and accepted late results.
+- `[Cross-paper inference]` Reliability outcomes should separately inject transient tool failure, worker crash, timeout, stale dependency, merge conflict, verifier disagreement, and orchestrator cancellation.
+- `[Cross-paper inference]` Required ablations should remove the router, dependency graph, typed handoff, worktree isolation, version checks, independent verifier, scoped capabilities, and generation-based cancellation one at a time.
+- `[Cross-paper inference]` The architecture should be rejected for a task stratum when its confidence interval does not beat the strongest simpler baseline or when its gain requires materially worse safety.
+
+## Traceability matrix
+
+| ID | Design decision | Primary paper evidence | Evidence status |
+| --- | --- | --- | --- |
+| D1 | Default to one agent and admit delegation conditionally. | The hybrid study found about 80% outcome agreement, large multi-agent token inflation, and routing or cascade gains only under identifiable difficulty or cheap checking, while the Illusion study found broad losses to equal-sample self-consistency. | Direct evidence supports the premise, while the exact admission rule is a cross-paper inference. |
+| D2 | Cap the first experiment at two concurrent mutating workers. | CAID degraded at eight workers, CooperBench fell from 68.6% with two agents to 30.0% with four, and Co-Coder collapsed toward sequential work under dense coupling. | The cap is a conservative cross-paper inference. |
+| D3 | Schedule only dependency-ready cohesive work units. | CAID dispatches ready dependency-graph nodes, and Co-Coder uses repository dependency communities with one owner per group. | Direct mechanism evidence supports this decision. |
+| D4 | Give workers fresh bounded context plus explicit dependency artifacts. | Recursive Agent Harnesses combines fresh worker contexts with several other harness changes without a component ablation, OrchBench's deterministic simulator models selected context transfers, and Semantic Snapshot Isolation pins resource versions across branches. | The component mechanisms are direct evidence, while their effectiveness as one decision is inferred. |
+| D5 | Prefer typed manager-mediated handoffs over free-form peer chat. | CooperBench found that communication reduced textual conflicts without significant success gains, while MASAI and STORM coordinate through structured artifacts. | Direct evidence supports the risk and alternatives. |
+| D6 | Use worktrees for mutating workers and version checks for their premises. | CAID found worktrees better than soft isolation, while STORM found versioned shared state better than worktrees on coupled tasks and CoAgent exposed stale-read hazards. | The combined defense is a cross-paper inference from contrary isolation results. |
+| D7 | Make one integration controller own the canonical branch. | CAID and STORM centralize merge or commit responsibility, while Claim Plane applies exact verified patches in dependency order. | Direct mechanism evidence supports this decision. |
+| D8 | Reject stale outputs instead of silently merging them. | STORM validates complete read versions, Claim Plane propagates dependency invalidation, CoAgent repairs ordering violations, and Proof-or-Stop binds evidence to current hashes. | Direct evidence strongly supports this decision. |
+| D9 | Verify the exact integrated state in a fresh context. | MASAI improves candidate selection with independent reproduction tests, CAID manager review beats self-verification, and Proof-or-Stop reduces false completion with current-state evidence gates. | Direct evidence supports independent evidence, while fresh-context isolation is inferred. |
+| D10 | Bind least-privilege grants to task and version. | ClawArena-Team exposes low path-permission precision, SkillScope reduces triggered over-privileged actions by 88.56%, and Claim Plane binds capabilities to intent versions and leases. | Direct evidence supports the controls, while the coding-agent grant schema is inferred. |
+| D11 | Use generation-based cancellation and quarantine late results. | SHEPHERD demonstrates typed discard and rollback, Proof-or-Stop rejects stale receipts, and ClawArena-Team shows that managers can retain stale beliefs or leave earlier deliverables unrevised after staged updates. | Cancellation propagation remains a coverage gap, so this decision is primarily inferred. |
+| D12 | Classify retries by failure cause and bound them. | Proof-or-Stop uses bounded reflection and fail-closed stopping, while CoAgent distinguishes repairable order violations from delayed non-invertible effects. | Direct evidence supports bounded and typed recovery, while the proposed taxonomy is inferred. |
+| D13 | Record causal, capability, state, and evidence events. | SHEPHERD supplies immutable execution traces, Claim Plane records provenance and fencing, and Proof-or-Stop records command and digest receipts. | Direct mechanism evidence supports this decision. |
+| D14 | Evaluate against strong single-agent and equal-budget baselines under failure injection. | The Illusion study shows weak baselines can create false multi-agent gains, OrchBench shows simulator limits, and OrchestraBench shows aligned cases can conceal adversarial routing and recovery failures. | Direct evidence strongly supports this methodology. |
+
+## Unresolved research questions
+
+- `[Coverage gap]` No reviewed study jointly evaluates dynamic routing, worktree isolation, semantic-version pinning, least privilege, cancellation, and independent verification in one coding-agent system.
+- `[Coverage gap]` The best online predictor of task coupling remains unknown because file overlap, dependency density, edit locality, and semantic contract overlap have not been compared prospectively.
+- `[Coverage gap]` It is unknown whether an orchestrator can predict the value of delegation accurately enough to beat a cheap single-agent-first cascade on open-ended repository tasks.
+- `[Coverage gap]` The optimal boundary between shared versioned state and isolated worktrees remains unresolved because CAID and STORM compare different shared-state protections.
+- `[Coverage gap]` No strong evidence establishes when direct peer communication adds value beyond typed artifacts and manager-mediated clarification.
+- `[Coverage gap]` The reviewed papers do not quantify how much context a child needs to preserve architectural invariants without inheriting distracting parent history.
+- `[Coverage gap]` Semantic Snapshot Isolation has not been tested together with mutable repository state, changing tests, or evolving tool implementations during a coding task.
+- `[Coverage gap]` Cancellation studies do not yet report propagation latency, subprocess leakage, irreversible effect exposure, or acceptance of late results under adversarial timing.
+- `[Coverage gap]` Retry studies rarely distinguish transient infrastructure failures from deterministic reasoning failures, stale premises, and integration conflicts.
+- `[Coverage gap]` Least-privilege studies do not yet measure whether narrower grants reduce coding success or merely increase capability-expansion requests.
+- `[Coverage gap]` Independent verification can share model blind spots with implementation workers, and the value of model diversity versus fresh context alone remains uncertain.
+- `[Coverage gap]` Repository benchmarks rarely include concurrent upstream edits, branch replacement, user cancellation, or tool-version drift despite their importance in interactive coding agents.
+- `[Coverage gap]` Multi-agent evaluations need standardized reporting for total tokens, peak concurrency, wall-clock critical path, failed worker cost, integration cost, and verifier cost.
+- `[Coverage gap]` The relationship between simulator-selected orchestration and real end-to-end reliability remains uncertain because quality correlations are promising but timing and token fidelity are weak.
+
+## Conclusion
+
+- `[Cross-paper inference]` The literature does not support unconditional subagent use, fixed wide teams, free-form peer chat, or worktrees as a complete concurrency solution.
+- `[Cross-paper inference]` The combined evidence supports conditional routing, dependency-aware decomposition, small bounded concurrency, structured artifacts, explicit state validation, centralized integration, and evidence-bound verification.
+- `[Cross-paper inference]` A coding agent should treat each subagent as a speculative, scoped, cancellable producer whose output is only a claim until the current integrated state independently verifies it.
+- `[Cross-paper inference]` The proposed minimal architecture is intentionally small so its routing, isolation, stale-state, privilege, cancellation, and verification mechanisms can be falsified independently before recursive or high-width delegation is considered.

--- a/docs/research/2026-08-10-coding-agent-subagents-arxiv-survey.md
+++ b/docs/research/2026-08-10-coding-agent-subagents-arxiv-survey.md
@@ -1,0 +1,163 @@
+# Coding-Agent Subagents and Multi-Agent Orchestration on arXiv
+
+## Methodology and scope
+
+This survey covers recent arXiv literature on subagents for coding agents, hierarchical or multi-agent software-engineering systems, delegation and planning, and agent orchestration.
+The literature search used the AlphaXiv MCP `discover_papers` tool as the required primary discovery source.
+Paper metadata, architecture claims, evaluation results, and limitations were checked against paper text retrieved through the AlphaXiv MCP `answer_pdf_queries` tool.
+The search prioritized recent work and included earlier repository-level systems when they provided direct evidence about explicit software-engineering subagents.
+The research cutoff is 2026-08-10.
+The selected papers are divided by whether they explicitly implement identifiable subagents or instead evaluate broader multi-agent teams, orchestration plans, or pipeline behavior.
+An explicit subagent system must name subordinate agents or workers and define how a parent, manager, orchestrator, or fixed composition delegates work to them.
+A broader multi-agent system may coordinate several agents or evaluate orchestration without implementing runtime parent-to-subagent delegation.
+The newest 2026 papers are recent preprints, so their results should be treated as preliminary until they receive broader replication.
+
+## Explicit subagent systems
+
+### Recursive Agent Harnesses
+
+- **Title:** Recursive Agent Harnesses.
+- **arXiv:** [2606.13643](https://arxiv.org/abs/2606.13643).
+- **Date:** 2026-06-11.
+- **Classification:** This is an explicit, dynamic, and recursive subagent system.
+- **Approach:** A parent coding agent writes and executes orchestration code that launches parallel subagents as complete agent harnesses with planning, filesystem tools, code execution, and isolated contexts.
+- **Approach:** Small workloads use structured `Task` calls, while large workloads use generated asynchronous scripts that can launch thousands of subagent harnesses without a per-turn tool-call limit.
+- **Approach:** Each subagent can use the same spawning capability to create grandchildren, with recursion bounded by a configurable depth limit whose default is three.
+- **Evaluation:** On 199 Oolong-Synthetic instances spanning 13 context-length buckets from 1K to 4M tokens, GPT-5 RAH scored 81.36 percent.
+- **Evaluation:** The same-model Codex-style coding-agent baseline scored 71.75 percent, giving RAH a gain of 9.61 percentage points with a reported 95 percent bootstrap confidence interval of 4.2 to 14.8 points.
+- **Evaluation:** The recursive-language-model baseline scored 64.38 percent, while the same RAH design reached 89.77 percent with Claude Sonnet 4.5.
+- **Limitation:** The evaluation measures long-context aggregation rather than repository issue resolution or general software development.
+- **Limitation:** Exact token and wall-clock profiles were not instrumented, and the paper did not ablate recursion depth, entries per subagent, or script-based spawning against tool-call spawning.
+- **Implication:** Recursing over complete tool-bearing harnesses can outperform both a single coding harness and recursion over bare model calls when independent evidence exceeds one context window.
+
+### ClawArena-Team: Benchmarking Subagent Orchestration and Dynamic Workflows in Language-Model Agents
+
+- **Title:** ClawArena-Team: Benchmarking Subagent Orchestration and Dynamic Workflows in Language-Model Agents.
+- **arXiv:** [2606.31174](https://arxiv.org/abs/2606.31174).
+- **Date:** First posted 2026-06-30, with the queried v2 PDF dated 2026-07-02.
+- **Classification:** This is an explicit runtime manager-to-subagent benchmark.
+- **Approach:** A text-only main agent creates and configures LLM, vision, or multimodal subagents from a fixed locally served worker pool.
+- **Approach:** The manager chooses tools, workspace paths, foreground or background execution, session reuse, and JavaScript-style parallel or pipeline workflows.
+- **Approach:** The worker pool remains fixed across runs so score differences isolate the main model's management ability rather than worker capability.
+- **Evaluation:** The benchmark contains 41 multimodal and multi-directory scenarios, 258 evaluation rounds, and 72 staged workspace updates.
+- **Evaluation:** Among 12 manager models, the best run achieved a 60.0 percent Subagent-Management Score and a 74.4 percent task-completion rate.
+- **Evaluation:** No evaluated manager exceeded 50 percent workspace-permission precision, which means workers were routinely granted about twice the files they actually accessed.
+- **Evaluation:** Main-agent API cost varied by more than 100 times, while the overall management score varied by less than four times.
+- **Evaluation:** Ten middle-ranked models occupied a narrow 43.9 to 53.8 percent score band even though their forbidden-access rates and workflow behavior differed by more than an order of magnitude.
+- **Limitation:** The fixed worker pool couples the findings to one particular worker capability level.
+- **Limitation:** The 41-scenario sample is modest, and execution-based checks can under-reward correct conditional reasoning that does not match the expected artifact form.
+- **Implication:** Subagent benchmarks should score least-privilege delegation, modality routing, scheduling, and state integration rather than final task correctness alone.
+
+### SWARMRESEARCH: Orchestrating Coding Agents for Open-Ended Discovery
+
+- **Title:** SWARMRESEARCH: Orchestrating Coding Agents for Open-Ended Discovery.
+- **arXiv:** [2607.02807](https://arxiv.org/abs/2607.02807).
+- **Date:** 2026-07-02.
+- **Classification:** This is an explicit dynamic orchestrator-to-coding-subagent system.
+- **Approach:** A Shepherd Agent maintains global search context and spawns Explorer or Optimizer Search Agents in isolated Git branches and worktrees.
+- **Approach:** Explorer agents receive fresh contexts to pursue different high-level approaches, while Optimizer agents inherit a parent's conversation history to continue a promising lineage.
+- **Approach:** The Shepherd controls parent-branch selection, subagent type, prompts, and the balance between parallel breadth and serial depth.
+- **Evaluation:** Across 15 open-ended mathematics, systems, and heuristic optimization tasks, SWARMRESEARCH exceeded or matched the EvoX and CORAL comparison methods on 13 tasks.
+- **Evaluation:** In a controlled 60-iteration study, orchestrator-guided scaling beat the best tested fixed serial-and-parallel configuration on four of five tasks.
+- **Evaluation:** In the speculative-decoding case study, the discovered implementation produced 4.58 times the vanilla token throughput, compared with 1.80 times for autoresearch and 2.26 times for CORAL after similar elapsed time.
+- **Evaluation:** The orchestrator added only 7.7 percent output tokens over the 60 subagent calls in the controlled scaling study.
+- **Limitation:** The primary 15-task comparison used one long run per method and task because repeated runs were prohibitively expensive.
+- **Limitation:** SWARMRESEARCH and CORAL each received a 50-dollar budget per task, baseline model choices were not fully matched, and performance had not converged when the budget ended.
+- **Implication:** A manager can improve coding exploration by controlling context lineage and preserving alternative program states instead of letting peer agents converge on the current best branch.
+
+### MAGIS: LLM-Based Multi-Agent Framework for GitHub Issue Resolution
+
+- **Title:** MAGIS: LLM-Based Multi-Agent Framework for GitHub Issue Resolution.
+- **arXiv:** [2403.17927](https://arxiv.org/abs/2403.17927).
+- **Date:** First posted 2024-03-27, with the queried v2 PDF dated 2024-06-27.
+- **Classification:** This is an explicit hierarchical software-engineering subagent system.
+- **Approach:** A Repository Custodian localizes candidate files, and a Manager decomposes the issue into tasks and creates a matching team of Developer agents.
+- **Approach:** Developers implement assigned changes, while a Quality Assurance Engineer reviews each change and can request revisions before integration.
+- **Evaluation:** On the paper's 25 percent SWE-bench subset, MAGIS resolved 13.94 percent of issues and applied patches successfully in 97.39 percent of cases.
+- **Evaluation:** Direct GPT-4 resolved 1.74 percent on the same comparison, so MAGIS reported roughly an eight-fold resolution improvement.
+- **Evaluation:** Removing both QA and pull-request hints reduced resolution to 8.71 percent, while removing only QA produced 10.63 percent and removing only hints produced 10.28 percent.
+- **Limitation:** The experiment used an early SWE-bench subset rather than the later SWE-bench Lite or Verified protocols.
+- **Limitation:** The headline configuration used pull-request hints, and the paper did not report a detailed cost comparison in the queried evaluation text.
+- **Implication:** Repository localization, manager-authored task decomposition, delegated editing, and review can materially outperform direct model application, but auxiliary information affects the measured gain.
+
+### MASAI: Modular Architecture for Software-engineering AI Agents
+
+- **Title:** MASAI: Modular Architecture for Software-engineering AI Agents.
+- **arXiv:** [2406.11638](https://arxiv.org/abs/2406.11638).
+- **Date:** 2024-06-17.
+- **Classification:** This explicitly implements subagents, but they form a fixed non-recursive pipeline rather than a runtime manager-created hierarchy.
+- **Approach:** Five named subagents handle test-template generation, issue reproduction, edit localization, candidate patch generation, and patch ranking.
+- **Approach:** Each subagent has its own objective, tools, inputs, outputs, and reasoning strategy, and agents communicate by passing structured outputs rather than by open-ended conversation.
+- **Evaluation:** On 300 SWE-bench Lite issues, MASAI resolved 28.33 percent, tying CodeR for the best reported resolution rate in the paper's comparison.
+- **Evaluation:** MASAI localized all ground-truth patch files in 75.0 percent of cases and generated applicable patches in 95.33 percent of cases.
+- **Evaluation:** The average inference cost was 1.96 dollars per issue.
+- **Evaluation:** Its reproduction-test-aware ranker selected from five candidate patches to reach 28.33 percent, compared with 23.33 percent for selection without the generated test.
+- **Limitation:** The architecture is predetermined, so it does not test whether a manager can choose the number, roles, topology, or recursion depth of subagents at runtime.
+- **Limitation:** The results use the older SWE-bench Lite benchmark and GPT-4o throughout the pipeline.
+- **Implication:** Specialized short trajectories and machine-executed test feedback can make a fixed subagent pipeline effective even without adaptive orchestration.
+
+## Broader multi-agent orchestration systems and benchmarks
+
+### An Empirical Study of Coordination Mode as the First-Class Citizen in From-Scratch Multi-Agent Coding
+
+- **Title:** An Empirical Study of Coordination Mode as the First-Class Citizen in From-Scratch Multi-Agent Coding.
+- **arXiv:** [2607.27877](https://arxiv.org/abs/2607.27877).
+- **Date:** 2026-07-30.
+- **Classification:** This is a broader fixed-team multi-agent coding study rather than a general parent-to-subagent system.
+- **Approach:** MSEval combines ten real full-stack project specifications with ten four-agent collaboration topologies, including feature squads, layer specialists, pipelines, swarming, rotation, project-manager oversight, QA-first work, open-source review, adversarial testing, and competing teams.
+- **Approach:** LegoGent provides isolated resumable agent processes, periodic status synchronization, targeted peer messages, shared repositories, and CI/CD deployment.
+- **Approach:** TAgent evaluates deployed UI, API, and code behavior against weighted deterministic requirements and returns evidence for up to three repair rounds.
+- **Evaluation:** Holding tasks and models fixed, changing coordination topology shifted functional scores by more than 30 points and could double wall-clock time.
+- **Evaluation:** On the instant-messaging project, DeepSeek v4 Pro ranged from 89.9 under pipeline coordination to 43.0 under open-source review.
+- **Evaluation:** Across the ten-project aggregate cited by the authors, QA-first and rotation tied at 83.3 while open-source review scored 73.5.
+- **Evaluation:** Across 600 adjacent refinement transitions, 82.0 percent improved, and 94.7 percent of runs finished the third round above the first round.
+- **Limitation:** The projects come from university capstone assignments, so they do not directly represent maintenance of mature production repositories.
+- **Limitation:** Some transport and security checks depend on the benchmark's fixed deployment infrastructure, which creates a ceiling unrelated to agent coding quality.
+- **Implication:** Team topology can rival model capability, and clear ownership plus early executable validation generally beats diffuse collaboration or heavy managerial oversight.
+
+### OrchBench: Evaluating Multi-Agent Orchestration Plans in Isolation via Deterministic Simulation
+
+- **Title:** OrchBench: Evaluating Multi-Agent Orchestration Plans in Isolation via Deterministic Simulation.
+- **arXiv:** [2607.25656](https://arxiv.org/abs/2607.25656).
+- **Date:** 2026-07-28.
+- **Classification:** This evaluates multi-agent plans without running actual subagent workers during benchmark scoring.
+- **Approach:** A planner receives a fixed task-dependency graph, context limit, and agent budget, then assigns tasks to agents and specifies cross-agent information transfers and retention ratios.
+- **Approach:** A deterministic simulator measures terminal-result quality, critical-path efficiency, token efficiency, missing transfers, and context-compression loss.
+- **Evaluation:** Simulated final scores correlated with Claude Code execution quality at Pearson r equals 0.816 and Spearman rho equals 0.771.
+- **Evaluation:** The simulator used 1.3 percent of the real-execution tokens and 10.3 percent of the wall-clock time in the headline comparison.
+- **Evaluation:** At a 16K context limit, simulated multi-agent quality exceeded the single-agent baseline by 0.302, but the advantage fell to 0.007 at 128K.
+- **Evaluation:** Adding one simulator-selected handoff raised mean real MultiAgentBench execution score from 3.754 to 4.150 out of five.
+- **Limitation:** Task decomposition and dependencies are supplied rather than discovered by the planner.
+- **Limitation:** Simulated time and token metrics did not correlate reliably with real framework consumption, so target-framework validation remains necessary.
+- **Implication:** Additional agents help most when working state exceeds one context window, while preserving dependency information matters more than maximizing agent count.
+
+### OrchestraBench: Evaluating Multi-Agent Orchestration Failure Modes, Recovery, and Decomposition Quality
+
+- **Title:** OrchestraBench: Evaluating Multi-Agent Orchestration Failure Modes, Recovery, and Decomposition Quality.
+- **arXiv:** [2608.05263](https://arxiv.org/abs/2608.05263).
+- **Date:** 2026-08-05.
+- **Classification:** This studies controlled multi-agent pipelines and failure handling rather than runtime parent-created coding subagents.
+- **Approach:** The benchmark injects seeded routing, delegation, tool, context, conflicting-output, and premature-action failures into reproducible workflow chains.
+- **Approach:** It measures routing accuracy, per-failure-mode recovery, cascade radius, time to detection, and decomposition fidelity.
+- **Evaluation:** On a 26-case routing diagnostic, a keyword-and-flag heuristic scored zero percent on adversarial cases, while both an intent-reading TF-IDF router and an LLM router scored 100 percent.
+- **Evaluation:** In the arithmetic-chain probe, tool-invocation failures recovered at 1.00, ambiguous delegation recovered at 0.30, and context pollution, conflicting outputs, and premature action recovered at 0.00.
+- **Evaluation:** Mean latent-failure cascade radius grew from 0.93 at pipeline depth three to 4.67 at depth seven, while tool-failure cascade radius remained zero.
+- **Evaluation:** A decomposition policy achieved 1.00 delegation fidelity versus 0.37 for a monolithic policy even though both produced correct final answers.
+- **Limitation:** The routing diagnostic contains only 26 author-labelled cases and saturates for description-reading routers.
+- **Limitation:** Most failure experiments use synthetic arithmetic chains and Claude-family models, so broader production and cross-provider validation remains future work.
+- **Implication:** Routing should inspect task intent, and blind retries cannot repair corrupted shared state because reliable containment requires detection, attribution, and trustworthy state repair.
+
+## Synthesis
+
+The literature supports a spectrum rather than one uniform definition of a coding subagent.
+Recursive Agent Harnesses and SWARMRESEARCH provide the clearest evidence for dynamic runtime delegation in which a manager chooses and launches subordinate coding harnesses.
+MAGIS also uses a true hierarchy because its Manager decomposes repository issues and creates Developer agents for the resulting tasks.
+MASAI explicitly names and implements subagents, but its contribution is fixed role specialization rather than adaptive spawning or orchestration.
+MSEval, OrchBench, and OrchestraBench provide important orchestration evidence without demonstrating the same parent-created subagent architecture.
+Across these categories, extra agents are most useful when they isolate context, tools, program branches, modalities, or narrowly defined responsibilities.
+More agents alone do not guarantee better outcomes because missing handoffs, ambiguous ownership, over-broad permissions, stale state, and merge contention can erase the benefit of parallelism.
+The strongest recurring design pattern is a manager with global but compact state that delegates bounded tasks to workers with isolated local contexts and integrates machine-verifiable outputs.
+Executable tests, deployment checks, and structured artifacts provide more reliable coordination signals than self-reported completion or unconstrained inter-agent conversation.
+Dynamic orchestration appears most valuable for open-ended exploration and work that exceeds one context window, while fixed pipelines remain competitive for predictable repository-repair stages.
+Current evidence does not establish a universal best topology because results depend strongly on task structure, context pressure, model choice, worker capability, budget, and evaluation protocol.
+Future evaluations should jointly report task quality, cost, latency, information-transfer fidelity, permission precision, recovery behavior, and the marginal benefit over a matched single-agent baseline.

--- a/docs/research/2026-08-10-coding-agent-subagents-engineering-notes.md
+++ b/docs/research/2026-08-10-coding-agent-subagents-engineering-notes.md
@@ -1,0 +1,187 @@
+# Coding-Agent Subagents: Engineering Evidence and Recommendations
+
+## Methodology and scope
+
+This synthesis uses the AlphaXiv MCP paper-discovery and PDF-query tools as its required and primary evidence source.
+The search focused on coding-agent subagents and adjacent multi-agent orchestration research covering delegation, context isolation, communication, parallelism, verification, benchmarks, costs, and failures.
+Claims in the direct-evidence section come from the papers' reported methods, measurements, or stated limitations.
+The recommendations section is explicitly inferential and combines patterns across papers rather than presenting them as directly tested conclusions.
+Several cited 2026 papers are recent preprints, so their findings should be replicated before being treated as settled engineering results.
+
+## Summary
+
+Subagents help most when work has genuinely distinct roles, separable context, or a dependency structure that supports useful parallel execution.
+Adding agents without structural guidance often increases communication cost, loses task-critical information, creates interface conflicts, and weakens verification.
+The most defensible system pattern is a dependency-aware orchestrator with isolated worker contexts, structured artifact handoffs, bounded authority, and independent executable verification.
+
+## Direct evidence
+
+### AgentCoder
+
+[AgentCoder: Multi-Agent Code Generation with Effective Testing and Self-optimisation](https://arxiv.org/abs/2312.13010) is arXiv:2312.13010, with the examined v3 dated 2024-05-24.
+AgentCoder uses three roles consisting of a programmer, an independent test designer, and a test executor.
+The test designer creates tests without seeing the generated implementation, which is intended to reduce correlated blind spots between code and tests.
+The test executor runs the generated tests and returns concrete failures to the programmer until the code passes or the iteration budget ends.
+With GPT-4, AgentCoder reported 96.3% pass@1 on HumanEval and 91.8% on MBPP, compared with reported prior-best values of 90.2% and 78.9%.
+It reported aggregate token overheads of 56.9K on HumanEval and 66.3K on MBPP, compared with 138.2K and 206.5K for MetaGPT and still higher totals for ChatDev and AgentVerse.
+Its test designer reported 89.6% and 91.4% test accuracy and 91.7% and 92.3% line coverage on HumanEval and MBPP.
+The main limitation is that HumanEval and MBPP are function-level benchmarks, so the results do not directly establish repository-scale effectiveness or parallel speedups.
+
+### MASAI
+
+[MASAI: Modular Architecture for Software-engineering AI Agents](https://arxiv.org/abs/2406.11638) is arXiv:2406.11638, dated 2024-06-17.
+MASAI defines each subagent with an explicit input, problem-solving strategy, and output specification.
+Its five specialized subagents generate a test template, reproduce the issue, localize edits, generate candidate fixes, and rank those fixes.
+Subagents communicate by passing specified artifacts to later stages instead of holding free-form one-to-one or group conversations.
+MASAI reported a 28.33% resolution rate on the 300-task SWE-bench Lite benchmark, a 75% file-localization rate, and an average cost of $1.96 per issue.
+Sampling five candidate patches raised oracle resolution from 23.33% with one sample to 35% with five samples.
+Random selection achieved 22.28%, LLM ranking without test evidence achieved 23.33%, and ranking with an independently generated reproduction test achieved 28.33%.
+These results support executable evidence over model self-evaluation when selecting among candidate patches.
+The evaluation used GPT-4o on an early SWE-bench Lite setup, and the architecture is primarily a staged pipeline rather than an experiment in wall-clock parallelism.
+
+### MAST failure taxonomy
+
+[Why Do Multi-Agent LLM Systems Fail?](https://arxiv.org/abs/2503.13657) is arXiv:2503.13657, with the examined v3 dated 2025-10-26.
+The MAST study analyzes 1,642 traces from seven multi-agent systems across coding, mathematics, and general-agent tasks.
+Observed system failure rates ranged from 41% to 86.7% across the evaluated systems.
+The taxonomy contains 14 failure modes grouped into system-design problems at 44.2%, inter-agent misalignment at 32.3%, and task-verification problems at 23.5%.
+Reported modes include disobeying task or role specifications, repeated steps, lost conversation history, conversation resets, information withholding, ignored agent input, premature termination, and missing or incorrect verification.
+The taxonomy was developed with human inter-annotator agreement of kappa 0.88.
+A workflow correction that restored the intended decision authority in ChatDev contributed to a reported 9.4% increase in task success.
+The authors caution that isolated prompt or workflow fixes are often insufficient because many failures arise from structural system design.
+The taxonomy is not claimed to be exhaustive, and much of the full dataset was labeled by an LLM annotator calibrated against a smaller human-labeled set.
+
+### Cohesion-aware parallel coding
+
+[When Parallelism Pays Off: Cohesion-Aware Task Partitioning for Multi-Agent Coding](https://arxiv.org/abs/2606.00953) is arXiv:2606.00953, dated 2026-05-31.
+Co-Coder models a repository as a weighted dependency graph whose nodes represent work and whose cross-partition edges approximate communication cost.
+It isolates structural hub files, groups strongly coupled files, exposes safe latent parallelism, and schedules ready work without global synchronization barriers.
+A leader runs the test suite after generation and sends repair work only to the partition that owns the implicated files.
+Across 28 Python repository-generation tasks, Co-Coder improved DevEval average pass rate from 56.8% to 68.1%, reduced mean latency from 800 to 442 seconds, and reduced mean API cost from $0.25 to $0.18.
+On CodeProjectEval, it improved average pass rate from 20.1% to 34.1%, reduced mean latency from 2,756 to 1,315 seconds, and reduced mean cost from $1.03 to $0.67.
+These values correspond to as much as a 2.10-times wall-clock speedup and a 35% cost reduction relative to sequential execution.
+Naive file-based parallelism increased cost by 44% on DevEval and 60% on CodeProjectEval while producing only small average quality gains.
+The evaluated Claude Code Agent Teams configuration was faster and cheaper but had lower average pass rates than the sequential baseline on both benchmarks.
+Co-Coder becomes effectively sequential when nearly every file is tightly coupled, and the reported evaluation covers only Python repositories.
+
+### Software delegation contracts
+
+[Software Delegation Contracts: Measuring Reviewability in AI Coding-Agent Work](https://arxiv.org/abs/2606.17099) is arXiv:2606.17099, dated 2026-06-14.
+The paper defines a delegation contract as the task, granted authority, returned work package, and acceptance context around a coding-agent run.
+Its explicit contracts specify objectives, non-goals, allowed paths and commands, forbidden actions, expected tests, required evidence, and acceptance criteria.
+Across 64 runs on ten small TypeScript tasks, every condition passed hidden acceptance checks and produced no scope violation, so contracts did not improve objective correctness in this saturated setting.
+Contracts increased evidence sufficiency by 0.83 on a five-point scale, improved 22 of 30 paired comparisons without worsening any, and reduced reviewer ambiguity.
+Changed-file lists with reasons increased from 7% to 93%, commands-run reporting increased from 7% to 70%, and known-limitations sections increased from 0% to 80%.
+Contracts increased agent tokens by 13%, wall-clock time by 38.3%, and tool invocations by 23.3%.
+The effect on reviewability was roughly twice as large for the weaker model tier.
+The study is a small pilot on a roughly 600-line toy repository, objective outcomes reached a ceiling, and the blinded reviewers were models rather than humans.
+
+### OrchBench
+
+[OrchBench: Evaluating Multi-Agent Orchestration Plans in Isolation via Deterministic Simulation](https://arxiv.org/abs/2607.25656) is arXiv:2607.25656, dated 2026-07-28.
+OrchBench evaluates task assignments, dependency scheduling, information transfers, compression, makespan, and tokens without executing worker agents.
+Its simulated orchestration scores correlated with Claude Code execution quality at Pearson r equals 0.816 while requiring 1.3% of the tokens and 10.3% of the wall-clock time.
+Transfer coverage correlated with quality between 0.614 and 0.952 across tested workflow sizes.
+At 100 tasks, agent count was almost uncorrelated with quality at negative 0.021, while missing-transfer counts ranged from 0.07 to 22.70 across planners.
+Increasing the maximum agent cap from 16 to 64 more than doubled the selected agent count while leaving scores nearly unchanged.
+Multi-agent execution improved quality over single-agent execution by 0.302 under a 16K context limit, but the advantage fell to 0.007 under a 128K limit.
+At 1,000 tasks, two tested planners accumulated more than 870 missing transfers while another preserved complete transfer coverage, showing that coordination quality can diverge sharply at scale.
+Adding one simulator-selected handoff increased mean real-execution evaluation scores from 3.754 to 4.150 out of five on 20 tasks.
+The simulator is useful for plan screening, but its simulated time and token measures did not correlate reliably with real framework costs, and it assumes a fixed task decomposition rather than evaluating decomposition itself.
+
+### OrchestraBench
+
+[OrchestraBench: Evaluating Multi-Agent Orchestration Failure Modes, Recovery, and Decomposition Quality](https://arxiv.org/abs/2608.05263) is arXiv:2608.05263, dated 2026-08-05.
+OrchestraBench uses controlled failure injection to measure routing accuracy, recovery by failure mode, cascade radius, time to detection, and delegation fidelity.
+In a 26-case routing diagnostic, a keyword and flag heuristic scored 0% on adversarial cases while a TF-IDF router that read the task description and an LLM router each scored 100%.
+This result favors intent-aware routing but does not establish that expensive LLM routing is necessary.
+In controlled dependency chains, tool faults recovered at 1.0, ambiguous delegation recovered at 0.30, and three latent or semantic failure classes recovered at 0.0.
+Blind retries reproduced latent failures instead of repairing them and only increased time to detection.
+Mean cascade radius grew from 0.9 to 4.7 as pipeline depth increased from three to seven stages.
+The routing diagnostic is small and author-labeled, and the recovery experiments are controlled arithmetic-chain probes rather than broad coding workloads.
+
+## Cross-paper engineering lessons from direct evidence
+
+Delegation performs best when roles correspond to different strategies or evidence sources rather than cosmetic personas.
+Independent test generation and execution provide more useful selection signals than model-only review of candidate patches.
+Context isolation can reduce correlated errors and long-trajectory noise, but every isolated context creates an information-transfer obligation.
+Structured artifact handoffs make missing information visible and reduce the ambiguity of free-form conversational coordination.
+Raw agent count is a weak optimization target because useful concurrency depends on dependency structure, context pressure, and communication cost.
+Parallel work is most effective when strongly coupled code remains under one owner and only dependency-ready tasks execute concurrently.
+Blind retry is appropriate for transient tool faults but is ineffective against latent semantic errors, bad delegation, or corrupted shared state.
+Delegation contracts improve the review surface, especially for weaker or cheaper workers, but impose measurable token and latency overhead.
+Simulation can cheaply screen orchestration plans, but final validation must still execute the target coding system in its real environment.
+
+## Inferred practical recommendations
+
+The recommendations below are engineering inferences drawn across the direct evidence rather than conclusions tested by one paper end to end.
+
+### Delegate selectively
+
+Use a subagent when it supplies a distinct problem-solving strategy, independent verification, necessary context isolation, or meaningful critical-path parallelism.
+Keep work in one agent when the relevant state fits comfortably in one context and the task has dense shared dependencies.
+Require the orchestrator to record why delegation is expected to improve quality, latency, context pressure, or verification before launching another worker.
+
+### Partition by cohesion and dependencies
+
+Build or infer a dependency graph before assigning repository work.
+Keep files with dense shared interfaces, types, or call relationships under one owner.
+Assign independent leaves or weakly coupled modules to separate workers only when the expected latency reduction exceeds handoff and integration cost.
+Release work when its actual upstream artifacts are ready instead of launching all planned workers simultaneously.
+Use a bounded dynamic concurrency limit derived from ready work rather than treating the configured maximum as a target.
+
+### Make delegation contractual
+
+Every request should specify a task identifier, objective, non-goals, writable scope, allowed tools, dependencies, required inputs, acceptance checks, and deadline or budget.
+Grant each worker only the paths, tools, credentials, and destructive authority necessary for its task.
+Every result should report status, changed paths, artifact or patch reference, claims, tests run, raw evidence, limitations, unresolved dependencies, and token and time usage.
+Require explicit acknowledgement or rejection when a worker lacks required context, authority, tools, or verification capability.
+
+### Isolate context while preserving provenance
+
+Give workers minimal task-specific contexts instead of cloning the entire parent conversation by default.
+Pass immutable source references and structured upstream artifacts rather than compressed conversational summaries whenever practical.
+Mark each transferred claim as observed, inferred, or unverified and attach the producing task and artifact version.
+Reject or revalidate results produced from stale repository generations, invalidated dependencies, or superseded plans.
+
+### Separate generation, integration, and verification
+
+Do not let the implementation worker provide the only acceptance evidence for its own change.
+Use an independently contextualized verifier for tests, compilation, static analysis, security checks, or behavioral evaluation.
+For uncertain fixes, generate diverse candidates independently and rank them with executable evidence rather than self-reported confidence.
+Give one integration owner authority to resolve cross-partition interfaces and require it to rerun repository-level checks on the assembled state.
+
+### Make recovery failure-specific
+
+Retry transient transport, rate-limit, or tool failures within a bounded policy.
+For missing context, issue a structured request for the exact absent dependency instead of replaying the same prompt.
+For semantic or verification failures, restore trusted state, revise the plan, change the worker or verifier, and rerun acceptance checks.
+For repeated task derailment or ignored input, terminate the worker and preserve its trace for diagnosis rather than allowing an unbounded loop.
+
+### Observe orchestration as a first-class system
+
+Record every delegation decision, worker assignment, dependency, context transfer, tool action, artifact version, verification result, retry, cancellation, and termination reason.
+Classify incidents using a stable taxonomy covering specification failure, role failure, history loss, information withholding, ignored input, premature termination, and incomplete verification.
+Track missing transfers and cascade radius so a plausible final answer cannot hide upstream coordination failures.
+
+### Benchmark against credible alternatives
+
+Compare the subagent system with a strong single agent, equal-budget best-of-N sampling, naive parallelism, and an ablated orchestrator.
+Report resolved-task rate, wall-clock latency, total tokens, monetary cost, peak concurrency, context transferred, conflicting edits, verification failures, and reviewability.
+Evaluate both loosely coupled and densely coupled repository tasks because average results can hide where parallelism collapses.
+Use deterministic orchestration simulation for cheap stress tests and parameter sweeps, then confirm selected designs with repeated end-to-end runs in the target framework.
+
+## Recommended minimum architecture
+
+The orchestrator should construct the task graph, decide whether delegation is justified, issue bounded contracts, and schedule only dependency-ready work.
+Each worker should own a cohesive scope, operate in an isolated context and workspace, and return a structured artifact with evidence.
+The communication layer should provide versioned request, result, acknowledgement, rejection, cancellation, and invalidation messages.
+The integration owner should assemble compatible artifacts, detect ownership conflicts, and invalidate downstream work when an upstream contract changes.
+The verifier should independently execute acceptance checks against the integrated state and attribute failures to responsible tasks or handoffs.
+The observability layer should preserve sufficient traces to measure cost, locate missing transfers, classify failures, and reproduce cascades.
+
+## Conclusion
+
+The literature does not support a general rule that more coding agents produce better software.
+It supports a narrower rule that specialized, dependency-aware, independently verified delegation can improve quality or latency when context and communication are engineered as carefully as code execution.
+The central design problem is therefore not spawning subagents but deciding when to delegate, defining what information crosses each boundary, and proving that the assembled result is correct.

--- a/docs/research/2026-08-10-coding-agent-subagents-evidence-audit.md
+++ b/docs/research/2026-08-10-coding-agent-subagents-evidence-audit.md
@@ -1,0 +1,257 @@
+# Coding-Agent Subagents: AlphaXiv Evidence Audit
+
+## Executive finding
+
+The audited literature does not establish that coding subagents generally outperform a strong single coding agent under simultaneously matched model, information, token or dollar budget, wall-clock budget, sampling, and evaluation protocol.
+The strongest positive repository-scale result is Co-Coder, which uses the same base model and reports higher test pass rates together with lower observed API cost and latency than its sequential baseline across 28 from-scratch Python repository tasks.
+The strongest negative coding evidence is CooperBench, where same-model two-agent teams solved substantially fewer paired features than one agent handling both features, even though the two-agent condition had up to twice the aggregate action allowance.
+The strongest broad baseline audit is *The Illusion of Multi-Agent Advantage*, where automatic multi-agent systems failed to beat five-sample self-consistency on SWE-bench Lite across the evaluated GPT-4o, GPT-5, and Gemini 2.5 Pro settings.
+Dynamic parent-created delegation remains weakly supported for repository maintenance because the clearest dynamic systems were evaluated on long-context aggregation, mixed workspace management, tool-use workflows, or open-ended optimization rather than repeated real-issue repair with a matched single-agent control.
+The defensible conclusion is narrower than the existing notes imply: structured delegation can help when it isolates genuine context pressure, preserves alternative program states, or partitions weakly coupled work, but free-form spawning and additional agents are not independently validated sources of coding quality.
+
+## Evidence labels
+
+**Direct evidence** means a method, number, limitation, or protocol stated in the queried paper PDF, not an independently reproduced result.
+**Paper-author claim** means the authors' interpretation of their measurements.
+**Audit inference** means a conclusion drawn here from protocol comparison or synthesis across papers.
+
+## Search scope and method
+
+The audit read the two existing local notes in full before searching.
+The audit used AlphaXiv MCP `discover_papers` twice at difficulty 10, once for explicit coding subagents, repository-scale coding, dynamic delegation, matched baselines, costs, latency, failures, and benchmark validity, and once specifically for negative results and simple-baseline comparisons.
+The discovery calls returned papers on Recursive Agent Harnesses, ClawArena-Team, Software Delegation Contracts, subagent inheritance, Claw-SWE-Bench, multi-agent coding coordination, harness failure attribution, real-world coding-agent failures, automatic-MAS baseline audits, paired noise floors, and related failure studies.
+The audit then used AlphaXiv MCP `answer_pdf_queries` on 16 papers to inspect experimental tables, model and budget controls, task scale, repeated-run policy, failure modes, and author-stated limitations.
+The 16 queried papers were [Recursive Agent Harnesses](https://arxiv.org/abs/2606.13643), [ClawArena-Team](https://arxiv.org/abs/2606.31174), [SWARMRESEARCH](https://arxiv.org/abs/2607.02807), [MAGIS](https://arxiv.org/abs/2403.17927), [MASAI](https://arxiv.org/abs/2406.11638), [Co-Coder](https://arxiv.org/abs/2606.00953), [The Illusion of Multi-Agent Advantage](https://arxiv.org/abs/2606.13003), [How Much Coordination Gain Is Real?](https://arxiv.org/abs/2606.20695), [CooperBench](https://arxiv.org/abs/2601.13295), [When Child Inherits](https://arxiv.org/abs/2605.08460), [Why Do Multi-Agent LLM Systems Fail?](https://arxiv.org/abs/2503.13657), [OrchBench](https://arxiv.org/abs/2607.25656), [OrchestraBench](https://arxiv.org/abs/2608.05263), [CodeDelegator](https://arxiv.org/abs/2601.14914), [Single-Agent LLMs Outperform Multi-Agent Systems on Multi-Hop Reasoning Under Equal Thinking Token Budgets](https://arxiv.org/abs/2604.02460), and [Claw-SWE-Bench](https://arxiv.org/abs/2606.12344).
+The research cutoff is 2026-08-10.
+No factual claim in this report relies on memory.
+
+## What counts as a fair baseline
+
+A matched-model comparison uses the same model version and reasoning setting for the single-agent and multi-agent arms.
+A matched-information comparison gives both arms the same issue text, repository state, hints, tests, tools, and external access.
+A matched-budget comparison constrains total model calls, generated and input tokens, dollar cost, wall-clock time, retries, and independent samples rather than merely using the same per-call limit.
+A matched-harness comparison changes delegation while holding the agent loop, system prompt, tool interface, patch extraction, stopping logic, and evaluator stable.
+A strong single-agent baseline may use the same total test-time compute through self-consistency, best-of-N sampling, or sequential refinement.
+No explicit repository-scale parent-subagent study in the audited set satisfies all five conditions.
+
+## Audit of representative headline claims in the existing notes
+
+### Recursive Agent Harnesses
+
+- **Direct evidence:** [RAH](https://arxiv.org/abs/2606.13643) reports 81.36% on 199 Oolong-Synthetic instances versus a published GPT-5 Codex-style baseline of 71.75%, with a reported gain of 9.61 points and a bootstrap interval of 4.2 to 14.8 points.
+- **Direct evidence:** The parent, subagents, and answer extractor use GPT-5, so model family and version are matched to the imported Codex result.
+- **Direct evidence:** The baseline was not rerun by the RAH authors, its per-instance outcomes were unavailable, and the reported difference interval bootstraps only RAH scores while treating the baseline point estimate as fixed.
+- **Audit inference:** The same-model headline is real as a model-control claim but is not a matched-compute or paired statistical comparison.
+- **Direct evidence:** Exact token and wall-clock profiles were not instrumented, and recursion depth, entries per subagent, and script spawning versus tool spawning were not ablated.
+- **Direct evidence:** The paper says both that every evaluated instance produced a task script and that a small number of instances answered directly without spawning, which is an unresolved internal reporting inconsistency.
+- **Audit inference:** RAH is evidence for parallel long-context aggregation, not repository issue resolution, code integration, or general coding delegation.
+
+### ClawArena-Team
+
+- **Direct evidence:** [ClawArena-Team](https://arxiv.org/abs/2606.31174) contains 41 scenarios, 258 rounds, and 72 staged updates, and the best manager obtained 60.0% Subagent-Management Score and 74.4% task completion.
+- **Direct evidence:** Every manager uses the same locally served worker pool, no manager exceeded 50% workspace-permission precision, and main-agent API cost ranged from about $0.80 to $92.80 while management score ranged from 15.3% to 60.0%.
+- **Direct evidence:** Delegation is mandatory because the text-only manager cannot directly access all workspace regions or non-text modalities.
+- **Direct evidence:** The study compares manager models in one run each and does not include a no-subagent or single-agent baseline under matched budget.
+- **Direct evidence:** Reported dollar cost covers the main-agent API, while the fixed local worker pool is not priced as an equivalent external API workload.
+- **Audit inference:** The benchmark credibly measures management behavior under a fixed worker pool but cannot show that a managed team beats a capable single agent.
+
+### SWARMRESEARCH
+
+- **Direct evidence:** [SWARMRESEARCH](https://arxiv.org/abs/2607.02807) reports exceeding or matching EvoX and CORAL on 13 of 15 open-ended optimization tasks and beating the best tested fixed scaling configuration on four of five controlled tasks.
+- **Direct evidence:** The primary comparison uses one stochastic run per method and task, gives SWARMRESEARCH and CORAL $50 per task, gives EvoX 100 iterations costing $23.50 on average, and notes that neither SWARMRESEARCH nor CORAL converged within budget.
+- **Direct evidence:** The controlled 60-iteration comparison uses Minimax-M2.5 workers in both arms but adds a Claude Sonnet 4.6 orchestrator in the dynamic arm, which increases total output tokens by 7.7%.
+- **Audit inference:** The controlled scaling result does not isolate orchestration under a matched-model or matched-token design.
+- **Direct evidence:** The speculative-decoding implementation reached 4.58 times vanilla throughput at 60.6% accuracy, while autoresearch reached 1.80 times at 65.8% accuracy and CORAL reached 2.26 times at 58.4% accuracy.
+- **Direct evidence:** SWARMRESEARCH used an approximately 11-hour analysis phase followed by an approximately 11-hour solution-generation phase, while the compared methods generated solutions for approximately 12 hours.
+- **Audit inference:** The existing note's implication of similar elapsed time omits an additional analysis phase and an accuracy tradeoff, so the 4.58-times result is not a matched-time dominance claim.
+
+### MAGIS
+
+- **Direct evidence:** [MAGIS](https://arxiv.org/abs/2403.17927) reports 13.94% resolved and 97.39% applicable on the 25% SWE-bench subset used by the original GPT-4 study, versus 1.74% resolved for direct GPT-4.
+- **Direct evidence:** The evaluation setting provides the files requiring modification, and the full MAGIS configuration also uses pre-commit pull-request comments as hints.
+- **Direct evidence:** Removing hints lowers resolution to 10.28%, removing QA lowers it to 10.63%, and removing both lowers it to 8.71%.
+- **Direct evidence:** The direct GPT-4 baseline and MAGIS are not matched for model calls, tokens, cost, latency, QA iterations, or auxiliary information.
+- **Audit inference:** The roughly eight-fold number demonstrates the value of a larger engineered workflow over a minimal direct call, not a clean causal advantage from multiple agents.
+
+### MASAI
+
+- **Direct evidence:** [MASAI](https://arxiv.org/abs/2406.11638) reports 28.33% resolution, 75.0% file localization, 95.33% patch application, and $1.96 average cost on 300 SWE-bench Lite issues from 11 Python repositories.
+- **Direct evidence:** Five GPT-4o subagents form a fixed pipeline, and the Fixer samples five patches before the Ranker uses a generated reproduction test.
+- **Direct evidence:** Random five-way selection reaches 22.28%, model ranking without the generated test reaches 23.33%, and test-informed ranking reaches 28.33%.
+- **Audit inference:** This is useful direct evidence that executable test evidence improves candidate selection inside the pipeline.
+- **Direct evidence:** The leaderboard comparisons mix models, hints, testing assumptions, tools, and harnesses, and no same-model equal-budget single-agent or best-of-five ablation reproduces the full MASAI workload.
+- **Audit inference:** MASAI supports fixed specialization and test-guided selection but does not validate dynamic parent-to-subagent delegation.
+
+### Co-Coder
+
+- **Direct evidence:** [Co-Coder](https://arxiv.org/abs/2606.00953) evaluates 28 from-scratch Python repository-generation tasks over three independent runs per repository with GPT-5-mini as the base model for all methods.
+- **Direct evidence:** On DevEval, Co-Coder reports 68.1% average pass rate, 442 seconds, and $0.18 per task, versus 56.8%, 800 seconds, and $0.25 for the sequential OpenHands baseline.
+- **Direct evidence:** On CodeProjectEval, Co-Coder reports 34.1%, 1,315 seconds, and $0.67, versus 20.1%, 2,756 seconds, and $1.03 for the sequential baseline.
+- **Direct evidence:** Naive file parallelism costs 44% more than sequential on DevEval and 60% more on CodeProjectEval for only 0.9-point and 3.2-point average pass-rate gains.
+- **Direct evidence:** Claude Code Agent Teams is faster and cheaper but scores below sequential on both benchmarks, at 54.1% versus 56.8% and 16.3% versus 20.1%.
+- **Audit inference:** Co-Coder is the strongest audited positive evidence because the same-model main comparison improves quality, observed cost, and latency at once.
+- **Direct evidence:** The tasks generate repositories averaging 3.1 files and 243 lines on DevEval and 11.9 files and 2,371 lines on CodeProjectEval rather than repairing mature repositories.
+- **Direct evidence:** Co-Coder and sequential use the same OpenHands SDK, while the Agent Teams reference uses a different Claude Code harness, and the paper does not impose an equal-token or equal-dollar ceiling.
+- **Audit inference:** The result supports cohesion-aware partitioning for bounded from-scratch generation but does not establish a general parent-subagent advantage for issue repair.
+
+### MAST failure taxonomy
+
+- **Direct evidence:** [MAST](https://arxiv.org/abs/2503.13657) analyzes 1,642 traces from seven systems across coding, mathematics, and general-agent tasks and reports system failure rates from 41.0% to 86.7% on different benchmarks.
+- **Direct evidence:** Its pooled taxonomy assigns 44.2% of observed failure labels to system design, 32.3% to inter-agent misalignment, and 23.5% to task verification.
+- **Direct evidence:** Human development of the taxonomy reached kappa 0.88, while the scalable few-shot LLM annotator reached kappa 0.77 against human labels.
+- **Direct evidence:** The repository-repair component is only 30 HyperAgent traces on SWE-bench Lite, while most labels come from other systems and tasks.
+- **Direct evidence:** The reported 9.4-point and 15.6-point ChatDev interventions are on small from-scratch ProgramDev studies rather than repository maintenance.
+- **Audit inference:** MAST is strong evidence that coordination and verification failures are common, but its pooled percentages should not be presented as coding-subagent-specific rates.
+
+### OrchBench and OrchestraBench
+
+- **Direct evidence:** [OrchBench](https://arxiv.org/abs/2607.25656) simulates fixed task DAGs rather than discovering decompositions or executing repository workers.
+- **Direct evidence:** Its final simulated score correlates with real Claude Code quality at Pearson 0.816 with a two-sided permutation p-value of 0.047 across six model-level points, while Spearman 0.771 has p-value 0.103.
+- **Direct evidence:** Simulated time and token measures do not reliably correlate with real resource consumption, and cross-framework time correlation is negative 0.104.
+- **Direct evidence:** The reported multi-agent quality advantage falls from 0.302 at a 16K simulated context limit to 0.007 at 128K.
+- **Audit inference:** This supports the hypothesis that context pressure creates a delegation regime, but it is indirect evidence because the effect is produced by the simulator's explicit compression and transfer rules.
+- **Direct evidence:** [OrchestraBench](https://arxiv.org/abs/2608.05263) uses controlled arithmetic chains, author-labelled routing cases, and prompt-level fault injection for its headline experiments.
+- **Direct evidence:** The paper explicitly states that the core failure experiments use one Claude agent over a staged chain rather than a literal multi-agent system.
+- **Direct evidence:** Tool faults recover at 1.0, ambiguous delegation recovers at 0.30, and three latent or semantic failures recover at 0.0 in the main arithmetic probe.
+- **Direct evidence:** Removing trusted upstream state collapses the apparent LLM-router latent recovery from 0.67 to 0.08, near the baseline level.
+- **Audit inference:** OrchestraBench is useful mechanistic counterevidence against blind retries, but its headline results should not be described as observed production multi-agent or coding behavior.
+
+## Materially relevant papers missed by the existing notes
+
+### The Illusion of Multi-Agent Advantage
+
+- **Direct evidence:** [The Illusion of Multi-Agent Advantage](https://arxiv.org/abs/2606.13003) compares six automatic multi-agent frameworks with chain-of-thought and five-sample self-consistency across reasoning, browsing, and 168 SWE-bench Lite test tasks.
+- **Direct evidence:** Results average three runs except the Gemini 2.5 Pro cells, which use one run because of cost.
+- **Direct evidence:** On SWE-bench Lite with GPT-5, self-consistency scores 57.09% at $286.40, while DyLAN scores 55.97% at $227.40 and the other automatic systems score from 27.23% to 45.52% at costs from $83.50 to $998.20.
+- **Direct evidence:** On SWE-bench Lite with GPT-4o, self-consistency scores 22.01% at $168.30, while all automatic systems score lower at 8.97% to 19.28% with costs from $35.60 to $1,210.90.
+- **Direct evidence:** On SWE-bench Lite with Gemini 2.5 Pro, direct chain-of-thought scores 28.70% at $47.17, while the evaluated automatic systems score from 0.00% to 27.60% at $206.27 to $434.00.
+- **Paper-author claim:** Current automatic architectures exhibit role redundancy, functional collapse, and architectural bloat that fails to convert extra inference into useful coordination.
+- **Audit inference:** This is direct contradictory evidence for automatic multi-agent coding, although it does not rule out carefully hand-designed systems such as Co-Coder or MASAI.
+
+### CooperBench
+
+- **Direct evidence:** [CooperBench](https://arxiv.org/abs/2601.13295) contains 652 paired-feature tasks over 12 open-source repositories in Python, TypeScript, Go, and Rust, with 77.3% of tasks having conflicting ground-truth edits.
+- **Direct evidence:** Under the same model, GPT-5 scores 48% solo versus 28% with two agents, Claude Sonnet 4.5 scores 47% versus 26%, and MiniMax-M2 scores 36% versus 14%.
+- **Direct evidence:** Each agent in the cooperative condition may take up to 100 actions, while one solo agent handles both features under the same per-agent cap, so the team has more aggregate action capacity rather than a stricter matched budget.
+- **Direct evidence:** Adding natural-language communication reduces raw merge conflicts but does not significantly improve final cooperation success, and the final average communication effect after merge resolution is negative 0.5 points.
+- **Direct evidence:** On a 46-task subset, success falls from 68.6% with two agents to 46.5% with three and 30.0% with four.
+- **Paper-author claim:** Vague or late messages, broken commitments, and incorrect beliefs about peers create a curse of coordination.
+- **Audit inference:** CooperBench is not a parent-subagent system, but it directly falsifies the assumption that parallel coding agents naturally combine into a stronger repository result.
+
+### CodeDelegator
+
+- **Direct evidence:** [CodeDelegator](https://arxiv.org/abs/2601.14914) implements an explicit persistent Delegator that creates fresh ephemeral Coder agents with isolated execution contexts and structured artifacts.
+- **Direct evidence:** With DeepSeekV3.2, it scores 82.0% versus 79.6% for ReAct on tau2-bench retail, 63.5% versus 58.5% on airline, and 38.4% versus 25.8% on 127 MCPMark tasks.
+- **Direct evidence:** The PostgreSQL MCPMark domain is a negative case where ReAct scores 52.4% and CodeDelegator scores 41.7%.
+- **Direct evidence:** The same backbone is used within each comparison, but baselines allow 200 interaction steps while CodeDelegator allows up to 100 dispatch rounds with 20 Coder iterations each.
+- **Direct evidence:** The paper reports no total token, dollar, or wall-clock comparison and supports only sequential decomposition.
+- **Audit inference:** CodeDelegator is relevant architecture evidence for isolated parent-to-child handoffs, but it is not repository coding evidence and does not survive a matched-compute test.
+
+### Equal-thinking-token single-agent comparison
+
+- **Direct evidence:** [Single-Agent LLMs Outperform Multi-Agent Systems on Multi-Hop Reasoning Under Equal Thinking Token Budgets](https://arxiv.org/abs/2604.02460) compares sequential, subtask-parallel, role-parallel, debate, and ensemble systems with single agents across Qwen3, DeepSeek-R1-Distill-Llama, and Gemini 2.5.
+- **Direct evidence:** At a nominal 1,000-token budget, the cross-model and cross-dataset average is 0.418 for the single agent versus 0.388 for the strongest multi-agent average, which is debate.
+- **Direct evidence:** At 2,000 tokens, the average is 0.421 for the single agent versus 0.403 for the strongest multi-agent average, again debate.
+- **Direct evidence:** Actual thinking-token use often falls below or exceeds requested budgets, especially through Gemini API accounting, and the paper treats these artifacts as a validity problem.
+- **Audit inference:** This is the clearest matched-token counterevidence but covers multi-hop question answering rather than coding, so it supports evaluation methodology more strongly than a coding conclusion.
+
+### Claw-SWE-Bench
+
+- **Direct evidence:** [Claw-SWE-Bench](https://arxiv.org/abs/2606.12344) standardizes 350 GitHub issue-resolution tasks across eight languages and 43 repositories with a fixed prompt, one-hour outer timeout, workspace contract, patch extraction, and evaluator.
+- **Direct evidence:** With the same GLM 5.1 model and tasks, a bare direct-diff adapter scores 19.1% with 69.1% patch-application failures, while the full repository-editing adapter scores 73.4% with fewer than 1.5% application failures.
+- **Direct evidence:** Holding model fixed, harness choice changes Pass@1 by as much as 27.4 points, and the study reports only one run per cell.
+- **Paper-author claim:** Model, harness, task, and cost must be separated because a single resolved rate conflates all four.
+- **Audit inference:** Cross-paper multi-agent gains smaller than plausible harness effects are not attributable unless prompt, patch extraction, stopping, tools, and outer budget are controlled.
+
+### Subagent inheritance security
+
+- **Direct evidence:** [When Child Inherits](https://arxiv.org/abs/2605.08460) demonstrates OpenClaw proofs of concept for full parent-memory inheritance, excessive child tool access, stale asynchronous state, and unauthorized sibling termination.
+- **Direct evidence:** The core attacks reproduce across MiniMax M2.5, Llama 4 Maverick, Qwen3.5 Plus, DeepSeek V3.2, and GPT-5.2 Codex according to the paper's model sweep.
+- **Direct evidence:** Agent Zero and Hermes narrow inherited prompts but still exhibit post-spawn state divergence because executing children do not receive later parent corrections.
+- **Audit inference:** This paper provides no coding-quality comparison, but it shows that unrestricted context inheritance and authority are concrete failure surfaces for parent-subagent coding systems.
+
+### Paired benchmark noise floor
+
+- **Direct evidence:** [How Much Coordination Gain Is Real?](https://arxiv.org/abs/2606.20695) finds a pooled configuration-equivalent paired gap of 5 points with a 95% interval from negative 2 to positive 12 points across two 100-task seeds on tau2-bench retail.
+- **Direct evidence:** A positive 18-point single-seed contrast reverses to negative 3 points at the second seed and is not significant when pooled.
+- **Direct evidence:** The authors explicitly limit the estimated envelope to one model, domain, harness, and protocol, and cross-model or cross-domain probes do not preserve it.
+- **Audit inference:** This is not a coding result, but it shows why single-run architectural deltas of a few points should not be treated as stable gains without paired replication.
+
+## Evidence-quality table
+
+Confidence grades the strength of the cited paper for the narrow claim in this audit rather than the overall quality of the paper.
+
+| Paper and arXiv link | Queried version date | Task scale | Baseline fairness | Quantitative result | Principal caveat | Confidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| [Recursive Agent Harnesses, 2606.13643](https://arxiv.org/abs/2606.13643) | 2026-06-11 | 199 synthetic long-context aggregation tasks | Same GPT-5, but imported baseline and unmatched compute | 81.36% versus 71.75% | Not repository coding, no cost profile, and no paired baseline outcomes | Medium for long-context delegation and low for coding |
+| [ClawArena-Team, 2606.31174](https://arxiv.org/abs/2606.31174) | 2026-07-02 | 41 mixed workspace scenarios and 258 rounds | Fixed workers across managers, but no single-agent control | Best SMS 60.0% and TCR 74.4% | Delegation is mandatory and each model has one run | Medium for management diagnosis |
+| [SWARMRESEARCH, 2607.02807](https://arxiv.org/abs/2607.02807) | 2026-07-02 | 15 open-ended optimization tasks plus five controlled tasks | Partly dollar-matched, but models, repetitions, and case-study time differ | Better or comparable on 13 of 15 and better fixed scaling on four of five | One run per main task and non-converged search | Low to medium |
+| [MAGIS, 2403.17927](https://arxiv.org/abs/2403.17927) | 2024-06-27 | 25% of 2,294 SWE-bench issues | Same base model family, but oracle files, hints, and compute differ | 13.94% versus direct GPT-4 at 1.74% | Eight-fold claim is heavily scaffold-confounded | Low for agent-count causality |
+| [MASAI, 2406.11638](https://arxiv.org/abs/2406.11638) | 2024-06-17 | 300 SWE-bench Lite issues | Heterogeneous leaderboard baselines and no equal-budget single agent | 28.33% resolved at $1.96 per issue | Fixed pipeline on an older benchmark | Medium for test-guided modularity |
+| [Co-Coder, 2606.00953](https://arxiv.org/abs/2606.00953) | 2026-05-31 | 28 Python repository-generation tasks with three runs each | Same GPT-5-mini and shared blueprint for main baselines | 68.1% versus 56.8% and 34.1% versus 20.1%, with lower cost and time | From-scratch generation and small project count | High for bounded cohesion-aware generation |
+| [MAST, 2503.13657](https://arxiv.org/abs/2503.13657) | 2025-10-26 | 1,642 traces from seven systems | Diagnostic corpus rather than a single-agent comparison | Failure categories 44.2%, 32.3%, and 23.5% | Coding-specific subset is small and most labels are automated | Medium for general failure taxonomy |
+| [The Illusion of Multi-Agent Advantage, 2606.13003](https://arxiv.org/abs/2606.13003) | 2026-06-13 | 168 SWE-bench Lite test tasks plus four other benchmarks | Same backbone with a strong self-consistency baseline, but costs are observed rather than exactly matched | GPT-5 SWE 57.09% for self-consistency versus at most 55.97% for automatic MAS | Tests automatic frameworks, not all hand-designed architectures | High for negative automatic-MAS evidence |
+| [CooperBench, 2601.13295](https://arxiv.org/abs/2601.13295) | 2026-01-26 | 652 paired-feature tasks across 12 repositories | Same model and workload, but teams have more aggregate actions | GPT-5 48% solo versus 28% team and Claude 47% versus 26% | Peer collaboration rather than parent-subagent delegation | High for coordination failure |
+| [CodeDelegator, 2601.14914](https://arxiv.org/abs/2601.14914) | 2026-01-21 | 165 tau2-bench tasks and 127 MCPMark tasks | Same model, but interaction caps and total compute are unmatched | MCPMark 38.4% versus ReAct 25.8% | Tool workflows rather than repository coding | Medium for isolated delegation architecture |
+| [Equal Thinking Token Budgets, 2604.02460](https://arxiv.org/abs/2604.02460) | 2026-04-11 | FRAMES and MuSiQue across three model families | Nominal thinking tokens matched, with documented API accounting artifacts | At 1,000 tokens, single-agent average 0.418 versus best MAS average 0.388 | No coding tasks | Medium for matched-budget methodology |
+| [OrchBench, 2607.25656](https://arxiv.org/abs/2607.25656) | 2026-07-28 | 240 generated DAGs plus limited real validation | Deterministic simulation with a modeled single-agent reference | Multi-agent quality gain drops from 0.302 at 16K to 0.007 at 128K | Fixed decompositions and simulator-defined costs | Low for real coding outcomes |
+| [OrchestraBench, 2608.05263](https://arxiv.org/abs/2608.05263) | 2026-08-05 | Synthetic arithmetic chains and 26 routing cases | Controlled probes without a real multi-agent control | Recovery 1.0 for tool faults, 0.30 for ambiguity, and 0.0 for three latent faults | One agent simulates a staged chain | Low for literal subagent behavior |
+| [Claw-SWE-Bench, 2606.12344](https://arxiv.org/abs/2606.12344) | 2026-06-10 | 350 issues across eight languages and 43 repositories | Fixed outer protocol with model or harness sweeps | Same-model adapter change raises 19.1% to 73.4% | Single runs and adapter comparison is not a component ablation | High for harness-confound evidence |
+| [When Child Inherits, 2605.08460](https://arxiv.org/abs/2605.08460) | 2026-05-08 | Three framework inspections and five-model attack sweep | Security proofs of concept without quality baseline | All five tested models reproduce core framework vulnerabilities | No task-success or coding benchmark | Medium for security failure surfaces |
+| [Paired Noise-Floor Protocol, 2606.20695](https://arxiv.org/abs/2606.20695) | 2026-06-15 | Two 100-task seeds on tau2-bench retail | Same-model paired configuration-equivalent protocols | Pooled gap 5 points with interval negative 2 to positive 12 | Local to one benchmark, model, and harness | Medium for replication methodology |
+
+## Matched-model and matched-budget synthesis
+
+- **Direct evidence:** Co-Coder holds the base model fixed and reports a Pareto improvement over a sequential baseline, but it does not enforce equal total tokens or dollars and evaluates from-scratch repository generation.
+- **Direct evidence:** RAH holds GPT-5 fixed but imports the baseline, adds many subagent calls, and does not instrument total cost or latency.
+- **Direct evidence:** CodeDelegator holds the backbone fixed but gives its hierarchy a potentially much larger aggregate interaction allowance and reports no resource totals.
+- **Direct evidence:** MAGIS and MASAI do not provide a full same-model, equal-information, equal-budget single-agent control for their headline repository results.
+- **Direct evidence:** The automatic-MAS audit shows that simple self-consistency beats all evaluated automatic systems on SWE-bench Lite, although the self-consistency and MAS arms do not all spend identical dollars.
+- **Direct evidence:** The equal-thinking-token study finds single agents match or beat five multi-agent structures on non-coding tasks, with API token-control artifacts explicitly documented.
+- **Audit inference:** Same-model matching alone is insufficient because subagent systems commonly multiply calls, contexts, retries, or samples.
+- **Audit inference:** Observed Pareto dominance, as in Co-Coder, is more informative than an equal-cost ceiling when a system simultaneously improves measured quality, cost, and time, but it still needs replication on maintenance tasks.
+- **Audit inference:** The audited evidence does not show that dynamic delegation itself survives a strong repository-scale best-of-N or self-consistency baseline under equal total compute.
+
+## Failure modes supported by direct evidence
+
+- **Direct evidence:** Naive file parallelism creates interface conflicts and redundant repair costs in Co-Coder's baselines.
+- **Direct evidence:** Peer coding agents send vague or late messages, break commitments, and mispredict partner behavior in CooperBench.
+- **Direct evidence:** MAST observes repeated steps, task and role violations, lost history, ignored input, premature termination, and inadequate verification across seven systems.
+- **Direct evidence:** ClawArena managers over-grant files and tools, preserve stale beliefs across updates, and take incorrect text shortcuts on multimodal tasks.
+- **Direct evidence:** SWARMRESEARCH's Shepherd tends to collapse onto one approach, prescribe ideas, rarely merge branches, and struggles to synthesize limitations into strategic prompts.
+- **Direct evidence:** RAH sometimes skips delegation, provides no measured budget guard, and depends on generating valid spawning scripts.
+- **Direct evidence:** CodeDelegator loses to ReAct on PostgreSQL workflows, showing that code-loop delegation can conflict with transactional boundaries.
+- **Direct evidence:** OpenClaw-style subagents can inherit malicious parent context, excessive tools, stale state, and unsafe termination authority.
+- **Direct evidence:** OrchestraBench shows that retry can repair transient tool faults while reproducing latent semantic corruption when trusted state is not restored.
+- **Audit inference:** Context isolation creates an information-transfer obligation, and failures shift from context pollution to missing, stale, or unsafe handoffs when isolation is added without a strong protocol.
+
+## Benchmark-validity findings
+
+- **Direct evidence:** Claw-SWE-Bench shows a 54.3-point same-model change from adapter design alone, which is larger than most reported multi-agent gains.
+- **Direct evidence:** RAH's confidence interval excludes uncertainty in the imported baseline because per-instance baseline outcomes were unavailable.
+- **Direct evidence:** ClawArena and the main SWARMRESEARCH comparison use one run per model or method despite stochastic execution.
+- **Direct evidence:** The paired-noise study demonstrates that a positive 18-point single-seed result can reverse sign on replication in an agent benchmark.
+- **Direct evidence:** MAGIS uses oracle modified-file input and its full system uses pull-request comments, while several SWE-bench Lite systems compared by MASAI use different hints and test commands.
+- **Direct evidence:** OrchBench's simulated resource measures do not predict real framework cost or time reliably.
+- **Direct evidence:** OrchestraBench's main chain is partly deterministic by construction and is executed by one agent rather than a real team.
+- **Audit inference:** A credible future benchmark must pair identical tasks and seeds, rerun both arms, preserve per-instance outcomes, and report confidence intervals for the paired difference.
+- **Audit inference:** It must also fix or disclose model version, harness, prompt, tools, patch extraction, hints, test visibility, context limits, retries, concurrency, cache pricing, and total model usage.
+
+## Overall conclusion
+
+The existing notes are directionally right that useful subagents require bounded roles, isolated state, structured artifacts, dependency-aware scheduling, and executable verification.
+They are too optimistic when they treat same-model results as sufficient evidence, describe synthetic orchestration probes as real multi-agent behavior, or omit unmatched analysis time, auxiliary information, model tiers, and total compute.
+Direct repository evidence favors carefully engineered partitioning and verification rather than agent count or open-ended conversation.
+Direct contradictory evidence shows that naive or automatically generated teams can cost more, solve less, communicate ineffectively, and become less reliable as agent count rises.
+The current literature therefore supports selective delegation under identifiable context or dependency pressure, not a general presumption that a coding parent should spawn subagents.
+The most important missing experiment is a paired, repeated repository-maintenance evaluation that compares one strong model in one harness against dynamic parent-subagent delegation, self-consistency, and naive parallelism under the same information, total token or dollar budget, wall-clock ceiling, and patch evaluator.
+
+## Limitations of this audit
+
+AlphaXiv discovery is ranked rather than exhaustive, and its two-search-per-message constraint required broad queries rather than a formal systematic-review search string over every synonym.
+AlphaXiv covers arXiv and related indexed papers but not all peer-reviewed venues, industry evaluations, unpublished negative results, or product telemetry.
+Several 2026 papers are recent preprints whose tables, titles, code, or conclusions may change after the cutoff.
+The audit verified paper text but did not reproduce code, rerun benchmarks, inspect released datasets, or validate provider billing logs.
+Reported dollar costs are not directly comparable across papers because models, provider prices, cache discounts, local workers, and accounting boundaries differ.
+The audit deliberately treats task scale, baseline fairness, and external validity separately, so a low confidence grade does not imply that a paper's internal measurements are false.
+The audit searched actively for contradiction, which improves balance but cannot prove that every relevant positive or negative paper was found.

--- a/docs/roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md
+++ b/docs/roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md
@@ -1,0 +1,182 @@
+# Pi Subagents Delegation Intelligence Roadmap
+
+- **Status:** Proposed strategic direction; not an implementation or release commitment.
+- **Audience:** `@narumitw/pi-subagents` maintainers and contributors.
+- **Planning horizon:** Evidence-qualified phases without delivery dates.
+- **Research basis:** [`2026-08-10-coding-agent-subagents-arxiv-survey.md`](../research/2026-08-10-coding-agent-subagents-arxiv-survey.md) and [`2026-08-10-coding-agent-subagents-engineering-notes.md`](../research/2026-08-10-coding-agent-subagents-engineering-notes.md).
+
+## Vision
+
+Evolve `pi-subagents` from a reliable process and lifecycle manager into a verifiable delegation system that decides when delegation is justified, transfers the information required for success, grants bounded authority, schedules only dependency-ready work, preserves provenance, and accepts results only through explicit evidence.
+
+Keep Pi as the owner of model execution, tools, sessions, provider behavior, and extension runtime mechanics.
+
+Keep `pi-subagents` as the owner of delegation contracts, execution planning, subagent lifecycle, orchestration state, handoff integrity, task-scoped policy, and delegation observability.
+
+## Objectives
+
+- **Preserve handoff fidelity** — Success: every opted-in delegation has a versioned request and result contract whose required inputs, outputs, evidence, limitations, and acceptance state survive chain, fan-in, detached completion, persistence, and inspection.
+- **Make authority reviewable** — Success: every contracted launch exposes requested, available, and effective capabilities and identifies overgrant, mismatch, and unsupported guarantees before side effects begin.
+- **Make inability actionable** — Success: capability mismatch, missing input, insufficient authority, unavailable verification, and ambiguous work produce typed outcomes that support clarification, rerouting, fallback, or safe termination rather than blind retry.
+- **Make orchestration dependency-aware** — Success: bounded WorkItem graphs own task identity, dependencies, artifacts, versions, ownership, invalidation, and terminal state, and cyclic graphs launch zero children.
+- **Use parallelism selectively** — Success: the scheduler treats configured concurrency as a ceiling, starts only ready and safely independent work, and records why delegation or parallel execution was selected.
+- **Reject stale evidence** — Success: changed semantic resources, repository generations, dependencies, or artifact versions cannot be silently combined with retained state or accepted as current verification.
+- **Measure orchestration quality** — Success: deterministic and representative evaluations report transfer coverage, delegation fidelity, permission precision, cascade radius, verification quality, cost, tokens, latency, and quality against credible non-orchestrated baselines.
+
+## Current State
+
+- `pi-subagents` already supports blocking single, parallel, chain, and fan-in execution plus detached reusable agents, mailboxes, inspection, read-only consultation, multiple transports, worktrees, recursion limits, work deadlines, bounded timeout finalization, idempotent spawn, persistence, and completion delivery.
+- `structured-v1` is an opt-in stateful result shape with `summary`, `evidence`, `changes`, `verification`, and `risks`, while blocking task, chain, and fan-in handoffs remain primarily free-form text.
+- Blocking chain execution substitutes raw previous output into `{previous}`, and fan-in composes bounded Markdown from worker outputs.
+- `AgentConfig` describes tools, model, thinking level, timeout, and prompt but has no versioned capability or result-format manifest.
+- Automatic transport selection distinguishes custom tools, write-capable built-ins, and read-only built-ins but does not evaluate task intent or capability fit.
+- Stateful lifecycle states distinguish starting, running, idle, completed, interrupted, failed, and closed but do not represent acknowledgement, blocked work, missing input, abstention, stale evidence, or revalidation.
+- `AgentRegistry` owns a bounded parent tree, FIFO turn queue, mailbox, persistence, and concurrency limits but not an explicit task-dependency or artifact graph.
+- Current trust, tool, cwd, and worktree policies are valuable controls but are not an operating-system filesystem, network, secret, or credential sandbox.
+- The package has no established benchmark baseline for handoff fidelity, permission precision, missing transfers, cascade radius, or the marginal value of orchestration over matched alternatives.
+
+## Guiding Principles
+
+- **Contracts before automation:** define requests, results, evidence, acknowledgement, and rejection before allowing policy to route or reject work.
+- **Audit before enforcement:** collect mismatches and overgrant evidence before changing established launches, and enforce only where the requested guarantee is technically real.
+- **Authority must be truthful:** distinguish enforced tool and runtime policy from advisory prompt scope and unsupported OS-level isolation.
+- **Dependencies before parallelism:** infer or declare task dependencies and cohesion before increasing worker count or selecting dynamic concurrency.
+- **Artifacts before conversation:** transfer bounded versioned artifacts and provenance rather than relying on unconstrained summaries or copied dialogue.
+- **Verification must be independent:** an implementation worker's report is evidence input, not sufficient acceptance proof for its own change.
+- **Recovery must match failure:** retry transient transport or tool failures, request missing inputs explicitly, and replan semantic or stale-state failures.
+- **No automatic side-effect replay:** uncertain or accepted write-capable work is never replayed solely because orchestration did not observe completion.
+- **Compatibility by omission:** existing payloads retain current behavior when new contract, capability, ledger, scheduler, and semantic-isolation fields are absent.
+- **Evidence before defaults:** new enforcement and scheduling behavior remains opt-in or audit-only until deterministic and representative measurements justify a default change.
+
+## Roadmap
+
+### Phase 1: Establish delegation contracts and structured handoffs
+
+- [ ] A versioned delegation-request contract covers task identity, objective, non-goals, dependencies, required inputs, requested authority, acceptance criteria, required evidence, and bounded budgets without claiming those requests are already enforced.
+- [ ] A versioned result contract preserves status, evidence-backed claims, artifact references, changed paths, verification results, limitations, unresolved dependencies, provenance, usage, and truncation metadata across every supported execution and delivery path.
+- [ ] Blocking single, parallel, chain, fan-in, and detached execution can opt into the same contract while existing text and `structured-v1` behavior remain compatible.
+- [ ] Chain and fan-in transfer validated structured envelopes when available and retain bounded raw text only as an explicit compatibility fallback.
+- [ ] Contract levels or profiles let small lookup tasks avoid the measured token, latency, and tool-call overhead of a full software delegation contract.
+- [ ] Deterministic contract tests cover malformed, partial, oversized, private, stale-version, unknown-field, and fallback behavior without silently presenting invalid structured data as successful evidence.
+
+**Outcome:** Every opted-in subagent boundary has a reviewable request, result, and evidence surface that later policy can safely inspect and enforce.
+
+### Phase 2: Add capability manifests and audit-only ExecutionPlan
+
+- [ ] Built-in and custom agent definitions can declare versioned capabilities, modalities, supported result contracts, authority needs, and verification roles while old definitions remain valid.
+- [ ] One transport-neutral `ExecutionPlan` records task requirements, selected agent, declared capability fit, requested and effective tools, cwd and trust decision, workspace mode, transport, model and thinking selection, budgets, and unsupported guarantees.
+- [ ] The first planner is deterministic and uses explicit contract requirements rather than task-keyword heuristics or an additional classifier model call.
+- [ ] Audit-only planning does not change the caller-selected agent, tools, transport, workspace, or launch result, but it reports mismatch, overgrant, omission, and unsupported-policy findings through bounded details and inspection.
+- [ ] Agent catalogs and inspection expose only safe manifest metadata and never expose system prompts, credentials, raw protected paths, or private context.
+- [ ] Baseline evaluation measures capability coverage and permission precision before any enforcement default is considered.
+
+**Outcome:** Maintainers can observe whether a launch is appropriately matched and minimally authorized without breaking existing workflows.
+
+### Phase 3: Enforce capabilities and make inability actionable
+
+- [ ] Contracted calls can explicitly request capability enforcement, while legacy and uncontracted calls retain audit-only behavior unless a separately approved compatibility change says otherwise.
+- [ ] Preflight acknowledgement returns a typed accepted or rejected decision before project-agent confirmation, worktree creation, child allocation, provider work, or other side effects.
+- [ ] Runtime results distinguish completed, partial, blocked, needs-input, abstained, failed, interrupted, stale, and contract-invalid outcomes with bounded reason codes and actionable recovery metadata.
+- [ ] Enforceable controls cover actual agent capability, tool allow-lists, cwd and trust policy, resource policy, workspace mode, result-contract support, concurrency, and budgets consistently across subprocess, in-process, RPC, and automatic transport.
+- [ ] Requested filesystem, network, secret, or credential guarantees fail closed when no real sandbox or policy provider can enforce them, rather than being represented as prompt-only protection.
+- [ ] Recovery policy retries only classified transient failures, requests exact missing inputs for dependency failures, reroutes capability mismatch, and never blindly replays work whose side effects may already have occurred.
+
+**Outcome:** The system can safely refuse, clarify, reroute, or stop unsuitable work without turning every inability into an opaque failure or repeated prompt.
+
+### Phase 4: Introduce a WorkItem and artifact ledger
+
+- [ ] A bounded WorkItem model owns workflow identity, task identity, dependencies, assignment, cohesive scope, artifact inputs and outputs, acceptance criteria, state, provenance, and terminal outcome without replacing Pi's agent loop.
+- [ ] Existing single, parallel, chain, fan-in, parent-child, and mailbox behavior projects into the ledger before an explicit DAG execution surface is admitted.
+- [ ] Explicit workflow graphs validate identifiers, dependencies, limits, ownership conflicts, and cycles before any child starts or project-authored agent confirmation appears.
+- [ ] Artifact versions and dependency generations make missing transfers, superseded inputs, conflicting ownership, and downstream invalidation observable.
+- [ ] One integration owner can assemble compatible artifacts, and one independently contextualized verifier can attach machine-executed acceptance evidence without becoming another completion owner.
+- [ ] Ledger state is bounded, redacted, branch-aware where applicable, versioned for persistence, recoverable after partial writes, and inspectable without exposing artifact contents by default.
+
+**Outcome:** Delegation becomes a reproducible state machine over tasks and artifacts rather than a collection of loosely related agent transcripts.
+
+### Phase 5: Add adaptive scheduling and semantic isolation
+
+- [ ] A dependency-aware ready queue starts only work whose required artifacts are current and whose effective scopes do not create known write, ownership, or integration conflicts.
+- [ ] Configured parallel limits remain hard ceilings, while effective concurrency adapts deterministically to ready work, cohesion, critical path, remaining budget, transport capacity, and workspace safety.
+- [ ] Semantic resource snapshots bind retained work to bounded identities or hashes for agent definition, role prompt, tool policy, model resolution, protected resources, repository generation, dependency artifacts, and scheduler policy without persisting secrets or full prompts.
+- [ ] Restore and continuation detect semantic skew and apply an explicit compatible, warn, needs-revalidation, or reject decision before new model work begins.
+- [ ] Upstream artifact or policy changes invalidate affected downstream work transitively, preserve prior evidence for diagnosis, and never auto-replay side effects.
+- [ ] Orchestration observability records decision reasons, transfers, acknowledgements, failures, retries, cancellations, invalidations, verification, cost, timing, and cascade radius through bounded safe metadata.
+- [ ] Matched evaluations compare the adaptive system with a strong single agent, equal-budget best-of-N, naive parallelism, fixed scheduling, and an orchestrator ablation before any default scheduling change.
+
+**Outcome:** `pi-subagents` uses concurrency and retained context only when the task graph and semantic state justify them, and it can prove when evidence remains current.
+
+## Cross-Cutting Verification Strategy
+
+- Every phase begins with deterministic characterization or failing behavior tests at the public contract and ends with focused tests, package checks, root `npm run check`, `git diff --check`, and `just pack subagents`.
+- Every changed asynchronous flow is audited for user cancellation, component disposal, session replacement, shutdown, stale generation after each `await`, partial creation, and repeated cleanup.
+- Every changed setting follows `docs/extension-settings.md` for side-effect-free loads, validation, latest-document reads, ordered writes, unknown-field preservation, atomic rename, rollback, reload behavior, and non-TUI handling.
+- Every model-facing and terminal-facing field is bounded, redacted, and sanitized before transfer, persistence, rendering, inspection, or completion delivery.
+- Representative live-provider smokes stop after one clear external failure and fall back to deterministic transport and fake-provider evidence unless a retry is explicitly requested.
+- Every published behavior change receives an independent package Changeset, while publication, tags, visibility changes, and release workflow dispatch remain separately approved actions.
+
+## Success Metrics
+
+| Indicator | Baseline | Target or invariant | Evidence source |
+| --- | --- | --- | --- |
+| Contract-valid opted-in completions | Not established | Baseline in Phase 1, then no silent contract-invalid success | Contract and provider-compatibility tests |
+| Required handoff transfer coverage | Not measured | Baseline in Phase 1, improvement target decided from evidence | Chain, fan-in, and workflow benchmark |
+| Capability mismatch detected before launch | Not represented | Every enforced mismatch | ExecutionPlan preflight tests |
+| Permission precision | Not measured | Baseline in Phase 2, target TBD | Requested-versus-effective authority audit |
+| Unsupported guarantees reported as enforced | Current docs warn globally | 0 | Policy matrix and inspection tests |
+| Blind retries for semantic or stale failures | No typed policy | 0 | Recovery-classification tests |
+| Cyclic workflow children started | No explicit workflow DAG | 0 | Graph preflight tests |
+| Downstream results silently accepted after dependency invalidation | Not represented | 0 | Generation and invalidation tests |
+| Independent acceptance evidence for contracted implementation work | Optional and unmeasured | Baseline in Phase 4, target TBD | Verifier and integration benchmark |
+| Agent count used as a scheduling objective | Fixed ceiling only | 0 policies that maximize count | Scheduler policy review |
+| Existing omitted-field behavior regressions | Current package behavior | 0 unapproved regressions | Compatibility suites and Pi smoke |
+| Orchestrated quality advantage over matched alternatives | Unknown | TBD from repeated target-framework evaluation | Benchmark matrix |
+
+Unsupported numeric improvement targets remain TBD until the package establishes repeatable baselines.
+
+## Risks and Dependencies
+
+| Risk or dependency | Impact | Mitigation or decision |
+| --- | --- | --- |
+| Contract detail increases cost and latency | Small tasks could become slower and more verbose | Support bounded contract levels, keep text compatibility, and measure overhead by task class before changing defaults. |
+| Capability metadata becomes cosmetic | Incorrect manifests could create false confidence | Keep audit-only first, expose requested versus effective policy, and require deterministic enforcement evidence. |
+| Intent inference becomes another unreliable model call | Routing cost and failure could exceed its value | Start from explicit requirements and deterministic matching, and gate learned routing on a later benchmark decision. |
+| Tool policy is mistaken for OS sandboxing | Users could believe paths, network, or secrets are protected when they are not | Represent enforceability explicitly and fail closed for requested unsupported guarantees. |
+| Result states proliferate without one owner | Callers could handle outcomes inconsistently | Give one versioned result contract and one recovery-policy owner across transports and orchestration modes. |
+| WorkItem ledger duplicates Pi session or agent execution | The package could become a second workflow runtime | Limit the ledger to delegation tasks, artifacts, policy, and orchestration state while Pi and existing transports retain execution ownership. |
+| Explicit DAG support widens tool schemas | Provider compatibility and prompt cost could regress | Project existing modes into the ledger first, bound graph size, and add an explicit mode only after schema compatibility tests. |
+| Semantic snapshots capture private material | Persistence could leak prompts, paths, or credentials | Store allowlisted identities and hashes only, redact paths, and never persist raw secrets or full prompts. |
+| Snapshot mismatches block useful restored work | Benign changes could produce unnecessary revalidation | Begin with warn and explicit compatibility rules, then enforce only mismatch classes proven unsafe. |
+| Adaptive scheduling obscures predictable ordering | Debugging and compatibility could become harder | Keep deterministic policy, preserve a legacy scheduler rollback, and expose every decision reason. |
+| Independent verification doubles work | Cost can rise without improving simple tasks | Require it only for selected risk classes and measure marginal value against executable acceptance evidence. |
+| New settings can be invalid to older releases | Downgrade can strand user configuration | Keep defaults compatible, document downgrade edits, and preserve unknown fields and old state readers. |
+
+## Non-Goals
+
+- Maximize subagent count, recursion depth, or configured concurrency.
+- Replace Pi's agent loop, provider retry, tool execution, session storage, compaction, or extension runtime.
+- Build a general-purpose distributed workflow engine, CI system, cron service, or unrestricted DAG scheduler.
+- Claim filesystem, process, network, secret, or credential isolation without a concrete enforcing runtime.
+- Parse hidden chain-of-thought or persist raw model reasoning as orchestration evidence.
+- Infer successful verification from assistant prose, terminal status, `agent_end`, `agent_settled`, or an exit code alone.
+- Automatically retry uncertain write-capable work or merge conflicting worktrees without explicit integration policy.
+- Make project-authored agents available without existing trust and confirmation protections.
+- Publish a package, change npm visibility, create a tag, or dispatch a release workflow without separate explicit approval.
+
+## Assumptions and Unknowns
+
+- The five-phase direction is approved for planning, while each implementation phase still requires its saved plan to be executed explicitly.
+- Existing text payloads, tool names, workflow modes, settings defaults, retained records, and transport choices remain compatible by omission.
+- `structured-v2` is expected to be additive, but its exact public field names remain subject to provider-schema and compatibility tests in Phase 1.
+- Capability requirements are expected to be explicit before learned or heuristic intent inference is considered.
+- It is unknown which requested path, network, credential, or sandbox controls Pi or a future public policy provider can enforce uniformly across all transports.
+- It is unknown which task classes justify full contracts, independent verification, adaptive scheduling, or multi-agent execution after overhead is included.
+- It is unknown whether explicit workflow DAGs belong in the existing `subagent` tool or a later separately named surface, so Phase 4 must decide from schema and usability evidence.
+- No delivery dates, staffing, publication schedule, or adoption target were provided.
+
+## Decisions and Changes
+
+- **2026-08-10 — Adopt research-grounded sequencing:** Build contracts before planning, audit before enforcement, dependency state before adaptive scheduling, and semantic snapshots before accepting restored evidence.
+- **2026-08-10 — Keep enforcement truthful:** Enforce only controls available through the selected runtime and report unsupported guarantees instead of treating prompt instructions as security boundaries.
+- **2026-08-10 — Treat verification and observability as cross-cutting:** Every phase carries independent-evidence and bounded-diagnostic requirements rather than deferring correctness measurement to the final scheduler.
+- **2026-08-10 — Keep defaults compatible:** New public behavior remains explicit, audit-only, or opt-in until package-specific evidence supports a separately approved default change.

--- a/docs/roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md
+++ b/docs/roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md
@@ -4,6 +4,10 @@
 - **Audience:** `@narumitw/pi-subagents` maintainers and contributors.
 - **Planning horizon:** Evidence-qualified phases without delivery dates.
 - **Research basis:** [`2026-08-10-coding-agent-subagents-arxiv-survey.md`](../research/2026-08-10-coding-agent-subagents-arxiv-survey.md) and [`2026-08-10-coding-agent-subagents-engineering-notes.md`](../research/2026-08-10-coding-agent-subagents-engineering-notes.md).
+- **Post-hoc research addition (2026-08-10):** Also use [`2026-08-10-coding-agent-subagents-evidence-audit.md`](../research/2026-08-10-coding-agent-subagents-evidence-audit.md) and [`2026-08-10-coding-agent-subagents-architecture-deep-dive.md`](../research/2026-08-10-coding-agent-subagents-architecture-deep-dive.md).
+  **Reason:** The deeper audit added strong single-agent counterevidence, stricter matched-baseline requirements, cancellation-generation requirements, and a smaller falsifiable architecture that the initial roadmap did not cover.
+- **Post-hoc status clarification (2026-08-10):** This direction remains proposed until an explicit approval records otherwise.
+  **Reason:** The original assumptions called the direction approved for planning even though the document header and repository evidence only established a proposal.
 
 ## Vision
 
@@ -22,6 +26,10 @@ Keep `pi-subagents` as the owner of delegation contracts, execution planning, su
 - **Use parallelism selectively** — Success: the scheduler treats configured concurrency as a ceiling, starts only ready and safely independent work, and records why delegation or parallel execution was selected.
 - **Reject stale evidence** — Success: changed semantic resources, repository generations, dependencies, or artifact versions cannot be silently combined with retained state or accepted as current verification.
 - **Measure orchestration quality** — Success: deterministic and representative evaluations report transfer coverage, delegation fidelity, permission precision, cascade radius, verification quality, cost, tokens, latency, and quality against credible non-orchestrated baselines.
+- **Post-hoc objective — Decide whether to delegate** — Success: an audit-first admission policy distinguishes parent-owned direct work, one child, one child plus independent verification, and bounded multi-child work, records its benefit hypothesis, and never treats subagent count as success.
+  **Reason:** The deeper evidence found that strong single-agent and equal-budget sampling baselines often match or beat automatic multi-agent systems.
+- **Post-hoc objective — Quarantine cancelled and replaced generations** — Success: task-version-bound authority is revoked on cancellation or replacement, and no result from an old generation can enter integration or satisfy current acceptance.
+  **Reason:** The initial roadmap audited cancellation but did not make late-result rejection an orchestration invariant.
 
 ## Current State
 
@@ -47,12 +55,18 @@ Keep `pi-subagents` as the owner of delegation contracts, execution planning, su
 - **No automatic side-effect replay:** uncertain or accepted write-capable work is never replayed solely because orchestration did not observe completion.
 - **Compatibility by omission:** existing payloads retain current behavior when new contract, capability, ledger, scheduler, and semantic-isolation fields are absent.
 - **Evidence before defaults:** new enforcement and scheduling behavior remains opt-in or audit-only until deterministic and representative measurements justify a default change.
+- **Post-hoc principle — Single-agent first:** keep parent-owned or one-child execution as the default recommendation unless explicit context, decomposition, specialist, or verification value exceeds coordination cost.
+  **Reason:** The deeper audit did not find a general matched-budget coding advantage for dynamic subagents.
+- **Post-hoc principle — Generation before side effects:** bind requests, plans, grants, artifacts, results, cancellation, and integration decisions to one immutable task generation before enforceable work begins.
+  **Reason:** Capability enforcement without generation identity cannot safely revoke authority or reject late results after replacement.
 
 ## Roadmap
 
 ### Phase 1: Establish delegation contracts and structured handoffs
 
 - [ ] A versioned delegation-request contract covers task identity, objective, non-goals, dependencies, required inputs, requested authority, acceptance criteria, required evidence, and bounded budgets without claiming those requests are already enforced.
+- [ ] **Post-hoc addition:** The executor attaches an immutable task generation and cancellation lineage to the request and stamps the normalized structured result with that generation without trusting model output or claiming enforcement.
+  **Reason:** Generation provenance must exist before later phases can revoke grants or quarantine results from cancelled and replaced work.
 - [ ] A versioned result contract preserves status, evidence-backed claims, artifact references, changed paths, verification results, limitations, unresolved dependencies, provenance, usage, and truncation metadata across every supported execution and delivery path.
 - [ ] Blocking single, parallel, chain, fan-in, and detached execution can opt into the same contract while existing text and `structured-v1` behavior remain compatible.
 - [ ] Chain and fan-in transfer validated structured envelopes when available and retain bounded raw text only as an explicit compatibility fallback.
@@ -66,6 +80,8 @@ Keep `pi-subagents` as the owner of delegation contracts, execution planning, su
 - [ ] Built-in and custom agent definitions can declare versioned capabilities, modalities, supported result contracts, authority needs, and verification roles while old definitions remain valid.
 - [ ] One transport-neutral `ExecutionPlan` records task requirements, selected agent, declared capability fit, requested and effective tools, cwd and trust decision, workspace mode, transport, model and thinking selection, budgets, and unsupported guarantees.
 - [ ] The first planner is deterministic and uses explicit contract requirements rather than task-keyword heuristics or an additional classifier model call.
+- [ ] **Post-hoc addition:** Audit-only `ExecutionPlan` records a delegation-admission recommendation, benefit hypothesis, task generation, and one of parent-owned direct work, one child, one child plus verification, or bounded multi-child work without changing launch behavior.
+  **Reason:** The original planner audited capability fit but did not answer the roadmap's core question of whether delegation was justified.
 - [ ] Audit-only planning does not change the caller-selected agent, tools, transport, workspace, or launch result, but it reports mismatch, overgrant, omission, and unsupported-policy findings through bounded details and inspection.
 - [ ] Agent catalogs and inspection expose only safe manifest metadata and never expose system prompts, credentials, raw protected paths, or private context.
 - [ ] Baseline evaluation measures capability coverage and permission precision before any enforcement default is considered.
@@ -76,10 +92,14 @@ Keep `pi-subagents` as the owner of delegation contracts, execution planning, su
 
 - [ ] Contracted calls can explicitly request capability enforcement, while legacy and uncontracted calls retain audit-only behavior unless a separately approved compatibility change says otherwise.
 - [ ] Preflight acknowledgement returns a typed accepted or rejected decision before project-agent confirmation, worktree creation, child allocation, provider work, or other side effects.
+- [ ] **Post-hoc addition:** Every enforceable capability grant is bound to the accepted task generation and `ExecutionPlan` identity, has an explicit lifetime, and is revocable before cancellation signals are delivered.
+  **Reason:** Phase 3 otherwise enforces authority before Phase 4 introduces enough version identity to prevent stale grants and late-result races.
 - [ ] Runtime results distinguish completed, partial, blocked, needs-input, abstained, failed, interrupted, stale, and contract-invalid outcomes with bounded reason codes and actionable recovery metadata.
 - [ ] Enforceable controls cover actual agent capability, tool allow-lists, cwd and trust policy, resource policy, workspace mode, result-contract support, concurrency, and budgets consistently across subprocess, in-process, RPC, and automatic transport.
 - [ ] Requested filesystem, network, secret, or credential guarantees fail closed when no real sandbox or policy provider can enforce them, rather than being represented as prompt-only protection.
 - [ ] Recovery policy retries only classified transient failures, requests exact missing inputs for dependency failures, reroutes capability mismatch, and never blindly replays work whose side effects may already have occurred.
+- [ ] **Post-hoc addition:** For contracted generation-aware work, cancellation or session replacement rotates the generation, revokes matching grants, classifies later completions as stale, and prevents them from triggering recovery or acceptance while legacy omitted-field behavior remains unchanged.
+  **Reason:** Logging cancellation is insufficient when detached or slow workers can settle after their owner has moved on.
 
 **Outcome:** The system can safely refuse, clarify, reroute, or stop unsuitable work without turning every inability into an opaque failure or repeated prompt.
 
@@ -90,13 +110,36 @@ Keep `pi-subagents` as the owner of delegation contracts, execution planning, su
 - [ ] Explicit workflow graphs validate identifiers, dependencies, limits, ownership conflicts, and cycles before any child starts or project-authored agent confirmation appears.
 - [ ] Artifact versions and dependency generations make missing transfers, superseded inputs, conflicting ownership, and downstream invalidation observable.
 - [ ] One integration owner can assemble compatible artifacts, and one independently contextualized verifier can attach machine-executed acceptance evidence without becoming another completion owner.
+- [ ] **Post-hoc addition:** In an opted-in managed-integration WorkItem, the integration owner is the only component allowed to update canonical integration state and must fail closed on stale task generation, base commit, dependency or read-set version, accepted-plan identity, scope, patch digest, or required evidence.
+  **Reason:** Worktree isolation prevents direct file interference but does not prevent logically incompatible or stale patches from being accepted.
+- [ ] **Post-hoc addition:** Cancellation forms a WorkItem subtree operation that rotates affected generations, quarantines late artifacts, preserves their diagnostic provenance, and never treats quarantine as successful completion.
+  **Reason:** The deeper research identified cancellation propagation and accepted late results as important unmeasured correctness risks.
 - [ ] Ledger state is bounded, redacted, branch-aware where applicable, versioned for persistence, recoverable after partial writes, and inspectable without exposing artifact contents by default.
 
 **Outcome:** Delegation becomes a reproducible state machine over tasks and artifacts rather than a collection of loosely related agent transcripts.
 
+### Post-hoc Gate 4A: Qualify minimal delegation admission before Phase 5
+
+**Post-hoc addition (2026-08-10):** This gate and its corresponding [`2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md`](../plans/2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md) were added after the initial five-phase roadmap.
+
+**Reason:** The deeper evidence showed that building adaptive orchestration before comparing it with strong simpler baselines could turn extra models, tokens, or harness differences into a false delegation advantage.
+
+- [ ] An audit-only deterministic admission policy is evaluated on paired repeated repository tasks against parent-owned or equivalent strong single-agent execution, one-child execution, equal-budget best-of-N, naive parallelism, and a fixed two-child architecture with the same model, information, harness, evaluator, token or dollar ceiling, and wall-clock ceiling.
+- [ ] The first multi-child experiment permits at most two concurrent mutating children and no recursive grandchildren, and it uses one integration owner plus one fresh-context verifier.
+- [ ] Outcomes report verified task success, cost, tokens, wall-clock time, unnecessary delegation, handoff coverage, conflicts, stale-result rejection, cancellation latency, leaked work, and accepted late results with paired confidence intervals.
+- [ ] A recorded **Admit**, **Revise**, or **Defer** decision determines whether Phase 5 may implement adaptive admission and scheduling, while contracts, capability audit, typed outcomes, and fail-closed integration remain useful independently.
+
+**Outcome:** Adaptive orchestration proceeds only if a small falsifiable architecture demonstrates value or a precisely bounded research gap justifies continued experimental work.
+
 ### Phase 5: Add adaptive scheduling and semantic isolation
 
+- [ ] **Post-hoc admission dependency:** Phase 5 implementation begins only after Gate 4A records **Admit** or a separately approved **Revise** scope.
+  **Reason:** The original roadmap postponed matched comparison until the end of adaptive-scheduler implementation.
 - [ ] A dependency-aware ready queue starts only work whose required artifacts are current and whose effective scopes do not create known write, ownership, or integration conflicts.
+- [ ] **Post-hoc addition:** The scheduler consumes the admitted audit policy and can recommend parent-owned direct work, one child, one child plus verification, or bounded multi-child work before allocating children.
+  **Reason:** Dependency-aware scheduling alone decides when work is ready, not whether spawning subagents is worthwhile.
+- [ ] **Post-hoc addition:** Multi-child mutation remains capped at the Gate 4A bound and recursive delegation remains disabled until a separate matched evaluation and approval justify expansion.
+  **Reason:** Wider teams and recursion would confound the first admission-policy evidence and can reduce success as coordination width grows.
 - [ ] Configured parallel limits remain hard ceilings, while effective concurrency adapts deterministically to ready work, cohesion, critical path, remaining budget, transport capacity, and workspace safety.
 - [ ] Semantic resource snapshots bind retained work to bounded identities or hashes for agent definition, role prompt, tool policy, model resolution, protected resources, repository generation, dependency artifacts, and scheduler policy without persisting secrets or full prompts.
 - [ ] Restore and continuation detect semantic skew and apply an explicit compatible, warn, needs-revalidation, or reject decision before new model work begins.
@@ -108,12 +151,13 @@ Keep `pi-subagents` as the owner of delegation contracts, execution planning, su
 
 ## Cross-Cutting Verification Strategy
 
-- Every phase begins with deterministic characterization or failing behavior tests at the public contract and ends with focused tests, package checks, root `npm run check`, `git diff --check`, and `just pack subagents`.
-- Every changed asynchronous flow is audited for user cancellation, component disposal, session replacement, shutdown, stale generation after each `await`, partial creation, and repeated cleanup.
-- Every changed setting follows `docs/extension-settings.md` for side-effect-free loads, validation, latest-document reads, ordered writes, unknown-field preservation, atomic rename, rollback, reload behavior, and non-TUI handling.
-- Every model-facing and terminal-facing field is bounded, redacted, and sanitized before transfer, persistence, rendering, inspection, or completion delivery.
-- Representative live-provider smokes stop after one clear external failure and fall back to deterministic transport and fake-provider evidence unless a retry is explicitly requested.
-- Every published behavior change receives an independent package Changeset, while publication, tags, visibility changes, and release workflow dispatch remain separately approved actions.
+**Post-hoc simplification (2026-08-10):** Keep strategic evidence invariants here and leave exact commands, test matrices, lifecycle audits, settings procedures, smokes, packaging, and Changeset tasks in each corresponding implementation plan.
+
+**Reason:** The original roadmap duplicated implementation checklists and blurred the boundary between strategic milestones and executable plans.
+
+- Every phase must preserve omitted-field compatibility, bound and sanitize model-facing data, and prove cancellation, replacement, stale-generation, partial-creation, restore, and repeated-cleanup behavior for its changed asynchronous flows.
+- Every phase must provide deterministic public-contract evidence and the smallest representative runtime evidence that its owning plan requires, while unavailable live-provider paths remain explicitly unverified rather than replaced with unsupported claims.
+- Every default, release, publication, tag, visibility, or workflow-dispatch change remains a separate evidence-backed and explicitly approved decision.
 
 ## Success Metrics
 
@@ -131,6 +175,10 @@ Keep `pi-subagents` as the owner of delegation contracts, execution planning, su
 | Agent count used as a scheduling objective | Fixed ceiling only | 0 policies that maximize count | Scheduler policy review |
 | Existing omitted-field behavior regressions | Current package behavior | 0 unapproved regressions | Compatibility suites and Pi smoke |
 | Orchestrated quality advantage over matched alternatives | Unknown | TBD from repeated target-framework evaluation | Benchmark matrix |
+| **Post-hoc:** Unnecessary delegation rate | Not measured | Baseline at Gate 4A, then no admitted policy without a task-stratified decision rule | Paired admission benchmark |
+| **Post-hoc:** Old-generation results accepted | Not represented | 0 | Cancellation, replacement, restore, and integration race tests |
+| **Post-hoc:** Stale integration inputs accepted | Not represented | 0 across generation, base, dependency, plan, scope, digest, and evidence checks | Integration-controller tests |
+| **Post-hoc:** Cancellation containment | Not measured | Baseline propagation latency and 0 accepted late results or leaked owned work in deterministic tests | Lifecycle failure-injection matrix |
 
 Unsupported numeric improvement targets remain TBD until the package establishes repeatable baselines.
 
@@ -150,6 +198,8 @@ Unsupported numeric improvement targets remain TBD until the package establishes
 | Adaptive scheduling obscures predictable ordering | Debugging and compatibility could become harder | Keep deterministic policy, preserve a legacy scheduler rollback, and expose every decision reason. |
 | Independent verification doubles work | Cost can rise without improving simple tasks | Require it only for selected risk classes and measure marginal value against executable acceptance evidence. |
 | New settings can be invalid to older releases | Downgrade can strand user configuration | Keep defaults compatible, document downgrade edits, and preserve unknown fields and old state readers. |
+| **Post-hoc:** Admission policy cannot predict delegation value | A router can add cost or reject work without improving verified success | Keep admission audit-only through Gate 4A, compare it with simpler baselines, and defer adaptive execution when paired evidence is absent. |
+| **Post-hoc:** Capability grants outlive their task generation | Cancelled or replaced work can retain authority or race a late result into integration | Bind grants to generation and accepted-plan identity, revoke before signalling cancellation, and fail closed at integration. |
 
 ## Non-Goals
 
@@ -165,7 +215,8 @@ Unsupported numeric improvement targets remain TBD until the package establishes
 
 ## Assumptions and Unknowns
 
-- The five-phase direction is approved for planning, while each implementation phase still requires its saved plan to be executed explicitly.
+- **Post-hoc correction (2026-08-10):** The direction remains proposed, and neither a phase nor Gate 4A is admitted for implementation until the user explicitly approves its saved plan.
+  **Reason:** The original statement claimed planning approval without an approval record and conflicted with the roadmap's proposed status.
 - Existing text payloads, tool names, workflow modes, settings defaults, retained records, and transport choices remain compatible by omission.
 - `structured-v2` is expected to be additive, but its exact public field names remain subject to provider-schema and compatibility tests in Phase 1.
 - Capability requirements are expected to be explicit before learned or heuristic intent inference is considered.
@@ -180,3 +231,7 @@ Unsupported numeric improvement targets remain TBD until the package establishes
 - **2026-08-10 — Keep enforcement truthful:** Enforce only controls available through the selected runtime and report unsupported guarantees instead of treating prompt instructions as security boundaries.
 - **2026-08-10 — Treat verification and observability as cross-cutting:** Every phase carries independent-evidence and bounded-diagnostic requirements rather than deferring correctness measurement to the final scheduler.
 - **2026-08-10 — Keep defaults compatible:** New public behavior remains explicit, audit-only, or opt-in until package-specific evidence supports a separately approved default change.
+- **Post-hoc addition, 2026-08-10 — Add a delegation-admission evidence gate:** Add Gate 4A, keep its router audit-only, constrain the first experiment to two mutating children without grandchildren, and require a recorded admission decision before adaptive scheduling.
+  **Reason:** The later AlphaXiv evidence audit found no general matched-budget coding advantage for dynamic subagents and identified strong single-agent, self-consistency, harness-confound, cancellation, and stale-integration counterevidence.
+- **Post-hoc addition, 2026-08-10 — Move generation and fail-closed integration earlier:** Carry task generation from the handoff contract through plans and grants, revoke it on cancellation, and reject stale integration inputs in Phase 4.
+  **Reason:** The original sequence treated cancellation mainly as an audit concern and deferred semantic rejection until Phase 5, leaving late-result and stale-patch races under-specified.


### PR DESCRIPTION
## Summary

- add an AlphaXiv-grounded survey of coding-agent subagent and orchestration research
- synthesize engineering evidence on delegation contracts, capability routing, dependency-aware scheduling, verification, and failure recovery
- define a five-phase `pi-subagents` delegation-intelligence roadmap
- add executable plans for handoff contract v2, audit-only ExecutionPlan, typed abstention and enforcement, the WorkItem ledger, and adaptive scheduling with semantic snapshots

## Planning principles

- contracts before automation
- audit before enforcement
- dependencies before parallelism
- artifacts and provenance before conversational handoffs
- independent verification and orchestration observability across every phase
- compatibility by omission until evidence supports a separately approved default change

## Verification

- pre-commit `biome check .`
- all workspace typechecks
- documentation structure, trailing-whitespace, final-newline, and local-link validation
- `git diff --cached --check`

## Scope

Documentation and planning only.
No package behavior, release metadata, or publication state changes.
