### PR TITLE
test: isolate Pi agent directories globally

### DIFF
--- a/packages/pi-subagents/test/inspect.test.ts
+++ b/packages/pi-subagents/test/inspect.test.ts
@@ -2,17 +2,13 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, test } from "vitest";
+import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerSubagentInspect } from "../src/inspect.js";
 import type { AgentRunInspectionDetail, AgentRunInspectionSummary } from "../src/registry.js";
 import { resolveStatefulLimits } from "../src/stateful-limits.js";
 import { WorkItemLedger } from "../src/work-item-ledger.js";
 import { createSessionWorkItemPersistence } from "../src/work-item-persistence.js";
-import { installSubagentsTestEnvironment } from "./subagents-test-helpers.js";
-
-const restoreTestEnvironment = installSubagentsTestEnvironment();
-afterAll(restoreTestEnvironment);
 
 function runtime(
 	options: {

--- a/packages/pi-subagents/test/panel-execution.test.ts
+++ b/packages/pi-subagents/test/panel-execution.test.ts
@@ -11,13 +11,9 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, test } from "vitest";
+import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import subagents from "../src/subagents.js";
-import { installSubagentsTestEnvironment } from "./subagents-test-helpers.js";
-
-const restoreTestEnvironment = installSubagentsTestEnvironment();
-afterAll(restoreTestEnvironment);
 
 const CORE_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
 

--- a/test/vitest.global-setup.ts
+++ b/test/vitest.global-setup.ts
@@ -1,0 +1,15 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export default function setup(): () => void {
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const testRoot = mkdtempSync(path.join(os.tmpdir(), "pi-extensions-test-"));
+	process.env.PI_CODING_AGENT_DIR = testRoot;
+
+	return () => {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		rmSync(testRoot, { recursive: true, force: true });
+	};
+}

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,4 +1,16 @@
-import { afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, vi } from "vitest";
+
+const testRoot = process.env.PI_CODING_AGENT_DIR;
+if (!testRoot) throw new Error("Vitest global setup did not provide PI_CODING_AGENT_DIR");
+const testAgentDir = mkdtempSync(path.join(testRoot, "agent-"));
+process.env.PI_CODING_AGENT_DIR = testAgentDir;
+
+afterAll(() => {
+	process.env.PI_CODING_AGENT_DIR = testRoot;
+	rmSync(testAgentDir, { recursive: true, force: true });
+});
 
 afterEach(() => {
 	vi.useRealTimers();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 		environment: "node",
 		hookTimeout: 0,
 		include: ["test/**/*.test.ts", "packages/*/test/**/*.test.ts"],
+		globalSetup: ["./test/vitest.global-setup.ts"],
 		pool: "forks",
 		setupFiles: ["./test/vitest.setup.ts"],
 		testTimeout: 0,


### PR DESCRIPTION
## Summary

- Set `PI_CODING_AGENT_DIR` from Vitest global setup before test modules load.
- Give every test file its own empty agent directory so parallel suites cannot share settings or state.
- Restore the original environment and recursively remove the test root after the run, including leftovers from interrupted file cleanup.
- Remove the now-redundant per-suite workaround from the Pi Subagents inspect and panel tests.

## Verification

- `npx vitest run packages/pi-subagents/test/inspect.test.ts packages/pi-subagents/test/panel-execution.test.ts` with 22 passing tests under local user settings that disable blocking subagents.
- `npm run check` with 305 passing test files and 3,025 passing tests.
- Verified zero `pi-extensions-test-*` temporary roots before and after focused and full test runs.
- `git diff --check`.

## Semantic audit

- Every Vitest file receives an empty, file-owned `PI_CODING_AGENT_DIR` before its imports execute.
- Tests that explicitly override the variable continue restoring to their isolated file directory.
- File cleanup runs after suite-owned cleanup, while global teardown provides a final recursive cleanup boundary.
- No production extension or settings behavior changed.

## Release

- No changeset because this is test infrastructure only.