### PR TITLE
fix(goal): clamp short wait deadlines

### DIFF
--- a/.changeset/tidy-goals-wait.md
+++ b/.changeset/tidy-goals-wait.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-goal": patch
+---
+
+Clamp sub-ten-second `goal_wait` deadlines and report their effective delay to prevent rapid automatic wake loops.

--- a/docs/plans/archived/2026-08-10_pi-goal-codex-wait-hardening-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-goal-codex-wait-hardening-plan.md
@@ -1,0 +1,119 @@
+# pi-goal Codex-inspired wait hardening plan
+
+## Goal
+
+Harden `pi-goal`'s existing `goal_wait` deadline against model-driven busy polling by borrowing Codex's minimum-wait clamp, effective-timeout reporting, and longer-wait guidance.
+
+Keep the existing quiet external-wait lifecycle, persistence, wake behavior, and Pi compatibility unchanged.
+
+## Context
+
+The inspected Codex evidence is recorded in [`docs/research/2026-08-10_codex-waiting-mechanisms.md`](../research/2026-08-10_codex-waiting-mechanisms.md).
+
+Codex's `wait_agent` clamps requested timeouts below its configured minimum and reports the effective timeout to the model.
+
+Codex currently defaults that minimum to 10,000 milliseconds and separately tells agents to prefer waits measured in minutes to avoid busy polling.
+
+`pi-goal` currently accepts `resume_after_ms` from 1 through 2,147,483,647 milliseconds.
+
+A model can therefore request repeated one-millisecond deadline wake-ups, and each new `goal_wait` tool call resets the existing tool-free no-progress heuristic.
+
+`goal_wait` already handles external input through Pi lifecycle events and keeps at most one session-owned deadline timer, so it does not need a new event API or Pi Core change.
+
+The deadline is a safety wake-up rather than a polling interval, and omitting it remains the preferred indefinite external-wait contract.
+
+## Architecture
+
+Add a package-owned minimum effective deadline of 10,000 milliseconds.
+
+Keep accepting positive integer requests below that minimum for compatibility, but clamp their effective deadline to 10,000 milliseconds.
+
+Persist and schedule the effective absolute deadline rather than the shorter requested deadline.
+
+Return both requested and effective values when clamping occurs so the model and tests can observe the change.
+
+Keep `resume_after_ms` in successful tool details as the effective delay, and add `requested_resume_after_ms` only when it differs.
+
+Tell the model in tool output when clamping occurred.
+
+Update the tool description, prompt guidance, Goal-mode rules, and README to state that deadlines below ten seconds are clamped and longer waits are preferred.
+
+Do not add a setting for the minimum because the first change is a fixed safety boundary rather than user policy.
+
+Do not change deadline-free waits, external-message wake-up, `/goal resume`, retry ownership, timer restoration, or waiting-time accounting.
+
+## Non-Goals
+
+- Add or modify a Pi Core API.
+- Implement Codex's `clock.sleep`, `wait_agent`, mailbox protocol, or idle-turn reservation.
+- Replace `goal_wait` with an in-turn sleep tool.
+- Add periodic polling, repeated timers, or a background task scheduler.
+- Add a configurable minimum, maximum, or default wait setting.
+- Change the canonical active Goal status or managed-run RPC status.
+- Remove the current continuation ownership and stale-session safeguards.
+- Claim a live third-party monitor reproduction without running one.
+
+## Assumptions
+
+- Ten seconds is a safety floor, not a recommended polling interval.
+- Existing persisted `resumeAt` values remain authoritative and must not be migrated or extended during reload.
+- A request below ten seconds may come from an older stored tool call, so runtime clamping remains necessary even if prompt metadata documents the floor.
+- Users needing an immediate manual wake can send input or run `/goal resume` instead of relying on a sub-ten-second deadline.
+
+## Risks
+
+- Clamping changes the documented timing of previously accepted short waits and therefore requires tests, README updates, and a Changeset.
+- Reporting requested and effective values inconsistently can make restored deadlines or tool rendering misleading.
+- Applying the floor during reload would incorrectly extend already-persisted deadlines.
+- A ten-second floor reduces hot looping but cannot prevent a model from repeatedly waiting every ten seconds forever.
+- Adding a wait-cycle circuit breaker in the same change could pause legitimate external workflows and would exceed this hardening scope.
+- Prompt guidance alone is not enforcement, so runtime clamping must remain the authoritative boundary.
+
+## Rollback / Recovery
+
+Older sessions with deadline-free waits remain unchanged.
+
+Older sessions with an absolute `resumeAt` continue using that timestamp without migration.
+
+Reverting the clamp restores the previous accepted range because no new persisted field is required.
+
+`/goal resume`, external input, pause, clear, edit, replace, and session shutdown remain recovery paths.
+
+If ten seconds proves incompatible with real workflows, a follow-up can adjust the fixed constant with evidence or propose an explicit setting.
+
+## Plan
+
+- [x] Add failing focused tests in `packages/pi-goal/test/goal-wait.test.ts` for a one-millisecond request being clamped to ten seconds, effective `resumeAt`, requested-versus-effective tool details, bounded clamp text, and exactly-once deadline delivery at the effective time.
+- [x] Add failing contract tests for unchanged requests at ten seconds and above, unchanged deadline-free waits, rejection of zero, negative, fractional, and oversized values, and unmodified restoration of an already-persisted deadline below the new floor.
+- [x] Add `MIN_GOAL_WAIT_DELAY_MS` beside the existing wait limits in `packages/pi-goal/src/wait.ts`, and add one helper that returns requested and effective delay values without changing persisted `GoalWait` shape.
+- [x] Update `packages/pi-goal/src/tools.ts` to create and report waits from the effective delay, preserve runtime validation for old tool calls, and mention clamping in bounded sanitized output only when it occurs.
+- [x] Update `packages/pi-goal/src/prompts.ts` and tool guidance to say that `resume_after_ms` is a safety deadline, sub-ten-second requests are clamped, and waits measured in minutes are preferred over repeated short wakes.
+- [x] Update `packages/pi-goal/README.md` with the requested-versus-effective contract, ten-second floor, deadline restoration behavior, and the recommendation to omit the deadline for true external-event waiting.
+- [x] Add a Changeset for the published `@narumitw/pi-goal` hardening without changing unrelated package versions or metadata.
+- [x] Audit every changed wait path for user cancellation, session replacement, shutdown, timer identity, reload, stale callbacks, pending messages, terminal sanitization, and every `await` boundary; verify no second timer or polling path was introduced.
+- [x] Run the focused wait and contract tests, `npm run typecheck --workspace @narumitw/pi-goal`, and `npm run test:runtime --workspace @narumitw/pi-goal`; record exact passing counts and any unavailable live monitor path.
+- [x] Run root `npm test`, root `npm run check`, `just pack goal`, `npm run changeset:status`, and `git diff --check`; inspect the package tarball and final diff for unintended settings, queue, dependency, or cross-package changes.
+- [x] Recheck that Issue #661 remains solved when no deadline is supplied, when a clamped deadline wakes the Goal, and when external input arrives before the effective deadline; archive this plan only after every completion item has evidence.
+
+## Verification Evidence
+
+- The initial focused red run executed 54 tests and failed only the missing clamp behavior and missing anti-polling tool guidance, with 52 tests passing.
+- Independent review identified missing clamped-deadline external-wake cancellation, negative and maximum bounds, and terminal-output safety coverage; all findings were addressed with deterministic tests.
+- Focused wait, tool-policy, and contract verification passed 80 tests across three files after hardening.
+- The complete `pi-goal` suite passed 342 tests across 20 files, package typechecking passed, and the real Pi runtime smoke passed.
+- One repeated root test run hit an unrelated `pi-sync` condition-wait timeout; its focused 14-test file passed immediately, and the subsequent root `npm test` plus CI-equivalent `npm run check` each passed 2,792 tests across 256 files together with Biome, boundary validation, every workspace typecheck, and required builds.
+- `just pack goal` inspected 24 published files including `src/wait.ts`, updated source, README, manifest, and license, and left no tarball artifact.
+- `npm run changeset:status` recognized `.changeset/tidy-goals-wait.md`; the existing minor `goal_wait` Changeset remains the effective package bump.
+- `git diff --check` passed, and the semantic audit found no new timer, polling path, setting, queue mutation, dependency, cross-package source change, asynchronous boundary, or Pi Core change.
+- A live third-party monitor smoke was unavailable because no external monitor integration is present; deterministic extension-input, clamped-deadline, legacy-restore, cancellation, retry, lifecycle, and real Pi runtime coverage verifies the repository-owned contract.
+
+## Completion Checklist
+
+- [x] Requests from 1 through 9,999 milliseconds produce one effective ten-second deadline and visibly report the clamp.
+- [x] Requests of ten seconds or longer preserve their requested value, and invalid or oversized requests retain current rejection behavior.
+- [x] Deadline-free waits remain indefinitely quiet until external input or explicit resume.
+- [x] Persisted absolute deadlines restore without being extended, restarted, or clamped during reload.
+- [x] External input before a clamped deadline cancels timer ownership and does not produce a later stale continuation.
+- [x] Tool output, details, prompts, README, status, and tests agree on requested and effective timing.
+- [x] Only `pi-goal` source, tests, documentation, and its Changeset are changed.
+- [x] Focused tests, runtime smoke, package typecheck, root tests, CI-equivalent checks, package inspection, Changeset status, semantic lifecycle audit, and final diff review pass with recorded evidence.

--- a/docs/research/2026-08-10_codex-waiting-mechanisms.md
+++ b/docs/research/2026-08-10_codex-waiting-mechanisms.md
@@ -1,0 +1,158 @@
+# Codex waiting and idle-continuation reference
+
+## Purpose
+
+This document records Codex mechanisms relevant to quiet external waiting and race-safe automatic continuation.
+
+It supports the archived [`docs/plans/archived/2026-08-10_pi-goal-codex-wait-hardening-plan.md`](../plans/archived/2026-08-10_pi-goal-codex-wait-hardening-plan.md), and it is not a claim that Codex has an exact equivalent of `pi-goal`'s `goal_wait`.
+
+A separate future Pi Core proposal may cite the core-owned admission findings, but that proposal is not part of the `pi-goal` hardening plan.
+
+## Evidence snapshot
+
+The source was inspected in a clean local checkout of `openai/codex` at commit `33e365b19e4a7023b9b3ed74b57aa11748165a53`.
+
+The findings below are source-level observations rather than runtime reproduction evidence.
+
+Permalinks use that commit so later Codex changes do not silently change the cited behavior.
+
+## Findings
+
+### Codex has no exact `goal_wait` tool
+
+Codex exposes `get_goal`, `create_goal`, and `update_goal` in [`codex-rs/ext/goal/src/spec.rs`](https://github.com/openai/codex/blob/33e365b19e4a7023b9b3ed74b57aa11748165a53/codex-rs/ext/goal/src/spec.rs).
+
+The model-facing `update_goal` schema only accepts `complete` and `blocked`.
+
+It cannot set a Goal to waiting, pause it, resume it, or attach an external-wake deadline.
+
+Therefore Codex does not directly solve Issue #661 through its Goal tool surface.
+
+### `clock.sleep` provides interruptible bounded waiting
+
+[`codex-rs/core/src/tools/handlers/sleep.rs`](https://github.com/openai/codex/blob/33e365b19e4a7023b9b3ed74b57aa11748165a53/codex-rs/core/src/tools/handlers/sleep.rs) implements `clock.sleep`.
+
+The tool validates a duration between one millisecond and twelve hours.
+
+It subscribes to input-queue activity and uses `tokio::select!` to finish on either the deadline or new input.
+
+Already-pending activity interrupts the sleep immediately.
+
+This avoids polling, but the tool call and current agent turn remain active while sleeping.
+
+It is suitable for a bounded in-turn delay but does not provide a quiet, persisted, turn-ending wait.
+
+The tool was introduced by [`08901fc8e1`](https://github.com/openai/codex/commit/08901fc8e1), titled `[codex] Add interruptible sleep tool (#28429)`.
+
+### `wait_agent` reacts to mailbox and steering activity
+
+[`codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs`](https://github.com/openai/codex/blob/33e365b19e4a7023b9b3ed74b57aa11748165a53/codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs) implements `wait_agent` for subagent workflows.
+
+It subscribes to an input-queue watch channel and completes because of mailbox activity, steering input, or timeout.
+
+It reports whether the wait timed out.
+
+A requested timeout below the configured minimum is clamped upward, and the result explains the clamp.
+
+[`codex-rs/core/src/config/mod.rs`](https://github.com/openai/codex/blob/33e365b19e4a7023b9b3ed74b57aa11748165a53/codex-rs/core/src/config/mod.rs) currently sets the default minimum to 10,000 milliseconds and tells agents to prefer longer waits measured in minutes.
+
+That minimum reduces very short repeated waits that behave like busy polling.
+
+Like `clock.sleep`, `wait_agent` keeps the current tool call and turn alive.
+
+The minimum-timeout hardening was added by [`4d7e3e90d9`](https://github.com/openai/codex/commit/4d7e3e90d9), titled `Clamp short wait_agent timeouts to the configured minimum (#37357)`.
+
+### Automatic idle work uses a core-owned admission gate
+
+[`codex-rs/core/src/session/inject.rs`](https://github.com/openai/codex/blob/33e365b19e4a7023b9b3ed74b57aa11748165a53/codex-rs/core/src/session/inject.rs) implements `Session::try_start_turn_if_idle()`.
+
+The method rejects empty work, pending trigger-turn mailbox items, an active task, and automatic work disallowed by the current mode.
+
+It reserves the idle turn under the active-turn lock.
+
+It checks pending trigger-turn work again after reservation and again after asynchronous turn preparation.
+
+If user work appears, it clears the reservation and starts the pending user work instead.
+
+It also verifies that the same reservation still exists before starting the task.
+
+This core-owned transaction is stronger than an extension separately calling `isIdle()`, `hasPendingMessages()`, and `sendUserMessage()`.
+
+The Goal runtime calls this gate from [`codex-rs/ext/goal/src/runtime.rs`](https://github.com/openai/codex/blob/33e365b19e4a7023b9b3ed74b57aa11748165a53/codex-rs/ext/goal/src/runtime.rs).
+
+A rejected automatic continuation is logged and is not inserted ahead of user work.
+
+Relevant history includes [`f1b1b64005`](https://github.com/openai/codex/commit/f1b1b64005), titled `Add goal extension idle continuation (#25060)`, and [`c4f509101b`](https://github.com/openai/codex/commit/c4f509101b), titled `Make goal idle continuation start idle turns only`.
+
+### Idle lifecycle callbacks run after user-triggered work checks
+
+[`codex-rs/core/src/tasks/lifecycle.rs`](https://github.com/openai/codex/blob/33e365b19e4a7023b9b3ed74b57aa11748165a53/codex-rs/core/src/tasks/lifecycle.rs) emits the thread-idle lifecycle only when no active turn exists and no trigger-turn mailbox work is pending.
+
+This ordering reduces unnecessary automatic continuation attempts.
+
+The admission gate is still necessary because new work can arrive after an idle callback begins.
+
+### Codex persists a Goal continuation deferral marker
+
+[`codex-rs/state/goals_migrations/0002_thread_goal_continuation_deferrals.sql`](https://github.com/openai/codex/blob/33e365b19e4a7023b9b3ed74b57aa11748165a53/codex-rs/state/goals_migrations/0002_thread_goal_continuation_deferrals.sql) creates one continuation-deferral row per thread.
+
+The Goal runtime checks that marker before trying to continue an idle Goal.
+
+The marker is a persisted suppression mechanism, but it has no model-facing wait tool, reason, deadline, external-wake contract, or waiting-time accounting.
+
+It should not be copied as a generic global Pi deferral table without a broader use case.
+
+## Comparison with `pi-goal`
+
+| Capability | Codex mechanism | Current `pi-goal` |
+| --- | --- | --- |
+| Model explicitly declares an external wait | No exact Goal tool. | `goal_wait({ goal_id, reason, resume_after_ms? })`. |
+| Current turn ends while waiting | `clock.sleep` and `wait_agent` do not end it. | A successful `goal_wait` returns `terminate: true`. |
+| Wait survives reload | Goal deferral is persisted but is not an external-wait record. | Wait reason and absolute deadline are persisted in Goal state. |
+| New input wakes waiting work | Sleep and agent waits subscribe to input activity. | Non-Goal-owned input clears the wait before its turn. |
+| User work wins an idle-start race | Core-owned `try_start_turn_if_idle()`. | Extension checks and prompt ownership contain the race but cannot reserve the turn atomically. |
+| Very short wait protection | `wait_agent` clamps to a configured minimum. | `goal_wait` currently validates a positive timer but does not impose a minimum above one millisecond. |
+| Goal-specific wait reason and deadline | Not present. | Present and visible in status. |
+
+## Design lessons applicable to current `pi-goal`
+
+- Clamp unsafe short deadline requests and report the requested and effective values.
+- Tell the model to prefer longer waits and to treat a deadline as a safety wake-up rather than a polling interval.
+- Keep external-message wake-up event-driven instead of creating repeated timer checks.
+- Persist the domain-owned absolute deadline so reload does not restart a relative delay.
+- Keep one timer owner and revalidate Goal and session identity before deadline delivery.
+
+## Core-only observations outside the hardening plan
+
+- Atomic idle-turn admission belongs in the runtime that owns active-turn and message-queue state.
+- A core reservation should recheck pending user work around asynchronous preparation boundaries.
+- User and client input should have priority over synthetic automatic continuation.
+- These observations cannot be fully implemented inside `pi-goal` through current public extension APIs.
+
+## Behaviors not to copy directly
+
+- Do not replace `goal_wait` with `clock.sleep` because that would keep the agent turn and model workflow active.
+- Do not make Codex's subagent mailbox protocol a prerequisite for Pi extension waiting.
+- Do not add a hidden automatic-input path that bypasses Pi extension input hooks without an explicit compatibility design.
+- Do not make a Goal-specific database table part of Pi core merely to support one extension.
+- Do not silently clamp a public API timeout unless the contract and returned result make the effective timeout observable.
+
+## Planned `pi-goal` mapping
+
+`goal_wait` should keep its existing turn-ending, persisted, external-message-driven design.
+
+Requests below ten seconds should be accepted for compatibility but clamped to an effective ten-second safety deadline.
+
+Tool output and details should expose the clamp, while prompt guidance should recommend waits measured in minutes and deadline omission for true external-event waiting.
+
+Persisted absolute deadlines must remain unchanged during reload, including deadlines originally created by older versions below the new floor.
+
+The plan intentionally makes no Pi Core change.
+
+## Verification limits
+
+No Codex runtime tests or live sessions were executed for this reference.
+
+The cited behavior was verified by reading the source files and relevant commit history at the recorded snapshot.
+
+Any upstream Pi proposal should recheck Codex and Pi against their then-current heads before relying on these details.

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -233,7 +233,7 @@ goal_wait({
 })
 ```
 
-`goal_id` must match the current active Goal, `reason` must contain 1–1,000 characters, and the optional `resume_after_ms` must be a whole number from 1 through 2,147,483,647. The deadline is a safety wake-up rather than a polling interval. Omitting it intentionally permits an indefinite quiet wait.
+`goal_id` must match the current active Goal, `reason` must contain 1–1,000 characters, and the optional `resume_after_ms` must be a whole number from 1 through 2,147,483,647. The deadline is a safety wake-up rather than a polling interval. Requests below 10,000 milliseconds are accepted for compatibility but clamped to an effective 10,000-millisecond deadline; the tool result reports both the requested and effective values. Prefer deadlines measured in minutes instead of repeated short wakes. Omitting `resume_after_ms` intentionally permits an indefinite quiet wait.
 
 An accepted call keeps the canonical Goal status active, checkpoints active elapsed time, cancels pending continuation work, persists the reason and absolute optional deadline, and terminates the normal single-tool run. Call `goal_wait` alone because Pi only guarantees early termination when every finalized result in a parallel tool batch terminates.
 
@@ -241,7 +241,7 @@ Interactive input, RPC input, another extension's `sendUserMessage()` input, and
 
 After a waking turn ends, ordinary continuation rules apply again. The agent can complete or block the Goal, continue working, or call `goal_wait` again after arranging the next wake source. `/goal resume` also clears waiting and sends one manual resume prompt without resetting cumulative usage or the safety epoch. `/goal pause`, clear, edit, replace, completion, blocking, terminal limits, tool loss, queue displacement, session replacement, and shutdown cancel the in-memory deadline owner.
 
-A future deadline is restored from its absolute timestamp after reload. An already-due deadline waits for Pi's settled, idle, no-pending-message boundary and then requests exactly one continuation through the normal dispatcher. If that delivery throws, pi-goal restores the wait, retries once after one second, and leaves the Goal visibly waiting after a second failure instead of retry-looping. A deadline never sends a prompt directly from a stale timer.
+A future deadline is restored from its absolute timestamp after reload. Reload never restarts, extends, or newly clamps an already-persisted absolute deadline, including a short deadline written by an older version. An already-due deadline waits for Pi's settled, idle, no-pending-message boundary and then requests exactly one continuation through the normal dispatcher. If that delivery throws, pi-goal restores the wait, retries once after one second, and leaves the Goal visibly waiting after a second failure instead of retry-looping. A deadline never sends a prompt directly from a stale timer.
 
 Waiting time is excluded from **Active elapsed**, while tokens, iteration, automatic-response count, no-progress state, queue data, and managed-run ownership remain preserved. The managed-run protocol continues reporting `active` because waiting is non-terminal. When an experimental priority Goal displaces a waiting head, the shelved Goal loses its wait so later reactivation performs a fresh external-state check.
 

--- a/packages/pi-goal/src/prompts.ts
+++ b/packages/pi-goal/src/prompts.ts
@@ -1,4 +1,5 @@
 import { formatTokenCount } from "./accounting.js";
+import { MIN_GOAL_WAIT_DELAY_MS } from "./wait.js";
 
 export type GoalStatus =
 	| "active"
@@ -88,7 +89,8 @@ function goalModeRules(goalLabel: string) {
 		`- Only call the goal_complete tool after evidence proves every requirement of ${goalLabel} is satisfied and no required work remains. Pass this exact goal_id and never reuse an id from an older, stopped, replaced, or cleared turn.`,
 		"- Use goal_blocked only at a true impasse after the same blocker recurs for at least three consecutive goal turns, with concrete evidence that user or external action is required. Never use it merely because work is hard, slow, uncertain, incomplete, needs ordinary clarification, or hit a recoverable failure.",
 		"- After a blocked goal is resumed, start a fresh three-turn blocker audit before using goal_blocked again.",
-		"- When progress genuinely depends on a later external event, first arrange a non-goal wake message, then call goal_wait with the exact current goal_id to keep the goal active without automatic continuation. Use resume_after_ms when a bounded safety wake-up is needed.",
+		"- When progress genuinely depends on a later external event, first arrange a non-goal wake message, then call goal_wait with the exact current goal_id to keep the goal active without automatic continuation. Use resume_after_ms only as a bounded safety wake-up, not as a polling interval.",
+		`- Prefer longer goal_wait deadlines measured in minutes to avoid busy polling. Requests below ${MIN_GOAL_WAIT_DELAY_MS}ms are clamped to ${MIN_GOAL_WAIT_DELAY_MS}ms, and omitting resume_after_ms keeps the goal quiet until external input or explicit resume.`,
 		"- Call goal_wait alone because parallel sibling tools can prevent immediate turn termination. Do not use it for ordinary unfinished work, and do not use goal_blocked for a recoverable external wait.",
 		"- If the goal is incomplete at the end of a turn and goal_wait was not accepted, expect automatic continuation and keep working from the current state.",
 	].join("\n");

--- a/packages/pi-goal/src/tools.ts
+++ b/packages/pi-goal/src/tools.ts
@@ -20,7 +20,13 @@ import {
 	transitionGoal,
 	truncateNotification,
 } from "./runtime.js";
-import { createGoalWait, MAX_GOAL_WAIT_DELAY_MS, MAX_GOAL_WAIT_REASON_LENGTH } from "./wait.js";
+import {
+	createGoalWait,
+	MAX_GOAL_WAIT_DELAY_MS,
+	MAX_GOAL_WAIT_REASON_LENGTH,
+	MIN_GOAL_WAIT_DELAY_MS,
+	resolveGoalWaitDelay,
+} from "./wait.js";
 
 interface GoalCompleteDetails {
 	goal: string;
@@ -40,6 +46,7 @@ interface GoalWaitDetails {
 	goal: string;
 	goal_id: string;
 	reason: string;
+	requested_resume_after_ms?: number;
 	resume_after_ms?: number;
 	resume_at?: number;
 }
@@ -312,12 +319,12 @@ export function registerGoalTools(pi: ExtensionAPI, runtime: GoalRuntime) {
 	const goalWaitTool = defineTool({
 		name: GOAL_WAIT_TOOL,
 		label: "Goal Wait",
-		description:
-			"Keep the active /goal alive but quiet while an external event is expected. Call goal_wait alone after arranging a wake message, or provide resume_after_ms as a safety deadline. Do not use it for ordinary unfinished work.",
+		description: `Keep the active /goal alive but quiet while an external event is expected. Call goal_wait alone after arranging a wake message, or provide resume_after_ms as a safety deadline. Requests below ${MIN_GOAL_WAIT_DELAY_MS}ms are clamped to ${MIN_GOAL_WAIT_DELAY_MS}ms. Do not use it for ordinary unfinished work.`,
 		promptSnippet:
 			"Wait quietly for an external event without stopping the active /goal or starting automatic continuations",
 		promptGuidelines: [
-			"Use goal_wait only when progress depends on a later non-goal message, or when resume_after_ms provides a bounded wake-up.",
+			"Use goal_wait only when progress depends on a later non-goal message, or when resume_after_ms provides a bounded safety wake-up rather than a polling interval.",
+			`Prefer longer waits measured in minutes to avoid busy polling; goal_wait requests below ${MIN_GOAL_WAIT_DELAY_MS}ms are clamped to ${MIN_GOAL_WAIT_DELAY_MS}ms.`,
 			"Arrange the external monitor or wake source before calling goal_wait, and call goal_wait alone because parallel sibling tools can prevent immediate turn termination.",
 			"Pass the exact current goal_id so a stale turn cannot put a replacement goal into waiting.",
 			"Do not use goal_blocked for a recoverable external wait that can be resumed by a message or deadline.",
@@ -337,8 +344,7 @@ export function registerGoalTools(pi: ExtensionAPI, runtime: GoalRuntime) {
 				Type.Integer({
 					minimum: 1,
 					maximum: MAX_GOAL_WAIT_DELAY_MS,
-					description:
-						"Optional safety deadline in milliseconds that requests one continuation if no wake message arrives.",
+					description: `Optional safety deadline in milliseconds that requests one continuation if no wake message arrives. Values below ${MIN_GOAL_WAIT_DELAY_MS} are accepted but clamped to ${MIN_GOAL_WAIT_DELAY_MS}.`,
 				}),
 			),
 		}),
@@ -380,13 +386,26 @@ export function registerGoalTools(pi: ExtensionAPI, runtime: GoalRuntime) {
 				return reject(`resume_after_ms must be a whole number from 1 to ${MAX_GOAL_WAIT_DELAY_MS}`);
 			}
 
+			const { requestedMs, effectiveMs } = resolveGoalWaitDelay(resumeAfterMs);
 			const waiting = createGoalWait(reason, resumeAfterMs);
 			const waitingGoal = runtime.enterGoalWait(ctx, activeGoal.id, waiting);
 			if (!waitingGoal) return reject("active goal changed before waiting transition");
+			const clamped = requestedMs !== undefined && effectiveMs !== requestedMs;
 			notifyTerminal(ctx.ui, `Goal waiting: ${truncateNotification(reason)}`, "info");
 			return {
-				content: toolContent(`Goal waiting: ${reason}`),
-				details: waitDetails(goal, requestedGoalId, reason, resumeAfterMs, waiting.resumeAt),
+				content: toolContent(
+					clamped
+						? `Goal waiting: ${reason}\nRequested resume_after_ms ${requestedMs} was clamped to ${effectiveMs}.`
+						: `Goal waiting: ${reason}`,
+				),
+				details: waitDetails(
+					goal,
+					requestedGoalId,
+					reason,
+					effectiveMs,
+					waiting.resumeAt,
+					clamped ? requestedMs : undefined,
+				),
 				terminate: true,
 			};
 		},
@@ -439,11 +458,15 @@ function waitDetails(
 	reason: string,
 	resumeAfterMs: number | undefined,
 	resumeAt?: number,
+	requestedResumeAfterMs?: number,
 ): GoalWaitDetails {
 	return {
 		goal: goal.slice(0, MAX_GOAL_TEXT_LENGTH),
 		goal_id: goalId.slice(0, MAX_GOAL_ID_LENGTH),
 		reason: reason.slice(0, MAX_GOAL_WAIT_REASON_LENGTH),
+		...(requestedResumeAfterMs === undefined
+			? {}
+			: { requested_resume_after_ms: requestedResumeAfterMs }),
 		...(resumeAfterMs === undefined ? {} : { resume_after_ms: resumeAfterMs }),
 		...(resumeAt === undefined ? {} : { resume_at: resumeAt }),
 	};

--- a/packages/pi-goal/src/wait.ts
+++ b/packages/pi-goal/src/wait.ts
@@ -4,17 +4,30 @@ export interface GoalWait {
 }
 
 export const MAX_GOAL_WAIT_REASON_LENGTH = 1_000;
+export const MIN_GOAL_WAIT_DELAY_MS = 10_000;
 export const MAX_GOAL_WAIT_DELAY_MS = 2_147_483_647;
 const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
+
+export function resolveGoalWaitDelay(resumeAfterMs: number | undefined): {
+	requestedMs?: number;
+	effectiveMs?: number;
+} {
+	if (resumeAfterMs === undefined) return {};
+	return {
+		requestedMs: resumeAfterMs,
+		effectiveMs: Math.max(MIN_GOAL_WAIT_DELAY_MS, resumeAfterMs),
+	};
+}
 
 export function createGoalWait(
 	reason: string,
 	resumeAfterMs: number | undefined,
 	now = Date.now(),
 ): GoalWait {
+	const { effectiveMs } = resolveGoalWaitDelay(resumeAfterMs);
 	return {
 		reason,
-		...(resumeAfterMs === undefined ? {} : { resumeAt: now + resumeAfterMs }),
+		...(effectiveMs === undefined ? {} : { resumeAt: now + effectiveMs }),
 	};
 }
 

--- a/packages/pi-goal/test/goal-tool-policy.test.ts
+++ b/packages/pi-goal/test/goal-tool-policy.test.ts
@@ -105,10 +105,12 @@ test("goal registers command, status tools, and lifecycle hooks", () => {
 	assert.equal(waitParameters?.properties?.resume_after_ms?.minimum, 1);
 	assert.equal(waitParameters?.properties?.resume_after_ms?.maximum, 2_147_483_647);
 	assert.match(String(waitDefinition?.description), /external event.*call goal_wait alone/is);
-	assert.match(
-		String((waitDefinition?.promptGuidelines as string[] | undefined)?.join(" ")),
-		/arrange the external monitor.*goal_wait alone/is,
+	assert.match(String(waitDefinition?.description), /below 10000ms.*clamped/is);
+	const waitGuidelines = String(
+		(waitDefinition?.promptGuidelines as string[] | undefined)?.join(" "),
 	);
+	assert.match(waitGuidelines, /arrange the external monitor.*goal_wait alone/is);
+	assert.match(waitGuidelines, /prefer longer waits.*minutes.*busy polling/is);
 	assert.deepEqual([...mock.events.keys()].sort(), [
 		"agent_end",
 		"agent_settled",

--- a/packages/pi-goal/test/goal-wait.test.ts
+++ b/packages/pi-goal/test/goal-wait.test.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from "node:fs";
 import { afterEach, beforeEach, test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { createGoal, GoalRuntime } from "../src/runtime.js";
+import { MAX_GOAL_WAIT_DELAY_MS, MIN_GOAL_WAIT_DELAY_MS } from "../src/wait.js";
 import {
 	lastGoal,
 	requireGoalTool,
@@ -274,6 +275,7 @@ test("goal_wait validates stale ownership, reason, deadline, and duplicate waits
 		[{ goal_id: "stale", reason: "Wait" }, /goal_id does not match/i],
 		[{ goal_id: goal.id, reason: "   " }, /reason is empty/i],
 		[{ goal_id: goal.id, reason: "x".repeat(1_001) }, /reason is too long/i],
+		[{ goal_id: goal.id, reason: "Wait", resume_after_ms: -1 }, /whole number/i],
 		[{ goal_id: goal.id, reason: "Wait", resume_after_ms: 0 }, /whole number/i],
 		[{ goal_id: goal.id, reason: "Wait", resume_after_ms: 1.5 }, /whole number/i],
 		[{ goal_id: goal.id, reason: "Wait", resume_after_ms: 2_147_483_648 }, /whole number/i],
@@ -307,6 +309,144 @@ test("goal_wait validates stale ownership, reason, deadline, and duplicate waits
 	assert.equal(requireLastGoal(waiting.mock).waiting?.reason, "First wait");
 });
 
+test("goal_wait clamps sub-ten-second deadlines and reports the effective delay", async () => {
+	for (const requestedMs of [1, MIN_GOAL_WAIT_DELAY_MS - 1]) {
+		const waiting = await startGoalForTest();
+		const goal = requireLastGoal(waiting.mock);
+		const result = await requireGoalTool(waiting.mock, "goal_wait").execute(
+			`wait-clamped-${requestedMs}`,
+			{
+				goal_id: goal.id,
+				reason: "Waiting without busy polling",
+				resume_after_ms: requestedMs,
+			},
+			new AbortController().signal,
+			() => undefined,
+			waiting.ctx,
+		);
+
+		assert.deepEqual(result.details, {
+			goal: goal.text,
+			goal_id: goal.id,
+			reason: "Waiting without busy polling",
+			requested_resume_after_ms: requestedMs,
+			resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+			resume_at: Date.now() + MIN_GOAL_WAIT_DELAY_MS,
+		});
+		assert.match(
+			result.content?.[0]?.text ?? "",
+			new RegExp(`requested.*${requestedMs}.*clamped.*${MIN_GOAL_WAIT_DELAY_MS}`, "is"),
+		);
+		assert.equal(
+			requireLastGoal(waiting.mock).waiting?.resumeAt,
+			Date.now() + MIN_GOAL_WAIT_DELAY_MS,
+		);
+
+		await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS - 1);
+		assert.equal(waiting.mock.sentUserMessages.length, 1);
+		await vi.advanceTimersByTimeAsync(1);
+		assert.equal(waiting.mock.sentUserMessages.length, 2);
+		assert.equal(requireLastGoal(waiting.mock).waiting, undefined);
+		await vi.runOnlyPendingTimersAsync();
+		assert.equal(waiting.mock.sentUserMessages.length, 2);
+	}
+});
+
+test("goal_wait preserves valid effective deadlines and deadline-free waits", async () => {
+	for (const resumeAfterMs of [10_000, 10_001, MAX_GOAL_WAIT_DELAY_MS, undefined] as const) {
+		const waiting = await startGoalForTest();
+		const goal = requireLastGoal(waiting.mock);
+		const result = await requireGoalTool(waiting.mock, "goal_wait").execute(
+			`wait-${resumeAfterMs ?? "indefinite"}`,
+			{
+				goal_id: goal.id,
+				reason: "Waiting at a safe interval",
+				...(resumeAfterMs === undefined ? {} : { resume_after_ms: resumeAfterMs }),
+			},
+			new AbortController().signal,
+			() => undefined,
+			waiting.ctx,
+		);
+		const details = result.details as {
+			requested_resume_after_ms?: number;
+			resume_after_ms?: number;
+			resume_at?: number;
+		};
+
+		assert.equal(details.requested_resume_after_ms, undefined);
+		assert.equal(details.resume_after_ms, resumeAfterMs);
+		assert.equal(
+			details.resume_at,
+			resumeAfterMs === undefined ? undefined : Date.now() + resumeAfterMs,
+		);
+		assert.equal(requireLastGoal(waiting.mock).waiting?.resumeAt, details.resume_at);
+		assert.doesNotMatch(result.content?.[0]?.text ?? "", /clamped/i);
+	}
+});
+
+test("external input cancels a clamped deadline without a stale continuation", async () => {
+	const waiting = await startGoalForTest();
+	const goal = requireLastGoal(waiting.mock);
+	await requireGoalTool(waiting.mock, "goal_wait").execute(
+		"wait-clamped-external-wake",
+		{
+			goal_id: goal.id,
+			reason: "Waiting for an external wake before the clamped deadline",
+			resume_after_ms: 1,
+		},
+		new AbortController().signal,
+		() => undefined,
+		waiting.ctx,
+	);
+
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS / 2);
+	waiting.mock.events.get("input")?.[0]?.(
+		{ source: "extension", text: "external wake", streamingBehavior: "followUp" },
+		waiting.ctx,
+	);
+	assert.equal(requireLastGoal(waiting.mock).waiting, undefined);
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS);
+	assert.equal(waiting.mock.sentUserMessages.length, 1);
+});
+
+test("clamp output sanitizes terminal controls and remains bounded", async () => {
+	const waiting = await startGoalForTest();
+	const goal = requireLastGoal(waiting.mock);
+	const result = await requireGoalTool(waiting.mock, "goal_wait").execute(
+		"wait-clamped-output",
+		{
+			goal_id: goal.id,
+			reason: `Waiting ${"\u001b]0;unsafe\u0007"}${"x".repeat(900)}`,
+			resume_after_ms: 1,
+		},
+		new AbortController().signal,
+		() => undefined,
+		waiting.ctx,
+	);
+	const text = result.content?.[0]?.text ?? "";
+
+	assert.equal(text.includes("\u001b"), false);
+	assert.equal(text.includes("\u0007"), false);
+	assert.ok(Buffer.byteLength(text, "utf8") <= 50 * 1024);
+	assert.match(text, /clamped to 10000/i);
+});
+
+test("restoring a persisted short absolute deadline does not extend it to the new floor", async () => {
+	const stored = createGoal("restore legacy short wait", undefined, 0);
+	stored.waiting = {
+		reason: "Legacy short deadline",
+		resumeAt: Date.now() + 100,
+	};
+	stored.activeStartedAt = undefined;
+	const restored = restoreStoredGoalForTest(stored);
+
+	await vi.advanceTimersByTimeAsync(99);
+	assert.equal(restored.mock.sentUserMessages.length, 0);
+	await vi.advanceTimersByTimeAsync(1);
+	assert.equal(restored.mock.sentUserMessages.length, 1);
+	assert.equal(requireLastGoal(restored.mock).waiting, undefined);
+});
+
 test("goal_wait deadline dispatches exactly one continuation through settled gates", async () => {
 	const waiting = await startGoalForTest();
 	const goal = requireLastGoal(waiting.mock);
@@ -315,7 +455,7 @@ test("goal_wait deadline dispatches exactly one continuation through settled gat
 		{
 			goal_id: goal.id,
 			reason: "Waiting for a bounded monitor",
-			resume_after_ms: 1_000,
+			resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
 		},
 		new AbortController().signal,
 		() => undefined,
@@ -329,7 +469,7 @@ test("goal_wait deadline dispatches exactly one continuation through settled gat
 	);
 	assert.match(
 		waiting.notifications.at(-1)?.message ?? "",
-		/Resume deadline: 2026-08-10T00:00:01.000Z/i,
+		/Resume deadline: 2026-08-10T00:00:10.000Z/i,
 	);
 	await waiting.mock.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", stopReason: "toolUse" }] },
@@ -338,7 +478,7 @@ test("goal_wait deadline dispatches exactly one continuation through settled gat
 	await waiting.mock.events.get("agent_settled")?.[0]?.({}, waiting.ctx);
 	assert.equal(waiting.mock.sentUserMessages.length, 1);
 
-	await vi.advanceTimersByTimeAsync(999);
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS - 1);
 	assert.equal(waiting.mock.sentUserMessages.length, 1);
 	await vi.advanceTimersByTimeAsync(1);
 	assert.equal(waiting.mock.sentUserMessages.length, 2);
@@ -354,7 +494,11 @@ test("a failed deadline delivery restores waiting and retries exactly once", asy
 	const goal = requireLastGoal(waiting.mock);
 	await requireGoalTool(waiting.mock, "goal_wait").execute(
 		"wait-retry",
-		{ goal_id: goal.id, reason: "Waiting for retry", resume_after_ms: 100 },
+		{
+			goal_id: goal.id,
+			reason: "Waiting for retry",
+			resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+		},
 		new AbortController().signal,
 		() => undefined,
 		waiting.ctx,
@@ -364,7 +508,7 @@ test("a failed deadline delivery restores waiting and retries exactly once", asy
 		throw new Error("deadline delivery failed");
 	};
 
-	await vi.advanceTimersByTimeAsync(100);
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS);
 	assert.equal(waiting.mock.sentUserMessages.length, 1);
 	assert.equal(requireLastGoal(waiting.mock).waiting?.reason, "Waiting for retry");
 	assert.equal(requireLastGoal(waiting.mock).activeStartedAt, undefined);
@@ -384,7 +528,11 @@ test("two failed deadline deliveries leave a visible wait without retry looping"
 	const goal = requireLastGoal(waiting.mock);
 	await requireGoalTool(waiting.mock, "goal_wait").execute(
 		"wait-retry-exhausted",
-		{ goal_id: goal.id, reason: "Waiting after retry failure", resume_after_ms: 100 },
+		{
+			goal_id: goal.id,
+			reason: "Waiting after retry failure",
+			resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+		},
 		new AbortController().signal,
 		() => undefined,
 		waiting.ctx,
@@ -393,7 +541,7 @@ test("two failed deadline deliveries leave a visible wait without retry looping"
 		throw new Error("deadline delivery failed");
 	};
 
-	await vi.advanceTimersByTimeAsync(1_100);
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS + 1_000);
 	assert.equal(waiting.mock.sentUserMessages.length, 1);
 	assert.equal(requireLastGoal(waiting.mock).waiting?.reason, "Waiting after retry failure");
 	await vi.advanceTimersByTimeAsync(10_000);
@@ -408,12 +556,16 @@ test("a deadline that expires while busy waits for the next settled idle boundar
 	const goal = requireLastGoal(waiting.mock);
 	await requireGoalTool(waiting.mock, "goal_wait").execute(
 		"wait-busy",
-		{ goal_id: goal.id, reason: "Waiting while busy", resume_after_ms: 100 },
+		{
+			goal_id: goal.id,
+			reason: "Waiting while busy",
+			resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+		},
 		new AbortController().signal,
 		() => undefined,
 		waiting.ctx,
 	);
-	await vi.advanceTimersByTimeAsync(100);
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS);
 	assert.equal(waiting.mock.sentUserMessages.length, 1);
 	assert.ok(requireLastGoal(waiting.mock).waiting);
 
@@ -453,13 +605,17 @@ test("shutdown cancels a waiting deadline without discarding persisted waiting s
 	const goal = requireLastGoal(waiting.mock);
 	await requireGoalTool(waiting.mock, "goal_wait").execute(
 		"wait-shutdown",
-		{ goal_id: goal.id, reason: "Waiting through reload", resume_after_ms: 100 },
+		{
+			goal_id: goal.id,
+			reason: "Waiting through reload",
+			resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+		},
 		new AbortController().signal,
 		() => undefined,
 		waiting.ctx,
 	);
 	await waiting.mock.events.get("session_shutdown")?.[0]?.({}, waiting.ctx);
-	await vi.advanceTimersByTimeAsync(100);
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS);
 
 	assert.equal(waiting.mock.sentUserMessages.length, 1);
 	assert.equal(lastGoal(waiting.mock)?.waiting?.reason, "Waiting through reload");
@@ -471,7 +627,11 @@ test("pause, clear, edit, completion, and blocking cancel waiting deadlines", as
 		const goal = requireLastGoal(waiting.mock);
 		await requireGoalTool(waiting.mock, "goal_wait").execute(
 			`wait-${action}`,
-			{ goal_id: goal.id, reason: `Waiting before ${action}`, resume_after_ms: 100 },
+			{
+				goal_id: goal.id,
+				reason: `Waiting before ${action}`,
+				resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+			},
 			new AbortController().signal,
 			() => undefined,
 			waiting.ctx,
@@ -506,7 +666,7 @@ test("pause, clear, edit, completion, and blocking cancel waiting deadlines", as
 
 		const messagesAfterAction = waiting.mock.sentUserMessages.length;
 		assert.equal(lastGoal(waiting.mock)?.waiting, undefined, action);
-		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS);
 		assert.equal(waiting.mock.sentUserMessages.length, messagesAfterAction, action);
 	}
 });
@@ -517,7 +677,11 @@ test("failed edit and replacement delivery restore the exact waiting goal and de
 		const goal = requireLastGoal(waiting.mock);
 		await requireGoalTool(waiting.mock, "goal_wait").execute(
 			"wait-rollback",
-			{ goal_id: goal.id, reason: "Waiting before failed delivery", resume_after_ms: 100 },
+			{
+				goal_id: goal.id,
+				reason: "Waiting before failed delivery",
+				resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+			},
 			new AbortController().signal,
 			() => undefined,
 			waiting.ctx,
@@ -532,11 +696,11 @@ test("failed edit and replacement delivery restore the exact waiting goal and de
 		assert.equal(restored.id, goal.id);
 		assert.deepEqual(restored.waiting, {
 			reason: "Waiting before failed delivery",
-			resumeAt: Date.now() + 100,
+			resumeAt: Date.now() + MIN_GOAL_WAIT_DELAY_MS,
 		});
 
 		waiting.mock.rawPi.sendUserMessage = sendUserMessage;
-		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS);
 		assert.equal(waiting.mock.sentUserMessages.length, 2);
 	}
 });
@@ -548,7 +712,11 @@ test("failed priority delivery restores the waiting head and its deadline", asyn
 	const goal = requireLastGoal(waiting.mock);
 	await requireGoalTool(waiting.mock, "goal_wait").execute(
 		"wait-priority-rollback",
-		{ goal_id: goal.id, reason: "Waiting before failed priority", resume_after_ms: 100 },
+		{
+			goal_id: goal.id,
+			reason: "Waiting before failed priority",
+			resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+		},
 		new AbortController().signal,
 		() => undefined,
 		waiting.ctx,
@@ -563,7 +731,7 @@ test("failed priority delivery restores the waiting head and its deadline", asyn
 	assert.equal(requireLastGoal(waiting.mock).waiting?.reason, "Waiting before failed priority");
 
 	waiting.mock.rawPi.sendUserMessage = sendUserMessage;
-	await vi.advanceTimersByTimeAsync(100);
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS);
 	assert.equal(waiting.mock.sentUserMessages.length, 2);
 });
 
@@ -574,7 +742,11 @@ test("priority displacement cancels waiting before shelving the old goal", async
 	const goal = requireLastGoal(waiting.mock);
 	await requireGoalTool(waiting.mock, "goal_wait").execute(
 		"wait-priority",
-		{ goal_id: goal.id, reason: "Waiting before priority", resume_after_ms: 100 },
+		{
+			goal_id: goal.id,
+			reason: "Waiting before priority",
+			resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+		},
 		new AbortController().signal,
 		() => undefined,
 		waiting.ctx,
@@ -588,7 +760,7 @@ test("priority displacement cancels waiting before shelving the old goal", async
 	assert.equal(state?.goal?.text, "urgent goal");
 	assert.equal(state?.queue?.[0]?.waiting, undefined);
 	const messagesAfterPriority = waiting.mock.sentUserMessages.length;
-	await vi.advanceTimersByTimeAsync(100);
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS);
 	assert.equal(waiting.mock.sentUserMessages.length, messagesAfterPriority);
 });
 
@@ -597,7 +769,11 @@ test("session restore keeps a waiting deadline absolute and wakes once", async (
 	const goal = requireLastGoal(original.mock);
 	await requireGoalTool(original.mock, "goal_wait").execute(
 		"wait-restore",
-		{ goal_id: goal.id, reason: "Waiting across reload", resume_after_ms: 1_000 },
+		{
+			goal_id: goal.id,
+			reason: "Waiting across reload",
+			resume_after_ms: MIN_GOAL_WAIT_DELAY_MS,
+		},
 		new AbortController().signal,
 		() => undefined,
 		original.ctx,
@@ -608,7 +784,7 @@ test("session restore keeps a waiting deadline absolute and wakes once", async (
 	await vi.advanceTimersByTimeAsync(400);
 	const restored = restoreStoredGoalForTest(stored);
 	assert.equal(restored.mock.sentUserMessages.length, 0);
-	await vi.advanceTimersByTimeAsync(599);
+	await vi.advanceTimersByTimeAsync(MIN_GOAL_WAIT_DELAY_MS - 401);
 	assert.equal(restored.mock.sentUserMessages.length, 0);
 	await vi.advanceTimersByTimeAsync(1);
 	assert.equal(restored.mock.sentUserMessages.length, 1);

--- a/packages/pi-goal/test/support/goal-fixture.ts
+++ b/packages/pi-goal/test/support/goal-fixture.ts
@@ -124,6 +124,8 @@ export function assertHardenedGoalPrompt(prompt: string) {
 	assert.match(prompt, /resumed.*fresh three-turn blocker audit/is);
 	assert.match(prompt, /hard, slow, uncertain.*recoverable/is);
 	assert.match(prompt, /arrange a non-goal wake message.*goal_wait.*exact current goal_id/is);
+	assert.match(prompt, /prefer longer goal_wait deadlines.*minutes.*busy polling/is);
+	assert.match(prompt, /below 10000ms.*clamped.*omitting resume_after_ms.*quiet/is);
 	assert.match(prompt, /goal_wait alone.*parallel sibling tools/is);
 	assert.match(prompt, /goal_blocked.*recoverable external wait/is);
 }


### PR DESCRIPTION
## Summary

- clamp `goal_wait` deadlines below 10 seconds to prevent rapid automatic wake loops
- report requested and effective delays while preserving deadline-free waits and persisted absolute deadlines
- strengthen anti-polling prompt guidance, documentation, lifecycle coverage, and boundary tests
- record the Codex waiting comparison and archive the completed implementation plan

Follow-up hardening for #661 and #663.

## Review

An independent hardening review found missing coverage for external wake cancellation, negative and maximum bounds, and terminal-output safety.

The final tests cover each finding, including stale-timer prevention after an external wake.

No Pi Core API or dependency changes are included.

## Verification

- `npx vitest run packages/pi-goal/test/goal-wait.test.ts packages/pi-goal/test/goal-tool-policy.test.ts packages/pi-goal/test/goal-contracts.test.ts` — 80 passed
- complete `pi-goal` suite — 342 passed
- `npm run typecheck --workspace @narumitw/pi-goal`
- `npm run test:runtime --workspace @narumitw/pi-goal`
- `npm test` — 2,792 passed across 256 files
- `npm run check` — Biome, boundaries, all workspace typechecks, builds, and 2,792 tests passed
- `just pack goal` — 24 expected package files and no retained tarball
- `npm run changeset:status`
- `git diff --check`

One earlier repeated root-test run hit an unrelated `pi-sync` condition-wait timeout.

That 14-test file passed immediately in isolation, and both subsequent full root gates passed.
