### PR TITLE
feat(subagents)!: remove worker aliases

### DIFF
--- a/.changeset/remove-subagent-worker-aliases.md
+++ b/.changeset/remove-subagent-worker-aliases.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": major
+---
+
+Remove the built-in `general` and `general-purpose` worker aliases so the built-in implementation agent catalog exposes only `worker`.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -834,7 +834,6 @@ Built-in agents are available without setup and can be overridden by user or pro
 | `planner` | Grounded implementation plans. | `read`, `grep`, `find`, `ls` |
 | `reviewer` | Independent review of code and existing verification evidence. | `read`, `grep`, `find`, `ls`, `bash` |
 | `worker` | General-purpose implementation. | Pi default tools |
-| `general`, `general-purpose` | Aliases for `worker`. | Pi default tools |
 
 The built-in `reviewer` does not run tests, builds, benchmarks, or formatters. It recommends additional verification commands for the main agent to run instead. Custom agents can override this behavior.
 
@@ -843,7 +842,7 @@ Built-ins also have no fixed thinking override until a caller, frontmatter, per-
 
 The optional profiles apply these provider-neutral thinking defaults:
 
-| Profile | `scout` | `planner` | `reviewer` | `worker` and aliases |
+| Profile | `scout` | `planner` | `reviewer` | `worker` |
 | --- | --- | --- | --- | --- |
 | Fast | `low` | `low` | `medium` | `low` |
 | Balanced | `low` | `medium` | `medium` | `medium` |

--- a/packages/pi-subagents/src/agents/built-ins.ts
+++ b/packages/pi-subagents/src/agents/built-ins.ts
@@ -67,28 +67,6 @@ export const BUILT_IN_AGENTS: AgentConfig[] = [
 		filePath: "built-in:worker",
 		systemPrompt: workerSystemPrompt(),
 	},
-	{
-		name: "general",
-		description: "Alias for worker; kept for model-generated subagent names.",
-		capabilityManifest: builtInManifest(
-			["implementation", "command-execution", "repository-modification"],
-			"write",
-		),
-		source: "built-in",
-		filePath: "built-in:general",
-		systemPrompt: workerSystemPrompt(),
-	},
-	{
-		name: "general-purpose",
-		description: "Alias for worker; compatible with common subagent naming conventions.",
-		capabilityManifest: builtInManifest(
-			["implementation", "command-execution", "repository-modification"],
-			"write",
-		),
-		source: "built-in",
-		filePath: "built-in:general-purpose",
-		systemPrompt: workerSystemPrompt(),
-	},
 ];
 
 export function getBuiltInAgent(name: string): AgentConfig | undefined {

--- a/packages/pi-subagents/src/execution-profiles.ts
+++ b/packages/pi-subagents/src/execution-profiles.ts
@@ -4,14 +4,7 @@ import { readSubagentSettings, updateAgentSettingsPatch } from "./settings.js";
 export const EXECUTION_PROFILES = ["fast", "balanced", "deep"] as const;
 export type ExecutionProfile = (typeof EXECUTION_PROFILES)[number];
 
-const PROFILE_AGENT_ORDER = [
-	"scout",
-	"planner",
-	"reviewer",
-	"worker",
-	"general",
-	"general-purpose",
-] as const;
+const PROFILE_AGENT_ORDER = ["scout", "planner", "reviewer", "worker"] as const;
 
 type ProfileAgent = (typeof PROFILE_AGENT_ORDER)[number];
 
@@ -24,24 +17,18 @@ export const EXECUTION_PROFILE_THINKING: Record<
 		planner: "low",
 		reviewer: "medium",
 		worker: "low",
-		general: "low",
-		"general-purpose": "low",
 	},
 	balanced: {
 		scout: "low",
 		planner: "medium",
 		reviewer: "medium",
 		worker: "medium",
-		general: "medium",
-		"general-purpose": "medium",
 	},
 	deep: {
 		scout: "medium",
 		planner: "high",
 		reviewer: "high",
 		worker: "high",
-		general: "high",
-		"general-purpose": "high",
 	},
 };
 

--- a/packages/pi-subagents/test/agents.test.ts
+++ b/packages/pi-subagents/test/agents.test.ts
@@ -81,6 +81,10 @@ test("built-in lookup is immutable when a user agent and settings override the s
 		assert.equal(builtIn?.thinkingLevel, undefined);
 		builtIn?.tools?.push("write");
 		assert.deepEqual(getBuiltInAgent("planner")?.tools, ["read", "grep", "find", "ls"]);
+		assert.equal(getBuiltInAgent("general"), undefined);
+		assert.equal(getBuiltInAgent("general-purpose"), undefined);
+		const builtInNames = discoverAgents(directory, "project").agents.map((agent) => agent.name);
+		assert.deepEqual(builtInNames, ["scout", "planner", "reviewer", "worker"]);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;

--- a/packages/pi-subagents/test/consult.test.ts
+++ b/packages/pi-subagents/test/consult.test.ts
@@ -167,7 +167,7 @@ test("subagent_consult bounds unknown-agent recovery metadata", async () => {
 		assert.equal(requests.length, 0);
 		assert.ok(Buffer.byteLength(message, "utf8") <= 6 * 1024);
 		assert.doesNotMatch(message, /x{200}/);
-		assert.match(message, /14 additional agent definitions? omitted/);
+		assert.match(message, /12 additional agent definitions? omitted/);
 
 		rmSync(agentsDir, { recursive: true, force: true });
 		writeFileSync(agentsDir, "not a directory");

--- a/packages/pi-subagents/test/execution-ui.test.ts
+++ b/packages/pi-subagents/test/execution-ui.test.ts
@@ -67,7 +67,9 @@ test("execution profile preview cancels without a write and applies one atomic p
 		const saved = JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8"));
 		assert.equal(saved.agents.scout.thinkingLevel, "low");
 		assert.equal(saved.agents.reviewer.thinkingLevel, "medium");
-		assert.equal(saved.agents.general.thinkingLevel, "medium");
+		assert.equal(saved.agents.worker.thinkingLevel, "medium");
+		assert.equal(saved.agents.general, undefined);
+		assert.equal(saved.agents["general-purpose"], undefined);
 		assert.equal(saved.agents.backend.thinkingLevel, undefined);
 		assert.equal(saved.agents.backend.model, "unavailable/model");
 		assert.deepEqual(saved.agents.backend.tools, ["bash"]);


### PR DESCRIPTION
## Summary

- Remove the built-in `general` and `general-purpose` subagent aliases.
- Keep `worker` as the only built-in implementation worker.
- Update execution profiles, README docs, tests, and Changeset release metadata.

## Verification

- TDD red: focused `agents.test.ts` assertion initially failed because `getBuiltInAgent("general")` still resolved.
- `npx vitest run packages/pi-subagents/test/consult.test.ts packages/pi-subagents/test/agents.test.ts packages/pi-subagents/test/execution-ui.test.ts`
- `npm run check`

## Audit

- Read and applied `docs/extension-conventions.md`.
- Read and applied `docs/extension-settings.md` because execution profile writes settings.
- Accepted breaking-change deviation intentionally to keep the built-in agent catalog minimal.
