### PR TITLE
feat(goal): add continuation delay

### DIFF
--- a/.changeset/calm-goals-wait.md
+++ b/.changeset/calm-goals-wait.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-goal": minor
+---
+
+Add a configurable minimum interval before automatic Goal continuation dispatch.

--- a/docs/plans/pi-goal-continuation-delay.md
+++ b/docs/plans/pi-goal-continuation-delay.md
@@ -1,0 +1,24 @@
+# Pi Goal continuation delay
+
+## Objective
+
+Add a supported `continuationLimits.minIntervalMs` setting so automatic Goal continuations can wait before dispatching.
+
+The default remains `0`, preserving current behavior.
+
+## Implementation
+
+1. Add and atomically persist a non-negative safe-integer `minIntervalMs` setting.
+2. Expose the setting in the existing Goal Settings menu.
+3. Reuse GoalRuntime's owned continuation timer for delayed dispatch.
+4. Cancel the timer through existing continuation cancellation and session-shutdown paths.
+5. Keep exact runtime-generation and goal-ID checks before dispatch.
+6. Document the setting and add a minor Changeset.
+
+## Success criteria and verification
+
+- **No overengineering:** reuse `continuationDispatchTimer`; add no companion extension, queue, or second scheduler.
+- **Behavioral tests:** prove no continuation before the interval, dispatch at the interval, and no dispatch after pause/replacement/shutdown.
+- **Reusable ownership:** settings parsing, UI, persistence, and runtime scheduling each retain one source of truth.
+- **SDD and TDD:** this repository has no `sdd/`; write failing settings/runtime/UI tests before production changes and verify through upstream CI.
+- `continuationLimits.automaticTurns: 10` and `continuationLimits.minIntervalMs: 60000` load together from `pi-goal.json`.

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -72,22 +72,31 @@ built-in defaults without creating the file:
   },
   "continuationLimits": {
     "automaticTurns": 25,
-    "noProgressTurns": 3
+    "noProgressTurns": 3,
+    "minIntervalMs": 0
   }
 }
 ```
 
-Use `/goal` → **Settings…** in the TUI to create or update the file interactively, or create
-and edit it directly. The standard Settings screen keeps all five controls on one level in task
-order; the two safety limits open standard choice screens:
+Use `/goal` → **Settings…** in the TUI to create or update the file interactively, or create and edit it directly.
+The standard Settings screen keeps all six controls on one level in task order.
+The safety limits and continuation delay open standard choice screens:
 
 - **Automatic-work limit** shows the exact response limit or **Unlimited**. Choose **Set response limit…** to edit the current finite value (or the built-in default of 25 when switching from Unlimited), or choose **Unlimited…**. Unlimited requires confirmation that tool loops may continue consuming tokens and provider cost without a response-count cap.
 - **No-progress guard** shows **_N_ runs** or **Off**. Choose the default threshold, **Off**, or **Set threshold…** and enter a safe whole number greater than zero.
+- **Continuation delay** shows **Off** for `0` or the configured milliseconds.
+  Choose **Off** or **Set delay…** and enter a non-negative safe whole number of milliseconds.
 - **Goal tools** controls whether all Goal tools are always visible or appear after the first goal.
 - **Ordered goal queue** controls the experimental ordered-goal workflows.
 - **Managed run RPC** controls whether trusted installed extensions may start and cancel managed Goal runs. It defaults to **Off** and is a cooperation setting, not an extension security sandbox.
 
-Custom number inputs reject zero, negative numbers, decimals, text, and unsafe integers without saving; use the explicit **Unlimited** or **Off** choice instead. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. A successful change updates the visible state immediately. A failed save restores the prior value and reports the settings path so it can be retried. Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy; retry after Pi settles. Escape returns to the previous screen without reverting changes that were already saved.
+Safety-limit number inputs reject zero, negative numbers, decimals, text, and unsafe integers without saving; use the explicit **Unlimited** or **Off** choice instead.
+The continuation-delay input accepts zero and rejects negative numbers, decimals, text, and unsafe integers.
+Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime.
+A successful change updates the visible state immediately.
+A failed save restores the prior value and reports the settings path so it can be retried.
+Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy; retry after Pi settles.
+Escape returns to the previous screen without reverting changes that were already saved.
 
 `toolVisibility` accepts:
 
@@ -102,6 +111,8 @@ Custom number inputs reject zero, negative numbers, decimals, text, and unsafe i
 
 - `automaticTurns` accepts a positive safe integer or `null` and defaults to `25`. It counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries. The user-triggered kickoff, resume, edit, and ordinary user runs are not charged. At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted before a 26th normal response starts. Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work. Set this field explicitly to `null` to opt into Unlimited mode; existing explicit `null` values remain compatible.
 - `noProgressTurns` is a positive safe integer and defaults to `3`. At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercasing, control-character removal, and whitespace collapse. Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent. Consecutive empty or identical tool-free outputs increment the repeat count. Different non-empty output starts a new run at one, and any attempted tool call resets it. Set this field to `null` to disable only this heuristic.
+- `minIntervalMs` is a non-negative safe integer and defaults to `0`.
+  It delays normal settled continuation dispatch and the manual-compaction fallback from their eligible scheduling boundary, while `0` preserves immediate dispatch.
 
 Settings are reread at Pi startup, session replacement, and `/reload`; direct external file edits are not watched live, while changes made through the Goal menu apply immediately. A missing file remains absent and uses the built-in defaults. The first successful settings change creates the file atomically; later saves preserve unknown fields.
 
@@ -217,9 +228,15 @@ Before completion, the shared audit tells the agent to treat completion as unpro
 
 To finish, the agent must call `goal_complete` with the exact current `goal_id` and a `summary` of completion evidence. Missing or stale `goal_id` values are rejected before summary validation. Paused, blocked, and usage-limited goals cannot be completed until resumed; a budget-limited goal permits completion only during its bounded in-flight wrap-up. The summary is completion evidence, not the stale-turn safety token.
 
-If a turn ends before completion, `pi-goal` records usage and creates one continuation intent unless a circuit breaker pauses it first. It dispatches that continuation only from Pi's `agent_settled` lifecycle after retries, automatic compaction, steering, and follow-up work have drained, `ctx.isIdle()` is true, and no messages are pending. Repeated settled events cannot dispatch the same intent twice. Goal-owned kickoff, resume, active-edit, and automatic-continuation deliveries are bound to the goal instance that created them; a delayed prompt from a replaced goal is aborted without rolling back, injecting, or stopping the newer goal. Plain assistant text never marks a goal complete—even an exact-reply objective pauses safely when the model repeatedly omits `goal_complete`.
+If a turn ends before completion, `pi-goal` records usage and creates one continuation intent unless a circuit breaker pauses it first.
+It dispatches that continuation only after Pi's `agent_settled` lifecycle proves retries, automatic compaction, steering, and follow-up work have drained, `ctx.isIdle()` is true, and no messages are pending.
+A configured `minIntervalMs` delay starts at that eligible settled scheduling boundary.
+Repeated settled events cannot dispatch the same intent twice or restart its active delay.
+Goal-owned kickoff, resume, active-edit, and automatic-continuation deliveries are bound to the goal instance that created them; a delayed prompt from a replaced goal is aborted without rolling back, injecting, or stopping the newer goal.
+Plain assistant text never marks a goal complete—even an exact-reply objective pauses safely when the model repeatedly omits `goal_complete`.
 
-Manual compaction does not emit `agent_settled`, so its completion hook uses the same single-flight dispatcher as a narrow idle-only fallback. Pi extensions cannot reserve an idle turn atomically like Codex core; another extension can still win the race after the idle check, and its newer turn supersedes the old continuation intent.
+Manual compaction does not emit `agent_settled`, so its completion hook uses the same single owned continuation timer as a narrow idle-only fallback and applies `minIntervalMs` from that eligible boundary.
+Pi extensions cannot reserve an idle turn atomically like Codex core; another extension can still win the race after the idle check, and its newer turn supersedes the old continuation intent.
 
 ## ⏳ External waiting
 

--- a/packages/pi-goal/src/lifecycle.ts
+++ b/packages/pi-goal/src/lifecycle.ts
@@ -225,9 +225,9 @@ export function registerGoalLifecycle(
 		runtime.requestContinuation(runtime.activeGoal);
 		// Pi emits session_compact before it clears its manual-compaction controller,
 		// so sendUserMessage still rejects inside this hook even when ctx reports idle.
-		// Defer one task; threshold compaction retains the intent for agent_settled
-		// when Pi is still busy.
-		runtime.scheduleContinuationDispatch(ctx, runtime.activeGoal.id);
+		// The owned timer defers one task at the default 0 ms or waits the configured interval.
+		// Threshold compaction retains the intent for agent_settled when Pi is still busy.
+		runtime.scheduleContinuationDispatch(ctx, runtime.activeGoal.id, { deferImmediate: true });
 	});
 
 	pi.on("input", (event, ctx) => {
@@ -631,7 +631,9 @@ export function registerGoalLifecycle(
 		}
 		if (!dispatchedQueueAction) {
 			const resumedWait = runtime.dispatchDueGoalWait(ctx);
-			if (!resumedWait) runtime.dispatchContinuationIfSettled(ctx);
+			if (!resumedWait && runtime.continuationIntent) {
+				runtime.scheduleContinuationDispatch(ctx, runtime.continuationIntent.goalId);
+			}
 		}
 		runtime.clearSettledSafetyTracking();
 	});

--- a/packages/pi-goal/src/runtime.ts
+++ b/packages/pi-goal/src/runtime.ts
@@ -176,6 +176,13 @@ interface PendingGoalPrompt {
 	prompt: string;
 }
 
+interface ContinuationDispatchOwner {
+	goalId: string;
+	marker: string;
+	generation: number;
+	scheduledAt: number;
+}
+
 interface PendingNonGoalInput {
 	behavior: "steer" | "followUp";
 	fingerprint: string;
@@ -183,6 +190,7 @@ interface PendingNonGoalInput {
 }
 
 const MAX_CANCELLED_CONTINUATION_PROMPTS = 20;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const MAX_PENDING_GOAL_PROMPTS = 20;
 const MAX_PENDING_NON_GOAL_INPUTS = 20;
 const BUDGET_WRAP_UP_MESSAGE_TYPE = "goal-budget-wrap-up";
@@ -214,6 +222,7 @@ export class GoalRuntime {
 	queueFreezeAwaitingSettle = false;
 	completionStatusTimer?: NodeJS.Timeout;
 	private continuationDispatchTimer?: NodeJS.Timeout;
+	private continuationDispatchOwner?: ContinuationDispatchOwner;
 	private readonly goalWaitTimer = new GoalWaitTimer();
 	private goalWaitDeadlineRetry?: {
 		goalId: string;
@@ -896,26 +905,110 @@ export class GoalRuntime {
 		this.continuationDelivery = undefined;
 	}
 
-	scheduleContinuationDispatch(ctx: StatusContext, goalId: string) {
-		this.clearContinuationDispatchTimer();
-		const generation = this.menuGeneration;
+	scheduleContinuationDispatch(
+		ctx: StatusContext,
+		goalId: string,
+		options: { deferImmediate?: boolean } = {},
+	) {
+		const intent = this.continuationIntent;
+		if (!intent || intent.goalId !== goalId) return false;
+		if (this.continuationDispatchTimer) return true;
+		if (
+			this.settings.continuationLimits.minIntervalMs === 0 &&
+			options.deferImmediate !== true
+		) {
+			return this.dispatchContinuationIfSettled(ctx);
+		}
+		if (this.activeGoal?.status === "active" && !this.toolPolicy.toolsAvailable()) {
+			this.pauseGoalForUnavailableTools(ctx);
+			return false;
+		}
+		if (
+			!this.activeGoal ||
+			this.activeGoal.id !== goalId ||
+			this.activeGoal.status !== "active" ||
+			this.activeGoal.waiting
+		) {
+			this.continuationIntent = undefined;
+			return false;
+		}
+		if (this.enforceAutomaticTurnLimit(ctx, false) || this.enforceNoProgressLimit(ctx)) {
+			return false;
+		}
+		if (ctx.isIdle?.() !== true || hasPendingMessages(ctx)) return false;
+
+		const owner = {
+			goalId,
+			marker: intent.marker,
+			generation: this.menuGeneration,
+			scheduledAt: Date.now(),
+		};
+		this.continuationDispatchOwner = owner;
+		this.armContinuationDispatchTimer(ctx, owner);
+		return true;
+	}
+
+	reconcileContinuationDispatchTimer(ctx: StatusContext) {
+		const owner = this.continuationDispatchOwner;
+		if (!owner || !this.continuationDispatchTimer) return false;
+		clearTimeout(this.continuationDispatchTimer);
+		this.continuationDispatchTimer = undefined;
+		if (!this.isContinuationDispatchOwnerCurrent(owner)) {
+			this.continuationDispatchOwner = undefined;
+			return false;
+		}
+		if (this.settings.continuationLimits.minIntervalMs === 0) {
+			this.continuationDispatchOwner = undefined;
+			return this.dispatchContinuationIfSettled(ctx);
+		}
+		this.armContinuationDispatchTimer(ctx, owner);
+		return true;
+	}
+
+	private armContinuationDispatchTimer(ctx: StatusContext, owner: ContinuationDispatchOwner) {
+		const elapsedMs = Math.max(0, Date.now() - owner.scheduledAt);
+		const remainingMs = Math.max(
+			0,
+			this.settings.continuationLimits.minIntervalMs - elapsedMs,
+		);
+		const delayMs = Math.min(remainingMs, MAX_TIMER_DELAY_MS);
 		this.continuationDispatchTimer = setTimeout(() => {
 			this.continuationDispatchTimer = undefined;
-			if (
-				generation !== this.menuGeneration ||
-				this.activeGoal?.id !== goalId ||
-				this.activeGoal.status !== "active"
-			) {
+			if (!this.isContinuationDispatchOwnerCurrent(owner)) {
+				if (this.continuationDispatchOwner === owner) {
+					this.continuationDispatchOwner = undefined;
+				}
 				return;
 			}
+			const nextRemainingMs = Math.max(
+				0,
+				this.settings.continuationLimits.minIntervalMs -
+					Math.max(0, Date.now() - owner.scheduledAt),
+			);
+			if (nextRemainingMs > 0) {
+				this.armContinuationDispatchTimer(ctx, owner);
+				return;
+			}
+			this.continuationDispatchOwner = undefined;
 			this.dispatchContinuationIfSettled(ctx);
-		}, 0);
+		}, delayMs);
+	}
+
+	private isContinuationDispatchOwnerCurrent(owner: ContinuationDispatchOwner) {
+		return (
+			this.continuationDispatchOwner === owner &&
+			owner.generation === this.menuGeneration &&
+			this.activeGoal?.id === owner.goalId &&
+			this.activeGoal.status === "active" &&
+			this.continuationIntent?.goalId === owner.goalId &&
+			this.continuationIntent.marker === owner.marker
+		);
 	}
 
 	private clearContinuationDispatchTimer() {
-		if (!this.continuationDispatchTimer) return;
-		clearTimeout(this.continuationDispatchTimer);
+		if (this.continuationDispatchTimer) clearTimeout(this.continuationDispatchTimer);
 		this.continuationDispatchTimer = undefined;
+		this.continuationDispatchOwner = undefined;
 	}
 
 	consumeCancelledGoalPrompt(prompt: string) {

--- a/packages/pi-goal/src/settings-ui.ts
+++ b/packages/pi-goal/src/settings-ui.ts
@@ -23,6 +23,7 @@ interface GoalSettingsApplyOptions {
 
 type LimitField = "automaticTurns" | "noProgressTurns";
 type LimitSelection = "unlimited" | "default" | "custom" | "off";
+type DelaySelection = "custom" | "off";
 export async function showGoalSettings(
 	runtime: GoalRuntime,
 	ctx: ExtensionCommandContext,
@@ -44,12 +45,19 @@ export async function showGoalSettings(
 	if (!isMenuCurrent()) return;
 	const invalid = runtime.settingsLoadIssue?.kind === "invalid";
 	const previewGoalIds = new Map<LimitField, string | null>();
-	type Screen = "settings" | "automatic" | "no-progress" | "invalid";
+	type Screen =
+		| "settings"
+		| "automatic"
+		| "no-progress"
+		| "continuation-delay"
+		| "invalid";
 	type Action =
 		| "open-automatic"
 		| "open-no-progress"
+		| "open-continuation-delay"
 		| "choose-automatic"
 		| "choose-no-progress"
+		| "choose-continuation-delay"
 		| "set-visibility"
 		| "set-queue"
 		| "set-rpc";
@@ -80,6 +88,15 @@ export async function showGoalSettings(
 						action: "open-no-progress",
 					},
 					{
+						id: "minIntervalMs",
+						label: "Continuation delay",
+						description: "Wait before dispatching each eligible automatic continuation.",
+						currentValue: formatContinuationDelay(
+							runtime.settings.continuationLimits.minIntervalMs,
+						),
+						action: "open-continuation-delay",
+					},
+					{
 						id: "toolVisibility",
 						label: "Goal tools",
 						description: "Keep terminal Goal tools visible, or reveal them after the first goal.",
@@ -108,6 +125,7 @@ export async function showGoalSettings(
 			}),
 			automatic: () => limitChoiceScreen(runtime, "automaticTurns", "choose-automatic"),
 			"no-progress": () => limitChoiceScreen(runtime, "noProgressTurns", "choose-no-progress"),
+			"continuation-delay": () => continuationDelayChoiceScreen(runtime),
 			invalid: () => ({
 				kind: "detail",
 				title: "Pi Goal Settings · Read only",
@@ -115,6 +133,9 @@ export async function showGoalSettings(
 					`Invalid settings file. Pi-goal is using built-in defaults. Fix ${safeTerminalText(settingsPath)} and run /reload. The file will not be overwritten.`,
 					`Automatic-work limit: ${formatAutomaticWork(runtime.settings.continuationLimits.automaticTurns)}`,
 					`No-progress guard: ${formatNoProgressProtection(runtime.settings.continuationLimits.noProgressTurns)}`,
+					`Continuation delay: ${formatContinuationDelay(
+						runtime.settings.continuationLimits.minIntervalMs,
+					)}`,
 					`Goal tools: ${visibilityLabel(runtime.settings.toolVisibility)}`,
 					`Ordered goal queue: ${runtime.settings.experimental.goals ? "Experimental" : "Off"}`,
 					`Managed run RPC: ${runtime.settings.rpc.enabled ? "On" : "Off"}`,
@@ -131,6 +152,10 @@ export async function showGoalSettings(
 				previewGoalIds.set("noProgressTurns", runtime.activeGoal?.id ?? null);
 				return { kind: "to", screen: "no-progress" };
 			},
+			"open-continuation-delay": async () => ({
+				kind: "to",
+				screen: "continuation-delay",
+			}),
 			"choose-automatic": async ({ itemId }) =>
 				applyLimitChoice(
 					runtime,
@@ -151,6 +176,15 @@ export async function showGoalSettings(
 					"noProgressTurns",
 					itemId,
 					previewGoalIds.get("noProgressTurns") ?? null,
+					isMenuCurrent,
+				),
+			"choose-continuation-delay": async ({ itemId }) =>
+				applyContinuationDelayChoice(
+					runtime,
+					ctx,
+					options,
+					settingsPath,
+					itemId,
 					isMenuCurrent,
 				),
 			"set-visibility": async ({ value }) => {
@@ -228,6 +262,33 @@ export async function showGoalSettings(
 		signal: runtime.menuController.signal,
 		isCurrent: isMenuCurrent,
 	});
+}
+
+function continuationDelayChoiceScreen(runtime: GoalRuntime) {
+	const value = runtime.settings.continuationLimits.minIntervalMs;
+	return {
+		kind: "actions" as const,
+		title: "Continuation delay",
+		lines: [
+			`Current: ${formatContinuationDelay(value)}`,
+			"Wait this many whole milliseconds after an eligible settled boundary before dispatching.",
+		],
+		items: [
+			{
+				id: "off",
+				label: "Off",
+				description: "Dispatch immediately with a delay of 0 milliseconds.",
+				action: "choose-continuation-delay" as const,
+			},
+			{
+				id: "custom",
+				label: "Set delay…",
+				description: "Choose a non-negative safe whole number of milliseconds.",
+				action: "choose-continuation-delay" as const,
+			},
+		],
+		hint: "back" as const,
+	};
 }
 
 function limitChoiceScreen(
@@ -382,6 +443,12 @@ export function applyGoalSettings(
 		if (runtime.activeGoal && !runtime.queueFrozen) {
 			runtime.updateStatus(ctx, runtime.activeGoal);
 		}
+		if (
+			snapshot.settings.continuationLimits.minIntervalMs !==
+			next.continuationLimits.minIntervalMs
+		) {
+			runtime.reconcileContinuationDispatchTimer(ctx);
+		}
 	} catch (error) {
 		const rollbackErrors: unknown[] = [];
 		try {
@@ -409,6 +476,13 @@ export function applyGoalSettings(
 		}
 		throw error;
 	}
+}
+
+export function parseContinuationDelay(value: string): number | undefined {
+	const normalized = value.trim();
+	if (!/^\d+$/u.test(normalized)) return undefined;
+	const parsed = Number(normalized);
+	return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
 export function parseGoalLimit(value: string): number | undefined {
@@ -460,6 +534,53 @@ async function resolveLimitSelection(
 			`Enter a whole number greater than 0. Choose ${field === "automaticTurns" ? "Unlimited" : "Off"} from the previous screen if you do not want a limit.`,
 			"warning",
 		);
+	}
+}
+
+async function applyContinuationDelayChoice(
+	runtime: GoalRuntime,
+	ctx: ExtensionCommandContext,
+	options: GoalSettingsUiOptions,
+	settingsPath: string,
+	itemId: string,
+	isCurrent: () => boolean,
+) {
+	if (!isCurrent() || !isDelaySelection(itemId)) return { kind: "rejected" as const };
+	let delay = 0;
+	if (itemId === "custom") {
+		while (true) {
+			const raw = await ctx.ui.input(
+				"Continuation delay (whole milliseconds, 0 or greater)",
+				String(runtime.settings.continuationLimits.minIntervalMs),
+			);
+			if (!isCurrent() || raw === undefined) return { kind: "rejected" as const };
+			const parsed = parseContinuationDelay(raw);
+			if (parsed !== undefined) {
+				delay = parsed;
+				break;
+			}
+			notifyTerminal(ctx.ui, "Enter a whole number of milliseconds, 0 or greater.", "warning");
+		}
+	}
+	if (delay === runtime.settings.continuationLimits.minIntervalMs) {
+		return { kind: "back" as const };
+	}
+	try {
+		const next = {
+			...structuredClone(runtime.settings),
+			continuationLimits: {
+				...runtime.settings.continuationLimits,
+				minIntervalMs: delay,
+			},
+		} satisfies GoalSettings;
+		applyGoalSettings(runtime, next, ctx, {
+			save: (settings) => (options.save ?? saveGoalSettings)(settings, settingsPath),
+		});
+		notifyTerminal(ctx.ui, `Continuation delay: ${formatContinuationDelay(delay)}.`, "info");
+		return { kind: "back" as const };
+	} catch (error) {
+		notifySettingsFailure(ctx, settingsPath, error);
+		return { kind: "rejected" as const };
 	}
 }
 
@@ -580,6 +701,10 @@ function withLimit(settings: GoalSettings, field: LimitField, value: number | nu
 	};
 }
 
+function formatContinuationDelay(value: number) {
+	return value === 0 ? "Off" : `${value} ms`;
+}
+
 function formatAutomaticSettingValue(value: number | null) {
 	return value === null ? "Unlimited" : `${value} responses`;
 }
@@ -606,6 +731,10 @@ function formatLimitSuccess(field: LimitField, value: number | null) {
 
 function isLimitSelection(value: string): value is LimitSelection {
 	return value === "unlimited" || value === "default" || value === "custom" || value === "off";
+}
+
+function isDelaySelection(value: string): value is DelaySelection {
+	return value === "custom" || value === "off";
 }
 
 function visibilityLabel(value: GoalSettings["toolVisibility"]) {

--- a/packages/pi-goal/src/settings.ts
+++ b/packages/pi-goal/src/settings.ts
@@ -20,6 +20,7 @@ export interface GoalSettings {
 	continuationLimits: {
 		automaticTurns: ContinuationLimit;
 		noProgressTurns: ContinuationLimit;
+		minIntervalMs: number;
 	};
 }
 
@@ -27,7 +28,7 @@ export const DEFAULT_GOAL_SETTINGS: GoalSettings = {
 	toolVisibility: "always",
 	experimental: { goals: false },
 	rpc: { enabled: false },
-	continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
+	continuationLimits: { automaticTurns: 25, noProgressTurns: 3, minIntervalMs: 0 },
 };
 
 export type GoalSettingsLoadResult =
@@ -104,13 +105,25 @@ export function normalizeGoalSettings(value: unknown): GoalSettings | undefined 
 				DEFAULT_GOAL_SETTINGS.continuationLimits.noProgressTurns,
 			)
 		: DEFAULT_GOAL_SETTINGS.continuationLimits.noProgressTurns;
-	if (automaticTurns === undefined || noProgressTurns === undefined) return undefined;
+	const minIntervalMs = continuationLimitsValue
+		? normalizeNonNegativeSafeInteger(
+				Reflect.get(continuationLimitsValue, "minIntervalMs"),
+				DEFAULT_GOAL_SETTINGS.continuationLimits.minIntervalMs,
+			)
+		: DEFAULT_GOAL_SETTINGS.continuationLimits.minIntervalMs;
+	if (
+		automaticTurns === undefined ||
+		noProgressTurns === undefined ||
+		minIntervalMs === undefined
+	) {
+		return undefined;
+	}
 
 	return {
 		toolVisibility: toolVisibility as GoalToolVisibility,
 		experimental: { goals },
 		rpc: { enabled: rpcEnabled },
-		continuationLimits: { automaticTurns, noProgressTurns },
+		continuationLimits: { automaticTurns, noProgressTurns, minIntervalMs },
 	};
 }
 
@@ -121,6 +134,13 @@ function normalizeContinuationLimit(
 	if (value === undefined) return fallback;
 	if (value === null) return null;
 	return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+function normalizeNonNegativeSafeInteger(value: unknown, fallback: number) {
+	if (value === undefined) return fallback;
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+		? value
+		: undefined;
 }
 
 export function saveGoalSettings(
@@ -158,6 +178,7 @@ export function saveGoalSettings(
 				...continuationLimits,
 				automaticTurns: normalized.continuationLimits.automaticTurns,
 				noProgressTurns: normalized.continuationLimits.noProgressTurns,
+				minIntervalMs: normalized.continuationLimits.minIntervalMs,
 			},
 		},
 		null,

--- a/packages/pi-goal/test/goal-continuation.test.ts
+++ b/packages/pi-goal/test/goal-continuation.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import {
+	DELAYED_CONTINUATION_SETTINGS_PATH,
+	DELAYED_QUEUE_SETTINGS_PATH,
 	lastGoalStatus,
 	requireGoalTool,
 	requireLastGoal,
@@ -26,6 +28,78 @@ test("agent_settled dispatches one idle continuation after agent_end records int
 
 	await settled.mock.events.get("agent_settled")?.[0]?.({}, settled.ctx);
 	assert.equal(settled.mock.sentUserMessages.length, 2);
+});
+
+test("agent_settled waits the configured interval before dispatching continuation", async () => {
+	vi.useFakeTimers();
+	try {
+		const delayed = await startGoalForTest(
+			{},
+			"finish",
+			DELAYED_CONTINUATION_SETTINGS_PATH,
+		);
+
+		await delayed.mock.events.get("agent_end")?.[0]?.(
+			{ messages: [{ role: "assistant", stopReason: "stop" }] },
+			delayed.ctx,
+		);
+		await delayed.mock.events.get("agent_settled")?.[0]?.({}, delayed.ctx);
+
+		assert.equal(delayed.mock.sentUserMessages.length, 1);
+		await vi.advanceTimersByTimeAsync(500);
+		await delayed.mock.events.get("agent_settled")?.[0]?.({}, delayed.ctx);
+		await vi.advanceTimersByTimeAsync(499);
+		assert.equal(delayed.mock.sentUserMessages.length, 1);
+		await vi.advanceTimersByTimeAsync(1);
+		assert.equal(delayed.mock.sentUserMessages.length, 2);
+		assert.match(delayed.mock.sentUserMessages.at(-1)?.text ?? "", /automatic continuation #1/i);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test("goal transitions cancel delayed continuation dispatch", async () => {
+	vi.useFakeTimers();
+	try {
+		for (const action of ["pause", "clear", "replace", "prioritize", "shutdown"] as const) {
+			const delayed = await startGoalForTest(
+				{},
+				"finish",
+				action === "prioritize"
+					? DELAYED_QUEUE_SETTINGS_PATH
+					: DELAYED_CONTINUATION_SETTINGS_PATH,
+			);
+			await delayed.mock.events.get("agent_end")?.[0]?.(
+				{ messages: [{ role: "assistant", stopReason: "stop" }] },
+				delayed.ctx,
+			);
+			await delayed.mock.events.get("agent_settled")?.[0]?.({}, delayed.ctx);
+
+			if (action === "pause" || action === "clear") {
+				await delayed.mock.commands.get("goal")?.handler(action, delayed.ctx);
+			} else if (action === "replace") {
+				await delayed.mock.commands
+					.get("goal")
+					?.handler("replacement objective", delayed.ctx);
+			} else if (action === "prioritize") {
+				await delayed.mock.commands
+					.get("goal")
+					?.handler("prioritize urgent objective", delayed.ctx);
+			} else {
+				delayed.mock.events.get("session_shutdown")?.[0]?.({}, delayed.ctx);
+			}
+
+			const messagesAfterCancellation = delayed.mock.sentUserMessages.length;
+			await vi.advanceTimersByTimeAsync(1_000);
+			assert.equal(
+				delayed.mock.sentUserMessages.length,
+				messagesAfterCancellation,
+				`${action} must cancel delayed continuation dispatch`,
+			);
+		}
+	} finally {
+		vi.useRealTimers();
+	}
 });
 
 test("agent_settled retains intent until idle and pending-message gates allow dispatch", async () => {

--- a/packages/pi-goal/test/goal-error-lifecycle.test.ts
+++ b/packages/pi-goal/test/goal-error-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import {
 	findFinalAssistantMessage,
 	isRetryableGoalInterruption,
@@ -8,6 +8,7 @@ import {
 } from "../src/goal.js";
 import {
 	assistantUsageEntry,
+	DELAYED_CONTINUATION_SETTINGS_PATH,
 	LOW_LIMITS_SETTINGS_PATH,
 	lastGoalStatus,
 	requireLastGoal,
@@ -537,18 +538,29 @@ test("manual compaction cancels stale continuation and sends one fresh continuat
 	assert.equal(compacted.mock.sentUserMessages.length, 3);
 });
 
-test("idle manual compaction defers continuation until Pi clears compaction", async () => {
-	const compacted = await startGoalForTest({ isIdle: () => true });
+test("idle manual compaction waits the configured interval before fallback dispatch", async () => {
+	vi.useFakeTimers();
+	try {
+		const compacted = await startGoalForTest(
+			{ isIdle: () => true },
+			"finish",
+			DELAYED_CONTINUATION_SETTINGS_PATH,
+		);
 
-	await compacted.mock.events.get("session_compact")?.[0]?.(
-		{ reason: "manual", willRetry: false },
-		compacted.ctx,
-	);
-	assert.equal(compacted.mock.sentUserMessages.length, 1);
+		await compacted.mock.events.get("session_compact")?.[0]?.(
+			{ reason: "manual", willRetry: false },
+			compacted.ctx,
+		);
+		assert.equal(compacted.mock.sentUserMessages.length, 1);
 
-	await new Promise((resolve) => setTimeout(resolve, 10));
-	assert.equal(compacted.mock.sentUserMessages.length, 2);
-	assert.match(compacted.mock.sentUserMessages.at(-1)?.text ?? "", /pi-goal-continuation/);
+		await vi.advanceTimersByTimeAsync(999);
+		assert.equal(compacted.mock.sentUserMessages.length, 1);
+		await vi.advanceTimersByTimeAsync(1);
+		assert.equal(compacted.mock.sentUserMessages.length, 2);
+		assert.match(compacted.mock.sentUserMessages.at(-1)?.text ?? "", /pi-goal-continuation/);
+	} finally {
+		vi.useRealTimers();
+	}
 });
 
 test("session shutdown cancels a deferred manual-compaction continuation", async () => {

--- a/packages/pi-goal/test/settings-ui.test.ts
+++ b/packages/pi-goal/test/settings-ui.test.ts
@@ -107,7 +107,7 @@ test("applyGoalSettings extends an owned continuation timer from its original se
 		assert.equal(mock.sentUserMessages.length, 0);
 		await vi.advanceTimersByTimeAsync(1);
 		assert.equal(mock.sentUserMessages.length, 1);
-		assert.match(mock.sentUserMessages[0]?.text ?? "", /automatic continuation #1/i);
+		assert.match(mock.sentUserMessages[0]?.text ?? "", /automatic continuation #0/i);
 	} finally {
 		vi.useRealTimers();
 	}
@@ -155,7 +155,7 @@ test("applyGoalSettings dispatches an eligible settled continuation immediately 
 		applyGoalSettings(state, off, context.ctx, { save() {} });
 
 		assert.equal(mock.sentUserMessages.length, 1);
-		assert.match(mock.sentUserMessages[0]?.text ?? "", /automatic continuation #1/i);
+		assert.match(mock.sentUserMessages[0]?.text ?? "", /automatic continuation #0/i);
 		await vi.advanceTimersByTimeAsync(500);
 		assert.equal(mock.sentUserMessages.length, 1);
 	} finally {

--- a/packages/pi-goal/test/settings-ui.test.ts
+++ b/packages/pi-goal/test/settings-ui.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { GoalCommandController } from "../src/commands.js";
 import { createGoal, GoalRuntime } from "../src/runtime.js";
@@ -10,6 +10,7 @@ import { DEFAULT_GOAL_SETTINGS, type GoalSettings } from "../src/settings.js";
 import {
 	applyGoalSettings,
 	formatGoalLimit,
+	parseContinuationDelay,
 	parseGoalLimit,
 	showGoalSettings,
 } from "../src/settings-ui.js";
@@ -52,6 +53,116 @@ test("goal setting custom limits accept only safe whole numbers greater than zer
 	assert.equal(formatGoalLimit(null), "Unlimited");
 });
 
+test("continuation delay accepts non-negative safe whole milliseconds", () => {
+	assert.equal(parseContinuationDelay("0"), 0);
+	assert.equal(parseContinuationDelay(" 1500 "), 1_500);
+	for (const invalid of [
+		"",
+		"-1",
+		"1.5",
+		"off",
+		"many",
+		String(Number.MAX_SAFE_INTEGER + 1),
+	]) {
+		assert.equal(parseContinuationDelay(invalid), undefined);
+	}
+});
+
+test("applyGoalSettings extends an owned continuation timer from its original settled boundary", async () => {
+	vi.useFakeTimers();
+	try {
+		const mock = createMockPi({
+			activeTools: ["goal_complete", "goal_blocked", "goal_wait"],
+		});
+		const state = new GoalRuntime(mock.pi);
+		state.settings = {
+			...structuredClone(DEFAULT_GOAL_SETTINGS),
+			continuationLimits: {
+				...DEFAULT_GOAL_SETTINGS.continuationLimits,
+				minIntervalMs: 1_000,
+			},
+		};
+		state.activeGoal = createGoal("current objective", undefined, 0);
+		const context = createMockContext({ isIdle: () => true });
+		assert.equal(state.requestContinuation(state.activeGoal), true);
+		assert.equal(state.scheduleContinuationDispatch(context.ctx, state.activeGoal.id), true);
+
+		await vi.advanceTimersByTimeAsync(500);
+		applyGoalSettings(
+			state,
+			{
+				...structuredClone(state.settings),
+				continuationLimits: {
+					...state.settings.continuationLimits,
+					minIntervalMs: 2_000,
+				},
+			},
+			context.ctx,
+			{ save() {} },
+		);
+
+		await vi.advanceTimersByTimeAsync(500);
+		assert.equal(mock.sentUserMessages.length, 0);
+		await vi.advanceTimersByTimeAsync(999);
+		assert.equal(mock.sentUserMessages.length, 0);
+		await vi.advanceTimersByTimeAsync(1);
+		assert.equal(mock.sentUserMessages.length, 1);
+		assert.match(mock.sentUserMessages[0]?.text ?? "", /automatic continuation #1/i);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test("applyGoalSettings dispatches an eligible settled continuation immediately when delay turns Off", async () => {
+	vi.useFakeTimers();
+	try {
+		const mock = createMockPi({
+			activeTools: ["goal_complete", "goal_blocked", "goal_wait"],
+		});
+		const state = new GoalRuntime(mock.pi);
+		state.settings = {
+			...structuredClone(DEFAULT_GOAL_SETTINGS),
+			continuationLimits: {
+				...DEFAULT_GOAL_SETTINGS.continuationLimits,
+				minIntervalMs: 1_000,
+			},
+		};
+		state.activeGoal = createGoal("current objective", undefined, 0);
+		const context = createMockContext({ isIdle: () => true });
+		assert.equal(state.requestContinuation(state.activeGoal), true);
+		assert.equal(state.scheduleContinuationDispatch(context.ctx, state.activeGoal.id), true);
+		await vi.advanceTimersByTimeAsync(500);
+
+		const off = {
+			...structuredClone(state.settings),
+			continuationLimits: {
+				...state.settings.continuationLimits,
+				minIntervalMs: 0,
+			},
+		};
+		assert.throws(
+			() =>
+				applyGoalSettings(state, off, context.ctx, {
+					save() {
+						throw new Error("disk full");
+					},
+				}),
+			/disk full/,
+		);
+		assert.equal(state.settings.continuationLimits.minIntervalMs, 1_000);
+		assert.equal(mock.sentUserMessages.length, 0);
+
+		applyGoalSettings(state, off, context.ctx, { save() {} });
+
+		assert.equal(mock.sentUserMessages.length, 1);
+		assert.match(mock.sentUserMessages[0]?.text ?? "", /automatic continuation #1/i);
+		await vi.advanceTimersByTimeAsync(500);
+		assert.equal(mock.sentUserMessages.length, 1);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
 test("applyGoalSettings saves before committing runtime settings and enforces lower limits", () => {
 	const state = runtime();
 	let saved: GoalSettings | undefined;
@@ -62,7 +173,7 @@ test("applyGoalSettings saves before committing runtime settings and enforces lo
 	};
 	const next: GoalSettings = {
 		...structuredClone(DEFAULT_GOAL_SETTINGS),
-		continuationLimits: { automaticTurns: 10, noProgressTurns: 2 },
+		continuationLimits: { automaticTurns: 10, noProgressTurns: 2, minIntervalMs: 1_000 },
 	};
 	const context = createMockContext();
 
@@ -249,7 +360,7 @@ test("lowering the no-progress limit pauses and aborts in-flight Goal work", () 
 	const state = new GoalRuntime(mock.pi);
 	state.settings = {
 		...structuredClone(DEFAULT_GOAL_SETTINGS),
-		continuationLimits: { automaticTurns: 25, noProgressTurns: 5 },
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 5, minIntervalMs: 0 },
 	};
 	state.activeGoal = createGoal("current objective", undefined, 0);
 	state.activeGoal.toolFreeRepeatCount = 3;
@@ -262,7 +373,7 @@ test("lowering the no-progress limit pauses and aborts in-flight Goal work", () 
 	});
 	const next = {
 		...structuredClone(state.settings),
-		continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 3, minIntervalMs: 0 },
 	};
 
 	applyGoalSettings(state, next, context.ctx, { save() {} });
@@ -277,7 +388,7 @@ test("lowering a reached limit preserves an unrelated in-flight run", () => {
 	const state = new GoalRuntime(mock.pi);
 	state.settings = {
 		...structuredClone(DEFAULT_GOAL_SETTINGS),
-		continuationLimits: { automaticTurns: 25, noProgressTurns: 5 },
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 5, minIntervalMs: 0 },
 	};
 	state.activeGoal = createGoal("current objective", undefined, 0);
 	state.activeGoal.toolFreeRepeatCount = 3;
@@ -290,7 +401,7 @@ test("lowering a reached limit preserves an unrelated in-flight run", () => {
 	});
 	const next = {
 		...structuredClone(state.settings),
-		continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 3, minIntervalMs: 0 },
 	};
 
 	applyGoalSettings(state, next, context.ctx, { save() {} });
@@ -426,7 +537,7 @@ test("unfreezing a pending priority dispatches it at the idle boundary", async (
 	assert.equal(mock.sentUserMessages.length, 1);
 });
 
-test("standard settings keep all five controls on one level", async () => {
+test("standard settings keep all six controls on one level", async () => {
 	const state = runtime();
 	let title = "";
 	let options: string[] = [];
@@ -444,10 +555,70 @@ test("standard settings keep all five controls on one level", async () => {
 	assert.deepEqual(options, [
 		"Automatic-work limit",
 		"No-progress guard",
+		"Continuation delay",
 		"Goal tools",
 		"Ordered goal queue",
 		"Managed run RPC",
 	]);
+});
+
+test("Continuation delay applies Off or custom milliseconds immediately", async () => {
+	for (const scenario of [
+		{
+			initial: 0,
+			selections: ["Continuation delay", "Set delay…", undefined],
+			input: "1500",
+			expected: 1_500,
+		},
+		{
+			initial: 1_500,
+			selections: ["Continuation delay", "Off", undefined],
+			input: undefined,
+			expected: 0,
+		},
+	] as const) {
+		const state = runtime();
+		state.settings.continuationLimits.minIntervalMs = scenario.initial;
+		let saved: GoalSettings | undefined;
+		const selections: Array<string | undefined> = [...scenario.selections];
+		const context = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => selections.shift(),
+			input: async () => scenario.input,
+		});
+
+		await showGoalSettings(state, context.ctx, {
+			settingsPath: "/tmp/pi-goal.json",
+			save(settings) {
+				saved = structuredClone(settings);
+			},
+		});
+
+		assert.equal(saved?.continuationLimits.minIntervalMs, scenario.expected);
+		assert.equal(state.settings.continuationLimits.minIntervalMs, scenario.expected);
+	}
+});
+
+test("Continuation delay rolls back after a save failure", async () => {
+	const state = runtime();
+	const selections = ["Continuation delay", "Set delay…", undefined];
+	const context = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		select: async () => selections.shift(),
+		input: async () => "2500",
+	});
+
+	await showGoalSettings(state, context.ctx, {
+		settingsPath: "/tmp/pi-goal.json",
+		save() {
+			throw new Error("disk full");
+		},
+	});
+
+	assert.equal(state.settings.continuationLimits.minIntervalMs, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /previous value remains/i);
 });
 
 test("automatic-work settings can open directly from the safety recovery flow", async () => {
@@ -821,6 +992,7 @@ test("invalid settings use a standard read-only detail screen", async () => {
 	assert.match(title, /Read only/i);
 	assert.match(title, /Invalid settings file/i);
 	assert.match(title, /Automatic-work limit: Up to 25 responses/i);
+	assert.match(title, /Continuation delay: Off/i);
 	assert.match(title, /Managed run RPC: Off/i);
 });
 

--- a/packages/pi-goal/test/settings.test.ts
+++ b/packages/pi-goal/test/settings.test.ts
@@ -15,6 +15,7 @@ const DEFAULT_GOAL_SETTINGS_DOCUMENT = `${JSON.stringify(DEFAULT_GOAL_SETTINGS, 
 
 test("normalizeGoalSettings applies defaults and accepts bounded continuation limits", () => {
 	assert.equal(DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns, 25);
+	assert.equal(DEFAULT_GOAL_SETTINGS.continuationLimits.minIntervalMs, 0);
 	assert.deepEqual(DEFAULT_GOAL_SETTINGS.rpc, { enabled: false });
 	assert.deepEqual(normalizeGoalSettings({}), DEFAULT_GOAL_SETTINGS);
 	assert.deepEqual(normalizeGoalSettings({ futureOption: true }), DEFAULT_GOAL_SETTINGS);
@@ -45,19 +46,32 @@ test("normalizeGoalSettings applies defaults and accepts bounded continuation li
 	assert.deepEqual(normalizeGoalSettings({ continuationLimits: {} }), DEFAULT_GOAL_SETTINGS);
 	assert.deepEqual(normalizeGoalSettings({ continuationLimits: { automaticTurns: 7 } }), {
 		...DEFAULT_GOAL_SETTINGS,
-		continuationLimits: { automaticTurns: 7, noProgressTurns: 3 },
+		continuationLimits: { automaticTurns: 7, noProgressTurns: 3, minIntervalMs: 0 },
 	});
 	assert.deepEqual(normalizeGoalSettings({ continuationLimits: { noProgressTurns: 2 } }), {
 		...DEFAULT_GOAL_SETTINGS,
-		continuationLimits: { automaticTurns: 25, noProgressTurns: 2 },
+		continuationLimits: { automaticTurns: 25, noProgressTurns: 2, minIntervalMs: 0 },
 	});
+	assert.deepEqual(
+		normalizeGoalSettings({
+			continuationLimits: { automaticTurns: 10, minIntervalMs: 60_000 },
+		}),
+		{
+			...DEFAULT_GOAL_SETTINGS,
+			continuationLimits: {
+				automaticTurns: 10,
+				noProgressTurns: 3,
+				minIntervalMs: 60_000,
+			},
+		},
+	);
 	assert.deepEqual(
 		normalizeGoalSettings({
 			continuationLimits: { automaticTurns: null, noProgressTurns: null, future: true },
 		}),
 		{
 			...DEFAULT_GOAL_SETTINGS,
-			continuationLimits: { automaticTurns: null, noProgressTurns: null },
+			continuationLimits: { automaticTurns: null, noProgressTurns: null, minIntervalMs: 0 },
 		},
 	);
 
@@ -78,6 +92,10 @@ test("normalizeGoalSettings applies defaults and accepts bounded continuation li
 		{ continuationLimits: { automaticTurns: 1.5 } },
 		{ continuationLimits: { automaticTurns: Number.MAX_SAFE_INTEGER + 1 } },
 		{ continuationLimits: { noProgressTurns: "3" } },
+		{ continuationLimits: { minIntervalMs: null } },
+		{ continuationLimits: { minIntervalMs: -1 } },
+		{ continuationLimits: { minIntervalMs: 1.5 } },
+		{ continuationLimits: { minIntervalMs: Number.MAX_SAFE_INTEGER + 1 } },
 	]) {
 		assert.equal(normalizeGoalSettings(value), undefined);
 	}
@@ -112,7 +130,12 @@ test("saveGoalSettings atomically preserves unknown top-level and nested fields"
 			toolVisibility: "after-first-goal",
 			experimental: { goals: false, futureQueue: "keep" },
 			rpc: { enabled: true, futureRpc: "keep" },
-			continuationLimits: { automaticTurns: 25, noProgressTurns: 3, futureLimit: 9 },
+			continuationLimits: {
+				automaticTurns: 25,
+				noProgressTurns: 3,
+				minIntervalMs: 500,
+				futureLimit: 9,
+			},
 		}),
 	);
 
@@ -121,7 +144,11 @@ test("saveGoalSettings atomically preserves unknown top-level and nested fields"
 			toolVisibility: "always",
 			experimental: { goals: true },
 			rpc: { enabled: false },
-			continuationLimits: { automaticTurns: 40, noProgressTurns: null },
+			continuationLimits: {
+				automaticTurns: 40,
+				noProgressTurns: null,
+				minIntervalMs: 1_000,
+			},
 		},
 		settingsPath,
 	);
@@ -131,7 +158,12 @@ test("saveGoalSettings atomically preserves unknown top-level and nested fields"
 		toolVisibility: "always",
 		experimental: { goals: true, futureQueue: "keep" },
 		rpc: { enabled: false, futureRpc: "keep" },
-		continuationLimits: { automaticTurns: 40, noProgressTurns: null, futureLimit: 9 },
+		continuationLimits: {
+			automaticTurns: 40,
+			noProgressTurns: null,
+			minIntervalMs: 1_000,
+			futureLimit: 9,
+		},
 	});
 	assert.deepEqual(readdirSync(directory), ["pi-goal.json"]);
 });
@@ -176,9 +208,13 @@ test("readGoalSettings distinguishes missing, loaded, malformed, and unreadable 
 			toolVisibility: "after-first-goal",
 			experimental: { goals: true },
 			rpc: { enabled: false },
-			continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },
+			continuationLimits: { automaticTurns: 25, noProgressTurns: 3, minIntervalMs: 0 },
 		},
 	});
+
+	await writeFile(settingsPath, '{"continuationLimits":{"minIntervalMs":-1}}', "utf8");
+	const invalidDelay = readGoalSettings(settingsPath);
+	assert.equal(invalidDelay.kind, "invalid");
 
 	await writeFile(settingsPath, "{invalid", "utf8");
 	const malformed = readGoalSettings(settingsPath);

--- a/packages/pi-goal/test/support/goal-fixture.ts
+++ b/packages/pi-goal/test/support/goal-fixture.ts
@@ -16,6 +16,14 @@ export const MISSING_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "missing.json
 export const LOW_LIMITS_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "low-limits.json");
 export const ONE_TURN_LIMIT_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "one-turn-limit.json");
 export const UNLIMITED_SETTINGS_PATH = join(GOAL_SETTINGS_DIRECTORY, "unlimited.json");
+export const DELAYED_CONTINUATION_SETTINGS_PATH = join(
+	GOAL_SETTINGS_DIRECTORY,
+	"delayed-continuation.json",
+);
+export const DELAYED_QUEUE_SETTINGS_PATH = join(
+	GOAL_SETTINGS_DIRECTORY,
+	"delayed-queue.json",
+);
 
 writeFileSync(ALWAYS_SETTINGS_PATH, '{"toolVisibility":"always"}\n');
 writeFileSync(LAZY_SETTINGS_PATH, '{"toolVisibility":"after-first-goal"}\n');
@@ -31,6 +39,14 @@ writeFileSync(
 writeFileSync(
 	UNLIMITED_SETTINGS_PATH,
 	'{"continuationLimits":{"automaticTurns":null,"noProgressTurns":3}}\n',
+);
+writeFileSync(
+	DELAYED_CONTINUATION_SETTINGS_PATH,
+	'{"continuationLimits":{"minIntervalMs":1000}}\n',
+);
+writeFileSync(
+	DELAYED_QUEUE_SETTINGS_PATH,
+	'{"continuationLimits":{"minIntervalMs":1000},"experimental":{"goals":true}}\n',
 );
 
 afterAll(() => rmSync(GOAL_SETTINGS_DIRECTORY, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary
- add `continuationLimits.minIntervalMs` with a backward-compatible default of `0`
- reuse the Goal-owned continuation timer with exact goal, marker, generation, cancellation, and live-settings guards
- expose the delay in Goal Settings and document the behavior

## Test plan
- [ ] Repository CI passes
- [ ] Fake-timer tests prove interval boundaries and cancellation on pause, clear, replacement, queue transition, and shutdown
- [ ] Settings tests cover validation, unknown-field preservation, rollback, and live timer reconciliation

Local test, build, lint, formatting, and typecheck commands were not run in the resource-constrained container; CI is the verification authority.