### PR TITLE
feat(chrome-devtools): add persistent browser settings

### DIFF
--- a/.changeset/bright-browsers-configure.md
+++ b/.changeset/bright-browsers-configure.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-chrome-devtools": minor
+---
+
+Add validated JSON and `/chrome-devtools settings` controls for the DevTools endpoint, auto-launch policy, and browser executable.
+
+Keep existing `PI_CHROME_DEVTOOLS_*` overrides temporarily, but warn that they are deprecated and should be migrated to `pi-chrome-devtools.json`.

--- a/docs/plans/archived/2026-08-13_pi-chrome-devtools-json-browser-settings-plan.md
+++ b/docs/plans/archived/2026-08-13_pi-chrome-devtools-json-browser-settings-plan.md
@@ -1,0 +1,40 @@
+# Pi Chrome DevTools JSON Browser Settings Plan
+
+## Goal
+
+Make the Chrome DevTools endpoint, auto-launch policy, and browser executable editable through `pi-chrome-devtools.json` and the `/chrome-devtools` Settings flow while temporarily preserving the existing `PI_CHROME_DEVTOOLS_*` overrides with a visible deprecation warning.
+
+## Context
+
+The canonical user file already owns browser executable and unpacked-extension paths, but endpoint and auto-launch behavior are initialized from environment variables at module load.
+The current **Settings & setup** menu is read-only.
+The environment variables must remain effective during this compatibility period, take precedence over JSON, and identify themselves as deprecated without exposing sensitive values.
+
+Applicable convention gates are `docs/extension-conventions.md` and `docs/extension-settings.md`.
+The change must preserve user cancellation, RPC/TUI mode adaptation, project trust, unknown JSON fields, invalid-file protection, ordered atomic writes, runtime rollback, stale-session checks, managed-browser cleanup, and shutdown durability.
+
+## Architecture
+
+- Store user-owned `browser.endpoint`, `browser.autoLaunch`, and `browser.executablePath` in the canonical extension JSON file.
+- Keep trusted project ownership limited to `browser.extensionPaths`; warn and ignore project attempts to set machine-owned browser connection fields.
+- Resolve defaults, user JSON, trusted project extension paths, then deprecated environment overrides.
+- Move runtime endpoint and launch initialization to `session_start` so each session receives one coherent effective settings snapshot.
+- Add a Pi TUI Kit settings workflow with immediate, serialized saves for endpoint, auto-launch, and executable selection; apply successful changes to the next browser connection and close any extension-owned managed browser first.
+- Keep unpacked-extension paths visible with manual JSON guidance because they require multi-path manifest validation and are not environment-variable replacements.
+
+## Plan
+
+- [x] Add focused failing settings and lifecycle tests for JSON endpoint/auto-launch resolution, deprecated environment precedence and warnings, project-scope rejection, validation, unknown-field preservation, ordered writes, and runtime application; the initial focused run failed six new settings contracts before implementation.
+- [x] Refactor `packages/pi-chrome-devtools/src/settings.ts` and `src/runtime.ts` to own validated browser connection settings, compatibility overrides, source metadata, shared atomic mutation ordering, and session-time runtime publication; focused settings and lifecycle tests pass.
+- [x] Add focused failing TUI/RPC menu tests for editable browser settings, cancellation, invalid-file read-only behavior, failed-save rollback, immediate runtime refresh, stale-session disposal, and narrow rendering; the initial test could not resolve the not-yet-created settings workflow module.
+- [x] Implement the `/chrome-devtools` browser settings workflow with Pi TUI Kit screens and package-owned persistence/lifecycle policy; 80 focused package tests and package typechecking pass.
+- [x] Update `packages/pi-chrome-devtools/README.md`, status/setup copy, and a minor Changeset to document JSON fields, defaults, precedence, deprecation, reload/runtime behavior, and security boundaries; Changesets resolves the package to a minor bump.
+- [x] Audit the final diff against both convention guides, including TUI/RPC modes, cancellation/disposal, generation checks after awaits, settings read/write ordering, failure recovery, invalid-file protection, unknown-field preservation, and managed-browser cleanup; no unresolved convention finding remains.
+- [x] Run package-focused tests and typecheck, `npm run check`, `just pack chrome-devtools`, Changesets status, and an isolated non-interactive Pi entrypoint smoke; the repository gate passed 364 files and 3,697 tests, the 17-file tarball contains the new settings module, and RPC applied the JSON endpoint and auto-launch source without a provider request. Chrome's built-in permission endpoint and native Windows rendering remain unverified and are documented as unsupported or untested rather than claimed.
+
+## Completion Checklist
+
+- [x] JSON and `/chrome-devtools` Settings can manage endpoint, auto-launch, and executable behavior without requiring environment variables.
+- [x] Existing environment overrides still win and emit an actionable deprecation warning.
+- [x] Settings persistence and UI lifecycle semantics satisfy the repository guides.
+- [x] Documentation, release metadata, focused checks, repository checks, package contents, and runtime loading are verified.

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -27,7 +27,8 @@ This package is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDev
 - Retries briefly while Chrome is starting and reports actionable endpoint errors.
 - Shows statusline activity only while Chrome DevTools tools are running.
 - Keeps one loader tool active and exposes matching browser capabilities only when the agent needs them.
-- Provides a state-first `/chrome-devtools` menu for tool availability, browser status, setup, and help.
+- Provides a state-first `/chrome-devtools` menu for tool availability, editable browser settings,
+  browser status, setup, and help.
 - Stages menu-based availability changes for exact review before one confirmed apply.
 - Uses `@narumitw/pi-tui-kit` for width-safe TUI menus and equivalent RPC dialogs.
 - Persists the Chrome DevTools lazy-load catalog across Pi restarts.
@@ -52,15 +53,33 @@ pi -e ./packages/pi-chrome-devtools
 
 ## 🚀 Browser startup
 
-Without unpacked extensions, the extension first tries the configured endpoint, defaulting to
-`127.0.0.1:9222`. If that local endpoint is unavailable, it lazily launches an extension-owned
-Chromium-family browser with an isolated temp profile and retries the CDP request. Existing endpoints
-are reused and are never terminated by the extension.
+Without unpacked extensions, the extension first tries `browser.endpoint`, defaulting to
+`http://127.0.0.1:9222`. If that local endpoint is unavailable and `browser.autoLaunch` is `true`, it
+lazily launches an extension-owned Chromium-family browser with an isolated temp profile and retries
+the CDP request. Existing endpoints are reused and are never terminated by the extension.
 
-When `PI_CHROME_DEVTOOLS_PORT` is not set, auto-launch uses Chrome's dynamic DevTools port mode
-(`--remote-debugging-port=0`) and reads `DevToolsActivePort` from the temp profile. If you set a valid
-`PI_CHROME_DEVTOOLS_PORT` (`1`-`65535`), the extension uses that explicit port. Empty or invalid values
-fall back to the default attach-first behavior.
+Configure the canonical user file at
+`${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json`:
+
+```json
+{
+  "browser": {
+    "endpoint": "http://127.0.0.1:9222",
+    "autoLaunch": true,
+    "executablePath": "/absolute/path/to/chromium"
+  }
+}
+```
+
+`browser.endpoint` must be an HTTP origin with an explicit port and no credentials, path, query, or
+fragment. Omitting it keeps attach-first behavior on `127.0.0.1:9222` and lets a managed launch use
+Chrome's dynamic DevTools port mode (`--remote-debugging-port=0`). Explicitly saving an endpoint pins
+managed launches to that port. `browser.autoLaunch` defaults to `true`. `browser.executablePath` is
+optional and must be an absolute path; when absent, normal browser discovery applies.
+
+The configured endpoint must expose the standard CDP HTTP discovery routes such as `/json/version`
+and `/json/list`. Chrome's newer built-in permission flow can listen on port `9222` while returning
+`404` from those routes; setting the same HTTP origin does not by itself make that flow compatible.
 
 ### Unpacked extensions
 
@@ -68,8 +87,7 @@ fall back to the default attach-first behavior.
 > An unpacked extension executes privileged browser code. Load only code you trust. Project settings
 > are honored only when Pi reports the project as trusted.
 
-Configure the canonical user file at
-`${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json`:
+Add trusted unpacked-extension paths to the same canonical user file:
 
 ```json
 {
@@ -101,9 +119,10 @@ A trusted project can replace the user extension list in
 ```
 
 Project `extensionPaths` replace, rather than append to, the user array. A project file cannot
-override `browser.executablePath`; browser selection remains machine-owned user configuration.
-Effective precedence is defaults, user settings, trusted project override, then existing explicit
-runtime environment overrides. No new environment variable is required.
+override `browser.endpoint`, `browser.autoLaunch`, or `browser.executablePath`; browser connection
+settings remain machine-owned user configuration. Effective precedence is defaults, user settings,
+trusted project extension paths, then deprecated environment overrides. No new environment variable
+is required.
 
 When `extensionPaths` is non-empty, the extension skips attach-first behavior and starts an isolated,
 extension-owned managed browser with `--disable-extensions-except` and `--load-extension`. It fails
@@ -116,24 +135,17 @@ old managed browser is closed before the new configuration is applied. Missing f
 existing no-extension behavior. Invalid JSON, invalid browser values, and missing manifests are left
 unchanged and ignored with an actionable warning.
 
-### Environment overrides and manual endpoints
+### Deprecated environment overrides and manual endpoints
 
-`PI_CHROME_DEVTOOLS_BROWSER` remains the explicit runtime executable override. Without unpacked
-extensions, browser discovery still checks platform-specific Chrome, Chromium, Brave, and Microsoft
-Edge candidates. Disable auto-launch to keep the manual flow:
+The existing `PI_CHROME_DEVTOOLS_HOST`, `PI_CHROME_DEVTOOLS_PORT`,
+`PI_CHROME_DEVTOOLS_AUTO_LAUNCH`, and `PI_CHROME_DEVTOOLS_BROWSER` variables remain temporary
+compatibility overrides. They still take precedence over JSON, but every session that sees one emits
+a deprecation warning. Move their values to `browser.endpoint`, `browser.autoLaunch`, and
+`browser.executablePath`; the variables will be removed in a future version.
 
-```bash
-PI_CHROME_DEVTOOLS_AUTO_LAUNCH=0 pi -e ./packages/pi-chrome-devtools
-```
-
-Force an executable or endpoint if needed:
-
-```bash
-PI_CHROME_DEVTOOLS_BROWSER=/usr/bin/chromium pi -e ./packages/pi-chrome-devtools
-PI_CHROME_DEVTOOLS_HOST=127.0.0.1 PI_CHROME_DEVTOOLS_PORT=9223 pi -e ./packages/pi-chrome-devtools
-```
-
-Manual launch remains available when no unpacked extensions are configured:
+Without unpacked extensions, browser discovery still checks platform-specific Chrome, Chromium,
+Brave, and Microsoft Edge candidates. Manual launch remains available when no unpacked extensions are
+configured:
 
 ```bash
 google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/pi-chrome-devtools
@@ -212,7 +224,9 @@ an action. The five actions stay on one level:
   context-appropriate bulk change before applying it.
 - **Browser status** — inspect runtime, endpoint, launch mode, and the last launch attempt without
   probing the endpoint or starting Chrome.
-- **Settings & setup** — inspect effective files, sources, trust, reload steps, and recovery guidance.
+- **Browser settings** — immediately save the endpoint, auto-launch policy, or browser executable;
+  inspect unpacked-extension paths and effective sources. A deprecated environment override remains
+  effective until removed even when its underlying JSON value changes.
 - **Help** — view command usage and return to the menu.
 
 In the tool screen, **Select all** and **Select none** are unambiguous shortcuts; individual rows use
@@ -229,6 +243,7 @@ Direct subcommands are also available:
 /chrome-devtools help
 /chrome-devtools quickstart
 /chrome-devtools status
+/chrome-devtools settings
 /chrome-devtools tools
 /chrome-devtools toggle
 /chrome-devtools enable
@@ -244,6 +259,7 @@ Compatibility aliases remain available: `toggle` and `select` mean `tools`, `on`
 - `status` shows available and loaded capability counts, loader state, the persisted catalog,
   settings file path, endpoint source, launch mode, last launch attempt, and active non-Chrome tool
   count.
+- `settings` opens the same immediate-save browser settings flow used by the menu.
 - `tools` opens the same staged, width-safe availability and review flow used by the menu.
 - `toggle` and `select` are compatibility aliases for `tools`.
 - `enable` makes all five capability tools available to the loader and saves that catalog; `on` is a
@@ -251,11 +267,13 @@ Compatibility aliases remain available: `toggle` and `select` mean `tools`, `on`
 - `disable` makes all five capability tools unavailable and saves the empty catalog; `off` is a
   compatibility alias. The slash command and `chrome_devtools_load` remain available.
 
-The menu, `tools`, `help`, `quickstart`, and `status` require TUI or RPC mode so their result is
-observable. TUI uses keyboard navigation and injected Pi keybindings; RPC receives equivalent
-standard dialogs. In print and JSON modes, interactive and informational routes reject explicitly
-instead of silently opening unavailable UI. The immediate `enable`/`disable` routes remain available
-for deterministic non-interactive use.
+The menu, `settings`, `tools`, `help`, `quickstart`, and `status` require TUI or RPC mode so their
+result is observable. TUI uses keyboard navigation and injected Pi keybindings; RPC receives
+equivalent standard dialogs. In print and JSON modes, interactive and informational routes reject
+explicitly instead of silently opening unavailable UI. The immediate `enable`/`disable` routes remain
+available for deterministic non-interactive use.
+
+## ⚙️ Settings
 
 The available capability names are saved to:
 
@@ -263,14 +281,19 @@ The available capability names are saved to:
 ${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json
 ```
 
+The same file owns `browser.endpoint`, `browser.autoLaunch`, `browser.executablePath`, and
+`browser.extensionPaths`. Browser connection fields are machine-owned user settings; trusted project
+files may replace only `browser.extensionPaths`. Confirmed menu changes apply before the next browser
+connection and close only an extension-owned managed browser. Manual JSON edits and unpacked-extension
+changes apply after `/reload` or session replacement.
+
 When the file is missing or invalid, the extension preserves Pi's current Chrome DevTools
 availability policy instead of replacing it. A valid saved catalog is restored on Pi startup and
 `/reload`, while its capability definitions remain deferred. A missing file is created by the first
-confirmed menu apply or successful direct availability change. Within one Pi process, catalog saves
-run in invocation order, reread the latest valid document, and preserve unknown fields. Malformed
-JSON or invalid recognized fields make menu mutation unavailable and block direct saves without
-replacement; a failed save restores the prior Chrome DevTools availability and loaded-tool state
-while preserving other extensions' current tools.
+confirmed browser or tool setting. Within one Pi process, all browser and tool saves run in invocation
+order, reread the latest valid document, publish by temporary-file rename, and preserve unknown
+fields. Malformed JSON or invalid recognized fields make menu mutation unavailable and block direct
+saves without replacement; a failed save restores the prior displayed and effective state.
 
 Compatibility: older versions used `pi-chrome-devtools-settings.json`. A legacy-only file remains
 readable with a warning and is never modified automatically; rename it to

--- a/packages/pi-chrome-devtools/src/browser-manager.ts
+++ b/packages/pi-chrome-devtools/src/browser-manager.ts
@@ -143,7 +143,7 @@ async function prepareManagedBrowserLaunch(
 		throwIfBrowserLaunchCancelled(generation, signal);
 		if (!available) {
 			throw new DevToolsEndpointError(
-				`Cannot launch the extension-owned browser because explicit port ${state.port} is already in use. Choose a free PI_CHROME_DEVTOOLS_PORT or remove the override for a dynamic port.`,
+				`Cannot launch the extension-owned browser because explicit port ${state.port} is already in use. Choose a free browser.endpoint port or reset the endpoint to use a dynamic managed port.`,
 			);
 		}
 	}
@@ -609,9 +609,7 @@ export function formatHostForUrl(host: string) {
 }
 
 export function endpointSourceLabel() {
-	const hostSource = state.hostConfigured ? "PI_CHROME_DEVTOOLS_HOST" : "default host";
-	const portSource = state.portConfigured ? "PI_CHROME_DEVTOOLS_PORT" : "default/dynamic port";
-	return `${hostSource}; ${portSource}`;
+	return state.endpointSource;
 }
 
 export type BrowserLifecycleState = "starting" | "running" | "exited" | "failed" | "unobserved";
@@ -710,7 +708,7 @@ export function quoteCommandPart(value: string) {
 }
 
 export function endpointConfigHint() {
-	return "Set PI_CHROME_DEVTOOLS_HOST and PI_CHROME_DEVTOOLS_PORT for a manual endpoint, PI_CHROME_DEVTOOLS_BROWSER to choose an executable, or PI_CHROME_DEVTOOLS_AUTO_LAUNCH=0 to disable auto-launch.";
+	return "Configure browser.endpoint, browser.executablePath, and browser.autoLaunch in pi-chrome-devtools.json or the /chrome-devtools Settings flow.";
 }
 
 export function isLocalDevToolsHost(host: string) {

--- a/packages/pi-chrome-devtools/src/browser-settings-menu.ts
+++ b/packages/pi-chrome-devtools/src/browser-settings-menu.ts
@@ -1,0 +1,275 @@
+import { isAbsolute } from "node:path";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { shutdownManagedBrowser } from "./browser-manager.js";
+import { applyRuntimeBrowserSettings, state } from "./runtime.js";
+import {
+	type BrowserSettingsPatch,
+	loadSettings,
+	parseBrowserEndpoint,
+	type SettingsLoadResult,
+	saveBrowserSettings,
+	settingsFilePath,
+} from "./settings.js";
+import { sanitizeChromeDevtoolsDisplay } from "./tool-selector.js";
+
+type BrowserSettingsScreen = "settings" | "endpoint" | "executable" | "extensions";
+type BrowserSettingsAction =
+	| "open-endpoint"
+	| "save-endpoint"
+	| "set-auto-launch"
+	| "open-executable"
+	| "save-executable"
+	| "show-extensions";
+
+interface BrowserSettingsMenuState {
+	load: SettingsLoadResult;
+}
+
+type CommandContext = ExtensionCommandContext;
+
+export async function showChromeDevtoolsBrowserSettings(
+	ctx: CommandContext,
+	generation: number,
+): Promise<{ closeParent: boolean }> {
+	const ownerSignal = state.sessionController.signal;
+	const isCurrent = () => generation === state.sessionGeneration && !ownerSignal.aborted;
+	const projectTrusted = ctx.isProjectTrusted();
+	const menu = defineMenu<BrowserSettingsMenuState, BrowserSettingsScreen, BrowserSettingsAction>({
+		start: "settings",
+		screens: {
+			settings: ({ state: current }) => {
+				if (current.load.kind === "invalid") return invalidSettingsScreen(current.load);
+				const browser = current.load.effectiveBrowser;
+				return {
+					kind: "settings",
+					title: "Chrome DevTools Browser settings",
+					lines: settingsContextLines(current.load),
+					items: [
+						{
+							id: "endpoint",
+							label: "DevTools endpoint",
+							description:
+								'HTTP origin with an explicit port; enter "default" to restore 127.0.0.1:9222.',
+							currentValue: browser.endpoint,
+							action: "open-endpoint",
+						},
+						{
+							id: "auto-launch",
+							label: "Auto-launch",
+							description:
+								"Launch an isolated managed browser when a local endpoint is unavailable.",
+							currentValue: browser.autoLaunchEnabled ? "On" : "Off",
+							values: ["On", "Off"],
+							action: "set-auto-launch",
+						},
+						{
+							id: "executable",
+							label: "Browser executable",
+							description:
+								'Absolute executable path; enter "automatic" to restore browser discovery.',
+							currentValue: browser.executablePath ?? "Automatic",
+							action: "open-executable",
+						},
+						{
+							id: "extensions",
+							label: "Unpacked extensions",
+							description: "Inspect trusted extension paths configured in user or project JSON.",
+							currentValue: `${browser.extensionPaths.length} configured`,
+							action: "show-extensions",
+						},
+					],
+				};
+			},
+			endpoint: ({ state: current }) => ({
+				kind: "input",
+				title: "DevTools endpoint",
+				lines: [
+					`Current effective endpoint: ${current.load.effectiveBrowser.endpoint}`,
+					'Enter an HTTP origin with an explicit port, or "default".',
+				],
+				placeholder: "http://127.0.0.1:9222",
+				action: "save-endpoint",
+				hint: "back",
+			}),
+			executable: ({ state: current }) => ({
+				kind: "input",
+				title: "Browser executable",
+				lines: [
+					`Current effective executable: ${current.load.effectiveBrowser.executablePath ?? "automatic discovery"}`,
+					'Enter an absolute path, or "automatic".',
+				],
+				placeholder: "absolute browser executable path",
+				action: "save-executable",
+				hint: "back",
+			}),
+			extensions: ({ state: current }) => ({
+				kind: "detail",
+				title: "Unpacked extensions",
+				lines: extensionDetailLines(current.load),
+				hint: "back",
+			}),
+		},
+		actions: {
+			"open-endpoint": () => ({ kind: "to", screen: "endpoint" }),
+			"save-endpoint": async ({ value, signal }) => {
+				if (value === undefined) return { kind: "rejected" };
+				let endpoint: string | null;
+				try {
+					const trimmed = value.trim();
+					endpoint =
+						trimmed.toLowerCase() === "default" ? null : parseBrowserEndpoint(trimmed).endpoint;
+				} catch (error) {
+					notifySaveFailure(ctx, error);
+					return { kind: "rejected" };
+				}
+				const saved = await saveAndApplyBrowserPatch(
+					ctx,
+					generation,
+					ownerSignal,
+					signal,
+					projectTrusted,
+					{ endpoint },
+				);
+				if (!saved) return { kind: "rejected" };
+				ctx.ui.notify(
+					`Chrome DevTools endpoint saved: ${endpoint ?? "default (http://127.0.0.1:9222)"}.`,
+					"info",
+				);
+				return { kind: "back" };
+			},
+			"set-auto-launch": async ({ value, signal }) => {
+				if (value !== "On" && value !== "Off") return { kind: "rejected" };
+				const saved = await saveAndApplyBrowserPatch(
+					ctx,
+					generation,
+					ownerSignal,
+					signal,
+					projectTrusted,
+					{ autoLaunch: value === "On" },
+				);
+				if (!saved) return { kind: "rejected" };
+				ctx.ui.notify(`Chrome DevTools auto-launch: ${value}.`, "info");
+				return { kind: "stay" };
+			},
+			"open-executable": () => ({ kind: "to", screen: "executable" }),
+			"save-executable": async ({ value, signal }) => {
+				if (value === undefined) return { kind: "rejected" };
+				const trimmed = value.trim();
+				const reset = ["automatic", "default", "none"].includes(trimmed.toLowerCase());
+				if (!reset && (!trimmed || !isAbsolute(trimmed))) {
+					notifySaveFailure(ctx, new Error('Enter an absolute path or "automatic".'));
+					return { kind: "rejected" };
+				}
+				const executablePath = reset ? null : trimmed;
+				const saved = await saveAndApplyBrowserPatch(
+					ctx,
+					generation,
+					ownerSignal,
+					signal,
+					projectTrusted,
+					{ executablePath },
+				);
+				if (!saved) return { kind: "rejected" };
+				ctx.ui.notify(
+					`Chrome DevTools browser executable saved: ${executablePath ?? "automatic discovery"}.`,
+					"info",
+				);
+				return { kind: "back" };
+			},
+			"show-extensions": () => ({ kind: "to", screen: "extensions" }),
+		},
+	});
+	const result = await runMenu(ctx, menu, {
+		getState: async ({ signal }) => {
+			signal.throwIfAborted();
+			const load = await loadSettings({ cwd: ctx.cwd, projectTrusted });
+			signal.throwIfAborted();
+			return { load };
+		},
+		signal: ownerSignal,
+		isCurrent,
+		onError: (currentCtx, error) =>
+			currentCtx.ui.notify(
+				sanitizeChromeDevtoolsDisplay(
+					`Chrome DevTools browser settings failed: ${formatError(error)}`,
+				),
+				"error",
+			),
+	});
+	return { closeParent: result.kind === "closed" && result.reason === "close" };
+}
+
+async function saveAndApplyBrowserPatch(
+	ctx: CommandContext,
+	generation: number,
+	ownerSignal: AbortSignal,
+	actionSignal: AbortSignal,
+	projectTrusted: boolean,
+	patch: BrowserSettingsPatch,
+) {
+	try {
+		await ctx.waitForIdle();
+		if (!isCurrent(generation, ownerSignal, actionSignal)) return false;
+		await saveBrowserSettings(patch);
+		if (!isCurrent(generation, ownerSignal, actionSignal)) return false;
+		await shutdownManagedBrowser();
+		if (!isCurrent(generation, ownerSignal, actionSignal)) return false;
+		const loaded = await loadSettings({ cwd: ctx.cwd, projectTrusted });
+		if (!isCurrent(generation, ownerSignal, actionSignal)) return false;
+		applyRuntimeBrowserSettings(loaded.effectiveBrowser, loaded.paths, projectTrusted);
+		state.settingsNotice = loaded.notice;
+		return true;
+	} catch (error) {
+		if (isCurrent(generation, ownerSignal, actionSignal)) notifySaveFailure(ctx, error);
+		return false;
+	}
+}
+
+function isCurrent(generation: number, ownerSignal: AbortSignal, actionSignal: AbortSignal) {
+	return generation === state.sessionGeneration && !ownerSignal.aborted && !actionSignal.aborted;
+}
+
+function invalidSettingsScreen(load: SettingsLoadResult) {
+	const reason = load.kind === "invalid" ? load.reason : "The settings file is unavailable.";
+	return {
+		kind: "detail" as const,
+		title: "Chrome DevTools Browser settings · Read only",
+		lines: [`Fix ${settingsFilePath()} before saving. The file will not be overwritten.`, reason],
+		hint: "back" as const,
+	};
+}
+
+function settingsContextLines(load: SettingsLoadResult) {
+	const browser = load.effectiveBrowser;
+	return [
+		`User settings · ${load.paths.user}`,
+		`Effective sources: endpoint ${browser.endpointSource} · auto-launch ${browser.autoLaunchSource} · executable ${browser.executablePathSource}`,
+		...(load.notice ? [`Warning: ${load.notice}`] : []),
+	];
+}
+
+function extensionDetailLines(load: SettingsLoadResult) {
+	const browser = load.effectiveBrowser;
+	return [
+		`Effective source: ${browser.extensionPathsSource}`,
+		...(browser.extensionPaths.length > 0
+			? browser.extensionPaths.map((extensionPath) => `- ${extensionPath}`)
+			: ["No unpacked extensions are configured."]),
+		"Edit browser.extensionPaths in the user JSON or a trusted project JSON, then run /reload.",
+		"Unpacked extensions execute privileged browser code; load only paths you trust.",
+	];
+}
+
+function notifySaveFailure(ctx: CommandContext, error: unknown) {
+	ctx.ui.notify(
+		sanitizeChromeDevtoolsDisplay(
+			`Chrome DevTools browser settings save failed; previous settings remain active: ${formatError(error)}`,
+		),
+		"warning",
+	);
+}
+
+function formatError(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-chrome-devtools/src/browser-settings-menu.ts
+++ b/packages/pi-chrome-devtools/src/browser-settings-menu.ts
@@ -5,11 +5,11 @@ import { shutdownManagedBrowser } from "./browser-manager.js";
 import { applyRuntimeBrowserSettings, state } from "./runtime.js";
 import {
 	type BrowserSettingsPatch,
+	type BrowserSettingsSource,
 	loadSettings,
 	parseBrowserEndpoint,
 	type SettingsLoadResult,
 	saveBrowserSettings,
-	settingsFilePath,
 } from "./settings.js";
 import { sanitizeChromeDevtoolsDisplay } from "./tool-selector.js";
 
@@ -39,7 +39,7 @@ export async function showChromeDevtoolsBrowserSettings(
 		start: "settings",
 		screens: {
 			settings: ({ state: current }) => {
-				if (current.load.kind === "invalid") return invalidSettingsScreen(current.load);
+				if (current.load.userFile.kind === "invalid") return invalidSettingsScreen(current.load);
 				const browser = current.load.effectiveBrowser;
 				return {
 					kind: "settings",
@@ -51,7 +51,7 @@ export async function showChromeDevtoolsBrowserSettings(
 							label: "DevTools endpoint",
 							description:
 								'HTTP origin with an explicit port; enter "default" to restore 127.0.0.1:9222.',
-							currentValue: browser.endpoint,
+							currentValue: sanitizeChromeDevtoolsDisplay(browser.endpoint),
 							action: "open-endpoint",
 						},
 						{
@@ -68,7 +68,7 @@ export async function showChromeDevtoolsBrowserSettings(
 							label: "Browser executable",
 							description:
 								'Absolute executable path; enter "automatic" to restore browser discovery.',
-							currentValue: browser.executablePath ?? "Automatic",
+							currentValue: sanitizeChromeDevtoolsDisplay(browser.executablePath ?? "Automatic"),
 							action: "open-executable",
 						},
 						{
@@ -85,7 +85,9 @@ export async function showChromeDevtoolsBrowserSettings(
 				kind: "input",
 				title: "DevTools endpoint",
 				lines: [
-					`Current effective endpoint: ${current.load.effectiveBrowser.endpoint}`,
+					sanitizeChromeDevtoolsDisplay(
+						`Current effective endpoint: ${current.load.effectiveBrowser.endpoint}`,
+					),
 					'Enter an HTTP origin with an explicit port, or "default".',
 				],
 				placeholder: "http://127.0.0.1:9222",
@@ -96,7 +98,9 @@ export async function showChromeDevtoolsBrowserSettings(
 				kind: "input",
 				title: "Browser executable",
 				lines: [
-					`Current effective executable: ${current.load.effectiveBrowser.executablePath ?? "automatic discovery"}`,
+					sanitizeChromeDevtoolsDisplay(
+						`Current effective executable: ${current.load.effectiveBrowser.executablePath ?? "automatic discovery"}`,
+					),
 					'Enter an absolute path, or "automatic".',
 				],
 				placeholder: "absolute browser executable path",
@@ -132,9 +136,11 @@ export async function showChromeDevtoolsBrowserSettings(
 					{ endpoint },
 				);
 				if (!saved) return { kind: "rejected" };
-				ctx.ui.notify(
-					`Chrome DevTools endpoint saved: ${endpoint ?? "default (http://127.0.0.1:9222)"}.`,
-					"info",
+				notifyEffectiveSave(
+					ctx,
+					"endpoint",
+					saved.effectiveBrowser.endpoint,
+					saved.effectiveBrowser.endpointSource,
 				);
 				return { kind: "back" };
 			},
@@ -149,7 +155,12 @@ export async function showChromeDevtoolsBrowserSettings(
 					{ autoLaunch: value === "On" },
 				);
 				if (!saved) return { kind: "rejected" };
-				ctx.ui.notify(`Chrome DevTools auto-launch: ${value}.`, "info");
+				notifyEffectiveSave(
+					ctx,
+					"auto-launch",
+					saved.effectiveBrowser.autoLaunchEnabled ? "On" : "Off",
+					saved.effectiveBrowser.autoLaunchSource,
+				);
 				return { kind: "stay" };
 			},
 			"open-executable": () => ({ kind: "to", screen: "executable" }),
@@ -171,9 +182,11 @@ export async function showChromeDevtoolsBrowserSettings(
 					{ executablePath },
 				);
 				if (!saved) return { kind: "rejected" };
-				ctx.ui.notify(
-					`Chrome DevTools browser executable saved: ${executablePath ?? "automatic discovery"}.`,
-					"info",
+				notifyEffectiveSave(
+					ctx,
+					"browser executable",
+					saved.effectiveBrowser.executablePath ?? "automatic discovery",
+					saved.effectiveBrowser.executablePathSource,
 				);
 				return { kind: "back" };
 			},
@@ -219,7 +232,7 @@ async function saveAndApplyBrowserPatch(
 		if (!isCurrent(generation, ownerSignal, actionSignal)) return false;
 		applyRuntimeBrowserSettings(loaded.effectiveBrowser, loaded.paths, projectTrusted);
 		state.settingsNotice = loaded.notice;
-		return true;
+		return loaded;
 	} catch (error) {
 		if (isCurrent(generation, ownerSignal, actionSignal)) notifySaveFailure(ctx, error);
 		return false;
@@ -231,11 +244,18 @@ function isCurrent(generation: number, ownerSignal: AbortSignal, actionSignal: A
 }
 
 function invalidSettingsScreen(load: SettingsLoadResult) {
-	const reason = load.kind === "invalid" ? load.reason : "The settings file is unavailable.";
+	const reason =
+		load.userFile.kind === "invalid"
+			? load.userFile.reason
+			: "The user settings file is unavailable.";
 	return {
 		kind: "detail" as const,
 		title: "Chrome DevTools Browser settings · Read only",
-		lines: [`Fix ${settingsFilePath()} before saving. The file will not be overwritten.`, reason],
+		lines: [
+			sanitizeChromeDevtoolsDisplay(
+				`Fix the active user settings before saving; the file will not be overwritten. ${reason}`,
+			),
+		],
 		hint: "back" as const,
 	};
 }
@@ -246,7 +266,7 @@ function settingsContextLines(load: SettingsLoadResult) {
 		`User settings · ${load.paths.user}`,
 		`Effective sources: endpoint ${browser.endpointSource} · auto-launch ${browser.autoLaunchSource} · executable ${browser.executablePathSource}`,
 		...(load.notice ? [`Warning: ${load.notice}`] : []),
-	];
+	].map((line) => sanitizeChromeDevtoolsDisplay(line));
 }
 
 function extensionDetailLines(load: SettingsLoadResult) {
@@ -258,7 +278,23 @@ function extensionDetailLines(load: SettingsLoadResult) {
 			: ["No unpacked extensions are configured."]),
 		"Edit browser.extensionPaths in the user JSON or a trusted project JSON, then run /reload.",
 		"Unpacked extensions execute privileged browser code; load only paths you trust.",
-	];
+	].map((line) => sanitizeChromeDevtoolsDisplay(line));
+}
+
+function notifyEffectiveSave(
+	ctx: CommandContext,
+	setting: string,
+	effectiveValue: string,
+	source: BrowserSettingsSource,
+) {
+	const overrideNotice =
+		source === "environment" ? " The deprecated environment override remains effective." : "";
+	ctx.ui.notify(
+		sanitizeChromeDevtoolsDisplay(
+			`Chrome DevTools ${setting} saved. Effective ${setting}: ${effectiveValue} (${source}).${overrideNotice}`,
+		),
+		"info",
+	);
 }
 
 function notifySaveFailure(ctx: CommandContext, error: unknown) {

--- a/packages/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/packages/pi-chrome-devtools/src/chrome-devtools.ts
@@ -7,7 +7,7 @@ import {
 	initializeAvailableChromeDevtoolsTools,
 } from "./lazy-tools.js";
 import { applyRuntimeBrowserSettings, state } from "./runtime.js";
-import { loadSettings } from "./settings.js";
+import { loadSettings, waitForSettingsWrites } from "./settings.js";
 import {
 	allChromeDevtoolsTools,
 	buildCommandGuide,
@@ -25,13 +25,22 @@ import {
 	selectPageTool,
 } from "./tools.js";
 
-type CommandAction = "menu" | "help" | "quickstart" | "status" | "tools" | "enable" | "disable";
+type CommandAction =
+	| "menu"
+	| "help"
+	| "quickstart"
+	| "status"
+	| "settings"
+	| "tools"
+	| "enable"
+	| "disable";
 type CommandContext = ExtensionCommandContext;
 const STATUS_KEY = "chrome-devtools";
 const COMMAND_COMPLETIONS = [
 	{ value: "help", label: "help", description: "Show command usage" },
 	{ value: "quickstart", label: "quickstart", description: "Show endpoint and launch help" },
 	{ value: "status", label: "status", description: "Show tool and settings status" },
+	{ value: "settings", label: "settings", description: "Edit browser connection settings" },
 	{ value: "tools", label: "tools", description: "Choose lazy-loadable Chrome DevTools tools" },
 	{ value: "toggle", label: "toggle", description: "Alias for tools" },
 	{ value: "select", label: "select", description: "Compatibility alias for tools" },
@@ -90,6 +99,7 @@ export default function chromeDevtools(pi: ExtensionAPI) {
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		const browserShutdown = shutdownManagedBrowser(undefined, { cancelLaunch: true });
 		await waitForChromeDevtoolsSettings();
+		await waitForSettingsWrites();
 		await browserShutdown;
 	});
 }
@@ -118,6 +128,15 @@ async function handleChromeDevtoolsCommand(
 			const status = await buildToolStatusMessage(pi);
 			if (generation !== state.sessionGeneration) return;
 			ctx.ui.notify(status, "info");
+			return;
+		}
+		case "settings": {
+			if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+				throw new Error("/chrome-devtools settings requires TUI or RPC mode");
+			}
+			const { showChromeDevtoolsBrowserSettings } = await import("./browser-settings-menu.js");
+			if (generation !== state.sessionGeneration) return;
+			await showChromeDevtoolsBrowserSettings(ctx, generation);
 			return;
 		}
 		case "tools": {
@@ -174,6 +193,7 @@ export function parseCommand(args: string): CommandAction | "unknown" {
 	if (command === "help") return "help";
 	if (command === "quickstart") return "quickstart";
 	if (command === "status") return "status";
+	if (command === "settings") return "settings";
 	if (command === "tools" || command === "select" || command === "toggle") return "tools";
 	if (command === "enable" || command === "on") return "enable";
 	if (command === "disable" || command === "off") return "disable";

--- a/packages/pi-chrome-devtools/src/menu.ts
+++ b/packages/pi-chrome-devtools/src/menu.ts
@@ -8,14 +8,13 @@ import { CHROME_DEVTOOLS_TOOL_NAMES, type ChromeDevToolsToolName } from "./tool-
 import {
 	buildBrowserStatusMessage,
 	buildCommandGuide,
-	buildSettingsSetupMessage,
 	sanitizeChromeDevtoolsDisplay,
 	setSelectedChromeDevtoolsTools,
 } from "./tool-selector.js";
 
 type CommandContext = ExtensionCommandContext;
-type MainScreen = "main" | "browserStatus" | "settings" | "help";
-type MainAction = "tools" | "bulk";
+type MainScreen = "main" | "browserStatus" | "help";
+type MainAction = "tools" | "bulk" | "settings";
 type ToolScreen = "tools" | "review";
 type ToolAction = "toggle" | "selectAll" | "selectNone" | "review" | "apply" | "cancel";
 
@@ -104,9 +103,9 @@ export async function showChromeDevtoolsMenu(
 					},
 					{
 						id: "settings",
-						label: "Settings & setup",
-						description: "Files, sources, trust, and reload steps.",
-						to: "settings",
+						label: "Browser settings",
+						description: "Edit endpoint, auto-launch, and browser executable settings.",
+						action: "settings",
 					},
 					{
 						id: "help",
@@ -121,14 +120,6 @@ export async function showChromeDevtoolsMenu(
 				kind: "review",
 				title: "Browser status",
 				content: buildBrowserStatusMessage(),
-				format: { kind: "text" },
-				viewportSize: "adaptive",
-				hint: "back",
-			}),
-			settings: () => ({
-				kind: "review",
-				title: "Settings & setup",
-				content: buildSettingsSetupMessage(),
 				format: { kind: "text" },
 				viewportSize: "adaptive",
 				hint: "back",
@@ -162,6 +153,13 @@ export async function showChromeDevtoolsMenu(
 				});
 				if (result?.applied && isCurrent()) updateSnapshotAfterApply(current, result.selectedTools);
 				return result?.closeParent ? { kind: "close" } : { kind: "stay" };
+			},
+			settings: async () => {
+				const { showChromeDevtoolsBrowserSettings } = await import("./browser-settings-menu.js");
+				if (!isCurrent()) return { kind: "stay" };
+				const result = await showChromeDevtoolsBrowserSettings(ctx, generation);
+				if (!isCurrent()) return { kind: "stay" };
+				return result.closeParent ? { kind: "close" } : { kind: "stay" };
 			},
 		},
 	});

--- a/packages/pi-chrome-devtools/src/runtime.ts
+++ b/packages/pi-chrome-devtools/src/runtime.ts
@@ -1,8 +1,13 @@
 import type { ChildProcess } from "node:child_process";
-import type { EffectiveBrowserSettings } from "./settings.js";
+import {
+	DEFAULT_BROWSER_HOST,
+	DEFAULT_BROWSER_PORT,
+	type EffectiveBrowserSettings,
+	parseConfiguredPort,
+} from "./settings.js";
 
-export const DEFAULT_HOST = "127.0.0.1";
-export const DEFAULT_PORT = 9222;
+export const DEFAULT_HOST = DEFAULT_BROWSER_HOST;
+export const DEFAULT_PORT = DEFAULT_BROWSER_PORT;
 export const DEFAULT_TIMEOUT_MS = 10_000;
 export const DEFAULT_HTTP_TIMEOUT_MS = 1_000;
 export const DEFAULT_ENDPOINT_WAIT_MS = 5_000;
@@ -26,6 +31,8 @@ export interface ChromeDevToolsState {
 	hostConfigured: boolean;
 	portConfigured: boolean;
 	autoLaunchEnabled: boolean;
+	endpointSource: EffectiveBrowserSettings["endpointSource"];
+	autoLaunchSource: EffectiveBrowserSettings["autoLaunchSource"];
 	browserExecutable?: string;
 	extensionPaths: string[];
 	browserExecutableSource: EffectiveBrowserSettings["executablePathSource"];
@@ -71,29 +78,19 @@ export interface BrowserCandidate extends BrowserCandidateDefinition {
 	resolvedExecutable: string;
 }
 
-export function parseConfiguredPort(value: string | undefined) {
-	if (value === undefined) return undefined;
-	const trimmedValue = value.trim();
-	if (!/^\d+$/.test(trimmedValue)) return undefined;
-	const port = Number(trimmedValue);
-	if (!Number.isInteger(port) || port < 1 || port > 65_535) return undefined;
-	return port;
-}
-
-const configuredHost = process.env.PI_CHROME_DEVTOOLS_HOST ?? DEFAULT_HOST;
-const configuredPortOverride = parseConfiguredPort(process.env.PI_CHROME_DEVTOOLS_PORT);
-const configuredPort = configuredPortOverride ?? DEFAULT_PORT;
+export { parseConfiguredPort };
 
 export const state: ChromeDevToolsState = {
-	host: configuredHost,
-	port: configuredPort,
-	configuredPort,
-	hostConfigured: process.env.PI_CHROME_DEVTOOLS_HOST !== undefined,
-	portConfigured: configuredPortOverride !== undefined,
-	autoLaunchEnabled: process.env.PI_CHROME_DEVTOOLS_AUTO_LAUNCH !== "0",
-	browserExecutable: process.env.PI_CHROME_DEVTOOLS_BROWSER,
+	host: DEFAULT_HOST,
+	port: DEFAULT_PORT,
+	configuredPort: DEFAULT_PORT,
+	hostConfigured: false,
+	portConfigured: false,
+	autoLaunchEnabled: true,
+	endpointSource: "default",
+	autoLaunchSource: "default",
 	extensionPaths: [],
-	browserExecutableSource: process.env.PI_CHROME_DEVTOOLS_BROWSER ? "environment" : "default",
+	browserExecutableSource: "default",
 	extensionPathsSource: "default",
 	projectSettingsTrusted: false,
 	shuttingDown: false,
@@ -106,6 +103,14 @@ export function applyRuntimeBrowserSettings(
 	paths: { user: string; project?: string },
 	projectTrusted: boolean,
 ) {
+	state.host = browser.host;
+	state.port = browser.port;
+	state.configuredPort = browser.port;
+	state.hostConfigured = browser.hostConfigured;
+	state.portConfigured = browser.portConfigured;
+	state.autoLaunchEnabled = browser.autoLaunchEnabled;
+	state.endpointSource = browser.endpointSource;
+	state.autoLaunchSource = browser.autoLaunchSource;
 	state.browserExecutable = browser.executablePath;
 	state.extensionPaths = [...browser.extensionPaths];
 	state.browserExecutableSource = browser.executablePathSource;

--- a/packages/pi-chrome-devtools/src/settings.ts
+++ b/packages/pi-chrome-devtools/src/settings.ts
@@ -23,11 +23,36 @@ export interface ChromeDevToolsSettings {
 	updatedAt: number;
 }
 
+export const DEFAULT_BROWSER_HOST = "127.0.0.1";
+export const DEFAULT_BROWSER_PORT = 9222;
+export const DEFAULT_BROWSER_ENDPOINT = `http://${DEFAULT_BROWSER_HOST}:${DEFAULT_BROWSER_PORT}`;
+
 export type BrowserSettingsSource = "default" | "environment" | "project" | "user";
 
+export interface UserBrowserSettings {
+	endpoint?: string;
+	autoLaunch?: boolean;
+	executablePath?: string;
+	extensionPaths?: string[];
+}
+
+export interface BrowserSettingsPatch {
+	endpoint?: string | null;
+	autoLaunch?: boolean | null;
+	executablePath?: string | null;
+}
+
 export interface EffectiveBrowserSettings {
+	endpoint: string;
+	host: string;
+	port: number;
+	hostConfigured: boolean;
+	portConfigured: boolean;
+	autoLaunchEnabled: boolean;
 	executablePath?: string;
 	extensionPaths: string[];
+	endpointSource: BrowserSettingsSource;
+	autoLaunchSource: BrowserSettingsSource;
 	executablePathSource: BrowserSettingsSource;
 	extensionPathsSource: BrowserSettingsSource;
 }
@@ -60,15 +85,10 @@ export interface SettingsFileOperations {
 	rename(source: string, destination: string): Promise<void>;
 }
 
-interface NormalizedBrowserSection {
-	executablePath?: string;
-	extensionPaths?: string[];
-}
-
 interface NormalizedSettingsDocument {
 	tools?: ChromeDevToolsToolName[];
 	updatedAt?: number;
-	browser?: NormalizedBrowserSection;
+	browser?: UserBrowserSettings;
 }
 
 interface SettingsDocumentResult {
@@ -85,6 +105,10 @@ const DEFAULT_FILE_OPERATIONS: SettingsFileOperations = {
 };
 
 let settingsSaveQueue = Promise.resolve();
+
+export async function waitForSettingsWrites() {
+	await settingsSaveQueue;
+}
 
 export async function loadSettings(options: SettingsLoadOptions = {}): Promise<SettingsLoadResult> {
 	await settingsSaveQueue;
@@ -127,10 +151,11 @@ export async function loadSettings(options: SettingsLoadOptions = {}): Promise<S
 		warnings.push(...project.warnings);
 	}
 
-	const effectiveBrowser = resolveEffectiveBrowser(
-		user.normalized?.browser,
-		project.normalized?.browser,
-	);
+	const environmentWarning = deprecatedEnvironmentWarning();
+	if (environmentWarning) warnings.push(environmentWarning);
+
+	const userBrowser = user.normalized?.browser ?? {};
+	const effectiveBrowser = resolveEffectiveBrowser(userBrowser, project.normalized?.browser);
 	const settings = resolveSettings(user.normalized, project.normalized, effectiveBrowser);
 	const recognized =
 		settings.tools !== undefined ||
@@ -166,26 +191,67 @@ function resolveSettings(
 }
 
 function resolveEffectiveBrowser(
-	user: NormalizedBrowserSection | undefined,
-	project: NormalizedBrowserSection | undefined,
+	user: UserBrowserSettings,
+	project: UserBrowserSettings | undefined,
 ): EffectiveBrowserSettings {
+	const configuredEndpoint = parseBrowserEndpoint(user.endpoint ?? DEFAULT_BROWSER_ENDPOINT);
+	const environmentHost = process.env.PI_CHROME_DEVTOOLS_HOST;
+	const environmentPortValue = process.env.PI_CHROME_DEVTOOLS_PORT;
+	const environmentPort = parseConfiguredPort(environmentPortValue);
+	const environmentEndpointConfigured =
+		environmentHost !== undefined || environmentPort !== undefined;
+	const host = environmentHost ?? configuredEndpoint.host;
+	const port = environmentPort ?? configuredEndpoint.port;
+	const environmentAutoLaunch = process.env.PI_CHROME_DEVTOOLS_AUTO_LAUNCH;
 	const environmentExecutable = process.env.PI_CHROME_DEVTOOLS_BROWSER;
-	const executablePath = environmentExecutable || user?.executablePath;
-	const extensionPaths = project?.extensionPaths ?? user?.extensionPaths ?? [];
+	const executablePath = environmentExecutable || user.executablePath;
+	const extensionPaths = project?.extensionPaths ?? user.extensionPaths ?? [];
+	const endpointSource: BrowserSettingsSource = environmentEndpointConfigured
+		? "environment"
+		: user.endpoint
+			? "user"
+			: "default";
 	return {
+		endpoint: formatBrowserEndpoint(host, port),
+		host,
+		port,
+		hostConfigured: environmentHost !== undefined || user.endpoint !== undefined,
+		portConfigured: environmentPort !== undefined || user.endpoint !== undefined,
+		autoLaunchEnabled:
+			environmentAutoLaunch === undefined
+				? (user.autoLaunch ?? true)
+				: environmentAutoLaunch !== "0",
 		...(executablePath ? { executablePath } : {}),
 		extensionPaths: [...extensionPaths],
+		endpointSource,
+		autoLaunchSource:
+			environmentAutoLaunch !== undefined
+				? "environment"
+				: user.autoLaunch !== undefined
+					? "user"
+					: "default",
 		executablePathSource: environmentExecutable
 			? "environment"
-			: user?.executablePath
+			: user.executablePath
 				? "user"
 				: "default",
 		extensionPathsSource: project?.extensionPaths
 			? "project"
-			: user?.extensionPaths
+			: user.extensionPaths
 				? "user"
 				: "default",
 	};
+}
+
+function deprecatedEnvironmentWarning() {
+	const configuredNames = [
+		"PI_CHROME_DEVTOOLS_HOST",
+		"PI_CHROME_DEVTOOLS_PORT",
+		"PI_CHROME_DEVTOOLS_AUTO_LAUNCH",
+		"PI_CHROME_DEVTOOLS_BROWSER",
+	].filter((name) => process.env[name] !== undefined);
+	if (configuredNames.length === 0) return undefined;
+	return `Chrome DevTools environment settings are deprecated and will be removed in a future version: ${configuredNames.join(", ")}. Move them to browser.endpoint, browser.autoLaunch, and browser.executablePath in ${settingsFilePath()}. Environment values remain active overrides during the deprecation period.`;
 }
 
 async function readSettingsDocument(
@@ -214,7 +280,7 @@ async function readSettingsDocument(
 		return { kind: "invalid", reason, warnings: [`Chrome DevTools settings ignored: ${reason}`] };
 	}
 
-	const scopeWarnings = projectExecutableWarnings(parsed, scope, filePath);
+	const scopeWarnings = projectMachineSettingsWarnings(parsed, scope, filePath);
 	try {
 		const normalized = await normalizeSettingsDocument(parsed, scope, filePath, cwd);
 		return { kind: "valid", document: { ...parsed }, normalized, warnings: scopeWarnings };
@@ -228,21 +294,19 @@ async function readSettingsDocument(
 	}
 }
 
-function projectExecutableWarnings(
+function projectMachineSettingsWarnings(
 	document: Record<string, unknown>,
 	scope: "project" | "user",
 	filePath: string,
 ) {
-	if (
-		scope !== "project" ||
-		!isRecord(document.browser) ||
-		document.browser.executablePath === undefined
-	) {
-		return [];
-	}
-	return [
-		`Chrome DevTools project browser.executablePath ignored in ${filePath}; configure the machine-owned executable in ${settingsFilePath()}.`,
-	];
+	if (scope !== "project" || !isRecord(document.browser)) return [];
+	const browser = document.browser;
+	return ["endpoint", "autoLaunch", "executablePath"]
+		.filter((field) => browser[field] !== undefined)
+		.map(
+			(field) =>
+				`Chrome DevTools project browser.${field} ignored in ${filePath}; configure this machine-owned setting in ${settingsFilePath()}.`,
+		);
 }
 
 async function normalizeSettingsDocument(
@@ -277,8 +341,20 @@ async function normalizeBrowserSection(
 	scope: "project" | "user",
 	_filePath: string,
 	cwd?: string,
-): Promise<NormalizedBrowserSection> {
-	const normalized: NormalizedBrowserSection = {};
+): Promise<UserBrowserSettings> {
+	const normalized: UserBrowserSettings = {};
+	if (scope === "user" && browser.endpoint !== undefined) {
+		if (typeof browser.endpoint !== "string") {
+			throw new Error("expected browser.endpoint to be an HTTP URL with an explicit port");
+		}
+		normalized.endpoint = parseBrowserEndpoint(browser.endpoint).endpoint;
+	}
+	if (scope === "user" && browser.autoLaunch !== undefined) {
+		if (typeof browser.autoLaunch !== "boolean") {
+			throw new Error("expected browser.autoLaunch to be a boolean");
+		}
+		normalized.autoLaunch = browser.autoLaunch;
+	}
 	if (scope === "user" && browser.executablePath !== undefined) {
 		if (typeof browser.executablePath !== "string" || browser.executablePath.length === 0) {
 			throw new Error("expected browser.executablePath to be a non-empty absolute path");
@@ -350,6 +426,52 @@ async function validateUnpackedExtensionPath(extensionPath: string) {
 	return canonicalPath;
 }
 
+export function parseBrowserEndpoint(value: string) {
+	const trimmedValue = value.trim();
+	const explicitPort = trimmedValue.match(/^http:\/\/(?:\[[^\]]+\]|[^/:?#]+):(\d+)\/?$/i)?.[1];
+	let endpoint: URL;
+	try {
+		endpoint = new URL(trimmedValue);
+	} catch {
+		throw new Error("browser.endpoint must be a valid HTTP URL with an explicit port");
+	}
+	if (
+		endpoint.protocol !== "http:" ||
+		endpoint.username ||
+		endpoint.password ||
+		!endpoint.hostname ||
+		!explicitPort ||
+		(endpoint.pathname !== "/" && endpoint.pathname !== "") ||
+		endpoint.search ||
+		endpoint.hash
+	) {
+		throw new Error(
+			"browser.endpoint must be an HTTP origin with an explicit port and no credentials, path, query, or fragment",
+		);
+	}
+	const port = parseConfiguredPort(explicitPort);
+	if (port === undefined) {
+		throw new Error("browser.endpoint must use a port from 1 through 65535");
+	}
+	const host = endpoint.hostname;
+	return { endpoint: formatBrowserEndpoint(host, port), host, port };
+}
+
+export function parseConfiguredPort(value: string | undefined) {
+	if (value === undefined) return undefined;
+	const trimmedValue = value.trim();
+	if (!/^\d+$/.test(trimmedValue)) return undefined;
+	const port = Number(trimmedValue);
+	if (!Number.isInteger(port) || port < 1 || port > 65_535) return undefined;
+	return port;
+}
+
+function formatBrowserEndpoint(host: string, port: number) {
+	const formattedHost =
+		host.startsWith("[") && host.endsWith("]") ? host : host.includes(":") ? `[${host}]` : host;
+	return `http://${formattedHost}:${port}`;
+}
+
 export function normalizeChromeDevtoolsSettings(
 	value: unknown,
 ): ChromeDevToolsSettings | undefined {
@@ -381,13 +503,48 @@ export function saveSettings(
 	settings: ChromeDevToolsSettings,
 	operations: Partial<SettingsFileOperations> = {},
 ): Promise<void> {
-	const operation = settingsSaveQueue.then(() => saveSettingsNow(settings, operations));
+	return queueSettingsMutation(
+		(current) => ({
+			...current,
+			tools: [...settings.tools],
+			updatedAt: settings.updatedAt,
+		}),
+		operations,
+	);
+}
+
+export function saveBrowserSettings(
+	patch: BrowserSettingsPatch,
+	operations: Partial<SettingsFileOperations> = {},
+): Promise<void> {
+	return queueSettingsMutation(async (current) => {
+		const browser = isRecord(current.browser) ? { ...current.browser } : {};
+		for (const field of ["endpoint", "autoLaunch", "executablePath"] as const) {
+			const value = patch[field];
+			if (value === undefined) continue;
+			if (value === null) delete browser[field];
+			else browser[field] = value;
+		}
+		await normalizeBrowserSection(browser, "user", settingsFilePath());
+		return { ...current, browser };
+	}, operations);
+}
+
+function queueSettingsMutation(
+	mutate: (
+		current: Record<string, unknown>,
+	) => Record<string, unknown> | Promise<Record<string, unknown>>,
+	operations: Partial<SettingsFileOperations>,
+) {
+	const operation = settingsSaveQueue.then(() => saveSettingsMutationNow(mutate, operations));
 	settingsSaveQueue = operation.catch(() => undefined);
 	return operation;
 }
 
-async function saveSettingsNow(
-	settings: ChromeDevToolsSettings,
+async function saveSettingsMutationNow(
+	mutate: (
+		current: Record<string, unknown>,
+	) => Record<string, unknown> | Promise<Record<string, unknown>>,
 	operations: Partial<SettingsFileOperations>,
 ): Promise<void> {
 	const filePath = settingsFilePath();
@@ -397,11 +554,7 @@ async function saveSettingsNow(
 	if (current.kind === "invalid") {
 		throw new Error(`Cannot save Chrome DevTools settings until you repair ${current.reason}`);
 	}
-	const nextDocument = {
-		...(current.document ?? {}),
-		tools: [...settings.tools],
-		updatedAt: settings.updatedAt,
-	};
+	const nextDocument = await mutate(current.document ?? {});
 	await mkdir(dirname(filePath), { recursive: true });
 	const tempFile = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
 	try {

--- a/packages/pi-chrome-devtools/src/settings.ts
+++ b/packages/pi-chrome-devtools/src/settings.ts
@@ -68,9 +68,14 @@ export interface SettingsLoadOptions {
 	projectTrusted?: boolean;
 }
 
+export type UserSettingsFileStatus =
+	| { kind: "missing" | "valid" }
+	| { kind: "invalid"; reason: string };
+
 interface SettingsLoadBase {
 	effectiveBrowser: EffectiveBrowserSettings;
 	paths: { user: string; project?: string };
+	userFile: UserSettingsFileStatus;
 	warnings: string[];
 	notice?: string;
 }
@@ -165,9 +170,17 @@ export async function loadSettings(options: SettingsLoadOptions = {}): Promise<S
 		.filter((result) => result.kind === "invalid")
 		.map((result) => result.reason)
 		.filter((reason): reason is string => Boolean(reason));
+	const userFile: UserSettingsFileStatus =
+		user.kind === "invalid"
+			? {
+					kind: "invalid",
+					reason: user.reason ?? `${userPath}: invalid settings`,
+				}
+			: { kind: user.kind };
 	const base = {
 		effectiveBrowser,
 		paths,
+		userFile,
 		warnings,
 		...(warnings.length > 0 ? { notice: warnings.join("\n") } : {}),
 	};

--- a/packages/pi-chrome-devtools/src/tool-selector.ts
+++ b/packages/pi-chrome-devtools/src/tool-selector.ts
@@ -268,10 +268,11 @@ function browserSettingsStatusLines() {
 					`Project settings: ${state.projectSettingsFilePath} (${state.projectSettingsTrusted ? "trusted" : "untrusted; ignored"})`,
 				]
 			: []),
+		`Auto-launch: ${state.autoLaunchEnabled ? "on" : "off"} (${state.autoLaunchSource})`,
 		`Browser executable: ${state.browserExecutable ?? "automatic discovery"} (${state.browserExecutableSource})`,
 		`Unpacked extensions (${state.extensionPathsSource}):`,
 		...extensionLines,
-		"Settings changes apply to a new managed browser after /reload or session replacement.",
+		"Confirmed menu settings apply before the next browser connection; manual JSON edits require /reload or session replacement.",
 		...(state.extensionPaths.length > 0
 			? [
 					"Unpacked extensions require Chrome for Testing or Chromium and execute trusted browser code.",
@@ -287,6 +288,7 @@ export function buildCommandGuide() {
 		"/chrome-devtools help — show command usage",
 		"/chrome-devtools quickstart — show endpoint and launch help",
 		"/chrome-devtools status — show tool and settings status",
+		"/chrome-devtools settings — edit browser connection settings",
 		"/chrome-devtools tools — choose tools available to lazy-load",
 		"/chrome-devtools toggle|select — compatibility aliases for tools",
 		"/chrome-devtools enable|on — make all Chrome DevTools tools available to lazy-load",

--- a/packages/pi-chrome-devtools/test/browser-settings-menu.test.ts
+++ b/packages/pi-chrome-devtools/test/browser-settings-menu.test.ts
@@ -1,0 +1,284 @@
+import assert from "node:assert/strict";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { showChromeDevtoolsBrowserSettings } from "../src/browser-settings-menu.js";
+import chromeDevtools from "../src/chrome-devtools.js";
+import { state } from "../src/runtime.js";
+import { settingsFilePath } from "../src/settings.js";
+
+class OwnedBrowserChild extends EventEmitter {
+	killCalls = 0;
+
+	kill() {
+		this.killCalls += 1;
+		queueMicrotask(() => this.emit("exit", 0, null));
+		return true;
+	}
+}
+
+const ENVIRONMENT_NAMES = [
+	"PI_CHROME_DEVTOOLS_HOST",
+	"PI_CHROME_DEVTOOLS_PORT",
+	"PI_CHROME_DEVTOOLS_AUTO_LAUNCH",
+	"PI_CHROME_DEVTOOLS_BROWSER",
+] as const;
+
+async function withBrowserSettingsMenu(
+	run: (fixture: {
+		directory: string;
+		ctx: ReturnType<typeof createMockContext>["ctx"];
+		notifications: ReturnType<typeof createMockContext>["notifications"];
+		tui: ReturnType<typeof createTuiHarness>;
+		generation: number;
+	}) => Promise<void>,
+) {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-cdp-browser-menu-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const previousEnvironment = Object.fromEntries(
+		ENVIRONMENT_NAMES.map((name) => [name, process.env[name]]),
+	) as Record<(typeof ENVIRONMENT_NAMES)[number], string | undefined>;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	for (const name of ENVIRONMENT_NAMES) delete process.env[name];
+	state.sessionController.abort();
+	state.sessionController = new AbortController();
+	const generation = ++state.sessionGeneration;
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	const mock = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	try {
+		await run({ directory, ctx: mock.ctx, notifications: mock.notifications, tui, generation });
+	} finally {
+		tui.dispose();
+		state.sessionController.abort();
+		state.sessionController = new AbortController();
+		state.sessionGeneration += 1;
+		state.managedBrowser = undefined;
+		state.launchPromise = undefined;
+		state.lastLaunchAttempt = undefined;
+		state.settingsNotice = undefined;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		for (const name of ENVIRONMENT_NAMES) {
+			const previous = previousEnvironment[name];
+			if (previous === undefined) delete process.env[name];
+			else process.env[name] = previous;
+		}
+		rmSync(directory, { recursive: true, force: true });
+	}
+}
+
+function readSettings() {
+	return JSON.parse(readFileSync(settingsFilePath(), "utf8")) as Record<string, unknown>;
+}
+
+test("browser settings save endpoint and auto-launch immediately while preserving unknown fields", async () => {
+	await withBrowserSettingsMenu(async ({ ctx, notifications, tui, generation }) => {
+		writeFileSync(
+			settingsFilePath(),
+			'{"future":{"kept":true},"browser":{"futureBrowserField":"kept"}}\n',
+		);
+		const running = showChromeDevtoolsBrowserSettings(ctx, generation);
+		await tui.waitForOpen();
+		const initial = tui.render().join("\n");
+		assert.match(initial, /Browser settings/);
+		assert.match(initial, /DevTools endpoint\s+http:\/\/127\.0\.0\.1:9222/);
+		assert.match(initial, /Auto-launch\s+On/);
+		assert.match(initial, /Browser executable\s+Automatic/);
+		assert.match(initial, /Unpacked extensions\s+0 configured/);
+		assert.ok(tui.resize({ width: 28 }).every((line) => visibleWidth(line) <= 28));
+		tui.resize({ width: 80 });
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /DevTools endpoint/);
+		tui.setFocused(true);
+		tui.type("http://localhost:9333");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /DevTools endpoint\s+http:\/\/localhost:9333/);
+		assert.equal(state.host, "localhost");
+		assert.equal(state.port, 9333);
+		assert.equal(state.endpointSource, "user");
+
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(state.autoLaunchEnabled, false);
+		assert.equal(state.autoLaunchSource, "user");
+		assert.deepEqual(readSettings(), {
+			future: { kept: true },
+			browser: {
+				futureBrowserField: "kept",
+				endpoint: "http://localhost:9333",
+				autoLaunch: false,
+			},
+		});
+		assert.ok(notifications.some(({ message }) => /endpoint saved/i.test(message)));
+		assert.ok(notifications.some(({ message }) => /auto-launch: Off/i.test(message)));
+		tui.press("ctrl+c");
+		assert.deepEqual(await running, { closeParent: true });
+	});
+});
+
+test("a successful browser setting closes only the extension-owned managed browser", async () => {
+	await withBrowserSettingsMenu(async ({ directory, ctx, tui, generation }) => {
+		const child = new OwnedBrowserChild();
+		const profile = path.join(directory, "managed-profile");
+		mkdirSync(profile);
+		state.managedBrowser = {
+			process: child as unknown as ChildProcess,
+			userDataDir: profile,
+			exited: false,
+			ready: true,
+			ownerGeneration: generation,
+		};
+		const running = showChromeDevtoolsBrowserSettings(ctx, generation);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+
+		assert.equal(child.killCalls, 1);
+		assert.equal(state.managedBrowser, undefined);
+		assert.equal(existsSync(profile), false);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("browser settings edit and reset the executable through the same user JSON", async () => {
+	await withBrowserSettingsMenu(async ({ directory, ctx, tui, generation }) => {
+		const executable = path.join(directory, "chrome-for-testing");
+		writeFileSync(executable, "browser");
+		const running = showChromeDevtoolsBrowserSettings(ctx, generation);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.setFocused(true);
+		tui.type(executable);
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal((readSettings().browser as Record<string, unknown>).executablePath, executable);
+		assert.equal(state.browserExecutable, executable);
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.setFocused(true);
+		tui.type("automatic");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.deepEqual(readSettings().browser, {});
+		assert.equal(state.browserExecutable, undefined);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("browser settings cancellation and invalid files remain read-only", async () => {
+	await withBrowserSettingsMenu(async ({ ctx, tui, generation }) => {
+		const cancelled = showChromeDevtoolsBrowserSettings(ctx, generation);
+		await tui.waitForOpen();
+		tui.press("tui.select.cancel");
+		assert.deepEqual(await cancelled, { closeParent: false });
+		assert.equal(existsSync(settingsFilePath()), false);
+
+		writeFileSync(settingsFilePath(), "{ invalid\n");
+		const invalid = showChromeDevtoolsBrowserSettings(ctx, generation);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Read only/);
+		assert.match(tui.render().join("\n"), /invalid JSON/);
+		tui.press("tui.select.cancel");
+		await invalid;
+		assert.equal(readFileSync(settingsFilePath(), "utf8"), "{ invalid\n");
+	});
+});
+
+test("a failed browser settings save restores the accepted value and retains the input draft", async () => {
+	await withBrowserSettingsMenu(async ({ ctx, notifications, tui, generation }) => {
+		const running = showChromeDevtoolsBrowserSettings(ctx, generation);
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		mkdirSync(settingsFilePath());
+		tui.setFocused(true);
+		tui.type("http://localhost:9333");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		assert.match(tui.render().join("\n"), /http:\/\/localhost:9333/);
+		assert.equal(state.host, "127.0.0.1");
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/save failed.*previous settings remain active/i,
+		);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("the direct settings command dispatches the same RPC workflow", async () => {
+	await withBrowserSettingsMenu(async () => {
+		const mockPi = createMockPi();
+		chromeDevtools(mockPi.pi);
+		let selectCalls = 0;
+		const mock = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			select: async () => {
+				selectCalls += 1;
+				return undefined;
+			},
+		});
+
+		await mockPi.commands.get("chrome-devtools")?.handler("settings", mock.ctx);
+
+		assert.equal(selectCalls, 1);
+	});
+});
+
+test("RPC browser settings use standard selectors and input without custom TUI", async () => {
+	await withBrowserSettingsMenu(async ({ generation }) => {
+		let settingsDialogs = 0;
+		let customCalls = 0;
+		const mock = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			select: async (_title: string, options: string[]) => {
+				settingsDialogs += 1;
+				if (settingsDialogs === 1) {
+					return options.find((option) => option.includes("DevTools endpoint"));
+				}
+				return undefined;
+			},
+			input: async () => "http://localhost:9444",
+			custom: async () => {
+				customCalls += 1;
+			},
+		});
+
+		await showChromeDevtoolsBrowserSettings(mock.ctx, generation);
+
+		assert.equal(customCalls, 0);
+		assert.equal(
+			(readSettings().browser as Record<string, unknown>).endpoint,
+			"http://localhost:9444",
+		);
+		assert.equal(state.port, 9444);
+	});
+});

--- a/packages/pi-chrome-devtools/test/browser-settings-menu.test.ts
+++ b/packages/pi-chrome-devtools/test/browser-settings-menu.test.ts
@@ -10,8 +10,8 @@ import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { showChromeDevtoolsBrowserSettings } from "../src/browser-settings-menu.js";
 import chromeDevtools from "../src/chrome-devtools.js";
-import { state } from "../src/runtime.js";
-import { settingsFilePath } from "../src/settings.js";
+import { DEFAULT_HOST, DEFAULT_PORT, state } from "../src/runtime.js";
+import { projectSettingsFilePath, settingsFilePath } from "../src/settings.js";
 
 class OwnedBrowserChild extends EventEmitter {
 	killCalls = 0;
@@ -30,6 +30,28 @@ const ENVIRONMENT_NAMES = [
 	"PI_CHROME_DEVTOOLS_BROWSER",
 ] as const;
 
+function resetBrowserRuntimeState() {
+	state.host = DEFAULT_HOST;
+	state.port = DEFAULT_PORT;
+	state.configuredPort = DEFAULT_PORT;
+	state.hostConfigured = false;
+	state.portConfigured = false;
+	state.autoLaunchEnabled = true;
+	state.endpointSource = "default";
+	state.autoLaunchSource = "default";
+	state.browserExecutable = undefined;
+	state.extensionPaths = [];
+	state.browserExecutableSource = "default";
+	state.extensionPathsSource = "default";
+	state.settingsFilePath = undefined;
+	state.projectSettingsFilePath = undefined;
+	state.projectSettingsTrusted = false;
+	state.managedBrowser = undefined;
+	state.launchPromise = undefined;
+	state.lastLaunchAttempt = undefined;
+	state.settingsNotice = undefined;
+}
+
 async function withBrowserSettingsMenu(
 	run: (fixture: {
 		directory: string;
@@ -46,6 +68,7 @@ async function withBrowserSettingsMenu(
 	) as Record<(typeof ENVIRONMENT_NAMES)[number], string | undefined>;
 	process.env.PI_CODING_AGENT_DIR = directory;
 	for (const name of ENVIRONMENT_NAMES) delete process.env[name];
+	resetBrowserRuntimeState();
 	state.sessionController.abort();
 	state.sessionController = new AbortController();
 	const generation = ++state.sessionGeneration;
@@ -58,10 +81,7 @@ async function withBrowserSettingsMenu(
 		state.sessionController.abort();
 		state.sessionController = new AbortController();
 		state.sessionGeneration += 1;
-		state.managedBrowser = undefined;
-		state.launchPromise = undefined;
-		state.lastLaunchAttempt = undefined;
-		state.settingsNotice = undefined;
+		resetBrowserRuntimeState();
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		for (const name of ENVIRONMENT_NAMES) {
@@ -126,6 +146,29 @@ test("browser settings save endpoint and auto-launch immediately while preservin
 		assert.ok(notifications.some(({ message }) => /auto-launch: Off/i.test(message)));
 		tui.press("ctrl+c");
 		assert.deepEqual(await running, { closeParent: true });
+	});
+});
+
+test("browser settings report the effective value when an environment override shadows a save", async () => {
+	await withBrowserSettingsMenu(async ({ ctx, notifications, tui, generation }) => {
+		process.env.PI_CHROME_DEVTOOLS_AUTO_LAUNCH = "1";
+		const running = showChromeDevtoolsBrowserSettings(ctx, generation);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+
+		assert.equal((readSettings().browser as Record<string, unknown>).autoLaunch, false);
+		assert.equal(state.autoLaunchEnabled, true);
+		assert.equal(state.autoLaunchSource, "environment");
+		assert.match(
+			notifications.at(-1)?.message ?? "",
+			/Effective auto-launch: On \(environment\).*environment override remains effective/i,
+		);
+		assert.doesNotMatch(notifications.at(-1)?.message ?? "", /auto-launch: Off/);
+		tui.press("ctrl+c");
+		await running;
 	});
 });
 
@@ -206,6 +249,42 @@ test("browser settings cancellation and invalid files remain read-only", async (
 		tui.press("tui.select.cancel");
 		await invalid;
 		assert.equal(readFileSync(settingsFilePath(), "utf8"), "{ invalid\n");
+	});
+});
+
+test("an invalid trusted project file warns without blocking user browser settings", async () => {
+	await withBrowserSettingsMenu(async ({ directory, tui, generation }) => {
+		const projectPath = projectSettingsFilePath(directory);
+		mkdirSync(path.dirname(projectPath), { recursive: true });
+		writeFileSync(projectPath, "{ invalid project JSON\n");
+		const mock = createMockContext({
+			cwd: directory,
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			isProjectTrusted: () => true,
+		});
+		const running = showChromeDevtoolsBrowserSettings(mock.ctx, generation);
+		await tui.waitForOpen();
+		const rendered = tui.render().join("\n");
+		assert.match(rendered, /DevTools endpoint/);
+		assert.match(rendered, /invalid JSON/);
+		assert.doesNotMatch(rendered, /Read only/);
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.setFocused(true);
+		tui.type("http://localhost:9555");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(
+			(readSettings().browser as Record<string, unknown>).endpoint,
+			"http://localhost:9555",
+		);
+		tui.press("ctrl+c");
+		await running;
 	});
 });
 

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -87,11 +87,15 @@ test("chrome-devtools registers deferred CDP tools and one loader", () => {
 test("chrome-devtools command parsing and completions cover aliases", () => {
 	assert.equal(parseCommand(""), "menu");
 	assert.equal(parseCommand("toggle"), "tools");
+	assert.equal(parseCommand("settings"), "settings");
 	assert.equal(parseCommand("on"), "enable");
 	assert.equal(parseCommand("off"), "disable");
 	assert.equal(parseCommand("wat"), "unknown");
 	assert.deepEqual(commandCompletions("qui"), [
 		{ value: "quickstart", label: "quickstart", description: "Show endpoint and launch help" },
+	]);
+	assert.deepEqual(commandCompletions("set"), [
+		{ value: "settings", label: "settings", description: "Edit browser connection settings" },
 	]);
 	assert.deepEqual(commandCompletions("sel"), [
 		{ value: "select", label: "select", description: "Compatibility alias for tools" },

--- a/packages/pi-chrome-devtools/test/lifecycle.test.ts
+++ b/packages/pi-chrome-devtools/test/lifecycle.test.ts
@@ -9,7 +9,7 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import { setBrowserManagerOperationsForTests } from "../src/browser-manager.js";
 import chromeDevtools from "../src/chrome-devtools.js";
 import { state } from "../src/runtime.js";
-import { projectSettingsFilePath, settingsFilePath } from "../src/settings.js";
+import { projectSettingsFilePath, saveBrowserSettings, settingsFilePath } from "../src/settings.js";
 
 class LifecycleChild extends EventEmitter {
 	killCalls = 0;
@@ -31,6 +31,15 @@ async function withFixture(
 ) {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-cdp-lifecycle-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const environmentNames = [
+		"PI_CHROME_DEVTOOLS_HOST",
+		"PI_CHROME_DEVTOOLS_PORT",
+		"PI_CHROME_DEVTOOLS_AUTO_LAUNCH",
+		"PI_CHROME_DEVTOOLS_BROWSER",
+	] as const;
+	const previousEnvironment = Object.fromEntries(
+		environmentNames.map((name) => [name, process.env[name]]),
+	) as Record<(typeof environmentNames)[number], string | undefined>;
 	const agentDir = path.join(root, "agent");
 	const cwdA = path.join(root, "project-a");
 	const cwdB = path.join(root, "project-b");
@@ -52,6 +61,7 @@ async function withFixture(
 	writeFileSync(executable, "#!/bin/sh\nexit 0\n");
 	chmodSync(executable, 0o755);
 	process.env.PI_CODING_AGENT_DIR = agentDir;
+	for (const name of environmentNames) delete process.env[name];
 	try {
 		await fn({ cwdA, cwdB, extensionA, extensionB, executable });
 	} finally {
@@ -61,6 +71,11 @@ async function withFixture(
 		state.launchPromise = undefined;
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		for (const name of environmentNames) {
+			const previous = previousEnvironment[name];
+			if (previous === undefined) delete process.env[name];
+			else process.env[name] = previous;
+		}
 		rmSync(root, { recursive: true, force: true });
 	}
 }
@@ -73,7 +88,12 @@ function writeJson(filePath: string, value: unknown) {
 test("session_start applies trusted project browser settings and status reports effective sources", async () => {
 	await withFixture(async ({ cwdA, extensionA, extensionB, executable }) => {
 		writeJson(settingsFilePath(), {
-			browser: { executablePath: executable, extensionPaths: [extensionA] },
+			browser: {
+				endpoint: "http://localhost:9333",
+				autoLaunch: false,
+				executablePath: executable,
+				extensionPaths: [extensionA],
+			},
 		});
 		writeJson(projectSettingsFilePath(cwdA), {
 			browser: { extensionPaths: [path.relative(cwdA, extensionB)] },
@@ -90,14 +110,45 @@ test("session_start applies trusted project browser settings and status reports 
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 		await mock.commands.get("chrome-devtools")?.handler("status", ctx);
 
+		assert.equal(state.host, "localhost");
+		assert.equal(state.port, 9333);
+		assert.equal(state.configuredPort, 9333);
+		assert.equal(state.autoLaunchEnabled, false);
+		assert.equal(state.endpointSource, "user");
+		assert.equal(state.autoLaunchSource, "user");
 		assert.deepEqual(state.extensionPaths, [extensionB]);
 		assert.equal(state.browserExecutable, executable);
 		assert.equal(state.extensionPathsSource, "project");
 		const status = notifications.at(-1)?.message ?? "";
 		assert.match(status, new RegExp(`Project settings: .*${path.basename(cwdA)}.*trusted`));
+		assert.match(status, /Endpoint source: user/);
+		assert.match(status, /Auto-launch: off \(user\)/);
 		assert.match(status, /Unpacked extensions \(project\)/);
 		assert.match(status, /Chrome for Testing or Chromium/);
-		assert.match(status, /after \/reload or session replacement/);
+		assert.match(status, /manual JSON edits require \/reload or session replacement/);
+	});
+});
+
+test("session start warns when deprecated environment overrides remain active", async () => {
+	await withFixture(async ({ cwdA }) => {
+		writeJson(settingsFilePath(), {
+			browser: { endpoint: "http://json.example:9333", autoLaunch: false },
+		});
+		process.env.PI_CHROME_DEVTOOLS_HOST = "127.0.0.1";
+		process.env.PI_CHROME_DEVTOOLS_PORT = "9444";
+		const mock = createMockPi();
+		const { ctx, notifications } = createMockContext({ cwd: cwdA });
+		chromeDevtools(mock.pi);
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.equal(state.host, "127.0.0.1");
+		assert.equal(state.port, 9444);
+		assert.equal(state.endpointSource, "environment");
+		assert.equal(notifications.length, 1);
+		assert.equal(notifications[0]?.level, "warning");
+		assert.match(notifications[0]?.message ?? "", /environment settings are deprecated/i);
+		assert.match(notifications[0]?.message ?? "", /browser\.endpoint/);
 	});
 });
 
@@ -121,6 +172,44 @@ test("session replacement discards the stale continuation and applies only the l
 
 		assert.deepEqual(state.extensionPaths, [extensionB]);
 		assert.equal(state.projectSettingsFilePath, projectSettingsFilePath(cwdB));
+	});
+});
+
+test("session shutdown waits for an in-flight browser settings publication", async () => {
+	await withFixture(async () => {
+		let markWriteStarted: (() => void) | undefined;
+		const writeStarted = new Promise<void>((resolve) => {
+			markWriteStarted = resolve;
+		});
+		let releaseWrite: (() => void) | undefined;
+		const writeBlocked = new Promise<void>((resolve) => {
+			releaseWrite = resolve;
+		});
+		const save = saveBrowserSettings(
+			{ autoLaunch: false },
+			{
+				write: async (temporaryPath, data) => {
+					writeFileSync(temporaryPath, data);
+					markWriteStarted?.();
+					await writeBlocked;
+				},
+			},
+		);
+		await writeStarted;
+		const mock = createMockPi();
+		const { ctx } = createMockContext();
+		chromeDevtools(mock.pi);
+		let shutdownSettled = false;
+		const shutdown = Promise.resolve(mock.events.get("session_shutdown")?.[0]?.({}, ctx)).then(
+			() => {
+				shutdownSettled = true;
+			},
+		);
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+		assert.equal(shutdownSettled, false);
+		releaseWrite?.();
+		await Promise.all([save, shutdown]);
+		assert.equal(shutdownSettled, true);
 	});
 });
 

--- a/packages/pi-chrome-devtools/test/managed-browser.test.ts
+++ b/packages/pi-chrome-devtools/test/managed-browser.test.ts
@@ -34,6 +34,8 @@ function resetRuntime(overrides: Partial<typeof state> = {}) {
 		hostConfigured: false,
 		portConfigured: false,
 		autoLaunchEnabled: true,
+		endpointSource: "default",
+		autoLaunchSource: "default",
 		browserExecutable: "/test/chrome-for-testing",
 		extensionPaths: ["/test/extension-a", "/test/extension-b"],
 		browserExecutableSource: "user",

--- a/packages/pi-chrome-devtools/test/menu.test.ts
+++ b/packages/pi-chrome-devtools/test/menu.test.ts
@@ -49,7 +49,7 @@ test("main menu presents consequential state and five goal-oriented actions with
 		assert.match(rendered, /[→›] Choose available browser tools…/);
 		assert.match(rendered, /Make all browser tools available…/);
 		assert.match(rendered, /Browser status/);
-		assert.match(rendered, /Settings & setup/);
+		assert.match(rendered, /Browser settings/);
 		assert.match(rendered, /Help/);
 		assert.equal(state.managedBrowser, undefined);
 		assert.equal(state.launchPromise, undefined);
@@ -230,12 +230,14 @@ test("bulk preview and nested detail navigation return without side effects", as
 				}
 				if (
 					rendered.startsWith("Browser status") ||
-					rendered.startsWith("Settings & setup") ||
+					(rendered.includes("DevTools endpoint") && rendered.includes("Auto-launch")) ||
 					rendered.startsWith("Chrome DevTools help")
 				) {
 					details.push(rendered);
 					harness.setTerminalRows(8);
-					narrowDetails.push(harness.render(20));
+					const narrow = harness.render(20);
+					assert.ok(narrow.every((line) => visibleWidth(line) <= 20));
+					if (!rendered.includes("DevTools endpoint")) narrowDetails.push(narrow);
 					harness.handleInput("tui.select.cancel");
 					return harness.result;
 				}
@@ -255,8 +257,8 @@ test("bulk preview and nested detail navigation return without side effects", as
 
 		assert.match(details[0] ?? "", /Proposed availability: 5\/5/);
 		assert.match(details[1] ?? "", /does not probe the endpoint or launch Chrome/);
-		assert.match(details[2] ?? "", /Settings changes apply.*\/reload/s);
-		assert.match(details[3] ?? "", /\/chrome-devtools tools/);
+		assert.match(details[2] ?? "", /DevTools endpoint/);
+		assert.match(details[2] ?? "", /Auto-launch/);
 		assert.ok(narrowDetails.flat().every((line) => visibleWidth(line) <= 20));
 		assert.ok(narrowDetails.every((screen) => screen.length <= 5));
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool"]);
@@ -335,6 +337,7 @@ test("interactive routes reject unsupported modes while direct mutations remain 
 		await assert.rejects(() => invoke("help"), /requires TUI or RPC/);
 		await assert.rejects(() => invoke("status"), /requires TUI or RPC/);
 		await assert.rejects(() => invoke("quickstart"), /requires TUI or RPC/);
+		await assert.rejects(() => invoke("settings"), /requires TUI or RPC/);
 		await assert.rejects(() => invoke("tools"), /requires TUI or RPC/);
 		await invoke("disable");
 

--- a/packages/pi-chrome-devtools/test/settings.test.ts
+++ b/packages/pi-chrome-devtools/test/settings.test.ts
@@ -14,6 +14,7 @@ import { test } from "vitest";
 import {
 	loadSettings,
 	projectSettingsFilePath,
+	saveBrowserSettings,
 	saveSettings,
 	settingsFilePath,
 } from "../src/settings.js";
@@ -31,7 +32,15 @@ async function withSettingsFixture(
 ) {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-cdp-browser-settings-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	const previousBrowser = process.env.PI_CHROME_DEVTOOLS_BROWSER;
+	const environmentNames = [
+		"PI_CHROME_DEVTOOLS_HOST",
+		"PI_CHROME_DEVTOOLS_PORT",
+		"PI_CHROME_DEVTOOLS_AUTO_LAUNCH",
+		"PI_CHROME_DEVTOOLS_BROWSER",
+	] as const;
+	const previousEnvironment = Object.fromEntries(
+		environmentNames.map((name) => [name, process.env[name]]),
+	) as Record<(typeof environmentNames)[number], string | undefined>;
 	const agentDir = path.join(root, "agent");
 	const cwd = path.join(root, "project");
 	const extensionA = path.join(root, "extension-a");
@@ -44,14 +53,17 @@ async function withSettingsFixture(
 	writeFileSync(executable, "#!/bin/sh\nexit 0\n");
 	chmodSync(executable, 0o755);
 	process.env.PI_CODING_AGENT_DIR = agentDir;
-	delete process.env.PI_CHROME_DEVTOOLS_BROWSER;
+	for (const name of environmentNames) delete process.env[name];
 	try {
 		await fn({ agentDir, cwd, extensionA, extensionB, executable });
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-		if (previousBrowser === undefined) delete process.env.PI_CHROME_DEVTOOLS_BROWSER;
-		else process.env.PI_CHROME_DEVTOOLS_BROWSER = previousBrowser;
+		for (const name of environmentNames) {
+			const previous = previousEnvironment[name];
+			if (previous === undefined) delete process.env[name];
+			else process.env[name] = previous;
+		}
 		rmSync(root, { recursive: true, force: true });
 	}
 }
@@ -72,7 +84,12 @@ function writeJson(filePath: string, value: unknown) {
 test("browser-only user settings load without creating or requiring tool settings", async () => {
 	await withSettingsFixture(async ({ cwd, extensionA, executable }) => {
 		writeJson(settingsFilePath(), {
-			browser: { executablePath: executable, extensionPaths: [extensionA] },
+			browser: {
+				endpoint: "http://localhost:9333",
+				autoLaunch: false,
+				executablePath: executable,
+				extensionPaths: [extensionA],
+			},
 			future: { kept: true },
 		});
 
@@ -80,12 +97,16 @@ test("browser-only user settings load without creating or requiring tool setting
 
 		assert.equal(loaded.kind, "loaded");
 		assert.equal(loaded.settings?.tools, undefined);
-		assert.deepEqual(loaded.effectiveBrowser, {
-			executablePath: executable,
-			extensionPaths: [extensionA],
-			executablePathSource: "user",
-			extensionPathsSource: "user",
-		});
+		assert.equal(loaded.effectiveBrowser.endpoint, "http://localhost:9333");
+		assert.equal(loaded.effectiveBrowser.host, "localhost");
+		assert.equal(loaded.effectiveBrowser.port, 9333);
+		assert.equal(loaded.effectiveBrowser.autoLaunchEnabled, false);
+		assert.equal(loaded.effectiveBrowser.endpointSource, "user");
+		assert.equal(loaded.effectiveBrowser.autoLaunchSource, "user");
+		assert.equal(loaded.effectiveBrowser.executablePath, executable);
+		assert.deepEqual(loaded.effectiveBrowser.extensionPaths, [extensionA]);
+		assert.equal(loaded.effectiveBrowser.executablePathSource, "user");
+		assert.equal(loaded.effectiveBrowser.extensionPathsSource, "user");
 		assert.deepEqual(loaded.warnings, []);
 	});
 });
@@ -98,6 +119,9 @@ test("missing user and project settings are side-effect free defaults", async ()
 		const loaded = await loadSettings({ cwd, projectTrusted: true });
 
 		assert.equal(loaded.kind, "missing");
+		assert.equal(loaded.effectiveBrowser.endpoint, "http://127.0.0.1:9222");
+		assert.equal(loaded.effectiveBrowser.autoLaunchEnabled, true);
+		assert.equal(loaded.effectiveBrowser.endpointSource, "default");
 		assert.deepEqual(loaded.effectiveBrowser.extensionPaths, []);
 		assert.equal(existsSync(settingsFilePath()), false);
 		assert.equal(existsSync(projectSettingsFilePath(cwd)), false);
@@ -112,6 +136,34 @@ test("an explicit empty tool selection remains a loaded global setting", async (
 
 		assert.equal(loaded.kind, "loaded");
 		assert.deepEqual(loaded.settings?.tools, []);
+	});
+});
+
+test("browser endpoints retain explicitly configured default HTTP ports", async () => {
+	await withSettingsFixture(async ({ cwd }) => {
+		writeJson(settingsFilePath(), { browser: { endpoint: "http://localhost:80" } });
+
+		const loaded = await loadSettings({ cwd, projectTrusted: false });
+
+		assert.equal(loaded.kind, "loaded");
+		assert.equal(loaded.effectiveBrowser.endpoint, "http://localhost:80");
+		assert.equal(loaded.effectiveBrowser.port, 80);
+	});
+});
+
+test("user browser endpoint and auto-launch values are validated", async () => {
+	await withSettingsFixture(async ({ cwd }) => {
+		for (const browser of [
+			{ endpoint: "https://127.0.0.1:9222" },
+			{ endpoint: "http://127.0.0.1" },
+			{ endpoint: "http://127.0.0.1:9222/json/list" },
+			{ autoLaunch: "no" },
+		]) {
+			writeJson(settingsFilePath(), { browser });
+			const loaded = await loadSettings({ cwd, projectTrusted: false });
+			assert.equal(loaded.kind, "invalid");
+			assert.match(loaded.warnings.join("\n"), /browser\.(?:endpoint|autoLaunch)/i);
+		}
 	});
 });
 
@@ -179,6 +231,34 @@ test("untrusted projects are not read or allowed to override browser settings", 
 	});
 });
 
+test("project machine-owned browser settings are ignored with user-file guidance", async () => {
+	await withSettingsFixture(async ({ cwd, executable }) => {
+		writeJson(settingsFilePath(), {
+			browser: {
+				endpoint: "http://127.0.0.1:9333",
+				autoLaunch: false,
+				executablePath: executable,
+			},
+		});
+		writeJson(projectSettingsFilePath(cwd), {
+			browser: {
+				endpoint: "http://remote.example:9444",
+				autoLaunch: true,
+				executablePath: "/project/cannot/override",
+			},
+		});
+
+		const loaded = await loadSettings({ cwd, projectTrusted: true });
+
+		assert.equal(loaded.effectiveBrowser.endpoint, "http://127.0.0.1:9333");
+		assert.equal(loaded.effectiveBrowser.autoLaunchEnabled, false);
+		assert.equal(loaded.effectiveBrowser.executablePath, executable);
+		assert.match(loaded.warnings.join("\n"), /project browser\.endpoint ignored/i);
+		assert.match(loaded.warnings.join("\n"), /project browser\.autoLaunch ignored/i);
+		assert.match(loaded.warnings.join("\n"), /project browser\.executablePath ignored/i);
+	});
+});
+
 test("project executablePath is ignored while invalid project extension settings are warned", async () => {
 	await withSettingsFixture(async ({ cwd, extensionA, executable }) => {
 		writeJson(settingsFilePath(), {
@@ -197,15 +277,67 @@ test("project executablePath is ignored while invalid project extension settings
 	});
 });
 
-test("environment browser executable remains the explicit runtime override", async () => {
+test("deprecated environment settings remain explicit overrides and emit one migration warning", async () => {
 	await withSettingsFixture(async ({ cwd, executable }) => {
-		writeJson(settingsFilePath(), { browser: { executablePath: executable } });
+		writeJson(settingsFilePath(), {
+			browser: {
+				endpoint: "http://json.example:9333",
+				autoLaunch: false,
+				executablePath: executable,
+			},
+		});
+		process.env.PI_CHROME_DEVTOOLS_HOST = "127.0.0.1";
+		process.env.PI_CHROME_DEVTOOLS_PORT = "9444";
+		process.env.PI_CHROME_DEVTOOLS_AUTO_LAUNCH = "1";
 		process.env.PI_CHROME_DEVTOOLS_BROWSER = "chromium-from-environment";
 
 		const loaded = await loadSettings({ cwd, projectTrusted: false });
 
+		assert.equal(loaded.effectiveBrowser.endpoint, "http://127.0.0.1:9444");
+		assert.equal(loaded.effectiveBrowser.autoLaunchEnabled, true);
 		assert.equal(loaded.effectiveBrowser.executablePath, "chromium-from-environment");
+		assert.equal(loaded.effectiveBrowser.endpointSource, "environment");
+		assert.equal(loaded.effectiveBrowser.autoLaunchSource, "environment");
 		assert.equal(loaded.effectiveBrowser.executablePathSource, "environment");
+		assert.equal(loaded.warnings.length, 1);
+		assert.match(loaded.warnings[0] ?? "", /deprecated.*future version/i);
+		for (const name of [
+			"PI_CHROME_DEVTOOLS_HOST",
+			"PI_CHROME_DEVTOOLS_PORT",
+			"PI_CHROME_DEVTOOLS_AUTO_LAUNCH",
+			"PI_CHROME_DEVTOOLS_BROWSER",
+		]) {
+			assert.match(loaded.warnings[0] ?? "", new RegExp(name));
+		}
+		assert.match(loaded.warnings[0] ?? "", /browser\.endpoint.*browser\.autoLaunch/i);
+	});
+});
+
+test("browser saves preserve unknown top-level and browser fields", async () => {
+	await withSettingsFixture(async ({ extensionA, executable }) => {
+		writeJson(settingsFilePath(), {
+			browser: {
+				executablePath: executable,
+				extensionPaths: [extensionA],
+				futureBrowserField: { kept: true },
+			},
+			future: { kept: true },
+		});
+
+		await saveBrowserSettings({
+			endpoint: "http://localhost:9333",
+			autoLaunch: false,
+		});
+
+		const saved = JSON.parse(readFileSync(settingsFilePath(), "utf8")) as Record<string, unknown>;
+		assert.deepEqual(saved.browser, {
+			executablePath: executable,
+			extensionPaths: [extensionA],
+			futureBrowserField: { kept: true },
+			endpoint: "http://localhost:9333",
+			autoLaunch: false,
+		});
+		assert.deepEqual(saved.future, { kept: true });
 	});
 });
 


### PR DESCRIPTION
## Summary

- Add validated `browser.endpoint`, `browser.autoLaunch`, and `browser.executablePath` settings to `pi-chrome-devtools.json`.
- Add `/chrome-devtools settings` and a TUI/RPC browser settings workflow that applies successful changes before the next connection.
- Keep `PI_CHROME_DEVTOOLS_*` overrides temporarily with precedence and actionable deprecation warnings.
- Preserve unknown JSON fields, reject invalid files without overwriting them, serialize atomic writes, and clean up extension-owned managed browsers when settings change.
- Document precedence and compatibility limits, add focused lifecycle/UI tests, and include a minor Changeset.

## Verification

- `npm run check` — 3,699 tests passed across 364 files.
- `npx vitest run packages/pi-chrome-devtools/test/*.test.ts` — 82 tests passed.
- `npm run check --workspace @narumitw/pi-chrome-devtools` — passed.
- `just pack chrome-devtools` — expected 17-file package produced.
- `npm run changeset:status` — resolves `@narumitw/pi-chrome-devtools` as a minor release.
- Isolated RPC smoke — JSON endpoint and auto-launch settings loaded with user-source status.

## Compatibility note

Chrome's newer Windows built-in permission endpoint can return `404` for standard CDP discovery routes and remains unsupported until `DevToolsActivePort` compatibility is implemented.
Native Windows rendering was not exercised.

