### PR TITLE
chore: add Just test recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,6 +8,10 @@ default:
 check:
     npm run check
 
+# Run all active tests
+test:
+    npm test
+
 # Format all files with Biome
 format:
     npm run format


### PR DESCRIPTION
## Summary

- Add a `just test` recipe that delegates to `npm test`.
- Expose the active test suite alongside the existing check and format workflows.

## Verification

- `PI_CODING_AGENT_DIR=<temporary directory> just test` with 302 passing test files and 3,012 passing tests.
- Commit pre-checks: `npm run biome:check` and `npm run typecheck`.
- `git diff --check`.

## Release

- No changeset because this is a repository-only tooling change.