### PR TITLE
feat(subagents)!: rename scout to explorer

### DIFF
--- a/.changeset/remove-subagent-reviewer.md
+++ b/.changeset/remove-subagent-reviewer.md
@@ -2,5 +2,5 @@
 "@narumitw/pi-subagents": major
 ---
 
-Remove the built-in `reviewer` subagent so the built-in catalog exposes only `scout`, `planner`, and `worker`.
+Remove the built-in `reviewer` subagent so the built-in catalog exposes only `explorer`, `planner`, and `worker`.
 Review workflows can still use custom user or project agents with review capabilities.

--- a/.changeset/remove-subagent-worker-aliases.md
+++ b/.changeset/remove-subagent-worker-aliases.md
@@ -4,4 +4,4 @@
 
 Remove the built-in `general` and `general-purpose` worker aliases so the built-in implementation agent catalog exposes only `worker`.
 Remove Fast/Balanced/Deep execution profile presets so thinking defaults are selected by task calls or explicit per-agent settings.
-Default the built-in `scout` agent to `low` thinking while `planner`, `reviewer`, and `worker` inherit unless configured.
+Default the built-in `explorer` agent to `low` thinking while `planner` and `worker` inherit unless configured.

--- a/.changeset/rename-scout-explorer.md
+++ b/.changeset/rename-scout-explorer.md
@@ -3,3 +3,4 @@
 ---
 
 Rename the built-in `scout` subagent to `explorer` to align the read-only codebase exploration role with Codex.
+Existing `agents.scout` settings apply to `explorer` when they are unambiguous.

--- a/.changeset/rename-scout-explorer.md
+++ b/.changeset/rename-scout-explorer.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": major
+---
+
+Rename the built-in `scout` subagent to `explorer` to align the read-only codebase exploration role with Codex.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -854,6 +854,7 @@ tool names and availability metadata; Save and Discard remain pinned below the m
 settings stored in `~/.pi/agent/pi-subagents.json` and affect future sessions.
 
 Compatibility: a valid legacy `pi-subagents-config.json` remains readable with a warning and is never modified automatically; rename it to `pi-subagents.json`. The first subsequent settings save writes the canonical file. If both files exist, the new filename takes precedence.
+A saved `agents.scout` override from earlier releases applies to the renamed built-in `explorer` only when no explicit `agents.explorer` override exists and no custom `scout` agent is available.
 
 - Select an agent, then press Enter or Space to toggle tools.
 - Choose **Save changes** to write the draft, choose **Discard draft** to abandon it, or press Esc to

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -18,7 +18,7 @@ Use it to split independent research, planning, implementation, and review work 
 - Supports an opt-in public-SDK `in-process` stateful transport with one reusable child `AgentSession` per `agentId`.
 - Supports an opt-in persistent `rpc` transport with one isolated Pi RPC process per active retained agent and `pi-subagents:v1` lifecycle metadata.
 - Supports deterministic opt-in `auto` routing: read-only built-ins use in-process, write-capable built-ins use RPC, and custom tools use the compatibility subprocess path.
-- Supports built-in `scout`, `planner`, and `worker` agents.
+- Supports built-in `explorer`, `planner`, and `worker` agents.
 - Loads custom user agents from `~/.pi/agent/agents/*.md`.
 - Optionally loads project agents from `.pi/agents/*.md` with confirmation.
 - Provides a current-session-first `/subagents` manager, direct `settings|status|help` routes, and compatibility aliases for agent tools and retained agents.
@@ -200,7 +200,7 @@ One detached agent for broad asynchronous research that the current response doe
 
 ```json
 {
-  "agent": "scout",
+  "agent": "explorer",
   "task": "Inspect source, tests, and integration risks for the current changes. Do not edit files. Report concise findings with evidence."
 }
 ```
@@ -212,16 +212,16 @@ A blocking fan-out is reserved for output that must be synthesized before the ro
 {
   "tasks": [
     {
-      "agent": "scout",
+      "agent": "explorer",
       "task": "Research auth-related source files. Report paths and open questions. Do not edit files."
     },
     {
-      "agent": "scout",
+      "agent": "explorer",
       "task": "Research auth-related tests. Report coverage gaps. Do not edit files."
     }
   ],
   "aggregator": {
-    "agent": "scout",
+    "agent": "explorer",
     "task": "Merge these findings into a concise implementation-risk summary. Use {previous}."
   }
 }
@@ -320,7 +320,7 @@ The schema rejects fields that do not belong to the selected action. Explicit `p
 
 ```json
 {
-  "agent": "scout",
+  "agent": "explorer",
   "task": "Inspect the authentication changes and report correctness and security findings with paths.",
   "thinkingLevel": "high"
 }
@@ -360,7 +360,7 @@ Run one read-only reconnaissance agent:
 
 ```json
 {
-  "agent": "scout",
+  "agent": "explorer",
   "task": "Find the statusline extension entry points"
 }
 ```
@@ -373,13 +373,13 @@ Run multiple agents in parallel with a shared thinking level and one per-task ov
 {
   "tasks": [
     {
-      "agent": "scout",
+      "agent": "explorer",
       "task": "Map package metadata files",
       "timeoutMs": 30000,
       "thinkingLevel": "low"
     },
     {
-      "agent": "scout",
+      "agent": "explorer",
       "task": "Inspect TypeScript config consistency"
     }
   ],
@@ -397,11 +397,11 @@ Run parallel workers, then aggregate their results:
 ```json
 {
   "tasks": [
-    { "agent": "scout", "task": "Find auth-related code" },
-    { "agent": "scout", "task": "Find auth-related tests" }
+    { "agent": "explorer", "task": "Find auth-related code" },
+    { "agent": "explorer", "task": "Find auth-related tests" }
   ],
   "aggregator": {
-    "agent": "scout",
+    "agent": "explorer",
     "task": "Merge, dedupe, and verify these findings. Use {previous}."
   }
 }
@@ -412,7 +412,7 @@ Run a chain where each step receives the previous output:
 ```json
 {
   "chain": [
-    { "agent": "scout", "task": "Find subagent-related code" },
+    { "agent": "explorer", "task": "Find subagent-related code" },
     {
       "agent": "planner",
       "task": "Using this context, plan the extension: {previous}"
@@ -431,10 +431,10 @@ Run an evidence-preserving panel:
     "task": "Review the authentication change for correctness and regressions.",
     "context": "Inspect the current repository snapshot and existing test evidence.",
     "reviewers": [
-      { "id": "correctness", "agent": "scout", "focus": "Control flow and edge cases" },
-      { "id": "tests", "agent": "scout", "focus": "Coverage and regression risk" }
+      { "id": "correctness", "agent": "explorer", "focus": "Control flow and edge cases" },
+      { "id": "tests", "agent": "explorer", "focus": "Coverage and regression risk" }
     ],
-    "synthesizer": { "agent": "scout" },
+    "synthesizer": { "agent": "explorer" },
     "minValidReviews": 2
   },
   "totalTimeoutMs": 120000
@@ -463,14 +463,14 @@ Run an explicit dependency workflow:
     "tasks": [
       {
         "id": "inventory",
-        "agent": "scout",
+        "agent": "explorer",
         "task": "Produce the auth inventory artifact.",
         "resultFormat": "structured-v2",
         "readPaths": ["src/auth"]
       },
       {
         "id": "review",
-        "agent": "scout",
+        "agent": "explorer",
         "task": "Inspect the inventory and report verification evidence.",
         "dependsOn": ["inventory"],
         "inputArtifacts": ["auth-inventory"],
@@ -740,7 +740,7 @@ A spawn can request a thinking level explicitly:
 
 ```json
 {
-  "agent": "scout",
+  "agent": "explorer",
   "task": "Analyze the cross-package concurrency failure and identify the safest fix",
   "thinkingLevel": "high"
 }
@@ -833,14 +833,14 @@ Built-in agents are available without setup and can be overridden by user or pro
 
 | Agent | Purpose | Tools |
 | --- | --- | --- |
-| `scout` | Read-only codebase reconnaissance. | `read`, `grep`, `find`, `ls`, `bash` |
+| `explorer` | Read-only codebase exploration for specific questions. | `read`, `grep`, `find`, `ls`, `bash` |
 | `planner` | Grounded implementation plans. | `read`, `grep`, `find`, `ls` |
 | `worker` | General-purpose implementation. | Pi default tools |
 
 Review-specific delegation should use a custom user or project agent when needed.
 
 Built-in agents inherit the active/default Pi model instead of forcing a provider-specific model alias, which keeps every transport usable across different Pi setups.
-The built-in `scout` defaults to `low` thinking for bounded reconnaissance.
+The built-in `explorer` defaults to `low` thinking for bounded exploration.
 `planner` and `worker` inherit thinking unless a caller, frontmatter, or per-agent setting selects one.
 
 ## ⚙️ Configure agent tools

--- a/packages/pi-subagents/src/agents/built-ins.ts
+++ b/packages/pi-subagents/src/agents/built-ins.ts
@@ -7,19 +7,20 @@ import type { AgentConfig } from "./types.js";
 
 export const BUILT_IN_AGENTS: AgentConfig[] = [
 	{
-		name: "scout",
+		name: "explorer",
 		description:
-			"Read-only codebase reconnaissance; returns concise findings with paths and evidence.",
+			"Read-only codebase exploration for specific questions; returns concise findings with paths and evidence.",
 		tools: ["read", "grep", "find", "ls", "bash"],
 		capabilityManifest: builtInManifest(["repository-search", "code-evidence"], "read", [
 			"evidence-gathering",
 		]),
 		thinkingLevel: "low",
 		source: "built-in",
-		filePath: "built-in:scout",
+		filePath: "built-in:explorer",
 		systemPrompt: [
-			"You are a scout subagent. Explore the codebase quickly and report grounded findings.",
-			"Do not edit files. Prefer read, grep, find, ls, and safe bash inspection commands.",
+			"You are an explorer subagent. Explore the codebase for specific, well-scoped questions and report grounded findings.",
+			"Do not edit files. Use bash only for safe read-only inspection commands.",
+			"Do not install dependencies, run formatters, start servers, run tests, or execute long-running commands.",
 			"Return concise bullets with exact file paths, symbols, and open questions.",
 		].join("\n"),
 	},

--- a/packages/pi-subagents/src/agents/discovery.ts
+++ b/packages/pi-subagents/src/agents/discovery.ts
@@ -179,6 +179,24 @@ function hasOwn(obj: object, key: PropertyKey): boolean {
 	return Object.hasOwn(obj, key);
 }
 
+function applyAgentOverride(
+	agent: AgentConfig,
+	override: NonNullable<SubagentSettings["agents"]>[string],
+): AgentConfig {
+	const nextAgent: AgentConfig = { ...agent };
+	if (hasOwn(override, "tools")) nextAgent.tools = override.tools;
+	if (hasOwn(override, "model")) {
+		nextAgent.model = override.model === null ? undefined : override.model;
+	}
+	if (hasOwn(override, "thinkingLevel")) {
+		nextAgent.thinkingLevel = override.thinkingLevel === null ? undefined : override.thinkingLevel;
+	}
+	if (hasOwn(override, "timeoutMs")) {
+		nextAgent.timeoutMs = override.timeoutMs === null ? undefined : override.timeoutMs;
+	}
+	return nextAgent;
+}
+
 export function discoverAgents(
 	cwd: string,
 	scope: AgentScope,
@@ -217,23 +235,21 @@ export function discoverAgents(
 
 	// Apply user-configured overrides (from /subagents → Agent tool settings) on top of
 	// the final resolved agent map, regardless of agent source.
-	for (const [name, override] of Object.entries(config?.agents ?? {})) {
+	const configuredAgents = config?.agents ?? {};
+	for (const [name, override] of Object.entries(configuredAgents)) {
 		const agent = agentMap.get(name);
 		if (!agent) continue;
-
-		const nextAgent: AgentConfig = { ...agent };
-		if (hasOwn(override, "tools")) nextAgent.tools = override.tools;
-		if (hasOwn(override, "model")) {
-			nextAgent.model = override.model === null ? undefined : override.model;
-		}
-		if (hasOwn(override, "thinkingLevel")) {
-			nextAgent.thinkingLevel =
-				override.thinkingLevel === null ? undefined : override.thinkingLevel;
-		}
-		if (hasOwn(override, "timeoutMs")) {
-			nextAgent.timeoutMs = override.timeoutMs === null ? undefined : override.timeoutMs;
-		}
-		agentMap.set(name, nextAgent);
+		agentMap.set(name, applyAgentOverride(agent, override));
+	}
+	const legacyScoutOverride = configuredAgents.scout;
+	const explorerAgent = agentMap.get("explorer");
+	if (
+		legacyScoutOverride &&
+		explorerAgent &&
+		!hasOwn(configuredAgents, "explorer") &&
+		!agentMap.has("scout")
+	) {
+		agentMap.set("explorer", applyAgentOverride(explorerAgent, legacyScoutOverride));
 	}
 
 	const omittedAgentDefinitions =

--- a/packages/pi-subagents/test/agents.test.ts
+++ b/packages/pi-subagents/test/agents.test.ts
@@ -79,16 +79,17 @@ test("built-in lookup is immutable when a user agent and settings override the s
 		assert.deepEqual(builtIn?.tools, ["read", "grep", "find", "ls"]);
 		assert.equal(builtIn?.model, undefined);
 		assert.equal(builtIn?.thinkingLevel, undefined);
-		assert.equal(getBuiltInAgent("scout")?.thinkingLevel, "low");
+		assert.equal(getBuiltInAgent("explorer")?.thinkingLevel, "low");
 		assert.equal(getBuiltInAgent("reviewer")?.thinkingLevel, undefined);
 		assert.equal(getBuiltInAgent("worker")?.thinkingLevel, undefined);
 		builtIn?.tools?.push("write");
 		assert.deepEqual(getBuiltInAgent("planner")?.tools, ["read", "grep", "find", "ls"]);
+		assert.equal(getBuiltInAgent("scout"), undefined);
 		assert.equal(getBuiltInAgent("reviewer"), undefined);
 		assert.equal(getBuiltInAgent("general"), undefined);
 		assert.equal(getBuiltInAgent("general-purpose"), undefined);
 		const builtInNames = discoverAgents(directory, "project").agents.map((agent) => agent.name);
-		assert.deepEqual(builtInNames, ["scout", "planner", "worker"]);
+		assert.deepEqual(builtInNames, ["explorer", "planner", "worker"]);
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;

--- a/packages/pi-subagents/test/automation.test.ts
+++ b/packages/pi-subagents/test/automation.test.ts
@@ -177,7 +177,7 @@ test("objective compiles to one capability-routed child", async () => {
 	const { result, workflowCalls } = await run(plan([task("inspect")]));
 	assert.equal(result.details.status, "executed");
 	assert.equal(result.details.childCount, 1);
-	assert.equal(result.details.compiled?.workflow.tasks[0]?.agent, "scout");
+	assert.equal(result.details.compiled?.workflow.tasks[0]?.agent, "explorer");
 	assert.equal(workflowCalls, 1);
 });
 

--- a/packages/pi-subagents/test/blocking-subagents-execution.test.ts
+++ b/packages/pi-subagents/test/blocking-subagents-execution.test.ts
@@ -52,22 +52,22 @@ test("blocking delegation preflights every target and passes explicit saved trus
 		const tool = mock.tools.find((candidate) => candidate.name === "subagent") as SubagentTool;
 		const ctx = createMockContext({ cwd: workspace, isProjectTrusted: () => true }).ctx;
 		for (const params of [
-			{ agent: "scout", task: "single", cwd: external },
+			{ agent: "explorer", task: "single", cwd: external },
 			{
 				chain: [
-					{ agent: "scout", task: "first", cwd: workspace },
-					{ agent: "scout", task: "second", cwd: external },
+					{ agent: "explorer", task: "first", cwd: workspace },
+					{ agent: "explorer", task: "second", cwd: external },
 				],
 			},
 			{
 				tasks: [
-					{ agent: "scout", task: "first", cwd: workspace },
-					{ agent: "scout", task: "second", cwd: external },
+					{ agent: "explorer", task: "first", cwd: workspace },
+					{ agent: "explorer", task: "second", cwd: external },
 				],
 			},
 			{
-				tasks: [{ agent: "scout", task: "first", cwd: workspace }],
-				aggregator: { agent: "scout", task: "fan-in", cwd: external },
+				tasks: [{ agent: "explorer", task: "first", cwd: workspace }],
+				aggregator: { agent: "explorer", task: "fan-in", cwd: external },
 			},
 		] as Array<Record<string, unknown>>) {
 			await assert.rejects(
@@ -80,7 +80,7 @@ test("blocking delegation preflights every target and passes explicit saved trus
 		new ProjectTrustStore(agentDir).set(external, true);
 		const accepted = await tool.execute(
 			"cwd-trusted",
-			{ agent: "scout", task: "trusted", cwd: external },
+			{ agent: "explorer", task: "trusted", cwd: external },
 			undefined,
 			undefined,
 			ctx,
@@ -102,7 +102,7 @@ test("blocking delegation preflights every target and passes explicit saved trus
 		new ProjectTrustStore(agentDir).set(external, false);
 		const anywhere = await anywhereTool.execute(
 			"cwd-anywhere",
-			{ agent: "scout", task: "anywhere", cwd: external },
+			{ agent: "explorer", task: "anywhere", cwd: external },
 			undefined,
 			undefined,
 			ctx,
@@ -140,8 +140,8 @@ test("parallel execution ignores an empty optional aggregator and preserves work
 			"empty-aggregator",
 			{
 				tasks: [
-					{ agent: "scout", task: "PROOF" },
-					{ agent: "scout", task: "CALC" },
+					{ agent: "explorer", task: "PROOF" },
+					{ agent: "explorer", task: "CALC" },
 				],
 				aggregator: { agent: " ", task: "\t", thinkingLevel: "off", timeoutMs: 1 },
 			},
@@ -186,7 +186,7 @@ test("blocking totalTimeoutMs caps chains, queued parallel work, and fan-in", as
 		const earlyLimit = await tool.execute(
 			"early-limit",
 			{
-				agent: "scout",
+				agent: "explorer",
 				task: "LIMIT_EARLY",
 				timeoutMs: 5_000,
 				totalTimeoutMs: 1_000,
@@ -205,8 +205,8 @@ test("blocking totalTimeoutMs caps chains, queued parallel work, and fan-in", as
 			{
 				totalTimeoutMs: 120,
 				chain: [
-					{ agent: "scout", task: "SLOW_FIRST", timeoutMs: 5_000 },
-					{ agent: "scout", task: "SECOND_MUST_NOT_START", timeoutMs: 5_000 },
+					{ agent: "explorer", task: "SLOW_FIRST", timeoutMs: 5_000 },
+					{ agent: "explorer", task: "SECOND_MUST_NOT_START", timeoutMs: 5_000 },
 				],
 			},
 			new AbortController().signal,
@@ -223,7 +223,7 @@ test("blocking totalTimeoutMs caps chains, queued parallel work, and fan-in", as
 			{
 				totalTimeoutMs: 250,
 				tasks: Array.from({ length: 5 }, (_, index) => ({
-					agent: "scout",
+					agent: "explorer",
 					task: `SLOW_${index}`,
 					timeoutMs: 5_000,
 				})),
@@ -241,8 +241,8 @@ test("blocking totalTimeoutMs caps chains, queued parallel work, and fan-in", as
 			"total-fan-in",
 			{
 				totalTimeoutMs: 120,
-				tasks: [{ agent: "scout", task: "SLOW_FANOUT", timeoutMs: 5_000 }],
-				aggregator: { agent: "scout", task: "AGGREGATOR_MUST_NOT_START", timeoutMs: 5_000 },
+				tasks: [{ agent: "explorer", task: "SLOW_FANOUT", timeoutMs: 5_000 }],
+				aggregator: { agent: "explorer", task: "AGGREGATOR_MUST_NOT_START", timeoutMs: 5_000 },
 			},
 			new AbortController().signal,
 			undefined,
@@ -333,8 +333,8 @@ test("parallel updates keep failed fan-out pending while fan-in starts", async (
 		const result = await tool.execute(
 			"pending-fan-in",
 			{
-				tasks: [{ agent: "scout", task: "RUN_FANOUT_FAILURE" }],
-				aggregator: { agent: "scout", task: "RUN_AGGREGATOR" },
+				tasks: [{ agent: "explorer", task: "RUN_FANOUT_FAILURE" }],
+				aggregator: { agent: "explorer", task: "RUN_AGGREGATOR" },
 			},
 			signal,
 			(update: unknown) => updates.push(update as (typeof updates)[number]),
@@ -380,8 +380,8 @@ test("parallel summaries classify provider errors and retain partial output", as
 			"parallel-errors",
 			{
 				tasks: [
-					{ agent: "scout", task: "provider failure" },
-					{ agent: "scout", task: "success" },
+					{ agent: "explorer", task: "provider failure" },
+					{ agent: "explorer", task: "success" },
 				],
 			},
 			signal,
@@ -390,9 +390,9 @@ test("parallel summaries classify provider errors and retain partial output", as
 		);
 		const text = result.content?.[0]?.text ?? "";
 		assert.match(text, /Parallel: 1\/2 succeeded/);
-		assert.match(text, /\[scout\] failed: PROVIDER_FAILED/);
+		assert.match(text, /\[explorer\] failed: PROVIDER_FAILED/);
 		assert.match(text, /Partial output:\nPARTIAL/);
-		assert.match(text, /\[scout\] completed: DONE/);
+		assert.match(text, /\[explorer\] completed: DONE/);
 	} finally {
 		restorePiPackage();
 		rmSync(dir, { recursive: true, force: true });

--- a/packages/pi-subagents/test/capability-grant.test.ts
+++ b/packages/pi-subagents/test/capability-grant.test.ts
@@ -10,11 +10,11 @@ import { createExecutionPlan } from "../src/execution-plan.js";
 
 const plan = createExecutionPlan({
 	agent: {
-		name: "scout",
-		description: "scout",
+		name: "explorer",
+		description: "explorer",
 		systemPrompt: "",
 		source: "built-in",
-		filePath: "built-in:scout",
+		filePath: "built-in:explorer",
 		tools: ["read"],
 	},
 	effectiveTools: ["read"],

--- a/packages/pi-subagents/test/capability-router.test.ts
+++ b/packages/pi-subagents/test/capability-router.test.ts
@@ -34,7 +34,7 @@ function candidate(
 test("capability routing rejects unsupported work before execution", () => {
 	assert.throws(
 		() =>
-			routeByCapability([candidate("scout", ["repository-research"], "low")], {
+			routeByCapability([candidate("explorer", ["repository-research"], "low")], {
 				requiredCapabilities: ["typescript-implementation"],
 			}),
 		/no capable agent/i,
@@ -56,8 +56,8 @@ test("capability routing deterministically prefers the requested cost profile", 
 test("capability routing validates an explicitly selected agent", () => {
 	assert.throws(
 		() =>
-			routeByCapability([candidate("scout", ["repository-research"], "low")], {
-				agent: "scout",
+			routeByCapability([candidate("explorer", ["repository-research"], "low")], {
+				agent: "explorer",
 				requiredCapabilities: ["code-review"],
 			}),
 		/does not satisfy/i,

--- a/packages/pi-subagents/test/completion-delivery.test.ts
+++ b/packages/pi-subagents/test/completion-delivery.test.ts
@@ -6,7 +6,7 @@ import { CompletionDeliveryBroker } from "../src/stateful.js";
 function completion(id: string, output = `output:${id}`): AgentTurnCompletion {
 	const agent: ManagedAgent = {
 		id,
-		agent: "scout",
+		agent: "explorer",
 		rootId: id,
 		depth: 0,
 		children: [],
@@ -111,7 +111,7 @@ test("next-turn completion delivery never wakes an idle root", () => {
 		runId: "run:sa_one:1",
 		generation: 1,
 		agentId: "sa_one",
-		agent: "scout",
+		agent: "explorer",
 		state: "completed",
 	});
 	broker.close();
@@ -138,7 +138,7 @@ test("auto-resume batches simultaneous completions into one root synthesis turn"
 				runId: "run:sa_one:1",
 				generation: 1,
 				agentId: "sa_one",
-				agent: "scout",
+				agent: "explorer",
 				state: "completed",
 			},
 			{
@@ -147,7 +147,7 @@ test("auto-resume batches simultaneous completions into one root synthesis turn"
 				runId: "run:sa_two:1",
 				generation: 1,
 				agentId: "sa_two",
-				agent: "scout",
+				agent: "explorer",
 				state: "completed",
 			},
 		],

--- a/packages/pi-subagents/test/consult.test.ts
+++ b/packages/pi-subagents/test/consult.test.ts
@@ -131,7 +131,7 @@ test("subagent_consult reports actionable available agents before launching a ch
 			assert.ok(error instanceof Error);
 			assert.match(error.message, /Unknown subagent definition: tester-one/);
 			assert.match(error.message, /Available agents for agentScope "user":/);
-			assert.match(error.message, /scout \(built-in\)/);
+			assert.match(error.message, /explorer \(built-in\)/);
 			assert.doesNotMatch(error.message, /reviewer \(built-in\)/);
 			return true;
 		},

--- a/packages/pi-subagents/test/context-protocol.test.ts
+++ b/packages/pi-subagents/test/context-protocol.test.ts
@@ -11,7 +11,7 @@ import { buildStatefulTurnPrompt, resolveStatefulTurnTimeout } from "../src/stat
 function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 	return {
 		id: "sa_test",
-		agent: "scout",
+		agent: "explorer",
 		rootId: "sa_test",
 		depth: 0,
 		children: [],

--- a/packages/pi-subagents/test/execution-plan.test.ts
+++ b/packages/pi-subagents/test/execution-plan.test.ts
@@ -82,11 +82,11 @@ test("execution plans record deterministic admission and rotate cancellation gen
 	const plan = createExecutionPlan({
 		contract,
 		agent: {
-			name: "scout",
-			description: "scout",
+			name: "explorer",
+			description: "explorer",
 			systemPrompt: "private",
 			source: "built-in",
-			filePath: "built-in:scout",
+			filePath: "built-in:explorer",
 			capabilityManifest: {
 				version: "pi-subagents:capabilities:v1",
 				capabilities: ["repository-search"],
@@ -143,11 +143,11 @@ test("enforced execution plans narrow tools and reject unknown or unsupported gu
 	const plan = createExecutionPlan({
 		contract,
 		agent: {
-			name: "scout",
-			description: "scout",
+			name: "explorer",
+			description: "explorer",
 			systemPrompt: "private",
 			source: "built-in",
-			filePath: "built-in:scout",
+			filePath: "built-in:explorer",
 			tools: ["read", "grep", "bash"],
 			capabilityManifest: {
 				version: "pi-subagents:capabilities:v1",

--- a/packages/pi-subagents/test/execution-ui.test.ts
+++ b/packages/pi-subagents/test/execution-ui.test.ts
@@ -46,11 +46,11 @@ test("per-agent execution screens expose defaults without profile presets", asyn
 		assert.match(
 			JSON.stringify(
 				executionAgentScreen({
-					name: "scout",
-					description: "scout",
+					name: "explorer",
+					description: "explorer",
 					systemPrompt: "",
 					source: "built-in",
-					filePath: "built-in:scout",
+					filePath: "built-in:explorer",
 					thinkingLevel: "low",
 				}),
 			),
@@ -63,11 +63,11 @@ test("per-agent execution screens expose defaults without profile presets", asyn
 			JSON.stringify(
 				executionModelScreen(
 					{
-						name: "scout",
-						description: "scout",
+						name: "explorer",
+						description: "explorer",
 						systemPrompt: "",
 						source: "built-in",
-						filePath: "built-in:scout",
+						filePath: "built-in:explorer",
 					},
 					catalogContext.ctx,
 				),
@@ -81,25 +81,25 @@ test("per-agent execution controls validate, preserve tools, and reset inheritan
 	await withAgentDir(async (directory) => {
 		const context = createMockContext();
 		const agent = {
-			name: "scout",
-			description: "scout",
+			name: "explorer",
+			description: "explorer",
 			tools: ["read"],
 			systemPrompt: "",
 			source: "built-in" as const,
-			filePath: "built-in:scout",
+			filePath: "built-in:explorer",
 		};
-		updateAgentSettingsPatch({ scout: { tools: ["read"] } });
+		updateAgentSettingsPatch({ explorer: { tools: ["read"] } });
 		assert.equal(applyAgentThinking(agent, "high", context.ctx).kind, "back");
 		assert.equal(applyAgentModel(agent, "provider/model", context.ctx).kind, "back");
 		assert.equal(applyAgentTimeout(agent, "1234", context.ctx).kind, "back");
 		assert.equal(applyAgentTimeout(agent, "0", context.ctx).kind, "rejected");
 		let saved = JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8"));
-		assert.equal(saved.agents.scout.thinkingLevel, "high");
-		assert.equal(saved.agents.scout.model, "provider/model");
-		assert.equal(saved.agents.scout.timeoutMs, 1234);
+		assert.equal(saved.agents.explorer.thinkingLevel, "high");
+		assert.equal(saved.agents.explorer.model, "provider/model");
+		assert.equal(saved.agents.explorer.timeoutMs, 1234);
 		assert.equal(resetAgentExecution(agent, context.ctx).kind, "back");
 		saved = JSON.parse(readFileSync(path.join(directory, "pi-subagents.json"), "utf8"));
-		assert.deepEqual(saved.agents.scout, { tools: ["read"] });
+		assert.deepEqual(saved.agents.explorer, { tools: ["read"] });
 	});
 });
 

--- a/packages/pi-subagents/test/in-process-transport.test.ts
+++ b/packages/pi-subagents/test/in-process-transport.test.ts
@@ -31,7 +31,7 @@ import { type IsolatedWorkspace, WorkspaceManager } from "../src/workspace.js";
 function managedAgent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 	return {
 		id: "sa_test",
-		agent: "scout",
+		agent: "explorer",
 		rootId: "sa_test",
 		depth: 0,
 		children: [],
@@ -47,12 +47,12 @@ function managedAgent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 
 function agentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
 	return {
-		name: "scout",
-		description: "test scout",
+		name: "explorer",
+		description: "test explorer",
 		tools: ["read"],
-		systemPrompt: "Scout safely.",
+		systemPrompt: "Explorer safely.",
 		source: "built-in",
-		filePath: "built-in:scout",
+		filePath: "built-in:explorer",
 		...overrides,
 	};
 }
@@ -726,7 +726,7 @@ test("registered detached spawn auto-resumes without exposing a wait tool", asyn
 
 		child.waitForNextAbort();
 		const spawned = await execute("subagent_spawn", {
-			agent: "scout",
+			agent: "explorer",
 			task: "first",
 			thinkingLevel: "high",
 		});
@@ -916,7 +916,7 @@ test("consolidated close reports cleanup failure and remains safely repeatable",
 			}>;
 		};
 		const spawned = await execute("subagent_spawn", {
-			agent: "scout",
+			agent: "explorer",
 			task: "complete before close",
 			workspaceMode: "worktree",
 		});
@@ -984,12 +984,12 @@ test("session shutdown closes completion delivery before delayed isolated-agent 
 			}>;
 		};
 		const first = await execute("subagent_spawn", {
-			agent: "scout",
+			agent: "explorer",
 			task: "complete before shutdown",
 			workspaceMode: "worktree",
 		});
 		const second = await execute("subagent_spawn", {
-			agent: "scout",
+			agent: "explorer",
 			task: "delay shutdown cleanup",
 			workspaceMode: "worktree",
 		});

--- a/packages/pi-subagents/test/inspect.test.ts
+++ b/packages/pi-subagents/test/inspect.test.ts
@@ -274,7 +274,7 @@ test("subagent_inspect projects safe agent metadata and gates project discovery 
 test("subagent_inspect returns metadata-only run summaries", async () => {
 	const summary: AgentRunInspectionSummary = {
 		id: "sa_one",
-		agent: "scout",
+		agent: "explorer",
 		state: "running",
 		createdAt: 1,
 		updatedAt: 2,

--- a/packages/pi-subagents/test/orchestration-metrics.test.ts
+++ b/packages/pi-subagents/test/orchestration-metrics.test.ts
@@ -5,7 +5,7 @@ import type { SingleResult } from "../src/runner.js";
 import { WorkItemLedger } from "../src/work-item-ledger.js";
 
 const result: SingleResult = {
-	agent: "scout",
+	agent: "explorer",
 	agentSource: "built-in",
 	task: "inspect",
 	exitCode: 0,

--- a/packages/pi-subagents/test/orchestration-test-helpers.ts
+++ b/packages/pi-subagents/test/orchestration-test-helpers.ts
@@ -3,7 +3,7 @@ import type { ManagedAgent } from "../src/registry.js";
 export function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 	return {
 		id: "sa_test",
-		agent: "scout",
+		agent: "explorer",
 		rootId: "sa_test",
 		depth: 0,
 		children: [],

--- a/packages/pi-subagents/test/panel-execution.test.ts
+++ b/packages/pi-subagents/test/panel-execution.test.ts
@@ -97,14 +97,14 @@ test("panel mode rejects mixed modes and unknown agents before launch", async ()
 	const panel = {
 		task: "Review",
 		reviewers: [
-			{ id: "a", agent: "scout" },
-			{ id: "b", agent: "scout" },
+			{ id: "a", agent: "explorer" },
+			{ id: "b", agent: "explorer" },
 		],
-		synthesizer: { agent: "scout" },
+		synthesizer: { agent: "explorer" },
 	};
 	const mixed = await tool.execute(
 		"panel-mixed",
-		{ agent: "scout", task: "single", panel },
+		{ agent: "explorer", task: "single", panel },
 		undefined,
 		undefined,
 		createMockContext().ctx,
@@ -219,10 +219,10 @@ test("panel executes isolated reviewers, preserves evidence, then synthesizes on
 					task: "Review the shared change",
 					context: "diff: shared",
 					reviewers: [
-						{ id: "a", agent: "scout", focus: "correctness" },
-						{ id: "b", agent: "scout", focus: "tests" },
+						{ id: "a", agent: "explorer", focus: "correctness" },
+						{ id: "b", agent: "explorer", focus: "tests" },
 					],
-					synthesizer: { agent: "scout" },
+					synthesizer: { agent: "explorer" },
 					minValidReviews: 2,
 				},
 			},
@@ -291,10 +291,10 @@ test("timed-out reviewers receive one bounded contract finalization turn", async
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "scout", timeoutMs: 50 },
-						{ id: "b", agent: "scout", timeoutMs: 50 },
+						{ id: "a", agent: "explorer", timeoutMs: 50 },
+						{ id: "b", agent: "explorer", timeoutMs: 50 },
 					],
-					synthesizer: { agent: "scout" },
+					synthesizer: { agent: "explorer" },
 				},
 			},
 			undefined,
@@ -337,10 +337,10 @@ test("panel preserves valid reviews when synthesis returns an invalid contract",
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "scout" },
-						{ id: "b", agent: "scout" },
+						{ id: "a", agent: "explorer" },
+						{ id: "b", agent: "explorer" },
 					],
-					synthesizer: { agent: "scout" },
+					synthesizer: { agent: "explorer" },
 				},
 			},
 			undefined,
@@ -385,10 +385,10 @@ test("panel marks valid synthesis output from an errored process as failed", asy
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "scout" },
-						{ id: "b", agent: "scout" },
+						{ id: "a", agent: "explorer" },
+						{ id: "b", agent: "explorer" },
 					],
-					synthesizer: { agent: "scout" },
+					synthesizer: { agent: "explorer" },
 				},
 			},
 			undefined,
@@ -434,10 +434,10 @@ test("panel retries transient transport failures once within the review phase", 
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "scout" },
-						{ id: "b", agent: "scout" },
+						{ id: "a", agent: "explorer" },
+						{ id: "b", agent: "explorer" },
 					],
-					synthesizer: { agent: "scout" },
+					synthesizer: { agent: "explorer" },
 				},
 			},
 			undefined,
@@ -567,10 +567,10 @@ test("an insufficient panel returns partial evidence and never launches synthesi
 				panel: {
 					task: "Review",
 					reviewers: [
-						{ id: "a", agent: "scout" },
-						{ id: "b", agent: "scout" },
+						{ id: "a", agent: "explorer" },
+						{ id: "b", agent: "explorer" },
 					],
-					synthesizer: { agent: "scout" },
+					synthesizer: { agent: "explorer" },
 				},
 			},
 			undefined,
@@ -613,10 +613,10 @@ test("ordinary reviewer progress updates do not trigger a semantic stall", async
 				panel: {
 					task: "Review after ordinary progress",
 					reviewers: [
-						{ id: "a", agent: "scout" },
-						{ id: "b", agent: "scout" },
+						{ id: "a", agent: "explorer" },
+						{ id: "b", agent: "explorer" },
 					],
-					synthesizer: { agent: "scout" },
+					synthesizer: { agent: "explorer" },
 				},
 			},
 			undefined,
@@ -658,10 +658,10 @@ test("panel semantic progress stops repeated evidence states without blind retri
 				panel: {
 					task: "Review with evidence",
 					reviewers: [
-						{ id: "a", agent: "scout" },
-						{ id: "b", agent: "scout" },
+						{ id: "a", agent: "explorer" },
+						{ id: "b", agent: "explorer" },
 					],
-					synthesizer: { agent: "scout" },
+					synthesizer: { agent: "explorer" },
 				},
 			},
 			undefined,
@@ -918,9 +918,9 @@ test("panel cancellation closes the child group and skips synthesis", async () =
 					task: "Review until cancelled",
 					reviewers: Array.from({ length: 5 }, (_, index) => ({
 						id: `reviewer-${index}`,
-						agent: "scout",
+						agent: "explorer",
 					})),
-					synthesizer: { agent: "scout" },
+					synthesizer: { agent: "explorer" },
 				},
 			},
 			controller.signal,

--- a/packages/pi-subagents/test/panel.test.ts
+++ b/packages/pi-subagents/test/panel.test.ts
@@ -174,7 +174,7 @@ test("panel planning reserves synthesis and cleanup before launch", () => {
 				task: "review",
 				reviewers: [
 					{ id: "same", agent: "reviewer" },
-					{ id: "same", agent: "scout" },
+					{ id: "same", agent: "explorer" },
 				],
 				synthesizer: { agent: "reviewer" },
 			}),

--- a/packages/pi-subagents/test/registry-cancellation-and-retention.test.ts
+++ b/packages/pi-subagents/test/registry-cancellation-and-retention.test.ts
@@ -7,11 +7,11 @@ import { AgentRegistry } from "../src/registry.js";
 test("AgentRegistry rotates the accepted generation before abort and quarantines late results", async () => {
 	const plan = createExecutionPlan({
 		agent: {
-			name: "scout",
-			description: "scout",
+			name: "explorer",
+			description: "explorer",
 			systemPrompt: "",
 			source: "built-in",
-			filePath: "built-in:scout",
+			filePath: "built-in:explorer",
 		},
 		target: {
 			cwd: process.cwd(),
@@ -30,7 +30,7 @@ test("AgentRegistry rotates the accepted generation before abort and quarantines
 		return { output: "late completion", exitCode: 0, aborted: true };
 	});
 	const agent = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "work",
 		cwd: process.cwd(),
 		executionPlan: plan,
@@ -56,8 +56,8 @@ test("AgentRegistry shutdown aborts active work and drains queued work without s
 		},
 		{ maxActiveTurns: 1 },
 	);
-	const active = await registry.spawn({ agent: "scout", task: "active", cwd: process.cwd() });
-	const queued = await registry.spawn({ agent: "scout", task: "queued", cwd: process.cwd() });
+	const active = await registry.spawn({ agent: "explorer", task: "active", cwd: process.cwd() });
+	const queued = await registry.spawn({ agent: "explorer", task: "queued", cwd: process.cwd() });
 	await registry.shutdown();
 	assert.deepEqual(started, ["active"]);
 	assert.equal(registry.get(active.id)?.state, "interrupted");
@@ -77,13 +77,13 @@ test("AgentRegistry eviction preserves active ancestry and removes expired trees
 		},
 		{ idleTtlMs: 100, now: () => now },
 	);
-	const root = await registry.spawn({ agent: "scout", task: "done", cwd: process.cwd() });
+	const root = await registry.spawn({ agent: "explorer", task: "done", cwd: process.cwd() });
 	await registry.wait(root.id, 100);
 	for (const completion of registry.listPendingCompletions()) {
 		await registry.markCompletionDelivered(completion.completionId, now);
 	}
 	const child = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "slow",
 		cwd: process.cwd(),
 		parentId: root.id,
@@ -120,10 +120,10 @@ test("AgentRegistry expiry prunes stale child links and releases its transport",
 			now: () => now,
 		},
 	);
-	const root = await registry.spawn({ agent: "scout", task: "root", cwd: process.cwd() });
+	const root = await registry.spawn({ agent: "explorer", task: "root", cwd: process.cwd() });
 	await registry.wait(root.id, 100);
 	const child = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "child",
 		cwd: process.cwd(),
 		parentId: root.id,
@@ -149,7 +149,7 @@ test("AgentRegistry keeps an expired agent until its durable completion is ackno
 		idleTtlMs: 100,
 		now: () => now,
 	});
-	const agent = await registry.spawn({ agent: "scout", task: "done", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "done", cwd: process.cwd() });
 	await registry.wait(agent.id, 100);
 	now += 101;
 	assert.equal(await registry.sweepExpired(), 0);
@@ -166,7 +166,7 @@ test("AgentRegistry bounds retained closed records", async () => {
 	});
 	for (let index = 0; index < 4; index++) {
 		const agent = await registry.spawn({
-			agent: "scout",
+			agent: "explorer",
 			task: String(index),
 			cwd: process.cwd(),
 		});
@@ -190,7 +190,7 @@ test("AgentRegistry serializes state snapshots so slow persistence cannot overwr
 			savedStates.push(agents[0]?.state ?? "missing");
 		},
 	});
-	const agent = await registry.spawn({ agent: "scout", task: "task", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "task", cwd: process.cwd() });
 	await registry.wait(agent.id, 100);
 	await new Promise((resolve) => setImmediate(resolve));
 	releaseSlowSave?.();
@@ -213,7 +213,7 @@ test("AgentRegistry keeps an unpersisted terminal run pending until shutdown rep
 			throw new Error("disk unavailable");
 		},
 	});
-	const agent = await registry.spawn({ agent: "scout", task: "done", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "done", cwd: process.cwd() });
 	await retryStarted;
 	let waitResolved = false;
 	const waiting = registry.wait(agent.id, 1_000).then((result) => {

--- a/packages/pi-subagents/test/registry-completion-delivery.test.ts
+++ b/packages/pi-subagents/test/registry-completion-delivery.test.ts
@@ -38,7 +38,7 @@ test("AgentRegistry emits one detached completion event for every settled turn",
 			},
 		},
 	);
-	const agent = await registry.spawn({ agent: "scout", task: "first", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "first", cwd: process.cwd() });
 	assert.deepEqual(completions, []);
 	settlers.shift()?.({ output: "first result", exitCode: 0 });
 	await registry.wait(agent.id, 100);
@@ -92,7 +92,7 @@ test("AgentRegistry retries terminal persistence before resolving or notifying",
 			},
 		},
 	);
-	const agent = await registry.spawn({ agent: "scout", task: "persist", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "persist", cwd: process.cwd() });
 	settleTurn({ output: "done", exitCode: 0 });
 	let waitResolved = false;
 	const waiting = registry.wait(agent.id, 1_000).then((result) => {
@@ -117,12 +117,12 @@ test("detached completion messages retain bounded task, partial output, and erro
 		runId: "run:test:1",
 		generation: 1,
 		createdAt: 1,
-		agent: record({ agent: "scout\nspoofed", state: "failed" }),
+		agent: record({ agent: "explorer\nspoofed", state: "failed" }),
 		task: `inspect <private>task secret</private> ${"界".repeat(200)}`,
 		output: `partial output <private>output secret</private> ${"x".repeat(4_000)}`,
 		error: `provider failed ${"e".repeat(4_000)}`,
 	});
-	assert.match(content, /Agent: scout spoofed/);
+	assert.match(content, /Agent: explorer spoofed/);
 	assert.match(content, /Task: inspect/);
 	assert.match(content, /Error:\nprovider failed/);
 	assert.match(content, /Payload:\npartial output/);
@@ -136,7 +136,7 @@ test("AgentRegistry keeps detached lifecycle stable when completion delivery fai
 			throw new Error("stale parent session");
 		},
 	});
-	const agent = await registry.spawn({ agent: "scout", task: "task", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "task", cwd: process.cwd() });
 	const settled = await registry.wait(agent.id, 100);
 	assert.equal(settled.agent.state, "completed");
 	assert.equal(settled.agent.history.at(-1)?.output, "done");
@@ -162,8 +162,8 @@ test("AgentRegistry emits a detached completion when queued work is interrupted"
 			},
 		},
 	);
-	const active = await registry.spawn({ agent: "scout", task: "active", cwd: process.cwd() });
-	const queued = await registry.spawn({ agent: "scout", task: "queued", cwd: process.cwd() });
+	const active = await registry.spawn({ agent: "explorer", task: "active", cwd: process.cwd() });
+	const queued = await registry.spawn({ agent: "explorer", task: "queued", cwd: process.cwd() });
 	assert.equal(registry.get(queued.id)?.state, "starting");
 	await registry.interrupt(queued.id);
 	await new Promise((resolve) => setImmediate(resolve));

--- a/packages/pi-subagents/test/registry-hierarchy-and-mailbox.test.ts
+++ b/packages/pi-subagents/test/registry-hierarchy-and-mailbox.test.ts
@@ -20,7 +20,7 @@ test("AgentRegistry persists closed state even when transport release reports cl
 			},
 		},
 	);
-	const agent = await registry.spawn({ agent: "scout", task: "task", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "task", cwd: process.cwd() });
 	await registry.wait(agent.id, 100);
 	await assert.rejects(() => registry.close(agent.id), /cleanup failed/);
 	assert.equal(snapshots.at(-1)?.find((candidate) => candidate.id === agent.id)?.state, "closed");
@@ -37,10 +37,10 @@ test("AgentRegistry releases subtree transport sessions child-first and exactly 
 			released.push(agent.id);
 		},
 	});
-	const root = await registry.spawn({ agent: "scout", task: "root", cwd: process.cwd() });
+	const root = await registry.spawn({ agent: "explorer", task: "root", cwd: process.cwd() });
 	await registry.wait(root.id, 100);
 	const child = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "child",
 		cwd: process.cwd(),
 		parentId: root.id,
@@ -57,7 +57,7 @@ test("AgentRegistry delivers unread mailbox messages to only the next follow-up 
 		delivered.push(agent.currentMailboxMessageIds ?? []);
 		return { output: "done", exitCode: 0 };
 	});
-	const agent = await registry.spawn({ agent: "scout", task: "initial", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "initial", cwd: process.cwd() });
 	await registry.wait(agent.id, 100);
 	const message = await registry.sendMessage(agent.id, "once");
 	await registry.followUp(agent.id, "first follow-up");
@@ -76,17 +76,17 @@ test("AgentRegistry preserves hierarchy and delivers bounded deduplicated mailbo
 			maxMailboxMessages: 2,
 		},
 	);
-	const root = await registry.spawn({ agent: "scout", task: "root", cwd: process.cwd() });
+	const root = await registry.spawn({ agent: "explorer", task: "root", cwd: process.cwd() });
 	await registry.wait(root.id, 100);
 	const child = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "child",
 		cwd: process.cwd(),
 		parentId: root.id,
 	});
 	await registry.wait(child.id, 100);
 	const grandchild = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "grandchild",
 		cwd: process.cwd(),
 		parentId: child.id,
@@ -95,7 +95,7 @@ test("AgentRegistry preserves hierarchy and delivers bounded deduplicated mailbo
 	await assert.rejects(
 		() =>
 			registry.spawn({
-				agent: "scout",
+				agent: "explorer",
 				task: "too deep",
 				cwd: process.cwd(),
 				parentId: grandchild.id,
@@ -141,10 +141,10 @@ test("AgentRegistry bounds mailbox input and reports rejected child turns to the
 		},
 		{ maxMailboxMessageBytes: 64 },
 	);
-	const root = await registry.spawn({ agent: "scout", task: "root", cwd: process.cwd() });
+	const root = await registry.spawn({ agent: "explorer", task: "root", cwd: process.cwd() });
 	await registry.wait(root.id, 100);
 	const child = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "reject",
 		cwd: process.cwd(),
 		parentId: root.id,
@@ -160,7 +160,7 @@ test("AgentRegistry bounds mailbox input and reports rejected child turns to the
 		() => registry.sendMessage(child.id, "message", "missing"),
 		/Unknown subagent/,
 	);
-	const other = await registry.spawn({ agent: "scout", task: "other", cwd: process.cwd() });
+	const other = await registry.spawn({ agent: "explorer", task: "other", cwd: process.cwd() });
 	await registry.wait(other.id, 100);
 	await assert.rejects(
 		() => registry.sendMessage(child.id, "message", other.id),

--- a/packages/pi-subagents/test/registry-lifecycle-and-budgets.test.ts
+++ b/packages/pi-subagents/test/registry-lifecycle-and-budgets.test.ts
@@ -12,16 +12,17 @@ test("AgentRegistry rejects invalid capacity and wait bounds", async () => {
 		/non-negative safe integer/,
 	);
 	const registry = new AgentRegistry(async () => ({ output: "", exitCode: 0 }));
-	const agent = await registry.spawn({ agent: "scout", task: "done", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "done", cwd: process.cwd() });
 	await assert.rejects(() => registry.wait(agent.id, Number.NaN), /positive finite/);
 	await registry.wait(agent.id, 100);
 	await registry.close(agent.id);
 	await assert.rejects(
-		() => registry.spawn({ agent: "scout", task: "child", cwd: process.cwd(), parentId: agent.id }),
+		() =>
+			registry.spawn({ agent: "explorer", task: "child", cwd: process.cwd(), parentId: agent.id }),
 		/Cannot spawn under closed agent/,
 	);
 	await assert.rejects(
-		() => registry.spawn({ agent: "scout", task: "  ", cwd: process.cwd() }),
+		() => registry.spawn({ agent: "explorer", task: "  ", cwd: process.cwd() }),
 		/tasks cannot be empty/,
 	);
 
@@ -34,7 +35,7 @@ test("AgentRegistry rejects invalid capacity and wait bounds", async () => {
 		{ maxTaskBytes: 64, maxTurnOutputBytes: 64 },
 	);
 	const boundedAgent = await boundedRegistry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "x".repeat(200),
 		cwd: process.cwd(),
 	});
@@ -59,7 +60,7 @@ test("AgentRegistry supports follow-up, wait timeout, interrupt/reuse, limits, a
 		},
 		{ maxAgents: 2, maxActiveTurns: 1 },
 	);
-	const first = await registry.spawn({ agent: "scout", task: "slow", cwd: process.cwd() });
+	const first = await registry.spawn({ agent: "explorer", task: "slow", cwd: process.cwd() });
 	const second = await registry.spawn({ agent: "reviewer", task: "queued", cwd: process.cwd() });
 	const queued = await registry.wait(second.id, 5);
 	assert.equal(queued.timedOut, true);
@@ -119,7 +120,7 @@ test("AgentRegistry retains explicit execution defaults and applies one-turn bud
 		return { output: "done", exitCode: 0 };
 	});
 	const spawned = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "first",
 		cwd: process.cwd(),
 		thinkingLevel: "high",
@@ -205,7 +206,7 @@ test("AgentRegistry runs lifecycle operations through a transport contract", asy
 			calls.push("shutdown");
 		},
 	});
-	const agent = await registry.spawn({ agent: "scout", task: "slow", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "slow", cwd: process.cwd() });
 	await registry.interrupt(agent.id);
 	await registry.followUp(agent.id, "next");
 	await registry.wait(agent.id, 100);
@@ -224,7 +225,7 @@ test("AgentRegistry clears stale terminal errors when a detached follow-up start
 		);
 		return { output: "", exitCode: 130, aborted: true };
 	});
-	const agent = await registry.spawn({ agent: "scout", task: "first", cwd: process.cwd() });
+	const agent = await registry.spawn({ agent: "explorer", task: "first", cwd: process.cwd() });
 	await registry.wait(agent.id, 100);
 	assert.equal(registry.get(agent.id)?.error, "first failure");
 	const followUp = await registry.followUp(agent.id, "second");

--- a/packages/pi-subagents/test/registry-persistence.test.ts
+++ b/packages/pi-subagents/test/registry-persistence.test.ts
@@ -198,7 +198,7 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 			agents: [
 				{
 					id: "legacy",
-					agent: "scout",
+					agent: "explorer",
 					state: "completed",
 					createdAt: Date.now(),
 					updatedAt: Date.now(),
@@ -218,7 +218,7 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 			agents: [
 				{
 					id: "invalid-thinking",
-					agent: "scout",
+					agent: "explorer",
 					thinkingLevel: "huge",
 					state: "idle",
 					createdAt: Date.now(),
@@ -238,7 +238,7 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 			agents: [
 				{
 					id: "malformed",
-					agent: "scout",
+					agent: "explorer",
 					state: "idle",
 					createdAt: Date.now(),
 					updatedAt: Date.now(),

--- a/packages/pi-subagents/test/registry-spawn-and-inspection.test.ts
+++ b/packages/pi-subagents/test/registry-spawn-and-inspection.test.ts
@@ -6,7 +6,7 @@ import { hashSpawnRequest } from "../src/spawn-idempotency.js";
 
 test("spawn idempotency includes retained execution budgets", () => {
 	const request = {
-		agent: "scout",
+		agent: "explorer",
 		task: "inspect",
 		cwd: process.cwd(),
 		agentScope: "user" as const,
@@ -45,7 +45,7 @@ test("spawn idempotency includes retained execution budgets", () => {
 test("AgentRegistry retains spawn idempotency only until close", async () => {
 	const registry = new AgentRegistry(async () => ({ output: "done", exitCode: 0 }));
 	const first = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "first",
 		cwd: process.cwd(),
 		spawnIdempotencyKey: "key",
@@ -56,7 +56,7 @@ test("AgentRegistry retains spawn idempotency only until close", async () => {
 	await registry.close(first.id);
 	assert.equal(registry.findBySpawnIdempotencyKey("key", "hash"), undefined);
 	const replacement = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "different after close",
 		cwd: process.cwd(),
 		spawnIdempotencyKey: "key",
@@ -90,7 +90,7 @@ test("AgentRegistry preserves queue and transport timing without persisting prog
 		},
 		{ now: () => now++ },
 	);
-	const spawned = await registry.spawn({ agent: "scout", task: "timed", cwd: process.cwd() });
+	const spawned = await registry.spawn({ agent: "explorer", task: "timed", cwd: process.cwd() });
 	await registry.wait(spawned.id, 100);
 	const telemetry = registry.getInspection(spawned.id)?.telemetry;
 	assert.equal(telemetry?.transport, "rpc");
@@ -117,7 +117,7 @@ test("AgentRegistry retains ordered completion identities until exact acknowledg
 			},
 		},
 	);
-	const spawned = await registry.spawn({ agent: "scout", task: "first", cwd: process.cwd() });
+	const spawned = await registry.spawn({ agent: "explorer", task: "first", cwd: process.cwd() });
 	await registry.wait(spawned.id, 100);
 	await registry.followUp(spawned.id, "second");
 	await registry.wait(spawned.id, 100);
@@ -157,7 +157,7 @@ test("AgentRegistry exposes metadata-only inspection snapshots", async () => {
 			}),
 	);
 	const spawned = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "private current task",
 		cwd: process.cwd(),
 		thinkingLevel: "high",
@@ -170,7 +170,7 @@ test("AgentRegistry exposes metadata-only inspection snapshots", async () => {
 	assert.equal(listed.length, 1);
 	assert.deepEqual(listed[0], {
 		id: spawned.id,
-		agent: "scout",
+		agent: "explorer",
 		state: "running",
 		createdAt: spawned.createdAt,
 		updatedAt: listed[0].updatedAt,
@@ -213,7 +213,7 @@ test("AgentRegistry deduplicates exact spawn retries before another transport tu
 		};
 	});
 	const input = {
-		agent: "scout",
+		agent: "explorer",
 		task: "inspect",
 		cwd: process.cwd(),
 		spawnIdempotencyKey: "request-1",
@@ -252,7 +252,7 @@ test("AgentRegistry projects actionable structured v2 outcomes into lifecycle st
 		exitCode: 0,
 	}));
 	const agent = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "inspect",
 		cwd: process.cwd(),
 		resultFormat: "structured-v2",
@@ -272,7 +272,7 @@ test("AgentRegistry projects actionable structured v2 outcomes into lifecycle st
 test("AgentRegistry fails closed when a requested structured result is malformed", async () => {
 	const registry = new AgentRegistry(async () => ({ output: "ordinary text", exitCode: 0 }));
 	const agent = await registry.spawn({
-		agent: "scout",
+		agent: "explorer",
 		task: "inspect",
 		cwd: process.cwd(),
 		resultFormat: "structured-v2",

--- a/packages/pi-subagents/test/registry-test-helpers.ts
+++ b/packages/pi-subagents/test/registry-test-helpers.ts
@@ -3,7 +3,7 @@ import type { ManagedAgent } from "../src/registry.js";
 export function record(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
 	return {
 		id: "sa_test",
-		agent: "scout",
+		agent: "explorer",
 		rootId: "sa_test",
 		depth: 0,
 		children: [],

--- a/packages/pi-subagents/test/runner-rendering.test.ts
+++ b/packages/pi-subagents/test/runner-rendering.test.ts
@@ -49,7 +49,7 @@ test("renderSubagentCall omits an empty optional aggregator", () => {
 	};
 	const rendered = renderSubagentCall(
 		{
-			tasks: [{ agent: "scout", task: "Inspect the implementation" }],
+			tasks: [{ agent: "explorer", task: "Inspect the implementation" }],
 			aggregator: { agent: "  ", task: "\t" },
 		},
 		identityTheme as never,

--- a/packages/pi-subagents/test/startup-imports.test.ts
+++ b/packages/pi-subagents/test/startup-imports.test.ts
@@ -22,7 +22,7 @@ async function emitAll(
 function managedAgent(): ManagedAgent {
 	return {
 		id: "sa_lazy",
-		agent: "scout",
+		agent: "explorer",
 		rootId: "sa_lazy",
 		depth: 0,
 		children: [],
@@ -222,19 +222,25 @@ test("blocking execution caches a successful module and retries a rejected load"
 	const context = createMockContext();
 	await assert.rejects(
 		() =>
-			tool.execute("first", { agent: "scout", task: "inspect" }, undefined, undefined, context.ctx),
+			tool.execute(
+				"first",
+				{ agent: "explorer", task: "inspect" },
+				undefined,
+				undefined,
+				context.ctx,
+			),
 		/temporary blocking loader failure/u,
 	);
 	await tool.execute(
 		"second",
-		{ agent: "scout", task: "inspect" },
+		{ agent: "explorer", task: "inspect" },
 		undefined,
 		undefined,
 		context.ctx,
 	);
 	await tool.execute(
 		"third",
-		{ agent: "scout", task: "inspect" },
+		{ agent: "explorer", task: "inspect" },
 		undefined,
 		undefined,
 		context.ctx,
@@ -274,7 +280,7 @@ test("blocking execution cancellation waits for a pending import and starts no s
 	const context = createMockContext();
 	const running = tool.execute(
 		"pending",
-		{ agent: "scout", task: "inspect" },
+		{ agent: "explorer", task: "inspect" },
 		undefined,
 		undefined,
 		context.ctx,

--- a/packages/pi-subagents/test/stateful-session-lifecycle.test.ts
+++ b/packages/pi-subagents/test/stateful-session-lifecycle.test.ts
@@ -67,7 +67,7 @@ test("stateful worktree spawn revalidates session ownership and cleans stale wor
 		assert.ok(spawn);
 		const pending = spawn.execute(
 			"worktree",
-			{ agent: "scout", task: "inspect", workspaceMode: "worktree" },
+			{ agent: "explorer", task: "inspect", workspaceMode: "worktree" },
 			undefined,
 			undefined,
 			first.ctx,
@@ -149,7 +149,7 @@ test("stale idempotent spawn cleanup cannot delete a replacement session attempt
 			execute: (...args: unknown[]) => Promise<unknown>;
 		};
 		const spawnParams = {
-			agent: "scout",
+			agent: "explorer",
 			task: "same request",
 			workspaceMode: "worktree" as const,
 			idempotencyKey: "replacement-key",
@@ -251,7 +251,7 @@ test("stateful clear and session replacement serialize active-child cleanup befo
 		assert.ok(spawn);
 		await spawn.execute(
 			"active",
-			{ agent: "scout", task: "wait" },
+			{ agent: "explorer", task: "wait" },
 			undefined,
 			undefined,
 			first.ctx,

--- a/packages/pi-subagents/test/stateful-tool-registration.test.ts
+++ b/packages/pi-subagents/test/stateful-tool-registration.test.ts
@@ -375,7 +375,7 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 				() =>
 					spawnTool.execute(
 						"id",
-						{ agent: "scout", task: "nested" },
+						{ agent: "explorer", task: "nested" },
 						undefined,
 						undefined,
 						context.ctx,

--- a/packages/pi-subagents/test/stateful-trust.test.ts
+++ b/packages/pi-subagents/test/stateful-trust.test.ts
@@ -42,7 +42,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 			settings: { transport: "in-process" },
 			getSettings: () => ({
 				cwdPolicy: { delegation },
-				agents: { scout: { tools: [] } },
+				agents: { explorer: { tools: [] } },
 			}),
 			workspaceManager: {
 				async create() {
@@ -96,7 +96,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 			() =>
 				spawn.execute(
 					"unsaved",
-					{ agent: "scout", task: "inspect", cwd: external },
+					{ agent: "explorer", task: "inspect", cwd: external },
 					undefined,
 					undefined,
 					context.ctx,
@@ -108,7 +108,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 		new ProjectTrustStore(agentDir).set(external, true);
 		await spawn.execute(
 			"trusted",
-			{ agent: "scout", task: "inspect", cwd: external },
+			{ agent: "explorer", task: "inspect", cwd: external },
 			undefined,
 			undefined,
 			context.ctx,
@@ -122,7 +122,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 		const idempotentFirst = (await spawn.execute(
 			"idempotent-1",
 			{
-				agent: "scout",
+				agent: "explorer",
 				task: "idempotent inspect",
 				cwd: external,
 				idempotencyKey: "inspect-external",
@@ -135,7 +135,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 		const idempotentSecond = (await spawn.execute(
 			"idempotent-2",
 			{
-				agent: "scout",
+				agent: "explorer",
 				task: "idempotent inspect",
 				cwd: external,
 				idempotencyKey: "inspect-external",
@@ -153,7 +153,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 				spawn.execute(
 					"idempotent-mismatch",
 					{
-						agent: "scout",
+						agent: "explorer",
 						task: "different task",
 						cwd: external,
 						idempotencyKey: "inspect-external",
@@ -169,7 +169,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 		delegation = "anywhere";
 		await spawn.execute(
 			"anywhere",
-			{ agent: "scout", task: "inspect", cwd: external },
+			{ agent: "explorer", task: "inspect", cwd: external },
 			undefined,
 			undefined,
 			context.ctx,
@@ -180,7 +180,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 
 		await spawn.execute(
 			"worktree",
-			{ agent: "scout", task: "inspect", workspaceMode: "worktree" },
+			{ agent: "explorer", task: "inspect", workspaceMode: "worktree" },
 			undefined,
 			undefined,
 			context.ctx,
@@ -243,7 +243,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 		const isolatedFirst = (await spawn.execute(
 			"worktree-idempotent-1",
 			{
-				agent: "scout",
+				agent: "explorer",
 				task: "isolated exact retry",
 				workspaceMode: "worktree",
 				idempotencyKey: "isolated-retry",
@@ -255,7 +255,7 @@ test("stateful spawn enforces trusted targets and carries trust into in-process 
 		const isolatedSecond = (await spawn.execute(
 			"worktree-idempotent-2",
 			{
-				agent: "scout",
+				agent: "explorer",
 				task: "isolated exact retry",
 				workspaceMode: "worktree",
 				idempotencyKey: "isolated-retry",
@@ -351,7 +351,7 @@ test("stateful subprocess uses the retained resolved trust decision", async () =
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 	try {
 		const transport = new SubprocessTransport({
-			getSettings: () => ({ agents: { scout: { tools: [] } } }),
+			getSettings: () => ({ agents: { explorer: { tools: [] } } }),
 		});
 		for (const [projectTrusted, expected] of [
 			[true, "--approve"],

--- a/packages/pi-subagents/test/stateful-utilities-and-settings.test.ts
+++ b/packages/pi-subagents/test/stateful-utilities-and-settings.test.ts
@@ -52,13 +52,13 @@ test("shared-workspace write classification and follow-up guards are conservativ
 test("stateful agent lines escape terminal controls from retained agent data", () => {
 	const line = formatStatefulAgentLine(
 		record({
-			agent: "scout\u001b]8;;https://example.com\u0007linked",
+			agent: "explorer\u001b]8;;https://example.com\u0007linked",
 			currentTask: "first line\nsecond line\u009b31m",
 		}),
 	);
 	// biome-ignore lint/suspicious/noControlCharactersInRegex: Verify terminal-control escaping.
 	assert.doesNotMatch(line, /[\u0000-\u001f\u007f-\u009f]/u);
-	assert.match(line, /scout.*linked/);
+	assert.match(line, /explorer.*linked/);
 	assert.match(line, /first line second line/);
 });
 
@@ -91,7 +91,7 @@ test("selected context entries imply all mode only when context mode is omitted"
 });
 
 test("stateful subprocess thinking uses spawn override before the agent default", () => {
-	const agents = [{ name: "scout", thinkingLevel: "low" as const }, { name: "reviewer" }];
+	const agents = [{ name: "explorer", thinkingLevel: "low" as const }, { name: "reviewer" }];
 	assert.equal(
 		resolveStatefulSubprocessThinkingLevel(agents, record({ thinkingLevel: "high" })),
 		"high",

--- a/packages/pi-subagents/test/subagent-workflow-execution.test.ts
+++ b/packages/pi-subagents/test/subagent-workflow-execution.test.ts
@@ -73,13 +73,13 @@ test("workflow mode schedules dependency-ready tasks and rejects cycles before c
 					tasks: [
 						{
 							id: "produce",
-							agent: "scout",
+							agent: "explorer",
 							task: "produce schema",
 							resultFormat: "structured-v2",
 						},
 						{
 							id: "consume",
-							agent: "scout",
+							agent: "explorer",
 							task: "consume schema",
 							dependsOn: ["produce"],
 							inputArtifacts: ["schema"],
@@ -125,7 +125,7 @@ test("workflow mode schedules dependency-ready tasks and rejects cycles before c
 			undefined,
 			ctx,
 		);
-		assert.equal(routed.details?.results[0]?.agent, "scout");
+		assert.equal(routed.details?.results[0]?.agent, "explorer");
 
 		rmSync(marker, { force: true });
 		const mismatched = await tool.execute(
@@ -135,13 +135,13 @@ test("workflow mode schedules dependency-ready tasks and rejects cycles before c
 					tasks: [
 						{
 							id: "produce",
-							agent: "scout",
+							agent: "explorer",
 							task: "produce schema",
 							resultFormat: "structured-v2",
 						},
 						{
 							id: "consume",
-							agent: "scout",
+							agent: "explorer",
 							task: "consume schema",
 							dependsOn: ["produce"],
 							inputArtifacts: ["schema"],
@@ -169,7 +169,7 @@ test("workflow mode schedules dependency-ready tasks and rejects cycles before c
 					tasks: [
 						{
 							id: "produce",
-							agent: "scout",
+							agent: "explorer",
 							task: "duplicate artifact",
 							resultFormat: "structured-v2",
 						},
@@ -195,7 +195,7 @@ test("workflow mode schedules dependency-ready tasks and rejects cycles before c
 							tasks: [
 								{
 									id: "lookup",
-									agent: "scout",
+									agent: "explorer",
 									task: "lookup",
 									contract: {
 										version: "pi-subagents:delegation:v2",
@@ -233,13 +233,13 @@ test("workflow mode schedules dependency-ready tasks and rejects cycles before c
 							tasks: [
 								{
 									id: "implementation",
-									agent: "scout",
+									agent: "explorer",
 									task: "produce schema",
 									resultFormat: "structured-v2",
 								},
 								{
 									id: "verification",
-									agent: "scout",
+									agent: "explorer",
 									task: "verify schema",
 									dependsOn: ["implementation"],
 									verifierFor: "implementation",
@@ -263,8 +263,8 @@ test("workflow mode schedules dependency-ready tasks and rejects cycles before c
 					{
 						workflow: {
 							tasks: [
-								{ id: "a", agent: "scout", task: "a", dependsOn: ["b"] },
-								{ id: "b", agent: "scout", task: "b", dependsOn: ["a"] },
+								{ id: "a", agent: "explorer", task: "a", dependsOn: ["b"] },
+								{ id: "b", agent: "explorer", task: "b", dependsOn: ["a"] },
 							],
 						},
 					},
@@ -530,7 +530,7 @@ test("workflow retries are bounded and require an idempotent contract", async ()
 							tasks: [
 								{
 									id: "retry",
-									agent: "scout",
+									agent: "explorer",
 									task: "retry",
 									retryPolicy: { maxAttempts: 2 },
 								},
@@ -552,7 +552,7 @@ test("workflow retries are bounded and require an idempotent contract", async ()
 					tasks: [
 						{
 							id: "retry",
-							agent: "scout",
+							agent: "explorer",
 							task: "retry",
 							retryPolicy: { maxAttempts: 2 },
 							contract: {
@@ -604,7 +604,7 @@ test("workflow hedging duplicates only an explicitly read-only task and cancels 
 					tasks: [
 						{
 							id: "hedge",
-							agent: "scout",
+							agent: "explorer",
 							task: "read only",
 							hedgeAfterMs: 20,
 							contract: {
@@ -791,7 +791,7 @@ test("opt-in verified execution owns accept, bounded rework, drift, checks, evid
 			/unsafe verification command/i,
 		);
 		await assert.rejects(
-			() => run("scenario-incapable-verifier", { verifierAgent: "scout" }),
+			() => run("scenario-incapable-verifier", { verifierAgent: "explorer" }),
 			/independent structured-v2 review capability/i,
 		);
 		const launchesAfterUnsafe = readFileSync(launches, "utf8").trim().split("\n").length;

--- a/packages/pi-subagents/test/subagents-agent-catalog.test.ts
+++ b/packages/pi-subagents/test/subagents-agent-catalog.test.ts
@@ -27,7 +27,7 @@ test("subagent recursion guard rejects nested delegation before spawning", async
 			() =>
 				tool.execute(
 					"call",
-					{ agent: "scout", task: "nested" },
+					{ agent: "explorer", task: "nested" },
 					undefined,
 					undefined,
 					createMockContext().ctx,
@@ -141,48 +141,47 @@ test("discoverAgents includes built-ins and lets project agents override by name
 	const agentsDir = path.join(cwd, ".pi", "agents");
 	mkdirSync(agentsDir, { recursive: true });
 	writeFileSync(
-		path.join(agentsDir, "scout.md"),
+		path.join(agentsDir, "explorer.md"),
 		[
 			"---",
-			"name: scout",
-			"description: Project-specific scout",
+			"name: explorer",
+			"description: Project-specific explorer",
 			"tools: read,bash",
 			"model: gpt-test",
 			"thinkingLevel: high",
 			"---",
-			"Project scout prompt.",
+			"Project explorer prompt.",
 		].join("\n"),
 	);
 
 	const baseResult = discoverAgents(cwd, "project");
-	const baseScout = baseResult.agents.find((agent) => agent.name === "scout");
-	assert.equal(baseScout?.thinkingLevel, "high");
+	const baseExplorer = baseResult.agents.find((agent) => agent.name === "explorer");
+	assert.equal(baseExplorer?.thinkingLevel, "high");
 
 	const result = discoverAgents(cwd, "project", {
-		agents: { scout: { timeoutMs: 1234, thinkingLevel: "low" } },
+		agents: { explorer: { timeoutMs: 1234, thinkingLevel: "low" } },
 	});
-	const scout = result.agents.find((agent) => agent.name === "scout");
+	const explorer = result.agents.find((agent) => agent.name === "explorer");
 
 	assert.equal(result.projectAgentsDir, agentsDir);
-	assert.equal(scout?.source, "project");
-	assert.deepEqual(scout?.tools, ["read", "bash"]);
-	assert.equal(scout?.model, "gpt-test");
-	assert.equal(scout?.thinkingLevel, "low");
-	assert.equal(scout?.timeoutMs, 1234);
+	assert.equal(explorer?.source, "project");
+	assert.deepEqual(explorer?.tools, ["read", "bash"]);
+	assert.equal(explorer?.model, "gpt-test");
+	assert.equal(explorer?.thinkingLevel, "low");
+	assert.equal(explorer?.timeoutMs, 1234);
 
-	const cleared = discoverAgents(cwd, "project", { agents: { scout: { thinkingLevel: null } } });
-	assert.equal(cleared.agents.find((agent) => agent.name === "scout")?.thinkingLevel, undefined);
+	const cleared = discoverAgents(cwd, "project", { agents: { explorer: { thinkingLevel: null } } });
+	assert.equal(cleared.agents.find((agent) => agent.name === "explorer")?.thinkingLevel, undefined);
 	assert.ok(result.agents.some((agent) => agent.name === "worker" && agent.source === "built-in"));
 });
 
-test("reviewer is no longer a built-in agent", () => {
-	const cwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-reviewer-test-"));
+test("removed built-in agent names are unavailable", () => {
+	const cwd = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-removed-agent-test-"));
 	try {
-		const reviewer = discoverAgents(cwd, "project").agents.find(
-			(agent) => agent.name === "reviewer",
-		);
+		const names = discoverAgents(cwd, "project").agents.map((agent) => agent.name);
 
-		assert.equal(reviewer, undefined);
+		assert.equal(names.includes("reviewer"), false);
+		assert.equal(names.includes("scout"), false);
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}
@@ -192,7 +191,7 @@ test("formatAgentList returns concise text and remaining count", () => {
 	const agents = discoverAgents(process.cwd(), "project").agents;
 	const formatted = formatAgentList(agents, 2);
 
-	assert.match(formatted.text, /scout \(built-in\)/);
+	assert.match(formatted.text, /explorer \(built-in\)/);
 	assert.equal(formatted.remaining, Math.max(0, agents.length - 2));
 });
 
@@ -202,8 +201,8 @@ test("formatAgentCatalog advertises scope variants deterministically and within 
 		const projectAgentsDir = path.join(cwd, ".pi", "agents");
 		mkdirSync(projectAgentsDir, { recursive: true });
 		writeFileSync(
-			path.join(projectAgentsDir, "scout.md"),
-			"---\nname: scout\ndescription: Project\n---\nProject prompt.",
+			path.join(projectAgentsDir, "explorer.md"),
+			"---\nname: explorer\ndescription: Project\n---\nProject prompt.",
 		);
 		writeFileSync(
 			path.join(projectAgentsDir, "project.md"),
@@ -222,8 +221,11 @@ test("formatAgentCatalog advertises scope variants deterministically and within 
 		const first = formatAgentCatalog({ user, project }, { maxCharacters: 5_000 });
 		const second = formatAgentCatalog({ user, project }, { maxCharacters: 5_000 });
 		assert.equal(first.text, second.text);
-		assert.match(first.text, /scout \[source: built-in; agentScope: "user"\]/);
-		assert.match(first.text, /scout \[source: project; requires agentScope: "project" or "both"/);
+		assert.match(first.text, /explorer \[source: built-in; agentScope: "user"\]/);
+		assert.match(
+			first.text,
+			/explorer \[source: project; requires agentScope: "project" or "both"/,
+		);
 		assert.match(first.text, /Project/);
 		assert.match(first.text, /Same-name precedence/);
 		assert.match(first.text, /project \[source: project/);
@@ -332,8 +334,8 @@ test("session start refreshes every agent catalog and gates project metadata on 
 			"---\nname: api-reviewer\ndescription: Reviews API compatibility\n---\nReview APIs.",
 		);
 		writeFileSync(
-			path.join(agentDir, "agents", "scout.md"),
-			"---\nname: scout\ndescription: User scout override\n---\nUser scout.",
+			path.join(agentDir, "agents", "explorer.md"),
+			"---\nname: explorer\ndescription: User explorer override\n---\nUser explorer.",
 		);
 		for (const cwd of [trustedCwd, untrustedCwd]) {
 			mkdirSync(path.join(cwd, ".pi", "agents"), { recursive: true });
@@ -342,8 +344,8 @@ test("session start refreshes every agent catalog and gates project metadata on 
 				"---\nname: local\ndescription: Project-only description\n---\nProject work.",
 			);
 			writeFileSync(
-				path.join(cwd, ".pi", "agents", "scout.md"),
-				"---\nname: scout\ndescription: Project scout override\n---\nProject scout.",
+				path.join(cwd, ".pi", "agents", "explorer.md"),
+				"---\nname: explorer\ndescription: Project explorer override\n---\nProject explorer.",
 			);
 		}
 		const mock = createMockPi();
@@ -368,10 +370,10 @@ test("session start refreshes every agent catalog and gates project metadata on 
 		const untrusted = await start(untrustedCwd, false);
 		for (const description of Object.values(untrusted)) {
 			assert.match(description, /api-reviewer/);
-			assert.match(description, /User scout override/);
+			assert.match(description, /User explorer override/);
 			assert.doesNotMatch(
 				description,
-				/Project-only description|Project scout override|local \[source: project|scout \[source: project/,
+				/Project-only description|Project explorer override|local \[source: project|explorer \[source: project/,
 			);
 		}
 		const trusted = await start(trustedCwd, true);
@@ -379,14 +381,14 @@ test("session start refreshes every agent catalog and gates project metadata on 
 			assert.match(description, /local \[source: project/);
 			assert.match(description, /agentScope: "project" or "both"/);
 			assert.match(description, /Project-only description/);
-			assert.match(description, /Project scout override/);
+			assert.match(description, /Project explorer override/);
 			assert.doesNotMatch(description, /untrusted/);
 		}
 		const untrustedAgain = await start(untrustedCwd, false);
 		for (const description of Object.values(untrustedAgain)) {
 			assert.doesNotMatch(
 				description,
-				/Project-only description|Project scout override|local \[source: project|scout \[source: project/,
+				/Project-only description|Project explorer override|local \[source: project|explorer \[source: project/,
 			);
 		}
 	} finally {

--- a/packages/pi-subagents/test/subagents-manager-ui.test.ts
+++ b/packages/pi-subagents/test/subagents-manager-ui.test.ts
@@ -181,7 +181,7 @@ test("agent tool drafts preserve settings across searchable save, discard, and E
 			settingsPath,
 			JSON.stringify({
 				future: { kept: true },
-				agents: { scout: { tools: ["read", "missing-tool"] } },
+				agents: { explorer: { tools: ["read", "missing-tool"] } },
 			}),
 		);
 		const mock = createMockPi({
@@ -258,7 +258,7 @@ test("agent tool drafts preserve settings across searchable save, discard, and E
 		assert.equal(call, 5, openedScreens.join("\n---\n"));
 		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
 			future: { kept: true },
-			agents: { scout: { tools: ["read", "missing-tool", "remote-tool"] } },
+			agents: { explorer: { tools: ["read", "missing-tool", "remote-tool"] } },
 		});
 		const savedDocument = readFileSync(settingsPath, "utf8");
 
@@ -657,7 +657,7 @@ test("current-session manager excludes already closed agent records", async () =
 		const mock = createMockPi();
 		const closedAgent: ManagedAgent = {
 			id: "sa_closed",
-			agent: "scout",
+			agent: "explorer",
 			rootId: "sa_closed",
 			depth: 0,
 			children: [],

--- a/packages/pi-subagents/test/subagents-registration.test.ts
+++ b/packages/pi-subagents/test/subagents-registration.test.ts
@@ -160,7 +160,7 @@ test("blocking parallel calls honor the configured worker limit", async () => {
 					"parallel-limit",
 					{
 						tasks: [
-							{ agent: "scout", task: "first" },
+							{ agent: "explorer", task: "first" },
 							{
 								agent: "reviewer",
 								task: "second",

--- a/packages/pi-subagents/test/subagents-settings-persistence.test.ts
+++ b/packages/pi-subagents/test/subagents-settings-persistence.test.ts
@@ -14,6 +14,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import { discoverAgents } from "../src/agents.js";
 import { consumeSubagentSettingsNotice } from "../src/settings.js";
 import subagents, {
 	inspectCompletionDeliverySettings,
@@ -57,6 +58,71 @@ test("subagent settings normalize known override fields only", () => {
 	assert.equal(normalizeSubagentSettings({ blocking: { enabled: "no" } }), undefined);
 	assert.equal(normalizeSubagentSettings({ blocking: false }), undefined);
 	assert.equal(normalizeSubagentSettings({ agents: [] }), undefined);
+});
+
+test("legacy scout agent overrides apply to explorer without overriding conflicts", () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-scout-settings-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({
+				agents: {
+					scout: {
+						tools: ["read"],
+						model: "legacy-model",
+						thinkingLevel: "medium",
+						timeoutMs: 1234,
+					},
+				},
+			}),
+		);
+
+		const migrated = discoverAgents(directory, "user", readSubagentSettings()).agents.find(
+			(agent) => agent.name === "explorer",
+		);
+		assert.deepEqual(migrated?.tools, ["read"]);
+		assert.equal(migrated?.model, "legacy-model");
+		assert.equal(migrated?.thinkingLevel, "medium");
+		assert.equal(migrated?.timeoutMs, 1234);
+
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({
+				agents: {
+					explorer: { tools: ["grep"] },
+					scout: { tools: ["read"] },
+				},
+			}),
+		);
+		const explicit = discoverAgents(directory, "user", readSubagentSettings()).agents.find(
+			(agent) => agent.name === "explorer",
+		);
+		assert.deepEqual(explicit?.tools, ["grep"]);
+
+		const agentsDir = path.join(directory, "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		writeFileSync(
+			path.join(agentsDir, "scout.md"),
+			"---\nname: scout\ndescription: Custom scout\ntools: bash\n---\nCustom scout.",
+		);
+		writeFileSync(settingsPath, JSON.stringify({ agents: { scout: { tools: ["read"] } } }));
+		const withCustomScout = discoverAgents(directory, "user", readSubagentSettings()).agents;
+		assert.deepEqual(withCustomScout.find((agent) => agent.name === "scout")?.tools, ["read"]);
+		assert.deepEqual(withCustomScout.find((agent) => agent.name === "explorer")?.tools, [
+			"read",
+			"grep",
+			"find",
+			"ls",
+			"bash",
+		]);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
 });
 
 test("session start re-reads settings before reporting warnings", async () => {

--- a/packages/pi-subagents/test/subagents-settings-persistence.test.ts
+++ b/packages/pi-subagents/test/subagents-settings-persistence.test.ts
@@ -38,7 +38,7 @@ test("subagent settings normalize known override fields only", () => {
 			blocking: { enabled: false },
 			stateful: { enabled: true },
 			agents: {
-				scout: { tools: ["read"], model: null, timeoutMs: 1, thinkingLevel: "medium" },
+				explorer: { tools: ["read"], model: null, timeoutMs: 1, thinkingLevel: "medium" },
 				clearThinking: { thinkingLevel: null },
 				bad: { tools: [1] },
 				badThinking: { thinkingLevel: "huge" },
@@ -47,7 +47,7 @@ test("subagent settings normalize known override fields only", () => {
 		}),
 		{
 			agents: {
-				scout: { tools: ["read"], model: null, timeoutMs: 1, thinkingLevel: "medium" },
+				explorer: { tools: ["read"], model: null, timeoutMs: 1, thinkingLevel: "medium" },
 				clearThinking: { thinkingLevel: null },
 			},
 			blocking: { enabled: false },
@@ -154,7 +154,7 @@ test("subagent settings read legacy files and save to the canonical package file
 		writeFileSync(
 			legacyPath,
 			JSON.stringify({
-				agents: { scout: { tools: ["read"] } },
+				agents: { explorer: { tools: ["read"] } },
 				blocking: { enabled: false },
 				stateful: { completionDelivery: "auto-resume" },
 				futureOption: true,
@@ -174,7 +174,7 @@ test("subagent settings read legacy files and save to the canonical package file
 		subagents(migrationMock.pi);
 		assert.equal(existsSync(canonicalPath), false);
 		assert.deepEqual(JSON.parse(readFileSync(legacyPath, "utf8")), {
-			agents: { scout: { tools: ["read"] } },
+			agents: { explorer: { tools: ["read"] } },
 			blocking: { enabled: false },
 			stateful: { completionDelivery: "auto-resume" },
 			futureOption: true,
@@ -185,9 +185,9 @@ test("subagent settings read legacy files and save to the canonical package file
 		}
 		assert.match(migrationContext.notifications[0]?.message ?? "", /using legacy/i);
 
-		writeFileSync(legacyPath, JSON.stringify({ agents: { scout: { tools: ["bash"] } } }));
-		writeFileSync(canonicalPath, JSON.stringify({ agents: { scout: { tools: ["read"] } } }));
-		assert.deepEqual(readSubagentSettings(), { agents: { scout: { tools: ["read"] } } });
+		writeFileSync(legacyPath, JSON.stringify({ agents: { explorer: { tools: ["bash"] } } }));
+		writeFileSync(canonicalPath, JSON.stringify({ agents: { explorer: { tools: ["read"] } } }));
+		assert.deepEqual(readSubagentSettings(), { agents: { explorer: { tools: ["read"] } } });
 		assert.deepEqual(inspectDelegationWorkflowSettings(), {
 			path: canonicalPath,
 			value: "all",
@@ -202,17 +202,17 @@ test("subagent settings read legacy files and save to the canonical package file
 		assert.match(inspectDelegationWorkflowSettings().error ?? "", /JSON/i);
 		assert.equal(readFileSync(legacyPath, "utf8").includes("bash"), true);
 		unlinkSync(legacyPath);
-		writeFileSync(canonicalPath, JSON.stringify({ agents: { scout: { tools: ["read"] } } }));
-		assert.deepEqual(readSubagentSettings(), { agents: { scout: { tools: ["read"] } } });
+		writeFileSync(canonicalPath, JSON.stringify({ agents: { explorer: { tools: ["read"] } } }));
+		assert.deepEqual(readSubagentSettings(), { agents: { explorer: { tools: ["read"] } } });
 		assert.equal(consumeSubagentSettingsNotice(), undefined);
 		unlinkSync(canonicalPath);
 		writeFileSync(legacyPath, "invalid");
 		assert.equal(readSubagentSettings(), undefined);
 		assert.equal(existsSync(canonicalPath), false);
 
-		writeFileSync(legacyPath, JSON.stringify({ agents: { scout: { tools: ["read"] } } }));
+		writeFileSync(legacyPath, JSON.stringify({ agents: { explorer: { tools: ["read"] } } }));
 		symlinkSync("missing-target", canonicalPath);
-		assert.deepEqual(readSubagentSettings(), { agents: { scout: { tools: ["read"] } } });
+		assert.deepEqual(readSubagentSettings(), { agents: { explorer: { tools: ["read"] } } });
 		assert.equal(existsSync(legacyPath), true);
 
 		saveSubagentConfig({ stateful: { enabled: false } });
@@ -354,7 +354,7 @@ test("legacy-seeded updates preserve canonical settings created before publicati
 		["delegation workflow", () => updateDelegationWorkflowSetting("async-only")],
 		["blocking parallel limit", () => updateBlockingMaxParallelTasksSetting(4)],
 		["detached limit", () => updateStatefulLimitSetting("maxAgents", 4)],
-		["agent tools", () => updateAgentToolsSetting("scout", ["read"])],
+		["agent tools", () => updateAgentToolsSetting("explorer", ["read"])],
 	] as const;
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	try {

--- a/packages/pi-subagents/test/subagents-settings-ui.test.ts
+++ b/packages/pi-subagents/test/subagents-settings-ui.test.ts
@@ -387,7 +387,7 @@ test("detached-limit lowering cancellation and stale previews leave settings unc
 		const agents: ManagedAgent[] = [
 			{
 				id: "older",
-				agent: "scout",
+				agent: "explorer",
 				rootId: "older",
 				depth: 0,
 				children: [],
@@ -505,7 +505,7 @@ test("detached-limit previews depth and stored-record reductions", async () => {
 	try {
 		const root: ManagedAgent = {
 			id: "root",
-			agent: "scout",
+			agent: "explorer",
 			rootId: "root",
 			depth: 0,
 			children: ["child"],
@@ -799,14 +799,14 @@ test("subagent settings UI preserves unknown JSON and applies completion deliver
 				completionDelivery: "auto-resume",
 			},
 		});
-		updateAgentToolsSetting("scout", ["read"]);
+		updateAgentToolsSetting("explorer", ["read"]);
 		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
 			futureOption: true,
 			stateful: {
 				futureStatefulOption: "keep",
 				completionDelivery: "auto-resume",
 			},
-			agents: { scout: { tools: ["read"] } },
+			agents: { explorer: { tools: ["read"] } },
 		});
 		await command.handler("status", context.ctx);
 		assert.match(
@@ -823,7 +823,7 @@ test("subagent settings UI preserves unknown JSON and applies completion deliver
 				futureStatefulOption: "keep",
 				completionDelivery: "auto-resume",
 			},
-			agents: { scout: { tools: ["read"] } },
+			agents: { explorer: { tools: ["read"] } },
 			consult: { resources: "none" },
 		});
 		await command.handler("status", context.ctx);

--- a/packages/pi-subagents/test/subagents-utilities.test.ts
+++ b/packages/pi-subagents/test/subagents-utilities.test.ts
@@ -49,11 +49,11 @@ test("subagent formatting and set helpers are deterministic", () => {
 });
 
 test("subagent thinking levels resolve by local, top-level, then agent default", () => {
-	const agents = [{ name: "scout", thinkingLevel: "low" }, { name: "reviewer" }] as const;
+	const agents = [{ name: "explorer", thinkingLevel: "low" }, { name: "reviewer" }] as const;
 
-	assert.equal(resolveSubagentThinkingLevel(agents, "scout", "medium", "high"), "high");
-	assert.equal(resolveSubagentThinkingLevel(agents, "scout", "medium"), "medium");
-	assert.equal(resolveSubagentThinkingLevel(agents, "scout"), "low");
+	assert.equal(resolveSubagentThinkingLevel(agents, "explorer", "medium", "high"), "high");
+	assert.equal(resolveSubagentThinkingLevel(agents, "explorer", "medium"), "medium");
+	assert.equal(resolveSubagentThinkingLevel(agents, "explorer"), "low");
 	assert.equal(resolveSubagentThinkingLevel(agents, "reviewer"), undefined);
 	assert.equal(resolveSubagentThinkingLevel(agents, "missing", "minimal"), "minimal");
 });

--- a/packages/pi-subagents/test/supervision.test.ts
+++ b/packages/pi-subagents/test/supervision.test.ts
@@ -5,7 +5,7 @@ import { runHedgedAttempt } from "../src/supervision.js";
 
 function result(exitCode: number, output: string): SingleResult {
 	return {
-		agent: "scout",
+		agent: "explorer",
 		agentSource: "built-in",
 		task: "inspect",
 		exitCode,

--- a/packages/pi-subagents/test/tool-rendering.test.ts
+++ b/packages/pi-subagents/test/tool-rendering.test.ts
@@ -444,19 +444,19 @@ test("inspect renderer summarizes every action instead of dumping collapsed JSON
 			args: { action: "list_agents", agentScope: "user" },
 			details: {
 				action: "list_agents",
-				agents: [{ name: "scout", source: "built-in", toolCount: 4, consultTools: ["read"] }],
+				agents: [{ name: "explorer", source: "built-in", toolCount: 4, consultTools: ["read"] }],
 				returned: 1,
 				omitted: 0,
 			},
-			expected: /1 agent.*scout/is,
+			expected: /1 agent.*explorer/is,
 		},
 		{
-			args: { action: "get_agent", agent: "scout" },
+			args: { action: "get_agent", agent: "explorer" },
 			details: {
 				action: "get_agent",
-				agent: { name: "scout", source: "built-in", description: "Scout files" },
+				agent: { name: "explorer", source: "built-in", description: "Explorer files" },
 			},
-			expected: /scout.*built-in.*Scout files/is,
+			expected: /explorer.*built-in.*Explorer files/is,
 		},
 		{
 			args: { action: "list_runs" },

--- a/packages/pi-subagents/test/verification-policy.test.ts
+++ b/packages/pi-subagents/test/verification-policy.test.ts
@@ -71,7 +71,7 @@ test("verification policy validates one distinct direct structured verifier", ()
 			validateWorkflowVerificationGraph(
 				[
 					{ id: "implementation", agent: "worker", resultFormat: "structured-v2" },
-					{ id: "other", agent: "scout", resultFormat: "structured-v2" },
+					{ id: "other", agent: "explorer", resultFormat: "structured-v2" },
 					{
 						id: "verification",
 						agent: "reviewer",
@@ -98,7 +98,7 @@ test("verification policy validates one distinct direct structured verifier", ()
 					},
 					{
 						id: "verification-b",
-						agent: "scout",
+						agent: "explorer",
 						dependsOn: ["implementation"],
 						verifierFor: "implementation",
 						resultFormat: "structured-v2",

--- a/packages/pi-subagents/test/workflow-plan-compiler.test.ts
+++ b/packages/pi-subagents/test/workflow-plan-compiler.test.ts
@@ -49,7 +49,7 @@ const agents = [
 	agent("worker", ["implementation"], "write"),
 	agent("worker-two", ["implementation"], "write"),
 	agent("reviewer", ["code-review"], "read", ["independent-review"]),
-	agent("scout", ["repository-search"], "read"),
+	agent("explorer", ["repository-search"], "read"),
 ];
 
 function request(overrides: Record<string, unknown> = {}) {
@@ -146,7 +146,7 @@ test("compiler admits one child and a sequential dependency without widening aut
 	assert.equal(one.status, "compiled");
 	if (one.status !== "compiled") return;
 	assert.equal(one.workflow.tasks.length, 1);
-	assert.equal(one.workflow.tasks[0]?.agent, "scout");
+	assert.equal(one.workflow.tasks[0]?.agent, "explorer");
 	assert.deepEqual(one.workflow.tasks[0]?.requiredTools, ["read"]);
 
 	const sequential = compile([task("inspect"), task("summarize", { dependsOn: ["inspect"] })]);


### PR DESCRIPTION
## Summary
- Rename the built-in pi-subagents read-only role from `scout` to `explorer`.
- Update the explorer prompt to emphasize specific, well-scoped codebase questions and read-only bash usage.
- Update README examples, tests, and changesets so `scout` is no longer treated as available.

## Verification
- `npx vitest run packages/pi-subagents/test/agents.test.ts packages/pi-subagents/test/subagents-agent-catalog.test.ts packages/pi-subagents/test/execution-ui.test.ts packages/pi-subagents/test/subagents-settings-persistence.test.ts packages/pi-subagents/test/subagents-settings-ui.test.ts packages/pi-subagents/test/automation.test.ts packages/pi-subagents/test/panel-execution.test.ts packages/pi-subagents/test/subagent-workflow-execution.test.ts`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npm run check`
- precommit: `npm run biome:check && npm run typecheck`

## Convention audit
- Read `docs/extension-conventions.md`, `docs/extension-settings.md`, and `packages/pi-subagents/AGENTS.md`.
- Touched built-in catalog, docs, tests, and release notes only.
- Settings persistence behavior was not changed; settings tests were updated for the renamed key.

## Breaking change
- The built-in `scout` agent is renamed to `explorer`; `scout` is not kept as an alias.