### PR TITLE
feat(subagents): allow concurrent shared-workspace writers

### DIFF
--- a/.changeset/allow-shared-subagent-writes.md
+++ b/.changeset/allow-shared-subagent-writes.md
@@ -1,0 +1,6 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Allow detached write-capable subagents to run concurrently in the shared workspace by default.
+Keep disposable worktree isolation available and accept `allowConcurrentWrites` as a deprecated compatibility field.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -228,7 +228,7 @@ The main agent owns `src/parser.ts`, immediately continues that work after spawn
 ```
 
 For two or more implementation workers, issue one spawn per disjoint slice, state each file or responsibility boundary, and keep integration in the main agent.
-Use isolated worktrees for repository-write isolation, or set `allowConcurrentWrites` only when shared-workspace overlap is knowingly safe.
+Shared-workspace agents may write concurrently by default; use isolated worktrees when repository-write isolation is required.
 
 A blocking fan-out is reserved for output that must be synthesized before the main agent continues:
 
@@ -665,7 +665,7 @@ This avoids lifecycle-driven tool-schema churn and preserves a stable provider p
 | Tool | Purpose |
 | --- | --- |
 | `subagent_spawn` | Start detached work with optional task-selected thinking and retained timeout, exact-retry `idempotencyKey`, and `text`, `structured-v1`, or `structured-v2` result format; return an opaque `agentId` immediately and deliver completion asynchronously. |
-| `subagent_send` | Send follow-up work with an optional one-turn timeout override and trigger a new turn on a reusable agent; semantic skew requires explicit `revalidate: true`, and shared-workspace write conflicts are guarded unless explicitly overridden. |
+| `subagent_send` | Send follow-up work with an optional one-turn timeout override and trigger a new turn on a reusable agent; semantic skew requires explicit `revalidate: true`, and shared-workspace concurrency is allowed by default. |
 | `subagent_manage` | Use `"interrupt"` to retain an agent after aborting active work or `"close"` to release it; both actions accept optional `subtree`. Use `subagent_inspect` for all list and detail operations. |
 | `subagent_mailbox` | Use `action: "send"` for queue-only messages that do not start a turn, or `"read"` to read and optionally acknowledge unread messages. |
 
@@ -773,11 +773,11 @@ No private Pi imports, runtime casts, or `ExtensionAPI` monkey-patching are used
 The package uses public Pi root RPC types but owns exact CLI resolution, bounded framing, readiness, stderr, cancellation, and process-group cleanup because the stock client does not provide those package-specific guarantees.
 Approval policy, sandbox profile, provider-header hooks, extension state, global scheduling, and parent/child transcript switching are not inherited or provided by in-process or RPC transport.
 
-Write-capable agents share the workspace by default.
-Concurrent write-capable starts in the same cwd are rejected unless `allowConcurrentWrites` is explicitly set.
-Classification is intentionally conservative: an agent with `bash`, `write`, or `edit` is write-capable even when its task prompt says “read only,” because prompt wording is not a filesystem sandbox.
-Keep one existing bounded detached worker only while the main agent continues its named non-overlapping work, or close it before handling the work directly.
-For truly independent disjoint write slices, use isolated worktrees, or set `allowConcurrentWrites` only when shared overlap is knowingly safe.
+Write-capable detached agents share the workspace and may run concurrently by default.
+Classification remains intentionally conservative for automatic transport selection: an agent with `bash`, `write`, or `edit` is write-capable even when its task prompt says “read only,” because prompt wording is not a filesystem sandbox.
+Assign disjoint file or responsibility ownership to concurrent writers and keep integration in the main agent.
+Use isolated worktrees when repository-write isolation is required.
+The deprecated `allowConcurrentWrites` field remains accepted for compatibility but no longer changes admission behavior.
 Use the blocking batch only when synchronous outputs justify making the main agent unavailable.
 
 Set `workspaceMode: "worktree"` to opt into a disposable detached Git worktree; this requires a clean repository and the worktree is removed on close or session shutdown. The generated path inherits the approved base cwd's trust snapshot. Retained records mark disposable worktrees explicitly, so they are never restored even if cleanup could not remove the generated directory. Shared-workspace retained records store an additive bounded target-trust snapshot for transport and inspection parity; session restore canonicalizes the retained cwd and re-resolves current/saved trust rather than blindly trusting the persisted value. Older records without either field remain readable.
@@ -786,6 +786,8 @@ Set `workspaceMode: "worktree"` to opt into a disposable detached Git worktree; 
 
 Existing accepted `subagent` payload shapes remain unchanged.
 `subagent_spawn` adds optional `idempotencyKey` and `resultFormat` fields without changing omitted behavior.
+`allowConcurrentWrites` remains accepted by `subagent_spawn` and `subagent_send` as a deprecated no-op so stored or resumed calls remain valid.
+Spawn request identity continues to include its submitted value for exact-retry compatibility.
 Older releases do not recognize `stateful.transport: "rpc"` or `"auto"`; change the value to `"subprocess"` and reload before downgrading.
 Retained records remain transport-neutral, and older readers ignore the additive idempotency and context-footprint fields while the state version remains compatible.
 The `tasks` schema now advertises the absolute 64-item safety bound, while the effective `blocking.maxParallelTasks` value may be lower.

--- a/packages/pi-subagents/src/stateful-guidance.ts
+++ b/packages/pi-subagents/src/stateful-guidance.ts
@@ -27,7 +27,7 @@ export function createSpawnPromptGuidelines(
 					"When subagent_spawn fits the completion-delivery policy, do not choose a blocking parallel subagent merely to keep delegation in the same turn.",
 				]
 			: []),
-		"Add another subagent_spawn only for truly independent work with safe workspace concurrency and disjoint write ownership; the main agent still owns integration.",
+		"Add another subagent_spawn only for truly independent work with safe workspace concurrency and disjoint write ownership; shared workspaces permit concurrent writes by default, so use workspaceMode worktree when repository isolation is required. The main agent still owns integration.",
 		"After subagent_spawn returns, immediately continue the identified local task; do not merely announce the spawn, wait, poll, or end the response while useful local work remains.",
 		'Consume and synthesize available subagent_spawn completion messages; use subagent_manage with action "interrupt" or "close" for agents that are no longer needed.',
 		'Completion from subagent_spawn is delivered automatically. Do not poll with subagent_inspect or subagent_mailbox action "read", repeatedly check progress, or duplicate the delegated work.',

--- a/packages/pi-subagents/src/stateful-safety.ts
+++ b/packages/pi-subagents/src/stateful-safety.ts
@@ -3,53 +3,8 @@ import * as path from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { discoverAgents } from "./agents/discovery.js";
 import type { AgentScope, SubagentSettings } from "./agents/types.js";
-import type { AgentRegistry, ManagedAgent } from "./registry.js";
 import { safeTerminalLine } from "./safe-text.js";
 import { readSubagentSettings } from "./settings.js";
-
-export function assertNoSharedWriteConflict(
-	registry: AgentRegistry,
-	agentName: string,
-	cwd: string,
-	scope: AgentScope,
-	settings?: SubagentSettings,
-): void {
-	const agents = discoverAgents(cwd, scope, settings ?? readSubagentSettings()).agents;
-	const requested = agents.find((agent) => agent.name === agentName);
-	if (!isWriteCapable(requested?.tools)) return;
-	for (const active of registry.list()) {
-		if (
-			!isSameCwd(active.cwd, cwd) ||
-			(active.state !== "running" && active.state !== "starting")
-		) {
-			continue;
-		}
-		const activeConfig = agents.find((agent) => agent.name === active.agent);
-		if (isWriteCapable(activeConfig?.tools)) {
-			throw new Error(
-				`Write-capable subagent ${active.id} is already active in shared workspace ${cwd}. ` +
-					"Keep the existing bounded subagent_spawn and continue the main agent's named non-overlapping work, or close it before handling the work directly. For truly independent disjoint write slices, use workspaceMode worktree; set allowConcurrentWrites only when shared overlap is knowingly safe. Use the blocking subagent parallel mode only when concurrent synchronous outputs justify making the main agent unavailable.",
-			);
-		}
-	}
-}
-
-export function assertFollowUpWriteAllowed(
-	registry: AgentRegistry,
-	agent: ManagedAgent,
-	allowConcurrentWrites: boolean,
-	isolatedWorkspace: boolean,
-	settings?: SubagentSettings,
-): void {
-	if (allowConcurrentWrites || isolatedWorkspace) return;
-	assertNoSharedWriteConflict(
-		registry,
-		agent.agent,
-		agent.cwd,
-		agent.agentScope ?? "user",
-		settings,
-	);
-}
 
 export function isWriteCapable(tools: string[] | undefined): boolean {
 	if (!tools) return true;

--- a/packages/pi-subagents/src/stateful.ts
+++ b/packages/pi-subagents/src/stateful.ts
@@ -47,18 +47,10 @@ import { createSpawnPromptGuidelines } from "./stateful-guidance.js";
 import { assertCurrentSpawn, waitForOwnedSpawn } from "./stateful-lifecycle.js";
 import { resolveStatefulLimits, type StatefulLimits } from "./stateful-limits.js";
 import { createStatefulToolRenderer } from "./stateful-render.js";
-import {
-	assertFollowUpWriteAllowed,
-	assertNoSharedWriteConflict,
-	confirmProjectAgent,
-} from "./stateful-safety.js";
+import { confirmProjectAgent } from "./stateful-safety.js";
 import { MAX_SUBAGENT_TOOL_CALLS, MAX_SUBAGENT_TURNS } from "./turn-budget.js";
 
-export {
-	assertFollowUpWriteAllowed,
-	assertNoSharedWriteConflict,
-	isWriteCapable,
-} from "./stateful-safety.js";
+export { isWriteCapable } from "./stateful-safety.js";
 
 import {
 	MailboxParamsSchema,
@@ -588,11 +580,14 @@ export function registerStatefulSubagents(
 			),
 			parentId: Type.Optional(Type.String({ description: "Optional parent agent ID." })),
 			allowConcurrentWrites: Type.Optional(
-				Type.Boolean({ description: "Override the shared-workspace write conflict guard." }),
+				Type.Boolean({
+					description:
+						"Deprecated compatibility field; shared-workspace concurrency is allowed by default.",
+				}),
 			),
 			workspaceMode: Type.Optional(
 				StringEnum(["shared", "worktree"] as const, {
-					description: "Use the shared workspace or an opt-in disposable Git worktree.",
+					description: "Use the shared workspace (default) or an opt-in disposable Git worktree.",
 				}),
 			),
 			contract: Type.Optional(DelegationContractSchema),
@@ -752,15 +747,6 @@ export function registerStatefulSubagents(
 					throw new Error("Project-local subagent definitions cannot run in a detached worktree");
 				}
 				const requestedCwd = cwd;
-				if ((params.workspaceMode ?? "shared") === "shared" && !params.allowConcurrentWrites) {
-					assertNoSharedWriteConflict(
-						ownedRegistry,
-						params.agent,
-						requestedCwd,
-						scope,
-						currentSettings,
-					);
-				}
 				const workspaceOwner = `pending-${randomUUID()}`;
 				const workspace =
 					params.workspaceMode === "worktree"
@@ -871,7 +857,10 @@ export function registerStatefulSubagents(
 				}),
 			),
 			allowConcurrentWrites: Type.Optional(
-				Type.Boolean({ description: "Override the shared-workspace write conflict guard." }),
+				Type.Boolean({
+					description:
+						"Deprecated compatibility field; shared-workspace concurrency is allowed by default.",
+				}),
 			),
 		}),
 		...createStatefulToolRenderer("send"),
@@ -959,13 +948,6 @@ export function registerStatefulSubagents(
 				currentSettings,
 			);
 			assertCurrentSpawn(signal, generation, runtimeGeneration);
-			assertFollowUpWriteAllowed(
-				ownedRegistry,
-				existing,
-				params.allowConcurrentWrites ?? false,
-				isolatedAgents.has(existing.id),
-				currentSettings,
-			);
 			const currentGrant = modules.capabilityGrant.issueCapabilityGrant(
 				currentPlan,
 				Date.now(),

--- a/packages/pi-subagents/test/in-process-transport.test.ts
+++ b/packages/pi-subagents/test/in-process-transport.test.ts
@@ -654,6 +654,66 @@ test("in-process resource loading rejects a non-regular system prompt source", a
 	}
 });
 
+test("registered detached workers share a workspace without a write override", async () => {
+	const originalDir = process.env.PI_CODING_AGENT_DIR;
+	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-shared-workers-"));
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		const children: FakeChildSession[] = [];
+		const mock = createMockPi();
+		const controller = registerStatefulSubagents(mock.pi, {
+			settings: { transport: "in-process" },
+			createInProcessSession: async () => {
+				const child = new FakeChildSession(true);
+				children.push(child);
+				return child;
+			},
+		});
+		const context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		const execute = async (name: string, params: Record<string, unknown>) => {
+			const tool = mock.tools.find((candidate) => candidate.name === name) as {
+				execute: (...args: unknown[]) => Promise<unknown>;
+			};
+			return tool.execute(
+				`call-${name}`,
+				params,
+				new AbortController().signal,
+				undefined,
+				context.ctx,
+			) as Promise<{ details: { agent: { id: string; state: string } } }>;
+		};
+
+		const first = await execute("subagent_spawn", { agent: "worker", task: "first" });
+		const [second, third] = await Promise.all([
+			execute("subagent_spawn", { agent: "worker", task: "second" }),
+			execute("subagent_spawn", { agent: "worker", task: "third" }),
+		]);
+		assert.equal(new Set([first, second, third].map((entry) => entry.details.agent.id)).size, 3);
+		assert.equal(controller.getRuntimeStatus().activeAgents, 3);
+
+		await execute("subagent_manage", {
+			action: "interrupt",
+			agentId: first.details.agent.id,
+		});
+		const followedUp = await execute("subagent_send", {
+			agentId: first.details.agent.id,
+			task: "continue while second is active",
+			allowConcurrentWrites: false,
+		});
+		assert.match(followedUp.details.agent.state, /starting|running/);
+		assert.equal(controller.getRuntimeStatus().activeAgents, 3);
+
+		assert.equal(children.length, 3);
+		assert.equal(await controller.clearAgents(), 3);
+		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+	} finally {
+		if (originalDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalDir;
+		rmSync(agentDir, { recursive: true, force: true });
+	}
+});
+
 test("registered detached spawn auto-resumes without exposing a wait tool", async () => {
 	const originalDir = process.env.PI_CODING_AGENT_DIR;
 	const agentDir = mkdtempSync(path.join(os.tmpdir(), "pi-subagent-sdk-tools-"));

--- a/packages/pi-subagents/test/stateful-tool-registration.test.ts
+++ b/packages/pi-subagents/test/stateful-tool-registration.test.ts
@@ -86,7 +86,19 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		assert.match(spawn.parameters.properties?.idleTimeoutMs?.description ?? "", /completed/i);
 		assert.match(spawn.parameters.properties?.maxTurns?.description ?? "", /assistant turns/i);
 		assert.match(spawn.parameters.properties?.maxToolCalls?.description ?? "", /tool calls/i);
+		assert.match(
+			spawn.parameters.properties?.allowConcurrentWrites?.description ?? "",
+			/deprecated compatibility field.*allowed by default/i,
+		);
+		assert.match(
+			spawn.parameters.properties?.workspaceMode?.description ?? "",
+			/shared workspace \(default\).*worktree/i,
+		);
 		assert.match(spawn.promptGuidelines.join("\n"), /timeoutMs.*task difficulty/i);
+		assert.match(
+			spawn.promptGuidelines.join("\n"),
+			/shared workspaces permit concurrent writes by default.*workspaceMode worktree/i,
+		);
 
 		const send = mock.tools.find((tool) => tool.name === "subagent_send") as {
 			description: string;
@@ -103,6 +115,10 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		assert.match(
 			send.parameters.properties?.revalidate?.description ?? "",
 			/semantic resource snapshot/i,
+		);
+		assert.match(
+			send.parameters.properties?.allowConcurrentWrites?.description ?? "",
+			/deprecated compatibility field.*allowed by default/i,
 		);
 		const manage = mock.tools.find((tool) => tool.name === "subagent_manage") as {
 			description: string;

--- a/packages/pi-subagents/test/stateful-utilities-and-settings.test.ts
+++ b/packages/pi-subagents/test/stateful-utilities-and-settings.test.ts
@@ -1,9 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { AgentRegistry } from "../src/registry.js";
 import { normalizeSubagentSettings } from "../src/settings.js";
 import {
-	assertFollowUpWriteAllowed,
 	formatStatefulAgentLine,
 	isWriteCapable,
 	resolveCompletionDelivery,
@@ -15,36 +13,11 @@ import { waitForOwnedSpawn } from "../src/stateful-lifecycle.js";
 import { resolveStatefulSubprocessThinkingLevel } from "../src/subprocess-transport.js";
 import { record } from "./orchestration-test-helpers.js";
 
-test("shared-workspace write classification and follow-up guards are conservative", async () => {
+test("write classification remains conservative for automatic transport selection", () => {
 	assert.equal(isWriteCapable(undefined), true);
 	assert.equal(isWriteCapable(["read", "grep"]), false);
 	assert.equal(isWriteCapable(["read", "bash"]), true);
 	assert.equal(isWriteCapable(["edit"]), true);
-	const registry = new AgentRegistry(async (_agent, _task, signal) => {
-		await new Promise<void>((resolve) =>
-			signal.addEventListener("abort", () => resolve(), { once: true }),
-		);
-		return { output: "interrupted", exitCode: 130, aborted: true };
-	});
-	const active = await registry.spawn({ agent: "worker", task: "active", cwd: process.cwd() });
-	const followUp = record({ agent: "worker", cwd: process.cwd(), state: "completed" });
-	assert.throws(
-		() => assertFollowUpWriteAllowed(registry, followUp, false, false),
-		(error: unknown) => {
-			assert.match(String(error), /already active in shared workspace/);
-			assert.match(String(error), /keep the existing bounded subagent_spawn/i);
-			assert.match(String(error), /continue.*main agent.*non-overlapping work/i);
-			assert.match(String(error), /close it before.*directly/i);
-			assert.match(String(error), /blocking subagent parallel mode.*synchronous outputs/i);
-			assert.doesNotMatch(String(error), /combined asynchronous work/i);
-			assert.match(String(error), /disjoint write slices.*worktree/i);
-			assert.match(String(error), /allowConcurrentWrites/);
-			return true;
-		},
-	);
-	assert.doesNotThrow(() => assertFollowUpWriteAllowed(registry, followUp, true, false));
-	assert.doesNotThrow(() => assertFollowUpWriteAllowed(registry, followUp, false, true));
-	await registry.interrupt(active.id);
 });
 
 test("stateful agent lines escape terminal controls from retained agent data", () => {


### PR DESCRIPTION
## Summary

- Allow detached write-capable subagents to run concurrently in the shared workspace by default.
- Keep disposable worktree isolation available through `workspaceMode: "worktree"`.
- Retain `allowConcurrentWrites` as a deprecated compatibility no-op and cover three concurrent workers plus follow-up reuse.
- Add a minor Changeset for `@narumitw/pi-subagents`.

## Verification

- `npm run check`
- `npm run check --workspace @narumitw/pi-subagents`
- `npx vitest run packages/pi-subagents/test/in-process-transport.test.ts packages/pi-subagents/test/stateful-utilities-and-settings.test.ts packages/pi-subagents/test/stateful-tool-registration.test.ts`
- `just pack subagents`
- `git diff --check`

## Semantic audit

- Cancellation, disposal, session replacement, shutdown, settings, and worktree cleanup behavior are unchanged.
- Shared writers can conflict by design, so the prompt and README require disjoint ownership and main-agent integration.
- No interactive Pi runtime smoke was run; the edited extension requires `/reload` in an existing session.
