### PR TITLE
feat(btw): resume in-memory side threads

### DIFF
--- a/.changeset/tidy-bats-resume.md
+++ b/.changeset/tidy-bats-resume.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": minor
+---
+
+Add an in-memory Resume picker to `/btw` so the current Pi session can continue any non-empty side thread by its first question while `/btw <question>` remains a fresh-thread fast path.

--- a/docs/plans/archived/2026-08-10_pi-btw-in-memory-resume-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-btw-in-memory-resume-plan.md
@@ -1,0 +1,85 @@
+# pi-btw in-memory Resume plan
+
+## Goal
+
+Add a minimal `/btw` Resume flow that uses Pi TUI Kit's existing `choice` screen to select any non-empty BTW side thread retained by the current extension instance.
+
+## Context
+
+- `/btw <question>` remains a fresh-thread fast path.
+- Pi TUI Kit `choice` provides stable-ID selection, bounded navigation, descriptions, Back/Close semantics, TUI/RPC adaptation, and existing test support, but no search.
+- Searchable single choice is tracked separately in `docs/roadmaps/pi-tui-kit-roadmap.md` Phase 7.
+- The initial feature intentionally uses no files, settings fields, Pi custom session entries, or other persistence.
+
+## Architecture
+
+Keep an extension-instance-owned registry in `btw()`:
+
+```ts
+interface ResumableBtwThread {
+  id: string;
+  title: string;
+  thread: SideThread;
+  thinkingLevel: BtwThinkingLevel;
+  createdAt: number;
+  updatedAt: number;
+}
+```
+
+- Create a fresh candidate for Start and `/btw <question>`.
+- Add the candidate to the registry only after it records at least one answered or visible error turn.
+- Keep all non-empty threads until the extension instance is replaced or unloaded.
+- Sort Resume choices by `updatedAt` descending without mutating thread identity.
+- Derive the fixed title from the first submitted question and sanitize it for terminal display.
+- Show the question count as the Kit choice description.
+- Reuse the selected `SideThread` and its latest local thinking level when resuming.
+- Resolve model credentials again for every invocation and never retain authentication material in the registry.
+- Update `updatedAt` only when a new answered or error turn is recorded; merely opening and closing Resume does not reorder the list.
+
+The `/btw` main menu remains Start-first for compatibility:
+
+```text
+Start side thread
+Resume side thread    # shown only when at least one thread is resumable
+Settings
+```
+
+The Resume screen uses the first question as each stable label, newest activity first, and Escape to return to the main menu.
+
+## Non-Goals
+
+- Search, rename, delete, pin, tree relationships, custom names, disk persistence, or cross-session restore.
+- Restoring an unsent composer draft, queued steering, or an interrupted answer.
+- Reusing Pi's `SessionSelectorComponent` or imitating its filesystem, folder-scope, and session-management behavior.
+- Changing `/btw <question>` into a follow-up route.
+
+## Plan
+
+- [x] Add focused failing menu tests in `packages/pi-btw/test/menu.test.ts` for conditional Resume visibility, Start-first compatibility, recent-first choice ordering, fixed first-question labels, counts, selection, Back, Close, narrow widths, and editor preservation. Evidence: the focused test build failed because `resumeThreads` does not exist.
+- [x] Add focused failing command/state tests in `packages/pi-btw/test/btw.test.ts` and `packages/pi-btw/test/side-thread.test.ts` for multiple retained threads, stable IDs, selected-thread reuse, provider-history continuation, per-thread thinking-level reuse, fresh direct questions, empty/cancelled candidates, visible error turns, model re-resolution, and isolated extension instances. Evidence: the focused test build failed because resumable state and the deterministic `now` dependency do not exist.
+- [x] Add an extension-instance registry and thread-state handoff in `packages/pi-btw/src/btw.ts`; verify no factory-load action methods, background resources, timers, settings writes, session entries, or authentication data are introduced. Evidence: focused command and thread tests pass, and the registry retains only thread messages, title, thinking level, ID, and timestamps.
+- [x] Extend `packages/pi-btw/src/menu.ts` with a Kit `choice` Resume screen and typed selected-thread result while preserving the existing Settings flow, invalid-settings protection, Back/Close behavior, and TUI-only command boundary. Evidence: focused menu tests pass across selection, Back, Close, width bounds, and editor preservation.
+- [x] Update `packages/pi-btw/README.md` to document first-question labels, recent-activity ordering, fresh direct questions, retained and discarded fields, and loss on `/new`, Pi `/resume`, `/reload`, extension replacement, or restart.
+- [x] Add a minor Changeset for `@narumitw/pi-btw`; do not change the Pi TUI Kit dependency floor because the implementation uses the already-supported `choice` contract. Evidence: `.changeset/tidy-bats-resume.md` records the minor behavior change.
+- [x] Run focused pi-btw tests, package typecheck/check, root `npm test`, and `npm run check`; inspect `just pack btw` because published behavior and README content change. Evidence: 121 focused tests passed; package check passed; root `npm run check` passed with 2,870 tests; the dry-run tarball contained the expected 12 files; Changesets selected a pi-btw minor; and a fresh-agent-directory `pi -e ./packages/pi-btw --list-models` smoke exited 0.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`, including custom-UI mode guards, width safety, terminal sanitization, IME ownership inherited from Kit, cancellation, disposal, stale contexts after every await, editor preservation, session replacement, settings ordering, and absence of new persistence. Evidence: the command retains its TUI guard; Kit owns choice rendering/focus/Back/Close; titles cross `sanitizeSingleLine`; existing fullscreen disposal and safe notifications remain unchanged; no settings or session entry is added; Pi's documented replacement flow creates a fresh extension instance; and the isolated-factory test proves closure state is not shared.
+
+## Risks
+
+- Long-lived sessions can retain many or large side threads in memory.
+  The initial tradeoff is accepted because state is session-instance scoped and no arbitrary eviction policy has been approved.
+- A resumed thread may continue with a different configured model.
+  Re-resolving current credentials avoids stale secrets; prior assistant messages remain conversation history.
+- Choice has no search and becomes less convenient as the list grows.
+  The roadmap tracks a generic searchable picker rather than expanding this first implementation.
+
+## Completion Checklist
+
+- [x] `/btw` shows Start, Resume, and Settings when resumable threads exist, with Start still selected first.
+- [x] Resume lists every non-empty in-memory thread by fixed first question and newest recorded activity.
+- [x] Selecting an item continues that exact side conversation and local thinking level.
+- [x] `/btw <question>` always starts a new thread.
+- [x] Empty or cancelled threads are not listed, while completed visible errors are resumable.
+- [x] Drafts, steering queues, interrupted answers, credentials, and contexts from replaced extension instances are not retained.
+- [x] No settings schema, settings file, Pi session entry, package dependency floor, or disk state changes.
+- [x] Documentation, Changeset, tests, package smoke, repository gate, and semantic audits are complete.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -1,7 +1,8 @@
 # Pi TUI Kit Roadmap
 
 - **Status:** Source API 9 live-choice capability is complete and verified; publication and
-  post-publication consumer migrations remain gated
+  post-publication consumer migrations remain gated; searchable single-choice remains a future
+  evidence-gated candidate
 - **Audience:** Pi TUI Kit maintainers and extension authors
 - **Planning horizon:** The reviewed Pi 0.84.1 capability baseline; no delivery dates are committed
 - **Repository source:** API version 9 adds standalone live choice, generic interaction hints, and
@@ -42,6 +43,8 @@ handling.
   while keeping preview snapshots, rollback, persistence, and final apply policy consumer-owned.
 - Keep injected-key hint formatting and stable-ID selection behavior consistent without making
   declarative choice screens side-effecting.
+- Qualify a Pi-resume-inspired searchable single-choice interaction without importing Pi's session
+  storage, filesystem mutation, scope, naming, or tree semantics into the Kit.
 - Keep package source imports from Pi private `dist/*` paths at zero through every roadmap phase.
 
 ## Current State
@@ -88,6 +91,12 @@ cross-mode, cancellation, navigation, rollback, or stale-owner policy.
 Production and experimental consumers continue to use the Kit alongside direct Pi dialogs. Raw
 consumer and dialog counts are intentionally not pinned because they change independently of roadmap
 outcomes; the stable admission rule is compatible lifecycle evidence, not call volume.
+
+The current Kit has no searchable single-choice interaction equivalent to Pi's `/resume` selector.
+Declarative `choice` confirms a bounded static item without search, while `browse` searches read-only
+items and opens details instead of returning a selected item. Pi-btw will initially use `choice` for
+its session-local in-memory thread list; that consumer provides evidence for a future generic picker
+but does not by itself waive the normal two-consumer admission gate.
 
 ## Guiding Principles
 
@@ -296,6 +305,30 @@ abstractions when Pi provides a better stable owner.
 published and proven by both consumers, live preview pickers can delete duplicate interaction code
 without turning the Kit into a preview-state or transaction owner.
 
+### Phase 7: Searchable Single Choice
+
+**Status:** Proposed and evidence-gated.
+
+**Milestones:**
+
+- [ ] Pi-btw's in-memory Resume picker and at least one compatible consumer, or an explicit recorded
+  exception, demonstrate the same searchable single-choice lifecycle and mode contract.
+- [ ] A public contract returns a raw stable item ID on confirmation while keeping labels, metadata,
+  search text, ordering, and domain state consumer-owned.
+- [ ] TUI presentation follows the useful parts of Pi `/resume`: visible fuzzy search, a bounded
+  one-line list, consumer-supplied primary labels, right-aligned textual metadata, preservation of
+  consumer-provided recent-first ordering, IME focus, injected navigation, Enter selection, Escape
+  Back, and Ctrl+C Close.
+- [ ] RPC degrades to deterministic signal-aware ordinary selection without claiming an unsupported
+  interactive search protocol; print and JSON remain explicitly unsupported.
+- [ ] Focused tests prove filtering, stable selection, no-match and empty states, sanitization, narrow
+  widths, resize, disposal, owner replacement, stale continuations, and exact terminal outcomes.
+- [ ] Publish the Kit API independently before any consumer raises its compatibility floor.
+
+**Outcome:** Extensions can present searchable in-memory or domain-owned records with a Pi-familiar
+selection experience without pretending those records are Pi sessions or inheriting filesystem and
+session-management behavior.
+
 ## Technical Health
 
 - Keep TypeScript strict, NodeNext-compatible, and built as published JavaScript plus declarations.
@@ -345,6 +378,10 @@ without turning the Kit into a preview-state or transaction owner.
   revalidate generation after awaits, and require consumers to honor the callback signal.
 - **Premature consumer adoption:** source API 9 is not yet a published compatibility floor.
   Mitigation: publish the Kit-only Changeset first, then migrate consumers in later PRs.
+- **Session-selector overreach:** copying Pi `/resume` too literally would pull session paths, folder
+  scope, naming, deletion, and tree semantics into a generic picker.
+  Mitigation: reuse only presentation and interaction evidence, keep raw IDs and domain mutation with
+  consumers, and require compatible non-session proof before admission.
 
 ## Success Metrics
 
@@ -367,6 +404,7 @@ without turning the Kit into a preview-state or transaction owner.
 | Disabled action presentation | Disabled action rows could hide their state or truncate labels ambiguously | Published API 8 presents sanitized reasons and ellipsis-safe labels across TUI/RPC while keeping actions inert and raw identities stable | Phase 4 published; registry package, maintained component/runtime tests, and archived implementation plan |
 | Bounded live-choice ownership | Statusline and Starship repeated cursor navigation, preview dispatch, key hints, and exit handling | Source API 9 owns selection and lifecycle mechanics while consumers retain preview state, rollback, persistence, and final apply | Phase 6 source-complete; Kit TUI/RPC/lifecycle tests, repository gate, package dry run, and post-publication proof migrations |
 | Interaction-hint consistency | Kit and specialized pickers repeated binding lookup, aliases, exclusions, and sanitization | Source API 9 exposes one formatter and uses it for Kit menu, browse, and live-choice hints | Phase 6 source-complete; formatter and rendering tests |
+| Searchable single-choice ownership | `choice` has no search; `browse` cannot confirm and return an item | Admit a generic Pi-familiar picker only after compatible consumers prove raw-ID selection, search, lifecycle, and cross-mode boundaries | Phase 7 proposed; pi-btw in-memory Resume is the first evidence source |
 | Regression gate | Repository CI-equivalent gate at each capability change | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
@@ -385,6 +423,8 @@ and adoption rather than calendar output.
 - Adding a multi-line editor while Pi lacks an abort-aware RPC editor contract.
 - Building an action-bearing catalog, tree, transcript, general preview-state framework, or reorder
   framework; bounded live choice does not own preview state or transactions.
+- Reproducing Pi's session selector domain, including session loading, folder scope, names, paths,
+  parent trees, rename, delete, trash, or persistence behavior.
 - Reducing direct dialog counts as an end in itself.
 - Committing to delivery dates, speculative package versions, or implementation scope without a
   focused approved plan.
@@ -425,3 +465,4 @@ and adoption rather than calendar output.
 | 2026-08-08 | Classify remaining direct dialogs without admitting a new API. | One-off choices and values fit Pi's direct primitives; setup/auth sequences retain extension-owned drafts, secrets, validation, and publication; boolean confirmations use direct dialogs when all dismissals mean no and can adopt published `runConfirmation()` when richer outcomes are proven; multi-line editors remain deferred pending abort-aware RPC support. Raw call volume is not an admission criterion. |
 | 2026-08-08 | Complete Phase 5 capability and public-export review against Pi 0.84.1 without admitting or retiring an API. | Recall, File Context, Statusline, and Starship then demonstrated incompatible specialized catalog, preview, reorder, and transaction contracts; no maintained tree pair exists; Pi's editor remains non-abort-aware; and its public TUI controls remain lower-level than the Kit's cross-mode lifecycle contracts. Reassess after a Pi dependency upgrade or two compatible consumers provide new evidence. |
 | 2026-08-08 | Admit source API 9 bounded live choice after Starship preset selection converged with Statusline palette selection. | `runLiveChoice()` owns injected navigation, typed exits, optional shortcuts, RPC downgrade, stale checks, coalescing, disposal, and draining; a shared internal controller and public hint formatter remove repeated interaction mechanics. Preview snapshots, rollback, persistence, confirmation, and final apply remain consumer-owned. Publication must precede separate proof migrations. |
+| 2026-08-10 | Add searchable single choice as an evidence-gated future phase while pi-btw initially uses static `choice` for in-memory Resume. | Pi-btw needs Pi-familiar selection by first question and recent activity, but in-memory ownership is the immediate priority. The future Kit contract may borrow search and list presentation from Pi `/resume` without absorbing Pi session paths, scope, rename, delete, tree, or persistence semantics. |

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -8,11 +8,12 @@ Use it when you want to ask a temporary question, inspect context, or get a shor
 
 ## ✨ Features
 
-- Adds a `/btw` menu for starting a side thread or changing pi-btw settings.
-- Keeps `/btw <question>` as a direct fast path.
+- Adds a `/btw` menu for starting or resuming an in-memory side thread or changing pi-btw settings.
+- Keeps `/btw <question>` as a direct fast path that always starts a fresh side thread.
 - Answers side questions in a dedicated, scrollable full-screen UI.
 - Keeps mouse-drag copying stable while the main agent continues running in the background.
 - Supports follow-up questions in the same ephemeral side thread.
+- Resumes any non-empty side thread retained by the current Pi session, listed by its first question.
 - Queues Pi-style `Steering` questions while an answer is running and processes them one at a time.
 - Optionally brings the latest answer, a question-to-end suffix, an exact line range, or the entire side thread into the main editor.
 - Uses the current session branch as context.
@@ -57,10 +58,14 @@ Examples:
 /btw is this API name idiomatic?
 ```
 
-Running `/btw` alone opens a two-row menu. **Start side thread** is selected first, so pressing
-`Enter` opens an empty ephemeral side thread; **Settings** changes the starting thinking level
-and whether shortcut changes are remembered. `/btw <question>` bypasses this menu, and its answer
-opens above the side-thread editor. The side thread uses a dedicated full-screen terminal view.
+Running `/btw` alone opens a menu with **Start side thread** selected first. When the current Pi
+session has non-empty side threads in memory, **Resume side thread** opens a bounded choice list;
+**Settings** changes the starting thinking level and whether shortcut changes are remembered.
+Each Resume row keeps the first question as its fixed title, shows its question count, and the list
+is ordered by the newest recorded answer or visible error. Opening and closing a thread without a
+new result does not reorder it. `/btw <question>` bypasses this menu and always starts a fresh side
+thread. Its answer opens above the side-thread editor. The side thread uses a dedicated full-screen
+terminal view.
 The main agent continues running in the background, but its screen rendering stays suspended until
 `/btw` closes, so new main-thread output cannot move a mouse selection inside the side thread.
 Drag the primary mouse button across side-thread text to select and copy it through Pi's terminal
@@ -83,8 +88,9 @@ submission order and answered one at a time after the active response completes.
 A queued question uses the side thread's thinking level when its turn begins.
 A failed active response is shown in the transcript and does not discard later steering questions.
 The footer shows `PgUp`/`PgDn` only when history can scroll; press `Ctrl+C` to cancel the active
-response and discard the ephemeral side-thread draft and steering queue.
-Steering remains entirely inside pi-btw and never appends to the main conversation or editor.
+response and discard the ephemeral side-thread draft and steering queue. Completed questions,
+answers, and visible errors remain available through Resume until the current extension instance
+ends. Steering remains entirely inside pi-btw and never appends to the main conversation or editor.
 
 After at least one successful answer, press `Ctrl+R` to bring selected context to the main
 editor. The scope menu shows the size of the latest question and answer and the entire side
@@ -108,9 +114,11 @@ into Pi's main editor. It never sends the draft automatically. If the main edito
 draft, append is the recommended default. Replace is labeled as destructive and requires a second
 confirmation; Cancel returns to the side thread without changing either draft. Concurrent editor
 updates made while these menus are open are preserved. A success message reports whether context
-was loaded, appended, or replaced and its approximate size. Without an explicit bring-to-main
-action, closing `/btw`, reloading Pi, or switching sessions still discards the side thread without
-adding it to the main conversation.
+was loaded, appended, or replaced and its approximate size.
+Without an explicit bring-to-main action, closing `/btw` never adds the side thread to the main
+conversation. Non-empty threads remain only in memory for Resume within the current Pi session.
+`/new`, Pi `/resume`, `/reload`, extension replacement, and process restart discard every retained
+thread. Unsent drafts, steering queues, interrupted answers, and model credentials are never retained.
 
 ## ⚙️ Model and thinking level
 

--- a/packages/pi-btw/src/btw.ts
+++ b/packages/pi-btw/src/btw.ts
@@ -28,6 +28,7 @@ import {
 import { type RunBtwFullscreen, runBtwFullscreen } from "./fullscreen-ui.js";
 import {
 	type BtwCommandMenuResult,
+	type BtwResumeThreadSummary,
 	runBtwMenuPreservingEditor,
 	showBtwCommandMenu,
 } from "./menu.js";
@@ -105,6 +106,15 @@ interface ResolveBtwModelOptions {
 export interface ResolvedBtwModel {
 	model: Model<Api>;
 	auth: SideQuestionAuth;
+}
+
+export interface BtwThreadState {
+	id: string;
+	title?: string;
+	thread: SideThread;
+	thinkingLevel: BtwThinkingLevel;
+	createdAt: number;
+	updatedAt: number;
 }
 
 export async function resolveBtwModel({
@@ -210,6 +220,7 @@ export interface BtwExtensionDependencies {
 	showCommandMenu?: (
 		pi: ExtensionAPI,
 		ctx: ExtensionCommandContext,
+		resumeThreads: readonly BtwResumeThreadSummary[],
 	) => Promise<BtwCommandMenuResult>;
 	loadSettings?: typeof loadSettingsForCommand;
 	resolveModel?: typeof resolveBtwModelWithLoader;
@@ -223,6 +234,21 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 	const resolveModel = dependencies.resolveModel ?? resolveBtwModelWithLoader;
 	const runThread = dependencies.runThread ?? runBtwThread;
 	const runFullscreen = dependencies.runFullscreen ?? runBtwFullscreen;
+	// Pi creates a fresh extension instance after session replacement or reload.
+	const resumableThreads = new Map<string, BtwThreadState>();
+	let nextThreadNumber = 1;
+	const listResumeThreads = (): BtwResumeThreadSummary[] =>
+		[...resumableThreads.values()]
+			.reverse()
+			.filter((state) => state.thread.turns.length > 0 && state.title)
+			.sort(
+				(first, second) => second.updatedAt - first.updatedAt || second.createdAt - first.createdAt,
+			)
+			.map((state) => ({
+				id: state.id,
+				title: state.title ?? "Untitled side thread",
+				questionCount: state.thread.turns.length,
+			}));
 	pi.registerCommand("btw", {
 		description: "Ask a quick side question without adding it to the main conversation",
 		handler: async (args, ctx) => {
@@ -231,7 +257,12 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 				ctx.ui.notify("/btw requires interactive TUI mode", "error");
 				return;
 			}
-			if (!question && (await showCommandMenu(pi, ctx)) !== "start") return;
+
+			let menuResult: BtwCommandMenuResult = "start";
+			if (!question) {
+				menuResult = await showCommandMenu(pi, ctx, listResumeThreads());
+				if (menuResult === "closed") return;
+			}
 
 			const settings = await loadSettings(ctx);
 			const resolution = await resolveModel(settings, ctx);
@@ -244,15 +275,46 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 				return;
 			}
 
-			await runFullscreen(ctx, (fullscreenCtx) =>
-				runThread({
-					initialQuestion: question || undefined,
-					selected: resolution.selected,
-					thinkingLevel: settings.thinkingLevel ?? pi.getThinkingLevel(),
-					rememberThinkingLevelChanges: effectiveRememberThinkingLevelChanges(settings),
-					ctx: fullscreenCtx,
-				}),
-			);
+			let state =
+				typeof menuResult === "object" ? resumableThreads.get(menuResult.threadId) : undefined;
+			if (typeof menuResult === "object" && !state) {
+				notifySafely(ctx, "The selected /btw side thread is no longer available", "warning");
+				return;
+			}
+			const startingTurnCount = state?.thread.turns.length ?? 0;
+
+			try {
+				await runFullscreen(ctx, (fullscreenCtx) => {
+					if (!state) {
+						const createdAt = Date.now();
+						state = {
+							id: `btw-${nextThreadNumber}`,
+							thread: createSideThread(
+								buildConversationContext(fullscreenCtx.sessionManager.getBranch()),
+							),
+							thinkingLevel: settings.thinkingLevel ?? pi.getThinkingLevel(),
+							createdAt,
+							updatedAt: createdAt,
+						};
+						nextThreadNumber += 1;
+					}
+					return runThread({
+						initialQuestion: question || undefined,
+						selected: resolution.selected,
+						thinkingLevel: state.thinkingLevel,
+						rememberThinkingLevelChanges: effectiveRememberThinkingLevelChanges(settings),
+						state,
+						ctx: fullscreenCtx,
+					});
+				});
+			} finally {
+				if (state?.title && state.thread.turns.length > 0) {
+					if (state.thread.turns.length > startingTurnCount) {
+						resumableThreads.delete(state.id);
+					}
+					resumableThreads.set(state.id, state);
+				}
+			}
 		},
 	});
 }
@@ -260,6 +322,7 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 async function showCommandMenuForBtw(
 	pi: ExtensionAPI,
 	ctx: ExtensionCommandContext,
+	resumeThreads: readonly BtwResumeThreadSummary[],
 ): Promise<BtwCommandMenuResult> {
 	const currentModel = ctx.model;
 	const availableModels = ctx.modelRegistry.getAll();
@@ -276,6 +339,7 @@ async function showCommandMenuForBtw(
 	return showBtwCommandMenu(ctx, {
 		currentThinkingLevel,
 		availableThinkingLevels: model ? getSupportedThinkingLevels(model) : BTW_THINKING_LEVELS,
+		resumeThreads,
 	});
 }
 
@@ -335,6 +399,7 @@ interface RunBtwThreadDependencies {
 	chooseBringToMain?: typeof chooseBringToMain;
 	deliverBringToMain?: typeof loadBringToMainDraft;
 	persistThinkingLevel?: (level: BtwThinkingLevel) => Promise<unknown>;
+	now?: () => number;
 }
 
 export type BtwThreadResult = { kind: "closed" };
@@ -365,6 +430,7 @@ interface RunBtwThreadOptions {
 	thinkingLevel: BtwThinkingLevel;
 	rememberThinkingLevelChanges?: boolean;
 	settingsPath?: string;
+	state?: BtwThreadState;
 	ctx: ExtensionCommandContext;
 	dependencies?: RunBtwThreadDependencies;
 }
@@ -375,6 +441,7 @@ export async function runBtwThread({
 	thinkingLevel,
 	rememberThinkingLevelChanges = false,
 	settingsPath,
+	state,
 	ctx,
 	dependencies = {},
 }: RunBtwThreadOptions): Promise<BtwThreadResult> {
@@ -385,11 +452,17 @@ export async function runBtwThread({
 	const persistThinkingLevel =
 		dependencies.persistThinkingLevel ??
 		((level: BtwThinkingLevel) => updateBtwSettings({ thinkingLevel: level }, { settingsPath }));
-	const thread = createSideThread(buildConversationContext(ctx.sessionManager.getBranch()));
+	const now = dependencies.now ?? Date.now;
+	const thread =
+		state?.thread ?? createSideThread(buildConversationContext(ctx.sessionManager.getBranch()));
 	const thinkingLevels = getSupportedThinkingLevels(selected.model);
 	const pendingWrites = new Set<Promise<void>>();
 	const steeringQuestions: string[] = [];
-	let activeThinkingLevel = clampThinkingLevel(selected.model, thinkingLevel);
+	let activeThinkingLevel = clampThinkingLevel(
+		selected.model,
+		state?.thinkingLevel ?? thinkingLevel,
+	);
+	if (state) state.thinkingLevel = activeThinkingLevel;
 	let pendingQuestion = initialQuestion;
 	let composerDraft: string | undefined;
 	const createThinkingControl = (): BtwThreadThinkingControl => ({
@@ -398,6 +471,7 @@ export async function runBtwThread({
 		onChange: (level) => {
 			if (!thinkingLevels.includes(level)) return;
 			activeThinkingLevel = level;
+			if (state) state.thinkingLevel = level;
 			if (!rememberThinkingLevelChanges) return;
 			let write!: Promise<void>;
 			write = Promise.resolve()
@@ -457,6 +531,10 @@ export async function runBtwThread({
 					question: pendingQuestion,
 					answer: result.message,
 				});
+			}
+			if (state) {
+				state.title ||= sanitizeSingleLine(pendingQuestion) || "Untitled side thread";
+				state.updatedAt = now();
 			}
 
 			pendingQuestion = steeringQuestions.shift();

--- a/packages/pi-btw/src/menu.ts
+++ b/packages/pi-btw/src/menu.ts
@@ -22,9 +22,16 @@ interface BtwMenuState {
 	reason?: string;
 }
 
+export interface BtwResumeThreadSummary {
+	id: string;
+	title: string;
+	questionCount: number;
+}
+
 export interface ShowBtwCommandMenuOptions {
 	currentThinkingLevel: BtwThinkingLevel;
 	availableThinkingLevels: readonly BtwThinkingLevel[];
+	resumeThreads?: readonly BtwResumeThreadSummary[];
 	settingsPath?: string;
 	readSettings?: typeof readBtwSettings;
 	updateSettings?: (
@@ -33,10 +40,10 @@ export interface ShowBtwCommandMenuOptions {
 	) => Promise<BtwSettings>;
 }
 
-export type BtwCommandMenuResult = "start" | "closed";
+export type BtwCommandMenuResult = "start" | "closed" | { kind: "resume"; threadId: string };
 
-type BtwMenuScreen = "main" | "settings" | "invalid";
-type BtwMenuAction = "start" | "set-thinking" | "set-remember";
+type BtwMenuScreen = "main" | "resume" | "settings" | "invalid";
+type BtwMenuAction = "start" | "resume" | "set-thinking" | "set-remember";
 type BtwCustomOptions = Parameters<ExtensionCommandContext["ui"]["custom"]>[1];
 
 type BtwCustomFactory<T> = (
@@ -61,7 +68,9 @@ export async function showBtwCommandMenu(
 			? [...options.availableThinkingLevels]
 			: (["off"] satisfies BtwThinkingLevel[]);
 	const displaySettingsPath = sanitizeSingleLine(settingsPath);
+	const resumeThreads = options.resumeThreads ?? [];
 	let startSelected = false;
+	let resumedThreadId: string | undefined;
 
 	const loadState = async (): Promise<BtwMenuState> => {
 		const loaded = await readSettings(settingsPath);
@@ -89,6 +98,16 @@ export async function showBtwCommandMenu(
 						description: "Open an empty side thread",
 						action: "start",
 					},
+					...(resumeThreads.length > 0
+						? [
+								{
+									id: "resume" as const,
+									label: "Resume side thread",
+									description: "Continue an in-memory side thread",
+									to: "resume" as const,
+								},
+							]
+						: []),
 					{
 						id: "settings",
 						label: "Settings",
@@ -97,6 +116,18 @@ export async function showBtwCommandMenu(
 					},
 				],
 				hint: "close",
+			}),
+			resume: () => ({
+				kind: "choice",
+				title: "Resume BTW side thread",
+				items: resumeThreads.map((thread) => ({
+					id: thread.id,
+					label: thread.title,
+					description: `${thread.questionCount} ${thread.questionCount === 1 ? "question" : "questions"}`,
+				})),
+				action: "resume",
+				viewportSize: 10,
+				hint: "back",
 			}),
 			settings: ({ state }) => ({
 				kind: "settings",
@@ -136,6 +167,13 @@ export async function showBtwCommandMenu(
 				startSelected = true;
 				return { kind: "close" };
 			},
+			resume: async ({ itemId }: { itemId: string }) => {
+				if (!resumeThreads.some((thread) => thread.id === itemId)) {
+					return { kind: "rejected" } as const;
+				}
+				resumedThreadId = itemId;
+				return { kind: "close" } as const;
+			},
 			"set-thinking": async ({ value, signal }) => {
 				if (!value || !levels.includes(value as BtwThinkingLevel)) return { kind: "rejected" };
 				try {
@@ -172,9 +210,9 @@ export async function showBtwCommandMenu(
 	const result = await runBtwMenuPreservingEditor(ctx, (menuContext) =>
 		runMenu(menuContext, menu, { getState: loadState }),
 	);
-	return startSelected && result.kind === "closed" && result.reason === "close"
-		? "start"
-		: "closed";
+	if (result.kind !== "closed" || result.reason !== "close") return "closed";
+	if (resumedThreadId) return { kind: "resume", threadId: resumedThreadId };
+	return startSelected ? "start" : "closed";
 }
 
 export async function runBtwMenuPreservingEditor(

--- a/packages/pi-btw/test/btw.test.ts
+++ b/packages/pi-btw/test/btw.test.ts
@@ -405,6 +405,164 @@ test("btw command routes no arguments through the menu and preserves direct ques
 	assert.deepEqual(mock.thinkingLevels, []);
 });
 
+test("btw keeps multiple in-memory threads, resumes the selected one, and keeps direct questions fresh", async () => {
+	const mock = createMockPi({ thinkingLevel: "low" });
+	const selected = {
+		model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+		auth: { apiKey: "key" },
+	};
+	const menuResults: unknown[] = ["start", { kind: "resume", threadId: "btw-1" }, "closed"];
+	const menuSnapshots: Array<Array<{ id: string; title: string; questionCount: number }>> = [];
+	const states: Array<{
+		id: string;
+		title?: string;
+		thread: { turns: Array<{ kind: "error"; question: string; answer: string }> };
+		thinkingLevel: string;
+		updatedAt: number;
+	}> = [];
+	const initialQuestions: Array<string | undefined> = [];
+	let modelResolutions = 0;
+	btw(mock.pi, {
+		showCommandMenu: (async (
+			_pi: unknown,
+			_ctx: unknown,
+			resumeThreads: Array<{ id: string; title: string; questionCount: number }>,
+		) => {
+			menuSnapshots.push(resumeThreads.map((thread) => ({ ...thread })));
+			return menuResults.shift();
+		}) as never,
+		loadSettings: async () => ({ thinkingLevel: "medium" }),
+		resolveModel: async () => {
+			modelResolutions += 1;
+			return { kind: "selected", selected };
+		},
+		runFullscreen: async (ctx, run) => run(ctx),
+		runThread: (async (options: {
+			initialQuestion?: string;
+			state: {
+				id: string;
+				title?: string;
+				thread: { turns: Array<{ kind: "error"; question: string; answer: string }> };
+				thinkingLevel: string;
+				updatedAt: number;
+			};
+		}) => {
+			initialQuestions.push(options.initialQuestion);
+			states.push(options.state);
+			if (states.length === 1) {
+				options.state.title = "First side topic";
+				options.state.thread.turns.push({
+					kind: "error",
+					question: "First side topic",
+					answer: "first error",
+				});
+				options.state.thinkingLevel = "high";
+				options.state.updatedAt = 10;
+			} else if (states.length === 3) {
+				options.state.title = "Direct side topic";
+				options.state.thread.turns.push({
+					kind: "error",
+					question: "Direct side topic",
+					answer: "direct error",
+				});
+				options.state.updatedAt = 20;
+			}
+			return { kind: "closed" };
+		}) as never,
+	});
+	const command = mock.commands.get("btw");
+	assert.ok(command);
+	const interactive = createMockContext({ mode: "tui", hasUI: true });
+
+	await command.handler("", interactive.ctx);
+	await command.handler("", interactive.ctx);
+	await command.handler("Direct side topic", interactive.ctx);
+	await command.handler("", interactive.ctx);
+
+	assert.deepEqual(initialQuestions, [undefined, undefined, "Direct side topic"]);
+	assert.equal(states[1], states[0]);
+	assert.equal(states[1]?.thinkingLevel, "high");
+	assert.notEqual(states[2], states[0]);
+	assert.equal(states[2]?.thread.turns.length, 1);
+	assert.equal(modelResolutions, 3);
+	assert.deepEqual(menuSnapshots, [
+		[],
+		[{ id: "btw-1", title: "First side topic", questionCount: 1 }],
+		[
+			{ id: "btw-2", title: "Direct side topic", questionCount: 1 },
+			{ id: "btw-1", title: "First side topic", questionCount: 1 },
+		],
+	]);
+});
+
+test("an empty fresh btw thread does not enter or erase the in-memory Resume list", async () => {
+	const mock = createMockPi();
+	const selected = {
+		model: { provider: "test", id: "side" } as Model<Api>,
+		auth: { apiKey: "key" },
+	};
+	const menuResults = ["start", "closed"];
+	const menuSnapshots: Array<Array<{ id: string }>> = [];
+	const states: Array<{
+		id: string;
+		title?: string;
+		thread: { turns: unknown[] };
+		updatedAt: number;
+	}> = [];
+	btw(mock.pi, {
+		showCommandMenu: (async (_pi: unknown, _ctx: unknown, resumeThreads: Array<{ id: string }>) => {
+			menuSnapshots.push(resumeThreads.map((thread) => ({ id: thread.id })));
+			return menuResults.shift();
+		}) as never,
+		loadSettings: async () => ({}),
+		resolveModel: async () => ({ kind: "selected", selected }),
+		runFullscreen: async (ctx, run) => run(ctx),
+		runThread: (async (options: {
+			state: { id: string; title?: string; thread: { turns: unknown[] }; updatedAt: number };
+		}) => {
+			states.push(options.state);
+			if (states.length === 1) {
+				options.state.title = "Retained";
+				options.state.thread.turns.push({ kind: "error" });
+				options.state.updatedAt = 1;
+			}
+			return { kind: "closed" };
+		}) as never,
+	});
+	const command = mock.commands.get("btw");
+	assert.ok(command);
+	const interactive = createMockContext({ mode: "tui", hasUI: true });
+
+	await command.handler("Retained", interactive.ctx);
+	await command.handler("", interactive.ctx);
+	await command.handler("", interactive.ctx);
+
+	assert.deepEqual(menuSnapshots, [[{ id: "btw-1" }], [{ id: "btw-1" }]]);
+	assert.equal(states.length, 2);
+	assert.equal(states[1]?.thread.turns.length, 0);
+});
+
+test("separate btw extension instances do not share in-memory Resume state", async () => {
+	const first = createMockPi();
+	const second = createMockPi();
+	const snapshots: unknown[][] = [];
+	const register = (mock: ReturnType<typeof createMockPi>) =>
+		btw(mock.pi, {
+			showCommandMenu: (async (_pi: unknown, _ctx: unknown, threads: unknown[]) => {
+				snapshots.push([...threads]);
+				return "closed";
+			}) as never,
+		});
+	register(first);
+	register(second);
+	const interactive = createMockContext({ mode: "tui", hasUI: true });
+
+	await first.commands.get("btw")?.handler("", interactive.ctx);
+	await second.commands.get("btw")?.handler("", interactive.ctx);
+
+	assert.deepEqual(snapshots, [[], []]);
+});
+
 test("btw command cancellation at the no-argument menu does not resolve a model", async () => {
 	const mock = createMockPi();
 	let modelResolutions = 0;

--- a/packages/pi-btw/test/menu.test.ts
+++ b/packages/pi-btw/test/menu.test.ts
@@ -91,10 +91,64 @@ test("btw no-argument menu selects Start side thread first and preserves the edi
 		const rendered = tui.render().join("\n");
 		assert.match(rendered, /Pi BTW/);
 		assert.match(rendered, /→ Start side thread/);
+		assert.doesNotMatch(rendered, /Resume side thread/);
 		assert.match(rendered, /Settings/);
 		tui.press("tui.select.confirm");
 
 		assert.equal(await running, "start");
+		assert.equal(ctx.ui.getEditorText(), "draft");
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});
+
+test("btw menu selects an in-memory side thread through a Kit choice screen", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx }) => {
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "low",
+			availableThinkingLevels: ["off", "low", "medium", "high"],
+			resumeThreads: [
+				{ id: "newer", title: "Second side topic", questionCount: 3 },
+				{ id: "older", title: "First side topic", questionCount: 1 },
+			],
+		});
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /→ Start side thread/);
+		tui.press("tui.select.down");
+		assert.match(tui.render().join("\n"), /→ Resume side thread/);
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const choices = tui.render().join("\n");
+		assert.ok(choices.indexOf("Second side topic") < choices.indexOf("First side topic"));
+		assert.match(choices, /Second side topic\s+3 questions/);
+		assert.match(choices, /First side topic\s+1 question/);
+		assert.ok(tui.resize({ width: 32 }).every((line) => visibleWidth(line) <= 32));
+		tui.press("tui.select.confirm");
+
+		assert.deepEqual(await running, { kind: "resume", threadId: "newer" });
+		assert.equal(ctx.ui.getEditorText(), "draft");
+		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});
+
+test("btw Resume choice returns to the main menu with Back and closes with Ctrl+C", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx }) => {
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "low",
+			availableThinkingLevels: ["off", "low"],
+			resumeThreads: [{ id: "thread", title: "Side topic", questionCount: 1 }],
+		});
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /→ Resume side thread/);
+		tui.press("ctrl+c");
+
+		assert.equal(await running, "closed");
 		assert.equal(ctx.ui.getEditorText(), "draft");
 		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
 	});

--- a/packages/pi-btw/test/side-thread.test.ts
+++ b/packages/pi-btw/test/side-thread.test.ts
@@ -825,6 +825,97 @@ test("side-thread command loop opens the composer before the first question", as
 	assert.deepEqual(result, { kind: "closed" });
 });
 
+test("side-thread command loop updates resumable title, activity, and local thinking state", async () => {
+	const state = {
+		id: "btw-1",
+		title: undefined,
+		thread: createSideThread("main context"),
+		thinkingLevel: "low" as const,
+		createdAt: 10,
+		updatedAt: 10,
+	};
+	const askedWith: string[] = [];
+	let interactions = 0;
+
+	await runBtwThread({
+		selected: {
+			model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+			auth: { apiKey: "key" },
+		},
+		thinkingLevel: "off",
+		state,
+		ctx: {
+			ui: { notify() {} },
+			sessionManager: { getBranch: () => assert.fail("resumed state owns its original context") },
+		} as never,
+		dependencies: {
+			now: () => 42,
+			interact: async (_thread, _atBottom, _ctx, _draft, thinking) => {
+				interactions += 1;
+				if (interactions === 1) {
+					assert.equal(thinking.level, "low");
+					thinking.onChange("high");
+					return { kind: "submit", question: "First\nquestion" };
+				}
+				return { kind: "close" };
+			},
+			ask: async (thread, question, _selected, thinkingLevel) => {
+				askedWith.push(thinkingLevel);
+				const assistant = response("answer");
+				thread.turns.push({ kind: "answered", question, answer: "answer", response: assistant });
+				return { kind: "answered", response: assistant, answer: "answer" };
+			},
+		},
+	});
+
+	assert.equal(state.title, "First question");
+	assert.equal(state.thinkingLevel, "high");
+	assert.equal(state.updatedAt, 42);
+	assert.deepEqual(askedWith, ["high"]);
+	assert.equal(state.thread.turns.length, 1);
+});
+
+test("side-thread command loop retains a visible error as resumable activity", async () => {
+	const state = {
+		id: "btw-error",
+		title: undefined,
+		thread: createSideThread("main context"),
+		thinkingLevel: "off" as const,
+		createdAt: 5,
+		updatedAt: 5,
+	};
+	let interactions = 0;
+
+	await runBtwThread({
+		initialQuestion: "Failed question",
+		selected: {
+			model: { provider: "test", id: "side" } as Model<Api>,
+			auth: { apiKey: "key" },
+		},
+		thinkingLevel: "off",
+		state,
+		ctx: {
+			ui: { notify() {} },
+			sessionManager: { getBranch: () => assert.fail("provided state owns its context") },
+		} as never,
+		dependencies: {
+			now: () => 9,
+			ask: async () => ({ kind: "error", message: "provider unavailable" }),
+			interact: async () => {
+				interactions += 1;
+				return { kind: "close" };
+			},
+		},
+	});
+
+	assert.equal(interactions, 1);
+	assert.equal(state.title, "Failed question");
+	assert.equal(state.updatedAt, 9);
+	assert.deepEqual(state.thread.turns, [
+		{ kind: "error", question: "Failed question", answer: "provider unavailable" },
+	]);
+});
+
 test("side-thread command loop immediately accepts another question after each answer", async () => {
 	const ctx = {
 		ui: { notify() {} },


### PR DESCRIPTION
## Summary

- retain every non-empty `/btw` side thread in the current extension instance and resume one through a Pi TUI Kit `choice` screen
- keep the first question as the fixed title, order by latest recorded activity, preserve local thinking level, and keep `/btw <question>` fresh
- document the in-memory lifecycle, archive the implementation plan, add a minor Changeset, and track searchable single choice in the Pi TUI Kit roadmap

## Verification

- `npx vitest run packages/pi-btw/test/menu.test.ts packages/pi-btw/test/btw.test.ts packages/pi-btw/test/side-thread.test.ts` — 121 passed
- `npm run check --workspace @narumitw/pi-btw` — passed
- `npm run check` — passed, including 2,870 tests
- `npm run changeset:status` — selects a minor pi-btw release
- `just pack btw` — expected 12-file tarball
- fresh `PI_CODING_AGENT_DIR` with `pi -e ./packages/pi-btw --list-models` — exited 0

## Lifecycle audit

- no settings field, session entry, disk persistence, timer, background resource, or retained credentials were added
- Kit owns choice rendering, focus, width bounds, Back, and Close behavior
- Pi session replacement and reload create a fresh extension instance, so retained threads cannot cross those boundaries
