### PR TITLE
feat(tui-kit): gate live choice confirmation

### DIFF
--- a/.changeset/soft-live-choice-gating.md
+++ b/.changeset/soft-live-choice-gating.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add confirmation-only Live Choice gating so a row can reject its primary action while keeping shortcuts available, with explanatory TUI and RPC presentation and full-disabled precedence.

--- a/docs/plans/2026-08-10_pi-tui-kit-consumer-convergence-plan.md
+++ b/docs/plans/2026-08-10_pi-tui-kit-consumer-convergence-plan.md
@@ -95,14 +95,14 @@ Each implementation pull request starts from then-current `origin/main`, changes
 
 ### Phase 3: Pi TUI Kit confirmation-gating API
 
-- [ ] Wait until pull request #685 is merged, then create a Kit-only branch from the resulting `origin/main` so API compatibility metadata and Changeset intent advance from one authoritative base.
-- [ ] Add failing public type and declaration tests for a Live Choice item whose primary confirmation is disabled while shortcuts remain enabled, including full-disabled precedence and the incremented compatibility literal.
-- [ ] Add failing TUI tests for textual presentation, injected confirm rejection, shortcut dispatch, current and initial selection, preview callbacks, terminal controls, narrow widths, Back/Close, owner abort, disposal, stale preview completion, and preview failure.
-- [ ] Add failing RPC tests proving the confirmation-disabled row is explanatory and inert, no shortcut or preview executes, duplicate labels preserve raw identity, cancellation follows the requested hint, and full-disabled precedence remains unchanged.
-- [ ] Implement the smallest Live Choice-only public contract and internal adaptation needed to separate primary confirmation from shortcut availability without changing existing `disabled`, declarative `choice`, or default behavior.
-- [ ] Update Kit README examples, public exports or declarations as required, API compatibility metadata, type fixtures, and a Kit-only minor Changeset.
-- [ ] Run the complete Kit check and tests, `npm run check:boundaries`, `npm run check`, `git diff --check`, and `just pack tui-kit`; inspect root declarations and prove no consumer adopts the unpublished API.
-- [ ] Audit display-cell bounds, sanitization, disabled-state precedence, shortcut conflicts, preview queue cancellation and draining, stale ownership after awaits, error reporting, TUI/RPC compatibility, and final diff scope before opening the Kit pull request.
+- [x] Wait until pull request #685 is merged, then create a Kit-only branch from the resulting `origin/main` so API compatibility metadata and Changeset intent advance from one authoritative base.
+- [x] Add failing public type and declaration tests for a Live Choice item whose primary confirmation is disabled while shortcuts remain enabled, including full-disabled precedence and the incremented compatibility literal.
+- [x] Add failing TUI tests for textual presentation, injected confirm rejection, shortcut dispatch, current and initial selection, preview callbacks, terminal controls, narrow widths, Back/Close, owner abort, disposal, stale preview completion, and preview failure.
+- [x] Add failing RPC tests proving the confirmation-disabled row is explanatory and inert, no shortcut or preview executes, duplicate labels preserve raw identity, cancellation follows the requested hint, and full-disabled precedence remains unchanged.
+- [x] Implement the smallest Live Choice-only public contract and internal adaptation needed to separate primary confirmation from shortcut availability without changing existing `disabled`, declarative `choice`, or default behavior.
+- [x] Update Kit README examples, public exports or declarations as required, API compatibility metadata, type fixtures, and a Kit-only minor Changeset.
+- [x] Run the complete Kit check and tests, `npm run check:boundaries`, `npm run check`, `git diff --check`, and `just pack tui-kit`; inspect root declarations and prove no consumer adopts the unpublished API.
+- [x] Audit display-cell bounds, sanitization, disabled-state precedence, shortcut conflicts, preview queue cancellation and draining, stale ownership after awaits, error reporting, TUI/RPC compatibility, and final diff scope before opening the Kit pull request.
 
 ### Release gate
 
@@ -158,10 +158,20 @@ Each implementation pull request starts from then-current `origin/main`, changes
 - Branch `feat/pi-starship-review-inspector` started from `origin/main` merge `8da1ca13f6e5e4f7e63e579726fb243e8748855b`, then rebased onto `0d254565a30e7ecd911228ea32b35077ac176e1d`; the Starship package check and 190 focused tests passed at baseline.
 - The formatter test failed before implementation because `formatFooterExplanation` did not exist, then passed after the custom component was reduced to terminal-safe content formatting and the menu adopted an adaptive `review` screen.
 - Final evidence after rebasing: Starship package check passed; 193 focused tests passed; boundaries passed; CI-equivalent `npm run check` passed with 274 files and 2,941 tests; `git diff --check` passed.
-- Starship inspector pull request: [#690](https://github.com/narumiruna/pi-extensions/pull/690), with implementation commit `306a4e58`, plan commit `6e919e79`, and evidence commit `ad35979a`. CI run `31410070343` passed in 57s; no review was submitted at this refresh.
+- Starship inspector pull request [#690](https://github.com/narumiruna/pi-extensions/pull/690) merged as `81c279717e9a04799d918a2f4f1e707a1a4d00d8`, carrying implementation commit `306a4e58`, plan commit `6e919e79`, evidence commit `ad35979a`, and PR record commit `fd6d36cd`. Final CI run `31410197960` passed in 1m; no review was submitted.
 - `just pack starship` exposed the expected 79 manifest-listed source, notice, README, and license files (81.7 kB packed, 303.2 kB unpacked); tests and generated artifacts were absent.
 - A live TUI smoke remained unavailable in the non-interactive terminal. Kit-harness tests covered unavailable, empty, populated, long, and unsafe documents; adaptive heights and widths; Home/End and paging; resize clamping; Back, Close, owner abort, external disposal, and parent cursor restoration.
 - Audit confirmed inspection acquisition, module ordering, preview text, TUI-only routing, and session ownership remain in Starship. The removed code owned only generic layout, scroll, keybinding, abort-listener, and disposal behavior now supplied by the Kit.
+
+### Phase 3 Live Choice confirmation gating
+
+- Branch `feat/pi-tui-kit-live-choice-confirmation-gating` started from `origin/main` merge `81c279717e9a04799d918a2f4f1e707a1a4d00d8`, after browse pull request #685 and the two preceding consumer phases merged.
+- Kit baseline passed its package check and 170 focused tests. New TUI and RPC tests failed before implementation because gated confirmation still selected the item and no explanation was rendered.
+- The public contract adds only `confirmationDisabled` and `confirmationDisabledReason` to `LiveChoiceItem`; API compatibility advances from 10 to 11 and declarative `choice` remains unchanged.
+- Final evidence: Kit package check and build passed; 176 focused tests passed; root declarations and runtime export compatibility fixtures passed; boundaries passed; CI-equivalent `npm run check` passed with 274 files and 2,947 tests; `git diff --check` passed.
+- Kit implementation commit: `93b507b5` (`feat(tui-kit): gate live choice confirmation`).
+- `just pack tui-kit` exposed 59 expected built files (51.2 kB packed, 230.9 kB unpacked). Root declarations contain both gating fields and compatibility literal 11. Repository search proved no Statusline, Starship, Tool, or other consumer uses the unpublished fields.
+- Audit confirmed full `disabled` presentation and shortcut blocking take precedence; gating blocks only Enter/Space activation, leaves non-conflicting shortcuts and previews active in TUI, stays inert without previews or shortcuts in RPC, sanitizes labels and reasons, preserves raw IDs, and reuses existing preview draining, stale checks, disposal, and error reporting.
 
 ### Applicable MUST mapping for Phase 1
 
@@ -189,7 +199,7 @@ Each implementation pull request starts from then-current `origin/main`, changes
 
 - [x] `pi-statusline` uses published `runLiveChoice()` for palette previews and preserves settings, preview, cancellation, and rollback behavior.
 - [x] Starship footer explanation uses the standard adaptive `review` screen with no extension-owned generic scroll component.
-- [ ] Pi TUI Kit exposes and documents confirmation-only Live Choice gating with unchanged legacy disabled behavior and complete TUI/RPC lifecycle tests.
+- [x] Pi TUI Kit exposes and documents confirmation-only Live Choice gating with unchanged legacy disabled behavior and complete TUI/RPC lifecycle tests.
 - [ ] The enhanced Kit release is explicitly approved, published, registry-verified, and independently installable before consumer adoption.
 - [ ] `pi-starship` uses the published Live Choice contract for presets while active Apply remains inert and Customize remains available.
 - [ ] `pi-tool` uses published exact browse details and no longer owns a duplicate browser or unnecessary direct Pi TUI dependency.

--- a/docs/plans/2026-08-10_pi-tui-kit-consumer-convergence-plan.md
+++ b/docs/plans/2026-08-10_pi-tui-kit-consumer-convergence-plan.md
@@ -169,7 +169,7 @@ Each implementation pull request starts from then-current `origin/main`, changes
 - Kit baseline passed its package check and 170 focused tests. New TUI and RPC tests failed before implementation because gated confirmation still selected the item and no explanation was rendered.
 - The public contract adds only `confirmationDisabled` and `confirmationDisabledReason` to `LiveChoiceItem`; API compatibility advances from 10 to 11 and declarative `choice` remains unchanged.
 - Final evidence: Kit package check and build passed; 176 focused tests passed; root declarations and runtime export compatibility fixtures passed; boundaries passed; CI-equivalent `npm run check` passed with 274 files and 2,947 tests; `git diff --check` passed.
-- Kit implementation commit: `93b507b5` (`feat(tui-kit): gate live choice confirmation`).
+- Kit pull request: [#691](https://github.com/narumiruna/pi-extensions/pull/691), with implementation commit `93b507b5` and plan commit `cc659b7e`. CI run `31411243052` passed in 2m57s; no review was submitted at this refresh.
 - `just pack tui-kit` exposed 59 expected built files (51.2 kB packed, 230.9 kB unpacked). Root declarations contain both gating fields and compatibility literal 11. Repository search proved no Statusline, Starship, Tool, or other consumer uses the unpublished fields.
 - Audit confirmed full `disabled` presentation and shortcut blocking take precedence; gating blocks only Enter/Space activation, leaves non-conflicting shortcuts and previews active in TUI, stays inert without previews or shortcuts in RPC, sanitizes labels and reasons, preserves raw IDs, and reuses existing preview draining, stale checks, disposal, and error reporting.
 

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -207,6 +207,9 @@ try {
       description: preset.description,
       disabled: !preset.available,
       disabledReason: preset.available ? undefined : "Required font is unavailable",
+      confirmationDisabled: preset.id === activePresetId,
+      confirmationDisabledReason:
+        preset.id === activePresetId ? "Already applied" : undefined,
     })),
     currentItemId: activePresetId,
     initialItemId: activePresetId,
@@ -227,9 +230,14 @@ if (choice?.kind === "selected") await saveAndApplyPreset(choice.itemId);
 else if (choice?.kind === "shortcut") await customizePreset(choice.itemId);
 ```
 
-TUI calls `onSelectionChange` for the initial cursor and later focused rows, including disabled rows;
-only confirmation and shortcuts are blocked for a disabled row. Shortcut keys use Pi `KeyId` values;
-keys that conflict with current standard choice controls are omitted from shortcut hints and dispatch.
+TUI calls `onSelectionChange` for the initial cursor and later focused rows, including disabled rows.
+A fully `disabled` row blocks both primary confirmation and shortcuts.
+Set `confirmationDisabled` with an optional `confirmationDisabledReason` when only the primary action
+must be inert while shortcuts remain available, such as allowing Customize for an already-active
+preset that cannot be applied again.
+If both states are present, full `disabled` behavior and its reason take precedence.
+Shortcut keys use Pi `KeyId` values; keys that conflict with current standard choice controls are
+omitted from shortcut hints and dispatch.
 Synchronous previews run immediately.
 While an asynchronous preview is pending, newer cursor changes coalesce to the latest row. Completion,
 Back, Close, owner cancellation, external disposal, and errors abort the callback signal and drain
@@ -237,9 +245,9 @@ owned preview work before returning. The callback must honor that signal. The ca
 preview snapshot, rollback, persistence, confirmation, and final apply policy.
 
 RPC deliberately degrades to a signal-aware ordinary selector: it never runs live previews or custom
-shortcuts, disabled rows remain inert, and cancellation follows the requested Back/Close hint. Print
-and JSON return `unsupported`. Results distinguish `selected`, `shortcut`, `closed`, `stale`,
-`unsupported`, and `error`.
+shortcuts, disabled and confirmation-disabled rows remain explanatory and inert, and cancellation
+follows the requested Back/Close hint. Print and JSON return `unsupported`. Results distinguish
+`selected`, `shortcut`, `closed`, `stale`, `unsupported`, and `error`.
 
 `formatInteractionHints()` is available for other specialized components. Pass the callback-injected
 keybindings plus binding-backed or literal-key hint groups; the formatter normalizes arrows,
@@ -676,7 +684,7 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `runConfirmation()` — preserves Confirmed, Back, Close, Stale, Unsupported, and Error for one
   standalone confirmation without owning the confirmed side effect.
 - `runLiveChoice()` — adapts a live-preview choice to TUI and ordinary RPC selection while preserving
-  typed selection, shortcut, Back, Close, Stale, Unsupported, and Error outcomes.
+  typed selection, confirmation-only gating, shortcuts, Back, Close, Stale, Unsupported, and Error.
 - `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and
   literal shortcut keys for specialized interaction hints.
 - `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending
@@ -687,10 +695,11 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
   `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
   strict scripts, and their public testing types; it is not re-exported from the production root.
-- `PI_EXTENSION_MENU_API_VERSION` — current API version (`10`). Version 10 adds exact browse detail
-  documents while version-9 menu definitions remain valid. Version 9 added `runLiveChoice()` and
-  `formatInteractionHints()`, version 8 added disabled action reasons and adaptive action-label
-  columns, version 7 added `runConfirmation()`, and version 6 added the read-only `browse` screen and
+- `PI_EXTENSION_MENU_API_VERSION` — current API version (`11`). Version 11 adds Live Choice
+  confirmation-only gating while version-10 menu definitions remain valid. Version 10 added exact
+  browse detail documents, version 9 added `runLiveChoice()` and `formatInteractionHints()`, version 8
+  added disabled action reasons and adaptive action-label columns, version 7 added
+  `runConfirmation()`, and version 6 added the read-only `browse` screen and
   `runCustomInteraction()`.
 
 ## 🗂️ Package layout

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -57,4 +57,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 10;
+export const PI_EXTENSION_MENU_API_VERSION = 11;

--- a/packages/pi-tui-kit/src/live-choice.ts
+++ b/packages/pi-tui-kit/src/live-choice.ts
@@ -14,6 +14,8 @@ export interface LiveChoiceItem<ItemId extends string = string> {
 	details?: readonly string[];
 	disabled?: boolean;
 	disabledReason?: string;
+	confirmationDisabled?: boolean;
+	confirmationDisabledReason?: string;
 }
 
 export interface LiveChoiceShortcut<ShortcutId extends string = string> {
@@ -118,7 +120,7 @@ async function runTuiLiveChoice<
 					kind: "choice",
 					title: options.title,
 					lines: options.lines,
-					items: options.items,
+					items: tuiItems(options),
 					action: "select",
 					currentItemId: options.currentItemId,
 					viewportSize: options.viewportSize,
@@ -136,6 +138,8 @@ async function runTuiLiveChoice<
 				},
 				onEvent: (event) => {
 					if (event.kind === "activate") {
+						const item = findItem(options.items, event.itemId);
+						if (itemConfirmationDisabled(item)) return;
 						complete({ kind: "selected", itemId: event.itemId as Item["id"] });
 						return;
 					}
@@ -213,7 +217,9 @@ async function runRpcLiveChoice<
 			);
 		}
 		if (row.kind === "exit") return { kind: "closed", reason: options.hint ?? "back" };
-		if (!row.item.disabled) return { kind: "selected", itemId: row.item.id };
+		if (!row.item.disabled && !itemConfirmationDisabled(row.item)) {
+			return { kind: "selected", itemId: row.item.id };
+		}
 	}
 }
 
@@ -416,6 +422,35 @@ function findItem<Item extends LiveChoiceItem>(
 	return items.find((item) => item.id === itemId);
 }
 
+function tuiItems<
+	Item extends LiveChoiceItem,
+	ShortcutId extends string,
+	Context extends MenuContext,
+>(options: RunLiveChoiceOptions<Item, ShortcutId, Context>) {
+	return options.items.map((item) => {
+		const explanation = confirmationDisabledText(item, options.confirmLabel);
+		return explanation ? { ...item, details: [explanation, ...(item.details ?? [])] } : item;
+	});
+}
+
+function itemConfirmationDisabled(item: LiveChoiceItem | undefined): boolean {
+	return item?.disabled !== true && item?.confirmationDisabled === true;
+}
+
+function confirmationDisabledText(
+	item: LiveChoiceItem,
+	confirmLabel: string | undefined,
+): string | undefined {
+	if (!itemConfirmationDisabled(item)) return undefined;
+	const action = safeMenuText(confirmLabel ?? "select").trim() || "select";
+	const reason = safeMenuText(item.confirmationDisabledReason ?? "").trim();
+	return `Cannot ${action}${reason ? `: ${reason}` : ""}`;
+}
+
+function lowercaseInitial(value: string | undefined): string | undefined {
+	return value ? `${value[0]?.toLowerCase() ?? ""}${value.slice(1)}` : undefined;
+}
+
 type RpcRow<Item extends LiveChoiceItem> =
 	| { kind: "item"; label: string; item: Item }
 	| { kind: "exit"; label: string };
@@ -432,6 +467,7 @@ function rpcRows<
 			item.disabled
 				? `unavailable${item.disabledReason ? `: ${safeMenuText(item.disabledReason)}` : ""}`
 				: undefined,
+			lowercaseInitial(confirmationDisabledText(item, options.confirmLabel)),
 			item.description ? safeMenuText(item.description) : undefined,
 		].filter((value): value is string => Boolean(value));
 		const label = `${item.disabled ? "[-] " : ""}${safeMenuText(item.label)}${

--- a/packages/pi-tui-kit/test/context-usage.ts
+++ b/packages/pi-tui-kit/test/context-usage.ts
@@ -3,6 +3,7 @@ import {
 	type BrowseScreen,
 	defineMenu,
 	type InputScreen,
+	type LiveChoiceItem,
 	type MenuCloseReason,
 	type ReviewScreen,
 	type RunConfirmationResult,
@@ -190,11 +191,17 @@ void runCustomInteraction(lifecycleContext, {
 	}),
 });
 
+const confirmationGatedItem: LiveChoiceItem<"one"> = {
+	id: "one",
+	label: "One",
+	confirmationDisabled: true,
+	confirmationDisabledReason: "Already active",
+};
 const commandLiveChoice: Promise<RunLiveChoiceResult<"one", never>> = runLiveChoice(
 	commandContext,
 	{
 		title: "Command choice",
-		items: [{ id: "one", label: "One" }],
+		items: [confirmationGatedItem],
 		onSelectionChange: async ({ ctx }) => ctx.waitForIdle(),
 	},
 );

--- a/packages/pi-tui-kit/test/live-choice.test.ts
+++ b/packages/pi-tui-kit/test/live-choice.test.ts
@@ -19,6 +19,8 @@ const choices = [
 		description: "Unavailable profile",
 		disabled: true,
 		disabledReason: "Missing\u0007 font",
+		confirmationDisabled: true,
+		confirmationDisabledReason: "This must not replace the disabled reason",
 	},
 	{
 		id: "full",
@@ -27,6 +29,132 @@ const choices = [
 		details: ["Model, tokens, tools, and time"],
 	},
 ] as const;
+
+const confirmationGatedChoices = [
+	{
+		id: "active",
+		label: "Active preset",
+		description: "Currently applied",
+		confirmationDisabled: true,
+		confirmationDisabledReason: "Already\u0007 active",
+	},
+	{ id: "other", label: "Other preset" },
+] as const;
+
+test("runLiveChoice blocks gated confirmation while preserving preview and shortcuts", async () => {
+	const previews: string[] = [];
+	const tui = createTuiHarness({ width: 24, rows: 12 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(context.ctx, {
+		title: "Preset\u001b[2J picker",
+		items: confirmationGatedChoices,
+		currentItemId: "active",
+		initialItemId: "active",
+		confirmLabel: "apply",
+		shortcuts: [{ id: "customize", keys: ["e"], label: "customize" }],
+		onSelectionChange: ({ item }) => {
+			previews.push(item.id);
+		},
+	});
+	await tui.waitForOpen();
+	await tui.waitForPending();
+	const frame = tui.render();
+	const plain = stripVTControlCharacters(frame.join("\n"));
+	assert.match(plain, /Active preset.*curr/u);
+	assert.match(plain, /Cannot apply: Already\s+active/u);
+	assert.equal(frame.join("\n").includes("\u001b[2J"), false);
+	for (const line of frame) assert.ok(visibleWidth(line) <= 24);
+	assert.deepEqual(previews, ["active"]);
+
+	tui.press("tui.select.confirm");
+	assert.equal(tui.isOpen, true);
+	tui.type("e");
+	assert.deepEqual(await running, {
+		kind: "shortcut",
+		shortcutId: "customize",
+		itemId: "active",
+	});
+});
+
+test("runLiveChoice preserves gated Back, Close, owner abort, and disposal", async () => {
+	async function drive(exit: "tui.select.cancel" | "ctrl+c") {
+		const tui = createTuiHarness();
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = runLiveChoice(context.ctx, {
+			title: "Preset",
+			items: confirmationGatedChoices,
+			initialItemId: "active",
+		});
+		await tui.waitForOpen();
+		await tui.waitForPending();
+		tui.press(exit);
+		return running;
+	}
+	assert.deepEqual(await drive("tui.select.cancel"), { kind: "closed", reason: "back" });
+	assert.deepEqual(await drive("ctrl+c"), { kind: "closed", reason: "close" });
+
+	const owner = new AbortController();
+	const staleTui = createTuiHarness();
+	const staleContext = createMockContext({ mode: "tui", hasUI: true, custom: staleTui.custom });
+	const stale = runLiveChoice(staleContext.ctx, {
+		title: "Preset",
+		items: confirmationGatedChoices,
+		signal: owner.signal,
+	});
+	await staleTui.waitForOpen();
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await stale, { kind: "stale" });
+
+	const disposedTui = createTuiHarness();
+	const disposedContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: disposedTui.custom,
+	});
+	const disposed = runLiveChoice(disposedContext.ctx, {
+		title: "Preset",
+		items: confirmationGatedChoices,
+	});
+	await disposedTui.waitForOpen();
+	disposedTui.dispose();
+	assert.deepEqual(await disposed, { kind: "stale" });
+});
+
+test("runLiveChoice gives full disabled state precedence over confirmation gating", async () => {
+	const previews: string[] = [];
+	const tui = createTuiHarness({ width: 40, rows: 12 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(context.ctx, {
+		title: "Preset",
+		items: [
+			{
+				...confirmationGatedChoices[0],
+				disabled: true,
+				disabledReason: "Missing font",
+			},
+			confirmationGatedChoices[1],
+		],
+		initialItemId: "active",
+		confirmLabel: "apply",
+		shortcuts: [{ id: "customize", keys: ["e"], label: "customize" }],
+		onSelectionChange: ({ item }) => {
+			previews.push(item.id);
+		},
+	});
+	await tui.waitForOpen();
+	await tui.waitForPending();
+	const plain = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(plain, /Unavailable: Missing font/u);
+	assert.doesNotMatch(plain, /Cannot apply|Already active/u);
+	tui.press("tui.select.confirm");
+	tui.type("e");
+	assert.equal(tui.isOpen, true);
+	tui.press("tui.select.down");
+	await tui.waitForPending();
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "selected", itemId: "other" });
+	assert.deepEqual(previews, ["active", "other"]);
+});
 
 test("runLiveChoice previews initial and cursor choices and dispatches enabled shortcuts", async () => {
 	const previews: string[] = [];
@@ -300,6 +428,86 @@ test("runLiveChoice degrades RPC to ordinary selection without preview or shortc
 	});
 	assert.deepEqual(result, { kind: "selected", itemId: "full" });
 	assert.equal(previews, 0);
+	rpc.assertConsumed();
+});
+
+test("runLiveChoice keeps confirmation-gated RPC rows explanatory and inert", async () => {
+	let previews = 0;
+	const options = [
+		"Same — current · cannot apply: Already active · Currently applied",
+		"Same",
+		"Close",
+	];
+	const rpc = createRpcHarness([
+		{ kind: "select", options, response: options[0] },
+		{ kind: "select", options, response: options[1] },
+	]);
+	const base = createMockContext({ mode: "rpc", hasUI: true }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const context = { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+	assert.deepEqual(
+		await runLiveChoice(context, {
+			title: "Preset",
+			items: [
+				{ ...confirmationGatedChoices[0], label: "Same" },
+				{ ...confirmationGatedChoices[1], label: "Same" },
+			],
+			currentItemId: "active",
+			confirmLabel: "apply",
+			hint: "close",
+			shortcuts: [{ id: "customize", keys: ["e"], label: "customize" }],
+			onSelectionChange: () => {
+				previews += 1;
+			},
+		}),
+		{ kind: "selected", itemId: "other" },
+	);
+	assert.equal(previews, 0);
+	rpc.assertConsumed();
+});
+
+test("runLiveChoice preserves raw identity for duplicate RPC labels", async () => {
+	const options = ["Same", "Same [2]", "← Back"];
+	const rpc = createRpcHarness([{ kind: "select", options, response: options[1] }]);
+	const base = createMockContext({ mode: "rpc", hasUI: true }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const context = { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+	assert.deepEqual(
+		await runLiveChoice(context, {
+			title: "Preset",
+			items: [
+				{ id: "first", label: "Same" },
+				{ id: "second", label: "Same" },
+			],
+		}),
+		{ kind: "selected", itemId: "second" },
+	);
+	rpc.assertConsumed();
+});
+
+test("runLiveChoice follows the requested RPC cancellation hint for gated rows", async () => {
+	const options = ["Active preset — cannot select: Already active · Currently applied", "Close"];
+	const rpc = createRpcHarness([
+		{ kind: "select", options, response: options[0] },
+		{ kind: "select", options, response: "Close" },
+	]);
+	const base = createMockContext({ mode: "rpc", hasUI: true }).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const context = { ...base, ui: { ...base.ui, ...rpc.ui } } as never;
+	assert.deepEqual(
+		await runLiveChoice(context, {
+			title: "Preset",
+			items: [confirmationGatedChoices[0]],
+			hint: "close",
+		}),
+		{ kind: "closed", reason: "close" },
+	);
 	rpc.assertConsumed();
 });
 

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -40,7 +40,7 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("package exposes API version 10 and exact browse detail types", () => {
+test("package exposes API version 11 and exact browse detail types", () => {
 	const document: BrowseDetailDocument = {
 		content: "  exact\nbody",
 		format: { kind: "code", language: "json" },
@@ -51,7 +51,7 @@ test("package exposes API version 10 and exact browse detail types", () => {
 		detailDocument: document,
 	};
 	assert.equal(item.detailDocument, document);
-	assert.equal(PI_EXTENSION_MENU_API_VERSION, 10);
+	assert.equal(PI_EXTENSION_MENU_API_VERSION, 11);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/testing-exports.test.ts
+++ b/packages/pi-tui-kit/test/testing-exports.test.ts
@@ -11,7 +11,7 @@ test("built package roots resolve separate production and testing exports", asyn
 	const testingSpecifier = "@narumitw/pi-tui-kit/testing";
 	const production = await import(productionSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 10);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 11);
 	assert.equal(typeof production.formatInteractionHints, "function");
 	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");
@@ -26,12 +26,13 @@ test("built package roots resolve separate production and testing exports", asyn
 	t.onTestFinished(() => rmSync(fixture, { recursive: true, force: true }));
 	writeFileSync(
 		path.join(fixture, "usage.ts"),
-		`import { PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type MenuBrowseItem } from "@narumitw/pi-tui-kit";\n` +
+		`import { PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type LiveChoiceItem, type MenuBrowseItem } from "@narumitw/pi-tui-kit";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 10 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const version: 11 = PI_EXTENSION_MENU_API_VERSION;\n` +
 			`const document: BrowseDetailDocument = { content: "  exact", format: { kind: "text" } };\n` +
 			`const item: MenuBrowseItem = { id: "one", label: "One", detailDocument: document };\n` +
-			`void version;\nvoid item;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
+			`const choice: LiveChoiceItem = { id: "active", label: "Active", confirmationDisabled: true, confirmationDisabledReason: "Already active" };\n` +
+			`void version;\nvoid item;\nvoid choice;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
 	);
 	writeFileSync(
 		path.join(fixture, "tsconfig.json"),


### PR DESCRIPTION
## Summary

- Add `confirmationDisabled` and `confirmationDisabledReason` to `LiveChoiceItem` so primary confirmation can be inert while shortcuts remain available.
- Preserve full `disabled` precedence, preview callbacks, shortcut conflict handling, lifecycle draining, and declarative `choice` behavior.
- Present the gated reason in TUI and RPC while keeping RPC previews and shortcuts inert.
- Advance `PI_EXTENSION_MENU_API_VERSION` to 11, update declarations/examples, and add a Kit-only minor Changeset.
- Record Phase 3 evidence in the [consumer convergence plan](https://github.com/narumiruna/pi-extensions/blob/feat/pi-tui-kit-live-choice-confirmation-gating/docs/plans/2026-08-10_pi-tui-kit-consumer-convergence-plan.md).

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit`
- `npx vitest run packages/pi-tui-kit/test` — 176 tests passed
- `npm run check:boundaries`
- `npm run check` — 274 files and 2,947 tests passed
- `git diff --check`
- `just pack tui-kit` — 59 expected built files inspected
- Built root declarations contain both gating fields and API literal 11
- Repository search confirms no consumer adopts the unpublished API

## Risks and unverified paths

- This pull request does not publish the Kit or raise any consumer compatibility floor.
- The new state is scoped only to `runLiveChoice()` and does not alter declarative `choice` screens.
- Tests cover TUI/RPC presentation, Enter rejection, shortcut dispatch, full-disabled precedence, terminal controls, narrow widths, Back/Close, owner abort, disposal, preview lifecycle, duplicate labels, and cancellation hints.
