### PR TITLE
feat(file-context): redesign command as quote menu

### DIFF
--- a/.changeset/clean-file-quotes.md
+++ b/.changeset/clean-file-quotes.md
@@ -1,5 +1,5 @@
 ---
-"@narumitw/pi-file-context": patch
+"@narumitw/pi-file-context": minor
 ---
 
-Add `/file-context remove` so users can remove one pending quote before submitting their next prompt.
+Redesign `/file-context` as an Add, Remove, and Help menu with exact quote previews, repeated removal, cancellable project scanning, and compatible direct `browse` and `remove` routes.

--- a/.changeset/clean-file-quotes.md
+++ b/.changeset/clean-file-quotes.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": patch
+---
+
+Add `/file-context remove` so users can remove one pending quote before submitting their next prompt.

--- a/docs/plans/archived/2026-08-12_pi-file-context-menu-redesign-plan.md
+++ b/docs/plans/archived/2026-08-12_pi-file-context-menu-redesign-plan.md
@@ -1,0 +1,45 @@
+# Pi File Context menu redesign plan
+
+## Goal
+
+Make `/file-context` open a clear File Context menu where users can add, inspect, and repeatedly remove pending quotes without remembering a subcommand.
+
+## Architecture
+
+- Keep quote snapshots, limits, injection order, and lifecycle ownership in `packages/pi-file-context/src/file-context.ts`.
+- Add a package-owned menu module that lazy-loads `@narumitw/pi-tui-kit`, projects current pending state into standard actions, choice, and detail screens, and delegates mutations to identity-safe callbacks.
+- Give each pending quote a session-local stable ID so duplicate paths, ranges, or snapshots never rely on display labels for removal.
+- Keep the configured shortcut as the direct explorer path, add `/file-context browse` as the explicit direct route, and retain `/file-context remove` as a compatibility route into the removal screen.
+- Use the session controller and generation checks across menu state loads, project scanning, explorer results, quote removal, session replacement, and shutdown.
+
+## Non-Goals
+
+- Do not add bulk clear, reorder, quote editing, persistence, or a settings menu.
+- Do not change file discovery, content search, Git provenance, quote limits, prompt injection syntax, or settings storage.
+- Do not support interactive File Context flows in RPC, JSON, or print mode.
+
+## Risks
+
+- Menu and custom explorer handoffs could lose Back versus Close semantics or leave stale components active.
+- Duplicate quote labels could remove the wrong snapshot unless stable identity is kept separate from display text.
+- Adding the Kit dependency could resolve an incompatible minor unless the package floor and lockfile are verified.
+- Narrow terminals and untrusted paths or quote text could overflow or inject controls into menu output.
+
+## Plan
+
+- [x] Add focused failing tests for the main menu, disabled empty removal, Help, compatibility routes, direct shortcut behavior, repeated identity-safe removal, cancellation, loading failure, lifecycle replacement, terminal sanitization, and constrained layouts; the first runs failed because the menu module did not exist and command completion lacked `browse`.
+- [x] Add the lazy-loaded File Context menu module and stable pending IDs; all 60 focused File Context tests pass with the Kit TUI harness.
+- [x] Refactor explorer launch ownership so menu Add uses cancellable discovery, root Escape returns to the menu, Ctrl+C closes the browser, and direct shortcut or `browse` behavior remains compatible; the Kit scan loader maps either cancel key to a side-effect-free return to the menu.
+- [x] Update package dependency metadata and lock resolution for the approved `@narumitw/pi-tui-kit` compatibility floor; root `npm install` resolves the package-local dependency to published version 0.51.0.
+- [x] Update the README, package layout, commands, quick start, experimental limitations, and existing Changeset for the redesigned published behavior.
+- [x] Audit the complete diff against `docs/extension-conventions.md`, including TUI-only mode handling, cancellation, disposal, stale awaits, sanitization, disabled reasons, widget state, unknown settings preservation, and independent installability; no settings storage changed and the proportionate no-confirmation removal trade-off remains as approved.
+- [x] Run focused File Context tests and typecheck, the isolated full repository check, Changeset status, and `just pack file-context`; `npm run check` passed 3,006 tests and the 13-file dry-run tarball contains the new menu source.
+
+## Completion Checklist
+
+- [x] `/file-context` opens a responsive Add, Remove, and Help menu with visible pending and shortcut state.
+- [x] Empty or limit-reached actions remain visible with textual reasons and cannot mutate state.
+- [x] A user can preview and remove several exact pending quotes in one menu visit.
+- [x] Back, Close, cancellation, errors, concurrent changes, session replacement, and shutdown preserve valid state and settle owned work.
+- [x] `F8`, `/file-context browse`, and `/file-context remove` remain tested compatibility paths.
+- [x] Documentation, dependency metadata, lockfile, Changeset, checks, and package contents match the implemented experience.

--- a/docs/plans/archived/2026-08-12_pi-file-context-pending-quote-removal-plan.md
+++ b/docs/plans/archived/2026-08-12_pi-file-context-pending-quote-removal-plan.md
@@ -1,0 +1,35 @@
+# Pi File Context pending quote removal plan
+
+## Goal
+
+Let a user remove one specific pending File Context quote before submitting the next prompt.
+
+## Architecture
+
+- Keep pending quote state inside `pi-file-context`, where attachment and lifecycle cleanup already live.
+- Add `/file-context remove` as a documented TUI-only route that opens a short selector containing each pending path and line range.
+- Treat selecting a row as the explicit remove action, while `Escape` or `Ctrl+C` closes the selector without changing pending quotes.
+- Revalidate the owning session, generation, and selected quote after the selector resolves so stale or concurrent flows cannot remove the wrong quote.
+- Refresh the existing package-owned widget after every removal and advertise the removal route beside the pending state.
+
+## Non-Goals
+
+- Do not add quote reordering, editing, persistence, or bulk clearing.
+- Do not change quote injection order or snapshot contents.
+- Do not add a settings option or a new shortcut.
+
+## Plan
+
+- [x] Add focused command tests for completion, removing one selected quote, selector cancellation, empty state, unsupported modes, and stale-session protection; the focused run failed in all four new behavior areas before implementation.
+- [x] Implement `/file-context remove`, safe pending-state removal, widget refresh, and strict argument handling; all 50 focused File Context tests and the package typecheck pass.
+- [x] Update the package README and add a patch Changeset for the published behavior.
+- [x] Audit command modes, user cancellation, selector failure recovery, session replacement, concurrent stale selection, widget lifecycle, terminal sanitization, and unchanged quote injection semantics against `docs/extension-conventions.md`; focused tests cover each changed path and no guide deviation remains.
+- [x] Run `npm run check`, inspect `just pack file-context`, and archive this completed plan; the isolated-agent-dir repository gate passed 2,996 tests and the dry-run tarball contains the expected 12 published files.
+
+## Completion Checklist
+
+- [x] A user can identify and remove one pending quote without affecting the others.
+- [x] Cancelling the removal selector has no side effects.
+- [x] Stale or concurrent selector results cannot remove a replacement-session quote or the wrong pending quote.
+- [x] `/file-context` browsing remains compatible and unknown or trailing arguments are rejected observably.
+- [x] Documentation, Changeset, focused tests, repository checks, and package smoke all pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9448,6 +9448,9 @@
 			"name": "@narumitw/pi-file-context",
 			"version": "0.51.1",
 			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.51.0"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",
 				"@earendil-works/pi-coding-agent": "0.84.1",
@@ -9457,6 +9460,28 @@
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
+			}
+		},
+		"packages/pi-file-context/node_modules/@narumitw/pi-tui-kit": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.51.0.tgz",
+			"integrity": "sha512-NH5G2GTegZwU7H5anGnTox7q+2PIhTOz6W+4YRgyYb9xuqLfOBBtY58xwoDxYqrgnmfycc0d9O6PvF37gWtzug==",
+			"license": "MIT",
+			"dependencies": {
+				"highlight.js": "11.11.1"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
+			}
+		},
+		"packages/pi-file-context/node_modules/highlight.js": {
+			"version": "11.11.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"packages/pi-firecrawl": {

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -11,14 +11,14 @@ Browse project files inside Pi, preview text, select a line range, and attach th
 
 ## ✨ Features
 
-- Opens the file explorer with a configurable shortcut that defaults to `F8`.
-- Provides `/file-context` as a discoverable fallback without replacing Pi's normal editor.
+- Opens the file explorer directly with a configurable shortcut that defaults to `F8`.
+- Provides a `/file-context` menu for adding quotes, previewing and repeatedly removing pending snapshots, and reviewing help without replacing Pi's normal editor.
 - Fuzzy-searches project file names with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
 - Switches with `Ctrl+F` to cancellable cwd content search with highlighted result cards, literal case-insensitive matching by default, and visible case-sensitive and fuzzy toggles.
 - Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
 - Selects a contiguous line range or changed hunk without using the system clipboard and shows a deterministic token estimate before attachment.
 - Discloses current-line blame and bounded file history, opens a validated commit/branch/tag version, and attaches explicit Git diff hunks.
-- Accumulates selected ranges in one compact pending-quote widget, lets you remove one with `/file-context remove`, and injects the remaining snapshots into the next ordinary interactive prompt.
+- Accumulates selected ranges in one compact pending-quote widget, lets you preview and remove exact snapshots from the menu, and injects the remaining snapshots into the next ordinary interactive prompt.
 - Skips common dependency, VCS, build, and coverage directories and does not follow symlinks during discovery.
 
 ## 📦 Install
@@ -43,15 +43,15 @@ pi -e ./packages/pi-file-context
 
 ## 🚀 Quick start
 
-1. Press `F8` or run `/file-context`.
+1. Run `/file-context` and choose **Add file quote**. Press `F8` or run `/file-context browse` to open the browser directly.
 2. Type to fuzzy-search file names in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
 3. Press `Ctrl+F` to switch between file-name and content search. Content search is literal and case-insensitive by default; `Alt+C` toggles case sensitivity and `Alt+F` toggles ordered fuzzy matching. The current states remain visible above the results.
 4. In content results, use `Up`/`Down` to choose a highlighted path-and-line card. Press `Tab` for a whole-file reference or `Enter` to preview the file at that line. `Escape` from the preview restores the query, result selection, and scroll position.
 5. In the preview, press `Space` to anchor the selection. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
 6. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.
-7. Repeat from the shortcut to attach more ranges from the same or different files. Run `/file-context remove` to choose and remove one pending quote, or press `Escape`/`Ctrl+C` in that selector to keep every quote. Then write the question and submit normally. All remaining quotes are attached in selection order and cleared together.
+7. Repeat from the menu or shortcut to attach more ranges from the same or different files. Open `/file-context`, choose **Remove pending quote**, preview the selected snapshot, and press `Enter` to remove it. The removal list stays open for more removals. `Escape` goes back without changing quotes, while `Ctrl+C` closes File Context. Then write the question and submit normally. All remaining quotes are attached in selection order and cleared together.
 
-`Escape` returns from a preview to its originating file-name or content results; from either search screen it cancels without changing the draft. `Ctrl+C` cancels from every view.
+`Escape` returns from a preview to its originating file-name or content results. When the browser was opened from the menu, `Escape` from a root search returns to the menu. Direct browser routes cancel instead. `Ctrl+C` closes menus and browsers. During project scanning, either cancel key stops the scan and returns to the menu.
 
 The agent receives an explicit block similar to:
 
@@ -77,7 +77,7 @@ The file is not created when defaults are used.
 }
 ```
 
-Set `openShortcut` to any valid Pi key identifier, or set it to `null` to disable the shortcut and use `/file-context` only.
+Set `openShortcut` to any valid Pi key identifier, or set it to `null` to disable the direct browser shortcut and use the `/file-context` menu.
 
 Run `/reload` after editing the file because Pi registers extension shortcuts during extension loading.
 
@@ -91,8 +91,9 @@ The previous `Ctrl+Alt+F` default depended on terminal modifier support and may 
 
 | Command | Mode | Description |
 | --- | --- | --- |
-| `/file-context` | TUI only | Open the file explorer. |
-| `/file-context remove` | TUI only | Choose and remove one pending quote. |
+| `/file-context` | TUI only | Open the Add, Remove, and Help menu. |
+| `/file-context browse` | TUI only | Open the file explorer directly. |
+| `/file-context remove` | TUI only | Open pending quote removal directly for compatibility. |
 
 Unknown and trailing arguments are rejected. RPC receives an observable warning. JSON and print modes do not enter interactive UI.
 
@@ -114,7 +115,7 @@ Unknown and trailing arguments are rejected. RPC receives an observable warning.
 ## 🧪 Experimental limitations
 
 - Keyboard line selection only; mouse drag selection is not implemented.
-- Up to eight pending quotes; removal is supported, but there is not yet a reorder action.
+- Up to eight pending quotes; repeated removal is supported, but there are not yet bulk clear or reorder actions.
 - Pending quotes do not survive `/reload`, session replacement, or shutdown.
 - The configurable shortcut is registered without replacing another extension's custom editor; `/file-context` remains available if the shortcut is disabled or conflicts.
 - File discovery uses a small built-in ignore list rather than `.gitignore` semantics.
@@ -127,7 +128,8 @@ Unknown and trailing arguments are rejected. RPC receives an observable warning.
 
 ```text
 src/index.ts                   Thin Pi entrypoint
-src/file-context.ts            Lifecycle, shortcut registration, filesystem boundaries, quote injection
+src/file-context.ts            Lifecycle, routes, filesystem boundaries, pending state, quote injection
+src/file-context-menu.ts       Standard Add, Remove, preview, Help, and disabled-state menu flow
 src/file-context-settings.ts   User shortcut loading and validation
 src/file-context-explorer.ts   File list, Git detail views, and line-range TUI
 src/content-search.ts          Bounded literal and fuzzy content matching
@@ -139,7 +141,9 @@ src/git-context.ts             Bounded read-only Git status, diff, blame, histor
 test/content-search.test.ts     Content matcher behavior and limits
 test/content-search-ui.test.ts  Content interaction, rendering, and lifecycle tests
 test/file-context.test.ts       Filesystem, prompt, lifecycle, shortcut, and explorer tests
-test/pending-quotes.test.ts     Pending quote removal, cancellation, and stale-flow tests
+test/file-context-menu.test.ts  Menu states, navigation, previews, limits, and responsive rendering tests
+test/file-context-command-menu.test.ts  Command routes, loading, and direct browser compatibility tests
+test/pending-quotes.test.ts     Exact pending quote removal, cancellation, and stale-flow tests
 test/file-context-settings.test.ts  Shortcut settings defaults and validation tests
 test/git-context.test.ts        Git repository behavior and parser tests
 ```

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -18,7 +18,7 @@ Browse project files inside Pi, preview text, select a line range, and attach th
 - Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
 - Selects a contiguous line range or changed hunk without using the system clipboard and shows a deterministic token estimate before attachment.
 - Discloses current-line blame and bounded file history, opens a validated commit/branch/tag version, and attaches explicit Git diff hunks.
-- Accumulates selected ranges in one compact pending-quote widget and injects every snapshot into the next ordinary interactive prompt.
+- Accumulates selected ranges in one compact pending-quote widget, lets you remove one with `/file-context remove`, and injects the remaining snapshots into the next ordinary interactive prompt.
 - Skips common dependency, VCS, build, and coverage directories and does not follow symlinks during discovery.
 
 ## 📦 Install
@@ -49,7 +49,7 @@ pi -e ./packages/pi-file-context
 4. In content results, use `Up`/`Down` to choose a highlighted path-and-line card. Press `Tab` for a whole-file reference or `Enter` to preview the file at that line. `Escape` from the preview restores the query, result selection, and scroll position.
 5. In the preview, press `Space` to anchor the selection. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
 6. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.
-7. Repeat from the shortcut to attach more ranges from the same or different files, then write the question and submit normally. All pending quotes are attached in selection order and then cleared together.
+7. Repeat from the shortcut to attach more ranges from the same or different files. Run `/file-context remove` to choose and remove one pending quote, or press `Escape`/`Ctrl+C` in that selector to keep every quote. Then write the question and submit normally. All remaining quotes are attached in selection order and cleared together.
 
 `Escape` returns from a preview to its originating file-name or content results; from either search screen it cancels without changing the draft. `Ctrl+C` cancels from every view.
 
@@ -91,9 +91,10 @@ The previous `Ctrl+Alt+F` default depended on terminal modifier support and may 
 
 | Command | Mode | Description |
 | --- | --- | --- |
-| `/file-context` | TUI only | Open the file explorer. Arguments are rejected. |
+| `/file-context` | TUI only | Open the file explorer. |
+| `/file-context remove` | TUI only | Choose and remove one pending quote. |
 
-RPC receives an observable warning. JSON and print modes do not enter custom UI.
+Unknown and trailing arguments are rejected. RPC receives an observable warning. JSON and print modes do not enter interactive UI.
 
 ## 🔒 Security and limits
 
@@ -113,7 +114,7 @@ RPC receives an observable warning. JSON and print modes do not enter custom UI.
 ## 🧪 Experimental limitations
 
 - Keyboard line selection only; mouse drag selection is not implemented.
-- Up to eight pending quotes; there is not yet an interactive remove/reorder action.
+- Up to eight pending quotes; removal is supported, but there is not yet a reorder action.
 - Pending quotes do not survive `/reload`, session replacement, or shutdown.
 - The configurable shortcut is registered without replacing another extension's custom editor; `/file-context` remains available if the shortcut is disabled or conflicts.
 - File discovery uses a small built-in ignore list rather than `.gitignore` semantics.
@@ -138,6 +139,7 @@ src/git-context.ts             Bounded read-only Git status, diff, blame, histor
 test/content-search.test.ts     Content matcher behavior and limits
 test/content-search-ui.test.ts  Content interaction, rendering, and lifecycle tests
 test/file-context.test.ts       Filesystem, prompt, lifecycle, shortcut, and explorer tests
+test/pending-quotes.test.ts     Pending quote removal, cancellation, and stale-flow tests
 test/file-context-settings.test.ts  Shortcut settings defaults and validation tests
 test/git-context.test.ts        Git repository behavior and parser tests
 ```

--- a/packages/pi-file-context/package.json
+++ b/packages/pi-file-context/package.json
@@ -32,6 +32,9 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.51.0"
+	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*",
 		"@earendil-works/pi-tui": "*"

--- a/packages/pi-file-context/src/file-context-explorer.ts
+++ b/packages/pi-file-context/src/file-context-explorer.ts
@@ -35,7 +35,9 @@ const DIFF_CHROME_ROWS = 3;
 
 export type FileQuoteExplorerResult =
 	| { kind: "quote"; quote: FileQuote }
-	| { kind: "reference"; path: string };
+	| { kind: "reference"; path: string }
+	| { kind: "back" }
+	| { kind: "close" };
 
 interface FileQuoteExplorerOptions {
 	tui: TUI;
@@ -45,6 +47,7 @@ interface FileQuoteExplorerOptions {
 	cwd?: string;
 	loadFile: (path: string, signal?: AbortSignal) => Promise<LoadedProjectTextFile>;
 	gitContext?: GitContext;
+	rootNavigation?: boolean;
 	done: (result: FileQuoteExplorerResult | undefined) => void;
 }
 
@@ -100,7 +103,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 			},
 			onReference: (path) => this.finish({ kind: "reference", path }),
 			onSwitchFiles: () => this.showFileSearch(),
-			onCancel: () => this.finish(undefined),
+			onCancel: () => this.finish(this.rootExit("back")),
 		});
 	}
 
@@ -128,7 +131,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 	handleInput(data: string): void {
 		if (this.finished || this.disposed) return;
 		if (matchesKey(data, Key.ctrl("c"))) {
-			this.finish(undefined);
+			this.finish(this.rootExit("close"));
 			return;
 		}
 		if (this.mode === "files") this.handleFileInput(data);
@@ -414,7 +417,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 			return;
 		}
 		if (matchesKey(data, Key.escape)) {
-			this.finish(undefined);
+			this.finish(this.rootExit("back"));
 			return;
 		}
 		if (this.loading) return;
@@ -909,6 +912,10 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.cancelOpenRequest();
 		this.cancelDetailRequest();
 		this.options.done(result);
+	}
+
+	private rootExit(kind: "back" | "close"): FileQuoteExplorerResult | undefined {
+		return this.options.rootNavigation ? { kind } : undefined;
 	}
 
 	private getSelectionRange(): { start: number; end: number } {

--- a/packages/pi-file-context/src/file-context-menu.ts
+++ b/packages/pi-file-context/src/file-context-menu.ts
@@ -1,0 +1,204 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { RunMenuResult } from "@narumitw/pi-tui-kit";
+
+export interface FileContextMenuQuote {
+	id: string;
+	path: string;
+	startLine: number;
+	endLine: number;
+	text: string;
+}
+
+export interface FileContextMenuState {
+	quotes: readonly FileContextMenuQuote[];
+	shortcut: string | null;
+	maximumQuotes: number;
+	maximumBytes: number;
+	totalBytes: number;
+}
+
+export type FileContextMenuAddResult = "stay" | "close";
+
+export type FileContextMenuRemovalResult =
+	| { kind: "removed"; quote: FileContextMenuQuote; remaining: number }
+	| { kind: "missing" };
+
+export interface FileContextMenuOptions {
+	start?: "main" | "remove";
+	signal: AbortSignal;
+	isCurrent(): boolean;
+	getState(): FileContextMenuState | Promise<FileContextMenuState>;
+	addQuote(signal: AbortSignal): FileContextMenuAddResult | Promise<FileContextMenuAddResult>;
+	removeQuote(
+		id: string,
+		signal: AbortSignal,
+	): FileContextMenuRemovalResult | Promise<FileContextMenuRemovalResult>;
+}
+
+type Screen = "main" | "remove" | "help";
+type Action = "add" | "remove";
+
+export async function showFileContextMenu(
+	ctx: ExtensionCommandContext,
+	options: FileContextMenuOptions,
+): Promise<RunMenuResult> {
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!options.isCurrent() || options.signal.aborted) return { kind: "stale" };
+
+	let addRequested = false;
+	const menu = defineMenu<FileContextMenuState, Screen, Action, ExtensionCommandContext>({
+		start: options.start ?? "main",
+		screens: {
+			main: ({ state }) => ({
+				kind: "actions",
+				title: "File Context",
+				lines: [
+					`Pending quotes: ${state.quotes.length}/${state.maximumQuotes} · ~${estimateTokens(state.totalBytes)} tokens`,
+					`Shortcut: ${formatShortcut(state.shortcut)}`,
+				],
+				items: [
+					{
+						id: "add",
+						label: "Add file quote",
+						description: "Browse project files and select lines",
+						action: "add",
+						busyLabel: "Scanning project files",
+						disabled: addDisabledReason(state) !== undefined,
+						disabledReason: addDisabledReason(state),
+					},
+					{
+						id: "remove",
+						label: `Remove pending quote (${state.quotes.length})`,
+						description: "Preview and remove exact snapshots",
+						to: "remove",
+						disabled: state.quotes.length === 0,
+						disabledReason: state.quotes.length === 0 ? "No pending quotes to remove" : undefined,
+					},
+					{
+						id: "help",
+						label: "Help",
+						description: "Review shortcuts and attachment behavior",
+						to: "help",
+					},
+				],
+				hint: "close",
+			}),
+			remove: ({ state }) => ({
+				kind: "choice",
+				title: "Remove pending quote",
+				lines: [`${state.quotes.length} pending · choose one exact snapshot to remove`],
+				items: state.quotes.map((quote, index) => ({
+					id: quote.id,
+					label: `${index + 1}. ${quote.path}`,
+					description: `lines ${quote.startLine}-${quote.endLine} · ~${estimateTokens(Buffer.byteLength(quote.text, "utf8"))} tokens`,
+					details: [
+						`Path: ${quote.path}`,
+						`Lines: ${quote.startLine}-${quote.endLine}`,
+						`Preview: ${singleLinePreview(quote.text)}`,
+					],
+				})),
+				action: "remove",
+				viewportSize: 8,
+				hint: "back",
+			}),
+			help: () => ({
+				kind: "detail",
+				title: "File Context help",
+				lines: [
+					"Add file quote opens the project browser. Select a file, preview it, and press Enter to attach the selected line or range.",
+					"Pending quotes are attached in order to your next prompt, then cleared together.",
+					"Use Remove pending quote to preview and remove exact snapshots without changing the others.",
+					"The configured shortcut and /file-context browse open the browser directly.",
+					"Escape goes back. Ctrl+C closes File Context. Cancelling never changes pending quotes.",
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			add: () => {
+				addRequested = true;
+				return { kind: "close" };
+			},
+			remove: async ({ itemId, signal }) => {
+				const result = await options.removeQuote(itemId, signal);
+				if (signal.aborted || !options.isCurrent()) return { kind: "close" };
+				if (result.kind === "missing") {
+					ctx.ui.notify("That quote is no longer pending. The list was refreshed.", "warning");
+					return { kind: "stay" };
+				}
+				ctx.ui.notify(
+					`Removed pending quote: ${safeTerminalText(result.quote.path)} · lines ${result.quote.startLine}-${result.quote.endLine}.`,
+					"info",
+				);
+				return result.remaining === 0 ? { kind: "back" } : { kind: "stay" };
+			},
+		},
+	});
+
+	while (options.isCurrent() && !options.signal.aborted) {
+		addRequested = false;
+		const result = await runMenu(ctx, menu, {
+			getState: () => options.getState(),
+			signal: options.signal,
+			isCurrent: options.isCurrent,
+			onError: (_menuContext, error) => {
+				ctx.ui.notify(
+					`File Context menu failed: ${safeTerminalText(formatError(error))}. Pending quotes were kept; try again.`,
+					"error",
+				);
+			},
+			onUnsupportedMode: (_menuContext, mode) => {
+				ctx.ui.notify(`File Context is unavailable in ${mode} mode.`, "warning");
+			},
+		});
+		if (!addRequested || result.kind !== "closed") return result;
+		const addResult = await options.addQuote(options.signal);
+		if (!options.isCurrent() || options.signal.aborted) return { kind: "stale" };
+		if (addResult === "close") return { kind: "closed", reason: "close" };
+	}
+	return { kind: "stale" };
+}
+
+function addDisabledReason(state: FileContextMenuState): string | undefined {
+	if (state.quotes.length >= state.maximumQuotes) {
+		return `The ${state.maximumQuotes}-quote limit is reached; remove a quote first`;
+	}
+	if (state.totalBytes >= state.maximumBytes) {
+		return `The ${formatBytes(state.maximumBytes)} pending limit is reached; remove a quote first`;
+	}
+	return undefined;
+}
+
+function formatShortcut(shortcut: string | null): string {
+	return shortcut ? shortcut.toUpperCase() : "Disabled (use /file-context browse)";
+}
+
+function singleLinePreview(text: string): string {
+	const normalized = text.replaceAll("\r\n", "\n").replaceAll("\r", "\n").split("\n").join(" ↵ ");
+	const characters = [...normalized];
+	if (characters.length === 0) return "(empty)";
+	return characters.length <= 200 ? normalized : `${characters.slice(0, 199).join("")}…`;
+}
+
+function estimateTokens(bytes: number): number {
+	return bytes === 0 ? 0 : Math.max(1, Math.ceil(bytes / 4));
+}
+
+function formatBytes(bytes: number): string {
+	return bytes % 1_000 === 0 ? `${bytes / 1_000} KB` : `${bytes} bytes`;
+}
+
+function safeTerminalText(text: string): string {
+	return [...text]
+		.map((character) => {
+			const code = character.charCodeAt(0);
+			return code <= 31 || (code >= 127 && code <= 159)
+				? `\\x${code.toString(16).padStart(2, "0")}`
+				: character;
+		})
+		.join("");
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -4,10 +4,12 @@ import { lstat, open, readdir, realpath } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
 	type ExtensionAPI,
+	type ExtensionCommandContext,
 	type ExtensionContext,
 	getAgentDir,
 } from "@earendil-works/pi-coding-agent";
 import { FileQuoteExplorer, type FileQuoteExplorerResult } from "./file-context-explorer.js";
+import { type FileContextMenuQuote, showFileContextMenu } from "./file-context-menu.js";
 import {
 	type LoadedFileContextSettings,
 	loadFileContextSettings,
@@ -74,6 +76,20 @@ interface ActiveExplorer {
 	controller: AbortController;
 	component?: FileQuoteExplorer;
 }
+
+interface PendingQuote {
+	id: string;
+	quote: FileQuote;
+}
+
+interface ExplorerRunOptions {
+	menuOwned?: boolean;
+	signal?: AbortSignal;
+	showScanTask?: boolean;
+}
+
+type ExplorerRunResult = "stay" | "close";
+type ExplorerDiscovery = [string[], Awaited<ReturnType<typeof createGitContext>>];
 
 export async function discoverProjectFiles(
 	root: string,
@@ -274,6 +290,8 @@ export function formatQuoteContext(quotes: readonly FileQuote[]): string {
 
 interface FileQuoteExtensionDependencies {
 	loadSettings?: () => Promise<LoadedFileContextSettings>;
+	discoverFiles?: typeof discoverProjectFiles;
+	createGit?: typeof createGitContext;
 }
 
 export async function registerFileQuoteExtension(
@@ -284,11 +302,16 @@ export async function registerFileQuoteExtension(
 		dependencies.loadSettings ??
 		(() => loadFileContextSettings(join(getAgentDir(), "pi-file-context.json")))
 	)();
-	let pendingQuotes: FileQuote[] = [];
+	const discoverFiles = dependencies.discoverFiles ?? discoverProjectFiles;
+	const createGit = dependencies.createGit ?? createGitContext;
+	let pendingQuotes: PendingQuote[] = [];
+	let nextPendingQuoteId = 1;
 	let activeSessionManager: unknown;
 	let sessionGeneration = 0;
+	let sessionController = new AbortController();
 	const activeExplorers = new Set<ActiveExplorer>();
 	let activeExplorerLaunch: { promise: Promise<void> } | undefined;
+	let activeMenuLaunch: { promise: Promise<void> } | undefined;
 
 	const updatePendingWidget = (ctx: ExtensionContext) => {
 		if (!ctx.hasUI) return;
@@ -297,18 +320,18 @@ export async function registerFileQuoteExtension(
 			return;
 		}
 		const totalBytes = pendingQuotes.reduce(
-			(total, item) => total + Buffer.byteLength(item.text, "utf8"),
+			(total, item) => total + Buffer.byteLength(item.quote.text, "utf8"),
 			0,
 		);
 		ctx.ui.setWidget(WIDGET_KEY, [
 			ctx.ui.theme.fg(
 				"accent",
-				`Quotes (${pendingQuotes.length}) · ~${estimateTokens(totalBytes)} tokens · /file-context remove`,
+				`Quotes (${pendingQuotes.length}) · ~${estimateTokens(totalBytes)} tokens · /file-context to manage`,
 			),
-			...pendingQuotes.map((item, index) =>
+			...pendingQuotes.map(({ quote }, index) =>
 				ctx.ui.theme.fg(
 					"muted",
-					`${index + 1}. ${escapeTerminalControls(item.path)} · lines ${item.startLine}-${item.endLine} · ~${estimateTokens(Buffer.byteLength(item.text, "utf8"))} tokens`,
+					`${index + 1}. ${escapeTerminalControls(quote.path)} · lines ${quote.startLine}-${quote.endLine} · ~${estimateTokens(Buffer.byteLength(quote.text, "utf8"))} tokens`,
 				),
 			),
 		]);
@@ -316,91 +339,91 @@ export async function registerFileQuoteExtension(
 
 	const clearPending = (ctx: ExtensionContext) => {
 		pendingQuotes = [];
+		nextPendingQuoteId = 1;
 		updatePendingWidget(ctx);
 	};
 
 	const appendPending = (quote: FileQuote, ctx: ExtensionContext) => {
-		pendingQuotes = appendPendingQuote(pendingQuotes, quote);
+		appendPendingQuote(
+			pendingQuotes.map((item) => item.quote),
+			quote,
+		);
+		pendingQuotes = [...pendingQuotes, { id: `quote-${nextPendingQuoteId}`, quote }];
+		nextPendingQuoteId += 1;
 		updatePendingWidget(ctx);
 	};
 
 	const isCurrentSession = (owner: unknown, generation: number) =>
 		owner === activeSessionManager && generation === sessionGeneration;
 
-	const removePending = async (ctx: ExtensionContext): Promise<void> => {
-		if (ctx.mode !== "tui") {
-			rejectCommand(ctx, "File Context requires Pi's interactive TUI.");
-			return;
-		}
-		const owner = ctx.sessionManager;
-		const generation = sessionGeneration;
-		if (!isCurrentSession(owner, generation)) return;
-		if (pendingQuotes.length === 0) {
-			ctx.ui.notify("File Context has no pending quotes.", "warning");
-			return;
-		}
-		const choices = pendingQuotes.map((quote, index) => ({
-			label: `${index + 1}. ${escapeTerminalControls(quote.path)} · lines ${quote.startLine}-${quote.endLine}`,
-			quote,
-		}));
-		let selectedLabel: string | undefined;
-		try {
-			selectedLabel = await ctx.ui.select(
-				"Remove a pending quote",
-				choices.map(({ label }) => label),
-			);
-		} catch (error: unknown) {
-			if (!isCurrentSession(owner, generation)) return;
-			ctx.ui.notify(
-				`File Context could not remove a quote: ${escapeTerminalControls(formatError(error))}. Pending quotes were kept; run /file-context remove to retry.`,
-				"error",
-			);
-			return;
-		}
-		if (!isCurrentSession(owner, generation) || selectedLabel === undefined) return;
-		const selected = choices.find(({ label }) => label === selectedLabel);
-		if (!selected) return;
-		const currentIndex = pendingQuotes.indexOf(selected.quote);
-		if (currentIndex === -1) {
-			ctx.ui.notify("That quote is no longer pending.", "warning");
-			return;
-		}
-		pendingQuotes = pendingQuotes.filter((_quote, index) => index !== currentIndex);
-		updatePendingWidget(ctx);
-		ctx.ui.notify(
-			`Removed pending quote: ${escapeTerminalControls(selected.quote.path)} · lines ${selected.quote.startLine}-${selected.quote.endLine}.`,
-			"info",
-		);
-	};
+	const menuQuote = ({ id, quote }: PendingQuote): FileContextMenuQuote => ({
+		id,
+		path: quote.path,
+		startLine: quote.startLine,
+		endLine: quote.endLine,
+		text: quote.text,
+	});
 
 	const cancelExplorers = () => {
 		activeExplorerLaunch = undefined;
 		for (const explorer of activeExplorers) {
-			explorer.controller.abort();
+			explorer.controller.abort(new DOMException("File Context explorer closed", "AbortError"));
 			explorer.component?.dispose();
 		}
 		activeExplorers.clear();
 	};
 
-	const runExplorer = async (ctx: ExtensionContext): Promise<void> => {
+	const runExplorer = async (
+		ctx: ExtensionContext,
+		options: ExplorerRunOptions = {},
+	): Promise<ExplorerRunResult> => {
 		if (ctx.mode !== "tui") {
 			rejectCommand(ctx, "File Context requires Pi's interactive TUI.");
-			return;
+			return "close";
 		}
 		const owner = ctx.sessionManager;
 		const generation = sessionGeneration;
 		const activeExplorer: ActiveExplorer = { controller: new AbortController() };
 		const { controller } = activeExplorer;
+		const flowSignal = options.signal
+			? AbortSignal.any([controller.signal, options.signal])
+			: controller.signal;
 		activeExplorers.add(activeExplorer);
 		try {
-			const [files, gitContext] = await Promise.all([
-				discoverProjectFiles(ctx.cwd, { signal: controller.signal }),
-				createGitContext(ctx.cwd, controller.signal),
-			]);
-			if (!isCurrentSession(owner, generation) || controller.signal.aborted) return;
+			let discovery: ExplorerDiscovery;
+			if (options.showScanTask) {
+				const { runTask } = await import("@narumitw/pi-tui-kit");
+				if (!isCurrentSession(owner, generation) || flowSignal.aborted) return "close";
+				const task = await runTask(ctx, {
+					label: "Scanning project files…",
+					signal: flowSignal,
+					isCurrent: () => isCurrentSession(owner, generation) && !flowSignal.aborted,
+					task: ({ signal }) =>
+						Promise.all([discoverFiles(ctx.cwd, { signal }), createGit(ctx.cwd, signal)]),
+					onError: (_taskContext, error) => {
+						ctx.ui.notify(
+							`File Context could not scan project files: ${escapeTerminalControls(formatError(error))}. Choose Add file quote to retry.`,
+							"error",
+						);
+					},
+				});
+				if (task.kind === "cancelled" || task.kind === "error") return "stay";
+				if (task.kind === "stale") return "close";
+				discovery = task.value;
+			} else {
+				discovery = await Promise.all([
+					discoverFiles(ctx.cwd, { signal: flowSignal }),
+					createGit(ctx.cwd, flowSignal),
+				]);
+			}
+			if (!isCurrentSession(owner, generation) || flowSignal.aborted) return "close";
+			const [files, gitContext] = discovery;
 			if (files.length === 0) {
-				ctx.ui.notify("File Context found no project files.", "warning");
-				return;
+				ctx.ui.notify(
+					"File Context found no project files. Choose Add file quote to retry.",
+					"warning",
+				);
+				return options.menuOwned ? "stay" : "close";
 			}
 			const result = await ctx.ui.custom<FileQuoteExplorerResult | undefined>(
 				(tui, theme, keybindings, done) => {
@@ -412,31 +435,37 @@ export async function registerFileQuoteExtension(
 						cwd: ctx.cwd,
 						loadFile: (path, signal) => loadProjectTextFile(ctx.cwd, path, { signal }),
 						gitContext,
+						rootNavigation: options.menuOwned,
 						done,
 					});
 					activeExplorer.component = component;
-					if (controller.signal.aborted) component.dispose();
+					if (flowSignal.aborted) component.dispose();
 					return component;
 				},
 			);
-			if (!isCurrentSession(owner, generation) || controller.signal.aborted) return;
-			if (result?.kind === "quote") appendPending(result.quote, ctx);
-			else if (result?.kind === "reference") {
-				ctx.ui.pasteToEditor(formatFileReference(result.path));
+			if (!isCurrentSession(owner, generation) || flowSignal.aborted) return "close";
+			if (result?.kind === "quote") {
+				appendPending(result.quote, ctx);
+				return "close";
 			}
+			if (result?.kind === "reference") {
+				ctx.ui.pasteToEditor(formatFileReference(result.path));
+				return "close";
+			}
+			return result?.kind === "back" ? "stay" : "close";
 		} catch (error: unknown) {
-			if (
-				!isCurrentSession(owner, generation) ||
-				controller.signal.aborted ||
-				isAbortError(error)
-			) {
-				return;
+			if (!isCurrentSession(owner, generation) || flowSignal.aborted || isAbortError(error)) {
+				return "close";
 			}
 			try {
-				ctx.ui.notify(`File Context failed: ${formatError(error)}`, "error");
+				ctx.ui.notify(
+					`File Context failed: ${escapeTerminalControls(formatError(error))}. Choose Add file quote to retry.`,
+					"error",
+				);
 			} catch {
 				// The session may have been replaced while the picker was open.
 			}
+			return options.menuOwned ? "stay" : "close";
 		} finally {
 			activeExplorers.delete(activeExplorer);
 		}
@@ -444,7 +473,8 @@ export async function registerFileQuoteExtension(
 
 	const openExplorer = (ctx: ExtensionContext): Promise<void> => {
 		if (activeExplorerLaunch) return activeExplorerLaunch.promise;
-		const launch = { promise: runExplorer(ctx) };
+		if (activeMenuLaunch) return activeMenuLaunch.promise;
+		const launch = { promise: runExplorer(ctx).then(() => undefined) };
 		activeExplorerLaunch = launch;
 		const clearLaunch = () => {
 			if (activeExplorerLaunch === launch) activeExplorerLaunch = undefined;
@@ -453,31 +483,94 @@ export async function registerFileQuoteExtension(
 		return launch.promise;
 	};
 
-	const handleFileContextCommand = async (args: string, ctx: ExtensionContext) => {
+	const openMenu = (
+		ctx: ExtensionCommandContext,
+		start: "main" | "remove" = "main",
+	): Promise<void> => {
+		if (ctx.mode !== "tui") {
+			rejectCommand(ctx, "File Context requires Pi's interactive TUI.");
+			return Promise.resolve();
+		}
+		if (activeMenuLaunch) return activeMenuLaunch.promise;
+		if (activeExplorerLaunch) return activeExplorerLaunch.promise;
+		if (start === "remove" && pendingQuotes.length === 0) {
+			ctx.ui.notify("File Context has no pending quotes.", "warning");
+			return Promise.resolve();
+		}
+		const owner = ctx.sessionManager;
+		const generation = sessionGeneration;
+		const ownerController = sessionController;
+		const isCurrent = () =>
+			isCurrentSession(owner, generation) &&
+			ownerController === sessionController &&
+			!ownerController.signal.aborted;
+		const promise = showFileContextMenu(ctx, {
+			start,
+			signal: ownerController.signal,
+			isCurrent,
+			getState: () => {
+				if (!isCurrent()) throw new DOMException("File Context session replaced", "AbortError");
+				const quotes = pendingQuotes.map(menuQuote);
+				return {
+					quotes,
+					shortcut: loadedSettings.settings.openShortcut,
+					maximumQuotes: MAX_PENDING_QUOTES,
+					maximumBytes: MAX_PENDING_QUOTE_BYTES,
+					totalBytes: quotes.reduce(
+						(total, quote) => total + Buffer.byteLength(quote.text, "utf8"),
+						0,
+					),
+				};
+			},
+			addQuote: (signal) => runExplorer(ctx, { menuOwned: true, showScanTask: true, signal }),
+			removeQuote: (id, signal) => {
+				if (!isCurrent() || signal.aborted) return { kind: "missing" };
+				const index = pendingQuotes.findIndex((item) => item.id === id);
+				const selected = pendingQuotes[index];
+				if (!selected) return { kind: "missing" };
+				pendingQuotes = pendingQuotes.filter((_item, itemIndex) => itemIndex !== index);
+				updatePendingWidget(ctx);
+				return {
+					kind: "removed",
+					quote: menuQuote(selected),
+					remaining: pendingQuotes.length,
+				};
+			},
+		}).then(() => undefined);
+		const launch = { promise };
+		activeMenuLaunch = launch;
+		const clearLaunch = () => {
+			if (activeMenuLaunch === launch) activeMenuLaunch = undefined;
+		};
+		void promise.then(clearLaunch, clearLaunch);
+		return promise;
+	};
+
+	const handleFileContextCommand = async (args: string, ctx: ExtensionCommandContext) => {
 		const normalized = args.trim().toLowerCase();
 		if (!normalized) {
+			await openMenu(ctx);
+			return;
+		}
+		if (normalized === "browse") {
 			await openExplorer(ctx);
 			return;
 		}
 		if (normalized === "remove") {
-			await removePending(ctx);
+			await openMenu(ctx, "remove");
 			return;
 		}
-		rejectCommand(ctx, "Usage: /file-context [remove]");
+		rejectCommand(ctx, "Usage: /file-context [browse|remove]");
 	};
 	pi.registerCommand("file-context", {
-		description: "Browse project files or remove a pending quote",
+		description: "Open the File Context menu",
 		getArgumentCompletions: (prefix) => {
 			const normalized = prefix.trimStart().toLowerCase();
-			return "remove".startsWith(normalized)
-				? [
-						{
-							value: "remove",
-							label: "remove",
-							description: "Remove one pending quote",
-						},
-					]
-				: null;
+			const completions = [
+				{ value: "browse", label: "browse", description: "Open the file browser directly" },
+				{ value: "remove", label: "remove", description: "Manage pending quotes directly" },
+			].filter(({ value }) => value.startsWith(normalized));
+			return completions.length > 0 ? completions : null;
 		},
 		handler: handleFileContextCommand,
 	});
@@ -489,6 +582,9 @@ export async function registerFileQuoteExtension(
 	}
 
 	pi.on("session_start", (_event, ctx) => {
+		sessionController.abort(new DOMException("File Context session replaced", "AbortError"));
+		sessionController = new AbortController();
+		activeMenuLaunch = undefined;
 		cancelExplorers();
 		activeSessionManager = ctx.sessionManager;
 		sessionGeneration += 1;
@@ -498,15 +594,15 @@ export async function registerFileQuoteExtension(
 		const shortcut = loadedSettings.settings.openShortcut;
 		ctx.ui.notify(
 			shortcut
-				? `Experimental File Context loaded. Press ${shortcut} or run /file-context.`
-				: "Experimental File Context loaded. Run /file-context to browse files.",
+				? `Experimental File Context loaded. Press ${shortcut} to browse or run /file-context to manage quotes.`
+				: "Experimental File Context loaded. Run /file-context to add or manage quotes.",
 			"warning",
 		);
 	});
 
 	pi.on("before_agent_start", (_event, ctx) => {
 		if (ctx.sessionManager !== activeSessionManager || pendingQuotes.length === 0) return;
-		const quotes = pendingQuotes;
+		const quotes = pendingQuotes.map((item) => item.quote);
 		clearPending(ctx);
 		return {
 			message: {
@@ -519,6 +615,8 @@ export async function registerFileQuoteExtension(
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (ctx.sessionManager !== activeSessionManager) return;
+		sessionController.abort(new DOMException("File Context session shut down", "AbortError"));
+		activeMenuLaunch = undefined;
 		cancelExplorers();
 		clearPending(ctx);
 	});

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -290,35 +290,88 @@ export async function registerFileQuoteExtension(
 	const activeExplorers = new Set<ActiveExplorer>();
 	let activeExplorerLaunch: { promise: Promise<void> } | undefined;
 
+	const updatePendingWidget = (ctx: ExtensionContext) => {
+		if (!ctx.hasUI) return;
+		if (pendingQuotes.length === 0) {
+			ctx.ui.setWidget(WIDGET_KEY, undefined);
+			return;
+		}
+		const totalBytes = pendingQuotes.reduce(
+			(total, item) => total + Buffer.byteLength(item.text, "utf8"),
+			0,
+		);
+		ctx.ui.setWidget(WIDGET_KEY, [
+			ctx.ui.theme.fg(
+				"accent",
+				`Quotes (${pendingQuotes.length}) · ~${estimateTokens(totalBytes)} tokens · /file-context remove`,
+			),
+			...pendingQuotes.map((item, index) =>
+				ctx.ui.theme.fg(
+					"muted",
+					`${index + 1}. ${escapeTerminalControls(item.path)} · lines ${item.startLine}-${item.endLine} · ~${estimateTokens(Buffer.byteLength(item.text, "utf8"))} tokens`,
+				),
+			),
+		]);
+	};
+
 	const clearPending = (ctx: ExtensionContext) => {
 		pendingQuotes = [];
-		if (ctx.hasUI) ctx.ui.setWidget(WIDGET_KEY, undefined);
+		updatePendingWidget(ctx);
 	};
 
 	const appendPending = (quote: FileQuote, ctx: ExtensionContext) => {
 		pendingQuotes = appendPendingQuote(pendingQuotes, quote);
-		if (ctx.hasUI) {
-			const totalBytes = pendingQuotes.reduce(
-				(total, item) => total + Buffer.byteLength(item.text, "utf8"),
-				0,
-			);
-			ctx.ui.setWidget(WIDGET_KEY, [
-				ctx.ui.theme.fg(
-					"accent",
-					`Quotes (${pendingQuotes.length}) · ~${estimateTokens(totalBytes)} tokens:`,
-				),
-				...pendingQuotes.map((item) =>
-					ctx.ui.theme.fg(
-						"muted",
-						`• ${escapeTerminalControls(item.path)} · lines ${item.startLine}-${item.endLine} · ~${estimateTokens(Buffer.byteLength(item.text, "utf8"))} tokens`,
-					),
-				),
-			]);
-		}
+		updatePendingWidget(ctx);
 	};
 
 	const isCurrentSession = (owner: unknown, generation: number) =>
 		owner === activeSessionManager && generation === sessionGeneration;
+
+	const removePending = async (ctx: ExtensionContext): Promise<void> => {
+		if (ctx.mode !== "tui") {
+			rejectCommand(ctx, "File Context requires Pi's interactive TUI.");
+			return;
+		}
+		const owner = ctx.sessionManager;
+		const generation = sessionGeneration;
+		if (!isCurrentSession(owner, generation)) return;
+		if (pendingQuotes.length === 0) {
+			ctx.ui.notify("File Context has no pending quotes.", "warning");
+			return;
+		}
+		const choices = pendingQuotes.map((quote, index) => ({
+			label: `${index + 1}. ${escapeTerminalControls(quote.path)} · lines ${quote.startLine}-${quote.endLine}`,
+			quote,
+		}));
+		let selectedLabel: string | undefined;
+		try {
+			selectedLabel = await ctx.ui.select(
+				"Remove a pending quote",
+				choices.map(({ label }) => label),
+			);
+		} catch (error: unknown) {
+			if (!isCurrentSession(owner, generation)) return;
+			ctx.ui.notify(
+				`File Context could not remove a quote: ${escapeTerminalControls(formatError(error))}. Pending quotes were kept; run /file-context remove to retry.`,
+				"error",
+			);
+			return;
+		}
+		if (!isCurrentSession(owner, generation) || selectedLabel === undefined) return;
+		const selected = choices.find(({ label }) => label === selectedLabel);
+		if (!selected) return;
+		const currentIndex = pendingQuotes.indexOf(selected.quote);
+		if (currentIndex === -1) {
+			ctx.ui.notify("That quote is no longer pending.", "warning");
+			return;
+		}
+		pendingQuotes = pendingQuotes.filter((_quote, index) => index !== currentIndex);
+		updatePendingWidget(ctx);
+		ctx.ui.notify(
+			`Removed pending quote: ${escapeTerminalControls(selected.quote.path)} · lines ${selected.quote.startLine}-${selected.quote.endLine}.`,
+			"info",
+		);
+	};
 
 	const cancelExplorers = () => {
 		activeExplorerLaunch = undefined;
@@ -401,14 +454,31 @@ export async function registerFileQuoteExtension(
 	};
 
 	const handleFileContextCommand = async (args: string, ctx: ExtensionContext) => {
-		if (args.trim()) {
-			rejectCommand(ctx, "Usage: /file-context");
+		const normalized = args.trim().toLowerCase();
+		if (!normalized) {
+			await openExplorer(ctx);
 			return;
 		}
-		await openExplorer(ctx);
+		if (normalized === "remove") {
+			await removePending(ctx);
+			return;
+		}
+		rejectCommand(ctx, "Usage: /file-context [remove]");
 	};
 	pi.registerCommand("file-context", {
-		description: "Browse project files and attach a selected line range",
+		description: "Browse project files or remove a pending quote",
+		getArgumentCompletions: (prefix) => {
+			const normalized = prefix.trimStart().toLowerCase();
+			return "remove".startsWith(normalized)
+				? [
+						{
+							value: "remove",
+							label: "remove",
+							description: "Remove one pending quote",
+						},
+					]
+				: null;
+		},
 		handler: handleFileContextCommand,
 	});
 	if (loadedSettings.settings.openShortcut) {

--- a/packages/pi-file-context/test/file-context-command-menu.test.ts
+++ b/packages/pi-file-context/test/file-context-command-menu.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { registerFileQuoteExtension } from "../src/file-context.js";
+
+async function withTempProject(run: (root: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-file-context-menu-command-test-"));
+	try {
+		await writeFile(join(root, "example.ts"), "export const example = true;\n");
+		await run(root);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+async function waitForNextOpen(
+	tui: ReturnType<typeof createTuiHarness>,
+	previousCount: number,
+): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (tui.openCount > previousCount && tui.isOpen) return;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+	throw new Error("Timed out waiting for the next File Context screen");
+}
+
+test("makes the no-argument command a menu and advertises compatibility routes", async () => {
+	await withTempProject(async (root) => {
+		const mock = createMockPi();
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
+		});
+		const command = mock.commands.get("file-context");
+		assert.ok(command?.getArgumentCompletions);
+		assert.deepEqual(
+			(command.getArgumentCompletions("") as Array<{ value: string }>).map(({ value }) => value),
+			["browse", "remove"],
+		);
+		assert.deepEqual(
+			(command.getArgumentCompletions("br") as Array<{ value: string }>).map(({ value }) => value),
+			["browse"],
+		);
+
+		const tui = createTuiHarness({ width: 40, rows: 12 });
+		const base = createMockContext({ mode: "tui", hasUI: true, cwd: root });
+		const baseCtx = base.ctx as unknown as { ui: Record<string, unknown> } & Record<
+			string,
+			unknown
+		>;
+		const context = {
+			...base,
+			ctx: {
+				...baseCtx,
+				ui: { ...baseCtx.ui, custom: tui.custom },
+			} as never,
+		};
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		const running = Promise.resolve(command?.handler("", context.ctx));
+		await tui.waitForOpen();
+		const frame = tui.render().join("\n");
+		assert.match(frame, /File Context/u);
+		assert.match(frame, /Add file quote/u);
+		assert.match(frame, /Remove pending quote \(0\)/u);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("keeps browse and the configured shortcut as direct explorer paths", async () => {
+	for (const route of ["browse", "shortcut"] as const) {
+		await withTempProject(async (root) => {
+			const mock = createMockPi();
+			await registerFileQuoteExtension(mock.pi, {
+				loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
+			});
+			const pasted: string[] = [];
+			const context = createMockContext({
+				mode: "tui",
+				hasUI: true,
+				cwd: root,
+				ui: {
+					theme: { fg: (_color: string, text: string) => text },
+					notify() {},
+					setWidget() {},
+					async custom() {
+						return { kind: "reference", path: "example.ts" };
+					},
+					pasteToEditor(value: string) {
+						pasted.push(value);
+					},
+				},
+			});
+			await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+			if (route === "browse") {
+				await mock.commands.get("file-context")?.handler("browse", context.ctx);
+			} else {
+				await mock.shortcuts.get("f8")?.handler(context.ctx);
+			}
+			assert.deepEqual(pasted, ["@example.ts "]);
+		});
+	}
+});
+
+test("reports project scanning failures and returns to a retryable menu", async () => {
+	await withTempProject(async (root) => {
+		const mock = createMockPi();
+		let rejectScan: ((error: Error) => void) | undefined;
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
+			discoverFiles: async () =>
+				new Promise<string[]>((_resolve, reject) => {
+					rejectScan = reject;
+				}),
+		});
+		const tui = createTuiHarness({ width: 40, rows: 12 });
+		const base = createMockContext({ mode: "tui", hasUI: true, cwd: root });
+		const baseCtx = base.ctx as unknown as { ui: Record<string, unknown> } & Record<
+			string,
+			unknown
+		>;
+		const ctx = {
+			...baseCtx,
+			ui: { ...baseCtx.ui, custom: tui.custom },
+		} as never;
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		const running = Promise.resolve(mock.commands.get("file-context")?.handler("", ctx));
+		await tui.waitForOpen();
+		const menuOpenCount = tui.openCount;
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await waitForNextOpen(tui, menuOpenCount);
+		const scanOpenCount = tui.openCount;
+		rejectScan?.(new Error("scan \u001b[31mfailed"));
+		await waitForNextOpen(tui, scanOpenCount);
+		assert.match(tui.render().join("\n"), /Add file quote/u);
+		assert.ok(!(base.notifications.at(-1)?.message ?? "").includes("\u001b"));
+		assert.match(base.notifications.at(-1)?.message ?? "", /could not scan.*retry/iu);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("shows cancellable project scanning before Add and returns to the menu on cancellation", async () => {
+	await withTempProject(async (root) => {
+		const mock = createMockPi();
+		let scanSignal: AbortSignal | undefined;
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
+			discoverFiles: async (_root, { signal } = {}) => {
+				scanSignal = signal;
+				return new Promise<string[]>((_resolve, reject) => {
+					signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+				});
+			},
+		});
+		const tui = createTuiHarness({ width: 40, rows: 12 });
+		const base = createMockContext({ mode: "tui", hasUI: true, cwd: root });
+		const baseCtx = base.ctx as unknown as { ui: Record<string, unknown> } & Record<
+			string,
+			unknown
+		>;
+		const ctx = {
+			...baseCtx,
+			ui: { ...baseCtx.ui, custom: tui.custom },
+		} as never;
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		const running = Promise.resolve(mock.commands.get("file-context")?.handler("", ctx));
+		await tui.waitForOpen();
+		const menuOpenCount = tui.openCount;
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await waitForNextOpen(tui, menuOpenCount);
+		assert.match(tui.render().join("\n"), /Scanning project files/u);
+		const scanOpenCount = tui.openCount;
+		tui.press("tui.select.cancel");
+		await waitForNextOpen(tui, scanOpenCount);
+		assert.equal(scanSignal?.aborted, true);
+		assert.match(tui.render().join("\n"), /Add file quote/u);
+		tui.press("ctrl+c");
+		await running;
+	});
+});

--- a/packages/pi-file-context/test/file-context-lifecycle.test.ts
+++ b/packages/pi-file-context/test/file-context-lifecycle.test.ts
@@ -77,7 +77,7 @@ async function assertExplorerLifecycleCancellation(
 		await mock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
 		let settled = false;
 		const command = Promise.resolve(
-			mock.commands.get("file-context")?.handler("", oldContext.ctx),
+			mock.commands.get("file-context")?.handler("browse", oldContext.ctx),
 		).then(() => {
 			settled = true;
 		});

--- a/packages/pi-file-context/test/file-context-menu.test.ts
+++ b/packages/pi-file-context/test/file-context-menu.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	type FileContextMenuOptions,
+	type FileContextMenuState,
+	showFileContextMenu,
+} from "../src/file-context-menu.js";
+
+function quote(
+	id: string,
+	overrides: Partial<FileContextMenuState["quotes"][number]> = {},
+): FileContextMenuState["quotes"][number] {
+	return {
+		id,
+		path: "src/example.ts",
+		startLine: 1,
+		endLine: 1,
+		text: "const example = true;",
+		...overrides,
+	};
+}
+
+function state(
+	quotes: FileContextMenuState["quotes"] = [],
+	overrides: Partial<FileContextMenuState> = {},
+): FileContextMenuState {
+	return {
+		quotes,
+		shortcut: "f8",
+		maximumQuotes: 8,
+		maximumBytes: 100_000,
+		totalBytes: quotes.reduce((total, item) => total + Buffer.byteLength(item.text), 0),
+		...overrides,
+	};
+}
+
+function menuContext(width = 80, rows = 24) {
+	const tui = createTuiHarness({ width, rows });
+	const base = createMockContext({ mode: "tui", hasUI: true });
+	const baseCtx = base.ctx as unknown as { ui: Record<string, unknown> } & Record<string, unknown>;
+	return {
+		tui,
+		notifications: base.notifications,
+		ctx: {
+			...baseCtx,
+			ui: { ...baseCtx.ui, custom: tui.custom },
+		} as never,
+	};
+}
+
+function options(
+	getState: () => FileContextMenuState,
+	overrides: Partial<FileContextMenuOptions> = {},
+): FileContextMenuOptions {
+	return {
+		getState,
+		isCurrent: () => true,
+		signal: new AbortController().signal,
+		addQuote: async () => "close" as const,
+		removeQuote: () => ({ kind: "missing" }),
+		...overrides,
+	};
+}
+
+test("shows the primary menu immediately with visible state and disabled reasons", async () => {
+	const { tui, ctx } = menuContext(20, 6);
+	let removeCalls = 0;
+	const running = showFileContextMenu(
+		ctx,
+		options(() => state(), {
+			removeQuote: () => {
+				removeCalls += 1;
+				return { kind: "missing" };
+			},
+		}),
+	);
+	await tui.waitForOpen();
+
+	for (const size of [
+		{ width: 20, rows: 6 },
+		{ width: 40, rows: 12 },
+		{ width: 80, rows: 24 },
+	]) {
+		const frame = tui.resize(size);
+		assert.ok(frame.length > 0);
+		assert.ok(frame.every((line) => visibleWidth(line) <= size.width));
+	}
+	const initial = tui.render().join("\n");
+	assert.match(initial, /File Context/u);
+	assert.match(initial, /Pending quotes: 0\/8/u);
+	assert.match(initial, /Shortcut: F8/u);
+	assert.match(initial, /Add file quote/u);
+
+	tui.press("tui.select.down");
+	const disabled = tui.render().join("\n");
+	assert.match(disabled, /\[-\].*Remove pending quote \(0\)/u);
+	assert.match(disabled, /No pending quotes to remove/u);
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	assert.equal(removeCalls, 0);
+	assert.equal(tui.isOpen, true);
+
+	tui.press("ctrl+c");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+});
+
+test("closes the menu before handing off to Add", async () => {
+	const { tui, ctx } = menuContext();
+	let menuWasOpenDuringAdd = true;
+	const running = showFileContextMenu(
+		ctx,
+		options(() => state(), {
+			addQuote: async () => {
+				menuWasOpenDuringAdd = tui.isOpen;
+				return "close" as const;
+			},
+		}),
+	);
+	await tui.waitForOpen();
+	tui.press("tui.select.confirm");
+	await running;
+	assert.equal(menuWasOpenDuringAdd, false);
+});
+
+test("opens Help from the menu and Escape returns without side effects", async () => {
+	const { tui, ctx } = menuContext();
+	let addCalls = 0;
+	const running = showFileContextMenu(
+		ctx,
+		options(() => state(), {
+			addQuote: async () => {
+				addCalls += 1;
+				return "close" as const;
+			},
+		}),
+	);
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	assert.match(tui.render().join("\n"), /Pending quotes are attached.*next prompt/u);
+	tui.press("tui.select.cancel");
+	await tui.waitForOpen();
+	assert.match(tui.render().join("\n"), /Add file quote/u);
+	assert.equal(addCalls, 0);
+	tui.press("ctrl+c");
+	await running;
+});
+
+test("previews and repeatedly removes exact duplicate-looking quotes by stable ID", async () => {
+	const { tui, ctx, notifications } = menuContext(40, 12);
+	let current = state([
+		quote("quote-1", { text: "first snapshot\nwith details" }),
+		quote("quote-2", { text: "second snapshot\nwith details" }),
+	]);
+	const removedIds: string[] = [];
+	const running = showFileContextMenu(
+		ctx,
+		options(() => current, {
+			removeQuote: (id) => {
+				const selected = current.quotes.find((item) => item.id === id);
+				if (!selected) return { kind: "missing" };
+				removedIds.push(id);
+				current = state(current.quotes.filter((item) => item.id !== id));
+				return { kind: "removed", quote: selected, remaining: current.quotes.length };
+			},
+		}),
+	);
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	const firstChoice = tui.render().join("\n");
+	assert.match(firstChoice, /src\/example\.ts/u);
+	assert.match(firstChoice, /Lines: 1-1/u);
+	assert.match(firstChoice, /first snapshot.*with details/u);
+
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.match(tui.render().join("\n"), /second snapshot.*with details/u);
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+
+	assert.deepEqual(removedIds, ["quote-1", "quote-2"]);
+	assert.match(tui.render().join("\n"), /Pending quotes: 0\/8/u);
+	assert.equal(
+		notifications.filter(({ message }) => /Removed pending quote/u.test(message)).length,
+		2,
+	);
+	tui.press("ctrl+c");
+	await running;
+});
+
+test("sanitizes untrusted quote text and keeps cancellation side-effect free", async () => {
+	const { tui, ctx } = menuContext(32, 12);
+	const unsafe = quote("quote-unsafe", {
+		path: "src/unsafe\u001b[31m.ts",
+		text: "first\u0000 line\nsecond",
+	});
+	let removeCalls = 0;
+	const running = showFileContextMenu(
+		ctx,
+		options(() => state([unsafe]), {
+			removeQuote: () => {
+				removeCalls += 1;
+				return { kind: "missing" };
+			},
+		}),
+	);
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	const frame = tui.render();
+	assert.ok(frame.every((line) => visibleWidth(line) <= 32));
+	assert.ok(frame.every((line) => !line.includes("\u001b[31m") && !line.includes("\u0000")));
+	tui.press("tui.select.cancel");
+	await tui.waitForOpen();
+	assert.equal(removeCalls, 0);
+	tui.press("ctrl+c");
+	await running;
+});
+
+test("disables Add at either hard pending limit", async () => {
+	for (const limited of [
+		state(Array.from({ length: 8 }, (_, index) => quote(`quote-${index}`))),
+		state([quote("quote-bytes")], { totalBytes: 100_000 }),
+	]) {
+		const { tui, ctx } = menuContext();
+		let addCalls = 0;
+		const running = showFileContextMenu(
+			ctx,
+			options(() => limited, {
+				addQuote: async () => {
+					addCalls += 1;
+					return "close" as const;
+				},
+			}),
+		);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /\[-\].*Add file quote/u);
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		assert.equal(addCalls, 0);
+		tui.press("ctrl+c");
+		await running;
+	}
+});

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -836,9 +836,9 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 	await mock.commands.get("file-context")?.handler("", context.ctx);
 	assert.equal(typeof customFactory, "function");
 	assert.deepEqual(widgets.get("file-context"), [
-		"Quotes (2) · ~13 tokens:",
-		"• src/example.ts · lines 1-1 · ~6 tokens",
-		"• test/example.test.ts · lines 2-3 · ~8 tokens",
+		"Quotes (2) · ~13 tokens · /file-context remove",
+		"1. src/example.ts · lines 1-1 · ~6 tokens",
+		"2. test/example.test.ts · lines 2-3 · ~8 tokens",
 	]);
 
 	assert.equal(mock.events.get("input"), undefined);
@@ -950,14 +950,22 @@ test("rejects the fallback command observably outside TUI mode", async () => {
 	});
 	const rpc = createMockContext({ mode: "rpc", hasUI: true });
 	await mock.commands.get("file-context")?.handler("", rpc.ctx);
-	assert.match(rpc.notifications[0]?.message ?? "", /interactive TUI/);
-	assert.equal(rpc.notifications[0]?.level, "warning");
+	await mock.commands.get("file-context")?.handler("remove", rpc.ctx);
+	assert.equal(rpc.notifications.length, 2);
+	assert.ok(rpc.notifications.every(({ message }) => /interactive TUI/.test(message)));
+	assert.ok(rpc.notifications.every(({ level }) => level === "warning"));
 
 	const print = createMockContext({ mode: "print", hasUI: false });
 	await assert.rejects(async () => {
 		await mock.commands.get("file-context")?.handler("", print.ctx);
 	}, /interactive TUI/);
 	await assert.rejects(async () => {
+		await mock.commands.get("file-context")?.handler("remove", print.ctx);
+	}, /interactive TUI/);
+	await assert.rejects(async () => {
 		await mock.commands.get("file-context")?.handler("unexpected", print.ctx);
+	}, /Usage/);
+	await assert.rejects(async () => {
+		await mock.commands.get("file-context")?.handler("remove trailing", print.ctx);
 	}, /Usage/);
 });

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -227,6 +227,25 @@ test("explorer previews a file, selects a range, and keeps rendered rows width-s
 	});
 	cancelledExplorer.handleInput("\u001b");
 	assert.equal(result, undefined);
+
+	const menuExplorer = (input: string) => {
+		result = "unchanged";
+		const explorer = new FileQuoteExplorer({
+			tui: tui as never,
+			theme: theme as never,
+			keybindings: keybindings as never,
+			files: ["src/menu.ts"],
+			loadFile: async () => ({ path: "", lines: [] }),
+			rootNavigation: true,
+			done: (value) => {
+				result = value;
+			},
+		});
+		explorer.handleInput(input);
+		return result;
+	};
+	assert.deepEqual(menuExplorer("\u001b"), { kind: "back" });
+	assert.deepEqual(menuExplorer("\u0003"), { kind: "close" });
 });
 
 test("explorer escapes errors and keeps narrow empty states width-safe", async () => {
@@ -833,10 +852,10 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.shortcuts.get("ctrl+alt+f")?.handler(context.ctx);
-	await mock.commands.get("file-context")?.handler("", context.ctx);
+	await mock.commands.get("file-context")?.handler("browse", context.ctx);
 	assert.equal(typeof customFactory, "function");
 	assert.deepEqual(widgets.get("file-context"), [
-		"Quotes (2) · ~13 tokens · /file-context remove",
+		"Quotes (2) · ~13 tokens · /file-context to manage",
 		"1. src/example.ts · lines 1-1 · ~6 tokens",
 		"2. test/example.test.ts · lines 2-3 · ~8 tokens",
 	]);
@@ -892,7 +911,7 @@ test("quotes whole-file references and rejects picker results from replaced sess
 		},
 	});
 	await referenceMock.events.get("session_start")?.[0]?.({}, referenceContext.ctx);
-	await referenceMock.commands.get("file-context")?.handler("", referenceContext.ctx);
+	await referenceMock.commands.get("file-context")?.handler("browse", referenceContext.ctx);
 	assert.deepEqual(pasted, ['@"docs/my \\"note\\".md" ']);
 
 	const staleMock = createMockPi();
@@ -926,7 +945,7 @@ test("quotes whole-file references and rejects picker results from replaced sess
 	const oldContext = makeContext(oldManager, async () => picker);
 	const newContext = makeContext(newManager, async () => undefined);
 	await staleMock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
-	const command = staleMock.commands.get("file-context")?.handler("", oldContext.ctx);
+	const command = staleMock.commands.get("file-context")?.handler("browse", oldContext.ctx);
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	await staleMock.events.get("session_start")?.[0]?.({}, newContext.ctx);
 	resolvePicker?.({

--- a/packages/pi-file-context/test/pending-quotes.test.ts
+++ b/packages/pi-file-context/test/pending-quotes.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerFileQuoteExtension } from "../src/file-context.js";
@@ -9,59 +10,49 @@ import { registerFileQuoteExtension } from "../src/file-context.js";
 async function withTempProject(run: (root: string) => Promise<void>): Promise<void> {
 	const root = await mkdtemp(join(tmpdir(), "pi-file-context-pending-test-"));
 	try {
+		await writeFile(join(root, "example.txt"), "example\n");
 		await run(root);
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}
 }
 
-test("removes one selected pending quote and refreshes the widget", async () => {
+async function waitForNextOpen(
+	tui: ReturnType<typeof createTuiHarness>,
+	previousCount: number,
+): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (tui.openCount > previousCount && tui.isOpen) return;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+	throw new Error("Timed out waiting for the next File Context screen");
+}
+
+test("removes an exact duplicate-looking pending quote and refreshes the widget", async () => {
 	await withTempProject(async (root) => {
-		await writeFile(join(root, "example.txt"), "example\n");
 		const mock = createMockPi();
 		await registerFileQuoteExtension(mock.pi, {
-			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
 		});
-		const command = mock.commands.get("file-context");
-		assert.ok(command?.getArgumentCompletions);
-		assert.deepEqual(
-			(command.getArgumentCompletions("") as Array<{ value: string }>).map((item) => item.value),
-			["remove"],
-		);
-		assert.deepEqual(
-			(command.getArgumentCompletions("rem") as Array<{ value: string }>).map((item) => item.value),
-			["remove"],
-		);
-
 		const quoteResults = [
 			{
 				kind: "quote",
-				quote: { path: "src/first.ts", startLine: 1, endLine: 1, text: "first" },
+				quote: { path: "src/example.ts", startLine: 1, endLine: 1, text: "first snapshot" },
 			},
 			{
 				kind: "quote",
-				quote: {
-					path: "src/unsafe\u001b[31m.ts",
-					startLine: 2,
-					endLine: 3,
-					text: "second\nthird",
-				},
+				quote: { path: "src/example.ts", startLine: 1, endLine: 1, text: "second snapshot" },
 			},
 		];
 		let quoteIndex = 0;
-		let removalTitle = "";
-		let removalOptions: string[] = [];
 		const widgets = new Map<string, unknown>();
-		const notifications: string[] = [];
 		const context = createMockContext({
 			mode: "tui",
 			hasUI: true,
 			cwd: root,
 			ui: {
 				theme: { fg: (_color: string, text: string) => text },
-				notify(message: string) {
-					notifications.push(message);
-				},
+				notify() {},
 				setWidget(key: string, value: unknown) {
 					widgets.set(key, value);
 				},
@@ -70,46 +61,54 @@ test("removes one selected pending quote and refreshes the widget", async () => 
 					quoteIndex += 1;
 					return result;
 				},
-				async select(title: string, options: string[]) {
-					removalTitle = title;
-					removalOptions = options;
-					return options[1];
-				},
 				pasteToEditor() {},
 			},
 		});
-
+		const command = mock.commands.get("file-context");
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await command.handler("", context.ctx);
-		await command.handler("", context.ctx);
-		await command.handler("remove", context.ctx);
+		await command?.handler("browse", context.ctx);
+		await command?.handler("browse", context.ctx);
 
-		assert.equal(removalTitle, "Remove a pending quote");
-		assert.equal(removalOptions.length, 2);
-		assert.ok(removalOptions.every((option) => !option.includes("\u001b")));
+		const tui = createTuiHarness({ width: 60, rows: 18 });
+		(context.ctx as unknown as { ui: { custom: typeof tui.custom } }).ui.custom = tui.custom;
+		const running = Promise.resolve(command?.handler("", context.ctx));
+		await tui.waitForOpen();
+		const mainCount = tui.openCount;
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await waitForNextOpen(tui, mainCount);
+		assert.match(tui.render().join("\n"), /first snapshot/u);
+		tui.press("tui.select.down");
+		const removeCount = tui.openCount;
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await waitForNextOpen(tui, removeCount);
+		assert.match(tui.render().join("\n"), /first snapshot/u);
+		assert.doesNotMatch(tui.render().join("\n"), /second snapshot/u);
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		tui.press("ctrl+c");
+		await running;
+
 		assert.deepEqual(widgets.get("file-context"), [
-			"Quotes (1) · ~2 tokens · /file-context remove",
-			"1. src/first.ts · lines 1-1 · ~2 tokens",
+			"Quotes (1) · ~4 tokens · /file-context to manage",
+			"1. src/example.ts · lines 1-1 · ~4 tokens",
 		]);
-		assert.match(notifications.at(-1) ?? "", /Removed.*unsafe\\x1b\[31m\.ts.*2-3/u);
-
 		const injection = await mock.events.get("before_agent_start")?.[0]?.(
 			{ prompt: "Explain", systemPrompt: "base" },
 			context.ctx,
 		);
-		assert.match(JSON.stringify(injection), /src\/first\.ts/u);
-		assert.doesNotMatch(JSON.stringify(injection), /unsafe/u);
+		assert.match(JSON.stringify(injection), /first snapshot/u);
+		assert.doesNotMatch(JSON.stringify(injection), /second snapshot/u);
 	});
 });
 
-test("cancellation and selector failures leave every pending quote unchanged", async () => {
+test("removal cancellation and menu failures preserve pending quotes", async () => {
 	await withTempProject(async (root) => {
-		await writeFile(join(root, "example.txt"), "example\n");
 		const mock = createMockPi();
 		await registerFileQuoteExtension(mock.pi, {
-			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
 		});
-		let selectCalls = 0;
 		const widgets = new Map<string, unknown>();
 		const notifications: string[] = [];
 		const context = createMockContext({
@@ -130,163 +129,93 @@ test("cancellation and selector failures leave every pending quote unchanged", a
 						quote: { path: "src/keep.ts", startLine: 4, endLine: 4, text: "keep" },
 					};
 				},
-				async select() {
-					selectCalls += 1;
-					if (selectCalls === 1) throw new Error("picker \u001b[31mfailed");
-					return undefined;
-				},
 				pasteToEditor() {},
 			},
 		});
 		const command = mock.commands.get("file-context");
-
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await command?.handler("", context.ctx);
-		const widgetBeforeCancel = widgets.get("file-context");
-		await command?.handler("remove", context.ctx);
-		assert.equal(selectCalls, 1);
-		assert.deepEqual(widgets.get("file-context"), widgetBeforeCancel);
-		assert.ok(!(notifications.at(-1) ?? "").includes("\u001b"));
-		assert.match(notifications.at(-1) ?? "", /picker \\x1b\[31mfailed.*kept.*retry/iu);
+		await command?.handler("browse", context.ctx);
+		const widgetBefore = widgets.get("file-context");
 
+		const tui = createTuiHarness();
+		(context.ctx as unknown as { ui: { custom: typeof tui.custom } }).ui.custom = tui.custom;
+		const cancelled = Promise.resolve(command?.handler("remove", context.ctx));
+		await tui.waitForOpen();
+		tui.press("tui.select.cancel");
+		await cancelled;
+		assert.deepEqual(widgets.get("file-context"), widgetBefore);
+
+		(
+			context.ctx as unknown as {
+				ui: { custom: (factory: unknown) => Promise<unknown> };
+			}
+		).ui.custom = async () => {
+			throw new Error("picker \u001b[31mfailed");
+		};
 		await command?.handler("remove", context.ctx);
-		assert.equal(selectCalls, 2);
-		assert.deepEqual(widgets.get("file-context"), widgetBeforeCancel);
+		assert.deepEqual(widgets.get("file-context"), widgetBefore);
+		assert.ok(!(notifications.at(-1) ?? "").includes("\u001b"));
+		assert.match(notifications.at(-1) ?? "", /failed.*kept.*try again/iu);
 
 		const injection = await mock.events.get("before_agent_start")?.[0]?.(
 			{ prompt: "Explain", systemPrompt: "base" },
 			context.ctx,
 		);
 		assert.match(JSON.stringify(injection), /src\/keep\.ts/u);
-
 		await command?.handler("remove", context.ctx);
-		assert.equal(selectCalls, 2);
 		assert.match(notifications.at(-1) ?? "", /no pending quotes/iu);
 	});
 });
 
-test("ignores stale and concurrent pending quote removal selections", async () => {
+test("session replacement closes the menu and ignores stale input", async () => {
 	await withTempProject(async (root) => {
-		await writeFile(join(root, "example.txt"), "example\n");
 		const mock = createMockPi();
 		await registerFileQuoteExtension(mock.pi, {
-			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
 		});
-		const command = mock.commands.get("file-context");
-		const manager = { getSessionId: () => "same" };
-		const quoteResults = [
-			{ kind: "quote", quote: { path: "src/first.ts", startLine: 1, endLine: 1, text: "first" } },
-			{ kind: "quote", quote: { path: "src/second.ts", startLine: 2, endLine: 2, text: "second" } },
-		];
-		let quoteIndex = 0;
-		const pendingSelections: Array<{
-			options: string[];
-			resolve(value: string | undefined): void;
-		}> = [];
-		const context = createMockContext({
+		const oldManager = { getSessionId: () => "old" };
+		const newManager = { getSessionId: () => "new" };
+		const oldContext = createMockContext({
 			mode: "tui",
 			hasUI: true,
 			cwd: root,
-			sessionManager: manager,
+			sessionManager: oldManager,
 			ui: {
 				theme: { fg: (_color: string, text: string) => text },
 				notify() {},
 				setWidget() {},
 				async custom() {
-					const result = quoteResults[quoteIndex];
-					quoteIndex += 1;
-					return result;
-				},
-				select(_title: string, options: string[]) {
-					return new Promise<string | undefined>((resolve) => {
-						pendingSelections.push({ options, resolve });
-					});
+					return {
+						kind: "quote",
+						quote: { path: "src/old.ts", startLine: 1, endLine: 1, text: "old" },
+					};
 				},
 				pasteToEditor() {},
 			},
 		});
-
-		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await command?.handler("", context.ctx);
-		await command?.handler("", context.ctx);
-		const firstRemoval = Promise.resolve(command?.handler("remove", context.ctx));
-		const secondRemoval = Promise.resolve(command?.handler("remove", context.ctx));
-		assert.equal(pendingSelections.length, 2);
-		pendingSelections[1]?.resolve(pendingSelections[1]?.options[0]);
-		await secondRemoval;
-		pendingSelections[0]?.resolve(pendingSelections[0]?.options[0]);
-		await firstRemoval;
-
-		const injection = await mock.events.get("before_agent_start")?.[0]?.(
-			{ prompt: "Explain", systemPrompt: "base" },
-			context.ctx,
-		);
-		assert.doesNotMatch(JSON.stringify(injection), /src\/first\.ts/u);
-		assert.match(JSON.stringify(injection), /src\/second\.ts/u);
-	});
-
-	await withTempProject(async (root) => {
-		await writeFile(join(root, "example.txt"), "example\n");
-		const mock = createMockPi();
-		await registerFileQuoteExtension(mock.pi, {
-			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
-		});
-		const command = mock.commands.get("file-context");
-		let resolveOldSelection: ((value: string | undefined) => void) | undefined;
-		let oldSelection: string | undefined;
-		const oldManager = { getSessionId: () => "old" };
-		const newManager = { getSessionId: () => "new" };
-		const makeContext = (
-			sessionManager: object,
-			quote: { path: string; startLine: number; endLine: number; text: string },
-			select?: (_title: string, options: string[]) => Promise<string | undefined>,
-		) =>
-			createMockContext({
-				mode: "tui",
-				hasUI: true,
-				cwd: root,
-				sessionManager,
-				ui: {
-					theme: { fg: (_color: string, text: string) => text },
-					notify() {},
-					setWidget() {},
-					async custom() {
-						return { kind: "quote", quote };
-					},
-					select: select ?? (async () => undefined),
-					pasteToEditor() {},
-				},
-			});
-		const oldContext = makeContext(
-			oldManager,
-			{ path: "src/old.ts", startLine: 1, endLine: 1, text: "old" },
-			async (_title, options) => {
-				oldSelection = options[0];
-				return new Promise((resolve) => {
-					resolveOldSelection = resolve;
-				});
-			},
-		);
-		const newContext = makeContext(newManager, {
-			path: "src/new.ts",
-			startLine: 1,
-			endLine: 1,
-			text: "new",
-		});
-
 		await mock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
-		await command?.handler("", oldContext.ctx);
-		const oldRemoval = Promise.resolve(command?.handler("remove", oldContext.ctx));
-		await mock.events.get("session_start")?.[0]?.({}, newContext.ctx);
-		await command?.handler("", newContext.ctx);
-		resolveOldSelection?.(oldSelection);
-		await oldRemoval;
+		await mock.commands.get("file-context")?.handler("browse", oldContext.ctx);
+		const tui = createTuiHarness();
+		(oldContext.ctx as unknown as { ui: { custom: typeof tui.custom } }).ui.custom = tui.custom;
+		const oldMenu = Promise.resolve(mock.commands.get("file-context")?.handler("", oldContext.ctx));
+		await tui.waitForOpen();
 
-		const injection = await mock.events.get("before_agent_start")?.[0]?.(
-			{ prompt: "Explain", systemPrompt: "base" },
-			newContext.ctx,
+		const newContext = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			sessionManager: newManager,
+		});
+		await mock.events.get("session_start")?.[0]?.({}, newContext.ctx);
+		await oldMenu;
+		assert.equal(tui.isOpen, false);
+		tui.press("tui.select.confirm");
+		assert.equal(
+			await mock.events.get("before_agent_start")?.[0]?.(
+				{ prompt: "new", systemPrompt: "base" },
+				newContext.ctx,
+			),
+			undefined,
 		);
-		assert.doesNotMatch(JSON.stringify(injection), /src\/old\.ts/u);
-		assert.match(JSON.stringify(injection), /src\/new\.ts/u);
 	});
 });

--- a/packages/pi-file-context/test/pending-quotes.test.ts
+++ b/packages/pi-file-context/test/pending-quotes.test.ts
@@ -1,0 +1,292 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { registerFileQuoteExtension } from "../src/file-context.js";
+
+async function withTempProject(run: (root: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-file-context-pending-test-"));
+	try {
+		await run(root);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("removes one selected pending quote and refreshes the widget", async () => {
+	await withTempProject(async (root) => {
+		await writeFile(join(root, "example.txt"), "example\n");
+		const mock = createMockPi();
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+		});
+		const command = mock.commands.get("file-context");
+		assert.ok(command?.getArgumentCompletions);
+		assert.deepEqual(
+			(command.getArgumentCompletions("") as Array<{ value: string }>).map((item) => item.value),
+			["remove"],
+		);
+		assert.deepEqual(
+			(command.getArgumentCompletions("rem") as Array<{ value: string }>).map((item) => item.value),
+			["remove"],
+		);
+
+		const quoteResults = [
+			{
+				kind: "quote",
+				quote: { path: "src/first.ts", startLine: 1, endLine: 1, text: "first" },
+			},
+			{
+				kind: "quote",
+				quote: {
+					path: "src/unsafe\u001b[31m.ts",
+					startLine: 2,
+					endLine: 3,
+					text: "second\nthird",
+				},
+			},
+		];
+		let quoteIndex = 0;
+		let removalTitle = "";
+		let removalOptions: string[] = [];
+		const widgets = new Map<string, unknown>();
+		const notifications: string[] = [];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			ui: {
+				theme: { fg: (_color: string, text: string) => text },
+				notify(message: string) {
+					notifications.push(message);
+				},
+				setWidget(key: string, value: unknown) {
+					widgets.set(key, value);
+				},
+				async custom() {
+					const result = quoteResults[quoteIndex];
+					quoteIndex += 1;
+					return result;
+				},
+				async select(title: string, options: string[]) {
+					removalTitle = title;
+					removalOptions = options;
+					return options[1];
+				},
+				pasteToEditor() {},
+			},
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await command.handler("", context.ctx);
+		await command.handler("", context.ctx);
+		await command.handler("remove", context.ctx);
+
+		assert.equal(removalTitle, "Remove a pending quote");
+		assert.equal(removalOptions.length, 2);
+		assert.ok(removalOptions.every((option) => !option.includes("\u001b")));
+		assert.deepEqual(widgets.get("file-context"), [
+			"Quotes (1) · ~2 tokens · /file-context remove",
+			"1. src/first.ts · lines 1-1 · ~2 tokens",
+		]);
+		assert.match(notifications.at(-1) ?? "", /Removed.*unsafe\\x1b\[31m\.ts.*2-3/u);
+
+		const injection = await mock.events.get("before_agent_start")?.[0]?.(
+			{ prompt: "Explain", systemPrompt: "base" },
+			context.ctx,
+		);
+		assert.match(JSON.stringify(injection), /src\/first\.ts/u);
+		assert.doesNotMatch(JSON.stringify(injection), /unsafe/u);
+	});
+});
+
+test("cancellation and selector failures leave every pending quote unchanged", async () => {
+	await withTempProject(async (root) => {
+		await writeFile(join(root, "example.txt"), "example\n");
+		const mock = createMockPi();
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+		});
+		let selectCalls = 0;
+		const widgets = new Map<string, unknown>();
+		const notifications: string[] = [];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			ui: {
+				theme: { fg: (_color: string, text: string) => text },
+				notify(message: string) {
+					notifications.push(message);
+				},
+				setWidget(key: string, value: unknown) {
+					widgets.set(key, value);
+				},
+				async custom() {
+					return {
+						kind: "quote",
+						quote: { path: "src/keep.ts", startLine: 4, endLine: 4, text: "keep" },
+					};
+				},
+				async select() {
+					selectCalls += 1;
+					if (selectCalls === 1) throw new Error("picker \u001b[31mfailed");
+					return undefined;
+				},
+				pasteToEditor() {},
+			},
+		});
+		const command = mock.commands.get("file-context");
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await command?.handler("", context.ctx);
+		const widgetBeforeCancel = widgets.get("file-context");
+		await command?.handler("remove", context.ctx);
+		assert.equal(selectCalls, 1);
+		assert.deepEqual(widgets.get("file-context"), widgetBeforeCancel);
+		assert.ok(!(notifications.at(-1) ?? "").includes("\u001b"));
+		assert.match(notifications.at(-1) ?? "", /picker \\x1b\[31mfailed.*kept.*retry/iu);
+
+		await command?.handler("remove", context.ctx);
+		assert.equal(selectCalls, 2);
+		assert.deepEqual(widgets.get("file-context"), widgetBeforeCancel);
+
+		const injection = await mock.events.get("before_agent_start")?.[0]?.(
+			{ prompt: "Explain", systemPrompt: "base" },
+			context.ctx,
+		);
+		assert.match(JSON.stringify(injection), /src\/keep\.ts/u);
+
+		await command?.handler("remove", context.ctx);
+		assert.equal(selectCalls, 2);
+		assert.match(notifications.at(-1) ?? "", /no pending quotes/iu);
+	});
+});
+
+test("ignores stale and concurrent pending quote removal selections", async () => {
+	await withTempProject(async (root) => {
+		await writeFile(join(root, "example.txt"), "example\n");
+		const mock = createMockPi();
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+		});
+		const command = mock.commands.get("file-context");
+		const manager = { getSessionId: () => "same" };
+		const quoteResults = [
+			{ kind: "quote", quote: { path: "src/first.ts", startLine: 1, endLine: 1, text: "first" } },
+			{ kind: "quote", quote: { path: "src/second.ts", startLine: 2, endLine: 2, text: "second" } },
+		];
+		let quoteIndex = 0;
+		const pendingSelections: Array<{
+			options: string[];
+			resolve(value: string | undefined): void;
+		}> = [];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			sessionManager: manager,
+			ui: {
+				theme: { fg: (_color: string, text: string) => text },
+				notify() {},
+				setWidget() {},
+				async custom() {
+					const result = quoteResults[quoteIndex];
+					quoteIndex += 1;
+					return result;
+				},
+				select(_title: string, options: string[]) {
+					return new Promise<string | undefined>((resolve) => {
+						pendingSelections.push({ options, resolve });
+					});
+				},
+				pasteToEditor() {},
+			},
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await command?.handler("", context.ctx);
+		await command?.handler("", context.ctx);
+		const firstRemoval = Promise.resolve(command?.handler("remove", context.ctx));
+		const secondRemoval = Promise.resolve(command?.handler("remove", context.ctx));
+		assert.equal(pendingSelections.length, 2);
+		pendingSelections[1]?.resolve(pendingSelections[1]?.options[0]);
+		await secondRemoval;
+		pendingSelections[0]?.resolve(pendingSelections[0]?.options[0]);
+		await firstRemoval;
+
+		const injection = await mock.events.get("before_agent_start")?.[0]?.(
+			{ prompt: "Explain", systemPrompt: "base" },
+			context.ctx,
+		);
+		assert.doesNotMatch(JSON.stringify(injection), /src\/first\.ts/u);
+		assert.match(JSON.stringify(injection), /src\/second\.ts/u);
+	});
+
+	await withTempProject(async (root) => {
+		await writeFile(join(root, "example.txt"), "example\n");
+		const mock = createMockPi();
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+		});
+		const command = mock.commands.get("file-context");
+		let resolveOldSelection: ((value: string | undefined) => void) | undefined;
+		let oldSelection: string | undefined;
+		const oldManager = { getSessionId: () => "old" };
+		const newManager = { getSessionId: () => "new" };
+		const makeContext = (
+			sessionManager: object,
+			quote: { path: string; startLine: number; endLine: number; text: string },
+			select?: (_title: string, options: string[]) => Promise<string | undefined>,
+		) =>
+			createMockContext({
+				mode: "tui",
+				hasUI: true,
+				cwd: root,
+				sessionManager,
+				ui: {
+					theme: { fg: (_color: string, text: string) => text },
+					notify() {},
+					setWidget() {},
+					async custom() {
+						return { kind: "quote", quote };
+					},
+					select: select ?? (async () => undefined),
+					pasteToEditor() {},
+				},
+			});
+		const oldContext = makeContext(
+			oldManager,
+			{ path: "src/old.ts", startLine: 1, endLine: 1, text: "old" },
+			async (_title, options) => {
+				oldSelection = options[0];
+				return new Promise((resolve) => {
+					resolveOldSelection = resolve;
+				});
+			},
+		);
+		const newContext = makeContext(newManager, {
+			path: "src/new.ts",
+			startLine: 1,
+			endLine: 1,
+			text: "new",
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
+		await command?.handler("", oldContext.ctx);
+		const oldRemoval = Promise.resolve(command?.handler("remove", oldContext.ctx));
+		await mock.events.get("session_start")?.[0]?.({}, newContext.ctx);
+		await command?.handler("", newContext.ctx);
+		resolveOldSelection?.(oldSelection);
+		await oldRemoval;
+
+		const injection = await mock.events.get("before_agent_start")?.[0]?.(
+			{ prompt: "Explain", systemPrompt: "base" },
+			newContext.ctx,
+		);
+		assert.doesNotMatch(JSON.stringify(injection), /src\/old\.ts/u);
+		assert.match(JSON.stringify(injection), /src\/new\.ts/u);
+	});
+});


### PR DESCRIPTION
## Summary

- Make `/file-context` open an Add, Remove, and Help menu with visible pending-quote and shortcut state.
- Preview and repeatedly remove exact pending snapshots by stable identity while keeping cancellation, failures, and stale sessions side-effect free.
- Preserve `F8` as the direct explorer path and add compatible `/file-context browse` and `/file-context remove` routes.
- Add cancellable project scanning, Pi TUI Kit integration, updated documentation, and a minor Changeset.

## Verification

- `npx vitest run packages/pi-file-context/test/*.test.ts` — 60 tests passed.
- `PI_CODING_AGENT_DIR=<temp> npm run check` — 3,006 tests passed.
- `npm run check:boundaries` — passed.
- `just pack file-context` — 13-file dry-run tarball inspected successfully.
- `npx changeset status --verbose` — `@narumitw/pi-file-context` scheduled for a minor release.

## Notes

- The Kit scan loader maps either cancel key to a side-effect-free return to the menu.
- A live interactive Pi smoke was not run in this non-interactive harness.