### PR TITLE
feat(sync): add reviewed mismatch recovery

### DIFF
--- a/.changeset/calm-sync-attention.md
+++ b/.changeset/calm-sync-attention.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Open reviewed synced-content recovery when automatic or interactive TUI sync detects a content-list mismatch, preserve deferred attention in the manager and editor, and keep deterministic and non-TUI routes non-blocking.

--- a/docs/plans/archived/2026-08-10_pi-sync-attention-recovery-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-sync-attention-recovery-plan.md
@@ -1,0 +1,330 @@
+# pi-sync attention recovery plan
+
+## Goal
+
+Let TUI users resolve an explicit local/remote synced-content-list mismatch at the point where
+pi-sync detects it, without requiring them to remember `/sync` or search Settings, while preserving
+every existing no-mutation default, exact review, privacy acknowledgement, force-push confirmation,
+remote freshness check, atomic settings write, cancellation, and non-TUI compatibility guarantee.
+
+## Context
+
+- The current package is `@narumitw/pi-sync` version 0.49.7, and the exact historical error
+  **Remote included content differs from this sync setup** no longer exists in current source.
+- The completed inline-selection work already routes no-argument manager operations into
+  **Synced content differs**, with review-first remote adoption and the existing reviewed local-wins
+  push.
+- `packages/pi-sync/test/sync.test.ts` deliberately proves that automatic selection mismatch is
+  warning-only and never opens recovery UI.
+- Direct `/sync sync`, `/sync pull`, and `/sync push` routes still convert a typed selection mismatch
+  into an actionable notification rather than continuing into the existing resolution flow.
+- `packages/pi-sync/src/manager-state.ts` always reports **Remote status: Not checked** because opening
+  the manager intentionally avoids remote I/O and cannot currently receive a mismatch already
+  observed by automatic sync.
+- Pi notifications, statuses, and widgets are not actionable controls, so copy-only changes cannot
+  remove the command-and-search step.
+- Pi TUI Kit supports lifecycle-owned menus using `ExtensionContext`, but the current pi-sync review,
+  cancellable-operation, dispatcher, and resolution APIs are typed around `ExtensionCommandContext`.
+- `sync-operations.ts` is already 1,000 lines and `manager-ui.ts` is above 900 lines, so new state and
+  orchestration must live in focused modules.
+- The worktree currently lacks installed test dependencies, and the research-time focused Vitest
+  command could not start because `vitest` was unavailable.
+- Implementation remains unauthorized until the user explicitly approves it; this plan creation does
+  not authorize product changes.
+
+## Architecture
+
+### Session-owned attention state
+
+Add a focused `sync-attention.ts` domain/presentation module that owns only in-memory state for the
+current session.
+
+The state will contain the typed `RemoteSelectionDecision`, the originating route, whether the
+startup offer has already been shown, and a generation or owner identity needed to reject stale
+continuations.
+
+The state will never contain credentials, file contents, unsanitized terminal text, mutable backend
+objects, or a captured stale context.
+
+The state will reset on `session_start`, abort on replacement or shutdown, and never be serialized to
+`pi-sync.json`, sync state, session entries, or snapshot metadata.
+
+Every resolution action will still reload and revalidate the setup, remote head, immutable snapshot,
+and local include list before mutation, so the in-memory decision is a navigation aid rather than an
+authority.
+
+### Automatic TUI recovery
+
+When startup automatic sync catches exactly `RemoteSelectionMismatchError`, it will retain the typed
+decision instead of reducing it immediately to a generic warning.
+
+In TUI mode, the session will open the existing **Synced content differs** flow once, with
+**Review all paths (recommended)** first and **Later** as the no-side-effect exit.
+
+The automatic offer will not appear for authentication, network, malformed settings, lock,
+secret-scan, publication, ordinary file-direction conflict, or unknown errors.
+
+Selecting **Later**, pressing Escape, cancelling a nested confirmation, or encountering an ordinary
+failure will return control to the Pi editor and preserve attention for later recovery.
+
+Session shutdown will never open a dialog because Pi is exiting, and shutdown mismatch will retain
+warning-only behavior for compatibility and lifecycle safety.
+
+### Persistent non-modal attention presentation
+
+After deferral or a non-resolving TUI route, pi-sync will show one compact, width-safe widget above
+the editor and the aggregated `sync` footer status.
+
+The widget will name the setup, show remote-only/device-only counts or the order-only condition, say
+that nothing changed, and identify `/sync` as the fallback route.
+
+The widget is informational rather than pretending to be clickable, and it will use textual meaning
+rather than color alone.
+
+The widget and attention status will clear only after a successful resolution, a fresh check proving
+that the lists match, a setup change that invalidates the decision, session replacement, or shutdown.
+
+Temporary activity text such as checking or pushing must restore the pending attention status rather
+than accidentally clearing it.
+
+### Manager priority and disabled state
+
+Pass current in-memory attention into the manager state projection without adding remote I/O to
+ordinary manager loading.
+
+When attention is current, the main screen will show **Sync status: Review needed**, place
+**Review synced content (recommended)** first, and keep **Sync now** visible but unavailable with the
+reason **Choose which content list to use first**.
+
+The main screen remains one flat group of at most seven actions and uses Pi TUI Kit's existing
+disabled-row reason presentation.
+
+Back from the review returns to the manager with attention intact, while successful resolution
+refreshes the manager and removes the disabled state.
+
+### Direct command behavior
+
+Interactive TUI invocations of `/sync sync`, `/sync pull`, and `/sync push` without `--yes` will feed
+a typed selection mismatch into the same dispatcher and review flow instead of ending at a
+notification.
+
+Established command names, flags, completions, setup targeting, exact previews, and force semantics
+will remain unchanged.
+
+TUI routes that explicitly use `--yes` will remain deterministic and non-resolving, but will show the
+exact mismatch and leave visible attention for manual recovery.
+
+RPC will remain read-only for remote-selection review and will not receive an unsolicited startup
+dialog.
+
+Print and JSON will retain their current observable rejection, and shutdown automation will retain
+warning-only behavior.
+
+### Shared context and route boundary
+
+Generalize only the UI and production-route surfaces needed by lifecycle recovery from
+`ExtensionCommandContext` to the smallest common `ExtensionContext`-compatible contract.
+
+Do not cast a lifecycle context to `ExtensionCommandContext` and do not expose command-only session
+replacement methods through a fake interface.
+
+Reuse `push()`, `pull()`, and `syncBoth()` production paths, the cross-process operation lock,
+`runCancellableOperation()`, `showRemoteSelectionReview()`, and the iterative manager dispatcher.
+
+If current Pi cannot safely host a `ctx.ui.custom()` interaction during `session_start`, stop after the
+qualification test and request approval for a deferred-idle or banner-only fallback rather than
+silently changing the approved experience.
+
+## Non-Goals
+
+- Do not automatically adopt the remote list or publish the device list.
+- Do not make the widget clickable or register a global keyboard shortcut.
+- Do not add `/sync review`, a new flag, a new settings field, or a stored snooze preference.
+- Do not persist a mismatch decision across processes or sessions.
+- Do not change ordered `sync.include` equality, snapshot selection format, sync state, backend wire
+  format, or the version 3 settings schema.
+- Do not make legacy snapshot discovery authoritative or adoptable.
+- Do not broaden interactive recovery to ordinary file-direction conflicts during automatic startup.
+- Do not weaken `--yes`, force-push, forced-pull, secret scan, backup, publication precondition, or
+  commit-boundary behavior.
+
+## Assumptions
+
+- The proposed startup interruption is acceptable only for a typed content-list mismatch that has
+  already blocked automatic sync.
+- **Later** means defer for the current interaction, not suppress the condition permanently.
+- The existing remote-adoption and local-wins implementations remain the sole mutation paths.
+- Direct routes without `--yes` are already interactive workflows, so continuing into reviewed TUI
+  recovery is compatible with their user intent.
+- A patch Changeset is required because the work changes published package behavior.
+
+## Unknowns
+
+- A real Pi smoke must confirm that a lifecycle-owned standard menu can safely open during
+  `session_start` without racing another startup UI or retaining stale focus.
+- The current test fixtures must be checked for a reliable way to distinguish automatic startup,
+  direct TUI, and shutdown contexts without source-text assertions.
+- The final widget height and copy must be validated at constrained terminal heights so persistent
+  recovery does not crowd the editor.
+
+## Risks
+
+- **Startup interruption:** A modal recovery screen may surprise users who only wanted to start Pi.
+  Mitigation: trigger only for the typed blocking mismatch, show it once per session, keep **Later**
+  immediate, and never trigger for generic failures.
+- **UI contention:** Another extension may also request startup interaction.
+  Mitigation: qualify the real lifecycle behavior first, retain one owner signal, and stop for an
+  approved fallback if Pi cannot safely serialize the interaction.
+- **Stale decision:** The setup or remote head can change after detection or deferral.
+  Mitigation: keep decisions in memory only and retain every existing local/remote revalidation before
+  settings or remote mutation.
+- **Status loss:** Existing operations clear the shared `sync` status in many completion paths.
+  Mitigation: centralize activity-versus-attention publication and test restoration after success,
+  failure, cancellation, and stale refresh.
+- **Unsafe over-classification:** A generic failure could accidentally expose a force action.
+  Mitigation: enter attention and resolution only from `RemoteSelectionMismatchError` or its typed
+  internal result.
+- **Automation regression:** RPC or `--yes` callers could unexpectedly block on a dialog.
+  Mitigation: keep those routes non-resolving and add explicit negative tests for every supported
+  mode.
+- **Lifecycle leak:** Startup prompt, widget, nested loader, or direct-route continuation could outlive
+  its session.
+  Mitigation: combine owner/action signals, abort and drain owned work, revalidate after every await,
+  and clear exact UI keys on replacement and shutdown.
+- **Source-size regression:** Changes could push large orchestration modules beyond the repository
+  boundary.
+  Mitigation: add a focused attention module and keep `sync-operations.ts` unchanged unless code is
+  first moved along a clear responsibility boundary.
+
+## Plan
+
+- [x] Install the locked workspace dependencies with `npm install`, verify no intended manifest or
+  lockfile change with `git diff -- package.json package-lock.json`, and run the four current focused
+  pi-sync suites to establish a green baseline before behavior changes.
+- [x] Add a narrow lifecycle qualification test and temporary local Pi smoke for opening and
+  cancelling an `ExtensionContext`-owned Pi TUI Kit menu during `session_start`; verify the test first
+  fails because automatic mismatch remains warning-only, and stop for user approval if the real
+  runtime cannot safely host the interaction.
+- [x] Add red-first tests in `packages/pi-sync/test/sync.test.ts` for a typed automatic selection
+  mismatch opening exactly one TUI recovery offer, **Later** returning without mutation, generic
+  automatic failures remaining notification-only, and shutdown remaining non-interactive; record the
+  intended assertion failures before production edits.
+- [x] Implement session-owned attention state in a focused `packages/pi-sync/src/sync-attention.ts`
+  module and connect only typed startup mismatch detection in `sync-extension.ts`; verify the new
+  automatic-flow tests pass without changing settings, files, sync state, or remote data.
+- [x] Add TUI presentation tests for the deferred attention widget and footer state,
+  terminal-control sanitization, remote/device counts, order-only wording, stable rendering at
+  32/60/100 columns and constrained heights, and exact cleanup on resolution, replacement, and
+  shutdown.
+- [x] Implement the compact attention widget and centralized activity/attention status restoration;
+  verify temporary checking/pushing states restore pending attention after cancellation or failure
+  and clear it only after a verified resolution or invalidation.
+- [x] Add red-first manager tests in `packages/pi-sync/test/menu-wording.test.ts` and
+  `packages/pi-sync/test/sync-resolution-ui.test.ts` for **Review synced content (recommended)** as
+  the first action, visible disabled **Sync now** with a reason, Back preserving attention, and
+  success refreshing the ordinary manager state.
+- [x] Pass attention into a structured manager-state projection and connect the existing
+  remote-selection dispatcher without remote I/O during ordinary manager loading; verify the action
+  group stays flat, bounded, sanitized, and at most seven rows.
+- [x] Add red-first command-boundary tests for direct TUI `sync`, `pull`, and `push` continuing into
+  resolution without `--yes`, while TUI `--yes`, RPC, print, and JSON remain non-resolving and
+  observable; verify setup targeting, completions, and ordinary error routing remain unchanged.
+- [x] Generalize the smallest shared context and route contracts needed by startup/direct recovery,
+  reuse existing locked production push/pull/sync paths, and make the direct-route tests pass without
+  casts to command context or duplicate feedback.
+- [x] Extend existing remote-selection tests for adoption, sessions acknowledgement refusal, local-wins
+  force-push preparation, stale remote refresh, concurrent local include change, continuation,
+  ordinary failure, and cancellation after deferral; verify every side effect still passes through
+  existing expected-storage/include and remote-revision checks.
+- [x] Extend lifecycle tests for Escape, Later, Back, Ctrl+C, component disposal, session replacement,
+  reload, repeated `session_start`, owner abort during loading, pre-commit cancellation, post-commit
+  non-cancellability, and pending-work draining; verify no stale context or widget survives shutdown.
+- [x] Update `packages/pi-sync/README.md` with automatic TUI attention, Later recovery, manager
+  priority, direct-route mode behavior, no-mutation guarantees, and accessibility limits; verify
+  every documented mode and action has matching deterministic test evidence. The Changesets release
+  workflow owns `CHANGELOG.md`, so no manual unreleased section was added.
+- [x] Add a patch Changeset for `@narumitw/pi-sync` and run `just changeset-status`; verify the release
+  intent names the user-visible recovery improvement and states that settings and snapshot schemas do
+  not change.
+- [x] Audit the complete diff against `docs/extension-conventions.md`,
+  `docs/extension-settings.md`, the touched-area checklist, and the accepted portable-selection ADR;
+  record command compatibility, settings concurrency, invalid-file protection, unknown-field
+  preservation, cancellation/disposal/replacement/shutdown, post-await freshness, terminal safety,
+  accessibility, source-size, and any deviation in this plan.
+- [x] Run focused Vitest suites, all pi-sync tests, `npm test`, `npm run check`, `git diff --check`,
+  `just pack sync`, and a temporary-agent TUI/RPC extension smoke without real credentials or remote
+  storage; inspect the tarball and leave every unavailable or failing verification unchecked.
+- [x] Compare the final implementation against every acceptance item below, inspect the selected diff
+  for unrelated changes, record exact evidence and unverified live-backend paths in this plan, and
+  move the fully completed plan to `docs/plans/archived/` only after all checks pass.
+
+## Evidence
+
+- Baseline: `npm install` resolved the lockfile, the intended Kit floor was then raised to the
+  registry-visible `@narumitw/pi-tui-kit@0.52.0`, and the four baseline suites passed 73 tests.
+- TDD: automatic recovery, direct recovery, manager priority, lock release, stale-attention cleanup,
+  and completed-force-push regressions each failed for the intended missing behavior before the
+  production fix and passed afterward.
+- Lifecycle: deterministic Pi TUI Kit harness tests cover startup opening, Later, Back, Ctrl+C,
+  replacement, shutdown, loader disposal, pre-commit cancellation, post-commit settlement, repeated
+  mismatch transitions, and concurrent state-directory access while the startup menu remains open.
+- Presentation: `sync-attention.test.ts` proves sanitized, cell-bounded 32/60/100-column rendering,
+  order-only wording, status restoration, and exact status/widget cleanup.
+- Modes: command-boundary tests prove direct interactive TUI recovery, non-interactive TUI `--yes`,
+  read-only RPC mismatch behavior, and shutdown warning-only behavior.
+- Safety: existing and extended tests prove remote-head and local-config revalidation, sessions privacy
+  refusal, atomic settings adoption, unknown-field preservation, force-push confirmation, and stale
+  refresh behavior.
+- Hardening: review fixed an unsolicited startup menu holding the state-directory migration guard,
+  stale attention after local setup changes or successful force push, non-current setup attention,
+  current-setup Sync-now gating, and stale callback identity races.
+- Package verification: all 39 pi-sync files passed 335 tests, `npm test` passed 2,651 tests in 232
+  files, and the final `npm run check` passed build, Biome, boundaries, all typechecks, and all tests.
+- Release verification: `just changeset-status` reports only a patch for `@narumitw/pi-sync`, and
+  `just pack sync` includes both new attention modules in a 58-file dry-run tarball.
+- Runtime verification: a temporary-agent Pi RPC process loaded the local extension and returned the
+  registered `/sync` command without credentials or remote storage.
+- Interactive TUI verification used the repository's real Pi TUI Kit harness because repository
+  execution policy forbids launching an interactive TUI command; no live-provider backend smoke was
+  run because this recovery path has deterministic backend doubles and needs no credentials.
+- Semantic audits found no settings or snapshot schema change, no migration, no extension-boundary
+  violation, no terminal-control leak, and no changed source file over 1,000 lines.
+- Documentation deviation: this repository's Changesets workflow owns release notes, so the README and
+  patch Changeset were updated instead of adding a manual `CHANGELOG.md` entry.
+
+## Rollback / Recovery
+
+The change adds no stored migration, so code rollback restores the prior warning-only automatic
+behavior without transforming settings, sync state, or remote snapshots.
+
+If the startup interaction proves disruptive after deterministic verification, revert the lifecycle
+entry while retaining existing inline manager recovery and remove its widget/attention state in the
+same focused rollback.
+
+Never roll back by automatically choosing a content list, deleting remote snapshots, rewriting
+`pi-sync.json`, or clearing an operation lock.
+
+## Completion Checklist
+
+- [x] A typed automatic content-list mismatch opens one immediate, review-first TUI recovery flow with
+  **Later**, while generic automatic failures and shutdown never open it.
+- [x] Deferral leaves settings, files, sync state, and remote data unchanged and leaves a compact,
+  sanitized, width-safe attention state visible until verified resolution or invalidation.
+- [x] The manager makes recovery the first action, explains why Sync now is unavailable, preserves
+  Back and Close behavior, and performs no extra remote I/O merely to open.
+- [x] Direct interactive TUI sync/pull/push routes resolve inline without `--yes`, while `--yes`, RPC,
+  print, JSON, command names, flags, completions, and setup targeting remain compatible.
+- [x] Remote adoption, sessions privacy acknowledgement, local-wins force push, stale refresh,
+  secrets, backups, publication preconditions, atomic settings writes, and commit boundaries retain
+  their existing production safeguards.
+- [x] Loading, empty, partial, success, error, disabled, cancellation, recovery, replacement, reload,
+  and shutdown states have deterministic behavior and test evidence.
+- [x] TUI output is keyboard-operable, textually meaningful without color, focus-safe, control-safe,
+  and bounded at tested widths and constrained heights.
+- [x] No settings, snapshot, sync-state, backend, or session-entry schema changes or migrations were
+  introduced, and unknown settings fields remain preserved.
+- [x] README, Changeset-managed release notes, semantic audits, focused tests, repository gate, package
+  dry run, and deterministic TUI/RPC smokes all match the final diff with unverified live-provider
+  paths recorded.
+- [x] Every plan task and completion item is checked with evidence, the final diff contains only the
+  approved scope, and the completed plan is archived before implementation is declared complete.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9934,7 +9934,7 @@
 			"version": "0.49.7",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1",
+				"@narumitw/pi-tui-kit": "^0.52.0",
 				"fast-xml-parser": "^5.10.1",
 				"proper-lockfile": "^4.1.2"
 			},
@@ -9948,28 +9948,6 @@
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-sync/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.49.3",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
-			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
-			"license": "MIT",
-			"dependencies": {
-				"highlight.js": "11.11.1"
-			},
-			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-sync/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"packages/pi-tui-kit": {

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -54,8 +54,11 @@ Remote status: Not checked
 ```
 
 Primary actions include **Sync now**, **Switch sync setup**, **Status & changes**, **Settings**, and
-**More…**. The standard manager also owns setup and connection lists/details plus history and
-recovery. Secondary screens provide **Back**; Escape goes back and Ctrl+C closes the flow.
+**More…**. When pi-sync has already detected a synced-content-list mismatch, the manager instead
+shows **Sync status: Review needed**, puts **Review synced content (recommended)** first, and keeps
+**Sync now** visibly unavailable until the choice is reviewed. Opening the manager still performs no
+new remote request. The standard manager also owns setup and connection lists/details plus history
+and recovery. Secondary screens provide **Back**; Escape goes back and Ctrl+C closes the flow.
 Destructive, credential-bearing, and externally visible operations retain exact specialized previews
 and confirmations.
 
@@ -76,6 +79,8 @@ Then choose one action:
 - **Keep this device's content list and update remote…** opens the existing `push --force` preparation and exact confirmation without `--yes`.
   Cancelling preparation or confirmation returns to the content-list choice without changing remote data.
 - **Cancel** returns to the manager without changing settings, files, remote data, or sync state.
+- **Later** appears when automatic startup sync detected the mismatch and returns immediately to the
+  Pi editor without changing anything.
 
 Choose **Review differences (recommended)** in an ordinary file-direction conflict to inspect the exact affected paths without changing local files, remote data, or sync state.
 Then choose one reviewed direction:
@@ -90,9 +95,20 @@ Then choose one reviewed direction:
 
 Cancelling a preparation or confirmation returns to conflict resolution with no side effects.
 Back returns to the sync manager, and Ctrl+C closes the complete flow.
-Automatic startup/shutdown sync never opens either interactive resolution and continues to report an actionable warning.
-Deterministic direct routes remain non-interactive and report remote-only, device-only, or order-only differences with `/sync` recovery guidance.
-RPC remote content-list review remains read-only, while print and JSON modes remain unsupported for `/sync` because their UI output is not observable.
+
+When automatic startup sync detects an explicit content-list mismatch in TUI mode, it opens
+**Synced content differs** once for that session instead of ending at a warning. Choosing **Later** or
+closing the flow leaves a compact **Pi Sync needs review** widget above the editor and a
+**review needed** footer status. The attention state is in memory only, contains no credentials or
+file contents, and is revalidated before any settings or remote mutation. It clears after verified
+resolution, invalidation, session replacement, or shutdown.
+
+Interactive TUI `/sync sync`, `/sync pull`, and `/sync push` routes without `--yes` open the same
+review flow when they detect the mismatch. Explicit `--yes` routes remain non-interactive and report
+exact remote-only, device-only, or order-only guidance while leaving visible attention for later
+review. Shutdown automatic sync never opens a dialog because Pi is exiting.
+RPC startup and direct routes remain read-only and notification-based, while print and JSON modes
+remain unsupported for `/sync` because their UI output is not observable.
 
 ## ⚙️ Settings
 
@@ -306,7 +322,7 @@ The operational state root is `<agent-dir>/pi-sync/`. An existing installation c
 
 ## ♿ Conditional terminal accessibility smoke
 
-Pi exposes terminal components rather than a semantic/ARIA tree. Release validation checks textual state, keyboard operation, Escape/Back, control escaping, and narrow rendering. Critical meaning appears in text such as `(current)`, `Warning`, `Invalid`, `Saved`, `Cancelled`, and `Applied`; color is supplementary.
+Pi exposes terminal components rather than a semantic/ARIA tree. Release validation checks textual state, keyboard operation, Escape/Back, control escaping, and narrow rendering. Critical meaning appears in text such as `(current)`, `Review needed`, `Later`, `Warning`, `Invalid`, `Saved`, `Cancelled`, and `Applied`; color is supplementary. The attention widget is informational and does not pretend to be a clickable control.
 
 ## 🗂️ Package layout
 
@@ -322,6 +338,8 @@ packages/pi-sync/
 │   ├── state-directory.ts
 │   ├── settings-management.ts
 │   ├── manager-ui.ts
+│   ├── manager-attention.ts
+│   ├── sync-attention.ts
 │   ├── storage-connections-ui.ts
 │   ├── sync-setups-ui.ts
 │   ├── file-selection.ts

--- a/packages/pi-sync/package.json
+++ b/packages/pi-sync/package.json
@@ -39,7 +39,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1",
+		"@narumitw/pi-tui-kit": "^0.52.0",
 		"fast-xml-parser": "^5.10.1",
 		"proper-lockfile": "^4.1.2"
 	},

--- a/packages/pi-sync/src/cancellable-operation.ts
+++ b/packages/pi-sync/src/cancellable-operation.ts
@@ -1,6 +1,6 @@
 import {
 	BorderedLoader,
-	type ExtensionCommandContext,
+	type ExtensionContext,
 	type KeybindingsManager,
 } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
@@ -36,7 +36,7 @@ interface CancellableOperationOptions {
 }
 
 export async function runCancellableOperation(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	message: string,
 	route: string,
 	runRoute: RunRoute,
@@ -53,7 +53,10 @@ export async function runCancellableOperation(
 	}
 	let commitStarted = false;
 	let routeResult: RunRouteResult | undefined;
-	const interaction = await runCustomInteraction<{ cancelled?: boolean; error?: unknown }>(ctx, {
+	const interaction = await runCustomInteraction<
+		{ cancelled?: boolean; error?: unknown },
+		ExtensionContext
+	>(ctx, {
 		signal,
 		isCurrent: () => !signal?.aborted,
 		create: ({ tui, theme, keybindings, signal: interactionSignal, complete }) => {

--- a/packages/pi-sync/src/manager-attention.ts
+++ b/packages/pi-sync/src/manager-attention.ts
@@ -1,0 +1,81 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ActionMenuItem } from "@narumitw/pi-tui-kit";
+import type { RunRoute } from "./cancellable-operation.js";
+import { dispatchManagerResult } from "./manager-result-dispatcher.js";
+import type { ManagerDescription } from "./manager-state.js";
+import type { SyncAttentionState } from "./sync-attention.js";
+
+export interface SyncManagerAttentionOptions {
+	getAttention?: () => SyncAttentionState | undefined;
+	onSelectionResolved?: (expected: SyncAttentionState) => void;
+}
+
+export function attentionMainMenuItems(
+	manager: ManagerDescription,
+): ActionMenuItem<"main" | "more" | "recovery", "review-attention">[] {
+	if (!manager.attention) return [];
+	const disabled = manager.attentionReviewDisabled === true;
+	return [
+		{
+			id: "review-attention",
+			label: "Review synced content (recommended)",
+			action: "review-attention",
+			...(disabled
+				? {
+						disabled: true,
+						disabledReason: "Finish or recover the active operation first.",
+					}
+				: {}),
+		},
+	];
+}
+
+export function blockedSyncMenuItem(
+	label: string,
+	manager: ManagerDescription,
+): ActionMenuItem<"main" | "more" | "recovery", "sync"> | undefined {
+	if (label !== "Sync now (recommended)" || !manager.attentionBlocksSync) return undefined;
+	return {
+		id: "sync",
+		label,
+		description: "Review first.",
+		action: "sync",
+		disabled: true,
+		disabledReason: "Review synced content first.",
+	};
+}
+
+export async function showManagerAttention(
+	ctx: ExtensionCommandContext,
+	attention: SyncAttentionState,
+	runRoute: RunRoute,
+	signal: AbortSignal | undefined,
+	onSelectionResolved: (() => void) | undefined,
+): Promise<"close" | "stay"> {
+	const { showRemoteSelectionReview } = await import("./remote-selection-ui.js");
+	if (signal?.aborted) return "close";
+	const review = await showRemoteSelectionReview(
+		ctx,
+		attention.decision.setupName,
+		signal,
+		undefined,
+		{
+			decision: attention.decision,
+			origin: attention.origin,
+			runRoute,
+			onSelectionResolved,
+		},
+	);
+	if (review.kind === "route-result") {
+		const disposition = await dispatchManagerResult(
+			ctx,
+			review.result,
+			review.route,
+			runRoute,
+			signal,
+			{ onSelectionResolved },
+		);
+		return disposition.kind;
+	}
+	return review.kind === "closed" || review.kind === "stale" ? "close" : "stay";
+}

--- a/packages/pi-sync/src/manager-result-dispatcher.ts
+++ b/packages/pi-sync/src/manager-result-dispatcher.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type {
 	CancellableOperationResult,
 	RunRoute,
@@ -14,12 +14,19 @@ export interface ManagerResultDisposition {
 	appliedRoute?: "sync" | "pull" | "push";
 }
 
+export interface ManagerResultOptions {
+	cancelLabel?: string;
+	onSelectionResolved?: () => void;
+	withStateAccess?: <T>(task: () => Promise<T>) => Promise<T>;
+}
+
 export async function dispatchManagerResult(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	initialResult: CancellableOperationResult,
 	origin: Exclude<RemoteSelectionOrigin, "settings">,
 	runRoute: RunRoute,
 	signal?: AbortSignal,
+	options: ManagerResultOptions = {},
 ): Promise<ManagerResultDisposition> {
 	let result: CancellableOperationResult | RunRouteResult = initialResult;
 	let currentRoute: "sync" | "pull" | "push" = origin;
@@ -38,6 +45,9 @@ export async function dispatchManagerResult(
 					decision: result.decision,
 					origin: currentRoute,
 					runRoute,
+					cancelLabel: options.cancelLabel,
+					onSelectionResolved: options.onSelectionResolved,
+					withStateAccess: options.withStateAccess,
 				},
 			);
 			if (resolution.kind === "route-result") {

--- a/packages/pi-sync/src/manager-state.ts
+++ b/packages/pi-sync/src/manager-state.ts
@@ -7,7 +7,8 @@ import {
 } from "./config.js";
 import { inspectLock, isStaleLock } from "./lock.js";
 import { errorMessage, ownRecord, safeTerminalText } from "./manager-helpers.js";
-import { syncIncludeSelection } from "./sync-policy.js";
+import { type SyncAttentionState, syncAttentionMatchesConfig } from "./sync-attention.js";
+import { compareSyncInclude, syncIncludeSelection } from "./sync-policy.js";
 import { countValidSyncSetups } from "./sync-setups-ui.js";
 import type { AnySyncConfig } from "./types.js";
 
@@ -19,9 +20,18 @@ export const MAIN_MENU_ACTIONS = [
 	"More…",
 ] as const;
 
+export interface ManagerDescription {
+	title: string;
+	actions: string[];
+	attention?: SyncAttentionState;
+	attentionBlocksSync?: boolean;
+	attentionReviewDisabled?: boolean;
+}
+
 export async function describeManagerState(
 	signal?: AbortSignal,
-): Promise<{ title: string; actions: string[] }> {
+	attention?: SyncAttentionState,
+): Promise<ManagerDescription> {
 	let raw: Record<string, unknown> | undefined;
 	try {
 		raw = await readLocalConfigObject();
@@ -66,6 +76,25 @@ export async function describeManagerState(
 		const recoverableLock =
 			lock.status === "unreadable" || (lock.status === "valid" && isStaleLock(lock.lock));
 		const selection = syncIncludeSelection(config.include);
+		let currentAttention: SyncAttentionState | undefined;
+		if (attention) {
+			try {
+				const attentionConfig =
+					attention.decision.setupName === config.setupName
+						? config
+						: await loadConfig(attention.decision.setupName);
+				if (syncAttentionMatchesConfig(attention, attentionConfig)) currentAttention = attention;
+			} catch {
+				currentAttention = undefined;
+			}
+			if (signal?.aborted) throw signal.reason;
+		}
+		const attentionComparison = currentAttention
+			? compareSyncInclude(
+					currentAttention.decision.localInclude,
+					currentAttention.decision.remoteInclude,
+				)
+			: undefined;
 		const noSyncedContent = config.include.length === 0;
 		const syncState =
 			liveLock || recoverableLock
@@ -92,7 +121,18 @@ export async function describeManagerState(
 				`Included: ${selection.builtIns.length} built-in group${selection.builtIns.length === 1 ? "" : "s"} · ${selection.custom.length} extra path${selection.custom.length === 1 ? "" : "s"} · Sessions ${selection.sessions ? "on" : "off"}`,
 				`Automatic sync: ${config.automatic ? "On" : "Off"}`,
 				`Last applied: ${lastAppliedSnapshot}`,
-				"Remote status: Not checked",
+				...(currentAttention
+					? [
+							currentAttention.decision.setupName === config.setupName
+								? "Sync status: Review needed"
+								: `Sync status: Review needed for setup ${safeTerminalText(currentAttention.decision.setupName)}`,
+							attentionComparison?.remoteOnly.length === 0 &&
+							attentionComparison.localOnly.length === 0
+								? "Only the synced-content order differs."
+								: `Remote-only paths: ${attentionComparison?.remoteOnly.length ?? 0} · Device-only paths: ${attentionComparison?.localOnly.length ?? 0}`,
+							"Nothing has been changed.",
+						]
+					: ["Remote status: Not checked"]),
 				...(noSyncedContent
 					? [
 							"",
@@ -117,6 +157,13 @@ export async function describeManagerState(
 					: noSyncedContent
 						? ["Settings", ...(canSwitch ? ["Switch sync setup"] : []), "Status & changes", "More…"]
 						: mainActions,
+			...(currentAttention
+				? {
+						attention: currentAttention,
+						attentionBlocksSync: currentAttention.decision.setupName === config.setupName,
+						attentionReviewDisabled: liveLock || recoverableLock,
+					}
+				: {}),
 		};
 	} catch (error) {
 		if (signal?.aborted) throw error;

--- a/packages/pi-sync/src/manager-ui.ts
+++ b/packages/pi-sync/src/manager-ui.ts
@@ -15,6 +15,12 @@ import {
 import { showAddGitTarget, showEditGitTarget, showGitSetup } from "./git-ui.js";
 import { inspectLock, isStaleLock } from "./lock.js";
 import {
+	attentionMainMenuItems,
+	blockedSyncMenuItem,
+	type SyncManagerAttentionOptions,
+	showManagerAttention,
+} from "./manager-attention.js";
+import {
 	errorMessage,
 	ownRecord,
 	requiredExistingBucket,
@@ -42,6 +48,7 @@ export async function showSyncManager(
 	ctx: ExtensionCommandContext,
 	runRoute: RunRoute,
 	sessionSignal?: AbortSignal,
+	options: SyncManagerAttentionOptions = {},
 ): Promise<void> {
 	if (!ctx.hasUI) {
 		await runRoute("help");
@@ -49,6 +56,7 @@ export async function showSyncManager(
 	}
 	type Screen = "main" | "more" | "recovery";
 	type Action =
+		| "review-attention"
 		| "sync"
 		| "switch"
 		| "diff"
@@ -74,7 +82,12 @@ export async function showSyncManager(
 				kind: "actions",
 				title: "Manage sync",
 				lines: state.manager.title.split("\n").slice(1),
-				items: state.manager.actions.map(syncMainMenuItem),
+				items: [
+					...attentionMainMenuItems(state.manager),
+					...state.manager.actions.map(
+						(label) => blockedSyncMenuItem(label, state.manager) ?? syncMainMenuItem(label),
+					),
+				],
 				hint: "close",
 			}),
 			more: () => ({
@@ -110,7 +123,28 @@ export async function showSyncManager(
 			}),
 		},
 		actions: {
+			"review-attention": async () => {
+				const attention = options.getAttention?.();
+				if (!attention) return { kind: "stay" };
+				const disposition = await showManagerAttention(
+					ctx,
+					attention,
+					runRoute,
+					sessionSignal,
+					() => options.onSelectionResolved?.(attention),
+				);
+				return { kind: disposition };
+			},
 			sync: async () => {
+				const pendingAttention = options.getAttention?.();
+				if (pendingAttention) {
+					const activeConfig = await loadConfig();
+					if (sessionSignal?.aborted) return { kind: "close" };
+					if (pendingAttention.decision.setupName === activeConfig.setupName) {
+						ctx.ui.notify("Review synced content before starting Sync now.", "warning");
+						return { kind: "stay" };
+					}
+				}
 				const result = await runCancellableOperation(
 					ctx,
 					"Checking current sync setup…",
@@ -225,10 +259,14 @@ export async function showSyncManager(
 	});
 	await runMenu(ctx, menu, {
 		getState: async () => {
+			const pendingAttention = options.getAttention?.();
 			const [manager, lock] = await Promise.all([
-				describeManagerState(sessionSignal),
+				describeManagerState(sessionSignal, pendingAttention),
 				inspectLock(),
 			]);
+			if (pendingAttention && options.getAttention?.() === pendingAttention && !manager.attention) {
+				options.onSelectionResolved?.(pendingAttention);
+			}
 			return {
 				manager,
 				canRecover:

--- a/packages/pi-sync/src/remote-selection-ui.ts
+++ b/packages/pi-sync/src/remote-selection-ui.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import { createSyncBackend, type SyncBackendFactory } from "./backend-factory.js";
 import {
@@ -33,6 +33,9 @@ export interface RemoteSelectionReviewOptions {
 	decision?: RemoteSelectionDecision;
 	origin?: RemoteSelectionOrigin;
 	runRoute?: RunRoute;
+	cancelLabel?: string;
+	onSelectionResolved?: () => void;
+	withStateAccess?: <T>(task: () => Promise<T>) => Promise<T>;
 }
 
 export type RemoteSelectionReviewResult =
@@ -43,7 +46,7 @@ export type RemoteSelectionReviewResult =
 	| { kind: "route-result"; result: RunRouteResult; route: "sync" | "pull" | "push" };
 
 export async function showRemoteSelectionReview(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	setupName?: string,
 	signal?: AbortSignal,
 	factory: SyncBackendFactory = createSyncBackend,
@@ -88,13 +91,11 @@ export async function showRemoteSelectionReview(
 				options.runRoute,
 				signal,
 				factory,
+				options,
 			);
 			if (result.kind !== "refresh") return result;
-			const refreshed = await inspectConfiguredRemoteSelection(
-				ctx,
-				currentDecision.setupName,
-				signal,
-				factory,
+			const refreshed = await runWithOptionalStateAccess(options, () =>
+				inspectConfiguredRemoteSelection(ctx, currentDecision.setupName, signal, factory),
 			);
 			if (!refreshed || signal?.aborted) return { kind: "stale" };
 			if (refreshed.kind === "empty") {
@@ -108,7 +109,8 @@ export async function showRemoteSelectionReview(
 						: "The refreshed legacy snapshot has no authoritative synced-content list.",
 					"info",
 				);
-				return { kind: "back" };
+				options.onSelectionResolved?.();
+				return { kind: "done" };
 			}
 			currentDecision = decisionFromState(refreshed.config, refreshed.state);
 		}
@@ -124,12 +126,16 @@ export async function showRemoteSelectionReview(
 type DifferenceFlowResult = RemoteSelectionReviewResult | { kind: "refresh" };
 
 async function showSelectionDifference(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	initialDecision: RemoteSelectionDecision,
 	origin: RemoteSelectionOrigin,
 	runRoute: RunRoute | undefined,
 	sessionSignal: AbortSignal | undefined,
 	factory: SyncBackendFactory,
+	options: Pick<
+		RemoteSelectionReviewOptions,
+		"cancelLabel" | "onSelectionResolved" | "withStateAccess"
+	>,
 ): Promise<DifferenceFlowResult> {
 	type Screen = "choice" | "review" | "saved";
 	type Action = "adopt" | "keep" | "cancel" | "continue" | "done";
@@ -142,7 +148,7 @@ async function showSelectionDifference(
 	let nextResult: RemoteSelectionReviewResult | undefined;
 	let refreshRequested = false;
 	const route = origin === "settings" ? "sync" : origin;
-	const menu = defineMenu<FlowState, Screen, Action, ExtensionCommandContext>({
+	const menu = defineMenu<FlowState, Screen, Action, ExtensionContext>({
 		start: "choice",
 		screens: {
 			choice: ({ state }) => ({
@@ -169,7 +175,7 @@ async function showSelectionDifference(
 							"Open the existing exact force-push preview without skipping confirmation.",
 						action: "keep",
 					},
-					{ id: "cancel", label: "Cancel", action: "cancel" },
+					{ id: "cancel", label: options.cancelLabel ?? "Cancel", action: "cancel" },
 				],
 				hint: "back",
 			}),
@@ -224,10 +230,14 @@ async function showSelectionDifference(
 						if (signal.aborted) return { kind: "close" as const };
 						if (!acknowledged) return { kind: "stay" as const };
 					}
-					const review = await loadAdoptionReview(state.decision, signal, factory);
+					const review = await runWithOptionalStateAccess(options, async () => {
+						const loaded = await loadAdoptionReview(state.decision, signal, factory);
+						if (signal.aborted) throw signal.reason;
+						await revalidateAndAdopt(loaded, state.decision, signal);
+						return loaded;
+					});
 					if (signal.aborted) return { kind: "close" as const };
-					await revalidateAndAdopt(review, state.decision, signal);
-					if (signal.aborted) return { kind: "close" as const };
+					options.onSelectionResolved?.();
 					continuationReview = {
 						...review.storageReview,
 						setupName: state.decision.setupName,
@@ -324,6 +334,9 @@ async function showSelectionDifference(
 		result: Awaited<ReturnType<typeof runCancellableOperation>>,
 		nestedRoute: "sync" | "pull" | "push",
 	) {
+		if (result.kind === "completed" && result.outcome === "applied") {
+			options.onSelectionResolved?.();
+		}
 		if (result.kind === "closed") {
 			nextResult = { kind: "closed" };
 			return { kind: "close" as const };
@@ -437,7 +450,7 @@ async function revalidateAndAdopt(
 }
 
 async function inspectConfiguredRemoteSelection(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	setupName: string | undefined,
 	signal: AbortSignal | undefined,
 	factory: SyncBackendFactory,
@@ -464,12 +477,12 @@ async function inspectConfiguredRemoteSelection(
 }
 
 async function showLegacyDiscovery(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	config: AnySyncConfig,
 	discovered: string[],
 	signal?: AbortSignal,
 ) {
-	const menu = defineMenu<undefined, "choice" | "review", "back", ExtensionCommandContext>({
+	const menu = defineMenu<undefined, "choice" | "review", "back", ExtensionContext>({
 		start: "choice",
 		screens: {
 			choice: () => ({
@@ -644,6 +657,13 @@ function isStaleReviewError(error: unknown) {
 	return (
 		error instanceof StaleRemoteSelectionReviewError || error instanceof SyncSetupReviewChangedError
 	);
+}
+
+function runWithOptionalStateAccess<T>(
+	options: Pick<RemoteSelectionReviewOptions, "withStateAccess">,
+	task: () => Promise<T>,
+) {
+	return options.withStateAccess ? options.withStateAccess(task) : task();
 }
 
 function combineSignals(sessionSignal: AbortSignal | undefined, actionSignal: AbortSignal) {

--- a/packages/pi-sync/src/sync-attention.ts
+++ b/packages/pi-sync/src/sync-attention.ts
@@ -1,0 +1,100 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+import { syncConfigReviewFingerprint } from "./config.js";
+import { safeTerminalText } from "./sync-format.js";
+import {
+	compareSyncInclude,
+	type RemoteSelectionDecision,
+	sameSyncInclude,
+} from "./sync-policy.js";
+import type { AnySyncConfig } from "./types.js";
+
+const STATUS_KEY = "sync";
+const WIDGET_KEY = "sync:attention";
+
+export type SyncAttentionOrigin = "sync" | "pull" | "push";
+
+export interface SyncAttentionState {
+	decision: RemoteSelectionDecision;
+	origin: SyncAttentionOrigin;
+	offered: boolean;
+}
+
+export function syncAttentionMatchesConfig(attention: SyncAttentionState, config: AnySyncConfig) {
+	return (
+		attention.decision.setupName === config.setupName &&
+		attention.decision.configIdentity === syncConfigReviewFingerprint(config) &&
+		sameSyncInclude(attention.decision.localInclude, config.include)
+	);
+}
+
+export interface SyncAttentionController {
+	set(decision: RemoteSelectionDecision, origin: SyncAttentionOrigin): void;
+	current(): SyncAttentionState | undefined;
+	markOffered(): boolean;
+	clear(ctx: ExtensionContext): void;
+	reset(ctx: ExtensionContext): void;
+	publish(ctx: ExtensionContext): void;
+}
+
+export function createSyncAttentionController(): SyncAttentionController {
+	let state: SyncAttentionState | undefined;
+
+	return {
+		set(decision, origin) {
+			state = { decision, origin, offered: false };
+		},
+		current() {
+			return state;
+		},
+		markOffered() {
+			if (!state || state.offered) return false;
+			state = { ...state, offered: true };
+			return true;
+		},
+		clear(ctx) {
+			state = undefined;
+			clearAttentionPresentation(ctx);
+		},
+		reset(ctx) {
+			state = undefined;
+			clearAttentionPresentation(ctx);
+		},
+		publish(ctx) {
+			if (!state) {
+				clearAttentionPresentation(ctx);
+				return;
+			}
+			const presentation = attentionPresentation(state.decision);
+			ctx.ui.setStatus(STATUS_KEY, presentation.status);
+			if (ctx.mode !== "tui") return;
+			ctx.ui.setWidget(WIDGET_KEY, (_tui, theme) => ({
+				render(width: number) {
+					const safeWidth = Math.max(1, width);
+					return presentation.lines.map((line, index) =>
+						truncateToWidth(theme.fg(index === 0 ? "warning" : "muted", line), safeWidth, "…"),
+					);
+				},
+				invalidate() {},
+			}));
+		},
+	};
+}
+
+function attentionPresentation(decision: RemoteSelectionDecision) {
+	const setupName = safeTerminalText(decision.setupName);
+	const comparison = compareSyncInclude(decision.localInclude, decision.remoteInclude);
+	const difference =
+		comparison.remoteOnly.length === 0 && comparison.localOnly.length === 0
+			? "Only list order differs"
+			: `Remote ${comparison.remoteOnly.length} · Device ${comparison.localOnly.length}`;
+	return {
+		status: "review needed",
+		lines: [`Pi Sync needs review · ${setupName}`, difference, "No changes · Run /sync to review"],
+	};
+}
+
+function clearAttentionPresentation(ctx: ExtensionContext) {
+	ctx.ui.setStatus(STATUS_KEY, undefined);
+	ctx.ui.setWidget(WIDGET_KEY, undefined);
+}

--- a/packages/pi-sync/src/sync-extension.ts
+++ b/packages/pi-sync/src/sync-extension.ts
@@ -37,11 +37,21 @@ import {
 	withStateDirectoryAccess,
 } from "./state-directory.js";
 import {
+	createSyncAttentionController,
+	type SyncAttentionController,
+	type SyncAttentionOrigin,
+	syncAttentionMatchesConfig,
+} from "./sync-attention.js";
+import {
 	errorMessage,
 	isSyncDecisionRequiredError,
 	SetupPullRequiresUiError,
 } from "./sync-errors.js";
-import { formatRemoteSelectionMismatch, RemoteSelectionMismatchError } from "./sync-policy.js";
+import {
+	formatRemoteSelectionMismatch,
+	type RemoteSelectionDecision,
+	RemoteSelectionMismatchError,
+} from "./sync-policy.js";
 import type { AnySyncConfig, CommandOptions, SnapshotOptions } from "./types.js";
 
 const STATUS_KEY = "sync";
@@ -85,6 +95,7 @@ export default function sync(pi: ExtensionAPI, dependencies: Partial<SyncDepende
 			dependencies.loadSyncOperations ?? (() => import("./sync-operations.js")),
 		),
 	};
+	const attention = createSyncAttentionController();
 	let sessionAbort = new AbortController();
 	let shutdownAbort: AbortController | undefined;
 
@@ -97,7 +108,7 @@ export default function sync(pi: ExtensionAPI, dependencies: Partial<SyncDepende
 					"/sync requires TUI or RPC mode so results and safety prompts are observable.",
 				);
 			}
-			const run = () => handleCommand(args, ctx, sessionAbort.signal, loaders);
+			const run = () => handleCommand(args, ctx, sessionAbort.signal, loaders, attention);
 			if (splitArgs(args)[0] === "migrate-state") await run();
 			else await withStateDirectoryAccess(run);
 		},
@@ -109,17 +120,38 @@ export default function sync(pi: ExtensionAPI, dependencies: Partial<SyncDepende
 		sessionAbort.abort(new DOMException("Session replaced", "AbortError"));
 		sessionAbort = new AbortController();
 		const signal = sessionAbort.signal;
-		ctx.ui.setStatus(STATUS_KEY, undefined);
+		attention.reset(ctx);
+		let decision: RemoteSelectionDecision | undefined;
 		try {
-			await withStateDirectoryAccess(() => startSession(ctx, signal, loaders));
+			decision = await withStateDirectoryAccess(() => startSession(ctx, signal, loaders));
 		} catch (error) {
 			if (signal.aborted) return;
 			ctx.ui.notify(`pi-sync state access failed: ${errorMessage(error)}`, "error");
+			return;
 		}
+		if (!decision || signal.aborted) return;
+		attention.set(decision, "sync");
+		if (ctx.mode !== "tui") {
+			ctx.ui.notify(
+				`pi-sync auto sync skipped: ${formatRemoteSelectionMismatch(
+					decision.setupName,
+					decision.localInclude,
+					decision.remoteInclude,
+				)}\nRPC review is read-only.`,
+				"warning",
+			);
+		} else if (attention.markOffered()) {
+			await resolveSelectionAttention(ctx, attention, signal, loaders, {
+				cancelLabel: "Later",
+				withStateAccess: withStateDirectoryAccess,
+			});
+		}
+		if (!signal.aborted) attention.publish(ctx);
 	});
 
 	pi.on("session_shutdown", async (event, ctx) => {
 		sessionAbort.abort(new DOMException("Session shut down", "AbortError"));
+		attention.reset(ctx);
 		shutdownAbort?.abort(new DOMException("Session shut down again", "AbortError"));
 		const controller = new AbortController();
 		shutdownAbort = controller;
@@ -172,7 +204,7 @@ async function startSession(ctx: ExtensionContext, signal: AbortSignal, loaders:
 	const migrationNotice = consumeLocalConfigMigrationNotice();
 	if (migrationNotice) ctx.ui.notify(migrationNotice, "warning");
 	if (signal.aborted) return;
-	await autoSync(ctx, signal, loaders);
+	return autoSync(ctx, signal, loaders);
 }
 
 async function handleCommand(
@@ -180,6 +212,7 @@ async function handleCommand(
 	ctx: ExtensionCommandContext,
 	sessionSignal: AbortSignal,
 	loaders: SyncLoaders,
+	attention: SyncAttentionController,
 ) {
 	if (!rawArgs.trim()) {
 		try {
@@ -197,26 +230,173 @@ async function handleCommand(
 						target,
 					),
 				sessionSignal,
+				{
+					getAttention: () => attention.current(),
+					onSelectionResolved: (expected) => {
+						if (attention.current() === expected) attention.clear(ctx);
+					},
+				},
 			);
 		} catch (error) {
 			if (sessionSignal.aborted) return;
 			ctx.ui.setStatus(STATUS_KEY, undefined);
 			ctx.ui.notify(errorMessage(error), "error");
 		}
+		if (!sessionSignal.aborted) attention.publish(ctx);
 		return;
 	}
 	const result = await executeCommand(rawArgs, ctx, sessionSignal, loaders);
 	if (result.kind === "decision-required") {
 		ctx.ui.notify(result.decision.directMessage, "error");
 	} else if (result.kind === "remote-selection-required") {
-		ctx.ui.notify(
-			formatRemoteSelectionMismatch(
-				result.decision.setupName,
-				result.decision.localInclude,
-				result.decision.remoteInclude,
-			),
-			"error",
-		);
+		const origin = directSelectionOrigin(rawArgs);
+		if (origin) attention.set(result.decision, origin);
+		const deterministic = splitArgs(rawArgs).some((arg) => arg === "--yes" || arg === "-y");
+		if (origin && ctx.mode === "tui" && !deterministic) {
+			await resolveSelectionAttention(ctx, attention, sessionSignal, loaders);
+		} else {
+			ctx.ui.notify(
+				formatRemoteSelectionMismatch(
+					result.decision.setupName,
+					result.decision.localInclude,
+					result.decision.remoteInclude,
+				),
+				"error",
+			);
+		}
+	}
+	await clearAttentionAfterCompletedOperation(rawArgs, result, ctx, attention, sessionSignal);
+	await reconcileSelectionAttention(ctx, attention, sessionSignal);
+	if (!sessionSignal.aborted) attention.publish(ctx);
+}
+
+async function clearAttentionAfterCompletedOperation(
+	rawArgs: string,
+	result: RunRouteResult,
+	ctx: ExtensionContext,
+	attention: SyncAttentionController,
+	signal: AbortSignal,
+) {
+	if (result.kind !== "completed" || result.outcome === "cancelled" || signal.aborted) return;
+	const [command, ...rest] = splitArgs(rawArgs);
+	if (command !== "sync" && command !== "pull" && command !== "push") return;
+	const current = attention.current();
+	if (!current) return;
+	try {
+		const options = parseOptions(rest);
+		const setupName = options.setup ?? (await loadConfig()).setupName;
+		if (signal.aborted || attention.current() !== current) return;
+		if (current.decision.setupName === setupName) attention.clear(ctx);
+	} catch {
+		// Attention reconciliation below owns malformed or concurrently changed settings.
+	}
+}
+
+async function reconcileSelectionAttention(
+	ctx: ExtensionContext,
+	attention: SyncAttentionController,
+	signal: AbortSignal,
+) {
+	const current = attention.current();
+	if (!current || signal.aborted) return;
+	try {
+		const config = await loadConfig(current.decision.setupName);
+		if (signal.aborted || attention.current() !== current) return;
+		if (!syncAttentionMatchesConfig(current, config)) attention.clear(ctx);
+	} catch {
+		if (!signal.aborted && attention.current() === current) attention.clear(ctx);
+	}
+}
+
+function directSelectionOrigin(rawArgs: string): SyncAttentionOrigin | undefined {
+	const command = splitArgs(rawArgs)[0];
+	return command === "sync" || command === "pull" || command === "push" ? command : undefined;
+}
+
+async function resolveSelectionAttention(
+	ctx: ExtensionContext,
+	attention: SyncAttentionController,
+	signal: AbortSignal,
+	loaders: SyncLoaders,
+	options: {
+		cancelLabel?: string;
+		withStateAccess?: <T>(task: () => Promise<T>) => Promise<T>;
+	} = {},
+) {
+	const current = attention.current();
+	if (!current || signal.aborted) return;
+	const { dispatchManagerResult } = await import("./manager-result-dispatcher.js");
+	if (signal.aborted || attention.current() !== current) return;
+	await dispatchManagerResult(
+		ctx,
+		{ kind: "remote-selection-required", decision: current.decision },
+		current.origin,
+		(route, actionSignal, onCommit, target) => {
+			const execute = () =>
+				executeRecoveryCommand(
+					route,
+					ctx,
+					combineSignals(signal, actionSignal),
+					loaders,
+					onCommit,
+					target,
+				);
+			return options.withStateAccess ? options.withStateAccess(execute) : execute();
+		},
+		signal,
+		{
+			cancelLabel: options.cancelLabel,
+			withStateAccess: options.withStateAccess,
+			onSelectionResolved: () => {
+				if (attention.current() === current) attention.clear(ctx);
+			},
+		},
+	);
+}
+
+async function executeRecoveryCommand(
+	rawArgs: string,
+	ctx: ExtensionContext,
+	signal: AbortSignal | undefined,
+	loaders: SyncLoaders,
+	onCommit?: () => void,
+	setup?: string,
+): Promise<RunRouteResult> {
+	try {
+		const [subcommand, ...rest] = splitArgs(rawArgs);
+		if (subcommand !== "sync" && subcommand !== "pull" && subcommand !== "push") {
+			throw new Error(`Unsupported sync recovery route: ${subcommand ?? "missing"}`);
+		}
+		const options = parseOptions(rest);
+		if (setup !== undefined) options.setup = setup;
+		if (signal) options.signal = signal;
+		if (onCommit) options.onCommit = onCommit;
+		options.reload = false;
+		options.auto = false;
+		validateCommandOptions(subcommand, options);
+		const operations = await loaders.operations();
+		throwIfAborted(options.signal);
+		if (subcommand === "push") {
+			const outcome = await withLock("push", () => operations.push(ctx, options));
+			return { kind: "completed", ...(outcome ? { outcome } : {}) };
+		}
+		if (subcommand === "pull") {
+			const outcome = await withLock("pull", () => operations.pull(ctx, options));
+			return { kind: "completed", ...(outcome ? { outcome } : {}) };
+		}
+		await withLock("sync", () => operations.syncBoth(ctx, options));
+		return { kind: "completed" };
+	} catch (error) {
+		if (signal?.aborted) return { kind: "failed" };
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		if (error instanceof RemoteSelectionMismatchError) {
+			return { kind: "remote-selection-required", decision: error.decision };
+		}
+		if (isSyncDecisionRequiredError(error)) {
+			return { kind: "decision-required", decision: error.decision };
+		}
+		ctx.ui.notify(errorMessage(error), "error");
+		return { kind: "failed" };
 	}
 }
 
@@ -372,7 +552,11 @@ async function migrateStateDirectory(ctx: ExtensionCommandContext, options: Comm
 	ctx.ui.notify(result.message, result.status === "migrated" ? "info" : "warning");
 }
 
-async function autoSync(ctx: ExtensionContext, signal: AbortSignal, loaders: SyncLoaders) {
+async function autoSync(
+	ctx: ExtensionContext,
+	signal: AbortSignal,
+	loaders: SyncLoaders,
+): Promise<RemoteSelectionDecision | undefined> {
 	try {
 		const partial = await loadPartialConfig();
 		throwIfAborted(signal);
@@ -390,6 +574,7 @@ async function autoSync(ctx: ExtensionContext, signal: AbortSignal, loaders: Syn
 	} catch (error) {
 		if (signal.aborted || isMissingConfigError(error)) return;
 		ctx.ui.setStatus(STATUS_KEY, undefined);
+		if (error instanceof RemoteSelectionMismatchError) return error.decision;
 		ctx.ui.notify(`pi-sync auto sync skipped: ${errorMessage(error)}`, "warning");
 	}
 }

--- a/packages/pi-sync/src/sync-resolution-ui.ts
+++ b/packages/pi-sync/src/sync-resolution-ui.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import {
 	type RunRoute,
@@ -21,7 +21,7 @@ export type SyncResolutionResult =
 	| { kind: "stale" };
 
 export async function showSyncResolution(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	initialDecision: SyncDecision,
 	runRoute: RunRoute,
 	sessionSignal?: AbortSignal,
@@ -31,7 +31,7 @@ export async function showSyncResolution(
 	let currentDecision = initialDecision;
 	let resolvedDirection: SyncResolutionDirection | undefined;
 	let chainedResult: { result: RunRouteResult; route: SyncResolutionDirection } | undefined;
-	const menu = defineMenu<SyncDecision, Screen, Action, ExtensionCommandContext>({
+	const menu = defineMenu<SyncDecision, Screen, Action, ExtensionContext>({
 		start: "resolve",
 		screens: {
 			resolve: ({ state }) => ({

--- a/packages/pi-sync/test/remote-selection-ui.test.ts
+++ b/packages/pi-sync/test/remote-selection-ui.test.ts
@@ -139,11 +139,20 @@ test("remote selection adoption saves settings only after session acknowledgemen
 			},
 		});
 		let routeCalls = 0;
+		let resolutions = 0;
+		let protectedActions = 0;
 		const running = showRemoteSelectionReview(ctx, "home", undefined, () => backend, {
 			origin: "settings",
 			runRoute: async () => {
 				routeCalls += 1;
 				return { kind: "completed" };
+			},
+			onSelectionResolved: () => {
+				resolutions += 1;
+			},
+			withStateAccess: async (task) => {
+				protectedActions += 1;
+				return task();
 			},
 		});
 
@@ -160,6 +169,8 @@ test("remote selection adoption saves settings only after session acknowledgemen
 
 		assert.equal(confirmations, 1);
 		assert.equal(routeCalls, 0);
+		assert.equal(resolutions, 1);
+		assert.equal(protectedActions, 1);
 		assert.deepEqual((await readLocalConfigObject())?.syncSetups.home.sync.include, [
 			"settings.json",
 			"pi-starship.toml",

--- a/packages/pi-sync/test/sync-attention.test.ts
+++ b/packages/pi-sync/test/sync-attention.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { createSyncAttentionController } from "../src/sync-attention.js";
+
+test("attention presentation is sanitized, textual, bounded, and clearable", () => {
+	const controller = createSyncAttentionController();
+	const { ctx, statuses, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+	controller.set(
+		{
+			setupName: "home\u001b]8;;spoof",
+			configIdentity: "identity",
+			localInclude: ["settings.json", "AGENTS.md"],
+			remoteInclude: ["settings.json", "models.json"],
+		},
+		"sync",
+	);
+
+	controller.publish(ctx);
+
+	assert.equal(statuses.get("sync"), "review needed");
+	const factory = widgets.get("sync:attention");
+	assert.equal(typeof factory, "function");
+	const component = (
+		factory as (
+			tui: unknown,
+			theme: { fg(color: string, text: string): string },
+		) => { render(width: number): string[] }
+	)({}, { fg: (_color, text) => text });
+	for (const width of [32, 60, 100]) {
+		const lines = component.render(width);
+		assert.ok(lines.every((line) => visibleWidth(line) <= width));
+		assert.equal(lines.join("\n").includes("\u001b]8"), false);
+		assert.match(lines.join("\n"), /Remote 1 · Device 1/u);
+		assert.match(lines.join("\n"), /No changes/u);
+	}
+
+	controller.clear(ctx);
+	assert.equal(statuses.get("sync"), undefined);
+	assert.equal(widgets.get("sync:attention"), undefined);
+});
+
+test("attention presentation explains an order-only difference", () => {
+	const controller = createSyncAttentionController();
+	const { ctx, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+	controller.set(
+		{
+			setupName: "home",
+			configIdentity: "identity",
+			localInclude: ["settings.json", "AGENTS.md"],
+			remoteInclude: ["AGENTS.md", "settings.json"],
+		},
+		"sync",
+	);
+	controller.publish(ctx);
+	const factory = widgets.get("sync:attention") as (
+		tui: unknown,
+		theme: { fg(color: string, text: string): string },
+	) => { render(width: number): string[] };
+	const component = factory({}, { fg: (_color, text) => text });
+	assert.match(component.render(60).join("\n"), /Only list order differs/u);
+});

--- a/packages/pi-sync/test/sync-resolution-ui.test.ts
+++ b/packages/pi-sync/test/sync-resolution-ui.test.ts
@@ -426,6 +426,108 @@ test("the main manager opens inline remote-selection recovery", async () => {
 	});
 });
 
+test("pending selection attention is the manager's first action and blocks Sync now", async () => {
+	await withConfiguredDecision(async (_decision, selectionConfigIdentity) => {
+		const attention = {
+			decision: {
+				setupName: "home",
+				configIdentity: selectionConfigIdentity,
+				localInclude: ["settings.json"],
+				remoteInclude: ["settings.json", "pi-starship.toml"],
+			},
+			origin: "sync" as const,
+			offered: true,
+		};
+		const tui = createTuiHarness({ width: 60, rows: 24 });
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+		const running = showSyncManager(ctx, async () => ({ kind: "failed" }), undefined, {
+			getAttention: () => attention,
+		});
+
+		await tui.waitForOpen();
+		for (const width of [32, 60, 100]) {
+			assert.ok(tui.render(width).every((line) => visibleWidth(line) <= width));
+		}
+		const frame = tui.render().join("\n");
+		assert.match(frame, /Sync status: Review needed/u);
+		assert.match(frame, /Review synced content \(recommended\)/u);
+		tui.press("tui.select.down");
+		assert.match(tui.render().join("\n"), /\[-\] Sync now/u);
+		assert.match(tui.render().join("\n"), /Review first/u);
+		tui.press("tui.select.up");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Synced content differs/u);
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Manage sync/u);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("attention for a non-current setup stays reviewable without blocking current Sync now", async () => {
+	await withConfiguredDecision(async () => {
+		await updateLocalConfig((settings) => ({
+			...settings,
+			syncSetups: {
+				...settings.syncSetups,
+				work: {
+					storage: { connection: "r2", bucket: "pi-sync-test", path: "pi-sync/work" },
+					sync: { include: ["settings.json"], automatic: false },
+				},
+			},
+		}));
+		const work = await loadConfig("work");
+		const attention = {
+			decision: {
+				setupName: "work",
+				configIdentity: syncConfigReviewFingerprint(work),
+				localInclude: ["settings.json"],
+				remoteInclude: ["settings.json", "models.json"],
+			},
+			origin: "pull" as const,
+			offered: true,
+		};
+		const tui = createTuiHarness({ width: 80, rows: 24 });
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+		let routeCalls = 0;
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
+		const running = showSyncManager(
+			ctx,
+			async () => {
+				routeCalls += 1;
+				await routeGate;
+				return { kind: "failed" };
+			},
+			undefined,
+			{
+				getAttention: () => attention,
+			},
+		);
+
+		await tui.waitForOpen();
+		const frame = tui.render().join("\n");
+		assert.match(frame, /Current sync setup: home/u);
+		assert.match(frame, /Review needed for setup work/u);
+		assert.match(frame, /Review synced content \(recommended\)/u);
+		assert.match(frame, /Sync now \(recommended\)/u);
+		assert.doesNotMatch(frame, /\[-\] Sync now/u);
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await waitFor(() => routeCalls === 1);
+		await tui.waitForOpen();
+		const loaderOpenCount = tui.openCount;
+		releaseRoute();
+		await waitFor(() => tui.isOpen && tui.openCount > loaderOpenCount);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
 test("the main manager opens conflict recovery instead of ending at an error", async () => {
 	await withConfiguredDecision(async (decision) => {
 		const tui = createTuiHarness({ width: 60, rows: 18 });

--- a/packages/pi-sync/test/sync.test.ts
+++ b/packages/pi-sync/test/sync.test.ts
@@ -18,8 +18,15 @@ import {
 	usage,
 	validateCommandOptions,
 } from "../src/command.js";
-import { localConfigPath, readLocalConfigObject, updateLocalConfig } from "../src/config.js";
+import {
+	loadConfig,
+	localConfigPath,
+	readLocalConfigObject,
+	syncConfigReviewFingerprint,
+	updateLocalConfig,
+} from "../src/config.js";
 import { showFileSelection } from "../src/file-selection.js";
+import { withStateDirectoryAccess } from "../src/state-directory.js";
 import sync from "../src/sync.js";
 import { syncBoth } from "../src/sync-operations.js";
 import { BUILT_IN_SYNC_ROOTS, RemoteSelectionMismatchError } from "../src/sync-policy.js";
@@ -212,6 +219,194 @@ test("direct selection mismatch reports exact differences and inline recovery gu
 	});
 });
 
+test("direct interactive selection mismatch opens recovery and cancellation preserves attention", async () => {
+	await withStateDirectory(async () => {
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const config = await loadConfig("home");
+		const mock = createMockPi();
+		sync(mock.pi, {
+			loadSyncOperations: async () =>
+				({
+					pull: async () => {
+						throw new RemoteSelectionMismatchError(
+							"home",
+							["settings.json"],
+							["settings.json", "models.json"],
+							syncConfigReviewFingerprint(config),
+						);
+					},
+				}) as never,
+		});
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx, notifications, statuses, widgets } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: tui.custom,
+		});
+
+		const running = mock.commands.get("sync")?.handler("pull --setup home", ctx);
+		await waitFor(() => tui.isOpen);
+		assert.match(tui.render().join("\n"), /Synced content differs/u);
+		tui.press("tui.select.cancel");
+		await running;
+
+		assert.deepEqual(notifications, []);
+		assert.match(statuses.get("sync") ?? "", /review needed/u);
+		assert.ok(widgets.get("sync:attention"));
+	});
+});
+
+test("direct interactive local-wins recovery clears attention after reviewed publication", async () => {
+	await withStateDirectory(async () => {
+		mkdirSync(path.dirname(localConfigPath()), { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const config = await loadConfig("home");
+		let pushes = 0;
+		const mock = createMockPi();
+		sync(mock.pi, {
+			loadSyncOperations: async () =>
+				({
+					pull: async () => {
+						throw new RemoteSelectionMismatchError(
+							"home",
+							["settings.json"],
+							["settings.json", "models.json"],
+							syncConfigReviewFingerprint(config),
+						);
+					},
+					push: async (_ctx: unknown, options: { force?: boolean; yes?: boolean }) => {
+						assert.equal(options.force, true);
+						assert.equal(options.yes, false);
+						pushes += 1;
+						return "applied";
+					},
+				}) as never,
+		});
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx, statuses, widgets } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: tui.custom,
+		});
+
+		const running = mock.commands.get("sync")?.handler("pull --setup home", ctx);
+		await waitFor(() => tui.isOpen);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await running;
+
+		assert.equal(pushes, 1);
+		assert.equal(statuses.get("sync"), undefined);
+		assert.equal(widgets.get("sync:attention"), undefined);
+	});
+});
+
+test("direct TUI --yes mismatch remains non-interactive but publishes attention", async () => {
+	await withStateDirectory(async () => {
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const config = await loadConfig("home");
+		const mock = createMockPi();
+		sync(mock.pi, {
+			loadSyncOperations: async () =>
+				({
+					pull: async () => {
+						throw new RemoteSelectionMismatchError(
+							"home",
+							["settings.json"],
+							["models.json"],
+							syncConfigReviewFingerprint(config),
+						);
+					},
+				}) as never,
+		});
+		let customCalls = 0;
+		const { ctx, notifications, statuses } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async () => {
+				customCalls += 1;
+				return undefined;
+			},
+		});
+
+		await mock.commands.get("sync")?.handler("pull --yes --setup home", ctx);
+
+		assert.equal(customCalls, 0);
+		assert.match(notifications.at(-1)?.message ?? "", /Remote-only: models\.json/u);
+		assert.match(statuses.get("sync") ?? "", /review needed/u);
+	});
+});
+
+test("a successful deterministic force push clears matching attention", async () => {
+	await withStateDirectory(async () => {
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const config = await loadConfig("home");
+		const mock = createMockPi();
+		sync(mock.pi, {
+			loadSyncOperations: async () =>
+				({
+					pull: async () => {
+						throw new RemoteSelectionMismatchError(
+							"home",
+							["settings.json"],
+							["settings.json", "models.json"],
+							syncConfigReviewFingerprint(config),
+						);
+					},
+					push: async () => "applied",
+				}) as never,
+		});
+		const { ctx, statuses, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+		await mock.commands.get("sync")?.handler("pull --yes --setup home", ctx);
+		assert.match(statuses.get("sync") ?? "", /review needed/u);
+
+		await mock.commands.get("sync")?.handler("push --force --yes --setup home", ctx);
+
+		assert.equal(statuses.get("sync"), undefined);
+		assert.equal(widgets.get("sync:attention"), undefined);
+	});
+});
+
+test("a later direct command clears attention invalidated by local setup changes", async () => {
+	await withStateDirectory(async () => {
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const config = await loadConfig("home");
+		const mock = createMockPi();
+		sync(mock.pi, {
+			loadSyncOperations: async () =>
+				({
+					pull: async () => {
+						throw new RemoteSelectionMismatchError(
+							"home",
+							["settings.json"],
+							["settings.json", "models.json"],
+							syncConfigReviewFingerprint(config),
+						);
+					},
+				}) as never,
+		});
+		const { ctx, statuses, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+		await mock.commands.get("sync")?.handler("pull --yes --setup home", ctx);
+		assert.match(statuses.get("sync") ?? "", /review needed/u);
+		await updateLocalConfig((settings) => ({
+			...settings,
+			syncSetups: {
+				...settings.syncSetups,
+				home: {
+					...settings.syncSetups.home,
+					sync: { ...settings.syncSetups.home.sync, include: ["models.json"] },
+				},
+			},
+		}));
+
+		await mock.commands.get("sync")?.handler("help", ctx);
+
+		assert.equal(statuses.get("sync"), undefined);
+		assert.equal(widgets.get("sync:attention"), undefined);
+	});
+});
+
 test("direct order-only mismatch explains both ordered lists", async () => {
 	await withStateDirectory(async () => {
 		const mock = createMockPi();
@@ -302,7 +497,7 @@ test("the command boundary sends only typed selection mismatches to the manager 
 	});
 });
 
-test("automatic selection mismatch remains warning-only and never opens resolution UI", async () => {
+test("automatic selection mismatch offers immediate TUI recovery and Later preserves attention", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		const before = Buffer.from(
@@ -316,15 +511,170 @@ test("automatic selection mismatch remains warning-only and never opens resoluti
 			loadSyncOperations: async () =>
 				({
 					syncBoth: async () => {
-						throw selectionMismatch();
+						throw await selectionMismatch();
 					},
 					push: async () => {
-						throw selectionMismatch();
+						throw await selectionMismatch();
+					},
+				}) as never,
+		});
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const { ctx, notifications, statuses, widgets } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: tui.custom,
+		});
+
+		const starting = mock.events.get("session_start")?.[0]?.({}, ctx);
+		await waitFor(() => tui.isOpen);
+		const frame = tui.render().join("\n");
+		assert.match(frame, /Synced content differs/u);
+		assert.match(frame, /Later/u);
+		assert.match(frame, /Remote-only paths: 1/u);
+		let concurrentStateAccess = false;
+		await withStateDirectoryAccess(async () => {
+			concurrentStateAccess = true;
+		});
+		assert.equal(concurrentStateAccess, true);
+		tui.press("tui.select.cancel");
+		await starting;
+
+		assert.deepEqual(notifications, []);
+		assert.match(statuses.get("sync") ?? "", /review needed/u);
+		assert.ok(widgets.get("sync:attention"));
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+
+		const manager = mock.commands.get("sync")?.handler("", ctx);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Review synced content \(recommended\)/u);
+		tui.press("ctrl+c");
+		await manager;
+
+		let shutdownCustomCalls = 0;
+		const shutdown = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async () => {
+				shutdownCustomCalls += 1;
+				return undefined;
+			},
+		});
+		await mock.events.get("session_shutdown")?.[0]?.({ reason: "exit" }, shutdown.ctx);
+		assert.equal(shutdownCustomCalls, 0);
+		assert.match(shutdown.notifications.at(-1)?.message ?? "", /session push skipped/u);
+		assert.match(shutdown.notifications.at(-1)?.message ?? "", /Remote-only: pi-starship\.toml/u);
+		assert.equal(shutdown.widgets.get("sync:attention"), undefined);
+		assert.equal(shutdown.statuses.get("sync"), undefined);
+
+		async function selectionMismatch() {
+			const config = await loadConfig("home");
+			return new RemoteSelectionMismatchError(
+				"home",
+				["settings.json", "sessions"],
+				["settings.json", "pi-starship.toml", "sessions"],
+				syncConfigReviewFingerprint(config),
+			);
+		}
+	});
+});
+
+test("session replacement aborts startup attention without stale presentation", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings({ automatic: true })), {
+			mode: 0o600,
+		});
+		const config = await loadConfig("home");
+		let syncCalls = 0;
+		const mock = createMockPi();
+		sync(mock.pi, {
+			loadSyncOperations: async () =>
+				({
+					syncBoth: async () => {
+						syncCalls += 1;
+						if (syncCalls === 1) {
+							throw new RemoteSelectionMismatchError(
+								"home",
+								["settings.json"],
+								["settings.json", "models.json"],
+								syncConfigReviewFingerprint(config),
+							);
+						}
+					},
+				}) as never,
+		});
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		const first = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+		const firstStart = mock.events.get("session_start")?.[0]?.({}, first.ctx);
+		await waitFor(() => tui.isOpen);
+		let replacementCustomCalls = 0;
+		const replacement = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async () => {
+				replacementCustomCalls += 1;
+				return undefined;
+			},
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, replacement.ctx);
+		await firstStart;
+
+		assert.equal(syncCalls, 2);
+		assert.equal(replacementCustomCalls, 0);
+		assert.equal(replacement.widgets.get("sync:attention"), undefined);
+		assert.equal(replacement.statuses.get("sync"), undefined);
+	});
+});
+
+test("automatic RPC selection mismatch remains read-only and observable", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings({ automatic: true })), {
+			mode: 0o600,
+		});
+		const config = await loadConfig("home");
+		const mock = createMockPi();
+		sync(mock.pi, {
+			loadSyncOperations: async () =>
+				({
+					syncBoth: async () => {
+						throw new RemoteSelectionMismatchError(
+							"home",
+							["settings.json"],
+							["settings.json", "models.json"],
+							syncConfigReviewFingerprint(config),
+						);
+					},
+				}) as never,
+		});
+		const { ctx, notifications } = createMockContext({ hasUI: true, mode: "rpc" });
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.match(notifications.at(-1)?.message ?? "", /pi-sync auto sync skipped/u);
+		assert.match(notifications.at(-1)?.message ?? "", /Remote-only: models\.json/u);
+		assert.match(notifications.at(-1)?.message ?? "", /RPC review is read-only/u);
+	});
+});
+
+test("generic automatic failure remains notification-only", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings({ automatic: true })), {
+			mode: 0o600,
+		});
+		const mock = createMockPi();
+		sync(mock.pi, {
+			loadSyncOperations: async () =>
+				({
+					syncBoth: async () => {
+						throw new Error("transport unavailable");
 					},
 				}) as never,
 		});
 		let customCalls = 0;
-		const { ctx, notifications } = createMockContext({
+		const { ctx, notifications, widgets } = createMockContext({
 			hasUI: true,
 			mode: "tui",
 			custom: async () => {
@@ -334,21 +684,10 @@ test("automatic selection mismatch remains warning-only and never opens resoluti
 		});
 
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
-		assert.match(notifications.at(-1)?.message ?? "", /pi-sync auto sync skipped/u);
-		await mock.events.get("session_shutdown")?.[0]?.({ reason: "exit" }, ctx);
 
 		assert.equal(customCalls, 0);
-		assert.match(notifications.at(-1)?.message ?? "", /pi-sync session push skipped/u);
-		assert.match(notifications.at(-1)?.message ?? "", /Remote-only: pi-starship\.toml/u);
-		assert.deepEqual(readFileSync(localConfigPath()), before);
-
-		function selectionMismatch() {
-			return new RemoteSelectionMismatchError(
-				"home",
-				["settings.json", "sessions"],
-				["settings.json", "pi-starship.toml", "sessions"],
-			);
-		}
+		assert.match(notifications.at(-1)?.message ?? "", /transport unavailable/u);
+		assert.equal(widgets.get("sync:attention"), undefined);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Open the existing reviewed synced-content recovery flow when automatic or interactive TUI sync detects a typed content-list mismatch.
- Preserve deferred recovery as sanitized editor attention and prioritize it in `/sync` while keeping deterministic and RPC routes non-blocking.
- Raise the pi-sync Pi TUI Kit floor to the published disabled-row API and add a patch Changeset.

## Review and hardening

- Release the state-directory migration guard before the unsolicited startup menu opens, then reacquire it only for protected recovery work.
- Revalidate attention after config changes, successful force pushes, setup switches, stale callbacks, session replacement, and shutdown.
- Keep non-current setup attention reviewable without blocking Sync now for the active setup.
- Preserve existing remote-head, config-identity, sessions privacy, force-push confirmation, atomic settings, and cancellation safeguards.

## Verification

- `npm run check` passed build, Biome, extension boundaries, all typechecks, and 2,651 tests in 232 files.
- All 39 pi-sync test files passed 335 tests.
- `just pack sync` produced a 58-file dry-run tarball containing both new attention modules.
- `just changeset-status` reports only a patch release for `@narumitw/pi-sync`.
- A temporary-agent Pi RPC smoke loaded the extension and returned the registered `/sync` command.
- Deterministic Pi TUI Kit harness tests cover startup, deferral, recovery, cancellation, replacement, shutdown, constrained rendering, and guard release.

## Notes

- No settings, snapshot, sync-state, backend, or session-entry schema changed.
- No live-provider smoke was run because the recovery paths use deterministic backend doubles and require no provider-specific behavior.
- The completed implementation plan and audit evidence are archived in `docs/plans/archived/2026-08-10_pi-sync-attention-recovery-plan.md`.
