### PR TITLE
fix(sync): avoid state migration lock contention

### DIFF
--- a/.changeset/fuzzy-locks-share.md
+++ b/.changeset/fuzzy-locks-share.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Avoid migration-lock contention during normal state access and safely share legacy migration protection across overlapping work in one Pi process.

--- a/docs/plans/archived/2026-08-11_pi-sync-shared-state-access-plan.md
+++ b/docs/plans/archived/2026-08-11_pi-sync-shared-state-access-plan.md
@@ -1,0 +1,19 @@
+# Pi-sync shared state access plan
+
+## Goal
+
+Prevent overlapping pi-sync work in one process from failing with `Lock file is already being held`, while preserving exclusive legacy-state migration.
+
+## Plan
+
+- [x] Add deterministic regression tests in `packages/pi-sync/test/state-directory.test.ts`; the pre-fix overlapping-user test timed out and the focused post-fix suite passed 12 tests.
+- [x] Update `packages/pi-sync/src/state-directory.ts` to bypass the legacy migration lock for canonical state and share one process-owned guard across concurrent legacy state users.
+- [x] Add `.changeset/fuzzy-locks-share.md` with a patch bump for the published behavior fix.
+- [x] Audit lock compromise, acquisition failure, release, concurrent migration, and lifecycle paths; `npm run check` passed all validators and 2,989 tests.
+
+## Completion Checklist
+
+- [x] The overlapping-user regression timed out before the fix and passes afterward without lock contention.
+- [x] All 12 state-directory migration and access tests pass.
+- [x] The repository CI-equivalent `npm run check` passes.
+- [x] The completed plan is archived at `docs/plans/archived/2026-08-11_pi-sync-shared-state-access-plan.md`.

--- a/packages/pi-sync/src/state-directory.ts
+++ b/packages/pi-sync/src/state-directory.ts
@@ -22,6 +22,14 @@ interface StateDirectoryGuard {
 	throwIfCompromised: () => void;
 }
 
+interface SharedStateDirectoryGuard {
+	guard: Promise<StateDirectoryGuard>;
+	users: number;
+	closing?: Promise<void>;
+}
+
+const sharedStateDirectoryGuards = new Map<string, SharedStateDirectoryGuard>();
+
 export function stateDir() {
 	const roots = inspectStateRoots();
 	if (roots.canonical) return canonicalStateDir();
@@ -40,7 +48,9 @@ export function stateDirectoryMigrationNotice() {
 }
 
 export async function withStateDirectoryAccess<T>(fn: () => Promise<T>): Promise<T> {
-	return runWithStateDirectoryGuard(await acquireStateDirectoryGuard(), fn);
+	const roots = inspectStateRoots();
+	if (!roots.legacy) return fn();
+	return runWithStateDirectoryGuard(await acquireSharedStateDirectoryGuard(), fn);
 }
 
 export async function migrateLegacyStateDirectory(): Promise<StateDirectoryPreparation> {
@@ -85,6 +95,50 @@ export async function migrateLegacyStateDirectory(): Promise<StateDirectoryPrepa
 			message: `Migrated pi-sync state from ${legacyStateDir()} to ${canonicalStateDir()}.`,
 		};
 	});
+}
+
+async function acquireSharedStateDirectoryGuard(): Promise<StateDirectoryGuard> {
+	const key = migrationLockPath();
+	for (;;) {
+		let shared = sharedStateDirectoryGuards.get(key);
+		if (shared?.closing) {
+			await shared.closing;
+			continue;
+		}
+		if (!shared) {
+			shared = { guard: acquireStateDirectoryGuard(), users: 0 };
+			sharedStateDirectoryGuards.set(key, shared);
+		}
+		shared.users += 1;
+		let guard: StateDirectoryGuard;
+		try {
+			guard = await shared.guard;
+		} catch (error) {
+			if (sharedStateDirectoryGuards.get(key) === shared) {
+				sharedStateDirectoryGuards.delete(key);
+			}
+			throw error;
+		}
+		let released = false;
+		return {
+			throwIfCompromised: guard.throwIfCompromised,
+			release: async () => {
+				if (released) return;
+				released = true;
+				shared.users -= 1;
+				if (shared.users > 0) return;
+				const closing = guard.release();
+				shared.closing = closing;
+				try {
+					await closing;
+				} finally {
+					if (sharedStateDirectoryGuards.get(key) === shared) {
+						sharedStateDirectoryGuards.delete(key);
+					}
+				}
+			},
+		};
+	}
 }
 
 async function acquireStateDirectoryGuard(): Promise<StateDirectoryGuard> {

--- a/packages/pi-sync/test/state-directory.test.ts
+++ b/packages/pi-sync/test/state-directory.test.ts
@@ -85,6 +85,60 @@ test("a legacy operation guard without metadata defers migration", async () => {
 	});
 });
 
+test("canonical state access does not take the legacy migration lock", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(path.join(agentDir, "pi-sync"), { recursive: true });
+		await withStateDirectoryAccess(async () => {
+			assert.equal(existsSync(path.join(agentDir, ".pi-sync-state-migration.lock")), false);
+		});
+	});
+});
+
+test("overlapping legacy state users share migration protection without lock contention", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(path.join(agentDir, ".pisync"), { recursive: true });
+		let firstStarted: () => void = () => undefined;
+		const started = new Promise<void>((resolve) => {
+			firstStarted = resolve;
+		});
+		let releaseUsers: () => void = () => undefined;
+		const usersReleased = new Promise<void>((resolve) => {
+			releaseUsers = resolve;
+		});
+		const first = withStateDirectoryAccess(async () => {
+			firstStarted();
+			await usersReleased;
+		});
+		await started;
+
+		let secondStarted: () => void = () => undefined;
+		const secondEntered = new Promise<void>((resolve) => {
+			secondStarted = resolve;
+		});
+		const second = withStateDirectoryAccess(async () => {
+			secondStarted();
+			await usersReleased;
+		});
+		const secondOutcome = second.then(
+			() => "completed" as const,
+			(error: unknown) => error,
+		);
+
+		try {
+			const outcome = await Promise.race([
+				secondEntered.then(() => "entered" as const),
+				secondOutcome,
+				new Promise<"blocked">((resolve) => setTimeout(() => resolve("blocked"), 100)),
+			]);
+			assert.equal(outcome, "entered");
+		} finally {
+			releaseUsers();
+			await first;
+			await secondOutcome;
+		}
+	});
+}, 5_000);
+
 test("active state access defers migration without moving or recreating the legacy root", async () => {
 	await withTempHome(async (agentDir) => {
 		const legacy = path.join(agentDir, ".pisync");


### PR DESCRIPTION
## Summary

- bypass the legacy migration lock during normal canonical `pi-sync/` state access
- share one process-owned migration guard across overlapping legacy `.pisync` users
- preserve exclusive explicit migration and add deterministic concurrency regressions
- add a patch changeset and archive the implementation plan

## Testing

- `npx vitest run packages/pi-sync/test/state-directory.test.ts --reporter verbose --testTimeout 10000`
- `npm --workspace @narumitw/pi-sync run check`
- `npm test` — 301 files and 2,989 tests passed
- `npm run check`

## Review notes

- Audited guard acquisition failure, compromise propagation, reference-counted release, concurrent migration, and session lifecycle paths.
- No package metadata or extension-loading path changed, so no additional pack or runtime smoke was required.
