### PR TITLE
feat(fleet): default session spawning to tmux

### DIFF
--- a/.changeset/brave-clouds-split.md
+++ b/.changeset/brave-clouds-split.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-fleet": minor
+---
+
+Default session spawning to tmux 3.2 or newer while preserving Ghostty as an explicit opt-in backend.

--- a/docs/plans/archived/2026-08-14_pi-fleet-tmux-default-plan.md
+++ b/docs/plans/archived/2026-08-14_pi-fleet-tmux-default-plan.md
@@ -1,0 +1,36 @@
+# Pi Fleet tmux-default launch plan
+
+## Goal
+
+Make tmux the default `session_spawn` backend while preserving Ghostty as an explicit opt-in backend.
+
+## Context
+
+- Pi Fleet currently launches every child through Ghostty on macOS.
+- The user selected a tmux default with Ghostty available only after explicit selection.
+- This changes the published tool schema, menu workflow, launch result, terminal adapter boundary, documentation, and package contents.
+- No persistent setting is needed because the tool argument or menu choice owns each launch decision.
+
+## Architecture
+
+- Keep group creation, launch envelopes, child readiness, kickoff delivery, rollback, and cleanup in `fleet-controller.ts`.
+- Add an isolated tmux adapter that validates the current pane, requires a tmux version with per-pane environment support, creates directional splits, and reports partial-launch state.
+- Keep the Ghostty adapter and route to it only when `terminal: "ghostty"` is explicitly selected.
+- Preserve `ghosttyVersion` for Ghostty result compatibility while adding backend-neutral terminal metadata.
+
+## Plan
+
+- [x] Add failing adapter tests for tmux availability, directional command construction, environment propagation, cancellation, stale sessions, and partial splits; `tmux.test.ts` first failed on the missing adapter and invalid direction, then passed with `src/tmux.ts` and shared terminal types.
+- [x] Add failing controller and integration tests proving omitted terminal selection uses tmux, explicit Ghostty still works, confirmation identifies the selected backend, and rollback/partial-launch behavior remains safe; `spawn.test.ts` and `launch-integration.test.ts` failed against Ghostty-only routing before passing with backend routing.
+- [x] Add failing menu and tool tests proving tmux appears first/default and Ghostty requires explicit selection; focused menu and tool tests failed before the schema, workflow, prompt guidance, and notifications were updated, then passed.
+- [x] Update `packages/pi-fleet/README.md`, package keywords, changelog-facing Changeset, and package layout for tmux requirements, explicit Ghostty behavior, result compatibility, security, and limitations; Changesets reports the intended `0.2.0` minor bump.
+- [x] Run formatting, focused Pi Fleet tests, package typechecking, root `npm run check`, `just pack fleet`, a local Pi entrypoint smoke, and a disposable tmux split smoke; all passed, and the tarball contains 21 declared files with the new terminal sources and no tests.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`, including command/tool compatibility, mode behavior, cancellation, disposal, stale-session guards, terminal sanitization, package boundaries, and published files; no convention deviation remains.
+
+## Completion Checklist
+
+- [x] `session_spawn` without `terminal` launches through tmux and never probes Ghostty.
+- [x] Ghostty launches occur only after an explicit menu choice or `terminal: "ghostty"` tool argument.
+- [x] Tmux and Ghostty launches preserve confirmation, authenticated readiness, kickoff, rollback, cancellation, and cleanup semantics.
+- [x] Documentation and tool schemas accurately describe supported platforms, versions, defaults, and recovery.
+- [x] All required checks and smokes pass, and the unchanged real Ghostty AppleScript path remains unverified on this Linux host while its adapter and explicit routing pass deterministic tests.

--- a/packages/pi-fleet/README.md
+++ b/packages/pi-fleet/README.md
@@ -4,14 +4,16 @@
 
 > [!WARNING]
 > Pi Fleet is experimental.
-> Its local protocol, Ghostty automation, tool schemas, and agent-request behavior may change between releases.
+> Its local protocol, terminal automation, tool schemas, and agent-request behavior may change between releases.
 
-`@narumitw/pi-fleet` starts a separate Pi process in a new Ghostty split while preserving the parent session.
+`@narumitw/pi-fleet` starts a separate Pi process in a terminal split while preserving the parent session.
+It defaults to tmux and uses Ghostty only after an explicit selection.
 It also lets explicitly joined Pi sessions owned by the same operating-system user exchange bounded local messages and one-turn requests.
 
 ## ✨ Features
 
-- Starts a distinct Pi process through Ghostty's native macOS AppleScript API.
+- Starts a distinct Pi process in a tmux split by default.
+- Preserves Ghostty's native macOS AppleScript integration as an explicit opt-in backend.
 - Preserves the parent Pi session instead of replacing it with `ctx.newSession()`.
 - Inherits the parent cwd, model identity, thinking level, and an optional first task.
 - Waits for an authenticated child endpoint before reporting that the new session is ready.
@@ -43,7 +45,7 @@ Load the extension from a local checkout:
 pi --no-extensions --no-skills --no-session -e ./packages/pi-fleet
 ```
 
-A child started by Ghostty uses normal Pi extension discovery.
+A child started in either terminal backend uses normal Pi extension discovery.
 Install Pi Fleet persistently before testing the complete split-and-auto-join flow because a parent's temporary `-e` argument is not copied into the child process.
 
 Pi extensions execute with your user permissions.
@@ -57,29 +59,32 @@ Run:
 /fleet
 ```
 
-Choose **New Pi session in Ghostty**.
+Choose **New Pi session…**.
 
-Pi Fleet asks for a split direction and an optional first task.
-It then shows the experimental warning and an exact launch preview before creating any socket or split.
+The backend selector starts on **tmux — default**.
+Choose **Ghostty — explicit opt-in** only when you want Ghostty automation for this launch.
+Pi Fleet then asks for a split direction and an optional first task.
+It shows the experimental warning and an exact launch preview before creating any socket or split.
 
 After confirmation, Pi Fleet:
 
 1. Creates or reuses an ephemeral local group.
-2. Creates the Ghostty split.
+2. Creates the selected terminal split.
 3. Starts a separate named Pi process in the selected cwd.
 4. Waits for the child to authenticate and report readiness.
 5. Sends the optional first task through a launch-specific one-time kickoff.
 
-If Ghostty creates the split but the child does not become ready, Pi Fleet leaves the visible split open and reports a partial launch instead of closing a potentially useful terminal.
+If the terminal creates a split but the child does not become ready, Pi Fleet leaves the visible split open and reports a partial launch instead of closing a potentially useful pane.
 
 ## 🧰 Tools
 
 ### `session_spawn`
 
-Creates a separate Pi process in a Ghostty split.
+Creates a separate Pi process in a terminal split.
 
 | Parameter | Required | Description |
 | --- | --- | --- |
+| `terminal` | No | `tmux` or `ghostty`; defaults to `tmux`. Ghostty requires explicit selection. |
 | `direction` | No | `right`, `down`, `left`, or `up`; defaults to `right`. |
 | `task` | No | First task sent only after authenticated readiness. |
 | `name` | No | Child session display name. |
@@ -87,6 +92,8 @@ Creates a separate Pi process in a Ghostty split.
 
 The tool works only in TUI and RPC modes because it requires user confirmation.
 JSON and print modes fail before creating a group, launcher, or split.
+Successful details include `terminal`, `terminalId`, and `terminalVersion`.
+Ghostty results also retain `ghosttyVersion` for compatibility.
 
 ### `session_bus`
 
@@ -114,12 +121,30 @@ Peer-list text and details share a 40 KiB UTF-8 result budget below Pi's tool-ou
 Unknown and trailing arguments are rejected.
 JSON and print command routes fail before opening sockets or custom UI.
 
-The manager keeps **New Pi session in Ghostty** first whether connected or disconnected.
+The manager keeps **New Pi session…** first whether connected or disconnected.
+Its terminal selector lists tmux first and requires a separate Ghostty choice.
 Connected sessions can send a message, inspect peers, copy the explicit invite, change request policy, inspect status and help, or leave the group.
 
-## 🍎 Ghostty requirements
+## 🖥️ Terminal backends
 
-Split automation currently requires:
+Pi Fleet does not automatically fall back between terminal backends.
+A failed tmux launch never probes or starts Ghostty.
+
+### tmux default
+
+The default backend requires:
+
+- tmux 3.2 or newer.
+- Pi running inside the target tmux pane with `TMUX` and `TMUX_PANE` available.
+
+Pi Fleet targets the current pane, uses `split-window`, passes the cwd and launch-only environment to the new pane, and maps left or up to a split inserted before the current pane.
+
+### Ghostty explicit opt-in
+
+Choose Ghostty in the manager or pass `terminal: "ghostty"` to `session_spawn`.
+Do not select it when the user requested only another Pi session without naming Ghostty.
+
+Ghostty requires:
 
 - macOS.
 - Ghostty 1.3 or newer.
@@ -129,12 +154,13 @@ Split automation currently requires:
 Pi Fleet uses Ghostty's native `split` AppleScript command with positional arguments.
 It does not simulate user key presses or depend on customized keybindings.
 
-The first launch may trigger a macOS Automation permission prompt.
+The first Ghostty launch may trigger a macOS Automation permission prompt.
 If permission is denied, enable it in **System Settings → Privacy & Security → Automation** and retry.
 
 ## ⚙️ Settings and lifecycle
 
 Pi Fleet has no user or project settings file in this release.
+The terminal backend is selected per launch, and an omitted tool argument defaults to tmux.
 
 Group secrets, request permission, peers, readiness state, and deduplication state are held only in memory by Pi Fleet.
 The `pifleet:v1` prefix versions the bearer-invite encoding independently from the version-2 socket protocol.
@@ -144,7 +170,7 @@ A copied invite is still a reusable bearer secret, so discard it or start a new 
 A short-lived in-process handoff preserves a group across `/reload` for the same `sessionManager` only.
 Membership does not carry into `/new`, `/resume`, or another logical session without a new invite.
 
-The Ghostty child receives an internal launch-only environment envelope containing a parent-only kickoff capability.
+The terminal child receives an internal launch-only environment envelope containing a parent-only kickoff capability.
 The child consumes and deletes those values during `session_start` before Pi tools can inherit them.
 These values are not user settings or supported environment overrides.
 
@@ -166,18 +192,21 @@ Enabling them permits trusted invite holders to start paid model turns that may 
 - Bearer invites are shown only on the explicit invite screen or direct join input.
 - Pi Fleet does not persist invites, but a recipient can copy and reuse one until every holder discards it or moves to a new group.
 - Invites are not placed in tool output, status, notifications, custom renderers, launch scripts, or model context.
+- Tmux receives launch values through per-pane `-e` arguments and Pi Fleet never publishes them to the tmux global environment.
 - Peer names, paths, messages, model ids, and errors are treated as untrusted terminal text and sanitized only at display boundaries.
-- A same-user process or another privileged Pi extension is outside the security boundary and may inspect process memory or environment.
+- A same-user process or another privileged Pi extension is outside the security boundary and may inspect process arguments, memory, or environment.
 - Pi Fleet provides explicit group separation, not a sandbox against the operating-system user.
 
 ## 🧪 Experimental limitations
 
 - Local same-user communication only.
 - POSIX Unix-socket transport only.
-- Ghostty split automation only on macOS.
+- Tmux spawning requires tmux 3.2 or newer and an active current pane.
+- Ghostty spawning remains an explicit opt-in and works only on macOS.
 - No LAN, internet, cross-user, remote-host, or public-room transport.
 - No daemon, offline mailbox, separate Fleet history, delivery receipt, global ordering, or exactly-once guarantee.
 - No automatic trust or discovery of every Pi process.
+- No automatic backend fallback after launch failure.
 - No automatic close of a split after partial child startup.
 - Protocol version 2 intentionally rejects version-1 manifests and frames while the package remains experimental.
 - One request uses one short-lived socket connection; there is no persistent multiplexed channel or delivery stream.
@@ -201,10 +230,13 @@ packages/pi-fleet/
 │   ├── transport.ts
 │   ├── transport-io.ts
 │   ├── runtime-directory.ts
+│   ├── terminal.ts
+│   ├── tmux.ts
 │   ├── ghostty.ts
 │   ├── pi-invocation.ts
 │   ├── launcher.ts
 │   ├── launch-envelope.ts
+│   ├── reload-handoff.ts
 │   ├── renderer.ts
 │   └── text.ts
 ├── scripts/
@@ -219,7 +251,7 @@ packages/pi-fleet/
 
 ## 🔎 Keywords
 
-Pi extension, Pi Fleet, Pi sessions, Ghostty split, local agents, agent communication, Unix socket, TypeScript.
+Pi extension, Pi Fleet, Pi sessions, tmux split, Ghostty split, local agents, agent communication, Unix socket, TypeScript.
 
 ## 📄 License
 

--- a/packages/pi-fleet/package.json
+++ b/packages/pi-fleet/package.json
@@ -11,6 +11,7 @@
 		"pi",
 		"fleet",
 		"session",
+		"tmux",
 		"ghostty"
 	],
 	"files": [

--- a/packages/pi-fleet/src/fleet-controller.ts
+++ b/packages/pi-fleet/src/fleet-controller.ts
@@ -7,7 +7,7 @@ import type {
 	SessionShutdownEvent,
 	SessionStartEvent,
 } from "@earendil-works/pi-coding-agent";
-import { GhosttyAdapter, GhosttyLaunchError, type GhosttySplitDirection } from "./ghostty.js";
+import { GhosttyAdapter } from "./ghostty.js";
 import {
 	consumeLaunchEnvelope,
 	type FleetLaunchEnvelope,
@@ -28,8 +28,17 @@ import {
 	MAX_MESSAGE_BYTES,
 	parseInvite,
 } from "./protocol.js";
+import { putReloadHandoff, takeReloadHandoff } from "./reload-handoff.js";
 import { FLEET_MESSAGE_TYPE, type FleetMessageDetails } from "./renderer.js";
+import {
+	createTerminalLaunchError,
+	type FleetTerminal,
+	isTerminalLaunchError,
+	normalizeTerminal,
+	type TerminalSplitDirection,
+} from "./terminal.js";
 import { safeError, safeTerminalLine } from "./text.js";
+import { TmuxAdapter } from "./tmux.js";
 import {
 	type FleetDeliveryAck,
 	type FleetDiscoveryIssue,
@@ -43,7 +52,6 @@ const STATUS_KEY = "fleet";
 const DEFAULT_LAUNCH_TIMEOUT_MS = 15_000;
 const DEFAULT_POLL_INTERVAL_MS = 100;
 const RELOAD_HANDOFF_TTL_MS = 30_000;
-const RELOAD_HANDOFFS = Symbol.for("@narumitw/pi-fleet/reload-handoffs");
 
 export interface FleetTransportPort {
 	start(signal?: AbortSignal): Promise<void>;
@@ -67,10 +75,12 @@ export interface FleetTransportPort {
 		| undefined;
 }
 
-export interface FleetGhosttyPort {
+export type { FleetTerminal } from "./terminal.js";
+
+export interface FleetTerminalPort {
 	assertAvailable(signal?: AbortSignal): Promise<string>;
 	spawnSplit(options: {
-		direction: GhosttySplitDirection;
+		direction: TerminalSplitDirection;
 		cwd: string;
 		launcherCommand: string;
 		environment: Readonly<Record<string, string>>;
@@ -81,7 +91,8 @@ export interface FleetGhosttyPort {
 
 export interface FleetControllerDependencies {
 	createTransport(options: FleetTransportOptions): FleetTransportPort;
-	createGhostty(): FleetGhosttyPort;
+	createTmux(): FleetTerminalPort;
+	createGhostty(): FleetTerminalPort;
 	resolveInvocation(args: string[]): PiInvocation;
 	createLauncher(invocation: PiInvocation, directory: string): Promise<PiLauncher>;
 	realpath(value: string): Promise<string>;
@@ -106,7 +117,8 @@ export interface FleetSnapshot {
 }
 
 export interface SpawnSessionInput {
-	direction?: GhosttySplitDirection;
+	terminal?: FleetTerminal;
+	direction?: TerminalSplitDirection;
 	task?: string;
 	name?: string;
 	cwd?: string;
@@ -116,8 +128,10 @@ export interface SpawnSessionResult {
 	sessionId: string;
 	name?: string;
 	cwd: string;
+	terminal: FleetTerminal;
 	terminalId: string;
-	ghosttyVersion: string;
+	terminalVersion: string;
+	ghosttyVersion?: string;
 	kickoffAccepted: boolean;
 }
 
@@ -132,19 +146,17 @@ interface Membership {
 	rollbackLaunch?: object;
 }
 
-interface ReloadHandoff {
-	invite: string;
-	acceptsRequests: boolean;
-	launchId?: string;
-	kickoffCapability?: string;
-	kickoffConsumed: boolean;
-	warningAccepted: boolean;
-	expiresAt: number;
-}
-
 export function defaultFleetControllerDependencies(pi: ExtensionAPI): FleetControllerDependencies {
 	return {
 		createTransport: (options) => new FleetTransport(options),
+		createTmux: () =>
+			new TmuxAdapter({
+				execute: async (command, args, options) =>
+					pi.exec(command, args, {
+						...(options.signal ? { signal: options.signal } : {}),
+						timeout: options.timeoutMs,
+					}),
+			}),
 		createGhostty: () =>
 			new GhosttyAdapter({
 				execute: async (command, args, options) =>
@@ -206,7 +218,7 @@ export class FleetController {
 		if (!handoff?.warningAccepted) {
 			this.notify(
 				ctx,
-				"Pi Fleet is experimental. Local protocol, Ghostty automation, and agent-request behavior may change.",
+				"Pi Fleet is experimental. Local protocol, terminal automation, and agent-request behavior may change.",
 				"warning",
 			);
 		}
@@ -280,7 +292,7 @@ export class FleetController {
 		const ownerGeneration = this.generation;
 		const accepted = await ctx.ui.confirm(
 			"Use experimental Pi Fleet?",
-			"Pi Fleet starts local sockets and may launch paid model turns in new Ghostty splits. Its protocol and behavior may change.",
+			"Pi Fleet starts local sockets and may launch paid model turns in new terminal splits. Its protocol and behavior may change.",
 			{ signal: combineSignals(signal, this.controller.signal) },
 		);
 		if (!this.isCurrent(owner, ownerGeneration)) return false;
@@ -453,6 +465,8 @@ export class FleetController {
 		const owner = ctx.sessionManager;
 		const ownerGeneration = this.generation;
 		const operationSignal = combineSignals(signal, this.controller.signal);
+		const terminal = normalizeTerminal(input.terminal);
+		const terminalLabel = terminal === "tmux" ? "tmux" : "Ghostty";
 		const direction = input.direction ?? "right";
 		const cwd = await this.resolveSpawnCwd(ctx, input.cwd);
 		if (!this.isCurrent(owner, ownerGeneration)) throw staleError();
@@ -460,8 +474,9 @@ export class FleetController {
 		const launchId = this.deps.randomId("launch");
 		const kickoffCapability = this.deps.randomId("kickoff");
 		const name = normalizeOptional(input.name, "name", 200) ?? `Fleet ${launchId.slice(-6)}`;
-		const ghostty = this.deps.createGhostty();
-		const ghosttyVersion = await ghostty.assertAvailable(operationSignal);
+		const terminalAdapter =
+			terminal === "tmux" ? this.deps.createTmux() : this.deps.createGhostty();
+		const terminalVersion = await terminalAdapter.assertAvailable(operationSignal);
 		if (!this.isCurrent(owner, ownerGeneration)) throw staleError();
 		if (!(await this.acceptExperimentalWarning(ctx, operationSignal))) {
 			throw abortError("Pi Fleet launch cancelled before creating a split");
@@ -469,7 +484,7 @@ export class FleetController {
 		const confirmed = await ctx.ui.confirm(
 			"Create a new Pi session?",
 			[
-				`Ghostty split: ${direction}`,
+				`${terminalLabel} split: ${direction}`,
 				`Name: ${safeTerminalLine(name)}`,
 				`Cwd: ${safeTerminalLine(cwd)}`,
 				`Model: ${safeTerminalLine(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "Pi default")}`,
@@ -483,9 +498,9 @@ export class FleetController {
 		let claimedMembership: Membership | undefined;
 		let splitCreated = false;
 		let terminalId: string | undefined;
-		let actualGhosttyVersion = ghosttyVersion;
+		let actualTerminalVersion = terminalVersion;
 		let launcher: PiLauncher | undefined;
-		const statusToken = this.beginStatus(ctx, "fleet: launching Ghostty split");
+		const statusToken = this.beginStatus(ctx, `fleet: launching ${terminalLabel} split`);
 		try {
 			const membership = await this.claimSpawnMembership(ctx, operationSignal, rollbackOwner);
 			claimedMembership = membership;
@@ -510,7 +525,7 @@ export class FleetController {
 						}
 					: {}),
 			};
-			const split = await ghostty.spawnSplit({
+			const split = await terminalAdapter.spawnSplit({
 				direction,
 				cwd,
 				launcherCommand: launcher.command,
@@ -520,7 +535,7 @@ export class FleetController {
 			});
 			splitCreated = true;
 			terminalId = split.terminalId;
-			actualGhosttyVersion = split.version;
+			actualTerminalVersion = split.version;
 			this.updateStatus(statusToken, "fleet: waiting for child session");
 			const child = await this.waitForChild(launchId, operationSignal, owner, ownerGeneration);
 			let kickoffAccepted = false;
@@ -553,8 +568,9 @@ export class FleetController {
 					throw staleError();
 				}
 				if (!acknowledgement.accepted) {
-					throw new GhosttyLaunchError(
-						`Ghostty created the split, but the child rejected its first task: ${safeTerminalLine(acknowledgement.error ?? "unknown reason")}`,
+					throw createTerminalLaunchError(
+						terminal,
+						`${terminalLabel} created the split, but the child rejected its first task: ${safeTerminalLine(acknowledgement.error ?? "unknown reason")}`,
 						true,
 						terminalId,
 					);
@@ -565,13 +581,14 @@ export class FleetController {
 				sessionId: child.sessionId,
 				...(child.name ? { name: child.name } : {}),
 				cwd: child.cwd,
+				terminal,
 				terminalId,
-				ghosttyVersion: actualGhosttyVersion,
+				terminalVersion: actualTerminalVersion,
+				...(terminal === "ghostty" ? { ghosttyVersion: actualTerminalVersion } : {}),
 				kickoffAccepted,
 			};
 		} catch (error) {
-			const partial =
-				splitCreated || (error instanceof GhosttyLaunchError && error.splitCreated === true);
+			const partial = splitCreated || (isTerminalLaunchError(error) && error.splitCreated);
 			if (
 				!partial &&
 				claimedMembership?.rollbackLaunch === rollbackOwner &&
@@ -579,9 +596,10 @@ export class FleetController {
 			) {
 				await this.leaveGroupInternal();
 			}
-			if (partial && !(error instanceof GhosttyLaunchError)) {
-				throw new GhosttyLaunchError(
-					`Ghostty created the split, but the child session did not become ready: ${safeError(error)}`,
+			if (partial && !isTerminalLaunchError(error)) {
+				throw createTerminalLaunchError(
+					terminal,
+					`${terminalLabel} created the split, but the child session did not become ready: ${safeError(error)}`,
 					true,
 					terminalId,
 				);
@@ -881,26 +899,6 @@ export class FleetController {
 			// Notification is best-effort during replacement.
 		}
 	}
-}
-
-function reloadHandoffs(): WeakMap<object, ReloadHandoff> {
-	const root = globalThis as unknown as Record<PropertyKey, unknown>;
-	const existing = root[RELOAD_HANDOFFS];
-	if (existing instanceof WeakMap) return existing as WeakMap<object, ReloadHandoff>;
-	const created = new WeakMap<object, ReloadHandoff>();
-	root[RELOAD_HANDOFFS] = created;
-	return created;
-}
-
-function putReloadHandoff(owner: object, handoff: ReloadHandoff): void {
-	reloadHandoffs().set(owner, handoff);
-}
-
-function takeReloadHandoff(owner: object, now: number): ReloadHandoff | undefined {
-	const store = reloadHandoffs();
-	const value = store.get(owner);
-	store.delete(owner);
-	return value && value.expiresAt >= now ? value : undefined;
 }
 
 function recentFleetState(ctx: ExtensionContext): {

--- a/packages/pi-fleet/src/ghostty.ts
+++ b/packages/pi-fleet/src/ghostty.ts
@@ -1,4 +1,6 @@
-export type GhosttySplitDirection = "right" | "down" | "left" | "up";
+import type { TerminalSplitDirection } from "./terminal.js";
+
+export type GhosttySplitDirection = TerminalSplitDirection;
 
 export interface GhosttyCommandResult {
 	stdout: string;
@@ -21,7 +23,7 @@ export interface GhosttyAdapterOptions {
 }
 
 export interface SpawnGhosttySplitOptions {
-	direction: GhosttySplitDirection;
+	direction: TerminalSplitDirection;
 	cwd: string;
 	launcherCommand: string;
 	environment: Readonly<Record<string, string>>;

--- a/packages/pi-fleet/src/menu.ts
+++ b/packages/pi-fleet/src/menu.ts
@@ -33,6 +33,7 @@ type Screen =
 	| "leave";
 type Action = "spawn" | "start" | "join" | "send" | "setPolicy" | "leave";
 
+const TERMINAL_OPTIONS = ["tmux — default", "Ghostty — explicit opt-in"] as const;
 const DIRECTION_OPTIONS = ["Right", "Down", "Left", "Up"] as const;
 
 export function createFleetMenu(source: FleetMenuSource) {
@@ -121,8 +122,8 @@ export function createFleetMenu(source: FleetMenuSource) {
 				title: "Pi Fleet help",
 				lines: [
 					"Pi Fleet is experimental and connects explicit sessions owned by one OS user.",
-					"New Pi session creates a separate process in a Ghostty split and preserves the parent.",
-					"Ghostty automation currently requires macOS and Ghostty 1.3 or newer.",
+					"New Pi session creates a separate process in a terminal split and preserves the parent.",
+					"tmux 3.2 or newer is the default; Ghostty 1.3 on macOS requires explicit selection.",
 					"Notify messages do not start turns, requests require recipient permission, and replies do not auto-trigger another turn.",
 					"Groups, invites, peer state, and message deduplication are ephemeral.",
 				],
@@ -143,10 +144,19 @@ export function createFleetMenu(source: FleetMenuSource) {
 		},
 		actions: {
 			spawn: async ({ ctx, signal }) => {
-				const selected = await ctx.ui.select("Ghostty split direction", [...DIRECTION_OPTIONS], {
-					signal,
-				});
-				if (!selected || signal.aborted) return { kind: "stay" };
+				const terminalChoice = await ctx.ui.select(
+					"Terminal split backend",
+					[...TERMINAL_OPTIONS],
+					{ signal },
+				);
+				if (!terminalChoice || signal.aborted) return { kind: "stay" };
+				const terminal = terminalChoice === TERMINAL_OPTIONS[0] ? "tmux" : "ghostty";
+				const directionChoice = await ctx.ui.select(
+					`${terminal === "tmux" ? "tmux" : "Ghostty"} split direction`,
+					[...DIRECTION_OPTIONS],
+					{ signal },
+				);
+				if (!directionChoice || signal.aborted) return { kind: "stay" };
 				const task = await ctx.ui.input(
 					"Optional first task",
 					"Submit an empty value for an idle child session",
@@ -156,7 +166,8 @@ export function createFleetMenu(source: FleetMenuSource) {
 				await source.spawn(
 					ctx,
 					{
-						direction: selected.toLowerCase() as SpawnSessionInput["direction"],
+						terminal,
+						direction: directionChoice.toLowerCase() as SpawnSessionInput["direction"],
 						...(task ? { task } : {}),
 					},
 					signal,
@@ -271,11 +282,11 @@ function mainScreen(state: FleetSnapshot) {
 		return {
 			kind: "actions" as const,
 			title: "Pi Fleet · disconnected",
-			lines: ["Experimental local Pi sessions with confirmed Ghostty launch and messaging."],
+			lines: ["Experimental local Pi sessions with confirmed terminal launch and messaging."],
 			items: [
 				{
 					id: "spawn",
-					label: "New Pi session in Ghostty",
+					label: "New Pi session…",
 					action: "spawn" as const,
 					busyLabel: "Launching",
 				},
@@ -297,7 +308,7 @@ function mainScreen(state: FleetSnapshot) {
 		items: [
 			{
 				id: "spawn",
-				label: "New Pi session in Ghostty",
+				label: "New Pi session…",
 				action: "spawn" as const,
 				busyLabel: "Launching",
 			},

--- a/packages/pi-fleet/src/pi-fleet.ts
+++ b/packages/pi-fleet/src/pi-fleet.ts
@@ -87,8 +87,9 @@ function menuSource(controller: FleetController, ctx: ExtensionCommandContext): 
 		spawn: async (commandContext, input, signal) => {
 			const result = await controller.spawn(commandContext, input, signal);
 			if (controller.isCurrent(commandContext)) {
+				const terminalLabel = result.terminal === "ghostty" ? "Ghostty" : "tmux";
 				commandContext.ui.notify(
-					`Pi session ${safeTerminalLine(result.name ?? result.sessionId)} is ready in Ghostty.`,
+					`Pi session ${safeTerminalLine(result.name ?? result.sessionId)} is ready in ${terminalLabel}.`,
 					"info",
 				);
 			}

--- a/packages/pi-fleet/src/reload-handoff.ts
+++ b/packages/pi-fleet/src/reload-handoff.ts
@@ -1,0 +1,31 @@
+const RELOAD_HANDOFFS = Symbol.for("@narumitw/pi-fleet/reload-handoffs");
+
+export interface FleetReloadHandoff {
+	invite: string;
+	acceptsRequests: boolean;
+	launchId?: string;
+	kickoffCapability?: string;
+	kickoffConsumed: boolean;
+	warningAccepted: boolean;
+	expiresAt: number;
+}
+
+export function putReloadHandoff(owner: object, handoff: FleetReloadHandoff): void {
+	reloadHandoffs().set(owner, handoff);
+}
+
+export function takeReloadHandoff(owner: object, now: number): FleetReloadHandoff | undefined {
+	const store = reloadHandoffs();
+	const value = store.get(owner);
+	store.delete(owner);
+	return value && value.expiresAt >= now ? value : undefined;
+}
+
+function reloadHandoffs(): WeakMap<object, FleetReloadHandoff> {
+	const root = globalThis as unknown as Record<PropertyKey, unknown>;
+	const existing = root[RELOAD_HANDOFFS];
+	if (existing instanceof WeakMap) return existing as WeakMap<object, FleetReloadHandoff>;
+	const created = new WeakMap<object, FleetReloadHandoff>();
+	root[RELOAD_HANDOFFS] = created;
+	return created;
+}

--- a/packages/pi-fleet/src/terminal.ts
+++ b/packages/pi-fleet/src/terminal.ts
@@ -1,0 +1,28 @@
+import { GhosttyLaunchError } from "./ghostty.js";
+import { TmuxLaunchError } from "./tmux.js";
+
+export type FleetTerminal = "tmux" | "ghostty";
+export type TerminalSplitDirection = "right" | "down" | "left" | "up";
+
+export function normalizeTerminal(value: FleetTerminal | undefined): FleetTerminal {
+	if (value === undefined || value === "tmux") return "tmux";
+	if (value === "ghostty") return "ghostty";
+	throw new Error("Pi Fleet terminal must be tmux or ghostty");
+}
+
+export function isTerminalLaunchError(
+	error: unknown,
+): error is GhosttyLaunchError | TmuxLaunchError {
+	return error instanceof GhosttyLaunchError || error instanceof TmuxLaunchError;
+}
+
+export function createTerminalLaunchError(
+	terminal: FleetTerminal,
+	message: string,
+	splitCreated: boolean,
+	terminalId?: string,
+): GhosttyLaunchError | TmuxLaunchError {
+	return terminal === "ghostty"
+		? new GhosttyLaunchError(message, splitCreated, terminalId)
+		: new TmuxLaunchError(message, splitCreated, terminalId);
+}

--- a/packages/pi-fleet/src/tmux.ts
+++ b/packages/pi-fleet/src/tmux.ts
@@ -1,0 +1,226 @@
+import type { TerminalSplitDirection } from "./terminal.js";
+
+export interface TmuxCommandResult {
+	stdout: string;
+	stderr: string;
+	code: number;
+	killed: boolean;
+}
+
+export type TmuxCommandExecutor = (
+	command: string,
+	args: string[],
+	options: { signal?: AbortSignal; timeoutMs: number },
+) => Promise<TmuxCommandResult>;
+
+export interface TmuxAdapterOptions {
+	execute: TmuxCommandExecutor;
+	tmuxEnvironment?: string;
+	tmuxPane?: string;
+	timeoutMs?: number;
+}
+
+export interface SpawnTmuxSplitOptions {
+	direction: TerminalSplitDirection;
+	cwd: string;
+	launcherCommand: string;
+	environment: Readonly<Record<string, string>>;
+	signal?: AbortSignal;
+	isCurrent(): boolean;
+}
+
+export class TmuxLaunchError extends Error {
+	constructor(
+		message: string,
+		readonly splitCreated = false,
+		readonly terminalId?: string,
+	) {
+		super(message);
+		this.name = "TmuxLaunchError";
+	}
+}
+
+const MINIMUM_TMUX_VERSION = { major: 3, minor: 2 } as const;
+
+export class TmuxAdapter {
+	private readonly tmuxEnvironment: string | undefined;
+	private readonly tmuxPane: string | undefined;
+	private readonly timeoutMs: number;
+
+	constructor(private readonly options: TmuxAdapterOptions) {
+		this.tmuxEnvironment = options.tmuxEnvironment ?? process.env.TMUX;
+		this.tmuxPane = options.tmuxPane ?? process.env.TMUX_PANE;
+		this.timeoutMs = options.timeoutMs ?? 5_000;
+	}
+
+	async assertAvailable(signal?: AbortSignal): Promise<string> {
+		throwIfAborted(signal, "tmux availability check aborted");
+		if (!this.tmuxEnvironment) {
+			throw new TmuxLaunchError("Pi Fleet must be running inside tmux to create a split");
+		}
+		if (!this.tmuxPane || !/^%\d{1,20}$/u.test(this.tmuxPane)) {
+			throw new TmuxLaunchError("Pi Fleet could not identify the current tmux pane");
+		}
+		let result: TmuxCommandResult;
+		try {
+			result = await this.options.execute("tmux", ["-V"], {
+				...(signal ? { signal } : {}),
+				timeoutMs: this.timeoutMs,
+			});
+		} catch {
+			if (signal?.aborted) throwIfAborted(signal, "tmux availability check aborted");
+			throw new TmuxLaunchError("Pi Fleet could not run tmux to check its version");
+		}
+		throwIfAborted(signal, "tmux availability check aborted");
+		if (result.code !== 0 || result.killed) {
+			throw new TmuxLaunchError("Pi Fleet could not query the tmux version");
+		}
+		const version = result.stdout.trim().replace(/^tmux\s+/u, "");
+		const parsed = parseVersion(version);
+		if (!parsed) throw new TmuxLaunchError("tmux returned an invalid version");
+		if (
+			parsed.major < MINIMUM_TMUX_VERSION.major ||
+			(parsed.major === MINIMUM_TMUX_VERSION.major && parsed.minor < MINIMUM_TMUX_VERSION.minor)
+		) {
+			throw new TmuxLaunchError(
+				"Pi Fleet requires tmux 3.2 or newer for per-pane launch environments",
+			);
+		}
+		return version;
+	}
+
+	async spawnSplit(
+		options: SpawnTmuxSplitOptions,
+	): Promise<{ terminalId: string; version: string }> {
+		throwIfAborted(options.signal, "tmux split creation aborted");
+		validateSpawnOptions(options);
+		const version = await this.assertAvailable(options.signal);
+		if (!options.isCurrent()) {
+			throw new TmuxLaunchError("Pi Fleet session became stale before tmux split creation");
+		}
+		throwIfAborted(options.signal, "tmux split creation aborted");
+		const directionArgs = splitDirectionArgs(options.direction);
+		const environmentArgs = Object.entries(options.environment)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.flatMap(([key, value]) => ["-e", `${key}=${value}`]);
+		let result: TmuxCommandResult;
+		try {
+			result = await this.options.execute(
+				"tmux",
+				[
+					"split-window",
+					...directionArgs,
+					"-c",
+					options.cwd,
+					...environmentArgs,
+					"-P",
+					"-F",
+					"#{pane_id}",
+					"-t",
+					this.tmuxPane as string,
+					quoteShell(options.launcherCommand),
+				],
+				{
+					...(options.signal ? { signal: options.signal } : {}),
+					timeoutMs: this.timeoutMs,
+				},
+			);
+		} catch (error) {
+			if (options.signal?.aborted) {
+				throw new TmuxLaunchError(
+					"tmux split creation was cancelled after launch began; a partial split may remain open",
+					true,
+				);
+			}
+			throw error;
+		}
+		const terminalId = /^%\d{1,20}$/u.test(result.stdout.trim()) ? result.stdout.trim() : undefined;
+		if (options.signal?.aborted) {
+			throw new TmuxLaunchError(
+				"tmux created the split after Pi Fleet launch was cancelled",
+				true,
+				terminalId,
+			);
+		}
+		if (result.killed) {
+			throw new TmuxLaunchError(
+				"tmux split creation timed out; a partial split may remain open",
+				true,
+				terminalId,
+			);
+		}
+		if (result.code !== 0) {
+			throw new TmuxLaunchError("tmux could not create the Pi Fleet split");
+		}
+		if (!terminalId) {
+			throw new TmuxLaunchError("tmux created a split but returned no pane identity", true);
+		}
+		if (!options.isCurrent()) {
+			throw new TmuxLaunchError(
+				"Pi Fleet session became stale after tmux created the split",
+				true,
+				terminalId,
+			);
+		}
+		return { terminalId, version };
+	}
+}
+
+function splitDirectionArgs(direction: TerminalSplitDirection): string[] {
+	switch (direction) {
+		case "right":
+			return ["-h"];
+		case "down":
+			return ["-v"];
+		case "left":
+			return ["-h", "-b"];
+		case "up":
+			return ["-v", "-b"];
+	}
+}
+
+function validateSpawnOptions(options: SpawnTmuxSplitOptions): void {
+	if (
+		options.direction !== "right" &&
+		options.direction !== "down" &&
+		options.direction !== "left" &&
+		options.direction !== "up"
+	) {
+		throw new TmuxLaunchError("Pi Fleet split direction is invalid");
+	}
+	for (const [label, value, maxBytes] of [
+		["working directory", options.cwd, 4_096],
+		["launcher command", options.launcherCommand, 4_096],
+	] as const) {
+		if (!value || value.includes("\0") || Buffer.byteLength(value) > maxBytes) {
+			throw new TmuxLaunchError(`Pi Fleet ${label} is invalid`);
+		}
+	}
+	let environmentBytes = 0;
+	for (const [key, value] of Object.entries(options.environment)) {
+		if (!/^[A-Z][A-Z0-9_]{0,63}$/u.test(key) || value.includes("\0")) {
+			throw new TmuxLaunchError("Pi Fleet launch environment is invalid");
+		}
+		environmentBytes += Buffer.byteLength(key) + Buffer.byteLength(value) + 1;
+	}
+	if (environmentBytes > 24 * 1024) {
+		throw new TmuxLaunchError("Pi Fleet launch environment is too large");
+	}
+}
+
+function quoteShell(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function parseVersion(value: string): { major: number; minor: number } | undefined {
+	const match = /^(\d+)\.(\d+)(?:[a-z]|[-+].*)?$/u.exec(value);
+	if (!match) return undefined;
+	return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+function throwIfAborted(signal: AbortSignal | undefined, message: string): void {
+	if (!signal?.aborted) return;
+	const error = new Error(message);
+	error.name = "AbortError";
+	throw error;
+}

--- a/packages/pi-fleet/src/tools.ts
+++ b/packages/pi-fleet/src/tools.ts
@@ -6,6 +6,7 @@ import type { FleetMessage } from "./protocol.js";
 import { safeTerminalLine } from "./text.js";
 import type { FleetDeliveryAck } from "./transport.js";
 
+const TERMINALS = ["tmux", "ghostty"] as const;
 const DIRECTIONS = ["right", "down", "left", "up"] as const;
 const BUS_ACTIONS = ["list", "send", "reply"] as const;
 const SEND_MODES = ["notify", "request"] as const;
@@ -33,7 +34,12 @@ export interface FleetToolController {
 
 const spawnSchema = Type.Object(
 	{
-		direction: Type.Optional(StringEnum(DIRECTIONS, { description: "Ghostty split direction" })),
+		terminal: Type.Optional(
+			StringEnum(TERMINALS, {
+				description: "Terminal split backend; defaults to tmux, while ghostty is explicit opt-in",
+			}),
+		),
+		direction: Type.Optional(StringEnum(DIRECTIONS, { description: "Terminal split direction" })),
 		task: Type.Optional(
 			Type.String({
 				description: "Optional first task sent after child readiness",
@@ -77,25 +83,33 @@ export function registerFleetTools(pi: ExtensionAPI, controller: FleetToolContro
 		name: "session_spawn",
 		label: "Spawn Pi Session",
 		description:
-			"Create a separate Pi process in a new Ghostty split, wait for authenticated readiness, and optionally send its first task. This preserves the current session and requires user confirmation.",
-		promptSnippet: "Start a collaborating Pi session in a new Ghostty split",
+			"Create a separate Pi process in a terminal split, wait for authenticated readiness, and optionally send its first task. tmux is the default backend; Ghostty is used only when terminal is explicitly ghostty. This preserves the current session and requires user confirmation.",
+		promptSnippet: "Start a collaborating Pi session in a confirmed terminal split",
 		promptGuidelines: [
 			"Use session_spawn only when the user explicitly asks to open or start another Pi session.",
+			"Use session_spawn with terminal ghostty only when the user explicitly requests Ghostty; otherwise omit terminal to use tmux.",
 			"Do not claim the child is ready until session_spawn returns authenticated readiness metadata.",
 		],
 		parameters: spawnSchema,
 		executionMode: "sequential",
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const requestedTerminal = params.terminal === "ghostty" ? "Ghostty" : "tmux";
 			onUpdate?.({
-				content: [{ type: "text", text: "Preparing a confirmed Ghostty Pi session launch…" }],
-				details: { phase: "preparing" },
+				content: [
+					{
+						type: "text",
+						text: `Preparing a confirmed ${requestedTerminal} Pi session launch…`,
+					},
+				],
+				details: { phase: "preparing", terminal: params.terminal ?? "tmux" },
 			});
 			const result = await controller.spawn(ctx, params, signal);
+			const terminalLabel = result.terminal === "ghostty" ? "Ghostty" : "tmux";
 			return {
 				content: [
 					{
 						type: "text",
-						text: `Pi session ${safeTerminalLine(result.name ?? result.sessionId)} is ready in Ghostty (${safeTerminalLine(result.cwd)}).${result.kickoffAccepted ? " Its first task was accepted." : " No first task was sent."}`,
+						text: `Pi session ${safeTerminalLine(result.name ?? result.sessionId)} is ready in ${terminalLabel} (${safeTerminalLine(result.cwd)}).${result.kickoffAccepted ? " Its first task was accepted." : " No first task was sent."}`,
 					},
 				],
 				details: result,

--- a/packages/pi-fleet/test/fleet-controller.test.ts
+++ b/packages/pi-fleet/test/fleet-controller.test.ts
@@ -61,6 +61,10 @@ function dependencies(
 			transports.push(transport);
 			return transport;
 		},
+		createTmux: () => ({
+			assertAvailable: async () => "3.4",
+			spawnSplit: async () => ({ terminalId: "%42", version: "3.4" }),
+		}),
 		createGhostty: () => ({
 			assertAvailable: async () => "1.3.1",
 			spawnSplit: async () => ({ terminalId: "terminal-child", version: "1.3.1" }),

--- a/packages/pi-fleet/test/ghostty-smoke.md
+++ b/packages/pi-fleet/test/ghostty-smoke.md
@@ -29,7 +29,7 @@ npm run smoke:pi-fleet:ghostty
 ## Deterministic coverage
 
 - `ghostty.test.ts` covers version gating, all split directions, positional arguments, cancellation, Automation denial, missing focus, and stale ownership.
-- `launch-integration.test.ts` covers a real child process, cwd and launch-id propagation, environment consumption, authenticated readiness, kickoff delivery, and cleanup with a fake Ghostty boundary.
+- `launch-integration.test.ts` covers a real child process, cwd and launch-id propagation, environment consumption, authenticated readiness, kickoff delivery, and cleanup through the default fake tmux boundary.
 - `process-transport.test.ts` covers separate-process discovery, authentication, duplicate suppression, group isolation, and cleanup.
 
 ## Evidence

--- a/packages/pi-fleet/test/launch-integration.test.ts
+++ b/packages/pi-fleet/test/launch-integration.test.ts
@@ -11,7 +11,7 @@ import { FleetTransport } from "../src/transport.js";
 const posixTest = process.platform === "win32" ? test.skip : test;
 
 posixTest(
-	"fake Ghostty launches a real child endpoint, propagates cwd and launch id, and delivers kickoff",
+	"fake tmux launches a real child endpoint, propagates cwd and launch id, and delivers kickoff",
 	async () => {
 		const runtimeBase = await mkdtemp("/tmp/pi-fleet-launch-integration-");
 		const childCwd = await mkdtemp("/tmp/pi-fleet-child-cwd-");
@@ -21,31 +21,38 @@ posixTest(
 		const childEvents: Array<Record<string, unknown>> = [];
 		let buffer = "";
 		const mock = createMockPi();
+		const spawnChild = async (
+			options: Parameters<ReturnType<FleetControllerDependencies["createTmux"]>["spawnSplit"]>[0],
+		) => {
+			child = spawn(process.execPath, [fixturePath], {
+				cwd: options.cwd,
+				env: {
+					...process.env,
+					...options.environment,
+					PI_FLEET_TEST_BASE: runtimeBase,
+				},
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+			child.stdout.on("data", (chunk) => {
+				buffer += String(chunk);
+				while (true) {
+					const newline = buffer.indexOf("\n");
+					if (newline < 0) break;
+					childEvents.push(JSON.parse(buffer.slice(0, newline)) as Record<string, unknown>);
+					buffer = buffer.slice(newline + 1);
+				}
+			});
+			return { terminalId: "fake-pane", version: "3.4" };
+		};
 		const deps: FleetControllerDependencies = {
 			createTransport: (options) => new FleetTransport(options),
+			createTmux: () => ({
+				assertAvailable: async () => "3.4",
+				spawnSplit: spawnChild,
+			}),
 			createGhostty: () => ({
 				assertAvailable: async () => "1.3.1",
-				spawnSplit: async (options) => {
-					child = spawn(process.execPath, [fixturePath], {
-						cwd: options.cwd,
-						env: {
-							...process.env,
-							...options.environment,
-							PI_FLEET_TEST_BASE: runtimeBase,
-						},
-						stdio: ["pipe", "pipe", "pipe"],
-					});
-					child.stdout.on("data", (chunk) => {
-						buffer += String(chunk);
-						while (true) {
-							const newline = buffer.indexOf("\n");
-							if (newline < 0) break;
-							childEvents.push(JSON.parse(buffer.slice(0, newline)) as Record<string, unknown>);
-							buffer = buffer.slice(newline + 1);
-						}
-					});
-					return { terminalId: "fake-terminal", version: "1.3.1" };
-				},
+				spawnSplit: async (options) => ({ ...(await spawnChild(options)), version: "1.3.1" }),
 			}),
 			resolveInvocation: () => ({ command: "/bin/pi", args: [] }),
 			createLauncher: async () => ({
@@ -85,6 +92,8 @@ posixTest(
 			});
 			assert.equal(result.sessionId, "child-process");
 			assert.equal(result.cwd, canonicalChildCwd);
+			assert.equal(result.terminal, "tmux");
+			assert.equal(result.terminalVersion, "3.4");
 			assert.equal(result.kickoffAccepted, true);
 			assert.equal(
 				childEvents.some(

--- a/packages/pi-fleet/test/menu.test.ts
+++ b/packages/pi-fleet/test/menu.test.ts
@@ -64,7 +64,7 @@ function source(overrides: Partial<FleetMenuSource> = {}) {
 	return { source: value, calls };
 }
 
-test("main menu keeps New Pi session first when disconnected or connected", () => {
+test("main menu keeps the terminal-neutral New Pi session action first", () => {
 	const first = source({ snapshot: async () => disconnected });
 	const firstMenu = createFleetMenu(first.source);
 	assert.deepEqual(
@@ -73,7 +73,7 @@ test("main menu keeps New Pi session first when disconnected or connected", () =
 				items: ReadonlyArray<{ label: string }>;
 			}
 		).items.map(({ label }) => label),
-		["New Pi session in Ghostty", "Join with invite", "Start local group", "Status", "Help"],
+		["New Pi session…", "Join with invite", "Start local group", "Status", "Help"],
 	);
 	const second = source({ snapshot: async () => connected });
 	const secondMenu = createFleetMenu(second.source);
@@ -84,7 +84,7 @@ test("main menu keeps New Pi session first when disconnected or connected", () =
 			}
 		).items.map(({ label }) => label),
 		[
-			"New Pi session in Ghostty",
+			"New Pi session…",
 			"Send message",
 			"Sessions",
 			"Invite another session",
@@ -96,15 +96,49 @@ test("main menu keeps New Pi session first when disconnected or connected", () =
 	);
 });
 
-test("spawn collects direction and preserves the first task", async () => {
+test("spawn defaults the backend choice to tmux and preserves direction and first task", async () => {
 	const { source: menuSource, calls } = source({ snapshot: async () => disconnected });
 	const { menu } = createFleetMenu(menuSource);
-	const selections = ["Down", undefined];
+	const selections = ["tmux — default", "Down"];
+	const selectionOptions: string[][] = [];
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
-		select: async () => selections.shift(),
+		select: async (_title: string, options: string[]) => {
+			selectionOptions.push(options);
+			return selections.shift();
+		},
 		input: async () => "Investigate tests",
+	});
+	const result = await menu.actions.spawn({
+		ctx: context.ctx,
+		state: disconnected,
+		signal: new AbortController().signal,
+		itemId: "spawn",
+	});
+	assert.deepEqual(result, { kind: "close" });
+	assert.deepEqual(selectionOptions[0], ["tmux — default", "Ghostty — explicit opt-in"]);
+	assert.deepEqual(calls, [
+		{
+			kind: "spawn",
+			input: {
+				terminal: "tmux",
+				direction: "down",
+				task: "Investigate tests",
+			} satisfies SpawnSessionInput,
+		},
+	]);
+});
+
+test("spawn uses Ghostty only after its explicit backend choice", async () => {
+	const { source: menuSource, calls } = source({ snapshot: async () => disconnected });
+	const { menu } = createFleetMenu(menuSource);
+	const selections = ["Ghostty — explicit opt-in", "Left"];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => selections.shift(),
+		input: async () => "",
 	});
 	const result = await menu.actions.spawn({
 		ctx: context.ctx,
@@ -116,9 +150,32 @@ test("spawn collects direction and preserves the first task", async () => {
 	assert.deepEqual(calls, [
 		{
 			kind: "spawn",
-			input: { direction: "down", task: "Investigate tests" } satisfies SpawnSessionInput,
+			input: { terminal: "ghostty", direction: "left" } satisfies SpawnSessionInput,
 		},
 	]);
+});
+
+test("cancelled terminal or direction choices create no spawn side effects", async () => {
+	for (const selections of [[undefined], ["tmux — default", undefined]]) {
+		const { source: menuSource, calls } = source({ snapshot: async () => disconnected });
+		const { menu } = createFleetMenu(menuSource);
+		const pending = [...selections];
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			select: async () => pending.shift(),
+		});
+		assert.deepEqual(
+			await menu.actions.spawn({
+				ctx: context.ctx,
+				state: disconnected,
+				signal: new AbortController().signal,
+				itemId: "spawn",
+			}),
+			{ kind: "stay" },
+		);
+		assert.deepEqual(calls, []);
+	}
 });
 
 test("cancelled warning and dialogs create no group, join, or spawn side effects", async () => {

--- a/packages/pi-fleet/test/pi-fleet.test.ts
+++ b/packages/pi-fleet/test/pi-fleet.test.ts
@@ -24,6 +24,10 @@ function dependencies(): FleetControllerDependencies {
 				manifestPath: "/tmp/pi-fleet-test/endpoint.json",
 			},
 		}),
+		createTmux: () => ({
+			assertAvailable: async () => "3.4",
+			spawnSplit: async () => ({ terminalId: "%42", version: "3.4" }),
+		}),
 		createGhostty: () => ({
 			assertAvailable: async () => "1.3.1",
 			spawnSplit: async () => ({ terminalId: "child", version: "1.3.1" }),

--- a/packages/pi-fleet/test/spawn.test.ts
+++ b/packages/pi-fleet/test/spawn.test.ts
@@ -4,11 +4,11 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import {
 	FleetController,
 	type FleetControllerDependencies,
-	type FleetGhosttyPort,
+	type FleetTerminalPort,
 	type FleetTransportPort,
 } from "../src/fleet-controller.js";
-import { GhosttyLaunchError } from "../src/ghostty.js";
 import type { FleetMessage, FleetPeerDescription } from "../src/protocol.js";
+import { TmuxLaunchError } from "../src/tmux.js";
 import type {
 	FleetDeliveryAck,
 	FleetSendAuthorization,
@@ -53,19 +53,49 @@ class SpawnTransport implements FleetTransportPort {
 	}
 }
 
-function harness(options: { ready?: boolean; ghosttyError?: Error } = {}) {
+function harness(options: { ready?: boolean; launchError?: Error } = {}) {
 	const mock = createMockPi();
 	const transports: SpawnTransport[] = [];
-	const splitCalls: Parameters<FleetGhosttyPort["spawnSplit"]>[0][] = [];
+	const tmuxSplitCalls: Parameters<FleetTerminalPort["spawnSplit"]>[0][] = [];
+	const ghosttySplitCalls: Parameters<FleetTerminalPort["spawnSplit"]>[0][] = [];
 	let now = 1_800_000_000_000;
+	let tmuxCreated = 0;
+	let ghosttyCreated = 0;
 	let launcherCleaned = false;
 	let cleanupStateAtFirstPoll: boolean | undefined;
 	let pendingPeer: FleetPeerDescription | undefined;
+	const spawnSplit = async (
+		terminal: "tmux" | "ghostty",
+		spawnOptions: Parameters<FleetTerminalPort["spawnSplit"]>[0],
+	) => {
+		const calls = terminal === "tmux" ? tmuxSplitCalls : ghosttySplitCalls;
+		calls.push(spawnOptions);
+		if (options.launchError) throw options.launchError;
+		if (options.ready !== false) {
+			pendingPeer = {
+				protocolVersion: 2,
+				sessionId: "child-session",
+				endpointId: "b".repeat(24),
+				name: spawnOptions.environment.PI_FLEET_CHILD_NAME,
+				cwd: spawnOptions.cwd,
+				pid: 456,
+				launchId: spawnOptions.environment.PI_FLEET_LAUNCH_ID,
+				acceptsRequests: false,
+			};
+		}
+		return {
+			terminalId: `${terminal}-child`,
+			version: terminal === "tmux" ? "3.4" : "1.3.1",
+		};
+	};
 	const deps: FleetControllerDependencies = {
 		createTransport: (transportOptions) => {
 			const transport = new SpawnTransport(transportOptions);
 			transport.beforeList = () => {
-				if (splitCalls.length > 0 && cleanupStateAtFirstPoll === undefined) {
+				if (
+					(tmuxSplitCalls.length > 0 || ghosttySplitCalls.length > 0) &&
+					cleanupStateAtFirstPoll === undefined
+				) {
 					cleanupStateAtFirstPoll = launcherCleaned;
 				}
 				if (pendingPeer) {
@@ -76,26 +106,20 @@ function harness(options: { ready?: boolean; ghosttyError?: Error } = {}) {
 			transports.push(transport);
 			return transport;
 		},
-		createGhostty: () => ({
-			assertAvailable: async () => "1.3.1",
-			spawnSplit: async (spawnOptions) => {
-				splitCalls.push(spawnOptions);
-				if (options.ghosttyError) throw options.ghosttyError;
-				if (options.ready !== false) {
-					pendingPeer = {
-						protocolVersion: 2,
-						sessionId: "child-session",
-						endpointId: "b".repeat(24),
-						name: spawnOptions.environment.PI_FLEET_CHILD_NAME,
-						cwd: spawnOptions.cwd,
-						pid: 456,
-						launchId: spawnOptions.environment.PI_FLEET_LAUNCH_ID,
-						acceptsRequests: false,
-					};
-				}
-				return { terminalId: "terminal-child", version: "1.3.1" };
-			},
-		}),
+		createTmux: () => {
+			tmuxCreated += 1;
+			return {
+				assertAvailable: async () => "3.4",
+				spawnSplit: (spawnOptions) => spawnSplit("tmux", spawnOptions),
+			};
+		},
+		createGhostty: () => {
+			ghosttyCreated += 1;
+			return {
+				assertAvailable: async () => "1.3.1",
+				spawnSplit: (spawnOptions) => spawnSplit("ghostty", spawnOptions),
+			};
+		},
 		resolveInvocation: (args) => ({ command: "/bin/pi", args }),
 		createLauncher: async () => ({
 			path: "/tmp/pi-fleet-spawn-test/launch.sh",
@@ -118,7 +142,14 @@ function harness(options: { ready?: boolean; ghosttyError?: Error } = {}) {
 		mock,
 		deps,
 		transports,
-		splitCalls,
+		splitCalls: tmuxSplitCalls,
+		ghosttySplitCalls,
+		get tmuxCreated() {
+			return tmuxCreated;
+		},
+		get ghosttyCreated() {
+			return ghosttyCreated;
+		},
 		get launcherCleaned() {
 			return launcherCleaned;
 		},
@@ -132,15 +163,15 @@ test("spawn auto-creates a group, preserves parent, inherits model, and sends ki
 	const runtime = harness();
 	const { mock, deps, transports, splitCalls } = runtime;
 	const controller = new FleetController(mock.pi, deps);
-	let confirmations = 0;
+	const confirmationMessages: string[] = [];
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
 		cwd: "/project",
 		model: { provider: "provider", id: "model" },
 		thinkingLevel: "high",
-		confirm: async () => {
-			confirmations += 1;
+		confirm: async (_title: string, message: string) => {
+			confirmationMessages.push(message);
 			return true;
 		},
 	});
@@ -151,9 +182,15 @@ test("spawn auto-creates a group, preserves parent, inherits model, and sends ki
 		task: "Check tests",
 		cwd: "worktree",
 	});
-	assert.equal(confirmations, 2);
+	assert.equal(confirmationMessages.length, 2);
+	assert.equal(
+		confirmationMessages.some((message) => /tmux split: down/u.test(message)),
+		true,
+	);
 	assert.equal(transports.length, 1);
 	assert.equal(splitCalls.length, 1);
+	assert.equal(runtime.tmuxCreated, 1);
+	assert.equal(runtime.ghosttyCreated, 0);
 	assert.equal(splitCalls[0]?.direction, "down");
 	assert.equal(runtime.cleanupStateAtFirstPoll, false);
 	assert.equal(splitCalls[0]?.cwd, "/real/project/worktree");
@@ -169,6 +206,10 @@ test("spawn auto-creates a group, preserves parent, inherits model, and sends ki
 	);
 	assert.equal(transports[0]?.messages[0]?.text, "Check tests");
 	assert.equal(result.sessionId, "child-session");
+	assert.equal(result.terminal, "tmux");
+	assert.equal(result.terminalId, "tmux-child");
+	assert.equal(result.terminalVersion, "3.4");
+	assert.equal(result.ghosttyVersion, undefined);
 	assert.equal(result.kickoffAccepted, true);
 	assert.equal(runtime.launcherCleaned, true);
 	assert.equal(mock.sentMessages.length, 0);
@@ -189,17 +230,46 @@ test("spawn reuses an existing group and supports all split directions", async (
 	}
 });
 
+test("spawn uses Ghostty only after explicit selection and reports compatible metadata", async () => {
+	const runtime = harness();
+	const controller = new FleetController(runtime.mock.pi, runtime.deps);
+	const confirmations: string[] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		confirm: async (_title: string, message: string) => {
+			confirmations.push(message);
+			return true;
+		},
+	});
+	await controller.sessionStart({ reason: "startup" }, context.ctx);
+	const result = await controller.spawn(context.ctx, { terminal: "ghostty", direction: "left" });
+	assert.equal(runtime.splitCalls.length, 0);
+	assert.equal(runtime.tmuxCreated, 0);
+	assert.equal(runtime.ghosttyCreated, 1);
+	assert.equal(runtime.ghosttySplitCalls.length, 1);
+	assert.equal(runtime.ghosttySplitCalls[0]?.direction, "left");
+	assert.equal(
+		confirmations.some((message) => /Ghostty split: left/u.test(message)),
+		true,
+	);
+	assert.equal(result.terminal, "ghostty");
+	assert.equal(result.terminalVersion, "1.3.1");
+	assert.equal(result.ghosttyVersion, "1.3.1");
+	await controller.sessionShutdown({ reason: "quit" }, context.ctx);
+});
+
 test("a concurrent launch failure cannot roll back another launch's automatic group", async () => {
 	const runtime = harness();
-	let ghosttyIndex = 0;
+	let terminalIndex = 0;
 	let availabilityCount = 0;
 	let releaseAvailability!: () => void;
 	const availabilityReleased = new Promise<void>((resolve) => {
 		releaseAvailability = resolve;
 	});
-	runtime.deps.createGhostty = () => {
-		const index = ghosttyIndex;
-		ghosttyIndex += 1;
+	runtime.deps.createTmux = () => {
+		const index = terminalIndex;
+		terminalIndex += 1;
 		return {
 			assertAvailable: async () => {
 				availabilityCount += 1;
@@ -208,7 +278,7 @@ test("a concurrent launch failure cannot roll back another launch's automatic gr
 				return "1.3.1";
 			},
 			spawnSplit: async (options) => {
-				if (index === 1) throw new GhosttyLaunchError("second launch denied", false);
+				if (index === 1) throw new TmuxLaunchError("second launch denied", false);
 				const transport = runtime.transports[0];
 				assert.ok(transport);
 				transport.peers.push({
@@ -323,7 +393,7 @@ test("session shutdown waits for an in-flight launch to release its launcher", a
 });
 
 test("pre-split failure rolls back an automatic group while readiness timeout keeps it", async () => {
-	const failedHarness = harness({ ghosttyError: new GhosttyLaunchError("denied", false) });
+	const failedHarness = harness({ launchError: new TmuxLaunchError("denied", false) });
 	const failed = new FleetController(failedHarness.mock.pi, failedHarness.deps);
 	const firstContext = createMockContext({ mode: "tui", hasUI: true, confirm: async () => true });
 	await failed.sessionStart({ reason: "startup" }, firstContext.ctx);
@@ -339,7 +409,7 @@ test("pre-split failure rolls back an automatic group while readiness timeout ke
 	await timeout.sessionStart({ reason: "startup" }, secondContext.ctx);
 	await assert.rejects(
 		timeout.spawn(secondContext.ctx, {}),
-		(error: unknown) => error instanceof GhosttyLaunchError && error.splitCreated,
+		(error: unknown) => error instanceof TmuxLaunchError && error.splitCreated,
 	);
 	assert.equal(timeoutHarness.launcherCleaned, true);
 	assert.equal((await timeout.snapshot()).connected, true);

--- a/packages/pi-fleet/test/tmux.test.ts
+++ b/packages/pi-fleet/test/tmux.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { TmuxAdapter, type TmuxCommandExecutor, TmuxLaunchError } from "../src/tmux.js";
+
+function result(stdout = "", stderr = "", code = 0) {
+	return { stdout, stderr, code, killed: false };
+}
+
+function adapter(
+	execute: TmuxCommandExecutor,
+	overrides: { tmuxEnvironment?: string; tmuxPane?: string } = {},
+) {
+	return new TmuxAdapter({
+		execute,
+		tmuxEnvironment:
+			overrides.tmuxEnvironment === undefined
+				? "/tmp/tmux-1000/default,1234,0"
+				: overrides.tmuxEnvironment,
+		tmuxPane: overrides.tmuxPane === undefined ? "%7" : overrides.tmuxPane,
+	});
+}
+
+test("tmux adapter requires a current pane and per-pane environment support", async () => {
+	await assert.rejects(
+		adapter(async () => result("tmux 3.4\n"), { tmuxEnvironment: "" }).assertAvailable(),
+		/running inside tmux/iu,
+	);
+	await assert.rejects(
+		adapter(async () => result("tmux 3.4\n"), { tmuxPane: "pane-7" }).assertAvailable(),
+		/current tmux pane/iu,
+	);
+	await assert.rejects(adapter(async () => result("tmux 3.1c\n")).assertAvailable(), /3\.2/u);
+	await assert.rejects(adapter(async () => result("unexpected\n")).assertAvailable(), /version/iu);
+	assert.equal(await adapter(async () => result("tmux 3.4\n")).assertAvailable(), "3.4");
+});
+
+test("tmux split targets the current pane and passes positional data for every direction", async () => {
+	const directionFlags = {
+		right: ["-h"],
+		down: ["-v"],
+		left: ["-h", "-b"],
+		up: ["-v", "-b"],
+	} as const;
+	for (const direction of ["right", "down", "left", "up"] as const) {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const tmux = adapter(async (command, args) => {
+			calls.push({ command, args });
+			return calls.length === 1 ? result("tmux 3.4\n") : result("%42\n");
+		});
+		assert.deepEqual(
+			await tmux.spawnSplit({
+				direction,
+				cwd: "/tmp/project ' quoted",
+				launcherCommand: "/tmp/launcher's path",
+				environment: {
+					PI_FLEET_INVITE: "pifleet:v1:secret-placeholder",
+					PI_FLEET_LAUNCH_ID: "launch_123",
+				},
+				isCurrent: () => true,
+			}),
+			{ terminalId: "%42", version: "3.4" },
+		);
+		assert.deepEqual(calls[0], { command: "tmux", args: ["-V"] });
+		assert.deepEqual(calls[1], {
+			command: "tmux",
+			args: [
+				"split-window",
+				...directionFlags[direction],
+				"-c",
+				"/tmp/project ' quoted",
+				"-e",
+				"PI_FLEET_INVITE=pifleet:v1:secret-placeholder",
+				"-e",
+				"PI_FLEET_LAUNCH_ID=launch_123",
+				"-P",
+				"-F",
+				"#{pane_id}",
+				"-t",
+				"%7",
+				"'/tmp/launcher'\"'\"'s path'",
+			],
+		});
+	}
+});
+
+test("tmux adapter rejects invalid split input before running tmux", async () => {
+	let calls = 0;
+	const tmux = adapter(async () => {
+		calls += 1;
+		return result("tmux 3.4\n");
+	});
+	await assert.rejects(
+		tmux.spawnSplit({
+			direction: "auto" as "right",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			isCurrent: () => true,
+		}),
+		/split direction is invalid/u,
+	);
+	await assert.rejects(
+		tmux.spawnSplit({
+			direction: "right",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: { "bad-key": "value" },
+			isCurrent: () => true,
+		}),
+		/launch environment is invalid/u,
+	);
+	assert.equal(calls, 0);
+});
+
+test("tmux adapter cancels and suppresses stale work before split creation", async () => {
+	let calls = 0;
+	const tmux = adapter(async () => {
+		calls += 1;
+		return result("tmux 3.4\n");
+	});
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		tmux.spawnSplit({
+			direction: "right",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			signal: controller.signal,
+			isCurrent: () => true,
+		}),
+		/aborted/u,
+	);
+	assert.equal(calls, 0);
+
+	let current = true;
+	calls = 0;
+	const stale = adapter(async () => {
+		calls += 1;
+		current = false;
+		return result("tmux 3.4\n");
+	});
+	await assert.rejects(
+		stale.spawnSplit({
+			direction: "down",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			isCurrent: () => current,
+		}),
+		(error: unknown) =>
+			error instanceof TmuxLaunchError && !error.splitCreated && /stale/u.test(error.message),
+	);
+	assert.equal(calls, 1);
+});
+
+test("tmux adapter reports cancellation, invalid identity, and staleness after a split as partial", async () => {
+	const during = new AbortController();
+	let calls = 0;
+	const cancelled = adapter(async () => {
+		calls += 1;
+		if (calls === 1) return result("tmux 3.4\n");
+		during.abort();
+		return result("%8\n");
+	});
+	await assert.rejects(
+		cancelled.spawnSplit({
+			direction: "right",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			signal: during.signal,
+			isCurrent: () => true,
+		}),
+		(error: unknown) =>
+			error instanceof TmuxLaunchError && error.splitCreated && error.terminalId === "%8",
+	);
+
+	calls = 0;
+	const invalid = adapter(async () => {
+		calls += 1;
+		return calls === 1 ? result("tmux 3.4\n") : result("not-a-pane\n");
+	});
+	await assert.rejects(
+		invalid.spawnSplit({
+			direction: "left",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			isCurrent: () => true,
+		}),
+		(error: unknown) => error instanceof TmuxLaunchError && error.splitCreated,
+	);
+
+	let current = true;
+	calls = 0;
+	const stale = adapter(async () => {
+		calls += 1;
+		if (calls === 1) return result("tmux 3.4\n");
+		current = false;
+		return result("%9\n");
+	});
+	await assert.rejects(
+		stale.spawnSplit({
+			direction: "up",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			isCurrent: () => current,
+		}),
+		(error: unknown) =>
+			error instanceof TmuxLaunchError && error.splitCreated && error.terminalId === "%9",
+	);
+});

--- a/packages/pi-fleet/test/tools.test.ts
+++ b/packages/pi-fleet/test/tools.test.ts
@@ -25,8 +25,9 @@ function stubController(overrides: Partial<FleetToolController> = {}) {
 		sessionId: "child",
 		name: "Child",
 		cwd: "/tmp/child",
-		terminalId: "terminal-child",
-		ghosttyVersion: "1.3.1",
+		terminal: "tmux",
+		terminalId: "%42",
+		terminalVersion: "3.4",
 		kickoffAccepted: true,
 	};
 	const controller: FleetToolController = {
@@ -72,6 +73,7 @@ test("registers separate spawn and bus tools with focused schemas", () => {
 		"direction",
 		"name",
 		"task",
+		"terminal",
 	]);
 	assert.deepEqual(Object.keys(bus.parameters.properties ?? {}).sort(), [
 		"action",
@@ -103,8 +105,41 @@ test("session_spawn delegates launch input and returns readiness without secrets
 			input: { direction: "down", task: "check tests", name: "Child", cwd: "/tmp/child" },
 		},
 	]);
-	assert.match(result.content[0]?.text ?? "", /child.*ready/iu);
+	assert.match(result.content[0]?.text ?? "", /child.*ready.*tmux/iu);
 	assert.equal(JSON.stringify(result).includes("pifleet:v1"), false);
+});
+
+test("session_spawn uses Ghostty only when the tool argument explicitly requests it", async () => {
+	const mock = createMockPi();
+	const ghosttyResult: SpawnSessionResult = {
+		sessionId: "ghostty-child",
+		cwd: "/tmp/child",
+		terminal: "ghostty",
+		terminalId: "terminal-child",
+		terminalVersion: "1.3.1",
+		ghosttyVersion: "1.3.1",
+		kickoffAccepted: false,
+	};
+	const { controller, calls } = stubController({
+		spawn: async (_ctx, input) => {
+			calls.push({ kind: "spawn", input });
+			return ghosttyResult;
+		},
+	});
+	registerFleetTools(mock.pi, controller);
+	const tool = mock.tools.find(({ name }) => name === "session_spawn") as {
+		execute(...args: unknown[]): Promise<{ content: Array<{ text: string }>; details: unknown }>;
+	};
+	const context = createMockContext({ mode: "rpc", hasUI: true });
+	const result = await tool.execute(
+		"call-ghostty",
+		{ terminal: "ghostty", direction: "right" },
+		undefined,
+		undefined,
+		context.ctx,
+	);
+	assert.deepEqual(calls, [{ kind: "spawn", input: { terminal: "ghostty", direction: "right" } }]);
+	assert.match(result.content[0]?.text ?? "", /ready.*Ghostty/iu);
 });
 
 test("session_bus lists peers, sends requests, and correlates replies", async () => {


### PR DESCRIPTION
## Summary

- add tmux 3.2+ split launching and make it the default `session_spawn` backend
- keep Ghostty available only through an explicit menu choice or `terminal: "ghostty"`
- preserve confirmation, authenticated readiness, kickoff, rollback, cancellation, cleanup, and Ghostty result compatibility
- document backend requirements and record the `@narumitw/pi-fleet` minor release intent

## Verification

- `npm run check` — 375 test files and 3,767 tests passed
- `just pack fleet` — 21 declared files, including the new terminal sources and no tests
- local Pi RPC entrypoint load smoke passed
- disposable real tmux split, cwd, and per-pane environment smoke passed
- `npm run changeset:status` reports the intended `0.2.0` minor bump

The real Ghostty AppleScript smoke was unavailable on the Linux host.
The unchanged adapter and explicit Ghostty routing pass deterministic tests.

## Convention audit

Reviewed the diff against `docs/extension-conventions.md` and `docs/extension-settings.md`.
No deviations remain.
