### PR TITLE
feat(codex-compact): promote extension to stable

### DIFF
--- a/.changeset/calm-codex-compact-stable.md
+++ b/.changeset/calm-codex-compact-stable.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-codex-compact": minor
+---
+
+Promote the extension to stable, include it in root Git installations, and remove its experimental startup warning.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ pi -e npm:@narumitw/pi-goal \
 
 | Package | Use it for | Install |
 | --- | --- | --- |
+| [`pi-codex-compact`](./packages/pi-codex-compact) | Use OpenAI Codex Remote Compaction V2 to persist and replay bounded opaque checkpoints, with `/codex-compact` manual controls and safe Pi-native fallback. | `pi install npm:@narumitw/pi-codex-compact` |
 | [`pi-lsp`](./packages/pi-lsp) | Language-server diagnostics and code actions across JavaScript, TypeScript, Python, Rust, Go, Ruby, C/C++, JVM, .NET, Swift, shell, infrastructure formats, and more. | `pi install npm:@narumitw/pi-lsp` |
 | [`pi-plan-mode`](./packages/pi-plan-mode) | Codex-like, read-only `/plan` collaboration before implementation begins. | `pi install npm:@narumitw/pi-plan-mode` |
 | [`pi-subagents`](./packages/pi-subagents) | Delegate isolated work in single, parallel, or chained execution modes. | `pi install npm:@narumitw/pi-subagents` |
@@ -104,7 +105,6 @@ commands, settings persistence, confirmations, and specialized UI.
 | Package | Use it for | Install |
 | --- | --- | --- |
 | [`pi-analytics`](./packages/pi-analytics) | Review private, content-free local metrics for model calls, skills, tools, response cycles, and observed provider reliability through `/analytics`. | `pi install npm:@narumitw/pi-analytics` |
-| [`pi-codex-compact`](./packages/pi-codex-compact) | Use OpenAI Codex Remote Compaction V2 to persist and replay bounded opaque checkpoints, with `/codex-compact` manual controls and safe Pi-native fallback. | `pi install npm:@narumitw/pi-codex-compact` |
 | [`pi-file-context`](./packages/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it with configurable `F8` or `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
 | [`pi-webui`](./packages/pi-webui) | Use a private loopback browser companion for the current terminal session with live activity and text/image input. | `pi install npm:@narumitw/pi-webui` |
 

--- a/docs/implementation-notes/codex-compaction-mechanism.md
+++ b/docs/implementation-notes/codex-compaction-mechanism.md
@@ -783,11 +783,11 @@ The transferable design is the checkpoint protocol rather than any one summary p
 9. **Do not infer losslessness from persistence.** An exactly replayable summary checkpoint can still
    omit critical task state, so long conversations and repeated compactions remain accuracy risks.
 
-## Experimental Pi extension boundary
+## Pi extension boundary
 
-This repository now contains
-[`packages/pi-codex-compact`](../../packages/pi-codex-compact/README.md), an experimental
-Pi extension for the built-in `openai-codex` OAuth provider. It implements the Remote V2 wire path
+This repository contains
+[`packages/pi-codex-compact`](../../packages/pi-codex-compact/README.md), a stable Pi extension for
+the built-in `openai-codex` OAuth provider. It implements the Remote V2 wire path
 inside Pi's public extension boundary:
 
 - add `compaction_trigger` to an extension-owned Codex Responses request;

--- a/docs/plans/archived/2026-08-11_pi-codex-compact-stable-promotion-plan.md
+++ b/docs/plans/archived/2026-08-11_pi-codex-compact-stable-promotion-plan.md
@@ -1,0 +1,21 @@
+# Pi Codex Compact stable promotion plan
+
+## Goal
+
+Promote `@narumitw/pi-codex-compact` from experimental to stable without changing its compaction protocol or safety fallbacks.
+
+## Plan
+
+- [x] Update package and root lifecycle metadata so direct Git installation loads `pi-codex-compact`; `npm run check:boundaries` passed with 25 active extensions and 5 experimental extensions.
+- [x] Remove package-level experimental warnings from runtime text and add a regression proving ordinary startup is quiet; all 4 focused lifecycle tests passed, and the RPC smoke emitted no startup notification.
+- [x] Move the package into the stable root catalog and revise package and implementation documentation while retaining concrete wire-contract, backup, and replay limitations; the remaining package references to “experimental” describe upstream Codex settings or a different strategy.
+- [x] Add a minor Changeset for the published stable promotion; `npm run changeset:status` reports `@narumitw/pi-codex-compact` 0.50.0.
+- [x] Run verification: the package check, boundary check, 2,987-test full suite with one worker, 10-file dry-run pack inspection, and local RPC Pi load smoke passed. Two default-concurrency `npm run check` attempts completed Biome, boundaries, and all workspace typechecks but exposed unrelated load-sensitive `pi-subagents` and `pi-sync` test flakes; every failed file passed alone, and the complete one-worker suite passed 301/301 files.
+- [x] Audit the final diff against `docs/extension-conventions.md` and Pi's extension, package, and RPC documentation; settings conventions are not applicable because settings behavior and schema do not change.
+
+## Completion Checklist
+
+- [x] `piExtension.lifecycle` is `stable`, and the root Pi manifest includes the extension.
+- [x] No experimental startup warning remains, while real compatibility limitations remain documented.
+- [x] Focused tests, boundary validation, package check, full serialized test suite, pack inspection, and load smoke pass; the default-concurrency gate deviation is recorded above.
+- [x] The completed plan is archived under `docs/plans/archived/`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 			"./packages/pi-btw/src/index.ts",
 			"./packages/pi-caffeinate/src/index.ts",
 			"./packages/pi-chrome-devtools/src/index.ts",
+			"./packages/pi-codex-compact/src/index.ts",
 			"./packages/pi-firecrawl/src/index.ts",
 			"./packages/pi-github-pr/src/index.ts",
 			"./packages/pi-goal/src/index.ts",

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -2,10 +2,6 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-codex-compact)](https://www.npmjs.com/package/@narumitw/pi-codex-compact) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-> [!WARNING]
-> This extension is experimental. It depends on an undocumented OpenAI Codex Responses wire
-> contract and stores provider-specific opaque checkpoints. Keep backups of important sessions.
-
 `@narumitw/pi-codex-compact` adds Codex Remote Compaction V2 to the
 [Pi Coding Agent](https://pi.dev) for the built-in `openai-codex` OAuth provider. It replaces Pi's
 plaintext summary-generation call with a server-generated opaque compaction item and safely replays
@@ -63,8 +59,7 @@ and the local workspace at the same time.
 4. Run `/codex-compact` to inspect the effective route or choose **Compact now**.
 5. After compaction, continue the session normally; compatible requests replay the opaque checkpoint.
 
-The extension shows an experimental warning at session start in UI-capable modes. When the active
-model is unsupported, compaction remains entirely Pi-native.
+When the active model is unsupported, compaction remains entirely Pi-native.
 
 ## 💬 Command
 
@@ -191,9 +186,10 @@ An individually oversized media item is dropped rather than making the session e
 oldest fitting text item may be partially truncated to preserve newer context. These hard byte
 ceilings are intentionally not configurable.
 
-## 🚧 Experimental limitations
+## 🚧 Known limitations
 
-- The wire contract is undocumented and can change independently of Pi or this package.
+- The wire contract is undocumented and can change independently of Pi or this package. Keep
+  backups of important sessions.
 - Full older history depends on this extension and the same compatible model. Removing the extension
   exposes only the portability fallback marker and Pi-retained recent messages.
 - The package does not reproduce Codex core's context-window UUID/number lineage, previous-model

--- a/packages/pi-codex-compact/package.json
+++ b/packages/pi-codex-compact/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-codex-compact",
 	"version": "0.49.5",
-	"description": "Experimental Codex Remote Compaction V2 for Pi's OpenAI Codex provider.",
+	"description": "Codex Remote Compaction V2 for Pi's OpenAI Codex provider.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -24,7 +24,7 @@
 		]
 	},
 	"piExtension": {
-		"lifecycle": "experimental"
+		"lifecycle": "stable"
 	},
 	"scripts": {
 		"check": "biome check --vcs-use-ignore-file=false src test package.json tsconfig.json README.md && npm run typecheck",

--- a/packages/pi-codex-compact/src/codex-compact.ts
+++ b/packages/pi-codex-compact/src/codex-compact.ts
@@ -30,8 +30,6 @@ import {
 import { showCodexCompactMenu } from "./settings-menu.js";
 
 const STATUS_KEY = "codex-compact";
-const EXPERIMENTAL_WARNING =
-	"Experimental: Codex Remote Compaction V2 uses an opaque, provider-specific checkpoint. Sessions require this extension and openai-codex for full replay.";
 
 function isSupportedModel(model: Model<Api> | undefined): model is Model<"openai-codex-responses"> {
 	return model?.provider === "openai-codex" && hasApi(model, "openai-codex-responses");
@@ -186,7 +184,7 @@ export function createCodexCompactExtension(
 		let generation = 0;
 
 		pi.registerCommand("codex-compact", {
-			description: "Compact now or configure experimental Codex Remote Compaction V2",
+			description: "Compact now or configure Codex Remote Compaction V2",
 			handler: async (_args, ctx) => {
 				const ownerGeneration = generation;
 				await showCodexCompactMenu(settingsRuntime, ctx, {
@@ -223,14 +221,11 @@ export function createCodexCompactExtension(
 			) {
 				return;
 			}
-			if (ctx.hasUI) {
-				ctx.ui.notify(EXPERIMENTAL_WARNING, "warning");
-				if (state.kind === "invalid") {
-					ctx.ui.notify(
-						`Invalid pi-codex-compact.json; using defaults without overwriting it. ${state.issue}`,
-						"warning",
-					);
-				}
+			if (ctx.hasUI && state.kind === "invalid") {
+				ctx.ui.notify(
+					`Invalid pi-codex-compact.json; using defaults without overwriting it. ${state.issue}`,
+					"warning",
+				);
 			}
 		});
 

--- a/packages/pi-codex-compact/test/lifecycle.test.ts
+++ b/packages/pi-codex-compact/test/lifecycle.test.ts
@@ -181,7 +181,10 @@ test("registers the settings command and returns a versioned Remote V2 compactio
 	createCodexCompactExtension({ settingsRuntime: runtime, fetch: async () => sseResponse() })(
 		mock.pi,
 	);
-	assert.ok(mock.commands.has("codex-compact"));
+	assert.equal(
+		mock.commands.get("codex-compact")?.description,
+		"Compact now or configure Codex Remote Compaction V2",
+	);
 	const handler = mock.events.get("session_before_compact")?.[0];
 	assert.ok(handler);
 	const entries = branch();
@@ -268,7 +271,21 @@ test("registers the settings command and returns a versioned Remote V2 compactio
 	assert.match(JSON.stringify(rewritten.input.at(-1)), /later/);
 });
 
-test("session lifecycle reloads settings, warns once current, and drops stale reload continuations", async () => {
+test("valid session startup reloads settings without a package warning", async () => {
+	const mock = createMockPi();
+	createCodexCompactExtension({ settingsRuntime: settingsRuntime() })(mock.pi);
+	const start = mock.events.get("session_start")?.[0];
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		sessionManager: { getSessionId: () => "session", getBranch: () => [] },
+	});
+
+	await start?.({ type: "session_start", reason: "startup" }, ctx);
+
+	assert.deepEqual(notifications, []);
+});
+
+test("session lifecycle reloads settings and drops stale reload continuations", async () => {
 	const mock = createMockPi();
 	let reloads = 0;
 	let flushes = 0;


### PR DESCRIPTION
## Summary

- promote `@narumitw/pi-codex-compact` from experimental to stable and include it in root Git installs
- remove the package-level experimental startup warning while retaining wire-contract, backup, and replay limitations
- add startup regression coverage and a minor Changeset for `0.50.0`

## Verification

- `npm --workspace @narumitw/pi-codex-compact run check`
- `npm run biome:check`
- `npm run check:boundaries`
- pre-commit workspace typechecks
- focused lifecycle tests: 4/4 passed
- full serialized suite: 301 files and 2,987 tests passed
- dry-run pack: 10 expected files with no tests
- local RPC load smoke registered `/codex-compact` and emitted no startup notification

## Audit notes

- audited the lifecycle, root manifest, documentation, packaging, startup behavior, and tests against `docs/extension-conventions.md` and Pi's extension, package, and RPC documentation
- `docs/extension-settings.md` is not applicable because the settings schema and behavior do not change
- two default-concurrency `npm run check` attempts exposed unrelated load-sensitive `pi-subagents` and `pi-sync` test flakes; every failed file passed alone, and the complete one-worker suite passed
- no changed-path verification remains outstanding
