### PR TITLE
fix(codex-compact): project resumed checkpoints

### DIFF
--- a/.changeset/tidy-codex-checkpoints.md
+++ b/.changeset/tidy-codex-checkpoints.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-codex-compact": patch
+---
+
+Preserve Codex Remote V2 replay and repeated compaction after session resume when Pi interleaves older compaction summaries with the newest checkpoint's retained messages.

--- a/docs/plans/archived/2026-08-13_pi-codex-compact-resumed-projection-plan.md
+++ b/docs/plans/archived/2026-08-13_pi-codex-compact-resumed-projection-plan.md
@@ -1,0 +1,33 @@
+# Pi Codex Compact resumed projection plan
+
+## Goal
+
+Keep repeated Codex Remote V2 compaction working after session resume when Pi rebuilds the newest checkpoint's retained range with older compaction summaries interleaved among its fingerprinted messages.
+
+## Context
+
+Issue #726 reports that `projectCheckpointContext()` requires the newest checkpoint's kept-message fingerprints to appear contiguously after its fallback summary.
+
+A credential-free reproduction with Pi 0.84.1's real `buildSessionContext()` confirms that resumed repeated compaction can place an older `compactionSummary` inside that retained range, so projection fails even though every stored kept-message fingerprint is valid.
+
+## Risks
+
+The projection must not skip arbitrary messages or remove a summary created after the active checkpoint.
+
+Existing version-1 checkpoints whose stored fingerprints include a compaction summary must remain projectable.
+
+## Plan
+
+- [x] Add a focused regression to `packages/pi-codex-compact/test/checkpoint.test.ts` that uses Pi's context builder to reproduce the resumed repeated-compaction ordering; `npx vitest run packages/pi-codex-compact/test/checkpoint.test.ts` failed at `assert.ok(projected)` with 7 passing tests and 1 failing regression.
+- [x] Update `packages/pi-codex-compact/src/checkpoint.ts` to match exact kept-message fingerprints in order while skipping only finite-timestamped older structural compaction summaries inside the checkpoint-covered range.
+- [x] Add boundary coverage proving trailing older summaries are removed, changed or unexpected messages still fail closed, newer summaries are rejected within or preserved after the covered range, and stored summary fingerprints remain compatible; all 11 focused tests pass.
+- [x] Add patch Changeset `.changeset/tidy-codex-checkpoints.md` for `@narumitw/pi-codex-compact`; `npm run changeset:status` resolves the next release as 0.50.1.
+- [x] Run verification: 11 focused checkpoint tests passed, the package check passed, `npm run check` passed with 361 files and 3,671 tests, and the credential-free repeated-compaction smoke projected `["user", "user"]` while preserving the later message.
+- [x] Audit the final diff against issue #726, `docs/extension-conventions.md`, and the touched-area checklist; exact non-summary fingerprint validation and message order remain fail-closed, no settings or asynchronous lifecycle flow changed, no metadata/load smoke is required, and issue #726 now has the repository's `bug` label.
+
+## Completion Checklist
+
+- [x] Resumed repeated-compaction context projects the newest opaque checkpoint without weakening exact fingerprint and ordering checks.
+- [x] Existing checkpoint persistence remains version-compatible, and unrelated context after the checkpoint-covered range is preserved.
+- [x] Focused tests, package validation, the repository CI-equivalent gate, and the deterministic smoke pass with recorded evidence.
+- [x] The final diff contains only the focused fix, regression coverage, Changeset, and archived completed plan.

--- a/packages/pi-codex-compact/src/checkpoint.ts
+++ b/packages/pi-codex-compact/src/checkpoint.ts
@@ -123,6 +123,15 @@ export function latestCheckpoint(entries: readonly SessionEntry[]):
 	return undefined;
 }
 
+function isOlderCompactionSummary(message: AgentMessage, timestamp: number): boolean {
+	return (
+		message.role === "compactionSummary" &&
+		Number.isFinite(message.timestamp) &&
+		Number.isFinite(timestamp) &&
+		message.timestamp < timestamp
+	);
+}
+
 export function projectCheckpointContext(
 	messages: readonly AgentMessage[],
 	details: CodexCheckpointDetails,
@@ -132,21 +141,33 @@ export function projectCheckpointContext(
 		(message) => message.role === "compactionSummary" && message.summary === summary,
 	);
 	if (summaryIndex < 0) return undefined;
-	const keptStart = summaryIndex + 1;
-	const keptEnd = keptStart + details.keptMessageFingerprints.length;
-	if (keptEnd > messages.length) return undefined;
-	for (let index = keptStart; index < keptEnd; index++) {
-		if (
-			fingerprintMessage(messages[index]) !== details.keptMessageFingerprints[index - keptStart]
-		) {
-			return undefined;
-		}
-	}
 	const timestamp = messages[summaryIndex].timestamp;
+	let messageIndex = summaryIndex + 1;
+	let fingerprintIndex = 0;
+	while (fingerprintIndex < details.keptMessageFingerprints.length) {
+		if (messageIndex >= messages.length) return undefined;
+		const message = messages[messageIndex];
+		if (fingerprintMessage(message) === details.keptMessageFingerprints[fingerprintIndex]) {
+			messageIndex += 1;
+			fingerprintIndex += 1;
+			continue;
+		}
+		if (isOlderCompactionSummary(message, timestamp)) {
+			messageIndex += 1;
+			continue;
+		}
+		return undefined;
+	}
+	while (
+		messageIndex < messages.length &&
+		isOlderCompactionSummary(messages[messageIndex], timestamp)
+	) {
+		messageIndex += 1;
+	}
 	return [
 		...messages.slice(0, summaryIndex),
 		markerMessage(details.checkpointId, timestamp),
-		...messages.slice(keptEnd),
+		...messages.slice(messageIndex),
 	];
 }
 

--- a/packages/pi-codex-compact/test/checkpoint.test.ts
+++ b/packages/pi-codex-compact/test/checkpoint.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { CompactionEntry, SessionEntry } from "@earendil-works/pi-coding-agent";
+import {
+	buildSessionContext,
+	type CompactionEntry,
+	type SessionEntry,
+} from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import {
 	buildReplacementHistory,
@@ -31,6 +35,39 @@ function checkpoint(kept: AgentMessage[] = [user("kept", 2)], id = "checkpoint-1
 		checkpointId: id,
 		createdAt: "2026-01-01T00:00:00.000Z",
 	});
+}
+
+function compactionSummary(summary: string, timestamp: number): AgentMessage {
+	return { role: "compactionSummary", summary, tokensBefore: 100, timestamp };
+}
+
+function messageEntry(id: string, parentId: string | null, message: AgentMessage): SessionEntry {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: new Date(message.timestamp).toISOString(),
+		message,
+	};
+}
+
+function compactionEntry(
+	id: string,
+	parentId: string,
+	firstKeptEntryId: string,
+	details: ReturnType<typeof checkpoint>,
+	timestamp: string,
+): CompactionEntry {
+	return {
+		type: "compaction",
+		id,
+		parentId,
+		timestamp,
+		summary: fallbackSummary(details.checkpointId),
+		firstKeptEntryId,
+		tokensBefore: 100,
+		details,
+	};
 }
 
 test("builds newest-first bounded replacement history and puts opaque item last", () => {
@@ -101,6 +138,97 @@ test("projects only an exact summary and kept suffix while preserving unrelated 
 	assert.deepEqual(projected?.[2], after);
 	assert.equal(projectCheckpointContext([summary, user("changed", 2), after], details), undefined);
 	assert.equal(projectCheckpointContext([kept, after], details), undefined);
+});
+
+test("projects resumed repeated compaction when Pi interleaves an older summary", () => {
+	const firstKept = user("first kept", 1);
+	const secondKept = user("second kept", 2);
+	const thirdKept = user("third kept", 4);
+	const fourthKept = user("fourth kept", 5);
+	const later = user("later", 7);
+	const firstDetails = checkpoint([firstKept, secondKept], "checkpoint-first");
+	const secondDetails = checkpoint(
+		[firstKept, secondKept, thirdKept, fourthKept],
+		"checkpoint-second",
+	);
+	const entries = [
+		messageEntry("first-kept", null, firstKept),
+		messageEntry("second-kept", "first-kept", secondKept),
+		compactionEntry(
+			"first-compaction",
+			"second-kept",
+			"first-kept",
+			firstDetails,
+			"2026-01-01T00:00:03.000Z",
+		),
+		messageEntry("third-kept", "first-compaction", thirdKept),
+		messageEntry("fourth-kept", "third-kept", fourthKept),
+		compactionEntry(
+			"second-compaction",
+			"fourth-kept",
+			"first-kept",
+			secondDetails,
+			"2026-01-01T00:00:06.000Z",
+		),
+		messageEntry("later", "second-compaction", later),
+	];
+
+	const resumed = buildSessionContext(entries, "later").messages;
+	assert.deepEqual(
+		resumed.map((message) => message.role),
+		["compactionSummary", "user", "user", "compactionSummary", "user", "user", "user"],
+	);
+	const projected = projectCheckpointContext(resumed, secondDetails);
+	assert.ok(projected);
+	assert.equal(projected[0].role, "user");
+	assert.match(JSON.stringify(projected[0]), /checkpoint-second/);
+	assert.deepEqual(projected[1], later);
+});
+
+test("removes trailing older compaction summaries covered by the checkpoint", () => {
+	const kept = user("kept", 2);
+	const after = user("after", 4);
+	const details = checkpoint([kept]);
+	const activeSummary = compactionSummary(fallbackSummary(details.checkpointId), 3);
+	const olderSummary = compactionSummary("older structural summary", 1);
+
+	const projected = projectCheckpointContext([activeSummary, kept, olderSummary, after], details);
+	assert.ok(projected);
+	assert.equal(projected.length, 2);
+	assert.deepEqual(projected[1], after);
+});
+
+test("does not skip unverified messages or newer compaction summaries", () => {
+	const first = user("first", 2);
+	const second = user("second", 3);
+	const details = checkpoint([first, second]);
+	const activeSummary = compactionSummary(fallbackSummary(details.checkpointId), 4);
+	const newerSummary = compactionSummary("newer summary", 5);
+
+	assert.equal(
+		projectCheckpointContext([activeSummary, first, user("unexpected", 3), second], details),
+		undefined,
+	);
+	assert.equal(
+		projectCheckpointContext([activeSummary, first, newerSummary, second], details),
+		undefined,
+	);
+	const projected = projectCheckpointContext([activeSummary, first, second, newerSummary], details);
+	assert.ok(projected);
+	assert.deepEqual(projected.at(-1), newerSummary);
+});
+
+test("matches stored summary fingerprints before treating old summaries as structural", () => {
+	const storedSummary = compactionSummary("fingerprinted summary", 1);
+	const kept = user("kept", 2);
+	const after = user("after", 4);
+	const details = checkpoint([storedSummary, kept]);
+	const activeSummary = compactionSummary(fallbackSummary(details.checkpointId), 3);
+
+	const projected = projectCheckpointContext([activeSummary, storedSummary, kept, after], details);
+	assert.ok(projected);
+	assert.equal(projected.length, 2);
+	assert.deepEqual(projected[1], after);
 });
 
 test("uses canonical SHA-256 message fingerprints", () => {


### PR DESCRIPTION
## Summary

- project resumed repeated Codex checkpoints when Pi interleaves older compaction summaries with the newest retained-message range
- keep exact ordered fingerprint validation for retained messages while skipping only finite-timestamped older structural summaries
- add regression and fail-closed boundary coverage plus a patch Changeset

## Verification

- `npx vitest run packages/pi-codex-compact/test/checkpoint.test.ts` — 11 tests passed
- `npm --workspace @narumitw/pi-codex-compact run check` — passed
- `npm run check` — 361 test files and 3,671 tests passed
- credential-free Pi 0.84.1 repeated-compaction projection smoke — projected the newest checkpoint and preserved the later message
- pre-commit Biome and all workspace typechecks — passed

## Audit

- audited the diff against `docs/extension-conventions.md` and its touched-area checklist
- exact non-summary fingerprint validation and ordering remain fail-closed
- existing version-1 checkpoint details remain compatible
- no settings, package metadata, or asynchronous lifecycle behavior changed
- full OAuth/RPC remote compaction was not rerun; the credential-free reproduction exercises Pi's real `buildSessionContext()` and the failing projection boundary

Fixes #726
