### PR TITLE
fix(langfuse): attribute observations to sessions

### DIFF
--- a/.changeset/quick-mice-trace.md
+++ b/.changeset/quick-mice-trace.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-langfuse": patch
+---
+
+Stamp the Langfuse session ID on every observation so session-level token and cost totals include generations.

--- a/docs/plans/archived/2026-08-16_pi-langfuse-session-id-plan.md
+++ b/docs/plans/archived/2026-08-16_pi-langfuse-session-id-plan.md
@@ -1,0 +1,71 @@
+# Pi Langfuse session attribution plan
+
+## Goal
+
+Ensure every Langfuse observation emitted by `@narumitw/pi-langfuse` carries the current Pi session ID so generation token and cost data aggregate into the correct Langfuse session.
+
+## Context
+
+Issue [#763](https://github.com/narumiruna/pi-extensions/issues/763) reports that only the root `pi.agent` observation receives `session.id` while the `pi.llm` generation carrying usage and cost does not.
+
+A live Langfuse Cloud reproduction with Pi 0.84.2, `@narumitw/pi-langfuse` 0.49.3, and Langfuse SDK 5.10.0 exported 490 tokens and $0.000534 for the trace but zero tokens and zero cost when filtered by the root session ID.
+
+The reproduction used `captureContent: false`, one non-sensitive provider request, and the isolated environment `issue-763-repro`.
+
+Langfuse SDK 5.10.0 defines `LangfuseOtelSpanAttributes.TRACE_SESSION_ID` as the per-span OpenTelemetry attribute `session.id`.
+
+The applicable extension-convention requirements are deterministic tests for changed behavior, a patch Changeset for published behavior, the repository CI-equivalent check, and explicit reporting of the live smoke result.
+
+## Architecture
+
+`TraceRecorder` owns the Pi session ID and creates the `pi.agent`, `pi.attempt`, `pi.turn`, `pi.llm`, `pi.tool.*`, and `pi.compaction` observations.
+
+`ProductionTraceBackend` owns translation from recorder attributes to Langfuse observations and native OpenTelemetry span attributes.
+
+The recorder will attach its session ID through one observation-creation helper, and the production backend will remove that extension-owned field before Langfuse observation serialization and set it directly as `session.id` on the native span.
+
+The root `updateTrace()` flow will remain responsible for trace name, trace input and output, metadata, tags, and schema version.
+
+## Non-Goals
+
+- Do not invent or add a Langfuse user ID.
+- Do not refactor the event-driven recorder into a `propagateAttributes()` callback scope.
+- Do not change the `pi-langfuse.json` schema or settings behavior.
+- Do not change observation hierarchy, usage, cost, metadata, content capture, or lifecycle behavior.
+- Do not include the contributor branch's unrelated root `prepare` script change.
+
+## Risks
+
+- Passing `sessionId` into Langfuse's normal observation serializer could silently discard it, so the production backend must extract it and set the native OpenTelemetry attribute explicitly.
+- Updating only `pi.llm` could leave the trace internally inconsistent, so one helper and a test covering all six observation kinds must enforce complete attribution.
+- Changing root trace updates could regress trace naming or metadata, so the existing root `updateTrace()` behavior must remain intact and the current runtime assertions must continue passing.
+- The post-fix Cloud smoke uses an external provider and Langfuse service, so it must use one bounded request, `captureContent: false`, and honest reporting if either service is unavailable.
+
+## Plan
+
+- [x] Add a regression test to `packages/pi-langfuse/test/recorder.test.ts` that creates all six observation kinds and expects each initial attribute set to contain the same session ID; the focused run failed at `recorder.test.ts:738` because the actual session ID was `undefined`.
+- [x] Add an integration assertion to `packages/pi-langfuse/test/runtime.test.ts` that expects every finished OpenTelemetry span to contain `session.id = runtime-session`; the focused run failed at `runtime.test.ts:137` because the actual span attribute was `undefined`.
+- [x] Add one observation-creation helper to `packages/pi-langfuse/src/tracing.ts` that forces `this.context.sessionId` onto every backend start, and route the six existing observation creation paths through it; the recorder test passed with 15 tests.
+- [x] Update `packages/pi-langfuse/src/runtime.ts` to extract `sessionId` before Langfuse observation serialization and set `LangfuseOtelSpanAttributes.TRACE_SESSION_ID` on the created native span; the runtime test passed with 3 tests.
+- [x] Add a patch Changeset for `@narumitw/pi-langfuse` that describes restored session-level token and cost aggregation; `npm run changeset:status` reports the planned 0.49.4 patch.
+- [x] Add the repository's `bug` label to issue #763 after the deterministic regression test confirms the defect; `gh issue view 763 --json labels` reports `bug`.
+- [x] Run `npm run check --workspace @narumitw/pi-langfuse`; Biome checked 15 files and the package TypeScript check passed.
+- [x] Run `npm exec vitest -- run packages/pi-langfuse/test/recorder.test.ts packages/pi-langfuse/test/runtime.test.ts`; both files passed with 18 tests.
+- [x] Run the CI-equivalent `npm run check`; build, Biome over 1,124 files, boundaries, all workspace typechecks, and 3,798 tests passed.
+- [x] Run `just pack langfuse`; the dry run contained only `LICENSE`, `README.md`, `package.json`, and the six expected `src/*.ts` files.
+- [x] Run one post-fix Langfuse Cloud smoke with `captureContent: false` and environment `issue-763-fixed`; Observations API v2 reported matching root session IDs for `pi.agent`, `pi.attempt`, `pi.turn`, and `pi.llm`.
+- [x] Compare post-fix Metrics API totals filtered by trace ID and session ID; both reported 488 tokens and $0.000527999999.
+- [x] Audit the final diff against `docs/extension-conventions.md`, issue #763 acceptance criteria, and the touched-area checklist; the change affects only synchronous observation attribution, adds the required deterministic tests and Changeset, preserves lifecycle and settings behavior, and has no deviation or unverified path.
+
+## Completion Checklist
+
+- [x] Every recorder-created observation carries the current Pi session ID.
+- [x] Every production OpenTelemetry span carries the matching `session.id` attribute.
+- [x] Generation usage and cost values remain unchanged.
+- [x] Observation hierarchy and root trace attributes remain unchanged.
+- [x] Recorder and runtime regression tests pass.
+- [x] Package checks and the repository CI-equivalent gate pass.
+- [x] The patch Changeset is valid and issue #763 has the `bug` label.
+- [x] The package dry run contains only intended publishable files.
+- [x] The post-fix Cloud smoke shows matching trace and session token and cost totals.
+- [x] The final diff contains no unrelated changes.

--- a/packages/pi-langfuse/src/runtime.ts
+++ b/packages/pi-langfuse/src/runtime.ts
@@ -51,9 +51,7 @@ class ProductionObservation implements Observation {
 		if (name !== undefined) {
 			this.native.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_NAME, name);
 		}
-		if (sessionId !== undefined) {
-			this.native.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_SESSION_ID, sessionId);
-		}
+		applySessionId(this.native, sessionId);
 		if (tags !== undefined) {
 			this.native.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_TAGS, tags);
 		}
@@ -86,11 +84,14 @@ class ProductionTraceBackend implements TraceBackend {
 		attributes: ObservationAttributes,
 		options: { asType: ObservationType; parent?: Observation },
 	): Observation {
+		const { sessionId, ...observationAttributes } = attributes;
 		const parent = options.parent;
-		if (parent instanceof ProductionObservation) {
-			return new ProductionObservation(startChild(parent.native, name, attributes, options.asType));
-		}
-		return new ProductionObservation(startRoot(name, attributes, options.asType));
+		const native =
+			parent instanceof ProductionObservation
+				? startChild(parent.native, name, observationAttributes, options.asType)
+				: startRoot(name, observationAttributes, options.asType);
+		applySessionId(native, sessionId);
+		return new ProductionObservation(native);
 	}
 
 	async forceFlush(): Promise<void> {
@@ -176,6 +177,12 @@ const defaultFactories: RuntimeFactories = {
 	createProvider: (processor) => new NodeTracerProvider({ spanProcessors: [processor] }),
 	selectProvider: setLangfuseTracerProvider,
 };
+
+function applySessionId(observation: LangfuseObservation, sessionId: string | undefined): void {
+	if (sessionId !== undefined) {
+		observation.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_SESSION_ID, sessionId);
+	}
+}
 
 function startRoot(
 	name: string,

--- a/packages/pi-langfuse/src/tracing.ts
+++ b/packages/pi-langfuse/src/tracing.ts
@@ -234,6 +234,14 @@ export class TraceRecorder {
 		private readonly context: RecorderContext,
 	) {}
 
+	private startObservation(
+		name: string,
+		attributes: ObservationAttributes,
+		options: { asType: ObservationType; parent?: Observation },
+	): Observation {
+		return this.backend.start(name, { ...attributes, sessionId: this.context.sessionId }, options);
+	}
+
 	hasActiveTrace(): boolean {
 		return this.root !== undefined;
 	}
@@ -275,7 +283,7 @@ export class TraceRecorder {
 				? "git:detached"
 				: undefined;
 
-		this.root = this.backend.start("pi.agent", attributes, { asType: "agent" });
+		this.root = this.startObservation("pi.agent", attributes, { asType: "agent" });
 		this.root.updateTrace?.({
 			name: "pi.trace",
 			sessionId: this.context.sessionId,
@@ -296,7 +304,7 @@ export class TraceRecorder {
 		this.lastAssistant = undefined;
 		this.unresolvedToolErrors = 0;
 		this.attemptIndex = index;
-		this.attempt = this.backend.start(
+		this.attempt = this.startObservation(
 			"pi.attempt",
 			{
 				metadata: {
@@ -325,7 +333,7 @@ export class TraceRecorder {
 		if (this.turn) this.closeTurn("Interrupted by the next Pi turn.", "ERROR");
 		this.counters.turns += 1;
 		this.turnIndex = turnIndex;
-		this.turn = this.backend.start(
+		this.turn = this.startObservation(
 			"pi.turn",
 			{ metadata: { "pi.turn.index": turnIndex }, version: TRACE_SCHEMA_VERSION },
 			{ asType: "span", parent: this.attempt ?? this.root },
@@ -372,7 +380,7 @@ export class TraceRecorder {
 			...(input.model?.api ? { "pi.request.api": input.model.api } : {}),
 			...(input.thinkingLevel ? { "pi.request.thinking_level": input.thinkingLevel } : {}),
 		};
-		const observation = this.backend.start(
+		const observation = this.startObservation(
 			"pi.llm",
 			{
 				...(input.payload !== undefined ? { input: this.capture(input.payload) } : {}),
@@ -559,7 +567,7 @@ export class TraceRecorder {
 		this.closeCompaction("Interrupted by another Pi compaction.");
 		this.counters.compactions += 1;
 		this.compaction = {
-			observation: this.backend.start(
+			observation: this.startObservation(
 				"pi.compaction",
 				{
 					metadata: {
@@ -711,7 +719,7 @@ export class TraceRecorder {
 	}
 
 	private startToolObservation(toolCallId: string, toolName: string, args?: unknown): Observation {
-		return this.backend.start(
+		return this.startObservation(
 			`pi.tool.${toolName}`,
 			{
 				...(args !== undefined ? { input: this.capture(args) } : {}),

--- a/packages/pi-langfuse/test/recorder.test.ts
+++ b/packages/pi-langfuse/test/recorder.test.ts
@@ -691,3 +691,50 @@ test("TraceRecorder omits generation request content when capture is disabled", 
 		"[content capture disabled]",
 	);
 });
+
+test("TraceRecorder stamps the session id on every observation", () => {
+	const backend = new FakeBackend();
+	const recorder = new TraceRecorder(backend, {
+		sessionId: "session-42",
+		cwd: "/workspace",
+		mode: "tui",
+		captureContent: true,
+	});
+
+	recorder.beginAgent({ prompt: "trace everything" });
+	recorder.beginAttempt();
+	recorder.beginTurn(0);
+	recorder.beginGeneration({ payloadStage: "before_provider_request" });
+	recorder.finishAssistant({
+		role: "assistant",
+		content: "done",
+		usage: { input: 10, output: 5, totalTokens: 15 },
+		stopReason: "stop",
+	});
+	recorder.beginTool("call-1", "bash", { command: "ls" });
+	recorder.finishTool("call-1", { content: "ok" });
+	recorder.beginCompaction({
+		reason: "threshold",
+		willRetry: false,
+		messagesToSummarize: 1,
+		turnPrefixMessages: 0,
+		branchEntries: 0,
+		isSplitTurn: false,
+	});
+	recorder.finishCompaction({ reason: "threshold", willRetry: false, fromExtension: false });
+	recorder.finishTurn(0, { message: { role: "assistant" }, toolResultCount: 1 });
+	recorder.finishAttempt({ role: "assistant", content: "done", stopReason: "stop" });
+	recorder.settle();
+
+	assert.deepEqual(backend.observations.map(({ name }) => name).sort(), [
+		"pi.agent",
+		"pi.attempt",
+		"pi.compaction",
+		"pi.llm",
+		"pi.tool.bash",
+		"pi.turn",
+	]);
+	for (const observation of backend.observations) {
+		assert.equal(observation.attributes.sessionId, "session-42");
+	}
+});

--- a/packages/pi-langfuse/test/runtime.test.ts
+++ b/packages/pi-langfuse/test/runtime.test.ts
@@ -134,6 +134,7 @@ test("isolated runtime preserves the global provider and exports native observat
 		"tool",
 	]);
 	for (const span of spans) assert.equal(span.attributes["langfuse.version"], "2");
+	for (const span of spans) assert.equal(span.attributes["session.id"], "runtime-session");
 	const agent = spans.find((span) => span.name === "pi.agent");
 	const attempt = spans.find((span) => span.name === "pi.attempt");
 	const turn = spans.find((span) => span.name === "pi.turn");


### PR DESCRIPTION
## Summary

- Stamp the Pi session ID on every Langfuse observation.
- Extract the extension-owned session field before Langfuse serialization and set native OpenTelemetry `session.id`.
- Add recorder and production-runtime regressions plus a patch Changeset.

Closes #763.

## Verification

- Red tests failed with `sessionId` and `session.id` equal to `undefined` before the fix.
- `npm exec vitest -- run packages/pi-langfuse/test/recorder.test.ts packages/pi-langfuse/test/runtime.test.ts` passed 18 tests.
- `npm run check --workspace @narumitw/pi-langfuse` passed Biome and package typecheck.
- `npm run check` passed build, Biome over 1,124 files, boundaries, all workspace typechecks, and 3,798 tests across 379 files.
- `npm run changeset:status` reports the `@narumitw/pi-langfuse` patch.
- `just pack langfuse` included only the expected manifest, notices, README, and six source files.
- Langfuse Cloud smoke with `captureContent: false` gave every observation the root session ID.
- Cloud trace and session metrics both reported 488 tokens and $0.000527999999 after the fix.

## Risk and audit

- Existing trace hierarchy, usage, cost, root trace attributes, settings, and lifecycle behavior are unchanged.
- The diff was audited against `docs/extension-conventions.md` and the touched-area checklist.
- No unverified paths remain, and no package was published.

## Plan

- [Completed implementation plan](https://github.com/narumiruna/pi-extensions/blob/narumiruna/fix/pi-langfuse-session-attribution/docs/plans/archived/2026-08-16_pi-langfuse-session-id-plan.md)
