### PR TITLE
feat: add pi tui kit showcase

### DIFF
--- a/docs/plans/archived/2026-08-16_pi-tui-kit-showcase-plan.md
+++ b/docs/plans/archived/2026-08-16_pi-tui-kit-showcase-plan.md
@@ -1,0 +1,53 @@
+# Pi TUI Kit Showcase Plan
+
+## Goal
+
+Add a repository-only interactive showcase that lets maintainers open one Pi command and inspect each public `@narumitw/pi-tui-kit` presentation pattern in a real TUI session.
+
+## Context
+
+`@narumitw/pi-tui-kit` is a reusable library and must not declare `pi.extensions`.
+
+The showcase therefore belongs in a separate private experimental extension package.
+
+The package will use only public Kit exports, so it doubles as a realistic consumer example.
+
+The showcase owns no persistent settings; its settings screen mutates only in-memory demo state.
+
+## Architecture
+
+- Add `packages/pi-tui-kit-showcase/` as a private experimental extension package.
+- Keep `src/index.ts` as the required thin default-export forwarder.
+- Put the command factory in `src/showcase.ts` and the declarative menu in `src/menu.ts`.
+- Register `/tui-kit-showcase` with no arguments as the primary TUI demo route.
+- Use `defineMenu()` and `runMenu()` for actions, detail, browse, choice, settings, input, review, and multi-select screens.
+- Use standalone `runTask()`, `runConfirmation()`, and `runLiveChoice()` from action handlers so those wrappers are visible from the same menu.
+- Keep state in memory per session and abort owned work on session shutdown or replacement.
+- Add `just showcase-tui-kit` as the local script that builds Kit and runs only this showcase extension.
+
+## Non-Goals
+
+- Do not publish the showcase package.
+- Do not add it to the root stable `pi.extensions` manifest or the default `just dev` extension set.
+- Do not deep-import Kit internals.
+- Do not add persistent settings, migrations, network calls, or external dependencies.
+
+## Plan
+
+- [x] Review extension and settings conventions, Kit package boundaries, and representative Kit consumers before editing; evidence: `docs/extension-conventions.md`, `docs/extension-settings.md`, `packages/pi-tui-kit/AGENTS.md`, `packages/pi-fleet` metadata and menu patterns were inspected.
+- [x] Add a focused failing showcase menu test using Kit's public test boundary; evidence: `npx vitest run packages/pi-tui-kit-showcase/test/showcase.test.ts` failed with `Cannot find module '../src/index.js'` before implementation.
+- [x] Add package metadata, README, license, TypeScript config, thin entrypoint, command factory, in-memory state, and menu screens under `packages/pi-tui-kit-showcase/`; evidence: package files exist, `src/index.ts` forwards default export, `src/showcase.ts` lazy-loads `src/runtime.ts`, and `rg` review shows source uses public `@narumitw/pi-tui-kit` exports only.
+- [x] Add a `just showcase-tui-kit` recipe without changing `just dev`; evidence: `just --list | rg "showcase-tui-kit|try|dev"` lists the new recipe and the existing `dev`/`try` recipes.
+- [x] Run focused package tests and typechecking; evidence: `npx vitest run packages/pi-tui-kit-showcase/test/showcase.test.ts` passed 4 tests, `npm --workspace @narumitw/pi-tui-kit-showcase run typecheck` passed, and `npm --workspace @narumitw/pi-tui-kit-showcase run check` passed.
+- [x] Run boundary checks and the repository CI-equivalent gate without concurrent Kit builds; evidence: `npm run check:boundaries` passed with 1 library and 28 active extensions, and `npm run check` passed with 380 files and 3,802 tests.
+- [x] Run a package dry-run and a non-interactive Pi entrypoint smoke where practical; evidence: `npm --workspace @narumitw/pi-tui-kit-showcase pack --dry-run --json` produced 7 declared files, and `PI_CODING_AGENT_DIR=$(mktemp -d) pi --no-extensions --no-skills --no-session -e ./packages/pi-tui-kit-showcase --list-models` exited 0 with the expected no-models message.
+- [x] Audit the final diff against touched extension conventions, settings non-persistence, Kit runtime boundary, cancellation/disposal, non-TUI behavior, documentation, and verification requirements; evidence: final audit found the package private and experimental, absent from root stable `pi.extensions`, no persistent settings path, lazy Kit runtime loading, session-owner abort tests, RPC unsupported-mode tests, README warning, pack contents, and passing gate evidence.
+
+## Completion Checklist
+
+- [x] The showcase opens from `/tui-kit-showcase` in TUI mode and links to every intended screen or standalone interaction; evidence: focused menu test validates all eight standard screens plus Task loader, Confirmation, and Live choice rows, and the Pi entrypoint smoke loads the package.
+- [x] Print and JSON modes do not attempt custom TUI or ad hoc protocol output; evidence: command mode guard throws before runtime loading outside TUI/RPC and writes no direct output.
+- [x] RPC mode has an observable unsupported-mode notification rather than starting the visual showcase; evidence: focused command test asserts the notification and proves the runtime loader is not called.
+- [x] User cancellation, session shutdown, and replacement abort owned work; evidence: command lifecycle test asserts `session_shutdown` aborts the supplied signal and flips `isCurrent()` false, and menu/standalone flows pass the owner signal into Kit runners.
+- [x] The package remains private, experimental, and absent from the root stable `pi.extensions` list; evidence: manifest metadata, unchanged root `package.json`, and `npm run check:boundaries`.
+- [x] All required checks and smokes are recorded, or deviations are explicitly named; evidence: focused tests, package check, boundary check, root check, pack dry run, changeset status, diff check, and Pi smoke are recorded; live interactive traversal is intentionally left to `just showcase-tui-kit` because this agent terminal is non-interactive.

--- a/justfile
+++ b/justfile
@@ -79,6 +79,11 @@ try name: (_validate-package-name name)
     npm --workspace {{ quote("@narumitw/pi-" + name) }} run build --if-present
     pi -e {{ quote("./packages/pi-" + name) }}
 
+# Open the private Pi TUI Kit showcase extension from this working tree
+showcase-tui-kit:
+    npm --workspace @narumitw/pi-tui-kit run build
+    pi -e ./packages/pi-tui-kit-showcase
+
 # Run Pi Chat's opt-in real local DHT and process-boundary smoke
 smoke-chat-network:
     npm run smoke:chat-network

--- a/justfile
+++ b/justfile
@@ -82,7 +82,7 @@ try name: (_validate-package-name name)
 # Open the private Pi TUI Kit showcase extension from this working tree
 showcase-tui-kit:
     npm --workspace @narumitw/pi-tui-kit run build
-    pi -e ./packages/pi-tui-kit-showcase
+    pi --no-extensions --no-skills -e ./packages/pi-tui-kit-showcase
 
 # Run Pi Chat's opt-in real local DHT and process-boundary smoke
 smoke-chat-network:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2509,6 +2509,10 @@
 			"resolved": "packages/pi-tui-kit",
 			"link": true
 		},
+		"node_modules/@narumitw/pi-tui-kit-showcase": {
+			"resolved": "packages/pi-tui-kit-showcase",
+			"link": true
+		},
 		"node_modules/@narumitw/pi-usage": {
 			"resolved": "packages/pi-usage",
 			"link": true
@@ -9294,6 +9298,23 @@
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
+			}
+		},
+		"packages/pi-tui-kit-showcase": {
+			"name": "@narumitw/pi-tui-kit-showcase",
+			"version": "0.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.54.0"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.5.8",
+				"@earendil-works/pi-coding-agent": "0.84.2",
+				"@narumitw/pi-tui-kit": "^0.54.0",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*"
 			}
 		},
 		"packages/pi-tui-kit/node_modules/highlight.js": {

--- a/packages/pi-tui-kit-showcase/LICENSE
+++ b/packages/pi-tui-kit-showcase/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-tui-kit-showcase/README.md
+++ b/packages/pi-tui-kit-showcase/README.md
@@ -1,0 +1,87 @@
+# 🧭 Pi TUI Kit Showcase
+
+[![private](https://img.shields.io/badge/npm-private-lightgrey)](./package.json) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+> [!WARNING]
+> Pi TUI Kit Showcase is experimental and private.
+> It is a local maintainer demo, not a published extension.
+
+`@narumitw/pi-tui-kit-showcase` opens an interactive local demo of public `@narumitw/pi-tui-kit` screens and standalone interactions.
+
+It stores no persistent settings.
+
+It uses only in-memory state for the current demo session.
+
+## ✨ Features
+
+- Shows `actions`, `detail`, `browse`, `choice`, `settings`, `input`, `review`, and `multiSelect` menu screens.
+- Shows standalone `runTask()`, `runConfirmation()`, and `runLiveChoice()` interactions from the same entry menu.
+- Demonstrates disabled rows, busy labels, searchable choices, exact browse documents, adaptive review, bulk multi-select actions, and selected-row descriptions.
+- Keeps all side effects inside the demo process.
+- Lazy-loads the Kit runtime only after the command runs.
+
+## 📦 Install
+
+This package is private and is not meant for npm publication.
+
+Load it from a local checkout:
+
+```bash
+pi --no-extensions --no-skills --no-session -e ./packages/pi-tui-kit-showcase
+```
+
+The repository shortcut builds Kit first and then loads only this showcase extension:
+
+```bash
+just showcase-tui-kit
+```
+
+## 🚀 Quick start
+
+Run this command in Pi TUI mode:
+
+```text
+/tui-kit-showcase
+```
+
+Choose any row to inspect a presentation pattern.
+
+The standalone task, confirmation, and live-choice rows close the menu, show the standalone interaction, then reopen the menu when the interaction finishes.
+
+RPC mode reports that the showcase requires TUI mode.
+
+Print and JSON modes reject the command without writing ad hoc output.
+
+## ⚙️ Settings
+
+The showcase has no extension-owned settings file.
+
+The **Settings screen** row edits in-memory demo values only.
+
+Those values reset when the command starts again or the session owner is replaced.
+
+## 💬 Commands
+
+### `/tui-kit-showcase`
+
+Opens the showcase menu in TUI mode.
+
+The command accepts no arguments.
+
+Unknown arguments are rejected with usage text.
+
+## 🗂️ Package layout
+
+- `src/index.ts` — thin Pi extension entrypoint forwarder.
+- `src/showcase.ts` — command registration, lazy runtime loading, mode handling, and session owner cancellation.
+- `src/runtime.ts` — menu loop plus standalone Kit interactions.
+- `src/menu.ts` — declarative showcase screens and in-memory demo state.
+- `test/` — focused package behavior tests.
+
+## 🔎 Keywords
+
+pi, pi-extension, tui, showcase, demo
+
+## 📄 License
+
+MIT © narumiruna

--- a/packages/pi-tui-kit-showcase/package.json
+++ b/packages/pi-tui-kit-showcase/package.json
@@ -1,0 +1,50 @@
+{
+	"name": "@narumitw/pi-tui-kit-showcase",
+	"version": "0.0.0",
+	"description": "Private interactive showcase for Pi TUI Kit screens and interactions.",
+	"type": "module",
+	"license": "MIT",
+	"private": true,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"tui",
+		"showcase"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"piExtension": {
+		"lifecycle": "experimental"
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.54.0"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.8",
+		"@earendil-works/pi-coding-agent": "0.84.2",
+		"@narumitw/pi-tui-kit": "^0.54.0",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "packages/pi-tui-kit-showcase"
+	}
+}

--- a/packages/pi-tui-kit-showcase/src/index.ts
+++ b/packages/pi-tui-kit-showcase/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./showcase.js";

--- a/packages/pi-tui-kit-showcase/src/menu.ts
+++ b/packages/pi-tui-kit-showcase/src/menu.ts
@@ -1,0 +1,441 @@
+import { defineMenu, type MenuDefinition } from "@narumitw/pi-tui-kit";
+
+export type ShowcaseScreen =
+	| "main"
+	| "actions"
+	| "detail"
+	| "browse"
+	| "choice"
+	| "settings"
+	| "input"
+	| "review"
+	| "multiSelect";
+
+export type ShowcaseAction =
+	| "recordAction"
+	| "setProfile"
+	| "setSetting"
+	| "submitInput"
+	| "applyReview"
+	| "toggleFeature"
+	| "selectAllFeatures"
+	| "resetFeatures"
+	| "openTask"
+	| "openConfirmation"
+	| "openLiveChoice";
+
+export type ShowcaseStandaloneInteraction = "task" | "confirmation" | "liveChoice";
+
+export interface ShowcaseState {
+	profile: "Minimal" | "Balanced" | "Verbose";
+	density: "Comfortable" | "Compact";
+	accent: "Blue" | "Green" | "Purple";
+	inputText: string;
+	reviewApplied: boolean;
+	featureFlags: Record<"search" | "details" | "bulk", boolean>;
+	log: readonly string[];
+}
+
+export interface ShowcaseMenuRuntime {
+	requestStandalone(interaction: ShowcaseStandaloneInteraction): void;
+}
+
+export function createInitialShowcaseState(): ShowcaseState {
+	return {
+		profile: "Balanced",
+		density: "Comfortable",
+		accent: "Blue",
+		inputText: "",
+		reviewApplied: false,
+		featureFlags: {
+			search: true,
+			details: true,
+			bulk: false,
+		},
+		log: ["Open any row to inspect that Kit pattern."],
+	};
+}
+
+export function createShowcaseMenu(
+	runtime: ShowcaseMenuRuntime,
+): MenuDefinition<ShowcaseState, ShowcaseScreen, ShowcaseAction> {
+	return defineMenu<ShowcaseState, ShowcaseScreen, ShowcaseAction>({
+		start: "main",
+		screens: {
+			main: ({ state }) => ({
+				kind: "actions",
+				title: "Pi TUI Kit Showcase",
+				lines: [
+					"Experimental local demo for maintainers.",
+					"It stores no settings and uses only public @narumitw/pi-tui-kit exports.",
+					`Current demo state: ${state.profile} · ${state.density} · ${state.accent}`,
+				],
+				items: [
+					{
+						id: "actions",
+						label: "Actions screen",
+						description: "Navigation, busy labels, disabled rows",
+						to: "actions",
+					},
+					{
+						id: "detail",
+						label: "Detail screen",
+						description: "Read-only wrapped prose",
+						to: "detail",
+					},
+					{
+						id: "browse",
+						label: "Browse screen",
+						description: "Searchable read-only catalog with exact details",
+						to: "browse",
+					},
+					{
+						id: "choice",
+						label: "Choice screen",
+						description: "Single selected value with details",
+						to: "choice",
+					},
+					{
+						id: "settings",
+						label: "Settings screen",
+						description: "In-memory settings-list presentation",
+						to: "settings",
+					},
+					{
+						id: "input",
+						label: "Input screen",
+						description: "Single-line value entry",
+						to: "input",
+					},
+					{
+						id: "review",
+						label: "Review screen",
+						description: "Exact text, code, or diff review with confirmation",
+						to: "review",
+					},
+					{
+						id: "multi-select",
+						label: "Multi-select screen",
+						description: "Toggles, search, and bulk actions",
+						to: "multiSelect",
+					},
+					{
+						id: "task",
+						label: "Task loader",
+						description: "Closes this menu, shows runTask(), then reopens",
+						action: "openTask",
+						busyLabel: "Preparing task",
+					},
+					{
+						id: "confirmation",
+						label: "Confirmation",
+						description: "Closes this menu, shows runConfirmation(), then reopens",
+						action: "openConfirmation",
+					},
+					{
+						id: "live-choice",
+						label: "Live choice",
+						description: "Closes this menu, shows runLiveChoice(), then reopens",
+						action: "openLiveChoice",
+					},
+					{ id: "close", label: "Close", close: true },
+				],
+				hint: "close",
+			}),
+			actions: ({ state }) => ({
+				kind: "actions",
+				title: "Actions screen",
+				lines: latestLogLines(state),
+				items: [
+					{
+						id: "record",
+						label: "Record an action",
+						description: "Adds a log line and stays here",
+						action: "recordAction",
+						busyLabel: "Recording",
+					},
+					{
+						id: "disabled",
+						label: "Disabled row",
+						description: "Focusable explanation without side effects",
+						disabled: true,
+						disabledReason: "This row exists only to show unavailable styling.",
+						action: "recordAction",
+					},
+					{ id: "back", label: "Back to showcase", to: "main" },
+				],
+				hint: "back",
+			}),
+			detail: ({ state }) => ({
+				kind: "detail",
+				title: "Detail screen",
+				lines: [
+					"Detail screens are for read-only explanations.",
+					"They preserve simple navigation and keep domain actions elsewhere.",
+					`Last input: ${state.inputText || "none yet"}`,
+					...latestLogLines(state),
+				],
+				hint: "back",
+			}),
+			browse: () => ({
+				kind: "browse",
+				title: "Browse screen",
+				lines: ["Search the list, press Enter for details, Escape returns to the list."],
+				items: [
+					{
+						id: "json",
+						label: "Exact JSON document",
+						statusText: "code",
+						description: "Whitespace-sensitive browse detailDocument",
+						searchText: "schema exact code json",
+						detailDocument: {
+							content: JSON.stringify(
+								{ package: "@narumitw/pi-tui-kit", screen: "browse", exact: true },
+								null,
+								2,
+							),
+							format: { kind: "code", language: "json" },
+						},
+					},
+					{
+						id: "legacy",
+						label: "Legacy prose details",
+						statusText: "text",
+						description: "Status and description are included in detail output",
+						searchText: "wrapped details prose",
+						details: [
+							"First detail line.",
+							"Second detail line with enough words to wrap on narrow terminals.",
+						],
+					},
+					{
+						id: "diff",
+						label: "Diff detail document",
+						statusText: "diff",
+						description: "Exact diff rendering",
+						searchText: "patch review",
+						detailDocument: {
+							content: "--- a/demo.ts\n+++ b/demo.ts\n@@ -1 +1 @@\n-old();\n+newShowcase();\n",
+							format: { kind: "diff", filePath: "demo.ts" },
+						},
+					},
+				],
+				viewportSize: "adaptive",
+				hint: "back",
+			}),
+			choice: ({ state }) => ({
+				kind: "choice",
+				title: "Choice screen",
+				lines: ["Pick one profile. Search is TUI-only; RPC would keep a deterministic selector."],
+				items: [
+					{
+						id: "Minimal",
+						label: "Minimal",
+						description: "Few rows",
+						details: ["Best for tiny terminals."],
+						searchText: "small short",
+					},
+					{
+						id: "Balanced",
+						label: "Balanced",
+						description: "Default",
+						details: ["Shows context without crowding the screen."],
+						searchText: "recommended default",
+					},
+					{
+						id: "Verbose",
+						label: "Verbose",
+						description: "More annotations",
+						details: ["Useful when demonstrating wrapping and selected-row details."],
+						searchText: "full annotated",
+					},
+				],
+				action: "setProfile",
+				currentItemId: state.profile,
+				initialItemId: state.profile,
+				enableSearch: true,
+				viewportSize: 6,
+				hint: "back",
+			}),
+			settings: ({ state }) => ({
+				kind: "settings",
+				title: "Settings screen",
+				lines: ["Demo settings are in memory only. Back does not roll them back."],
+				items: [
+					{
+						id: "density",
+						label: "Density",
+						description: "Controls copy density in demo text.",
+						currentValue: state.density,
+						values: ["Comfortable", "Compact"],
+						action: "setSetting",
+					},
+					{
+						id: "accent",
+						label: "Accent",
+						description: "Shows ordinary bounded enum rows.",
+						currentValue: state.accent,
+						values: ["Blue", "Green", "Purple"],
+						action: "setSetting",
+					},
+				],
+			}),
+			input: ({ state }) => ({
+				kind: "input",
+				title: "Input screen",
+				lines: [`Current draft: ${state.inputText || "empty"}`],
+				placeholder: "Type any short demo note",
+				action: "submitInput",
+				hint: "back",
+			}),
+			review: ({ state }) => ({
+				kind: "review",
+				title: "Review screen",
+				lines: [
+					state.reviewApplied
+						? "The demo apply action was already accepted."
+						: "Review preserves indentation and hard-wraps exact content.",
+				],
+				content:
+					"diff --git a/showcase.txt b/showcase.txt\n--- a/showcase.txt\n+++ b/showcase.txt\n@@ -1,3 +1,4 @@\n actions\n detail\n browse\n+review\n",
+				format: { kind: "diff", filePath: "showcase.txt" },
+				viewportSize: "adaptive",
+				confirm: {
+					id: "apply",
+					label: state.reviewApplied ? "Apply again" : "Apply demo",
+					action: "applyReview",
+				},
+				hint: "back",
+			}),
+			multiSelect: ({ state }) => ({
+				kind: "multiSelect",
+				title: "Multi-select screen",
+				lines: ["Toggle rows optimistically; bulk actions stay below filtered results."],
+				items: [
+					{
+						id: "search",
+						label: "Search field",
+						description: "Shows fuzzy filtering over safe metadata.",
+						selected: state.featureFlags.search,
+						searchText: "filter query",
+					},
+					{
+						id: "details",
+						label: "Selected-row details",
+						description: "Keeps explanation near the current row.",
+						selected: state.featureFlags.details,
+						searchText: "description help",
+					},
+					{
+						id: "bulk",
+						label: "Bulk actions",
+						description: "Adds select-all and reset rows below items.",
+						selected: state.featureFlags.bulk,
+						searchText: "select all reset",
+					},
+					{
+						id: "blocked",
+						label: "Unavailable option",
+						description: "Disabled rows remain visible.",
+						selected: false,
+						disabled: true,
+						disabledReason: "Disabled rows cannot be toggled.",
+						searchText: "disabled unavailable",
+					},
+				],
+				action: "toggleFeature",
+				enableSearch: true,
+				viewportSize: 6,
+				actions: [
+					{ id: "select-all", label: "Select all available", action: "selectAllFeatures" },
+					{ id: "reset", label: "Reset demo toggles", action: "resetFeatures" },
+				],
+				doneLabel: "Back to showcase",
+				hint: "back",
+			}),
+		},
+		actions: {
+			recordAction: ({ state, ctx }) => {
+				appendLog(state, "Actions screen row activated.");
+				if (ctx.hasUI) ctx.ui.notify?.("Recorded an in-memory showcase action.", "info");
+				return { kind: "stay" };
+			},
+			setProfile: ({ state, itemId }) => {
+				if (isProfile(itemId)) state.profile = itemId;
+				appendLog(state, `Choice profile set to ${state.profile}.`);
+				return { kind: "back" };
+			},
+			setSetting: ({ state, itemId, value }) => {
+				if (itemId === "density" && isDensity(value)) state.density = value;
+				if (itemId === "accent" && isAccent(value)) state.accent = value;
+				appendLog(state, `Setting ${itemId} changed to ${value ?? "unknown"}.`);
+				return { kind: "stay" };
+			},
+			submitInput: ({ state, value }) => {
+				state.inputText = (value ?? "").trim();
+				appendLog(state, `Input submitted: ${state.inputText || "empty"}.`);
+				return { kind: "back" };
+			},
+			applyReview: ({ state }) => {
+				state.reviewApplied = true;
+				appendLog(state, "Review confirmation accepted.");
+				return { kind: "back" };
+			},
+			toggleFeature: ({ state, itemId, selected }) => {
+				if (isFeature(itemId)) state.featureFlags[itemId] = selected ?? !state.featureFlags[itemId];
+				appendLog(state, `Multi-select ${itemId} is ${selected ? "on" : "off"}.`);
+				return { kind: "stay" };
+			},
+			selectAllFeatures: ({ state }) => {
+				for (const feature of FEATURE_IDS) state.featureFlags[feature] = true;
+				appendLog(state, "All available multi-select rows enabled.");
+				return { kind: "stay" };
+			},
+			resetFeatures: ({ state }) => {
+				state.featureFlags.search = true;
+				state.featureFlags.details = true;
+				state.featureFlags.bulk = false;
+				appendLog(state, "Multi-select rows reset.");
+				return { kind: "stay" };
+			},
+			openTask: () => {
+				runtime.requestStandalone("task");
+				return { kind: "close" };
+			},
+			openConfirmation: () => {
+				runtime.requestStandalone("confirmation");
+				return { kind: "close" };
+			},
+			openLiveChoice: () => {
+				runtime.requestStandalone("liveChoice");
+				return { kind: "close" };
+			},
+		},
+	});
+}
+
+const FEATURE_IDS = ["search", "details", "bulk"] as const;
+
+function latestLogLines(state: ShowcaseState): string[] {
+	return state.log.slice(-3).map((line) => `Log: ${line}`);
+}
+
+export function appendLog(state: ShowcaseState, line: string): void {
+	state.log = [...state.log, line].slice(-8);
+}
+
+function isProfile(value: string | undefined): value is ShowcaseState["profile"] {
+	return value === "Minimal" || value === "Balanced" || value === "Verbose";
+}
+
+function isDensity(value: string | undefined): value is ShowcaseState["density"] {
+	return value === "Comfortable" || value === "Compact";
+}
+
+function isAccent(value: string | undefined): value is ShowcaseState["accent"] {
+	return value === "Blue" || value === "Green" || value === "Purple";
+}
+
+function isFeature(value: string): value is keyof ShowcaseState["featureFlags"] {
+	return FEATURE_IDS.includes(value as keyof ShowcaseState["featureFlags"]);
+}

--- a/packages/pi-tui-kit-showcase/src/runtime.ts
+++ b/packages/pi-tui-kit-showcase/src/runtime.ts
@@ -1,0 +1,164 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { runConfirmation, runLiveChoice, runMenu, runTask } from "@narumitw/pi-tui-kit";
+import {
+	appendLog,
+	createInitialShowcaseState,
+	createShowcaseMenu,
+	type ShowcaseStandaloneInteraction,
+	type ShowcaseState,
+} from "./menu.js";
+
+export interface ShowTuiKitShowcaseOptions {
+	signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+export async function showTuiKitShowcase(
+	ctx: ExtensionCommandContext,
+	options: ShowTuiKitShowcaseOptions,
+): Promise<void> {
+	const state = createInitialShowcaseState();
+	let pendingStandalone: ShowcaseStandaloneInteraction | undefined;
+	const menu = createShowcaseMenu({
+		requestStandalone(interaction) {
+			pendingStandalone = interaction;
+		},
+	});
+
+	while (!options.signal.aborted && options.isCurrent()) {
+		pendingStandalone = undefined;
+		const result = await runMenu(ctx, menu, {
+			getState: () => state,
+			signal: options.signal,
+			isCurrent: options.isCurrent,
+			onError: (_ctx, error) => notify(ctx, safeError(error), "error"),
+			onUnsupportedMode: (_ctx, mode) => {
+				notify(
+					ctx,
+					`Pi TUI Kit Showcase needs TUI mode and is unavailable in ${mode} mode.`,
+					"warning",
+				);
+			},
+		});
+
+		if (
+			!pendingStandalone ||
+			result.kind !== "closed" ||
+			result.reason !== "close" ||
+			options.signal.aborted ||
+			!options.isCurrent()
+		) {
+			return;
+		}
+
+		await runStandaloneInteraction(ctx, state, pendingStandalone, options);
+	}
+}
+
+async function runStandaloneInteraction(
+	ctx: ExtensionCommandContext,
+	state: ShowcaseState,
+	interaction: ShowcaseStandaloneInteraction,
+	options: ShowTuiKitShowcaseOptions,
+): Promise<void> {
+	if (interaction === "task") {
+		const result = await runTask(ctx, {
+			label: "Running a short showcase task…",
+			signal: options.signal,
+			isCurrent: options.isCurrent,
+			task: ({ signal }) => delay(250, signal),
+			onError: (_ctx, error) => notify(ctx, safeError(error), "error"),
+		});
+		if (result.kind === "completed") {
+			appendLog(state, "Standalone task completed.");
+			notify(ctx, "Showcase task completed.", "info");
+		}
+		return;
+	}
+
+	if (interaction === "confirmation") {
+		const result = await runConfirmation(ctx, {
+			title: "Confirm showcase action?",
+			message: "This only writes an in-memory log line for the current demo session.",
+			confirmLabel: "Record confirmation",
+			cancelLabel: "Back",
+			signal: options.signal,
+			isCurrent: options.isCurrent,
+			onError: (_ctx, error) => notify(ctx, safeError(error), "error"),
+		});
+		if (result.kind === "confirmed") {
+			appendLog(state, "Standalone confirmation accepted.");
+			notify(ctx, "Confirmation recorded.", "info");
+		} else if (result.kind === "closed") {
+			appendLog(state, `Standalone confirmation closed with ${result.reason}.`);
+		}
+		return;
+	}
+
+	const previousProfile = state.profile;
+	const result = await runLiveChoice(ctx, {
+		title: "Live choice showcase",
+		items: [
+			{ id: "Minimal", label: "Minimal", description: "Preview a compact profile" },
+			{ id: "Balanced", label: "Balanced", description: "Preview the balanced default" },
+			{ id: "Verbose", label: "Verbose", description: "Preview an annotated profile" },
+		],
+		currentItemId: state.profile,
+		initialItemId: state.profile,
+		navigationLabel: "preview",
+		confirmLabel: "apply profile",
+		shortcuts: [{ id: "details", keys: ["d"], label: "note details" }],
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+		onSelectionChange: ({ item, signal }) => {
+			if (!signal.aborted && isShowcaseProfile(item.id)) state.profile = item.id;
+		},
+		onError: (_ctx, error) => notify(ctx, safeError(error), "error"),
+	});
+
+	if (result.kind === "selected" && isShowcaseProfile(result.itemId)) {
+		state.profile = result.itemId;
+		appendLog(state, `Live choice applied ${result.itemId}.`);
+		notify(ctx, `Applied ${result.itemId}.`, "info");
+		return;
+	}
+
+	state.profile = previousProfile;
+	if (result.kind === "shortcut") appendLog(state, `Live choice shortcut ${result.shortcutId}.`);
+	else if (result.kind === "closed") appendLog(state, `Live choice closed with ${result.reason}.`);
+}
+
+function notify(
+	ctx: ExtensionCommandContext,
+	message: string,
+	level: "error" | "info" | "warning",
+) {
+	if (ctx.hasUI) ctx.ui.notify(message, level);
+}
+
+function safeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function delay(milliseconds: number, signal: AbortSignal): Promise<void> {
+	if (signal.aborted) return Promise.reject(new Error("Task was cancelled."));
+	return new Promise<void>((resolve, reject) => {
+		let settled = false;
+		const timeout = setTimeout(() => {
+			settled = true;
+			signal.removeEventListener("abort", abort);
+			resolve();
+		}, milliseconds);
+		const abort = () => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			reject(new Error("Task was cancelled."));
+		};
+		signal.addEventListener("abort", abort, { once: true });
+	});
+}
+
+function isShowcaseProfile(value: string): value is ShowcaseState["profile"] {
+	return value === "Minimal" || value === "Balanced" || value === "Verbose";
+}

--- a/packages/pi-tui-kit-showcase/src/showcase.ts
+++ b/packages/pi-tui-kit-showcase/src/showcase.ts
@@ -1,0 +1,85 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+
+const COMMAND_NAME = "tui-kit-showcase";
+const USAGE = "Usage: /tui-kit-showcase";
+
+type ShowcaseRuntimeModule = Pick<typeof import("./runtime.js"), "showTuiKitShowcase">;
+
+export interface PiTuiKitShowcaseDependencies {
+	loadRuntime?: () => Promise<ShowcaseRuntimeModule>;
+}
+
+export function createPiTuiKitShowcaseExtension(
+	dependencies: PiTuiKitShowcaseDependencies = {},
+): (pi: ExtensionAPI) => void {
+	return function piTuiKitShowcaseExtension(pi: ExtensionAPI): void {
+		const loadRuntime = cachedModuleLoader(
+			dependencies.loadRuntime ?? (() => import("./runtime.js")),
+		);
+		let generation = 0;
+		let owner = new AbortController();
+
+		function replaceSessionOwner() {
+			owner.abort();
+			owner = new AbortController();
+			generation += 1;
+		}
+
+		function abortSessionOwner() {
+			owner.abort();
+			generation += 1;
+		}
+
+		pi.on("session_start", () => {
+			replaceSessionOwner();
+		});
+		pi.on("session_shutdown", () => {
+			abortSessionOwner();
+		});
+
+		pi.registerCommand(COMMAND_NAME, {
+			description: "Open the private experimental Pi TUI Kit showcase",
+			getArgumentCompletions: () => [],
+			handler: async (rawArgs, ctx) => {
+				const args = rawArgs.trim();
+				if (args) throw new Error(USAGE);
+				if (ctx.mode !== "tui") {
+					reportUnsupportedMode(ctx);
+					return;
+				}
+
+				const commandGeneration = generation;
+				const signal = owner.signal;
+				const runtime = await loadRuntime();
+				if (signal.aborted || commandGeneration !== generation) return;
+				await runtime.showTuiKitShowcase(ctx, {
+					signal,
+					isCurrent: () => !signal.aborted && commandGeneration === generation,
+				});
+			},
+		});
+	};
+}
+
+function reportUnsupportedMode(ctx: ExtensionCommandContext): void {
+	const message =
+		"Pi TUI Kit Showcase is an interactive visual demo. Run /tui-kit-showcase in TUI mode.";
+	if (ctx.mode === "rpc" && ctx.hasUI) {
+		ctx.ui.notify(message, "warning");
+		return;
+	}
+	throw new Error(`${message} ${USAGE}`);
+}
+
+function cachedModuleLoader<T>(load: () => Promise<T>): () => Promise<T> {
+	let promise: Promise<T> | undefined;
+	return async () => {
+		promise ??= load().catch((error) => {
+			promise = undefined;
+			throw error;
+		});
+		return promise;
+	};
+}
+
+export default createPiTuiKitShowcaseExtension();

--- a/packages/pi-tui-kit-showcase/test/showcase.test.ts
+++ b/packages/pi-tui-kit-showcase/test/showcase.test.ts
@@ -1,0 +1,120 @@
+import { resolveMenuScreen } from "@narumitw/pi-tui-kit";
+import { describe, expect, test } from "vitest";
+import extension from "../src/index.js";
+import { createInitialShowcaseState, createShowcaseMenu } from "../src/menu.js";
+import { createPiTuiKitShowcaseExtension } from "../src/showcase.js";
+
+describe("Pi TUI Kit showcase", () => {
+	test("exposes every standard Kit screen from the main menu", () => {
+		const state = createInitialShowcaseState();
+		const menu = createShowcaseMenu({ requestStandalone: () => {} });
+
+		const screenKinds = [
+			"main",
+			"actions",
+			"detail",
+			"browse",
+			"choice",
+			"settings",
+			"input",
+			"review",
+			"multiSelect",
+		].map((screen) => resolveMenuScreen(menu, screen, state).kind);
+
+		expect(screenKinds).toEqual([
+			"actions",
+			"actions",
+			"detail",
+			"browse",
+			"choice",
+			"settings",
+			"input",
+			"review",
+			"multiSelect",
+		]);
+
+		const main = resolveMenuScreen(menu, "main", state);
+		expect(main.kind).toBe("actions");
+		if (main.kind !== "actions") return;
+		expect(main.items.map((item) => item.label)).toEqual(
+			expect.arrayContaining(["Task loader", "Confirmation", "Live choice"]),
+		);
+	});
+
+	test("registers one TUI-only showcase command and rejects arguments", async () => {
+		const commands = new Map<string, ShowcaseCommand>();
+		extension({
+			registerCommand(name: string, command: ShowcaseCommand) {
+				commands.set(name, command);
+			},
+			on() {},
+		} as never);
+
+		expect([...commands.keys()]).toEqual(["tui-kit-showcase"]);
+		await expect(commands.get("tui-kit-showcase")?.handler("extra", {})).rejects.toThrow(
+			"Usage: /tui-kit-showcase",
+		);
+	});
+
+	test("reports RPC unsupported mode without loading the TUI runtime", async () => {
+		const notifications: string[] = [];
+		const commands = new Map<string, ShowcaseCommand>();
+		createPiTuiKitShowcaseExtension({
+			loadRuntime: async () => {
+				throw new Error("runtime should not load");
+			},
+		})({
+			registerCommand(name: string, command: ShowcaseCommand) {
+				commands.set(name, command);
+			},
+			on() {},
+		} as never);
+
+		await commands.get("tui-kit-showcase")?.handler("", {
+			mode: "rpc",
+			hasUI: true,
+			ui: { notify: (message: string) => notifications.push(message) },
+		});
+
+		expect(notifications).toEqual([
+			"Pi TUI Kit Showcase is an interactive visual demo. Run /tui-kit-showcase in TUI mode.",
+		]);
+	});
+
+	test("aborts command-owned showcase work on session shutdown", async () => {
+		let captured:
+			| {
+					signal: AbortSignal;
+					isCurrent(): boolean;
+			  }
+			| undefined;
+		const commands = new Map<string, ShowcaseCommand>();
+		const events = new Map<string, () => void>();
+		createPiTuiKitShowcaseExtension({
+			loadRuntime: async () => ({
+				showTuiKitShowcase: async (_ctx, options) => {
+					captured = options;
+				},
+			}),
+		})({
+			registerCommand(name: string, command: ShowcaseCommand) {
+				commands.set(name, command);
+			},
+			on(name: string, handler: () => void) {
+				events.set(name, handler);
+			},
+		} as never);
+
+		await commands.get("tui-kit-showcase")?.handler("", { mode: "tui", hasUI: true, ui: {} });
+
+		expect(captured?.signal.aborted).toBe(false);
+		expect(captured?.isCurrent()).toBe(true);
+		events.get("session_shutdown")?.();
+		expect(captured?.signal.aborted).toBe(true);
+		expect(captured?.isCurrent()).toBe(false);
+	});
+});
+
+interface ShowcaseCommand {
+	handler(args: string, ctx: unknown): Promise<void>;
+}

--- a/packages/pi-tui-kit-showcase/tsconfig.json
+++ b/packages/pi-tui-kit-showcase/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a private experimental `pi-tui-kit-showcase` extension with `/tui-kit-showcase`
- showcase standard Kit screens plus task, confirmation, and live-choice interactions
- add `just showcase-tui-kit` and archive the implementation plan

## Verification
- `npx vitest run packages/pi-tui-kit-showcase/test/showcase.test.ts`
- `npm --workspace @narumitw/pi-tui-kit-showcase run check`
- `npm run check:boundaries`
- `npm run check`
- `npm --workspace @narumitw/pi-tui-kit-showcase pack --dry-run --json`
- `PI_CODING_AGENT_DIR=$(mktemp -d) pi --no-extensions --no-skills --no-session -e ./packages/pi-tui-kit-showcase --list-models`
- `git diff --check`
- `npm run changeset:status`

## Notes
- No changeset: the showcase package is private and repo-only.
- Live interactive traversal remains available through `just showcase-tui-kit`.