### PR TITLE
test(pi-subagents): stabilize auto-resume completion wait

### DIFF
--- a/packages/pi-subagents/test/in-process-transport.test.ts
+++ b/packages/pi-subagents/test/in-process-transport.test.ts
@@ -710,8 +710,9 @@ test("registered detached spawn auto-resumes without exposing a wait tool", asyn
 			}>;
 		};
 		const waitForCompletionCount = async (expected: number) => {
-			for (let attempt = 0; attempt < 50 && mock.sentMessages.length < expected; attempt++) {
-				await new Promise((resolve) => setTimeout(resolve, 2));
+			const deadline = Date.now() + 5_000;
+			while (mock.sentMessages.length < expected && Date.now() < deadline) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			}
 			assert.equal(mock.sentMessages.length, expected);
 		};


### PR DESCRIPTION
## Summary

- Replace the auto-resume test's roughly 100 ms attempt limit with a five-second wall-clock deadline.
- Keep the exact completion-count assertion while allowing normal CI scheduler delays.
- Address the flaky failure in [CI run 31521843392](https://github.com/narumiruna/pi-extensions/actions/runs/31521843392/job/93880517193).

## Verification

- Focused auto-resume test passed 20 consecutive runs.
- `npm run check` passed with 305 test files and 3,032 tests.
- `git diff --check` passed.

## Notes

- No production behavior changed, so red-first TDD and a Changeset are not applicable.
- Reviewed the extension conventions touched-area checklist; this test-only change affects no package, lifecycle, settings, command, or publishing contract.
