### PR TITLE
refactor(file-context): reuse custom interaction lifecycle

### DIFF
--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -393,7 +393,7 @@ export async function registerFileQuoteExtension(
 			: controller.signal;
 		activeExplorers.add(activeExplorer);
 		try {
-			const { runTask } = await import("@narumitw/pi-tui-kit");
+			const { runCustomInteraction, runTask } = await import("@narumitw/pi-tui-kit");
 			if (!isCurrentSession(owner, generation) || flowSignal.aborted) return "close";
 			const task = await runTask(ctx, {
 				label: "Scanning project files…",
@@ -422,15 +422,24 @@ export async function registerFileQuoteExtension(
 				);
 				return options.menuOwned ? "stay" : "close";
 			}
-			const result = await ctx.ui.custom<FileQuoteExplorerResult | undefined>(
-				(tui, theme, keybindings, done) => {
+			const interaction = await runCustomInteraction<
+				FileQuoteExplorerResult | undefined,
+				ExtensionContext
+			>(ctx, {
+				signal: flowSignal,
+				isCurrent: () => isCurrentSession(owner, generation),
+				onError: () => {},
+				create: ({ tui, theme, keybindings, signal: interactionSignal, complete }) => {
 					const component = new FileQuoteExplorer({
 						tui,
 						theme,
 						keybindings,
 						files,
 						cwd: ctx.cwd,
-						loadFile: (path, signal) => loadProjectTextFile(ctx.cwd, path, { signal }),
+						loadFile: (path, signal) =>
+							loadProjectTextFile(ctx.cwd, path, {
+								signal: signal ? AbortSignal.any([signal, interactionSignal]) : interactionSignal,
+							}),
 						gitContext,
 						rootNavigation: options.menuOwned,
 						getSelectedContextState: () => ({
@@ -446,7 +455,7 @@ export async function registerFileQuoteExtension(
 						}),
 						validateQuote: validatePending,
 						onAddAndContinue: (quote) => {
-							if (!isCurrentSession(owner, generation) || flowSignal.aborted) {
+							if (!isCurrentSession(owner, generation) || interactionSignal.aborted) {
 								throw new DOMException("File Context session replaced", "AbortError");
 							}
 							appendPending(quote, ctx);
@@ -459,13 +468,14 @@ export async function registerFileQuoteExtension(
 								// The widget already reflects the selected snapshot.
 							}
 						},
-						done,
+						done: complete,
 					});
 					activeExplorer.component = component;
-					if (flowSignal.aborted) component.dispose();
 					return component;
 				},
-			);
+			});
+			if (interaction.kind === "error") throw interaction.error;
+			const result = interaction.kind === "completed" ? interaction.value : undefined;
 			if (!isCurrentSession(owner, generation) || flowSignal.aborted) return "close";
 			if (result?.kind === "quote") {
 				appendPending(result.quote, ctx);

--- a/packages/pi-file-context/test/file-context-lifecycle.test.ts
+++ b/packages/pi-file-context/test/file-context-lifecycle.test.ts
@@ -2,12 +2,9 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
-import {
-	createCustomSelectorHarness,
-	createMockContext,
-	createMockPi,
-} from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerFileQuoteExtension } from "../src/file-context.js";
 
 test("disposes and settles an active explorer on session replacement", async () => {
@@ -28,15 +25,10 @@ async function assertExplorerLifecycleCancellation(
 		await registerFileQuoteExtension(mock.pi, {
 			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
 		});
-		let markReady!: () => void;
-		const ready = new Promise<void>((resolve) => {
-			markReady = resolve;
-		});
-		let disposed = false;
-		let customCalls = 0;
 		const oldManager = { getSessionId: () => "old" };
 		const newManager = { getSessionId: () => "new" };
-		const makeContext = (sessionManager: object, custom?: (factory: unknown) => Promise<unknown>) =>
+		const tui = createTuiHarness({ width: 80, rows: 18 });
+		const makeContext = (sessionManager: object, custom = tui.custom) =>
 			createMockContext({
 				mode: "tui",
 				hasUI: true,
@@ -48,39 +40,12 @@ async function assertExplorerLifecycleCancellation(
 					setWidget() {},
 					setEditorComponent() {},
 					getEditorComponent: () => undefined,
-					custom: custom ?? (async () => undefined),
+					custom,
 					pasteToEditor() {},
 				},
 			});
-		const oldContext = makeContext(oldManager, async (factory) => {
-			customCalls += 1;
-			if (customCalls === 1) {
-				return createCustomSelectorHarness(factory).resultPromise;
-			}
-			return new Promise((resolve) => {
-				const component = (
-					factory as (...args: unknown[]) => {
-						dispose(): void;
-					}
-				)(
-					{ terminal: { rows: 18 }, requestRender() {} },
-					{
-						fg: (_color: string, text: string) => text,
-						bg: (_color: string, text: string) => text,
-						bold: (text: string) => text,
-					},
-					{ matches: () => false },
-					resolve,
-				);
-				const dispose = component.dispose.bind(component);
-				component.dispose = () => {
-					disposed = true;
-					dispose();
-				};
-				markReady();
-			});
-		});
-		const newContext = makeContext(newManager);
+		const oldContext = makeContext(oldManager);
+		const newContext = makeContext(newManager, createTuiHarness().custom);
 		await mock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
 		let settled = false;
 		const command = Promise.resolve(
@@ -88,7 +53,13 @@ async function assertExplorerLifecycleCancellation(
 		).then(() => {
 			settled = true;
 		});
-		await ready;
+		const deadline = Date.now() + 3_000;
+		while (Date.now() < deadline) {
+			if (tui.isOpen && tui.render().join("\n").includes("File Context")) break;
+			await new Promise<void>((resolve) => setTimeout(resolve, 5));
+		}
+		assert.equal(tui.isOpen, true);
+		assert.match(tui.render().join("\n"), /File Context/u);
 
 		if (event === "session_start") {
 			await mock.events.get(event)?.[0]?.({}, newContext.ctx);
@@ -97,7 +68,7 @@ async function assertExplorerLifecycleCancellation(
 		}
 		await new Promise<void>((resolve) => setImmediate(resolve));
 
-		assert.equal(disposed, true);
+		assert.equal(tui.isOpen, false);
 		assert.equal(settled, true);
 		await command;
 	} finally {

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -3,12 +3,9 @@ import { mkdir, mkdtemp, rename, rm, symlink, writeFile } from "node:fs/promises
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
-import {
-	createCustomSelectorHarness,
-	createMockContext,
-	createMockPi,
-} from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import {
 	appendPendingQuote,
 	createFileQuote,
@@ -27,6 +24,64 @@ async function withTempProject(run: (root: string) => Promise<void>): Promise<vo
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}
+}
+
+function createFileContextHarness() {
+	const bindingInputs: Record<string, string> = {
+		"tui.select.up": "\u001b[A",
+		"tui.select.down": "\u001b[B",
+		"tui.select.pageUp": "\u001b[5~",
+		"tui.select.pageDown": "\u001b[6~",
+		"tui.select.confirm": "\r",
+		"tui.select.cancel": "\u001b",
+		"tui.input.submit": "\r",
+	};
+	return createTuiHarness({
+		width: 80,
+		rows: 18,
+		keybindings: {
+			matches(data, binding) {
+				if (binding === "tui.input.tab") return data === "\t";
+				return bindingInputs[binding] === data;
+			},
+			getKeys(binding) {
+				return binding === "tui.input.tab" ? ["tab"] : [];
+			},
+		},
+	});
+}
+
+async function waitForHarnessText(
+	tui: ReturnType<typeof createTuiHarness>,
+	text: string,
+): Promise<void> {
+	const deadline = Date.now() + 3_000;
+	while (Date.now() < deadline) {
+		if (tui.isOpen && tui.render().join("\n").includes(text)) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error(`Timed out waiting for File Context text: ${text}`);
+}
+
+async function runFileContextExplorer(
+	command: { handler(args: string, ctx: unknown): unknown } | undefined,
+	context: ReturnType<typeof createMockContext>,
+	path: string,
+	finish: "quote" | "reference",
+): Promise<void> {
+	const tui = createFileContextHarness();
+	(context.ctx as unknown as { ui: { custom: typeof tui.custom } }).ui.custom = tui.custom;
+	const running = Promise.resolve(command?.handler("browse", context.ctx));
+	await waitForHarnessText(tui, "File Context");
+	tui.type(path);
+	if (finish === "reference") {
+		tui.send("\t");
+	} else {
+		tui.press("tui.select.confirm");
+		await waitForHarnessText(tui, "Enter add");
+		tui.press("tui.select.confirm");
+	}
+	await running;
 }
 
 test("discovers bounded project text candidates without traversing ignored directories or symlinks", async () => {
@@ -766,187 +821,159 @@ test("accumulates ordered pending quotes within aggregate limits", () => {
 });
 
 test("registers a TUI fallback command and injects all pending quotes only once", async () => {
-	const mock = createMockPi();
-	await registerFileQuoteExtension(mock.pi, {
-		loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
-	});
-	assert.ok(mock.commands.has("file-context"));
-	assert.equal(mock.commands.has("file-quote"), false);
+	await withTempProject(async (root) => {
+		await mkdir(join(root, "src"));
+		await mkdir(join(root, "test"));
+		await writeFile(join(root, "src", "example.ts"), "const example = true;\n");
+		await writeFile(
+			join(root, "test", "example.test.ts"),
+			"skip\nexpect(example)\n  .toBe(true);\n",
+		);
+		const mock = createMockPi();
+		await registerFileQuoteExtension(mock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+		});
+		assert.ok(mock.commands.has("file-context"));
+		assert.equal(mock.commands.has("file-quote"), false);
 
-	let customFactory: unknown;
-	const widgets = new Map<string, unknown>();
-	let customCall = 0;
-	let quoteIndex = 0;
-	const quoteResults = [
-		{
-			kind: "quote",
-			quote: {
-				path: "src/example.ts",
-				startLine: 1,
-				endLine: 1,
-				text: "const example = true;",
-			},
-		},
-		{
-			kind: "quote",
-			quote: {
-				path: "test/example.test.ts",
-				startLine: 2,
-				endLine: 3,
-				text: "expect(example)\n  .toBe(true);",
-			},
-		},
-	];
-	const context = createMockContext({
-		mode: "tui",
-		hasUI: true,
-		cwd: process.cwd(),
-		ui: {
-			theme: {
-				fg(_color: string, text: string) {
-					return text;
+		const widgets = new Map<string, unknown>();
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			ui: {
+				theme: { fg: (_color: string, text: string) => text },
+				notify() {},
+				setWidget(key: string, value: unknown) {
+					widgets.set(key, value);
 				},
+				async custom() {
+					return undefined;
+				},
+				pasteToEditor() {},
 			},
-			notify() {},
-			setWidget(key: string, value: unknown) {
-				widgets.set(key, value);
-			},
-			async custom(factory: unknown) {
-				customCall += 1;
-				if (customCall % 2 === 1) {
-					return createCustomSelectorHarness(factory).resultPromise;
-				}
-				customFactory = factory;
-				const result = quoteResults[quoteIndex];
-				quoteIndex += 1;
-				return result;
-			},
-		},
-	});
+		});
 
-	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	await mock.shortcuts.get("ctrl+alt+f")?.handler(context.ctx);
-	await mock.commands.get("file-context")?.handler("browse", context.ctx);
-	assert.equal(typeof customFactory, "function");
-	assert.deepEqual(widgets.get("file-context"), [
-		"Next prompt context · 2 snippets · ~13 tokens · /file-context to review",
-		"1. src/example.ts · lines 1-1 · ~6 tokens",
-		"2. test/example.test.ts · lines 2-3 · ~8 tokens",
-	]);
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		const command = mock.commands.get("file-context");
+		await runFileContextExplorer(command, context, "src/example.ts", "quote");
 
-	assert.equal(mock.events.get("input"), undefined);
-	assert.notEqual(widgets.get("file-context"), undefined);
-	const beforeStart = mock.events.get("before_agent_start")?.[0];
-	const injection = await beforeStart?.(
-		{ prompt: "/skill:explain Explain this", images: [], systemPrompt: "base" },
-		context.ctx,
-	);
-	assert.deepEqual(injection, {
-		message: {
-			customType: "file-context-quotes",
-			content:
-				'<user_file_quote path="src/example.ts" lines="1-1">\nconst example = true;\n</user_file_quote>\n\n<user_file_quote path="test/example.test.ts" lines="2-3">\nexpect(example)\n  .toBe(true);\n</user_file_quote>\n\nThe user intentionally selected the file excerpts above.',
-			display: false,
-		},
+		const secondTui = createFileContextHarness();
+		(context.ctx as unknown as { ui: { custom: typeof secondTui.custom } }).ui.custom =
+			secondTui.custom;
+		const second = Promise.resolve(command?.handler("browse", context.ctx));
+		await waitForHarnessText(secondTui, "File Context");
+		secondTui.type("test/example.test.ts");
+		secondTui.press("tui.select.confirm");
+		await waitForHarnessText(secondTui, "Enter add");
+		secondTui.press("tui.select.down");
+		secondTui.send(" ");
+		secondTui.press("tui.select.down");
+		secondTui.press("tui.select.confirm");
+		await second;
+
+		assert.deepEqual(widgets.get("file-context"), [
+			"Next prompt context · 2 snippets · ~13 tokens · /file-context to review",
+			"1. src/example.ts · lines 1-1 · ~6 tokens",
+			"2. test/example.test.ts · lines 2-3 · ~8 tokens",
+		]);
+
+		assert.equal(mock.events.get("input"), undefined);
+		const beforeStart = mock.events.get("before_agent_start")?.[0];
+		const injection = await beforeStart?.(
+			{ prompt: "/skill:explain Explain this", images: [], systemPrompt: "base" },
+			context.ctx,
+		);
+		assert.deepEqual(injection, {
+			message: {
+				customType: "file-context-quotes",
+				content:
+					'<user_file_quote path="src/example.ts" lines="1-1">\nconst example = true;\n</user_file_quote>\n\n<user_file_quote path="test/example.test.ts" lines="2-3">\nexpect(example)\n  .toBe(true);\n</user_file_quote>\n\nThe user intentionally selected the file excerpts above.',
+				display: false,
+			},
+		});
+		assert.equal(widgets.get("file-context"), undefined);
+		assert.equal(
+			await beforeStart?.({ prompt: "Again", systemPrompt: "base" }, context.ctx),
+			undefined,
+		);
+		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+		assert.equal(widgets.get("file-context"), undefined);
 	});
-	assert.equal(widgets.get("file-context"), undefined);
-	assert.equal(
-		await beforeStart?.({ prompt: "Again", systemPrompt: "base" }, context.ctx),
-		undefined,
-	);
-	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
-	assert.equal(widgets.get("file-context"), undefined);
 });
 
 test("quotes whole-file references and rejects picker results from replaced sessions", async () => {
-	const referenceMock = createMockPi();
-	await registerFileQuoteExtension(referenceMock.pi, {
-		loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
-	});
-	const pasted: string[] = [];
-	let referenceCustomCalls = 0;
-	const referenceContext = createMockContext({
-		mode: "tui",
-		hasUI: true,
-		cwd: process.cwd(),
-		ui: {
-			theme: { fg: (_color: string, text: string) => text },
-			notify() {},
-			setWidget() {},
-			setEditorComponent() {},
-			getEditorComponent() {
-				return undefined;
-			},
-			async custom(factory: unknown) {
-				referenceCustomCalls += 1;
-				if (referenceCustomCalls === 1) {
-					return createCustomSelectorHarness(factory).resultPromise;
-				}
-				return { kind: "reference", path: 'docs/my "note".md' };
-			},
-			pasteToEditor(value: string) {
-				pasted.push(value);
-			},
-		},
-	});
-	await referenceMock.events.get("session_start")?.[0]?.({}, referenceContext.ctx);
-	await referenceMock.commands.get("file-context")?.handler("browse", referenceContext.ctx);
-	assert.deepEqual(pasted, ['@"docs/my \\"note\\".md" ']);
-
-	const staleMock = createMockPi();
-	await registerFileQuoteExtension(staleMock.pi, {
-		loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
-	});
-	let resolvePicker: ((value: unknown) => void) | undefined;
-	const picker = new Promise((resolve) => {
-		resolvePicker = resolve;
-	});
-	const oldManager = { getSessionId: () => "old" };
-	const newManager = { getSessionId: () => "new" };
-	const makeContext = (sessionManager: object, custom: () => Promise<unknown>) => {
-		let customCalls = 0;
-		return createMockContext({
+	await withTempProject(async (root) => {
+		await mkdir(join(root, "docs"));
+		await writeFile(join(root, "docs", 'my "note".md'), "reference\n");
+		const referenceMock = createMockPi();
+		await registerFileQuoteExtension(referenceMock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+		});
+		const pasted: string[] = [];
+		const referenceContext = createMockContext({
 			mode: "tui",
 			hasUI: true,
-			cwd: process.cwd(),
-			sessionManager,
+			cwd: root,
 			ui: {
 				theme: { fg: (_color: string, text: string) => text },
 				notify() {},
 				setWidget() {},
 				setEditorComponent() {},
-				getEditorComponent() {
+				getEditorComponent: () => undefined,
+				async custom() {
 					return undefined;
 				},
-				async custom(factory: unknown) {
-					customCalls += 1;
-					if (customCalls === 1) {
-						return createCustomSelectorHarness(factory).resultPromise;
-					}
-					return custom();
+				pasteToEditor(value: string) {
+					pasted.push(value);
 				},
-				pasteToEditor() {},
 			},
 		});
-	};
-	const oldContext = makeContext(oldManager, async () => picker);
-	const newContext = makeContext(newManager, async () => undefined);
-	await staleMock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
-	const command = staleMock.commands.get("file-context")?.handler("browse", oldContext.ctx);
-	await new Promise<void>((resolve) => setImmediate(resolve));
-	await staleMock.events.get("session_start")?.[0]?.({}, newContext.ctx);
-	resolvePicker?.({
-		kind: "quote",
-		quote: { path: "old.ts", startLine: 1, endLine: 1, text: "old" },
+		await referenceMock.events.get("session_start")?.[0]?.({}, referenceContext.ctx);
+		await runFileContextExplorer(
+			referenceMock.commands.get("file-context"),
+			referenceContext,
+			'docs/my "note".md',
+			"reference",
+		);
+		assert.deepEqual(pasted, ['@"docs/my \\"note\\".md" ']);
+
+		const staleMock = createMockPi();
+		await registerFileQuoteExtension(staleMock.pi, {
+			loadSettings: async () => ({ settings: { openShortcut: "ctrl+alt+f" } }),
+		});
+		const oldManager = { getSessionId: () => "old" };
+		const newManager = { getSessionId: () => "new" };
+		const tui = createFileContextHarness();
+		const oldContext = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			sessionManager: oldManager,
+			ui: { custom: tui.custom, notify() {}, setWidget() {} },
+		});
+		const newContext = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			sessionManager: newManager,
+		});
+		await staleMock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
+		const command = Promise.resolve(
+			staleMock.commands.get("file-context")?.handler("browse", oldContext.ctx),
+		);
+		await waitForHarnessText(tui, "File Context");
+		await staleMock.events.get("session_start")?.[0]?.({}, newContext.ctx);
+		await command;
+		assert.equal(tui.isOpen, false);
+		assert.equal(
+			await staleMock.events.get("before_agent_start")?.[0]?.(
+				{ prompt: "new", systemPrompt: "base" },
+				newContext.ctx,
+			),
+			undefined,
+		);
 	});
-	await command;
-	assert.equal(
-		await staleMock.events.get("before_agent_start")?.[0]?.(
-			{ prompt: "new", systemPrompt: "base" },
-			newContext.ctx,
-		),
-		undefined,
-	);
 });
 
 test("rejects the fallback command observably outside TUI mode", async () => {

--- a/packages/pi-file-context/test/pending-quotes.test.ts
+++ b/packages/pi-file-context/test/pending-quotes.test.ts
@@ -1,14 +1,10 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
-import {
-	createCustomSelectorHarness,
-	createMockContext,
-	createMockPi,
-} from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerFileQuoteExtension } from "../src/file-context.js";
 
 async function withTempProject(run: (root: string) => Promise<void>): Promise<void> {
@@ -25,11 +21,40 @@ async function waitForNextOpen(
 	tui: ReturnType<typeof createTuiHarness>,
 	previousCount: number,
 ): Promise<void> {
-	for (let attempt = 0; attempt < 100; attempt += 1) {
+	const deadline = Date.now() + 3_000;
+	while (Date.now() < deadline) {
 		if (tui.openCount > previousCount && tui.isOpen) return;
-		await new Promise<void>((resolve) => setImmediate(resolve));
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
 	}
 	throw new Error("Timed out waiting for the next File Context screen");
+}
+
+async function waitForText(tui: ReturnType<typeof createTuiHarness>, text: string): Promise<void> {
+	const deadline = Date.now() + 3_000;
+	while (Date.now() < deadline) {
+		if (tui.isOpen && tui.render().join("\n").includes(text)) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error(`Timed out waiting for File Context text: ${text}`);
+}
+
+async function stageQuote(
+	command: { handler(args: string, ctx: unknown): unknown } | undefined,
+	context: ReturnType<typeof createMockContext>,
+	path: string,
+	text: string,
+): Promise<void> {
+	const tui = createTuiHarness({ width: 80, rows: 18 });
+	(context.ctx as unknown as { ui: { custom: typeof tui.custom } }).ui.custom = tui.custom;
+	const running = Promise.resolve(command?.handler("browse", context.ctx));
+	await waitForText(tui, "File Context");
+	assert.equal(path.startsWith("src/"), true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await waitForText(tui, "Enter add");
+	assert.match(tui.render().join("\n"), new RegExp(text, "u"));
+	tui.press("tui.select.confirm");
+	await running;
 }
 
 test("removes an exact duplicate-looking pending quote and refreshes the widget", async () => {
@@ -38,18 +63,9 @@ test("removes an exact duplicate-looking pending quote and refreshes the widget"
 		await registerFileQuoteExtension(mock.pi, {
 			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
 		});
-		const quoteResults = [
-			{
-				kind: "quote",
-				quote: { path: "src/example.ts", startLine: 1, endLine: 1, text: "first snapshot" },
-			},
-			{
-				kind: "quote",
-				quote: { path: "src/example.ts", startLine: 1, endLine: 1, text: "second snapshot" },
-			},
-		];
-		let customCalls = 0;
-		let quoteIndex = 0;
+		await mkdir(join(root, "src"));
+		const quotePath = join(root, "src", "example.ts");
+		await writeFile(quotePath, "first snapshot\n");
 		const widgets = new Map<string, unknown>();
 		const context = createMockContext({
 			mode: "tui",
@@ -61,22 +77,17 @@ test("removes an exact duplicate-looking pending quote and refreshes the widget"
 				setWidget(key: string, value: unknown) {
 					widgets.set(key, value);
 				},
-				async custom(factory: unknown) {
-					customCalls += 1;
-					if (customCalls % 2 === 1) {
-						return createCustomSelectorHarness(factory).resultPromise;
-					}
-					const result = quoteResults[quoteIndex];
-					quoteIndex += 1;
-					return result;
+				async custom() {
+					return undefined;
 				},
 				pasteToEditor() {},
 			},
 		});
 		const command = mock.commands.get("file-context");
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await command?.handler("browse", context.ctx);
-		await command?.handler("browse", context.ctx);
+		await stageQuote(command, context, "src/example.ts", "first snapshot");
+		await writeFile(quotePath, "second snapshot\n");
+		await stageQuote(command, context, "src/example.ts", "second snapshot");
 
 		const tui = createTuiHarness({ width: 60, rows: 18 });
 		(context.ctx as unknown as { ui: { custom: typeof tui.custom } }).ui.custom = tui.custom;
@@ -123,9 +134,10 @@ test("removal cancellation and menu failures preserve pending quotes", async () 
 		await registerFileQuoteExtension(mock.pi, {
 			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
 		});
+		await mkdir(join(root, "src"));
+		await writeFile(join(root, "src", "keep.ts"), "keep\n");
 		const widgets = new Map<string, unknown>();
 		const notifications: string[] = [];
-		let customCalls = 0;
 		const context = createMockContext({
 			mode: "tui",
 			hasUI: true,
@@ -138,22 +150,15 @@ test("removal cancellation and menu failures preserve pending quotes", async () 
 				setWidget(key: string, value: unknown) {
 					widgets.set(key, value);
 				},
-				async custom(factory: unknown) {
-					customCalls += 1;
-					if (customCalls === 1) {
-						return createCustomSelectorHarness(factory).resultPromise;
-					}
-					return {
-						kind: "quote",
-						quote: { path: "src/keep.ts", startLine: 4, endLine: 4, text: "keep" },
-					};
+				async custom() {
+					return undefined;
 				},
 				pasteToEditor() {},
 			},
 		});
 		const command = mock.commands.get("file-context");
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-		await command?.handler("browse", context.ctx);
+		await stageQuote(command, context, "src/keep.ts", "keep");
 		const widgetBefore = widgets.get("file-context");
 
 		const tui = createTuiHarness();
@@ -192,9 +197,10 @@ test("session replacement closes the menu and ignores stale input", async () => 
 		await registerFileQuoteExtension(mock.pi, {
 			loadSettings: async () => ({ settings: { openShortcut: "f8" } }),
 		});
+		await mkdir(join(root, "src"));
+		await writeFile(join(root, "src", "old.ts"), "old\n");
 		const oldManager = { getSessionId: () => "old" };
 		const newManager = { getSessionId: () => "new" };
-		let oldCustomCalls = 0;
 		const oldContext = createMockContext({
 			mode: "tui",
 			hasUI: true,
@@ -204,21 +210,14 @@ test("session replacement closes the menu and ignores stale input", async () => 
 				theme: { fg: (_color: string, text: string) => text },
 				notify() {},
 				setWidget() {},
-				async custom(factory: unknown) {
-					oldCustomCalls += 1;
-					if (oldCustomCalls === 1) {
-						return createCustomSelectorHarness(factory).resultPromise;
-					}
-					return {
-						kind: "quote",
-						quote: { path: "src/old.ts", startLine: 1, endLine: 1, text: "old" },
-					};
+				async custom() {
+					return undefined;
 				},
 				pasteToEditor() {},
 			},
 		});
 		await mock.events.get("session_start")?.[0]?.({}, oldContext.ctx);
-		await mock.commands.get("file-context")?.handler("browse", oldContext.ctx);
+		await stageQuote(mock.commands.get("file-context"), oldContext, "src/old.ts", "old");
 		const tui = createTuiHarness();
 		(oldContext.ctx as unknown as { ui: { custom: typeof tui.custom } }).ui.custom = tui.custom;
 		const oldMenu = Promise.resolve(mock.commands.get("file-context")?.handler("", oldContext.ctx));


### PR DESCRIPTION
## Summary

- host File Context's specialized explorer through Pi TUI Kit's published custom-interaction lifecycle
- compose explorer file-load cancellation with the helper-owned interaction signal
- replace raw custom-result mocks with real supported TUI harness interactions

## Verification

- focused File Context explorer, pending quote, replacement, and shutdown tests
- `npm run check --workspace @narumitw/pi-file-context`
- `npm run check` (372 files, 3,747 tests)
- `just pack file-context`
- `git diff --check`

File search, content search, Git history/revision/diff, quote validation, widgets, and session ownership remain File Context-owned.
