### PR TITLE
feat(usage): add Codex Fast mode

### DIFF
--- a/.changeset/fast-crabs-respond.md
+++ b/.changeset/fast-crabs-respond.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add persistent OpenAI Codex Fast routing with a `/fast` shortcut, a contextual `/usage` toggle, explicit usage guidance, and effective statusline labeling.

--- a/docs/plans/2026-08-13_pi-usage-codex-fast-mode-plan.md
+++ b/docs/plans/2026-08-13_pi-usage-codex-fast-mode-plan.md
@@ -1,0 +1,107 @@
+# pi-usage Codex Fast mode plan
+
+## Goal
+
+Add one persistent Codex Fast preference to `@narumitw/pi-usage` that users can toggle with `/fast` or from `/usage`, and apply the same effective state to official OpenAI Codex requests without changing other providers.
+
+## Context
+
+- `packages/pi-usage/src/usage.ts` currently owns `/usage`, provider usage state, status publication, and session lifecycle, and it is already 979 lines.
+- Pi 0.84.1 exposes `before_provider_request`, but the hook receives only the serialized payload and not the provider's `serviceTier` option.
+- Codex represents Fast with request value `service_tier: "priority"` and explicit standard routing with `service_tier: "default"`.
+- The inspected Codex catalog currently exposes Fast for `gpt-5.4`, `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, but not `gpt-5.4-mini` or older catalog entries.
+- Codex describes Fast as approximately 1.5× faster with increased plan usage, so every enabling surface must make the usage consequence visible.
+- This change touches command, menu, settings, provider-request, lifecycle, status, documentation, and release conventions.
+- Execution started on `feat/pi-usage-codex-fast` from `main` at `a18694ee`, with the pre-existing untracked plan preserved.
+
+### Touched-area MUST map
+
+- Command changes must document and test every accepted route and mode, reject arguments and unsupported modes observably, and preserve `/usage` compatibility through tests and README review.
+- Settings changes must use `getAgentDir()`, keep missing reads side-effect free, validate runtime values, preserve unknown fields, block invalid-file overwrite, serialize dependent reads and writes, publish atomically, and prove failure recovery through tests and review.
+- Lifecycle changes must start session work at `session_start`, abort or release owned work, await settings durability at `session_shutdown`, and revalidate generations and contexts after asynchronous boundaries through tests and review.
+- Menu changes must continue using `@narumitw/pi-tui-kit`, keep cancellation side-effect free, avoid TUI-only calls outside TUI, and prove RPC plus TUI behavior through tests.
+- Status changes must reuse and clear the exact `usage` key on model changes, replacement, failure, and shutdown through lifecycle tests and review.
+- Published-behavior changes must add a package Changeset, retain the canonical entrypoint and package boundaries, pass `npm run check`, and receive package and local-load smoke evidence.
+
+## Architecture
+
+- Add `packages/pi-usage/src/settings.ts` as the sole owner of the user-level `pi-usage.json` document and a `codexFastMode` boolean whose code default is `false`.
+- Store settings only at `<getAgentDir()>/pi-usage.json` because Fast is an account-wide consumption preference, not a project-owned policy.
+- Keep missing-file reads side-effect free, validate the whole JSON object, preserve unknown fields, reject malformed files, serialize in-process reads and writes, publish with temporary-file-plus-rename, retain the previous effective state on failure, and expose a shutdown durability boundary.
+- Add `packages/pi-usage/src/codex-fast.ts` as the single owner of Fast-capable model IDs, official-Codex eligibility, `priority` versus `default` payload rewriting, labels, and toggle behavior.
+- Treat Fast as effective only for an `openai-codex` model using `openai-codex-responses` at the official `https://chatgpt.com` origin and present in the explicit supported-model set.
+- Rewrite only object payloads, preserve every unrelated payload field, send `priority` when Fast is effective, and send `default` for an eligible official Codex request when Fast is off or the selected Codex model does not support Fast.
+- Leave non-Codex providers, custom Codex origins, incompatible APIs, and malformed payloads unchanged.
+- Register bare `/fast` as the frequent direct action, reject arguments, support observable TUI and RPC notifications, and reject print and JSON modes before mutation.
+- Show current Fast state and one dynamic `Turn Fast mode on/off` action in the existing `/usage` root menu when Codex is current, with an unavailable or read-only explanation for unsupported models or invalid settings.
+- Keep `/usage` as one shallow menu because the new contextual toggle keeps the action count at seven or fewer and does not justify a separate settings screen.
+- Reuse the existing `usage` status key and add a `fast` marker only while Fast is effective instead of creating another permanent status channel.
+- Apply a successful toggle to the next provider request that has not already been sent, while an in-flight HTTP request remains unchanged.
+- Keep `usage.ts` below 1,000 lines by exposing narrow Fast helpers from the new module, or extract a coherent existing responsibility if integration would cross the limit.
+
+## Non-Goals
+
+- Do not add Fast support to direct OpenAI API, GitHub Copilot, OpenRouter, custom Codex proxies, or unsupported Codex models.
+- Do not read or modify Codex CLI `config.toml` or depend on the local Codex checkout at runtime.
+- Do not add project settings, environment-variable overrides, keyboard shortcuts, `/usage` arguments, or `/fast on|off|status` subcommands.
+- Do not replace or wrap the complete built-in `openai-codex` provider solely to bypass a missing Pi request-option API.
+- Do not promise an exact quota multiplier because provider plan accounting can change independently of the extension.
+
+## Assumptions
+
+- Fast defaults to Off for backward compatibility and persists across Pi sessions after the first explicit toggle.
+- The explicit supported-model set is intentionally conservative and will require maintenance when Codex adds another Fast-capable model.
+- A global toggle remains stored while another provider or unsupported Codex model is selected and becomes effective again after returning to a supported official Codex model.
+- In-process settings operations are ordered, but separate Pi processes are not claimed to be mutually serialized.
+- `/usage` continues to require TUI or RPC mode, while `/fast` follows the same supported-mode boundary.
+
+## Unknowns
+
+- Pi's post-serialization payload hook may not preserve correct session cost accounting when Codex echoes `service_tier: "default"`, because Pi's priority-tier fallback currently reads the provider option rather than the rewritten payload.
+- A deterministic source probe and, when credentials permit, one live Codex smoke must resolve that accounting question before the user-facing command is shipped.
+- If the installed Pi extension API cannot express Fast without inaccurate accounting, implementation must stop and record the required upstream Pi request-option capability instead of shipping a partial provider override.
+
+## Risks
+
+- Another extension can rewrite `service_tier` later in load order, so tests can prove this extension's output but cannot guarantee final ownership across arbitrary third-party extensions.
+- A stale supported-model set can hide Fast for a new model or incorrectly offer it after Codex removes support.
+- A failed or concurrent settings write can otherwise leave the menu, statusline, and request hook disagreeing unless all three read one committed runtime state.
+- Session replacement or shutdown during a toggle can otherwise publish stale UI or lose an accepted write unless cancellation, generation checks, and the settings flush boundary are coordinated.
+- Adding Fast behavior directly to `usage.ts` can cross the repository's 1,000-line source limit and further mix provider mutation with usage orchestration.
+
+## Rollback / Recovery
+
+- Turning Fast off writes `codexFastMode: false` and sends explicit `service_tier: "default"` for eligible official Codex requests.
+- Uninstalling or disabling `pi-usage` removes the request hook, and the unused `pi-usage.json` field remains harmless.
+- A patch rollback may remove `/fast`, the `/usage` action, and the request hook while retaining settings parsing so an existing forward-compatible file is not corrupted.
+- Invalid settings remain untouched and read-only until the user repairs or removes `pi-usage.json`.
+
+## Plan
+
+- [x] Trace a Fast request through installed Pi 0.84.1 and Codex response accounting before adding product surfaces; deterministic source and provider regressions prove the payload hook emits `priority`, Pi can echo `default`, and `message_end` corrects the same 2× or GPT-5.5 2.5× accounting without double charging.
+- [x] Record the supported Fast model IDs from `/Users/narumi.chen/personal/codex/codex-rs/models-manager/models.json` in one tested `packages/pi-usage/src/codex-fast.ts` constant; `codex-fast.test.ts` accepts exactly the five advertised Fast models and rejects `gpt-5.4-mini`, Codex Spark, incompatible APIs, and custom origins.
+- [x] Implement `packages/pi-usage/src/settings.ts` with default-Off normalization, side-effect-free load, unknown-field preservation, invalid-file protection, private atomic writes, an unpoisoned in-process queue, and `flush()`; `settings.test.ts` covers missing, valid, malformed, invalid, oversized, symlink, first-save, permission repair, unknown-field, aborted-save, failed-save, and serialized-update cases.
+- [x] Implement pure Fast eligibility and payload rewriting in `packages/pi-usage/src/codex-fast.ts`; `codex-fast.test.ts` proves `priority`, `default`, field preservation, original-payload immutability, unsupported-model fallback, unchanged non-Codex or malformed payloads, scoped status labeling, and cost correction.
+- [x] Integrate settings reload, invalid-file warnings, request-hook registration, cancellation, and settings flush through `packages/pi-usage/src/codex-fast-runtime.ts` without factory-time session work; runtime tests cover startup, replacement, shutdown, stale loads, invalid files, failed write recovery, and the shutdown durability boundary.
+- [x] Register `/fast` through the shared Fast state and persistence path; runtime tests cover bare toggle on and off, exact argument rejection, supported and unsupported models, custom origin, invalid settings, save rollback, TUI/RPC notifications, print/JSON rejection before mutation, and before-versus-after request capture.
+- [x] Add the shared Fast state and one dynamic action to the `/usage` root menu; menu tests cover Off, unavailable, invalid-file, successful save, and cancellation, while the existing Kit menu retains action ownership and session-generation guards after awaits.
+- [x] Extend status publication to render `codex fast …` only when Fast is effective; focused unit and lifecycle tests cover immediate refresh, model eligibility, failed-save rollback, replacement, and existing exact-key shutdown cleanup.
+- [x] Extract small orchestration helpers and the Fast runtime so `packages/pi-usage/src/usage.ts` remains 990 lines; all 77 focused package tests pass, including usage queries, reset redemption, cache isolation, provider selection, cancellation, and status refresh.
+- [x] Update `packages/pi-usage/README.md` with `/fast`, the `/usage` toggle, supported modes and models, the increased-usage warning, default and persistence path, user-only scope, reload behavior, official-origin boundary, concurrency scope, invalid-file recovery, limitations, and package layout while retaining existing badges and standard sections.
+- [x] Add `.changeset/fast-crabs-respond.md` as a minor Changeset for `@narumitw/pi-usage`; `npm run changeset:status -- --verbose` reports the intended package and also names the two unrelated pre-existing Changesets separately.
+- [x] Audit the final diff against `docs/extension-conventions.md`, `docs/extension-settings.md`, the review skill, and the hardening edge-case checklist; command modes, settings ordering/recovery, menu cancellation/disposal, session replacement/shutdown, post-await ownership, provider origin/model boundaries, sanitized model display, request-tier capture, cost accounting, and the 990-line `usage.ts` disposition are covered by code, tests, or documented residual risks.
+- [ ] Run `npm exec vitest -- run packages/pi-usage/test`, `npm run typecheck --workspace @narumitw/pi-usage`, `npm run check:boundaries`, `npm run check`, and `git diff --check`; focused tests pass 77/77, workspace typecheck, boundaries, Biome, and diff checks pass, but two full `npm run check` attempts remain red because unrelated `pi-subagents`, `pi-sync`, and `pi-worktree` timing/path tests fail under repository-wide parallel load even though a representative 20-test rerun passed in isolation.
+- [x] Run `just pack usage` and inspect the tarball for the new source, README, license, and canonical entrypoint, then run a non-interactive local Pi entrypoint load; the dry-run contains 17 intended files, `pi --list-models -e ./packages/pi-usage` exits 0, print-mode `/fast` rejects without creating settings, and real OAuth-backed GPT-5.4 smokes capture `priority` with Fast On and `default` with Fast Off.
+
+## Completion Checklist
+
+- [ ] `/fast` and `/usage` read and update one committed persistent Fast preference.
+- [ ] Supported official Codex requests send `priority` when effective and `default` otherwise without mutating unrelated payload data.
+- [ ] Unsupported providers, APIs, models, origins, and non-interactive command modes fail safely without changing settings.
+- [ ] Fast state and increased-usage consequences are visible in the command notification, `/usage`, README, and effective Codex statusline.
+- [ ] Settings loading, validation, ordering, atomic publication, rollback, unknown-field preservation, shutdown durability, and concurrency scope have deterministic evidence.
+- [ ] Cancellation, disposal, in-flight toggles, model changes, stale sessions, replacement, and shutdown have deterministic lifecycle evidence.
+- [ ] Existing provider usage, reset redemption, caching, selection, and status behavior remain covered and passing.
+- [ ] The provider accounting unknown is resolved or explicitly accepted as an upstream blocker before release.
+- [ ] The minor Changeset, package tarball inspection, focused tests, root CI-equivalent gate, diff check, and applicable runtime smoke are complete.
+- [ ] The fully executed plan is moved to `docs/plans/archived/2026-08-13_pi-usage-codex-fast-mode-plan.md` only after every item above has evidence.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10132,11 +10132,13 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",
+				"@earendil-works/pi-ai": "0.84.1",
 				"@earendil-works/pi-coding-agent": "0.84.1",
 				"@types/node": "26.1.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
+				"@earendil-works/pi-ai": "*",
 				"@earendil-works/pi-coding-agent": "*"
 			}
 		},

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -2,13 +2,14 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-usage)](https://www.npmjs.com/package/@narumitw/pi-usage) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-usage` is a native [Pi coding agent](https://pi.dev) extension that adds one interactive `/usage` command for reading usage from the account Pi is actually using. It supports OpenAI Codex ChatGPT subscription windows, GitHub Copilot allowances, and OpenRouter API-key spend limits without pretending those limits have the same semantics.
+`@narumitw/pi-usage` is a native [Pi coding agent](https://pi.dev) extension that adds an interactive `/usage` command for reading usage from the account Pi is actually using and a `/fast` shortcut for supported OpenAI Codex models. It supports Codex ChatGPT subscription windows, GitHub Copilot allowances, and OpenRouter API-key spend limits without pretending those limits have the same semantics.
 
 ## ✨ Features
 
 - Opens one interactive `/usage` menu with current state and next actions.
 - Automatically queries the selected model provider and active runtime account.
 - Supports OpenAI Codex subscription windows, resets, credits, and model-specific buckets.
+- Toggles persistent Codex Fast routing through `/fast` or the contextual `/usage` action.
 - Redeems earned Codex usage-limit resets for the active, matching Pi OAuth account with fresh availability, explicit confirmation, and idempotent retry.
 - Supports GitHub Copilot AI Credits, legacy premium requests, Free chat quota, additional usage, percentage, and reset time.
 - Supports OpenRouter per-key credit limits plus daily, weekly, monthly, and all-time spend.
@@ -52,6 +53,7 @@ with these actions:
 
 ```text
 Refresh current usage
+Turn Fast mode on/off       # Supported current Codex models only
 Redeem usage limit reset…   # Current Codex OAuth accounts only
 View another configured provider…
 View all configured providers…
@@ -73,6 +75,25 @@ same redemption request ID so the backend can treat an uncertain retry idempoten
 already-completed, not-needed, and no-credit outcomes are reported separately, then usage and the
 statusline are refreshed for the still-current account.
 
+### Codex Fast mode
+
+Run bare `/fast` to toggle Fast for the active supported Codex model, or use **Turn Fast mode on/off** in `/usage`.
+
+Fast is about 1.5× faster and uses more of your plan allowance.
+The preference defaults to Off and is saved as `codexFastMode` in Pi's user agent directory as `pi-usage.json`, normally `~/.pi/agent/pi-usage.json`.
+The extension reloads this file at every session start and does not create it until the first successful toggle.
+
+Fast currently applies only to official `openai-codex-responses` requests for `gpt-5.4`, `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` at `https://chatgpt.com`.
+It sends `service_tier: "priority"` while enabled and explicit `service_tier: "default"` otherwise.
+The statusline adds `fast` only while the preference is effective, for example `codex fast 59% 5h`.
+Unsupported models and custom or proxy origins are left unchanged.
+
+`/fast` supports TUI and RPC mode, accepts no arguments, and rejects print or JSON mode before mutation.
+A toggle affects provider requests whose payload hook starts after the save; a request already sent is unchanged.
+Settings operations are serialized inside one Pi process, but separate Pi processes are not mutually locked.
+Unknown JSON fields are preserved, writes use a private temporary file plus rename, and a malformed or invalid file is never overwritten.
+Repair or remove an invalid file, then run `/reload` before trying the toggle again.
+
 ## 📋 Provider semantics
 
 ### OpenAI Codex
@@ -82,7 +103,7 @@ statusline are refreshed for the still-current account.
 - Source: the Codex usage and earned-reset endpoints using Pi's resolved runtime authorization
 - Displayed data: returned duration-based windows, resets, credits, earned usage-limit resets, and additional model buckets
 - Reset mutation: `POST /wham/rate-limit-reset-credits/consume` with a unique redemption request ID and, when available, the selected opaque credit ID
-- Statusline examples: `codex 59% 5h 61% wk` or `codex spark 100% 5h`
+- Statusline examples: `codex 59% 5h 61% wk`, `codex fast 59% 5h`, or `codex spark 100% 5h`
 
 The statusline selects a returned bucket that matches the current Codex model when one is available. Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.
 
@@ -138,7 +159,7 @@ Remove the deprecated package rather than loading both usage extensions together
 
 Behavior changes:
 
-- Use `/usage` as the only entry point; `/codex-status` is no longer registered.
+- Use `/usage` for usage management; `/codex-status` is no longer registered.
 - Refresh and cross-provider operations are menu actions rather than flags.
 - Codex CLI fallback is removed to preserve active-runtime-account correctness.
 - The status key changes from `codex-usage` to `usage`.
@@ -153,6 +174,8 @@ Behavior changes:
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
 - A provider may not return a safe human-readable account identity. In that case the provider and runtime credential state remain visible without exposing secrets.
 - Immediate account-change events are not available from Pi; auth is re-resolved before commands, turns, and scheduled refreshes.
+- Fast model support is intentionally conservative and may require an extension update when Codex adds or removes service tiers.
+- Another later-loaded extension can replace the final provider payload, so arbitrary third-party payload-rewrite conflicts cannot be prevented.
 
 ## 🗂️ Package layout
 
@@ -160,7 +183,11 @@ Behavior changes:
 packages/pi-usage/
 ├── src/
 │   ├── index.ts       # Pi package entrypoint and helper export barrel
-│   ├── usage.ts       # Menu, cache, and lifecycle orchestration
+│   ├── usage.ts       # Menu, cache, and usage lifecycle orchestration
+│   ├── codex-fast.ts  # Fast eligibility, request tier, and cost correction
+│   ├── codex-fast-runtime.ts # Fast command, persistence lifecycle, and request hooks
+│   ├── settings.ts    # Validated user settings and atomic persistence
+│   ├── usage-helpers.ts # Small orchestration helpers
 │   ├── query.ts       # Runtime auth resolution and bounded provider queries
 │   ├── codex-resets.ts # Codex reset auth, API contracts, and normalization
 │   ├── format.ts      # Provider-aware notifications and statusline text

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -34,10 +34,12 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"peerDependencies": {
+		"@earendil-works/pi-ai": "*",
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.7",
+		"@earendil-works/pi-ai": "0.84.1",
 		"@earendil-works/pi-coding-agent": "0.84.1",
 		"@types/node": "26.1.2",
 		"typescript": "7.0.2"

--- a/packages/pi-usage/src/codex-fast-runtime.ts
+++ b/packages/pi-usage/src/codex-fast-runtime.ts
@@ -147,16 +147,14 @@ export function registerCodexFastMode(
 		return rewritten;
 	});
 	pi.on("message_end", (event, ctx) => {
-		const request = peekFastRequest(ctx, event.message, pendingFastRequests);
+		const request = consumeFastRequest(ctx, event.message, pendingFastRequests);
 		if (request === NO_FAST_REQUEST) return undefined;
 		const message = correctCodexFastMessageCost(
 			event.message,
 			request.model,
 			request.fastRequested,
 		);
-		if (!message) return undefined;
-		pendingFastRequests.delete(request.key);
-		return { message: message as never };
+		return message ? { message: message as never } : undefined;
 	});
 	pi.on("session_shutdown", async () => {
 		generation += 1;
@@ -184,16 +182,17 @@ function activeRequestKey(ctx: ExtensionContext): string | undefined {
 	return model ? `${ctx.sessionManager.getSessionId()}:${model.provider}/${model.id}` : undefined;
 }
 
-function peekFastRequest(
+function consumeFastRequest(
 	ctx: ExtensionContext,
 	message: unknown,
 	pending: Map<string, PendingFastRequest>,
-): (PendingFastRequest & { key: string }) | typeof NO_FAST_REQUEST {
+): PendingFastRequest | typeof NO_FAST_REQUEST {
 	if (!isRecord(message) || message.role !== "assistant") return NO_FAST_REQUEST;
 	const key = messageRequestKey(ctx, message);
-	if (!key || !pending.has(key)) return NO_FAST_REQUEST;
+	if (!key) return NO_FAST_REQUEST;
 	const request = pending.get(key);
-	return request ? { ...request, key } : NO_FAST_REQUEST;
+	pending.delete(key);
+	return request ?? NO_FAST_REQUEST;
 }
 
 function messageRequestKey(

--- a/packages/pi-usage/src/codex-fast-runtime.ts
+++ b/packages/pi-usage/src/codex-fast-runtime.ts
@@ -1,0 +1,213 @@
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+	codexFastAvailability,
+	codexFastIsEffective,
+	codexFastStatusLabel,
+	correctCodexFastMessageCost,
+	rewriteCodexFastPayload,
+} from "./codex-fast.js";
+import { errorMessage } from "./core.js";
+import { isStaleExtensionContextError } from "./query.js";
+import type { UsageSettingsRuntime, UsageSettingsState } from "./settings.js";
+import type { PiModel } from "./types.js";
+
+const NO_FAST_REQUEST = Symbol("no-fast-request");
+type PendingFastRequest = { fastRequested: boolean; model: PiModel };
+
+export const FAST_USAGE_WARNING = "Fast is about 1.5× faster and uses more of your plan allowance.";
+
+export function registerCodexFastMode(
+	pi: ExtensionAPI,
+	settingsRuntime: UsageSettingsRuntime,
+	refreshStatus: (ctx: ExtensionContext) => void,
+) {
+	let sessionController = new AbortController();
+	let generation = 0;
+	const pendingFastRequests = new Map<string, PendingFastRequest>();
+
+	const toggle = async (
+		ctx: ExtensionCommandContext,
+		enabled: boolean,
+		callerSignal?: AbortSignal,
+	): Promise<boolean> => {
+		const ownerGeneration = generation;
+		const sessionId = ctx.sessionManager.getSessionId();
+		const signal = callerSignal
+			? AbortSignal.any([callerSignal, sessionController.signal])
+			: sessionController.signal;
+		try {
+			await settingsRuntime.update({ codexFastMode: enabled }, signal);
+		} catch (error) {
+			if (isAbortError(error) || isStaleExtensionContextError(error)) return false;
+			ctx.ui.notify(`Could not save pi-usage.json: ${errorMessage(error)}`, "error");
+			return false;
+		}
+		if (
+			signal.aborted ||
+			ownerGeneration !== generation ||
+			ctx.sessionManager.getSessionId() !== sessionId
+		) {
+			return false;
+		}
+		refreshStatus(ctx);
+		ctx.ui.notify(
+			enabled
+				? `Codex Fast mode enabled. ${FAST_USAGE_WARNING}`
+				: "Codex Fast mode disabled; standard routing will be used.",
+			"info",
+		);
+		return true;
+	};
+
+	pi.registerCommand("fast", {
+		description: "Toggle Codex Fast mode",
+		handler: async (args, ctx) => {
+			if (args.trim()) {
+				if (!ctx.hasUI) throw new Error("/fast does not accept arguments.");
+				ctx.ui.notify("/fast does not accept arguments.", "warning");
+				return;
+			}
+			if (!ctx.hasUI) throw new Error("/fast requires TUI or RPC mode.");
+			const availability = codexFastAvailability(
+				ctx.model,
+				settingsRuntime.get().settings.codexFastMode,
+			);
+			if (availability.kind === "not-codex") {
+				ctx.ui.notify("/fast is available only for the active OpenAI Codex model.", "warning");
+				return;
+			}
+			if (availability.kind === "unavailable") {
+				ctx.ui.notify(availability.reason, "warning");
+				return;
+			}
+			if (settingsRuntime.get().kind === "invalid") {
+				ctx.ui.notify(
+					"pi-usage.json is invalid; repair it and run /reload before changing Fast mode.",
+					"error",
+				);
+				return;
+			}
+			await toggle(ctx, !availability.enabled);
+		},
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		generation += 1;
+		sessionController.abort();
+		pendingFastRequests.clear();
+		sessionController = new AbortController();
+		const ownerGeneration = generation;
+		const sessionId = ctx.sessionManager.getSessionId();
+		let state: Readonly<UsageSettingsState>;
+		try {
+			state = await settingsRuntime.reload(sessionController.signal);
+		} catch (error) {
+			if (sessionController.signal.aborted || ownerGeneration !== generation) return;
+			if (ctx.hasUI) {
+				ctx.ui.notify(
+					`Could not load pi-usage.json; using defaults. ${errorMessage(error)}`,
+					"warning",
+				);
+			}
+			return;
+		}
+		if (
+			sessionController.signal.aborted ||
+			ownerGeneration !== generation ||
+			ctx.sessionManager.getSessionId() !== sessionId
+		) {
+			return;
+		}
+		if (ctx.hasUI && state.kind === "invalid") {
+			ctx.ui.notify(
+				`Invalid pi-usage.json; using defaults without overwriting it. ${state.issue}`,
+				"warning",
+			);
+		}
+		refreshStatus(ctx);
+	});
+
+	pi.on("before_provider_request", (event, ctx) => {
+		const rewritten = rewriteCodexFastPayload(
+			event.payload,
+			ctx.model,
+			settingsRuntime.get().settings.codexFastMode,
+		);
+		const key = activeRequestKey(ctx);
+		if (key && ctx.model) {
+			pendingFastRequests.set(key, {
+				fastRequested: isRecord(rewritten) && rewritten.service_tier === "priority",
+				model: ctx.model,
+			});
+		}
+		return rewritten;
+	});
+	pi.on("message_end", (event, ctx) => {
+		const request = peekFastRequest(ctx, event.message, pendingFastRequests);
+		if (request === NO_FAST_REQUEST) return undefined;
+		const message = correctCodexFastMessageCost(
+			event.message,
+			request.model,
+			request.fastRequested,
+		);
+		if (!message) return undefined;
+		pendingFastRequests.delete(request.key);
+		return { message: message as never };
+	});
+	pi.on("session_shutdown", async () => {
+		generation += 1;
+		sessionController.abort();
+		pendingFastRequests.clear();
+		await settingsRuntime.flush();
+	});
+
+	return {
+		availability(model: PiModel | undefined) {
+			return codexFastAvailability(model, settingsRuntime.get().settings.codexFastMode);
+		},
+		decorateStatus(model: PiModel | undefined, status: string) {
+			return codexFastStatusLabel(
+				status,
+				codexFastIsEffective(model, settingsRuntime.get().settings.codexFastMode),
+			);
+		},
+		toggle,
+	};
+}
+
+function activeRequestKey(ctx: ExtensionContext): string | undefined {
+	const model = ctx.model;
+	return model ? `${ctx.sessionManager.getSessionId()}:${model.provider}/${model.id}` : undefined;
+}
+
+function peekFastRequest(
+	ctx: ExtensionContext,
+	message: unknown,
+	pending: Map<string, PendingFastRequest>,
+): (PendingFastRequest & { key: string }) | typeof NO_FAST_REQUEST {
+	if (!isRecord(message) || message.role !== "assistant") return NO_FAST_REQUEST;
+	const key = messageRequestKey(ctx, message);
+	if (!key || !pending.has(key)) return NO_FAST_REQUEST;
+	const request = pending.get(key);
+	return request ? { ...request, key } : NO_FAST_REQUEST;
+}
+
+function messageRequestKey(
+	ctx: ExtensionContext,
+	message: Record<string, unknown>,
+): string | undefined {
+	if (typeof message.provider !== "string" || typeof message.model !== "string") return undefined;
+	return `${ctx.sessionManager.getSessionId()}:${message.provider}/${message.model}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
+}

--- a/packages/pi-usage/src/codex-fast.ts
+++ b/packages/pi-usage/src/codex-fast.ts
@@ -1,0 +1,124 @@
+import { calculateCost, hasApi } from "@earendil-works/pi-ai";
+import type { PiModel } from "./types.js";
+
+export const CODEX_FAST_SERVICE_TIER = "priority";
+export const CODEX_STANDARD_SERVICE_TIER = "default";
+
+export const CODEX_FAST_MODEL_IDS: ReadonlySet<string> = new Set([
+	"gpt-5.4",
+	"gpt-5.5",
+	"gpt-5.6-luna",
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+]);
+
+export type CodexFastAvailability =
+	| { kind: "available"; enabled: boolean }
+	| { kind: "not-codex" }
+	| { kind: "unavailable"; reason: string };
+
+export function codexFastAvailability(
+	model: PiModel | undefined,
+	enabled: boolean,
+): CodexFastAvailability {
+	if (model?.provider !== "openai-codex") return { kind: "not-codex" };
+	if (!isOfficialCodexModel(model)) {
+		return {
+			kind: "unavailable",
+			reason: "Fast mode requires the official OpenAI Codex Responses endpoint.",
+		};
+	}
+	if (!CODEX_FAST_MODEL_IDS.has(model.id)) {
+		return {
+			kind: "unavailable",
+			reason: `${model.id} does not advertise Codex Fast support.`,
+		};
+	}
+	return { kind: "available", enabled };
+}
+
+export function codexFastIsEffective(model: PiModel | undefined, enabled: boolean): boolean {
+	return codexFastAvailability(model, enabled).kind === "available" && enabled;
+}
+
+export function codexFastRequestTier(
+	model: PiModel | undefined,
+	enabled: boolean,
+): typeof CODEX_FAST_SERVICE_TIER | typeof CODEX_STANDARD_SERVICE_TIER | undefined {
+	if (!isOfficialCodexModel(model)) return undefined;
+	return enabled && CODEX_FAST_MODEL_IDS.has(model.id)
+		? CODEX_FAST_SERVICE_TIER
+		: CODEX_STANDARD_SERVICE_TIER;
+}
+
+export function rewriteCodexFastPayload(
+	payload: unknown,
+	model: PiModel | undefined,
+	enabled: boolean,
+): unknown | undefined {
+	const serviceTier = codexFastRequestTier(model, enabled);
+	if (!serviceTier || !isRecord(payload)) return undefined;
+	return { ...payload, service_tier: serviceTier };
+}
+
+export function correctCodexFastMessageCost(
+	message: unknown,
+	model: PiModel | undefined,
+	fastRequested: boolean,
+): unknown | undefined {
+	if (
+		!codexFastIsEffective(model, fastRequested) ||
+		!isRecord(message) ||
+		message.role !== "assistant" ||
+		message.provider !== model?.provider ||
+		message.model !== model?.id
+	) {
+		return undefined;
+	}
+	const usage = isRecord(message.usage) ? message.usage : undefined;
+	const cost = usage && isRecord(usage.cost) ? usage.cost : undefined;
+	if (!usage || !cost || !hasCompleteUsage(usage) || !isOfficialCodexModel(model)) return undefined;
+	const correctedUsage = structuredClone(usage) as typeof usage;
+	calculateCost(model, correctedUsage as never);
+	const multiplier = model.id === "gpt-5.5" ? 2.5 : 2;
+	const correctedCost = correctedUsage.cost as Record<string, number>;
+	for (const key of ["input", "output", "cacheRead", "cacheWrite", "total"] as const) {
+		correctedCost[key] *= multiplier;
+	}
+	if (costsEqual(cost, correctedCost)) return undefined;
+	return { ...message, usage: correctedUsage };
+}
+
+export function codexFastStatusLabel(status: string, enabled: boolean): string {
+	if (!enabled || !/^codex(?:\s|$)/u.test(status)) return status;
+	return status === "codex" ? "codex fast" : `codex fast${status.slice("codex".length)}`;
+}
+
+function isOfficialCodexModel(
+	model: PiModel | undefined,
+): model is PiModel & { api: "openai-codex-responses" } {
+	if (model?.provider !== "openai-codex" || !hasApi(model, "openai-codex-responses")) {
+		return false;
+	}
+	try {
+		return new URL(model.baseUrl).origin === "https://chatgpt.com";
+	} catch {
+		return false;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasCompleteUsage(value: Record<string, unknown>): boolean {
+	return ["input", "output", "cacheRead", "cacheWrite"].every(
+		(key) => typeof value[key] === "number" && Number.isFinite(value[key]),
+	);
+}
+
+function costsEqual(left: Record<string, unknown>, right: Record<string, number>): boolean {
+	return ["input", "output", "cacheRead", "cacheWrite", "total"].every(
+		(key) => left[key] === right[key],
+	);
+}

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -1,3 +1,14 @@
+export {
+	CODEX_FAST_MODEL_IDS,
+	CODEX_FAST_SERVICE_TIER,
+	CODEX_STANDARD_SERVICE_TIER,
+	codexFastAvailability,
+	codexFastIsEffective,
+	codexFastRequestTier,
+	codexFastStatusLabel,
+	correctCodexFastMessageCost,
+	rewriteCodexFastPayload,
+} from "./codex-fast.js";
 export type {
 	CodexResetAvailability,
 	CodexResetOption,
@@ -32,6 +43,18 @@ export {
 	resolveUsageAuth,
 	SUPPORTED_ADAPTERS,
 } from "./query.js";
+export type {
+	UsageSettings,
+	UsageSettingsRuntime,
+	UsageSettingsState,
+} from "./settings.js";
+export {
+	createUsageSettingsRuntime,
+	DEFAULT_USAGE_SETTINGS,
+	loadUsageSettings,
+	normalizeUsageSettings,
+	usageSettingsPath,
+} from "./settings.js";
 export type {
 	ProviderUsageState,
 	ResolvedUsageAuth,

--- a/packages/pi-usage/src/settings.ts
+++ b/packages/pi-usage/src/settings.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, mkdir, open, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export const USAGE_SETTINGS_FILE = "pi-usage.json";
+export const MAX_USAGE_SETTINGS_BYTES = 64 * 1024;
+
+export interface UsageSettings {
+	codexFastMode: boolean;
+}
+
+export const DEFAULT_USAGE_SETTINGS: Readonly<UsageSettings> = Object.freeze({
+	codexFastMode: false,
+});
+
+export interface UsageSettingsState {
+	kind: "missing" | "loaded" | "invalid";
+	path: string;
+	settings: UsageSettings;
+	document?: Record<string, unknown>;
+	issue?: string;
+}
+
+export interface UsageSettingsRuntime {
+	get(): Readonly<UsageSettingsState>;
+	reload(signal?: AbortSignal): Promise<Readonly<UsageSettingsState>>;
+	update(
+		patch: Partial<UsageSettings>,
+		signal?: AbortSignal,
+	): Promise<Readonly<UsageSettingsState>>;
+	flush(): Promise<void>;
+}
+
+export function usageSettingsPath(): string {
+	return join(getAgentDir(), USAGE_SETTINGS_FILE);
+}
+
+export function normalizeUsageSettings(value: unknown): UsageSettings | undefined {
+	if (!isRecord(value)) return undefined;
+	if (Object.hasOwn(value, "codexFastMode") && typeof value.codexFastMode !== "boolean") {
+		return undefined;
+	}
+	return {
+		codexFastMode:
+			typeof value.codexFastMode === "boolean"
+				? value.codexFastMode
+				: DEFAULT_USAGE_SETTINGS.codexFastMode,
+	};
+}
+
+export async function loadUsageSettings(
+	path = usageSettingsPath(),
+	signal?: AbortSignal,
+): Promise<UsageSettingsState> {
+	throwIfAborted(signal);
+	try {
+		const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+		let text: string;
+		try {
+			const stats = await handle.stat();
+			throwIfAborted(signal);
+			if (!stats.isFile()) throw new Error("settings path is not a regular file");
+			if (stats.size > MAX_USAGE_SETTINGS_BYTES) {
+				throw new Error("settings file exceeds 64 KiB");
+			}
+			text = await handle.readFile("utf8");
+		} finally {
+			await handle.close();
+		}
+		throwIfAborted(signal);
+		const document = JSON.parse(text) as unknown;
+		const settings = normalizeUsageSettings(document);
+		if (!settings || !isRecord(document)) throw new Error("invalid settings shape");
+		return { kind: "loaded", path, settings, document };
+	} catch (error) {
+		if (signal?.aborted) throw error;
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return {
+				kind: "missing",
+				path,
+				settings: { ...DEFAULT_USAGE_SETTINGS },
+				document: {},
+			};
+		}
+		return {
+			kind: "invalid",
+			path,
+			settings: { ...DEFAULT_USAGE_SETTINGS },
+			issue:
+				isNodeError(error) && error.code === "ELOOP"
+					? "symbolic links are not accepted"
+					: error instanceof Error
+						? error.message
+						: String(error),
+		};
+	}
+}
+
+export function createUsageSettingsRuntime(path = usageSettingsPath()): UsageSettingsRuntime {
+	let state: UsageSettingsState = {
+		kind: "missing",
+		path,
+		settings: { ...DEFAULT_USAGE_SETTINGS },
+		document: {},
+	};
+	let queue = Promise.resolve();
+	const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+		const result = queue.then(operation, operation);
+		queue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	};
+	return {
+		get: () => structuredClone(state),
+		reload: (signal) =>
+			enqueue(async () => {
+				const loaded = await loadUsageSettings(path, signal);
+				state = loaded;
+				return structuredClone(state);
+			}),
+		update: (patch, signal) =>
+			enqueue(async () => {
+				const saved = await saveUsageSettingsPatch(path, patch, signal);
+				state = saved;
+				return structuredClone(state);
+			}),
+		flush: () => queue,
+	};
+}
+
+async function saveUsageSettingsPatch(
+	path: string,
+	patch: Partial<UsageSettings>,
+	signal?: AbortSignal,
+): Promise<UsageSettingsState> {
+	const latest = await loadUsageSettings(path, signal);
+	if (latest.kind === "invalid") {
+		throw new Error("Cannot overwrite an invalid pi-usage.json; repair it and reload first");
+	}
+	const document = { ...latest.document, ...patch };
+	const settings = normalizeUsageSettings(document);
+	if (!settings) throw new Error("Refusing to save invalid pi-usage settings");
+	const directory = dirname(path);
+	const temporaryPath = join(directory, `.${basename(path)}.${randomUUID()}.tmp`);
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	throwIfAborted(signal);
+	try {
+		await writeFile(temporaryPath, `${JSON.stringify(document, null, 2)}\n`, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: 0o600,
+		});
+		if (process.platform !== "win32") await chmodPrivate(temporaryPath);
+		throwIfAborted(signal);
+		const current = await loadUsageSettings(path, signal);
+		if (
+			current.kind === "invalid" ||
+			current.kind !== latest.kind ||
+			JSON.stringify(current.document) !== JSON.stringify(latest.document)
+		) {
+			throw new Error("pi-usage.json changed while saving; retry the action");
+		}
+		throwIfAborted(signal);
+		await rename(temporaryPath, path);
+	} finally {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+	}
+	return { kind: "loaded", path, settings, document };
+}
+
+async function chmodPrivate(path: string): Promise<void> {
+	await chmod(path, 0o600);
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+	if (signal?.aborted) throw new DOMException("Settings operation aborted", "AbortError");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}

--- a/packages/pi-usage/src/settings.ts
+++ b/packages/pi-usage/src/settings.ts
@@ -33,6 +33,16 @@ export interface UsageSettingsRuntime {
 	flush(): Promise<void>;
 }
 
+interface UsageSettingsFileOperations {
+	rename: typeof rename;
+	writeFile: typeof writeFile;
+}
+
+interface UsageSettingsRuntimeOptions {
+	operations?: Partial<UsageSettingsFileOperations>;
+	path?: string;
+}
+
 export function usageSettingsPath(): string {
 	return join(getAgentDir(), USAGE_SETTINGS_FILE);
 }
@@ -98,7 +108,15 @@ export async function loadUsageSettings(
 	}
 }
 
-export function createUsageSettingsRuntime(path = usageSettingsPath()): UsageSettingsRuntime {
+export function createUsageSettingsRuntime(
+	options: UsageSettingsRuntimeOptions | string = {},
+): UsageSettingsRuntime {
+	const path = typeof options === "string" ? options : (options.path ?? usageSettingsPath());
+	const operations: UsageSettingsFileOperations = {
+		rename,
+		writeFile,
+		...(typeof options === "string" ? undefined : options.operations),
+	};
 	let state: UsageSettingsState = {
 		kind: "missing",
 		path,
@@ -124,7 +142,7 @@ export function createUsageSettingsRuntime(path = usageSettingsPath()): UsageSet
 			}),
 		update: (patch, signal) =>
 			enqueue(async () => {
-				const saved = await saveUsageSettingsPatch(path, patch, signal);
+				const saved = await saveUsageSettingsPatch(path, patch, operations, signal);
 				state = saved;
 				return structuredClone(state);
 			}),
@@ -135,6 +153,7 @@ export function createUsageSettingsRuntime(path = usageSettingsPath()): UsageSet
 async function saveUsageSettingsPatch(
 	path: string,
 	patch: Partial<UsageSettings>,
+	operations: UsageSettingsFileOperations,
 	signal?: AbortSignal,
 ): Promise<UsageSettingsState> {
 	const latest = await loadUsageSettings(path, signal);
@@ -149,7 +168,7 @@ async function saveUsageSettingsPatch(
 	await mkdir(directory, { recursive: true, mode: 0o700 });
 	throwIfAborted(signal);
 	try {
-		await writeFile(temporaryPath, `${JSON.stringify(document, null, 2)}\n`, {
+		await operations.writeFile(temporaryPath, `${JSON.stringify(document, null, 2)}\n`, {
 			encoding: "utf8",
 			flag: "wx",
 			mode: 0o600,
@@ -165,7 +184,7 @@ async function saveUsageSettingsPatch(
 			throw new Error("pi-usage.json changed while saving; retry the action");
 		}
 		throwIfAborted(signal);
-		await rename(temporaryPath, path);
+		await operations.rename(temporaryPath, path);
 	} finally {
 		await rm(temporaryPath, { force: true }).catch(() => undefined);
 	}

--- a/packages/pi-usage/src/usage-helpers.ts
+++ b/packages/pi-usage/src/usage-helpers.ts
@@ -1,0 +1,40 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { sanitizeDisplayText } from "./core.js";
+import { providerIsConfigured, SUPPORTED_ADAPTERS } from "./query.js";
+import type { PiModel, UsageProviderAdapter } from "./types.js";
+
+export function configuredAdapters(ctx: ExtensionContext): UsageProviderAdapter[] {
+	return SUPPORTED_ADAPTERS.filter(
+		(adapter) => adapter.id === ctx.model?.provider || providerIsConfigured(ctx, adapter.id),
+	);
+}
+
+export function providerDisplayName(ctx: ExtensionContext, providerId: string): string {
+	try {
+		return sanitizeDisplayText(ctx.modelRegistry.getProviderDisplayName(providerId), 80);
+	} catch {
+		return sanitizeDisplayText(providerId, 80);
+	}
+}
+
+export function setBoundedMap<T>(map: Map<string, T>, key: string, value: T, limit: number): void {
+	map.delete(key);
+	while (map.size >= limit) {
+		const oldest = map.keys().next().value;
+		if (oldest === undefined) break;
+		map.delete(oldest);
+	}
+	map.set(key, value);
+}
+
+export function modelIdentity(model: PiModel | undefined): string | undefined {
+	return model ? `${model.provider}/${model.id}` : undefined;
+}
+
+export function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
+}
+
+export function isTimeoutError(error: unknown): boolean {
+	return error instanceof Error && error.name === "TimeoutError";
+}

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -4,6 +4,7 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import { FAST_USAGE_WARNING, registerCodexFastMode } from "./codex-fast-runtime.js";
 import {
 	type CodexResetAvailability,
 	type CodexResetOption,
@@ -19,22 +20,15 @@ import {
 	resetOptionExpiration,
 	resolveCodexResetAuth,
 } from "./codex-resets.js";
-import {
-	awaitWithDeadline,
-	errorMessage,
-	runWithConcurrency,
-	sanitizeDisplayText,
-	UsageCache,
-} from "./core.js";
+import { awaitWithDeadline, errorMessage, runWithConcurrency, UsageCache } from "./core.js";
 import { formatProviderStates, formatUsageStatusline } from "./format.js";
 import {
 	adapterForProvider,
 	isStaleExtensionContextError,
-	providerIsConfigured,
 	queryProviderUsage,
 	resolveUsageAuth,
-	SUPPORTED_ADAPTERS,
 } from "./query.js";
+import { createUsageSettingsRuntime, type UsageSettingsRuntime } from "./settings.js";
 import type {
 	PiModel,
 	ProviderUsageState,
@@ -42,6 +36,14 @@ import type {
 	UsageDisplayState,
 	UsageProviderAdapter,
 } from "./types.js";
+import {
+	configuredAdapters,
+	isAbortError,
+	isTimeoutError,
+	modelIdentity,
+	providerDisplayName,
+	setBoundedMap,
+} from "./usage-helpers.js";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -59,6 +61,7 @@ const REDEEM_CODEX_RESET = "Redeem usage limit reset…";
 type UsageExtensionDependencies = {
 	credentialReader?: (providerId: string) => unknown;
 	createRedemptionId?: () => string;
+	settingsRuntime?: UsageSettingsRuntime;
 };
 
 type QueryOutcome = {
@@ -78,6 +81,7 @@ export default function usageExtension(
 ) {
 	const credentialReader = dependencies.credentialReader;
 	const createRedemptionId = dependencies.createRedemptionId ?? randomUUID;
+	const settingsRuntime = dependencies.settingsRuntime ?? createUsageSettingsRuntime();
 	const cache = new UsageCache(CACHE_TTL_MS);
 	const failureBackoff = new Map<string, { until: number; message: string }>();
 	const latestQueries = new Map<string, number>();
@@ -88,6 +92,7 @@ export default function usageExtension(
 	let statusGeneration = 0;
 	let statusRefreshTimer: ReturnType<typeof setTimeout> | undefined;
 	let statusController: AbortController | undefined;
+	let fastRuntime: ReturnType<typeof registerCodexFastMode>;
 
 	const clearStatusTimer = () => {
 		if (statusRefreshTimer) clearTimeout(statusRefreshTimer);
@@ -145,7 +150,8 @@ export default function usageExtension(
 			}
 			return;
 		}
-		const value = formatUsageStatusline(outcome.state.report, model);
+		const rawValue = formatUsageStatusline(outcome.state.report, model);
+		const value = rawValue ? fastRuntime.decorateStatus(model, rawValue) : undefined;
 		if (!safeSetStatus(ctx, value)) return;
 		if (shouldSchedule && sessionActive) scheduleStatusRefresh(ctx, model);
 	};
@@ -497,6 +503,7 @@ export default function usageExtension(
 			publishStableCurrent(ctx, stableCurrent);
 			let current = stableCurrent.outcome;
 			let visibleStates: ProviderUsageState[] = [current.state];
+			let fastState = settingsRuntime.get();
 			let resetAvailability: CodexResetAvailability | undefined;
 			let selectedReset: CodexResetOption | undefined;
 			let resetAuthFingerprint: string | undefined;
@@ -515,6 +522,7 @@ export default function usageExtension(
 				| "reset-error";
 			type Action =
 				| "refresh"
+				| "toggle-fast"
 				| "another"
 				| "all"
 				| "provider"
@@ -527,29 +535,54 @@ export default function usageExtension(
 			const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
 				start: "main",
 				screens: {
-					main: () => ({
-						kind: "actions",
-						title: "Provider usage",
-						lines: formatProviderStates(visibleStates).split("\n"),
-						items: [
-							{ id: "refresh", label: REFRESH_CURRENT, action: "refresh" },
-							...(current.state.status === "ready" && current.state.providerId === "openai-codex"
-								? [
-										{
-											id: "open-resets",
-											label: REDEEM_CODEX_RESET,
-											description: codexResetActionDescription(current.state.report),
-											disabled: codexResetCount(current.state.report) === 0,
-											action: "open-resets" as const,
-										},
-									]
-								: []),
-							{ id: "another", label: VIEW_ANOTHER, action: "another" },
-							{ id: "all", label: VIEW_ALL, action: "all" },
-							{ id: "close", label: CLOSE, close: true },
-						],
-						hint: "close",
-					}),
+					main: () => {
+						const fastAvailability = fastRuntime.availability(ctx.model);
+						const fastLines =
+							fastAvailability.kind === "available"
+								? [`Fast mode: ${fastAvailability.enabled ? "On" : "Off"}`, FAST_USAGE_WARNING]
+								: fastAvailability.kind === "unavailable"
+									? [`Fast mode: Unavailable · ${fastAvailability.reason}`]
+									: [];
+						return {
+							kind: "actions",
+							title: "Provider usage",
+							lines: [...formatProviderStates(visibleStates).split("\n"), ...fastLines],
+							items: [
+								{ id: "refresh", label: REFRESH_CURRENT, action: "refresh" },
+								...(fastAvailability.kind === "available"
+									? [
+											{
+												id: "toggle-fast",
+												label: fastAvailability.enabled
+													? "Turn Fast mode off"
+													: "Turn Fast mode on",
+												description:
+													fastState.kind === "invalid"
+														? "Repair pi-usage.json and reload before changing Fast mode."
+														: FAST_USAGE_WARNING,
+												disabled: fastState.kind === "invalid",
+												action: "toggle-fast" as const,
+											},
+										]
+									: []),
+								...(current.state.status === "ready" && current.state.providerId === "openai-codex"
+									? [
+											{
+												id: "open-resets",
+												label: REDEEM_CODEX_RESET,
+												description: codexResetActionDescription(current.state.report),
+												disabled: codexResetCount(current.state.report) === 0,
+												action: "open-resets" as const,
+											},
+										]
+									: []),
+								{ id: "another", label: VIEW_ANOTHER, action: "another" },
+								{ id: "all", label: VIEW_ALL, action: "all" },
+								{ id: "close", label: CLOSE, close: true },
+							],
+							hint: "close",
+						};
+					},
 					providers: () => ({
 						kind: "actions",
 						title: "Select a configured provider",
@@ -621,6 +654,16 @@ export default function usageExtension(
 					}),
 				},
 				actions: {
+					"toggle-fast": async () => {
+						const availability = fastRuntime.availability(ctx.model);
+						if (availability.kind !== "available" || fastState.kind === "invalid") {
+							return { kind: "rejected" };
+						}
+						const changed = await fastRuntime.toggle(ctx, !availability.enabled, controller.signal);
+						if (!changed) return { kind: "rejected" };
+						fastState = settingsRuntime.get();
+						return { kind: "stay" };
+					},
 					"open-resets": async () => {
 						const summaryCount =
 							current.state.status === "ready" && current.state.providerId === "openai-codex"
@@ -891,24 +934,24 @@ export default function usageExtension(
 		}
 	};
 
-	const commandHandler = async (args: string, ctx: ExtensionCommandContext) => {
-		if (args.trim()) {
-			ctx.ui.notify("/usage does not accept arguments; choose an action from its menu.", "warning");
-			return;
-		}
-		try {
-			await showMenu(ctx);
-		} catch (error) {
-			if (isStaleExtensionContextError(error) || isAbortError(error)) return;
-			throw error;
-		}
-	};
-
 	pi.registerCommand("usage", {
 		description: "Show usage for the current runtime account",
-		handler: commandHandler,
+		handler: async (args, ctx) => {
+			if (args.trim()) {
+				ctx.ui.notify(
+					"/usage does not accept arguments; choose an action from its menu.",
+					"warning",
+				);
+				return;
+			}
+			try {
+				await showMenu(ctx);
+			} catch (error) {
+				if (isStaleExtensionContextError(error) || isAbortError(error)) return;
+				throw error;
+			}
+		},
 	});
-
 	pi.on("session_start", (_event, ctx) => {
 		statusGeneration += 1;
 		clearStatusTimer();
@@ -940,40 +983,8 @@ export default function usageExtension(
 		activeCurrentIdentity = undefined;
 		safeSetStatus(ctx, undefined);
 	});
-}
 
-function configuredAdapters(ctx: ExtensionContext): UsageProviderAdapter[] {
-	return SUPPORTED_ADAPTERS.filter(
-		(adapter) => adapter.id === ctx.model?.provider || providerIsConfigured(ctx, adapter.id),
+	fastRuntime = registerCodexFastMode(pi, settingsRuntime, (ctx) =>
+		startStatusRefresh(ctx, ctx.model, false),
 	);
-}
-
-function providerDisplayName(ctx: ExtensionContext, providerId: string): string {
-	try {
-		return sanitizeDisplayText(ctx.modelRegistry.getProviderDisplayName(providerId), 80);
-	} catch {
-		return sanitizeDisplayText(providerId, 80);
-	}
-}
-
-function setBoundedMap<T>(map: Map<string, T>, key: string, value: T, limit: number): void {
-	map.delete(key);
-	while (map.size >= limit) {
-		const oldest = map.keys().next().value;
-		if (oldest === undefined) break;
-		map.delete(oldest);
-	}
-	map.set(key, value);
-}
-
-function modelIdentity(model: PiModel | undefined): string | undefined {
-	return model ? `${model.provider}/${model.id}` : undefined;
-}
-
-function isAbortError(error: unknown): boolean {
-	return error instanceof Error && error.name === "AbortError";
-}
-
-function isTimeoutError(error: unknown): boolean {
-	return error instanceof Error && error.name === "TimeoutError";
 }

--- a/packages/pi-usage/test/codex-fast-menu.test.ts
+++ b/packages/pi-usage/test/codex-fast-menu.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import type { UsageSettingsRuntime, UsageSettingsState } from "../src/settings.js";
+import usageExtension from "../src/usage.js";
+
+const codexModel = {
+	id: "gpt-5.4",
+	name: "GPT-5.4",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+	contextWindow: 1_000_000,
+	maxTokens: 128_000,
+};
+
+function runtime(kind: UsageSettingsState["kind"] = "loaded") {
+	let state: UsageSettingsState = {
+		kind,
+		path: "/tmp/pi-usage.json",
+		settings: { codexFastMode: false },
+		...(kind === "invalid" ? { issue: "bad file" } : { document: {} }),
+	};
+	const patches: unknown[] = [];
+	const settingsRuntime: UsageSettingsRuntime = {
+		get: () => structuredClone(state),
+		async reload() {
+			return structuredClone(state);
+		},
+		async update(patch) {
+			patches.push(patch);
+			state = {
+				...state,
+				kind: "loaded",
+				settings: { ...state.settings, ...patch },
+				document: { ...state.document, ...patch },
+			};
+			return structuredClone(state);
+		},
+		async flush() {},
+	};
+	return {
+		settingsRuntime,
+		patches,
+		get state() {
+			return state;
+		},
+	};
+}
+
+function registry() {
+	return {
+		getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "codex-token" }),
+		getProviderAuth: async () => ({ auth: { apiKey: "codex-token" } }),
+		getAvailable: () => [codexModel],
+		getAll: () => [codexModel],
+		getProviderAuthStatus: () => ({ configured: true }),
+		getProviderDisplayName: () => "OpenAI Codex",
+	};
+}
+
+function response(): Promise<Response> {
+	return Promise.resolve(
+		new Response(
+			JSON.stringify({
+				rate_limit: { primary_window: { used_percent: 20, limit_window_seconds: 18_000 } },
+			}),
+			{ status: 200 },
+		),
+	);
+}
+
+test("/usage shows Fast state and toggles the same persistent preference", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = response;
+	const memory = runtime();
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: memory.settingsRuntime });
+	const choices = ["Turn Fast mode on", "Close"];
+	const titles: string[] = [];
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async (title: string) => {
+			titles.push(title);
+			return choices.shift();
+		},
+		modelRegistry: registry(),
+	});
+	await mock.commands.get("usage")?.handler("", ctx);
+	assert.deepEqual(memory.patches, [{ codexFastMode: true }]);
+	assert.match(titles[0] ?? "", /Fast mode: Off/);
+	assert.match(titles[0] ?? "", /1\.5× faster.*uses more/);
+	assert.match(notifications[0]?.message ?? "", /Fast mode enabled/);
+});
+
+test("/usage cancellation does not change Fast and unsupported models show no toggle", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = response;
+	const cancelled = runtime();
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: cancelled.settingsRuntime });
+	let options: string[] = [];
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async (_title: string, values: string[]) => {
+			options = values;
+			return undefined;
+		},
+		modelRegistry: registry(),
+	});
+	await mock.commands.get("usage")?.handler("", ctx);
+	assert.ok(options.includes("Turn Fast mode on"));
+	assert.deepEqual(cancelled.patches, []);
+
+	const unsupported = runtime();
+	const unsupportedMock = createMockPi();
+	usageExtension(unsupportedMock.pi, { settingsRuntime: unsupported.settingsRuntime });
+	let unsupportedTitle = "";
+	let unsupportedOptions: string[] = [];
+	const unsupportedModel = { ...codexModel, id: "gpt-5.4-mini" };
+	const unsupportedContext = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: unsupportedModel,
+		select: async (title: string, values: string[]) => {
+			unsupportedTitle = title;
+			unsupportedOptions = values;
+			return "Close";
+		},
+		modelRegistry: {
+			...registry(),
+			getAvailable: () => [unsupportedModel],
+			getAll: () => [unsupportedModel],
+		},
+	});
+	await unsupportedMock.commands.get("usage")?.handler("", unsupportedContext.ctx);
+	assert.match(unsupportedTitle, /Fast mode: Unavailable/);
+	assert.ok(!unsupportedOptions.some((value) => value.includes("Fast mode on")));
+});
+
+test("invalid settings make the /usage Fast action visibly read-only", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = response;
+	const invalid = runtime("invalid");
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: invalid.settingsRuntime });
+	let rendered = "";
+	let options: string[] = [];
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		select: async (title: string, values: string[]) => {
+			rendered = title;
+			options = values;
+			return "Close";
+		},
+		modelRegistry: registry(),
+	});
+	await mock.commands.get("usage")?.handler("", ctx);
+	assert.match(rendered, /Fast mode: Off/);
+	assert.ok(options.includes("Turn Fast mode on"));
+	assert.deepEqual(invalid.patches, []);
+});

--- a/packages/pi-usage/test/codex-fast-runtime.test.ts
+++ b/packages/pi-usage/test/codex-fast-runtime.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import { correctCodexFastMessageCost } from "../src/codex-fast.js";
 import { registerCodexFastMode } from "../src/codex-fast-runtime.js";
 import type { UsageSettingsRuntime, UsageSettingsState } from "../src/settings.js";
 
@@ -228,6 +229,51 @@ test("cost correction follows the captured request tier across a later toggle", 
 		),
 		undefined,
 		"one request marker is consumed exactly once",
+	);
+});
+
+test("an already-correct cost still consumes its request marker", async () => {
+	const memory = memoryRuntime({ enabled: true });
+	const mock = createMockPi();
+	registerCodexFastMode(mock.pi, memory.runtime, () => undefined);
+	const hook = mock.events.get("before_provider_request")?.[0];
+	const messageEnd = mock.events.get("message_end")?.[0];
+	assert.ok(hook);
+	assert.ok(messageEnd);
+	const current = context();
+	await hook({ payload: { model: "gpt-5.4" } }, current.ctx);
+	const usage = {
+		input: 100,
+		output: 20,
+		cacheRead: 10,
+		cacheWrite: 0,
+		totalTokens: 130,
+		cost: {
+			input: 0.0005,
+			output: 0.0006,
+			cacheRead: 0.000005,
+			cacheWrite: 0,
+			total: 0.001105,
+		},
+	};
+	const alreadyCorrect = correctCodexFastMessageCost(
+		{
+			role: "assistant",
+			provider: "openai-codex",
+			model: "gpt-5.4",
+			usage,
+		},
+		codexModel as never,
+		true,
+	) as { usage: typeof usage };
+	assert.ok(alreadyCorrect);
+	const event = { message: alreadyCorrect };
+	assert.equal(await messageEnd(event, current.ctx), undefined);
+	alreadyCorrect.usage.cost.total = 0;
+	assert.equal(
+		await messageEnd(event, current.ctx),
+		undefined,
+		"the completed request cannot affect a later assistant message",
 	);
 });
 

--- a/packages/pi-usage/test/codex-fast-runtime.test.ts
+++ b/packages/pi-usage/test/codex-fast-runtime.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { registerCodexFastMode } from "../src/codex-fast-runtime.js";
+import type { UsageSettingsRuntime, UsageSettingsState } from "../src/settings.js";
+
+const codexModel = {
+	id: "gpt-5.4",
+	name: "GPT-5.4",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+	contextWindow: 1_000_000,
+	maxTokens: 128_000,
+};
+
+function memoryRuntime(
+	options: {
+		kind?: UsageSettingsState["kind"];
+		enabled?: boolean;
+		failUpdates?: number;
+		reload?: () => Promise<UsageSettingsState>;
+	} = {},
+) {
+	let state: UsageSettingsState = {
+		kind: options.kind ?? "loaded",
+		path: "/tmp/pi-usage.json",
+		settings: { codexFastMode: options.enabled ?? false },
+		...(options.kind === "invalid" ? { issue: "bad file" } : { document: {} }),
+	};
+	let failUpdates = options.failUpdates ?? 0;
+	let flushes = 0;
+	const patches: unknown[] = [];
+	const runtime: UsageSettingsRuntime = {
+		get: () => structuredClone(state),
+		async reload() {
+			if (options.reload) state = await options.reload();
+			return structuredClone(state);
+		},
+		async update(patch, signal) {
+			signal?.throwIfAborted();
+			patches.push(patch);
+			if (failUpdates > 0) {
+				failUpdates -= 1;
+				throw new Error("disk full");
+			}
+			state = {
+				...state,
+				kind: "loaded",
+				settings: { ...state.settings, ...patch },
+				document: { ...state.document, ...patch },
+			};
+			return structuredClone(state);
+		},
+		async flush() {
+			flushes += 1;
+		},
+	};
+	return {
+		runtime,
+		patches,
+		get state() {
+			return state;
+		},
+		get flushes() {
+			return flushes;
+		},
+	};
+}
+
+function context(overrides: Record<string, unknown> = {}) {
+	return createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: codexModel,
+		sessionManager: {
+			getSessionId: () => "session-a",
+			getBranch: () => [],
+			getEntries: () => [],
+		},
+		...overrides,
+	});
+}
+
+test("/fast toggles one persistent setting on and off with visible usage guidance", async () => {
+	const memory = memoryRuntime();
+	const mock = createMockPi();
+	let refreshes = 0;
+	registerCodexFastMode(mock.pi, memory.runtime, () => {
+		refreshes += 1;
+	});
+	const command = mock.commands.get("fast");
+	assert.ok(command);
+	const first = context();
+	await command.handler("", first.ctx);
+	assert.equal(memory.state.settings.codexFastMode, true);
+	assert.match(first.notifications[0]?.message ?? "", /1\.5× faster.*uses more/);
+	const second = context();
+	await command.handler("", second.ctx);
+	assert.equal(memory.state.settings.codexFastMode, false);
+	assert.match(second.notifications[0]?.message ?? "", /standard routing/);
+	assert.equal(refreshes, 2);
+});
+
+test("/fast rejects arguments and unsafe modes before mutation", async () => {
+	const memory = memoryRuntime();
+	const mock = createMockPi();
+	registerCodexFastMode(mock.pi, memory.runtime, () => undefined);
+	const command = mock.commands.get("fast");
+	assert.ok(command);
+	const rpc = context();
+	await command.handler("on", rpc.ctx);
+	assert.match(rpc.notifications[0]?.message ?? "", /does not accept arguments/);
+	const print = context({ hasUI: false, mode: "print" });
+	await assert.rejects(Promise.resolve(command.handler("", print.ctx)), /requires TUI or RPC/);
+	const json = context({ hasUI: false, mode: "json" });
+	await assert.rejects(
+		Promise.resolve(command.handler("on", json.ctx)),
+		/does not accept arguments/,
+	);
+	assert.deepEqual(memory.patches, []);
+});
+
+test("/fast rejects foreign, unsupported, custom-origin, and invalid-file contexts", async () => {
+	for (const currentModel of [
+		{ ...codexModel, provider: "openrouter" },
+		{ ...codexModel, id: "gpt-5.4-mini" },
+		{ ...codexModel, baseUrl: "https://proxy.example.test" },
+	]) {
+		const memory = memoryRuntime();
+		const mock = createMockPi();
+		registerCodexFastMode(mock.pi, memory.runtime, () => undefined);
+		const current = context({ model: currentModel });
+		await mock.commands.get("fast")?.handler("", current.ctx);
+		assert.deepEqual(memory.patches, []);
+		assert.equal(current.notifications[0]?.level, "warning");
+	}
+	const invalid = memoryRuntime({ kind: "invalid" });
+	const mock = createMockPi();
+	registerCodexFastMode(mock.pi, invalid.runtime, () => undefined);
+	const current = context();
+	await mock.commands.get("fast")?.handler("", current.ctx);
+	assert.deepEqual(invalid.patches, []);
+	assert.equal(current.notifications[0]?.level, "error");
+});
+
+test("failed persistence rolls back effective state and the queue permits retry", async () => {
+	const memory = memoryRuntime({ failUpdates: 1 });
+	const mock = createMockPi();
+	registerCodexFastMode(mock.pi, memory.runtime, () => undefined);
+	const command = mock.commands.get("fast");
+	assert.ok(command);
+	const failed = context();
+	await command.handler("", failed.ctx);
+	assert.equal(memory.state.settings.codexFastMode, false);
+	assert.match(failed.notifications[0]?.message ?? "", /disk full/);
+	const retried = context();
+	await command.handler("", retried.ctx);
+	assert.equal(memory.state.settings.codexFastMode, true);
+});
+
+test("provider payload captures the toggle state when its hook begins", async () => {
+	const memory = memoryRuntime();
+	const mock = createMockPi();
+	registerCodexFastMode(mock.pi, memory.runtime, () => undefined);
+	const hook = mock.events.get("before_provider_request")?.[0];
+	assert.ok(hook);
+	const current = context();
+	const before = await hook({ payload: { model: "gpt-5.4" } }, current.ctx);
+	await mock.commands.get("fast")?.handler("", current.ctx);
+	const after = await hook({ payload: { model: "gpt-5.4" } }, current.ctx);
+	assert.deepEqual(before, { model: "gpt-5.4", service_tier: "default" });
+	assert.deepEqual(after, { model: "gpt-5.4", service_tier: "priority" });
+});
+
+test("cost correction follows the captured request tier across a later toggle", async () => {
+	const memory = memoryRuntime();
+	const mock = createMockPi();
+	registerCodexFastMode(mock.pi, memory.runtime, () => undefined);
+	const hook = mock.events.get("before_provider_request")?.[0];
+	const messageEnd = mock.events.get("message_end")?.[0];
+	assert.ok(hook);
+	assert.ok(messageEnd);
+	const current = context();
+	await mock.commands.get("fast")?.handler("", current.ctx);
+	await hook({ payload: { model: "gpt-5.4" } }, current.ctx);
+	await mock.commands.get("fast")?.handler("", current.ctx);
+	const usage = {
+		input: 100,
+		output: 20,
+		cacheRead: 10,
+		cacheWrite: 0,
+		totalTokens: 130,
+		cost: {
+			input: 0.00025,
+			output: 0.0003,
+			cacheRead: 0.0000025,
+			cacheWrite: 0,
+			total: 0.0005525,
+		},
+	};
+	const correction = (await messageEnd(
+		{
+			message: {
+				role: "assistant",
+				provider: "openai-codex",
+				model: "gpt-5.4",
+				usage,
+			},
+		},
+		current.ctx,
+	)) as { message?: { usage: typeof usage } };
+	assert.equal(correction.message?.usage.cost.total, usage.cost.total * 2);
+	assert.equal(
+		await messageEnd(
+			{
+				message: {
+					role: "assistant",
+					provider: "openai-codex",
+					model: "gpt-5.4",
+					usage,
+				},
+			},
+			current.ctx,
+		),
+		undefined,
+		"one request marker is consumed exactly once",
+	);
+});
+
+test("session reload warns for invalid settings, refreshes status, and shutdown flushes", async () => {
+	const memory = memoryRuntime({ kind: "invalid" });
+	const mock = createMockPi();
+	let refreshes = 0;
+	registerCodexFastMode(mock.pi, memory.runtime, () => {
+		refreshes += 1;
+	});
+	const current = context();
+	await mock.events.get("session_start")?.[0]?.({}, current.ctx);
+	assert.match(current.notifications[0]?.message ?? "", /Invalid pi-usage\.json/);
+	assert.equal(refreshes, 1);
+	await mock.events.get("session_shutdown")?.[0]?.({}, current.ctx);
+	assert.equal(memory.flushes, 1);
+});
+
+test("session replacement aborts stale loads and accepted writes before UI publication", async () => {
+	let releaseLoad!: (state: UsageSettingsState) => void;
+	const slowLoad = new Promise<UsageSettingsState>((resolve) => {
+		releaseLoad = resolve;
+	});
+	const memory = memoryRuntime({ reload: () => slowLoad });
+	const mock = createMockPi();
+	let refreshes = 0;
+	registerCodexFastMode(mock.pi, memory.runtime, () => {
+		refreshes += 1;
+	});
+	const first = context();
+	const pendingLoad = mock.events.get("session_start")?.[0]?.({}, first.ctx);
+	await mock.events.get("session_shutdown")?.[0]?.({}, first.ctx);
+	releaseLoad({
+		kind: "loaded",
+		path: "/tmp/pi-usage.json",
+		settings: { codexFastMode: true },
+		document: { codexFastMode: true },
+	});
+	await pendingLoad;
+	assert.equal(refreshes, 0);
+	assert.deepEqual(first.notifications, []);
+});

--- a/packages/pi-usage/test/codex-fast.test.ts
+++ b/packages/pi-usage/test/codex-fast.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	CODEX_FAST_MODEL_IDS,
+	codexFastAvailability,
+	codexFastRequestTier,
+	codexFastStatusLabel,
+	correctCodexFastMessageCost,
+	rewriteCodexFastPayload,
+} from "../src/codex-fast.js";
+
+const model = (id = "gpt-5.4", overrides: Record<string, unknown> = {}) => ({
+	id,
+	name: id,
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+	contextWindow: 1_000_000,
+	maxTokens: 128_000,
+	...overrides,
+});
+
+const usage = {
+	input: 100,
+	output: 20,
+	cacheRead: 10,
+	cacheWrite: 0,
+	totalTokens: 130,
+	cost: { input: 0.00025, output: 0.0003, cacheRead: 0.0000025, cacheWrite: 0, total: 0.0005525 },
+};
+
+test("the supported model set matches the inspected Codex catalog", () => {
+	assert.deepEqual([...CODEX_FAST_MODEL_IDS].sort(), [
+		"gpt-5.4",
+		"gpt-5.5",
+		"gpt-5.6-luna",
+		"gpt-5.6-sol",
+		"gpt-5.6-terra",
+	]);
+	for (const id of CODEX_FAST_MODEL_IDS) {
+		assert.deepEqual(codexFastAvailability(model(id) as never, true), {
+			kind: "available",
+			enabled: true,
+		});
+	}
+	for (const id of ["gpt-5.4-mini", "gpt-5.3-codex-spark", "gpt-5.2"]) {
+		assert.equal(codexFastAvailability(model(id) as never, true).kind, "unavailable");
+	}
+});
+
+test("eligibility requires the official Codex provider, API, and origin", () => {
+	assert.equal(codexFastAvailability(model() as never, false).kind, "available");
+	assert.equal(
+		codexFastAvailability(model("gpt-5.4", { provider: "openai" }) as never, true).kind,
+		"not-codex",
+	);
+	assert.equal(
+		codexFastAvailability(model("gpt-5.4", { api: "openai-responses" }) as never, true).kind,
+		"unavailable",
+	);
+	assert.equal(
+		codexFastAvailability(
+			model("gpt-5.4", { baseUrl: "https://proxy.example.test" }) as never,
+			true,
+		).kind,
+		"unavailable",
+	);
+});
+
+test("request tiers use priority for supported Fast and explicit default otherwise", () => {
+	assert.equal(codexFastRequestTier(model() as never, true), "priority");
+	assert.equal(codexFastRequestTier(model() as never, false), "default");
+	assert.equal(codexFastRequestTier(model("gpt-5.4-mini") as never, true), "default");
+	assert.equal(
+		codexFastRequestTier(model("gpt-5.4", { provider: "openai" }) as never, true),
+		undefined,
+	);
+});
+
+test("payload rewriting is immutable, preserves fields, and ignores foreign payloads", () => {
+	const payload = { model: "gpt-5.4", input: [{ type: "message" }], service_tier: "flex" };
+	const rewritten = rewriteCodexFastPayload(payload, model() as never, true);
+	assert.deepEqual(rewritten, { ...payload, service_tier: "priority" });
+	assert.equal(payload.service_tier, "flex");
+	assert.deepEqual(rewriteCodexFastPayload(payload, model() as never, false), {
+		...payload,
+		service_tier: "default",
+	});
+	assert.equal(
+		rewriteCodexFastPayload(payload, model("gpt-5.4", { provider: "openai" }) as never, true),
+		undefined,
+	);
+	assert.equal(rewriteCodexFastPayload([], model() as never, true), undefined);
+});
+
+test("priority cost correction repairs Pi's default-tier echo fallback without double charging", () => {
+	const message = { role: "assistant", provider: "openai-codex", model: "gpt-5.4", usage };
+	const corrected = correctCodexFastMessageCost(message, model() as never, true) as {
+		usage: typeof usage;
+	};
+	assert.equal(corrected.usage.cost.total, usage.cost.total * 2);
+	assert.equal(message.usage.cost.total, usage.cost.total);
+	assert.equal(
+		correctCodexFastMessageCost(corrected, model() as never, true),
+		undefined,
+		"already-corrected cost remains unchanged",
+	);
+
+	const gpt55 = model("gpt-5.5", {
+		cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+	});
+	const gpt55Usage = {
+		...usage,
+		cost: { input: 0.0005, output: 0.0006, cacheRead: 0.000005, cacheWrite: 0, total: 0.001105 },
+	};
+	const corrected55 = correctCodexFastMessageCost(
+		{ role: "assistant", provider: "openai-codex", model: "gpt-5.5", usage: gpt55Usage },
+		gpt55 as never,
+		true,
+	) as { usage: typeof gpt55Usage };
+	assert.equal(corrected55.usage.cost.total, gpt55Usage.cost.total * 2.5);
+});
+
+test("cost correction and status labels stay scoped to effective Fast", () => {
+	assert.equal(
+		correctCodexFastMessageCost(
+			{ role: "assistant", provider: "openai-codex", model: "gpt-5.4", usage },
+			model() as never,
+			false,
+		),
+		undefined,
+	);
+	assert.equal(
+		correctCodexFastMessageCost(
+			{
+				role: "assistant",
+				provider: "openai-codex",
+				model: "gpt-5.4-mini",
+				usage,
+			},
+			model("gpt-5.4-mini") as never,
+			true,
+		),
+		undefined,
+	);
+	assert.equal(
+		correctCodexFastMessageCost(
+			{ role: "assistant", provider: "openai-codex", model: "other", usage },
+			model() as never,
+			true,
+		),
+		undefined,
+	);
+	assert.equal(codexFastStatusLabel("codex 80% 5h", true), "codex fast 80% 5h");
+	assert.equal(codexFastStatusLabel("codex credits available", false), "codex credits available");
+	assert.equal(codexFastStatusLabel("openrouter $10 left", true), "openrouter $10 left");
+	assert.equal(codexFastStatusLabel("codexical provider", true), "codexical provider");
+});

--- a/packages/pi-usage/test/settings.test.ts
+++ b/packages/pi-usage/test/settings.test.ts
@@ -1,5 +1,15 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import {
+	chmod,
+	mkdtemp,
+	readdir,
+	readFile,
+	rename,
+	rm,
+	stat,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "vitest";
@@ -107,7 +117,7 @@ test("serialized updates reread the latest document and leave no temporary files
 	);
 });
 
-test("aborted and failed saves retain prior runtime state and do not poison retries", async () => {
+test("aborted saves retain prior runtime state", async () => {
 	const abortedPath = await tempSettingsPath();
 	const abortedRuntime = createUsageSettingsRuntime(abortedPath);
 	const controller = new AbortController();
@@ -118,18 +128,29 @@ test("aborted and failed saves retain prior runtime state and do not poison retr
 	);
 	assert.equal(abortedRuntime.get().settings.codexFastMode, false);
 	assert.equal((await loadUsageSettings(abortedPath)).kind, "missing");
+});
 
-	if (process.platform === "win32") return;
-	const failedPath = await tempSettingsPath();
-	const directory = join(failedPath, "..");
-	const failedRuntime = createUsageSettingsRuntime(failedPath);
-	await chmod(directory, 0o500);
-	try {
-		await assert.rejects(failedRuntime.update({ codexFastMode: true }));
-		assert.equal(failedRuntime.get().settings.codexFastMode, false);
-	} finally {
-		await chmod(directory, 0o700);
-	}
-	await failedRuntime.update({ codexFastMode: true });
-	assert.equal(failedRuntime.get().settings.codexFastMode, true);
+test("failed saves retain prior runtime state, clean up, and do not poison retries", async () => {
+	const path = await tempSettingsPath();
+	let rejectRename = true;
+	const runtime = createUsageSettingsRuntime({
+		path,
+		operations: {
+			rename: async (source, destination) => {
+				if (rejectRename) throw new Error("rename rejected");
+				await rename(source, destination);
+			},
+		},
+	});
+	await assert.rejects(runtime.update({ codexFastMode: true }), /rename rejected/);
+	assert.equal(runtime.get().settings.codexFastMode, false);
+	assert.equal((await loadUsageSettings(path)).kind, "missing");
+	assert.deepEqual(
+		(await readdir(join(path, ".."))).filter((name) => name.endsWith(".tmp")),
+		[],
+	);
+
+	rejectRename = false;
+	await runtime.update({ codexFastMode: true });
+	assert.equal(runtime.get().settings.codexFastMode, true);
 });

--- a/packages/pi-usage/test/settings.test.ts
+++ b/packages/pi-usage/test/settings.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test } from "vitest";
+import {
+	createUsageSettingsRuntime,
+	DEFAULT_USAGE_SETTINGS,
+	loadUsageSettings,
+	normalizeUsageSettings,
+} from "../src/settings.js";
+
+const temporaryDirectories: string[] = [];
+
+async function tempSettingsPath(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), "pi-usage-settings-test-"));
+	temporaryDirectories.push(directory);
+	return join(directory, "pi-usage.json");
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+	);
+});
+
+test("normalizes the default-Off setting and rejects invalid values", () => {
+	assert.deepEqual(normalizeUsageSettings({}), DEFAULT_USAGE_SETTINGS);
+	assert.deepEqual(normalizeUsageSettings({ codexFastMode: true }), { codexFastMode: true });
+	assert.equal(normalizeUsageSettings({ codexFastMode: "true" }), undefined);
+	assert.equal(normalizeUsageSettings([]), undefined);
+});
+
+test("missing loads are side-effect free and valid loads preserve unknown fields", async () => {
+	const path = await tempSettingsPath();
+	const missing = await loadUsageSettings(path);
+	assert.equal(missing.kind, "missing");
+	assert.equal((await readdir(join(path, ".."))).length, 0);
+
+	await writeFile(path, '{"codexFastMode":true,"future":"kept"}\n');
+	const loaded = await loadUsageSettings(path);
+	assert.equal(loaded.kind, "loaded");
+	assert.equal(loaded.settings.codexFastMode, true);
+	assert.equal(loaded.document?.future, "kept");
+});
+
+test("malformed, invalid, oversized, and symbolic-link settings stay read-only", async () => {
+	const malformedPath = await tempSettingsPath();
+	await writeFile(malformedPath, "{invalid");
+	const malformed = await loadUsageSettings(malformedPath);
+	assert.equal(malformed.kind, "invalid");
+	const runtime = createUsageSettingsRuntime(malformedPath);
+	await runtime.reload();
+	await assert.rejects(runtime.update({ codexFastMode: true }), /Cannot overwrite an invalid/);
+	assert.equal(await readFile(malformedPath, "utf8"), "{invalid");
+
+	const invalidPath = await tempSettingsPath();
+	await writeFile(invalidPath, '{"codexFastMode":"yes"}\n');
+	assert.equal((await loadUsageSettings(invalidPath)).kind, "invalid");
+
+	const oversizedPath = await tempSettingsPath();
+	await writeFile(oversizedPath, JSON.stringify({ padding: "x".repeat(70 * 1024) }));
+	assert.match((await loadUsageSettings(oversizedPath)).issue ?? "", /64 KiB/);
+
+	const target = await tempSettingsPath();
+	const link = await tempSettingsPath();
+	await writeFile(target, "{}");
+	await symlink(target, link);
+	assert.match((await loadUsageSettings(link)).issue ?? "", /symbolic links/);
+});
+
+test("the first explicit save creates a private file and preserves unknown fields", async () => {
+	const path = await tempSettingsPath();
+	const runtime = createUsageSettingsRuntime(path);
+	await runtime.update({ codexFastMode: true });
+	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), { codexFastMode: true });
+	if (process.platform !== "win32") assert.equal((await stat(path)).mode & 0o777, 0o600);
+
+	await writeFile(path, '{"codexFastMode":true,"future":"kept"}\n');
+	if (process.platform !== "win32") await chmod(path, 0o644);
+	await runtime.update({ codexFastMode: false });
+	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
+		codexFastMode: false,
+		future: "kept",
+	});
+	if (process.platform !== "win32") assert.equal((await stat(path)).mode & 0o777, 0o600);
+});
+
+test("serialized updates reread the latest document and leave no temporary files", async () => {
+	const path = await tempSettingsPath();
+	await writeFile(path, '{"codexFastMode":false,"external":"first"}\n');
+	const runtime = createUsageSettingsRuntime(path);
+	await runtime.reload();
+	await writeFile(path, '{"codexFastMode":false,"external":"newer"}\n');
+	await Promise.all([
+		runtime.update({ codexFastMode: true }),
+		runtime.update({ codexFastMode: false }),
+	]);
+	await runtime.flush();
+	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
+		codexFastMode: false,
+		external: "newer",
+	});
+	assert.deepEqual(
+		(await readdir(join(path, ".."))).filter((name) => name.endsWith(".tmp")),
+		[],
+	);
+});
+
+test("aborted and failed saves retain prior runtime state and do not poison retries", async () => {
+	const abortedPath = await tempSettingsPath();
+	const abortedRuntime = createUsageSettingsRuntime(abortedPath);
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		abortedRuntime.update({ codexFastMode: true }, controller.signal),
+		/aborted/i,
+	);
+	assert.equal(abortedRuntime.get().settings.codexFastMode, false);
+	assert.equal((await loadUsageSettings(abortedPath)).kind, "missing");
+
+	if (process.platform === "win32") return;
+	const failedPath = await tempSettingsPath();
+	const directory = join(failedPath, "..");
+	const failedRuntime = createUsageSettingsRuntime(failedPath);
+	await chmod(directory, 0o500);
+	try {
+		await assert.rejects(failedRuntime.update({ codexFastMode: true }));
+		assert.equal(failedRuntime.get().settings.codexFastMode, false);
+	} finally {
+		await chmod(directory, 0o700);
+	}
+	await failedRuntime.update({ codexFastMode: true });
+	assert.equal(failedRuntime.get().settings.codexFastMode, true);
+});

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -56,14 +56,18 @@ function usageFetch(input: string | URL | Request): Promise<Response> {
 	);
 }
 
-test("pi-usage registers only its primary command and lifecycle hooks", () => {
+test("pi-usage registers its usage and Fast commands with lifecycle hooks", () => {
 	const mock = createMockPi();
 	usageExtension(mock.pi);
 
 	assert.ok(mock.commands.has("usage"));
+	assert.ok(mock.commands.has("fast"));
 	assert.equal(mock.commands.has("codex-status"), false);
 	assert.equal(mock.commands.get("usage")?.getArgumentCompletions, undefined);
+	assert.equal(mock.commands.get("fast")?.getArgumentCompletions, undefined);
 	assert.deepEqual([...mock.events.keys()].sort(), [
+		"before_provider_request",
+		"message_end",
 		"model_select",
 		"session_shutdown",
 		"session_start",


### PR DESCRIPTION
## Summary

- add persistent Codex Fast mode through `/fast` and the contextual `/usage` action
- scope priority routing and corrected cost accounting to supported models on the official Codex endpoint
- add serialized atomic settings, lifecycle handling, documentation, focused tests, and a minor changeset

## Verification

- `npm exec vitest -- run packages/pi-usage/test` — 77 passed
- `npm run typecheck --workspace @narumitw/pi-usage`
- `npm run check:boundaries`
- `npm exec biome -- check packages/pi-usage/src packages/pi-usage/test packages/pi-usage/README.md packages/pi-usage/package.json packages/pi-usage/tsconfig.json`
- `git diff --check`
- `just pack usage` — inspected 17-file dry-run tarball
- local Pi entrypoint load and OAuth-backed GPT-5.4 smokes captured `priority` with Fast On and `default` with Fast Off
- signed pre-commit gate ran repository Biome and all workspace typechecks

## Full-gate note

- `npm run check` reached green build, Biome, boundaries, and typechecks, but its repository-wide parallel test phase had unrelated timing/path failures in `pi-subagents`, `pi-sync`, and `pi-worktree`.
- The focused package suite and representative affected isolation reruns passed.
