### PR TITLE
fix(subagents): stabilize result and completion delivery

### DIFF
--- a/.changeset/fix-subagent-results-and-delivery.md
+++ b/.changeset/fix-subagent-results-and-delivery.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Give structured-v2 subagents a complete copyable result shape and prevent non-waking completion steering from being inserted repeatedly during active parent turns.

--- a/docs/implementation-notes/pi-subagents-stateful-runtime.md
+++ b/docs/implementation-notes/pi-subagents-stateful-runtime.md
@@ -17,9 +17,10 @@ availability.
 
 Detached completion is configurable. `stateful.completionDelivery: "next-turn"` is the default
 Codex-style behavior: the lifecycle observer publishes final status/output with
-`deliverAs: "steer"` and `triggerTurn: false`. Opt-in `"auto-resume"` holds completion while the root
-is active, coalesces simultaneous completions, and requests at most one synthesis turn after the
-parent settles when no input is pending. Completion metadata/output/error fields are independently
+`deliverAs: "steer"` and omits `triggerTurn`, allowing active-turn steering without waking an idle
+root. Opt-in `"auto-resume"` holds completion while the root is active, coalesces simultaneous
+completions, and requests at most one synthesis turn after the parent settles when no input is
+pending. Completion metadata/output/error fields are independently
 sanitized and bounded, and session-generation, shutdown, batching, and in-flight wake guards prevent
 stale or duplicate scheduling pressure. Delivery remains best-effort because Pi's custom-message API
 is fire-and-forget.

--- a/packages/pi-subagents/AGENTS.md
+++ b/packages/pi-subagents/AGENTS.md
@@ -3,7 +3,10 @@
 ## Process lifecycle
 
 - Keep signalling a cancelled POSIX process group until captured stdout and stderr close because descendants can outlive the leader while retaining its streams.
-- Snapshot detached-subagent terminal state before resolving waiters, inject completion with `deliverAs: "steer"` and `triggerTurn: false`, and serialize persistence callbacks in invocation order.
+- Snapshot detached-subagent terminal state before resolving waiters.
+- Deliver non-waking detached completions with `deliverAs: "steer"` and omit `triggerTurn`; explicit `false` bypasses steering while streaming.
+- Set `triggerTurn: true` only when auto-resume must wake an idle root.
+- Serialize persistence callbacks in invocation order.
 
 ## Pi runtime and settings
 

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -586,7 +586,7 @@ Simple and immediate critical-path work should stay in the main agent.
 
 `stateful.completionDelivery` controls settled completion delivery:
 
-- `"next-turn"` (default) preserves the previous behavior: use `deliverAs: "steer"` with `triggerTurn: false`. An active root can consume completion naturally; an idle root is not awakened.
+- `"next-turn"` (default) sends `deliverAs: "steer"` without a turn trigger. Pi queues it into an active root's context, while an idle root records it without waking.
 - `"auto-resume"` holds completion while the root is active, then requests one synthesis turn after the parent settles when no user or extension messages are already pending. Simultaneous completions share that turn, active work is not interrupted, and pending input suppresses the automatic wake.
 
 The bounded persisted completion outbox provides ordered at-least-once delivery across process restart without replaying the child turn. A top-level completion targets `/root`; a nested completion enters the direct retained parent's mailbox and is not duplicated into the root transcript. If the direct parent cannot own delivery, routing walks toward the nearest live retained ancestor and uses `/root` only as the final fallback. An idle parent remains asleep, and inspection exposes its unread and pending-completion counts until a later turn consumes the envelope. When state must be reduced to its storage bound, persistence drops roots without pending completions first and trims old history rather than discarding an outbox-owned root. A completion is acknowledged only after the intended recipient context observes its exact `completionId`; an injection that returns synchronously but never reaches context remains pending for retry. If the process exits after context assembly but before acknowledgement is persisted, the same ID can be delivered again and consumers must deduplicate it. Auto-resume applies only to `/root`; nested delivery never silently starts the parent. Transient terminal-persistence failures retry with bounded exponential backoff and keep the run pending; shutdown cancels retry waits and reports a final persistence failure instead of silently resolving unsaved work.
@@ -772,6 +772,7 @@ Closing the retained record releases the key.
 
 Set `resultFormat: "structured-v1"` to ask for legacy `summary`, `evidence`, `changes`, `verification`, and `risks` fields.
 Prefer `resultFormat: "structured-v2"` when orchestration must distinguish `completed`, `partial`, `blocked`, `needs-input`, `failed`, `interrupted`, `abstained`, `stale`, or `contract-invalid` outcomes and consume typed artifact evidence.
+The child prompt includes a complete minimum JSON object and item shapes; every displayed top-level field remains required even when its array is empty.
 Valid structured data and deterministic recovery classification appear in completion and inspection details, while malformed structured output becomes `contract-invalid` instead of being treated as success.
 The executor stamps task generation, cancellation lineage, and accepted `ExecutionPlan` identity after parsing, so model output cannot forge the provenance used for stale-result containment.
 

--- a/packages/pi-subagents/src/completion-delivery.ts
+++ b/packages/pi-subagents/src/completion-delivery.ts
@@ -111,7 +111,11 @@ export class CompletionDeliveryBroker {
 			if (triggerTurn) this.wakeInFlight = true;
 			this.awaitingParentAck.push(...batch);
 			try {
-				this.pi.sendMessage(message, { deliverAs: "steer", triggerTurn });
+				// Pi treats explicit false as immediate insertion instead of queued steering while streaming.
+				this.pi.sendMessage(message, {
+					deliverAs: "steer",
+					...(triggerTurn ? { triggerTurn: true } : {}),
+				});
 			} catch (primaryError) {
 				this.removeAwaiting(batch);
 				if (triggerTurn) this.wakeInFlight = false;

--- a/packages/pi-subagents/src/result-contract.ts
+++ b/packages/pi-subagents/src/result-contract.ts
@@ -110,15 +110,30 @@ export function structuredResultInstruction(format: SubagentResultFormat | undef
 		].join(" ");
 	}
 	if (format === "structured-v2") {
+		const minimumResult = JSON.stringify({
+			version: "pi-subagents:result:v2",
+			status: "completed",
+			summary: "Concise outcome",
+			claims: [],
+			artifacts: [],
+			changes: [],
+			verification: [],
+			limitations: [],
+			unresolvedDependencies: [],
+		});
 		return [
 			"Return the final answer as one JSON object and no surrounding prose.",
-			'Use exactly version "pi-subagents:result:v2".',
-			"Required fields are status, summary, claims, artifacts, changes, verification, limitations, and unresolvedDependencies.",
+			"Minimum valid result:",
+			minimumResult,
+			"Keep every top-level field shown, including empty arrays.",
 			`status must be one of ${SUBAGENT_OUTCOME_STATUSES.join(", ")}.`,
-			"Each claim must include claim, classification (observed, inferred, or unverified), and an evidence string array.",
-			"Each artifact must include id and kind; each change must include path and summary; each verification item must include status (passed, failed, or not-run) and summary.",
+			'Claim item shape: {"claim":"Observed fact","classification":"observed","evidence":["path:line"]}.',
+			'Artifact item shape: {"id":"artifact-id","kind":"file","version":"optional","location":"optional","digest":"optional"}.',
+			'Change item shape: {"path":"path/to/file","summary":"What changed"}.',
+			'Verification item shape: {"status":"passed","summary":"What was checked","command":"optional","evidence":["optional"]}.',
+			"Claim classification must be observed, inferred, or unverified; verification status must be passed, failed, or not-run.",
 			"Use optional reasonCode for non-completed outcomes and optional provenance for taskId, inputArtifacts, and repositoryGeneration; executor-owned generation and plan identity are stamped after parsing.",
-		].join(" ");
+		].join("\n");
 	}
 	return "";
 }

--- a/packages/pi-subagents/test/completion-delivery.test.ts
+++ b/packages/pi-subagents/test/completion-delivery.test.ts
@@ -102,7 +102,7 @@ test("next-turn completion delivery never wakes an idle root", () => {
 	broker.flush();
 
 	assert.equal(harness.sent.length, 1);
-	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer", triggerTurn: false });
+	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer" });
 	assert.equal(harness.sent[0]?.message.customType, "pi-subagent-completion");
 	assert.match(String(harness.sent[0]?.message.content), /Agent ID: sa_one/);
 	assert.deepEqual(harness.sent[0]?.message.details, {
@@ -115,6 +115,44 @@ test("next-turn completion delivery never wakes an idle root", () => {
 		task: "task:sa_one",
 		state: "completed",
 	});
+	broker.close();
+});
+
+test("active-turn next-turn delivery queues once for context acknowledgement", () => {
+	const queuedSteering: Record<string, unknown>[] = [];
+	const insertedImmediately: Record<string, unknown>[] = [];
+	const acknowledged: string[] = [];
+	const broker = new CompletionDeliveryBroker(
+		{
+			sendMessage(message: Record<string, unknown>, options?: { triggerTurn?: boolean }) {
+				if (options?.triggerTurn !== false) queuedSteering.push(message);
+				else insertedImmediately.push(message);
+			},
+		} as never,
+		{ isIdle: () => false, hasPendingMessages: () => false },
+		"next-turn",
+		{
+			onAcknowledged: (completions) => {
+				acknowledged.push(...completions.map((value) => value.completionId));
+			},
+		},
+	);
+	broker.enqueue(completion("sa_streaming"));
+	broker.flush();
+
+	assert.equal(queuedSteering.length, 1);
+	assert.equal(insertedImmediately.length, 0);
+	broker.onParentContext([
+		{
+			role: "custom",
+			customType: "pi-subagent-completion",
+			details: queuedSteering[0]?.details,
+		},
+	]);
+	broker.flush();
+
+	assert.deepEqual(acknowledged, ["completion:sa_streaming:1"]);
+	assert.equal(queuedSteering.length, 1);
 	broker.close();
 });
 
@@ -195,10 +233,7 @@ test("large completion bursts stay bounded and request only one synthesis turn",
 	assert.equal(harness.sent.length, 2);
 	assert.deepEqual(
 		harness.sent.map((entry) => entry.options),
-		[
-			{ deliverAs: "steer", triggerTurn: false },
-			{ deliverAs: "steer", triggerTurn: true },
-		],
+		[{ deliverAs: "steer" }, { deliverAs: "steer", triggerTurn: true }],
 	);
 	assert.ok(Buffer.byteLength(String(harness.sent[0]?.message.content), "utf8") <= 50 * 1024);
 	broker.close();
@@ -219,7 +254,7 @@ test("auto-resume allows only one in-flight wake until the parent starts", () =>
 		harness.sent.map((entry) => entry.options),
 		[
 			{ deliverAs: "steer", triggerTurn: true },
-			{ deliverAs: "steer", triggerTurn: false },
+			{ deliverAs: "steer" },
 			{ deliverAs: "steer", triggerTurn: true },
 		],
 	);
@@ -252,7 +287,7 @@ test("changing delivery policy flushes an active-root batch without waiting for 
 	assert.equal(harness.sent.length, 0);
 	broker.setDelivery("next-turn");
 	broker.flush();
-	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer", triggerTurn: false });
+	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer" });
 	broker.close();
 });
 
@@ -261,7 +296,7 @@ test("auto-resume lets pending user input suppress its wake", () => {
 	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "auto-resume");
 	broker.enqueue(completion("sa_pending"));
 	broker.flush();
-	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer", triggerTurn: false });
+	assert.deepEqual(harness.sent[0]?.options, { deliverAs: "steer" });
 	broker.close();
 });
 

--- a/packages/pi-subagents/test/result-contract.test.ts
+++ b/packages/pi-subagents/test/result-contract.test.ts
@@ -5,6 +5,7 @@ import {
 	parseStructuredSubagentResult,
 	parseStructuredSubagentResultV2,
 	resultContractEnvelope,
+	structuredResultInstruction,
 } from "../src/result-contract.js";
 
 test("structured result contract validates versioned fields and redacts private text", () => {
@@ -55,7 +56,31 @@ test("structured result instruction is opt-in and bounded", () => {
 	const oversized = appendResultInstruction("x".repeat(100 * 1024), "structured-v1");
 	assert.match(oversized, /pi-subagents:result:v1/);
 	assert.ok(Buffer.byteLength(oversized, "utf8") <= 50 * 1024);
+	const oversizedV2 = appendResultInstruction("界".repeat(100 * 1024), "structured-v2");
+	assert.match(oversizedV2, /Minimum valid result:/u);
+	assert.ok(Buffer.byteLength(oversizedV2, "utf8") <= 50 * 1024);
 	assert.equal(parseStructuredSubagentResult("x".repeat(50 * 1024 + 1)), undefined);
+});
+
+test("structured v2 instruction provides a complete parseable result shape", () => {
+	const instruction = structuredResultInstruction("structured-v2");
+	const example = /Minimum valid result:\n(\{[^\n]+\})/u.exec(instruction)?.[1];
+	assert.ok(example);
+	assert.deepEqual(parseStructuredSubagentResultV2(example), {
+		version: "pi-subagents:result:v2",
+		status: "completed",
+		summary: "Concise outcome",
+		claims: [],
+		artifacts: [],
+		changes: [],
+		verification: [],
+		limitations: [],
+		unresolvedDependencies: [],
+	});
+	assert.match(instruction, /Claim item shape: \{"claim":/u);
+	assert.match(instruction, /Artifact item shape: \{"id":/u);
+	assert.match(instruction, /Change item shape: \{"path":/u);
+	assert.match(instruction, /Verification item shape: \{"status":/u);
 });
 
 test("structured v2 result preserves evidence provenance and actionable outcomes", () => {


### PR DESCRIPTION
## Summary

- give `structured-v2` subagents a complete parseable JSON result shape and item examples
- omit `triggerTurn` for non-waking steering so active-turn completions enter context once and acknowledge without repeated delivery
- document the corrected behavior and add release metadata

## Verification

- `npm run check` — 348 test files and 3,465 tests passed
- `npx vitest run packages/pi-subagents/test` — 433 tests passed
- `npx vitest run packages/pi-subagents/test/result-contract.test.ts packages/pi-subagents/test/completion-delivery.test.ts` — 23 tests passed
- `npm run check --workspace packages/pi-subagents`
- `just pack subagents`

## Smoke coverage

A live-provider Pi smoke was not run; deterministic tests cover the result prompt and Pi 0.84.2 streaming-delivery branch without external model use.
