### PR TITLE
fix(accounts): pass menu signal to OAuth login

### DIFF
--- a/.changeset/gentle-accounts-signal.md
+++ b/.changeset/gentle-accounts-signal.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-accounts": patch
+---
+
+Pass the account menu's abort signal to provider-owned OAuth login so interactive GitHub Copilot and other provider logins do not fail while Pi is idle and stop safely when their session closes.

--- a/docs/plans/archived/2026-08-10_pi-accounts-oauth-signal-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-accounts-oauth-signal-plan.md
@@ -1,0 +1,54 @@
+# Fix pi-accounts OAuth login signal
+
+## Context
+
+Issue [#664](https://github.com/narumiruna/pi-extensions/issues/664) is an open, unlabeled bug in `@narumitw/pi-accounts` 0.49.5 with Pi 0.84.1.
+
+The interactive `/accounts` login path runs while Pi is idle, so `ExtensionCommandContext.signal` is `undefined`.
+
+`packages/pi-accounts/src/oauth.ts` forwards that value through an `AuthInteraction`, while Pi's provider login contract requires a non-optional `ProviderAuthInteraction.signal`.
+
+GitHub Copilot reads `interaction.signal.aborted` before its network request and therefore throws `Cannot read properties of undefined (reading 'aborted')`.
+
+The failure was reproduced through `/accounts` and independently against the pinned GitHub Copilot OAuth implementation without making a network request.
+
+The account menu already provides each action with a non-optional signal tied to menu ownership, session replacement, and shutdown, but the login action currently ignores it.
+
+## Goal
+
+Make every `/accounts` provider login receive the menu action's concrete `AbortSignal`, so idle GitHub Copilot login proceeds instead of crashing and stale login work remains cancellable by its owning lifecycle.
+
+## Non-Goals
+
+- Do not change provider selection, account naming, credential storage, activation, refresh, or fail-closed behavior.
+- Do not alter Pi's provider implementations or make GitHub Copilot-specific exceptions.
+- Do not add new commands, settings, dependencies, or menu screens.
+- Do not require a live GitHub login or external entitlement for deterministic verification.
+
+## Plan
+
+- [x] Update `packages/pi-accounts/src/oauth.ts` to type provider-owned login against Pi's `ProviderAuthInteraction` contract and require `createOAuthInteraction` callers to supply a concrete `AbortSignal`; package typechecking passed.
+- [x] Update the `login-provider` action and `loginAccount` flow in `packages/pi-accounts/src/accounts.ts` to pass the action-owned signal into `createOAuthInteraction`; `rg` confirms no login path falls back to idle `ctx.signal`.
+- [x] Extend `packages/pi-accounts/test/accounts.test.ts` with a regression test where `ctx.signal` is undefined and the provider observes a usable action signal; the focused test failed on both missing-signal assertions before implementation and passed afterward.
+- [x] Add lifecycle coverage in `packages/pi-accounts/test/accounts.test.ts` proving session shutdown aborts a pending provider login and prevents stale credential publication.
+- [x] Add `.changeset/gentle-accounts-signal.md` as a patch changeset for `@narumitw/pi-accounts`.
+- [x] Run the focused account test, package typecheck, and CI-equivalent gate; 31 focused tests, package typechecking, and the post-rebase `npm run check` with 2,798 tests passed.
+- [x] Inspect the final diff against `docs/extension-conventions.md`; prompt cancellation, component ownership, session replacement, shutdown, post-`await` freshness checks, and unchanged credential behavior were audited with no required deviation.
+- [x] Add the repository's `bug` label to issue #664 after deterministic tests and required checks confirm the reproduced defect is fixed.
+
+## Risks
+
+- A fallback signal that never aborts would stop the crash but leave device-code polling alive after its owner becomes stale, so the implementation must use the existing action-owned signal rather than a detached `AbortController`.
+- Cancellation can race with credential normalization or storage, so tests must prove stale completion cannot publish an account after the owner signal aborts.
+- Narrowing the local login type could reveal another internal contract mismatch, which should be corrected only where required by Pi's published provider interaction contract.
+
+## Completion Checklist
+
+- [x] Idle `/accounts` login always passes a non-optional `AbortSignal` to every supported provider.
+- [x] The GitHub Copilot regression test reaches provider login without the `undefined.aborted` failure.
+- [x] Pending OAuth work aborts on the covered lifecycle boundary and does not store or activate stale credentials.
+- [x] Existing account login, replacement, switching, storage, and provider-overlay tests remain passing.
+- [x] A patch changeset covers `@narumitw/pi-accounts`.
+- [x] Focused tests, package typechecking, and `npm run check` pass with recorded command evidence.
+- [x] The final diff contains only the plan, implementation, regression tests, and changeset required for issue #664.
+- [x] The completed plan is archived under `docs/plans/archived/` only after every checklist item is satisfied.

--- a/packages/pi-accounts/src/accounts.ts
+++ b/packages/pi-accounts/src/accounts.ts
@@ -343,12 +343,14 @@ async function showAccountsMenu(
 		},
 		actions: {
 			"login-route": async () => ({ kind: "to", screen: "login-providers" }),
-			"login-provider": async ({ itemId }) => {
+			"login-provider": async ({ itemId, signal }) => {
 				if (!isAccountProviderId(itemId)) return { kind: "rejected" };
 				const adapter = requireAdapter(adapters, itemId);
-				const name = await ctx.ui.input(`Name this ${adapter.displayName} account:`, "work");
+				const name = await ctx.ui.input(`Name this ${adapter.displayName} account:`, "work", {
+					signal,
+				});
 				if (name === undefined || !owner.isCurrent()) return { kind: "close" };
-				await loginAccount(pi, ctx, store, adapter, name, syncProvider, owner.isCurrent);
+				await loginAccount(pi, ctx, store, adapter, name, signal, syncProvider, owner.isCurrent);
 				return { kind: "close" };
 			},
 			"switch-current": async ({ itemId }) => {
@@ -598,6 +600,7 @@ async function loginAccount(
 	store: AccountStore,
 	adapter: AccountProviderAdapter,
 	nameArg: string,
+	signal: AbortSignal,
 	syncProvider: (
 		providerId: AccountProviderId,
 		ctx: ExtensionContext,
@@ -626,7 +629,7 @@ async function loginAccount(
 	ctx.ui.notify(`Starting ${adapter.displayName} login for "${parsed.name}".`, "info");
 	try {
 		const credential = normalizeStoredCredential(
-			await adapter.oauth.login(createOAuthInteraction(ctx, adapter.displayName)),
+			await adapter.oauth.login(createOAuthInteraction(ctx, adapter.displayName, signal)),
 			parsed.name,
 		);
 		if (!isCurrent()) return;

--- a/packages/pi-accounts/src/oauth.ts
+++ b/packages/pi-accounts/src/oauth.ts
@@ -1,10 +1,10 @@
 import {
 	type AuthEvent,
-	type AuthInteraction,
 	type AuthPrompt,
 	cleanupSessionResources,
 	type ModelAuth,
 	type OAuthCredential,
+	type ProviderAuthInteraction,
 } from "@earendil-works/pi-ai";
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
@@ -13,7 +13,7 @@ export const SUPPORTED_PROVIDER_IDS = ["anthropic", "github-copilot", "openai-co
 export type AccountProviderId = (typeof SUPPORTED_PROVIDER_IDS)[number];
 
 export interface ProviderOwnedOAuth {
-	login(interaction: AuthInteraction): Promise<OAuthCredential>;
+	login(interaction: ProviderAuthInteraction): Promise<OAuthCredential>;
 	refresh(credential: OAuthCredential, signal?: AbortSignal): Promise<OAuthCredential>;
 	toAuth(credential: OAuthCredential): Promise<ModelAuth>;
 }
@@ -73,10 +73,11 @@ export function createBuiltinProviderAdapters(
 export function createOAuthInteraction(
 	ctx: ExtensionCommandContext,
 	providerName: string,
-): AuthInteraction {
+	signal: AbortSignal,
+): ProviderAuthInteraction {
 	return {
-		signal: ctx.signal,
-		prompt: async (prompt) => promptForOAuth(ctx, prompt),
+		signal,
+		prompt: async (prompt) => promptForOAuth(ctx, prompt, signal),
 		notify: (event) => notifyOAuthEvent(ctx, providerName, event),
 	};
 }
@@ -114,20 +115,23 @@ async function defaultProviderModuleLoader(): Promise<BuiltinProviderModule> {
 	return (await import(PROVIDERS_MODULE_ID)) as BuiltinProviderModule;
 }
 
-async function promptForOAuth(ctx: ExtensionCommandContext, prompt: AuthPrompt): Promise<string> {
+async function promptForOAuth(
+	ctx: ExtensionCommandContext,
+	prompt: AuthPrompt,
+	loginSignal: AbortSignal,
+): Promise<string> {
+	const signal = prompt.signal ? AbortSignal.any([loginSignal, prompt.signal]) : loginSignal;
 	if (prompt.type === "select") {
 		const selected = await ctx.ui.select(
 			prompt.message,
 			prompt.options.map((option) => option.label),
-			{ signal: prompt.signal },
+			{ signal },
 		);
 		const id = prompt.options.find((option) => option.label === selected)?.id;
 		if (id === undefined) throw new Error("Login cancelled");
 		return id;
 	}
-	const value = await ctx.ui.input(prompt.message, prompt.placeholder ?? "", {
-		signal: prompt.signal,
-	});
+	const value = await ctx.ui.input(prompt.message, prompt.placeholder ?? "", { signal });
 	if (value === undefined) throw new Error("Login cancelled");
 	return value;
 }

--- a/packages/pi-accounts/test/accounts.test.ts
+++ b/packages/pi-accounts/test/accounts.test.ts
@@ -169,12 +169,21 @@ test("built-in provider adapters preserve each provider's complete OAuth auth sh
 });
 
 test("OAuth interaction preserves provider prompts, cancellation, and notifications", async () => {
+	const dialogSignals: Array<AbortSignal | undefined> = [];
 	const { ctx, notifications } = createMockContext({
 		hasUI: true,
-		input: async () => undefined,
-		select: async () => "Device login",
+		input: async (_title: string, _placeholder: string, options?: { signal?: AbortSignal }) => {
+			dialogSignals.push(options?.signal);
+			return undefined;
+		},
+		select: async (_title: string, _options: string[], options?: { signal?: AbortSignal }) => {
+			dialogSignals.push(options?.signal);
+			return "Device login";
+		},
 	});
-	const interaction = createOAuthInteraction(ctx, "Example");
+	const owner = new AbortController();
+	const interaction = createOAuthInteraction(ctx, "Example", owner.signal);
+	assert.equal(interaction.signal, owner.signal);
 	assert.equal(
 		await interaction.prompt({
 			type: "select",
@@ -190,6 +199,7 @@ test("OAuth interaction preserves provider prompts, cancellation, and notificati
 		interaction.prompt({ type: "manual_code", message: "Code" }),
 		/Login cancelled/,
 	);
+	assert.deepEqual(dialogSignals, [owner.signal, owner.signal]);
 	interaction.notify({
 		type: "device_code",
 		userCode: "ABCD",
@@ -654,6 +664,50 @@ test("generic login stores the full provider-owned credential and activates it",
 	assert.equal(stored?.active, "personal");
 	assert.deepEqual(stored?.accounts.personal?.availableModelIds, ["allowed"]);
 	assert.equal(keys.get("github-copilot"), "access-login-github-copilot");
+});
+
+test("session shutdown aborts idle OAuth login before stale credentials can publish", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	let loginStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		loginStarted = resolve;
+	});
+	let loginSignal: AbortSignal | undefined;
+	const copilot = fakeProvider("github-copilot");
+	copilot.oauth.login = async (interaction) => {
+		loginSignal = interaction.signal;
+		loginStarted();
+		if (!loginSignal) throw new Error("Missing OAuth login signal");
+		await new Promise<void>((resolve) => {
+			if (loginSignal?.aborted) resolve();
+			else loginSignal?.addEventListener("abort", () => resolve(), { once: true });
+		});
+		return credential("stale");
+	};
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [fakeProvider("openai-codex"), fakeProvider("anthropic"), copilot],
+	});
+	const { registry } = runtimeHarness(mock);
+	const { ctx } = createInteractiveAccountContext(
+		{
+			model: { provider: "github-copilot", id: "allowed" },
+			modelRegistry: registry,
+		},
+		{ selections: ["Login new account", "GitHub Copilot"], inputs: ["personal"] },
+	);
+
+	const login = mock.commands.get("accounts")?.handler("ignored", ctx);
+	await started;
+	await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	await login;
+
+	assert.ok(loginSignal);
+	assert.equal(loginSignal.aborted, true);
+	const state = await store.readProviderAsync("github-copilot");
+	assert.equal(state.active, undefined);
+	assert.deepEqual(Object.keys(state.accounts), []);
 });
 
 test("login rejects default as a reserved account name", async () => {


### PR DESCRIPTION
## Summary

- pass the `/accounts` menu action signal to provider-owned OAuth login while Pi is idle
- align the local provider adapter with Pi's required `ProviderAuthInteraction` contract
- forward login cancellation into OAuth prompts and prevent stale credentials after shutdown
- add regression and lifecycle coverage plus a patch changeset

## Verification

- `npm exec vitest run -- packages/pi-accounts/test/accounts.test.ts` — 31 tests passed
- `npm run typecheck --workspace @narumitw/pi-accounts` — passed
- `npm run check` — 257 test files and 2,798 tests passed

Closes #664
