### PR TITLE
feat(tui-kit): add exact browse details

### DIFF
--- a/.changeset/calm-browsers-document.md
+++ b/.changeset/calm-browsers-document.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add exact text, code, and diff documents to read-only browse item details while preserving legacy prose behavior.

--- a/docs/plans/2026-08-10_pi-tui-kit-browse-detail-document-plan.md
+++ b/docs/plans/2026-08-10_pi-tui-kit-browse-detail-document-plan.md
@@ -1,0 +1,112 @@
+# Pi TUI Kit Browse Detail Document Plan
+
+## Goal
+
+Add an explicit exact-document detail contract to Pi TUI Kit's declarative `browse` screen so JSON, code, diffs, and other whitespace-sensitive content render safely and consistently in TUI and RPC modes without changing legacy prose details.
+
+After the Kit API is published, migrate `pi-tool` back to the standard browse screen and remove its extension-owned browser workaround in a separate consumer pull request.
+
+## Context
+
+`MenuBrowseItem.details` currently accepts prose lines that `browse.ts` passes through `safeBrowseText()`, whose whitespace normalization removes indentation before both TUI wrapping and RPC pagination.
+
+The existing `review` screen already owns the required document boundary in `review.ts`: terminal-control removal, newline normalization, tab expansion, grapheme-aware hard wrapping, syntax or diff formatting, adaptive TUI scrolling, and bounded RPC pages.
+
+`pi-tool` currently preserves schema indentation by owning a searchable TUI component in `packages/pi-tool/src/tool-browser.ts` and routing detail content through a separate review screen.
+
+That workaround is correct and independently publishable, but it duplicates browse search, layout, focus, width, lifecycle, and navigation behavior that belongs in Pi TUI Kit.
+
+The delivery requires at least two implementation pull requests because repository policy requires a new Kit API to be published before a consumer raises its compatibility floor to use it.
+
+## Architecture
+
+Add a public `BrowseDetailDocument` value with `content: string` and optional `format: ReviewFormat`, then add optional `detailDocument` to `MenuBrowseItem` without changing the existing `details` field.
+
+When `detailDocument` is present, it is the complete detail body and takes precedence over `details`; the item label remains the detail title, while the consumer includes any desired status, description, or provenance in the exact document.
+
+When `detailDocument` is absent, the existing generated body of sanitized status, description, and `details` lines remains byte-for-byte compatible at the dialog and rendered-text boundaries.
+
+Keep `detailDocument.content` out of implicit fuzzy-search input because exact documents may be large or sensitive, and require consumers to opt searchable metadata into the existing `searchText` field.
+
+Extract the document sanitization, tab expansion, grapheme segmentation, hard wrapping, plain RPC line generation, and themed text/code/diff formatting from `review.ts` into one package-internal document-formatting module used by both review and browse.
+
+Keep browse list rendering, query and stable-ID restoration, detail scrolling, Back/Close behavior, focus forwarding, adaptive row allocation, and RPC navigation in their existing owners.
+
+Do not expose internal formatter helpers from the package root because consumers need a declarative document contract rather than rendering implementation details.
+
+Advance the declarative menu API compatibility marker, export the new public type, document legacy and exact detail semantics, and record an additive Kit release through Changesets.
+
+## Non-Goals
+
+- Do not change legacy `details` whitespace normalization, ordering, generated status or description lines, search behavior, selection restoration, or exact RPC labels.
+- Do not add browse actions, confirmation, mutation hooks, arbitrary component callbacks, horizontal scrolling, or consumer-owned render functions.
+- Do not make document content implicitly searchable or persist any browse state outside the current menu instance.
+- Do not modify `pi-tool`, raise a consumer dependency floor, publish a package, merge a release pull request, or dispatch a release workflow in the Kit API pull request.
+- Do not migrate another consumer unless it has a confirmed whitespace-sensitive browse detail and can adopt the already-published API independently.
+
+## Execution Evidence
+
+- Branch: `feat/pi-tui-kit-browse-detail-document`, created from `origin/main` at `e4e3abcb`.
+- Preserved pre-existing work: this plan was the only untracked path before implementation.
+- Baseline: `npm run check --workspace @narumitw/pi-tui-kit` passed before production edits.
+- Applicable repository rules: deterministic behavior tests, width-bounded and terminal-safe TUI rendering, IME focus forwarding, Back/Close and disposal preservation, reusable-library packaging, independent Changeset versioning, and publication before consumer adoption.
+- Verification map: package tests cover public types, TUI, RPC, navigation, controls, widths, focus, and disposal; `npm run check:boundaries`, `npm run check`, `git diff --check`, and `just pack tui-kit` cover repository and package gates.
+- Red evidence: the initial Kit typecheck failed only on the absent `BrowseDetailDocument` export, `detailDocument` property, and version-10 contract.
+- Focused evidence: the complete Kit check passed and all 168 Kit tests passed after implementation.
+- Repository evidence: `npm run check:boundaries` passed, and `npm run check` passed with 268 test files and 2,900 tests.
+- Packaging evidence: `just pack tui-kit` built the package and listed 59 manifest-approved files containing the manifest, README, license, built JavaScript, and declarations.
+- Semantic audit: the formatter is stateless and shared; browse still reads live width and rows on every render, clamps scroll after reflow, forwards list focus to the existing `Input`, and retains its existing synchronous Back, Close, cancellation, and disposal ownership.
+- Scope audit: no consumer source, dependency range, lockfile, setting, command, action, or lifecycle implementation changed.
+- Release status: publication and the dependent `pi-tool` migration remain deliberately open because this execution explicitly forbids publishing and repository policy forbids consumer adoption before registry verification.
+- Execution deviation: formatter extraction and browse wiring landed in one working-tree batch rather than two intermediate commits; the unchanged review contract was still verified independently by the focused review suite.
+
+## Plan
+
+### Phase 1: Pi TUI Kit API
+
+- [x] Record the current focused Kit baseline and map the touched public-type, browse TUI, RPC adapter, exact-document, terminal-safety, package, and release rules; verify with the existing package tests and `npm run check --workspace @narumitw/pi-tui-kit` before production edits.
+- [x] Add failing public-contract tests for `BrowseDetailDocument` and `MenuBrowseItem.detailDocument`, including the package root declaration export and the incremented API compatibility literal; verify that typechecking initially fails only because the API is absent.
+- [x] Add failing TUI browse regressions in `packages/pi-tui-kit/test/browse-screen.test.ts` for two- and four-space indentation, tabs, narrow cell widths, CJK or emoji boundaries, terminal controls, scrolling, and query plus raw-ID restoration after returning from an exact detail.
+- [x] Add failing RPC regressions in `packages/pi-tui-kit/test/runtime.test.ts` for exact indentation, deterministic hard wrapping, bounded pagination, sanitized controls, duplicate display labels, Back behavior, and the guarantee that document content never appears in list choices or implicit search metadata.
+- [x] Add legacy characterization tests proving that items using only `details` retain their current normalized TUI text, RPC titles and pages, status and description ordering, empty fallback, navigation, and existing exact scripts.
+- [x] Extract one internal document-formatting module from `review.ts` and make review use it without behavior changes; verify all existing review text, code, diff, width, control, adaptive-height, and RPC pagination tests before wiring browse to it.
+- [x] Update `types.ts`, browse TUI rendering, and RPC browse pagination so `detailDocument` uses the shared exact-document pipeline while legacy `details` stays on the existing prose pipeline; define and test `detailDocument` precedence when both fields are supplied.
+- [x] Audit theme invalidation, syntax highlighting after wrapping, display-cell bounds, empty and very narrow terminals, scroll clamping after resize, IME focus restoration, cancellation, disposal, and stale menu ownership across both detail representations.
+- [x] Update `packages/pi-tui-kit/README.md`, public examples, package-root exports, API compatibility metadata, and type fixtures to describe full-body ownership, explicit `searchText`, mode behavior, precedence, and compatibility with existing browse definitions.
+- [x] Add a Kit-only minor Changeset, run the complete Kit check and tests, `npm run check:boundaries`, the CI-equivalent `npm run check`, `git diff --check`, and `just pack tui-kit`, then inspect the tarball for built JavaScript, declarations, README, license, and manifest only.
+- [x] Audit the final Phase 1 diff against repository conventions and prove that no consumer source or dependency floor adopts the unpublished API.
+
+### Release gate
+
+- [ ] Obtain explicit user approval before merging the Changesets release pull request or otherwise publishing the new Kit release.
+- [ ] Verify the released Kit version, root export, declaration shape, tarball integrity, and registry visibility with `npm view` and a clean temporary install before any consumer migration begins.
+
+### Phase 2: pi-tool consumer migration
+
+- [ ] Create a separate consumer branch from then-current `origin/main`, raise only `pi-tool`'s Kit compatibility floor to the verified published release, run root `npm install`, and prove the lockfile resolves that compatible version within the consumer install scope.
+- [ ] Replace `pi-tool`'s custom TUI browser and separate detail menu loop with the standard Kit `browse` screen using `detailDocument`, while preserving tool ordering, active status, metadata search, fresh command-time state, TUI and RPC navigation, and exact schema content.
+- [ ] Delete `packages/pi-tool/src/tool-browser.ts`, remove direct Pi TUI peer and development dependencies if no production import remains, and update package layout documentation and lockfile metadata.
+- [ ] Keep consumer regressions for TUI and RPC indentation, 20-column wrapping, terminal controls, query restoration, session replacement, shutdown, arguments, and unsupported modes, and add a comparison proving no supported `/tool` behavior regresses.
+- [ ] Add the appropriate `pi-tool` Changeset for its raised compatibility floor and packaged implementation change, then run focused tests, package check, the CI-equivalent root check, `git diff --check`, `just pack tool`, and the local Pi load smoke.
+- [ ] Inspect the final consumer diff for removal of duplicated UI ownership, verify independent installation against the published Kit package, and archive this completed plan only when every phase and release gate has evidence.
+
+## Risks
+
+- A silent global change to `details` would alter existing consumers, so the new exact path must be opt-in and legacy behavior must remain characterized.
+- Allowing both `details` and `detailDocument` creates ambiguity, so the public contract must define `detailDocument` precedence and test it in TUI and RPC.
+- Duplicating review's formatter inside browse would allow sanitization or wrapping behavior to drift, so both screens must share one internal document pipeline.
+- Syntax or diff formatting can become incorrect if it classifies wrapped fragments instead of original source lines, so the shared formatter must preserve the existing source-versus-rendered-segment contract.
+- Exact documents can be large or sensitive, so they must not enter fuzzy-search strings, selector labels, logs, or autocomplete metadata unless the consumer explicitly copies safe metadata into `searchText`.
+- A zero-major Kit range does not cross minor releases, so migrating `pi-tool` before registry publication would pass through local hoisting while failing for independent installs.
+- Simplifying `pi-tool` can accidentally change query restoration or lifecycle cleanup, so the migration must retain behavior-level tests rather than only replacing source structure.
+
+## Completion Checklist
+
+- [x] Browse supports a documented exact full-body detail with text, code, and diff formats in both TUI and RPC modes.
+- [x] Exact details preserve indentation, tabs, Unicode display-cell bounds, terminal safety, scrolling, pagination, Back/Close behavior, query restoration, and stable raw identity.
+- [x] Legacy `details` behavior and existing browse consumers remain compatible without source or dependency changes in the Kit API pull request.
+- [x] Review and browse share one internal document-formatting implementation with no new public rendering helper.
+- [x] Public exports, API compatibility metadata, README, declarations, Changeset intent, package contents, and repository checks agree.
+- [ ] The Kit API is published and registry-verified before `pi-tool` raises its compatibility floor.
+- [ ] `pi-tool` uses the standard browse screen, retains all supported behavior, and no longer owns duplicated browser UI or unnecessary direct Pi TUI dependencies.
+- [ ] The completed plan is archived with all checks, release evidence, consumer migration evidence, deviations, and unverified paths recorded.

--- a/docs/plans/archived/2026-08-10_pi-tui-kit-pr-685-feedback-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-tui-kit-pr-685-feedback-plan.md
@@ -1,0 +1,40 @@
+# Pi TUI Kit Pull Request 685 Feedback Plan
+
+## Goal
+
+Resolve every feedback item on pull request #685 with a verified fix, thread response, signed commit, and push to `feat/pi-tui-kit-browse-detail-document`.
+
+## Context
+
+The exact target is https://github.com/narumiruna/pi-extensions/pull/685 from `feat/pi-tui-kit-browse-detail-document` into `main`.
+The reviewed head was `4a0358bf4dc2cc48d897e4dce5f8fb19de7cc2a9`, and this worktree was clean before feedback work began.
+The pull request had one successful CI check, one submitted Codex review, one unresolved inline thread, and no conversation comments.
+The touched area is synchronous read-only TUI browse and review document rendering in the reusable `pi-tui-kit` library.
+Applicable convention MUST rules are width-bounded and terminal-safe rendering, themed-cache invalidation, deterministic behavior tests, the root CI-equivalent gate, and package inspection because published package source changed.
+Settings, commands, asynchronous work, session replacement, shutdown resources, and extension-owned lifecycle are not touched.
+
+## Review Ledger
+
+| Feedback | Final outcome | Evidence |
+| --- | --- | --- |
+| `browse.ts`: cache exact detail formatting across renders by document content, format, and width, and clear themed output from `invalidate()` | Actionable and addressed | Fix commit `69228f204fddf0ec9d321f54d3c72b93e16e6a68` adds one shared single-entry cache keyed by content, format kind and fields, and width; browse and the same-pattern review path reuse it, and each component clears it from `invalidate()`. Focused regressions prove scroll reuse plus width, content, format, and invalidation recomputation. |
+| Codex submitted-review wrapper for commit `4a0358bf4d` | Outdated or superseded | The wrapper is informational and its single inline finding is tracked separately above. |
+
+## Plan
+
+- [x] Add a focused regression proving unchanged scroll renders reuse exact formatted lines while content, format, width, and invalidation changes recompute them; the new browse assertion failed `24 !== 12` before implementation and passes afterward.
+- [x] Cache exact browse detail formatting at component scope without changing legacy prose, search, navigation, width, terminal-safety, or disposal behavior; the cache retains only one formatted document and validates every output-affecting input.
+- [x] Scan the full pull-request diff and sibling exact-document rendering for the same repeated-formatting pattern; review rendering had the same render-time work, so both components now use the shared internal cache and review has its own reuse and invalidation regression.
+- [x] Run verification sequentially where Kit build output is shared; 20 focused browse and review tests, all 170 Kit tests, the complete Kit check, final root `npm run check` with 268 files and 2,902 tests, `git diff --check`, and the 59-file `just pack tui-kit` dry run pass. The first Kit-suite attempt correctly exposed missing built output and passed after the required Kit build. The first two root runs exposed unrelated timing failures in `pi-sync` and `pi-worktree`; each passed alone, and the clean final root rerun passed completely.
+- [x] Re-read all pull-request reviews, inline comments, conversation comments, and thread state; no new feedback appeared, the final diff has no whitespace errors, and an independent scoped reviewer reported no confirmed findings.
+- [x] Reply to and resolve the inline thread only after verification; reply `discussion_r3751124751` cites the implementation and passing checks, and GraphQL confirmed thread `PRRT_kwDOSW8GGM6X7tkG` is resolved.
+- [x] Stage only the five implementation and regression files, create signed conventional fix commit `69228f204fddf0ec9d321f54d3c72b93e16e6a68`, and push it without rewriting history. Archive this completed ledger in a separate signed documentation commit, push it, then perform the required single post-push pull-request refresh.
+
+## Completion Checklist
+
+- [x] Every feedback item has an evidence-backed final outcome.
+- [x] Scroll-only renders no longer reformat unchanged exact documents.
+- [x] Cache invalidation and changed document inputs cannot reuse stale themed output.
+- [x] Required tests, checks, and package inspection pass.
+- [x] The review thread is answered and resolved only after verification.
+- [x] The signed fix commit is pushed without rewriting history.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -287,7 +287,7 @@ const result = await runCustomInteraction<{ kind: "back" | "close" }>(ctx, {
   adaptive long-label columns, and disabled explanations.
 - **`detail`** — read-only wrapped text with Back or Close behavior.
 - **`browse`** — a read-only searchable catalog with textual status, adaptive list/detail views,
-  stable selection restoration, and paginated RPC details.
+  stable selection restoration, legacy prose or exact document details, and paginated RPC details.
 - **`choice`** — one confirmed value from a static list, with separate current and initial items,
   selected details, disabled explanations, and a bounded viewport.
 - **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes,
@@ -368,6 +368,20 @@ row budget; a positive number caps item rows without disabling terminal bounds. 
 keeps one deterministic unfiltered list, then presents bounded detail pages; `searchText` is never
 rendered.
 
+Use `details` for legacy prose lines. The Kit normalizes their whitespace and prepends available
+status and description text. Use `detailDocument` for a complete whitespace-sensitive body such as
+JSON, source code, or a diff. Its `content` preserves indentation, expands tabs to four-column stops,
+hard-wraps by terminal cells, strips terminal controls, and uses the same optional text, code, or diff
+`format` as a review screen. When both fields are present, `detailDocument` is the complete body and
+takes precedence over `details`, status, and description inside the detail body. The item label still
+names the detail, while status and description remain available in list presentation. RPC retains the
+existing status-bearing selector label as the dialog title for compatibility, but does not prepend a
+second status line to the exact body.
+
+Exact document content is never added to fuzzy-search metadata or RPC selector labels. Copy only safe,
+intentional aliases or metadata into `searchText`; do not copy a large or sensitive document merely
+to make it searchable.
+
 ```ts
 const modulesScreen = {
   kind: "browse" as const,
@@ -384,6 +398,20 @@ const modulesScreen = {
     ],
   })),
   viewportSize: "adaptive" as const,
+};
+
+const schemasScreen = {
+  kind: "browse" as const,
+  title: "Schemas",
+  items: schemas.map((schema) => ({
+    id: schema.name,
+    label: schema.name,
+    searchText: schema.description,
+    detailDocument: {
+      content: JSON.stringify(schema.value, null, 2),
+      format: { kind: "code" as const, language: "json" },
+    },
+  })),
 };
 ```
 
@@ -558,8 +586,8 @@ The library owns:
 - serial settings and multi-select updates, optimistic rollback, and pending-update draining;
 - menu, screen, and busy-action cancellation;
 - stale-continuation checks around asynchronous work;
-- input draft/pending behavior and exact review formatting, scrolling, and RPC pagination;
-- read-only browse search, list/detail disclosure, cursor restoration, and RPC pagination;
+- input draft/pending behavior and shared exact-document formatting, scrolling, and RPC pagination;
+- read-only browse search, legacy or exact detail disclosure, cursor restoration, and RPC pagination;
 - TUI/RPC adaptation and unsupported-mode routing.
 
 The consuming extension still owns:
@@ -655,18 +683,20 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
   work draining, and typed results around one extension-owned custom TUI component.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
 - `createMenuNavigator()` — lower-level stack and selection state helper.
-- exported screen, item, action, transition, runtime option, `MenuCloseReason`, and result types.
+- exported screen, item, action, transition, runtime option, `BrowseDetailDocument`,
+  `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
   strict scripts, and their public testing types; it is not re-exported from the production root.
-- `PI_EXTENSION_MENU_API_VERSION` — current API version (`9`). Version 9 adds `runLiveChoice()` and
-  `formatInteractionHints()` while version-8 menu definitions remain valid. Version 8 added disabled
-  action reasons and adaptive action-label columns, version 7 added `runConfirmation()`, and version
-  6 added the read-only `browse` screen and `runCustomInteraction()`.
+- `PI_EXTENSION_MENU_API_VERSION` — current API version (`10`). Version 10 adds exact browse detail
+  documents while version-9 menu definitions remain valid. Version 9 added `runLiveChoice()` and
+  `formatInteractionHints()`, version 8 added disabled action reasons and adaptive action-label
+  columns, version 7 added `runConfirmation()`, and version 6 added the read-only `browse` screen and
+  `runCustomInteraction()`.
 
 ## 🗂️ Package layout
 
 - `src/` — authored TypeScript and the public package entrypoint
-- `src/components/` — internal TUI input, review, list, settings, and rendering adapters
+- `src/components/` — internal TUI input, browse, review, exact-document, settings, and rendering adapters
 - `src/testing/` — supported TUI/RPC test drivers exported only through the `/testing` subpath
 - `src/task.ts` — standalone and menu-shared task lifecycle orchestration
 - `src/confirmation.ts` — standalone confirmation mode adaptation and lifecycle results

--- a/packages/pi-tui-kit/src/components/browse.ts
+++ b/packages/pi-tui-kit/src/components/browse.ts
@@ -12,6 +12,12 @@ import {
 import { formatInteractionHints } from "../interaction-hints.js";
 import type { MenuBrowseItem } from "../types.js";
 import type { BrowseOptions, MenuKeybindings, MenuScreenComponent } from "./contracts.js";
+import {
+	documentDialogPages,
+	formatDocumentLines,
+	RPC_DOCUMENT_LINE_WIDTH,
+	RPC_DOCUMENT_PAGE_SIZE,
+} from "./document-formatting.js";
 import { handleSearchInput, safeMenuText } from "./rendering.js";
 import { reviewDialogPages } from "./review.js";
 
@@ -107,7 +113,7 @@ export function createBrowseComponent<ScreenId extends string, ActionId extends 
 			const safeWidth = Math.max(1, width);
 			const availableRows = componentRows(options.tui.terminal.rows);
 			if (view === "detail") {
-				const content = detailLines(selected()?.item, safeWidth);
+				const content = detailLines(selected()?.item, safeWidth, options.theme);
 				const layout = detailLayout(availableRows, content.length);
 				detailViewportRows = layout.contentRows;
 				detailMaximumScroll = Math.max(0, content.length - layout.contentRows);
@@ -264,8 +270,20 @@ function listRows<ScreenId extends string, ActionId extends string>(
 	});
 }
 
-function detailLines(item: MenuBrowseItem | undefined, width: number): string[] {
+function detailLines<ScreenId extends string, ActionId extends string>(
+	item: MenuBrowseItem | undefined,
+	width: number,
+	theme: BrowseOptions<ScreenId, ActionId>["theme"],
+): string[] {
 	if (!item) return ["No matching item."];
+	if (item.detailDocument) {
+		return formatDocumentLines(
+			item.detailDocument.content,
+			item.detailDocument.format,
+			width,
+			theme,
+		);
+	}
 	return browseDetailSource(item).flatMap((line) => (line ? wrapTextWithAnsi(line, width) : [""]));
 }
 
@@ -276,6 +294,13 @@ export function browseDialogLabel(item: MenuBrowseItem) {
 }
 
 export function browseDialogPages(item: MenuBrowseItem) {
+	if (item.detailDocument) {
+		return documentDialogPages(
+			item.detailDocument.content,
+			RPC_DOCUMENT_LINE_WIDTH,
+			RPC_DOCUMENT_PAGE_SIZE,
+		);
+	}
 	return reviewDialogPages({
 		kind: "review",
 		title: safeBrowseText(item.label),

--- a/packages/pi-tui-kit/src/components/browse.ts
+++ b/packages/pi-tui-kit/src/components/browse.ts
@@ -13,8 +13,8 @@ import { formatInteractionHints } from "../interaction-hints.js";
 import type { MenuBrowseItem } from "../types.js";
 import type { BrowseOptions, MenuKeybindings, MenuScreenComponent } from "./contracts.js";
 import {
+	createDocumentLineCache,
 	documentDialogPages,
-	formatDocumentLines,
 	RPC_DOCUMENT_LINE_WIDTH,
 	RPC_DOCUMENT_PAGE_SIZE,
 } from "./document-formatting.js";
@@ -59,6 +59,7 @@ export function createBrowseComponent<ScreenId extends string, ActionId extends 
 	let view: BrowseView = "list";
 	let focused = false;
 	let disposed = false;
+	const detailLineCache = createDocumentLineCache(options.theme);
 	const selected = () => filteredItems[selectedIndex];
 	const syncFocus = () => {
 		searchInput.focused = focused && view === "list" && searchInputVisible;
@@ -113,7 +114,14 @@ export function createBrowseComponent<ScreenId extends string, ActionId extends 
 			const safeWidth = Math.max(1, width);
 			const availableRows = componentRows(options.tui.terminal.rows);
 			if (view === "detail") {
-				const content = detailLines(selected()?.item, safeWidth, options.theme);
+				const selectedItem = selected()?.item;
+				const content = selectedItem?.detailDocument
+					? detailLineCache.lines(
+							selectedItem.detailDocument.content,
+							selectedItem.detailDocument.format,
+							safeWidth,
+						)
+					: legacyDetailLines(selectedItem, safeWidth);
 				const layout = detailLayout(availableRows, content.length);
 				detailViewportRows = layout.contentRows;
 				detailMaximumScroll = Math.max(0, content.length - layout.contentRows);
@@ -186,6 +194,7 @@ export function createBrowseComponent<ScreenId extends string, ActionId extends 
 			return boundedLines(lines, safeWidth, availableRows);
 		},
 		invalidate() {
+			detailLineCache.invalidate();
 			searchInput.invalidate();
 		},
 		handleInput(data) {
@@ -270,20 +279,8 @@ function listRows<ScreenId extends string, ActionId extends string>(
 	});
 }
 
-function detailLines<ScreenId extends string, ActionId extends string>(
-	item: MenuBrowseItem | undefined,
-	width: number,
-	theme: BrowseOptions<ScreenId, ActionId>["theme"],
-): string[] {
+function legacyDetailLines(item: MenuBrowseItem | undefined, width: number): string[] {
 	if (!item) return ["No matching item."];
-	if (item.detailDocument) {
-		return formatDocumentLines(
-			item.detailDocument.content,
-			item.detailDocument.format,
-			width,
-			theme,
-		);
-	}
 	return browseDetailSource(item).flatMap((line) => (line ? wrapTextWithAnsi(line, width) : [""]));
 }
 

--- a/packages/pi-tui-kit/src/components/document-formatting.ts
+++ b/packages/pi-tui-kit/src/components/document-formatting.ts
@@ -1,0 +1,115 @@
+import { stripVTControlCharacters } from "node:util";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { ReviewFormat } from "../types.js";
+import { getLanguageFromPath, highlightCode } from "./syntax-highlighting.js";
+
+export const RPC_DOCUMENT_LINE_WIDTH = 120;
+export const RPC_DOCUMENT_PAGE_SIZE = 8;
+
+const TAB_SIZE = 4;
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+type DocumentTheme = Pick<Theme, "fg" | "bold">;
+
+export function formatDocumentLines(
+	content: string,
+	format: ReviewFormat | undefined,
+	width: number,
+	theme: DocumentTheme,
+): string[] {
+	const segments = documentSegments(content, width);
+	const resolvedFormat = format ?? { kind: "text" as const };
+	if (resolvedFormat.kind === "code") {
+		const language =
+			resolvedFormat.language ??
+			(resolvedFormat.filePath ? getLanguageFromPath(resolvedFormat.filePath) : undefined);
+		return segments.map(({ text }) => highlightCode(text, language, theme));
+	}
+	if (resolvedFormat.kind === "diff") {
+		return segments.map(({ source, text }) => {
+			if (source.startsWith("@@")) return theme.fg("accent", text);
+			if (source.startsWith("+") && !source.startsWith("+++")) {
+				return theme.fg("toolDiffAdded", text);
+			}
+			if (source.startsWith("-") && !source.startsWith("---")) {
+				return theme.fg("toolDiffRemoved", text);
+			}
+			return theme.fg("toolDiffContext", text);
+		});
+	}
+	return segments.map(({ text }) => theme.fg("text", text));
+}
+
+export function plainDocumentLines(content: string, width: number): string[] {
+	return documentSegments(content, width).map(({ text }) => text);
+}
+
+export function documentDialogPages(content: string, width: number, pageSize: number): string[][] {
+	const lines = plainDocumentLines(content, width);
+	const safePageSize = Math.max(1, Math.floor(pageSize));
+	const pages: string[][] = [];
+	for (let index = 0; index < lines.length; index += safePageSize) {
+		pages.push(lines.slice(index, index + safePageSize));
+	}
+	return pages.length > 0 ? pages : [[""]];
+}
+
+export function sanitizeDocumentText(value: unknown): string {
+	const stripped = stripVTControlCharacters(String(value)).replace(/\r\n?/gu, "\n");
+	return Array.from(stripped, (character) => {
+		if (character === "\n" || character === "\t") return character;
+		const codePoint = character.codePointAt(0) ?? 0;
+		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+	}).join("");
+}
+
+function documentSegments(content: string, width: number) {
+	const safe = sanitizeDocumentText(content);
+	return safe.split("\n").flatMap((line) => {
+		const source = expandTabs(line);
+		return hardWrapLine(source, width).map((text) => ({ source, text }));
+	});
+}
+
+function expandTabs(line: string): string {
+	let column = 0;
+	let result = "";
+	for (const { segment } of graphemeSegmenter.segment(line)) {
+		if (segment === "\t") {
+			const count = TAB_SIZE - (column % TAB_SIZE);
+			result += " ".repeat(count);
+			column += count;
+			continue;
+		}
+		result += segment;
+		column += visibleWidth(segment);
+	}
+	return result;
+}
+
+function hardWrapLine(line: string, width: number): string[] {
+	const safeWidth = Math.max(1, width);
+	if (line.length === 0) return [""];
+	const lines: string[] = [];
+	let current = "";
+	let currentWidth = 0;
+	const flush = () => {
+		lines.push(current);
+		current = "";
+		currentWidth = 0;
+	};
+	for (const { segment } of graphemeSegmenter.segment(line)) {
+		const segmentWidth = visibleWidth(segment);
+		if (segmentWidth > safeWidth) {
+			if (current.length > 0) flush();
+			lines.push("?".repeat(safeWidth));
+			continue;
+		}
+		if (currentWidth + segmentWidth > safeWidth && current.length > 0) flush();
+		current += segment;
+		currentWidth += segmentWidth;
+	}
+	if (current.length > 0 || lines.length === 0) lines.push(current);
+	return lines;
+}

--- a/packages/pi-tui-kit/src/components/document-formatting.ts
+++ b/packages/pi-tui-kit/src/components/document-formatting.ts
@@ -12,6 +12,46 @@ const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme
 
 type DocumentTheme = Pick<Theme, "fg" | "bold">;
 
+export function createDocumentLineCache(theme: DocumentTheme) {
+	let cached:
+		| {
+				content: string;
+				formatKind: ReviewFormat["kind"];
+				language: string | undefined;
+				filePath: string | undefined;
+				width: number;
+				lines: string[];
+		  }
+		| undefined;
+	return {
+		lines(content: string, format: ReviewFormat | undefined, width: number) {
+			const identity = documentFormatIdentity(format);
+			if (
+				cached?.content === content &&
+				cached.formatKind === identity.kind &&
+				cached.language === identity.language &&
+				cached.filePath === identity.filePath &&
+				cached.width === width
+			) {
+				return cached.lines;
+			}
+			const lines = formatDocumentLines(content, format, width, theme);
+			cached = {
+				content,
+				formatKind: identity.kind,
+				language: identity.language,
+				filePath: identity.filePath,
+				width,
+				lines,
+			};
+			return lines;
+		},
+		invalidate() {
+			cached = undefined;
+		},
+	};
+}
+
 export function formatDocumentLines(
 	content: string,
 	format: ReviewFormat | undefined,
@@ -53,6 +93,16 @@ export function documentDialogPages(content: string, width: number, pageSize: nu
 		pages.push(lines.slice(index, index + safePageSize));
 	}
 	return pages.length > 0 ? pages : [[""]];
+}
+
+function documentFormatIdentity(format: ReviewFormat | undefined) {
+	if (format?.kind === "code") {
+		return { kind: format.kind, language: format.language, filePath: format.filePath };
+	}
+	if (format?.kind === "diff") {
+		return { kind: format.kind, language: undefined, filePath: format.filePath };
+	}
+	return { kind: "text" as const, language: undefined, filePath: undefined };
 }
 
 export function sanitizeDocumentText(value: unknown): string {

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -1,26 +1,20 @@
-import { stripVTControlCharacters } from "node:util";
-import {
-	Key,
-	matchesKey,
-	truncateToWidth,
-	visibleWidth,
-	wrapTextWithAnsi,
-} from "@earendil-works/pi-tui";
+import { Key, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { MenuScreen, ReviewScreen } from "../types.js";
 import type {
 	MenuKeybindings,
 	MenuScreenComponent,
 	MenuScreenComponentOptions,
 } from "./contracts.js";
+import {
+	documentDialogPages,
+	formatDocumentLines,
+	RPC_DOCUMENT_LINE_WIDTH,
+	RPC_DOCUMENT_PAGE_SIZE,
+} from "./document-formatting.js";
 import { menuHint, renderFrame, safeMenuText } from "./rendering.js";
-import { getLanguageFromPath, highlightCode } from "./syntax-highlighting.js";
 
 const DEFAULT_REVIEW_VIEWPORT_SIZE = 14;
-const RPC_REVIEW_VIEWPORT_SIZE = 8;
-const RPC_REVIEW_LINE_WIDTH = 120;
 const RESERVED_HOST_ROWS = 3;
-const TAB_SIZE = 4;
-const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 export type ReviewOptions<
 	ScreenId extends string,
@@ -285,13 +279,7 @@ function reviewBindingText(
 export function reviewDialogPages<ActionId extends string>(
 	screen: ReviewScreen<ActionId>,
 ): string[][] {
-	const lines = plainReviewLines(screen.content, RPC_REVIEW_LINE_WIDTH);
-	const pageSize = reviewDialogPageSize(screen);
-	const pages: string[][] = [];
-	for (let index = 0; index < lines.length; index += pageSize) {
-		pages.push(lines.slice(index, index + pageSize));
-	}
-	return pages.length > 0 ? pages : [[""]];
+	return documentDialogPages(screen.content, RPC_DOCUMENT_LINE_WIDTH, reviewDialogPageSize(screen));
 }
 
 function formatReviewLines<ActionId extends string>(
@@ -299,89 +287,7 @@ function formatReviewLines<ActionId extends string>(
 	width: number,
 	theme: MenuScreenComponentOptions<string, ActionId>["theme"],
 ): string[] {
-	const segments = reviewSegments(screen.content, width);
-	const format = screen.format ?? { kind: "text" as const };
-	if (format.kind === "code") {
-		const language =
-			format.language ?? (format.filePath ? getLanguageFromPath(format.filePath) : undefined);
-		return segments.map(({ text }) => highlightCode(text, language, theme));
-	}
-	if (format.kind === "diff") {
-		return segments.map(({ source, text }) => {
-			if (source.startsWith("@@")) return theme.fg("accent", text);
-			if (source.startsWith("+") && !source.startsWith("+++")) {
-				return theme.fg("toolDiffAdded", text);
-			}
-			if (source.startsWith("-") && !source.startsWith("---")) {
-				return theme.fg("toolDiffRemoved", text);
-			}
-			return theme.fg("toolDiffContext", text);
-		});
-	}
-	return segments.map(({ text }) => theme.fg("text", text));
-}
-
-function plainReviewLines(content: string, width: number): string[] {
-	return reviewSegments(content, width).map(({ text }) => text);
-}
-
-function reviewSegments(content: string, width: number) {
-	const safe = sanitizeDocumentText(content);
-	return safe.split("\n").flatMap((line) => {
-		const source = expandTabs(line);
-		return hardWrapLine(source, width).map((text) => ({ source, text }));
-	});
-}
-
-export function sanitizeDocumentText(value: unknown): string {
-	const stripped = stripVTControlCharacters(String(value)).replace(/\r\n?/gu, "\n");
-	return Array.from(stripped, (character) => {
-		if (character === "\n" || character === "\t") return character;
-		const codePoint = character.codePointAt(0) ?? 0;
-		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
-	}).join("");
-}
-
-function expandTabs(line: string): string {
-	let column = 0;
-	let result = "";
-	for (const { segment } of graphemeSegmenter.segment(line)) {
-		if (segment === "\t") {
-			const count = TAB_SIZE - (column % TAB_SIZE);
-			result += " ".repeat(count);
-			column += count;
-			continue;
-		}
-		result += segment;
-		column += visibleWidth(segment);
-	}
-	return result;
-}
-
-function hardWrapLine(line: string, width: number): string[] {
-	const safeWidth = Math.max(1, width);
-	if (line.length === 0) return [""];
-	const lines: string[] = [];
-	let current = "";
-	let currentWidth = 0;
-	const flush = () => {
-		lines.push(current);
-		current = "";
-		currentWidth = 0;
-	};
-	for (const { segment } of graphemeSegmenter.segment(line)) {
-		const segmentWidth = visibleWidth(segment);
-		if (segmentWidth > safeWidth) {
-			if (current.length > 0) flush();
-			lines.push("?".repeat(safeWidth));
-			continue;
-		}
-		if (currentWidth + segmentWidth > safeWidth && current.length > 0) flush();
-		current += segment;
-		currentWidth += segmentWidth;
-	}
-	if (current.length > 0 || lines.length === 0) lines.push(current);
-	return lines;
+	return formatDocumentLines(screen.content, screen.format, width, theme);
 }
 
 function reviewViewportSize<ActionId extends string>(screen: ReviewScreen<ActionId>) {
@@ -392,6 +298,6 @@ function reviewViewportSize<ActionId extends string>(screen: ReviewScreen<Action
 
 function reviewDialogPageSize<ActionId extends string>(screen: ReviewScreen<ActionId>) {
 	return typeof screen.viewportSize === "number"
-		? Math.min(screen.viewportSize, RPC_REVIEW_VIEWPORT_SIZE)
-		: RPC_REVIEW_VIEWPORT_SIZE;
+		? Math.min(screen.viewportSize, RPC_DOCUMENT_PAGE_SIZE)
+		: RPC_DOCUMENT_PAGE_SIZE;
 }

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -6,8 +6,8 @@ import type {
 	MenuScreenComponentOptions,
 } from "./contracts.js";
 import {
+	createDocumentLineCache,
 	documentDialogPages,
-	formatDocumentLines,
 	RPC_DOCUMENT_LINE_WIDTH,
 	RPC_DOCUMENT_PAGE_SIZE,
 } from "./document-formatting.js";
@@ -30,6 +30,7 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 	let lastMaximumScroll = 0;
 	let lastViewportSize = reviewViewportSize(options.screen);
 	let disposed = false;
+	const documentLineCache = createDocumentLineCache(options.theme);
 
 	const moveTo = (offset: number) => {
 		scrollOffset = Math.max(0, Math.min(offset, lastMaximumScroll));
@@ -39,7 +40,11 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 	return {
 		render(width) {
 			const safeWidth = Math.max(1, width);
-			const allLines = formatReviewLines(options.screen, safeWidth, options.theme);
+			const allLines = documentLineCache.lines(
+				options.screen.content,
+				options.screen.format,
+				safeWidth,
+			);
 			const terminalRows =
 				options.screen.viewportSize === "adaptive" ? options.tui.terminal.rows : undefined;
 			if (terminalRows !== undefined && Number.isFinite(terminalRows)) {
@@ -79,7 +84,9 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 				options.screen.confirm ? safeMenuText(options.screen.confirm.label) : "",
 			);
 		},
-		invalidate() {},
+		invalidate() {
+			documentLineCache.invalidate();
+		},
 		handleInput(data) {
 			if (disposed) return;
 			if (matchesKey(data, Key.ctrl("c"))) options.onEvent({ kind: "close" });
@@ -280,14 +287,6 @@ export function reviewDialogPages<ActionId extends string>(
 	screen: ReviewScreen<ActionId>,
 ): string[][] {
 	return documentDialogPages(screen.content, RPC_DOCUMENT_LINE_WIDTH, reviewDialogPageSize(screen));
-}
-
-function formatReviewLines<ActionId extends string>(
-	screen: ReviewScreen<ActionId>,
-	width: number,
-	theme: MenuScreenComponentOptions<string, ActionId>["theme"],
-): string[] {
-	return formatDocumentLines(screen.content, screen.format, width, theme);
 }
 
 function reviewViewportSize<ActionId extends string>(screen: ReviewScreen<ActionId>) {

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -31,6 +31,7 @@ export { type RunTaskOptions, type RunTaskResult, runTask } from "./task.js";
 export type {
 	ActionMenuItem,
 	ActionsScreen,
+	BrowseDetailDocument,
 	BrowseScreen,
 	ChoiceScreen,
 	DetailScreen,
@@ -56,4 +57,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 9;
+export const PI_EXTENSION_MENU_API_VERSION = 10;

--- a/packages/pi-tui-kit/src/types.ts
+++ b/packages/pi-tui-kit/src/types.ts
@@ -90,15 +90,29 @@ export interface ChoiceScreen<ActionId extends string> {
 	hint?: "back" | "close";
 }
 
+export type ReviewFormat =
+	| { kind: "text" }
+	| { kind: "code"; language?: string; filePath?: string }
+	| { kind: "diff"; filePath?: string };
+
+/** Exact full-body content for a browse detail view. */
+export interface BrowseDetailDocument {
+	content: string;
+	format?: ReviewFormat;
+}
+
 export interface MenuBrowseItem {
 	id: string;
 	label: string;
 	description?: string;
-	/** Textual state shown with the row and in detail. */
+	/** Textual state shown with the row and in legacy detail. */
 	statusText?: string;
 	/** Additional non-rendered text used by TUI fuzzy search. */
 	searchText?: string;
+	/** Legacy prose lines normalized for display. Ignored when detailDocument is present. */
 	details?: readonly string[];
+	/** Exact full detail body. Content is not included in fuzzy search. */
+	detailDocument?: BrowseDetailDocument;
 }
 
 export interface BrowseScreen {
@@ -134,11 +148,6 @@ export interface InputScreen<ActionId extends string> {
 }
 
 export const MAX_REVIEW_VIEWPORT_SIZE = 50;
-
-export type ReviewFormat =
-	| { kind: "text" }
-	| { kind: "code"; language?: string; filePath?: string }
-	| { kind: "diff"; filePath?: string };
 
 export interface ReviewConfirmation<ActionId extends string> {
 	id: string;

--- a/packages/pi-tui-kit/test/browse-screen.test.ts
+++ b/packages/pi-tui-kit/test/browse-screen.test.ts
@@ -8,7 +8,7 @@ import {
 	type MenuScreenComponent,
 	type MenuScreenEvent,
 } from "../src/components/index.js";
-import type { MenuScreen } from "../src/types.js";
+import type { BrowseDetailDocument, MenuBrowseItem, MenuScreen } from "../src/types.js";
 
 initTheme("dark", false);
 
@@ -269,6 +269,52 @@ test("browse exact details apply shared code and diff formatting", () => {
 	assert.match(rendered, /accent:@@ header/u);
 });
 
+test("browse caches exact detail formatting until its inputs or theme change", () => {
+	const colorCalls: string[] = [];
+	const detailDocument: BrowseDetailDocument = {
+		content: Array.from({ length: 12 }, (_, index) => `document line ${index + 1}`).join("\n"),
+		format: { kind: "text" },
+	};
+	const item: MenuBrowseItem = { id: "document", label: "Document", detailDocument };
+	const harness = componentHarness(
+		{ kind: "browse", title: "Documents", items: [item] },
+		{ rows: 10, onColor: (color) => colorCalls.push(color) },
+	);
+	harness.component.handleInput("y");
+
+	harness.component.render(40);
+	const initialTextCalls = colorCalls.filter((color) => color === "text").length;
+	assert.equal(initialTextCalls, 12);
+	harness.component.handleInput("j");
+	harness.component.render(40);
+	assert.equal(colorCalls.filter((color) => color === "text").length, initialTextCalls);
+
+	harness.component.render(12);
+	const resizedTextCalls = colorCalls.filter((color) => color === "text").length;
+	assert.ok(resizedTextCalls > initialTextCalls);
+	harness.component.render(12);
+	assert.equal(colorCalls.filter((color) => color === "text").length, resizedTextCalls);
+
+	detailDocument.content += "\nchanged content";
+	harness.component.render(12);
+	const changedContentCalls = colorCalls.filter((color) => color === "text").length;
+	assert.ok(changedContentCalls > resizedTextCalls);
+
+	detailDocument.format = { kind: "diff" };
+	harness.component.render(12);
+	const changedFormatCalls = colorCalls.filter((color) => color === "toolDiffContext").length;
+	assert.ok(changedFormatCalls > 0);
+	harness.component.render(12);
+	assert.equal(
+		colorCalls.filter((color) => color === "toolDiffContext").length,
+		changedFormatCalls,
+	);
+
+	harness.component.invalidate();
+	harness.component.render(12);
+	assert.ok(colorCalls.filter((color) => color === "toolDiffContext").length > changedFormatCalls);
+});
+
 test("browse is adaptively bounded, handles empty searches, and distinguishes Back from Close", () => {
 	const harness = componentHarness(browseScreen(), { rows: 10 });
 	for (const { width, rows } of [
@@ -316,7 +362,12 @@ function plainRender(component: MenuScreenComponent, width: number) {
 
 function componentHarness(
 	screen: MenuScreen<ScreenId, ActionId>,
-	options: { rows?: number; selectedItemId?: string; themed?: boolean } = {},
+	options: {
+		rows?: number;
+		selectedItemId?: string;
+		themed?: boolean;
+		onColor?: (color: string) => void;
+	} = {},
 ) {
 	const events: MenuScreenEvent[] = [];
 	const selectionChanges: string[] = [];
@@ -326,7 +377,10 @@ function componentHarness(
 		selectedItemId: options.selectedItemId,
 		tui: host,
 		theme: {
-			fg: (color: string, text: string) => (options.themed ? `${color}:${text}` : text),
+			fg: (color: string, text: string) => {
+				options.onColor?.(color);
+				return options.themed ? `${color}:${text}` : text;
+			},
 			bold: (text: string) => text,
 		},
 		keybindings,

--- a/packages/pi-tui-kit/test/browse-screen.test.ts
+++ b/packages/pi-tui-kit/test/browse-screen.test.ts
@@ -114,6 +114,161 @@ test("browse searches catalog metadata and preserves query and selection across 
 	assert.equal(harness.component.render(48).join("\n").includes(CURSOR_MARKER), true);
 });
 
+test("browse legacy details retain normalized ordering and empty fallback", () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "browse",
+		title: "Legacy browse",
+		items: [
+			{
+				id: "legacy",
+				label: "Legacy",
+				statusText: "  Ready   state  ",
+				description: " Legacy\tdescription ",
+				details: ["  nested   prose  ", ""],
+			},
+			{ id: "empty", label: "Empty" },
+		],
+		hint: "back",
+	};
+	const harness = componentHarness(screen, { rows: 24, selectedItemId: "legacy" });
+	harness.component.handleInput("y");
+	assert.deepEqual(plainRender(harness.component, 80), [
+		"Legacy",
+		"Status: Ready state",
+		"Legacy description",
+		"nested prose",
+		"",
+		"k/j scroll · u/d page · q back · ctrl+c close",
+	]);
+	harness.component.handleInput("q");
+	harness.component.handleInput("j");
+	harness.component.handleInput("y");
+	assert.match(plainRender(harness.component, 80).join("\n"), /No details available\./u);
+});
+
+test("browse exact details preserve documents, precedence, search identity, and scrolling", () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "browse",
+		title: "Schemas",
+		items: [
+			{
+				id: "schema-alpha",
+				label: "Schema",
+				searchText: "alpha",
+				detailDocument: { content: "private-document-token" },
+			},
+			{
+				id: "schema-beta",
+				label: "Schema",
+				statusText: "Ready",
+				description: "Legacy description",
+				searchText: "beta alias",
+				details: ["legacy detail must not render"],
+				detailDocument: {
+					content: [
+						"  two spaces",
+						"    four spaces",
+						"\ttabbed",
+						"你🙂wide",
+						"unsafe\u001b]8;;https://unsafe.example\u0007text",
+						...Array.from({ length: 10 }, (_, index) => `tail ${index + 1}`),
+					].join("\n"),
+					format: { kind: "text" },
+				},
+			},
+		],
+		viewportSize: "adaptive",
+		hint: "back",
+	};
+	const harness = componentHarness(screen, { rows: 14, selectedItemId: "schema-alpha" });
+	const focusable = harness.component as MenuScreenComponent & Focusable;
+	focusable.focused = true;
+	for (const input of "beta") harness.component.handleInput(input);
+	assert.equal(harness.selectionChanges.at(-1), "schema-beta");
+
+	harness.component.handleInput("y");
+	let rendered = plainRender(harness.component, 40).join("\n");
+	assert.match(rendered, /^Schemas?$/mu);
+	assert.match(rendered, /^ {2}two spaces$/mu);
+	assert.match(rendered, /^ {4}four spaces$/mu);
+	assert.match(rendered, /^ {4}tabbed$/mu);
+	assert.match(rendered, /^你🙂wide$/mu);
+	assert.doesNotMatch(rendered, /Status:|Legacy description|legacy detail must not render/u);
+	assert.equal(harness.component.render(40).join("\n").includes("https://unsafe.example"), false);
+	assert.equal(
+		harness.component.render(8).every((line) => visibleWidth(line) <= 8),
+		true,
+	);
+
+	const graphemes = componentHarness(
+		{
+			kind: "browse",
+			title: "Wide",
+			items: [{ id: "wide", label: "Wide", detailDocument: { content: "你🙂x" } }],
+		} as MenuScreen<ScreenId, ActionId>,
+		{ rows: 24 },
+	);
+	graphemes.component.handleInput("y");
+	const narrow = plainRender(graphemes.component, 2);
+	assert.equal(narrow.includes("你"), true);
+	assert.equal(narrow.includes("🙂"), true);
+	assert.equal(narrow.includes("x"), true);
+	assert.equal(
+		narrow.every((line) => visibleWidth(line) <= 2),
+		true,
+	);
+
+	harness.component.handleInput("d");
+	assert.match(plainRender(harness.component, 40).join("\n"), /tail 10/u);
+	harness.component.handleInput("q");
+	rendered = plainRender(harness.component, 40).join("\n");
+	assert.match(rendered, /beta/u);
+	assert.equal(harness.component.render(40).join("\n").includes(CURSOR_MARKER), true);
+	assert.equal(harness.selectionChanges.at(-1), "schema-beta");
+
+	const privateSearch = componentHarness(screen, { rows: 14 });
+	for (const input of "private-document-token") privateSearch.component.handleInput(input);
+	assert.match(plainRender(privateSearch.component, 40).join("\n"), /No matching items/u);
+});
+
+test("browse exact details apply shared code and diff formatting", () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "browse",
+		title: "Documents",
+		items: [
+			{
+				id: "code",
+				label: "Code",
+				detailDocument: {
+					content: "const answer: number = 42;",
+					format: { kind: "code", filePath: "answer.ts" },
+				},
+			},
+			{
+				id: "diff",
+				label: "Diff",
+				detailDocument: {
+					content: "@@ header\n-old\n+new\n same",
+					format: { kind: "diff", filePath: "settings.json" },
+				},
+			},
+		],
+	};
+	const harness = componentHarness(screen, { rows: 24, themed: true });
+	harness.component.handleInput("y");
+	let rendered = harness.component.render(200).join("\n");
+	assert.match(rendered, /syntaxKeyword:const/u);
+	assert.match(rendered, /syntaxType:number/u);
+	assert.match(rendered, /syntaxNumber:42/u);
+	harness.component.handleInput("q");
+	harness.component.handleInput("j");
+	harness.component.handleInput("y");
+	rendered = harness.component.render(200).join("\n");
+	assert.match(rendered, /toolDiffRemoved:-old/u);
+	assert.match(rendered, /toolDiffAdded:\+new/u);
+	assert.match(rendered, /accent:@@ header/u);
+});
+
 test("browse is adaptively bounded, handles empty searches, and distinguishes Back from Close", () => {
 	const harness = componentHarness(browseScreen(), { rows: 10 });
 	for (const { width, rows } of [
@@ -161,7 +316,7 @@ function plainRender(component: MenuScreenComponent, width: number) {
 
 function componentHarness(
 	screen: MenuScreen<ScreenId, ActionId>,
-	options: { rows?: number; selectedItemId?: string } = {},
+	options: { rows?: number; selectedItemId?: string; themed?: boolean } = {},
 ) {
 	const events: MenuScreenEvent[] = [];
 	const selectionChanges: string[] = [];
@@ -170,7 +325,10 @@ function componentHarness(
 		screen,
 		selectedItemId: options.selectedItemId,
 		tui: host,
-		theme: { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+		theme: {
+			fg: (color: string, text: string) => (options.themed ? `${color}:${text}` : text),
+			bold: (text: string) => text,
+		},
 		keybindings,
 		onEvent: (event) => events.push(event),
 		onSelectionChange: (itemId) => selectionChanges.push(itemId),

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import {
+	type BrowseDetailDocument,
 	type ChoiceScreen,
 	createMenuNavigator,
 	defineMenu,
+	type MenuBrowseItem,
 	type MenuDefinition,
 	PI_EXTENSION_MENU_API_VERSION,
 	resolveMenuScreen,
@@ -38,8 +40,18 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("package exposes API version 9", () => {
-	assert.equal(PI_EXTENSION_MENU_API_VERSION, 9);
+test("package exposes API version 10 and exact browse detail types", () => {
+	const document: BrowseDetailDocument = {
+		content: "  exact\nbody",
+		format: { kind: "code", language: "json" },
+	};
+	const item: MenuBrowseItem = {
+		id: "schema",
+		label: "Schema",
+		detailDocument: document,
+	};
+	assert.equal(item.detailDocument, document);
+	assert.equal(PI_EXTENSION_MENU_API_VERSION, 10);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/readme-usage.ts
+++ b/packages/pi-tui-kit/test/readme-usage.ts
@@ -1,5 +1,6 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
+	type BrowseDetailDocument,
 	type BrowseScreen,
 	defineMenu,
 	formatInteractionHints,
@@ -29,6 +30,11 @@ declare function currentGeneration(): number;
 declare function currentSessionSignal(): AbortSignal;
 declare function formatError(error: unknown): string;
 
+const schemaDocument: BrowseDetailDocument = {
+	content: '{\n  "type": "object"\n}',
+	format: { kind: "code", language: "json" },
+};
+
 const modulesScreen: BrowseScreen = {
 	kind: "browse",
 	title: "Modules",
@@ -40,6 +46,12 @@ const modulesScreen: BrowseScreen = {
 			description: "Current model",
 			searchText: "provider llm",
 			details: ["Preview: claude"],
+		},
+		{
+			id: "schema",
+			label: "schema",
+			searchText: "configuration object",
+			detailDocument: schemaDocument,
 		},
 	],
 	viewportSize: "adaptive",

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -196,6 +196,30 @@ test("review scrolls by injected keys, pages, and clamps after resize", () => {
 	assert.ok(harness.component.render(8).every((line) => visibleWidth(line) <= 8));
 });
 
+test("review reuses exact formatting across scroll renders and clears it on invalidation", () => {
+	const colorCalls: string[] = [];
+	const harness = reviewComponentHarness(
+		{
+			...reviewScreen,
+			content: Array.from({ length: 10 }, (_, index) => `row ${index + 1}`).join("\n"),
+		},
+		false,
+		24,
+		(color) => colorCalls.push(color),
+	);
+	harness.component.render(40);
+	const initialTextCalls = colorCalls.filter((color) => color === "text").length;
+	assert.equal(initialTextCalls, 10);
+
+	harness.component.handleInput("j");
+	harness.component.render(40);
+	assert.equal(colorCalls.filter((color) => color === "text").length, initialTextCalls);
+
+	harness.component.invalidate();
+	harness.component.render(40);
+	assert.equal(colorCalls.filter((color) => color === "text").length, initialTextCalls * 2);
+});
+
 test("review confirmation dispatches raw identity and exits remain Back versus Close", () => {
 	const confirm = reviewComponentHarness(reviewScreen);
 	confirm.component.handleInput("l");
@@ -448,14 +472,22 @@ test("owner abort dismisses an unanswered adaptive RPC review without invoking c
 	assert.equal(invoked, false);
 });
 
-function reviewComponentHarness(screen: ReviewScreen<ActionId>, themed = false, terminalRows = 24) {
+function reviewComponentHarness(
+	screen: ReviewScreen<ActionId>,
+	themed = false,
+	terminalRows = 24,
+	onColor?: (color: string) => void,
+) {
 	const events: Array<{ kind: "back" | "close" } | { kind: "activate"; itemId: string }> = [];
 	const terminal = { rows: terminalRows };
 	const component = createMenuScreenComponent<ScreenId, ActionId>({
 		screen,
 		tui: { terminal, requestRender() {} },
 		theme: {
-			fg: (color: string, text: string) => (themed ? `${color}:${text}` : text),
+			fg: (color: string, text: string) => {
+				onColor?.(color);
+				return themed ? `${color}:${text}` : text;
+			},
 			bold: (text: string) => text,
 		},
 		keybindings: {

--- a/packages/pi-tui-kit/test/runtime.test.ts
+++ b/packages/pi-tui-kit/test/runtime.test.ts
@@ -393,6 +393,144 @@ test("browse stays read-only across TUI detail navigation and RPC pagination", a
 	assert.equal(rpcCall, 4);
 });
 
+test("RPC browse exact details preserve documents, bounds, identity, and Back behavior", async () => {
+	const longLine = `${"x".repeat(120)}y`;
+	const items = [
+		{
+			id: "first-raw",
+			label: "Same",
+			statusText: "Ready",
+			searchText: "first metadata",
+			detailDocument: { content: "private-document-token" },
+		},
+		{
+			id: "second-raw",
+			label: "Same",
+			statusText: "Ready",
+			description: "Legacy description",
+			searchText: "second metadata",
+			details: ["legacy detail must not render"],
+			detailDocument: {
+				content: [
+					"  two spaces",
+					"    four spaces",
+					"\ttabbed",
+					"unsafe\u001b]8;;https://unsafe.example\u0007text",
+					longLine,
+					...Array.from({ length: 6 }, (_, index) => `tail ${index + 1}`),
+				].join("\n"),
+				format: { kind: "code" as const, language: "json" },
+			},
+		},
+	];
+	const menu = defineMenu<undefined, "browse", "unused">({
+		start: "browse",
+		screens: {
+			browse: () => ({ kind: "browse", title: "Documents", items, hint: "back" }),
+		},
+		actions: { unused: async () => ({ kind: "close" }) },
+	});
+	let call = 0;
+	const titles: string[] = [];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (title: string, choices: string[]) => {
+			call += 1;
+			titles.push(title);
+			assert.equal(new Set(choices).size, choices.length);
+			if (call === 1) {
+				assert.deepEqual(choices, ["Same [Ready]", "Same [Ready] [2]", "Back"]);
+				assert.doesNotMatch(
+					choices.join("\n"),
+					/private-document-token|first metadata|second metadata|two spaces/u,
+				);
+				return "Same [Ready] [2]";
+			}
+			if (call === 2) {
+				assert.match(title, /\n {2}two spaces\n {4}four spaces\n {4}tabbed\n/u);
+				assert.equal(title.includes("\u001b"), false);
+				assert.equal(title.includes("https://unsafe.example"), false);
+				assert.match(title, new RegExp(`\\n${"x".repeat(120)}\\ny\\n`, "u"));
+				assert.doesNotMatch(
+					title,
+					/Status: Ready|Legacy description|legacy detail must not render/u,
+				);
+				return choices.find((choice) => choice.startsWith("Next"));
+			}
+			if (call === 3) {
+				assert.match(title, /tail 6/u);
+				return choices.find((choice) => choice.startsWith("Back"));
+			}
+			return choices.find((choice) => choice.startsWith("Back"));
+		},
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+		kind: "closed",
+		reason: "back",
+	});
+	assert.equal(call, 4);
+	assert.equal(
+		titles.every((title) => title.length < 2000),
+		true,
+	);
+});
+
+test("RPC browse legacy details retain exact labels, normalized ordering, and fallback", async () => {
+	const menu = defineMenu<undefined, "browse", "unused">({
+		start: "browse",
+		screens: {
+			browse: () => ({
+				kind: "browse",
+				title: "Legacy",
+				items: [
+					{
+						id: "legacy",
+						label: " Item ",
+						statusText: " Ready   state ",
+						description: " Legacy\tdescription ",
+						details: ["  nested   prose  "],
+					},
+					{ id: "empty", label: "Empty" },
+				],
+				hint: "back",
+			}),
+		},
+		actions: { unused: async () => ({ kind: "close" }) },
+	});
+	let call = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (title: string, choices: string[]) => {
+			call += 1;
+			if (call === 1) {
+				assert.deepEqual(choices, ["Item [Ready state]", "Empty", "Back"]);
+				return choices[0];
+			}
+			if (call === 2) {
+				assert.equal(
+					title,
+					"Item [Ready state]\nStatus: Ready state\nLegacy description\nnested prose",
+				);
+				return "Back";
+			}
+			if (call === 3) return choices[1];
+			if (call === 4) {
+				assert.equal(title, "Empty\nNo details available.");
+				return "Back";
+			}
+			return "Back";
+		},
+	});
+	assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+		kind: "closed",
+		reason: "back",
+	});
+	assert.equal(call, 5);
+});
+
 test("TUI and RPC preserve the eight-screen semantic action matrix", async () => {
 	type MatrixScreen = MenuScreen<"main", "act">;
 	type MatrixPayload = { itemId: string; value?: string; selected?: boolean };

--- a/packages/pi-tui-kit/test/testing-exports.test.ts
+++ b/packages/pi-tui-kit/test/testing-exports.test.ts
@@ -11,7 +11,7 @@ test("built package roots resolve separate production and testing exports", asyn
 	const testingSpecifier = "@narumitw/pi-tui-kit/testing";
 	const production = await import(productionSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 9);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 10);
 	assert.equal(typeof production.formatInteractionHints, "function");
 	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");
@@ -26,10 +26,12 @@ test("built package roots resolve separate production and testing exports", asyn
 	t.onTestFinished(() => rmSync(fixture, { recursive: true, force: true }));
 	writeFileSync(
 		path.join(fixture, "usage.ts"),
-		`import { PI_EXTENSION_MENU_API_VERSION } from "@narumitw/pi-tui-kit";\n` +
+		`import { PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type MenuBrowseItem } from "@narumitw/pi-tui-kit";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 9 = PI_EXTENSION_MENU_API_VERSION;\n` +
-			`void version;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
+			`const version: 10 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const document: BrowseDetailDocument = { content: "  exact", format: { kind: "text" } };\n` +
+			`const item: MenuBrowseItem = { id: "one", label: "One", detailDocument: document };\n` +
+			`void version;\nvoid item;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
 	);
 	writeFileSync(
 		path.join(fixture, "tsconfig.json"),


### PR DESCRIPTION
## Summary

- Add `BrowseDetailDocument` and `MenuBrowseItem.detailDocument` for exact text, code, and diff browse details.
- Share terminal-safe, cell-aware document formatting between browse and review without changing legacy `details` behavior.
- Preserve browse search privacy, stable raw identity, Back/Close navigation, focus, scrolling, and bounded RPC pagination.
- Advance the declarative menu API marker to 10, document the contract, and add a Kit-only minor Changeset.

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit`
- `npx vitest run packages/pi-tui-kit/test` — 168 tests passed.
- `npm run check:boundaries`
- `npm run check` — 268 test files and 2,900 tests passed.
- `git diff --check`
- `just pack tui-kit` — 59 expected package files with built JavaScript, declarations, README, license, and manifest.

## Risks and unverified paths

- The API is not published or registry-verified in this pull request.
- `pi-tool` is intentionally unchanged because repository policy requires the Kit release to be published first.
- The release gate and consumer migration remain open in the plan and require a later branch after explicit release approval.

## Plan

- [Pi TUI Kit browse detail document plan](https://github.com/narumiruna/pi-extensions/blob/feat/pi-tui-kit-browse-detail-document/docs/plans/2026-08-10_pi-tui-kit-browse-detail-document-plan.md)
