### PR TITLE
feat(accounts): reuse native login dialog

### DIFF
--- a/.changeset/calm-accounts-login.md
+++ b/.changeset/calm-accounts-login.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-accounts": patch
+---
+
+Use Pi's native login dialog and selector for provider OAuth steps in TUI mode while preserving standard extension UI requests in RPC mode.

--- a/docs/plans/archived/2026-08-10_pi-accounts-native-login-dialog-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-accounts-native-login-dialog-plan.md
@@ -1,0 +1,35 @@
+# pi-accounts native login dialog plan
+
+## Goal
+
+Use Pi's exported native login dialog for `pi-accounts` OAuth flows in TUI mode while preserving named-account policy, RPC behavior, cancellation, and credential safety.
+
+## Context
+
+`pi-accounts` currently translates provider OAuth events into separate extension notifications and prompts.
+Pi's native `/login` keeps those events in `LoginDialogComponent` and temporarily uses `ExtensionSelectorComponent` for provider-owned choices.
+This is a bounded login-flow UI change and does not change account storage or authentication semantics.
+
+## Architecture
+
+TUI login will run inside one `ctx.ui.custom()` flow backed by Pi's exported `LoginDialogComponent`.
+Provider-owned select prompts will temporarily delegate rendering and input to Pi's exported `ExtensionSelectorComponent`, then restore the login dialog.
+RPC login will retain the existing `ctx.ui.select()`, `ctx.ui.input()`, and `ctx.ui.notify()` adapter.
+The flow will combine menu ownership, dialog cancellation, prompt cancellation, and component disposal into one abort protocol.
+
+## Plan
+
+- [x] Add focused failing tests in `packages/pi-accounts/test/accounts.test.ts` for native dialog rendering, provider-owned selection, Escape cancellation, and disposal/owner cancellation. Evidence: the three new tests initially failed because `loginWithOAuthUI` did not exist, then passed after implementation.
+- [x] Update `packages/pi-accounts/src/oauth.ts` and the login call site to use Pi's native dialog only in TUI mode while retaining the current RPC interaction. Evidence: focused TUI tests and the existing RPC account integration matrix pass.
+- [x] Update `packages/pi-accounts/README.md` and add a Changeset for the published behavior change. Evidence: `.changeset/calm-accounts-login.md` records a patch release.
+- [x] Run focused tests, package typechecking, the repository `npm run check` gate, and a local Pi package load smoke. Evidence: 50 focused tests, all 2,863 repository tests, typechecks, Biome, boundaries, `pi --list-models -e ./packages/pi-accounts`, and the package dry run passed.
+- [x] Audit the touched flow against `docs/extension-conventions.md`, including TUI-only guards, width delegation, IME focus, cancellation, disposal, stale owner checks, and non-TUI behavior. Evidence: custom UI is guarded by `ctx.mode === "tui"`; native components own rendering; the wrapper forwards focus; combined abort signals cover Escape, prompts, owner shutdown, and disposal; and `loginAccount` retains its post-await owner checks.
+
+## Completion Checklist
+
+- [x] TUI OAuth URL, device code, waiting, progress, and input states render through Pi's native login dialog.
+- [x] Provider-owned select prompts render through Pi's native selector and return to the same login dialog.
+- [x] RPC behavior remains deterministic through standard extension UI requests.
+- [x] Escape, provider prompt cancellation, owner cancellation, component disposal, session replacement, and shutdown release the active login task without publishing stale credentials.
+- [x] Focused and repository-wide checks pass, and runtime loading succeeds.
+- [x] The completed plan is archived under `docs/plans/archived/`.

--- a/packages/pi-accounts/README.md
+++ b/packages/pi-accounts/README.md
@@ -97,7 +97,11 @@ What do you want to do?
   Switch another provider’s account
 ```
 
-Login follows Pi's built-in `/login` style: choose a provider, enter a named account, then complete that provider's OAuth flow. `default` is reserved for Pi's built-in login. Reusing an existing provider/account name asks before replacing the stored credential.
+Login reuses Pi's native `/login` dialog in TUI mode: choose a provider, enter a named account, then complete the provider's OAuth flow in the same bordered screen with native links, device codes, progress, prompts, and Escape cancellation.
+Provider-owned choices temporarily use Pi's native selector before returning to the login dialog.
+RPC mode uses Pi's standard extension UI requests for the same OAuth contract.
+`default` is reserved for Pi's built-in login.
+Reusing an existing provider/account name asks before replacing the stored credential.
 
 Switching the current model provider is the primary flow. Switching a different provider is explicit: choose **Switch another provider’s account**, choose the provider, then choose the account. Choosing `default` restores Pi's built-in login for that provider. `/accounts` manages account identity only; it does not switch models except when login succeeds while the current model is still `unknown`, where it selects that provider's default model as onboarding help.
 

--- a/packages/pi-accounts/src/accounts.ts
+++ b/packages/pi-accounts/src/accounts.ts
@@ -17,7 +17,7 @@ import {
 	type AccountProviderAdapter,
 	type AccountProviderId,
 	createBuiltinProviderAdapters,
-	createOAuthInteraction,
+	loginWithOAuthUI,
 	SUPPORTED_PROVIDER_IDS,
 } from "./oauth.js";
 import {
@@ -629,7 +629,7 @@ async function loginAccount(
 	ctx.ui.notify(`Starting ${adapter.displayName} login for "${parsed.name}".`, "info");
 	try {
 		const credential = normalizeStoredCredential(
-			await adapter.oauth.login(createOAuthInteraction(ctx, adapter.displayName, signal)),
+			await loginWithOAuthUI(ctx, adapter, signal),
 			parsed.name,
 		);
 		if (!isCurrent()) return;

--- a/packages/pi-accounts/src/oauth.ts
+++ b/packages/pi-accounts/src/oauth.ts
@@ -6,7 +6,11 @@ import {
 	type OAuthCredential,
 	type ProviderAuthInteraction,
 } from "@earendil-works/pi-ai";
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import {
+	type ExtensionCommandContext,
+	ExtensionSelectorComponent,
+	LoginDialogComponent,
+} from "@earendil-works/pi-coding-agent";
 
 export const SUPPORTED_PROVIDER_IDS = ["anthropic", "github-copilot", "openai-codex"] as const;
 
@@ -80,6 +84,199 @@ export function createOAuthInteraction(
 		prompt: async (prompt) => promptForOAuth(ctx, prompt, signal),
 		notify: (event) => notifyOAuthEvent(ctx, providerName, event),
 	};
+}
+
+export async function loginWithOAuthUI(
+	ctx: ExtensionCommandContext,
+	adapter: AccountProviderAdapter,
+	signal: AbortSignal,
+): Promise<OAuthCredential> {
+	if (ctx.mode !== "tui") {
+		return adapter.oauth.login(createOAuthInteraction(ctx, adapter.displayName, signal));
+	}
+	const result = await ctx.ui.custom<NativeOAuthLoginResult>((tui, _theme, _keybindings, done) => {
+		const flow = new NativeOAuthLoginFlow(tui, adapter, signal, done);
+		flow.start();
+		return flow;
+	});
+	if (result.ok) return result.credential;
+	throw result.error;
+}
+
+type NativeOAuthLoginResult =
+	| { ok: true; credential: OAuthCredential }
+	| { ok: false; error: unknown };
+
+type NativeOAuthComponent = {
+	render(width: number): string[];
+	handleInput?(data: string): void;
+	invalidate(): void;
+	dispose?(): void;
+	focused?: boolean;
+};
+
+class NativeOAuthLoginFlow {
+	private readonly dialog: LoginDialogComponent;
+	private readonly controller = new AbortController();
+	private readonly signal: AbortSignal;
+	private current: NativeOAuthComponent;
+	private focusedState = false;
+	private completed = false;
+
+	constructor(
+		private readonly tui: ConstructorParameters<typeof LoginDialogComponent>[0],
+		private readonly adapter: AccountProviderAdapter,
+		ownerSignal: AbortSignal,
+		private readonly done: (result: NativeOAuthLoginResult) => void,
+	) {
+		this.dialog = new LoginDialogComponent(
+			tui,
+			adapter.id,
+			() => this.controller.abort(),
+			adapter.displayName,
+		);
+		this.current = this.dialog;
+		this.signal = AbortSignal.any([ownerSignal, this.dialog.signal, this.controller.signal]);
+	}
+
+	get focused(): boolean {
+		return this.focusedState;
+	}
+
+	set focused(value: boolean) {
+		this.focusedState = value;
+		setComponentFocus(this.current, value);
+	}
+
+	start(): void {
+		if (this.signal.aborted) {
+			this.finish({ ok: false, error: new Error("Login cancelled") });
+			return;
+		}
+		const login = this.adapter.oauth.login({
+			signal: this.signal,
+			prompt: (prompt) => this.prompt(prompt),
+			notify: (event) => this.notify(event),
+		});
+		void abortable(login, this.signal).then(
+			(credential) => this.finish({ ok: true, credential }),
+			(error) => this.finish({ ok: false, error }),
+		);
+	}
+
+	render(width: number): string[] {
+		return this.current.render(width);
+	}
+
+	handleInput(data: string): void {
+		this.current.handleInput?.(data);
+	}
+
+	invalidate(): void {
+		this.current.invalidate();
+	}
+
+	dispose(): void {
+		this.controller.abort();
+		if (this.current !== this.dialog) this.current.dispose?.();
+	}
+
+	private async prompt(prompt: AuthPrompt): Promise<string> {
+		if (prompt.type === "select") return this.select(prompt);
+		const response =
+			prompt.type === "manual_code"
+				? this.dialog.showManualInput(prompt.message)
+				: this.dialog.showPrompt(prompt.message, prompt.placeholder);
+		const signal = prompt.signal ? AbortSignal.any([this.signal, prompt.signal]) : this.signal;
+		return abortable(response, signal);
+	}
+
+	private select(prompt: Extract<AuthPrompt, { type: "select" }>): Promise<string> {
+		return new Promise((resolve, reject) => {
+			let settled = false;
+			const signal = prompt.signal ? AbortSignal.any([this.signal, prompt.signal]) : this.signal;
+			const restore = () => {
+				if (settled) return false;
+				settled = true;
+				signal.removeEventListener("abort", cancel);
+				selector.dispose();
+				this.show(this.dialog);
+				return true;
+			};
+			const cancel = () => {
+				if (!restore()) return;
+				reject(new Error("Login cancelled"));
+			};
+			const selector = new ExtensionSelectorComponent(
+				prompt.message,
+				prompt.options.map((option) => option.label),
+				(label) => {
+					if (!restore()) return;
+					const id = prompt.options.find((option) => option.label === label)?.id;
+					if (id === undefined) reject(new Error("Login cancelled"));
+					else resolve(id);
+				},
+				cancel,
+				{ tui: this.tui },
+			);
+			if (signal.aborted) {
+				cancel();
+				return;
+			}
+			signal.addEventListener("abort", cancel, { once: true });
+			this.show(selector);
+		});
+	}
+
+	private notify(event: AuthEvent): void {
+		if (this.completed) return;
+		switch (event.type) {
+			case "auth_url":
+				this.dialog.showAuth(event.url, event.instructions);
+				break;
+			case "device_code":
+				this.dialog.showDeviceCode(event);
+				this.dialog.showWaiting("Waiting for authentication...");
+				break;
+			case "info":
+				this.dialog.showInfo(event.message, event.links);
+				break;
+			case "progress":
+				this.dialog.showProgress(event.message);
+				break;
+		}
+	}
+
+	private show(component: NativeOAuthComponent): void {
+		setComponentFocus(this.current, false);
+		this.current = component;
+		setComponentFocus(this.current, this.focusedState);
+		this.tui.requestRender();
+	}
+
+	private finish(result: NativeOAuthLoginResult): void {
+		if (this.completed) return;
+		this.completed = true;
+		this.done(result);
+	}
+}
+
+function setComponentFocus(component: NativeOAuthComponent, focused: boolean): void {
+	if ("focused" in component) component.focused = focused;
+}
+
+async function abortable<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted) throw new Error("Login cancelled");
+	let onAbort: (() => void) | undefined;
+	const aborted = new Promise<never>((_resolve, reject) => {
+		onAbort = () => reject(new Error("Login cancelled"));
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+	try {
+		return await Promise.race([operation, aborted]);
+	} finally {
+		if (onAbort) signal.removeEventListener("abort", onAbort);
+	}
 }
 
 function createLazyProviderOwnedOAuth(

--- a/packages/pi-accounts/test/accounts.test.ts
+++ b/packages/pi-accounts/test/accounts.test.ts
@@ -1,8 +1,13 @@
 // Cohesion justification: this account-manager integration matrix shares credential/provider
 // fixtures and cross-covers menus, OAuth, replacement, switching, persistence, and lifecycle safety.
 import assert from "node:assert/strict";
-import { test } from "vitest";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { beforeAll, test } from "vitest";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
 import accountsExtension, {
 	ACCOUNTS_STATUS_KEY,
 	AccountStore,
@@ -14,9 +19,12 @@ import {
 	type AccountProviderAdapter,
 	createBuiltinProviderAdapters,
 	createOAuthInteraction,
+	loginWithOAuthUI,
 } from "../src/oauth.js";
 import { RuntimeAuthCoordinator } from "../src/runtime-auth.js";
 import { InMemoryAccountStorageBackend } from "../src/storage.js";
+
+beforeAll(() => initTheme("dark", false));
 
 const credential = (
 	suffix: string,
@@ -124,6 +132,7 @@ function createInteractiveAccountContext(
 	const inputCalls: Array<{ title: string; placeholder?: string }> = [];
 	const confirmCalls: Array<{ title: string; message: string }> = [];
 	const context = createMockContext({
+		mode: "rpc",
 		hasUI: true,
 		...overrides,
 		select: async (title: string, values: string[]) => {
@@ -207,6 +216,146 @@ test("OAuth interaction preserves provider prompts, cancellation, and notificati
 	});
 	assert.match(notifications.at(-1)?.message ?? "", /ABCD/);
 });
+
+test("TUI OAuth login uses Pi's native dialog across provider-owned steps", async () => {
+	let harness: ReturnType<typeof createCustomSelectorHarness> | undefined;
+	let continueToPrompt!: () => void;
+	const authShown = new Promise<void>((resolve) => {
+		continueToPrompt = resolve;
+	});
+	let selectedMethod: string | undefined;
+	let manualCode: string | undefined;
+	const provider = fakeProvider("github-copilot");
+	provider.oauth.login = async (interaction) => {
+		interaction.notify({
+			type: "info",
+			message: "Sign in with GitHub",
+			links: [{ label: "Help", url: "https://example.test/help" }],
+		});
+		await authShown;
+		selectedMethod = await interaction.prompt({
+			type: "select",
+			message: "Choose login method",
+			options: [
+				{ id: "browser", label: "Browser" },
+				{ id: "device", label: "Device login" },
+			],
+		});
+		interaction.notify({
+			type: "device_code",
+			userCode: "ABCD-EFGH",
+			verificationUri: "https://example.test/device",
+		});
+		interaction.notify({ type: "progress", message: "Checking authorization..." });
+		manualCode = await interaction.prompt({ type: "manual_code", message: "Paste callback:" });
+		return credential("native-dialog", { availableModelIds: ["allowed"] });
+	};
+	const { ctx } = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			harness = createCustomSelectorHarness(factory, 100);
+			return harness.resultPromise;
+		},
+	});
+
+	const login = loginWithOAuthUI(ctx, provider, new AbortController().signal);
+	await waitForTest(() => harness !== undefined);
+	assert.ok(harness);
+	assert.equal(harness.isFocusable, true);
+	assert.match(harness.render().join("\n"), /Login to GitHub Copilot/);
+	assert.match(harness.render().join("\n"), /Sign in with GitHub/);
+	assert.match(harness.render().join("\n"), /Help: https:\/\/example\.test\/help/);
+
+	continueToPrompt();
+	await waitForTest(() => harness?.render().join("\n").includes("Device login") ?? false);
+	assert.match(harness.render().join("\n"), /Choose login method/);
+	harness.handleInput("tui.select.down");
+	harness.handleInput("tui.select.confirm");
+	await waitForTest(() => harness?.render().join("\n").includes("ABCD-EFGH") ?? false);
+	const loginScreen = harness.render().join("\n");
+	assert.match(loginScreen, /https:\/\/example\.test\/device/);
+	assert.match(loginScreen, /Enter code: ABCD-EFGH/);
+	assert.match(loginScreen, /Waiting for authentication/);
+	assert.match(loginScreen, /Checking authorization/);
+	assert.match(loginScreen, /Paste callback/);
+
+	harness.setFocused(true);
+	harness.handleInput("callback-value");
+	harness.handleInput("tui.input.submit");
+	assert.equal((await login).access, "access-native-dialog");
+	assert.equal(selectedMethod, "device");
+	assert.equal(manualCode, "callback-value");
+});
+
+test("TUI OAuth login aborts provider work on Escape and component disposal", async () => {
+	for (const cancellation of ["escape", "dispose"] as const) {
+		let harness: ReturnType<typeof createCustomSelectorHarness> | undefined;
+		let providerSignal: AbortSignal | undefined;
+		const provider = fakeProvider("anthropic");
+		provider.oauth.login = async (interaction) => {
+			providerSignal = interaction.signal;
+			await new Promise<void>((resolve) => {
+				if (interaction.signal.aborted) resolve();
+				else interaction.signal.addEventListener("abort", () => resolve(), { once: true });
+			});
+			throw new Error("Login cancelled");
+		};
+		const { ctx } = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				harness = createCustomSelectorHarness(factory, 100);
+				return harness.resultPromise;
+			},
+		});
+
+		const login = loginWithOAuthUI(ctx, provider, new AbortController().signal);
+		await waitForTest(() => harness !== undefined && providerSignal !== undefined);
+		assert.ok(harness);
+		if (cancellation === "escape") harness.handleInput("tui.select.cancel");
+		else harness.dispose();
+		await assert.rejects(login, /Login cancelled/);
+		assert.equal(providerSignal?.aborted, true);
+	}
+});
+
+test("TUI OAuth login closes when its menu owner is cancelled", async () => {
+	let harness: ReturnType<typeof createCustomSelectorHarness> | undefined;
+	let providerSignal: AbortSignal | undefined;
+	const provider = fakeProvider("openai-codex");
+	provider.oauth.login = async (interaction) => {
+		providerSignal = interaction.signal;
+		await new Promise<void>((resolve) => {
+			if (interaction.signal.aborted) resolve();
+			else interaction.signal.addEventListener("abort", () => resolve(), { once: true });
+		});
+		throw new Error("Login cancelled");
+	};
+	const owner = new AbortController();
+	const { ctx } = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			harness = createCustomSelectorHarness(factory, 100);
+			return harness.resultPromise;
+		},
+	});
+
+	const login = loginWithOAuthUI(ctx, provider, owner.signal);
+	await waitForTest(() => harness !== undefined && providerSignal !== undefined);
+	owner.abort();
+	await assert.rejects(login, /Login cancelled/);
+	assert.equal(providerSignal?.aborted, true);
+});
+
+async function waitForTest(predicate: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+	throw new Error("Timed out waiting for test state");
+}
 
 test("accounts registers only the interactive /accounts command and lifecycle hooks", () => {
 	const mock = createMockPi();


### PR DESCRIPTION
## Summary

- reuse Pi's exported `LoginDialogComponent` for subscription OAuth in TUI mode
- use Pi's native selector for provider-owned OAuth choices while preserving the dialog state
- retain standard extension UI prompts and notifications in RPC mode
- abort provider work on Escape, prompt cancellation, menu-owner cancellation, and component disposal
- document the native login flow and add a patch changeset

## Verification

- `npm run check` (Biome, boundaries, all workspace typechecks, 2,863 tests)
- `npx vitest run packages/pi-accounts/test/accounts-storage.test.ts packages/pi-accounts/test/accounts.test.ts` (50 tests)
- `npm run check --workspace @narumitw/pi-accounts`
- `pi --list-models -e ./packages/pi-accounts`
- `npm pack --workspace @narumitw/pi-accounts --dry-run --json`

## Audit

Reviewed the touched flow against `docs/extension-conventions.md` for TUI-only custom UI, render-width delegation, IME focus forwarding, cancellation and disposal, stale session ownership, and RPC compatibility.
No convention deviations remain.
A live external-provider OAuth login was not run.
