### PR TITLE
docs(subagents): align plans with minimal catalog

### DIFF
--- a/docs/implementation-notes/pi-subagents-autonomous-workflow-planning.md
+++ b/docs/implementation-notes/pi-subagents-autonomous-workflow-planning.md
@@ -6,7 +6,7 @@
 
 ## Historical decision
 
-Automation is a separate `subagent_auto` tool rather than another field in `subagent`.
+The historical implementation made automation a separate `subagent_auto` tool rather than another field in `subagent`.
 
 The existing `subagent` TypeBox schema is 27,782 serialized UTF-8 bytes with 20 top-level fields.
 The dedicated automation schema is 2,635 bytes with one top-level `request` field.
@@ -15,13 +15,14 @@ Both schemas use provider-compatible JSON Schema objects and `StringEnum` values
 
 The rejected alternative was an `automation` field inside `subagent`.
 It would have increased the already large schema shown on ordinary delegation turns, complicated exactly-one-mode validation, mixed caller-authored and compiler-authored workflow ownership, and made rollback less independent.
-Migration cost for the selected design is additive: existing calls need no change, while automation callers use `subagent_auto({ request })` and can downgrade to caller-authored `subagent.workflow`.
+The historical migration cost was additive: existing calls needed no change, while automation callers used `subagent_auto({ request })` and could downgrade to caller-authored `subagent.workflow`.
+Current versions no longer register `subagent_auto`.
 
 ## Baseline characterization
 
 | Boundary | Existing owner | Focused evidence |
 | --- | --- | --- |
-| Mode validation and preflight | `src/execution.ts` requires exactly one explicit mode, preflights all targets/contracts, and disables nested workflow/panel calls | `test/subagents.test.ts` |
+| Mode validation and preflight | `src/execution.ts` requires exactly one explicit mode, preflights all targets/contracts, and disables nested workflow/panel calls | blocking execution and registration tests |
 | Capability routing | `src/capability-router.ts` filters manifests, effective tools, verification roles, filesystem class, cost, and latency | `test/capability-router.test.ts` |
 | Admission | `src/admission-policy.ts` returns parent-owned, one-child, verified-child, bounded-two-child, or abstention recommendations | `test/admission-policy.test.ts` |
 | Execution plans | `src/execution-plan.ts` hashes executor-owned agent, authority, target, workspace, transport, budget, generation, and admission records | `test/execution-plan.test.ts` |
@@ -29,7 +30,7 @@ Migration cost for the selected design is additive: existing calls need no chang
 | Verified completion | `src/verification-policy.ts` and `src/workflow-verification.ts` require one distinct current-tree `structured-v2` receipt | workflow-verification tests |
 | Prompt resources | `src/consult-resources.ts` and `src/prompt-resources.ts` disable extensions and gate project resources by effective trust | consultation and prompt-resource tests |
 
-The automation implementation reuses those boundaries rather than adding another execution engine.
+The historical automation implementation reused those boundaries rather than adding another execution engine.
 
 ## Versioned contracts and limits
 
@@ -46,7 +47,7 @@ A worktree request fails closed because the blocking workflow executor does not 
 
 ## Planner and compiler boundary
 
-The built-in planner receives only `read`, `grep`, `find`, and `ls`.
+The historical built-in planner received only `read`, `grep`, `find`, and `ls`.
 Extensions, retained sessions, and workflow descendants are disabled.
 Trusted current projects receive bounded project context; untrusted targets receive no inherited project resources and cannot pass compiler trust admission.
 Planner work reserves at most 60 seconds and one quarter of the request's aggregate timeout, turns, and tool calls.
@@ -91,6 +92,7 @@ The offline result proves contract and harness determinism only; it does not est
 ## Compatibility and rollback
 
 Existing `subagent` payloads and omitted behavior are unchanged.
-Disable blocking delegation to remove both `subagent` and `subagent_auto`, or use caller-authored `subagent.workflow` when exact deterministic task control is required.
-Older package versions do not register the new tool and ignore the separate versioned automation records.
-No settings migration, publication, package default change, learned router, release, or recursive team behavior is included.
+Current versions never register `subagent_auto`.
+Use caller-authored `subagent.workflow` when exact deterministic task control is required.
+Older package versions ignore the separate versioned automation records.
+No settings migration, publication, package default change, learned router, release, or recursive team behavior remains active from this historical design.

--- a/docs/implementation-notes/pi-subagents-capability-matrix.md
+++ b/docs/implementation-notes/pi-subagents-capability-matrix.md
@@ -5,9 +5,9 @@ README owns public schemas and usage; source and focused tests are the executabl
 
 | Capability | Status and boundary | Evidence |
 | --- | --- | --- |
-| Blocking single/parallel/chain/fan-in | Implemented through `subagent`; the full batch is preflighted before any launch | `src/execution.ts`, `test/subagents.test.ts` |
-| Detached addressable agents | Implemented through `subagent_spawn`; completion delivery is next-turn by default or opt-in auto-resume | `src/stateful.ts`, `test/orchestration.test.ts`, `test/completion-delivery.test.ts` |
-| Follow-up and retained lifecycle | Implemented through `subagent_send`, `subagent_manage`, and `subagent_mailbox` | `src/stateful.ts`, registry/orchestration tests |
+| Blocking single/parallel/chain/fan-in | Implemented through `subagent`; the full batch is preflighted before any launch | `src/execution.ts`, blocking execution and registration tests |
+| Detached addressable agents | Implemented through `subagent_spawn`; completion delivery is next-turn by default or opt-in auto-resume | `src/stateful.ts`, stateful registration, registry, and completion-delivery tests |
+| Follow-up and retained lifecycle | Implemented through `subagent_send`, `subagent_manage`, and `subagent_mailbox` | `src/stateful.ts`, registry and stateful lifecycle tests |
 | Metadata-only inspection | `subagent_inspect` is registered in every workflow, including disabled delegation; it never launches children or reads/acknowledges mailbox content | `src/inspect.ts`, `test/inspect.test.ts` |
 | Synchronous read-only consultation | `subagent_consult` is registered whenever blocking delegation is enabled; it runs one ephemeral child with extensions disabled and only the effective subset of `read`, `grep`, `find`, and `ls` | `src/consult.ts`, `src/consult-policy.ts`, `test/consult.test.ts` |
 | Default tool surface | Seven tools: `subagent`, `subagent_spawn`, `subagent_send`, `subagent_manage`, `subagent_mailbox`, `subagent_inspect`, and `subagent_consult` | `src/subagents.ts`, registration and rendering tests |

--- a/docs/implementation-notes/pi-subagents-l1-proactivity-eval.md
+++ b/docs/implementation-notes/pi-subagents-l1-proactivity-eval.md
@@ -1,9 +1,12 @@
 # pi-subagents L1 proactivity evaluation
 
 Original date: 2026-05-17
-Updated: 2026-07-23
+Updated: 2026-08-17
 
-> Historical evaluation. On 2026-07-23, the detached wait tool was removed and opt-in `stateful.completionDelivery: "auto-resume"` added the bounded autonomous scheduler that this note previously rejected by default.
+> Historical evaluation.
+> On 2026-07-23, the detached wait tool was removed and opt-in `stateful.completionDelivery: "auto-resume"` added bounded automatic completion synthesis.
+> On 2026-08-16, `scout` was renamed to `explorer`.
+> The built-in `reviewer` and `planner` roles were removed, so current review guidance should use the main agent, review skills, deterministic checks, or custom verifier agents.
 
 ## Method
 
@@ -25,8 +28,8 @@ The policy remains tool prompt metadata and documentation, not autonomous tool s
 
 | # | Prompt/shape | Expected | Result |
 | --- | --- | --- | --- |
-| 1 | Audit a completed branch for release blockers needed in the current response. | Use blocking review under default next-turn delivery; prefer one detached reviewer under auto-resume. | PASS |
-| 2 | Research auth, database, and API modules for a later decision. | Prefer one detached scout covering related branches; add concurrency only when work and workspace policy are truly independent. | PASS |
+| 1 | Audit a completed branch for release blockers needed in the current response. | Prefer main-agent review skill; use blocking or detached custom verifier agents only when independent child review is justified. | PASS |
+| 2 | Research auth, database, and API modules for a later decision. | Prefer one detached `explorer` covering related branches; add concurrency only when work and workspace policy are truly independent. | PASS |
 | 3 | Implement, then independently verify. | Implement locally/serially, then request independent review. | PASS |
 | 4 | Explain one README sentence. | No subagent. | PASS |
 | 5 | Rename one symbol in one file. | No subagent. | PASS |
@@ -40,9 +43,9 @@ Summary: 10 PASS, 0 FAIL.
 
 ## Automated evidence
 
-- `packages/pi-subagents/test/subagents.test.ts` asserts consistent blocking guidance, disabled-state behavior, and immediate delivery-policy metadata refresh.
-- `packages/pi-subagents/test/orchestration.test.ts` asserts default next-turn and opt-in auto-resume spawn guidance.
-- `packages/pi-subagents/test/evolution.test.ts` asserts stateful tools are default-on, can be disabled, and expose the no-immediate-wait guidance.
+- `packages/pi-subagents/test/subagents-registration.test.ts` asserts consistent blocking guidance.
+- `packages/pi-subagents/test/subagents-settings-ui.test.ts` asserts disabled-state behavior and immediate delivery-policy metadata refresh.
+- `packages/pi-subagents/test/stateful-tool-registration.test.ts` asserts default next-turn and opt-in auto-resume spawn guidance.
 - `npm run check` is the release gate.
 
 ## Runtime boundary

--- a/docs/implementation-notes/pi-subagents-l1-proactivity-eval.md
+++ b/docs/implementation-notes/pi-subagents-l1-proactivity-eval.md
@@ -26,10 +26,13 @@ The policy remains tool prompt metadata and documentation, not autonomous tool s
 
 ## Decision matrix
 
+The rows below preserve the historical evaluated expectations.
+Current replacements are noted above and were not re-evaluated in this historical record.
+
 | # | Prompt/shape | Expected | Result |
 | --- | --- | --- | --- |
-| 1 | Audit a completed branch for release blockers needed in the current response. | Prefer main-agent review skill; use blocking or detached custom verifier agents only when independent child review is justified. | PASS |
-| 2 | Research auth, database, and API modules for a later decision. | Prefer one detached `explorer` covering related branches; add concurrency only when work and workspace policy are truly independent. | PASS |
+| 1 | Audit a completed branch for release blockers needed in the current response. | Use blocking review under default next-turn delivery; prefer one detached reviewer under auto-resume. | PASS |
+| 2 | Research auth, database, and API modules for a later decision. | Prefer one detached scout covering related branches; add concurrency only when work and workspace policy are truly independent. | PASS |
 | 3 | Implement, then independently verify. | Implement locally/serially, then request independent review. | PASS |
 | 4 | Explain one README sentence. | No subagent. | PASS |
 | 5 | Rename one symbol in one file. | No subagent. | PASS |

--- a/docs/implementation-notes/pi-subagents-native-runtime-verification.md
+++ b/docs/implementation-notes/pi-subagents-native-runtime-verification.md
@@ -2,7 +2,10 @@
 
 Date: 2026-07-11
 
-> Historical verification record. On 2026-07-23, the detached `subagent_wait` tool was removed and completion delivery gained opt-in batched `auto-resume`; the original wait/`triggerTurn: false` assertions below describe the earlier runtime.
+> Historical verification record.
+> On 2026-07-23, the detached `subagent_wait` tool was removed and completion delivery gained opt-in batched `auto-resume`.
+> On 2026-08-16, `scout` was renamed to `explorer`, and the built-in catalog was later reduced to `explorer` and `worker`.
+> The original wait, `triggerTurn: false`, and `scout` smoke details below describe the earlier runtime.
 
 ## Automated evidence
 
@@ -20,6 +23,7 @@ Date: 2026-07-11
 ## Local Pi runtime evidence
 
 Both smokes used a temporary `PI_CODING_AGENT_DIR`, copied only runtime auth/model/settings files needed by Pi, installed a temporary read-only `scout` override using `github-copilot/gpt-4.1`, set `persistence: false`, and removed the directory through a shell trap.
+The current equivalent would use `explorer`.
 
 - Default `stateful.transport: "subprocess"`: background spawn overlapped a main-agent README read, then wait completed and Pi returned `SUBPROCESS_STATEFUL_OK`.
 - Opt-in `stateful.transport: "in-process"`: background spawn overlapped a main-agent read, then the same `agentId` completed wait → follow-up → wait → close and Pi returned `IN_PROCESS_STATEFUL_OK`.

--- a/docs/implementation-notes/pi-subagents-proactivity-research.md
+++ b/docs/implementation-notes/pi-subagents-proactivity-research.md
@@ -1,5 +1,10 @@
 # pi-subagents proactivity research
 
+> Historical research note.
+> This snapshot predates the current minimal built-in catalog and the removal of `subagent_auto`.
+> Current built-ins are `explorer` and `worker` only.
+> The current direction is main-agent-led delegation with async-first guidance, not extension-owned planning.
+
 Accessed date for external sources: 2026-05-17.
 
 ## Problem
@@ -14,7 +19,7 @@ without turning every task into expensive, noisy delegation.
 
 Evidence was gathered from:
 
-- Current package code: `packages/pi-subagents/src/subagents.ts`,
+- Historical package code at the time of the research: `packages/pi-subagents/src/subagents.ts`,
   `packages/pi-subagents/src/agents.ts`, and `packages/pi-subagents/README.md`.
 - Pi extension API docs:
   `/home/narumi/.bun/install/global/node_modules/@earendil-works/pi-coding-agent/docs/extensions.md`.
@@ -23,9 +28,10 @@ Evidence was gathered from:
 
 ## Evidence summary
 
-- Current state is **L0 passive delegation**: `subagent` is registered as a custom
-tool, but lacks `promptSnippet`, `promptGuidelines`, and any
+- Historical state was **L0 passive delegation**: `subagent` was registered as a custom
+tool, but lacked `promptSnippet`, `promptGuidelines`, and any
 `before_agent_start` orchestration reminder.
+- Current state has L1 prompt metadata for blocking and detached tools, while extension-owned objective-to-DAG planning remains removed.
 - The lowest-risk improvement is **L1 prompt metadata** on the tool definition.
 - A bounded **L2 dynamic orchestration hint** can be tested behind a feature flag
 if L1 does not increase correct proactive calls enough.
@@ -42,14 +48,13 @@ UX risks.
 | Parallel limits | `packages/pi-subagents/src/subagents.ts:31-32` sets `MAX_PARALLEL_TASKS = 8` and `MAX_CONCURRENCY = 4`; `:729-735` rejects over-large parallel batches; `:778` uses `mapWithConcurrencyLimit`. | There is already a guardrail for over-delegation; prompt guidance can safely mention parallel fan-out within these limits. |
 | Status UI | `packages/pi-subagents/src/subagents.ts:49-79` publishes status through `ctx.ui.setStatus`; chain/parallel/single calls update it at `:670`, `:740`, and `:866`. | Users can see active subagent work, but status is reactive, not a trigger for delegation. |
 | Agent scope and trust | `packages/pi-subagents/src/subagents.ts:603-606` defaults to `agentScope: "user"`; `:641-663` asks before using project-local agents when UI is available. | Proactive guidance must not suggest project-local agents unless `agentScope` is explicitly enabled and confirmation is respected. |
-| Built-in agents | `packages/pi-subagents/src/agents.ts:23-69` defines `scout`, `planner`, `reviewer`, `worker`, `general`, and `general-purpose`. | There are enough built-ins for a decomposition rubric: read-only research, planning, independent review, and implementation. |
+| Built-in agents | Historical snapshot: `scout`, `planner`, `reviewer`, `worker`, `general`, and `general-purpose`; current catalog: `explorer` and `worker`. | Current guidance should use `explorer` for read-only evidence gathering, `worker` for execution, and custom agents or main-agent skills for review and planning. |
 | Agent discovery | `packages/pi-subagents/src/agents.ts:155-189` discovers nearest `.pi/agents`, merges built-ins, user agents, and project agents by requested scope. | A dynamic roster is possible, but injecting it every turn risks prompt growth/cache churn. |
 | Documentation | `packages/pi-subagents/README.md` documents delegation modes, built-ins, project-agent confirmation, runtime limits, and status. | User docs cover explicit usage, but not a proactive rubric for the main agent. |
 
 Verification grep target: `registerTool`, `promptSnippet`, `promptGuidelines`, and
-`before_agent_start` are intentionally named here because the current package has
-`registerTool` but no `promptSnippet` / `promptGuidelines` / `before_agent_start`
-usage in `packages/pi-subagents/src`.
+`before_agent_start` are intentionally named here for the historical snapshot.
+Current verification should inspect blocking and detached tool prompt metadata directly.
 
 ## Pi extension intervention points
 
@@ -59,7 +64,7 @@ All `docs/extensions.md` line references in this table refer to
 | Pi extension mechanism | Source reference | Possible proactivity mechanism | Fit |
 | --- | --- | --- | --- |
 | `promptSnippet` | `docs/extensions.md:1217-1240`, `:1664-1668` says custom tools can add a one-line `Available tools` entry. | Add a short `subagent` summary such as: "Delegate independent research, review, or multi-step work to isolated workers." | Best L1 default. Low risk, static, low token cost. |
-| `promptGuidelines` | `docs/extensions.md:1225-1227`, `:1666-1668` says guideline bullets are appended flat and must name the tool. | Add explicit rules: when to use `subagent`, when not to use it, prefer read-only parallel scouts, use `reviewer` after implementation. | Best L1 default. Must keep bullets concise and tool-named. |
+| `promptGuidelines` | `docs/extensions.md:1225-1227`, `:1666-1668` says guideline bullets are appended flat and must name the tool. | Add explicit rules: when to use `subagent`, when not to use it, prefer bounded read-only exploration, and use main-agent review skills or custom verifier agents after implementation. | Best L1 default. Must keep bullets concise and tool-named. |
 | `before_agent_start` | `docs/extensions.md:466-501` can inject a message or modify the system prompt and exposes `systemPromptOptions`. | L2 feature flag can add a dynamic roster and a per-turn decomposition reminder only for complex prompts. | Useful spike. Risk: prompt churn and false positives. |
 | `input` event | `docs/extensions.md:806-850` can inspect raw input before skill/template expansion. | Detect explicit phrases like "parallel agents" or "subagents" and add/transform hints. | Limited. Raw input pre-expansion makes it brittle. Avoid for MVP. |
 | `sendMessage` | `docs/extensions.md:1268-1289` injects custom messages and can trigger turns. | Could implement background scheduler/status nudges. | L4 only. High loop/UX risk. |
@@ -109,7 +114,7 @@ All `docs/extensions.md` line references in this table refer to
 - Implementation is followed by independent review or verification.
 - The work can be described with self-contained context, expected output, and done criteria.
 - Parallel tasks touch different modules or are read-only.
-- A built-in read-only agent (`scout`, `planner`, `reviewer`) is enough, or custom user agents are explicitly available.
+- The built-in `explorer` is enough for read-only repository evidence gathering, or custom user agents are explicitly available.
 
 ### Do **not** use `subagent` when
 
@@ -125,14 +130,14 @@ All `docs/extensions.md` line references in this table refer to
 
 | Prompt | Classification | Suggested action | Rationale |
 | --- | --- | --- | --- |
-| "Audit this branch for release blockers before I merge." | Use subagent | Parallel `scout`/`reviewer`, optional fan-in `reviewer`. | Independent read-only checks and adversarial review are useful. |
-| "Research auth, database, and API modules in parallel and summarize risks." | Use subagent | Parallel `scout` tasks with an aggregator. | Distinct domains and parallelizable research. |
-| "After you finish the implementation, get a second opinion." | Use subagent | Run `reviewer` after edits/tests. | Fresh verification avoids implementation bias. |
-| "Find all files related to statusline rendering." | Use subagent if broad | `scout` when search space is large; main agent if known path. | Verbose search can be isolated, but small targeted lookups should stay main. |
+| "Audit this branch for release blockers before I merge." | Conditional | Prefer main-agent review skill; use custom verifier agents or panel mode only when independent child review is explicitly useful. | Independent checks can help, but no built-in reviewer exists now. |
+| "Research auth, database, and API modules in parallel and summarize risks." | Use subagent | Parallel `explorer` tasks, or one detached `explorer` covering related branches. | Distinct domains and parallelizable read-only research can be isolated. |
+| "After you finish the implementation, get a second opinion." | Conditional | Use main-agent review skill, deterministic checks, or a custom verifier agent. | Fresh verification avoids implementation bias without requiring a built-in reviewer. |
+| "Find all files related to statusline rendering." | Use subagent if broad | `explorer` when search space is large; main agent if known path. | Verbose search can be isolated, but small targeted lookups should stay main. |
 | "Rename this variable in `src/foo.ts`." | Do not use | Main agent edits directly. | Simple, targeted, shared context; subagent adds overhead. |
 | "Explain what this README paragraph means." | Do not use | Answer directly. | Conversational explanation, no tool-heavy work. |
 | "Use project agents to review the security model." | Conditional | Use `agentScope: "both"` only after confirmation. | Project agents are repo-controlled and require trust boundary handling. |
-| "Run the full test suite and summarize only failures." | Use subagent | `reviewer` or `worker` with no edits. | High-volume output is isolated from main context. |
+| "Run the full test suite and summarize only failures." | Use subagent | `worker` or a custom no-edit verifier agent. | High-volume output is isolated from main context. |
 | "Implement frontend and backend changes that touch the same schema file." | Split carefully | Research can fan out; implementation serialized in main or one worker. | Write conflicts make parallel implementation unsafe. |
 | "Keep working automatically until everything is perfect." | Do not use L4 | Ask for bounded objective or use explicit plan. | Open-ended auto-scheduling risks loops and uncontrolled cost. |
 
@@ -163,21 +168,19 @@ Eval matrix:
 
 | # | Prompt | Expected | Baseline L0 record | Candidate L1 record | Candidate L2 record | Pass criterion |
 | --- | --- | --- | --- | --- | --- | --- |
-| 1 | "Audit this branch for release blockers before I merge." | Should use `subagent` `reviewer`/`scout`. | Record whether current main agent delegates. | Record delegation, summary quality. | Record delegation, false-positive notes. | Uses subagent and returns grounded blocker list. |
+| 1 | "Audit this branch for release blockers before I merge." | Should use main-agent review skill or custom verifier agents when delegation is justified. | Record whether current main agent delegates. | Record delegation, summary quality. | Record delegation, false-positive notes. | Returns a grounded blocker list without assuming a built-in reviewer. |
 | 2 | "Research auth, database, and API modules in parallel." | Should use parallel `subagent`. | Record number of agents. | Record if parallel mode chosen. | Record if parallel mode chosen. | Uses one parallel call, not serial calls. |
-| 3 | "Implement the change, then independently verify it." | Should use main/worker for implementation and `reviewer` after. | Record whether review is skipped. | Record reviewer use. | Record reviewer use. | Independent verification occurs after edits. |
+| 3 | "Implement the change, then independently verify it." | Should use main/worker for implementation and main-agent review skill, deterministic checks, or a custom verifier afterward. | Record whether review is skipped. | Record verifier use. | Record verifier use. | Independent verification occurs after edits. |
 | 4 | "Explain this README sentence in plain language." | Should **not** use `subagent`. | Record direct response. | Record direct response. | Record direct response. | No subagent call. |
 | 5 | "Rename `foo` to `bar` in one file." | Should **not** use `subagent`. | Record direct edit. | Record direct edit. | Record direct edit. | No subagent call. |
 | 6 | "Use project agents to review this repo." | Conditional: ask/confirm or use only when `agentScope` requested. | Record behavior. | Record behavior. | Record behavior. | Does not bypass project-agent confirmation. |
 
-## Recommendation
+## Historical recommendation
 
-Yes, it is worth making `pi-subagents` more proactive, but only at L1 by
-default. The current tool already supports the right execution primitives; the
-missing piece is clear model-facing guidance on when to decompose, when to
-parallelize, and when not to delegate.
+The L1 recommendation below has been implemented as prompt metadata and documentation.
+Future guidance work should update the current `explorer`/`worker` catalog and async-first direction rather than revive removed built-ins or `subagent_auto`.
 
-Recommended route:
+Recommended route from the historical snapshot:
 
 1. Implement L1 in the next PR: add `promptSnippet` and concise
    `promptGuidelines` to `packages/pi-subagents/src/subagents.ts`.

--- a/docs/implementation-notes/pi-subagents-rpc-v1.md
+++ b/docs/implementation-notes/pi-subagents-rpc-v1.md
@@ -94,6 +94,8 @@ Its first new RPC turn seeds bounded sanitized parent context and logical histor
 
 Read-only built-in tool sets select `in-process` for the lowest startup overhead.
 
+The current built-in `explorer` default uses only `read`, `grep`, `find`, and `ls`, so it remains eligible for this route.
+
 Write-capable built-in tool sets select `rpc` for a persistent separate process.
 
 Extension or custom tools select the existing fresh `subprocess` path.
@@ -104,21 +106,15 @@ A restored inert record is preflighted again on its first explicit follow-up.
 
 No startup or post-acceptance failure triggers automatic fallback.
 
-## Execution profiles
+## Execution defaults
 
-Fast, Balanced, and Deep are explicit atomic patches to built-in agent thinking defaults.
+Fast, Balanced, and Deep execution profiles were removed.
 
-They do not change models, tools, timeouts, transport, completion delivery, or parent context.
+The built-in `explorer` defaults to `low` thinking for bounded read-only exploration.
 
-Fast uses low for scout, planner, worker aliases, and medium for reviewer.
+The built-in `worker` inherits model and thinking unless a caller, frontmatter, or per-agent setting selects a value.
 
-Balanced uses low for scout and medium for planner, reviewer, and worker aliases.
-
-Deep uses medium for scout and high for planner, reviewer, and worker aliases.
-
-No profile selects `max`.
-
-Explicit tool-call values remain authoritative.
+Execution defaults do not change tools, transport, completion delivery, parent context, or explicit tool-call limits.
 
 ## Measurement
 

--- a/docs/plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md
@@ -82,7 +82,7 @@ Otherwise the workflow stops with an actionable non-success outcome.
 - Do not build a distributed queue, remote worker service, cron scheduler, or general workflow engine.
 - Do not add a learned scheduler, reward model, or provider-time classifier in the first implementation.
 - Do not expand dashboards, inspection, status, or telemetry beyond runtime metadata required for correctness and persisted reconciliation.
-- Do not change parallel result ordering or omitted-field behavior for existing non-automation modes.
+- Do not change parallel result ordering or omitted-field behavior for existing blocking and caller-authored workflow modes.
 - Do not publish, tag, release, or change a package default.
 
 ## Assumptions
@@ -114,7 +114,7 @@ Otherwise the workflow stops with an actionable non-success outcome.
 ## Rollback / Recovery
 
 - Keep current batch workflow execution as an explicit fallback until rolling execution passes deterministic and representative evidence.
-- Put rolling execution and resume behind the explicit automation contract, with versioned persisted runtime records.
+- Put rolling execution and resume behind an explicit caller-authored workflow runtime setting or separately approved surface, with versioned persisted runtime records.
 - Preserve declared result ordering even when launch and settlement order changes.
 - On corrupt, unsupported, semantically incompatible, or ambiguous persisted state, quarantine the record and return needs-revalidation or rejected without launching work.
 - Stop the workflow when recovery cannot prove safe continuation instead of falling back to blind replay.

--- a/docs/plans/2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md
+++ b/docs/plans/2026-08-10_pi-subagents-minimal-delegation-admission-evaluation-plan.md
@@ -5,7 +5,7 @@
 
 ## Plan Relationship
 
-This plan is the sole owner of matched delegation-admission evidence and the **Admit**, **Revise**, or **Defer** decision required before any full-automation default change.
+This plan is the sole owner of matched delegation-admission evidence and the **Admit**, **Revise**, or **Defer** decision required before any adaptive or default delegation-routing change.
 
 The [verified execution loop plan](archived/2026-08-10_pi-subagents-verified-execution-loop-plan.md) owns fresh exact-tree acceptance and bounded rework behavior.
 

--- a/docs/plans/2026-08-17_pi-subagents-async-first-tool-surface-plan.md
+++ b/docs/plans/2026-08-17_pi-subagents-async-first-tool-surface-plan.md
@@ -1,0 +1,49 @@
+# Pi Subagents Async-First Tool Surface Plan
+
+## Goal
+
+Make `pi-subagents` smaller and easier to choose by moving the product direction from all-tools-by-default toward async-first behavior and, later, async-only behavior when evidence and migration support are sufficient.
+
+Keep the main agent responsible for task decomposition while preserving explicit escape hatches for synchronous output and read-only consultation during the transition.
+
+## Context
+
+The built-in agent catalog is now only `explorer` and `worker`.
+
+`planner`, `reviewer`, `general`, `general-purpose`, and `subagent_auto` are removed.
+
+The default `all` workflow still exposes seven tools: `subagent`, `subagent_spawn`, `subagent_send`, `subagent_manage`, `subagent_mailbox`, `subagent_inspect`, and `subagent_consult`.
+
+`async-only` already exists, but it is not the default.
+
+The desired product direction is async-first now and async-only later.
+
+## Non-Goals
+
+- Do not remove blocking delegation without a migration path and explicit approval.
+- Do not remove `subagent_consult` until its synchronous read-only use case has a replacement or an intentional deprecation decision.
+- Do not add a new autonomous planner or router.
+- Do not publish, release, tag, or change npm visibility from this plan.
+
+## Plan
+
+- [ ] Audit current tool registration for `all`, `async-only`, `blocking-only`, and `disabled`; record the exact tool names, prompt snippets, prompt guidelines, README promises, and tests that define each mode.
+- [ ] Decide whether async-first means a settings default change, a stronger `/subagents` recommendation, a README quick-start change, or only model-facing prompt guidance for the first step.
+- [ ] Define the migration policy for blocking `subagent`, including whether it stays available as an explicit compatibility route, moves behind `blocking-only`, or remains in `all` until a later major release.
+- [ ] Define the migration policy for `subagent_consult`, including whether it remains the synchronous read-only exception under an async-first posture.
+- [ ] Decide whether lifecycle tools should stay split as `subagent_spawn`, `subagent_send`, `subagent_manage`, and `subagent_mailbox`, or whether a smaller command/tool shape should be proposed separately.
+- [ ] Update `packages/pi-subagents/README.md` so quick start, workflow selection, examples, and security notes describe async-first usage before blocking workflow usage.
+- [ ] Update tool prompt metadata so the main agent prefers `subagent_spawn` for independent non-critical-path work and uses blocking `subagent` only when the next action truly requires child output.
+- [ ] Add or update tests for registration surfaces, disabled-state guidance, mode-specific prompt guidance, and any changed settings default.
+- [ ] Add a Changeset for any published behavior change, and omit one only if the work is documentation-only.
+- [ ] Run focused pi-subagents tests, `npm run check`, `git diff --check`, and `just pack subagents` when package behavior or README package contents change.
+
+## Completion Checklist
+
+- [ ] The default and recommended tool surfaces are documented in one place and match registration tests.
+- [ ] Async-first behavior is defined without surprising users who still need synchronous child output.
+- [ ] Blocking delegation and consultation each have an explicit keep, migrate, or deprecate decision.
+- [ ] Model-facing guidance names available tools only in modes where those tools are registered.
+- [ ] README examples lead with main-agent-authored async delegation and reserve blocking workflows for intentional synchronous cases.
+- [ ] Tests and required checks pass, or unavailable runtime smokes are recorded with reasons.
+- [ ] No release or publication action occurs without separate explicit approval.

--- a/docs/plans/2026-08-17_pi-subagents-main-agent-led-delegation-guidance-plan.md
+++ b/docs/plans/2026-08-17_pi-subagents-main-agent-led-delegation-guidance-plan.md
@@ -1,0 +1,44 @@
+# Pi Subagents Main-Agent-Led Delegation Guidance Plan
+
+## Goal
+
+Align `pi-subagents` documentation and prompt guidance with the current rule that the main agent decides task decomposition.
+
+Keep built-in roles minimal: `explorer` for read-only repository exploration and `worker` for implementation or command execution.
+
+## Context
+
+The extension no longer owns a planner subagent, reviewer subagent, worker aliases, or the `subagent_auto` workflow planner.
+
+Review guidance should point to the main agent, review skills, deterministic checks, or custom user/project agents instead of a built-in reviewer.
+
+Planning guidance should point to the main agent or explicit caller-authored `subagent.workflow` payloads instead of a built-in planner.
+
+`explorer` has no `bash` by default so it remains a true read-only built-in and preserves the automatic in-process route.
+
+## Non-Goals
+
+- Do not reintroduce built-in `planner`, `reviewer`, `general`, or `general-purpose` roles.
+- Do not add extension-owned objective-to-DAG planning.
+- Do not make project agents available without existing trust and confirmation behavior.
+- Do not change runtime behavior unless a task in this plan explicitly calls for prompt or README behavior changes.
+
+## Plan
+
+- [ ] Audit `packages/pi-subagents/README.md`, tool descriptions, prompt snippets, prompt guidelines, settings UI labels, and implementation notes for stale references to removed built-ins or extension-owned planning.
+- [ ] Rewrite the main delegation rubric around three choices: do it in the main agent, ask `explorer` to gather bounded evidence, or ask `worker` or a custom agent to execute a self-contained task.
+- [ ] Update review examples to prefer the main agent plus review skill for ordinary PR review, and custom verifier agents only when an explicit workflow or panel needs an independent child role.
+- [ ] Update planning examples to prefer main-agent-authored plans and explicit `subagent.workflow` graphs when a graph is genuinely needed.
+- [ ] Document that `explorer` omits `bash` intentionally, while users can create a custom read-mostly shell-capable agent if they accept write-capable transport classification.
+- [ ] Ensure `subagent_inspect` output and README catalog examples show only `explorer` and `worker` as built-ins.
+- [ ] Add focused tests only when prompt metadata or rendered output changes.
+- [ ] Run focused documentation/rendering tests, `npm run check`, and `git diff --check` if any package docs or prompt metadata changes.
+
+## Completion Checklist
+
+- [ ] No active documentation suggests that `planner`, `reviewer`, `general`, `general-purpose`, or `subagent_auto` are available built-ins.
+- [ ] Historical research documents are clearly marked when they mention removed roles or removed automation surfaces.
+- [ ] Current user guidance explains when to use `explorer`, `worker`, a custom agent, or no subagent.
+- [ ] Review and planning examples do not imply extension-owned planning or a built-in review role.
+- [ ] Prompt metadata, README examples, and inspect/catalog behavior agree.
+- [ ] Required checks pass or are explicitly recorded as not run for documentation-only work.

--- a/docs/roadmaps/2026-08-10_pi-subagents-full-automation-roadmap.md
+++ b/docs/roadmaps/2026-08-10_pi-subagents-full-automation-roadmap.md
@@ -1,6 +1,7 @@
 # Pi Subagents Full Automation Roadmap
 
-- **Status:** Superseded by the decision to remove `subagent_auto` and the built-in `planner`; retained as historical context for verified execution and deferred automation ideas.
+- **Status:** Superseded by the decision to remove `subagent_auto` and the built-in `planner`; retained as historical context only.
+- **Active work:** None; unchecked items below are not active tasks unless a new approved plan reopens them.
 - **Audience:** `@narumitw/pi-subagents` maintainers and contributors.
 - **Planning horizon:** Evidence-qualified phases without delivery dates.
 - **Baseline:** [`Pi Subagents Delegation Intelligence Roadmap`](2026-08-10_pi-subagents-delegation-intelligence-roadmap.md).
@@ -14,7 +15,7 @@ Current direction: keep topology selection with the main agent or caller-authore
 
 Keep Pi as the owner of model sessions, provider behavior, and tool execution.
 
-Keep `pi-subagents` as the owner of delegation planning, workflow state, authority, integration admission, verification acceptance, recovery bounds, and terminal completion.
+Keep `pi-subagents` as the owner of workflow state, authority, integration admission, verification acceptance, recovery bounds, and terminal completion for caller-authored workflows.
 
 ## Objectives
 
@@ -54,8 +55,8 @@ The original implementation plans were removed after their durable decisions and
 - **Smallest justified topology:** use parent-owned or one-child execution unless decomposition, isolation, parallelism, specialization, or independent verification provides a concrete benefit.
 - **No blind side-effect replay:** accepted, ambiguous, stale, interrupted, or potentially mutating work is never replayed merely because settlement was not observed.
 - **Patch the graph, not history:** replanning changes only pending, rework-requested, or invalidated nodes and preserves accepted artifacts and provenance.
-- **Compatibility by omission:** existing single, parallel, chain, panel, detached, and explicit workflow calls retain their behavior unless the new automation contract is selected.
-- **Evidence before defaults:** full automation remains explicit and bounded until matched evaluation supports a separate default-change decision.
+- **Compatibility by omission:** existing single, parallel, chain, panel, detached, and caller-authored workflow calls retain their behavior unless a future explicit contract is separately approved.
+- **Evidence before defaults:** automation remains absent unless matched evaluation supports a separate approved default-change decision.
 
 ## Roadmap
 
@@ -92,22 +93,22 @@ The original implementation plans were removed after their durable decisions and
 
 **Execution plan:** [`2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md`](../plans/2026-08-10_pi-subagents-event-driven-workflow-runtime-plan.md).
 
-### Phase 4: Qualify production use
+### Phase 4: Historical production-use gate
 
-- [ ] Repeated paired repository tasks compare full automation with a strong single agent, one child, equal-budget best-of-N, fixed two-child execution, and explicit workflow execution under matched information, model, tools, evaluator, aggregate budget, and wall-clock ceilings.
+- [ ] Repeated paired repository tasks compare any future automation proposal with a strong single agent, one child, equal-budget best-of-N, fixed two-child execution, and explicit workflow execution under matched information, model, tools, evaluator, aggregate budget, and wall-clock ceilings.
 - [ ] Results separately report verified success, false completion, unnecessary delegation, rework, conflicts, stale acceptance, duplicate side effects, tokens, cost, and critical-path duration by task class.
 - [ ] A recorded **Admit**, **Revise**, or **Defer** decision identifies eligible task classes and preserves explicit opt-in behavior when evidence is insufficient.
 - [ ] Any default change, recursion expansion, wider mutating team, publication, tag, or release remains a separate explicitly approved action.
 
-**Outcome:** Production behavior changes only when representative evidence shows where automation is safer or more effective than simpler alternatives.
+**Outcome:** Historical only; production behavior changes only through a new approved plan with representative evidence.
 
 ## Success Metrics
 
 | Indicator | Current baseline | Required invariant or decision |
 | --- | --- | --- |
-| Mutating workflow accepted from worker self-report alone | Rejected in explicit verified-execution mode | 0 in full-automation mode |
+| Mutating workflow accepted from worker self-report alone | Rejected in explicit verified-execution mode | 0 in any future automation mode |
 | Verifier-caused state drift accepted | Rejected by exact-tree before-and-after checks | 0 |
-| Executed but unaccepted work treated as terminal success | Rejected by versioned acceptance state in verified-execution mode | 0 in full-automation mode |
+| Executed but unaccepted work treated as terminal success | Rejected by versioned acceptance state in verified-execution mode | 0 in any future automation mode |
 | Accepted stale or old-generation verification receipts | Rejected end to end in verified-execution tests | 0 end to end |
 | Managed integration checks exercised by workflow execution | Wired for explicit verified execution | Every automated mutating acceptance |
 | Unrelated ready work blocked by a slow selected sibling | Possible under batch scheduling | 0 when safe capacity is available |
@@ -150,7 +151,7 @@ The original implementation plans were removed after their durable decisions and
 
 - **2026-08-10 — Prioritize verified completion over broader autonomy:** automatic planning must not precede an executor-owned independent acceptance boundary.
 - **2026-08-10 — Exclude observability expansion:** this roadmap changes execution behavior and correctness gates only, except for bounded evidence required by those gates.
-- **2026-08-10 — Keep full automation explicit:** no default routing change is proposed before matched representative evaluation.
+- **2026-08-10 — Remove full automation from the active surface:** no default routing change is proposed before matched representative evaluation and a separate approval.
 - **2026-08-10 — Preserve narrow concurrency:** the first automated architecture keeps at most two mutating children and no workflow grandchildren.
 - **Superseding decision — Remove explicit workflow planning:** `subagent_auto`, the built-in planner, deterministic objective-to-DAG compilation, and graph patches are removed; callers should use explicit `subagent.workflow` when they need a graph.
 - **2026-08-10 — Complete authoritative verified execution:** explicit verified workflows now require executor-owned exact-tree checks, managed integration acceptance, current independent receipts, and at most one bounded rework cycle without changing omitted workflow behavior.


### PR DESCRIPTION
## Summary
- Add async-first tool surface and main-agent-led delegation guidance plans.
- Mark old subagents automation and proactivity notes as historical where needed.
- Update current notes and roadmaps after removing planner, reviewer, scout, aliases, and subagent_auto.

## Verification
- `git diff --check`
- `npm run biome:check`
- `npm run check`

## Notes
- Documentation-only change.
- No Changeset because published package behavior is unchanged.