### PR TITLE
fix(tool): preserve schema indentation

### DIFF
--- a/.changeset/fuzzy-tools-indent.md
+++ b/.changeset/fuzzy-tools-indent.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tool": patch
+---
+
+Preserve nested parameter-schema indentation in TUI and RPC tool details.

--- a/docs/plans/2026-08-10_pi-tool-pr-679-feedback-plan.md
+++ b/docs/plans/2026-08-10_pi-tool-pr-679-feedback-plan.md
@@ -1,0 +1,42 @@
+# Pi Tool Pull Request 679 Feedback Plan
+
+## Goal
+
+Resolve every feedback item on pull request #679 with a verified fix, thread response, signed commit, and push to `feat/pi-tool-browser`.
+
+## Context
+
+The exact target is https://github.com/narumiruna/pi-extensions/pull/679 from `feat/pi-tool-browser` into `main`.
+The pull request was merged as `36321964b02dbb9d9cd1c0946a2a3f7aad93d071` before the automated review was submitted, and GitHub deleted the remote head branch.
+The local target branch remained at reviewed commit `6a032290452c8226aa7f40d532954987a4ad0360` with a clean working tree before this plan was created.
+The submitted review contains one unresolved inline finding and no conversation comments.
+The pull-request CI check and the post-merge CI check both pass.
+The touched areas are exact document rendering in the `/tool` TUI and RPC detail paths, terminal-safe display, package tests, and release documentation.
+Applicable convention MUST rules are width-bounded and terminal-safe custom rendering, cancellation and disposal ownership, deterministic behavior tests, a release changeset, the root CI gate, and package inspection.
+
+## Review Ledger
+
+| Feedback | Current outcome | Evidence |
+| --- | --- | --- |
+| `tool-catalog.ts`: preserve indentation in nested parameter schemas in TUI and RPC detail views | Already addressed by the current code | `tool-catalog.ts` keeps the pretty JSON as one exact document and both mode paths use Pi TUI Kit's cell-aware `review` renderer; regressions assert two- and four-space nesting in RPC and TUI, including a 20-column TUI. |
+| Codex submitted-review wrapper for commit `6a03229045` | Outdated or superseded | The wrapper is informational and names the reviewed commit; its single inline finding is tracked separately above. |
+
+## Plan
+
+- [x] Add focused regressions that exercise nested schema details through the real TUI and RPC display boundaries and fail when indentation is flattened; both mode assertions failed against reviewed commit `6a032290` and now pass.
+- [x] Fix exact schema rendering at the owning `pi-tool` boundary without relying on an unpublished Pi TUI Kit release; the installed `@narumitw/pi-tui-kit@0.51.0` review API preserves document whitespace.
+- [x] Scan the full pull-request diff and sibling exact-text paths for the same whitespace-loss pattern; the parameter schema is the only exact-text document in the package, while prose metadata remains safely normalized at list boundaries.
+- [x] Audit width bounds, terminal sanitization, cancellation, disposal, session replacement, shutdown, and RPC navigation against `docs/extension-conventions.md`; focused tests cover narrow widths, controls, back-state preservation, replacement, shutdown, and scripted RPC pages.
+- [x] Run focused package tests, `git diff --check`, the CI-equivalent `npm run check`, and `just pack tool`; 8 focused tests, all validators, 2,888 root tests, and the 7-file dry-run pack pass, and the local print-mode smoke reports the expected observable rejection. The first root run exposed one unrelated `pi-sync` timing failure that passed alone and in the clean full rerun.
+- [x] Re-read all pull-request feedback and inspect the final diff; both ledger items have final evidence-backed outcomes, and an independent scoped reviewer reported no findings.
+- [ ] Reply to and resolve the addressed review thread only after verification.
+- [ ] Create signed conventional commits, push them to the recreated `feat/pi-tool-browser` branch without rewriting history, then refresh the pull request once.
+
+## Completion Checklist
+
+- [x] Every feedback item has an evidence-backed final outcome.
+- [x] Nested schema indentation remains visible in both TUI and RPC detail views at narrow and ordinary widths.
+- [x] Terminal controls remain stripped and every rendered TUI line remains width-bounded.
+- [x] Required checks and smokes pass with the initial unrelated timing failure recorded above.
+- [ ] The review thread is answered and resolved only after verification.
+- [ ] The signed fix commit is pushed without rewriting history.

--- a/docs/plans/archived/2026-08-10_pi-tool-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-tool-plan.md
@@ -9,13 +9,13 @@ Add a small stable `@narumitw/pi-tool` extension whose `/tool` command lists eve
 - The package name is `@narumitw/pi-tool`, matching the requested `pi-tool` name.
 - The primary command is `/tool`, derived from the unscoped package name.
 - The extension is read-only and owns no settings, persistence, status, or background resources.
-- The bounded UI uses Pi TUI Kit's searchable `browse` screen for list-to-detail progressive disclosure.
+- The bounded UI uses an extension-owned searchable list and Pi TUI Kit's exact-document `review` screen for list-to-detail progressive disclosure.
 - Applicable convention MUST rules are package layout and lifecycle metadata, a thin entrypoint, independent runtime dependencies, command argument and mode handling, TUI lifecycle cancellation, terminal-safe rendering, deterministic tests, the root CI gate, package inspection, and a local Pi load smoke.
 
 ## Plan
 
 - [x] Add focused tests under `packages/pi-tool/test/` for catalog status, complete details, command validation, supported modes, cancellation ownership, and terminal-safe rendering; the initial six-test run failed against intentional production stubs.
-- [x] Implement `packages/pi-tool/src/` with a thin entrypoint, a read-only catalog projection, `/tool` registration, and session-owned menu cancellation; all six focused tests pass.
+- [x] Implement `packages/pi-tool/src/` with a thin entrypoint, a read-only catalog projection, a searchable TUI browser, exact-document detail views, `/tool` registration, and session-owned menu cancellation; focused tests pass.
 - [x] Add the package manifest, README, license, TypeScript config, root stable-extension registration, lockfile entry, and release changeset; package boundaries, package typechecking, and Changesets status pass.
 - [x] Run formatting, focused tests, `npm run check`, `just pack tool`, and a local Pi package-load smoke; the full gate passed 2,869 tests, the dry-run tarball contains only the six intended publish files, and Pi loaded `/tool` and reported its expected print-mode rejection.
 - [x] Audit the final diff against `docs/extension-conventions.md`, including cancellation, disposal, session replacement, shutdown, non-TUI rejection, terminal sanitization, and package publication rules; no deviations or unverified required paths remain.

--- a/docs/plans/archived/2026-08-10_pi-tool-pr-679-feedback-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-tool-pr-679-feedback-plan.md
@@ -29,8 +29,8 @@ Applicable convention MUST rules are width-bounded and terminal-safe custom rend
 - [x] Audit width bounds, terminal sanitization, cancellation, disposal, session replacement, shutdown, and RPC navigation against `docs/extension-conventions.md`; focused tests cover narrow widths, controls, back-state preservation, replacement, shutdown, and scripted RPC pages.
 - [x] Run focused package tests, `git diff --check`, the CI-equivalent `npm run check`, and `just pack tool`; 8 focused tests, all validators, 2,888 root tests, and the 7-file dry-run pack pass, and the local print-mode smoke reports the expected observable rejection. The first root run exposed one unrelated `pi-sync` timing failure that passed alone and in the clean full rerun.
 - [x] Re-read all pull-request feedback and inspect the final diff; both ledger items have final evidence-backed outcomes, and an independent scoped reviewer reported no findings.
-- [ ] Reply to and resolve the addressed review thread only after verification.
-- [ ] Create signed conventional commits, push them to the recreated `feat/pi-tool-browser` branch without rewriting history, then refresh the pull request once.
+- [x] Reply to and resolve the addressed review thread only after verification; reply `discussion_r3750638306` cites the fix and checks, and GraphQL confirms the thread is resolved.
+- [x] Create signed conventional fix commit `c3ce1c5d715fc70dad878ae6bcdb35fe318852b2` and push it to the recreated `feat/pi-tool-browser` branch without rewriting history; defer the one pull-request refresh until after archiving this ledger.
 
 ## Completion Checklist
 
@@ -38,5 +38,5 @@ Applicable convention MUST rules are width-bounded and terminal-safe custom rend
 - [x] Nested schema indentation remains visible in both TUI and RPC detail views at narrow and ordinary widths.
 - [x] Terminal controls remain stripped and every rendered TUI line remains width-bounded.
 - [x] Required checks and smokes pass with the initial unrelated timing failure recorded above.
-- [ ] The review thread is answered and resolved only after verification.
-- [ ] The signed fix commit is pushed without rewriting history.
+- [x] The review thread is answered and resolved only after verification.
+- [x] The signed fix commit is pushed without rewriting history.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9964,11 +9964,13 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",
 				"@earendil-works/pi-coding-agent": "0.84.1",
+				"@earendil-works/pi-tui": "0.84.1",
 				"@types/node": "26.1.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*"
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"packages/pi-tool/node_modules/@narumitw/pi-tui-kit": {

--- a/packages/pi-tool/README.md
+++ b/packages/pi-tool/README.md
@@ -73,7 +73,8 @@ packages/pi-tool/
 ├── src/
 │   ├── index.ts         # Thin Pi package entrypoint
 │   ├── tool.ts          # Command and session lifecycle ownership
-│   └── tool-catalog.ts  # Read-only catalog and detail projection
+│   ├── tool-browser.ts  # Searchable TUI catalog component
+│   └── tool-catalog.ts  # Read-only catalog and exact detail projection
 ├── test/
 ├── README.md
 ├── LICENSE

--- a/packages/pi-tool/package.json
+++ b/packages/pi-tool/package.json
@@ -35,11 +35,13 @@
 		"@narumitw/pi-tui-kit": "^0.51.0"
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-coding-agent": "*"
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.7",
 		"@earendil-works/pi-coding-agent": "0.84.1",
+		"@earendil-works/pi-tui": "0.84.1",
 		"@types/node": "26.1.2",
 		"typescript": "7.0.2"
 	},

--- a/packages/pi-tool/src/tool-browser.ts
+++ b/packages/pi-tool/src/tool-browser.ts
@@ -1,0 +1,288 @@
+import { stripVTControlCharacters } from "node:util";
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import {
+	type Focusable,
+	fuzzyFilter,
+	Input,
+	Key,
+	matchesKey,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import type { CustomInteractionComponent } from "@narumitw/pi-tui-kit";
+import type { ToolCatalog, ToolCatalogItem } from "./tool-catalog.js";
+
+const RESERVED_HOST_ROWS = 3;
+
+export type ToolBrowserResult =
+	| { kind: "close" }
+	| { kind: "select"; itemId: string; query: string };
+
+interface ToolBrowserOptions {
+	catalog: ToolCatalog;
+	initialItemId?: string;
+	initialQuery?: string;
+	tui: TUI;
+	theme: Theme;
+	keybindings: KeybindingsManager;
+	onClose(): void;
+	onSelect(selection: ToolBrowserResult & { kind: "select" }): void;
+}
+
+interface SearchableTool {
+	item: ToolCatalogItem;
+	label: string;
+	statusText: string;
+	description: string;
+	searchText: string;
+}
+
+export function createToolBrowserComponent(
+	options: ToolBrowserOptions,
+): CustomInteractionComponent {
+	const searchInput = new Input();
+	searchInput.setValue(options.initialQuery ?? "");
+	const allItems = options.catalog.items.map(
+		(item): SearchableTool => ({
+			item,
+			label: safeSingleLine(item.label),
+			statusText: safeSingleLine(item.statusText),
+			description: safeSingleLine(item.description),
+			searchText: safeSingleLine(item.searchText),
+		}),
+	);
+	let filteredItems = filterItems(allItems, searchInput.getValue());
+	let selectedIndex = Math.max(
+		0,
+		filteredItems.findIndex(({ item }) => item.id === options.initialItemId),
+	);
+	let itemRows = 1;
+	let focused = false;
+	let disposed = false;
+	const selected = () => filteredItems[selectedIndex];
+	const setSelectedIndex = (index: number, wrap: boolean) => {
+		if (filteredItems.length === 0) {
+			selectedIndex = 0;
+			return;
+		}
+		selectedIndex = wrap
+			? (index + filteredItems.length) % filteredItems.length
+			: Math.max(0, Math.min(index, filteredItems.length - 1));
+	};
+	const applyFilter = () => {
+		const selectedId = selected()?.item.id;
+		filteredItems = filterItems(allItems, searchInput.getValue());
+		const preservedIndex = filteredItems.findIndex(({ item }) => item.id === selectedId);
+		selectedIndex = preservedIndex >= 0 ? preservedIndex : 0;
+	};
+
+	const component: CustomInteractionComponent & Focusable = {
+		get focused() {
+			return focused;
+		},
+		set focused(value: boolean) {
+			focused = value;
+			searchInput.focused = value;
+		},
+		render(width) {
+			const safeWidth = Math.max(1, width);
+			const availableRows = componentRows(options.tui.terminal.rows);
+			const layout = browserLayout(availableRows, filteredItems.length);
+			itemRows = layout.itemRows;
+			const viewportStart = listWindowStart(selectedIndex, filteredItems.length, layout.itemRows);
+			const description = selected()?.description;
+			const lines = [
+				...(layout.titleRows
+					? [options.theme.fg("accent", options.theme.bold(safeSingleLine(options.catalog.title)))]
+					: []),
+				...(layout.searchRows ? renderSearchInput(searchInput, safeWidth) : []),
+				...listRows(
+					filteredItems,
+					selectedIndex,
+					viewportStart,
+					layout.itemRows,
+					safeWidth,
+					options.theme,
+				),
+				...(layout.positionRows
+					? [
+							options.theme.fg(
+								"dim",
+								positionText(viewportStart, layout.itemRows, filteredItems.length),
+							),
+						]
+					: []),
+				...(layout.descriptionRows && description
+					? [options.theme.fg("muted", truncateToWidth(description, safeWidth, ""))]
+					: []),
+				...(layout.hintRows
+					? [
+							options.theme.fg(
+								"dim",
+								truncateToWidth(browserHint(options.keybindings), safeWidth, ""),
+							),
+						]
+					: []),
+			];
+			return lines.slice(0, availableRows).map((line) => truncateToWidth(line, safeWidth, ""));
+		},
+		invalidate() {
+			searchInput.invalidate();
+		},
+		handleInput(data) {
+			if (disposed) return;
+			if (
+				matchesKey(data, Key.ctrl("c")) ||
+				options.keybindings.matches(data, "tui.select.cancel")
+			) {
+				options.onClose();
+			} else if (options.keybindings.matches(data, "tui.select.up")) {
+				setSelectedIndex(selectedIndex - 1, true);
+			} else if (options.keybindings.matches(data, "tui.select.down")) {
+				setSelectedIndex(selectedIndex + 1, true);
+			} else if (options.keybindings.matches(data, "tui.select.pageUp")) {
+				setSelectedIndex(selectedIndex - itemRows, false);
+			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
+				setSelectedIndex(selectedIndex + itemRows, false);
+			} else if (matchesKey(data, Key.home)) setSelectedIndex(0, false);
+			else if (matchesKey(data, Key.end)) setSelectedIndex(filteredItems.length - 1, false);
+			else if (options.keybindings.matches(data, "tui.select.confirm")) {
+				const item = selected()?.item;
+				if (item) {
+					options.onSelect({
+						kind: "select",
+						itemId: item.id,
+						query: searchInput.getValue(),
+					});
+				}
+			} else {
+				searchInput.handleInput(data);
+				const safeQuery = replaceTerminalControls(searchInput.getValue());
+				if (safeQuery !== searchInput.getValue()) searchInput.setValue(safeQuery);
+				applyFilter();
+			}
+			options.tui.requestRender();
+		},
+		async waitForPending() {},
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			searchInput.focused = false;
+		},
+	};
+	return component;
+}
+
+function filterItems(items: readonly SearchableTool[], query: string) {
+	return fuzzyFilter([...items], query, (candidate) =>
+		[candidate.label, candidate.statusText, candidate.description, candidate.searchText].join(" "),
+	);
+}
+
+function listRows(
+	items: readonly SearchableTool[],
+	selectedIndex: number,
+	viewportStart: number,
+	viewportRows: number,
+	width: number,
+	theme: Theme,
+) {
+	if (items.length === 0) return [theme.fg("dim", "  No matching tools")];
+	return items.slice(viewportStart, viewportStart + viewportRows).map((candidate, offset) => {
+		const index = viewportStart + offset;
+		const prefix = index === selectedIndex ? "› " : "  ";
+		const suffix = `  [${candidate.statusText}]`;
+		const labelWidth = Math.max(0, width - visibleWidth(prefix) - visibleWidth(suffix));
+		const label = truncateToWidth(candidate.label, labelWidth, "");
+		const line = truncateToWidth(`${prefix}${label}${suffix}`, width, "");
+		return index === selectedIndex ? theme.fg("accent", line) : line;
+	});
+}
+
+function renderSearchInput(input: Input, width: number) {
+	const prefix = "Search: ";
+	const inputWidth = Math.max(1, width - visibleWidth(prefix));
+	return input.render(inputWidth).map((line) => truncateToWidth(`${prefix}${line}`, width, ""));
+}
+
+interface BrowserLayout {
+	titleRows: number;
+	searchRows: number;
+	itemRows: number;
+	positionRows: number;
+	descriptionRows: number;
+	hintRows: number;
+}
+
+function browserLayout(availableRows: number, itemCount: number): BrowserLayout {
+	if (availableRows === 1) {
+		return {
+			titleRows: 0,
+			searchRows: 0,
+			itemRows: 1,
+			positionRows: 0,
+			descriptionRows: 0,
+			hintRows: 0,
+		};
+	}
+	const titleRows = availableRows >= 4 ? 1 : 0;
+	const searchRows = availableRows >= 3 ? 1 : 0;
+	const hintRows = availableRows >= 3 ? 1 : 0;
+	const descriptionRows = availableRows >= 7 ? 1 : 0;
+	const itemBudget = Math.max(
+		1,
+		availableRows - titleRows - searchRows - hintRows - descriptionRows,
+	);
+	const positionRows = itemCount > itemBudget && itemBudget >= 2 ? 1 : 0;
+	return {
+		titleRows,
+		searchRows,
+		itemRows: itemBudget - positionRows,
+		positionRows,
+		descriptionRows,
+		hintRows,
+	};
+}
+
+function componentRows(rows: number) {
+	const terminalRows = Number.isFinite(rows) ? Math.floor(rows) : 24;
+	return Math.max(1, terminalRows - RESERVED_HOST_ROWS);
+}
+
+function listWindowStart(selectedIndex: number, itemCount: number, viewportSize: number) {
+	if (itemCount <= viewportSize) return 0;
+	return Math.max(
+		0,
+		Math.min(selectedIndex - Math.floor(viewportSize / 2), itemCount - viewportSize),
+	);
+}
+
+function positionText(offset: number, viewportSize: number, itemCount: number) {
+	if (itemCount === 0) return "0/0";
+	return `${offset + 1}-${Math.min(itemCount, offset + viewportSize)}/${itemCount}`;
+}
+
+function browserHint(keybindings: KeybindingsManager) {
+	const keys = (binding: Parameters<KeybindingsManager["getKeys"]>[0], fallback: string) =>
+		keybindings.getKeys(binding).join("/") || fallback;
+	return [
+		"type to search",
+		`${keys("tui.select.up", "up")}/${keys("tui.select.down", "down")} navigate`,
+		`${keys("tui.select.confirm", "enter")} details`,
+		`${keys("tui.select.cancel", "esc")} close`,
+	].join(" · ");
+}
+
+function safeSingleLine(value: unknown) {
+	return replaceTerminalControls(stripVTControlCharacters(String(value)))
+		.replace(/\s+/gu, " ")
+		.trim();
+}
+
+function replaceTerminalControls(value: unknown) {
+	return Array.from(String(value), (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+	}).join("");
+}

--- a/packages/pi-tool/src/tool-catalog.ts
+++ b/packages/pi-tool/src/tool-catalog.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { MenuBrowseItem, MenuDefinition } from "@narumitw/pi-tui-kit";
+import type { MenuDefinition } from "@narumitw/pi-tui-kit";
 
 export interface ToolCatalogState {
 	tools: ReturnType<ExtensionAPI["getAllTools"]>;
@@ -7,10 +7,27 @@ export interface ToolCatalogState {
 	toolSnippets: Readonly<Record<string, string>>;
 }
 
+export interface ToolCatalogItem {
+	id: string;
+	label: string;
+	statusText: "active" | "inactive";
+	description: string;
+	searchText: string;
+	detailContent: string;
+}
+
 export interface ToolCatalog {
 	title: string;
-	items: MenuBrowseItem[];
+	items: ToolCatalogItem[];
 }
+
+interface ToolMenuState {
+	catalog: ToolCatalog;
+	selectedItemId?: string;
+}
+
+type ToolMenuScreen = "tools" | "detail";
+type ToolMenuAction = "view";
 
 export function createToolCatalog(
 	tools: ToolCatalogState["tools"],
@@ -20,7 +37,7 @@ export function createToolCatalog(
 	const active = new Set(activeToolNames);
 	const items = [...tools]
 		.sort((left, right) => left.name.localeCompare(right.name))
-		.map((tool): MenuBrowseItem => {
+		.map((tool): ToolCatalogItem => {
 			const parameterSchema = JSON.stringify(tool.parameters, null, 2) ?? "Unavailable";
 			const guidelines = tool.promptGuidelines ?? [];
 			const effectivePromptSnippet = toolSnippets[tool.name];
@@ -43,7 +60,9 @@ export function createToolCatalog(
 				]
 					.filter(Boolean)
 					.join(" "),
-				details: [
+				detailContent: [
+					`Status: ${active.has(tool.name) ? "active" : "inactive"}`,
+					tool.description,
 					`Source: ${tool.sourceInfo.source}`,
 					`Scope: ${tool.sourceInfo.scope}`,
 					`Origin: ${tool.sourceInfo.origin}`,
@@ -54,26 +73,68 @@ export function createToolCatalog(
 					effectivePromptSnippet ?? "None in the current system prompt.",
 					"",
 					"Parameter schema",
-					...parameterSchema.split("\n"),
+					parameterSchema,
 					"",
 					"Prompt guidelines",
 					...(guidelines.length > 0 ? guidelines.map((guideline) => `• ${guideline}`) : ["None"]),
-				],
+				].join("\n"),
 			};
 		});
 	const activeCount = tools.reduce((count, tool) => count + Number(active.has(tool.name)), 0);
 	return { title: `Tools · ${activeCount}/${tools.length} active`, items };
 }
 
-export function createToolMenu(): MenuDefinition<ToolCatalogState, "tools", never> {
+export function createToolMenu(): MenuDefinition<ToolMenuState, ToolMenuScreen, ToolMenuAction> {
 	return {
 		start: "tools",
 		screens: {
 			tools: ({ state }) => ({
-				kind: "browse",
-				...createToolCatalog(state.tools, state.activeToolNames, state.toolSnippets),
-				viewportSize: "adaptive",
+				kind: "choice",
+				title: state.catalog.title,
+				items: state.catalog.items.map((item) => ({
+					id: item.id,
+					label: `${item.label} [${item.statusText}]`,
+					description: item.description,
+				})),
+				action: "view",
+				initialItemId: state.selectedItemId,
+				viewportSize: 12,
 				hint: "close",
+			}),
+			detail: ({ state }) => {
+				const item = state.catalog.items.find(({ id }) => id === state.selectedItemId);
+				return {
+					kind: "review",
+					title: item?.label ?? "Tool details",
+					content: item?.detailContent ?? "The selected tool is no longer available.",
+					format: { kind: "text" },
+					viewportSize: "adaptive",
+					hint: "back",
+				};
+			},
+		},
+		actions: {
+			view: ({ state, itemId }) => {
+				state.selectedItemId = itemId;
+				return { kind: "to", screen: "detail" };
+			},
+		},
+	};
+}
+
+export function createToolDetailMenu(
+	item: ToolCatalogItem,
+): MenuDefinition<undefined, "detail", never> {
+	return {
+		start: "detail",
+		screens: {
+			detail: () => ({
+				kind: "review",
+				title: item.label,
+				content: item.detailContent,
+				format: { kind: "text" },
+				viewportSize: "adaptive",
+				hint: "back",
 			}),
 		},
 		actions: {},

--- a/packages/pi-tool/src/tool.ts
+++ b/packages/pi-tool/src/tool.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { createToolMenu } from "./tool-catalog.js";
+import { createToolBrowserComponent, type ToolBrowserResult } from "./tool-browser.js";
+import { createToolCatalog, createToolDetailMenu, createToolMenu } from "./tool-catalog.js";
 
 const COMMAND_NAME = "tool";
 
@@ -32,24 +33,67 @@ export default function toolExtension(pi: ExtensionAPI) {
 			const commandGeneration = generation;
 			const signal = sessionController.signal;
 			const isCurrent = () => commandGeneration === generation && !signal.aborted;
-			const { runMenu } = await import("@narumitw/pi-tui-kit");
+			const { runCustomInteraction, runMenu } = await import("@narumitw/pi-tui-kit");
 			if (!isCurrent()) return;
+			const catalog = createToolCatalog(
+				pi.getAllTools(),
+				pi.getActiveTools(),
+				ctx.getSystemPromptOptions().toolSnippets ?? {},
+			);
+			const onError = (errorCtx: typeof ctx) => {
+				if (isCurrent()) errorCtx.ui.notify("The tool catalog could not be displayed.", "error");
+			};
+			const onUnsupportedMode = (_unsupportedCtx: typeof ctx, mode: typeof ctx.mode) => {
+				throw new Error(`/tool is unavailable in ${mode} mode; use TUI or RPC mode.`);
+			};
 
-			await runMenu(ctx, createToolMenu(), {
-				getState: () => ({
-					tools: pi.getAllTools(),
-					activeToolNames: pi.getActiveTools(),
-					toolSnippets: ctx.getSystemPromptOptions().toolSnippets ?? {},
-				}),
-				signal,
-				isCurrent,
-				onError: (errorCtx) => {
-					if (isCurrent()) errorCtx.ui.notify("The tool catalog could not be displayed.", "error");
-				},
-				onUnsupportedMode: (_unsupportedCtx, mode) => {
-					throw new Error(`/tool is unavailable in ${mode} mode; use TUI or RPC mode.`);
-				},
-			});
+			if (ctx.mode === "rpc") {
+				const menuState = { catalog };
+				await runMenu(ctx, createToolMenu(), {
+					getState: () => menuState,
+					signal,
+					isCurrent,
+					onError,
+					onUnsupportedMode,
+				});
+				return;
+			}
+
+			let initialItemId: string | undefined;
+			let initialQuery = "";
+			while (isCurrent()) {
+				const browser = await runCustomInteraction<ToolBrowserResult>(ctx, {
+					signal,
+					isCurrent,
+					onError,
+					onUnsupportedMode,
+					create: ({ tui, theme, keybindings, complete }) =>
+						createToolBrowserComponent({
+							catalog,
+							initialItemId,
+							initialQuery,
+							tui,
+							theme,
+							keybindings,
+							onClose: () => complete({ kind: "close" }),
+							onSelect: complete,
+						}),
+				});
+				if (browser.kind !== "completed" || browser.value.kind === "close") return;
+				const selection = browser.value;
+				initialItemId = selection.itemId;
+				initialQuery = selection.query;
+				const item = catalog.items.find(({ id }) => id === selection.itemId);
+				if (!item) continue;
+				const detail = await runMenu(ctx, createToolDetailMenu(item), {
+					getState: () => undefined,
+					signal,
+					isCurrent,
+					onError,
+					onUnsupportedMode,
+				});
+				if (detail.kind !== "closed" || detail.reason === "close") return;
+			}
 		},
 	});
 }

--- a/packages/pi-tool/test/tool.test.ts
+++ b/packages/pi-tool/test/tool.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
 import { initTheme } from "@earendil-works/pi-coding-agent";
-import { resolveMenuScreen } from "@narumitw/pi-tui-kit";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import toolExtension from "../src/index.js";
-import { createToolCatalog, createToolMenu } from "../src/tool-catalog.js";
+import { createToolCatalog } from "../src/tool-catalog.js";
 
 initTheme("dark", false);
 
@@ -57,44 +58,63 @@ test("catalog lists every tool alphabetically with active state and complete exp
 	const deploy = catalog.items[0];
 	assert.ok(deploy);
 	assert.equal(deploy.description, "Deploy the current project.");
-	assert.deepEqual(deploy.details?.slice(0, 5), [
-		"Source: deploy.ts",
-		"Scope: user",
-		"Origin: package",
-		"Path: /home/test/.pi/extensions/deploy.ts",
-		"Base directory: /home/test/.pi/extensions",
-	]);
-	assert.match(deploy.details?.join("\n") ?? "", /Parameter schema\n\{\n {2}"type": "object"/u);
 	assert.match(
-		deploy.details?.join("\n") ?? "",
+		deploy.detailContent,
+		/Source: deploy\.ts\nScope: user\nOrigin: package\nPath: \/home\/test/u,
+	);
+	assert.match(deploy.detailContent, /Parameter schema\n\{\n {2}"type": "object"/u);
+	assert.match(
+		deploy.detailContent,
 		/Effective prompt snippet\nNone in the current system prompt\./u,
 	);
-	assert.match(deploy.details?.join("\n") ?? "", /Prompt guidelines\nNone/u);
+	assert.match(deploy.detailContent, /Prompt guidelines\nNone/u);
 
 	const read = catalog.items[1];
-	assert.match(read?.details?.join("\n") ?? "", /"required": \[\n {4}"path"\n {2}\]/u);
+	assert.match(read?.detailContent ?? "", /"required": \[\n {4}"path"\n {2}\]/u);
 	assert.match(
-		read?.details?.join("\n") ?? "",
+		read?.detailContent ?? "",
 		/Effective prompt snippet\nRead file contents from the current workspace/u,
 	);
-	assert.match(read?.details?.join("\n") ?? "", /Prompt guidelines\n• Use read before editing/u);
+	assert.match(read?.detailContent ?? "", /Prompt guidelines\n• Use read before editing/u);
 });
 
-test("browse menu exposes searchable list-to-detail progressive disclosure", () => {
-	const menu = createToolMenu();
-	const screen = resolveMenuScreen(menu, "tools", {
-		tools: configuredTools as never,
-		activeToolNames: ["read"],
-		toolSnippets: { read: "Read file contents from the current workspace" },
-	});
-	assert.equal(screen.kind, "browse");
-	if (screen.kind !== "browse") return;
-	assert.equal(screen.viewportSize, "adaptive");
-	assert.equal(screen.hint, "close");
-	assert.match(
-		screen.items.find(({ id }) => id === "read")?.searchText ?? "",
-		/builtin temporary/u,
-	);
+test("TUI browser searches across exposed tool metadata", async () => {
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi);
+	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
+	const tui = createTuiHarness({ width: 100, rows: 24 });
+	const base = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		getSystemPromptOptions: () => ({ cwd: "/home/test/project", toolSnippets: {} }),
+	}).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
+	await tui.waitForOpen();
+	for (const size of [
+		{ width: 60, rows: 16 },
+		{ width: 24, rows: 8 },
+		{ width: 8, rows: 4 },
+		{ width: 1, rows: 1 },
+	]) {
+		const lines = tui.resize(size);
+		assert.ok(lines.length <= Math.max(1, size.rows - 3), `${size.width}x${size.rows}`);
+		assert.ok(
+			lines.every((line) => visibleWidth(line) <= size.width),
+			`${size.width}x${size.rows}`,
+		);
+	}
+	tui.resize({ width: 100, rows: 24 });
+	tui.type("builtin temporary");
+	const frame = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(frame, /read.*\[active\]/u);
+	assert.doesNotMatch(frame, /deploy/u);
+	tui.press("ctrl+c");
+	await running;
 });
 
 test("/tool supports RPC list and detail navigation", async () => {
@@ -134,6 +154,8 @@ test("/tool supports RPC list and detail navigation", async () => {
 		.map(({ title }) => title)
 		.join("\n");
 	assert.match(detailPages, /Parameter schema/u);
+	assert.match(detailPages, /^ {2}"type": "object",$/mu);
+	assert.match(detailPages, /^ {4}"path": \{$/mu);
 	assert.match(detailPages, /Read file contents from the current workspace/u);
 	assert.match(detailPages, /Use read before editing/u);
 	assert.equal(promptOptionReads, 1);
@@ -154,6 +176,45 @@ test("/tool rejects arguments and noninteractive modes before opening the catalo
 	}
 });
 
+test("nested parameter schema indentation survives the TUI detail boundary", async () => {
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi);
+	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
+	const tui = createTuiHarness({ width: 100, rows: 24 });
+	const base = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		getSystemPromptOptions: () => ({ cwd: "/home/test/project", toolSnippets: {} }),
+	}).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
+	await tui.waitForOpen();
+	tui.type("builtin temporary");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	const frame = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(frame, /^ {2}"type": "object",$/mu);
+	assert.match(frame, /^ {4}"path": \{$/mu);
+	const narrowFrame = tui.resize({ width: 20, rows: 24 });
+	assert.ok(narrowFrame.every((line) => visibleWidth(line) <= 20));
+	const narrowText = stripVTControlCharacters(narrowFrame.join("\n"));
+	assert.match(narrowText, /^ {2}"type": "object",$/mu);
+	tui.press("tui.select.pageDown");
+	const scrolledNarrowFrame = tui.render();
+	assert.ok(scrolledNarrowFrame.every((line) => visibleWidth(line) <= 20));
+	assert.match(stripVTControlCharacters(scrolledNarrowFrame.join("\n")), /^ {4}"path": \{$/mu);
+	tui.resize({ width: 100, rows: 24 });
+	tui.press("tui.select.cancel");
+	await tui.waitForOpen();
+	assert.match(stripVTControlCharacters(tui.render().join("\n")), /Search: > builtin temporary/u);
+	tui.press("ctrl+c");
+	await running;
+});
+
 test("terminal controls are stripped by the browse display boundary", async () => {
 	const unsafeTools = [
 		{
@@ -162,23 +223,51 @@ test("terminal controls are stripped by the browse display boundary", async () =
 			description: "Read\u001b[31m file",
 		},
 	];
-	const menu = createToolMenu();
+	const mock = createMockPi({ allTools: unsafeTools as never, activeTools: [] });
+	toolExtension(mock.pi);
+	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
 	const tui = createTuiHarness({ width: 100, rows: 24 });
-	const base = createMockContext({ hasUI: true, mode: "tui" }).ctx as unknown as {
+	const base = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		getSystemPromptOptions: () => ({ cwd: "/home/test/project", toolSnippets: {} }),
+	}).ctx as unknown as {
 		ui: Record<string, unknown>;
 		[key: string]: unknown;
 	};
-	const { runMenu } = await import("@narumitw/pi-tui-kit");
-	const running = runMenu({ ...base, ui: { ...base.ui, custom: tui.custom } } as never, menu, {
-		getState: () => ({ tools: unsafeTools as never, activeToolNames: [], toolSnippets: {} }),
-		isCurrent: () => true,
-	});
+	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
 	await tui.waitForOpen();
 	const frame = tui.render().join("\n");
 	assert.equal(frame.includes("\u001b]0;owned"), false);
 	assert.equal(frame.includes("\u0007"), false);
 	tui.press("ctrl+c");
 	await running;
+});
+
+test("session replacement aborts and disposes an open menu", async () => {
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi);
+	const lifecycle = createMockContext({ hasUI: true, mode: "tui" }).ctx;
+	await mock.events.get("session_start")?.[0]?.({}, lifecycle);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
+	const tui = createTuiHarness({ width: 100, rows: 24 });
+	const base = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		getSystemPromptOptions: () => ({ cwd: "/home/test/project", toolSnippets: {} }),
+	}).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
+	await tui.waitForOpen();
+	await mock.events.get("session_start")?.[0]?.({}, lifecycle);
+	await running;
+	assert.equal(tui.isOpen, false);
+	assert.equal((tui.result as { kind?: unknown } | undefined)?.kind, "stale");
 });
 
 test("session shutdown aborts and disposes an open menu", async () => {
@@ -201,5 +290,6 @@ test("session shutdown aborts and disposes an open menu", async () => {
 	await tui.waitForOpen();
 	await mock.events.get("session_shutdown")?.[0]?.({}, lifecycle);
 	await running;
-	assert.equal((tui.result as { kind?: unknown } | undefined)?.kind, "close");
+	assert.equal(tui.isOpen, false);
+	assert.equal((tui.result as { kind?: unknown } | undefined)?.kind, "stale");
 });


### PR DESCRIPTION
## Summary

- Preserve pretty-printed parameter-schema indentation in both TUI and RPC tool details.
- Keep the searchable TUI catalog while routing exact documents through Pi TUI Kit's cell-aware review renderer.
- Cover narrow widths, terminal controls, RPC navigation, session replacement, shutdown, and search-state restoration.

## Context

Follow-up to #679 because its automated review arrived after that pull request had already merged.
The #679 review thread is answered and resolved with the verified fix commit.

## Verification

- `npx vitest run packages/pi-tool/test/tool.test.ts --testTimeout 10000` — passed 8 tests.
- `npm run check` — passed all validators and 2,888 tests.
- `just pack tool` — passed with the 7 intended publish files.
- `PI_OFFLINE=1 pi -ne -ns -np --no-themes --no-session -e ./packages/pi-tool -p '/tool'` — loaded the extension and produced the expected observable print-mode rejection.
