### PR TITLE
feat(chrome-devtools): load browser tools on demand

### DIFF
--- a/.changeset/lazy-chrome-tools.md
+++ b/.changeset/lazy-chrome-tools.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-chrome-devtools": minor
+---
+
+Load Chrome DevTools capability tools on demand through a persistent `chrome_devtools_load` tool.
+
+Treat the saved tool selection as the allowed lazy-load catalog and keep deferred capability metadata out of the stable system prompt prefix.

--- a/docs/plans/archived/2026-08-10_pi-chrome-devtools-lazy-tools-plan.md
+++ b/docs/plans/archived/2026-08-10_pi-chrome-devtools-lazy-tools-plan.md
@@ -1,0 +1,45 @@
+# Pi Chrome DevTools Lazy Tools Plan
+
+## Goal
+
+Keep one lightweight `chrome_devtools_load` tool active and load the five Chrome DevTools capability tools only when the model requests a matching browser capability.
+
+## Context
+
+Pi 0.84 supports dynamic tool loading when a loader makes a purely additive `setActiveTools()` call during execution.
+
+The five existing tools are already independently registered and configurable through `pi-chrome-devtools.json`.
+
+The saved `tools` array becomes the allowed lazy-load catalog rather than an eager startup list.
+
+## Architecture
+
+- Register all five capability tools plus one loader tool at extension load.
+- Keep the loader active across the session and remove allowed capability definitions from the initial active set.
+- Match loader queries against a small package-owned capability catalog and add only allowed matches.
+- Keep loader activation additive so Pi can use native deferred tool references where supported.
+- Remove `promptSnippet` metadata from deferred tools so loading a tool does not rebuild the system prompt prefix.
+- Treat menu and settings selection as availability policy; removing availability also unloads the affected active capability, while adding availability waits for a loader call.
+
+## Non-Goals
+
+- Do not lazy-load the extension module itself.
+- Do not change CDP execution, browser launch, screenshot safety, or endpoint behavior.
+- Do not add provider-specific deferred-loading payloads.
+
+## Plan
+
+- [x] Add focused lazy-loading tests under `packages/pi-chrome-devtools/test/` for registration, initial active-set reduction, matching, additive activation, allowed-catalog enforcement, and repeated loads; the initial focused run failed in the four new lazy-loading cases before implementation.
+- [x] Add the loader and allowed-catalog runtime policy under `packages/pi-chrome-devtools/src/`; package typecheck and all 65 Chrome DevTools tests pass.
+- [x] Update menu, command status, and settings language to distinguish available tools from currently loaded tools; focused menu, settings, lifecycle, managed-browser, and extension tests pass.
+- [x] Update `packages/pi-chrome-devtools/README.md` and add a minor Changeset; `npm run changeset:status` resolves the package to the intended minor release.
+- [x] Audit dynamic-loading additivity, prompt metadata, cancellation/lifecycle, settings ordering and rollback, invalid-file protection, unknown-field preservation, and session replacement against `docs/extension-conventions.md` and `docs/extension-settings.md`; no deviation remains.
+- [x] Run package-focused tests and typecheck, `npm run check`, `just pack chrome-devtools`, and a non-interactive Pi load smoke; all pass with an isolated temporary Pi agent directory, and the tarball contains 16 expected files including `src/lazy-tools.ts`.
+
+## Completion Checklist
+
+- [x] Only `chrome_devtools_load` is initially active for the extension after session initialization.
+- [x] A loader call exposes matching allowed capability tools on the next model request without removing any active tool.
+- [x] Disabled capabilities cannot be loaded, and explicit settings changes remain ordered, atomic, and rollback-safe.
+- [x] Documentation explains native deferred loading, fallback behavior, availability policy, and command semantics.
+- [x] All required checks pass and the completed plan is archived.

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -26,10 +26,11 @@ This package is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDev
   explicit endpoint overrides.
 - Retries briefly while Chrome is starting and reports actionable endpoint errors.
 - Shows statusline activity only while Chrome DevTools tools are running.
-- Provides a state-first `/chrome-devtools` menu for tool access, browser status, setup, and help.
-- Stages menu-based tool changes for exact review before one confirmed apply.
+- Keeps one loader tool active and exposes matching browser capabilities only when the agent needs them.
+- Provides a state-first `/chrome-devtools` menu for tool availability, browser status, setup, and help.
+- Stages menu-based availability changes for exact review before one confirmed apply.
 - Uses `@narumitw/pi-tui-kit` for width-safe TUI menus and equivalent RPC dialogs.
-- Persists the selected Chrome DevTools tools across Pi restarts.
+- Persists the Chrome DevTools lazy-load catalog across Pi restarts.
 
 ## 📦 Install
 
@@ -143,11 +144,30 @@ removes their temporary profiles. It never closes user-started browsers or remot
 
 ## 🛠️ Pi tools
 
+- `chrome_devtools_load` — find and load browser capabilities relevant to a task.
 - `chrome_devtools_list_pages` — list inspectable Chrome tabs/pages.
 - `chrome_devtools_select_page` — select the active page for later tool calls.
 - `chrome_devtools_navigate` — navigate a page to a URL; if no page exists, create one first.
 - `chrome_devtools_evaluate` — evaluate JavaScript in the selected page.
 - `chrome_devtools_screenshot` — capture a PNG screenshot and save it as a PNG file.
+
+### Lazy tool loading
+
+All six tools are registered, but only `chrome_devtools_load` starts active for this extension.
+
+The loader accepts a task-oriented `query`, matches it against the five capability tools, and adds matching available tools without removing any active Pi tool.
+
+Loaded capability tools remain active for the rest of the session unless the user makes them unavailable through `/chrome-devtools`.
+
+Pi uses native deferred tool references on compatible Anthropic and OpenAI models.
+
+Other models receive Pi's safe fallback: the newly active definitions appear in the normal tool list on the next model request.
+
+The capability tools omit active-only prompt snippets so a lazy load does not rebuild the system prompt prefix.
+
+The saved `tools` array controls which capabilities the loader may expose.
+
+An empty array leaves the loader active but makes every browser capability unavailable.
 
 ### Screenshot files
 
@@ -182,14 +202,14 @@ to read the saved path, for example `read({ path: "artifacts/homepage.png" })`.
 /chrome-devtools
 ```
 
-Opens a menu that shows the current browser-tool count, whether that selection is saved, the
-configured endpoint, the observed managed-browser state, and any settings or launch warning before
-you choose an action. The five actions stay on one level:
+Opens a menu that shows the lazy catalog size, whether that catalog is saved, the configured
+endpoint, the observed managed-browser state, and any settings or launch warning before you choose
+an action. The five actions stay on one level:
 
-- **Choose browser tools…** — stage any combination of the five capabilities, then review the exact
-  enabled/disabled result before selecting **Apply tool changes**.
-- **Enable all browser tools…** or **Disable all browser tools…** — preview the context-appropriate
-  bulk change before applying it.
+- **Choose available browser tools…** — stage any combination of the five capabilities, then review
+  the exact available/unavailable result before selecting **Apply tool changes**.
+- **Make all browser tools available…** or **Make all browser tools unavailable…** — preview the
+  context-appropriate bulk change before applying it.
 - **Browser status** — inspect runtime, endpoint, launch mode, and the last launch attempt without
   probing the endpoint or starting Chrome.
 - **Settings & setup** — inspect effective files, sources, trust, reload steps, and recovery guidance.
@@ -200,8 +220,8 @@ friendly task labels while retaining their raw `chrome_devtools_*` identity in t
 Toggles remain a command-local draft. **Review changes** previews the exact effect, **Apply tool
 changes** saves it, and Cancel, Escape, Ctrl+C, disposal, or session replacement discards an
 unconfirmed draft without changing runtime tools or settings. A failed apply restores the previous
-active-tool state, preserves the settings file, retains the draft for retry, and reports how to
-recover.
+availability and loaded-tool state, preserves the settings file, retains the draft for retry, and
+reports how to recover.
 
 Direct subcommands are also available:
 
@@ -221,14 +241,15 @@ Compatibility aliases remain available: `toggle` and `select` mean `tools`, `on`
 - `help` shows command usage.
 - `quickstart` shows the configured CDP endpoint, endpoint source, auto-launch mode, browser
   candidates, last launch attempt, and launch hints.
-- `status` shows runtime tool state, persisted selection, settings file path, endpoint source,
-  launch mode, last launch attempt, and active non-Chrome tool count.
-- `tools` opens the same staged, width-safe selection and review flow used by the menu.
+- `status` shows available and loaded capability counts, loader state, the persisted catalog,
+  settings file path, endpoint source, launch mode, last launch attempt, and active non-Chrome tool
+  count.
+- `tools` opens the same staged, width-safe availability and review flow used by the menu.
 - `toggle` and `select` are compatibility aliases for `tools`.
-- `enable` immediately enables and saves all `chrome_devtools_*` tools for future turns; `on` is a
+- `enable` makes all five capability tools available to the loader and saves that catalog; `on` is a
   compatibility alias.
-- `disable` immediately disables and saves all `chrome_devtools_*` tools for future turns; `off` is a
-  compatibility alias. The slash command remains available.
+- `disable` makes all five capability tools unavailable and saves the empty catalog; `off` is a
+  compatibility alias. The slash command and `chrome_devtools_load` remain available.
 
 The menu, `tools`, `help`, `quickstart`, and `status` require TUI or RPC mode so their result is
 observable. TUI uses keyboard navigation and injected Pi keybindings; RPC receives equivalent
@@ -236,19 +257,20 @@ standard dialogs. In print and JSON modes, interactive and informational routes 
 instead of silently opening unavailable UI. The immediate `enable`/`disable` routes remain available
 for deterministic non-interactive use.
 
-The selected tool names are saved to:
+The available capability names are saved to:
 
 ```text
 ${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json
 ```
 
-When the file is missing or invalid, the extension preserves Pi's current active-tool policy
-instead of enabling tools by itself. A valid saved selection is restored on Pi startup and
-`/reload`. A missing file is created by the first confirmed menu apply or successful direct
-selection change. Within one Pi process, selection saves run in invocation order, reread the latest
-valid document, and preserve unknown fields. Malformed JSON or invalid recognized fields make menu
-mutation unavailable and block direct saves without replacement; a failed save restores the prior
-Chrome DevTools tool selection while preserving other extensions' current tools.
+When the file is missing or invalid, the extension preserves Pi's current Chrome DevTools
+availability policy instead of replacing it. A valid saved catalog is restored on Pi startup and
+`/reload`, while its capability definitions remain deferred. A missing file is created by the first
+confirmed menu apply or successful direct availability change. Within one Pi process, catalog saves
+run in invocation order, reread the latest valid document, and preserve unknown fields. Malformed
+JSON or invalid recognized fields make menu mutation unavailable and block direct saves without
+replacement; a failed save restores the prior Chrome DevTools availability and loaded-tool state
+while preserving other extensions' current tools.
 
 Compatibility: older versions used `pi-chrome-devtools-settings.json`. A legacy-only file remains
 readable with a warning and is never modified automatically; rename it to
@@ -271,6 +293,7 @@ packages/pi-chrome-devtools/
 ├── src/
 │   ├── index.ts            # Pi package entrypoint
 │   ├── chrome-devtools.ts  # Extension registration and command orchestration
+│   ├── lazy-tools.ts       # Deferred capability catalog and loader tool
 │   └── *.ts                # Package-local browser, CDP, tool, and storage modules
 ├── README.md
 ├── LICENSE

--- a/packages/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/packages/pi-chrome-devtools/src/chrome-devtools.ts
@@ -1,10 +1,15 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { shutdownManagedBrowser } from "./browser-manager.js";
+import {
+	availableChromeDevtoolsTools,
+	configureLazyChromeDevtoolsTools,
+	createChromeDevtoolsLoadTool,
+	initializeAvailableChromeDevtoolsTools,
+} from "./lazy-tools.js";
 import { applyRuntimeBrowserSettings, state } from "./runtime.js";
 import { loadSettings } from "./settings.js";
 import {
 	allChromeDevtoolsTools,
-	applyChromeDevtoolsTools,
 	buildCommandGuide,
 	buildQuickstartMessage,
 	buildToolStatusMessage,
@@ -27,12 +32,12 @@ const COMMAND_COMPLETIONS = [
 	{ value: "help", label: "help", description: "Show command usage" },
 	{ value: "quickstart", label: "quickstart", description: "Show endpoint and launch help" },
 	{ value: "status", label: "status", description: "Show tool and settings status" },
-	{ value: "tools", label: "tools", description: "Select Chrome DevTools tools" },
+	{ value: "tools", label: "tools", description: "Choose lazy-loadable Chrome DevTools tools" },
 	{ value: "toggle", label: "toggle", description: "Alias for tools" },
 	{ value: "select", label: "select", description: "Compatibility alias for tools" },
-	{ value: "enable", label: "enable", description: "Enable all Chrome DevTools tools" },
+	{ value: "enable", label: "enable", description: "Make all Chrome DevTools tools available" },
 	{ value: "on", label: "on", description: "Compatibility alias for enable" },
-	{ value: "disable", label: "disable", description: "Disable all Chrome DevTools tools" },
+	{ value: "disable", label: "disable", description: "Make all Chrome DevTools tools unavailable" },
 	{ value: "off", label: "off", description: "Compatibility alias for disable" },
 ];
 export default function chromeDevtools(pi: ExtensionAPI) {
@@ -41,6 +46,8 @@ export default function chromeDevtools(pi: ExtensionAPI) {
 	pi.registerTool(navigateTool);
 	pi.registerTool(evaluateTool);
 	pi.registerTool(screenshotTool);
+	pi.registerTool(createChromeDevtoolsLoadTool(pi));
+	initializeAvailableChromeDevtoolsTools(pi);
 
 	pi.registerCommand("chrome-devtools", {
 		description: "Open Chrome DevTools help and tool controls",
@@ -69,9 +76,11 @@ export default function chromeDevtools(pi: ExtensionAPI) {
 		for (const warning of settings.warnings) {
 			ctx.ui.notify(sanitizeChromeDevtoolsDisplay(warning), "warning");
 		}
-		if (settings.kind === "loaded" && settings.settings.tools) {
-			applyChromeDevtoolsTools(pi, settings.settings.tools);
-		}
+		const availableTools =
+			settings.kind === "loaded" && settings.settings.tools
+				? settings.settings.tools
+				: availableChromeDevtoolsTools(pi);
+		configureLazyChromeDevtoolsTools(pi, availableTools);
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
@@ -120,10 +129,10 @@ async function handleChromeDevtoolsCommand(
 			return;
 		}
 		case "enable":
-			await updateChromeDevtoolsTools(pi, ctx, allChromeDevtoolsTools(), "enabled all");
+			await updateChromeDevtoolsTools(pi, ctx, allChromeDevtoolsTools(), "made all available");
 			return;
 		case "disable":
-			await updateChromeDevtoolsTools(pi, ctx, [], "disabled all");
+			await updateChromeDevtoolsTools(pi, ctx, [], "made all unavailable");
 			return;
 	}
 
@@ -185,6 +194,7 @@ export {
 	isLocalDevToolsHost,
 	quoteCommandPart,
 } from "./browser-manager.js";
+export { CHROME_DEVTOOLS_LOAD_TOOL_NAME } from "./lazy-tools.js";
 export { parseConfiguredPort } from "./runtime.js";
 export {
 	hasParentPathSegment,

--- a/packages/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/packages/pi-chrome-devtools/src/chrome-devtools.ts
@@ -47,12 +47,12 @@ export default function chromeDevtools(pi: ExtensionAPI) {
 	pi.registerTool(evaluateTool);
 	pi.registerTool(screenshotTool);
 	pi.registerTool(createChromeDevtoolsLoadTool(pi));
-	initializeAvailableChromeDevtoolsTools(pi);
 
 	pi.registerCommand("chrome-devtools", {
 		description: "Open Chrome DevTools help and tool controls",
 		getArgumentCompletions: (prefix) => commandCompletions(prefix),
 		handler: async (args, ctx) => {
+			initializeAvailableChromeDevtoolsTools(pi);
 			const generation = state.sessionGeneration;
 			await handleChromeDevtoolsCommand(pi, args, ctx, generation);
 		},
@@ -60,6 +60,7 @@ export default function chromeDevtools(pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		const generation = ++state.sessionGeneration;
+		initializeAvailableChromeDevtoolsTools(pi);
 		replaceSessionController("Chrome DevTools session replaced");
 		state.shuttingDown = false;
 		state.settingsNotice = undefined;

--- a/packages/pi-chrome-devtools/src/lazy-tools.ts
+++ b/packages/pi-chrome-devtools/src/lazy-tools.ts
@@ -23,9 +23,11 @@ const SEARCH_TEXT: Record<ChromeDevToolsToolName, string> = {
 };
 
 export function initializeAvailableChromeDevtoolsTools(pi: ExtensionAPI) {
+	if (availableToolsByApi.has(pi)) return;
+	const activeTools = new Set(pi.getActiveTools());
 	setAvailableTools(
 		pi,
-		CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => pi.getActiveTools().includes(name)),
+		CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => activeTools.has(name)),
 	);
 }
 

--- a/packages/pi-chrome-devtools/src/lazy-tools.ts
+++ b/packages/pi-chrome-devtools/src/lazy-tools.ts
@@ -1,0 +1,141 @@
+import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { CHROME_DEVTOOLS_TOOL_NAMES, type ChromeDevToolsToolName } from "./tool-names.js";
+
+export const CHROME_DEVTOOLS_LOAD_TOOL_NAME = "chrome_devtools_load";
+
+const AVAILABLE_TOOLS_STORE = Symbol.for("@narumitw/pi-chrome-devtools.available-tools-store");
+type ChromeDevtoolsGlobal = typeof globalThis & {
+	[AVAILABLE_TOOLS_STORE]?: WeakMap<ExtensionAPI, Set<ChromeDevToolsToolName>>;
+};
+const sharedGlobal = globalThis as ChromeDevtoolsGlobal;
+const existingAvailableToolsStore = sharedGlobal[AVAILABLE_TOOLS_STORE];
+const availableToolsByApi =
+	existingAvailableToolsStore ?? new WeakMap<ExtensionAPI, Set<ChromeDevToolsToolName>>();
+if (!existingAvailableToolsStore) sharedGlobal[AVAILABLE_TOOLS_STORE] = availableToolsByApi;
+
+const SEARCH_TEXT: Record<ChromeDevToolsToolName, string> = {
+	chrome_devtools_list_pages: "list open inspectable chrome browser pages tabs targets",
+	chrome_devtools_select_page: "select choose active chrome browser page tab target",
+	chrome_devtools_navigate: "navigate open create chrome browser page url website",
+	chrome_devtools_evaluate: "evaluate run javascript expression dom inspect chrome browser page",
+	chrome_devtools_screenshot: "capture screenshot png image visual chrome browser page",
+};
+
+export function initializeAvailableChromeDevtoolsTools(pi: ExtensionAPI) {
+	setAvailableTools(
+		pi,
+		CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => pi.getActiveTools().includes(name)),
+	);
+}
+
+export function configureLazyChromeDevtoolsTools(
+	pi: ExtensionAPI,
+	availableTools: readonly ChromeDevToolsToolName[],
+) {
+	setAvailableTools(pi, availableTools);
+	const nonCapabilityTools = pi
+		.getActiveTools()
+		.filter((name) => !CHROME_DEVTOOLS_TOOL_NAMES.includes(name as ChromeDevToolsToolName));
+	pi.setActiveTools(unique([...nonCapabilityTools, CHROME_DEVTOOLS_LOAD_TOOL_NAME]));
+}
+
+export function applyAvailableChromeDevtoolsTools(
+	pi: ExtensionAPI,
+	availableTools: readonly ChromeDevToolsToolName[],
+) {
+	const available = setAvailableTools(pi, availableTools);
+	const active = pi
+		.getActiveTools()
+		.filter(
+			(name) =>
+				!CHROME_DEVTOOLS_TOOL_NAMES.includes(name as ChromeDevToolsToolName) ||
+				available.has(name as ChromeDevToolsToolName),
+		);
+	pi.setActiveTools(unique([...active, CHROME_DEVTOOLS_LOAD_TOOL_NAME]));
+}
+
+export function availableChromeDevtoolsTools(pi: ExtensionAPI) {
+	const available = availableToolsByApi.get(pi) ?? new Set();
+	return CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => available.has(name));
+}
+
+export function createChromeDevtoolsLoadTool(pi: ExtensionAPI) {
+	return defineTool({
+		name: CHROME_DEVTOOLS_LOAD_TOOL_NAME,
+		label: "Chrome DevTools: Load Tools",
+		description:
+			"Find and enable Chrome DevTools browser tools relevant to a task. Loaded tools remain available for the session.",
+		promptSnippet: "Load Chrome DevTools browser capabilities on demand",
+		promptGuidelines: [
+			"Use chrome_devtools_load when a task requires inspecting or controlling a Chrome browser and the needed chrome_devtools_* capability is not active.",
+		],
+		parameters: Type.Object({
+			query: Type.String({
+				description: "Browser capability or task to find tools for.",
+				maxLength: 500,
+			}),
+			limit: Type.Optional(
+				Type.Integer({
+					description: "Maximum tools to load. Defaults to 3.",
+					minimum: 1,
+					maximum: 5,
+				}),
+			),
+		}),
+		async execute(_toolCallId, params, signal) {
+			signal?.throwIfAborted();
+			const available = new Set(availableChromeDevtoolsTools(pi));
+			const matches = matchChromeDevtoolsTools(params.query, params.limit ?? 3, available);
+			const active = pi.getActiveTools();
+			const activeSet = new Set(active);
+			const added = matches.filter((name) => !activeSet.has(name));
+			if (added.length > 0) {
+				pi.setActiveTools(unique([...active, ...added]));
+			}
+
+			const text =
+				matches.length === 0
+					? "No available Chrome DevTools tools matched the query."
+					: added.length > 0
+						? `Loaded Chrome DevTools tools: ${added.join(", ")}`
+						: `Matching Chrome DevTools tools are already loaded: ${matches.join(", ")}`;
+			return {
+				content: [{ type: "text" as const, text }],
+				details: { matches, added },
+			};
+		},
+	});
+}
+
+function matchChromeDevtoolsTools(
+	query: string,
+	limit: number,
+	available: ReadonlySet<ChromeDevToolsToolName>,
+) {
+	const terms = query
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter((term) => term.length >= 2);
+	if (terms.length === 0) return [];
+	return CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => available.has(name))
+		.map((name, index) => ({
+			name,
+			index,
+			score: terms.reduce((score, term) => score + (SEARCH_TEXT[name].includes(term) ? 1 : 0), 0),
+		}))
+		.filter((match) => match.score > 0)
+		.sort((left, right) => right.score - left.score || left.index - right.index)
+		.slice(0, limit)
+		.map((match) => match.name);
+}
+
+function setAvailableTools(pi: ExtensionAPI, availableTools: readonly ChromeDevToolsToolName[]) {
+	const available = new Set(availableTools);
+	availableToolsByApi.set(pi, available);
+	return available;
+}
+
+function unique(values: readonly string[]) {
+	return [...new Set(values)];
+}

--- a/packages/pi-chrome-devtools/src/menu.ts
+++ b/packages/pi-chrome-devtools/src/menu.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu, runTask } from "@narumitw/pi-tui-kit";
 import { browserLifecycleState, devToolsEndpoint, launchModeLabel } from "./browser-manager.js";
+import { availableChromeDevtoolsTools } from "./lazy-tools.js";
 import { state } from "./runtime.js";
 import { loadSettings, type SettingsLoadResult } from "./settings.js";
 import { CHROME_DEVTOOLS_TOOL_NAMES, type ChromeDevToolsToolName } from "./tool-names.js";
@@ -75,8 +76,8 @@ export async function showChromeDevtoolsMenu(
 				items: [
 					{
 						id: "tools",
-						label: "Choose browser tools…",
-						description: "Select what Pi may do in Chrome.",
+						label: "Choose available browser tools…",
+						description: "Choose which capabilities the loader may expose.",
 						disabled: Boolean(current.mutationBlockedReason),
 						disabledReason: current.mutationBlockedReason,
 						action: "tools",
@@ -85,8 +86,8 @@ export async function showChromeDevtoolsMenu(
 						id: "bulk",
 						label:
 							current.activeTools.length === CHROME_DEVTOOLS_TOOL_NAMES.length
-								? "Disable all browser tools…"
-								: "Enable all browser tools…",
+								? "Make all browser tools unavailable…"
+								: "Make all browser tools available…",
 						description:
 							current.activeTools.length === CHROME_DEVTOOLS_TOOL_NAMES.length
 								? "Preview 0 of 5; other active tools stay enabled."
@@ -250,8 +251,8 @@ export async function showChromeDevtoolsToolWorkflow(
 				kind: "review",
 				title: "Review tool changes",
 				lines: [
-					`Current: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
-					`Proposed: ${current.draft.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+					`Currently available: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+					`Proposed availability: ${current.draft.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
 				],
 				content: buildToolReview(current),
 				format: { kind: "text" },
@@ -307,7 +308,7 @@ export async function showChromeDevtoolsToolWorkflow(
 				current.draft = new Set(selectedTools);
 				current.applied = true;
 				ctx.ui.notify(
-					`Saved: ${selectedTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} browser tools enabled.`,
+					`Saved: ${selectedTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} browser tools available to lazy-load.`,
 					"info",
 				);
 				return { kind: "close" };
@@ -363,7 +364,7 @@ function buildMenuSnapshot(pi: ExtensionAPI, settings: SettingsLoadResult): Menu
 				? "not saved"
 				: arraysEqual(activeTools, persistedTools)
 					? "saved"
-					: "runtime differs from saved selection";
+					: "runtime catalog differs from saved catalog";
 	const settingsWarning = [
 		...new Set([settings.notice, state.settingsNotice].filter(Boolean)),
 	].join("\n");
@@ -379,7 +380,7 @@ function buildMenuSnapshot(pi: ExtensionAPI, settings: SettingsLoadResult): Menu
 
 function mainStateLines(snapshot: MenuSnapshot) {
 	return sanitizeLines([
-		`Tools: ${snapshot.activeTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} enabled · ${snapshot.persistenceLabel}`,
+		`Lazy catalog: ${snapshot.activeTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} available · ${snapshot.persistenceLabel}`,
 		`Browser: ${browserLifecycleSummary()}`,
 		`Endpoint: ${devToolsEndpoint()}`,
 		...(snapshot.settingsWarning ? [`Settings warning: ${snapshot.settingsWarning}`] : []),
@@ -406,7 +407,7 @@ function toolDraftLines(current: ToolWorkflowState) {
 		return sanitizeLines([`Unavailable: ${current.mutationBlockedReason}`]);
 	const changes = symmetricDifferenceSize(current.accepted, current.draft);
 	return [
-		`Current accepted: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+		`Currently available: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
 		changes === 0
 			? "No unapplied changes · Escape cancels"
 			: `${changes} unapplied ${changes === 1 ? "change" : "changes"} · Escape cancels`,
@@ -415,25 +416,26 @@ function toolDraftLines(current: ToolWorkflowState) {
 }
 
 function buildToolReview(current: ToolWorkflowState) {
-	const enabled = CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => current.draft.has(name));
-	const disabled = CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => !current.draft.has(name));
+	const available = CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => current.draft.has(name));
+	const unavailable = CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => !current.draft.has(name));
 	return sanitizeChromeDevtoolsDisplay(
 		[
-			`Current browser tools: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
-			`Proposed browser tools: ${current.draft.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+			`Current available browser tools: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+			`Proposed available browser tools: ${current.draft.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
 			"",
-			"Enabled after apply:",
-			...(enabled.length > 0
-				? enabled.map((name) => `  - ${TOOL_PRESENTATION[name].label} (${name})`)
+			"Available to lazy-load after apply:",
+			...(available.length > 0
+				? available.map((name) => `  - ${TOOL_PRESENTATION[name].label} (${name})`)
 				: ["  - none"]),
 			"",
-			"Disabled after apply:",
-			...(disabled.length > 0
-				? disabled.map((name) => `  - ${TOOL_PRESENTATION[name].label} (${name})`)
+			"Unavailable after apply:",
+			...(unavailable.length > 0
+				? unavailable.map((name) => `  - ${TOOL_PRESENTATION[name].label} (${name})`)
 				: ["  - none"]),
 			"",
 			"Other active Pi tools remain unchanged.",
-			"The accepted selection is saved for future sessions.",
+			"Newly available tools remain deferred until chrome_devtools_load selects them.",
+			"The accepted availability policy is saved for future sessions.",
 		].join("\n"),
 	);
 }
@@ -447,8 +449,7 @@ function updateSnapshotAfterApply(
 }
 
 function activeChromeTools(pi: ExtensionAPI) {
-	const active = new Set(pi.getActiveTools());
-	return CHROME_DEVTOOLS_TOOL_NAMES.filter((toolName) => active.has(toolName));
+	return availableChromeDevtoolsTools(pi);
 }
 
 function orderedTools(tools: ReadonlySet<ChromeDevToolsToolName>) {

--- a/packages/pi-chrome-devtools/src/tool-selector.ts
+++ b/packages/pi-chrome-devtools/src/tool-selector.ts
@@ -10,6 +10,11 @@ import {
 	launchHint,
 	launchModeLabel,
 } from "./browser-manager.js";
+import {
+	applyAvailableChromeDevtoolsTools,
+	availableChromeDevtoolsTools,
+	CHROME_DEVTOOLS_LOAD_TOOL_NAME,
+} from "./lazy-tools.js";
 import { state } from "./runtime.js";
 import { loadSettings, saveSettings, settingsFilePath } from "./settings.js";
 import { CHROME_DEVTOOLS_TOOL_NAMES, type ChromeDevToolsToolName } from "./tool-names.js";
@@ -25,8 +30,9 @@ function formatError(error: unknown) {
 }
 
 interface ToolStatusSummary {
-	runtimeStatus: "enabled" | "disabled" | "partial";
-	activeChromeToolCount: number;
+	availabilityStatus: "enabled" | "disabled" | "partial";
+	availableChromeToolCount: number;
+	loadedChromeToolCount: number;
 	activeNonChromeToolCount: number;
 }
 
@@ -43,7 +49,7 @@ export async function updateChromeDevtoolsTools(
 	if (result !== "saved" || generation !== state.sessionGeneration) return;
 	const status = await buildToolStatusMessage(pi);
 	if (generation !== state.sessionGeneration) return;
-	ctx.ui.notify(`Chrome DevTools tools ${action}.\n\n${status}`, "info");
+	ctx.ui.notify(`Chrome DevTools lazy catalog ${action}.\n\n${status}`, "info");
 }
 
 export async function setSelectedChromeDevtoolsTools(
@@ -92,7 +98,7 @@ async function transactSelectedToolsNow(
 	expectedActiveTools?: readonly ChromeDevToolsToolName[],
 ): Promise<ToolSelectionSaveResult> {
 	if (expectedGeneration !== state.sessionGeneration) return "failed";
-	if (expectedActiveTools && !arraysEqual(activeChromeDevtoolsTools(pi), expectedActiveTools)) {
+	if (expectedActiveTools && !arraysEqual(availableChromeDevtoolsTools(pi), expectedActiveTools)) {
 		ctx.ui.notify(
 			"Browser tool selection changed while review was open. Review the current state, then apply again.",
 			"warning",
@@ -100,6 +106,7 @@ async function transactSelectedToolsNow(
 		return "active-tools-changed";
 	}
 	const previousActiveTools = pi.getActiveTools();
+	const previousAvailableTools = availableChromeDevtoolsTools(pi);
 	try {
 		applyChromeDevtoolsTools(pi, selectedTools);
 		await persistSettings(selectedTools);
@@ -107,10 +114,14 @@ async function transactSelectedToolsNow(
 	} catch (error) {
 		let rollbackError: unknown;
 		try {
-			const previousChromeTools = previousActiveTools.filter((name) =>
+			applyAvailableChromeDevtoolsTools(pi, previousAvailableTools);
+			const currentNonChromeTools = pi
+				.getActiveTools()
+				.filter((name) => !CHROME_DEVTOOLS_TOOL_NAMES.includes(name as ChromeDevToolsToolName));
+			const previousLoadedChromeTools = previousActiveTools.filter((name) =>
 				CHROME_DEVTOOLS_TOOL_NAMES.includes(name as ChromeDevToolsToolName),
-			) as ChromeDevToolsToolName[];
-			applyChromeDevtoolsTools(pi, previousChromeTools);
+			);
+			pi.setActiveTools(unique([...currentNonChromeTools, ...previousLoadedChromeTools]));
 		} catch (caught) {
 			rollbackError = caught;
 		}
@@ -127,11 +138,6 @@ async function transactSelectedToolsNow(
 	}
 }
 
-function activeChromeDevtoolsTools(pi: ExtensionAPI) {
-	const active = new Set(pi.getActiveTools());
-	return CHROME_DEVTOOLS_TOOL_NAMES.filter((toolName) => active.has(toolName));
-}
-
 function arraysEqual<T>(left: readonly T[], right: readonly T[]) {
 	return left.length === right.length && left.every((value, index) => value === right[index]);
 }
@@ -140,29 +146,32 @@ export function applyChromeDevtoolsTools(
 	pi: ExtensionAPI,
 	selectedTools: readonly ChromeDevToolsToolName[],
 ) {
-	const activeToolNames = pi.getActiveTools();
-	const chromeToolNames = new Set<string>(CHROME_DEVTOOLS_TOOL_NAMES);
-	const activeNonChromeToolNames = activeToolNames.filter((name) => !chromeToolNames.has(name));
-	pi.setActiveTools(unique([...activeNonChromeToolNames, ...selectedTools]));
+	applyAvailableChromeDevtoolsTools(pi, selectedTools);
 }
 
 function getToolStatusSummary(pi: ExtensionAPI): ToolStatusSummary {
 	const chromeToolNames = new Set<string>(CHROME_DEVTOOLS_TOOL_NAMES);
 	const activeToolNames = new Set(pi.getActiveTools());
-	const activeChromeToolCount = CHROME_DEVTOOLS_TOOL_NAMES.filter((name) =>
+	const loadedChromeToolCount = CHROME_DEVTOOLS_TOOL_NAMES.filter((name) =>
 		activeToolNames.has(name),
 	).length;
+	const availableChromeToolCount = availableChromeDevtoolsTools(pi).length;
 	const activeNonChromeToolCount = Array.from(activeToolNames).filter(
-		(name) => !chromeToolNames.has(name),
+		(name) => !chromeToolNames.has(name) && name !== CHROME_DEVTOOLS_LOAD_TOOL_NAME,
 	).length;
-	const runtimeStatus =
-		activeChromeToolCount === CHROME_DEVTOOLS_TOOL_NAMES.length
+	const availabilityStatus =
+		availableChromeToolCount === CHROME_DEVTOOLS_TOOL_NAMES.length
 			? "enabled"
-			: activeChromeToolCount === 0
+			: availableChromeToolCount === 0
 				? "disabled"
 				: "partial";
 
-	return { runtimeStatus, activeChromeToolCount, activeNonChromeToolCount };
+	return {
+		availabilityStatus,
+		availableChromeToolCount,
+		loadedChromeToolCount,
+		activeNonChromeToolCount,
+	};
 }
 
 export async function buildToolStatusMessage(pi: ExtensionAPI) {
@@ -170,8 +179,10 @@ export async function buildToolStatusMessage(pi: ExtensionAPI) {
 	const persistedSetting = await persistedSettingLabel();
 	return sanitizeChromeDevtoolsDisplay(
 		[
-			`Chrome DevTools tools: ${formatRuntimeStatus(summary)}`,
-			`Persisted selection: ${persistedSetting}`,
+			`Chrome DevTools tools available to lazy-load: ${formatRuntimeStatus(summary)}`,
+			`Loaded capability tools this session: ${summary.loadedChromeToolCount}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
+			`Loader: ${pi.getActiveTools().includes(CHROME_DEVTOOLS_LOAD_TOOL_NAME) ? "active" : "inactive"}`,
+			`Persisted lazy catalog: ${persistedSetting}`,
 			...browserSettingsStatusLines(),
 			...(state.settingsNotice ? [`Settings note: ${state.settingsNotice}`] : []),
 			`Other active tools preserved: ${summary.activeNonChromeToolCount}`,
@@ -276,10 +287,10 @@ export function buildCommandGuide() {
 		"/chrome-devtools help — show command usage",
 		"/chrome-devtools quickstart — show endpoint and launch help",
 		"/chrome-devtools status — show tool and settings status",
-		"/chrome-devtools tools — select individual Chrome DevTools tools",
+		"/chrome-devtools tools — choose tools available to lazy-load",
 		"/chrome-devtools toggle|select — compatibility aliases for tools",
-		"/chrome-devtools enable|on — enable all Chrome DevTools tools immediately",
-		"/chrome-devtools disable|off — disable all Chrome DevTools tools immediately",
+		"/chrome-devtools enable|on — make all Chrome DevTools tools available to lazy-load",
+		"/chrome-devtools disable|off — make all Chrome DevTools capability tools unavailable",
 	].join("\n");
 }
 
@@ -292,7 +303,7 @@ export function orderedChromeDevtoolsTools(selectedTools: ReadonlySet<ChromeDevT
 }
 
 function formatRuntimeStatus(summary: ToolStatusSummary) {
-	return `${summary.runtimeStatus} (${summary.activeChromeToolCount}/${CHROME_DEVTOOLS_TOOL_NAMES.length} active)`;
+	return `${summary.availabilityStatus} (${summary.availableChromeToolCount}/${CHROME_DEVTOOLS_TOOL_NAMES.length} available)`;
 }
 
 async function persistedSettingLabel() {
@@ -308,9 +319,10 @@ async function persistedSettingLabel() {
 
 function formatPersistedSelection(tools: readonly ChromeDevToolsToolName[]) {
 	if (tools.length === CHROME_DEVTOOLS_TOOL_NAMES.length) {
-		return `all enabled (${tools.length}/${CHROME_DEVTOOLS_TOOL_NAMES.length} selected)`;
+		return `all available (${tools.length}/${CHROME_DEVTOOLS_TOOL_NAMES.length} selected)`;
 	}
-	if (tools.length === 0) return `all disabled (0/${CHROME_DEVTOOLS_TOOL_NAMES.length} selected)`;
+	if (tools.length === 0)
+		return `all unavailable (0/${CHROME_DEVTOOLS_TOOL_NAMES.length} selected)`;
 	return `${tools.length}/${CHROME_DEVTOOLS_TOOL_NAMES.length} selected: ${tools.join(", ")}`;
 }
 

--- a/packages/pi-chrome-devtools/src/tools.ts
+++ b/packages/pi-chrome-devtools/src/tools.ts
@@ -18,7 +18,6 @@ export const listPagesTool = defineTool({
 	name: CHROME_DEVTOOLS_TOOL_NAMES[0],
 	label: "Chrome DevTools: List Pages",
 	description: "List Chrome tabs/pages from a running Chrome DevTools Protocol endpoint.",
-	promptSnippet: "List Chrome tabs/pages available over Chrome DevTools Protocol",
 	parameters: Type.Object({}),
 	renderCall: renderToolCall("list pages"),
 	renderResult: renderTextResult,
@@ -34,7 +33,6 @@ export const selectPageTool = defineTool({
 	name: CHROME_DEVTOOLS_TOOL_NAMES[1],
 	label: "Chrome DevTools: Select Page",
 	description: "Select the active Chrome page for later chrome_devtools_* tool calls.",
-	promptSnippet: "Select the Chrome tab/page to inspect or control",
 	parameters: Type.Object({
 		pageId: Type.String({ description: "Page id from chrome_devtools_list_pages." }),
 	}),
@@ -56,7 +54,6 @@ export const navigateTool = defineTool({
 	label: "Chrome DevTools: Navigate",
 	description:
 		"Navigate a Chrome page to a URL through Chrome DevTools Protocol, creating a page first if none is available.",
-	promptSnippet: "Navigate the selected or first Chrome tab to a URL, creating one if needed",
 	parameters: Type.Object({
 		url: Type.String({ description: "URL to navigate to." }),
 		pageId: Type.Optional(
@@ -88,7 +85,6 @@ export const evaluateTool = defineTool({
 	name: CHROME_DEVTOOLS_TOOL_NAMES[3],
 	label: "Chrome DevTools: Evaluate",
 	description: "Evaluate JavaScript in a Chrome page through Chrome DevTools Protocol.",
-	promptSnippet: "Evaluate JavaScript in the selected Chrome tab",
 	parameters: Type.Object({
 		expression: Type.String({ description: "JavaScript expression to evaluate." }),
 		pageId: Type.Optional(
@@ -121,7 +117,6 @@ export const screenshotTool = defineTool({
 	name: CHROME_DEVTOOLS_TOOL_NAMES[4],
 	label: "Chrome DevTools: Screenshot",
 	description: "Capture a PNG screenshot from a Chrome page through Chrome DevTools Protocol.",
-	promptSnippet: "Capture a screenshot from the selected Chrome tab",
 	parameters: Type.Object({
 		pageId: Type.Optional(
 			Type.String({ description: "Optional page id. Defaults to selected or first page." }),

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -39,12 +39,20 @@ const LEGACY_SETTINGS_FILE = "pi-chrome-devtools-settings.json";
 const LIST_PAGES_TOOL = "chrome_devtools_list_pages";
 const EVALUATE_TOOL = "chrome_devtools_evaluate";
 const SCREENSHOT_TOOL = "chrome_devtools_screenshot";
+const LOAD_TOOL = "chrome_devtools_load";
+const CAPABILITY_TOOLS = [
+	"chrome_devtools_list_pages",
+	"chrome_devtools_select_page",
+	"chrome_devtools_navigate",
+	"chrome_devtools_evaluate",
+	"chrome_devtools_screenshot",
+] as const;
 
-test("chrome-devtools registers all CDP tools and command", () => {
+test("chrome-devtools registers deferred CDP tools and one loader", () => {
 	const mock = createMockPi();
 	chromeDevtools(mock.pi);
 
-	assert.equal(mock.tools.length, 5);
+	assert.equal(mock.tools.length, 6);
 	assert.deepEqual(
 		mock.tools.map((tool) => tool.name),
 		[
@@ -53,8 +61,12 @@ test("chrome-devtools registers all CDP tools and command", () => {
 			"chrome_devtools_navigate",
 			"chrome_devtools_evaluate",
 			"chrome_devtools_screenshot",
+			LOAD_TOOL,
 		],
 	);
+	for (const tool of mock.tools.filter((candidate) => candidate.name !== LOAD_TOOL)) {
+		assert.equal(tool.promptSnippet, undefined);
+	}
 	assert.ok(mock.commands.has("chrome-devtools"));
 	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
 });
@@ -90,7 +102,7 @@ test("chrome-devtools settings normalize ordered unique tool names", () => {
 	assert.deepEqual(orderedChromeDevtoolsTools(new Set([EVALUATE_TOOL])), [EVALUATE_TOOL]);
 });
 
-test("chrome-devtools preserves active tools when settings are missing", async () => {
+test("chrome-devtools keeps only its loader active when settings are missing", async () => {
 	await withTempAgentDir(async () => {
 		const chromeDevtoolsModule = await importFreshChromeDevtools();
 		const mock = createMockPi({ activeTools: ["other_tool", EVALUATE_TOOL] });
@@ -99,12 +111,86 @@ test("chrome-devtools preserves active tools when settings are missing", async (
 		chromeDevtoolsModule.default(mock.pi);
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", EVALUATE_TOOL]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		assert.deepEqual(notifications, []);
 	});
 });
 
-test("chrome-devtools loads the new settings file without a migration warning", async () => {
+test("chrome-devtools loader additively activates matching allowed tools", async () => {
+	await withTempAgentDir(async () => {
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const { ctx } = createMockContext();
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		const loader = mock.tools.find((tool) => tool.name === LOAD_TOOL) as {
+			execute: (...args: unknown[]) => Promise<{
+				details: { matches: string[]; added: string[] };
+			}>;
+		};
+
+		const first = await loader.execute(
+			"loader-1",
+			{ query: "capture a screenshot" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.deepEqual(first.details, { matches: [SCREENSHOT_TOOL], added: [SCREENSHOT_TOOL] });
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, SCREENSHOT_TOOL]);
+
+		const second = await loader.execute(
+			"loader-2",
+			{ query: "capture a screenshot" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.deepEqual(second.details, { matches: [SCREENSHOT_TOOL], added: [] });
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, SCREENSHOT_TOOL]);
+	});
+});
+
+test("chrome-devtools loader does not expose tools outside the saved catalog", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		writeSettings(agentDir, NEW_SETTINGS_FILE, [SCREENSHOT_TOOL]);
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", EVALUATE_TOOL, SCREENSHOT_TOOL] });
+		const { ctx } = createMockContext();
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		const loader = mock.tools.find((tool) => tool.name === LOAD_TOOL) as {
+			execute: (...args: unknown[]) => Promise<{
+				details: { matches: string[]; added: string[] };
+			}>;
+		};
+
+		const result = await loader.execute(
+			"loader-1",
+			{ query: "evaluate JavaScript" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+
+		assert.deepEqual(result.details, { matches: [], added: [] });
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
+
+		const genericResult = await loader.execute(
+			"loader-2",
+			{ query: "browser" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.deepEqual(genericResult.details, {
+			matches: [SCREENSHOT_TOOL],
+			added: [SCREENSHOT_TOOL],
+		});
+	});
+});
+
+test("chrome-devtools loads the new settings file as the lazy catalog without a warning", async () => {
 	await withTempAgentDir(async (agentDir) => {
 		writeSettings(agentDir, NEW_SETTINGS_FILE, [SCREENSHOT_TOOL]);
 		const chromeDevtoolsModule = await importFreshChromeDevtools();
@@ -114,7 +200,7 @@ test("chrome-devtools loads the new settings file without a migration warning", 
 		chromeDevtoolsModule.default(mock.pi);
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", SCREENSHOT_TOOL]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		assert.deepEqual(notifications, []);
 	});
 });
@@ -129,7 +215,7 @@ test("chrome-devtools reads legacy-only settings without modifying either path",
 		chromeDevtoolsModule.default(mock.pi);
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LIST_PAGES_TOOL]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		assert.equal(existsSync(path.join(agentDir, NEW_SETTINGS_FILE)), false);
 		assert.deepEqual(readSettings(agentDir, LEGACY_SETTINGS_FILE).tools, [LIST_PAGES_TOOL]);
 		assert.match(notifications[0]?.message ?? "", /using legacy/i);
@@ -149,7 +235,7 @@ test("chrome-devtools prefers new settings created while legacy settings are loa
 		writeSettings(agentDir, NEW_SETTINGS_FILE, [SCREENSHOT_TOOL]);
 		await sessionStart;
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", SCREENSHOT_TOOL]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, [SCREENSHOT_TOOL]);
 		assert.equal(existsSync(path.join(agentDir, LEGACY_SETTINGS_FILE)), true);
 		assert.match(notifications[0]?.message ?? "", /legacy settings ignored/i);
@@ -168,7 +254,7 @@ test("chrome-devtools prefers new settings when both files exist and reports leg
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 		await mock.commands.get("chrome-devtools")?.handler("status", ctx);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", SCREENSHOT_TOOL]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, [SCREENSHOT_TOOL]);
 		assert.equal(existsSync(path.join(agentDir, LEGACY_SETTINGS_FILE)), true);
 		assert.match(notifications[0]?.message ?? "", /legacy settings ignored/i);
@@ -191,7 +277,7 @@ test("chrome-devtools ignores invalid legacy settings without creating the new f
 		chromeDevtoolsModule.default(mock.pi);
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", EVALUATE_TOOL]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		assert.equal(existsSync(path.join(agentDir, NEW_SETTINGS_FILE)), false);
 		assert.match(notifications[0]?.message ?? "", /settings ignored/i);
 		assert.match(notifications[0]?.message ?? "", /pi-chrome-devtools-settings\.json/);
@@ -212,7 +298,7 @@ test("chrome-devtools does not fall back to legacy settings when the new file is
 		chromeDevtoolsModule.default(mock.pi);
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", EVALUATE_TOOL]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		assert.equal(existsSync(path.join(agentDir, LEGACY_SETTINGS_FILE)), true);
 		assert.match(notifications[0]?.message ?? "", /legacy settings ignored/i);
 		assert.match(notifications[1]?.message ?? "", /settings ignored/i);
@@ -233,7 +319,7 @@ test("chrome-devtools saves tool selection only to the new settings file", async
 		chromeDevtoolsModule.default(mock.pi);
 		await mock.commands.get("chrome-devtools")?.handler("disable", ctx);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, []);
 		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).future, { kept: true });
 		assert.equal(existsSync(path.join(agentDir, LEGACY_SETTINGS_FILE)), false);
@@ -303,7 +389,7 @@ test("chrome-devtools rejects invalid settings updates and restores active tools
 		await mock.commands.get("chrome-devtools")?.handler("disable", ctx);
 
 		assert.equal(readFileSync(settingsPath, "utf8"), invalid);
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LIST_PAGES_TOOL]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, LIST_PAGES_TOOL]);
 		assert.match(notifications.at(-1)?.message ?? "", /settings save failed/i);
 
 		writeSettings(agentDir, NEW_SETTINGS_FILE, [LIST_PAGES_TOOL]);
@@ -322,11 +408,11 @@ test("chrome-devtools rolls back a failed save after shutdown invalidates its se
 
 		const command = mock.commands.get("chrome-devtools")?.handler("disable", ctx);
 		await Promise.resolve();
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		const shutdown = mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 
 		await Promise.all([command, shutdown]);
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LIST_PAGES_TOOL]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, LIST_PAGES_TOOL]);
 		assert.deepEqual(notifications, []);
 	});
 });
@@ -342,7 +428,7 @@ test("chrome-devtools serializes rapid tool saves in invocation order", async ()
 		const second = mock.commands.get("chrome-devtools")?.handler("disable", ctx);
 		await Promise.all([first, second]);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
 		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, []);
 	});
 });
@@ -383,17 +469,15 @@ test("Chrome DevTools main menu dispatches declarative actions at narrow widths"
 	});
 	await mock.commands.get("chrome-devtools")?.handler("", ctx);
 	assert.ok(renders.flat().every((line) => visibleWidth(line) <= 20));
-	assert.match(renders.flat().join("\n"), /Tools: 0 of 5/);
+	assert.match(renders.flat().join("\n"), /Lazy catalog: 0 of 5/);
 	assert.deepEqual(notifications, []);
 });
 
 test("Chrome DevTools tool selection keeps the cursor on the staged row", async () => {
 	await withTempAgentDir(async (agentDir) => {
-		const mock = createMockPi({ activeTools: ["other_tool"] });
+		const initialTools = ["other_tool", ...CAPABILITY_TOOLS, LOAD_TOOL];
+		const mock = createMockPi({ activeTools: initialTools });
 		chromeDevtools(mock.pi);
-		const toolNames = mock.tools.map((tool) => String(tool.name));
-		const initialTools = ["other_tool", ...toolNames];
-		mock.rawPi.setActiveTools(initialTools);
 		let toolScreen = 0;
 		let refreshed = "";
 		const { ctx } = createMockContext({
@@ -423,10 +507,8 @@ test("Chrome DevTools tool selection keeps the cursor on the staged row", async 
 
 test("Chrome DevTools tool selection refreshes dynamic draft state after a toggle", async () => {
 	await withTempAgentDir(async () => {
-		const mock = createMockPi({ activeTools: ["other_tool"] });
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS, LOAD_TOOL] });
 		chromeDevtools(mock.pi);
-		const toolNames = mock.tools.map((tool) => String(tool.name));
-		mock.rawPi.setActiveTools(["other_tool", ...toolNames]);
 		let toolScreens = 0;
 		let refreshed = "";
 		const { ctx } = createMockContext({

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -48,6 +48,19 @@ const CAPABILITY_TOOLS = [
 	"chrome_devtools_screenshot",
 ] as const;
 
+test("chrome-devtools factory registers without reading action methods", () => {
+	const mock = createMockPi();
+	mock.rawPi.getActiveTools = () => {
+		throw new Error("must wait for session_start");
+	};
+	mock.rawPi.setActiveTools = () => {
+		throw new Error("must wait for session_start");
+	};
+
+	assert.doesNotThrow(() => chromeDevtools(mock.pi));
+	assert.ok(mock.events.has("session_start"));
+});
+
 test("chrome-devtools registers deferred CDP tools and one loader", () => {
 	const mock = createMockPi();
 	chromeDevtools(mock.pi);
@@ -148,6 +161,40 @@ test("chrome-devtools loader additively activates matching allowed tools", async
 		);
 		assert.deepEqual(second.details, { matches: [SCREENSHOT_TOOL], added: [] });
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, SCREENSHOT_TOOL]);
+	});
+});
+
+test("chrome-devtools keeps its missing-settings catalog across session replacement", async () => {
+	await withTempAgentDir(async () => {
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const { ctx } = createMockContext();
+		chromeDevtoolsModule.default(mock.pi);
+		const sessionStart = mock.events.get("session_start")?.[0];
+		await sessionStart?.({}, ctx);
+		const loader = mock.tools.find((tool) => tool.name === LOAD_TOOL) as {
+			execute: (...args: unknown[]) => Promise<{
+				details: { matches: string[]; added: string[] };
+			}>;
+		};
+
+		await loader.execute(
+			"loader-1",
+			{ query: "capture a screenshot" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		await sessionStart?.({}, ctx);
+		const result = await loader.execute(
+			"loader-2",
+			{ query: "evaluate JavaScript" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+
+		assert.deepEqual(result.details, { matches: [EVALUATE_TOOL], added: [EVALUATE_TOOL] });
 	});
 });
 

--- a/packages/pi-chrome-devtools/test/menu.test.ts
+++ b/packages/pi-chrome-devtools/test/menu.test.ts
@@ -10,6 +10,7 @@ import {
 	createMockPi,
 } from "../../../test/support.js";
 import chromeDevtools from "../src/chrome-devtools.js";
+import { applyAvailableChromeDevtoolsTools } from "../src/lazy-tools.js";
 import { state } from "../src/runtime.js";
 import { settingsFilePath } from "../src/settings.js";
 import { buildBrowserStatusMessage } from "../src/tool-selector.js";
@@ -42,11 +43,11 @@ test("main menu presents consequential state and five goal-oriented actions with
 
 		await mock.commands.get("chrome-devtools")?.handler("", ctx);
 
-		assert.match(rendered, /Tools: 2 of 5 enabled · not saved/);
+		assert.match(rendered, /Lazy catalog: 2 of 5 available · not\s+saved/);
 		assert.match(rendered, /Browser: not started · attaches or\s+launches on first use/);
 		assert.match(rendered, /Endpoint: http:\/\/127\.0\.0\.1:9222/);
-		assert.match(rendered, /[→›] Choose browser tools…/);
-		assert.match(rendered, /Enable all browser tools…/);
+		assert.match(rendered, /[→›] Choose available browser tools…/);
+		assert.match(rendered, /Make all browser tools available…/);
 		assert.match(rendered, /Browser status/);
 		assert.match(rendered, /Settings & setup/);
 		assert.match(rendered, /Help/);
@@ -115,9 +116,9 @@ test("main menu shows saved all-enabled state and the reversible disable preview
 
 		await mock.commands.get("chrome-devtools")?.handler("", ctx);
 
-		assert.match(rendered, /Tools: 5 of 5 enabled · saved/);
-		assert.match(rendered, /Disable all browser tools…/);
-		assert.match(rendered, /Preview 0 of 5; other active tools stay enabled/);
+		assert.match(rendered, /Lazy catalog: 5 of 5 available · saved/);
+		assert.match(rendered, /Make all browser tools unavailable…/);
+		assert.match(rendered, /Preview 0 of 5; other active tools stay/);
 	});
 });
 
@@ -252,7 +253,7 @@ test("bulk preview and nested detail navigation return without side effects", as
 
 		await mock.commands.get("chrome-devtools")?.handler("", ctx);
 
-		assert.match(details[0] ?? "", /Proposed: 5\/5/);
+		assert.match(details[0] ?? "", /Proposed availability: 5\/5/);
 		assert.match(details[1] ?? "", /does not probe the endpoint or launch Chrome/);
 		assert.match(details[2] ?? "", /Settings changes apply.*\/reload/s);
 		assert.match(details[3] ?? "", /\/chrome-devtools tools/);
@@ -286,7 +287,7 @@ test("invalid settings keep tool mutation unavailable and preserve the file", as
 		await mock.commands.get("chrome-devtools")?.handler("", ctx);
 
 		assert.match(rendered, /settings need repair/);
-		assert.match(rendered, /\[-\] Choose browser tools…/);
+		assert.match(rendered, /\[-\] Choose available browser tools…/);
 		assert.match(rendered, /Repair\s+.*invalid JSON\s+before saving/s);
 		assert.equal(readFileSync(settingsFilePath(), "utf8"), invalid);
 	});
@@ -337,7 +338,7 @@ test("interactive routes reject unsupported modes while direct mutations remain 
 		await assert.rejects(() => invoke("tools"), /requires TUI or RPC/);
 		await invoke("disable");
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", "chrome_devtools_load"]);
 		assert.deepEqual(JSON.parse(readFileSync(settingsFilePath(), "utf8")).tools, []);
 	});
 });
@@ -345,7 +346,6 @@ test("interactive routes reject unsupported modes while direct mutations remain 
 test("apply refreshes review instead of overwriting browser tools changed while waiting", async () => {
 	await withTempAgentDir(async () => {
 		const initialTools = ["other_tool", ...CHROME_TOOLS];
-		const concurrentTools = ["other_tool", ...CHROME_TOOLS.slice(0, 3)];
 		const mock = createMockPi({ activeTools: initialTools });
 		chromeDevtools(mock.pi);
 		let changedWhileWaiting = false;
@@ -356,7 +356,7 @@ test("apply refreshes review instead of overwriting browser tools changed while 
 			waitForIdle: async () => {
 				if (changedWhileWaiting) return;
 				changedWhileWaiting = true;
-				mock.rawPi.setActiveTools(concurrentTools);
+				applyAvailableChromeDevtoolsTools(mock.pi, CHROME_TOOLS.slice(0, 3));
 			},
 			hasUI: true,
 			mode: "tui",
@@ -386,9 +386,13 @@ test("apply refreshes review instead of overwriting browser tools changed while 
 		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
 
 		assert.equal(reviewScreen, 2);
-		assert.match(refreshedReview, /Current: 3\/5/);
-		assert.match(refreshedReview, /Proposed: 4\/5/);
-		assert.deepEqual(mock.rawPi.getActiveTools(), concurrentTools);
+		assert.match(refreshedReview, /Currently available: 3\/5/);
+		assert.match(refreshedReview, /Proposed availability: 4\/5/);
+		assert.deepEqual(mock.rawPi.getActiveTools(), [
+			"other_tool",
+			...CHROME_TOOLS.slice(0, 3),
+			"chrome_devtools_load",
+		]);
 		assert.equal(existsSync(settingsFilePath()), false);
 		assert.match(notifications.at(-1)?.message ?? "", /changed while review was open/i);
 	});
@@ -433,8 +437,12 @@ test("a failed confirmed save restores runtime and retains the draft for retry",
 		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
 
 		assert.equal(reviewScreen, 2);
-		assert.match(retryReview, /Proposed: 4\/5/);
-		assert.deepEqual(mock.rawPi.getActiveTools(), initialTools);
+		assert.match(retryReview, /Proposed availability: 4\/5/);
+		assert.deepEqual(mock.rawPi.getActiveTools(), [
+			"other_tool",
+			"chrome_devtools_load",
+			...CHROME_TOOLS,
+		]);
 		assert.match(
 			notifications.at(-1)?.message ?? "",
 			/settings save failed; active tools restored/i,
@@ -509,9 +517,13 @@ test("RPC dialogs preserve staged review and confirmed apply semantics", async (
 
 		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
 
-		assert.ok(dialogTitles.some((title) => title.includes("Current accepted: 5/5")));
-		assert.ok(dialogTitles.some((title) => title.includes("Proposed: 4/5")));
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", ...CHROME_TOOLS.slice(1)]);
+		assert.ok(dialogTitles.some((title) => title.includes("Currently available: 5/5")));
+		assert.ok(dialogTitles.some((title) => title.includes("Proposed availability: 4/5")));
+		assert.deepEqual(mock.rawPi.getActiveTools(), [
+			"other_tool",
+			...CHROME_TOOLS.slice(1),
+			"chrome_devtools_load",
+		]);
 		assert.deepEqual(
 			JSON.parse(readFileSync(settingsFilePath(), "utf8")).tools,
 			CHROME_TOOLS.slice(1),
@@ -563,20 +575,27 @@ test("review previews the exact tool effect and one confirmed apply persists it"
 
 		await mock.commands.get("chrome-devtools")?.handler("tools", ctx);
 
-		assert.match(review, /Current: 5\/5/);
-		assert.match(review, /Proposed: 4\/5/);
-		assert.match(review, /Disabled after apply:/);
+		assert.match(review, /Currently available: 5\/5/);
+		assert.match(review, /Proposed availability: 4\/5/);
+		assert.match(review, /Unavailable after apply:/);
 		assert.match(review, /List open pages \(chrome_devtools_list_pages\)/);
 		assert.match(review, /Other active Pi tools remain unchanged/);
 		assert.ok(narrowReview.every((line) => visibleWidth(line) <= 20));
 		assert.ok(narrowReview.length <= 5);
 		assert.deepEqual(applicationOrder, ["wait-for-idle", "apply-runtime"]);
-		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", ...CHROME_TOOLS.slice(1)]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), [
+			"other_tool",
+			...CHROME_TOOLS.slice(1),
+			"chrome_devtools_load",
+		]);
 		assert.deepEqual(
 			JSON.parse(readFileSync(settingsFilePath(), "utf8")).tools,
 			CHROME_TOOLS.slice(1),
 		);
-		assert.match(notifications.at(-1)?.message ?? "", /Saved: 4 of 5 browser tools enabled/);
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/Saved: 4 of 5 browser tools available to lazy-load/,
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

- add `chrome_devtools_load` as the always-active gateway for deferred browser capabilities
- treat the saved Chrome DevTools tool list as the allowed lazy-load catalog
- update tool controls, status, documentation, rollback behavior, and focused coverage for availability versus loaded state

## Verification

- `PI_CODING_AGENT_DIR=<temporary-directory> npm run check` — 301 files and 2,991 tests passed
- `npm run typecheck --workspace @narumitw/pi-chrome-devtools`
- `npx vitest run packages/pi-chrome-devtools/test` — 65 tests passed
- `just pack chrome-devtools` — 16 expected files, including `src/lazy-tools.ts`
- offline `pi --no-extensions -e ./packages/pi-chrome-devtools --list-models` entrypoint smoke
- `npm run changeset:status` — minor release intent detected

## Semantic audits

- reviewed dynamic activation for purely additive loader execution and stable prompt metadata
- reviewed settings ordering, stale review detection, invalid-file protection, rollback, and unknown-field preservation
- reviewed session replacement, cancellation, shutdown, and browser lifecycle behavior
