### PR TITLE
feat(subagents): add collapsible completion messages

### DIFF
--- a/.changeset/collapsible-subagent-completions.md
+++ b/.changeset/collapsible-subagent-completions.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Render detached completion messages as compact TUI summaries that expand to their full safe payload with Pi's tool-output toggle.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -567,6 +567,7 @@ Legacy v1 and v2 records without acceptance fields retain their prior completed 
 ## 🔁 Stateful agents
 
 Stateful lifecycle tools are available by default. `subagent_spawn` is detached: it schedules work, returns immediately with an opaque `agentId`, and later injects a bounded `pi-subagent-completion` custom message. Every turn receives an executor-owned `runId`, monotonically increasing agent-local generation, and unique `completionId`. The terminal completion is persisted before delivery, simultaneous completions are batched, and the broker allows at most one in-flight root wake until that parent turn starts.
+In TUI mode, completion messages show a compact task and payload summary while collapsed; use the configured tool-output expansion action (`Ctrl+O` by default) to show or hide the complete message globally.
 
 Detached work follows a non-polling policy.
 Before one ordinary `subagent_spawn`, identify useful non-overlapping main-agent work that starts immediately and a supported completion integration path.

--- a/packages/pi-subagents/src/completion-delivery.ts
+++ b/packages/pi-subagents/src/completion-delivery.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { CompletionDelivery } from "./agents/types.js";
+import { SUBAGENT_COMPLETION_MESSAGE_TYPE } from "./completion-render.js";
 import { redactPrivateText } from "./context.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, MAX_TOOL_MESSAGE_BYTES, truncateUtf8 } from "./limits.js";
 import type { AgentTurnCompletion, ManagedAgent } from "./registry.js";
@@ -17,6 +18,7 @@ interface CompletionMetadata {
 	generation: number;
 	agentId: string;
 	agent: string;
+	task: string;
 	state: string;
 	transport?: string;
 	structuredResult?: ManagedAgent["structuredResult"];
@@ -25,7 +27,7 @@ interface CompletionMetadata {
 }
 
 interface CompletionMessage {
-	customType: "pi-subagent-completion";
+	customType: typeof SUBAGENT_COMPLETION_MESSAGE_TYPE;
 	content: string;
 	display: true;
 	details:
@@ -202,7 +204,8 @@ function completionIdsFromContext(messages: readonly unknown[]): Set<string> {
 	for (const message of messages) {
 		if (!message || typeof message !== "object" || Array.isArray(message)) continue;
 		const record = message as Record<string, unknown>;
-		if (record.role !== "custom" || record.customType !== "pi-subagent-completion") continue;
+		if (record.role !== "custom" || record.customType !== SUBAGENT_COMPLETION_MESSAGE_TYPE)
+			continue;
 		const details = record.details;
 		if (!details || typeof details !== "object" || Array.isArray(details)) continue;
 		const metadata = details as Record<string, unknown>;
@@ -236,7 +239,7 @@ function buildCompletionMessage(completions: AgentTurnCompletion[]): CompletionM
 	if (completions.length === 1) {
 		const completion = completions[0];
 		return {
-			customType: "pi-subagent-completion",
+			customType: SUBAGENT_COMPLETION_MESSAGE_TYPE,
 			content: buildDetachedCompletionMessage(completion),
 			display: true,
 			details: completionMetadata(completion),
@@ -256,7 +259,7 @@ function buildCompletionMessage(completions: AgentTurnCompletion[]): CompletionM
 		DEFAULT_MAX_CONTEXT_BYTES,
 	).text;
 	return {
-		customType: "pi-subagent-completion",
+		customType: SUBAGENT_COMPLETION_MESSAGE_TYPE,
 		content,
 		display: true,
 		details: {
@@ -274,6 +277,7 @@ function completionMetadata(completion: AgentTurnCompletion): CompletionMetadata
 		generation: completion.generation,
 		agentId: completion.agent.id,
 		agent: completion.agent.agent,
+		task: sanitizeCompletionLine(completion.task, 256) || "(unknown task)",
 		state: completion.agent.state,
 		...(completion.agent.telemetry?.transport
 			? { transport: completion.agent.telemetry.transport }

--- a/packages/pi-subagents/src/completion-render.ts
+++ b/packages/pi-subagents/src/completion-render.ts
@@ -171,8 +171,19 @@ function hardWrapExact(value: string, width: number): string[] {
 	const columns = visibleWidth(value);
 	if (columns === 0) return [value];
 	const lines: string[] = [];
-	for (let column = 0; column < columns; column += width) {
-		lines.push(sliceByColumn(value, column, width, true));
+	let column = 0;
+	while (column < columns) {
+		const chunk = sliceByColumn(value, column, width, true);
+		const chunkWidth = visibleWidth(chunk);
+		if (chunkWidth > 0) {
+			lines.push(chunk);
+			column += chunkWidth;
+			continue;
+		}
+		const oversized = sliceByColumn(value, column, width, false);
+		const oversizedWidth = visibleWidth(oversized);
+		lines.push("?".repeat(width));
+		column += Math.max(1, oversizedWidth);
 	}
 	return lines;
 }

--- a/packages/pi-subagents/src/completion-render.ts
+++ b/packages/pi-subagents/src/completion-render.ts
@@ -1,0 +1,178 @@
+import type { MessageRenderer, Theme } from "@earendil-works/pi-coding-agent";
+import { Box, type Component, Spacer, sliceByColumn, visibleWidth } from "@earendil-works/pi-tui";
+import { MAX_TOOL_MESSAGE_BYTES } from "./limits.js";
+import {
+	COLLAPSED_LIST_LIMIT,
+	expansionHint,
+	type RenderStatus,
+	recordList,
+	recordValue,
+	safeBlock,
+	safeLine,
+	statusBadge,
+} from "./render-common.js";
+
+export const SUBAGENT_COMPLETION_MESSAGE_TYPE = "pi-subagent-completion";
+
+export const renderCompletionMessage: MessageRenderer = (message, options, theme) => {
+	const box = new Box(options.outputPad, 1, (text) => theme.bg("customMessageBg", text));
+	if (options.expanded) {
+		box.addChild(
+			new ExactText(
+				theme.fg("customMessageLabel", theme.bold(`[${SUBAGENT_COMPLETION_MESSAGE_TYPE}]`)),
+			),
+		);
+		box.addChild(new Spacer(1));
+		box.addChild(
+			new ExactText(
+				safeBlock(messageText(message.content), "(no completion content)", MAX_TOOL_MESSAGE_BYTES),
+				(text) => theme.fg("customMessageText", text),
+			),
+		);
+		return box;
+	}
+
+	box.addChild(new ExactText(collapsedCompletion(message.content, message.details, theme)));
+	return box;
+};
+
+function collapsedCompletion(contentValue: unknown, detailsValue: unknown, theme: Theme): string {
+	const content = safeBlock(messageText(contentValue), "", MAX_TOOL_MESSAGE_BYTES);
+	const details = recordValue(detailsValue) ?? {};
+	const completions = recordList(details.completions);
+	if (completions.length > 0 || details.completionCount !== undefined) {
+		return collapsedBatch(details, completions, theme);
+	}
+	return collapsedSingle(content, details, theme);
+}
+
+function collapsedSingle(content: string, details: Record<string, unknown>, theme: Theme): string {
+	const agent = optionalLine(details.agent) || extractedField(content, "Agent") || "subagent";
+	const state = optionalLine(details.state) || extractedField(content, "State") || "completed";
+	const task = optionalLine(details.task) || extractedField(content, "Task");
+	const payload = payloadPreview(content);
+	const lines = [
+		`${statusBadge(theme, renderStatus(state))}${theme.fg("muted", " · ")}${theme.fg("customMessageLabel", theme.bold(agent))}`,
+	];
+	if (task) lines.push(`${theme.fg("muted", "Task: ")}${theme.fg("customMessageText", task)}`);
+	if (payload) {
+		lines.push(`${theme.fg("muted", "Payload: ")}${theme.fg("customMessageText", payload)}`);
+	}
+	lines.push(expansionHint());
+	return lines.join("\n");
+}
+
+function collapsedBatch(
+	details: Record<string, unknown>,
+	completions: Record<string, unknown>[],
+	theme: Theme,
+): string {
+	const declaredCount =
+		typeof details.completionCount === "number" && Number.isFinite(details.completionCount)
+			? Math.max(0, Math.floor(details.completionCount))
+			: completions.length;
+	const count = Math.max(declaredCount, completions.length);
+	const statuses = completions.map((completion) => renderStatus(optionalLine(completion.state)));
+	const icon = statuses.includes("failed")
+		? theme.fg("error", "✗")
+		: statuses.some((status) => status !== "completed" && status !== "closed")
+			? theme.fg("warning", "◐")
+			: theme.fg("success", "✓");
+	const lines = [
+		`${icon} ${theme.fg("customMessageLabel", theme.bold(`${count} subagent completions`))}`,
+	];
+	for (const completion of completions.slice(0, COLLAPSED_LIST_LIMIT)) {
+		const agent = optionalLine(completion.agent) || "subagent";
+		const state = optionalLine(completion.state) || "completed";
+		const task = optionalLine(completion.task);
+		lines.push(
+			`${theme.fg("muted", "• ")}${theme.fg("accent", agent)} · ${statusBadge(theme, renderStatus(state))}${task ? theme.fg("dim", ` — ${task}`) : ""}`,
+		);
+	}
+	const visibleCount = Math.min(completions.length, COLLAPSED_LIST_LIMIT);
+	if (count > visibleCount) {
+		lines.push(theme.fg("muted", `… ${count - visibleCount} more`));
+	}
+	lines.push(expansionHint());
+	return lines.join("\n");
+}
+
+function messageText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (!Array.isArray(value)) return "";
+	return value
+		.flatMap((part) => {
+			const record = recordValue(part);
+			return record?.type === "text" && typeof record.text === "string" ? [record.text] : [];
+		})
+		.join("\n");
+}
+
+function extractedField(content: string, label: string): string {
+	const prefix = `${label}:`;
+	const line = content.split("\n").find((candidate) => candidate.startsWith(prefix));
+	return line ? safeLine(line.slice(prefix.length), "", 512) : "";
+}
+
+function payloadPreview(content: string): string {
+	const marker = "\nPayload:\n";
+	const start = content.indexOf(marker);
+	if (start < 0) return "";
+	for (const line of content.slice(start + marker.length).split("\n")) {
+		const preview = safeLine(line, "", 1024);
+		if (preview) return preview;
+	}
+	return "";
+}
+
+function optionalLine(value: unknown): string {
+	return typeof value === "string" ? safeLine(value, "", 512) : "";
+}
+
+function renderStatus(state: string): RenderStatus {
+	switch (state) {
+		case "failed":
+			return "failed";
+		case "cancelled":
+			return "cancelled";
+		case "interrupted":
+			return "interrupted";
+		case "closed":
+			return "closed";
+		case "blocked":
+		case "needs-input":
+		case "abstained":
+		case "stale":
+			return "warning";
+		default:
+			return "completed";
+	}
+}
+
+class ExactText implements Component {
+	constructor(
+		private readonly value: string,
+		private readonly style: (text: string) => string = (text) => text,
+	) {}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		return this.value
+			.split("\n")
+			.flatMap((line) => hardWrapExact(line, safeWidth))
+			.map(this.style);
+	}
+
+	invalidate(): void {}
+}
+
+function hardWrapExact(value: string, width: number): string[] {
+	if (value.length === 0) return [""];
+	const columns = visibleWidth(value);
+	if (columns === 0) return [value];
+	const lines: string[] = [];
+	for (let column = 0; column < columns; column += width) {
+		lines.push(sliceByColumn(value, column, width, true));
+	}
+	return lines;
+}

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -22,6 +22,7 @@ import type {
 	SubagentSettings,
 } from "./agents/types.js";
 import { cachedModuleLoader, throwIfAborted } from "./cached-module-loader.js";
+import { renderCompletionMessage, SUBAGENT_COMPLETION_MESSAGE_TYPE } from "./completion-render.js";
 import {
 	type ConfigRegistrationDependencies,
 	registerSubagentConfigCommand,
@@ -62,6 +63,7 @@ export interface SubagentsDependencies {
 }
 
 export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies = {}) {
+	pi.registerMessageRenderer(SUBAGENT_COMPLETION_MESSAGE_TYPE, renderCompletionMessage);
 	const loadBlockingExecution = cachedModuleLoader(
 		dependencies.loadBlockingExecution ?? (() => import("./execution.js")),
 	);

--- a/packages/pi-subagents/test/completion-delivery.test.ts
+++ b/packages/pi-subagents/test/completion-delivery.test.ts
@@ -112,6 +112,7 @@ test("next-turn completion delivery never wakes an idle root", () => {
 		generation: 1,
 		agentId: "sa_one",
 		agent: "explorer",
+		task: "task:sa_one",
 		state: "completed",
 	});
 	broker.close();
@@ -139,6 +140,7 @@ test("auto-resume batches simultaneous completions into one root synthesis turn"
 				generation: 1,
 				agentId: "sa_one",
 				agent: "explorer",
+				task: "task:sa_one",
 				state: "completed",
 			},
 			{
@@ -148,6 +150,7 @@ test("auto-resume batches simultaneous completions into one root synthesis turn"
 				generation: 1,
 				agentId: "sa_two",
 				agent: "explorer",
+				task: "task:sa_two",
 				state: "completed",
 			},
 		],

--- a/packages/pi-subagents/test/completion-rendering.test.ts
+++ b/packages/pi-subagents/test/completion-rendering.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { afterAll, test } from "vitest";
+import { createMockPi } from "../../../test/support.js";
+import subagents from "../src/subagents.js";
+import { installSubagentsTestEnvironment } from "./subagents-test-helpers.js";
+
+initTheme("dark", false);
+
+const restoreTestEnvironment = installSubagentsTestEnvironment();
+afterAll(restoreTestEnvironment);
+
+const identityTheme = {
+	fg: (_color: string, text: string) => text,
+	bg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+};
+
+type CompletionRenderer = (
+	message: { customType: string; content: string; details?: unknown },
+	options: { expanded: boolean; outputPad: number },
+	theme: typeof identityTheme,
+) => { render(width: number): string[] };
+
+function registeredRenderer(): CompletionRenderer {
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const renderer = mock.messageRenderers.get("pi-subagent-completion");
+	assert.ok(renderer, "pi-subagent-completion must register a TUI renderer");
+	return renderer as CompletionRenderer;
+}
+
+function render(
+	renderer: CompletionRenderer,
+	message: Parameters<CompletionRenderer>[0],
+	expanded: boolean,
+	width = 40,
+): string[] {
+	return renderer(message, { expanded, outputPad: 1 }, identityTheme).render(width);
+}
+
+test("completion messages collapse to a useful summary and expand to the full safe payload", () => {
+	const renderer = registeredRenderer();
+	const message = {
+		customType: "pi-subagent-completion",
+		content: [
+			"Message Type: SUBAGENT_COMPLETION",
+			"Protocol: pi-subagents:v1",
+			"Completion ID: completion:sa_worker:1",
+			"Agent: worker",
+			"Task: Fix the parser",
+			"State: completed",
+			"Payload:",
+			"first\u001b[31m payload line",
+			"second payload line",
+		].join("\n"),
+		details: {
+			protocol: "pi-subagents:v1",
+			completionId: "completion:sa_worker:1",
+			runId: "run:sa_worker:1",
+			generation: 1,
+			agentId: "sa_worker",
+			agent: "worker",
+			state: "completed",
+		},
+	};
+
+	const collapsedLines = render(renderer, message, false, 36);
+	const collapsedRaw = collapsedLines.join("\n");
+	const collapsed = stripTerminalSequences(collapsedRaw);
+	assert.match(collapsed, /Completed.*worker/is);
+	assert.match(collapsed, /Task: Fix the parser/i);
+	assert.match(collapsed, /Payload: first\?\[31m payload line/i);
+	assert.doesNotMatch(collapsed, /Completion ID|second payload line/i);
+	assert.match(collapsed, /expand/i);
+	assert.equal(collapsedRaw.includes("\u001b[31m"), false);
+	assert.ok(collapsedLines.every((line) => visibleWidth(line) <= 36));
+
+	const expandedLines = render(renderer, message, true, 80);
+	const expandedRaw = expandedLines.join("\n");
+	const expanded = stripTerminalSequences(expandedRaw);
+	assert.match(expanded, /Completion ID: completion:sa_worker:1/);
+	assert.match(expanded, /second payload line/);
+	assert.equal(expandedRaw.includes("\u001b[31m"), false);
+	assert.ok(expandedLines.every((line) => visibleWidth(line) <= 80));
+});
+
+test("completion batches collapse to bounded agent rows and expand to the full message", () => {
+	const renderer = registeredRenderer();
+	const completions = Array.from({ length: 7 }, (_, index) => ({
+		protocol: "pi-subagents:v1",
+		completionId: `completion:sa_${index}:1`,
+		runId: `run:sa_${index}:1`,
+		generation: 1,
+		agentId: `sa_${index}`,
+		agent: `worker-${index}`,
+		task: `task-${index}`,
+		state: index === 1 ? "failed" : "completed",
+	}));
+	const message = {
+		customType: "pi-subagent-completion",
+		content: "Message Type: SUBAGENT_COMPLETION_BATCH\nFULL_BATCH_BODY_SHOULD_HIDE",
+		details: { completionCount: completions.length, completions },
+	};
+
+	const collapsedLines = render(renderer, message, false, 42);
+	const collapsed = collapsedLines.join("\n");
+	assert.match(collapsed, /7 subagent completions/i);
+	assert.match(collapsed, /worker-0.*Completed.*task-0/is);
+	assert.match(collapsed, /worker-1.*Failed.*task-1/is);
+	assert.match(collapsed, /2 more/i);
+	assert.doesNotMatch(collapsed, /worker-5|FULL_BATCH_BODY_SHOULD_HIDE/i);
+	assert.ok(collapsedLines.every((line) => visibleWidth(line) <= 42));
+
+	const expanded = render(renderer, message, true, 42).join("\n");
+	assert.match(expanded, /FULL_BATCH_BODY_SHOULD_HIDE/);
+});

--- a/packages/pi-subagents/test/completion-rendering.test.ts
+++ b/packages/pi-subagents/test/completion-rendering.test.ts
@@ -86,6 +86,24 @@ test("completion messages collapse to a useful summary and expand to the full sa
 	assert.ok(expandedLines.every((line) => visibleWidth(line) <= 80));
 });
 
+test("expanded completion messages preserve wide graphemes at wrap boundaries", () => {
+	const renderer = registeredRenderer();
+	const lines = render(
+		renderer,
+		{
+			customType: "pi-subagent-completion",
+			content: "ab😀z\nab\tz",
+		},
+		true,
+		5,
+	);
+	const text = stripTerminalSequences(lines.join("\n"));
+	assert.match(text, /😀/u);
+	assert.match(text, /z/u);
+	assert.equal(text.includes("\t"), true);
+	assert.ok(lines.every((line) => visibleWidth(line) <= 5));
+});
+
 test("completion batches collapse to bounded agent rows and expand to the full message", () => {
 	const renderer = registeredRenderer();
 	const completions = Array.from({ length: 7 }, (_, index) => ({


### PR DESCRIPTION
## Summary

- Register a `pi-subagent-completion` TUI renderer with compact single-completion and bounded batch summaries.
- Use Pi's global tool-output toggle (`Ctrl+O` by default) to reveal or hide the complete completion payload.
- Sanitize terminal input before layout, preserve exact whitespace with cell-aware hard wrapping, and keep older completion metadata readable.
- Document the interaction and add a minor Changeset for `@narumitw/pi-subagents`.

## Verification

- `npx vitest run packages/pi-subagents/test/completion-rendering.test.ts packages/pi-subagents/test/completion-delivery.test.ts packages/pi-subagents/test/subagents-registration.test.ts` — 19 tests passed.
- `npm run check --workspace @narumitw/pi-subagents`
- `npm run check` — 345 test files and 3,431 tests passed.
- `just pack subagents` — 121 packaged files inspected.
- `npm run changeset:status` — succeeded with existing repository-wide Pi TUI Kit range warnings.
- `git diff --check`

## Semantic audit

- The renderer is stateless and owns no asynchronous work, lifecycle resource, setting, or cancellation path.
- Collapsed success and failure states retain text labels rather than relying on color alone.
- Single, batch, legacy-metadata fallback, expansion, terminal-control, and narrow-width behavior are covered deterministically.
- No interactive Pi runtime smoke was run; an existing Pi session requires `/reload` to load the renderer.
