### PR TITLE
refactor(starship): reuse custom interaction lifecycle

### DIFF
--- a/packages/pi-starship/src/command-preview.ts
+++ b/packages/pi-starship/src/command-preview.ts
@@ -1,6 +1,7 @@
 import { stripVTControlCharacters } from "node:util";
 import type { ExtensionCommandContext, KeybindingsManager } from "@earendil-works/pi-coding-agent";
 import { Key, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { runCustomInteraction } from "@narumitw/pi-tui-kit";
 
 const RESERVED_HOST_ROWS = 3;
 
@@ -20,107 +21,104 @@ export async function showPreviewActionMenu<Value extends string>(
 	body: (width: number) => readonly string[],
 	items: readonly PreviewMenuItem<Value>[],
 	signal?: AbortSignal,
+	isCurrent: () => boolean = () => !signal?.aborted,
 ): Promise<PreviewMenuResult<Value> | undefined> {
-	if (signal?.aborted) return { kind: "closed" };
-	return ctx.ui.custom<PreviewMenuResult<Value> | undefined>((tui, theme, keybindings, done) => {
-		let selectedIndex = 0;
-		let scrollOffset = 0;
-		let lastMaximumScroll = 0;
-		let lastViewportSize = 1;
-		let disposed = false;
-		let deferredAbort: ReturnType<typeof setImmediate> | undefined;
-		const closeForAbort = () => {
-			if (disposed) return;
-			if (deferredAbort) clearImmediate(deferredAbort);
-			deferredAbort = undefined;
-			done({ kind: "closed" });
-		};
-		signal?.addEventListener("abort", closeForAbort, { once: true });
-		if (signal?.aborted) deferredAbort = setImmediate(closeForAbort);
+	if (signal?.aborted || !isCurrent()) return { kind: "closed" };
+	const result = await runCustomInteraction<PreviewMenuResult<Value>>(ctx, {
+		signal,
+		isCurrent,
+		create: ({ tui, theme, keybindings, complete }) => {
+			let selectedIndex = 0;
+			let scrollOffset = 0;
+			let lastMaximumScroll = 0;
+			let lastViewportSize = 1;
+			let disposed = false;
 
-		const requestRender = () => {
-			if (!disposed) tui.requestRender();
-		};
-		const moveSelection = (delta: number) => {
-			if (items.length === 0) return;
-			selectedIndex = (selectedIndex + delta + items.length) % items.length;
-			requestRender();
-		};
-		const movePreview = (offset: number) => {
-			scrollOffset = Math.max(0, Math.min(offset, lastMaximumScroll));
-			requestRender();
-		};
+			const requestRender = () => {
+				if (!disposed) tui.requestRender();
+			};
+			const moveSelection = (delta: number) => {
+				if (items.length === 0) return;
+				selectedIndex = (selectedIndex + delta + items.length) % items.length;
+				requestRender();
+			};
+			const movePreview = (offset: number) => {
+				scrollOffset = Math.max(0, Math.min(offset, lastMaximumScroll));
+				requestRender();
+			};
 
-		return {
-			render(width: number): string[] {
-				const safeWidth = Math.max(1, width);
-				const terminalRows = Number.isFinite(tui.terminal.rows)
-					? Math.floor(tui.terminal.rows)
-					: 24;
-				const availableRows = Math.max(1, terminalRows - RESERVED_HOST_ROWS);
-				const bodyLines = body(safeWidth).flatMap((line) =>
-					line ? wrapTextWithAnsi(line, safeWidth) : [""],
-				);
-				const layout = allocateLayout(availableRows, items.length, bodyLines.length);
-				lastViewportSize = layout.previewRows;
-				lastMaximumScroll = Math.max(0, bodyLines.length - layout.previewRows);
-				scrollOffset = Math.max(0, Math.min(scrollOffset, lastMaximumScroll));
-				const actionStart = actionWindowStart(selectedIndex, items.length, layout.actionRows);
-				const actionLines = items
-					.slice(actionStart, actionStart + layout.actionRows)
-					.map((item, index) => {
-						const absoluteIndex = actionStart + index;
-						const prefix = absoluteIndex === selectedIndex ? "→ " : "  ";
-						return theme.fg(
-							absoluteIndex === selectedIndex ? "accent" : "text",
-							`${prefix}${safeDisplayText(item.label)}`,
-						);
-					});
-				const position = layout.positionRows
-					? [theme.fg("dim", previewPosition(scrollOffset, layout.previewRows, bodyLines.length))]
-					: [];
-				const lines = [
-					...(layout.titleRows ? [theme.fg("accent", theme.bold(safeDisplayText(title)))] : []),
-					...bodyLines.slice(scrollOffset, scrollOffset + layout.previewRows),
-					...position,
-					...actionLines,
-					...(layout.hintRows ? [theme.fg("dim", previewHint(keybindings))] : []),
-				];
-				return lines.map((line) => truncateToWidth(line, safeWidth, ""));
-			},
-			invalidate() {},
-			handleInput(data: string) {
-				if (disposed) return;
-				if (matchesKey(data, Key.ctrl("c"))) {
-					done({ kind: "closed" });
-				} else if (keybindings.matches(data, "tui.select.cancel")) {
-					done({ kind: "cancelled" });
-				} else if (keybindings.matches(data, "tui.select.up")) {
-					moveSelection(-1);
-				} else if (keybindings.matches(data, "tui.select.down")) {
-					moveSelection(1);
-				} else if (keybindings.matches(data, "tui.select.pageUp")) {
-					movePreview(scrollOffset - lastViewportSize);
-				} else if (keybindings.matches(data, "tui.select.pageDown")) {
-					movePreview(scrollOffset + lastViewportSize);
-				} else if (matchesKey(data, Key.home)) {
-					movePreview(0);
-				} else if (matchesKey(data, Key.end)) {
-					movePreview(lastMaximumScroll);
-				} else if (keybindings.matches(data, "tui.select.confirm")) {
-					const item = items[selectedIndex];
-					if (item) done({ kind: "selected", value: item.value });
-				}
-			},
-			dispose() {
-				if (disposed) return;
-				disposed = true;
-				if (deferredAbort) clearImmediate(deferredAbort);
-				deferredAbort = undefined;
-				signal?.removeEventListener("abort", closeForAbort);
-			},
-		};
+			return {
+				render(width: number): string[] {
+					const safeWidth = Math.max(1, width);
+					const terminalRows = Number.isFinite(tui.terminal.rows)
+						? Math.floor(tui.terminal.rows)
+						: 24;
+					const availableRows = Math.max(1, terminalRows - RESERVED_HOST_ROWS);
+					const bodyLines = body(safeWidth).flatMap((line) =>
+						line ? wrapTextWithAnsi(line, safeWidth) : [""],
+					);
+					const layout = allocateLayout(availableRows, items.length, bodyLines.length);
+					lastViewportSize = layout.previewRows;
+					lastMaximumScroll = Math.max(0, bodyLines.length - layout.previewRows);
+					scrollOffset = Math.max(0, Math.min(scrollOffset, lastMaximumScroll));
+					const actionStart = actionWindowStart(selectedIndex, items.length, layout.actionRows);
+					const actionLines = items
+						.slice(actionStart, actionStart + layout.actionRows)
+						.map((item, index) => {
+							const absoluteIndex = actionStart + index;
+							const prefix = absoluteIndex === selectedIndex ? "→ " : "  ";
+							return theme.fg(
+								absoluteIndex === selectedIndex ? "accent" : "text",
+								`${prefix}${safeDisplayText(item.label)}`,
+							);
+						});
+					const position = layout.positionRows
+						? [theme.fg("dim", previewPosition(scrollOffset, layout.previewRows, bodyLines.length))]
+						: [];
+					const lines = [
+						...(layout.titleRows ? [theme.fg("accent", theme.bold(safeDisplayText(title)))] : []),
+						...bodyLines.slice(scrollOffset, scrollOffset + layout.previewRows),
+						...position,
+						...actionLines,
+						...(layout.hintRows ? [theme.fg("dim", previewHint(keybindings))] : []),
+					];
+					return lines.map((line) => truncateToWidth(line, safeWidth, ""));
+				},
+				invalidate() {},
+				handleInput(data: string) {
+					if (disposed) return;
+					if (matchesKey(data, Key.ctrl("c"))) {
+						complete({ kind: "closed" });
+					} else if (keybindings.matches(data, "tui.select.cancel")) {
+						complete({ kind: "cancelled" });
+					} else if (keybindings.matches(data, "tui.select.up")) {
+						moveSelection(-1);
+					} else if (keybindings.matches(data, "tui.select.down")) {
+						moveSelection(1);
+					} else if (keybindings.matches(data, "tui.select.pageUp")) {
+						movePreview(scrollOffset - lastViewportSize);
+					} else if (keybindings.matches(data, "tui.select.pageDown")) {
+						movePreview(scrollOffset + lastViewportSize);
+					} else if (matchesKey(data, Key.home)) {
+						movePreview(0);
+					} else if (matchesKey(data, Key.end)) {
+						movePreview(lastMaximumScroll);
+					} else if (keybindings.matches(data, "tui.select.confirm")) {
+						const item = items[selectedIndex];
+						if (item) complete({ kind: "selected", value: item.value });
+					}
+				},
+				dispose() {
+					if (disposed) return;
+					disposed = true;
+				},
+			};
+		},
 	});
+	if (result.kind === "completed") return result.value;
+	if (result.kind === "error") throw result.error;
+	if (result.kind === "stale" && (signal?.aborted || !isCurrent())) return { kind: "closed" };
+	return undefined;
 }
 
 interface PreviewLayout {

--- a/packages/pi-starship/src/commands.ts
+++ b/packages/pi-starship/src/commands.ts
@@ -300,6 +300,7 @@ async function editSettings(
 					{ value: PREVIEW_ACTIONS.cancel, label: "Discard draft" },
 				],
 				owner.signal,
+				owner.isCurrent,
 			);
 			if (!isCurrentOwner(owner)) return "cancel";
 			if (action?.kind === "closed") return "close";
@@ -384,6 +385,7 @@ async function applyPreset(
 					{ value: PREVIEW_ACTIONS.cancel, label: "Choose another preset" },
 				],
 				owner.signal,
+				owner.isCurrent,
 			);
 			if (!isCurrentOwner(owner)) return "cancel";
 			if (action?.kind === "closed") return "close";
@@ -461,6 +463,7 @@ async function reviewAndApply(
 					},
 				],
 				owner.signal,
+				owner.isCurrent,
 			);
 			if (!isCurrentOwner(owner)) return "cancel";
 			if (selection?.kind === "closed") return "close";

--- a/packages/pi-starship/test/commands.test.ts
+++ b/packages/pi-starship/test/commands.test.ts
@@ -6,12 +6,21 @@ import { initTheme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
-import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerStarshipCommand } from "../src/commands.js";
 import { BUILT_IN_EXAMPLE, loadStarshipConfig, settingsFilePath } from "../src/config.js";
 import piStarshipRuntime from "../src/pi-starship.js";
 
 initTheme("dark", false);
+
+async function driveTuiCustom(factory: unknown, inputs: readonly string[], width: number) {
+	const tui = createTuiHarness({ width, rows: 24 });
+	const running = (tui.custom as unknown as (customFactory: unknown) => Promise<unknown>)(factory);
+	await tui.waitForOpen();
+	const renders = [Array.from(tui.render())];
+	for (const input of inputs) renders.push(Array.from(tui.send(input)));
+	return { renders, result: await running };
+}
 
 function piStarship(pi: Parameters<typeof piStarshipRuntime>[0]) {
 	return piStarshipRuntime(pi, {
@@ -50,7 +59,7 @@ test("/starship keeps direct routes and opens a stateful narrow TUI menu", async
 		mode: "tui",
 		hasUI: true,
 		custom: async (factory: unknown) => {
-			const driven = driveCustomSelector(factory, ["\u001b"], 28);
+			const driven = await driveTuiCustom(factory, ["\u001b"], 28);
 			renders.push(...driven.renders);
 			return driven.result;
 		},
@@ -137,7 +146,7 @@ test("settings opens the raw TOML in TUI, saves atomically, and applies immediat
 				return "format = 'saved'\n";
 			},
 			custom: async (factory: unknown) => {
-				const driven = driveCustomSelector(factory, ["\r"], 40);
+				const driven = await driveTuiCustom(factory, ["\r"], 40);
 				preview = driven.renders.flat().join("\n");
 				return driven.result;
 			},
@@ -191,7 +200,7 @@ test("preview failure remains explicit and offers edit or discard recovery", asy
 			hasUI: true,
 			editor: async () => "format = 'draft'\n",
 			custom: async (factory: unknown) => {
-				const driven = driveCustomSelector(factory, ["\u001b"], 60);
+				const driven = await driveTuiCustom(factory, ["\u001b"], 60);
 				preview = driven.renders.flat().join("\n");
 				return driven.result;
 			},
@@ -226,7 +235,7 @@ test("warning drafts remain applicable and report their warning count", async ()
 			mode: "tui",
 			hasUI: true,
 			editor: async () => "format = 'warning'\nfuture = true\n",
-			custom: async (factory: unknown) => driveCustomSelector(factory, ["\r"], 40).result,
+			custom: async (factory: unknown) => (await driveTuiCustom(factory, ["\r"], 40)).result,
 			confirm: async () => true,
 		});
 		await mock.commands.get("starship")?.handler("settings", context.ctx);
@@ -259,7 +268,7 @@ test("invalid and cancelled edits keep the old file and effective config", async
 			mode: "tui",
 			editor: async () => nextEdit,
 			custom: async (factory: unknown) => {
-				const driven = driveCustomSelector(factory, ["\u001b"], 40);
+				const driven = await driveTuiCustom(factory, ["\u001b"], 40);
 				invalidReview = driven.renders.flat().join("\n");
 				return driven.result;
 			},
@@ -306,7 +315,7 @@ test("save failures retain current state and report the error", async () => {
 			editor: async () => "format = 'new'\n",
 			custom: async (factory: unknown) => {
 				const inputs = previewCalls++ === 0 ? ["\r"] : ["\u001b"];
-				return driveCustomSelector(factory, inputs, 40).result;
+				return (await driveTuiCustom(factory, inputs, 40)).result;
 			},
 			confirm: async () => true,
 		});
@@ -342,7 +351,7 @@ test("runtime apply failures restore the previous file and effective configurati
 			editor: async () => "format = 'new'\n",
 			custom: async (factory: unknown) => {
 				const inputs = previewCalls++ === 0 ? ["\r"] : ["\u001b"];
-				return driveCustomSelector(factory, inputs, 36).result;
+				return (await driveTuiCustom(factory, inputs, 36)).result;
 			},
 			confirm: async () => true,
 		});
@@ -376,7 +385,7 @@ test("a failed first runtime apply restores the missing Starship settings file",
 			editor: async () => "format = 'new'\n",
 			custom: async (factory: unknown) => {
 				const inputs = previewCalls++ === 0 ? ["\r"] : ["\u001b"];
-				return driveCustomSelector(factory, inputs, 36).result;
+				return (await driveTuiCustom(factory, inputs, 36)).result;
 			},
 			confirm: async () => true,
 		});
@@ -417,7 +426,7 @@ test("a failed first runtime apply preserves settings replaced concurrently", as
 			editor: async () => "format = 'new'\n",
 			custom: async (factory: unknown) => {
 				const inputs = previewCalls++ === 0 ? ["\r"] : ["\u001b"];
-				return driveCustomSelector(factory, inputs, 36).result;
+				return (await driveTuiCustom(factory, inputs, 36)).result;
 			},
 			confirm: async () => true,
 		});
@@ -460,7 +469,7 @@ test("a failed Starship update preserves existing settings replaced before rollb
 			editor: async () => "format = 'new'\n",
 			custom: async (factory: unknown) => {
 				const inputs = previewCalls++ === 0 ? ["\r"] : ["\u001b"];
-				return driveCustomSelector(factory, inputs, 36).result;
+				return (await driveTuiCustom(factory, inputs, 36)).result;
 			},
 			confirm: async () => true,
 		});
@@ -578,7 +587,7 @@ test("preview and confirmation cancellation preserve the previous document and r
 			editor: async () => "format = 'new'\nfuture = 'preserved'\n",
 			custom: async (factory: unknown) => {
 				customCalls += 1;
-				return driveCustomSelector(factory, ["\u001b"], 30).result;
+				return (await driveTuiCustom(factory, ["\u001b"], 30)).result;
 			},
 			confirm: async () => {
 				confirmations += 1;
@@ -598,7 +607,7 @@ test("preview and confirmation cancellation preserve the previous document and r
 			editor: async () => "format = 'new'\nfuture = 'preserved'\n",
 			custom: async (factory: unknown) => {
 				const inputs = customCalls++ === 0 ? ["\r"] : ["\u001b"];
-				return driveCustomSelector(factory, inputs, 30).result;
+				return (await driveTuiCustom(factory, inputs, 30)).result;
 			},
 			confirm: async () => false,
 		});
@@ -627,7 +636,7 @@ test("main and Configuration menus expose current state and a clear Back path", 
 		custom: async (factory: unknown) => {
 			const inputs =
 				call === 0 ? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"] : ["\u001b"];
-			const driven = driveCustomSelector(factory, inputs, 26);
+			const driven = await driveTuiCustom(factory, inputs, 26);
 			screens[call++] = driven.renders.flat().join("\n");
 			assert.ok(driven.renders.flat().every((line) => visibleWidth(line) <= 26));
 			return driven.result;
@@ -669,7 +678,7 @@ test("Restore previews, confirms, and atomically applies the built-in footer", a
 					call === 0
 						? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"]
 						: ["\r"];
-				const driven = driveCustomSelector(factory, inputs, 32);
+				const driven = await driveTuiCustom(factory, inputs, 32);
 				if (call === 1) restorePreview = driven.renders.flat().join("\n");
 				call += 1;
 				return driven.result;
@@ -725,7 +734,7 @@ test("Restore recovers a malformed settings document", async () => {
 					call++ === 0
 						? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"]
 						: ["\r"];
-				return driveCustomSelector(factory, inputs, 60).result;
+				return (await driveTuiCustom(factory, inputs, 60)).result;
 			},
 			confirm: async () => true,
 		});
@@ -764,7 +773,7 @@ test("invalid drafts can return to editing before preview and atomic apply", asy
 			custom: async (factory: unknown) => {
 				assert.equal(readFileSync(path, "utf8"), "format = 'old'\nfuture = 'preserved'\n");
 				menuCalls += 1;
-				return driveCustomSelector(factory, ["\r"], 34).result;
+				return (await driveTuiCustom(factory, ["\r"], 34)).result;
 			},
 			confirm: async () => true,
 		});

--- a/packages/pi-starship/test/lifecycle.test.ts
+++ b/packages/pi-starship/test/lifecycle.test.ts
@@ -3,8 +3,9 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { afterAll, test, vi } from "vitest";
-import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import piStarshipRuntime, {
 	parseGitStatusPorcelain,
 	parseGitWorktree,
@@ -257,11 +258,12 @@ test("accepted settings disable and re-enable native PR refresh immediately", as
 		};
 		piStarship(mock.pi);
 		const drafts = ["format = '$model'\n", "format = '$github_pr'\n"];
+		const tui = createTuiHarness({ width: 80, rows: 24 });
 		const context = createMockContext({
 			mode: "tui",
 			hasUI: true,
 			editor: async () => drafts.shift(),
-			custom: async (factory: unknown) => driveCustomSelector(factory, ["\r"], 80).result,
+			custom: tui.custom,
 			confirm: async () => true,
 		});
 		await emit(mock.events, "session_start", {}, context.ctx);
@@ -279,7 +281,10 @@ test("accepted settings disable and re-enable native PR refresh immediately", as
 
 		await emit(mock.events, "agent_end", {}, context.ctx);
 		assert.equal(prCalls, 2);
-		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		const disableSettings = mock.commands.get("starship")?.handler("settings", context.ctx);
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await disableSettings;
 		assert.equal(prSignals[1]?.aborted, true);
 		assert.equal(prCalls, 2);
 		assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#123/u);
@@ -287,7 +292,10 @@ test("accepted settings disable and re-enable native PR refresh immediately", as
 		await flushAsync();
 		assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#999/u);
 
-		await mock.commands.get("starship")?.handler("settings", context.ctx);
+		const enableSettings = mock.commands.get("starship")?.handler("settings", context.ctx);
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await enableSettings;
 		await flushAsync();
 		assert.equal(prCalls, 3);
 		assert.match(stripAnsi(footer.render(300).join("\n")), /#456/u);


### PR DESCRIPTION
## Summary

- run Starship preview action menus through Pi TUI Kit's published custom-interaction lifecycle
- preserve Starship-owned layout, scrolling, Back/Close results, and workflow state
- migrate affected tests from the legacy selector helper to the supported TUI harness

## Verification

- focused Starship command, lifecycle, and interaction tests
- `npm run check --workspace @narumitw/pi-starship`
- `npm run check` (372 files, 3,747 tests)
- `just pack starship`
- `git diff --check`

The first root gate exposed an unrelated flaky Fleet launch-integration assertion. It passed in isolation, and the complete root gate then passed.
