### PR TITLE
perf: reduce tui kit helper import cost

### DIFF
--- a/.changeset/fast-tui-kit-consumers.md
+++ b/.changeset/fast-tui-kit-consumers.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-starship": patch
+"@narumitw/pi-statusline": patch
+"@narumitw/pi-recall": patch
+---
+
+Load lightweight Pi TUI Kit helpers without evaluating the full menu runtime during extension startup.

--- a/packages/pi-recall/src/picker.ts
+++ b/packages/pi-recall/src/picker.ts
@@ -10,7 +10,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
-import { formatInteractionHints } from "@narumitw/pi-tui-kit";
+import { formatInteractionHints } from "@narumitw/pi-tui-kit/interaction-hints";
 import {
 	filterRecallMessages,
 	messagePreview,

--- a/packages/pi-starship/src/modules/directory.ts
+++ b/packages/pi-starship/src/modules/directory.ts
@@ -1,5 +1,5 @@
 import { basename, isAbsolute, relative, sep } from "node:path";
-import { sanitizeTerminalText } from "@narumitw/pi-tui-kit";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import {
 	graphemes,
 	toSlashPath,

--- a/packages/pi-starship/src/modules/model.ts
+++ b/packages/pi-starship/src/modules/model.ts
@@ -1,4 +1,4 @@
-import { sanitizeTerminalText } from "@narumitw/pi-tui-kit";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import { defineModule } from "./types.js";
 
 const TRUNCATION_DIRECTIONS = ["start", "middle", "end"] as const;

--- a/packages/pi-statusline/src/directory.ts
+++ b/packages/pi-statusline/src/directory.ts
@@ -1,5 +1,5 @@
 import { basename, isAbsolute, relative, sep } from "node:path";
-import { sanitizeTerminalText } from "@narumitw/pi-tui-kit";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 
 const DEFAULT_TRUNCATION_LENGTH = 3;
 const DEFAULT_HOME_SYMBOL = "~";

--- a/packages/pi-statusline/src/render.ts
+++ b/packages/pi-statusline/src/render.ts
@@ -5,7 +5,7 @@ import type {
 	Theme,
 	ThemeColor,
 } from "@earendil-works/pi-coding-agent";
-import { sanitizeTerminalText } from "@narumitw/pi-tui-kit";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import { formatDirectoryPath } from "./directory.js";
 import {
 	type ExtensionStatusRuntime,


### PR DESCRIPTION
## Summary

- load `sanitizeTerminalText` through the published `/terminal-text` subpath in Pi Starship and Pi Statusline
- load `formatInteractionHints` through `/interaction-hints` in Pi Recall
- preserve type-only and dynamically loaded full Kit root imports, with patch Changesets for all three consumers

## Performance

Five fresh Pi-loader runs before and after the migration produced these medians:

- Pi Starship: `419ms` → `326ms`
- Pi Statusline: `204ms` → `131ms`
- Pi Recall: `114ms` → `40ms`

## Verification

- confirmed npm `@narumitw/pi-tui-kit@0.56.0` exports and registry tarball contents
- rebuilt Pi TUI Kit and typechecked all three consumers
- `npx vitest run packages/pi-starship/test packages/pi-statusline/test packages/pi-recall/test` (`31` files, `372` tests)
- `just pack starship`, `just pack statusline`, and `just pack recall`
- `npm run check` (`354` files, `3,483` tests)

## Risks and unverified paths

- Sanitizer and hint behavior is unchanged; only package resolution paths changed.
- Existing lazy menu/command imports remain on the Kit root.
- No settings, lifecycle, state, publication, tag, or release workflow changed.
- No required verification path remains unverified.
