### PR TITLE
perf: defer heavy extension imports

### DIFF
--- a/.changeset/faster-extension-startup.md
+++ b/.changeset/faster-extension-startup.md
@@ -1,0 +1,6 @@
+---
+"@narumitw/pi-subagents": patch
+"@narumitw/pi-workflow": patch
+---
+
+Reduce idle Pi startup imports by loading Subagents execution and selected transport implementations, plus Workflow manager and fresh-session handoff code, only when their registered routes first need them.

--- a/docs/plans/archived/2026-08-13_slow-extension-startup-plan.md
+++ b/docs/plans/archived/2026-08-13_slow-extension-startup-plan.md
@@ -1,0 +1,60 @@
+# Slow extension startup reduction plan
+
+## Goal
+
+Reduce idle Pi startup time from `pi-subagents` and `pi-workflow` without delaying equivalent work into `session_start` or changing their tools, commands, settings, persistence, or lifecycle behavior.
+
+## Context
+
+- The reported installed startup attributes 1,397 ms to `pi-subagents` and 668 ms to `pi-workflow`, which together account for about 59% of all extension import time.
+- A five-run source baseline on Node 25.9.0 measured a combined import median of 1,932 ms with 126 ms MAD and a first-response median of 3,056.21 ms with 258.91 ms MAD.
+- Jiti tracing shows 107 eagerly loaded `pi-subagents` TypeScript modules and 41 eagerly loaded `pi-workflow` TypeScript modules.
+- The largest `pi-subagents` eager roots are registration modules that also import execution, transport, inspection, and settings UI implementations.
+- `pi-workflow` eagerly imports its Pi TUI Kit manager and fresh-session handoff even when neither route is used.
+- Applicable rules are in `docs/extension-conventions.md`, `docs/extension-settings.md`, the Pi extension documentation, and the package-specific `pi-subagents` guidance.
+
+## Architecture
+
+- Keep both canonical `src/index.ts` entrypoints and synchronous factory registration unchanged.
+- Register every existing tool and command eagerly with its current schema, description, renderer, and completion behavior.
+- Cache only code-module imports, clear a rejected loader promise so later use can retry, and never cache a session context or task in a module loader.
+- Load blocking execution, selected detached transport implementations, inspection execution, and manager UI only when their corresponding route is first used.
+- Revalidate abort signals, session generations, session managers, and mutable runtime ownership immediately after each lazy import and before side effects.
+- Keep persistence restoration, pending completion delivery, settings validation, and session cleanup eager where startup correctness requires them.
+- Keep Workflow Plan and Goal runtime registration eager, while deferring only the top-level manager UI and fresh-session implementation handoff.
+
+## Non-Goals
+
+- Reintroduce generated runtime bundles or emit extension implementations outside `src/`.
+- Change public tool or command names, parameter schemas, prompt guidance, settings files, defaults, persistence formats, or transport selection.
+- Delay required state restoration or completion delivery merely to improve the module-import timing line.
+- Optimize smaller extensions until the two dominant packages are measured again.
+- Publish packages, create tags, or dispatch release workflows.
+
+## Risks
+
+- A dynamic import can finish after cancellation or session replacement, so every continuation must prove ownership before running implementation code.
+- Lazy transport loading can race shutdown, so a loader must not start a turn after closure and must dispose an implementation that resolves after shutdown.
+- Splitting registration from implementation can drift tool schemas or renderers, so one lightweight contract must remain the canonical owner.
+- A lower module-import number can hide equivalent startup work, so both import time and first RPC response are completion gates.
+- First use will pay a bounded one-time import cost, which must fail observably and remain retryable after loader rejection.
+
+## Plan
+
+- [x] Capture a five-run combined source baseline and Jiti import traces for both declared entries; evidence is recorded in Context and `/tmp/pi-slow-extensions-baseline.json`.
+- [x] Add focused loader tests for idle registration, successful cache reuse, retry after rejection, and cancellation or replacement while a module is loading; evidence: `startup-imports.test.ts` and `lazy-loading.test.ts` pass.
+- [x] Refactor `pi-subagents` registration boundaries so blocking execution, selected detached transports, inspection work, and manager UI remain absent from idle startup while all current tools and commands register synchronously; evidence: injected idle-loader test and Jiti benchmark passed.
+- [x] Audit `pi-subagents` startup restoration, pending completion delivery, task cancellation, session replacement, shutdown, transport disposal, settings ordering, and invalid-file protection after each new lazy boundary; evidence: focused lifecycle tests and the 3,720-test root gate pass.
+- [x] Refactor `pi-workflow` so `/workflow` manager UI and fresh-session handoff load only for those routes, with retryable loaders and generation checks before UI or session replacement; evidence: four focused lazy-loading regressions pass.
+- [x] Update focused READMEs and add patch Changesets for both published packages without changing public behavior claims; evidence: `.changeset/faster-extension-startup.md` is accepted by Changesets status.
+- [x] Run focused `pi-subagents` and `pi-workflow` tests, then run the five-run combined benchmark and require at least a 30% import-median reduction with no first-response regression larger than three baseline MADs; evidence: import median improved from 1,932 ms to 1,064 ms (44.9%) and first response from 3,056.21 ms to 2,081.75 ms (31.9%).
+- [x] Run `npm run check`, `just pack subagents`, `npm pack --workspace @narumitw/pi-workflow --dry-run --json`, and offline Pi RPC entrypoint smokes; evidence: Node 26.5.0 root check passed 3,720 tests, both package inspections contain complete source trees, and combined RPC command discovery returned success.
+- [x] Audit the final diff against the extension and settings guides, recording cancellation, disposal, replacement, shutdown, settings, benchmark, test, pack, smoke, deviation, and unverified-path evidence; evidence: only code modules are cached, loader rejection resets, lifecycle ownership is revalidated after awaits, idle transport shutdown does not load code, and no settings protocol changed.
+
+## Completion Checklist
+
+- [x] Idle startup does not evaluate deferred Subagents execution, selected transport, inspection, or manager implementations, nor Workflow manager or fresh-handoff implementations.
+- [x] Every existing tool, command, schema, completion, renderer, direct route, settings behavior, and lifecycle contract remains available and tested.
+- [x] Loader rejection is observable and retryable, and stale or aborted loads perform no tool, UI, process, session, persistence, or settings side effect.
+- [x] Combined import median improves by at least 30% and first-response timing stays within the recorded regression gate.
+- [x] Focused tests, `npm run check`, package inspections, offline Pi smokes, Changesets, and semantic audits pass with no unaccepted deviation.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -613,6 +613,9 @@ A detached agent additionally needs a concrete isolation or specialization benef
 The bounded persisted completion outbox provides ordered at-least-once delivery across process restart without replaying the child turn. When state must be reduced to its storage bound, persistence drops roots without pending completions first and trims old history rather than discarding an outbox-owned root. A completion is acknowledged only after parent context assembly observes its exact `completionId`; an injection that returns synchronously but never reaches context remains pending for retry. If the process exits after context assembly but before acknowledgement is persisted, the same ID can be delivered again and consumers must deduplicate it. Auto-resume wake admission remains best-effort because Pi's custom-message API is fire-and-forget, but an unacknowledged terminal completion itself remains available for redelivery on the next start of the owning session. Transient terminal-persistence failures retry with bounded exponential backoff and keep the run pending; shutdown cancels retry waits and reports a final persistence failure instead of silently resolving unsaved work.
 
 The default `subprocess` transport preserves compatibility: each turn starts a fresh isolated `pi --mode json -p --no-session` child and receives sanitized, bounded history.
+Pi registers every Subagents tool and command during startup, but loads blocking execution, manager UI, inspection work, and the selected detached transport implementation only on first use.
+Session restoration, pending completion delivery, settings validation, and cleanup ownership remain eager.
+A failed first-use code load is reported normally and can be retried.
 Set `transport` to `in-process` to retain one public Pi SDK `AgentSession` per stateful `agentId`, avoiding repeated process startup while preserving native child history in memory.
 Set it to `rpc` to retain one `pi --mode rpc --no-session --no-extensions` process per active retained agent, preserving native child history with a separate process boundary.
 Set it to `auto` for deterministic preflight selection: read-only built-in tools use in-process, write-capable built-in tools use RPC, and extension/custom tools use subprocess.
@@ -1049,20 +1052,25 @@ Downgrading is safe: older extension versions ignore this separate state directo
 packages/pi-subagents/
 ├── src/
 │   ├── index.ts                  # Pi package entrypoint
-│   ├── subagents.ts              # Extension registration and blocking tool schema
-│   ├── automation.ts             # Explicit autonomous planning tool and lifecycle owner
+│   ├── subagents.ts              # Lightweight extension composition and blocking registration
+│   ├── cached-module-loader.ts   # Retryable first-use code-module cache
+│   ├── automation-registration.ts # Lightweight autonomous tool registration
+│   ├── automation.ts             # First-use autonomous planning execution
 │   ├── automation-contract.ts    # Strict request, proposal, and graph-patch contracts
 │   ├── automation-planner.ts     # Bounded read-only planner prompt and resource policy
 │   ├── workflow-plan-compiler.ts # Deterministic admission, routing, and workflow compilation
 │   ├── workflow-plan-patch.ts    # Generation-safe revisions and atomic plan persistence
 │   ├── workflow-planning-benchmark.ts # Frozen matched offline evaluation protocol
-│   ├── inspect.ts                # Side-effect-free metadata inspection tool
-│   ├── consult.ts                # Synchronous read-only consultation tool
+│   ├── inspect-registration.ts   # Lightweight inspection tool registration
+│   ├── inspect.ts                # First-use side-effect-free metadata inspection
+│   ├── consult-registration.ts   # Lightweight consultation tool registration
+│   ├── consult.ts                # First-use synchronous read-only consultation
 │   ├── consult-policy.ts         # Enforced read-only tool intersection
 │   ├── cwd-policy.ts             # Canonical target and saved-trust resolution
 │   ├── prompt-resources.ts       # Core-selected SYSTEM and APPEND_SYSTEM resources
 │   ├── safe-text.ts              # Shared byte/line/path sanitization
 │   ├── stateful.ts               # Detached lifecycle registration and dispatch
+│   ├── create-stateful-transport.ts # First-turn selected transport loader
 │   ├── rpc-transport.ts          # Persistent strict-JSONL Pi RPC child transport
 │   ├── rpc-timeout-finalization.ts # RPC abort-settle-summary recovery
 │   ├── rpc-transport-metadata.ts # RPC result policy and bounded metadata helpers

--- a/packages/pi-subagents/src/automation-registration.ts
+++ b/packages/pi-subagents/src/automation-registration.ts
@@ -1,0 +1,137 @@
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import type { AutomationExecutionOptions } from "./automation.js";
+import { type AutomationDetails, SubagentAutomationParams } from "./automation-tool.js";
+import { cachedModuleLoader, throwIfAborted } from "./cached-module-loader.js";
+import { renderFallbackResult, safeLine, toolHeader } from "./render-common.js";
+
+interface AutomationExecutionModule {
+	executeAutomationRequest: typeof import("./automation.js").executeAutomationRequest;
+}
+
+export interface AutomationRegistrationDependencies {
+	loadExecution?: () => Promise<AutomationExecutionModule>;
+}
+
+export function registerSubagentAutomation(
+	pi: ExtensionAPI,
+	options: AutomationExecutionOptions,
+	dependencies: AutomationRegistrationDependencies = {},
+): void {
+	const loadExecution = cachedModuleLoader(
+		dependencies.loadExecution ?? (() => import("./automation.js")),
+	);
+	let generation = 0;
+	const activeControllers = new Set<AbortController>();
+	const activeWork = new Set<Promise<unknown>>();
+	const cancelAndWait = async (reason: string) => {
+		generation++;
+		for (const controller of activeControllers) {
+			controller.abort(new DOMException(reason, "AbortError"));
+		}
+		await Promise.allSettled([...activeWork]);
+	};
+	pi.on("session_start", () => cancelAndWait("Autonomous workflow session replaced"));
+	pi.on("session_shutdown", () => cancelAndWait("Autonomous workflow session shut down"));
+	const definition: ToolDefinition<typeof SubagentAutomationParams, AutomationDetails> = {
+		name: "subagent_auto",
+		label: "Autonomous Subagent Workflow",
+		description: [
+			"Explicitly opt in to one bounded read-only planning turn that compiles a high-level objective into the smallest justified existing workflow.",
+			"The deterministic compiler may return parent-owned work, request missing input, or reject without launching execution workers.",
+			"Mutating workflows require an authoritative integration path and an independent verifier, allow at most two concurrent mutating workers, and never allow workflow grandchildren.",
+			"The first version routes only built-in and user-scoped agents; use caller-authored workflow mode for project-local agents.",
+		].join(" "),
+		promptSnippet:
+			"Explicitly compile one high-level objective into a bounded capability-matched workflow",
+		promptGuidelines: [
+			"Use subagent_auto only when the caller explicitly opts into autonomous workflow planning.",
+			"Provide a complete authority ceiling and aggregate budget; parent-owned and insufficient-evidence results launch no execution workers.",
+			"Use caller-authored subagent workflow mode as the compatibility fallback when deterministic task control is required.",
+		],
+		parameters: SubagentAutomationParams,
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const ownerGeneration = generation;
+			const controller = new AbortController();
+			activeControllers.add(controller);
+			const combined = combineSignals(signal, controller.signal);
+			const work = (async () => {
+				throwIfAborted(combined.signal, "Autonomous workflow loading was cancelled");
+				let executionModule: AutomationExecutionModule;
+				try {
+					executionModule = await loadExecution();
+				} catch (error) {
+					throwIfAborted(combined.signal, "Autonomous workflow loading was cancelled");
+					throw error;
+				}
+				throwIfAborted(combined.signal, "Autonomous workflow loading was cancelled");
+				if (ownerGeneration !== generation) {
+					throw new DOMException("Autonomous workflow owner was replaced", "AbortError");
+				}
+				return executionModule.executeAutomationRequest(
+					toolCallId,
+					params,
+					combined.signal,
+					onUpdate,
+					ctx,
+					options,
+					() => ownerGeneration === generation,
+				);
+			})();
+			activeWork.add(work);
+			try {
+				return await work;
+			} finally {
+				combined.dispose();
+				activeControllers.delete(controller);
+				activeWork.delete(work);
+			}
+		},
+		renderCall(args, theme) {
+			const request = (args as { request?: { objective?: string; version?: string } }).request;
+			return new Text(
+				toolHeader(theme, "subagent_auto", request?.objective, [request?.version ?? "request"]),
+				0,
+				0,
+			);
+		},
+		renderResult(result, renderOptions, theme) {
+			const status = safeLine(result.details?.status, "completed", 128);
+			return renderFallbackResult(
+				result,
+				renderOptions,
+				theme,
+				result.details?.isError === true ||
+					status.endsWith("failed") ||
+					status.endsWith("rejected"),
+			);
+		},
+	};
+	pi.registerTool<typeof SubagentAutomationParams, AutomationDetails>(definition);
+	pi.on("tool_result", (event) => {
+		if (event.toolName !== "subagent_auto") return;
+		if ((event.details as AutomationDetails | undefined)?.isError) return { isError: true };
+	});
+}
+
+function combineSignals(
+	external: AbortSignal | undefined,
+	owned: AbortSignal,
+): { signal: AbortSignal; dispose(): void } {
+	const controller = new AbortController();
+	const signals = [external, owned].filter((value): value is AbortSignal => value !== undefined);
+	const listeners = signals.map((source) => {
+		const listener = () => {
+			if (!controller.signal.aborted) controller.abort(source.reason);
+		};
+		if (source.aborted) listener();
+		else source.addEventListener("abort", listener, { once: true });
+		return { source, listener };
+	});
+	return {
+		signal: controller.signal,
+		dispose() {
+			for (const { source, listener } of listeners) source.removeEventListener("abort", listener);
+		},
+	};
+}

--- a/packages/pi-subagents/src/automation-tool.ts
+++ b/packages/pi-subagents/src/automation-tool.ts
@@ -1,0 +1,40 @@
+import { type Static, Type } from "typebox";
+import { AutomationRequestSchema } from "./automation-contract.js";
+import type { SubagentDetails } from "./runner.js";
+import type { CompiledWorkflowPlan } from "./workflow-plan-compiler.js";
+
+export const SubagentAutomationParams = Type.Object(
+	{ request: AutomationRequestSchema },
+	{ additionalProperties: false },
+);
+export type SubagentAutomationParams = Static<typeof SubagentAutomationParams>;
+
+export interface AutomationDetails {
+	status:
+		| "planning"
+		| "planner-failed"
+		| "parent-owned"
+		| "needs-input"
+		| "compiler-rejected"
+		| "executed";
+	requestVersion: string;
+	planVersion?: string;
+	planId?: string;
+	workflowGeneration?: number;
+	revision?: number;
+	childCount: number;
+	reasonCodes: string[];
+	missingInputs?: string[];
+	planner?: {
+		agent: string;
+		tools: string[];
+		resources: "project-context" | "none";
+		timeoutMs: number;
+		maxTurns: number;
+		maxToolCalls: number;
+		failed?: boolean;
+	};
+	compiled?: CompiledWorkflowPlan;
+	execution?: SubagentDetails;
+	isError?: boolean;
+}

--- a/packages/pi-subagents/src/automation.ts
+++ b/packages/pi-subagents/src/automation.ts
@@ -1,22 +1,11 @@
 import { createHash } from "node:crypto";
 import * as path from "node:path";
 import type { AgentToolResult, AgentToolUpdateCallback } from "@earendil-works/pi-agent-core";
-import {
-	type ExtensionAPI,
-	type ExtensionContext,
-	getAgentDir,
-	type ToolDefinition,
-} from "@earendil-works/pi-coding-agent";
-import { Text } from "@earendil-works/pi-tui";
-import { type Static, Type } from "typebox";
+import { type ExtensionContext, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { getBuiltInAgent } from "./agents/built-ins.js";
 import { discoverAgents } from "./agents/discovery.js";
 import type { SubagentSettings } from "./agents/types.js";
-import {
-	AutomationRequestSchema,
-	parseAutomationRequest,
-	type WorkflowPlan,
-} from "./automation-contract.js";
+import { parseAutomationRequest, type WorkflowPlan } from "./automation-contract.js";
 import {
 	AUTOMATION_PLANNER_MAX_TIMEOUT_MS,
 	AUTOMATION_PLANNER_MAX_TOOL_CALLS,
@@ -26,13 +15,13 @@ import {
 	parseAutomationPlannerOutput,
 	resolveAutomationPlannerPolicy,
 } from "./automation-planner.js";
+import type { AutomationDetails, SubagentAutomationParams } from "./automation-tool.js";
 import {
 	assertDelegationTargetAllowed,
 	resolveSubagentTarget,
 	targetPolicyAudit,
 } from "./cwd-policy.js";
 import { executeSubagent } from "./execution.js";
-import { renderFallbackResult, safeLine, toolHeader } from "./render-common.js";
 import {
 	getResultFinalOutput,
 	isResultError,
@@ -53,41 +42,9 @@ import {
 import { AutomationPlanPersistence, createWorkflowPlanRecord } from "./workflow-plan-patch.js";
 import { createBlockingWorkLedger, resolveWorkflowTasks } from "./workflow-planning.js";
 
-export const SubagentAutomationParams = Type.Object(
-	{ request: AutomationRequestSchema },
-	{ additionalProperties: false },
-);
-export type SubagentAutomationParams = Static<typeof SubagentAutomationParams>;
-
-export interface AutomationDetails {
-	status:
-		| "planning"
-		| "planner-failed"
-		| "parent-owned"
-		| "needs-input"
-		| "compiler-rejected"
-		| "executed";
-	requestVersion: string;
-	planVersion?: string;
-	planId?: string;
-	workflowGeneration?: number;
-	revision?: number;
-	childCount: number;
-	reasonCodes: string[];
-	missingInputs?: string[];
-	planner?: {
-		agent: string;
-		tools: string[];
-		resources: "project-context" | "none";
-		timeoutMs: number;
-		maxTurns: number;
-		maxToolCalls: number;
-		failed?: boolean;
-	};
-	compiled?: CompiledWorkflowPlan;
-	execution?: SubagentDetails;
-	isError?: boolean;
-}
+export { registerSubagentAutomation } from "./automation-registration.js";
+export type { AutomationDetails } from "./automation-tool.js";
+export { SubagentAutomationParams } from "./automation-tool.js";
 
 export interface AutomationPlannerRequest {
 	prompt: string;
@@ -108,91 +65,6 @@ export interface AutomationExecutionOptions {
 		ctx: ExtensionContext,
 	) => ReturnType<typeof executeSubagent>;
 	persistCompiled?: (compiled: CompiledWorkflowPlan, ctx: ExtensionContext) => Promise<void>;
-}
-
-export function registerSubagentAutomation(
-	pi: ExtensionAPI,
-	options: AutomationExecutionOptions,
-): void {
-	let generation = 0;
-	const activeControllers = new Set<AbortController>();
-	const activeWork = new Set<Promise<unknown>>();
-	const cancelAndWait = async (reason: string) => {
-		generation++;
-		for (const controller of activeControllers) {
-			controller.abort(new DOMException(reason, "AbortError"));
-		}
-		await Promise.allSettled([...activeWork]);
-	};
-	pi.on("session_start", () => cancelAndWait("Autonomous workflow session replaced"));
-	pi.on("session_shutdown", () => cancelAndWait("Autonomous workflow session shut down"));
-	const description = () =>
-		[
-			"Explicitly opt in to one bounded read-only planning turn that compiles a high-level objective into the smallest justified existing workflow.",
-			"The deterministic compiler may return parent-owned work, request missing input, or reject without launching execution workers.",
-			"Mutating workflows require an authoritative integration path and an independent verifier, allow at most two concurrent mutating workers, and never allow workflow grandchildren.",
-			"The first version routes only built-in and user-scoped agents; use caller-authored workflow mode for project-local agents.",
-		].join(" ");
-	const definition: ToolDefinition<typeof SubagentAutomationParams, AutomationDetails> = {
-		name: "subagent_auto",
-		label: "Autonomous Subagent Workflow",
-		description: description(),
-		promptSnippet:
-			"Explicitly compile one high-level objective into a bounded capability-matched workflow",
-		promptGuidelines: [
-			"Use subagent_auto only when the caller explicitly opts into autonomous workflow planning.",
-			"Provide a complete authority ceiling and aggregate budget; parent-owned and insufficient-evidence results launch no execution workers.",
-			"Use caller-authored subagent workflow mode as the compatibility fallback when deterministic task control is required.",
-		],
-		parameters: SubagentAutomationParams,
-		async execute(toolCallId, params, signal, onUpdate, ctx) {
-			const ownerGeneration = generation;
-			const controller = new AbortController();
-			activeControllers.add(controller);
-			const combined = combineSignals(signal, controller.signal);
-			const work = executeAutomationRequest(
-				toolCallId,
-				params,
-				combined.signal,
-				onUpdate,
-				ctx,
-				options,
-				() => ownerGeneration === generation,
-			);
-			activeWork.add(work);
-			try {
-				return await work;
-			} finally {
-				combined.dispose();
-				activeControllers.delete(controller);
-				activeWork.delete(work);
-			}
-		},
-		renderCall(args, theme) {
-			const request = (args as { request?: { objective?: string; version?: string } }).request;
-			return new Text(
-				toolHeader(theme, "subagent_auto", request?.objective, [request?.version ?? "request"]),
-				0,
-				0,
-			);
-		},
-		renderResult(result, renderOptions, theme) {
-			const status = safeLine(result.details?.status, "completed", 128);
-			return renderFallbackResult(
-				result,
-				renderOptions,
-				theme,
-				result.details?.isError === true ||
-					status.endsWith("failed") ||
-					status.endsWith("rejected"),
-			);
-		},
-	};
-	pi.registerTool<typeof SubagentAutomationParams, AutomationDetails>(definition);
-	pi.on("tool_result", (event) => {
-		if (event.toolName !== "subagent_auto") return;
-		if ((event.details as AutomationDetails | undefined)?.isError) return { isError: true };
-	});
 }
 
 export async function executeAutomationRequest(
@@ -560,26 +432,4 @@ function abortError(message: string): Error {
 	const error = new Error(message);
 	error.name = "AbortError";
 	return error;
-}
-
-function combineSignals(
-	external: AbortSignal | undefined,
-	owned: AbortSignal,
-): { signal: AbortSignal; dispose(): void } {
-	const controller = new AbortController();
-	const signals = [external, owned].filter((value): value is AbortSignal => value !== undefined);
-	const listeners = signals.map((source) => {
-		const listener = () => {
-			if (!controller.signal.aborted) controller.abort(source.reason);
-		};
-		if (source.aborted) listener();
-		else source.addEventListener("abort", listener, { once: true });
-		return { source, listener };
-	});
-	return {
-		signal: controller.signal,
-		dispose() {
-			for (const { source, listener } of listeners) source.removeEventListener("abort", listener);
-		},
-	};
 }

--- a/packages/pi-subagents/src/cached-module-loader.ts
+++ b/packages/pi-subagents/src/cached-module-loader.ts
@@ -1,0 +1,18 @@
+export function cachedModuleLoader<Module>(load: () => Promise<Module>): () => Promise<Module> {
+	let pending: Promise<Module> | undefined;
+	return () => {
+		if (!pending) {
+			pending = load().catch((error) => {
+				pending = undefined;
+				throw error;
+			});
+		}
+		return pending;
+	};
+}
+
+export function throwIfAborted(signal: AbortSignal | undefined, message: string): void {
+	if (!signal?.aborted) return;
+	if (signal.reason instanceof Error) throw signal.reason;
+	throw new DOMException(message, "AbortError");
+}

--- a/packages/pi-subagents/src/config-registration.ts
+++ b/packages/pi-subagents/src/config-registration.ts
@@ -1,0 +1,89 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { cachedModuleLoader } from "./cached-module-loader.js";
+import { showSubagentHelp, showSubagentStatus } from "./config-status.js";
+import type { SubagentMenuOwner, SubagentSettingsRuntime } from "./config-ui.js";
+
+const SUBCOMMANDS = [
+	{ value: "settings", label: "settings", description: "Configure subagent user settings" },
+	{ value: "status", label: "status", description: "Show effective subagent settings" },
+	{ value: "help", label: "help", description: "Show subagent settings help" },
+];
+
+type ConfigUiModule = Pick<
+	typeof import("./config-ui.js"),
+	"showSubagentManager" | "showSubagentSettings"
+>;
+
+export interface ConfigRegistrationDependencies {
+	loadConfigUi?: () => Promise<ConfigUiModule>;
+}
+
+export function registerSubagentConfigLifecycle(pi: ExtensionAPI): SubagentMenuOwner {
+	const owner: SubagentMenuOwner = { generation: 0, controller: new AbortController() };
+	pi.on("session_start", () => {
+		owner.generation += 1;
+		owner.controller.abort(new DOMException("Subagent session replaced", "AbortError"));
+		owner.controller = new AbortController();
+	});
+	pi.on("session_shutdown", () => {
+		owner.generation += 1;
+		owner.controller.abort(new DOMException("Subagent session shut down", "AbortError"));
+	});
+	return owner;
+}
+
+export function registerSubagentConfigCommand(
+	pi: ExtensionAPI,
+	runtime: SubagentSettingsRuntime,
+	owner = registerSubagentConfigLifecycle(pi),
+	dependencies: ConfigRegistrationDependencies = {},
+): void {
+	const loadConfigUi = cachedModuleLoader(
+		dependencies.loadConfigUi ?? (() => import("./config-ui.js")),
+	);
+	pi.registerCommand("subagents", {
+		description: "Manage current-session subagents and user settings",
+		getArgumentCompletions(prefix: string) {
+			const normalized = prefix.trim().toLowerCase();
+			const matches = SUBCOMMANDS.filter((item) => item.value.startsWith(normalized));
+			return matches.length > 0 ? matches : null;
+		},
+		async handler(args, ctx) {
+			const subcommand = args.trim().toLowerCase();
+			if (!subcommand && ctx.mode !== "tui") {
+				showSubagentStatus(ctx, runtime);
+				return;
+			}
+			if (subcommand === "status") {
+				showSubagentStatus(ctx, runtime);
+				return;
+			}
+			if (subcommand === "help") {
+				showSubagentHelp(ctx, runtime);
+				return;
+			}
+			if (!subcommand || subcommand === "settings") {
+				const generation = owner.generation;
+				const controller = owner.controller;
+				const isCurrent = () =>
+					generation === owner.generation &&
+					controller === owner.controller &&
+					!controller.signal.aborted;
+				let configUi: ConfigUiModule;
+				try {
+					configUi = await loadConfigUi();
+				} catch (error) {
+					if (!isCurrent()) return;
+					throw error;
+				}
+				if (!isCurrent()) return;
+				if (!subcommand) await configUi.showSubagentManager(pi, ctx, runtime, owner);
+				else await configUi.showSubagentSettings(ctx, runtime, owner);
+				return;
+			}
+			if (ctx.mode === "tui" || ctx.hasUI) {
+				ctx.ui.notify(`Unknown /subagents subcommand: ${subcommand}`, "warning");
+			}
+		},
+	});
+}

--- a/packages/pi-subagents/src/config-ui.ts
+++ b/packages/pi-subagents/src/config-ui.ts
@@ -168,7 +168,7 @@ function registerSubagentPrimaryCommand(
 	});
 }
 
-async function showSubagentManager(
+export async function showSubagentManager(
 	pi: ExtensionAPI,
 	ctx: ExtensionCommandContext,
 	runtime: SubagentSettingsRuntime,
@@ -681,7 +681,7 @@ async function showSubagentManager(
 	});
 }
 
-async function showSubagentSettings(
+export async function showSubagentSettings(
 	ctx: ExtensionCommandContext,
 	runtime: SubagentSettingsRuntime,
 	owner: SubagentMenuOwner,

--- a/packages/pi-subagents/src/consult-registration.ts
+++ b/packages/pi-subagents/src/consult-registration.ts
@@ -1,0 +1,132 @@
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { cachedModuleLoader, throwIfAborted } from "./cached-module-loader.js";
+import type { RegisterSubagentConsultOptions } from "./consult.js";
+import { renderConsultCall, renderConsultResult } from "./consult-render.js";
+import { type ConsultDetails, SubagentConsultParams } from "./consult-tool.js";
+import {
+	DEFAULT_CONSULT_RESOURCE_POLICY,
+	DEFAULT_CONSULTATION_CWD_POLICY,
+} from "./settings/inspection.js";
+
+interface ConsultExecutionModule {
+	executeSubagentConsult: typeof import("./consult.js").executeSubagentConsult;
+}
+
+export interface ConsultRegistrationDependencies {
+	loadExecution?: () => Promise<ConsultExecutionModule>;
+}
+
+export function registerSubagentConsult(
+	pi: ExtensionAPI,
+	options: RegisterSubagentConsultOptions,
+	dependencies: ConsultRegistrationDependencies = {},
+): (catalog: string) => void {
+	const loadExecution = cachedModuleLoader(
+		dependencies.loadExecution ?? (() => import("./consult.js")),
+	);
+	let generation = 0;
+	const active = new Set<AbortController>();
+	const activeWork = new Set<Promise<unknown>>();
+	const cancelActive = (reason: string) => {
+		generation++;
+		for (const controller of active) {
+			controller.abort(new DOMException(reason, "AbortError"));
+		}
+		active.clear();
+	};
+	const cancelAndWaitForWork = async (reason: string) => {
+		cancelActive(reason);
+		await Promise.allSettled([...activeWork]);
+	};
+	pi.on("session_start", () => cancelAndWaitForWork("Subagent consultation session replaced"));
+	pi.on("session_shutdown", () => cancelAndWaitForWork("Subagent consultation session shut down"));
+
+	const baseDescription = () =>
+		`Run one ephemeral subagent synchronously under enforced read-only tool and resource policies and return its answer. The child can use only the effective subset of Pi's built-in read, grep, find, and ls tools. Shell commands, file writes, extension tools, detached lifecycle operations, and persistent agent state are disabled. Working-directory target policy: ${options.getSettings()?.cwdPolicy?.consultation ?? DEFAULT_CONSULTATION_CWD_POLICY}; configured trusted-target resources: ${options.getSettings()?.consult?.resources ?? DEFAULT_CONSULT_RESOURCE_POLICY}; allowed targets without effective trust inherit no target/project resources. This is not a filesystem sandbox.`;
+	const definition: ToolDefinition<typeof SubagentConsultParams, ConsultDetails> = {
+		name: "subagent_consult",
+		label: "Consult Read-only Subagent",
+		description: baseDescription(),
+		promptSnippet: "Consult one constrained read-only subagent and wait for its answer",
+		promptGuidelines: [
+			"Use subagent_consult for bounded reconnaissance, planning, or review whose result is required in the current turn.",
+			"Set subagent_consult timeoutMs to the shortest realistic work deadline for the task difficulty; split oversized consultations instead of extending the deadline merely to compensate for broad scope.",
+			"Implementation-shaped tasks remain read-only and can return only analysis or instructions.",
+		],
+		parameters: SubagentConsultParams,
+		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const ownerGeneration = generation;
+			const ownedController = new AbortController();
+			active.add(ownedController);
+			const combined = combineAbortSignals(signal, ownedController.signal);
+			const work = (async () => {
+				throwIfAborted(combined.signal, "Subagent consultation loading was cancelled");
+				let executionModule: ConsultExecutionModule;
+				try {
+					executionModule = await loadExecution();
+				} catch (error) {
+					throwIfAborted(combined.signal, "Subagent consultation loading was cancelled");
+					throw error;
+				}
+				throwIfAborted(combined.signal, "Subagent consultation loading was cancelled");
+				if (ownerGeneration !== generation) {
+					throw new DOMException("Subagent consultation owner was replaced", "AbortError");
+				}
+				return executionModule.executeSubagentConsult(
+					params,
+					combined.signal,
+					onUpdate,
+					ctx,
+					options,
+					() => ownerGeneration === generation,
+				);
+			})();
+			activeWork.add(work);
+			try {
+				return await work;
+			} finally {
+				combined.dispose();
+				active.delete(ownedController);
+				activeWork.delete(work);
+			}
+		},
+		renderCall(args, theme) {
+			return renderConsultCall(args, theme);
+		},
+		renderResult(result, renderOptions, theme, context) {
+			return renderConsultResult(result, renderOptions, theme, context);
+		},
+	};
+	pi.registerTool<typeof SubagentConsultParams, ConsultDetails>(definition);
+	pi.on("tool_result", (event) => {
+		if (event.toolName !== "subagent_consult") return;
+		if ((event.details as ConsultDetails | undefined)?.isError) return { isError: true };
+	});
+	return (catalog: string) => {
+		definition.description = catalog ? `${baseDescription()}\n\n${catalog}` : baseDescription();
+		pi.registerTool<typeof SubagentConsultParams, ConsultDetails>(definition);
+	};
+}
+
+function combineAbortSignals(
+	external: AbortSignal | undefined,
+	owned: AbortSignal,
+): { signal: AbortSignal; dispose(): void } {
+	if (!external) return { signal: owned, dispose() {} };
+	const controller = new AbortController();
+	const sources = [external, owned];
+	const listeners = sources.map((source) => {
+		const listener = () => {
+			if (!controller.signal.aborted) controller.abort(source.reason);
+		};
+		if (source.aborted) listener();
+		else source.addEventListener("abort", listener, { once: true });
+		return { source, listener };
+	});
+	return {
+		signal: controller.signal,
+		dispose() {
+			for (const { source, listener } of listeners) source.removeEventListener("abort", listener);
+		},
+	};
+}

--- a/packages/pi-subagents/src/consult-tool.ts
+++ b/packages/pi-subagents/src/consult-tool.ts
@@ -1,0 +1,95 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import { type Static, Type } from "typebox";
+import type { AgentScope, ConsultResourcePolicy } from "./agents/types.js";
+import { THINKING_LEVELS } from "./agents/types.js";
+import { DEFAULT_MAX_CONTEXT_BYTES, MAX_SUBAGENT_TIMEOUT_MS } from "./limits.js";
+
+const ConsultScopeSchema = StringEnum(["user", "project", "both"] as const, {
+	default: "user",
+	description: "Agent definition scope. Project scopes require a trusted project.",
+});
+const ConsultThinkingSchema = StringEnum(THINKING_LEVELS);
+
+export const SubagentConsultParams = Type.Object(
+	{
+		agent: Type.String({ minLength: 1 }),
+		task: Type.String({ minLength: 1, maxLength: DEFAULT_MAX_CONTEXT_BYTES }),
+		agentScope: Type.Optional(ConsultScopeSchema),
+		confirmProjectAgents: Type.Optional(Type.Boolean({ default: true })),
+		cwd: Type.Optional(Type.String({ minLength: 1 })),
+		timeoutMs: Type.Optional(
+			Type.Number({
+				minimum: 1,
+				maximum: MAX_SUBAGENT_TIMEOUT_MS,
+				description:
+					"Work deadline selected for the consultation difficulty. On expiry, Pi aborts the work and makes one separately bounded summary attempt.",
+			}),
+		),
+		thinkingLevel: Type.Optional(ConsultThinkingSchema),
+	},
+	{ additionalProperties: false },
+);
+
+export type SubagentConsultParams = Static<typeof SubagentConsultParams>;
+
+export interface ConsultProgressActivity {
+	type: "text" | "toolCall";
+	text?: string;
+	name?: "read" | "grep" | "find" | "ls";
+	args?: Record<string, string | number | boolean>;
+}
+
+export interface ConsultProgress {
+	phase: "starting" | "running";
+	recentActivity: ConsultProgressActivity[];
+	recentActivityTotal: number;
+	actualProvider?: string;
+	actualModel?: string;
+	usage: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+		cost: number;
+		contextTokens: number;
+		turns: number;
+	};
+}
+
+export interface ConsultDetails {
+	agent: string;
+	agentSource: string;
+	agentScope: AgentScope;
+	cwd: string;
+	model?: string;
+	thinkingLevel?: string;
+	timeoutMs: number;
+	policy: {
+		requestedTools: string[] | null;
+		effectiveTools: string[];
+		cwdBoundary: "current-workspace" | "external";
+		targetTrust: {
+			kind: string;
+			projectTrusted: boolean;
+			sourcePath?: string;
+			warning?: string;
+		};
+		requestedResources: ConsultResourcePolicy;
+		effectiveResources: {
+			policy: ConsultResourcePolicy;
+			projectResources: boolean;
+			contextFiles: boolean;
+			skills: boolean;
+			promptTemplates: boolean;
+		};
+		resourceDowngradeReason?: string;
+		extensions: "disabled";
+		sessionPersistence: "disabled";
+		retainedAgent: false;
+	};
+	child?: Record<string, unknown>;
+	progress?: ConsultProgress;
+	cancelled?: boolean;
+	isError?: boolean;
+	truncated?: boolean;
+}

--- a/packages/pi-subagents/src/consult.ts
+++ b/packages/pi-subagents/src/consult.ts
@@ -1,13 +1,7 @@
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { StringEnum, type Usage } from "@earendil-works/pi-ai";
-import {
-	CONFIG_DIR_NAME,
-	type ExtensionAPI,
-	type ExtensionContext,
-	type ToolDefinition,
-} from "@earendil-works/pi-coding-agent";
-import { type Static, Type } from "typebox";
+import type { Usage } from "@earendil-works/pi-ai";
+import { CONFIG_DIR_NAME, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_AGENT_CATALOG_MAX_ITEMS } from "./agents/catalog.js";
 import { type AgentDiscoveryResult, discoverAgents } from "./agents/discovery.js";
 import {
@@ -16,11 +10,16 @@ import {
 	type ConsultResourcePolicy,
 	isThinkingLevel,
 	type SubagentSettings,
-	THINKING_LEVELS,
+	type THINKING_LEVELS,
 } from "./agents/types.js";
 import { resolveConsultTools } from "./consult-policy.js";
-import { renderConsultCall, renderConsultResult } from "./consult-render.js";
 import { resolveConsultResourceLaunchPolicy } from "./consult-resources.js";
+import type {
+	ConsultDetails,
+	ConsultProgress,
+	ConsultProgressActivity,
+	SubagentConsultParams,
+} from "./consult-tool.js";
 import {
 	assertConsultationTargetAllowed,
 	type ResolvedSubagentTarget,
@@ -50,33 +49,13 @@ import {
 } from "./settings/inspection.js";
 import { resolveSubagentThinkingLevel } from "./settings.js";
 
-const ConsultScopeSchema = StringEnum(["user", "project", "both"] as const, {
-	default: "user",
-	description: "Agent definition scope. Project scopes require a trusted project.",
-});
-const ConsultThinkingSchema = StringEnum(THINKING_LEVELS);
-
-export const SubagentConsultParams = Type.Object(
-	{
-		agent: Type.String({ minLength: 1 }),
-		task: Type.String({ minLength: 1, maxLength: DEFAULT_MAX_CONTEXT_BYTES }),
-		agentScope: Type.Optional(ConsultScopeSchema),
-		confirmProjectAgents: Type.Optional(Type.Boolean({ default: true })),
-		cwd: Type.Optional(Type.String({ minLength: 1 })),
-		timeoutMs: Type.Optional(
-			Type.Number({
-				minimum: 1,
-				maximum: MAX_SUBAGENT_TIMEOUT_MS,
-				description:
-					"Work deadline selected for the consultation difficulty. On expiry, Pi aborts the work and makes one separately bounded summary attempt.",
-			}),
-		),
-		thinkingLevel: Type.Optional(ConsultThinkingSchema),
-	},
-	{ additionalProperties: false },
-);
-
-export type SubagentConsultParams = Static<typeof SubagentConsultParams>;
+export { registerSubagentConsult } from "./consult-registration.js";
+export type {
+	ConsultDetails,
+	ConsultProgress,
+	ConsultProgressActivity,
+} from "./consult-tool.js";
+export { SubagentConsultParams } from "./consult-tool.js";
 
 export interface ConsultChildRequest {
 	agent: AgentConfig;
@@ -99,68 +78,6 @@ export interface RegisterSubagentConsultOptions {
 	resolveResourceLaunchPolicy?: typeof resolveConsultResourceLaunchPolicy;
 }
 
-export interface ConsultProgressActivity {
-	type: "text" | "toolCall";
-	text?: string;
-	name?: "read" | "grep" | "find" | "ls";
-	args?: Record<string, string | number | boolean>;
-}
-
-export interface ConsultProgress {
-	phase: "starting" | "running";
-	recentActivity: ConsultProgressActivity[];
-	recentActivityTotal: number;
-	actualProvider?: string;
-	actualModel?: string;
-	usage: {
-		input: number;
-		output: number;
-		cacheRead: number;
-		cacheWrite: number;
-		cost: number;
-		contextTokens: number;
-		turns: number;
-	};
-}
-
-export interface ConsultDetails {
-	agent: string;
-	agentSource: string;
-	agentScope: AgentScope;
-	cwd: string;
-	model?: string;
-	thinkingLevel?: string;
-	timeoutMs: number;
-	policy: {
-		requestedTools: string[] | null;
-		effectiveTools: string[];
-		cwdBoundary: "current-workspace" | "external";
-		targetTrust: {
-			kind: string;
-			projectTrusted: boolean;
-			sourcePath?: string;
-			warning?: string;
-		};
-		requestedResources: ConsultResourcePolicy;
-		effectiveResources: {
-			policy: ConsultResourcePolicy;
-			projectResources: boolean;
-			contextFiles: boolean;
-			skills: boolean;
-			promptTemplates: boolean;
-		};
-		resourceDowngradeReason?: string;
-		extensions: "disabled";
-		sessionPersistence: "disabled";
-		retainedAgent: false;
-	};
-	child?: Record<string, unknown>;
-	progress?: ConsultProgress;
-	cancelled?: boolean;
-	isError?: boolean;
-	truncated?: boolean;
-}
-
 const READ_ONLY_INSTRUCTION = [
 	"This is a read-only consultation.",
 	"Use only the tools made available by the executor to inspect and reason about existing content.",
@@ -170,88 +87,29 @@ const READ_ONLY_INSTRUCTION = [
 
 const MAX_UNKNOWN_AGENT_NAME_BYTES = 128;
 
-export function registerSubagentConsult(
-	pi: ExtensionAPI,
+export async function executeSubagentConsult(
+	params: SubagentConsultParams,
+	signal: AbortSignal,
+	onUpdate: ((partial: AgentToolResult<ConsultDetails>) => void) | undefined,
+	ctx: ExtensionContext,
 	options: RegisterSubagentConsultOptions,
-): (catalog: string) => void {
-	let generation = 0;
-	const active = new Set<AbortController>();
-	const activeWork = new Set<Promise<unknown>>();
-	const cancelActive = (reason: string) => {
-		generation++;
-		for (const controller of active) {
-			controller.abort(new DOMException(reason, "AbortError"));
-		}
-		active.clear();
-	};
-	const cancelAndWaitForWork = async (reason: string) => {
-		cancelActive(reason);
-		await Promise.allSettled([...activeWork]);
-	};
-	pi.on("session_start", () => cancelAndWaitForWork("Subagent consultation session replaced"));
-	pi.on("session_shutdown", () => cancelAndWaitForWork("Subagent consultation session shut down"));
-
-	const baseDescription = () =>
-		`Run one ephemeral subagent synchronously under enforced read-only tool and resource policies and return its answer. The child can use only the effective subset of Pi's built-in read, grep, find, and ls tools. Shell commands, file writes, extension tools, detached lifecycle operations, and persistent agent state are disabled. Working-directory target policy: ${options.getSettings()?.cwdPolicy?.consultation ?? DEFAULT_CONSULTATION_CWD_POLICY}; configured trusted-target resources: ${options.getSettings()?.consult?.resources ?? DEFAULT_CONSULT_RESOURCE_POLICY}; allowed targets without effective trust inherit no target/project resources. This is not a filesystem sandbox.`;
-	const definition: ToolDefinition<typeof SubagentConsultParams, ConsultDetails> = {
-		name: "subagent_consult",
-		label: "Consult Read-only Subagent",
-		description: baseDescription(),
-		promptSnippet: "Consult one constrained read-only subagent and wait for its answer",
-		promptGuidelines: [
-			"Use subagent_consult for bounded reconnaissance, planning, or review whose result is required in the current turn.",
-			"Set subagent_consult timeoutMs to the shortest realistic work deadline for the task difficulty; split oversized consultations instead of extending the deadline merely to compensate for broad scope.",
-			"Implementation-shaped tasks remain read-only and can return only analysis or instructions.",
-		],
-		parameters: SubagentConsultParams,
-		async execute(_toolCallId, params, signal, onUpdate, ctx) {
-			const operation = validateConsultParams(params);
-			assertSubagentDepthAllowed();
-			if (signal?.aborted) throw abortError("Subagent consultation was aborted before start");
-			const ownerGeneration = generation;
-			const ownedController = new AbortController();
-			active.add(ownedController);
-			const combined = combineAbortSignals(signal, ownedController.signal);
-			try {
-				return await executeConsult(
-					operation,
-					ctx,
-					combined.signal,
-					options,
-					(partial) => {
-						if (ownerGeneration !== generation || combined.signal.aborted) return;
-						onUpdate?.(partial);
-					},
-					() => ownerGeneration === generation,
-					(work) => {
-						activeWork.add(work);
-						void work.then(
-							() => activeWork.delete(work),
-							() => activeWork.delete(work),
-						);
-					},
-				);
-			} finally {
-				combined.dispose();
-				active.delete(ownedController);
-			}
+	isCurrent: () => boolean = () => true,
+): Promise<AgentToolResult<ConsultDetails>> {
+	const operation = validateConsultParams(params);
+	assertSubagentDepthAllowed();
+	if (signal.aborted) throw abortError("Subagent consultation was aborted before start");
+	return executeConsult(
+		operation,
+		ctx,
+		signal,
+		options,
+		(partial) => {
+			if (signal.aborted || !isCurrent()) return;
+			onUpdate?.(partial);
 		},
-		renderCall(args, theme) {
-			return renderConsultCall(args, theme);
-		},
-		renderResult(result, renderOptions, theme, context) {
-			return renderConsultResult(result, renderOptions, theme, context);
-		},
-	};
-	pi.registerTool<typeof SubagentConsultParams, ConsultDetails>(definition);
-	pi.on("tool_result", (event) => {
-		if (event.toolName !== "subagent_consult") return;
-		if ((event.details as ConsultDetails | undefined)?.isError) return { isError: true };
-	});
-	return (catalog: string) => {
-		definition.description = catalog ? `${baseDescription()}\n\n${catalog}` : baseDescription();
-		pi.registerTool<typeof SubagentConsultParams, ConsultDetails>(definition);
-	};
+		isCurrent,
+		() => undefined,
+	);
 }
 
 function formatAvailableConsultAgents(discovery: AgentDiscoveryResult): string {
@@ -697,31 +555,6 @@ function abortError(message: string): Error {
 	const error = new Error(message);
 	error.name = "AbortError";
 	return error;
-}
-
-function combineAbortSignals(
-	external: AbortSignal | undefined,
-	owned: AbortSignal,
-): { signal: AbortSignal; dispose(): void } {
-	const controller = new AbortController();
-	const signals = [external, owned].filter((value): value is AbortSignal => value !== undefined);
-	const abort = (signal: AbortSignal) => {
-		if (!controller.signal.aborted) controller.abort(signal.reason);
-	};
-	const listeners = signals.map((signal) => {
-		const listener = () => abort(signal);
-		if (signal.aborted) abort(signal);
-		else signal.addEventListener("abort", listener, { once: true });
-		return { signal, listener };
-	});
-	return {
-		signal: controller.signal,
-		dispose() {
-			for (const { signal, listener } of listeners) {
-				signal.removeEventListener("abort", listener);
-			}
-		},
-	};
 }
 
 function requiredString(value: unknown, name: string): string {

--- a/packages/pi-subagents/src/create-stateful-transport.ts
+++ b/packages/pi-subagents/src/create-stateful-transport.ts
@@ -1,15 +1,10 @@
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
-import { discoverAgents } from "./agents/discovery.js";
 import type { SubagentSettings, SubagentTransportKind } from "./agents/types.js";
-import { AutoTransport } from "./auto-transport.js";
-import {
-	type ChildSessionFactory,
-	InProcessTransport,
-	type ParentRuntimeSnapshot,
-} from "./in-process-transport.js";
-import { RpcTransport } from "./rpc-transport.js";
-import { SubprocessTransport } from "./subprocess-transport.js";
+import { cachedModuleLoader } from "./cached-module-loader.js";
+import type { ChildSessionFactory, ParentRuntimeSnapshot } from "./in-process-transport.js";
+import type { ManagedAgent, TurnOutcome } from "./registry.js";
 import type { SubagentTransport } from "./transport.js";
+import type { TransportProgressCallback } from "./transport-types.js";
 
 export interface CreateStatefulTransportOptions {
 	kind: SubagentTransportKind;
@@ -17,14 +12,94 @@ export interface CreateStatefulTransportOptions {
 	getParentRuntime(): ParentRuntimeSnapshot;
 	getSettings(): SubagentSettings | undefined;
 	createInProcessSession?: ChildSessionFactory;
+	loadTransport?: () => Promise<SubagentTransport>;
 }
 
 export function createStatefulTransport(
 	options: CreateStatefulTransportOptions,
 ): SubagentTransport {
-	const subprocess = () => new SubprocessTransport({ getSettings: options.getSettings });
-	const inProcess = () =>
-		new InProcessTransport({
+	return new LazyStatefulTransport(
+		options.kind,
+		cachedModuleLoader(options.loadTransport ?? (() => loadStatefulTransport(options))),
+	);
+}
+
+class LazyStatefulTransport implements SubagentTransport {
+	private loaded: SubagentTransport | undefined;
+	private loading: Promise<SubagentTransport> | undefined;
+	private closed = false;
+	private shutdownPromise: Promise<void> | undefined;
+
+	constructor(
+		readonly kind: SubagentTransportKind,
+		private readonly loadImplementation: () => Promise<SubagentTransport>,
+	) {}
+
+	async runTurn(
+		agent: ManagedAgent,
+		task: string,
+		signal: AbortSignal,
+		onProgress?: TransportProgressCallback,
+	): Promise<TurnOutcome> {
+		if (this.closed) throw new Error("Subagent transport is shut down");
+		const transport = await this.load();
+		if (this.closed) {
+			await this.shutdownLoaded();
+			throw new Error("Subagent transport shut down while loading");
+		}
+		return transport.runTurn(agent, task, signal, onProgress);
+	}
+
+	async release(agent: ManagedAgent): Promise<void> {
+		const transport =
+			this.loaded ?? (this.loading ? await this.loading.catch(() => undefined) : undefined);
+		if (!transport || this.closed) return;
+		await transport.release?.(agent);
+	}
+
+	async shutdown(): Promise<void> {
+		this.closed = true;
+		if (this.loading && !this.loaded) await this.loading.catch(() => undefined);
+		await this.shutdownLoaded();
+	}
+
+	private async load(): Promise<SubagentTransport> {
+		if (this.loaded) return this.loaded;
+		if (!this.loading) {
+			this.loading = this.loadImplementation()
+				.then((transport) => {
+					this.loaded = transport;
+					return transport;
+				})
+				.finally(() => {
+					this.loading = undefined;
+				});
+		}
+		return this.loading;
+	}
+
+	private async shutdownLoaded(): Promise<void> {
+		if (!this.loaded) return;
+		if (!this.shutdownPromise) {
+			this.shutdownPromise = Promise.resolve(this.loaded.shutdown?.());
+		}
+		await this.shutdownPromise;
+	}
+}
+
+async function loadStatefulTransport(
+	options: CreateStatefulTransportOptions,
+): Promise<SubagentTransport> {
+	const subprocess = async () => {
+		const { SubprocessTransport } = await import("./subprocess-transport.js");
+		return new SubprocessTransport({ getSettings: options.getSettings });
+	};
+	const inProcess = async () => {
+		const [{ discoverAgents }, { InProcessTransport }] = await Promise.all([
+			import("./agents/discovery.js"),
+			import("./in-process-transport.js"),
+		]);
+		return new InProcessTransport({
 			modelRegistry: options.modelRegistry,
 			getParentRuntime: options.getParentRuntime,
 			createSession: options.createInProcessSession,
@@ -33,11 +108,14 @@ export function createStatefulTransport(
 					(candidate) => candidate.name === agent.agent,
 				),
 		});
-	const rpc = () =>
-		new RpcTransport({
+	};
+	const rpc = async () => {
+		const { RpcTransport } = await import("./rpc-transport.js");
+		return new RpcTransport({
 			getSettings: options.getSettings,
 			getParentRuntime: options.getParentRuntime,
 		});
+	};
 	switch (options.kind) {
 		case "subprocess":
 			return subprocess();
@@ -45,12 +123,14 @@ export function createStatefulTransport(
 			return inProcess();
 		case "rpc":
 			return rpc();
-		case "auto":
+		case "auto": {
+			const { AutoTransport } = await import("./auto-transport.js");
 			return new AutoTransport({
-				subprocess: subprocess(),
-				inProcess: inProcess(),
-				rpc: rpc(),
+				subprocess: new LazyStatefulTransport("subprocess", cachedModuleLoader(subprocess)),
+				inProcess: new LazyStatefulTransport("in-process", cachedModuleLoader(inProcess)),
+				rpc: new LazyStatefulTransport("rpc", cachedModuleLoader(rpc)),
 				getSettings: options.getSettings,
 			});
+		}
 	}
 }

--- a/packages/pi-subagents/src/create-stateful-transport.ts
+++ b/packages/pi-subagents/src/create-stateful-transport.ts
@@ -1,6 +1,6 @@
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { SubagentSettings, SubagentTransportKind } from "./agents/types.js";
-import { cachedModuleLoader } from "./cached-module-loader.js";
+import { cachedModuleLoader, throwIfAborted } from "./cached-module-loader.js";
 import type { ChildSessionFactory, ParentRuntimeSnapshot } from "./in-process-transport.js";
 import type { ManagedAgent, TurnOutcome } from "./registry.js";
 import type { SubagentTransport } from "./transport.js";
@@ -42,7 +42,15 @@ class LazyStatefulTransport implements SubagentTransport {
 		onProgress?: TransportProgressCallback,
 	): Promise<TurnOutcome> {
 		if (this.closed) throw new Error("Subagent transport is shut down");
-		const transport = await this.load();
+		throwIfAborted(signal, "Subagent transport loading was cancelled");
+		let transport: SubagentTransport;
+		try {
+			transport = await this.load();
+		} catch (error) {
+			throwIfAborted(signal, "Subagent transport loading was cancelled");
+			throw error;
+		}
+		throwIfAborted(signal, "Subagent transport loading was cancelled");
 		if (this.closed) {
 			await this.shutdownLoaded();
 			throw new Error("Subagent transport shut down while loading");

--- a/packages/pi-subagents/src/inspect-registration.ts
+++ b/packages/pi-subagents/src/inspect-registration.ts
@@ -1,0 +1,64 @@
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { cachedModuleLoader, throwIfAborted } from "./cached-module-loader.js";
+import type { SubagentInspectRuntime } from "./inspect.js";
+import { renderInspectCall, renderInspectResult } from "./inspect-render.js";
+import { SubagentInspectParams } from "./inspect-tool.js";
+
+interface InspectExecutionModule {
+	executeSubagentInspect: typeof import("./inspect.js").executeSubagentInspect;
+}
+
+export interface InspectRegistrationDependencies {
+	loadExecution?: () => Promise<InspectExecutionModule>;
+}
+
+export function registerSubagentInspect(
+	pi: ExtensionAPI,
+	runtime: SubagentInspectRuntime,
+	dependencies: InspectRegistrationDependencies = {},
+): void {
+	const loadExecution = cachedModuleLoader(
+		dependencies.loadExecution ?? (() => import("./inspect.js")),
+	);
+	let lifecycleGeneration = 0;
+	pi.on("session_start", () => {
+		lifecycleGeneration += 1;
+	});
+	pi.on("session_shutdown", () => {
+		lifecycleGeneration += 1;
+	});
+	const definition: ToolDefinition<typeof SubagentInspectParams, Record<string, unknown>> = {
+		name: "subagent_inspect",
+		label: "Inspect Subagents",
+		description:
+			"Inspect available subagent definitions, models, retained runs, persisted blocking workflows, runtime status, and diagnostics without changing subagent or workspace state. This tool never starts a child, sends or acknowledges messages, interrupts or closes runs, changes settings, or modifies files.",
+		promptSnippet: "Inspect subagent metadata and runtime state without changing it",
+		parameters: SubagentInspectParams,
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			const ownerGeneration = lifecycleGeneration;
+			throwIfAborted(signal, "Subagent inspection loading was cancelled");
+			let executionModule: InspectExecutionModule;
+			try {
+				executionModule = await loadExecution();
+			} catch (error) {
+				throwIfAborted(signal, "Subagent inspection loading was cancelled");
+				if (ownerGeneration !== lifecycleGeneration) {
+					throw new DOMException("Subagent inspection session was replaced", "AbortError");
+				}
+				throw error;
+			}
+			throwIfAborted(signal, "Subagent inspection loading was cancelled");
+			if (ownerGeneration !== lifecycleGeneration) {
+				throw new DOMException("Subagent inspection session was replaced", "AbortError");
+			}
+			return executionModule.executeSubagentInspect(params, ctx, runtime);
+		},
+		renderCall(args, theme) {
+			return renderInspectCall(args, theme);
+		},
+		renderResult(result, options, theme, context) {
+			return renderInspectResult(result, options, theme, context);
+		},
+	};
+	pi.registerTool(definition);
+}

--- a/packages/pi-subagents/src/inspect-tool.ts
+++ b/packages/pi-subagents/src/inspect-tool.ts
@@ -1,0 +1,43 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import { type Static, Type } from "typebox";
+
+const INSPECT_ACTIONS = [
+	"list_agents",
+	"get_agent",
+	"list_runs",
+	"get_run",
+	"list_workflows",
+	"get_workflow",
+	"list_models",
+	"preview_context",
+	"status",
+	"diagnose",
+] as const;
+
+const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
+	default: "user",
+	description: "Agent definition scope. Project scopes require a trusted project.",
+});
+const LimitSchema = Type.Number({ minimum: 1, maximum: 100, multipleOf: 1 });
+const ContextModeSchema = Type.Union([
+	StringEnum(["none", "all", "summary"] as const),
+	Type.Number({ minimum: 1, multipleOf: 1 }),
+]);
+
+export const SubagentInspectParams = Type.Object(
+	{
+		action: StringEnum(INSPECT_ACTIONS),
+		agent: Type.Optional(Type.String({ minLength: 1 })),
+		agentId: Type.Optional(Type.String({ minLength: 1 })),
+		workflowId: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
+		agentScope: Type.Optional(AgentScopeSchema),
+		limit: Type.Optional(LimitSchema),
+		includeClosed: Type.Optional(Type.Boolean({ default: false })),
+		context: Type.Optional(ContextModeSchema),
+		contextEntryIds: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
+	},
+	{ additionalProperties: false },
+);
+
+export type SubagentInspectParams = Static<typeof SubagentInspectParams>;
+export { INSPECT_ACTIONS };

--- a/packages/pi-subagents/src/inspect.ts
+++ b/packages/pi-subagents/src/inspect.ts
@@ -1,11 +1,5 @@
 import * as path from "node:path";
-import { StringEnum } from "@earendil-works/pi-ai";
-import {
-	CONFIG_DIR_NAME,
-	type ExtensionAPI,
-	type ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
-import { type Static, Type } from "typebox";
+import { CONFIG_DIR_NAME, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { discoverAgents } from "./agents/discovery.js";
 import type {
 	AgentConfig,
@@ -16,7 +10,7 @@ import type {
 import { projectCapabilityManifest } from "./capabilities.js";
 import { resolveConsultTools } from "./consult-policy.js";
 import { buildContextSnapshot, type ContextMode } from "./context.js";
-import { renderInspectCall, renderInspectResult } from "./inspect-render.js";
+import { INSPECT_ACTIONS } from "./inspect-tool.js";
 import { DEFAULT_MAX_CONTEXT_BYTES } from "./limits.js";
 import { resolvePiInvocation } from "./pi-invocation.js";
 import type { AgentRunInspectionDetail, AgentRunInspectionSummary } from "./registry.js";
@@ -36,47 +30,10 @@ import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
 import type { WorkItemLedgerSnapshot } from "./work-item-ledger.js";
 import { inspectSessionWorkflows } from "./work-item-persistence.js";
 
-const INSPECT_ACTIONS = [
-	"list_agents",
-	"get_agent",
-	"list_runs",
-	"get_run",
-	"list_workflows",
-	"get_workflow",
-	"list_models",
-	"preview_context",
-	"status",
-	"diagnose",
-] as const;
-
-const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
-	default: "user",
-	description: "Agent definition scope. Project scopes require a trusted project.",
-});
-
-const LimitSchema = Type.Number({ minimum: 1, maximum: 100, multipleOf: 1 });
-const ContextModeSchema = Type.Union([
-	StringEnum(["none", "all", "summary"] as const),
-	Type.Number({ minimum: 1, multipleOf: 1 }),
-]);
 const MAX_DETAILS_LIST_BYTES = 40 * 1024;
 
-export const SubagentInspectParams = Type.Object(
-	{
-		action: StringEnum(INSPECT_ACTIONS),
-		agent: Type.Optional(Type.String({ minLength: 1 })),
-		agentId: Type.Optional(Type.String({ minLength: 1 })),
-		workflowId: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
-		agentScope: Type.Optional(AgentScopeSchema),
-		limit: Type.Optional(LimitSchema),
-		includeClosed: Type.Optional(Type.Boolean({ default: false })),
-		context: Type.Optional(ContextModeSchema),
-		contextEntryIds: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
-	},
-	{ additionalProperties: false },
-);
-
-export type SubagentInspectParams = Static<typeof SubagentInspectParams>;
+export { registerSubagentInspect } from "./inspect-registration.js";
+export { SubagentInspectParams } from "./inspect-tool.js";
 
 export interface SubagentInspectRuntime {
 	getBlockingEnabled(): boolean;
@@ -105,26 +62,6 @@ type ValidatedInspectOperation =
 	| { action: "preview_context"; context: ContextMode; contextEntryIds?: string[] }
 	| { action: "status" }
 	| { action: "diagnose" };
-
-export function registerSubagentInspect(pi: ExtensionAPI, runtime: SubagentInspectRuntime): void {
-	pi.registerTool({
-		name: "subagent_inspect",
-		label: "Inspect Subagents",
-		description:
-			"Inspect available subagent definitions, models, retained runs, persisted blocking workflows, runtime status, and diagnostics without changing subagent or workspace state. This tool never starts a child, sends or acknowledges messages, interrupts or closes runs, changes settings, or modifies files.",
-		promptSnippet: "Inspect subagent metadata and runtime state without changing it",
-		parameters: SubagentInspectParams,
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<InspectToolResult> {
-			return executeSubagentInspect(validateInspectParams(params), ctx, runtime);
-		},
-		renderCall(args, theme) {
-			return renderInspectCall(args, theme);
-		},
-		renderResult(result, options, theme, context) {
-			return renderInspectResult(result, options, theme, context);
-		},
-	});
-}
 
 export function validateInspectParams(params: unknown): ValidatedInspectOperation {
 	const values = parameterRecord(params);
@@ -195,11 +132,12 @@ export function validateInspectParams(params: unknown): ValidatedInspectOperatio
 	return { action };
 }
 
-async function executeSubagentInspect(
-	operation: ValidatedInspectOperation,
+export async function executeSubagentInspect(
+	params: unknown,
 	ctx: ExtensionContext,
 	runtime: SubagentInspectRuntime,
 ): Promise<InspectToolResult> {
+	const operation = validateInspectParams(params);
 	if (operation.action === "list_agents" || operation.action === "get_agent") {
 		assertTrustedScope(operation.agentScope, ctx);
 		const settings = inspectSubagentSettings().settings;

--- a/packages/pi-subagents/src/params.ts
+++ b/packages/pi-subagents/src/params.ts
@@ -6,7 +6,7 @@ import { MAX_CONFIGURABLE_PARALLEL_TASKS, MAX_SUBAGENT_TIMEOUT_MS } from "./limi
 import { PANEL_PRESETS } from "./panel-planning.js";
 import { SUBAGENT_RESULT_FORMATS } from "./result-contract.js";
 import { MAX_SUBAGENT_TOOL_CALLS, MAX_SUBAGENT_TURNS } from "./turn-budget.js";
-import { VerifiedExecutionContractSchema } from "./verified-execution-contract.js";
+import { VerifiedExecutionContractSchema } from "./verified-execution-schema.js";
 
 const TimeoutMs = Type.Number({
 	description:

--- a/packages/pi-subagents/src/pi-args.ts
+++ b/packages/pi-subagents/src/pi-args.ts
@@ -1,0 +1,41 @@
+import type { SubagentThinkingLevel } from "./agents/types.js";
+
+export interface PiArgsOptions {
+	model?: string;
+	thinkingLevel?: SubagentThinkingLevel;
+	tools?: string[];
+	disableExtensions?: boolean;
+	disableSkills?: boolean;
+	disablePromptTemplates?: boolean;
+	disableContextFiles?: boolean;
+	projectTrust?: boolean;
+	baseSystemPromptPath?: string;
+	appendSystemPromptPaths?: string[];
+	/** Existing single append prompt path retained for compatibility. */
+	systemPromptPath?: string;
+	task: string;
+}
+
+export function buildPiArgs(options: PiArgsOptions): string[] {
+	const args: string[] = ["--mode", "json", "-p", "--no-session"];
+	if (options.model) args.push("--model", options.model);
+	if (options.thinkingLevel) args.push("--thinking", options.thinkingLevel);
+	if (options.disableExtensions) args.push("--no-extensions");
+	if (options.disableSkills) args.push("--no-skills");
+	if (options.disablePromptTemplates) args.push("--no-prompt-templates");
+	if (options.disableContextFiles) args.push("--no-context-files");
+	if (options.projectTrust !== undefined) {
+		args.push(options.projectTrust ? "--approve" : "--no-approve");
+	}
+	if (Array.isArray(options.tools)) {
+		if (options.tools.length > 0) args.push("--tools", options.tools.join(","));
+		else args.push("--no-tools");
+	}
+	if (options.baseSystemPromptPath) args.push("--system-prompt", options.baseSystemPromptPath);
+	for (const promptPath of options.appendSystemPromptPaths ?? []) {
+		args.push("--append-system-prompt", promptPath);
+	}
+	if (options.systemPromptPath) args.push("--append-system-prompt", options.systemPromptPath);
+	args.push(`Task: ${options.task}`);
+	return args;
+}

--- a/packages/pi-subagents/src/render.ts
+++ b/packages/pi-subagents/src/render.ts
@@ -11,12 +11,8 @@ import type { AgentScope, SubagentThinkingLevel } from "./agents/types.js";
 import { renderPanelCall, renderPanelResult } from "./panel-render.js";
 import { hasUsableAggregator, type SubagentParams } from "./params.js";
 import { expansionHint, formatToolActivity, safeBlock, safeLine } from "./render-common.js";
-import {
-	getResultFinalOutput,
-	isResultError,
-	type SingleResult,
-	type SubagentDetails,
-} from "./runner.js";
+import type { SingleResult, SubagentDetails } from "./runner.js";
+import { getResultFinalOutput, isResultError } from "./runner-outcome.js";
 
 const COLLAPSED_ITEM_COUNT = 5;
 

--- a/packages/pi-subagents/src/runner-outcome.ts
+++ b/packages/pi-subagents/src/runner-outcome.ts
@@ -1,0 +1,31 @@
+import type { SingleResult } from "./runner.js";
+import {
+	formatResultFailure as formatBaseResultFailure,
+	getResultFinalOutput as getBaseResultFinalOutput,
+	isResultError as isBaseResultError,
+} from "./runner-result.js";
+
+export function getResultFinalOutput(result: SingleResult): string {
+	return getBaseResultFinalOutput(result);
+}
+
+export function isResultError(result: SingleResult): boolean {
+	return (
+		isBaseResultError(result) ||
+		result.resultContractInvalid === true ||
+		(result.outcome !== undefined &&
+			result.outcome.status !== "completed" &&
+			result.outcome.status !== "partial")
+	);
+}
+
+export function formatResultFailure(result: SingleResult): string {
+	const contractError = result.resultContractInvalid
+		? `Subagent returned an invalid ${result.resultFormat ?? "structured"} result contract`
+		: result.outcome && !["completed", "partial"].includes(result.outcome.status)
+			? `Subagent outcome ${result.outcome.status}${result.outcome.reasonCode ? ` (${result.outcome.reasonCode})` : ""}; recovery: ${result.outcome.recoveryActions.join(", ") || "none"}`
+			: undefined;
+	return contractError
+		? formatBaseResultFailure({ ...result, errorMessage: contractError })
+		: formatBaseResultFailure(result);
+}

--- a/packages/pi-subagents/src/runner.ts
+++ b/packages/pi-subagents/src/runner.ts
@@ -31,6 +31,7 @@ import type { PanelSynthesis } from "./panel-contract.js";
 import type { PanelEvidenceArtifact } from "./panel-evidence.js";
 import type { PanelFailure } from "./panel-failure.js";
 import type { PanelPhaseBudgets, PanelPreset } from "./panel-planning.js";
+import { buildPiArgs } from "./pi-args.js";
 import { resolvePiInvocation } from "./pi-invocation.js";
 import { JsonLineDecoder } from "./protocol.js";
 import {
@@ -38,12 +39,8 @@ import {
 	parseAnyStructuredSubagentResult,
 	type SubagentResultFormat,
 } from "./result-contract.js";
-import {
-	formatResultFailure as formatBaseResultFailure,
-	getResultFinalOutput as getBaseResultFinalOutput,
-	getFinalOutput,
-	isResultError as isBaseResultError,
-} from "./runner-result.js";
+import { formatResultFailure, getResultFinalOutput, isResultError } from "./runner-outcome.js";
+import { getFinalOutput } from "./runner-result.js";
 import {
 	addUsageValue,
 	mergeUsageStats,
@@ -68,6 +65,13 @@ import type { WorkItemLedgerSnapshot } from "./work-item-ledger.js";
 
 export const KILL_GRACE_MS = 5000;
 
+export type { PiArgsOptions } from "./pi-args.js";
+export { buildPiArgs } from "./pi-args.js";
+export {
+	formatResultFailure,
+	getResultFinalOutput,
+	isResultError,
+} from "./runner-outcome.js";
 export type { UsageStats } from "./runner-usage.js";
 export type RecentActivityItem =
 	| { type: "text"; text: string }
@@ -152,31 +156,6 @@ export interface SubagentDetails {
 	metrics?: OrchestrationMetrics;
 	panel?: PanelDetails;
 	isError?: boolean;
-}
-
-export function getResultFinalOutput(result: SingleResult): string {
-	return getBaseResultFinalOutput(result);
-}
-
-export function isResultError(result: SingleResult): boolean {
-	return (
-		isBaseResultError(result) ||
-		result.resultContractInvalid === true ||
-		(result.outcome !== undefined &&
-			result.outcome.status !== "completed" &&
-			result.outcome.status !== "partial")
-	);
-}
-
-export function formatResultFailure(result: SingleResult): string {
-	const contractError = result.resultContractInvalid
-		? `Subagent returned an invalid ${result.resultFormat ?? "structured"} result contract`
-		: result.outcome && !["completed", "partial"].includes(result.outcome.status)
-			? `Subagent outcome ${result.outcome.status}${result.outcome.reasonCode ? ` (${result.outcome.reasonCode})` : ""}; recovery: ${result.outcome.recoveryActions.join(", ") || "none"}`
-			: undefined;
-	return contractError
-		? formatBaseResultFailure({ ...result, errorMessage: contractError })
-		: formatBaseResultFailure(result);
 }
 
 function boundMessageText(
@@ -357,46 +336,6 @@ async function writePromptToTempFile(
 		await fs.promises.writeFile(filePath, prompt, { encoding: "utf-8", mode: 0o600 });
 	});
 	return { dir: tmpDir, filePath };
-}
-
-export interface PiArgsOptions {
-	model?: string;
-	thinkingLevel?: SubagentThinkingLevel;
-	tools?: string[];
-	disableExtensions?: boolean;
-	disableSkills?: boolean;
-	disablePromptTemplates?: boolean;
-	disableContextFiles?: boolean;
-	projectTrust?: boolean;
-	baseSystemPromptPath?: string;
-	appendSystemPromptPaths?: string[];
-	/** Existing single append prompt path retained for compatibility. */
-	systemPromptPath?: string;
-	task: string;
-}
-
-export function buildPiArgs(options: PiArgsOptions): string[] {
-	const args: string[] = ["--mode", "json", "-p", "--no-session"];
-	if (options.model) args.push("--model", options.model);
-	if (options.thinkingLevel) args.push("--thinking", options.thinkingLevel);
-	if (options.disableExtensions) args.push("--no-extensions");
-	if (options.disableSkills) args.push("--no-skills");
-	if (options.disablePromptTemplates) args.push("--no-prompt-templates");
-	if (options.disableContextFiles) args.push("--no-context-files");
-	if (options.projectTrust !== undefined) {
-		args.push(options.projectTrust ? "--approve" : "--no-approve");
-	}
-	if (Array.isArray(options.tools)) {
-		if (options.tools.length > 0) args.push("--tools", options.tools.join(","));
-		else args.push("--no-tools");
-	}
-	if (options.baseSystemPromptPath) args.push("--system-prompt", options.baseSystemPromptPath);
-	for (const promptPath of options.appendSystemPromptPaths ?? []) {
-		args.push("--append-system-prompt", promptPath);
-	}
-	if (options.systemPromptPath) args.push("--append-system-prompt", options.systemPromptPath);
-	args.push(`Task: ${options.task}`);
-	return args;
 }
 
 function signalProcess(proc: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
@@ -857,16 +796,16 @@ export async function runSingleAgent(
 				onExceeded: stopForBudget,
 			});
 
-			timeout = setTimeout(() => {
-				stopForBudget({
-					reason: launchPolicy?.workTimeoutReason ?? "work_timeout",
-					limit: launchPolicy?.workTimeoutReportLimit ?? timeoutMs,
-				});
-			}, timeoutMs);
-			timeout.unref();
-
 			proc.once("spawn", () => {
 				currentResult.processStarted = true;
+				if (settled || budgetStop || wasAborted) return;
+				timeout = setTimeout(() => {
+					stopForBudget({
+						reason: launchPolicy?.workTimeoutReason ?? "work_timeout",
+						limit: launchPolicy?.workTimeoutReportLimit ?? timeoutMs,
+					});
+				}, timeoutMs);
+				timeout.unref();
 			});
 			proc.stdout?.on("data", (data) => decoder.push(data));
 			proc.stderr?.on("data", (data) => {

--- a/packages/pi-subagents/src/stateful.ts
+++ b/packages/pi-subagents/src/stateful.ts
@@ -20,7 +20,10 @@ import {
 import { issueCapabilityGrant } from "./capability-grant.js";
 import { CompletionDeliveryBroker } from "./completion-delivery.js";
 import { buildContextSnapshot, type ContextMode, redactPrivateText } from "./context.js";
-import { createStatefulTransport } from "./create-stateful-transport.js";
+import {
+	type CreateStatefulTransportOptions,
+	createStatefulTransport,
+} from "./create-stateful-transport.js";
 import {
 	assertDelegationTargetAllowed,
 	resolveSubagentTarget,
@@ -133,6 +136,7 @@ export interface StatefulSubagentDependencies {
 	workspaceManager?: WorkspaceManager;
 	settings?: SubagentRuntimeSettings;
 	getSettings?: () => SubagentSettings | undefined;
+	loadTransport?: CreateStatefulTransportOptions["loadTransport"];
 }
 
 export interface StatefulSubagentRuntimeStatus {
@@ -319,6 +323,7 @@ export function registerStatefulSubagents(
 				getParentRuntime: () => ({ ...parentRuntime }),
 				getSettings: getCurrentSettings,
 				createInProcessSession: dependencies.createInProcessSession,
+				loadTransport: dependencies.loadTransport,
 			});
 			nextRegistry = new AgentRegistry(transport, {
 				maxAgents: nextLimits.maxAgents,

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -21,11 +21,24 @@ import type {
 	DelegationCwdPolicy,
 	SubagentSettings,
 } from "./agents/types.js";
-import { registerSubagentAutomation } from "./automation.js";
-import { registerSubagentConfigCommand, registerSubagentConfigLifecycle } from "./config-ui.js";
-import { registerSubagentConsult } from "./consult.js";
-import { executeSubagent } from "./execution.js";
-import { registerSubagentInspect } from "./inspect.js";
+import {
+	type AutomationRegistrationDependencies,
+	registerSubagentAutomation,
+} from "./automation-registration.js";
+import { cachedModuleLoader, throwIfAborted } from "./cached-module-loader.js";
+import {
+	type ConfigRegistrationDependencies,
+	registerSubagentConfigCommand,
+	registerSubagentConfigLifecycle,
+} from "./config-registration.js";
+import {
+	type ConsultRegistrationDependencies,
+	registerSubagentConsult,
+} from "./consult-registration.js";
+import {
+	type InspectRegistrationDependencies,
+	registerSubagentInspect,
+} from "./inspect-registration.js";
 import { MAX_BLOCKING_PARALLEL_CONCURRENCY } from "./limits.js";
 import { SubagentParams } from "./params.js";
 import { renderSubagentCall, renderSubagentResult } from "./render.js";
@@ -40,17 +53,34 @@ import {
 	resolveBlockingMaxParallelTasks,
 } from "./settings.js";
 import { registerStatefulSubagents } from "./stateful.js";
+import type { SubagentTransport } from "./transport.js";
 
-export default function (pi: ExtensionAPI) {
+type BlockingExecutionModule = Pick<typeof import("./execution.js"), "executeSubagent">;
+
+export interface SubagentsDependencies {
+	loadBlockingExecution?: () => Promise<BlockingExecutionModule>;
+	loadStatefulTransport?: () => Promise<SubagentTransport>;
+	automation?: AutomationRegistrationDependencies;
+	config?: ConfigRegistrationDependencies;
+	consult?: ConsultRegistrationDependencies;
+	inspect?: InspectRegistrationDependencies;
+}
+
+export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies = {}) {
+	const loadBlockingExecution = cachedModuleLoader(
+		dependencies.loadBlockingExecution ?? (() => import("./execution.js")),
+	);
 	const configOwner = registerSubagentConfigLifecycle(pi);
 	const settings = readSubagentSettings();
 	let currentSettings: SubagentSettings | undefined = settings;
 	let currentCatalog = "";
 	const blockingEnabled = settings?.blocking?.enabled !== false;
 	const refreshBlockingCatalog = blockingEnabled
-		? registerBlockingSubagent(pi, () => currentSettings)
+		? registerBlockingSubagent(pi, () => currentSettings, loadBlockingExecution)
 		: () => undefined;
-	if (blockingEnabled) registerSubagentAutomation(pi, { getSettings: () => currentSettings });
+	if (blockingEnabled) {
+		registerSubagentAutomation(pi, { getSettings: () => currentSettings }, dependencies.automation);
+	}
 	let refreshStatefulCatalog: (catalog: string) => void = () => undefined;
 	let refreshConsultCatalog: (catalog: string) => void = () => undefined;
 
@@ -78,6 +108,7 @@ export default function (pi: ExtensionAPI) {
 		blockingEnabled,
 		settings: settings?.stateful,
 		getSettings: () => currentSettings,
+		loadTransport: dependencies.loadStatefulTransport,
 	});
 	refreshStatefulCatalog = statefulRuntime.setAgentCatalog;
 	const getBlockingEnabled = () => blockingEnabled;
@@ -88,18 +119,24 @@ export default function (pi: ExtensionAPI) {
 		currentSettings?.cwdPolicy?.consultation ?? DEFAULT_CONSULTATION_CWD_POLICY;
 	const getDelegationCwdPolicy = () =>
 		currentSettings?.cwdPolicy?.delegation ?? DEFAULT_DELEGATION_CWD_POLICY;
-	registerSubagentInspect(pi, {
-		...statefulRuntime,
-		getBlockingEnabled,
-		getMaxParallelTasks,
-		getConsultResourcePolicy,
-		getConsultationCwdPolicy,
-		getDelegationCwdPolicy,
-	});
+	registerSubagentInspect(
+		pi,
+		{
+			...statefulRuntime,
+			getBlockingEnabled,
+			getMaxParallelTasks,
+			getConsultResourcePolicy,
+			getConsultationCwdPolicy,
+			getDelegationCwdPolicy,
+		},
+		dependencies.inspect,
+	);
 	if (blockingEnabled) {
-		refreshConsultCatalog = registerSubagentConsult(pi, {
-			getSettings: () => currentSettings,
-		});
+		refreshConsultCatalog = registerSubagentConsult(
+			pi,
+			{ getSettings: () => currentSettings },
+			dependencies.consult,
+		);
 	}
 	registerSubagentConfigCommand(
 		pi,
@@ -155,12 +192,14 @@ export default function (pi: ExtensionAPI) {
 			},
 		},
 		configOwner,
+		dependencies.config,
 	);
 }
 
 function registerBlockingSubagent(
 	pi: ExtensionAPI,
 	getSettings: () => SubagentSettings | undefined,
+	loadExecution: () => Promise<BlockingExecutionModule>,
 ): (catalog: string) => void {
 	let catalog = "";
 	const activeControllers = new Set<AbortController>();
@@ -212,14 +251,28 @@ function registerBlockingSubagent(
 			const effectiveSignal = signal
 				? AbortSignal.any([signal, lifecycleController.signal])
 				: lifecycleController.signal;
-			const work = executeSubagent(
-				toolCallId,
-				params,
-				effectiveSignal,
-				onUpdate,
-				ctx,
-				getSettings(),
-			);
+			const work = (async () => {
+				throwIfAborted(effectiveSignal, "Blocking subagent execution was cancelled");
+				let executionModule: BlockingExecutionModule;
+				try {
+					executionModule = await loadExecution();
+				} catch (error) {
+					throwIfAborted(
+						effectiveSignal,
+						"Blocking subagent execution was cancelled while loading",
+					);
+					throw error;
+				}
+				throwIfAborted(effectiveSignal, "Blocking subagent execution was cancelled while loading");
+				return executionModule.executeSubagent(
+					toolCallId,
+					params,
+					effectiveSignal,
+					onUpdate,
+					ctx,
+					getSettings(),
+				);
+			})();
 			activeWork.add(work);
 			try {
 				return await work;
@@ -256,8 +309,8 @@ function appendAgentCatalog(baseDescription: string, catalog: string): string {
 }
 
 export { parsePositiveInteger } from "./execution/runtime-policy.js";
+export { buildPiArgs } from "./pi-args.js";
 export { formatTokens, formatUsageStats } from "./render.js";
-export { buildPiArgs } from "./runner.js";
 export {
 	DEFAULT_CONSULT_RESOURCE_POLICY,
 	DEFAULT_CONSULTATION_CWD_POLICY,

--- a/packages/pi-subagents/src/verified-execution-contract.ts
+++ b/packages/pi-subagents/src/verified-execution-contract.ts
@@ -1,41 +1,13 @@
-import { StringEnum } from "@earendil-works/pi-ai";
-import { type Static, Type } from "typebox";
 import { normalizeDelegationContract } from "./delegation-contract.js";
 import {
 	type VerificationCheckRequest,
 	validateVerificationChecks,
 } from "./verification-harness.js";
+import type { VerifiedExecutionContract } from "./verified-execution-schema.js";
 import type { ResolvedWorkflowTask } from "./workflow-planning.js";
 
-const VerificationCheckSchema = Type.Object(
-	{
-		id: Type.String({
-			minLength: 1,
-			maxLength: 256,
-			pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$",
-		}),
-		command: StringEnum(["git", "node", "npm", "npx"] as const),
-		args: Type.Optional(Type.Array(Type.String({ maxLength: 4096 }), { maxItems: 64 })),
-		cwd: Type.Optional(Type.String({ minLength: 1, maxLength: 4096 })),
-		timeoutMs: Type.Optional(Type.Integer({ minimum: 1, maximum: 600_000 })),
-	},
-	{ additionalProperties: false },
-);
-
-export const VerifiedExecutionContractSchema = Type.Object(
-	{
-		verifierAgent: Type.String({ minLength: 1, maxLength: 256 }),
-		maxReworkCycles: Type.Optional(Type.Integer({ minimum: 0, maximum: 1, default: 1 })),
-		checks: Type.Optional(Type.Array(VerificationCheckSchema, { maxItems: 32 })),
-	},
-	{
-		additionalProperties: false,
-		description:
-			"Explicitly gate mutating workflow success on executor-owned deterministic checks, one least-authority independent verifier, exact submitted-state identity, and managed integration acceptance.",
-	},
-);
-
-export type VerifiedExecutionContract = Static<typeof VerifiedExecutionContractSchema>;
+export type { VerifiedExecutionContract } from "./verified-execution-schema.js";
+export { VerifiedExecutionContractSchema } from "./verified-execution-schema.js";
 
 export interface PreparedVerifiedWorkflow {
 	tasks: ResolvedWorkflowTask[];

--- a/packages/pi-subagents/src/verified-execution-schema.ts
+++ b/packages/pi-subagents/src/verified-execution-schema.ts
@@ -1,0 +1,32 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import { type Static, Type } from "typebox";
+
+const VerificationCheckSchema = Type.Object(
+	{
+		id: Type.String({
+			minLength: 1,
+			maxLength: 256,
+			pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$",
+		}),
+		command: StringEnum(["git", "node", "npm", "npx"] as const),
+		args: Type.Optional(Type.Array(Type.String({ maxLength: 4096 }), { maxItems: 64 })),
+		cwd: Type.Optional(Type.String({ minLength: 1, maxLength: 4096 })),
+		timeoutMs: Type.Optional(Type.Integer({ minimum: 1, maximum: 600_000 })),
+	},
+	{ additionalProperties: false },
+);
+
+export const VerifiedExecutionContractSchema = Type.Object(
+	{
+		verifierAgent: Type.String({ minLength: 1, maxLength: 256 }),
+		maxReworkCycles: Type.Optional(Type.Integer({ minimum: 0, maximum: 1, default: 1 })),
+		checks: Type.Optional(Type.Array(VerificationCheckSchema, { maxItems: 32 })),
+	},
+	{
+		additionalProperties: false,
+		description:
+			"Explicitly gate mutating workflow success on executor-owned deterministic checks, one least-authority independent verifier, exact submitted-state identity, and managed integration acceptance.",
+	},
+);
+
+export type VerifiedExecutionContract = Static<typeof VerifiedExecutionContractSchema>;

--- a/packages/pi-subagents/test/consult.test.ts
+++ b/packages/pi-subagents/test/consult.test.ts
@@ -355,9 +355,14 @@ test("subagent_consult shutdown awaits delayed resource setup cleanup", async ()
 	const delayed = new Promise<void>((resolve) => {
 		release = resolve;
 	});
+	let markSetupStarted!: () => void;
+	const setupStarted = new Promise<void>((resolve) => {
+		markSetupStarted = resolve;
+	});
 	const { tool, mock, requests } = setup({
 		settings: { consult: { resources: "all" } },
 		resolveResourceLaunchPolicy: async () => {
+			markSetupStarted();
 			await delayed;
 			return { disableExtensions: true, projectTrust: true };
 		},
@@ -367,7 +372,8 @@ test("subagent_consult shutdown awaits delayed resource setup cleanup", async ()
 		{ agent: "worker", task: "inspect" },
 		createMockContext({ isProjectTrusted: () => true }).ctx,
 	);
-	await Promise.resolve();
+	void running.catch(() => undefined);
+	await setupStarted;
 	let shutdownSettled = false;
 	const shutdown = Promise.all(
 		(mock.events.get("session_shutdown") ?? []).map((handler) =>

--- a/packages/pi-subagents/test/in-process-transport.test.ts
+++ b/packages/pi-subagents/test/in-process-transport.test.ts
@@ -716,6 +716,13 @@ test("registered detached spawn auto-resumes without exposing a wait tool", asyn
 			}
 			assert.equal(mock.sentMessages.length, expected);
 		};
+		const waitForPromptCount = async (expected: number) => {
+			const deadline = Date.now() + 5_000;
+			while (child.prompts.length < expected && Date.now() < deadline) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+			assert.equal(child.prompts.length, expected);
+		};
 
 		child.waitForNextAbort();
 		const spawned = await execute("subagent_spawn", {
@@ -738,6 +745,7 @@ test("registered detached spawn auto-resumes without exposing a wait tool", asyn
 		assert.match(spawned.content[0]?.text ?? "", /useful non-overlapping work immediately/i);
 		assert.match(spawned.content[0]?.text ?? "", /end the response/i);
 		assert.match(spawned.content[0]?.text ?? "", /do not poll/i);
+		await waitForPromptCount(1);
 		assert.deepEqual(child.prompts, ["first"]);
 		assert.equal(created[0].agent.thinkingLevel, "high");
 		assert.equal(

--- a/packages/pi-subagents/test/runner-budgets-and-output.test.ts
+++ b/packages/pi-subagents/test/runner-budgets-and-output.test.ts
@@ -112,7 +112,7 @@ test("runSingleAgent aborts timed-out work and returns a hard-bounded tool-less 
 		undefined,
 		undefined,
 		"low",
-		150,
+		500,
 		undefined,
 		(results) => ({ mode: "single", agentScope: "user", projectAgentsDir: null, results }),
 		{ command: process.execPath, argsPrefix: ["-e", script, "--"] },

--- a/packages/pi-subagents/test/startup-imports.test.ts
+++ b/packages/pi-subagents/test/startup-imports.test.ts
@@ -311,6 +311,89 @@ test("stateful transport retries a rejected implementation load", async () => {
 	await transport.shutdown?.();
 });
 
+test("stateful transport cancellation during loading starts no turn", async () => {
+	let releaseLoading!: (transport: SubagentTransport) => void;
+	const loading = new Promise<SubagentTransport>((resolve) => {
+		releaseLoading = resolve;
+	});
+	const implementation = new FakeTransport();
+	const transport = createStatefulTransport({
+		kind: "subprocess",
+		modelRegistry: {} as never,
+		getParentRuntime: () => ({ model: undefined, thinkingLevel: "off" }),
+		getSettings: () => undefined,
+		loadTransport: () => loading,
+	});
+	const controller = new AbortController();
+	const running = transport.runTurn(managedAgent(), "first", controller.signal);
+	void running.catch(() => undefined);
+	await Promise.resolve();
+	controller.abort(new DOMException("turn cancelled", "AbortError"));
+	releaseLoading(implementation);
+
+	await assert.rejects(
+		running,
+		(error) =>
+			error instanceof DOMException &&
+			error.name === "AbortError" &&
+			error.message === "turn cancelled",
+	);
+	assert.equal(implementation.turns, 0);
+	await transport.shutdown?.();
+});
+
+test("stateful transport cancellation wins over a loader rejection", async () => {
+	let rejectLoading!: (error: Error) => void;
+	const loading = new Promise<SubagentTransport>((_resolve, reject) => {
+		rejectLoading = reject;
+	});
+	const transport = createStatefulTransport({
+		kind: "subprocess",
+		modelRegistry: {} as never,
+		getParentRuntime: () => ({ model: undefined, thinkingLevel: "off" }),
+		getSettings: () => undefined,
+		loadTransport: () => loading,
+	});
+	const controller = new AbortController();
+	const running = transport.runTurn(managedAgent(), "first", controller.signal);
+	void running.catch(() => undefined);
+	await Promise.resolve();
+	controller.abort(new DOMException("turn cancelled", "AbortError"));
+	rejectLoading(new Error("loader failed after cancellation"));
+
+	await assert.rejects(
+		running,
+		(error) =>
+			error instanceof DOMException &&
+			error.name === "AbortError" &&
+			error.message === "turn cancelled",
+	);
+	await transport.shutdown?.();
+});
+
+test("stateful transport rejects an already-cancelled turn without loading", async () => {
+	let loads = 0;
+	const transport = createStatefulTransport({
+		kind: "subprocess",
+		modelRegistry: {} as never,
+		getParentRuntime: () => ({ model: undefined, thinkingLevel: "off" }),
+		getSettings: () => undefined,
+		loadTransport: async () => {
+			loads += 1;
+			return new FakeTransport();
+		},
+	});
+	const controller = new AbortController();
+	controller.abort(new DOMException("turn cancelled", "AbortError"));
+
+	await assert.rejects(
+		() => transport.runTurn(managedAgent(), "first", controller.signal),
+		(error) => error instanceof DOMException && error.name === "AbortError",
+	);
+	assert.equal(loads, 0);
+	await transport.shutdown?.();
+});
+
 test("stateful transport shutdown disposes an implementation that resolves after closure", async () => {
 	let releaseLoading!: (transport: SubagentTransport) => void;
 	const loading = new Promise<SubagentTransport>((resolve) => {

--- a/packages/pi-subagents/test/startup-imports.test.ts
+++ b/packages/pi-subagents/test/startup-imports.test.ts
@@ -1,0 +1,336 @@
+import assert from "node:assert/strict";
+import { afterAll, test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { createStatefulTransport } from "../src/create-stateful-transport.js";
+import type { ManagedAgent, TurnOutcome } from "../src/registry.js";
+import subagents from "../src/subagents.js";
+import type { SubagentTransport } from "../src/transport.js";
+import { installSubagentsTestEnvironment } from "./subagents-test-helpers.js";
+
+const restoreTestEnvironment = installSubagentsTestEnvironment();
+afterAll(restoreTestEnvironment);
+
+async function emitAll(
+	mock: ReturnType<typeof createMockPi>,
+	name: string,
+	event: unknown,
+	ctx = createMockContext().ctx,
+): Promise<void> {
+	for (const handler of mock.events.get(name) ?? []) await handler(event, ctx);
+}
+
+function managedAgent(): ManagedAgent {
+	return {
+		id: "sa_lazy",
+		agent: "scout",
+		rootId: "sa_lazy",
+		depth: 0,
+		children: [],
+		state: "running",
+		createdAt: 1,
+		updatedAt: 1,
+		cwd: process.cwd(),
+		history: [],
+		mailbox: [],
+	};
+}
+
+class FakeTransport implements SubagentTransport {
+	readonly kind = "fake" as const;
+	turns = 0;
+	shutdowns = 0;
+
+	async runTurn(): Promise<TurnOutcome> {
+		this.turns += 1;
+		return { output: "done", exitCode: 0 };
+	}
+
+	async shutdown(): Promise<void> {
+		this.shutdowns += 1;
+	}
+}
+
+test("Subagents idle startup registers every surface without loading deferred implementations", async () => {
+	const mock = createMockPi();
+	const loads = {
+		automation: 0,
+		blocking: 0,
+		config: 0,
+		consult: 0,
+		inspect: 0,
+		transport: 0,
+	};
+	subagents(mock.pi, {
+		loadBlockingExecution: async () => {
+			loads.blocking += 1;
+			return {} as never;
+		},
+		loadStatefulTransport: async () => {
+			loads.transport += 1;
+			return new FakeTransport();
+		},
+		automation: {
+			loadExecution: async () => {
+				loads.automation += 1;
+				return {} as never;
+			},
+		},
+		config: {
+			loadConfigUi: async () => {
+				loads.config += 1;
+				return {} as never;
+			},
+		},
+		consult: {
+			loadExecution: async () => {
+				loads.consult += 1;
+				return {} as never;
+			},
+		},
+		inspect: {
+			loadExecution: async () => {
+				loads.inspect += 1;
+				return {} as never;
+			},
+		},
+	});
+	const context = createMockContext();
+	await emitAll(mock, "session_start", { reason: "startup" }, context.ctx);
+
+	assert.deepEqual(loads, {
+		automation: 0,
+		blocking: 0,
+		config: 0,
+		consult: 0,
+		inspect: 0,
+		transport: 0,
+	});
+	assert.deepEqual(
+		[...new Set(mock.tools.map((tool) => tool.name))],
+		[
+			"subagent",
+			"subagent_auto",
+			"subagent_spawn",
+			"subagent_send",
+			"subagent_manage",
+			"subagent_mailbox",
+			"subagent_inspect",
+			"subagent_consult",
+		],
+	);
+	assert.ok(mock.commands.has("subagents"));
+	await emitAll(mock, "session_shutdown", { reason: "quit" }, context.ctx);
+});
+
+test("Subagents direct status stays lightweight and manager UI loads once on demand", async () => {
+	const mock = createMockPi();
+	let loads = 0;
+	let shows = 0;
+	subagents(mock.pi, {
+		config: {
+			loadConfigUi: async () => {
+				loads += 1;
+				return {
+					showSubagentManager: async () => {
+						shows += 1;
+					},
+					showSubagentSettings: async () => undefined,
+				};
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	await emitAll(mock, "session_start", { reason: "startup" }, context.ctx);
+	const command = mock.commands.get("subagents");
+	assert.ok(command);
+	await command.handler("status", context.ctx);
+	assert.equal(loads, 0);
+	await command.handler("", context.ctx);
+	await command.handler("", context.ctx);
+	assert.equal(loads, 1);
+	assert.equal(shows, 2);
+	await emitAll(mock, "session_shutdown", { reason: "quit" }, context.ctx);
+});
+
+test("blocking execution caches a successful module and retries a rejected load", async () => {
+	const mock = createMockPi();
+	let loads = 0;
+	let executions = 0;
+	subagents(mock.pi, {
+		loadBlockingExecution: async () => {
+			loads += 1;
+			if (loads === 1) throw new Error("temporary blocking loader failure");
+			return {
+				executeSubagent: async () => {
+					executions += 1;
+					return {
+						content: [{ type: "text" as const, text: "done" }],
+						details: {
+							mode: "single" as const,
+							agentScope: "user" as const,
+							projectAgentsDir: null,
+							results: [],
+						},
+					};
+				},
+			} as never;
+		},
+	});
+	const tool = mock.tools.find((candidate) => candidate.name === "subagent") as
+		| { execute: (...args: unknown[]) => Promise<unknown> }
+		| undefined;
+	assert.ok(tool);
+	const context = createMockContext();
+	await assert.rejects(
+		() =>
+			tool.execute("first", { agent: "scout", task: "inspect" }, undefined, undefined, context.ctx),
+		/temporary blocking loader failure/u,
+	);
+	await tool.execute(
+		"second",
+		{ agent: "scout", task: "inspect" },
+		undefined,
+		undefined,
+		context.ctx,
+	);
+	await tool.execute(
+		"third",
+		{ agent: "scout", task: "inspect" },
+		undefined,
+		undefined,
+		context.ctx,
+	);
+
+	assert.equal(loads, 2);
+	assert.equal(executions, 2);
+});
+
+test("blocking execution cancellation waits for a pending import and starts no stale work", async () => {
+	const mock = createMockPi();
+	let startLoading!: () => void;
+	const loadingStarted = new Promise<void>((resolve) => {
+		startLoading = resolve;
+	});
+	let releaseLoading!: () => void;
+	const loadingGate = new Promise<void>((resolve) => {
+		releaseLoading = resolve;
+	});
+	let executions = 0;
+	subagents(mock.pi, {
+		loadBlockingExecution: async () => {
+			startLoading();
+			await loadingGate;
+			return {
+				executeSubagent: async () => {
+					executions += 1;
+					throw new Error("stale execution started");
+				},
+			} as never;
+		},
+	});
+	const tool = mock.tools.find((candidate) => candidate.name === "subagent") as
+		| { execute: (...args: unknown[]) => Promise<unknown> }
+		| undefined;
+	assert.ok(tool);
+	const context = createMockContext();
+	const running = tool.execute(
+		"pending",
+		{ agent: "scout", task: "inspect" },
+		undefined,
+		undefined,
+		context.ctx,
+	);
+	void running.catch(() => undefined);
+	await loadingStarted;
+	let shutdownSettled = false;
+	const shutdown = emitAll(mock, "session_shutdown", { reason: "quit" }, context.ctx).then(() => {
+		shutdownSettled = true;
+	});
+	await new Promise((resolve) => setTimeout(resolve, 5));
+	assert.equal(shutdownSettled, false);
+	releaseLoading();
+	await shutdown;
+	await assert.rejects(running, (error) => error instanceof Error && error.name === "AbortError");
+	assert.equal(executions, 0);
+});
+
+test("stateful transport loads once on first turn and stays unloaded on idle shutdown", async () => {
+	let loads = 0;
+	const implementation = new FakeTransport();
+	const transport = createStatefulTransport({
+		kind: "subprocess",
+		modelRegistry: {} as never,
+		getParentRuntime: () => ({ model: undefined, thinkingLevel: "off" }),
+		getSettings: () => undefined,
+		loadTransport: async () => {
+			loads += 1;
+			return implementation;
+		},
+	});
+	const idle = createStatefulTransport({
+		kind: "subprocess",
+		modelRegistry: {} as never,
+		getParentRuntime: () => ({ model: undefined, thinkingLevel: "off" }),
+		getSettings: () => undefined,
+		loadTransport: async () => {
+			throw new Error("idle shutdown loaded a transport");
+		},
+	});
+
+	await idle.shutdown?.();
+	assert.equal(loads, 0);
+	await transport.runTurn(managedAgent(), "first", new AbortController().signal);
+	await transport.runTurn(managedAgent(), "second", new AbortController().signal);
+	assert.equal(loads, 1);
+	assert.equal(implementation.turns, 2);
+	await transport.shutdown?.();
+	assert.equal(implementation.shutdowns, 1);
+});
+
+test("stateful transport retries a rejected implementation load", async () => {
+	let loads = 0;
+	const implementation = new FakeTransport();
+	const transport = createStatefulTransport({
+		kind: "subprocess",
+		modelRegistry: {} as never,
+		getParentRuntime: () => ({ model: undefined, thinkingLevel: "off" }),
+		getSettings: () => undefined,
+		loadTransport: async () => {
+			loads += 1;
+			if (loads === 1) throw new Error("temporary transport loader failure");
+			return implementation;
+		},
+	});
+	await assert.rejects(
+		() => transport.runTurn(managedAgent(), "first", new AbortController().signal),
+		/temporary transport loader failure/u,
+	);
+	await transport.runTurn(managedAgent(), "second", new AbortController().signal);
+	assert.equal(loads, 2);
+	assert.equal(implementation.turns, 1);
+	await transport.shutdown?.();
+});
+
+test("stateful transport shutdown disposes an implementation that resolves after closure", async () => {
+	let releaseLoading!: (transport: SubagentTransport) => void;
+	const loading = new Promise<SubagentTransport>((resolve) => {
+		releaseLoading = resolve;
+	});
+	const implementation = new FakeTransport();
+	const transport = createStatefulTransport({
+		kind: "subprocess",
+		modelRegistry: {} as never,
+		getParentRuntime: () => ({ model: undefined, thinkingLevel: "off" }),
+		getSettings: () => undefined,
+		loadTransport: () => loading,
+	});
+	const running = transport.runTurn(managedAgent(), "first", new AbortController().signal);
+	void running.catch(() => undefined);
+	await Promise.resolve();
+	const shutdown = transport.shutdown?.();
+	releaseLoading(implementation);
+	await shutdown;
+	await assert.rejects(running, /shut down while loading/u);
+	assert.equal(implementation.turns, 0);
+	assert.equal(implementation.shutdowns, 1);
+});

--- a/packages/pi-subagents/test/stateful-trust.test.ts
+++ b/packages/pi-subagents/test/stateful-trust.test.ts
@@ -27,6 +27,13 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 	let delegation: "trusted-targets" | "anywhere" = "trusted-targets";
 	const created: ManagedAgent[] = [];
 	const createdTools: Array<string[] | undefined> = [];
+	const waitForCreated = async (expected: number) => {
+		const deadline = Date.now() + 5_000;
+		while (created.length < expected && Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		assert.equal(created.length, expected);
+	};
 	let workspaceCreates = 0;
 	let projectConfirmations = 0;
 	try {
@@ -106,7 +113,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 			undefined,
 			context.ctx,
 		);
-		await new Promise<void>((resolve) => setImmediate(resolve));
+		await waitForCreated(1);
 		assert.deepEqual(createdTools[0], []);
 		assert.equal(created[0]?.target?.trust.kind, "saved-trusted");
 		assert.equal(created[0]?.target?.trust.projectTrusted, true);
@@ -140,8 +147,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 		)) as { details: { agent: { id: string } } };
 		assert.equal(idempotentSecond.details.agent.id, idempotentFirst.details.agent.id);
 		assert.equal(idempotentFirst.details.agent.context.bytes, 0);
-		await new Promise<void>((resolve) => setImmediate(resolve));
-		assert.equal(created.length, 2);
+		await waitForCreated(2);
 		await assert.rejects(
 			() =>
 				spawn.execute(
@@ -168,7 +174,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 			undefined,
 			context.ctx,
 		);
-		await new Promise<void>((resolve) => setImmediate(resolve));
+		await waitForCreated(3);
 		assert.equal(created[2]?.target?.trust.kind, "saved-denied");
 		assert.equal(created[2]?.target?.trust.projectTrusted, false);
 
@@ -179,7 +185,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 			undefined,
 			context.ctx,
 		);
-		await new Promise<void>((resolve) => setImmediate(resolve));
+		await waitForCreated(4);
 		assert.equal(created[3]?.cwd, generated);
 		assert.equal(created[3]?.workspaceMode, "worktree");
 		assert.equal(created[3]?.target?.cwd, realpathSync(workspace));

--- a/packages/pi-subagents/test/subagent-workflow-execution.test.ts
+++ b/packages/pi-subagents/test/subagent-workflow-execution.test.ts
@@ -775,4 +775,4 @@ test("opt-in verified execution owns accept, bounded rework, drift, checks, evid
 		restorePiPackage();
 		rmSync(root, { recursive: true, force: true });
 	}
-});
+}, 60_000);

--- a/packages/pi-workflow/README.md
+++ b/packages/pi-workflow/README.md
@@ -15,6 +15,7 @@ Those packages intentionally share command, tool, event-channel, and session-sta
 ## ✨ Features
 
 - Provides `/workflow`, `/plan`, and `/goal` from one extension.
+- Registers Plan and Goal behavior eagerly while loading the combined manager and fresh-session handoff code only when those routes are used.
 - Preserves Plan exploration, structured questions, completion, save, export, tool selection, and thinking-level control.
 - Supports Plan alone, Goal alone, and approved Plan-to-Goal execution without adding a non-Goal implementation path.
 - Preserves Goal completion, blocking, external waits, pause, resume, edit, clear, token budgets, continuation guards, optional ordered queues, and managed-run RPC.
@@ -335,8 +336,9 @@ Behavioral updates to either stable predecessor must be intentionally synchroniz
 packages/pi-workflow/
 ├── src/
 │   ├── index.ts       # Thin Pi package entrypoint
-│   ├── workflow.ts    # Composition, command guards, lifecycle, and handoff ownership
-│   ├── handoff.ts     # Fresh linked-session Plan-to-Goal transfer
+│   ├── workflow.ts    # Composition, lifecycle, and retryable first-use loaders
+│   ├── workflow-contract.ts # Lightweight shared handoff identity
+│   ├── handoff.ts     # First-use fresh linked-session Plan-to-Goal transfer
 │   ├── menu.ts        # Standard /workflow TUI and RPC manager
 │   ├── settings.ts    # Unified validated and atomic settings store
 │   ├── plan/          # Package-owned Plan mode runtime

--- a/packages/pi-workflow/src/handoff.ts
+++ b/packages/pi-workflow/src/handoff.ts
@@ -9,8 +9,9 @@ import {
 	formatImplementationHandoff,
 } from "./plan/fresh-implementation.js";
 import type { PlanModeState } from "./plan/state.js";
+import { WORKFLOW_GOAL_OBJECTIVE } from "./workflow-contract.js";
 
-export const WORKFLOW_GOAL_OBJECTIVE = "Implement and verify the approved Plan-mode plan.";
+export { WORKFLOW_GOAL_OBJECTIVE } from "./workflow-contract.js";
 
 type NewSessionOptions = Exclude<Parameters<ExtensionCommandContext["newSession"]>[0], undefined>;
 type ReplacementContext = Parameters<NonNullable<NewSessionOptions["withSession"]>>[0];

--- a/packages/pi-workflow/src/workflow-contract.ts
+++ b/packages/pi-workflow/src/workflow-contract.ts
@@ -1,0 +1,1 @@
+export const WORKFLOW_GOAL_OBJECTIVE = "Implement and verify the approved Plan-mode plan.";

--- a/packages/pi-workflow/src/workflow.ts
+++ b/packages/pi-workflow/src/workflow.ts
@@ -3,8 +3,7 @@ import { safeTerminalText } from "./goal/errors.js";
 import goal from "./goal/goal.js";
 import type { ActiveGoal } from "./goal/persistence.js";
 import { buildGoalPrompt } from "./goal/prompts.js";
-import { startFreshWorkflowImplementation, WORKFLOW_GOAL_OBJECTIVE } from "./handoff.js";
-import { showWorkflowMenu, type WorkflowMenuController } from "./menu.js";
+import type { WorkflowMenuController } from "./menu.js";
 import planMode, { type PlanModeHandle } from "./plan/plan-mode.js";
 import { restorePlanModeState } from "./plan/state.js";
 import {
@@ -18,19 +17,32 @@ import {
 	type WorkflowSettingsLoadResult,
 	workflowSettingsPath,
 } from "./settings.js";
+import { WORKFLOW_GOAL_OBJECTIVE } from "./workflow-contract.js";
+
+type WorkflowMenuModule = Pick<typeof import("./menu.js"), "showWorkflowMenu">;
+type FreshHandoffModule = Pick<typeof import("./handoff.js"), "startFreshWorkflowImplementation">;
 
 export interface WorkflowDependencies {
 	settingsPath?: string;
 	readSettings?: () => WorkflowSettingsLoadResult;
+	loadWorkflowMenu?: () => Promise<WorkflowMenuModule>;
+	loadFreshHandoff?: () => Promise<FreshHandoffModule>;
 }
 
 export default function workflow(pi: ExtensionAPI, dependencies: WorkflowDependencies = {}) {
 	const settingsPath = dependencies.settingsPath ?? workflowSettingsPath();
 	const readSettings = dependencies.readSettings ?? (() => readWorkflowSettings(settingsPath));
+	const loadWorkflowMenu = cachedModuleLoader(
+		dependencies.loadWorkflowMenu ?? (() => import("./menu.js")),
+	);
+	const loadFreshHandoff = cachedModuleLoader(
+		dependencies.loadFreshHandoff ?? (() => import("./handoff.js")),
+	);
 	let planHandoff: PlanHandoffBehavior = "review";
 	let settingsIssue: string | undefined;
 	let workflowGeneration = 0;
 	let workflowController = new AbortController();
+	let currentSessionManager: unknown;
 	const readPlanSettings = () => {
 		if (!dependencies.readSettings) return readWorkflowPlanSettings(settingsPath);
 		const loaded = readSettings();
@@ -87,7 +99,22 @@ export default function workflow(pi: ExtensionAPI, dependencies: WorkflowDepende
 			goalHandle.runtime.activeGoal
 				? "Clear the current Goal before starting Plan mode."
 				: undefined,
-		startFreshImplementation: startFreshWorkflowImplementation,
+		startFreshImplementation: async (ctx, request) => {
+			const ownership = captureWorkflowOwnership(ctx, request.isCurrent);
+			if (!ownership.isCurrent()) return { kind: "stale" };
+			let handoffModule: FreshHandoffModule;
+			try {
+				handoffModule = await loadFreshHandoff();
+			} catch (error) {
+				if (!ownership.isCurrent()) return { kind: "stale" };
+				throw error;
+			}
+			if (!ownership.isCurrent()) return { kind: "stale" };
+			return handoffModule.startFreshWorkflowImplementation(ctx, {
+				...request,
+				isCurrent: ownership.isCurrent,
+			});
+		},
 		updateSettings: (patch, options) =>
 			updateWorkflowPlanSettings(patch, {
 				settingsPath,
@@ -122,6 +149,7 @@ export default function workflow(pi: ExtensionAPI, dependencies: WorkflowDepende
 	});
 	pi.on("session_start", (_event, ctx) => {
 		workflowGeneration += 1;
+		currentSessionManager = ctx.sessionManager;
 		let restoredGoal = goalHandle.runtime.activeGoal;
 		const restoredPlanState = planHandle?.getState();
 		const unlinkedImplementation =
@@ -155,8 +183,9 @@ export default function workflow(pi: ExtensionAPI, dependencies: WorkflowDepende
 			"warning",
 		);
 	});
-	pi.on("session_shutdown", () => {
+	pi.on("session_shutdown", (_event, ctx) => {
 		workflowGeneration += 1;
+		if (currentSessionManager === ctx.sessionManager) currentSessionManager = undefined;
 		workflowController.abort(new DOMException("Workflow session shut down", "AbortError"));
 	});
 
@@ -201,17 +230,40 @@ export default function workflow(pi: ExtensionAPI, dependencies: WorkflowDepende
 			if (ctx.mode === "print" || ctx.mode === "json") {
 				throw new Error("The /workflow manager requires TUI or RPC mode.");
 			}
-			const generation = workflowGeneration;
-			const controller = workflowController;
-			await showWorkflowMenu(ctx, menuController, {
-				signal: controller.signal,
-				isCurrent: () =>
-					generation === workflowGeneration &&
-					controller === workflowController &&
-					!controller.signal.aborted,
+			const ownership = captureWorkflowOwnership(ctx);
+			if (!ownership.isCurrent()) return;
+			let menuModule: WorkflowMenuModule;
+			try {
+				menuModule = await loadWorkflowMenu();
+			} catch (error) {
+				if (!ownership.isCurrent()) return;
+				throw error;
+			}
+			if (!ownership.isCurrent()) return;
+			await menuModule.showWorkflowMenu(ctx, menuController, {
+				signal: ownership.signal,
+				isCurrent: ownership.isCurrent,
 			});
 		},
 	});
+
+	function captureWorkflowOwnership(
+		ctx: { sessionManager: unknown },
+		additionalCheck: () => boolean = () => true,
+	) {
+		const generation = workflowGeneration;
+		const controller = workflowController;
+		const sessionManager = ctx.sessionManager;
+		return {
+			signal: controller.signal,
+			isCurrent: () =>
+				generation === workflowGeneration &&
+				controller === workflowController &&
+				!controller.signal.aborted &&
+				currentSessionManager === sessionManager &&
+				additionalCheck(),
+		};
+	}
 }
 
 function latestCustomEntryIndex(entries: unknown[], customType: string) {
@@ -232,4 +284,19 @@ function latestCustomEntryIndex(entries: unknown[], customType: string) {
 function reportWorkflowError(message: string, ctx: ExtensionCommandContext) {
 	if (ctx.mode === "print" || ctx.mode === "json") throw new Error(message);
 	ctx.ui.notify(message, "warning");
+}
+
+function cachedModuleLoader<Module>(load: () => Promise<Module>): () => Promise<Module> {
+	let pending: Promise<Module> | undefined;
+	return () => {
+		if (!pending) {
+			pending = Promise.resolve()
+				.then(load)
+				.catch((error) => {
+					pending = undefined;
+					throw error;
+				});
+		}
+		return pending;
+	};
 }

--- a/packages/pi-workflow/test/lazy-loading.test.ts
+++ b/packages/pi-workflow/test/lazy-loading.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { builtinTool, createMockContext, createMockPi } from "../../../test/support.js";
+import workflow from "../src/workflow.js";
+
+const BASE_TOOLS = ["read", "bash", "edit", "write"];
+const GOAL_TOOLS = ["goal_complete", "goal_blocked", "goal_wait"];
+
+async function emitAll(
+	mock: ReturnType<typeof createMockPi>,
+	name: string,
+	event: unknown,
+	ctx: unknown,
+) {
+	for (const handler of mock.events.get(name) ?? []) await handler(event, ctx);
+}
+
+function createWorkflow() {
+	return createMockPi({
+		activeTools: [...BASE_TOOLS, ...GOAL_TOOLS],
+		allTools: [...BASE_TOOLS, ...GOAL_TOOLS].map(builtinTool),
+	});
+}
+
+test("idle startup keeps Workflow manager and fresh handoff modules unloaded", async () => {
+	const mock = createWorkflow();
+	let menuLoads = 0;
+	let handoffLoads = 0;
+	workflow(mock.pi, {
+		readSettings: () => ({ kind: "missing" }),
+		loadWorkflowMenu: async () => {
+			menuLoads += 1;
+			return { showWorkflowMenu: async () => undefined as never };
+		},
+		loadFreshHandoff: async () => {
+			handoffLoads += 1;
+			return { startFreshWorkflowImplementation: async () => ({ kind: "started" }) };
+		},
+	});
+
+	assert.deepEqual([...mock.commands.keys()], ["goal", "plan", "workflow"]);
+	assert.deepEqual(
+		mock.tools.map((tool) => tool.name),
+		["goal_complete", "goal_blocked", "goal_wait", "plan_mode_question", "plan_mode_complete"],
+	);
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	await emitAll(mock, "session_start", { reason: "startup" }, context.ctx);
+
+	assert.equal(menuLoads, 0);
+	assert.equal(handoffLoads, 0);
+});
+
+test("Workflow manager caches a successful load and retries a rejected load", async () => {
+	const mock = createWorkflow();
+	let loads = 0;
+	let shows = 0;
+	workflow(mock.pi, {
+		readSettings: () => ({ kind: "missing" }),
+		loadWorkflowMenu: async () => {
+			loads += 1;
+			if (loads === 1) throw new Error("temporary Workflow UI load failure");
+			return {
+				showWorkflowMenu: async () => {
+					shows += 1;
+					return undefined as never;
+				},
+			};
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	await emitAll(mock, "session_start", { reason: "startup" }, context.ctx);
+	const command = mock.commands.get("workflow");
+	assert.ok(command);
+
+	await assert.rejects(async () => command.handler("", context.ctx), /temporary Workflow UI/u);
+	await command.handler("", context.ctx);
+	await command.handler("", context.ctx);
+
+	assert.equal(loads, 2);
+	assert.equal(shows, 2);
+});
+
+test("session replacement while the Workflow manager loads prevents stale UI", async () => {
+	const mock = createWorkflow();
+	let releaseLoad!: () => void;
+	let loadingStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		loadingStarted = resolve;
+	});
+	const loadGate = new Promise<void>((resolve) => {
+		releaseLoad = resolve;
+	});
+	let shows = 0;
+	workflow(mock.pi, {
+		readSettings: () => ({ kind: "missing" }),
+		loadWorkflowMenu: async () => {
+			loadingStarted();
+			await loadGate;
+			return {
+				showWorkflowMenu: async () => {
+					shows += 1;
+					return undefined as never;
+				},
+			};
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	await emitAll(mock, "session_start", { reason: "startup" }, context.ctx);
+
+	const pending = mock.commands.get("workflow")?.handler("", context.ctx);
+	await started;
+	await emitAll(mock, "session_shutdown", { reason: "new" }, context.ctx);
+	releaseLoad();
+	await pending;
+
+	assert.equal(shows, 0);
+});
+
+test("session replacement while the fresh handoff loads prevents session replacement", async () => {
+	const mock = createWorkflow();
+	let releaseLoad!: () => void;
+	let loadingStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		loadingStarted = resolve;
+	});
+	const loadGate = new Promise<void>((resolve) => {
+		releaseLoad = resolve;
+	});
+	let handoffs = 0;
+	workflow(mock.pi, {
+		readSettings: () => ({ kind: "missing" }),
+		loadFreshHandoff: async () => {
+			loadingStarted();
+			await loadGate;
+			return {
+				startFreshWorkflowImplementation: async () => {
+					handoffs += 1;
+					return { kind: "started" };
+				},
+			};
+		},
+	});
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (_title: string, options: string[]) =>
+			options.includes("Start fresh with Goal") ? "Start fresh with Goal" : undefined,
+		newSession: async () => ({ cancelled: false }),
+	});
+	await emitAll(mock, "session_start", { reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete");
+	assert.ok(complete);
+	await (complete.execute as (...args: unknown[]) => Promise<unknown>)(
+		"plan-call",
+		{ plan: "# Approved lazy handoff" },
+		undefined,
+		undefined,
+		context.ctx,
+	);
+
+	const pending = mock.commands.get("plan")?.handler("", context.ctx);
+	await started;
+	await emitAll(mock, "session_shutdown", { reason: "new" }, context.ctx);
+	releaseLoad();
+	await pending;
+
+	assert.equal(handoffs, 0);
+});


### PR DESCRIPTION
## Summary

- Defer heavy `pi-subagents` execution, UI, inspection, and selected transport modules until their registered routes first need them.
- Defer the `pi-workflow` manager UI and fresh-session handoff while keeping Plan and Goal registration eager.
- Add retryable module loaders, stale-session and shutdown guards, focused regression tests, documentation, and patch Changesets.

## Performance

A five-run source benchmark reduced the combined import median from 1,932 ms to 1,064 ms, a 44.9% improvement.

The first-response median improved from 3,056.21 ms to 2,081.75 ms, a 31.9% improvement.

Jiti tracing confirmed that the deferred implementations are absent from idle startup.

## Verification

- `fnm exec --using=26.5.0 -- npm run check` — 3,720 tests passed.
- Focused `pi-subagents` and `pi-workflow` package checks passed.
- `just pack subagents` passed and produced a complete source package.
- `npm pack --workspace @narumitw/pi-workflow --dry-run --json` passed.
- Combined offline Pi RPC command discovery passed.
- Loader cancellation, session replacement, shutdown, transport disposal, retry, and cache behavior were audited and covered by focused tests.
- No settings protocol or public tool and command schema changed.
