### PR TITLE
fix(file-context): prioritize shallow discovery

### DIFF
--- a/.changeset/shallow-file-context-discovery.md
+++ b/.changeset/shallow-file-context-discovery.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": patch
+---
+
+Prioritize shallow project files before deeper files during bounded File Context discovery.

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -102,7 +102,7 @@ Unknown and trailing arguments are rejected. RPC receives an observable warning.
 - Extensions run with the user's full permissions; install only trusted code.
 - File paths and symlink targets are checked against the real project root before reading.
 - Preview files are limited to 1 MB and NUL-containing files are treated as binary.
-- Discovery is limited to 5,000 files and skips symlinks.
+- Discovery is limited to 5,000 files, skips symlinks, and prioritizes shallow files before deeper files.
 - File-name and content-search queries are limited to 256 characters. Content search returns at most 100 cards and reports truncation and unreadable, oversized, or binary files as skipped.
 - Content search uses the same 5,000-file, 1 MB-per-file, real-project-path, and no-symlink boundaries as preview loading. Superseded searches and file opens are cancelled.
 - Terminal control characters are escaped before file names, Git refs, authors, summaries, search context, or file contents are rendered.

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -98,30 +98,34 @@ export async function discoverProjectFiles(
 	const files: string[] = [];
 	options.signal?.throwIfAborted();
 
-	async function walk(directory: string, prefix: string): Promise<void> {
+	const canonicalRoot = await realpath(root);
+	const directories: Array<{ directory: string; prefix: string }> = [
+		{ directory: canonicalRoot, prefix: "" },
+	];
+	options.signal?.throwIfAborted();
+
+	for (let index = 0; index < directories.length && files.length < maxFiles; index += 1) {
 		options.signal?.throwIfAborted();
-		if (files.length >= maxFiles) return;
+		const current = directories[index];
+		if (!current) break;
+		const { directory, prefix } = current;
 		const entries = (await readdir(directory, { withFileTypes: true })).sort((left, right) =>
 			compareStrings(left.name, right.name),
 		);
 		options.signal?.throwIfAborted();
 		for (const entry of entries) {
 			options.signal?.throwIfAborted();
-			if (files.length >= maxFiles) return;
 			if (IGNORED_DIRECTORIES.has(entry.name) || entry.isSymbolicLink()) continue;
 			const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
 			const absolutePath = resolve(directory, entry.name);
 			if (entry.isDirectory()) {
-				await walk(absolutePath, relativePath);
+				directories.push({ directory: absolutePath, prefix: relativePath });
 			} else if (entry.isFile()) {
 				files.push(relativePath);
+				if (files.length >= maxFiles) break;
 			}
 		}
 	}
-
-	const canonicalRoot = await realpath(root);
-	options.signal?.throwIfAborted();
-	await walk(canonicalRoot, "");
 	options.signal?.throwIfAborted();
 	return files.sort(compareStrings);
 }

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -105,6 +105,21 @@ test("discovers bounded project text candidates without traversing ignored direc
 	});
 });
 
+test("discovers shallow files before deep files when the file limit is reached", async () => {
+	await withTempProject(async (root) => {
+		await mkdir(join(root, "a-deep"), { recursive: true });
+		await writeFile(join(root, "a-deep", "one.txt"), "one");
+		await writeFile(join(root, "a-deep", "two.txt"), "two");
+		await writeFile(join(root, "b-shallow.txt"), "b");
+		await writeFile(join(root, "c-shallow.txt"), "c");
+
+		assert.deepEqual(await discoverProjectFiles(root, { maxFiles: 2 }), [
+			"b-shallow.txt",
+			"c-shallow.txt",
+		]);
+	});
+});
+
 test("loads only bounded regular text files inside the project", async () => {
 	await withTempProject(async (root) => {
 		await writeFile(join(root, "safe.ts"), "one\ntwo\nthree\n");


### PR DESCRIPTION
## Summary
- Change File Context project discovery from depth-first traversal to shallow-first traversal under the 5,000-file cap.
- Add a regression test proving shallow files are discovered before deeper files when the cap is reached.
- Document the shallow-priority discovery limit and add a patch changeset.

## Verification
- npx vitest run packages/pi-file-context/test/file-context.test.ts
- npm --workspace @narumitw/pi-file-context run check
- npm run check

## Convention audit
- Read docs/extension-conventions.md before editing extension behavior.
- Touched areas: deterministic tests, README limitations, Changesets release note.
- No settings, command surface, package metadata, custom TUI, async UI flow, or lifecycle behavior changed.
- No deviations or unverified paths.