### PR TITLE
fix(sync): make operation recovery actionable

### DIFF
--- a/.changeset/bright-sync-recovery.md
+++ b/.changeset/bright-sync-recovery.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Make interrupted-operation recovery immediately actionable in the sync manager, distinguish live and guarded operations from recoverable locks, confirm local-lock removal, and return directly to normal sync actions after recovery.

--- a/docs/plans/archived/2026-08-10_pi-sync-operation-recovery-ux-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-sync-operation-recovery-ux-plan.md
@@ -1,0 +1,299 @@
+# pi-sync operation recovery UX plan
+
+## Goal
+
+Make the `/sync` manager explain operation-lock failures at first sight, place the safe recovery action
+at the point of failure, and return users directly to the normal manager after recovery without
+weakening pi-sync's cross-process lock, cancellation, data-preservation, or compatibility guarantees.
+
+## Context
+
+- The proposed scope is the manager's live, stale, unreadable, guard-only, and lock-inspection states
+  rather than a broad redesign of setup, conflict, or backend workflows.
+- `packages/pi-sync/src/manager-state.ts` currently collapses stale and unreadable metadata into
+  **Recovery required: lock metadata is stale or unreadable** and removes **Settings** and **More…**.
+- `packages/pi-sync/src/manager-ui.ts` hides **Recover stale operation** one level below
+  **History & recovery…**, so the visible failure does not expose its resolution.
+- Successful recovery currently leaves the user in the recovery submenu and requires Back before the
+  ordinary manager actions reappear.
+- `showSyncManager()` separately loads `describeManagerState()` and `inspectLock()`, so one rendered
+  screen can combine observations from different lock generations.
+- `inspectLock()` does not include the `proper-lockfile` guard; a guard-only writer can therefore look
+  free in the manager even though the next operation is rejected.
+- `packages/pi-sync/src/lock.ts` already rechecks metadata and guard ownership before removal, refuses
+  live owners, and requires explicit `--stale` authorization for unreadable metadata.
+- Existing lock tests cover low-level stale, unreadable, live, guard, and race behavior, but no focused
+  manager test covers recovery prominence, confirmation, success navigation, cancellation, narrow
+  rendering, RPC adaptation, or session replacement.
+- The primary evidence-backed audience is an interactive terminal user synchronizing Pi content
+  across devices; multi-setup users and deterministic command/RPC callers are secondary or
+  compatibility audiences.
+- No usage telemetry exists, so recovery is treated as uncommon but blocking and safety-critical
+  rather than assigned an asserted real-world frequency.
+- Applicable convention areas are slash-command menus, TUI/RPC adaptation, terminal safety,
+  cancellation/disposal/session replacement, extension-owned settings preservation, deterministic
+  tests, documentation, and Changesets.
+- Research-time tests could not start because `node_modules/typescript/package.json` and
+  `packages/pi-tui-kit/dist/index.js` are absent; dependency installation and a green baseline are an
+  execution prerequisite.
+- The active goal explicitly authorized branch creation, implementation, review, hardening, and pull
+  request delivery after this plan was created.
+
+## Architecture
+
+### One operation-availability snapshot
+
+Add a focused operation-availability projection, outside the already 959-line `manager-ui.ts`, that
+reads lock metadata and the lock guard as one manager state input.
+
+Represent the result as an explicit union:
+
+- `free` — no metadata and no active guard;
+- `live` — valid metadata whose owner still appears live;
+- `busy` — an active guard with missing, unreadable, or stale metadata, meaning another writer may be
+  starting, finishing, or waiting for guard expiry;
+- `recoverable-stale` — valid stale metadata with no active guard;
+- `recoverable-unreadable` — unreadable metadata with no active guard;
+- `inspection-error` — filesystem or guard inspection failed and must not be mislabeled as a settings
+  error.
+
+`describeManagerState()` will consume that single structured snapshot, and `showSyncManager()` will
+stop performing its independent `canRecover` inspection.
+
+Every destructive decision will still recheck the real lock and guard in `lock.ts`; the projection is
+presentation state, not mutation authority.
+
+### Contextual manager states
+
+Keep the normal, missing-settings, empty-catalog, no-included-content, and content-review manager
+states unchanged.
+
+For `recoverable-stale` and `recoverable-unreadable`, show a concise **Sync paused** cause and recovery
+instruction, state when Settings and More return, and place **Restore sync access… (recommended)**
+first.
+
+Keep the first frame within the constrained terminal row budget and move the complete local-lock-only
+effect and no-data-change explanation into the mandatory confirmation.
+
+Keep **Status & changes**, **History & recovery…**, and **Help** as secondary actions so established
+read-only and compatibility paths remain reachable.
+
+For `live`, show the command, PID, and instruction to wait, and put **Refresh operation status** first
+without exposing lock removal.
+
+For `busy`, explain that another process may be starting or finishing and offer only refresh plus safe
+secondary actions.
+
+For `inspection-error`, name the operation-lock inspection problem and retry path without claiming
+that `pi-sync.json` is invalid.
+
+Do not restore **Settings** or **More…** while mutation remains blocked; instead explain that they
+return after access is restored.
+
+### Reviewed recovery
+
+Use Pi TUI Kit's standard confirmation interaction before lock removal.
+
+For a valid stale lock, invoke the conservative `unlock` route so the domain layer removes only a lock
+that still proves stale.
+
+For unreadable metadata, invoke `unlock --stale` only after copy explicitly tells the user to close
+other Pi sessions because ownership cannot be verified.
+
+Pass a combined session/action signal through confirmation, route execution, post-action inspection,
+and every continuation.
+
+Allow cancellation before the guarded removal boundary, but once the checked filesystem removal has
+started, finish guard release and suppress stale-context UI rather than pretending the mutation was
+rolled back.
+
+After the route settles, inspect operation availability again instead of trusting the pre-confirmation
+state.
+
+If the state is `free`, notify that no settings, local files, sync state, or remote data changed and
+transition directly to the refreshed main screen.
+
+If the state is still blocked or changed to live/busy, remain in the contextual state and show the
+specific refusal or retry guidance.
+
+### Compatibility and storage boundary
+
+Preserve every documented slash command, including `/sync unlock --stale`, and do not change argument
+completion or direct-route semantics.
+
+Preserve RPC as Pi TUI Kit's signal-aware selector/confirmation adaptation and keep print/JSON from
+entering TUI-only components.
+
+Do not change `pi-sync.json`, snapshots, sync state, backend wire formats, credentials, permissions,
+settings precedence, filename migration, or unknown-field preservation.
+
+Create a new patch Changeset for `@narumitw/pi-sync`; do not alter the existing
+`.changeset/calm-sync-attention.md`, which owns a separate published behavior change.
+
+## Non-Goals
+
+- Do not redesign the normal manager, Settings, setup, storage-connection, conflict-resolution, or
+  included-content flows.
+- Do not automatically remove a stale or unreadable lock when the manager opens.
+- Do not let a live or guard-owned operation expose a forced recovery action.
+- Do not recover, roll back, or mutate local synchronized files as part of restoring manager access.
+- Do not add a setting, preference, public command, flag, schema field, timer, or automatic polling
+  loop.
+- Do not contact remote storage merely to render or refresh operation availability.
+- Do not remove **History & recovery…** or the existing doctor/history routes.
+
+## Assumptions
+
+- A single confirmation is proportionate because lock removal is locally small but can create unsafe
+  concurrency if ownership is misclassified.
+- Explicit refresh is preferable to an automatic timer because operation transitions are uncommon,
+  local reads are cheap, and timers add lifecycle and layout instability.
+- The established Pi TUI Kit action, confirmation, disabled-reason, Back, Close, and RPC contracts are
+  sufficient; no new Kit API or compatibility-floor increase is expected.
+- The existing lock guard's 30-second stale policy remains unchanged.
+
+## Unknowns
+
+- Resolved: `npm install` restored the locked dependency baseline without manifest or lockfile changes.
+- Resolved: Pi TUI Kit harness tests exercise 32, 60, and 100 columns at 12, 16, and 24 rows.
+- Resolved: current temporary-state helpers can create a real guard-only snapshot and a confirmed
+  guard-acquisition race without a production-only test seam.
+
+## Risks
+
+- **Unsafe unlock:** An unreadable lock may belong to an initializing legacy writer; mitigate with
+  guard-aware classification, explicit confirmation, and the existing guarded recheck.
+- **Stale presentation:** Lock ownership can change while the confirmation is open; mitigate by
+  rechecking through the production unlock path and inspecting again before navigation.
+- **Lifecycle leak:** Recovery could continue after session replacement or component disposal;
+  mitigate with combined signals, post-await ownership checks, and pending-work draining tests.
+- **False settings diagnosis:** Lock filesystem failures currently fall into a broad manager error;
+  mitigate by separating operation inspection errors from settings validation errors.
+- **Navigation regression:** Dynamic recovery actions could break Back/Close or cursor restoration;
+  mitigate with Pi TUI Kit harness and RPC scripts at the complete manager boundary.
+- **Source-size regression:** `manager-ui.ts` is close to 1,000 lines; mitigate by putting lock-state
+  projection and recovery copy/coordination in focused modules and auditing final authored sizes.
+- **Changeset overlap:** Another pending patch already targets pi-sync; mitigate by creating a separate
+  narrowly worded Changeset and leaving the existing file unchanged.
+
+## Rollback / Recovery
+
+The change requires no stored-data migration, so code rollback restores the former nested recovery
+menu without rewriting settings, state, snapshots, locks, or remote data.
+
+If the new contextual flow causes a runtime regression, revert its manager projection and UI wiring
+while retaining the existing guarded `/sync unlock --stale` route.
+
+Never roll back by automatically clearing an operation lock or choosing a sync direction.
+
+## Plan
+
+- [x] Run `npm install` from the repository root, verify `git diff -- package.json package-lock.json`
+      has no unintended dependency change, rebuild `@narumitw/pi-tui-kit`, and run the current
+      pi-sync manager/lock suites to establish a green baseline before behavior edits.
+- [x] Add red-first tests in a focused `packages/pi-sync/test/manager-recovery.test.ts` for `free`,
+      `live`, `busy`, `recoverable-stale`, `recoverable-unreadable`, and `inspection-error`
+      projections; verify the new assertions fail because the manager currently collapses or misses
+      those states.
+- [x] Implement one guard-aware operation-availability projection under `packages/pi-sync/src/`, wire
+      `manager-state.ts` to consume it, and remove the independent `canRecover` inspection from
+      `manager-ui.ts`; verify the projection tests pass and lock rechecks remain in `lock.ts`.
+- [x] Add red-first TUI manager tests requiring **Sync is paused**, concrete unavailable/recovery
+      guidance, and first-row **Restore sync access… (recommended)** for both recoverable states;
+      implement the contextual action projection without changing ordinary manager actions.
+- [x] Add red-first tests for live and guard-owned operations requiring command/PID or starting/
+      finishing copy, first-row **Refresh operation status**, and no recovery action; implement local
+      refresh so a changed state returns to the matching contextual or ordinary manager screen.
+- [x] Add red-first confirmation tests proving stale recovery uses conservative `unlock`, unreadable
+      recovery uses explicit `unlock --stale`, confirmation copy names the local-lock-only effect,
+      and Cancel/Escape preserve the lock and all settings bytes; implement the standard Pi TUI Kit
+      confirmation flow.
+- [x] Add red-first race and result tests proving recovery rechecks a lock that disappears, becomes
+      live, changes identity, remains unreadable, or retains an active guard; implement post-action
+      inspection, direct success transition to the normal main screen, and actionable stay/retry
+      feedback without duplicate notifications.
+- [x] Extend `lock.ts` and manager lifecycle tests only as needed to pass the session/action signal
+      through pre-removal waits, guard acquisition, confirmation, route execution, and state refresh;
+      verify user cancellation, external disposal, session replacement, reload, and shutdown leave no
+      stale-context notification or unintended mutation.
+- [x] Add Pi TUI Kit harness coverage at 32, 60, and 100 columns and constrained heights for stale,
+      unreadable, live, busy, success, failure, and cancellation frames; verify every rendered line is
+      bounded, critical meaning is textual, terminal controls are stripped, and navigation remains
+      keyboard-complete.
+- [x] Add strict RPC harness coverage for recovery confirmation, cancellation, refusal, success, and
+      refreshed navigation; verify print/JSON remain non-interactive and direct
+      `/sync unlock --stale` compatibility tests still pass.
+- [x] Extend deterministic no-side-effect assertions to prove recovery changes only the eligible
+      operation-lock path and does not alter `pi-sync.json`, synchronized local files, sync state,
+      backups, credentials, unknown settings fields, or remote backend doubles.
+- [x] Update `packages/pi-sync/README.md` to document the visible paused/live states, first-action
+      recovery, confirmation safety rule, automatic return to normal actions, direct-command fallback,
+      mode behavior, and terminal accessibility limits.
+- [x] Add a new patch Changeset for `@narumitw/pi-sync`, run `just changeset-status`, and verify its
+      release note describes only the operation-recovery UX and no schema or migration claim.
+- [x] Audit the complete diff against `docs/extension-conventions.md` and
+      `docs/extension-settings.md`, including command compatibility, mode guards, settings ordering,
+      invalid-file protection, unknown-field preservation, cancellation/disposal/replacement/
+      shutdown, post-`await` freshness, terminal safety, accessibility, source ownership, and every
+      touched-area MUST verification method.
+- [x] Run focused Vitest suites, all pi-sync tests, `npm test`, `npm run check`, `git diff --check`,
+      `just pack sync`, and a temporary-agent Pi RPC load smoke without credentials or remote access;
+      inspect the tarball and leave every failed or unavailable check open with exact evidence.
+- [x] Compare the final implementation against every completion item, inspect the selected diff for
+      unrelated changes, record exact verification and unverified live-backend paths in this plan,
+      and move the fully completed file to `docs/plans/archived/` only when every item is satisfied.
+
+## Evidence
+
+- Branch: `feat/pi-sync-operation-recovery-ux` created from `origin/main`.
+- Dependency baseline: `npm install` added only ignored dependencies; `package.json` and
+  `package-lock.json` remained unchanged.
+- TDD baseline: the first four manager-recovery tests failed on the missing first-action recovery,
+  unreadable-owner guidance, live refresh action, and guard-only state before production changes.
+- Focused behavior: `manager-recovery.test.ts` passes 18 tests covering free/live/stale/unreadable/
+  guarded/inspection-error projection, main and History recovery, confirmation, cancellation,
+  success navigation, guard and ownership races, pre/post-commit aborts, terminal controls, RPC, and
+  32/60/100-column by 12/16/24-row rendering.
+- Review and hardening: independent review identified an abort gap, a real-guard race test gap, and
+  unverified recovery-submenu navigation; all three were fixed and covered by focused regressions.
+- Data safety: deterministic tests compare settings and lock bytes, exercise the real guarded unlock,
+  and prove cancellation or refusal leaves the lock intact while successful recovery removes only the
+  eligible local lock.
+- Documentation and release: `packages/pi-sync/README.md` documents the flow, and
+  `.changeset/bright-sync-recovery.md` records a patch without schema or migration claims.
+- Package verification: `just pack sync` reports a 60-file dry-run tarball containing
+  `manager-recovery.ts` and `operation-availability.ts`, with no tests or credentials.
+- Changeset verification: `just changeset-status` reports the new pi-sync patch alongside the existing
+  independent pi-sync attention patch.
+- Repository gate: final `npm run check` passed build, Biome, boundaries, every workspace typecheck,
+  and 2,816 tests in 258 files.
+- Runtime smoke: a temporary-agent, no-session Pi RPC process loaded the local package and returned a
+  successful `get_commands` response containing `sync`, without credentials or remote access.
+- Source-size audit: `manager-ui.ts` remains below the repository boundary at 997 lines; the new
+  focused modules are 64 lines each, and no changed authored source exceeds 1,000 lines.
+- Live Git, WebDAV, S3, and R2 providers were not contacted because lock recovery is local-only and the
+  unchanged backend paths retain deterministic contract and publication coverage.
+
+## Completion Checklist
+
+- [x] A recoverable stale or unreadable lock makes the safe recovery action visible first without a
+      History submenu detour.
+- [x] The first frame explains why sync, Settings, and More are unavailable and when they return.
+- [x] Stale, unreadable, live, guard-owned, free, and inspection-error states have distinct,
+      actionable, non-color-only presentation.
+- [x] Live and guard-owned operations never expose forced lock removal.
+- [x] Recovery is confirmed, guard-aware, identity-rechecked, cancellation-safe, and limited to the
+      local operation lock.
+- [x] Successful recovery returns directly to the refreshed normal manager and restores Settings and
+      More without another `/sync` invocation or Back step.
+- [x] Failure, refusal, cancellation, disposal, replacement, reload, shutdown, and ownership races
+      preserve the previous valid settings, files, state, and remote data with specific feedback.
+- [x] TUI rendering is sanitized and bounded at 32, 60, and 100 columns plus constrained heights, with
+      injected keyboard navigation and textual accessibility cues intact.
+- [x] RPC, print/JSON handling, direct commands, completions, settings schema, snapshot/state/backend
+      formats, credentials, permissions, unknown fields, and existing recovery/history routes remain
+      compatible.
+- [x] Focused tests, all pi-sync tests, the repository CI-equivalent gate, diff check, package dry run,
+      Changeset status, and deterministic Pi/RPC smoke pass with evidence recorded.
+- [x] The final diff contains only approved scope, all convention audits are documented, no authored
+      source exceeds the 1,000-line boundary without resolution, and the completed plan is archived.

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -62,6 +62,27 @@ and recovery. Secondary screens provide **Back**; Escape goes back and Ctrl+C cl
 Destructive, credential-bearing, and externally visible operations retain exact specialized previews
 and confirmations.
 
+### Restore sync access
+
+When an operation is currently running, the manager shows its command and process ID, keeps sync and
+settings changes unavailable, and puts **Refresh operation status** first.
+When lock metadata is still protected by an active guard, the manager explains that another pi-sync
+process may be starting or finishing and asks the user to wait before refreshing.
+It never offers lock removal while an owner or guard may still be active.
+
+When a previous operation appears to have stopped without releasing its local lock, the manager shows
+**Sync paused** and puts **Restore sync access… (recommended)** first instead of hiding recovery
+inside **History & recovery…**.
+Unreadable metadata receives a stronger warning because pi-sync cannot verify who owns it.
+Close every other Pi session that may still be syncing, review the local-lock-only confirmation, then
+choose **Remove local lock and continue**.
+The guarded recovery path rechecks metadata and ownership before removal, changes no settings, local
+files, sync state, or remote data, and returns directly to the normal manager when access is restored.
+Cancellation leaves the lock unchanged.
+If ownership changes or a guard is still expiring, pi-sync refuses removal and keeps actionable status
+available for refresh or retry.
+The deterministic fallback remains `/sync unlock --stale` after the same no-other-sync verification.
+
 ### Resolve conflicts in the manager
 
 When **Sync now**, **Pull from remote…**, or **Push to remote…** finds changes that require a human direction choice, the manager opens **Resolve sync conflict** instead of ending at a command-only error.
@@ -338,6 +359,9 @@ packages/pi-sync/
 │   ├── state-directory.ts
 │   ├── settings-management.ts
 │   ├── manager-ui.ts
+│   ├── manager-state.ts
+│   ├── manager-recovery.ts
+│   ├── operation-availability.ts
 │   ├── manager-attention.ts
 │   ├── sync-attention.ts
 │   ├── storage-connections-ui.ts

--- a/packages/pi-sync/src/lock.ts
+++ b/packages/pi-sync/src/lock.ts
@@ -152,7 +152,9 @@ export function isStaleLock(lock: LockFile) {
 }
 
 export async function unlock(ctx: ExtensionCommandContext, options: CommandOptions) {
+	throwIfAborted(options.signal);
 	await ensureStateDir();
+	throwIfAborted(options.signal);
 	let guard: Guard;
 	try {
 		guard = await acquireGuard();
@@ -179,7 +181,9 @@ export async function unlock(ctx: ExtensionCommandContext, options: CommandOptio
 }
 
 async function unlockGuarded(ctx: ExtensionCommandContext, options: CommandOptions) {
+	throwIfAborted(options.signal);
 	let inspection = await inspectLock();
+	throwIfAborted(options.signal);
 	if (inspection.status === "missing") {
 		ctx.ui.notify("No pi-sync lock is present.", "info");
 		return;
@@ -193,12 +197,19 @@ async function unlockGuarded(ctx: ExtensionCommandContext, options: CommandOptio
 			return;
 		}
 		inspection = await inspectLock();
+		throwIfAborted(options.signal);
 		if (inspection.status === "unreadable") {
 			// Legacy writers expose an empty file before writing owner metadata, so no
 			// automatic test can prove this file is abandoned. The explicit --stale
 			// flag is the user's confirmation that no legacy sync is still running.
+			throwIfAborted(options.signal);
 			await fs.rm(lockPath(), { force: true });
-			ctx.ui.notify("Removed unreadable pi-sync lock.", "info");
+			if (!options.signal?.aborted) {
+				ctx.ui.notify(
+					"Removed unreadable pi-sync lock. No settings, files, sync state, or remote data were changed.",
+					"info",
+				);
+			}
 			return;
 		}
 		if (inspection.status === "missing") {
@@ -210,8 +221,21 @@ async function unlockGuarded(ctx: ExtensionCommandContext, options: CommandOptio
 		ctx.ui.notify("Lock owner is still live; refusing to remove it.", "warning");
 		return;
 	}
+	throwIfAborted(options.signal);
 	await fs.rm(lockPath(), { force: true });
-	ctx.ui.notify("Removed stale pi-sync lock.", "info");
+	if (!options.signal?.aborted) {
+		ctx.ui.notify(
+			"Removed stale pi-sync lock. No settings, files, sync state, or remote data were changed.",
+			"info",
+		);
+	}
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error
+		? signal.reason
+		: new DOMException("The operation was aborted", "AbortError");
 }
 
 async function releaseGuard(guard: Guard) {

--- a/packages/pi-sync/src/manager-recovery.ts
+++ b/packages/pi-sync/src/manager-recovery.ts
@@ -1,0 +1,65 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { runConfirmation } from "@narumitw/pi-tui-kit";
+import type { RunRoute } from "./cancellable-operation.js";
+import { errorMessage, safeTerminalText } from "./manager-helpers.js";
+import type { ManagerDescription } from "./manager-state.js";
+import { inspectOperationAvailability, operationCanRecover } from "./operation-availability.js";
+
+export type RecoveryDisposition = "restored" | "stay" | "close";
+
+export async function recoverSyncAccess(
+	ctx: ExtensionCommandContext,
+	manager: ManagerDescription,
+	runRoute: RunRoute,
+	sessionSignal: AbortSignal | undefined,
+	actionSignal: AbortSignal,
+): Promise<RecoveryDisposition> {
+	const operation = manager.operation;
+	if (!operation || !operationCanRecover(operation)) {
+		ctx.ui.notify(
+			"Operation status changed. Refresh the manager before retrying recovery.",
+			"warning",
+		);
+		return "stay";
+	}
+	const signal = sessionSignal ? AbortSignal.any([sessionSignal, actionSignal]) : actionSignal;
+	if (signal.aborted) return "close";
+	const unreadable = operation.kind === "recoverable-unreadable";
+	const details = unreadable
+		? "Pi-sync cannot verify who owns the unreadable lock. Close other Pi sessions that may be syncing before continuing."
+		: `The recorded ${safeTerminalText(operation.lock.command)} operation (pid ${operation.lock.pid}) appears to have stopped. Close other Pi sessions that may still be syncing before continuing.`;
+	const confirmation = await runConfirmation(ctx, {
+		title: "Restore sync access?",
+		message: [
+			details,
+			"",
+			"This removes only the local operation lock.",
+			"It does not change settings, local files, sync state, or remote data.",
+		].join("\n"),
+		confirmLabel: "Remove local lock and continue",
+		cancelLabel: "Cancel",
+		signal,
+		isCurrent: () => !signal.aborted,
+		onError: (_currentCtx, error) => {
+			ctx.ui.notify(
+				`Recovery confirmation failed: ${safeTerminalText(errorMessage(error))}`,
+				"error",
+			);
+		},
+	});
+	if (confirmation.kind === "stale") return "close";
+	if (confirmation.kind === "closed") {
+		if (confirmation.reason === "close") return "close";
+		if (!signal.aborted) {
+			ctx.ui.notify("Recovery cancelled; the local operation lock was not changed.", "info");
+		}
+		return "stay";
+	}
+	if (confirmation.kind !== "confirmed") return "stay";
+	if (signal.aborted) return "close";
+	await runRoute(unreadable ? "unlock --stale" : "unlock", signal);
+	if (signal.aborted) return "close";
+	const latest = await inspectOperationAvailability();
+	if (signal.aborted) return "close";
+	return latest.kind === "free" ? "restored" : "stay";
+}

--- a/packages/pi-sync/src/manager-state.ts
+++ b/packages/pi-sync/src/manager-state.ts
@@ -1,3 +1,4 @@
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import {
 	activeLocalConfigPath,
 	isCloudflareR2Endpoint,
@@ -5,8 +6,13 @@ import {
 	readLocalConfigObject,
 	readStateForConfig,
 } from "./config.js";
-import { inspectLock, isStaleLock } from "./lock.js";
 import { errorMessage, ownRecord, safeTerminalText } from "./manager-helpers.js";
+import {
+	inspectOperationAvailability,
+	type OperationAvailability,
+	operationBlocksChanges,
+	operationCanRecover,
+} from "./operation-availability.js";
 import { type SyncAttentionState, syncAttentionMatchesConfig } from "./sync-attention.js";
 import { compareSyncInclude, syncIncludeSelection } from "./sync-policy.js";
 import { countValidSyncSetups } from "./sync-setups-ui.js";
@@ -23,6 +29,7 @@ export const MAIN_MENU_ACTIONS = [
 export interface ManagerDescription {
 	title: string;
 	actions: string[];
+	operation?: OperationAvailability;
 	attention?: SyncAttentionState;
 	attentionBlocksSync?: boolean;
 	attentionReviewDisabled?: boolean;
@@ -31,6 +38,7 @@ export interface ManagerDescription {
 export async function describeManagerState(
 	signal?: AbortSignal,
 	attention?: SyncAttentionState,
+	inspectOperation: () => Promise<OperationAvailability> = inspectOperationAvailability,
 ): Promise<ManagerDescription> {
 	let raw: Record<string, unknown> | undefined;
 	try {
@@ -71,10 +79,8 @@ export async function describeManagerState(
 	}
 	try {
 		const config = await loadConfig();
-		const lock = await inspectLock();
-		const liveLock = lock.status === "valid" && !isStaleLock(lock.lock);
-		const recoverableLock =
-			lock.status === "unreadable" || (lock.status === "valid" && isStaleLock(lock.lock));
+		const operation = await inspectOperation();
+		const changesBlocked = operationBlocksChanges(operation);
 		const selection = syncIncludeSelection(config.include);
 		let currentAttention: SyncAttentionState | undefined;
 		if (attention) {
@@ -96,72 +102,61 @@ export async function describeManagerState(
 				)
 			: undefined;
 		const noSyncedContent = config.include.length === 0;
-		const syncState =
-			liveLock || recoverableLock
-				? undefined
-				: await readStateForConfig(config).catch(() => undefined);
-		const lastAppliedSnapshot =
-			liveLock || recoverableLock
-				? "Unavailable while operations are locked"
-				: syncState?.lastAppliedSnapshot
-					? safeTerminalText(syncState.lastAppliedSnapshot)
-					: syncState
-						? "Never synced"
-						: "Unavailable";
+		const syncState = changesBlocked
+			? undefined
+			: await readStateForConfig(config).catch(() => undefined);
+		const lastAppliedSnapshot = changesBlocked
+			? "Unavailable while operations are locked"
+			: syncState?.lastAppliedSnapshot
+				? safeTerminalText(syncState.lastAppliedSnapshot)
+				: syncState
+					? "Never synced"
+					: "Unavailable";
 		const canSwitch = (await countValidSyncSetups(configuredTargets, signal)) > 1;
 		const mainActions = MAIN_MENU_ACTIONS.filter(
 			(action) => action !== "Switch sync setup" || canSwitch,
 		);
+		const ordinaryTitle = [
+			"Manage sync",
+			"",
+			`Current sync setup: ${safeTerminalText(config.setupName)}`,
+			`Storage: ${backendStorageDescription(config)}`,
+			`Included: ${selection.builtIns.length} built-in group${selection.builtIns.length === 1 ? "" : "s"} · ${selection.custom.length} extra path${selection.custom.length === 1 ? "" : "s"} · Sessions ${selection.sessions ? "on" : "off"}`,
+			`Automatic sync: ${config.automatic ? "On" : "Off"}`,
+			`Last applied: ${lastAppliedSnapshot}`,
+			...(currentAttention
+				? [
+						currentAttention.decision.setupName === config.setupName
+							? "Sync status: Review needed"
+							: `Sync status: Review needed for setup ${safeTerminalText(currentAttention.decision.setupName)}`,
+						attentionComparison?.remoteOnly.length === 0 &&
+						attentionComparison.localOnly.length === 0
+							? "Only the synced-content order differs."
+							: `Remote-only paths: ${attentionComparison?.remoteOnly.length ?? 0} · Device-only paths: ${attentionComparison?.localOnly.length ?? 0}`,
+						"Nothing has been changed.",
+					]
+				: ["Remote status: Not checked"]),
+			...(noSyncedContent
+				? [
+						"",
+						"No included content is selected. Choose included content in Settings before syncing.",
+					]
+				: []),
+			"",
+			"What do you want to do?",
+		];
 		return {
-			title: [
-				"Manage sync",
-				"",
-				`Current sync setup: ${safeTerminalText(config.setupName)}`,
-				`Storage: ${backendStorageDescription(config)}`,
-				`Included: ${selection.builtIns.length} built-in group${selection.builtIns.length === 1 ? "" : "s"} · ${selection.custom.length} extra path${selection.custom.length === 1 ? "" : "s"} · Sessions ${selection.sessions ? "on" : "off"}`,
-				`Automatic sync: ${config.automatic ? "On" : "Off"}`,
-				`Last applied: ${lastAppliedSnapshot}`,
-				...(currentAttention
-					? [
-							currentAttention.decision.setupName === config.setupName
-								? "Sync status: Review needed"
-								: `Sync status: Review needed for setup ${safeTerminalText(currentAttention.decision.setupName)}`,
-							attentionComparison?.remoteOnly.length === 0 &&
-							attentionComparison.localOnly.length === 0
-								? "Only the synced-content order differs."
-								: `Remote-only paths: ${attentionComparison?.remoteOnly.length ?? 0} · Device-only paths: ${attentionComparison?.localOnly.length ?? 0}`,
-							"Nothing has been changed.",
-						]
-					: ["Remote status: Not checked"]),
-				...(noSyncedContent
-					? [
-							"",
-							"No included content is selected. Choose included content in Settings before syncing.",
-						]
-					: []),
-				...(liveLock
-					? [
-							"",
-							`Operation in progress: ${safeTerminalText(lock.lock.command)} (pid ${lock.lock.pid}). Sync and settings changes are disabled.`,
-						]
-					: []),
-				...(recoverableLock
-					? ["", "Recovery required: lock metadata is stale or unreadable."]
-					: []),
-				"",
-				"What do you want to do?",
-			].join("\n"),
-			actions:
-				liveLock || recoverableLock
-					? ["Status & changes", "History & recovery…", "Help"]
-					: noSyncedContent
-						? ["Settings", ...(canSwitch ? ["Switch sync setup"] : []), "Status & changes", "More…"]
-						: mainActions,
+			title: (changesBlocked
+				? ["Manage sync", ...operationStatusLines(operation)]
+				: ordinaryTitle
+			).join("\n"),
+			actions: operationActions(operation, noSyncedContent, canSwitch, mainActions),
+			operation,
 			...(currentAttention
 				? {
 						attention: currentAttention,
 						attentionBlocksSync: currentAttention.decision.setupName === config.setupName,
-						attentionReviewDisabled: liveLock || recoverableLock,
+						attentionReviewDisabled: changesBlocked,
 					}
 				: {}),
 		};
@@ -180,6 +175,57 @@ export async function describeManagerState(
 			].join("\n"),
 			actions: ["Sync setups…", "Storage connections…", "History & recovery…", "Help"],
 		};
+	}
+}
+
+function operationActions(
+	operation: OperationAvailability,
+	noSyncedContent: boolean,
+	canSwitch: boolean,
+	mainActions: string[],
+) {
+	if (operationCanRecover(operation)) {
+		return [
+			"Restore sync access… (recommended)",
+			"Status & changes",
+			"History & recovery…",
+			"Help",
+		];
+	}
+	if (operation.kind !== "free") {
+		return ["Refresh operation status", "Status & changes", "History & recovery…", "Help"];
+	}
+	return noSyncedContent
+		? ["Settings", ...(canSwitch ? ["Switch sync setup"] : []), "Status & changes", "More…"]
+		: mainActions;
+}
+
+function operationStatusLines(operation: OperationAvailability): string[] {
+	switch (operation.kind) {
+		case "free":
+			return [];
+		case "live": {
+			const command = truncateToWidth(safeTerminalText(operation.lock.command), 16, "…");
+			return [
+				`Running: ${command} (pid ${operation.lock.pid}). Wait, then refresh; Settings and More return.`,
+			];
+		}
+		case "busy":
+			return [
+				"Pi-sync may be starting or finishing. Wait, then refresh; Settings and More remain unavailable.",
+			];
+		case "recoverable-stale":
+			return [
+				"Sync paused: old lock remains. Close other Pi sessions then restore; Settings and More return.",
+			];
+		case "recoverable-unreadable":
+			return [
+				"Sync paused: owner unknown. Close other Pi sessions then restore; Settings and More return.",
+			];
+		case "inspection-error":
+			return [
+				"Lock check failed. Fix path access, then refresh; Settings and More remain unavailable.",
+			];
 	}
 }
 

--- a/packages/pi-sync/src/manager-ui.ts
+++ b/packages/pi-sync/src/manager-ui.ts
@@ -13,7 +13,6 @@ import {
 	syncConfigReviewIdentity,
 } from "./config.js";
 import { showAddGitTarget, showEditGitTarget, showGitSetup } from "./git-ui.js";
-import { inspectLock, isStaleLock } from "./lock.js";
 import {
 	attentionMainMenuItems,
 	blockedSyncMenuItem,
@@ -27,8 +26,10 @@ import {
 	requiredInput,
 	safeTerminalText,
 } from "./manager-helpers.js";
+import { recoverSyncAccess } from "./manager-recovery.js";
 import { dispatchManagerResult } from "./manager-result-dispatcher.js";
 import { backendStorageDescription, describeManagerState } from "./manager-state.js";
+import { operationCanRecover } from "./operation-availability.js";
 import { chooseS3Credentials } from "./s3-credentials-ui.js";
 import {
 	addSyncSetup,
@@ -68,28 +69,34 @@ export async function showSyncManager(
 		| "history"
 		| "doctor"
 		| "unlock"
+		| "recover"
+		| "refresh"
 		| "help"
 		| "init"
 		| "back";
 	interface State {
 		manager: Awaited<ReturnType<typeof describeManagerState>>;
-		canRecover: boolean;
 	}
 	const menu = defineMenu<State, Screen, Action, ExtensionCommandContext>({
 		start: "main",
 		screens: {
-			main: ({ state }) => ({
-				kind: "actions",
-				title: "Manage sync",
-				lines: state.manager.title.split("\n").slice(1),
-				items: [
-					...attentionMainMenuItems(state.manager),
-					...state.manager.actions.map(
-						(label) => blockedSyncMenuItem(label, state.manager) ?? syncMainMenuItem(label),
-					),
-				],
-				hint: "close",
-			}),
+			main: ({ state }) => {
+				const attentionItems = attentionMainMenuItems(state.manager);
+				const managerItems = state.manager.actions.map(
+					(label) => blockedSyncMenuItem(label, state.manager) ?? syncMainMenuItem(label),
+				);
+				const operationFirst =
+					state.manager.operation !== undefined && state.manager.operation.kind !== "free";
+				return {
+					kind: "actions",
+					title: "Manage sync",
+					lines: state.manager.title.split("\n").slice(1),
+					items: operationFirst
+						? [...managerItems, ...attentionItems]
+						: [...attentionItems, ...managerItems],
+					hint: "close",
+				};
+			},
 			more: () => ({
 				kind: "actions",
 				title: "More options",
@@ -114,7 +121,7 @@ export async function showSyncManager(
 				items: [
 					{ id: "history", label: "Browse history", action: "history" },
 					{ id: "doctor", label: "Check setup", action: "doctor" },
-					...(state.canRecover
+					...(state.manager.operation && operationCanRecover(state.manager.operation)
 						? [{ id: "unlock", label: "Recover stale operation", action: "unlock" as const }]
 						: []),
 					{ id: "back", label: "Back", action: "back" },
@@ -242,10 +249,28 @@ export async function showSyncManager(
 				await runRoute("doctor");
 				return { kind: "stay" };
 			},
-			unlock: async () => {
-				await runRoute("unlock --stale");
-				return { kind: "stay" };
+			unlock: async ({ state, signal: actionSignal }) => {
+				const result = await recoverSyncAccess(
+					ctx,
+					state.manager,
+					runRoute,
+					sessionSignal,
+					actionSignal,
+				);
+				if (result === "close") return { kind: "close" };
+				return result === "restored" ? { kind: "to", screen: "main" } : { kind: "stay" };
 			},
+			recover: async ({ state, signal: actionSignal }) => {
+				const result = await recoverSyncAccess(
+					ctx,
+					state.manager,
+					runRoute,
+					sessionSignal,
+					actionSignal,
+				);
+				return { kind: result === "close" ? "close" : "stay" };
+			},
+			refresh: async () => ({ kind: "stay" }),
 			help: async () => {
 				await runRoute("help");
 				return { kind: "close" };
@@ -260,18 +285,11 @@ export async function showSyncManager(
 	await runMenu(ctx, menu, {
 		getState: async () => {
 			const pendingAttention = options.getAttention?.();
-			const [manager, lock] = await Promise.all([
-				describeManagerState(sessionSignal, pendingAttention),
-				inspectLock(),
-			]);
+			const manager = await describeManagerState(sessionSignal, pendingAttention);
 			if (pendingAttention && options.getAttention?.() === pendingAttention && !manager.attention) {
 				options.onSelectionResolved?.(pendingAttention);
 			}
-			return {
-				manager,
-				canRecover:
-					lock.status === "unreadable" || (lock.status === "valid" && isStaleLock(lock.lock)),
-			};
+			return { manager };
 		},
 		signal: sessionSignal,
 		isCurrent: () => !sessionSignal?.aborted,
@@ -282,18 +300,38 @@ function syncMainMenuItem(
 	label: string,
 ): ActionMenuItem<
 	"main" | "more" | "recovery",
-	"sync" | "switch" | "diff" | "settings" | "setups" | "connections" | "help" | "init"
+	| "sync"
+	| "switch"
+	| "diff"
+	| "settings"
+	| "setups"
+	| "connections"
+	| "recover"
+	| "refresh"
+	| "help"
+	| "init"
 > {
 	if (label === "More…") return { id: "more", label, to: "more" };
 	if (label === "History & recovery…") return { id: "recovery", label, to: "recovery" };
 	const actions = new Map<
 		string,
-		"sync" | "switch" | "diff" | "settings" | "setups" | "connections" | "help" | "init"
+		| "sync"
+		| "switch"
+		| "diff"
+		| "settings"
+		| "setups"
+		| "connections"
+		| "recover"
+		| "refresh"
+		| "help"
+		| "init"
 	>([
 		["Sync now (recommended)", "sync"],
 		["Switch sync setup", "switch"],
 		["Status & changes", "diff"],
 		["Settings", "settings"],
+		["Restore sync access… (recommended)", "recover"],
+		["Refresh operation status", "refresh"],
 		["Sync setups…", "setups"],
 		["Storage connections…", "connections"],
 		["Help", "help"],

--- a/packages/pi-sync/src/operation-availability.ts
+++ b/packages/pi-sync/src/operation-availability.ts
@@ -1,0 +1,64 @@
+import { inspectLock, isLockGuardHeld, isStaleLock, type LockInspection } from "./lock.js";
+import { errorMessage } from "./manager-helpers.js";
+import type { LockFile } from "./types.js";
+
+export type OperationAvailability =
+	| { kind: "free" }
+	| { kind: "live"; lock: LockFile }
+	| { kind: "busy"; lock?: LockFile; metadata: LockInspection["status"] }
+	| { kind: "recoverable-stale"; lock: LockFile }
+	| { kind: "recoverable-unreadable" }
+	| { kind: "inspection-error"; message: string };
+
+interface OperationInspectionDependencies {
+	inspectMetadata(): Promise<LockInspection>;
+	inspectGuard(): Promise<boolean>;
+}
+
+const DEFAULT_INSPECTION_DEPENDENCIES: OperationInspectionDependencies = {
+	inspectMetadata: inspectLock,
+	inspectGuard: isLockGuardHeld,
+};
+
+export async function inspectOperationAvailability(
+	dependencies: OperationInspectionDependencies = DEFAULT_INSPECTION_DEPENDENCIES,
+): Promise<OperationAvailability> {
+	try {
+		const metadata = await dependencies.inspectMetadata();
+		const guardHeld = await dependencies.inspectGuard();
+		return classifyOperationAvailability(metadata, guardHeld);
+	} catch (error) {
+		return { kind: "inspection-error", message: errorMessage(error) };
+	}
+}
+
+export function classifyOperationAvailability(
+	metadata: LockInspection,
+	guardHeld: boolean,
+): OperationAvailability {
+	if (metadata.status === "valid" && !isStaleLock(metadata.lock)) {
+		return { kind: "live", lock: metadata.lock };
+	}
+	if (guardHeld) {
+		return {
+			kind: "busy",
+			metadata: metadata.status,
+			...(metadata.status === "valid" ? { lock: metadata.lock } : {}),
+		};
+	}
+	if (metadata.status === "valid") {
+		return { kind: "recoverable-stale", lock: metadata.lock };
+	}
+	if (metadata.status === "unreadable") return { kind: "recoverable-unreadable" };
+	return { kind: "free" };
+}
+
+export function operationBlocksChanges(availability: OperationAvailability) {
+	return availability.kind !== "free";
+}
+
+export function operationCanRecover(availability: OperationAvailability) {
+	return (
+		availability.kind === "recoverable-stale" || availability.kind === "recoverable-unreadable"
+	);
+}

--- a/packages/pi-sync/test/manager-recovery.test.ts
+++ b/packages/pi-sync/test/manager-recovery.test.ts
@@ -1,0 +1,587 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import fs from "node:fs/promises";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { ensureStateDir, localConfigPath, lockPath } from "../src/config.js";
+import { isLockGuardHeld, unlock } from "../src/lock.js";
+import { describeManagerState } from "../src/manager-state.js";
+import { showSyncManager } from "../src/manager-ui.js";
+import {
+	classifyOperationAvailability,
+	inspectOperationAvailability,
+} from "../src/operation-availability.js";
+import type { CommandOptions } from "../src/types.js";
+import { v3S3Settings, withTempHome } from "./helpers.js";
+
+initTheme("dark", false);
+
+const unlockOptions: CommandOptions = {
+	yes: false,
+	force: false,
+	stale: true,
+	silent: false,
+	reload: true,
+	auto: false,
+	args: [],
+};
+
+test("operation availability keeps guarded and inspection-error states distinct", async () => {
+	const deadLock = {
+		id: "dead-owner",
+		pid: 2_147_483_647,
+		command: "sync",
+		startedAt: new Date().toISOString(),
+	};
+	assert.equal(
+		classifyOperationAvailability({ status: "valid", lock: deadLock }, true).kind,
+		"busy",
+	);
+	assert.equal(
+		classifyOperationAvailability({ status: "unreadable" }, false).kind,
+		"recoverable-unreadable",
+	);
+	const failed = await inspectOperationAvailability({
+		inspectMetadata: async () => {
+			throw new Error("permission denied");
+		},
+		inspectGuard: async () => false,
+	});
+	assert.deepEqual(failed, { kind: "inspection-error", message: "permission denied" });
+});
+
+test("operation inspection failures are not mislabeled as settings errors", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		const manager = await describeManagerState(undefined, undefined, async () => ({
+			kind: "inspection-error",
+			message: "permission denied",
+		}));
+		assert.match(manager.title, /Lock check failed/iu);
+		assert.doesNotMatch(manager.title, /Settings need attention/iu);
+		assert.equal(manager.actions[0], "Refresh operation status");
+	});
+});
+
+async function renderManagerWithLock(contents: string) {
+	return withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		writeFileSync(lockPath(), contents);
+		const titles: string[] = [];
+		const optionsSeen: string[][] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				titles.push(title);
+				optionsSeen.push(options);
+				return undefined;
+			},
+		});
+		await showSyncManager(ctx, async () => ({ kind: "completed" }));
+		return { rendered: titles.join("\n"), options: optionsSeen[0] ?? [] };
+	});
+}
+
+test("stale operation recovery is the first visible manager action", async () => {
+	const { rendered, options } = await renderManagerWithLock(
+		JSON.stringify({
+			id: "dead-owner",
+			pid: 2_147_483_647,
+			command: "sync",
+			startedAt: new Date().toISOString(),
+		}),
+	);
+	assert.match(rendered, /Sync paused/u);
+	assert.match(rendered, /Settings and More.*return/u);
+	assert.equal(options[0], "Restore sync access… (recommended)");
+});
+
+test("unreadable operation recovery explains that ownership cannot be verified", async () => {
+	const { rendered, options } = await renderManagerWithLock("{broken");
+	assert.match(rendered, /owner unknown/iu);
+	assert.match(rendered, /close other Pi sessions/iu);
+	assert.equal(options[0], "Restore sync access… (recommended)");
+});
+
+test("a live operation offers refresh without exposing lock removal", async () => {
+	const { rendered, options } = await renderManagerWithLock(
+		JSON.stringify({
+			id: "live-owner",
+			pid: process.pid,
+			command: "sync\u0007",
+			startedAt: new Date().toISOString(),
+		}),
+	);
+	assert.match(rendered, /Running: sync.*\(pid/u);
+	assert.equal(rendered.includes("\u0007"), false);
+	assert.equal(options[0], "Refresh operation status");
+	assert.equal(
+		options.some((option) => /Restore sync access/u.test(option)),
+		false,
+	);
+});
+
+test("guard-only operation state asks the user to wait instead of looking free", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		mkdirSync(`${lockPath()}.guard`);
+		const titles: string[] = [];
+		const optionsSeen: string[][] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (title: string, options: string[]) => {
+				titles.push(title);
+				optionsSeen.push(options);
+				return undefined;
+			},
+		});
+		await showSyncManager(ctx, async () => ({ kind: "completed" }));
+		assert.match(titles.join("\n"), /starting or finishing/iu);
+		assert.equal(optionsSeen[0]?.[0], "Refresh operation status");
+		assert.equal(
+			optionsSeen[0]?.some((option) => /Restore sync access/u.test(option)),
+			false,
+		);
+	});
+});
+
+test("RPC stale recovery confirms the local-only effect and returns directly to the normal manager", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const settingsBytes = Buffer.from(JSON.stringify(v3S3Settings()));
+		writeFileSync(localConfigPath(), settingsBytes, { mode: 0o600 });
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "dead-owner",
+				pid: 2_147_483_647,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		const rpc = createRpcHarness([
+			{ kind: "select", response: "Restore sync access… (recommended)" },
+			{ kind: "select", response: "Remove local lock and continue" },
+			{ kind: "select", response: undefined },
+		]);
+		const base = createMockContext({ hasUI: true, mode: "rpc" });
+		const ctx = withRpcUi(base.ctx, rpc);
+		const routes: string[] = [];
+		await showSyncManager(ctx, async (route) => {
+			routes.push(route);
+			if (route === "unlock") await fs.rm(lockPath(), { force: true });
+			return { kind: "completed" };
+		});
+		rpc.assertConsumed();
+		assert.deepEqual(routes, ["unlock"]);
+		assert.equal(await fileExists(lockPath()), false);
+		assert.deepEqual(readFileSync(localConfigPath()), settingsBytes);
+		assert.match(rpc.dialogs[1]?.title ?? "", /only the local operation lock/iu);
+		assert.ok(rpc.dialogs[2]?.options?.includes("More…"));
+	});
+});
+
+test("RPC unreadable recovery uses explicit stale authorization", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		writeFileSync(lockPath(), "{broken");
+		const rpc = createRpcHarness([
+			{ kind: "select", response: "Restore sync access… (recommended)" },
+			{ kind: "select", response: "Remove local lock and continue" },
+			{ kind: "select", response: undefined },
+		]);
+		const base = createMockContext({ hasUI: true, mode: "rpc" });
+		const ctx = withRpcUi(base.ctx, rpc);
+		const routes: string[] = [];
+		await showSyncManager(ctx, async (route) => {
+			routes.push(route);
+			if (route === "unlock --stale") await fs.rm(lockPath(), { force: true });
+			return { kind: "completed" };
+		});
+		rpc.assertConsumed();
+		assert.deepEqual(routes, ["unlock --stale"]);
+		assert.match(rpc.dialogs[1]?.title ?? "", /cannot verify who owns/iu);
+	});
+});
+
+test("recovery cancellation preserves the lock and returns to the paused manager", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		const bytes = Buffer.from("{broken");
+		writeFileSync(lockPath(), bytes);
+		const rpc = createRpcHarness([
+			{ kind: "select", response: "Restore sync access… (recommended)" },
+			{ kind: "select", response: "Cancel" },
+			{ kind: "select", response: undefined },
+		]);
+		const base = createMockContext({ hasUI: true, mode: "rpc" });
+		const ctx = withRpcUi(base.ctx, rpc);
+		let routeCalled = false;
+		await showSyncManager(ctx, async () => {
+			routeCalled = true;
+			return { kind: "completed" };
+		});
+		rpc.assertConsumed();
+		assert.equal(routeCalled, false);
+		assert.deepEqual(readFileSync(lockPath()), bytes);
+		assert.match(base.notifications.at(-1)?.message ?? "", /cancelled.*not changed/iu);
+		assert.equal(rpc.dialogs[2]?.options?.[0], "Restore sync access… (recommended)");
+	});
+});
+
+test("refresh returns a finished live operation directly to the normal manager", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "live-owner",
+				pid: process.pid,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		const optionsSeen: string[][] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async (_title: string, options: string[]) => {
+				optionsSeen.push(options);
+				if (options[0] === "Refresh operation status") {
+					await fs.rm(lockPath(), { force: true });
+					return "Refresh operation status";
+				}
+				return undefined;
+			},
+		});
+		await showSyncManager(ctx, async () => ({ kind: "completed" }));
+		assert.equal(optionsSeen[0]?.[0], "Refresh operation status");
+		assert.ok(optionsSeen[1]?.includes("More…"));
+	});
+});
+
+test("a lock that becomes live during recovery is not removed and refreshes to the live state", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		writeFileSync(lockPath(), "{broken");
+		const rpc = createRpcHarness([
+			{ kind: "select", response: "Restore sync access… (recommended)" },
+			{ kind: "select", response: "Remove local lock and continue" },
+			{ kind: "select", response: undefined },
+		]);
+		const base = createMockContext({ hasUI: true, mode: "rpc" });
+		const ctx = withRpcUi(base.ctx, rpc);
+		await showSyncManager(ctx, async () => {
+			writeFileSync(
+				lockPath(),
+				JSON.stringify({
+					id: "new-live-owner",
+					pid: process.pid,
+					command: "pull",
+					startedAt: new Date().toISOString(),
+				}),
+			);
+			return { kind: "completed" };
+		});
+		rpc.assertConsumed();
+		assert.equal(rpc.dialogs[2]?.options?.[0], "Refresh operation status");
+		assert.equal(await fileExists(lockPath()), true);
+	});
+});
+
+test("a guard acquired after confirmation blocks the real unlock path", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		const bytes = Buffer.from("{broken");
+		writeFileSync(lockPath(), bytes);
+		const optionsSeen: string[][] = [];
+		let selection = 0;
+		const mock = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			select: async (_title: string, options: string[]) => {
+				optionsSeen.push(options);
+				selection += 1;
+				if (selection === 1) return "Restore sync access… (recommended)";
+				if (selection === 2) {
+					mkdirSync(`${lockPath()}.guard`);
+					return "Remove local lock and continue";
+				}
+				return undefined;
+			},
+		});
+		await showSyncManager(mock.ctx, async (route, signal) => {
+			assert.equal(route, "unlock --stale");
+			await unlock(mock.ctx, { ...unlockOptions, signal });
+			return { kind: "completed" };
+		});
+		assert.deepEqual(readFileSync(lockPath()), bytes);
+		assert.equal(optionsSeen[2]?.[0], "Refresh operation status");
+		assert.match(mock.notifications.at(-1)?.message ?? "", /currently running/iu);
+	});
+});
+
+test("recovery from History returns directly to the normal main manager", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		writeFileSync(lockPath(), "{broken");
+		const rpc = createRpcHarness([
+			{ kind: "select", response: "History & recovery…" },
+			{ kind: "select", response: "Recover stale operation" },
+			{ kind: "select", response: "Remove local lock and continue" },
+			{ kind: "select", response: undefined },
+		]);
+		const base = createMockContext({ hasUI: true, mode: "rpc" });
+		const ctx = withRpcUi(base.ctx, rpc);
+		await showSyncManager(ctx, async (route) => {
+			assert.equal(route, "unlock --stale");
+			await fs.rm(lockPath(), { force: true });
+			return { kind: "completed" };
+		});
+		rpc.assertConsumed();
+		assert.ok(rpc.dialogs[3]?.options?.includes("More…"));
+	});
+});
+
+test("cancelling recovery from History stays in recovery without calling unlock", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		const bytes = Buffer.from("{broken");
+		writeFileSync(lockPath(), bytes);
+		const rpc = createRpcHarness([
+			{ kind: "select", response: "History & recovery…" },
+			{ kind: "select", response: "Recover stale operation" },
+			{ kind: "select", response: "Cancel" },
+			{ kind: "select", response: "Back" },
+			{ kind: "select", response: undefined },
+		]);
+		const base = createMockContext({ hasUI: true, mode: "rpc" });
+		const ctx = withRpcUi(base.ctx, rpc);
+		let routeCalled = false;
+		await showSyncManager(ctx, async () => {
+			routeCalled = true;
+			return { kind: "completed" };
+		});
+		rpc.assertConsumed();
+		assert.equal(routeCalled, false);
+		assert.deepEqual(readFileSync(lockPath()), bytes);
+		assert.ok(rpc.dialogs[3]?.options?.includes("Recover stale operation"));
+	});
+});
+
+test("an owner abort immediately after confirmation cannot start unlock routing", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		const bytes = Buffer.from("{broken");
+		writeFileSync(lockPath(), bytes);
+		const owner = new AbortController();
+		let selection = 0;
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			select: async () => {
+				selection += 1;
+				if (selection === 1) return "Restore sync access… (recommended)";
+				owner.abort(new DOMException("Session replaced", "AbortError"));
+				return "Remove local lock and continue";
+			},
+		});
+		let routeCalled = false;
+		await showSyncManager(
+			ctx,
+			async () => {
+				routeCalled = true;
+				return { kind: "completed" };
+			},
+			owner.signal,
+		);
+		assert.equal(routeCalled, false);
+		assert.deepEqual(readFileSync(lockPath()), bytes);
+	});
+});
+
+test("abort after lock removal still releases the guard and suppresses stale success UI", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		await ensureStateDir();
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({
+				id: "dead-owner",
+				pid: 2_147_483_647,
+				command: "sync",
+				startedAt: new Date().toISOString(),
+			}),
+		);
+		const owner = new AbortController();
+		const originalRm = fs.rm;
+		fs.rm = (async (...args: Parameters<typeof fs.rm>) => {
+			const result = await originalRm(...args);
+			if (args[0] === lockPath()) {
+				owner.abort(new DOMException("Session replaced", "AbortError"));
+			}
+			return result;
+		}) as typeof fs.rm;
+		const mock = createMockContext({ hasUI: true, mode: "tui" });
+		try {
+			await unlock(mock.ctx, { ...unlockOptions, signal: owner.signal });
+			assert.equal(await fileExists(lockPath()), false);
+			assert.equal(await isLockGuardHeld(), false);
+			assert.equal(
+				mock.notifications.some(({ message }) => /Removed stale/iu.test(message)),
+				false,
+			);
+		} finally {
+			fs.rm = originalRm;
+		}
+	});
+});
+
+test("operation frames stay bounded and actionable at supported terminal sizes", async () => {
+	const scenarios = [
+		{
+			name: "unreadable",
+			prepare: () => writeFileSync(lockPath(), "{broken"),
+			action: /Restore sync access/iu,
+		},
+		{
+			name: "stale",
+			prepare: () =>
+				writeFileSync(
+					lockPath(),
+					JSON.stringify({
+						id: "dead-owner",
+						pid: 2_147_483_647,
+						command: "sync",
+						startedAt: new Date().toISOString(),
+					}),
+				),
+			action: /Restore sync access/iu,
+		},
+		{
+			name: "live",
+			prepare: () =>
+				writeFileSync(
+					lockPath(),
+					JSON.stringify({
+						id: "live-owner",
+						pid: process.pid,
+						command: "a-very-long-sync-operation-name",
+						startedAt: new Date().toISOString(),
+					}),
+				),
+			action: /Refresh operation status/iu,
+		},
+		{
+			name: "guarded",
+			prepare: () => mkdirSync(`${lockPath()}.guard`),
+			action: /Refresh operation status/iu,
+		},
+	];
+	for (const scenario of scenarios) {
+		for (const { width, rows } of [
+			{ width: 32, rows: 12 },
+			{ width: 60, rows: 16 },
+			{ width: 100, rows: 24 },
+		]) {
+			await withTempHome(async (agentDir) => {
+				mkdirSync(agentDir, { recursive: true });
+				writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+				await ensureStateDir();
+				scenario.prepare();
+				const tui = createTuiHarness({ width, rows });
+				const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+				const running = showSyncManager(ctx, async () => ({ kind: "completed" }));
+				await tui.waitForOpen();
+				const frame = tui.render();
+				assert.ok(frame.every((line) => visibleWidth(line) <= width));
+				assert.ok(
+					frame.length <= rows,
+					`${scenario.name} rendered ${frame.length} rows into a ${rows}-row terminal`,
+				);
+				assert.match(frame.join("\n"), scenario.action);
+				tui.press("ctrl+c");
+				await running;
+			});
+		}
+	}
+});
+
+test("session replacement during recovery confirmation leaves the lock untouched", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3S3Settings()), { mode: 0o600 });
+		await ensureStateDir();
+		const bytes = Buffer.from("{broken");
+		writeFileSync(lockPath(), bytes);
+		const owner = new AbortController();
+		const tui = createTuiHarness({ width: 60, rows: 16 });
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+		let routeCalled = false;
+		const running = showSyncManager(
+			ctx,
+			async () => {
+				routeCalled = true;
+				return { kind: "completed" };
+			},
+			owner.signal,
+		);
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await waitForOpenCount(tui, 2);
+		owner.abort(new DOMException("Session replaced", "AbortError"));
+		await running;
+		assert.equal(routeCalled, false);
+		assert.deepEqual(readFileSync(lockPath()), bytes);
+	});
+});
+
+function withRpcUi(context: unknown, rpc: ReturnType<typeof createRpcHarness>): never {
+	const base = context as { ui: Record<string, unknown>; [key: string]: unknown };
+	return { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+}
+
+async function fileExists(filePath: string) {
+	try {
+		await fs.stat(filePath);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+async function waitForOpenCount(tui: ReturnType<typeof createTuiHarness>, count: number) {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (tui.openCount >= count) return;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+	assert.fail(`Timed out waiting for ${count} TUI interactions`);
+}


### PR DESCRIPTION
## Summary

- Put **Restore sync access…** first when stale or unreadable lock metadata pauses sync.
- Distinguish live, guarded, recoverable, free, and inspection-error operation states from one guard-aware snapshot.
- Confirm local-lock removal, preserve cancellation and session ownership, and return directly to normal manager actions after success.
- Keep blocked-state frames bounded at 32/60/100 columns and 12/16/24 rows.
- Document the recovery workflow and add a patch Changeset.

## Review and hardening

- Added an abort check between confirmation and unlock routing.
- Added a real guard-acquisition race regression that proves unlock refuses removal.
- Added main and History recovery navigation, cancellation, ownership-change, pre/post-commit abort, RPC, terminal-control, and no-side-effect coverage.

## Verification

- `npm run check` — passed build, Biome, boundaries, all workspace typechecks, and 2,816 tests in 258 files.
- `npx vitest run packages/pi-sync/test/manager-recovery.test.ts` — 18 tests passed.
- `just changeset-status` — pi-sync patch detected.
- `just pack sync` — 60-file dry-run tarball inspected.
- Temporary-agent Pi RPC load smoke — `sync` command registered successfully.

No live Git, WebDAV, S3, or R2 provider was contacted because this recovery path is local-only.

Implementation evidence is archived in `docs/plans/archived/2026-08-10_pi-sync-operation-recovery-ux-plan.md`.
