### PR TITLE
fix(github-pr): preserve status after aborted turns

### DIFF
--- a/.changeset/calm-pr-statuses-stay.md
+++ b/.changeset/calm-pr-statuses-stay.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-github-pr": patch
+---
+
+Keep the last successful pull request status visible when an agent turn is aborted.

--- a/docs/plans/archived/2026-08-13_pi-github-pr-abort-status-plan.md
+++ b/docs/plans/archived/2026-08-13_pi-github-pr-abort-status-plan.md
@@ -1,0 +1,35 @@
+# Preserve pi-github-pr status after abort
+
+## Goal
+
+Keep the last successful pull request status visible when an agent tool run is aborted.
+
+## Context
+
+A real TUI reproduction confirmed that aborting `sleep 20` clears the `pi-github-pr` status until the next successful agent turn or periodic refresh.
+
+The reported Pi process exit in issue 725 was not reproduced and is outside this fix.
+
+## Non-Goals
+
+- Do not claim to fix the unconfirmed Pi TUI exit.
+- Do not close issue 725.
+- Do not change normal GitHub failure reporting, branch refreshes, or shutdown cleanup.
+
+## Plan
+
+- [x] Add focused lifecycle regression coverage proving an aborted `agent_end` preserves the displayed PR status, skips the cancelled refresh, and leaves periodic polling active.
+- [x] Update `packages/pi-github-pr/src/github-pr.ts` so pre-aborted and mid-refresh cancellation cannot clear or replace the last successful status.
+- [x] Document cancellation behavior in `packages/pi-github-pr/README.md` and add `.changeset/calm-pr-statuses-stay.md` as a patch changeset.
+- [x] Run the focused `pi-github-pr` test file and package checks; 28 tests and the package check passed.
+- [x] Run the repository `npm run check` gate; 363 files and 3,680 tests passed with all checks green.
+- [x] Audit cancellation, session replacement, shutdown, timer ownership, and the final diff for unintended behavior; existing ownership and cleanup guards remain intact.
+
+## Completion Checklist
+
+- [x] The two regression tests failed for the cancellation behavior before the production fix and passed afterward.
+- [x] Aborting a tool run leaves the current PR status visible.
+- [x] A later periodic refresh still updates the status.
+- [x] Existing ambient-failure and session-shutdown tests prove their prior behavior remains intact.
+- [x] Issue 725 remains open and the handoff distinguishes the fixed status bug from the unverified TUI exit.
+- [x] Move this completed plan to `docs/plans/archived/`.

--- a/packages/pi-github-pr/README.md
+++ b/packages/pi-github-pr/README.md
@@ -68,6 +68,7 @@ The extension runs passively:
 - On session start, it checks the current branch PR and sets a compact statusline entry.
 - On Git branch change, it clears the old PR immediately and refreshes the new current branch.
 - While the session remains open, it refreshes that same current branch PR every 60 seconds and after each agent turn.
+- When an agent turn is aborted, it keeps the last successful PR status instead of treating cancellation as a GitHub failure.
 - On branch change, session replacement, or session shutdown, it cancels the previous refresh timer and any in-flight periodic request.
 - On session shutdown, it clears the statusline entry.
 - If the directory has no GitHub PR, the statusline entry stays empty.

--- a/packages/pi-github-pr/src/github-pr.ts
+++ b/packages/pi-github-pr/src/github-pr.ts
@@ -90,12 +90,15 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 	) => {
 		branchWatch.request += 1;
 		const request = branchWatch.request;
+		if (signal?.aborted) return request;
 		try {
 			const status = await runGhPrView(pi, ctx.cwd, signal);
+			if (signal?.aborted) return request;
 			if (generation === branchWatch.generation && request === branchWatch.request) {
 				renderStatus(ctx, status, branchWatch, generation);
 			}
 		} catch (error) {
+			if (signal?.aborted) return request;
 			if (generation === branchWatch.generation && request === branchWatch.request) {
 				clearExpiryTimer(branchWatch);
 				renderAmbientFailure(ctx, error);
@@ -166,7 +169,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 	});
 
 	pi.on("agent_end", async (_event, ctx) => {
-		if (ctx.sessionManager !== branchWatch.sessionManager) return;
+		if (ctx.sessionManager !== branchWatch.sessionManager || ctx.signal?.aborted) return;
 		const session = branchWatch.session;
 		cancelPeriodicRefresh(branchWatch);
 		const request = await refreshStatus(ctx, ctx.signal);

--- a/packages/pi-github-pr/test/github-pr.test.ts
+++ b/packages/pi-github-pr/test/github-pr.test.ts
@@ -454,6 +454,98 @@ test("lifecycle refresh sets and clears only statusline output", async () => {
 	assert.equal(context.notifications.length, 0);
 });
 
+test("an aborted agent-end preserves the current status and periodic refresh schedule", async () => {
+	vi.useFakeTimers({ toFake: ["setTimeout"] });
+	const mock = createMockPi();
+	const controller = new AbortController();
+	let prViews = 0;
+	installExec(mock, async (command, args, options) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (options?.signal?.aborted) {
+				return { stdout: "", stderr: "", code: 1, killed: true };
+			}
+			return okResult(
+				prViews === 1
+					? samplePr
+					: {
+							...samplePr,
+							reviewDecision: "CHANGES_REQUESTED",
+							latestReviews: [{ state: "CHANGES_REQUESTED", author: { login: "carol" } }],
+						},
+			);
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 100 });
+	const context = createMockContext({ cwd: "/repo", signal: controller.signal });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(agentEnd);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, context.ctx);
+		const visibleStatus = context.statuses.get("github-pr");
+		assert.match(visibleStatus ?? "", /PR .*#123/);
+		vi.advanceTimersByTime(60);
+
+		controller.abort();
+		await agentEnd({}, context.ctx);
+
+		assert.equal(prViews, 1);
+		assert.equal(context.statuses.get("github-pr"), visibleStatus);
+
+		await vi.advanceTimersByTimeAsync(40);
+		assert.equal(prViews, 2);
+		assert.match(context.statuses.get("github-pr") ?? "", /changes requested/);
+	} finally {
+		await sessionShutdown({}, context.ctx);
+	}
+});
+
+test("a refresh aborted during agent-end preserves the current status", async () => {
+	const mock = createMockPi();
+	const controller = new AbortController();
+	const abortedPrView = deferred<ExecResult>();
+	let prViews = 0;
+	installExec(mock, async (command, args) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (prViews === 2) return abortedPrView.promise;
+		}
+		return okResult(args[0] === "pr" ? samplePr : sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 100 });
+	const context = createMockContext({ cwd: "/repo", signal: controller.signal });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(agentEnd);
+	assert.ok(sessionShutdown);
+
+	try {
+		await sessionStart({}, context.ctx);
+		const visibleStatus = context.statuses.get("github-pr");
+		const agentEndPromise = agentEnd({}, context.ctx);
+		assert.equal(prViews, 2);
+
+		controller.abort();
+		abortedPrView.resolve({ stdout: "", stderr: "", code: 1, killed: true });
+		await agentEndPromise;
+
+		assert.equal(context.statuses.get("github-pr"), visibleStatus);
+	} finally {
+		abortedPrView.resolve({ stdout: "", stderr: "", code: 1, killed: true });
+		await sessionShutdown({}, context.ctx);
+	}
+});
+
 test("rejects invalid periodic refresh intervals", () => {
 	const mock = createMockPi();
 	for (const refreshIntervalMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {


### PR DESCRIPTION
## Summary

- skip PR refreshes when `agent_end` receives an already-aborted signal
- preserve the last successful PR status when an in-flight refresh is cancelled
- keep the existing periodic refresh schedule active after an aborted turn
- add regression coverage, user-facing documentation, and a patch changeset

## Verification

- `npx vitest run packages/pi-github-pr/test/github-pr.test.ts` — 28 tests passed
- `npm run check --workspace @narumitw/pi-github-pr` — passed
- `npm run check` — 363 test files and 3,680 tests passed
- `npm run pack:github-pr -- --json` — dry-run package contents verified

## Issue context

Related to #725.

This PR fixes the separately reproduced PR statusline clearing after an aborted tool run.
It does not close #725 because the reported Pi TUI process exit was not reproduced.
