### PR TITLE
feat(workflow): keep plans linked through goal completion

### DIFF
--- a/.changeset/bright-plans-finish.md
+++ b/.changeset/bright-plans-finish.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-workflow": minor
+---
+
+Keep each approved Plan linked and compaction-safe until its Goal completes, is cleared, or is superseded, and retire workflow-specific implementation retention choices.

--- a/docs/plans/2026-08-12_pi-workflow-linked-plan-goal-lifecycle-plan.md
+++ b/docs/plans/2026-08-12_pi-workflow-linked-plan-goal-lifecycle-plan.md
@@ -1,0 +1,88 @@
+# pi-workflow linked Plan and Goal lifecycle plan
+
+## Goal
+
+Make `pi-workflow` express one clear execution contract: a ready Plan starts Goal when the user chooses Implement, and the exact linked Plan remains available until that Goal completes, is cleared, or is superseded.
+
+## Context
+
+The approved product model has three uses.
+
+1. Plan alone produces a ready, saved, exported, or discarded planning artifact without execution.
+2. Goal alone starts managed execution without requiring a Plan.
+3. Plan followed by Implement starts Goal in the current or a fresh session and lets Goal run the approved Plan to completion.
+
+`pi-workflow` already labels the ready actions **Run with Goal** and **Start fresh with Goal**, and `/plan implement` already routes to current-session Goal activation.
+
+The remaining mismatch is inherited standalone Plan retention behavior, which can clear the exact Plan while its linked Goal is still active.
+
+This plan records the approved substantial workflow proposal, so implementation does not require another product-design approval unless execution discovers a materially different migration or recovery decision.
+
+## Architecture
+
+- Keep Plan-only, Goal-only, and Plan-to-Goal as independent entry paths inside the one `pi-workflow` extension.
+- Treat Implement as Goal activation rather than adding a non-Goal implementation path.
+- Keep current-session and fresh-session choices as placement choices for the same linked Plan-to-Goal contract.
+- Persist the exact approved Plan in `plan-mode-state.activeImplementation` with its linked Goal ID, and inject one canonical hidden Plan copy after the original handoff disappears from model context.
+- Keep a linked Plan through active, paused, blocked, waiting, usage-limited, budget-limited, resumed, retried, and compacted Goal states.
+- Clear the linked Plan only when its Goal completes, is cleared, or is successfully superseded by another objective or queue transition.
+- Preserve Goal ID rotation by relinking the Plan before a resumed or edited Goal continues.
+- Recover a persisted unlinked implementation as a ready Plan because no Goal owns execution, while an orphaned linked Plan without its Goal is cleared.
+- Remove workflow-owned **After Implement** behavior from runtime and UI while retaining any legacy `plan.implementationPlanRetention` JSON field as ignored, preserved data during ordinary settings saves.
+- Keep the package-owned Plan snapshot internals cohesive without creating a shared engine or changing `pi-plan-mode` behavior.
+
+## Non-Goals
+
+- Do not add **Implement normally** or any other non-Goal execution path to `pi-workflow`.
+- Do not change standalone `pi-plan-mode` retention choices or standalone `pi-goal` behavior.
+- Do not change the five registered Plan and Goal tool names, the `/plan`, `/goal`, or `/workflow` command names, or managed-run event channels.
+- Do not automatically start Goal merely because a review-first Plan became ready.
+- Do not copy source planning messages into a fresh implementation session.
+- Do not create a shared workflow engine or an extension-to-extension dependency.
+
+## Risks
+
+- Clearing or converting state before the exact handoff reaches context can remove the only authoritative Plan from the first Goal request.
+- A process can stop after unlinked Plan state is published but before Goal linkage is published, so reload recovery must return the Plan to ready state without claiming execution started.
+- Goal resume, edit, priority, and queue transitions rotate IDs and can detach cleanup from the new Goal if relinking order regresses.
+- Context hooks can duplicate the Plan or place it on the wrong side of compaction and branch summaries if canonical insertion rules change.
+- Legacy workflow settings and session entries can contain shorter retention values, which must not reactivate early cleanup or make the whole settings file invalid after this behavior is retired.
+- `/plan exit` and the active Plan menu currently allow Plan-only cleanup while Goal continues, which would recreate the missing-Plan failure after later compaction.
+
+## Rollback / Recovery
+
+- Retain the existing `plan-mode-state` and `goal-state` entry names and accepted legacy fields so reverting does not require a session-data migration.
+- Ignore rather than delete legacy retention fields during reads and unrelated saves, preserving unknown-field and forward-compatibility guarantees.
+- Restore the exact ready or saved Plan and clear provisional Goal state when current-session activation or delivery fails.
+- Leave the source Plan unchanged when fresh-session replacement is cancelled or rejected.
+- Keep the existing compensated fresh-session recovery when both destination states cannot be published.
+- Require `/goal clear` or successful Goal supersession to end a linked execution; a rejected or cancelled action leaves both linked states unchanged.
+
+## Plan
+
+- [x] Add failing integration tests in `packages/pi-workflow/test/workflow.test.ts` proving ready, saved, direct `/plan implement`, review-first, automatic, current-session, and fresh-session Implement paths all start Goal and expose no non-Goal implementation branch; evidence: the new saved-Plan and linked-retention tests failed against the previous behavior, then all 567 package tests passed.
+- [x] Add failing linked-context tests that remove the original handoff behind compaction or branch summaries, assert one exact hidden Plan copy across repeated contexts, retain it through stopped and resumed Goal states, and remove it only after Goal completion, clear, or supersession; evidence: `workflow.test.ts` and `linked-plan-lifecycle.test.ts` cover canonical reinjection, summary ordering, stopped states, ID rotation, and terminal cleanup.
+- [x] Simplify the `packages/pi-workflow/src/plan/` active-implementation policy so workflow implementations always retain the exact Plan until an explicit linked-Goal terminal transition, while legacy persisted retention values restore without early cleanup; evidence: workflow composition forces `keep`, linked restore upgrades legacy short retention, and focused settlement tests pass.
+- [x] Update `packages/pi-workflow/src/workflow.ts` and the Plan handle contract so current and fresh handoffs publish one linked Plan and Goal ownership transition, preserve rollback after partial failure, relink every committed Goal ID rotation, and revalidate session and request ownership after each `await`; evidence: activation, delivery, persistence-failure, replacement, shutdown, resume, edit, queue, and fresh-session suites pass.
+- [x] Add reload recovery for interrupted unlinked handoffs by restoring their exact Plan as ready, keep entry-order conflict resolution deterministic, and continue clearing orphaned or superseded linked Plans; evidence: branch fixtures cover newer and older Plan/Goal entries, orphaned links, failed compensation, and ready-state recovery.
+- [x] Change linked execution controls so `/plan exit` cannot silently detach an active Goal, and replace active-Plan menu actions that would clear or replace the Plan with **Manage linked Goal**; evidence: TUI cancellation and narrow rendering tests pass, and TUI plus print/JSON command tests preserve both states on rejection.
+- [x] Remove **After Implement** from workflow Plan settings, workflow descriptions, Plan action previews, and workflow-owned setting patches, while accepting and preserving legacy `plan.implementationPlanRetention` content as ignored data; evidence: settings tests cover missing, arbitrary legacy, unknown-field preservation, malformed read-only files, atomic failure, TUI, and RPC behavior.
+- [x] Update `packages/pi-workflow` menus, status text, help, and `README.md` to describe the three supported uses, define Implement as Goal execution, distinguish current versus fresh placement, explain compaction-safe Plan retention, and direct linked cancellation through Goal; evidence: menu tests and the package runtime smoke match the documented behavior while standard README sections remain intact.
+- [x] Extend `packages/pi-workflow/test/workflow-runtime-smoke.mjs` with a deterministic Plan-ready-to-Goal scenario that observes the exact handoff, continued Goal ownership, terminal cleanup, and extension disposal through real Pi lifecycle ordering; evidence: `npm --workspace @narumitw/pi-workflow run test:runtime` passes.
+- [x] Add a minor Changeset for `@narumitw/pi-workflow` describing the experimental settings and linked-lifecycle behavior change; evidence: `npm run changeset:status` reports only `@narumitw/pi-workflow` moving to `0.3.0`.
+- [x] Audit and harden the final diff against `docs/extension-conventions.md`, `docs/extension-settings.md`, the edge-case checklist, and the approved experience; evidence: a red regression exposed terminal Goal ID rotation leaving a stale Plan, the shared transition now clears it, all 567 package tests pass, and the final command-scoped-signing `npm run check` passes all 3,677 repository tests.
+- [ ] Stage only the intended paths and create focused signed commits; verify each index diff, signature, commit ID, and remaining worktree state.
+- [ ] Push `feat/pi-workflow-linked-plan-lifecycle` and open a pull request against `main` with behavior, checks, compatibility, risk, and plan evidence; verify the remote branch and PR URL before archiving this plan.
+
+## Completion Checklist
+
+- [x] All ready or saved Implement actions start linked Goal execution, while Plan-only save, export, stay, and discard actions remain available without execution.
+- [x] The exact linked Plan survives repeated context assembly, retry, compaction, reload, pause, block, wait, limits, and resume until its Goal reaches an approved terminal or superseding transition.
+- [x] No settings value or Plan-only command can silently remove a Plan from an active linked Goal.
+- [x] Legacy workflow settings and session entries load safely, remain forward-compatible, and cannot restore early linked-Plan cleanup.
+- [x] All 567 focused `pi-workflow` unit and integration tests pass.
+- [x] `npm --workspace @narumitw/pi-workflow run test:runtime` passes.
+- [x] The final `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm run check` passes the CI-equivalent gate, including all 3,677 tests; the command-scoped override only lets test fixtures commit without the unavailable signing agent.
+- [x] `just pack workflow` succeeds with the manifest-listed README, license, package manifest, and 51 source files in the 54-file dry-run tarball.
+- [x] The Changeset names only `@narumitw/pi-workflow` with a minor bump from `0.2.0` to `0.3.0`.
+- [ ] Every plan task and completion check has current evidence before this plan moves to `docs/plans/archived/`.

--- a/docs/plans/archived/2026-08-12_pi-workflow-linked-plan-goal-lifecycle-plan.md
+++ b/docs/plans/archived/2026-08-12_pi-workflow-linked-plan-goal-lifecycle-plan.md
@@ -71,8 +71,8 @@ This plan records the approved substantial workflow proposal, so implementation 
 - [x] Extend `packages/pi-workflow/test/workflow-runtime-smoke.mjs` with a deterministic Plan-ready-to-Goal scenario that observes the exact handoff, continued Goal ownership, terminal cleanup, and extension disposal through real Pi lifecycle ordering; evidence: `npm --workspace @narumitw/pi-workflow run test:runtime` passes.
 - [x] Add a minor Changeset for `@narumitw/pi-workflow` describing the experimental settings and linked-lifecycle behavior change; evidence: `npm run changeset:status` reports only `@narumitw/pi-workflow` moving to `0.3.0`.
 - [x] Audit and harden the final diff against `docs/extension-conventions.md`, `docs/extension-settings.md`, the edge-case checklist, and the approved experience; evidence: a red regression exposed terminal Goal ID rotation leaving a stale Plan, the shared transition now clears it, all 567 package tests pass, and the final command-scoped-signing `npm run check` passes all 3,677 repository tests.
-- [ ] Stage only the intended paths and create focused signed commits; verify each index diff, signature, commit ID, and remaining worktree state.
-- [ ] Push `feat/pi-workflow-linked-plan-lifecycle` and open a pull request against `main` with behavior, checks, compatibility, risk, and plan evidence; verify the remote branch and PR URL before archiving this plan.
+- [x] Stage only the intended paths and create focused signed commits; evidence: commit `613284553f769e735f303240b2217f155c75a60c` contains the reviewed feature boundary and an SSH signature, with no unrelated worktree changes.
+- [x] Push `feat/pi-workflow-linked-plan-lifecycle` and open a pull request against `main` with behavior, checks, compatibility, risk, and plan evidence; evidence: the remote branch tracks origin and pull request `https://github.com/narumiruna/pi-extensions/pull/727` is open.
 
 ## Completion Checklist
 
@@ -85,4 +85,4 @@ This plan records the approved substantial workflow proposal, so implementation 
 - [x] The final `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm run check` passes the CI-equivalent gate, including all 3,677 tests; the command-scoped override only lets test fixtures commit without the unavailable signing agent.
 - [x] `just pack workflow` succeeds with the manifest-listed README, license, package manifest, and 51 source files in the 54-file dry-run tarball.
 - [x] The Changeset names only `@narumitw/pi-workflow` with a minor bump from `0.2.0` to `0.3.0`.
-- [ ] Every plan task and completion check has current evidence before this plan moves to `docs/plans/archived/`.
+- [x] Every plan task and completion check has current evidence before this plan moves to `docs/plans/archived/`.

--- a/packages/pi-workflow/README.md
+++ b/packages/pi-workflow/README.md
@@ -15,7 +15,8 @@ Those packages intentionally share command, tool, event-channel, and session-sta
 ## ✨ Features
 
 - Provides `/workflow`, `/plan`, and `/goal` from one extension.
-- Preserves Plan exploration, structured questions, completion, save, export, tool selection, thinking-level control, current-session implementation, and fresh-session implementation.
+- Preserves Plan exploration, structured questions, completion, save, export, tool selection, and thinking-level control.
+- Supports Plan alone, Goal alone, and approved Plan-to-Goal execution without adding a non-Goal implementation path.
 - Preserves Goal completion, blocking, external waits, pause, resume, edit, clear, token budgets, continuation guards, optional ordered queues, and managed-run RPC.
 - Uses review-first handoff by default, matching Codex's authoritative-plan and explicit-approval workflow.
 - Offers **Run with Goal** and **Start fresh with Goal** as the primary completed-plan actions.
@@ -68,7 +69,15 @@ Start planning:
 /plan describe the feature and produce an implementation plan
 ```
 
-When the plan is complete, choose **Run with Goal** to keep the planning conversation or **Start fresh with Goal** to transfer only the approved plan.
+A Plan can remain planning-only: save it, export it, continue revising it, or discard it without execution.
+
+When the Plan is ready, choose **Run with Goal** to keep the planning conversation or **Start fresh with Goal** to transfer only the approved Plan.
+
+Start Goal directly when no prior Plan is needed:
+
+```text
+/goal implement and verify the requested change
+```
 
 Use `/goal` to inspect, pause, resume, edit, or clear managed execution.
 
@@ -110,19 +119,21 @@ If the destination kickoff fails after state is saved, the destination retains b
 
 The source planning session remains resumable after every fresh handoff.
 
-### Plan retention
+### Linked Plan lifecycle
 
-The Plan **After Implement** policy still controls how long the accepted Plan is retained and reinjected.
+Implement always starts Goal; `pi-workflow` has no non-Goal implementation path.
 
-The default keeps the Plan active while its linked Goal runs.
+The exact approved Plan remains linked and available while Goal is active, paused, blocked, waiting, usage-limited, budget-limited, retried, compacted, or resumed.
 
-Goal completion, clear, or supersession clears the linked implementation Plan so stale context does not leak into later work.
+The original combined handoff supplies the first Goal request without duplication.
 
-Pausing, blocking, waiting, usage limits, budget limits, and resume retain or relink the approved Plan for recovery.
+After that handoff disappears from model context, the extension injects one hidden canonical copy of the exact Plan instead of depending on a lossy compaction summary.
 
-Shorter retention policies use the exact Plan in the initial handoff and then follow their established cleanup behavior.
+Goal completion, clear, or successful supersession clears the linked Plan so stale context does not leak into later work.
 
-Goal state remains independently persistent until completion, clear, or another Goal transition.
+A linked `/plan exit` is rejected because it would leave Goal referring to a missing Plan; use `/goal` to manage execution or `/goal clear` to stop it and clear both states.
+
+Persisted unlinked implementation state is recovered as a ready Plan because no Goal owns execution.
 
 ## 💬 Commands
 
@@ -151,7 +162,9 @@ It works in TUI and RPC modes and rejects print and JSON modes before opening in
 /plan exit
 ```
 
-`/plan` retains the Plan-mode read-only tool policy, structured `plan_mode_question` interaction, standalone `plan_mode_complete` completion contract, saved-plan slot, export safety, session persistence, and compaction-aware implementation context.
+`/plan` retains the Plan-mode read-only tool policy, structured `plan_mode_question` interaction, standalone `plan_mode_complete` completion contract, saved-plan slot, export safety, session persistence, and compaction-aware linked-Plan context.
+
+`/plan implement` is the direct compatibility route for starting the ready or saved Plan as Goal in the current session.
 
 A new Plan cannot start while any unfinished Goal exists.
 
@@ -233,7 +246,6 @@ Example:
   "plan": {
     "thinkingLevel": "inherit",
     "defaultPlanTools": ["read", "bash", "grep", "find", "ls"],
-    "implementationPlanRetention": "keep",
     "defaultPlanExportPath": "PLAN.md",
     "safeSubcommands": {
       "git": ["status", "log", "diff", "show"]
@@ -257,7 +269,11 @@ Example:
 
 `workflow.planHandoff` accepts `review` or `automatic`.
 
-The `plan` object accepts the same Plan defaults and reviewed shell subcommands as the standalone Plan extension.
+The `plan` object accepts Plan thinking, tools, export destination, and reviewed shell-subcommand defaults.
+
+The standalone `implementationPlanRetention` setting is not used by `pi-workflow` because every Implement action starts Goal and keeps the exact Plan until linked execution ends.
+
+A legacy `plan.implementationPlanRetention` field is ignored and preserved as unknown data during ordinary settings saves.
 
 The `goal` object accepts the same tool visibility, queue, RPC, and continuation-limit settings as the standalone Goal extension.
 
@@ -279,7 +295,7 @@ Recreate their desired values through `/workflow` or manually place them under t
 
 ## 📊 Status and persistence
 
-`workflow:plan` reports `plan active`, `plan ready`, `plan saved`, or `plan implementing`.
+`workflow:plan` reports `plan active`, `plan ready`, `plan saved`, or `plan implementing` while the exact Plan is linked to Goal.
 
 `workflow:goal` reports active, waiting, paused, blocked, usage-limited, budget-limited, complete, and queue-frozen states.
 

--- a/packages/pi-workflow/src/goal/commands.ts
+++ b/packages/pi-workflow/src/goal/commands.ts
@@ -746,10 +746,12 @@ export class GoalCommandController {
 		} else {
 			this.runtime.clearStaleGoalToolCallBlock();
 		}
-		try {
-			this.onGoalSuperseded?.(previousGoal, editedGoal);
-		} catch {
-			// The edited Goal is committed. Restore reconciliation retries Plan cleanup.
+		if (previousGoal.text !== editedGoal.text) {
+			try {
+				this.onGoalSuperseded?.(previousGoal, editedGoal);
+			} catch {
+				// The edited Goal is committed. Restore reconciliation retries Plan cleanup.
+			}
 		}
 		notifyTerminal(ctx.ui, `Goal updated: ${objective}`, "info");
 	}

--- a/packages/pi-workflow/src/menu.ts
+++ b/packages/pi-workflow/src/menu.ts
@@ -88,7 +88,7 @@ export function createWorkflowMenu(controller: WorkflowMenuController) {
 					{
 						id: "planSettings",
 						label: "Plan settings",
-						description: "Thinking, tools, implementation retention, and export destination.",
+						description: "Thinking, tools, and export destination.",
 						currentValue: "Open…",
 						action: "open-plan-settings",
 					},
@@ -120,8 +120,10 @@ export function createWorkflowMenu(controller: WorkflowMenuController) {
 				kind: "detail",
 				title: "How Workflow works",
 				lines: [
-					"Use /plan to produce an authoritative implementation plan without mutating files.",
-					"After approval, pi-workflow transfers the exact approved Plan to Goal in one implementation request.",
+					"Use /plan alone to produce, save, export, revise, or discard an authoritative Plan without execution.",
+					"Use /goal alone when managed execution does not need a prior Plan.",
+					"Choosing Implement transfers the exact approved Plan to Goal in one implementation request.",
+					"The linked Plan remains available until Goal completes, is cleared, or is superseded.",
 					"Use /goal to pause, resume, edit, inspect, or clear managed execution.",
 					"Review-first handoff is the safe default. Automatic handoff must be explicitly enabled.",
 					"Do not load pi-workflow together with pi-plan-mode or pi-goal.",
@@ -204,8 +206,8 @@ function planDescription(state: WorkflowMenuState["plan"]) {
 		off: "Start a read-only planning workflow",
 		planning: "Continue or manage the active Plan",
 		ready: "Review and hand the approved Plan to Goal",
-		saved: "Show, run, export, or clear the saved Plan",
-		implementing: "Show, export, replace, or clear the implementation Plan",
+		saved: "Show, run with Goal, export, or clear the saved Plan",
+		implementing: "Show or export the linked Plan, or manage Goal",
 	}[state];
 }
 

--- a/packages/pi-workflow/src/plan/active-implementation-menu.ts
+++ b/packages/pi-workflow/src/plan/active-implementation-menu.ts
@@ -10,8 +10,9 @@ interface ActiveImplementationMenuOptions {
 	show(): void;
 	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	settings(signal: AbortSignal): Promise<boolean>;
-	startNew(): void;
-	clear(): void;
+	manageGoal?(): void | Promise<void>;
+	startNew?(): void;
+	clear?(): void;
 }
 
 export async function showActiveImplementationMenu(
@@ -19,20 +20,38 @@ export async function showActiveImplementationMenu(
 	options: ActiveImplementationMenuOptions,
 ) {
 	type Screen = "active" | "export";
-	type Action = "show" | "export" | "settings" | "start-new" | "clear";
+	type Action = "show" | "export" | "settings" | "manage-goal" | "start-new" | "clear";
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "active",
 		screens: {
 			active: () => ({
 				kind: "actions",
 				title: "Active implementation plan",
-				lines: [options.statusText],
+				lines: [
+					options.statusText,
+					...(options.manageGoal
+						? ["The exact Plan remains linked until Goal completes, is cleared, or is superseded."]
+						: []),
+				],
 				items: [
 					{ id: "show", label: "Show active implementation plan", action: "show" },
 					{ id: "export", label: "Export plan…", to: "export" },
+					...(options.manageGoal
+						? [{ id: "manage-goal", label: "Manage linked Goal…", action: "manage-goal" as const }]
+						: []),
 					{ id: "settings", label: "Settings", action: "settings" },
-					{ id: "start-new", label: "Start a new plan", action: "start-new" },
-					{ id: "clear", label: "Clear active implementation plan", action: "clear" },
+					...(options.startNew
+						? [{ id: "start-new", label: "Start a new plan", action: "start-new" as const }]
+						: []),
+					...(options.clear
+						? [
+								{
+									id: "clear",
+									label: "Clear active implementation plan",
+									action: "clear" as const,
+								},
+							]
+						: []),
 				],
 				hint: "close",
 			}),
@@ -50,11 +69,18 @@ export async function showActiveImplementationMenu(
 				if (signal.aborted || !options.isCurrent()) return { kind: "rejected" };
 				return close ? { kind: "close" } : { kind: "stay" };
 			},
+			"manage-goal": async () => {
+				if (!options.manageGoal) return { kind: "rejected" };
+				await options.manageGoal();
+				return { kind: "close" };
+			},
 			"start-new": async () => {
+				if (!options.startNew) return { kind: "rejected" };
 				options.startNew();
 				return { kind: "close" };
 			},
 			clear: async () => {
+				if (!options.clear) return { kind: "rejected" };
 				options.clear();
 				return { kind: "close" };
 			},

--- a/packages/pi-workflow/src/plan/plan-mode.ts
+++ b/packages/pi-workflow/src/plan/plan-mode.ts
@@ -52,6 +52,7 @@ import {
 	awaitPlanModeSettingsWrites,
 	configuredImplementationPlanRetention,
 	configuredThinkingLevel,
+	type ImplementationPlanRetention,
 	type PlanModeSettings,
 	readPlanModeSettings,
 	type updatePlanModeSettings,
@@ -99,6 +100,10 @@ export interface PlanModeDependencies {
 	updateSettings?: typeof updatePlanModeSettings;
 	shouldAutoHandoff?(): boolean;
 	canStartPlan?(): string | undefined;
+	implementationPlanRetention?: ImplementationPlanRetention;
+	implementationOutcome?(): string;
+	showImplementationPlanRetentionSetting?: boolean;
+	manageLinkedGoal?(ctx: ExtensionCommandContext): Promise<void>;
 	startFreshImplementation?: FreshImplementationFromStateOptions["startSession"];
 	startImplementation?(
 		request: PlanImplementationHandoffRequest,
@@ -113,6 +118,7 @@ export interface PlanModeHandle {
 	linkImplementationToGoal(implementationId: string, goalId: string): boolean;
 	clearLinkedGoal(goalId: string): boolean;
 	clearForGoalConflict(ctx: ExtensionContext): boolean;
+	recoverUnlinkedImplementation(ctx: ExtensionContext): boolean;
 	handleGoalState(snapshot: { goalId: string; status: string }): void;
 	reconcileGoalState(goal: { id: string; status: string } | undefined): void;
 }
@@ -297,6 +303,7 @@ export default function planMode(
 				return;
 			}
 			if (command === "exit" || command === "off") {
+				if (linkedPlanExitBlocked(ctx)) return;
 				const notification = state.activeImplementation
 					? "Active implementation plan cleared."
 					: state.savedPlan
@@ -697,7 +704,7 @@ export default function planMode(
 		await startFreshImplementationFromState(ctx, {
 			getState: () => state,
 			menuIsCurrent,
-			retention: configuredImplementationPlanRetention(settings),
+			retention: effectiveImplementationPlanRetention(),
 			stateEntryType: STATE_ENTRY_TYPE,
 			...(dependencies.startFreshImplementation
 				? { startSession: dependencies.startFreshImplementation }
@@ -737,7 +744,7 @@ export default function planMode(
 			plan,
 			source,
 			startedAt: Date.now(),
-			retention: configuredImplementationPlanRetention(settings),
+			retention: effectiveImplementationPlanRetention(),
 		};
 		state = {
 			...state,
@@ -814,7 +821,11 @@ export default function planMode(
 		if (activeImplementation?.id !== implementationId) return false;
 		state = {
 			...state,
-			activeImplementation: { ...activeImplementation, goalId },
+			activeImplementation: {
+				...activeImplementation,
+				goalId,
+				retention: effectiveImplementationPlanRetention(),
+			},
 		};
 		persistState();
 		if (currentContext) updateUi(currentContext);
@@ -833,21 +844,60 @@ export default function planMode(
 		return true;
 	}
 
+	function recoverUnlinkedImplementation(ctx: ExtensionContext) {
+		const activeImplementation = state.activeImplementation;
+		if (!activeImplementation || activeImplementation.goalId) return false;
+		workflowGeneration += 1;
+		state = {
+			...state,
+			enabled: true,
+			latestPlan: activeImplementation.plan,
+			latestPlanSource: activeImplementation.source,
+			awaitingAction: true,
+			activeImplementation: undefined,
+		};
+		implementationRetention.reset();
+		activatePlanModeTools();
+		applyPlanThinkingLevel();
+		persistState();
+		updateUi(ctx);
+		return true;
+	}
+
 	function handleGoalState(snapshot: { goalId: string; status: string }) {
 		if (!sessionReady) return;
 		const activeImplementation = state.activeImplementation;
 		const linkedGoalId = activeImplementation?.goalId;
 		if (!activeImplementation || !linkedGoalId) return;
-		const linkedTerminal =
-			linkedGoalId === snapshot.goalId &&
-			(snapshot.status === "complete" || snapshot.status === "cleared");
+		const terminalStatus = snapshot.status === "complete" || snapshot.status === "cleared";
+		const linkedTerminal = linkedGoalId === snapshot.goalId && terminalStatus;
 		const linkedChanged = linkedGoalId !== snapshot.goalId;
 		if (linkedChanged) {
+			if (terminalStatus) {
+				if (handoffInFlightImplementationId !== activeImplementation.id) {
+					clearActiveImplementation(activeImplementation.id, currentContext);
+				}
+				return;
+			}
 			// Goal rotates stale-turn IDs for resume, edit, and priority transitions.
-			// Relink every persisted replacement first; committed supersession is cleared
-			// explicitly after delivery, so failed transitions can relink on rollback.
+			// Relink every persisted nonterminal replacement first; committed supersession
+			// is cleared explicitly after delivery, so failed transitions can relink on rollback.
 			linkImplementationToGoal(activeImplementation.id, snapshot.goalId);
 			return;
+		}
+		if (
+			!linkedTerminal &&
+			activeImplementation.retention !== effectiveImplementationPlanRetention()
+		) {
+			state = {
+				...state,
+				activeImplementation: {
+					...activeImplementation,
+					retention: effectiveImplementationPlanRetention(),
+				},
+			};
+			persistState();
+			if (currentContext) updateUi(currentContext);
 		}
 		if (linkedTerminal && handoffInFlightImplementationId !== activeImplementation.id) {
 			clearActiveImplementation(activeImplementation.id, currentContext);
@@ -909,7 +959,7 @@ export default function planMode(
 		});
 	}
 
-	async function showActivePlanMenu(ctx: ExtensionContext) {
+	async function showActivePlanMenu(ctx: ExtensionCommandContext) {
 		if (!ctx.hasUI) {
 			ctx.ui.notify(planStatusText(), "info");
 			return;
@@ -926,15 +976,26 @@ export default function planMode(
 			show: () => showStoredPlan(pi, ctx, state),
 			exportPlan: (path, signal) => planExports.export(path, ctx, signal, lifecycle.isCurrent),
 			settings: (signal) => showSettings(ctx, signal, lifecycle.isCurrent),
-			startNew: () => {
-				if (planStartBlocked(ctx)) return;
-				enterPlanMode(ctx);
-				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
-			},
-			clear: () => {
-				exitPlanMode(ctx);
-				ctx.ui.notify("Active implementation plan cleared.", "info");
-			},
+			...(state.activeImplementation?.goalId
+				? {
+						manageGoal: dependencies.manageLinkedGoal
+							? () => dependencies.manageLinkedGoal?.(ctx)
+							: undefined,
+					}
+				: {
+						startNew: () => {
+							if (planStartBlocked(ctx)) return;
+							enterPlanMode(ctx);
+							ctx.ui.notify(
+								"Plan mode enabled. I will explore and plan, but not modify files.",
+								"info",
+							);
+						},
+						clear: () => {
+							exitPlanMode(ctx);
+							ctx.ui.notify("Active implementation plan cleared.", "info");
+						},
+					}),
 		});
 	}
 
@@ -948,6 +1009,8 @@ export default function planMode(
 		if (!isCurrent() || signal.aborted) return false;
 		const result = await ui.showPlanModeSettings(ctx, {
 			tools: selectableTools(),
+			showImplementationPlanRetention:
+				dependencies.showImplementationPlanRetentionSetting !== false,
 			signal,
 			isCurrent,
 			settingsPath: dependencies.settingsPath,
@@ -1101,6 +1164,15 @@ export default function planMode(
 		state = restorePlanModeState(ctx.sessionManager.getBranch(), STATE_ENTRY_TYPE);
 	}
 
+	function linkedPlanExitBlocked(ctx: ExtensionContext) {
+		if (!state.activeImplementation?.goalId) return false;
+		const message =
+			"The linked Goal must retain its active Plan until Goal ends. Use /goal to manage execution or /goal clear to stop it and clear the Plan.";
+		if (ctx.mode === "print" || ctx.mode === "json") throw new Error(message);
+		ctx.ui.notify(message, "warning");
+		return true;
+	}
+
 	function updateUi(ctx: ExtensionContext) {
 		updatePlanModeUi(ctx, state, formatToolSummary);
 	}
@@ -1113,8 +1185,17 @@ export default function planMode(
 		return formatPlanModeStatusText(state, formatToolSummary);
 	}
 
+	function effectiveImplementationPlanRetention() {
+		return (
+			dependencies.implementationPlanRetention ?? configuredImplementationPlanRetention(settings)
+		);
+	}
+
 	function implementationOutcome() {
-		return implementationRetentionPreview(configuredImplementationPlanRetention(settings));
+		return (
+			dependencies.implementationOutcome?.() ??
+			implementationRetentionPreview(effectiveImplementationPlanRetention())
+		);
 	}
 
 	function formatToolSummary() {
@@ -1176,6 +1257,7 @@ export default function planMode(
 		linkImplementationToGoal,
 		clearLinkedGoal,
 		clearForGoalConflict,
+		recoverUnlinkedImplementation,
 		handleGoalState,
 		reconcileGoalState,
 	};

--- a/packages/pi-workflow/src/plan/presentation.ts
+++ b/packages/pi-workflow/src/plan/presentation.ts
@@ -27,10 +27,15 @@ export function updatePlanModeUi(
 			"Use /plan to show, implement, or clear it.",
 		]);
 	} else if (state.activeImplementation) {
-		ctx.ui.setWidget(PLAN_WIDGET_KEY, [
-			"Implementation plan active",
-			"Use /plan to show, replace, or clear it.",
-		]);
+		ctx.ui.setWidget(
+			PLAN_WIDGET_KEY,
+			state.activeImplementation.goalId
+				? [
+						"Implementation Plan linked to Goal",
+						"Use /plan to show or export it, and /goal to manage execution.",
+					]
+				: ["Implementation plan active", "Use /plan to show, replace, or clear it."],
+		);
 	} else {
 		ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
 	}
@@ -93,6 +98,7 @@ export function planModeStatusText(state: PlanModeState, toolSummary: () => stri
 		return `Plan mode is active. ${toolSummary()} Explore, ask, and finish with plan_mode_complete when decision-ready.`;
 	}
 	if (state.savedPlan) return "A plan is saved for later.";
+	if (state.activeImplementation?.goalId) return "An implementation Plan is linked to Goal.";
 	if (state.activeImplementation) return "An implementation plan is active.";
 	return "Plan mode is off.";
 }

--- a/packages/pi-workflow/src/plan/settings-menu.ts
+++ b/packages/pi-workflow/src/plan/settings-menu.ts
@@ -33,6 +33,7 @@ export interface PlanModeSettingsMenuOptions {
 	isCurrent(): boolean;
 	settingsPath?: string;
 	legacySettingsPath?: string;
+	showImplementationPlanRetention?: boolean;
 	readSettings?: (settingsPath?: string) => Promise<PlanModeSettingsLoadResult>;
 	updateSettings?: (
 		patch: PlanModeSettingsPatch,
@@ -107,16 +108,21 @@ export async function showPlanModeSettings(
 									currentValue: defaultToolsValue(state.settings.defaultPlanTools),
 									action: "open-tools",
 								},
-								{
-									id: "implementationPlanRetention",
-									label: "After Implement",
-									description: "Choose how long the accepted plan keeps guiding implementation.",
-									currentValue: retentionLabel(
-										configuredImplementationPlanRetention(state.settings),
-									),
-									values: IMPLEMENTATION_PLAN_RETENTIONS.map(retentionLabel),
-									action: "set-retention",
-								},
+								...(options.showImplementationPlanRetention === false
+									? []
+									: [
+											{
+												id: "implementationPlanRetention",
+												label: "After Implement",
+												description:
+													"Choose how long the accepted plan keeps guiding implementation.",
+												currentValue: retentionLabel(
+													configuredImplementationPlanRetention(state.settings),
+												),
+												values: IMPLEMENTATION_PLAN_RETENTIONS.map(retentionLabel),
+												action: "set-retention" as const,
+											},
+										]),
 								{
 									id: "defaultPlanExportPath",
 									label: "Export destination",
@@ -265,7 +271,7 @@ export async function showPlanModeSettings(
 function settingsLines(settingsPath: string, notice: string | undefined) {
 	return [
 		`User settings · ${safeTerminalText(settingsPath)}`,
-		"Plan defaults apply to the next workflow; handoff and export choices apply to their next action.",
+		"Plan defaults apply to the next workflow; export choices apply to the next export.",
 		...(notice ? [safeTerminalText(notice)] : []),
 	];
 }

--- a/packages/pi-workflow/src/settings.ts
+++ b/packages/pi-workflow/src/settings.ts
@@ -102,14 +102,11 @@ export async function updateWorkflowPlanSettings(
 	else if (patch.defaultPlanTools !== undefined) {
 		plan.defaultPlanTools = [...patch.defaultPlanTools];
 	}
-	if (patch.implementationPlanRetention !== undefined) {
-		plan.implementationPlanRetention = patch.implementationPlanRetention;
-	}
 	if (patch.defaultPlanExportPath === null) delete plan.defaultPlanExportPath;
 	else if (patch.defaultPlanExportPath !== undefined) {
 		plan.defaultPlanExportPath = patch.defaultPlanExportPath;
 	}
-	const normalized = normalizePlanModeSettings(plan);
+	const normalized = normalizeWorkflowPlanSettings(plan);
 	if (!normalized) throw invalidSettingsError(settingsPath, "invalid Plan settings shape");
 	const document = { ...current, plan };
 	if (!normalizeWorkflowDocument(document)) {
@@ -166,7 +163,7 @@ function normalizeWorkflowDocument(value: unknown): WorkflowSettingsSnapshot | u
 	if (!workflow || !plan || !goal) return undefined;
 	const planHandoff = Object.hasOwn(workflow, "planHandoff") ? workflow.planHandoff : "review";
 	if (!PLAN_HANDOFF_BEHAVIORS.includes(planHandoff as PlanHandoffBehavior)) return undefined;
-	const normalizedPlan = normalizePlanModeSettings(plan);
+	const normalizedPlan = normalizeWorkflowPlanSettings(plan);
 	const normalizedGoal = normalizeGoalSettings(goal);
 	if (!normalizedPlan || !normalizedGoal) return undefined;
 	return {
@@ -174,6 +171,14 @@ function normalizeWorkflowDocument(value: unknown): WorkflowSettingsSnapshot | u
 		plan: normalizedPlan,
 		goal: normalizedGoal,
 	};
+}
+
+function normalizeWorkflowPlanSettings(value: unknown): PlanModeSettings | undefined {
+	const plan = ownRecord(value);
+	if (!plan) return undefined;
+	const supported = { ...plan };
+	delete supported.implementationPlanRetention;
+	return normalizePlanModeSettings(supported);
 }
 
 function section(document: SettingsDocument, key: string): SettingsDocument | undefined {

--- a/packages/pi-workflow/src/workflow.ts
+++ b/packages/pi-workflow/src/workflow.ts
@@ -78,6 +78,11 @@ export default function workflow(pi: ExtensionAPI, dependencies: WorkflowDepende
 		readSettings: async () => readPlanSettings(),
 		reportSettingsIssues: false,
 		shouldAutoHandoff: () => planHandoff === "automatic",
+		implementationPlanRetention: "keep",
+		implementationOutcome: () =>
+			"Goal execution keeps the exact Plan linked until Goal completes, is cleared, or is superseded.",
+		showImplementationPlanRetentionSetting: false,
+		manageLinkedGoal: (ctx) => goalHandle.ui.showManager(ctx),
 		canStartPlan: () =>
 			goalHandle.runtime.activeGoal
 				? "Clear the current Goal before starting Plan mode."
@@ -130,6 +135,7 @@ export default function workflow(pi: ExtensionAPI, dependencies: WorkflowDepende
 				planHandle?.clearForGoalConflict(ctx);
 			}
 		}
+		if (!restoredGoal) planHandle?.recoverUnlinkedImplementation(ctx);
 		const restoredPlan = planHandle?.getState().activeImplementation;
 		if (restoredGoal && restoredGoal.text !== WORKFLOW_GOAL_OBJECTIVE && restoredPlan?.goalId) {
 			planHandle?.clearLinkedGoal(restoredPlan.goalId);

--- a/packages/pi-workflow/test/active-linked-plan-menu.test.ts
+++ b/packages/pi-workflow/test/active-linked-plan-menu.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { showActiveImplementationMenu } from "../src/plan/active-implementation-menu.js";
+
+function linkedMenuOptions(manageGoal: () => void | Promise<void>) {
+	return {
+		statusText: "A linked implementation Plan is active.",
+		getExportDestination: () => ({
+			configuredPath: "PLAN.md",
+			resolvedPath: "/tmp/PLAN.md",
+		}),
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+		show: () => undefined,
+		exportPlan: async () => false,
+		settings: async () => false,
+		manageGoal,
+	};
+}
+
+test("linked Plan menu routes lifecycle management through Goal", async () => {
+	const tui = createTuiHarness({ width: 72, rows: 20 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	let managed = 0;
+	try {
+		const running = showActiveImplementationMenu(
+			context.ctx,
+			linkedMenuOptions(() => {
+				managed += 1;
+			}),
+		);
+		await tui.waitForOpen();
+		const frame = tui.render().join("\n");
+		assert.match(frame, /exact Plan remains linked until Goal completes/i);
+		assert.match(frame, /Manage linked Goal/);
+		assert.doesNotMatch(frame, /Start a new plan|Clear active implementation plan/);
+		assert.ok(tui.render(28).every((line) => visibleWidth(line) <= 28));
+
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await running;
+		assert.equal(managed, 1);
+	} finally {
+		tui.dispose();
+	}
+});
+
+test("cancelling the linked Plan menu does not manage or clear Goal", async () => {
+	const tui = createTuiHarness({ width: 48, rows: 16 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	let managed = 0;
+	try {
+		const running = showActiveImplementationMenu(
+			context.ctx,
+			linkedMenuOptions(() => {
+				managed += 1;
+			}),
+		);
+		await tui.waitForOpen();
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(managed, 0);
+	} finally {
+		tui.dispose();
+	}
+});

--- a/packages/pi-workflow/test/compat-plan-fresh-implementation-session.test.ts
+++ b/packages/pi-workflow/test/compat-plan-fresh-implementation-session.test.ts
@@ -162,6 +162,45 @@ test("fresh selection fails closed when automatic readiness has no command conte
 	assert.match(context.notifications.at(-1)?.message ?? "", /reopen \/plan/i);
 });
 
+test("workflow retention override keeps fresh Goal handoffs linked", async () => {
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	let capturedRetention: string | undefined;
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: {
+				thinkingLevel: "inherit" as const,
+				implementationPlanRetention: "clear-on-start" as const,
+			},
+		}),
+		implementationPlanRetention: "keep",
+		implementationOutcome: () => "Goal keeps the exact Plan until it ends.",
+		startFreshImplementation: async (_ctx, request) => {
+			capturedRetention = request.retention;
+			return { kind: "started" };
+		},
+	});
+	let menuTitle = "";
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (title: string, options: string[]) => {
+			menuTitle = title;
+			return options.includes("Start fresh with Goal") ? "Start fresh with Goal" : undefined;
+		},
+		newSession: async () => ({ cancelled: false }),
+	});
+
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	await completePlan(mock, context.ctx);
+	await mock.commands.get("plan")?.handler("", context.ctx);
+
+	assert.equal(capturedRetention, "keep");
+	assert.match(menuTitle, /Goal keeps the exact Plan until it ends/u);
+	assert.doesNotMatch(menuTitle, /After Implement/u);
+});
+
 test("fresh implementation creates a linked destination and hands off only through replacement context", async () => {
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi, {

--- a/packages/pi-workflow/test/compat-plan-settings-menu.test.ts
+++ b/packages/pi-workflow/test/compat-plan-settings-menu.test.ts
@@ -72,6 +72,26 @@ test("Plan settings show four flat workflow rows without materializing a missing
 	});
 });
 
+test("Workflow Plan settings hide standalone implementation retention", async () => {
+	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
+		const running = showPlanModeSettings(
+			ctx,
+			menuOptions(settingsPath, saved, { showImplementationPlanRetention: false }),
+		);
+		await tui.waitForOpen();
+		const frame = tui.render().join("\n");
+		assert.match(frame, /Plan thinking\s+inherit/);
+		assert.match(frame, /Plan tools\s+Automatic safe built-ins/);
+		assert.doesNotMatch(frame, /After Implement/);
+		assert.match(frame, /Export destination\s+PLAN\.md/);
+		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
+
+		tui.press("ctrl+c");
+		await running;
+		assert.deepEqual(saved, []);
+	});
+});
+
 test("Plan settings save thinking immediately for the next workflow", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));

--- a/packages/pi-workflow/test/linked-plan-lifecycle.test.ts
+++ b/packages/pi-workflow/test/linked-plan-lifecycle.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import planMode from "../src/plan/plan-mode.js";
+
+async function linkedPlanFixture() {
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	const handle = planMode(mock.pi, {
+		readSettings: async () => ({ kind: "missing" }),
+		implementationPlanRetention: "keep",
+	});
+	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as
+		| ((...args: unknown[]) => Promise<unknown>)
+		| undefined;
+	assert.ok(complete);
+	await complete(
+		"complete",
+		{ plan: "# Lifecycle Plan\n\nKeep this exact contract." },
+		undefined,
+		undefined,
+		context.ctx,
+	);
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	const implementationId = handle.getState().activeImplementation?.id;
+	assert.ok(implementationId);
+	assert.equal(handle.linkImplementationToGoal(implementationId, "goal-1"), true);
+	return { context, handle, mock };
+}
+
+test("every nonterminal Goal state retains and relinks the exact Plan", async () => {
+	const { context, handle, mock } = await linkedPlanFixture();
+	for (const [index, status] of [
+		"active",
+		"paused",
+		"blocked",
+		"usage_limited",
+		"budget_limited",
+	] as const) {
+		const goalId = `goal-${index + 2}`;
+		handle.handleGoalState({ goalId, status });
+		assert.equal(handle.getState().activeImplementation?.goalId, goalId);
+		const transformed = (await mock.events.get("context")?.[0]?.(
+			{
+				messages: [
+					{ role: "compactionSummary", content: `Recovered ${status} work.` },
+					{ role: "user", content: "Continue when permitted." },
+				],
+			},
+			context.ctx,
+		)) as { messages: unknown[] };
+		assert.match(JSON.stringify(transformed.messages), /Lifecycle Plan/u);
+	}
+});
+
+test("terminal Goal state clears matching and newly rotated linked IDs", async () => {
+	for (const [goalId, status] of [
+		["goal-1", "cleared"],
+		["goal-rotated-at-terminal", "complete"],
+	] as const) {
+		const { handle } = await linkedPlanFixture();
+		handle.handleGoalState({ goalId, status });
+		assert.equal(handle.getState().activeImplementation, undefined);
+	}
+});

--- a/packages/pi-workflow/test/settings.test.ts
+++ b/packages/pi-workflow/test/settings.test.ts
@@ -75,7 +75,11 @@ test("Plan, Goal, and handoff saves preserve every unowned field", async () => {
 				{
 					futureTopLevel: { enabled: true },
 					workflow: { planHandoff: "review", futureWorkflow: 1 },
-					plan: { thinkingLevel: "low", futurePlan: 2 },
+					plan: {
+						thinkingLevel: "low",
+						implementationPlanRetention: "legacy-retention",
+						futurePlan: 2,
+					},
 					goal: {
 						futureGoal: 3,
 						experimental: { goals: false, futureQueue: 4 },
@@ -113,6 +117,7 @@ test("Plan, Goal, and handoff saves preserve every unowned field", async () => {
 		});
 		assert.deepEqual(document.plan, {
 			thinkingLevel: "xhigh",
+			implementationPlanRetention: "legacy-retention",
 			defaultPlanExportPath: "docs/PLAN.md",
 			futurePlan: 2,
 		});
@@ -197,6 +202,38 @@ test("atomic publication failure preserves the previous file and removes tempora
 		if (process.platform !== "win32") {
 			assert.equal((await stat(fixture.path)).mode & 0o777, 0o600);
 		}
+	} finally {
+		await fixture.cleanup();
+	}
+});
+
+test("retired Plan retention is ignored at runtime and preserved during saves", async () => {
+	const fixture = await temporarySettings();
+	try {
+		await writeFile(
+			fixture.path,
+			JSON.stringify({
+				workflow: { planHandoff: "review" },
+				plan: {
+					thinkingLevel: "medium",
+					implementationPlanRetention: "future-retention-policy",
+					futurePlan: { kept: true },
+				},
+				goal: {},
+			}),
+		);
+
+		const loaded = readWorkflowSettings(fixture.path);
+		assert.equal(loaded.kind, "loaded");
+		if (loaded.kind !== "loaded") assert.fail("Expected workflow settings to load");
+		assert.equal(loaded.settings.plan.implementationPlanRetention, undefined);
+
+		await updateWorkflowPlanSettings({ thinkingLevel: "high" }, { settingsPath: fixture.path });
+		const document = JSON.parse(await readFile(fixture.path, "utf8")) as {
+			plan?: Record<string, unknown>;
+		};
+		assert.equal(document.plan?.implementationPlanRetention, "future-retention-policy");
+		assert.deepEqual(document.plan?.futurePlan, { kept: true });
 	} finally {
 		await fixture.cleanup();
 	}

--- a/packages/pi-workflow/test/workflow-runtime-smoke.mjs
+++ b/packages/pi-workflow/test/workflow-runtime-smoke.mjs
@@ -217,6 +217,15 @@ function persistedGoalState(session) {
 		.at(-1)?.data;
 }
 
+function persistedPlanState(session) {
+	return session.sessionManager
+		.getBranch()
+		.filter(
+			(candidate) => candidate.type === "custom" && candidate.customType === "plan-mode-state",
+		)
+		.at(-1)?.data;
+}
+
 function persistedGoalStatus(session) {
 	return persistedGoalState(session)?.goal?.status ?? null;
 }
@@ -234,6 +243,51 @@ async function waitFor(predicate, description, timeoutMs = 10_000) {
 	while (!predicate()) {
 		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${description}`);
 		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+async function linkedPlanGoalScenario() {
+	const approvedPlan = "# Runtime linked Plan\n\n1. Implement the change.\n2. Verify it.";
+	let sawExactHandoff = false;
+	let sawRetainedContext = false;
+	let harness;
+	harness = await createHarness([
+		fauxAssistantMessage(fauxToolCall("plan_mode_complete", { plan: approvedPlan })),
+		(context) => {
+			const contextText = JSON.stringify(context.messages);
+			assert.match(contextText, /Runtime linked Plan/);
+			assert.match(contextText, /Goal mode is active\. Complete this goal fully/);
+			assert.ok(persistedPlanState(harness.session)?.activeImplementation?.goalId);
+			assert.equal(persistedGoalStatus(harness.session), "active");
+			sawExactHandoff = true;
+			return fauxAssistantMessage("Implementation remains incomplete after the first Goal run.");
+		},
+		(context) => {
+			const contextText = JSON.stringify(context.messages);
+			assert.match(contextText, /Runtime linked Plan/);
+			assert.match(context.systemPrompt ?? "", /Active \/goal/);
+			assert.ok(persistedPlanState(harness.session)?.activeImplementation?.goalId);
+			sawRetainedContext = true;
+			return completionResponse(context);
+		},
+	]);
+	try {
+		await harness.session.prompt("/plan produce the runtime linked implementation plan");
+		await waitFor(() => harness.faux.state.callCount === 1, "Plan completion");
+		await harness.session.agent.waitForIdle();
+		assert.equal(harness.faux.state.callCount, 1);
+		assert.equal(persistedPlanState(harness.session)?.awaitingAction, true);
+		assert.equal(persistedGoalStatus(harness.session), null);
+
+		await harness.session.prompt("/plan implement");
+		await waitFor(() => harness.faux.state.callCount === 3, "linked Plan Goal completion");
+		await harness.session.agent.waitForIdle();
+		assert.equal(sawExactHandoff, true);
+		assert.equal(sawRetainedContext, true);
+		assert.equal(persistedGoalStatus(harness.session), null);
+		assert.equal(persistedPlanState(harness.session)?.activeImplementation, undefined);
+	} finally {
+		await harness.cleanup();
 	}
 }
 
@@ -834,6 +888,7 @@ async function manualCompactionScenario() {
 }
 
 await agentDirectoryIsolationScenario();
+await linkedPlanGoalScenario();
 await normalContinuationScenario();
 await runawayNoProgressScenario();
 await automaticToolLoopLimitScenario();
@@ -852,5 +907,5 @@ await managedRunRpcScenario();
 await managedRunDisabledScenario();
 await manualCompactionScenario();
 console.log(
-	"pi-workflow runtime smoke: normal, runaway guards, retry and busy-edit ownership, ordered queue, queued input, pause, frozen-queue and stale blocked-tool aborts, managed-run RPC, bounded budget behavior, and manual compaction passed",
+	"pi-workflow runtime smoke: linked Plan-to-Goal execution, normal and guarded continuation, retry and busy-edit ownership, ordered queue, queued input, pause, frozen-queue and stale blocked-tool aborts, managed-run RPC, bounded budget behavior, and manual compaction passed",
 );

--- a/packages/pi-workflow/test/workflow.test.ts
+++ b/packages/pi-workflow/test/workflow.test.ts
@@ -4,7 +4,7 @@ import { builtinTool, createMockContext, createMockPi } from "../../../test/supp
 import { serializeGoalState } from "../src/goal/persistence.js";
 import { createGoal } from "../src/goal/runtime.js";
 import { DEFAULT_GOAL_SETTINGS } from "../src/goal/settings.js";
-import { startFreshWorkflowImplementation } from "../src/handoff.js";
+import { startFreshWorkflowImplementation, WORKFLOW_GOAL_OBJECTIVE } from "../src/handoff.js";
 import workflow from "../src/workflow.js";
 
 const BASE_TOOLS = ["read", "bash", "edit", "write"];
@@ -233,6 +233,43 @@ test("stopped Goal ID rotation keeps Plan cleanup linked", async () => {
 		.filter((entry) => entry.customType === "plan-mode-state")
 		.at(-1)?.data as { activeImplementation?: unknown };
 	assert.equal(finalPlan.activeImplementation, undefined);
+});
+
+test("budget-only Goal edits retain and relink the exact Plan", async () => {
+	const fixture = setup();
+	await startLinkedWorkflow(fixture, "# Keep through budget edit");
+	const initialPlan = fixture.mock.entries
+		.filter((entry) => entry.customType === "plan-mode-state")
+		.at(-1)?.data as { activeImplementation?: { goalId?: string } };
+	const initialGoalId = initialPlan.activeImplementation?.goalId;
+	assert.ok(initialGoalId);
+
+	await fixture.mock.commands
+		.get("goal")
+		?.handler(`edit --tokens 20 ${WORKFLOW_GOAL_OBJECTIVE}`, fixture.ctx);
+
+	const editedGoal = fixture.mock.entries
+		.filter((entry) => entry.customType === "goal-state")
+		.at(-1)?.data as { goal?: { id?: string; text?: string; tokenBudget?: number } };
+	const retainedPlan = fixture.mock.entries
+		.filter((entry) => entry.customType === "plan-mode-state")
+		.at(-1)?.data as { activeImplementation?: { goalId?: string; plan?: string } };
+	assert.notEqual(editedGoal.goal?.id, initialGoalId);
+	assert.equal(editedGoal.goal?.text, WORKFLOW_GOAL_OBJECTIVE);
+	assert.equal(editedGoal.goal?.tokenBudget, 20);
+	assert.equal(retainedPlan.activeImplementation?.goalId, editedGoal.goal?.id);
+	assert.equal(retainedPlan.activeImplementation?.plan, "# Keep through budget edit");
+	const compactedContext = await transformContext(fixture, [
+		{ role: "compactionSummary", content: "Budget changed after earlier work." },
+		{ role: "user", content: "Continue within the updated budget." },
+	]);
+	assert.match(JSON.stringify(compactedContext), /Keep through budget edit/u);
+
+	await fixture.mock.commands.get("goal")?.handler("clear", fixture.ctx);
+	const clearedPlan = fixture.mock.entries
+		.filter((entry) => entry.customType === "plan-mode-state")
+		.at(-1)?.data as { activeImplementation?: unknown };
+	assert.equal(clearedPlan.activeImplementation, undefined);
 });
 
 test("failed resume relinks the restored Goal so clear still removes Plan", async () => {

--- a/packages/pi-workflow/test/workflow.test.ts
+++ b/packages/pi-workflow/test/workflow.test.ts
@@ -19,16 +19,33 @@ async function emitAll(
 	for (const handler of mock.events.get(name) ?? []) await handler(event, ctx);
 }
 
-function setup() {
+function setup(
+	readSettings: NonNullable<Parameters<typeof workflow>[1]>["readSettings"] = () => ({
+		kind: "missing",
+	}),
+	contextOptions: Parameters<typeof createMockContext>[0] = {},
+) {
 	const mock = createMockPi({
 		activeTools: [...BASE_TOOLS, ...GOAL_TOOLS],
 		allTools: [...BASE_TOOLS, ...GOAL_TOOLS].map(builtinTool),
 	});
-	workflow(mock.pi, {
-		readSettings: () => ({ kind: "missing" }),
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true });
+	workflow(mock.pi, { readSettings });
+	const context = createMockContext({ mode: "tui", hasUI: true, ...contextOptions });
 	return { mock, ...context };
+}
+
+async function transformContext(
+	fixture: ReturnType<typeof setup>,
+	messages: unknown[],
+): Promise<unknown[]> {
+	let transformedMessages = messages;
+	for (const handler of fixture.mock.events.get("context") ?? []) {
+		const transformed = (await handler({ messages: transformedMessages }, fixture.ctx)) as
+			| { messages?: unknown[] }
+			| undefined;
+		transformedMessages = transformed?.messages ?? transformedMessages;
+	}
+	return transformedMessages;
 }
 
 async function startLinkedWorkflow(fixture: ReturnType<typeof setup>, plan = "# Approved") {
@@ -135,6 +152,40 @@ test("an approved Plan starts Goal with one exact combined implementation reques
 	assert.equal(goalState.goal?.text, "Implement and verify the approved Plan-mode plan.");
 });
 
+test("Plan-only actions do not execute until Implement starts Goal", async () => {
+	const fixture = setup(undefined, {
+		model: { provider: "test", id: "model" },
+		modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true }) },
+	});
+	await emitAll(fixture.mock, "session_start", { reason: "startup" }, fixture.ctx);
+	await fixture.mock.commands.get("plan")?.handler("start", fixture.ctx);
+	const complete = fixture.mock.tools.find((tool) => tool.name === "plan_mode_complete");
+	assert.ok(complete);
+	await (complete.execute as (...args: unknown[]) => Promise<unknown>)(
+		"plan-call",
+		{ plan: "# Saved before execution" },
+		undefined,
+		undefined,
+		fixture.ctx,
+	);
+	await fixture.mock.commands.get("plan")?.handler("save", fixture.ctx);
+	assert.equal(fixture.mock.entries.filter((entry) => entry.customType === "goal-state").length, 0);
+	const saved = fixture.mock.entries
+		.filter((entry) => entry.customType === "plan-mode-state")
+		.at(-1)?.data as { savedPlan?: { plan?: string } };
+	assert.equal(saved.savedPlan?.plan, "# Saved before execution");
+
+	await fixture.mock.commands.get("plan")?.handler("implement", fixture.ctx);
+	const activeGoal = fixture.mock.entries
+		.filter((entry) => entry.customType === "goal-state")
+		.at(-1)?.data as { goal?: { status?: string } };
+	assert.equal(activeGoal.goal?.status, "active");
+	const linkedPlan = fixture.mock.entries
+		.filter((entry) => entry.customType === "plan-mode-state")
+		.at(-1)?.data as { activeImplementation?: { goalId?: string } };
+	assert.ok(linkedPlan.activeImplementation?.goalId);
+});
+
 test("paused and resumed Goal states retain and relink the approved Plan", async () => {
 	const { mock, ctx } = setup();
 	await emitAll(mock, "session_start", { reason: "startup" }, ctx);
@@ -227,6 +278,96 @@ test("successful Goal objective supersession clears the linked Plan", async () =
 		.filter((entry) => entry.customType === "plan-mode-state")
 		.at(-1)?.data as { activeImplementation?: unknown };
 	assert.equal(finalPlan.activeImplementation, undefined);
+});
+
+test("legacy short retention cannot detach a Plan from its linked Goal", async () => {
+	for (const retention of ["clear-on-start", "clear-after-first-run"] as const) {
+		const fixture = setup(() => ({
+			kind: "loaded",
+			settings: {
+				planHandoff: "review",
+				plan: { thinkingLevel: "inherit", implementationPlanRetention: retention },
+				goal: structuredClone(DEFAULT_GOAL_SETTINGS),
+			},
+		}));
+		await startLinkedWorkflow(fixture, `# Retain through Goal\n\nPolicy: ${retention}`);
+
+		const compactedContext = await transformContext(fixture, [
+			{ role: "compactionSummary", content: "Earlier implementation work was compacted." },
+			{ role: "user", content: "Continue the linked Goal." },
+		]);
+		assert.equal(
+			compactedContext.filter(
+				(message) =>
+					(message as { customType?: string }).customType === "plan-mode-implementation-context",
+			).length,
+			1,
+		);
+		assert.match(JSON.stringify(compactedContext), /Retain through Goal/u);
+		const repeatedContext = await transformContext(fixture, [
+			{ role: "branchSummary", content: "A branch summary remains first." },
+			...compactedContext,
+		]);
+		assert.equal(
+			repeatedContext.filter(
+				(message) =>
+					(message as { customType?: string }).customType === "plan-mode-implementation-context",
+			).length,
+			1,
+		);
+		const firstNonSummary = repeatedContext.findIndex(
+			(message) =>
+				!["branchSummary", "compactionSummary"].includes((message as { role?: string }).role ?? ""),
+		);
+		assert.equal(
+			(repeatedContext[firstNonSummary] as { customType?: string }).customType,
+			"plan-mode-implementation-context",
+		);
+
+		await fixture.mock.commands.get("goal")?.handler("pause", fixture.ctx);
+		const pausedContext = await transformContext(fixture, [
+			{ role: "compactionSummary", content: "Paused after compaction." },
+			{ role: "user", content: "Inspect the paused workflow." },
+		]);
+		assert.match(JSON.stringify(pausedContext), /Retain through Goal/u);
+		await fixture.mock.commands.get("goal")?.handler("resume", fixture.ctx);
+		await emitAll(fixture.mock, "agent_settled", {}, fixture.ctx);
+		const retainedPlan = fixture.mock.entries
+			.filter((entry) => entry.customType === "plan-mode-state")
+			.at(-1)?.data as { activeImplementation?: { goalId?: string; retention?: string } };
+		assert.ok(retainedPlan.activeImplementation?.goalId);
+		assert.equal(retainedPlan.activeImplementation.retention, "keep");
+
+		await fixture.mock.commands.get("goal")?.handler("clear", fixture.ctx);
+		const laterContext = await transformContext(fixture, [
+			{ role: "compactionSummary", content: "Goal ended." },
+			{ role: "user", content: "Start unrelated work." },
+		]);
+		assert.doesNotMatch(JSON.stringify(laterContext), /Retain through Goal/u);
+	}
+});
+
+test("plan exit cannot detach an active linked Goal", async () => {
+	const fixture = setup();
+	await startLinkedWorkflow(fixture, "# Keep linked");
+
+	await fixture.mock.commands.get("plan")?.handler("exit", fixture.ctx);
+
+	const retainedPlan = fixture.mock.entries
+		.filter((entry) => entry.customType === "plan-mode-state")
+		.at(-1)?.data as { activeImplementation?: { goalId?: string } };
+	assert.ok(retainedPlan.activeImplementation?.goalId);
+	assert.match(fixture.notifications.at(-1)?.message ?? "", /linked Goal.*\/goal clear/iu);
+	const retainedGoal = fixture.mock.entries
+		.filter((entry) => entry.customType === "goal-state")
+		.at(-1)?.data as { goal?: { status?: string } };
+	assert.equal(retainedGoal.goal?.status, "active");
+
+	const print = createMockContext({ mode: "print", hasUI: false });
+	await assert.rejects(
+		async () => fixture.mock.commands.get("plan")?.handler("exit", print.ctx),
+		/linked Goal.*\/goal clear/iu,
+	);
 });
 
 test("Goal completion clears the linked implementation Plan", async () => {
@@ -481,7 +622,7 @@ test("linkage persistence failure rolls back provisional Goal ownership and tool
 	]);
 });
 
-test("linked fresh-session restore activates Goal terminal tools hidden in the source", async () => {
+test("linked restore activates Goal tools and upgrades legacy short retention", async () => {
 	const mock = createMockPi({
 		activeTools: [...BASE_TOOLS],
 		allTools: [...BASE_TOOLS, ...GOAL_TOOLS].map(builtinTool),
@@ -506,7 +647,7 @@ test("linked fresh-session restore activates Goal terminal tools hidden in the s
 					plan: "# Fresh",
 					source: "plan_mode_complete",
 					startedAt: 1,
-					retention: "keep",
+					retention: "clear-on-start",
 				},
 			},
 		},
@@ -531,6 +672,18 @@ test("linked fresh-session restore activates Goal terminal tools hidden in the s
 
 	for (const tool of GOAL_TOOLS) assert.ok(mock.rawPi.getActiveTools().includes(tool));
 	assert.match(restored.statuses.get("workflow:goal") ?? "", /^active/u);
+	const migratedPlan = mock.entries.filter((entry) => entry.customType === "plan-mode-state").at(-1)
+		?.data as { activeImplementation?: { retention?: string } };
+	assert.equal(migratedPlan.activeImplementation?.retention, "keep");
+	const context = await transformContext({ mock, ...restored }, [
+		{ role: "compactionSummary", content: "Restored after compaction." },
+		{ role: "user", content: "Continue." },
+	]);
+	assert.match(JSON.stringify(context), /# Fresh/u);
+	await emitAll(mock, "agent_settled", {}, restored.ctx);
+	const retainedPlan = mock.entries.filter((entry) => entry.customType === "plan-mode-state").at(-1)
+		?.data as { activeImplementation?: { goalId?: string } };
+	assert.equal(retainedPlan.activeImplementation?.goalId, restoredGoal.id);
 });
 
 test("Goal restore cannot mutate stale Plan state before the new Plan session is ready", async () => {
@@ -651,7 +804,7 @@ test("session restore keeps a newer Goal and clears an older unlinked implementa
 	assert.doesNotMatch(JSON.stringify(messages), /Stale standalone plan/u);
 });
 
-test("session restore keeps a newer unlinked implementation Plan and clears an older Goal", async () => {
+test("session restore recovers a newer unlinked implementation as ready and clears an older Goal", async () => {
 	const mock = createMockPi({
 		activeTools: [...BASE_TOOLS, ...GOAL_TOOLS],
 		allTools: [...BASE_TOOLS, ...GOAL_TOOLS].map(builtinTool),
@@ -702,7 +855,13 @@ test("session restore keeps a newer unlinked implementation Plan and clears an o
 		?.data as { goal?: unknown };
 	assert.equal(finalGoal.goal, null);
 	assert.equal(restored.statuses.get("workflow:goal"), undefined);
-	assert.equal(restored.statuses.get("workflow:plan"), "plan implementing");
+	assert.equal(restored.statuses.get("workflow:plan"), "plan ready");
+	const recoveredPlan = mock.entries
+		.filter((entry) => entry.customType === "plan-mode-state")
+		.at(-1)?.data as { enabled?: boolean; latestPlan?: string; activeImplementation?: unknown };
+	assert.equal(recoveredPlan.enabled, true);
+	assert.equal(recoveredPlan.latestPlan, "# Current standalone plan");
+	assert.equal(recoveredPlan.activeImplementation, undefined);
 	let messages: unknown[] = [{ role: "user", content: [{ type: "text", text: "continue" }] }];
 	for (const handler of mock.events.get("context") ?? []) {
 		const transformed = (await handler({ messages }, restored.ctx)) as
@@ -710,7 +869,7 @@ test("session restore keeps a newer unlinked implementation Plan and clears an o
 			| undefined;
 		messages = transformed?.messages ?? messages;
 	}
-	assert.match(JSON.stringify(messages), /Current standalone plan/u);
+	assert.doesNotMatch(JSON.stringify(messages), /ACTIVE IMPLEMENTATION PLAN/u);
 });
 
 test("session restore clears a stale Plan linked to a superseding objective", async () => {


### PR DESCRIPTION
## Summary

- Make every ready or saved Plan **Implement** action start linked Goal execution in the current or a fresh session.
- Keep the exact approved Plan compaction-safe until Goal completes, is cleared, or is superseded.
- Retire workflow-specific **After Implement** choices while ignoring and preserving legacy settings data.
- Recover interrupted unlinked handoffs as ready Plans and route linked lifecycle management through Goal.
- Add a minor Changeset for `@narumitw/pi-workflow` only.

## Verification

- `npx vitest run packages/pi-workflow/test/*.test.ts` — 567 tests passed.
- `npm --workspace @narumitw/pi-workflow run test:runtime` — linked Plan-to-Goal and existing lifecycle smoke passed.
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm run check` — Biome, boundaries, all workspace typechecks, and 3,677 tests passed.
- `just pack workflow` — 54 manifest-listed files inspected in the dry-run tarball.
- `npm run changeset:status` — only `@narumitw/pi-workflow` receives the intended minor bump.
- GitHub Actions CI run `31601413472` — passed.

The command-scoped Git override was limited to test fixtures because the signing agent was unavailable inside their temporary repositories.
An earlier full-suite run also hit an unrelated `pi-fleet` timing failure; its focused test and later full gates passed.

## Risks and unverified paths

- This intentionally changes experimental `pi-workflow` retention semantics; standalone `pi-plan-mode` and `pi-goal` are unchanged.
- Legacy `plan.implementationPlanRetention` values remain on disk as ignored forward-compatible data.
- No live-provider smoke was run; deterministic faux-provider lifecycle coverage exercises the Plan-to-Goal path without external cost or entitlement dependencies.
- No package was published and no release workflow was dispatched.

## Plan

- [Completed implementation plan](https://github.com/narumiruna/pi-extensions/blob/feat/pi-workflow-linked-plan-lifecycle/docs/plans/archived/2026-08-12_pi-workflow-linked-plan-goal-lifecycle-plan.md)
