### PR TITLE
test: bound Vitest tests and hooks

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,11 +3,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		environment: "node",
-		hookTimeout: 0,
+		hookTimeout: 30_000,
 		include: ["test/**/*.test.ts", "packages/*/test/**/*.test.ts"],
 		globalSetup: ["./test/vitest.global-setup.ts"],
 		pool: "forks",
 		setupFiles: ["./test/vitest.setup.ts"],
-		testTimeout: 0,
+		teardownTimeout: 10_000,
+		testTimeout: 30_000,
 	},
 });


### PR DESCRIPTION
## Summary

- Replace unlimited Vitest test timeouts with a 30-second limit per test.
- Replace unlimited hook timeouts with a 30-second limit per hook.
- Set an explicit 10-second teardown timeout.
- Keep the change limited to timeout controls supported directly by Vitest.

## Verification

- `npm run check` with 305 passing test files and 3,032 passing tests.
- Commit pre-checks: `npm run biome:check` and `npm run typecheck`.
- `git diff --check`.

## Notes

- Vitest does not provide aggregate per-file or full-run hard caps, so this PR does not add external process supervision.
- No red-first test was added because this is static test-runner configuration; successful config loading and the full suite verify it.

## Release

- No changeset because this is repository test tooling only.