### PR TITLE
docs(subagents): plan full automation roadmap

### DIFF
--- a/docs/plans/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md
@@ -1,0 +1,130 @@
+# Pi Subagents Autonomous Workflow Planning Plan
+
+## Goal
+
+Add an explicit opt-in mode that accepts one high-level objective and compiles it into the smallest justified, capability-matched, bounded workflow without requiring the caller to author every task and dependency.
+
+Support versioned revisions to pending or invalidated work while preserving completed history and the verified-execution boundary.
+
+## Context
+
+`executeSubagent()` currently requires exactly one caller-selected single, parallel, chain, workflow, or panel mode.
+
+`evaluateDelegationAdmission()` can recommend parent-owned direct work, one child, one child plus verification, bounded two-child work, or abstention, but it consumes explicit metadata and normally remains audit-only.
+
+`workflow.honorAdmission` can decline caller-authored tasks but cannot create tasks, choose a topology, add a verifier, or widen a workflow.
+
+`routeByCapability()` can select an eligible agent after the caller declares capabilities, tools, verification role, side-effect class, and cost or latency hints.
+
+The verified-execution loop from the preceding plan is a required dependency because broader autonomous planning must not rely on worker self-report for completion.
+
+No matched repository evidence currently justifies a production default, learned router, wider mutating team, or recursive workflow.
+
+## Architecture
+
+Add one explicit automation request containing an objective, non-goals, required inputs, acceptance criteria, required evidence, authority ceiling, aggregate budget, and optional caller constraints.
+
+A read-only planning turn will return a bounded `pi-subagents:workflow-plan:v1` proposal rather than execute repository mutations.
+
+The proposal will contain typed tasks, dependencies, artifacts, side-effect policy, read and write scopes, ownership keys, capability requirements, acceptance criteria, integration ownership, verifier relationships, and per-task budget requests.
+
+A deterministic `WorkflowPlanCompiler` will normalize the proposal, reject malformed or unsafe graphs, evaluate admission, minimize topology, route agents, create immutable `ExecutionPlan` records, and produce the existing explicit workflow representation.
+
+The compiler, not the planner model, will enforce hard limits, trust, capability grants, result contracts, workspace policy, task generations, two-mutating-child width, and no-grandchild recursion.
+
+The planner may propose one of direct, sequential, sparse parallel, implementation plus verification, or bounded two-child plus integration structures.
+
+The admission owner may reduce or reject the proposed topology but may not silently widen authority, mutating width, recursion, or aggregate budget.
+
+When admission returns parent-owned direct work or insufficient evidence, the automation call will return a typed non-launch result so the parent can continue directly or request missing information.
+
+A bounded `pi-subagents:workflow-plan-patch:v1` format will support adding a task, replacing an unstarted task, adding a dependency, cancelling pending work, requesting verification, or invalidating downstream work.
+
+Plan patches will include the workflow generation and may modify only pending, needs-input, stale, or invalidated nodes.
+
+Completed tasks, accepted artifacts, current verification receipts, and executor-owned identities remain immutable.
+
+The first implementation will not learn from historical runs or use a learned router.
+
+## Non-Goals
+
+- Do not make automation the default or intercept every user prompt.
+- Do not permit more than two concurrent mutating children or any workflow grandchildren.
+- Do not add unrestricted debate, free-form multi-agent chat, or unbounded graph revision.
+- Do not let planner output grant tools, trust, filesystem, network, secret, credential, sandbox, model, or budget authority.
+- Do not infer successful verification from planner or worker prose.
+- Do not add a learned router, reinforcement-learning policy, reward model, or permanent skill library in the first implementation.
+- Do not expand inspection, status, dashboards, or telemetry beyond runtime fields required to compile and execute the plan safely.
+- Do not change existing execution modes when the automation request is omitted.
+- Do not publish, tag, release, or change package defaults.
+
+## Assumptions
+
+- The verified-execution loop is implemented and stable before mutating automatic plans are admitted.
+- Existing delegation contract v2, capability manifests, `ExecutionPlan`, WorkItem ledger, semantic snapshots, and workflow executor remain the compilation targets.
+- One read-only planning turn can access enough bounded repository context to propose a useful graph without mutating canonical state.
+- The parent agent can handle a typed parent-owned or needs-input result after the automation tool returns.
+- Existing provider schemas can carry a bounded automation request and plan result after compatibility tests.
+
+## Unknowns
+
+- Whether automation should be a new `subagent` mode or a separately named tool requires a schema-size, discoverability, and provider-compatibility decision.
+- The exact planner context policy and maximum graph size require measured token and latency baselines.
+- The best deterministic mapping from proposal metadata to admission inputs remains unverified by representative repository tasks.
+- The initial task classes eligible for automatic planning must be selected before live evaluation rather than after observing favorable results.
+- The benefit of different model families for planner, implementer, and verifier remains unknown.
+
+## Risks
+
+- A planning model can invent dependencies, capabilities, scopes, or acceptance criteria that appear valid but omit important work.
+- A plan compiler can become a second wide orchestration interface instead of concentrating policy.
+- Planner overhead can exceed the cost of direct work on small tasks.
+- Automatic decomposition can create tightly coupled tasks whose handoffs lose necessary context.
+- Graph patches can invalidate correct work or create loops if generation and ownership checks are incomplete.
+- A benchmark can mistake extra model calls or aggregate budget for planning quality.
+- A large public schema can reduce provider compatibility or make ordinary model tool use less reliable.
+
+## Rollback / Recovery
+
+- Keep automation behind one explicit request and compile to the existing workflow executor rather than adding a second execution engine.
+- Preserve the caller-authored explicit workflow as the documented fallback and downgrade path.
+- Return parent-owned direct work or abstention without launching children when the planner or compiler cannot establish benefit or safety.
+- Reject unknown plan versions and unsafe graph patches before confirmation, workspace creation, child allocation, or provider work.
+- Preserve the last accepted plan and WorkItem generation when a patch is rejected.
+- Disable planner-driven revisions independently from initial plan compilation if patch quality is insufficient.
+- Remove the automation schema without migrating legacy workflow records because all new fields are versioned and opt-in.
+
+## Plan
+
+- [ ] Characterize existing tool schema size, provider compatibility, mode validation, capability routing, admission decisions, workflow preflight, `ExecutionPlan` construction, WorkItem creation, verified completion, and prompt-resource boundaries; record focused baseline tests.
+- [ ] Decide whether automation is a new `subagent` mode or a separate tool by comparing schema size, provider compatibility, prompt burden, lifecycle ownership, backwards compatibility, and discoverability; record the rejected alternative and migration consequences.
+- [ ] Define bounded `pi-subagents:automation-request:v1`, `workflow-plan:v1`, and `workflow-plan-patch:v1` schemas with exact limits, unknown-field policy, executor-owned fields, provenance, generation, authority ceiling, aggregate budget, acceptance criteria, and result outcomes.
+- [ ] Add failing parser tests for malformed JSON, unsupported version, duplicate or missing IDs, cycles, excessive graph size, oversized text, invalid paths, conflicting ownership, unsupported guarantees, forged generation, forged authority, terminal controls, and private data.
+- [ ] Define planner resource and tool policy as read-only, bounded, trust-aware, cancellation-aware, and incapable of delegating grandchildren or mutating the repository.
+- [ ] Implement a planner prompt that requests tasks, dependencies, artifacts, scopes, side effects, capabilities, acceptance criteria, risks, integration ownership, verifier needs, and budgets without asking for hidden reasoning.
+- [ ] Implement `WorkflowPlanCompiler` as the single deterministic owner of normalization, graph validation, admission, topology minimization, capability routing, authority enforcement, workspace selection, task generations, hard limits, and compilation to the existing workflow shape.
+- [ ] Add compiler tests for parent-owned direct work, one child, one child plus verifier, sequential dependency, two safe mutating children, dense coupling, missing verification, unsupported capability, insufficient budget, scope conflict, no integration owner, and attempted grandchildren.
+- [ ] Ensure the compiler may narrow or reject a model proposal but cannot silently add authority, exceed aggregate budget, raise mutating width, or relax verification and trust requirements.
+- [ ] Integrate verified-execution synthesis so every compiled risk-selected mutating plan contains one distinct verifier and one authoritative integration path before any mutating child starts.
+- [ ] Implement graph patch validation and application for pending or invalidated nodes only, with current workflow generation, dependency closure, artifact invalidation, plan identity rotation, bounded revision count, and atomic persistence.
+- [ ] Add tests proving plan patches cannot rewrite completed work, forge artifacts, remove required verification, revive cancelled generations, widen authority, exceed budget, create cycles, or trigger side-effect replay.
+- [ ] Add end-to-end deterministic fixtures for objective to direct result, objective to one child, objective to verified child, objective to bounded parallel workflow, missing-input abstention, planner failure, compiler rejection, one revision after failed assumption, and terminal stop after revision exhaustion.
+- [ ] Define a frozen matched evaluation protocol against strong single-agent, one-child, caller-authored workflow, fixed two-child, and equal-budget best-of-N arms with identical model information, tools, evaluator, aggregate token or dollar ceiling, wall-clock ceiling, and repeated paired tasks.
+- [ ] Run the offline protocol and deterministic fixtures, then record which task classes remain eligible for a separately authorized live-provider evaluation without making a production-quality claim.
+- [ ] Update `packages/pi-subagents/README.md`, tool documentation, compatibility and downgrade guidance, package layout, and an appropriate Changeset for the new explicit automation surface.
+- [ ] Audit cancellation, every post-`await` generation check, session replacement, shutdown, planner disposal, persistence ordering, project trust, prompt resources, output bounds, terminal sanitization, invalid-file protection if configuration changes, and repeated cleanup against `docs/extension-conventions.md` and `docs/extension-settings.md` when applicable.
+- [ ] Run focused parser, planner, compiler, routing, admission, workflow, verification, persistence, and lifecycle tests; then run `npm test`, `npm run check`, `git diff --check`, `just pack subagents`, and representative local explicit-automation smokes when practical.
+
+## Completion Checklist
+
+- [ ] One high-level automation request can compile to the smallest justified existing workflow topology without caller-authored tasks.
+- [ ] Planner execution is read-only, bounded, trust-aware, cancellable, and unable to grant itself authority or descendants.
+- [ ] Deterministic compilation rejects unsafe or malformed plans before side effects and never silently widens authority, budget, width, or recursion.
+- [ ] Parent-owned and insufficient-evidence decisions start zero children.
+- [ ] Every admitted mutating plan uses the verified-execution acceptance boundary.
+- [ ] Plan patches modify only eligible current-generation work and preserve completed history, accepted artifacts, and verification receipts.
+- [ ] Mutating width remains at most two and workflow grandchildren remain rejected.
+- [ ] Existing omitted-field modes remain compatible with a documented fallback and downgrade path.
+- [ ] Matched evaluation protocol is frozen before live results, and no unsupported default-quality claim is made.
+- [ ] Focused tests, semantic audits, root CI-equivalent gate, package dry run, and representative runtime smokes pass or unavailable paths are explicitly recorded.
+- [ ] Published behavior has an appropriate Changeset, and no publication or release action has occurred.

--- a/docs/plans/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md
@@ -4,7 +4,17 @@
 
 Add an explicit opt-in mode that accepts one high-level objective and compiles it into the smallest justified, capability-matched, bounded workflow without requiring the caller to author every task and dependency.
 
-Support versioned revisions to pending or invalidated work while preserving completed history and the verified-execution boundary.
+Support versioned revisions to pending, rework-requested, or invalidated work while preserving accepted history and the verified-execution boundary.
+
+## Plan Relationship
+
+This plan owns only the explicit automation request, read-only planning turn, deterministic plan compiler, topology minimization, and graph-patch contract.
+
+It depends on the [verified execution loop plan](2026-08-10_pi-subagents-verified-execution-loop-plan.md) for acceptance and rework semantics.
+
+It consumes the implemented capability, contract, `ExecutionPlan`, WorkItem, and workflow baselines preserved under [`docs/plans/superseded/`](superseded/) without reopening their original checklists.
+
+The [minimal delegation admission evaluation plan](2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md) remains the sole owner of matched evidence required before a default change.
 
 ## Context
 
@@ -40,9 +50,9 @@ When admission returns parent-owned direct work or insufficient evidence, the au
 
 A bounded `pi-subagents:workflow-plan-patch:v1` format will support adding a task, replacing an unstarted task, adding a dependency, cancelling pending work, requesting verification, or invalidating downstream work.
 
-Plan patches will include the workflow generation and may modify only pending, needs-input, stale, or invalidated nodes.
+Plan patches will include the workflow generation and may modify only pending, needs-input, rework-requested, stale, or invalidated nodes.
 
-Completed tasks, accepted artifacts, current verification receipts, and executor-owned identities remain immutable.
+Accepted tasks, accepted artifacts, current verification receipts, and executor-owned identities remain immutable.
 
 The first implementation will not learn from historical runs or use a learned router.
 
@@ -106,7 +116,7 @@ The first implementation will not learn from historical runs or use a learned ro
 - [ ] Add compiler tests for parent-owned direct work, one child, one child plus verifier, sequential dependency, two safe mutating children, dense coupling, missing verification, unsupported capability, insufficient budget, scope conflict, no integration owner, and attempted grandchildren.
 - [ ] Ensure the compiler may narrow or reject a model proposal but cannot silently add authority, exceed aggregate budget, raise mutating width, or relax verification and trust requirements.
 - [ ] Integrate verified-execution synthesis so every compiled risk-selected mutating plan contains one distinct verifier and one authoritative integration path before any mutating child starts.
-- [ ] Implement graph patch validation and application for pending or invalidated nodes only, with current workflow generation, dependency closure, artifact invalidation, plan identity rotation, bounded revision count, and atomic persistence.
+- [ ] Implement graph patch validation and application for pending, rework-requested, or invalidated nodes only, with current workflow generation, dependency closure, artifact invalidation, plan identity rotation, bounded revision count, and atomic persistence.
 - [ ] Add tests proving plan patches cannot rewrite completed work, forge artifacts, remove required verification, revive cancelled generations, widen authority, exceed budget, create cycles, or trigger side-effect replay.
 - [ ] Add end-to-end deterministic fixtures for objective to direct result, objective to one child, objective to verified child, objective to bounded parallel workflow, missing-input abstention, planner failure, compiler rejection, one revision after failed assumption, and terminal stop after revision exhaustion.
 - [ ] Define a frozen matched evaluation protocol against strong single-agent, one-child, caller-authored workflow, fixed two-child, and equal-budget best-of-N arms with identical model information, tools, evaluator, aggregate token or dollar ceiling, wall-clock ceiling, and repeated paired tasks.
@@ -122,7 +132,7 @@ The first implementation will not learn from historical runs or use a learned ro
 - [ ] Deterministic compilation rejects unsafe or malformed plans before side effects and never silently widens authority, budget, width, or recursion.
 - [ ] Parent-owned and insufficient-evidence decisions start zero children.
 - [ ] Every admitted mutating plan uses the verified-execution acceptance boundary.
-- [ ] Plan patches modify only eligible current-generation work and preserve completed history, accepted artifacts, and verification receipts.
+- [ ] Plan patches modify only eligible current-generation work and preserve accepted history, accepted artifacts, and verification receipts.
 - [ ] Mutating width remains at most two and workflow grandchildren remain rejected.
 - [ ] Existing omitted-field modes remain compatible with a documented fallback and downgrade path.
 - [ ] Matched evaluation protocol is frozen before live results, and no unsupported default-quality claim is made.

--- a/docs/plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md
@@ -1,0 +1,147 @@
+# Pi Subagents Event-Driven Workflow Runtime Plan
+
+## Goal
+
+Replace batch-barrier workflow execution with one rolling event-driven runtime that schedules after every task settlement, performs bounded typed recovery, and safely reconciles persisted workflows after interruption.
+
+Keep uncertain mutating work from being replayed or accepted while allowing current safe work to continue automatically.
+
+## Context
+
+`AdaptiveScheduler.decide()` already evaluates dependency readiness, critical-path depth, capacity, remaining budget, declared scopes, ownership keys, and a two-mutating-child ceiling.
+
+The blocking workflow loop currently passes `activeCount: 0`, starts a selected batch with `mapWithConcurrencyLimit()`, waits for the complete batch, and only then schedules again.
+
+This batch barrier can leave capacity idle when a fast task unlocks downstream work while an unrelated sibling remains slow.
+
+`WorkItemLedger` provides `rerun()` and `invalidate()`, while typed outcomes provide recovery actions such as retry, reroute, supply input, revalidate, replan, verify, or stop.
+
+The runtime currently performs only caller-configured transient retries or read-only hedging and otherwise settles blocked dependents before returning.
+
+Workflow persistence saves snapshots, but blocking execution does not load and reconcile a previous snapshot for continuation.
+
+The verified-execution and autonomous-planning plans provide the acceptance and graph-revision boundaries required before automatic recovery can safely become a closed loop.
+
+## Architecture
+
+Add one session-owned `WorkflowRuntime` that owns the active-task map, completion queue, scheduler invocation, task launches, aggregate deadline, remaining budgets, active scopes, ownership, cancellation tree, persistence publication, recovery decisions, and terminal settlement.
+
+Keep `AdaptiveScheduler` pure.
+
+Call it whenever the ledger changes, capacity changes, a task settles, a task becomes stale, a recovery action completes, or the aggregate deadline expires.
+
+The runtime will launch selected tasks without waiting for all currently active tasks and will consume settlement through a completion queue or equivalent `Promise.race()` loop.
+
+Every scheduling call will receive truthful active counts, mutating counts, read and write scopes, ownership keys, transport capacity, and remaining aggregate budget.
+
+A deterministic `WorkflowRecoveryController` will translate typed outcomes into bounded executor actions.
+
+Transient pre-acceptance transport or tool failures may retry within the declared aggregate budget.
+
+Capability mismatch may reroute only before uncertain side effects and only to an agent satisfying the accepted authority ceiling.
+
+Missing inputs may request one bounded planner patch.
+
+Stale read-only evidence may revalidate against the current semantic snapshot.
+
+Verifier rejection may invoke the verified-execution rework path.
+
+Unsupported guarantees, ambiguous mutation, exhausted revision or retry bounds, repeated unchanged failures, and stale integration state will stop without replay.
+
+Persistence will use one serialized publication owner and include enough current-generation runtime state to reconcile pending, ready, active, settled, invalidated, and terminal WorkItems.
+
+Restore will never assume an in-flight process survived.
+
+Persisted running tasks will restore as interrupted and require classification before any rerun.
+
+Pending current work may resume after semantic compatibility and dependency revalidation.
+
+Read-only or proven idempotent interrupted work may rerun under a new generation after current-state revalidation.
+
+Mutating interrupted work may rerun only when the runtime can prove that prior side effects did not occur or when an explicit idempotency contract and current integration state make repetition safe.
+
+Otherwise the workflow stops with an actionable non-success outcome.
+
+## Non-Goals
+
+- Do not maximize worker count or treat configured concurrency as a target.
+- Do not exceed two concurrent mutating children or enable workflow grandchildren.
+- Do not automatically replay accepted, ambiguous, or potentially side-effecting work.
+- Do not build a distributed queue, remote worker service, cron scheduler, or general workflow engine.
+- Do not add a learned scheduler, reward model, or provider-time classifier in the first implementation.
+- Do not expand dashboards, inspection, status, or telemetry beyond runtime metadata required for correctness and persisted reconciliation.
+- Do not change parallel result ordering or omitted-field behavior for existing non-automation modes.
+- Do not publish, tag, release, or change a package default.
+
+## Assumptions
+
+- The verified-execution loop supplies authoritative acceptance and bounded rework.
+- The autonomous planner supplies versioned graph patches for missing-input and semantic replanning.
+- WorkItem generations, capability grants, semantic snapshots, artifacts, and persistence remain the authoritative workflow data.
+- A session-owned runtime can cancel every task, timer, completion waiter, persistence operation, status owner, and disposable workspace it creates.
+- A deterministic fake transport and virtual clock can exercise scheduling and recovery without live-provider variance.
+
+## Unknowns
+
+- The public resume selector, idempotency key, or workflow identity required to choose a persisted workflow must be decided before exposing continuation.
+- The exact supported restore behavior for dirty repositories and non-Git targets may remain needs-revalidation or unsupported.
+- Transport capacity may require a normalized runtime adapter because subprocess, RPC, in-process, and retained agents have different settlement semantics.
+- Fairness and starvation bounds must be selected without weakening critical-path or scope safety.
+- The first eligible task classes for automatic resume require failure-injection evidence before live evaluation.
+
+## Risks
+
+- Concurrent settlement and cancellation can double-complete a WorkItem or publish state out of order.
+- A false active-scope release can allow conflicting writes.
+- Recovery can loop between reroute, replan, and verification without making progress.
+- Restored state can describe side effects that the runtime cannot observe or undo.
+- A fast downstream task can consume budget needed by a critical-path verifier if budget reservation is incomplete.
+- Changing launch timing can expose tests or tools that were accidentally relying on batch barriers.
+- Persistence loading can create a second state owner if registry, ledger, and runtime responsibilities are not explicit.
+
+## Rollback / Recovery
+
+- Keep current batch workflow execution as an explicit fallback until rolling execution passes deterministic and representative evidence.
+- Put rolling execution and resume behind the explicit automation contract, with versioned persisted runtime records.
+- Preserve declared result ordering even when launch and settlement order changes.
+- On corrupt, unsupported, semantically incompatible, or ambiguous persisted state, quarantine the record and return needs-revalidation or rejected without launching work.
+- Stop the workflow when recovery cannot prove safe continuation instead of falling back to blind replay.
+- Allow automatic resume to be disabled independently from rolling scheduling and bounded recovery.
+- Restore the legacy batch executor without migrating legacy records by keeping the WorkItem snapshot compatible and versioning new runtime metadata.
+
+## Plan
+
+- [ ] Characterize current batch launch order, result order, scheduler decisions, `mapWithConcurrencyLimit()`, task start and settlement, retry and hedge behavior, aggregate deadlines, cancellation, persistence publication, restore projection, workspace cleanup, and transport settlement; preserve focused baseline tests.
+- [ ] Define the `WorkflowRuntime` ownership boundary against `executeSubagent()`, `AdaptiveScheduler`, `WorkItemLedger`, registry, transports, persistence, completion controller, UI status, and session lifecycle; reject designs with more than one transition or cleanup owner.
+- [ ] Define the event vocabulary and deterministic ordering for task selected, launch accepted, tool or transport failure, child settled, verification settled, invalidation, recovery requested, cancellation, deadline, persistence completion, and shutdown.
+- [ ] Add a virtual-clock deterministic harness and failing fixtures proving a fast task can unlock and start downstream work while an unrelated slow sibling remains active.
+- [ ] Implement an active-task registry that tracks task and workflow generation, agent, transport, side-effect policy, read and write scopes, ownership, budget, cancellation controller, workspace, and settlement promise without storing private prompts.
+- [ ] Replace workflow batch waiting with a completion queue or bounded `Promise.race()` event loop that invokes the pure scheduler after each authoritative state change and preserves declared result ordering.
+- [ ] Pass truthful active counts, mutating counts, active scopes, ownership, transport capacity, and remaining budget into every scheduling decision, and add tests for no overcommit, no scope conflict, critical-path progress, fairness, and aggregate deadline exhaustion.
+- [ ] Define a bounded recovery matrix for transient retry, capability reroute, missing-input planner patch, stale read-only revalidation, verifier-directed rework, contract repair, unsupported guarantee, ambiguous mutation, repeated unchanged failure, and terminal stop.
+- [ ] Implement `WorkflowRecoveryController` with aggregate retry, reroute, revision, revalidation, rework, provider-call, token or cost when available, and wall-clock ceilings; prevent model output from increasing any bound.
+- [ ] Add tests proving capability reroute cannot occur after ambiguous side effects, planner repair cannot alter completed work, verification rework uses a new generation, and repeated identical failures terminate.
+- [ ] Decide the explicit persisted workflow identity and resume request surface, including compatibility, trust, project scope, branch behavior, idempotency, missing record, duplicate request, and downgrade semantics.
+- [ ] Implement serialized load, reconcile, and save so in-flight records restore as interrupted, completed evidence remains immutable, stale generations stay quarantined, and publication cannot regress to an older snapshot.
+- [ ] Implement restore classification for pending, ready, read-only interrupted, idempotent interrupted, mutating interrupted, awaiting verification, accepted, stale, invalidated, and terminal work with a default stop for uncertain mutation.
+- [ ] Add crash and restart fixtures for pre-launch, launch-accepted, mid-tool, post-side-effect ambiguous, worker-settled pre-persist, verifier-running, persistence-failing, cancellation, replacement, timeout, and late completion states.
+- [ ] Prove session replacement and shutdown cancel or release every runtime-owned child, timer, waiter, queue entry, persistence lease, status, and disposable workspace, and revalidate generation and context after every `await`.
+- [ ] Add a deterministic makespan comparison between legacy batch and rolling scheduling with identical tasks, capacities, and budgets, while preserving zero-conflict and zero-duplicate-side-effect invariants.
+- [ ] Freeze a matched live-provider evaluation protocol for eligible task classes against legacy batch, explicit workflow, and simpler single-agent baselines before observing provider results; keep rolling mode explicit until a separate decision.
+- [ ] Update `packages/pi-subagents/README.md`, runtime and persistence guidance, compatibility and downgrade notes, package layout, and an appropriate Changeset for rolling execution and any resume surface.
+- [ ] Audit lifecycle, settings if added, file-mutation serialization, fork-sensitive state, cancellation, stale continuations, non-TUI behavior, terminal safety, output bounds, persistence failure recovery, invalid-file protection, and repeated cleanup against the extension guides.
+- [ ] Run focused scheduler, execution, recovery, WorkItem, persistence, semantic snapshot, verification, registry, transport, cancellation, and shutdown tests; then run `npm test`, `npm run check`, `git diff --check`, `just benchmark-subagents`, `just pack subagents`, and representative local interruption and resume smokes when practical.
+
+## Completion Checklist
+
+- [ ] One session-owned runtime is the sole owner of rolling workflow transitions, active work, recovery, persistence publication, and cleanup.
+- [ ] Newly ready safe work starts after any settlement without waiting for unrelated active siblings.
+- [ ] Every scheduler call receives truthful active capacity, scopes, ownership, generations, and remaining budget.
+- [ ] Typed recovery is bounded, deterministic, generation-aware, and cannot replay uncertain mutating work.
+- [ ] Persisted workflows load through semantic and side-effect reconciliation, and corrupt or unsupported state launches zero children.
+- [ ] Restored running work is never assumed complete or safely repeatable merely from persisted state.
+- [ ] Cancellation, replacement, timeout, crash, shutdown, and late settlement produce zero accepted old-generation artifacts and no leaked runtime-owned resources.
+- [ ] Declared result order, omitted-field compatibility, two-mutating-child limit, and no-grandchild rule remain intact.
+- [ ] Deterministic evidence demonstrates reduced batch-barrier makespan without conflicts or duplicate side effects.
+- [ ] Focused tests, semantic audits, root CI-equivalent gate, benchmark, package dry run, and representative runtime smokes pass or unavailable paths are explicitly recorded.
+- [ ] Published behavior has an appropriate Changeset, and no publication or release action has occurred.

--- a/docs/plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md
@@ -6,6 +6,18 @@ Replace batch-barrier workflow execution with one rolling event-driven runtime t
 
 Keep uncertain mutating work from being replayed or accepted while allowing current safe work to continue automatically.
 
+## Plan Relationship
+
+This plan owns only rolling dispatch, active-task state, bounded recovery execution, persistence reconciliation, and explicit resume behavior.
+
+It depends on the [verified execution loop plan](2026-08-10_pi-subagents-verified-execution-loop-plan.md) for acceptance-state and rework transitions.
+
+It depends on the [autonomous workflow planning plan](2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md) for bounded graph patches.
+
+It continues the implemented dependency scheduler and semantic snapshot baseline preserved in the [superseded adaptive scheduling plan](superseded/2026-08-10_pi-subagents-adaptive-scheduling-semantic-snapshot-plan.md) without re-owning that baseline.
+
+The [minimal delegation admission evaluation plan](2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md) remains the sole owner of matched evidence required before a default change.
+
 ## Context
 
 `AdaptiveScheduler.decide()` already evaluates dependency readiness, critical-path depth, capacity, remaining budget, declared scopes, ownership keys, and a two-mutating-child ceiling.

--- a/docs/plans/2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md
@@ -1,7 +1,19 @@
 # Pi Subagents Minimal Delegation Admission Evaluation Plan
 
-- **Status:** Revise recorded for an explicit opt-in implementation; paired live-provider evaluation remains deferred.
+- **Status:** Active evidence gate; deterministic baseline complete and paired live-provider evaluation deferred.
 - **Decision:** [`2026-08-10_pi-subagents-admission-gate-decision.md`](../benchmarks/2026-08-10_pi-subagents-admission-gate-decision.md).
+
+## Plan Relationship
+
+This plan is the sole owner of matched delegation-admission evidence and the **Admit**, **Revise**, or **Defer** decision required before any full-automation default change.
+
+The [verified execution loop plan](2026-08-10_pi-subagents-verified-execution-loop-plan.md) owns fresh exact-tree acceptance and bounded rework behavior.
+
+The [autonomous workflow planning plan](2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md) owns objective-to-DAG compilation and opt-in topology selection.
+
+The [event-driven workflow runtime plan](2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md) owns rolling scheduling, recovery, and resume.
+
+Those plans may provide evaluated implementations and fixtures, but they do not satisfy this plan's paired live-provider gate by themselves.
 
 ## Post-hoc Origin
 

--- a/docs/plans/2026-08-10_pi-subagents-verified-execution-loop-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-verified-execution-loop-plan.md
@@ -4,7 +4,17 @@
 
 Make independent verification and managed integration authoritative runtime gates for opt-in mutating workflows.
 
-Allow one bounded rework cycle after verifier rejection while preventing worker self-report, stale evidence, or uncertain side effects from becoming successful completion.
+Allow one bounded rework cycle after verifier rejection while preventing worker self-report, verifier-caused mutation, stale evidence, or uncertain side effects from becoming successful completion.
+
+## Plan Relationship
+
+This plan owns the acceptance-state migration, immutable verification boundary, managed integration wiring, and bounded rework loop.
+
+It continues the implemented WorkItem, capability, and semantic-snapshot baseline recorded in the [delegation-intelligence roadmap](../roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md).
+
+The original WorkItem implementation plan is preserved as non-executable provenance under [`docs/plans/superseded/`](superseded/).
+
+The [minimal delegation admission evaluation plan](2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md) remains the sole owner of matched evidence required before a default change.
 
 ## Context
 
@@ -24,31 +34,46 @@ The first implementation must remain explicit and opt-in, retain the two-mutatin
 
 Add one executor-owned `WorkflowCompletionController` that alone can move an opted-in mutating workflow from executed to accepted.
 
+The WorkItem ledger will separate execution progress from acceptance with a versioned `acceptanceState` such as `not-required`, `pending`, `accepted`, `rework-requested`, or `rejected`.
+
+For gated work, worker execution may become complete while acceptance remains pending.
+
+Verifier dependencies may become ready from execution completion, while downstream integration and terminal workflow success require accepted evidence.
+
+Legacy v1 `completed` records will restore with their existing terminal meaning, while new gated records use the explicit acceptance state.
+
 The controller will synthesize or validate one distinct dependent verifier for every task selected by `requiresIndependentVerification()`.
 
-A versioned executor-owned verification receipt will bind the verifier decision to the target task ID and generation, accepted `ExecutionPlan` ID, repository or exact-tree identity, patch digest, acceptance criteria, required evidence IDs, executed checks, and verifier identity.
+The verifier will receive no mutable repository authority.
 
-Model output may propose evidence, but it cannot author or override executor-owned generation, plan, tree, digest, or verifier identity fields.
+Deterministic commands will run under an executor-owned verification harness, and any command that requires a mutable build environment will run in a disposable verification copy rather than the submitted integration state.
 
-The verifier will receive the original objective, acceptance criteria, exact integrated state, relevant raw artifacts, and deterministic check results through a fresh context rather than through the implementer's narrative alone.
+The executor will capture the submitted state identity before verification, capture it again afterward, and reject the receipt if tracked or acceptance-relevant state drifts.
+
+A versioned executor-owned verification receipt will bind the verifier decision to the target task ID and generation, accepted `ExecutionPlan` ID, before-and-after repository or exact-tree identity, patch digest, acceptance criteria, required evidence IDs, executed checks, and verifier identity.
+
+Model output may propose evidence, but it cannot author or override executor-owned generation, plan, tree, digest, check result, or verifier identity fields.
+
+The verifier will receive the original objective, acceptance criteria, immutable submitted state, relevant raw artifacts, and executor-owned deterministic check results through a fresh context rather than through the implementer's narrative alone.
 
 `WorkItemLedger.complete()` will record execution output without treating worker self-verification as final acceptance for a gated task.
 
-`WorkItemLedger.acceptIntegration()` and `verifyManagedIntegration()` will become the authoritative acceptance path for an integration owner.
+`WorkItemLedger.acceptIntegration()` and `verifyManagedIntegration()` will atomically move current gated work to accepted only after the independent receipt passes.
 
-Verifier rejection may create one new task generation and one bounded rework turn in the first implementation.
+Verifier rejection will move the target to `rework-requested`, rotate its task generation, revoke the prior grant, invalidate dependent evidence, and permit one bounded rework turn in the first implementation.
 
-A second rejection, exhausted aggregate budget, stale state, unsupported guarantee, ambiguous side-effect state, or missing current evidence will stop with a typed non-success outcome.
+A second rejection, exhausted aggregate budget, stale state, unsupported guarantee, verifier-caused drift, ambiguous side-effect state, or missing current evidence will stop with a typed non-success outcome.
 
 The controller will not implement a general patch-merging engine.
 
-It will use the selected workspace policy and require the integration owner to produce the exact state that the verifier evaluates.
+It will use the selected workspace policy and require the integration owner to produce the exact immutable state that the verifier evaluates.
 
 ## Non-Goals
 
 - Do not enable automatic objective decomposition or topology selection in this plan.
 - Do not add more than one automated rework cycle in the first implementation.
 - Do not accept majority vote, confidence, consensus, worker prose, or an exit code as verification.
+- Do not allow the verifier to mutate the submitted integration state or supply its own machine-check results.
 - Do not replay uncertain mutating work after timeout, crash, cancellation, or ambiguous settlement.
 - Do not add inspection, dashboard, status, or telemetry features beyond bounded receipt fields required for execution correctness.
 - Do not add a general Git patch application, merge-conflict resolution, or operating-system sandbox layer.
@@ -58,7 +83,8 @@ It will use the selected workspace policy and require the integration owner to p
 ## Assumptions
 
 - Structured result v2, task generations, capability grants, WorkItem artifacts, semantic snapshots, and workflow persistence remain available.
-- A fresh verifier can run in a distinct child context with the original requirements and exact target workspace.
+- A fresh verifier can run in a distinct child context with the original requirements and an immutable view of the exact target state.
+- Executor-owned deterministic checks can use a disposable environment without changing acceptance-relevant state.
 - Repository identity is truthful only to the precision supported by the selected target and semantic snapshot.
 - The package can distinguish worker evidence from executor-owned verification receipts without breaking legacy result formats.
 
@@ -72,6 +98,7 @@ It will use the selected workspace policy and require the integration owner to p
 ## Risks
 
 - A verifier with the same evidence and failure mode can repeat the implementer's mistake.
+- A verifier with shell or write authority can mutate the state under review and bypass the integration owner.
 - Automatically synthesized verifier tasks can increase cost for changes with cheap deterministic verification.
 - Incorrect tree or patch identity can reject valid work or accept stale work.
 - A rework turn can overwrite a correct result if rejection evidence is weak or stale.
@@ -85,21 +112,23 @@ It will use the selected workspace policy and require the integration owner to p
 - Reject or return needs-revalidation when exact-tree or side-effect state cannot be proved.
 - Preserve worker outputs, rejected receipts, and prior task generations as bounded evidence without accepting them as current.
 - Disable automated rework independently from independent verification if rework evidence is unsafe or provider behavior is unstable.
-- Revert the completion-controller integration without changing stored legacy WorkItem records by versioning new receipt fields.
+- Version the new acceptance state and receipt fields, and preserve a backward reader that gives legacy `completed` records their existing terminal meaning.
+- Revert the completion-controller integration without rewriting stored legacy WorkItem records.
 
 ## Plan
 
 - [ ] Map current workflow preflight, inferred and explicit integration ownership, `settleWorkItem()`, structured verification parsing, WorkItem completion, persistence, cancellation, timeout, worktree cleanup, and terminal rendering; record characterization tests before behavior changes.
-- [ ] Decide the explicit opt-in request field, `pi-subagents:verification-receipt:v1` schema, executor-owned fields, size bounds, status vocabulary, unknown-field policy, exact-tree identity, and compatibility behavior; verify the schema with provider-compatible TypeBox tests.
-- [ ] Define one completion state machine covering executed, awaiting integration, awaiting verification, accepted, rework requested, rejected, stale, interrupted, and failed; prove one owner controls terminal acceptance and every transition has a bounded cause.
-- [ ] Add failing tests proving a worker's own `passed` verification cannot accept a gated mutating task, while legacy omitted-field behavior remains unchanged.
+- [ ] Decide the explicit opt-in request field, `pi-subagents:verification-receipt:v1` schema, executor-owned fields, size bounds, status vocabulary, unknown-field policy, before-and-after exact-tree identity, and compatibility behavior; verify the schema with provider-compatible TypeBox tests.
+- [ ] Define a versioned WorkItem acceptance state that is separate from execution progress, including legacy-v1 restore mapping, terminal-state rules, verifier-ready dependency rules, accepted downstream dependency rules, and atomic executed, accepted, rework, rejected, stale, interrupted, and failed transitions.
+- [ ] Add failing ledger and persistence tests proving a worker's own `passed` verification cannot accept a gated mutating task, a verifier can start from executed work, rejected work can enter one new generation, accepted work remains terminal, and legacy omitted-field records retain their existing meaning.
 - [ ] Reconcile inferred integration ownership in `workflow-planning.ts` with preflight verification policy so the final inferred mutating integration owner cannot bypass a distinct verifier in the opt-in mode.
-- [ ] Implement verifier synthesis and validation before child allocation, including distinct agent identity, dependency on the target task, fresh context, required result contract, accepted scopes, aggregate budget, and zero workflow grandchildren.
-- [ ] Build the verifier prompt from the original objective, acceptance criteria, current artifacts, exact integrated state, and deterministic evidence without treating upstream summaries as instructions or proof.
-- [ ] Implement executor-owned receipt construction and validation, binding task generation, `ExecutionPlan`, repository or tree identity, patch digest, required evidence, executed checks, verifier identity, and acceptance status.
-- [ ] Wire `verifyManagedIntegration()` and `WorkItemLedger.acceptIntegration()` into the blocking workflow execution path, and reject missing, stale, mismatched, out-of-scope, self-issued, or non-exact-tree receipts before terminal success.
-- [ ] Implement one bounded rework cycle that rotates the target generation, revokes the prior grant, invalidates dependent evidence, passes only verifier findings and current requirements, and refuses replay when prior side effects are ambiguous.
-- [ ] Add end-to-end fixtures for accept, rework then accept, rework then reject, deterministic-check failure, stale verifier, cancelled verifier, late worker completion, missing evidence, patch mismatch, scope mismatch, wrong plan, wrong tree, and budget exhaustion.
+- [ ] Implement verifier synthesis and validation before child allocation, including distinct agent identity, read-only effective authority, no mutable shell or custom tools, dependency on the target task, fresh context, required result contract, accepted scopes, aggregate budget, and zero workflow grandchildren.
+- [ ] Implement an executor-owned verification harness that runs declared deterministic checks, isolates mutable build output from the submitted state, captures bounded raw results, and fails closed when a check cannot be run safely.
+- [ ] Build the verifier prompt from the original objective, acceptance criteria, current artifacts, immutable integrated state, and executor-owned deterministic evidence without treating upstream summaries as instructions or proof.
+- [ ] Implement executor-owned receipt construction and validation, binding task generation, `ExecutionPlan`, before-and-after repository or tree identity, patch digest, required evidence, executed checks, verifier identity, and acceptance status.
+- [ ] Wire `verifyManagedIntegration()` and `WorkItemLedger.acceptIntegration()` into the blocking workflow execution path as one atomic acceptance transition, and reject missing, stale, mismatched, out-of-scope, self-issued, drifted, or non-exact-tree receipts before terminal success.
+- [ ] Implement one bounded rework cycle that moves executed work to `rework-requested`, rotates the target generation, revokes the prior grant, invalidates dependent evidence, passes only verifier findings and current requirements, and refuses replay when prior side effects are ambiguous.
+- [ ] Add end-to-end fixtures for accept, rework then accept, rework then reject, verifier mutation, generated build files, unsafe verification command, deterministic-check failure, stale verifier, cancelled verifier, late worker completion, missing evidence, patch mismatch, scope mismatch, wrong plan, wrong tree, legacy snapshot restore, and budget exhaustion.
 - [ ] Add session replacement, shutdown, timeout, partial initialization, repeated cleanup, and every-post-`await` generation tests for the completion controller, verifier child, integration owner, status owner, persistence owner, and disposable workspace.
 - [ ] Add a matched deterministic benchmark fixture comparing worker self-report, independent verifier, and deterministic exact-tree verification for false acceptance and added cost without claiming a provider-quality advantage.
 - [ ] Update `packages/pi-subagents/README.md`, tool schema guidance, compatibility and downgrade notes, package layout, and an appropriate Changeset for the new opt-in public behavior.
@@ -109,9 +138,11 @@ It will use the selected workspace policy and require the integration owner to p
 ## Completion Checklist
 
 - [ ] One executor-owned controller is the only terminal acceptance owner for opt-in verified workflows.
-- [ ] Every gated mutating integration has a distinct fresh-context verifier on the exact integrated state.
+- [ ] Every gated mutating integration has a distinct fresh-context verifier over an immutable view of the exact integrated state.
+- [ ] Verifiers have no mutable repository authority, deterministic checks are executor-owned, and before-and-after state drift invalidates the receipt.
+- [ ] Execution completion and acceptance are distinct persisted states with backward-compatible legacy restoration and legal verifier and rework transitions.
 - [ ] Worker self-verification, confidence, consensus, prose, and exit status cannot independently satisfy acceptance.
-- [ ] Every accepted receipt is bound to current task generation, `ExecutionPlan`, tree identity, patch digest, evidence, and verifier identity.
+- [ ] Every accepted receipt is bound to current task generation, `ExecutionPlan`, before-and-after tree identity, patch digest, evidence, executed checks, and verifier identity.
 - [ ] Stale, cancelled, replaced, late, mismatched, out-of-scope, and incomplete evidence produces zero successful acceptance.
 - [ ] Automated rework is bounded to one cycle and never blindly replays uncertain mutating work.
 - [ ] Existing omitted-field workflows remain compatible, and the opt-in mode has downgrade guidance.

--- a/docs/plans/2026-08-10_pi-subagents-verified-execution-loop-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-verified-execution-loop-plan.md
@@ -1,0 +1,119 @@
+# Pi Subagents Verified Execution Loop Plan
+
+## Goal
+
+Make independent verification and managed integration authoritative runtime gates for opt-in mutating workflows.
+
+Allow one bounded rework cycle after verifier rejection while preventing worker self-report, stale evidence, or uncertain side effects from becoming successful completion.
+
+## Context
+
+`packages/pi-subagents/src/verification-policy.ts` identifies work that requires independent verification, but the workflow caller must explicitly provide the verifier task.
+
+`packages/pi-subagents/src/execution.ts` currently maps any worker-reported structured verification with status `passed` to `verificationAccepted` during ordinary WorkItem completion.
+
+`packages/pi-subagents/src/integration-controller.ts` and `WorkItemLedger.acceptIntegration()` already define generation, repository, dependency, read-set, plan, scope, patch, evidence, fresh-context, and exact-tree checks.
+
+The blocking workflow runtime does not currently call that managed integration boundary.
+
+`createBlockingWorkLedger()` can infer the final workflow task as integration owner, while preflight verification policy checks only the caller's explicit `integrationOwner` field.
+
+The first implementation must remain explicit and opt-in, retain the two-mutating-child and no-grandchild limits, and avoid a new settings surface.
+
+## Architecture
+
+Add one executor-owned `WorkflowCompletionController` that alone can move an opted-in mutating workflow from executed to accepted.
+
+The controller will synthesize or validate one distinct dependent verifier for every task selected by `requiresIndependentVerification()`.
+
+A versioned executor-owned verification receipt will bind the verifier decision to the target task ID and generation, accepted `ExecutionPlan` ID, repository or exact-tree identity, patch digest, acceptance criteria, required evidence IDs, executed checks, and verifier identity.
+
+Model output may propose evidence, but it cannot author or override executor-owned generation, plan, tree, digest, or verifier identity fields.
+
+The verifier will receive the original objective, acceptance criteria, exact integrated state, relevant raw artifacts, and deterministic check results through a fresh context rather than through the implementer's narrative alone.
+
+`WorkItemLedger.complete()` will record execution output without treating worker self-verification as final acceptance for a gated task.
+
+`WorkItemLedger.acceptIntegration()` and `verifyManagedIntegration()` will become the authoritative acceptance path for an integration owner.
+
+Verifier rejection may create one new task generation and one bounded rework turn in the first implementation.
+
+A second rejection, exhausted aggregate budget, stale state, unsupported guarantee, ambiguous side-effect state, or missing current evidence will stop with a typed non-success outcome.
+
+The controller will not implement a general patch-merging engine.
+
+It will use the selected workspace policy and require the integration owner to produce the exact state that the verifier evaluates.
+
+## Non-Goals
+
+- Do not enable automatic objective decomposition or topology selection in this plan.
+- Do not add more than one automated rework cycle in the first implementation.
+- Do not accept majority vote, confidence, consensus, worker prose, or an exit code as verification.
+- Do not replay uncertain mutating work after timeout, crash, cancellation, or ambiguous settlement.
+- Do not add inspection, dashboard, status, or telemetry features beyond bounded receipt fields required for execution correctness.
+- Do not add a general Git patch application, merge-conflict resolution, or operating-system sandbox layer.
+- Do not change existing behavior when the verified-execution contract is omitted.
+- Do not publish, tag, release, or change a package default.
+
+## Assumptions
+
+- Structured result v2, task generations, capability grants, WorkItem artifacts, semantic snapshots, and workflow persistence remain available.
+- A fresh verifier can run in a distinct child context with the original requirements and exact target workspace.
+- Repository identity is truthful only to the precision supported by the selected target and semantic snapshot.
+- The package can distinguish worker evidence from executor-owned verification receipts without breaking legacy result formats.
+
+## Unknowns
+
+- The exact public opt-in field and receipt schema must be finalized against TypeBox provider compatibility before implementation.
+- The exact-tree identity for dirty non-Git targets may require an explicit unsupported or needs-revalidation outcome.
+- The first supported integration workspace mode must be chosen from shared workspace, disposable worktree, or both after characterization.
+- Whether a different model family is required for selected risk classes remains an evaluation question rather than an assumed guarantee.
+
+## Risks
+
+- A verifier with the same evidence and failure mode can repeat the implementer's mistake.
+- Automatically synthesized verifier tasks can increase cost for changes with cheap deterministic verification.
+- Incorrect tree or patch identity can reject valid work or accept stale work.
+- A rework turn can overwrite a correct result if rejection evidence is weak or stale.
+- Wiring integration admission into execution can expose lifecycle races that isolated helper tests do not cover.
+- The inferred integration-owner discrepancy can change which legacy workflows require verification if compatibility is not explicitly gated.
+
+## Rollback / Recovery
+
+- Keep verified execution behind an explicit per-call contract and preserve existing explicit workflow behavior by omission.
+- Keep the current workflow result projection as the compatibility path while the new controller owns only opted-in acceptance.
+- Reject or return needs-revalidation when exact-tree or side-effect state cannot be proved.
+- Preserve worker outputs, rejected receipts, and prior task generations as bounded evidence without accepting them as current.
+- Disable automated rework independently from independent verification if rework evidence is unsafe or provider behavior is unstable.
+- Revert the completion-controller integration without changing stored legacy WorkItem records by versioning new receipt fields.
+
+## Plan
+
+- [ ] Map current workflow preflight, inferred and explicit integration ownership, `settleWorkItem()`, structured verification parsing, WorkItem completion, persistence, cancellation, timeout, worktree cleanup, and terminal rendering; record characterization tests before behavior changes.
+- [ ] Decide the explicit opt-in request field, `pi-subagents:verification-receipt:v1` schema, executor-owned fields, size bounds, status vocabulary, unknown-field policy, exact-tree identity, and compatibility behavior; verify the schema with provider-compatible TypeBox tests.
+- [ ] Define one completion state machine covering executed, awaiting integration, awaiting verification, accepted, rework requested, rejected, stale, interrupted, and failed; prove one owner controls terminal acceptance and every transition has a bounded cause.
+- [ ] Add failing tests proving a worker's own `passed` verification cannot accept a gated mutating task, while legacy omitted-field behavior remains unchanged.
+- [ ] Reconcile inferred integration ownership in `workflow-planning.ts` with preflight verification policy so the final inferred mutating integration owner cannot bypass a distinct verifier in the opt-in mode.
+- [ ] Implement verifier synthesis and validation before child allocation, including distinct agent identity, dependency on the target task, fresh context, required result contract, accepted scopes, aggregate budget, and zero workflow grandchildren.
+- [ ] Build the verifier prompt from the original objective, acceptance criteria, current artifacts, exact integrated state, and deterministic evidence without treating upstream summaries as instructions or proof.
+- [ ] Implement executor-owned receipt construction and validation, binding task generation, `ExecutionPlan`, repository or tree identity, patch digest, required evidence, executed checks, verifier identity, and acceptance status.
+- [ ] Wire `verifyManagedIntegration()` and `WorkItemLedger.acceptIntegration()` into the blocking workflow execution path, and reject missing, stale, mismatched, out-of-scope, self-issued, or non-exact-tree receipts before terminal success.
+- [ ] Implement one bounded rework cycle that rotates the target generation, revokes the prior grant, invalidates dependent evidence, passes only verifier findings and current requirements, and refuses replay when prior side effects are ambiguous.
+- [ ] Add end-to-end fixtures for accept, rework then accept, rework then reject, deterministic-check failure, stale verifier, cancelled verifier, late worker completion, missing evidence, patch mismatch, scope mismatch, wrong plan, wrong tree, and budget exhaustion.
+- [ ] Add session replacement, shutdown, timeout, partial initialization, repeated cleanup, and every-post-`await` generation tests for the completion controller, verifier child, integration owner, status owner, persistence owner, and disposable workspace.
+- [ ] Add a matched deterministic benchmark fixture comparing worker self-report, independent verifier, and deterministic exact-tree verification for false acceptance and added cost without claiming a provider-quality advantage.
+- [ ] Update `packages/pi-subagents/README.md`, tool schema guidance, compatibility and downgrade notes, package layout, and an appropriate Changeset for the new opt-in public behavior.
+- [ ] Audit the final diff against `docs/extension-conventions.md`, including bounded failures, cancellation, fork-sensitive state, non-TUI behavior, resource disposal, terminal sanitization, persistence ordering, and output limits.
+- [ ] Run focused tests for execution, verification policy, integration controller, WorkItem ledger, workflow persistence, and lifecycle behavior; then run `npm test`, `npm run check`, `git diff --check`, `just pack subagents`, and one representative local `pi -e` or `just try subagents` smoke when practical.
+
+## Completion Checklist
+
+- [ ] One executor-owned controller is the only terminal acceptance owner for opt-in verified workflows.
+- [ ] Every gated mutating integration has a distinct fresh-context verifier on the exact integrated state.
+- [ ] Worker self-verification, confidence, consensus, prose, and exit status cannot independently satisfy acceptance.
+- [ ] Every accepted receipt is bound to current task generation, `ExecutionPlan`, tree identity, patch digest, evidence, and verifier identity.
+- [ ] Stale, cancelled, replaced, late, mismatched, out-of-scope, and incomplete evidence produces zero successful acceptance.
+- [ ] Automated rework is bounded to one cycle and never blindly replays uncertain mutating work.
+- [ ] Existing omitted-field workflows remain compatible, and the opt-in mode has downgrade guidance.
+- [ ] Focused tests, lifecycle audit, root CI-equivalent gate, package dry run, and representative runtime smoke pass or any unavailable smoke remains explicitly recorded.
+- [ ] Published behavior has an appropriate Changeset, and no publication or release action has occurred.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,7 +1,10 @@
 # Plan lifecycle
 
-`docs/plans/` contains active executable plans. Keep each plan current while work is in progress and
-archive it under `docs/plans/archived/` only after every task and completion check has evidence.
+`docs/plans/` contains active executable plans. Keep each plan current while work is in progress.
+
+Move a plan to `docs/plans/archived/` only after every task and completion check has evidence.
+
+Move an incomplete plan to `docs/plans/superseded/` only after its remaining work has one explicit current owner and the replacement records the relationship. Superseded plans are design provenance, not executable checklists, and their unchecked boxes must not be treated as active work.
 
 The archive is a workflow handoff, not permanent product documentation. During later curation:
 
@@ -13,5 +16,6 @@ The archive is a workflow handoff, not permanent product documentation. During l
 
 After durable facts are represented by their maintained owner, completed checklists, migration
 sequence, review follow-ups, old counts/versions, and superseded designs may be deleted from the
-archive. Git and GitHub remain the historical record. Never move whole plans into another directory
-solely to retain execution history.
+archive or superseded directory. Git and GitHub remain the historical record. Never move whole plans
+solely to retain execution history without first assigning every remaining obligation to a current
+owner.

--- a/docs/plans/superseded/2026-08-10_pi-subagents-adaptive-scheduling-semantic-snapshot-plan.md
+++ b/docs/plans/superseded/2026-08-10_pi-subagents-adaptive-scheduling-semantic-snapshot-plan.md
@@ -1,5 +1,11 @@
 # Pi Subagents Adaptive Scheduling and Semantic Snapshot Plan
 
+> **Superseded as an executable plan on 2026-08-10.**
+> The implemented dependency scheduler and semantic snapshot baseline are documented in the [delegation-intelligence roadmap](../../roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md).
+> Rolling dispatch, recovery, and resume are owned by the [event-driven workflow runtime plan](../2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md).
+> Matched admission evidence remains owned by the [minimal delegation admission evaluation plan](../2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md).
+> Unchecked boxes below preserve the original design sequence and are not current executable work.
+
 ## Goal
 
 Add deterministic dependency-aware scheduling and semantic resource snapshots so `pi-subagents` starts only current, ready, safely independent work, adapts effective concurrency below hard ceilings, detects semantic skew before continuation, and invalidates stale downstream evidence.

--- a/docs/plans/superseded/2026-08-10_pi-subagents-capability-manifest-execution-plan.md
+++ b/docs/plans/superseded/2026-08-10_pi-subagents-capability-manifest-execution-plan.md
@@ -1,5 +1,11 @@
 # Pi Subagents Capability Manifest and Audit-Only ExecutionPlan Plan
 
+> **Superseded as an executable plan on 2026-08-10.**
+> The implemented capability-manifest, routing, and `ExecutionPlan` baseline is documented in the [delegation-intelligence roadmap](../../roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md).
+> Automatic plan compilation and capability routing are owned by the [autonomous workflow planning plan](../2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md).
+> Representative admission and permission evidence remains owned by the [minimal delegation admission evaluation plan](../2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md).
+> Unchecked boxes below preserve the original design sequence and are not current executable work.
+
 ## Goal
 
 Add versioned agent capability manifests and one deterministic transport-neutral `ExecutionPlan` that audits task fit, requested authority, effective policy, overgrant, mismatch, and unsupported guarantees without changing established launch behavior.

--- a/docs/plans/superseded/2026-08-10_pi-subagents-handoff-contract-v2-plan.md
+++ b/docs/plans/superseded/2026-08-10_pi-subagents-handoff-contract-v2-plan.md
@@ -1,5 +1,11 @@
 # Pi Subagents Handoff Contract v2 Plan
 
+> **Superseded as an executable plan on 2026-08-10.**
+> The implemented delegation and result-contract baseline is documented in the [delegation-intelligence roadmap](../../roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md).
+> New automation-plan and verification-receipt contracts are owned by the active full-automation plans in the parent directory.
+> Optional contract-profile work is deferred and requires a separately approved active plan.
+> Unchecked boxes below preserve the original design sequence and are not current executable work.
+
 ## Goal
 
 Add one opt-in versioned delegation request and result contract that preserves objectives, authority requests, dependencies, evidence, artifacts, limitations, provenance, and outcome state across blocking, chained, fan-in, detached, persisted, inspected, and rendered subagent flows.

--- a/docs/plans/superseded/2026-08-10_pi-subagents-typed-abstention-enforcement-plan.md
+++ b/docs/plans/superseded/2026-08-10_pi-subagents-typed-abstention-enforcement-plan.md
@@ -1,5 +1,11 @@
 # Pi Subagents Typed Abstention and Capability Enforcement Plan
 
+> **Superseded as an executable plan on 2026-08-10.**
+> The implemented typed-outcome, capability-enforcement, generation, and recovery baseline is documented in the [delegation-intelligence roadmap](../../roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md).
+> Automatic planning decisions are owned by the [autonomous workflow planning plan](../2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md).
+> Closed-loop recovery is owned by the [event-driven workflow runtime plan](../2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md).
+> Unchecked boxes below preserve the original design sequence and are not current executable work.
+
 ## Goal
 
 Turn audited capability and authority findings into an explicit opt-in enforcement and recovery protocol that can acknowledge suitable work, reject unsuitable work before side effects, request missing inputs, abstain safely, and avoid blind retries.

--- a/docs/plans/superseded/2026-08-10_pi-subagents-work-item-ledger-plan.md
+++ b/docs/plans/superseded/2026-08-10_pi-subagents-work-item-ledger-plan.md
@@ -1,5 +1,12 @@
 # Pi Subagents WorkItem and Artifact Ledger Plan
 
+> **Superseded as an executable plan on 2026-08-10.**
+> The implemented WorkItem and artifact-ledger baseline is documented in the [delegation-intelligence roadmap](../../roadmaps/2026-08-10_pi-subagents-delegation-intelligence-roadmap.md).
+> Acceptance-state migration and managed verification are owned by the [verified execution loop plan](../2026-08-10_pi-subagents-verified-execution-loop-plan.md).
+> Rolling persistence and resume are owned by the [event-driven workflow runtime plan](../2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md).
+> Detached-agent projection remains intentionally deferred and requires a separately approved plan.
+> Unchecked boxes below preserve the original design sequence and are not current executable work.
+
 ## Goal
 
 Add a bounded persistent orchestration ledger that owns WorkItem identity, dependencies, cohesive scope, assignment, artifacts, versions, ownership, acceptance, invalidation, and terminal state while leaving Pi and existing transports responsible for agent execution.

--- a/docs/plans/superseded/README.md
+++ b/docs/plans/superseded/README.md
@@ -1,0 +1,11 @@
+# Superseded plans
+
+This directory contains incomplete plans that no longer own executable work.
+
+A plan belongs here only when a current roadmap or active plan owns every remaining obligation and records the replacement relationship.
+
+Unchecked boxes in these documents preserve the original design sequence and must not be executed or reported as current work.
+
+Move only fully evidenced plans to `docs/plans/archived/`.
+
+Delete superseded plans during later curation after maintained roadmaps, implementation notes, tests, and active plans preserve every durable decision and remaining obligation.

--- a/docs/research/2026-08-10_alphaxiv-subagents-collaboration.md
+++ b/docs/research/2026-08-10_alphaxiv-subagents-collaboration.md
@@ -1,0 +1,370 @@
+# Research on AI/LLM Subagent Communication, Debate, Consensus, and Error Propagation
+
+## Research Scope
+
+This research focuses on inter-agent communication, debate, consensus, shared messages, groupthink, and error propagation in AI/LLM subagent and multi-agent methods from 2024 through 2026.
+The research cutoff date is 2026-08-10.
+Literature discovery used the AlphaXiv MCP `discover_papers` tool, and candidate papers were read with `answer_pdf_queries` and `get_paper_content`.
+Publication status, venue, and DOI information were cross-checked against official pages from Scientific Reports, Springer Nature, the ACL Anthology, and arXiv.
+The research prioritized formally peer-reviewed journals, followed by the ACL main conference and ACL Findings, and finally highly relevant methods available only on arXiv.
+Scientific Reports is a Springer Nature journal, not the journal Nature.
+ACL Findings is a peer-reviewed proceedings series, but it is neither a journal nor the ACL or EMNLP main-conference long-paper track.
+An arXiv DOI identifies a preprint and must not be treated as a journal DOI.
+
+## Summary of Conclusions
+
+The most transferable direction for coding-agent workflows is not to let more agents chat without limits, but to require independent answers, sparse exchange, preserved dissent, evidence verification, and aggregation only at the end.
+Fully connected sharing can rapidly spread wrong answers, perceived authority, and persuasive language across the entire team.
+Sparse topologies can reduce cost, delay incorrect consensus, and preserve a longer period of effective debate.
+Genuine diversity produced by different models, tools, or roles is more effective at reducing shared blind spots than repeated sampling from the same model.
+Consensus should trigger final verification only and must not directly imply that an answer is correct or a task is complete.
+A dedicated dissenting agent can break silent agreement, but its claims must still undergo evidence verification.
+Messages from other agents should be treated as untrusted input because natural-language persuasion, incorrect citations, and RAG packaging can all amplify error propagation.
+
+## Recommendation Ranking
+
+The ranking combines transferability to coding agents, strength of publication evidence, and direct relevance to groupthink and error propagation.
+
+### 1. Improving Multi-Agent Debate with Sparse Communication Topology
+
+- **Authors:** Yunxuan Li, Yibing Du, Jiageng Zhang, Le Hou, Peter Grabowski, Yeqing Li, and Eugene Ie.
+- **Year:** 2024.
+- **Publication status:** A peer-reviewed ACL Findings paper, not a journal article and not an EMNLP main-conference paper.
+- **Venue:** Findings of the Association for Computational Linguistics: EMNLP 2024.
+- **DOI:** [10.18653/v1/2024.findings-emnlp.427](https://doi.org/10.18653/v1/2024.findings-emnlp.427).
+- **AlphaXiv:** [2406.11776](https://www.alphaxiv.org/abs/2406.11776).
+- **arXiv:** [2406.11776](https://arxiv.org/abs/2406.11776).
+- **Official publication page:** [ACL Anthology](https://aclanthology.org/2024.findings-emnlp.427/).
+
+#### Method and Results
+
+The paper models agents as nodes in a graph, with each agent reading only the previous-round answers of adjacent agents instead of broadcasting every answer to every other agent.
+The main experiments compare regular six-agent graphs whose density ranges from 1 for the fully connected graph down to 2/5 for the neighbor-connected topology.
+Each agent first answers independently, then uses only the previous-round answers of connected agents as references, and finally all agents determine the answer by majority vote.
+The neighbor-connected sparse topology scored about two percentage points higher than the fully connected topology on MATH, maintained the same accuracy on GSM8K, and reduced average input-token cost for reasoning tasks by more than 40%.
+On the helpfulness and harmlessness labeling tasks, the sparsest settings saved up to approximately 53.5% and 53.3% of cost, respectively, while achieving similar or better results.
+The authors found that on difficult questions, seeing more incorrect reference answers made an agent more likely to be misled, while sparse communication delayed premature convergence and preserved more effective debate rounds.
+In the multi-model setting, placing the stronger model at a high-centrality node performed better than placing it at a low-centrality node.
+
+#### Coding-Agent Implementation Recommendations
+
+- Let implementers, testers, security reviewers, and requirements reviewers analyze the task independently first.
+- Send each agent's result to only one or two designated neighbors instead of broadcasting the full content to every agent.
+- Place the testing or evidence-verification agent at a more highly connected node.
+- Share conclusions, evidence, tests, and unresolved questions, but not unnecessary full-form free-form narratives.
+- Have an aggregator collect candidate conclusions at the end and use reproducible tests, rather than repetition count, as the primary decision criterion.
+- Record which messages each agent actually saw so that error-propagation paths can be analyzed.
+
+#### Limitations
+
+The research mainly analyzes static regular graphs and does not cover the continuously changing dynamic topologies of real workflows.
+The main models are GPT-3.5, GPT-4/4o, and Mistral 7B, so the results cannot directly represent every current coding-agent model.
+Some GPT experiments sampled only 100 questions, and the datasets concentrate on mathematics, multimodal reasoning, and preference labeling.
+The authors provide neither a general algorithm for choosing the best topology nor a rigorous theoretical proof that sparse topology must be better.
+
+### 2. ReConcile: Round-Table Conference Improves Reasoning via Consensus among Diverse LLMs
+
+- **Authors:** Justin Chih-Yao Chen, Swarnadeep Saha, and Mohit Bansal.
+- **Year:** 2024.
+- **Publication status:** A peer-reviewed ACL 2024 main-conference long paper, not a journal article.
+- **Venue:** Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics, Volume 1: Long Papers.
+- **DOI:** [10.18653/v1/2024.acl-long.381](https://doi.org/10.18653/v1/2024.acl-long.381).
+- **AlphaXiv:** [2309.13007](https://www.alphaxiv.org/abs/2309.13007).
+- **arXiv:** [2309.13007](https://arxiv.org/abs/2309.13007).
+- **Official publication page:** [ACL Anthology](https://aclanthology.org/2024.acl-long.381/).
+
+#### Method and Results
+
+ReConcile first has different model families independently produce answers, explanations, and self-reported confidence.
+In each round, the discussion prompt groups all agents' previous-round answers, explanations, and confidence by candidate answer instead of merely concatenating messages in agent order.
+The prompt also includes examples of human explanations that previously helped other agents correct errors, teaching agents to produce explanations with corrective value.
+Discussion stops when every agent agrees or the maximum number of rounds is reached, and the team answer is then produced through recalibrated confidence-weighted voting.
+The maximum improvement across seven benchmarks was 11.4 percentage points, and the method exceeded GPT-4 on some tasks.
+Ablation experiments show that diversity across model families is the most important component, while answer grouping, confidence estimation, and corrective examples each also contribute positively.
+The first arXiv version of ReConcile appeared in 2023, but its formal ACL publication year is 2024.
+
+#### Coding-Agent Implementation Recommendations
+
+- Require every agent to submit an independent plan and initial judgment before any messages are shared.
+- Use different models, different tools, or different roles to create genuinely different failure modes.
+- Require every agent to submit a structured summary containing `conclusion`, `change scope`, `evidence`, `tests`, `confidence`, and `unresolved risks`.
+- Group messages by candidate plan or failure hypothesis instead of building a single conversation log that accumulates one agent at a time.
+- Provide minimal examples that previously corrected the same class of error, but do not treat those examples as direct evidence for the current problem.
+- Use confidence only as an aggregation weight and never as a replacement for test results, static analysis, or source-code evidence.
+
+#### Limitations
+
+The main agents depended on closed APIs available at the time, so the authors could not fully know or control model data, parameter counts, or behavior.
+Agent confidence is a self-reported value elicited after the fact by prompting, not a naturally calibrated probability.
+Because of API cost, some main experiments used only about 100 samples, although the authors reproduced the same trend on two complete test sets.
+The capabilities, data, and costs of the different models were not perfectly matched, so the findings cannot be reduced to a claim that adding more model types always helps.
+
+### 3. When collaboration fails: persuasion driven adversarial influence in multi agent large language model debate
+
+- **Authors:** Insaf Kraidia, Iyas Qaddara, Alhanof Almutairi, Nada Alzaben, and Samir Brahim Belhouari.
+- **Year:** 2026.
+- **Publication status:** A formally peer-reviewed journal article.
+- **Venue:** Scientific Reports 16, Article 11640.
+- **DOI:** [10.1038/s41598-026-42705-7](https://doi.org/10.1038/s41598-026-42705-7).
+- **AlphaXiv/arXiv:** This search did not find a verifiable AlphaXiv or arXiv version.
+- **Official publication page:** [Scientific Reports](https://www.nature.com/articles/s41598-026-42705-7).
+
+#### Method and Results
+
+The study inserts an adversarial agent that uses natural-language persuasion into an otherwise normal multi-agent debate.
+The adversarial agent uses debate history, counterargument generation, argument refinement, Best-of-N selection, and RAG to package an incorrect answer.
+The study measures both final majority-vote accuracy and the change in other agents from their initial answers toward the adversarial answer.
+A single adversarial agent can reduce overall accuracy by 10-40% and increase consensus on an incorrect answer by more than 30%.
+Low-quality, irrelevant, or selectively retrieved RAG content can still make an incorrect argument appear more credible.
+Adding more agents or debate rounds does not reliably defend against the attack, and additional rounds can even entrench an incorrect consensus that has already formed.
+
+#### Coding-Agent Implementation Recommendations
+
+- Treat text from other agents as untrusted input even when it includes citations, tool names, or high-confidence language.
+- Preserve each agent's initial answer and monitor the harmful-revision rate or flip rate when a correct answer is changed into an incorrect one.
+- Require every important claim to include a reproducible test, file location, original document, or tool output.
+- Do not treat the presence of RAG citations as proof that the citations actually support the claim.
+- Limit the message-propagation scope and modifiable resources of high-influence agents.
+- Perform independent verification after consensus instead of ending the workflow immediately.
+- Preserve the provenance of opinion changes so error propagation can be traced and isolated.
+
+#### Limitations
+
+Multi-round experiments are expensive, limiting repetitions, model variety, and the scale of hyperparameter searches.
+Most open models in the study have only 8B-14B parameters, so they cannot fully represent the behavior of large closed models such as GPT-4.
+The experiments use synchronous, text-only, controlled debates that differ from real coding agents with tools, asynchronous execution, permission controls, and human oversight.
+The paper primarily demonstrates attack risk and does not validate a complete defense capable of resisting these attacks.
+
+### 4. Silence is Not Consensus: Disrupting Agreement Bias in Multi-Agent LLMs via Catfish Agent for Clinical Decision Making
+
+- **Authors:** Yihan Wang, Qiao Yan, Zhenghao Xing, Lihao Liu, Junjun He, Chi-Wing Fu, Xiaowei Hu, and Pheng-Ann Heng.
+- **Year:** 2025.
+- **Publication status:** This search could confirm only an arXiv preprint and found no formal journal or conference version.
+- **Venue:** arXiv cs.CL.
+- **DOI:** [10.48550/arXiv.2505.21503](https://doi.org/10.48550/arXiv.2505.21503), which is an arXiv DOI rather than a journal DOI.
+- **AlphaXiv:** [2505.21503](https://www.alphaxiv.org/abs/2505.21503).
+- **arXiv:** [2505.21503](https://arxiv.org/abs/2505.21503).
+
+#### Method and Results
+
+The paper defines superficial consensus formed without sufficient discussion as Silent Agreement.
+The Catfish Agent injects structured dissent when it detects premature agreement, missing justification, ignored alternatives, or logical contradictions.
+Intervention strength is adjusted to task complexity, while the tone of dissent is adjusted to current consensus strength so that criticism is neither too weak nor disruptive.
+The Catfish Agent can operate both within the expert team and at the moderator level, providing peer-level and top-down challenges.
+In the MedQA ablation, the full design reduced the silent-agreement rate for intermediate cases from 61.8% to 17.1% and raised overall accuracy from 36% to 50%.
+In another analysis on MedQA and PubMedQA, the method reduced the silent rate to 17% and 11%, respectively.
+
+#### Coding-Agent Implementation Recommendations
+
+- Assign a dedicated Catfish or dissenting agent to search for counterexamples, missing tests, and incorrect assumptions before integration.
+- Use one lightweight challenge for simple changes and activate multi-round falsification only for high-risk or cross-module changes.
+- Require the dissenting agent to propose verifiable failure cases instead of disagreeing merely for the sake of disagreement.
+- Keep the dissenting agent's tone focused on evidence and risk so that forceful wording does not create a new authority bias.
+- Require the aggregator to answer each objection instead of merely declaring a majority decision or ignoring minority views.
+- Let the dissenting agent inspect the new shared conclusion once more before final integration so errors do not reappear during summarization.
+
+#### Limitations
+
+The work remains a preprint, and no formal journal or conference version was available for verification.
+The experiments concentrate on medical question answering and medical visual question answering and do not directly validate software-engineering workflows.
+Multi-agent coordination and Catfish interventions increase inference cost, while the authors leave lower coordination cost as future work.
+The paper presents a failure case in which the moderator rejects valid dissent and preserves an incorrect answer, so adding a dissenting agent does not guarantee correction.
+
+### 5. Selective agreement, not sycophancy: investigating opinion dynamics in LLM interactions
+
+- **Authors:** Erica Cau, Valentina Pansanella, Dino Pedreschi, and Giulio Rossetti.
+- **Year:** 2025.
+- **Publication status:** A formally peer-reviewed journal article.
+- **Venue:** EPJ Data Science 14, Article 59.
+- **DOI:** [10.1140/epjds/s13688-025-00579-1](https://doi.org/10.1140/epjds/s13688-025-00579-1).
+- **AlphaXiv/arXiv:** This search did not find a verifiable AlphaXiv or arXiv version.
+- **Official publication page:** [EPJ Data Science](https://link.springer.com/article/10.1140/epjds/s13688-025-00579-1).
+
+#### Method and Results
+
+LODAS gives 140 Llama or Mistral agents seven-level discrete opinions and pairs them randomly for persuasion over 30 rounds.
+In each interaction, a Discussant listens to a persuasive message from an Opponent and then either moves its opinion by one level or leaves it unchanged.
+The study uses a DistilBERT classifier to detect fallacies involving relevance, credibility, circular reasoning, faulty generalization, and false causality.
+Agents converge naturally and are both producers and victims of fallacies.
+Under the two statement formulations, approximately 75-78% of Llama Discussants changed their opinions after exposure to fallacious messages, compared with about 60-61% of Mistral Discussants.
+The results indicate that opinion changes are not simple indiscriminate agreement, but asymmetric persuasion affected by the model, statement direction, perceived credibility, and argument form.
+
+#### Coding-Agent Implementation Recommendations
+
+- Divide shared messages into four fields: claim, evidence, inference, and conclusion.
+- Check for appeals to authority, irrelevant reasons, circular reasoning, false causality, and unsupported generalizations before aggregation.
+- Track opinion changes across rounds and require agents to state whether each change was caused by new evidence, test results, or peer pressure.
+- Preserve a disagreement or candidate-count metric so that all agents do not converge too quickly on one answer.
+- Allow agents to retain their position or abstain rather than forcing them to accept another agent's position in every round.
+- Use fallacy detection only as a warning and never as the sole basis for automatically rejecting a claim.
+
+#### Limitations
+
+The study uses only the Ship of Theseus topic, one mean-field pairing structure, English prompts, and 7B-8B models.
+The agents have no distinct personalities or cognitive strategies and do not simulate clustering or echo-chamber structures from real social networks.
+The fallacy classifier can itself misclassify content, and the paper explores the relationship between fallacies and opinion change only preliminarily.
+This is a diagnostic study of opinion dynamics, not a method directly shown to improve coding-task accuracy.
+
+## Coding-Agent Workflow Recommendations
+
+The following design is a cross-paper engineering synthesis, not a complete coding-agent architecture directly validated by any single paper.
+
+### 1. Generate Independent Initial Answers
+
+Three to five agents should first analyze the problem independently without seeing one another's work.
+Each agent should preserve its initial conclusion, assumptions, confidence, citations, intended change scope, and verification method.
+This step prevents the first speaker from becoming an incorrect anchor for the other agents.
+
+### 2. Use Structured Messages
+
+The minimum message shared between agents should contain `claim`, `evidence`, `assumptions`, `tests`, `confidence`, and `open_risks`.
+Evidence should prioritize file locations, original documents, reproducible commands, and test output.
+Agents should not pass only unsourced conclusions, role authority, or long persuasive narratives.
+
+### 3. Use a Sparse Topology
+
+Use a ring, neighbor-connected, or responsibility-partitioned topology by default instead of fully connected broadcasting.
+Testing, integration, or evidence agents may occupy higher-centrality nodes, but their claims must still be verified.
+Messages need to reach every agent only during low-cost summarization or final integration.
+
+### 4. Preserve Structured Dissent
+
+At least one agent should be responsible for finding counterexamples, missing tests, incorrect assumptions, and overlooked alternatives.
+The dissenting agent should adjust intervention depth to task risk and raise objections that can be executed or checked.
+The aggregator must answer minority opinions rather than eliminating disagreement through majority vote.
+
+### 5. Independently Verify Shared Claims
+
+The evidence agent should execute tests, read original files, or query official documentation independently instead of merely restating another agent's results.
+RAG, citation count, high confidence, and model capability cannot replace primary evidence.
+If multiple agents share the same untrusted source, voting does not turn their correlated error into independent evidence.
+
+### 6. Aggregation and Stopping Conditions
+
+Aggregation may consider calibrated confidence, but final weight should depend primarily on tests, source quality, and reproducibility.
+Consensus should only enter final verification and must not directly mark the task complete.
+The workflow should stop after verification passes, important objections are resolved, or a clearly defined cost limit is reached.
+
+### 7. Track Error Propagation
+
+The system should record when each agent changes its answer, which messages it saw, and which evidence triggered the change.
+Corrective revisions from wrong to correct and harmful revisions from correct to wrong should be monitored separately.
+When an error spreads through shared messages, the system should be able to isolate the source, retract downstream summaries, and reverify affected conclusions.
+
+## Actual AlphaXiv MCP Search Evidence
+
+### First Discovery Round
+
+The actual call used the following parameters.
+
+```text
+tool: mcp__alphaxiv__discover_papers
+difficulty: 10
+prioritize: recency
+published_after: 2024-01-01
+published_before: 2026-08-10
+keywords:
+  AI
+  LLM
+  subagent
+  multi-agent
+  communication
+  debate
+  consensus
+  shared messages
+  groupthink
+  error propagation
+question (English translation of the submitted query):
+  Recent AI/LLM subagent and multi-agent methods, focusing on inter-agent communication, debate or consensus, shared messages, and preventing groupthink and error propagation
+```
+
+The leading returned candidates included the following papers.
+
+```text
+2608.03421  When Truth Is Distributed: Misinformation Derails Collective Fact Recovery in LLM-Based Multi-Agent Systems
+2608.03648  Group Perspective Matters: Regulating Debate Relationships Can Mitigate Blind Conformity in Multi-Agent Debate
+2608.03239  Relational Priors as Convergence Pressure in LLM-Based Multi-Agent Systems
+2608.01463  Where Reasoning Diverges: Localized Multi-Agent Debate for Multi-Hop Question Answering
+2606.29026  Preventing Error Propagation in Multi-Agent AI through Runtime Monitoring
+2603.04474  From Spark to Fire: Modeling and Mitigating Error Cascades in LLM-Based Multi-Agent Collaboration
+```
+
+This recency-ranked round returned mostly 2026 preprints, so the search ranking was not treated as a publication-quality ranking.
+
+### Second Discovery Round
+
+The actual call used the following parameters.
+
+```text
+tool: mcp__alphaxiv__discover_papers
+difficulty: 10
+prioritize: popular
+published_after: 2024-01-01
+published_before: 2026-08-10
+keywords:
+  LLM
+  multi-agent
+  debate
+  consensus
+  groupthink
+  error propagation
+  peer-reviewed
+  journal
+  conference
+question (English translation of the submitted query):
+  In AI/LLM multi-agent methods, inter-agent communication, debate, consensus, shared messages, and avoiding groupthink and error propagation; prioritize well-known peer-reviewed journals, then top conferences, and finally arXiv
+```
+
+The leading returned candidates included the following papers.
+
+```text
+2505.21503  Silence is Not Consensus: Disrupting Agreement Bias in Multi-Agent LLMs via Catfish Agent for Clinical Decision Making
+2603.04474  From Spark to Fire: Modeling and Mitigating Error Cascades in LLM-Based Multi-Agent Collaboration
+2508.17536  Debate or Vote: Which Yields Better Decisions in Multi-Agent Large Language Models?
+2506.01332  An Empirical Study of Group Conformity in Multi-Agent Systems
+2505.22960  Revisiting Multi-Agent Debate as Test-Time Scaling: A Systematic Study of Conditional Effectiveness
+```
+
+### AlphaXiv Paper-Content Queries
+
+The following papers were read through `get_paper_content` or `answer_pdf_queries` using exact AlphaXiv URLs.
+
+```text
+2309.13007v3  ReConcile
+2406.11776v1  Improving Multi-Agent Debate with Sparse Communication Topology
+2506.01332v1  An Empirical Study of Group Conformity in Multi-Agent Systems
+2505.21503v1  Silence is Not Consensus
+```
+
+The PDF queries covered communication or debate methods, quantitative results, error propagation, group conformity, costs, and author-stated limitations.
+The batched PDF response was truncated because it was too long, so follow-up queries used exact paper IDs to retrieve methods, numerical results, and limitations one paper at a time.
+
+### Search and Resolution Limitations
+
+When the full title of the Scientific Reports article was passed to AlphaXiv `answer_pdf_queries`, the tool incorrectly resolved it to `2606.19826v1 Heterogeneous LLM Debate Under Adversarial Peers`.
+That incorrect resolution was not used as evidence for the Scientific Reports article, whose information was instead verified from the journal's official version.
+This search also found no AlphaXiv or arXiv versions for the Scientific Reports and EPJ Data Science journal articles.
+The first arXiv version of ReConcile appeared in 2023, so the hard 2024 date filter excluded it even though its formal ACL publication year is 2024.
+
+## Source Classification
+
+### Formally Peer-Reviewed Journals
+
+- [When collaboration fails: persuasion driven adversarial influence in multi agent large language model debate](https://www.nature.com/articles/s41598-026-42705-7).
+- [Selective agreement, not sycophancy: investigating opinion dynamics in LLM interactions](https://link.springer.com/article/10.1140/epjds/s13688-025-00579-1).
+
+### Formally Peer-Reviewed Conference and Findings Papers
+
+- [ReConcile: Round-Table Conference Improves Reasoning via Consensus among Diverse LLMs](https://aclanthology.org/2024.acl-long.381/).
+- [Improving Multi-Agent Debate with Sparse Communication Topology](https://aclanthology.org/2024.findings-emnlp.427/).
+
+### Preprint
+
+- [Silence is Not Consensus: Disrupting Agreement Bias in Multi-Agent LLMs via Catfish Agent for Clinical Decision Making](https://arxiv.org/abs/2505.21503).
+
+## Final Recommendations
+
+If only one change can be implemented, replace fully connected agent chat with independent drafts followed by sparse, structured message exchange.
+If a second change can be implemented, add an independent evidence agent and traceable opinion-flip records.
+If the task involves a high-risk merge, security, or architectural decision, also add a Catfish agent that can produce verifiable counterexamples.
+Every vote, consensus, or high-confidence output must undergo independent verification against source code, tests, or official documentation.

--- a/docs/research/2026-08-10_alphaxiv-subagents-orchestration.md
+++ b/docs/research/2026-08-10_alphaxiv-subagents-orchestration.md
@@ -1,0 +1,489 @@
+# Research on AI/LLM Subagent Multi-Agent Orchestration Methods
+
+## Abstract
+
+This research reviews five representative papers from 2024–2025 that are directly relevant to AI/LLM subagent multi-agent orchestration.
+It focuses on task decomposition, role specialization, model and workflow routing, dynamic team formation, communication cost, and execution latency.
+AlphaXiv MCP was the primary source for literature discovery and paper-content verification.
+Publication status, venue, and DOI were cross-checked separately against publisher pages or official conference proceedings.
+The research cutoff is 2026-08-10.
+
+Among the five selected papers, only TDAG is a formally peer-reviewed journal article.
+MasRouter, DynTaskMAS, AgentPrune, and GPTSwarm are all formally peer-reviewed conference papers rather than journal articles.
+This research does not present an arXiv preprint or an arXiv DOI as a formal journal or conference DOI.
+
+## Recommendation Ranking
+
+The ranking considers evidence quality, transferability to coding agents, and coverage of task decomposition, routing, cost, and latency.
+
+1. **TDAG**: The only selected formal journal article, and the best fit for dynamic task decomposition and on-demand subagent generation.
+2. **MasRouter**: The most complete coverage of collaboration modes, team size, role allocation, model routing, and cost.
+3. **DynTaskMAS**: The most direct treatment of dynamic DAGs, asynchronous parallel execution, resource utilization, and latency.
+4. **AgentPrune**: The best fit for reducing multi-agent communication tokens and inference cost.
+5. **GPTSwarm**: The best fit for automatically searching workflows with offline evaluation, although the optimization itself can be expensive.
+
+## Paper Comparison
+
+| Rank | Paper | Year | Publication status | Venue | DOI |
+| --- | --- | --- | --- | --- | --- |
+| 1 | TDAG | 2025 | Peer-reviewed journal article | *Neural Networks*, 185, 107200 | [10.1016/j.neunet.2025.107200](https://doi.org/10.1016/j.neunet.2025.107200) |
+| 2 | MasRouter | 2025 | Peer-reviewed long conference paper | ACL 2025 | [10.18653/v1/2025.acl-long.757](https://doi.org/10.18653/v1/2025.acl-long.757) |
+| 3 | DynTaskMAS | 2025 | Peer-reviewed conference paper | ICAPS 2025 | [10.1609/icaps.v35i1.36130](https://doi.org/10.1609/icaps.v35i1.36130) |
+| 4 | AgentPrune | 2025 | Peer-reviewed conference paper | ICLR 2025 | No DOI listed in the official proceedings |
+| 5 | GPTSwarm | 2024 | Peer-reviewed conference paper and ICML Oral | ICML 2024, PMLR 235 | No DOI listed on the official PMLR page |
+
+## 1. TDAG
+
+### Publication Metadata
+
+- **Title:** *TDAG: A Multi-Agent Framework based on Dynamic Task Decomposition and Agent Generation*.
+- **Authors:** Yaoxiang Wang, Zhiyong Wu, Junfeng Yao, and Jinsong Su.
+- **Year:** The first arXiv version appeared in 2024, and the formal journal article was published in 2025.
+- **Publication status:** Formally peer-reviewed journal article.
+- **Venue:** *Neural Networks*, Volume 185, Article 107200.
+- **DOI:** [10.1016/j.neunet.2025.107200](https://doi.org/10.1016/j.neunet.2025.107200).
+- **AlphaXiv:** [2402.10178](https://www.alphaxiv.org/abs/2402.10178).
+- **arXiv:** [2402.10178](https://arxiv.org/abs/2402.10178).
+- **Formal publication page:** [ScienceDirect](https://www.sciencedirect.com/science/article/pii/S0893608025000796).
+
+### Method
+
+TDAG begins with a main agent that decomposes a complex task into a sequence of subtasks.
+These subtasks are not generated once and then kept unchanged.
+After each subtask finishes, the main agent uses the actual result to revise the tasks that have not yet run.
+This design aims to reduce the risk that an early error propagates forward and invalidates an entire fixed plan.
+
+Each subtask receives a dedicated subagent generated dynamically through an LLM prompt.
+The subagent receives tool documentation reorganized for that specific subtask.
+After successful execution, the subagent summarizes its execution method as a skill and submits it to a skill library.
+Later tasks use SentenceBERT to retrieve the most relevant skill, while another agent continuously updates the library and removes duplicate skills.
+
+### Experimental Evidence
+
+- TDAG achieves an average score of 49.08 on ItineraryBench.
+- ADAPT achieves an average score of 44.74 in the same comparison.
+- Removing agent generation lowers the average score to 46.69.
+- Removing dynamic decomposition lowers the average score to 46.23.
+- TDAG also outperforms the comparison methods used by the paper on WebShop and TextCraft.
+- The paper does not report token consumption, API cost, or wall-clock latency.
+
+### Coding-Agent Implementation Recommendations
+
+- Let an orchestrator create the initial issue checklist, but allow it to rewrite steps that have not run after every verification result.
+- Give each subagent only its current subtask, required upstream artifacts, and relevant tools.
+- Treat build, test, typecheck, or runtime smoke results as replanning signals.
+- When an intermediate assumption fails, rebuild downstream tasks instead of continuing with a plan known to be stale.
+- Store repair methods that pass tests as retrievable skills.
+- Do not write untested results or results that only the model itself declares successful into a permanent skill library.
+- Restrict skill content to reusable operational patterns, preconditions, commands, and verification methods.
+
+### Limitations
+
+- The primary experiments use GPT-3.5-turbo-16k.
+- The core benchmark is a controlled travel-planning simulator rather than a large software repository.
+- In the WebShop and TextCraft experiments, the authors do not use dynamic agent generation because tool documentation is unavailable or the tasks are too monotonous.
+- Skill correctness cannot be guaranteed as directly by the environment as executable program correctness can.
+- The system still exhibits commonsense errors, external-information misalignment, hallucinations, and constraint violations.
+- The paper's workflow executes subtasks primarily in sequence, so it does not show that dynamic decomposition can reduce coding-agent wall-clock latency.
+
+## 2. MasRouter
+
+### Publication Metadata
+
+- **Title:** *MasRouter: Learning to Route LLMs for Multi-Agent Systems*.
+- **Authors:** Yanwei Yue, Guibin Zhang, Boyang Liu, Guancheng Wan, Kun Wang, Dawei Cheng, and Yiyan Qi.
+- **Year:** 2025.
+- **Publication status:** Formally peer-reviewed long conference paper, not a journal article.
+- **Venue:** ACL 2025, Volume 1: Long Papers, pages 15549–15572.
+- **DOI:** [10.18653/v1/2025.acl-long.757](https://doi.org/10.18653/v1/2025.acl-long.757).
+- **AlphaXiv:** [2502.11133](https://www.alphaxiv.org/abs/2502.11133).
+- **arXiv:** [2502.11133](https://arxiv.org/abs/2502.11133).
+- **Formal publication page:** [ACL Anthology](https://aclanthology.org/2025.acl-long.757/).
+
+### Method
+
+MasRouter divides multi-agent routing into three dependent decision stages covering collaboration mode, roles, and LLMs.
+The collaboration-mode determiner uses a variational latent-variable model to choose among candidate modes such as chain, reflection, self-consistency, and debate.
+The system dynamically determines the number of agents from input complexity, with a maximum of six agents in the experiments.
+The role allocator uses the input, collaboration mode, and previously selected roles to construct a mutually compatible sequence of roles.
+The LLM router then assigns different models to different agents according to the task, collaboration mode, and roles.
+
+The complete cascaded controller is trained with policy gradient.
+The optimization objective includes both correctness utility and penalties for LLM calls, API cost, or token cost.
+The cost weight controls how much additional spending the system will accept in exchange for higher result quality.
+
+### Experimental Evidence
+
+- The paper reports that HumanEval cost decreases from USD 0.363 to USD 0.185.
+- The abstract reports an overhead reduction of up to 52.07% relative to comparison methods.
+- Cost decreases by 17.21%–28.17% when MasRouter is integrated with existing multi-agent methods.
+- On MBPP, MasRouter outperforms AgentPrune and AFlow by 8.20 and 1.80 percentage points, respectively.
+- Increasing the maximum number of agents from six to ten yields only a small performance gain but increases per-query inference cost by approximately 1.5 times.
+- The paper does not report complete wall-clock latency.
+
+### Coding-Agent Implementation Recommendations
+
+- Start with a lightweight classifier that decides whether a request needs a subagent instead of launching the same team for every task.
+- Form teams on demand from a role pool such as repository researcher, planner, implementer, reviewer, and tester.
+- Keep simple documentation or single-file changes on one low-cost model.
+- Add reviewers and testers only for cross-module refactors, unknown APIs, or high-risk changes.
+- Use models with different prices or capabilities for research, implementation, testing, and summarization roles.
+- Treat sequential, parallel, review-loop, and debate structures as workflow topologies that can be routed.
+- Before formally training a router, use interpretable rules to establish complexity, risk, and uncertainty thresholds.
+- Include the quality-cost Pareto frontier in routing regression tests.
+
+### Limitations
+
+- Collaboration modes, roles, and models all come from predefined candidate pools.
+- The controller requires training data with oracle answers or a computable utility.
+- Policy-gradient search itself introduces additional model calls and training cost.
+- The experimental benchmarks mainly cover general reasoning, mathematics, and function-level code generation.
+- The paper does not evaluate file localization, merge conflicts, or long-running builds in mature repositories.
+- The experiments use at most six agents, so they do not demonstrate scalability to large teams.
+- Existing routers may require recalibration after model prices, API behavior, or model capabilities change.
+
+## 3. DynTaskMAS
+
+### Publication Metadata
+
+- **Title:** *DynTaskMAS: A Dynamic Task Graph-driven Framework for Asynchronous and Parallel LLM-based Multi-Agent Systems*.
+- **Authors:** Junwei Yu, Yepeng Ding, and Hiroyuki Sato.
+- **Year:** 2025.
+- **Publication status:** Formally peer-reviewed conference paper, not a journal article.
+- **Venue:** ICAPS 2025, Algorithmic Papers, pages 288–296.
+- **DOI:** [10.1609/icaps.v35i1.36130](https://doi.org/10.1609/icaps.v35i1.36130).
+- **AlphaXiv:** [2503.07675](https://www.alphaxiv.org/abs/2503.07675).
+- **arXiv:** [2503.07675](https://arxiv.org/abs/2503.07675).
+- **Formal publication page:** [ICAPS Proceedings](https://ojs.aaai.org/index.php/ICAPS/article/view/36130).
+
+### Method
+
+DynTaskMAS consists of a Dynamic Task Graph Generator, an Asynchronous Parallel Execution Engine, a Semantic-Aware Context Management System, and an Adaptive Workflow Manager.
+The Task Graph Generator decomposes tasks into a DAG with dependencies and updates the DAG when inputs or execution state change.
+Each edge weight accounts for downstream computational complexity and context-transfer time.
+
+The Parallel Execution Engine schedules only dependency-ready nodes.
+Its priority queue considers computational cost, downstream paths, and current load.
+The agent-pool manager then assigns nodes to available agents according to capability and load.
+
+The context manager uses semantic relevance to determine which information to send to which agents.
+The workflow manager continuously observes throughput, latency, agent utilization, and task completion, then adjusts workflow and resource allocation.
+
+### Experimental Evidence
+
+- Relative to the serial baseline, simple-task execution time decreases from 4.7 seconds to 3.7 seconds, an improvement of 21.3%.
+- Medium-task execution time decreases from 9.8 seconds to 7.1 seconds, an improvement of 27.6%.
+- Complex-task execution time decreases from 18.5 seconds to 12.4 seconds, an improvement of 33.0%.
+- GPU utilization increases from 65% to 88%.
+- Throughput with four agents is 12.3 tasks per second.
+- Throughput with sixteen agents is 42.7 tasks per second, a relative increase of 3.47 times.
+- Latency with thirty-two agents is 104.2 ms, compared with 81.3 ms with four agents.
+- At thirty-two agents, marginal benefits have already declined because of shared-context and scheduler contention.
+
+### Coding-Agent Implementation Recommendations
+
+- Represent independent work such as repository search, documentation verification, API-type confirmation, and test preparation as parallelizable DAG nodes.
+- Explicitly record dependencies among implementation, build, test, review, and final integration.
+- Require each node to declare its inputs, outputs, resource class, deadline, retry policy, and cancellation owner.
+- Add a node to the ready queue only after every required upstream node has succeeded and been revalidated.
+- Prioritize critical-path work that blocks multiple downstream tasks.
+- Limit concurrency to avoid API rate limits, test interference, filesystem contention, or build-cache contamination.
+- Pass only required artifacts, conclusions, and provenance instead of copying every agent conversation in full.
+- An agent failure should explicitly mark the node as failed and trigger replanning rather than leaving the entire workflow waiting indefinitely.
+
+### Limitations
+
+- The experiments use only Llama-3.1-8B, TensorRT-LLM, and four RTX 3090 GPUs.
+- The main case is a controlled travel-planning system rather than repository-level coding.
+- The primary latency comparison is against serial processing and does not cover multiple mature multi-agent runtimes.
+- The paper does not provide validation across models, hardware platforms, or remote-API latency conditions.
+- The paper does not provide a code-quality, test-pass-rate, or repository-correctness benchmark.
+- As more agents are added, shared-context and scheduler overhead reduce scaling efficiency.
+- Context relevance, complexity estimation, and task granularity all require additional implementation before they can work reliably in a real coding agent.
+
+## 4. AgentPrune
+
+### Publication Metadata
+
+- **Title:** *Cut the Crap: An Economical Communication Pipeline for LLM-based Multi-Agent Systems*.
+- **Method name:** AgentPrune.
+- **Authors:** Guibin Zhang, Yanwei Yue, Zhixun Li, Sukwon Yun, Guancheng Wan, Kun Wang, Dawei Cheng, Jeffrey Yu, and Tianlong Chen.
+- **Author-name note:** The AlphaXiv PDF renders Jeffrey Yu as Jeffrey Xu Yu.
+- **Year:** 2025.
+- **Publication status:** Formally peer-reviewed conference paper, not a journal article.
+- **Venue:** ICLR 2025.
+- **DOI:** The official ICLR proceedings do not list a DOI, so this research does not present the arXiv DOI as a conference DOI.
+- **AlphaXiv:** [2410.02506](https://www.alphaxiv.org/abs/2410.02506).
+- **arXiv:** [2410.02506](https://arxiv.org/abs/2410.02506).
+- **Formal publication page:** [ICLR Proceedings](https://proceedings.iclr.cc/paper_files/paper/2025/hash/bbc461518c59a2a8d64e70e2c38c4a0e-Abstract-Conference.html).
+
+### Method
+
+AgentPrune represents multi-agent communication as a spatial-temporal message graph.
+Spatial edges represent agent-to-agent messages within the same round.
+Temporal edges represent whether messages from an earlier round are passed into the next round.
+
+The system first converts the original binary edges into learnable continuous graph masks.
+Policy gradient makes the retained communication structure improve task utility.
+Low-rank regularization encourages sparse graph masks and reduces redundancy.
+After several optimization rounds, the system uses one-shot magnitude pruning to retain the most important edges.
+The resulting sparse topology remains fixed during subsequent rounds.
+
+### Experimental Evidence
+
+- The paper reports that AgentPrune costs approximately USD 5.6 at comparable quality, while comparison topologies cost approximately USD 43.7.
+- Token consumption decreases by 28.1%–72.8% after integration with existing multi-agent frameworks.
+- Randomly removing some communication edges sometimes improves performance, supporting the hypothesis that existing topologies contain communication redundancy.
+- The experiments include MMLU, GSM8K, MultiArith, SVAMP, AQuA, and HumanEval.
+- The paper does not provide sufficiently complete measurements to determine production wall-clock latency.
+
+### Coding-Agent Implementation Recommendations
+
+- First record which agent messages actually change downstream patches, test results, or decisions.
+- Send only patches, test-failure summaries, API contracts, unresolved questions, or required provenance to relevant roles.
+- Avoid making every agent read the complete transcripts of every other agent.
+- Treat communication as a directed edge with token, latency, and attention costs.
+- Use a fixed regression suite to determine whether removing an edge preserves success rate.
+- Learn or configure communication policy separately for each workflow or task class.
+- Start with an interpretable artifact allowlist before considering automatic pruning with policy gradient.
+- Make the context budget and maximum payload per edge part of the runtime contract.
+
+### Limitations
+
+- The authors explicitly state that the method generally requires more than three agents.
+- The original communication topology must be complex enough to contain redundancy worth pruning.
+- Simple chain or direct-output workflows are not applicable.
+- Before pruning, the method still incurs model-interaction, utility-evaluation, and graph-mask optimization costs.
+- The topology is fixed after pruning, so it may fail to retain necessary information when the task distribution changes.
+- The experiments mainly cover general reasoning, mathematics, and function-level code generation.
+- The paper does not evaluate the transfer requirements of repository-level artifacts, separate sessions, or mutable filesystem state.
+
+## 5. GPTSwarm
+
+### Publication Metadata
+
+- **Title:** *GPTSwarm: Language Agents as Optimizable Graphs*.
+- **Authors:** Mingchen Zhuge, Wenyi Wang, Louis Kirsch, Francesco Faccio, Dmitrii Khizbullin, and Jürgen Schmidhuber.
+- **Year:** 2024.
+- **Publication status:** Formally peer-reviewed conference paper and ICML Oral, but not a journal article.
+- **Venue:** ICML 2024, PMLR 235, pages 62743–62767.
+- **DOI:** The official PMLR page does not list a DOI, so this research does not present the arXiv DOI as an ICML DOI.
+- **AlphaXiv:** [2402.16823](https://www.alphaxiv.org/abs/2402.16823).
+- **arXiv:** [2402.16823](https://arxiv.org/abs/2402.16823).
+- **Formal publication page:** [PMLR](https://proceedings.mlr.press/v235/zhuge24a.html).
+- **Conference status:** [ICML Oral](https://icml.cc/virtual/2024/oral/35447).
+
+### Method
+
+GPTSwarm represents LLM calls, tools, functions, and other operations as graph nodes.
+A single agent is a directed acyclic graph composed of multiple nodes.
+Multiple agents form a composite graph, and cross-agent edges represent communication and collaboration.
+
+Node optimization uses existing prompt-optimization methods to improve each node's prompt.
+Edge optimization uses REINFORCE to sample candidate graph connectivity and adjust edge probabilities according to task utility.
+This representation can combine existing Chain-of-Thought, Tree-of-Thought, Reflection, and other workflow components.
+
+### Experimental Evidence
+
+- In one MMLU comparison, GPTSwarm optimization costs approximately USD 5.32 and inference costs approximately USD 1.82.
+- In the same comparison, DyLAN optimization costs approximately USD 105.93 and inference costs approximately USD 14.99.
+- Mini Crosswords edge optimization uses more than fifty million prompt tokens and costs USD 77.42.
+- On GAIA, a single ToT takes approximately 71.31 seconds, while a three-agent ToT takes approximately 198.50 seconds.
+- On GAIA, a seven-agent ToT takes approximately 414.89 seconds.
+- These results show that graph optimization can improve quality or find a better topology, but multi-agent execution is not inherently a low-latency approach.
+
+### Coding-Agent Implementation Recommendations
+
+- Represent search, edit, build, test, review, and final synthesis as testable nodes with explicit inputs and outputs.
+- Use benchmark repositories, historical issues, or synthetic tasks as an offline workflow-evaluation set.
+- Search for the edge, role, prompt, and tool combinations that pass the same tests at lower cost.
+- Fix a repeatedly validated successful DAG as the production workflow.
+- Do not perform expensive graph search again for every user request.
+- Separate node optimization from edge optimization so the source of improvement can be attributed to prompts or orchestration.
+- Calculate optimization cost together with the amortization horizon.
+- Revalidate a fixed graph for a new repository, model, or tool version.
+
+### Limitations
+
+- Graph search and node optimization can consume far more tokens and money than one production inference.
+- Dense or large graphs increase computational and communication cost.
+- The primary experiments use older GPT-3.5-Turbo and GPT-4-Turbo APIs.
+- Different benchmarks use different graphs and aggregation logic, so there is no single universally optimal topology.
+- The GAIA results show that adding agents can substantially increase wall-clock time.
+- The authors state that communication efficiency and system robustness become major challenges beyond one hundred agents.
+- The paper does not evaluate branch isolation, merge conflicts, or concurrent edits in mature repositories.
+
+## Integrated Design Recommendations
+
+These five papers do not jointly establish one best multi-agent topology.
+A more reliable implementation approach is to treat them as complementary parts of a four-layer control problem.
+
+### 1. Admission and Routing
+
+- First determine whether the task actually needs a subagent.
+- Include task complexity, cross-module scope, unknown APIs, verification cost, and risk in the admission decision.
+- Keep simple tasks on one agent to avoid fixed coordination costs.
+- Select the number of agents, roles, models, and collaboration mode on demand only for complex tasks.
+
+### 2. Dynamic Task DAG
+
+- Decompose the task into a DAG with dependencies and verification conditions.
+- Run only nodes whose dependencies are complete.
+- Revalidate the unexecuted plan after every subagent, tool, or test completes.
+- Intermediate failures should update the DAG instead of only retrying the same prompt.
+
+### 3. Artifact and Context Protocol
+
+- Require each agent to produce a structured artifact instead of only a natural-language status report.
+- Artifacts should include results, evidence, unresolved questions, sources, and scope of applicability.
+- Downstream agents should receive only the artifacts required for their current tasks.
+- Raw transcripts, complete repository context, and unrelated agent outputs should not be broadcast by default.
+
+### 4. Cost, Latency, and Quality Control
+
+- Track task success, test results, tokens, API cost, wall-clock latency, and retry count together.
+- Parallelize only work that has no shared mutable state or that can be isolated explicitly.
+- Beyond the concurrency sweet spot, new agents can create negative effects through context, scheduler, rate-limit, or filesystem contention.
+- Learned routing, graph search, or pruning must amortize training cost across the expected number of uses.
+- Every automatically optimized workflow must pass a fixed regression suite.
+
+## Recommended Coding-Agent Workflow
+
+1. Use a low-cost admission router to decide whether to start a multi-agent workflow.
+2. When needed, use a TDAG-style planner to create a revisable task DAG.
+3. Apply MasRouter principles to select agent count, roles, models, and collaboration mode.
+4. Apply DynTaskMAS principles to run only dependency-ready nodes in parallel.
+5. Apply AgentPrune principles to constrain the content and token budget of each communication edge.
+6. Use tests, typecheck, lint, runtime smoke tests, and review findings to calculate node utility.
+7. Use GPTSwarm-style offline search only for high-frequency, expensive workflows that can be evaluated repeatedly.
+8. After every wait completes, revalidate the session, branch, artifact, mutable state, and whether the original plan remains valid.
+9. Stop expanding the team when another agent no longer improves the critical path, quality, or risk.
+10. Version validated workflows and reevaluate them when models, tools, or repository structure change.
+
+## Research Conclusion
+
+Useful dynamic behavior is not limited to creating more agents at runtime.
+It also includes redecomposing tasks, selecting roles and models on demand, adjusting the DAG, stopping low-value agents, and removing ineffective messages.
+
+Task decomposition and verification should take priority over role-play.
+Explicit dependencies and an artifact protocol should take priority over unrestricted agent conversation.
+Cost routing and communication pruning can reduce tokens but may add training or optimization cost.
+An asynchronous DAG can reduce wall-clock time, but only when work can be parallelized safely and resources are not saturated.
+More agents do not necessarily produce lower latency, lower cost, or higher quality.
+
+The most practical current coding-agent design is a small, on-demand, replannable team of specialized roles.
+This team should share compact global state, use isolated local contexts, transfer verifiable artifacts, and control integration and stopping conditions through executable checks.
+
+## AlphaXiv MCP Search Evidence
+
+This research actually used the AlphaXiv MCP tools `discover_papers`, `get_paper_content`, and `answer_pdf_queries`.
+
+### First Discovery Search
+
+The first search prioritized the newest work from 2024–2026.
+
+```yaml
+tool: mcp__alphaxiv__discover_papers
+difficulty: 10
+prioritize: recency
+published_after: 2024-01-01
+published_before: 2026-08-10
+keywords:
+  - AI
+  - LLM
+  - subagent
+  - multi-agent
+  - task decomposition
+  - role assignment
+  - routing
+  - dynamic team
+  - cost
+  - latency
+question: >-
+  Recent AI/LLM subagent multi-agent methods, focusing on task decomposition,
+  role specialization, routing, dynamic team formation, cost, and latency;
+  prioritize well-known peer-reviewed journals, and label top conferences or
+  arXiv-only work accurately
+```
+
+The leading results from the first search were as follows.
+
+```text
+2606.31174  ClawArena-Team: Benchmarking Subagent Orchestration and Dynamic Workflows in Language-Model Agents
+2607.22465  TRACE-ROUTER: Task-Consistent and Adaptive Online Routing for Agentic AI
+2607.25446  Toward an Organizational Science of Multi-Agent LLM Systems
+2606.20629  Specialize Roles, Mix Deployments: Pushing the Cost-Accuracy Frontier of LLM Agent Teams
+2606.12950  Maestro: Workload-Aware Cross-Cluster Scheduling for LLM-Based Multi-Agent Systems
+2606.11440  INFRAMIND: Infrastructure-Aware Multi-Agent Orchestration
+```
+
+These results are primarily new 2026 preprints.
+To avoid treating the newest preprints as the strongest formal evidence, this research did not select papers by recency alone.
+
+### Second Search for Mature Work
+
+The second search instead prioritized mature work from 2024–2025 that might already have a formal venue.
+
+```yaml
+tool: mcp__alphaxiv__discover_papers
+difficulty: 10
+prioritize: historical
+published_after: 2024-01-01
+published_before: 2025-12-31
+keywords:
+  - LLM
+  - subagent
+  - multi-agent
+  - task decomposition
+  - role assignment
+  - routing
+  - dynamic team
+  - cost
+  - latency
+question: >-
+  AI/LLM subagent multi-agent methods, focusing on task decomposition, role
+  specialization, routing, dynamic team formation, cost, and latency; find
+  representative 2024–2025 methods that are mature and have peer-reviewed venues
+```
+
+The leading results from the second search were as follows.
+
+```text
+2512.11426  AgentBalance: Backbone-then-Topology Design for Cost-Effective Multi-Agent Systems under Budget Constraints
+2502.11133  MasRouter: Learning to Route LLMs for Multi-Agent Systems
+2508.04903  RCR-Router: Efficient Role-Aware Context Routing for Multi-Agent LLM Systems with Structured Memory
+2503.07675  DynTaskMAS: A Dynamic Task Graph-driven Framework for Asynchronous and Parallel LLM-based Multi-Agent Systems
+2402.10178  TDAG: A Multi-Agent Framework based on Dynamic Task Decomposition and Agent Generation
+2511.01149  Modular Task Decomposition and Dynamic Collaboration in Multi-Agent Systems Driven by Large Language Models
+2504.02051  Self-Resource Allocation in Multi-Agent LLM Systems
+```
+
+### Papers Actually Read
+
+The following papers were actually read through the AlphaXiv MCP `get_paper_content` or `answer_pdf_queries` tools.
+
+```text
+2402.10178  TDAG
+2502.11133  MasRouter
+2503.07675  DynTaskMAS
+2410.02506  AgentPrune
+2402.16823  GPTSwarm
+```
+
+Queries for each paper covered methods, task decomposition, roles, routing, dynamic teams, token or monetary cost, latency, limitations, and whether the PDF stated a venue or DOI.
+AlphaXiv PDFs or reports were used to verify paper methods, numerical results, and author-stated limitations.
+Formal publication status, venue, and DOI were verified against official pages from Neural Networks, ACL Anthology, ICLR, PMLR, ICML, and ICAPS.
+
+## Sources
+
+- [TDAG on AlphaXiv](https://www.alphaxiv.org/abs/2402.10178).
+- [TDAG in Neural Networks](https://www.sciencedirect.com/science/article/pii/S0893608025000796).
+- [MasRouter on AlphaXiv](https://www.alphaxiv.org/abs/2502.11133).
+- [MasRouter in ACL Anthology](https://aclanthology.org/2025.acl-long.757/).
+- [DynTaskMAS on AlphaXiv](https://www.alphaxiv.org/abs/2503.07675).
+- [DynTaskMAS in ICAPS Proceedings](https://ojs.aaai.org/index.php/ICAPS/article/view/36130).
+- [AgentPrune on AlphaXiv](https://www.alphaxiv.org/abs/2410.02506).
+- [AgentPrune in ICLR Proceedings](https://proceedings.iclr.cc/paper_files/paper/2025/hash/bbc461518c59a2a8d64e70e2c38c4a0e-Abstract-Conference.html).
+- [GPTSwarm on AlphaXiv](https://www.alphaxiv.org/abs/2402.16823).
+- [GPTSwarm in PMLR](https://proceedings.mlr.press/v235/zhuge24a.html).
+- [GPTSwarm at ICML 2024](https://icml.cc/virtual/2024/oral/35447).

--- a/docs/research/2026-08-10_alphaxiv-subagents-verification.md
+++ b/docs/research/2026-08-10_alphaxiv-subagents-verification.md
@@ -1,0 +1,387 @@
+# AI/LLM Subagent Verification and Multi-Agent Methods
+
+## Executive conclusion
+
+Multi-agent workflows sometimes outperform one-shot single-agent generation, but the evidence does not support a general rule that more agents are better.
+Independent sampling followed by voting often improves accuracy, but its token and latency costs usually grow with the number of samples.
+Multi-agent debate does not reliably beat equal-compute self-consistency, best-of-N sampling, or a stronger single agent.
+The most defensible benefits come from independent generation, heterogeneous perspectives, externally verifiable evidence, calibrated aggregation, and explicit stopping conditions.
+Unstructured reflection can turn a correct answer into an incorrect one, so a critic should not merely reread the original model's reasoning.
+Multi-agent designs also introduce role violations, information loss, mutual anchoring, error propagation, verification failures, security risks, and termination failures.
+For coding agents, the strongest default is a primary implementer, an independent reviewer, and deterministic tool-based verification rather than an unrestricted agent debate.
+
+## Scope and evidence policy
+
+This review prioritizes work formally published from 2024 through 2026 and uses earlier arXiv submission dates only when the formal publication occurred within that period.
+Publication status, venue, and DOI were verified against official ACL Anthology, NeurIPS Proceedings, or OpenReview pages.
+AlphaXiv was used for literature discovery and direct PDF-page queries.
+AlphaXiv primarily indexes arXiv material, so an AlphaXiv or arXiv page alone was not treated as evidence of peer review.
+All five selected papers have a peer-reviewed publication, but only *More Agents Is All You Need* is a journal article.
+ACL, ICLR, NeurIPS, and Findings papers are identified as conference proceedings rather than journals.
+The research cutoff is 2026-08-10.
+
+## Recommendation ranking
+
+The ranking weighs coding-agent relevance, evidence quality, failure coverage, and practical usefulness rather than venue prestige alone.
+
+### 1. Why Do Multi-Agent LLM Systems Fail?
+
+- **Title:** *Why Do Multi-Agent LLM Systems Fail?*
+- **Authors:** Mert Cemri, Melissa Z. Pan, Shuyi Yang, Lakshya A. Agrawal, Bhavya Chopra, Rishabh Tiwari, Kurt Keutzer, Aditya Parameswaran, Dan Klein, Kannan Ramchandran, Matei A. Zaharia, Joseph E. Gonzalez, and Ion Stoica.
+- **Year:** 2025.
+- **Publication status:** Formally published peer-reviewed conference paper.
+- **Venue:** NeurIPS 2025 Datasets and Benchmarks Track.
+- **DOI:** [10.52202/085713-4082](https://doi.org/10.52202/085713-4082).
+- **AlphaXiv:** [https://www.alphaxiv.org/abs/2503.13657](https://www.alphaxiv.org/abs/2503.13657).
+- **arXiv:** [https://arxiv.org/abs/2503.13657](https://arxiv.org/abs/2503.13657).
+- **Official venue page:** [NeurIPS Proceedings](https://proceedings.neurips.cc/paper_files/paper/2025/hash/b1041e52d3be19f0a9bc491657488e4a-Abstract-Datasets_and_Benchmarks_Track.html).
+
+#### Method and findings
+
+The paper introduces MAST, a taxonomy derived from 1,642 execution traces across seven multi-agent frameworks.
+The taxonomy contains 14 failure modes grouped into system design, inter-agent misalignment, and task verification.
+The studied systems showed failure rates ranging from 41% to 86.7%.
+Relevant observed failure modes include unawareness of termination conditions at 12.4%, premature termination at 6.2%, no or incomplete verification at 8.2%, and incorrect verification at 9.1%.
+The taxonomy development used six expert annotators and reached inter-annotator agreement of kappa 0.88.
+An LLM-as-a-judge annotation pipeline reached kappa 0.77 against human labels and kappa 0.79 on two unseen systems and benchmarks.
+A ChatDev role-specification intervention improved task success by 9.4 percentage points.
+Adding high-level task-objective verification to ChatDev improved task success by 15.6 percentage points.
+The paper does not establish that multi-agent systems generally outperform matched single-agent systems.
+
+#### Coding-agent implementation guidance
+
+- Record every planner, implementer, reviewer, and verifier input, output, tool result, state transition, and termination reason.
+- Verify low-level correctness such as compilation together with high-level acceptance criteria and runtime behavior.
+- Give only one designated verifier or orchestrator authority to declare completion.
+- Detect repeated steps, context loss, ignored feedback, missing clarification, premature completion, and incomplete verification as explicit events.
+- Classify failed trajectories by failure mode instead of relying only on aggregate pass rates.
+- Revalidate task state and evidence after each asynchronous handoff.
+
+#### Limitations
+
+- MAST is a failure analysis rather than an equal-budget single-agent versus multi-agent experiment.
+- The taxonomy is empirically grounded but does not claim to cover every possible failure.
+- Most large-scale labels come from a proprietary LLM judge, while the fully human-annotated subset is much smaller.
+- Frameworks were evaluated on different tasks and models, so raw failure counts are not a valid framework leaderboard.
+- The coding tasks include from-scratch programming and only a limited repository-repair component.
+
+### 2. ReConcile: Round-Table Conference Improves Reasoning via Consensus among Diverse LLMs
+
+- **Title:** *ReConcile: Round-Table Conference Improves Reasoning via Consensus among Diverse LLMs*.
+- **Authors:** Justin Chih-Yao Chen, Swarnadeep Saha, and Mohit Bansal.
+- **Year:** Formally published in 2024 after an initial 2023 arXiv submission.
+- **Publication status:** Formally published peer-reviewed ACL main-conference long paper.
+- **Venue:** Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics, Volume 1: Long Papers.
+- **DOI:** [10.18653/v1/2024.acl-long.381](https://doi.org/10.18653/v1/2024.acl-long.381).
+- **AlphaXiv:** [https://www.alphaxiv.org/abs/2309.13007](https://www.alphaxiv.org/abs/2309.13007).
+- **arXiv:** [https://arxiv.org/abs/2309.13007](https://arxiv.org/abs/2309.13007).
+- **Official venue page:** [ACL Anthology](https://aclanthology.org/2024.acl-long.381/).
+
+#### Method and findings
+
+ReConcile begins with heterogeneous model families independently producing an answer, explanation, and confidence score.
+Each subsequent round lets every agent review the other agents' previous answers and explanations before retaining or revising its position.
+The method rescales self-reported confidence through manually designed buckets and uses confidence-weighted voting for the team answer.
+The discussion stops when all agents reach the same answer or when the configured maximum of three rounds is reached.
+Across seven reasoning benchmarks, the method outperformed prior single-agent and multi-agent baselines by as much as 11.4 percentage points.
+The study compares against self-consistency with approximately the same average number of model calls and also reports a nine-way self-consistency comparison.
+The paper attributes a substantial part of the gain to diversity across different model families rather than multiple copies of one model.
+
+#### Coding-agent implementation guidance
+
+- Require implementers and reviewers to analyze the task independently before exposing them to each other's conclusions.
+- Use different prompts, tools, model families, or review specialties when genuine diversity is needed.
+- Require reviewers to identify the exact point of agreement or disagreement and attach reproducible evidence.
+- Treat confidence as a secondary weight behind tests, type checks, static analysis, runtime evidence, and acceptance criteria.
+- Stop when all acceptance gates pass and no unresolved high-confidence issue remains.
+- Impose a hard maximum of two or three review rounds to prevent endless discussion.
+
+#### Limitations
+
+- Most experiments use only 100 samples because of API cost, although two datasets also receive full-test-set evaluation.
+- The evaluated ChatGPT, Bard, and Claude 2 versions are older than current production models.
+- Self-reported confidence is overconfident and requires a hand-designed recalibration function.
+- The strongest configuration uses selected human-written convincing examples.
+- The evaluation focuses on reasoning benchmarks rather than complete software-engineering tasks.
+
+### 3. Large Language Models Cannot Self-Correct Reasoning Yet
+
+- **Title:** *Large Language Models Cannot Self-Correct Reasoning Yet*.
+- **Authors:** Jie Huang, Xinyun Chen, Swaroop Mishra, Huaixiu Steven Zheng, Adams Wei Yu, Xinying Song, and Denny Zhou.
+- **Year:** Formally published in 2024 after an initial 2023 arXiv submission.
+- **Publication status:** Formally published peer-reviewed conference paper.
+- **Venue:** ICLR 2024 poster.
+- **DOI:** The official publication record does not list a DOI.
+- **AlphaXiv:** [https://www.alphaxiv.org/abs/2310.01798](https://www.alphaxiv.org/abs/2310.01798).
+- **arXiv:** [https://arxiv.org/abs/2310.01798](https://arxiv.org/abs/2310.01798).
+- **Official venue page:** [OpenReview](https://openreview.net/forum?id=IkmD3fKBPQ).
+
+#### Method and findings
+
+The paper distinguishes intrinsic self-correction without external information from correction guided by an oracle label, another model, a tool, or human feedback.
+It evaluates up to two self-correction rounds on GSM8K, CommonSenseQA, and HotpotQA.
+GPT-3.5 accuracy on GSM8K falls from 75.9% with standard prompting to 74.7% after two intrinsic correction rounds.
+GPT-4 accuracy on GSM8K falls from 95.5% to 89.0% after two intrinsic correction rounds.
+The model sometimes changes a correct answer into an incorrect one because it cannot reliably judge its own reasoning correctness.
+Under an equal-response comparison, multi-agent debate performs no better than self-consistency.
+External execution results, tests, search, calculators, or trained verifiers provide more reliable correction signals than ungrounded introspection.
+
+#### Coding-agent implementation guidance
+
+- Do not treat a prompt such as “review your answer again” as independent verification.
+- Give the reviewer new evidence such as unit-test output, compiler diagnostics, static-analysis findings, runtime reproduction, or a fresh requirements comparison.
+- Do not modify a previously correct result merely because an ungrounded reviewer expresses doubt.
+- Keep the original answer and revised answer so the adjudicator can detect regressions.
+- Compare a multi-agent design against equal-token best-of-N, self-consistency, and sequential-refinement baselines.
+
+#### Limitations
+
+- The study covers selected reasoning tasks rather than all forms of reflection or correction.
+- The evaluated models are GPT-3.5, GPT-4, GPT-4 Turbo, and Llama 2 versions available during the study.
+- The conclusions do not rule out useful self-correction for safety, style, formatting, or other easily judged preferences.
+- OpenReview feedback notes that the broad title is stronger than the experimental coverage supports.
+
+### 4. Red-Teaming LLM Multi-Agent Systems via Communication Attacks
+
+- **Title:** *Red-Teaming LLM Multi-Agent Systems via Communication Attacks*.
+- **Authors:** Pengfei He, Yuping Lin, Shen Dong, Han Xu, Yue Xing, and Hui Liu.
+- **Year:** 2025.
+- **Publication status:** Formally published peer-reviewed Findings paper rather than an ACL main-track paper or journal article.
+- **Venue:** Findings of the Association for Computational Linguistics: ACL 2025.
+- **DOI:** [10.18653/v1/2025.findings-acl.349](https://doi.org/10.18653/v1/2025.findings-acl.349).
+- **AlphaXiv:** [https://www.alphaxiv.org/abs/2502.14847](https://www.alphaxiv.org/abs/2502.14847).
+- **arXiv:** [https://arxiv.org/abs/2502.14847](https://arxiv.org/abs/2502.14847).
+- **Official venue page:** [ACL Anthology](https://aclanthology.org/2025.findings-acl.349/).
+
+#### Method and findings
+
+Agent-in-the-Middle intercepts and rewrites messages sent to one victim agent without directly modifying the other agents or tools.
+An adversarial LLM uses reflection over earlier attack attempts and intercepted context to generate progressively tailored malicious instructions.
+The experiments cover AutoGen, CAMEL, HumanEval, MBPP, two MMLU domains, and chain, tree, complete, and random communication structures.
+Attack success exceeds 40% in every reported framework, dataset, topology, and attack-objective combination and exceeds 70% in most cases.
+Linear chain structures are especially vulnerable because one contaminated message can influence every downstream agent.
+In MetaGPT experiments, attack success is above 75% in all reported HumanEval and MBPP cases and reaches 100% in several SoftwareDev cases.
+
+#### Coding-agent implementation guidance
+
+- Treat every subagent message as untrusted data rather than as a new instruction source.
+- Use typed schemas, explicit provenance, integrity checks, and role-specific capability restrictions for handoffs.
+- Have reviewers inspect the original task, diff, and tool evidence rather than trusting an upstream summary.
+- Run generated code in a sandbox with minimum filesystem, network, process, and credential permissions.
+- Prevent untrusted repository text, logs, and tool output from changing agent authority or policy.
+- Make the final verifier consume raw artifacts through an independent channel rather than the same potentially contaminated message chain.
+
+#### Limitations
+
+- The paper primarily demonstrates attacks and does not experimentally validate a complete defense.
+- Experiments focus on black-box GPT models, four communication structures, and two real multi-agent applications.
+- The threat model assumes the attacker can intercept and modify messages sent to one agent.
+- The findings do not imply that authenticated, local, or capability-isolated agent systems are equally vulnerable.
+
+### 5. More Agents Is All You Need
+
+- **Title:** *More Agents Is All You Need*.
+- **Authors:** Junyou Li, Qin Zhang, Yangbin Yu, Qiang Fu, and Deheng Ye.
+- **Year:** 2024.
+- **Publication status:** Formally published peer-reviewed journal article and the only journal article in this selected set.
+- **Venue:** Transactions on Machine Learning Research, published in October 2024.
+- **DOI:** The official publication record does not list a DOI.
+- **AlphaXiv:** [https://www.alphaxiv.org/abs/2402.05120](https://www.alphaxiv.org/abs/2402.05120).
+- **arXiv:** [https://arxiv.org/abs/2402.05120](https://arxiv.org/abs/2402.05120).
+- **Official venue page:** [OpenReview](https://openreview.net/forum?id=bgzUSZ8aeg).
+
+#### Method and findings
+
+Agent Forest generates independent answers to the same question and chooses the majority answer.
+The method has no role specialization or inter-agent communication and is more accurately understood as parallel sampling and ensembling.
+Experiments cover GSM8K, MATH, Chess, MMLU, HumanEval, multiple model sizes, and combinations with prompting, debate, and reflection methods.
+Increasing the ensemble size usually improves accuracy, particularly on moderately difficult tasks, longer reasoning chains, and weaker models.
+The benefit falls on extremely difficult tasks when the model's probability of producing a correct answer becomes too low.
+The HumanEval experiments show that debate with Llama 2 can fail because exposing agents to other answers introduces noise into code logic.
+Token usage grows proportionally with the ensemble size.
+
+#### Coding-agent implementation guidance
+
+- Generate two or three isolated candidate designs before comparison when a decision is high risk and objectively testable.
+- Prefer independent generation followed by evidence-based selection over unrestricted debate when interaction is likely to cause anchoring.
+- Use deterministic tests or acceptance criteria rather than majority vote when candidate correctness can be executed or measured.
+- Allocate additional samples only to uncertain or high-impact steps.
+- Keep easy and directly verifiable tasks on a single-agent path.
+
+#### Limitations
+
+- Model calls and token use grow approximately linearly with the number of samples.
+- The study does not establish superiority over a stronger single agent under matched money, latency, and token budgets.
+- Majority voting depends on partially independent errors and on the correct answer having enough probability to become the modal answer.
+- The method does not provide a complete adaptive stopping or abstention policy.
+- Calling independent samples “agents” can obscure the distinction from stateful, role-based subagent systems.
+
+## Cross-paper answer: do multiple agents really beat one agent?
+
+The answer depends on the baseline and the source of additional information.
+Multiple independent samples commonly beat one sample, but this demonstrates test-time ensembling rather than a unique benefit from agent communication.
+ReConcile shows that heterogeneous models, independent initial answers, calibrated aggregation, and bounded discussion can outperform comparable reasoning baselines on its selected tasks.
+The self-correction study shows that multi-agent debate may not beat self-consistency when the number of responses is matched.
+MAST shows that orchestration creates substantial new failure surfaces, including incomplete verification and incorrect stopping.
+The communication-attack study shows that collaboration channels can propagate malicious or simply incorrect instructions through the system.
+The overall evidence therefore supports conditional escalation rather than multi-agent execution by default.
+A system should add agents only when their independence, specialization, parallelism, or access to new evidence offsets the coordination cost and failure risk.
+
+## Recommended coding-agent workflow
+
+### 1. Admission decision
+
+Use a single agent for small, local, directly testable changes.
+Add a reviewer when the change has meaningful correctness, lifecycle, security, concurrency, compatibility, or integration risk.
+Add parallel implementers only when the alternatives can remain isolated until an evidence-based selection point.
+
+### 2. Independent proposal phase
+
+Give each participating agent the original task, repository state, constraints, and permitted tools.
+Do not initially expose one agent's reasoning or confidence to another agent.
+Require each proposal to identify assumptions, affected files, expected behavior, verification commands, and unresolved risks.
+
+### 3. Independent review phase
+
+Give the reviewer the original request, resulting diff, relevant source, and available tests.
+Require every finding to name a concrete failure scenario and reproducible evidence.
+Ask the reviewer to separate confirmed defects, uncertain risks, and non-blocking preferences.
+Do not accept agreement, confidence, or persuasive language as proof.
+
+### 4. Deterministic verification phase
+
+Run the narrowest relevant tests first and then the repository's required integration gates.
+Verify high-level user requirements separately from compilation, formatting, and unit-level correctness.
+Use runtime output, tests, type checks, static analysis, security checks, and artifact inspection as external feedback.
+Preserve raw outputs so the adjudicator does not depend on a lossy or contaminated summary.
+
+### 5. Adjudication and confidence handling
+
+Prefer objective evidence over the number of agents supporting a position.
+Treat self-reported confidence as uncalibrated unless it has been validated on representative local tasks.
+When evidence is incomplete, retain competing hypotheses rather than forcing consensus.
+Escalate unresolved high-impact disagreement to a human or a stronger independent verifier.
+
+### 6. Termination conditions
+
+Stop successfully only when every acceptance criterion has evidence and no unresolved high-severity finding remains.
+Stop with abstention when required evidence cannot be obtained safely or within the authorized scope.
+Limit ordinary reviewer-revision cycles to two rounds unless a new external signal justifies another round.
+Terminate repeated, non-progressing, or state-divergent agent loops explicitly rather than waiting for conversational consensus.
+Only the designated orchestrator or verifier should publish the final completion state.
+
+### 7. Security boundaries
+
+Treat model output, repository content, issue text, logs, test output, and pasted instructions as untrusted input.
+Separate data fields from instruction fields in every handoff schema.
+Give each agent only the tools and filesystem or network authority required for its assigned task.
+Authenticate or integrity-protect remote agent communication where applicable.
+Ensure that one agent cannot silently change another agent's role, policy, permissions, or completion state.
+
+### 8. Local evaluation requirement
+
+Compare the multi-agent workflow with a strong single-agent baseline on the same tasks.
+Match the model, task information, tool access, token or dollar budget, wall-clock budget, retry policy, and stopping rules where practical.
+Include best-of-N or self-consistency when the multi-agent method also consumes multiple generations.
+Measure correctness, regression rate, cost, latency, reviewer precision, verification coverage, and abstention quality.
+Do not adopt additional agents when the gain is smaller than normal benchmark variance or harness effects.
+
+## AlphaXiv MCP search evidence
+
+The following evidence records the actual AlphaXiv MCP discovery and PDF-query calls used for this review.
+
+### Discovery call 1
+
+```text
+tool: mcp__alphaxiv__discover_papers
+difficulty: 9
+published_after: 2024-01-01
+published_before: 2026-08-10
+prioritize: recency
+keywords:
+  AI
+  LLM
+  subagent
+  multi-agent
+  independent verification
+  critic
+  reviewer
+  reflection
+  error detection
+  confidence calibration
+  safety
+  termination conditions
+  single-agent
+```
+
+The returned candidates included the following ranked results.
+
+```text
+#1  2607.28527  MANTA: Multi-Agent Network Topology Adaptation for Self-Evolving Multi-Agent Systems
+#2  2606.05670  Do More Agents Help? Controlled and Protocol-Aligned Evaluation of LLM Agent Workflows
+#3  2607.02186  UA-ChatDev: Uncertainty-Aware Multi-Agent Collaboration for Reliable Software Development
+#4  2606.29026  Preventing Error Propagation in Multi-Agent AI through Runtime Monitoring
+#5  2607.12397  Critic Experience Bank: Self-Evolving Step-Level Confidence Estimation for LLM Agents
+#6  2606.27409  Delayed Verification Destabilizes Multi-Agent LLM Belief
+#13 2606.20158  N-Version Programming with Coding Agents
+#15 2606.05704  Critic-Guided Heterogeneous Multi-Agent Reasoning for Reliable Mathematical Problem Solving
+```
+
+The 2026 candidates were not promoted into the final five because the retrieved records were recent arXiv entries without a verified peer-reviewed publication at the research cutoff.
+
+### Discovery call 2
+
+```text
+tool: mcp__alphaxiv__discover_papers
+difficulty: 9
+published_after: 2024-01-01
+published_before: 2025-12-31
+prioritize: historical
+keywords:
+  LLM
+  multi-agent
+  independent verification
+  critic
+  reviewer
+  reflection
+  error detection
+  confidence calibration
+  safety
+  termination conditions
+  single-agent
+```
+
+The returned candidates included the following ranked results.
+
+```text
+#1  2503.13657  Why Do Multi-Agent LLM Systems Fail?
+#2  2505.18286  Single-agent or Multi-agent Systems? Why Not Both?
+#5  2505.00212  Which Agent Causes Task Failures and When?
+#8  2412.01928  MALT: Improving Reasoning with Multi-Agent LLM Training
+#13 2502.14847  Red-Teaming LLM Multi-Agent Systems via Communication Attacks
+#14 2505.22960  Revisiting Multi-Agent Debate as Test-Time Scaling
+```
+
+### Direct PDF queries
+
+The review then called `mcp__alphaxiv__answer_pdf_queries` for each selected paper.
+
+```text
+2503.13657 -> <paper id="2503.13657v3"> -> pages 1, 2, 7, 8, 26, and related appendix pages
+2402.05120 -> <paper id="2402.05120v2"> -> pages 1, 7, 8, 10, 11, and 12
+2309.13007 -> <paper id="2309.13007v3"> -> pages 1, 2, 6, 9, and 15
+2310.01798 -> <paper id="2310.01798v2"> -> pages 1 through 6, 8, and 9
+2502.14847 -> <paper id="2502.14847v2"> -> pages 1 through 6 and 9
+```
+
+The PDF queries requested exact title and authors, publication claims printed in the paper, methods, single-agent comparisons, confidence handling, verification, stopping behavior, security findings, quantitative results, and limitations.
+Venue and DOI metadata were subsequently checked against the official publication pages listed in each paper entry.
+
+## Final recommendation
+
+Start with one capable coding agent and deterministic external verification.
+Add one independent reviewer when a separate failure-detection perspective is justified.
+Use multiple implementers only for separable work or genuinely different candidate approaches.
+Do not let agents debate indefinitely or treat consensus as correctness.
+Require evidence-backed acceptance gates, a single completion authority, a bounded retry policy, and explicit abstention.
+Before adopting a multi-agent workflow, verify that it beats an equal-budget single-agent or best-of-N baseline on representative repository tasks.

--- a/docs/roadmaps/2026-08-10_pi-subagents-full-automation-roadmap.md
+++ b/docs/roadmaps/2026-08-10_pi-subagents-full-automation-roadmap.md
@@ -18,7 +18,7 @@ Keep `pi-subagents` as the owner of delegation planning, workflow state, authori
 
 - **Make completion evidence-owned** — Success: no opted-in mutating workflow can complete from worker self-report alone, and every accepted result has a current independent verification receipt for the exact integrated state.
 - **Automate topology selection** — Success: one high-level objective can produce parent-owned, one-child, verified-one-child, or bounded two-child execution without requiring the caller to author a complete workflow graph.
-- **Automate bounded replanning** — Success: failed assumptions, missing inputs, stale evidence, and verifier rejection can revise only unstarted or invalidated work without blindly replaying side effects.
+- **Automate bounded replanning** — Success: failed assumptions, missing inputs, stale evidence, and verifier rejection can revise only unstarted, rework-requested, or invalidated work without blindly replaying side effects.
 - **Keep capacity productive** — Success: newly ready safe work can start after any task settles instead of waiting for an unrelated batch sibling.
 - **Resume safely** — Success: restored workflows reconcile generations and side-effect state before continuing, with zero automatic replay of uncertain mutating work.
 - **Preserve the smallest useful team** — Success: delegation remains conditional, mutating width stays bounded, and recursive grandchildren remain disabled until separate matched evidence supports expansion.
@@ -34,6 +34,17 @@ Keep `pi-subagents` as the owner of delegation planning, workflow state, authori
 - Workflow persistence saves ledger snapshots, but the blocking execution path does not load and reconcile an interrupted workflow for continuation.
 - The admission decision remains opt-in because no paired live-provider repository benchmark has established a general quality, cost, or latency advantage over strong simpler baselines.
 
+## Plan Ownership
+
+| Concern | Current owner | Relationship to earlier plans |
+| --- | --- | --- |
+| Independent acceptance, immutable verification, and bounded rework | [`Verified Execution Loop Plan`](../plans/2026-08-10_pi-subagents-verified-execution-loop-plan.md) | Continues the implemented WorkItem baseline and owns the acceptance-state migration. |
+| Objective-to-DAG compilation and graph revision | [`Autonomous Workflow Planning Plan`](../plans/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md) | Continues capability routing and explicit workflow compilation without reopening their implemented baselines. |
+| Rolling scheduling, recovery, persistence reconciliation, and resume | [`Event-Driven Workflow Runtime Plan`](../plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md) | Continues the dependency scheduler and semantic snapshot baseline without duplicating it. |
+| Matched evidence before a default change | [`Minimal Delegation Admission Evaluation Plan`](../plans/2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md) | Remains the sole active admission evidence gate. |
+
+The original implementation plans now live under [`docs/plans/superseded/`](../plans/superseded/) as non-executable design provenance.
+
 ## Guiding Principles
 
 - **Verification before autonomy:** increase autonomous action only after completion requires independent current evidence.
@@ -41,7 +52,7 @@ Keep `pi-subagents` as the owner of delegation planning, workflow state, authori
 - **External evidence over agreement:** tests, type checks, builds, runtime smokes, artifact digests, and acceptance criteria outrank confidence or agent consensus.
 - **Smallest justified topology:** use parent-owned or one-child execution unless decomposition, isolation, parallelism, specialization, or independent verification provides a concrete benefit.
 - **No blind side-effect replay:** accepted, ambiguous, stale, interrupted, or potentially mutating work is never replayed merely because settlement was not observed.
-- **Patch the graph, not history:** replanning changes only pending or invalidated nodes and preserves accepted artifacts and provenance.
+- **Patch the graph, not history:** replanning changes only pending, rework-requested, or invalidated nodes and preserves accepted artifacts and provenance.
 - **Compatibility by omission:** existing single, parallel, chain, panel, detached, and explicit workflow calls retain their behavior unless the new automation contract is selected.
 - **Evidence before defaults:** full automation remains explicit and bounded until matched evaluation supports a separate default-change decision.
 
@@ -50,7 +61,9 @@ Keep `pi-subagents` as the owner of delegation planning, workflow state, authori
 ### Phase 1: Make verified completion authoritative
 
 - [ ] Every opted-in mutating or integration workflow automatically receives a distinct verifier when risk policy requires one.
+- [ ] The verifier cannot mutate the submitted state, and executor-owned before-and-after identities reject any verification-time drift.
 - [ ] Verification runs in a fresh context against the exact integrated state and returns an executor-validated receipt bound to task generation, `ExecutionPlan`, repository identity, patch digest, and required evidence.
+- [ ] WorkItem execution completion and acceptance are distinct versioned states, so verification and rework do not depend on the legacy terminal `completed` state.
 - [ ] The blocking workflow path uses managed integration admission before terminal success and rejects worker self-verification as sufficient acceptance.
 - [ ] Verifier rejection can trigger at most the configured bounded rework cycle, after which the workflow returns rework, rejected, or failed without claiming success.
 - [ ] Stale, cancelled, replaced, or mismatched verification evidence cannot complete current work.
@@ -65,7 +78,7 @@ Keep `pi-subagents` as the owner of delegation planning, workflow state, authori
 - [ ] A read-only planning turn proposes a bounded typed DAG, while deterministic compilation validates dependencies, scopes, authority, capabilities, artifacts, verification, and hard limits before any mutating child starts.
 - [ ] Admission selects the smallest justified topology and can return parent-owned direct work or abstention without allocating a child.
 - [ ] Capability routing assigns agents and tools from enforceable manifests without silently widening authority.
-- [ ] Versioned graph patches can revise pending or invalidated work after new evidence without replacing completed history.
+- [ ] Versioned graph patches can revise pending, rework-requested, or invalidated work after new evidence without replacing accepted history.
 
 **Outcome:** One high-level request can become a safe executable workflow with no manual topology authoring.
 
@@ -97,6 +110,8 @@ Keep `pi-subagents` as the owner of delegation planning, workflow state, authori
 | Indicator | Current baseline | Required invariant or decision |
 | --- | --- | --- |
 | Mutating workflow accepted from worker self-report alone | Possible | 0 in full-automation mode |
+| Verifier-caused state drift accepted | Not represented | 0 |
+| Executed but unaccepted work treated as terminal success | Possible through legacy `completed` semantics | 0 in full-automation mode |
 | Accepted stale or old-generation verification receipts | Rejected in isolated helpers | 0 end to end |
 | Managed integration checks exercised by workflow execution | Not wired | Every automated mutating acceptance |
 | Unrelated ready work blocked by a slow selected sibling | Possible under batch scheduling | 0 when safe capacity is available |
@@ -111,6 +126,7 @@ Keep `pi-subagents` as the owner of delegation planning, workflow state, authori
 | Risk or dependency | Impact | Mitigation or decision |
 | --- | --- | --- |
 | A verifier repeats the worker's blind spot | False confidence can become automated acceptance | Require fresh context, original requirements, raw artifacts, deterministic evidence, and a distinct agent identity. |
+| A verifier mutates the state under review | The receipt can attest to verifier-authored state and bypass the integration owner | Run checks under executor ownership, constrain verifier authority, compare before-and-after state identity, and reject drift. |
 | Planner output invents unsafe dependencies or scopes | Incorrect topology can race writes or omit required evidence | Compile model output through deterministic graph, capability, scope, authority, and artifact validation before allocation. |
 | Replanning loops consume budget without progress | Automation can become slower and less reliable than direct work | Bound plan revisions, rework cycles, model calls, total budget, and unchanged-state repetitions. |
 | Rolling scheduling introduces cancellation races | Late results or duplicate work can enter acceptance | Keep one event-loop owner, generation-bound grants, active-task cancellation, and stale-result quarantine. |

--- a/docs/roadmaps/2026-08-10_pi-subagents-full-automation-roadmap.md
+++ b/docs/roadmaps/2026-08-10_pi-subagents-full-automation-roadmap.md
@@ -1,0 +1,143 @@
+# Pi Subagents Full Automation Roadmap
+
+- **Status:** Proposed continuation of the implemented opt-in delegation-intelligence foundation.
+- **Audience:** `@narumitw/pi-subagents` maintainers and contributors.
+- **Planning horizon:** Evidence-qualified phases without delivery dates.
+- **Baseline:** [`Pi Subagents Delegation Intelligence Roadmap`](2026-08-10_pi-subagents-delegation-intelligence-roadmap.md).
+- **Research basis:** The three AlphaXiv reports under [`docs/research/`](../research/) covering orchestration, collaboration, and verification.
+
+## Vision
+
+Let a user provide one high-level objective while `pi-subagents` selects the smallest justified execution topology, executes dependency-ready work, verifies the exact integrated result independently, performs bounded recovery, and stops with a truthful terminal outcome.
+
+Keep Pi as the owner of model sessions, provider behavior, and tool execution.
+
+Keep `pi-subagents` as the owner of delegation planning, workflow state, authority, integration admission, verification acceptance, recovery bounds, and terminal completion.
+
+## Objectives
+
+- **Make completion evidence-owned** — Success: no opted-in mutating workflow can complete from worker self-report alone, and every accepted result has a current independent verification receipt for the exact integrated state.
+- **Automate topology selection** — Success: one high-level objective can produce parent-owned, one-child, verified-one-child, or bounded two-child execution without requiring the caller to author a complete workflow graph.
+- **Automate bounded replanning** — Success: failed assumptions, missing inputs, stale evidence, and verifier rejection can revise only unstarted or invalidated work without blindly replaying side effects.
+- **Keep capacity productive** — Success: newly ready safe work can start after any task settles instead of waiting for an unrelated batch sibling.
+- **Resume safely** — Success: restored workflows reconcile generations and side-effect state before continuing, with zero automatic replay of uncertain mutating work.
+- **Preserve the smallest useful team** — Success: delegation remains conditional, mutating width stays bounded, and recursive grandchildren remain disabled until separate matched evidence supports expansion.
+
+## Current State
+
+- Structured delegation contracts, typed outcomes, capability manifests, `ExecutionPlan`, capability grants, WorkItem state, artifacts, semantic snapshots, cancellation generations, explicit workflows, panels, retries, hedging, and persistence already exist.
+- The caller still selects exactly one execution mode and supplies the task graph, scopes, verifier relationship, retry policy, and topology.
+- `workflow.honorAdmission` can decline caller-authored work but cannot construct or widen a workflow.
+- Independent verification policy validates an explicitly declared verifier, while ordinary completion can still accept a worker's own structured `passed` verification entry.
+- `verifyManagedIntegration()` and `WorkItemLedger.acceptIntegration()` define a stronger acceptance boundary but are not wired into the blocking workflow execution path.
+- The workflow scheduler selects a batch with `activeCount: 0`, waits for that batch to settle, and then schedules again.
+- Workflow persistence saves ledger snapshots, but the blocking execution path does not load and reconcile an interrupted workflow for continuation.
+- The admission decision remains opt-in because no paired live-provider repository benchmark has established a general quality, cost, or latency advantage over strong simpler baselines.
+
+## Guiding Principles
+
+- **Verification before autonomy:** increase autonomous action only after completion requires independent current evidence.
+- **One completion owner:** workers, reviewers, and integrators submit evidence, but only the executor-owned controller declares terminal success.
+- **External evidence over agreement:** tests, type checks, builds, runtime smokes, artifact digests, and acceptance criteria outrank confidence or agent consensus.
+- **Smallest justified topology:** use parent-owned or one-child execution unless decomposition, isolation, parallelism, specialization, or independent verification provides a concrete benefit.
+- **No blind side-effect replay:** accepted, ambiguous, stale, interrupted, or potentially mutating work is never replayed merely because settlement was not observed.
+- **Patch the graph, not history:** replanning changes only pending or invalidated nodes and preserves accepted artifacts and provenance.
+- **Compatibility by omission:** existing single, parallel, chain, panel, detached, and explicit workflow calls retain their behavior unless the new automation contract is selected.
+- **Evidence before defaults:** full automation remains explicit and bounded until matched evaluation supports a separate default-change decision.
+
+## Roadmap
+
+### Phase 1: Make verified completion authoritative
+
+- [ ] Every opted-in mutating or integration workflow automatically receives a distinct verifier when risk policy requires one.
+- [ ] Verification runs in a fresh context against the exact integrated state and returns an executor-validated receipt bound to task generation, `ExecutionPlan`, repository identity, patch digest, and required evidence.
+- [ ] The blocking workflow path uses managed integration admission before terminal success and rejects worker self-verification as sufficient acceptance.
+- [ ] Verifier rejection can trigger at most the configured bounded rework cycle, after which the workflow returns rework, rejected, or failed without claiming success.
+- [ ] Stale, cancelled, replaced, or mismatched verification evidence cannot complete current work.
+
+**Outcome:** Autonomous execution has a trustworthy stopping condition and a bounded correction loop.
+
+**Execution plan:** [`2026-08-10_pi-subagents-verified-execution-loop-plan.md`](../plans/2026-08-10_pi-subagents-verified-execution-loop-plan.md).
+
+### Phase 2: Accept one objective and construct the workflow
+
+- [ ] An explicit automation mode accepts one objective, constraints, acceptance criteria, and aggregate budget without requiring a caller-authored task graph.
+- [ ] A read-only planning turn proposes a bounded typed DAG, while deterministic compilation validates dependencies, scopes, authority, capabilities, artifacts, verification, and hard limits before any mutating child starts.
+- [ ] Admission selects the smallest justified topology and can return parent-owned direct work or abstention without allocating a child.
+- [ ] Capability routing assigns agents and tools from enforceable manifests without silently widening authority.
+- [ ] Versioned graph patches can revise pending or invalidated work after new evidence without replacing completed history.
+
+**Outcome:** One high-level request can become a safe executable workflow with no manual topology authoring.
+
+**Execution plan:** [`2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md`](../plans/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md).
+
+### Phase 3: Run a rolling recoverable workflow runtime
+
+- [ ] The workflow runtime maintains active work, safe scopes, ownership, budget, and transport capacity continuously and reschedules after every settlement.
+- [ ] Newly ready work starts without waiting for an unrelated slow sibling when capacity and scope safety permit it.
+- [ ] Typed outcomes drive bounded executor actions for transient retry, capability rerouting, input repair, read-only revalidation, verifier-directed rework, or terminal stop.
+- [ ] Persisted workflows can be loaded and reconciled after interruption without accepting stale generations or replaying uncertain mutating work.
+- [ ] Session replacement, shutdown, timeout, cancellation, and late completion leave no accepted old-generation artifacts or leaked owned tasks.
+
+**Outcome:** Automation continues productively through ordinary failures and interruptions while retaining one authoritative workflow state machine.
+
+**Execution plan:** [`2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md`](../plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md).
+
+### Phase 4: Qualify production use
+
+- [ ] Repeated paired repository tasks compare full automation with a strong single agent, one child, equal-budget best-of-N, fixed two-child execution, and explicit workflow execution under matched information, model, tools, evaluator, aggregate budget, and wall-clock ceilings.
+- [ ] Results separately report verified success, false completion, unnecessary delegation, rework, conflicts, stale acceptance, duplicate side effects, tokens, cost, and critical-path duration by task class.
+- [ ] A recorded **Admit**, **Revise**, or **Defer** decision identifies eligible task classes and preserves explicit opt-in behavior when evidence is insufficient.
+- [ ] Any default change, recursion expansion, wider mutating team, publication, tag, or release remains a separate explicitly approved action.
+
+**Outcome:** Production behavior changes only when representative evidence shows where automation is safer or more effective than simpler alternatives.
+
+## Success Metrics
+
+| Indicator | Current baseline | Required invariant or decision |
+| --- | --- | --- |
+| Mutating workflow accepted from worker self-report alone | Possible | 0 in full-automation mode |
+| Accepted stale or old-generation verification receipts | Rejected in isolated helpers | 0 end to end |
+| Managed integration checks exercised by workflow execution | Not wired | Every automated mutating acceptance |
+| Unrelated ready work blocked by a slow selected sibling | Possible under batch scheduling | 0 when safe capacity is available |
+| Uncertain mutating work replayed after restore | Not resumed automatically today | 0 |
+| Automated rework cycles | Not implemented | Hard bounded with no unbounded loop |
+| Automatic topology quality against matched simpler baselines | Unknown | Decision by task class before any default change |
+| Concurrent mutating children | Hard cap available | At most two until separately approved |
+| Recursive workflow grandchildren | Rejected | Remain rejected until separately evaluated |
+
+## Risks and Dependencies
+
+| Risk or dependency | Impact | Mitigation or decision |
+| --- | --- | --- |
+| A verifier repeats the worker's blind spot | False confidence can become automated acceptance | Require fresh context, original requirements, raw artifacts, deterministic evidence, and a distinct agent identity. |
+| Planner output invents unsafe dependencies or scopes | Incorrect topology can race writes or omit required evidence | Compile model output through deterministic graph, capability, scope, authority, and artifact validation before allocation. |
+| Replanning loops consume budget without progress | Automation can become slower and less reliable than direct work | Bound plan revisions, rework cycles, model calls, total budget, and unchanged-state repetitions. |
+| Rolling scheduling introduces cancellation races | Late results or duplicate work can enter acceptance | Keep one event-loop owner, generation-bound grants, active-task cancellation, and stale-result quarantine. |
+| Restore cannot prove prior side effects | Automatic continuation could duplicate mutations | Resume only current unstarted work or safely revalidated read-only/idempotent work, and stop uncertain mutation. |
+| More automation is mistaken for better outcomes | Extra calls can hide a quality or cost regression | Preserve simpler baselines and require matched repeated evidence before defaults change. |
+
+## Non-Goals
+
+- Expand inspection, dashboards, status rendering, telemetry, or other observability surfaces beyond metadata required for runtime correctness and verification receipts.
+- Maximize agent count, debate rounds, recursion depth, or configured concurrency.
+- Build a general distributed workflow engine, CI service, unrestricted patch-merging system, or operating-system sandbox.
+- Treat consensus, confidence, persuasive prose, exit code, `agent_end`, or `agent_settled` as sufficient correctness evidence.
+- Automatically replay uncertain write-capable work.
+- Replace Pi's model loop, session runtime, provider retry, or tool execution.
+- Change package defaults, publish, tag, or dispatch a release workflow without separate evidence and explicit approval.
+
+## Assumptions and Unknowns
+
+- The first implementation remains opt-in through an explicit automation contract or mode.
+- The existing two-mutating-child limit and no-grandchild rule remain hard boundaries.
+- The exact public automation schema, planner model budget, rework bound, and persisted resume selector require provider-compatibility decisions in the owning implementation plans.
+- It remains unknown which repository task classes justify automatic planning after coordination overhead is included.
+- It remains unknown whether a fresh verifier should always use a different model family or whether distinct context, role, and evidence are sufficient for specific task classes.
+
+## Decisions and Changes
+
+- **2026-08-10 — Prioritize verified completion over broader autonomy:** automatic planning must not precede an executor-owned independent acceptance boundary.
+- **2026-08-10 — Exclude observability expansion:** this roadmap changes execution behavior and correctness gates only, except for bounded evidence required by those gates.
+- **2026-08-10 — Keep full automation explicit:** no default routing change is proposed before matched representative evaluation.
+- **2026-08-10 — Preserve narrow concurrency:** the first automated architecture keeps at most two mutating children and no workflow grandchildren.


### PR DESCRIPTION
## Summary

- add AlphaXiv-backed research on subagent orchestration, collaboration, and verification methods
- define an evidence-gated roadmap for verified completion, autonomous workflow planning, and event-driven recovery
- add three executable implementation plans with compatibility, lifecycle, rollback, and validation gates
- separate worker execution from authoritative acceptance and require immutable independent verification
- keep full automation opt-in, cap mutating concurrency at two, and preserve the no-grandchild boundary until matched evaluation supports expansion
- move superseded implementation checklists out of the active plan directory and assign every continuing obligation to one current owner

## Review follow-up

- constrain verifiers from mutating submitted state, keep deterministic checks executor-owned, and reject before-and-after state drift
- add a versioned WorkItem acceptance state with legal verifier and rework transitions plus legacy restoration
- make the minimal admission evaluation plan the sole matched-evidence gate and document plan dependencies explicitly

## Validation

- `npm run check` — passed: Biome, boundaries, all workspace typechecks, and 2,863 tests
- `git diff --check`
- targeted Markdown relative-link validation
- English-only documentation validation

## Release

- No changeset is included because this pull request changes repository documentation only.
