### PR TITLE
fix(pi-usage): display OpenCode rate-limited windows

### DIFF
--- a/.changeset/sharp-owls-usage.md
+++ b/.changeset/sharp-owls-usage.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add OpenCode Go Zen usage reporting for rolling, weekly, and monthly quota windows.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -139,7 +139,7 @@ The extension does not call OpenRouter's account-level `/credits` endpoint becau
 - Provider ID: `opencode-go`
 - Semantics: OpenCode Zen plan usage windows—rolling, weekly, and monthly
 - Source: `GET {model base URL}/usage` on the configured `opencode.ai` gateway using Pi's resolved inference API key
-- Displayed data: used percentage and reset time for each window; windows with a non-`ok` status are reported as unavailable notes
+- Displayed data: used percentage and reset time for each window; `rate-limited` windows remain visible at their reported usage, while unknown statuses are reported as unavailable notes
 - Statusline examples: `zen 0% r 4% w 2% m`
 
 The usage endpoint is derived from the model's base URL (`…/zen/go/v1/usage`) and is only queried when the resolved origin is `https://opencode.ai`; other origins fail before sending the credential.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -134,6 +134,16 @@ GitHub's quota endpoint requires the original GitHub OAuth token rather than the
 
 The extension does not call OpenRouter's account-level `/credits` endpoint because that operation requires a separate management key. OpenRouter documents the distinction between credit and rate limits in its [API limits guide](https://openrouter.ai/docs/api_reference/limits).
 
+### OpenCode Go (Zen)
+
+- Provider ID: `opencode-go`
+- Semantics: OpenCode Zen plan usage windows—rolling, weekly, and monthly
+- Source: `GET {model base URL}/usage` on the configured `opencode.ai` gateway using Pi's resolved inference API key
+- Displayed data: used percentage and reset time for each window; windows with a non-`ok` status are reported as unavailable notes
+- Statusline examples: `zen 0% r 4% w 2% m`
+
+The usage endpoint is derived from the model's base URL (`…/zen/go/v1/usage`) and is only queried when the resolved origin is `https://opencode.ai`; other origins fail before sending the credential.
+
 ## 🧭 Current and configured accounts
 
 `Current` means the provider and credential used by Pi's selected model. `Configured` means Pi reports runtime auth for another supported provider; it does not mean that provider is active.

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-usage",
 	"version": "0.51.0",
-	"description": "Pi extension that shows current-account usage for Codex, GitHub Copilot, and OpenRouter.",
+	"description": "Pi extension that shows current-account usage for Codex, GitHub Copilot, OpenRouter, and OpenCode Zen.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -13,7 +13,9 @@
 		"quota",
 		"codex",
 		"copilot",
-		"openrouter"
+		"openrouter",
+		"opencode",
+		"zen"
 	],
 	"files": [
 		"src",

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -18,6 +18,7 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 	if (report.providerId === "openai-codex") formatCodexReport(lines, report);
 	else if (report.providerId === "github-copilot") formatGitHubCopilotReport(lines, report);
 	else if (report.providerId === "openrouter") formatOpenRouterReport(lines, report);
+	else if (report.providerId === "opencode-go") formatOpenCodeZenReport(lines, report);
 	else formatGenericReport(lines, report);
 
 	if (report.notes) {
@@ -35,6 +36,7 @@ export function formatUsageStatusline(report: UsageReport, model?: UsageModel): 
 		const total = report.metrics.find((metric) => metric.id === "usage-total");
 		if (typeof total?.value === "number") return `openrouter ${formatUsd(total.value)} used`;
 	}
+	if (report.providerId === "opencode-go") return formatOpenCodeZenStatusline(report);
 	return undefined;
 }
 
@@ -138,6 +140,24 @@ function formatOpenRouterReport(lines: string[], report: UsageReport): void {
 			`${`${metric.label}:`.padEnd(VALUE_COLUMN)}${formatMetricValue(metric.value, metric.unit)}`,
 		);
 	}
+}
+
+function formatOpenCodeZenReport(lines: string[], report: UsageReport): void {
+	for (const bucket of report.buckets) {
+		const reset = bucket.resetsAt ? ` (resets ${formatReset(bucket.resetsAt)})` : "";
+		const used = bucket.used ?? "unavailable";
+		lines.push(`${`${bucket.label}:`.padEnd(VALUE_COLUMN)}${used}% used${reset}`);
+	}
+}
+
+function formatOpenCodeZenStatusline(report: UsageReport): string | undefined {
+	const parts = ["zen"];
+	for (const bucket of report.buckets) {
+		if (bucket.used === undefined) continue;
+		const compact = bucket.id === "rolling" ? "r" : bucket.id === "weekly" ? "w" : "m";
+		parts.push(`${clampPercent(bucket.used).toFixed(0)}% ${compact}`);
+	}
+	return parts.length > 1 ? parts.join(" ") : undefined;
 }
 
 function formatGenericReport(lines: string[], report: UsageReport): void {

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -34,6 +34,7 @@ export {
 export { formatProviderStates, formatUsageReport, formatUsageStatusline } from "./format.js";
 export { normalizeCodexBackendPayload } from "./providers/codex.js";
 export { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
+export { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
 export { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
 export {
 	adapterForProvider,

--- a/packages/pi-usage/src/providers/opencode-zen.ts
+++ b/packages/pi-usage/src/providers/opencode-zen.ts
@@ -20,7 +20,7 @@ export function normalizeOpenCodeZenPayload(
 		const raw = asObject(usage[window.key]);
 		if (!raw) continue;
 		const status = asString(raw.status);
-		if (status !== "ok") {
+		if (status !== "ok" && status !== "rate-limited") {
 			notes.push(`${window.label} window unavailable (${status ?? "unknown status"}).`);
 			continue;
 		}

--- a/packages/pi-usage/src/providers/opencode-zen.ts
+++ b/packages/pi-usage/src/providers/opencode-zen.ts
@@ -1,0 +1,83 @@
+import { sanitizeDisplayText } from "../core.js";
+import type { OpenCodeZenPayload, UsageBucket, UsageReport } from "../types.js";
+
+const ZEN_WINDOWS = [
+	{ key: "rolling", label: "Rolling" },
+	{ key: "weekly", label: "Weekly" },
+	{ key: "monthly", label: "Monthly" },
+] as const;
+
+export function normalizeOpenCodeZenPayload(
+	payload: OpenCodeZenPayload,
+	capturedAt: number,
+): UsageReport {
+	const usage = asObject(payload.usage);
+	if (!usage) throw new Error("OpenCode Zen usage response was not an object.");
+
+	const buckets: UsageBucket[] = [];
+	const notes: string[] = [];
+	for (const window of ZEN_WINDOWS) {
+		const raw = asObject(usage[window.key]);
+		if (!raw) continue;
+		const status = asString(raw.status);
+		if (status !== "ok") {
+			notes.push(`${window.label} window unavailable (${status ?? "unknown status"}).`);
+			continue;
+		}
+		const used = asNonnegativeNumber(raw.percent);
+		if (used === undefined) continue;
+		const resetsAt = asEpochSeconds(raw.resetsAt);
+		buckets.push({
+			id: window.key,
+			label: `${window.label} window`,
+			used,
+			remaining: 100 - clampPercent(used),
+			limit: 100,
+			unit: "percent",
+			...(resetsAt !== undefined ? { resetsAt } : {}),
+		});
+	}
+	if (buckets.length === 0) {
+		throw new Error("OpenCode Zen usage endpoint returned no displayable usage data.");
+	}
+
+	return {
+		providerId: "opencode-go",
+		providerName: "OpenCode Go",
+		capturedAt,
+		source: "opencode-zen-usage",
+		semantics: {
+			kind: "consumer-subscription",
+			label: "OpenCode Zen plan usage",
+		},
+		buckets,
+		metrics: [],
+		...(notes.length > 0 ? { notes } : {}),
+	};
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	return sanitizeDisplayText(value, 80) || undefined;
+}
+
+function asNonnegativeNumber(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
+	return value;
+}
+
+function asEpochSeconds(value: unknown): number | undefined {
+	if (typeof value !== "string" || !value.trim()) return undefined;
+	const parsed = Date.parse(value);
+	if (Number.isNaN(parsed)) return undefined;
+	return Math.floor(parsed / 1000);
+}
+
+function clampPercent(value: number): number {
+	return Math.min(100, Math.max(0, value));
+}

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -3,10 +3,12 @@ import { type ExtensionContext, readStoredCredential } from "@earendil-works/pi-
 import { errorMessage, fingerprintResolvedAuth, redactUsageError } from "./core.js";
 import { normalizeCodexBackendPayload } from "./providers/codex.js";
 import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
+import { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
 import { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
 import type {
 	CodexBackendPayload,
 	GitHubCopilotUsagePayload,
+	OpenCodeZenPayload,
 	OpenRouterKeyPayload,
 	PiModel,
 	ResolvedUsageAuth,
@@ -72,6 +74,21 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 				"OpenRouter key endpoint",
 			);
 			return normalizeOpenRouterKeyPayload(payload as OpenRouterKeyPayload, Date.now());
+		},
+	},
+	{
+		id: "opencode-go",
+		displayName: "OpenCode Go",
+		semantics: { kind: "consumer-subscription", label: "OpenCode Zen plan usage" },
+		async query(auth, signal, timeoutMs) {
+			const payload = await fetchProviderJson(
+				opencodeUsageUrl(auth.model.baseUrl),
+				auth,
+				signal,
+				timeoutMs,
+				"OpenCode Zen usage endpoint",
+			);
+			return normalizeOpenCodeZenPayload(payload as OpenCodeZenPayload, Date.now());
 		},
 	},
 ];
@@ -393,6 +410,7 @@ function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
 		const url = new URL(value);
 		if (providerId === "openai-codex") return url.origin === "https://chatgpt.com";
 		if (providerId === "openrouter") return url.origin === "https://openrouter.ai";
+		if (providerId === "opencode-go") return url.origin === "https://opencode.ai";
 		if (providerId === "github-copilot") {
 			return (
 				url.protocol === "https:" && /^api\.[a-z0-9-]+\.githubcopilot\.com$/u.test(url.hostname)
@@ -416,6 +434,12 @@ function headerValue(
 
 function hasHeader(headers: Record<string, string>, name: string): boolean {
 	return Object.keys(headers).some((key) => key.toLowerCase() === name.toLowerCase());
+}
+
+function opencodeUsageUrl(baseUrl: string | undefined): string {
+	const base = baseUrl?.trim().replace(/\/+$/u, "");
+	if (!base) throw new Error("OpenCode Go model base URL is unavailable.");
+	return `${base}/usage`;
 }
 
 function isAbortError(error: unknown): boolean {

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -93,6 +93,10 @@ export type OpenRouterKeyPayload = {
 	data?: unknown;
 };
 
+export type OpenCodeZenPayload = {
+	usage?: unknown;
+};
+
 export type CodexBackendPayload = {
 	plan_type?: unknown;
 	rate_limit?: unknown;

--- a/packages/pi-usage/test/opencode-zen.test.ts
+++ b/packages/pi-usage/test/opencode-zen.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	formatUsageReport,
+	formatUsageStatusline,
+	normalizeOpenCodeZenPayload,
+} from "../src/index.js";
+
+const ZEN_PAYLOAD = {
+	usage: {
+		rolling: { status: "ok", percent: 0, resetsAt: "2026-08-15T12:34:04.072Z" },
+		weekly: { status: "ok", percent: 4, resetsAt: "2026-08-17T00:00:00.072Z" },
+		monthly: { status: "ok", percent: 2, resetsAt: "2026-09-12T16:44:54.072Z" },
+	},
+};
+
+test("OpenCode Zen adapter normalizes rolling, weekly, and monthly windows", () => {
+	const report = normalizeOpenCodeZenPayload(ZEN_PAYLOAD, 500);
+
+	assert.equal(report.providerId, "opencode-go");
+	assert.equal(report.providerName, "OpenCode Go");
+	assert.equal(report.semantics.kind, "consumer-subscription");
+	assert.equal(report.buckets.length, 3);
+
+	const rolling = report.buckets.find((bucket) => bucket.id === "rolling");
+	assert.deepEqual(rolling?.used, 0);
+	assert.deepEqual(rolling?.remaining, 100);
+	assert.deepEqual(rolling?.resetsAt, Math.floor(Date.parse("2026-08-15T12:34:04.072Z") / 1000));
+
+	const weekly = report.buckets.find((bucket) => bucket.id === "weekly");
+	assert.deepEqual(weekly?.used, 4);
+	assert.deepEqual(weekly?.remaining, 96);
+
+	const monthly = report.buckets.find((bucket) => bucket.id === "monthly");
+	assert.deepEqual(monthly?.used, 2);
+	assert.deepEqual(monthly?.remaining, 98);
+
+	assert.equal(formatUsageStatusline(report), "zen 0% r 4% w 2% m");
+	assert.match(formatUsageReport(report, "current"), /OpenCode Go Usage · Current/);
+	assert.match(formatUsageReport(report, "current"), /Rolling window:\s+0% used/);
+	assert.match(formatUsageReport(report, "current"), /Weekly window:\s+4% used/);
+	assert.match(formatUsageReport(report, "current"), /Monthly window:\s+2% used/);
+});
+
+test("OpenCode Zen adapter reports non-ok windows as unavailable notes", () => {
+	const report = normalizeOpenCodeZenPayload(
+		{
+			usage: {
+				rolling: { status: "ok", percent: 10, resetsAt: "2026-08-15T12:34:04.072Z" },
+				weekly: { status: "error", percent: 4, resetsAt: "2026-08-17T00:00:00.072Z" },
+			},
+		},
+		600,
+	);
+
+	assert.equal(report.buckets.length, 1);
+	assert.equal(report.buckets[0]?.id, "rolling");
+	assert.match(report.notes?.join(" ") ?? "", /Weekly window unavailable/);
+	assert.equal(formatUsageStatusline(report), "zen 10% r");
+});
+
+test("OpenCode Zen adapter rejects empty or fully unavailable responses", () => {
+	assert.throws(() => normalizeOpenCodeZenPayload({}, 0), /not an object/);
+	assert.throws(
+		() =>
+			normalizeOpenCodeZenPayload(
+				{ usage: { rolling: { status: "error" }, weekly: { status: "error" } } },
+				0,
+			),
+		/no displayable usage data/,
+	);
+});

--- a/packages/pi-usage/test/opencode-zen.test.ts
+++ b/packages/pi-usage/test/opencode-zen.test.ts
@@ -42,7 +42,7 @@ test("OpenCode Zen adapter normalizes rolling, weekly, and monthly windows", () 
 	assert.match(formatUsageReport(report, "current"), /Monthly window:\s+2% used/);
 });
 
-test("OpenCode Zen adapter reports non-ok windows as unavailable notes", () => {
+test("OpenCode Zen adapter reports unknown-status windows as unavailable notes", () => {
 	const report = normalizeOpenCodeZenPayload(
 		{
 			usage: {
@@ -57,6 +57,46 @@ test("OpenCode Zen adapter reports non-ok windows as unavailable notes", () => {
 	assert.equal(report.buckets[0]?.id, "rolling");
 	assert.match(report.notes?.join(" ") ?? "", /Weekly window unavailable/);
 	assert.equal(formatUsageStatusline(report), "zen 10% r");
+});
+
+test("OpenCode Zen adapter displays rate-limited windows", () => {
+	const report = normalizeOpenCodeZenPayload(
+		{
+			usage: {
+				rolling: {
+					status: "rate-limited",
+					percent: 100,
+					resetsAt: "2026-08-15T12:34:04.072Z",
+				},
+				weekly: { status: "ok", percent: 4, resetsAt: "2026-08-17T00:00:00.072Z" },
+			},
+		},
+		700,
+	);
+
+	assert.equal(report.buckets.length, 2);
+	assert.equal(report.buckets[0]?.id, "rolling");
+	assert.equal(report.buckets[0]?.used, 100);
+	assert.equal(report.buckets[0]?.remaining, 0);
+	assert.equal(report.notes, undefined);
+	assert.equal(formatUsageStatusline(report), "zen 100% r 4% w");
+	assert.match(formatUsageReport(report, "current"), /Rolling window:\s+100% used/);
+});
+
+test("OpenCode Zen adapter keeps fully rate-limited responses displayable", () => {
+	const report = normalizeOpenCodeZenPayload(
+		{
+			usage: {
+				rolling: { status: "rate-limited", percent: 100 },
+				weekly: { status: "rate-limited", percent: 100 },
+				monthly: { status: "rate-limited", percent: 100 },
+			},
+		},
+		800,
+	);
+
+	assert.equal(report.buckets.length, 3);
+	assert.equal(formatUsageStatusline(report), "zen 100% r 100% w 100% m");
 });
 
 test("OpenCode Zen adapter rejects empty or fully unavailable responses", () => {


### PR DESCRIPTION
## Summary
- Treat OpenCode Zen `rate-limited` windows as displayable quota data instead of unavailable notes.
- Add regression coverage for partially and fully rate-limited OpenCode Go responses.
- Add the missing `@narumitw/pi-usage` changeset for the new adapter behavior.

## Tests
- `npx vitest run packages/pi-usage/test/opencode-zen.test.ts`
- `npm --workspace @narumitw/pi-usage run check`
- `npx changeset status --since=origin/main --verbose`
- `npm --workspace @narumitw/pi-usage pack --dry-run`
- `npm run check` attempted; existing root `test/changesets-release.test.ts` fails because the installed Changesets CLI reports fixture packages are not in the workspace.

## Notes
- This PR is based on PR #772 and includes its OpenCode Go adapter changes plus the two review fixes.

Closes #772 