### PR TITLE
feat(tui-kit): add terminal display sanitizer

### DIFF
--- a/.changeset/safe-tui-terminal-text.md
+++ b/.changeset/safe-tui-terminal-text.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add a display-only terminal sanitizer for specialized extension components.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -271,11 +271,10 @@ work before returning. The consumer still owns the component, its Back/Close val
 side effect. Async factories and pending work must honor the supplied signal; the helper drains them
 but does not hide uncooperative work behind a timeout.
 
-Use `sanitizeTerminalText()` when a specialized component must place an untrusted model label, path,
-or other value on one terminal line. It removes complete and unterminated terminal control sequences,
-C0/C1 controls, and bidirectional display controls; line separators become spaces. The result is for
-display only. Keep raw paths, IDs, URLs, settings, and action payloads separate, then use Pi TUI's
-cell-aware wrapping or truncation for layout.
+Use `sanitizeTerminalText()` when a specialized component must place an untrusted model label, path, or other value on one terminal line.
+It removes complete and unterminated terminal control sequences, C0/C1 controls, and bidirectional display controls; line separators become spaces.
+The result is for display only.
+Keep raw paths, IDs, URLs, settings, and action payloads separate, then use Pi TUI's cell-aware wrapping or truncation for layout.
 
 ```ts
 import { sanitizeTerminalText } from "@narumitw/pi-tui-kit";
@@ -700,8 +699,7 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
   typed selection, confirmation-only gating, shortcuts, Back, Close, Stale, Unsupported, and Error.
 - `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and
   literal shortcut keys for specialized interaction hints.
-- `sanitizeTerminalText()` — removes terminal and bidirectional display controls from untrusted
-  single-line presentation text without mutating raw payloads.
+- `sanitizeTerminalText()` — removes terminal and bidirectional display controls from untrusted single-line presentation text without mutating raw payloads.
 - `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending
   work draining, and typed results around one extension-owned custom TUI component.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -271,6 +271,19 @@ work before returning. The consumer still owns the component, its Back/Close val
 side effect. Async factories and pending work must honor the supplied signal; the helper drains them
 but does not hide uncooperative work behind a timeout.
 
+Use `sanitizeTerminalText()` when a specialized component must place an untrusted model label, path,
+or other value on one terminal line. It removes complete and unterminated terminal control sequences,
+C0/C1 controls, and bidirectional display controls; line separators become spaces. The result is for
+display only. Keep raw paths, IDs, URLs, settings, and action payloads separate, then use Pi TUI's
+cell-aware wrapping or truncation for layout.
+
+```ts
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+
+const label = truncateToWidth(sanitizeTerminalText(rawModelId), width, "");
+```
+
 ```ts
 import { runCustomInteraction } from "@narumitw/pi-tui-kit";
 
@@ -687,6 +700,8 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
   typed selection, confirmation-only gating, shortcuts, Back, Close, Stale, Unsupported, and Error.
 - `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and
   literal shortcut keys for specialized interaction hints.
+- `sanitizeTerminalText()` — removes terminal and bidirectional display controls from untrusted
+  single-line presentation text without mutating raw payloads.
 - `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending
   work draining, and typed results around one extension-owned custom TUI component.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -28,6 +28,7 @@ export { defineMenu, resolveMenuScreen } from "./model.js";
 export { createMenuNavigator, type MenuNavigator } from "./navigator.js";
 export { type RunMenuOptions, type RunMenuResult, runMenu } from "./runtime.js";
 export { type RunTaskOptions, type RunTaskResult, runTask } from "./task.js";
+export { sanitizeTerminalText } from "./terminal-text.js";
 export type {
 	ActionMenuItem,
 	ActionsScreen,

--- a/packages/pi-tui-kit/src/terminal-text.ts
+++ b/packages/pi-tui-kit/src/terminal-text.ts
@@ -53,7 +53,18 @@ function skipEscSequence(value: string, start: number): number {
 	if (introducer === 0x50 || introducer === 0x5e || introducer === 0x5f) {
 		return skipStringSequence(value, start + 2, false);
 	}
-	return Math.min(value.length, start + 2);
+	return skipGenericEscSequence(value, start);
+}
+
+function skipGenericEscSequence(value: string, start: number): number {
+	let index = start + 1;
+	while (index < value.length) {
+		const code = value.charCodeAt(index);
+		if (code < 0x20 || code > 0x2f) break;
+		index += 1;
+	}
+	const final = value.charCodeAt(index);
+	return final >= 0x30 && final <= 0x7e ? index + 1 : start + 1;
 }
 
 function skipCsi(value: string, start: number): number {

--- a/packages/pi-tui-kit/src/terminal-text.ts
+++ b/packages/pi-tui-kit/src/terminal-text.ts
@@ -1,0 +1,100 @@
+const ESC = 0x1b;
+const BEL = 0x07;
+const CSI = 0x9b;
+const ST = 0x9c;
+const OSC = 0x9d;
+const DCS = 0x90;
+const PM = 0x9e;
+const APC = 0x9f;
+
+/**
+ * Remove terminal control sequences and display-direction controls from untrusted single-line text.
+ *
+ * This function is only for presentation. Keep raw identities and payloads separate.
+ */
+export function sanitizeTerminalText(value: string): string {
+	let output = "";
+	for (let index = 0; index < value.length; ) {
+		const codePoint = value.codePointAt(index) ?? 0;
+		const length = codePoint > 0xffff ? 2 : 1;
+
+		if (codePoint === ESC) {
+			index = skipEscSequence(value, index);
+			continue;
+		}
+		if (codePoint === CSI) {
+			index = skipCsi(value, index + length);
+			continue;
+		}
+		if (codePoint === OSC || codePoint === DCS || codePoint === PM || codePoint === APC) {
+			index = skipStringSequence(value, index + length, codePoint === OSC);
+			continue;
+		}
+		if (isLineSeparator(codePoint)) {
+			output += " ";
+			index += length;
+			continue;
+		}
+		if (isControl(codePoint) || isBidiControl(codePoint)) {
+			index += length;
+			continue;
+		}
+
+		output += String.fromCodePoint(codePoint);
+		index += length;
+	}
+	return output;
+}
+
+function skipEscSequence(value: string, start: number): number {
+	const introducer = value.charCodeAt(start + 1);
+	if (introducer === 0x5b) return skipCsi(value, start + 2);
+	if (introducer === 0x5d) return skipStringSequence(value, start + 2, true);
+	if (introducer === 0x50 || introducer === 0x5e || introducer === 0x5f) {
+		return skipStringSequence(value, start + 2, false);
+	}
+	return Math.min(value.length, start + 2);
+}
+
+function skipCsi(value: string, start: number): number {
+	for (let index = start; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code >= 0x40 && code <= 0x7e) return index + 1;
+	}
+	return value.length;
+}
+
+function skipStringSequence(value: string, start: number, bellTerminates: boolean): number {
+	for (let index = start; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (bellTerminates && code === BEL) return index + 1;
+		if (code === ST) return index + 1;
+		if (code === ESC && value.charCodeAt(index + 1) === 0x5c) return index + 2;
+	}
+	return value.length;
+}
+
+function isLineSeparator(codePoint: number): boolean {
+	return (
+		codePoint === 0x09 ||
+		codePoint === 0x0a ||
+		codePoint === 0x0d ||
+		codePoint === 0x85 ||
+		codePoint === 0x2028 ||
+		codePoint === 0x2029
+	);
+}
+
+function isControl(codePoint: number): boolean {
+	return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+}
+
+function isBidiControl(codePoint: number): boolean {
+	return (
+		codePoint === 0x061c ||
+		codePoint === 0x200e ||
+		codePoint === 0x200f ||
+		(codePoint >= 0x202a && codePoint <= 0x202e) ||
+		(codePoint >= 0x2066 && codePoint <= 0x2069)
+	);
+}

--- a/packages/pi-tui-kit/test/terminal-text.test.ts
+++ b/packages/pi-tui-kit/test/terminal-text.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { sanitizeTerminalText } from "../src/index.js";
+
+test("sanitizes untrusted terminal display text without changing printable identity", () => {
+	assert.equal(sanitizeTerminalText("model/😀/e\u0301"), "model/😀/e\u0301");
+	assert.equal(sanitizeTerminalText("a\tb\nc\rd\u0085e\u2028f\u2029g"), "a b c d e f g");
+	assert.equal(sanitizeTerminalText("a\u0000\u0007\u007f\u0080g"), "ag");
+	assert.equal(sanitizeTerminalText("safe\u202eevil\u2066text"), "safeeviltext");
+});
+
+test("removes complete and unterminated terminal control sequences as units", () => {
+	assert.equal(sanitizeTerminalText("before\u001b[31mred\u001b[0mafter"), "beforeredafter");
+	assert.equal(sanitizeTerminalText("before\u009b31mred\u009b0mafter"), "beforeredafter");
+	assert.equal(
+		sanitizeTerminalText("before\u001b]8;;https://example.com\u0007label\u001b]8;;\u001b\\after"),
+		"beforelabelafter",
+	);
+	assert.equal(sanitizeTerminalText("before\u001bPpayload\u001b\\after"), "beforeafter");
+	assert.equal(sanitizeTerminalText("before\u001b_private\u001b\\after"), "beforeafter");
+	assert.equal(sanitizeTerminalText("before\u001b^private\u001b\\after"), "beforeafter");
+	assert.equal(sanitizeTerminalText("before\u001b]unterminated"), "before");
+	assert.equal(sanitizeTerminalText("before\u001b[31"), "before");
+	assert.equal(sanitizeTerminalText("before\u001bXafter"), "beforeafter");
+});
+
+test("composes with Pi TUI cell-aware truncation", () => {
+	const sanitized = sanitizeTerminalText("\u001b[31m目標😀value\u001b[0m");
+	assert.equal(sanitized.includes("\u001b"), false);
+	const rendered = truncateToWidth(sanitized, 8, "");
+	assert.ok(visibleWidth(rendered) <= 8);
+});

--- a/packages/pi-tui-kit/test/terminal-text.test.ts
+++ b/packages/pi-tui-kit/test/terminal-text.test.ts
@@ -25,6 +25,14 @@ test("removes complete and unterminated terminal control sequences as units", ()
 	assert.equal(sanitizeTerminalText("before\u001bXafter"), "beforeafter");
 });
 
+test("parses generic ESC sequences without corrupting following Unicode", () => {
+	assert.equal(sanitizeTerminalText("before\u001b(0after"), "beforeafter");
+	assert.equal(sanitizeTerminalText("before\u001b#8after"), "beforeafter");
+	assert.equal(sanitizeTerminalText("before\u001b!/Aafter"), "beforeafter");
+	assert.equal(sanitizeTerminalText("before\u001b😀after"), "before😀after");
+	assert.equal(sanitizeTerminalText("before\u001b(😀after"), "before(😀after");
+});
+
 test("composes with Pi TUI cell-aware truncation", () => {
 	const sanitized = sanitizeTerminalText("\u001b[31m目標😀value\u001b[0m");
 	assert.equal(sanitized.includes("\u001b"), false);

--- a/packages/pi-tui-kit/test/testing-exports.test.ts
+++ b/packages/pi-tui-kit/test/testing-exports.test.ts
@@ -12,6 +12,7 @@ test("built package roots resolve separate production and testing exports", asyn
 	const production = await import(productionSpecifier);
 	const testing = await import(testingSpecifier);
 	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 11);
+	assert.equal(typeof production.sanitizeTerminalText, "function");
 	assert.equal(typeof production.formatInteractionHints, "function");
 	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");


### PR DESCRIPTION
## Summary

- add a display-only sanitizer for untrusted specialized-component labels
- remove complete and unterminated CSI, OSC, DCS, PM, and APC sequences plus C0/C1 and bidi controls
- preserve raw payload ownership and compose with Pi TUI's cell-aware layout utilities

## Verification

- red-first focused sanitizer tests
- complete Pi TUI Kit check and build
- `npm run check` (373 files, 3,750 tests)
- runtime import benchmark (`codingAgentLoaded: false` in every scenario)
- `just pack tui-kit` (61 intended files, including runtime and declarations)
- `git diff --check`

`PI_EXTENSION_MENU_API_VERSION` remains 11 because this additive utility does not change menu definitions or adapters.

This PR does not publish the package or migrate a consumer. The new Kit API must be released and registry-verified first.
