### PR TITLE
feat(caffeinate): inhibit Linux desktop idle

### DIFF
--- a/.changeset/awake-wayland-desktops.md
+++ b/.changeset/awake-wayland-desktops.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-caffeinate": patch
+---
+
+Keep Linux desktops awake by pairing sleep blocking with `org.freedesktop.ScreenSaver` idle inhibition in display mode.

--- a/docs/plans/archived/2026-08-12_pi-caffeinate-linux-idle-inhibit-plan.md
+++ b/docs/plans/archived/2026-08-12_pi-caffeinate-linux-idle-inhibit-plan.md
@@ -1,0 +1,31 @@
+# Pi Caffeinate Linux Idle Inhibit Plan
+
+## Goal
+
+Make Linux `display` mode block desktop or compositor idle actions as well as system sleep.
+
+## Context
+
+`systemd-inhibit --what=idle:sleep` blocks logind suspend but does not stop every Wayland compositor idle timer.
+
+Issue #248 requests compositor-level idle inhibition, and a 20-minute niri and DankMaterialShell smoke confirmed `org.freedesktop.ScreenSaver` works for this setup.
+
+## Plan
+
+- [x] Pair Linux display-mode process inhibition with a session-bus `org.freedesktop.ScreenSaver.Inhibit` cookie.
+- [x] Support both standard `/org/freedesktop/ScreenSaver` and niri-compatible `/ScreenSaver` object paths.
+- [x] Release D-Bus and child-process resources on agent end, manual stop, session replacement, shutdown, partial failure, and an in-flight acquisition race.
+- [x] Preserve mode-change persistence ordering and runtime rollback behavior.
+- [x] Add the runtime dependency, package Changeset, focused tests, and user-facing Linux behavior documentation.
+- [x] Run package checks, repository gate, package dry-run, and local Pi smoke.
+  Evidence: package format, typecheck, and 31 tests pass; repository build, Biome check over 974 source-controlled files, boundaries, all workspace typechecks, and 3,104 tests pass; dry-run tarball contains nine expected files; tsx loads the entrypoint.
+- [x] Audit lifecycle, package, documentation, and verification requirements from `docs/extension-conventions.md` and `docs/extension-settings.md`.
+  Evidence: session generations and inhibitor sequence reject stale async work; every child and D-Bus path releases on stop or connection close; package metadata and README match runtime behavior; settings ordering and rollback remain intact; independent review found no blocking issues.
+
+## Completion Checklist
+
+- [x] Linux sleep mode remains system-sleep-only.
+- [x] Linux display mode can remain partially active when one inhibitor backend fails.
+- [x] D-Bus-only fallback reports its logind limitation.
+- [x] No behavior changes on macOS, Windows, WSL, or custom commands.
+- [x] Verification evidence recorded and plan archived.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5929,6 +5929,21 @@
 				"node": ">= 12"
 			}
 		},
+		"node_modules/dbus-native": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.15.1.tgz",
+			"integrity": "sha512-2Zdm+2eQuhmX08/Dyk3fltCqij5LGUwSx3Wj/ZN9IowlUw6eGfYZZXxkviUcN1iPOvWOQWUi74/nVnjZmg37vg==",
+			"license": "MIT",
+			"dependencies": {
+				"xml2js": "^0.6.2"
+			},
+			"bin": {
+				"dbus-native": "bin/dbus-native.js"
+			},
+			"engines": {
+				"node": ">=22.12.0"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -8100,6 +8115,15 @@
 			"integrity": "sha512-Zq+J1TefpoEq/HTUabo0YXX5MNvttjWYODGohgPBO2jfko8Wqx3JYMgE823szDFVamdH5PlpByvfiWScTdSYDA==",
 			"license": "MIT"
 		},
+		"node_modules/sax": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+			"integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
+		},
 		"node_modules/scheduler": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -9079,6 +9103,28 @@
 				"node": ">=16.0.0"
 			}
 		},
+		"node_modules/xml2js": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -9287,7 +9333,8 @@
 			"version": "0.49.3",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1"
+				"@narumitw/pi-tui-kit": "^0.49.1",
+				"dbus-native": "^0.15.1"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",

--- a/packages/pi-caffeinate/README.md
+++ b/packages/pi-caffeinate/README.md
@@ -17,6 +17,7 @@ It is designed for long-running coding, refactoring, debugging, web research, an
 - Persists the selected keep-awake mode and optional quiet mode in a small JSON settings file.
 - Allows a custom inhibitor command through environment configuration.
 - Emits plain status text; `@narumitw/pi-statusline` can add or suppress the status icon from JSON config.
+- Uses the standard `org.freedesktop.ScreenSaver` D-Bus idle-inhibition service for Linux `display` mode.
 - Fails safely when no supported inhibitor is available.
 
 ## 📦 Install
@@ -48,8 +49,17 @@ Use `/caffeinate sleep` if you want to prevent system sleep while allowing norma
 | macOS | `caffeinate -ims` | `caffeinate -dimsu` |
 | Windows | PowerShell `SetThreadExecutionState(0x80000001)` | PowerShell `SetThreadExecutionState(0x80000003)` |
 | WSL | Windows `powershell.exe` with `SetThreadExecutionState(0x80000001)` | Windows `powershell.exe` with `SetThreadExecutionState(0x80000003)` |
-| Linux with systemd | `systemd-inhibit --what=sleep ... sleep infinity` | `systemd-inhibit --what=idle:sleep ... sleep infinity` |
-| Linux fallback | `caffeinate -ims` when available | `caffeinate -dimsu` when available |
+| Linux with systemd | `systemd-inhibit --what=sleep ... sleep infinity` | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `systemd-inhibit --what=sleep ... sleep infinity` |
+| Linux without systemd | `caffeinate -ims` when available | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `caffeinate -dimsu` when available; D-Bus only otherwise |
+
+On Linux, `display` mode requests idle inhibition through the standard `org.freedesktop.ScreenSaver`
+D-Bus service, trying both `/org/freedesktop/ScreenSaver` and `/ScreenSaver` for desktop compatibility.
+The session-bus connection stays open for the whole agent turn.
+The inhibition ends when `UnInhibit` is called or the connection closes.
+`systemd-inhibit --what=sleep` runs alongside it to block actual suspend through logind.
+If no ScreenSaver service is available, pi-caffeinate keeps the systemd blocker or `caffeinate`
+fallback and reports a partial-activation warning.
+If only D-Bus is available, desktop idle is inhibited but direct logind suspend may remain possible.
 
 If no supported inhibitor is available, the extension stays loaded and reports that caffeinate is unavailable.
 
@@ -165,6 +175,11 @@ Without `@narumitw/pi-statusline`, keep using `PI_CAFFEINATE_ICON` during the co
 AI coding agents often run tool-heavy tasks that take several minutes. `pi-caffeinate` keeps your machine awake during active Pi work, helping browser automation, local builds, test runs, code generation, and long prompts finish reliably.
 
 The default display-awake mode prioritizes uninterrupted long-running Pi work across platforms, including Linux desktops that require idle inhibition to prevent automatic suspend. Use `/caffeinate sleep` (shown as `system-awake` in status output) when you prefer normal screen power saving and your system does not need idle inhibition to keep Pi running.
+
+## 📦 Dependencies
+
+On Linux, `display` mode uses the `dbus-native` package (pure JavaScript, no native build step) to
+call `org.freedesktop.ScreenSaver` on the session bus.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-caffeinate/package.json
+++ b/packages/pi-caffeinate/package.json
@@ -46,6 +46,7 @@
 		"directory": "packages/pi-caffeinate"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1"
+		"@narumitw/pi-tui-kit": "^0.49.1",
+		"dbus-native": "^0.15.1"
 	}
 }

--- a/packages/pi-caffeinate/src/caffeinate.ts
+++ b/packages/pi-caffeinate/src/caffeinate.ts
@@ -5,6 +5,13 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import {
+	type DbusScreenSaverClient,
+	type DbusScreenSaverFactory,
+	defaultDbusScreenSaverFactory,
+	INHIBIT_REASON,
+	SCREENSAVER_BUS_NAME,
+} from "./dbus-inhibit.js";
 import { startInhibitorProcess, stopInhibitorProcess } from "./inhibitor-process.js";
 import { formatMode, getInhibitorCommand, type InhibitorCommand } from "./inhibitors.js";
 import {
@@ -41,11 +48,18 @@ const MODE_OPTIONS = {
 type CommandAction = "menu" | "help" | "status" | "mode" | "sleep" | "display" | "stop";
 type CommandContext = ExtensionCommandContext;
 
+interface CaffeinateOptions {
+	dbusFactory?: DbusScreenSaverFactory;
+}
+
 interface CaffeinateState {
 	process?: ChildProcess;
+	dbus?: DbusScreenSaverClient;
 	startedAt?: number;
 	command?: InhibitorCommand;
 	lastError?: string;
+	inhibitWarning?: string;
+	inhibitorStarting: boolean;
 	activeTurns: number;
 	available: boolean;
 	disabled: boolean;
@@ -62,6 +76,7 @@ interface CaffeinateState {
 const state: CaffeinateState = {
 	activeTurns: 0,
 	available: true,
+	inhibitorStarting: false,
 	disabled: isDisabled(),
 	mode: DEFAULT_MODE,
 	quiet: false,
@@ -71,7 +86,11 @@ const state: CaffeinateState = {
 	menuController: new AbortController(),
 };
 
-export default function caffeinate(pi: ExtensionAPI) {
+let dbusFactory = defaultDbusScreenSaverFactory;
+let inhibitSequence = 0;
+
+export default function caffeinate(pi: ExtensionAPI, options: CaffeinateOptions = {}) {
+	dbusFactory = options.dbusFactory ?? defaultDbusScreenSaverFactory;
 	pi.on("session_start", async (_event, ctx) => {
 		const generation = ++state.sessionGeneration;
 		replaceMenuController("Caffeinate session replaced");
@@ -88,24 +107,27 @@ export default function caffeinate(pi: ExtensionAPI) {
 		await ensureSettingsLoaded(ctx, generation);
 		if (generation !== state.sessionGeneration) return;
 		state.activeTurns += 1;
-		startInhibitor(ctx, { notify: !state.quiet });
+		await startInhibitor(ctx, generation, { notify: !state.quiet });
 	});
 
-	pi.on("agent_end", (_event, ctx) => {
+	pi.on("agent_end", async (_event, ctx) => {
+		const generation = state.sessionGeneration;
 		state.activeTurns = Math.max(0, state.activeTurns - 1);
 		if (state.activeTurns === 0) {
-			stopInhibitor(ctx, "agent finished", { notify: !state.quiet });
+			await stopInhibitor(ctx, "agent finished", { notify: !state.quiet });
 		}
+		if (generation !== state.sessionGeneration) return;
 		updateStatus(ctx);
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
-		state.sessionGeneration += 1;
+		const generation = ++state.sessionGeneration;
 		state.menuController.abort(new DOMException("Caffeinate session shut down", "AbortError"));
 		state.activeTurns = 0;
-		stopInhibitor(ctx, "session shutdown", { notify: false });
-		ctx.ui.setStatus(STATUS_KEY, undefined);
+		await stopInhibitor(ctx, "session shutdown", { notify: false });
 		await modeOperationQueue;
+		if (generation !== state.sessionGeneration) return;
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 
 	pi.registerCommand("caffeinate", {
@@ -147,7 +169,7 @@ async function handleCaffeinateCommand(args: string, ctx: CommandContext, genera
 			await setMode(ctx, "display", generation);
 			return;
 		case "stop":
-			stopCaffeinate(ctx, "manual stop");
+			await stopCaffeinate(ctx, "manual stop", generation);
 			return;
 	}
 
@@ -215,7 +237,7 @@ async function runCaffeinateMenu(ctx: CommandContext, generation: number, start:
 				return { kind: "close" };
 			},
 			stop: async () => {
-				stopCaffeinate(ctx, "manual stop");
+				await stopCaffeinate(ctx, "manual stop", generation);
 				return { kind: "close" };
 			},
 			help: async () => {
@@ -264,18 +286,23 @@ async function setModeNow(ctx: ExtensionContext, mode: CaffeinateMode, generatio
 	if (generation !== state.sessionGeneration) return;
 	const previousMode = state.mode;
 	const previousQuiet = state.quiet;
-	const restartRequired = Boolean(state.process && previousMode !== mode && !state.command?.custom);
+	const restartRequired = Boolean(
+		hasActiveInhibitor() && previousMode !== mode && !state.command?.custom,
+	);
 	state.settingsError = undefined;
 
 	if (restartRequired) {
 		state.mode = mode;
-		stopInhibitor(ctx, "mode changed", { notify: false });
-		startInhibitor(ctx, { notify: false });
-		if (!state.process) {
+		await stopInhibitor(ctx, "mode changed", { notify: false });
+		if (generation !== state.sessionGeneration) return;
+		await startInhibitor(ctx, generation, { notify: false });
+		if (generation !== state.sessionGeneration) return;
+		if (!hasActiveInhibitor()) {
 			const applicationError = state.lastError ?? "the inhibitor could not be restarted";
 			state.mode = previousMode;
-			startInhibitor(ctx, { notify: false });
-			const rollbackError = state.process
+			await startInhibitor(ctx, generation, { notify: false });
+			if (generation !== state.sessionGeneration) return;
+			const rollbackError = hasActiveInhibitor()
 				? undefined
 				: (state.lastError ?? "the previous inhibitor could not be restored");
 			state.settingsError = rollbackError
@@ -296,9 +323,13 @@ async function setModeNow(ctx: ExtensionContext, mode: CaffeinateMode, generatio
 		if (restartRequired) {
 			state.mode = previousMode;
 			state.quiet = previousQuiet;
-			stopInhibitor(ctx, "settings save failed", { notify: false });
-			startInhibitor(ctx, { notify: false });
-			if (!state.process) rollbackError = state.lastError ?? "the prior inhibitor was not restored";
+			await stopInhibitor(ctx, "settings save failed", { notify: false });
+			if (generation !== state.sessionGeneration) return;
+			await startInhibitor(ctx, generation, { notify: false });
+			if (generation !== state.sessionGeneration) return;
+			if (!hasActiveInhibitor()) {
+				rollbackError = state.lastError ?? "the prior inhibitor was not restored";
+			}
 		}
 		state.settingsError = rollbackError
 			? `settings save failed (${formatError(error)}); runtime rollback failed: ${rollbackError}`
@@ -323,9 +354,10 @@ function showStatus(ctx: ExtensionContext) {
 	updateStatus(ctx);
 }
 
-function stopCaffeinate(ctx: ExtensionContext, reason: string) {
+async function stopCaffeinate(ctx: ExtensionContext, reason: string, sessionGeneration: number) {
 	state.activeTurns = 0;
-	stopInhibitor(ctx, reason);
+	await stopInhibitor(ctx, reason);
+	if (sessionGeneration !== state.sessionGeneration) return;
 	updateStatus(ctx);
 }
 
@@ -363,14 +395,24 @@ function buildCommandGuide() {
 	].join("\n");
 }
 
-function startInhibitor(ctx: ExtensionContext, options: { notify?: boolean } = {}) {
-	if (state.disabled || state.process) {
+async function startInhibitor(
+	ctx: ExtensionContext,
+	sessionGeneration: number,
+	options: { notify?: boolean } = {},
+) {
+	if (state.disabled || hasActiveInhibitor() || state.inhibitorStarting) {
 		updateStatus(ctx);
 		return;
 	}
 
+	const token = ++inhibitSequence;
 	const command = getInhibitorCommand(state.mode);
-	if (!command) {
+	const wantsDbus =
+		!command?.custom &&
+		state.mode === "display" &&
+		process.platform === "linux" &&
+		(command === undefined || command.addDbusIdleInhibit === true);
+	if (!command && !wantsDbus) {
 		state.available = false;
 		state.lastError = `No supported sleep inhibitor found for ${process.platform}.`;
 		ctx.ui.notify(state.lastError, "warning");
@@ -378,56 +420,154 @@ function startInhibitor(ctx: ExtensionContext, options: { notify?: boolean } = {
 		return;
 	}
 
-	try {
-		const child = startInhibitorProcess(
-			command,
-			(error) => {
-				if (state.process === child) {
-					state.process = undefined;
-					state.startedAt = undefined;
-				}
-				state.available = false;
-				state.lastError = `${command.description} failed: ${error.message}`;
-				ctx.ui.notify(state.lastError, "warning");
-				updateStatus(ctx);
-			},
-			(exit) => {
-				if (state.process !== child) return;
-				state.process = undefined;
-				state.startedAt = undefined;
-				state.available = false;
-				state.lastError = `${command.description} exited unexpectedly (${exit}).`;
-				ctx.ui.notify(state.lastError, "warning");
-				updateStatus(ctx);
-			},
-		);
-		state.process = child;
-		state.startedAt = Date.now();
-		state.command = command;
-		state.available = true;
-		state.lastError = undefined;
-		if (options.notify !== false) {
-			ctx.ui.notify(`Keeping computer awake (${statusModeLabel()}).`, "info");
-		}
-		updateStatus(ctx);
-	} catch (error) {
+	state.inhibitorStarting = true;
+	state.inhibitWarning = undefined;
+	let child: ChildProcess | undefined;
+	let childError: string | undefined;
+	let assembling = true;
+	const handleChildFailure = (message: string) => {
+		if (!child || token !== inhibitSequence || state.process !== child) return;
 		state.process = undefined;
-		state.startedAt = undefined;
-		state.available = false;
-		state.lastError = error instanceof Error ? error.message : String(error);
-		ctx.ui.notify(`Unable to start pi-caffeinate: ${state.lastError}`, "warning");
-		updateStatus(ctx);
+		state.command = undefined;
+		if (assembling) {
+			childError = message;
+			return;
+		}
+		applyChildFailure(ctx, message);
+	};
+
+	if (command) {
+		try {
+			child = startInhibitorProcess(
+				command,
+				(error) => handleChildFailure(`${command.description} failed: ${error.message}`),
+				(exit) => handleChildFailure(`${command.description} exited unexpectedly (${exit}).`),
+			);
+			state.process = child;
+			state.command = command;
+			state.startedAt = Date.now();
+		} catch (error) {
+			childError = `${command.description}: ${formatError(error)}`;
+		}
 	}
+
+	let dbus: DbusScreenSaverClient | undefined;
+	let dbusError: string | undefined;
+	if (wantsDbus) {
+		try {
+			dbus = await dbusFactory();
+			if (startIsStale(token, sessionGeneration)) {
+				await cancelPendingStart(token, child, command, dbus);
+				return;
+			}
+			await dbus.inhibit(INHIBIT_REASON);
+		} catch (error) {
+			dbusError = `D-Bus idle inhibit (${SCREENSAVER_BUS_NAME}): ${formatError(error)}`;
+			await dbus?.close().catch(() => undefined);
+			dbus = undefined;
+		}
+	}
+
+	assembling = false;
+	if (startIsStale(token, sessionGeneration)) {
+		await cancelPendingStart(token, child, command, dbus);
+		return;
+	}
+
+	state.inhibitorStarting = false;
+	state.dbus = dbus;
+	const failures = [childError, dbusError].filter((failure): failure is string => Boolean(failure));
+	if (!hasActiveInhibitor()) {
+		state.startedAt = undefined;
+		state.command = undefined;
+		state.available = false;
+		state.lastError =
+			failures.join("; ") || `No supported sleep inhibitor found for ${process.platform}.`;
+		ctx.ui.notify(state.lastError, "warning");
+		updateStatus(ctx);
+		return;
+	}
+
+	state.startedAt ??= Date.now();
+	state.available = true;
+	state.lastError = undefined;
+	state.inhibitWarning = failures.length > 0 ? failures.join("; ") : undefined;
+	if (state.inhibitWarning) {
+		ctx.ui.notify(`pi-caffeinate is partially active: ${state.inhibitWarning}`, "warning");
+	} else if (options.notify !== false) {
+		ctx.ui.notify(`Keeping computer awake (${statusModeLabel()}).`, "info");
+	}
+	updateStatus(ctx);
 }
 
-function stopInhibitor(ctx: ExtensionContext, reason: string, options: { notify?: boolean } = {}) {
+async function stopInhibitor(
+	ctx: ExtensionContext,
+	reason: string,
+	options: { notify?: boolean } = {},
+) {
+	inhibitSequence += 1;
 	const child = state.process;
-	if (!child) return;
+	const dbus = state.dbus;
+	const command = state.command;
+	const wasStarting = state.inhibitorStarting;
 	state.process = undefined;
-	state.startedAt = undefined;
-	stopInhibitorProcess(child, state.command);
+	state.dbus = undefined;
 	state.command = undefined;
+	state.startedAt = undefined;
+	state.inhibitWarning = undefined;
+	state.inhibitorStarting = false;
+	if (child) stopInhibitorProcess(child, command);
+	if (!child && !dbus && !wasStarting) return;
 	if (options.notify !== false) ctx.ui.notify(`Released pi-caffeinate (${reason}).`, "info");
+	if (!dbus) return;
+	try {
+		await dbus.uninhibit();
+	} catch {
+		// Closing the session-bus connection also releases its inhibition cookie.
+	}
+	await dbus.close().catch(() => undefined);
+}
+
+function applyChildFailure(ctx: ExtensionContext, message: string) {
+	if (state.dbus) {
+		state.available = true;
+		state.lastError = undefined;
+		state.inhibitWarning = message;
+	} else {
+		state.startedAt = undefined;
+		state.available = false;
+		state.lastError = message;
+		state.inhibitWarning = undefined;
+	}
+	ctx.ui.notify(message, "warning");
+	updateStatus(ctx);
+}
+
+function hasActiveInhibitor() {
+	return Boolean(state.process || state.dbus);
+}
+
+function startIsStale(token: number, sessionGeneration: number) {
+	return token !== inhibitSequence || sessionGeneration !== state.sessionGeneration;
+}
+
+async function cancelPendingStart(
+	token: number,
+	child: ChildProcess | undefined,
+	command: InhibitorCommand | undefined,
+	dbus: DbusScreenSaverClient | undefined,
+) {
+	if (token === inhibitSequence) {
+		inhibitSequence += 1;
+		state.inhibitorStarting = false;
+		if (child && state.process === child) {
+			state.process = undefined;
+			state.command = undefined;
+			state.startedAt = undefined;
+			stopInhibitorProcess(child, command);
+		}
+	}
+	await dbus?.close().catch(() => undefined);
 }
 
 function updateStatus(ctx: ExtensionContext) {
@@ -436,7 +576,7 @@ function updateStatus(ctx: ExtensionContext) {
 		return;
 	}
 
-	if (state.process) {
+	if (hasActiveInhibitor()) {
 		ctx.ui.setStatus(STATUS_KEY, withDeprecatedIcon(statusModeLabel()));
 		return;
 	}
@@ -465,11 +605,15 @@ function describeState() {
 		return lines.join("\n");
 	}
 
-	if (state.process) {
+	if (hasActiveInhibitor()) {
 		const seconds = state.startedAt ? Math.round((Date.now() - state.startedAt) / 1000) : 0;
+		const activeParts: string[] = [];
+		if (state.dbus) activeParts.push(`D-Bus idle inhibit (${SCREENSAVER_BUS_NAME})`);
+		if (state.process && state.command) activeParts.push(state.command.description);
 		lines.unshift(
-			`pi-caffeinate is active using ${state.command?.description ?? "an inhibitor"} for ${seconds}s.`,
+			`pi-caffeinate is active using ${activeParts.join(" + ") || "an inhibitor"} for ${seconds}s.`,
 		);
+		if (state.inhibitWarning) lines.push(`Inhibitor warning: ${state.inhibitWarning}`);
 		return lines.join("\n");
 	}
 
@@ -485,7 +629,7 @@ function describeState() {
 }
 
 function statusLevel() {
-	return state.available && !state.settingsError ? "info" : "warning";
+	return state.available && !state.settingsError && !state.inhibitWarning ? "info" : "warning";
 }
 
 function statusModeLabel() {
@@ -559,5 +703,10 @@ function warnDeprecatedIcon(ctx: ExtensionContext) {
 	);
 }
 
-export { formatMode, splitCommand, windowsInhibitorScript } from "./inhibitors.js";
+export {
+	formatMode,
+	getInhibitorCommand,
+	splitCommand,
+	windowsInhibitorScript,
+} from "./inhibitors.js";
 export { normalizeCaffeinateSettings } from "./settings.js";

--- a/packages/pi-caffeinate/src/dbus-inhibit.ts
+++ b/packages/pi-caffeinate/src/dbus-inhibit.ts
@@ -1,0 +1,84 @@
+import { type Message, type MessageBus, sessionBus } from "dbus-native";
+
+export const SCREENSAVER_BUS_NAME = "org.freedesktop.ScreenSaver";
+export const SCREENSAVER_INTERFACE = "org.freedesktop.ScreenSaver";
+export const INHIBIT_REASON = "Pi agent is running";
+
+const INHIBIT_APPLICATION_NAME = "pi-caffeinate";
+const SCREENSAVER_OBJECT_PATHS = ["/org/freedesktop/ScreenSaver", "/ScreenSaver"];
+
+export interface DbusScreenSaverClient {
+	inhibit(reason: string): Promise<void>;
+	uninhibit(): Promise<void>;
+	close(): Promise<void>;
+}
+
+export type DbusScreenSaverFactory = () => Promise<DbusScreenSaverClient>;
+
+export async function defaultDbusScreenSaverFactory(): Promise<DbusScreenSaverClient> {
+	return new NativeScreenSaverClient(sessionBus());
+}
+
+class NativeScreenSaverClient implements DbusScreenSaverClient {
+	private cookie?: number;
+	private objectPath?: string;
+
+	constructor(private readonly bus: MessageBus) {}
+
+	async inhibit(reason: string): Promise<void> {
+		let lastError: unknown;
+		for (const objectPath of SCREENSAVER_OBJECT_PATHS) {
+			try {
+				this.cookie = await invoke<number>(this.bus, {
+					destination: SCREENSAVER_BUS_NAME,
+					path: objectPath,
+					interface: SCREENSAVER_INTERFACE,
+					member: "Inhibit",
+					signature: "ss",
+					body: [INHIBIT_APPLICATION_NAME, reason],
+				});
+				this.objectPath = objectPath;
+				return;
+			} catch (error) {
+				lastError = error;
+			}
+		}
+		throw new Error(`D-Bus idle inhibit failed: ${formatError(lastError)}`, {
+			cause: lastError,
+		});
+	}
+
+	async uninhibit(): Promise<void> {
+		if (this.cookie === undefined || !this.objectPath) return;
+		const cookie = this.cookie;
+		this.cookie = undefined;
+		await invoke<void>(this.bus, {
+			destination: SCREENSAVER_BUS_NAME,
+			path: this.objectPath,
+			interface: SCREENSAVER_INTERFACE,
+			member: "UnInhibit",
+			signature: "u",
+			body: [cookie],
+		});
+	}
+
+	async close(): Promise<void> {
+		await this.bus.close();
+	}
+}
+
+function invoke<TResult>(bus: MessageBus, message: Message): Promise<TResult> {
+	return new Promise<TResult>((resolve, reject) => {
+		bus.invoke(message, (error, ...values) => {
+			if (error) reject(error);
+			else resolve(values[0] as TResult);
+		});
+	});
+}
+
+function formatError(error: unknown) {
+	if (error instanceof Error) {
+		return error.name === "Error" ? error.message : `${error.name}: ${error.message}`;
+	}
+	return String(error);
+}

--- a/packages/pi-caffeinate/src/inhibitors.ts
+++ b/packages/pi-caffeinate/src/inhibitors.ts
@@ -9,6 +9,8 @@ export interface InhibitorCommand {
 	description: string;
 	releaseOnStdinClose?: boolean;
 	custom?: boolean;
+	/** Display mode still needs D-Bus idle inhibit on top of this command (systemd blocks sleep only). */
+	addDbusIdleInhibit?: boolean;
 }
 
 export function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | undefined {
@@ -29,11 +31,10 @@ export function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | un
 			return windowsPowerInhibitorCommand("powershell.exe", mode);
 		}
 		if (commandExists("systemd-inhibit")) {
-			const what = mode === "sleep" ? "sleep" : "idle:sleep";
 			return parentBoundUnixCommand(
 				"systemd-inhibit",
 				[
-					`--what=${what}`,
+					"--what=sleep",
 					"--who=pi-caffeinate",
 					"--why=Pi agent is running",
 					"--mode=block",
@@ -41,6 +42,7 @@ export function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | un
 					"infinity",
 				],
 				`systemd-inhibit (${formatMode(mode)})`,
+				mode === "display",
 			);
 		}
 		if (commandExists("caffeinate")) {
@@ -48,6 +50,7 @@ export function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | un
 				"caffeinate",
 				macCaffeinateArgs(mode),
 				caffeinateDescription(mode),
+				mode === "display",
 			);
 		}
 	}
@@ -67,6 +70,7 @@ function parentBoundUnixCommand(
 	command: string,
 	args: string[],
 	description: string,
+	addDbusIdleInhibit = false,
 ): InhibitorCommand {
 	return {
 		command: "sh",
@@ -79,6 +83,7 @@ function parentBoundUnixCommand(
 			...args,
 		],
 		description,
+		...(addDbusIdleInhibit ? { addDbusIdleInhibit: true } : {}),
 	};
 }
 

--- a/packages/pi-caffeinate/test/caffeinate.test.ts
+++ b/packages/pi-caffeinate/test/caffeinate.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+	chmodSync,
 	existsSync,
 	mkdtempSync,
 	readdirSync,
@@ -15,11 +16,13 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import caffeinate, {
 	commandCompletions,
 	formatMode,
+	getInhibitorCommand,
 	normalizeCaffeinateSettings,
 	parseCommand,
 	splitCommand,
 	windowsInhibitorScript,
 } from "../src/caffeinate.js";
+import type { DbusScreenSaverClient, DbusScreenSaverFactory } from "../src/dbus-inhibit.js";
 import { saveSettings } from "../src/settings.js";
 
 const NEW_SETTINGS_FILE = "pi-caffeinate.json";
@@ -116,6 +119,79 @@ test("windowsInhibitorScript flags and formatMode labels are user-facing", () =>
 	assert.match(windowsInhibitorScript("display"), /\[uint32\]'0x80000000'/);
 	assert.equal(formatMode("sleep"), "system-awake");
 	assert.equal(formatMode("display"), "display-awake");
+});
+
+test("Linux display mode pairs the systemd sleep blocker with D-Bus idle inhibit", async () => {
+	await withLinuxPathCommands(["systemd-inhibit"], () => {
+		const command = getInhibitorCommand("display");
+
+		assert.equal(command?.description, "systemd-inhibit (display-awake)");
+		assert.ok(command?.args.includes("--what=sleep"));
+		assert.equal(command?.addDbusIdleInhibit, true);
+	});
+});
+
+test("Linux sleep mode uses only the systemd sleep blocker", async () => {
+	await withLinuxPathCommands(["systemd-inhibit"], () => {
+		const command = getInhibitorCommand("sleep");
+
+		assert.equal(command?.description, "systemd-inhibit (system-awake)");
+		assert.ok(command?.args.includes("--what=sleep"));
+		assert.equal(command?.addDbusIdleInhibit, undefined);
+	});
+});
+
+test("D-Bus idle inhibit falls back to the niri ScreenSaver object path", async () => {
+	const calls: Array<{ member?: string; path?: string; body?: unknown[] }> = [];
+	let closeCalls = 0;
+	vi.resetModules();
+	vi.doMock("dbus-native", () => ({
+		sessionBus: () => ({
+			invoke(
+				message: { member?: string; path?: string; body?: unknown[] },
+				callback: (error: Error | null, value?: number) => void,
+			) {
+				calls.push(message);
+				if (message.member === "Inhibit" && message.path === "/org/freedesktop/ScreenSaver") {
+					callback(new Error("Unknown object"));
+					return;
+				}
+				callback(null, message.member === "Inhibit" ? 42 : undefined);
+			},
+			async close() {
+				closeCalls += 1;
+			},
+		}),
+	}));
+
+	try {
+		const { defaultDbusScreenSaverFactory } = await import("../src/dbus-inhibit.js");
+		const client = await defaultDbusScreenSaverFactory();
+		await client.inhibit("test");
+		await client.uninhibit();
+		await client.close();
+
+		assert.deepEqual(
+			calls.map(({ member, path, body }) => ({ member, path, body })),
+			[
+				{
+					member: "Inhibit",
+					path: "/org/freedesktop/ScreenSaver",
+					body: ["pi-caffeinate", "test"],
+				},
+				{
+					member: "Inhibit",
+					path: "/ScreenSaver",
+					body: ["pi-caffeinate", "test"],
+				},
+				{ member: "UnInhibit", path: "/ScreenSaver", body: [42] },
+			],
+		);
+		assert.equal(closeCalls, 1);
+	} finally {
+		vi.doUnmock("dbus-native");
+		vi.resetModules();
+	}
 });
 
 test("caffeinate loads the new settings file without a migration warning", async () => {
@@ -515,6 +591,85 @@ test("default settings keep routine lifecycle notifications", async () => {
 	});
 });
 
+test("Linux display mode holds one D-Bus inhibitor for the agent turn", async () => {
+	await withLinuxPathCommands([], async () => {
+		await withTempAgentDir(async () => {
+			const clients: FakeDbusClient[] = [];
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const { ctx, notifications, statuses } = createMockContext();
+
+			caffeinateModule.default(mock.pi, { dbusFactory: fakeDbusFactory(clients) });
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			await mock.events.get("agent_start")?.[0]?.({}, ctx);
+
+			assert.equal(clients.length, 1);
+			assert.deepEqual(clients[0]?.inhibitCalls, ["Pi agent is running"]);
+			assert.equal(statuses.get("caffeinate"), "display-awake");
+			assert.match(notifications[0]?.message ?? "", /Keeping computer awake/);
+
+			await mock.events.get("agent_end")?.[0]?.({}, ctx);
+
+			assert.equal(clients[0]?.uninhibitCalls, 1);
+			assert.equal(clients[0]?.closeCalls, 1);
+			assert.equal(statuses.get("caffeinate"), undefined);
+		});
+	});
+});
+
+test("Linux display mode keeps the sleep blocker when D-Bus is unavailable", async () => {
+	await withLinuxPathCommands(["sh", "systemd-inhibit"], async () => {
+		await withTempAgentDir(async () => {
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const { ctx, notifications, statuses } = createMockContext();
+
+			caffeinateModule.default(mock.pi, {
+				dbusFactory: async () => {
+					throw new Error("no ScreenSaver service");
+				},
+			});
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			await mock.events.get("agent_start")?.[0]?.({}, ctx);
+
+			assert.equal(statuses.get("caffeinate"), "display-awake");
+			assert.match(notifications.at(-1)?.message ?? "", /partially active/);
+			assert.match(notifications.at(-1)?.message ?? "", /no ScreenSaver service/);
+
+			await mock.events.get("agent_end")?.[0]?.({}, ctx);
+		});
+	});
+});
+
+test("agent_end closes a D-Bus inhibitor acquired after stop began", async () => {
+	await withLinuxPathCommands([], async () => {
+		await withTempAgentDir(async () => {
+			const clients: FakeDbusClient[] = [];
+			let releaseInhibit: (() => void) | undefined;
+			const gate = new Promise<void>((resolve) => {
+				releaseInhibit = resolve;
+			});
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const { ctx, statuses } = createMockContext();
+
+			caffeinateModule.default(mock.pi, {
+				dbusFactory: fakeDbusFactory(clients, gate),
+			});
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			const startPromise = mock.events.get("agent_start")?.[0]?.({}, ctx);
+			await waitFor(() => clients[0]?.inhibitCalls.length === 1);
+			await mock.events.get("agent_end")?.[0]?.({}, ctx);
+			releaseInhibit?.();
+			await startPromise;
+
+			assert.equal(clients[0]?.uninhibitCalls, 0);
+			assert.equal(clients[0]?.closeCalls, 1);
+			assert.equal(statuses.get("caffeinate"), undefined);
+		});
+	});
+});
+
 async function importFreshCaffeinate() {
 	vi.resetModules();
 	return import("../src/caffeinate.js");
@@ -543,6 +698,70 @@ async function withTempAgentDir<T>(fn: (agentDir: string) => Promise<T>) {
 		else process.env.PI_CAFFEINATE_COMMAND = previousCommand;
 		rmSync(agentDir, { recursive: true, force: true });
 	}
+}
+
+async function withLinuxPathCommands<T>(commands: string[], fn: () => T | Promise<T>) {
+	const previousPath = process.env.PATH;
+	const previousCommand = process.env.PI_CAFFEINATE_COMMAND;
+	const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+	const binDir = mkdtempSync(path.join(os.tmpdir(), "pi-caffeinate-bin-"));
+
+	try {
+		for (const command of commands) {
+			const file = path.join(binDir, command);
+			if (command === "sh") {
+				const shell = process.env.SHELL;
+				if (!shell) throw new Error("SHELL is required for inhibitor lifecycle tests");
+				symlinkSync(shell, file);
+				continue;
+			}
+			writeFileSync(file, "#!/usr/bin/env sh\nwhile :; do :; done\n");
+			chmodSync(file, 0o755);
+		}
+		Object.defineProperty(process, "platform", { value: "linux" });
+		process.env.PATH = binDir;
+		delete process.env.PI_CAFFEINATE_COMMAND;
+		return await fn();
+	} finally {
+		if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+		if (previousPath === undefined) delete process.env.PATH;
+		else process.env.PATH = previousPath;
+		if (previousCommand === undefined) delete process.env.PI_CAFFEINATE_COMMAND;
+		else process.env.PI_CAFFEINATE_COMMAND = previousCommand;
+		rmSync(binDir, { recursive: true, force: true });
+	}
+}
+
+class FakeDbusClient implements DbusScreenSaverClient {
+	readonly inhibitCalls: string[] = [];
+	uninhibitCalls = 0;
+	closeCalls = 0;
+
+	constructor(private readonly inhibitResult: Promise<void> = Promise.resolve()) {}
+
+	async inhibit(reason: string): Promise<void> {
+		this.inhibitCalls.push(reason);
+		await this.inhibitResult;
+	}
+
+	async uninhibit(): Promise<void> {
+		this.uninhibitCalls += 1;
+	}
+
+	async close(): Promise<void> {
+		this.closeCalls += 1;
+	}
+}
+
+function fakeDbusFactory(
+	clients: FakeDbusClient[],
+	inhibitResult: Promise<void> = Promise.resolve(),
+): DbusScreenSaverFactory {
+	return async () => {
+		const client = new FakeDbusClient(inhibitResult);
+		clients.push(client);
+		return client;
+	};
 }
 
 function writeSettings(agentDir: string, fileName: string, mode: string, quiet?: boolean) {


### PR DESCRIPTION
## Summary

- pair Linux `display` mode sleep blocking with `org.freedesktop.ScreenSaver` idle inhibition
- support both standard `/org/freedesktop/ScreenSaver` and niri-compatible `/ScreenSaver` object paths
- preserve partial activation when either D-Bus or process inhibition fails
- release in-flight and active inhibitors across agent, command, session replacement, and shutdown paths
- document Linux behavior and add a patch Changeset

Closes https://github.com/narumiruna/pi-extensions/issues/248

## Verification

- 20-minute live run on niri with DankMaterialShell
- package format and typecheck
- 31 focused pi-caffeinate tests
- repository build, boundary check, and all workspace typechecks
- 322 test files and 3,104 tests
- Biome check over 974 source-controlled files
- `npm run changeset:status`
- `just pack caffeinate` (9 expected files)
- offline TypeScript entrypoint load
