### PR TITLE
feat(btw): add same-as-main thinking level option

### DIFF
--- a/.changeset/same-main-btw-thinking.md
+++ b/.changeset/same-main-btw-thinking.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": minor
+---
+
+Add a Same as main thread thinking option that starts new side threads from the current main thread level while keeping shortcut changes local.

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -18,7 +18,7 @@ Use it when you want to ask a temporary question, inspect context, or get a shor
 - Optionally brings the latest answer, a question-to-end suffix, an exact line range, or the entire side thread into the main editor.
 - Uses the current session branch as context.
 - Uses Pi's current model or an independent model selected in `pi-btw.json`.
-- Uses a pi-btw thinking level that can be changed with Pi's configured thinking shortcut and remembered for next time.
+- Uses a pi-btw thinking level that can either start from the main thread or use a fixed remembered value.
 - Does not append the side question or answer to the main conversation.
 - Works as an independently installable npm Pi extension package.
 
@@ -61,7 +61,7 @@ Examples:
 Running `/btw` alone opens a menu with **Start side thread** selected first.
 When the current Pi session has non-empty side threads in memory, **Resume side thread** opens a bounded searchable choice list.
 Search matches the displayed first question and question count while returning the thread's raw in-memory ID.
-**Settings** changes the starting thinking level and whether shortcut changes are remembered.
+**Settings** changes the starting thinking level and whether shortcut changes for fixed levels are remembered.
 Each Resume row keeps the first question as its fixed title, shows its question count, and the list is ordered by the newest recorded answer or visible error.
 Opening and closing a thread without a new result does not reorder it.
 `/btw <question>` bypasses this menu and always starts a fresh side thread.
@@ -79,9 +79,11 @@ Previous side questions and answers remain available to the model and visible fo
 invocation. The side-thread header shows its current thinking level. Press Pi's configured
 `app.thinking.cycle` shortcut (`Shift+Tab` by default) in the composer to cycle the levels
 supported by the side-thread model; every later question uses the displayed level until it is
-changed again. By default, each shortcut change is also written to `pi-btw.json` for the next
-invocation. Turn **Remember thinking level changes** off in Settings to keep changes local to the
-current side thread. Neither path changes the main session's thinking level.
+changed again. When a fixed thinking level is selected, each shortcut change is also written to
+`pi-btw.json` for the next invocation by default. Turn **Remember thinking level changes** off in
+Settings to keep fixed-level changes local to the current side thread. When **Same as main thread** is
+selected, shortcut changes are always local to the current side thread. Neither path changes the main
+session's thinking level.
 While a response is running, the transcript and composer remain visible above an `Answering…`
 status.
 Type another question and press `Enter` to queue it as `Steering`; queued questions are shown in
@@ -148,18 +150,23 @@ cannot be found or authenticated, pi-btw warns and falls back to the current ses
 If neither model is available, `/btw` reports an error and stops. This selection affects only
 `/btw`; it does not change the main session model.
 
-Pi calls its reasoning setting the **thinking level**. `thinkingLevel` sets pi-btw's starting
-level; accepted values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. When the
-field is absent for backward compatibility, the next invocation starts from the current session
-level. The initial value and shortcut cycle are clamped to the selected side model's capabilities
-using Pi's model rules. Pi-btw does not read, write, or change the main session's
-`defaultThinkingLevel`.
+Pi calls its reasoning setting the **thinking level**. In Settings, choose **Same as main thread**
+to start each new side thread from the main thread's current thinking level. This is stored by
+omitting `thinkingLevel` from `pi-btw.json`.
 
-`rememberThinkingLevelChanges` controls only persistence and defaults to `true` when omitted. A
-side-thread shortcut always changes that side thread immediately. When remembering is on, the
-concrete level is written for the next invocation; when off, `pi-btw.json` stays unchanged. If a
-shortcut write fails, the local change remains active and pi-btw warns that it was not remembered.
-A failed Settings-screen save instead restores the previous displayed value.
+Set `thinkingLevel` only when you want a fixed pi-btw starting level. Accepted fixed values are
+`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. The initial value and shortcut cycle
+are clamped to the selected side model's capabilities using Pi's model rules. Resumed side threads
+keep their own local thinking level instead of re-syncing with the main thread. Pi-btw does not read,
+write, or change the main session's `defaultThinkingLevel`.
+
+`rememberThinkingLevelChanges` controls only persistence for fixed thinking levels and defaults to
+`true` when omitted. A side-thread shortcut always changes that side thread immediately. When a fixed
+thinking level is selected and remembering is on, the concrete level is written for the next
+invocation; when off, `pi-btw.json` stays unchanged. When **Same as main thread** is selected,
+shortcut changes stay local even when remembering is on. If a shortcut write fails, the local change
+remains active and pi-btw warns that it was not remembered. A failed Settings-screen save instead
+restores the previous displayed value.
 
 A missing settings file is a side-effect-free read: pi-btw creates it only after a Settings change
 or a remembered shortcut change. Saves are ordered within the Pi process and published atomically

--- a/packages/pi-btw/src/btw.ts
+++ b/packages/pi-btw/src/btw.ts
@@ -194,7 +194,7 @@ export async function loadBtwThinkingLevel(
 
 	options.warn?.(
 		sanitizeSingleLine(
-			`pi-btw settings ignored: ${settings.reason}; expected optional model "provider/model-id", thinkingLevel "${BTW_THINKING_LEVELS.join('" | "')}", and boolean rememberThinkingLevelChanges. Using current Pi thinking level.`,
+			`pi-btw settings ignored: ${settings.reason}; expected optional model "provider/model-id", omitted thinkingLevel for Same as main thread or thinkingLevel "${BTW_THINKING_LEVELS.join('" | "')}", and boolean rememberThinkingLevelChanges. Using current Pi thinking level.`,
 		),
 	);
 	return currentThinkingLevel;
@@ -265,6 +265,7 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 			}
 
 			const settings = await loadSettings(ctx);
+			const sameAsMainThinkingLevel = settings.thinkingLevel === undefined;
 			const resolution = await resolveModel(settings, ctx);
 			if (resolution.kind === "cancelled") {
 				notifySafely(ctx, "Cancelled", "info");
@@ -302,7 +303,8 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 						initialQuestion: question || undefined,
 						selected: resolution.selected,
 						thinkingLevel: state.thinkingLevel,
-						rememberThinkingLevelChanges: effectiveRememberThinkingLevelChanges(settings),
+						rememberThinkingLevelChanges:
+							!sameAsMainThinkingLevel && effectiveRememberThinkingLevelChanges(settings),
 						state,
 						ctx: fullscreenCtx,
 					});

--- a/packages/pi-btw/src/menu.ts
+++ b/packages/pi-btw/src/menu.ts
@@ -7,6 +7,7 @@ import type { Component, TUI } from "@earendil-works/pi-tui";
 import type { MenuContext, RunMenuResult } from "@narumitw/pi-tui-kit";
 import {
 	type BtwSettings,
+	type BtwSettingsPatch,
 	btwSettingsPath,
 	effectiveRememberThinkingLevelChanges,
 	readBtwSettings,
@@ -35,7 +36,7 @@ export interface ShowBtwCommandMenuOptions {
 	settingsPath?: string;
 	readSettings?: typeof readBtwSettings;
 	updateSettings?: (
-		patch: Partial<Pick<BtwSettings, "thinkingLevel" | "rememberThinkingLevelChanges">>,
+		patch: BtwSettingsPatch,
 		options: UpdateBtwSettingsOptions,
 	) => Promise<BtwSettings>;
 }
@@ -44,6 +45,7 @@ export type BtwCommandMenuResult = "start" | "closed" | { kind: "resume"; thread
 
 type BtwMenuScreen = "main" | "resume" | "settings" | "invalid";
 type BtwMenuAction = "start" | "resume" | "set-thinking" | "set-remember";
+const SAME_AS_MAIN_THREAD = "Same as main thread";
 type BtwCustomOptions = Parameters<ExtensionCommandContext["ui"]["custom"]>[1];
 
 type BtwCustomFactory<T> = (
@@ -79,8 +81,22 @@ export async function showBtwCommandMenu(
 		}
 		return { kind: "valid", settings: loaded.kind === "loaded" ? loaded.settings : {} };
 	};
-	const displayThinkingLevel = (settings: BtwSettings): BtwThinkingLevel =>
-		clampToAvailableThinkingLevel(settings.thinkingLevel ?? options.currentThinkingLevel, levels);
+	const currentMainThinkingLevel = clampToAvailableThinkingLevel(
+		options.currentThinkingLevel,
+		levels,
+	);
+	const displayThinkingLevel = (settings: BtwSettings): string =>
+		settings.thinkingLevel === undefined
+			? SAME_AS_MAIN_THREAD
+			: clampToAvailableThinkingLevel(settings.thinkingLevel, levels);
+	const displayThinkingSummary = (settings: BtwSettings): string =>
+		settings.thinkingLevel === undefined
+			? `${SAME_AS_MAIN_THREAD} (currently ${currentMainThinkingLevel})`
+			: displayThinkingLevel(settings);
+	const displayRememberSummary = (settings: BtwSettings): string => {
+		const value = effectiveRememberThinkingLevelChanges(settings) ? "On" : "Off";
+		return settings.thinkingLevel === undefined ? `${value} (fixed levels only)` : value;
+	};
 
 	const menu = defineMenu<BtwMenuState, BtwMenuScreen, BtwMenuAction, MenuContext>({
 		start: "main",
@@ -89,7 +105,7 @@ export async function showBtwCommandMenu(
 				kind: "actions",
 				title: "Pi BTW",
 				lines: [
-					`Thinking: ${displayThinkingLevel(state.settings)} · Remember changes: ${effectiveRememberThinkingLevelChanges(state.settings) ? "On" : "Off"}`,
+					`Thinking: ${displayThinkingSummary(state.settings)} · Remember changes: ${displayRememberSummary(state.settings)}`,
 				],
 				items: [
 					{
@@ -111,7 +127,7 @@ export async function showBtwCommandMenu(
 					{
 						id: "settings",
 						label: "Settings",
-						description: "Choose pi-btw thinking and whether shortcut changes are remembered",
+						description: "Choose pi-btw thinking level and fixed-level shortcut memory",
 						to: state.kind === "invalid" ? "invalid" : "settings",
 					},
 				],
@@ -138,15 +154,15 @@ export async function showBtwCommandMenu(
 					{
 						id: "thinkingLevel",
 						label: "Thinking level",
-						description: "Set the starting level for future pi-btw side threads.",
+						description: `Set the starting level for future pi-btw side threads. Currently ${currentMainThinkingLevel}.`,
 						currentValue: displayThinkingLevel(state.settings),
-						values: levels,
+						values: [SAME_AS_MAIN_THREAD, ...levels],
 						action: "set-thinking",
 					},
 					{
 						id: "rememberThinkingLevelChanges",
 						label: "Remember thinking level changes",
-						description: "Save side-thread shortcut changes to pi-btw.json for next time.",
+						description: "Save shortcut changes for fixed thinking levels to pi-btw.json.",
 						currentValue: effectiveRememberThinkingLevelChanges(state.settings) ? "On" : "Off",
 						values: ["On", "Off"],
 						action: "set-remember",
@@ -176,12 +192,16 @@ export async function showBtwCommandMenu(
 				return { kind: "close" } as const;
 			},
 			"set-thinking": async ({ value, signal }) => {
-				if (!value || !levels.includes(value as BtwThinkingLevel)) return { kind: "rejected" };
+				if (!value) return { kind: "rejected" };
+				const patch =
+					value === SAME_AS_MAIN_THREAD
+						? ({ thinkingLevel: undefined } satisfies BtwSettingsPatch)
+						: levels.includes(value as BtwThinkingLevel)
+							? ({ thinkingLevel: value as BtwThinkingLevel } satisfies BtwSettingsPatch)
+							: undefined;
+				if (!patch) return { kind: "rejected" };
 				try {
-					await updateSettings(
-						{ thinkingLevel: value as BtwThinkingLevel },
-						{ settingsPath, signal },
-					);
+					await updateSettings(patch, { settingsPath, signal });
 					if (signal.aborted) return { kind: "rejected" };
 					notifySafely(ctx, `Pi BTW thinking level: ${value}.`, "info");
 					return { kind: "stay" };

--- a/packages/pi-btw/src/settings.ts
+++ b/packages/pi-btw/src/settings.ts
@@ -20,6 +20,11 @@ export type BtwSettingsLoadResult =
 	| { kind: "invalid"; reason: string }
 	| { kind: "loaded"; settings: BtwSettings };
 
+export interface BtwSettingsPatch {
+	thinkingLevel?: BtwThinkingLevel;
+	rememberThinkingLevelChanges?: boolean;
+}
+
 export interface UpdateBtwSettingsOptions {
 	settingsPath?: string;
 	signal?: AbortSignal;
@@ -77,14 +82,14 @@ export async function readBtwSettings(
 }
 
 export function updateBtwSettings(
-	patch: Partial<Pick<BtwSettings, "thinkingLevel" | "rememberThinkingLevelChanges">>,
+	patch: BtwSettingsPatch,
 	options: UpdateBtwSettingsOptions = {},
 ): Promise<BtwSettings> {
 	const settingsPath = options.settingsPath ?? btwSettingsPath();
 	return enqueueMutation(settingsPath, async () => {
 		options.signal?.throwIfAborted();
 		const current = await readSettingsDocumentForUpdate(settingsPath);
-		const updated: SettingsDocument = { ...current, ...patch };
+		const updated = applyBtwSettingsPatch(current, patch);
 		const settings = normalizeBtwSettings(updated);
 		if (!settings) throw invalidSettingsError(settingsPath, "invalid settings shape");
 		await publishSettings(settingsPath, updated, options.signal, options.beforeRename);
@@ -214,6 +219,21 @@ async function publishSettings(
 		await rm(temporaryPath, { force: true }).catch(() => undefined);
 		throw error;
 	}
+}
+
+function applyBtwSettingsPatch(
+	current: SettingsDocument,
+	patch: BtwSettingsPatch,
+): SettingsDocument {
+	const updated: SettingsDocument = { ...current };
+	if (Object.hasOwn(patch, "thinkingLevel")) {
+		if (patch.thinkingLevel === undefined) delete updated.thinkingLevel;
+		else updated.thinkingLevel = patch.thinkingLevel;
+	}
+	if (Object.hasOwn(patch, "rememberThinkingLevelChanges")) {
+		updated.rememberThinkingLevelChanges = patch.rememberThinkingLevelChanges;
+	}
+	return updated;
 }
 
 function isSettingsDocument(value: unknown): value is SettingsDocument {

--- a/packages/pi-btw/test/btw.test.ts
+++ b/packages/pi-btw/test/btw.test.ts
@@ -405,6 +405,45 @@ test("btw command routes no arguments through the menu and preserves direct ques
 	assert.deepEqual(mock.thinkingLevels, []);
 });
 
+test("btw same-as-main mode starts fresh threads from the current main level without remembering shortcut changes", async () => {
+	const mock = createMockPi({ thinkingLevel: "high" });
+	const selected = {
+		model: { provider: "test", id: "side", reasoning: true } as Model<Api>,
+		auth: { apiKey: "key" },
+	};
+	const threadStarts: Array<{
+		initialQuestion?: string;
+		thinkingLevel: string;
+		rememberThinkingLevelChanges?: boolean;
+	}> = [];
+	btw(mock.pi, {
+		loadSettings: async () => ({}),
+		resolveModel: async () => ({ kind: "selected", selected }),
+		runFullscreen: async (ctx, run) => run(ctx),
+		runThread: async (options) => {
+			threadStarts.push({
+				initialQuestion: options.initialQuestion,
+				thinkingLevel: options.thinkingLevel,
+				rememberThinkingLevelChanges: options.rememberThinkingLevelChanges,
+			});
+			return { kind: "closed" };
+		},
+	});
+	const command = mock.commands.get("btw");
+	assert.ok(command);
+
+	await command.handler("same as main", createMockContext({ mode: "tui", hasUI: true }).ctx);
+
+	assert.deepEqual(threadStarts, [
+		{
+			initialQuestion: "same as main",
+			thinkingLevel: "high",
+			rememberThinkingLevelChanges: false,
+		},
+	]);
+	assert.deepEqual(mock.thinkingLevels, []);
+});
+
 test("btw keeps multiple in-memory threads, resumes the selected one, and keeps direct questions fresh", async () => {
 	const mock = createMockPi({ thinkingLevel: "low" });
 	const selected = {

--- a/packages/pi-btw/test/menu.test.ts
+++ b/packages/pi-btw/test/menu.test.ts
@@ -222,7 +222,8 @@ test("btw menu opens Pi-style thinking settings and cancellation is read-only", 
 		await openSettings(tui);
 		const settings = tui.render().join("\n");
 		assert.match(settings, /Pi BTW Settings/);
-		assert.match(settings, /Thinking level\s+medium/);
+		assert.match(settings, /Thinking level\s+Same as main thread/);
+		assert.match(settings, /Currently medium/);
 		assert.match(settings, /Remember thinking level changes\s+On/);
 		tui.press("ctrl+c");
 
@@ -232,9 +233,46 @@ test("btw menu opens Pi-style thinking settings and cancellation is read-only", 
 	});
 });
 
+test("btw settings can choose Same as main thread and clear a fixed thinking level", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx, notifications }) => {
+		await writeFile(
+			settingsPath,
+			'{"model":"test/side","future":{"kept":true},"thinkingLevel":"high","rememberThinkingLevelChanges":false}\n',
+			"utf8",
+		);
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "medium",
+			availableThinkingLevels: ["off", "low", "medium", "high"],
+		});
+		await openSettings(tui);
+		assert.match(tui.render().join("\n"), /Thinking level\s+high/);
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+
+		const saved = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.deepEqual(saved, {
+			model: "test/side",
+			future: { kept: true },
+			rememberThinkingLevelChanges: false,
+		});
+		assert.match(tui.render().join("\n"), /Thinking level\s+Same as main thread/);
+		assert.ok(
+			notifications.some(({ message }) => /thinking level: Same as main thread/i.test(message)),
+		);
+		tui.press("ctrl+c");
+		assert.equal(await running, "closed");
+	});
+});
+
 test("btw settings save thinking and remembering immediately while preserving unknown fields", async () => {
 	await withMenu(async ({ settingsPath, tui, ctx, notifications }) => {
-		await writeFile(settingsPath, '{"model":"test/side","future":{"kept":true}}\n', "utf8");
+		await writeFile(
+			settingsPath,
+			'{"model":"test/side","future":{"kept":true},"thinkingLevel":"medium"}\n',
+			"utf8",
+		);
 		const running = showBtwCommandMenu(ctx, {
 			settingsPath,
 			currentThinkingLevel: "medium",
@@ -280,7 +318,7 @@ test("btw settings reject failed saves and restore the prior displayed value", a
 		await tui.waitForOpen();
 		const narrow = tui.render(32);
 		assert.ok(narrow.every((line) => visibleWidth(line) <= 32));
-		assert.match(tui.render(80).join("\n"), /Thinking level\s+medium/);
+		assert.match(tui.render(80).join("\n"), /Thinking level\s+Same as main thread/);
 		const failureMessage = notifications[0]?.message ?? "";
 		assert.match(failureMessage, /previous value remains active.*disk full/i);
 		assert.equal(
@@ -298,6 +336,7 @@ test("btw settings reject failed saves and restore the prior displayed value", a
 
 test("btw settings retain a completed save when its notification context is stale", async () => {
 	await withMenu(async ({ settingsPath, tui, ctx }) => {
+		await writeFile(settingsPath, '{"thinkingLevel":"low"}\n', "utf8");
 		ctx.ui.notify = () => {
 			throw new Error("Extension context is no longer active");
 		};

--- a/packages/pi-btw/test/settings.test.ts
+++ b/packages/pi-btw/test/settings.test.ts
@@ -50,6 +50,33 @@ test("btw settings preserve omitted thinking levels for backward compatibility",
 	});
 });
 
+test("btw settings can clear thinking level while preserving other fields", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await updateBtwSettings(
+			{ thinkingLevel: "low", rememberThinkingLevelChanges: false },
+			{ settingsPath },
+		);
+		await writeFile(
+			settingsPath,
+			'{"model":"test/side","future":{"kept":true},"thinkingLevel":"low","rememberThinkingLevelChanges":false}\n',
+			"utf8",
+		);
+
+		await updateBtwSettings({ thinkingLevel: undefined }, { settingsPath });
+
+		const saved = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.deepEqual(saved, {
+			model: "test/side",
+			future: { kept: true },
+			rememberThinkingLevelChanges: false,
+		});
+		assert.deepEqual(await readBtwSettings(settingsPath), {
+			kind: "loaded",
+			settings: { model: "test/side", rememberThinkingLevelChanges: false },
+		});
+	});
+});
+
 test("btw settings updates preserve unknown fields and create only on explicit save", async () => {
 	await withTempSettings(async (settingsPath) => {
 		await updateBtwSettings(


### PR DESCRIPTION
## Summary
- Add a "Same as main thread" thinking level option to /btw Settings.
- Store that option by omitting pi-btw's thinkingLevel and keep shortcut changes local while that option is selected.
- Preserve fixed thinking-level persistence and document the updated behavior.

## Checks
- npm run check
- precommit: biome:check and typecheck