### PR TITLE
fix: let changesets maintain non-workspace internal dependency ranges

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"ignore": [],
-	"bumpVersionsWithWorkspaceProtocolOnly": true,
+	"bumpVersionsWithWorkspaceProtocolOnly": false,
 	"format": false,
 	"privatePackages": {
 		"version": false,


### PR DESCRIPTION
## Problem

Published packages resolve their internal dependencies several minors behind what the workspace links, and the drift is invisible during development because workspaces resolve locally.

`@narumitw/pi-goal@0.51.0` declares:

```json
"dependencies": { "@narumitw/pi-tui-kit": "^0.49.1" }
```

`@narumitw/pi-tui-kit` is published at `0.54.0`. A caret on a `0.x` version pins the **minor**, so `^0.49.1` means `>=0.49.1 <0.50.0`:

```console
$ npm view "@narumitw/pi-tui-kit@^0.49.1" version
@narumitw/pi-tui-kit@0.49.1  '0.49.1'
@narumitw/pi-tui-kit@0.49.3  '0.49.3'
```

So `pi install npm:@narumitw/pi-goal` installs pi-tui-kit **0.49.3**, five minors behind the `0.54.0` the workspace symlinks. Local development and published installs run different code.

25 packages depend on pi-tui-kit across five ranges:

| Range | Packages |
| --- | --- |
| `^0.49.1` | 15 — including `pi-goal`, `pi-subagents`, `pi-workflow`, `pi-webui` |
| `^0.51.0` | 4 |
| `^0.52.0` | 1 |
| `^0.53.0` | 1 |
| `^0.54.0` | 4 |

Those ranges are mutually **disjoint** under `0.x` caret rules, so installing several `@narumitw` extensions into one project can pull three or four copies of pi-tui-kit into a single `node_modules`.

## Cause

`.changeset/config.json` sets:

```json
"updateInternalDependencies": "patch",
"bumpVersionsWithWorkspaceProtocolOnly": true
```

The second option restricts changesets to bumping internal dependency ranges that use the `workspace:` protocol. Every internal range in this repo is a plain caret range, so `updateInternalDependencies` has never applied to any of them and the ranges have only ever moved when edited by hand.

## Change

One line: `bumpVersionsWithWorkspaceProtocolOnly` → `false`.

With the flag off, the existing `updateInternalDependencies: "patch"` setting maintains internal ranges during `changeset version`, so the current drift corrects itself on the next release that touches these packages, and new drift cannot accumulate.

## Why not fix the ranges directly

Hand-bumping the 25 stale ranges in this PR would assert that every dependent is compatible with pi-tui-kit 0.54.0 — which I cannot verify from outside, and which would need a re-check on every future release anyway. Fixing the mechanism lets the release tooling do it with CI behind it.

If you would rather correct the existing ranges immediately as well, I am happy to add that as a second commit here or a follow-up PR.

## Alternative worth considering

Switching internal dependencies to `workspace:^` would make this class of drift structurally impossible — the package manager rewrites the range to the concrete version at publish time, so the published range always matches what the workspace resolved. That is a larger change and touches how the packages are consumed, so I have not assumed it; this PR takes the minimal path through the existing configuration.

## Verification

No source or behavior changes; the effect appears at `changeset version` time. The `npm view` command above reproduces the resolution problem against the currently published packages.

---

This pull request is AI-assisted: the analysis and patch were produced with Claude Code and reviewed before submission.
