### PR TITLE
feat: expand local extension development command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ vite.config.ts.timestamp-*
 # Project
 third_party/
 packages/pi-lsp/test/docker/results/raw/
+.pi/agent/

--- a/justfile
+++ b/justfile
@@ -87,11 +87,12 @@ smoke-chat-network:
 benchmark-subagents samples="7":
     node scripts/benchmark-pi-subagents-transports.mjs --samples {{ quote(samples) }}
 
-# Install dependencies and start Pi with every local extension package
-# pi-statusline and pi-tui-kit are intentionally excluded
+# Install dependencies, build the shared TUI library, and start every local extension package
+# pi-statusline and pi-tui-kit are intentionally excluded from Pi extension loading
 # PI_TIMING reports startup timing and PI_CODING_AGENT_DIR isolates local development state
 dev:
     npm install
+    npm --workspace @narumitw/pi-tui-kit run build
     PI_TIMING=1 PI_CODING_AGENT_DIR=./.pi/agent pi \
         -e ./packages/pi-accounts \
         -e ./packages/pi-analytics \

--- a/justfile
+++ b/justfile
@@ -87,28 +87,36 @@ smoke-chat-network:
 benchmark-subagents samples="7":
     node scripts/benchmark-pi-subagents-transports.mjs --samples {{ quote(samples) }}
 
-# Start Pi with the commonly used extensions loaded from this working tree
-# PI_TIMING reports startup timing for local extension development
+# Install dependencies and start Pi with every local extension package
+# pi-statusline and pi-tui-kit are intentionally excluded
+# PI_TIMING reports startup timing and PI_CODING_AGENT_DIR isolates local development state
 dev:
-    PI_TIMING=1 pi -ns -ne \
+    npm install
+    PI_TIMING=1 PI_CODING_AGENT_DIR=./.pi/agent pi \
         -e ./packages/pi-accounts \
+        -e ./packages/pi-analytics \
         -e ./packages/pi-btw \
         -e ./packages/pi-caffeinate \
+        -e ./packages/pi-chat \
         -e ./packages/pi-chrome-devtools \
-        -e ./packages/pi-github-pr \
-        -e ./packages/pi-goal \
-        -e ./packages/pi-plan-mode \
+        -e ./packages/pi-codex-compact \
+        -e ./packages/pi-file-context \
         -e ./packages/pi-firecrawl \
-        -e ./packages/pi-sync \
-        -e ./packages/pi-usage \
-        -e ./packages/pi-worktree \
+        -e ./packages/pi-fleet \
+        -e ./packages/pi-github-pr \
+        -e ./packages/pi-image-drop \
+        -e ./packages/pi-langfuse \
+        -e ./packages/pi-lsp \
+        -e ./packages/pi-recall \
         -e ./packages/pi-stamp \
         -e ./packages/pi-starship \
-        -e ./packages/pi-codex-compact
-
-# Start a fresh Pi session with every local extension package loaded
-try-all:
-    shopt -s nullglob; args=(); for package_json in ./packages/pi-*/package.json; do if node -e 'const p = require(process.argv[1]); process.exit(p.pi?.extensions ? 0 : 1)' "$package_json"; then args+=(-e "$(dirname "$package_json")"); fi; done; pi -ne "${args[@]}"
+        -e ./packages/pi-subagents \
+        -e ./packages/pi-sync \
+        -e ./packages/pi-tool \
+        -e ./packages/pi-usage \
+        -e ./packages/pi-webui \
+        -e ./packages/pi-workflow \
+        -e ./packages/pi-worktree
 
 # Install a package through pi, falling back to the local workspace if unpublished
 # Usage: just install subagents


### PR DESCRIPTION
## Summary

- Expand `just dev` to install dependencies and load local extension packages explicitly.
- Keep `pi-statusline` and `pi-tui-kit` out of Pi extension loading.
- Build `pi-tui-kit` before startup so consumers use its current exports.
- Isolate generated Pi state under the ignored `.pi/agent/` directory.
- Remove the dynamic `try-all` recipe.

## Verification

- `just --dry-run dev`
- `npm --workspace @narumitw/pi-tui-kit run build`
- Runtime import check for `sanitizeTerminalText`
- Pre-commit hook: `npm run biome:check && npm run typecheck`

Changeset omitted because this only changes repository development tooling.