### PR TITLE
feat(btw): search resumable side threads

### DIFF
--- a/.changeset/bright-btw-resume.md
+++ b/.changeset/bright-btw-resume.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": minor
+---
+
+Add local fuzzy search to the in-memory Resume thread choice.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9295,7 +9295,7 @@
 			"version": "0.50.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1"
+				"@narumitw/pi-tui-kit": "^0.54.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",
@@ -9308,28 +9308,6 @@
 				"@earendil-works/pi-ai": "*",
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-btw/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.49.3",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
-			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
-			"license": "MIT",
-			"dependencies": {
-				"highlight.js": "11.11.1"
-			},
-			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-btw/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"packages/pi-caffeinate": {

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -58,14 +58,15 @@ Examples:
 /btw is this API name idiomatic?
 ```
 
-Running `/btw` alone opens a menu with **Start side thread** selected first. When the current Pi
-session has non-empty side threads in memory, **Resume side thread** opens a bounded choice list;
+Running `/btw` alone opens a menu with **Start side thread** selected first.
+When the current Pi session has non-empty side threads in memory, **Resume side thread** opens a bounded searchable choice list.
+Search matches the displayed first question and question count while returning the thread's raw in-memory ID.
 **Settings** changes the starting thinking level and whether shortcut changes are remembered.
-Each Resume row keeps the first question as its fixed title, shows its question count, and the list
-is ordered by the newest recorded answer or visible error. Opening and closing a thread without a
-new result does not reorder it. `/btw <question>` bypasses this menu and always starts a fresh side
-thread. Its answer opens above the side-thread editor. The side thread uses a dedicated full-screen
-terminal view.
+Each Resume row keeps the first question as its fixed title, shows its question count, and the list is ordered by the newest recorded answer or visible error.
+Opening and closing a thread without a new result does not reorder it.
+`/btw <question>` bypasses this menu and always starts a fresh side thread.
+Its answer opens above the side-thread editor.
+The side thread uses a dedicated full-screen terminal view.
 The main agent continues running in the background, but its screen rendering stays suspended until
 `/btw` closes, so new main-thread output cannot move a mouse selection inside the side thread.
 Drag the primary mouse button across side-thread text to select and copy it through Pi's terminal

--- a/packages/pi-btw/package.json
+++ b/packages/pi-btw/package.json
@@ -43,7 +43,7 @@
 		"directory": "packages/pi-btw"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1"
+		"@narumitw/pi-tui-kit": "^0.54.0"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",

--- a/packages/pi-btw/src/menu.ts
+++ b/packages/pi-btw/src/menu.ts
@@ -120,6 +120,7 @@ export async function showBtwCommandMenu(
 			resume: () => ({
 				kind: "choice",
 				title: "Resume BTW side thread",
+				enableSearch: true,
 				items: resumeThreads.map((thread) => ({
 					id: thread.id,
 					label: thread.title,

--- a/packages/pi-btw/test/menu.test.ts
+++ b/packages/pi-btw/test/menu.test.ts
@@ -122,12 +122,45 @@ test("btw menu selects an in-memory side thread through a Kit choice screen", as
 		assert.ok(choices.indexOf("Second side topic") < choices.indexOf("First side topic"));
 		assert.match(choices, /Second side topic\s+3 questions/);
 		assert.match(choices, /First side topic\s+1 question/);
+		tui.type("missing");
+		assert.match(tui.render().join("\n"), /No matching choices/u);
+		for (let index = 0; index < 7; index += 1) tui.send("\u007f");
+		tui.type("first");
+		const filtered = tui.render().join("\n");
+		assert.match(filtered, /→ First side topic/u);
+		assert.doesNotMatch(filtered, /Second side topic/u);
 		assert.ok(tui.resize({ width: 32 }).every((line) => visibleWidth(line) <= 32));
 		tui.press("tui.select.confirm");
 
-		assert.deepEqual(await running, { kind: "resume", threadId: "newer" });
+		assert.deepEqual(await running, { kind: "resume", threadId: "older" });
 		assert.equal(ctx.ui.getEditorText(), "draft");
 		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});
+
+test("btw Resume search keeps duplicate titles tied to raw thread ids", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx }) => {
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "low",
+			availableThinkingLevels: ["off", "low"],
+			resumeThreads: [
+				{ id: "newer", title: "Repeated question", questionCount: 3 },
+				{ id: "older", title: "Repeated question", questionCount: 1 },
+			],
+		});
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.type("1 question");
+		const filtered = tui.render().join("\n");
+		assert.match(filtered, /→ Repeated question\s+1 question/u);
+		assert.doesNotMatch(filtered, /3 questions/u);
+		tui.press("tui.select.confirm");
+
+		assert.deepEqual(await running, { kind: "resume", threadId: "older" });
+		assert.equal(ctx.ui.getEditorText(), "draft");
 	});
 });
 


### PR DESCRIPTION
## Summary

- raise BTW's Pi TUI Kit floor to the registry-verified 0.54 release
- opt the in-memory Resume choice into local TUI fuzzy search
- search displayed first questions and question counts while preserving raw thread IDs and newest-first empty-query order

## Verification

- red-first BTW Resume search tests
- focused BTW menu and command tests (35 tests)
- duplicate-title raw-ID selection, no-match recovery, narrow resize, Back, Close, disposal, and empty-list coverage
- `npm ls @narumitw/pi-tui-kit --workspace @narumitw/pi-btw --all`
- BTW package check and typecheck
- `npm run check` (374 files, 3,757 tests)
- `just pack btw` (12 intended files)
- `git diff --check`

The first root gate exposed the unrelated flaky Fleet launch integration.

That test passed in isolation, and the complete root gate then passed.

The registry release was clean-installed and verified at runtime and through NodeNext declarations before this consumer floor changed.

Thread loading, newest-first ordering, titles, counts, persistence lifetime, Back, Close, non-TUI behavior, and session ownership remain BTW-owned and unchanged.

The deterministic TUI harness covered the complete interaction; an interactive Pi TUI smoke was not run because it would require opening an interactive terminal flow.
