### PR TITLE
feat(file-context): add configurable open shortcut

### DIFF
--- a/.changeset/fuzzy-files-shortcut.md
+++ b/.changeset/fuzzy-files-shortcut.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": minor
+---
+
+Replace the immediate `@` screen takeover with a configurable File Context shortcut that defaults to `Ctrl+Alt+F`, preserves Pi's native editor, and can be disabled in user settings.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ commands, settings persistence, confirmations, and specialized UI.
 | --- | --- | --- |
 | [`pi-analytics`](./packages/pi-analytics) | Review private, content-free local metrics for model calls, skills, tools, response cycles, and observed provider reliability through `/analytics`. | `pi install npm:@narumitw/pi-analytics` |
 | [`pi-codex-compact`](./packages/pi-codex-compact) | Use OpenAI Codex Remote Compaction V2 to persist and replay bounded opaque checkpoints, with `/codex-compact` manual controls and safe Pi-native fallback. | `pi install npm:@narumitw/pi-codex-compact` |
-| [`pi-file-context`](./packages/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it by typing `@` at a word boundary or running `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
+| [`pi-file-context`](./packages/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it with configurable `Ctrl+Alt+F` or `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
 | [`pi-webui`](./packages/pi-webui) | Use a private loopback browser companion for the current terminal session with live activity and text/image input. | `pi install npm:@narumitw/pi-webui` |
 
 ## 🔧 Advanced installation

--- a/docs/plans/archived/2026-08-10_pi-file-context-shortcut-settings-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-file-context-shortcut-settings-plan.md
@@ -1,0 +1,35 @@
+# Pi File Context shortcut settings plan
+
+## Goal
+
+Replace the immediate `@` screen takeover with a configurable File Context shortcut that defaults to `Ctrl+Alt+F`, while preserving `/file-context` and Pi's native editor behavior.
+
+## Architecture
+
+- `pi-file-context` owns user settings in `<getAgentDir()>/pi-file-context.json`.
+- The extension loads and validates `openShortcut` during factory initialization so Pi can register the resolved shortcut before interactive shortcut setup.
+- `openShortcut` accepts a Pi key identifier string or `null` to disable the shortcut.
+- Missing settings use `ctrl+alt+f`, while malformed files or invalid values keep the default and produce a TUI warning after `session_start`.
+- Shortcut and slash-command activation share the existing abort-aware explorer lifecycle.
+
+## Non-Goals
+
+- Do not add project-level shortcut overrides.
+- Do not add a settings menu for this single manually editable setting.
+- Do not change File Context's internal `Ctrl+F` file/content search toggle.
+
+## Plan
+
+- [x] Add focused tests for default, custom, disabled, malformed, and invalid shortcut settings, plus shortcut registration and removal of the immediate `@` editor takeover; the settings test first failed on custom and malformed inputs, registration tests failed before the new installer existed, and the repeated-launch test observed two concurrent explorers.
+- [x] Add the settings loader and register the resolved shortcut without replacing Pi's editor; all 47 focused File Context tests pass.
+- [x] Update package documentation and add a Changeset for the published behavior change; `README.md`, `packages/pi-file-context/README.md`, and `.changeset/fuzzy-files-shortcut.md` describe the implemented default, settings path, reload boundary, and fallback.
+- [x] Audit lifecycle cancellation, session replacement, settings failure behavior, native editor preservation, and shortcut conflicts against the extension guides; session generation and abort guards remain active, repeated launches coalesce, RPC and TUI warnings are observable, modified function-key combinations unsupported by Pi are rejected, and no editor component is installed.
+- [x] Run the package checks, full repository check, and package dry run, then archive this completed plan; the package check, 2,792-test repository gate, and `just pack file-context` pass.
+
+## Completion Checklist
+
+- [x] `@` no longer directly opens File Context or replaces the normal editor.
+- [x] `Ctrl+Alt+F` opens File Context by default and `openShortcut` can replace or disable it after `/reload`.
+- [x] `/file-context` remains compatible in TUI and rejects unsupported modes as before.
+- [x] Invalid settings never overwrite the source file and produce an observable warning in TUI and RPC modes.
+- [x] Focused tests, `npm run check`, and `just pack file-context` pass.

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -11,8 +11,8 @@ Browse project files inside Pi, preview text, select a line range, and attach th
 
 ## ✨ Features
 
-- Opens the file explorer when `@` is typed at a word boundary in Pi's normal editor.
-- Provides `/file-context` as a discoverable fallback when another extension owns the editor.
+- Opens the file explorer with a configurable shortcut that defaults to `Ctrl+Alt+F` (`Control+Option+F` on macOS).
+- Provides `/file-context` as a discoverable fallback without replacing Pi's normal editor.
 - Fuzzy-searches project file names with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
 - Switches with `Ctrl+F` to cancellable cwd content search with highlighted result cards, literal case-insensitive matching by default, and visible case-sensitive and fuzzy toggles.
 - Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
@@ -43,13 +43,13 @@ pi -e ./packages/pi-file-context
 
 ## 🚀 Quick start
 
-1. Type `@` at the start of a word in Pi's editor. If another custom editor is active, run `/file-context` instead.
+1. Press `Ctrl+Alt+F` (`Control+Option+F` on macOS) or run `/file-context`.
 2. Type to fuzzy-search file names in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
 3. Press `Ctrl+F` to switch between file-name and content search. Content search is literal and case-insensitive by default; `Alt+C` toggles case sensitivity and `Alt+F` toggles ordered fuzzy matching. The current states remain visible above the results.
 4. In content results, use `Up`/`Down` to choose a highlighted path-and-line card. Press `Tab` for a whole-file reference or `Enter` to preview the file at that line. `Escape` from the preview restores the query, result selection, and scroll position.
 5. In the preview, press `Space` to anchor the selection. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
 6. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.
-7. Repeat from `@` to attach more ranges from the same or different files, then write the question and submit normally. All pending quotes are attached in selection order and then cleared together.
+7. Repeat from the shortcut to attach more ranges from the same or different files, then write the question and submit normally. All pending quotes are attached in selection order and then cleared together.
 
 `Escape` returns from a preview to its originating file-name or content results; from either search screen it cancels without changing the draft. `Ctrl+C` cancels from every view.
 
@@ -64,6 +64,28 @@ selected content
 Non-Git quotes retain the original `path` and `lines` attributes exactly. Git-backed quotes add ordered optional provenance: the repository HEAD at selection time, branch, file status, selected revision or baseline, tracked blob when available, source kind (`worktree`, `revision`, or `git_diff`), and SHA-256 of the exact attached text. HEAD alone does not identify uncommitted content; `content_sha256` identifies the actual snapshot.
 
 Token counts are deterministic byte-based estimates (`ceil(UTF-8 bytes / 4)`), not provider billing guarantees. Diff context is never attached automatically.
+
+## ⚙️ Settings
+
+File Context reads optional user settings from `~/.pi/agent/pi-file-context.json`, or the equivalent file under Pi's configured agent directory.
+
+The file is not created when defaults are used.
+
+```json
+{
+  "openShortcut": "ctrl+alt+f"
+}
+```
+
+Set `openShortcut` to any valid Pi key identifier, or set it to `null` to disable the shortcut and use `/file-context` only.
+
+Run `/reload` after editing the file because Pi registers extension shortcuts during extension loading.
+
+Invalid JSON or values leave the source file unchanged, use the default shortcut, and produce a warning.
+
+Choose a shortcut that does not conflict with Pi or another extension; `Ctrl+F` is already Pi's cursor-right binding and File Context's internal search-mode toggle.
+
+On macOS, terminals may require **Use Option as Meta key** for `Control+Option` combinations.
 
 ## 💬 Commands
 
@@ -93,7 +115,7 @@ RPC receives an observable warning. JSON and print modes do not enter custom UI.
 - Keyboard line selection only; mouse drag selection is not implemented.
 - Up to eight pending quotes; there is not yet an interactive remove/reorder action.
 - Pending quotes do not survive `/reload`, session replacement, or shutdown.
-- The `@` trigger is not installed when another extension already owns the custom editor; `/file-context` remains available.
+- The configurable shortcut is registered without replacing another extension's custom editor; `/file-context` remains available if the shortcut is disabled or conflicts.
 - File discovery uses a small built-in ignore list rather than `.gitignore` semantics.
 - Content search scans discovered files natively and sequentially; large projects or queries with no matches may take longer than indexed or external search tools.
 - Fuzzy content search matches query characters in order on one line; it is not semantic search and does not cross line boundaries.
@@ -104,7 +126,8 @@ RPC receives an observable warning. JSON and print modes do not enter custom UI.
 
 ```text
 src/index.ts                   Thin Pi entrypoint
-src/file-context.ts            Lifecycle, filesystem boundaries, quote injection
+src/file-context.ts            Lifecycle, shortcut registration, filesystem boundaries, quote injection
+src/file-context-settings.ts   User shortcut loading and validation
 src/file-context-explorer.ts   File list, Git detail views, and line-range TUI
 src/content-search.ts          Bounded literal and fuzzy content matching
 src/content-search-session.ts  Search input, toggles, navigation, and cancellation
@@ -114,7 +137,8 @@ src/git-context.ts             Bounded read-only Git status, diff, blame, histor
 
 test/content-search.test.ts     Content matcher behavior and limits
 test/content-search-ui.test.ts  Content interaction, rendering, and lifecycle tests
-test/file-context.test.ts       Filesystem, prompt, lifecycle, and explorer tests
+test/file-context.test.ts       Filesystem, prompt, lifecycle, shortcut, and explorer tests
+test/file-context-settings.test.ts  Shortcut settings defaults and validation tests
 test/git-context.test.ts        Git repository behavior and parser tests
 ```
 

--- a/packages/pi-file-context/src/file-context-settings.ts
+++ b/packages/pi-file-context/src/file-context-settings.ts
@@ -1,0 +1,146 @@
+import { readFile } from "node:fs/promises";
+import type { KeyId } from "@earendil-works/pi-tui";
+
+export interface FileContextSettings {
+	openShortcut: KeyId | null;
+}
+
+export interface LoadedFileContextSettings {
+	settings: FileContextSettings;
+	warning?: string;
+}
+
+export const DEFAULT_FILE_CONTEXT_SETTINGS: FileContextSettings = {
+	openShortcut: "ctrl+alt+f",
+};
+
+const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
+const BASE_KEYS = new Set([
+	..."abcdefghijklmnopqrstuvwxyz0123456789",
+	"`",
+	"-",
+	"=",
+	"[",
+	"]",
+	"\\",
+	";",
+	"'",
+	",",
+	".",
+	"/",
+	"!",
+	"@",
+	"#",
+	"$",
+	"%",
+	"^",
+	"&",
+	"*",
+	"(",
+	")",
+	"_",
+	"+",
+	"|",
+	"~",
+	"{",
+	"}",
+	":",
+	"<",
+	">",
+	"?",
+	"escape",
+	"esc",
+	"enter",
+	"return",
+	"tab",
+	"space",
+	"backspace",
+	"delete",
+	"insert",
+	"clear",
+	"home",
+	"end",
+	"pageup",
+	"pagedown",
+	"up",
+	"down",
+	"left",
+	"right",
+	...Array.from({ length: 12 }, (_, index) => `f${index + 1}`),
+]);
+
+export async function loadFileContextSettings(
+	settingsPath: string,
+): Promise<LoadedFileContextSettings> {
+	let source: string;
+	try {
+		source = await readFile(settingsPath, "utf8");
+	} catch (error: unknown) {
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return { settings: { ...DEFAULT_FILE_CONTEXT_SETTINGS } };
+		}
+		return defaultWithWarning(`Cannot read File Context settings: ${formatError(error)}`);
+	}
+
+	let document: unknown;
+	try {
+		document = JSON.parse(source);
+	} catch (error: unknown) {
+		return defaultWithWarning(`Cannot parse File Context settings: ${formatError(error)}`);
+	}
+	if (!isRecord(document)) {
+		return defaultWithWarning("File Context settings must contain a JSON object.");
+	}
+	if (!("openShortcut" in document)) {
+		return { settings: { ...DEFAULT_FILE_CONTEXT_SETTINGS } };
+	}
+	if (document.openShortcut === null) {
+		return { settings: { openShortcut: null } };
+	}
+	if (typeof document.openShortcut !== "string") {
+		return defaultWithWarning('File Context setting "openShortcut" must be a key string or null.');
+	}
+	const shortcut = normalizeKeyId(document.openShortcut);
+	if (!shortcut) {
+		return defaultWithWarning(
+			`File Context setting "openShortcut" is invalid: ${JSON.stringify(document.openShortcut)}.`,
+		);
+	}
+	return { settings: { openShortcut: shortcut } };
+}
+
+function normalizeKeyId(value: string): KeyId | undefined {
+	const normalized = value.trim().toLowerCase();
+	const base = [...BASE_KEYS]
+		.sort((left, right) => right.length - left.length)
+		.find((candidate) => normalized === candidate || normalized.endsWith(`+${candidate}`));
+	if (!base) return undefined;
+	const prefix = normalized.slice(0, normalized.length - base.length);
+	if (!prefix) return base as KeyId;
+	if (/^f(?:[1-9]|1[0-2])$/.test(base) || !prefix.endsWith("+")) return undefined;
+	const modifiers = prefix.slice(0, -1).split("+");
+	if (
+		modifiers.length === 0 ||
+		modifiers.some((modifier) => !MODIFIERS.has(modifier)) ||
+		new Set(modifiers).size !== modifiers.length
+	) {
+		return undefined;
+	}
+	return normalized as KeyId;
+}
+
+function defaultWithWarning(warning: string): LoadedFileContextSettings {
+	return { settings: { ...DEFAULT_FILE_CONTEXT_SETTINGS }, warning };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error;
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -1,15 +1,17 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import { lstat, open, readdir, realpath } from "node:fs/promises";
-import { isAbsolute, relative, resolve, sep } from "node:path";
-import type { KeybindingsManager } from "@earendil-works/pi-coding-agent";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
-	CustomEditor,
 	type ExtensionAPI,
 	type ExtensionContext,
+	getAgentDir,
 } from "@earendil-works/pi-coding-agent";
-import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { FileQuoteExplorer, type FileQuoteExplorerResult } from "./file-context-explorer.js";
+import {
+	type LoadedFileContextSettings,
+	loadFileContextSettings,
+} from "./file-context-settings.js";
 import { createGitContext } from "./git-context.js";
 
 const WIDGET_KEY = "file-context";
@@ -270,43 +272,23 @@ export function formatQuoteContext(quotes: readonly FileQuote[]): string {
 	return `${blocks.join("\n\n")}\n\n${description}`;
 }
 
-export class FileQuoteTriggerEditor extends CustomEditor {
-	private opening = false;
-
-	constructor(
-		tui: TUI,
-		theme: EditorTheme,
-		keybindings: KeybindingsManager,
-		private readonly openExplorer: () => Promise<void>,
-	) {
-		super(tui, theme, keybindings);
-	}
-
-	override handleInput(data: string): void {
-		if (data === "@" && !this.opening && this.isQuoteTriggerPosition()) {
-			this.opening = true;
-			void this.openExplorer().finally(() => {
-				this.opening = false;
-				this.tui.requestRender();
-			});
-			return;
-		}
-		super.handleInput(data);
-	}
-
-	private isQuoteTriggerPosition(): boolean {
-		const { line, col } = this.getCursor();
-		const currentLine = this.getLines()[line] ?? "";
-		return col === 0 || /\s/.test(currentLine[col - 1] ?? "");
-	}
+interface FileQuoteExtensionDependencies {
+	loadSettings?: () => Promise<LoadedFileContextSettings>;
 }
 
-export default function fileQuoteExtension(pi: ExtensionAPI): void {
+export async function registerFileQuoteExtension(
+	pi: ExtensionAPI,
+	dependencies: FileQuoteExtensionDependencies = {},
+): Promise<void> {
+	const loadedSettings = await (
+		dependencies.loadSettings ??
+		(() => loadFileContextSettings(join(getAgentDir(), "pi-file-context.json")))
+	)();
 	let pendingQuotes: FileQuote[] = [];
-	let installedEditorFactory: unknown;
 	let activeSessionManager: unknown;
 	let sessionGeneration = 0;
 	const activeExplorers = new Set<ActiveExplorer>();
+	let activeExplorerLaunch: { promise: Promise<void> } | undefined;
 
 	const clearPending = (ctx: ExtensionContext) => {
 		pendingQuotes = [];
@@ -339,6 +321,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		owner === activeSessionManager && generation === sessionGeneration;
 
 	const cancelExplorers = () => {
+		activeExplorerLaunch = undefined;
 		for (const explorer of activeExplorers) {
 			explorer.controller.abort();
 			explorer.component?.dispose();
@@ -346,7 +329,7 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		activeExplorers.clear();
 	};
 
-	const openExplorer = async (ctx: ExtensionContext): Promise<void> => {
+	const runExplorer = async (ctx: ExtensionContext): Promise<void> => {
 		if (ctx.mode !== "tui") {
 			rejectCommand(ctx, "File Context requires Pi's interactive TUI.");
 			return;
@@ -406,6 +389,17 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		}
 	};
 
+	const openExplorer = (ctx: ExtensionContext): Promise<void> => {
+		if (activeExplorerLaunch) return activeExplorerLaunch.promise;
+		const launch = { promise: runExplorer(ctx) };
+		activeExplorerLaunch = launch;
+		const clearLaunch = () => {
+			if (activeExplorerLaunch === launch) activeExplorerLaunch = undefined;
+		};
+		void launch.promise.then(clearLaunch, clearLaunch);
+		return launch.promise;
+	};
+
 	const handleFileContextCommand = async (args: string, ctx: ExtensionContext) => {
 		if (args.trim()) {
 			rejectCommand(ctx, "Usage: /file-context");
@@ -417,29 +411,27 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		description: "Browse project files and attach a selected line range",
 		handler: handleFileContextCommand,
 	});
+	if (loadedSettings.settings.openShortcut) {
+		pi.registerShortcut(loadedSettings.settings.openShortcut, {
+			description: "Open File Context",
+			handler: openExplorer,
+		});
+	}
 
 	pi.on("session_start", (_event, ctx) => {
 		cancelExplorers();
 		activeSessionManager = ctx.sessionManager;
 		sessionGeneration += 1;
 		clearPending(ctx);
+		if (loadedSettings.warning && ctx.hasUI) ctx.ui.notify(loadedSettings.warning, "warning");
 		if (ctx.mode !== "tui") return;
+		const shortcut = loadedSettings.settings.openShortcut;
 		ctx.ui.notify(
-			"Experimental File Context loaded. Type @ at a word boundary to browse files.",
+			shortcut
+				? `Experimental File Context loaded. Press ${shortcut} or run /file-context.`
+				: "Experimental File Context loaded. Run /file-context to browse files.",
 			"warning",
 		);
-		const previous = ctx.ui.getEditorComponent();
-		if (previous) {
-			ctx.ui.notify(
-				"File Context left the existing custom editor unchanged; use /file-context.",
-				"warning",
-			);
-			return;
-		}
-		const factory = (tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) =>
-			new FileQuoteTriggerEditor(tui, theme, keybindings, () => openExplorer(ctx));
-		installedEditorFactory = factory;
-		ctx.ui.setEditorComponent(factory);
 	});
 
 	pi.on("before_agent_start", (_event, ctx) => {
@@ -459,12 +451,11 @@ export default function fileQuoteExtension(pi: ExtensionAPI): void {
 		if (ctx.sessionManager !== activeSessionManager) return;
 		cancelExplorers();
 		clearPending(ctx);
-		if (installedEditorFactory && ctx.mode === "tui") {
-			if (ctx.ui.getEditorComponent() === installedEditorFactory)
-				ctx.ui.setEditorComponent(undefined);
-			installedEditorFactory = undefined;
-		}
 	});
+}
+
+export default async function fileQuoteExtension(pi: ExtensionAPI): Promise<void> {
+	await registerFileQuoteExtension(pi);
 }
 
 function normalizeTextLines(contents: string): string[] {

--- a/packages/pi-file-context/test/file-context-lifecycle.test.ts
+++ b/packages/pi-file-context/test/file-context-lifecycle.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
-import fileQuoteExtension from "../src/file-context.js";
+import { registerFileQuoteExtension } from "../src/file-context.js";
 
 test("disposes and settles an active explorer on session replacement", async () => {
 	await assertExplorerLifecycleCancellation("session_start");
@@ -21,7 +21,9 @@ async function assertExplorerLifecycleCancellation(
 	try {
 		await writeFile(join(root, "example.txt"), "needle\n");
 		const mock = createMockPi();
-		fileQuoteExtension(mock.pi);
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+		});
 		let markReady!: () => void;
 		const ready = new Promise<void>((resolve) => {
 			markReady = resolve;

--- a/packages/pi-file-context/test/file-context-settings.test.ts
+++ b/packages/pi-file-context/test/file-context-settings.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import {
+	DEFAULT_FILE_CONTEXT_SETTINGS,
+	loadFileContextSettings,
+} from "../src/file-context-settings.js";
+
+async function withTempSettings(run: (settingsPath: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-file-context-settings-test-"));
+	try {
+		await run(join(root, "pi-file-context.json"));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("missing settings use Ctrl+Alt+F without creating a file", async () => {
+	await withTempSettings(async (settingsPath) => {
+		const result = await loadFileContextSettings(settingsPath);
+		assert.deepEqual(result, { settings: DEFAULT_FILE_CONTEXT_SETTINGS });
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});
+
+test("settings normalize a custom shortcut and allow disabling it", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await writeFile(settingsPath, JSON.stringify({ openShortcut: "Ctrl+Alt+R", future: true }));
+		assert.deepEqual(await loadFileContextSettings(settingsPath), {
+			settings: { openShortcut: "ctrl+alt+r" },
+		});
+
+		await writeFile(settingsPath, JSON.stringify({ openShortcut: null }));
+		assert.deepEqual(await loadFileContextSettings(settingsPath), {
+			settings: { openShortcut: null },
+		});
+	});
+});
+
+test("malformed or invalid settings keep the default and return an observable warning", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await writeFile(settingsPath, "{broken");
+		const malformed = await loadFileContextSettings(settingsPath);
+		assert.deepEqual(malformed.settings, DEFAULT_FILE_CONTEXT_SETTINGS);
+		assert.match(malformed.warning ?? "", /cannot parse/i);
+		assert.equal(await readFile(settingsPath, "utf8"), "{broken");
+
+		for (const openShortcut of ["ctrl+not-a-key", "ctrl+f1"]) {
+			await writeFile(settingsPath, JSON.stringify({ openShortcut }));
+			const invalid = await loadFileContextSettings(settingsPath);
+			assert.deepEqual(invalid.settings, DEFAULT_FILE_CONTEXT_SETTINGS);
+			assert.match(invalid.warning ?? "", /openShortcut/);
+		}
+	});
+});

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -5,14 +5,14 @@ import { join } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
-import fileQuoteExtension, {
+import {
 	appendPendingQuote,
 	createFileQuote,
 	discoverProjectFiles,
-	FileQuoteTriggerEditor,
 	formatPromptWithQuote,
 	formatPromptWithQuotes,
 	loadProjectTextFile,
+	registerFileQuoteExtension,
 } from "../src/file-context.js";
 import { FileQuoteExplorer } from "../src/file-context-explorer.js";
 import { ProjectFileSearch } from "../src/file-search.js";
@@ -624,34 +624,89 @@ test("explorer loads validated revisions and attaches explicit Git diff context"
 	assert.equal(diffResult.quote.git?.base, "HEAD");
 });
 
-test("custom editor opens the explorer on a boundary @ without changing the draft", async () => {
-	let opened = 0;
-	const editor = new FileQuoteTriggerEditor(
-		{ requestRender() {} } as never,
-		{
-			borderColor: (text: string) => text,
-			selectList: {
-				selectedPrefix: (text: string) => text,
-				selectedText: (text: string) => text,
-				description: (text: string) => text,
-				scrollInfo: (text: string) => text,
-				noMatch: (text: string) => text,
-			},
-		},
-		{ matches: () => false } as never,
-		async () => {
-			opened += 1;
-		},
-	);
-	editor.setText("draft ");
-	editor.handleInput("@");
-	await Promise.resolve();
-	assert.equal(opened, 1);
-	assert.equal(editor.getText(), "draft ");
+test("registers the configured shortcut without replacing Pi's editor", async () => {
+	const mock = createMockPi();
+	await registerFileQuoteExtension(mock.pi, {
+		loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+r" } }),
+	});
+	assert.deepEqual([...mock.shortcuts.keys()], ["ctrl+alt+r"]);
 
-	editor.setText("email");
-	editor.handleInput("@");
-	assert.equal(editor.getText(), "email@");
+	let editorFactoryChanges = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			notify() {},
+			setWidget() {},
+			setEditorComponent() {
+				editorFactoryChanges += 1;
+			},
+			getEditorComponent: () => undefined,
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	assert.equal(editorFactoryChanges, 0);
+});
+
+test("coalesces repeated shortcut presses while the explorer is active", async () => {
+	await withTempProject(async (root) => {
+		await writeFile(join(root, "example.ts"), "export {};\n");
+		const mock = createMockPi();
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+		});
+		let customCalls = 0;
+		let markExplorerReady!: () => void;
+		const explorerReady = new Promise<void>((resolve) => {
+			markExplorerReady = resolve;
+		});
+		let closeExplorer!: () => void;
+		const explorerClosed = new Promise<void>((resolve) => {
+			closeExplorer = resolve;
+		});
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			ui: {
+				notify() {},
+				setWidget() {},
+				async custom() {
+					customCalls += 1;
+					markExplorerReady();
+					await explorerClosed;
+					return undefined;
+				},
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		const shortcut = mock.shortcuts.get("ctrl+alt+f");
+		const first = shortcut?.handler(context.ctx);
+		const second = shortcut?.handler(context.ctx);
+		await explorerReady;
+		assert.equal(customCalls, 1);
+		closeExplorer();
+		await Promise.all([first, second]);
+	});
+});
+
+test("allows disabling the shortcut and reports settings warnings after session start", async () => {
+	const mock = createMockPi();
+	await registerFileQuoteExtension(mock.pi, {
+		loadSettings: async () => ({
+			settings: { openShortcut: null },
+			warning: "Invalid File Context settings; using the default.",
+		}),
+	});
+	assert.equal(mock.shortcuts.size, 0);
+
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	assert.ok(context.notifications.some(({ message }) => message.includes("Invalid File Context")));
+
+	const rpc = createMockContext({ mode: "rpc", hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, rpc.ctx);
+	assert.ok(rpc.notifications.some(({ message }) => message.includes("Invalid File Context")));
 });
 
 test("captures an exact normalized line snapshot and formats one focused prompt", () => {
@@ -724,14 +779,14 @@ test("accumulates ordered pending quotes within aggregate limits", () => {
 
 test("registers a TUI fallback command and injects all pending quotes only once", async () => {
 	const mock = createMockPi();
-	fileQuoteExtension(mock.pi);
+	await registerFileQuoteExtension(mock.pi, {
+		loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+	});
 	assert.ok(mock.commands.has("file-context"));
 	assert.equal(mock.commands.has("file-quote"), false);
 
 	let customFactory: unknown;
 	const widgets = new Map<string, unknown>();
-	const editorFactories: unknown[] = [];
-	let currentEditorFactory: unknown;
 	let quoteIndex = 0;
 	const quoteResults = [
 		{
@@ -767,13 +822,6 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 			setWidget(key: string, value: unknown) {
 				widgets.set(key, value);
 			},
-			setEditorComponent(factory: unknown) {
-				currentEditorFactory = factory;
-				editorFactories.push(factory);
-			},
-			getEditorComponent() {
-				return currentEditorFactory;
-			},
 			async custom(factory: unknown) {
 				customFactory = factory;
 				const result = quoteResults[quoteIndex];
@@ -784,8 +832,7 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 	});
 
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	assert.equal(editorFactories.length, 1);
-	await mock.commands.get("file-context")?.handler("", context.ctx);
+	await mock.shortcuts.get("ctrl+alt+f")?.handler(context.ctx);
 	await mock.commands.get("file-context")?.handler("", context.ctx);
 	assert.equal(typeof customFactory, "function");
 	assert.deepEqual(widgets.get("file-context"), [
@@ -815,13 +862,14 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 		undefined,
 	);
 	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
-	assert.equal(currentEditorFactory, undefined);
 	assert.equal(widgets.get("file-context"), undefined);
 });
 
 test("quotes whole-file references and rejects picker results from replaced sessions", async () => {
 	const referenceMock = createMockPi();
-	fileQuoteExtension(referenceMock.pi);
+	await registerFileQuoteExtension(referenceMock.pi, {
+		loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+	});
 	const pasted: string[] = [];
 	const referenceContext = createMockContext({
 		mode: "tui",
@@ -848,7 +896,9 @@ test("quotes whole-file references and rejects picker results from replaced sess
 	assert.deepEqual(pasted, ['@"docs/my \\"note\\".md" ']);
 
 	const staleMock = createMockPi();
-	fileQuoteExtension(staleMock.pi);
+	await registerFileQuoteExtension(staleMock.pi, {
+		loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+	});
 	let resolvePicker: ((value: unknown) => void) | undefined;
 	const picker = new Promise((resolve) => {
 		resolvePicker = resolve;
@@ -895,7 +945,9 @@ test("quotes whole-file references and rejects picker results from replaced sess
 
 test("rejects the fallback command observably outside TUI mode", async () => {
 	const mock = createMockPi();
-	fileQuoteExtension(mock.pi);
+	await registerFileQuoteExtension(mock.pi, {
+		loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+	});
 	const rpc = createMockContext({ mode: "rpc", hasUI: true });
 	await mock.commands.get("file-context")?.handler("", rpc.ctx);
 	assert.match(rpc.notifications[0]?.message ?? "", /interactive TUI/);

--- a/test/support.ts
+++ b/test/support.ts
@@ -22,6 +22,7 @@ type MockFlag = {
 
 type MockPiApi = {
 	registerCommand(name: string, command: unknown): void;
+	registerShortcut(shortcut: KeyId, options: unknown): void;
 	registerFlag(name: string, flag: unknown): void;
 	registerTool(tool: unknown): void;
 	registerEntryRenderer(customType: string, renderer: MockHandler): void;
@@ -54,6 +55,7 @@ export function createMockPi(
 	} = {},
 ) {
 	const commands = new Map<string, MockCommand>();
+	const shortcuts = new Map<KeyId, { description?: string; handler: MockHandler }>();
 	const entryRenderers = new Map<string, MockHandler>();
 	const flags = new Map<string, MockFlag>();
 	const events = new Map<string, MockHandler[]>();
@@ -100,6 +102,9 @@ export function createMockPi(
 	const rawPi: MockPiApi = {
 		registerCommand(name: string, command: unknown) {
 			commands.set(name, command as MockCommand);
+		},
+		registerShortcut(shortcut: KeyId, options: unknown) {
+			shortcuts.set(shortcut, options as { description?: string; handler: MockHandler });
 		},
 		registerFlag(name: string, flag: unknown) {
 			flags.set(name, flag as MockFlag);
@@ -170,6 +175,7 @@ export function createMockPi(
 		pi: rawPi as never,
 		rawPi,
 		commands,
+		shortcuts,
 		entryRenderers,
 		flags,
 		events,


### PR DESCRIPTION
## Summary

- replace the immediate `@` editor takeover with a configurable shortcut that defaults to `Ctrl+Alt+F`
- preserve `/file-context`, native editor behavior, and explorer lifecycle cancellation
- add settings validation, documentation, tests, and a minor Changeset

## Verification

- `npm run check` (257 files, 2,792 tests)
- `npx vitest run packages/pi-file-context/test/*.test.ts` (47 tests)
- `just pack file-context`
- lifecycle/settings audit against `docs/extension-conventions.md` and `docs/extension-settings.md`