### PR TITLE
feat(worktree): search worktree selectors

### DIFF
--- a/.changeset/fresh-worktree-choice.md
+++ b/.changeset/fresh-worktree-choice.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-worktree": minor
+---
+
+Add local fuzzy search to worktree identity selectors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10311,7 +10311,7 @@
 			"version": "0.50.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.51.0"
+				"@narumitw/pi-tui-kit": "^0.54.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",
@@ -10321,28 +10321,6 @@
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*"
-			}
-		},
-		"packages/pi-worktree/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.51.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.51.0.tgz",
-			"integrity": "sha512-NH5G2GTegZwU7H5anGnTox7q+2PIhTOz6W+4YRgyYb9xuqLfOBBtY58xwoDxYqrgnmfycc0d9O6PvF37gWtzug==",
-			"license": "MIT",
-			"dependencies": {
-				"highlight.js": "11.11.1"
-			},
-			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-worktree/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		}
 	}

--- a/packages/pi-worktree/README.md
+++ b/packages/pi-worktree/README.md
@@ -54,8 +54,8 @@ Choose one action:
 
 - **Worktree status** — browse a local snapshot for every registered worktree without fetching remotes.
 - **Add worktree** — enter a branch, optional start point, and optional path; review exact base provenance, confirm creation, and optionally switch.
-- **Switch worktree** — select another existing worktree and continue this Pi conversation there.
-- **Remove worktree** — remove a linked worktree without deleting its branch; ignored-only data is listed for explicit confirmation.
+- **Switch worktree** — search for another existing worktree by displayed path, branch, or HEAD and continue this Pi conversation there.
+- **Remove worktree** — search for a linked worktree by displayed path, branch, or HEAD, then remove it without deleting its branch; ignored-only data is listed for explicit confirmation.
 - **Prune stale metadata** — inspect Git's dry-run output, then optionally run the matching prune.
 - **Configure worktree root** — set a machine-local default root or submit a blank value to restore `~/.worktrees`.
 
@@ -63,7 +63,7 @@ The standard root menu shows the registered count, current path, effective workt
 and any settings warning. Escape closes it. `/worktree` intentionally does not accept text
 subcommands or expose argument autocomplete. Every change is initiated and confirmed through TUI or
 RPC dialogs; print and JSON modes reject the command observably. Operation-specific branch/path
-inputs, worktree identity selectors, preflight previews, and destructive confirmations remain
+inputs, searchable worktree identity selectors, preflight previews, and destructive confirmations remain
 extension-owned because they carry Git safety and commit-aware revalidation.
 
 The status browser runs only when selected and has no watcher, timer, persistent cache, or network

--- a/packages/pi-worktree/package.json
+++ b/packages/pi-worktree/package.json
@@ -46,6 +46,6 @@
 		"directory": "packages/pi-worktree"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.51.0"
+		"@narumitw/pi-tui-kit": "^0.54.0"
 	}
 }

--- a/packages/pi-worktree/src/command.ts
+++ b/packages/pi-worktree/src/command.ts
@@ -768,9 +768,11 @@ async function selectWorktree(
 			worktrees: () => ({
 				kind: "choice",
 				title,
+				enableSearch: true,
 				items: records.map((record, index) => ({
 					id: record.path,
 					label: `${index + 1}. ${formatWorktree(record, currentPath)}`,
+					searchText: [record.path, record.branch, record.head].filter(Boolean).join(" "),
 				})),
 				action: "choose",
 				hint: "close",

--- a/packages/pi-worktree/test/command.test.ts
+++ b/packages/pi-worktree/test/command.test.ts
@@ -549,9 +549,9 @@ test("switch selection searches branch and path while preserving raw worktree id
 				tui.press("tui.select.down");
 				tui.press("tui.select.confirm");
 			} else {
-				tui.type("fix/api");
+				tui.type("backend fix/api");
 				const filtered = tui.render().join("\n");
-				assert.match(filtered, /→ 2\..*backend.*fix\/api/u);
+				assert.match(filtered, /→ 2\..*backend/u);
 				assert.doesNotMatch(filtered, /frontend/u);
 				tui.press("tui.select.confirm");
 				await tui.waitForPending();

--- a/packages/pi-worktree/test/command.test.ts
+++ b/packages/pi-worktree/test/command.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExecResult } from "@earendil-works/pi-coding-agent";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import {
 	createCustomSelectorHarness,
@@ -505,6 +506,74 @@ test("switch action prepares a target-cwd session and uses the replacement conte
 		assert.equal(switchedCwd, linked);
 		assert.match(replacementNotice, /switched/i);
 	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("switch selection searches branch and path while preserving raw worktree identity", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-worktree-search-choice-"));
+	const main = join(root, "repo");
+	const first = join(root, "worktrees", "frontend");
+	const second = join(root, "worktrees", "backend");
+	mkdirSync(main, { recursive: true });
+	mkdirSync(first, { recursive: true });
+	mkdirSync(second, { recursive: true });
+	const mock = createMockPi();
+	(mock.rawPi as typeof mock.rawPi & { exec: ExecFunction }).exec = async (_command, args) => {
+		if (args[0] === "worktree") {
+			return result(
+				porcelain([
+					{ path: main, branch: "main" },
+					{ path: first, branch: "feature/ui" },
+					{ path: second, branch: "fix/api" },
+				]),
+			);
+		}
+		return result(`${main}\n`);
+	};
+	worktreeExtension(mock.pi);
+	const tui = createTuiHarness({ width: 72, rows: 20 });
+	let customCalls = 0;
+	let switchedCwd = "";
+	const context = createMockContext({
+		cwd: main,
+		hasUI: true,
+		mode: "tui",
+		sessionManager: { getSessionFile: () => undefined, getEntries: () => [] },
+		custom: async (factory: Parameters<typeof tui.custom>[0], options?: unknown) => {
+			customCalls += 1;
+			const pending = tui.custom(factory, options as never);
+			await tui.waitForOpen();
+			if (customCalls === 1) {
+				tui.press("tui.select.down");
+				tui.press("tui.select.down");
+				tui.press("tui.select.confirm");
+			} else {
+				tui.type("fix/api");
+				const filtered = tui.render().join("\n");
+				assert.match(filtered, /→ 2\..*backend.*fix\/api/u);
+				assert.doesNotMatch(filtered, /frontend/u);
+				tui.press("tui.select.confirm");
+				await tui.waitForPending();
+			}
+			return pending;
+		},
+		switchSession: async (
+			path: string,
+			options: { withSession?: (ctx: unknown) => Promise<void> },
+		) => {
+			const session = (await import("@earendil-works/pi-coding-agent")).SessionManager.open(path);
+			switchedCwd = session.getCwd();
+			await options.withSession?.({ cwd: second, ui: { notify() {} } });
+			return { cancelled: false };
+		},
+	});
+	try {
+		await mock.commands.get("worktree")?.handler("", context.ctx);
+		assert.equal(customCalls, 2);
+		assert.equal(switchedCwd, second, JSON.stringify(context.notifications));
+	} finally {
+		tui.dispose();
 		rmSync(root, { recursive: true, force: true });
 	}
 });

--- a/packages/pi-worktree/test/command.test.ts
+++ b/packages/pi-worktree/test/command.test.ts
@@ -535,6 +535,7 @@ test("switch selection searches branch and path while preserving raw worktree id
 	const tui = createTuiHarness({ width: 72, rows: 20 });
 	let customCalls = 0;
 	let switchedCwd = "";
+	let filteredFrame = "";
 	const context = createMockContext({
 		cwd: main,
 		hasUI: true,
@@ -550,9 +551,7 @@ test("switch selection searches branch and path while preserving raw worktree id
 				tui.press("tui.select.confirm");
 			} else {
 				tui.type("backend fix/api");
-				const filtered = tui.render().join("\n");
-				assert.match(filtered, /→ 2\..*backend/u);
-				assert.doesNotMatch(filtered, /frontend/u);
+				filteredFrame = tui.render().join("\n");
 				tui.press("tui.select.confirm");
 				await tui.waitForPending();
 			}
@@ -571,6 +570,8 @@ test("switch selection searches branch and path while preserving raw worktree id
 	try {
 		await mock.commands.get("worktree")?.handler("", context.ctx);
 		assert.equal(customCalls, 2);
+		assert.match(filteredFrame, /→ 2\..*backend/u);
+		assert.doesNotMatch(filteredFrame, /frontend/u);
 		assert.equal(switchedCwd, second, JSON.stringify(context.notifications));
 	} finally {
 		tui.dispose();


### PR DESCRIPTION
## Summary

- raise Worktree's Pi TUI Kit floor to the registry-verified 0.54 release
- opt shared Switch and Remove worktree identity choices into local TUI fuzzy search
- search displayed labels plus explicit raw path, branch, and HEAD metadata while preserving raw path identity and post-selection revalidation

## Verification

- red-first Worktree selector search test
- focused command and Git formatting tests (32 tests)
- exact raw-path switch result through the real Kit TUI harness
- `npm ls @narumitw/pi-tui-kit --workspace @narumitw/pi-worktree --all`
- Worktree package check and typecheck
- `npm run check` (374 files, 3,757 tests)
- `just pack worktree` (10 intended files)
- `git diff --check`

The registry release was clean-installed and verified at runtime and through NodeNext declarations before this consumer floor changed.

Git inventory, source ordering, format labels, post-selection identity checks, destructive confirmation, mutation policy, RPC behavior, and session switching remain Worktree-owned and unchanged.

The deterministic TUI harness covered the complete switch interaction; an interactive Pi switch smoke was not run because it would replace the active coding session.
