### PR TITLE
feat(tool): add configured tool browser

### DIFF
--- a/.changeset/quiet-tools-browse.md
+++ b/.changeset/quiet-tools-browse.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tool": minor
+---
+
+Add a read-only `/tool` catalog for browsing configured tools, their exposed metadata, and effective active prompt snippets.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ pi -e npm:@narumitw/pi-goal \
 | [`pi-stamp`](./packages/pi-stamp) | Show configurable timestamps with opt-in assistant metadata, response timing, and tool timing in the TUI transcript. | `pi install npm:@narumitw/pi-stamp` |
 | [`pi-starship`](./packages/pi-starship) | Use a native Starship-style TOML footer with Pi-specific modules and no Starship binary dependency. | `pi install npm:@narumitw/pi-starship` |
 | [`pi-statusline`](./packages/pi-statusline) | Show model, tools, Git state, context usage, tokens, cost, and time in a preset or JSON-configured footer. | `pi install npm:@narumitw/pi-statusline` |
+| [`pi-tool`](./packages/pi-tool) | Browse every configured tool and inspect its active state, source, parameter schema, and prompt guidelines with `/tool`. | `pi install npm:@narumitw/pi-tool` |
 
 Choose either `pi-starship` or `pi-statusline`; do not enable both footer extensions together.
 

--- a/docs/plans/archived/2026-08-10_pi-tool-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-tool-plan.md
@@ -1,0 +1,29 @@
+# Pi Tool Extension Plan
+
+## Goal
+
+Add a small stable `@narumitw/pi-tool` extension whose `/tool` command lists every configured Pi tool and reveals all metadata exposed by `pi.getAllTools()`.
+
+## Context
+
+- The package name is `@narumitw/pi-tool`, matching the requested `pi-tool` name.
+- The primary command is `/tool`, derived from the unscoped package name.
+- The extension is read-only and owns no settings, persistence, status, or background resources.
+- The bounded UI uses Pi TUI Kit's searchable `browse` screen for list-to-detail progressive disclosure.
+- Applicable convention MUST rules are package layout and lifecycle metadata, a thin entrypoint, independent runtime dependencies, command argument and mode handling, TUI lifecycle cancellation, terminal-safe rendering, deterministic tests, the root CI gate, package inspection, and a local Pi load smoke.
+
+## Plan
+
+- [x] Add focused tests under `packages/pi-tool/test/` for catalog status, complete details, command validation, supported modes, cancellation ownership, and terminal-safe rendering; the initial six-test run failed against intentional production stubs.
+- [x] Implement `packages/pi-tool/src/` with a thin entrypoint, a read-only catalog projection, `/tool` registration, and session-owned menu cancellation; all six focused tests pass.
+- [x] Add the package manifest, README, license, TypeScript config, root stable-extension registration, lockfile entry, and release changeset; package boundaries, package typechecking, and Changesets status pass.
+- [x] Run formatting, focused tests, `npm run check`, `just pack tool`, and a local Pi package-load smoke; the full gate passed 2,869 tests, the dry-run tarball contains only the six intended publish files, and Pi loaded `/tool` and reported its expected print-mode rejection.
+- [x] Audit the final diff against `docs/extension-conventions.md`, including cancellation, disposal, session replacement, shutdown, non-TUI rejection, terminal sanitization, and package publication rules; no deviations or unverified required paths remain.
+
+## Completion Checklist
+
+- [x] `/tool` opens a searchable list in TUI and RPC modes and shows every configured tool with active state.
+- [x] Each detail view includes description, source metadata, JSON parameter schema, and prompt guidelines when exposed by Pi.
+- [x] Arguments and print/JSON modes fail observably without opening interactive UI.
+- [x] Session replacement and shutdown abort any open menu without stale-context use.
+- [x] The package is independently installable, documented, included as a stable root extension, covered by a changeset, and passes all required checks and smokes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2539,6 +2539,10 @@
 			"resolved": "packages/pi-sync",
 			"link": true
 		},
+		"node_modules/@narumitw/pi-tool": {
+			"resolved": "packages/pi-tool",
+			"link": true
+		},
 		"node_modules/@narumitw/pi-tui-kit": {
 			"resolved": "packages/pi-tui-kit",
 			"link": true
@@ -9948,6 +9952,45 @@
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
+			}
+		},
+		"packages/pi-tool": {
+			"name": "@narumitw/pi-tool",
+			"version": "0.1.0",
+			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.51.0"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.5.7",
+				"@earendil-works/pi-coding-agent": "0.84.1",
+				"@types/node": "26.1.2",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*"
+			}
+		},
+		"packages/pi-tool/node_modules/@narumitw/pi-tui-kit": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.51.0.tgz",
+			"integrity": "sha512-NH5G2GTegZwU7H5anGnTox7q+2PIhTOz6W+4YRgyYb9xuqLfOBBtY58xwoDxYqrgnmfycc0d9O6PvF37gWtzug==",
+			"license": "MIT",
+			"dependencies": {
+				"highlight.js": "11.11.1"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
+			}
+		},
+		"packages/pi-tool/node_modules/highlight.js": {
+			"version": "11.11.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"packages/pi-tui-kit": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 			"./packages/pi-statusline/src/index.ts",
 			"./packages/pi-subagents/src/index.ts",
 			"./packages/pi-sync/src/index.ts",
+			"./packages/pi-tool/src/index.ts",
 			"./packages/pi-usage/src/index.ts",
 			"./packages/pi-worktree/src/index.ts"
 		]

--- a/packages/pi-tool/LICENSE
+++ b/packages/pi-tool/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-tool/README.md
+++ b/packages/pi-tool/README.md
@@ -1,0 +1,91 @@
+# 🧰 pi-tool — Tool Browser for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-tool)](https://www.npmjs.com/package/@narumitw/pi-tool) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+`@narumitw/pi-tool` adds one read-only `/tool` command for browsing every tool configured in the current Pi session and inspecting the metadata Pi exposes for it.
+
+## ✨ Features
+
+- Lists built-in, SDK-provided, and extension-provided tools in one searchable catalog.
+- Shows whether each tool is currently active.
+- Shows the tool description, source, scope, origin, path, and optional base directory.
+- Shows the complete JSON parameter schema and every prompt guideline exposed by `pi.getAllTools()`.
+- Shows the effective prompt snippet exposed for an active tool by `ctx.getSystemPromptOptions()`.
+- Reads fresh tool and system-prompt metadata each time the catalog opens.
+- Changes no tools, settings, files, or session data.
+
+## 📦 Install
+
+Install persistently from npm:
+
+```bash
+pi install npm:@narumitw/pi-tool
+```
+
+Try without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-tool
+```
+
+Try this package from a local checkout:
+
+```bash
+pi -e ./packages/pi-tool
+```
+
+Extensions run with the same permissions as Pi.
+Only install packages from sources you trust.
+
+## 🚀 Quick start
+
+Run:
+
+```text
+/tool
+```
+
+Type to filter the list, move to a tool, and press Enter to open its details.
+Escape returns to the list and then closes the catalog.
+
+The command works in TUI and RPC modes.
+It rejects arguments and rejects print or JSON modes because Pi does not provide an observable interactive command surface there.
+
+## 💬 Commands
+
+| Command | Description |
+| --- | --- |
+| `/tool` | Browse configured tools and inspect their exposed metadata. |
+
+`/tool` intentionally accepts no arguments and does not enable, disable, or execute tools.
+
+## ℹ️ Metadata limits
+
+The catalog displays the fields returned by Pi's public `pi.getAllTools()` API: name, description, parameter schema, prompt guidelines, and source metadata.
+It combines those fields with the effective snippets returned by `ctx.getSystemPromptOptions()` for the current active tool set.
+An inactive tool's configured snippet is not exposed through the Extension API, so “None in the current system prompt” does not mean its full definition has no snippet.
+Pi does not expose a tool's implementation, runtime secrets, or label through these Extension APIs.
+
+## 🗂️ Package layout
+
+```text
+packages/pi-tool/
+├── src/
+│   ├── index.ts         # Thin Pi package entrypoint
+│   ├── tool.ts          # Command and session lifecycle ownership
+│   └── tool-catalog.ts  # Read-only catalog and detail projection
+├── test/
+├── README.md
+├── LICENSE
+├── package.json
+└── tsconfig.json
+```
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, tool browser, tool catalog, tool schema, prompt guidelines, TypeScript Pi package.
+
+## 📄 License
+
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-tool/package.json
+++ b/packages/pi-tool/package.json
@@ -1,0 +1,51 @@
+{
+	"name": "@narumitw/pi-tool",
+	"version": "0.1.0",
+	"description": "Browse configured Pi tools and inspect their exposed metadata.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"tools",
+		"tool-catalog",
+		"developer-tools"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"piExtension": {
+		"lifecycle": "stable"
+	},
+	"scripts": {
+		"check": "biome check --vcs-use-ignore-file=false src test package.json tsconfig.json README.md && npm run typecheck",
+		"format": "biome check --write --vcs-use-ignore-file=false src test package.json tsconfig.json README.md",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.51.0"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.7",
+		"@earendil-works/pi-coding-agent": "0.84.1",
+		"@types/node": "26.1.2",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "packages/pi-tool"
+	}
+}

--- a/packages/pi-tool/src/index.ts
+++ b/packages/pi-tool/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./tool.js";

--- a/packages/pi-tool/src/tool-catalog.ts
+++ b/packages/pi-tool/src/tool-catalog.ts
@@ -1,0 +1,81 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { MenuBrowseItem, MenuDefinition } from "@narumitw/pi-tui-kit";
+
+export interface ToolCatalogState {
+	tools: ReturnType<ExtensionAPI["getAllTools"]>;
+	activeToolNames: readonly string[];
+	toolSnippets: Readonly<Record<string, string>>;
+}
+
+export interface ToolCatalog {
+	title: string;
+	items: MenuBrowseItem[];
+}
+
+export function createToolCatalog(
+	tools: ToolCatalogState["tools"],
+	activeToolNames: readonly string[],
+	toolSnippets: ToolCatalogState["toolSnippets"],
+): ToolCatalog {
+	const active = new Set(activeToolNames);
+	const items = [...tools]
+		.sort((left, right) => left.name.localeCompare(right.name))
+		.map((tool): MenuBrowseItem => {
+			const parameterSchema = JSON.stringify(tool.parameters, null, 2) ?? "Unavailable";
+			const guidelines = tool.promptGuidelines ?? [];
+			const effectivePromptSnippet = toolSnippets[tool.name];
+			return {
+				id: tool.name,
+				label: tool.name,
+				statusText: active.has(tool.name) ? "active" : "inactive",
+				description: tool.description,
+				searchText: [
+					tool.name,
+					tool.description,
+					tool.sourceInfo.source,
+					tool.sourceInfo.scope,
+					tool.sourceInfo.origin,
+					tool.sourceInfo.path,
+					tool.sourceInfo.baseDir,
+					effectivePromptSnippet,
+					...guidelines,
+					parameterSchema,
+				]
+					.filter(Boolean)
+					.join(" "),
+				details: [
+					`Source: ${tool.sourceInfo.source}`,
+					`Scope: ${tool.sourceInfo.scope}`,
+					`Origin: ${tool.sourceInfo.origin}`,
+					`Path: ${tool.sourceInfo.path}`,
+					...(tool.sourceInfo.baseDir ? [`Base directory: ${tool.sourceInfo.baseDir}`] : []),
+					"",
+					"Effective prompt snippet",
+					effectivePromptSnippet ?? "None in the current system prompt.",
+					"",
+					"Parameter schema",
+					...parameterSchema.split("\n"),
+					"",
+					"Prompt guidelines",
+					...(guidelines.length > 0 ? guidelines.map((guideline) => `• ${guideline}`) : ["None"]),
+				],
+			};
+		});
+	const activeCount = tools.reduce((count, tool) => count + Number(active.has(tool.name)), 0);
+	return { title: `Tools · ${activeCount}/${tools.length} active`, items };
+}
+
+export function createToolMenu(): MenuDefinition<ToolCatalogState, "tools", never> {
+	return {
+		start: "tools",
+		screens: {
+			tools: ({ state }) => ({
+				kind: "browse",
+				...createToolCatalog(state.tools, state.activeToolNames, state.toolSnippets),
+				viewportSize: "adaptive",
+				hint: "close",
+			}),
+		},
+		actions: {},
+	};
+}

--- a/packages/pi-tool/src/tool.ts
+++ b/packages/pi-tool/src/tool.ts
@@ -1,0 +1,55 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createToolMenu } from "./tool-catalog.js";
+
+const COMMAND_NAME = "tool";
+
+export default function toolExtension(pi: ExtensionAPI) {
+	let generation = 0;
+	let sessionController = new AbortController();
+
+	const replaceSessionOwner = () => {
+		sessionController.abort(new DOMException("Tool catalog session replaced", "AbortError"));
+		sessionController = new AbortController();
+		generation += 1;
+	};
+
+	pi.on("session_start", () => {
+		replaceSessionOwner();
+	});
+
+	pi.on("session_shutdown", () => {
+		sessionController.abort(new DOMException("Tool catalog session ended", "AbortError"));
+	});
+
+	pi.registerCommand(COMMAND_NAME, {
+		description: "Browse configured tools and inspect their metadata",
+		handler: async (args, ctx) => {
+			if (args.trim()) throw new Error("/tool does not accept arguments.");
+			if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+				throw new Error("/tool requires TUI or RPC mode.");
+			}
+
+			const commandGeneration = generation;
+			const signal = sessionController.signal;
+			const isCurrent = () => commandGeneration === generation && !signal.aborted;
+			const { runMenu } = await import("@narumitw/pi-tui-kit");
+			if (!isCurrent()) return;
+
+			await runMenu(ctx, createToolMenu(), {
+				getState: () => ({
+					tools: pi.getAllTools(),
+					activeToolNames: pi.getActiveTools(),
+					toolSnippets: ctx.getSystemPromptOptions().toolSnippets ?? {},
+				}),
+				signal,
+				isCurrent,
+				onError: (errorCtx) => {
+					if (isCurrent()) errorCtx.ui.notify("The tool catalog could not be displayed.", "error");
+				},
+				onUnsupportedMode: (_unsupportedCtx, mode) => {
+					throw new Error(`/tool is unavailable in ${mode} mode; use TUI or RPC mode.`);
+				},
+			});
+		},
+	});
+}

--- a/packages/pi-tool/test/tool.test.ts
+++ b/packages/pi-tool/test/tool.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { resolveMenuScreen } from "@narumitw/pi-tui-kit";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import toolExtension from "../src/index.js";
+import { createToolCatalog, createToolMenu } from "../src/tool-catalog.js";
+
+initTheme("dark", false);
+
+const configuredTools = [
+	{
+		name: "read",
+		description: "Read a file from disk.",
+		parameters: {
+			type: "object",
+			properties: { path: { type: "string", description: "File path" } },
+			required: ["path"],
+		},
+		promptGuidelines: ["Use read before editing a file."],
+		sourceInfo: {
+			path: "<builtin:read>",
+			source: "builtin",
+			scope: "temporary",
+			origin: "top-level",
+		},
+	},
+	{
+		name: "deploy",
+		description: "Deploy the current project.",
+		parameters: { type: "object", properties: {} },
+		promptGuidelines: undefined,
+		sourceInfo: {
+			path: "/home/test/.pi/extensions/deploy.ts",
+			source: "deploy.ts",
+			scope: "user",
+			origin: "package",
+			baseDir: "/home/test/.pi/extensions",
+		},
+	},
+] as const;
+
+test("catalog lists every tool alphabetically with active state and complete exposed metadata", () => {
+	const catalog = createToolCatalog(configuredTools as never, ["read"], {
+		read: "Read file contents from the current workspace",
+	});
+	assert.equal(catalog.title, "Tools · 1/2 active");
+	assert.deepEqual(
+		catalog.items.map(({ id, statusText }) => ({ id, statusText })),
+		[
+			{ id: "deploy", statusText: "inactive" },
+			{ id: "read", statusText: "active" },
+		],
+	);
+
+	const deploy = catalog.items[0];
+	assert.ok(deploy);
+	assert.equal(deploy.description, "Deploy the current project.");
+	assert.deepEqual(deploy.details?.slice(0, 5), [
+		"Source: deploy.ts",
+		"Scope: user",
+		"Origin: package",
+		"Path: /home/test/.pi/extensions/deploy.ts",
+		"Base directory: /home/test/.pi/extensions",
+	]);
+	assert.match(deploy.details?.join("\n") ?? "", /Parameter schema\n\{\n {2}"type": "object"/u);
+	assert.match(
+		deploy.details?.join("\n") ?? "",
+		/Effective prompt snippet\nNone in the current system prompt\./u,
+	);
+	assert.match(deploy.details?.join("\n") ?? "", /Prompt guidelines\nNone/u);
+
+	const read = catalog.items[1];
+	assert.match(read?.details?.join("\n") ?? "", /"required": \[\n {4}"path"\n {2}\]/u);
+	assert.match(
+		read?.details?.join("\n") ?? "",
+		/Effective prompt snippet\nRead file contents from the current workspace/u,
+	);
+	assert.match(read?.details?.join("\n") ?? "", /Prompt guidelines\n• Use read before editing/u);
+});
+
+test("browse menu exposes searchable list-to-detail progressive disclosure", () => {
+	const menu = createToolMenu();
+	const screen = resolveMenuScreen(menu, "tools", {
+		tools: configuredTools as never,
+		activeToolNames: ["read"],
+		toolSnippets: { read: "Read file contents from the current workspace" },
+	});
+	assert.equal(screen.kind, "browse");
+	if (screen.kind !== "browse") return;
+	assert.equal(screen.viewportSize, "adaptive");
+	assert.equal(screen.hint, "close");
+	assert.match(
+		screen.items.find(({ id }) => id === "read")?.searchText ?? "",
+		/builtin temporary/u,
+	);
+});
+
+test("/tool supports RPC list and detail navigation", async () => {
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi);
+	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
+	const rpc = createRpcHarness([
+		{ kind: "select", response: "read [active]" },
+		{ kind: "select", response: "Next" },
+		{ kind: "select", response: "Next" },
+		{ kind: "select", response: "Next" },
+		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Close" },
+	]);
+	let promptOptionReads = 0;
+	const base = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		getSystemPromptOptions: () => {
+			promptOptionReads += 1;
+			return {
+				cwd: "/home/test/project",
+				selectedTools: ["read"],
+				toolSnippets: { read: "Read file contents from the current workspace" },
+			};
+		},
+	}).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	await command.handler("", { ...base, ui: { ...base.ui, ...rpc.ui } });
+	rpc.assertConsumed();
+	const detailPages = rpc.dialogs
+		.slice(1, 5)
+		.map(({ title }) => title)
+		.join("\n");
+	assert.match(detailPages, /Parameter schema/u);
+	assert.match(detailPages, /Read file contents from the current workspace/u);
+	assert.match(detailPages, /Use read before editing/u);
+	assert.equal(promptOptionReads, 1);
+});
+
+test("/tool rejects arguments and noninteractive modes before opening the catalog", async () => {
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
+	await assert.rejects(async () => {
+		await command.handler("read", createMockContext({ hasUI: true, mode: "tui" }).ctx);
+	}, /does not accept arguments/u);
+	for (const mode of ["print", "json"] as const) {
+		await assert.rejects(async () => {
+			await command.handler("", createMockContext({ hasUI: false, mode }).ctx);
+		}, /requires TUI or RPC mode/u);
+	}
+});
+
+test("terminal controls are stripped by the browse display boundary", async () => {
+	const unsafeTools = [
+		{
+			...configuredTools[0],
+			name: "read\u001b]0;owned\u0007",
+			description: "Read\u001b[31m file",
+		},
+	];
+	const menu = createToolMenu();
+	const tui = createTuiHarness({ width: 100, rows: 24 });
+	const base = createMockContext({ hasUI: true, mode: "tui" }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const { runMenu } = await import("@narumitw/pi-tui-kit");
+	const running = runMenu({ ...base, ui: { ...base.ui, custom: tui.custom } } as never, menu, {
+		getState: () => ({ tools: unsafeTools as never, activeToolNames: [], toolSnippets: {} }),
+		isCurrent: () => true,
+	});
+	await tui.waitForOpen();
+	const frame = tui.render().join("\n");
+	assert.equal(frame.includes("\u001b]0;owned"), false);
+	assert.equal(frame.includes("\u0007"), false);
+	tui.press("ctrl+c");
+	await running;
+});
+
+test("session shutdown aborts and disposes an open menu", async () => {
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi);
+	const lifecycle = createMockContext({ hasUI: true, mode: "tui" }).ctx;
+	await mock.events.get("session_start")?.[0]?.({}, lifecycle);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
+	const tui = createTuiHarness({ width: 100, rows: 24 });
+	const base = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		getSystemPromptOptions: () => ({ cwd: "/home/test/project", toolSnippets: {} }),
+	}).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
+	await tui.waitForOpen();
+	await mock.events.get("session_shutdown")?.[0]?.({}, lifecycle);
+	await running;
+	assert.equal((tui.result as { kind?: unknown } | undefined)?.kind, "close");
+});

--- a/packages/pi-tool/tsconfig.json
+++ b/packages/pi-tool/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Add the stable `@narumitw/pi-tool` extension with a searchable, read-only `/tool` catalog for TUI and RPC modes.
- Show active state, source metadata, parameter schemas, prompt guidelines, and effective active prompt snippets from `getSystemPromptOptions()`.
- Add lifecycle cancellation, terminal-safe rendering coverage, package documentation, root registration, and a Changeset.

## Verification

- `npm run check` — passed with 2,886 tests.
- `just pack tool` — passed and contained only the six intended publish files.
- `PI_OFFLINE=1 pi -ne -ns -np --no-themes --no-session -e ./packages/pi-tool -p '/tool'` — loaded the extension and produced the expected observable print-mode rejection.
