### PR TITLE
fix: allow production installs without husky

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,3 +1,5 @@
+// Follow Husky's guidance for production and CI installs:
+// https://typicode.github.io/husky/how-to.html#ci-server-and-docker
 if (process.env.NODE_ENV === "production" || process.env.CI === "true") {
 	process.exit(0);
 }

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,6 @@
+if (process.env.NODE_ENV === "production" || process.env.CI === "true") {
+	process.exit(0);
+}
+
+const husky = (await import("husky")).default;
+console.log(husky());

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"smoke:pi-fleet:ghostty": "cd packages/pi-fleet && tsc -p tsconfig.process-smoke.json && node ../../node_modules/.cache/pi-fleet-process/scripts/ghostty-smoke.js",
 		"check": "npm run build && node ./scripts/run-checks.mjs",
 		"precommit": "npm run biome:check && npm run typecheck",
-		"prepare": "husky",
+		"prepare": "node .husky/install.mjs",
 		"changeset": "changeset",
 		"changeset:status": "changeset status --verbose",
 		"version-packages": "changeset version && npm install --package-lock-only --ignore-scripts",


### PR DESCRIPTION
## Summary

- Route the root `prepare` lifecycle through Husky's official conditional install script.
- Skip Git hook setup in production and CI before importing the development-only Husky package.
- Preserve automatic hook setup for normal local development installs.
- Fix the unrelated Pi Git-package installation failure reported in [issue #763's discussion](https://github.com/narumiruna/pi-extensions/issues/763#issuecomment-5300340997).

## Verification

- `npm run prepare` configured `core.hooksPath=.husky/_` for a development install.
- A clean temporary `npm install --omit=dev` completed with 386 packages and no installed Husky package.
- `CI=true node .husky/install.mjs` completed in a temporary fixture without Husky installed.
- `npm run check` passed Biome over 1,125 files, package boundaries, all workspace typechecks, and 3,798 tests across 379 files.
- An isolated `pi install git:github.com/narumiruna/pi-extensions@477f1ca84c81dd7999677c0bcb9dd13fe3ac765b` completed successfully without installing Husky.
- `npm run changeset:status` passed; no changeset was added because this only changes the private root package's installation tooling.

## Risk

The production skip relies on npm's documented behavior of setting `NODE_ENV=production` for lifecycle scripts when `dev` dependencies are omitted.
The exact Pi Git-install path was verified, and no remaining path is unverified.
