### PR TITLE
docs: revalidate browse detail document plan

### DIFF
--- a/docs/plans/archived/2026-08-10_pi-tui-kit-browse-detail-document-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-tui-kit-browse-detail-document-plan.md
@@ -62,6 +62,15 @@ Advance the declarative menu API compatibility marker, export the new public typ
 - Consumer audit: document content is excluded from implicit search, explicitly projected metadata remains searchable, exact details preserve schema indentation and tabs, stable raw identity survives duplicate sanitized labels, and the single Kit interaction owns query restoration, Back/Close, replacement, shutdown, and disposal.
 - Execution deviation: formatter extraction and browse wiring landed in one working-tree batch rather than two intermediate commits; the unchanged review contract was still verified independently by the focused review suite. The Tool implementation commit was prepared in a separate worktree and cherry-picked onto the post-Starship authoritative base while that worktree's staged archive remained untouched.
 
+## Revalidation Evidence
+
+- On 2026-08-11, branch `docs/revalidate-browse-detail-document-plan` was created from clean `origin/main` at `f8010851`; the implementation and consumer pull requests were already merged, so no production, test, dependency, or release artifact required another change.
+- The focused Kit and Tool checks, extension-boundary validator, and CI-equivalent `npm run check` passed with 279 test files and 2,979 tests.
+- `just pack tui-kit` confirmed the 59-file Kit package with built JavaScript, declarations, README, license, and manifest; `just pack tool` confirmed the six intended Tool files and no custom browser.
+- npm reported Kit `0.53.0` as `latest` with the expected root and testing exports, and Tool resolved the local package at the required `0.53.0` version.
+- Changesets status retained Tool's pending patch release and introduced no release action; an independent read-only review found no actionable correctness, terminal-safety, lifecycle, compatibility, regression, or packaging defect.
+- Historical implementation commits contain SSH signature headers; local cryptographic identity verification remained unavailable because this checkout has no `gpg.ssh.allowedSignersFile`.
+
 ## Plan
 
 ### Phase 1: Pi TUI Kit API


### PR DESCRIPTION
## Summary

- Revalidates the completed Pi TUI Kit exact browse-detail API and the merged `pi-tool` migration against current `main`.
- Records current repository, package, registry, Changesets, packaging, and independent-review evidence in the archived plan.
- Confirms that no production, test, dependency, package-release, tag, or workflow change is required.

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit`
- `npm run check --workspace @narumitw/pi-tool`
- `npm run check:boundaries`
- `npm run check` — 279 test files and 2,979 tests passed.
- `just pack tui-kit` — 59 intended files.
- `just pack tool` — 6 intended files.
- `npm run changeset:status`
- `npm view @narumitw/pi-tui-kit@0.53.0 version dist-tags.latest exports --json`
- `git diff --check`

The first focused check attempt found that this fresh worktree lacked the root TypeScript installation.
`npm install` restored the clean lockfile installation, and every focused and full check then passed.

## Risks and unverified paths

- This pull request changes documentation only, so it adds no runtime or release risk.
- Deterministic TUI and RPC tests passed, but no new interactive Pi smoke was run.
- Historical commits contain SSH signature headers, but local identity verification is unavailable because this checkout has no `gpg.ssh.allowedSignersFile`.

## Plan

- [Completed archived plan](https://github.com/narumiruna/pi-extensions/blob/docs/revalidate-browse-detail-document-plan/docs/plans/archived/2026-08-10_pi-tui-kit-browse-detail-document-plan.md)
