### PR TITLE
feat(pi-accounts): expose named Anthropic accounts as providers

### DIFF
--- a/packages/pi-accounts/src/accounts.ts
+++ b/packages/pi-accounts/src/accounts.ts
@@ -13,6 +13,7 @@ import {
 	parseAccountName,
 	type StoredOAuthCredential,
 } from "./account-store.js";
+import { registerAnthropicProviderAliases } from "./anthropic-provider-aliases.js";
 import {
 	type AccountProviderAdapter,
 	type AccountProviderId,
@@ -206,6 +207,9 @@ export default function accountsExtension(
 		);
 		setStatus(ctx, undefined);
 	});
+
+	const anthropic = adapters.get("anthropic");
+	if (anthropic) registerAnthropicProviderAliases(pi, store, anthropic);
 }
 
 function createAccountCommand(

--- a/packages/pi-accounts/src/anthropic-provider-aliases.ts
+++ b/packages/pi-accounts/src/anthropic-provider-aliases.ts
@@ -1,0 +1,76 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AccountStore } from "./account-store.js";
+import type { AccountProviderAdapter } from "./oauth.js";
+import { RuntimeAuthCoordinator } from "./runtime-auth.js";
+
+const PREFIX = "anthropic-";
+const PLACEHOLDER_KEY = "pi-accounts-pending";
+
+type ModelConfig = { id: string; [key: string]: unknown };
+
+export function registerAnthropicProviderAliases(
+	pi: ExtensionAPI,
+	store: AccountStore,
+	adapter: AccountProviderAdapter,
+): void {
+	const coordinators = new Map<string, RuntimeAuthCoordinator>();
+	let aliases = new Set<string>();
+	let models: ModelConfig[] = [];
+
+	const sync = async (ctx: ExtensionContext) => {
+		const state = await store.readProviderAsync("anthropic");
+		models = ctx.modelRegistry
+			.getAvailable()
+			.filter((model) => model.provider === "anthropic")
+			.map(({ provider: _provider, baseUrl: _baseUrl, ...model }) => model as ModelConfig);
+		const next = new Set(Object.keys(state.accounts).map((name) => `${PREFIX}${name}`));
+		for (const alias of aliases) {
+			if (next.has(alias)) continue;
+			await coordinators.get(alias)?.clear(ctx);
+			coordinators.delete(alias);
+			pi.unregisterProvider(alias);
+		}
+		for (const alias of next) {
+			registerAlias(pi, alias, models, PLACEHOLDER_KEY);
+			const name = alias.slice(PREFIX.length);
+			const coordinator = new RuntimeAuthCoordinator(pi, adapter, undefined, {
+				providerId: alias,
+				accountName: name,
+			});
+			coordinators.set(alias, coordinator);
+			await coordinator.ensureActive(ctx, store);
+		}
+		aliases = next;
+	};
+
+	pi.on("session_start", async (_event, ctx) => {
+		await sync(ctx);
+	});
+	pi.on("before_agent_start", async (_event, ctx) => {
+		const alias = ctx.model?.provider;
+		if (!alias?.startsWith(PREFIX)) return;
+		const coordinator = coordinators.get(alias);
+		if (!coordinator) throw new Error(`Anthropic account alias ${alias} is not configured.`);
+		const result = await coordinator.ensureActive(ctx, store);
+		if (result.status !== "active") {
+			ctx.ui.notify(`Anthropic account ${alias.slice(PREFIX.length)} is unavailable.`, "error");
+			ctx.abort();
+		}
+	});
+	pi.on("session_shutdown", async (_event, ctx) => {
+		await Promise.allSettled(
+			[...coordinators.values()].map((coordinator) => coordinator.clear(ctx)),
+		);
+	});
+}
+
+function registerAlias(pi: ExtensionAPI, id: string, models: ModelConfig[], apiKey: string): void {
+	pi.unregisterProvider(id);
+	pi.registerProvider(id, {
+		name: id,
+		baseUrl: "https://api.anthropic.com",
+		api: "anthropic-messages",
+		apiKey,
+		models: models as never,
+	});
+}

--- a/packages/pi-accounts/src/runtime-auth.ts
+++ b/packages/pi-accounts/src/runtime-auth.ts
@@ -39,7 +39,7 @@ export type RuntimeAccountStore = {
 };
 
 export type EnsureActiveProviderAuthResult =
-	| { status: "inactive"; providerId: AccountProviderId }
+	| { status: "inactive"; providerId: string }
 	| { status: "active"; providerId: AccountProviderId; accountName: string }
 	| { status: "error"; providerId: AccountProviderId; accountName: string; message: string };
 
@@ -47,14 +47,23 @@ export class RuntimeAuthCoordinator {
 	private readonly controller: RuntimeApiKeyController;
 	private readonly overlay: RuntimeProviderOverlay;
 	private availableModelIds: ReadonlySet<string> | undefined;
+	private readonly runtimeProviderId: string;
+	private readonly accountName: string | undefined;
 
 	constructor(
 		pi: ExtensionAPI,
 		readonly provider: AccountProviderAdapter,
 		private readonly failClosedApiKey = RUNTIME_FAIL_CLOSED_API_KEY,
+		options: { providerId?: string; accountName?: string } = {},
 	) {
-		this.controller = new RuntimeApiKeyController(provider.id);
-		this.overlay = new RuntimeProviderOverlay(pi, provider, failClosedApiKey);
+		this.runtimeProviderId = options.providerId ?? provider.id;
+		this.accountName = options.accountName;
+		this.controller = new RuntimeApiKeyController(this.runtimeProviderId);
+		this.overlay = new RuntimeProviderOverlay(
+			pi,
+			{ ...provider, id: this.runtimeProviderId } as AccountProviderAdapter,
+			failClosedApiKey,
+		);
 	}
 
 	async ensureActive(
@@ -70,7 +79,7 @@ export class RuntimeAuthCoordinator {
 		} catch (error) {
 			return this.failClosed(ctx, operation, runtimeOverride, "unknown", error);
 		}
-		const active = state.active;
+		const active = this.accountName ?? state.active;
 		if (!active) {
 			this.availableModelIds = undefined;
 			try {
@@ -112,7 +121,7 @@ export class RuntimeAuthCoordinator {
 			try {
 				current = await store.updateProviderAsync(this.provider.id, async (latest) => {
 					const latestCredential = getOwnCredential(latest.accounts, active);
-					if (latest.active !== active || !latestCredential) return latest;
+					if (!this.isSelectedAccount(latest, active) || !latestCredential) return latest;
 					credential = latestCredential;
 					if (latestCredential.expires > now + REFRESH_SKEW_MS) return latest;
 					try {
@@ -131,7 +140,7 @@ export class RuntimeAuthCoordinator {
 				refreshError = error;
 				credential = getOwnCredential(current.accounts, active) ?? credential;
 			}
-			if (current.active !== active || !getOwnCredential(current.accounts, active)) {
+			if (!this.isSelectedAccount(current, active)) {
 				return this.ensureActive(ctx, store, now);
 			}
 			if (refreshError !== undefined) {
@@ -273,13 +282,20 @@ export class RuntimeAuthCoordinator {
 			const current = getOwnCredential(latest.accounts, accountName);
 			return {
 				matches:
-					latest.active === accountName &&
+					this.isSelectedAccount(latest, accountName) &&
 					current !== undefined &&
 					JSON.stringify(current) === JSON.stringify(expected),
 			};
 		} catch (error) {
 			return { matches: false, error };
 		}
+	}
+
+	private isSelectedAccount(state: ProviderAccountState, accountName: string): boolean {
+		return (
+			(this.accountName ? this.accountName === accountName : state.active === accountName) &&
+			getOwnCredential(state.accounts, accountName) !== undefined
+		);
 	}
 
 	private async verifyOverlay(


### PR DESCRIPTION
Closes #754.

Each saved named Anthropic account receives an `anthropic-<account>` provider with an independent RuntimeAuthCoordinator. Alias refresh, credential identity checks, runtime API key overlays, fail-closed behavior, and cleanup are isolated from the built-in `anthropic` active/default flow.

Validation: Biome, package typecheck, and pi-accounts Vitest suites.