### PR TITLE
test(sync): stabilize UI lifecycle waits

### DIFF
--- a/packages/pi-sync/test/remote-selection-ui.test.ts
+++ b/packages/pi-sync/test/remote-selection-ui.test.ts
@@ -236,7 +236,7 @@ test("saved remote list can continue the captured route or stop without file mut
 		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Continue Pull now/u);
 		tui.press("tui.select.confirm");
-		await waitFor(() => routes.length === 1);
+		await tui.waitForOpen();
 		assert.deepEqual(routes, [{ route: "pull", target: "home" }]);
 		assert.equal(existsSync(path.join(agentDir, "pi-starship.toml")), false);
 		releaseRoute();
@@ -256,6 +256,10 @@ test("keeping this device list invokes reviewed push force and cancellation retu
 		const tui = createTuiHarness({ width: 80, rows: 20 });
 		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
 		const routes: Array<{ route: string; target?: string }> = [];
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
 		const config = await loadConfig("home");
 		const running = showRemoteSelectionReview(ctx, "home", undefined, undefined, {
 			decision: {
@@ -267,6 +271,7 @@ test("keeping this device list invokes reviewed push force and cancellation retu
 			origin: "sync",
 			runRoute: async (route, _signal, _onCommit, target) => {
 				routes.push({ route, target });
+				await routeGate;
 				return { kind: "completed", outcome: "cancelled" };
 			},
 		});
@@ -275,9 +280,11 @@ test("keeping this device list invokes reviewed push force and cancellation retu
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
-		await waitFor(() => routes.length === 1);
 		await tui.waitForOpen();
 		assert.deepEqual(routes, [{ route: "push --force", target: "home" }]);
+		releaseRoute();
+		await tui.waitForPending();
+		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Synced content differs/u);
 		tui.press("tui.select.cancel");
 		assert.deepEqual(await running, { kind: "back" });
@@ -320,7 +327,7 @@ test("local-wins action refreshes when the reviewed setup identity changes", asy
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
-		await waitFor(() => tui.openCount >= 2);
+		await tui.waitForOpen();
 		assert.equal(routeCalls, 0);
 		assert.match(notifications.at(-1)?.message ?? "", /Refreshing the comparison/u);
 		tui.press("tui.select.cancel");
@@ -413,7 +420,7 @@ test("remote selection adoption refreshes a changed remote head and preserves se
 		await tui.waitForOpen();
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
-		await waitFor(() => tui.openCount >= 2);
+		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Synced content differs/u);
 		assert.match(notifications.at(-1)?.message ?? "", /Refreshing the comparison/u);
 		tui.press("tui.select.cancel");
@@ -450,7 +457,7 @@ test("remote selection adoption refreshes a concurrent local include change", as
 		await tui.waitForOpen();
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
-		await waitFor(() => tui.openCount >= 2);
+		await tui.waitForOpen();
 		assert.deepEqual((await readLocalConfigObject())?.syncSetups.home.sync.include, [
 			"models.json",
 		]);
@@ -525,12 +532,4 @@ async function publishSelection(backend: MemorySyncBackend, include: string[]) {
 		},
 		expectedRemoteHead(await backend.readHead()),
 	);
-}
-
-async function waitFor(condition: () => boolean) {
-	for (let attempt = 0; attempt < 100; attempt += 1) {
-		if (condition()) return;
-		await new Promise<void>((resolve) => setTimeout(resolve, 1));
-	}
-	assert.fail("Timed out waiting for condition");
 }

--- a/packages/pi-sync/test/sync-resolution-ui.test.ts
+++ b/packages/pi-sync/test/sync-resolution-ui.test.ts
@@ -52,7 +52,6 @@ test("resolution reviews exact differences and invokes local-wins push through t
 		assert.match(tui.render().join("\n"), /Review differences \(recommended\)/u);
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
-		await waitFor(() => routes.length === 1);
 		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Preparing local-wins push preview/u);
 		assert.deepEqual(
@@ -90,7 +89,7 @@ test("cancelling a remote-wins preparation drains work and returns to resolution
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		tui.press("tui.select.cancel");
-		await waitFor(() => routeSignal?.aborted === true);
+		assert.equal(routeSignal?.aborted, true);
 		releaseRoute();
 		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Resolve sync conflict/u);
@@ -153,9 +152,9 @@ test("cancelling the exact push confirmation returns to conflict resolution", as
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
-		const loaderOpenCount = tui.openCount;
 		releaseRoute();
-		await waitFor(() => tui.isOpen && tui.openCount > loaderOpenCount);
+		await tui.waitForPending();
+		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Resolve sync conflict/u);
 		tui.press("ctrl+c");
 		assert.deepEqual(await running, { kind: "closed" });
@@ -184,9 +183,9 @@ test("a repeated conflict refreshes resolution labels instead of closing", async
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
-		const loaderOpenCount = tui.openCount;
 		releaseRoute();
-		await waitFor(() => tui.isOpen && tui.openCount > loaderOpenCount);
+		await tui.waitForPending();
+		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Use local as initial source/u);
 		tui.press("ctrl+c");
 		assert.deepEqual(await running, { kind: "closed" });
@@ -258,7 +257,7 @@ test("session replacement aborts and drains a resolution operation", async () =>
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		owner.abort(new DOMException("Session replaced", "AbortError"));
-		await waitFor(() => routeSignal?.aborted === true);
+		assert.equal(routeSignal?.aborted, true);
 		releaseRoute();
 		assert.deepEqual(await running, { kind: "stale" });
 	});
@@ -269,6 +268,10 @@ test("repeated remote-selection decisions refresh through bounded manager dispat
 		const tui = createTuiHarness({ width: 60, rows: 18 });
 		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
 		let routeCalls = 0;
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
 		const running = dispatchManagerResult(
 			ctx,
 			{
@@ -285,6 +288,7 @@ test("repeated remote-selection decisions refresh through bounded manager dispat
 				routeCalls += 1;
 				assert.equal(route, "push --force");
 				assert.equal(target, "home");
+				await routeGate;
 				return {
 					kind: "remote-selection-required",
 					decision: {
@@ -301,8 +305,12 @@ test("repeated remote-selection decisions refresh through bounded manager dispat
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
-		await waitFor(() => routeCalls === 1);
-		await waitFor(() => tui.isOpen && /Synced content differs/u.test(tui.render().join("\n")));
+		await tui.waitForOpen();
+		assert.equal(routeCalls, 1);
+		releaseRoute();
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Synced content differs/u);
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /models\.json/u);
@@ -318,6 +326,10 @@ test("selection continuation hands a file-direction decision to existing resolut
 		const tui = createTuiHarness({ width: 60, rows: 18 });
 		const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
 		let routeCalls = 0;
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
+		});
 		const running = dispatchManagerResult(
 			ctx,
 			{
@@ -332,6 +344,7 @@ test("selection continuation hands a file-direction decision to existing resolut
 			"pull",
 			async () => {
 				routeCalls += 1;
+				await routeGate;
 				return { kind: "decision-required", decision };
 			},
 		);
@@ -340,8 +353,12 @@ test("selection continuation hands a file-direction decision to existing resolut
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
-		await waitFor(() => routeCalls === 1);
-		await waitFor(() => tui.isOpen && /Resolve sync conflict/u.test(tui.render().join("\n")));
+		await tui.waitForOpen();
+		assert.equal(routeCalls, 1);
+		releaseRoute();
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Resolve sync conflict/u);
 		tui.press("tui.select.cancel");
 		assert.deepEqual(await running, { kind: "stay" });
 	});
@@ -354,6 +371,10 @@ test("ordinary selection continuation failure is reported only by its route", as
 			hasUI: true,
 			mode: "tui",
 			custom: tui.custom,
+		});
+		let releaseRoute: () => void = () => undefined;
+		const routeGate = new Promise<void>((resolve) => {
+			releaseRoute = resolve;
 		});
 		const running = dispatchManagerResult(
 			ctx,
@@ -369,6 +390,7 @@ test("ordinary selection continuation failure is reported only by its route", as
 			"push",
 			async () => {
 				notifications.push({ message: "transport failed", level: "error" });
+				await routeGate;
 				return { kind: "failed" };
 			},
 		);
@@ -377,7 +399,10 @@ test("ordinary selection continuation failure is reported only by its route", as
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
-		await waitFor(() => notifications.length === 1);
+		await tui.waitForOpen();
+		assert.equal(notifications.length, 1);
+		releaseRoute();
+		await tui.waitForPending();
 		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Synced content differs/u);
 		assert.deepEqual(
@@ -414,9 +439,9 @@ test("the main manager opens inline remote-selection recovery", async () => {
 		await tui.waitForOpen();
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
-		const loaderOpenCount = tui.openCount;
 		releaseRoute();
-		await waitFor(() => tui.isOpen && tui.openCount > loaderOpenCount);
+		await tui.waitForPending();
+		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Synced content differs/u);
 		tui.press("tui.select.cancel");
 		await tui.waitForOpen();
@@ -518,11 +543,11 @@ test("attention for a non-current setup stays reviewable without blocking curren
 		assert.doesNotMatch(frame, /\[-\] Sync now/u);
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
-		await waitFor(() => routeCalls === 1);
 		await tui.waitForOpen();
-		const loaderOpenCount = tui.openCount;
+		assert.equal(routeCalls, 1);
 		releaseRoute();
-		await waitFor(() => tui.isOpen && tui.openCount > loaderOpenCount);
+		await tui.waitForPending();
+		await tui.waitForOpen();
 		tui.press("ctrl+c");
 		await running;
 	});
@@ -545,9 +570,9 @@ test("the main manager opens conflict recovery instead of ending at an error", a
 		await tui.waitForOpen();
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
-		const loaderOpenCount = tui.openCount;
 		releaseRoute();
-		await waitFor(() => tui.isOpen && tui.openCount > loaderOpenCount);
+		await tui.waitForPending();
+		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Resolve sync conflict/u);
 		tui.press("tui.select.cancel");
 		await tui.waitForOpen();
@@ -578,12 +603,4 @@ async function withConfiguredDecision(
 			syncConfigReviewFingerprint(config),
 		);
 	});
-}
-
-async function waitFor(condition: () => boolean) {
-	for (let attempt = 0; attempt < 100; attempt += 1) {
-		if (condition()) return;
-		await new Promise<void>((resolve) => setTimeout(resolve, 1));
-	}
-	assert.fail("Timed out waiting for condition");
 }

--- a/packages/pi-sync/test/sync.test.ts
+++ b/packages/pi-sync/test/sync.test.ts
@@ -245,7 +245,7 @@ test("direct interactive selection mismatch opens recovery and cancellation pres
 		});
 
 		const running = mock.commands.get("sync")?.handler("pull --setup home", ctx);
-		await waitFor(() => tui.isOpen);
+		await tui.waitForOpen();
 		assert.match(tui.render().join("\n"), /Synced content differs/u);
 		tui.press("tui.select.cancel");
 		await running;
@@ -290,7 +290,7 @@ test("direct interactive local-wins recovery clears attention after reviewed pub
 		});
 
 		const running = mock.commands.get("sync")?.handler("pull --setup home", ctx);
-		await waitFor(() => tui.isOpen);
+		await tui.waitForOpen();
 		tui.press("tui.select.down");
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
@@ -487,7 +487,9 @@ test("the command boundary sends only typed selection mismatches to the manager 
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
 		releaseOperation();
-		await waitFor(() => tui.isOpen && /Synced content differs/u.test(tui.render().join("\n")));
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Synced content differs/u);
 		assert.match(tui.render().join("\n"), /Remote-only paths: 1/u);
 		assert.deepEqual(notifications, []);
 		tui.press("tui.select.cancel");
@@ -526,7 +528,7 @@ test("automatic selection mismatch offers immediate TUI recovery and Later prese
 		});
 
 		const starting = mock.events.get("session_start")?.[0]?.({}, ctx);
-		await waitFor(() => tui.isOpen);
+		await tui.waitForOpen();
 		const frame = tui.render().join("\n");
 		assert.match(frame, /Synced content differs/u);
 		assert.match(frame, /Later/u);
@@ -606,7 +608,7 @@ test("session replacement aborts startup attention without stale presentation", 
 		const tui = createTuiHarness({ width: 60, rows: 18 });
 		const first = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
 		const firstStart = mock.events.get("session_start")?.[0]?.({}, first.ctx);
-		await waitFor(() => tui.isOpen);
+		await tui.waitForOpen();
 		let replacementCustomCalls = 0;
 		const replacement = createMockContext({
 			hasUI: true,
@@ -1044,12 +1046,4 @@ async function withStateDirectory(run: () => Promise<void>) {
 		mkdirSync(agentDir, { recursive: true });
 		await run();
 	});
-}
-
-async function waitFor(condition: () => boolean) {
-	for (let attempt = 0; attempt < 100; attempt += 1) {
-		if (condition()) return;
-		await new Promise<void>((resolve) => setTimeout(resolve, 1));
-	}
-	assert.fail("Timed out waiting for condition");
 }


### PR DESCRIPTION
## Summary

- Replace fixed 100 × 1 ms polling with `createTuiHarness` lifecycle waits.
- Gate mocked routes so busy components open before the mocked operation settles.
- Stabilize the same selection and conflict-recovery pattern across three `pi-sync` test files.

## Why

The linked [CI job](https://github.com/narumiruna/pi-extensions/actions/runs/31523679489/job/93886669679) timed out while waiting for a refreshed remote-selection screen.
The 100 ms polling budget could expire under load even though the UI flow was still progressing correctly.
The tests now wait for observable component openings and pending-work completion instead of elapsed time.

## Verification

- `npm run check` — 322 test files and 3,099 tests passed.
- Twenty consecutive combined runs of the three changed test files passed.
- The originally failing focused test passed after the synchronization change.

## Release

No changeset is included because this PR changes tests only.
