### PR TITLE
feat(langfuse): attribute observations to a configured user

### DIFF
--- a/.changeset/add-langfuse-user-id.md
+++ b/.changeset/add-langfuse-user-id.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-langfuse": minor
+---
+
+Add an optional `userId` setting to `pi-langfuse.json` and stamp it on every observation so Langfuse attributes traces and sessions to a user.

--- a/packages/pi-langfuse/README.md
+++ b/packages/pi-langfuse/README.md
@@ -68,7 +68,7 @@ You can also create the file manually:
 
 `publicKey` and `secretKey` are required literal strings. Environment-variable and command interpolation are intentionally unsupported. `baseUrl` defaults to `https://us.cloud.langfuse.com`; regional and self-hosted HTTP or HTTPS endpoints are supported. Prefer HTTPS because HTTP sends Langfuse credentials and trace content without transport encryption.
 
-`environment`, `release`, and `userId` are optional Langfuse trace attributes. An environment must match Langfuse's contract: at most 40 lowercase letters, numbers, hyphens, or underscores, and it cannot start with `langfuse`. `userId` populates the Langfuse user dimension, which is what the Sessions and Traces views group by; leave it unset to report no user. It is read when a session starts and is not part of the tracer runtime fingerprint, so a changed `userId` applies to the next session without restarting Pi. Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata without sending prompts, provider-request snapshots, responses, or tool content.
+`environment`, `release`, and `userId` are optional Langfuse trace attributes. An environment must match Langfuse's contract: at most 40 lowercase letters, numbers, hyphens, or underscores, and it cannot start with `langfuse`. `userId` populates the Langfuse user dimension, which is what the Sessions and Traces views group by; Langfuse accepts at most 200 characters, and leaving it unset reports no user. Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata without sending prompts, provider-request snapshots, responses, or tool content.
 
 The extension automatically restricts an existing config file to mode `0600` and refuses to load credentials if that protection cannot be enforced. You can also set it explicitly:
 
@@ -76,7 +76,7 @@ The extension automatically restricts an existing config file to mode `0600` and
 chmod 600 ~/.pi/agent/pi-langfuse.json
 ```
 
-Restart Pi after changing credentials, endpoint, environment, release, or `captureContent`. The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
+Restart Pi after changing credentials, endpoint, environment, release, or `captureContent`. Changes to `userId` apply to new sessions without restarting Pi. The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
 
 ## 🔭 What is traced
 
@@ -167,7 +167,7 @@ includes current tracing state and the manual configuration path.
 
 With content capture enabled, traces can contain user prompts, model responses, tool arguments, and tool results. These may include source code, file contents, shell output, or other sensitive project data. Review your Langfuse retention and access controls before enabling this extension.
 
-Git branch names, commit ids, working directory, session/leaf ids, model identity, usage/cost, aggregate counts, and allowlisted response-header values are metadata. They remain exported when `captureContent` is `false`; branch names and diagnostic header values can themselves contain operational details.
+Git branch names, commit ids, working directory, session/leaf ids, the configured `userId`, model identity, usage/cost, aggregate counts, and allowlisted response-header values are metadata. They remain exported when `captureContent` is `false`; branch names and diagnostic header values can themselves contain operational details, and a `userId` may itself be personally identifying if you set it to an email address or a real name. Choose a pseudonymous value when that matters, or leave `userId` unset to export no user at all.
 
 The built-in mask specifically protects Langfuse credentials; it is not a general secret scanner. Set `"captureContent": false` in `pi-langfuse.json` when prompts, provider-request snapshots, responses, and tool content must remain local. Compaction summaries, tool partial results, opaque continuation signatures, authorization headers, cookies, and unapproved response headers are never exported in either mode.
 

--- a/packages/pi-langfuse/README.md
+++ b/packages/pi-langfuse/README.md
@@ -61,13 +61,14 @@ You can also create the file manually:
   "baseUrl": "https://us.cloud.langfuse.com",
   "environment": "development",
   "release": "local",
+  "userId": "your-user-id",
   "captureContent": true
 }
 ```
 
 `publicKey` and `secretKey` are required literal strings. Environment-variable and command interpolation are intentionally unsupported. `baseUrl` defaults to `https://us.cloud.langfuse.com`; regional and self-hosted HTTP or HTTPS endpoints are supported. Prefer HTTPS because HTTP sends Langfuse credentials and trace content without transport encryption.
 
-`environment` and `release` are optional Langfuse trace attributes. An environment must match Langfuse's contract: at most 40 lowercase letters, numbers, hyphens, or underscores, and it cannot start with `langfuse`. Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata without sending prompts, provider-request snapshots, responses, or tool content.
+`environment`, `release`, and `userId` are optional Langfuse trace attributes. An environment must match Langfuse's contract: at most 40 lowercase letters, numbers, hyphens, or underscores, and it cannot start with `langfuse`. `userId` populates the Langfuse user dimension, which is what the Sessions and Traces views group by; leave it unset to report no user. Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata without sending prompts, provider-request snapshots, responses, or tool content.
 
 The extension automatically restricts an existing config file to mode `0600` and refuses to load credentials if that protection cannot be enforced. You can also set it explicitly:
 
@@ -75,7 +76,7 @@ The extension automatically restricts an existing config file to mode `0600` and
 chmod 600 ~/.pi/agent/pi-langfuse.json
 ```
 
-Restart Pi after changing credentials, endpoint, environment, release, or `captureContent`. The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
+Restart Pi after changing credentials, endpoint, environment, release, user, or `captureContent`. The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
 
 ## 🔭 What is traced
 

--- a/packages/pi-langfuse/README.md
+++ b/packages/pi-langfuse/README.md
@@ -68,7 +68,7 @@ You can also create the file manually:
 
 `publicKey` and `secretKey` are required literal strings. Environment-variable and command interpolation are intentionally unsupported. `baseUrl` defaults to `https://us.cloud.langfuse.com`; regional and self-hosted HTTP or HTTPS endpoints are supported. Prefer HTTPS because HTTP sends Langfuse credentials and trace content without transport encryption.
 
-`environment`, `release`, and `userId` are optional Langfuse trace attributes. An environment must match Langfuse's contract: at most 40 lowercase letters, numbers, hyphens, or underscores, and it cannot start with `langfuse`. `userId` populates the Langfuse user dimension, which is what the Sessions and Traces views group by; leave it unset to report no user. Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata without sending prompts, provider-request snapshots, responses, or tool content.
+`environment`, `release`, and `userId` are optional Langfuse trace attributes. An environment must match Langfuse's contract: at most 40 lowercase letters, numbers, hyphens, or underscores, and it cannot start with `langfuse`. `userId` populates the Langfuse user dimension, which is what the Sessions and Traces views group by; leave it unset to report no user. It is read when a session starts and is not part of the tracer runtime fingerprint, so a changed `userId` applies to the next session without restarting Pi. Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata without sending prompts, provider-request snapshots, responses, or tool content.
 
 The extension automatically restricts an existing config file to mode `0600` and refuses to load credentials if that protection cannot be enforced. You can also set it explicitly:
 
@@ -76,7 +76,7 @@ The extension automatically restricts an existing config file to mode `0600` and
 chmod 600 ~/.pi/agent/pi-langfuse.json
 ```
 
-Restart Pi after changing credentials, endpoint, environment, release, user, or `captureContent`. The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
+Restart Pi after changing credentials, endpoint, environment, release, or `captureContent`. The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
 
 ## 🔭 What is traced
 

--- a/packages/pi-langfuse/src/config.ts
+++ b/packages/pi-langfuse/src/config.ts
@@ -213,6 +213,9 @@ export function normalizeLangfuseConfig(
 	if (!release.ok) return release;
 	const userId = optionalString(input.userId, "userId");
 	if (!userId.ok) return userId;
+	if (userId.value && userId.value.length > 200) {
+		return { ok: false, reason: "pi-langfuse.json userId must be at most 200 characters." };
+	}
 
 	return {
 		ok: true,

--- a/packages/pi-langfuse/src/config.ts
+++ b/packages/pi-langfuse/src/config.ts
@@ -12,6 +12,7 @@ export interface LangfuseConfig {
 	baseUrl: string;
 	environment?: string;
 	release?: string;
+	userId?: string;
 	captureContent: boolean;
 }
 
@@ -61,6 +62,7 @@ async function writeLangfuseConfigNow(
 		baseUrl: _baseUrl,
 		environment: _environment,
 		release: _release,
+		userId: _userId,
 		captureContent: _captureContent,
 		...unknownFields
 	} = currentDocument;
@@ -209,6 +211,8 @@ export function normalizeLangfuseConfig(
 	}
 	const release = optionalString(input.release, "release");
 	if (!release.ok) return release;
+	const userId = optionalString(input.userId, "userId");
+	if (!userId.ok) return userId;
 
 	return {
 		ok: true,
@@ -218,6 +222,7 @@ export function normalizeLangfuseConfig(
 			baseUrl,
 			...(environment.value ? { environment: environment.value } : {}),
 			...(release.value ? { release: release.value } : {}),
+			...(userId.value ? { userId: userId.value } : {}),
 			captureContent: input.captureContent ?? true,
 		},
 	};

--- a/packages/pi-langfuse/src/langfuse.ts
+++ b/packages/pi-langfuse/src/langfuse.ts
@@ -201,6 +201,7 @@ export function createLangfuseExtension(
 				activeConfig = result.config;
 				recorder = new TraceRecorder(backend, {
 					sessionId: ctx.sessionManager.getSessionId(),
+					...(result.config.userId ? { userId: result.config.userId } : {}),
 					cwd: ctx.cwd,
 					mode: ctx.mode,
 					captureContent: result.config.captureContent,

--- a/packages/pi-langfuse/src/runtime.ts
+++ b/packages/pi-langfuse/src/runtime.ts
@@ -39,14 +39,15 @@ class ProductionObservation implements Observation {
 	constructor(readonly native: LangfuseObservation) {}
 
 	update(attributes: ObservationAttributes): Observation {
-		const { sessionId, ...observationAttributes } = attributes;
+		const { sessionId, userId, ...observationAttributes } = attributes;
 		this.native.updateOtelSpanAttributes(observationAttributes as LangfuseObservationAttributes);
 		applySessionId(this.native, sessionId);
+		applyUserId(this.native, userId);
 		return this;
 	}
 
 	updateTrace(attributes: ObservationAttributes): Observation {
-		const { input, output, metadata, name, sessionId, tags, version } = attributes;
+		const { input, output, metadata, name, sessionId, userId, tags, version } = attributes;
 		if (input !== undefined || output !== undefined) {
 			this.native.setTraceIO({ input, output });
 		}
@@ -54,6 +55,7 @@ class ProductionObservation implements Observation {
 			this.native.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_NAME, name);
 		}
 		applySessionId(this.native, sessionId);
+		applyUserId(this.native, userId);
 		if (tags !== undefined) {
 			this.native.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_TAGS, tags);
 		}
@@ -86,13 +88,14 @@ class ProductionTraceBackend implements TraceBackend {
 		attributes: ObservationAttributes,
 		options: { asType: ObservationType; parent?: Observation },
 	): Observation {
-		const { sessionId, ...observationAttributes } = attributes;
+		const { sessionId, userId, ...observationAttributes } = attributes;
 		const parent = options.parent;
 		const native =
 			parent instanceof ProductionObservation
 				? startChild(parent.native, name, observationAttributes, options.asType)
 				: startRoot(name, observationAttributes, options.asType);
 		applySessionId(native, sessionId);
+		applyUserId(native, userId);
 		return new ProductionObservation(native);
 	}
 
@@ -183,6 +186,12 @@ const defaultFactories: RuntimeFactories = {
 function applySessionId(observation: LangfuseObservation, sessionId: string | undefined): void {
 	if (sessionId !== undefined) {
 		observation.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_SESSION_ID, sessionId);
+	}
+}
+
+function applyUserId(observation: LangfuseObservation, userId: string | undefined): void {
+	if (userId !== undefined) {
+		observation.otelSpan.setAttribute(LangfuseOtelSpanAttributes.TRACE_USER_ID, userId);
 	}
 }
 

--- a/packages/pi-langfuse/src/tracing.ts
+++ b/packages/pi-langfuse/src/tracing.ts
@@ -40,6 +40,7 @@ export interface ObservationAttributes {
 	version?: string;
 	name?: string;
 	sessionId?: string;
+	userId?: string;
 	tags?: string[];
 }
 
@@ -63,6 +64,7 @@ export interface TraceBackend {
 
 interface RecorderContext {
 	sessionId: string;
+	userId?: string;
 	cwd: string;
 	mode: string;
 	captureContent: boolean;
@@ -239,7 +241,12 @@ export class TraceRecorder {
 		attributes: ObservationAttributes,
 		options: { asType: ObservationType; parent?: Observation },
 	): Observation {
-		return this.backend.start(name, { ...attributes, sessionId: this.context.sessionId }, options);
+		const { sessionId, userId } = this.context;
+		return this.backend.start(
+			name,
+			{ ...attributes, sessionId, ...(userId ? { userId } : {}) },
+			options,
+		);
 	}
 
 	hasActiveTrace(): boolean {
@@ -287,6 +294,7 @@ export class TraceRecorder {
 		this.root.updateTrace?.({
 			name: "pi.trace",
 			sessionId: this.context.sessionId,
+			...(this.context.userId ? { userId: this.context.userId } : {}),
 			version: TRACE_SCHEMA_VERSION,
 			input: traceInput,
 			metadata,

--- a/packages/pi-langfuse/test/config.test.ts
+++ b/packages/pi-langfuse/test/config.test.ts
@@ -232,6 +232,28 @@ test("configuration covers malformed JSON, normalization, and captureContent fal
 		assert.equal(normalized.ok, false, String(userId));
 		if (!normalized.ok) assert.match(normalized.reason, /userId/i);
 	}
+	const maxLengthUserId = "u".repeat(200);
+	assert.deepEqual(
+		normalizeLangfuseConfig({ publicKey: "pk", secretKey: "sk", userId: maxLengthUserId }),
+		{
+			ok: true,
+			config: {
+				publicKey: "pk",
+				secretKey: "sk",
+				baseUrl: "https://us.cloud.langfuse.com",
+				userId: maxLengthUserId,
+				captureContent: true,
+			},
+		},
+	);
+	const tooLongUserId = normalizeLangfuseConfig({
+		publicKey: "pk",
+		secretKey: "sk",
+		userId: "u".repeat(201),
+	});
+	assert.equal(tooLongUserId.ok, false);
+	if (!tooLongUserId.ok)
+		assert.match(tooLongUserId.reason, /userId must be at most 200 characters/);
 
 	await writeFile(path, JSON.stringify({ publicKey: "pk", secretKey: "sk" }), { mode: 0o600 });
 	await chmod(path, 0o644);

--- a/packages/pi-langfuse/test/config.test.ts
+++ b/packages/pi-langfuse/test/config.test.ts
@@ -214,6 +214,25 @@ test("configuration covers malformed JSON, normalization, and captureContent fal
 		if (!normalized.ok) assert.match(normalized.reason, /environment/i);
 	}
 
+	assert.deepEqual(
+		normalizeLangfuseConfig({ publicKey: "pk", secretKey: "sk", userId: "  analyst-7  " }),
+		{
+			ok: true,
+			config: {
+				publicKey: "pk",
+				secretKey: "sk",
+				baseUrl: "https://us.cloud.langfuse.com",
+				userId: "analyst-7",
+				captureContent: true,
+			},
+		},
+	);
+	for (const userId of ["", "   ", 7, null]) {
+		const normalized = normalizeLangfuseConfig({ publicKey: "pk", secretKey: "sk", userId });
+		assert.equal(normalized.ok, false, String(userId));
+		if (!normalized.ok) assert.match(normalized.reason, /userId/i);
+	}
+
 	await writeFile(path, JSON.stringify({ publicKey: "pk", secretKey: "sk" }), { mode: 0o600 });
 	await chmod(path, 0o644);
 	const repaired = await loadLangfuseConfig(path);

--- a/packages/pi-langfuse/test/recorder.test.ts
+++ b/packages/pi-langfuse/test/recorder.test.ts
@@ -692,10 +692,11 @@ test("TraceRecorder omits generation request content when capture is disabled", 
 	);
 });
 
-test("TraceRecorder stamps the session id on every observation", () => {
+test("TraceRecorder stamps the session and user id on every observation", () => {
 	const backend = new FakeBackend();
 	const recorder = new TraceRecorder(backend, {
 		sessionId: "session-42",
+		userId: "user-42",
 		cwd: "/workspace",
 		mode: "tui",
 		captureContent: true,
@@ -736,5 +737,10 @@ test("TraceRecorder stamps the session id on every observation", () => {
 	]);
 	for (const observation of backend.observations) {
 		assert.equal(observation.attributes.sessionId, "session-42");
+		assert.equal(observation.attributes.userId, "user-42");
 	}
+	assert.equal(
+		backend.observations.find(({ name }) => name === "pi.agent")?.traceUpdates[0]?.userId,
+		"user-42",
+	);
 });

--- a/packages/pi-langfuse/test/runtime.test.ts
+++ b/packages/pi-langfuse/test/runtime.test.ts
@@ -65,6 +65,7 @@ test("isolated runtime preserves the global provider and exports native observat
 
 	const recorder = new TraceRecorder(backend, {
 		sessionId: "runtime-session",
+		userId: "runtime-user",
 		cwd: "/workspace",
 		mode: "tui",
 		captureContent: true,
@@ -135,6 +136,7 @@ test("isolated runtime preserves the global provider and exports native observat
 	]);
 	for (const span of spans) assert.equal(span.attributes["langfuse.version"], "2");
 	for (const span of spans) assert.equal(span.attributes["session.id"], "runtime-session");
+	for (const span of spans) assert.equal(span.attributes["user.id"], "runtime-user");
 	const agent = spans.find((span) => span.name === "pi.agent");
 	const attempt = spans.find((span) => span.name === "pi.attempt");
 	const turn = spans.find((span) => span.name === "pi.turn");
@@ -187,13 +189,20 @@ test("isolated runtime preserves the global provider and exports native observat
 	);
 
 	const updatedSession = backend.start("updated-session", {}, { asType: "span" });
-	updatedSession.update({ sessionId: "updated-session" });
+	updatedSession.update({ sessionId: "updated-session", userId: "updated-user" });
 	updatedSession.end();
 	await backend.forceFlush();
 	const updatedSessionSpan = exporter
 		.getFinishedSpans()
 		.find((span) => span.name === "updated-session");
 	assert.equal(updatedSessionSpan?.attributes["session.id"], "updated-session");
+	assert.equal(updatedSessionSpan?.attributes["user.id"], "updated-user");
+
+	const withoutUser = backend.start("without-user", {}, { asType: "span" });
+	withoutUser.end();
+	await backend.forceFlush();
+	const withoutUserSpan = exporter.getFinishedSpans().find((span) => span.name === "without-user");
+	assert.equal("user.id" in (withoutUserSpan?.attributes ?? {}), false);
 
 	await backend.shutdown();
 	await backend.shutdown();


### PR DESCRIPTION
Closes #816.

Adds an optional `userId` to `pi-langfuse.json` and stamps it on every observation, following your suggestion on the issue — and you were right to ask for every observation rather than the root only. My note on the issue ("user id only has to be on the root trace") was wrong: `TRACE_USER_ID` (`user.id`) and `TRACE_SESSION_ID` (`session.id`) are a symmetric pair in the Langfuse SDK, right down to their `langfuse.*` compat aliases, so the ingestion path that made #763 necessary applies here too. Langfuse's own OpenCode plugin reaches the same conclusion from the other direction: it installs a span processor whose `onStart` sets the user id on every span.

## Approach

The value comes from configuration, because Pi itself has no notion of a user — nothing on `ctx` can supply one. `userId` therefore sits next to `environment` and `release`: an optional literal string, validated by the existing `optionalString()` helper, and omitted from the normalized config when unset. That also matches the shape Langfuse's OpenCode plugin exposes.

- `config.ts` — optional `userId` on `LangfuseConfig`, validated and preserved through the update path.
- `tracing.ts` — `userId` on `RecorderContext` and `ObservationAttributes`; `startObservation()` stamps it alongside the session id, and the root `updateTrace()` carries it too.
- `runtime.ts` — `applyUserId()` mirrors `applySessionId()` and is applied in `start()`, `update()`, and `updateTrace()`.
- `langfuse.ts` — passes `result.config.userId` into the `TraceRecorder`.

Two deliberate choices:

- The canonical `LangfuseOtelSpanAttributes.TRACE_USER_ID` (`user.id`) is used rather than the `langfuse.user.id` compat alias, to stay consistent with the existing session id handling.
- When no user is configured the attribute is spread in conditionally, so observation attributes keep exactly the shape they have today and nothing is written to the span.

## Tests

- `recorder.test.ts` — the existing session-id test now also asserts the user id on all six observation kinds and on the root trace update. I extended it in place rather than duplicating its 55-line setup; happy to split it into a separate test if you would rather keep that one focused.
- `runtime.test.ts` — the exported spans assert `user.id`, the `update()` path asserts it, and a span started without a user asserts that `user.id` is absent.
- `config.test.ts` — trimming, plus rejection of empty, whitespace, numeric, and null values.

All three fail without the `src/` changes and pass with them (verified by stashing only `src/`). Full package suite: 48 passed. Repo-wide `precommit` (biome + every workspace typecheck) is clean. Changeset included.

## Verification against a live instance

Self-hosted Langfuse v4 in `events_only` mode, one Pi run on the patched build and one on `@narumitw/pi-langfuse@0.49.4`, same prompt and same token count. Metrics API, `observations` view grouped by user and session:

```json
{ "userId": "juishu", "sessionId": "01a01013-34b0-71d8-a8f9-adc88c0575ad", "sum_totalTokens": 3785 }
{ "userId": null,     "sessionId": "01a01018-5fb7-7e27-959c-c1f7009f55e2", "sum_totalTokens": 3785 }
```

Broken out per observation for the patched run, every one of them carries the user:

```json
{ "userId": "juishu", "name": "pi.agent",   "count": 1 }
{ "userId": "juishu", "name": "pi.attempt", "count": 1 }
{ "userId": "juishu", "name": "pi.turn",    "count": 1 }
{ "userId": "juishu", "name": "pi.llm",     "count": 1 }
```

`pi.llm` is the one that matters for the aggregates: it is a child span, and it is where usage lives.

## One open question

Langfuse's OpenCode plugin also accepts `LANGFUSE_USER_ID` from the environment, falling back to it when the config file omits a user. I left that out because `pi-langfuse.json` is deliberately the single source of truth here — even the keys are not read from the environment, and `isInterpolation()` rejects `$`-prefixed values outright. Say the word if you want the env fallback and I will add it.
