### PR TITLE
feat(fleet): add launch settings and zellij support

### DIFF
--- a/.changeset/brave-clouds-split.md
+++ b/.changeset/brave-clouds-split.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-fleet": minor
 ---
 
-Default session spawning to tmux 3.2 or newer while preserving Ghostty as an explicit opt-in backend.
+Default session spawning to tmux 3.2 or newer, preserve Ghostty and add Zellij 0.44 or newer as configurable backends, and add persistent launch confirmation settings shared by menu and tool launches.

--- a/docs/plans/archived/2026-08-15_pi-fleet-launch-settings-plan.md
+++ b/docs/plans/archived/2026-08-15_pi-fleet-launch-settings-plan.md
@@ -1,0 +1,57 @@
+# Pi Fleet launch settings plan
+
+## Goal
+
+Add persistent `/fleet` settings for the default terminal backend and per-launch confirmation, with the same effective launch policy applied to menu and `session_spawn` launches.
+
+## Context
+
+- The approved settings are **Default terminal** (`tmux` or `Ghostty`) and **Confirm new sessions** (`Ask` or `Skip`).
+- The configured terminal replaces the per-launch backend selector when **New Pi session…** is chosen.
+- An explicit `session_spawn.terminal` argument overrides the configured default.
+- Disabling launch confirmation skips only the final launch preview for both menu and tool launches.
+- Experimental consent remains required once per Pi Fleet runtime.
+- The existing tmux default remains compatible when no settings file exists.
+
+## Architecture
+
+- Own user settings in `<getAgentDir()>/pi-fleet.json`; do not add project overrides or environment-variable overrides.
+- Keep defaults, validation, ordered in-process persistence, unknown-field preservation, and atomic temporary-file-plus-rename publication in a new package-owned settings module.
+- Reload settings during `session_start`, flush pending writes during `session_shutdown`, and retain the previous effective state when loading or publication fails.
+- Let `FleetController` resolve omitted tool terminals and confirmation policy from the shared settings runtime.
+- Project the same settings runtime into a Pi TUI Kit `settings` screen so TUI and RPC use one menu and one persistence path.
+- Document that ordering is process-local; separately running Pi sessions reload the shared file on their next session start or `/reload`.
+
+## Applicable MUST Rules
+
+- Preserve the extension factory, command routes, TUI/RPC mode behavior, tool failure signaling, cancellation, stale-session checks, and session-owned cleanup; verify with focused lifecycle, menu, tool, and spawn tests plus review.
+- Use the existing Pi TUI Kit manager for the standard Settings screen and keep unsupported print/JSON behavior unchanged; verify with TUI/RPC menu tests and typechecking.
+- Use `getAgentDir()`, keep missing-file reads side-effect free, validate runtime JSON, preserve unknown fields, block malformed-file writes, serialize reads and writes, publish atomically, and reload/flush at lifecycle boundaries; verify with deterministic settings and lifecycle tests.
+- Keep changed published behavior documented and represented by the existing Pi Fleet Changeset; verify with README review, Changesets status, and package dry run.
+- Run the CI-equivalent `npm run check`; do not treat it as a substitute for the settings concurrency, cancellation, replacement, and failure-recovery audit.
+
+## Non-Goals
+
+- Do not make experimental consent configurable.
+- Do not add project-scoped settings, environment overrides, terminal auto-detection, or backend fallback.
+- Do not change split direction, first-task, readiness, kickoff, group, or messaging semantics.
+- Do not synchronize effective in-memory settings across already-running Pi processes.
+
+## Plan
+
+- [x] Add focused settings tests for defaults, validation, side-effect-free missing loads, first save, unknown-field preservation, malformed-file protection, atomic failure recovery, and ordered read/write behavior; the absent new module prevented a valid executable red state, then the smallest implementation passed all six tests.
+- [x] Implement `packages/pi-fleet/src/settings.ts` and make session start, shutdown, spawn terminal resolution, and launch confirmation consume one shared settings runtime; three focused spawn/lifecycle tests failed against the old behavior, then the settings, spawn, and extension suites passed all 20 tests.
+- [x] Add focused failing menu tests for Settings navigation, immediate terminal/confirmation updates, rollback on save failure, configured-backend spawning without a backend prompt, and TUI/RPC adaptation; four focused tests failed against the old menu, then all nine menu tests passed with the Pi TUI Kit settings screen.
+- [x] Update tool metadata, README settings/default/confirmation/lifecycle guidance, package layout, and the existing Changeset while preserving explicit terminal override behavior; all 88 Pi Fleet tests and package typechecking passed.
+- [x] Run formatting, Pi Fleet tests, package typechecking, root `npm run check`, `just pack fleet`, Changesets status, and a local Pi entrypoint smoke; root checks passed 3,779 tests across 376 files, the dry-run package contains 22 declared files including `src/settings.ts`, the Changeset remains a minor bump, and the isolated entrypoint loaded successfully.
+- [x] Audit the final diff against `docs/extension-conventions.md` and `docs/extension-settings.md`, including cancellation, disposal, session replacement, shutdown, stale state after every await, settings ordering, invalid-file protection, unknown-field preservation, atomic publication, and all changed TUI/RPC/tool paths; no convention deviation remains, while process-local write ordering and unavailable live terminal smokes are documented limitations.
+
+## Completion Checklist
+
+- [x] Missing settings preserve tmux plus per-launch confirmation as the compatible defaults.
+- [x] `/fleet → Settings` changes the default backend and launch confirmation immediately and durably.
+- [x] Menu launches use the configured backend without asking for a backend each time.
+- [x] Omitted `session_spawn.terminal` uses the configured backend, while an explicit argument wins.
+- [x] Confirmation policy applies to menu and tool launches without suppressing experimental consent.
+- [x] Invalid settings never get overwritten, failed saves restore the prior effective value, and lifecycle reads/writes remain ordered.
+- [x] Documentation, Changeset, tests, checks, package contents, and unverified smokes are accurately reported.

--- a/docs/plans/archived/2026-08-15_pi-fleet-zellij-support-plan.md
+++ b/docs/plans/archived/2026-08-15_pi-fleet-zellij-support-plan.md
@@ -9,7 +9,7 @@ Add Zellij as a configurable and explicit Pi Fleet terminal backend while keepin
 - Pi Fleet currently supports tmux and Ghostty through one terminal adapter contract.
 - `/fleet` Settings persists `defaultTerminal`, and `session_spawn.terminal` can override it.
 - Zellij 0.44 introduced pane IDs from pane-creating CLI commands and pane-targeted `move-pane`, which are needed for authenticated readiness metadata and left/up placement.
-- The installed host has Zellij 0.44.3, but this Pi process is not running inside Zellij.
+- The installed host has Zellij 0.44.3, and the final implementation was live-smoked from an active Zellij pane.
 
 ## Architecture
 
@@ -24,17 +24,17 @@ Add Zellij as a configurable and explicit Pi Fleet terminal backend while keepin
 - A failed left/up move can leave a successfully created child pane, so it must be reported as a partial launch with the pane ID.
 - Cancellation or session replacement after pane creation can leave a visible pane, so post-await stale and abort checks must preserve partial-launch semantics.
 - Zellij lacks per-pane environment flags, so launch values briefly exist in a private launcher that must unlink itself before starting Pi and remain covered by the existing same-user process boundary.
-- A real split smoke is unavailable unless Pi runs inside Zellij, so deterministic adapter tests and local CLI capability checks are required, with the live path reported as unverified.
+- A real split smoke requires Pi to run inside Zellij, so deterministic adapter tests remain the primary repeatable gate and a live four-direction smoke supplies runtime evidence.
 
 ## Plan
 
 - [x] Add focused failing tests for Zellij availability, version gating, all split directions, private launcher transport, invalid input, partial failures, cancellation, and stale continuations; the initial adapter run executed five tests and all failed on the unimplemented behavior.
-- [x] Implement `packages/pi-fleet/src/zellij.ts` with Zellij 0.44+ capability checks, direct pane launch, left/up placement, bounded validation, and partial-launch errors; focused adapter tests pass.
+- [x] Implement `packages/pi-fleet/src/zellij.ts` with Zellij 0.44+ capability checks, direct pane launch, left/up placement, bounded validation, and partial-launch errors; focused adapter tests pass, and a live smoke exposed and removed `--near-current-pane` because Zellij 0.44.3 hid that pane while leaving its child process running.
 - [x] Add focused failing integration tests for Settings normalization and UI selection, configured/default controller routing, explicit tool override, result labels, and unchanged tmux default; the integration red run executed 37 tests and failed the seven intended Zellij assertions.
 - [x] Wire Zellij through `terminal.ts`, `settings.ts`, `fleet-controller.ts`, `menu.ts`, `pi-fleet.ts`, and `tools.ts`; package tests and typechecking pass.
 - [x] Update the Pi Fleet README, package keywords/layout, and existing minor Changeset to document Zellij requirements, no fallback, private launcher transport, limitations, and tmux remaining the default.
-- [x] Audit cancellation, partial pane creation, stale sessions, shutdown, settings preservation/order/failure behavior, terminal-safe labels, and every touched MUST rule in `docs/extension-conventions.md` and `docs/extension-settings.md`; no deviation remains, and a real Zellij split is the only unverified runtime path.
-- [x] Run formatting, focused tests, package typechecking, `npm run check`, `just pack fleet`, Changesets status, local Pi entrypoint loading, and non-interactive Zellij CLI capability checks; the root gate passed 378 files and 3,790 tests, and the dry-run tarball contains 23 files including `src/zellij.ts`.
+- [x] Audit cancellation, partial pane creation, stale sessions, shutdown, settings preservation/order/failure behavior, terminal-safe labels, and every touched MUST rule in `docs/extension-conventions.md` and `docs/extension-settings.md`; no deviation or unverified Zellij launch path remains.
+- [x] Run formatting, focused tests, package typechecking, `npm run check`, `just pack fleet`, Changesets status, local Pi entrypoint loading, non-interactive Zellij CLI capability checks, and a live runtime smoke; Zellij 0.44.3 created visible authenticated panes in all four directions, delivered a kickoff and reply, and cleaned every smoke pane and peer.
 
 ## Completion Checklist
 
@@ -43,4 +43,4 @@ Add Zellij as a configurable and explicit Pi Fleet terminal backend while keepin
 - [x] Zellij launches return authenticated readiness metadata with a validated pane ID for right, down, left, and up.
 - [x] Pre-launch failures create no Fleet group or pane, while post-pane failures are reported as partial and preserve launcher cleanup semantics.
 - [x] Documentation and the Changeset describe the shipped behavior and supported Zellij floor.
-- [x] All required deterministic checks pass, and the unavailable live Zellij split is named for the handoff.
+- [x] All required deterministic checks and the live Zellij four-direction split smoke pass.

--- a/docs/plans/archived/2026-08-15_pi-fleet-zellij-support-plan.md
+++ b/docs/plans/archived/2026-08-15_pi-fleet-zellij-support-plan.md
@@ -1,0 +1,46 @@
+# Pi Fleet Zellij Support Plan
+
+## Goal
+
+Add Zellij as a configurable and explicit Pi Fleet terminal backend while keeping tmux as the built-in default.
+
+## Context
+
+- Pi Fleet currently supports tmux and Ghostty through one terminal adapter contract.
+- `/fleet` Settings persists `defaultTerminal`, and `session_spawn.terminal` can override it.
+- Zellij 0.44 introduced pane IDs from pane-creating CLI commands and pane-targeted `move-pane`, which are needed for authenticated readiness metadata and left/up placement.
+- The installed host has Zellij 0.44.3, but this Pi process is not running inside Zellij.
+
+## Architecture
+
+- Add a package-owned `ZellijAdapter` that validates the current Zellij pane, requires Zellij 0.44 or newer, launches through `zellij action new-pane`, and returns its `terminal_<id>` identity.
+- Pass Zellij only a private self-deleting launcher path, with launch-only environment values embedded briefly in that `0700` file so Zellij command metadata cannot retain bearer values.
+- Use Zellij's native right/down split and a pane-targeted move for left/up placement.
+- Extend the existing terminal union, controller dependency port, Settings row, tool schema, labels, and documentation without adding fallback behavior.
+- Preserve `defaultTerminal: "tmux"` for missing settings and existing files.
+
+## Risks
+
+- A failed left/up move can leave a successfully created child pane, so it must be reported as a partial launch with the pane ID.
+- Cancellation or session replacement after pane creation can leave a visible pane, so post-await stale and abort checks must preserve partial-launch semantics.
+- Zellij lacks per-pane environment flags, so launch values briefly exist in a private launcher that must unlink itself before starting Pi and remain covered by the existing same-user process boundary.
+- A real split smoke is unavailable unless Pi runs inside Zellij, so deterministic adapter tests and local CLI capability checks are required, with the live path reported as unverified.
+
+## Plan
+
+- [x] Add focused failing tests for Zellij availability, version gating, all split directions, private launcher transport, invalid input, partial failures, cancellation, and stale continuations; the initial adapter run executed five tests and all failed on the unimplemented behavior.
+- [x] Implement `packages/pi-fleet/src/zellij.ts` with Zellij 0.44+ capability checks, direct pane launch, left/up placement, bounded validation, and partial-launch errors; focused adapter tests pass.
+- [x] Add focused failing integration tests for Settings normalization and UI selection, configured/default controller routing, explicit tool override, result labels, and unchanged tmux default; the integration red run executed 37 tests and failed the seven intended Zellij assertions.
+- [x] Wire Zellij through `terminal.ts`, `settings.ts`, `fleet-controller.ts`, `menu.ts`, `pi-fleet.ts`, and `tools.ts`; package tests and typechecking pass.
+- [x] Update the Pi Fleet README, package keywords/layout, and existing minor Changeset to document Zellij requirements, no fallback, private launcher transport, limitations, and tmux remaining the default.
+- [x] Audit cancellation, partial pane creation, stale sessions, shutdown, settings preservation/order/failure behavior, terminal-safe labels, and every touched MUST rule in `docs/extension-conventions.md` and `docs/extension-settings.md`; no deviation remains, and a real Zellij split is the only unverified runtime path.
+- [x] Run formatting, focused tests, package typechecking, `npm run check`, `just pack fleet`, Changesets status, local Pi entrypoint loading, and non-interactive Zellij CLI capability checks; the root gate passed 378 files and 3,790 tests, and the dry-run tarball contains 23 files including `src/zellij.ts`.
+
+## Completion Checklist
+
+- [x] Missing or legacy settings still resolve to tmux without rewriting the file.
+- [x] `/fleet` Settings and `session_spawn` accept `zellij`, and explicit terminal arguments still override settings.
+- [x] Zellij launches return authenticated readiness metadata with a validated pane ID for right, down, left, and up.
+- [x] Pre-launch failures create no Fleet group or pane, while post-pane failures are reported as partial and preserve launcher cleanup semantics.
+- [x] Documentation and the Changeset describe the shipped behavior and supported Zellij floor.
+- [x] All required deterministic checks pass, and the unavailable live Zellij split is named for the handoff.

--- a/packages/pi-fleet/README.md
+++ b/packages/pi-fleet/README.md
@@ -7,15 +7,16 @@
 > Its local protocol, terminal automation, tool schemas, and agent-request behavior may change between releases.
 
 `@narumitw/pi-fleet` starts a separate Pi process in a terminal split while preserving the parent session.
-It defaults to tmux and uses Ghostty only after an explicit selection.
+Its built-in default remains tmux, and users can select Ghostty or Zellij in Settings or per tool call.
 It also lets explicitly joined Pi sessions owned by the same operating-system user exchange bounded local messages and one-turn requests.
 
 ## ✨ Features
 
-- Starts a distinct Pi process in a tmux split by default.
-- Preserves Ghostty's native macOS AppleScript integration as an explicit opt-in backend.
+- Starts a distinct Pi process with a configurable tmux, Ghostty, or Zellij backend.
+- Keeps tmux as the built-in default while preserving native Ghostty and Zellij integrations.
 - Preserves the parent Pi session instead of replacing it with `ctx.newSession()`.
 - Inherits the parent cwd, model identity, thinking level, and an optional first task.
+- Lets users keep or skip the final launch preview while retaining one-time experimental consent.
 - Waits for an authenticated child endpoint before reporting that the new session is ready.
 - Connects explicit sessions through owner-only Unix sockets and ephemeral bearer invites.
 - Authenticates strict version-2 manifests and frames with separate HMAC-SHA-256 domains.
@@ -45,7 +46,7 @@ Load the extension from a local checkout:
 pi --no-extensions --no-skills --no-session -e ./packages/pi-fleet
 ```
 
-A child started in either terminal backend uses normal Pi extension discovery.
+A child started in any supported terminal backend uses normal Pi extension discovery.
 Install Pi Fleet persistently before testing the complete split-and-auto-join flow because a parent's temporary `-e` argument is not copied into the child process.
 
 Pi extensions execute with your user permissions.
@@ -59,14 +60,13 @@ Run:
 /fleet
 ```
 
-Choose **New Pi session…**.
+Choose **Settings** first when you want to change the default terminal or final launch confirmation.
+Then choose **New Pi session…**.
+Pi Fleet uses the configured terminal and asks for a split direction and an optional first task.
+It always requires one-time experimental consent.
+When **Confirm new sessions** is **Ask**, it also shows an exact launch preview before creating any socket or split.
 
-The backend selector starts on **tmux — default**.
-Choose **Ghostty — explicit opt-in** only when you want Ghostty automation for this launch.
-Pi Fleet then asks for a split direction and an optional first task.
-It shows the experimental warning and an exact launch preview before creating any socket or split.
-
-After confirmation, Pi Fleet:
+After the required consent and optional launch confirmation, Pi Fleet:
 
 1. Creates or reuses an ephemeral local group.
 2. Creates the selected terminal split.
@@ -84,13 +84,13 @@ Creates a separate Pi process in a terminal split.
 
 | Parameter | Required | Description |
 | --- | --- | --- |
-| `terminal` | No | `tmux` or `ghostty`; defaults to `tmux`. Ghostty requires explicit selection. |
+| `terminal` | No | Explicit `tmux`, `ghostty`, or `zellij` override; omission uses the configured default, initially `tmux`. |
 | `direction` | No | `right`, `down`, `left`, or `up`; defaults to `right`. |
 | `task` | No | First task sent only after authenticated readiness. |
 | `name` | No | Child session display name. |
 | `cwd` | No | Existing directory; defaults to the current cwd. |
 
-The tool works only in TUI and RPC modes because it requires user confirmation.
+The tool works only in TUI and RPC modes because Pi Fleet requires experimental consent and may require launch confirmation.
 JSON and print modes fail before creating a group, launcher, or split.
 Successful details include `terminal`, `terminalId`, and `terminalVersion`.
 Ghostty results also retain `ghosttyVersion` for compatibility.
@@ -122,17 +122,17 @@ Unknown and trailing arguments are rejected.
 JSON and print command routes fail before opening sockets or custom UI.
 
 The manager keeps **New Pi session…** first whether connected or disconnected.
-Its terminal selector lists tmux first and requires a separate Ghostty choice.
-Connected sessions can send a message, inspect peers, copy the explicit invite, change request policy, inspect status and help, or leave the group.
+Its **Settings** screen changes the default terminal and final launch confirmation.
+Connected sessions can send a message, inspect peers, copy the explicit invite, change request policy, inspect settings, status, and help, or leave the group.
 
 ## 🖥️ Terminal backends
 
 Pi Fleet does not automatically fall back between terminal backends.
-A failed tmux launch never probes or starts Ghostty.
+A failed launch never probes or starts another configured backend.
 
-### tmux default
+### tmux built-in default
 
-The default backend requires:
+The tmux backend requires:
 
 - tmux 3.2 or newer.
 - Pi running inside the target tmux pane with `TMUX` and `TMUX_PANE` available.
@@ -141,8 +141,7 @@ Pi Fleet targets the current pane, uses `split-window`, passes the cwd and launc
 
 ### Ghostty explicit opt-in
 
-Choose Ghostty in the manager or pass `terminal: "ghostty"` to `session_spawn`.
-Do not select it when the user requested only another Pi session without naming Ghostty.
+Choose Ghostty under **Settings**, or pass `terminal: "ghostty"` to override the configured default for one `session_spawn` call.
 
 Ghostty requires:
 
@@ -157,12 +156,47 @@ It does not simulate user key presses or depend on customized keybindings.
 The first Ghostty launch may trigger a macOS Automation permission prompt.
 If permission is denied, enable it in **System Settings → Privacy & Security → Automation** and retry.
 
+### Zellij explicit opt-in
+
+Choose Zellij under **Settings**, or pass `terminal: "zellij"` to override the configured default for one `session_spawn` call.
+
+Zellij requires:
+
+- Zellij 0.44 or newer.
+- Pi running inside the target Zellij pane with `ZELLIJ` and `ZELLIJ_PANE_ID` available.
+
+Pi Fleet uses `zellij action new-pane` with a private self-deleting launcher path and validates the returned `terminal_<id>` pane identity.
+Right and down use Zellij's native split directions.
+Left and up create the corresponding native pane and then use pane-targeted `move-pane` placement.
+A placement failure is a partial launch because the child pane may already be running and remains visible.
+
 ## ⚙️ Settings and lifecycle
 
-Pi Fleet has no user or project settings file in this release.
-The terminal backend is selected per launch, and an omitted tool argument defaults to tmux.
+Open `/fleet` and choose **Settings**.
+Pi Fleet stores user settings in `<getAgentDir()>/pi-fleet.json`, normally `~/.pi/agent/pi-fleet.json`:
 
-Group secrets, request permission, peers, readiness state, and deduplication state are held only in memory by Pi Fleet.
+```json
+{
+  "defaultTerminal": "tmux",
+  "confirmSessionLaunch": true
+}
+```
+
+| Setting | Values | Default | Behavior |
+| --- | --- | --- | --- |
+| `defaultTerminal` | `tmux`, `ghostty`, `zellij` | `tmux` | Used by menu launches and by `session_spawn` when `terminal` is omitted. |
+| `confirmSessionLaunch` | `true`, `false` | `true` | Shows or skips the final launch preview for menu and tool launches. |
+
+An explicit `session_spawn.terminal` value overrides `defaultTerminal` for that launch.
+Disabling launch confirmation does not disable one-time experimental consent.
+Pi Fleet does not read project overrides or extension-specific environment variables.
+A missing file keeps defaults without creating the file, while each Settings change saves immediately.
+Writes preserve unknown fields, serialize within one Pi process, and publish atomically through a private temporary file and rename.
+Malformed or invalid files are reported and never overwritten by the Settings screen.
+Separately running Pi processes do not share a settings lock, so avoid changing this file concurrently from multiple sessions.
+A Settings change applies immediately in the current process; other running Pi processes reload it on their next session start or `/reload`.
+
+Group secrets, request permission, peers, readiness state, and deduplication state stay in memory except for the short-lived private Zellij launch copy described below.
 The `pifleet:v1` prefix versions the bearer-invite encoding independently from the version-2 socket protocol.
 Version-2 messages normally expire after two minutes and cannot declare a lifetime longer than five minutes.
 Accepted message ids remain deduplicated for ten minutes, so their retry window outlives their valid delivery window.
@@ -190,11 +224,12 @@ Enabling them permits trusted invite holders to start paid model turns that may 
 - Launch kickoffs additionally require a random capability shared only through the parent-to-child launch envelope; it is not published through peer discovery or persisted with delivered messages.
 - Two simultaneously live endpoints claiming one session id are omitted from discovery and rejected as an explicit identity conflict.
 - Bearer invites are shown only on the explicit invite screen or direct join input.
-- Pi Fleet does not persist invites, but a recipient can copy and reuse one until every holder discards it or moves to a new group.
-- Invites are not placed in tool output, status, notifications, custom renderers, launch scripts, or model context.
+- Pi Fleet does not retain invites as durable settings or group state, but a recipient can copy and reuse one until every holder discards it or moves to a new group.
+- Invites are not placed in tool output, status, notifications, custom renderers, or model context.
 - Tmux receives launch values through per-pane `-e` arguments and Pi Fleet never publishes them to the tmux global environment.
+- Zellij receives only a launcher path, while launch values briefly exist in a private `0700` launcher that unlinks itself before starting Pi so Zellij command metadata cannot retain them.
 - Peer names, paths, messages, model ids, and errors are treated as untrusted terminal text and sanitized only at display boundaries.
-- A same-user process or another privileged Pi extension is outside the security boundary and may inspect process arguments, memory, or environment.
+- A same-user process or another privileged Pi extension is outside the security boundary and may inspect process arguments, private runtime files, memory, or environment.
 - Pi Fleet provides explicit group separation, not a sandbox against the operating-system user.
 
 ## 🧪 Experimental limitations
@@ -203,6 +238,7 @@ Enabling them permits trusted invite holders to start paid model turns that may 
 - POSIX Unix-socket transport only.
 - Tmux spawning requires tmux 3.2 or newer and an active current pane.
 - Ghostty spawning remains an explicit opt-in and works only on macOS.
+- Zellij spawning remains an explicit opt-in and requires Zellij 0.44 or newer in an active pane.
 - No LAN, internet, cross-user, remote-host, or public-room transport.
 - No daemon, offline mailbox, separate Fleet history, delivery receipt, global ordering, or exactly-once guarantee.
 - No automatic trust or discovery of every Pi process.
@@ -212,7 +248,7 @@ Enabling them permits trusted invite holders to start paid model turns that may 
 - One request uses one short-lived socket connection; there is no persistent multiplexed channel or delivery stream.
 - Server connections use an absolute request deadline rather than an activity-reset timeout, and at most eight message deliveries run concurrently.
 - Per-sender and endpoint-wide rate limits are fixed windows, so a busy response can require waiting before retrying.
-- Old orphan temporary files and sockets are removed after a grace period, while empty private group directories may remain to avoid cross-process startup races.
+- Old orphan temporary files, private launchers, and sockets are removed after a grace period, while empty private group directories may remain to avoid cross-process startup races.
 - No tab, window, resize, focus-navigation, or general layout manager.
 - Multiple Pi sessions can still race while editing the same workspace.
 
@@ -231,8 +267,10 @@ packages/pi-fleet/
 │   ├── transport-io.ts
 │   ├── runtime-directory.ts
 │   ├── terminal.ts
+│   ├── settings.ts
 │   ├── tmux.ts
 │   ├── ghostty.ts
+│   ├── zellij.ts
 │   ├── pi-invocation.ts
 │   ├── launcher.ts
 │   ├── launch-envelope.ts
@@ -251,7 +289,7 @@ packages/pi-fleet/
 
 ## 🔎 Keywords
 
-Pi extension, Pi Fleet, Pi sessions, tmux split, Ghostty split, local agents, agent communication, Unix socket, TypeScript.
+Pi extension, Pi Fleet, Pi sessions, tmux split, Ghostty split, Zellij pane, local agents, agent communication, Unix socket, TypeScript.
 
 ## 📄 License
 

--- a/packages/pi-fleet/package.json
+++ b/packages/pi-fleet/package.json
@@ -12,7 +12,8 @@
 		"fleet",
 		"session",
 		"tmux",
-		"ghostty"
+		"ghostty",
+		"zellij"
 	],
 	"files": [
 		"src",

--- a/packages/pi-fleet/src/fleet-controller.ts
+++ b/packages/pi-fleet/src/fleet-controller.ts
@@ -7,7 +7,6 @@ import type {
 	SessionShutdownEvent,
 	SessionStartEvent,
 } from "@earendil-works/pi-coding-agent";
-import { GhosttyAdapter } from "./ghostty.js";
 import {
 	consumeLaunchEnvelope,
 	type FleetLaunchEnvelope,
@@ -30,15 +29,18 @@ import {
 } from "./protocol.js";
 import { putReloadHandoff, takeReloadHandoff } from "./reload-handoff.js";
 import { FLEET_MESSAGE_TYPE, type FleetMessageDetails } from "./renderer.js";
+import { createInMemoryFleetSettingsRuntime, type FleetSettingsRuntime } from "./settings.js";
 import {
+	createDefaultTerminalPort,
 	createTerminalLaunchError,
 	type FleetTerminal,
+	type FleetTerminalPort,
 	isTerminalLaunchError,
 	normalizeTerminal,
 	type TerminalSplitDirection,
+	terminalLabel,
 } from "./terminal.js";
-import { safeError, safeTerminalLine } from "./text.js";
-import { TmuxAdapter } from "./tmux.js";
+import { normalizeOptionalText, safeError, safeTerminalLine } from "./text.js";
 import {
 	type FleetDeliveryAck,
 	type FleetDiscoveryIssue,
@@ -75,26 +77,19 @@ export interface FleetTransportPort {
 		| undefined;
 }
 
-export type { FleetTerminal } from "./terminal.js";
-
-export interface FleetTerminalPort {
-	assertAvailable(signal?: AbortSignal): Promise<string>;
-	spawnSplit(options: {
-		direction: TerminalSplitDirection;
-		cwd: string;
-		launcherCommand: string;
-		environment: Readonly<Record<string, string>>;
-		signal?: AbortSignal;
-		isCurrent(): boolean;
-	}): Promise<{ terminalId: string; version: string }>;
-}
+export type { FleetTerminal, FleetTerminalPort } from "./terminal.js";
 
 export interface FleetControllerDependencies {
 	createTransport(options: FleetTransportOptions): FleetTransportPort;
 	createTmux(): FleetTerminalPort;
 	createGhostty(): FleetTerminalPort;
+	createZellij(): FleetTerminalPort;
 	resolveInvocation(args: string[]): PiInvocation;
-	createLauncher(invocation: PiInvocation, directory: string): Promise<PiLauncher>;
+	createLauncher(
+		invocation: PiInvocation,
+		directory: string,
+		embeddedEnvironment?: Readonly<Record<string, string>>,
+	): Promise<PiLauncher>;
 	realpath(value: string): Promise<string>;
 	isDirectory(value: string): Promise<boolean>;
 	now(): number;
@@ -149,24 +144,12 @@ interface Membership {
 export function defaultFleetControllerDependencies(pi: ExtensionAPI): FleetControllerDependencies {
 	return {
 		createTransport: (options) => new FleetTransport(options),
-		createTmux: () =>
-			new TmuxAdapter({
-				execute: async (command, args, options) =>
-					pi.exec(command, args, {
-						...(options.signal ? { signal: options.signal } : {}),
-						timeout: options.timeoutMs,
-					}),
-			}),
-		createGhostty: () =>
-			new GhosttyAdapter({
-				execute: async (command, args, options) =>
-					pi.exec(command, args, {
-						...(options.signal ? { signal: options.signal } : {}),
-						timeout: options.timeoutMs,
-					}),
-			}),
+		createTmux: () => createDefaultTerminalPort(pi, "tmux"),
+		createGhostty: () => createDefaultTerminalPort(pi, "ghostty"),
+		createZellij: () => createDefaultTerminalPort(pi, "zellij"),
 		resolveInvocation: (args) => resolvePiInvocation(args),
-		createLauncher: (invocation, directory) => createPiLauncher(invocation, directory),
+		createLauncher: (invocation, directory, embeddedEnvironment) =>
+			createPiLauncher(invocation, directory, embeddedEnvironment),
 		realpath,
 		isDirectory: async (value) => (await stat(value)).isDirectory(),
 		now: Date.now,
@@ -190,6 +173,7 @@ export class FleetController {
 	constructor(
 		private readonly pi: ExtensionAPI,
 		private readonly deps: FleetControllerDependencies = defaultFleetControllerDependencies(pi),
+		private readonly settings: FleetSettingsRuntime = createInMemoryFleetSettingsRuntime(),
 	) {}
 
 	async sessionStart(
@@ -211,6 +195,14 @@ export class FleetController {
 			envelope = consumeLaunchEnvelope(this.deps.environment);
 		} catch (error) {
 			this.notify(ctx, `Pi Fleet ignored an invalid launch envelope: ${safeError(error)}`, "error");
+		}
+		try {
+			const settings = await this.settings.reload(this.controller.signal);
+			if (!this.isCurrent(owner, ownerGeneration)) return;
+			if (settings.issue) this.notify(ctx, settings.issue.message, "warning");
+		} catch (error) {
+			if (!this.isCurrent(owner, ownerGeneration)) return;
+			this.notify(ctx, `Pi Fleet could not load settings: ${safeError(error)}`, "error");
 		}
 		const handoff =
 			event.reason === "reload" ? takeReloadHandoff(owner, this.deps.now()) : undefined;
@@ -276,8 +268,12 @@ export class FleetController {
 				expiresAt: this.deps.now() + RELOAD_HANDOFF_TTL_MS,
 			});
 		}
-		await this.cleanupActive(event.reason === "reload");
-		this.clearStatus(ctx);
+		try {
+			await this.cleanupActive(event.reason === "reload");
+		} finally {
+			this.clearStatus(ctx);
+			await this.settings.flush();
+		}
 	}
 
 	get sessionSignal(): AbortSignal {
@@ -465,49 +461,57 @@ export class FleetController {
 		const owner = ctx.sessionManager;
 		const ownerGeneration = this.generation;
 		const operationSignal = combineSignals(signal, this.controller.signal);
-		const terminal = normalizeTerminal(input.terminal);
-		const terminalLabel = terminal === "tmux" ? "tmux" : "Ghostty";
+		await this.settings.flush();
+		if (!this.isCurrent(owner, ownerGeneration)) throw staleError();
+		const launchSettings = this.settings.get().settings;
+		const terminal = normalizeTerminal(input.terminal ?? launchSettings.defaultTerminal);
+		const selectedTerminalLabel = terminalLabel(terminal);
 		const direction = input.direction ?? "right";
 		const cwd = await this.resolveSpawnCwd(ctx, input.cwd);
 		if (!this.isCurrent(owner, ownerGeneration)) throw staleError();
-		const task = normalizeOptional(input.task, "task", MAX_MESSAGE_BYTES);
+		const task = normalizeOptionalText(input.task, "task", MAX_MESSAGE_BYTES);
 		const launchId = this.deps.randomId("launch");
 		const kickoffCapability = this.deps.randomId("kickoff");
-		const name = normalizeOptional(input.name, "name", 200) ?? `Fleet ${launchId.slice(-6)}`;
+		const name = normalizeOptionalText(input.name, "name", 200) ?? `Fleet ${launchId.slice(-6)}`;
 		const terminalAdapter =
-			terminal === "tmux" ? this.deps.createTmux() : this.deps.createGhostty();
+			terminal === "tmux"
+				? this.deps.createTmux()
+				: terminal === "ghostty"
+					? this.deps.createGhostty()
+					: this.deps.createZellij();
 		const terminalVersion = await terminalAdapter.assertAvailable(operationSignal);
 		if (!this.isCurrent(owner, ownerGeneration)) throw staleError();
 		if (!(await this.acceptExperimentalWarning(ctx, operationSignal))) {
 			throw abortError("Pi Fleet launch cancelled before creating a split");
 		}
-		const confirmed = await ctx.ui.confirm(
-			"Create a new Pi session?",
-			[
-				`${terminalLabel} split: ${direction}`,
-				`Name: ${safeTerminalLine(name)}`,
-				`Cwd: ${safeTerminalLine(cwd)}`,
-				`Model: ${safeTerminalLine(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "Pi default")}`,
-				"The child may spend model tokens and edit the same workspace concurrently.",
-			].join("\n"),
-			{ signal: operationSignal },
-		);
-		if (!this.isCurrent(owner, ownerGeneration)) throw staleError();
-		if (!confirmed) throw abortError("Pi Fleet launch cancelled before creating a split");
+		if (launchSettings.confirmSessionLaunch) {
+			const confirmed = await ctx.ui.confirm(
+				"Create a new Pi session?",
+				[
+					`${selectedTerminalLabel} split: ${direction}`,
+					`Name: ${safeTerminalLine(name)}`,
+					`Cwd: ${safeTerminalLine(cwd)}`,
+					`Model: ${safeTerminalLine(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "Pi default")}`,
+					"The child may spend model tokens and edit the same workspace concurrently.",
+				].join("\n"),
+				{ signal: operationSignal },
+			);
+			if (!this.isCurrent(owner, ownerGeneration)) throw staleError();
+			if (!confirmed) throw abortError("Pi Fleet launch cancelled before creating a split");
+		}
 		const rollbackOwner = {};
 		let claimedMembership: Membership | undefined;
 		let splitCreated = false;
 		let terminalId: string | undefined;
 		let actualTerminalVersion = terminalVersion;
 		let launcher: PiLauncher | undefined;
-		const statusToken = this.beginStatus(ctx, `fleet: launching ${terminalLabel} split`);
+		const statusToken = this.beginStatus(ctx, `fleet: launching ${selectedTerminalLabel} split`);
 		try {
 			const membership = await this.claimSpawnMembership(ctx, operationSignal, rollbackOwner);
 			claimedMembership = membership;
 			const directory = membership.transport.endpointManifest?.directory;
 			if (!directory) throw new Error("Pi Fleet runtime directory is unavailable");
 			const invocation = this.deps.resolveInvocation(["--name", name]);
-			launcher = await this.deps.createLauncher(invocation, directory);
 			const envelope: FleetLaunchEnvelope = {
 				invite: membership.invite,
 				parentSessionId: ctx.sessionManager.getSessionId(),
@@ -525,11 +529,18 @@ export class FleetController {
 						}
 					: {}),
 			};
+			const launchEnvironment = launchEnvelopeEnvironment(envelope);
+			launcher = await this.deps.createLauncher(
+				invocation,
+				directory,
+				terminal === "zellij" ? launchEnvironment : undefined,
+			);
+			if (!this.isCurrent(owner, ownerGeneration)) throw staleError();
 			const split = await terminalAdapter.spawnSplit({
 				direction,
 				cwd,
 				launcherCommand: launcher.command,
-				environment: launchEnvelopeEnvironment(envelope),
+				environment: terminal === "zellij" ? {} : launchEnvironment,
 				signal: operationSignal,
 				isCurrent: () => this.isCurrent(owner, ownerGeneration),
 			});
@@ -570,7 +581,7 @@ export class FleetController {
 				if (!acknowledgement.accepted) {
 					throw createTerminalLaunchError(
 						terminal,
-						`${terminalLabel} created the split, but the child rejected its first task: ${safeTerminalLine(acknowledgement.error ?? "unknown reason")}`,
+						`${selectedTerminalLabel} created the split, but the child rejected its first task: ${safeTerminalLine(acknowledgement.error ?? "unknown reason")}`,
 						true,
 						terminalId,
 					);
@@ -599,7 +610,7 @@ export class FleetController {
 			if (partial && !isTerminalLaunchError(error)) {
 				throw createTerminalLaunchError(
 					terminal,
-					`${terminalLabel} created the split, but the child session did not become ready: ${safeError(error)}`,
+					`${selectedTerminalLabel} created the split, but the child session did not become ready: ${safeError(error)}`,
 					true,
 					terminalId,
 				);
@@ -929,20 +940,6 @@ function recentFleetState(ctx: ExtensionContext): {
 		}
 	}
 	return { messageIds, consumedLaunchIds };
-}
-
-function normalizeOptional(
-	value: string | undefined,
-	label: string,
-	maxBytes: number,
-): string | undefined {
-	if (value === undefined) return undefined;
-	const normalized = value.trim();
-	if (!normalized) return undefined;
-	if (normalized.includes("\0") || Buffer.byteLength(normalized) > maxBytes) {
-		throw new Error(`Pi Fleet ${label} is invalid or too large`);
-	}
-	return normalized;
 }
 
 function combineSignals(...signals: Array<AbortSignal | undefined>): AbortSignal {

--- a/packages/pi-fleet/src/launcher.ts
+++ b/packages/pi-fleet/src/launcher.ts
@@ -12,6 +12,7 @@ export interface PiLauncher {
 export async function createPiLauncher(
 	invocation: PiInvocation,
 	directory: string,
+	embeddedEnvironment?: Readonly<Record<string, string>>,
 ): Promise<PiLauncher> {
 	await assertPrivateDirectory(directory);
 	const launcherPath = join(directory, `launch-${randomBytes(8).toString("hex")}.sh`);
@@ -20,14 +21,26 @@ export async function createPiLauncher(
 	for (const value of command) {
 		if (value.includes("\0")) throw new Error("Pi Fleet launcher argument contains a NUL byte");
 	}
-	const source = `#!/bin/sh\nexec ${command.map(quoteShell).join(" ")}\n`;
+	const environment = validateEmbeddedEnvironment(embeddedEnvironment);
+	const setup = environment.length
+		? [
+				`rm -f ${quoteShell(launcherPath)} || exit 1`,
+				...environment.map(([key, value]) => `export ${key}=${quoteShell(value)}`),
+			]
+		: [];
+	const source = ["#!/bin/sh", ...setup, `exec ${command.map(quoteShell).join(" ")}`, ""].join(
+		"\n",
+	);
 	const handle = await open(launcherPath, "wx", 0o700);
 	try {
 		await handle.writeFile(source, "utf8");
 		await handle.sync();
 		await handle.chmod(0o700);
-	} finally {
 		await handle.close();
+	} catch (error) {
+		await handle.close().catch(() => undefined);
+		await rm(launcherPath, { force: true }).catch(() => undefined);
+		throw error;
 	}
 	let cleaned = false;
 	return {
@@ -40,6 +53,23 @@ export async function createPiLauncher(
 			await rm(launcherPath, { force: true });
 		},
 	};
+}
+
+function validateEmbeddedEnvironment(
+	environment: Readonly<Record<string, string>> | undefined,
+): Array<readonly [string, string]> {
+	const entries = Object.entries(environment ?? {}).sort(([left], [right]) =>
+		left.localeCompare(right),
+	);
+	let bytes = 0;
+	for (const [key, value] of entries) {
+		if (!/^[A-Z][A-Z0-9_]{0,63}$/u.test(key) || value.includes("\0")) {
+			throw new Error("Pi Fleet launch environment is invalid");
+		}
+		bytes += Buffer.byteLength(key) + Buffer.byteLength(value) + 1;
+	}
+	if (bytes > 24 * 1024) throw new Error("Pi Fleet launch environment is too large");
+	return entries;
 }
 
 function quoteShell(value: string): string {

--- a/packages/pi-fleet/src/menu.ts
+++ b/packages/pi-fleet/src/menu.ts
@@ -1,10 +1,16 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { MenuDefinition } from "@narumitw/pi-tui-kit";
 import type { FleetSnapshot, SpawnSessionInput } from "./fleet-controller.js";
+import type { FleetSettingsPatch, FleetSettingsState } from "./settings.js";
+import { type FleetTerminal, terminalLabel } from "./terminal.js";
 import { safeError, safeTerminalLine } from "./text.js";
 
+export interface FleetMenuState extends FleetSnapshot, FleetSettingsState {
+	settingsPath: string;
+}
+
 export interface FleetMenuSource {
-	snapshot(signal?: AbortSignal): Promise<FleetSnapshot>;
+	snapshot(signal?: AbortSignal): Promise<FleetMenuState>;
 	acceptExperimentalWarning(ctx: ExtensionCommandContext, signal?: AbortSignal): Promise<boolean>;
 	spawn(
 		ctx: ExtensionCommandContext,
@@ -18,6 +24,7 @@ export interface FleetMenuSource {
 		options: { targetSessionId: string; text: string; mode: "notify" | "request" },
 		signal?: AbortSignal,
 	): Promise<void>;
+	updateSettings(patch: FleetSettingsPatch, signal?: AbortSignal): Promise<void>;
 	setAcceptsRequests(value: boolean): void;
 	leave(): Promise<void>;
 }
@@ -28,17 +35,26 @@ type Screen =
 	| "sessions"
 	| "invite"
 	| "requestPolicy"
+	| "settings"
+	| "settingsInvalid"
 	| "status"
 	| "help"
 	| "leave";
-type Action = "spawn" | "start" | "join" | "send" | "setPolicy" | "leave";
+type Action =
+	| "spawn"
+	| "start"
+	| "join"
+	| "send"
+	| "setTerminal"
+	| "setConfirmation"
+	| "setPolicy"
+	| "leave";
 
-const TERMINAL_OPTIONS = ["tmux — default", "Ghostty — explicit opt-in"] as const;
 const DIRECTION_OPTIONS = ["Right", "Down", "Left", "Up"] as const;
 
 export function createFleetMenu(source: FleetMenuSource) {
 	const getState = ({ signal }: { signal?: AbortSignal } = {}) => source.snapshot(signal);
-	const menu: MenuDefinition<FleetSnapshot, Screen, Action> = {
+	const menu: MenuDefinition<FleetMenuState, Screen, Action> = {
 		start: "main",
 		screens: {
 			main: ({ state }) => mainScreen(state),
@@ -102,6 +118,38 @@ export function createFleetMenu(source: FleetMenuSource) {
 				viewportSize: 4,
 				hint: "back",
 			}),
+			settings: ({ state }) => ({
+				kind: "settings",
+				title: "Pi Fleet Settings",
+				lines: [`User settings · ${safeTerminalLine(state.settingsPath)}`],
+				items: [
+					{
+						id: "defaultTerminal",
+						label: "Default terminal",
+						description: "Use this backend when a launch does not explicitly choose one.",
+						currentValue: terminalLabel(state.settings.defaultTerminal),
+						values: ["tmux", "Ghostty", "Zellij"],
+						action: "setTerminal",
+					},
+					{
+						id: "confirmSessionLaunch",
+						label: "Confirm new sessions",
+						description: "Ask before a new Pi process may spend tokens or edit the workspace.",
+						currentValue: state.settings.confirmSessionLaunch ? "Ask" : "Skip",
+						values: ["Ask", "Skip"],
+						action: "setConfirmation",
+					},
+				],
+			}),
+			settingsInvalid: ({ state }) => ({
+				kind: "detail",
+				title: "Pi Fleet Settings · Read only",
+				lines: [
+					`Invalid settings file. Fix ${safeTerminalLine(state.settingsPath)} and run /reload. The file will not be overwritten.`,
+					...(state.issue ? [`Issue: ${safeTerminalLine(state.issue.message)}`] : []),
+				],
+				hint: "back",
+			}),
 			status: ({ state }) => ({
 				kind: "detail",
 				title: "Pi Fleet status",
@@ -112,9 +160,16 @@ export function createFleetMenu(source: FleetMenuSource) {
 							`Cwd: ${safeTerminalLine(state.self?.cwd ?? "unknown")}`,
 							`Other live sessions: ${state.peers.length}`,
 							`Incoming requests: ${state.acceptsRequests ? "allowed" : "blocked"}`,
+							`Default terminal: ${terminalLabel(state.settings.defaultTerminal)}`,
+							`Launch confirmation: ${state.settings.confirmSessionLaunch ? "Ask" : "Skip"}`,
 							"Delivery acknowledgement means extension acceptance, not remote task completion.",
 						]
-					: ["State: disconnected", "No socket, group secret, or background discovery is active."],
+					: [
+							"State: disconnected",
+							"No socket, group secret, or background discovery is active.",
+							`Default terminal: ${terminalLabel(state.settings.defaultTerminal)}`,
+							`Launch confirmation: ${state.settings.confirmSessionLaunch ? "Ask" : "Skip"}`,
+						],
 				hint: "back",
 			}),
 			help: () => ({
@@ -123,7 +178,7 @@ export function createFleetMenu(source: FleetMenuSource) {
 				lines: [
 					"Pi Fleet is experimental and connects explicit sessions owned by one OS user.",
 					"New Pi session creates a separate process in a terminal split and preserves the parent.",
-					"tmux 3.2 or newer is the default; Ghostty 1.3 on macOS requires explicit selection.",
+					"tmux remains the built-in default; Settings can select Ghostty 1.3+ on macOS or Zellij 0.44+.",
 					"Notify messages do not start turns, requests require recipient permission, and replies do not auto-trigger another turn.",
 					"Groups, invites, peer state, and message deduplication are ephemeral.",
 				],
@@ -143,16 +198,10 @@ export function createFleetMenu(source: FleetMenuSource) {
 			}),
 		},
 		actions: {
-			spawn: async ({ ctx, signal }) => {
-				const terminalChoice = await ctx.ui.select(
-					"Terminal split backend",
-					[...TERMINAL_OPTIONS],
-					{ signal },
-				);
-				if (!terminalChoice || signal.aborted) return { kind: "stay" };
-				const terminal = terminalChoice === TERMINAL_OPTIONS[0] ? "tmux" : "ghostty";
+			spawn: async ({ ctx, signal, state }) => {
+				const terminal = state.settings.defaultTerminal;
 				const directionChoice = await ctx.ui.select(
-					`${terminal === "tmux" ? "tmux" : "Ghostty"} split direction`,
+					`${terminalLabel(terminal)} split direction`,
 					[...DIRECTION_OPTIONS],
 					{ signal },
 				);
@@ -232,6 +281,22 @@ export function createFleetMenu(source: FleetMenuSource) {
 				);
 				return { kind: "stay" };
 			},
+			setTerminal: ({ ctx, signal, value }) =>
+				saveSettingsPatch(
+					source,
+					ctx,
+					signal,
+					{ defaultTerminal: terminalSettingValue(value) },
+					`Default terminal: ${value}.`,
+				),
+			setConfirmation: ({ ctx, signal, value }) =>
+				saveSettingsPatch(
+					source,
+					ctx,
+					signal,
+					{ confirmSessionLaunch: value !== "Skip" },
+					`Confirm new sessions: ${value}.`,
+				),
 			setPolicy: async ({ ctx, signal, itemId }) => {
 				const allow = itemId === "allow";
 				if (itemId !== "allow" && itemId !== "block") {
@@ -277,12 +342,60 @@ export async function showFleetMenu(
 	});
 }
 
-function mainScreen(state: FleetSnapshot) {
+function terminalSettingValue(value: string | undefined): FleetTerminal {
+	switch (value) {
+		case "tmux":
+			return "tmux";
+		case "Ghostty":
+			return "ghostty";
+		case "Zellij":
+			return "zellij";
+		default:
+			throw new Error("Pi Fleet terminal setting is invalid");
+	}
+}
+
+async function saveSettingsPatch(
+	source: FleetMenuSource,
+	ctx: ExtensionCommandContext,
+	signal: AbortSignal,
+	patch: FleetSettingsPatch,
+	successMessage: string,
+) {
+	if (signal.aborted) return { kind: "rejected" as const };
+	try {
+		await source.updateSettings(patch, signal);
+		if (signal.aborted) return { kind: "rejected" as const };
+		ctx.ui.notify(successMessage, "info");
+		return { kind: "stay" as const };
+	} catch (error) {
+		if (!signal.aborted) {
+			ctx.ui.notify(
+				`Could not save Pi Fleet settings; the previous value remains: ${safeError(error)}`,
+				"error",
+			);
+		}
+		return { kind: "rejected" as const };
+	}
+}
+
+function settingsMenuItem(state: FleetMenuState) {
+	return state.issue
+		? {
+				id: "settings",
+				label: "Settings",
+				description: "Read-only until the invalid settings file is fixed.",
+				to: "settingsInvalid" as const,
+			}
+		: { id: "settings", label: "Settings", to: "settings" as const };
+}
+
+function mainScreen(state: FleetMenuState) {
 	if (!state.connected) {
 		return {
 			kind: "actions" as const,
 			title: "Pi Fleet · disconnected",
-			lines: ["Experimental local Pi sessions with confirmed terminal launch and messaging."],
+			lines: ["Experimental local Pi sessions with configured terminal launches and messaging."],
 			items: [
 				{
 					id: "spawn",
@@ -292,6 +405,7 @@ function mainScreen(state: FleetSnapshot) {
 				},
 				{ id: "join", label: "Join with invite", to: "join" as const },
 				{ id: "start", label: "Start local group", action: "start" as const },
+				settingsMenuItem(state),
 				{ id: "status", label: "Status", to: "status" as const },
 				{ id: "help", label: "Help", to: "help" as const },
 			],
@@ -316,6 +430,7 @@ function mainScreen(state: FleetSnapshot) {
 			{ id: "sessions", label: "Sessions", to: "sessions" as const },
 			{ id: "invite", label: "Invite another session", to: "invite" as const },
 			{ id: "policy", label: "Request policy", to: "requestPolicy" as const },
+			settingsMenuItem(state),
 			{ id: "status", label: "Status", to: "status" as const },
 			{ id: "help", label: "Help", to: "help" as const },
 			{ id: "leave", label: "Leave group…", to: "leave" as const },

--- a/packages/pi-fleet/src/pi-fleet.ts
+++ b/packages/pi-fleet/src/pi-fleet.ts
@@ -3,6 +3,8 @@ import { FleetController, type FleetControllerDependencies } from "./fleet-contr
 import type { FleetMenuSource } from "./menu.js";
 import { parseInvite } from "./protocol.js";
 import { FLEET_MESSAGE_TYPE, renderFleetMessage } from "./renderer.js";
+import { createFleetSettingsRuntime, type FleetSettingsRuntime } from "./settings.js";
+import { terminalLabel } from "./terminal.js";
 import { safeError, safeTerminalLine } from "./text.js";
 import { registerFleetTools } from "./tools.js";
 
@@ -12,6 +14,7 @@ type FleetMenuModule = Pick<typeof import("./menu.js"), "showFleetMenu">;
 
 export interface PiFleetDependencies {
 	controllerDependencies?: FleetControllerDependencies;
+	settingsRuntime?: FleetSettingsRuntime;
 	loadMenu?: () => Promise<FleetMenuModule>;
 }
 
@@ -19,7 +22,8 @@ export function createPiFleetExtension(
 	dependencies: PiFleetDependencies = {},
 ): (pi: ExtensionAPI) => void {
 	return function piFleetExtension(pi: ExtensionAPI): void {
-		const controller = new FleetController(pi, dependencies.controllerDependencies);
+		const settings = dependencies.settingsRuntime ?? createFleetSettingsRuntime();
+		const controller = new FleetController(pi, dependencies.controllerDependencies, settings);
 		const loadMenu = cachedModuleLoader(dependencies.loadMenu ?? (() => import("./menu.js")));
 
 		pi.registerMessageRenderer(FLEET_MESSAGE_TYPE, renderFleetMessage);
@@ -46,7 +50,7 @@ export function createPiFleetExtension(
 				const ownerSignal = controller.sessionSignal;
 				const menuModule = await loadMenu();
 				if (ownerSignal.aborted || !controller.isCurrent(ctx)) return;
-				await menuModule.showFleetMenu(ctx, menuSource(controller, ctx), {
+				await menuModule.showFleetMenu(ctx, menuSource(controller, settings, ctx), {
 					signal: ownerSignal,
 					isCurrent: () => controller.isCurrent(ctx) && !ownerSignal.aborted,
 				});
@@ -79,17 +83,25 @@ async function joinDirectInvite(
 	}
 }
 
-function menuSource(controller: FleetController, ctx: ExtensionCommandContext): FleetMenuSource {
+function menuSource(
+	controller: FleetController,
+	settings: FleetSettingsRuntime,
+	ctx: ExtensionCommandContext,
+): FleetMenuSource {
 	return {
-		snapshot: (signal) => controller.snapshot(signal),
+		snapshot: async (signal) => ({
+			...(await controller.snapshot(signal)),
+			...settings.get(),
+			settingsPath: settings.getPath(),
+		}),
 		acceptExperimentalWarning: (commandContext, signal) =>
 			controller.acceptExperimentalWarning(commandContext, signal),
 		spawn: async (commandContext, input, signal) => {
 			const result = await controller.spawn(commandContext, input, signal);
 			if (controller.isCurrent(commandContext)) {
-				const terminalLabel = result.terminal === "ghostty" ? "Ghostty" : "tmux";
+				const resultTerminalLabel = terminalLabel(result.terminal);
 				commandContext.ui.notify(
-					`Pi session ${safeTerminalLine(result.name ?? result.sessionId)} is ready in ${terminalLabel}.`,
+					`Pi session ${safeTerminalLine(result.name ?? result.sessionId)} is ready in ${resultTerminalLabel}.`,
 					"info",
 				);
 			}
@@ -120,6 +132,9 @@ function menuSource(controller: FleetController, ctx: ExtensionCommandContext): 
 					"info",
 				);
 			}
+		},
+		updateSettings: async (patch) => {
+			await settings.update(patch);
 		},
 		setAcceptsRequests: (value) => controller.setAcceptsRequests(ctx, value),
 		leave: () => controller.leave(ctx),

--- a/packages/pi-fleet/src/runtime-directory.ts
+++ b/packages/pi-fleet/src/runtime-directory.ts
@@ -12,6 +12,7 @@ const SAFE_ENDPOINT_ID = /^[a-f0-9]{24}$/u;
 const SAFE_SOCKET_NAME = /^([a-f0-9]{24})\.sock$/u;
 const SAFE_MANIFEST_NAME = /^([a-f0-9]{24})\.json$/u;
 const SAFE_TEMPORARY_NAME = /^\.([a-f0-9]{24})\.json\.[a-f0-9]{16}\.tmp$/u;
+const SAFE_LAUNCHER_NAME = /^launch-[a-f0-9]{16}\.sh$/u;
 
 export interface RuntimeDirectoryOptions {
 	baseDirectory?: string;
@@ -146,7 +147,7 @@ export async function cleanupStaleRuntimeEntries(
 			}
 			continue;
 		}
-		if (SAFE_TEMPORARY_NAME.test(name)) {
+		if (SAFE_TEMPORARY_NAME.test(name) || SAFE_LAUNCHER_NAME.test(name)) {
 			if (await removeStaleOwnedEntry(directory, name, "file", now)) {
 				removedTemporaryFiles += 1;
 			}

--- a/packages/pi-fleet/src/settings.ts
+++ b/packages/pi-fleet/src/settings.ts
@@ -1,0 +1,362 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { FleetTerminal } from "./terminal.js";
+
+export const FLEET_SETTINGS_FILE = "pi-fleet.json";
+export const MAX_FLEET_SETTINGS_BYTES = 64 * 1024;
+export const DEFAULT_FLEET_SETTINGS: Readonly<FleetSettings> = Object.freeze({
+	defaultTerminal: "tmux",
+	confirmSessionLaunch: true,
+});
+
+export interface FleetSettings {
+	defaultTerminal: FleetTerminal;
+	confirmSessionLaunch: boolean;
+}
+
+export type FleetSettingsField = keyof FleetSettings;
+export type FleetSettingsSource = "built-in" | "user";
+export type FleetSettingsPatch = Partial<FleetSettings>;
+
+export interface NormalizedFleetSettings {
+	settings: FleetSettings;
+	sources: Record<FleetSettingsField, FleetSettingsSource>;
+}
+
+export interface FleetSettingsIssue {
+	kind: "invalid";
+	message: string;
+}
+
+export interface FleetSettingsState extends NormalizedFleetSettings {
+	issue?: FleetSettingsIssue;
+	canSave: boolean;
+}
+
+export type FleetSettingsLoadResult =
+	| (NormalizedFleetSettings & {
+			kind: "missing";
+			path: string;
+			document: Record<string, unknown>;
+	  })
+	| (NormalizedFleetSettings & {
+			kind: "loaded";
+			path: string;
+			document: Record<string, unknown>;
+	  })
+	| (NormalizedFleetSettings & {
+			kind: "invalid";
+			path: string;
+			issue: FleetSettingsIssue;
+	  });
+
+export interface FleetSettingsOperations {
+	writeFile: typeof writeFile;
+	rename: typeof rename;
+}
+
+export interface FleetSettingsRuntime {
+	get(): Readonly<FleetSettingsState>;
+	getPath(): string;
+	reload(signal?: AbortSignal): Promise<Readonly<FleetSettingsState>>;
+	update(patch: FleetSettingsPatch): Promise<Readonly<FleetSettingsState>>;
+	flush(): Promise<void>;
+}
+
+export interface FleetSettingsRuntimeOptions {
+	path?: string | (() => string);
+	operations?: Partial<FleetSettingsOperations>;
+}
+
+const SETTING_FIELDS = [
+	"defaultTerminal",
+	"confirmSessionLaunch",
+] as const satisfies readonly FleetSettingsField[];
+const SETTING_FIELD_SET = new Set<string>(SETTING_FIELDS);
+
+export function fleetSettingsFilePath(): string {
+	return join(getAgentDir(), FLEET_SETTINGS_FILE);
+}
+
+export function normalizeFleetSettingsDocument(
+	value: unknown,
+): NormalizedFleetSettings | undefined {
+	if (!isRecord(value)) return undefined;
+	const settings: FleetSettings = { ...DEFAULT_FLEET_SETTINGS };
+	const sources = builtInSources();
+
+	if (Object.hasOwn(value, "defaultTerminal")) {
+		if (
+			value.defaultTerminal !== "tmux" &&
+			value.defaultTerminal !== "ghostty" &&
+			value.defaultTerminal !== "zellij"
+		) {
+			return undefined;
+		}
+		settings.defaultTerminal = value.defaultTerminal;
+		sources.defaultTerminal = "user";
+	}
+	if (Object.hasOwn(value, "confirmSessionLaunch")) {
+		if (typeof value.confirmSessionLaunch !== "boolean") return undefined;
+		settings.confirmSessionLaunch = value.confirmSessionLaunch;
+		sources.confirmSessionLaunch = "user";
+	}
+	return { settings, sources };
+}
+
+export async function loadFleetSettings(
+	path = fleetSettingsFilePath(),
+	signal?: AbortSignal,
+): Promise<FleetSettingsLoadResult> {
+	let text: string;
+	try {
+		text = await readSettingsDocument(path, signal);
+	} catch (error) {
+		if (signal?.aborted) throw error;
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return {
+				kind: "missing",
+				path,
+				document: {},
+				settings: { ...DEFAULT_FLEET_SETTINGS },
+				sources: builtInSources(),
+			};
+		}
+		return invalidLoad(path, formatError(error));
+	}
+
+	try {
+		const document = JSON.parse(text) as unknown;
+		const normalized = normalizeFleetSettingsDocument(document);
+		if (!normalized || !isRecord(document)) {
+			return invalidLoad(path, "the document is malformed or contains an invalid setting");
+		}
+		return { kind: "loaded", path, document, ...normalized };
+	} catch (error) {
+		return invalidLoad(path, formatError(error));
+	}
+}
+
+export function createInMemoryFleetSettingsRuntime(): FleetSettingsRuntime {
+	let state: FleetSettingsState = {
+		settings: { ...DEFAULT_FLEET_SETTINGS },
+		sources: builtInSources(),
+		canSave: true,
+	};
+	return {
+		get: () => freezeState(state),
+		getPath: () => "",
+		reload: async () => freezeState(state),
+		update: async (patch) => {
+			const canonical = normalizePatch(patch);
+			state = {
+				settings: { ...state.settings, ...canonical },
+				sources: {
+					...state.sources,
+					...(canonical.defaultTerminal ? { defaultTerminal: "user" as const } : {}),
+					...(canonical.confirmSessionLaunch !== undefined
+						? { confirmSessionLaunch: "user" as const }
+						: {}),
+				},
+				canSave: true,
+			};
+			return freezeState(state);
+		},
+		flush: async () => undefined,
+	};
+}
+
+export function createFleetSettingsRuntime(
+	options: FleetSettingsRuntimeOptions = {},
+): FleetSettingsRuntime {
+	let resolvedPath: string | undefined;
+	const getPath = () => {
+		resolvedPath ??=
+			typeof options.path === "function"
+				? options.path()
+				: (options.path ?? fleetSettingsFilePath());
+		return resolvedPath;
+	};
+	const operations: FleetSettingsOperations = {
+		writeFile,
+		rename,
+		...options.operations,
+	};
+	let state: FleetSettingsState = {
+		settings: { ...DEFAULT_FLEET_SETTINGS },
+		sources: builtInSources(),
+		canSave: true,
+	};
+	let queue = Promise.resolve();
+
+	const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+		const result = queue.then(operation, operation);
+		queue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	};
+
+	return {
+		get: () => freezeState(state),
+		getPath,
+		reload(signal) {
+			return enqueue(async () => {
+				const loaded = await loadFleetSettings(getPath(), signal);
+				if (loaded.kind === "invalid") {
+					state = { ...state, issue: loaded.issue, canSave: false };
+					return freezeState(state);
+				}
+				state = { settings: loaded.settings, sources: loaded.sources, canSave: true };
+				return freezeState(state);
+			});
+		},
+		update(patch) {
+			return enqueue(async () => {
+				const canonicalPatch = normalizePatch(patch);
+				const latest = await loadFleetSettings(getPath());
+				if (latest.kind === "invalid") {
+					state = { ...state, issue: latest.issue, canSave: false };
+					throw new Error(`Cannot update malformed or invalid settings: ${latest.issue.message}`);
+				}
+				const document = { ...latest.document, ...canonicalPatch };
+				const normalized = normalizeFleetSettingsDocument(document);
+				if (!normalized) throw new Error("Refusing to publish invalid Pi Fleet settings.");
+				await publishSettingsDocument(document, getPath(), operations);
+				state = { ...normalized, canSave: true };
+				return freezeState(state);
+			});
+		},
+		async flush() {
+			await queue;
+		},
+	};
+}
+
+function normalizePatch(patch: FleetSettingsPatch): FleetSettingsPatch {
+	if (!isRecord(patch) || Object.keys(patch).some((key) => !SETTING_FIELD_SET.has(key))) {
+		throw new Error("Refusing to update unknown Pi Fleet settings.");
+	}
+	const normalized = normalizeFleetSettingsDocument(patch);
+	if (!normalized) throw new Error("Refusing to update invalid Pi Fleet settings.");
+	const canonical: FleetSettingsPatch = {};
+	for (const field of SETTING_FIELDS) {
+		if (Object.hasOwn(patch, field)) assignSetting(canonical, field, normalized.settings[field]);
+	}
+	return canonical;
+}
+
+function assignSetting<K extends FleetSettingsField>(
+	settings: FleetSettingsPatch,
+	field: K,
+	value: FleetSettings[K],
+): void {
+	settings[field] = value;
+}
+
+async function publishSettingsDocument(
+	document: Record<string, unknown>,
+	path: string,
+	operations: FleetSettingsOperations,
+): Promise<void> {
+	const contents = `${JSON.stringify(document, null, "\t")}\n`;
+	if (Buffer.byteLength(contents, "utf8") > MAX_FLEET_SETTINGS_BYTES) {
+		throw new Error(`settings document exceeds ${MAX_FLEET_SETTINGS_BYTES} bytes`);
+	}
+	await mkdir(dirname(path), { recursive: true });
+	const temporaryPath = join(
+		dirname(path),
+		`.${basename(path)}.${process.pid}.${randomUUID()}.tmp`,
+	);
+	try {
+		await operations.writeFile(temporaryPath, contents, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: 0o600,
+		});
+		await operations.rename(temporaryPath, path);
+	} finally {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+	}
+}
+
+async function readSettingsDocument(path: string, signal?: AbortSignal): Promise<string> {
+	throwIfAborted(signal);
+	const flags = constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0);
+	const handle = await open(path, flags);
+	try {
+		throwIfAborted(signal);
+		const [descriptorStats, pathStats] = await Promise.all([handle.stat(), lstat(path)]);
+		throwIfAborted(signal);
+		if (pathStats.isSymbolicLink()) throw new Error("symbolic links are not accepted");
+		if (!descriptorStats.isFile() || !pathStats.isFile()) {
+			throw new Error("settings path is not a regular file");
+		}
+		if (descriptorStats.dev !== pathStats.dev || descriptorStats.ino !== pathStats.ino) {
+			throw new Error("settings path changed while it was being opened");
+		}
+		if (descriptorStats.size > MAX_FLEET_SETTINGS_BYTES) {
+			throw new Error(`settings file exceeds ${MAX_FLEET_SETTINGS_BYTES} bytes`);
+		}
+		const buffer = Buffer.alloc(MAX_FLEET_SETTINGS_BYTES + 1);
+		let offset = 0;
+		while (offset < buffer.length) {
+			const result = await handle.read(buffer, offset, buffer.length - offset, offset);
+			throwIfAborted(signal);
+			if (result.bytesRead === 0) break;
+			offset += result.bytesRead;
+		}
+		if (offset > MAX_FLEET_SETTINGS_BYTES) {
+			throw new Error(`settings file exceeds ${MAX_FLEET_SETTINGS_BYTES} bytes`);
+		}
+		try {
+			return new TextDecoder("utf-8", { fatal: true }).decode(buffer.subarray(0, offset));
+		} catch {
+			throw new Error("settings file is not valid UTF-8");
+		}
+	} finally {
+		await handle.close();
+	}
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+	if (signal?.aborted) throw signal.reason;
+}
+
+function invalidLoad(path: string, reason: string): FleetSettingsLoadResult {
+	return {
+		kind: "invalid",
+		path,
+		settings: { ...DEFAULT_FLEET_SETTINGS },
+		sources: builtInSources(),
+		issue: { kind: "invalid", message: `${FLEET_SETTINGS_FILE} ignored (${path}: ${reason})` },
+	};
+}
+
+function builtInSources(): Record<FleetSettingsField, FleetSettingsSource> {
+	return { defaultTerminal: "built-in", confirmSessionLaunch: "built-in" };
+}
+
+function freezeState(state: FleetSettingsState): Readonly<FleetSettingsState> {
+	return Object.freeze({
+		...state,
+		settings: Object.freeze({ ...state.settings }),
+		sources: Object.freeze({ ...state.sources }),
+	});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-fleet/src/terminal.ts
+++ b/packages/pi-fleet/src/terminal.ts
@@ -1,19 +1,76 @@
-import { GhosttyLaunchError } from "./ghostty.js";
-import { TmuxLaunchError } from "./tmux.js";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { GhosttyAdapter, GhosttyLaunchError } from "./ghostty.js";
+import { TmuxAdapter, TmuxLaunchError } from "./tmux.js";
+import { ZellijAdapter, ZellijLaunchError } from "./zellij.js";
 
-export type FleetTerminal = "tmux" | "ghostty";
+export type FleetTerminal = "tmux" | "ghostty" | "zellij";
 export type TerminalSplitDirection = "right" | "down" | "left" | "up";
+
+export interface FleetTerminalPort {
+	assertAvailable(signal?: AbortSignal): Promise<string>;
+	spawnSplit(options: {
+		direction: TerminalSplitDirection;
+		cwd: string;
+		launcherCommand: string;
+		environment: Readonly<Record<string, string>>;
+		signal?: AbortSignal;
+		isCurrent(): boolean;
+	}): Promise<{ terminalId: string; version: string }>;
+}
 
 export function normalizeTerminal(value: FleetTerminal | undefined): FleetTerminal {
 	if (value === undefined || value === "tmux") return "tmux";
-	if (value === "ghostty") return "ghostty";
-	throw new Error("Pi Fleet terminal must be tmux or ghostty");
+	if (value === "ghostty" || value === "zellij") return value;
+	throw new Error("Pi Fleet terminal must be tmux, ghostty, or zellij");
+}
+
+export function terminalLabel(terminal: FleetTerminal): string {
+	switch (terminal) {
+		case "tmux":
+			return "tmux";
+		case "ghostty":
+			return "Ghostty";
+		case "zellij":
+			return "Zellij";
+	}
+}
+
+export function createDefaultTerminalPort(
+	pi: ExtensionAPI,
+	terminal: FleetTerminal,
+): FleetTerminalPort {
+	const options = {
+		execute: async (
+			command: string,
+			args: string[],
+			execution: {
+				signal?: AbortSignal;
+				timeoutMs: number;
+			},
+		) =>
+			pi.exec(command, args, {
+				...(execution.signal ? { signal: execution.signal } : {}),
+				timeout: execution.timeoutMs,
+			}),
+	};
+	switch (terminal) {
+		case "tmux":
+			return new TmuxAdapter(options);
+		case "ghostty":
+			return new GhosttyAdapter(options);
+		case "zellij":
+			return new ZellijAdapter(options);
+	}
 }
 
 export function isTerminalLaunchError(
 	error: unknown,
-): error is GhosttyLaunchError | TmuxLaunchError {
-	return error instanceof GhosttyLaunchError || error instanceof TmuxLaunchError;
+): error is GhosttyLaunchError | TmuxLaunchError | ZellijLaunchError {
+	return (
+		error instanceof GhosttyLaunchError ||
+		error instanceof TmuxLaunchError ||
+		error instanceof ZellijLaunchError
+	);
 }
 
 export function createTerminalLaunchError(
@@ -21,8 +78,13 @@ export function createTerminalLaunchError(
 	message: string,
 	splitCreated: boolean,
 	terminalId?: string,
-): GhosttyLaunchError | TmuxLaunchError {
-	return terminal === "ghostty"
-		? new GhosttyLaunchError(message, splitCreated, terminalId)
-		: new TmuxLaunchError(message, splitCreated, terminalId);
+): GhosttyLaunchError | TmuxLaunchError | ZellijLaunchError {
+	switch (terminal) {
+		case "tmux":
+			return new TmuxLaunchError(message, splitCreated, terminalId);
+		case "ghostty":
+			return new GhosttyLaunchError(message, splitCreated, terminalId);
+		case "zellij":
+			return new ZellijLaunchError(message, splitCreated, terminalId);
+	}
 }

--- a/packages/pi-fleet/src/text.ts
+++ b/packages/pi-fleet/src/text.ts
@@ -18,6 +18,20 @@ export function safeError(error: unknown): string {
 	return safeTerminalLine(error instanceof Error ? error.message : String(error));
 }
 
+export function normalizeOptionalText(
+	value: string | undefined,
+	label: string,
+	maxBytes: number,
+): string | undefined {
+	if (value === undefined) return undefined;
+	const normalized = value.trim();
+	if (!normalized) return undefined;
+	if (normalized.includes("\0") || Buffer.byteLength(normalized) > maxBytes) {
+		throw new Error(`Pi Fleet ${label} is invalid or too large`);
+	}
+	return normalized;
+}
+
 function isTerminalControl(codePoint: number): boolean {
 	return (
 		(codePoint >= 0x00 && codePoint <= 0x08) ||

--- a/packages/pi-fleet/src/tools.ts
+++ b/packages/pi-fleet/src/tools.ts
@@ -3,10 +3,11 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { Type } from "typebox";
 import type { FleetSnapshot, SpawnSessionInput, SpawnSessionResult } from "./fleet-controller.js";
 import type { FleetMessage } from "./protocol.js";
+import { terminalLabel } from "./terminal.js";
 import { safeTerminalLine } from "./text.js";
 import type { FleetDeliveryAck } from "./transport.js";
 
-const TERMINALS = ["tmux", "ghostty"] as const;
+const TERMINALS = ["tmux", "ghostty", "zellij"] as const;
 const DIRECTIONS = ["right", "down", "left", "up"] as const;
 const BUS_ACTIONS = ["list", "send", "reply"] as const;
 const SEND_MODES = ["notify", "request"] as const;
@@ -36,7 +37,8 @@ const spawnSchema = Type.Object(
 	{
 		terminal: Type.Optional(
 			StringEnum(TERMINALS, {
-				description: "Terminal split backend; defaults to tmux, while ghostty is explicit opt-in",
+				description:
+					"Explicit terminal split backend override; omission uses the configured Pi Fleet default",
 			}),
 		),
 		direction: Type.Optional(StringEnum(DIRECTIONS, { description: "Terminal split direction" })),
@@ -83,33 +85,35 @@ export function registerFleetTools(pi: ExtensionAPI, controller: FleetToolContro
 		name: "session_spawn",
 		label: "Spawn Pi Session",
 		description:
-			"Create a separate Pi process in a terminal split, wait for authenticated readiness, and optionally send its first task. tmux is the default backend; Ghostty is used only when terminal is explicitly ghostty. This preserves the current session and requires user confirmation.",
-		promptSnippet: "Start a collaborating Pi session in a confirmed terminal split",
+			"Create a separate Pi process in a terminal split, wait for authenticated readiness, and optionally send its first task. An omitted terminal uses the configured Pi Fleet default, while an explicit terminal overrides it. This preserves the current session and follows the configured launch-confirmation policy.",
+		promptSnippet: "Start a collaborating Pi session in a configured terminal split",
 		promptGuidelines: [
 			"Use session_spawn only when the user explicitly asks to open or start another Pi session.",
-			"Use session_spawn with terminal ghostty only when the user explicitly requests Ghostty; otherwise omit terminal to use tmux.",
+			"Omit session_spawn terminal to use the user's configured Pi Fleet default; pass terminal only when the user explicitly requests a backend override.",
 			"Do not claim the child is ready until session_spawn returns authenticated readiness metadata.",
 		],
 		parameters: spawnSchema,
 		executionMode: "sequential",
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
-			const requestedTerminal = params.terminal === "ghostty" ? "Ghostty" : "tmux";
+			const requestedTerminal = params.terminal
+				? terminalLabel(params.terminal)
+				: "the configured terminal";
 			onUpdate?.({
 				content: [
 					{
 						type: "text",
-						text: `Preparing a confirmed ${requestedTerminal} Pi session launch…`,
+						text: `Preparing a Pi session launch using ${requestedTerminal}…`,
 					},
 				],
-				details: { phase: "preparing", terminal: params.terminal ?? "tmux" },
+				details: { phase: "preparing", terminal: params.terminal ?? "configured" },
 			});
 			const result = await controller.spawn(ctx, params, signal);
-			const terminalLabel = result.terminal === "ghostty" ? "Ghostty" : "tmux";
+			const resultTerminalLabel = terminalLabel(result.terminal);
 			return {
 				content: [
 					{
 						type: "text",
-						text: `Pi session ${safeTerminalLine(result.name ?? result.sessionId)} is ready in ${terminalLabel} (${safeTerminalLine(result.cwd)}).${result.kickoffAccepted ? " Its first task was accepted." : " No first task was sent."}`,
+						text: `Pi session ${safeTerminalLine(result.name ?? result.sessionId)} is ready in ${resultTerminalLabel} (${safeTerminalLine(result.cwd)}).${result.kickoffAccepted ? " Its first task was accepted." : " No first task was sent."}`,
 					},
 				],
 				details: result,

--- a/packages/pi-fleet/src/zellij.ts
+++ b/packages/pi-fleet/src/zellij.ts
@@ -109,7 +109,6 @@ export class ZellijAdapter {
 					nativeDirection,
 					"--cwd",
 					options.cwd,
-					"--near-current-pane",
 					"--",
 					options.launcherCommand,
 				],

--- a/packages/pi-fleet/src/zellij.ts
+++ b/packages/pi-fleet/src/zellij.ts
@@ -1,0 +1,266 @@
+import type { TerminalSplitDirection } from "./terminal.js";
+
+export interface ZellijCommandResult {
+	stdout: string;
+	stderr: string;
+	code: number;
+	killed: boolean;
+}
+
+export type ZellijCommandExecutor = (
+	command: string,
+	args: string[],
+	options: { signal?: AbortSignal; timeoutMs: number },
+) => Promise<ZellijCommandResult>;
+
+export interface ZellijAdapterOptions {
+	execute: ZellijCommandExecutor;
+	zellijEnvironment?: string;
+	zellijPaneId?: string;
+	timeoutMs?: number;
+}
+
+export interface SpawnZellijSplitOptions {
+	direction: TerminalSplitDirection;
+	cwd: string;
+	launcherCommand: string;
+	environment: Readonly<Record<string, string>>;
+	signal?: AbortSignal;
+	isCurrent(): boolean;
+}
+
+export class ZellijLaunchError extends Error {
+	constructor(
+		message: string,
+		readonly splitCreated = false,
+		readonly terminalId?: string,
+	) {
+		super(message);
+		this.name = "ZellijLaunchError";
+	}
+}
+
+const MINIMUM_ZELLIJ_VERSION = { major: 0, minor: 44, patch: 0 } as const;
+
+export class ZellijAdapter {
+	private readonly zellijEnvironment: string | undefined;
+	private readonly zellijPaneId: string | undefined;
+	private readonly timeoutMs: number;
+
+	constructor(private readonly options: ZellijAdapterOptions) {
+		this.zellijEnvironment = options.zellijEnvironment ?? process.env.ZELLIJ;
+		this.zellijPaneId = options.zellijPaneId ?? process.env.ZELLIJ_PANE_ID;
+		this.timeoutMs = options.timeoutMs ?? 5_000;
+	}
+
+	async assertAvailable(signal?: AbortSignal): Promise<string> {
+		throwIfAborted(signal, "Zellij availability check aborted");
+		if (!this.zellijEnvironment) {
+			throw new ZellijLaunchError("Pi Fleet must be running inside Zellij to create a split");
+		}
+		if (!this.zellijPaneId || !/^\d{1,20}$/u.test(this.zellijPaneId)) {
+			throw new ZellijLaunchError("Pi Fleet could not identify the current Zellij pane");
+		}
+		let result: ZellijCommandResult;
+		try {
+			result = await this.options.execute("zellij", ["--version"], {
+				...(signal ? { signal } : {}),
+				timeoutMs: this.timeoutMs,
+			});
+		} catch {
+			if (signal?.aborted) throwIfAborted(signal, "Zellij availability check aborted");
+			throw new ZellijLaunchError("Pi Fleet could not run Zellij to check its version");
+		}
+		throwIfAborted(signal, "Zellij availability check aborted");
+		if (result.code !== 0 || result.killed) {
+			throw new ZellijLaunchError("Pi Fleet could not query the Zellij version");
+		}
+		const version = result.stdout.trim().replace(/^zellij\s+/u, "");
+		const parsed = parseVersion(version);
+		if (!parsed) throw new ZellijLaunchError("Zellij returned an invalid version");
+		if (compareVersion(parsed, MINIMUM_ZELLIJ_VERSION) < 0) {
+			throw new ZellijLaunchError(
+				"Pi Fleet requires Zellij 0.44 or newer for pane identity and placement",
+			);
+		}
+		return version;
+	}
+
+	async spawnSplit(
+		options: SpawnZellijSplitOptions,
+	): Promise<{ terminalId: string; version: string }> {
+		throwIfAborted(options.signal, "Zellij split creation aborted");
+		validateSpawnOptions(options);
+		const version = await this.assertAvailable(options.signal);
+		if (!options.isCurrent()) {
+			throw new ZellijLaunchError("Pi Fleet session became stale before Zellij pane creation");
+		}
+		throwIfAborted(options.signal, "Zellij split creation aborted");
+		const nativeDirection =
+			options.direction === "down" || options.direction === "up" ? "down" : "right";
+		let result: ZellijCommandResult;
+		try {
+			result = await this.options.execute(
+				"zellij",
+				[
+					"action",
+					"new-pane",
+					"--direction",
+					nativeDirection,
+					"--cwd",
+					options.cwd,
+					"--near-current-pane",
+					"--",
+					options.launcherCommand,
+				],
+				{
+					...(options.signal ? { signal: options.signal } : {}),
+					timeoutMs: this.timeoutMs,
+				},
+			);
+		} catch {
+			if (options.signal?.aborted) {
+				throw new ZellijLaunchError(
+					"Zellij pane creation was cancelled after launch began; a partial pane may remain open",
+					true,
+				);
+			}
+			throw new ZellijLaunchError("Zellij could not create the Pi Fleet pane");
+		}
+		const terminalId = /^terminal_\d{1,20}$/u.test(result.stdout.trim())
+			? result.stdout.trim()
+			: undefined;
+		if (options.signal?.aborted) {
+			throw new ZellijLaunchError(
+				"Zellij created the pane after Pi Fleet launch was cancelled",
+				true,
+				terminalId,
+			);
+		}
+		if (result.killed) {
+			throw new ZellijLaunchError(
+				"Zellij pane creation timed out; a partial pane may remain open",
+				true,
+				terminalId,
+			);
+		}
+		if (result.code !== 0) {
+			throw new ZellijLaunchError(
+				"Zellij could not create the Pi Fleet pane",
+				terminalId !== undefined,
+				terminalId,
+			);
+		}
+		if (!terminalId) {
+			throw new ZellijLaunchError("Zellij created a pane but returned no terminal identity", true);
+		}
+		if (!options.isCurrent()) {
+			throw new ZellijLaunchError(
+				"Pi Fleet session became stale after Zellij created the pane",
+				true,
+				terminalId,
+			);
+		}
+		if (options.direction === "left" || options.direction === "up") {
+			await this.placePane(options.direction, terminalId, options.signal);
+		}
+		if (options.signal?.aborted) {
+			throw new ZellijLaunchError(
+				"Zellij created the pane after Pi Fleet launch was cancelled",
+				true,
+				terminalId,
+			);
+		}
+		if (!options.isCurrent()) {
+			throw new ZellijLaunchError(
+				"Pi Fleet session became stale after Zellij created the pane",
+				true,
+				terminalId,
+			);
+		}
+		return { terminalId, version };
+	}
+
+	private async placePane(
+		direction: "left" | "up",
+		terminalId: string,
+		signal?: AbortSignal,
+	): Promise<void> {
+		let result: ZellijCommandResult;
+		try {
+			result = await this.options.execute(
+				"zellij",
+				["action", "move-pane", "--pane-id", terminalId, direction],
+				{
+					...(signal ? { signal } : {}),
+					timeoutMs: this.timeoutMs,
+				},
+			);
+		} catch {
+			if (signal?.aborted) throw placementCancellationError(terminalId);
+			throw new ZellijLaunchError(
+				`Zellij created the Pi Fleet pane, but ${direction} placement failed`,
+				true,
+				terminalId,
+			);
+		}
+		if (signal?.aborted) throw placementCancellationError(terminalId);
+		if (result.killed || result.code !== 0) {
+			throw new ZellijLaunchError(
+				`Zellij created the Pi Fleet pane, but ${direction} placement failed`,
+				true,
+				terminalId,
+			);
+		}
+	}
+}
+
+function placementCancellationError(terminalId: string): ZellijLaunchError {
+	return new ZellijLaunchError(
+		"Zellij pane placement was cancelled after creation; the partial pane remains open",
+		true,
+		terminalId,
+	);
+}
+
+function validateSpawnOptions(options: SpawnZellijSplitOptions): void {
+	if (
+		options.direction !== "right" &&
+		options.direction !== "down" &&
+		options.direction !== "left" &&
+		options.direction !== "up"
+	) {
+		throw new ZellijLaunchError("Pi Fleet split direction is invalid");
+	}
+	for (const [label, value, maxBytes] of [
+		["working directory", options.cwd, 4_096],
+		["launcher command", options.launcherCommand, 4_096],
+	] as const) {
+		if (!value || value.includes("\0") || Buffer.byteLength(value) > maxBytes) {
+			throw new ZellijLaunchError(`Pi Fleet ${label} is invalid`);
+		}
+	}
+	if (Object.keys(options.environment).length > 0) {
+		throw new ZellijLaunchError("Pi Fleet Zellij launch environment must use the private launcher");
+	}
+}
+
+function parseVersion(value: string): { major: number; minor: number; patch: number } | undefined {
+	const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/u.exec(value);
+	if (!match) return undefined;
+	return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+function compareVersion(
+	left: { major: number; minor: number; patch: number },
+	right: { major: number; minor: number; patch: number },
+): number {
+	return left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined, message: string): void {
+	if (!signal?.aborted) return;
+	const error = new Error(message);
+	error.name = "AbortError";
+	throw error;
+}

--- a/packages/pi-fleet/test/fleet-controller.test.ts
+++ b/packages/pi-fleet/test/fleet-controller.test.ts
@@ -69,6 +69,10 @@ function dependencies(
 			assertAvailable: async () => "1.3.1",
 			spawnSplit: async () => ({ terminalId: "terminal-child", version: "1.3.1" }),
 		}),
+		createZellij: () => ({
+			assertAvailable: async () => "0.44.3",
+			spawnSplit: async () => ({ terminalId: "terminal_42", version: "0.44.3" }),
+		}),
 		resolveInvocation: () => ({ command: "/bin/pi", args: [] }),
 		createLauncher: async () => ({
 			path: "/tmp/pi-fleet-test/launch.sh",

--- a/packages/pi-fleet/test/launch-integration.test.ts
+++ b/packages/pi-fleet/test/launch-integration.test.ts
@@ -54,6 +54,10 @@ posixTest(
 				assertAvailable: async () => "1.3.1",
 				spawnSplit: async (options) => ({ ...(await spawnChild(options)), version: "1.3.1" }),
 			}),
+			createZellij: () => ({
+				assertAvailable: async () => "0.44.3",
+				spawnSplit: async (options) => ({ ...(await spawnChild(options)), version: "0.44.3" }),
+			}),
 			resolveInvocation: () => ({ command: "/bin/pi", args: [] }),
 			createLauncher: async () => ({
 				path: join(runtimeBase, "launcher.sh"),

--- a/packages/pi-fleet/test/launcher.test.ts
+++ b/packages/pi-fleet/test/launcher.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { access, mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { test } from "vitest";
 import { createPiLauncher } from "../src/launcher.js";
+
+const execFileAsync = promisify(execFile);
 
 test("launcher quotes paths and arguments, stays private, excludes secrets, and cleans once", async () => {
 	const directory = await mkdtemp("/tmp/pi-fleet-launcher-test-");
@@ -25,6 +29,42 @@ test("launcher quotes paths and arguments, stays private, excludes secrets, and 
 		await launcher.cleanup();
 		await assert.rejects(access(launcher.path));
 		assert.equal(join(directory, "."), directory);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("embedded launch environments stay in a private self-deleting launcher", async () => {
+	const directory = await mkdtemp("/tmp/pi-fleet-launcher-environment-test-");
+	try {
+		const output = join(directory, "child-environment.txt");
+		const invite = "pifleet:v1:secret-placeholder";
+		const launcher = await createPiLauncher(
+			{
+				command: process.execPath,
+				args: [
+					"-e",
+					'require("node:fs").writeFileSync(process.argv[1], process.env.PI_FLEET_INVITE ?? "")',
+					output,
+				],
+			},
+			directory,
+			{ PI_FLEET_INVITE: invite },
+		);
+		const source = await readFile(launcher.path, "utf8");
+		assert.match(source, /rm -f/u);
+		assert.match(source, /export PI_FLEET_INVITE=/u);
+		assert.equal(source.indexOf("rm -f") < source.indexOf("export PI_FLEET_INVITE="), true);
+		assert.equal((await stat(launcher.path)).mode & 0o777, 0o700);
+		await execFileAsync(launcher.command);
+		await assert.rejects(access(launcher.path));
+		assert.equal(await readFile(output, "utf8"), invite);
+		await launcher.cleanup();
+
+		await assert.rejects(
+			createPiLauncher({ command: "/bin/true", args: [] }, directory, { "bad-key": "value" }),
+			/launch environment is invalid/u,
+		);
 	} finally {
 		await rm(directory, { recursive: true, force: true });
 	}

--- a/packages/pi-fleet/test/menu.test.ts
+++ b/packages/pi-fleet/test/menu.test.ts
@@ -1,15 +1,33 @@
 import assert from "node:assert/strict";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext } from "../../../test/support.js";
-import type { FleetSnapshot, SpawnSessionInput } from "../src/fleet-controller.js";
-import { createFleetMenu, type FleetMenuSource } from "../src/menu.js";
+import type { SpawnSessionInput } from "../src/fleet-controller.js";
+import {
+	createFleetMenu,
+	type FleetMenuSource,
+	type FleetMenuState,
+	showFleetMenu,
+} from "../src/menu.js";
+import {
+	DEFAULT_FLEET_SETTINGS,
+	type FleetSettingsPatch,
+	type FleetSettingsState,
+} from "../src/settings.js";
 
-const disconnected: FleetSnapshot = {
+const defaultSettings: FleetSettingsState = {
+	settings: { ...DEFAULT_FLEET_SETTINGS },
+	sources: { defaultTerminal: "built-in", confirmSessionLaunch: "built-in" },
+	canSave: true,
+};
+const disconnected: FleetMenuState = {
 	connected: false,
 	acceptsRequests: false,
 	peers: [],
+	...defaultSettings,
+	settingsPath: "/tmp/pi-fleet.json",
 };
-const connected: FleetSnapshot = {
+const connected: FleetMenuState = {
 	connected: true,
 	groupId: "a".repeat(32),
 	invite: `pifleet:v1:${"A".repeat(43)}`,
@@ -34,6 +52,8 @@ const connected: FleetSnapshot = {
 			acceptsRequests: true,
 		},
 	],
+	...defaultSettings,
+	settingsPath: "/tmp/pi-fleet.json",
 };
 
 function source(overrides: Partial<FleetMenuSource> = {}) {
@@ -53,6 +73,9 @@ function source(overrides: Partial<FleetMenuSource> = {}) {
 		send: async (_ctx, options) => {
 			calls.push({ kind: "send", options });
 		},
+		updateSettings: async (patch) => {
+			calls.push({ kind: "settings", patch });
+		},
 		setAcceptsRequests: (value) => {
 			calls.push({ kind: "policy", value });
 		},
@@ -64,7 +87,7 @@ function source(overrides: Partial<FleetMenuSource> = {}) {
 	return { source: value, calls };
 }
 
-test("main menu keeps the terminal-neutral New Pi session action first", () => {
+test("main menu exposes New Pi session first plus Settings, Status, and Help", () => {
 	const first = source({ snapshot: async () => disconnected });
 	const firstMenu = createFleetMenu(first.source);
 	assert.deepEqual(
@@ -73,7 +96,7 @@ test("main menu keeps the terminal-neutral New Pi session action first", () => {
 				items: ReadonlyArray<{ label: string }>;
 			}
 		).items.map(({ label }) => label),
-		["New Pi session…", "Join with invite", "Start local group", "Status", "Help"],
+		["New Pi session…", "Join with invite", "Start local group", "Settings", "Status", "Help"],
 	);
 	const second = source({ snapshot: async () => connected });
 	const secondMenu = createFleetMenu(second.source);
@@ -89,24 +112,107 @@ test("main menu keeps the terminal-neutral New Pi session action first", () => {
 			"Sessions",
 			"Invite another session",
 			"Request policy",
+			"Settings",
 			"Status",
 			"Help",
 			"Leave group…",
 		],
 	);
+
+	const settings = firstMenu.menu.screens.settings({ state: disconnected });
+	assert.equal(settings.kind, "settings");
+	if (settings.kind !== "settings") assert.fail("Expected settings screen");
+	assert.deepEqual(
+		settings.items.map((item) => [item.id, item.currentValue]),
+		[
+			["defaultTerminal", "tmux"],
+			["confirmSessionLaunch", "Ask"],
+		],
+	);
+	assert.deepEqual(settings.items[0]?.values, ["tmux", "Ghostty", "Zellij"]);
+	assert.match((settings.lines ?? []).join("\n"), /\/tmp\/pi-fleet\.json/u);
+
+	const invalidState: FleetMenuState = {
+		...disconnected,
+		issue: { kind: "invalid", message: "invalid file" },
+		canSave: false,
+	};
+	const invalidMain = firstMenu.menu.screens.main({ state: invalidState });
+	assert.equal(invalidMain.kind, "actions");
+	if (invalidMain.kind !== "actions") assert.fail("Expected actions screen");
+	const invalidSettings = invalidMain.items.find((item) => item.id === "settings");
+	assert.equal(
+		invalidSettings && "to" in invalidSettings ? invalidSettings.to : undefined,
+		"settingsInvalid",
+	);
 });
 
-test("spawn defaults the backend choice to tmux and preserves direction and first task", async () => {
+test("setting actions persist exact patches and reject failed saves", async () => {
+	const first = source();
+	const firstMenu = createFleetMenu(first.source).menu;
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	assert.deepEqual(
+		await firstMenu.actions.setTerminal({
+			ctx: context.ctx,
+			state: disconnected,
+			signal: new AbortController().signal,
+			itemId: "defaultTerminal",
+			value: "Ghostty",
+		}),
+		{ kind: "stay" },
+	);
+	assert.deepEqual(
+		await firstMenu.actions.setTerminal({
+			ctx: context.ctx,
+			state: disconnected,
+			signal: new AbortController().signal,
+			itemId: "defaultTerminal",
+			value: "Zellij",
+		}),
+		{ kind: "stay" },
+	);
+	assert.deepEqual(
+		await firstMenu.actions.setConfirmation({
+			ctx: context.ctx,
+			state: disconnected,
+			signal: new AbortController().signal,
+			itemId: "confirmSessionLaunch",
+			value: "Skip",
+		}),
+		{ kind: "stay" },
+	);
+	assert.deepEqual(first.calls, [
+		{ kind: "settings", patch: { defaultTerminal: "ghostty" } },
+		{ kind: "settings", patch: { defaultTerminal: "zellij" } },
+		{ kind: "settings", patch: { confirmSessionLaunch: false } },
+	]);
+	assert.equal(context.notifications.at(-1)?.level, "info");
+
+	const second = source({ updateSettings: async () => Promise.reject(new Error("save rejected")) });
+	const failedContext = createMockContext({ mode: "tui", hasUI: true });
+	assert.deepEqual(
+		await createFleetMenu(second.source).menu.actions.setTerminal({
+			ctx: failedContext.ctx,
+			state: disconnected,
+			signal: new AbortController().signal,
+			itemId: "defaultTerminal",
+			value: "Ghostty",
+		}),
+		{ kind: "rejected" },
+	);
+	assert.match(failedContext.notifications.at(-1)?.message ?? "", /previous value remains/u);
+});
+
+test("spawn uses the configured backend without prompting for a backend", async () => {
 	const { source: menuSource, calls } = source({ snapshot: async () => disconnected });
 	const { menu } = createFleetMenu(menuSource);
-	const selections = ["tmux — default", "Down"];
 	const selectionOptions: string[][] = [];
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
 		select: async (_title: string, options: string[]) => {
 			selectionOptions.push(options);
-			return selections.shift();
+			return "Down";
 		},
 		input: async () => "Investigate tests",
 	});
@@ -117,7 +223,7 @@ test("spawn defaults the backend choice to tmux and preserves direction and firs
 		itemId: "spawn",
 	});
 	assert.deepEqual(result, { kind: "close" });
-	assert.deepEqual(selectionOptions[0], ["tmux — default", "Ghostty — explicit opt-in"]);
+	assert.deepEqual(selectionOptions, [["Right", "Down", "Left", "Up"]]);
 	assert.deepEqual(calls, [
 		{
 			kind: "spawn",
@@ -130,19 +236,22 @@ test("spawn defaults the backend choice to tmux and preserves direction and firs
 	]);
 });
 
-test("spawn uses Ghostty only after its explicit backend choice", async () => {
-	const { source: menuSource, calls } = source({ snapshot: async () => disconnected });
+test("spawn uses Ghostty after it is selected in Settings", async () => {
+	const ghosttyState: FleetMenuState = {
+		...disconnected,
+		settings: { ...disconnected.settings, defaultTerminal: "ghostty" },
+	};
+	const { source: menuSource, calls } = source({ snapshot: async () => ghosttyState });
 	const { menu } = createFleetMenu(menuSource);
-	const selections = ["Ghostty — explicit opt-in", "Left"];
 	const context = createMockContext({
 		mode: "rpc",
 		hasUI: true,
-		select: async () => selections.shift(),
+		select: async () => "Left",
 		input: async () => "",
 	});
 	const result = await menu.actions.spawn({
 		ctx: context.ctx,
-		state: disconnected,
+		state: ghosttyState,
 		signal: new AbortController().signal,
 		itemId: "spawn",
 	});
@@ -155,27 +264,59 @@ test("spawn uses Ghostty only after its explicit backend choice", async () => {
 	]);
 });
 
-test("cancelled terminal or direction choices create no spawn side effects", async () => {
-	for (const selections of [[undefined], ["tmux — default", undefined]]) {
-		const { source: menuSource, calls } = source({ snapshot: async () => disconnected });
-		const { menu } = createFleetMenu(menuSource);
-		const pending = [...selections];
-		const context = createMockContext({
-			mode: "tui",
-			hasUI: true,
-			select: async () => pending.shift(),
-		});
-		assert.deepEqual(
-			await menu.actions.spawn({
-				ctx: context.ctx,
-				state: disconnected,
-				signal: new AbortController().signal,
-				itemId: "spawn",
-			}),
-			{ kind: "stay" },
-		);
-		assert.deepEqual(calls, []);
-	}
+test("spawn uses Zellij after it is selected in Settings", async () => {
+	const zellijState: FleetMenuState = {
+		...disconnected,
+		settings: { ...disconnected.settings, defaultTerminal: "zellij" },
+	};
+	const { source: menuSource, calls } = source({ snapshot: async () => zellijState });
+	const { menu } = createFleetMenu(menuSource);
+	const titles: string[] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async (title: string) => {
+			titles.push(title);
+			return "Up";
+		},
+		input: async () => "",
+	});
+	assert.deepEqual(
+		await menu.actions.spawn({
+			ctx: context.ctx,
+			state: zellijState,
+			signal: new AbortController().signal,
+			itemId: "spawn",
+		}),
+		{ kind: "close" },
+	);
+	assert.deepEqual(titles, ["Zellij split direction"]);
+	assert.deepEqual(calls, [
+		{
+			kind: "spawn",
+			input: { terminal: "zellij", direction: "up" } satisfies SpawnSessionInput,
+		},
+	]);
+});
+
+test("cancelled direction choice creates no spawn side effects", async () => {
+	const { source: menuSource, calls } = source({ snapshot: async () => disconnected });
+	const { menu } = createFleetMenu(menuSource);
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		select: async () => undefined,
+	});
+	assert.deepEqual(
+		await menu.actions.spawn({
+			ctx: context.ctx,
+			state: disconnected,
+			signal: new AbortController().signal,
+			itemId: "spawn",
+		}),
+		{ kind: "stay" },
+	);
+	assert.deepEqual(calls, []);
 });
 
 test("cancelled warning and dialogs create no group, join, or spawn side effects", async () => {
@@ -230,3 +371,129 @@ test("request policy warns before enabling and leave requires its review action"
 	);
 	assert.deepEqual(calls, [{ kind: "policy", value: true }, { kind: "leave" }]);
 });
+
+test("TUI Settings changes apply immediately and failed saves restore the previous value", async () => {
+	let state = disconnected;
+	const patches: FleetSettingsPatch[] = [];
+	const tui = createTuiHarness({ width: 70, rows: 24 });
+	const successfulSource = source({
+		snapshot: async () => state,
+		updateSettings: async (patch) => {
+			patches.push(patch);
+			state = { ...state, settings: { ...state.settings, ...patch } };
+		},
+	}).source;
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = showFleetMenu(context.ctx, successfulSource, {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+	});
+	await tui.waitForOpen();
+	for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await waitForOpenCount(tui, 2);
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await waitForOpenCount(tui, 3);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await waitForOpenCount(tui, 4);
+	tui.press("tui.select.cancel");
+	await waitForOpenCount(tui, 5);
+	tui.press("ctrl+c");
+	await running;
+	assert.deepEqual(patches, [{ defaultTerminal: "ghostty" }, { confirmSessionLaunch: false }]);
+
+	const failingTui = createTuiHarness({ width: 70, rows: 24 });
+	const failedContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: failingTui.custom,
+	});
+	const failing = showFleetMenu(
+		failedContext.ctx,
+		source({ updateSettings: async () => Promise.reject(new Error("save rejected")) }).source,
+		{ signal: new AbortController().signal, isCurrent: () => true },
+	);
+	await failingTui.waitForOpen();
+	for (let index = 0; index < 3; index += 1) failingTui.press("tui.select.down");
+	failingTui.press("tui.select.confirm");
+	await waitForOpenCount(failingTui, 2);
+	failingTui.press("tui.select.confirm");
+	await failingTui.waitForPending();
+	assert.match(failingTui.render().join("\n"), /Default terminal\s+tmux/u);
+	failingTui.press("ctrl+c");
+	await failing;
+	assert.match(failedContext.notifications.at(-1)?.message ?? "", /previous value remains/u);
+});
+
+test("RPC Settings changes apply immediately through the shared menu", async () => {
+	let state = disconnected;
+	const patches: FleetSettingsPatch[] = [];
+	const menuSource = source({
+		snapshot: async () => state,
+		updateSettings: async (patch) => {
+			patches.push(patch);
+			state = { ...state, settings: { ...state.settings, ...patch } };
+		},
+	}).source;
+	const rpc = createRpcHarness([
+		{
+			kind: "select",
+			options: [
+				"New Pi session…",
+				"Join with invite",
+				"Start local group",
+				"Settings",
+				"Status",
+				"Help",
+			],
+			response: "Settings",
+		},
+		{
+			kind: "select",
+			options: ["Default terminal (tmux)", "Confirm new sessions (Ask)", "Back"],
+			response: "Default terminal (tmux)",
+		},
+		{
+			kind: "select",
+			options: ["Default terminal (Ghostty)", "Confirm new sessions (Ask)", "Back"],
+			response: "Confirm new sessions (Ask)",
+		},
+		{
+			kind: "select",
+			options: ["Default terminal (Ghostty)", "Confirm new sessions (Skip)", "Back"],
+			response: undefined,
+		},
+		{
+			kind: "select",
+			options: [
+				"New Pi session…",
+				"Join with invite",
+				"Start local group",
+				"Settings",
+				"Status",
+				"Help",
+			],
+			response: undefined,
+		},
+	]);
+	const context = createMockContext({ mode: "rpc", hasUI: true, ...rpc.ui });
+	await showFleetMenu(context.ctx, menuSource, {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+	});
+	assert.deepEqual(patches, [{ defaultTerminal: "ghostty" }, { confirmSessionLaunch: false }]);
+	rpc.assertConsumed();
+});
+
+async function waitForOpenCount(
+	tui: ReturnType<typeof createTuiHarness>,
+	expected: number,
+): Promise<void> {
+	while (tui.openCount < expected) {
+		if (tui.isOpen) await Promise.resolve();
+		else await tui.waitForOpen();
+	}
+}

--- a/packages/pi-fleet/test/pi-fleet.test.ts
+++ b/packages/pi-fleet/test/pi-fleet.test.ts
@@ -4,6 +4,11 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import type { FleetControllerDependencies } from "../src/fleet-controller.js";
 import { createPiFleetExtension } from "../src/pi-fleet.js";
 import { createGroup, formatInvite } from "../src/protocol.js";
+import {
+	DEFAULT_FLEET_SETTINGS,
+	type FleetSettingsRuntime,
+	type FleetSettingsState,
+} from "../src/settings.js";
 
 function dependencies(): FleetControllerDependencies {
 	return {
@@ -32,6 +37,10 @@ function dependencies(): FleetControllerDependencies {
 			assertAvailable: async () => "1.3.1",
 			spawnSplit: async () => ({ terminalId: "child", version: "1.3.1" }),
 		}),
+		createZellij: () => ({
+			assertAvailable: async () => "0.44.3",
+			spawnSplit: async () => ({ terminalId: "terminal_42", version: "0.44.3" }),
+		}),
 		resolveInvocation: () => ({ command: "/bin/pi", args: [] }),
 		createLauncher: async () => ({
 			path: "/tmp/launch.sh",
@@ -59,9 +68,11 @@ async function emit(
 
 test("extension registers its command, tools, renderer, and lifecycle without factory resources", async () => {
 	const mock = createMockPi();
+	const settings = memorySettingsRuntime();
 	let menuLoads = 0;
 	createPiFleetExtension({
 		controllerDependencies: dependencies(),
+		settingsRuntime: settings,
 		loadMenu: async () => {
 			menuLoads += 1;
 			return { showFleetMenu: async () => undefined };
@@ -77,7 +88,9 @@ test("extension registers its command, tools, renderer, and lifecycle without fa
 	const context = createMockContext({ mode: "tui", hasUI: true });
 	await emit(mock, "session_start", { reason: "startup" }, context.ctx);
 	assert.equal(menuLoads, 0);
+	assert.equal(settings.calls.reload, 1);
 	await emit(mock, "session_shutdown", { reason: "quit" }, context.ctx);
+	assert.equal(settings.calls.flush, 1);
 });
 
 test("fleet menu loads on demand, caches success, retries failure, and suppresses stale loads", async () => {
@@ -87,6 +100,7 @@ test("fleet menu loads on demand, caches success, retries failure, and suppresse
 	let release: (() => void) | undefined;
 	createPiFleetExtension({
 		controllerDependencies: dependencies(),
+		settingsRuntime: memorySettingsRuntime(),
 		loadMenu: async () => {
 			loads += 1;
 			if (loads === 1) throw new Error("temporary menu failure");
@@ -125,7 +139,10 @@ test("fleet menu loads on demand, caches success, retries failure, and suppresse
 test("direct invite joins in TUI and RPC but rejects unknown, trailing, JSON, and print input", async () => {
 	for (const mode of ["tui", "rpc"] as const) {
 		const mock = createMockPi();
-		createPiFleetExtension({ controllerDependencies: dependencies() })(mock.pi);
+		createPiFleetExtension({
+			controllerDependencies: dependencies(),
+			settingsRuntime: memorySettingsRuntime(),
+		})(mock.pi);
 		const context = createMockContext({ mode, hasUI: true, confirm: async () => true });
 		await emit(mock, "session_start", { reason: "startup" }, context.ctx);
 		const command = mock.commands.get("fleet");
@@ -143,7 +160,10 @@ test("direct invite joins in TUI and RPC but rejects unknown, trailing, JSON, an
 	}
 	for (const mode of ["json", "print"] as const) {
 		const mock = createMockPi();
-		createPiFleetExtension({ controllerDependencies: dependencies() })(mock.pi);
+		createPiFleetExtension({
+			controllerDependencies: dependencies(),
+			settingsRuntime: memorySettingsRuntime(),
+		})(mock.pi);
 		const context = createMockContext({ mode, hasUI: false });
 		await emit(mock, "session_start", { reason: "startup" }, context.ctx);
 		const command = mock.commands.get("fleet");
@@ -153,3 +173,27 @@ test("direct invite joins in TUI and RPC but rejects unknown, trailing, JSON, an
 		await emit(mock, "session_shutdown", { reason: "quit" }, context.ctx);
 	}
 });
+
+function memorySettingsRuntime(): FleetSettingsRuntime & {
+	calls: { reload: number; flush: number };
+} {
+	const state: FleetSettingsState = {
+		settings: { ...DEFAULT_FLEET_SETTINGS },
+		sources: { defaultTerminal: "built-in", confirmSessionLaunch: "built-in" },
+		canSave: true,
+	};
+	const calls = { reload: 0, flush: 0 };
+	return {
+		calls,
+		get: () => state,
+		getPath: () => "/tmp/pi-fleet.json",
+		reload: async () => {
+			calls.reload += 1;
+			return state;
+		},
+		update: async () => state,
+		flush: async () => {
+			calls.flush += 1;
+		},
+	};
+}

--- a/packages/pi-fleet/test/runtime-directory.test.ts
+++ b/packages/pi-fleet/test/runtime-directory.test.ts
@@ -94,7 +94,7 @@ posixTest(
 );
 
 posixTest(
-	"old orphan sockets and temporary files are removed while fresh entries survive",
+	"old orphan sockets and temporary launch files are removed while fresh entries survive",
 	async () => {
 		await fixture(async (base) => {
 			const group = createGroup(Buffer.alloc(32, 6));
@@ -103,6 +103,10 @@ posixTest(
 			await createOrphanSocket(orphanSocket);
 			const oldTemporary = join(directory, `.${"c".repeat(24)}.json.${"d".repeat(16)}.tmp`);
 			await writeFile(oldTemporary, "old", { mode: 0o600 });
+			const oldLauncher = join(directory, `launch-${"a".repeat(16)}.sh`);
+			await writeFile(oldLauncher, "private launch values", { mode: 0o700 });
+			const unrelatedScript = join(directory, "launch-not-owned.sh");
+			await writeFile(unrelatedScript, "keep", { mode: 0o700 });
 			const pairedSocket = join(directory, `${"7".repeat(24)}.sock`);
 			await createOrphanSocket(pairedSocket);
 			await writeFile(join(directory, `${"7".repeat(24)}.json`), "paired", { mode: 0o600 });
@@ -112,17 +116,21 @@ posixTest(
 			);
 			assert.deepEqual(oldResult, {
 				removedSockets: 1,
-				removedTemporaryFiles: 1,
+				removedTemporaryFiles: 2,
 				saturated: false,
 			});
 			await assert.rejects(lstat(orphanSocket));
 			await assert.rejects(lstat(oldTemporary));
+			await assert.rejects(lstat(oldLauncher));
+			assert.equal((await lstat(unrelatedScript)).isFile(), true);
 			assert.equal((await lstat(pairedSocket)).isSocket(), true);
 
 			const freshSocket = join(directory, `${"8".repeat(24)}.sock`);
 			await createOrphanSocket(freshSocket);
 			const freshTemporary = join(directory, `.${"e".repeat(24)}.json.${"f".repeat(16)}.tmp`);
 			await writeFile(freshTemporary, "fresh", { mode: 0o600 });
+			const freshLauncher = join(directory, `launch-${"b".repeat(16)}.sh`);
+			await writeFile(freshLauncher, "fresh", { mode: 0o700 });
 			assert.deepEqual(await cleanupStaleRuntimeEntries(directory, Date.now()), {
 				removedSockets: 0,
 				removedTemporaryFiles: 0,
@@ -130,6 +138,7 @@ posixTest(
 			});
 			assert.equal((await lstat(freshSocket)).isSocket(), true);
 			assert.equal((await lstat(freshTemporary)).isFile(), true);
+			assert.equal((await lstat(freshLauncher)).isFile(), true);
 		});
 	},
 );

--- a/packages/pi-fleet/test/settings.test.ts
+++ b/packages/pi-fleet/test/settings.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { rename, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { type TestContext, test } from "vitest";
+import {
+	createFleetSettingsRuntime,
+	DEFAULT_FLEET_SETTINGS,
+	loadFleetSettings,
+	normalizeFleetSettingsDocument,
+} from "../src/settings.js";
+
+function temporarySettings(t: TestContext) {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-fleet-settings-"));
+	t.onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
+	return { directory, settingsPath: path.join(directory, "agent", "pi-fleet.json") };
+}
+
+test("missing settings stay side-effect free until the first explicit save", async (t) => {
+	const { directory, settingsPath } = temporarySettings(t);
+	const loaded = await loadFleetSettings(settingsPath);
+	assert.equal(loaded.kind, "missing");
+	assert.deepEqual(loaded.settings, DEFAULT_FLEET_SETTINGS);
+	assert.equal(exists(path.join(directory, "agent")), false);
+
+	const runtime = createFleetSettingsRuntime({ path: settingsPath });
+	await runtime.reload();
+	assert.equal(exists(path.join(directory, "agent")), false);
+	await runtime.update({ confirmSessionLaunch: false });
+	assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+		confirmSessionLaunch: false,
+	});
+});
+
+test("normalization accepts partial settings and rejects invalid owned values", () => {
+	assert.deepEqual(
+		normalizeFleetSettingsDocument({
+			defaultTerminal: "ghostty",
+			confirmSessionLaunch: false,
+			future: { retained: true },
+		}),
+		{
+			settings: { defaultTerminal: "ghostty", confirmSessionLaunch: false },
+			sources: { defaultTerminal: "user", confirmSessionLaunch: "user" },
+		},
+	);
+	assert.deepEqual(normalizeFleetSettingsDocument({ defaultTerminal: "zellij" }), {
+		settings: { defaultTerminal: "zellij", confirmSessionLaunch: true },
+		sources: { defaultTerminal: "user", confirmSessionLaunch: "built-in" },
+	});
+	assert.deepEqual(normalizeFleetSettingsDocument({}), {
+		settings: DEFAULT_FLEET_SETTINGS,
+		sources: { defaultTerminal: "built-in", confirmSessionLaunch: "built-in" },
+	});
+	for (const value of [
+		null,
+		[],
+		{ defaultTerminal: "auto" },
+		{ defaultTerminal: true },
+		{ confirmSessionLaunch: "yes" },
+	]) {
+		assert.equal(normalizeFleetSettingsDocument(value), undefined);
+	}
+});
+
+test("updates preserve unknown fields and publish private JSON atomically", async (t) => {
+	const { settingsPath } = temporarySettings(t);
+	mkdirSync(path.dirname(settingsPath), { recursive: true });
+	writeFileSync(
+		settingsPath,
+		`${JSON.stringify({ confirmSessionLaunch: true, future: { retained: true } }, null, 2)}\n`,
+	);
+	const runtime = createFleetSettingsRuntime({ path: settingsPath });
+	await runtime.reload();
+	await runtime.update({ defaultTerminal: "ghostty" });
+	await runtime.update({ confirmSessionLaunch: false });
+
+	assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+		confirmSessionLaunch: false,
+		future: { retained: true },
+		defaultTerminal: "ghostty",
+	});
+	assert.deepEqual(runtime.get().settings, {
+		defaultTerminal: "ghostty",
+		confirmSessionLaunch: false,
+	});
+	if (process.platform !== "win32") {
+		assert.equal(statSync(settingsPath).mode & 0o777, 0o600);
+	}
+	assert.deepEqual(listTemporaryFiles(settingsPath), []);
+});
+
+test("malformed, invalid, and invalid UTF-8 files remain unchanged and block updates", async (t) => {
+	for (const contents of [
+		Buffer.from("{bad json\n"),
+		Buffer.from('{"defaultTerminal":"auto"}\n'),
+		Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d]),
+	]) {
+		const { settingsPath } = temporarySettings(t);
+		mkdirSync(path.dirname(settingsPath), { recursive: true });
+		writeFileSync(settingsPath, contents);
+		const runtime = createFleetSettingsRuntime({ path: settingsPath });
+		const state = await runtime.reload();
+		assert.ok(state.issue);
+		await assert.rejects(
+			runtime.update({ defaultTerminal: "ghostty" }),
+			/invalid|malformed|UTF-8/u,
+		);
+		assert.deepEqual(readFileSync(settingsPath), contents);
+		assert.deepEqual(runtime.get().settings, DEFAULT_FLEET_SETTINGS);
+	}
+});
+
+test("publication failure retains effective state, cleans temporary files, and queue recovers", async (t) => {
+	const { settingsPath } = temporarySettings(t);
+	let rejectRename = true;
+	const runtime = createFleetSettingsRuntime({
+		path: settingsPath,
+		operations: {
+			rename: async (
+				source: Parameters<typeof rename>[0],
+				destination: Parameters<typeof rename>[1],
+			) => {
+				if (rejectRename) throw new Error("rename rejected");
+				await rename(source, destination);
+			},
+		},
+	});
+	await runtime.reload();
+	await assert.rejects(runtime.update({ defaultTerminal: "ghostty" }), /rename rejected/u);
+	assert.deepEqual(runtime.get().settings, DEFAULT_FLEET_SETTINGS);
+	assert.deepEqual(listTemporaryFiles(settingsPath), []);
+
+	rejectRename = false;
+	await runtime.update({ defaultTerminal: "ghostty" });
+	assert.equal(runtime.get().settings.defaultTerminal, "ghostty");
+});
+
+test("concurrent updates serialize in call order and reload waits for pending publication", async (t) => {
+	const { settingsPath } = temporarySettings(t);
+	let releaseFirst!: () => void;
+	const firstWrite = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
+	let writes = 0;
+	const runtime = createFleetSettingsRuntime({
+		path: settingsPath,
+		operations: {
+			writeFile: async (
+				file: Parameters<typeof writeFile>[0],
+				data: Parameters<typeof writeFile>[1],
+				options: Parameters<typeof writeFile>[2],
+			) => {
+				writes += 1;
+				if (writes === 1) await firstWrite;
+				await writeFile(file, data, options);
+			},
+		},
+	});
+	await runtime.reload();
+	const first = runtime.update({ defaultTerminal: "ghostty" });
+	const second = runtime.update({ confirmSessionLaunch: false });
+	const reload = runtime.reload();
+	await Promise.resolve();
+	assert.deepEqual(runtime.get().settings, DEFAULT_FLEET_SETTINGS);
+	releaseFirst();
+	await Promise.all([first, second, reload, runtime.flush()]);
+	assert.deepEqual(runtime.get().settings, {
+		defaultTerminal: "ghostty",
+		confirmSessionLaunch: false,
+	});
+});
+
+function exists(target: string) {
+	try {
+		statSync(target);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function listTemporaryFiles(settingsPath: string) {
+	try {
+		return readdirSync(path.dirname(settingsPath)).filter((name) => name.endsWith(".tmp"));
+	} catch {
+		return [];
+	}
+}

--- a/packages/pi-fleet/test/spawn.test.ts
+++ b/packages/pi-fleet/test/spawn.test.ts
@@ -8,6 +8,13 @@ import {
 	type FleetTransportPort,
 } from "../src/fleet-controller.js";
 import type { FleetMessage, FleetPeerDescription } from "../src/protocol.js";
+import {
+	DEFAULT_FLEET_SETTINGS,
+	type FleetSettings,
+	type FleetSettingsPatch,
+	type FleetSettingsRuntime,
+	type FleetSettingsState,
+} from "../src/settings.js";
 import { TmuxLaunchError } from "../src/tmux.js";
 import type {
 	FleetDeliveryAck,
@@ -58,34 +65,46 @@ function harness(options: { ready?: boolean; launchError?: Error } = {}) {
 	const transports: SpawnTransport[] = [];
 	const tmuxSplitCalls: Parameters<FleetTerminalPort["spawnSplit"]>[0][] = [];
 	const ghosttySplitCalls: Parameters<FleetTerminalPort["spawnSplit"]>[0][] = [];
+	const zellijSplitCalls: Parameters<FleetTerminalPort["spawnSplit"]>[0][] = [];
 	let now = 1_800_000_000_000;
 	let tmuxCreated = 0;
 	let ghosttyCreated = 0;
+	let zellijCreated = 0;
 	let launcherCleaned = false;
+	const launcherEnvironments: Array<Readonly<Record<string, string>> | undefined> = [];
 	let cleanupStateAtFirstPoll: boolean | undefined;
 	let pendingPeer: FleetPeerDescription | undefined;
 	const spawnSplit = async (
-		terminal: "tmux" | "ghostty",
+		terminal: "tmux" | "ghostty" | "zellij",
 		spawnOptions: Parameters<FleetTerminalPort["spawnSplit"]>[0],
 	) => {
-		const calls = terminal === "tmux" ? tmuxSplitCalls : ghosttySplitCalls;
+		const calls =
+			terminal === "tmux"
+				? tmuxSplitCalls
+				: terminal === "ghostty"
+					? ghosttySplitCalls
+					: zellijSplitCalls;
 		calls.push(spawnOptions);
 		if (options.launchError) throw options.launchError;
 		if (options.ready !== false) {
+			const childEnvironment =
+				Object.keys(spawnOptions.environment).length > 0
+					? spawnOptions.environment
+					: (launcherEnvironments.at(-1) ?? {});
 			pendingPeer = {
 				protocolVersion: 2,
 				sessionId: "child-session",
 				endpointId: "b".repeat(24),
-				name: spawnOptions.environment.PI_FLEET_CHILD_NAME,
+				name: childEnvironment.PI_FLEET_CHILD_NAME,
 				cwd: spawnOptions.cwd,
 				pid: 456,
-				launchId: spawnOptions.environment.PI_FLEET_LAUNCH_ID,
+				launchId: childEnvironment.PI_FLEET_LAUNCH_ID,
 				acceptsRequests: false,
 			};
 		}
 		return {
 			terminalId: `${terminal}-child`,
-			version: terminal === "tmux" ? "3.4" : "1.3.1",
+			version: terminal === "tmux" ? "3.4" : terminal === "ghostty" ? "1.3.1" : "0.44.3",
 		};
 	};
 	const deps: FleetControllerDependencies = {
@@ -93,7 +112,9 @@ function harness(options: { ready?: boolean; launchError?: Error } = {}) {
 			const transport = new SpawnTransport(transportOptions);
 			transport.beforeList = () => {
 				if (
-					(tmuxSplitCalls.length > 0 || ghosttySplitCalls.length > 0) &&
+					(tmuxSplitCalls.length > 0 ||
+						ghosttySplitCalls.length > 0 ||
+						zellijSplitCalls.length > 0) &&
 					cleanupStateAtFirstPoll === undefined
 				) {
 					cleanupStateAtFirstPoll = launcherCleaned;
@@ -120,14 +141,24 @@ function harness(options: { ready?: boolean; launchError?: Error } = {}) {
 				spawnSplit: (spawnOptions) => spawnSplit("ghostty", spawnOptions),
 			};
 		},
+		createZellij: () => {
+			zellijCreated += 1;
+			return {
+				assertAvailable: async () => "0.44.3",
+				spawnSplit: (spawnOptions) => spawnSplit("zellij", spawnOptions),
+			};
+		},
 		resolveInvocation: (args) => ({ command: "/bin/pi", args }),
-		createLauncher: async () => ({
-			path: "/tmp/pi-fleet-spawn-test/launch.sh",
-			command: "/tmp/pi-fleet-spawn-test/launch.sh",
-			cleanup: async () => {
-				launcherCleaned = true;
-			},
-		}),
+		createLauncher: async (_invocation, _directory, environment) => {
+			launcherEnvironments.push(environment);
+			return {
+				path: "/tmp/pi-fleet-spawn-test/launch.sh",
+				command: "/tmp/pi-fleet-spawn-test/launch.sh",
+				cleanup: async () => {
+					launcherCleaned = true;
+				},
+			};
+		},
 		realpath: async (value) => `/real${value}`,
 		isDirectory: async () => true,
 		now: () => now,
@@ -144,11 +175,16 @@ function harness(options: { ready?: boolean; launchError?: Error } = {}) {
 		transports,
 		splitCalls: tmuxSplitCalls,
 		ghosttySplitCalls,
+		zellijSplitCalls,
+		launcherEnvironments,
 		get tmuxCreated() {
 			return tmuxCreated;
 		},
 		get ghosttyCreated() {
 			return ghosttyCreated;
+		},
+		get zellijCreated() {
+			return zellijCreated;
 		},
 		get launcherCleaned() {
 			return launcherCleaned;
@@ -193,6 +229,7 @@ test("spawn auto-creates a group, preserves parent, inherits model, and sends ki
 	assert.equal(runtime.ghosttyCreated, 0);
 	assert.equal(splitCalls[0]?.direction, "down");
 	assert.equal(runtime.cleanupStateAtFirstPoll, false);
+	assert.equal(runtime.launcherEnvironments[0], undefined);
 	assert.equal(splitCalls[0]?.cwd, "/real/project/worktree");
 	assert.equal(splitCalls[0]?.environment.PI_FLEET_MODEL_PROVIDER, "provider");
 	assert.equal(splitCalls[0]?.environment.PI_FLEET_MODEL_ID, "model");
@@ -228,6 +265,86 @@ test("spawn reuses an existing group and supports all split directions", async (
 		assert.equal(splitCalls[0]?.direction, direction);
 		await controller.sessionShutdown({ reason: "quit" }, context.ctx);
 	}
+});
+
+test("spawn uses the configured terminal when omitted and lets an explicit argument override it", async () => {
+	for (const explicitTerminal of [undefined, "tmux"] as const) {
+		const runtime = harness();
+		const settings = memorySettingsRuntime({ defaultTerminal: "ghostty" });
+		const controller = new FleetController(runtime.mock.pi, runtime.deps, settings);
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			confirm: async () => true,
+		});
+		await controller.sessionStart({ reason: "startup" }, context.ctx);
+		const result = await controller.spawn(context.ctx, {
+			...(explicitTerminal ? { terminal: explicitTerminal } : {}),
+		});
+		assert.equal(result.terminal, explicitTerminal ?? "ghostty");
+		assert.equal(runtime.tmuxCreated, explicitTerminal === "tmux" ? 1 : 0);
+		assert.equal(runtime.ghosttyCreated, explicitTerminal === "tmux" ? 0 : 1);
+		await controller.sessionShutdown({ reason: "quit" }, context.ctx);
+	}
+});
+
+test("spawn routes configured and explicit Zellij launches without changing the tmux default", async () => {
+	for (const configured of [false, true]) {
+		const runtime = harness();
+		const settings = memorySettingsRuntime(configured ? { defaultTerminal: "zellij" } : {});
+		const controller = new FleetController(runtime.mock.pi, runtime.deps, settings);
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			confirm: async () => true,
+		});
+		await controller.sessionStart({ reason: "startup" }, context.ctx);
+		const result = await controller.spawn(
+			context.ctx,
+			configured ? {} : { terminal: "zellij", direction: "up" },
+		);
+		assert.equal(result.terminal, "zellij");
+		assert.equal(result.terminalVersion, "0.44.3");
+		assert.equal(runtime.zellijCreated, 1);
+		assert.equal(runtime.zellijSplitCalls.length, 1);
+		assert.equal(runtime.zellijSplitCalls[0]?.direction, configured ? "right" : "up");
+		assert.deepEqual(runtime.zellijSplitCalls[0]?.environment, {});
+		assert.match(runtime.launcherEnvironments[0]?.PI_FLEET_INVITE ?? "", /^pifleet:v1:/u);
+		assert.equal(runtime.tmuxCreated, 0);
+		assert.equal(runtime.ghosttyCreated, 0);
+		await controller.sessionShutdown({ reason: "quit" }, context.ctx);
+	}
+});
+
+test("disabled launch confirmation skips the preview but preserves experimental consent", async () => {
+	const runtime = harness();
+	const settings = memorySettingsRuntime({ confirmSessionLaunch: false });
+	const controller = new FleetController(runtime.mock.pi, runtime.deps, settings);
+	const confirmationTitles: string[] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		confirm: async (title: string) => {
+			confirmationTitles.push(title);
+			return true;
+		},
+	});
+	await controller.sessionStart({ reason: "startup" }, context.ctx);
+	await controller.spawn(context.ctx, {});
+	assert.deepEqual(confirmationTitles, ["Use experimental Pi Fleet?"]);
+	await controller.sessionShutdown({ reason: "quit" }, context.ctx);
+});
+
+test("settings reload on session start, report invalid data, and flush on shutdown", async () => {
+	const runtime = harness();
+	const settings = memorySettingsRuntime({}, "invalid settings");
+	const controller = new FleetController(runtime.mock.pi, runtime.deps, settings);
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	await controller.sessionStart({ reason: "startup" }, context.ctx);
+	assert.equal(settings.calls.reload, 1);
+	assert.match(context.notifications.at(-1)?.message ?? "", /invalid settings/u);
+	await controller.sessionShutdown({ reason: "quit" }, context.ctx);
+	assert.equal(settings.calls.flush, 1);
 });
 
 test("spawn uses Ghostty only after explicit selection and reports compatible metadata", async () => {
@@ -340,6 +457,41 @@ test("spawn rejects unsupported modes and cancellation before side effects", asy
 	await second.sessionShutdown({ reason: "quit" }, cancelled.ctx);
 });
 
+test("session shutdown suppresses a split after delayed launcher creation", async () => {
+	const runtime = harness();
+	let signalLauncherStarted!: () => void;
+	const launcherStarted = new Promise<void>((resolve) => {
+		signalLauncherStarted = resolve;
+	});
+	let releaseLauncher!: () => void;
+	const launcherReleased = new Promise<void>((resolve) => {
+		releaseLauncher = resolve;
+	});
+	let launcherCleaned = false;
+	runtime.deps.createLauncher = async () => {
+		signalLauncherStarted();
+		await launcherReleased;
+		return {
+			path: "/tmp/pi-fleet-test/launch.sh",
+			command: "/tmp/pi-fleet-test/launch.sh",
+			cleanup: async () => {
+				launcherCleaned = true;
+			},
+		};
+	};
+	const controller = new FleetController(runtime.mock.pi, runtime.deps);
+	const context = createMockContext({ mode: "tui", hasUI: true, confirm: async () => true });
+	await controller.sessionStart({ reason: "startup" }, context.ctx);
+	const spawning = controller.spawn(context.ctx, {});
+	await launcherStarted;
+	const shuttingDown = controller.sessionShutdown({ reason: "quit" }, context.ctx);
+	releaseLauncher();
+	await assert.rejects(spawning, /stale|aborted/u);
+	await shuttingDown;
+	assert.equal(runtime.splitCalls.length, 0);
+	assert.equal(launcherCleaned, true);
+});
+
 test("session shutdown waits for an in-flight launch to release its launcher", async () => {
 	const runtime = harness({ ready: false });
 	let signalSleepEntered!: () => void;
@@ -415,3 +567,41 @@ test("pre-split failure rolls back an automatic group while readiness timeout ke
 	assert.equal((await timeout.snapshot()).connected, true);
 	await timeout.sessionShutdown({ reason: "quit" }, secondContext.ctx);
 });
+
+function memorySettingsRuntime(
+	overrides: Partial<FleetSettings> = {},
+	issue?: string,
+): FleetSettingsRuntime & {
+	calls: { reload: number; flush: number };
+	patches: FleetSettingsPatch[];
+} {
+	let state: FleetSettingsState = {
+		settings: { ...DEFAULT_FLEET_SETTINGS, ...overrides },
+		sources: {
+			defaultTerminal: Object.hasOwn(overrides, "defaultTerminal") ? "user" : "built-in",
+			confirmSessionLaunch: Object.hasOwn(overrides, "confirmSessionLaunch") ? "user" : "built-in",
+		},
+		canSave: issue === undefined,
+		...(issue ? { issue: { kind: "invalid", message: issue } } : {}),
+	};
+	const calls = { reload: 0, flush: 0 };
+	const patches: FleetSettingsPatch[] = [];
+	return {
+		calls,
+		patches,
+		get: () => state,
+		getPath: () => "/tmp/pi-fleet.json",
+		reload: async () => {
+			calls.reload += 1;
+			return state;
+		},
+		update: async (patch) => {
+			patches.push(patch);
+			state = { ...state, settings: { ...state.settings, ...patch } };
+			return state;
+		},
+		flush: async () => {
+			calls.flush += 1;
+		},
+	};
+}

--- a/packages/pi-fleet/test/terminal.test.ts
+++ b/packages/pi-fleet/test/terminal.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	createTerminalLaunchError,
+	isTerminalLaunchError,
+	normalizeTerminal,
+} from "../src/terminal.js";
+import { ZellijLaunchError } from "../src/zellij.js";
+
+test("terminal helpers normalize and classify Zellij launch errors", () => {
+	assert.equal(normalizeTerminal("zellij"), "zellij");
+	assert.equal(isTerminalLaunchError(new ZellijLaunchError("partial", true, "terminal_7")), true);
+	assert.ok(
+		createTerminalLaunchError("zellij", "failed", true, "terminal_8") instanceof ZellijLaunchError,
+	);
+});

--- a/packages/pi-fleet/test/tools.test.ts
+++ b/packages/pi-fleet/test/tools.test.ts
@@ -109,7 +109,7 @@ test("session_spawn delegates launch input and returns readiness without secrets
 	assert.equal(JSON.stringify(result).includes("pifleet:v1"), false);
 });
 
-test("session_spawn uses Ghostty only when the tool argument explicitly requests it", async () => {
+test("session_spawn forwards an explicit Ghostty override", async () => {
 	const mock = createMockPi();
 	const ghosttyResult: SpawnSessionResult = {
 		sessionId: "ghostty-child",
@@ -140,6 +140,38 @@ test("session_spawn uses Ghostty only when the tool argument explicitly requests
 	);
 	assert.deepEqual(calls, [{ kind: "spawn", input: { terminal: "ghostty", direction: "right" } }]);
 	assert.match(result.content[0]?.text ?? "", /ready.*Ghostty/iu);
+});
+
+test("session_spawn forwards and labels an explicit Zellij override", async () => {
+	const mock = createMockPi();
+	const zellijResult: SpawnSessionResult = {
+		sessionId: "zellij-child",
+		cwd: "/tmp/child",
+		terminal: "zellij",
+		terminalId: "terminal_42",
+		terminalVersion: "0.44.3",
+		kickoffAccepted: false,
+	};
+	const { controller, calls } = stubController({
+		spawn: async (_ctx, input) => {
+			calls.push({ kind: "spawn", input });
+			return zellijResult;
+		},
+	});
+	registerFleetTools(mock.pi, controller);
+	const tool = mock.tools.find(({ name }) => name === "session_spawn") as {
+		execute(...args: unknown[]): Promise<{ content: Array<{ text: string }>; details: unknown }>;
+	};
+	const context = createMockContext({ mode: "rpc", hasUI: true });
+	const result = await tool.execute(
+		"call-zellij",
+		{ terminal: "zellij", direction: "left" },
+		undefined,
+		undefined,
+		context.ctx,
+	);
+	assert.deepEqual(calls, [{ kind: "spawn", input: { terminal: "zellij", direction: "left" } }]);
+	assert.match(result.content[0]?.text ?? "", /ready.*Zellij/iu);
 });
 
 test("session_bus lists peers, sends requests, and correlates replies", async () => {

--- a/packages/pi-fleet/test/zellij.test.ts
+++ b/packages/pi-fleet/test/zellij.test.ts
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { ZellijAdapter, type ZellijCommandExecutor, ZellijLaunchError } from "../src/zellij.js";
+
+function result(stdout = "", stderr = "", code = 0, killed = false) {
+	return { stdout, stderr, code, killed };
+}
+
+function adapter(
+	execute: ZellijCommandExecutor,
+	overrides: { zellijEnvironment?: string; zellijPaneId?: string } = {},
+) {
+	return new ZellijAdapter({
+		execute,
+		zellijEnvironment:
+			overrides.zellijEnvironment === undefined ? "0" : overrides.zellijEnvironment,
+		zellijPaneId: overrides.zellijPaneId === undefined ? "7" : overrides.zellijPaneId,
+	});
+}
+
+test("Zellij adapter requires a current pane and Zellij 0.44 or newer", async () => {
+	await assert.rejects(
+		adapter(async () => result("zellij 0.44.3\n"), { zellijEnvironment: "" }).assertAvailable(),
+		/running inside Zellij/iu,
+	);
+	await assert.rejects(
+		adapter(async () => result("zellij 0.44.3\n"), {
+			zellijPaneId: "terminal_7",
+		}).assertAvailable(),
+		/current Zellij pane/iu,
+	);
+	await assert.rejects(adapter(async () => result("zellij 0.43.1\n")).assertAvailable(), /0\.44/u);
+	await assert.rejects(adapter(async () => result("unexpected\n")).assertAvailable(), /version/iu);
+	assert.equal(await adapter(async () => result("zellij 0.44.3\n")).assertAvailable(), "0.44.3");
+});
+
+test("Zellij split uses a private launcher path and pane-targeted placement for every direction", async () => {
+	for (const direction of ["right", "down", "left", "up"] as const) {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const zellij = adapter(async (command, args) => {
+			calls.push({ command, args });
+			if (calls.length === 1) return result("zellij 0.44.3\n");
+			if (calls.length === 2) return result(`terminal_${direction === "up" ? 43 : 42}\n`);
+			return result();
+		});
+		const terminalId = `terminal_${direction === "up" ? 43 : 42}`;
+		assert.deepEqual(
+			await zellij.spawnSplit({
+				direction,
+				cwd: "/tmp/project ' quoted",
+				launcherCommand: "/tmp/launcher path",
+				environment: {},
+				isCurrent: () => true,
+			}),
+			{ terminalId, version: "0.44.3" },
+		);
+		assert.deepEqual(calls[0], { command: "zellij", args: ["--version"] });
+		assert.deepEqual(calls[1], {
+			command: "zellij",
+			args: [
+				"action",
+				"new-pane",
+				"--direction",
+				direction === "down" || direction === "up" ? "down" : "right",
+				"--cwd",
+				"/tmp/project ' quoted",
+				"--near-current-pane",
+				"--",
+				"/tmp/launcher path",
+			],
+		});
+		assert.doesNotMatch(JSON.stringify(calls[1]), /PI_FLEET|secret-placeholder/u);
+		if (direction === "left" || direction === "up") {
+			assert.deepEqual(calls[2], {
+				command: "zellij",
+				args: ["action", "move-pane", "--pane-id", terminalId, direction],
+			});
+		} else {
+			assert.equal(calls.length, 2);
+		}
+	}
+});
+
+test("Zellij adapter rejects invalid split input before running Zellij", async () => {
+	let calls = 0;
+	const zellij = adapter(async () => {
+		calls += 1;
+		return result("zellij 0.44.3\n");
+	});
+	await assert.rejects(
+		zellij.spawnSplit({
+			direction: "auto" as "right",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			isCurrent: () => true,
+		}),
+		/split direction is invalid/u,
+	);
+	await assert.rejects(
+		zellij.spawnSplit({
+			direction: "right",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: { PI_FLEET_INVITE: "pifleet:v1:secret-placeholder" },
+			isCurrent: () => true,
+		}),
+		/private launcher/u,
+	);
+	assert.equal(calls, 0);
+});
+
+test("Zellij adapter cancels and suppresses stale work before pane creation", async () => {
+	let calls = 0;
+	const zellij = adapter(async () => {
+		calls += 1;
+		return result("zellij 0.44.3\n");
+	});
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		zellij.spawnSplit({
+			direction: "right",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			signal: controller.signal,
+			isCurrent: () => true,
+		}),
+		/aborted/u,
+	);
+	assert.equal(calls, 0);
+
+	let current = true;
+	calls = 0;
+	const stale = adapter(async () => {
+		calls += 1;
+		current = false;
+		return result("zellij 0.44.3\n");
+	});
+	await assert.rejects(
+		stale.spawnSplit({
+			direction: "down",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			isCurrent: () => current,
+		}),
+		(error: unknown) =>
+			error instanceof ZellijLaunchError && !error.splitCreated && /stale/u.test(error.message),
+	);
+	assert.equal(calls, 1);
+});
+
+test("Zellij adapter reports post-pane cancellation, identity, placement, and stale failures as partial", async () => {
+	const during = new AbortController();
+	let calls = 0;
+	const cancelled = adapter(async () => {
+		calls += 1;
+		if (calls === 1) return result("zellij 0.44.3\n");
+		during.abort();
+		return result("terminal_8\n");
+	});
+	await assert.rejects(
+		cancelled.spawnSplit({
+			direction: "right",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			signal: during.signal,
+			isCurrent: () => true,
+		}),
+		(error: unknown) =>
+			error instanceof ZellijLaunchError && error.splitCreated && error.terminalId === "terminal_8",
+	);
+
+	calls = 0;
+	const invalid = adapter(async () => {
+		calls += 1;
+		return calls === 1 ? result("zellij 0.44.3\n") : result("not-a-pane\n");
+	});
+	await assert.rejects(
+		invalid.spawnSplit({
+			direction: "right",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			isCurrent: () => true,
+		}),
+		(error: unknown) => error instanceof ZellijLaunchError && error.splitCreated,
+	);
+
+	calls = 0;
+	const placement = adapter(async () => {
+		calls += 1;
+		if (calls === 1) return result("zellij 0.44.3\n");
+		if (calls === 2) return result("terminal_9\n");
+		return result("", "move rejected", 1);
+	});
+	await assert.rejects(
+		placement.spawnSplit({
+			direction: "left",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			isCurrent: () => true,
+		}),
+		(error: unknown) =>
+			error instanceof ZellijLaunchError &&
+			error.splitCreated &&
+			error.terminalId === "terminal_9" &&
+			/placement/u.test(error.message),
+	);
+
+	const placementCancellation = new AbortController();
+	calls = 0;
+	const cancelledPlacement = adapter(async () => {
+		calls += 1;
+		if (calls === 1) return result("zellij 0.44.3\n");
+		if (calls === 2) return result("terminal_10\n");
+		placementCancellation.abort();
+		return result();
+	});
+	await assert.rejects(
+		cancelledPlacement.spawnSplit({
+			direction: "up",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			signal: placementCancellation.signal,
+			isCurrent: () => true,
+		}),
+		(error: unknown) =>
+			error instanceof ZellijLaunchError &&
+			error.splitCreated &&
+			error.terminalId === "terminal_10" &&
+			/cancelled/u.test(error.message),
+	);
+
+	let current = true;
+	calls = 0;
+	const stale = adapter(async () => {
+		calls += 1;
+		if (calls === 1) return result("zellij 0.44.3\n");
+		if (calls === 2) return result("terminal_11\n");
+		current = false;
+		return result();
+	});
+	await assert.rejects(
+		stale.spawnSplit({
+			direction: "left",
+			cwd: "/tmp",
+			launcherCommand: "/tmp/launcher",
+			environment: {},
+			isCurrent: () => current,
+		}),
+		(error: unknown) =>
+			error instanceof ZellijLaunchError &&
+			error.splitCreated &&
+			error.terminalId === "terminal_11",
+	);
+});

--- a/packages/pi-fleet/test/zellij.test.ts
+++ b/packages/pi-fleet/test/zellij.test.ts
@@ -34,7 +34,7 @@ test("Zellij adapter requires a current pane and Zellij 0.44 or newer", async ()
 	assert.equal(await adapter(async () => result("zellij 0.44.3\n")).assertAvailable(), "0.44.3");
 });
 
-test("Zellij split uses a private launcher path and pane-targeted placement for every direction", async () => {
+test("Zellij split uses a visible private-launcher pane and pane-targeted placement for every direction", async () => {
 	for (const direction of ["right", "down", "left", "up"] as const) {
 		const calls: Array<{ command: string; args: string[] }> = [];
 		const zellij = adapter(async (command, args) => {
@@ -64,12 +64,14 @@ test("Zellij split uses a private launcher path and pane-targeted placement for 
 				direction === "down" || direction === "up" ? "down" : "right",
 				"--cwd",
 				"/tmp/project ' quoted",
-				"--near-current-pane",
 				"--",
 				"/tmp/launcher path",
 			],
 		});
-		assert.doesNotMatch(JSON.stringify(calls[1]), /PI_FLEET|secret-placeholder/u);
+		assert.doesNotMatch(
+			JSON.stringify(calls[1]),
+			/PI_FLEET|secret-placeholder|--near-current-pane/u,
+		);
 		if (direction === "left" || direction === "up") {
 			assert.deepEqual(calls[2], {
 				command: "zellij",


### PR DESCRIPTION
## Summary

- Add persistent `/fleet` settings for the default terminal and launch confirmation while keeping tmux as the built-in default.
- Add Zellij 0.44+ spawning with pane identity, directional placement, cancellation and partial-launch reporting, and a private self-deleting launcher for launch secrets.
- Apply configured defaults consistently to menu and tool launches while preserving explicit tool overrides.
- Update documentation, tests, archived implementation plans, package metadata, and the minor Changeset.

## Verification

- `npm run check` passed with 378 test files and 3,792 tests.
- `just pack fleet` produced the expected 23-file package, including `src/settings.ts` and `src/zellij.ts`.
- The isolated Pi extension entrypoint loaded successfully.
- Local Zellij 0.44.3 CLI capability checks passed for pane identity and pane-targeted movement.
- A live Zellij 0.44.3 smoke created visible authenticated panes in right, down, left, and up positions.
- The live kickoff was accepted, the child replied through Pi Fleet, and every smoke pane and peer was cleaned up.
- The live smoke exposed `--near-current-pane` hiding its pane while orphaning the child process, so the option was removed and covered by a regression test.
- The final diff was audited against `docs/extension-conventions.md` and `docs/extension-settings.md` with no deviations.
