### PR TITLE
fix(file-context): use reliable default shortcut

### DIFF
--- a/.changeset/clear-cloud-shortcut.md
+++ b/.changeset/clear-cloud-shortcut.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": patch
+---
+
+Change the default File Context shortcut from terminal-dependent `Ctrl+Alt+F` to `F8` while preserving explicit custom shortcut settings and `/file-context`.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ commands, settings persistence, confirmations, and specialized UI.
 | --- | --- | --- |
 | [`pi-analytics`](./packages/pi-analytics) | Review private, content-free local metrics for model calls, skills, tools, response cycles, and observed provider reliability through `/analytics`. | `pi install npm:@narumitw/pi-analytics` |
 | [`pi-codex-compact`](./packages/pi-codex-compact) | Use OpenAI Codex Remote Compaction V2 to persist and replay bounded opaque checkpoints, with `/codex-compact` manual controls and safe Pi-native fallback. | `pi install npm:@narumitw/pi-codex-compact` |
-| [`pi-file-context`](./packages/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it with configurable `Ctrl+Alt+F` or `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
+| [`pi-file-context`](./packages/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it with configurable `F8` or `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
 | [`pi-webui`](./packages/pi-webui) | Use a private loopback browser companion for the current terminal session with live activity and text/image input. | `pi install npm:@narumitw/pi-webui` |
 
 ## 🔧 Advanced installation

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -11,7 +11,7 @@ Browse project files inside Pi, preview text, select a line range, and attach th
 
 ## ✨ Features
 
-- Opens the file explorer with a configurable shortcut that defaults to `Ctrl+Alt+F` (`Control+Option+F` on macOS).
+- Opens the file explorer with a configurable shortcut that defaults to `F8`.
 - Provides `/file-context` as a discoverable fallback without replacing Pi's normal editor.
 - Fuzzy-searches project file names with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
 - Switches with `Ctrl+F` to cancellable cwd content search with highlighted result cards, literal case-insensitive matching by default, and visible case-sensitive and fuzzy toggles.
@@ -43,7 +43,7 @@ pi -e ./packages/pi-file-context
 
 ## 🚀 Quick start
 
-1. Press `Ctrl+Alt+F` (`Control+Option+F` on macOS) or run `/file-context`.
+1. Press `F8` or run `/file-context`.
 2. Type to fuzzy-search file names in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
 3. Press `Ctrl+F` to switch between file-name and content search. Content search is literal and case-insensitive by default; `Alt+C` toggles case sensitivity and `Alt+F` toggles ordered fuzzy matching. The current states remain visible above the results.
 4. In content results, use `Up`/`Down` to choose a highlighted path-and-line card. Press `Tab` for a whole-file reference or `Enter` to preview the file at that line. `Escape` from the preview restores the query, result selection, and scroll position.
@@ -73,7 +73,7 @@ The file is not created when defaults are used.
 
 ```json
 {
-  "openShortcut": "ctrl+alt+f"
+  "openShortcut": "f8"
 }
 ```
 
@@ -85,7 +85,7 @@ Invalid JSON or values leave the source file unchanged, use the default shortcut
 
 Choose a shortcut that does not conflict with Pi or another extension; `Ctrl+F` is already Pi's cursor-right binding and File Context's internal search-mode toggle.
 
-On macOS, terminals may require **Use Option as Meta key** for `Control+Option` combinations.
+The previous `Ctrl+Alt+F` default depended on terminal modifier support and may not reach Pi. An explicit `"openShortcut": "ctrl+alt+f"` value remains supported but is not migrated automatically; replace it with `"f8"` and run `/reload` to adopt the reliable default.
 
 ## 💬 Commands
 

--- a/packages/pi-file-context/src/file-context-settings.ts
+++ b/packages/pi-file-context/src/file-context-settings.ts
@@ -11,7 +11,7 @@ export interface LoadedFileContextSettings {
 }
 
 export const DEFAULT_FILE_CONTEXT_SETTINGS: FileContextSettings = {
-	openShortcut: "ctrl+alt+f",
+	openShortcut: "f8",
 };
 
 const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);

--- a/packages/pi-file-context/test/file-context-settings.test.ts
+++ b/packages/pi-file-context/test/file-context-settings.test.ts
@@ -17,10 +17,10 @@ async function withTempSettings(run: (settingsPath: string) => Promise<void>): P
 	}
 }
 
-test("missing settings use Ctrl+Alt+F without creating a file", async () => {
+test("missing settings use F8 without creating a file", async () => {
 	await withTempSettings(async (settingsPath) => {
 		const result = await loadFileContextSettings(settingsPath);
-		assert.deepEqual(result, { settings: DEFAULT_FILE_CONTEXT_SETTINGS });
+		assert.deepEqual(result, { settings: { openShortcut: "f8" } });
 		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
 	});
 });


### PR DESCRIPTION
## Summary

- change the default File Context shortcut from terminal-dependent `Ctrl+Alt+F` to `F8`
- preserve explicit custom shortcuts and document how existing users can opt into the new default
- update focused settings coverage and add a patch changeset

## Verification

- `npm run check`
  - Biome and extension boundaries passed
  - all workspace typechecks passed
  - 264 test files and 2,860 tests passed
- audited the settings and documentation changes against `docs/extension-conventions.md` and `docs/extension-settings.md`; no deviations or skipped applicable smokes