### PR TITLE
fix(langfuse): apply session ids on updates

### DIFF
--- a/.changeset/quick-mice-trace.md
+++ b/.changeset/quick-mice-trace.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-langfuse": patch
 ---
 
-Stamp the Langfuse session ID on every observation so session-level token and cost totals include generations.
+Stamp the Langfuse session ID on every observation and apply session updates so session-level token and cost totals include generations.

--- a/packages/pi-langfuse/src/runtime.ts
+++ b/packages/pi-langfuse/src/runtime.ts
@@ -39,7 +39,9 @@ class ProductionObservation implements Observation {
 	constructor(readonly native: LangfuseObservation) {}
 
 	update(attributes: ObservationAttributes): Observation {
-		this.native.updateOtelSpanAttributes(attributes as LangfuseObservationAttributes);
+		const { sessionId, ...observationAttributes } = attributes;
+		this.native.updateOtelSpanAttributes(observationAttributes as LangfuseObservationAttributes);
+		applySessionId(this.native, sessionId);
 		return this;
 	}
 

--- a/packages/pi-langfuse/test/runtime.test.ts
+++ b/packages/pi-langfuse/test/runtime.test.ts
@@ -185,6 +185,16 @@ test("isolated runtime preserves the global provider and exports native observat
 		compaction?.attributes["langfuse.observation.metadata.pi.compaction.from_extension"],
 		"false",
 	);
+
+	const updatedSession = backend.start("updated-session", {}, { asType: "span" });
+	updatedSession.update({ sessionId: "updated-session" });
+	updatedSession.end();
+	await backend.forceFlush();
+	const updatedSessionSpan = exporter
+		.getFinishedSpans()
+		.find((span) => span.name === "updated-session");
+	assert.equal(updatedSessionSpan?.attributes["session.id"], "updated-session");
+
 	await backend.shutdown();
 	await backend.shutdown();
 	await existingGlobalProvider.shutdown();


### PR DESCRIPTION
## Summary

- Apply `sessionId` passed through `Observation.update()` as the native OpenTelemetry `session.id` attribute.
- Remove the extension-owned field before Langfuse observation serialization instead of letting the SDK silently discard it.
- Extend the existing runtime regression and pending Changeset.

Follow-up to #776 and #763.

## Verification

- The new regression failed before the fix because the updated span's `session.id` was `undefined`.
- `npm exec vitest -- run packages/pi-langfuse/test/runtime.test.ts` passed 3 tests after the fix.
- `npm run check --workspace @narumitw/pi-langfuse` passed Biome and package typecheck.
- The first repository gate encountered local 1Password signing-agent failures in 19 tests that create temporary Git commits.
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm run check` passed build, Biome, boundaries, all workspace typechecks, and 3,798 tests.
- `npm run changeset:status` reports the existing `@narumitw/pi-langfuse` patch.
- `just pack langfuse` included only the expected nine publishable files.

## Risk and audit

- Session attribution at observation start and root trace updates remains unchanged.
- Updates without `sessionId` remain no-ops for the existing span attribute, as covered by the recorder's later observation updates.
- No async lifecycle, settings, hierarchy, usage, cost, or content-capture behavior changed.
- No package was published.
