### PR TITLE
fix(btw): make fullscreen transcript and selector scrollable

### DIFF
--- a/.changeset/fix-btw-fullscreen-scroll.md
+++ b/.changeset/fix-btw-fullscreen-scroll.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": patch
+---
+
+Fix unscrollable fullscreen views: render the full transcript and text selector into the alt-screen scroll view so wheel, PgUp/PgDn, Home/End, and Ctrl+Shift+F search work instead of being consumed as no-op viewport scrolls.

--- a/packages/pi-btw/src/bring-to-main.ts
+++ b/packages/pi-btw/src/bring-to-main.ts
@@ -9,7 +9,8 @@ import {
 } from "@earendil-works/pi-tui";
 import type { SideThreadTurn } from "./side-thread.js";
 
-const RESERVED_APP_ROWS = 3;
+// Title + status lines rendered above the transcript rows.
+const SELECTOR_CHROME_LINES = 2;
 const GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 export interface BtwBringToMainSegment {
@@ -38,7 +39,6 @@ export interface BtwTextRangeSelectorState {
 	anchor?: BtwTextPosition;
 	lineAnchor?: number;
 	preferredColumn: number;
-	scrollOffset: number;
 	horizontalOffset: number;
 }
 
@@ -176,7 +176,6 @@ export class BtwTextRangeSelector implements Component {
 	private anchor: BtwTextPosition | undefined;
 	private lineAnchor: number | undefined;
 	private preferredColumn = 0;
-	private scrollOffset = 0;
 	private horizontalOffset = 0;
 	private warning: string | undefined;
 	private finished = false;
@@ -200,9 +199,10 @@ export class BtwTextRangeSelector implements Component {
 					? undefined
 					: Math.max(0, Math.min(this.lines.length - 1, initialState.lineAnchor));
 			this.preferredColumn = Math.max(0, initialState.preferredColumn);
-			this.scrollOffset = Math.max(0, initialState.scrollOffset);
 			this.horizontalOffset = Math.max(0, initialState.horizontalOffset);
 		}
+		// The fullscreen scroll view may be left at the bottom by the previous view.
+		queueMicrotask(() => this.keepCursorVisible());
 	}
 
 	getState(): BtwTextRangeSelectorState {
@@ -211,28 +211,17 @@ export class BtwTextRangeSelector implements Component {
 			anchor: this.anchor ? { ...this.anchor } : undefined,
 			lineAnchor: this.lineAnchor,
 			preferredColumn: this.preferredColumn,
-			scrollOffset: this.scrollOffset,
 			horizontalOffset: this.horizontalOffset,
 		};
 	}
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const availableRows = Math.max(1, this.tui.terminal.rows - RESERVED_APP_ROWS);
-		const showStatus = availableRows >= 4;
-		const showFooter = availableRows >= 3;
-		const viewportHeight = Math.max(
-			1,
-			availableRows - 1 - (showStatus ? 1 : 0) - (showFooter ? 1 : 0),
-		);
-		this.keepCursorVisible(viewportHeight);
 		const textWidth = Math.max(1, safeWidth - visibleWidth("●> Assistant │ "));
 		this.keepCursorHorizontallyVisible(textWidth);
 		const range = this.getSelectionRange();
 		const lineRange = this.getLineSelectionRange();
-		const visible = this.lines.slice(this.scrollOffset, this.scrollOffset + viewportHeight);
-		const rows = visible.map((line, visibleIndex) => {
-			const lineIndex = this.scrollOffset + visibleIndex;
+		const rows = this.lines.map((line, lineIndex) => {
 			const role = line.role === "user" ? "User" : "Assistant";
 			const lineSelected = lineRange
 				? lineIndex >= lineRange.start && lineIndex <= lineRange.end
@@ -262,27 +251,16 @@ export class BtwTextRangeSelector implements Component {
 				: `Shift+Arrows select • Arrows move${confirmUsesSpace ? "" : " • Space lines"} • ${confirm} bring • ${back} back • Ctrl+C close`;
 		const criticalFooter = `${confirm} bring • ${back} back • Ctrl+C close`;
 		const footer = visibleWidth(detailedFooter) <= safeWidth ? detailedFooter : criticalFooter;
-		return fitRows(
-			[
-				truncateToWidth(
-					this.theme.fg("accent", this.theme.bold("Select text to bring to main")),
-					safeWidth,
-					"",
-				),
-				...(showStatus ? [truncateToWidth(this.theme.fg("muted", status), safeWidth, "")] : []),
-				...rows,
-				...(showFooter
-					? [
-							truncateToWidth(
-								this.theme.fg(this.warning ? "warning" : "muted", footer),
-								safeWidth,
-								"",
-							),
-						]
-					: []),
-			],
-			availableRows,
-		);
+		return [
+			truncateToWidth(
+				this.theme.fg("accent", this.theme.bold("Select text to bring to main")),
+				safeWidth,
+				"",
+			),
+			truncateToWidth(this.theme.fg("muted", status), safeWidth, ""),
+			...rows,
+			truncateToWidth(this.theme.fg(this.warning ? "warning" : "muted", footer), safeWidth, ""),
+		];
 	}
 
 	handleInput(data: string): void {
@@ -343,14 +321,6 @@ export class BtwTextRangeSelector implements Component {
 		}
 		if (this.keybindings.matches(data, "tui.select.down")) {
 			this.moveVertical(1, false);
-			return;
-		}
-		if (this.keybindings.matches(data, "tui.select.pageUp")) {
-			this.moveVertical(-10, false);
-			return;
-		}
-		if (this.keybindings.matches(data, "tui.select.pageDown")) {
-			this.moveVertical(10, false);
 			return;
 		}
 	}
@@ -474,15 +444,20 @@ export class BtwTextRangeSelector implements Component {
 
 	private afterMove(): void {
 		this.warning = undefined;
+		this.keepCursorVisible();
 		this.tui.requestRender();
 	}
 
-	private keepCursorVisible(height: number): void {
-		if (height <= 0) return;
-		if (this.cursor.line < this.scrollOffset) this.scrollOffset = this.cursor.line;
-		if (this.cursor.line >= this.scrollOffset + height) {
-			this.scrollOffset = this.cursor.line - height + 1;
-		}
+	// Reveal the cursor row inside the fullscreen scroll view (wheel/PgUp/PgDn scroll it natively).
+	private keepCursorVisible(): void {
+		const view = this.tui as TUI & { viewportTop?: number; scrollBy?: (lines: number) => void };
+		if (typeof view.scrollBy !== "function" || typeof view.viewportTop !== "number") return;
+		const row = SELECTOR_CHROME_LINES + this.cursor.line;
+		const height = Math.max(1, this.tui.terminal.rows);
+		const top = view.viewportTop + SELECTOR_CHROME_LINES;
+		const bottom = view.viewportTop + height - 2;
+		if (row < top) view.scrollBy(row - top);
+		else if (row > bottom) view.scrollBy(row - bottom);
 	}
 
 	private keepCursorHorizontallyVisible(width: number): void {
@@ -539,13 +514,7 @@ function matchesConfirm(data: string, keybindings: KeybindingsManager): boolean 
 
 function keybindingLabel(
 	keybindings: KeybindingsManager,
-	keybinding:
-		| "tui.select.confirm"
-		| "tui.select.cancel"
-		| "tui.select.up"
-		| "tui.select.down"
-		| "tui.select.pageUp"
-		| "tui.select.pageDown",
+	keybinding: "tui.select.confirm" | "tui.select.cancel" | "tui.select.up" | "tui.select.down",
 	excluded: readonly string[] = [],
 	fallback?: string,
 ): string {
@@ -593,12 +562,6 @@ function positionFallsInside(
 		compareTextPositions(position, range.start) >= 0 &&
 		compareTextPositions(position, range.end) < 0
 	);
-}
-
-function fitRows(rows: string[], availableRows: number): string[] {
-	if (rows.length <= availableRows) return rows;
-	if (availableRows <= 1) return rows.slice(0, 1);
-	return [rows[0] ?? "", ...rows.slice(rows.length - availableRows + 1)];
 }
 
 function escapeBringToMainText(text: string): string {

--- a/packages/pi-btw/src/btw.ts
+++ b/packages/pi-btw/src/btw.ts
@@ -524,13 +524,7 @@ export async function runBtwThread({
 	try {
 		while (true) {
 			if (!pendingQuestion) {
-				const action = await interact(
-					thread,
-					thread.turns.length > 0,
-					ctx,
-					composerDraft,
-					createThinkingControl(),
-				);
+				const action = await interact(thread, ctx, composerDraft, createThinkingControl());
 				if (action.kind === "close") return { kind: "closed" };
 				if (action.kind === "bringToMain") {
 					const choice = await chooseBringToMainAction(thread, ctx);
@@ -903,7 +897,6 @@ async function askThreadQuestion(
 
 async function showThreadComposer(
 	thread: SideThread,
-	startAtBottom: boolean,
 	ctx: ExtensionCommandContext,
 	initialQuestion: string | undefined,
 	thinking: BtwThreadThinkingControl,
@@ -911,7 +904,6 @@ async function showThreadComposer(
 	return ctx.ui.custom<TranscriptPagerAction>(
 		(tui, theme, keybindings, done) =>
 			new BtwTranscriptPager(tui, theme, thread.turns, done, {
-				startAtBottom,
 				initialQuestion,
 				thinking: { ...thinking, keybindings },
 			}),

--- a/packages/pi-btw/src/transcript-pager.ts
+++ b/packages/pi-btw/src/transcript-pager.ts
@@ -8,7 +8,6 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import {
 	type Component,
-	CURSOR_MARKER,
 	Editor,
 	type EditorTheme,
 	type Focusable,
@@ -23,11 +22,10 @@ import {
 import type { BtwThinkingLevel, SideThreadTurn } from "./side-thread.js";
 import { sanitizeSingleLine } from "./text.js";
 
-const TRANSCRIPT_CHROME_LINES = 2;
+// Scrolling is owned by the fullscreen TUI: the transcript is rendered in full
+// and the alt-screen primary scroll view handles wheel/PgUp/PgDn/Home/End/search.
 const MAX_STEERING_DISPLAY_LINES = 3;
 const OSC133_MARKERS = ["\u001b]133;A\u0007", "\u001b]133;B\u0007", "\u001b]133;C\u0007"];
-// Pi renders a spacer above the custom component and a two-line built-in footer below it.
-const RESERVED_APP_LINES = 3;
 
 export type TranscriptPagerAction =
 	| { kind: "submit"; question: string }
@@ -53,10 +51,6 @@ export class BtwTranscriptPager implements Component, Focusable {
 	private readonly transcriptComponents: Component[];
 	private readonly editor: Editor;
 	private readonly canBringToMain: boolean;
-	private scrollOffset = 0;
-	private lastContentLineCount = 0;
-	private lastViewportHeight = 1;
-	private followBottom: boolean;
 	private warning: string | undefined;
 	private finished = false;
 	private isFocused = false;
@@ -68,14 +62,12 @@ export class BtwTranscriptPager implements Component, Focusable {
 		turns: readonly SideThreadTurn[],
 		private readonly onAction: (action: TranscriptPagerAction) => void,
 		private readonly options: {
-			startAtBottom?: boolean;
 			initialQuestion?: string;
 			thinking?: BtwThinkingControl;
 		} = {},
 	) {
 		this.transcriptComponents = buildTranscriptComponents(turns, this.theme);
 		this.canBringToMain = turns.some((turn) => turn.kind === "answered");
-		this.followBottom = options.startAtBottom ?? false;
 		this.thinkingLevel = options.thinking?.level;
 		const editorTheme: EditorTheme = {
 			borderColor: (text) => this.theme.fg("accent", text),
@@ -115,24 +107,13 @@ export class BtwTranscriptPager implements Component, Focusable {
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
 		const editorLines = this.editor.render(safeWidth);
-		const availableRows = Math.max(1, this.tui.terminal.rows - RESERVED_APP_LINES);
-		const viewportHeight = Math.max(
-			0,
-			availableRows - editorLines.length - TRANSCRIPT_CHROME_LINES,
-		);
 		const contentLines = renderTranscriptLines(this.transcriptComponents, safeWidth);
-		this.lastContentLineCount = contentLines.length;
-		this.lastViewportHeight = viewportHeight;
-		if (this.followBottom) this.scrollOffset = this.getMaxScrollOffset();
-		this.clampScrollOffset();
-
-		return fitComposerLayout(
+		return [
 			renderSideThreadHeader(safeWidth, this.theme, this.thinkingLevel),
-			contentLines.slice(this.scrollOffset, this.scrollOffset + viewportHeight),
+			...contentLines,
 			this.renderFooter(safeWidth),
-			editorLines,
-			availableRows,
-		);
+			...editorLines,
+		];
 	}
 
 	handleInput(data: string): void {
@@ -163,19 +144,6 @@ export class BtwTranscriptPager implements Component, Focusable {
 			}
 			return;
 		}
-		if (matchesKey(data, Key.pageUp)) {
-			const previousOffset = this.scrollOffset;
-			this.scrollBy(-this.lastViewportHeight);
-			if (this.scrollOffset < previousOffset) this.followBottom = false;
-			this.tui.requestRender();
-			return;
-		}
-		if (matchesKey(data, Key.pageDown)) {
-			this.scrollBy(this.lastViewportHeight);
-			this.followBottom = this.scrollOffset >= this.getMaxScrollOffset();
-			this.tui.requestRender();
-			return;
-		}
 		this.editor.handleInput(data);
 		if (!this.finished) this.tui.requestRender();
 	}
@@ -185,18 +153,11 @@ export class BtwTranscriptPager implements Component, Focusable {
 		this.editor.invalidate();
 	}
 
-	dispose(): void {
-		if (this.finished) return;
-		this.finished = true;
-		this.onAction({ kind: "close" });
-	}
-
 	private renderFooter(width: number): string {
 		if (this.warning) {
 			const warning = width < 32 ? "Empty • Ctrl+C" : `${this.warning} • Ctrl+C exit`;
 			return truncateToWidth(this.theme.fg("warning", warning), width);
 		}
-		const scrollable = this.getMaxScrollOffset() > 0;
 		const thinking = this.options.thinking;
 		const cycleHint =
 			thinking && thinking.levels.length > 1 && this.thinkingLevel
@@ -205,50 +166,16 @@ export class BtwTranscriptPager implements Component, Focusable {
 		const base = this.canBringToMain
 			? "btw • Enter send • Ctrl+R bring to main • Ctrl+C exit"
 			: "btw • Enter send • Ctrl+C exit";
-		const fullBase = `${base}${cycleHint}`;
-		const fallbackBase = "btw • Enter • Ctrl+C";
-		const compactBase = this.canBringToMain ? "btw • Enter • Ctrl+R • Ctrl+C" : fallbackBase;
-		const compactWithThinking = `${compactBase}${cycleHint}`;
-		let hints =
-			visibleWidth(fullBase) <= width
-				? fullBase
-				: visibleWidth(compactWithThinking) <= width
-					? compactWithThinking
-					: visibleWidth(compactBase) <= width
-						? compactBase
-						: fallbackBase;
-		if (scrollable) {
-			const history = ` • ${this.scrollOffset > 0 ? "↑ older" : "↓ newer"} • PgUp/PgDn history`;
-			const compactHistory = " • PgUp/PgDn";
-			const compactScrollable = this.canBringToMain
-				? "Enter • Ctrl+R • Ctrl+C • PgUp/PgDn"
-				: `${fallbackBase}${compactHistory}`;
-			if (visibleWidth(`${hints}${history}`) <= width) {
-				hints += history;
-			} else if (visibleWidth(`${compactBase}${history}`) <= width) {
-				hints = `${compactBase}${history}`;
-			} else if (visibleWidth(`${hints}${compactHistory}`) <= width) {
-				hints += compactHistory;
-			} else if (visibleWidth(`${compactBase}${compactHistory}`) <= width) {
-				hints = `${compactBase}${compactHistory}`;
-			} else if (visibleWidth(compactScrollable) <= width) {
-				hints = compactScrollable;
-			}
-		}
+		const full = `${base}${cycleHint} • PgUp/PgDn scroll`;
+		const compact = this.canBringToMain ? "btw • Enter • Ctrl+R • Ctrl+C" : "btw • Enter • Ctrl+C";
+		const hints = visibleWidth(full) <= width ? full : compact;
 		return truncateToWidth(this.theme.fg("muted", hints), width);
 	}
 
-	private scrollBy(delta: number): void {
-		this.scrollOffset += delta;
-		this.clampScrollOffset();
-	}
-
-	private clampScrollOffset(): void {
-		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, this.getMaxScrollOffset()));
-	}
-
-	private getMaxScrollOffset(): number {
-		return Math.max(0, this.lastContentLineCount - this.lastViewportHeight);
+	dispose(): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.onAction({ kind: "close" });
 	}
 }
 
@@ -257,10 +184,6 @@ export class BtwAnsweringView implements Component, Focusable {
 	private readonly loader: Loader;
 	private readonly editor: Editor | undefined;
 	private readonly controller = new AbortController();
-	private scrollOffset = 0;
-	private lastContentLineCount = 0;
-	private lastViewportHeight = 1;
-	private followBottom = true;
 	private warning: string | undefined;
 	private finished = false;
 	private isFocused = false;
@@ -325,36 +248,20 @@ export class BtwAnsweringView implements Component, Focusable {
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const availableRows = Math.max(1, this.tui.terminal.rows - RESERVED_APP_LINES);
 		const editorLines = this.editor?.render(safeWidth) ?? [];
-		const steeringCapacity = Math.max(
-			0,
-			availableRows - editorLines.length - TRANSCRIPT_CHROME_LINES,
-		);
 		const steeringLines = renderSteeringLines(
 			this.options.steering?.questions ?? [],
 			safeWidth,
 			this.theme,
-			Math.min(MAX_STEERING_DISPLAY_LINES, steeringCapacity),
-		);
-		const viewportHeight = Math.max(
-			0,
-			availableRows - editorLines.length - TRANSCRIPT_CHROME_LINES - steeringLines.length,
 		);
 		const contentLines = renderTranscriptLines(this.transcriptComponents, safeWidth);
-		this.lastContentLineCount = contentLines.length;
-		this.lastViewportHeight = viewportHeight;
-		if (this.followBottom) this.scrollOffset = this.getMaxScrollOffset();
-		this.clampScrollOffset();
-
-		return fitComposerLayout(
+		return [
 			renderSideThreadHeader(safeWidth, this.theme, this.thinkingLevel),
-			contentLines.slice(this.scrollOffset, this.scrollOffset + viewportHeight),
+			...contentLines,
+			...steeringLines,
 			this.renderFooter(safeWidth),
-			editorLines,
-			availableRows,
-			steeringLines,
-		);
+			...editorLines,
+		];
 	}
 
 	handleInput(data: string): void {
@@ -380,19 +287,6 @@ export class BtwAnsweringView implements Component, Focusable {
 				this.warning = undefined;
 				this.tui.requestRender();
 			}
-			return;
-		}
-		if (matchesKey(data, Key.pageUp)) {
-			const previousOffset = this.scrollOffset;
-			this.scrollBy(-this.lastViewportHeight);
-			if (this.scrollOffset < previousOffset) this.followBottom = false;
-			this.tui.requestRender();
-			return;
-		}
-		if (matchesKey(data, Key.pageDown)) {
-			this.scrollBy(this.lastViewportHeight);
-			this.followBottom = this.scrollOffset >= this.getMaxScrollOffset();
-			this.tui.requestRender();
 			return;
 		}
 		this.editor?.handleInput(data);
@@ -433,26 +327,13 @@ export class BtwAnsweringView implements Component, Focusable {
 			thinking && thinking.levels.length > 1 && this.thinkingLevel
 				? ` • thinking ${this.thinkingLevel} • ${thinkingKeyLabel(thinking.keybindings)} cycle`
 				: "";
-		const scrollHint = this.getMaxScrollOffset() > 0 ? " • PgUp/PgDn history" : "";
+		const scrollHint = " • PgUp/PgDn scroll";
 		const hints = `${baseHint}${cycleHint}${scrollHint}`;
 		const compactHints = this.editor ? "Enter • Ctrl+C" : "Ctrl+C";
 		const selectedHints = visibleWidth(hints) <= width ? hints : compactHints;
 		const loaderWidth = Math.max(1, width - visibleWidth(selectedHints) - 3);
 		const loaderLine = this.loader.render(loaderWidth).at(-1) ?? "Answering…";
 		return truncateToWidth(`${loaderLine} • ${this.theme.fg("muted", selectedHints)}`, width);
-	}
-
-	private scrollBy(delta: number): void {
-		this.scrollOffset += delta;
-		this.clampScrollOffset();
-	}
-
-	private clampScrollOffset(): void {
-		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, this.getMaxScrollOffset()));
-	}
-
-	private getMaxScrollOffset(): number {
-		return Math.max(0, this.lastContentLineCount - this.lastViewportHeight);
 	}
 }
 
@@ -539,52 +420,14 @@ function thinkingKeyLabel(keybindings: KeybindingsManager): string {
 		.join("+");
 }
 
-function fitComposerLayout(
-	header: string,
-	contentLines: string[],
-	footer: string,
-	editorLines: string[],
-	availableRows: number,
-	statusLines: string[] = [],
-): string[] {
-	const lines = [header, ...contentLines, ...statusLines, footer, ...editorLines];
-	if (lines.length <= availableRows) return lines;
-	if (availableRows <= 1) return [header];
-	const editorBudget = Math.max(0, availableRows - 2);
-	return [header, footer, ...fitEditorLines(editorLines, editorBudget)];
-}
-
-function fitEditorLines(editorLines: string[], budget: number): string[] {
-	if (budget <= 0) return [];
-	if (editorLines.length <= budget) return editorLines;
-	const cursorIndex = editorLines.findIndex((line) => line.includes(CURSOR_MARKER));
-	if (cursorIndex < 0) return editorLines.slice(-budget);
-	const start = Math.min(cursorIndex, editorLines.length - budget);
-	return editorLines.slice(start, start + budget);
-}
-
-function renderSteeringLines(
-	questions: readonly string[],
-	width: number,
-	theme: Theme,
-	maxLines: number,
-): string[] {
-	if (questions.length === 0 || maxLines <= 0) return [];
+function renderSteeringLines(questions: readonly string[], width: number, theme: Theme): string[] {
+	if (questions.length === 0) return [];
 	const formatQuestion = (question: string) =>
 		sanitizeSingleLine(question) || "(non-printing message)";
-	if (maxLines === 1 && questions.length > 1) {
-		return [
-			truncateToWidth(
-				theme.fg(
-					"dim",
-					`Steering (+${questions.length - 1} more): ${formatQuestion(questions[0] ?? "")}`,
-				),
-				width,
-			),
-		];
-	}
-	const hasOverflow = questions.length > maxLines;
-	const questionLimit = hasOverflow ? Math.max(1, maxLines - 1) : maxLines;
+	const hasOverflow = questions.length > MAX_STEERING_DISPLAY_LINES;
+	const questionLimit = hasOverflow
+		? Math.max(1, MAX_STEERING_DISPLAY_LINES - 1)
+		: MAX_STEERING_DISPLAY_LINES;
 	const lines = questions
 		.slice(0, questionLimit)
 		.map((question) =>

--- a/packages/pi-btw/src/transcript-pager.ts
+++ b/packages/pi-btw/src/transcript-pager.ts
@@ -168,7 +168,13 @@ export class BtwTranscriptPager implements Component, Focusable {
 			: "btw • Enter send • Ctrl+C exit";
 		const full = `${base}${cycleHint} • PgUp/PgDn scroll`;
 		const compact = this.canBringToMain ? "btw • Enter • Ctrl+R • Ctrl+C" : "btw • Enter • Ctrl+C";
-		const hints = visibleWidth(full) <= width ? full : compact;
+		const compactWithThinking = cycleHint ? `${compact}${cycleHint}` : compact;
+		const hints =
+			visibleWidth(full) <= width
+				? full
+				: visibleWidth(compactWithThinking) <= width
+					? compactWithThinking
+					: compact;
 		return truncateToWidth(this.theme.fg("muted", hints), width);
 	}
 
@@ -330,7 +336,13 @@ export class BtwAnsweringView implements Component, Focusable {
 		const scrollHint = " • PgUp/PgDn scroll";
 		const hints = `${baseHint}${cycleHint}${scrollHint}`;
 		const compactHints = this.editor ? "Enter • Ctrl+C" : "Ctrl+C";
-		const selectedHints = visibleWidth(hints) <= width ? hints : compactHints;
+		const compactWithThinking = cycleHint ? `${compactHints}${cycleHint}` : compactHints;
+		const selectedHints =
+			visibleWidth(hints) <= width
+				? hints
+				: visibleWidth(compactWithThinking) <= width
+					? compactWithThinking
+					: compactHints;
 		const loaderWidth = Math.max(1, width - visibleWidth(selectedHints) - 3);
 		const loaderLine = this.loader.render(loaderWidth).at(-1) ?? "Answering…";
 		return truncateToWidth(`${loaderLine} • ${this.theme.fg("muted", selectedHints)}`, width);


### PR DESCRIPTION
## Summary

- Fix `/btw` fullscreen views being unscrollable: when content exceeded the screen, mouse wheel, PgUp/PgDn, Home/End, and shift+scroll all did nothing in the transcript composer, the answering view, and the bring-to-main "Select exact text" selector.
- Root cause: `TuiAltScreen` consumes wheel/page/home-end input before focused components and routes it to its primary ScrollView, but both views self-clipped their render output to the terminal height (`scrollOffset` windowing plus `fitComposerLayout`/`fitRows`), so the scroll view's document was never taller than the viewport and nothing could scroll. The components' own PgUp/PgDn handlers were unreachable for the same reason.
- Fix: render the full transcript and selector lines and let the alt-screen primary scroll view own scrolling, matching Pi's own fullscreen layout (scroll view above the docked editor). The selector reveals its cursor via `viewportTop`/`scrollBy`.
- The side thread gains the alt screen's native features for free: wheel scrolling, PgUp/PgDn, Home/End, Ctrl+Shift+F transcript search, scrollbar dragging, and mouse text selection.
- Roughly 200 lines net deleted: hand-rolled scroll windows, dead page-key handlers, `fitRows`/`fitEditorLines`, and the now-meaningless `startAtBottom` plumbing.

## Verification

- `npm run check` — Biome, package boundaries, and all workspace typechecks passed (also enforced by the pre-commit hook).
- Manual TUI smoke test: a long `/btw` answer scrolls with wheel/PgUp/PgDn/Home/End and Ctrl+Shift+F search finds text in the transcript; Ctrl+R → "Select exact text…" scrolls with the wheel, arrow keys still move the cursor and auto-reveal it, Space/Shift+arrows selection and the preview round-trip behave as before; steering questions queued during a long answer still render.

## Risks and unverified paths

- The composer footer/editor now scrolls with the document (like `less`) instead of staying pinned; the view follows the end, so new turns stay visible and submitting returns to the bottom.
- The selector no longer stores `scrollOffset` in its persisted state; re-entering the selector reveals the restored cursor row rather than restoring the exact previous viewport.
- No vitest coverage was added for the two views (they are render/input driven and have no existing test harness in this package).
