### PR TITLE
test(chat): isolate real network smokes

### DIFF
--- a/docs/plans/archived/2026-08-11_stabilize-pi-chat-cross-process-dht-plan.md
+++ b/docs/plans/archived/2026-08-11_stabilize-pi-chat-cross-process-dht-plan.md
@@ -1,0 +1,21 @@
+# Separate Pi Chat network smokes from mocked tests
+
+## Goal
+
+Keep Pi Chat's normal automated tests deterministic and mocked while preserving real local DHT, process-boundary discovery, relay, retry, directory, delivery, and cleanup coverage in an explicit local script.
+
+## Plan
+
+- [x] Inspect the failed Actions job and current network coverage; the failure came from a real local DHT smoke running amid the parallel full suite after both child processes had started.
+- [x] Move every real-network scenario and its child fixture out of `packages/pi-chat/test/` into `packages/pi-chat/scripts/network-smoke.ts`; all six retained local scenarios passed.
+- [x] Replace the normal transport tests with deterministic Hyperswarm and directory transport mocks covering limits, startup, refresh scheduling, discovery results, completed-signal ownership, and cleanup; all 86 Pi Chat tests passed.
+- [x] Add `npm run smoke:chat-network` and `just smoke-chat-network`, and document the local-only boundary in `packages/pi-chat/README.md`.
+- [x] Run the mocked Pi Chat tests, the local network smoke, and the CI-equivalent `npm run check` gate; the gate passed 274 files and 2,954 tests.
+- [x] Audit process, timer, discovery, socket, and DHT cleanup against `docs/extension-conventions.md` and the touched-area checklist; each local scenario retains `finally` cleanup, child startup is tracked before waits, child exit is bounded by forced termination, and mocked tests verify discovery/swarm teardown.
+
+## Completion Checklist
+
+- [x] No normal Pi Chat test opens a real DHT or network socket; `packages/pi-chat/test/` contains no HyperDHT testnet import, and the Hyperswarm constructor is mocked.
+- [x] The opt-in local smoke proves real networking and exits cleanly; all six scenarios passed in one invocation.
+- [x] The repository CI-equivalent check passes without the real-network smoke; `npm run check` passed.
+- [x] No changeset is added because test orchestration and contributor commands do not change published behavior.

--- a/justfile
+++ b/justfile
@@ -75,6 +75,10 @@ try name: (_validate-package-name name)
     npm --workspace {{ quote("@narumitw/pi-" + name) }} run build --if-present
     pi -e {{ quote("./packages/pi-" + name) }}
 
+# Run Pi Chat's opt-in real local DHT and process-boundary smoke
+smoke-chat-network:
+    npm run smoke:chat-network
+
 # Measure offline pi-subagents transport startup and retained-command overhead
 benchmark-subagents samples="7":
     node scripts/benchmark-pi-subagents-transports.mjs --samples {{ quote(samples) }}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"typecheck": "node ./scripts/run-typechecks.mjs",
 		"build": "npm --workspaces --if-present run build",
 		"test": "node ./scripts/run-tests.mjs",
+		"smoke:chat-network": "node ./scripts/run-pi-chat-network-smoke.mjs",
 		"check": "npm run build && node ./scripts/run-checks.mjs",
 		"precommit": "npm run biome:check && npm run typecheck",
 		"prepare": "husky",

--- a/packages/pi-chat/README.md
+++ b/packages/pi-chat/README.md
@@ -287,6 +287,19 @@ rows before hiding room, connectivity, or input-target status.
 Pi's public extension widget API does not provide generic mouse hit-testing, so the dock is not
 clickable and Pi Chat registers no global shortcut. `/chat` remains the menu-first entrypoint.
 
+## 🧪 Local network smoke
+
+The normal repository test suite mocks Pi Chat's network transports and does not open DHT sockets.
+Run the opt-in smoke from a local checkout to exercise real local DHT nodes, sparse relay, retries,
+process-boundary discovery and delivery, public-room discovery, and resource cleanup:
+
+```bash
+npm run smoke:chat-network
+```
+
+The equivalent Just command is `just smoke-chat-network`.
+This smoke is intentionally excluded from `npm test` and CI because local UDP scheduling can be nondeterministic under parallel load.
+
 ## 🗂️ Package layout
 
 ```text
@@ -308,11 +321,13 @@ packages/pi-chat/
 │   ├── chat-view.ts           # Loaded on the first composer request
 │   ├── widget.ts              # Loaded before the first room joins
 │   └── text.ts
-├── test/
+├── scripts/                  # Opt-in real local network smoke and child fixture
+├── test/                     # Deterministic tests with mocked network boundaries
 ├── README.md
 ├── LICENSE
 ├── package.json
-└── tsconfig.json
+├── tsconfig.json
+└── tsconfig.network-smoke.json
 ```
 
 ## 🔎 Keywords

--- a/packages/pi-chat/scripts/network-peer-fixture.ts
+++ b/packages/pi-chat/scripts/network-peer-fixture.ts
@@ -4,8 +4,9 @@ import { HyperswarmTransport } from "../src/network.js";
 import { createPrivateRoom } from "../src/protocol.js";
 
 const [bootstrapJson, seedText, secretText] = process.argv.slice(2);
-if (!bootstrapJson || !seedText || !secretText)
+if (!bootstrapJson || !seedText || !secretText) {
 	throw new Error("Missing network peer fixture args");
+}
 const bootstrap = JSON.parse(Buffer.from(bootstrapJson, "base64url").toString("utf8")) as unknown[];
 const seed = Number.parseInt(seedText, 10);
 const secret = Buffer.from(secretText, "base64url");

--- a/packages/pi-chat/scripts/network-smoke.ts
+++ b/packages/pi-chat/scripts/network-smoke.ts
@@ -1,0 +1,415 @@
+import assert from "node:assert/strict";
+import { type ChildProcess, fork } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import createTestnet from "hyperdht/testnet.js";
+import { ChatSession } from "../src/chat-session.js";
+import {
+	HyperswarmDirectoryTransport,
+	PublicRoomDirectorySession,
+} from "../src/directory-network.js";
+import { createIdentity, deriveScopedIdentity } from "../src/identity.js";
+import { HyperswarmTransport } from "../src/network.js";
+import { createPrivateRoom, createPublicRoom, MAX_GOSSIP_HOPS } from "../src/protocol.js";
+
+await smoke("three local DHT peers discover, authenticate, exchange, and fully stop", async () => {
+	const testnet = await createTestnet(3);
+	const room = createPrivateRoom(Buffer.alloc(32, 42));
+	const sessions = Array.from({ length: 3 }, (_, index) => {
+		const identity = createIdentity(Buffer.alloc(32, index + 1));
+		const transport = new HyperswarmTransport({
+			room,
+			identity,
+			dht: testnet.createNode({ firewalled: false }),
+			maxPeers: 8,
+		});
+		return {
+			transport,
+			session: new ChatSession({
+				room,
+				identity,
+				nickname: `Dev${index + 1}`,
+				transport,
+			}),
+		};
+	});
+	try {
+		await Promise.all(sessions.map(({ session }) => session.start()));
+		await waitFor(
+			() => sessions.every(({ session }) => session.snapshot().participants.length === 2),
+			() =>
+				sessions
+					.map(({ session, transport }) => {
+						const snapshot = session.snapshot();
+						return `${snapshot.state}:${snapshot.participants.length}:${transport.connectionCount}:${snapshot.lastError ?? "ok"}`;
+					})
+					.join(","),
+		);
+		const sender = sessions[0];
+		assert.ok(sender);
+		assert.equal(sender.session.send("hello gossip").relayedTo, 2);
+		await waitFor(() =>
+			sessions
+				.slice(1)
+				.every(({ session }) =>
+					session.snapshot().transcript.some((entry) => entry.text === "hello gossip"),
+				),
+		);
+	} finally {
+		await Promise.allSettled(sessions.map(({ session }) => session.leave()));
+		await testnet.destroy();
+	}
+	assert.equal(
+		sessions.every(({ transport }) => transport.connectionCount === 0),
+		true,
+	);
+});
+
+await smoke("ten-peer sparse overlay relays once through a non-origin intermediate", async () => {
+	const testnet = await createTestnet(4);
+	const room = createPublicRoom("sparse-gossip");
+	const sessions = Array.from({ length: 10 }, (_, index) => {
+		const identity = createIdentity(Buffer.alloc(32, index + 31));
+		const transport = new HyperswarmTransport({
+			room,
+			identity,
+			dht: testnet.createNode({ firewalled: false }),
+			maxPeers: 64,
+		});
+		return {
+			identity,
+			transport,
+			session: new ChatSession({
+				room,
+				identity,
+				nickname: `Sparse${index + 1}`,
+				transport,
+			}),
+		};
+	});
+	try {
+		await Promise.all(sessions.map(({ session }) => session.start()));
+		const sender = sessions[0];
+		assert.ok(sender);
+		const senderKey = sender.identity.publicKey.toString("hex");
+		const sessionsByKey = new Map(
+			sessions.map((entry) => [entry.identity.publicKey.toString("hex"), entry]),
+		);
+		const findAuthenticatedRelayTarget = () => {
+			if (
+				!sessions.every(
+					({ session, transport }) =>
+						session.snapshot().directNeighbors === transport.connectedPeerKeys.length,
+				)
+			) {
+				return undefined;
+			}
+			const distances = new Map([[senderKey, 0]]);
+			const pending = [senderKey];
+			for (const key of pending) {
+				const distance = distances.get(key);
+				const current = sessionsByKey.get(key);
+				if (distance === undefined || distance >= MAX_GOSSIP_HOPS || !current) continue;
+				for (const neighbor of current.transport.connectedPeerKeys) {
+					if (!sessionsByKey.has(neighbor) || distances.has(neighbor)) continue;
+					distances.set(neighbor, distance + 1);
+					pending.push(neighbor);
+				}
+			}
+			if (distances.size !== sessions.length) return undefined;
+			return sessions.slice(1).find(({ identity }) => {
+				const distance = distances.get(identity.publicKey.toString("hex"));
+				return distance !== undefined && distance >= 2;
+			});
+		};
+		const relayPath = { target: undefined as ReturnType<typeof findAuthenticatedRelayTarget> };
+		await waitFor(
+			() => {
+				relayPath.target = findAuthenticatedRelayTarget();
+				return relayPath.target !== undefined;
+			},
+			() =>
+				sessions
+					.map(({ session, transport }) => {
+						const snapshot = session.snapshot();
+						return `${snapshot.participants.length}/${snapshot.directNeighbors}/${transport.connectionCount}`;
+					})
+					.join(","),
+			20_000,
+		);
+		assert.equal(
+			sessions.every(({ transport }) => transport.connectionCount <= 8),
+			true,
+		);
+		const indirect = relayPath.target;
+		assert.ok(indirect, "the sender must have an authenticated target across a two-hop path");
+		sender.session.send("through sparse overlay");
+		const deliveryCounts = () =>
+			sessions.map(
+				({ session }) =>
+					session.snapshot().transcript.filter(({ text }) => text === "through sparse overlay")
+						.length,
+			);
+		await waitFor(
+			() => deliveryCounts().every((count) => count === 1),
+			() => deliveryCounts().join(","),
+			8_000,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 500));
+		assert.deepEqual(
+			deliveryCounts(),
+			Array.from({ length: sessions.length }, () => 1),
+		);
+	} finally {
+		await Promise.allSettled(sessions.map(({ session }) => session.leave()));
+		await testnet.destroy();
+	}
+});
+
+await smoke("early discovery retries recover after initial DHT lookups miss peers", async () => {
+	const testnet = await createTestnet(3);
+	const room = createPublicRoom("retry-room");
+	const sessions = Array.from({ length: 2 }, (_, index) => {
+		const identity = createIdentity(Buffer.alloc(32, index + 11));
+		const dht = suppressPeerResults(testnet.createNode({ firewalled: false }), 3);
+		const transport = new HyperswarmTransport({ room, identity, dht, maxPeers: 8 });
+		return new ChatSession({
+			room,
+			identity,
+			nickname: `Retry${index + 1}`,
+			transport,
+		});
+	});
+	try {
+		await Promise.all(sessions.map((session) => session.start()));
+		await waitFor(
+			() => sessions.every((session) => session.snapshot().participants.length === 1),
+			() => sessions.map((session) => session.snapshot().participants.length).join(","),
+			8_000,
+		);
+	} finally {
+		await Promise.allSettled(sessions.map((session) => session.leave()));
+		await testnet.destroy();
+	}
+});
+
+await smoke("a completed startup releases its caller signal without leaving the room", async () => {
+	const testnet = await createTestnet(3);
+	const room = createPublicRoom("released-startup-signal");
+	const controller = new AbortController();
+	const sessions = Array.from({ length: 2 }, (_, index) => {
+		const identity = createIdentity(Buffer.alloc(32, index + 21));
+		const transport = new HyperswarmTransport({
+			room,
+			identity,
+			dht: testnet.createNode({ firewalled: false }),
+			maxPeers: 8,
+		});
+		return new ChatSession({
+			room,
+			identity,
+			nickname: `Owner${index + 1}`,
+			transport,
+		});
+	});
+	try {
+		await sessions[0]?.start(controller.signal);
+		controller.abort(new DOMException("Menu closed", "AbortError"));
+		await sessions[1]?.start();
+		await waitFor(
+			() => sessions.every((session) => session.snapshot().participants.length === 1),
+			() => sessions.map((session) => session.snapshot().participants.length).join(","),
+			5_000,
+		);
+	} finally {
+		await Promise.allSettled(sessions.map((session) => session.leave()));
+		await testnet.destroy();
+	}
+});
+
+await smoke("two separate Node processes connect through a local DHT bootstrap", async () => {
+	const testnet = await createTestnet(3);
+	const secret = Buffer.alloc(32, 77);
+	const bootstrapArg = Buffer.from(JSON.stringify(testnet.bootstrap)).toString("base64url");
+	const fixturePath = fileURLToPath(new URL("./network-peer-fixture.js", import.meta.url));
+	const children: ChildProcess[] = [];
+	const messages = new Map<ChildProcess, Array<Record<string, unknown>>>();
+	const errors = new Map<ChildProcess, string>();
+	const startChild = (index: number): ChildProcess => {
+		const child = fork(
+			fixturePath,
+			[bootstrapArg, String(index + 1), secret.toString("base64url")],
+			{
+				execArgv: [],
+				stdio: ["ignore", "ignore", "pipe", "ipc"],
+			},
+		);
+		children.push(child);
+		messages.set(child, []);
+		child.on("message", (message: unknown) => {
+			if (message && typeof message === "object") {
+				messages.get(child)?.push(message as Record<string, unknown>);
+			}
+		});
+		child.stderr?.on("data", (chunk) => {
+			errors.set(child, `${errors.get(child) ?? ""}${String(chunk)}`);
+		});
+		return child;
+	};
+	try {
+		for (let index = 0; index < 2; index += 1) {
+			const child = startChild(index);
+			await waitFor(
+				() => messages.get(child)?.some((message) => message.kind === "ready") === true,
+				() => childDetails(children, messages, errors),
+				20_000,
+			);
+		}
+		await waitFor(
+			() =>
+				children.every((child) =>
+					messages
+						.get(child)
+						?.some((message) => message.kind === "snapshot" && message.peers === 1),
+				),
+			() => childDetails(children, messages, errors),
+			27_000,
+		);
+		children[0]?.send({ command: "send", text: "cross-process hello" });
+		await waitFor(
+			() =>
+				children
+					.slice(1)
+					.every((child) =>
+						messages
+							.get(child)
+							?.some(
+								(message) =>
+									Array.isArray(message.texts) && message.texts.includes("cross-process hello"),
+							),
+					),
+			() => childDetails(children, messages, errors),
+			10_000,
+		);
+	} finally {
+		for (const child of children) {
+			if (child.connected) child.send({ command: "stop" });
+		}
+		await Promise.all(children.map((child) => waitForExit(child)));
+		await testnet.destroy();
+	}
+});
+
+await smoke("local DHT directory discovers two scoped advertisers and fully stops", async () => {
+	const testnet = await createTestnet(4);
+	const scoped = (seed: number, slug: string) =>
+		deriveScopedIdentity(createIdentity(Buffer.alloc(32, seed)), `directory:#${slug}`);
+	const makeDirectory = (seed: number, slug?: string) => {
+		const identity = slug ? scoped(seed, slug) : createIdentity(Buffer.alloc(32, seed));
+		return new PublicRoomDirectorySession({
+			identity,
+			...(slug ? { advertisedSlug: slug } : {}),
+			transport: new HyperswarmDirectoryTransport({
+				identity,
+				dht: testnet.createNode({ firewalled: false }),
+			}),
+		});
+	};
+	const first = makeDirectory(10, "pi-dev");
+	const second = makeDirectory(11, "pi-dev");
+	const browser = makeDirectory(12);
+	try {
+		await Promise.all([first.start(), second.start()]);
+		const result = await browser.browse(new AbortController().signal, 1_500);
+		assert.deepEqual(result.rooms, [{ slug: "pi-dev", estimatedParticipants: 2 }]);
+	} finally {
+		await Promise.allSettled([first.stop(), second.stop(), browser.stop()]);
+		await testnet.destroy();
+	}
+});
+
+interface AnnounceResult {
+	peers: unknown[];
+	[key: string]: unknown;
+}
+
+interface AnnounceQuery extends AsyncIterable<AnnounceResult> {
+	readonly closestNodes: unknown;
+	destroy(): void;
+}
+
+interface DhtWithAnnounce {
+	announce(...args: unknown[]): AnnounceQuery;
+}
+
+function suppressPeerResults(value: unknown, callsToSuppress: number): unknown {
+	const dht = value as DhtWithAnnounce;
+	const announce = dht.announce.bind(dht);
+	let calls = 0;
+	dht.announce = (...args: unknown[]): AnnounceQuery => {
+		const query = announce(...args);
+		calls += 1;
+		if (calls > callsToSuppress) return query;
+		return {
+			get closestNodes() {
+				return query.closestNodes;
+			},
+			destroy: () => query.destroy(),
+			async *[Symbol.asyncIterator]() {
+				for await (const result of query) yield { ...result, peers: [] };
+			},
+		};
+	};
+	return dht;
+}
+
+async function smoke(name: string, run: () => Promise<void>): Promise<void> {
+	const startedAt = Date.now();
+	process.stdout.write(`• ${name}\n`);
+	await run();
+	process.stdout.write(`  passed (${Date.now() - startedAt} ms)\n`);
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	detail: () => string = () => "",
+	timeoutMs = 10_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) {
+			throw new Error(`Timed out waiting for local DHT mesh (${detail()})`);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}
+
+function childDetails(
+	children: readonly ChildProcess[],
+	messages: ReadonlyMap<ChildProcess, Array<Record<string, unknown>>>,
+	errors: ReadonlyMap<ChildProcess, string>,
+): string {
+	return children
+		.map((child) => {
+			const latest = messages.get(child)?.at(-1);
+			return `${child.exitCode ?? "running"}:${JSON.stringify(latest)}:${errors.get(child) ?? ""}`;
+		})
+		.join(" | ");
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null) return;
+	let timeout: NodeJS.Timeout | undefined;
+	try {
+		await Promise.race([
+			new Promise<void>((resolve) => child.once("exit", () => resolve())),
+			new Promise<void>((resolve) => {
+				timeout = setTimeout(() => {
+					child.kill("SIGKILL");
+					resolve();
+				}, 5_000);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}

--- a/packages/pi-chat/test/directory.test.ts
+++ b/packages/pi-chat/test/directory.test.ts
@@ -1,10 +1,8 @@
 import assert from "node:assert/strict";
-import createTestnet from "hyperdht/testnet.js";
 import { test } from "vitest";
 import {
 	type DirectoryTransport,
 	type DirectoryTransportListener,
-	HyperswarmDirectoryTransport,
 	PublicRoomDirectorySession,
 } from "../src/directory-network.js";
 import { createIdentity, deriveScopedIdentity } from "../src/identity.js";
@@ -38,6 +36,26 @@ class IdleDirectoryTransport implements DirectoryTransport {
 	}
 	async stop(): Promise<void> {
 		this.stopped += 1;
+	}
+}
+
+class CatalogDirectoryTransport extends IdleDirectoryTransport {
+	override async refresh(): Promise<void> {
+		await super.refresh();
+		const peer = {
+			publicKey: Buffer.alloc(32, 99),
+			send: () => undefined,
+			close: () => undefined,
+		};
+		this.listener?.onPeer(peer);
+		for (const [index, identity] of [scoped(10, "pi-dev"), scoped(11, "pi-dev")].entries()) {
+			this.listener?.onMessage(
+				peer,
+				createDirectoryWireMessage(
+					createDirectoryPresence(identity, "pi-dev", "online", 10_000, `mock-${index}`),
+				),
+			);
+		}
 	}
 }
 
@@ -146,6 +164,21 @@ test("sort helper is deterministic and does not mutate caller state", () => {
 	assert.equal(rooms[0]?.slug, "zeta");
 });
 
+test("mocked directory discovery returns two scoped advertisers and fully stops", async () => {
+	const transport = new CatalogDirectoryTransport();
+	const directory = new PublicRoomDirectorySession({
+		identity: createIdentity(Buffer.alloc(32, 12)),
+		transport,
+		now: () => 10_000,
+	});
+
+	const result = await directory.browse(new AbortController().signal, 0);
+	assert.deepEqual(result.rooms, [{ slug: "pi-dev", estimatedParticipants: 2 }]);
+	assert.equal(transport.started, 1);
+	assert.equal(transport.refreshed, 1);
+	assert.equal(transport.stopped, 1);
+});
+
 test("temporary browsing aborts and stops every owned directory resource", async () => {
 	const transport = new IdleDirectoryTransport();
 	const directory = new PublicRoomDirectorySession({
@@ -158,32 +191,4 @@ test("temporary browsing aborts and stops every owned directory resource", async
 	await assert.rejects(browsing, /Menu disposed/u);
 	assert.equal(transport.started, 1);
 	assert.equal(transport.stopped, 1);
-});
-
-test("local DHT directory discovers two scoped advertisers and fully stops", {
-	timeout: 20_000,
-}, async () => {
-	const testnet = await createTestnet(4);
-	const makeDirectory = (seed: number, slug?: string) => {
-		const identity = slug ? scoped(seed, slug) : createIdentity(Buffer.alloc(32, seed));
-		return new PublicRoomDirectorySession({
-			identity,
-			...(slug ? { advertisedSlug: slug } : {}),
-			transport: new HyperswarmDirectoryTransport({
-				identity,
-				dht: testnet.createNode({ firewalled: false }),
-			}),
-		});
-	};
-	const first = makeDirectory(10, "pi-dev");
-	const second = makeDirectory(11, "pi-dev");
-	const browser = makeDirectory(12);
-	try {
-		await Promise.all([first.start(), second.start()]);
-		const result = await browser.browse(new AbortController().signal, 1_500);
-		assert.deepEqual(result.rooms, [{ slug: "pi-dev", estimatedParticipants: 2 }]);
-	} finally {
-		await Promise.allSettled([first.stop(), second.stop(), browser.stop()]);
-		await testnet.destroy();
-	}
 });

--- a/packages/pi-chat/test/network.test.ts
+++ b/packages/pi-chat/test/network.test.ts
@@ -1,12 +1,67 @@
 import assert from "node:assert/strict";
-import { type ChildProcess, fork } from "node:child_process";
-import path from "node:path";
-import createTestnet from "hyperdht/testnet.js";
-import { test } from "vitest";
+import { afterEach, beforeEach, test, vi } from "vitest";
 import { ChatSession } from "../src/chat-session.js";
 import { createIdentity } from "../src/identity.js";
 import { directNeighborLimit, HyperswarmTransport, MAX_DIRECT_NEIGHBORS } from "../src/network.js";
-import { createPrivateRoom, createPublicRoom, MAX_GOSSIP_HOPS } from "../src/protocol.js";
+import { createPublicRoom } from "../src/protocol.js";
+
+const fakeNetwork = vi.hoisted(() => {
+	class FakeDiscovery {
+		flushedCalls = 0;
+		refreshCalls = 0;
+		destroyCalls = 0;
+
+		async flushed(): Promise<void> {
+			this.flushedCalls += 1;
+		}
+
+		async refresh(): Promise<void> {
+			this.refreshCalls += 1;
+		}
+
+		async destroy(): Promise<void> {
+			this.destroyCalls += 1;
+		}
+	}
+
+	class FakeHyperswarm {
+		static instances: FakeHyperswarm[] = [];
+		readonly discovery = new FakeDiscovery();
+		readonly options: Record<string, unknown>;
+		readonly joins: Array<{ topic: Buffer; options: Record<string, unknown> }> = [];
+		destroyCalls = 0;
+
+		constructor(options: Record<string, unknown>) {
+			this.options = options;
+			FakeHyperswarm.instances.push(this);
+		}
+
+		on(): this {
+			return this;
+		}
+
+		join(topic: Buffer, options: Record<string, unknown>): FakeDiscovery {
+			this.joins.push({ topic: Buffer.from(topic), options });
+			return this.discovery;
+		}
+
+		async destroy(): Promise<void> {
+			this.destroyCalls += 1;
+		}
+	}
+
+	return { FakeHyperswarm };
+});
+
+vi.mock("hyperswarm", () => ({ default: fakeNetwork.FakeHyperswarm }));
+
+beforeEach(() => {
+	fakeNetwork.FakeHyperswarm.instances.length = 0;
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 test("room overlays clamp every requested direct-neighbor limit to eight", () => {
 	assert.equal(MAX_DIRECT_NEIGHBORS, 8);
@@ -16,384 +71,86 @@ test("room overlays clamp every requested direct-neighbor limit to eight", () =>
 	assert.equal(directNeighborLimit(-1), 8);
 });
 
-test("three local DHT peers discover, authenticate, exchange, and fully stop", {
-	timeout: 20_000,
-}, async () => {
-	const testnet = await createTestnet(3);
-	const room = createPrivateRoom(Buffer.alloc(32, 42));
-	const sessions = Array.from({ length: 3 }, (_, index) => {
-		const identity = createIdentity(Buffer.alloc(32, index + 1));
-		const transport = new HyperswarmTransport({
-			room,
-			identity,
-			dht: testnet.createNode({ firewalled: false }),
-			maxPeers: 8,
-		});
-		return {
-			transport,
-			session: new ChatSession({
-				room,
-				identity,
-				nickname: `Dev${index + 1}`,
-				transport,
-			}),
-		};
+test("transport startup joins through a mocked swarm and fully stops owned resources", async () => {
+	const identity = createIdentity(Buffer.alloc(32, 1));
+	const room = createPublicRoom("mocked-network");
+	const dht = { kind: "mock-dht" };
+	const transport = new HyperswarmTransport({ room, identity, dht, maxPeers: 64 });
+
+	await transport.start({
+		onPeer: () => undefined,
+		onMessage: () => undefined,
+		onDisconnect: () => undefined,
+		onError: () => undefined,
 	});
-	try {
-		await Promise.all(sessions.map(({ session }) => session.start()));
-		await waitFor(
-			() => sessions.every(({ session }) => session.snapshot().participants.length === 2),
-			() =>
-				sessions
-					.map(({ session, transport }) => {
-						const snapshot = session.snapshot();
-						return `${snapshot.state}:${snapshot.participants.length}:${transport.connectionCount}:${snapshot.lastError ?? "ok"}`;
-					})
-					.join(","),
-		);
-		const sender = sessions[0];
-		assert.ok(sender);
-		assert.equal(sender.session.send("hello gossip").relayedTo, 2);
-		await waitFor(() =>
-			sessions
-				.slice(1)
-				.every(({ session }) =>
-					session.snapshot().transcript.some((entry) => entry.text === "hello gossip"),
-				),
-		);
-	} finally {
-		await Promise.allSettled(sessions.map(({ session }) => session.leave()));
-		await testnet.destroy();
-	}
-	assert.equal(
-		sessions.every(({ transport }) => transport.connectionCount === 0),
-		true,
-	);
+
+	const swarm = fakeNetwork.FakeHyperswarm.instances[0];
+	assert.ok(swarm);
+	assert.equal(swarm.options.dht, dht);
+	assert.equal(swarm.options.maxPeers, 8);
+	assert.equal(swarm.discovery.flushedCalls, 1);
+	assert.deepEqual(swarm.joins, [
+		{
+			topic: room.topic,
+			options: { server: true, client: true, limit: 8 },
+		},
+	]);
+
+	await transport.stop();
+	await transport.stop();
+	assert.equal(swarm.discovery.destroyCalls, 1);
+	assert.equal(swarm.destroyCalls, 1);
 });
 
-test("ten-peer sparse overlay relays once through a non-origin intermediate", {
-	timeout: 35_000,
-}, async () => {
-	const testnet = await createTestnet(4);
-	const room = createPublicRoom("sparse-gossip");
-	const sessions = Array.from({ length: 10 }, (_, index) => {
-		const identity = createIdentity(Buffer.alloc(32, index + 31));
-		const transport = new HyperswarmTransport({
-			room,
-			identity,
-			dht: testnet.createNode({ firewalled: false }),
-			maxPeers: 64,
-		});
-		return {
-			identity,
-			transport,
-			session: new ChatSession({
-				room,
-				identity,
-				nickname: `Sparse${index + 1}`,
-				transport,
-			}),
-		};
+test("mocked early discovery refreshes follow the bounded retry schedule", async () => {
+	vi.useFakeTimers();
+	const identity = createIdentity(Buffer.alloc(32, 2));
+	const transport = new HyperswarmTransport({
+		room: createPublicRoom("mocked-refresh"),
+		identity,
+		maxPeers: 8,
 	});
-	try {
-		await Promise.all(sessions.map(({ session }) => session.start()));
-		const sender = sessions[0];
-		assert.ok(sender);
-		const senderKey = sender.identity.publicKey.toString("hex");
-		const sessionsByKey = new Map(
-			sessions.map((entry) => [entry.identity.publicKey.toString("hex"), entry]),
-		);
-		const findAuthenticatedRelayTarget = () => {
-			if (
-				!sessions.every(
-					({ session, transport }) =>
-						session.snapshot().directNeighbors === transport.connectedPeerKeys.length,
-				)
-			) {
-				return undefined;
-			}
-			const distances = new Map([[senderKey, 0]]);
-			const pending = [senderKey];
-			for (const key of pending) {
-				const distance = distances.get(key);
-				const current = sessionsByKey.get(key);
-				if (distance === undefined || distance >= MAX_GOSSIP_HOPS || !current) continue;
-				for (const neighbor of current.transport.connectedPeerKeys) {
-					if (!sessionsByKey.has(neighbor) || distances.has(neighbor)) continue;
-					distances.set(neighbor, distance + 1);
-					pending.push(neighbor);
-				}
-			}
-			if (distances.size !== sessions.length) return undefined;
-			return sessions.slice(1).find(({ identity }) => {
-				const distance = distances.get(identity.publicKey.toString("hex"));
-				return distance !== undefined && distance >= 2;
-			});
-		};
-		const relayPath = { target: undefined as ReturnType<typeof findAuthenticatedRelayTarget> };
-		await waitFor(
-			() => {
-				relayPath.target = findAuthenticatedRelayTarget();
-				return relayPath.target !== undefined;
-			},
-			() =>
-				sessions
-					.map(({ session, transport }) => {
-						const snapshot = session.snapshot();
-						return `${snapshot.participants.length}/${snapshot.directNeighbors}/${transport.connectionCount}`;
-					})
-					.join(","),
-			20_000,
-		);
-		assert.equal(
-			sessions.every(({ transport }) => transport.connectionCount <= 8),
-			true,
-		);
-		const indirect = relayPath.target;
-		assert.ok(indirect, "the sender must have an authenticated target across a two-hop path");
-		sender.session.send("through sparse overlay");
-		const deliveryCounts = () =>
-			sessions.map(
-				({ session }) =>
-					session.snapshot().transcript.filter(({ text }) => text === "through sparse overlay")
-						.length,
-			);
-		await waitFor(
-			() => deliveryCounts().every((count) => count === 1),
-			() => deliveryCounts().join(","),
-			8_000,
-		);
-		// Keep the fully ready overlay alive for slower alternate-path copies to arrive.
-		await new Promise((resolve) => setTimeout(resolve, 500));
-		assert.deepEqual(
-			deliveryCounts(),
-			Array.from({ length: sessions.length }, () => 1),
-		);
-	} finally {
-		await Promise.allSettled(sessions.map(({ session }) => session.leave()));
-		await testnet.destroy();
+
+	await transport.start({
+		onPeer: () => undefined,
+		onMessage: () => undefined,
+		onDisconnect: () => undefined,
+		onError: () => undefined,
+	});
+	const swarm = fakeNetwork.FakeHyperswarm.instances[0];
+	assert.ok(swarm);
+
+	for (const [index, delay] of [250, 750, 1_500, 3_000, 6_000, 12_000].entries()) {
+		await vi.advanceTimersByTimeAsync(delay);
+		assert.equal(swarm.discovery.refreshCalls, index + 1);
 	}
+	await vi.advanceTimersByTimeAsync(30_000);
+	assert.equal(swarm.discovery.refreshCalls, 6);
+	await transport.stop();
 });
 
-test("early discovery retries recover after initial DHT lookups miss peers", {
-	timeout: 20_000,
-}, async () => {
-	const testnet = await createTestnet(3);
-	const room = createPublicRoom("retry-room");
-	const sessions = Array.from({ length: 2 }, (_, index) => {
-		const identity = createIdentity(Buffer.alloc(32, index + 11));
-		const dht = suppressPeerResults(testnet.createNode({ firewalled: false }), 3);
-		const transport = new HyperswarmTransport({ room, identity, dht, maxPeers: 8 });
-		return new ChatSession({
-			room,
-			identity,
-			nickname: `Retry${index + 1}`,
-			transport,
-		});
-	});
-	try {
-		await Promise.all(sessions.map((session) => session.start()));
-		await waitFor(
-			() => sessions.every((session) => session.snapshot().participants.length === 1),
-			() => sessions.map((session) => session.snapshot().participants.length).join(","),
-			8_000,
-		);
-	} finally {
-		await Promise.allSettled(sessions.map((session) => session.leave()));
-		await testnet.destroy();
-	}
-});
-
-test("a completed startup releases its caller signal without leaving the room", {
-	timeout: 15_000,
-}, async () => {
-	const testnet = await createTestnet(3);
-	const room = createPublicRoom("released-startup-signal");
+test("a completed mocked startup releases its caller signal without stopping the room", async () => {
 	const controller = new AbortController();
-	const sessions = Array.from({ length: 2 }, (_, index) => {
-		const identity = createIdentity(Buffer.alloc(32, index + 21));
-		const transport = new HyperswarmTransport({
-			room,
-			identity,
-			dht: testnet.createNode({ firewalled: false }),
-			maxPeers: 8,
-		});
-		return new ChatSession({
-			room,
-			identity,
-			nickname: `Owner${index + 1}`,
-			transport,
-		});
+	const identity = createIdentity(Buffer.alloc(32, 3));
+	const transport = new HyperswarmTransport({
+		room: createPublicRoom("mocked-signal"),
+		identity,
+		maxPeers: 8,
 	});
-	try {
-		await sessions[0]?.start(controller.signal);
-		controller.abort(new DOMException("Menu closed", "AbortError"));
-		await sessions[1]?.start();
-		await waitFor(
-			() => sessions.every((session) => session.snapshot().participants.length === 1),
-			() => sessions.map((session) => session.snapshot().participants.length).join(","),
-			5_000,
-		);
-	} finally {
-		await Promise.allSettled(sessions.map((session) => session.leave()));
-		await testnet.destroy();
-	}
+	const session = new ChatSession({
+		room: createPublicRoom("mocked-signal"),
+		identity,
+		nickname: "Owner",
+		transport,
+	});
+
+	await session.start(controller.signal);
+	controller.abort(new DOMException("Menu closed", "AbortError"));
+	const swarm = fakeNetwork.FakeHyperswarm.instances[0];
+	assert.ok(swarm);
+	assert.equal(session.snapshot().state, "connected");
+	assert.equal(swarm.destroyCalls, 0);
+
+	await session.leave();
+	assert.equal(swarm.destroyCalls, 1);
 });
-
-test("two separate Node processes connect through a local DHT bootstrap", {
-	timeout: 90_000,
-}, async () => {
-	const testnet = await createTestnet(3);
-	const secret = Buffer.alloc(32, 77);
-	const bootstrapArg = Buffer.from(JSON.stringify(testnet.bootstrap)).toString("base64url");
-	const fixturePath = path.join(
-		process.cwd(),
-		"node_modules/.cache/pi-extensions-test/packages/pi-chat/test/network-peer-fixture.js",
-	);
-	const children: ChildProcess[] = [];
-	const messages = new Map<ChildProcess, Array<Record<string, unknown>>>();
-	const errors = new Map<ChildProcess, string>();
-	const startChild = (index: number): ChildProcess => {
-		const child = fork(
-			fixturePath,
-			[bootstrapArg, String(index + 1), secret.toString("base64url")],
-			{
-				execArgv: [],
-				stdio: ["ignore", "ignore", "pipe", "ipc"],
-			},
-		);
-		children.push(child);
-		messages.set(child, []);
-		child.on("message", (message: unknown) => {
-			if (message && typeof message === "object") {
-				messages.get(child)?.push(message as Record<string, unknown>);
-			}
-		});
-		child.stderr?.on("data", (chunk) => {
-			errors.set(child, `${errors.get(child) ?? ""}${String(chunk)}`);
-		});
-		return child;
-	};
-	try {
-		for (let index = 0; index < 2; index += 1) {
-			const child = startChild(index);
-			await waitFor(
-				() => messages.get(child)?.some((message) => message.kind === "ready") === true,
-				() => childDetails(children, messages, errors),
-				20_000,
-			);
-		}
-		await waitFor(
-			() =>
-				children.every((child) =>
-					messages
-						.get(child)
-						?.some((message) => message.kind === "snapshot" && message.peers === 1),
-				),
-			() => childDetails(children, messages, errors),
-			27_000,
-		);
-		children[0]?.send({ command: "send", text: "cross-process hello" });
-		await waitFor(
-			() =>
-				children
-					.slice(1)
-					.every((child) =>
-						messages
-							.get(child)
-							?.some(
-								(message) =>
-									Array.isArray(message.texts) && message.texts.includes("cross-process hello"),
-							),
-					),
-			() => childDetails(children, messages, errors),
-			10_000,
-		);
-	} finally {
-		for (const child of children) {
-			if (child.connected) child.send({ command: "stop" });
-		}
-		await Promise.all(children.map((child) => waitForExit(child)));
-		await testnet.destroy();
-	}
-});
-
-interface AnnounceResult {
-	peers: unknown[];
-	[key: string]: unknown;
-}
-
-interface AnnounceQuery extends AsyncIterable<AnnounceResult> {
-	readonly closestNodes: unknown;
-	destroy(): void;
-}
-
-interface DhtWithAnnounce {
-	announce(...args: unknown[]): AnnounceQuery;
-}
-
-function suppressPeerResults(value: unknown, callsToSuppress: number): unknown {
-	const dht = value as DhtWithAnnounce;
-	const announce = dht.announce.bind(dht);
-	let calls = 0;
-	dht.announce = (...args: unknown[]): AnnounceQuery => {
-		const query = announce(...args);
-		calls += 1;
-		if (calls > callsToSuppress) return query;
-		return {
-			get closestNodes() {
-				return query.closestNodes;
-			},
-			destroy: () => query.destroy(),
-			async *[Symbol.asyncIterator]() {
-				for await (const result of query) yield { ...result, peers: [] };
-			},
-		};
-	};
-	return dht;
-}
-
-async function waitFor(
-	predicate: () => boolean,
-	detail: () => string = () => "",
-	timeoutMs = 10_000,
-): Promise<void> {
-	const deadline = Date.now() + timeoutMs;
-	while (!predicate()) {
-		if (Date.now() >= deadline) {
-			throw new Error(`Timed out waiting for local DHT mesh (${detail()})`);
-		}
-		await new Promise((resolve) => setTimeout(resolve, 20));
-	}
-}
-
-function childDetails(
-	children: readonly ChildProcess[],
-	messages: ReadonlyMap<ChildProcess, Array<Record<string, unknown>>>,
-	errors: ReadonlyMap<ChildProcess, string>,
-): string {
-	return children
-		.map((child) => {
-			const latest = messages.get(child)?.at(-1);
-			return `${child.exitCode ?? "running"}:${JSON.stringify(latest)}:${errors.get(child) ?? ""}`;
-		})
-		.join(" | ");
-}
-
-async function waitForExit(child: ChildProcess): Promise<void> {
-	if (child.exitCode !== null) return;
-	let timeout: NodeJS.Timeout | undefined;
-	try {
-		await Promise.race([
-			new Promise<void>((resolve) => child.once("exit", () => resolve())),
-			new Promise<void>((resolve) => {
-				timeout = setTimeout(() => {
-					child.kill("SIGKILL");
-					resolve();
-				}, 5_000);
-			}),
-		]);
-	} finally {
-		if (timeout) clearTimeout(timeout);
-	}
-}

--- a/packages/pi-chat/tsconfig.network-smoke.json
+++ b/packages/pi-chat/tsconfig.network-smoke.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "../../node_modules/.cache/pi-chat-network-smoke",
+		"rootDir": "../.."
+	},
+	"include": ["src/external.d.ts", "scripts/**/*.ts"]
+}

--- a/scripts/run-pi-chat-network-smoke.mjs
+++ b/scripts/run-pi-chat-network-smoke.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outDir = path.join(root, "node_modules", ".cache", "pi-chat-network-smoke");
+const tsc = path.join(
+	root,
+	"node_modules",
+	".bin",
+	process.platform === "win32" ? "tsc.cmd" : "tsc",
+);
+
+fs.rmSync(outDir, { recursive: true, force: true });
+run(tsc, ["-p", "packages/pi-chat/tsconfig.network-smoke.json"]);
+run(process.execPath, [path.join(outDir, "packages", "pi-chat", "scripts", "network-smoke.js")]);
+
+function run(command, args) {
+	const result = spawnSync(command, args, { cwd: root, stdio: "inherit", env: process.env });
+	if (result.error) {
+		console.error(result.error.message);
+		process.exit(1);
+	}
+	if (result.status !== 0) process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
## Summary

- Replace Pi Chat's real-network CI tests with deterministic Hyperswarm and directory transport mocks.
- Move all six real local DHT, relay, retry, cross-process, and directory scenarios into an opt-in `npm run smoke:chat-network` script.
- Document the local-only smoke boundary and archive the completed implementation plan.

This removes the nondeterministic UDP smoke from the parallel suite that failed in [Actions run 31413917503](https://github.com/narumiruna/pi-extensions/actions/runs/31413917503/job/93538275665) while preserving explicit real-network coverage for local execution.

## Verification

- `npx vitest run packages/pi-chat/test/*.test.ts` — 86 tests passed.
- `npm run smoke:chat-network` — all six real local network scenarios passed.
- `npm run check` — Biome, boundaries, builds, workspace typechecks, 274 test files, and 2,954 tests passed.
- Signed commit pre-commit gate — Biome and all workspace typechecks passed.
- `git diff --check` — passed.

## Convention audit

- Reviewed `docs/extension-conventions.md` and `docs/extension-settings.md` before editing.
- Retained bounded child termination plus `finally` cleanup for sessions, DHT nodes, discovery, sockets, and child processes.
- No settings, package contents, runtime loading, or published behavior changed, so no changeset, pack smoke, or Pi runtime smoke is required.
