### PR TITLE
feat(pi-subagents): add evidence-preserving panel workflow

### DIFF
--- a/.changeset/fair-panels-review.md
+++ b/.changeset/fair-panels-review.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Add a first-class blocking panel mode with independent reviewer contracts, bounded evidence artifacts, reserved synthesis and cleanup budgets, objection-preserving synthesis, failure-specific recovery, WorkItem inspection metadata, and disposable worktree isolation for write-capable reviewers.

--- a/docs/plans/archived/2026-08-10_pi-subagents-panel-workflow-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-subagents-panel-workflow-plan.md
@@ -1,0 +1,253 @@
+# Pi Subagents Panel Workflow Plan
+
+## Goal
+
+Add a first-class blocking panel mode to `@narumitw/pi-subagents` that runs at least two independent reviewer instances over one shared task and snapshot, preserves objections and dissent, and asks one synthesizer to reconcile valid evidence without treating majority vote as truth.
+
+The panel must remain bounded, cancellation-safe, provider-compatible, and compatible with existing single, parallel, chain, fan-in, workflow, detached, consultation, inspection, and settings behavior.
+
+## Context
+
+The existing `subagent` tool can approximate a panel with parallel tasks and an aggregator, but it does not enforce a shared review contract, minimum valid-review count, objection preservation, dissent reporting, or a panel-specific synthesis contract.
+
+The package already owns the required execution primitives through blocking parallel execution, structured results, capability planning, WorkItems, target preflight, output bounds, timeout checkpoints, usage accounting, and rendering.
+
+`packages/pi-subagents/src/execution.ts` is already over 1,000 lines, so panel execution must be added through responsibility-focused modules instead of extending that file with another large branch.
+
+This plan intentionally excludes benchmark work because the requested product priority is tool construction.
+
+The failed research panel exposed five concrete product gaps: reviewer budgets were consumed before finalization, useful evidence existed only in truncated failure payloads, broad semantic stalls were treated like generic timeouts, no synthesis barrier ever formed, and retained children required manual closure.
+
+The design therefore adopts research-backed safeguards rather than claiming benchmark gains: MAST motivates explicit progress and termination controls, Software Delegation Contracts and Proof-or-Stop motivate evidence-bearing completion, OrchestraBench motivates failure-specific recovery instead of blind retries, OrchBench motivates complete transfer artifacts, and CooperBench motivates bounded panels rather than adding agents without coordination controls.
+
+## Architecture
+
+### Public surface
+
+Add an optional top-level `panel` mode to the existing `subagent` tool instead of registering an eighth tool.
+
+Exactly one of `agent` plus `task`, `tasks`, `chain`, `workflow`, or `panel` remains valid per call.
+
+The proposed panel request contains:
+
+- An optional bounded panel id.
+- A preset selected with `StringEnum`: `code-review`, `research`, `security-review`, or `custom`.
+- One required shared task and one optional bounded shared-context block.
+- Two through the configured blocking worker limit reviewer entries.
+- One required synthesizer entry.
+- A `minValidReviews` value whose default is two and whose maximum cannot exceed the reviewer count.
+- Existing per-child model, thinking, timeout, idle, turn, and tool-call controls where they remain semantically valid.
+
+Each reviewer entry contains a stable unique id, agent name, and optional bounded focus instructions.
+
+Reviewer entries do not receive separate tasks or cwd values, so every instance receives the same shared task, shared context, agent scope, canonical target, and repository generation.
+
+The synthesizer receives only validated bounded review envelopes plus explicit failed or invalid reviewer metadata.
+
+The first version runs one review round followed by at most one synthesis turn.
+
+### Phase budgets and progress
+
+Panel preflight divides the total budget into explicit review, evidence-finalization, synthesis, and cleanup reserves before launching any child.
+
+Reviewer execution cannot borrow the synthesis or cleanup reserve, so an overlong reviewer cannot make a valid panel impossible to reconcile or release.
+
+Each reviewer receives a bounded soft evidence deadline before its hard deadline and must publish its latest valid evidence artifact at that boundary even when the requested review remains incomplete.
+
+Semantic progress is measured from accepted artifact revisions, newly supported findings, resolved missing checks, or explicit completion rather than raw assistant turns, tool calls, or output volume.
+
+A reviewer that reaches a configurable internal no-progress threshold is finalized once with its latest evidence and classified as `semantic-stall` instead of being blindly retried.
+
+The first version may retry only explicitly transient launch, transport, or tool-provider failures within the reviewer allocation, and it never retries invalid contracts, exhausted budgets, semantic stalls, permission failures, or deterministic task errors.
+
+### Incremental evidence artifacts
+
+Add a bounded executor-owned evidence ledger keyed by panel id, reviewer id, task generation, and monotonically increasing artifact revision.
+
+A reviewer artifact records claims, source or repository evidence, checks performed, unresolved objections, limitations, and completion state without requiring a polished final narrative.
+
+The executor validates and stores only the newest valid revision, stamps provenance, rejects stale generations, and exposes artifact status through the existing WorkItem and inspection surfaces.
+
+Artifacts are durable for the blocking call and bounded diagnostic result, but panel v1 does not create a new cross-session memory store or persist unrestricted research bodies.
+
+Synthesis consumes validated final artifacts rather than raw transcripts or ad hoc failure payloads.
+
+### Contracts
+
+Add `pi-subagents:panel-review:v1` and `pi-subagents:panel-synthesis:v1` contracts in a focused `panel-contract.ts` module.
+
+A review envelope records reviewer id, disposition, blocking status, severity-ranked findings, evidence, missing checks, limitations, and provenance.
+
+A synthesis envelope records the valid and failed reviewer ids, agreements, disagreements, every original blocking objection and its resolution state, evidence for any resolution, residual limitations, and final disposition.
+
+The executor validates identifiers and bounds, stamps actual agent/model/task-generation provenance, and rejects synthesizer attempts to invent reviewers or silently omit objections.
+
+Corroboration means multiple independent reports agree; it must not be labelled verified unless the synthesis includes concrete verification evidence.
+
+A vote count never clears a correctness, safety, security, or explicit-requirement objection.
+
+### Execution and isolation
+
+Preflight resolves every reviewer and synthesizer, target, scope, trust decision, budget, and capability plan before starting any child.
+
+Reviewer instances run independently and never receive sibling outputs.
+
+Reviewers whose effective tool surface is proven read-only may share the canonical target.
+
+Conservatively write-capable reviewers run in separate disposable Git worktrees created from the same clean base snapshot.
+
+A panel with write-capable reviewers fails before any launch when safe worktree isolation cannot be prepared.
+
+Worktrees isolate repository writes but are not presented as process, network, credential, secret, or filesystem sandboxes.
+
+The synthesizer starts only after all reviewer instances settle and the minimum valid-review threshold is met.
+
+If fewer than `minValidReviews` valid envelopes remain, synthesis does not start, the tool returns a structured `insufficient-panel` error with every validated partial artifact and failure classification, and no consensus claim is produced.
+
+If the threshold is met, failed reviewers and their latest valid partial artifacts remain visible and synthesis proceeds with the surviving complete envelopes.
+
+A panel call owns one explicit child group containing reviewers, synthesizer, timers, generations, transports, and disposable worktrees.
+
+Normal completion, degraded completion, insufficient evidence, cancellation, orchestration timeout, session replacement, shutdown, and initialization failure all close that group child-first through one idempotent cleanup path.
+
+Late results are rejected by generation and group state, and blocking panel children are never retained for follow-up after the parent call settles.
+
+### Result and presentation
+
+Extend blocking details with panel metadata rather than flattening panel output into ordinary fan-in text.
+
+The collapsed row shows preset, completed and valid reviewer counts, synthesis state, final disposition, blocking-objection count, and dissent count.
+
+The expanded row shows the shared task preview, reviewer identities, actual models, individual dispositions, failures, objections, disagreements, synthesis evidence, usage, and limitations.
+
+All model-facing and terminal-facing fields use the package's existing UTF-8, line, byte, private-text, path, and terminal-control boundaries.
+
+JSON, print, and RPC observers receive the same bounded tool result and details without ad hoc output.
+
+## Non-Goals
+
+- Run live benchmarks or decide whether panels outperform single agents.
+- Add learned routing, task-keyword routing, recursive reviewer teams, or more than one review round.
+- Implement automatic fixes, patch application, commits, pushes, or review-fix loops.
+- Treat agreement, model confidence, or reviewer count as proof.
+- Add panel settings, a panel manager screen, or another registered tool.
+- Promise operating-system, network, secret, credential, or process isolation.
+- Change the default delegation workflow or detached-agent lifecycle.
+
+## Assumptions
+
+- A generic panel may use independent instances of the same agent and model unless the caller deliberately selects different agent definitions.
+- Two valid reviews are the smallest panel that can expose agreement or disagreement.
+- Existing blocking concurrency and configured worker limits remain authoritative ceilings.
+- Existing agent scope and project-agent confirmation rules apply once per panel call and cannot be bypassed by reviewer entries.
+- A minor package release is appropriate because the new mode is additive public behavior.
+
+## Risks
+
+- A larger `subagent` schema may increase prompt cost or reduce provider tool-call reliability.
+- Dedicated compact schemas, strict bounds, and provider compatibility tests mitigate that risk.
+- A synthesizer may erase dissent, fabricate consensus, or resolve objections without evidence.
+- Executor-owned reconciliation and immutable preservation of reviewer objections mitigate that risk.
+- Write-capable reviewers may modify shared state despite review instructions.
+- Conservative classification and isolated disposable worktrees prevent concurrent canonical-repository writes.
+- Partial failures may be mistaken for consensus.
+- The minimum-valid threshold, failed-reviewer list, preserved evidence artifacts, and `insufficient-panel` outcome keep the degraded state explicit.
+- Reviewers may exhaust the total budget before synthesis or cleanup can run.
+- Executor-owned phase reserves and non-borrowable synthesis and cleanup allocations guarantee bounded finalization.
+- Turn or tool-call activity may conceal semantic stagnation.
+- Artifact-based progress revisions and explicit failure classes stop unproductive work without treating all failures as retryable.
+- Incremental artifacts may leak private text or grow without bound.
+- Existing redaction, provenance, generation, byte, line, and result-retention limits apply before any artifact enters the ledger or synthesis input.
+- Panel execution may duplicate existing parallel and workflow logic.
+- A panel planner and executor adapter must reuse existing runners, budgets, targets, ledgers, and cleanup owners rather than create a second orchestration runtime.
+- `execution.ts` refactoring may regress established modes.
+- Characterization tests and behavior-preserving extraction must precede panel integration.
+
+## Rollback / Recovery
+
+Omitting `panel` preserves every existing payload and execution path.
+
+The implementation must keep panel-specific parsing, contracts, execution, and rendering in removable modules with a small dispatch seam.
+
+An invalid or partially created panel performs idempotent child and worktree cleanup and retains bounded diagnostic evidence.
+
+Rollback removes the panel schema and dispatch while leaving persisted legacy workflow and detached records readable because panel v1 adds no settings or retained-agent state format.
+
+Graceful parent cancellation, session replacement, and session shutdown are lifecycle-tested and await panel cleanup.
+
+An externally forced host-process termination did not dispatch Pi lifecycle cleanup during the local smoke, so the README records the unavoidable manual `git worktree` recovery path for that unsupported condition.
+
+## Applicable Conventions and Verification
+
+- Tool schemas must use provider-compatible `StringEnum`, reject mixed modes and unknown fields, throw observable failures, honor cancellation, and bound output.
+  Verification is focused schema, execution, provider-shape, cancellation, and truncation tests.
+- Session-owned processes, timers, generations, and worktrees must be released on abort, timeout, replacement, shutdown, partial initialization, and repeated cleanup.
+  Verification is lifecycle and failure-injection tests plus semantic review after every asynchronous boundary.
+- Tool rendering must sanitize terminal input, respect supplied width, preserve compact and expanded states, and remain safe in non-TUI modes.
+  Verification is rendering tests at narrow widths and JSON/RPC-compatible execution tests.
+- Public package behavior requires README updates and a package-specific minor Changeset.
+  Verification is Changesets review and `just pack subagents` tarball inspection.
+- No settings are added or changed, so `pi-subagents.json`, settings precedence, persistence, and manager screens remain untouched.
+- The final implementation must run the repository CI-equivalent gate and a representative local Pi smoke.
+
+## Completion Evidence
+
+- TDD red state: focused panel tests initially failed because the panel modules and mode did not exist.
+- Focused package verification: all 39 `pi-subagents` test files passed with 332 tests.
+- Repository verification: the final `npm run check` gate passed 258 test files and 2,807 tests together with Biome, boundaries, builds, and all workspace typechecks.
+- Package verification: `just pack subagents` included all panel modules, README, manifest, and license in the dry-run tarball.
+- Live Pi verification: `pi --no-extensions -e ./packages/pi-subagents` produced completed, degraded, and `insufficient-panel` outcomes with cleanup complete.
+- Lifecycle verification: deterministic parent-abort and `session_shutdown` tests cancel active subprocesses and remove owned worktrees.
+- Unsupported environment path: an externally forced host-process termination did not dispatch graceful Pi lifecycle cleanup, so the README documents manual generated-worktree recovery.
+- Semantic audit: the change adds no settings, preserves all seven registered tools, constrains shared reviewers and synthesis to read-only effective tools, isolates write-capable reviewers in clean-base worktrees, redacts panel artifacts and rendering, and persists metadata without raw review bodies.
+
+## Plan
+
+- [x] Record characterization tests for current single, parallel, fan-in, chain, and workflow mode selection, target preflight, result ordering, partial failure, cancellation, timeout, and rendering; verify the focused suite passes before refactoring.
+- [x] Specify the exact bounded `panel` TypeBox schema, defaults, mode exclusivity, reviewer-count limits, unique-id rules, shared-context limit, and provider-compatible enums in a package-local design comment or contract test; verify invalid mixed and oversized payloads fail before discovery or launch.
+- [x] Define `pi-subagents:panel-review:v1` and `pi-subagents:panel-synthesis:v1` types and parsers in `src/panel-contract.ts`; verify malformed, unknown-field, duplicate-finding, oversized, private-text, terminal-control, fabricated-id, and omitted-objection cases fail or sanitize deterministically.
+- [x] Add preset-owned prompt builders in `src/panel-prompts.ts` that keep one byte-identical shared task and context block across reviewers while appending only the reviewer id and bounded focus; verify reviewers never receive sibling identities, outputs, or focus instructions.
+- [x] Define executor-owned panel reconciliation in `src/panel-reconciliation.ts`; verify it preserves every blocking objection and dissent item, distinguishes corroborated from verified claims, rejects fabricated reviewer ids, and produces `insufficient-panel` with bounded partial artifacts below the valid-review threshold.
+- [x] Define deterministic panel failure classes for transient launch or transport errors, invalid contracts, semantic stalls, permission failures, exhausted budgets, cancellations, and deterministic task failures; verify only explicitly transient classes are retryable and every class appears in details and diagnostics.
+- [x] Add phase-budget planning to `src/panel-planning.ts` with non-borrowable evidence-finalization, synthesis, and cleanup reserves; verify invalid or unsatisfiable allocations fail before launch and no reviewer can consume a reserved phase budget.
+- [x] Add a bounded generation-aware evidence ledger in a focused `src/panel-evidence.ts` module; verify monotonically revised reviewer artifacts survive timeout or stall, reject stale or fabricated provenance, redact private text, remain within line and byte limits, and become the only review content accepted by synthesis.
+- [x] Add artifact-based semantic-progress accounting and one bounded soft-finalization request before each reviewer hard deadline; verify repeated turns, repeated tools, duplicate claims, and larger prose do not reset progress while new supported evidence does.
+- [x] Characterize effective tool classification, target trust, clean-Git worktree creation, and cleanup for every built-in and custom-agent path used by panels; record unsupported isolation guarantees without widening existing authority.
+- [x] Implement panel preflight in `src/panel-planning.ts` by reusing agent discovery, capability planning, target policy, budget resolution, configured parallel limits, and project-agent confirmation inputs; verify all reviewers and the synthesizer are validated before any confirmation, worktree, child, or provider side effect.
+- [x] Extend `WorkspaceManager` with bounded blocking-panel ownership or a focused adapter that creates one worktree per conservatively write-capable reviewer from the same clean base; verify partial creation rollback, symlink/canonical-path handling, dirty-repository rejection, repeated cleanup, cancellation, replacement, and shutdown.
+- [x] Extract the blocking mode dispatch or parallel execution responsibility from `src/execution.ts` into a descriptively named module before adding panel logic; verify the file-size rule is satisfied or document a concrete cohesion reason for any remaining file over 1,000 lines.
+- [x] Implement `src/panel-execution.ts` as review, evidence-finalization, conditional synthesis, and cleanup phases using existing runners, status updates, deadlines, timeout checkpoints, usage accounting, generation revocation, and result bounds; verify reserved synthesis runs only after the barrier and never after abort, total timeout, or insufficient valid reviews.
+- [x] Introduce an executor-owned blocking panel child group that registers reviewers, synthesizer, timers, transports, generations, and worktrees under one lifecycle owner; verify every terminal path closes children child-first, blocks follow-up retention, and rejects late settlements.
+- [x] Project panel reviewers and synthesis into the existing WorkItem ledger with deterministic ids, dependencies, generations, provenance, and terminal states; verify inspection and workflow persistence expose metadata without persisting raw review bodies or creating a second lifecycle owner.
+- [x] Extend `SubagentDetails` and orchestration metrics with panel-specific valid, failed, blocking-objection, dissent, and synthesis state fields; verify partial evidence and usage survive reviewer or synthesizer failure without being presented as success.
+- [x] Add compact and expanded panel rendering in focused rendering helpers; verify preset, counts, disposition, objections, dissent, failures, actual models, usage, limitations, terminal sanitization, and widths from narrow supported layouts through ordinary terminal widths.
+- [x] Update `subagent` description, prompt snippet, and guidelines to explain when panel mode is justified, that it is blocking, that two independent instances are required, that agreement is not proof, and that simple or latency-sensitive work should not use a panel; verify the catalog refresh path preserves the guidance.
+- [x] Add integration tests for same-agent independent instances, mixed agents/models, project scope and confirmation, untrusted targets, read-only shared execution, write-capable worktree isolation, configured parallel ceilings, minimum valid reviews, one failed reviewer, invalid contracts, unresolved blockers, synthesizer failure, and deterministic result ordering.
+- [x] Add lifecycle failure-injection tests for parent abort, total timeout, reviewer soft finalization, semantic stall, synthesis timeout, session replacement, shutdown, late settlement, partial worktree creation, cleanup failure, and repeated cleanup; verify no stale generation enters synthesis and no owned child, timer, transport, or worktree remains active.
+- [x] Add recovery-policy tests that inject transient transport, deterministic task, invalid-contract, permission, and no-progress failures; verify bounded transient retry behavior, zero blind semantic retries, stable failure classification, and preservation of the newest valid evidence artifact.
+- [x] Add provider-schema and output-bound tests for Google-compatible enums, maximum reviewer count, bounded shared context, bounded fan-in payload, 50 KiB or 2,000-line result limits, and raw-output fallback diagnostics without accepting invalid panel contracts.
+- [x] Update `packages/pi-subagents/README.md` with the panel request shape, presets, lifecycle, partial-failure semantics, objection and dissent rules, isolation limits, examples, compatibility notes, and package layout.
+- [x] Add a minor Changeset for `@narumitw/pi-subagents` describing the additive first-class panel mode without claiming quality improvements or benchmark evidence.
+- [x] Audit the complete diff against `docs/extension-conventions.md`, including tool failure semantics, cancellation, resource disposal, terminal safety, non-TUI behavior, package boundaries, documentation, and verification; record every deviation or unverified path.
+- [x] Run focused panel tests, all `packages/pi-subagents` tests, `npm test`, `npm run check`, `git diff --check`, and `just pack subagents`; inspect the tarball and record exact command evidence.
+- [x] Run a local `pi -e ./packages/pi-subagents` smoke with one successful two-reviewer panel, one degraded panel that still meets the threshold, one insufficient panel, and one cancellation; record unsupported provider or environment paths without substituting simulations.
+
+## Completion Checklist
+
+- [x] `subagent` accepts exactly one bounded panel mode without registering another tool or changing omitted-field behavior.
+- [x] Every reviewer receives the same shared task, context, target snapshot, and scope while remaining isolated from sibling outputs.
+- [x] At least two valid independent review envelopes are required before synthesis.
+- [x] Review, evidence-finalization, synthesis, and cleanup have explicit allocations, and reviewers cannot consume the synthesis or cleanup reserve.
+- [x] Every reviewer can publish bounded provenance-stamped evidence incrementally, and the newest valid artifact remains available after timeout, stall, or failure.
+- [x] Semantic progress depends on accepted evidence revisions rather than activity volume, and only explicitly transient failures receive bounded retries.
+- [x] Failed or invalid reviewers remain visible and can never be counted as valid consensus participants.
+- [x] Every original blocking objection and disagreement survives synthesis unless a bounded evidence-backed resolution remains attached to it.
+- [x] Majority vote, model confidence, and reviewer count are never presented as verification.
+- [x] Write-capable reviewers cannot concurrently mutate the canonical repository, and worktree isolation is not misrepresented as an OS sandbox.
+- [x] Cancellation, timeout, replacement, shutdown, partial initialization, late settlement, and repeated cleanup close the panel-owned child group, release all owned work, and reject stale generations.
+- [x] An insufficient panel returns structured partial evidence and failure classes while making no synthesis, consensus, success, or verification claim.
+- [x] Compact and expanded rendering remains width-safe, sanitized, and informative in success, degraded, insufficient, failed, cancelled, and running states.
+- [x] JSON, print, RPC, and TUI paths preserve the same bounded model-facing result semantics without ad hoc protocol output.
+- [x] Existing single, parallel, fan-in, chain, workflow, detached, inspection, consultation, command, and settings tests retain their established behavior.
+- [x] README, package layout, compatibility notes, and the minor Changeset accurately describe the implemented public surface and limitations.
+- [x] Required focused tests, repository checks, package inspection, semantic audits, and representative Pi smokes pass with evidence and no publication.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -28,6 +28,7 @@ Use it to split independent research, planning, implementation, and review work 
 - Provides addressable stateful agents with follow-up, consolidated mailbox/management actions, idempotent spawn retries, context selection and preview, versioned structured outcomes, and persistence.
 - Publishes built-in and custom agent capability manifests, then records the executor-owned `ExecutionPlan` that resolves requested authority to effective tools, model, thinking, timeout, transport, trust, and workspace controls.
 - Runs explicit dependency workflows through a persistent `WorkItem` ledger, dependency-aware scheduler, declared scope-conflict checks, artifact provenance, stale-result invalidation, and bounded overall deadlines.
+- Runs first-class blocking panels with two or more independent reviewers, incremental bounded evidence artifacts, preserved blockers and dissent, a minimum-valid-review barrier, reserved synthesis and cleanup budgets, and one evidence-preserving synthesis.
 - Supports bounded retries only for explicitly idempotent work and hedged execution only for explicitly read-only work.
 - Detects retained-agent semantic skew across agent definitions, role prompts, tools, model resolution, transport, trust, repository generation, artifacts, and scheduler policy before follow-up work starts.
 - Publishes transient runtime status through Pi's generic extension status API while subagents are running.
@@ -66,7 +67,7 @@ The preview compares the selection with the tools registered in the current sess
 
 The available tools are:
 
-- `subagent` — delegate blocking single, parallel, fan-in, chained, or explicit dependency-workflow tasks. The main agent cannot process queued steering until the call returns.
+- `subagent` — delegate blocking single, parallel, fan-in, chained, panel-review, or explicit dependency-workflow tasks. The main agent cannot process queued steering until the call returns.
 - `subagent_spawn` and related lifecycle tools — when enabled, start reusable detached work, return immediately, and receive bounded completion messages automatically.
 - `subagent_inspect` — inspect agent/model/run/runtime metadata without launching work or changing state.
 - `subagent_consult` — run one ephemeral read-only consultation and wait for its answer.
@@ -110,12 +111,13 @@ Execution modes:
 - **parallel + aggregator** — run parallel jobs, then pass all outputs into one fan-in agent.
 - **chain** — run sequential steps, passing prior output with `{previous}`.
 - **workflow** — run named tasks only after declared `dependsOn` tasks and required `inputArtifacts` are ready; independent conflict-free tasks may run concurrently.
+- **panel** — run at least two independent reviewers over one shared task and snapshot, then run one synthesizer only when `minValidReviews` valid evidence artifacts remain.
 
 Common controls:
 
 - `cwd` — choose a launch directory subject to the user-owned trust-aware target policy described below.
 - `timeoutMs` — choose the per-turn work deadline for the task difficulty.
-- `totalTimeoutMs` — cap an entire blocking single, parallel, chain, or fan-in workflow, including queued work.
+- `totalTimeoutMs` — cap an entire blocking single, parallel, chain, panel, or fan-in workflow, including queued work and reserved panel phases.
 - `idleTimeoutMs` — stop work that produces no completed assistant turn or tool result within the selected interval.
 - `maxTurns` / `maxToolCalls` — stop unfinished repeated work after bounded assistant turns or tool calls.
 - `thinkingLevel` — request `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` thinking for the spawned Pi process or retained child.
@@ -136,7 +138,7 @@ The default target policies are:
 | `cwdPolicy.consultation` | `"anywhere"`, `"current-workspace"` | `"anywhere"`: consultation may start in any existing directory, but a target without effective trust is forced to `resources: "none"` |
 | `cwdPolicy.delegation` | `"trusted-targets"`, `"current-workspace"`, `"anywhere"` | `"trusted-targets"`: blocking and detached delegation may target the current workspace or an external folder covered by a saved `true` decision |
 
-All paths are resolved relative to the current session workspace and canonicalized before containment and trust checks. Missing paths, non-directories, sibling paths, and symlink escapes cannot bypass the policy. Blocking parallel, chain, and fan-in calls preflight every target before any child starts. A generated `workspaceMode: "worktree"` inherits the resolved trust of its approved base cwd.
+All paths are resolved relative to the current session workspace and canonicalized before containment and trust checks. Missing paths, non-directories, sibling paths, and symlink escapes cannot bypass the policy. Blocking parallel, chain, panel, and fan-in calls preflight every target before any child starts. A generated `workspaceMode: "worktree"` inherits the resolved trust of its approved base cwd.
 
 `"anywhere"` for general delegation restores the previous external-target flexibility. An external target without effective trust starts with `projectTrusted: false`, so Pi-protected project settings, packages, extensions, skills, prompts, and system resources stay disabled. General agents still have their configured tools and ordinary Pi/OS permissions, and Pi may still load `AGENTS.md` or `CLAUDE.md` because those context files are not protected by project trust. Resource-free consultation is stricter: it also passes `--no-context-files`, `--no-skills`, `--no-prompt-templates`, `--no-approve`, and `--no-extensions`.
 
@@ -349,6 +351,39 @@ Run a chain where each step receives the previous output:
   ]
 }
 ```
+
+Run an evidence-preserving panel:
+
+```json
+{
+  "panel": {
+    "id": "auth-panel",
+    "preset": "code-review",
+    "task": "Review the authentication change for correctness and regressions.",
+    "context": "Inspect the current repository snapshot and existing test evidence.",
+    "reviewers": [
+      { "id": "correctness", "agent": "reviewer", "focus": "Control flow and edge cases" },
+      { "id": "tests", "agent": "reviewer", "focus": "Coverage and regression risk" }
+    ],
+    "synthesizer": { "agent": "reviewer" },
+    "minValidReviews": 2
+  },
+  "totalTimeoutMs": 120000
+}
+```
+
+Every reviewer receives the same shared task, context, target snapshot, and scope, but never receives sibling output.
+Reviewer-specific `focus` text is appended after the shared block.
+The executor accepts only strict `pi-subagents:panel-review:v1` artifacts, stamps reviewer provenance, and starts synthesis only after the valid-review barrier.
+Agreement is corroboration rather than proof, and a vote cannot clear a correctness, safety, security, or explicit-requirement blocker.
+If too few valid reviews remain, the tool returns `insufficient-panel` with bounded partial evidence and failure classes without running synthesis or claiming consensus.
+Review, evidence-finalization, synthesis, and cleanup receive explicit phase allocations, and reviewer work cannot consume the synthesis or cleanup reserve.
+Only transient launch or transport failures receive one bounded retry; invalid contracts, semantic stalls, permission failures, exhausted budgets, cancellation, and deterministic task failures do not.
+Read-only reviewers share the approved target, while conservatively write-capable reviewers receive separate disposable Git worktrees from one clean base.
+Worktrees isolate repository writes but do not isolate processes, the network, secrets, credentials, or the rest of the filesystem.
+The blocking panel owns every reviewer, synthesizer, timer, generation, transport, and worktree and closes them when the call settles or Pi emits graceful session replacement or shutdown.
+An uncatchable host kill or forced process termination cannot guarantee cleanup; inspect `git worktree list`, remove any confirmed generated `pi-subagent-worktree-*` entry, and run `git worktree prune` if the host terminated before Pi dispatched lifecycle cleanup.
+Panel WorkItem snapshots persist metadata and artifact references for current-session inspection without storing raw review bodies.
 
 Run an explicit dependency workflow:
 
@@ -600,6 +635,7 @@ The intentional compatibility change is that an external target without saved tr
 | Parallel | Input order, up to `blocking.maxParallelTasks` total workers and at most four active children. | Rejects calls above the configured limit; otherwise collects all task results, and partial worker failure does not discard successful results. |
 | Parallel + aggregator | Source input order, then aggregator. | The aggregator runs with successful outputs and failure descriptions only when total budget remains; aggregator failure or orchestration expiry marks the tool result as an error. |
 | Workflow | Deterministic dependency-ready and critical-path order, with results returned in declared task order. | Invalid graphs fail before launch; blocked or failed dependencies prevent downstream start; bounded retry and hedging require explicit side-effect contracts. |
+| Panel | Reviewer declaration order, then at most one synthesizer. | Invalid or failed reviews remain visible; synthesis requires `minValidReviews`; insufficient panels preserve partial evidence without a consensus claim; synthesis contract failure marks the tool result as an error. |
 
 An aggregator whose `agent` or `task` is empty or whitespace-only is treated as absent, so successful
 parallel outputs remain available instead of being replaced by a malformed fan-in failure.
@@ -804,7 +840,7 @@ While the `subagent` tool is running, `pi-subagents` publishes compact activity 
 
 ## 🔒 Safety notes
 
-Subagents have separate processes and context windows, but they are **not security sandboxes**. They run as the same OS user, share the host filesystem and network access, and may conflict if they edit the same files. Tool allow-lists reduce available Pi tools but do not reduce operating-system permissions. `subagent_consult` prevents writes through its Pi tool surface and disables extensions, but it can read accessible paths, call the configured model over the network, and incur cost; its instruction-resource policy is not a filesystem or confidentiality boundary.
+Subagents have separate processes and context windows, but they are **not security sandboxes**. They run as the same OS user, share the host filesystem and network access, and may conflict if they edit the same files. Tool allow-lists reduce available Pi tools but do not reduce operating-system permissions. `subagent_consult` prevents writes through its Pi tool surface and disables extensions, but it can read accessible paths, call the configured model over the network, and incur cost; its instruction-resource policy is not a filesystem or confidentiality boundary. Panel write-capable reviewers use separate disposable Git worktrees, but those worktrees provide repository-write isolation only.
 
 Every contracted execution records a hashed immutable `ExecutionPlan` and an executor-owned capability grant bound to its task generation, effective tools, issuance time, and expiry.
 Interrupt, close, shutdown, replacement, persistence, and restore revoke active grants before signalling work or accepting another generation, and late old-plan results become `stale` diagnostic evidence.
@@ -858,6 +894,14 @@ packages/pi-subagents/
 │   ├── adaptive-scheduler.ts     # Dependency, capacity, budget, and conflict scheduling
 │   ├── semantic-snapshot.ts      # Privacy-safe continuation compatibility checks
 │   ├── supervision.ts            # Bounded idempotent retries and read-only hedging
+│   ├── panel-execution.ts        # Blocking review barrier, synthesis, and lifecycle owner
+│   ├── panel-contract.ts         # Strict review and synthesis evidence contracts
+│   ├── panel-evidence.ts         # Bounded monotonic reviewer evidence ledger
+│   ├── panel-planning.ts         # Panel validation, phase budgets, and WorkItems
+│   ├── panel-prompts.ts          # Shared-task reviewer and synthesis prompts
+│   ├── panel-reconciliation.ts   # Objection-preserving valid-review barrier
+│   ├── panel-child-group.ts      # Child signals and disposable-worktree cleanup
+│   ├── panel-render.ts           # Compact and expanded sanitized panel rows
 │   ├── execution-profiles.ts     # Provider-neutral thinking profile patches
 │   ├── execution-ui.ts           # Profile and per-agent execution settings screens
 │   ├── stateful-guidance.ts      # Detached model-facing workflow guidance
@@ -894,7 +938,7 @@ The package exposes its Pi extension through `package.json`:
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, subagents, agent delegation, parallel agents, fan-in aggregation, chained agents, isolated subprocesses, AI coding workflow, TypeScript Pi package.
+Pi extension, Pi coding agent, subagents, agent delegation, parallel agents, review panels, evidence synthesis, fan-in aggregation, chained agents, isolated subprocesses, AI coding workflow, TypeScript Pi package.
 
 ## 📄 License
 

--- a/packages/pi-subagents/src/blocking-status.ts
+++ b/packages/pi-subagents/src/blocking-status.ts
@@ -53,3 +53,11 @@ export function parallelStatus(done: number, total: number, running: number): st
 export function fanInStatus(agent: string): string {
 	return `fan-in ${agent}`;
 }
+
+export function panelReviewStatus(done: number, total: number, running: number): string {
+	return `panel review ${done}/${total}${running > 0 ? ` ${running} running` : ""}`;
+}
+
+export function panelSynthesisStatus(agent: string): string {
+	return `panel synthesis ${agent}`;
+}

--- a/packages/pi-subagents/src/execution.ts
+++ b/packages/pi-subagents/src/execution.ts
@@ -379,6 +379,7 @@ export async function executeSubagent(
 		await preflightPanelExecution({
 			panel: params.panel,
 			agents,
+			signal,
 			target: panelTarget,
 			resolveThinkingLevel,
 			resolveTimeoutMs,

--- a/packages/pi-subagents/src/execution.ts
+++ b/packages/pi-subagents/src/execution.ts
@@ -44,6 +44,8 @@ import {
 	truncateUtf8,
 } from "./limits.js";
 import { calculateOrchestrationMetrics } from "./orchestration-metrics.js";
+import { executePanel, preflightPanelExecution } from "./panel-execution.js";
+import { validatePanelRequest } from "./panel-planning.js";
 import { hasUsableAggregator, type SubagentParams } from "./params.js";
 import { appendResultInstruction, type SubagentResultFormat } from "./result-contract.js";
 import {
@@ -161,13 +163,19 @@ export async function executeSubagent(
 	const hasChain = (params.chain?.length ?? 0) > 0;
 	const hasTasks = (params.tasks?.length ?? 0) > 0;
 	const hasWorkflow = (params.workflow?.tasks.length ?? 0) > 0;
+	const hasPanel = params.panel !== undefined;
 	const hasSingle = Boolean(params.agent && params.task);
-	const modeCount = Number(hasChain) + Number(hasTasks) + Number(hasWorkflow) + Number(hasSingle);
+	const modeCount =
+		Number(hasChain) +
+		Number(hasTasks) +
+		Number(hasWorkflow) +
+		Number(hasPanel) +
+		Number(hasSingle);
 	let workLedger: WorkItemLedger | undefined;
 	const workflowScheduling: ReturnType<AdaptiveScheduler["decide"]>[] = [];
 
 	const makeDetails =
-		(mode: "single" | "parallel" | "chain" | "workflow") =>
+		(mode: "single" | "parallel" | "chain" | "workflow" | "panel") =>
 		(results: SingleResult[], aggregator?: SingleResult): SubagentDetails => {
 			const workflow = workLedger?.snapshot();
 			const metricResults = aggregator ? [...results, aggregator] : results;
@@ -239,14 +247,33 @@ export async function executeSubagent(
 			details: makeDetails("single")([]),
 		};
 	}
-	if (hasWorkflow && (Number.parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) || 0) > 0) {
-		throw new Error("Explicit workflow recursion is disabled until separately evaluated");
+	if (
+		(hasWorkflow || hasPanel) &&
+		(Number.parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) || 0) > 0
+	) {
+		throw new Error("Explicit workflow and panel recursion is disabled until separately evaluated");
+	}
+	if (params.panel) {
+		validatePanelRequest(params.panel, maxParallelTasks);
+		for (const agentName of [
+			...params.panel.reviewers.map((reviewer) => reviewer.agent),
+			params.panel.synthesizer.agent,
+		]) {
+			if (!agents.some((agent) => agent.name === agentName)) {
+				throw new Error(`Unknown panel agent: ${agentName}`);
+			}
+		}
 	}
 	if (
 		(hasTasks && (params.tasks?.length ?? 0) > maxParallelTasks) ||
-		(hasWorkflow && (params.workflow?.tasks.length ?? 0) > maxParallelTasks)
+		(hasWorkflow && (params.workflow?.tasks.length ?? 0) > maxParallelTasks) ||
+		(hasPanel && (params.panel?.reviewers.length ?? 0) > maxParallelTasks)
 	) {
-		const count = hasWorkflow ? (params.workflow?.tasks.length ?? 0) : (params.tasks?.length ?? 0);
+		const count = hasWorkflow
+			? (params.workflow?.tasks.length ?? 0)
+			: hasPanel
+				? (params.panel?.reviewers.length ?? 0)
+				: (params.tasks?.length ?? 0);
 		throw new Error(`Too many delegated tasks (${count}). Configured max is ${maxParallelTasks}.`);
 	}
 
@@ -343,10 +370,20 @@ export async function executeSubagent(
 		return target;
 	};
 	const singleTarget = hasSingle ? resolveTarget(params.cwd) : undefined;
+	const panelTarget = hasPanel ? resolveTarget(undefined) : undefined;
 	const chainTargets = params.chain?.map((step) => resolveTarget(step.cwd)) ?? [];
 	const parallelTargets = params.tasks?.map((task) => resolveTarget(task.cwd)) ?? [];
 	const workflowTargets = resolvedWorkflowTasks.map((task) => resolveTarget(task.cwd));
 	const aggregatorTarget = aggregator ? resolveTarget(aggregator.cwd) : undefined;
+	if (params.panel && panelTarget) {
+		await preflightPanelExecution({
+			panel: params.panel,
+			agents,
+			target: panelTarget,
+			resolveThinkingLevel,
+			resolveTimeoutMs,
+		});
+	}
 	const attachTarget = (result: SingleResult, target: ResolvedSubagentTarget): SingleResult => {
 		result.target = targetPolicyAudit(target);
 		return result;
@@ -537,6 +574,10 @@ export async function executeSubagent(
 		if (params.tasks) for (const t of params.tasks) requestedAgentNames.add(t.agent);
 		for (const task of resolvedWorkflowTasks) requestedAgentNames.add(task.agent);
 		if (aggregator) requestedAgentNames.add(aggregator.agent);
+		if (params.panel) {
+			for (const reviewer of params.panel.reviewers) requestedAgentNames.add(reviewer.agent);
+			requestedAgentNames.add(params.panel.synthesizer.agent);
+		}
 		if (params.agent) requestedAgentNames.add(params.agent);
 
 		const projectAgentsRequested = Array.from(requestedAgentNames)
@@ -565,7 +606,15 @@ export async function executeSubagent(
 					return {
 						content: [{ type: "text", text: "Canceled: project-local agents not approved." }],
 						details: makeDetails(
-							hasChain ? "chain" : hasTasks ? "parallel" : hasWorkflow ? "workflow" : "single",
+							hasChain
+								? "chain"
+								: hasTasks
+									? "parallel"
+									: hasWorkflow
+										? "workflow"
+										: hasPanel
+											? "panel"
+											: "single",
 						)([]),
 					};
 				}
@@ -577,6 +626,23 @@ export async function executeSubagent(
 		params.totalTimeoutMs === undefined
 			? undefined
 			: Date.now() + Math.floor(params.totalTimeoutMs);
+	if (params.panel && panelTarget) {
+		return executePanel({
+			toolCallId,
+			params,
+			panel: params.panel,
+			signal,
+			onUpdate,
+			ctx,
+			agents,
+			agentScope,
+			projectAgentsDir: discovery.projectAgentsDir,
+			maxParallelTasks,
+			target: panelTarget,
+			resolveThinkingLevel,
+			resolveTimeoutMs,
+		});
+	}
 	if (params.workflow && resolvedWorkflowTasks.length > 0 && workLedger) {
 		await persistWorkLedger();
 		const status = startSubagentStatus(

--- a/packages/pi-subagents/src/orchestration-metrics.ts
+++ b/packages/pi-subagents/src/orchestration-metrics.ts
@@ -14,11 +14,23 @@ export interface OrchestrationMetrics {
 	requestedTools: number;
 	effectiveRequestedTools: number;
 	permissionPrecision: number;
+	panelValidReviews?: number;
+	panelFailedReviews?: number;
+	panelBlockingObjections?: number;
+	panelDissent?: number;
+	panelSynthesisState?: string;
 }
 
 export function calculateOrchestrationMetrics(
 	workflow: WorkItemLedgerSnapshot | undefined,
 	results: SingleResult[],
+	panel?: {
+		validReviewCount: number;
+		failedReviewCount: number;
+		blockingObjectionCount: number;
+		dissentCount: number;
+		state: string;
+	},
 ): OrchestrationMetrics {
 	const items = workflow?.items ?? [];
 	const requiredTransfers = items.reduce((sum, item) => sum + item.inputArtifacts.length, 0);
@@ -53,5 +65,14 @@ export function calculateOrchestrationMetrics(
 		requestedTools,
 		effectiveRequestedTools,
 		permissionPrecision: requestedTools === 0 ? 1 : effectiveRequestedTools / requestedTools,
+		...(panel
+			? {
+					panelValidReviews: panel.validReviewCount,
+					panelFailedReviews: panel.failedReviewCount,
+					panelBlockingObjections: panel.blockingObjectionCount,
+					panelDissent: panel.dissentCount,
+					panelSynthesisState: panel.state,
+				}
+			: {}),
 	};
 }

--- a/packages/pi-subagents/src/panel-child-group.ts
+++ b/packages/pi-subagents/src/panel-child-group.ts
@@ -1,0 +1,35 @@
+import type { IsolatedWorkspace } from "./workspace.js";
+import { WorkspaceManager } from "./workspace.js";
+
+export class PanelChildGroup {
+	private readonly controller = new AbortController();
+	private readonly workspaces = new WorkspaceManager();
+	private closingStarted = false;
+	private cleanupComplete = false;
+	private readonly onParentAbort = () => this.controller.abort(this.parentSignal?.reason);
+
+	constructor(private readonly parentSignal?: AbortSignal) {
+		if (parentSignal?.aborted) this.controller.abort(parentSignal.reason);
+		else parentSignal?.addEventListener("abort", this.onParentAbort, { once: true });
+	}
+
+	get signal(): AbortSignal {
+		return this.controller.signal;
+	}
+
+	async createWorkspace(ownerId: string, cwd: string): Promise<IsolatedWorkspace> {
+		if (this.closingStarted) throw new Error("Panel child group is closing or closed");
+		return this.workspaces.create(ownerId, cwd);
+	}
+
+	async close(): Promise<void> {
+		if (this.cleanupComplete) return;
+		if (!this.closingStarted) {
+			this.closingStarted = true;
+			this.parentSignal?.removeEventListener("abort", this.onParentAbort);
+			if (!this.controller.signal.aborted) this.controller.abort("panel-settled");
+		}
+		await this.workspaces.cleanupAll();
+		this.cleanupComplete = true;
+	}
+}

--- a/packages/pi-subagents/src/panel-contract.ts
+++ b/packages/pi-subagents/src/panel-contract.ts
@@ -1,0 +1,343 @@
+import { redactPrivateText } from "./context.js";
+import { DEFAULT_MAX_OUTPUT_BYTES, truncateUtf8 } from "./limits.js";
+
+export const PANEL_REVIEW_VERSION = "pi-subagents:panel-review:v1" as const;
+export const PANEL_SYNTHESIS_VERSION = "pi-subagents:panel-synthesis:v1" as const;
+export const PANEL_DISPOSITIONS = ["pass", "fail", "partial"] as const;
+export const PANEL_SEVERITIES = ["critical", "high", "medium", "low", "info"] as const;
+
+export type PanelDisposition = (typeof PANEL_DISPOSITIONS)[number];
+export type PanelSeverity = (typeof PANEL_SEVERITIES)[number];
+
+export interface PanelFinding {
+	id: string;
+	severity: PanelSeverity;
+	title: string;
+	claim: string;
+	evidence: string[];
+	verification?: string[];
+}
+
+export interface PanelReviewProvenance {
+	reviewerId: string;
+	agent?: string;
+	model?: string;
+	taskGeneration: number;
+}
+
+export interface PanelReview {
+	version: typeof PANEL_REVIEW_VERSION;
+	reviewerId: string;
+	disposition: PanelDisposition;
+	blocking: boolean;
+	findings: PanelFinding[];
+	missingChecks: string[];
+	limitations: string[];
+	provenance?: PanelReviewProvenance;
+}
+
+export interface PanelDisagreement {
+	summary: string;
+	reviewerIds: string[];
+}
+
+export interface PanelObjectionResolution {
+	reviewerId: string;
+	findingId: string;
+	resolution: "resolved" | "unresolved";
+	evidence: string[];
+}
+
+export interface PanelSynthesis {
+	version: typeof PANEL_SYNTHESIS_VERSION;
+	disposition: PanelDisposition;
+	summary: string;
+	validReviewerIds: string[];
+	failedReviewerIds: string[];
+	agreements: string[];
+	disagreements: PanelDisagreement[];
+	objections: PanelObjectionResolution[];
+	limitations: string[];
+}
+
+const MAX_TEXT_BYTES = 8 * 1024;
+const MAX_ID_BYTES = 256;
+const MAX_ITEMS = 50;
+
+export function panelReviewInstruction(reviewerId: string): string {
+	return [
+		"Return one JSON object and no surrounding prose.",
+		`Use exactly version "${PANEL_REVIEW_VERSION}" and reviewerId "${boundedId(reviewerId)}".`,
+		"Required fields are disposition, blocking, findings, missingChecks, and limitations.",
+		`disposition must be one of ${PANEL_DISPOSITIONS.join(", ")}; blocking must be a JSON boolean.`,
+		`Each finding must contain a unique id, severity (${PANEL_SEVERITIES.join(", ")}), title, claim, evidence as an array of strings, and optional verification as an array of strings.`,
+		`Use this exact shape: {"version":"${PANEL_REVIEW_VERSION}","reviewerId":"${boundedId(reviewerId)}","disposition":"pass","blocking":false,"findings":[{"id":"F1","severity":"info","title":"title","claim":"claim","evidence":["source or check"],"verification":[]}],"missingChecks":[],"limitations":[]}.`,
+		"Set blocking only for an objection that prevents a correctness, safety, security, or explicit-requirement pass.",
+		"Do not infer consensus or include other reviewers' identities or outputs.",
+	].join(" ");
+}
+
+export function panelSynthesisInstruction(
+	reviewerIds: readonly string[],
+	failedReviewerIds: readonly string[],
+): string {
+	return [
+		"Return one JSON object and no surrounding prose.",
+		`Use exactly version "${PANEL_SYNTHESIS_VERSION}".`,
+		`validReviewerIds must contain exactly: ${reviewerIds.join(", ") || "none"}.`,
+		`failedReviewerIds must contain exactly: ${failedReviewerIds.join(", ") || "none"}.`,
+		"Required fields are disposition, summary, validReviewerIds, failedReviewerIds, agreements, disagreements, objections, and limitations.",
+		`Use this exact shape: {"version":"${PANEL_SYNTHESIS_VERSION}","disposition":"pass","summary":"summary","validReviewerIds":${JSON.stringify(reviewerIds)},"failedReviewerIds":${JSON.stringify(failedReviewerIds)},"agreements":[],"disagreements":[],"objections":[],"limitations":[]}.`,
+		"Preserve every blocking objection by reviewerId and findingId.",
+		"A resolved objection requires concrete evidence; votes, reviewer count, and model confidence are not verification.",
+	].join(" ");
+}
+
+export function parsePanelReview(
+	text: string,
+	expectedReviewerId: string,
+	provenance: Partial<Omit<PanelReviewProvenance, "reviewerId">> = {},
+): PanelReview | undefined {
+	const value = parseJsonObject(text);
+	if (
+		!value ||
+		!hasOnlyKeys(value, [
+			"version",
+			"reviewerId",
+			"disposition",
+			"blocking",
+			"findings",
+			"missingChecks",
+			"limitations",
+		]) ||
+		value.version !== PANEL_REVIEW_VERSION ||
+		value.reviewerId !== expectedReviewerId ||
+		typeof value.disposition !== "string" ||
+		!PANEL_DISPOSITIONS.includes(value.disposition as PanelDisposition) ||
+		typeof value.blocking !== "boolean"
+	) {
+		return undefined;
+	}
+	const findings = objectArray(value.findings, parseFinding);
+	const missingChecks = stringArray(value.missingChecks);
+	const limitations = stringArray(value.limitations);
+	if (!findings || !missingChecks || !limitations) return undefined;
+	if (new Set(findings.map((finding) => finding.id)).size !== findings.length) return undefined;
+	if (value.blocking && (findings.length === 0 || value.disposition === "pass")) return undefined;
+	return {
+		version: PANEL_REVIEW_VERSION,
+		reviewerId: boundedId(expectedReviewerId),
+		disposition: value.disposition as PanelDisposition,
+		blocking: value.blocking,
+		findings,
+		missingChecks,
+		limitations,
+		provenance: {
+			reviewerId: boundedId(expectedReviewerId),
+			...(provenance.agent ? { agent: boundedId(provenance.agent) } : {}),
+			...(provenance.model ? { model: boundedId(provenance.model) } : {}),
+			taskGeneration: provenance.taskGeneration ?? 0,
+		},
+	};
+}
+
+export function parsePanelSynthesis(
+	text: string,
+	reviews: readonly PanelReview[],
+	failedReviewerIds: readonly string[],
+): PanelSynthesis | undefined {
+	const value = parseJsonObject(text);
+	if (
+		!value ||
+		!hasOnlyKeys(value, [
+			"version",
+			"disposition",
+			"summary",
+			"validReviewerIds",
+			"failedReviewerIds",
+			"agreements",
+			"disagreements",
+			"objections",
+			"limitations",
+		]) ||
+		value.version !== PANEL_SYNTHESIS_VERSION ||
+		typeof value.disposition !== "string" ||
+		!PANEL_DISPOSITIONS.includes(value.disposition as PanelDisposition) ||
+		typeof value.summary !== "string"
+	) {
+		return undefined;
+	}
+	const validReviewerIds = idArray(value.validReviewerIds);
+	const parsedFailedReviewerIds = idArray(value.failedReviewerIds);
+	const agreements = stringArray(value.agreements);
+	const disagreements = objectArray(value.disagreements, parseDisagreement);
+	const objections = objectArray(value.objections, parseObjection);
+	const limitations = stringArray(value.limitations);
+	if (
+		!validReviewerIds ||
+		!parsedFailedReviewerIds ||
+		!agreements ||
+		!disagreements ||
+		!objections ||
+		!limitations
+	) {
+		return undefined;
+	}
+	const expectedValid = reviews.map((review) => review.reviewerId);
+	if (!sameIds(validReviewerIds, expectedValid)) return undefined;
+	if (!sameIds(parsedFailedReviewerIds, failedReviewerIds)) return undefined;
+	const validSet = new Set(expectedValid);
+	if (disagreements.some((item) => item.reviewerIds.some((id) => !validSet.has(id))))
+		return undefined;
+	const blockers = reviews.flatMap((review) =>
+		review.blocking
+			? review.findings.map((finding) => `${review.reviewerId}\u0000${finding.id}`)
+			: [],
+	);
+	const objectionKeys = objections.map((item) => `${item.reviewerId}\u0000${item.findingId}`);
+	if (new Set(objectionKeys).size !== objectionKeys.length) return undefined;
+	if (blockers.some((key) => !objectionKeys.includes(key))) return undefined;
+	if (objections.some((item) => !validSet.has(item.reviewerId))) return undefined;
+	if (objections.some((item) => item.resolution === "resolved" && item.evidence.length === 0)) {
+		return undefined;
+	}
+	if (value.disposition === "pass" && objections.some((item) => item.resolution === "unresolved")) {
+		return undefined;
+	}
+	return {
+		version: PANEL_SYNTHESIS_VERSION,
+		disposition: value.disposition as PanelDisposition,
+		summary: boundedText(value.summary),
+		validReviewerIds,
+		failedReviewerIds: parsedFailedReviewerIds,
+		agreements,
+		disagreements,
+		objections,
+		limitations,
+	};
+}
+
+function parseFinding(value: Record<string, unknown>): PanelFinding | undefined {
+	if (
+		!hasOnlyKeys(value, ["id", "severity", "title", "claim", "evidence", "verification"]) ||
+		typeof value.id !== "string" ||
+		typeof value.severity !== "string" ||
+		!PANEL_SEVERITIES.includes(value.severity as PanelSeverity) ||
+		typeof value.title !== "string" ||
+		typeof value.claim !== "string"
+	) {
+		return undefined;
+	}
+	const id = boundedId(value.id);
+	if (!/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(id)) return undefined;
+	const evidence = stringArray(value.evidence);
+	const verification =
+		value.verification === undefined ? undefined : stringArray(value.verification);
+	if (!evidence || (value.verification !== undefined && !verification)) return undefined;
+	return {
+		id,
+		severity: value.severity as PanelSeverity,
+		title: boundedText(value.title),
+		claim: boundedText(value.claim),
+		evidence,
+		...(verification ? { verification } : {}),
+	};
+}
+
+function parseDisagreement(value: Record<string, unknown>): PanelDisagreement | undefined {
+	if (!hasOnlyKeys(value, ["summary", "reviewerIds"]) || typeof value.summary !== "string") {
+		return undefined;
+	}
+	const reviewerIds = idArray(value.reviewerIds);
+	if (!reviewerIds || reviewerIds.length < 2) return undefined;
+	return { summary: boundedText(value.summary), reviewerIds };
+}
+
+function parseObjection(value: Record<string, unknown>): PanelObjectionResolution | undefined {
+	if (
+		!hasOnlyKeys(value, ["reviewerId", "findingId", "resolution", "evidence"]) ||
+		typeof value.reviewerId !== "string" ||
+		typeof value.findingId !== "string" ||
+		(value.resolution !== "resolved" && value.resolution !== "unresolved")
+	) {
+		return undefined;
+	}
+	const evidence = stringArray(value.evidence);
+	if (!evidence) return undefined;
+	return {
+		reviewerId: boundedId(value.reviewerId),
+		findingId: boundedId(value.findingId),
+		resolution: value.resolution,
+		evidence,
+	};
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | undefined {
+	if (Buffer.byteLength(text, "utf8") > DEFAULT_MAX_OUTPUT_BYTES) return undefined;
+	const source = text
+		.trim()
+		.replace(/^```(?:json)?\s*/u, "")
+		.replace(/\s*```$/u, "")
+		.trim();
+	if (!source.startsWith("{") || !source.endsWith("}")) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(source);
+		return isPlainObject(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function stringArray(value: unknown): string[] | undefined {
+	if (
+		!Array.isArray(value) ||
+		value.length > MAX_ITEMS ||
+		value.some((item) => typeof item !== "string")
+	) {
+		return undefined;
+	}
+	return value.map((item) => boundedText(item as string));
+}
+
+function idArray(value: unknown): string[] | undefined {
+	const values = stringArray(value)?.map(boundedId);
+	if (!values || new Set(values).size !== values.length || values.some((id) => !id))
+		return undefined;
+	return values;
+}
+
+function objectArray<T>(
+	value: unknown,
+	parser: (value: Record<string, unknown>) => T | undefined,
+): T[] | undefined {
+	if (!Array.isArray(value) || value.length > MAX_ITEMS) return undefined;
+	const parsed: T[] = [];
+	for (const item of value) {
+		if (!isPlainObject(item)) return undefined;
+		const result = parser(item);
+		if (!result) return undefined;
+		parsed.push(result);
+	}
+	return parsed;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+	const allowed = new Set(keys);
+	return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function boundedText(value: string): string {
+	return truncateUtf8(redactPrivateText(value), MAX_TEXT_BYTES).text;
+}
+
+function boundedId(value: string): string {
+	return truncateUtf8(redactPrivateText(value), MAX_ID_BYTES).text.trim();
+}
+
+function sameIds(actual: readonly string[], expected: readonly string[]): boolean {
+	return actual.length === expected.length && actual.every((id) => expected.includes(id));
+}

--- a/packages/pi-subagents/src/panel-evidence.ts
+++ b/packages/pi-subagents/src/panel-evidence.ts
@@ -1,0 +1,59 @@
+import type { PanelReview } from "./panel-contract.js";
+
+const MAX_PANEL_EVIDENCE_BYTES = 24 * 1024;
+export interface PanelEvidenceArtifact {
+	panelId: string;
+	reviewerId: string;
+	revision: number;
+	review: PanelReview;
+}
+
+export class PanelEvidenceLedger {
+	private readonly latestByReviewer = new Map<string, PanelEvidenceArtifact>();
+
+	constructor(
+		private readonly panelId: string,
+		private readonly maxArtifacts: number,
+	) {}
+
+	publish(review: PanelReview, revision: number): boolean {
+		if (!Number.isSafeInteger(revision) || revision < 1) return false;
+		const current = this.latestByReviewer.get(review.reviewerId);
+		if (
+			current &&
+			current.review.provenance?.taskGeneration !== review.provenance?.taskGeneration
+		) {
+			return false;
+		}
+		if ((!current && revision !== 1) || (current && revision !== current.revision + 1))
+			return false;
+		if (!current && this.latestByReviewer.size >= this.maxArtifacts) return false;
+		const artifact = {
+			panelId: this.panelId,
+			reviewerId: review.reviewerId,
+			revision,
+			review: structuredClone(review),
+		};
+		const candidate = [
+			...[...this.latestByReviewer.values()].filter(
+				(item) => item.reviewerId !== review.reviewerId,
+			),
+			artifact,
+		];
+		if (Buffer.byteLength(JSON.stringify(candidate), "utf8") > MAX_PANEL_EVIDENCE_BYTES)
+			return false;
+		this.latestByReviewer.set(review.reviewerId, artifact);
+		return true;
+	}
+
+	latest(reviewerId: string): PanelEvidenceArtifact | undefined {
+		const artifact = this.latestByReviewer.get(reviewerId);
+		return artifact ? structuredClone(artifact) : undefined;
+	}
+
+	snapshot(): PanelEvidenceArtifact[] {
+		return [...this.latestByReviewer.values()]
+			.sort((left, right) => left.reviewerId.localeCompare(right.reviewerId))
+			.map((artifact) => structuredClone(artifact));
+	}
+}

--- a/packages/pi-subagents/src/panel-execution.ts
+++ b/packages/pi-subagents/src/panel-execution.ts
@@ -1,0 +1,754 @@
+import type { AgentToolResult, AgentToolUpdateCallback } from "@earendil-works/pi-agent-core";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AgentConfig, AgentScope, SubagentThinkingLevel } from "./agents.js";
+import { panelReviewStatus, panelSynthesisStatus, startSubagentStatus } from "./blocking-status.js";
+import { issueCapabilityGrant, revokeCapabilityGrant } from "./capability-grant.js";
+import type { ResolvedSubagentTarget } from "./cwd-policy.js";
+import { targetPolicyAudit } from "./cwd-policy.js";
+import type { DelegationContract } from "./delegation-contract.js";
+import {
+	acknowledgeExecutionPlan,
+	createExecutionPlan,
+	resolveContractTools,
+} from "./execution-plan.js";
+import {
+	DEFAULT_MAX_OUTPUT_BYTES,
+	MAX_BLOCKING_PARALLEL_CONCURRENCY,
+	truncateUtf8,
+} from "./limits.js";
+import { calculateOrchestrationMetrics } from "./orchestration-metrics.js";
+import { PanelChildGroup } from "./panel-child-group.js";
+import { type PanelReview, parsePanelReview, parsePanelSynthesis } from "./panel-contract.js";
+import { PanelEvidenceLedger } from "./panel-evidence.js";
+import { classifyPanelFailure, type PanelFailure } from "./panel-failure.js";
+import {
+	createPanelWorkLedger,
+	type PanelPreset,
+	planPanelBudgets,
+	validatePanelRequest,
+} from "./panel-planning.js";
+import { buildPanelReviewerPrompt, buildPanelSynthesisPrompt } from "./panel-prompts.js";
+import { reconcilePanel } from "./panel-reconciliation.js";
+import type { SubagentParams } from "./params.js";
+import {
+	type ChildLaunchPolicy,
+	getResultFinalOutput,
+	isResultError,
+	mapWithConcurrencyLimit,
+	runSingleAgent,
+	type SingleResult,
+	type SubagentDetails,
+} from "./runner.js";
+import { boundedPrivateText, boundText } from "./safe-text.js";
+import { createSessionWorkItemPersistence } from "./work-item-persistence.js";
+import { assertWorkspaceIsolationReady } from "./workspace.js";
+
+export interface PanelExecutionInput {
+	toolCallId: string;
+	params: SubagentParams;
+	panel: NonNullable<SubagentParams["panel"]>;
+	signal?: AbortSignal;
+	onUpdate?: AgentToolUpdateCallback<SubagentDetails>;
+	ctx: ExtensionContext;
+	agents: AgentConfig[];
+	agentScope: AgentScope;
+	projectAgentsDir: string | null;
+	maxParallelTasks: number;
+	target: ResolvedSubagentTarget;
+	resolveThinkingLevel: (
+		agentName: string,
+		local?: SubagentThinkingLevel,
+	) => SubagentThinkingLevel | undefined;
+	resolveTimeoutMs: (agentName: string, local?: number) => number;
+}
+
+type PanelToolResult = AgentToolResult<SubagentDetails> & { isError?: boolean };
+
+const PANEL_READ_ONLY_TOOLS = new Set(["read", "grep", "find", "ls"]);
+
+export async function preflightPanelExecution(
+	input: Pick<
+		PanelExecutionInput,
+		"panel" | "agents" | "target" | "resolveThinkingLevel" | "resolveTimeoutMs"
+	>,
+): Promise<void> {
+	let requiresWorktree = false;
+	for (const [index, reviewer] of input.panel.reviewers.entries()) {
+		const agent = input.agents.find((candidate) => candidate.name === reviewer.agent);
+		if (!agent) throw new Error(`Unknown panel agent: ${reviewer.agent}`);
+		requiresWorktree ||= !isReadOnlyAgent(agent);
+		const policy = launchPolicy(
+			input as PanelExecutionInput,
+			reviewer.agent,
+			input.resolveThinkingLevel(reviewer.agent, reviewer.thinkingLevel),
+			input.panel.task,
+			input.resolveTimeoutMs(reviewer.agent, reviewer.timeoutMs),
+			index + 1,
+			isReadOnlyAgent(agent) ? "shared" : "worktree",
+			"review",
+		);
+		if (policy.capabilityGrant) {
+			revokeCapabilityGrant(policy.capabilityGrant, "preflight-complete", Date.now());
+		}
+	}
+	if (requiresWorktree) await assertWorkspaceIsolationReady(input.target.cwd);
+	const synthesizer = input.panel.synthesizer;
+	const policy = launchPolicy(
+		input as PanelExecutionInput,
+		synthesizer.agent,
+		input.resolveThinkingLevel(synthesizer.agent, synthesizer.thinkingLevel),
+		"Panel synthesis",
+		input.resolveTimeoutMs(synthesizer.agent, synthesizer.timeoutMs),
+		input.panel.reviewers.length + 1,
+		"shared",
+		"tool-less",
+	);
+	if (policy.capabilityGrant) {
+		revokeCapabilityGrant(policy.capabilityGrant, "preflight-complete", Date.now());
+	}
+}
+
+export async function executePanel(input: PanelExecutionInput): Promise<PanelToolResult> {
+	validatePanelRequest(input.panel, input.maxParallelTasks);
+	const panelId = input.panel.id ?? `panel-${input.toolCallId}`;
+	const preset: PanelPreset = input.panel.preset ?? "custom";
+	const minValidReviews = input.panel.minValidReviews ?? 2;
+	const requestedReviewTimeout = Math.max(
+		...input.panel.reviewers.map((reviewer) =>
+			input.resolveTimeoutMs(reviewer.agent, reviewer.timeoutMs),
+		),
+	);
+	const requestedSynthesisTimeout = input.resolveTimeoutMs(
+		input.panel.synthesizer.agent,
+		input.panel.synthesizer.timeoutMs,
+	);
+	const totalMs =
+		input.params.totalTimeoutMs ?? requestedReviewTimeout + requestedSynthesisTimeout + 60_000;
+	const budgets = planPanelBudgets(totalMs, input.panel.reviewers.length);
+	const panelStartedAt = Date.now();
+	const failureMessageLimit = Math.max(128, Math.floor((8 * 1024) / input.panel.reviewers.length));
+	const requiredAgents = [
+		...input.panel.reviewers.map((reviewer) => reviewer.agent),
+		input.panel.synthesizer.agent,
+	];
+	for (const agentName of requiredAgents) {
+		if (!input.agents.some((agent) => agent.name === agentName)) {
+			throw new Error(`Unknown panel agent: ${agentName}`);
+		}
+	}
+
+	const group = new PanelChildGroup(input.signal);
+	const ledger = new PanelEvidenceLedger(panelId, input.panel.reviewers.length);
+	const workLedger = createPanelWorkLedger(panelId, input.panel, input.agents);
+	const persistenceOwner =
+		input.ctx.sessionManager.getSessionId?.() ??
+		input.ctx.sessionManager.getSessionFile?.() ??
+		`ephemeral:${input.ctx.cwd}`;
+	const workPersistence = createSessionWorkItemPersistence(persistenceOwner, panelId);
+	const persistWork = () => workPersistence.save(workLedger.snapshot());
+	const workspaceByReviewer = new Map<string, string>();
+	let output: PanelToolResult | undefined;
+	const results: SingleResult[] = [];
+	const failures: PanelFailure[] = [];
+	let panelDetails = createPanelDetails({
+		panelId,
+		preset,
+		reviewerIds: input.panel.reviewers.map((reviewer) => reviewer.id),
+		sharedTask: input.panel.task,
+		budgets,
+	});
+	const makeDetails = (currentResults: SingleResult[] = results): SubagentDetails => ({
+		mode: "panel",
+		agentScope: input.agentScope,
+		projectAgentsDir: input.projectAgentsDir,
+		results: [...currentResults],
+		workflow: workLedger.snapshot(),
+		metrics: calculateOrchestrationMetrics(workLedger.snapshot(), currentResults, panelDetails),
+		panel: panelDetails,
+	});
+	const status = startSubagentStatus(
+		input.ctx,
+		input.toolCallId,
+		panelReviewStatus(0, input.panel.reviewers.length, input.panel.reviewers.length),
+	);
+
+	try {
+		await persistWork();
+		for (const reviewer of input.panel.reviewers) {
+			const agent = input.agents.find(
+				(candidate) => candidate.name === reviewer.agent,
+			) as AgentConfig;
+			if (isReadOnlyAgent(agent)) continue;
+			const workspace = await group.createWorkspace(`${panelId}:${reviewer.id}`, input.target.cwd);
+			workspaceByReviewer.set(reviewer.id, workspace.path);
+		}
+
+		let completed = 0;
+		const reviewPhaseStartedAt = panelStartedAt;
+		const reviewResults = await mapWithConcurrencyLimit(
+			input.panel.reviewers,
+			Math.min(MAX_BLOCKING_PARALLEL_CONCURRENCY, input.maxParallelTasks),
+			async (reviewer, index) => {
+				const workItemId = `review:${reviewer.id}`;
+				const startedWork = workLedger.start(workItemId, `agent:${reviewer.agent}`);
+				const taskGeneration = startedWork.taskGeneration;
+				const prompt = buildPanelReviewerPrompt({
+					panelId,
+					preset,
+					task: input.panel.task,
+					context: input.panel.context,
+					reviewerId: reviewer.id,
+					focus: reviewer.focus,
+				});
+				const phaseRemaining = budgets.reviewMs - (Date.now() - reviewPhaseStartedAt);
+				const reviewBudgetAvailable = phaseRemaining >= 1;
+				const timeoutMs = Math.min(
+					input.resolveTimeoutMs(reviewer.agent, reviewer.timeoutMs),
+					phaseRemaining,
+				);
+				const thinkingLevel = input.resolveThinkingLevel(reviewer.agent, reviewer.thinkingLevel);
+				let artifactRevision = 0;
+				let latestFingerprint = "";
+				let noProgressUpdates = 0;
+				const reviewerController = new AbortController();
+				const reviewerSignal = AbortSignal.any([group.signal, reviewerController.signal]);
+				const publishOutput = (candidate: SingleResult): PanelReview | undefined => {
+					const parsed = parsePanelReview(getResultFinalOutput(candidate), reviewer.id, {
+						agent: reviewer.agent,
+						model: candidate.actualModel ?? candidate.model,
+						taskGeneration,
+					});
+					if (!parsed) {
+						noProgressUpdates += 1;
+						if (noProgressUpdates >= 8 && !reviewerController.signal.aborted) {
+							reviewerController.abort("semantic-stall");
+						}
+						return undefined;
+					}
+					const fingerprint = JSON.stringify(parsed);
+					if (fingerprint === latestFingerprint) return parsed;
+					artifactRevision += 1;
+					if (!ledger.publish(parsed, artifactRevision)) {
+						artifactRevision -= 1;
+						noProgressUpdates += 1;
+						return undefined;
+					}
+					latestFingerprint = fingerprint;
+					noProgressUpdates = 0;
+					return parsed;
+				};
+				const runAttempt = async (attempt: number): Promise<SingleResult> => {
+					if (!reviewBudgetAvailable) {
+						return panelReviewerBudgetExhaustedResult(
+							input.agents,
+							reviewer.agent,
+							input.panel.task,
+							thinkingLevel,
+						);
+					}
+					const result = await runSingleAgent(
+						input.ctx.cwd,
+						input.agents,
+						reviewer.agent,
+						prompt,
+						workspaceByReviewer.get(reviewer.id) ?? input.target.cwd,
+						index + 1,
+						reviewerSignal,
+						thinkingLevel,
+						timeoutMs,
+						(partial) => {
+							const partialResult = partial.details?.results[0];
+							if (partialResult) publishOutput(partialResult);
+							input.onUpdate?.({
+								content: partial.content,
+								details: makeDetails(),
+							});
+						},
+						makeDetails,
+						undefined,
+						launchPolicy(
+							input,
+							reviewer.agent,
+							thinkingLevel,
+							`Panel review ${reviewer.id}`,
+							timeoutMs,
+							taskGeneration,
+							workspaceByReviewer.has(reviewer.id) ? "worktree" : "shared",
+							"review",
+							{
+								idleTimeoutMs: reviewer.idleTimeoutMs ?? input.params.idleTimeoutMs,
+								maxTurns: reviewer.maxTurns ?? input.params.maxTurns,
+								maxToolCalls: reviewer.maxToolCalls ?? input.params.maxToolCalls,
+							},
+							reviewPhaseStartedAt + budgets.reviewMs + budgets.finalizationMs,
+						),
+					);
+					result.target = targetPolicyAudit(input.target);
+					result.attemptCount = attempt;
+					if (
+						reviewerController.signal.reason === "semantic-stall" &&
+						result.aborted &&
+						!group.signal.aborted
+					) {
+						result.aborted = false;
+						result.stopReason = "semantic-stall";
+						result.errorMessage =
+							"Panel reviewer stopped after repeated updates without new valid evidence";
+					}
+					return result;
+				};
+
+				let result = await runAttempt(1);
+				let parsed = publishOutput(result) ?? ledger.latest(reviewer.id)?.review;
+				let classification = classifyPanelFailure(result);
+				if (!parsed && classification.retryable && !group.signal.aborted) {
+					result = await runAttempt(2);
+					parsed = publishOutput(result) ?? ledger.latest(reviewer.id)?.review;
+					classification = classifyPanelFailure(result);
+				}
+				if (!parsed && result.timedOut && reviewBudgetAvailable && !group.signal.aborted) {
+					const finalizationPrompt = `${prompt}\n\nYour prior attempt stopped before a valid artifact. Use this bounded checkpoint and return the required panel-review JSON now:\n${boundText(getResultFinalOutput(result), 8 * 1024, 200).text}`;
+					const finalized = await runSingleAgent(
+						input.ctx.cwd,
+						input.agents,
+						reviewer.agent,
+						finalizationPrompt,
+						workspaceByReviewer.get(reviewer.id) ?? input.target.cwd,
+						index + 1,
+						group.signal,
+						thinkingLevel,
+						budgets.finalizationMs,
+						undefined,
+						makeDetails,
+						undefined,
+						{
+							...launchPolicy(
+								input,
+								reviewer.agent,
+								thinkingLevel,
+								`Panel review finalization ${reviewer.id}`,
+								budgets.finalizationMs,
+								taskGeneration,
+								workspaceByReviewer.has(reviewer.id) ? "worktree" : "shared",
+								"tool-less",
+							),
+							finalizeOnTimeout: false,
+						},
+					);
+					finalized.attemptCount = (result.attemptCount ?? 1) + 1;
+					result = finalized;
+					parsed = publishOutput(result) ?? ledger.latest(reviewer.id)?.review;
+					classification = classifyPanelFailure(result);
+				}
+				if (parsed && isResultError(result)) {
+					failures.push({
+						reviewerId: reviewer.id,
+						...classification,
+						message: boundedPrivateText(
+							result.errorMessage ??
+								(result.stderr.trim() || "Reviewer failed after publishing valid evidence"),
+							failureMessageLimit,
+						),
+					});
+				}
+				if (!parsed) {
+					if (!isResultError(result)) result.resultContractInvalid = true;
+					classification = classifyPanelFailure(result);
+					failures.push({
+						reviewerId: reviewer.id,
+						...classification,
+						message: boundedPrivateText(
+							result.errorMessage ?? (result.stderr.trim() || "No valid panel review artifact"),
+							failureMessageLimit,
+						),
+					});
+					workLedger.settle(
+						workItemId,
+						result.aborted ? "interrupted" : "failed",
+						classification.kind,
+					);
+				} else {
+					const artifact = ledger.latest(reviewer.id);
+					workLedger.complete(workItemId, {
+						taskGeneration,
+						executionPlanId: result.executionPlan?.id,
+						artifacts: artifact
+							? [
+									{
+										id: `panel-review:${reviewer.id}`,
+										kind: "panel-review",
+										version: String(artifact.revision),
+										verified: false,
+									},
+								]
+							: [],
+						verificationAccepted: false,
+					});
+				}
+				completed += 1;
+				status.update(
+					panelReviewStatus(
+						completed,
+						input.panel.reviewers.length,
+						input.panel.reviewers.length - completed,
+					),
+				);
+				return compactPanelResult(result);
+			},
+			group.signal,
+			(reviewer) => {
+				const workItemId = `review:${reviewer.id}`;
+				workLedger.settle(workItemId, "interrupted", "parent-aborted-before-launch");
+				failures.push({
+					reviewerId: reviewer.id,
+					kind: "cancelled",
+					retryable: false,
+					message: "Panel reviewer was not launched because the parent call was cancelled",
+				});
+				completed += 1;
+				return cancelledPanelResult(
+					input.agents,
+					reviewer.agent,
+					input.panel.task,
+					input.resolveThinkingLevel(reviewer.agent, reviewer.thinkingLevel),
+				);
+			},
+		);
+		results.push(...reviewResults);
+		await persistWork();
+		const reviews = ledger.snapshot().map((artifact) => artifact.review);
+		const reconciliation = reconcilePanel({ reviews, failures, minValidReviews });
+		panelDetails = {
+			...panelDetails,
+			validReviewCount: reviews.length,
+			failedReviewCount: failures.length,
+			blockingObjectionCount: reconciliation.blockingObjections.length,
+			evidence: ledger.snapshot(),
+			failures: [...reconciliation.failures],
+		};
+		if (reconciliation.kind === "insufficient-panel") {
+			workLedger.settle(
+				"synthesis",
+				group.signal.aborted ? "interrupted" : "blocked",
+				"insufficient-valid-reviews",
+			);
+			await persistWork();
+			panelDetails.state = group.signal.aborted ? "cancelled" : "insufficient-panel";
+			output = {
+				content: [
+					{
+						type: "text",
+						text: boundText(
+							`Insufficient panel: ${reviews.length}/${minValidReviews} valid reviews. Partial evidence was preserved; synthesis was not run.`,
+							DEFAULT_MAX_OUTPUT_BYTES,
+						).text,
+					},
+				],
+				details: { ...makeDetails(), isError: true },
+				isError: true,
+			};
+		} else {
+			const synthesisWork = workLedger.start("synthesis", `agent:${input.panel.synthesizer.agent}`);
+			await persistWork();
+			status.update(panelSynthesisStatus(input.panel.synthesizer.agent));
+			const synthesisPrompt = buildPanelSynthesisPrompt({
+				panelId,
+				task: input.panel.task,
+				reviews: reconciliation.reviews,
+				failures: reconciliation.failures,
+			});
+			const synthesisTimeout = Math.min(
+				input.resolveTimeoutMs(input.panel.synthesizer.agent, input.panel.synthesizer.timeoutMs),
+				budgets.synthesisMs,
+				Math.max(0, panelStartedAt + budgets.totalMs - budgets.cleanupMs - Date.now()),
+			);
+			const synthesisThinkingLevel = input.resolveThinkingLevel(
+				input.panel.synthesizer.agent,
+				input.panel.synthesizer.thinkingLevel,
+			);
+			const synthesisResult =
+				synthesisTimeout < 1
+					? panelBudgetExhaustedResult(
+							input.agents,
+							input.panel.synthesizer.agent,
+							synthesisPrompt,
+							synthesisThinkingLevel,
+						)
+					: await runSingleAgent(
+							input.ctx.cwd,
+							input.agents,
+							input.panel.synthesizer.agent,
+							synthesisPrompt,
+							input.target.cwd,
+							undefined,
+							group.signal,
+							synthesisThinkingLevel,
+							synthesisTimeout,
+							undefined,
+							makeDetails,
+							undefined,
+							{
+								...launchPolicy(
+									input,
+									input.panel.synthesizer.agent,
+									synthesisThinkingLevel,
+									"Panel synthesis",
+									synthesisTimeout,
+									input.panel.reviewers.length + 1,
+									"shared",
+									"tool-less",
+									{
+										idleTimeoutMs:
+											input.panel.synthesizer.idleTimeoutMs ?? input.params.idleTimeoutMs,
+										maxTurns: input.panel.synthesizer.maxTurns ?? input.params.maxTurns,
+										maxToolCalls: input.panel.synthesizer.maxToolCalls ?? input.params.maxToolCalls,
+									},
+								),
+							},
+						);
+			synthesisResult.target = targetPolicyAudit(input.target);
+			const synthesis = parsePanelSynthesis(
+				getResultFinalOutput(synthesisResult),
+				reconciliation.reviews,
+				reconciliation.failures
+					.map((failure) => failure.reviewerId)
+					.filter((id): id is string => Boolean(id)),
+			);
+			compactPanelResult(synthesisResult);
+			panelDetails = {
+				...panelDetails,
+				synthesizerResult: synthesisResult,
+				synthesis,
+				dissentCount: synthesis?.disagreements.length ?? 0,
+				state: synthesis
+					? failures.length > 0
+						? "degraded"
+						: "completed"
+					: group.signal.aborted
+						? "cancelled"
+						: "failed",
+			};
+			const synthesisInvalid = !synthesis || isResultError(synthesisResult);
+			if (!synthesis && !isResultError(synthesisResult)) {
+				synthesisResult.resultContractInvalid = true;
+			}
+			if (synthesisInvalid) {
+				workLedger.settle(
+					"synthesis",
+					synthesisResult.aborted ? "interrupted" : "failed",
+					"invalid-panel-synthesis",
+				);
+			} else {
+				workLedger.complete("synthesis", {
+					taskGeneration: synthesisWork.taskGeneration,
+					executionPlanId: synthesisResult.executionPlan?.id,
+					verificationAccepted: false,
+				});
+			}
+			await persistWork();
+			output = {
+				content: [
+					{
+						type: "text",
+						text: synthesis
+							? boundText(synthesis.summary, DEFAULT_MAX_OUTPUT_BYTES).text
+							: "Panel synthesis failed or returned an invalid panel-synthesis contract.",
+					},
+				],
+				details: { ...makeDetails(), isError: synthesisInvalid || undefined },
+				isError: synthesisInvalid || undefined,
+			};
+		}
+	} finally {
+		status.clear();
+		await group.close();
+		panelDetails.cleanupComplete = true;
+		if (output?.details.panel) output.details.panel.cleanupComplete = true;
+	}
+	return output as PanelToolResult;
+}
+
+function isReadOnlyAgent(agent: AgentConfig): boolean {
+	return agent.capabilityManifest?.authority?.filesystem === "read";
+}
+
+function launchPolicy(
+	input: PanelExecutionInput,
+	agentName: string,
+	thinkingLevel: SubagentThinkingLevel | undefined,
+	displayTask: string,
+	timeoutMs: number,
+	taskGeneration: number,
+	workspaceMode: "shared" | "worktree",
+	toolMode: "review" | "tool-less",
+	turnLimits?: ChildLaunchPolicy["turnLimits"],
+	orchestrationDeadlineAt?: number,
+): ChildLaunchPolicy {
+	const agent = input.agents.find((candidate) => candidate.name === agentName);
+	if (!agent) throw new Error(`Unknown panel agent: ${agentName}`);
+	const resolvedTools = resolveContractTools(agent.tools, undefined);
+	const tools =
+		toolMode === "tool-less"
+			? []
+			: workspaceMode === "shared"
+				? (resolvedTools?.filter((tool) => PANEL_READ_ONLY_TOOLS.has(tool)) ?? [])
+				: resolvedTools;
+	const contract: DelegationContract = {
+		version: "pi-subagents:delegation:v2",
+		level: "minimal",
+		taskId: `panel-${taskGeneration}`,
+		objective: truncateUtf8(displayTask, 16 * 1024).text,
+		nonGoals: [],
+		dependencies: [],
+		requiredInputs: [],
+		acceptanceCriteria: ["Return one valid bounded panel contract"],
+		requiredEvidence: [],
+		sideEffectPolicy:
+			toolMode === "tool-less" || workspaceMode === "shared" ? "read-only" : "mutating",
+		enforcement: "audit",
+	};
+	const executionPlan = createExecutionPlan({
+		contract,
+		agent,
+		effectiveTools: tools,
+		target: targetPolicyAudit(input.target),
+		workspaceMode,
+		transport: "subprocess",
+		resultFormat: "text",
+		model: agent.model,
+		thinkingLevel,
+		timeoutMs,
+		taskGeneration,
+	});
+	const acknowledgement = acknowledgeExecutionPlan(executionPlan);
+	if (acknowledgement.status === "rejected") {
+		throw new Error(`Panel execution plan rejected: ${JSON.stringify(acknowledgement)}`);
+	}
+	return {
+		projectTrust: input.target.trust.projectTrusted,
+		tools,
+		contract,
+		displayTask,
+		turnLimits,
+		orchestrationDeadlineAt,
+		finalizeOnTimeout: false,
+		executionPlan,
+		capabilityGrant: issueCapabilityGrant(executionPlan, Date.now(), timeoutMs + 60_000),
+	};
+}
+
+function cancelledPanelResult(
+	agents: AgentConfig[],
+	agentName: string,
+	task: string,
+	thinkingLevel: SubagentThinkingLevel | undefined,
+): SingleResult {
+	const message = "Panel reviewer was not launched because the parent call was cancelled";
+	return {
+		agent: agentName,
+		agentSource: agents.find((agent) => agent.name === agentName)?.source ?? "unknown",
+		task,
+		exitCode: 130,
+		messages: [],
+		stderr: message,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+			contextTokens: 0,
+			turns: 0,
+		},
+		thinkingLevel,
+		finalOutput: "",
+		errorMessage: message,
+		aborted: true,
+		stopReason: "aborted",
+	};
+}
+
+function panelReviewerBudgetExhaustedResult(
+	agents: AgentConfig[],
+	agentName: string,
+	task: string,
+	thinkingLevel: SubagentThinkingLevel | undefined,
+): SingleResult {
+	const result = panelBudgetExhaustedResult(agents, agentName, task, thinkingLevel);
+	result.errorMessage = "Panel review budget was exhausted before launch";
+	result.stderr = result.errorMessage;
+	return result;
+}
+
+function panelBudgetExhaustedResult(
+	agents: AgentConfig[],
+	agentName: string,
+	task: string,
+	thinkingLevel: SubagentThinkingLevel | undefined,
+): SingleResult {
+	const message = "Panel synthesis budget was exhausted before launch";
+	return {
+		agent: agentName,
+		agentSource: agents.find((agent) => agent.name === agentName)?.source ?? "unknown",
+		task,
+		exitCode: 124,
+		messages: [],
+		stderr: message,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+			contextTokens: 0,
+			turns: 0,
+		},
+		thinkingLevel,
+		finalOutput: "",
+		errorMessage: message,
+		timedOut: true,
+		stopReason: "timeout",
+	};
+}
+
+function compactPanelResult(result: SingleResult): SingleResult {
+	result.messages = [];
+	result.recentActivity = undefined;
+	result.recentActivityTotal = undefined;
+	result.task = boundText(result.task, 512, 20).text;
+	result.finalOutput = result.finalOutput
+		? boundText(result.finalOutput, 512, 20).text
+		: result.finalOutput;
+	result.partialOutput = result.partialOutput
+		? boundText(result.partialOutput, 512, 20).text
+		: result.partialOutput;
+	result.stderr = boundText(result.stderr, 512, 20).text;
+	result.errorMessage = result.errorMessage
+		? boundedPrivateText(result.errorMessage, 512)
+		: result.errorMessage;
+	return result;
+}
+
+function createPanelDetails(input: {
+	panelId: string;
+	preset: PanelPreset;
+	reviewerIds: string[];
+	sharedTask: string;
+	budgets: ReturnType<typeof planPanelBudgets>;
+}): NonNullable<SubagentDetails["panel"]> {
+	return {
+		id: input.panelId,
+		preset: input.preset,
+		sharedTaskPreview: boundedPrivateText(input.sharedTask, 2 * 1024),
+		state: "running",
+		reviewerIds: input.reviewerIds,
+		validReviewCount: 0,
+		failedReviewCount: 0,
+		blockingObjectionCount: 0,
+		dissentCount: 0,
+		budgets: input.budgets,
+		evidence: [],
+		failures: [],
+		cleanupComplete: false,
+	};
+}

--- a/packages/pi-subagents/src/panel-execution.ts
+++ b/packages/pi-subagents/src/panel-execution.ts
@@ -69,11 +69,13 @@ const PANEL_READ_ONLY_TOOLS = new Set(["read", "grep", "find", "ls"]);
 export async function preflightPanelExecution(
 	input: Pick<
 		PanelExecutionInput,
-		"panel" | "agents" | "target" | "resolveThinkingLevel" | "resolveTimeoutMs"
+		"panel" | "agents" | "target" | "resolveThinkingLevel" | "resolveTimeoutMs" | "signal"
 	>,
 ): Promise<void> {
+	assertPanelActive(input.signal);
 	let requiresWorktree = false;
 	for (const [index, reviewer] of input.panel.reviewers.entries()) {
+		assertPanelActive(input.signal);
 		const agent = input.agents.find((candidate) => candidate.name === reviewer.agent);
 		if (!agent) throw new Error(`Unknown panel agent: ${reviewer.agent}`);
 		requiresWorktree ||= !isReadOnlyAgent(agent);
@@ -91,7 +93,10 @@ export async function preflightPanelExecution(
 			revokeCapabilityGrant(policy.capabilityGrant, "preflight-complete", Date.now());
 		}
 	}
-	if (requiresWorktree) await assertWorkspaceIsolationReady(input.target.cwd);
+	if (requiresWorktree) {
+		await assertWorkspaceIsolationReady(input.target.cwd);
+		assertPanelActive(input.signal);
+	}
 	const synthesizer = input.panel.synthesizer;
 	const policy = launchPolicy(
 		input as PanelExecutionInput,
@@ -174,12 +179,15 @@ export async function executePanel(input: PanelExecutionInput): Promise<PanelToo
 
 	try {
 		await persistWork();
+		assertPanelActive(group.signal);
 		for (const reviewer of input.panel.reviewers) {
+			assertPanelActive(group.signal);
 			const agent = input.agents.find(
 				(candidate) => candidate.name === reviewer.agent,
 			) as AgentConfig;
 			if (isReadOnlyAgent(agent)) continue;
 			const workspace = await group.createWorkspace(`${panelId}:${reviewer.id}`, input.target.cwd);
+			assertPanelActive(group.signal);
 			workspaceByReviewer.set(reviewer.id, workspace.path);
 		}
 
@@ -209,7 +217,7 @@ export async function executePanel(input: PanelExecutionInput): Promise<PanelToo
 				const thinkingLevel = input.resolveThinkingLevel(reviewer.agent, reviewer.thinkingLevel);
 				let artifactRevision = 0;
 				let latestFingerprint = "";
-				let noProgressUpdates = 0;
+				let repeatedEvidenceUpdates = 0;
 				const reviewerController = new AbortController();
 				const reviewerSignal = AbortSignal.any([group.signal, reviewerController.signal]);
 				const publishOutput = (candidate: SingleResult): PanelReview | undefined => {
@@ -218,23 +226,22 @@ export async function executePanel(input: PanelExecutionInput): Promise<PanelToo
 						model: candidate.actualModel ?? candidate.model,
 						taskGeneration,
 					});
-					if (!parsed) {
-						noProgressUpdates += 1;
-						if (noProgressUpdates >= 8 && !reviewerController.signal.aborted) {
+					if (!parsed) return undefined;
+					const fingerprint = JSON.stringify(parsed);
+					if (fingerprint === latestFingerprint) {
+						repeatedEvidenceUpdates += 1;
+						if (repeatedEvidenceUpdates >= 8 && !reviewerController.signal.aborted) {
 							reviewerController.abort("semantic-stall");
 						}
-						return undefined;
+						return parsed;
 					}
-					const fingerprint = JSON.stringify(parsed);
-					if (fingerprint === latestFingerprint) return parsed;
 					artifactRevision += 1;
 					if (!ledger.publish(parsed, artifactRevision)) {
 						artifactRevision -= 1;
-						noProgressUpdates += 1;
 						return undefined;
 					}
 					latestFingerprint = fingerprint;
-					noProgressUpdates = 0;
+					repeatedEvidenceUpdates = 0;
 					return parsed;
 				};
 				const runAttempt = async (attempt: number): Promise<SingleResult> => {
@@ -515,20 +522,25 @@ export async function executePanel(input: PanelExecutionInput): Promise<PanelToo
 					.filter((id): id is string => Boolean(id)),
 			);
 			compactPanelResult(synthesisResult);
+			const synthesisErrored = isResultError(synthesisResult);
 			panelDetails = {
 				...panelDetails,
 				synthesizerResult: synthesisResult,
 				synthesis,
 				dissentCount: synthesis?.disagreements.length ?? 0,
-				state: synthesis
-					? failures.length > 0
-						? "degraded"
-						: "completed"
-					: group.signal.aborted
+				state: synthesisErrored
+					? group.signal.aborted
 						? "cancelled"
-						: "failed",
+						: "failed"
+					: synthesis
+						? failures.length > 0
+							? "degraded"
+							: "completed"
+						: group.signal.aborted
+							? "cancelled"
+							: "failed",
 			};
-			const synthesisInvalid = !synthesis || isResultError(synthesisResult);
+			const synthesisInvalid = !synthesis || synthesisErrored;
 			if (!synthesis && !isResultError(synthesisResult)) {
 				synthesisResult.resultContractInvalid = true;
 			}
@@ -566,6 +578,12 @@ export async function executePanel(input: PanelExecutionInput): Promise<PanelToo
 		if (output?.details.panel) output.details.panel.cleanupComplete = true;
 	}
 	return output as PanelToolResult;
+}
+
+function assertPanelActive(signal?: AbortSignal): void {
+	if (!signal?.aborted) return;
+	if (signal.reason instanceof Error) throw signal.reason;
+	throw new DOMException("Panel execution was cancelled during setup", "AbortError");
 }
 
 function isReadOnlyAgent(agent: AgentConfig): boolean {

--- a/packages/pi-subagents/src/panel-failure.ts
+++ b/packages/pi-subagents/src/panel-failure.ts
@@ -1,0 +1,56 @@
+import type { SingleResult } from "./runner.js";
+
+export const PANEL_FAILURE_KINDS = [
+	"transient-launch",
+	"transient-transport",
+	"invalid-contract",
+	"semantic-stall",
+	"permission-denied",
+	"budget-exhausted",
+	"cancelled",
+	"task-failed",
+] as const;
+
+export type PanelFailureKind = (typeof PANEL_FAILURE_KINDS)[number];
+
+export interface PanelFailure {
+	reviewerId?: string;
+	kind: PanelFailureKind;
+	retryable: boolean;
+	message?: string;
+}
+
+export function classifyPanelFailure(
+	result: Partial<
+		Pick<
+			SingleResult,
+			| "launchFailed"
+			| "resultContractInvalid"
+			| "stopReason"
+			| "timedOut"
+			| "aborted"
+			| "errorMessage"
+			| "stderr"
+			| "termination"
+		>
+	>,
+): Omit<PanelFailure, "reviewerId" | "message"> {
+	if (result.launchFailed) return { kind: "transient-launch", retryable: true };
+	if (result.resultContractInvalid) return { kind: "invalid-contract", retryable: false };
+	if (result.stopReason === "semantic-stall" || result.termination?.reason === "idle_timeout") {
+		return { kind: "semantic-stall", retryable: false };
+	}
+	if (result.aborted || result.stopReason === "aborted")
+		return { kind: "cancelled", retryable: false };
+	if (result.timedOut || result.stopReason === "timeout") {
+		return { kind: "budget-exhausted", retryable: false };
+	}
+	const message = `${result.errorMessage ?? ""}\n${result.stderr ?? ""}`;
+	if (/permission|denied|not allowed|unauthori[sz]ed/iu.test(message)) {
+		return { kind: "permission-denied", retryable: false };
+	}
+	if (/transport|socket|connection reset|temporar|econnreset|eai_again/iu.test(message)) {
+		return { kind: "transient-transport", retryable: true };
+	}
+	return { kind: "task-failed", retryable: false };
+}

--- a/packages/pi-subagents/src/panel-planning.ts
+++ b/packages/pi-subagents/src/panel-planning.ts
@@ -1,0 +1,175 @@
+import type { AgentConfig } from "./agents.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import { type WorkItemDefinition, WorkItemLedger } from "./work-item-ledger.js";
+
+export const PANEL_PRESETS = ["code-review", "research", "security-review", "custom"] as const;
+export type PanelPreset = (typeof PANEL_PRESETS)[number];
+
+export interface PanelReviewerRequest {
+	id: string;
+	agent: string;
+	focus?: string;
+	timeoutMs?: number;
+	idleTimeoutMs?: number;
+	maxTurns?: number;
+	maxToolCalls?: number;
+	thinkingLevel?: string;
+}
+
+export interface PanelSynthesizerRequest {
+	agent: string;
+	timeoutMs?: number;
+	idleTimeoutMs?: number;
+	maxTurns?: number;
+	maxToolCalls?: number;
+	thinkingLevel?: string;
+}
+
+export interface PanelRequestLike {
+	id?: string;
+	preset?: PanelPreset;
+	task: string;
+	context?: string;
+	reviewers: PanelReviewerRequest[];
+	synthesizer: PanelSynthesizerRequest;
+	minValidReviews?: number;
+}
+
+export interface PanelPhaseBudgets {
+	totalMs: number;
+	reviewMs: number;
+	finalizationMs: number;
+	synthesisMs: number;
+	cleanupMs: number;
+	reviewerTimeoutMs: number;
+}
+
+const MIN_PHASE_MS = 1;
+const MAX_ID_BYTES = 256;
+const MAX_FOCUS_BYTES = 8 * 1024;
+
+export function planPanelBudgets(totalMs: number, _reviewerCount: number): PanelPhaseBudgets {
+	const normalized = Math.floor(totalMs);
+	if (!Number.isSafeInteger(normalized) || normalized < 4 * MIN_PHASE_MS) {
+		throw new Error(
+			"Panel total timeout is too small to reserve review, finalization, synthesis, and cleanup phases",
+		);
+	}
+	const cleanupMs = Math.max(MIN_PHASE_MS, Math.floor(normalized * 0.05));
+	const synthesisMs = Math.max(MIN_PHASE_MS, Math.floor(normalized * 0.2));
+	const finalizationMs = Math.max(MIN_PHASE_MS, Math.floor(normalized * 0.1));
+	const reviewMs = normalized - cleanupMs - synthesisMs - finalizationMs;
+	if (reviewMs < MIN_PHASE_MS) {
+		throw new Error("Panel total timeout is too small for the review phase");
+	}
+	return {
+		totalMs: normalized,
+		reviewMs,
+		finalizationMs,
+		synthesisMs,
+		cleanupMs,
+		reviewerTimeoutMs: reviewMs,
+	};
+}
+
+export function createPanelWorkLedger(
+	panelId: string,
+	panel: PanelRequestLike,
+	agents: readonly AgentConfig[],
+): WorkItemLedger {
+	const taskPreview = truncateUtf8(panel.task, 256).text;
+	const reviewerItems: WorkItemDefinition[] = panel.reviewers.map((reviewer) => {
+		const agent = agents.find((candidate) => candidate.name === reviewer.agent);
+		return {
+			id: `review:${reviewer.id}`,
+			objective: `Panel review ${reviewer.id}: ${taskPreview}`,
+			dependencies: [],
+			inputArtifacts: [],
+			inputArtifactVersions: {},
+			requiredCapabilities: ["independent-review"],
+			requiredTools: [],
+			selectedAgentName: reviewer.agent,
+			sideEffectPolicy:
+				agent?.capabilityManifest?.authority?.filesystem === "read" ? "read-only" : "mutating",
+			readPaths: [],
+			writePaths: [],
+			ownershipKeys: [],
+			acceptanceCriteria: ["Return one valid panel-review:v1 evidence artifact"],
+		};
+	});
+	return WorkItemLedger.create({
+		workflowId: panelId,
+		items: [
+			...reviewerItems,
+			{
+				id: "synthesis",
+				objective: "Reconcile valid panel evidence while preserving objections and dissent",
+				dependencies: reviewerItems.map((item) => item.id),
+				dependencyPolicy: "settled",
+				inputArtifacts: [],
+				inputArtifactVersions: {},
+				requiredCapabilities: ["evidence-review"],
+				requiredTools: [],
+				selectedAgentName: panel.synthesizer.agent,
+				sideEffectPolicy: "read-only",
+				readPaths: [],
+				writePaths: [],
+				ownershipKeys: [],
+				acceptanceCriteria: [
+					"Preserve every blocking objection and disagreement with evidence-backed resolution state",
+				],
+				integrationOwner: true,
+			},
+		],
+	});
+}
+
+export function validatePanelRequest(panel: PanelRequestLike, maxReviewers = 64): void {
+	if (
+		panel.id !== undefined &&
+		(!/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(panel.id) ||
+			Buffer.byteLength(panel.id, "utf8") > MAX_ID_BYTES)
+	) {
+		throw new Error("Panel id must use 1-256 safe identifier bytes");
+	}
+	if (!panel.task.trim()) throw new Error("Panel task must not be empty");
+	if (Buffer.byteLength(panel.task, "utf8") > DEFAULT_MAX_CONTEXT_BYTES) {
+		throw new Error("Panel task exceeds the bounded context limit");
+	}
+	if (panel.context && Buffer.byteLength(panel.context, "utf8") > DEFAULT_MAX_CONTEXT_BYTES) {
+		throw new Error("Panel shared context exceeds the bounded context limit");
+	}
+	if (panel.reviewers.length < 2) throw new Error("Panel mode requires at least two reviewers");
+	if (panel.reviewers.length > maxReviewers) {
+		throw new Error(
+			`Panel has too many reviewers (${panel.reviewers.length}); configured max is ${maxReviewers}`,
+		);
+	}
+	const ids = panel.reviewers.map((reviewer) => reviewer.id.trim());
+	if (
+		ids.some(
+			(id) =>
+				!id ||
+				Buffer.byteLength(id, "utf8") > MAX_ID_BYTES ||
+				!/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(id),
+		)
+	) {
+		throw new Error("Panel reviewer ids must use 1-256 safe identifier bytes");
+	}
+	if (new Set(ids).size !== ids.length) throw new Error("Panel reviewer ids must be unique");
+	if (panel.reviewers.some((reviewer) => !reviewer.agent.trim())) {
+		throw new Error("Every panel reviewer must name an agent");
+	}
+	if (
+		panel.reviewers.some(
+			(reviewer) => reviewer.focus && Buffer.byteLength(reviewer.focus, "utf8") > MAX_FOCUS_BYTES,
+		)
+	) {
+		throw new Error("Panel reviewer focus exceeds the bounded field limit");
+	}
+	if (!panel.synthesizer.agent.trim()) throw new Error("Panel synthesizer must name an agent");
+	const minValid = panel.minValidReviews ?? 2;
+	if (!Number.isInteger(minValid) || minValid < 2 || minValid > panel.reviewers.length) {
+		throw new Error("minValidReviews must be between two and the reviewer count");
+	}
+}

--- a/packages/pi-subagents/src/panel-prompts.ts
+++ b/packages/pi-subagents/src/panel-prompts.ts
@@ -17,6 +17,10 @@ const PRESET_GUIDANCE: Record<PanelPreset, string> = {
 	custom: "Apply the shared task and your assigned focus without inventing unstated requirements.",
 };
 
+const PROMPT_SEPARATOR = "\n\n";
+const MAX_REVIEWER_SUFFIX_BYTES = 12 * 1024;
+const REVIEWER_SHARED_BYTES = DEFAULT_MAX_CONTEXT_BYTES - MAX_REVIEWER_SUFFIX_BYTES;
+
 export function buildPanelReviewerPrompt(input: {
 	panelId: string;
 	preset: PanelPreset;
@@ -25,15 +29,7 @@ export function buildPanelReviewerPrompt(input: {
 	reviewerId: string;
 	focus?: string;
 }): string {
-	const shared = [
-		`Panel: ${input.panelId}`,
-		`Preset: ${input.preset}`,
-		`Shared task:\n${input.task}`,
-		input.context ? `Shared context:\n${input.context}` : undefined,
-		`Preset guidance:\n${PRESET_GUIDANCE[input.preset]}`,
-	]
-		.filter((part): part is string => Boolean(part))
-		.join("\n\n");
+	const shared = buildReviewerSharedBlock(input);
 	const reviewer = [
 		`Reviewer id: ${input.reviewerId}`,
 		input.focus ? `Reviewer focus:\n${input.focus}` : undefined,
@@ -41,8 +37,8 @@ export function buildPanelReviewerPrompt(input: {
 		`Panel review contract:\n${panelReviewInstruction(input.reviewerId)}`,
 	]
 		.filter((part): part is string => Boolean(part))
-		.join("\n\n");
-	return truncateUtf8(`${shared}\n\n${reviewer}`, DEFAULT_MAX_CONTEXT_BYTES).text;
+		.join(PROMPT_SEPARATOR);
+	return joinWithRequiredSuffix(shared, reviewer);
 }
 
 export function buildPanelSynthesisPrompt(input: {
@@ -64,13 +60,73 @@ export function buildPanelSynthesisPrompt(input: {
 		limitations: review.limitations,
 		provenance: review.provenance,
 	}));
-	const prompt = [
-		`Panel: ${input.panelId}`,
-		`Shared task:\n${input.task}`,
-		`Panel evidence artifacts:\n${JSON.stringify(artifacts)}`,
-		`Failed or invalid reviewers:\n${JSON.stringify(input.failures)}`,
+	const requiredSuffix = [
 		"Reconcile evidence without majority voting and without erasing dissent.",
 		`Panel synthesis contract:\n${panelSynthesisInstruction(validIds, failedIds)}`,
-	].join("\n\n");
-	return truncateUtf8(prompt, DEFAULT_MAX_CONTEXT_BYTES).text;
+	].join(PROMPT_SEPARATOR);
+	const fixedPrefixParts = [
+		`Panel: ${input.panelId}`,
+		"Shared task:\n",
+		`Panel evidence artifacts:\n${JSON.stringify(artifacts)}`,
+		`Failed or invalid reviewers:\n${JSON.stringify(input.failures)}`,
+	];
+	const taskBudget = Math.max(
+		0,
+		DEFAULT_MAX_CONTEXT_BYTES -
+			byteLength(fixedPrefixParts.join(PROMPT_SEPARATOR)) -
+			byteLength(PROMPT_SEPARATOR) -
+			byteLength(requiredSuffix),
+	);
+	const prefix = [
+		fixedPrefixParts[0],
+		`Shared task:\n${truncateUtf8(input.task, taskBudget).text}`,
+		fixedPrefixParts[2],
+		fixedPrefixParts[3],
+	].join(PROMPT_SEPARATOR);
+	return joinWithRequiredSuffix(prefix, requiredSuffix);
+}
+
+function buildReviewerSharedBlock(input: {
+	panelId: string;
+	preset: PanelPreset;
+	task: string;
+	context?: string;
+}): string {
+	const context = input.context || undefined;
+	const hasContext = context !== undefined;
+	const fixedParts = [
+		`Panel: ${input.panelId}`,
+		`Preset: ${input.preset}`,
+		"Shared task:\n",
+		hasContext ? "Shared context:\n" : undefined,
+		`Preset guidance:\n${PRESET_GUIDANCE[input.preset]}`,
+	].filter((part): part is string => part !== undefined);
+	const contentBudget = Math.max(
+		0,
+		REVIEWER_SHARED_BYTES - byteLength(fixedParts.join(PROMPT_SEPARATOR)),
+	);
+	const taskBudget = hasContext ? Math.floor(contentBudget / 2) : contentBudget;
+	const contextBudget = contentBudget - taskBudget;
+	return [
+		fixedParts[0],
+		fixedParts[1],
+		`Shared task:\n${truncateUtf8(input.task, taskBudget).text}`,
+		hasContext ? `Shared context:\n${truncateUtf8(context, contextBudget).text}` : undefined,
+		fixedParts.at(-1),
+	]
+		.filter((part): part is string => part !== undefined)
+		.join(PROMPT_SEPARATOR);
+}
+
+function joinWithRequiredSuffix(prefix: string, suffix: string): string {
+	const suffixBytes = byteLength(PROMPT_SEPARATOR) + byteLength(suffix);
+	if (suffixBytes > DEFAULT_MAX_CONTEXT_BYTES) {
+		throw new Error("Panel prompt contract exceeds the bounded context limit");
+	}
+	const boundedPrefix = truncateUtf8(prefix, DEFAULT_MAX_CONTEXT_BYTES - suffixBytes).text;
+	return `${boundedPrefix}${PROMPT_SEPARATOR}${suffix}`;
+}
+
+function byteLength(value: string): number {
+	return Buffer.byteLength(value, "utf8");
 }

--- a/packages/pi-subagents/src/panel-prompts.ts
+++ b/packages/pi-subagents/src/panel-prompts.ts
@@ -1,0 +1,76 @@
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import {
+	type PanelReview,
+	panelReviewInstruction,
+	panelSynthesisInstruction,
+} from "./panel-contract.js";
+import type { PanelFailure } from "./panel-failure.js";
+import type { PanelPreset } from "./panel-planning.js";
+
+const PRESET_GUIDANCE: Record<PanelPreset, string> = {
+	"code-review":
+		"Review correctness, regressions, baseline security, maintainability, tests, and integration risk.",
+	research:
+		"Assess source quality, evidence traceability, contradictory evidence, uncertainty, and unsupported claims.",
+	"security-review":
+		"Review trust boundaries, authority, injection, data exposure, unsafe side effects, and missing mitigations.",
+	custom: "Apply the shared task and your assigned focus without inventing unstated requirements.",
+};
+
+export function buildPanelReviewerPrompt(input: {
+	panelId: string;
+	preset: PanelPreset;
+	task: string;
+	context?: string;
+	reviewerId: string;
+	focus?: string;
+}): string {
+	const shared = [
+		`Panel: ${input.panelId}`,
+		`Preset: ${input.preset}`,
+		`Shared task:\n${input.task}`,
+		input.context ? `Shared context:\n${input.context}` : undefined,
+		`Preset guidance:\n${PRESET_GUIDANCE[input.preset]}`,
+	]
+		.filter((part): part is string => Boolean(part))
+		.join("\n\n");
+	const reviewer = [
+		`Reviewer id: ${input.reviewerId}`,
+		input.focus ? `Reviewer focus:\n${input.focus}` : undefined,
+		"Work independently and do not assume another reviewer will catch or resolve a problem.",
+		`Panel review contract:\n${panelReviewInstruction(input.reviewerId)}`,
+	]
+		.filter((part): part is string => Boolean(part))
+		.join("\n\n");
+	return truncateUtf8(`${shared}\n\n${reviewer}`, DEFAULT_MAX_CONTEXT_BYTES).text;
+}
+
+export function buildPanelSynthesisPrompt(input: {
+	panelId: string;
+	task: string;
+	reviews: readonly PanelReview[];
+	failures: readonly PanelFailure[];
+}): string {
+	const validIds = input.reviews.map((review) => review.reviewerId);
+	const failedIds = input.failures
+		.map((failure) => failure.reviewerId)
+		.filter((id): id is string => Boolean(id));
+	const artifacts = input.reviews.map((review) => ({
+		reviewerId: review.reviewerId,
+		disposition: review.disposition,
+		blocking: review.blocking,
+		findings: review.findings,
+		missingChecks: review.missingChecks,
+		limitations: review.limitations,
+		provenance: review.provenance,
+	}));
+	const prompt = [
+		`Panel: ${input.panelId}`,
+		`Shared task:\n${input.task}`,
+		`Panel evidence artifacts:\n${JSON.stringify(artifacts)}`,
+		`Failed or invalid reviewers:\n${JSON.stringify(input.failures)}`,
+		"Reconcile evidence without majority voting and without erasing dissent.",
+		`Panel synthesis contract:\n${panelSynthesisInstruction(validIds, failedIds)}`,
+	].join("\n\n");
+	return truncateUtf8(prompt, DEFAULT_MAX_CONTEXT_BYTES).text;
+}

--- a/packages/pi-subagents/src/panel-reconciliation.ts
+++ b/packages/pi-subagents/src/panel-reconciliation.ts
@@ -1,0 +1,57 @@
+import type { PanelFinding, PanelReview } from "./panel-contract.js";
+import type { PanelFailure } from "./panel-failure.js";
+
+export interface PanelBlockingObjection {
+	reviewerId: string;
+	finding: PanelFinding;
+}
+
+export type PanelReconciliation =
+	| {
+			kind: "ready-for-synthesis";
+			reviews: PanelReview[];
+			failures: PanelFailure[];
+			blockingObjections: PanelBlockingObjection[];
+			verified: false;
+	  }
+	| {
+			kind: "insufficient-panel";
+			partialReviews: PanelReview[];
+			failures: PanelFailure[];
+			blockingObjections: PanelBlockingObjection[];
+			consensus: false;
+	  };
+
+export function reconcilePanel(input: {
+	reviews: PanelReview[];
+	failures: PanelFailure[];
+	minValidReviews: number;
+}): PanelReconciliation {
+	const reviews = [...input.reviews].sort((left, right) =>
+		left.reviewerId.localeCompare(right.reviewerId),
+	);
+	const failures = [...input.failures].sort((left, right) =>
+		(left.reviewerId ?? "").localeCompare(right.reviewerId ?? ""),
+	);
+	const blockingObjections = reviews.flatMap((review) =>
+		review.blocking
+			? review.findings.map((finding) => ({ reviewerId: review.reviewerId, finding }))
+			: [],
+	);
+	if (reviews.length < input.minValidReviews) {
+		return {
+			kind: "insufficient-panel",
+			partialReviews: reviews,
+			failures,
+			blockingObjections,
+			consensus: false,
+		};
+	}
+	return {
+		kind: "ready-for-synthesis",
+		reviews,
+		failures,
+		blockingObjections,
+		verified: false,
+	};
+}

--- a/packages/pi-subagents/src/panel-render.ts
+++ b/packages/pi-subagents/src/panel-render.ts
@@ -1,0 +1,103 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import type { SubagentParams } from "./params.js";
+import { safeBlock, safeLine } from "./render-common.js";
+import type { SubagentDetails } from "./runner.js";
+
+export function renderPanelCall(args: SubagentParams, theme: Theme): Text | undefined {
+	const panel = args.panel;
+	if (!panel) return undefined;
+	const scope = args.agentScope ?? "user";
+	let text =
+		theme.fg("toolTitle", theme.bold("subagent ")) +
+		theme.fg("accent", `panel ${panel.preset ?? "custom"} (${panel.reviewers.length} reviewers)`) +
+		theme.fg("muted", ` [${scope}]`);
+	text += `\n  ${theme.fg("dim", preview(panel.task, 80))}`;
+	for (const reviewer of panel.reviewers.slice(0, 3)) {
+		text += `\n  ${theme.fg("muted", `${safeLine(reviewer.id, "reviewer", 256)}:`)} ${theme.fg("accent", safeLine(reviewer.agent, "agent", 256))}`;
+		if (reviewer.focus) text += theme.fg("dim", ` ${preview(reviewer.focus, 40)}`);
+	}
+	if (panel.reviewers.length > 3) {
+		text += `\n  ${theme.fg("muted", `... +${panel.reviewers.length - 3} more`)}`;
+	}
+	text += `\n  ${theme.fg("muted", "synthesis → ")}${theme.fg("accent", safeLine(panel.synthesizer.agent, "agent", 256))}`;
+	return new Text(text, 0, 0);
+}
+
+export function renderPanelResult(
+	details: SubagentDetails,
+	expanded: boolean,
+	isPartial: boolean,
+	theme: Theme,
+): Text | undefined {
+	const panel = details.panel;
+	if (details.mode !== "panel" || !panel) return undefined;
+	const running = isPartial || panel.state === "running";
+	const status = running ? "running" : panel.state;
+	const color =
+		status === "completed"
+			? "success"
+			: status === "running" || status === "degraded"
+				? "warning"
+				: "error";
+	let text = `${theme.fg(color, status)} ${theme.fg("accent", safeLine(panel.preset, "panel", 128))}`;
+	text += theme.fg(
+		"muted",
+		` · valid ${panel.validReviewCount}/${panel.reviewerIds.length} · failed ${panel.failedReviewCount} · blockers ${panel.blockingObjectionCount} · dissent ${panel.dissentCount}`,
+	);
+	if (panel.synthesis) {
+		text += `\n${theme.fg("toolOutput", safeBlock(panel.synthesis.summary, "", 8 * 1024))}`;
+	} else if (panel.state === "insufficient-panel") {
+		text += `\n${theme.fg("warning", "Synthesis skipped because too few valid reviews remained.")}`;
+	}
+	if (!expanded) return new Text(text, 0, 0);
+
+	text += `\n\n${theme.fg("muted", "Shared task: ")}${theme.fg("dim", safeBlock(panel.sharedTaskPreview, "", 2 * 1024))}`;
+	text += `\n\n${theme.fg("muted", "Reviewers:")}`;
+	for (const reviewerId of panel.reviewerIds) {
+		const artifact = panel.evidence.find((candidate) => candidate.reviewerId === reviewerId);
+		const failure = panel.failures.find((candidate) => candidate.reviewerId === reviewerId);
+		const result = details.results.find(
+			(candidate) => candidate.step === panel.reviewerIds.indexOf(reviewerId) + 1,
+		);
+		const model = result?.actualModel ?? result?.model;
+		text += `\n  ${theme.fg("accent", safeLine(reviewerId, "reviewer", 256))}`;
+		if (model) text += theme.fg("muted", ` · ${safeLine(model, "", 256)}`);
+		if (artifact) {
+			text += theme.fg(
+				"muted",
+				` · ${artifact.review.disposition} · revision ${artifact.revision}`,
+			);
+			for (const finding of artifact.review.findings) {
+				text += `\n    ${theme.fg(finding.severity === "critical" || finding.severity === "high" ? "error" : "warning", `[${finding.severity}]`)} ${safeLine(finding.title, "finding", 512)}`;
+			}
+		} else if (failure) {
+			text += theme.fg("error", ` · ${safeLine(failure.kind, "failed", 128)}`);
+		}
+	}
+	if (panel.synthesis?.disagreements.length) {
+		text += `\n\n${theme.fg("muted", "Disagreements:")}`;
+		for (const disagreement of panel.synthesis.disagreements) {
+			text += `\n  ${safeLine(disagreement.summary, "disagreement", 1024)}`;
+		}
+	}
+	if (panel.synthesis?.objections.length) {
+		text += `\n\n${theme.fg("muted", "Blocking objections:")}`;
+		for (const objection of panel.synthesis.objections) {
+			text += `\n  ${safeLine(`${objection.reviewerId}/${objection.findingId}: ${objection.resolution}`, "objection", 1024)}`;
+		}
+	}
+	const limitations = panel.synthesis?.limitations ?? [];
+	if (limitations.length) {
+		text += `\n\n${theme.fg("muted", "Limitations:")}`;
+		for (const limitation of limitations) text += `\n  ${safeLine(limitation, "", 1024)}`;
+	}
+	text += `\n\n${theme.fg("muted", `Budget: review ${panel.budgets.reviewMs}ms · finalization ${panel.budgets.finalizationMs}ms · synthesis ${panel.budgets.synthesisMs}ms · cleanup ${panel.budgets.cleanupMs}ms`)}`;
+	text += `\n${theme.fg("muted", `Cleanup: ${panel.cleanupComplete ? "complete" : "pending"}`)}`;
+	return new Text(text, 0, 0);
+}
+
+function preview(value: unknown, maxLength: number): string {
+	const text = safeLine(value, "", 2 * 1024);
+	return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+}

--- a/packages/pi-subagents/src/params.ts
+++ b/packages/pi-subagents/src/params.ts
@@ -3,6 +3,7 @@ import { type Static, Type } from "typebox";
 import { THINKING_LEVELS } from "./agents.js";
 import { DelegationContractSchema } from "./delegation-contract.js";
 import { MAX_CONFIGURABLE_PARALLEL_TASKS, MAX_SUBAGENT_TIMEOUT_MS } from "./limits.js";
+import { PANEL_PRESETS } from "./panel-planning.js";
 import { SUBAGENT_RESULT_FORMATS } from "./result-contract.js";
 import { MAX_SUBAGENT_TOOL_CALLS, MAX_SUBAGENT_TURNS } from "./turn-budget.js";
 
@@ -145,6 +146,48 @@ const AggregatorItem = Type.Object(
 	},
 );
 
+const PanelReviewerItem = Type.Object(
+	{
+		id: Type.String({ minLength: 1, maxLength: 256 }),
+		agent: Type.String({ minLength: 1 }),
+		focus: Type.Optional(Type.String({ maxLength: 8 * 1024 })),
+		timeoutMs: Type.Optional(TimeoutMs),
+		...TurnLimitFields,
+		thinkingLevel: Type.Optional(ThinkingLevelSchema),
+	},
+	{ additionalProperties: false },
+);
+
+const PanelSynthesizerItem = Type.Object(
+	{
+		agent: Type.String({ minLength: 1 }),
+		timeoutMs: Type.Optional(TimeoutMs),
+		...TurnLimitFields,
+		thinkingLevel: Type.Optional(ThinkingLevelSchema),
+	},
+	{ additionalProperties: false },
+);
+
+const PanelItem = Type.Object(
+	{
+		id: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
+		preset: Type.Optional(StringEnum(PANEL_PRESETS, { default: "custom" })),
+		task: Type.String({ minLength: 1, maxLength: 50 * 1024 }),
+		context: Type.Optional(Type.String({ maxLength: 50 * 1024 })),
+		reviewers: Type.Array(PanelReviewerItem, {
+			minItems: 2,
+			maxItems: MAX_CONFIGURABLE_PARALLEL_TASKS,
+		}),
+		synthesizer: PanelSynthesizerItem,
+		minValidReviews: Type.Optional(Type.Integer({ minimum: 2 })),
+	},
+	{
+		additionalProperties: false,
+		description:
+			"One bounded independent review round followed by one evidence-preserving synthesis when enough valid reviews remain.",
+	},
+);
+
 const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
 	description:
 		'Per-invocation custom agent scope. Default: "user". Use "project" for project-local agents or "both" for user and project agents; this is a tool argument, not a pi-subagents.json setting.',
@@ -166,6 +209,7 @@ export const SubagentParams = Type.Object({
 		Type.Array(ChainItem, { description: "Array of {agent, task} for sequential execution" }),
 	),
 	aggregator: Type.Optional(AggregatorItem),
+	panel: Type.Optional(PanelItem),
 	workflow: Type.Optional(
 		Type.Object(
 			{
@@ -198,7 +242,7 @@ export const SubagentParams = Type.Object({
 	totalTimeoutMs: Type.Optional(
 		Type.Number({
 			description:
-				"Overall blocking-workflow deadline in milliseconds, including queued work, workflow tasks, chain steps, and fan-in.",
+				"Overall blocking-workflow deadline in milliseconds, including queued work, workflow tasks, panel phases, chain steps, and fan-in.",
 			minimum: 1,
 			maximum: MAX_SUBAGENT_TIMEOUT_MS,
 		}),

--- a/packages/pi-subagents/src/render.ts
+++ b/packages/pi-subagents/src/render.ts
@@ -8,6 +8,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import type { AgentScope, SubagentThinkingLevel } from "./agents.js";
+import { renderPanelCall, renderPanelResult } from "./panel-render.js";
 import { hasUsableAggregator, type SubagentParams } from "./params.js";
 import { expansionHint, formatToolActivity, safeBlock, safeLine } from "./render-common.js";
 import {
@@ -203,6 +204,8 @@ export function renderSubagentCall(args: SubagentParams, theme: Theme) {
 		typeof args.maxToolCalls === "number" ? `tools:${args.maxToolCalls}` : undefined,
 	].filter((value): value is string => Boolean(value));
 	const limitText = limits.length > 0 ? ` · ${limits.join(" · ")}` : "";
+	const panelCall = renderPanelCall(args, theme);
+	if (panelCall) return panelCall;
 	if (args.workflow && args.workflow.tasks.length > 0) {
 		let text =
 			theme.fg("toolTitle", theme.bold("subagent ")) +
@@ -273,6 +276,10 @@ export function renderSubagentResult(
 	theme: Theme,
 ) {
 	const rawDetails = result.details as SubagentDetails | undefined;
+	if (rawDetails?.mode === "panel") {
+		const panelResult = renderPanelResult(rawDetails, expanded, isPartial, theme);
+		if (panelResult) return panelResult;
+	}
 	if (!rawDetails || rawDetails.results.length === 0) {
 		const text = result.content[0];
 		return new Text(

--- a/packages/pi-subagents/src/runner.ts
+++ b/packages/pi-subagents/src/runner.ts
@@ -22,6 +22,10 @@ import {
 } from "./limits.js";
 import type { OrchestrationMetrics } from "./orchestration-metrics.js";
 import { type ClassifiedSubagentOutcome, classifyStructuredOutcome } from "./outcome.js";
+import type { PanelSynthesis } from "./panel-contract.js";
+import type { PanelEvidenceArtifact } from "./panel-evidence.js";
+import type { PanelFailure } from "./panel-failure.js";
+import type { PanelPhaseBudgets, PanelPreset } from "./panel-planning.js";
 import { resolvePiInvocation } from "./pi-invocation.js";
 import { JsonLineDecoder } from "./protocol.js";
 import {
@@ -114,8 +118,26 @@ export interface SingleResult {
 	capabilityGrant?: CapabilityGrant;
 }
 
+export interface PanelDetails {
+	id: string;
+	preset: PanelPreset;
+	sharedTaskPreview: string;
+	state: "running" | "completed" | "degraded" | "insufficient-panel" | "failed" | "cancelled";
+	reviewerIds: string[];
+	validReviewCount: number;
+	failedReviewCount: number;
+	blockingObjectionCount: number;
+	dissentCount: number;
+	budgets: PanelPhaseBudgets;
+	evidence: PanelEvidenceArtifact[];
+	failures: PanelFailure[];
+	synthesis?: PanelSynthesis;
+	synthesizerResult?: SingleResult;
+	cleanupComplete: boolean;
+}
+
 export interface SubagentDetails {
-	mode: "single" | "parallel" | "chain" | "workflow";
+	mode: "single" | "parallel" | "chain" | "workflow" | "panel";
 	agentScope: AgentScope;
 	projectAgentsDir: string | null;
 	results: SingleResult[];
@@ -123,6 +145,7 @@ export interface SubagentDetails {
 	workflow?: WorkItemLedgerSnapshot;
 	schedulerDecisions?: SchedulingDecision[];
 	metrics?: OrchestrationMetrics;
+	panel?: PanelDetails;
 	isError?: boolean;
 }
 

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -4,10 +4,7 @@
  * Spawns a separate `pi` process for each subagent invocation,
  * giving it an isolated context window.
  *
- * Supports three modes:
- *   - Single: { agent: "name", task: "..." }
- *   - Parallel: { tasks: [{ agent: "name", task: "..." }, ...] }
- *   - Chain: { chain: [{ agent: "name", task: "... {previous} ..." }, ...] }
+ * Supports blocking single, parallel, chain, workflow, and panel modes.
  *
  * Uses JSON mode to capture structured output from subagents.
  */
@@ -165,11 +162,21 @@ function registerBlockingSubagent(
 	getSettings: () => SubagentSettings | undefined,
 ): (catalog: string) => void {
 	let catalog = "";
+	const activeControllers = new Set<AbortController>();
+	const activeWork = new Set<Promise<unknown>>();
+	const cancelAndWaitForWork = async (reason: string) => {
+		for (const controller of activeControllers) {
+			controller.abort(new DOMException(reason, "AbortError"));
+		}
+		await Promise.allSettled([...activeWork]);
+	};
+	pi.on("session_start", () => cancelAndWaitForWork("Blocking subagent session replaced"));
+	pi.on("session_shutdown", () => cancelAndWaitForWork("Blocking subagent session shut down"));
 	const baseDescription = () =>
 		[
 			"Run specialized subagents as a blocking operation with isolated contexts.",
 			"The call blocks the main agent until every worker and optional aggregator finishes, so queued steering waits.",
-			"Modes: single (agent + task), parallel (tasks array), chain (sequential with {previous} placeholder), or workflow (named dependency tasks with optional capability routing).",
+			"Modes: single (agent + task), parallel (tasks array), chain (sequential with {previous} placeholder), workflow (named dependency tasks with optional capability routing), or panel (independent reviewers plus evidence-preserving synthesis).",
 			"Parallel mode may include an aggregator fan-in step; workflow mode validates dependencies, authority, artifacts, scope conflicts, retries, and hedging before scheduling. Use subagent_consult instead for one synchronous child that must be executor-constrained to read-only tools.",
 			'Default agent scope is "user" (from ~/.pi/agent/agents).',
 			`To enable project-local agents in ${CONFIG_DIR_NAME}/agents, pass agentScope: "both" (or "project") as a top-level argument for that call.`,
@@ -180,10 +187,11 @@ function registerBlockingSubagent(
 		"Use subagent only when delegation fits; the main agent should decide how many subagents to spawn from task shape instead of waiting for the user to specify a count.",
 		"Use no subagent for simple answers, quick targeted edits, latency-sensitive one-step work, tasks requiring frequent user back-and-forth, or critical-path work the main agent can perform directly.",
 		"Use the blocking subagent tool only when delegated outputs are required before the main agent's next action and waiting is intentional; the main agent cannot process queued steering until the call returns.",
-		"Use a blocking subagent single, parallel, chain, workflow, or fan-in call only when synchronous context or output isolation is worth making the main agent unavailable while it runs.",
+		"Use a blocking subagent single, parallel, chain, workflow, panel, or fan-in call only when synchronous context or output isolation is worth making the main agent unavailable while it runs.",
 		`If a blocking parallel subagent call is genuinely required, keep tasks independent, stay within the configured max ${resolveBlockingMaxParallelTasks(getSettings())}, and avoid write-heavy implementation touching the same files or shared state.`,
 		"For parallel subagent calls, omit the aggregator key entirely unless a fan-in step is required; do not send null, empty strings, or an empty object for unused optional fields.",
 		"Use workflow mode for explicit dependencies or capability routing; declare read/write or ownership scopes, require structured-v2 artifacts when downstream tasks consume them, and use retry or hedging only with the required side-effect contract.",
+		"Use panel mode only for consequential review or research that benefits from at least two independent reviewers and one bounded synthesis; agreement is not proof, dissent and blocking objections remain visible, and simple or latency-sensitive work should not use a panel.",
 		'Do not use subagent with project-local agents unless the user explicitly wants project agents or sets agentScope to "project" or "both"; keep confirmation enabled for untrusted repositories.',
 		"When using subagent, write self-contained tasks with file paths, context, expected output, and whether the subagent may edit files.",
 		"Set subagent timeoutMs to the shortest realistic work deadline for the task difficulty, just as thinkingLevel should match reasoning difficulty; split oversized tasks instead of extending the deadline merely to compensate for broad scope. Use totalTimeoutMs to cap an entire blocking workflow, idleTimeoutMs for stalled work, and maxTurns or maxToolCalls to stop repeated work without progress. Every budget stop preserves a bounded checkpoint and may make one separately bounded summary attempt.",
@@ -198,7 +206,26 @@ function registerBlockingSubagent(
 		parameters: SubagentParams,
 
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
-			return executeSubagent(toolCallId, params, signal, onUpdate, ctx, getSettings());
+			const lifecycleController = new AbortController();
+			activeControllers.add(lifecycleController);
+			const effectiveSignal = signal
+				? AbortSignal.any([signal, lifecycleController.signal])
+				: lifecycleController.signal;
+			const work = executeSubagent(
+				toolCallId,
+				params,
+				effectiveSignal,
+				onUpdate,
+				ctx,
+				getSettings(),
+			);
+			activeWork.add(work);
+			try {
+				return await work;
+			} finally {
+				activeControllers.delete(lifecycleController);
+				activeWork.delete(work);
+			}
 		},
 
 		renderCall(args, theme) {

--- a/packages/pi-subagents/src/workspace.ts
+++ b/packages/pi-subagents/src/workspace.ts
@@ -14,24 +14,16 @@ export interface IsolatedWorkspace {
 	repositoryRoot: string;
 }
 
+export async function assertWorkspaceIsolationReady(cwd: string): Promise<void> {
+	await resolveWorkspaceBase(cwd);
+}
+
 export class WorkspaceManager {
 	private readonly owned = new Map<string, IsolatedWorkspace>();
 
 	async create(ownerId: string, cwd: string): Promise<IsolatedWorkspace> {
 		if (this.owned.has(ownerId)) throw new Error(`Workspace owner already exists: ${ownerId}`);
-		const resolvedCwd = await fs.promises.realpath(path.resolve(cwd));
-		const reportedRepositoryRoot = (
-			await execFileAsync("git", ["-C", resolvedCwd, "rev-parse", "--show-toplevel"])
-		).stdout.trim();
-		const repositoryRoot = await fs.promises.realpath(reportedRepositoryRoot);
-		const relativeCwd = path.relative(repositoryRoot, resolvedCwd);
-		if (relativeCwd.startsWith("..") || path.isAbsolute(relativeCwd)) {
-			throw new Error("Subagent cwd is outside the Git repository");
-		}
-		const status = (await execFileAsync("git", ["-C", repositoryRoot, "status", "--porcelain"]))
-			.stdout;
-		if (status.trim())
-			throw new Error("Isolated subagent workspace requires a clean Git repository");
+		const { repositoryRoot, relativeCwd } = await resolveWorkspaceBase(cwd);
 		const rootPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), WORKTREE_PREFIX));
 		let registered = false;
 		try {
@@ -149,6 +141,26 @@ export class WorkspaceManager {
 			return false;
 		}
 	}
+}
+
+async function resolveWorkspaceBase(
+	cwd: string,
+): Promise<{ repositoryRoot: string; relativeCwd: string }> {
+	const resolvedCwd = await fs.promises.realpath(path.resolve(cwd));
+	const reportedRepositoryRoot = (
+		await execFileAsync("git", ["-C", resolvedCwd, "rev-parse", "--show-toplevel"])
+	).stdout.trim();
+	const repositoryRoot = await fs.promises.realpath(reportedRepositoryRoot);
+	const relativeCwd = path.relative(repositoryRoot, resolvedCwd);
+	if (relativeCwd.startsWith("..") || path.isAbsolute(relativeCwd)) {
+		throw new Error("Subagent cwd is outside the Git repository");
+	}
+	const status = (await execFileAsync("git", ["-C", repositoryRoot, "status", "--porcelain"]))
+		.stdout;
+	if (status.trim()) {
+		throw new Error("Isolated subagent workspace requires a clean Git repository");
+	}
+	return { repositoryRoot, relativeCwd };
 }
 
 function findGeneratedWorktreeRoot(cwd: string): string | undefined {

--- a/packages/pi-subagents/test/panel-execution.test.ts
+++ b/packages/pi-subagents/test/panel-execution.test.ts
@@ -361,6 +361,53 @@ test("panel preserves valid reviews when synthesis returns an invalid contract",
 	}
 });
 
+test("panel marks valid synthesis output from an errored process as failed", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-synthesis-exit-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	writeFileSync(
+		fakePi,
+		[
+			"const task=process.argv.at(-1)??'';const match=task.match(/reviewerId \\\"([^\\\"]+)/);let result;",
+			"if(match){result={version:'pi-subagents:panel-review:v1',reviewerId:match[1],disposition:'pass',blocking:false,findings:[],missingChecks:[],limitations:[]};}",
+			"else{result={version:'pi-subagents:panel-synthesis:v1',disposition:'pass',summary:'valid but errored',validReviewerIds:['a','b'],failedReviewerIds:[],agreements:[],disagreements:[],objections:[],limitations:[]};}",
+			"const message={role:'assistant',content:[{type:'text',text:JSON.stringify(result)}],stopReason:'stop',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+			"if(!match)process.exitCode=1;",
+		].join(""),
+	);
+	const restore = useFakePiPackage(root, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const result = await tool.execute(
+			"panel-synthesis-exit",
+			{
+				panel: {
+					task: "Review",
+					reviewers: [
+						{ id: "a", agent: "reviewer" },
+						{ id: "b", agent: "reviewer" },
+					],
+					synthesizer: { agent: "reviewer" },
+				},
+			},
+			undefined,
+			undefined,
+			createMockContext().ctx,
+		);
+		assert.equal(result.isError, true);
+		assert.equal(result.details.panel.state, "failed");
+		assert.equal(result.details.panel.synthesis?.summary, "valid but errored");
+		assert.equal(
+			result.details.workflow.items.find((item) => item.id === "synthesis")?.state,
+			"failed",
+		);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("panel retries transient transport failures once within the review phase", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-retry-"));
 	const fakePi = path.join(root, "fake-pi.mjs");
@@ -542,7 +589,50 @@ test("an insufficient panel returns partial evidence and never launches synthesi
 	}
 });
 
-test("panel semantic progress stops repeated activity without blind retries", async () => {
+test("ordinary reviewer progress updates do not trigger a semantic stall", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-progress-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	writeFileSync(
+		fakePi,
+		[
+			"const task=process.argv.at(-1)??'';const match=task.match(/reviewerId \\\"([^\\\"]+)/);let result;",
+			"if(match){for(let i=0;i<10;i++){const progress={role:'assistant',content:[{type:'text',text:'ordinary tool progress '+i}],stopReason:'toolUse',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message:progress})+'\\n');await new Promise(resolve=>setTimeout(resolve,20));}result={version:'pi-subagents:panel-review:v1',reviewerId:match[1],disposition:'pass',blocking:false,findings:[],missingChecks:[],limitations:[]};}",
+			"else{result={version:'pi-subagents:panel-synthesis:v1',disposition:'pass',summary:'progress completed',validReviewerIds:['a','b'],failedReviewerIds:[],agreements:[],disagreements:[],objections:[],limitations:[]};}",
+			"const message={role:'assistant',content:[{type:'text',text:JSON.stringify(result)}],stopReason:'stop',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	const restore = useFakePiPackage(root, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const result = await tool.execute(
+			"panel-progress",
+			{
+				totalTimeoutMs: 5_000,
+				panel: {
+					task: "Review after ordinary progress",
+					reviewers: [
+						{ id: "a", agent: "reviewer" },
+						{ id: "b", agent: "reviewer" },
+					],
+					synthesizer: { agent: "reviewer" },
+				},
+			},
+			undefined,
+			undefined,
+			createMockContext().ctx,
+		);
+		assert.equal(result.details.panel.state, "completed");
+		assert.equal(result.details.panel.validReviewCount, 2);
+		assert.equal(result.details.panel.failures.length, 0);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("panel semantic progress stops repeated evidence states without blind retries", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-stall-"));
 	const fakePi = path.join(root, "fake-pi.mjs");
 	const log = path.join(root, "launches.txt");
@@ -551,8 +641,9 @@ test("panel semantic progress stops repeated activity without blind retries", as
 		[
 			"import{appendFileSync}from'node:fs';",
 			`appendFileSync(${JSON.stringify(log)},'launch\\n');`,
-			"for(let i=0;i<8;i++){const message={role:'assistant',content:[{type:'text',text:'activity '+i}],stopReason:'toolUse',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');}",
-			"setInterval(()=>{},1000);",
+			"const task=process.argv.at(-1)??'';const match=task.match(/reviewerId \\\"([^\\\"]+)/);",
+			"if(match){const result={version:'pi-subagents:panel-review:v1',reviewerId:match[1],disposition:'partial',blocking:false,findings:[],missingChecks:['unfinished'],limitations:[]};for(let i=0;i<9;i++){const message={role:'assistant',content:[{type:'text',text:JSON.stringify(result)}],stopReason:'toolUse',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');await new Promise(resolve=>setTimeout(resolve,20));}setInterval(()=>{},1000);}",
+			"else{const result={version:'pi-subagents:panel-synthesis:v1',disposition:'partial',summary:'partial evidence preserved',validReviewerIds:['a','b'],failedReviewerIds:['a','b'],agreements:[],disagreements:[],objections:[],limitations:['reviewers stalled']};const message={role:'assistant',content:[{type:'text',text:JSON.stringify(result)}],stopReason:'stop',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');}",
 		].join(""),
 	);
 	const restore = useFakePiPackage(root, fakePi);
@@ -577,14 +668,150 @@ test("panel semantic progress stops repeated activity without blind retries", as
 			undefined,
 			createMockContext().ctx,
 		);
-		assert.equal(result.details.panel.state, "insufficient-panel");
+		assert.equal(result.details.panel.state, "degraded");
+		assert.equal(result.details.panel.validReviewCount, 2);
 		assert.deepEqual(
 			result.details.panel.failures.map((failure) => failure.kind),
 			["semantic-stall", "semantic-stall"],
 		);
-		assert.equal(readFileSync(log, "utf8").trim().split("\n").length, 2);
+		assert.equal(readFileSync(log, "utf8").trim().split("\n").length, 3);
 	} finally {
 		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("pre-cancelled panel setup creates no disposable worktrees", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-setup-cancel-"));
+	const repository = path.join(root, "repository");
+	const worktreeLog = path.join(root, "worktrees.txt");
+	mkdirSync(repository);
+	writeFileSync(path.join(repository, "README.md"), "panel\n");
+	execFileSync("git", ["init", "-q", repository]);
+	execFileSync("git", ["-C", repository, "add", "README.md"]);
+	execFileSync("git", [
+		"-c",
+		"user.name=Panel Test",
+		"-c",
+		"user.email=panel@example.invalid",
+		"-c",
+		"commit.gpgsign=false",
+		"-C",
+		repository,
+		"commit",
+		"-qm",
+		"test fixture",
+	]);
+	const hook = path.join(repository, ".git", "hooks", "post-checkout");
+	writeFileSync(hook, `#!/bin/sh\nprintf '%s\\n' "$PWD" >> ${JSON.stringify(worktreeLog)}\n`);
+	chmodSync(hook, 0o755);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const controller = new AbortController();
+		controller.abort(new DOMException("test setup cancellation", "AbortError"));
+		await assert.rejects(
+			() =>
+				tool.execute(
+					"panel-setup-cancel",
+					{
+						panel: {
+							task: "Do not create worktrees",
+							reviewers: [
+								{ id: "a", agent: "worker" },
+								{ id: "b", agent: "worker" },
+							],
+							synthesizer: { agent: "worker" },
+						},
+					},
+					controller.signal,
+					undefined,
+					createMockContext({ cwd: repository, isProjectTrusted: () => true }).ctx,
+				),
+			/abort|cancel/i,
+		);
+		assert.equal(existsSync(worktreeLog), false);
+		assert.equal(
+			execFileSync("git", ["-C", repository, "worktree", "list", "--porcelain"], {
+				encoding: "utf8",
+			})
+				.trim()
+				.split("\n\n").length,
+			1,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("cancellation during worktree creation stops later setup and cleans partial state", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-setup-race-"));
+	const repository = path.join(root, "repository");
+	const worktreeLog = path.join(root, "worktrees.txt");
+	const releaseHook = path.join(root, "release-hook");
+	mkdirSync(repository);
+	writeFileSync(path.join(repository, "README.md"), "panel\n");
+	execFileSync("git", ["init", "-q", repository]);
+	execFileSync("git", ["-C", repository, "add", "README.md"]);
+	execFileSync("git", [
+		"-c",
+		"user.name=Panel Test",
+		"-c",
+		"user.email=panel@example.invalid",
+		"-c",
+		"commit.gpgsign=false",
+		"-C",
+		repository,
+		"commit",
+		"-qm",
+		"test fixture",
+	]);
+	const hook = path.join(repository, ".git", "hooks", "post-checkout");
+	writeFileSync(
+		hook,
+		`#!/bin/sh\nprintf '%s\\n' "$PWD" >> ${JSON.stringify(worktreeLog)}\nwhile [ ! -f ${JSON.stringify(releaseHook)} ]; do sleep 0.01; done\n`,
+	);
+	chmodSync(hook, 0o755);
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+	const controller = new AbortController();
+	const execution = tool.execute(
+		"panel-setup-race",
+		{
+			panel: {
+				task: "Stop setup after cancellation",
+				reviewers: [
+					{ id: "a", agent: "worker" },
+					{ id: "b", agent: "worker" },
+				],
+				synthesizer: { agent: "worker" },
+			},
+		},
+		controller.signal,
+		undefined,
+		createMockContext({ cwd: repository, isProjectTrusted: () => true }).ctx,
+	);
+	try {
+		await waitFor(() => existsSync(worktreeLog));
+		controller.abort(new DOMException("cancelled during workspace setup", "AbortError"));
+		writeFileSync(releaseHook, "release\n");
+		await assert.rejects(() => execution, /abort|cancel/i);
+		const createdWorktrees = readFileSync(worktreeLog, "utf8").trim().split("\n");
+		assert.equal(createdWorktrees.length, 1);
+		assert.equal(existsSync(createdWorktrees[0]), false);
+		assert.equal(
+			execFileSync("git", ["-C", repository, "worktree", "list", "--porcelain"], {
+				encoding: "utf8",
+			})
+				.trim()
+				.split("\n\n").length,
+			1,
+		);
+	} finally {
+		writeFileSync(releaseHook, "release\n");
+		await execution.catch(() => undefined);
 		rmSync(root, { recursive: true, force: true });
 	}
 });

--- a/packages/pi-subagents/test/panel-execution.test.ts
+++ b/packages/pi-subagents/test/panel-execution.test.ts
@@ -1,0 +1,715 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import subagents from "../src/subagents.js";
+
+const CORE_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
+
+type PanelTestResult = {
+	content: Array<{ type: string; text: string }>;
+	details: {
+		mode: string;
+		results: Array<{
+			attemptCount?: number;
+			executionPlan?: { effectiveTools?: string[]; workspaceMode?: string };
+		}>;
+		panel: {
+			state: string;
+			validReviewCount: number;
+			blockingObjectionCount: number;
+			evidence: unknown[];
+			failures: Array<{ kind: string }>;
+			synthesis?: { summary: string };
+			cleanupComplete: boolean;
+		};
+		workflow: { items: Array<{ id: string; state: string }> };
+	};
+	isError?: boolean;
+};
+
+type PanelTestTool = {
+	execute: (...args: unknown[]) => Promise<PanelTestResult>;
+};
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error("Timed out waiting for test readiness");
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+function useFakePiPackage(packageDir: string, cliPath: string): () => void {
+	writeFileSync(
+		path.join(packageDir, "package.json"),
+		JSON.stringify({ name: CORE_PACKAGE_NAME, bin: { pi: path.relative(packageDir, cliPath) } }),
+	);
+	const previous = process.env.PI_PACKAGE_DIR;
+	process.env.PI_PACKAGE_DIR = packageDir;
+	return () => {
+		if (previous === undefined) delete process.env.PI_PACKAGE_DIR;
+		else process.env.PI_PACKAGE_DIR = previous;
+	};
+}
+
+test("blocking tool exposes a bounded first-class panel schema and guidance", () => {
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const tool = mock.tools.find((candidate) => candidate.name === "subagent");
+	const schema = tool?.parameters as {
+		properties?: Record<
+			string,
+			{
+				enum?: string[];
+				properties?: Record<string, { enum?: string[]; minItems?: number; maxItems?: number }>;
+			}
+		>;
+	};
+	assert.deepEqual(schema.properties?.panel?.properties?.preset?.enum, [
+		"code-review",
+		"research",
+		"security-review",
+		"custom",
+	]);
+	assert.equal(schema.properties?.panel?.properties?.reviewers?.minItems, 2);
+	assert.match(String(tool?.description), /panel/i);
+	const guidelines = tool?.promptGuidelines;
+	assert.ok(Array.isArray(guidelines));
+	assert.match(guidelines.join("\n"), /agreement is not proof/i);
+});
+
+test("panel mode rejects mixed modes and unknown agents before launch", async () => {
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+	const panel = {
+		task: "Review",
+		reviewers: [
+			{ id: "a", agent: "reviewer" },
+			{ id: "b", agent: "reviewer" },
+		],
+		synthesizer: { agent: "reviewer" },
+	};
+	const mixed = await tool.execute(
+		"panel-mixed",
+		{ agent: "reviewer", task: "single", panel },
+		undefined,
+		undefined,
+		createMockContext().ctx,
+	);
+	assert.match(mixed.content[0].text, /exactly one mode/i);
+	await assert.rejects(
+		() =>
+			tool.execute(
+				"panel-unknown",
+				{ panel: { ...panel, synthesizer: { agent: "missing" } } },
+				undefined,
+				undefined,
+				createMockContext().ctx,
+			),
+		/unknown panel agent/i,
+	);
+});
+
+test("panel project agents use the existing trust and confirmation boundary", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-project-agent-"));
+	const agentsDir = path.join(root, ".pi", "agents");
+	mkdirSync(agentsDir, { recursive: true });
+	writeFileSync(
+		path.join(agentsDir, "project-reviewer.md"),
+		"---\nname: project-reviewer\ndescription: Project panel reviewer\ntools: read,grep,find,ls\n---\nReview independently.",
+	);
+	execFileSync("git", ["init", "-q", root]);
+	execFileSync("git", ["-C", root, "add", ".pi/agents/project-reviewer.md"]);
+	execFileSync("git", [
+		"-c",
+		"user.name=Panel Test",
+		"-c",
+		"user.email=panel@example.invalid",
+		"-c",
+		"commit.gpgsign=false",
+		"-C",
+		root,
+		"commit",
+		"-qm",
+		"test fixture",
+	]);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		let confirmation = "";
+		const result = await tool.execute(
+			"panel-project",
+			{
+				agentScope: "project",
+				panel: {
+					task: "Review",
+					reviewers: [
+						{ id: "a", agent: "project-reviewer" },
+						{ id: "b", agent: "project-reviewer" },
+					],
+					synthesizer: { agent: "project-reviewer" },
+				},
+			},
+			undefined,
+			undefined,
+			createMockContext({
+				cwd: root,
+				hasUI: true,
+				isProjectTrusted: () => true,
+				confirm: async (title: string, message: string) => {
+					confirmation = `${title}\n${message}`;
+					return false;
+				},
+			}).ctx,
+		);
+		assert.match(result.content[0].text, /Canceled/);
+		assert.match(confirmation, /project-reviewer/);
+		assert.match(confirmation, /\.pi\/agents/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("panel executes isolated reviewers, preserves evidence, then synthesizes once", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-success-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	const log = path.join(root, "launches.ndjson");
+	writeFileSync(
+		fakePi,
+		[
+			"import{appendFileSync}from'node:fs';",
+			`const log=${JSON.stringify(log)};`,
+			"const task=process.argv.at(-1)??'';",
+			"appendFileSync(log,JSON.stringify({task,cwd:process.cwd()})+'\\n');",
+			'const match=task.match(/reviewerId \\"([^\\"]+)/);',
+			"let result;",
+			"if(match){const id=match[1];result={version:'pi-subagents:panel-review:v1',reviewerId:id,disposition:id==='a'?'fail':'pass',blocking:id==='a',findings:id==='a'?[{id:'F1',severity:'high',title:'Bug',claim:'A bug exists',evidence:['src/a.ts:1']}]:[],missingChecks:[],limitations:[]};}",
+			"else{result={version:'pi-subagents:panel-synthesis:v1',disposition:'fail',summary:'Blocker preserved',validReviewerIds:['a','b'],failedReviewerIds:[],agreements:[],disagreements:[],objections:[{reviewerId:'a',findingId:'F1',resolution:'unresolved',evidence:[]}],limitations:[]};}",
+			"const message={role:'assistant',content:[{type:'text',text:JSON.stringify(result)}],stopReason:'stop',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	chmodSync(fakePi, 0o755);
+	const restore = useFakePiPackage(root, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const result = await tool.execute(
+			"panel-success",
+			{
+				totalTimeoutMs: 10_000,
+				panel: {
+					id: "panel-success",
+					preset: "code-review",
+					task: "Review the shared change",
+					context: "diff: shared",
+					reviewers: [
+						{ id: "a", agent: "reviewer", focus: "correctness" },
+						{ id: "b", agent: "reviewer", focus: "tests" },
+					],
+					synthesizer: { agent: "reviewer" },
+					minValidReviews: 2,
+				},
+			},
+			new AbortController().signal,
+			undefined,
+			createMockContext().ctx,
+		);
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details.mode, "panel");
+		assert.equal(result.details.panel.state, "completed");
+		assert.equal(result.details.panel.validReviewCount, 2);
+		assert.equal(result.details.panel.blockingObjectionCount, 1);
+		assert.equal(result.details.panel.synthesis?.summary, "Blocker preserved");
+		assert.match(result.content[0].text, /Blocker preserved/);
+		assert.ok(
+			result.details.results.every(
+				(reviewer) =>
+					reviewer.executionPlan?.workspaceMode === "shared" &&
+					!reviewer.executionPlan.effectiveTools?.includes("bash"),
+			),
+		);
+		const launches = readFileSync(log, "utf8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line));
+		assert.equal(launches.length, 3);
+		assert.equal(
+			launches.filter((entry) => entry.task.includes("Panel review contract")).length,
+			2,
+		);
+		assert.equal(
+			launches.filter((entry) => entry.task.includes("Panel evidence artifacts")).length,
+			1,
+		);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("timed-out reviewers receive one bounded contract finalization turn", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-finalization-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	const log = path.join(root, "launches.txt");
+	writeFileSync(
+		fakePi,
+		[
+			"import{appendFileSync}from'node:fs';",
+			`appendFileSync(${JSON.stringify(log)},'launch\\n');`,
+			"const task=process.argv.at(-1)??'';const match=task.match(/reviewerId \\\"([^\\\"]+)/);",
+			"if(match&&!task.includes('prior attempt stopped')){setInterval(()=>{},1000);}",
+			"else{let result;if(match){result={version:'pi-subagents:panel-review:v1',reviewerId:match[1],disposition:'partial',blocking:false,findings:[],missingChecks:['original work timed out'],limitations:['finalized from checkpoint']};}",
+			"else{result={version:'pi-subagents:panel-synthesis:v1',disposition:'partial',summary:'Finalized evidence preserved',validReviewerIds:['a','b'],failedReviewerIds:[],agreements:[],disagreements:[],objections:[],limitations:['reviewers timed out before finalization']};}",
+			"const message={role:'assistant',content:[{type:'text',text:JSON.stringify(result)}],stopReason:'stop',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');}",
+		].join(""),
+	);
+	const restore = useFakePiPackage(root, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const result = await tool.execute(
+			"panel-finalization",
+			{
+				totalTimeoutMs: 5_000,
+				panel: {
+					task: "Review",
+					reviewers: [
+						{ id: "a", agent: "reviewer", timeoutMs: 50 },
+						{ id: "b", agent: "reviewer", timeoutMs: 50 },
+					],
+					synthesizer: { agent: "reviewer" },
+				},
+			},
+			undefined,
+			undefined,
+			createMockContext().ctx,
+		);
+		assert.equal(result.details.panel.state, "completed");
+		assert.equal(result.details.panel.validReviewCount, 2);
+		assert.deepEqual(
+			result.details.results.map((reviewer) => reviewer.attemptCount),
+			[2, 2],
+		);
+		const launches = readFileSync(log, "utf8").trim().split("\n").length;
+		assert.ok(launches >= 3 && launches <= 5);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("panel preserves valid reviews when synthesis returns an invalid contract", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-synthesis-failure-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	writeFileSync(
+		fakePi,
+		[
+			"const task=process.argv.at(-1)??'';const match=task.match(/reviewerId \\\"([^\\\"]+)/);",
+			"const text=match?JSON.stringify({version:'pi-subagents:panel-review:v1',reviewerId:match[1],disposition:'pass',blocking:false,findings:[],missingChecks:[],limitations:[]}):'invalid synthesis';",
+			"const message={role:'assistant',content:[{type:'text',text}],stopReason:'stop',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	const restore = useFakePiPackage(root, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const result = await tool.execute(
+			"panel-synthesis-failure",
+			{
+				panel: {
+					task: "Review",
+					reviewers: [
+						{ id: "a", agent: "reviewer" },
+						{ id: "b", agent: "reviewer" },
+					],
+					synthesizer: { agent: "reviewer" },
+				},
+			},
+			undefined,
+			undefined,
+			createMockContext().ctx,
+		);
+		assert.equal(result.isError, true);
+		assert.equal(result.details.panel.state, "failed");
+		assert.equal(result.details.panel.evidence.length, 2);
+		assert.equal(
+			result.details.workflow.items.find((item) => item.id === "synthesis")?.state,
+			"failed",
+		);
+		assert.match(result.content[0].text, /invalid panel-synthesis contract/i);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("panel retries transient transport failures once within the review phase", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-retry-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	const log = path.join(root, "launches.txt");
+	writeFileSync(
+		fakePi,
+		[
+			"import{appendFileSync,existsSync,writeFileSync}from'node:fs';",
+			`const root=${JSON.stringify(root)};const log=${JSON.stringify(log)};`,
+			"appendFileSync(log,'launch\\n');const task=process.argv.at(-1)??'';const match=task.match(/reviewerId \\\"([^\\\"]+)/);let result;",
+			"if(match){const id=match[1];const marker=root+'/'+id+'.once';if(!existsSync(marker)){writeFileSync(marker,'1');process.stderr.write('ECONNRESET');process.exit(1);}result={version:'pi-subagents:panel-review:v1',reviewerId:id,disposition:'pass',blocking:false,findings:[],missingChecks:[],limitations:[]};}",
+			"else{result={version:'pi-subagents:panel-synthesis:v1',disposition:'pass',summary:'recovered',validReviewerIds:['a','b'],failedReviewerIds:[],agreements:[],disagreements:[],objections:[],limitations:[]};}",
+			"const message={role:'assistant',content:[{type:'text',text:JSON.stringify(result)}],stopReason:'stop',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	const restore = useFakePiPackage(root, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const result = await tool.execute(
+			"panel-retry",
+			{
+				panel: {
+					task: "Review",
+					reviewers: [
+						{ id: "a", agent: "reviewer" },
+						{ id: "b", agent: "reviewer" },
+					],
+					synthesizer: { agent: "reviewer" },
+				},
+			},
+			undefined,
+			undefined,
+			createMockContext().ctx,
+		);
+		assert.equal(result.details.panel.state, "completed");
+		assert.deepEqual(
+			result.details.results.map((reviewer) => reviewer.attemptCount),
+			[2, 2],
+		);
+		assert.equal(readFileSync(log, "utf8").trim().split("\n").length, 5);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("write-capable panel reviewers use separate disposable worktrees", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-worktrees-"));
+	const repository = path.join(root, "repository");
+	const packageRoot = path.join(root, "pi-package");
+	mkdirSync(repository);
+	mkdirSync(packageRoot);
+	writeFileSync(path.join(repository, "README.md"), "panel\n");
+	execFileSync("git", ["init", "-q", repository]);
+	execFileSync("git", ["-C", repository, "add", "README.md"]);
+	execFileSync("git", [
+		"-c",
+		"user.name=Panel Test",
+		"-c",
+		"user.email=panel@example.invalid",
+		"-c",
+		"commit.gpgsign=false",
+		"-C",
+		repository,
+		"commit",
+		"-qm",
+		"test fixture",
+	]);
+	const fakePi = path.join(packageRoot, "fake-pi.mjs");
+	const log = path.join(root, "launches.ndjson");
+	writeFileSync(
+		fakePi,
+		[
+			"import{appendFileSync}from'node:fs';",
+			`const log=${JSON.stringify(log)};`,
+			"const task=process.argv.at(-1)??'';appendFileSync(log,JSON.stringify({task,cwd:process.cwd()})+'\\n');",
+			'const match=task.match(/reviewerId \\"([^\\"]+)/);let result;',
+			"if(match){result={version:'pi-subagents:panel-review:v1',reviewerId:match[1],disposition:'pass',blocking:false,findings:[],missingChecks:[],limitations:[]};}",
+			"else{result={version:'pi-subagents:panel-synthesis:v1',disposition:'pass',summary:'ok',validReviewerIds:['a','b'],failedReviewerIds:[],agreements:[],disagreements:[],objections:[],limitations:[]};}",
+			"const message={role:'assistant',content:[{type:'text',text:JSON.stringify(result)}],stopReason:'stop',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	const restore = useFakePiPackage(packageRoot, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const result = await tool.execute(
+			"panel-worktrees",
+			{
+				panel: {
+					task: "Review without touching the canonical repository",
+					reviewers: [
+						{ id: "a", agent: "worker" },
+						{ id: "b", agent: "worker" },
+					],
+					synthesizer: { agent: "worker" },
+				},
+			},
+			undefined,
+			undefined,
+			createMockContext({ cwd: repository, isProjectTrusted: () => true }).ctx,
+		);
+		assert.equal(result.details.panel.state, "completed");
+		assert.ok(
+			result.details.results.every(
+				(reviewer) => reviewer.executionPlan?.workspaceMode === "worktree",
+			),
+		);
+		const launches = readFileSync(log, "utf8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line));
+		const reviewerCwds = launches
+			.filter((entry) => entry.task.includes("Panel review contract"))
+			.map((entry) => entry.cwd);
+		assert.equal(new Set(reviewerCwds).size, 2);
+		assert.ok(reviewerCwds.every((cwd) => cwd !== repository));
+		assert.ok(reviewerCwds.every((cwd) => !existsSync(cwd)));
+		assert.equal(
+			launches.find((entry) => entry.task.includes("Panel evidence artifacts"))?.cwd,
+			repository,
+		);
+		assert.equal(result.details.panel.cleanupComplete, true);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("an insufficient panel returns partial evidence and never launches synthesis", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-insufficient-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	const log = path.join(root, "launches.txt");
+	writeFileSync(
+		fakePi,
+		[
+			"import{appendFileSync}from'node:fs';",
+			`appendFileSync(${JSON.stringify(log)},'launch\\n');`,
+			"const task=process.argv.at(-1)??'';",
+			'const match=task.match(/reviewerId \\"([^\\"]+)/);',
+			"const text=match?.[1]==='a'?JSON.stringify({version:'pi-subagents:panel-review:v1',reviewerId:'a',disposition:'partial',blocking:false,findings:[],missingChecks:['b failed'],limitations:[]}):'not-json';",
+			"const message={role:'assistant',content:[{type:'text',text}],stopReason:'stop',timestamp:Date.now()};",
+			"process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');",
+		].join(""),
+	);
+	const restore = useFakePiPackage(root, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const result = await tool.execute(
+			"panel-insufficient",
+			{
+				panel: {
+					task: "Review",
+					reviewers: [
+						{ id: "a", agent: "reviewer" },
+						{ id: "b", agent: "reviewer" },
+					],
+					synthesizer: { agent: "reviewer" },
+				},
+			},
+			undefined,
+			undefined,
+			createMockContext().ctx,
+		);
+		assert.equal(result.isError, true);
+		assert.equal(result.details.panel.state, "insufficient-panel");
+		assert.equal(result.details.panel.evidence.length, 1);
+		assert.equal(result.details.panel.failures[0].kind, "invalid-contract");
+		assert.doesNotMatch(result.content[0].text, /consensus|verified/i);
+		assert.equal(readFileSync(log, "utf8").trim().split("\n").length, 2);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("panel semantic progress stops repeated activity without blind retries", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-stall-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	const log = path.join(root, "launches.txt");
+	writeFileSync(
+		fakePi,
+		[
+			"import{appendFileSync}from'node:fs';",
+			`appendFileSync(${JSON.stringify(log)},'launch\\n');`,
+			"for(let i=0;i<8;i++){const message={role:'assistant',content:[{type:'text',text:'activity '+i}],stopReason:'toolUse',timestamp:Date.now()};process.stdout.write(JSON.stringify({type:'message_end',message})+'\\n');}",
+			"setInterval(()=>{},1000);",
+		].join(""),
+	);
+	const restore = useFakePiPackage(root, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const result = await tool.execute(
+			"panel-stall",
+			{
+				totalTimeoutMs: 5_000,
+				panel: {
+					task: "Review with evidence",
+					reviewers: [
+						{ id: "a", agent: "reviewer" },
+						{ id: "b", agent: "reviewer" },
+					],
+					synthesizer: { agent: "reviewer" },
+				},
+			},
+			undefined,
+			undefined,
+			createMockContext().ctx,
+		);
+		assert.equal(result.details.panel.state, "insufficient-panel");
+		assert.deepEqual(
+			result.details.panel.failures.map((failure) => failure.kind),
+			["semantic-stall", "semantic-stall"],
+		);
+		assert.equal(readFileSync(log, "utf8").trim().split("\n").length, 2);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("session shutdown cancels blocking panels and removes owned worktrees", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-shutdown-"));
+	const repository = path.join(root, "repository");
+	const packageRoot = path.join(root, "pi-package");
+	mkdirSync(repository);
+	mkdirSync(packageRoot);
+	writeFileSync(path.join(repository, "README.md"), "panel\n");
+	execFileSync("git", ["init", "-q", repository]);
+	execFileSync("git", ["-C", repository, "add", "README.md"]);
+	execFileSync("git", [
+		"-c",
+		"user.name=Panel Test",
+		"-c",
+		"user.email=panel@example.invalid",
+		"-c",
+		"commit.gpgsign=false",
+		"-C",
+		repository,
+		"commit",
+		"-qm",
+		"test fixture",
+	]);
+	const fakePi = path.join(packageRoot, "fake-pi.mjs");
+	const log = path.join(root, "launches.ndjson");
+	writeFileSync(
+		fakePi,
+		[
+			"import{appendFileSync}from'node:fs';",
+			`appendFileSync(${JSON.stringify(log)},JSON.stringify({cwd:process.cwd()})+'\\n');`,
+			"setInterval(()=>{},1000);",
+		].join(""),
+	);
+	const restore = useFakePiPackage(packageRoot, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const context = createMockContext({ cwd: repository, isProjectTrusted: () => true });
+		const execution = tool.execute(
+			"panel-shutdown",
+			{
+				totalTimeoutMs: 10_000,
+				panel: {
+					task: "Wait for shutdown",
+					reviewers: [
+						{ id: "a", agent: "worker" },
+						{ id: "b", agent: "worker" },
+					],
+					synthesizer: { agent: "worker" },
+				},
+			},
+			undefined,
+			undefined,
+			context.ctx,
+		);
+		await waitFor(
+			() => existsSync(log) && readFileSync(log, "utf8").trim().split("\n").length === 2,
+		);
+		await Promise.all(
+			(mock.events.get("session_shutdown") ?? []).map((handler) => handler({}, context.ctx)),
+		);
+		const result = await execution;
+		assert.equal(result.details.panel.state, "cancelled");
+		assert.equal(result.details.panel.cleanupComplete, true);
+		const worktrees = readFileSync(log, "utf8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line).cwd as string);
+		assert.ok(worktrees.every((cwd) => !existsSync(cwd)));
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("panel cancellation closes the child group and skips synthesis", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-panel-cancel-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	const log = path.join(root, "launches.txt");
+	writeFileSync(
+		fakePi,
+		[
+			"import{appendFileSync}from'node:fs';",
+			`appendFileSync(${JSON.stringify(log)},'launch\\n');`,
+			"setInterval(()=>{},1000);",
+		].join(""),
+	);
+	const restore = useFakePiPackage(root, fakePi);
+	try {
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as PanelTestTool;
+		const controller = new AbortController();
+		setTimeout(() => controller.abort("test-cancel"), 50);
+		const result = await tool.execute(
+			"panel-cancel",
+			{
+				totalTimeoutMs: 2_000,
+				panel: {
+					task: "Review until cancelled",
+					reviewers: Array.from({ length: 5 }, (_, index) => ({
+						id: `reviewer-${index}`,
+						agent: "reviewer",
+					})),
+					synthesizer: { agent: "reviewer" },
+				},
+			},
+			controller.signal,
+			undefined,
+			createMockContext().ctx,
+		);
+		assert.equal(result.isError, true);
+		assert.equal(result.details.panel.state, "cancelled");
+		assert.equal(result.details.panel.cleanupComplete, true);
+		assert.equal(
+			result.details.workflow.items.find((item: { id: string }) => item.id === "synthesis")?.state,
+			"interrupted",
+		);
+		assert.ok(!existsSync(log) || readFileSync(log, "utf8").trim().split("\n").length <= 4);
+	} finally {
+		restore();
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-subagents/test/panel.test.ts
+++ b/packages/pi-subagents/test/panel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
+import { DEFAULT_MAX_CONTEXT_BYTES } from "../src/limits.js";
 import {
 	type PanelReview,
 	panelReviewInstruction,
@@ -9,7 +10,7 @@ import {
 import { PanelEvidenceLedger } from "../src/panel-evidence.js";
 import { classifyPanelFailure } from "../src/panel-failure.js";
 import { planPanelBudgets, validatePanelRequest } from "../src/panel-planning.js";
-import { buildPanelReviewerPrompt } from "../src/panel-prompts.js";
+import { buildPanelReviewerPrompt, buildPanelSynthesisPrompt } from "../src/panel-prompts.js";
 import { reconcilePanel } from "../src/panel-reconciliation.js";
 
 function review(overrides: Partial<PanelReview> = {}): PanelReview {
@@ -81,6 +82,44 @@ test("panel reviewer prompts keep a byte-identical shared block and hide sibling
 	assert.equal(first.split("\n\nReviewer id:")[0], second.split("\n\nReviewer id:")[0]);
 	assert.doesNotMatch(first, /Reviewer id: b|Reviewer focus:\ntests/u);
 	assert.doesNotMatch(second, /Reviewer id: a|Reviewer focus:\ncorrectness/u);
+});
+
+test("panel prompts preserve required contracts at maximum input bounds", () => {
+	const common = {
+		panelId: "bounded-panel",
+		preset: "research" as const,
+		task: "t".repeat(DEFAULT_MAX_CONTEXT_BYTES),
+		context: "c".repeat(DEFAULT_MAX_CONTEXT_BYTES),
+	};
+	const first = buildPanelReviewerPrompt({
+		...common,
+		reviewerId: "a",
+		focus: "f".repeat(8 * 1024),
+	});
+	const second = buildPanelReviewerPrompt({ ...common, reviewerId: "b" });
+	assert.ok(Buffer.byteLength(first, "utf8") <= DEFAULT_MAX_CONTEXT_BYTES);
+	assert.ok(Buffer.byteLength(second, "utf8") <= DEFAULT_MAX_CONTEXT_BYTES);
+	assert.equal(first.split("\n\nReviewer id:")[0], second.split("\n\nReviewer id:")[0]);
+	assert.match(first, /Reviewer id: a/u);
+	assert.match(first, /Panel review contract:/u);
+	assert.match(first, /pi-subagents:panel-review:v1/u);
+	assert.match(first, /Shared task:/u);
+	assert.match(first, /Shared context:/u);
+
+	const reviews = [
+		review({ reviewerId: "a", blocking: false, findings: [] }),
+		review({ reviewerId: "b", blocking: false, findings: [] }),
+	];
+	const synthesis = buildPanelSynthesisPrompt({
+		panelId: "bounded-panel",
+		task: common.task,
+		reviews,
+		failures: [],
+	});
+	assert.ok(Buffer.byteLength(synthesis, "utf8") <= DEFAULT_MAX_CONTEXT_BYTES);
+	assert.match(synthesis, /Panel evidence artifacts:/u);
+	assert.match(synthesis, /Panel synthesis contract:/u);
+	assert.match(synthesis, /pi-subagents:panel-synthesis:v1/u);
 });
 
 test("panel synthesis rejects fabricated reviewers and omitted blocking objections", () => {

--- a/packages/pi-subagents/test/panel.test.ts
+++ b/packages/pi-subagents/test/panel.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	type PanelReview,
+	panelReviewInstruction,
+	parsePanelReview,
+	parsePanelSynthesis,
+} from "../src/panel-contract.js";
+import { PanelEvidenceLedger } from "../src/panel-evidence.js";
+import { classifyPanelFailure } from "../src/panel-failure.js";
+import { planPanelBudgets, validatePanelRequest } from "../src/panel-planning.js";
+import { buildPanelReviewerPrompt } from "../src/panel-prompts.js";
+import { reconcilePanel } from "../src/panel-reconciliation.js";
+
+function review(overrides: Partial<PanelReview> = {}): PanelReview {
+	return {
+		version: "pi-subagents:panel-review:v1",
+		reviewerId: "reviewer-a",
+		disposition: "fail",
+		blocking: true,
+		findings: [
+			{
+				id: "F1",
+				severity: "high",
+				title: "Unsafe path",
+				claim: "The path is unsafe.",
+				evidence: ["src/a.ts:10"],
+			},
+		],
+		missingChecks: ["runtime smoke"],
+		limitations: [],
+		...overrides,
+	};
+}
+
+test("panel review contracts are strict, bounded, redacted, and reviewer-bound", () => {
+	const parsed = parsePanelReview(JSON.stringify(review()), "reviewer-a", {
+		agent: "reviewer",
+		model: "provider/model",
+		taskGeneration: 3,
+	});
+	assert.ok(parsed);
+	assert.equal(parsed.provenance?.reviewerId, "reviewer-a");
+	assert.equal(parsed.provenance?.taskGeneration, 3);
+	assert.equal(parsed.provenance?.agent, "reviewer");
+	assert.equal(
+		parsePanelReview(JSON.stringify({ ...review(), reviewerId: "invented" }), "reviewer-a"),
+		undefined,
+	);
+	assert.equal(
+		parsePanelReview(JSON.stringify({ ...review(), extra: true }), "reviewer-a"),
+		undefined,
+	);
+	assert.equal(
+		parsePanelReview(
+			JSON.stringify({
+				...review(),
+				findings: [review().findings[0], review().findings[0]],
+			}),
+			"reviewer-a",
+		),
+		undefined,
+	);
+	assert.match(panelReviewInstruction("reviewer-a"), /one JSON object/i);
+	assert.match(panelReviewInstruction("reviewer-a"), /reviewer-a/);
+});
+
+test("panel reviewer prompts keep a byte-identical shared block and hide siblings", () => {
+	const common = {
+		panelId: "panel-1",
+		preset: "code-review" as const,
+		task: "Review the change",
+		context: "shared snapshot",
+	};
+	const first = buildPanelReviewerPrompt({
+		...common,
+		reviewerId: "a",
+		focus: "correctness",
+	});
+	const second = buildPanelReviewerPrompt({ ...common, reviewerId: "b", focus: "tests" });
+	assert.equal(first.split("\n\nReviewer id:")[0], second.split("\n\nReviewer id:")[0]);
+	assert.doesNotMatch(first, /Reviewer id: b|Reviewer focus:\ntests/u);
+	assert.doesNotMatch(second, /Reviewer id: a|Reviewer focus:\ncorrectness/u);
+});
+
+test("panel synthesis rejects fabricated reviewers and omitted blocking objections", () => {
+	const reviews = [review(), review({ reviewerId: "reviewer-b", blocking: false, findings: [] })];
+	const valid = {
+		version: "pi-subagents:panel-synthesis:v1",
+		disposition: "fail",
+		summary: "One blocker remains.",
+		validReviewerIds: ["reviewer-a", "reviewer-b"],
+		failedReviewerIds: [],
+		agreements: [],
+		disagreements: [],
+		objections: [
+			{
+				reviewerId: "reviewer-a",
+				findingId: "F1",
+				resolution: "unresolved",
+				evidence: [],
+			},
+		],
+		limitations: [],
+	};
+	assert.ok(parsePanelSynthesis(JSON.stringify(valid), reviews, []));
+	assert.equal(
+		parsePanelSynthesis(
+			JSON.stringify({ ...valid, validReviewerIds: ["reviewer-a", "invented"] }),
+			reviews,
+			[],
+		),
+		undefined,
+	);
+	assert.equal(
+		parsePanelSynthesis(JSON.stringify({ ...valid, objections: [] }), reviews, []),
+		undefined,
+	);
+});
+
+test("panel planning reserves synthesis and cleanup before launch", () => {
+	const budgets = planPanelBudgets(10_000, 3);
+	assert.equal(
+		budgets.reviewMs + budgets.finalizationMs + budgets.synthesisMs + budgets.cleanupMs,
+		10_000,
+	);
+	assert.ok(budgets.synthesisMs > 0);
+	assert.ok(budgets.cleanupMs > 0);
+	assert.ok(budgets.reviewerTimeoutMs <= budgets.reviewMs);
+	assert.throws(() => planPanelBudgets(3, 2), /too small/i);
+
+	assert.throws(
+		() =>
+			validatePanelRequest({
+				task: "review",
+				reviewers: [
+					{ id: "same", agent: "reviewer" },
+					{ id: "same", agent: "scout" },
+				],
+				synthesizer: { agent: "reviewer" },
+			}),
+		/unique/i,
+	);
+	assert.throws(
+		() =>
+			validatePanelRequest({
+				task: "review",
+				reviewers: [
+					{ id: "unsafe\u001b", agent: "reviewer" },
+					{ id: "safe", agent: "reviewer" },
+				],
+				synthesizer: { agent: "reviewer" },
+			}),
+		/safe identifier/i,
+	);
+	assert.throws(
+		() =>
+			validatePanelRequest(
+				{
+					task: "review",
+					reviewers: [
+						{ id: "a", agent: "reviewer" },
+						{ id: "b", agent: "reviewer" },
+						{ id: "c", agent: "reviewer" },
+					],
+					synthesizer: { agent: "reviewer" },
+				},
+				2,
+			),
+		/configured max/i,
+	);
+});
+
+test("evidence ledger accepts monotonic current-generation artifacts only", () => {
+	const ledger = new PanelEvidenceLedger("panel-1", 3);
+	assert.equal(ledger.publish(review(), 1), true);
+	assert.equal(ledger.publish(review({ disposition: "partial" }), 1), false);
+	assert.equal(ledger.publish(review({ reviewerId: "reviewer-b" }), 2), false);
+	assert.equal(ledger.latest("reviewer-a")?.revision, 1);
+	assert.equal(ledger.snapshot().length, 1);
+	const generated = new PanelEvidenceLedger("panel-generation", 2);
+	assert.equal(
+		generated.publish(
+			{
+				...review(),
+				provenance: { reviewerId: "reviewer-a", taskGeneration: 1 },
+			},
+			1,
+		),
+		true,
+	);
+	assert.equal(
+		generated.publish(
+			{
+				...review({ disposition: "partial" }),
+				provenance: { reviewerId: "reviewer-a", taskGeneration: 2 },
+			},
+			2,
+		),
+		false,
+	);
+
+	const bounded = new PanelEvidenceLedger("panel-bounded", 2);
+	const large = review({
+		findings: [
+			{
+				...review().findings[0],
+				claim: "x".repeat(13 * 1024),
+			},
+		],
+	});
+	assert.equal(bounded.publish(large, 1), true);
+	assert.equal(bounded.publish({ ...large, reviewerId: "reviewer-b" }, 1), false);
+});
+
+test("panel recovery distinguishes transient failures from semantic failures", () => {
+	assert.deepEqual(classifyPanelFailure({ launchFailed: true }), {
+		kind: "transient-launch",
+		retryable: true,
+	});
+	assert.deepEqual(classifyPanelFailure({ resultContractInvalid: true }), {
+		kind: "invalid-contract",
+		retryable: false,
+	});
+	assert.deepEqual(classifyPanelFailure({ stopReason: "semantic-stall" }), {
+		kind: "semantic-stall",
+		retryable: false,
+	});
+});
+
+test("reconciliation never turns corroboration or votes into verification", () => {
+	const result = reconcilePanel({
+		reviews: [review(), review({ reviewerId: "reviewer-b" })],
+		failures: [],
+		minValidReviews: 2,
+	});
+	assert.equal(result.kind, "ready-for-synthesis");
+	assert.equal(result.blockingObjections.length, 2);
+	assert.equal(result.verified, false);
+
+	const insufficient = reconcilePanel({
+		reviews: [review()],
+		failures: [{ reviewerId: "reviewer-b", kind: "semantic-stall", retryable: false }],
+		minValidReviews: 2,
+	});
+	assert.equal(insufficient.kind, "insufficient-panel");
+	assert.equal(insufficient.partialReviews.length, 1);
+	assert.equal(insufficient.consensus, false);
+});

--- a/packages/pi-subagents/test/tool-rendering.test.ts
+++ b/packages/pi-subagents/test/tool-rendering.test.ts
@@ -163,6 +163,116 @@ test("all seven subagent tools register native call and result renderers", () =>
 	}
 });
 
+test("panel renderer is width-safe, sanitized, and preserves objections and dissent", () => {
+	const tool = registeredTools().get("subagent");
+	assert.ok(tool);
+	const args = {
+		panel: {
+			preset: "code-review",
+			task: "Review <private>SECRET</private> unsafe\u001b]8;;link\u0007 change",
+			reviewers: [
+				{ id: "a", agent: "reviewer", focus: "correctness" },
+				{ id: "b", agent: "reviewer", focus: "tests" },
+			],
+			synthesizer: { agent: "reviewer" },
+		},
+	};
+	const callLines = renderCall(tool, args, 32);
+	const call = withoutSgr(callLines.join("\n"));
+	assert.match(call, /panel code-review.*2\s+reviewers/is);
+	assert.doesNotMatch(call, /SECRET/u);
+	assert.equal(call.includes(ESCAPE), false);
+	assert.ok(callLines.every((line) => visibleWidth(line) <= 32));
+
+	const review = {
+		version: "pi-subagents:panel-review:v1",
+		reviewerId: "a",
+		disposition: "fail",
+		blocking: true,
+		findings: [
+			{
+				id: "F1",
+				severity: "high",
+				title: "Unsafe terminal\u001b[31m output",
+				claim: "unsafe",
+				evidence: ["src/a.ts:1"],
+			},
+		],
+		missingChecks: [],
+		limitations: [],
+	};
+	const details = {
+		mode: "panel",
+		agentScope: "user",
+		projectAgentsDir: null,
+		results: [
+			{
+				agent: "reviewer",
+				agentSource: "built-in",
+				task: "Review",
+				exitCode: 0,
+				messages: [],
+				stderr: "",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+				step: 1,
+			},
+		],
+		panel: {
+			id: "panel-1",
+			preset: "code-review",
+			state: "completed",
+			reviewerIds: ["a", "b"],
+			validReviewCount: 2,
+			failedReviewCount: 0,
+			blockingObjectionCount: 1,
+			dissentCount: 1,
+			budgets: {
+				totalMs: 10_000,
+				reviewMs: 6_500,
+				finalizationMs: 1_000,
+				synthesisMs: 2_000,
+				cleanupMs: 500,
+				reviewerTimeoutMs: 6_500,
+			},
+			evidence: [
+				{ panelId: "panel-1", reviewerId: "a", revision: 1, review },
+				{
+					panelId: "panel-1",
+					reviewerId: "b",
+					revision: 1,
+					review: { ...review, reviewerId: "b", blocking: false, findings: [] },
+				},
+			],
+			failures: [],
+			synthesis: {
+				version: "pi-subagents:panel-synthesis:v1",
+				disposition: "fail",
+				summary: "The blocker remains.",
+				validReviewerIds: ["a", "b"],
+				failedReviewerIds: [],
+				agreements: [],
+				disagreements: [{ summary: "Reviewers disagree", reviewerIds: ["a", "b"] }],
+				objections: [{ reviewerId: "a", findingId: "F1", resolution: "unresolved", evidence: [] }],
+				limitations: ["No runtime smoke"],
+			},
+			cleanupComplete: true,
+		},
+	};
+	const expandedLines = renderResult(
+		tool,
+		args,
+		{ content: [{ type: "text", text: "The blocker remains." }], details },
+		{ expanded: true, isPartial: false },
+		32,
+	);
+	const expanded = withoutSgr(expandedLines.join("\n"));
+	assert.match(expanded, /blockers 1.*dissent 1/is);
+	assert.match(expanded, /Reviewers disagree/);
+	assert.match(expanded, /a\/F1: unresolved/);
+	assert.equal(expanded.includes(ESCAPE), false);
+	assert.ok(expandedLines.every((line) => visibleWidth(line) <= 32));
+});
+
 test("consult renderer shows bounded live activity and progressive disclosure", () => {
 	const tool = registeredTools().get("subagent_consult");
 	assert.ok(tool);


### PR DESCRIPTION
## Summary

- add first-class blocking `panel` mode with independent reviewer and synthesis contracts
- reserve review, finalization, synthesis, and cleanup budgets while preserving bounded partial evidence
- isolate write-capable reviewers in disposable worktrees and close blocking work on cancellation or session lifecycle events
- add panel WorkItem metadata, metrics, rendering, documentation, tests, and a minor Changeset

## Verification

- `npm run check` — passed Biome, boundaries, builds, all workspace typechecks, 258 test files, and 2,807 tests
- `npx vitest run packages/pi-subagents/test` — 39 files and 332 tests passed
- `just pack subagents` — dry-run tarball contains all panel modules and documented package files
- local `pi --no-extensions -e ./packages/pi-subagents` smokes — completed, degraded, and insufficient outcomes verified with cleanup complete
- deterministic parent-abort and `session_shutdown` lifecycle tests — active children cancelled and owned worktrees removed

## Limitations

- no benchmark or quality-improvement claim is made
- disposable worktrees isolate repository writes, not processes, network, credentials, secrets, or the host filesystem
- externally forced host termination may bypass Pi lifecycle cleanup; the README documents manual generated-worktree recovery

No package was published.
