### PR TITLE
feat(tui-kit): add searchable choice screens

### DIFF
--- a/.changeset/searchable-tui-choice.md
+++ b/.changeset/searchable-tui-choice.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add optional TUI search to declarative choice screens while keeping RPC deterministic.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -296,8 +296,7 @@ const result = await runCustomInteraction<{ kind: "back" | "close" }>(ctx, {
 - **`detail`** — read-only wrapped text with Back or Close behavior.
 - **`browse`** — a read-only searchable catalog with textual status, adaptive list/detail views,
   stable selection restoration, legacy prose or exact document details, and paginated RPC details.
-- **`choice`** — one confirmed value from a static list, with separate current and initial items,
-  selected details, disabled explanations, an optional TUI search field, and a bounded viewport.
+- **`choice`** — one confirmed value from a static list, with separate current and initial items, selected details, disabled explanations, an optional TUI search field, and a bounded viewport.
 - **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes,
   serialized saves, and rollback when an action rejects.
 - **`input`** — single-line text entry inside the menu stack with IME focus, serialized submission,
@@ -364,12 +363,10 @@ const profileScreen = {
 };
 ```
 
-Set `enableSearch: true` when a choice list needs local filtering, and provide optional `searchText`
-for safe aliases or metadata that should not be rendered. TUI fuzzy-searches sanitized labels,
-descriptions, and explicit search text while preserving raw stable IDs, query and selection after a
-rejected action, disabled explanations, and IME focus. Details and raw IDs are not searched
-implicitly. RPC deliberately keeps one deterministic unfiltered selector and ignores interactive
-search metadata.
+Set `enableSearch: true` when a choice list needs local filtering, and provide optional `searchText` for safe aliases or metadata that should not be rendered.
+TUI fuzzy-searches sanitized labels, descriptions, and explicit search text while preserving raw stable IDs, query and selection after a rejected action, disabled explanations, and IME focus.
+Details and raw IDs are not searched implicitly.
+RPC deliberately keeps one deterministic unfiltered selector and ignores interactive search metadata.
 
 Keep preview snapshots, rollback, persistence, and confirmation policy in the consuming extension.
 Use standalone `runLiveChoice()` when its list-and-shortcut contract fits; keep a fully specialized UI
@@ -702,12 +699,9 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
   `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
   strict scripts, and their public testing types; it is not re-exported from the production root.
-- `PI_EXTENSION_MENU_API_VERSION` — current API version (`12`). Version 12 adds optional searchable
-  `choice` fields while version-11 menu definitions remain valid. Version 11 added Live Choice
-  confirmation-only gating, version 10 added exact browse detail documents, version 9 added
-  `runLiveChoice()` and `formatInteractionHints()`, version 8 added disabled action reasons and
-  adaptive action-label columns, version 7 added `runConfirmation()`, and version 6 added the
-  read-only `browse` screen and `runCustomInteraction()`.
+- `PI_EXTENSION_MENU_API_VERSION` — current API version (`12`).
+  Version 12 adds optional searchable `choice` fields while version-11 menu definitions remain valid.
+  Version 11 added Live Choice confirmation-only gating, version 10 added exact browse detail documents, version 9 added `runLiveChoice()` and `formatInteractionHints()`, version 8 added disabled action reasons and adaptive action-label columns, version 7 added `runConfirmation()`, and version 6 added the read-only `browse` screen and `runCustomInteraction()`.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -297,7 +297,7 @@ const result = await runCustomInteraction<{ kind: "back" | "close" }>(ctx, {
 - **`browse`** — a read-only searchable catalog with textual status, adaptive list/detail views,
   stable selection restoration, legacy prose or exact document details, and paginated RPC details.
 - **`choice`** — one confirmed value from a static list, with separate current and initial items,
-  selected details, disabled explanations, and a bounded viewport.
+  selected details, disabled explanations, an optional TUI search field, and a bounded viewport.
 - **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes,
   serialized saves, and rollback when an action rejects.
 - **`input`** — single-line text entry inside the menu stack with IME focus, serialized submission,
@@ -363,6 +363,13 @@ const profileScreen = {
   viewportSize: 8,
 };
 ```
+
+Set `enableSearch: true` when a choice list needs local filtering, and provide optional `searchText`
+for safe aliases or metadata that should not be rendered. TUI fuzzy-searches sanitized labels,
+descriptions, and explicit search text while preserving raw stable IDs, query and selection after a
+rejected action, disabled explanations, and IME focus. Details and raw IDs are not searched
+implicitly. RPC deliberately keeps one deterministic unfiltered selector and ignores interactive
+search metadata.
 
 Keep preview snapshots, rollback, persistence, and confirmation policy in the consuming extension.
 Use standalone `runLiveChoice()` when its list-and-shortcut contract fits; keep a fully specialized UI
@@ -695,12 +702,12 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
   `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
   strict scripts, and their public testing types; it is not re-exported from the production root.
-- `PI_EXTENSION_MENU_API_VERSION` — current API version (`11`). Version 11 adds Live Choice
-  confirmation-only gating while version-10 menu definitions remain valid. Version 10 added exact
-  browse detail documents, version 9 added `runLiveChoice()` and `formatInteractionHints()`, version 8
-  added disabled action reasons and adaptive action-label columns, version 7 added
-  `runConfirmation()`, and version 6 added the read-only `browse` screen and
-  `runCustomInteraction()`.
+- `PI_EXTENSION_MENU_API_VERSION` — current API version (`12`). Version 12 adds optional searchable
+  `choice` fields while version-11 menu definitions remain valid. Version 11 added Live Choice
+  confirmation-only gating, version 10 added exact browse detail documents, version 9 added
+  `runLiveChoice()` and `formatInteractionHints()`, version 8 added disabled action reasons and
+  adaptive action-label columns, version 7 added `runConfirmation()`, and version 6 added the
+  read-only `browse` screen and `runCustomInteraction()`.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-tui-kit/src/components/contracts.ts
+++ b/packages/pi-tui-kit/src/components/contracts.ts
@@ -70,6 +70,9 @@ export interface MenuScreenComponentOptions<ScreenId extends string, ActionId ex
 	onError?(error: unknown): void;
 	/** Internal standalone-interaction hint override. Declarative screens do not set this. */
 	interactionHint?: string;
+	/** Internal TUI-only query restoration for rejected searchable-choice actions. */
+	searchQuery?: string;
+	onSearchQueryChange?(query: string): void;
 	onDispose?(): void;
 }
 

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -175,7 +175,8 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 	options: ChoiceOptions<ScreenId, ActionId>,
 ): MenuScreenComponent {
 	const searchInput = new Input();
-	searchInput.setValue(options.searchQuery ?? "");
+	const restoredSearchQuery = options.searchQuery ?? "";
+	if (restoredSearchQuery) handleSearchInput(searchInput, restoredSearchQuery);
 	const border = new DynamicBorder((text: string) => options.theme.fg("border", text));
 	const allItems = options.screen.items.map((item) => {
 		const current = item.id === options.screen.currentItemId ? " ✓ current" : "";

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
 	type Focusable,
@@ -33,7 +34,6 @@ import {
 	safeMenuText,
 } from "./rendering.js";
 import { createReviewComponent, type ReviewOptions } from "./review.js";
-import { SelectionController } from "./selection-controller.js";
 
 export { browseDialogLabel, browseDialogPages } from "./browse.js";
 export type {
@@ -174,63 +174,135 @@ function createDetailComponent<ScreenId extends string, ActionId extends string>
 function createChoiceComponent<ScreenId extends string, ActionId extends string>(
 	options: ChoiceOptions<ScreenId, ActionId>,
 ): MenuScreenComponent {
+	const searchInput = new Input();
+	searchInput.setValue(options.searchQuery ?? "");
 	const border = new DynamicBorder((text: string) => options.theme.fg("border", text));
-	const items: SelectItem[] = options.screen.items.map((item) => {
+	const allItems = options.screen.items.map((item) => {
 		const current = item.id === options.screen.currentItemId ? " ✓ current" : "";
 		const unavailable = item.disabled
 			? `unavailable${item.disabledReason ? `: ${safeMenuText(item.disabledReason)}` : ""}`
 			: undefined;
+		const label = safeMenuText(item.label);
+		const description = item.description ? safeMenuText(item.description) : "";
 		return {
-			value: item.id,
-			label: `${item.disabled ? "[-] " : ""}${safeMenuText(item.label)}${current}`,
-			description:
-				[unavailable, item.description ? safeMenuText(item.description) : undefined]
-					.filter((value): value is string => Boolean(value))
-					.join(" · ") || undefined,
+			item,
+			selectItem: {
+				value: item.id,
+				label: `${item.disabled ? "[-] " : ""}${label}${current}`,
+				description:
+					[unavailable, description]
+						.filter((value): value is string => Boolean(value))
+						.join(" · ") || undefined,
+			} satisfies SelectItem,
+			searchText: [
+				safeChoiceText(item.label),
+				safeChoiceText(item.description ?? ""),
+				safeChoiceText(item.searchText ?? ""),
+			]
+				.filter(Boolean)
+				.join(" "),
 		};
 	});
-	const viewportSize = Math.min(items.length, options.screen.viewportSize ?? 10);
-	const list = new SelectList(items, viewportSize, selectTheme(options.theme));
-	const selection = new SelectionController(options.screen.items, options.selectedItemId);
-	setInitialSelection(list, items, selection.selectedItem?.id);
-	const syncSelection = () => {
-		const item = selection.selectedItem;
-		if (!item) return;
-		list.setSelectedIndex(selection.selectedIndex);
-		options.onSelectionChange?.(item.id);
+	let filteredItems = options.screen.enableSearch
+		? fuzzyFilter(allItems, searchInput.getValue(), (candidate) => candidate.searchText)
+		: [...allItems];
+	let selectedIndex = Math.max(
+		0,
+		filteredItems.findIndex(({ item }) => item.id === options.selectedItemId),
+	);
+	let restoreItemId: string | undefined;
+	let disposed = false;
+	let list = createList();
+
+	function pageSize() {
+		return Math.min(filteredItems.length, options.screen.viewportSize ?? 10);
+	}
+	function createList() {
+		const items = filteredItems.map(({ selectItem }) => selectItem);
+		const next = new SelectList(
+			items,
+			Math.min(items.length, options.screen.viewportSize ?? 10),
+			selectTheme(options.theme),
+		);
+		setInitialSelection(next, items, filteredItems[selectedIndex]?.item.id);
+		return next;
+	}
+	const selected = () => filteredItems[selectedIndex]?.item;
+	const setSelectedIndex = (index: number, wrap: boolean, rememberUserSelection: boolean) => {
+		if (filteredItems.length === 0) {
+			selectedIndex = 0;
+			return;
+		}
+		selectedIndex = wrap
+			? (index + filteredItems.length) % filteredItems.length
+			: Math.max(0, Math.min(index, filteredItems.length - 1));
+		if (rememberUserSelection) restoreItemId = undefined;
+		list.setSelectedIndex(selectedIndex);
+		const item = selected();
+		if (item) options.onSelectionChange?.(item.id);
 	};
-	const move = (delta: number) => {
-		if (selection.move(delta)) syncSelection();
+	const move = (delta: number) => setSelectedIndex(selectedIndex + delta, true, true);
+	const applyFilter = () => {
+		if (!options.screen.enableSearch) return;
+		const previouslySelectedId = selected()?.id;
+		filteredItems = fuzzyFilter(
+			allItems,
+			searchInput.getValue(),
+			(candidate) => candidate.searchText,
+		);
+		if (filteredItems.length === 0) {
+			if (previouslySelectedId) restoreItemId ??= previouslySelectedId;
+			selectedIndex = 0;
+			list = createList();
+			return;
+		}
+		const previousIndex = filteredItems.findIndex(({ item }) => item.id === previouslySelectedId);
+		if (previousIndex < 0 && previouslySelectedId) restoreItemId ??= previouslySelectedId;
+		const restoreIndex = filteredItems.findIndex(({ item }) => item.id === restoreItemId);
+		selectedIndex = restoreIndex >= 0 ? restoreIndex : previousIndex >= 0 ? previousIndex : 0;
+		if (restoreIndex >= 0) restoreItemId = undefined;
+		list = createList();
+		const item = selected();
+		if (item) options.onSelectionChange?.(item.id);
 	};
 	const activate = () => {
-		const item = selection.selectedItem;
+		const item = selected();
 		if (item && !item.disabled) options.onEvent({ kind: "activate", itemId: item.id });
 	};
-	let disposed = false;
-	return {
+	const component: MenuScreenComponent & Partial<Focusable> = {
 		render(width) {
 			const safeWidth = Math.max(1, width);
-			const selected = selection.selectedItem;
+			const selectedItem = selected();
 			const details = [
-				...(selected?.disabledReason
-					? [`Unavailable: ${safeMenuText(selected.disabledReason)}`]
+				...(selectedItem?.disabledReason
+					? [`Unavailable: ${safeMenuText(selectedItem.disabledReason)}`]
 					: []),
-				...(selected?.details ?? []).map(safeMenuText),
+				...(selectedItem?.details ?? []).map(safeMenuText),
 			];
-			const content =
-				items.length === 0
+			const choices =
+				allItems.length === 0
 					? [options.theme.fg("dim", "  No choices available")]
-					: [
-							...list.render(safeWidth),
-							...(details.length > 0
-								? [
-										"",
-										...details.flatMap((line) =>
-											wrapTextWithAnsi(options.theme.fg("muted", line), safeWidth),
-										),
-									]
-								: []),
-						];
+					: filteredItems.length === 0
+						? [options.theme.fg("dim", "  No matching choices")]
+						: [
+								...list.render(safeWidth),
+								...(details.length > 0
+									? [
+											"",
+											...details.flatMap((line) =>
+												wrapTextWithAnsi(options.theme.fg("muted", line), safeWidth),
+											),
+										]
+									: []),
+							];
+			const search = options.screen.enableSearch
+				? [
+						...renderChoiceSearchInput(searchInput, safeWidth),
+						"",
+						...choices,
+						options.theme.fg("dim", "Type to search"),
+					]
+				: choices;
 			const result = [
 				...border.render(safeWidth),
 				...wrapTextWithAnsi(
@@ -241,7 +313,7 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 					wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
 				),
 				"",
-				...content,
+				...search,
 				...wrapTextWithAnsi(
 					options.theme.fg(
 						"dim",
@@ -257,6 +329,7 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 		invalidate() {
 			border.invalidate();
 			list.invalidate();
+			if (options.screen.enableSearch) searchInput.invalidate();
 		},
 		handleInput(data) {
 			if (disposed) return;
@@ -266,15 +339,21 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 			} else if (options.keybindings.matches(data, "tui.select.up")) move(-1);
 			else if (options.keybindings.matches(data, "tui.select.down")) move(1);
 			else if (options.keybindings.matches(data, "tui.select.pageUp")) {
-				if (selection.page(-1, viewportSize)) syncSelection();
+				setSelectedIndex(selectedIndex - Math.max(1, pageSize()), false, true);
 			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
-				if (selection.page(1, viewportSize)) syncSelection();
-			} else if (matchesKey(data, Key.home)) {
-				if (selection.first()) syncSelection();
-			} else if (matchesKey(data, Key.end)) {
-				if (selection.last()) syncSelection();
-			} else if (options.keybindings.matches(data, "tui.select.confirm") || data === " ") {
+				setSelectedIndex(selectedIndex + Math.max(1, pageSize()), false, true);
+			} else if (matchesKey(data, Key.home)) setSelectedIndex(0, false, true);
+			else if (matchesKey(data, Key.end)) {
+				setSelectedIndex(filteredItems.length - 1, false, true);
+			} else if (
+				options.keybindings.matches(data, "tui.select.confirm") ||
+				(!options.screen.enableSearch && data === " ")
+			) {
 				activate();
+			} else if (options.screen.enableSearch) {
+				handleSearchInput(searchInput, data);
+				options.onSearchQueryChange?.(searchInput.getValue());
+				applyFilter();
 			}
 			options.tui.requestRender();
 		},
@@ -285,6 +364,25 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 			options.onDispose?.();
 		},
 	};
+	if (options.screen.enableSearch) {
+		Object.defineProperty(component, "focused", {
+			get: () => searchInput.focused,
+			set: (value: boolean) => {
+				searchInput.focused = value;
+			},
+		});
+	}
+	return component;
+}
+
+function safeChoiceText(value: unknown): string {
+	return safeMenuText(stripVTControlCharacters(String(value)));
+}
+
+function renderChoiceSearchInput(input: Input, width: number): string[] {
+	const prefix = "Search: ";
+	const inputWidth = Math.max(1, width - visibleWidth(prefix));
+	return input.render(inputWidth).map((line) => truncateToWidth(`${prefix}${line}`, width, ""));
 }
 
 // Pi's current SettingsList cannot initialize its cursor, enforce disabled rows, expose search

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -57,4 +57,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 11;
+export const PI_EXTENSION_MENU_API_VERSION = 12;

--- a/packages/pi-tui-kit/src/runtime.ts
+++ b/packages/pi-tui-kit/src/runtime.ts
@@ -80,12 +80,14 @@ async function runTuiMenu<
 		? AbortSignal.any([menuController.signal, options.signal])
 		: menuController.signal;
 	const navigator = createMenuNavigator(definition.start);
+	const searchQueries = new Map<ScreenId, string>();
 	try {
 		while (!navigator.closed) {
 			const loaded = await loadState(ctx, options, menuSignal);
 			if (loaded.kind !== "loaded") return loaded.result;
 			const state = loaded.state;
-			const screen = resolveMenuScreen(definition, navigator.current, state);
+			const screenId = navigator.current;
+			const screen = resolveMenuScreen(definition, screenId, state);
 			let staleAction = false;
 			const interact = async (interaction: MenuInteraction, interactionSignal?: AbortSignal) => {
 				const invocation = await invokeMenuInteraction({
@@ -107,10 +109,12 @@ async function runTuiMenu<
 			const event = await showTuiScreen(
 				ctx,
 				screen,
-				navigator.selectionFor(navigator.current, selectableItemIds(screen)),
+				navigator.selectionFor(screenId, selectableItemIds(screen)),
+				searchQueries.get(screenId),
 				menuSignal,
 				{
-					onSelectionChange: (itemId) => navigator.rememberSelection(navigator.current, itemId),
+					onSelectionChange: (itemId) => navigator.rememberSelection(screenId, itemId),
+					onSearchQueryChange: (query) => searchQueries.set(screenId, query),
 					onSettingChange: (change, signal) =>
 						interact({ kind: "setting", itemId: change.itemId, value: change.value }, signal),
 					onMultiSelectChange: (change, signal) =>
@@ -136,15 +140,18 @@ async function runTuiMenu<
 				continue;
 			}
 			if (event.kind === "back" || event.kind === "close") {
+				searchQueries.delete(screenId);
 				navigator.apply({ kind: event.kind });
 				continue;
 			}
 			if (event.kind === "transition") {
+				if (event.transition.kind !== "stay") searchQueries.delete(screenId);
 				navigator.apply(event.transition);
 				continue;
 			}
 			const outcome = await interact({ kind: "activate", itemId: event.itemId });
 			if (outcome.stale) return { kind: "stale" };
+			if (outcome.transition.kind !== "stay") searchQueries.delete(screenId);
 			navigator.apply(outcome.transition);
 		}
 		return closedMenuResult(navigator.closeReason);
@@ -181,9 +188,11 @@ async function showTuiScreen<
 	ctx: Context,
 	screen: MenuScreen<ScreenId, ActionId>,
 	selectedItemId: string | undefined,
+	searchQuery: string | undefined,
 	menuSignal: AbortSignal,
 	callbacks: {
 		onSelectionChange(itemId: string): void;
+		onSearchQueryChange(query: string): void;
 		onSettingChange(
 			change: MenuSettingChange,
 			signal: AbortSignal,
@@ -220,11 +229,13 @@ async function showTuiScreen<
 				component = createMenuScreenComponent({
 					screen,
 					selectedItemId,
+					searchQuery,
 					tui,
 					theme,
 					keybindings,
 					onEvent: finish,
 					onSelectionChange: callbacks.onSelectionChange,
+					onSearchQueryChange: callbacks.onSearchQueryChange,
 					onSettingChange: (change) => callbacks.onSettingChange(change, screenController.signal),
 					onMultiSelectChange: (change) =>
 						callbacks.onMultiSelectChange(change, screenController.signal),

--- a/packages/pi-tui-kit/src/types.ts
+++ b/packages/pi-tui-kit/src/types.ts
@@ -76,6 +76,8 @@ export interface DetailScreen {
 export interface MenuChoiceItem extends MenuItemBase {
 	details?: readonly string[];
 	disabledReason?: string;
+	/** Additional non-rendered text used by optional TUI fuzzy search. */
+	searchText?: string;
 }
 
 export interface ChoiceScreen<ActionId extends string> {
@@ -86,6 +88,8 @@ export interface ChoiceScreen<ActionId extends string> {
 	action: ActionId;
 	currentItemId?: string;
 	initialItemId?: string;
+	/** Enables TUI-only fuzzy filtering while RPC keeps one deterministic unfiltered list. */
+	enableSearch?: boolean;
 	viewportSize?: number;
 	hint?: "back" | "close";
 }

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -40,7 +40,7 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("package exposes API version 11 and exact browse detail types", () => {
+test("package exposes API version 12 and exact browse detail types", () => {
 	const document: BrowseDetailDocument = {
 		content: "  exact\nbody",
 		format: { kind: "code", language: "json" },
@@ -51,7 +51,7 @@ test("package exposes API version 11 and exact browse detail types", () => {
 		detailDocument: document,
 	};
 	assert.equal(item.detailDocument, document);
-	assert.equal(PI_EXTENSION_MENU_API_VERSION, 11);
+	assert.equal(PI_EXTENSION_MENU_API_VERSION, 12);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/searchable-choice.test.ts
+++ b/packages/pi-tui-kit/test/searchable-choice.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { defineMenu, runMenu } from "../src/index.js";
+import { createRpcHarness, createTuiHarness } from "../src/testing/index.js";
+
+function context(tui: ReturnType<typeof createTuiHarness>) {
+	return {
+		mode: "tui" as const,
+		hasUI: true,
+		ui: { custom: tui.custom, notify() {} },
+	} as unknown as ExtensionCommandContext;
+}
+
+test("searchable choice filters safe metadata and confirms the raw stable id", async () => {
+	let selected: string | undefined;
+	const menu = defineMenu<undefined, "choice", "select">({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "choice",
+				title: "Resume",
+				enableSearch: true,
+				items: [
+					{ id: "raw-one", label: "Duplicate", description: "Older", searchText: "alpha" },
+					{
+						id: "raw-two",
+						label: "Duplicate",
+						description: "Newer",
+						searchText: "beta\u001b[31m needle",
+					},
+				],
+				action: "select",
+				initialItemId: "raw-one",
+			}),
+		},
+		actions: {
+			select: async ({ itemId }) => {
+				selected = itemId;
+				return { kind: "close" };
+			},
+		},
+	});
+	const tui = createTuiHarness({ width: 32, rows: 16 });
+	const running = runMenu(context(tui), menu, { getState: () => undefined });
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	assert.equal(tui.render().join("\n").includes(CURSOR_MARKER), true);
+	tui.type("needle");
+	const filtered = tui.render();
+	assert.match(filtered.join("\n"), /→ Duplicate/u);
+	assert.equal(filtered.join("\n").includes("\u001b[31m"), false);
+	assert.ok(filtered.every((line) => visibleWidth(line) <= 32));
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+	assert.equal(selected, "raw-two");
+});
+
+test("searchable choice retains query and stable selection after rejection", async () => {
+	let attempts = 0;
+	const menu = defineMenu<undefined, "choice", "select">({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "choice",
+				title: "Records",
+				enableSearch: true,
+				items: [
+					{ id: "first", label: "First" },
+					{ id: "second", label: "Second" },
+				],
+				action: "select",
+			}),
+		},
+		actions: {
+			select: async () => {
+				attempts += 1;
+				return attempts === 1 ? { kind: "rejected" } : { kind: "close" };
+			},
+		},
+	});
+	const tui = createTuiHarness();
+	const running = runMenu(context(tui), menu, { getState: () => undefined });
+	await tui.waitForOpen();
+	tui.type("second");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	const retry = tui.render().join("\n");
+	assert.match(retry, /→ Second/u);
+	assert.doesNotMatch(retry, /First/u);
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+	assert.equal(attempts, 2);
+});
+
+test("searchable choice distinguishes owner abort and external disposal", async () => {
+	const menu = defineMenu<undefined, "choice", "select">({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "choice",
+				title: "Records",
+				enableSearch: true,
+				items: [{ id: "first", label: "First" }],
+				action: "select",
+			}),
+		},
+		actions: { select: async () => ({ kind: "close" }) },
+	});
+
+	const owner = new AbortController();
+	const abortedTui = createTuiHarness();
+	const aborted = runMenu(context(abortedTui), menu, {
+		getState: () => undefined,
+		signal: owner.signal,
+	});
+	await abortedTui.waitForOpen();
+	owner.abort();
+	assert.deepEqual(await aborted, { kind: "stale" });
+	assert.equal(abortedTui.isOpen, false);
+
+	const disposedTui = createTuiHarness();
+	const disposed = runMenu(context(disposedTui), menu, { getState: () => undefined });
+	await disposedTui.waitForOpen();
+	disposedTui.dispose();
+	assert.deepEqual(await disposed, { kind: "closed", reason: "close" });
+});
+
+test("RPC searchable choice remains one deterministic unfiltered selector", async () => {
+	let selected: string | undefined;
+	const menu = defineMenu<undefined, "choice", "select">({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "choice",
+				title: "Records",
+				enableSearch: true,
+				items: [
+					{ id: "first", label: "Same", searchText: "private first" },
+					{ id: "second", label: "Same", searchText: "private second" },
+				],
+				action: "select",
+			}),
+		},
+		actions: {
+			select: async ({ itemId }) => {
+				selected = itemId;
+				return { kind: "close" };
+			},
+		},
+	});
+	const rpc = createRpcHarness([
+		{ kind: "select", options: ["Same", "Same [2]", "Back"], response: "Same [2]" },
+	]);
+	const ctx = {
+		mode: "rpc" as const,
+		hasUI: true,
+		ui: rpc.ui,
+	} as unknown as ExtensionCommandContext;
+	assert.deepEqual(await runMenu(ctx, menu, { getState: () => undefined }), {
+		kind: "closed",
+		reason: "close",
+	});
+	assert.equal(selected, "second");
+	rpc.assertConsumed();
+});
+
+test("searchable choice exposes no-match recovery, disabled explanation, and exact exits", async () => {
+	const menu = defineMenu<undefined, "choice", "select">({
+		start: "choice",
+		screens: {
+			choice: () => ({
+				kind: "choice",
+				title: "Records",
+				enableSearch: true,
+				items: [
+					{
+						id: "disabled",
+						label: "Unavailable",
+						disabled: true,
+						disabledReason: "Policy blocked",
+					},
+				],
+				action: "select",
+				hint: "back",
+			}),
+		},
+		actions: { select: async () => assert.fail("disabled choice must stay inert") },
+	});
+	const tui = createTuiHarness({ width: 32, rows: 12 });
+	const running = runMenu(context(tui), menu, { getState: () => undefined });
+	await tui.waitForOpen();
+	tui.type("missing");
+	assert.match(tui.render().join("\n"), /No matching choices/u);
+	for (let index = 0; index < 7; index += 1) tui.send("\u007f");
+	assert.match(tui.render().join("\n"), /Policy\s+blocked/u);
+	tui.press("tui.select.confirm");
+	assert.equal(tui.isOpen, true);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});

--- a/packages/pi-tui-kit/test/searchable-choice.test.ts
+++ b/packages/pi-tui-kit/test/searchable-choice.test.ts
@@ -89,6 +89,11 @@ test("searchable choice retains query and stable selection after rejection", asy
 	const retry = tui.render().join("\n");
 	assert.match(retry, /→ Second/u);
 	assert.doesNotMatch(retry, /First/u);
+	tui.send("\u007f");
+	tui.type("d");
+	const editedRetry = tui.render().join("\n");
+	assert.match(editedRetry, /→ Second/u);
+	assert.doesNotMatch(editedRetry, /First/u);
 	tui.press("tui.select.confirm");
 	assert.deepEqual(await running, { kind: "closed", reason: "close" });
 	assert.equal(attempts, 2);

--- a/packages/pi-tui-kit/test/testing-exports.test.ts
+++ b/packages/pi-tui-kit/test/testing-exports.test.ts
@@ -11,7 +11,7 @@ test("built package roots resolve separate production and testing exports", asyn
 	const testingSpecifier = "@narumitw/pi-tui-kit/testing";
 	const production = await import(productionSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 11);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 12);
 	assert.equal(typeof production.formatInteractionHints, "function");
 	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");
@@ -26,13 +26,14 @@ test("built package roots resolve separate production and testing exports", asyn
 	t.onTestFinished(() => rmSync(fixture, { recursive: true, force: true }));
 	writeFileSync(
 		path.join(fixture, "usage.ts"),
-		`import { PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type LiveChoiceItem, type MenuBrowseItem } from "@narumitw/pi-tui-kit";\n` +
+		`import { PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type ChoiceScreen, type LiveChoiceItem, type MenuBrowseItem } from "@narumitw/pi-tui-kit";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 11 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const version: 12 = PI_EXTENSION_MENU_API_VERSION;\n` +
 			`const document: BrowseDetailDocument = { content: "  exact", format: { kind: "text" } };\n` +
 			`const item: MenuBrowseItem = { id: "one", label: "One", detailDocument: document };\n` +
 			`const choice: LiveChoiceItem = { id: "active", label: "Active", confirmationDisabled: true, confirmationDisabledReason: "Already active" };\n` +
-			`void version;\nvoid item;\nvoid choice;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
+			`const screen: ChoiceScreen<"select"> = { kind: "choice", title: "Records", enableSearch: true, items: [{ id: "one", label: "One", searchText: "alias" }], action: "select" };\n` +
+			`void version;\nvoid item;\nvoid choice;\nvoid screen;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
 	);
 	writeFileSync(
 		path.join(fixture, "tsconfig.json"),


### PR DESCRIPTION
## Summary

- add opt-in TUI fuzzy search to declarative choice screens
- preserve raw stable IDs, disabled explanations, IME focus, and rejected-action query restoration
- keep RPC as one deterministic unfiltered selector

## Verification

- red-first TUI and RPC searchable-choice tests
- 181 focused Pi TUI Kit tests
- complete Pi TUI Kit check and build
- `npm run check` (373 files, 3,752 tests)
- runtime import benchmark (`codingAgentLoaded: false` in every scenario)
- `just pack tui-kit` (59 intended files)
- `git diff --check`

The first root gate exposed the unrelated flaky Fleet launch integration. It passed in isolation, and the complete root gate then passed.

This Kit-only PR advances `PI_EXTENSION_MENU_API_VERSION` to 12. It does not publish the package or migrate a consumer; consumer adoption must follow a registry-verified release.
