### PR TITLE
docs(tui-kit): refresh roadmap from API 11

### DIFF
--- a/docs/plans/2026-08-13_pi-tui-kit-existing-contract-convergence-plan.md
+++ b/docs/plans/2026-08-13_pi-tui-kit-existing-contract-convergence-plan.md
@@ -1,0 +1,98 @@
+# Pi TUI Kit Existing Contract Convergence Plan
+
+## Goal
+
+Remove duplicated interaction lifecycle and test-host ownership from compatible specialized TUI flows by adopting the already-published `runCustomInteraction()` and `/testing` contracts without adding a new Pi TUI Kit API or moving domain behavior into the Kit.
+
+## Context
+
+Twenty-five active extensions consume Pi TUI Kit, but eight source areas still call `ctx.ui.custom()` directly.
+
+Direct custom UI is not automatically duplication because OAuth, chat composers, secret input, and multi-stage domain workflows own behavior that the Kit must not absorb.
+
+`packages/pi-starship/src/command-preview.ts` repeats owner-abort listening, external disposal, completion, and key-hint lifecycle around an extension-owned preview-and-action component.
+
+`packages/pi-file-context/src/file-context.ts` directly hosts `FileQuoteExplorer`, while the explorer already owns its file, search, preview, revision, and diff behavior and aborts its internal work from `dispose()`.
+
+`packages/pi-image-drop/src/menu.ts` is not a direct `runTask()` migration because its loader deliberately maps Escape to Back and Ctrl+C to Close, while `runTask()` currently returns one user-cancelled outcome.
+
+The plan therefore requires behavior matrices and explicit no-go decisions instead of treating every direct `custom()` or loader call as interchangeable.
+
+## Architecture
+
+Pi TUI Kit owns the interaction signal, stale-owner classification, exactly-once wrapper disposal, error routing, and optional pending-work draining.
+
+Each extension owns its component, raw result values, Back and Close mapping, domain state, asynchronous operations, persistence, notifications, and session-generation policy.
+
+The consumer passes its existing owner signal and `isCurrent()` check into `runCustomInteraction()`.
+
+The consumer component completes through the helper-provided `complete()` callback and continues to implement its own rendering, input, focus, and domain cancellation.
+
+Tests should use `createTuiHarness()` where it can drive the public custom-factory boundary without weakening specialized component assertions.
+
+Repository-level context, filesystem, clock, network, process, and domain fixtures remain outside `@narumitw/pi-tui-kit/testing`.
+
+## Non-Goals
+
+- Do not add a session-owner abstraction or register lifecycle hooks from Pi TUI Kit.
+- Do not redesign Starship preview content, File Context search, file loading, Git history, revision, diff, or quote behavior.
+- Do not migrate Accounts OAuth, BTW fullscreen or composer flows, Chat, secret input, or other multi-stage interfaces without a separate compatibility decision.
+- Do not change Image Drop's Escape-versus-Ctrl+C loader outcomes to make it fit `runTask()`.
+- Do not expose raw component instances or add a general `ExtensionContext` mock to the Kit testing entrypoint.
+- Do not combine unrelated extension migrations in one implementation pull request.
+
+## Risks
+
+- A wrapper migration can accidentally collapse Back, Close, stale owner, and external disposal into one result.
+- A component can call its old `done()` callback during wrapper disposal and race the helper's stale result.
+- File Context owns nested asynchronous searches and detail loads, so disposal evidence must prove that every controller is aborted and drained or safely settled.
+- Replacing root test helpers can reduce coverage if the Kit harness cannot observe a specialized component's required intermediate state.
+- A source-only refactor can still change published package behavior, so Changeset intent must be decided from the final diff rather than assumed.
+
+## Plan
+
+### Phase 1: Compatibility inventory
+
+- [ ] Record every active direct `ctx.ui.custom()` and local loader owner in `packages/*/src`; classify each as standard, lifecycle-only specialized, or domain-specialized, and preserve the evidence in this plan.
+- [ ] Write a Starship behavior matrix for selected, Back, Close, owner abort, external disposal, empty actions, constrained rows, scrolling, terminal controls, and thrown body rendering; verify each row against focused existing tests before editing production code.
+- [ ] Write a File Context behavior matrix for quote, reference, Back, Close, owner replacement, shutdown, external disposal, pending file load, content search, revision load, and error reporting; verify each row against focused existing tests before editing production code.
+- [ ] Record Image Drop as a `runTask()` migration or a finite no-go by comparing Escape, Ctrl+C, owner abort, error reporting, and task-draining semantics; require exact result compatibility before any source change.
+- [ ] Decide separately for each candidate whether `createTuiHarness()` can replace repository test support without losing direct component observations; retain the old helper where evidence says no.
+
+### Phase 2: Starship lifecycle convergence
+
+- [ ] Add or strengthen Starship characterization tests for every accepted behavior-matrix row; verify that the focused suite passes before the refactor.
+- [ ] Refactor `showPreviewActionMenu()` to run its extension-owned component through `runCustomInteraction()` with the existing session signal and current-owner check; preserve the public `PreviewMenuResult` contract.
+- [ ] Remove only Starship abort-listener, exactly-once completion, and wrapper-disposal code now owned by the Kit; retain preview layout, scrolling, injected controls, sanitization, and action semantics locally.
+- [ ] Migrate compatible Starship tests to `createTuiHarness()` and remove only test-support imports made unused by this flow; verify focus, resize, disposal, and result observations through the public factory boundary.
+- [ ] Audit every Starship await, cancellation path, component disposal, and session replacement against `docs/extension-conventions.md`; record any intentional deviation next to its owner.
+- [ ] Decide and record Starship Changeset intent from the final behavior and dependency diff, then run focused tests, the package check, `npm run check:boundaries`, `npm run check`, `git diff --check`, and `just pack starship` sequentially.
+- [ ] Run a local `pi -e` or `just try starship` interaction smoke when practical; leave the task open with the exact unavailable path if an interactive runtime cannot be exercised.
+
+### Phase 3: File Context lifecycle convergence
+
+- [ ] Add or strengthen File Context characterization tests for every accepted behavior-matrix row, including pending search and detail cancellation; verify that the focused suite passes before the refactor.
+- [ ] Adapt `FileQuoteExplorer` completion to `runCustomInteraction()` without moving files, Git state, selected quotes, notifications, or validation into the Kit.
+- [ ] Compose the existing flow signal with the helper-owned signal and prove owner replacement, shutdown, and external disposal abort all explorer-owned controllers exactly once.
+- [ ] Preserve menu-owned Back versus root Close, quote and reference payloads, post-await session checks, and the active-explorer guard while deleting only superseded custom-host ownership.
+- [ ] Migrate compatible File Context tests to `createTuiHarness()` and retain specialized fixtures required to inspect content search, revision, and diff behavior.
+- [ ] Audit user cancellation, component disposal, session replacement, shutdown, stale continuations after every await, and pending-work release against `docs/extension-conventions.md`.
+- [ ] Decide and record File Context Changeset intent from the final diff, then run focused tests, the package check, `npm run check:boundaries`, `npm run check`, `git diff --check`, and `just pack file-context` sequentially.
+- [ ] Run a local `pi -e` or `just try file-context` interaction smoke when practical; leave the task open with the exact unavailable path if an interactive runtime cannot be exercised.
+
+### Phase 4: Convergence decision
+
+- [ ] Recount direct custom hosts and repository test-helper consumers after both migrations; record deleted ownership and every retained specialized owner without setting a numeric removal target.
+- [ ] Reassess Image Drop and the remaining direct hosts against the published Kit contract; create a separate focused plan only when another exact behavior match exists.
+- [ ] Update `packages/pi-tui-kit/README.md` or the roadmap only if execution establishes a durable adoption rule not already documented.
+- [ ] Complete a final semantic audit across both extension diffs and verify that no domain state, persistence, transaction, or session-hook ownership moved into Pi TUI Kit.
+
+## Completion Checklist
+
+- [ ] Starship uses the published custom-interaction lifecycle shell without changing preview or action behavior.
+- [ ] File Context uses the published custom-interaction lifecycle shell without changing explorer behavior or leaking pending work.
+- [ ] Back, Close, stale owner, external disposal, errors, and successful domain results remain distinct where each extension currently distinguishes them.
+- [ ] Compatible tests use the supported Kit harness, while specialized fixtures remain local and no general context mock is added.
+- [ ] Image Drop and every retained direct host have an evidence-backed migration or no-go decision.
+- [ ] Focused tests, package checks, root gates, pack inspections, semantic audits, and practical runtime smokes are recorded for each implementation pull request.
+- [ ] The plan is archived only after every task has evidence and all intended pull requests are complete.

--- a/docs/plans/2026-08-13_pi-tui-kit-searchable-choice-plan.md
+++ b/docs/plans/2026-08-13_pi-tui-kit-searchable-choice-plan.md
@@ -1,0 +1,148 @@
+# Pi TUI Kit Searchable Choice Plan
+
+## Goal
+
+Qualify and, only with two compatible consumer needs, add optional TUI search to the existing declarative `choice` screen while preserving raw stable identity, deterministic RPC selection, lifecycle outcomes, and extension-owned domain behavior.
+
+## Context
+
+The current `choice` screen confirms one raw item ID and supports current and initial identity, descriptions, details, disabled reasons, paging, Back, Close, TUI, and RPC.
+
+The current `choice` screen does not support search.
+
+`browse` and searchable `multiSelect` already prove TUI fuzzy search, `searchText`, IME focus forwarding, control sanitization, no-match behavior, stable-ID restoration, and deterministic unfiltered RPC degradation inside Pi TUI Kit.
+
+Pi BTW's in-memory Resume screen is the first concrete searchable-choice candidate because it presents user-owned thread titles and stable thread IDs.
+
+Potential second candidates include long or variable Worktree selection, Recall's standard Save Message choice, and Pi Chat's public-room or participant choices, but none should be enrolled without evidence that search solves a real scan or recall problem and preserves its existing action contract.
+
+Recall's separate scoped picker, File Context explorer, Pi session management, delete actions, scope switching, persistence, and tree navigation are not evidence for this narrow screen contract.
+
+## Architecture
+
+The preferred candidate shape is additive `enableSearch?: boolean` on `ChoiceScreen` and `searchText?: string` on `MenuChoiceItem`.
+
+TUI search filters sanitized labels, descriptions, and explicit non-rendered `searchText` while actions continue to receive the original raw item ID.
+
+The query belongs only to the current screen instance and is not persisted by the Kit.
+
+The selected item is restored by stable raw ID after filtering, query clearing, resize, action rejection, and return navigation whenever that item remains visible.
+
+Disabled rows remain searchable, focusable, explanatory, and inert.
+
+Details describe the focused result but never become implicit search metadata unless the consumer explicitly supplies safe metadata through `searchText`.
+
+RPC presents one deterministic unfiltered selector and does not claim an interactive search protocol.
+
+Print and JSON retain their current unsupported-mode behavior.
+
+The implementation should reuse internal search and selection primitives only when doing so deletes duplicated policy without coupling `choice`, `browse`, and `multiSelect` domain semantics.
+
+## User Experience States
+
+- Empty input shows the consumer-provided ordering and existing initial or remembered selection.
+- A non-empty query shows matching rows without changing raw IDs or consumer ordering among equal matches unless the approved fuzzy-search contract already defines ranking.
+- No match keeps the search field editable, shows a non-color textual empty state, and preserves a recoverable selection for query clearing.
+- Disabled matches remain visible with their unavailable reason and cannot invoke the action.
+- Rejected or failed actions retain both the query and selected raw ID for correction or another choice.
+- Escape follows the screen's Back or Close hint, while Ctrl+C closes the whole menu.
+- Owner replacement, shutdown, and external disposal settle as stale and never invoke a choice action.
+- Narrow widths and resize preserve the search field, recognizable labels, selected details, and complete frame bounds.
+
+## Non-Goals
+
+- Do not add a new session picker, domain record store, filesystem scan, ordering policy, scope selector, rename, delete, trash, tree, persistence, or recent-item policy.
+- Do not make live cursor movement invoke preview side effects; `runLiveChoice()` remains the owner for bounded live-preview selection.
+- Do not add action rows, bulk actions, multiple selection, free-text submission, editor fallback, wizard steps, or forms to `choice`.
+- Do not index detail-document bodies, secrets, full transcripts, or other large or sensitive content implicitly.
+- Do not change ordinary choices unless `enableSearch` is explicitly set.
+- Do not release the Kit API together with its first consumer or publish without explicit user approval.
+
+## Risks
+
+- Adding search because a list can be long, rather than because users need it, would increase focus and navigation cost for small choices.
+- Fuzzy ranking can reorder consumer-provided recent-first lists and make the initial selection appear unstable.
+- Sanitized duplicate labels can lose identity if adapters infer IDs from display strings.
+- Searching details or raw IDs can disclose sensitive or implementation-only values.
+- Reusing browse or multi-select code too mechanically can import read-only detail or toggle semantics into single choice.
+- A zero-major dependency range can hide an unpublished API through workspace hoisting, so release and clean-install gates are mandatory.
+
+## Rollback / Recovery
+
+The new fields must be optional and preserve existing screen behavior when omitted.
+
+Consumer migrations can be reverted independently to ordinary `choice` without removing the additive Kit contract.
+
+If post-release evidence rejects the UX, stop further adoption and record the API disposition before considering a separately approved deprecation.
+
+No persisted data migration is involved because query and selection presentation remain interaction-local.
+
+## Plan
+
+### Phase 1: Consumer qualification
+
+- [ ] Measure and document the current BTW Resume list shape, ordering, labels, duplicate-title behavior, interaction frequency evidence if available, and failure cost; do not infer a search need from list capability alone.
+- [ ] Inventory standard `choice` screens with variable user-owned rows in Worktree, Recall, Chat, Analytics, Fleet, and File Context; identify candidates whose only missing behavior is local search and stable-ID confirmation.
+- [ ] Select at least one independent second consumer with an evidence-backed search job, or record a finite no-go and stop before changing the Kit.
+- [ ] Build a shared behavior matrix for both proof consumers covering initial ordering, raw ID, labels, descriptions, explicit search metadata, duplicate labels, disabled rows, details, empty data, Back, Close, stale owner, action rejection, RPC, and unsupported modes.
+- [ ] Verify that neither proof consumer requires scope changes, delete actions, live previews, persistence, domain loading, action rows, or a different cancellation contract.
+- [ ] Capture focused pre-change tests and map the proposal to TUI, IME, terminal-safety, lifecycle, package, Changeset, release, and consumer-mode MUST rules from `docs/extension-conventions.md`.
+
+### Phase 2: UX and public contract approval
+
+- [ ] Produce focused component examples for empty query, matches, no match, disabled match, duplicate sanitized labels, narrow width, and selected details using current Pi theme and injected keybindings.
+- [ ] Decide whether matching preserves source ordering or uses the existing Kit fuzzy ranking, and document the choice with both consumers' ordering requirements.
+- [ ] Decide the exact search corpus from sanitized label, description, and explicit `searchText`, and prove details plus raw IDs remain excluded unless intentionally copied into safe metadata.
+- [ ] Confirm the additive `enableSearch` and `searchText` shape or record why a different minimal contract is required; do not add a new screen kind without a separate approved architecture decision.
+- [ ] Obtain explicit user approval of the substantial cross-consumer interaction proposal before editing production UI files.
+
+### Phase 3: Kit-only implementation
+
+- [ ] Add failing public type and package-root declaration tests for optional searchable choice fields and the explicit compatibility-marker decision.
+- [ ] Add failing TUI tests for filtering, source-order or approved ranking, stable raw ID, duplicate labels, initial and current selection, query clearing, no match, disabled reasons, details, rejected retries, and empty items.
+- [ ] Add failing TUI lifecycle tests for IME focus, pasted controls, Escape Back, hinted Close, Ctrl+C Close, owner abort, `isCurrent()` failure, external disposal, resize, narrow widths, and complete frame bounds.
+- [ ] Add failing RPC tests proving one deterministic unfiltered selector, duplicate-label identity, disabled-row behavior, action rejection, signal cancellation, and unchanged non-search choices.
+- [ ] Implement optional search in the existing choice component and reuse internal search helpers only where behavior matrices prove exact compatibility.
+- [ ] Preserve raw item IDs outside rendered strings and revalidate the selected item after every filter, resize, return, and asynchronous action boundary.
+- [ ] Update the Kit README, examples, public types, API compatibility metadata when applicable, and root usage fixtures with TUI-only search and RPC degradation guidance.
+- [ ] Add a Kit-only minor Changeset and verify that no consumer source or dependency floor adopts the unpublished fields.
+- [ ] Run the complete Kit check and tests, runtime import benchmark, `npm run check:boundaries`, `npm run check`, `git diff --check`, and `just pack tui-kit` sequentially; inspect runtime and declaration exports.
+- [ ] Audit IME focus forwarding, terminal sanitization before filtering, width and row bounds, query and selection restoration, stale action continuations, component disposal, RPC identity, and unchanged ordinary choice behavior.
+
+### Release gate
+
+- [ ] Obtain explicit user approval before publishing, tagging, changing visibility, or dispatching a release workflow.
+- [ ] Verify the approved Kit release with `npm view`, tarball inspection, and a clean temporary installation that compiles and runs a searchable-choice fixture.
+- [ ] Record the registry-visible compatibility floor before either proof consumer raises its dependency range.
+
+### Phase 4: First proof consumer
+
+- [ ] Create a consumer-only branch from then-current `origin/main`, raise only that package's Kit floor to the verified release, refresh the lockfile, and prove resolved compatibility before typechecking.
+- [ ] Enable search without changing raw IDs, data loading, ordering, labels, domain actions, persistence, command modes, Back, Close, or session ownership.
+- [ ] Add focused tests for the consumer's real duplicate, empty, no-match, narrow, disabled, stale, and unsupported-mode cases.
+- [ ] Add the appropriate consumer Changeset, then run focused tests, the package check, dependency-resolution verification, `npm run check:boundaries`, `npm run check`, `git diff --check`, and the package's `just pack` recipe.
+- [ ] Run a practical local Pi interaction smoke when possible and record any unverified user-data or provider path.
+
+### Phase 5: Second proof consumer
+
+- [ ] Repeat the independent compatibility-floor, implementation, test, Changeset, package, root, pack, and runtime-smoke gates for the second consumer in a separate pull request.
+- [ ] Compare both final migrations against the qualification matrix and record any behavior that remained consumer-owned or prevented further convergence.
+- [ ] Remove only local search or selection code made redundant by the published contract and retain all domain loading, validation, actions, and persistence.
+
+### Phase 6: Completion decision
+
+- [ ] Update the roadmap with the verified API, release order, two proof migrations, UX trade-offs, retained domain boundaries, and any no-go consumers.
+- [ ] Recount ordinary searchable-choice adopters only as migration evidence, not as a target or justification for widening the API.
+- [ ] Complete a final semantic audit proving that no session, scope, delete, tree, persistence, preview, or action-bearing catalog policy entered Pi TUI Kit.
+
+## Completion Checklist
+
+- [ ] Two independent consumers prove the same searchable single-choice need, or qualification ends before implementation with a finite no-go.
+- [ ] Search is opt-in, TUI-local, IME-safe, terminal-safe, width-bounded, and preserves stable raw identity plus exact lifecycle outcomes.
+- [ ] RPC remains deterministic and unfiltered without claiming unsupported interactive search parity.
+- [ ] Ordinary choice, browse, multi-select, and live-choice behavior remain compatible and separately owned.
+- [ ] The Kit API is independently published and registry-verified before either consumer adopts it.
+- [ ] Both proof consumers preserve domain ordering, loading, validation, actions, persistence, and session ownership.
+- [ ] Focused tests, package checks, root gates, pack inspections, semantic audits, and practical smokes are recorded.
+- [ ] No release action occurs without explicit user approval.
+- [ ] The plan is archived only after all accepted implementation, release, and consumer work is complete.

--- a/docs/plans/2026-08-13_pi-tui-kit-terminal-display-safety-plan.md
+++ b/docs/plans/2026-08-13_pi-tui-kit-terminal-display-safety-plan.md
@@ -1,0 +1,122 @@
+# Pi TUI Kit Terminal Display Safety Plan
+
+## Goal
+
+Qualify one small extension-neutral terminal display sanitizer, publish it from Pi TUI Kit only if two consumers share an exact contract, and migrate those consumers only after the public API is independently released and registry-verified.
+
+## Context
+
+`packages/pi-statusline/src/terminal.ts` and `packages/pi-starship/src/modules/terminal.ts` contain the same `sanitizeTerminalText()` implementation.
+
+Both copies remove terminal escape sequences and unsafe controls before rendering model names, symbols, paths, and footer metadata.
+
+Other packages also sanitize terminal text, but their contracts differ materially.
+
+Pi Fleet preserves newlines and expands tabs, Pi Chat replaces unsafe sequences while preserving transcript layout, Pi Subagents combines sanitization with redaction and byte limits, and Pi GitHub PR intentionally creates safe OSC 8 links.
+
+Pi TUI Kit already sanitizes its declarative screens internally, but its internal `safeMenuText()` and `replaceTerminalControls()` normalize whitespace and individual controls for menu presentation rather than implementing the exact Statusline and Starship policy.
+
+The duplicated pair is sufficient evidence to qualify one narrow display-boundary API, but it is not evidence for a universal text, redaction, path, truncation, or hyperlink framework.
+
+## Architecture
+
+The candidate API accepts untrusted text and returns display-only text.
+
+Raw model IDs, paths, URLs, action IDs, persisted values, and domain payloads remain unchanged and never round-trip through the sanitizer.
+
+The qualification phase must choose and document exact behavior for complete CSI, OSC, DCS, APC, and unterminated sequences; C0 and C1 controls; tabs; CR and LF; Unicode separators; bidi controls; malformed surrogate input; and printable Unicode.
+
+The first public contract should be one single-line display policy unless the consumer matrix proves a second multiline policy is independently necessary.
+
+Cell-aware wrapping and truncation remain owned by Pi TUI's `visibleWidth()` and `truncateToWidth()` rather than the sanitizer.
+
+The Kit API pull request, package release, Statusline migration, and Starship migration remain separate, dependency-ordered changes.
+
+## Non-Goals
+
+- Do not add redaction, secret masking, byte or line limits, path contraction, URL validation, OSC 8 construction, error wording, or logging policy.
+- Do not mutate raw payloads or use sanitized text as a filesystem path, stable ID, action value, persistence value, or network value.
+- Do not replace package-specific multiline transcript policies whose replacement characters or whitespace semantics differ.
+- Do not deep-import Pi implementation files or duplicate a stable root-exported Pi function if the qualification finds an exact public owner.
+- Do not release the Kit API and its first consumer in the same publication step.
+- Do not publish, create tags, change visibility, or dispatch a release workflow without explicit user approval.
+
+## Risks
+
+- Stripping only the ESC byte can leave attacker-controlled sequence payload visible, while stripping too much can remove legitimate neighboring text.
+- Replacing line controls with spaces versus deleting them changes footer and path presentation and can create accidental token concatenation.
+- Removing bidi controls improves visual trust but changes the current duplicate contract and therefore requires an explicit compatibility decision.
+- Sanitizing before versus after path contraction can affect both display safety and recognizable path output.
+- A broad helper can attract incompatible transcript, redaction, and hyperlink responsibilities and become harder to evolve safely.
+- A local workspace can hide an unpublished or incompatible Kit dependency, so clean registry installation is a mandatory release gate.
+
+## Rollback / Recovery
+
+The Kit addition must be additive so consumer migrations can be reverted independently without removing the published export.
+
+If a migrated consumer exposes a compatibility problem, restore its local sanitizer and prior dependency floor while retaining the additive Kit API until a separately approved deprecation decision.
+
+No persisted data migration or rollback is required because sanitization occurs only at the display boundary.
+
+## Plan
+
+### Phase 1: Contract qualification
+
+- [ ] Inventory every call site and focused test for the Statusline and Starship duplicate sanitizer; record whether each value is a path, model ID, symbol, metadata value, or already-formatted line.
+- [ ] Compare the duplicate policy with Pi TUI root exports, Node's terminal-control utilities, and Pi TUI Kit's internal text functions; select an existing public owner if and only if its exact behavior and compatibility floor match.
+- [ ] Build a behavior matrix covering printable Unicode, combining marks, emoji, tabs, CR, LF, C0 and C1 controls, CSI, OSC, DCS, APC, ST and BEL terminators, unterminated sequences, Unicode separators, bidi controls, and adjacent safe text.
+- [ ] Run the matrix against both duplicate implementations and their real formatting call sites; record every current difference or missing test before choosing a public contract.
+- [ ] Decide whether one single-line function is sufficient, choose its stable name and replacement policy, and record a finite no-go instead of adding an API if the two consumers do not share the same required behavior.
+- [ ] Map the selected contract to terminal-safety, width, package, Changeset, and release MUST rules from `docs/extension-conventions.md` and identify focused verification for each rule.
+
+### Phase 2: Kit-only API
+
+- [ ] Add failing package-root type and runtime tests for the qualified sanitizer contract, including malicious complete and unterminated terminal sequences and printable Unicode preservation.
+- [ ] Add failing width-boundary composition tests proving sanitized output remains safe when consumers subsequently use Pi TUI cell-aware truncation.
+- [ ] Implement the smallest stateless sanitizer in a descriptive Pi TUI Kit module and export only the qualified function and required type, if any, from `packages/pi-tui-kit/src/index.ts`.
+- [ ] Reuse the new function internally only where exact existing Kit behavior is characterized as compatible; leave `safeMenuText()` and exact-document formatting unchanged where whitespace or multiline semantics differ.
+- [ ] Make an explicit compatibility-literal decision for `PI_EXTENSION_MENU_API_VERSION`; do not increment a menu-definition marker mechanically for an unrelated utility export.
+- [ ] Update the Kit README with the display-only trust boundary, examples, exclusions, and guidance to keep raw IDs and payloads separate.
+- [ ] Add a Kit-only minor Changeset and verify that no consumer source or dependency floor uses the unpublished export.
+- [ ] Run the complete Kit tests and check, the runtime import benchmark, `npm run check:boundaries`, `npm run check`, `git diff --check`, and `just pack tui-kit` sequentially; inspect root runtime and declaration exports in the tarball.
+- [ ] Audit the final Kit diff for escape-parser bounds, malformed input, memory behavior on large strings, zero private imports, and unchanged existing menu rendering.
+
+### Release gate
+
+- [ ] Obtain explicit user approval before performing any publication, tag, visibility, or release-workflow action.
+- [ ] Verify the approved Kit release with `npm view`, registry tarball inspection, and a clean temporary installation that imports the sanitizer from runtime JavaScript and declarations.
+- [ ] Record the registry-visible compatibility floor before changing either consumer manifest.
+
+### Phase 3: Statusline consumer
+
+- [ ] Create a Statusline-only branch from then-current `origin/main`, add characterization tests for every real call-site class, and verify the existing package baseline.
+- [ ] Raise only Statusline's Kit floor to the registry-verified release, refresh the root lockfile, and prove the consumer scope resolves the intended version before typechecking.
+- [ ] Replace the local sanitizer with the published Kit export while preserving model, symbol, directory, path fallback, width, and terminal-control presentation.
+- [ ] Delete only the superseded local module and imports, and retain raw path and model values for all non-display behavior.
+- [ ] Add the appropriate Statusline Changeset, then run focused tests, the package check, dependency-resolution verification, `npm run check:boundaries`, `npm run check`, `git diff --check`, and `just pack statusline`.
+- [ ] Exercise a practical local Pi footer smoke with malicious model or path display text when possible and record any unverified provider-controlled path.
+
+### Phase 4: Starship consumer
+
+- [ ] Create a Starship-only branch from then-current `origin/main`, add characterization tests for every model and directory call-site class, and verify the existing package baseline.
+- [ ] Raise only Starship's Kit floor when its current range does not already include the registry-verified release, refresh the lockfile if needed, and prove resolved compatibility before typechecking.
+- [ ] Replace the duplicate module with the published Kit export while preserving contracted paths, repository-relative paths, full-path metadata, model symbols, width, and terminal-control presentation.
+- [ ] Delete only the superseded local module and imports, and retain raw values for filesystem, settings, template, and action behavior.
+- [ ] Add the appropriate Starship Changeset, then run focused tests, the package check, dependency-resolution verification, `npm run check:boundaries`, `npm run check`, `git diff --check`, and `just pack starship`.
+- [ ] Exercise a practical local Pi Starship smoke with malicious model or path display text when possible and record any unverified provider-controlled path.
+
+### Phase 5: Follow-up boundary
+
+- [ ] Reassess Fleet, Chat, Subagents, GitHub PR, and other sanitizer implementations against the published contract; record compatible future migrations or explicit semantic no-go reasons without widening the API.
+- [ ] Update the roadmap decision record with the verified API, proof consumers, release ordering, retained specialized policies, and any accepted compatibility change.
+- [ ] Complete a final cross-package audit proving that sanitization remains at display boundaries and no raw identity, persistence, path, URL, or domain behavior changed.
+
+## Completion Checklist
+
+- [ ] One exact terminal display policy is qualified by at least two compatible consumers or the proposal ends with a finite no-go.
+- [ ] Any new Kit export is additive, documented, terminal-safe, independently published, registry-verified, and covered through runtime plus declaration tests.
+- [ ] Statusline and Starship adopt only a published compatible API and preserve their user-visible output contract or document an explicitly approved change.
+- [ ] Incompatible multiline, redaction, byte-bound, path, and hyperlink policies remain package-owned.
+- [ ] Every package change has focused tests, semantic audit evidence, package checks, root gates, and inspected tarballs.
+- [ ] No publication or release workflow occurs without explicit user approval.
+- [ ] The plan is archived only after all accepted implementation, release, and consumer tasks have evidence.

--- a/docs/roadmaps/pi-tui-kit-roadmap.md
+++ b/docs/roadmaps/pi-tui-kit-roadmap.md
@@ -1,17 +1,11 @@
 # Pi TUI Kit Roadmap
 
-- **Status:** Source API 9 live-choice capability is complete and verified; publication and
-  post-publication consumer migrations remain gated; searchable single-choice remains a future
-  evidence-gated candidate
-- **Audience:** Pi TUI Kit maintainers and extension authors
-- **Planning horizon:** The reviewed Pi 0.84.1 capability baseline; no delivery dates are committed
-- **Repository source:** API version 9 adds standalone live choice, generic interaction hints, and
-  shared choice selection behavior to the API-8 confirmation, browse, custom-interaction, adaptive
-  review, distinct Back/Close, disabled-action, and `/testing` foundations
-- **Published status:** API 8 is published; API 9 must publish independently before any consumer
-  raises its compatibility floor
-- **Migration evidence:** Maintained package/consumer tests and the stable PR references in the
-  decision log below
+- **Status:** Published API 11 and its proof migrations are complete; the next work is existing-contract convergence, terminal-display safety qualification, and evidence-gated searchable choice.
+- **Audience:** Pi TUI Kit maintainers and extension authors.
+- **Planning horizon:** The installed Pi 0.84.1 capability baseline; no delivery dates are committed.
+- **Repository source:** API 11 includes eight declarative screens, standalone task, confirmation, live-choice and custom-interaction lifecycles, exact browse documents, confirmation-only live-choice gating, interaction hints, and the supported `/testing` entrypoint.
+- **Published status:** The current registry release exposes API 11; every future public API must still publish independently before consumer adoption.
+- **Migration evidence:** Maintained package and consumer tests plus the stable pull-request references in the decision log below.
 
 ## Vision
 
@@ -49,54 +43,48 @@ handling.
 
 ## Current State
 
-The maintained package exposes eight declarative screen kinds: `actions`, `detail`, `browse`,
-`choice`, `settings`, `input`, `review`, and `multiSelect`. Source API 9 also exposes:
+The maintained package exposes eight declarative screen kinds: `actions`, `detail`, `browse`, `choice`, `settings`, `input`, `review`, and `multiSelect`.
+
+Published API 11 also exposes:
 
 - `runTask()` for abort-aware work with a TUI loader;
 - `runConfirmation()` for distinct Confirmed, Back, Close, Stale, Unsupported, and Error outcomes;
-- `runLiveChoice()` for initial and cursor preview callbacks, typed selection/shortcut/exit outcomes,
-  lifecycle draining, and deterministic ordinary RPC selection;
+- `runLiveChoice()` for initial and cursor preview callbacks, typed selection, shortcut and exit outcomes, confirmation-only gating, lifecycle draining, and deterministic ordinary RPC selection;
 - `formatInteractionHints()` for sanitized injected bindings and literal shortcuts;
-- `runCustomInteraction()` for lifecycle ownership around one extension-owned specialized
-  component; and
+- `runCustomInteraction()` for lifecycle ownership around one extension-owned specialized component; and
 - a supported `/testing` subpath for semantic TUI driving and strict RPC scripts.
 
-Published API 8 includes distinct root Back/Close results, adaptive review, read-only browse,
-custom-interaction lifecycle handling, standalone confirmation, and explanatory disabled action
-rows. Source API 9 adds live choice and hint formatting without changing declarative `choice`
-cursor semantics. The internal interaction driver owns shared semantic action coordination once for
-both modes while adapters retain TUI component and RPC dialog cadence.
+API 10 added exact whitespace-sensitive browse detail documents through the review formatter without making document content implicitly searchable.
 
-Representative migrations prove the shipped boundaries: Usage uses `runTask()`; Stamp uses
-validated input; Image Drop composes input, review, and confirmation; Starship uses read-only browse;
-Pi Sync uses custom-interaction lifecycle ownership; and Analytics uses confirmation. These consumers
-retain domain state, validation, persistence, rollback, and session ownership. The supported testing
-subpath is proven through Stamp and Image Drop.
+API 11 added confirmation-only live-choice gating so a primary action can remain inert while safe shortcuts stay available.
 
-Deferred multi-select qualification admitted no Kit transaction API because Pi Sync and Subagents do
-not share Save/Discard cadence, review, persistence, conflict recovery, or RPC behavior. The direct
-dialog inventory likewise admitted no new API: one-off values use Pi primitives, setup and
-authentication sequences remain domain transactions, boolean confirmation stays direct unless richer
-outcomes are required, and multi-line editing remains extension-owned.
+The internal interaction driver owns shared semantic action coordination once for TUI and RPC, while adapters retain their presentation cadence.
 
-The original Pi 0.84.1 review found no additional Kit capability to admit or shipped screen to
-retire. Subsequent Starship preset work converged with Statusline's palette picker on a bounded live
-choice contract: initial/cursor preview, Enter confirmation, Back/Close distinction, owner
-cancellation, and consumer-owned snapshot restoration. Optional shortcut dispatch covers Starship's
-customize route without absorbing its save/apply transaction. Action-bearing async catalogs,
-reorderable lists, forms, and editors remain unqualified. Public `Input`, `SelectList`,
-`SettingsList`, and `ScrollView` remain useful low-level building blocks but do not own the Kit's
-cross-mode, cancellation, navigation, rollback, or stale-owner policy.
+Representative migrations prove the shipped boundaries: Usage uses `runTask()`, Stamp uses validated input, Image Drop composes input, review and confirmation, Sync uses custom-interaction lifecycle ownership, Statusline and Starship use live choice, and Tool uses exact browse documents.
 
-Production and experimental consumers continue to use the Kit alongside direct Pi dialogs. Raw
-consumer and dialog counts are intentionally not pinned because they change independently of roadmap
-outcomes; the stable admission rule is compatible lifecycle evidence, not call volume.
+These consumers retain domain state, validation, persistence, rollback, preview snapshots, final apply policy, and session ownership.
 
-The current Kit has no searchable single-choice interaction equivalent to Pi's `/resume` selector.
-Declarative `choice` confirms a bounded static item without search, while `browse` searches read-only
-items and opens details instead of returning a selected item. Pi-btw will initially use `choice` for
-its session-local in-memory thread list; that consumer provides evidence for a future generic picker
-but does not by itself waive the normal two-consumer admission gate.
+The supported testing subpath is proven across menu, lifecycle, resize, disposal, and strict RPC tests in multiple consumers.
+
+A 2026-08-13 static inventory found that 25 active extensions use `runMenu()`, while remaining direct custom hosts mix reusable lifecycle ownership with specialized OAuth, chat, explorer, composer, preview, and loader semantics.
+
+Direct call count is not an admission or migration criterion.
+
+Image Drop's loader currently distinguishes Escape Back from Ctrl+C Close, while `runTask()` returns one user-cancelled outcome, so that flow is not a behavior-preserving migration under the present contract.
+
+Deferred multi-select qualification admitted no Kit transaction API because Sync and Subagents do not share Save/Discard cadence, review, persistence, conflict recovery, or RPC behavior.
+
+One-off values continue to use Pi primitives, setup and authentication remain domain transactions, and multi-line editing remains extension-owned while Pi's editor dialog lacks `AbortSignal` support.
+
+Public Pi `Input`, `SelectList`, `SettingsList`, `ScrollView`, overlays, statuses, widgets, footers, and editor replacement remain lower-level or host-owned capabilities that the Kit should not duplicate without a complete cross-mode lifecycle contract.
+
+The current Kit still has no searchable single-choice interaction.
+
+Declarative `choice` confirms a bounded static item without search, while `browse` searches read-only items and opens details instead of returning a selected item.
+
+Pi BTW Resume is the first concrete candidate, and Worktree, Recall, or Chat can qualify as a second proof consumer only when evidence shows the same search job without scope, delete, preview, persistence, or tree semantics.
+
+Execution is decomposed into the active existing-contract convergence, terminal-display safety, and searchable-choice plans under `docs/plans/`.
 
 ## Guiding Principles
 
@@ -279,55 +267,73 @@ abstractions when Pi provides a better stable owner.
 
 ### Phase 6: Bounded Live Choice
 
-**Status:** Source complete and verified as API 9; publication and consumer adoption remain gated.
+**Status:** Complete and published.
 
 **Milestones:**
 
-- [x] Statusline palette selection and Starship preset selection demonstrate a compatible bounded
-  contract: initial and cursor preview, injected navigation, Enter confirmation, Back/Close,
-  stale-owner protection, and consumer-owned restoration and persistence.
-- [x] Source API 9 exposes `runLiveChoice()` with current/disabled rows, optional shortcuts, synchronous
-  preview immediacy, latest-selection coalescing for pending async previews, cancellation/disposal
-  draining, typed terminal outcomes, and ordinary signal-aware RPC selection without preview effects.
-- [x] One internal stable-ID selection controller owns wrap, paging, Home/End, and empty-list behavior
-  for declarative and live choices without making declarative cursor movement side-effecting.
-- [x] `formatInteractionHints()` owns injected-binding lookup, aliases, control sanitization,
-  exclusions, de-duplication, literal shortcuts, and separator policy; existing Kit menu and browse
-  hints consume it.
-- [x] API-root type tests, TUI/RPC/lifecycle coverage, the repository gate, and dry-run package
-  inspection verify the source contract and Kit-only release intent.
-- [ ] Publish API 9 through the independent Changesets release before raising a consumer's Kit floor.
-- [ ] After publication, migrate Statusline and Starship in independently reviewable consumer changes
-  that remove local selection/hint loops while preserving preview snapshots, rollback, settings,
-  confirmation, collectors, and session-generation ownership.
+- [x] Statusline palette selection and Starship preset selection demonstrated a compatible bounded contract with initial and cursor preview, injected navigation, confirmation, Back, Close, stale-owner protection, and consumer-owned restoration and persistence.
+- [x] API 9 published `runLiveChoice()` with current and disabled rows, optional shortcuts, synchronous preview immediacy, latest-selection coalescing, cancellation and disposal draining, typed terminal outcomes, and ordinary signal-aware RPC selection without preview effects.
+- [x] One internal stable-ID selection controller owns wrap, paging, Home, End, and empty-list behavior for declarative and live choices without making declarative cursor movement side-effecting.
+- [x] `formatInteractionHints()` owns injected-binding lookup, aliases, control sanitization, exclusions, de-duplication, literal shortcuts, and separator policy.
+- [x] Statusline and Starship adopted the published contract in separate consumer changes while retaining preview snapshots, rollback, settings, confirmation, collectors, and session-generation ownership.
 
-**Outcome:** The source contract concentrates reusable cursor-selection and lifecycle policy. Once
-published and proven by both consumers, live preview pickers can delete duplicate interaction code
-without turning the Kit into a preview-state or transaction owner.
+**Outcome:** Reusable cursor-selection and lifecycle policy is published and proven without making the Kit a preview-state or transaction owner.
 
-### Phase 7: Searchable Single Choice
+### Phase 7: Exact Documents and Confirmation Gating
 
-**Status:** Proposed and evidence-gated.
+**Status:** Complete and published.
 
 **Milestones:**
 
-- [ ] Pi-btw's in-memory Resume picker and at least one compatible consumer, or an explicit recorded
-  exception, demonstrate the same searchable single-choice lifecycle and mode contract.
-- [ ] A public contract returns a raw stable item ID on confirmation while keeping labels, metadata,
-  search text, ordering, and domain state consumer-owned.
-- [ ] TUI presentation follows the useful parts of Pi `/resume`: visible fuzzy search, a bounded
-  one-line list, consumer-supplied primary labels, right-aligned textual metadata, preservation of
-  consumer-provided recent-first ordering, IME focus, injected navigation, Enter selection, Escape
-  Back, and Ctrl+C Close.
-- [ ] RPC degrades to deterministic signal-aware ordinary selection without claiming an unsupported
-  interactive search protocol; print and JSON remain explicitly unsupported.
-- [ ] Focused tests prove filtering, stable selection, no-match and empty states, sanitization, narrow
-  widths, resize, disposal, owner replacement, stale continuations, and exact terminal outcomes.
-- [ ] Publish the Kit API independently before any consumer raises its compatibility floor.
+- [x] API 10 added exact browse detail documents with shared text, code, and diff formatting, terminal-safe hard wrapping, deterministic RPC pagination, and no implicit document-content search.
+- [x] Tool adopted exact browse details after publication and removed its duplicate browser while retaining catalog state, ordering, metadata projection, and domain ownership.
+- [x] API 11 added confirmation-only live-choice gating with full-disabled precedence and explanatory TUI and RPC presentation.
+- [x] Starship adopted confirmation-only gating after publication so the active preset rejects Apply while Customize remains available.
+- [x] Every API and consumer change remained independently releasable and passed focused lifecycle, width, terminal-safety, package, and repository gates.
 
-**Outcome:** Extensions can present searchable in-memory or domain-owned records with a Pi-familiar
-selection experience without pretending those records are Pi sessions or inheriting filesystem and
-session-management behavior.
+**Outcome:** Exact document disclosure and bounded live-choice action gating are standard contracts with completed proof migrations.
+
+### Phase 8: Existing Contract Convergence
+
+**Status:** Planned through `docs/plans/2026-08-13_pi-tui-kit-existing-contract-convergence-plan.md`.
+
+**Milestones:**
+
+- [ ] Classify every remaining direct custom host by exact lifecycle and domain behavior instead of raw call count.
+- [ ] Adopt `runCustomInteraction()` in Starship preview actions and File Context exploration only if characterization proves Back, Close, stale, disposal, pending-work, and error compatibility.
+- [ ] Replace repository test-host ownership with `@narumitw/pi-tui-kit/testing` only where specialized observations remain intact.
+- [ ] Keep Image Drop's loader and every other incompatible flow local with an explicit no-go until a published contract preserves its terminal outcomes.
+- [ ] Record deleted ownership, retained specialized owners, checks, smokes, and semantic audits without setting a numeric migration target.
+
+**Outcome:** Existing public contracts remove proven duplicate lifecycle code while specialized UI and domain behavior remain extension-owned.
+
+### Phase 9: Shared Terminal Display Safety
+
+**Status:** Proposed and evidence-gated through `docs/plans/2026-08-13_pi-tui-kit-terminal-display-safety-plan.md`.
+
+**Milestones:**
+
+- [ ] Statusline and Starship prove one exact display-only sanitizer contract across complete terminal sequences, controls, whitespace, Unicode, paths, model labels, and symbols.
+- [ ] The qualification chooses an existing public Pi owner when exact behavior fits or adds one narrow Kit export without absorbing redaction, truncation, path, URL, hyperlink, or logging policy.
+- [ ] Any new Kit export publishes and passes registry clean-install verification before either consumer raises its compatibility floor.
+- [ ] Statusline and Starship complete separate proof migrations while raw paths, model IDs, settings, and action values remain untouched.
+- [ ] Fleet, Chat, Subagents, GitHub PR, and other incompatible text policies retain explicit package ownership.
+
+**Outcome:** Compatible display boundaries share one tested sanitizer without creating a universal text-processing framework.
+
+### Phase 10: Searchable Single Choice
+
+**Status:** Proposed and evidence-gated through `docs/plans/2026-08-13_pi-tui-kit-searchable-choice-plan.md`.
+
+**Milestones:**
+
+- [ ] Pi BTW Resume and at least one independent compatible consumer demonstrate the same user need for searchable stable-ID confirmation.
+- [ ] An approved additive contract returns a raw stable item ID while keeping labels, descriptions, explicit search text, ordering, loading, and domain state consumer-owned.
+- [ ] TUI search covers IME focus, no-match and empty states, disabled explanations, rejected retries, pasted controls, narrow widths, resize, Back, Close, owner replacement, and disposal.
+- [ ] RPC remains one deterministic unfiltered signal-aware selector, while print and JSON retain explicit unsupported behavior.
+- [ ] The Kit API publishes independently before two separate proof migrations, or qualification records a finite no-go before implementation.
+
+**Outcome:** Extensions can confirm searchable in-memory or domain-owned records without importing Pi session, filesystem, scope, delete, tree, or persistence semantics.
 
 ## Technical Health
 
@@ -376,8 +382,8 @@ session-management behavior.
 - **Preview continuation races:** a slow preview may finish after a newer cursor, owner replacement, or
   exit. Mitigation: keep one drained latest-selection queue, abort through the interaction signal,
   revalidate generation after awaits, and require consumers to honor the callback signal.
-- **Premature consumer adoption:** source API 9 is not yet a published compatibility floor.
-  Mitigation: publish the Kit-only Changeset first, then migrate consumers in later PRs.
+- **Premature consumer adoption:** a workspace can resolve an unpublished or newer local Kit API than an independently installed extension.
+  Mitigation: publish each Kit-only Changeset first, verify the registry tarball and clean installation, then migrate consumers in later pull requests.
 - **Session-selector overreach:** copying Pi `/resume` too literally would pull session paths, folder
   scope, naming, deletion, and tree semantics into a generic picker.
   Mitigation: reuse only presentation and interaction evidence, keep raw IDs and domain mutation with
@@ -402,9 +408,12 @@ session-management behavior.
 | Specialized interaction pressure | Action-bearing and async catalogs, reorderable lists, forms, editors, and preview workflows beyond bounded choice have incompatible or single-consumer contracts | Keep each specialized until two consumers prove compatible reusable policy | Phase 5 baseline plus Phase 6 bounded-live-choice exception; re-open on new evidence |
 | Public Pi replacement pressure | Pi 0.84.1 exposes useful low-level TUI primitives but no equivalent Kit cross-mode composite | Retire a Kit screen when a stable public Pi owner provides the complete contract | Phase 5 review complete; re-run after Pi dependency upgrades |
 | Disabled action presentation | Disabled action rows could hide their state or truncate labels ambiguously | Published API 8 presents sanitized reasons and ellipsis-safe labels across TUI/RPC while keeping actions inert and raw identities stable | Phase 4 published; registry package, maintained component/runtime tests, and archived implementation plan |
-| Bounded live-choice ownership | Statusline and Starship repeated cursor navigation, preview dispatch, key hints, and exit handling | Source API 9 owns selection and lifecycle mechanics while consumers retain preview state, rollback, persistence, and final apply | Phase 6 source-complete; Kit TUI/RPC/lifecycle tests, repository gate, package dry run, and post-publication proof migrations |
-| Interaction-hint consistency | Kit and specialized pickers repeated binding lookup, aliases, exclusions, and sanitization | Source API 9 exposes one formatter and uses it for Kit menu, browse, and live-choice hints | Phase 6 source-complete; formatter and rendering tests |
-| Searchable single-choice ownership | `choice` has no search; `browse` cannot confirm and return an item | Admit a generic Pi-familiar picker only after compatible consumers prove raw-ID selection, search, lifecycle, and cross-mode boundaries | Phase 7 proposed; pi-btw in-memory Resume is the first evidence source |
+| Bounded live-choice ownership | Statusline and Starship repeated cursor navigation, preview dispatch, key hints, and exit handling | Published API 9 owns selection and lifecycle mechanics while consumers retain preview state, rollback, persistence, and final apply | Phase 6 complete; Kit lifecycle tests and separate Statusline and Starship proof migrations |
+| Interaction-hint consistency | Kit and specialized pickers repeated binding lookup, aliases, exclusions, and sanitization | Published API 9 exposes one formatter and uses it for Kit menu, browse, and live-choice hints | Phase 6 complete; formatter and rendering tests |
+| Exact browse documents | Legacy browse prose removed indentation and Tool owned a duplicate browser | Published API 10 preserves exact text, code, and diff details without implicit document search | Phase 7 complete; Kit formatter tests and Tool proof migration |
+| Existing custom lifecycle duplication | Direct custom hosts mix repeated wrapper ownership with specialized domain behavior | Migrate only behavior-compatible hosts to published lifecycle and testing contracts | Phase 8 planned; behavior matrices, focused migrations, and explicit no-go records |
+| Shared terminal display safety | Statusline and Starship duplicate one sanitizer while other packages use incompatible policies | Publish one narrow display-only contract only after exact two-consumer qualification | Phase 9 proposed; contract matrix, release gate, and separate proof migrations |
+| Searchable single-choice ownership | `choice` has no search and `browse` cannot confirm and return an item | Admit optional search only after two compatible consumers prove raw-ID selection, search, lifecycle, and cross-mode boundaries | Phase 10 proposed; Pi BTW Resume is the first evidence source |
 | Regression gate | Repository CI-equivalent gate at each capability change | No regression in the repository CI-equivalent gate | Every phase; `npm run check` |
 
 Delivery dates and capacity targets are unknown; this roadmap intentionally measures verified behavior
@@ -466,3 +475,7 @@ and adoption rather than calendar output.
 | 2026-08-08 | Complete Phase 5 capability and public-export review against Pi 0.84.1 without admitting or retiring an API. | Recall, File Context, Statusline, and Starship then demonstrated incompatible specialized catalog, preview, reorder, and transaction contracts; no maintained tree pair exists; Pi's editor remains non-abort-aware; and its public TUI controls remain lower-level than the Kit's cross-mode lifecycle contracts. Reassess after a Pi dependency upgrade or two compatible consumers provide new evidence. |
 | 2026-08-08 | Admit source API 9 bounded live choice after Starship preset selection converged with Statusline palette selection. | `runLiveChoice()` owns injected navigation, typed exits, optional shortcuts, RPC downgrade, stale checks, coalescing, disposal, and draining; a shared internal controller and public hint formatter remove repeated interaction mechanics. Preview snapshots, rollback, persistence, confirmation, and final apply remain consumer-owned. Publication must precede separate proof migrations. |
 | 2026-08-10 | Add searchable single choice as an evidence-gated future phase while pi-btw initially uses static `choice` for in-memory Resume. | Pi-btw needs Pi-familiar selection by first question and recent activity, but in-memory ownership is the immediate priority. The future Kit contract may borrow search and list presentation from Pi `/resume` without absorbing Pi session paths, scope, rename, delete, tree, or persistence semantics. |
+| 2026-08-10 | Publish API 10 exact browse detail documents and complete the Tool proof migration. | Review and browse now share exact terminal-safe document formatting, while Tool removed duplicate browser ownership and kept document content out of implicit search. |
+| 2026-08-10 | Publish API 11 live-choice confirmation gating and complete Statusline and Starship live-choice adoption. | Full disabled state still blocks every action, confirmation-only gating keeps safe shortcuts available, and both consumers retain preview, rollback, persistence, and final apply policy. |
+| 2026-08-13 | Refresh the roadmap from the completed API-11 baseline and split future work into three executable plans. | Existing-contract convergence proceeds without a new API, terminal display safety requires exact two-consumer qualification, and searchable choice remains evidence-gated with an explicit UX approval and release boundary. |
+| 2026-08-13 | Keep Image Drop's loader local under the current `runTask()` contract. | Image Drop distinguishes Escape Back from Ctrl+C Close, while `runTask()` exposes one user-cancelled result, so a direct migration would lose an observable lifecycle outcome. |


### PR DESCRIPTION
## Summary

- update the Pi TUI Kit roadmap from the published API 11 baseline
- record completed live-choice, exact-document, and confirmation-gating work
- add executable plans for existing-contract convergence, terminal display safety, and searchable choice

## Verification

- `npm run check`
- `git diff --check`
- roadmap plan-link existence check
