### PR TITLE
feat(tui-kit): support LaTeX and Mermaid documents

### DIFF
--- a/.changeset/render-tui-markdown.md
+++ b/.changeset/render-tui-markdown.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add opt-in Markdown document rendering with terminal-friendly LaTeX and lazy, width-safe Unicode Mermaid diagrams.

--- a/docs/plans/archived/2026-08-17_pi-tui-kit-latex-mermaid-plan.md
+++ b/docs/plans/archived/2026-08-17_pi-tui-kit-latex-mermaid-plan.md
@@ -71,6 +71,10 @@ Advance `PI_EXTENSION_MENU_API_VERSION` for the additive public contract and rec
 - [x] Audit the final diff against `AGENTS.md`, `packages/pi-tui-kit/AGENTS.md`, and the touched TUI, package, documentation, and verification sections of `docs/extension-conventions.md`; review found no blocking correctness, security, lifecycle, compatibility, or scope issue. Hardening added shared bidi-control removal, alternate/case-insensitive fences, wide Unicode labels, disabled-load proof, third-party load/render failure fallbacks, and stale concurrent-load coverage. Existing formats/modes remain tested, coding-agent imports stay type-only, only public Pi APIs are used, and no consumer changed. A manual interactive TUI smoke remains unrun under the non-interactive execution policy; real-component harnesses, the benchmark, packaging smoke, and old-host smoke cover the runtime path.
 - [x] Mark this objective `DONE` and archive the plan only after every completion item has evidence; all required evidence is recorded, and the plan was moved to `docs/plans/archived/2026-08-17_pi-tui-kit-latex-mermaid-plan.md`.
 
+## Review Follow-up
+
+- [x] Align Mermaid preparation with the sanitized top-level Markdown tokens so CR-only line endings render while nested literal fences and tab-indented code do not load Grok; the two focused regressions initially failed on both mismatches, then 22 Kit files/198 tests, the Kit check, the 353-file/3,476-test root gate, the lazy-load benchmark, and a 65-file package inspection passed.
+
 ## Risks
 
 - Pi's Markdown renderer is semantic and may reflow or normalize source, so only the new explicit format may use it while exact formats retain their current hard-wrapping path.

--- a/docs/plans/archived/2026-08-17_pi-tui-kit-latex-mermaid-plan.md
+++ b/docs/plans/archived/2026-08-17_pi-tui-kit-latex-mermaid-plan.md
@@ -1,0 +1,103 @@
+# Pi TUI Kit LaTeX and Mermaid Plan
+
+Status: DONE
+
+## Goal
+
+Add an opt-in Markdown document format to `@narumitw/pi-tui-kit` so review screens and browse detail documents can render Pi TUI Markdown, terminal-friendly LaTeX, and width-safe Unicode Mermaid diagrams without changing existing text, code, diff, RPC, or older-host behavior.
+
+## Context
+
+The repository currently builds and tests against Pi `0.84.2`, whose public `Markdown` component renders supported LaTeX and accepts a width-aware source transform.
+
+Pi's Mermaid transcript support is not part of `pi-tui`; the coding-agent layer uses `grok-mermaid`, and its transformer is not a public package export.
+
+Pi TUI Kit already shares one cached, terminal-sanitized document pipeline between review screens and `browse.detailDocument`, while RPC intentionally paginates sanitized source text.
+
+The Kit's production boundary must continue using public `pi-tui` primitives, keep coding-agent imports type-only, preserve callback-provided themes, and avoid loading optional Mermaid work on existing menu paths.
+
+Applicable repository MUST rules are deterministic changed-behavior tests, width-bounded and terminal-safe rendering, theme invalidation, stale revalidation after asynchronous work, direct runtime dependency declaration, independent Changeset versioning, the root CI-equivalent gate, and package inspection.
+
+`docs/extension-settings.md` is not applicable because this change will not add, read, or write extension-owned or Pi-owned settings.
+
+## Architecture
+
+Extend `ReviewFormat` with `{ kind: "markdown"; renderLatex?: boolean; renderMermaid?: boolean }` and treat both options as `true` when omitted after a consumer explicitly chooses the Markdown format.
+
+Render Markdown only in TUI mode through Pi TUI's public `Markdown` component, a Markdown theme derived from the callback-provided Pi theme, and the Kit's existing syntax highlighter, without importing the coding-agent runtime.
+
+Sanitize raw document content before Markdown parsing or Mermaid transformation, then let the renderer add trusted theme ANSI sequences.
+
+Use a package-internal Mermaid transformer built from public `pi-tui` parsing exports and a declared direct `grok-mermaid` dependency; do not deep-import Pi's internal Mermaid transformer.
+
+Lazy-load `grok-mermaid` only before opening a TUI screen that contains an enabled Markdown Mermaid path, cache the module result, and revalidate menu ownership after the await.
+
+Feature-detect the host's rich Markdown capability through public `pi-tui` exports so older hosts continue importing the Kit and render readable Markdown source instead of failing module initialization.
+
+Render a Mermaid diagram only when parsing is complete enough to produce warning-free art and its natural width fits the current document width; otherwise preserve the original fenced source, with a concise sanitized warning for partial parses.
+
+Keep RPC pages as sanitized, bounded Markdown source because RPC has no terminal-rendering contract, and keep print and JSON behavior unchanged through the existing unsupported-mode result.
+
+Reuse the existing document line cache, include normalized Markdown flags in its identity, and rebuild on content, format, width, host capability, or theme invalidation so resize can switch safely between diagram and source.
+
+Advance `PI_EXTENSION_MENU_API_VERSION` for the additive public contract and record a minor Changeset without publishing or changing any consumer compatibility floor.
+
+## Non-Goals
+
+- Do not alter existing `text`, `code`, or `diff` formatting or treat semantic Markdown rendering as an exact whitespace preview.
+- Do not read Pi's private settings manager or make Kit rendering inherit the transcript-only `markdown.mermaid` setting.
+- Do not add streaming Mermaid rendering, arbitrary consumer transforms, browser graphics, SVG, images, horizontal scrolling, persistence, or network access.
+- Do not deep-import Pi internals, import the coding-agent runtime from Kit production code, or rely on another extension package.
+- Do not update the private showcase or any published consumer to use the new API before the Kit release is separately published and registry-verified.
+- Do not publish, tag, change npm visibility, or dispatch a release workflow as part of this objective.
+
+## Plan
+
+- [x] Install the locked workspace dependencies with `npm install`, confirm the pre-implementation worktree changes only contain this plan, and stop for review if npm changes tracked manifests or the lockfile unexpectedly; verified on `narumi/feat/tui-kit-latex-mermaid` with 393 packages installed, zero vulnerabilities, no tracked manifest or lockfile drift, and only this plan untracked.
+- [x] Record a clean behavioral and performance baseline for the Kit before production edits; package check passed, all 17 Kit test files and 185 tests passed, and five-run medians were 116.77 ms import, 122.37 ms actions first frame, 125.40 ms review first frame, and 119.82 ms task first frame with no coding-agent runtime load.
+- [x] Add failing public-contract tests for the Markdown `ReviewFormat`, both boolean controls, package-root declaration usability, README type examples, and API literal `13`; `npm run typecheck --workspace @narumitw/pi-tui-kit` failed only on absent `markdown` union members and the version-12-to-13 literal mismatch.
+- [x] Add failing review and browse TUI tests using the real Pi `Markdown` component for headings, code, inline and block LaTeX, malformed-LaTeX source fallback, disabled LaTeX, terminal-control removal, narrow widths, scrolling, resize reflow, cache reuse, and theme invalidation; focused Vitest ran 24 tests with only the three new semantic-rendering assertions failing on raw Markdown/LaTeX output.
+- [x] Implement the internal Markdown document renderer, callback-derived `MarkdownTheme`, semantic cache identity, and public type/API-version changes without Mermaid transformation; focused review, browse, and model suites passed all 36 tests and the Kit typecheck passed with existing text, code, and diff characterizations intact.
+- [x] Add failing Mermaid tests for a supported themed diagram, labels containing backtick runs, disabled rendering, unsupported syntax, partial-parse warnings, width overflow, narrow-to-wide resize recovery, terminal-control sanitization, and mixed Markdown around the fence; the focused review suite ran 19 tests with only valid-art rendering and partial-warning assertions failing on raw fences.
+- [x] Add the direct `grok-mermaid` runtime dependency, update `package-lock.json` through `npm install`, and implement a cached lazy loader plus width-aware top-level Mermaid transform using only public package APIs; all 19 focused review tests passed, `npm ls` resolved Kit-owned `grok-mermaid@0.2.2`, and import plus code-review benchmark workers loaded neither Grok nor the coding-agent runtime.
+- [x] Integrate Mermaid preparation into the TUI menu loop so only relevant screens await it, load failure degrades to fenced source, and owner abort or replacement during the await returns `stale` before opening UI; two isolated Vitest files passed controlled concurrent one-load, stale-owner, and mocked-load-failure regressions.
+- [x] Add RPC compatibility characterizations proving Markdown, LaTeX, and Mermaid remain sanitized bounded source in review and browse dialogs, selector labels do not absorb document content, and Back/Close plus pagination behavior is unchanged; focused `runtime.test.ts` passed all 37 cases.
+- [x] Build and pack the Kit, then exercise the tarball in a temporary install against the last pre-rich-Markdown Pi host to prove package import and existing formats still work while the new Markdown format degrades to readable source; a clean temporary install with Pi `0.83.0` rendered existing code, ordinary Markdown, raw LaTeX, and raw Mermaid successfully, then removed the temporary directory.
+- [x] Extend the runtime benchmark with a Markdown/Mermaid first-frame scenario and compare it with the recorded baseline; five-run medians were 117.88 ms import, 117.45 ms actions, 125.90 ms code review, 135.60 ms Mermaid, and 118.65 ms task, with no material existing-path regression, no coding-agent runtime load, and Grok loaded only by Mermaid.
+- [x] Update `packages/pi-tui-kit/README.md`, `test/readme-usage.ts`, public export fixtures, API-version history, runtime-performance notes, and package layout to document opt-in syntax, defaults, TUI-only rich rendering, supported Mermaid families, width/warning/source fallbacks, older-host degradation, terminal safety, and independence from Pi transcript settings; Kit typecheck passed, built-root/model tests passed 13 cases, and README badges plus required sections remain present.
+- [x] Add a minor Changeset for `@narumitw/pi-tui-kit`, run the repository formatter, and inspect the selected diff to ensure only the Kit, root lock metadata, Changeset, benchmark, and this plan changed; `npm run format` fixed six intended files, `git diff --check` passed, and status/stat showed only the planned package, lock, benchmark, Changeset, tests, and plan paths.
+- [x] Run focused and repository verification sequentially, keeping failed or skipped checks open; an initial package preflight found two import-order and two control-regex Biome errors, all were corrected, then the Kit check passed, 21 focused files/197 tests passed, boundaries passed, final root `npm run check` passed 352 files/3,475 tests, and Changesets selected Kit `0.55.0` while emitting the expected unchanged-consumer-floor notices.
+- [x] Run `just pack tui-kit` and inspect the dry-run artifact list and manifest so built ESM, declarations, README, license, and the declared Mermaid dependency are present with no source-only or unrelated files; pack produced 63 files with README, license, manifest, Mermaid ESM/declarations, no `src/` or tests, and direct Grok metadata. An auxiliary jq query initially assumed npm's JSON was an array, then the corrected package-key query passed.
+- [x] Audit the final diff against `AGENTS.md`, `packages/pi-tui-kit/AGENTS.md`, and the touched TUI, package, documentation, and verification sections of `docs/extension-conventions.md`; review found no blocking correctness, security, lifecycle, compatibility, or scope issue. Hardening added shared bidi-control removal, alternate/case-insensitive fences, wide Unicode labels, disabled-load proof, third-party load/render failure fallbacks, and stale concurrent-load coverage. Existing formats/modes remain tested, coding-agent imports stay type-only, only public Pi APIs are used, and no consumer changed. A manual interactive TUI smoke remains unrun under the non-interactive execution policy; real-component harnesses, the benchmark, packaging smoke, and old-host smoke cover the runtime path.
+- [x] Mark this objective `DONE` and archive the plan only after every completion item has evidence; all required evidence is recorded, and the plan was moved to `docs/plans/archived/2026-08-17_pi-tui-kit-latex-mermaid-plan.md`.
+
+## Risks
+
+- Pi's Markdown renderer is semantic and may reflow or normalize source, so only the new explicit format may use it while exact formats retain their current hard-wrapping path.
+- A static Mermaid import would tax every Kit consumer, so the implementation must preserve lazy loading and benchmark the existing cold paths.
+- An unavailable host transform API could break all screens if imported as a required named export, so capability detection must degrade only the new rich format.
+- Mermaid art can be misleading when a parse is partial or can overflow when its natural width exceeds the viewport, so both cases must retain source instead of clipping or presenting incomplete art as authoritative.
+- Expanding the internal theme surface can break lightweight test doubles, so all affected harness themes must supply the same style methods as the real callback theme.
+- A dynamic import cannot be cancelled, so the menu must ignore its completion after owner replacement and avoid opening a stale component.
+- The lockfile already contains `grok-mermaid` transitively, which can hide a missing direct declaration, so package-owned dependency metadata and a packed temporary install must prove independent resolution.
+
+## Rollback / Recovery
+
+No data or settings migration is involved.
+
+Before publication, the additive type, renderer, dependency, lock metadata, API version, documentation, and Changeset can be reverted together.
+
+After publication, preserve the public Markdown union and issue a patch that falls back to sanitized source if rich rendering causes a host incompatibility; do not remove the accepted format in a patch release.
+
+## Completion Checklist
+
+- [x] `ReviewFormat` exposes a documented opt-in Markdown contract with explicit LaTeX and Mermaid controls and API version `13`, proven by source and packed declaration typechecks.
+- [x] Review screens and browse detail documents render ordinary Markdown plus supported inline and block LaTeX in TUI mode, proven at normal, narrow, resized, scrolled, and invalidated states.
+- [x] Supported warning-free Mermaid fences render themed Unicode only when they fit, while disabled, unsupported, partial, failed, and oversized cases preserve safe source, proven by deterministic tests.
+- [x] Raw document controls cannot inject terminal sequences through Markdown, LaTeX, Mermaid labels, warnings, or fallbacks, and every rendered line stays within the supplied width.
+- [x] RPC retains bounded sanitized source, existing print/JSON behavior is unchanged, and Back/Close, pagination, focus, selection, cancellation, disposal, and stale-session contracts remain intact.
+- [x] Existing text, code, and diff outputs remain compatible, older hosts import without a missing-export crash, and rich-format absence degrades to readable source.
+- [x] Existing cold paths do not load the coding-agent runtime or Mermaid renderer, and benchmark evidence records the new Mermaid first-frame cost without an unexplained regression.
+- [x] Package metadata, lockfile ownership, built ESM, declarations, README, license, API history, Changeset intent, and packed contents agree.
+- [x] Focused tests, boundaries, the CI-equivalent `npm run check`, Changesets status, `git diff --check`, package inspection, and the semantic convention audit all pass with evidence.
+- [x] No consumer compatibility floor, npm publication, tag, visibility, or release workflow changed in this objective.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6306,6 +6306,7 @@
 			"version": "0.54.1",
 			"license": "MIT",
 			"dependencies": {
+				"grok-mermaid": "0.2.2",
 				"highlight.js": "11.12.0"
 			},
 			"devDependencies": {

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -42,10 +42,11 @@ The Kit's production JavaScript imports Pi TUI at runtime but keeps Pi Coding Ag
 This prevents a source-loaded extension from evaluating a second heavyweight coding-agent runtime
 when its menu first opens. Borders and task loaders compose public Pi TUI primitives with the theme
 and keybindings supplied by the active UI callback; review syntax coloring uses the Kit's declared
-highlighter dependency and the same callback theme.
+highlighter dependency and the same callback theme. Mermaid rendering lazy-loads its declared
+renderer only before the first screen containing an enabled Mermaid fence.
 
-Repository maintainers can measure cold package import, first actions/review frame, and first task
-frame in fresh serial processes:
+Repository maintainers can measure cold package import plus first actions, code-review, Mermaid, and
+task frames in fresh serial processes:
 
 ```bash
 npm run build --workspace @narumitw/pi-tui-kit
@@ -393,14 +394,15 @@ keeps one deterministic unfiltered list, then presents bounded detail pages; `se
 rendered.
 
 Use `details` for legacy prose lines. The Kit normalizes their whitespace and prepends available
-status and description text. Use `detailDocument` for a complete whitespace-sensitive body such as
-JSON, source code, or a diff. Its `content` preserves indentation, expands tabs to four-column stops,
-hard-wraps by terminal cells, strips terminal controls, and uses the same optional text, code, or diff
-`format` as a review screen. When both fields are present, `detailDocument` is the complete body and
-takes precedence over `details`, status, and description inside the detail body. The item label still
-names the detail, while status and description remain available in list presentation. RPC retains the
-existing status-bearing selector label as the dialog title for compatibility, but does not prepend a
-second status line to the exact body.
+status and description text. Use `detailDocument` for a complete body such as JSON, source code, a
+diff, or Markdown. Text, code, and diff formats preserve indentation, expand tabs to four-column
+stops, hard-wrap by terminal cells, and strip terminal plus bidirectional display controls. Markdown
+format applies the same safety boundary but then renders semantic Markdown rather than preserving
+exact source whitespace. When both fields are
+present, `detailDocument` is the complete body and takes precedence over `details`, status, and
+description inside the detail body. The item label still names the detail, while status and
+description remain available in list presentation. RPC retains the existing status-bearing selector
+label as the dialog title for compatibility, but does not prepend a second status line to the body.
 
 Exact document content is never added to fuzzy-search metadata or RPC selector labels. Copy only safe,
 intentional aliases or metadata into `searchText`; do not copy a large or sensitive document merely
@@ -466,8 +468,8 @@ const inputScreen = {
 
 Review screens preserve indentation and hard-wrap by terminal cells rather than prose words. Their
 viewport supports Up, Down, Page Up, Page Down, Home, and End. RPC sends bounded pages instead of one
-unbounded dialog title. Treat `content` as untrusted display input; the kit strips terminal controls
-before formatting it.
+unbounded dialog title. Treat `content` as untrusted display input; the kit strips terminal and
+bidirectional display controls before formatting it.
 
 ```ts
 const reviewScreen = {
@@ -480,12 +482,34 @@ const reviewScreen = {
 };
 ```
 
-Review formats are `{ kind: "text" }`, `{ kind: "code", language?, filePath? }`, and
-`{ kind: "diff", filePath? }`. Omitted `viewportSize` keeps the fixed 14-row TUI viewport, and
-numeric values remain fixed integers from 1 through 50. Set `viewportSize: "adaptive"` to recompute
-from the live terminal height on every TUI render. Adaptive review reserves three terminal rows for
-Pi-owned UI and keeps the complete frame within `max(1, floor(terminal rows) - 3)` rows; this mode is
-not capped at the numeric 50-row maximum.
+Review formats are `{ kind: "text" }`, `{ kind: "code", language?, filePath? }`,
+`{ kind: "diff", filePath? }`, and
+`{ kind: "markdown", renderLatex?, renderMermaid? }`. Choosing Markdown is opt-in; both rich
+renderers default to `true`, and either can be disabled explicitly. TUI uses Pi's Markdown renderer
+for headings, emphasis, links, lists, code highlighting, and supported inline or block LaTeX.
+
+Enabled top-level `mermaid` fences render locally as themed Unicode when a warning-free flowchart,
+state, class, entity-relationship, or sequence diagram fits the current width. Partial parses retain
+the fenced source and add a warning. Unsupported, oversized, unavailable, or disabled rendering
+retains readable fenced source. Resizing can switch between source and art. The Kit options are
+independent of Pi's transcript-only Mermaid setting and use no browser, image, SVG, or network.
+
+```ts
+const markdownReviewScreen = {
+  kind: "review" as const,
+  title: "Architecture notes",
+  content: "# Formula\\n\\n$x^2$\\n\\n```mermaid\\nflowchart LR\\n A --> B\\n```",
+  format: { kind: "markdown" as const },
+  viewportSize: "adaptive" as const,
+};
+```
+
+Rich Markdown rendering is TUI-only. RPC keeps sanitized, bounded source pages, and a host without
+Pi's public rich-Markdown capability safely displays readable source for unsupported rich elements.
+Omitted `viewportSize` keeps the fixed 14-row TUI viewport, and numeric values remain fixed integers
+from 1 through 50. Set `viewportSize: "adaptive"` to recompute from the live terminal height on every
+TUI render. Adaptive review reserves three terminal rows for Pi-owned UI and keeps the complete frame
+within `max(1, floor(terminal rows) - 3)` rows; this mode is not capped at the numeric 50-row maximum.
 
 At constrained heights, adaptive review prioritizes one content row, then a compact title, then a
 compact confirmation/Back-or-Close/navigation hint. From four available rows it shows position when
@@ -712,14 +736,18 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
   `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
   strict scripts, and their public testing types; it is not re-exported from the production root.
-- `PI_EXTENSION_MENU_API_VERSION` — current API version (`12`).
-  Version 12 adds optional searchable `choice` fields while version-11 menu definitions remain valid.
-  Version 11 added Live Choice confirmation-only gating, version 10 added exact browse detail documents, version 9 added `runLiveChoice()` and `formatInteractionHints()`, version 8 added disabled action reasons and adaptive action-label columns, version 7 added `runConfirmation()`, and version 6 added the read-only `browse` screen and `runCustomInteraction()`.
+- `PI_EXTENSION_MENU_API_VERSION` — current API version (`13`).
+  Version 13 adds opt-in Markdown, LaTeX, and Mermaid document formatting while version-12 menu
+  definitions remain valid. Version 12 added optional searchable `choice` fields, version 11 added
+  Live Choice confirmation-only gating, version 10 added exact browse detail documents, version 9
+  added `runLiveChoice()` and `formatInteractionHints()`, version 8 added disabled action reasons and
+  adaptive action-label columns, version 7 added `runConfirmation()`, and version 6 added the
+  read-only `browse` screen and `runCustomInteraction()`.
 
 ## 🗂️ Package layout
 
 - `src/` — authored TypeScript and the public package entrypoint
-- `src/components/` — internal TUI input, browse, review, exact-document, settings, and rendering adapters
+- `src/components/` — internal TUI input, browse, review, document, Markdown, Mermaid, settings, and rendering adapters
 - `src/testing/` — supported TUI/RPC test drivers exported only through the `/testing` subpath
 - `src/task.ts` — standalone and menu-shared task lifecycle orchestration
 - `src/confirmation.ts` — standalone confirmation mode adaptation and lifecycle results

--- a/packages/pi-tui-kit/package.json
+++ b/packages/pi-tui-kit/package.json
@@ -53,6 +53,7 @@
 		"directory": "packages/pi-tui-kit"
 	},
 	"dependencies": {
+		"grok-mermaid": "0.2.2",
 		"highlight.js": "11.12.0"
 	}
 }

--- a/packages/pi-tui-kit/src/components/contracts.ts
+++ b/packages/pi-tui-kit/src/components/contracts.ts
@@ -59,7 +59,8 @@ export interface MenuScreenComponentOptions<ScreenId extends string, ActionId ex
 	screen: MenuScreen<ScreenId, ActionId>;
 	selectedItemId?: string;
 	tui: RenderHost;
-	theme: Pick<Theme, "fg" | "bold">;
+	theme: Pick<Theme, "fg" | "bold"> &
+		Partial<Pick<Theme, "italic" | "underline" | "strikethrough">>;
 	keybindings: MenuKeybindings;
 	onEvent(event: MenuScreenEvent): void;
 	onSelectionChange?(itemId: string): void;

--- a/packages/pi-tui-kit/src/components/document-formatting.ts
+++ b/packages/pi-tui-kit/src/components/document-formatting.ts
@@ -1,8 +1,8 @@
-import { stripVTControlCharacters } from "node:util";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { MarkdownTheme } from "@earendil-works/pi-tui";
 import * as PiTui from "@earendil-works/pi-tui";
 import type { ReviewFormat } from "../types.js";
+import { sanitizeDocumentText } from "./document-sanitization.js";
 import { mermaidMarkdownTransform, supportsRichMarkdown } from "./mermaid.js";
 import { getLanguageFromPath, highlightCode } from "./syntax-highlighting.js";
 
@@ -174,26 +174,6 @@ function documentFormatIdentity(format: ReviewFormat | undefined) {
 		};
 	}
 	return { ...shared, kind: "text" as const, language: undefined, filePath: undefined };
-}
-
-export function sanitizeDocumentText(value: unknown): string {
-	const stripped = stripVTControlCharacters(String(value)).replace(/\r\n?/gu, "\n");
-	return Array.from(stripped, (character) => {
-		if (character === "\n" || character === "\t") return character;
-		const codePoint = character.codePointAt(0) ?? 0;
-		if (isBidiControl(codePoint)) return "";
-		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
-	}).join("");
-}
-
-function isBidiControl(codePoint: number) {
-	return (
-		codePoint === 0x061c ||
-		codePoint === 0x200e ||
-		codePoint === 0x200f ||
-		(codePoint >= 0x202a && codePoint <= 0x202e) ||
-		(codePoint >= 0x2066 && codePoint <= 0x2069)
-	);
 }
 
 function documentSegments(content: string, width: number) {

--- a/packages/pi-tui-kit/src/components/document-formatting.ts
+++ b/packages/pi-tui-kit/src/components/document-formatting.ts
@@ -1,7 +1,9 @@
 import { stripVTControlCharacters } from "node:util";
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import * as PiTui from "@earendil-works/pi-tui";
 import type { ReviewFormat } from "../types.js";
+import { mermaidMarkdownTransform, supportsRichMarkdown } from "./mermaid.js";
 import { getLanguageFromPath, highlightCode } from "./syntax-highlighting.js";
 
 export const RPC_DOCUMENT_LINE_WIDTH = 120;
@@ -10,7 +12,8 @@ export const RPC_DOCUMENT_PAGE_SIZE = 8;
 const TAB_SIZE = 4;
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
-type DocumentTheme = Pick<Theme, "fg" | "bold">;
+type DocumentTheme = Pick<Theme, "fg" | "bold"> &
+	Partial<Pick<Theme, "italic" | "underline" | "strikethrough">>;
 
 export function createDocumentLineCache(theme: DocumentTheme) {
 	let cached:
@@ -19,6 +22,9 @@ export function createDocumentLineCache(theme: DocumentTheme) {
 				formatKind: ReviewFormat["kind"];
 				language: string | undefined;
 				filePath: string | undefined;
+				renderLatex: boolean | undefined;
+				renderMermaid: boolean | undefined;
+				richMarkdown: boolean;
 				width: number;
 				lines: string[];
 		  }
@@ -31,6 +37,9 @@ export function createDocumentLineCache(theme: DocumentTheme) {
 				cached.formatKind === identity.kind &&
 				cached.language === identity.language &&
 				cached.filePath === identity.filePath &&
+				cached.renderLatex === identity.renderLatex &&
+				cached.renderMermaid === identity.renderMermaid &&
+				cached.richMarkdown === identity.richMarkdown &&
 				cached.width === width
 			) {
 				return cached.lines;
@@ -41,6 +50,9 @@ export function createDocumentLineCache(theme: DocumentTheme) {
 				formatKind: identity.kind,
 				language: identity.language,
 				filePath: identity.filePath,
+				renderLatex: identity.renderLatex,
+				renderMermaid: identity.renderMermaid,
+				richMarkdown: identity.richMarkdown,
 				width,
 				lines,
 			};
@@ -58,8 +70,11 @@ export function formatDocumentLines(
 	width: number,
 	theme: DocumentTheme,
 ): string[] {
-	const segments = documentSegments(content, width);
 	const resolvedFormat = format ?? { kind: "text" as const };
+	if (resolvedFormat.kind === "markdown") {
+		return renderMarkdownDocument(content, resolvedFormat, width, theme);
+	}
+	const segments = documentSegments(content, width);
 	if (resolvedFormat.kind === "code") {
 		const language =
 			resolvedFormat.language ??
@@ -85,6 +100,47 @@ export function plainDocumentLines(content: string, width: number): string[] {
 	return documentSegments(content, width).map(({ text }) => text);
 }
 
+function renderMarkdownDocument(
+	content: string,
+	format: Extract<ReviewFormat, { kind: "markdown" }>,
+	width: number,
+	theme: DocumentTheme,
+): string[] {
+	const component = new PiTui.Markdown(
+		sanitizeDocumentText(content),
+		0,
+		0,
+		markdownTheme(theme),
+		{ color: (text) => theme.fg("text", text) },
+		{
+			renderLatex: format.renderLatex ?? true,
+			transform: format.renderMermaid === false ? undefined : mermaidMarkdownTransform(theme),
+		},
+	);
+	return component.render(Math.max(1, width));
+}
+
+function markdownTheme(theme: DocumentTheme): MarkdownTheme {
+	return {
+		heading: (text) => theme.fg("mdHeading", text),
+		link: (text) => theme.fg("mdLink", text),
+		linkUrl: (text) => theme.fg("mdLinkUrl", text),
+		code: (text) => theme.fg("mdCode", text),
+		codeBlock: (text) => theme.fg("mdCodeBlock", text),
+		codeBlockBorder: (text) => theme.fg("mdCodeBlockBorder", text),
+		quote: (text) => theme.fg("mdQuote", text),
+		quoteBorder: (text) => theme.fg("mdQuoteBorder", text),
+		hr: (text) => theme.fg("mdHr", text),
+		listBullet: (text) => theme.fg("mdListBullet", text),
+		bold: (text) => theme.bold(text),
+		italic: (text) => theme.italic?.(text) ?? text,
+		underline: (text) => theme.underline?.(text) ?? text,
+		strikethrough: (text) => theme.strikethrough?.(text) ?? text,
+		highlightCode: (code, language) =>
+			code.split("\n").map((line) => highlightCode(line, language, theme)),
+	};
+}
+
 export function documentDialogPages(content: string, width: number, pageSize: number): string[][] {
 	const lines = plainDocumentLines(content, width);
 	const safePageSize = Math.max(1, Math.floor(pageSize));
@@ -96,13 +152,28 @@ export function documentDialogPages(content: string, width: number, pageSize: nu
 }
 
 function documentFormatIdentity(format: ReviewFormat | undefined) {
+	const shared = {
+		renderLatex: undefined,
+		renderMermaid: undefined,
+		richMarkdown: supportsRichMarkdown(),
+	};
 	if (format?.kind === "code") {
-		return { kind: format.kind, language: format.language, filePath: format.filePath };
+		return { ...shared, kind: format.kind, language: format.language, filePath: format.filePath };
 	}
 	if (format?.kind === "diff") {
-		return { kind: format.kind, language: undefined, filePath: format.filePath };
+		return { ...shared, kind: format.kind, language: undefined, filePath: format.filePath };
 	}
-	return { kind: "text" as const, language: undefined, filePath: undefined };
+	if (format?.kind === "markdown") {
+		return {
+			...shared,
+			kind: format.kind,
+			language: undefined,
+			filePath: undefined,
+			renderLatex: format.renderLatex ?? true,
+			renderMermaid: format.renderMermaid ?? true,
+		};
+	}
+	return { ...shared, kind: "text" as const, language: undefined, filePath: undefined };
 }
 
 export function sanitizeDocumentText(value: unknown): string {
@@ -110,8 +181,19 @@ export function sanitizeDocumentText(value: unknown): string {
 	return Array.from(stripped, (character) => {
 		if (character === "\n" || character === "\t") return character;
 		const codePoint = character.codePointAt(0) ?? 0;
+		if (isBidiControl(codePoint)) return "";
 		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
 	}).join("");
+}
+
+function isBidiControl(codePoint: number) {
+	return (
+		codePoint === 0x061c ||
+		codePoint === 0x200e ||
+		codePoint === 0x200f ||
+		(codePoint >= 0x202a && codePoint <= 0x202e) ||
+		(codePoint >= 0x2066 && codePoint <= 0x2069)
+	);
 }
 
 function documentSegments(content: string, width: number) {
@@ -133,7 +215,7 @@ function expandTabs(line: string): string {
 			continue;
 		}
 		result += segment;
-		column += visibleWidth(segment);
+		column += PiTui.visibleWidth(segment);
 	}
 	return result;
 }
@@ -150,7 +232,7 @@ function hardWrapLine(line: string, width: number): string[] {
 		currentWidth = 0;
 	};
 	for (const { segment } of graphemeSegmenter.segment(line)) {
-		const segmentWidth = visibleWidth(segment);
+		const segmentWidth = PiTui.visibleWidth(segment);
 		if (segmentWidth > safeWidth) {
 			if (current.length > 0) flush();
 			lines.push("?".repeat(safeWidth));

--- a/packages/pi-tui-kit/src/components/document-sanitization.ts
+++ b/packages/pi-tui-kit/src/components/document-sanitization.ts
@@ -1,0 +1,21 @@
+import { stripVTControlCharacters } from "node:util";
+
+export function sanitizeDocumentText(value: unknown): string {
+	const stripped = stripVTControlCharacters(String(value)).replace(/\r\n?/gu, "\n");
+	return Array.from(stripped, (character) => {
+		if (character === "\n" || character === "\t") return character;
+		const codePoint = character.codePointAt(0) ?? 0;
+		if (isBidiControl(codePoint)) return "";
+		return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+	}).join("");
+}
+
+function isBidiControl(codePoint: number) {
+	return (
+		codePoint === 0x061c ||
+		codePoint === 0x200e ||
+		codePoint === 0x200f ||
+		(codePoint >= 0x202a && codePoint <= 0x202e) ||
+		(codePoint >= 0x2066 && codePoint <= 0x2069)
+	);
+}

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -44,6 +44,7 @@ export type {
 	MenuScreenEvent,
 	MenuSettingChange,
 } from "./contracts.js";
+export { prepareMenuScreenRendering } from "./mermaid.js";
 export { actionMenuDialogLabel, safeMenuText } from "./rendering.js";
 export { reviewDialogPages } from "./review.js";
 

--- a/packages/pi-tui-kit/src/components/mermaid.ts
+++ b/packages/pi-tui-kit/src/components/mermaid.ts
@@ -4,6 +4,7 @@ import * as PiTui from "@earendil-works/pi-tui";
 import type { MermaidArt, Span } from "grok-mermaid";
 import { sanitizeTerminalText } from "../terminal-text.js";
 import type { MenuScreen, ReviewFormat } from "../types.js";
+import { sanitizeDocumentText } from "./document-sanitization.js";
 
 type MermaidRender = typeof import("grok-mermaid")["render"];
 type MermaidTheme = Pick<Theme, "fg" | "bold">;
@@ -57,12 +58,19 @@ export function mermaidMarkdownTransform(theme: MermaidTheme) {
 }
 
 function documentNeedsMermaid(content: string | undefined, format: ReviewFormat | undefined) {
-	return (
-		format?.kind === "markdown" &&
-		format.renderMermaid !== false &&
-		content !== undefined &&
-		/(?:^|\n)[\t ]{0,3}(?:`{3,}|~{3,})[\t ]*mermaid(?:[\t \r\n]|$)/iu.test(content)
-	);
+	if (
+		format?.kind !== "markdown" ||
+		format.renderMermaid === false ||
+		content === undefined ||
+		!supportsRichMarkdown()
+	) {
+		return false;
+	}
+	const markdown = sanitizeDocumentText(content);
+	if (!/(?:^|\n)[\t ]{0,3}(?:`{3,}|~{3,})[\t ]*mermaid(?:[\t \n]|$)/iu.test(markdown)) {
+		return false;
+	}
+	return new PiTui.Marked().lexer(markdown).some(isMermaid);
 }
 
 function renderToken(token: Token, availableWidth: number, theme: MermaidTheme) {

--- a/packages/pi-tui-kit/src/components/mermaid.ts
+++ b/packages/pi-tui-kit/src/components/mermaid.ts
@@ -1,0 +1,125 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { Token, Tokens } from "@earendil-works/pi-tui";
+import * as PiTui from "@earendil-works/pi-tui";
+import type { MermaidArt, Span } from "grok-mermaid";
+import { sanitizeTerminalText } from "../terminal-text.js";
+import type { MenuScreen, ReviewFormat } from "../types.js";
+
+type MermaidRender = typeof import("grok-mermaid")["render"];
+type MermaidTheme = Pick<Theme, "fg" | "bold">;
+
+let renderMermaid: MermaidRender | undefined;
+let loadPromise: Promise<void> | undefined;
+let loadFailed = false;
+
+export function supportsRichMarkdown() {
+	return typeof PiTui.renderLatex === "function" && typeof PiTui.Marked === "function";
+}
+
+export function prepareMermaidRenderer(): Promise<void> | undefined {
+	if (!supportsRichMarkdown() || renderMermaid || loadFailed) return undefined;
+	loadPromise ??= import("grok-mermaid")
+		.then((module) => {
+			renderMermaid = module.render;
+		})
+		.catch(() => {
+			loadFailed = true;
+		});
+	return loadPromise;
+}
+
+export function prepareMenuScreenRendering<ScreenId extends string, ActionId extends string>(
+	screen: MenuScreen<ScreenId, ActionId>,
+): Promise<void> | undefined {
+	if (screen.kind === "review") {
+		return documentNeedsMermaid(screen.content, screen.format)
+			? prepareMermaidRenderer()
+			: undefined;
+	}
+	if (screen.kind === "browse") {
+		return screen.items.some((item) =>
+			documentNeedsMermaid(item.detailDocument?.content, item.detailDocument?.format),
+		)
+			? prepareMermaidRenderer()
+			: undefined;
+	}
+	return undefined;
+}
+
+export function mermaidMarkdownTransform(theme: MermaidTheme) {
+	if (!renderMermaid || !supportsRichMarkdown()) return undefined;
+	const markdownParser = new PiTui.Marked();
+	return (markdown: string, availableWidth: number) =>
+		markdownParser
+			.lexer(markdown)
+			.map((token) => renderToken(token, availableWidth, theme))
+			.join("");
+}
+
+function documentNeedsMermaid(content: string | undefined, format: ReviewFormat | undefined) {
+	return (
+		format?.kind === "markdown" &&
+		format.renderMermaid !== false &&
+		content !== undefined &&
+		/(?:^|\n)[\t ]{0,3}(?:`{3,}|~{3,})[\t ]*mermaid(?:[\t \r\n]|$)/iu.test(content)
+	);
+}
+
+function renderToken(token: Token, availableWidth: number, theme: MermaidTheme) {
+	if (!isMermaid(token) || !renderMermaid) return token.raw;
+	let art: MermaidArt | null;
+	try {
+		art = renderMermaid(token.text);
+	} catch {
+		return token.raw;
+	}
+	if (!art || art.width > Math.max(1, availableWidth)) return token.raw;
+	if (art.warnings.length > 0) return warningFallback(token.raw, art.warnings, theme);
+	return `${themedLines(art, theme).map(codeSpan).join("  \n")}\n`;
+}
+
+function isMermaid(token: Token): token is Tokens.Code {
+	return (
+		token.type === "code" && token.lang?.trim().split(/\s+/u, 1)[0]?.toLowerCase() === "mermaid"
+	);
+}
+
+function warningFallback(raw: string, warnings: readonly string[], theme: MermaidTheme) {
+	const suffix = warnings.length > 1 ? ` (+${warnings.length - 1} more)` : "";
+	const warning = sanitizeTerminalText(
+		`Mermaid diagram not rendered: ${warnings[0] ?? "incomplete source"}${suffix}`,
+	);
+	return `${raw}\n${codeSpan(theme.fg("warning", warning))}  \n`;
+}
+
+function themedLines(art: MermaidArt, theme: MermaidTheme) {
+	return art.styled.map((row) => row.map((span) => styleSpan(span, theme)).join(""));
+}
+
+function styleSpan(span: Span, theme: MermaidTheme) {
+	switch (span.cls) {
+		case "border":
+			return theme.fg("borderMuted", span.text);
+		case "text":
+			return theme.fg("text", span.text);
+		case "edge":
+			return theme.fg("accent", span.text);
+		case "edgeLabel":
+			return theme.fg("muted", span.text);
+		case "title":
+			return theme.fg("accent", theme.bold(span.text));
+		case "none":
+			return span.text;
+	}
+}
+
+function codeSpan(line: string) {
+	const content = line || "\u00a0";
+	const longestBacktickRun = Math.max(
+		0,
+		...Array.from(content.matchAll(/`+/gu), (match) => match[0].length),
+	);
+	const fence = "`".repeat(longestBacktickRun + 1);
+	const padding = content.startsWith("`") || content.endsWith("`") ? " " : "";
+	return `${fence}${padding}${content}${padding}${fence}`;
+}

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -58,4 +58,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 12;
+export const PI_EXTENSION_MENU_API_VERSION = 13;

--- a/packages/pi-tui-kit/src/runtime.ts
+++ b/packages/pi-tui-kit/src/runtime.ts
@@ -9,6 +9,7 @@ import {
 	type MenuScreenComponent,
 	type MenuScreenEvent,
 	type MenuSettingChange,
+	prepareMenuScreenRendering,
 	reviewDialogPages,
 	safeMenuText,
 } from "./components/index.js";
@@ -88,6 +89,11 @@ async function runTuiMenu<
 			const state = loaded.state;
 			const screenId = navigator.current;
 			const screen = resolveMenuScreen(definition, screenId, state);
+			const renderingPreparation = prepareMenuScreenRendering(screen);
+			if (renderingPreparation) {
+				await renderingPreparation;
+				if (!isMenuCurrent(options) || menuSignal.aborted) return { kind: "stale" };
+			}
 			let staleAction = false;
 			const interact = async (interaction: MenuInteraction, interactionSignal?: AbortSignal) => {
 				const invocation = await invokeMenuInteraction({

--- a/packages/pi-tui-kit/src/types.ts
+++ b/packages/pi-tui-kit/src/types.ts
@@ -97,7 +97,8 @@ export interface ChoiceScreen<ActionId extends string> {
 export type ReviewFormat =
 	| { kind: "text" }
 	| { kind: "code"; language?: string; filePath?: string }
-	| { kind: "diff"; filePath?: string };
+	| { kind: "diff"; filePath?: string }
+	| { kind: "markdown"; renderLatex?: boolean; renderMermaid?: boolean };
 
 /** Exact full-body content for a browse detail view. */
 export interface BrowseDetailDocument {

--- a/packages/pi-tui-kit/test/browse-screen.test.ts
+++ b/packages/pi-tui-kit/test/browse-screen.test.ts
@@ -231,6 +231,46 @@ test("browse exact details preserve documents, precedence, search identity, and 
 	assert.match(plainRender(privateSearch.component, 40).join("\n"), /No matching items/u);
 });
 
+test("browse detail documents share semantic Markdown and LaTeX rendering", () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "browse",
+		title: "Guides",
+		items: [
+			{
+				id: "markdown",
+				label: "Rendered guide",
+				searchText: "formula math",
+				detailDocument: {
+					content: "# Formula guide\n\nThe result is $x^2$.\n\n```ts\nconst answer = 42;\n```",
+					format: { kind: "markdown", renderMermaid: false },
+				},
+			},
+		],
+		viewportSize: "adaptive",
+		hint: "back",
+	};
+	const harness = componentHarness(screen, { rows: 12 });
+	const focusable = harness.component as MenuScreenComponent & Focusable;
+	focusable.focused = true;
+	for (const input of "math") harness.component.handleInput(input);
+	harness.component.handleInput("y");
+
+	for (const width of [10, 24, 60]) {
+		assert.ok(harness.component.render(width).every((line) => visibleWidth(line) <= width));
+	}
+	const rendered = plainRender(harness.component, 60).join("\n");
+	assert.match(rendered, /^Formula guide\s*$/mu);
+	assert.match(rendered, /The result is x²\./u);
+	assert.match(rendered, /const answer = 42;/u);
+	assert.match(rendered, /```ts/u);
+	assert.doesNotMatch(rendered, /# Formula guide/u);
+
+	harness.component.handleInput("q");
+	assert.match(plainRender(harness.component, 60).join("\n"), /math/u);
+	assert.equal(harness.component.render(60).join("\n").includes(CURSOR_MARKER), true);
+	assert.equal(harness.selectionChanges.at(-1), "markdown");
+});
+
 test("browse exact details apply shared code and diff formatting", () => {
 	const screen: MenuScreen<ScreenId, ActionId> = {
 		kind: "browse",

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -8,6 +8,7 @@ import {
 	type MenuBrowseItem,
 	type MenuDefinition,
 	PI_EXTENSION_MENU_API_VERSION,
+	type ReviewFormat,
 	resolveMenuScreen,
 } from "../src/index.js";
 
@@ -40,18 +41,24 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("package exposes API version 12 and exact browse detail types", () => {
+test("package exposes API version 13 and Markdown document types", () => {
+	const markdown: ReviewFormat = {
+		kind: "markdown",
+		renderLatex: false,
+		renderMermaid: true,
+	};
 	const document: BrowseDetailDocument = {
-		content: "  exact\nbody",
-		format: { kind: "code", language: "json" },
+		content: "# Document\n\n$x^2$",
+		format: markdown,
 	};
 	const item: MenuBrowseItem = {
 		id: "schema",
 		label: "Schema",
 		detailDocument: document,
 	};
+	const apiVersion: 13 = PI_EXTENSION_MENU_API_VERSION;
 	assert.equal(item.detailDocument, document);
-	assert.equal(PI_EXTENSION_MENU_API_VERSION, 12);
+	assert.equal(apiVersion, 13);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/mermaid-disabled-loading.test.ts
+++ b/packages/pi-tui-kit/test/mermaid-disabled-loading.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { defineMenu, runMenu } from "../src/index.js";
+import { createTuiHarness } from "../src/testing/index.js";
+
+const loader = vi.hoisted(() => ({ calls: 0 }));
+
+vi.mock("grok-mermaid", () => {
+	loader.calls += 1;
+	return { render: () => null };
+});
+
+test("ordinary Markdown and disabled Mermaid fences do not load the renderer", async () => {
+	for (const screen of [
+		{
+			kind: "review" as const,
+			title: "Ordinary Markdown",
+			content: "# Formula\n\n$x^2$",
+			format: { kind: "markdown" as const },
+		},
+		{
+			kind: "review" as const,
+			title: "Disabled Mermaid",
+			content: "```mermaid\nflowchart LR\n A --> B\n```",
+			format: { kind: "markdown" as const, renderMermaid: false },
+		},
+	]) {
+		const tui = createTuiHarness({ width: 80, rows: 24 });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const menu = defineMenu<undefined, "review", "unused">({
+			start: "review",
+			screens: { review: () => screen },
+			actions: { unused: async () => ({ kind: "close" }) },
+		});
+		const running = runMenu(context.ctx, menu, { getState: () => undefined });
+		await tui.waitForOpen();
+		tui.render();
+		tui.press("tui.select.cancel");
+		assert.deepEqual(await running, { kind: "closed", reason: "back" });
+	}
+	assert.equal(loader.calls, 0);
+});

--- a/packages/pi-tui-kit/test/mermaid-disabled-loading.test.ts
+++ b/packages/pi-tui-kit/test/mermaid-disabled-loading.test.ts
@@ -11,7 +11,7 @@ vi.mock("grok-mermaid", () => {
 	return { render: () => null };
 });
 
-test("ordinary Markdown and disabled Mermaid fences do not load the renderer", async () => {
+test("only top-level enabled Mermaid fences load the renderer", async () => {
 	for (const screen of [
 		{
 			kind: "review" as const,
@@ -24,6 +24,18 @@ test("ordinary Markdown and disabled Mermaid fences do not load the renderer", a
 			title: "Disabled Mermaid",
 			content: "```mermaid\nflowchart LR\n A --> B\n```",
 			format: { kind: "markdown" as const, renderMermaid: false },
+		},
+		{
+			kind: "review" as const,
+			title: "Nested literal fence",
+			content: "````markdown\n```mermaid\nflowchart LR\n A --> B\n```\n````",
+			format: { kind: "markdown" as const },
+		},
+		{
+			kind: "review" as const,
+			title: "Tab-indented code",
+			content: "\t```mermaid\n\tflowchart LR\n\t A --> B\n\t```",
+			format: { kind: "markdown" as const },
 		},
 	]) {
 		const tui = createTuiHarness({ width: 80, rows: 24 });

--- a/packages/pi-tui-kit/test/mermaid-load-failure.test.ts
+++ b/packages/pi-tui-kit/test/mermaid-load-failure.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { defineMenu, runMenu } from "../src/index.js";
+import { createTuiHarness } from "../src/testing/index.js";
+
+vi.mock("grok-mermaid", () => {
+	throw new Error("simulated Mermaid module load failure");
+});
+
+test("a Mermaid module load failure degrades to sanitized fenced source", async () => {
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const menu = defineMenu<undefined, "review", "unused">({
+		start: "review",
+		screens: {
+			review: () => ({
+				kind: "review",
+				title: "Mermaid fallback",
+				content:
+					"```mermaid\nflowchart LR\n A[unsafe\u001b]8;;https://unsafe.example\u0007text] --> B\n```",
+				format: { kind: "markdown" },
+			}),
+		},
+		actions: { unused: async () => ({ kind: "close" }) },
+	});
+
+	const running = runMenu(context.ctx, menu, { getState: () => undefined });
+	await tui.waitForOpen();
+	const rendered = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(rendered, /```mermaid/u);
+	assert.match(rendered, /flowchart LR/u);
+	assert.match(rendered, /unsafetext/u);
+	assert.doesNotMatch(rendered, /https:\/\/unsafe\.example/u);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});

--- a/packages/pi-tui-kit/test/mermaid-loading.test.ts
+++ b/packages/pi-tui-kit/test/mermaid-loading.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { defineMenu, runMenu } from "../src/index.js";
+import { createTuiHarness } from "../src/testing/index.js";
+
+const loader = vi.hoisted(() => {
+	let reportStarted!: () => void;
+	let release!: () => void;
+	return {
+		calls: 0,
+		started: new Promise<void>((resolve) => {
+			reportStarted = resolve;
+		}),
+		gate: new Promise<void>((resolve) => {
+			release = resolve;
+		}),
+		reportStarted: () => reportStarted(),
+		release: () => release(),
+	};
+});
+
+vi.mock("grok-mermaid", async () => {
+	loader.calls += 1;
+	loader.reportStarted();
+	await loader.gate;
+	return { render: () => null };
+});
+
+const menu = defineMenu<undefined, "review", "unused">({
+	start: "review",
+	screens: {
+		review: () => ({
+			kind: "review",
+			title: "Mermaid loading",
+			content: "```mermaid\nflowchart LR\n A --> B\n```",
+			format: { kind: "markdown" },
+		}),
+	},
+	actions: { unused: async () => ({ kind: "close" }) },
+});
+
+test("concurrent Mermaid preparation loads once and revalidates stale owners", async () => {
+	const staleOwner = new AbortController();
+	let staleCustomCalls = 0;
+	const staleContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async () => {
+			staleCustomCalls += 1;
+			throw new Error("A stale Mermaid screen must not open");
+		},
+	});
+	const activeTui = createTuiHarness({ width: 80, rows: 24 });
+	const activeContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: activeTui.custom,
+	});
+
+	const staleRun = runMenu(staleContext.ctx, menu, {
+		getState: () => undefined,
+		signal: staleOwner.signal,
+	});
+	const activeRun = runMenu(activeContext.ctx, menu, { getState: () => undefined });
+	await loader.started;
+	staleOwner.abort(new DOMException("Session replaced", "AbortError"));
+	loader.release();
+
+	assert.deepEqual(await staleRun, { kind: "stale" });
+	assert.equal(staleCustomCalls, 0);
+	await activeTui.waitForOpen();
+	assert.match(stripVTControlCharacters(activeTui.render().join("\n")), /flowchart LR/u);
+	activeTui.press("tui.select.cancel");
+	assert.deepEqual(await activeRun, { kind: "closed", reason: "back" });
+	assert.equal(loader.calls, 1);
+});

--- a/packages/pi-tui-kit/test/mermaid-normalized-loading.test.ts
+++ b/packages/pi-tui-kit/test/mermaid-normalized-loading.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { defineMenu, runMenu } from "../src/index.js";
+import { createTuiHarness } from "../src/testing/index.js";
+
+const loader = vi.hoisted(() => ({ calls: 0 }));
+
+vi.mock("grok-mermaid", () => {
+	loader.calls += 1;
+	return {
+		render: () => ({
+			width: 3,
+			plain: ["ART"],
+			styled: [[{ cls: "text" as const, text: "ART" }]],
+			warnings: [],
+		}),
+	};
+});
+
+test("a top-level Mermaid fence after normalized line endings loads and renders", async () => {
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const menu = defineMenu<undefined, "review", "unused">({
+		start: "review",
+		screens: {
+			review: () => ({
+				kind: "review",
+				title: "Normalized Mermaid",
+				content: "Introduction\r```mermaid\rflowchart LR\r A --> B\r```",
+				format: { kind: "markdown" },
+			}),
+		},
+		actions: { unused: async () => ({ kind: "close" }) },
+	});
+
+	const running = runMenu(context.ctx, menu, { getState: () => undefined });
+	await tui.waitForOpen();
+	const rendered = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(rendered, /ART/u);
+	assert.doesNotMatch(rendered, /flowchart LR/u);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+	assert.equal(loader.calls, 1);
+});

--- a/packages/pi-tui-kit/test/mermaid-render-failure.test.ts
+++ b/packages/pi-tui-kit/test/mermaid-render-failure.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { defineMenu, runMenu } from "../src/index.js";
+import { createTuiHarness } from "../src/testing/index.js";
+
+vi.mock("grok-mermaid", () => ({
+	render: () => {
+		throw new Error("simulated Mermaid render failure");
+	},
+}));
+
+test("a Mermaid render failure preserves the fenced source", async () => {
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const menu = defineMenu<undefined, "review", "unused">({
+		start: "review",
+		screens: {
+			review: () => ({
+				kind: "review",
+				title: "Mermaid fallback",
+				content: "```mermaid\nflowchart LR\n A --> B\n```",
+				format: { kind: "markdown" },
+			}),
+		},
+		actions: { unused: async () => ({ kind: "close" }) },
+	});
+
+	const running = runMenu(context.ctx, menu, { getState: () => undefined });
+	await tui.waitForOpen();
+	const rendered = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(rendered, /```mermaid/u);
+	assert.match(rendered, /flowchart LR/u);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});

--- a/packages/pi-tui-kit/test/readme-usage.ts
+++ b/packages/pi-tui-kit/test/readme-usage.ts
@@ -92,6 +92,14 @@ const reviewChangesScreen: ReviewScreen<Action> = {
 };
 void reviewChangesScreen;
 
+const markdownScreen: ReviewScreen<Action> = {
+	kind: "review",
+	title: "Rendered document",
+	content: "# Formula\n\n$x^2$\n\n```mermaid\nflowchart LR\n A --> B\n```",
+	format: { kind: "markdown", renderLatex: true, renderMermaid: false },
+};
+void markdownScreen;
+
 const menu = defineMenu<State, Screen, Action>({
 	start: "main",
 	screens: {

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -6,6 +6,7 @@ import { test } from "vitest";
 import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
 import { createMenuScreenComponent } from "../src/components/index.js";
 import { defineMenu, type ReviewScreen, runMenu } from "../src/index.js";
+import { createTuiHarness } from "../src/testing/index.js";
 
 initTheme("dark", false);
 
@@ -234,6 +235,172 @@ test("review confirmation dispatches raw identity and exits remain Back versus C
 	const close = reviewComponentHarness(reviewScreen);
 	close.component.handleInput("\u0003");
 	assert.deepEqual(close.events, [{ kind: "close" }]);
+});
+
+test("review renders semantic Markdown, LaTeX, code, controls, and cache invalidation", () => {
+	const colorCalls: string[] = [];
+	const harness = reviewComponentHarness(
+		{
+			...reviewScreen,
+			content:
+				"# Formula\n\nInline $x^2 + y^2$.\n\n$$\\frac{a}{b}$$\n\n```ts\nconst answer = 42;\n```\nunsafe\u001b]8;;https://unsafe.example\u0007text\u202ereversed",
+			format: { kind: "markdown", renderMermaid: false },
+			viewportSize: 30,
+			confirm: undefined,
+		},
+		false,
+		40,
+		(color) => colorCalls.push(color),
+	);
+
+	for (const width of [8, 20, 40, 80]) {
+		const lines = harness.component.render(width);
+		assert.ok(
+			lines.every((line) => visibleWidth(line) <= width),
+			`width ${width}`,
+		);
+		assert.equal(lines.join("\n").includes("https://unsafe.example"), false);
+		assert.equal(lines.join("\n").includes("\u202e"), false);
+	}
+	const rendered = plainRender(harness.component, 80);
+	assert.match(rendered, /^Formula\s*$/mu);
+	assert.doesNotMatch(rendered, /^# Formula/mu);
+	assert.match(rendered, /Inline x² \+ y²\./u);
+	assert.match(rendered, /^a\s*\n─\s*\nb\s*$/mu);
+	assert.match(rendered, /const answer = 42;/u);
+	assert.match(rendered, /```ts/u);
+	assert.match(rendered, /unsafetextreversed/u);
+
+	const initialHeadingCalls = colorCalls.filter((color) => color === "mdHeading").length;
+	assert.ok(initialHeadingCalls > 0);
+	harness.component.handleInput("j");
+	harness.component.render(80);
+	assert.equal(colorCalls.filter((color) => color === "mdHeading").length, initialHeadingCalls);
+	const beforeInvalidation = colorCalls.filter((color) => color === "mdHeading").length;
+	harness.component.invalidate();
+	harness.component.render(80);
+	assert.ok(colorCalls.filter((color) => color === "mdHeading").length > beforeInvalidation);
+});
+
+test("review preserves disabled and malformed rich source", () => {
+	const disabled = reviewComponentHarness({
+		...reviewScreen,
+		content: "Disabled $x^2$\n\n```mermaid\nflowchart LR\n A --> B\n```",
+		format: { kind: "markdown", renderLatex: false, renderMermaid: false },
+		confirm: undefined,
+		viewportSize: 20,
+	});
+	const disabledRender = plainRender(disabled.component, 80);
+	assert.match(disabledRender, /Disabled \$x\^2\$/u);
+	assert.match(disabledRender, /flowchart LR/u);
+
+	const malformed = reviewComponentHarness({
+		...reviewScreen,
+		content: "Malformed $\\frac{a}{$",
+		format: { kind: "markdown", renderMermaid: false },
+		confirm: undefined,
+	});
+	assert.match(plainRender(malformed.component, 40), /Malformed \$\\frac\{a\}\{\$/u);
+});
+
+test("review renders fitting Mermaid art lazily and preserves mixed Markdown", async () => {
+	const colors: string[] = [];
+	const tui = createTuiHarness({
+		width: 120,
+		rows: 30,
+		theme: {
+			fg: (color, text) => {
+				colors.push(color);
+				return text;
+			},
+			bold: (text) => text,
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const menu = defineMenu<undefined, ScreenId, ActionId>({
+		start: "review",
+		screens: {
+			review: () => ({
+				kind: "review",
+				title: "Mermaid review",
+				content:
+					"Before diagram.\n\n~~~MerMaid\nflowchart LR\n A[plain ` tick] --> B[two `` ticks]\n C[unsafe\u001b]8;;https://unsafe.example\u0007text 你🙂wide]\n~~~\n\nAfter diagram.",
+				format: { kind: "markdown" },
+				viewportSize: "adaptive",
+			}),
+		},
+		actions: { apply: async () => ({ kind: "close" }) },
+	});
+
+	const running = runMenu(context.ctx, menu, { getState: () => undefined });
+	await tui.waitForOpen();
+	const narrow = stripVTControlCharacters(tui.resize({ width: 18 }).join("\n"));
+	assert.match(narrow, /flowchart/u);
+	assert.doesNotMatch(narrow, /https:\/\/unsafe\.example/u);
+	const wide = stripVTControlCharacters(tui.resize({ width: 120 }).join("\n"));
+	assert.match(wide, /Before diagram\./u);
+	assert.match(wide, /After diagram\./u);
+	assert.match(wide, /plain ` tick/u);
+	assert.match(wide, /two `` ticks/u);
+	assert.match(wide, /unsafetext/u);
+	assert.match(wide, /你🙂wide/u);
+	assert.match(wide, /[┌╭].*[┐╮]/u);
+	assert.doesNotMatch(wide, /flowchart LR/u);
+	assert.ok(colors.includes("borderMuted"));
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});
+
+test("review preserves Mermaid source and warns when a partial parse is not authoritative", async () => {
+	const tui = createTuiHarness({ width: 100, rows: 30 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const menu = defineMenu<undefined, ScreenId, ActionId>({
+		start: "review",
+		screens: {
+			review: () => ({
+				kind: "review",
+				title: "Mermaid fallbacks",
+				content:
+					"```mermaid\nflowchart LR\n A[Start --> B\n```\n\n```mermaid\npie\n title Unsupported\n```",
+				format: { kind: "markdown" },
+				viewportSize: "adaptive",
+			}),
+		},
+		actions: { apply: async () => ({ kind: "close" }) },
+	});
+
+	const running = runMenu(context.ctx, menu, { getState: () => undefined });
+	await tui.waitForOpen();
+	const rendered = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(rendered, /flowchart LR/u);
+	assert.match(rendered, /Mermaid diagram not rendered:/u);
+	assert.match(rendered, /pie/u);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});
+
+test("review Markdown reflows and clamps scrolling after width changes", () => {
+	const harness = reviewComponentHarness({
+		...reviewScreen,
+		content: [
+			"# Long document",
+			"",
+			"This paragraph contains enough words to wrap across several narrow terminal rows.",
+			"",
+			"Inline $x^2$ remains readable after resize.",
+		].join("\n"),
+		format: { kind: "markdown", renderMermaid: false },
+		viewportSize: 3,
+		confirm: undefined,
+	});
+	const wide = plainLines(harness.component, 80);
+	harness.component.handleInput("\u001b[F");
+	assert.match(plainRender(harness.component, 80), /x² remains readable/u);
+	const narrow = plainLines(harness.component, 18);
+	assert.ok(narrow.every((line) => visibleWidth(line) <= 18));
+	assert.notDeepEqual(narrow, wide);
+	harness.component.handleInput("\u001b[H");
+	assert.match(plainRender(harness.component, 18), /Long document/u);
 });
 
 test("review formats code and diffs through theme-aware display paths", () => {

--- a/packages/pi-tui-kit/test/runtime.test.ts
+++ b/packages/pi-tui-kit/test/runtime.test.ts
@@ -393,6 +393,104 @@ test("browse stays read-only across TUI detail navigation and RPC pagination", a
 	assert.equal(rpcCall, 4);
 });
 
+test("RPC review keeps Markdown, LaTeX, and Mermaid as bounded sanitized source", async () => {
+	let calls = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (title: string, choices: string[]) => {
+			calls += 1;
+			assert.match(title, /# Formula/u);
+			assert.match(title, /\$x\^2\$/u);
+			assert.match(title, /```mermaid[\s\S]*flowchart LR/u);
+			assert.doesNotMatch(title, /[┌╭].*[┐╮]/u);
+			assert.doesNotMatch(title, /https:\/\/unsafe\.example/u);
+			assert.equal(title.includes("\u001b"), false);
+			assert.match(title, /unsafetext/u);
+			assert.ok(title.split("\n").every((line) => line.length <= 120));
+			return choices.find((choice) => choice.startsWith("Back"));
+		},
+		custom: async () => {
+			throw new Error("RPC Markdown review must not open custom TUI");
+		},
+	});
+	const menu = defineMenu<undefined, "review", "unused">({
+		start: "review",
+		screens: {
+			review: () => ({
+				kind: "review",
+				title: "Formula",
+				content:
+					"# Formula\n\n$x^2$\n\n```mermaid\nflowchart LR\n A[unsafe\u001b]8;;https://unsafe.example\u0007text] --> B\n```",
+				format: { kind: "markdown" },
+			}),
+		},
+		actions: { unused: async () => ({ kind: "close" }) },
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+		kind: "closed",
+		reason: "back",
+	});
+	assert.equal(calls, 1);
+});
+
+test("RPC browse keeps Markdown source private until bounded detail pages", async () => {
+	let calls = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (title: string, choices: string[]) => {
+			calls += 1;
+			if (calls === 1) {
+				assert.deepEqual(choices, ["Guide", "Back"]);
+				assert.doesNotMatch(choices.join("\n"), /private-markdown|flowchart/u);
+				return "Guide";
+			}
+			if (calls === 2) {
+				assert.match(title, /private-markdown/u);
+				assert.match(title, /\$x\^2\$/u);
+				assert.match(title, /```mermaid[\s\S]*flowchart LR/u);
+				assert.doesNotMatch(title, /[┌╭].*[┐╮]/u);
+				assert.equal(title.includes("\u001b"), false);
+				assert.ok(title.split("\n").every((line) => line.length <= 120));
+				return choices.find((choice) => choice.startsWith("Back"));
+			}
+			return choices.find((choice) => choice.startsWith("Back"));
+		},
+		custom: async () => {
+			throw new Error("RPC Markdown browse must not open custom TUI");
+		},
+	});
+	const menu = defineMenu<undefined, "browse", "unused">({
+		start: "browse",
+		screens: {
+			browse: () => ({
+				kind: "browse",
+				title: "Guides",
+				items: [
+					{
+						id: "guide",
+						label: "Guide",
+						detailDocument: {
+							content: "private-markdown\n\n$x^2$\n\n```mermaid\nflowchart LR\n A --> B\n```",
+							format: { kind: "markdown" },
+						},
+					},
+				],
+				hint: "back",
+			}),
+		},
+		actions: { unused: async () => ({ kind: "close" }) },
+	});
+
+	assert.deepEqual(await runMenu(context.ctx, menu, { getState: () => undefined }), {
+		kind: "closed",
+		reason: "back",
+	});
+	assert.equal(calls, 3);
+});
+
 test("RPC browse exact details preserve documents, bounds, identity, and Back behavior", async () => {
 	const longLine = `${"x".repeat(120)}y`;
 	const items = [

--- a/packages/pi-tui-kit/test/testing-exports.test.ts
+++ b/packages/pi-tui-kit/test/testing-exports.test.ts
@@ -11,7 +11,7 @@ test("built package roots resolve separate production and testing exports", asyn
 	const testingSpecifier = "@narumitw/pi-tui-kit/testing";
 	const production = await import(productionSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 12);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 13);
 	assert.equal(typeof production.sanitizeTerminalText, "function");
 	assert.equal(typeof production.formatInteractionHints, "function");
 	assert.equal(typeof production.runConfirmation, "function");
@@ -27,10 +27,11 @@ test("built package roots resolve separate production and testing exports", asyn
 	t.onTestFinished(() => rmSync(fixture, { recursive: true, force: true }));
 	writeFileSync(
 		path.join(fixture, "usage.ts"),
-		`import { PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type ChoiceScreen, type LiveChoiceItem, type MenuBrowseItem } from "@narumitw/pi-tui-kit";\n` +
+		`import { PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type ChoiceScreen, type LiveChoiceItem, type MenuBrowseItem, type ReviewFormat } from "@narumitw/pi-tui-kit";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 12 = PI_EXTENSION_MENU_API_VERSION;\n` +
-			`const document: BrowseDetailDocument = { content: "  exact", format: { kind: "text" } };\n` +
+			`const version: 13 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const markdown: ReviewFormat = { kind: "markdown", renderLatex: false, renderMermaid: true };\n` +
+			`const document: BrowseDetailDocument = { content: "# Formula\\n\\n$x^2$", format: markdown };\n` +
 			`const item: MenuBrowseItem = { id: "one", label: "One", detailDocument: document };\n` +
 			`const choice: LiveChoiceItem = { id: "active", label: "Active", confirmationDisabled: true, confirmationDisabledReason: "Already active" };\n` +
 			`const screen: ChoiceScreen<"select"> = { kind: "choice", title: "Records", enableSearch: true, items: [{ id: "one", label: "One", searchText: "alias" }], action: "select" };\n` +

--- a/scripts/benchmark-tui-kit-runtime.mjs
+++ b/scripts/benchmark-tui-kit-runtime.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const DEFAULT_RUNS = 5;
 const DEFAULT_TIMEOUT_MS = 30_000;
-const SCENARIOS = ["import", "actions", "review", "task"];
+const SCENARIOS = ["import", "actions", "review", "mermaid", "task"];
 
 const options = parseArguments(process.argv.slice(2));
 if (options.worker) {
@@ -35,6 +35,9 @@ if (options.worker) {
 						.filter((value) => value !== undefined),
 				),
 				codingAgentLoaded: measurements[scenario].some((result) => result.codingAgentLoaded),
+				mermaidRendererLoaded: measurements[scenario].some(
+					(result) => result.mermaidRendererLoaded,
+				),
 			},
 		]),
 	);
@@ -94,6 +97,14 @@ async function runWorker(scenario) {
 			format: { kind: "code", filePath: "benchmark.ts" },
 			hint: "close",
 		});
+	} else if (scenario === "mermaid") {
+		firstFrameMs = await runMenuFrame(kit, startedAt, {
+			kind: "review",
+			title: "Benchmark Mermaid",
+			content: "```mermaid\nflowchart LR\n A[Start] --> B[Done]\n```",
+			format: { kind: "markdown" },
+			hint: "close",
+		});
 	} else if (scenario === "task") {
 		const context = benchmarkContext(
 			(elapsed) => {
@@ -124,6 +135,7 @@ async function runWorker(scenario) {
 			codingAgentLoaded: packageUrls.some((url) =>
 				url.includes("/@earendil-works/pi-coding-agent/"),
 			),
+			mermaidRendererLoaded: packageUrls.some((url) => url.includes("/grok-mermaid/")),
 			packageUrls,
 		})}\n`,
 	);


### PR DESCRIPTION
## Summary

- add opt-in Markdown document formatting for review screens and browse details
- render supported LaTeX through Pi TUI and lazy-load width-aware Unicode Mermaid rendering
- preserve sanitized RPC source, existing text/code/diff behavior, and older Pi host fallback
- add a minor Changeset and API compatibility marker 13

## Verification

- `npm run check` — 352 test files and 3,475 tests passed
- `npm exec -- vitest run packages/pi-tui-kit/test/*.test.ts` — 21 files and 197 tests passed
- `npm run check:boundaries` — passed
- `npm run changeset:status` — selects `@narumitw/pi-tui-kit` 0.55.0
- `just pack tui-kit` — 63 expected files with ESM, declarations, README, license, and manifest
- temporary packed install with Pi 0.83.0 — existing formats worked and rich elements degraded to readable source
- five-run benchmark — existing paths did not load Grok or the coding-agent runtime; Mermaid loaded Grok only on demand

## Risks and unverified paths

- No manual interactive TUI smoke was run under the non-interactive execution policy.
- Deterministic tests use Pi's real Markdown component and Kit TUI/RPC harnesses, including resize, sanitization, stale loading, and load/render failure paths.
- Changesets reports existing consumer-floor notices; this pull request intentionally changes no consumer range and publishes nothing.

## Plan

- [Completed implementation plan](https://github.com/narumiruna/pi-extensions/blob/narumi/feat/tui-kit-latex-mermaid/docs/plans/archived/2026-08-17_pi-tui-kit-latex-mermaid-plan.md)