### PR TITLE
feat(starship)!: compact GitHub PR status

### DIFF
--- a/.changeset/bright-rockets-smile.md
+++ b/.changeset/bright-rockets-smile.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-starship": minor
+---
+
+Render the existing native GitHub PR `$checks`, `$review`, and `$status` variables as compact symbols and counts by default.
+
+This is a breaking display change for custom formats that expect the previous English values; variable names and the default module format remain unchanged.

--- a/docs/plans/archived/2026-08-15_pi-starship-github-pr-short-status-plan.md
+++ b/docs/plans/archived/2026-08-15_pi-starship-github-pr-short-status-plan.md
@@ -1,0 +1,122 @@
+# pi-starship GitHub PR short-status plan
+
+## Goal
+
+Make the existing `$checks`, `$review`, and `$status` variables render a compact, font-safe summary by default, following Starship's symbol-plus-count Git style without adding parallel short variables.
+
+## Context
+
+The existing GitHub PR variables expose fixed English text such as `checks passing`, `2 failing`, and `approved`.
+
+The existing `git_status` module emits compact values such as `$1`, `!14`, and `?7`.
+
+This proposal intentionally changes the published values of the existing GitHub PR variables, so custom formats using them will also adopt the short output.
+
+## Architecture
+
+Keep the existing variable names and default module format:
+
+```toml
+[github_pr]
+format = "[ $symbol$link( · $status) ]($style)"
+```
+
+Change their values to:
+
+| Variable | Compact contract | Examples |
+| --- | --- | --- |
+| `$checks` | All non-zero check counts in passed/failed/pending order | `✓12`, `✓12 ×2 …7`, or `-` when no checks |
+| `$review` | Current review decision | `R✓`, `R×`, `R?`, or empty when unknown |
+| `$status` | One highest-priority compact result | `M`, `C`, `D`, `×2`, `R×`, `…7`, `R✓`, `R?`, `✓12`, or `-` |
+
+Use the existing `$status` precedence:
+
+```text
+merged > closed > draft > failing checks > changes requested > pending checks > approved > review required > passing checks > no checks
+```
+
+Use `✓`, `×`, and `…` instead of Git's `$`, `!`, and `?` check markers.
+
+Prefix review decisions with `R` so check and review outcomes remain distinguishable.
+
+Keep `M`, `C`, and `D` for merged, closed, and draft because the default presentation retains the blue `PR #<number>` context.
+
+The default output becomes:
+
+```text
+PR #123 · ×2
+PR #123 · R✓
+PR #123 · M
+```
+
+A user who wants checks and review together can keep using the existing variables:
+
+```toml
+[github_pr]
+format = "[$symbol$link( $checks)( $review) ]($style)"
+```
+
+```text
+PR #123 ✓12 ×2 …7 R×
+```
+
+Derive passed checks as `total - failed - pending`, preserving the current classification where successful, skipped, and neutral checks pass.
+
+Keep the existing immutable `checks`, `review`, and `status` snapshot fields so rendering remains pure and performs no subprocess or network work.
+
+## Non-Goals
+
+- Do not add `$checks_short`, `$review_short`, `$status_short`, or verbose replacement variables.
+- Do not add a global short-mode setting or user-configurable status symbols in the first version.
+- Do not change `$number`, `$link`, or `$state`.
+- Do not change the default module format, only the values supplied to it.
+- Do not change GitHub queries, refresh timing, expiry, authentication, or failure behavior.
+- Do not change `pi-github-pr` or `pi-statusline` in this implementation.
+
+## Risks
+
+Changing existing variable values is a deliberate breaking display change for custom `pi-starship.toml` files.
+
+The README and Changeset must show the old-to-new value mapping and explain that the previous English forms are no longer available from the native `github_pr` module.
+
+## Execution Context
+
+- Branch: `narumiruna/feat/pi-starship-pr-short-status`.
+- Base: `origin/main` at `ed9d3e0e`.
+- Preserved pre-existing work: this plan was the only untracked path before execution.
+- Touched areas: native GitHub PR snapshot formatting, its stable TOML format-variable contract, focused tests, package README, and Changeset.
+- Applicable MUST gates: deterministic changed-behavior tests, CI-equivalent `npm run check`, package smoke, Changeset coverage, and final review against `docs/extension-conventions.md` and `docs/extension-settings.md`.
+- Unchanged areas: settings persistence and validation mechanics, commands, TUI flows, asynchronous lifecycle ownership, cancellation, session replacement, shutdown, GitHub queries, and dependencies.
+
+## Plan
+
+- [x] Update `packages/pi-starship/test/github-pr.test.ts` with focused expected values for all-pass, mixed checks, no checks, every review decision, terminal/draft states, and `$status` precedence; focused Vitest failed on the old English `checks`, `review`, and `status` values after rebuilding `pi-tui-kit`, establishing the intended red state.
+- [x] Add pure compact-format helpers in `packages/pi-starship/src/runtime/github-pr.ts` that derive passed counts from the existing validated summary and populate the existing `checks`, `review`, and `status` snapshot fields; focused and full tests pass with compact mixed, terminal, and review values.
+- [x] Add a regression assertion that `packages/pi-starship/src/modules/github-pr.ts` exposes no new variables and that its default format remains unchanged while rendering the new compact values; the focused contract test passes.
+- [x] Update `packages/pi-starship/README.md` with the compact contracts, symbol legend, precedence, default output, custom combined example, and old-to-new migration table; the package Biome and typecheck gate passes.
+- [x] Add a minor Changeset for `@narumitw/pi-starship` that explicitly identifies the breaking display change while the package remains on the `0.x` line; `npm run changeset:status` resolves it to `0.51.0`.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`; the change preserves settings parsing, validation, unknown-field handling, atomic persistence, commands, TUI ownership, asynchronous lifecycle, cancellation, session replacement, shutdown, query bounds, terminal-safe links, and failure-to-empty behavior.
+- [x] Run `npm test`, `npm run check`, and `npm run pack:starship`; both full gates passed 375 files and 3,769 tests, and the dry-run tarball contained the expected README and source files.
+
+## Verification Evidence
+
+- TDD red: focused Vitest executed the changed contract and failed on the prior English values.
+- Focused green: GitHub PR and lifecycle coverage passed 30 tests after hardening.
+- Hardening: deterministic cases cover empty, singleton, mixed, zero-omission, every review decision, terminal states, priority branches, and the accepted 1,000-check boundary.
+- Package gate: `npm run check --workspace @narumitw/pi-starship` passed Biome and TypeScript.
+- Release intent: `npm run changeset:status` resolves `@narumitw/pi-starship` to minor `0.51.0`.
+- Repository tests: `npm test` passed 375 files and 3,769 tests.
+- CI-equivalent gate: `npm run check` passed Biome, boundaries, all workspace typechecks, and 3,769 tests.
+- Package smoke: `npm run pack:starship` inspected a 78-file dry-run tarball containing the changed README and runtime source.
+- Live TUI/GitHub smoke was not run because it would require an interactive Pi session and external current-branch PR; deterministic runtime, render, lifecycle, and packaging tests cover the changed path.
+
+## Completion Checklist
+
+- [x] `$checks`, `$review`, and `$status` use only the documented compact forms.
+- [x] No parallel short or verbose variables are added.
+- [x] The default `github_pr` module format renders the compact `$status` without a settings migration.
+- [x] Check output omits zero-count categories and does not reuse Git's `$`, `!`, or `?` check markers.
+- [x] Review output remains distinguishable from check output without relying only on color.
+- [x] Every documented compact value and precedence branch has deterministic test coverage.
+- [x] README migration guidance and the Changeset clearly disclose the existing-variable behavior change.
+- [x] Required tests, CI-equivalent checks, package smoke, semantic convention audit, and handoff evidence are complete.

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -491,10 +491,58 @@ Variables have these values:
 - `$number`: digits such as `123`.
 - `$link`: an OSC 8 `#123` link for a safe HTTP(S) URL, otherwise plain `#123`.
 - `$state`: `open`, `draft`, `merged`, or `closed`.
-- `$checks`: `checks passing`, `<n> failing`, `<n> pending`, or `no checks`.
-- `$review`: `approved`, `changes requested`, `review required`, or empty when unknown.
-- `$status`: one compact result selected in this order: merged, closed, draft, failing, changes
-  requested, pending, approved, review required, passing, then no checks.
+- `$checks`: all non-zero check counts in passed, failed, pending order, or `-` when no checks exist.
+- `$review`: `R✓` for approved, `R×` for changes requested, `R?` for review required, or empty
+  when unknown.
+- `$status`: one result selected in this order: merged, closed, draft, failing checks, changes
+  requested, pending checks, approved, review required, passing checks, then no checks.
+
+The compact symbols are font-safe and distinct from Git's default `$`, `!`, and `?` worktree markers:
+
+| Compact value | Meaning |
+| --- | --- |
+| `✓<n>` | Checks that passed, including successful, skipped, and neutral conclusions |
+| `×<n>` | Checks that failed |
+| `…<n>` | Checks that are pending |
+| `R✓` | Review approved |
+| `R×` | Changes requested |
+| `R?` | Review required |
+| `M` / `C` / `D` | Merged, closed, or draft PR |
+| `-` | No checks |
+
+The unchanged default module format uses `$status` and now renders compact output:
+
+```text
+PR #123 · ×2
+PR #123 · R✓
+PR #123 · M
+```
+
+Use the existing `$checks` and `$review` variables together when every check category and the review
+result should remain visible:
+
+```toml
+[github_pr]
+format = "[$symbol$link( $checks)( $review) ]($style)"
+```
+
+```text
+PR #123 ✓12 ×2 …7 R×
+```
+
+This is a breaking display migration for custom formats that use these variables:
+
+| Previous value | Compact value |
+| --- | --- |
+| `checks passing` | `✓<n>` |
+| `<n> failing` | `×<n>` |
+| `<n> pending` | `…<n>` |
+| `no checks` | `-` |
+| `approved` / `changes requested` / `review required` | `R✓` / `R×` / `R?` |
+| `merged` / `closed` / `draft` | `M` / `C` / `D` |
+
+The old English values have no verbose aliases.
+The variable names and default module format remain unchanged, so no TOML field migration is needed.
 
 The query runs only in TUI sessions when the enabled module is reachable from the root format. It
 refreshes at session start, immediately after a branch change, after each agent run, after accepted

--- a/packages/pi-starship/src/runtime/github-pr.ts
+++ b/packages/pi-starship/src/runtime/github-pr.ts
@@ -180,16 +180,25 @@ function summarizeChecks(value: unknown): CheckSummary {
 }
 
 function formatChecks(checks: CheckSummary): string {
-	if (checks.total === 0) return "no checks";
-	if (checks.failed > 0) return `${checks.failed} failing`;
-	if (checks.pending > 0) return `${checks.pending} pending`;
-	return "checks passing";
+	if (checks.total === 0) return "-";
+	const passed = checks.total - checks.failed - checks.pending;
+	return [
+		compactCount("✓", passed),
+		compactCount("×", checks.failed),
+		compactCount("…", checks.pending),
+	]
+		.filter(Boolean)
+		.join(" ");
+}
+
+function compactCount(symbol: string, count: number): string {
+	return count > 0 ? `${symbol}${count}` : "";
 }
 
 function formatReview(review: ReviewDecision): string {
-	if (review === "APPROVED") return "approved";
-	if (review === "CHANGES_REQUESTED") return "changes requested";
-	if (review === "REVIEW_REQUIRED") return "review required";
+	if (review === "APPROVED") return "R✓";
+	if (review === "CHANGES_REQUESTED") return "R×";
+	if (review === "REVIEW_REQUIRED") return "R?";
 	return "";
 }
 
@@ -199,11 +208,13 @@ function compactStatus(
 	checksText: string,
 	review: string,
 ): string {
-	if (state === "merged" || state === "closed" || state === "draft") return state;
-	if (checks.failed > 0) return checksText;
-	if (review === "changes requested") return review;
-	if (checks.pending > 0) return checksText;
-	if (review === "approved" || review === "review required") return review;
+	if (state === "merged") return "M";
+	if (state === "closed") return "C";
+	if (state === "draft") return "D";
+	if (checks.failed > 0) return compactCount("×", checks.failed);
+	if (review === "R×") return review;
+	if (checks.pending > 0) return compactCount("…", checks.pending);
+	if (review === "R✓" || review === "R?") return review;
 	return checksText;
 }
 

--- a/packages/pi-starship/test/github-pr.test.ts
+++ b/packages/pi-starship/test/github-pr.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import { BUILT_IN_CONFIG } from "../src/config.js";
 import { parseFormat } from "../src/format/formatter.js";
+import { githubPrModule } from "../src/modules/github-pr.js";
 import { renderStatusline, type StarshipRuntimeSnapshot } from "../src/modules/index.js";
 import {
 	buildGithubPrSnapshot,
@@ -52,11 +53,12 @@ function stripSgr(value: string): string {
 	return value.replace(new RegExp(`${escapeSequence}\\[[0-9;]*m`, "gu"), "");
 }
 
-test("github_pr exposes native variables and compact status priority", () => {
+test("github_pr exposes compact checks, review, and prioritized status", () => {
 	const snapshot = buildGithubPrSnapshot(
 		rawPr({
 			reviewDecision: "CHANGES_REQUESTED",
 			statusCheckRollup: [
+				{ status: "COMPLETED", conclusion: "SUCCESS" },
 				{ status: "COMPLETED", conclusion: "FAILURE" },
 				{ status: "COMPLETED", conclusion: "TIMED_OUT" },
 				{ status: "IN_PROGRESS", conclusion: null },
@@ -76,9 +78,9 @@ test("github_pr exposes native variables and compact status priority", () => {
 		{
 			number: "123",
 			state: "open",
-			checks: "2 failing",
-			review: "changes requested",
-			status: "2 failing",
+			checks: "✓1 ×2 …1",
+			review: "R×",
+			status: "×2",
 		},
 	);
 
@@ -90,7 +92,7 @@ test("github_pr exposes native variables and compact status priority", () => {
 	const rendered = stripSgr(renderStatusline(config, runtime(snapshot)).ansi);
 	assert.equal(
 		rendered,
-		`123|\u001b]8;;https://github.com/o/r/pull/123\u0007#123\u001b]8;;\u0007|open|2 failing|changes requested|2 failing`,
+		`123|\u001b]8;;https://github.com/o/r/pull/123\u0007#123\u001b]8;;\u0007|open|✓1 ×2 …1|R×|×2`,
 	);
 
 	const cases: Array<[Record<string, unknown>, string]> = [
@@ -99,27 +101,81 @@ test("github_pr exposes native variables and compact status priority", () => {
 				state: "MERGED",
 				mergedAt: new Date(NOW - 1_000).toISOString(),
 			},
-			"merged",
+			"M",
 		],
 		[
 			{
 				state: "CLOSED",
 				closedAt: new Date(NOW - 1_000).toISOString(),
 			},
-			"closed",
+			"C",
 		],
-		[{ isDraft: true }, "draft"],
-		[{ statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }] }, "1 failing"],
-		[{ reviewDecision: "CHANGES_REQUESTED" }, "changes requested"],
-		[{ statusCheckRollup: [{ status: "IN_PROGRESS", conclusion: null }] }, "1 pending"],
-		[{ reviewDecision: "APPROVED" }, "approved"],
-		[{ reviewDecision: "REVIEW_REQUIRED" }, "review required"],
-		[{ reviewDecision: "", statusCheckRollup: [{ state: "SUCCESS" }] }, "checks passing"],
-		[{ reviewDecision: "", statusCheckRollup: [] }, "no checks"],
+		[{ isDraft: true }, "D"],
+		[{ statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }] }, "×1"],
+		[{ reviewDecision: "CHANGES_REQUESTED" }, "R×"],
+		[{ statusCheckRollup: [{ status: "IN_PROGRESS", conclusion: null }] }, "…1"],
+		[{ reviewDecision: "APPROVED" }, "R✓"],
+		[{ reviewDecision: "REVIEW_REQUIRED" }, "R?"],
+		[
+			{
+				reviewDecision: "",
+				statusCheckRollup: [
+					{ state: "SUCCESS" },
+					{ status: "COMPLETED", conclusion: "SKIPPED" },
+					{ status: "COMPLETED", conclusion: "NEUTRAL" },
+				],
+			},
+			"✓3",
+		],
+		[{ reviewDecision: "", statusCheckRollup: [] }, "-"],
 	];
 	for (const [overrides, expected] of cases) {
 		assert.equal(buildGithubPrSnapshot(rawPr(overrides), NOW)?.status, expected);
 	}
+});
+
+test("compact PR values omit zero check categories and cover bounded decisions", () => {
+	const checkCases: Array<[unknown[], string]> = [
+		[[{ status: "COMPLETED", conclusion: "SUCCESS" }], "✓1"],
+		[[{ status: "COMPLETED", conclusion: "FAILURE" }], "×1"],
+		[[{ status: "IN_PROGRESS", conclusion: null }], "…1"],
+		[
+			[
+				{ status: "COMPLETED", conclusion: "SUCCESS" },
+				{ status: "COMPLETED", conclusion: "FAILURE" },
+				{ status: "IN_PROGRESS", conclusion: null },
+			],
+			"✓1 ×1 …1",
+		],
+		[[], "-"],
+		[Array.from({ length: 1_000 }, () => ({ state: "SUCCESS" })), "✓1000"],
+	];
+	for (const [statusCheckRollup, expected] of checkCases) {
+		assert.equal(buildGithubPrSnapshot(rawPr({ statusCheckRollup }), NOW)?.checks, expected);
+	}
+
+	const reviewCases: Array<[unknown, string]> = [
+		["APPROVED", "R✓"],
+		["CHANGES_REQUESTED", "R×"],
+		["REVIEW_REQUIRED", "R?"],
+		["UNKNOWN", ""],
+	];
+	for (const [reviewDecision, expected] of reviewCases) {
+		assert.equal(buildGithubPrSnapshot(rawPr({ reviewDecision }), NOW)?.review, expected);
+	}
+});
+
+test("github_pr keeps its established variables and default format", () => {
+	assert.deepEqual(githubPrModule.variables, [
+		"symbol",
+		"number",
+		"link",
+		"state",
+		"checks",
+		"review",
+		"status",
+	]);
+	assert.equal(githubPrModule.defaults.format, "[ $symbol$link( · $status) ]($style)");
 });
 
 test("terminal pull requests expire at the exact 24-hour boundary", () => {

--- a/packages/pi-starship/test/lifecycle.test.ts
+++ b/packages/pi-starship/test/lifecycle.test.ts
@@ -204,7 +204,7 @@ test("native PR refresh clears branch state, aborts stale work, and stops on foo
 			},
 		},
 	);
-	assert.match(stripAnsi(footer.render(300).join("\n")), /PR #123 · checks passing/u);
+	assert.match(stripAnsi(footer.render(300).join("\n")), /PR #123 · ✓1/u);
 
 	await emit(mock.events, "agent_end", {}, context.ctx);
 	assert.equal(prCalls, 2);
@@ -485,7 +485,7 @@ test("terminal native PR snapshots clear at their lifecycle expiry", async (t) =
 		footer.dispose();
 		await emit(mock.events, "session_shutdown", {}, context.ctx);
 	});
-	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · merged/u);
+	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · M/u);
 	now += 1_000;
 	vi.advanceTimersByTime(1_000);
 	assert.doesNotMatch(stripAnsi(footer.render(300).join("\n")), /#123/u);
@@ -526,11 +526,11 @@ test("terminal native PR expiry revalidates the wall clock before clearing", asy
 		footer.dispose();
 		await emit(mock.events, "session_shutdown", {}, context.ctx);
 	});
-	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · merged/u);
+	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · M/u);
 
 	now -= 10_000;
 	vi.advanceTimersByTime(500);
-	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · merged/u);
+	assert.match(stripAnsi(footer.render(300).join("\n")), /#123 · M/u);
 
 	now = expiresAt;
 	vi.advanceTimersByTime(10_500);

--- a/packages/pi-starship/test/modules.test.ts
+++ b/packages/pi-starship/test/modules.test.ts
@@ -55,9 +55,9 @@ function fixture(overrides: Partial<StarshipRuntimeSnapshot> = {}): StarshipRunt
 			number: "123",
 			link: LINK,
 			state: "open",
-			checks: "2 failing",
-			review: "approved",
-			status: "2 failing",
+			checks: "×2",
+			review: "R✓",
+			status: "×2",
 		},
 		gitStatus: {
 			ahead: 2,


### PR DESCRIPTION
## Summary

- Render the existing native GitHub PR `$checks`, `$review`, and `$status` variables as compact, font-safe symbols and counts.
- Keep the variable names and default module format unchanged while documenting the intentional breaking display migration.
- Cover mixed checks, every review and terminal state, status precedence, lifecycle rendering, zero omission, and the 1,000-check boundary.

## Verification

- Focused TDD red confirmed the old English values failed the new contract.
- Focused GitHub PR and lifecycle tests: 30 passed.
- `npm test`: 375 files and 3,769 tests passed.
- `npm run check`: Biome, boundaries, all workspace typechecks, and 3,769 tests passed.
- `npm run pack:starship`: expected 78-file dry-run tarball inspected.
- `npm run changeset:status`: `@narumitw/pi-starship` resolves to minor `0.51.0`.

## Risks and unverified paths

- This intentionally changes custom formats that expect the previous English variable values; the README and Changeset include migration guidance.
- A live interactive TUI/GitHub smoke was not run because it requires an interactive Pi session and an external current-branch PR; deterministic runtime, render, lifecycle, and packaging coverage passed.

## Plan

- [Completed implementation plan](https://github.com/narumiruna/pi-extensions/blob/narumiruna/feat/pi-starship-pr-short-status/docs/plans/archived/2026-08-15_pi-starship-github-pr-short-status-plan.md)
