### PR TITLE
feat(subagents)!: remove built-in reviewer

### DIFF
--- a/.changeset/remove-subagent-reviewer.md
+++ b/.changeset/remove-subagent-reviewer.md
@@ -1,0 +1,6 @@
+---
+"@narumitw/pi-subagents": major
+---
+
+Remove the built-in `reviewer` subagent so the built-in catalog exposes only `scout`, `planner`, and `worker`.
+Review workflows can still use custom user or project agents with review capabilities.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -232,6 +232,8 @@ A blocking fan-out is reserved for output that must be synthesized before the ro
 `subagent_auto` is an opt-in surface separate from the large multi-mode `subagent` schema.
 It never intercepts ordinary prompts and does not change existing calls when omitted.
 The caller supplies one versioned objective, non-goals, required inputs, acceptance criteria, required evidence, an authority ceiling, an aggregate budget, and deterministic constraints.
+Mutating autonomous workflows that require verification need a user-scoped custom verifier agent with `structured-v2` output and the `independent-review` role, because the built-in catalog intentionally has no reviewer.
+Create one like the [`api-reviewer` custom agent](#-custom-agents) before using the mutating example below, or omit review capability and verification requirements for reconnaissance-only automation.
 
 ```json
 {

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -18,7 +18,7 @@ Use it to split independent research, planning, implementation, and review work 
 - Supports an opt-in public-SDK `in-process` stateful transport with one reusable child `AgentSession` per `agentId`.
 - Supports an opt-in persistent `rpc` transport with one isolated Pi RPC process per active retained agent and `pi-subagents:v1` lifecycle metadata.
 - Supports deterministic opt-in `auto` routing: read-only built-ins use in-process, write-capable built-ins use RPC, and custom tools use the compatibility subprocess path.
-- Supports built-in `scout`, `planner`, `reviewer`, and `worker` agents.
+- Supports built-in `scout`, `planner`, and `worker` agents.
 - Loads custom user agents from `~/.pi/agent/agents/*.md`.
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
 - Provides a current-session-first `/subagents` manager, direct `settings|status|help` routes, and compatibility aliases for agent tools and retained agents.
@@ -196,12 +196,12 @@ No subagent for a known-file edit:
 Rename one symbol in src/foo.ts.
 ```
 
-One detached agent for a broad asynchronous review that the current response does not require, or when auto-resume is enabled (call `subagent_spawn`):
+One detached agent for broad asynchronous research that the current response does not require, or when auto-resume is enabled (call `subagent_spawn`):
 
 ```json
 {
-  "agent": "reviewer",
-  "task": "Review source, tests, and integration risks for the current changes. Do not edit files. Report PASS/FAIL/PARTIAL with evidence."
+  "agent": "scout",
+  "task": "Inspect source, tests, and integration risks for the current changes. Do not edit files. Report concise findings with evidence."
 }
 ```
 
@@ -221,7 +221,7 @@ A blocking fan-out is reserved for output that must be synthesized before the ro
     }
   ],
   "aggregator": {
-    "agent": "reviewer",
+    "agent": "scout",
     "task": "Merge these findings into a concise implementation-risk summary. Use {previous}."
   }
 }
@@ -318,7 +318,7 @@ The schema rejects fields that do not belong to the selected action. Explicit `p
 
 ```json
 {
-  "agent": "reviewer",
+  "agent": "scout",
   "task": "Inspect the authentication changes and report correctness and security findings with paths.",
   "thinkingLevel": "high"
 }
@@ -377,8 +377,8 @@ Run multiple agents in parallel with a shared thinking level and one per-task ov
       "thinkingLevel": "low"
     },
     {
-      "agent": "reviewer",
-      "task": "Review TypeScript config consistency"
+      "agent": "scout",
+      "task": "Inspect TypeScript config consistency"
     }
   ],
   "timeoutMs": 120000,
@@ -399,7 +399,7 @@ Run parallel workers, then aggregate their results:
     { "agent": "scout", "task": "Find auth-related tests" }
   ],
   "aggregator": {
-    "agent": "reviewer",
+    "agent": "scout",
     "task": "Merge, dedupe, and verify these findings. Use {previous}."
   }
 }
@@ -429,10 +429,10 @@ Run an evidence-preserving panel:
     "task": "Review the authentication change for correctness and regressions.",
     "context": "Inspect the current repository snapshot and existing test evidence.",
     "reviewers": [
-      { "id": "correctness", "agent": "reviewer", "focus": "Control flow and edge cases" },
-      { "id": "tests", "agent": "reviewer", "focus": "Coverage and regression risk" }
+      { "id": "correctness", "agent": "scout", "focus": "Control flow and edge cases" },
+      { "id": "tests", "agent": "scout", "focus": "Coverage and regression risk" }
     ],
-    "synthesizer": { "agent": "reviewer" },
+    "synthesizer": { "agent": "scout" },
     "minValidReviews": 2
   },
   "totalTimeoutMs": 120000
@@ -468,8 +468,8 @@ Run an explicit dependency workflow:
       },
       {
         "id": "review",
-        "agent": "reviewer",
-        "task": "Review the inventory and report verification evidence.",
+        "agent": "scout",
+        "task": "Inspect the inventory and report verification evidence.",
         "dependsOn": ["inventory"],
         "inputArtifacts": ["auth-inventory"],
         "resultFormat": "structured-v2"
@@ -481,6 +481,7 @@ Run an explicit dependency workflow:
 ```
 
 Managed verified execution is an explicit per-workflow contract.
+The verifier examples below assume a custom user agent named `api-reviewer` with `independent-review` capability.
 The executor infers the final mutating integration owner when none is declared, synthesizes one distinct read-only verifier, runs declared deterministic checks in a disposable Git worktree overlaid with the submitted state, and accepts only the exact unchanged submitted state.
 Every deterministic check has a stable evidence ID, a direct executable with argument-array invocation, and an optional relative `cwd` and timeout.
 Only `git`, `node`, `npm`, and `npx` are accepted; shell command strings fail before child allocation.
@@ -491,7 +492,7 @@ Every required evidence ID must match a currently passed executor-owned check; w
 {
   "workflow": {
     "verifiedExecution": {
-      "verifierAgent": "reviewer",
+      "verifierAgent": "api-reviewer",
       "maxReworkCycles": 1,
       "checks": [
         {
@@ -557,7 +558,7 @@ The older explicit verifier contract remains available as a compatibility gate w
       },
       {
         "id": "verification",
-        "agent": "reviewer",
+        "agent": "api-reviewer",
         "task": "Independently verify the staged result.",
         "dependsOn": ["implementation"],
         "verifierFor": "implementation",
@@ -737,7 +738,7 @@ A spawn can request a thinking level explicitly:
 
 ```json
 {
-  "agent": "reviewer",
+  "agent": "scout",
   "task": "Analyze the cross-package concurrency failure and identify the safest fix",
   "thinkingLevel": "high"
 }
@@ -832,14 +833,13 @@ Built-in agents are available without setup and can be overridden by user or pro
 | --- | --- | --- |
 | `scout` | Read-only codebase reconnaissance. | `read`, `grep`, `find`, `ls`, `bash` |
 | `planner` | Grounded implementation plans. | `read`, `grep`, `find`, `ls` |
-| `reviewer` | Independent review of code and existing verification evidence. | `read`, `grep`, `find`, `ls`, `bash` |
 | `worker` | General-purpose implementation. | Pi default tools |
 
-The built-in `reviewer` does not run tests, builds, benchmarks, or formatters. It recommends additional verification commands for the main agent to run instead. Custom agents can override this behavior.
+Review-specific delegation should use a custom user or project agent when needed.
 
 Built-in agents inherit the active/default Pi model instead of forcing a provider-specific model alias, which keeps every transport usable across different Pi setups.
 The built-in `scout` defaults to `low` thinking for bounded reconnaissance.
-`planner`, `reviewer`, and `worker` inherit thinking unless a caller, frontmatter, or per-agent setting selects one.
+`planner` and `worker` inherit thinking unless a caller, frontmatter, or per-agent setting selects one.
 
 ## ⚙️ Configure agent tools
 

--- a/packages/pi-subagents/src/agents/built-ins.ts
+++ b/packages/pi-subagents/src/agents/built-ins.ts
@@ -40,24 +40,6 @@ export const BUILT_IN_AGENTS: AgentConfig[] = [
 		].join("\n"),
 	},
 	{
-		name: "reviewer",
-		description: "Independent code review agent that inspects existing verification evidence.",
-		tools: ["read", "grep", "find", "ls", "bash"],
-		capabilityManifest: builtInManifest(
-			["code-review", "evidence-review", "security-baseline"],
-			"read",
-			["independent-review"],
-		),
-		source: "built-in",
-		filePath: "built-in:reviewer",
-		systemPrompt: [
-			"You are a reviewer subagent. Review changes adversarially and assess claims against the code and existing evidence.",
-			"Do not edit files or run tests, builds, benchmarks, formatters, or other long-running verification commands.",
-			"Inspect code, diffs, test definitions, and existing verification evidence. Recommend any additional commands for the main agent to run.",
-			"Report PASS, FAIL, or PARTIAL with evidence, commands inspected, and specific follow-ups.",
-		].join("\n"),
-	},
-	{
 		name: "worker",
 		description: "General-purpose implementation worker with the default Pi tool set.",
 		capabilityManifest: builtInManifest(

--- a/packages/pi-subagents/test/agents.test.ts
+++ b/packages/pi-subagents/test/agents.test.ts
@@ -84,10 +84,11 @@ test("built-in lookup is immutable when a user agent and settings override the s
 		assert.equal(getBuiltInAgent("worker")?.thinkingLevel, undefined);
 		builtIn?.tools?.push("write");
 		assert.deepEqual(getBuiltInAgent("planner")?.tools, ["read", "grep", "find", "ls"]);
+		assert.equal(getBuiltInAgent("reviewer"), undefined);
 		assert.equal(getBuiltInAgent("general"), undefined);
 		assert.equal(getBuiltInAgent("general-purpose"), undefined);
 		const builtInNames = discoverAgents(directory, "project").agents.map((agent) => agent.name);
-		assert.deepEqual(builtInNames, ["scout", "planner", "reviewer", "worker"]);
+		assert.deepEqual(builtInNames, ["scout", "planner", "worker"]);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;

--- a/packages/pi-subagents/test/automation.test.ts
+++ b/packages/pi-subagents/test/automation.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import type { SubagentSettings } from "../src/agents.js";
@@ -84,39 +87,73 @@ async function run(
 	let plannerCalls = 0;
 	let workflowCalls = 0;
 	let persistenceCalls = 0;
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-automation-agents-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	writeReviewerAgent(directory);
 	const context = createMockContext({ cwd: process.cwd(), isProjectTrusted: () => true });
-	const result = await executeAutomationRequest(
-		"auto-1",
-		{ request: requestValue },
-		new AbortController().signal,
-		undefined,
-		context.ctx,
-		{
-			getSettings: () => settings,
-			runPlanner: async () => {
-				plannerCalls++;
-				if (plannerOutput instanceof Error) throw plannerOutput;
-				return plannerOutput;
+	try {
+		const result = await executeAutomationRequest(
+			"auto-1",
+			{ request: requestValue },
+			new AbortController().signal,
+			undefined,
+			context.ctx,
+			{
+				getSettings: () => settings,
+				runPlanner: async () => {
+					plannerCalls++;
+					if (plannerOutput instanceof Error) throw plannerOutput;
+					return plannerOutput;
+				},
+				runWorkflow: async (params) => {
+					workflowCalls++;
+					return {
+						content: [{ type: "text" as const, text: `executed ${params.workflow?.tasks.length}` }],
+						details: {
+							mode: "workflow" as const,
+							agentScope: "user" as const,
+							projectAgentsDir: null,
+							results: [],
+						},
+					};
+				},
+				persistCompiled: async () => {
+					persistenceCalls++;
+				},
 			},
-			runWorkflow: async (params) => {
-				workflowCalls++;
-				return {
-					content: [{ type: "text" as const, text: `executed ${params.workflow?.tasks.length}` }],
-					details: {
-						mode: "workflow" as const,
-						agentScope: "user" as const,
-						projectAgentsDir: null,
-						results: [],
-					},
-				};
-			},
-			persistCompiled: async () => {
-				persistenceCalls++;
-			},
-		},
-		isCurrent,
+			isCurrent,
+		);
+		return { result, plannerCalls, workflowCalls, persistenceCalls };
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(directory, { recursive: true, force: true });
+	}
+}
+
+function writeReviewerAgent(directory: string): void {
+	const agentsDir = path.join(directory, "agents");
+	mkdirSync(agentsDir, { recursive: true });
+	writeFileSync(
+		path.join(agentsDir, "reviewer.md"),
+		[
+			"---",
+			"name: reviewer",
+			"description: Test review agent",
+			"tools: read,grep,find,ls",
+			"capabilityManifest:",
+			"  version: pi-subagents:capabilities:v1",
+			"  capabilities: [code-review]",
+			"  modalities: [text]",
+			"  resultFormats: [structured-v2]",
+			"  authority:",
+			"    filesystem: read",
+			"  verificationRoles: [independent-review]",
+			"---",
+			"Review independently.",
+		].join("\n"),
 	);
-	return { result, plannerCalls, workflowCalls, persistenceCalls };
 }
 
 test("objective compiles to a typed parent-owned result with zero execution workers", async () => {

--- a/packages/pi-subagents/test/consult.test.ts
+++ b/packages/pi-subagents/test/consult.test.ts
@@ -132,7 +132,7 @@ test("subagent_consult reports actionable available agents before launching a ch
 			assert.match(error.message, /Unknown subagent definition: tester-one/);
 			assert.match(error.message, /Available agents for agentScope "user":/);
 			assert.match(error.message, /scout \(built-in\)/);
-			assert.match(error.message, /reviewer \(built-in\)/);
+			assert.doesNotMatch(error.message, /reviewer \(built-in\)/);
 			return true;
 		},
 	);
@@ -167,7 +167,7 @@ test("subagent_consult bounds unknown-agent recovery metadata", async () => {
 		assert.equal(requests.length, 0);
 		assert.ok(Buffer.byteLength(message, "utf8") <= 6 * 1024);
 		assert.doesNotMatch(message, /x{200}/);
-		assert.match(message, /12 additional agent definitions? omitted/);
+		assert.match(message, /11 additional agent definitions? omitted/);
 
 		rmSync(agentsDir, { recursive: true, force: true });
 		writeFileSync(agentsDir, "not a directory");

--- a/packages/pi-subagents/test/execution-plan.test.ts
+++ b/packages/pi-subagents/test/execution-plan.test.ts
@@ -34,8 +34,8 @@ test("audit execution plan reports capability mismatch, tool overgrant, and unsu
 			name: "reviewer",
 			description: "review",
 			systemPrompt: "private",
-			source: "built-in",
-			filePath: "built-in:reviewer",
+			source: "user",
+			filePath: "user:reviewer",
 			tools: ["read", "grep", "bash"],
 			capabilityManifest: {
 				version: "pi-subagents:capabilities:v1",

--- a/packages/pi-subagents/test/panel-execution.test.ts
+++ b/packages/pi-subagents/test/panel-execution.test.ts
@@ -97,14 +97,14 @@ test("panel mode rejects mixed modes and unknown agents before launch", async ()
 	const panel = {
 		task: "Review",
 		reviewers: [
-			{ id: "a", agent: "reviewer" },
-			{ id: "b", agent: "reviewer" },
+			{ id: "a", agent: "scout" },
+			{ id: "b", agent: "scout" },
 		],
-		synthesizer: { agent: "reviewer" },
+		synthesizer: { agent: "scout" },
 	};
 	const mixed = await tool.execute(
 		"panel-mixed",
-		{ agent: "reviewer", task: "single", panel },
+		{ agent: "scout", task: "single", panel },
 		undefined,
 		undefined,
 		createMockContext().ctx,
@@ -219,10 +219,10 @@ test("panel executes isolated reviewers, preserves evidence, then synthesizes on
 					task: "Review the shared change",
 					context: "diff: shared",
 					reviewers: [
-						{ id: "a", agent: "reviewer", focus: "correctness" },
-						{ id: "b", agent: "reviewer", focus: "tests" },
+						{ id: "a", agent: "scout", focus: "correctness" },
+						{ id: "b", agent: "scout", focus: "tests" },
 					],
-					synthesizer: { agent: "reviewer" },
+					synthesizer: { agent: "scout" },
 					minValidReviews: 2,
 				},
 			},
@@ -291,10 +291,10 @@ test("timed-out reviewers receive one bounded contract finalization turn", async
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "reviewer", timeoutMs: 50 },
-						{ id: "b", agent: "reviewer", timeoutMs: 50 },
+						{ id: "a", agent: "scout", timeoutMs: 50 },
+						{ id: "b", agent: "scout", timeoutMs: 50 },
 					],
-					synthesizer: { agent: "reviewer" },
+					synthesizer: { agent: "scout" },
 				},
 			},
 			undefined,
@@ -337,10 +337,10 @@ test("panel preserves valid reviews when synthesis returns an invalid contract",
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "reviewer" },
-						{ id: "b", agent: "reviewer" },
+						{ id: "a", agent: "scout" },
+						{ id: "b", agent: "scout" },
 					],
-					synthesizer: { agent: "reviewer" },
+					synthesizer: { agent: "scout" },
 				},
 			},
 			undefined,
@@ -385,10 +385,10 @@ test("panel marks valid synthesis output from an errored process as failed", asy
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "reviewer" },
-						{ id: "b", agent: "reviewer" },
+						{ id: "a", agent: "scout" },
+						{ id: "b", agent: "scout" },
 					],
-					synthesizer: { agent: "reviewer" },
+					synthesizer: { agent: "scout" },
 				},
 			},
 			undefined,
@@ -434,10 +434,10 @@ test("panel retries transient transport failures once within the review phase", 
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "reviewer" },
-						{ id: "b", agent: "reviewer" },
+						{ id: "a", agent: "scout" },
+						{ id: "b", agent: "scout" },
 					],
-					synthesizer: { agent: "reviewer" },
+					synthesizer: { agent: "scout" },
 				},
 			},
 			undefined,
@@ -567,10 +567,10 @@ test("an insufficient panel returns partial evidence and never launches synthesi
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "reviewer" },
-						{ id: "b", agent: "reviewer" },
+						{ id: "a", agent: "scout" },
+						{ id: "b", agent: "scout" },
 					],
-					synthesizer: { agent: "reviewer" },
+					synthesizer: { agent: "scout" },
 				},
 			},
 			undefined,
@@ -613,10 +613,10 @@ test("ordinary reviewer progress updates do not trigger a semantic stall", async
 				panel: {
 					task: "Review after ordinary progress",
 					reviewers: [
-						{ id: "a", agent: "reviewer" },
-						{ id: "b", agent: "reviewer" },
+						{ id: "a", agent: "scout" },
+						{ id: "b", agent: "scout" },
 					],
-					synthesizer: { agent: "reviewer" },
+					synthesizer: { agent: "scout" },
 				},
 			},
 			undefined,
@@ -658,10 +658,10 @@ test("panel semantic progress stops repeated evidence states without blind retri
 				panel: {
 					task: "Review with evidence",
 					reviewers: [
-						{ id: "a", agent: "reviewer" },
-						{ id: "b", agent: "reviewer" },
+						{ id: "a", agent: "scout" },
+						{ id: "b", agent: "scout" },
 					],
-					synthesizer: { agent: "reviewer" },
+					synthesizer: { agent: "scout" },
 				},
 			},
 			undefined,
@@ -918,9 +918,9 @@ test("panel cancellation closes the child group and skips synthesis", async () =
 					task: "Review until cancelled",
 					reviewers: Array.from({ length: 5 }, (_, index) => ({
 						id: `reviewer-${index}`,
-						agent: "reviewer",
+						agent: "scout",
 					})),
-					synthesizer: { agent: "reviewer" },
+					synthesizer: { agent: "scout" },
 				},
 			},
 			controller.signal,

--- a/packages/pi-subagents/test/subagent-workflow-execution.test.ts
+++ b/packages/pi-subagents/test/subagent-workflow-execution.test.ts
@@ -14,7 +14,32 @@ import {
 } from "./subagents-test-helpers.js";
 
 const restoreTestEnvironment = installSubagentsTestEnvironment();
+writeReviewerAgent(process.env.PI_CODING_AGENT_DIR ?? "");
 afterAll(restoreTestEnvironment);
+
+function writeReviewerAgent(directory: string): void {
+	const agentsDir = path.join(directory, "agents");
+	mkdirSync(agentsDir, { recursive: true });
+	writeFileSync(
+		path.join(agentsDir, "reviewer.md"),
+		[
+			"---",
+			"name: reviewer",
+			"description: Test review agent",
+			"tools: read,grep,find,ls",
+			"capabilityManifest:",
+			"  version: pi-subagents:capabilities:v1",
+			"  capabilities: [code-review]",
+			"  modalities: [text]",
+			"  resultFormats: [structured-v2]",
+			"  authority:",
+			"    filesystem: read",
+			"  verificationRoles: [independent-review]",
+			"---",
+			"Review independently.",
+		].join("\n"),
+	);
+}
 
 test("workflow mode schedules dependency-ready tasks and rejects cycles before child launch", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-workflow-"));

--- a/packages/pi-subagents/test/subagents-agent-catalog.test.ts
+++ b/packages/pi-subagents/test/subagents-agent-catalog.test.ts
@@ -175,21 +175,14 @@ test("discoverAgents includes built-ins and lets project agents override by name
 	assert.ok(result.agents.some((agent) => agent.name === "worker" && agent.source === "built-in"));
 });
 
-test("built-in reviewer inspects evidence without running verification commands", () => {
+test("reviewer is no longer a built-in agent", () => {
 	const cwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-reviewer-test-"));
 	try {
 		const reviewer = discoverAgents(cwd, "project").agents.find(
 			(agent) => agent.name === "reviewer",
 		);
 
-		assert.ok(reviewer);
-		assert.match(
-			reviewer.systemPrompt,
-			/do not edit files or run tests, builds, benchmarks, formatters/i,
-		);
-		assert.match(reviewer.systemPrompt, /recommend.*commands for the main agent to run/i);
-		assert.doesNotMatch(reviewer.systemPrompt, /run safe inspection or test commands/i);
-		assert.ok(reviewer.tools?.includes("bash"));
+		assert.equal(reviewer, undefined);
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

- Remove the built-in `reviewer` subagent from the built-in agent catalog.
- Keep review-capable workflows available through custom user or project agents such as `api-reviewer`.
- Update docs, profile defaults, panel examples, and tests to use `scout` or custom review agents instead of the removed built-in.

## Verification

- TDD red: `npx vitest run packages/pi-subagents/test/agents.test.ts` initially failed because `getBuiltInAgent("reviewer")` still resolved.
- `npx vitest run packages/pi-subagents/test/*.test.ts`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm run check`

## Audit

- Read and applied `docs/extension-conventions.md`.
- Settings impact audited: execution profiles no longer patch `reviewer`, while custom per-agent settings remain available.
- Intentional breaking change: existing calls to built-in `reviewer` now require a custom agent definition.
