### PR TITLE
feat(pi-subagents): add autonomous workflow planning

### DIFF
--- a/.changeset/calm-autonomous-subagents.md
+++ b/.changeset/calm-autonomous-subagents.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Add explicit bounded autonomous workflow planning with deterministic compilation, verified mutating execution, and generation-safe graph revisions.

--- a/docs/implementation-notes/pi-subagents-autonomous-workflow-planning.md
+++ b/docs/implementation-notes/pi-subagents-autonomous-workflow-planning.md
@@ -1,0 +1,92 @@
+# pi-subagents autonomous workflow planning
+
+## Decision
+
+Automation is a separate `subagent_auto` tool rather than another field in `subagent`.
+
+The existing `subagent` TypeBox schema is 27,782 serialized UTF-8 bytes with 20 top-level fields.
+The dedicated automation schema is 2,635 bytes with one top-level `request` field.
+The separate tool keeps the established five-mode compatibility schema unchanged, makes opt-in intent discoverable, and gives the planner/compiler lifecycle one cancellation owner.
+Both schemas use provider-compatible JSON Schema objects and `StringEnum` values, and focused registration tests preserve strict `additionalProperties: false` for automation.
+
+The rejected alternative was an `automation` field inside `subagent`.
+It would have increased the already large schema shown on ordinary delegation turns, complicated exactly-one-mode validation, mixed caller-authored and compiler-authored workflow ownership, and made rollback less independent.
+Migration cost for the selected design is additive: existing calls need no change, while automation callers use `subagent_auto({ request })` and can downgrade to caller-authored `subagent.workflow`.
+
+## Baseline characterization
+
+| Boundary | Existing owner | Focused evidence |
+| --- | --- | --- |
+| Mode validation and preflight | `src/execution.ts` requires exactly one explicit mode, preflights all targets/contracts, and disables nested workflow/panel calls | `test/subagents.test.ts` |
+| Capability routing | `src/capability-router.ts` filters manifests, effective tools, verification roles, filesystem class, cost, and latency | `test/capability-router.test.ts` |
+| Admission | `src/admission-policy.ts` returns parent-owned, one-child, verified-child, bounded-two-child, or abstention recommendations | `test/admission-policy.test.ts` |
+| Execution plans | `src/execution-plan.ts` hashes executor-owned agent, authority, target, workspace, transport, budget, generation, and admission records | `test/execution-plan.test.ts` |
+| WorkItems and persistence | `src/work-item-ledger.ts` owns dependency/artifact/generation state; `src/work-item-persistence.ts` atomically publishes bounded mode-0600 snapshots | WorkItem tests |
+| Verified completion | `src/verification-policy.ts` and `src/workflow-verification.ts` require one distinct current-tree `structured-v2` receipt | workflow-verification tests |
+| Prompt resources | `src/consult-resources.ts` and `src/prompt-resources.ts` disable extensions and gate project resources by effective trust | consultation and prompt-resource tests |
+
+The automation implementation reuses those boundaries rather than adding another execution engine.
+
+## Versioned contracts and limits
+
+- `pi-subagents:automation-request:v1` requires an objective, non-goals, required inputs, acceptance criteria, required evidence, authority ceiling, aggregate budget, and constraints.
+- `pi-subagents:workflow-plan:v1` allows 1 through 8 tasks, strict unknown-field rejection, relative path scopes, typed artifacts, dependencies, side effects, capabilities, evidence, integration ownership, verifier links, and per-task budgets.
+- `pi-subagents:workflow-plan-patch:v1` allows at most 8 add, replace, dependency, cancel, verification, or downstream-invalidation operations against one current plan identity and workflow generation.
+- Text is bounded by UTF-8 bytes, identifiers by a conservative grammar, and terminal controls plus explicit private markers are rejected before persistence or display.
+- Planner output cannot contain plan IDs, workflow generations, execution-plan IDs, selected agents, trust, workspace grants, or descendant authority.
+- Path ceilings constrain compilation and conflict scheduling rather than the host OS; non-`unspecified` network or secrets guarantees fail closed as unenforceable.
+- Aggregate request limits allow at most 8 tasks, 3 revisions, 2 concurrent mutating workers, 1,000 turns, 2,000 tool calls, and the runtime timer ceiling.
+
+The first public automation tool supports `workspaceMode: "shared"` only.
+A worktree request fails closed because the blocking workflow executor does not yet create manager-owned task worktrees.
+
+## Planner and compiler boundary
+
+The built-in planner receives only `read`, `grep`, `find`, and `ls`.
+Extensions, retained sessions, and workflow descendants are disabled.
+Trusted current projects receive bounded project context; untrusted targets receive no inherited project resources and cannot pass compiler trust admission.
+Planner work reserves at most 60 seconds and one quarter of the request's aggregate timeout, turns, and tool calls.
+Cancellation, session replacement, and shutdown abort the planning subprocess and revalidate ownership after every await.
+
+`WorkflowPlanCompiler` alone owns normalization, admission, scope containment, capability routing, agent selection, aggregate budgets, mutating width, integration ownership, verifier synthesis, executor contracts, task generations, and compilation to `subagent.workflow`.
+It may reject or narrow a proposal and may synthesize one verifier only inside the caller's remaining authority, task count, and aggregate budget.
+It never adds tools, capabilities, path scope, side-effect class, trust, recursion, or budget beyond the request.
+
+Parent-owned, missing-input, planner-failed, persistence-failed, and compiler-rejected outcomes launch zero execution workers.
+A read-only planning turn may already have occurred before these typed non-launch results.
+
+## Revision and recovery boundary
+
+Automation plan persistence atomically stores the compiled plan and WorkItem snapshot in one mode-0600 file.
+A patch must match the current plan ID and workflow generation.
+Only pending, ready-to-start, needs-input, verification-rework, stale, or invalidated records can change.
+Completed work, accepted artifacts, current verification receipts, executor task IDs, and settled non-rework side effects are immutable.
+Accepted patches rotate plan identity, workflow generation, and affected task generations, preserve a bounded accepted-history record, invalidate dependency closure, and stop at the request revision limit.
+Rejected patches leave the last accepted record unchanged.
+
+## Frozen matched evaluation protocol
+
+`pi-subagents:workflow-planning-benchmark:v1` was frozen before any live-provider run.
+It compares these paired arms:
+
+1. strong single agent;
+2. one child;
+3. caller-authored workflow;
+4. fixed two-child workflow;
+5. equal-budget best-of-N;
+6. automation-compiled workflow.
+
+Every adapter must use identical repository information, model, evaluator, authority ceiling, aggregate token/dollar ceiling, wall-clock ceiling, two-mutating-child maximum, and zero recursion.
+The deterministic offline dry run uses three task classes and three paired seeds for nine paired instances.
+Focused fixtures pass for direct parent ownership, one child, one verified child, bounded parallel integration, missing input, planner failure, compiler rejection, one rework revision, and terminal revision exhaustion.
+
+The only task classes eligible for a separately authorized live-provider evaluation are bounded repository reconnaissance, a single-package implementation with independent verification, and sparse two-boundary implementation with one integration owner.
+No live-provider evaluation was authorized or run.
+The offline result proves contract and harness determinism only; it does not establish quality, benefit, or a production default.
+
+## Compatibility and rollback
+
+Existing `subagent` payloads and omitted behavior are unchanged.
+Disable blocking delegation to remove both `subagent` and `subagent_auto`, or use caller-authored `subagent.workflow` when exact deterministic task control is required.
+Older package versions do not register the new tool and ignore the separate versioned automation records.
+No settings migration, publication, package default change, learned router, release, or recursive team behavior is included.

--- a/docs/implementation-notes/pi-subagents-capability-matrix.md
+++ b/docs/implementation-notes/pi-subagents-capability-matrix.md
@@ -6,12 +6,13 @@ README owns public schemas and usage; source and focused tests are the executabl
 | Capability | Status and boundary | Evidence |
 | --- | --- | --- |
 | Blocking single/parallel/chain/fan-in | Implemented through `subagent`; the full batch is preflighted before any launch | `src/execution.ts`, `test/subagents.test.ts` |
+| Explicit autonomous workflow planning | `subagent_auto` runs one bounded read-only planner, then a deterministic compiler returns parent-owned/needs-input/rejected or executes the smallest admitted existing workflow | `src/automation*.ts`, `src/workflow-plan-compiler.ts`, automation/compiler tests |
 | Detached addressable agents | Implemented through `subagent_spawn`; completion delivery is next-turn by default or opt-in auto-resume | `src/stateful.ts`, `test/orchestration.test.ts`, `test/completion-delivery.test.ts` |
 | Follow-up and retained lifecycle | Implemented through `subagent_send`, `subagent_manage`, and `subagent_mailbox` | `src/stateful.ts`, registry/orchestration tests |
 | Metadata-only inspection | `subagent_inspect` is registered in every workflow, including disabled delegation; it never launches children or reads/acknowledges mailbox content | `src/inspect.ts`, `test/inspect.test.ts` |
 | Synchronous read-only consultation | `subagent_consult` is registered whenever blocking delegation is enabled; it runs one ephemeral child with extensions disabled and only the effective subset of `read`, `grep`, `find`, and `ls` | `src/consult.ts`, `src/consult-policy.ts`, `test/consult.test.ts` |
-| Default tool surface | Seven tools: `subagent`, `subagent_spawn`, `subagent_send`, `subagent_manage`, `subagent_mailbox`, `subagent_inspect`, and `subagent_consult` | `src/subagents.ts`, `test/subagents.test.ts`, `test/tool-rendering.test.ts` |
-| Workflow-dependent registration | `all`: seven tools; `async-only`: four detached tools plus inspection; `blocking-only`: blocking, consultation, and inspection; `disabled`: inspection only | exact registration cases in `test/subagents.test.ts` |
+| Default tool surface | Eight tools: `subagent`, `subagent_auto`, `subagent_spawn`, `subagent_send`, `subagent_manage`, `subagent_mailbox`, `subagent_inspect`, and `subagent_consult` | `src/subagents.ts`, `test/subagents.test.ts`, `test/tool-rendering.test.ts` |
+| Workflow-dependent registration | `all`: eight tools; `async-only`: four detached tools plus inspection; `blocking-only`: blocking, autonomous planning, consultation, and inspection; `disabled`: inspection only | exact registration cases in `test/subagents.test.ts` |
 | Deterministic timeout and process cleanup | Implemented with process-group termination and bounded settlement/cleanup | `src/runner.ts`, runner and evolution coverage |
 | Bounded protocol and output | Implemented at both 50 KB and 2,000-line limits for model-facing content and safe projections | `src/protocol.ts`, `src/limits.ts`, rendering/inspection/consultation tests |
 | Abort with partial structured result | Blocking/stateful operations preserve bounded partial results; consultation preserves post-launch evidence/usage and marks the finalized Pi result as an error | runner, consultation, and orchestration tests |
@@ -30,7 +31,8 @@ README owns public schemas and usage; source and focused tests are the executabl
 | Native transcript switching | Core-blocked because Pi exposes no supported child transcript/session switch handle | public SDK boundary review |
 | Approval/sandbox/header inheritance | Unsupported as a general guarantee; reported policy is bounded and explicit | result policy and transport tests |
 | Filesystem isolation | Optional disposable worktree only; shared cwd is default and neither target policy nor consultation resource policy is an OS sandbox | `src/workspace.ts`, README security boundary |
-| Autonomous recursive teams | Rejected; recursion is bounded and no unbounded scheduler is provided | execution settings and recursion tests |
+| Autonomous recursive teams | Rejected; `subagent_auto` permits no workflow grandchildren, at most two concurrent mutating workers, and a bounded revision count | compiler, patch, execution, and recursion tests |
+| Planner-driven graph revisions | Versioned internal patches can change only eligible current-generation work; accepted history, artifacts, and verifier receipts stay immutable and plan identity rotates atomically | `src/workflow-plan-patch.ts`, `test/workflow-plan-patch.test.ts` |
 
 ## Read-only boundary
 

--- a/docs/implementation-notes/pi-subagents-stateful-runtime.md
+++ b/docs/implementation-notes/pi-subagents-stateful-runtime.md
@@ -77,13 +77,13 @@ Subprocess cleanup retains process-group SIGTERM/SIGKILL escalation. In-process 
 
 ## Public surface
 
-The default `all` workflow exposes seven tools: blocking `subagent`; detached `subagent_spawn`,
+The default `all` workflow exposes eight tools: blocking `subagent`; explicit autonomous `subagent_auto`; detached `subagent_spawn`,
 `subagent_send`, `subagent_manage`, and `subagent_mailbox`; metadata-only `subagent_inspect`; and
 synchronous read-only `subagent_consult`. Registration follows workflow capability:
 
-- `all`: all seven tools;
+- `all`: all eight tools;
 - `async-only`: the four detached tools plus inspection;
-- `blocking-only`: blocking delegation, consultation, and inspection; and
+- `blocking-only`: blocking delegation, autonomous planning, consultation, and inspection; and
 - `disabled`: inspection only.
 
 Within an enabled stateful workflow, lifecycle tool membership does not change after spawn,

--- a/docs/plans/archived/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md
@@ -10,9 +10,9 @@ Support versioned revisions to pending, rework-requested, or invalidated work wh
 
 This plan owns only the explicit automation request, read-only planning turn, deterministic plan compiler, topology minimization, and graph-patch contract.
 
-It depends on the [verified execution loop plan](2026-08-10_pi-subagents-verified-execution-loop-plan.md) for acceptance and rework semantics.
+It depends on the verified execution loop merged in [PR #678](https://github.com/narumiruna/pi-extensions/pull/678) for acceptance and rework semantics.
 
-It consumes the implemented capability, contract, `ExecutionPlan`, WorkItem, and workflow baselines preserved under [`docs/plans/superseded/`](superseded/) without reopening their original checklists.
+It consumes the implemented capability, contract, `ExecutionPlan`, WorkItem, and workflow baselines tracked by the existing Pi Subagents plans in `docs/plans/` without reopening their original checklists.
 
 The [minimal delegation admission evaluation plan](2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md) remains the sole owner of matched evidence required before a default change.
 
@@ -76,13 +76,13 @@ The first implementation will not learn from historical runs or use a learned ro
 - The parent agent can handle a typed parent-owned or needs-input result after the automation tool returns.
 - Existing provider schemas can carry a bounded automation request and plan result after compatibility tests.
 
-## Unknowns
+## Resolved Decisions and Accepted Unknowns
 
-- Whether automation should be a new `subagent` mode or a separately named tool requires a schema-size, discoverability, and provider-compatibility decision.
-- The exact planner context policy and maximum graph size require measured token and latency baselines.
-- The best deterministic mapping from proposal metadata to admission inputs remains unverified by representative repository tasks.
-- The initial task classes eligible for automatic planning must be selected before live evaluation rather than after observing favorable results.
-- The benefit of different model families for planner, implementer, and verifier remains unknown.
+- Automation uses a separate `subagent_auto` tool because its 2,635-byte one-field schema avoids expanding the existing 27,782-byte, 20-field compatibility schema.
+- The planner uses trust-aware project context, only `read`, `grep`, `find`, and `ls`, at most 60 seconds, 8 turns, 16 tool calls, and an eight-task graph.
+- Deterministic fixtures verify the proposal-to-admission mapping for parent-owned, one-child, sequential, verified-child, and bounded-parallel shapes.
+- Only bounded reconnaissance, verified single-package changes, and sparse two-boundary changes are eligible for a separately authorized live evaluation.
+- Model-family benefit remains intentionally unmeasured because no live-provider evaluation was authorized, and this release makes no quality or default claim.
 
 ## Risks
 
@@ -106,35 +106,35 @@ The first implementation will not learn from historical runs or use a learned ro
 
 ## Plan
 
-- [ ] Characterize existing tool schema size, provider compatibility, mode validation, capability routing, admission decisions, workflow preflight, `ExecutionPlan` construction, WorkItem creation, verified completion, and prompt-resource boundaries; record focused baseline tests.
-- [ ] Decide whether automation is a new `subagent` mode or a separate tool by comparing schema size, provider compatibility, prompt burden, lifecycle ownership, backwards compatibility, and discoverability; record the rejected alternative and migration consequences.
-- [ ] Define bounded `pi-subagents:automation-request:v1`, `workflow-plan:v1`, and `workflow-plan-patch:v1` schemas with exact limits, unknown-field policy, executor-owned fields, provenance, generation, authority ceiling, aggregate budget, acceptance criteria, and result outcomes.
-- [ ] Add failing parser tests for malformed JSON, unsupported version, duplicate or missing IDs, cycles, excessive graph size, oversized text, invalid paths, conflicting ownership, unsupported guarantees, forged generation, forged authority, terminal controls, and private data.
-- [ ] Define planner resource and tool policy as read-only, bounded, trust-aware, cancellation-aware, and incapable of delegating grandchildren or mutating the repository.
-- [ ] Implement a planner prompt that requests tasks, dependencies, artifacts, scopes, side effects, capabilities, acceptance criteria, risks, integration ownership, verifier needs, and budgets without asking for hidden reasoning.
-- [ ] Implement `WorkflowPlanCompiler` as the single deterministic owner of normalization, graph validation, admission, topology minimization, capability routing, authority enforcement, workspace selection, task generations, hard limits, and compilation to the existing workflow shape.
-- [ ] Add compiler tests for parent-owned direct work, one child, one child plus verifier, sequential dependency, two safe mutating children, dense coupling, missing verification, unsupported capability, insufficient budget, scope conflict, no integration owner, and attempted grandchildren.
-- [ ] Ensure the compiler may narrow or reject a model proposal but cannot silently add authority, exceed aggregate budget, raise mutating width, or relax verification and trust requirements.
-- [ ] Integrate verified-execution synthesis so every compiled risk-selected mutating plan contains one distinct verifier and one authoritative integration path before any mutating child starts.
-- [ ] Implement graph patch validation and application for pending, rework-requested, or invalidated nodes only, with current workflow generation, dependency closure, artifact invalidation, plan identity rotation, bounded revision count, and atomic persistence.
-- [ ] Add tests proving plan patches cannot rewrite completed work, forge artifacts, remove required verification, revive cancelled generations, widen authority, exceed budget, create cycles, or trigger side-effect replay.
-- [ ] Add end-to-end deterministic fixtures for objective to direct result, objective to one child, objective to verified child, objective to bounded parallel workflow, missing-input abstention, planner failure, compiler rejection, one revision after failed assumption, and terminal stop after revision exhaustion.
-- [ ] Define a frozen matched evaluation protocol against strong single-agent, one-child, caller-authored workflow, fixed two-child, and equal-budget best-of-N arms with identical model information, tools, evaluator, aggregate token or dollar ceiling, wall-clock ceiling, and repeated paired tasks.
-- [ ] Run the offline protocol and deterministic fixtures, then record which task classes remain eligible for a separately authorized live-provider evaluation without making a production-quality claim.
-- [ ] Update `packages/pi-subagents/README.md`, tool documentation, compatibility and downgrade guidance, package layout, and an appropriate Changeset for the new explicit automation surface.
-- [ ] Audit cancellation, every post-`await` generation check, session replacement, shutdown, planner disposal, persistence ordering, project trust, prompt resources, output bounds, terminal sanitization, invalid-file protection if configuration changes, and repeated cleanup against `docs/extension-conventions.md` and `docs/extension-settings.md` when applicable.
-- [ ] Run focused parser, planner, compiler, routing, admission, workflow, verification, persistence, and lifecycle tests; then run `npm test`, `npm run check`, `git diff --check`, `just pack subagents`, and representative local explicit-automation smokes when practical.
+- [x] Characterize existing schema, compatibility, routing, admission, workflow, execution-plan, WorkItem, verification, and prompt-resource boundaries; evidence is recorded in `docs/implementation-notes/pi-subagents-autonomous-workflow-planning.md` and focused baseline tests.
+- [x] Select a separate `subagent_auto` tool after measuring 27,782 bytes for `subagent` versus 2,635 bytes for the dedicated schema; the rejected in-schema mode and downgrade consequences are documented.
+- [x] Define strict bounded `pi-subagents:automation-request:v1`, `workflow-plan:v1`, and `workflow-plan-patch:v1` contracts in `src/automation-contract.ts`.
+- [x] Add red-first parser coverage for malformed JSON, versions, identities, cycles, graph/text/path limits, ownership, guarantees, forgery, terminal controls, and private markers in `test/automation-contract.test.ts`.
+- [x] Enforce a read-only, bounded, trust-aware, cancellable, non-recursive planner policy in `src/automation-planner.ts` and `src/automation.ts`.
+- [x] Implement the exact-JSON planner prompt without hidden-reasoning requests and cover every required task field in planner tests.
+- [x] Implement `WorkflowPlanCompiler` as the deterministic owner of graph validation, admission, routing, authority/budget limits, workspace support, generations, verification, and existing-workflow compilation.
+- [x] Cover parent-owned, one-child, verified, sequential, bounded parallel, dense, missing verification, unsupported capability, insufficient budget, scope/integration conflicts, and recursion in compiler tests.
+- [x] Prove compiler narrowing and rejection cannot widen tools, capabilities, path scope, side effects, aggregate budget, trust, mutating width, or recursion.
+- [x] Synthesize one distinct verifier inside the remaining ceiling and require one authoritative integration path for every admitted mutating plan.
+- [x] Implement current-generation graph patches, dependency closure, artifact invalidation, identity/generation rotation, revision limits, patched ledgers, and atomic combined plan/ledger persistence.
+- [x] Cover completed-work, artifact, verifier, cancellation, authority, budget, cycle, replay, stale identity, and revision-exhaustion patch failures.
+- [x] Add deterministic end-to-end fixtures for parent-owned, one child, verified child, bounded parallel, missing input, planner failure, compiler rejection, rework revision, and terminal exhaustion.
+- [x] Freeze `pi-subagents:workflow-planning-benchmark:v1` with strong-single, one-child, caller-workflow, fixed-two-child, equal-budget best-of-N, and automation arms under matched information and resources.
+- [x] Run the offline dry run and fixtures; only bounded reconnaissance, verified single-package changes, and sparse two-boundary changes remain eligible for separately authorized live evaluation.
+- [x] Update the package README, capability/runtime notes, compatibility and downgrade guidance, package layout, and `.changeset/calm-autonomous-subagents.md`.
+- [x] Audit cancellation, post-await ownership, replacement, shutdown, planner disposal, persistence ordering, trust, prompt resources, output bounds, terminal safety, invalid-state quarantine, and repeated cleanup against both extension guides; no settings schema changed.
+- [x] Run 386 package tests, `npm test` with 2,934 tests, `npm run check`, `git diff --check`, and `just pack subagents`; deterministic explicit-automation smokes passed, while a live-provider smoke was intentionally not run because no live evaluation was authorized and model tool choice is not deterministic.
 
 ## Completion Checklist
 
-- [ ] One high-level automation request can compile to the smallest justified existing workflow topology without caller-authored tasks.
-- [ ] Planner execution is read-only, bounded, trust-aware, cancellable, and unable to grant itself authority or descendants.
-- [ ] Deterministic compilation rejects unsafe or malformed plans before side effects and never silently widens authority, budget, width, or recursion.
-- [ ] Parent-owned and insufficient-evidence decisions start zero children.
-- [ ] Every admitted mutating plan uses the verified-execution acceptance boundary.
-- [ ] Plan patches modify only eligible current-generation work and preserve accepted history, accepted artifacts, and verification receipts.
-- [ ] Mutating width remains at most two and workflow grandchildren remain rejected.
-- [ ] Existing omitted-field modes remain compatible with a documented fallback and downgrade path.
-- [ ] Matched evaluation protocol is frozen before live results, and no unsupported default-quality claim is made.
-- [ ] Focused tests, semantic audits, root CI-equivalent gate, package dry run, and representative runtime smokes pass or unavailable paths are explicitly recorded.
-- [ ] Published behavior has an appropriate Changeset, and no publication or release action has occurred.
+- [x] One high-level request compiles to the smallest justified existing topology without caller-authored tasks.
+- [x] Planner execution is read-only, bounded, trust-aware, cancellable, and unable to grant authority or descendants.
+- [x] Compilation rejects malformed or unsafe plans before execution side effects and never silently widens authority, budget, width, or recursion.
+- [x] Parent-owned and insufficient-evidence decisions start zero execution workers.
+- [x] Every admitted mutating plan uses the verified-execution acceptance boundary.
+- [x] Patches modify only eligible current-generation work and preserve accepted history, artifacts, and verification receipts.
+- [x] Mutating width remains at most two and workflow grandchildren are rejected before planning.
+- [x] Existing modes remain compatible with documented explicit-workflow fallback and downgrade guidance.
+- [x] The matched protocol was frozen before live results, and no unsupported default-quality claim is made.
+- [x] Focused tests, semantic audits, root CI gate, package dry run, and deterministic runtime fixtures pass; the intentionally unrun live-provider path is recorded.
+- [x] Published behavior has a minor Changeset, and no publication, tag, release, or workflow dispatch occurred.

--- a/docs/roadmaps/2026-08-10_pi-subagents-full-automation-roadmap.md
+++ b/docs/roadmaps/2026-08-10_pi-subagents-full-automation-roadmap.md
@@ -39,7 +39,7 @@ Keep `pi-subagents` as the owner of delegation planning, workflow state, authori
 | Concern | Current owner | Relationship to earlier plans |
 | --- | --- | --- |
 | Independent acceptance, immutable verification, and bounded rework | [`Verified Execution Loop Plan`](../plans/2026-08-10_pi-subagents-verified-execution-loop-plan.md) | Continues the implemented WorkItem baseline and owns the acceptance-state migration. |
-| Objective-to-DAG compilation and graph revision | [`Autonomous Workflow Planning Plan`](../plans/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md) | Continues capability routing and explicit workflow compilation without reopening their implemented baselines. |
+| Objective-to-DAG compilation and graph revision | [`Autonomous Workflow Planning Plan`](../plans/archived/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md) | Implemented as the explicit `subagent_auto` surface without reopening earlier baselines. |
 | Rolling scheduling, recovery, persistence reconciliation, and resume | [`Event-Driven Workflow Runtime Plan`](../plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md) | Continues the dependency scheduler and semantic snapshot baseline without duplicating it. |
 | Matched evidence before a default change | [`Minimal Delegation Admission Evaluation Plan`](../plans/2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md) | Remains the sole active admission evidence gate. |
 
@@ -74,15 +74,15 @@ The original implementation plans now live under [`docs/plans/superseded/`](../p
 
 ### Phase 2: Accept one objective and construct the workflow
 
-- [ ] An explicit automation mode accepts one objective, constraints, acceptance criteria, and aggregate budget without requiring a caller-authored task graph.
-- [ ] A read-only planning turn proposes a bounded typed DAG, while deterministic compilation validates dependencies, scopes, authority, capabilities, artifacts, verification, and hard limits before any mutating child starts.
-- [ ] Admission selects the smallest justified topology and can return parent-owned direct work or abstention without allocating a child.
-- [ ] Capability routing assigns agents and tools from enforceable manifests without silently widening authority.
-- [ ] Versioned graph patches can revise pending, rework-requested, or invalidated work after new evidence without replacing accepted history.
+- [x] An explicit automation mode accepts one objective, constraints, acceptance criteria, and aggregate budget without requiring a caller-authored task graph.
+- [x] A read-only planning turn proposes a bounded typed DAG, while deterministic compilation validates dependencies, scopes, authority, capabilities, artifacts, verification, and hard limits before any mutating child starts.
+- [x] Admission selects the smallest justified topology and can return parent-owned direct work or abstention without allocating an execution child.
+- [x] Capability routing assigns agents and tools from enforceable manifests without silently widening authority.
+- [x] Versioned graph patches can revise pending, rework-requested, or invalidated work after new evidence without replacing accepted history.
 
 **Outcome:** One high-level request can become a safe executable workflow with no manual topology authoring.
 
-**Execution plan:** [`2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md`](../plans/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md).
+**Completed plan:** [`2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md`](../plans/archived/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md).
 
 ### Phase 3: Run a rolling recoverable workflow runtime
 
@@ -157,3 +157,4 @@ The original implementation plans now live under [`docs/plans/superseded/`](../p
 - **2026-08-10 — Exclude observability expansion:** this roadmap changes execution behavior and correctness gates only, except for bounded evidence required by those gates.
 - **2026-08-10 — Keep full automation explicit:** no default routing change is proposed before matched representative evaluation.
 - **2026-08-10 — Preserve narrow concurrency:** the first automated architecture keeps at most two mutating children and no workflow grandchildren.
+- **2026-08-10 — Complete explicit workflow planning:** `subagent_auto`, deterministic compilation, verified mutating topology, bounded graph patches, and the frozen offline protocol complete Phase 2 without changing defaults or making a live-quality claim.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-subagents)](https://www.npmjs.com/package/@narumitw/pi-subagents) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-subagents` is a native [Pi coding agent](https://pi.dev) extension for delegating work to specialized agents. By default, it exposes seven capability-specific tools: blocking batches, four detached lifecycle tools, side-effect-free inspection, and synchronous read-only consultation. Users can keep every delegation method, choose async-only delegation, retain only blocking delegation, or disable delegation while keeping inspection available.
+`@narumitw/pi-subagents` is a native [Pi coding agent](https://pi.dev) extension for delegating work to specialized agents. By default, it exposes eight capability-specific tools: blocking batches, explicit autonomous workflow planning, four detached lifecycle tools, side-effect-free inspection, and synchronous read-only consultation. Users can keep every delegation method, choose async-only delegation, retain only blocking delegation, or disable delegation while keeping inspection available.
 
 Use it to split independent research, planning, implementation, and review work across focused workers. Under the default next-turn delivery policy, background delegation is for work the current response does not depend on. Opt-in auto-resume also supports final-answer-dependent background work by requesting a synthesis turn after completion.
 
@@ -11,6 +11,7 @@ Use it to split independent research, planning, implementation, and review work 
 - Offers all delegation methods by default, with goal-oriented presets for async-only, blocking-only, or disabled delegation.
 - Adds `subagent_inspect` for bounded metadata without child launch, mailbox-content access, acknowledgement, or mutation.
 - Adds `subagent_consult` for one synchronous ephemeral child constrained to built-in `read`, `grep`, `find`, and `ls` tools (or a narrower agent allow-list).
+- Adds explicit `subagent_auto` requests that use one bounded read-only planning turn and a deterministic compiler to select the smallest justified existing workflow without changing omitted-field behavior.
 - Keeps batch workers isolated in `pi --mode json -p --no-session` subprocesses.
 - Lets users set a blocking parallel call's maximum worker count from 1 through 64 while keeping four-at-a-time execution.
 - Registers detached stateful lifecycle tools by default; completion can stay queued for the next turn or opt into an idle root synthesis turn.
@@ -22,7 +23,7 @@ Use it to split independent research, planning, implementation, and review work 
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
 - Provides a current-session-first `/subagents` manager, direct `settings|status|help` routes, and compatibility aliases for agent tools and retained agents.
 - Supports trust-aware per-task `cwd` policies, task-selected work, workflow, idle, turn, and tool-call budgets, deterministic timeout checkpoints, bounded abort-then-summary recovery, progress telemetry, and explicit Fast, Balanced, or Deep thinking profiles.
-- Renders all seven tools with Pi-native compact/expanded transcript rows; long-running blocking and consultation calls show bounded live activity.
+- Uses Pi-native tool rows throughout; blocking and consultation calls add bounded custom live activity.
 - Bounds JSON lines, captured messages, stderr, final output, chain substitution, and fan-in context.
 - Enforces a recursion-depth guard and deterministic process-group termination.
 - Provides addressable stateful agents with follow-up, consolidated mailbox/management actions, idempotent spawn retries, context selection and preview, versioned structured outcomes, and persistence.
@@ -54,13 +55,13 @@ pi -e ./packages/pi-subagents
 
 ## 🛠️ Pi tool
 
-`pi-subagents` registers seven tools by default. Run `/subagents`, choose **Change delegation**, review the concrete tool changes, then select **Save and reload** to apply one of these workflows:
+`pi-subagents` registers eight tools by default. Run `/subagents`, choose **Change delegation**, review the concrete tool changes, then select **Save and reload** to apply one of these workflows:
 
 | Workflow | Registered tools |
 | --- | --- |
-| **All delegation methods** (default) | Existing five delegation/lifecycle tools, `subagent_inspect`, and `subagent_consult` |
+| **All delegation methods** (default) | Existing five delegation/lifecycle tools, `subagent_auto`, `subagent_inspect`, and `subagent_consult` |
 | **Async only** | Four detached lifecycle tools plus `subagent_inspect`; blocking `subagent` and `subagent_consult` are omitted |
-| **Blocking only** | `subagent`, `subagent_consult`, and `subagent_inspect` |
+| **Blocking only** | `subagent`, `subagent_auto`, `subagent_consult`, and `subagent_inspect` |
 | **Disabled** | `subagent_inspect` only; delegation is disabled |
 
 The preview compares the selection with the tools registered in the current session, even when a manual settings edit is pending, and remains read-only until confirmation. Escape or **Cancel** leaves settings unchanged. Tool removal requires an extension reload because Pi does not expose extension tool unregistration. To avoid aborting work or removing isolated worktrees during `session_shutdown`, workflow changes are blocked while detached agents are retained; finish or clear them through **Current agents** first. Pi owns reload-error reporting and does not return a success result to extensions, so the save notification also tells users to run `/reload` if the tool surface does not refresh.
@@ -68,6 +69,7 @@ The preview compares the selection with the tools registered in the current sess
 The available tools are:
 
 - `subagent` — delegate blocking single, parallel, fan-in, chained, panel-review, or explicit dependency-workflow tasks. The main agent cannot process queued steering until the call returns.
+- `subagent_auto` — explicitly request one read-only planning turn followed by deterministic compilation and, only when admitted, execution through the existing blocking workflow engine.
 - `subagent_spawn` and related lifecycle tools — when enabled, start reusable detached work, return immediately, and receive bounded completion messages automatically.
 - `subagent_inspect` — inspect agent/model/run/runtime metadata without launching work or changing state.
 - `subagent_consult` — run one ephemeral read-only consultation and wait for its answer.
@@ -96,6 +98,7 @@ Choose the API by lifecycle:
 
 | Need | Use |
 | --- | --- |
+| The caller explicitly wants a high-level objective decomposed under an authority ceiling and aggregate budget | `subagent_auto`, when blocking delegation is enabled |
 | A delegated result is required before the root's next action under default next-turn delivery | Use one blocking `subagent` call when registered. In **Async only**, complete the critical-path work directly or switch workflows before delegating it |
 | Broad research/review the current response does not depend on | Prefer one `subagent_spawn` covering related branches, when lifecycle tools are enabled |
 | Final-answer-dependent broad work with `completionDelivery: "auto-resume"` | Prefer one `subagent_spawn`; completion requests a synthesis turn |
@@ -223,6 +226,68 @@ A blocking fan-out is reserved for output that must be synthesized before the ro
   }
 }
 ```
+
+## 🧠 Explicit autonomous workflow planning
+
+`subagent_auto` is an opt-in surface separate from the large multi-mode `subagent` schema.
+It never intercepts ordinary prompts and does not change existing calls when omitted.
+The caller supplies one versioned objective, non-goals, required inputs, acceptance criteria, required evidence, an authority ceiling, an aggregate budget, and deterministic constraints.
+
+```json
+{
+  "request": {
+    "version": "pi-subagents:automation-request:v1",
+    "objective": "Implement and verify the package change",
+    "nonGoals": ["Do not publish or release"],
+    "requiredInputs": ["current trusted repository"],
+    "acceptanceCriteria": ["Focused and root checks pass"],
+    "requiredEvidence": ["test output", "final diff review"],
+    "authorityCeiling": {
+      "capabilities": ["implementation", "code-review"],
+      "tools": ["read", "bash", "edit", "write"],
+      "readPaths": ["packages/pi-subagents"],
+      "writePaths": ["packages/pi-subagents"],
+      "network": "unspecified",
+      "secrets": "unspecified",
+      "sideEffectPolicy": "mutating"
+    },
+    "aggregateBudget": {
+      "timeoutMs": 180000,
+      "maxTurns": 30,
+      "maxToolCalls": 60,
+      "maxTasks": 4,
+      "maxRevisions": 1
+    },
+    "constraints": {
+      "contextPressure": "high",
+      "maxMutatingWidth": 2,
+      "requireVerification": true,
+      "workspaceMode": "shared"
+    }
+  }
+}
+```
+
+The planner always uses the built-in `planner` with only `read`, `grep`, `find`, and `ls`, disabled extensions and session persistence, trust-aware prompt resources, a maximum 60-second planning deadline, and bounded turn/tool-call counts.
+The planner returns only `pi-subagents:workflow-plan:v1` JSON and cannot choose agents, grant authority, create descendants, or forge executor identities.
+The executor reserves at most one quarter of the aggregate timeout, turns, and tool calls for planning before compiling execution work.
+
+The compiler validates strict unknown-field and UTF-8 bounds, relative scopes, cycles, artifacts, ownership, capability routes, aggregate budgets, task generations, integration ownership, and the two-mutating-worker limit before execution.
+Path ceilings are compiler and conflict-scheduling constraints, not operating-system filesystem isolation; use a container or sandbox when host-level containment is required.
+Network and secrets guarantees other than `"unspecified"` fail closed because the current executor cannot enforce them.
+It can narrow or reject a proposal and can add one verifier only within the caller's remaining authority and budget.
+Parent-owned, needs-input, planner-failed, and compiler-rejected outcomes launch no execution workers.
+Every admitted mutating workflow has one authoritative integration owner and one distinct `structured-v2` verifier before any mutating worker starts.
+Project-local agents are not selected by this first surface, workflow grandchildren are rejected, and `workspaceMode: "worktree"` fails closed until blocking workflow worktree execution is supported.
+
+Pending, needs-input, verification-rework, stale, or invalidated work can be revised through the internal `pi-subagents:workflow-plan-patch:v1` contract.
+Each accepted patch must match the current plan identity and workflow generation, rotates both identity and task generations, preserves accepted history/artifacts/receipts, and stops after the caller's revision limit.
+The initial tool surface does not expose free-form public graph editing.
+
+For compatibility or exact task control, use caller-authored `subagent.workflow`.
+Before downgrading, use that explicit workflow fallback and let active automation calls finish.
+Older releases do not register `subagent_auto` and ignore the separate versioned automation records under `~/.pi/agent/pi-subagents-workflows/`; no settings migration is required.
+No benchmark result in this release changes the default delegation policy or makes a production-quality claim.
 
 ## 🔎 Read-only inspection
 
@@ -918,6 +983,12 @@ packages/pi-subagents/
 ├── src/
 │   ├── index.ts                  # Pi package entrypoint
 │   ├── subagents.ts              # Extension registration and blocking tool schema
+│   ├── automation.ts             # Explicit autonomous planning tool and lifecycle owner
+│   ├── automation-contract.ts    # Strict request, proposal, and graph-patch contracts
+│   ├── automation-planner.ts     # Bounded read-only planner prompt and resource policy
+│   ├── workflow-plan-compiler.ts # Deterministic admission, routing, and workflow compilation
+│   ├── workflow-plan-patch.ts    # Generation-safe revisions and atomic plan persistence
+│   ├── workflow-planning-benchmark.ts # Frozen matched offline evaluation protocol
 │   ├── inspect.ts                # Side-effect-free metadata inspection tool
 │   ├── consult.ts                # Synchronous read-only consultation tool
 │   ├── consult-policy.ts         # Enforced read-only tool intersection
@@ -972,7 +1043,7 @@ packages/pi-subagents/
 ```
 
 `index.ts` is the Pi entrypoint and forwards to `subagents.ts`; the other source modules are internal.
-Workflow settings remain backward compatible: older files without `blocking.enabled` receive the seven-tool default, and an absent `blocking.maxParallelTasks` keeps the previous eight-worker limit.
+Workflow settings remain backward compatible: older files without `blocking.enabled` receive the eight-tool default, and an absent `blocking.maxParallelTasks` keeps the previous eight-worker limit.
 Existing `stateful.enabled: false` files expose blocking delegation plus inspection/consultation.
 Older package releases ignore and preserve the optional `blocking.maxParallelTasks`, `consult`, and `cwdPolicy` fields.
 The package exposes its Pi extension through `package.json`:

--- a/packages/pi-subagents/src/automation-contract.ts
+++ b/packages/pi-subagents/src/automation-contract.ts
@@ -1,0 +1,708 @@
+import { createHash } from "node:crypto";
+import * as path from "node:path";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { type Static, Type } from "typebox";
+import { MAX_SUBAGENT_TIMEOUT_MS } from "./limits.js";
+
+export const AUTOMATION_REQUEST_VERSION = "pi-subagents:automation-request:v1" as const;
+export const WORKFLOW_PLAN_VERSION = "pi-subagents:workflow-plan:v1" as const;
+export const WORKFLOW_PLAN_PATCH_VERSION = "pi-subagents:workflow-plan-patch:v1" as const;
+export const MAX_AUTOMATION_TASKS = 8;
+export const MAX_AUTOMATION_REVISIONS = 3;
+export const MAX_AUTOMATION_TEXT_BYTES = 16 * 1024;
+const MAX_ITEM_BYTES = 4 * 1024;
+const MAX_ITEMS = 20;
+const MAX_PATH_BYTES = 4 * 1024;
+const MAX_BUDGET_TURNS = 1_000;
+const MAX_BUDGET_TOOL_CALLS = 2_000;
+const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u;
+const PLAN_ID_PATTERN = /^[a-f0-9]{64}$/u;
+const PRIVATE_MARKER_PATTERN = /<\/?private(?:\s|>)|\[subagent-private\]/iu;
+
+const SideEffectSchema = StringEnum(["read-only", "idempotent", "mutating"] as const);
+const AuthorityRequirementSchema = StringEnum(["unspecified", "denied", "required"] as const);
+const ItemSchema = Type.String({ minLength: 1, maxLength: MAX_ITEM_BYTES });
+const ItemListSchema = Type.Array(ItemSchema, { maxItems: MAX_ITEMS });
+const PathListSchema = Type.Array(Type.String({ minLength: 1, maxLength: MAX_PATH_BYTES }), {
+	maxItems: MAX_ITEMS,
+});
+
+const AggregateBudgetSchema = Type.Object(
+	{
+		timeoutMs: Type.Integer({ minimum: 1, maximum: MAX_SUBAGENT_TIMEOUT_MS }),
+		maxTurns: Type.Integer({ minimum: 1, maximum: MAX_BUDGET_TURNS }),
+		maxToolCalls: Type.Integer({ minimum: 1, maximum: MAX_BUDGET_TOOL_CALLS }),
+		maxTasks: Type.Integer({ minimum: 1, maximum: MAX_AUTOMATION_TASKS }),
+		maxRevisions: Type.Integer({ minimum: 0, maximum: MAX_AUTOMATION_REVISIONS }),
+	},
+	{ additionalProperties: false },
+);
+
+const TaskBudgetSchema = Type.Object(
+	{
+		timeoutMs: Type.Integer({ minimum: 1, maximum: MAX_SUBAGENT_TIMEOUT_MS }),
+		maxTurns: Type.Integer({ minimum: 1, maximum: MAX_BUDGET_TURNS }),
+		maxToolCalls: Type.Integer({ minimum: 1, maximum: MAX_BUDGET_TOOL_CALLS }),
+	},
+	{ additionalProperties: false },
+);
+
+export const AutomationRequestSchema = Type.Object(
+	{
+		version: Type.Literal(AUTOMATION_REQUEST_VERSION),
+		objective: Type.String({ minLength: 1, maxLength: MAX_AUTOMATION_TEXT_BYTES }),
+		nonGoals: ItemListSchema,
+		requiredInputs: ItemListSchema,
+		acceptanceCriteria: Type.Array(ItemSchema, { minItems: 1, maxItems: MAX_ITEMS }),
+		requiredEvidence: ItemListSchema,
+		authorityCeiling: Type.Object(
+			{
+				capabilities: ItemListSchema,
+				tools: ItemListSchema,
+				readPaths: PathListSchema,
+				writePaths: PathListSchema,
+				network: AuthorityRequirementSchema,
+				secrets: AuthorityRequirementSchema,
+				sideEffectPolicy: SideEffectSchema,
+			},
+			{ additionalProperties: false },
+		),
+		aggregateBudget: AggregateBudgetSchema,
+		constraints: Type.Object(
+			{
+				contextPressure: StringEnum(["low", "medium", "high"] as const),
+				maxMutatingWidth: Type.Integer({ minimum: 1, maximum: 2 }),
+				requireVerification: Type.Boolean(),
+				workspaceMode: StringEnum(["shared", "worktree"] as const),
+				allowedAgents: Type.Optional(ItemListSchema),
+			},
+			{ additionalProperties: false },
+		),
+	},
+	{ additionalProperties: false },
+);
+
+const ArtifactSchema = Type.Object(
+	{
+		id: Type.String({ minLength: 1, maxLength: 128 }),
+		kind: Type.String({ minLength: 1, maxLength: 128 }),
+		version: Type.String({ minLength: 1, maxLength: 128 }),
+	},
+	{ additionalProperties: false },
+);
+
+export const WorkflowPlanTaskSchema = Type.Object(
+	{
+		id: Type.String({ minLength: 1, maxLength: 128 }),
+		objective: Type.String({ minLength: 1, maxLength: MAX_AUTOMATION_TEXT_BYTES }),
+		dependsOn: Type.Array(Type.String({ minLength: 1, maxLength: 128 }), {
+			maxItems: MAX_AUTOMATION_TASKS,
+		}),
+		inputArtifacts: Type.Array(Type.String({ minLength: 1, maxLength: 128 }), {
+			maxItems: MAX_ITEMS,
+		}),
+		producesArtifacts: Type.Array(ArtifactSchema, { maxItems: MAX_ITEMS }),
+		sideEffectPolicy: SideEffectSchema,
+		readPaths: PathListSchema,
+		writePaths: PathListSchema,
+		ownershipKeys: ItemListSchema,
+		requiredCapabilities: ItemListSchema,
+		requiredTools: ItemListSchema,
+		requiredVerificationRole: Type.Optional(ItemSchema),
+		acceptanceCriteria: Type.Array(ItemSchema, { minItems: 1, maxItems: MAX_ITEMS }),
+		requiredEvidence: ItemListSchema,
+		integrationOwner: Type.Boolean(),
+		verifierFor: Type.Optional(Type.String({ minLength: 1, maxLength: 128 })),
+		preferredCostHint: Type.Optional(StringEnum(["low", "medium", "high"] as const)),
+		preferredLatencyHint: Type.Optional(StringEnum(["low", "medium", "high"] as const)),
+		budget: TaskBudgetSchema,
+		guarantees: Type.Optional(
+			Type.Object(
+				{ network: AuthorityRequirementSchema, secrets: Type.Optional(AuthorityRequirementSchema) },
+				{ additionalProperties: false },
+			),
+		),
+	},
+	{ additionalProperties: false },
+);
+
+export const WorkflowPlanSchema = Type.Object(
+	{
+		version: Type.Literal(WORKFLOW_PLAN_VERSION),
+		requestVersion: Type.Literal(AUTOMATION_REQUEST_VERSION),
+		summary: Type.String({ minLength: 1, maxLength: MAX_AUTOMATION_TEXT_BYTES }),
+		missingInputs: ItemListSchema,
+		risks: ItemListSchema,
+		tasks: Type.Array(WorkflowPlanTaskSchema, {
+			minItems: 1,
+			maxItems: MAX_AUTOMATION_TASKS,
+		}),
+	},
+	{ additionalProperties: false },
+);
+
+const PatchTaskSchema = WorkflowPlanTaskSchema;
+const PatchOperationSchema = Type.Union([
+	Type.Object(
+		{ type: Type.Literal("add-task"), task: PatchTaskSchema },
+		{ additionalProperties: false },
+	),
+	Type.Object(
+		{
+			type: Type.Literal("replace-task"),
+			taskId: Type.String({ minLength: 1, maxLength: 128 }),
+			task: PatchTaskSchema,
+		},
+		{ additionalProperties: false },
+	),
+	Type.Object(
+		{
+			type: Type.Literal("add-dependency"),
+			taskId: Type.String({ minLength: 1, maxLength: 128 }),
+			dependsOn: Type.String({ minLength: 1, maxLength: 128 }),
+		},
+		{ additionalProperties: false },
+	),
+	Type.Object(
+		{
+			type: Type.Literal("cancel-task"),
+			taskId: Type.String({ minLength: 1, maxLength: 128 }),
+		},
+		{ additionalProperties: false },
+	),
+	Type.Object(
+		{
+			type: Type.Literal("request-verification"),
+			taskId: Type.String({ minLength: 1, maxLength: 128 }),
+			verifier: PatchTaskSchema,
+		},
+		{ additionalProperties: false },
+	),
+	Type.Object(
+		{
+			type: Type.Literal("invalidate-downstream"),
+			taskId: Type.String({ minLength: 1, maxLength: 128 }),
+			reason: ItemSchema,
+		},
+		{ additionalProperties: false },
+	),
+]);
+
+export const WorkflowPlanPatchSchema = Type.Object(
+	{
+		version: Type.Literal(WORKFLOW_PLAN_PATCH_VERSION),
+		planId: Type.String({ pattern: "^[a-f0-9]{64}$" }),
+		workflowGeneration: Type.Integer({ minimum: 0 }),
+		reason: ItemSchema,
+		operations: Type.Array(PatchOperationSchema, { minItems: 1, maxItems: MAX_AUTOMATION_TASKS }),
+	},
+	{ additionalProperties: false },
+);
+
+export type AutomationRequest = Static<typeof AutomationRequestSchema>;
+export type WorkflowPlanTask = Static<typeof WorkflowPlanTaskSchema>;
+export type WorkflowPlan = Static<typeof WorkflowPlanSchema>;
+export type WorkflowPlanPatch = Static<typeof WorkflowPlanPatchSchema>;
+export type WorkflowPlanPatchOperation = WorkflowPlanPatch["operations"][number];
+
+export function parseAutomationRequest(value: unknown): AutomationRequest {
+	const object = strictObject(value, "automation request");
+	assertOnlyKeys(object, [
+		"version",
+		"objective",
+		"nonGoals",
+		"requiredInputs",
+		"acceptanceCriteria",
+		"requiredEvidence",
+		"authorityCeiling",
+		"aggregateBudget",
+		"constraints",
+	]);
+	if (object.version !== AUTOMATION_REQUEST_VERSION) {
+		throw new Error("Unsupported automation request version");
+	}
+	const parsed = parseBySchemaShape(object, "automation request") as AutomationRequest;
+	validateRequest(parsed);
+	return structuredClone(parsed);
+}
+
+export function parseWorkflowPlan(value: string | unknown): WorkflowPlan {
+	let decoded: unknown = value;
+	if (typeof value === "string") {
+		try {
+			decoded = JSON.parse(value);
+		} catch {
+			throw new Error("Workflow plan contains invalid JSON");
+		}
+	}
+	const object = strictObject(decoded, "workflow plan");
+	for (const key of ["planId", "workflowGeneration", "executionPlanId", "selectedAgent"]) {
+		if (key in object) throw new Error(`Workflow plan contains executor-owned field ${key}`);
+	}
+	assertOnlyKeys(object, [
+		"version",
+		"requestVersion",
+		"summary",
+		"missingInputs",
+		"risks",
+		"tasks",
+	]);
+	if (
+		object.version !== WORKFLOW_PLAN_VERSION ||
+		object.requestVersion !== AUTOMATION_REQUEST_VERSION
+	) {
+		throw new Error("Unsupported workflow plan version");
+	}
+	if (!Array.isArray(object.tasks) || object.tasks.length < 1) {
+		throw new Error("Workflow plan requires at least one task");
+	}
+	if (object.tasks.length > MAX_AUTOMATION_TASKS)
+		throw new Error("Workflow plan has too many tasks");
+	const parsed = parseBySchemaShape(object, "workflow plan") as WorkflowPlan;
+	validatePlan(parsed);
+	return structuredClone(parsed);
+}
+
+export function parseWorkflowPlanPatch(value: string | unknown): WorkflowPlanPatch {
+	let decoded: unknown = value;
+	if (typeof value === "string") {
+		try {
+			decoded = JSON.parse(value);
+		} catch {
+			throw new Error("Workflow plan patch contains invalid JSON");
+		}
+	}
+	const object = strictObject(decoded, "workflow plan patch");
+	assertOnlyKeys(object, ["version", "planId", "workflowGeneration", "reason", "operations"]);
+	if (object.version !== WORKFLOW_PLAN_PATCH_VERSION) {
+		throw new Error("Unsupported workflow plan patch version");
+	}
+	if (!Number.isSafeInteger(object.workflowGeneration) || Number(object.workflowGeneration) < 0) {
+		throw new Error("Workflow plan patch has invalid generation");
+	}
+	if (typeof object.planId !== "string" || !PLAN_ID_PATTERN.test(object.planId)) {
+		throw new Error("Workflow plan patch has invalid plan identity");
+	}
+	const parsed = parseBySchemaShape(object, "workflow plan patch") as WorkflowPlanPatch;
+	for (const operation of parsed.operations) {
+		if (operation.type === "add-task" || operation.type === "replace-task") {
+			validateTaskSafety(operation.task);
+		} else if (operation.type === "request-verification") {
+			validateTaskSafety(operation.verifier);
+		}
+	}
+	validateSafeValue(parsed, "workflow plan patch");
+	return structuredClone(parsed);
+}
+
+export function workflowPlanIdentity(
+	plan: WorkflowPlan,
+	generation: number,
+	revision: number,
+): string {
+	return createHash("sha256").update(JSON.stringify({ plan, generation, revision })).digest("hex");
+}
+
+function validateRequest(request: AutomationRequest): void {
+	for (const scope of [
+		...request.authorityCeiling.readPaths,
+		...request.authorityCeiling.writePaths,
+	]) {
+		validateRelativePath(scope);
+	}
+	validateSafeValue(request, "automation request");
+	if (
+		request.authorityCeiling.network !== "unspecified" ||
+		request.authorityCeiling.secrets !== "unspecified"
+	) {
+		throw new Error("Automation request asks for an unsupported network or secrets guarantee");
+	}
+}
+
+function validatePlan(plan: WorkflowPlan): void {
+	const byId = new Map<string, WorkflowPlanTask>();
+	const artifactProducer = new Map<string, string>();
+	for (const task of plan.tasks) {
+		validateTaskSafety(task);
+		if (byId.has(task.id)) throw new Error(`Duplicate workflow task id ${task.id}`);
+		byId.set(task.id, task);
+		for (const artifact of task.producesArtifacts) {
+			if (artifactProducer.has(artifact.id))
+				throw new Error(`Duplicate artifact id ${artifact.id}`);
+			artifactProducer.set(artifact.id, task.id);
+		}
+	}
+	for (const task of plan.tasks) {
+		for (const dependency of task.dependsOn) {
+			if (!ID_PATTERN.test(dependency))
+				throw new Error("Workflow task has an invalid dependency id");
+			if (!byId.has(dependency)) {
+				throw new Error(`Workflow task ${task.id} has a missing dependency`);
+			}
+		}
+		if (task.verifierFor && !byId.has(task.verifierFor)) {
+			throw new Error(`Workflow verifier ${task.id} targets missing task ${task.verifierFor}`);
+		}
+		for (const artifact of task.inputArtifacts) {
+			const producer = artifactProducer.get(artifact);
+			if (!producer || !task.dependsOn.includes(producer)) {
+				throw new Error(`Workflow task ${task.id} has missing artifact dependency ${artifact}`);
+			}
+		}
+	}
+	assertAcyclic(plan.tasks);
+	assertOwnershipCompatible(plan.tasks);
+	validateSafeValue(plan, "workflow plan");
+}
+
+function validateTaskSafety(task: WorkflowPlanTask): void {
+	if (!ID_PATTERN.test(task.id)) throw new Error("Workflow task has an invalid id");
+	if (
+		task.dependsOn.some((id) => !ID_PATTERN.test(id)) ||
+		task.inputArtifacts.some((id) => !ID_PATTERN.test(id)) ||
+		(task.verifierFor !== undefined && !ID_PATTERN.test(task.verifierFor)) ||
+		task.producesArtifacts.some(
+			(artifact) =>
+				!ID_PATTERN.test(artifact.id) ||
+				!ID_PATTERN.test(artifact.kind) ||
+				!ID_PATTERN.test(artifact.version),
+		)
+	) {
+		throw new Error(`Workflow task ${task.id} has an invalid dependency or artifact identity`);
+	}
+	for (const scope of [...task.readPaths, ...task.writePaths]) validateRelativePath(scope);
+	if (task.sideEffectPolicy === "read-only" && task.writePaths.length > 0) {
+		throw new Error(`Read-only workflow task ${task.id} declares write paths`);
+	}
+	if (task.guarantees && Object.values(task.guarantees).some((value) => value !== "unspecified")) {
+		throw new Error(`Workflow task ${task.id} requests an unsupported guarantee`);
+	}
+}
+
+function assertAcyclic(tasks: readonly WorkflowPlanTask[]): void {
+	const byId = new Map(tasks.map((task) => [task.id, task]));
+	const visiting = new Set<string>();
+	const visited = new Set<string>();
+	const visit = (id: string) => {
+		if (visiting.has(id)) throw new Error(`Workflow dependency cycle includes ${id}`);
+		if (visited.has(id)) return;
+		visiting.add(id);
+		for (const dependency of byId.get(id)?.dependsOn ?? []) visit(dependency);
+		visiting.delete(id);
+		visited.add(id);
+	};
+	for (const task of tasks) visit(task.id);
+}
+
+function assertOwnershipCompatible(tasks: readonly WorkflowPlanTask[]): void {
+	const byId = new Map(tasks.map((task) => [task.id, task]));
+	const dependsTransitively = (
+		taskId: string,
+		possibleAncestor: string,
+		seen = new Set<string>(),
+	): boolean => {
+		if (seen.has(taskId)) return false;
+		seen.add(taskId);
+		for (const dependency of byId.get(taskId)?.dependsOn ?? []) {
+			if (
+				dependency === possibleAncestor ||
+				dependsTransitively(dependency, possibleAncestor, seen)
+			) {
+				return true;
+			}
+		}
+		return false;
+	};
+	for (let leftIndex = 0; leftIndex < tasks.length; leftIndex++) {
+		for (let rightIndex = leftIndex + 1; rightIndex < tasks.length; rightIndex++) {
+			const left = tasks[leftIndex];
+			const right = tasks[rightIndex];
+			if (
+				left.ownershipKeys.some((key) => right.ownershipKeys.includes(key)) &&
+				!dependsTransitively(left.id, right.id) &&
+				!dependsTransitively(right.id, left.id)
+			) {
+				throw new Error(`Workflow tasks ${left.id} and ${right.id} have conflicting ownership`);
+			}
+		}
+	}
+}
+
+function parseBySchemaShape(value: Record<string, unknown>, label: string): unknown {
+	if (label === "automation request") {
+		validateRequiredObject(value.authorityCeiling, "authorityCeiling", [
+			"capabilities",
+			"tools",
+			"readPaths",
+			"writePaths",
+			"network",
+			"secrets",
+			"sideEffectPolicy",
+		]);
+		validateRequiredObject(value.aggregateBudget, "aggregateBudget", [
+			"timeoutMs",
+			"maxTurns",
+			"maxToolCalls",
+			"maxTasks",
+			"maxRevisions",
+		]);
+		validateRequiredObject(value.constraints, "constraints", [
+			"contextPressure",
+			"maxMutatingWidth",
+			"requireVerification",
+			"workspaceMode",
+			"allowedAgents",
+		]);
+		validateString(value.objective, "objective", MAX_AUTOMATION_TEXT_BYTES);
+		validateStringList(value.nonGoals, "nonGoals");
+		validateStringList(value.requiredInputs, "requiredInputs");
+		validateStringList(value.acceptanceCriteria, "acceptanceCriteria", true);
+		validateStringList(value.requiredEvidence, "requiredEvidence");
+		const ceiling = value.authorityCeiling as Record<string, unknown>;
+		validateStringList(ceiling.capabilities, "capabilities");
+		validateStringList(ceiling.tools, "tools");
+		validateStringList(ceiling.readPaths, "readPaths");
+		validateStringList(ceiling.writePaths, "writePaths");
+		if (!["unspecified", "denied", "required"].includes(String(ceiling.network)))
+			throw new Error("Invalid network authority ceiling");
+		if (!["unspecified", "denied", "required"].includes(String(ceiling.secrets)))
+			throw new Error("Invalid secrets authority ceiling");
+		if (!["read-only", "idempotent", "mutating"].includes(String(ceiling.sideEffectPolicy)))
+			throw new Error("Invalid side-effect authority ceiling");
+		const budget = value.aggregateBudget as Record<string, unknown>;
+		validateBudget(budget, true);
+		const constraints = value.constraints as Record<string, unknown>;
+		if (!["low", "medium", "high"].includes(String(constraints.contextPressure)))
+			throw new Error("Invalid context pressure");
+		if (
+			!Number.isSafeInteger(constraints.maxMutatingWidth) ||
+			Number(constraints.maxMutatingWidth) < 1 ||
+			Number(constraints.maxMutatingWidth) > 2
+		)
+			throw new Error("Invalid mutating width");
+		if (typeof constraints.requireVerification !== "boolean")
+			throw new Error("Invalid verification constraint");
+		if (!["shared", "worktree"].includes(String(constraints.workspaceMode)))
+			throw new Error("Invalid workspace mode");
+		if (constraints.allowedAgents !== undefined)
+			validateStringList(constraints.allowedAgents, "allowedAgents");
+		return value;
+	}
+	if (label === "workflow plan") {
+		validateString(value.summary, "summary", MAX_AUTOMATION_TEXT_BYTES);
+		validateStringList(value.missingInputs, "missingInputs");
+		validateStringList(value.risks, "risks");
+		for (const raw of value.tasks as unknown[]) validateTask(strictObject(raw, "workflow task"));
+		return value;
+	}
+	validateString(value.reason, "reason", MAX_ITEM_BYTES);
+	if (
+		!Array.isArray(value.operations) ||
+		value.operations.length < 1 ||
+		value.operations.length > MAX_AUTOMATION_TASKS
+	)
+		throw new Error("Invalid workflow plan patch operations");
+	for (const raw of value.operations) validatePatchOperation(strictObject(raw, "patch operation"));
+	return value;
+}
+
+function validateTask(task: Record<string, unknown>): void {
+	assertOnlyKeys(task, [
+		"id",
+		"objective",
+		"dependsOn",
+		"inputArtifacts",
+		"producesArtifacts",
+		"sideEffectPolicy",
+		"readPaths",
+		"writePaths",
+		"ownershipKeys",
+		"requiredCapabilities",
+		"requiredTools",
+		"requiredVerificationRole",
+		"acceptanceCriteria",
+		"requiredEvidence",
+		"integrationOwner",
+		"verifierFor",
+		"preferredCostHint",
+		"preferredLatencyHint",
+		"budget",
+		"guarantees",
+	]);
+	validateString(task.id, "task id", 128);
+	validateString(task.objective, "task objective", MAX_AUTOMATION_TEXT_BYTES);
+	for (const field of [
+		"dependsOn",
+		"inputArtifacts",
+		"readPaths",
+		"writePaths",
+		"ownershipKeys",
+		"requiredCapabilities",
+		"requiredTools",
+		"acceptanceCriteria",
+		"requiredEvidence",
+	] as const)
+		validateStringList(task[field], field, field === "acceptanceCriteria");
+	if (!Array.isArray(task.producesArtifacts) || task.producesArtifacts.length > MAX_ITEMS)
+		throw new Error("Invalid task artifacts");
+	for (const raw of task.producesArtifacts) {
+		const artifact = strictObject(raw, "artifact");
+		assertOnlyKeys(artifact, ["id", "kind", "version"]);
+		validateString(artifact.id, "artifact id", 128);
+		validateString(artifact.kind, "artifact kind", 128);
+		validateString(artifact.version, "artifact version", 128);
+	}
+	if (!["read-only", "idempotent", "mutating"].includes(String(task.sideEffectPolicy)))
+		throw new Error("Invalid task side-effect policy");
+	if (typeof task.integrationOwner !== "boolean") throw new Error("Invalid integration owner");
+	for (const field of ["requiredVerificationRole", "verifierFor"] as const)
+		if (task[field] !== undefined) validateString(task[field], field, MAX_ITEM_BYTES);
+	for (const field of ["preferredCostHint", "preferredLatencyHint"] as const)
+		if (task[field] !== undefined && !["low", "medium", "high"].includes(String(task[field])))
+			throw new Error(`Invalid ${field}`);
+	validateRequiredObject(task.budget, "task budget", ["timeoutMs", "maxTurns", "maxToolCalls"]);
+	validateBudget(task.budget as Record<string, unknown>, false);
+	if (task.guarantees !== undefined) {
+		validateRequiredObject(task.guarantees, "guarantees", ["network", "secrets"]);
+		const guarantees = task.guarantees as Record<string, unknown>;
+		for (const value of Object.values(guarantees))
+			if (!["unspecified", "denied", "required"].includes(String(value)))
+				throw new Error("Invalid task guarantee");
+	}
+}
+
+function validatePatchOperation(operation: Record<string, unknown>): void {
+	const type = operation.type;
+	if (type === "add-task") {
+		assertOnlyKeys(operation, ["type", "task"]);
+		validateTask(strictObject(operation.task, "patch task"));
+		return;
+	}
+	if (type === "replace-task") {
+		assertOnlyKeys(operation, ["type", "taskId", "task"]);
+		validateString(operation.taskId, "taskId", 128);
+		validateTask(strictObject(operation.task, "patch task"));
+		return;
+	}
+	if (type === "add-dependency") {
+		assertOnlyKeys(operation, ["type", "taskId", "dependsOn"]);
+		validateString(operation.taskId, "taskId", 128);
+		validateString(operation.dependsOn, "dependsOn", 128);
+		return;
+	}
+	if (type === "cancel-task") {
+		assertOnlyKeys(operation, ["type", "taskId"]);
+		validateString(operation.taskId, "taskId", 128);
+		return;
+	}
+	if (type === "request-verification") {
+		assertOnlyKeys(operation, ["type", "taskId", "verifier"]);
+		validateString(operation.taskId, "taskId", 128);
+		validateTask(strictObject(operation.verifier, "patch verifier"));
+		return;
+	}
+	if (type === "invalidate-downstream") {
+		assertOnlyKeys(operation, ["type", "taskId", "reason"]);
+		validateString(operation.taskId, "taskId", 128);
+		validateString(operation.reason, "reason", MAX_ITEM_BYTES);
+		return;
+	}
+	throw new Error("Unsupported workflow plan patch operation");
+}
+
+function validateBudget(budget: Record<string, unknown>, aggregate: boolean): void {
+	const limits: Record<string, number> = {
+		timeoutMs: MAX_SUBAGENT_TIMEOUT_MS,
+		maxTurns: MAX_BUDGET_TURNS,
+		maxToolCalls: MAX_BUDGET_TOOL_CALLS,
+		...(aggregate
+			? { maxTasks: MAX_AUTOMATION_TASKS, maxRevisions: MAX_AUTOMATION_REVISIONS }
+			: {}),
+	};
+	for (const [field, max] of Object.entries(limits)) {
+		const value = budget[field];
+		const minimum = field === "maxRevisions" ? 0 : 1;
+		if (!Number.isSafeInteger(value) || Number(value) < minimum || Number(value) > max)
+			throw new Error(`Invalid ${field} budget`);
+	}
+}
+
+function validateRequiredObject(value: unknown, label: string, keys: readonly string[]): void {
+	const object = strictObject(value, label);
+	assertOnlyKeys(object, keys);
+}
+
+function validateStringList(value: unknown, label: string, requireOne = false): void {
+	if (!Array.isArray(value) || value.length > MAX_ITEMS || (requireOne && value.length < 1))
+		throw new Error(`Invalid ${label}`);
+	for (const item of value) validateString(item, label, MAX_ITEM_BYTES);
+}
+
+function validateString(value: unknown, label: string, maxBytes: number): void {
+	if (typeof value !== "string" || !value.trim()) throw new Error(`Invalid ${label}`);
+	if (Buffer.byteLength(value, "utf8") > maxBytes) throw new Error(`${label} is too large`);
+}
+
+function validateSafeValue(value: unknown, label: string): void {
+	const visit = (candidate: unknown): void => {
+		if (typeof candidate === "string") {
+			if (containsTerminalControl(candidate)) {
+				throw new Error(`${label} contains terminal control bytes`);
+			}
+			if (PRIVATE_MARKER_PATTERN.test(candidate)) {
+				throw new Error(`${label} contains private data markers`);
+			}
+			return;
+		}
+		if (Array.isArray(candidate)) {
+			for (const item of candidate) visit(item);
+			return;
+		}
+		if (candidate && typeof candidate === "object") {
+			for (const item of Object.values(candidate as Record<string, unknown>)) visit(item);
+		}
+	};
+	visit(value);
+}
+
+function validateRelativePath(value: string): void {
+	if (
+		Buffer.byteLength(value, "utf8") > MAX_PATH_BYTES ||
+		containsTerminalControl(value) ||
+		value.includes("\\") ||
+		path.posix.isAbsolute(value) ||
+		value.split("/").includes("..")
+	) {
+		throw new Error(`Invalid workflow path ${JSON.stringify(value.slice(0, 128))}`);
+	}
+	const normalized = path.posix.normalize(value.trim());
+	if (!normalized || normalized === ".." || normalized.startsWith("../"))
+		throw new Error("Invalid workflow path");
+}
+
+function containsTerminalControl(value: string): boolean {
+	for (let index = 0; index < value.length; index++) {
+		const code = value.charCodeAt(index);
+		if (
+			code <= 0x08 ||
+			code === 0x0b ||
+			code === 0x0c ||
+			(code >= 0x0e && code <= 0x1f) ||
+			(code >= 0x7f && code <= 0x9f)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function strictObject(value: unknown, label: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value))
+		throw new Error(`${label} must be an object`);
+	return value as Record<string, unknown>;
+}
+
+function assertOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): void {
+	const unexpected = Object.keys(value).find((key) => !allowed.includes(key));
+	if (unexpected) throw new Error("Unknown field in versioned automation contract");
+}

--- a/packages/pi-subagents/src/automation-planner.ts
+++ b/packages/pi-subagents/src/automation-planner.ts
@@ -1,0 +1,65 @@
+import type { AutomationRequest, WorkflowPlan } from "./automation-contract.js";
+import { parseWorkflowPlan, WORKFLOW_PLAN_VERSION } from "./automation-contract.js";
+import { resolveConsultResourceLaunchPolicy } from "./consult-resources.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import type { ChildLaunchPolicy } from "./runner.js";
+
+export const AUTOMATION_PLANNER_TOOLS = ["read", "grep", "find", "ls"] as const;
+export const AUTOMATION_PLANNER_MAX_TIMEOUT_MS = 60_000;
+export const AUTOMATION_PLANNER_MAX_TURNS = 8;
+export const AUTOMATION_PLANNER_MAX_TOOL_CALLS = 16;
+
+export interface AutomationPlannerPolicy {
+	tools: string[];
+	resources: "project-context" | "none";
+	launchPolicy: ChildLaunchPolicy;
+}
+
+export function buildAutomationPlannerPrompt(request: AutomationRequest): string {
+	const prompt = [
+		"Compile the following explicit automation request into the smallest justified workflow proposal.",
+		`Return only JSON for ${WORKFLOW_PLAN_VERSION}; do not wrap it in Markdown or add prose.`,
+		"Do not provide hidden reasoning, chain-of-thought, or internal deliberation.",
+		"Use summary and risks only for concise, user-visible conclusions.",
+		"The executor, not this planning turn, owns identities, generations, agent selection, trust, tools, authority, workspace policy, and enforcement.",
+		"Your proposal cannot grant authority, tools, trust, network, secrets, descendants, or budget beyond the request.",
+		"Propose at most the request maxTasks and never propose workflow grandchildren.",
+		"Each task must include id, objective, dependsOn, inputArtifacts, producesArtifacts, sideEffectPolicy, readPaths, writePaths, ownershipKeys, requiredCapabilities, requiredTools, acceptanceCriteria, requiredEvidence, integrationOwner, and budget.",
+		"Use requiredVerificationRole and verifierFor only for a distinct direct verifier.",
+		"Declare dependencies with dependsOn, declare artifact id, kind, and version, and connect every consumed artifact through a direct dependency.",
+		"Use one authoritative integrationOwner for multi-task mutating work.",
+		"If required information is absent, list it in missingInputs instead of inventing it.",
+		"Request:",
+		JSON.stringify(request),
+		"Expected top-level fields: version, requestVersion, summary, missingInputs, risks, tasks.",
+	].join("\n");
+	const bounded = truncateUtf8(prompt, DEFAULT_MAX_CONTEXT_BYTES);
+	if (bounded.truncated)
+		throw new Error("Automation planner prompt exceeds the bounded context limit");
+	return bounded.text;
+}
+
+export async function resolveAutomationPlannerPolicy(
+	projectTrusted: boolean,
+	cwd: string,
+	resolver: typeof resolveConsultResourceLaunchPolicy = resolveConsultResourceLaunchPolicy,
+): Promise<AutomationPlannerPolicy> {
+	const resources = projectTrusted ? "project-context" : "none";
+	const launchPolicy = await resolver(resources, projectTrusted, cwd);
+	return {
+		tools: [...AUTOMATION_PLANNER_TOOLS],
+		resources,
+		launchPolicy: {
+			...launchPolicy,
+			tools: [...AUTOMATION_PLANNER_TOOLS],
+			disableExtensions: true,
+		},
+	};
+}
+
+export function parseAutomationPlannerOutput(output: string): WorkflowPlan {
+	if (typeof output !== "string" || !output.trim()) {
+		throw new Error("Automation planner returned no workflow plan");
+	}
+	return parseWorkflowPlan(output.trim());
+}

--- a/packages/pi-subagents/src/automation.ts
+++ b/packages/pi-subagents/src/automation.ts
@@ -1,0 +1,560 @@
+import { createHash } from "node:crypto";
+import * as path from "node:path";
+import type { AgentToolResult, AgentToolUpdateCallback } from "@earendil-works/pi-agent-core";
+import {
+	type ExtensionAPI,
+	type ExtensionContext,
+	getAgentDir,
+	type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { type Static, Type } from "typebox";
+import { discoverAgents, type SubagentSettings } from "./agents.js";
+import {
+	AutomationRequestSchema,
+	parseAutomationRequest,
+	type WorkflowPlan,
+} from "./automation-contract.js";
+import {
+	AUTOMATION_PLANNER_MAX_TIMEOUT_MS,
+	AUTOMATION_PLANNER_MAX_TOOL_CALLS,
+	AUTOMATION_PLANNER_MAX_TURNS,
+	AUTOMATION_PLANNER_TOOLS,
+	buildAutomationPlannerPrompt,
+	parseAutomationPlannerOutput,
+	resolveAutomationPlannerPolicy,
+} from "./automation-planner.js";
+import {
+	assertDelegationTargetAllowed,
+	resolveSubagentTarget,
+	targetPolicyAudit,
+} from "./cwd-policy.js";
+import { executeSubagent } from "./execution.js";
+import { renderFallbackResult, safeLine, toolHeader } from "./render-common.js";
+import {
+	getResultFinalOutput,
+	isResultError,
+	runSingleAgent,
+	type SingleResult,
+	type SubagentDetails,
+} from "./runner.js";
+import { boundedPrivateText } from "./safe-text.js";
+import { DEFAULT_DELEGATION_CWD_POLICY } from "./settings.js";
+import {
+	type CompiledWorkflowPlan,
+	compileWorkflowPlan,
+	type WorkflowPlanCompilerResult,
+} from "./workflow-plan-compiler.js";
+import { AutomationPlanPersistence, createWorkflowPlanRecord } from "./workflow-plan-patch.js";
+import { createBlockingWorkLedger, resolveWorkflowTasks } from "./workflow-planning.js";
+
+export const SubagentAutomationParams = Type.Object(
+	{ request: AutomationRequestSchema },
+	{ additionalProperties: false },
+);
+export type SubagentAutomationParams = Static<typeof SubagentAutomationParams>;
+
+export interface AutomationDetails {
+	status:
+		| "planning"
+		| "planner-failed"
+		| "parent-owned"
+		| "needs-input"
+		| "compiler-rejected"
+		| "executed";
+	requestVersion: string;
+	planVersion?: string;
+	planId?: string;
+	workflowGeneration?: number;
+	revision?: number;
+	childCount: number;
+	reasonCodes: string[];
+	missingInputs?: string[];
+	planner?: {
+		agent: string;
+		tools: string[];
+		resources: "project-context" | "none";
+		timeoutMs: number;
+		maxTurns: number;
+		maxToolCalls: number;
+		failed?: boolean;
+	};
+	compiled?: CompiledWorkflowPlan;
+	execution?: SubagentDetails;
+	isError?: boolean;
+}
+
+export interface AutomationPlannerRequest {
+	prompt: string;
+	ctx: ExtensionContext;
+	signal: AbortSignal;
+	settings: SubagentSettings | undefined;
+	timeoutMs: number;
+	maxTurns: number;
+	maxToolCalls: number;
+}
+
+export interface AutomationExecutionOptions {
+	getSettings(): SubagentSettings | undefined;
+	runPlanner?: (request: AutomationPlannerRequest) => Promise<string>;
+	runWorkflow?: (
+		params: Parameters<typeof executeSubagent>[1],
+		signal: AbortSignal,
+		ctx: ExtensionContext,
+	) => ReturnType<typeof executeSubagent>;
+	persistCompiled?: (compiled: CompiledWorkflowPlan, ctx: ExtensionContext) => Promise<void>;
+}
+
+export function registerSubagentAutomation(
+	pi: ExtensionAPI,
+	options: AutomationExecutionOptions,
+): void {
+	let generation = 0;
+	const activeControllers = new Set<AbortController>();
+	const activeWork = new Set<Promise<unknown>>();
+	const cancelAndWait = async (reason: string) => {
+		generation++;
+		for (const controller of activeControllers) {
+			controller.abort(new DOMException(reason, "AbortError"));
+		}
+		await Promise.allSettled([...activeWork]);
+	};
+	pi.on("session_start", () => cancelAndWait("Autonomous workflow session replaced"));
+	pi.on("session_shutdown", () => cancelAndWait("Autonomous workflow session shut down"));
+	const description = () =>
+		[
+			"Explicitly opt in to one bounded read-only planning turn that compiles a high-level objective into the smallest justified existing workflow.",
+			"The deterministic compiler may return parent-owned work, request missing input, or reject without launching execution workers.",
+			"Mutating workflows require an authoritative integration path and an independent verifier, allow at most two concurrent mutating workers, and never allow workflow grandchildren.",
+			"The first version routes only built-in and user-scoped agents; use caller-authored workflow mode for project-local agents.",
+		].join(" ");
+	const definition: ToolDefinition<typeof SubagentAutomationParams, AutomationDetails> = {
+		name: "subagent_auto",
+		label: "Autonomous Subagent Workflow",
+		description: description(),
+		promptSnippet:
+			"Explicitly compile one high-level objective into a bounded capability-matched workflow",
+		promptGuidelines: [
+			"Use subagent_auto only when the caller explicitly opts into autonomous workflow planning.",
+			"Provide a complete authority ceiling and aggregate budget; parent-owned and insufficient-evidence results launch no execution workers.",
+			"Use caller-authored subagent workflow mode as the compatibility fallback when deterministic task control is required.",
+		],
+		parameters: SubagentAutomationParams,
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const ownerGeneration = generation;
+			const controller = new AbortController();
+			activeControllers.add(controller);
+			const combined = combineSignals(signal, controller.signal);
+			const work = executeAutomationRequest(
+				toolCallId,
+				params,
+				combined.signal,
+				onUpdate,
+				ctx,
+				options,
+				() => ownerGeneration === generation,
+			);
+			activeWork.add(work);
+			try {
+				return await work;
+			} finally {
+				combined.dispose();
+				activeControllers.delete(controller);
+				activeWork.delete(work);
+			}
+		},
+		renderCall(args, theme) {
+			const request = (args as { request?: { objective?: string; version?: string } }).request;
+			return new Text(
+				toolHeader(theme, "subagent_auto", request?.objective, [request?.version ?? "request"]),
+				0,
+				0,
+			);
+		},
+		renderResult(result, renderOptions, theme) {
+			const status = safeLine(result.details?.status, "completed", 128);
+			return renderFallbackResult(
+				result,
+				renderOptions,
+				theme,
+				result.details?.isError === true ||
+					status.endsWith("failed") ||
+					status.endsWith("rejected"),
+			);
+		},
+	};
+	pi.registerTool<typeof SubagentAutomationParams, AutomationDetails>(definition);
+	pi.on("tool_result", (event) => {
+		if (event.toolName !== "subagent_auto") return;
+		if ((event.details as AutomationDetails | undefined)?.isError) return { isError: true };
+	});
+}
+
+export async function executeAutomationRequest(
+	toolCallId: string,
+	params: SubagentAutomationParams,
+	signal: AbortSignal,
+	onUpdate: AgentToolUpdateCallback<AutomationDetails> | undefined,
+	ctx: ExtensionContext,
+	options: AutomationExecutionOptions,
+	isCurrent: () => boolean = () => true,
+): Promise<AgentToolResult<AutomationDetails> & { isError?: boolean }> {
+	validateAutomationToolParams(params);
+	const request = parseAutomationRequest(params.request);
+	assertCurrent(signal, isCurrent);
+	const plannerBudget = reservePlannerBudget(request.aggregateBudget);
+	const plannerDetails: NonNullable<AutomationDetails["planner"]> = {
+		agent: "planner",
+		tools: [...AUTOMATION_PLANNER_TOOLS],
+		resources: ctx.isProjectTrusted() ? "project-context" : "none",
+		...plannerBudget,
+	};
+	const depth = Number.parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) || 0;
+	if (depth > 0) {
+		return {
+			content: [
+				{
+					type: "text",
+					text: "Automation compiler rejected workflow recursion before planning or execution.",
+				},
+			],
+			details: {
+				status: "compiler-rejected",
+				requestVersion: request.version,
+				childCount: 0,
+				reasonCodes: ["workflow-recursion-disabled"],
+				planner: plannerDetails,
+				isError: true,
+			},
+			isError: true,
+		};
+	}
+	onUpdate?.({
+		content: [{ type: "text", text: "Planning a bounded autonomous workflow." }],
+		details: {
+			status: "planning",
+			requestVersion: request.version,
+			childCount: 0,
+			reasonCodes: [],
+			planner: plannerDetails,
+		},
+	});
+	let proposal: WorkflowPlan;
+	try {
+		const prompt = buildAutomationPlannerPrompt(request);
+		const runPlanner = options.runPlanner ?? runDefaultPlanner;
+		const output = await runPlanner({
+			prompt,
+			ctx,
+			signal,
+			settings: options.getSettings(),
+			...plannerBudget,
+		});
+		assertCurrent(signal, isCurrent);
+		proposal = parseAutomationPlannerOutput(output);
+	} catch (error) {
+		if (signal.aborted || !isCurrent()) throw abortError("Automation planning was cancelled");
+		return nonLaunchResult(
+			"planner-failed",
+			request.version,
+			["planner-failed"],
+			plannerDetails,
+			error,
+		);
+	}
+	const executionRequest = reserveExecutionBudget(request, plannerBudget);
+	const settings = options.getSettings();
+	const target = resolveSubagentTarget({
+		workspace: ctx.cwd,
+		requestedCwd: ctx.cwd,
+		currentProjectTrusted: ctx.isProjectTrusted(),
+	});
+	try {
+		assertDelegationTargetAllowed(
+			target,
+			settings?.cwdPolicy?.delegation ?? DEFAULT_DELEGATION_CWD_POLICY,
+		);
+	} catch (error) {
+		return nonLaunchResult(
+			"compiler-rejected",
+			request.version,
+			["target-policy-rejected"],
+			plannerDetails,
+			error,
+		);
+	}
+	const agents = discoverAgents(ctx.cwd, "user", settings).agents;
+	const compiled = compileWorkflowPlan({
+		request: executionRequest,
+		proposal,
+		agents,
+		target: targetPolicyAudit(target),
+		depth,
+	});
+	assertCurrent(signal, isCurrent);
+	if (compiled.status !== "compiled") {
+		return compilerNonLaunch(request.version, proposal.version, compiled, plannerDetails);
+	}
+	try {
+		if (options.persistCompiled) await options.persistCompiled(compiled, ctx);
+		else await persistCompiledWorkflow(compiled, ctx, settings);
+		assertCurrent(signal, isCurrent);
+	} catch (error) {
+		return nonLaunchResult(
+			"compiler-rejected",
+			request.version,
+			["plan-persistence-failed"],
+			plannerDetails,
+			error,
+		);
+	}
+	const workflowParams = {
+		workflow: compiled.workflow,
+		agentScope: "user" as const,
+		totalTimeoutMs: executionRequest.aggregateBudget.timeoutMs,
+	};
+	const execute =
+		options.runWorkflow ??
+		((workflow, workflowSignal, workflowContext) =>
+			executeSubagent(toolCallId, workflow, workflowSignal, undefined, workflowContext, settings));
+	const result = await execute(workflowParams, signal, ctx);
+	assertCurrent(signal, isCurrent);
+	const details: AutomationDetails = {
+		status: "executed",
+		requestVersion: request.version,
+		planVersion: proposal.version,
+		planId: compiled.planId,
+		workflowGeneration: compiled.workflowGeneration,
+		revision: compiled.revision,
+		childCount: compiled.childCount,
+		reasonCodes: [],
+		planner: plannerDetails,
+		compiled,
+		execution: result.details,
+		...(result.isError ? { isError: true } : {}),
+	};
+	return {
+		content: result.content,
+		details,
+		...(result.usage ? { usage: result.usage } : {}),
+		...(result.isError ? { isError: true } : {}),
+	};
+}
+
+async function runDefaultPlanner(request: AutomationPlannerRequest): Promise<string> {
+	const discovery = discoverAgents(request.ctx.cwd, "user", request.settings);
+	const planner = discovery.agents.find((agent) => agent.name === "planner");
+	if (!planner) throw new Error("The built-in automation planner is unavailable");
+	const policy = await resolveAutomationPlannerPolicy(
+		request.ctx.isProjectTrusted(),
+		request.ctx.cwd,
+	);
+	if (request.signal.aborted) throw abortError("Automation planner was cancelled before launch");
+	const child = {
+		...planner,
+		tools: [...AUTOMATION_PLANNER_TOOLS],
+		systemPrompt: [
+			planner.systemPrompt,
+			"This planning turn is read-only and cannot execute delegated work or create descendants.",
+			"Return one exact versioned JSON workflow proposal without Markdown fences.",
+		].join("\n\n"),
+	};
+	const result = await runSingleAgent(
+		request.ctx.cwd,
+		[child],
+		child.name,
+		request.prompt,
+		request.ctx.cwd,
+		undefined,
+		request.signal,
+		child.thinkingLevel,
+		request.timeoutMs,
+		undefined,
+		(results): SubagentDetails => ({
+			mode: "single",
+			agentScope: "user",
+			projectAgentsDir: null,
+			results,
+		}),
+		undefined,
+		{
+			...policy.launchPolicy,
+			tools: [...AUTOMATION_PLANNER_TOOLS],
+			turnLimits: {
+				maxTurns: request.maxTurns,
+				maxToolCalls: request.maxToolCalls,
+			},
+		},
+	);
+	if (isResultError(result)) throw plannerFailure(result);
+	return getResultFinalOutput(result);
+}
+
+async function persistCompiledWorkflow(
+	compiled: CompiledWorkflowPlan,
+	ctx: ExtensionContext,
+	settings: SubagentSettings | undefined,
+): Promise<void> {
+	const agents = discoverAgents(ctx.cwd, "user", settings).agents;
+	const resolved = resolveWorkflowTasks({ workflow: compiled.workflow }, agents);
+	const ledger = createBlockingWorkLedger({ workflow: compiled.workflow }, resolved, undefined);
+	if (!ledger) throw new Error("Compiled automation workflow did not create a WorkItem ledger");
+	const owner =
+		ctx.sessionManager.getSessionId?.() ??
+		ctx.sessionManager.getSessionFile?.() ??
+		`ephemeral:${ctx.cwd}`;
+	const stable = createHash("sha256").update(`session:${owner}`).digest("hex").slice(0, 24);
+	const filePath = path.join(getAgentDir(), "pi-subagents-workflows", `automation-${stable}.json`);
+	await new AutomationPlanPersistence(filePath).save({
+		record: createWorkflowPlanRecord(compiled),
+		ledger: ledger.snapshot(),
+	});
+}
+
+function validateAutomationToolParams(value: unknown): asserts value is SubagentAutomationParams {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("subagent_auto parameters must be an object");
+	}
+	const keys = Object.keys(value as Record<string, unknown>);
+	if (keys.length !== 1 || keys[0] !== "request") {
+		throw new Error("subagent_auto accepts exactly one request field");
+	}
+}
+
+function compilerNonLaunch(
+	requestVersion: string,
+	planVersion: string,
+	compiled: Exclude<WorkflowPlanCompilerResult, CompiledWorkflowPlan>,
+	planner: NonNullable<AutomationDetails["planner"]>,
+): AgentToolResult<AutomationDetails> & { isError?: boolean } {
+	const status =
+		compiled.status === "parent-owned"
+			? "parent-owned"
+			: compiled.status === "needs-input"
+				? "needs-input"
+				: "compiler-rejected";
+	const isError = status === "compiler-rejected";
+	return {
+		content: [
+			{
+				type: "text",
+				text:
+					status === "parent-owned"
+						? "Automation decision: keep this objective parent-owned; no execution workers were launched."
+						: status === "needs-input"
+							? `Automation needs input: ${(compiled.missingInputs ?? []).join(", ")}`
+							: `Automation compiler rejected the proposal: ${compiled.reasonCodes.join(", ")}`,
+			},
+		],
+		details: {
+			status,
+			requestVersion,
+			planVersion,
+			childCount: 0,
+			reasonCodes: [...compiled.reasonCodes],
+			...(compiled.missingInputs ? { missingInputs: [...compiled.missingInputs] } : {}),
+			planner,
+			...(isError ? { isError: true } : {}),
+		},
+		...(isError ? { isError: true } : {}),
+	};
+}
+
+function nonLaunchResult(
+	status: "planner-failed" | "compiler-rejected",
+	requestVersion: string,
+	reasonCodes: string[],
+	planner: NonNullable<AutomationDetails["planner"]>,
+	error: unknown,
+): AgentToolResult<AutomationDetails> & { isError: true } {
+	const message = boundedPrivateText(
+		error instanceof Error ? error.message : String(error),
+		2 * 1024,
+	);
+	return {
+		content: [{ type: "text", text: `Automation ${status}: ${message}` }],
+		details: {
+			status,
+			requestVersion,
+			childCount: 0,
+			reasonCodes,
+			planner: { ...planner, ...(status === "planner-failed" ? { failed: true } : {}) },
+			isError: true,
+		},
+		isError: true,
+	};
+}
+
+function reservePlannerBudget(budget: {
+	timeoutMs: number;
+	maxTurns: number;
+	maxToolCalls: number;
+}) {
+	return {
+		timeoutMs: Math.max(
+			1,
+			Math.min(AUTOMATION_PLANNER_MAX_TIMEOUT_MS, Math.floor(budget.timeoutMs / 4)),
+		),
+		maxTurns: Math.max(1, Math.min(AUTOMATION_PLANNER_MAX_TURNS, Math.floor(budget.maxTurns / 4))),
+		maxToolCalls: Math.max(
+			1,
+			Math.min(AUTOMATION_PLANNER_MAX_TOOL_CALLS, Math.floor(budget.maxToolCalls / 4)),
+		),
+	};
+}
+
+function reserveExecutionBudget(
+	request: ReturnType<typeof parseAutomationRequest>,
+	planner: ReturnType<typeof reservePlannerBudget>,
+): ReturnType<typeof parseAutomationRequest> {
+	return {
+		...request,
+		aggregateBudget: {
+			...request.aggregateBudget,
+			timeoutMs: Math.max(1, request.aggregateBudget.timeoutMs - planner.timeoutMs),
+			maxTurns: Math.max(1, request.aggregateBudget.maxTurns - planner.maxTurns),
+			maxToolCalls: Math.max(1, request.aggregateBudget.maxToolCalls - planner.maxToolCalls),
+		},
+	};
+}
+
+function plannerFailure(result: SingleResult): Error {
+	return new Error(
+		boundedPrivateText(
+			result.errorMessage || result.stderr.trim() || "Automation planner failed",
+			2 * 1024,
+		),
+	);
+}
+
+function assertCurrent(signal: AbortSignal, isCurrent: () => boolean): void {
+	if (signal.aborted || !isCurrent()) throw abortError("Autonomous workflow owner was replaced");
+}
+
+function abortError(message: string): Error {
+	const error = new Error(message);
+	error.name = "AbortError";
+	return error;
+}
+
+function combineSignals(
+	external: AbortSignal | undefined,
+	owned: AbortSignal,
+): { signal: AbortSignal; dispose(): void } {
+	const controller = new AbortController();
+	const signals = [external, owned].filter((value): value is AbortSignal => value !== undefined);
+	const listeners = signals.map((source) => {
+		const listener = () => {
+			if (!controller.signal.aborted) controller.abort(source.reason);
+		};
+		if (source.aborted) listener();
+		else source.addEventListener("abort", listener, { once: true });
+		return { source, listener };
+	});
+	return {
+		signal: controller.signal,
+		dispose() {
+			for (const { source, listener } of listeners) source.removeEventListener("abort", listener);
+		},
+	};
+}

--- a/packages/pi-subagents/src/execution-plan.ts
+++ b/packages/pi-subagents/src/execution-plan.ts
@@ -161,7 +161,7 @@ export function resolveContractTools(
 	contract: DelegationContract | undefined,
 ): string[] | undefined {
 	const requested = contract?.requestedAuthority?.tools;
-	if (contract?.enforcement !== "enforce" || !requested || requested.length === 0) {
+	if (contract?.enforcement !== "enforce" || requested === undefined) {
 		return configuredTools ? unique(configuredTools) : undefined;
 	}
 	const availableTools = resolveAgentToolNames(configuredTools);

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -22,6 +22,7 @@ import {
 	formatAgentCatalog,
 	type SubagentSettings,
 } from "./agents.js";
+import { registerSubagentAutomation } from "./automation.js";
 import { registerSubagentConfigCommand, registerSubagentConfigLifecycle } from "./config-ui.js";
 import { registerSubagentConsult } from "./consult.js";
 import { executeSubagent } from "./execution.js";
@@ -50,6 +51,7 @@ export default function (pi: ExtensionAPI) {
 	const refreshBlockingCatalog = blockingEnabled
 		? registerBlockingSubagent(pi, () => currentSettings)
 		: () => undefined;
+	if (blockingEnabled) registerSubagentAutomation(pi, { getSettings: () => currentSettings });
 	let refreshStatefulCatalog: (catalog: string) => void = () => undefined;
 	let refreshConsultCatalog: (catalog: string) => void = () => undefined;
 

--- a/packages/pi-subagents/src/workflow-plan-compiler.ts
+++ b/packages/pi-subagents/src/workflow-plan-compiler.ts
@@ -1,0 +1,583 @@
+import {
+	type DelegationAdmissionDecision,
+	evaluateDelegationAdmission,
+} from "./admission-policy.js";
+import type { AgentConfig } from "./agents.js";
+import type { AutomationRequest, WorkflowPlan, WorkflowPlanTask } from "./automation-contract.js";
+import { workflowPlanIdentity } from "./automation-contract.js";
+import { routeByCapability } from "./capability-router.js";
+import type { TargetPolicyAudit } from "./cwd-policy.js";
+import {
+	acknowledgeExecutionPlan,
+	createExecutionPlan,
+	type ExecutionPlan,
+	resolveContractTools,
+} from "./execution-plan.js";
+import type { SubagentParams } from "./params.js";
+import { validateWorkflowVerificationGraph } from "./verification-policy.js";
+
+export interface WorkflowPlanCompilerInput {
+	request: AutomationRequest;
+	proposal: WorkflowPlan;
+	agents: readonly AgentConfig[];
+	target: TargetPolicyAudit;
+	depth: number;
+}
+
+interface NonLaunchResult {
+	status: "parent-owned" | "needs-input" | "rejected";
+	childCount: 0;
+	reasonCodes: string[];
+	admission?: DelegationAdmissionDecision;
+	missingInputs?: string[];
+}
+
+export interface CompiledWorkflowPlan {
+	status: "compiled";
+	childCount: number;
+	planId: string;
+	workflowGeneration: 0;
+	revision: 0;
+	request: AutomationRequest;
+	plan: WorkflowPlan;
+	workflow: NonNullable<SubagentParams["workflow"]>;
+	executionPlans: ExecutionPlan[];
+	admission: DelegationAdmissionDecision;
+	maxConcurrentMutating: number;
+	aggregateBudget: {
+		timeoutMs: number;
+		maxTurns: number;
+		maxToolCalls: number;
+	};
+}
+
+export type WorkflowPlanCompilerResult = NonLaunchResult | CompiledWorkflowPlan;
+
+export function compileWorkflowPlan(input: WorkflowPlanCompilerInput): WorkflowPlanCompilerResult {
+	if (input.depth > 0) return rejected("workflow-recursion-disabled");
+	if (!input.target.trust.projectTrusted) return rejected("target-not-trusted");
+	if (input.request.constraints.workspaceMode !== "shared") {
+		return rejected("workspace-mode-unsupported");
+	}
+	if (input.proposal.missingInputs.length > 0) {
+		return {
+			status: "needs-input",
+			childCount: 0,
+			reasonCodes: ["planner-reported-missing-inputs"],
+			missingInputs: [...input.proposal.missingInputs],
+		};
+	}
+	if (
+		input.proposal.tasks.length > input.request.aggregateBudget.maxTasks ||
+		input.proposal.tasks.length > 8
+	) {
+		return rejected("task-budget-exceeded");
+	}
+	const budget = aggregateBudget(input.proposal.tasks);
+	const budgetAllowsChildren = withinBudget(budget, input.request);
+	const authorityError = validateAuthority(input.proposal.tasks, input.request);
+	if (authorityError) return rejected(authorityError);
+	const primaryTasks = input.proposal.tasks.filter((task) => !task.verifierFor);
+	const roots = primaryTasks.filter((task) =>
+		task.dependsOn.every(
+			(dependency) => !primaryTasks.some((candidate) => candidate.id === dependency),
+		),
+	);
+	const mutatingTasks = primaryTasks.filter((task) => task.sideEffectPolicy === "mutating");
+	const verificationRequired =
+		input.request.constraints.requireVerification || mutatingTasks.length > 0;
+	const eligibleAgents = filterAllowedAgents(input.agents, input.request);
+	const verificationAvailable = verificationRequired
+		? eligibleAgents.some(
+				(agent) =>
+					agent.capabilityManifest?.verificationRoles.includes("independent-review") &&
+					agent.capabilityManifest.resultFormats.includes("structured-v2"),
+			)
+		: true;
+	const admission = evaluateDelegationAdmission({
+		contextPressure: input.request.constraints.contextPressure,
+		independentWorkItems: Math.max(1, roots.length),
+		coupling: roots.length >= 2 ? "sparse" : "dense",
+		verificationRequired,
+		verificationAvailable,
+		capabilitiesSupported: proposalCapabilitiesSupported(
+			input.proposal.tasks,
+			eligibleAgents,
+			input.request,
+		),
+		budgetAllowsChildren,
+		generationCurrent: true,
+		requirementsComplete:
+			input.request.acceptanceCriteria.length > 0 && input.proposal.missingInputs.length === 0,
+	});
+	if (admission.recommendation === "parent-owned-direct") {
+		return {
+			status: "parent-owned",
+			childCount: 0,
+			reasonCodes: [...admission.reasonCodes],
+			admission,
+		};
+	}
+	if (admission.recommendation === "abstain-insufficient-evidence") {
+		return {
+			status: "rejected",
+			childCount: 0,
+			reasonCodes: [...admission.reasonCodes],
+			admission,
+		};
+	}
+	const integrationError = validateIntegrationPath(primaryTasks, mutatingTasks);
+	if (integrationError) return rejected(integrationError, admission);
+	const maxConcurrentMutating = calculateMaxConcurrentMutating(primaryTasks);
+	if (
+		maxConcurrentMutating > 2 ||
+		maxConcurrentMutating > input.request.constraints.maxMutatingWidth
+	) {
+		return rejected("mutating-width-exceeded", admission);
+	}
+
+	let normalizedTasks = input.proposal.tasks.map((task) => structuredClone(task));
+	if (mutatingTasks.length === 1 && !mutatingTasks[0]?.integrationOwner) {
+		normalizedTasks = normalizedTasks.map((task) =>
+			task.id === mutatingTasks[0]?.id ? { ...task, integrationOwner: true } : task,
+		);
+	}
+	if (
+		verificationRequired &&
+		normalizedTasks.filter((task) => !task.verifierFor).length === 1 &&
+		!normalizedTasks.some((task) => task.integrationOwner)
+	) {
+		normalizedTasks = normalizedTasks.map((task) =>
+			task.verifierFor ? task : { ...task, integrationOwner: true },
+		);
+	}
+	if (verificationRequired) {
+		const target = verificationTarget(normalizedTasks);
+		if (!target) return rejected("integration-owner-required", admission);
+		const existing = normalizedTasks.filter((task) => task.verifierFor === target.id);
+		if (existing.length > 1) return rejected("multiple-verifiers", admission);
+		if (existing.length === 0) {
+			const synthesized = synthesizeVerifier(target, input.request, normalizedTasks);
+			if (!synthesized) return rejected("verification-budget-insufficient", admission);
+			normalizedTasks.push(synthesized);
+		}
+	}
+	if (normalizedTasks.length > input.request.aggregateBudget.maxTasks) {
+		return rejected("task-budget-exceeded-after-verification", admission);
+	}
+	const normalizedAuthorityError = validateAuthority(normalizedTasks, input.request);
+	if (normalizedAuthorityError) return rejected(normalizedAuthorityError, admission);
+	const normalizedPlan: WorkflowPlan = { ...input.proposal, tasks: normalizedTasks };
+	const finalBudget = aggregateBudget(normalizedTasks);
+	if (!withinBudget(finalBudget, input.request)) {
+		return rejected("aggregate-budget-exceeded", admission);
+	}
+
+	let compiled: ReturnType<typeof compileTasks>;
+	try {
+		validateVerifierTasks(normalizedTasks);
+		compiled = compileTasks(normalizedTasks, input.request, eligibleAgents, input.target);
+		const requiredTarget = verificationRequired ? verificationTarget(normalizedTasks) : undefined;
+		validateWorkflowVerificationGraph(
+			compiled.workflowTasks.map((task) => ({
+				id: task.id,
+				agent: task.agent as string,
+				dependsOn: task.dependsOn,
+				verifierFor: task.verifierFor,
+				resultFormat: task.resultFormat,
+			})),
+			new Set(requiredTarget ? [requiredTarget.id] : []),
+		);
+	} catch (error) {
+		return rejected(reasonFromError(error), admission);
+	}
+	const planId = workflowPlanIdentity(normalizedPlan, 0, 0);
+	return {
+		status: "compiled",
+		childCount: compiled.workflowTasks.length,
+		planId,
+		workflowGeneration: 0,
+		revision: 0,
+		request: structuredClone(input.request),
+		plan: normalizedPlan,
+		workflow: {
+			id: `auto-${planId.slice(0, 24)}`,
+			honorAdmission: false,
+			tasks: compiled.workflowTasks,
+		},
+		executionPlans: compiled.executionPlans,
+		admission,
+		maxConcurrentMutating,
+		aggregateBudget: finalBudget,
+	};
+}
+
+function compileTasks(
+	tasks: readonly WorkflowPlanTask[],
+	request: AutomationRequest,
+	agents: readonly AgentConfig[],
+	target: TargetPolicyAudit,
+): {
+	workflowTasks: NonNullable<SubagentParams["workflow"]>["tasks"];
+	executionPlans: ExecutionPlan[];
+} {
+	const selected = new Map<string, AgentConfig>();
+	const routingOrder = [...tasks].sort(
+		(left, right) => Number(Boolean(left.verifierFor)) - Number(Boolean(right.verifierFor)),
+	);
+	for (const task of routingOrder) {
+		const verifierTarget = task.verifierFor;
+		const candidates = verifierTarget
+			? agents.filter((agent) => agent.name !== selected.get(verifierTarget)?.name)
+			: agents;
+		const route = routeByCapability(candidates, {
+			requiredCapabilities: task.requiredCapabilities,
+			requiredTools: task.requiredTools,
+			requiredVerificationRole: task.verifierFor
+				? (task.requiredVerificationRole ?? "independent-review")
+				: task.requiredVerificationRole,
+			requiredSideEffectClass: task.sideEffectPolicy === "read-only" ? "read-only" : undefined,
+			preferredCostHint: task.preferredCostHint,
+			preferredLatencyHint: task.preferredLatencyHint,
+		});
+		selected.set(task.id, route.agent);
+	}
+	const workflowTasks: NonNullable<SubagentParams["workflow"]>["tasks"] = [];
+	const executionPlans: ExecutionPlan[] = [];
+	for (const task of tasks) {
+		const agent = selected.get(task.id);
+		if (!agent) throw new Error(`No capable agent for ${task.id}`);
+		if (task.verifierFor && selected.get(task.verifierFor)?.name === agent.name) {
+			throw new Error(`Verification agent for ${task.id} is not distinct`);
+		}
+		const dependencies = task.dependsOn.map((taskId) => ({ taskId }));
+		const contract = {
+			version: "pi-subagents:delegation:v2" as const,
+			level: "full" as const,
+			taskId: task.id,
+			objective: task.objective,
+			nonGoals: [...request.nonGoals],
+			dependencies,
+			requiredInputs: [...task.inputArtifacts],
+			requestedAuthority: {
+				capabilities: [...task.requiredCapabilities],
+				tools: [...task.requiredTools],
+				network: "unspecified" as const,
+				secrets: "unspecified" as const,
+			},
+			acceptanceCriteria: [...task.acceptanceCriteria],
+			requiredEvidence: [...task.requiredEvidence],
+			budget: { ...task.budget },
+			admission: {
+				contextPressure: request.constraints.contextPressure,
+				independentWorkItems: Math.min(
+					2,
+					Math.max(1, tasks.filter((item) => !item.verifierFor).length),
+				),
+				coupling: tasks.some((item) => item.dependsOn.length > 0)
+					? ("dense" as const)
+					: ("sparse" as const),
+				verificationRequired: task.integrationOwner && task.sideEffectPolicy === "mutating",
+				verificationAvailable: tasks.some((item) => item.verifierFor === task.id),
+				budgetAllowsChildren: true,
+				requirementsComplete: true,
+			},
+			sideEffectPolicy: task.sideEffectPolicy,
+			enforcement: "enforce" as const,
+		};
+		const effectiveTools = resolveContractTools(agent.tools, contract);
+		const resultFormat = "structured-v2" as const;
+		const executionPlan = createExecutionPlan({
+			contract,
+			agent,
+			effectiveTools,
+			target,
+			workspaceMode: request.constraints.workspaceMode,
+			transport: "subprocess",
+			resultFormat,
+			model: agent.model,
+			thinkingLevel: agent.thinkingLevel,
+			timeoutMs: task.budget.timeoutMs,
+			taskGeneration: 1,
+		});
+		const acknowledgement = acknowledgeExecutionPlan(executionPlan);
+		if (acknowledgement.status !== "accepted") {
+			throw new Error(`Execution plan rejected: ${acknowledgement.reasonCodes.join(",")}`);
+		}
+		executionPlans.push(executionPlan);
+		workflowTasks.push({
+			id: task.id,
+			agent: agent.name,
+			requiredCapabilities: [...task.requiredCapabilities],
+			requiredTools: [...task.requiredTools],
+			...(task.requiredVerificationRole
+				? { requiredVerificationRole: task.requiredVerificationRole }
+				: task.verifierFor
+					? { requiredVerificationRole: "independent-review" }
+					: {}),
+			task: taskPrompt(task),
+			dependsOn: [...task.dependsOn],
+			inputArtifacts: [...task.inputArtifacts],
+			inputArtifactVersions: Object.fromEntries(
+				task.inputArtifacts.flatMap((artifactId) => {
+					const artifact = tasks
+						.flatMap((candidate) => candidate.producesArtifacts)
+						.find((candidate) => candidate.id === artifactId);
+					return artifact ? [[artifact.id, artifact.version]] : [];
+				}),
+			),
+			readPaths: [...task.readPaths],
+			writePaths: [...task.writePaths],
+			ownershipKeys: [...task.ownershipKeys],
+			acceptanceCriteria: [...task.acceptanceCriteria],
+			integrationOwner: task.integrationOwner,
+			...(task.verifierFor ? { verifierFor: task.verifierFor } : {}),
+			timeoutMs: task.budget.timeoutMs,
+			maxTurns: task.budget.maxTurns,
+			maxToolCalls: task.budget.maxToolCalls,
+			contract,
+			resultFormat,
+		});
+	}
+	return { workflowTasks, executionPlans };
+}
+
+function validateVerifierTasks(tasks: readonly WorkflowPlanTask[]): void {
+	const byId = new Map(tasks.map((task) => [task.id, task]));
+	for (const task of tasks) {
+		if (!task.verifierFor) continue;
+		const target = byId.get(task.verifierFor);
+		if (!target || target.verifierFor) {
+			throw new Error(`Workflow verifier ${task.id} has an invalid verification target`);
+		}
+		if (
+			task.sideEffectPolicy !== "read-only" ||
+			task.writePaths.length > 0 ||
+			task.dependsOn.length !== 1 ||
+			task.dependsOn[0] !== target.id
+		) {
+			throw new Error(`Workflow verifier ${task.id} must be one direct read-only verifier`);
+		}
+	}
+}
+
+function validateAuthority(
+	tasks: readonly WorkflowPlanTask[],
+	request: AutomationRequest,
+): string | undefined {
+	const ceiling = request.authorityCeiling;
+	const sideEffectRank = { "read-only": 0, idempotent: 1, mutating: 2 } as const;
+	for (const task of tasks) {
+		if (
+			task.sideEffectPolicy === "read-only" &&
+			task.requiredTools.some((tool) => ["bash", "edit", "write"].includes(tool))
+		) {
+			return "read-only-tool-authority-conflict";
+		}
+		if (sideEffectRank[task.sideEffectPolicy] > sideEffectRank[ceiling.sideEffectPolicy]) {
+			return "side-effect-authority-exceeded";
+		}
+		if (task.requiredCapabilities.some((item) => !ceiling.capabilities.includes(item))) {
+			return "capability-authority-exceeded";
+		}
+		if (task.requiredTools.some((item) => !ceiling.tools.includes(item))) {
+			return "tool-authority-exceeded";
+		}
+		if (task.readPaths.some((item) => !withinAnyScope(item, ceiling.readPaths))) {
+			return "read-scope-exceeded";
+		}
+		if (task.writePaths.some((item) => !withinAnyScope(item, ceiling.writePaths))) {
+			return "write-scope-exceeded";
+		}
+	}
+	return undefined;
+}
+
+function validateIntegrationPath(
+	primaryTasks: readonly WorkflowPlanTask[],
+	mutatingTasks: readonly WorkflowPlanTask[],
+): string | undefined {
+	if (mutatingTasks.length <= 1) return undefined;
+	const owners = primaryTasks.filter((task) => task.integrationOwner);
+	if (owners.length !== 1) return "integration-owner-required";
+	const owner = owners[0];
+	const byId = new Map(primaryTasks.map((task) => [task.id, task]));
+	const dependsOn = (task: WorkflowPlanTask, target: string, seen = new Set<string>()): boolean => {
+		if (seen.has(task.id)) return false;
+		seen.add(task.id);
+		return task.dependsOn.some(
+			(dependency) =>
+				dependency === target ||
+				(Boolean(byId.get(dependency)) &&
+					dependsOn(byId.get(dependency) as WorkflowPlanTask, target, seen)),
+		);
+	};
+	if (mutatingTasks.some((task) => task.id !== owner.id && !dependsOn(owner, task.id))) {
+		return "integration-path-incomplete";
+	}
+	return undefined;
+}
+
+function synthesizeVerifier(
+	target: WorkflowPlanTask,
+	request: AutomationRequest,
+	tasks: readonly WorkflowPlanTask[],
+): WorkflowPlanTask | undefined {
+	if (
+		!request.authorityCeiling.capabilities.includes("code-review") ||
+		!request.authorityCeiling.tools.includes("read")
+	) {
+		return undefined;
+	}
+	const current = aggregateBudget(tasks);
+	const remaining = {
+		timeoutMs: request.aggregateBudget.timeoutMs - current.timeoutMs,
+		maxTurns: request.aggregateBudget.maxTurns - current.maxTurns,
+		maxToolCalls: request.aggregateBudget.maxToolCalls - current.maxToolCalls,
+	};
+	if (remaining.timeoutMs < 1 || remaining.maxTurns < 1 || remaining.maxToolCalls < 1)
+		return undefined;
+	let id = `verify-${target.id}`;
+	for (let suffix = 2; tasks.some((task) => task.id === id); suffix++)
+		id = `verify-${target.id}-${suffix}`;
+	return {
+		id,
+		objective: `Independently verify ${target.id} against its acceptance criteria and required evidence`,
+		dependsOn: [target.id],
+		inputArtifacts: [],
+		producesArtifacts: [],
+		sideEffectPolicy: "read-only",
+		readPaths: [...target.readPaths, ...target.writePaths].filter(
+			(value, index, values) => values.indexOf(value) === index,
+		),
+		writePaths: [],
+		ownershipKeys: [],
+		requiredCapabilities: ["code-review"],
+		requiredTools: ["read"],
+		requiredVerificationRole: "independent-review",
+		acceptanceCriteria: [...target.acceptanceCriteria],
+		requiredEvidence: [...target.requiredEvidence],
+		integrationOwner: false,
+		verifierFor: target.id,
+		budget: {
+			timeoutMs: Math.min(60_000, remaining.timeoutMs),
+			maxTurns: Math.min(8, remaining.maxTurns),
+			maxToolCalls: Math.min(16, remaining.maxToolCalls),
+		},
+	};
+}
+
+function verificationTarget(tasks: readonly WorkflowPlanTask[]): WorkflowPlanTask | undefined {
+	const primary = tasks.filter((task) => !task.verifierFor);
+	return (
+		primary.find((task) => task.integrationOwner) ??
+		(primary.filter((task) => task.sideEffectPolicy === "mutating").length === 1
+			? primary.find((task) => task.sideEffectPolicy === "mutating")
+			: undefined)
+	);
+}
+
+function proposalCapabilitiesSupported(
+	tasks: readonly WorkflowPlanTask[],
+	agents: readonly AgentConfig[],
+	request: AutomationRequest,
+): boolean {
+	if (validateAuthority(tasks, request)) return false;
+	return tasks.every((task) => {
+		try {
+			routeByCapability(agents, {
+				requiredCapabilities: task.requiredCapabilities,
+				requiredTools: task.requiredTools,
+				requiredVerificationRole: task.requiredVerificationRole,
+				requiredSideEffectClass: task.sideEffectPolicy === "read-only" ? "read-only" : undefined,
+			});
+			return true;
+		} catch {
+			return false;
+		}
+	});
+}
+
+function filterAllowedAgents(
+	agents: readonly AgentConfig[],
+	request: AutomationRequest,
+): AgentConfig[] {
+	const allowed = request.constraints.allowedAgents;
+	return allowed ? agents.filter((agent) => allowed.includes(agent.name)) : [...agents];
+}
+
+function aggregateBudget(tasks: readonly WorkflowPlanTask[]) {
+	return tasks.reduce(
+		(total, task) => ({
+			timeoutMs: total.timeoutMs + task.budget.timeoutMs,
+			maxTurns: total.maxTurns + task.budget.maxTurns,
+			maxToolCalls: total.maxToolCalls + task.budget.maxToolCalls,
+		}),
+		{ timeoutMs: 0, maxTurns: 0, maxToolCalls: 0 },
+	);
+}
+
+function withinBudget(
+	budget: ReturnType<typeof aggregateBudget>,
+	request: AutomationRequest,
+): boolean {
+	return (
+		budget.timeoutMs <= request.aggregateBudget.timeoutMs &&
+		budget.maxTurns <= request.aggregateBudget.maxTurns &&
+		budget.maxToolCalls <= request.aggregateBudget.maxToolCalls
+	);
+}
+
+function calculateMaxConcurrentMutating(tasks: readonly WorkflowPlanTask[]): number {
+	const levels = new Map<string, number>();
+	const byId = new Map(tasks.map((task) => [task.id, task]));
+	const level = (task: WorkflowPlanTask): number => {
+		const cached = levels.get(task.id);
+		if (cached !== undefined) return cached;
+		const value = task.dependsOn.length
+			? 1 + Math.max(...task.dependsOn.map((id) => level(byId.get(id) as WorkflowPlanTask)))
+			: 0;
+		levels.set(task.id, value);
+		return value;
+	};
+	const counts = new Map<number, number>();
+	for (const task of tasks) {
+		if (task.sideEffectPolicy !== "mutating") continue;
+		const taskLevel = level(task);
+		counts.set(taskLevel, (counts.get(taskLevel) ?? 0) + 1);
+	}
+	return Math.max(0, ...counts.values());
+}
+
+function withinAnyScope(candidate: string, scopes: readonly string[]): boolean {
+	return scopes.some(
+		(scope) =>
+			scope === "." || candidate === scope || candidate.startsWith(`${scope.replace(/\/$/u, "")}/`),
+	);
+}
+
+function taskPrompt(task: WorkflowPlanTask): string {
+	return [
+		task.objective,
+		`Acceptance criteria: ${JSON.stringify(task.acceptanceCriteria)}.`,
+		`Required evidence: ${JSON.stringify(task.requiredEvidence)}.`,
+		"Stay within the executor-declared authority and report missing inputs instead of guessing.",
+	].join("\n");
+}
+
+function rejected(reasonCode: string, admission?: DelegationAdmissionDecision): NonLaunchResult {
+	return {
+		status: "rejected",
+		childCount: 0,
+		reasonCodes: [reasonCode],
+		...(admission ? { admission } : {}),
+	};
+}
+
+function reasonFromError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	if (/verification/i.test(message)) return "verification-agent-unavailable";
+	if (/capab|tool/i.test(message)) return "capability-unsupported";
+	if (/execution plan/i.test(message)) return "execution-plan-rejected";
+	return "workflow-compilation-failed";
+}

--- a/packages/pi-subagents/src/workflow-plan-patch.ts
+++ b/packages/pi-subagents/src/workflow-plan-patch.ts
@@ -1,0 +1,564 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import type { AgentConfig } from "./agents.js";
+import {
+	parseAutomationRequest,
+	parseWorkflowPlan,
+	type WorkflowPlan,
+	type WorkflowPlanPatch,
+	type WorkflowPlanTask,
+	workflowPlanIdentity,
+} from "./automation-contract.js";
+import { redactPrivateText } from "./context.js";
+import type { TargetPolicyAudit } from "./cwd-policy.js";
+import {
+	WorkItemLedger,
+	type WorkItemLedgerSnapshot,
+	type WorkItemRecord,
+} from "./work-item-ledger.js";
+import { type CompiledWorkflowPlan, compileWorkflowPlan } from "./workflow-plan-compiler.js";
+
+export const WORKFLOW_PLAN_STATE_VERSION = "pi-subagents:workflow-plan-state:v1" as const;
+const MAX_STATE_BYTES = 1024 * 1024;
+
+export interface WorkflowPlanHistoryEntry {
+	planId: string;
+	workflowGeneration: number;
+	revision: number;
+	acceptedTaskIds: string[];
+	acceptedArtifactIds: string[];
+	verificationReceiptTaskIds: string[];
+}
+
+export interface WorkflowPlanRecord {
+	version: typeof WORKFLOW_PLAN_STATE_VERSION;
+	planId: string;
+	workflowGeneration: number;
+	revision: number;
+	maxRevisions: number;
+	request: CompiledWorkflowPlan["request"];
+	plan: WorkflowPlan;
+	cancelledTaskIds: string[];
+	invalidatedTaskIds: string[];
+	history: WorkflowPlanHistoryEntry[];
+}
+
+export interface ApplyWorkflowPlanPatchInput {
+	record: WorkflowPlanRecord;
+	ledger: WorkItemLedgerSnapshot;
+	patch: WorkflowPlanPatch;
+	agents: readonly AgentConfig[];
+	target: TargetPolicyAudit;
+}
+
+export interface AppliedWorkflowPlanPatch {
+	record: WorkflowPlanRecord;
+	ledger: WorkItemLedgerSnapshot;
+	compiled?: CompiledWorkflowPlan;
+	taskGenerations: Record<string, number>;
+	replayedTaskIds: string[];
+}
+
+export interface PersistedAutomationPlan {
+	record: WorkflowPlanRecord;
+	ledger: WorkItemLedgerSnapshot;
+}
+
+export function createWorkflowPlanRecord(compiled: CompiledWorkflowPlan): WorkflowPlanRecord {
+	return {
+		version: WORKFLOW_PLAN_STATE_VERSION,
+		planId: compiled.planId,
+		workflowGeneration: compiled.workflowGeneration,
+		revision: compiled.revision,
+		maxRevisions: compiled.request.aggregateBudget.maxRevisions,
+		request: structuredClone(compiled.request),
+		plan: structuredClone(compiled.plan),
+		cancelledTaskIds: [],
+		invalidatedTaskIds: [],
+		history: [],
+	};
+}
+
+export function applyWorkflowPlanPatch(
+	input: ApplyWorkflowPlanPatchInput,
+): AppliedWorkflowPlanPatch {
+	validateRecord(input.record);
+	const ledger = WorkItemLedger.restore(input.ledger).snapshot();
+	if (input.patch.planId !== input.record.planId) {
+		throw new Error("Workflow plan patch has a stale or forged plan identity");
+	}
+	if (input.patch.workflowGeneration !== input.record.workflowGeneration) {
+		throw new Error("Workflow plan patch has a stale or forged workflow generation");
+	}
+	if (input.record.revision >= input.record.maxRevisions) {
+		throw new Error("Workflow plan revision limit is exhausted");
+	}
+	if (
+		ledger.items.some((item) => item.state === "running" || item.state === "awaiting-verification")
+	) {
+		throw new Error("Workflow plan patches require a settled workflow snapshot");
+	}
+	const byState = new Map(ledger.items.map((item) => [item.id, item]));
+	const tasks = input.record.plan.tasks.map((task) => structuredClone(task));
+	const cancelled = new Set(input.record.cancelledTaskIds);
+	const invalidated = new Set(input.record.invalidatedTaskIds);
+	const modified = new Set<string>();
+	const acceptedArtifactIds = new Set(
+		ledger.items
+			.filter((item) => item.state === "completed" || item.verificationAccepted)
+			.flatMap((item) => item.artifacts.map((artifact) => artifact.id)),
+	);
+
+	for (const operation of input.patch.operations) {
+		if (operation.type === "add-task") {
+			if (tasks.some((task) => task.id === operation.task.id)) {
+				throw new Error(`Workflow patch cannot add duplicate task ${operation.task.id}`);
+			}
+			assertNoAcceptedArtifactForgery(operation.task, acceptedArtifactIds);
+			tasks.push(structuredClone(operation.task));
+			modified.add(operation.task.id);
+			continue;
+		}
+		const targetId = operation.taskId;
+		if (cancelled.has(targetId)) {
+			throw new Error(`Workflow patch cannot revive cancelled task ${targetId}`);
+		}
+		const taskIndex = tasks.findIndex((task) => task.id === targetId);
+		if (taskIndex < 0) throw new Error(`Workflow patch targets unknown task ${targetId}`);
+		const state = byState.get(targetId);
+		if (!state || !isPatchEligible(state)) {
+			throw new Error(`Workflow task ${targetId} is immutable while ${state?.state ?? "missing"}`);
+		}
+		if (operation.type === "replace-task") {
+			if (operation.task.id !== targetId) {
+				throw new Error("Workflow replacement must preserve the executor-owned task id");
+			}
+			assertNoAcceptedArtifactForgery(operation.task, acceptedArtifactIds);
+			tasks[taskIndex] = structuredClone(operation.task);
+			modified.add(targetId);
+			continue;
+		}
+		if (operation.type === "add-dependency") {
+			if (!tasks.some((task) => task.id === operation.dependsOn)) {
+				throw new Error(`Workflow patch dependency ${operation.dependsOn} is missing`);
+			}
+			const current = tasks[taskIndex];
+			if (!current.dependsOn.includes(operation.dependsOn)) {
+				current.dependsOn.push(operation.dependsOn);
+			}
+			modified.add(targetId);
+			continue;
+		}
+		if (operation.type === "cancel-task") {
+			const current = tasks[taskIndex];
+			if (
+				current.verifierFor &&
+				tasks.some(
+					(task) =>
+						task.id === current.verifierFor &&
+						task.sideEffectPolicy === "mutating" &&
+						!cancelled.has(task.id),
+				)
+			) {
+				throw new Error(`Workflow patch cannot remove required verification ${targetId}`);
+			}
+			for (const affected of downstreamTaskIds(tasks, targetId, true)) {
+				const affectedState = byState.get(affected);
+				if (affectedState && !isPatchEligible(affectedState)) {
+					throw new Error(`Workflow cancellation would rewrite immutable task ${affected}`);
+				}
+				cancelled.add(affected);
+				modified.add(affected);
+			}
+			continue;
+		}
+		if (operation.type === "request-verification") {
+			if (tasks.some((task) => task.verifierFor === targetId && !cancelled.has(task.id))) {
+				throw new Error(`Workflow task ${targetId} already has required verification`);
+			}
+			if (
+				operation.verifier.verifierFor !== targetId ||
+				operation.verifier.dependsOn.length !== 1 ||
+				operation.verifier.dependsOn[0] !== targetId
+			) {
+				throw new Error("Workflow verification patch must add one direct verifier");
+			}
+			tasks.push(structuredClone(operation.verifier));
+			modified.add(operation.verifier.id);
+			continue;
+		}
+		if (operation.type === "invalidate-downstream") {
+			for (const affected of downstreamTaskIds(tasks, targetId, false)) {
+				const affectedState = byState.get(affected);
+				if (affectedState && !isPatchEligible(affectedState)) {
+					throw new Error(`Workflow invalidation would rewrite immutable task ${affected}`);
+				}
+				invalidated.add(affected);
+				modified.add(affected);
+			}
+		}
+	}
+
+	const candidatePlan = parseWorkflowPlan({ ...input.record.plan, tasks });
+	const activeTasks = candidatePlan.tasks.filter((task) => !cancelled.has(task.id));
+	let compiled: CompiledWorkflowPlan | undefined;
+	if (activeTasks.length > 0) {
+		const activePlan = parseWorkflowPlan({ ...candidatePlan, tasks: activeTasks });
+		const result = compileWorkflowPlan({
+			request: input.record.request,
+			proposal: activePlan,
+			agents: input.agents,
+			target: input.target,
+			depth: 0,
+		});
+		if (result.status !== "compiled") {
+			throw new Error(
+				`Workflow patch rejected by compiler: ${result.reasonCodes.join(", ") || result.status}`,
+			);
+		}
+		compiled = result;
+	}
+	const nextGeneration = input.record.workflowGeneration + 1;
+	const nextRevision = input.record.revision + 1;
+	const historyEntry = captureHistory(input.record, ledger);
+	const nextPlanId = revisionIdentity(
+		input.record.planId,
+		candidatePlan,
+		nextGeneration,
+		nextRevision,
+		cancelled,
+		invalidated,
+	);
+	const taskGenerations = Object.fromEntries(
+		tasks.map((task) => [
+			task.id,
+			(byState.get(task.id)?.taskGeneration ?? 0) + (modified.has(task.id) ? 1 : 0),
+		]),
+	);
+	const nextLedger = buildPatchedLedger(
+		candidatePlan,
+		ledger,
+		compiled,
+		modified,
+		cancelled,
+		invalidated,
+		input.patch.reason,
+	);
+	return {
+		record: {
+			...input.record,
+			planId: nextPlanId,
+			workflowGeneration: nextGeneration,
+			revision: nextRevision,
+			plan: candidatePlan,
+			cancelledTaskIds: [...cancelled].sort(),
+			invalidatedTaskIds: [...invalidated].sort(),
+			history: [...input.record.history, historyEntry],
+		},
+		ledger: nextLedger,
+		...(compiled ? { compiled } : {}),
+		taskGenerations,
+		replayedTaskIds: [],
+	};
+}
+
+function buildPatchedLedger(
+	plan: WorkflowPlan,
+	previous: WorkItemLedgerSnapshot,
+	compiled: CompiledWorkflowPlan | undefined,
+	modified: ReadonlySet<string>,
+	cancelled: ReadonlySet<string>,
+	invalidated: ReadonlySet<string>,
+	reason: string,
+): WorkItemLedgerSnapshot {
+	const previousById = new Map(previous.items.map((item) => [item.id, item]));
+	const compiledById = new Map((compiled?.workflow.tasks ?? []).map((task) => [task.id, task]));
+	const fresh = WorkItemLedger.create({
+		workflowId: previous.workflowId,
+		items: plan.tasks.map((task) => ({
+			id: task.id,
+			objective: task.objective,
+			dependencies: [...task.dependsOn],
+			inputArtifacts: [...task.inputArtifacts],
+			inputArtifactVersions: Object.fromEntries(
+				task.inputArtifacts.flatMap((artifactId) => {
+					const artifact = plan.tasks
+						.flatMap((candidate) => candidate.producesArtifacts)
+						.find((candidate) => candidate.id === artifactId);
+					return artifact ? [[artifact.id, artifact.version]] : [];
+				}),
+			),
+			requiredCapabilities: [...task.requiredCapabilities],
+			requiredTools: [...task.requiredTools],
+			selectedAgentName:
+				compiledById.get(task.id)?.agent ?? previousById.get(task.id)?.selectedAgentName,
+			sideEffectPolicy: task.sideEffectPolicy,
+			readPaths: [...task.readPaths],
+			writePaths: [...task.writePaths],
+			ownershipKeys: [...task.ownershipKeys],
+			acceptanceCriteria: [...task.acceptanceCriteria],
+			integrationOwner: cancelled.has(task.id) ? false : task.integrationOwner,
+			verifierFor: task.verifierFor,
+		})),
+	}).snapshot();
+	let generation = previous.generation;
+	for (const item of fresh.items) {
+		const stored = previousById.get(item.id);
+		if (stored && !modified.has(item.id)) {
+			const dependencies = item.dependencies;
+			const dependents = item.dependents;
+			Object.assign(item, structuredClone(stored), { dependencies, dependents });
+			continue;
+		}
+		item.taskGeneration = stored ? stored.taskGeneration + 1 : 1;
+		item.state = cancelled.has(item.id) || invalidated.has(item.id) ? "invalidated" : "pending";
+		item.assignedAgentId = undefined;
+		item.acceptedExecutionPlanId = undefined;
+		item.artifactHistory = [
+			...(stored?.artifactHistory ?? []).map((artifact) => structuredClone(artifact)),
+			...(stored?.artifacts ?? []).map((artifact) => structuredClone(artifact)),
+		];
+		item.artifacts = [];
+		item.inputArtifactVersions = {};
+		item.verificationAccepted = false;
+		item.stagedTreeIdentity = undefined;
+		item.verificationReceipt = undefined;
+		item.invalidationReasons = [...(stored?.invalidationReasons ?? []), `${item.id}:${reason}`];
+		item.outcomeReason = item.state === "invalidated" ? reason : undefined;
+		item.generation = ++generation;
+	}
+	fresh.generation = generation;
+	return WorkItemLedger.restore(fresh).snapshot();
+}
+
+export class AutomationPlanPersistence {
+	constructor(readonly filePath: string) {}
+
+	async save(value: PersistedAutomationPlan): Promise<void> {
+		validateRecord(value.record);
+		WorkItemLedger.restore(value.ledger);
+		const filePath = path.resolve(this.filePath);
+		const sanitized = sanitizePersisted(value);
+		const content = `${JSON.stringify(sanitized)}\n`;
+		if (Buffer.byteLength(content, "utf8") > MAX_STATE_BYTES) {
+			throw new Error("Automation workflow state exceeds the persistence size limit");
+		}
+		await withFileMutationQueue(filePath, async () => {
+			await fs.promises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+			const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+			try {
+				await fs.promises.writeFile(temporary, content, { mode: 0o600 });
+				await fs.promises.rename(temporary, filePath);
+			} finally {
+				await fs.promises.rm(temporary, { force: true });
+			}
+		});
+	}
+
+	load(): PersistedAutomationPlan | undefined {
+		const filePath = path.resolve(this.filePath);
+		let source: string;
+		try {
+			const stat = fs.statSync(filePath);
+			if (stat.size > MAX_STATE_BYTES) throw new Error("automation workflow state exceeds limit");
+			source = fs.readFileSync(filePath, "utf8");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+			throw error;
+		}
+		try {
+			const decoded = JSON.parse(source) as PersistedAutomationPlan;
+			validateRecord(decoded.record);
+			const ledger = WorkItemLedger.restore(decoded.ledger).snapshot();
+			return { record: structuredClone(decoded.record), ledger };
+		} catch {
+			try {
+				fs.renameSync(filePath, `${filePath}.invalid-${Date.now()}`);
+			} catch {
+				// A concurrent owner may already have quarantined the invalid record.
+			}
+			return undefined;
+		}
+	}
+}
+
+function validateRecord(record: WorkflowPlanRecord): void {
+	if (!record || record.version !== WORKFLOW_PLAN_STATE_VERSION) {
+		throw new Error("Unsupported automation workflow state");
+	}
+	if (
+		!Number.isSafeInteger(record.workflowGeneration) ||
+		record.workflowGeneration < 0 ||
+		!Number.isSafeInteger(record.revision) ||
+		record.revision < 0 ||
+		!Number.isSafeInteger(record.maxRevisions) ||
+		record.maxRevisions < 0 ||
+		record.revision > record.maxRevisions
+	) {
+		throw new Error("Automation workflow state has an invalid generation or revision");
+	}
+	const request = parseAutomationRequest(record.request);
+	const plan = parseWorkflowPlan(record.plan);
+	if (record.maxRevisions !== request.aggregateBudget.maxRevisions) {
+		throw new Error("Automation workflow state has an invalid revision ceiling");
+	}
+	if (!Array.isArray(record.cancelledTaskIds) || !Array.isArray(record.invalidatedTaskIds)) {
+		throw new Error("Automation workflow state has invalid task state lists");
+	}
+	const taskIds = new Set(plan.tasks.map((task) => task.id));
+	for (const list of [record.cancelledTaskIds, record.invalidatedTaskIds]) {
+		if (new Set(list).size !== list.length || list.some((id) => !taskIds.has(id))) {
+			throw new Error("Automation workflow state has invalid task state identities");
+		}
+	}
+	if (!Array.isArray(record.history) || record.history.length !== record.revision) {
+		throw new Error("Automation workflow state has invalid history");
+	}
+	for (const [index, entry] of record.history.entries()) validateHistoryEntry(entry, index);
+	const expected =
+		record.revision === 0
+			? workflowPlanIdentity(record.plan, record.workflowGeneration, record.revision)
+			: revisionIdentity(
+					record.history.at(-1)?.planId ?? "",
+					record.plan,
+					record.workflowGeneration,
+					record.revision,
+					new Set(record.cancelledTaskIds),
+					new Set(record.invalidatedTaskIds),
+				);
+	if (record.planId !== expected)
+		throw new Error("Automation workflow state has a forged identity");
+}
+
+function validateHistoryEntry(entry: WorkflowPlanHistoryEntry, index: number): void {
+	if (
+		!entry ||
+		!/^[a-f0-9]{64}$/u.test(entry.planId) ||
+		!Number.isSafeInteger(entry.workflowGeneration) ||
+		entry.workflowGeneration < 0 ||
+		!Number.isSafeInteger(entry.revision) ||
+		entry.revision !== index ||
+		!Array.isArray(entry.acceptedTaskIds) ||
+		!Array.isArray(entry.acceptedArtifactIds) ||
+		!Array.isArray(entry.verificationReceiptTaskIds)
+	) {
+		throw new Error("Automation workflow state has malformed accepted history");
+	}
+	for (const list of [
+		entry.acceptedTaskIds,
+		entry.acceptedArtifactIds,
+		entry.verificationReceiptTaskIds,
+	]) {
+		if (
+			list.length > 64 ||
+			new Set(list).size !== list.length ||
+			list.some((value) => typeof value !== "string" || !value || value.length > 256)
+		) {
+			throw new Error("Automation workflow state has malformed accepted history identities");
+		}
+	}
+}
+
+function captureHistory(
+	record: WorkflowPlanRecord,
+	ledger: WorkItemLedgerSnapshot,
+): WorkflowPlanHistoryEntry {
+	const accepted = ledger.items.filter((item) => item.state === "completed");
+	return {
+		planId: record.planId,
+		workflowGeneration: record.workflowGeneration,
+		revision: record.revision,
+		acceptedTaskIds: accepted.map((item) => item.id).sort(),
+		acceptedArtifactIds: accepted
+			.flatMap((item) => item.artifacts.map((artifact) => artifact.id))
+			.sort(),
+		verificationReceiptTaskIds: accepted
+			.filter((item) => item.verificationReceipt)
+			.map((item) => item.id)
+			.sort(),
+	};
+}
+
+function revisionIdentity(
+	previousPlanId: string,
+	plan: WorkflowPlan,
+	workflowGeneration: number,
+	revision: number,
+	cancelled: ReadonlySet<string>,
+	invalidated: ReadonlySet<string>,
+): string {
+	return createHash("sha256")
+		.update(
+			JSON.stringify({
+				previousPlanId,
+				plan,
+				workflowGeneration,
+				revision,
+				cancelledTaskIds: [...cancelled].sort(),
+				invalidatedTaskIds: [...invalidated].sort(),
+			}),
+		)
+		.digest("hex");
+}
+
+function isPatchEligible(item: WorkItemRecord): boolean {
+	return (
+		["pending", "ready", "needs-input", "stale", "invalidated"].includes(item.state) ||
+		(item.state === "blocked" && item.outcomeReason === "verification-rework")
+	);
+}
+
+function downstreamTaskIds(
+	tasks: readonly WorkflowPlanTask[],
+	rootId: string,
+	includeRoot: boolean,
+): string[] {
+	const result: string[] = includeRoot ? [rootId] : [];
+	const queue = [rootId];
+	const seen = new Set(queue);
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current) continue;
+		for (const task of tasks) {
+			if (!task.dependsOn.includes(current) || seen.has(task.id)) continue;
+			seen.add(task.id);
+			result.push(task.id);
+			queue.push(task.id);
+		}
+	}
+	return result;
+}
+
+function assertNoAcceptedArtifactForgery(
+	task: WorkflowPlanTask,
+	acceptedArtifactIds: ReadonlySet<string>,
+): void {
+	const forged = task.producesArtifacts.find((artifact) => acceptedArtifactIds.has(artifact.id));
+	if (forged) throw new Error(`Workflow patch cannot forge accepted artifact ${forged.id}`);
+}
+
+function sanitizePersisted(value: PersistedAutomationPlan): PersistedAutomationPlan {
+	const clone = structuredClone(value);
+	const visit = (candidate: unknown): void => {
+		if (Array.isArray(candidate)) {
+			for (let index = 0; index < candidate.length; index++) {
+				if (typeof candidate[index] === "string") {
+					candidate[index] = redactPrivateText(candidate[index] as string).trim();
+				} else visit(candidate[index]);
+			}
+			return;
+		}
+		if (!candidate || typeof candidate !== "object") return;
+		for (const [key, item] of Object.entries(candidate as Record<string, unknown>)) {
+			if (typeof item === "string") {
+				(candidate as Record<string, unknown>)[key] = redactPrivateText(item).trim();
+			} else visit(item);
+		}
+	};
+	visit(clone);
+	validateRecord(clone.record);
+	WorkItemLedger.restore(clone.ledger);
+	return clone;
+}

--- a/packages/pi-subagents/src/workflow-planning-benchmark.ts
+++ b/packages/pi-subagents/src/workflow-planning-benchmark.ts
@@ -1,0 +1,95 @@
+export const AUTOMATION_BENCHMARK_VERSION = "pi-subagents:workflow-planning-benchmark:v1" as const;
+
+export const AUTOMATION_BENCHMARK_ARMS = [
+	"strong-single-agent",
+	"one-child",
+	"caller-authored-workflow",
+	"fixed-two-child",
+	"equal-budget-best-of-n",
+	"automation-compiled",
+] as const;
+
+export type AutomationBenchmarkArm = (typeof AUTOMATION_BENCHMARK_ARMS)[number];
+
+export interface AutomationBenchmarkProtocol {
+	version: typeof AUTOMATION_BENCHMARK_VERSION;
+	model: string;
+	evaluator: string;
+	taskIds: string[];
+	pairedSeeds: number[];
+	maxTokens: number;
+	maxCost: number;
+	maxWallClockMs: number;
+	maxMutatingChildren: number;
+	maxRecursiveDepth: number;
+	arms: AutomationBenchmarkArm[];
+}
+
+export interface AutomationBenchmarkAdapter {
+	arm: AutomationBenchmarkArm;
+	model: string;
+	evaluator: string;
+	maxTokens: number;
+	maxCost: number;
+	maxWallClockMs: number;
+	mutatingChildren: number;
+	recursiveDepth: number;
+	informationPolicy: "identical-repository-context";
+	toolPolicy: "matched-authority-ceiling";
+}
+
+export interface AutomationBenchmarkDryRun {
+	version: typeof AUTOMATION_BENCHMARK_VERSION;
+	pairedInstances: number;
+	arms: AutomationBenchmarkArm[];
+	valid: true;
+}
+
+export function validateAutomationBenchmark(
+	protocol: AutomationBenchmarkProtocol,
+	adapters: AutomationBenchmarkAdapter[],
+): AutomationBenchmarkDryRun {
+	if (protocol.version !== AUTOMATION_BENCHMARK_VERSION) {
+		throw new Error("Unsupported automation benchmark protocol");
+	}
+	if (protocol.taskIds.length < 1 || protocol.pairedSeeds.length < 2) {
+		throw new Error("Automation benchmark requires tasks and repeated paired seeds");
+	}
+	if (protocol.maxMutatingChildren !== 2 || protocol.maxRecursiveDepth !== 0) {
+		throw new Error("Automation benchmark width and depth must remain two and zero");
+	}
+	const arms = [...new Set(protocol.arms)].sort();
+	if (
+		arms.length !== AUTOMATION_BENCHMARK_ARMS.length ||
+		AUTOMATION_BENCHMARK_ARMS.some((arm) => !arms.includes(arm))
+	) {
+		throw new Error("Automation benchmark must include every frozen comparison arm");
+	}
+	for (const arm of AUTOMATION_BENCHMARK_ARMS) {
+		const adapter = adapters.find((candidate) => candidate.arm === arm);
+		if (!adapter) throw new Error(`Missing automation benchmark adapter ${arm}`);
+		if (
+			adapter.model !== protocol.model ||
+			adapter.evaluator !== protocol.evaluator ||
+			adapter.maxTokens !== protocol.maxTokens ||
+			adapter.maxCost !== protocol.maxCost ||
+			adapter.maxWallClockMs !== protocol.maxWallClockMs ||
+			adapter.informationPolicy !== "identical-repository-context" ||
+			adapter.toolPolicy !== "matched-authority-ceiling"
+		) {
+			throw new Error(`Automation benchmark adapter ${arm} violates matched resources`);
+		}
+		if (
+			adapter.mutatingChildren > protocol.maxMutatingChildren ||
+			adapter.recursiveDepth > protocol.maxRecursiveDepth
+		) {
+			throw new Error(`Automation benchmark adapter ${arm} exceeds width or depth`);
+		}
+	}
+	return {
+		version: AUTOMATION_BENCHMARK_VERSION,
+		pairedInstances: protocol.taskIds.length * protocol.pairedSeeds.length,
+		arms: [...AUTOMATION_BENCHMARK_ARMS],
+		valid: true,
+	};
+}

--- a/packages/pi-subagents/src/workflow-ui.ts
+++ b/packages/pi-subagents/src/workflow-ui.ts
@@ -46,8 +46,8 @@ function workflowEffects(current: DelegationWorkflow, next: DelegationWorkflow):
 	if (blockingEnabled(current) !== blockingEnabled(next)) {
 		effects.push(
 			blockingEnabled(next)
-				? "Add blocking `subagent` and read-only `subagent_consult`"
-				: "Remove blocking `subagent` and read-only `subagent_consult`",
+				? "Add blocking `subagent`, explicit `subagent_auto`, and read-only `subagent_consult`"
+				: "Remove blocking `subagent`, explicit `subagent_auto`, and read-only `subagent_consult`",
 		);
 	}
 	if (asyncEnabled(current) !== asyncEnabled(next)) {

--- a/packages/pi-subagents/test/automation-contract.test.ts
+++ b/packages/pi-subagents/test/automation-contract.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	AUTOMATION_REQUEST_VERSION,
+	MAX_AUTOMATION_TASKS,
+	parseAutomationRequest,
+	parseWorkflowPlan,
+	parseWorkflowPlanPatch,
+	WORKFLOW_PLAN_PATCH_VERSION,
+	WORKFLOW_PLAN_VERSION,
+} from "../src/automation-contract.js";
+
+function request(overrides: Record<string, unknown> = {}) {
+	return {
+		version: AUTOMATION_REQUEST_VERSION,
+		objective: "Implement the requested behavior",
+		nonGoals: [],
+		requiredInputs: ["repository"],
+		acceptanceCriteria: ["Focused tests pass"],
+		requiredEvidence: ["test output"],
+		authorityCeiling: {
+			capabilities: ["implementation", "code-review"],
+			tools: ["read", "bash", "edit", "write"],
+			readPaths: ["packages/pi-subagents"],
+			writePaths: ["packages/pi-subagents"],
+			network: "unspecified",
+			secrets: "unspecified",
+			sideEffectPolicy: "mutating",
+		},
+		aggregateBudget: {
+			timeoutMs: 120_000,
+			maxTurns: 20,
+			maxToolCalls: 40,
+			maxTasks: 4,
+			maxRevisions: 1,
+		},
+		constraints: {
+			contextPressure: "high",
+			maxMutatingWidth: 2,
+			requireVerification: true,
+			workspaceMode: "shared",
+		},
+		...overrides,
+	};
+}
+
+function task(id: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id,
+		objective: `Complete ${id}`,
+		dependsOn: [],
+		inputArtifacts: [],
+		producesArtifacts: [],
+		sideEffectPolicy: "read-only",
+		readPaths: ["packages/pi-subagents"],
+		writePaths: [],
+		ownershipKeys: [],
+		requiredCapabilities: [],
+		requiredTools: ["read"],
+		acceptanceCriteria: ["Evidence is grounded"],
+		requiredEvidence: ["path evidence"],
+		integrationOwner: false,
+		budget: { timeoutMs: 30_000, maxTurns: 4, maxToolCalls: 8 },
+		...overrides,
+	};
+}
+
+function plan(tasks: unknown[] = [task("inspect")], overrides: Record<string, unknown> = {}) {
+	return {
+		version: WORKFLOW_PLAN_VERSION,
+		requestVersion: AUTOMATION_REQUEST_VERSION,
+		summary: "Smallest useful workflow",
+		missingInputs: [],
+		risks: [],
+		tasks,
+		...overrides,
+	};
+}
+
+test("automation request parser normalizes a strict bounded request", () => {
+	const parsed = parseAutomationRequest(request());
+	assert.equal(parsed.objective, "Implement the requested behavior");
+	assert.equal(parsed.aggregateBudget.maxTasks, 4);
+	assert.equal(parsed.authorityCeiling.sideEffectPolicy, "mutating");
+	assert.throws(() => parseAutomationRequest({ ...request(), future: true }), /unknown field/i);
+	assert.throws(() => parseAutomationRequest({ ...request(), version: "v2" }), /unsupported/i);
+	assert.throws(
+		() =>
+			parseAutomationRequest({
+				...request(),
+				authorityCeiling: { ...request().authorityCeiling, secrets: "denied" },
+			}),
+		/unsupported.*secrets/i,
+	);
+});
+
+test("workflow plan parser rejects malformed JSON and unsupported versions", () => {
+	assert.throws(() => parseWorkflowPlan("{"), /invalid json/i);
+	assert.throws(() => parseWorkflowPlan(plan([], { version: "workflow-plan:v2" })), /unsupported/i);
+});
+
+test("workflow plan parser rejects missing, duplicate, cyclic, and excessive tasks", () => {
+	assert.throws(() => parseWorkflowPlan(plan([])), /at least one task/i);
+	assert.throws(() => parseWorkflowPlan(plan([task("same"), task("same")])), /duplicate/i);
+	assert.throws(
+		() =>
+			parseWorkflowPlan(plan([task("a", { dependsOn: ["b"] }), task("b", { dependsOn: ["a"] })])),
+		/cycle/i,
+	);
+	assert.throws(
+		() =>
+			parseWorkflowPlan(
+				plan(Array.from({ length: MAX_AUTOMATION_TASKS + 1 }, (_, index) => task(`t-${index}`))),
+			),
+		/too many tasks/i,
+	);
+});
+
+test("workflow plan parser rejects oversized text, unsafe paths, and controls", () => {
+	assert.throws(
+		() => parseWorkflowPlan(plan([task("large", { objective: "x".repeat(17 * 1024) })])),
+		/too large/i,
+	);
+	for (const path of ["/etc/passwd", "../outside", "packages/../outside", "bad\0path"]) {
+		assert.throws(() => parseWorkflowPlan(plan([task("unsafe", { readPaths: [path] })])), /path/i);
+	}
+	assert.throws(
+		() => parseWorkflowPlan(plan([task("control", { objective: "unsafe\u001b[31m" })])),
+		/terminal control/i,
+	);
+	assert.throws(
+		() => parseWorkflowPlan(plan([task("private", { objective: "<private>secret</private>" })])),
+		/private data/i,
+	);
+});
+
+test("workflow plan parser rejects conflicting ownership and unsupported guarantees", () => {
+	assert.throws(
+		() =>
+			parseWorkflowPlan(
+				plan([task("a", { ownershipKeys: ["shared"] }), task("b", { ownershipKeys: ["shared"] })]),
+			),
+		/ownership/i,
+	);
+	assert.throws(
+		() => parseWorkflowPlan(plan([task("network", { guarantees: { network: "denied" } })])),
+		/unsupported guarantee/i,
+	);
+});
+
+test("workflow plan and patch reject executor-owned identities and forged generations", () => {
+	assert.throws(() => parseWorkflowPlan(plan(undefined, { planId: "forged" })), /executor-owned/i);
+	const patch = {
+		version: WORKFLOW_PLAN_PATCH_VERSION,
+		planId: "a".repeat(64),
+		workflowGeneration: 3,
+		reason: "Assumption changed",
+		operations: [{ type: "cancel-task", taskId: "inspect" }],
+	};
+	assert.equal(parseWorkflowPlanPatch(patch).workflowGeneration, 3);
+	assert.throws(() => parseWorkflowPlanPatch({ ...patch, workflowGeneration: -1 }), /generation/i);
+	assert.throws(
+		() => parseWorkflowPlanPatch({ ...patch, executionPlanId: "forged" }),
+		/unknown field/i,
+	);
+	assert.throws(
+		() =>
+			parseWorkflowPlanPatch({
+				...patch,
+				operations: [{ type: "add-task", task: task("unsafe-patch", { readPaths: ["/outside"] }) }],
+			}),
+		/path/i,
+	);
+});

--- a/packages/pi-subagents/test/automation-planner.test.ts
+++ b/packages/pi-subagents/test/automation-planner.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	AUTOMATION_REQUEST_VERSION,
+	parseAutomationRequest,
+	WORKFLOW_PLAN_VERSION,
+} from "../src/automation-contract.js";
+import {
+	buildAutomationPlannerPrompt,
+	parseAutomationPlannerOutput,
+	resolveAutomationPlannerPolicy,
+} from "../src/automation-planner.js";
+
+const request = parseAutomationRequest({
+	version: AUTOMATION_REQUEST_VERSION,
+	objective: "Implement a bounded feature",
+	nonGoals: ["Do not publish"],
+	requiredInputs: ["repository"],
+	acceptanceCriteria: ["Tests pass"],
+	requiredEvidence: ["test output"],
+	authorityCeiling: {
+		capabilities: ["implementation"],
+		tools: ["read", "edit"],
+		readPaths: ["packages/pi-subagents"],
+		writePaths: ["packages/pi-subagents"],
+		network: "unspecified",
+		secrets: "unspecified",
+		sideEffectPolicy: "mutating",
+	},
+	aggregateBudget: {
+		timeoutMs: 120_000,
+		maxTurns: 20,
+		maxToolCalls: 40,
+		maxTasks: 4,
+		maxRevisions: 1,
+	},
+	constraints: {
+		contextPressure: "high",
+		maxMutatingWidth: 1,
+		requireVerification: true,
+		workspaceMode: "shared",
+	},
+});
+
+test("planner prompt requests a bounded workflow without hidden reasoning or authority grants", () => {
+	const prompt = buildAutomationPlannerPrompt(request);
+	for (const field of [
+		"dependencies",
+		"artifacts",
+		"sideEffectPolicy",
+		"requiredCapabilities",
+		"acceptanceCriteria",
+		"requiredEvidence",
+		"integrationOwner",
+		"verifierFor",
+		"budget",
+	]) {
+		assert.match(prompt, new RegExp(field, "i"));
+	}
+	assert.match(prompt, /return only json/i);
+	assert.match(prompt, /do not provide hidden reasoning/i);
+	assert.match(prompt, /cannot grant/i);
+	assert.ok(Buffer.byteLength(prompt, "utf8") < 32 * 1024);
+});
+
+test("planner policy is read-only, bounded, trust-aware, and non-recursive", async () => {
+	const trusted = await resolveAutomationPlannerPolicy(true, "/workspace", async () => ({
+		disableExtensions: true,
+		disableSkills: true,
+		disablePromptTemplates: true,
+		disableContextFiles: false,
+		projectTrust: true,
+	}));
+	assert.deepEqual(trusted.tools, ["read", "grep", "find", "ls"]);
+	assert.equal(trusted.resources, "project-context");
+	assert.equal(trusted.launchPolicy.disableExtensions, true);
+	assert.equal(trusted.launchPolicy.projectTrust, true);
+
+	const untrusted = await resolveAutomationPlannerPolicy(false, "/workspace", async (policy) => ({
+		disableExtensions: true,
+		disableSkills: true,
+		disablePromptTemplates: true,
+		disableContextFiles: true,
+		projectTrust: false,
+		baseSystemPrompt: policy,
+	}));
+	assert.equal(untrusted.resources, "none");
+	assert.equal(untrusted.launchPolicy.projectTrust, false);
+});
+
+test("planner output accepts one exact versioned object and rejects prose fences", () => {
+	const output = JSON.stringify({
+		version: WORKFLOW_PLAN_VERSION,
+		requestVersion: AUTOMATION_REQUEST_VERSION,
+		summary: "Inspect",
+		missingInputs: [],
+		risks: [],
+		tasks: [
+			{
+				id: "inspect",
+				objective: "Inspect the repository",
+				dependsOn: [],
+				inputArtifacts: [],
+				producesArtifacts: [],
+				sideEffectPolicy: "read-only",
+				readPaths: ["packages/pi-subagents"],
+				writePaths: [],
+				ownershipKeys: [],
+				requiredCapabilities: [],
+				requiredTools: ["read"],
+				acceptanceCriteria: ["Grounded result"],
+				requiredEvidence: ["path evidence"],
+				integrationOwner: false,
+				budget: { timeoutMs: 10_000, maxTurns: 2, maxToolCalls: 4 },
+			},
+		],
+	});
+	assert.equal(parseAutomationPlannerOutput(output).tasks[0]?.id, "inspect");
+	assert.throws(
+		() => parseAutomationPlannerOutput(`Here is the plan:\n${output}`),
+		/invalid json/i,
+	);
+	assert.throws(
+		() => parseAutomationPlannerOutput(`\`\`\`json\n${output}\n\`\`\``),
+		/invalid json/i,
+	);
+});

--- a/packages/pi-subagents/test/automation.test.ts
+++ b/packages/pi-subagents/test/automation.test.ts
@@ -1,0 +1,299 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	executeAutomationRequest,
+	registerSubagentAutomation,
+	type SubagentAutomationParams,
+} from "../src/automation.js";
+import { AUTOMATION_REQUEST_VERSION, WORKFLOW_PLAN_VERSION } from "../src/automation-contract.js";
+
+function request(overrides: Record<string, unknown> = {}): SubagentAutomationParams["request"] {
+	return {
+		version: AUTOMATION_REQUEST_VERSION,
+		objective: "Complete the high-level objective",
+		nonGoals: [],
+		requiredInputs: ["repository"],
+		acceptanceCriteria: ["Tests pass"],
+		requiredEvidence: ["test output"],
+		authorityCeiling: {
+			capabilities: ["implementation", "code-review", "repository-search"],
+			tools: ["read", "grep", "find", "ls", "bash", "edit", "write"],
+			readPaths: ["packages/pi-subagents"],
+			writePaths: ["packages/pi-subagents"],
+			network: "unspecified",
+			secrets: "unspecified",
+			sideEffectPolicy: "mutating",
+		},
+		aggregateBudget: {
+			timeoutMs: 180_000,
+			maxTurns: 30,
+			maxToolCalls: 60,
+			maxTasks: 4,
+			maxRevisions: 1,
+		},
+		constraints: {
+			contextPressure: "high",
+			maxMutatingWidth: 2,
+			requireVerification: false,
+			workspaceMode: "shared",
+		},
+		...overrides,
+	} as SubagentAutomationParams["request"];
+}
+
+function task(id: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id,
+		objective: `Complete ${id}`,
+		dependsOn: [],
+		inputArtifacts: [],
+		producesArtifacts: [],
+		sideEffectPolicy: "read-only",
+		readPaths: ["packages/pi-subagents"],
+		writePaths: [],
+		ownershipKeys: [],
+		requiredCapabilities: ["repository-search"],
+		requiredTools: ["read"],
+		acceptanceCriteria: ["Grounded result"],
+		requiredEvidence: ["path evidence"],
+		integrationOwner: false,
+		budget: { timeoutMs: 30_000, maxTurns: 4, maxToolCalls: 8 },
+		...overrides,
+	};
+}
+
+function plan(tasks: unknown[], missingInputs: string[] = []) {
+	return JSON.stringify({
+		version: WORKFLOW_PLAN_VERSION,
+		requestVersion: AUTOMATION_REQUEST_VERSION,
+		summary: "Bounded deterministic fixture",
+		missingInputs,
+		risks: [],
+		tasks,
+	});
+}
+
+async function run(
+	plannerOutput: string | Error,
+	requestValue = request(),
+	isCurrent: () => boolean = () => true,
+) {
+	let workflowCalls = 0;
+	const context = createMockContext({ cwd: process.cwd(), isProjectTrusted: () => true });
+	const result = await executeAutomationRequest(
+		"auto-1",
+		{ request: requestValue },
+		new AbortController().signal,
+		undefined,
+		context.ctx,
+		{
+			getSettings: () => undefined,
+			runPlanner: async () => {
+				if (plannerOutput instanceof Error) throw plannerOutput;
+				return plannerOutput;
+			},
+			runWorkflow: async (params) => {
+				workflowCalls++;
+				return {
+					content: [{ type: "text" as const, text: `executed ${params.workflow?.tasks.length}` }],
+					details: {
+						mode: "workflow" as const,
+						agentScope: "user" as const,
+						projectAgentsDir: null,
+						results: [],
+					},
+				};
+			},
+			persistCompiled: async () => undefined,
+		},
+		isCurrent,
+	);
+	return { result, workflowCalls };
+}
+
+test("objective compiles to a typed parent-owned result with zero execution workers", async () => {
+	const { result, workflowCalls } = await run(
+		plan([task("inspect")]),
+		request({
+			constraints: {
+				contextPressure: "low",
+				maxMutatingWidth: 2,
+				requireVerification: false,
+				workspaceMode: "shared",
+			},
+		}),
+	);
+	assert.equal(result.details.status, "parent-owned");
+	assert.equal(result.details.childCount, 0);
+	assert.equal(workflowCalls, 0);
+});
+
+test("objective compiles to one capability-routed child", async () => {
+	const { result, workflowCalls } = await run(plan([task("inspect")]));
+	assert.equal(result.details.status, "executed");
+	assert.equal(result.details.childCount, 1);
+	assert.equal(result.details.compiled?.workflow.tasks[0]?.agent, "scout");
+	assert.equal(workflowCalls, 1);
+});
+
+test("mutating objective compiles to an implementation child plus verifier", async () => {
+	const { result } = await run(
+		plan([
+			task("implement", {
+				sideEffectPolicy: "mutating",
+				writePaths: ["packages/pi-subagents"],
+				requiredCapabilities: ["implementation"],
+				requiredTools: ["read", "edit", "write"],
+				integrationOwner: true,
+			}),
+		]),
+	);
+	assert.equal(result.details.status, "executed");
+	assert.equal(result.details.childCount, 2);
+	assert.ok(
+		result.details.compiled?.workflow.tasks.some(
+			(candidate) => candidate.verifierFor === "implement",
+		),
+	);
+});
+
+test("objective compiles to a bounded two-child mutating width and integration path", async () => {
+	const mutating = (id: string) =>
+		task(id, {
+			sideEffectPolicy: "mutating",
+			writePaths: [`packages/pi-subagents/${id}`],
+			ownershipKeys: [id],
+			requiredCapabilities: ["implementation"],
+			requiredTools: ["read", "edit", "write"],
+		});
+	const { result } = await run(
+		plan([
+			mutating("a"),
+			mutating("b"),
+			task("integrate", {
+				dependsOn: ["a", "b"],
+				sideEffectPolicy: "mutating",
+				writePaths: ["packages/pi-subagents"],
+				requiredCapabilities: ["implementation"],
+				requiredTools: ["read", "edit", "write"],
+				integrationOwner: true,
+			}),
+		]),
+	);
+	assert.equal(result.details.status, "executed");
+	assert.equal(result.details.compiled?.maxConcurrentMutating, 2);
+	assert.equal(result.details.childCount, 4);
+});
+
+test("missing input, planner failure, and compiler rejection never launch execution workers", async () => {
+	for (const [plannerOutput, expected] of [
+		[plan([task("inspect")], ["API contract"]), "needs-input"],
+		[new Error("provider <private>SECRET</private> unavailable\u001b[31m"), "planner-failed"],
+		[plan([task("unsupported", { requiredCapabilities: ["gpu"] })]), "compiler-rejected"],
+	] as const) {
+		const { result, workflowCalls } = await run(plannerOutput);
+		assert.equal(result.details.status, expected);
+		assert.equal(result.details.childCount, 0);
+		assert.equal(workflowCalls, 0);
+		const text = result.content.find((part) => part.type === "text")?.text ?? "";
+		assert.doesNotMatch(text, /SECRET/u);
+		assert.equal(text.includes("\u001b"), false);
+	}
+});
+
+test("session shutdown aborts and drains the owned planner before cleanup returns", async () => {
+	const mock = createMockPi();
+	let started!: () => void;
+	const didStart = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	registerSubagentAutomation(mock.pi, {
+		getSettings: () => undefined,
+		runPlanner: async ({ signal }) => {
+			started();
+			await new Promise<void>((_resolve, reject) => {
+				signal.addEventListener("abort", () => reject(new DOMException("shutdown", "AbortError")), {
+					once: true,
+				});
+			});
+			return plan([task("inspect")]);
+		},
+		persistCompiled: async () => undefined,
+	});
+	const tool = mock.tools.find((candidate) => candidate.name === "subagent_auto") as
+		| { execute: (...args: unknown[]) => Promise<unknown> }
+		| undefined;
+	assert.ok(tool);
+	const context = createMockContext({ cwd: process.cwd(), isProjectTrusted: () => true });
+	const pending = tool.execute(
+		"auto-shutdown",
+		{ request: request() },
+		undefined,
+		undefined,
+		context.ctx,
+	);
+	await didStart;
+	const rejected = assert.rejects(
+		pending,
+		(error: unknown) => error instanceof Error && error.name === "AbortError",
+	);
+	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+	await rejected;
+});
+
+test("workflow grandchildren are rejected before the read-only planner starts", async () => {
+	const previous = process.env.PI_SUBAGENT_DEPTH;
+	process.env.PI_SUBAGENT_DEPTH = "1";
+	let plannerCalls = 0;
+	try {
+		const context = createMockContext({ cwd: process.cwd(), isProjectTrusted: () => true });
+		const result = await executeAutomationRequest(
+			"auto-recursive",
+			{ request: request() },
+			new AbortController().signal,
+			undefined,
+			context.ctx,
+			{
+				getSettings: () => undefined,
+				runPlanner: async () => {
+					plannerCalls++;
+					return plan([task("inspect")]);
+				},
+				persistCompiled: async () => undefined,
+			},
+		);
+		assert.equal(result.details.status, "compiler-rejected");
+		assert.equal(plannerCalls, 0);
+	} finally {
+		if (previous === undefined) delete process.env.PI_SUBAGENT_DEPTH;
+		else process.env.PI_SUBAGENT_DEPTH = previous;
+	}
+});
+
+test("session replacement after the planning await cancels before compilation or launch", async () => {
+	let current = true;
+	const context = createMockContext({ cwd: process.cwd(), isProjectTrusted: () => true });
+	await assert.rejects(
+		executeAutomationRequest(
+			"auto-stale",
+			{ request: request() },
+			new AbortController().signal,
+			undefined,
+			context.ctx,
+			{
+				getSettings: () => undefined,
+				runPlanner: async () => {
+					current = false;
+					return plan([task("inspect")]);
+				},
+				runWorkflow: async () => {
+					throw new Error("stale workflow launched");
+				},
+				persistCompiled: async () => undefined,
+			},
+			() => current,
+		),
+		(error: unknown) => error instanceof Error && error.name === "AbortError",
+	);
+});

--- a/packages/pi-subagents/test/execution-plan.test.ts
+++ b/packages/pi-subagents/test/execution-plan.test.ts
@@ -128,6 +128,12 @@ test("enforced execution plans narrow tools and reject unknown or unsupported gu
 	assert.ok(contract);
 	assert.deepEqual(resolveContractTools(["read", "grep", "bash"], contract), ["read"]);
 	assert.deepEqual(resolveContractTools(undefined, contract), ["read"]);
+	const noTools = normalizeDelegationContract({
+		...contract,
+		requestedAuthority: { ...contract.requestedAuthority, tools: [] },
+	});
+	assert.ok(noTools);
+	assert.deepEqual(resolveContractTools(["read", "grep", "bash"], noTools), []);
 	const unavailableDefaultTool = normalizeDelegationContract({
 		...contract,
 		requestedAuthority: { ...contract.requestedAuthority, tools: ["grep"] },

--- a/packages/pi-subagents/test/subagents.test.ts
+++ b/packages/pi-subagents/test/subagents.test.ts
@@ -142,6 +142,7 @@ test("subagents registers consistent blocking guidance and one management comman
 		mock.tools.map((candidate) => candidate.name),
 		[
 			"subagent",
+			"subagent_auto",
 			"subagent_spawn",
 			"subagent_send",
 			"subagent_manage",
@@ -224,6 +225,19 @@ test("subagents registers consistent blocking guidance and one management comman
 	assert.match(parameters?.properties?.maxToolCalls?.description ?? "", /tool calls/i);
 	assert.match(guidanceText, /totalTimeoutMs.*blocking workflow/i);
 	assert.match(guidanceText, /idleTimeoutMs.*stalled/i);
+	const automationTool = mock.tools.find((candidate) => candidate.name === "subagent_auto");
+	assert.ok(automationTool);
+	assert.match(String(automationTool.description), /explicitly opt in/i);
+	assert.match(String(automationTool.description), /two concurrent mutating workers/i);
+	assert.equal(
+		(automationTool.parameters as { additionalProperties?: boolean }).additionalProperties,
+		false,
+	);
+	assert.ok(
+		Buffer.byteLength(JSON.stringify(automationTool.parameters), "utf8") <
+			Buffer.byteLength(JSON.stringify(tool?.parameters), "utf8"),
+		"the dedicated automation schema stays smaller than the multi-mode compatibility schema",
+	);
 	assert.deepEqual(
 		[...mock.commands.keys()].filter((name) => name.startsWith("subagents")),
 		["subagents"],
@@ -1013,6 +1027,7 @@ test("delegation workflow settings control the registered tool surface", () => {
 				settings: {},
 				tools: [
 					"subagent",
+					"subagent_auto",
 					"subagent_spawn",
 					"subagent_send",
 					"subagent_manage",
@@ -1035,7 +1050,7 @@ test("delegation workflow settings control the registered tool surface", () => {
 			{
 				name: "blocking only",
 				settings: { blocking: { enabled: true }, stateful: { enabled: false } },
-				tools: ["subagent", "subagent_inspect", "subagent_consult"],
+				tools: ["subagent", "subagent_auto", "subagent_inspect", "subagent_consult"],
 			},
 			{
 				name: "disabled",
@@ -1081,7 +1096,7 @@ test("disabled stateful settings do not advertise unavailable lifecycle tools", 
 		subagents(mock.pi);
 		assert.deepEqual(
 			mock.tools.map((tool) => tool.name),
-			["subagent", "subagent_inspect", "subagent_consult"],
+			["subagent", "subagent_auto", "subagent_inspect", "subagent_consult"],
 		);
 		const blockingTool = mock.tools[0];
 		assert.doesNotMatch(String(blockingTool?.description), /subagent_spawn/i);

--- a/packages/pi-subagents/test/tool-rendering.test.ts
+++ b/packages/pi-subagents/test/tool-rendering.test.ts
@@ -146,10 +146,11 @@ const consultDetails = {
 	},
 };
 
-test("all seven subagent tools register native call and result renderers", () => {
+test("all eight subagent tools register native call and result renderers", () => {
 	const tools = registeredTools();
 	assert.deepEqual([...tools.keys()].sort(), [
 		"subagent",
+		"subagent_auto",
 		"subagent_consult",
 		"subagent_inspect",
 		"subagent_mailbox",
@@ -161,6 +162,44 @@ test("all seven subagent tools register native call and result renderers", () =>
 		assert.equal(typeof tool.renderCall, "function", `${tool.name} renderCall`);
 		assert.equal(typeof tool.renderResult, "function", `${tool.name} renderResult`);
 	}
+});
+
+test("automation renderer bounds and sanitizes untrusted objective and result text", () => {
+	const tool = registeredTools().get("subagent_auto");
+	assert.ok(tool);
+	const callLines = renderCall(
+		tool,
+		{
+			request: {
+				version: "pi-subagents:automation-request:v1",
+				objective: "Plan <private>SECRET</private>\u001b]8;;link\u0007 safely",
+			},
+		},
+		32,
+	);
+	const call = withoutSgr(callLines.join("\n"));
+	assert.doesNotMatch(call, /SECRET/u);
+	assert.equal(call.includes(ESCAPE), false);
+	assert.ok(callLines.every((line) => visibleWidth(line) <= 32));
+	const resultLines = renderResult(
+		tool,
+		{
+			request: {
+				version: "pi-subagents:automation-request:v1",
+				objective: "Plan safely",
+			},
+		},
+		{
+			content: [{ type: "text", text: "Compiler rejected <private>SECRET</private>\u001b[31m" }],
+			details: { status: "compiler-rejected", isError: true },
+		},
+		{ expanded: false, isPartial: false },
+		32,
+	);
+	const result = withoutSgr(resultLines.join("\n"));
+	assert.doesNotMatch(result, /SECRET/u);
+	assert.equal(result.includes(ESCAPE), false);
+	assert.ok(resultLines.every((line) => visibleWidth(line) <= 32));
 });
 
 test("panel renderer is width-safe, sanitized, and preserves objections and dissent", () => {

--- a/packages/pi-subagents/test/workflow-plan-compiler.test.ts
+++ b/packages/pi-subagents/test/workflow-plan-compiler.test.ts
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import type { AgentConfig } from "../src/agents.js";
+import {
+	AUTOMATION_REQUEST_VERSION,
+	parseAutomationRequest,
+	parseWorkflowPlan,
+	WORKFLOW_PLAN_VERSION,
+} from "../src/automation-contract.js";
+import { CAPABILITY_MANIFEST_VERSION } from "../src/capabilities.js";
+import { compileWorkflowPlan } from "../src/workflow-plan-compiler.js";
+
+const target = {
+	cwd: "/workspace",
+	boundary: "current-workspace" as const,
+	trust: { kind: "session-trusted" as const, projectTrusted: true },
+};
+
+function agent(
+	name: string,
+	capabilities: string[],
+	filesystem: "read" | "write",
+	verificationRoles: string[] = [],
+): AgentConfig {
+	return {
+		name,
+		description: name,
+		tools:
+			filesystem === "read" ? ["read", "grep", "find", "ls"] : ["read", "bash", "edit", "write"],
+		source: "built-in",
+		filePath: `built-in:${name}`,
+		systemPrompt: name,
+		capabilityManifest: {
+			version: CAPABILITY_MANIFEST_VERSION,
+			capabilities,
+			modalities: ["text"],
+			resultFormats: ["text", "structured-v1", "structured-v2"],
+			authority: { filesystem },
+			verificationRoles,
+			contextStrengths: ["repository"],
+			costHint: "low",
+			latencyHint: "low",
+			limitations: [],
+		},
+	};
+}
+
+const agents = [
+	agent("worker", ["implementation"], "write"),
+	agent("worker-two", ["implementation"], "write"),
+	agent("reviewer", ["code-review"], "read", ["independent-review"]),
+	agent("scout", ["repository-search"], "read"),
+];
+
+function request(overrides: Record<string, unknown> = {}) {
+	return parseAutomationRequest({
+		version: AUTOMATION_REQUEST_VERSION,
+		objective: "Complete the objective",
+		nonGoals: [],
+		requiredInputs: ["repository"],
+		acceptanceCriteria: ["Tests pass"],
+		requiredEvidence: ["test output"],
+		authorityCeiling: {
+			capabilities: ["implementation", "code-review", "repository-search"],
+			tools: ["read", "grep", "find", "ls", "bash", "edit", "write"],
+			readPaths: ["packages/pi-subagents"],
+			writePaths: ["packages/pi-subagents"],
+			network: "unspecified",
+			secrets: "unspecified",
+			sideEffectPolicy: "mutating",
+		},
+		aggregateBudget: {
+			timeoutMs: 180_000,
+			maxTurns: 30,
+			maxToolCalls: 60,
+			maxTasks: 4,
+			maxRevisions: 1,
+		},
+		constraints: {
+			contextPressure: "high",
+			maxMutatingWidth: 2,
+			requireVerification: false,
+			workspaceMode: "shared",
+		},
+		...overrides,
+	});
+}
+
+function task(id: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id,
+		objective: `Complete ${id}`,
+		dependsOn: [],
+		inputArtifacts: [],
+		producesArtifacts: [],
+		sideEffectPolicy: "read-only",
+		readPaths: ["packages/pi-subagents"],
+		writePaths: [],
+		ownershipKeys: [],
+		requiredCapabilities: ["repository-search"],
+		requiredTools: ["read"],
+		acceptanceCriteria: ["Grounded result"],
+		requiredEvidence: ["path evidence"],
+		integrationOwner: false,
+		budget: { timeoutMs: 30_000, maxTurns: 4, maxToolCalls: 8 },
+		...overrides,
+	};
+}
+
+function plan(tasks: unknown[], missingInputs: string[] = []) {
+	return parseWorkflowPlan({
+		version: WORKFLOW_PLAN_VERSION,
+		requestVersion: AUTOMATION_REQUEST_VERSION,
+		summary: "Bounded workflow",
+		missingInputs,
+		risks: [],
+		tasks,
+	});
+}
+
+function compile(tasks: unknown[], requestOverride: Record<string, unknown> = {}, depth = 0) {
+	return compileWorkflowPlan({
+		request: request(requestOverride),
+		proposal: plan(tasks),
+		agents,
+		target,
+		depth,
+	});
+}
+
+test("compiler returns parent-owned direct work without a launch", () => {
+	const result = compile([task("inspect")], {
+		constraints: {
+			contextPressure: "low",
+			maxMutatingWidth: 2,
+			requireVerification: false,
+			workspaceMode: "shared",
+		},
+	});
+	assert.equal(result.status, "parent-owned");
+	assert.equal(result.childCount, 0);
+});
+
+test("compiler admits one child and a sequential dependency without widening authority", () => {
+	const one = compile([task("inspect")]);
+	assert.equal(one.status, "compiled");
+	if (one.status !== "compiled") return;
+	assert.equal(one.workflow.tasks.length, 1);
+	assert.equal(one.workflow.tasks[0]?.agent, "scout");
+	assert.deepEqual(one.workflow.tasks[0]?.requiredTools, ["read"]);
+
+	const sequential = compile([task("inspect"), task("summarize", { dependsOn: ["inspect"] })]);
+	assert.equal(sequential.status, "compiled");
+	if (sequential.status !== "compiled") return;
+	assert.deepEqual(sequential.workflow.tasks[1]?.dependsOn, ["inspect"]);
+});
+
+test("compiler synthesizes a distinct verifier for one mutating child", () => {
+	const result = compile([
+		task("implement", {
+			sideEffectPolicy: "mutating",
+			writePaths: ["packages/pi-subagents"],
+			requiredCapabilities: ["implementation"],
+			requiredTools: ["read", "edit", "write"],
+			integrationOwner: true,
+		}),
+	]);
+	assert.equal(result.status, "compiled");
+	if (result.status !== "compiled") return;
+	assert.equal(result.workflow.tasks.length, 2);
+	const verifier = result.workflow.tasks.find((candidate) => candidate.verifierFor === "implement");
+	assert.equal(verifier?.agent, "reviewer");
+	assert.equal(verifier?.resultFormat, "structured-v2");
+	assert.notEqual(verifier?.agent, result.workflow.tasks[0]?.agent);
+});
+
+test("compiler admits two safe mutating children only with an authoritative integration path", () => {
+	const mutating = (id: string) =>
+		task(id, {
+			sideEffectPolicy: "mutating",
+			writePaths: [`packages/pi-subagents/${id}`],
+			ownershipKeys: [id],
+			requiredCapabilities: ["implementation"],
+			requiredTools: ["read", "edit", "write"],
+		});
+	const result = compile([
+		mutating("a"),
+		mutating("b"),
+		task("integrate", {
+			dependsOn: ["a", "b"],
+			sideEffectPolicy: "mutating",
+			writePaths: ["packages/pi-subagents"],
+			requiredCapabilities: ["implementation"],
+			requiredTools: ["read", "bash", "edit", "write"],
+			integrationOwner: true,
+		}),
+	]);
+	assert.equal(result.status, "compiled");
+	if (result.status !== "compiled") return;
+	assert.ok(result.workflow.tasks.some((candidate) => candidate.verifierFor === "integrate"));
+	assert.equal(result.maxConcurrentMutating, 2);
+});
+
+test("compiler rejects missing verification, unsupported capability, budget, and integration", () => {
+	const noReviewer = compileWorkflowPlan({
+		request: request(),
+		proposal: plan([
+			task("implement", {
+				sideEffectPolicy: "mutating",
+				writePaths: ["packages/pi-subagents"],
+				requiredCapabilities: ["implementation"],
+				requiredTools: ["edit"],
+				integrationOwner: true,
+			}),
+		]),
+		agents: agents.filter((candidate) => candidate.name !== "reviewer"),
+		target,
+		depth: 0,
+	});
+	assert.equal(noReviewer.status, "rejected");
+	assert.match(noReviewer.reasonCodes.join(" "), /verification/i);
+
+	const unsupported = compile([
+		task("gpu", { requiredCapabilities: ["gpu"], requiredTools: ["read"] }),
+	]);
+	assert.equal(unsupported.status, "rejected");
+	assert.match(unsupported.reasonCodes.join(" "), /capability/i);
+
+	const promptOnlyReadOnly = compile([
+		task("shell", { requiredCapabilities: ["repository-search"], requiredTools: ["bash"] }),
+	]);
+	assert.equal(promptOnlyReadOnly.status, "rejected");
+	assert.match(promptOnlyReadOnly.reasonCodes.join(" "), /read-only-tool/i);
+
+	const overBudget = compile(
+		[task("inspect", { budget: { timeoutMs: 100_000, maxTurns: 20, maxToolCalls: 40 } })],
+		{
+			aggregateBudget: {
+				timeoutMs: 10_000,
+				maxTurns: 2,
+				maxToolCalls: 2,
+				maxTasks: 4,
+				maxRevisions: 1,
+			},
+		},
+	);
+	assert.equal(overBudget.status, "parent-owned");
+
+	const noIntegration = compile([
+		task("a", {
+			sideEffectPolicy: "mutating",
+			writePaths: ["packages/pi-subagents/a"],
+			ownershipKeys: ["a"],
+			requiredCapabilities: ["implementation"],
+			requiredTools: ["edit"],
+		}),
+		task("b", {
+			sideEffectPolicy: "mutating",
+			writePaths: ["packages/pi-subagents/b"],
+			ownershipKeys: ["b"],
+			requiredCapabilities: ["implementation"],
+			requiredTools: ["edit"],
+		}),
+	]);
+	assert.equal(noIntegration.status, "rejected");
+	assert.match(noIntegration.reasonCodes.join(" "), /integration/i);
+});
+
+test("compiler returns needs-input and rejects attempted workflow grandchildren", () => {
+	const needsInput = compileWorkflowPlan({
+		request: request(),
+		proposal: plan([task("inspect")], ["API contract"]),
+		agents,
+		target,
+		depth: 0,
+	});
+	assert.equal(needsInput.status, "needs-input");
+	assert.equal(needsInput.childCount, 0);
+	const recursive = compile([task("inspect")], {}, 1);
+	assert.equal(recursive.status, "rejected");
+	assert.match(recursive.reasonCodes.join(" "), /recursion/i);
+});

--- a/packages/pi-subagents/test/workflow-plan-patch.test.ts
+++ b/packages/pi-subagents/test/workflow-plan-patch.test.ts
@@ -1,0 +1,359 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "vitest";
+import type { AgentConfig } from "../src/agents.js";
+import {
+	AUTOMATION_REQUEST_VERSION,
+	parseAutomationRequest,
+	parseWorkflowPlan,
+	parseWorkflowPlanPatch,
+	WORKFLOW_PLAN_PATCH_VERSION,
+	WORKFLOW_PLAN_VERSION,
+} from "../src/automation-contract.js";
+import { CAPABILITY_MANIFEST_VERSION } from "../src/capabilities.js";
+import type { TargetPolicyAudit } from "../src/cwd-policy.js";
+import { WorkItemLedger } from "../src/work-item-ledger.js";
+import { compileWorkflowPlan } from "../src/workflow-plan-compiler.js";
+import {
+	AutomationPlanPersistence,
+	applyWorkflowPlanPatch,
+	createWorkflowPlanRecord,
+} from "../src/workflow-plan-patch.js";
+
+function agent(name: string, review = false): AgentConfig {
+	return {
+		name,
+		description: name,
+		tools: review ? ["read"] : ["read", "edit", "write"],
+		source: "built-in",
+		filePath: `built-in:${name}`,
+		systemPrompt: name,
+		capabilityManifest: {
+			version: CAPABILITY_MANIFEST_VERSION,
+			capabilities: review ? ["code-review"] : ["implementation"],
+			modalities: ["text"],
+			resultFormats: ["structured-v2"],
+			authority: { filesystem: review ? "read" : "write" },
+			verificationRoles: review ? ["independent-review"] : [],
+			contextStrengths: ["repository"],
+			costHint: "low",
+			latencyHint: "low",
+			limitations: [],
+		},
+	};
+}
+
+const agents = [agent("worker"), agent("reviewer", true)];
+const target: TargetPolicyAudit = {
+	cwd: "/workspace",
+	boundary: "current-workspace",
+	trust: { kind: "session-trusted", projectTrusted: true },
+};
+
+function task(id: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id,
+		objective: `Complete ${id}`,
+		dependsOn: [],
+		inputArtifacts: [],
+		producesArtifacts: [],
+		sideEffectPolicy: "mutating",
+		readPaths: ["packages/pi-subagents"],
+		writePaths: ["packages/pi-subagents"],
+		ownershipKeys: [id],
+		requiredCapabilities: ["implementation"],
+		requiredTools: ["read", "edit", "write"],
+		acceptanceCriteria: ["Tests pass"],
+		requiredEvidence: ["test output"],
+		integrationOwner: true,
+		budget: { timeoutMs: 30_000, maxTurns: 4, maxToolCalls: 8 },
+		...overrides,
+	};
+}
+
+const request = parseAutomationRequest({
+	version: AUTOMATION_REQUEST_VERSION,
+	objective: "Implement safely",
+	nonGoals: [],
+	requiredInputs: ["repository"],
+	acceptanceCriteria: ["Tests pass"],
+	requiredEvidence: ["test output"],
+	authorityCeiling: {
+		capabilities: ["implementation", "code-review"],
+		tools: ["read", "edit", "write"],
+		readPaths: ["packages/pi-subagents"],
+		writePaths: ["packages/pi-subagents"],
+		network: "unspecified",
+		secrets: "unspecified",
+		sideEffectPolicy: "mutating",
+	},
+	aggregateBudget: {
+		timeoutMs: 120_000,
+		maxTurns: 20,
+		maxToolCalls: 40,
+		maxTasks: 4,
+		maxRevisions: 2,
+	},
+	constraints: {
+		contextPressure: "high",
+		maxMutatingWidth: 1,
+		requireVerification: true,
+		workspaceMode: "shared",
+	},
+});
+
+function compiledRecord() {
+	const proposal = parseWorkflowPlan({
+		version: WORKFLOW_PLAN_VERSION,
+		requestVersion: AUTOMATION_REQUEST_VERSION,
+		summary: "Implement and verify",
+		missingInputs: [],
+		risks: [],
+		tasks: [task("implement")],
+	});
+	const compiled = compileWorkflowPlan({ request, proposal, agents, target, depth: 0 });
+	assert.equal(compiled.status, "compiled");
+	if (compiled.status !== "compiled") throw new Error("fixture did not compile");
+	const ledger = WorkItemLedger.create({
+		workflowId: compiled.workflow.id ?? "auto",
+		items: compiled.workflow.tasks.map((item) => ({
+			id: item.id,
+			objective: item.task,
+			dependencies: item.dependsOn ?? [],
+			requiredCapabilities: item.requiredCapabilities,
+			requiredTools: item.requiredTools,
+			selectedAgentName: item.agent,
+			sideEffectPolicy: item.contract?.sideEffectPolicy,
+			readPaths: item.readPaths,
+			writePaths: item.writePaths,
+			ownershipKeys: item.ownershipKeys,
+			acceptanceCriteria: item.acceptanceCriteria,
+			integrationOwner: item.integrationOwner,
+			verifierFor: item.verifierFor,
+		})),
+	});
+	return { compiled, record: createWorkflowPlanRecord(compiled), ledger };
+}
+
+function patch(planId: string, generation: number, operations: unknown[]) {
+	return parseWorkflowPlanPatch({
+		version: WORKFLOW_PLAN_PATCH_VERSION,
+		planId,
+		workflowGeneration: generation,
+		reason: "Verifier requested rework",
+		operations,
+	});
+}
+
+test("patches reject completed work, accepted artifacts, and current verification", () => {
+	const { record, ledger } = compiledRecord();
+	const started = ledger.start("implement", "agent:worker");
+	ledger.complete("implement", {
+		taskGeneration: started.taskGeneration,
+		executionPlanId: "a".repeat(64),
+		artifacts: [{ id: "accepted", kind: "patch", version: "v1", verified: true }],
+	});
+	assert.throws(
+		() =>
+			applyWorkflowPlanPatch({
+				record,
+				ledger: ledger.snapshot(),
+				patch: patch(record.planId, record.workflowGeneration, [
+					{ type: "replace-task", taskId: "implement", task: task("implement") },
+				]),
+				agents,
+				target,
+			}),
+		/immutable|completed/i,
+	);
+	assert.throws(
+		() =>
+			applyWorkflowPlanPatch({
+				record,
+				ledger: ledger.snapshot(),
+				patch: patch(record.planId, record.workflowGeneration, [
+					{
+						type: "add-task",
+						task: task("forge", {
+							producesArtifacts: [{ id: "accepted", kind: "patch", version: "v2" }],
+						}),
+					},
+				]),
+				agents,
+				target,
+			}),
+		/accepted artifact/i,
+	);
+});
+
+test("patches cannot remove required verification or revive a cancelled generation", () => {
+	const { record, ledger } = compiledRecord();
+	const verifier = record.plan.tasks.find((candidate) => candidate.verifierFor === "implement");
+	assert.ok(verifier);
+	assert.throws(
+		() =>
+			applyWorkflowPlanPatch({
+				record,
+				ledger: ledger.snapshot(),
+				patch: patch(record.planId, 0, [{ type: "cancel-task", taskId: verifier.id }]),
+				agents,
+				target,
+			}),
+		/verification/i,
+	);
+	const cancelled = applyWorkflowPlanPatch({
+		record,
+		ledger: ledger.snapshot(),
+		patch: patch(record.planId, 0, [{ type: "cancel-task", taskId: "implement" }]),
+		agents,
+		target,
+	});
+	assert.throws(
+		() =>
+			applyWorkflowPlanPatch({
+				record: cancelled.record,
+				ledger: ledger.snapshot(),
+				patch: patch(cancelled.record.planId, 1, [
+					{ type: "replace-task", taskId: "implement", task: task("implement") },
+				]),
+				agents,
+				target,
+			}),
+		/cancelled/i,
+	);
+});
+
+test("patches reject authority widening, excess budget, and cycles", () => {
+	for (const replacement of [
+		task("implement", { requiredTools: ["read", "edit", "write", "bash"] }),
+		task("implement", { budget: { timeoutMs: 120_000, maxTurns: 20, maxToolCalls: 40 } }),
+	]) {
+		const { record, ledger } = compiledRecord();
+		assert.throws(
+			() =>
+				applyWorkflowPlanPatch({
+					record,
+					ledger: ledger.snapshot(),
+					patch: patch(record.planId, 0, [
+						{ type: "replace-task", taskId: "implement", task: replacement },
+					]),
+					agents,
+					target,
+				}),
+			/authority|budget/i,
+		);
+	}
+	const { record, ledger } = compiledRecord();
+	assert.throws(
+		() =>
+			applyWorkflowPlanPatch({
+				record,
+				ledger: ledger.snapshot(),
+				patch: patch(record.planId, 0, [
+					{ type: "add-dependency", taskId: "implement", dependsOn: "verify-implement" },
+				]),
+				agents,
+				target,
+			}),
+		/cycle/i,
+	);
+});
+
+test("eligible rework rotates plan identity and task generation without replaying a settled side effect", () => {
+	const { record, ledger } = compiledRecord();
+	ledger.settle("implement", "blocked", "verification-rework");
+	const result = applyWorkflowPlanPatch({
+		record,
+		ledger: ledger.snapshot(),
+		patch: patch(record.planId, 0, [
+			{
+				type: "replace-task",
+				taskId: "implement",
+				task: task("implement", { objective: "Fix the verified issue" }),
+			},
+		]),
+		agents,
+		target,
+	});
+	assert.equal(result.record.workflowGeneration, 1);
+	assert.equal(result.record.revision, 1);
+	assert.notEqual(result.record.planId, record.planId);
+	assert.equal(result.taskGenerations.implement, 2);
+	assert.equal(result.ledger.items.find((item) => item.id === "implement")?.taskGeneration, 2);
+	assert.equal(result.ledger.items.find((item) => item.id === "implement")?.state, "pending");
+	assert.deepEqual(result.replayedTaskIds, []);
+	assert.equal(result.record.history[0]?.planId, record.planId);
+});
+
+test("revision exhaustion is a terminal stop before another graph mutation", () => {
+	const { record, ledger } = compiledRecord();
+	ledger.settle("implement", "blocked", "verification-rework");
+	const first = applyWorkflowPlanPatch({
+		record,
+		ledger: ledger.snapshot(),
+		patch: patch(record.planId, 0, [
+			{
+				type: "replace-task",
+				taskId: "implement",
+				task: task("implement", { objective: "First correction" }),
+			},
+		]),
+		agents,
+		target,
+	});
+	const second = applyWorkflowPlanPatch({
+		record: first.record,
+		ledger: ledger.snapshot(),
+		patch: patch(first.record.planId, 1, [
+			{
+				type: "replace-task",
+				taskId: "implement",
+				task: task("implement", { objective: "Second correction" }),
+			},
+		]),
+		agents,
+		target,
+	});
+	assert.equal(second.record.revision, 2);
+	assert.throws(
+		() =>
+			applyWorkflowPlanPatch({
+				record: second.record,
+				ledger: ledger.snapshot(),
+				patch: patch(second.record.planId, 2, [
+					{
+						type: "replace-task",
+						taskId: "implement",
+						task: task("implement", { objective: "Forbidden third correction" }),
+					},
+				]),
+				agents,
+				target,
+			}),
+		/revision limit.*exhausted/i,
+	);
+});
+
+test("automation plan persistence publishes plan and ledger atomically and rejects stale saves", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-auto-plan-"));
+	try {
+		const { record, ledger } = compiledRecord();
+		const filePath = path.join(directory, "plan.json");
+		const persistence = new AutomationPlanPersistence(filePath);
+		await persistence.save({ record, ledger: ledger.snapshot() });
+		const loaded = persistence.load();
+		assert.equal(loaded?.record.planId, record.planId);
+		assert.equal(JSON.parse(readFileSync(filePath, "utf8")).record.version, record.version);
+		await assert.rejects(
+			persistence.save({
+				record: { ...record, workflowGeneration: -1 },
+				ledger: ledger.snapshot(),
+			}),
+			/generation/i,
+		);
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-subagents/test/workflow-planning-benchmark.test.ts
+++ b/packages/pi-subagents/test/workflow-planning-benchmark.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	AUTOMATION_BENCHMARK_ARMS,
+	AUTOMATION_BENCHMARK_VERSION,
+	validateAutomationBenchmark,
+} from "../src/workflow-planning-benchmark.js";
+
+const protocol = {
+	version: AUTOMATION_BENCHMARK_VERSION,
+	model: "matched-model",
+	evaluator: "frozen-evaluator-v1",
+	taskIds: ["read-only-recon", "verified-package-change", "sparse-two-boundary-change"],
+	pairedSeeds: [11, 23, 47],
+	maxTokens: 40_000,
+	maxCost: 2,
+	maxWallClockMs: 600_000,
+	maxMutatingChildren: 2,
+	maxRecursiveDepth: 0,
+	arms: [...AUTOMATION_BENCHMARK_ARMS],
+};
+
+const adapters = AUTOMATION_BENCHMARK_ARMS.map((arm) => ({
+	arm,
+	model: protocol.model,
+	evaluator: protocol.evaluator,
+	maxTokens: protocol.maxTokens,
+	maxCost: protocol.maxCost,
+	maxWallClockMs: protocol.maxWallClockMs,
+	mutatingChildren: arm === "strong-single-agent" ? 0 : 2,
+	recursiveDepth: 0,
+	informationPolicy: "identical-repository-context" as const,
+	toolPolicy: "matched-authority-ceiling" as const,
+}));
+
+test("frozen automation benchmark validates repeated paired matched arms", () => {
+	const dryRun = validateAutomationBenchmark(protocol, adapters);
+	assert.equal(dryRun.valid, true);
+	assert.equal(dryRun.pairedInstances, 9);
+	assert.deepEqual(dryRun.arms, [...AUTOMATION_BENCHMARK_ARMS]);
+});
+
+test("automation benchmark rejects unequal information, budgets, width, and recursion", () => {
+	for (const changed of [
+		{ ...adapters[0], informationPolicy: "extra-context" },
+		{ ...adapters[0], maxTokens: protocol.maxTokens + 1 },
+		{ ...adapters[0], mutatingChildren: 3 },
+		{ ...adapters[0], recursiveDepth: 1 },
+	]) {
+		assert.throws(
+			() => validateAutomationBenchmark(protocol, [changed, ...adapters.slice(1)] as never),
+			/matched|width|depth/i,
+		);
+	}
+});


### PR DESCRIPTION
## Summary

- Add explicit `subagent_auto` requests with one bounded read-only planner and deterministic compilation into the existing workflow executor.
- Enforce strict versioned request, proposal, and patch contracts, capability and authority ceilings, aggregate budgets, two-mutating-worker width, verified integration, and zero workflow grandchildren.
- Add generation-safe graph revisions, combined plan/ledger persistence, deterministic fixtures, a frozen matched offline protocol, documentation, and a minor Changeset.

## Verification

- `npx vitest run packages/pi-subagents/test/*.test.ts` — 386 tests passed.
- `npm run check` — 2,934 tests plus Biome, boundaries, and all workspace typechecks passed.
- The final root gate used command-scoped `commit.gpgsign=false` because test-created Git repositories intermittently could not access the 1Password signing agent.
- `just pack subagents` — dry run contained the declared entrypoint, README, license, and all new automation sources.
- `git diff --check` — passed.
- The signed commit was verified with its configured ED25519 public key.

## Risks and unverified paths

- The first automation surface supports shared-workspace execution only and rejects blocking-workflow worktree requests.
- Path ceilings constrain compilation and scheduling but are not an operating-system sandbox.
- No live-provider evaluation or model-selected runtime smoke was run, so this PR makes no automation-quality or default-change claim.
- No package publication, tag, release workflow, or visibility change was performed.

## Plan

- [Completed autonomous workflow planning plan](https://github.com/narumiruna/pi-extensions/blob/feat/pi-subagents-autonomous-workflow-planning/docs/plans/archived/2026-08-10_pi-subagents-autonomous-workflow-planning-plan.md)
