### PR TITLE
test(subagents): isolate settings-dependent suites

### DIFF
--- a/packages/pi-subagents/test/inspect.test.ts
+++ b/packages/pi-subagents/test/inspect.test.ts
@@ -2,13 +2,17 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { test } from "vitest";
+import { afterAll, test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerSubagentInspect } from "../src/inspect.js";
 import type { AgentRunInspectionDetail, AgentRunInspectionSummary } from "../src/registry.js";
 import { resolveStatefulLimits } from "../src/stateful-limits.js";
 import { WorkItemLedger } from "../src/work-item-ledger.js";
 import { createSessionWorkItemPersistence } from "../src/work-item-persistence.js";
+import { installSubagentsTestEnvironment } from "./subagents-test-helpers.js";
+
+const restoreTestEnvironment = installSubagentsTestEnvironment();
+afterAll(restoreTestEnvironment);
 
 function runtime(
 	options: {

--- a/packages/pi-subagents/test/panel-execution.test.ts
+++ b/packages/pi-subagents/test/panel-execution.test.ts
@@ -11,9 +11,13 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { test } from "vitest";
+import { afterAll, test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import subagents from "../src/subagents.js";
+import { installSubagentsTestEnvironment } from "./subagents-test-helpers.js";
+
+const restoreTestEnvironment = installSubagentsTestEnvironment();
+afterAll(restoreTestEnvironment);
 
 const CORE_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
 


### PR DESCRIPTION
## Summary

- Isolate the inspect and panel suites from the developer’s real `pi-subagents.json`.
- Restore `PI_CODING_AGENT_DIR` and remove the temporary test directory after each suite.
- Prevent user settings such as `blocking.enabled: false` from changing tool registration and status-source assertions.

## Verification

- Red: focused suites had 17 failures when the real user settings disabled blocking tools.
- `npx vitest run packages/pi-subagents/test/inspect.test.ts packages/pi-subagents/test/panel-execution.test.ts` with 22 passing tests.
- `just test` with 302 passing test files and 3,012 passing tests under the normal local environment.
- `npm run check`.
- `git diff --check`.

## Semantic audit

- Audited the test-only change against `docs/extension-conventions.md` and `docs/extension-settings.md`.
- The shared harness owns and removes its temporary agent directory and restores the prior environment value.
- No production settings, lifecycle, or extension behavior changed.

## Release

- No changeset because this is a test-only fix.