### PR TITLE
feat(file-context): improve context selection workflow

### DIFF
--- a/.changeset/kind-context-baskets.md
+++ b/.changeset/kind-context-baskets.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": minor
+---
+
+Make context selection a coherent next-prompt workflow with add-and-continue browsing, exact review before removal, visible capacity, adaptive preview help, and cancellable scanning from every explorer route.

--- a/docs/plans/archived/2026-08-13_pi-file-context-selection-experience-plan.md
+++ b/docs/plans/archived/2026-08-13_pi-file-context-selection-experience-plan.md
@@ -1,0 +1,46 @@
+# Pi File Context selection experience plan
+
+## Goal
+
+Make selecting context feel like one coherent next-prompt workflow by clarifying state, supporting repeated selection, keeping primary controls visible, and showing cancellable scanning from every entry route.
+
+## Architecture
+
+- Keep exact snapshots, aggregate limits, prompt injection, widget ownership, and lifecycle guards in `packages/pi-file-context/src/file-context.ts`.
+- Keep file, content, line-range, and Git navigation inside `FileQuoteExplorer`, with a callback for adding a snapshot without disposing the explorer.
+- Keep standard selected-context review in `file-context-menu.ts`, using Pi TUI Kit choice and review screens so preview precedes removal.
+- Preserve `F8`, `/file-context browse`, `/file-context remove`, normal `@path` references, XML injection syntax, and current cancellation semantics.
+
+## Non-Goals
+
+- Do not add persistence, quote editing, undo, bulk clearing, or reordering in this focused change.
+- Do not change file discovery limits, Git provenance, settings storage, non-TUI support, or prompt injection ordering.
+- Do not add a discovery cache that could hide files created during the current session.
+
+## Risks
+
+- A keep-browsing action could append twice or lose the originating search state unless it bypasses the explorer close result cleanly.
+- A scanning loader on direct routes adds a second custom TUI handoff and must remain cancellable and lifecycle-safe.
+- More preview state could recreate narrow-terminal truncation unless primary actions and advanced help are tested at constrained widths.
+- Menu terminology changes must not remove the established `remove` compatibility route.
+
+## Plan
+
+- [x] Add focused failing tests for selected-context terminology, preview-before-remove, add-and-continue, visible capacity, adaptive primary hints, advanced help, and direct-route cancellable scanning; the menu test failed in four vocabulary/review paths, the explorer test lacked capacity/help, and direct routes timed out before a loader existed.
+- [x] Update `file-context-menu.ts` so the menu presents next-prompt context, opens an exact review before removal, and preserves identity-safe repeated removal and compatibility entry routes.
+- [x] Update `file-context-explorer.ts` and lifecycle wiring so `A` adds and keeps browsing, preview hints remain useful at narrow widths, `?` exposes Git and range actions, and capacity is visible before adding.
+- [x] Route all explorer discovery through the existing cancellable Pi TUI Kit task while preserving stale-session, disposal, error, Back, and Close behavior.
+- [x] Update the widget, notifications, README, package layout guidance, and a minor Changeset to use one selected-context vocabulary and document the new controls.
+- [x] Audit the full diff against `docs/extension-conventions.md`, including TUI mode guards, async cancellation, component disposal, stale awaits, width safety, terminal sanitization, command compatibility, and deterministic tests; direct and menu scans share one abort-aware task, explorer disposal stays session-owned, every rendered line is bounded, established command routes remain, and independent review findings for stale help requests, short-terminal help, and per-snippet capacity warnings were fixed with regressions.
+- [x] Run focused File Context tests, package typecheck and formatting, `npm run check`, Changesets status, `just pack file-context`, and a non-interactive Pi load smoke; 68 focused tests, all 3,707 root tests on the final successful gate, package checks, the 14-file tarball, and offline RPC `get_commands` registration pass.
+- [x] Inspect the final diff and create a signed Conventional Commit containing the focused implementation, tests, docs, plan, and Changeset.
+- [x] Push `worktree/rapid-field-7396` and open pull request [#735](https://github.com/narumiruna/pi-extensions/pull/735) with checks, package-smoke evidence, audit scope, and the unverified live-TUI path.
+
+## Completion Checklist
+
+- [x] `F8`, `/file-context browse`, and menu Add all show the same cancellable scan state before browsing; focused tests cover direct completion/cancellation and menu cancellation/error recovery.
+- [x] Enter still adds one snippet and closes, while `A` adds the same exact snapshot and returns to the originating file or content results without duplicate insertion.
+- [x] The preview shows selection size and resulting next-prompt capacity, keeps primary actions discoverable at narrow widths, and exposes advanced actions through `?`.
+- [x] `/file-context` reviews exact selected context before removal, and cancellation never mutates selected snippets.
+- [x] Existing references, Git provenance, quote limits, injection order and syntax, command compatibility, lifecycle cleanup, and non-TUI rejection remain covered by 68 focused tests.
+- [x] Documentation, Changeset, repository gate, package contents, signed commit, pushed branch, and pull request match the implemented behavior.

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -7,18 +7,18 @@
 > [!WARNING]
 > This extension is experimental. Its interaction model and package API may change between releases.
 
-Browse project files inside Pi, preview text, select a line range, and attach the exact snapshot to the next prompt.
+Browse project files inside Pi, select exact snapshots, and review the context queued for the next prompt.
 
 ## ✨ Features
 
 - Opens the file explorer directly with a configurable shortcut that defaults to `F8`.
-- Provides a `/file-context` menu for adding quotes, previewing and repeatedly removing pending snapshots, and reviewing help without replacing Pi's normal editor.
+- Provides a `/file-context` menu for adding context snippets, reviewing exact selected snapshots before removal, and opening help without replacing Pi's normal editor.
 - Fuzzy-searches project file names with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
 - Switches with `Ctrl+F` to cancellable cwd content search with highlighted result cards, literal case-insensitive matching by default, and visible case-sensitive and fuzzy toggles.
 - Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
 - Selects a contiguous line range or changed hunk without using the system clipboard and shows a deterministic token estimate before attachment.
 - Discloses current-line blame and bounded file history, opens a validated commit/branch/tag version, and attaches explicit Git diff hunks.
-- Accumulates selected ranges in one compact pending-quote widget, lets you preview and remove exact snapshots from the menu, and injects the remaining snapshots into the next ordinary interactive prompt.
+- Shows selected snippets and capacity as next-prompt context, supports adding one and closing or adding repeatedly without leaving the browser, and injects snapshots in selection order.
 - Skips common dependency, VCS, build, and coverage directories and does not follow symlinks during discovery.
 
 ## 📦 Install
@@ -43,15 +43,15 @@ pi -e ./packages/pi-file-context
 
 ## 🚀 Quick start
 
-1. Run `/file-context` and choose **Add file quote**. Press `F8` or run `/file-context browse` to open the browser directly.
+1. Run `/file-context` and choose **Add context snippet**. Press `F8` or run `/file-context browse` to open the browser directly. Every route shows the same cancellable project scan before browsing.
 2. Type to fuzzy-search file names in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
 3. Press `Ctrl+F` to switch between file-name and content search. Content search is literal and case-insensitive by default; `Alt+C` toggles case sensitivity and `Alt+F` toggles ordered fuzzy matching. The current states remain visible above the results.
 4. In content results, use `Up`/`Down` to choose a highlighted path-and-line card. Press `Tab` for a whole-file reference or `Enter` to preview the file at that line. `Escape` from the preview restores the query, result selection, and scroll position.
-5. In the preview, press `Space` to anchor the selection. Extend the range with `Up`/`Down`, then press `Enter` to attach it. Without an anchor, `Enter` attaches the cursor line.
-6. In a Git worktree, use `[`/`]` to select changed hunks, `b` for current-line blame, `h` for file history, `r` to open a commit/branch/tag, or `d` to inspect and attach explicit diff context.
-7. Repeat from the menu or shortcut to attach more ranges from the same or different files. Open `/file-context`, choose **Remove pending quote**, preview the selected snapshot, and press `Enter` to remove it. The removal list stays open for more removals. `Escape` goes back without changing quotes, while `Ctrl+C` closes File Context. Then write the question and submit normally. All remaining quotes are attached in selection order and cleared together.
+5. In the preview, press `Space` to anchor the selection and extend the range with `Up`/`Down`. The footer shows the selected lines, estimated tokens, and resulting next-prompt capacity. Press `Enter` to add and close, or press `a` to add and return to the originating file or content results so you can keep browsing.
+6. Press `?` in the preview to review all actions. In a Git worktree, `[`/`]` selects changed hunks, `b` shows current-line blame, `h` opens file history, `r` opens a commit/branch/tag, and `d` reviews and adds explicit diff context.
+7. Open `/file-context` and choose **Review selected context** to inspect each exact snapshot. `Enter` opens the snapshot first and then offers **Remove from next prompt**. `Escape` goes back without changing selected context, while `Ctrl+C` closes File Context. Write the question and submit normally; selected snippets are attached in order and cleared together.
 
-`Escape` returns from a preview to its originating file-name or content results. When the browser was opened from the menu, `Escape` from a root search returns to the menu. Direct browser routes cancel instead. `Ctrl+C` closes menus and browsers. During project scanning, either cancel key stops the scan and returns to the menu.
+`Escape` returns from a preview to its originating file-name or content results. When the browser was opened from the menu, `Escape` from a root search returns to the menu. Direct browser routes cancel instead. `Ctrl+C` closes menus and browsers. During project scanning, either cancel key stops the scan; menu-owned scans return to the menu and direct scans close without opening a stale explorer.
 
 The agent receives an explicit block similar to:
 
@@ -91,9 +91,9 @@ The previous `Ctrl+Alt+F` default depended on terminal modifier support and may 
 
 | Command | Mode | Description |
 | --- | --- | --- |
-| `/file-context` | TUI only | Open the Add, Remove, and Help menu. |
-| `/file-context browse` | TUI only | Open the file explorer directly. |
-| `/file-context remove` | TUI only | Open pending quote removal directly for compatibility. |
+| `/file-context` | TUI only | Open the Add, Review, and Help menu. |
+| `/file-context browse` | TUI only | Scan and open the file explorer directly. |
+| `/file-context remove` | TUI only | Open selected-context review directly for compatibility. |
 
 Unknown and trailing arguments are rejected. RPC receives an observable warning. JSON and print modes do not enter interactive UI.
 
@@ -109,14 +109,14 @@ Unknown and trailing arguments are rejected. RPC receives an observable warning.
 - Git is invoked read-only without a shell, pager, external diff, or text conversion; commands time out after 5 seconds and output is bounded to 1.1 MB.
 - Revision names are resolved to a commit before file loading. Historical files remain subject to the 1 MB and binary guards.
 - Blame shows the author name but not author email. Commit summaries and diffs can still contain sensitive project text; inspect selections before attachment.
-- Each quote stores the text visible at selection time. It does not silently reread changed content when the prompt is submitted.
-- A quote is limited to 500 lines and 50 KB. At most eight pending quotes and 100 KB of aggregate quote text are accepted.
+- Each snippet stores the text visible at selection time. It does not silently reread changed content when the prompt is submitted.
+- A snippet is limited to 500 lines and 50 KB. At most eight selected snippets and 100 KB of aggregate context text are accepted.
 
 ## 🧪 Experimental limitations
 
 - Keyboard line selection only; mouse drag selection is not implemented.
-- Up to eight pending quotes; repeated removal is supported, but there are not yet bulk clear or reorder actions.
-- Pending quotes do not survive `/reload`, session replacement, or shutdown.
+- Up to eight selected snippets; exact review and repeated removal are supported, but there are not yet bulk clear, undo, or reorder actions.
+- Selected context does not survive `/reload`, session replacement, or shutdown.
 - The configurable shortcut is registered without replacing another extension's custom editor; `/file-context` remains available if the shortcut is disabled or conflicts.
 - File discovery uses a small built-in ignore list rather than `.gitignore` semantics.
 - Content search scans discovered files natively and sequentially; large projects or queries with no matches may take longer than indexed or external search tools.
@@ -128,10 +128,11 @@ Unknown and trailing arguments are rejected. RPC receives an observable warning.
 
 ```text
 src/index.ts                   Thin Pi entrypoint
-src/file-context.ts            Lifecycle, routes, filesystem boundaries, pending state, quote injection
-src/file-context-menu.ts       Standard Add, Remove, preview, Help, and disabled-state menu flow
+src/file-context.ts            Lifecycle, routes, filesystem boundaries, selected state, prompt injection
+src/file-context-menu.ts       Standard Add, selected-context review, Help, and removal flow
 src/file-context-settings.ts   User shortcut loading and validation
-src/file-context-explorer.ts   File list, Git detail views, and line-range TUI
+src/file-context-explorer.ts   File, content, Git, and line-range interaction controller
+src/file-context-preview-ui.ts Width-safe preview, capacity, and progressive action help
 src/content-search.ts          Bounded literal and fuzzy content matching
 src/content-search-session.ts  Search input, toggles, navigation, and cancellation
 src/content-search-ui.ts       Width-safe result cards and highlighted context
@@ -140,10 +141,12 @@ src/git-context.ts             Bounded read-only Git status, diff, blame, histor
 
 test/content-search.test.ts     Content matcher behavior and limits
 test/content-search-ui.test.ts  Content interaction, rendering, and lifecycle tests
+test/file-context-search.test.ts  File-name ranking, typo tolerance, and query-bound tests
 test/file-context.test.ts       Filesystem, prompt, lifecycle, shortcut, and explorer tests
-test/file-context-menu.test.ts  Menu states, navigation, previews, limits, and responsive rendering tests
+test/file-context-selection.test.ts  Add-and-continue, capacity, and progressive-help tests
+test/file-context-menu.test.ts  Menu states, exact review, removal, limits, and responsive rendering tests
 test/file-context-command-menu.test.ts  Command routes, loading, and direct browser compatibility tests
-test/pending-quotes.test.ts     Exact pending quote removal, cancellation, and stale-flow tests
+test/pending-quotes.test.ts     Exact selected-context removal, cancellation, and stale-flow tests
 test/file-context-settings.test.ts  Shortcut settings defaults and validation tests
 test/git-context.test.ts        Git repository behavior and parser tests
 ```

--- a/packages/pi-file-context/src/file-context-explorer.ts
+++ b/packages/pi-file-context/src/file-context-explorer.ts
@@ -11,13 +11,17 @@ import {
 } from "@earendil-works/pi-tui";
 import type { ContentSearchMatch } from "./content-search.js";
 import { ContentSearchSession } from "./content-search-session.js";
-import { highlightContentRanges } from "./content-search-ui.js";
 import {
 	createFileQuote,
 	createFileQuoteSnapshot,
 	type FileQuote,
 	type LoadedProjectTextFile,
 } from "./file-context.js";
+import {
+	renderFilePreview,
+	renderFilePreviewHelp,
+	type SelectedContextState,
+} from "./file-context-preview-ui.js";
 import { ProjectFileSearch } from "./file-search.js";
 import type {
 	GitBlameInfo,
@@ -29,7 +33,6 @@ import type {
 
 const RESERVED_APP_ROWS = 3;
 const EXPLORER_CHROME_ROWS = 4;
-const PREVIEW_CHROME_ROWS = 4;
 const HISTORY_CHROME_ROWS = 3;
 const DIFF_CHROME_ROWS = 3;
 
@@ -48,6 +51,9 @@ interface FileQuoteExplorerOptions {
 	loadFile: (path: string, signal?: AbortSignal) => Promise<LoadedProjectTextFile>;
 	gitContext?: GitContext;
 	rootNavigation?: boolean;
+	getSelectedContextState?: () => SelectedContextState;
+	validateQuote?: (quote: FileQuote) => void;
+	onAddAndContinue?: (quote: FileQuote) => void;
 	done: (result: FileQuoteExplorerResult | undefined) => void;
 }
 
@@ -59,7 +65,14 @@ export class FileQuoteExplorer implements Component, Focusable {
 	private filteredFiles: string[];
 	private selectedFileIndex = 0;
 	private fileScrollOffset = 0;
-	private mode: "files" | "contents" | "preview" | "history" | "revision" | "diff" = "files";
+	private mode:
+		| "files"
+		| "contents"
+		| "preview"
+		| "preview-help"
+		| "history"
+		| "revision"
+		| "diff" = "files";
 	private previewReturnMode: "files" | "contents" = "files";
 	private activeContentMatch: ContentSearchMatch | undefined;
 	private loadedFile: LoadedProjectTextFile | undefined;
@@ -125,6 +138,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 		if (this.mode === "history") return this.renderHistory(safeWidth);
 		if (this.mode === "revision") return this.renderRevisionInput(safeWidth);
 		if (this.mode === "diff") return this.renderDiff(safeWidth);
+		if (this.mode === "preview-help") return this.renderPreviewHelp(safeWidth);
 		return this.renderPreview(safeWidth);
 	}
 
@@ -139,6 +153,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 		else if (this.mode === "history") this.handleHistoryInput(data);
 		else if (this.mode === "revision") this.handleRevisionInput(data);
 		else if (this.mode === "diff") this.handleDiffInput(data);
+		else if (this.mode === "preview-help") this.handlePreviewHelpInput(data);
 		else this.handlePreviewInput(data);
 		if (!this.finished) this.options.tui.requestRender();
 	}
@@ -227,84 +242,29 @@ export class FileQuoteExplorer implements Component, Focusable {
 
 	private renderPreview(width: number): string[] {
 		const availableRows = Math.max(1, this.options.tui.terminal.rows - RESERVED_APP_ROWS);
-		const previewHeight = Math.max(1, availableRows - PREVIEW_CHROME_ROWS);
-		const loadedFile = this.loadedFile;
-		if (!loadedFile) return [this.options.theme.fg("warning", "Loading preview…")];
-		this.keepPreviewVisible(previewHeight);
-		const digits = String(Math.max(1, loadedFile.lines.length)).length;
-		const range = this.getSelectionRange();
-		const changedLines = new Set(this.loadedGit?.hunks.flatMap((hunk) => hunk.changedLines) ?? []);
-		const deletedAtLines = new Set(
-			(this.loadedGit?.hunks ?? [])
-				.filter((hunk) => hunk.changedLines.length === 0 && hunk.oldCount > 0)
-				.map((hunk) => Math.max(1, hunk.newStart)),
-		);
-		const visibleLines = loadedFile.lines.slice(
-			this.previewScrollOffset,
-			this.previewScrollOffset + previewHeight,
-		);
-		const previewLines = visibleLines.map((rawLine, visibleIndex) => {
-			const index = this.previewScrollOffset + visibleIndex;
-			const selected = index >= range.start && index <= range.end;
-			const cursor = index === this.previewCursor ? ">" : " ";
-			const marker = changedLines.has(index + 1) ? "+" : deletedAtLines.has(index + 1) ? "-" : " ";
-			const number = String(index + 1).padStart(digits, " ");
-			const contentMatch =
-				this.activeContentMatch?.path === loadedFile.path &&
-				this.activeContentMatch.lineNumber === index + 1 &&
-				this.activeContentMatch.line === rawLine
-					? this.activeContentMatch
-					: undefined;
-			const content = contentMatch
-				? highlightContentRanges(rawLine, contentMatch.ranges, this.options.theme)
-				: escapeTerminalControls(rawLine);
-			const line = `${cursor}${marker}${number} │ ${content}`;
-			const styled = selected
-				? this.options.theme.bg("selectedBg", this.options.theme.fg("text", line))
-				: index === this.previewCursor
-					? this.options.theme.fg("accent", line)
-					: line;
-			return truncateToWidth(styled, width, "");
-		});
-		if (previewLines.length === 0) {
-			previewLines.push(truncateToWidth(this.options.theme.fg("muted", "  Empty file"), width, ""));
-		}
-		const selecting =
-			this.previewAnchor === undefined
-				? "cursor line"
-				: `lines ${range.start + 1}-${range.end + 1}`;
-		const selectedText = loadedFile.lines.slice(range.start, range.end + 1).join("\n");
-		const estimatedTokens = Math.max(1, Math.ceil(Buffer.byteLength(selectedText, "utf8") / 4));
-		const footer = this.error
-			? this.options.theme.fg("error", escapeTerminalControls(this.error))
-			: `~${estimatedTokens} tokens · Enter attach ${selecting} · Space anchor · ↑↓ extend · [] hunks · b blame · h history · r revision · d diff · Esc ${this.previewReturnMode === "contents" ? "content results" : "files"}`;
-		const project = this.options.gitContext?.project;
-		const gitLabel = this.loadedRevision
-			? `${escapeTerminalControls(this.loadedRevision.revision)}@${this.loadedRevision.commit.slice(0, 12)} · historical`
-			: project
-				? `${escapeTerminalControls(project.branch)}@${project.head.slice(0, 12)}${project.dirty ? " · dirty" : ""}${this.loadedGit?.status ? ` · ${this.loadedGit.status.label}` : " · clean"}`
-				: "";
-		const blameLabel = this.blame
-			? `L${this.previewCursor + 1} · ${this.blame.committed ? this.blame.commit.slice(0, 12) : "uncommitted"} · ${escapeTerminalControls(this.blame.author)} · ${escapeTerminalControls(this.blame.summary)}`
-			: "";
-		return fitRows(
-			[
-				truncateToWidth(
-					this.options.theme.fg(
-						"accent",
-						this.options.theme.bold(
-							`${escapeTerminalControls(loadedFile.path)}${gitLabel ? ` · ${gitLabel}` : ""}`,
-						),
-					),
-					width,
-					"",
-				),
-				truncateToWidth(this.options.theme.fg("muted", blameLabel), width, ""),
-				...previewLines,
-				truncateToWidth(this.options.theme.fg("muted", footer), width, ""),
-			],
+		if (!this.loadedFile) return [this.options.theme.fg("warning", "Loading preview…")];
+		return renderFilePreview({
+			theme: this.options.theme,
+			width,
 			availableRows,
-		);
+			file: this.loadedFile,
+			fileGit: this.loadedGit,
+			project: this.options.gitContext?.project,
+			revision: this.loadedRevision,
+			contentMatch: this.activeContentMatch,
+			blame: this.blame,
+			cursor: this.previewCursor,
+			anchor: this.previewAnchor,
+			scrollOffset: this.previewScrollOffset,
+			error: this.error,
+			selectedContext: this.options.getSelectedContextState?.(),
+			canContinue: this.options.onAddAndContinue !== undefined,
+		});
+	}
+
+	private renderPreviewHelp(width: number): string[] {
+		const availableRows = Math.max(1, this.options.tui.terminal.rows - RESERVED_APP_ROWS);
+		return renderFilePreviewHelp(this.options.theme, width, availableRows);
 	}
 
 	private renderRevisionInput(width: number): string[] {
@@ -476,20 +436,29 @@ export class FileQuoteExplorer implements Component, Focusable {
 		if (!loadedFile) return;
 		const lines = loadedFile.lines;
 		if (matchesKey(data, Key.escape)) {
+			this.returnToOrigin();
+			return;
+		}
+		if (data === "?") {
 			this.cancelDetailRequest();
-			this.cancelOpenRequest();
-			this.mode = this.previewReturnMode;
-			this.loadedFile = undefined;
-			this.loadedGit = undefined;
-			this.loadedRevision = undefined;
-			this.previewAnchor = undefined;
-			this.blame = undefined;
-			this.search.focused = this.isFocused && this.mode === "files";
-			this.contentSearch.focused = this.isFocused && this.mode === "contents";
+			this.mode = "preview-help";
+			this.search.focused = false;
+			this.contentSearch.focused = false;
+			return;
+		}
+		if (data === "a" && this.options.onAddAndContinue) {
+			try {
+				const quote = this.createSelectedQuote();
+				this.options.onAddAndContinue(quote);
+				this.returnToOrigin();
+			} catch (error: unknown) {
+				this.error = formatError(error);
+			}
 			return;
 		}
 		if (data === " ") {
 			this.previewAnchor = this.previewAnchor === undefined ? this.previewCursor : undefined;
+			this.error = undefined;
 			return;
 		}
 		if (data === "b") {
@@ -543,34 +512,18 @@ export class FileQuoteExplorer implements Component, Focusable {
 			return;
 		}
 		if (this.options.keybindings.matches(data, "tui.select.confirm")) {
-			const anchor = this.previewAnchor ?? this.previewCursor;
 			try {
-				const project = this.options.gitContext?.project;
-				const revision = this.loadedRevision;
-				this.finish({
-					kind: "quote",
-					quote: createFileQuote(
-						loadedFile.path,
-						lines,
-						anchor,
-						this.previewCursor,
-						project
-							? {
-									head: project.head,
-									branch: project.branch,
-									status: revision ? "historical" : (this.loadedGit?.status?.label ?? "clean"),
-									revision: revision?.revision,
-									blob: revision?.blob ?? this.loadedGit?.blob,
-									source: revision ? "revision" : "worktree",
-									base: revision ? undefined : "HEAD",
-								}
-							: undefined,
-					),
-				});
+				const quote = this.createSelectedQuote();
+				this.options.validateQuote?.(quote);
+				this.finish({ kind: "quote", quote });
 			} catch (error: unknown) {
 				this.error = formatError(error);
 			}
 		}
+	}
+
+	private handlePreviewHelpInput(data: string): void {
+		if (matchesKey(data, Key.escape)) this.mode = "preview";
 	}
 
 	private handleHistoryInput(data: string): void {
@@ -656,23 +609,22 @@ export class FileQuoteExplorer implements Component, Focusable {
 			try {
 				const startLine = Math.max(1, hunk.newStart);
 				const endLine = Math.max(startLine, hunk.newStart + hunk.newCount - 1);
-				this.finish({
-					kind: "quote",
-					quote: createFileQuoteSnapshot(
-						loadedFile.path,
-						startLine,
-						endLine,
-						hunk.lines.join("\n"),
-						{
-							head: project.head,
-							branch: project.branch,
-							status: this.loadedGit?.status?.label ?? "modified",
-							blob: this.loadedGit?.blob,
-							source: "git_diff",
-							base: "HEAD",
-						},
-					),
-				});
+				const quote = createFileQuoteSnapshot(
+					loadedFile.path,
+					startLine,
+					endLine,
+					hunk.lines.join("\n"),
+					{
+						head: project.head,
+						branch: project.branch,
+						status: this.loadedGit?.status?.label ?? "modified",
+						blob: this.loadedGit?.blob,
+						source: "git_diff",
+						base: "HEAD",
+					},
+				);
+				this.options.validateQuote?.(quote);
+				this.finish({ kind: "quote", quote });
 			} catch (error: unknown) {
 				this.error = formatError(error);
 			}
@@ -904,6 +856,46 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.cancelDetailRequest();
 		this.previewCursor = next;
 		this.blame = undefined;
+		this.error = undefined;
+	}
+
+	private createSelectedQuote(): FileQuote {
+		const loadedFile = this.loadedFile;
+		if (!loadedFile) throw new Error("No file is open");
+		const anchor = this.previewAnchor ?? this.previewCursor;
+		const project = this.options.gitContext?.project;
+		const revision = this.loadedRevision;
+		return createFileQuote(
+			loadedFile.path,
+			loadedFile.lines,
+			anchor,
+			this.previewCursor,
+			project
+				? {
+						head: project.head,
+						branch: project.branch,
+						status: revision ? "historical" : (this.loadedGit?.status?.label ?? "clean"),
+						revision: revision?.revision,
+						blob: revision?.blob ?? this.loadedGit?.blob,
+						source: revision ? "revision" : "worktree",
+						base: revision ? undefined : "HEAD",
+					}
+				: undefined,
+		);
+	}
+
+	private returnToOrigin(): void {
+		this.cancelDetailRequest();
+		this.cancelOpenRequest();
+		this.mode = this.previewReturnMode;
+		this.loadedFile = undefined;
+		this.loadedGit = undefined;
+		this.loadedRevision = undefined;
+		this.previewAnchor = undefined;
+		this.blame = undefined;
+		this.error = undefined;
+		this.search.focused = this.isFocused && this.mode === "files";
+		this.contentSearch.focused = this.isFocused && this.mode === "contents";
 	}
 
 	private finish(result: FileQuoteExplorerResult | undefined): void {
@@ -918,27 +910,11 @@ export class FileQuoteExplorer implements Component, Focusable {
 		return this.options.rootNavigation ? { kind } : undefined;
 	}
 
-	private getSelectionRange(): { start: number; end: number } {
-		const anchor = this.previewAnchor ?? this.previewCursor;
-		return {
-			start: Math.min(anchor, this.previewCursor),
-			end: Math.max(anchor, this.previewCursor),
-		};
-	}
-
 	private keepFileVisible(height: number): void {
 		if (this.selectedFileIndex < this.fileScrollOffset)
 			this.fileScrollOffset = this.selectedFileIndex;
 		if (this.selectedFileIndex >= this.fileScrollOffset + height) {
 			this.fileScrollOffset = this.selectedFileIndex - height + 1;
-		}
-	}
-
-	private keepPreviewVisible(height: number): void {
-		if (this.previewCursor < this.previewScrollOffset)
-			this.previewScrollOffset = this.previewCursor;
-		if (this.previewCursor >= this.previewScrollOffset + height) {
-			this.previewScrollOffset = this.previewCursor - height + 1;
 		}
 	}
 }

--- a/packages/pi-file-context/src/file-context-menu.ts
+++ b/packages/pi-file-context/src/file-context-menu.ts
@@ -35,8 +35,8 @@ export interface FileContextMenuOptions {
 	): FileContextMenuRemovalResult | Promise<FileContextMenuRemovalResult>;
 }
 
-type Screen = "main" | "remove" | "help";
-type Action = "add" | "remove";
+type Screen = "main" | "selected" | "quote" | "help";
+type Action = "add" | "review" | "remove";
 
 export async function showFileContextMenu(
 	ctx: ExtensionCommandContext,
@@ -46,20 +46,21 @@ export async function showFileContextMenu(
 	if (!options.isCurrent() || options.signal.aborted) return { kind: "stale" };
 
 	let addRequested = false;
+	let selectedQuoteId: string | undefined;
 	const menu = defineMenu<FileContextMenuState, Screen, Action, ExtensionCommandContext>({
-		start: options.start ?? "main",
+		start: options.start === "remove" ? "selected" : "main",
 		screens: {
 			main: ({ state }) => ({
 				kind: "actions",
 				title: "File Context",
 				lines: [
-					`Pending quotes: ${state.quotes.length}/${state.maximumQuotes} · ~${estimateTokens(state.totalBytes)} tokens`,
+					`Next prompt context: ${state.quotes.length}/${state.maximumQuotes} snippets · ~${estimateTokens(state.totalBytes)} tokens`,
 					`Shortcut: ${formatShortcut(state.shortcut)}`,
 				],
 				items: [
 					{
 						id: "add",
-						label: "Add file quote",
+						label: "Add context snippet",
 						description: "Browse project files and select lines",
 						action: "add",
 						busyLabel: "Scanning project files",
@@ -67,12 +68,13 @@ export async function showFileContextMenu(
 						disabledReason: addDisabledReason(state),
 					},
 					{
-						id: "remove",
-						label: `Remove pending quote (${state.quotes.length})`,
-						description: "Preview and remove exact snapshots",
-						to: "remove",
+						id: "selected",
+						label: `Review selected context (${state.quotes.length})`,
+						description: "Preview exact snapshots before removing them",
+						to: "selected",
 						disabled: state.quotes.length === 0,
-						disabledReason: state.quotes.length === 0 ? "No pending quotes to remove" : undefined,
+						disabledReason:
+							state.quotes.length === 0 ? "No context selected for the next prompt" : undefined,
 					},
 					{
 						id: "help",
@@ -83,33 +85,69 @@ export async function showFileContextMenu(
 				],
 				hint: "close",
 			}),
-			remove: ({ state }) => ({
-				kind: "choice",
-				title: "Remove pending quote",
-				lines: [`${state.quotes.length} pending · choose one exact snapshot to remove`],
-				items: state.quotes.map((quote, index) => ({
-					id: quote.id,
-					label: `${index + 1}. ${quote.path}`,
-					description: `lines ${quote.startLine}-${quote.endLine} · ~${estimateTokens(Buffer.byteLength(quote.text, "utf8"))} tokens`,
-					details: [
-						`Path: ${quote.path}`,
-						`Lines: ${quote.startLine}-${quote.endLine}`,
-						`Preview: ${singleLinePreview(quote.text)}`,
+			selected: ({ state }) =>
+				state.quotes.length === 0
+					? {
+							kind: "detail",
+							title: "Selected context",
+							lines: ["No context selected for the next prompt."],
+							hint: "back",
+						}
+					: {
+							kind: "choice",
+							title: "Selected context",
+							lines: [
+								`${state.quotes.length} snippets · Enter reviews the exact snapshot before removal`,
+							],
+							items: state.quotes.map((quote, index) => ({
+								id: quote.id,
+								label: `${index + 1}. ${quote.path}`,
+								description: `lines ${quote.startLine}-${quote.endLine} · ~${estimateTokens(Buffer.byteLength(quote.text, "utf8"))} tokens`,
+								details: [
+									`Lines ${quote.startLine}-${quote.endLine} · Preview: ${singleLinePreview(quote.text)}`,
+								],
+							})),
+							action: "review",
+							viewportSize: 8,
+							hint: "back",
+						},
+			quote: ({ state }) => {
+				const quote = state.quotes.find((candidate) => candidate.id === selectedQuoteId);
+				if (!quote) {
+					return {
+						kind: "detail",
+						title: "Review context snippet",
+						lines: ["That snippet is no longer selected. Go back to refresh the list."],
+						hint: "back",
+					};
+				}
+				return {
+					kind: "review",
+					title: "Review context snippet",
+					lines: [
+						quote.path,
+						`Lines ${quote.startLine}-${quote.endLine} · ~${estimateTokens(Buffer.byteLength(quote.text, "utf8"))} tokens`,
 					],
-				})),
-				action: "remove",
-				viewportSize: 8,
-				hint: "back",
-			}),
+					content: quote.text,
+					format: { kind: "text" },
+					viewportSize: "adaptive",
+					confirm: {
+						id: "remove",
+						label: "Remove from next prompt",
+						action: "remove",
+					},
+					hint: "back",
+				};
+			},
 			help: () => ({
 				kind: "detail",
 				title: "File Context help",
 				lines: [
-					"Add file quote opens the project browser. Select a file, preview it, and press Enter to attach the selected line or range.",
-					"Pending quotes are attached in order to your next prompt, then cleared together.",
-					"Use Remove pending quote to preview and remove exact snapshots without changing the others.",
+					"Add context snippet opens the project browser. Select lines and press Enter to add and close, or A to add and keep browsing.",
+					"Selected context is attached in order to your next prompt, then cleared together.",
+					"Review selected context opens each exact snapshot before offering removal.",
 					"The configured shortcut and /file-context browse open the browser directly.",
-					"Escape goes back. Ctrl+C closes File Context. Cancelling never changes pending quotes.",
+					"Escape goes back. Ctrl+C closes File Context. Cancelling never changes selected context.",
 				],
 				hint: "back",
 			}),
@@ -119,18 +157,25 @@ export async function showFileContextMenu(
 				addRequested = true;
 				return { kind: "close" };
 			},
-			remove: async ({ itemId, signal }) => {
+			review: ({ itemId }) => {
+				selectedQuoteId = itemId;
+				return { kind: "to", screen: "quote" };
+			},
+			remove: async ({ signal }) => {
+				const itemId = selectedQuoteId;
+				if (!itemId) return { kind: "back" };
 				const result = await options.removeQuote(itemId, signal);
 				if (signal.aborted || !options.isCurrent()) return { kind: "close" };
 				if (result.kind === "missing") {
-					ctx.ui.notify("That quote is no longer pending. The list was refreshed.", "warning");
+					ctx.ui.notify("That snippet is no longer selected. The list was refreshed.", "warning");
 					return { kind: "stay" };
 				}
 				ctx.ui.notify(
-					`Removed pending quote: ${safeTerminalText(result.quote.path)} · lines ${result.quote.startLine}-${result.quote.endLine}.`,
+					`Removed from next prompt context: ${safeTerminalText(result.quote.path)} · lines ${result.quote.startLine}-${result.quote.endLine}.`,
 					"info",
 				);
-				return result.remaining === 0 ? { kind: "back" } : { kind: "stay" };
+				selectedQuoteId = undefined;
+				return { kind: "back" };
 			},
 		},
 	});
@@ -143,7 +188,7 @@ export async function showFileContextMenu(
 			isCurrent: options.isCurrent,
 			onError: (_menuContext, error) => {
 				ctx.ui.notify(
-					`File Context menu failed: ${safeTerminalText(formatError(error))}. Pending quotes were kept; try again.`,
+					`File Context menu failed: ${safeTerminalText(formatError(error))}. Selected context was kept; try again.`,
 					"error",
 				);
 			},
@@ -161,10 +206,10 @@ export async function showFileContextMenu(
 
 function addDisabledReason(state: FileContextMenuState): string | undefined {
 	if (state.quotes.length >= state.maximumQuotes) {
-		return `The ${state.maximumQuotes}-quote limit is reached; remove a quote first`;
+		return `The ${state.maximumQuotes}-snippet limit is reached; review selected context first`;
 	}
 	if (state.totalBytes >= state.maximumBytes) {
-		return `The ${formatBytes(state.maximumBytes)} pending limit is reached; remove a quote first`;
+		return `The ${formatBytes(state.maximumBytes)} context limit is reached; review selected context first`;
 	}
 	return undefined;
 }

--- a/packages/pi-file-context/src/file-context-preview-ui.ts
+++ b/packages/pi-file-context/src/file-context-preview-ui.ts
@@ -1,0 +1,236 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+import type { ContentSearchMatch } from "./content-search.js";
+import { highlightContentRanges } from "./content-search-ui.js";
+import type { LoadedProjectTextFile } from "./file-context.js";
+import type {
+	GitBlameInfo,
+	GitFileContext,
+	GitProjectInfo,
+	GitRevisionFile,
+} from "./git-context.js";
+
+export interface SelectedContextState {
+	count: number;
+	totalBytes: number;
+	maximumCount: number;
+	maximumBytes: number;
+	maximumSnippetLines?: number;
+	maximumSnippetBytes?: number;
+}
+
+interface FilePreviewRenderOptions {
+	theme: Theme;
+	width: number;
+	availableRows: number;
+	file: LoadedProjectTextFile;
+	fileGit?: GitFileContext;
+	project?: GitProjectInfo;
+	revision?: GitRevisionFile;
+	contentMatch?: ContentSearchMatch;
+	blame?: GitBlameInfo;
+	cursor: number;
+	anchor?: number;
+	scrollOffset: number;
+	error?: string;
+	selectedContext?: SelectedContextState;
+	canContinue: boolean;
+}
+
+export function renderFilePreview(options: FilePreviewRenderOptions): string[] {
+	const { file, theme, width } = options;
+	const range = selectionRange(options.anchor, options.cursor);
+	const selectedText = file.lines.slice(range.start, range.end + 1).join("\n");
+	const selectedBytes = Buffer.byteLength(selectedText, "utf8");
+	const estimatedTokens = Math.max(1, Math.ceil(selectedBytes / 4));
+	const footerLines = options.error
+		? [escapeTerminalControls(options.error)]
+		: previewFooterLines(
+				width,
+				range.start + 1,
+				range.end + 1,
+				estimatedTokens,
+				selectedBytes,
+				options.selectedContext,
+				options.canContinue,
+			);
+	const previewHeight = Math.max(1, options.availableRows - 2 - footerLines.length);
+	const scrollOffset = visiblePreviewOffset(options.scrollOffset, options.cursor, previewHeight);
+	const digits = String(Math.max(1, file.lines.length)).length;
+	const changedLines = new Set(options.fileGit?.hunks.flatMap((hunk) => hunk.changedLines) ?? []);
+	const deletedAtLines = new Set(
+		(options.fileGit?.hunks ?? [])
+			.filter((hunk) => hunk.changedLines.length === 0 && hunk.oldCount > 0)
+			.map((hunk) => Math.max(1, hunk.newStart)),
+	);
+	const previewLines = file.lines
+		.slice(scrollOffset, scrollOffset + previewHeight)
+		.map((rawLine, visibleIndex) => {
+			const index = scrollOffset + visibleIndex;
+			const selected = index >= range.start && index <= range.end;
+			const cursor = index === options.cursor ? ">" : " ";
+			const marker = changedLines.has(index + 1) ? "+" : deletedAtLines.has(index + 1) ? "-" : " ";
+			const number = String(index + 1).padStart(digits, " ");
+			const contentMatch =
+				options.contentMatch?.path === file.path &&
+				options.contentMatch.lineNumber === index + 1 &&
+				options.contentMatch.line === rawLine
+					? options.contentMatch
+					: undefined;
+			const content = contentMatch
+				? highlightContentRanges(rawLine, contentMatch.ranges, theme)
+				: escapeTerminalControls(rawLine);
+			const line = `${cursor}${marker}${number} │ ${content}`;
+			const styled = selected
+				? theme.bg("selectedBg", theme.fg("text", line))
+				: index === options.cursor
+					? theme.fg("accent", line)
+					: line;
+			return truncateToWidth(styled, width, "");
+		});
+	if (previewLines.length === 0) {
+		previewLines.push(truncateToWidth(theme.fg("muted", "  Empty file"), width, ""));
+	}
+	const gitLabel = options.revision
+		? `${escapeTerminalControls(options.revision.revision)}@${options.revision.commit.slice(0, 12)} · historical`
+		: options.project
+			? `${escapeTerminalControls(options.project.branch)}@${options.project.head.slice(0, 12)}${options.project.dirty ? " · dirty" : ""}${options.fileGit?.status ? ` · ${options.fileGit.status.label}` : " · clean"}`
+			: "";
+	const blameLabel = options.blame
+		? `L${options.cursor + 1} · ${options.blame.committed ? options.blame.commit.slice(0, 12) : "uncommitted"} · ${escapeTerminalControls(options.blame.author)} · ${escapeTerminalControls(options.blame.summary)}`
+		: "";
+	return fitRows(
+		[
+			truncateToWidth(
+				theme.fg(
+					"accent",
+					theme.bold(`${escapeTerminalControls(file.path)}${gitLabel ? ` · ${gitLabel}` : ""}`),
+				),
+				width,
+				"",
+			),
+			truncateToWidth(theme.fg("muted", blameLabel), width, ""),
+			...previewLines,
+			...footerLines.map((line) =>
+				truncateToWidth(theme.fg(options.error ? "error" : "muted", line), width, ""),
+			),
+		],
+		options.availableRows,
+	);
+}
+
+export function renderFilePreviewHelp(
+	theme: Theme,
+	width: number,
+	availableRows: number,
+): string[] {
+	const detailed = [
+		theme.fg("accent", theme.bold("Preview actions")),
+		"Enter  Add selected lines and close File Context",
+		"A      Add selected lines and keep browsing",
+		"Space  Set or clear the range anchor; arrows extend the range",
+		"[ / ]  Select the previous or next changed hunk",
+		"B      Blame: show ownership for the current line when Git is available",
+		"H      History: browse earlier versions of this file",
+		"R      Revision: open a commit, branch, or tag",
+		"D      Git diff: review and add one explicit changed hunk",
+		"Esc    Return to the preview without changing selected context",
+	];
+	const compact = [
+		theme.fg("accent", theme.bold("Preview actions")),
+		"Enter add · A keep browsing · Space range",
+		"↑↓ extend · [/] hunk · B blame",
+		"H history · R revision · D Git diff",
+		"Esc back without changing context",
+	];
+	const lines = availableRows < detailed.length ? compact : detailed;
+	return fitRows(
+		lines.map((line) => truncateToWidth(line, width, "")),
+		availableRows,
+	);
+}
+
+function previewFooterLines(
+	width: number,
+	startLine: number,
+	endLine: number,
+	tokens: number,
+	selectedBytes: number,
+	state: SelectedContextState | undefined,
+	canContinue: boolean,
+): string[] {
+	const nextCount = state ? state.count + 1 : undefined;
+	const nextBytes = state ? state.totalBytes + selectedBytes : undefined;
+	const selectedLines = endLine - startLine + 1;
+	const snippetOverLimit =
+		state !== undefined &&
+		((state.maximumSnippetLines !== undefined && selectedLines > state.maximumSnippetLines) ||
+			(state.maximumSnippetBytes !== undefined && selectedBytes > state.maximumSnippetBytes));
+	const aggregateOverLimit =
+		state !== undefined &&
+		nextCount !== undefined &&
+		(nextCount > state.maximumCount || (nextBytes ?? 0) > state.maximumBytes);
+	const warning = snippetOverLimit
+		? "Snippet limit exceeded"
+		: aggregateOverLimit
+			? "Next prompt limit exceeded"
+			: undefined;
+	if (width < 74) {
+		const selection = `L${startLine}-${endLine} · ~${tokens} tok`;
+		const capacity = state ? (warning ?? `Next ${nextCount}/${state.maximumCount}`) : undefined;
+		return [
+			[selection, capacity].filter(Boolean).join(" · "),
+			canContinue ? "Enter add · A keep browsing" : "Enter add & close",
+			"Space range · ? actions · Esc back",
+		];
+	}
+	const selection = `Lines ${startLine}-${endLine} · ~${tokens} tokens`;
+	const capacity = state
+		? snippetOverLimit
+			? "Snippet limit exceeded; shorten the range before adding"
+			: aggregateOverLimit
+				? "Next prompt limit exceeded; shorten the range or review selected context"
+				: `Next prompt: ${nextCount}/${state.maximumCount} snippets · ~${estimateTokens(nextBytes ?? 0)} tokens`
+		: undefined;
+	const actions = canContinue
+		? "Enter add & close · A add & continue · Space range · ? actions · Esc back"
+		: "Enter add & close · Space range · ? actions · Esc back";
+	return [[selection, capacity].filter(Boolean).join(" · "), actions];
+}
+
+function selectionRange(anchor: number | undefined, cursor: number) {
+	const rangeAnchor = anchor ?? cursor;
+	return {
+		start: Math.min(rangeAnchor, cursor),
+		end: Math.max(rangeAnchor, cursor),
+	};
+}
+
+function visiblePreviewOffset(current: number, cursor: number, height: number): number {
+	if (cursor < current) return cursor;
+	if (cursor >= current + height) return cursor - height + 1;
+	return current;
+}
+
+function estimateTokens(bytes: number): number {
+	return bytes === 0 ? 0 : Math.max(1, Math.ceil(bytes / 4));
+}
+
+function fitRows(lines: string[], height: number): string[] {
+	if (lines.length <= height) return lines;
+	if (height <= 1) return lines.slice(0, 1);
+	return [...lines.slice(0, height - 1), lines.at(-1) ?? ""];
+}
+
+function escapeTerminalControls(text: string): string {
+	return [...text]
+		.map((character) => {
+			if (character === "\t") return "    ";
+			const code = character.charCodeAt(0);
+			if (code <= 31 || (code >= 127 && code <= 159)) {
+				return `\\x${code.toString(16).padStart(2, "0")}`;
+			}
+			return character;
+		})
+		.join("");
+}

--- a/packages/pi-file-context/src/file-context-preview-ui.ts
+++ b/packages/pi-file-context/src/file-context-preview-ui.ts
@@ -54,7 +54,10 @@ export function renderFilePreview(options: FilePreviewRenderOptions): string[] {
 				options.selectedContext,
 				options.canContinue,
 			);
-	const previewHeight = Math.max(1, options.availableRows - 2 - footerLines.length);
+	const previewHeight = Math.max(
+		1,
+		options.availableRows - 1 - (options.blame ? 1 : 0) - footerLines.length,
+	);
 	const scrollOffset = visiblePreviewOffset(options.scrollOffset, options.cursor, previewHeight);
 	const digits = String(Math.max(1, file.lines.length)).length;
 	const changedLines = new Set(options.fileGit?.hunks.flatMap((hunk) => hunk.changedLines) ?? []);
@@ -99,22 +102,26 @@ export function renderFilePreview(options: FilePreviewRenderOptions): string[] {
 	const blameLabel = options.blame
 		? `L${options.cursor + 1} · ${options.blame.committed ? options.blame.commit.slice(0, 12) : "uncommitted"} · ${escapeTerminalControls(options.blame.author)} · ${escapeTerminalControls(options.blame.summary)}`
 		: "";
-	return fitRows(
-		[
-			truncateToWidth(
-				theme.fg(
-					"accent",
-					theme.bold(`${escapeTerminalControls(file.path)}${gitLabel ? ` · ${gitLabel}` : ""}`),
-				),
-				width,
-				"",
-			),
-			truncateToWidth(theme.fg("muted", blameLabel), width, ""),
-			...previewLines,
-			...footerLines.map((line) =>
-				truncateToWidth(theme.fg(options.error ? "error" : "muted", line), width, ""),
-			),
-		],
+	const titleLine = truncateToWidth(
+		theme.fg(
+			"accent",
+			theme.bold(`${escapeTerminalControls(file.path)}${gitLabel ? ` · ${gitLabel}` : ""}`),
+		),
+		width,
+		"",
+	);
+	const blameLine = blameLabel
+		? truncateToWidth(theme.fg("muted", blameLabel), width, "")
+		: undefined;
+	const renderedFooter = footerLines.map((line) =>
+		truncateToWidth(theme.fg(options.error ? "error" : "muted", line), width, ""),
+	);
+	return fitPreviewRows(
+		titleLine,
+		blameLine,
+		previewLines,
+		renderedFooter,
+		options.error ? 0 : Math.min(1, renderedFooter.length - 1),
 		options.availableRows,
 	);
 }
@@ -214,6 +221,63 @@ function visiblePreviewOffset(current: number, cursor: number, height: number): 
 
 function estimateTokens(bytes: number): number {
 	return bytes === 0 ? 0 : Math.max(1, Math.ceil(bytes / 4));
+}
+
+function fitPreviewRows(
+	title: string,
+	blame: string | undefined,
+	previewLines: readonly string[],
+	footerLines: readonly string[],
+	primaryFooterIndex: number,
+	height: number,
+): string[] {
+	let visibleTitle: string | undefined = title;
+	let visibleBlame = blame;
+	const visiblePreview = [...previewLines];
+	const visibleFooter = footerLines.map((line, index) => ({
+		line,
+		primary: index === primaryFooterIndex,
+	}));
+	const rowCount = () =>
+		(visibleTitle ? 1 : 0) + (visibleBlame ? 1 : 0) + visiblePreview.length + visibleFooter.length;
+
+	while (rowCount() > height) {
+		if (visibleBlame) {
+			visibleBlame = undefined;
+			continue;
+		}
+		if (visiblePreview.length > 1) {
+			visiblePreview.pop();
+			continue;
+		}
+		let optionalFooter = -1;
+		for (let index = visibleFooter.length - 1; index >= 0; index -= 1) {
+			if (!visibleFooter[index]?.primary) {
+				optionalFooter = index;
+				break;
+			}
+		}
+		if (optionalFooter >= 0) {
+			visibleFooter.splice(optionalFooter, 1);
+			continue;
+		}
+		if (visibleTitle) {
+			visibleTitle = undefined;
+			continue;
+		}
+		if (visiblePreview.length > 0) {
+			visiblePreview.pop();
+			continue;
+		}
+		break;
+	}
+
+	return [
+		...(visibleTitle ? [visibleTitle] : []),
+		...(visibleBlame ? [visibleBlame] : []),
+		...visiblePreview,
+		...visibleFooter.map(({ line }) => line),
+	];
 }
 
 function fitRows(lines: string[], height: number): string[] {

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -85,7 +85,6 @@ interface PendingQuote {
 interface ExplorerRunOptions {
 	menuOwned?: boolean;
 	signal?: AbortSignal;
-	showScanTask?: boolean;
 }
 
 type ExplorerRunResult = "stay" | "close";
@@ -326,7 +325,7 @@ export async function registerFileQuoteExtension(
 		ctx.ui.setWidget(WIDGET_KEY, [
 			ctx.ui.theme.fg(
 				"accent",
-				`Quotes (${pendingQuotes.length}) · ~${estimateTokens(totalBytes)} tokens · /file-context to manage`,
+				`Next prompt context · ${pendingQuotes.length} ${pendingQuotes.length === 1 ? "snippet" : "snippets"} · ~${estimateTokens(totalBytes)} tokens · /file-context to review`,
 			),
 			...pendingQuotes.map(({ quote }, index) =>
 				ctx.ui.theme.fg(
@@ -343,11 +342,15 @@ export async function registerFileQuoteExtension(
 		updatePendingWidget(ctx);
 	};
 
-	const appendPending = (quote: FileQuote, ctx: ExtensionContext) => {
+	const validatePending = (quote: FileQuote) => {
 		appendPendingQuote(
 			pendingQuotes.map((item) => item.quote),
 			quote,
 		);
+	};
+
+	const appendPending = (quote: FileQuote, ctx: ExtensionContext) => {
+		validatePending(quote);
 		pendingQuotes = [...pendingQuotes, { id: `quote-${nextPendingQuoteId}`, quote }];
 		nextPendingQuoteId += 1;
 		updatePendingWidget(ctx);
@@ -390,37 +393,31 @@ export async function registerFileQuoteExtension(
 			: controller.signal;
 		activeExplorers.add(activeExplorer);
 		try {
-			let discovery: ExplorerDiscovery;
-			if (options.showScanTask) {
-				const { runTask } = await import("@narumitw/pi-tui-kit");
-				if (!isCurrentSession(owner, generation) || flowSignal.aborted) return "close";
-				const task = await runTask(ctx, {
-					label: "Scanning project files…",
-					signal: flowSignal,
-					isCurrent: () => isCurrentSession(owner, generation) && !flowSignal.aborted,
-					task: ({ signal }) =>
-						Promise.all([discoverFiles(ctx.cwd, { signal }), createGit(ctx.cwd, signal)]),
-					onError: (_taskContext, error) => {
-						ctx.ui.notify(
-							`File Context could not scan project files: ${escapeTerminalControls(formatError(error))}. Choose Add file quote to retry.`,
-							"error",
-						);
-					},
-				});
-				if (task.kind === "cancelled" || task.kind === "error") return "stay";
-				if (task.kind === "stale") return "close";
-				discovery = task.value;
-			} else {
-				discovery = await Promise.all([
-					discoverFiles(ctx.cwd, { signal: flowSignal }),
-					createGit(ctx.cwd, flowSignal),
-				]);
+			const { runTask } = await import("@narumitw/pi-tui-kit");
+			if (!isCurrentSession(owner, generation) || flowSignal.aborted) return "close";
+			const task = await runTask(ctx, {
+				label: "Scanning project files…",
+				signal: flowSignal,
+				isCurrent: () => isCurrentSession(owner, generation) && !flowSignal.aborted,
+				task: ({ signal }) =>
+					Promise.all([discoverFiles(ctx.cwd, { signal }), createGit(ctx.cwd, signal)]),
+				onError: (_taskContext, error) => {
+					ctx.ui.notify(
+						`File Context could not scan project files: ${escapeTerminalControls(formatError(error))}. Open File Context to retry.`,
+						"error",
+					);
+				},
+			});
+			if (task.kind === "cancelled" || task.kind === "error") {
+				return options.menuOwned ? "stay" : "close";
 			}
+			if (task.kind === "stale") return "close";
+			const discovery: ExplorerDiscovery = task.value;
 			if (!isCurrentSession(owner, generation) || flowSignal.aborted) return "close";
 			const [files, gitContext] = discovery;
 			if (files.length === 0) {
 				ctx.ui.notify(
-					"File Context found no project files. Choose Add file quote to retry.",
+					"File Context found no project files. Choose Add context snippet to retry.",
 					"warning",
 				);
 				return options.menuOwned ? "stay" : "close";
@@ -436,6 +433,32 @@ export async function registerFileQuoteExtension(
 						loadFile: (path, signal) => loadProjectTextFile(ctx.cwd, path, { signal }),
 						gitContext,
 						rootNavigation: options.menuOwned,
+						getSelectedContextState: () => ({
+							count: pendingQuotes.length,
+							totalBytes: pendingQuotes.reduce(
+								(total, item) => total + Buffer.byteLength(item.quote.text, "utf8"),
+								0,
+							),
+							maximumCount: MAX_PENDING_QUOTES,
+							maximumBytes: MAX_PENDING_QUOTE_BYTES,
+							maximumSnippetLines: MAX_QUOTE_LINES,
+							maximumSnippetBytes: MAX_QUOTE_BYTES,
+						}),
+						validateQuote: validatePending,
+						onAddAndContinue: (quote) => {
+							if (!isCurrentSession(owner, generation) || flowSignal.aborted) {
+								throw new DOMException("File Context session replaced", "AbortError");
+							}
+							appendPending(quote, ctx);
+							try {
+								ctx.ui.notify(
+									`Added to next prompt context: ${escapeTerminalControls(quote.path)} · lines ${quote.startLine}-${quote.endLine}.`,
+									"info",
+								);
+							} catch {
+								// The widget already reflects the selected snapshot.
+							}
+						},
 						done,
 					});
 					activeExplorer.component = component;
@@ -459,7 +482,7 @@ export async function registerFileQuoteExtension(
 			}
 			try {
 				ctx.ui.notify(
-					`File Context failed: ${escapeTerminalControls(formatError(error))}. Choose Add file quote to retry.`,
+					`File Context failed: ${escapeTerminalControls(formatError(error))}. Open File Context to retry.`,
 					"error",
 				);
 			} catch {
@@ -494,7 +517,7 @@ export async function registerFileQuoteExtension(
 		if (activeMenuLaunch) return activeMenuLaunch.promise;
 		if (activeExplorerLaunch) return activeExplorerLaunch.promise;
 		if (start === "remove" && pendingQuotes.length === 0) {
-			ctx.ui.notify("File Context has no pending quotes.", "warning");
+			ctx.ui.notify("File Context has no context selected for the next prompt.", "warning");
 			return Promise.resolve();
 		}
 		const owner = ctx.sessionManager;
@@ -522,7 +545,7 @@ export async function registerFileQuoteExtension(
 					),
 				};
 			},
-			addQuote: (signal) => runExplorer(ctx, { menuOwned: true, showScanTask: true, signal }),
+			addQuote: (signal) => runExplorer(ctx, { menuOwned: true, signal }),
 			removeQuote: (id, signal) => {
 				if (!isCurrent() || signal.aborted) return { kind: "missing" };
 				const index = pendingQuotes.findIndex((item) => item.id === id);
@@ -568,7 +591,7 @@ export async function registerFileQuoteExtension(
 			const normalized = prefix.trimStart().toLowerCase();
 			const completions = [
 				{ value: "browse", label: "browse", description: "Open the file browser directly" },
-				{ value: "remove", label: "remove", description: "Manage pending quotes directly" },
+				{ value: "remove", label: "remove", description: "Review selected context directly" },
 			].filter(({ value }) => value.startsWith(normalized));
 			return completions.length > 0 ? completions : null;
 		},
@@ -594,8 +617,8 @@ export async function registerFileQuoteExtension(
 		const shortcut = loadedSettings.settings.openShortcut;
 		ctx.ui.notify(
 			shortcut
-				? `Experimental File Context loaded. Press ${shortcut} to browse or run /file-context to manage quotes.`
-				: "Experimental File Context loaded. Run /file-context to add or manage quotes.",
+				? `Experimental File Context loaded. Press ${shortcut} to browse or run /file-context to review selected context.`
+				: "Experimental File Context loaded. Run /file-context to add or review selected context.",
 			"warning",
 		);
 	});

--- a/packages/pi-file-context/test/content-search-ui.test.ts
+++ b/packages/pi-file-context/test/content-search-ui.test.ts
@@ -13,6 +13,7 @@ function createHarness(
 		path: string,
 		signal?: AbortSignal,
 	) => Promise<{ path: string; lines: string[] }> = async (path) => ({ path, lines: [] }),
+	onAddAndContinue?: (quote: unknown) => void,
 ) {
 	const foreground: Array<{ color: string; text: string }> = [];
 	const backgrounds: Array<{ color: string; text: string }> = [];
@@ -42,6 +43,7 @@ function createHarness(
 		} as never,
 		files: ["a.txt", "b.txt"],
 		loadFile,
+		onAddAndContinue,
 		done: (value) => {
 			result = value;
 		},
@@ -91,6 +93,34 @@ test("content result cards highlight literal matches and open preview at the sel
 	explorer.handleInput("enter");
 	await flushAsyncWork();
 	assert.deepEqual(loads.slice(-2), ["b.txt", "b.txt"]);
+});
+
+test("add and continue returns to the originating content results with search state intact", async () => {
+	const continued: unknown[] = [];
+	const { explorer, getResult } = createHarness(
+		async (path) => ({ path, lines: [path === "a.txt" ? "before needle after" : "no match"] }),
+		(quote) => continued.push(quote),
+	);
+	explorer.handleInput(CTRL_F);
+	explorer.handleInput("needle");
+	await flushAsyncWork();
+	explorer.handleInput("enter");
+	await flushAsyncWork();
+	explorer.handleInput("a");
+
+	assert.deepEqual(continued, [
+		{
+			path: "a.txt",
+			startLine: 1,
+			endLine: 1,
+			text: "before needle after",
+		},
+	]);
+	assert.equal(getResult(), "pending");
+	const restored = explorer.render(48).join("\n");
+	assert.match(restored, /Content Search/u);
+	assert.match(restored, /needle/u);
+	assert.match(restored, /a\.txt/u);
 });
 
 test("content result cards keep a distant match visible within narrow context", async () => {

--- a/packages/pi-file-context/test/file-context-command-menu.test.ts
+++ b/packages/pi-file-context/test/file-context-command-menu.test.ts
@@ -63,46 +63,106 @@ test("makes the no-argument command a menu and advertises compatibility routes",
 		await tui.waitForOpen();
 		const frame = tui.render().join("\n");
 		assert.match(frame, /File Context/u);
-		assert.match(frame, /Add file quote/u);
-		assert.match(frame, /Remove pending quote \(0\)/u);
+		assert.match(frame, /Add context snippet/u);
+		assert.match(frame, /Review selected context \(0\)/u);
 		tui.press("ctrl+c");
 		await running;
 	});
 });
 
-test("keeps browse and the configured shortcut as direct explorer paths", async () => {
+test("keeps direct routes while showing the same cancellable scan before browsing", async () => {
 	for (const route of ["browse", "shortcut"] as const) {
 		await withTempProject(async (root) => {
 			const mock = createMockPi();
+			let resolveScan: ((files: string[]) => void) | undefined;
 			await registerFileQuoteExtension(mock.pi, {
 				loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
+				discoverFiles: async () =>
+					new Promise<string[]>((resolve) => {
+						resolveScan = resolve;
+					}),
+				createGit: async () => undefined,
 			});
 			const pasted: string[] = [];
-			const context = createMockContext({
-				mode: "tui",
-				hasUI: true,
-				cwd: root,
-				ui: {
-					theme: { fg: (_color: string, text: string) => text },
-					notify() {},
-					setWidget() {},
-					async custom() {
-						return { kind: "reference", path: "example.ts" };
+			const tui = createTuiHarness({
+				width: 40,
+				rows: 12,
+				keybindings: {
+					matches(data: string, binding: string) {
+						return data === "\t" && binding === "tui.input.tab";
 					},
+					getKeys() {
+						return [];
+					},
+				} as never,
+			});
+			const base = createMockContext({ mode: "tui", hasUI: true, cwd: root });
+			const baseCtx = base.ctx as unknown as { ui: Record<string, unknown> } & Record<
+				string,
+				unknown
+			>;
+			const ctx = {
+				...baseCtx,
+				ui: {
+					...baseCtx.ui,
+					custom: tui.custom,
 					pasteToEditor(value: string) {
 						pasted.push(value);
 					},
 				},
-			});
-			await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-			if (route === "browse") {
-				await mock.commands.get("file-context")?.handler("browse", context.ctx);
-			} else {
-				await mock.shortcuts.get("f8")?.handler(context.ctx);
-			}
+			} as never;
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			const running = Promise.resolve(
+				route === "browse"
+					? mock.commands.get("file-context")?.handler("browse", ctx)
+					: mock.shortcuts.get("f8")?.handler(ctx),
+			);
+			await tui.waitForOpen();
+			assert.match(tui.render().join("\n"), /Scanning project files/u);
+			const scanOpenCount = tui.openCount;
+			resolveScan?.(["example.ts"]);
+			await waitForNextOpen(tui, scanOpenCount);
+			assert.match(tui.render().join("\n"), /File Context · files/u);
+			tui.send("\t");
+			await running;
 			assert.deepEqual(pasted, ["@example.ts "]);
 		});
 	}
+});
+
+test("cancels direct-route scanning without opening a stale explorer", async () => {
+	await withTempProject(async (root) => {
+		const mock = createMockPi();
+		let scanSignal: AbortSignal | undefined;
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
+			discoverFiles: async (_root, { signal } = {}) => {
+				scanSignal = signal;
+				return new Promise<string[]>((_resolve, reject) => {
+					signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+				});
+			},
+			createGit: async () => undefined,
+		});
+		const tui = createTuiHarness({ width: 40, rows: 12 });
+		const base = createMockContext({ mode: "tui", hasUI: true, cwd: root });
+		const baseCtx = base.ctx as unknown as { ui: Record<string, unknown> } & Record<
+			string,
+			unknown
+		>;
+		const ctx = {
+			...baseCtx,
+			ui: { ...baseCtx.ui, custom: tui.custom },
+		} as never;
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		const running = Promise.resolve(mock.shortcuts.get("f8")?.handler(ctx));
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Scanning project files/u);
+		tui.press("tui.select.cancel");
+		await running;
+		assert.equal(scanSignal?.aborted, true);
+		assert.equal(tui.openCount, 1);
+	});
 });
 
 test("reports project scanning failures and returns to a retryable menu", async () => {
@@ -136,7 +196,7 @@ test("reports project scanning failures and returns to a retryable menu", async 
 		const scanOpenCount = tui.openCount;
 		rejectScan?.(new Error("scan \u001b[31mfailed"));
 		await waitForNextOpen(tui, scanOpenCount);
-		assert.match(tui.render().join("\n"), /Add file quote/u);
+		assert.match(tui.render().join("\n"), /Add context snippet/u);
 		assert.ok(!(base.notifications.at(-1)?.message ?? "").includes("\u001b"));
 		assert.match(base.notifications.at(-1)?.message ?? "", /could not scan.*retry/iu);
 		tui.press("ctrl+c");
@@ -179,7 +239,7 @@ test("shows cancellable project scanning before Add and returns to the menu on c
 		tui.press("tui.select.cancel");
 		await waitForNextOpen(tui, scanOpenCount);
 		assert.equal(scanSignal?.aborted, true);
-		assert.match(tui.render().join("\n"), /Add file quote/u);
+		assert.match(tui.render().join("\n"), /Add context snippet/u);
 		tui.press("ctrl+c");
 		await running;
 	});

--- a/packages/pi-file-context/test/file-context-lifecycle.test.ts
+++ b/packages/pi-file-context/test/file-context-lifecycle.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "vitest";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
 import { registerFileQuoteExtension } from "../src/file-context.js";
 
 test("disposes and settles an active explorer on session replacement", async () => {
@@ -29,6 +33,7 @@ async function assertExplorerLifecycleCancellation(
 			markReady = resolve;
 		});
 		let disposed = false;
+		let customCalls = 0;
 		const oldManager = { getSessionId: () => "old" };
 		const newManager = { getSessionId: () => "new" };
 		const makeContext = (sessionManager: object, custom?: (factory: unknown) => Promise<unknown>) =>
@@ -47,32 +52,34 @@ async function assertExplorerLifecycleCancellation(
 					pasteToEditor() {},
 				},
 			});
-		const oldContext = makeContext(
-			oldManager,
-			(factory) =>
-				new Promise((resolve) => {
-					const component = (
-						factory as (...args: unknown[]) => {
-							dispose(): void;
-						}
-					)(
-						{ terminal: { rows: 18 }, requestRender() {} },
-						{
-							fg: (_color: string, text: string) => text,
-							bg: (_color: string, text: string) => text,
-							bold: (text: string) => text,
-						},
-						{ matches: () => false },
-						resolve,
-					);
-					const dispose = component.dispose.bind(component);
-					component.dispose = () => {
-						disposed = true;
-						dispose();
-					};
-					markReady();
-				}),
-		);
+		const oldContext = makeContext(oldManager, async (factory) => {
+			customCalls += 1;
+			if (customCalls === 1) {
+				return createCustomSelectorHarness(factory).resultPromise;
+			}
+			return new Promise((resolve) => {
+				const component = (
+					factory as (...args: unknown[]) => {
+						dispose(): void;
+					}
+				)(
+					{ terminal: { rows: 18 }, requestRender() {} },
+					{
+						fg: (_color: string, text: string) => text,
+						bg: (_color: string, text: string) => text,
+						bold: (text: string) => text,
+					},
+					{ matches: () => false },
+					resolve,
+				);
+				const dispose = component.dispose.bind(component);
+				component.dispose = () => {
+					disposed = true;
+					dispose();
+				};
+				markReady();
+			});
+		});
 		const newContext = makeContext(newManager);
 		await mock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
 		let settled = false;

--- a/packages/pi-file-context/test/file-context-menu.test.ts
+++ b/packages/pi-file-context/test/file-context-menu.test.ts
@@ -90,14 +90,14 @@ test("shows the primary menu immediately with visible state and disabled reasons
 	}
 	const initial = tui.render().join("\n");
 	assert.match(initial, /File Context/u);
-	assert.match(initial, /Pending quotes: 0\/8/u);
+	assert.match(initial, /Next prompt context: 0\/8 snippets/u);
 	assert.match(initial, /Shortcut: F8/u);
-	assert.match(initial, /Add file quote/u);
+	assert.match(initial, /Add context snippet/u);
 
 	tui.press("tui.select.down");
 	const disabled = tui.render().join("\n");
-	assert.match(disabled, /\[-\].*Remove pending quote \(0\)/u);
-	assert.match(disabled, /No pending quotes to remove/u);
+	assert.match(disabled, /\[-\].*Review selected context \(0\)/u);
+	assert.match(disabled, /No context selected for the next prompt/u);
 	tui.press("tui.select.confirm");
 	await tui.waitForPending();
 	assert.equal(removeCalls, 0);
@@ -142,16 +142,16 @@ test("opens Help from the menu and Escape returns without side effects", async (
 	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
 	await tui.waitForOpen();
-	assert.match(tui.render().join("\n"), /Pending quotes are attached.*next prompt/u);
+	assert.match(tui.render().join("\n"), /Selected context is attached.*next prompt/u);
 	tui.press("tui.select.cancel");
 	await tui.waitForOpen();
-	assert.match(tui.render().join("\n"), /Add file quote/u);
+	assert.match(tui.render().join("\n"), /Add context snippet/u);
 	assert.equal(addCalls, 0);
 	tui.press("ctrl+c");
 	await running;
 });
 
-test("previews and repeatedly removes exact duplicate-looking quotes by stable ID", async () => {
+test("reviews exact snippets before repeatedly removing them by stable ID", async () => {
 	const { tui, ctx, notifications } = menuContext(40, 12);
 	let current = state([
 		quote("quote-1", { text: "first snapshot\nwith details" }),
@@ -176,21 +176,39 @@ test("previews and repeatedly removes exact duplicate-looking quotes by stable I
 	await tui.waitForOpen();
 	const firstChoice = tui.render().join("\n");
 	assert.match(firstChoice, /src\/example\.ts/u);
-	assert.match(firstChoice, /Lines: 1-1/u);
-	assert.match(firstChoice, /first snapshot.*with details/u);
+	assert.match(firstChoice, /Lines 1-1/u);
+	assert.equal(removedIds.length, 0);
 
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	const firstReview = tui.render().join("\n");
+	assert.match(firstReview, /Review context snippet/u);
+	assert.match(firstReview, /first snapshot/u);
+	assert.match(firstReview, /with details/u);
+	assert.match(firstReview, /Remove from next\s+prompt/u);
+	assert.equal(removedIds.length, 0);
+
+	tui.press("tui.select.cancel");
+	await tui.waitForOpen();
+	assert.match(tui.render().join("\n"), /Selected context/u);
+	assert.equal(removedIds.length, 0);
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
 	tui.press("tui.select.confirm");
 	await tui.waitForPending();
 	await tui.waitForOpen();
-	assert.match(tui.render().join("\n"), /second snapshot.*with details/u);
+	assert.match(tui.render().join("\n"), /second snapshot/u);
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	assert.match(tui.render().join("\n"), /Review context snippet/u);
 	tui.press("tui.select.confirm");
 	await tui.waitForPending();
 	await tui.waitForOpen();
 
 	assert.deepEqual(removedIds, ["quote-1", "quote-2"]);
-	assert.match(tui.render().join("\n"), /Pending quotes: 0\/8/u);
+	assert.match(tui.render().join("\n"), /No context selected for the next prompt/u);
 	assert.equal(
-		notifications.filter(({ message }) => /Removed pending quote/u.test(message)).length,
+		notifications.filter(({ message }) => /Removed from next prompt context/u.test(message)).length,
 		2,
 	);
 	tui.press("ctrl+c");
@@ -244,7 +262,7 @@ test("disables Add at either hard pending limit", async () => {
 			}),
 		);
 		await tui.waitForOpen();
-		assert.match(tui.render().join("\n"), /\[-\].*Add file quote/u);
+		assert.match(tui.render().join("\n"), /\[-\].*Add context snippet/u);
 		tui.press("tui.select.confirm");
 		await tui.waitForPending();
 		assert.equal(addCalls, 0);

--- a/packages/pi-file-context/test/file-context-search.test.ts
+++ b/packages/pi-file-context/test/file-context-search.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { ProjectFileSearch } from "../src/file-search.js";
+
+test("ranks fuzzy file matches and tolerates typos", () => {
+	const files = [
+		"file-context.ts-notes/README.md",
+		"src/file-context.ts",
+		"src/settings.ts",
+		"docs/guide.md",
+	];
+
+	const search = new ProjectFileSearch(files);
+	assert.deepEqual(search.search("  FILE-context.ts  "), [
+		"src/file-context.ts",
+		"file-context.ts-notes/README.md",
+	]);
+	assert.deepEqual(search.search("src/settings"), ["src/settings.ts"]);
+	assert.deepEqual(search.search("fc"), ["src/file-context.ts", "file-context.ts-notes/README.md"]);
+	assert.deepEqual(search.search("stg"), ["src/settings.ts"]);
+	assert.deepEqual(search.search("setxings"), ["src/settings.ts"]);
+	assert.deepEqual(search.search("settigns"), ["src/settings.ts"]);
+	assert.deepEqual(search.search("file-contexx.ts"), [
+		"src/file-context.ts",
+		"file-context.ts-notes/README.md",
+	]);
+	assert.deepEqual(search.search("zzzzzz"), []);
+	assert.deepEqual(search.search("  "), files);
+});
+
+test("bounds fuzzy search before scoring overlong pasted queries", () => {
+	const maximumQuery = "a".repeat(256);
+	const overlongQuery = `${maximumQuery}a`;
+
+	assert.deepEqual(new ProjectFileSearch([maximumQuery]).search(maximumQuery), [maximumQuery]);
+	assert.deepEqual(new ProjectFileSearch([overlongQuery]).search(overlongQuery), []);
+});

--- a/packages/pi-file-context/test/file-context-selection.test.ts
+++ b/packages/pi-file-context/test/file-context-selection.test.ts
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { FileQuoteExplorer } from "../src/file-context-explorer.js";
+
+test("explorer keeps an over-limit selection editable instead of closing", async () => {
+	let result: unknown = "pending";
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 12 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return data === "enter" && key === "tui.select.confirm";
+			},
+		} as never,
+		files: ["large.txt"],
+		loadFile: async () => ({ path: "large.txt", lines: ["large"] }),
+		getSelectedContextState: () => ({
+			count: 8,
+			totalBytes: 100,
+			maximumCount: 8,
+			maximumBytes: 100_000,
+		}),
+		validateQuote: () => {
+			throw new Error("File Context supports at most 8 pending quotes");
+		},
+		done: (value) => {
+			result = value;
+		},
+	});
+
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.match(explorer.render(80).join("\n"), /Next prompt limit exceeded/u);
+	explorer.handleInput("enter");
+	assert.equal(result, "pending");
+	assert.match(explorer.render(80).join("\n"), /at most 8 pending quotes/u);
+});
+
+test("preview warns for per-snippet line and byte limits before adding", async () => {
+	for (const lines of [Array.from({ length: 501 }, () => "x"), ["x".repeat(50_001)]]) {
+		const explorer = new FileQuoteExplorer({
+			tui: { terminal: { rows: 12 }, requestRender() {} } as never,
+			theme: {
+				fg: (_color: string, text: string) => text,
+				bg: (_color: string, text: string) => text,
+				bold: (text: string) => text,
+			} as never,
+			keybindings: {
+				matches(data: string, key: string) {
+					return (
+						(data === "enter" && key === "tui.select.confirm") ||
+						(data === "down" && key === "tui.select.down")
+					);
+				},
+			} as never,
+			files: ["large.txt"],
+			loadFile: async () => ({ path: "large.txt", lines }),
+			getSelectedContextState: () => ({
+				count: 0,
+				totalBytes: 0,
+				maximumCount: 8,
+				maximumBytes: 100_000,
+				maximumSnippetLines: 500,
+				maximumSnippetBytes: 50_000,
+			}),
+			done() {},
+		});
+
+		explorer.handleInput("enter");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		if (lines.length > 1) {
+			explorer.handleInput(" ");
+			for (let index = 1; index < lines.length; index += 1) explorer.handleInput("down");
+		}
+		assert.match(explorer.render(80).join("\n"), /Snippet limit exceeded/u);
+	}
+});
+
+test("diff attachment also stays open when aggregate validation fails", async () => {
+	let result: unknown = "pending";
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 12 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return data === "enter" && key === "tui.select.confirm";
+			},
+		} as never,
+		files: ["changed.ts"],
+		loadFile: async () => ({ path: "changed.ts", lines: ["changed"] }),
+		gitContext: {
+			project: {
+				repositoryRoot: "/repo",
+				projectPrefix: "",
+				branch: "main",
+				head: "a".repeat(40),
+				dirty: true,
+			},
+			statuses: new Map(),
+			async getFileContext() {
+				return {
+					status: undefined,
+					blob: undefined,
+					hunks: [
+						{
+							header: "@@ -1 +1 @@",
+							oldStart: 1,
+							oldCount: 1,
+							newStart: 1,
+							newCount: 1,
+							lines: ["@@ -1 +1 @@", "-old", "+changed"],
+							changedLines: [1],
+						},
+					],
+				};
+			},
+		} as never,
+		validateQuote: () => {
+			throw new Error("Pending quotes exceed 100000 bytes");
+		},
+		done: (value) => {
+			result = value;
+		},
+	});
+
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput("d");
+	explorer.handleInput("enter");
+	assert.equal(result, "pending");
+	assert.match(explorer.render(80).join("\n"), /exceed 100000 bytes/u);
+});
+
+test("explorer adds exact context and keeps browsing with visible capacity and adaptive help", async () => {
+	let result: unknown = "pending";
+	let selectedCount = 2;
+	let selectedBytes = 100;
+	const continued: unknown[] = [];
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 16 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return (
+					(data === "enter" && key === "tui.select.confirm") ||
+					(data === "down" && key === "tui.select.down")
+				);
+			},
+		} as never,
+		files: ["src/context.ts"],
+		loadFile: async () => ({ path: "src/context.ts", lines: ["one", "two"] }),
+		getSelectedContextState: () => ({
+			count: selectedCount,
+			totalBytes: selectedBytes,
+			maximumCount: 8,
+			maximumBytes: 100_000,
+		}),
+		onAddAndContinue: (quote) => {
+			continued.push(quote);
+			selectedCount += 1;
+			selectedBytes += Buffer.byteLength(quote.text, "utf8");
+		},
+		done: (value) => {
+			result = value;
+		},
+	});
+
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput(" ");
+	explorer.handleInput("down");
+	const wide = explorer.render(80).join("\n");
+	assert.match(wide, /Next prompt: 3\/8 snippets/u);
+	assert.match(wide, /Enter add & close/u);
+	assert.match(wide, /A add & continue/u);
+	const narrow = explorer.render(36);
+	assert.ok(narrow.every((line) => visibleWidth(line) <= 36));
+	assert.match(narrow.join("\n"), /Enter add/u);
+	assert.match(narrow.join("\n"), /A keep browsing/u);
+	assert.match(narrow.join("\n"), /\? actions/u);
+
+	explorer.handleInput("?");
+	const help = explorer.render(36);
+	assert.ok(help.every((line) => visibleWidth(line) <= 36));
+	assert.match(help.join("\n"), /Preview actions/u);
+	assert.match(help.join("\n"), /Blame/u);
+	assert.match(help.join("\n"), /Git diff/u);
+	explorer.handleInput("\u001b");
+	assert.match(explorer.render(80).join("\n"), /Enter add & close/u);
+
+	explorer.handleInput("a");
+	assert.deepEqual(continued, [
+		{
+			path: "src/context.ts",
+			startLine: 1,
+			endLine: 2,
+			text: "one\ntwo",
+		},
+	]);
+	assert.equal(result, "pending");
+	assert.ok(explorer.render(80).some((line) => line.includes("File Context · files")));
+
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput("enter");
+	assert.deepEqual(result, {
+		kind: "quote",
+		quote: { path: "src/context.ts", startLine: 1, endLine: 1, text: "one" },
+	});
+});
+
+test("compact preview help keeps every advanced action visible on short terminals", async () => {
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 8 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return data === "enter" && key === "tui.select.confirm";
+			},
+		} as never,
+		files: ["short.ts"],
+		loadFile: async () => ({ path: "short.ts", lines: ["short"] }),
+		done() {},
+	});
+
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput("?");
+	const help = explorer.render(36);
+	assert.ok(help.every((line) => visibleWidth(line) <= 36));
+	assert.match(help.join("\n"), /B blame/u);
+	assert.match(help.join("\n"), /H history/u);
+	assert.match(help.join("\n"), /R revision/u);
+	assert.match(help.join("\n"), /D Git diff/u);
+});
+
+test("preview help cancels stale history loading before returning to preview", async () => {
+	let resolveHistory: ((entries: []) => void) | undefined;
+	let historySignal: AbortSignal | undefined;
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 12 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return data === "enter" && key === "tui.select.confirm";
+			},
+		} as never,
+		files: ["history.ts"],
+		loadFile: async () => ({ path: "history.ts", lines: ["history"] }),
+		gitContext: {
+			project: {
+				repositoryRoot: "/repo",
+				projectPrefix: "",
+				branch: "main",
+				head: "a".repeat(40),
+				dirty: false,
+			},
+			statuses: new Map(),
+			async getFileContext() {
+				return { status: undefined, blob: undefined, hunks: [] };
+			},
+			async getHistory(_path: string, signal: AbortSignal) {
+				historySignal = signal;
+				return new Promise<[]>((resolve) => {
+					resolveHistory = resolve;
+				});
+			},
+		} as never,
+		done() {},
+	});
+
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput("h");
+	explorer.handleInput("?");
+	assert.equal(historySignal?.aborted, true);
+	explorer.handleInput("\u001b");
+	resolveHistory?.([]);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.ok(explorer.render(80).some((line) => line.includes("history.ts")));
+	assert.ok(explorer.render(80).every((line) => !line.includes("File history")));
+});

--- a/packages/pi-file-context/test/file-context-selection.test.ts
+++ b/packages/pi-file-context/test/file-context-selection.test.ts
@@ -222,6 +222,33 @@ test("explorer adds exact context and keeps browsing with visible capacity and a
 	});
 });
 
+test("short narrow previews keep primary add controls visible", async () => {
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 8 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return data === "enter" && key === "tui.select.confirm";
+			},
+		} as never,
+		files: ["short.ts"],
+		loadFile: async () => ({ path: "short.ts", lines: ["short"] }),
+		onAddAndContinue() {},
+		done() {},
+	});
+
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	const preview = explorer.render(36);
+	assert.ok(preview.every((line) => visibleWidth(line) <= 36));
+	assert.match(preview.join("\n"), /Enter add/u);
+	assert.match(preview.join("\n"), /A keep browsing/u);
+});
+
 test("compact preview help keeps every advanced action visible on short terminals", async () => {
 	const explorer = new FileQuoteExplorer({
 		tui: { terminal: { rows: 8 }, requestRender() {} } as never,

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
 import {
 	appendPendingQuote,
 	createFileQuote,
@@ -15,7 +19,6 @@ import {
 	registerFileQuoteExtension,
 } from "../src/file-context.js";
 import { FileQuoteExplorer } from "../src/file-context-explorer.js";
-import { ProjectFileSearch } from "../src/file-search.js";
 
 async function withTempProject(run: (root: string) => Promise<void>): Promise<void> {
 	const root = await mkdtemp(join(tmpdir(), "pi-file-context-test-"));
@@ -103,40 +106,6 @@ test("rejects a validated file replaced by a symlink before descriptor open", as
 			await rm(outside, { recursive: true, force: true });
 		}
 	});
-});
-
-test("ranks fuzzy file matches and tolerates typos", () => {
-	const files = [
-		"file-context.ts-notes/README.md",
-		"src/file-context.ts",
-		"src/settings.ts",
-		"docs/guide.md",
-	];
-
-	const search = new ProjectFileSearch(files);
-	assert.deepEqual(search.search("  FILE-context.ts  "), [
-		"src/file-context.ts",
-		"file-context.ts-notes/README.md",
-	]);
-	assert.deepEqual(search.search("src/settings"), ["src/settings.ts"]);
-	assert.deepEqual(search.search("fc"), ["src/file-context.ts", "file-context.ts-notes/README.md"]);
-	assert.deepEqual(search.search("stg"), ["src/settings.ts"]);
-	assert.deepEqual(search.search("setxings"), ["src/settings.ts"]);
-	assert.deepEqual(search.search("settigns"), ["src/settings.ts"]);
-	assert.deepEqual(search.search("file-contexx.ts"), [
-		"src/file-context.ts",
-		"file-context.ts-notes/README.md",
-	]);
-	assert.deepEqual(search.search("zzzzzz"), []);
-	assert.deepEqual(search.search("  "), files);
-});
-
-test("bounds fuzzy search before scoring overlong pasted queries", () => {
-	const maximumQuery = "a".repeat(256);
-	const overlongQuery = `${maximumQuery}a`;
-
-	assert.deepEqual(new ProjectFileSearch([maximumQuery]).search(maximumQuery), [maximumQuery]);
-	assert.deepEqual(new ProjectFileSearch([overlongQuery]).search(overlongQuery), []);
 });
 
 test("explorer previews a file, selects a range, and keeps rendered rows width-safe", async () => {
@@ -806,6 +775,7 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 
 	let customFactory: unknown;
 	const widgets = new Map<string, unknown>();
+	let customCall = 0;
 	let quoteIndex = 0;
 	const quoteResults = [
 		{
@@ -842,6 +812,10 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 				widgets.set(key, value);
 			},
 			async custom(factory: unknown) {
+				customCall += 1;
+				if (customCall % 2 === 1) {
+					return createCustomSelectorHarness(factory).resultPromise;
+				}
 				customFactory = factory;
 				const result = quoteResults[quoteIndex];
 				quoteIndex += 1;
@@ -855,7 +829,7 @@ test("registers a TUI fallback command and injects all pending quotes only once"
 	await mock.commands.get("file-context")?.handler("browse", context.ctx);
 	assert.equal(typeof customFactory, "function");
 	assert.deepEqual(widgets.get("file-context"), [
-		"Quotes (2) · ~13 tokens · /file-context to manage",
+		"Next prompt context · 2 snippets · ~13 tokens · /file-context to review",
 		"1. src/example.ts · lines 1-1 · ~6 tokens",
 		"2. test/example.test.ts · lines 2-3 · ~8 tokens",
 	]);
@@ -890,6 +864,7 @@ test("quotes whole-file references and rejects picker results from replaced sess
 		loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
 	});
 	const pasted: string[] = [];
+	let referenceCustomCalls = 0;
 	const referenceContext = createMockContext({
 		mode: "tui",
 		hasUI: true,
@@ -902,7 +877,11 @@ test("quotes whole-file references and rejects picker results from replaced sess
 			getEditorComponent() {
 				return undefined;
 			},
-			async custom() {
+			async custom(factory: unknown) {
+				referenceCustomCalls += 1;
+				if (referenceCustomCalls === 1) {
+					return createCustomSelectorHarness(factory).resultPromise;
+				}
 				return { kind: "reference", path: 'docs/my "note".md' };
 			},
 			pasteToEditor(value: string) {
@@ -924,8 +903,9 @@ test("quotes whole-file references and rejects picker results from replaced sess
 	});
 	const oldManager = { getSessionId: () => "old" };
 	const newManager = { getSessionId: () => "new" };
-	const makeContext = (sessionManager: object, custom: () => Promise<unknown>) =>
-		createMockContext({
+	const makeContext = (sessionManager: object, custom: () => Promise<unknown>) => {
+		let customCalls = 0;
+		return createMockContext({
 			mode: "tui",
 			hasUI: true,
 			cwd: process.cwd(),
@@ -938,10 +918,17 @@ test("quotes whole-file references and rejects picker results from replaced sess
 				getEditorComponent() {
 					return undefined;
 				},
-				custom,
+				async custom(factory: unknown) {
+					customCalls += 1;
+					if (customCalls === 1) {
+						return createCustomSelectorHarness(factory).resultPromise;
+					}
+					return custom();
+				},
 				pasteToEditor() {},
 			},
 		});
+	};
 	const oldContext = makeContext(oldManager, async () => picker);
 	const newContext = makeContext(newManager, async () => undefined);
 	await staleMock.events.get("session_start")?.[0]?.({}, oldContext.ctx);

--- a/packages/pi-file-context/test/pending-quotes.test.ts
+++ b/packages/pi-file-context/test/pending-quotes.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	createCustomSelectorHarness,
+	createMockContext,
+	createMockPi,
+} from "../../../test/support.js";
 import { registerFileQuoteExtension } from "../src/file-context.js";
 
 async function withTempProject(run: (root: string) => Promise<void>): Promise<void> {
@@ -44,6 +48,7 @@ test("removes an exact duplicate-looking pending quote and refreshes the widget"
 				quote: { path: "src/example.ts", startLine: 1, endLine: 1, text: "second snapshot" },
 			},
 		];
+		let customCalls = 0;
 		let quoteIndex = 0;
 		const widgets = new Map<string, unknown>();
 		const context = createMockContext({
@@ -56,7 +61,11 @@ test("removes an exact duplicate-looking pending quote and refreshes the widget"
 				setWidget(key: string, value: unknown) {
 					widgets.set(key, value);
 				},
-				async custom() {
+				async custom(factory: unknown) {
+					customCalls += 1;
+					if (customCalls % 2 === 1) {
+						return createCustomSelectorHarness(factory).resultPromise;
+					}
 					const result = quoteResults[quoteIndex];
 					quoteIndex += 1;
 					return result;
@@ -79,10 +88,15 @@ test("removes an exact duplicate-looking pending quote and refreshes the widget"
 		await waitForNextOpen(tui, mainCount);
 		assert.match(tui.render().join("\n"), /first snapshot/u);
 		tui.press("tui.select.down");
-		const removeCount = tui.openCount;
+		const selectedCount = tui.openCount;
+		tui.press("tui.select.confirm");
+		await waitForNextOpen(tui, selectedCount);
+		assert.match(tui.render().join("\n"), /Review context snippet/u);
+		assert.match(tui.render().join("\n"), /second snapshot/u);
+		const reviewCount = tui.openCount;
 		tui.press("tui.select.confirm");
 		await tui.waitForPending();
-		await waitForNextOpen(tui, removeCount);
+		await waitForNextOpen(tui, reviewCount);
 		assert.match(tui.render().join("\n"), /first snapshot/u);
 		assert.doesNotMatch(tui.render().join("\n"), /second snapshot/u);
 		tui.press("tui.select.cancel");
@@ -91,7 +105,7 @@ test("removes an exact duplicate-looking pending quote and refreshes the widget"
 		await running;
 
 		assert.deepEqual(widgets.get("file-context"), [
-			"Quotes (1) · ~4 tokens · /file-context to manage",
+			"Next prompt context · 1 snippet · ~4 tokens · /file-context to review",
 			"1. src/example.ts · lines 1-1 · ~4 tokens",
 		]);
 		const injection = await mock.events.get("before_agent_start")?.[0]?.(
@@ -111,6 +125,7 @@ test("removal cancellation and menu failures preserve pending quotes", async () 
 		});
 		const widgets = new Map<string, unknown>();
 		const notifications: string[] = [];
+		let customCalls = 0;
 		const context = createMockContext({
 			mode: "tui",
 			hasUI: true,
@@ -123,7 +138,11 @@ test("removal cancellation and menu failures preserve pending quotes", async () 
 				setWidget(key: string, value: unknown) {
 					widgets.set(key, value);
 				},
-				async custom() {
+				async custom(factory: unknown) {
+					customCalls += 1;
+					if (customCalls === 1) {
+						return createCustomSelectorHarness(factory).resultPromise;
+					}
 					return {
 						kind: "quote",
 						quote: { path: "src/keep.ts", startLine: 4, endLine: 4, text: "keep" },
@@ -163,7 +182,7 @@ test("removal cancellation and menu failures preserve pending quotes", async () 
 		);
 		assert.match(JSON.stringify(injection), /src\/keep\.ts/u);
 		await command?.handler("remove", context.ctx);
-		assert.match(notifications.at(-1) ?? "", /no pending quotes/iu);
+		assert.match(notifications.at(-1) ?? "", /no .*context/iu);
 	});
 });
 
@@ -175,6 +194,7 @@ test("session replacement closes the menu and ignores stale input", async () => 
 		});
 		const oldManager = { getSessionId: () => "old" };
 		const newManager = { getSessionId: () => "new" };
+		let oldCustomCalls = 0;
 		const oldContext = createMockContext({
 			mode: "tui",
 			hasUI: true,
@@ -184,7 +204,11 @@ test("session replacement closes the menu and ignores stale input", async () => 
 				theme: { fg: (_color: string, text: string) => text },
 				notify() {},
 				setWidget() {},
-				async custom() {
+				async custom(factory: unknown) {
+					oldCustomCalls += 1;
+					if (oldCustomCalls === 1) {
+						return createCustomSelectorHarness(factory).resultPromise;
+					}
 					return {
 						kind: "quote",
 						quote: { path: "src/old.ts", startLine: 1, endLine: 1, text: "old" },


### PR DESCRIPTION
## Summary

- present queued snapshots consistently as next-prompt context and review exact content before removal
- add `a` for add-and-continue browsing, visible count/token capacity, per-snippet limit warnings, and adaptive `?` help
- show the same cancellable project scan for menu, shortcut, and direct command routes while preserving lifecycle and compatibility behavior

## Verification

- `npm run check` — 365 files and 3,707 tests passed
- focused File Context suite — 11 files and 68 tests passed
- `just pack file-context` — 14 published files inspected
- `npm run changeset:status` — `@narumitw/pi-file-context` resolves to a minor bump
- offline RPC `get_commands` smoke — extension loaded and registered `/file-context`
- `git diff --check`

## Review notes

- audited against `docs/extension-conventions.md` for TUI guards, cancellation, disposal, stale awaits, width bounds, terminal sanitization, command compatibility, tests, and package contents
- independent review findings for stale help requests, short-and-narrow help, and per-snippet capacity warnings were fixed with regression tests
- live interactive TUI smoke was not run because repository policy forbids interactive TUI commands; deterministic TUI harness tests cover the changed flows
