### PR TITLE
feat(caffeinate): harden Linux desktop idle inhibition

### DIFF
--- a/.changeset/awake-wayland-desktops.md
+++ b/.changeset/awake-wayland-desktops.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-caffeinate": patch
+---
+
+Keep Linux desktops awake by pairing sleep blocking with `org.freedesktop.ScreenSaver` idle inhibition in display mode.

--- a/docs/plans/archived/2026-08-12_pi-caffeinate-dbus-hardening-plan.md
+++ b/docs/plans/archived/2026-08-12_pi-caffeinate-dbus-hardening-plan.md
@@ -1,0 +1,44 @@
+# Pi Caffeinate D-Bus Hardening Plan
+
+## Goal
+
+Resolve the confirmed Linux D-Bus inhibitor review findings and add a reproducible Docker smoke for real session-bus behavior.
+
+## Context
+
+PR #721 adds `org.freedesktop.ScreenSaver` inhibition to Linux display mode.
+The follow-up must prevent transport errors from crashing Pi, report D-Bus-only activation honestly, cancel in-flight acquisition during cleanup, and retain logind idle inhibition.
+Docker can verify D-Bus transport and lifecycle behavior, but a real Wayland compositor remains outside this smoke.
+
+## Architecture
+
+Keep process and D-Bus backends independently owned by `caffeinate.ts`.
+Let `dbus-inhibit.ts` own transport errors, bounded calls, cancellation, and connection-loss reporting.
+Use deterministic fake clients for orchestration tests and a private `dbus-daemon` plus mock ScreenSaver service for the Docker smoke.
+
+## Plan
+
+- [x] Add focused failing tests for display-mode `idle:sleep`, D-Bus-only partial warnings, pending-acquisition cancellation, and active connection loss; verify each fails against the PR head.
+  Evidence: the focused file initially failed five tests for the five reviewed behaviors.
+- [x] Harden `dbus-inhibit.ts` and `caffeinate.ts` so transport errors are handled, D-Bus calls are bounded and abortable, pending clients are closed by stop/shutdown, and active disconnects update state; verify focused tests pass.
+  Evidence: all 34 focused tests and the package typecheck pass.
+- [x] Restore Linux display-mode logind idle inhibition while leaving sleep mode unchanged; verify command tests pass.
+  Evidence: focused command tests assert `idle:sleep` for display and `sleep` for sleep mode.
+- [x] Add `packages/pi-caffeinate/test/docker/` with a private session bus, mock standard and niri paths, stale-socket probe, D-Bus-only extension scenario, and pending-stop scenario; verify the Docker image passes.
+  Evidence: `npm run smoke:caffeinate-dbus` passes all five real-bus scenarios.
+- [x] Document the opt-in Docker command and its Wayland limitation, and expose a root smoke script; verify the documented command works.
+  Evidence: `test/docker/README.md` documents the passing root script and excludes compositor claims.
+- [x] Run package tests, package typecheck/format, root CI-equivalent checks, Changesets status, package dry-run, and an entrypoint load smoke.
+  Evidence: focused tests, package typecheck, Biome, `npm run check`, Changesets status, the nine-file package dry-run, and offline `pi --list-models` entrypoint load pass.
+- [x] Audit the final diff against `docs/extension-conventions.md`, `docs/extension-settings.md`, async cleanup, session replacement, partial failure, package, and Docker publishing boundaries.
+  Evidence: generation and token guards follow every acquisition await, pending and active clients have owned cleanup, shutdown covers replacement, settings ordering is unchanged, process and D-Bus partial failures remain independent, and package contents exclude Docker fixtures.
+
+## Completion Checklist
+
+- [x] A stale or unreachable session-bus socket cannot terminate Pi.
+- [x] D-Bus-only display mode is reported as partial and warns that system suspend may remain possible.
+- [x] Stop, agent end, replacement, and shutdown abort and close an in-flight D-Bus acquisition.
+- [x] Loss of an active D-Bus connection preserves process inhibition and reports partial activation, or reports unavailability when no process backend remains.
+- [x] Linux display mode keeps `idle:sleep`; Linux sleep mode keeps `sleep`.
+- [x] Docker smoke passes without claiming to emulate compositor display blanking.
+- [x] Required repository checks and package smokes pass with no known findings remaining.

--- a/docs/plans/archived/2026-08-12_pi-caffeinate-linux-idle-inhibit-plan.md
+++ b/docs/plans/archived/2026-08-12_pi-caffeinate-linux-idle-inhibit-plan.md
@@ -1,0 +1,31 @@
+# Pi Caffeinate Linux Idle Inhibit Plan
+
+## Goal
+
+Make Linux `display` mode block desktop or compositor idle actions as well as system sleep.
+
+## Context
+
+`systemd-inhibit --what=idle:sleep` blocks logind suspend but does not stop every Wayland compositor idle timer.
+
+Issue #248 requests compositor-level idle inhibition, and a 20-minute niri and DankMaterialShell smoke confirmed `org.freedesktop.ScreenSaver` works for this setup.
+
+## Plan
+
+- [x] Pair Linux display-mode process inhibition with a session-bus `org.freedesktop.ScreenSaver.Inhibit` cookie.
+- [x] Support both standard `/org/freedesktop/ScreenSaver` and niri-compatible `/ScreenSaver` object paths.
+- [x] Release D-Bus and child-process resources on agent end, manual stop, session replacement, shutdown, partial failure, and an in-flight acquisition race.
+- [x] Preserve mode-change persistence ordering and runtime rollback behavior.
+- [x] Add the runtime dependency, package Changeset, focused tests, and user-facing Linux behavior documentation.
+- [x] Run package checks, repository gate, package dry-run, and local Pi smoke.
+  Evidence: package format, typecheck, and 31 tests pass; repository build, Biome check over 974 source-controlled files, boundaries, all workspace typechecks, and 3,104 tests pass; dry-run tarball contains nine expected files; tsx loads the entrypoint.
+- [x] Audit lifecycle, package, documentation, and verification requirements from `docs/extension-conventions.md` and `docs/extension-settings.md`.
+  Evidence: session generations and inhibitor sequence reject stale async work; every child and D-Bus path releases on stop or connection close; package metadata and README match runtime behavior; settings ordering and rollback remain intact; independent review found no blocking issues.
+
+## Completion Checklist
+
+- [x] Linux sleep mode remains system-sleep-only.
+- [x] Linux display mode can remain partially active when one inhibitor backend fails.
+- [x] D-Bus-only fallback reports its logind limitation.
+- [x] No behavior changes on macOS, Windows, WSL, or custom commands.
+- [x] Verification evidence recorded and plan archived.

--- a/docs/plans/archived/2026-08-12_pi-caffeinate-pr-724-feedback-plan.md
+++ b/docs/plans/archived/2026-08-12_pi-caffeinate-pr-724-feedback-plan.md
@@ -1,0 +1,40 @@
+# Pi Caffeinate PR #724 Feedback Plan
+
+## Goal
+
+Resolve every feedback item on PR #724 without using a replaced session context and verify the full affected lifecycle.
+
+## Context
+
+The current branch is the exact head branch of PR #724, `fix/pi-caffeinate-dbus-hardening`.
+The working tree was clean before this plan was created.
+The PR has one submitted review, one unresolved inline thread, no conversation comments, and a passing CI check at commit `ea01e8f9eee883a18034903aeb808b34d4cf441d`.
+The PR diff, both commits, package metadata, generated lockfiles, lifecycle source, deterministic tests, and Docker smoke fixtures were inspected against merge base `c98af43a6c71c5839b2e0671db71ed1cc1fc0c51`.
+
+## Review Ledger
+
+| ID | Feedback | Outcome | Evidence |
+| --- | --- | --- | --- |
+| F1 | Rebind the active D-Bus failure handler after `session_start` replaces the session so it cannot use the prior `ExtensionContext`. | Already addressed by the current code. | `currentSessionContext()` resolves the replacement context at callback time, shutdown clears it, and both D-Bus and same-pattern child-process regression tests prove the prior context receives no warning or status update. |
+| F2 | The automated review summary says suggestions follow. | Outdated or superseded. | It contains no independent concern and points to F1, the review's only inline comment. |
+
+## Plan
+
+- [x] Identify PR #724 from the current branch with `gh pr view`, verify local and remote head identity, and inspect the clean working tree.
+- [x] Read repository and package instructions, `docs/extension-conventions.md`, the PR description, commits, full diff, checks, review, inline comment, and review thread metadata.
+- [x] Refactor active inhibitor failure reporting to mutate inhibitor state but send UI updates only through the current session context; `currentSessionContext()` now serves both retained failure callbacks.
+- [x] Add regression tests that replace the session before active D-Bus and child-process failures, then prove only the replacement context receives warning and status updates.
+- [x] Run focused pi-caffeinate tests and typechecking, then run the repository CI-equivalent check and applicable package/runtime smokes.
+  Evidence: 36 focused tests, package typechecking, 322 repository test files with 3,111 tests, the five-scenario Docker smoke, Changesets status, the nine-file package dry-run, and the Pi entrypoint load pass.
+- [x] Re-read all feedback, audit the final diff and lifecycle conventions, and update every ledger row with a final evidence-backed outcome.
+  Evidence: the only substantive thread is F1, the sibling callback scan covered D-Bus and child-process failures, and an independent review found no remaining issue.
+- [x] Prepare an evidence-backed thread response for delivery after the signed fix commit is pushed.
+- [x] Archive this completed plan with the implementation and verification evidence.
+
+## Completion Checklist
+
+- [x] No active inhibitor callback can notify or set status through a replaced session context.
+- [x] Active D-Bus and child-process failures still update shared inhibitor state and current-session UI.
+- [x] Focused and repository-required checks pass without concealed failures.
+- [x] Every feedback item has a final ledger outcome with evidence.
+- [x] The final lifecycle diff has no unresolved local review finding.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5929,6 +5929,21 @@
 				"node": ">= 12"
 			}
 		},
+		"node_modules/dbus-native": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.15.1.tgz",
+			"integrity": "sha512-2Zdm+2eQuhmX08/Dyk3fltCqij5LGUwSx3Wj/ZN9IowlUw6eGfYZZXxkviUcN1iPOvWOQWUi74/nVnjZmg37vg==",
+			"license": "MIT",
+			"dependencies": {
+				"xml2js": "^0.6.2"
+			},
+			"bin": {
+				"dbus-native": "bin/dbus-native.js"
+			},
+			"engines": {
+				"node": ">=22.12.0"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -8100,6 +8115,15 @@
 			"integrity": "sha512-Zq+J1TefpoEq/HTUabo0YXX5MNvttjWYODGohgPBO2jfko8Wqx3JYMgE823szDFVamdH5PlpByvfiWScTdSYDA==",
 			"license": "MIT"
 		},
+		"node_modules/sax": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+			"integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
+		},
 		"node_modules/scheduler": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -9079,6 +9103,28 @@
 				"node": ">=16.0.0"
 			}
 		},
+		"node_modules/xml2js": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -9287,7 +9333,8 @@
 			"version": "0.49.3",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1"
+				"@narumitw/pi-tui-kit": "^0.49.1",
+				"dbus-native": "^0.15.1"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"build": "npm --workspaces --if-present run build",
 		"test": "node ./scripts/run-tests.mjs",
 		"smoke:chat-network": "node ./scripts/run-pi-chat-network-smoke.mjs",
+		"smoke:caffeinate-dbus": "node ./packages/pi-caffeinate/test/docker/run-docker.mjs",
 		"smoke:pi-fleet:ghostty": "cd packages/pi-fleet && tsc -p tsconfig.process-smoke.json && node ../../node_modules/.cache/pi-fleet-process/scripts/ghostty-smoke.js",
 		"check": "npm run build && node ./scripts/run-checks.mjs",
 		"precommit": "npm run biome:check && npm run typecheck",

--- a/packages/pi-caffeinate/.dockerignore
+++ b/packages/pi-caffeinate/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/pi-caffeinate/README.md
+++ b/packages/pi-caffeinate/README.md
@@ -17,6 +17,7 @@ It is designed for long-running coding, refactoring, debugging, web research, an
 - Persists the selected keep-awake mode and optional quiet mode in a small JSON settings file.
 - Allows a custom inhibitor command through environment configuration.
 - Emits plain status text; `@narumitw/pi-statusline` can add or suppress the status icon from JSON config.
+- Uses the standard `org.freedesktop.ScreenSaver` D-Bus idle-inhibition service for Linux `display` mode.
 - Fails safely when no supported inhibitor is available.
 
 ## 📦 Install
@@ -48,8 +49,17 @@ Use `/caffeinate sleep` if you want to prevent system sleep while allowing norma
 | macOS | `caffeinate -ims` | `caffeinate -dimsu` |
 | Windows | PowerShell `SetThreadExecutionState(0x80000001)` | PowerShell `SetThreadExecutionState(0x80000003)` |
 | WSL | Windows `powershell.exe` with `SetThreadExecutionState(0x80000001)` | Windows `powershell.exe` with `SetThreadExecutionState(0x80000003)` |
-| Linux with systemd | `systemd-inhibit --what=sleep ... sleep infinity` | `systemd-inhibit --what=idle:sleep ... sleep infinity` |
-| Linux fallback | `caffeinate -ims` when available | `caffeinate -dimsu` when available |
+| Linux with systemd | `systemd-inhibit --what=sleep ... sleep infinity` | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `systemd-inhibit --what=sleep ... sleep infinity` |
+| Linux without systemd | `caffeinate -ims` when available | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `caffeinate -dimsu` when available; D-Bus only otherwise |
+
+On Linux, `display` mode requests idle inhibition through the standard `org.freedesktop.ScreenSaver`
+D-Bus service, trying both `/org/freedesktop/ScreenSaver` and `/ScreenSaver` for desktop compatibility.
+The session-bus connection stays open for the whole agent turn.
+The inhibition ends when `UnInhibit` is called or the connection closes.
+`systemd-inhibit --what=sleep` runs alongside it to block actual suspend through logind.
+If no ScreenSaver service is available, pi-caffeinate keeps the systemd blocker or `caffeinate`
+fallback and reports a partial-activation warning.
+If only D-Bus is available, desktop idle is inhibited but direct logind suspend may remain possible.
 
 If no supported inhibitor is available, the extension stays loaded and reports that caffeinate is unavailable.
 
@@ -165,6 +175,11 @@ Without `@narumitw/pi-statusline`, keep using `PI_CAFFEINATE_ICON` during the co
 AI coding agents often run tool-heavy tasks that take several minutes. `pi-caffeinate` keeps your machine awake during active Pi work, helping browser automation, local builds, test runs, code generation, and long prompts finish reliably.
 
 The default display-awake mode prioritizes uninterrupted long-running Pi work across platforms, including Linux desktops that require idle inhibition to prevent automatic suspend. Use `/caffeinate sleep` (shown as `system-awake` in status output) when you prefer normal screen power saving and your system does not need idle inhibition to keep Pi running.
+
+## 📦 Dependencies
+
+On Linux, `display` mode uses the `dbus-native` package (pure JavaScript, no native build step) to
+call `org.freedesktop.ScreenSaver` on the session bus.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-caffeinate/README.md
+++ b/packages/pi-caffeinate/README.md
@@ -49,17 +49,20 @@ Use `/caffeinate sleep` if you want to prevent system sleep while allowing norma
 | macOS | `caffeinate -ims` | `caffeinate -dimsu` |
 | Windows | PowerShell `SetThreadExecutionState(0x80000001)` | PowerShell `SetThreadExecutionState(0x80000003)` |
 | WSL | Windows `powershell.exe` with `SetThreadExecutionState(0x80000001)` | Windows `powershell.exe` with `SetThreadExecutionState(0x80000003)` |
-| Linux with systemd | `systemd-inhibit --what=sleep ... sleep infinity` | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `systemd-inhibit --what=sleep ... sleep infinity` |
+| Linux with systemd | `systemd-inhibit --what=sleep ... sleep infinity` | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `systemd-inhibit --what=idle:sleep ... sleep infinity` |
 | Linux without systemd | `caffeinate -ims` when available | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `caffeinate -dimsu` when available; D-Bus only otherwise |
 
 On Linux, `display` mode requests idle inhibition through the standard `org.freedesktop.ScreenSaver`
 D-Bus service, trying both `/org/freedesktop/ScreenSaver` and `/ScreenSaver` for desktop compatibility.
 The session-bus connection stays open for the whole agent turn.
 The inhibition ends when `UnInhibit` is called or the connection closes.
-`systemd-inhibit --what=sleep` runs alongside it to block actual suspend through logind.
+`systemd-inhibit --what=idle:sleep` runs alongside it to preserve logind idle and sleep inhibition.
 If no ScreenSaver service is available, pi-caffeinate keeps the systemd blocker or `caffeinate`
 fallback and reports a partial-activation warning.
-If only D-Bus is available, desktop idle is inhibited but direct logind suspend may remain possible.
+If only D-Bus is available, pi-caffeinate reports partial activation because desktop idle is
+inhibited but direct system suspend may remain possible.
+D-Bus method calls use short deadlines, and stop or shutdown aborts an in-flight acquisition before
+closing its session-bus connection.
 
 If no supported inhibitor is available, the extension stays loaded and reports that caffeinate is unavailable.
 

--- a/packages/pi-caffeinate/package.json
+++ b/packages/pi-caffeinate/package.json
@@ -46,6 +46,7 @@
 		"directory": "packages/pi-caffeinate"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1"
+		"@narumitw/pi-tui-kit": "^0.49.1",
+		"dbus-native": "^0.15.1"
 	}
 }

--- a/packages/pi-caffeinate/src/caffeinate.ts
+++ b/packages/pi-caffeinate/src/caffeinate.ts
@@ -5,6 +5,13 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import {
+	type DbusScreenSaverClient,
+	type DbusScreenSaverFactory,
+	defaultDbusScreenSaverFactory,
+	INHIBIT_REASON,
+	SCREENSAVER_BUS_NAME,
+} from "./dbus-inhibit.js";
 import { startInhibitorProcess, stopInhibitorProcess } from "./inhibitor-process.js";
 import { formatMode, getInhibitorCommand, type InhibitorCommand } from "./inhibitors.js";
 import {
@@ -41,11 +48,18 @@ const MODE_OPTIONS = {
 type CommandAction = "menu" | "help" | "status" | "mode" | "sleep" | "display" | "stop";
 type CommandContext = ExtensionCommandContext;
 
+interface CaffeinateOptions {
+	dbusFactory?: DbusScreenSaverFactory;
+}
+
 interface CaffeinateState {
 	process?: ChildProcess;
+	dbus?: DbusScreenSaverClient;
 	startedAt?: number;
 	command?: InhibitorCommand;
 	lastError?: string;
+	inhibitWarning?: string;
+	inhibitorStarting: boolean;
 	activeTurns: number;
 	available: boolean;
 	disabled: boolean;
@@ -62,6 +76,7 @@ interface CaffeinateState {
 const state: CaffeinateState = {
 	activeTurns: 0,
 	available: true,
+	inhibitorStarting: false,
 	disabled: isDisabled(),
 	mode: DEFAULT_MODE,
 	quiet: false,
@@ -71,7 +86,11 @@ const state: CaffeinateState = {
 	menuController: new AbortController(),
 };
 
-export default function caffeinate(pi: ExtensionAPI) {
+let dbusFactory = defaultDbusScreenSaverFactory;
+let inhibitSequence = 0;
+
+export default function caffeinate(pi: ExtensionAPI, options: CaffeinateOptions = {}) {
+	dbusFactory = options.dbusFactory ?? defaultDbusScreenSaverFactory;
 	pi.on("session_start", async (_event, ctx) => {
 		const generation = ++state.sessionGeneration;
 		replaceMenuController("Caffeinate session replaced");
@@ -88,24 +107,27 @@ export default function caffeinate(pi: ExtensionAPI) {
 		await ensureSettingsLoaded(ctx, generation);
 		if (generation !== state.sessionGeneration) return;
 		state.activeTurns += 1;
-		startInhibitor(ctx, { notify: !state.quiet });
+		await startInhibitor(ctx, generation, { notify: !state.quiet });
 	});
 
-	pi.on("agent_end", (_event, ctx) => {
+	pi.on("agent_end", async (_event, ctx) => {
+		const generation = state.sessionGeneration;
 		state.activeTurns = Math.max(0, state.activeTurns - 1);
 		if (state.activeTurns === 0) {
-			stopInhibitor(ctx, "agent finished", { notify: !state.quiet });
+			await stopInhibitor(ctx, "agent finished", { notify: !state.quiet });
 		}
+		if (generation !== state.sessionGeneration) return;
 		updateStatus(ctx);
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
-		state.sessionGeneration += 1;
+		const generation = ++state.sessionGeneration;
 		state.menuController.abort(new DOMException("Caffeinate session shut down", "AbortError"));
 		state.activeTurns = 0;
-		stopInhibitor(ctx, "session shutdown", { notify: false });
-		ctx.ui.setStatus(STATUS_KEY, undefined);
+		await stopInhibitor(ctx, "session shutdown", { notify: false });
 		await modeOperationQueue;
+		if (generation !== state.sessionGeneration) return;
+		ctx.ui.setStatus(STATUS_KEY, undefined);
 	});
 
 	pi.registerCommand("caffeinate", {
@@ -147,7 +169,7 @@ async function handleCaffeinateCommand(args: string, ctx: CommandContext, genera
 			await setMode(ctx, "display", generation);
 			return;
 		case "stop":
-			stopCaffeinate(ctx, "manual stop");
+			await stopCaffeinate(ctx, "manual stop", generation);
 			return;
 	}
 
@@ -215,7 +237,7 @@ async function runCaffeinateMenu(ctx: CommandContext, generation: number, start:
 				return { kind: "close" };
 			},
 			stop: async () => {
-				stopCaffeinate(ctx, "manual stop");
+				await stopCaffeinate(ctx, "manual stop", generation);
 				return { kind: "close" };
 			},
 			help: async () => {
@@ -264,18 +286,23 @@ async function setModeNow(ctx: ExtensionContext, mode: CaffeinateMode, generatio
 	if (generation !== state.sessionGeneration) return;
 	const previousMode = state.mode;
 	const previousQuiet = state.quiet;
-	const restartRequired = Boolean(state.process && previousMode !== mode && !state.command?.custom);
+	const restartRequired = Boolean(
+		hasActiveInhibitor() && previousMode !== mode && !state.command?.custom,
+	);
 	state.settingsError = undefined;
 
 	if (restartRequired) {
 		state.mode = mode;
-		stopInhibitor(ctx, "mode changed", { notify: false });
-		startInhibitor(ctx, { notify: false });
-		if (!state.process) {
+		await stopInhibitor(ctx, "mode changed", { notify: false });
+		if (generation !== state.sessionGeneration) return;
+		await startInhibitor(ctx, generation, { notify: false });
+		if (generation !== state.sessionGeneration) return;
+		if (!hasActiveInhibitor()) {
 			const applicationError = state.lastError ?? "the inhibitor could not be restarted";
 			state.mode = previousMode;
-			startInhibitor(ctx, { notify: false });
-			const rollbackError = state.process
+			await startInhibitor(ctx, generation, { notify: false });
+			if (generation !== state.sessionGeneration) return;
+			const rollbackError = hasActiveInhibitor()
 				? undefined
 				: (state.lastError ?? "the previous inhibitor could not be restored");
 			state.settingsError = rollbackError
@@ -296,9 +323,13 @@ async function setModeNow(ctx: ExtensionContext, mode: CaffeinateMode, generatio
 		if (restartRequired) {
 			state.mode = previousMode;
 			state.quiet = previousQuiet;
-			stopInhibitor(ctx, "settings save failed", { notify: false });
-			startInhibitor(ctx, { notify: false });
-			if (!state.process) rollbackError = state.lastError ?? "the prior inhibitor was not restored";
+			await stopInhibitor(ctx, "settings save failed", { notify: false });
+			if (generation !== state.sessionGeneration) return;
+			await startInhibitor(ctx, generation, { notify: false });
+			if (generation !== state.sessionGeneration) return;
+			if (!hasActiveInhibitor()) {
+				rollbackError = state.lastError ?? "the prior inhibitor was not restored";
+			}
 		}
 		state.settingsError = rollbackError
 			? `settings save failed (${formatError(error)}); runtime rollback failed: ${rollbackError}`
@@ -323,9 +354,10 @@ function showStatus(ctx: ExtensionContext) {
 	updateStatus(ctx);
 }
 
-function stopCaffeinate(ctx: ExtensionContext, reason: string) {
+async function stopCaffeinate(ctx: ExtensionContext, reason: string, sessionGeneration: number) {
 	state.activeTurns = 0;
-	stopInhibitor(ctx, reason);
+	await stopInhibitor(ctx, reason);
+	if (sessionGeneration !== state.sessionGeneration) return;
 	updateStatus(ctx);
 }
 
@@ -363,14 +395,24 @@ function buildCommandGuide() {
 	].join("\n");
 }
 
-function startInhibitor(ctx: ExtensionContext, options: { notify?: boolean } = {}) {
-	if (state.disabled || state.process) {
+async function startInhibitor(
+	ctx: ExtensionContext,
+	sessionGeneration: number,
+	options: { notify?: boolean } = {},
+) {
+	if (state.disabled || hasActiveInhibitor() || state.inhibitorStarting) {
 		updateStatus(ctx);
 		return;
 	}
 
+	const token = ++inhibitSequence;
 	const command = getInhibitorCommand(state.mode);
-	if (!command) {
+	const wantsDbus =
+		!command?.custom &&
+		state.mode === "display" &&
+		process.platform === "linux" &&
+		(command === undefined || command.addDbusIdleInhibit === true);
+	if (!command && !wantsDbus) {
 		state.available = false;
 		state.lastError = `No supported sleep inhibitor found for ${process.platform}.`;
 		ctx.ui.notify(state.lastError, "warning");
@@ -378,56 +420,154 @@ function startInhibitor(ctx: ExtensionContext, options: { notify?: boolean } = {
 		return;
 	}
 
-	try {
-		const child = startInhibitorProcess(
-			command,
-			(error) => {
-				if (state.process === child) {
-					state.process = undefined;
-					state.startedAt = undefined;
-				}
-				state.available = false;
-				state.lastError = `${command.description} failed: ${error.message}`;
-				ctx.ui.notify(state.lastError, "warning");
-				updateStatus(ctx);
-			},
-			(exit) => {
-				if (state.process !== child) return;
-				state.process = undefined;
-				state.startedAt = undefined;
-				state.available = false;
-				state.lastError = `${command.description} exited unexpectedly (${exit}).`;
-				ctx.ui.notify(state.lastError, "warning");
-				updateStatus(ctx);
-			},
-		);
-		state.process = child;
-		state.startedAt = Date.now();
-		state.command = command;
-		state.available = true;
-		state.lastError = undefined;
-		if (options.notify !== false) {
-			ctx.ui.notify(`Keeping computer awake (${statusModeLabel()}).`, "info");
-		}
-		updateStatus(ctx);
-	} catch (error) {
+	state.inhibitorStarting = true;
+	state.inhibitWarning = undefined;
+	let child: ChildProcess | undefined;
+	let childError: string | undefined;
+	let assembling = true;
+	const handleChildFailure = (message: string) => {
+		if (!child || token !== inhibitSequence || state.process !== child) return;
 		state.process = undefined;
-		state.startedAt = undefined;
-		state.available = false;
-		state.lastError = error instanceof Error ? error.message : String(error);
-		ctx.ui.notify(`Unable to start pi-caffeinate: ${state.lastError}`, "warning");
-		updateStatus(ctx);
+		state.command = undefined;
+		if (assembling) {
+			childError = message;
+			return;
+		}
+		applyChildFailure(ctx, message);
+	};
+
+	if (command) {
+		try {
+			child = startInhibitorProcess(
+				command,
+				(error) => handleChildFailure(`${command.description} failed: ${error.message}`),
+				(exit) => handleChildFailure(`${command.description} exited unexpectedly (${exit}).`),
+			);
+			state.process = child;
+			state.command = command;
+			state.startedAt = Date.now();
+		} catch (error) {
+			childError = `${command.description}: ${formatError(error)}`;
+		}
 	}
+
+	let dbus: DbusScreenSaverClient | undefined;
+	let dbusError: string | undefined;
+	if (wantsDbus) {
+		try {
+			dbus = await dbusFactory();
+			if (startIsStale(token, sessionGeneration)) {
+				await cancelPendingStart(token, child, command, dbus);
+				return;
+			}
+			await dbus.inhibit(INHIBIT_REASON);
+		} catch (error) {
+			dbusError = `D-Bus idle inhibit (${SCREENSAVER_BUS_NAME}): ${formatError(error)}`;
+			await dbus?.close().catch(() => undefined);
+			dbus = undefined;
+		}
+	}
+
+	assembling = false;
+	if (startIsStale(token, sessionGeneration)) {
+		await cancelPendingStart(token, child, command, dbus);
+		return;
+	}
+
+	state.inhibitorStarting = false;
+	state.dbus = dbus;
+	const failures = [childError, dbusError].filter((failure): failure is string => Boolean(failure));
+	if (!hasActiveInhibitor()) {
+		state.startedAt = undefined;
+		state.command = undefined;
+		state.available = false;
+		state.lastError =
+			failures.join("; ") || `No supported sleep inhibitor found for ${process.platform}.`;
+		ctx.ui.notify(state.lastError, "warning");
+		updateStatus(ctx);
+		return;
+	}
+
+	state.startedAt ??= Date.now();
+	state.available = true;
+	state.lastError = undefined;
+	state.inhibitWarning = failures.length > 0 ? failures.join("; ") : undefined;
+	if (state.inhibitWarning) {
+		ctx.ui.notify(`pi-caffeinate is partially active: ${state.inhibitWarning}`, "warning");
+	} else if (options.notify !== false) {
+		ctx.ui.notify(`Keeping computer awake (${statusModeLabel()}).`, "info");
+	}
+	updateStatus(ctx);
 }
 
-function stopInhibitor(ctx: ExtensionContext, reason: string, options: { notify?: boolean } = {}) {
+async function stopInhibitor(
+	ctx: ExtensionContext,
+	reason: string,
+	options: { notify?: boolean } = {},
+) {
+	inhibitSequence += 1;
 	const child = state.process;
-	if (!child) return;
+	const dbus = state.dbus;
+	const command = state.command;
+	const wasStarting = state.inhibitorStarting;
 	state.process = undefined;
-	state.startedAt = undefined;
-	stopInhibitorProcess(child, state.command);
+	state.dbus = undefined;
 	state.command = undefined;
+	state.startedAt = undefined;
+	state.inhibitWarning = undefined;
+	state.inhibitorStarting = false;
+	if (child) stopInhibitorProcess(child, command);
+	if (!child && !dbus && !wasStarting) return;
 	if (options.notify !== false) ctx.ui.notify(`Released pi-caffeinate (${reason}).`, "info");
+	if (!dbus) return;
+	try {
+		await dbus.uninhibit();
+	} catch {
+		// Closing the session-bus connection also releases its inhibition cookie.
+	}
+	await dbus.close().catch(() => undefined);
+}
+
+function applyChildFailure(ctx: ExtensionContext, message: string) {
+	if (state.dbus) {
+		state.available = true;
+		state.lastError = undefined;
+		state.inhibitWarning = message;
+	} else {
+		state.startedAt = undefined;
+		state.available = false;
+		state.lastError = message;
+		state.inhibitWarning = undefined;
+	}
+	ctx.ui.notify(message, "warning");
+	updateStatus(ctx);
+}
+
+function hasActiveInhibitor() {
+	return Boolean(state.process || state.dbus);
+}
+
+function startIsStale(token: number, sessionGeneration: number) {
+	return token !== inhibitSequence || sessionGeneration !== state.sessionGeneration;
+}
+
+async function cancelPendingStart(
+	token: number,
+	child: ChildProcess | undefined,
+	command: InhibitorCommand | undefined,
+	dbus: DbusScreenSaverClient | undefined,
+) {
+	if (token === inhibitSequence) {
+		inhibitSequence += 1;
+		state.inhibitorStarting = false;
+		if (child && state.process === child) {
+			state.process = undefined;
+			state.command = undefined;
+			state.startedAt = undefined;
+			stopInhibitorProcess(child, command);
+		}
+	}
+	await dbus?.close().catch(() => undefined);
 }
 
 function updateStatus(ctx: ExtensionContext) {
@@ -436,7 +576,7 @@ function updateStatus(ctx: ExtensionContext) {
 		return;
 	}
 
-	if (state.process) {
+	if (hasActiveInhibitor()) {
 		ctx.ui.setStatus(STATUS_KEY, withDeprecatedIcon(statusModeLabel()));
 		return;
 	}
@@ -465,11 +605,15 @@ function describeState() {
 		return lines.join("\n");
 	}
 
-	if (state.process) {
+	if (hasActiveInhibitor()) {
 		const seconds = state.startedAt ? Math.round((Date.now() - state.startedAt) / 1000) : 0;
+		const activeParts: string[] = [];
+		if (state.dbus) activeParts.push(`D-Bus idle inhibit (${SCREENSAVER_BUS_NAME})`);
+		if (state.process && state.command) activeParts.push(state.command.description);
 		lines.unshift(
-			`pi-caffeinate is active using ${state.command?.description ?? "an inhibitor"} for ${seconds}s.`,
+			`pi-caffeinate is active using ${activeParts.join(" + ") || "an inhibitor"} for ${seconds}s.`,
 		);
+		if (state.inhibitWarning) lines.push(`Inhibitor warning: ${state.inhibitWarning}`);
 		return lines.join("\n");
 	}
 
@@ -485,7 +629,7 @@ function describeState() {
 }
 
 function statusLevel() {
-	return state.available && !state.settingsError ? "info" : "warning";
+	return state.available && !state.settingsError && !state.inhibitWarning ? "info" : "warning";
 }
 
 function statusModeLabel() {
@@ -559,5 +703,10 @@ function warnDeprecatedIcon(ctx: ExtensionContext) {
 	);
 }
 
-export { formatMode, splitCommand, windowsInhibitorScript } from "./inhibitors.js";
+export {
+	formatMode,
+	getInhibitorCommand,
+	splitCommand,
+	windowsInhibitorScript,
+} from "./inhibitors.js";
 export { normalizeCaffeinateSettings } from "./settings.js";

--- a/packages/pi-caffeinate/src/caffeinate.ts
+++ b/packages/pi-caffeinate/src/caffeinate.ts
@@ -61,6 +61,7 @@ interface PendingDbusStart {
 interface CaffeinateState {
 	process?: ChildProcess;
 	dbus?: DbusScreenSaverClient;
+	currentSession?: { generation: number; ctx: ExtensionContext };
 	dbusCleanup?: Promise<void>;
 	pendingDbus?: PendingDbusStart;
 	startedAt?: number;
@@ -101,6 +102,7 @@ export default function caffeinate(pi: ExtensionAPI, options: CaffeinateOptions 
 	dbusFactory = options.dbusFactory ?? defaultDbusScreenSaverFactory;
 	pi.on("session_start", async (_event, ctx) => {
 		const generation = ++state.sessionGeneration;
+		state.currentSession = { generation, ctx };
 		replaceMenuController("Caffeinate session replaced");
 		state.iconWarningShown = false;
 		state.settingsNotice = undefined;
@@ -130,6 +132,7 @@ export default function caffeinate(pi: ExtensionAPI, options: CaffeinateOptions 
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		const generation = ++state.sessionGeneration;
+		state.currentSession = undefined;
 		state.menuController.abort(new DOMException("Caffeinate session shut down", "AbortError"));
 		state.activeTurns = 0;
 		await stopInhibitor(ctx, "session shutdown", { notify: false });
@@ -444,7 +447,7 @@ async function startInhibitor(
 			childError = message;
 			return;
 		}
-		applyChildFailure(ctx, message);
+		applyChildFailure(message);
 	};
 
 	if (command) {
@@ -506,7 +509,7 @@ async function startInhibitor(
 	state.inhibitorStarting = false;
 	state.dbus = dbus;
 	if (dbus) {
-		dbus.setFailureHandler((error) => applyDbusFailure(ctx, token, dbus, error));
+		dbus.setFailureHandler((error) => applyDbusFailure(token, dbus, error));
 		if (state.dbus !== dbus) return;
 	}
 	const failures = [childError, dbusError].filter((failure): failure is string => Boolean(failure));
@@ -572,7 +575,7 @@ async function stopInhibitor(
 	await dbus.close().catch(() => undefined);
 }
 
-function applyChildFailure(ctx: ExtensionContext, message: string) {
+function applyChildFailure(message: string) {
 	if (state.dbus) {
 		state.available = true;
 		state.lastError = undefined;
@@ -583,39 +586,43 @@ function applyChildFailure(ctx: ExtensionContext, message: string) {
 		state.lastError = message;
 		state.inhibitWarning = undefined;
 	}
+	const ctx = currentSessionContext();
+	if (!ctx) return;
 	ctx.ui.notify(message, "warning");
 	updateStatus(ctx);
 }
 
-function applyDbusFailure(
-	ctx: ExtensionContext,
-	token: number,
-	client: DbusScreenSaverClient,
-	error: Error,
-) {
+function applyDbusFailure(token: number, client: DbusScreenSaverClient, error: Error) {
 	if (token !== inhibitSequence || state.dbus !== client) return;
 	client.setFailureHandler(undefined);
 	state.dbus = undefined;
 	const message = `D-Bus idle inhibit (${SCREENSAVER_BUS_NAME}) failed: ${formatError(error)}`;
+	const notification = state.process ? `pi-caffeinate is partially active: ${message}` : message;
 	if (state.process) {
 		state.available = true;
 		state.lastError = undefined;
 		state.inhibitWarning = message;
-		ctx.ui.notify(`pi-caffeinate is partially active: ${message}`, "warning");
 	} else {
 		state.startedAt = undefined;
 		state.command = undefined;
 		state.available = false;
 		state.lastError = [state.inhibitWarning, message].filter(Boolean).join("; ");
 		state.inhibitWarning = undefined;
-		ctx.ui.notify(message, "warning");
 	}
 	const cleanup = client.close().catch(() => undefined);
 	state.dbusCleanup = cleanup;
 	void cleanup.then(() => {
 		if (state.dbusCleanup === cleanup) state.dbusCleanup = undefined;
 	});
+	const ctx = currentSessionContext();
+	if (!ctx) return;
+	ctx.ui.notify(notification, "warning");
 	updateStatus(ctx);
+}
+
+function currentSessionContext() {
+	const session = state.currentSession;
+	return session?.generation === state.sessionGeneration ? session.ctx : undefined;
 }
 
 function hasActiveInhibitor() {

--- a/packages/pi-caffeinate/src/caffeinate.ts
+++ b/packages/pi-caffeinate/src/caffeinate.ts
@@ -52,9 +52,17 @@ interface CaffeinateOptions {
 	dbusFactory?: DbusScreenSaverFactory;
 }
 
+interface PendingDbusStart {
+	token: number;
+	controller: AbortController;
+	client?: DbusScreenSaverClient;
+}
+
 interface CaffeinateState {
 	process?: ChildProcess;
 	dbus?: DbusScreenSaverClient;
+	dbusCleanup?: Promise<void>;
+	pendingDbus?: PendingDbusStart;
 	startedAt?: number;
 	command?: InhibitorCommand;
 	lastError?: string;
@@ -423,7 +431,10 @@ async function startInhibitor(
 	state.inhibitorStarting = true;
 	state.inhibitWarning = undefined;
 	let child: ChildProcess | undefined;
-	let childError: string | undefined;
+	let childError =
+		!command && wantsDbus
+			? "No supported system sleep inhibitor is available; direct system suspend may remain possible."
+			: undefined;
 	let assembling = true;
 	const handleChildFailure = (message: string) => {
 		if (!child || token !== inhibitSequence || state.process !== child) return;
@@ -454,28 +465,50 @@ async function startInhibitor(
 	let dbus: DbusScreenSaverClient | undefined;
 	let dbusError: string | undefined;
 	if (wantsDbus) {
+		const pending: PendingDbusStart = { token, controller: new AbortController() };
+		state.pendingDbus = pending;
 		try {
-			dbus = await dbusFactory();
-			if (startIsStale(token, sessionGeneration)) {
-				await cancelPendingStart(token, child, command, dbus);
+			const client = await dbusFactory();
+			if (!pendingStartIsCurrent(pending, sessionGeneration)) {
+				await client.close().catch(() => undefined);
+				await cancelPendingStart(token, child, command);
 				return;
 			}
-			await dbus.inhibit(INHIBIT_REASON);
+			pending.client = client;
+			await client.inhibit(INHIBIT_REASON, pending.controller.signal);
+			if (!pendingStartIsCurrent(pending, sessionGeneration)) {
+				await cancelPendingStart(token, child, command);
+				return;
+			}
+			pending.client = undefined;
+			state.pendingDbus = undefined;
+			dbus = client;
 		} catch (error) {
+			const stale =
+				!pendingStartIsCurrent(pending, sessionGeneration) || pending.controller.signal.aborted;
+			const pendingClient = takePendingDbusClient(pending);
+			await pendingClient?.close().catch(() => undefined);
+			if (stale) {
+				await cancelPendingStart(token, child, command);
+				return;
+			}
 			dbusError = `D-Bus idle inhibit (${SCREENSAVER_BUS_NAME}): ${formatError(error)}`;
-			await dbus?.close().catch(() => undefined);
-			dbus = undefined;
 		}
 	}
 
 	assembling = false;
 	if (startIsStale(token, sessionGeneration)) {
-		await cancelPendingStart(token, child, command, dbus);
+		await cancelPendingStart(token, child, command);
+		await dbus?.close().catch(() => undefined);
 		return;
 	}
 
 	state.inhibitorStarting = false;
 	state.dbus = dbus;
+	if (dbus) {
+		dbus.setFailureHandler((error) => applyDbusFailure(ctx, token, dbus, error));
+		if (state.dbus !== dbus) return;
+	}
 	const failures = [childError, dbusError].filter((failure): failure is string => Boolean(failure));
 	if (!hasActiveInhibitor()) {
 		state.startedAt = undefined;
@@ -508,17 +541,28 @@ async function stopInhibitor(
 	inhibitSequence += 1;
 	const child = state.process;
 	const dbus = state.dbus;
+	const dbusCleanup = state.dbusCleanup;
+	const pending = state.pendingDbus;
 	const command = state.command;
 	const wasStarting = state.inhibitorStarting;
 	state.process = undefined;
 	state.dbus = undefined;
+	state.dbusCleanup = undefined;
+	state.pendingDbus = undefined;
 	state.command = undefined;
 	state.startedAt = undefined;
 	state.inhibitWarning = undefined;
 	state.inhibitorStarting = false;
+	dbus?.setFailureHandler(undefined);
+	pending?.controller.abort(new DOMException(`Caffeinate stopped: ${reason}`, "AbortError"));
+	const pendingClient = pending ? takePendingDbusClient(pending) : undefined;
 	if (child) stopInhibitorProcess(child, command);
-	if (!child && !dbus && !wasStarting) return;
+	if (!child && !dbus && !pendingClient && !wasStarting) {
+		await dbusCleanup;
+		return;
+	}
 	if (options.notify !== false) ctx.ui.notify(`Released pi-caffeinate (${reason}).`, "info");
+	await Promise.all([dbusCleanup, pendingClient?.close().catch(() => undefined)]);
 	if (!dbus) return;
 	try {
 		await dbus.uninhibit();
@@ -543,6 +587,37 @@ function applyChildFailure(ctx: ExtensionContext, message: string) {
 	updateStatus(ctx);
 }
 
+function applyDbusFailure(
+	ctx: ExtensionContext,
+	token: number,
+	client: DbusScreenSaverClient,
+	error: Error,
+) {
+	if (token !== inhibitSequence || state.dbus !== client) return;
+	client.setFailureHandler(undefined);
+	state.dbus = undefined;
+	const message = `D-Bus idle inhibit (${SCREENSAVER_BUS_NAME}) failed: ${formatError(error)}`;
+	if (state.process) {
+		state.available = true;
+		state.lastError = undefined;
+		state.inhibitWarning = message;
+		ctx.ui.notify(`pi-caffeinate is partially active: ${message}`, "warning");
+	} else {
+		state.startedAt = undefined;
+		state.command = undefined;
+		state.available = false;
+		state.lastError = [state.inhibitWarning, message].filter(Boolean).join("; ");
+		state.inhibitWarning = undefined;
+		ctx.ui.notify(message, "warning");
+	}
+	const cleanup = client.close().catch(() => undefined);
+	state.dbusCleanup = cleanup;
+	void cleanup.then(() => {
+		if (state.dbusCleanup === cleanup) state.dbusCleanup = undefined;
+	});
+	updateStatus(ctx);
+}
+
 function hasActiveInhibitor() {
 	return Boolean(state.process || state.dbus);
 }
@@ -551,23 +626,40 @@ function startIsStale(token: number, sessionGeneration: number) {
 	return token !== inhibitSequence || sessionGeneration !== state.sessionGeneration;
 }
 
+function pendingStartIsCurrent(pending: PendingDbusStart, sessionGeneration: number) {
+	return (
+		state.pendingDbus === pending &&
+		!pending.controller.signal.aborted &&
+		!startIsStale(pending.token, sessionGeneration)
+	);
+}
+
+function takePendingDbusClient(pending: PendingDbusStart) {
+	if (state.pendingDbus === pending) state.pendingDbus = undefined;
+	const client = pending.client;
+	pending.client = undefined;
+	return client;
+}
+
 async function cancelPendingStart(
 	token: number,
 	child: ChildProcess | undefined,
 	command: InhibitorCommand | undefined,
-	dbus: DbusScreenSaverClient | undefined,
 ) {
-	if (token === inhibitSequence) {
-		inhibitSequence += 1;
-		state.inhibitorStarting = false;
-		if (child && state.process === child) {
-			state.process = undefined;
-			state.command = undefined;
-			state.startedAt = undefined;
-			stopInhibitorProcess(child, command);
-		}
+	if (token !== inhibitSequence) return;
+	inhibitSequence += 1;
+	state.inhibitorStarting = false;
+	const pending = state.pendingDbus?.token === token ? state.pendingDbus : undefined;
+	state.pendingDbus = undefined;
+	pending?.controller.abort(new DOMException("Caffeinate start cancelled", "AbortError"));
+	const pendingClient = pending ? takePendingDbusClient(pending) : undefined;
+	if (child && state.process === child) {
+		state.process = undefined;
+		state.command = undefined;
+		state.startedAt = undefined;
+		stopInhibitorProcess(child, command);
 	}
-	await dbus?.close().catch(() => undefined);
+	await pendingClient?.close().catch(() => undefined);
 }
 
 function updateStatus(ctx: ExtensionContext) {

--- a/packages/pi-caffeinate/src/dbus-inhibit.ts
+++ b/packages/pi-caffeinate/src/dbus-inhibit.ts
@@ -6,9 +6,13 @@ export const INHIBIT_REASON = "Pi agent is running";
 
 const INHIBIT_APPLICATION_NAME = "pi-caffeinate";
 const SCREENSAVER_OBJECT_PATHS = ["/org/freedesktop/ScreenSaver", "/ScreenSaver"];
+const DBUS_CALL_TIMEOUT_MS = 2_000;
+
+type DbusFailureHandler = (error: Error) => void;
 
 export interface DbusScreenSaverClient {
-	inhibit(reason: string): Promise<void>;
+	setFailureHandler(handler: DbusFailureHandler | undefined): void;
+	inhibit(reason: string, signal?: AbortSignal): Promise<void>;
 	uninhibit(): Promise<void>;
 	close(): Promise<void>;
 }
@@ -22,24 +26,57 @@ export async function defaultDbusScreenSaverFactory(): Promise<DbusScreenSaverCl
 class NativeScreenSaverClient implements DbusScreenSaverClient {
 	private cookie?: number;
 	private objectPath?: string;
+	private failureHandler?: DbusFailureHandler;
+	private pendingFailure?: Error;
+	private lastConnectionError?: Error;
+	private closing = false;
 
-	constructor(private readonly bus: MessageBus) {}
+	private readonly handleConnectionError = (error: unknown) => {
+		this.lastConnectionError = toError(error, "D-Bus session connection failed");
+		if (this.cookie !== undefined) this.reportFailure(this.lastConnectionError);
+	};
 
-	async inhibit(reason: string): Promise<void> {
+	private readonly handleConnectionClose = (error?: unknown) => {
+		if (this.closing || this.cookie === undefined) return;
+		this.reportFailure(
+			toError(error, this.lastConnectionError?.message ?? "D-Bus session connection closed"),
+		);
+	};
+
+	constructor(private readonly bus: MessageBus) {
+		this.bus.connection.on("error", this.handleConnectionError);
+		this.bus.connection.on("close", this.handleConnectionClose);
+	}
+
+	setFailureHandler(handler: DbusFailureHandler | undefined): void {
+		this.failureHandler = handler;
+		if (!handler || !this.pendingFailure) return;
+		const failure = this.pendingFailure;
+		this.pendingFailure = undefined;
+		handler(failure);
+	}
+
+	async inhibit(reason: string, signal?: AbortSignal): Promise<void> {
 		let lastError: unknown;
 		for (const objectPath of SCREENSAVER_OBJECT_PATHS) {
+			if (signal?.aborted) throw abortReason(signal);
 			try {
-				this.cookie = await invoke<number>(this.bus, {
-					destination: SCREENSAVER_BUS_NAME,
-					path: objectPath,
-					interface: SCREENSAVER_INTERFACE,
-					member: "Inhibit",
-					signature: "ss",
-					body: [INHIBIT_APPLICATION_NAME, reason],
-				});
+				this.cookie = await invoke<number>(
+					this.bus,
+					{
+						destination: SCREENSAVER_BUS_NAME,
+						path: objectPath,
+						interface: SCREENSAVER_INTERFACE,
+						member: "Inhibit",
+						signature: "ss",
+						body: [INHIBIT_APPLICATION_NAME, reason],
+					},
+					signal,
+				);
 				this.objectPath = objectPath;
 				return;
 			} catch (error) {
+				if (signal?.aborted) throw abortReason(signal);
 				lastError = error;
 			}
 		}
@@ -52,9 +89,11 @@ class NativeScreenSaverClient implements DbusScreenSaverClient {
 		if (this.cookie === undefined || !this.objectPath) return;
 		const cookie = this.cookie;
 		this.cookie = undefined;
+		const objectPath = this.objectPath;
+		this.objectPath = undefined;
 		await invoke<void>(this.bus, {
 			destination: SCREENSAVER_BUS_NAME,
-			path: this.objectPath,
+			path: objectPath,
 			interface: SCREENSAVER_INTERFACE,
 			member: "UnInhibit",
 			signature: "u",
@@ -63,17 +102,46 @@ class NativeScreenSaverClient implements DbusScreenSaverClient {
 	}
 
 	async close(): Promise<void> {
-		await this.bus.close();
+		this.closing = true;
+		this.cookie = undefined;
+		this.objectPath = undefined;
+		this.failureHandler = undefined;
+		try {
+			await this.bus.close();
+		} finally {
+			this.bus.connection.off("error", this.handleConnectionError);
+			this.bus.connection.off("close", this.handleConnectionClose);
+		}
+	}
+
+	private reportFailure(error: Error): void {
+		if (this.cookie === undefined) return;
+		this.cookie = undefined;
+		this.objectPath = undefined;
+		if (this.failureHandler) this.failureHandler(error);
+		else this.pendingFailure = error;
 	}
 }
 
-function invoke<TResult>(bus: MessageBus, message: Message): Promise<TResult> {
+function invoke<TResult>(
+	bus: MessageBus,
+	message: Message,
+	signal?: AbortSignal,
+): Promise<TResult> {
 	return new Promise<TResult>((resolve, reject) => {
-		bus.invoke(message, (error, ...values) => {
+		bus.invoke(message, { signal, timeout: DBUS_CALL_TIMEOUT_MS }, (error, ...values) => {
 			if (error) reject(error);
 			else resolve(values[0] as TResult);
 		});
 	});
+}
+
+function abortReason(signal: AbortSignal): unknown {
+	return signal.reason ?? new DOMException("D-Bus idle inhibit cancelled", "AbortError");
+}
+
+function toError(error: unknown, fallback: string): Error {
+	return error instanceof Error ? error : new Error(fallback);
 }
 
 function formatError(error: unknown) {

--- a/packages/pi-caffeinate/src/dbus-inhibit.ts
+++ b/packages/pi-caffeinate/src/dbus-inhibit.ts
@@ -1,0 +1,84 @@
+import { type Message, type MessageBus, sessionBus } from "dbus-native";
+
+export const SCREENSAVER_BUS_NAME = "org.freedesktop.ScreenSaver";
+export const SCREENSAVER_INTERFACE = "org.freedesktop.ScreenSaver";
+export const INHIBIT_REASON = "Pi agent is running";
+
+const INHIBIT_APPLICATION_NAME = "pi-caffeinate";
+const SCREENSAVER_OBJECT_PATHS = ["/org/freedesktop/ScreenSaver", "/ScreenSaver"];
+
+export interface DbusScreenSaverClient {
+	inhibit(reason: string): Promise<void>;
+	uninhibit(): Promise<void>;
+	close(): Promise<void>;
+}
+
+export type DbusScreenSaverFactory = () => Promise<DbusScreenSaverClient>;
+
+export async function defaultDbusScreenSaverFactory(): Promise<DbusScreenSaverClient> {
+	return new NativeScreenSaverClient(sessionBus());
+}
+
+class NativeScreenSaverClient implements DbusScreenSaverClient {
+	private cookie?: number;
+	private objectPath?: string;
+
+	constructor(private readonly bus: MessageBus) {}
+
+	async inhibit(reason: string): Promise<void> {
+		let lastError: unknown;
+		for (const objectPath of SCREENSAVER_OBJECT_PATHS) {
+			try {
+				this.cookie = await invoke<number>(this.bus, {
+					destination: SCREENSAVER_BUS_NAME,
+					path: objectPath,
+					interface: SCREENSAVER_INTERFACE,
+					member: "Inhibit",
+					signature: "ss",
+					body: [INHIBIT_APPLICATION_NAME, reason],
+				});
+				this.objectPath = objectPath;
+				return;
+			} catch (error) {
+				lastError = error;
+			}
+		}
+		throw new Error(`D-Bus idle inhibit failed: ${formatError(lastError)}`, {
+			cause: lastError,
+		});
+	}
+
+	async uninhibit(): Promise<void> {
+		if (this.cookie === undefined || !this.objectPath) return;
+		const cookie = this.cookie;
+		this.cookie = undefined;
+		await invoke<void>(this.bus, {
+			destination: SCREENSAVER_BUS_NAME,
+			path: this.objectPath,
+			interface: SCREENSAVER_INTERFACE,
+			member: "UnInhibit",
+			signature: "u",
+			body: [cookie],
+		});
+	}
+
+	async close(): Promise<void> {
+		await this.bus.close();
+	}
+}
+
+function invoke<TResult>(bus: MessageBus, message: Message): Promise<TResult> {
+	return new Promise<TResult>((resolve, reject) => {
+		bus.invoke(message, (error, ...values) => {
+			if (error) reject(error);
+			else resolve(values[0] as TResult);
+		});
+	});
+}
+
+function formatError(error: unknown) {
+	if (error instanceof Error) {
+		return error.name === "Error" ? error.message : `${error.name}: ${error.message}`;
+	}
+	return String(error);
+}

--- a/packages/pi-caffeinate/src/inhibitors.ts
+++ b/packages/pi-caffeinate/src/inhibitors.ts
@@ -9,6 +9,8 @@ export interface InhibitorCommand {
 	description: string;
 	releaseOnStdinClose?: boolean;
 	custom?: boolean;
+	/** Display mode still needs D-Bus idle inhibit on top of this command (systemd blocks sleep only). */
+	addDbusIdleInhibit?: boolean;
 }
 
 export function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | undefined {
@@ -29,11 +31,10 @@ export function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | un
 			return windowsPowerInhibitorCommand("powershell.exe", mode);
 		}
 		if (commandExists("systemd-inhibit")) {
-			const what = mode === "sleep" ? "sleep" : "idle:sleep";
 			return parentBoundUnixCommand(
 				"systemd-inhibit",
 				[
-					`--what=${what}`,
+					"--what=sleep",
 					"--who=pi-caffeinate",
 					"--why=Pi agent is running",
 					"--mode=block",
@@ -41,6 +42,7 @@ export function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | un
 					"infinity",
 				],
 				`systemd-inhibit (${formatMode(mode)})`,
+				mode === "display",
 			);
 		}
 		if (commandExists("caffeinate")) {
@@ -48,6 +50,7 @@ export function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | un
 				"caffeinate",
 				macCaffeinateArgs(mode),
 				caffeinateDescription(mode),
+				mode === "display",
 			);
 		}
 	}
@@ -67,6 +70,7 @@ function parentBoundUnixCommand(
 	command: string,
 	args: string[],
 	description: string,
+	addDbusIdleInhibit = false,
 ): InhibitorCommand {
 	return {
 		command: "sh",
@@ -79,6 +83,7 @@ function parentBoundUnixCommand(
 			...args,
 		],
 		description,
+		...(addDbusIdleInhibit ? { addDbusIdleInhibit: true } : {}),
 	};
 }
 

--- a/packages/pi-caffeinate/src/inhibitors.ts
+++ b/packages/pi-caffeinate/src/inhibitors.ts
@@ -9,7 +9,7 @@ export interface InhibitorCommand {
 	description: string;
 	releaseOnStdinClose?: boolean;
 	custom?: boolean;
-	/** Display mode still needs D-Bus idle inhibit on top of this command (systemd blocks sleep only). */
+	/** Display mode also needs D-Bus because logind idle inhibition misses some compositors. */
 	addDbusIdleInhibit?: boolean;
 }
 
@@ -31,10 +31,11 @@ export function getInhibitorCommand(mode: CaffeinateMode): InhibitorCommand | un
 			return windowsPowerInhibitorCommand("powershell.exe", mode);
 		}
 		if (commandExists("systemd-inhibit")) {
+			const what = mode === "display" ? "idle:sleep" : "sleep";
 			return parentBoundUnixCommand(
 				"systemd-inhibit",
 				[
-					"--what=sleep",
+					`--what=${what}`,
 					"--who=pi-caffeinate",
 					"--why=Pi agent is running",
 					"--mode=block",

--- a/packages/pi-caffeinate/test/caffeinate.test.ts
+++ b/packages/pi-caffeinate/test/caffeinate.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+	chmodSync,
 	existsSync,
 	mkdtempSync,
 	readdirSync,
@@ -15,11 +16,13 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import caffeinate, {
 	commandCompletions,
 	formatMode,
+	getInhibitorCommand,
 	normalizeCaffeinateSettings,
 	parseCommand,
 	splitCommand,
 	windowsInhibitorScript,
 } from "../src/caffeinate.js";
+import type { DbusScreenSaverClient, DbusScreenSaverFactory } from "../src/dbus-inhibit.js";
 import { saveSettings } from "../src/settings.js";
 
 const NEW_SETTINGS_FILE = "pi-caffeinate.json";
@@ -116,6 +119,79 @@ test("windowsInhibitorScript flags and formatMode labels are user-facing", () =>
 	assert.match(windowsInhibitorScript("display"), /\[uint32\]'0x80000000'/);
 	assert.equal(formatMode("sleep"), "system-awake");
 	assert.equal(formatMode("display"), "display-awake");
+});
+
+test("Linux display mode pairs the systemd sleep blocker with D-Bus idle inhibit", async () => {
+	await withLinuxPathCommands(["systemd-inhibit"], () => {
+		const command = getInhibitorCommand("display");
+
+		assert.equal(command?.description, "systemd-inhibit (display-awake)");
+		assert.ok(command?.args.includes("--what=sleep"));
+		assert.equal(command?.addDbusIdleInhibit, true);
+	});
+});
+
+test("Linux sleep mode uses only the systemd sleep blocker", async () => {
+	await withLinuxPathCommands(["systemd-inhibit"], () => {
+		const command = getInhibitorCommand("sleep");
+
+		assert.equal(command?.description, "systemd-inhibit (system-awake)");
+		assert.ok(command?.args.includes("--what=sleep"));
+		assert.equal(command?.addDbusIdleInhibit, undefined);
+	});
+});
+
+test("D-Bus idle inhibit falls back to the niri ScreenSaver object path", async () => {
+	const calls: Array<{ member?: string; path?: string; body?: unknown[] }> = [];
+	let closeCalls = 0;
+	vi.resetModules();
+	vi.doMock("dbus-native", () => ({
+		sessionBus: () => ({
+			invoke(
+				message: { member?: string; path?: string; body?: unknown[] },
+				callback: (error: Error | null, value?: number) => void,
+			) {
+				calls.push(message);
+				if (message.member === "Inhibit" && message.path === "/org/freedesktop/ScreenSaver") {
+					callback(new Error("Unknown object"));
+					return;
+				}
+				callback(null, message.member === "Inhibit" ? 42 : undefined);
+			},
+			async close() {
+				closeCalls += 1;
+			},
+		}),
+	}));
+
+	try {
+		const { defaultDbusScreenSaverFactory } = await import("../src/dbus-inhibit.js");
+		const client = await defaultDbusScreenSaverFactory();
+		await client.inhibit("test");
+		await client.uninhibit();
+		await client.close();
+
+		assert.deepEqual(
+			calls.map(({ member, path, body }) => ({ member, path, body })),
+			[
+				{
+					member: "Inhibit",
+					path: "/org/freedesktop/ScreenSaver",
+					body: ["pi-caffeinate", "test"],
+				},
+				{
+					member: "Inhibit",
+					path: "/ScreenSaver",
+					body: ["pi-caffeinate", "test"],
+				},
+				{ member: "UnInhibit", path: "/ScreenSaver", body: [42] },
+			],
+		);
+		assert.equal(closeCalls, 1);
+	} finally {
+		vi.doUnmock("dbus-native");
+		vi.resetModules();
+	}
 });
 
 test("caffeinate loads the new settings file without a migration warning", async () => {
@@ -515,6 +591,85 @@ test("default settings keep routine lifecycle notifications", async () => {
 	});
 });
 
+test("Linux display mode holds one D-Bus inhibitor for the agent turn", async () => {
+	await withLinuxPathCommands([], async () => {
+		await withTempAgentDir(async () => {
+			const clients: FakeDbusClient[] = [];
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const { ctx, notifications, statuses } = createMockContext();
+
+			caffeinateModule.default(mock.pi, { dbusFactory: fakeDbusFactory(clients) });
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			await mock.events.get("agent_start")?.[0]?.({}, ctx);
+
+			assert.equal(clients.length, 1);
+			assert.deepEqual(clients[0]?.inhibitCalls, ["Pi agent is running"]);
+			assert.equal(statuses.get("caffeinate"), "display-awake");
+			assert.match(notifications[0]?.message ?? "", /Keeping computer awake/);
+
+			await mock.events.get("agent_end")?.[0]?.({}, ctx);
+
+			assert.equal(clients[0]?.uninhibitCalls, 1);
+			assert.equal(clients[0]?.closeCalls, 1);
+			assert.equal(statuses.get("caffeinate"), undefined);
+		});
+	});
+});
+
+test("Linux display mode keeps the sleep blocker when D-Bus is unavailable", async () => {
+	await withLinuxPathCommands(["sh", "systemd-inhibit"], async () => {
+		await withTempAgentDir(async () => {
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const { ctx, notifications, statuses } = createMockContext();
+
+			caffeinateModule.default(mock.pi, {
+				dbusFactory: async () => {
+					throw new Error("no ScreenSaver service");
+				},
+			});
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			await mock.events.get("agent_start")?.[0]?.({}, ctx);
+
+			assert.equal(statuses.get("caffeinate"), "display-awake");
+			assert.match(notifications.at(-1)?.message ?? "", /partially active/);
+			assert.match(notifications.at(-1)?.message ?? "", /no ScreenSaver service/);
+
+			await mock.events.get("agent_end")?.[0]?.({}, ctx);
+		});
+	});
+});
+
+test("agent_end closes a D-Bus inhibitor acquired after stop began", async () => {
+	await withLinuxPathCommands([], async () => {
+		await withTempAgentDir(async () => {
+			const clients: FakeDbusClient[] = [];
+			let releaseInhibit: (() => void) | undefined;
+			const gate = new Promise<void>((resolve) => {
+				releaseInhibit = resolve;
+			});
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const { ctx, statuses } = createMockContext();
+
+			caffeinateModule.default(mock.pi, {
+				dbusFactory: fakeDbusFactory(clients, gate),
+			});
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			const startPromise = mock.events.get("agent_start")?.[0]?.({}, ctx);
+			await waitFor(() => clients[0]?.inhibitCalls.length === 1);
+			await mock.events.get("agent_end")?.[0]?.({}, ctx);
+			releaseInhibit?.();
+			await startPromise;
+
+			assert.equal(clients[0]?.uninhibitCalls, 0);
+			assert.equal(clients[0]?.closeCalls, 1);
+			assert.equal(statuses.get("caffeinate"), undefined);
+		});
+	});
+});
+
 async function importFreshCaffeinate() {
 	vi.resetModules();
 	return import("../src/caffeinate.js");
@@ -543,6 +698,70 @@ async function withTempAgentDir<T>(fn: (agentDir: string) => Promise<T>) {
 		else process.env.PI_CAFFEINATE_COMMAND = previousCommand;
 		rmSync(agentDir, { recursive: true, force: true });
 	}
+}
+
+async function withLinuxPathCommands<T>(commands: string[], fn: () => T | Promise<T>) {
+	const previousPath = process.env.PATH;
+	const previousCommand = process.env.PI_CAFFEINATE_COMMAND;
+	const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+	const binDir = mkdtempSync(path.join(os.tmpdir(), "pi-caffeinate-bin-"));
+
+	try {
+		for (const command of commands) {
+			const file = path.join(binDir, command);
+			if (command === "sh") {
+				const shell = process.env.SHELL;
+				if (!shell) throw new Error("SHELL is required for inhibitor lifecycle tests");
+				symlinkSync(shell, file);
+				continue;
+			}
+			writeFileSync(file, "#!/usr/bin/env sh\nwhile :; do :; done\n");
+			chmodSync(file, 0o755);
+		}
+		Object.defineProperty(process, "platform", { value: "linux" });
+		process.env.PATH = binDir;
+		delete process.env.PI_CAFFEINATE_COMMAND;
+		return await fn();
+	} finally {
+		if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+		if (previousPath === undefined) delete process.env.PATH;
+		else process.env.PATH = previousPath;
+		if (previousCommand === undefined) delete process.env.PI_CAFFEINATE_COMMAND;
+		else process.env.PI_CAFFEINATE_COMMAND = previousCommand;
+		rmSync(binDir, { recursive: true, force: true });
+	}
+}
+
+class FakeDbusClient implements DbusScreenSaverClient {
+	readonly inhibitCalls: string[] = [];
+	uninhibitCalls = 0;
+	closeCalls = 0;
+
+	constructor(private readonly inhibitResult: Promise<void> = Promise.resolve()) {}
+
+	async inhibit(reason: string): Promise<void> {
+		this.inhibitCalls.push(reason);
+		await this.inhibitResult;
+	}
+
+	async uninhibit(): Promise<void> {
+		this.uninhibitCalls += 1;
+	}
+
+	async close(): Promise<void> {
+		this.closeCalls += 1;
+	}
+}
+
+function fakeDbusFactory(
+	clients: FakeDbusClient[],
+	inhibitResult: Promise<void> = Promise.resolve(),
+): DbusScreenSaverFactory {
+	return async () => {
+		const client = new FakeDbusClient(inhibitResult);
+		clients.push(client);
+		return client;
+	};
 }
 
 function writeSettings(agentDir: string, fileName: string, mode: string, quiet?: boolean) {

--- a/packages/pi-caffeinate/test/caffeinate.test.ts
+++ b/packages/pi-caffeinate/test/caffeinate.test.ts
@@ -718,6 +718,66 @@ test("session_shutdown aborts and closes an in-flight D-Bus acquisition", async 
 	});
 });
 
+test("an active child failure after session replacement updates only the current context", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		const releasePath = path.join(agentDir, "release-inhibitor");
+		process.env.PI_CAFFEINATE_COMMAND = customNodeCommand(
+			`const fs=require("node:fs");setInterval(()=>{if(fs.existsSync(${JSON.stringify(releasePath)}))process.exit(7)},10)`,
+		);
+		const caffeinateModule = await importFreshCaffeinate();
+		const mock = createMockPi();
+		const original = createMockContext();
+		const replacement = createMockContext();
+
+		caffeinateModule.default(mock.pi);
+		const sessionStart = mock.events.get("session_start")?.[0];
+		await sessionStart?.({ reason: "startup" }, original.ctx);
+		await mock.events.get("agent_start")?.[0]?.({}, original.ctx);
+		const originalNotificationCount = original.notifications.length;
+		assert.equal(original.statuses.get("caffeinate"), "custom");
+
+		await sessionStart?.({ reason: "replacement" }, replacement.ctx);
+		writeFileSync(releasePath, "release");
+		await waitFor(() => replacement.notifications.length > 0);
+
+		assert.equal(original.notifications.length, originalNotificationCount);
+		assert.equal(original.statuses.get("caffeinate"), "custom");
+		assert.equal(replacement.notifications.at(-1)?.level, "warning");
+		assert.match(replacement.notifications.at(-1)?.message ?? "", /exited unexpectedly \(code 7\)/);
+		assert.equal(replacement.statuses.get("caffeinate"), "unavailable");
+		await mock.events.get("agent_end")?.[0]?.({}, replacement.ctx);
+	});
+});
+
+test("an active D-Bus failure after session replacement updates only the current context", async () => {
+	await withLinuxPathCommands([], async () => {
+		await withTempAgentDir(async () => {
+			const clients: FakeDbusClient[] = [];
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const original = createMockContext();
+			const replacement = createMockContext();
+
+			caffeinateModule.default(mock.pi, { dbusFactory: fakeDbusFactory(clients) });
+			const sessionStart = mock.events.get("session_start")?.[0];
+			await sessionStart?.({ reason: "startup" }, original.ctx);
+			await mock.events.get("agent_start")?.[0]?.({}, original.ctx);
+			const originalNotificationCount = original.notifications.length;
+			assert.equal(original.statuses.get("caffeinate"), "display-awake");
+
+			await sessionStart?.({ reason: "replacement" }, replacement.ctx);
+			clients[0]?.fail(new Error("session bus disconnected"));
+
+			assert.equal(original.notifications.length, originalNotificationCount);
+			assert.equal(original.statuses.get("caffeinate"), "display-awake");
+			assert.equal(replacement.notifications.at(-1)?.level, "warning");
+			assert.match(replacement.notifications.at(-1)?.message ?? "", /session bus disconnected/);
+			assert.equal(replacement.statuses.get("caffeinate"), "unavailable");
+			await mock.events.get("agent_end")?.[0]?.({}, replacement.ctx);
+		});
+	});
+});
+
 test("an active D-Bus transport failure makes D-Bus-only mode unavailable", async () => {
 	await withLinuxPathCommands([], async () => {
 		await withTempAgentDir(async () => {

--- a/packages/pi-caffeinate/test/caffeinate.test.ts
+++ b/packages/pi-caffeinate/test/caffeinate.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import {
 	chmodSync,
 	existsSync,
@@ -121,12 +122,12 @@ test("windowsInhibitorScript flags and formatMode labels are user-facing", () =>
 	assert.equal(formatMode("display"), "display-awake");
 });
 
-test("Linux display mode pairs the systemd sleep blocker with D-Bus idle inhibit", async () => {
+test("Linux display mode keeps logind idle and sleep inhibition alongside D-Bus", async () => {
 	await withLinuxPathCommands(["systemd-inhibit"], () => {
 		const command = getInhibitorCommand("display");
 
 		assert.equal(command?.description, "systemd-inhibit (display-awake)");
-		assert.ok(command?.args.includes("--what=sleep"));
+		assert.ok(command?.args.includes("--what=idle:sleep"));
 		assert.equal(command?.addDbusIdleInhibit, true);
 	});
 });
@@ -141,16 +142,24 @@ test("Linux sleep mode uses only the systemd sleep blocker", async () => {
 	});
 });
 
-test("D-Bus idle inhibit falls back to the niri ScreenSaver object path", async () => {
+test("D-Bus idle inhibit handles transport errors and falls back to the niri path", async () => {
 	const calls: Array<{ member?: string; path?: string; body?: unknown[] }> = [];
+	const connection = new EventEmitter();
 	let closeCalls = 0;
 	vi.resetModules();
 	vi.doMock("dbus-native", () => ({
 		sessionBus: () => ({
+			connection,
 			invoke(
 				message: { member?: string; path?: string; body?: unknown[] },
-				callback: (error: Error | null, value?: number) => void,
+				optionsOrCallback:
+					| { signal?: AbortSignal; timeout?: number }
+					| ((error: Error | null, value?: number) => void),
+				maybeCallback?: (error: Error | null, value?: number) => void,
 			) {
+				const callback =
+					typeof optionsOrCallback === "function" ? optionsOrCallback : maybeCallback;
+				assert.ok(callback);
 				calls.push(message);
 				if (message.member === "Inhibit" && message.path === "/org/freedesktop/ScreenSaver") {
 					callback(new Error("Unknown object"));
@@ -167,6 +176,7 @@ test("D-Bus idle inhibit falls back to the niri ScreenSaver object path", async 
 	try {
 		const { defaultDbusScreenSaverFactory } = await import("../src/dbus-inhibit.js");
 		const client = await defaultDbusScreenSaverFactory();
+		assert.doesNotThrow(() => connection.emit("error", new Error("session bus unavailable")));
 		await client.inhibit("test");
 		await client.uninhibit();
 		await client.close();
@@ -591,7 +601,7 @@ test("default settings keep routine lifecycle notifications", async () => {
 	});
 });
 
-test("Linux display mode holds one D-Bus inhibitor for the agent turn", async () => {
+test("Linux D-Bus-only display mode reports its missing system-sleep backend", async () => {
 	await withLinuxPathCommands([], async () => {
 		await withTempAgentDir(async () => {
 			const clients: FakeDbusClient[] = [];
@@ -606,7 +616,9 @@ test("Linux display mode holds one D-Bus inhibitor for the agent turn", async ()
 			assert.equal(clients.length, 1);
 			assert.deepEqual(clients[0]?.inhibitCalls, ["Pi agent is running"]);
 			assert.equal(statuses.get("caffeinate"), "display-awake");
-			assert.match(notifications[0]?.message ?? "", /Keeping computer awake/);
+			assert.equal(notifications[0]?.level, "warning");
+			assert.match(notifications[0]?.message ?? "", /partially active/);
+			assert.match(notifications[0]?.message ?? "", /system sleep inhibitor/i);
 
 			await mock.events.get("agent_end")?.[0]?.({}, ctx);
 
@@ -641,7 +653,7 @@ test("Linux display mode keeps the sleep blocker when D-Bus is unavailable", asy
 	});
 });
 
-test("agent_end closes a D-Bus inhibitor acquired after stop began", async () => {
+test("agent_end aborts and closes an in-flight D-Bus acquisition before returning", async () => {
 	await withLinuxPathCommands([], async () => {
 		await withTempAgentDir(async () => {
 			const clients: FakeDbusClient[] = [];
@@ -659,12 +671,96 @@ test("agent_end closes a D-Bus inhibitor acquired after stop began", async () =>
 			await mock.events.get("session_start")?.[0]?.({}, ctx);
 			const startPromise = mock.events.get("agent_start")?.[0]?.({}, ctx);
 			await waitFor(() => clients[0]?.inhibitCalls.length === 1);
-			await mock.events.get("agent_end")?.[0]?.({}, ctx);
-			releaseInhibit?.();
-			await startPromise;
+			try {
+				await mock.events.get("agent_end")?.[0]?.({}, ctx);
+				assert.equal(clients[0]?.inhibitSignal?.aborted, true);
+				assert.equal(clients[0]?.closeCalls, 1);
+			} finally {
+				releaseInhibit?.();
+				await startPromise;
+			}
 
 			assert.equal(clients[0]?.uninhibitCalls, 0);
 			assert.equal(clients[0]?.closeCalls, 1);
+			assert.equal(statuses.get("caffeinate"), undefined);
+		});
+	});
+});
+
+test("session_shutdown aborts and closes an in-flight D-Bus acquisition", async () => {
+	await withLinuxPathCommands([], async () => {
+		await withTempAgentDir(async () => {
+			const clients: FakeDbusClient[] = [];
+			let releaseInhibit: (() => void) | undefined;
+			const gate = new Promise<void>((resolve) => {
+				releaseInhibit = resolve;
+			});
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const { ctx, statuses } = createMockContext();
+
+			caffeinateModule.default(mock.pi, {
+				dbusFactory: fakeDbusFactory(clients, gate),
+			});
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			const startPromise = mock.events.get("agent_start")?.[0]?.({}, ctx);
+			await waitFor(() => clients[0]?.inhibitCalls.length === 1);
+			try {
+				await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+				assert.equal(clients[0]?.inhibitSignal?.aborted, true);
+				assert.equal(clients[0]?.closeCalls, 1);
+				assert.equal(statuses.get("caffeinate"), undefined);
+			} finally {
+				releaseInhibit?.();
+				await startPromise;
+			}
+		});
+	});
+});
+
+test("an active D-Bus transport failure makes D-Bus-only mode unavailable", async () => {
+	await withLinuxPathCommands([], async () => {
+		await withTempAgentDir(async () => {
+			const clients: FakeDbusClient[] = [];
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const { ctx, notifications, statuses } = createMockContext();
+
+			caffeinateModule.default(mock.pi, { dbusFactory: fakeDbusFactory(clients) });
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			await mock.events.get("agent_start")?.[0]?.({}, ctx);
+			clients[0]?.fail(new Error("session bus disconnected"));
+
+			assert.equal(statuses.get("caffeinate"), "unavailable");
+			assert.equal(notifications.at(-1)?.level, "warning");
+			assert.match(notifications.at(-1)?.message ?? "", /session bus disconnected/);
+			await mock.commands.get("caffeinate")?.handler("status", ctx);
+			assert.match(notifications.at(-1)?.message ?? "", /pi-caffeinate is unavailable/);
+
+			await mock.events.get("agent_end")?.[0]?.({}, ctx);
+		});
+	});
+});
+
+test("an active D-Bus transport failure preserves the system sleep blocker", async () => {
+	await withLinuxPathCommands(["sh", "systemd-inhibit"], async () => {
+		await withTempAgentDir(async () => {
+			const clients: FakeDbusClient[] = [];
+			const caffeinateModule = await importFreshCaffeinate();
+			const mock = createMockPi();
+			const { ctx, notifications, statuses } = createMockContext();
+
+			caffeinateModule.default(mock.pi, { dbusFactory: fakeDbusFactory(clients) });
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			await mock.events.get("agent_start")?.[0]?.({}, ctx);
+			clients[0]?.fail(new Error("session bus disconnected"));
+
+			assert.equal(statuses.get("caffeinate"), "display-awake");
+			assert.equal(notifications.at(-1)?.level, "warning");
+			assert.match(notifications.at(-1)?.message ?? "", /partially active/);
+			assert.match(notifications.at(-1)?.message ?? "", /session bus disconnected/);
+
+			await mock.events.get("agent_end")?.[0]?.({}, ctx);
 			assert.equal(statuses.get("caffeinate"), undefined);
 		});
 	});
@@ -734,13 +830,20 @@ async function withLinuxPathCommands<T>(commands: string[], fn: () => T | Promis
 
 class FakeDbusClient implements DbusScreenSaverClient {
 	readonly inhibitCalls: string[] = [];
+	inhibitSignal?: AbortSignal;
 	uninhibitCalls = 0;
 	closeCalls = 0;
+	private failureHandler?: (error: Error) => void;
 
 	constructor(private readonly inhibitResult: Promise<void> = Promise.resolve()) {}
 
-	async inhibit(reason: string): Promise<void> {
+	setFailureHandler(handler: ((error: Error) => void) | undefined): void {
+		this.failureHandler = handler;
+	}
+
+	async inhibit(reason: string, signal?: AbortSignal): Promise<void> {
 		this.inhibitCalls.push(reason);
+		this.inhibitSignal = signal;
 		await this.inhibitResult;
 	}
 
@@ -750,6 +853,10 @@ class FakeDbusClient implements DbusScreenSaverClient {
 
 	async close(): Promise<void> {
 		this.closeCalls += 1;
+	}
+
+	fail(error: Error): void {
+		this.failureHandler?.(error);
 	}
 }
 

--- a/packages/pi-caffeinate/test/docker/Dockerfile
+++ b/packages/pi-caffeinate/test/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:26-bookworm-slim
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends dbus \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /smoke
+COPY test/docker/package.json test/docker/package-lock.json ./
+RUN npm ci --ignore-scripts
+
+COPY . ./pi-caffeinate
+RUN ./node_modules/.bin/tsc -p /smoke/pi-caffeinate/test/docker/tsconfig.json
+
+ENTRYPOINT ["dbus-run-session", "--", "node", "/smoke/pi-caffeinate/test/docker/run-smoke.mjs"]

--- a/packages/pi-caffeinate/test/docker/README.md
+++ b/packages/pi-caffeinate/test/docker/README.md
@@ -1,0 +1,14 @@
+# pi-caffeinate D-Bus Docker smoke
+
+This opt-in smoke runs the real `dbus-native` transport and the local pi-caffeinate source against a private `dbus-daemon`.
+
+From the repository root, run:
+
+```bash
+npm run smoke:caffeinate-dbus
+```
+
+The smoke verifies a missing ScreenSaver service, the standard and niri object paths, D-Bus-only partial activation, cancellation and connection cleanup during an in-flight `Inhibit`, and an unreachable session-bus socket that must reject without terminating Node.
+
+Docker does not run a Wayland compositor, so this smoke does not prove that a real desktop refrains from locking, blanking, or powering off a display.
+Keep the niri, GNOME, or KDE live smoke as a separate verification step.

--- a/packages/pi-caffeinate/test/docker/package-lock.json
+++ b/packages/pi-caffeinate/test/docker/package-lock.json
@@ -1,0 +1,2258 @@
+{
+	"name": "pi-caffeinate-dbus-smoke",
+	"version": "0.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "pi-caffeinate-dbus-smoke",
+			"version": "0.0.0",
+			"dependencies": {
+				"@earendil-works/pi-coding-agent": "0.84.1",
+				"@narumitw/pi-tui-kit": "0.49.3",
+				"@types/node": "26.1.2",
+				"dbus-native": "0.15.1",
+				"typescript": "7.0.2"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.977.7",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+			"integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.3",
+				"@aws-sdk/xml-builder": "^3.972.38",
+				"@aws/lambda-invoke-store": "^0.3.0",
+				"@smithy/core": "^3.31.1",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.68",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+			"integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.70",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+			"integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+			"integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.973.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+			"integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/credential-provider-env": "^3.972.68",
+				"@aws-sdk/credential-provider-http": "^3.972.70",
+				"@aws-sdk/credential-provider-login": "^3.972.75",
+				"@aws-sdk/credential-provider-process": "^3.972.68",
+				"@aws-sdk/credential-provider-sso": "^3.973.12",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.74",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.75",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+			"integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.79",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+			"integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.68",
+				"@aws-sdk/credential-provider-http": "^3.972.70",
+				"@aws-sdk/credential-provider-ini": "^3.973.13",
+				"@aws-sdk/credential-provider-process": "^3.972.68",
+				"@aws-sdk/credential-provider-sso": "^3.973.12",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.74",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.68",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+			"integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.973.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+			"integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/token-providers": "3.1108.0",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1108.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+			"integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.74",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+			"integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.32",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.32.tgz",
+			"integrity": "sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.27.tgz",
+			"integrity": "sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.50",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.50.tgz",
+			"integrity": "sha512-gdcWRbmIf1dWA/prf44Bnnzgqj+AbsXX2yfhZhOQLwSm7NfKIYPmkRlPqP0CTepHzjxMIBdWBDdtQB+Y/dFUeg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+			"integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.44",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+			"integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.44",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+			"integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.974.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+			"integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.9.tgz",
+			"integrity": "sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+			"integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.84.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+			"integrity": "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w==",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.84.1",
+				"@earendil-works/pi-telemetry": "^0.84.1",
+				"diff": "8.0.4",
+				"ignore": "7.0.5",
+				"typebox": "1.3.7",
+				"yaml": "2.9.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-ai": {
+			"version": "0.84.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+			"integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@earendil-works/pi-telemetry": "^0.84.1",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.3.7"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-client": {
+			"version": "0.84.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+			"integrity": "sha512-/V5hGHE4Zq+jG0GtwIB9PyBUOGd6gBLZ7lkQYFKchKnxYHeH3rmWC5xw4kpnZKKBuBuFTdLVbU9vEjlAGMMb2A==",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-protocol": "^0.84.1"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent": {
+			"version": "0.84.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
+			"integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-agent-core": "^0.84.1",
+				"@earendil-works/pi-ai": "^0.84.1",
+				"@earendil-works/pi-client": "^0.84.1",
+				"@earendil-works/pi-protocol": "^0.84.1",
+				"@earendil-works/pi-tui": "^0.84.1",
+				"@silvia-odwyer/photon-node": "0.3.4",
+				"chalk": "5.6.2",
+				"cross-spawn": "7.0.6",
+				"diff": "8.0.4",
+				"glob": "13.0.6",
+				"grok-mermaid": "0.2.2",
+				"highlight.js": "10.7.3",
+				"hosted-git-info": "9.0.3",
+				"ignore": "7.0.5",
+				"jiti": "2.7.0",
+				"minimatch": "10.2.5",
+				"proper-lockfile": "4.1.2",
+				"semver": "7.8.0",
+				"typebox": "1.3.7",
+				"undici": "8.9.0",
+				"yaml": "2.9.0"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "0.3.9"
+			}
+		},
+		"node_modules/@earendil-works/pi-protocol": {
+			"version": "0.84.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+			"integrity": "sha512-Ox1pciyeSPGEEUcxvR0/dJcrY7C6hrEGA8y71rOsvSIUlXN1Cbp/be/eoL71OGDBk5O97TeQPfWN6Ju/2Ehjww==",
+			"license": "MIT",
+			"dependencies": {
+				"typebox": "1.3.7"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-telemetry": {
+			"version": "0.84.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+			"integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-tui": {
+			"version": "0.84.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+			"integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mariozechner/clipboard": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+			"integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.9",
+				"@mariozechner/clipboard-darwin-universal": "0.3.9",
+				"@mariozechner/clipboard-darwin-x64": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+			"integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+			"integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+			"integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+			"integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+			"integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+			"integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+			"integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+			"integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@narumitw/pi-tui-kit": {
+			"version": "0.49.3",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
+			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
+			"license": "MIT",
+			"dependencies": {
+				"highlight.js": "11.11.1"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
+			}
+		},
+		"node_modules/@narumitw/pi-tui-kit/node_modules/highlight.js": {
+			"version": "11.11.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.32.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
+			"integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+			"integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+			"integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+			"integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+			"integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "26.1.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+			"integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~8.3.0"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT"
+		},
+		"node_modules/@typescript/typescript-aix-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+			"integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+			"integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+			"integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+			"integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+			"integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+			"integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-loong64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+			"integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-mips64el": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+			"integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+			"cpu": [
+				"mips64el"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+			"integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-riscv64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+			"integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-s390x": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+			"integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+			"integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-sunos-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+			"integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+			"integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+			"integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"license": "MIT"
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/dbus-native": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.15.1.tgz",
+			"integrity": "sha512-2Zdm+2eQuhmX08/Dyk3fltCqij5LGUwSx3Wj/ZN9IowlUw6eGfYZZXxkviUcN1iPOvWOQWUi74/nVnjZmg37vg==",
+			"license": "MIT",
+			"dependencies": {
+				"xml2js": "^0.6.2"
+			},
+			"bin": {
+				"dbus-native": "bin/dbus-native.js"
+			},
+			"engines": {
+				"node": ">=22.12.0"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+			"integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+			"integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC"
+		},
+		"node_modules/grok-mermaid": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+			"integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC"
+		},
+		"node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"license": "MIT"
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/sax": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+			"integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT"
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/typebox": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+			"integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+			"license": "MIT"
+		},
+		"node_modules/typescript": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc"
+			},
+			"engines": {
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
+			}
+		},
+		"node_modules/undici": {
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+			"integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"license": "MIT"
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml2js": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		}
+	}
+}

--- a/packages/pi-caffeinate/test/docker/package.json
+++ b/packages/pi-caffeinate/test/docker/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "pi-caffeinate-dbus-smoke",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@earendil-works/pi-coding-agent": "0.84.1",
+		"@narumitw/pi-tui-kit": "0.49.3",
+		"@types/node": "26.1.2",
+		"dbus-native": "0.15.1",
+		"typescript": "7.0.2"
+	}
+}

--- a/packages/pi-caffeinate/test/docker/run-docker.mjs
+++ b/packages/pi-caffeinate/test/docker/run-docker.mjs
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dockerDirectory = path.dirname(fileURLToPath(import.meta.url));
+const packageDirectory = path.resolve(dockerDirectory, "../..");
+const image = `pi-caffeinate-dbus-smoke:${process.pid}`;
+
+const version = spawnSync("docker", ["--version"], { encoding: "utf8" });
+if (version.error || version.status !== 0) {
+	throw new Error("Docker is required for the pi-caffeinate D-Bus smoke.");
+}
+
+let built = false;
+try {
+	runDocker([
+		"build",
+		"--file",
+		path.join(dockerDirectory, "Dockerfile"),
+		"--tag",
+		image,
+		packageDirectory,
+	]);
+	built = true;
+	runDocker(["run", "--rm", image]);
+} finally {
+	if (built) {
+		spawnSync("docker", ["image", "rm", image], { encoding: "utf8", timeout: 60_000 });
+	}
+}
+
+function runDocker(args) {
+	const result = spawnSync("docker", args, {
+		cwd: packageDirectory,
+		stdio: "inherit",
+		timeout: 300_000,
+	});
+	if (result.error) throw result.error;
+	if (result.status !== 0) process.exit(result.status ?? 1);
+}

--- a/packages/pi-caffeinate/test/docker/run-smoke.mjs
+++ b/packages/pi-caffeinate/test/docker/run-smoke.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { defineInterface, sessionBus } from "dbus-native";
+import caffeinate from "/smoke/build/caffeinate.js";
+import { defaultDbusScreenSaverFactory } from "/smoke/build/dbus-inhibit.js";
+
+const BUS_NAME = "org.freedesktop.ScreenSaver";
+const INTERFACE = "org.freedesktop.ScreenSaver";
+const STANDARD_PATH = "/org/freedesktop/ScreenSaver";
+const NIRI_PATH = "/ScreenSaver";
+const scenarios = [];
+
+await runScenario("missing ScreenSaver service rejects without leaking the client", async () => {
+	const client = await defaultDbusScreenSaverFactory();
+	await assert.rejects(client.inhibit("missing service"), /D-Bus idle inhibit failed/u);
+	await client.close();
+});
+
+const service = await createScreenSaverService();
+try {
+	await runScenario("standard ScreenSaver path acquires and releases its cookie", async () => {
+		service.expose(STANDARD_PATH);
+		const client = await defaultDbusScreenSaverFactory();
+		await client.inhibit("standard path");
+		await client.uninhibit();
+		await client.close();
+		assert.deepEqual(service.takeCalls(), [
+			{ member: "Inhibit", path: STANDARD_PATH, application: "pi-caffeinate" },
+			{ member: "UnInhibit", path: STANDARD_PATH, cookie: 1 },
+		]);
+	});
+
+	await runScenario("niri ScreenSaver path is used after the standard path is absent", async () => {
+		service.expose(NIRI_PATH);
+		const client = await defaultDbusScreenSaverFactory();
+		await client.inhibit("niri path");
+		await client.uninhibit();
+		await client.close();
+		assert.deepEqual(service.takeCalls(), [
+			{ member: "Inhibit", path: NIRI_PATH, application: "pi-caffeinate" },
+			{ member: "UnInhibit", path: NIRI_PATH, cookie: 2 },
+		]);
+	});
+
+	await runScenario(
+		"D-Bus-only activation is partial and agent_end cancels pending acquisition",
+		async () => {
+			service.expose(NIRI_PATH);
+			service.mode = "success";
+			const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-caffeinate-docker-agent-"));
+			const emptyPath = path.join(agentDir, "empty-path");
+			mkdirSync(emptyPath);
+			const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+			const previousPath = process.env.PATH;
+			process.env.PI_CODING_AGENT_DIR = agentDir;
+			process.env.PATH = emptyPath;
+			try {
+				const runtime = createExtensionRuntime();
+				await runtime.emit("session_start", { reason: "startup" });
+				await runtime.emit("agent_start", {});
+				assert.equal(runtime.statuses.get("caffeinate"), "display-awake");
+				assert.equal(runtime.notifications[0]?.level, "warning");
+				assert.match(runtime.notifications[0]?.message ?? "", /partially active/u);
+				assert.match(runtime.notifications[0]?.message ?? "", /system sleep inhibitor/iu);
+				await runtime.emit("agent_end", {});
+				assert.equal(runtime.statuses.get("caffeinate"), undefined);
+				assert.equal(
+					service.takeCalls().some(({ member }) => member === "UnInhibit"),
+					true,
+				);
+
+				service.mode = "hang";
+				const observedInhibit = service.nextInhibit();
+				const start = runtime.emit("agent_start", {});
+				await withDeadline(observedInhibit, 1_000, "in-flight Inhibit was not observed");
+				await withDeadline(
+					runtime.emit("agent_end", {}),
+					1_000,
+					"agent_end did not cancel Inhibit",
+				);
+				await withDeadline(start, 1_000, "cancelled agent_start did not settle");
+				service.mode = "success";
+			} finally {
+				if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+				else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+				if (previousPath === undefined) delete process.env.PATH;
+				else process.env.PATH = previousPath;
+				rmSync(agentDir, { recursive: true, force: true });
+			}
+		},
+	);
+} finally {
+	await service.close();
+}
+
+await runScenario("unreachable session-bus socket rejects without crashing Node", async () => {
+	const result = spawnSync(
+		process.execPath,
+		["/smoke/pi-caffeinate/test/docker/stale-socket-probe.mjs"],
+		{
+			encoding: "utf8",
+			env: {
+				...process.env,
+				DBUS_SESSION_BUS_ADDRESS: "unix:path=/tmp/pi-caffeinate-missing-session-bus.sock",
+			},
+			timeout: 5_000,
+		},
+	);
+	assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+	assert.match(result.stdout, /caught: D-Bus idle inhibit failed/u);
+});
+
+process.stdout.write(`${JSON.stringify({ passed: true, scenarios })}\n`);
+
+async function runScenario(name, operation) {
+	await operation();
+	scenarios.push(name);
+	process.stdout.write(`ok - ${name}\n`);
+}
+
+async function createScreenSaverService() {
+	const bus = sessionBus();
+	let closing = false;
+	bus.connection.on("error", (error) => {
+		if (!closing) throw error;
+	});
+	const requestResult = await bus.requestName(BUS_NAME, 0);
+	assert.ok(requestResult === 1 || requestResult === 4);
+
+	let mode = "success";
+	let activePath;
+	let nextCookie = 1;
+	let calls = [];
+	const inhibitWaiters = [];
+	const definition = defineInterface({
+		name: INTERFACE,
+		methods: {
+			Inhibit: {
+				in: { application: "s", reason: "s" },
+				out: { cookie: "u" },
+				handler: ({ application }, context) => {
+					const call = { member: "Inhibit", path: context.path, application };
+					calls.push(call);
+					inhibitWaiters.shift()?.(call);
+					if (mode === "hang") return new Promise(() => undefined);
+					return nextCookie++;
+				},
+			},
+			UnInhibit: {
+				in: { cookie: "u" },
+				handler: ({ cookie }, context) => {
+					calls.push({ member: "UnInhibit", path: context.path, cookie });
+				},
+			},
+		},
+	});
+
+	return {
+		get mode() {
+			return mode;
+		},
+		set mode(value) {
+			mode = value;
+		},
+		expose(objectPath) {
+			if (activePath) bus.unexportInterface(activePath, INTERFACE);
+			activePath = objectPath;
+			bus.exportInterface(definition.impl, objectPath, definition.descriptor);
+		},
+		nextInhibit() {
+			return new Promise((resolve) => inhibitWaiters.push(resolve));
+		},
+		takeCalls() {
+			const result = calls;
+			calls = [];
+			return result;
+		},
+		async close() {
+			closing = true;
+			await bus.close();
+		},
+	};
+}
+
+function createExtensionRuntime() {
+	const events = new Map();
+	const commands = new Map();
+	const notifications = [];
+	const statuses = new Map();
+	const pi = {
+		on(type, handler) {
+			const handlers = events.get(type) ?? [];
+			handlers.push(handler);
+			events.set(type, handlers);
+		},
+		registerCommand(name, command) {
+			commands.set(name, command);
+		},
+	};
+	const ctx = {
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			notify(message, level = "info") {
+				notifications.push({ message, level });
+			},
+			setStatus(key, value) {
+				statuses.set(key, value);
+			},
+		},
+	};
+	caffeinate(pi);
+	return {
+		notifications,
+		statuses,
+		async emit(type, event) {
+			for (const handler of events.get(type) ?? []) await handler(event, ctx);
+		},
+	};
+}
+
+async function withDeadline(promise, timeoutMs, message) {
+	let timer;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise((_, reject) => {
+				timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/packages/pi-caffeinate/test/docker/stale-socket-probe.mjs
+++ b/packages/pi-caffeinate/test/docker/stale-socket-probe.mjs
@@ -1,0 +1,12 @@
+import { defaultDbusScreenSaverFactory } from "/smoke/build/dbus-inhibit.js";
+
+const client = await defaultDbusScreenSaverFactory();
+try {
+	await client.inhibit("stale socket probe");
+	throw new Error("Expected the stale D-Bus socket to reject inhibition");
+} catch (error) {
+	if (!(error instanceof Error)) throw error;
+	process.stdout.write(`caught: ${error.message}\n`);
+} finally {
+	await client.close();
+}

--- a/packages/pi-caffeinate/test/docker/tsconfig.json
+++ b/packages/pi-caffeinate/test/docker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"skipLibCheck": true,
+		"types": ["node"],
+		"rootDir": "../../src",
+		"outDir": "../../../build"
+	},
+	"include": ["../../src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- build on #721 to inhibit Linux desktop idle through `org.freedesktop.ScreenSaver`
- handle D-Bus transport failures, timeouts, active disconnects, and lifecycle cancellation without crashing Pi
- report D-Bus-only activation as partial and preserve independent process inhibition
- retain logind idle inhibition with `--what=idle:sleep` in display mode
- add an opt-in Docker smoke using a real private `dbus-daemon` and mock ScreenSaver service

This PR keeps the original #721 commit intact and adds a focused hardening commit on top.
It supersedes #721 for merging into `main`.

Closes #248.

## Review findings resolved

- transport `error` and `close` events are now handled
- pending `Inhibit` calls are abortable and clients are closed during stop, agent end, replacement, and shutdown
- D-Bus-only display mode no longer claims full sleep inhibition
- display mode no longer regresses from `idle:sleep` to `sleep`

## Verification

- `npm run check` — 322 test files and 3,108 tests passed
- `npx vitest run packages/pi-caffeinate/test/caffeinate.test.ts` — 34 tests passed
- `npm run smoke:caffeinate-dbus` — five real-session-bus scenarios passed
- `npm run changeset:status`
- `just pack caffeinate` — nine expected package files; Docker fixtures excluded
- offline Pi entrypoint load

The Docker smoke verifies D-Bus transport and lifecycle behavior.
It does not emulate a Wayland compositor or prove real display blanking behavior.
