### PR TITLE
feat(goal): start tools inactive by default

### DIFF
--- a/.changeset/silver-goals-wait.md
+++ b/.changeset/silver-goals-wait.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-goal": minor
+---
+
+Start `goal_complete`, `goal_blocked`, and `goal_wait` inactive by default until the first Goal activation or unfinished-goal restore.

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -23,7 +23,7 @@ Goal mode uses Codex-like persistence instructions and sends guarded continuatio
 - Registers a `goal_complete({ goal_id, summary })` tool for explicit completion, requiring the current goal id and rejecting missing/stale ids plus plainly contradictory summaries such as “not complete” or “tests still fail”.
 - Registers `goal_blocked({ goal_id, reason, evidence, repeated_turns })` for true impasses only; it requires the current goal id, concrete evidence, and the same blocker recurring for at least three consecutive goal turns.
 - Registers `goal_wait({ goal_id, reason, resume_after_ms? })` for an active Goal that has arranged an external wake message; waiting suppresses automatic continuation while preserving the objective, accounting, queue, and managed-run ownership.
-- Keeps all three Goal tools active by default for a stable tool schema; optional `"after-first-goal"` visibility hides them until the first accepted `/goal` activation or an unfinished goal is restored, then keeps them desired for the rest of that extension runtime without overriding a restrictive restore policy.
+- Starts all three Goal tools inactive by default, reveals them for the first accepted `/goal` activation or an unfinished-goal restore, and keeps them desired for the rest of that extension runtime without overriding a restrictive restore policy. Optional `"always"` visibility keeps them active from session startup.
 - Records continuation and queue-transition intent, then triggers exactly one next turn only after Pi reports the agent fully settled, idle, and free of pending messages; an explicit wait remains quiet until non-Goal work or its optional deadline wakes it, and missing terminal tools still pause before another model turn.
 - Lets retry, compaction, steering, follow-up, and other queued work settle before automatic goal continuation.
 - Separates user interruption (`paused`), true impasse or terminal non-usage error (`blocked`), provider/account quota exhaustion (`usage_limited`), and user token budget exhaustion (`budget_limited`).
@@ -63,7 +63,7 @@ built-in defaults without creating the file:
 
 ```json
 {
-  "toolVisibility": "always",
+  "toolVisibility": "after-first-goal",
   "experimental": {
     "goals": false
   },
@@ -91,8 +91,8 @@ Custom number inputs reject zero, negative numbers, decimals, text, and unsafe i
 
 `toolVisibility` accepts:
 
-- `"always"` (default) — pi-goal does not proactively hide `goal_complete`, `goal_blocked`, or `goal_wait`, keeping the Goal tool schema stable from session startup.
-- `"after-first-goal"` — hides all three Goal tools at fresh runtime startup, reveals them for the first accepted Goal activation, and treats an unfinished-goal restore as unlocked for the remainder of that extension runtime. On restore, pi-goal uses the active tools already established by earlier lifecycle handlers; it does not re-add missing terminal tools over a restrictive policy. Failed kickoff, replacement, resume, or reactivating-edit delivery restores the exact pre-activation tool set, including Goal tools exposed by another extension. If revealing the tools would widen an already-running turn, wait for Pi to become idle and retry `/goal`.
+- `"always"` — pi-goal does not proactively hide `goal_complete`, `goal_blocked`, or `goal_wait`, keeping the Goal tool schema stable from session startup.
+- `"after-first-goal"` (default) — hides all three Goal tools at fresh runtime startup, reveals them for the first accepted Goal activation, and treats an unfinished-goal restore as unlocked for the remainder of that extension runtime. On restore, pi-goal uses the active tools already established by earlier lifecycle handlers; it does not re-add missing terminal tools over a restrictive policy. Failed kickoff, replacement, resume, or reactivating-edit delivery restores the exact pre-activation tool set, including Goal tools exposed by another extension. If revealing the tools would widen an already-running turn, wait for Pi to become idle and retry `/goal`.
 
 `experimental.goals` accepts a boolean and defaults to `false`. Set it to `true` to enable the ordered-goal subcommands and automatic queue advancement described below. Enabled sessions show one warning because command behavior and persisted queue state remain experimental.
 

--- a/packages/pi-goal/src/settings.ts
+++ b/packages/pi-goal/src/settings.ts
@@ -24,7 +24,7 @@ export interface GoalSettings {
 }
 
 export const DEFAULT_GOAL_SETTINGS: GoalSettings = {
-	toolVisibility: "always",
+	toolVisibility: "after-first-goal",
 	experimental: { goals: false },
 	rpc: { enabled: false },
 	continuationLimits: { automaticTurns: 25, noProgressTurns: 3 },

--- a/packages/pi-goal/test/goal-queue.test.ts
+++ b/packages/pi-goal/test/goal-queue.test.ts
@@ -12,8 +12,8 @@ import type { ActiveGoal, GoalStateEntryData } from "../src/persistence.js";
 const settingsDirectory = mkdtempSync(join(tmpdir(), "pi-goal-queue-settings-"));
 const enabledSettingsPath = join(settingsDirectory, "enabled.json");
 const disabledSettingsPath = join(settingsDirectory, "disabled.json");
-writeFileSync(enabledSettingsPath, '{"experimental":{"goals":true}}\n');
-writeFileSync(disabledSettingsPath, "{}\n");
+writeFileSync(enabledSettingsPath, '{"toolVisibility":"always","experimental":{"goals":true}}\n');
+writeFileSync(disabledSettingsPath, '{"toolVisibility":"always"}\n');
 
 type GoalTool = {
 	execute: (...args: unknown[]) => Promise<{

--- a/packages/pi-goal/test/goal-tool-policy.test.ts
+++ b/packages/pi-goal/test/goal-tool-policy.test.ts
@@ -24,7 +24,7 @@ test("goal registers command, status tools, and lifecycle hooks", () => {
 	const mock = createMockPi({
 		activeTools: ["read", "bash", "goal_complete", "goal_blocked", "goal_wait"],
 	});
-	registerGoal(mock.pi);
+	registerGoalWithSettingsPath(mock.pi, MISSING_SETTINGS_PATH);
 
 	assert.ok(mock.commands.has("goal"));
 	assert.equal(typeof mock.commands.get("goal")?.getArgumentCompletions, "function");
@@ -41,14 +41,8 @@ test("goal registers command, status tools, and lifecycle hooks", () => {
 	]);
 	const context = createMockContext();
 	mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	// Default settings keep goal tools active for a stable schema.
-	assert.deepEqual(mock.rawPi.getActiveTools(), [
-		"read",
-		"bash",
-		"goal_complete",
-		"goal_blocked",
-		"goal_wait",
-	]);
+	// Default settings hide Goal tools until the first accepted Goal activation.
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash"]);
 	const completionParameters = mock.tools.find((tool) => tool.name === "goal_complete")
 		?.parameters as
 		| {
@@ -213,17 +207,11 @@ test("session start uses defaults without materializing missing settings", () =>
 	mock.events.get("session_start")?.[0]?.({}, context.ctx);
 
 	assert.equal(existsSync(parent), false);
-	assert.deepEqual(mock.rawPi.getActiveTools(), [
-		"read",
-		"bash",
-		"goal_complete",
-		"goal_blocked",
-		"goal_wait",
-	]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash"]);
 	assert.equal(context.notifications.length, 0);
 });
 
-test("missing and invalid settings fall back to always-visible tools", () => {
+test("missing and invalid settings fall back to inactive Goal tools", () => {
 	for (const [settingsPath, expectsWarning] of [
 		[MISSING_SETTINGS_PATH, false],
 		[INVALID_SETTINGS_PATH, true],
@@ -235,13 +223,7 @@ test("missing and invalid settings fall back to always-visible tools", () => {
 		const context = createMockContext();
 		mock.events.get("session_start")?.[0]?.({}, context.ctx);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), [
-			"read",
-			"bash",
-			"goal_complete",
-			"goal_blocked",
-			"goal_wait",
-		]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash"]);
 		assert.equal(
 			context.notifications.some((notice) => /settings ignored/.test(notice.message)),
 			expectsWarning,

--- a/packages/pi-goal/test/settings-ui.test.ts
+++ b/packages/pi-goal/test/settings-ui.test.ts
@@ -221,7 +221,10 @@ test("hiding always-visible Goal tools rejects a busy unrelated run", () => {
 		activeTools: ["read", "goal_complete", "goal_blocked", "goal_wait"],
 	});
 	const state = new GoalRuntime(mock.pi);
-	state.settings = structuredClone(DEFAULT_GOAL_SETTINGS);
+	state.settings = {
+		...structuredClone(DEFAULT_GOAL_SETTINGS),
+		toolVisibility: "always",
+	};
 	const before = state.toolPolicy.snapshot();
 	const next = {
 		...structuredClone(state.settings),
@@ -801,8 +804,8 @@ test("standard Goal tools setting saves and applies immediately", async () => {
 			saved = structuredClone(settings);
 		},
 	});
-	assert.equal(saved?.toolVisibility, "after-first-goal");
-	assert.equal(state.settings.toolVisibility, "after-first-goal");
+	assert.equal(saved?.toolVisibility, "always");
+	assert.equal(state.settings.toolVisibility, "always");
 });
 
 test("invalid settings use a standard read-only detail screen", async () => {

--- a/packages/pi-goal/test/settings.test.ts
+++ b/packages/pi-goal/test/settings.test.ts
@@ -14,6 +14,7 @@ import {
 const DEFAULT_GOAL_SETTINGS_DOCUMENT = `${JSON.stringify(DEFAULT_GOAL_SETTINGS, null, 2)}\n`;
 
 test("normalizeGoalSettings applies defaults and accepts bounded continuation limits", () => {
+	assert.equal(DEFAULT_GOAL_SETTINGS.toolVisibility, "after-first-goal");
 	assert.equal(DEFAULT_GOAL_SETTINGS.continuationLimits.automaticTurns, 25);
 	assert.deepEqual(DEFAULT_GOAL_SETTINGS.rpc, { enabled: false });
 	assert.deepEqual(normalizeGoalSettings({}), DEFAULT_GOAL_SETTINGS);


### PR DESCRIPTION
## Summary

- default Goal tool visibility to `after-first-goal`
- keep `goal_complete`, `goal_blocked`, and `goal_wait` inactive until Goal activation or restore
- preserve `always` as an explicit opt-in and update documentation and release metadata

## Checks

- `npm run check`
- 301 test files passed
- 2,987 tests passed