### PR TITLE
feat(plan-mode): add configurable global shortcut to toggle Plan mode

### DIFF
--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -168,10 +168,8 @@ Open **Settings** from an inactive `/plan` menu to edit one flat group of five w
 You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually.
 `safeSubcommands` remains JSON-only.
 You can change the Plan-mode shortcut with `toggleShortcut` as long as the file remains JSON-only and uses a valid key string.
-The file is optional, is read at session start, and is created only after an explicit Settings save or manual edit.
+The file is optional, is read at session start and reloaded automatically when changed, and is created only after an explicit Settings save or manual edit.
 When omitted, the shortcut is disabled by default.
-A recommended value is `ctrl+alt+p`.
-
 ```json
 {
   "thinkingLevel": "inherit",
@@ -182,7 +180,7 @@ A recommended value is `ctrl+alt+p`.
     "git": ["status", "log", "rev-parse", "blame"],
     "gh": ["pr view", "pr list", "issue view", "issue list"]
   },
-  "toggleShortcut": "ctrl+alt+p"
+  "toggleShortcut": "<your_key>"
 }
 ```
 
@@ -210,7 +208,7 @@ The existing no-overwrite, cancellation, and atomic Plan-state behavior is uncha
 
 `toggleShortcut` controls the global Plan-mode keybinding used by the TUI shortcut.
 Omit this setting to keep the shortcut disabled.
-Set `toggleShortcut` to the key string you want, such as `ctrl+alt+p` (recommended) or `ctrl+shift+p`.
+Set `toggleShortcut` to the key string you want.
 Avoid values that conflict with editor shortcuts.
 
 ### Safe shell subcommands

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -164,7 +164,13 @@ You can also exit directly. Before implementation, direct exit discards the late
 
 ## ⚙️ Settings
 
-Open **Settings** from an inactive `/plan` menu to edit one flat group of four workflow choices: **Plan thinking**, **Plan tools**, **After Implement**, and **Export destination**. You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually; `safeSubcommands` remains JSON-only. The file is optional, is read at session start, and is created only after an explicit Settings save or manual edit.
+Open **Settings** from an inactive `/plan` menu to edit one flat group of five workflow choices: **Plan thinking**, **Plan tools**, **After Implement**, **Export destination**, and **Plan mode shortcut**.
+You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually.
+`safeSubcommands` remains JSON-only.
+You can change the Plan-mode shortcut with `toggleShortcut` as long as the file remains JSON-only and uses a valid key string.
+The file is optional, is read at session start, and is created only after an explicit Settings save or manual edit.
+When omitted, the shortcut is disabled by default.
+A recommended value is `ctrl+alt+p`.
 
 ```json
 {
@@ -175,7 +181,8 @@ Open **Settings** from an inactive `/plan` menu to edit one flat group of four w
   "safeSubcommands": {
     "git": ["status", "log", "rev-parse", "blame"],
     "gh": ["pr view", "pr list", "issue view", "issue list"]
-  }
+  },
+  "toggleShortcut": "ctrl+alt+p"
 }
 ```
 
@@ -198,6 +205,13 @@ Changing this setting applies to the next Implement action only. Each active imp
 `defaultPlanExportPath` controls only exports that omit a path. Omit it—or submit an empty value in Settings—to use `PLAN.md`. The value must be a non-empty string of at most 4,096 characters without terminal control characters or NUL. Relative values are resolved against the current working directory at export time; the Settings detail and every export input preview the concrete resolved destination. An explicit `/plan export <path>` is a one-off override and does not edit Settings. Saving a new destination affects the next export immediately, including export of a currently active implementation.
 
 The existing no-overwrite, cancellation, and atomic Plan-state behavior is unchanged. A failed save rolls the row back to its previous value; a failed or cancelled export preserves the plan and target. Long previews wrap or truncate to the available terminal width without changing the raw path used by the action.
+
+### Toggle shortcut
+
+`toggleShortcut` controls the global Plan-mode keybinding used by the TUI shortcut.
+Omit this setting to keep the shortcut disabled.
+Set `toggleShortcut` to the key string you want, such as `ctrl+alt+p` (recommended) or `ctrl+shift+p`.
+Avoid values that conflict with editor shortcuts.
 
 ### Safe shell subcommands
 

--- a/packages/pi-plan-mode/src/plan-launch-menu.ts
+++ b/packages/pi-plan-mode/src/plan-launch-menu.ts
@@ -20,6 +20,13 @@ interface PlanLaunchMenuOptions {
 	start(signal: AbortSignal): void;
 	startWithTools(toolNames: string[], signal: AbortSignal): void;
 	settings(signal: AbortSignal): Promise<boolean>;
+	/** Enable Tab as an additional confirm shortcut on the launch menu. */
+	useTabConfirmShortcut?: boolean;
+}
+
+interface MenuKeybindings {
+	matches(data: string, binding: string): boolean;
+	getKeys(binding: string): readonly string[];
 }
 
 export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLaunchMenuOptions) {
@@ -114,9 +121,51 @@ export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLau
 			},
 		},
 	});
-	await runMenu(ctx, menu, {
+	const launchMenuContext = options.useTabConfirmShortcut ? createTabConfirmContext(ctx) : ctx;
+	await runMenu(launchMenuContext, menu, {
 		getState: () => undefined,
 		signal: options.signal,
 		isCurrent: options.isCurrent,
 	});
+}
+
+function createTabConfirmContext(ctx: ExtensionContext): ExtensionContext {
+	const custom = ctx.ui.custom;
+	return {
+		...ctx,
+		ui: {
+			...ctx.ui,
+			custom: (factory: unknown, options: unknown) => {
+				const factoryWrapper = ((
+					tui: unknown,
+					theme: unknown,
+					keybindings: MenuKeybindings,
+					done: (value: unknown) => void,
+				) =>
+					(factory as (...args: unknown[]) => unknown)(
+						tui,
+						theme,
+						createTabAsConfirmBindings(keybindings),
+						done,
+					)) as never;
+				return custom(factoryWrapper, options as never);
+			},
+		},
+	} as ExtensionContext;
+}
+
+function createTabAsConfirmBindings(base: MenuKeybindings): MenuKeybindings {
+	return {
+		matches(data: string, binding: string) {
+			if (binding === "tui.select.confirm") {
+				return data === "\t" || base.matches(data, binding);
+			}
+			return base.matches(data, binding);
+		},
+		getKeys(binding: string): readonly string[] {
+			const keys = base.getKeys(binding);
+			if (binding !== "tui.select.confirm" || keys.includes("tab")) return keys;
+			return ["tab", ...keys];
+		},
+	};
 }

--- a/packages/pi-plan-mode/src/plan-launch-menu.ts
+++ b/packages/pi-plan-mode/src/plan-launch-menu.ts
@@ -20,13 +20,6 @@ interface PlanLaunchMenuOptions {
 	start(signal: AbortSignal): void;
 	startWithTools(toolNames: string[], signal: AbortSignal): void;
 	settings(signal: AbortSignal): Promise<boolean>;
-	/** Enable Tab as an additional confirm shortcut on the launch menu. */
-	useTabConfirmShortcut?: boolean;
-}
-
-interface MenuKeybindings {
-	matches(data: string, binding: string): boolean;
-	getKeys(binding: string): readonly string[];
 }
 
 export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLaunchMenuOptions) {
@@ -121,51 +114,9 @@ export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLau
 			},
 		},
 	});
-	const launchMenuContext = options.useTabConfirmShortcut ? createTabConfirmContext(ctx) : ctx;
-	await runMenu(launchMenuContext, menu, {
+	await runMenu(ctx, menu, {
 		getState: () => undefined,
 		signal: options.signal,
 		isCurrent: options.isCurrent,
 	});
-}
-
-function createTabConfirmContext(ctx: ExtensionContext): ExtensionContext {
-	const custom = ctx.ui.custom;
-	return {
-		...ctx,
-		ui: {
-			...ctx.ui,
-			custom: (factory: unknown, options: unknown) => {
-				const factoryWrapper = ((
-					tui: unknown,
-					theme: unknown,
-					keybindings: MenuKeybindings,
-					done: (value: unknown) => void,
-				) =>
-					(factory as (...args: unknown[]) => unknown)(
-						tui,
-						theme,
-						createTabAsConfirmBindings(keybindings),
-						done,
-					)) as never;
-				return custom(factoryWrapper, options as never);
-			},
-		},
-	} as ExtensionContext;
-}
-
-function createTabAsConfirmBindings(base: MenuKeybindings): MenuKeybindings {
-	return {
-		matches(data: string, binding: string) {
-			if (binding === "tui.select.confirm") {
-				return data === "\t" || base.matches(data, binding);
-			}
-			return base.matches(data, binding);
-		},
-		getKeys(binding: string): readonly string[] {
-			const keys = base.getKeys(binding);
-			if (binding !== "tui.select.confirm" || keys.includes("tab")) return keys;
-			return ["tab", ...keys];
-		},
-	};
 }

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -740,6 +740,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		await ui.showPlanLaunchMenu(ctx, {
 			statusText: "Status: Off — normal tools are active.",
 			initialScreen,
+			useTabConfirmShortcut: initialScreen === "main",
 			getSelectedNames: () => snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot()),
 			toolSummary: (selectedNames) =>
 				`When started: ${snapshotPlanModeToolNames(tools, selectedNames, toolSelectionSnapshot()).join(", ")}`,

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -309,6 +309,13 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		},
 	});
 
+	pi.registerShortcut("ctrl+n", {
+		description: "Toggle Plan mode",
+		handler: (ctx) => {
+			togglePlanMode(ctx);
+		},
+	});
+
 	pi.on("session_start", async (event, ctx) => {
 		const generation = ++menuGeneration;
 		refreshStateBeforeFirstAgentStart = event.reason === "new";
@@ -607,6 +614,24 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	function readyPresentationIsCurrent(intent: ReadyPresentationIntent) {
 		return completedPlanIsCurrent(intent) && readyPresentationIntent?.nonce === intent.nonce;
+	}
+
+	function togglePlanMode(ctx: ExtensionContext) {
+		if (state.enabled) {
+			const notification = state.activeImplementation
+				? "Active implementation plan cleared."
+				: state.savedPlan
+					? "Saved plan cleared."
+					: state.latestPlan
+						? "Plan mode disabled. Proposed plan discarded."
+						: "Plan mode disabled.";
+			exitPlanMode(ctx);
+			ctx.ui.notify(notification, "info");
+			return;
+		}
+		if (savedPlanBlocksNewWorkflow(ctx, state.savedPlan !== undefined && !state.enabled)) return;
+		enterPlanMode(ctx);
+		ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
 	}
 
 	function requestFinalPlan(ctx: ExtensionContext) {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -258,15 +258,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				return;
 			}
 			if (command === "exit" || command === "off") {
-				const notification = state.activeImplementation
-					? "Active implementation plan cleared."
-					: state.savedPlan
-						? "Saved plan cleared."
-						: state.latestPlan
-							? "Plan mode disabled. Proposed plan discarded."
-							: "Plan mode disabled.";
+				ctx.ui.notify(planModeDisableNotification(), "info");
 				exitPlanMode(ctx);
-				ctx.ui.notify(notification, "info");
 				return;
 			}
 			if (command === "tools") {
@@ -642,20 +635,23 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	function togglePlanMode(ctx: ExtensionContext) {
 		if (state.enabled) {
-			const notification = state.activeImplementation
-				? "Active implementation plan cleared."
-				: state.savedPlan
-					? "Saved plan cleared."
-					: state.latestPlan
-						? "Plan mode disabled. Proposed plan discarded."
-						: "Plan mode disabled.";
+			ctx.ui.notify(planModeDisableNotification(), "info");
 			exitPlanMode(ctx);
-			ctx.ui.notify(notification, "info");
 			return;
 		}
-		if (savedPlanBlocksNewWorkflow(ctx, state.savedPlan !== undefined && !state.enabled)) return;
+		if (savedPlanBlocksNewWorkflow(ctx, state.savedPlan !== undefined)) return;
 		enterPlanMode(ctx);
 		ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+	}
+
+	function planModeDisableNotification() {
+		return state.activeImplementation
+			? "Active implementation plan cleared."
+			: state.savedPlan
+				? "Saved plan cleared."
+				: state.latestPlan
+					? "Plan mode disabled. Proposed plan discarded."
+					: "Plan mode disabled.";
 	}
 
 	function requestFinalPlan(ctx: ExtensionContext) {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -309,7 +309,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		},
 	});
 
-	pi.registerShortcut("ctrl+n", {
+	pi.registerShortcut("ctrl+alt+p", {
 		description: "Toggle Plan mode",
 		handler: (ctx) => {
 			togglePlanMode(ctx);

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -101,6 +101,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let state: PlanModeState = { enabled: false, awaitingAction: false };
 	let settings: PlanModeSettings = { thinkingLevel: "inherit" };
 	let toggleShortcut: ReturnType<typeof configuredPlanModeToggleShortcut>;
+	const clearPlanModeShortcutHandler = () => {};
 	let previousTools: string[] | undefined;
 	let readyPresentationIntent: ReadyPresentationIntent | undefined;
 	let latestCommandContext: ExtensionCommandContext | undefined;
@@ -311,14 +312,27 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		},
 	});
 
-	const registerPlanModeShortcut = () => {
-		if (!toggleShortcut) return;
-		pi.registerShortcut(toggleShortcut, {
+	const applyPlanModeShortcut = (
+		nextShortcut: ReturnType<typeof configuredPlanModeToggleShortcut>,
+	) => {
+		if (toggleShortcut && toggleShortcut !== nextShortcut) {
+			pi.registerShortcut(toggleShortcut, {
+				description: "Plan mode shortcut cleared",
+				handler: clearPlanModeShortcutHandler,
+			});
+		}
+		if (!nextShortcut) {
+			toggleShortcut = undefined;
+			return;
+		}
+		if (toggleShortcut === nextShortcut) return;
+		pi.registerShortcut(nextShortcut, {
 			description: "Toggle Plan mode",
 			handler: (ctx) => {
 				togglePlanMode(ctx);
 			},
 		});
+		toggleShortcut = nextShortcut;
 	};
 
 	pi.on("session_start", async (event, ctx) => {
@@ -336,15 +350,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (generation !== menuGeneration || menuController.signal.aborted) return;
 		if (loadedSettings.kind === "loaded") {
 			settings = loadedSettings.settings;
-			toggleShortcut = configuredPlanModeToggleShortcut(loadedSettings.settings);
+			applyPlanModeShortcut(configuredPlanModeToggleShortcut(loadedSettings.settings));
 		} else {
-			toggleShortcut = undefined;
+			applyPlanModeShortcut(undefined);
 			if (loadedSettings.kind === "invalid") {
 				ctx.ui.notify(`pi-plan-mode settings ignored: ${loadedSettings.reason}`, "warning");
 			}
 		}
 		if (loadedSettings.notice) ctx.ui.notify(loadedSettings.notice, "warning");
-		registerPlanModeShortcut();
 		const persistFlagActivation = pi.getFlag("plan") === true && !state.enabled;
 		if (persistFlagActivation) {
 			state = state.savedPlan
@@ -853,7 +866,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			isCurrent,
 			settingsPath: dependencies.settingsPath,
 			onSaved: (saved) => {
-				if (isCurrent()) settings = saved;
+				if (!isCurrent()) return;
+				settings = saved;
+				applyPlanModeShortcut(configuredPlanModeToggleShortcut(saved));
 			},
 			...(dependencies.readSettings
 				? { readSettings: async () => dependencies.readSettings?.() ?? { kind: "missing" } }

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { watch } from "node:fs";
+import { basename, dirname } from "node:path";
 import type {
 	ExtensionAPI,
 	ExtensionCommandContext,
@@ -53,6 +55,7 @@ import {
 	configuredPlanModeToggleShortcut,
 	configuredThinkingLevel,
 	type PlanModeSettings,
+	planModeSettingsPath,
 	readPlanModeSettings,
 } from "./settings.js";
 import { type PlanCompletionSource, type PlanModeState, restorePlanModeState } from "./state.js";
@@ -98,6 +101,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 		return interactiveUiPromise;
 	};
+	const explicitPlanModeSettingsPath = dependencies.settingsPath;
 	let state: PlanModeState = { enabled: false, awaitingAction: false };
 	let settings: PlanModeSettings = { thinkingLevel: "inherit" };
 	let toggleShortcut: ReturnType<typeof configuredPlanModeToggleShortcut>;
@@ -110,6 +114,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let workflowGeneration = 0;
 	let refreshStateBeforeFirstAgentStart = false;
 	let menuController = new AbortController();
+	let settingsWatch: ReturnType<typeof watch> | undefined;
+	let settingsReloadTimer: ReturnType<typeof setTimeout> | undefined;
 	const implementationRetention = createImplementationRetentionCoordinator();
 	const persistState = () => pi.appendEntry<PlanModeState>(STATE_ENTRY_TYPE, state);
 	const planExports = createPlanExportController({
@@ -310,7 +316,6 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	) => {
 		if (toggleShortcut && toggleShortcut !== nextShortcut) {
 			pi.registerShortcut(toggleShortcut, {
-				description: "Plan mode shortcut cleared",
 				handler: clearPlanModeShortcutHandler,
 			});
 		}
@@ -328,6 +333,76 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		toggleShortcut = nextShortcut;
 	};
 
+	const readPlanModeRuntimeSettings = async () => {
+		return dependencies.readSettings?.() ?? readPlanModeSettings(explicitPlanModeSettingsPath);
+	};
+
+	const applyPlanModeSettings = async (
+		generation: number,
+		ctx: ExtensionContext | undefined,
+		showWarnings: boolean,
+	) => {
+		const loadedSettings = await readPlanModeRuntimeSettings();
+		if (generation !== menuGeneration || menuController.signal.aborted) {
+			return undefined;
+		}
+		if (loadedSettings.kind === "loaded") {
+			settings = loadedSettings.settings;
+		} else {
+			settings = { thinkingLevel: "inherit" };
+		}
+		applyPlanModeShortcut(configuredPlanModeToggleShortcut(settings));
+		if (!ctx || !showWarnings) return loadedSettings;
+		if (loadedSettings.kind === "invalid") {
+			ctx.ui.notify(`pi-plan-mode settings ignored: ${loadedSettings.reason}`, "warning");
+		}
+		if (loadedSettings.notice) {
+			ctx.ui.notify(loadedSettings.notice, "warning");
+		}
+		return loadedSettings;
+	};
+
+	const stopPlanModeSettingsWatch = () => {
+		if (settingsReloadTimer) {
+			clearTimeout(settingsReloadTimer);
+			settingsReloadTimer = undefined;
+		}
+		settingsWatch?.close();
+		settingsWatch = undefined;
+	};
+
+	const schedulePlanModeSettingsReload = (generation: number) => {
+		if (settingsReloadTimer) {
+			clearTimeout(settingsReloadTimer);
+			settingsReloadTimer = undefined;
+		}
+		settingsReloadTimer = setTimeout(() => {
+			settingsReloadTimer = undefined;
+			void applyPlanModeSettings(generation, undefined, false);
+		}, 75);
+	};
+
+	const startPlanModeSettingsWatch = (generation: number) => {
+		stopPlanModeSettingsWatch();
+		if (dependencies.readSettings) return;
+		const pathToWatch = explicitPlanModeSettingsPath ?? planModeSettingsPath();
+		try {
+			const directory = dirname(pathToWatch);
+			const fileName = basename(pathToWatch);
+			const watcher = watch(directory, { persistent: false }, (event, changedFile) => {
+				if (event !== "rename" && event !== "change") return;
+				if (!changedFile || changedFile.toString() !== fileName) return;
+				schedulePlanModeSettingsReload(generation);
+			});
+			watcher.on("error", () => {
+				stopPlanModeSettingsWatch();
+			});
+			settingsWatch = watcher;
+		} catch {
+			stopPlanModeSettingsWatch();
+		}
+	};
+
 	pi.on("session_start", async (event, ctx) => {
 		const generation = ++menuGeneration;
 		refreshStateBeforeFirstAgentStart = event.reason === "new";
@@ -339,18 +414,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		settings = { thinkingLevel: "inherit" };
 		restoreState(ctx);
 		implementationRetention.restore(state.activeImplementation);
-		const loadedSettings = await (dependencies.readSettings?.() ?? readPlanModeSettings());
+		await applyPlanModeSettings(generation, ctx, true);
 		if (generation !== menuGeneration || menuController.signal.aborted) return;
-		if (loadedSettings.kind === "loaded") {
-			settings = loadedSettings.settings;
-			applyPlanModeShortcut(configuredPlanModeToggleShortcut(loadedSettings.settings));
-		} else {
-			applyPlanModeShortcut(undefined);
-			if (loadedSettings.kind === "invalid") {
-				ctx.ui.notify(`pi-plan-mode settings ignored: ${loadedSettings.reason}`, "warning");
-			}
-		}
-		if (loadedSettings.notice) ctx.ui.notify(loadedSettings.notice, "warning");
+		startPlanModeSettingsWatch(generation);
 		const persistFlagActivation = pi.getFlag("plan") === true && !state.enabled;
 		if (persistFlagActivation) {
 			state = state.savedPlan
@@ -400,6 +466,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			restoreTools();
 			restoreThinkingLevel();
 		}
+		stopPlanModeSettingsWatch();
 		clearUi(ctx);
 	});
 

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -765,7 +765,6 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		await ui.showPlanLaunchMenu(ctx, {
 			statusText: "Status: Off — normal tools are active.",
 			initialScreen,
-			useTabConfirmShortcut: initialScreen === "main",
 			getSelectedNames: () => snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot()),
 			toolSummary: (selectedNames) =>
 				`When started: ${snapshotPlanModeToolNames(tools, selectedNames, toolSelectionSnapshot()).join(", ")}`,

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -50,6 +50,7 @@ import {
 import {
 	awaitPlanModeSettingsWrites,
 	configuredImplementationPlanRetention,
+	configuredPlanModeToggleShortcut,
 	configuredThinkingLevel,
 	type PlanModeSettings,
 	readPlanModeSettings,
@@ -99,6 +100,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	};
 	let state: PlanModeState = { enabled: false, awaitingAction: false };
 	let settings: PlanModeSettings = { thinkingLevel: "inherit" };
+	let toggleShortcut: ReturnType<typeof configuredPlanModeToggleShortcut>;
 	let previousTools: string[] | undefined;
 	let readyPresentationIntent: ReadyPresentationIntent | undefined;
 	let latestCommandContext: ExtensionCommandContext | undefined;
@@ -309,12 +311,15 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		},
 	});
 
-	pi.registerShortcut("ctrl+alt+p", {
-		description: "Toggle Plan mode",
-		handler: (ctx) => {
-			togglePlanMode(ctx);
-		},
-	});
+	const registerPlanModeShortcut = () => {
+		if (!toggleShortcut) return;
+		pi.registerShortcut(toggleShortcut, {
+			description: "Toggle Plan mode",
+			handler: (ctx) => {
+				togglePlanMode(ctx);
+			},
+		});
+	};
 
 	pi.on("session_start", async (event, ctx) => {
 		const generation = ++menuGeneration;
@@ -329,11 +334,17 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		implementationRetention.restore(state.activeImplementation);
 		const loadedSettings = await (dependencies.readSettings?.() ?? readPlanModeSettings());
 		if (generation !== menuGeneration || menuController.signal.aborted) return;
-		if (loadedSettings.kind === "loaded") settings = loadedSettings.settings;
-		else if (loadedSettings.kind === "invalid") {
-			ctx.ui.notify(`pi-plan-mode settings ignored: ${loadedSettings.reason}`, "warning");
+		if (loadedSettings.kind === "loaded") {
+			settings = loadedSettings.settings;
+			toggleShortcut = configuredPlanModeToggleShortcut(loadedSettings.settings);
+		} else {
+			toggleShortcut = undefined;
+			if (loadedSettings.kind === "invalid") {
+				ctx.ui.notify(`pi-plan-mode settings ignored: ${loadedSettings.reason}`, "warning");
+			}
 		}
 		if (loadedSettings.notice) ctx.ui.notify(loadedSettings.notice, "warning");
+		registerPlanModeShortcut();
 		const persistFlagActivation = pi.getFlag("plan") === true && !state.enabled;
 		if (persistFlagActivation) {
 			state = state.savedPlan

--- a/packages/pi-plan-mode/src/settings-menu.ts
+++ b/packages/pi-plan-mode/src/settings-menu.ts
@@ -7,6 +7,7 @@ import { PLAN_MODE_QUESTION_TOOL_NAME } from "./question-tool.js";
 import {
 	configuredImplementationPlanRetention,
 	configuredPlanExportPath,
+	configuredPlanModeToggleShortcut,
 	IMPLEMENTATION_PLAN_RETENTIONS,
 	PLAN_MODE_THINKING_LEVELS,
 	type PlanModeSettings,
@@ -41,7 +42,7 @@ export interface PlanModeSettingsMenuOptions {
 	onSaved(settings: PlanModeSettings): void;
 }
 
-type Screen = "settings" | "tools" | "export";
+type Screen = "settings" | "tools" | "export" | "shortcut";
 type Action =
 	| "set-thinking"
 	| "open-tools"
@@ -49,7 +50,9 @@ type Action =
 	| "reset-tools"
 	| "set-retention"
 	| "open-export"
-	| "set-export";
+	| "set-export"
+	| "open-shortcut"
+	| "set-shortcut";
 
 export async function showPlanModeSettings(
 	ctx: ExtensionContext,
@@ -124,6 +127,13 @@ export async function showPlanModeSettings(
 									currentValue: safeTerminalText(configuredPlanExportPath(state.settings)),
 									action: "open-export",
 								},
+								{
+									id: "toggleShortcut",
+									label: "Plan mode shortcut",
+									description: "Set the global shortcut used to toggle Plan mode.",
+									currentValue: configuredPlanModeToggleShortcut(state.settings) ?? "none",
+									action: "open-shortcut",
+								},
 							],
 						},
 			tools: ({ state }) => ({
@@ -162,6 +172,20 @@ export async function showPlanModeSettings(
 					hint: "back",
 				};
 			},
+			shortcut: ({ state }) => ({
+				kind: "input",
+				title: "Plan mode shortcut",
+				lines: [
+					`Configured: ${configuredPlanModeToggleShortcut(state.settings) ?? "none"}`,
+					"Use Pi key identifiers such as ctrl+shift+p.",
+					"Submit an empty value to clear the shortcut.",
+					"When unset, Plan mode has no global shortcut.",
+					"Recommended value: ctrl+alt+p",
+				],
+				placeholder: configuredPlanModeToggleShortcut(state.settings) ?? "",
+				action: "set-shortcut",
+				hint: "back",
+			}),
 		},
 		actions: {
 			"set-thinking": async ({ ctx: actionCtx, value, signal }) => {
@@ -198,6 +222,19 @@ export async function showPlanModeSettings(
 					defaultPlanExportPath
 						? `Default Plan export destination: ${safeTerminalText(defaultPlanExportPath)}.`
 						: "Default Plan export destination reset to PLAN.md.",
+				);
+				return result.kind === "stay" ? { kind: "to", screen: "settings" } : result;
+			},
+			"open-shortcut": async () => ({ kind: "to", screen: "shortcut" }),
+			"set-shortcut": async ({ ctx: actionCtx, value, signal }) => {
+				const toggleShortcut = (value?.trim() || null) as PlanModeSettingsPatch["toggleShortcut"];
+				const result = await savePatch(
+					actionCtx,
+					{ toggleShortcut },
+					signal,
+					toggleShortcut
+						? `Plan mode shortcut: ${safeTerminalText(toggleShortcut)}.`
+						: "Plan mode shortcut cleared (no global shortcut).",
 				);
 				return result.kind === "stay" ? { kind: "to", screen: "settings" } : result;
 			},

--- a/packages/pi-plan-mode/src/settings-menu.ts
+++ b/packages/pi-plan-mode/src/settings-menu.ts
@@ -9,6 +9,7 @@ import {
 	configuredPlanExportPath,
 	configuredPlanModeToggleShortcut,
 	IMPLEMENTATION_PLAN_RETENTIONS,
+	normalizeKeyId,
 	PLAN_MODE_THINKING_LEVELS,
 	type PlanModeSettings,
 	type PlanModeSettingsLoadResult,
@@ -177,10 +178,9 @@ export async function showPlanModeSettings(
 				title: "Plan mode shortcut",
 				lines: [
 					`Configured: ${configuredPlanModeToggleShortcut(state.settings) ?? "none"}`,
-					"Use Pi key identifiers such as ctrl+shift+p.",
+					"Use Pi key identifiers.",
 					"Submit an empty value to clear the shortcut.",
 					"When unset, Plan mode has no global shortcut.",
-					"Recommended value: ctrl+alt+p",
 				],
 				placeholder: configuredPlanModeToggleShortcut(state.settings) ?? "",
 				action: "set-shortcut",
@@ -227,7 +227,15 @@ export async function showPlanModeSettings(
 			},
 			"open-shortcut": async () => ({ kind: "to", screen: "shortcut" }),
 			"set-shortcut": async ({ ctx: actionCtx, value, signal }) => {
-				const toggleShortcut = (value?.trim() || null) as PlanModeSettingsPatch["toggleShortcut"];
+				const raw = value?.trim() || null;
+				if (raw && !normalizeKeyId(raw)) {
+					actionCtx.ui.notify(
+						`Invalid key identifier: ${safeTerminalText(raw)}. Use Pi key identifiers like ctrl+alt+p.`,
+						"warning",
+					);
+					return { kind: "stay" as const };
+				}
+				const toggleShortcut = raw as PlanModeSettingsPatch["toggleShortcut"];
 				const result = await savePatch(
 					actionCtx,
 					{ toggleShortcut },

--- a/packages/pi-plan-mode/src/settings.ts
+++ b/packages/pi-plan-mode/src/settings.ts
@@ -31,7 +31,6 @@ export const IMPLEMENTATION_PLAN_RETENTIONS = [
 	"clear-after-first-run",
 ] as const;
 export const DEFAULT_PLAN_EXPORT_PATH = "PLAN.md";
-export const RECOMMENDED_PLAN_MODE_TOGGLE_SHORTCUT = "ctrl+alt+p";
 const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
 const BASE_KEYS = new Set([
 	..."abcdefghijklmnopqrstuvwxyz0123456789",
@@ -78,8 +77,6 @@ const BASE_KEYS = new Set([
 	"clear",
 	"home",
 	"end",
-	"pageUp",
-	"pageDown",
 	"pageup",
 	"pagedown",
 	"up",
@@ -210,7 +207,7 @@ function normalizePlanExportPath(value: unknown) {
 	return normalized;
 }
 
-function normalizeKeyId(value: unknown): KeyId | undefined {
+export function normalizeKeyId(value: unknown): KeyId | undefined {
 	if (typeof value !== "string") return undefined;
 	const normalized = value.trim().toLowerCase();
 	const base = [...BASE_KEYS]

--- a/packages/pi-plan-mode/src/settings.ts
+++ b/packages/pi-plan-mode/src/settings.ts
@@ -3,6 +3,7 @@ import { constants } from "node:fs";
 import { mkdir, open, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { KeyId } from "@earendil-works/pi-tui";
 import {
 	SAFE_GH_SUBCOMMAND_PATHS,
 	SAFE_GIT_SUBCOMMANDS,
@@ -30,6 +31,63 @@ export const IMPLEMENTATION_PLAN_RETENTIONS = [
 	"clear-after-first-run",
 ] as const;
 export const DEFAULT_PLAN_EXPORT_PATH = "PLAN.md";
+export const RECOMMENDED_PLAN_MODE_TOGGLE_SHORTCUT = "ctrl+alt+p";
+const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
+const BASE_KEYS = new Set([
+	..."abcdefghijklmnopqrstuvwxyz0123456789",
+	"`",
+	"-",
+	"=",
+	"[",
+	"]",
+	"\\",
+	";",
+	"'",
+	",",
+	".",
+	"/",
+	"!",
+	"@",
+	"#",
+	"$",
+	"%",
+	"^",
+	"&",
+	"*",
+	"(",
+	")",
+	"_",
+	"+",
+	"|",
+	"~",
+	"{",
+	"}",
+	":",
+	"<",
+	">",
+	"?",
+	"escape",
+	"esc",
+	"enter",
+	"return",
+	"tab",
+	"space",
+	"backspace",
+	"delete",
+	"insert",
+	"clear",
+	"home",
+	"end",
+	"pageUp",
+	"pageDown",
+	"pageup",
+	"pagedown",
+	"up",
+	"down",
+	"left",
+	"right",
+	...Array.from({ length: 12 }, (_unused, index) => `f${index + 1}`),
+]);
 const MAX_PLAN_EXPORT_PATH_LENGTH = 4096;
 
 export type PlanModeThinkingLevel = (typeof PLAN_MODE_THINKING_LEVELS)[number];
@@ -41,12 +99,14 @@ export interface PlanModeSettings {
 	implementationPlanRetention?: ImplementationPlanRetention;
 	defaultPlanExportPath?: string;
 	safeSubcommands?: SafeSubcommands;
+	toggleShortcut?: KeyId;
 }
 export interface PlanModeSettingsPatch {
 	thinkingLevel?: PlanModeThinkingLevel;
 	defaultPlanTools?: readonly string[] | null;
 	implementationPlanRetention?: ImplementationPlanRetention;
 	defaultPlanExportPath?: string | null;
+	toggleShortcut?: KeyId | null;
 }
 export interface UpdatePlanModeSettingsOptions {
 	settingsPath?: string;
@@ -110,6 +170,11 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 		if (!defaultPlanExportPath) return undefined;
 		settings.defaultPlanExportPath = defaultPlanExportPath;
 	}
+	if (Object.hasOwn(value, "toggleShortcut")) {
+		const toggleShortcut = normalizeKeyId(Reflect.get(value, "toggleShortcut"));
+		if (!toggleShortcut) return undefined;
+		settings.toggleShortcut = toggleShortcut;
+	}
 	if (Object.hasOwn(value, "safeSubcommands")) {
 		const safeSubcommands = normalizeSafeSubcommands(Reflect.get(value, "safeSubcommands"));
 		if (!safeSubcommands) return undefined;
@@ -143,6 +208,27 @@ function normalizePlanExportPath(value: unknown) {
 		return undefined;
 	}
 	return normalized;
+}
+
+function normalizeKeyId(value: unknown): KeyId | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().toLowerCase();
+	const base = [...BASE_KEYS]
+		.sort((left, right) => right.length - left.length)
+		.find((candidate) => normalized === candidate || normalized.endsWith(`+${candidate}`));
+	if (!base) return undefined;
+	const prefix = normalized.slice(0, normalized.length - base.length);
+	if (!prefix) return base as KeyId;
+	if (/^f(?:[1-9]|1[0-2])$/.test(base) || !prefix.endsWith("+")) return undefined;
+	const modifiers = prefix.slice(0, -1).split("+");
+	if (
+		modifiers.length === 0 ||
+		modifiers.some((modifier) => !MODIFIERS.has(modifier)) ||
+		new Set(modifiers).size !== modifiers.length
+	) {
+		return undefined;
+	}
+	return normalized as KeyId;
 }
 
 function normalizeSafeSubcommands(value: unknown): SafeSubcommands | undefined {
@@ -226,6 +312,10 @@ export function updatePlanModeSettings(
 		if (patch.defaultPlanExportPath === null) delete updated.defaultPlanExportPath;
 		else if (patch.defaultPlanExportPath !== undefined) {
 			updated.defaultPlanExportPath = patch.defaultPlanExportPath;
+		}
+		if (patch.toggleShortcut === null) delete updated.toggleShortcut;
+		else if (patch.toggleShortcut !== undefined) {
+			updated.toggleShortcut = patch.toggleShortcut;
 		}
 		const settings = normalizePlanModeSettings(updated);
 		if (!settings) throw invalidSettingsError(settingsPath, "invalid settings shape");
@@ -403,4 +493,8 @@ export function configuredImplementationPlanRetention(
 
 export function configuredPlanExportPath(settings: PlanModeSettings) {
 	return settings.defaultPlanExportPath ?? DEFAULT_PLAN_EXPORT_PATH;
+}
+
+export function configuredPlanModeToggleShortcut(settings: PlanModeSettings): KeyId | undefined {
+	return settings.toggleShortcut;
 }

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -67,6 +67,7 @@ test("inactive bare /plan opens a TUI launch menu without changing Plan state", 
 	assert.match(frame.join("\n"), /Plan mode/);
 	assert.match(frame.join("\n"), /Status: Off/i);
 	assert.match(frame.join("\n"), /Start Plan mode/);
+	assert.match(frame.join("\n"), /\btab\b/i);
 	assert.ok(frame.every((line) => line.length <= 42));
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
 	assert.equal(mock.entries.length, 0);
@@ -75,6 +76,21 @@ test("inactive bare /plan opens a TUI launch menu without changing Plan state", 
 	await running;
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
 	assert.equal(mock.entries.length, 0);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("Tab starts the inactive launch menu from TUI", async () => {
+	const mock = launchFixture();
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+
+	const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+	await waitForOpenCount(tui, 1, running);
+	tui.send("\t");
+	await running;
+
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
 	assert.equal(mock.sentUserMessages.length, 0);
 });
 

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -67,7 +67,6 @@ test("inactive bare /plan opens a TUI launch menu without changing Plan state", 
 	assert.match(frame.join("\n"), /Plan mode/);
 	assert.match(frame.join("\n"), /Status: Off/i);
 	assert.match(frame.join("\n"), /Start Plan mode/);
-	assert.match(frame.join("\n"), /\btab\b/i);
 	assert.ok(frame.every((line) => line.length <= 42));
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
 	assert.equal(mock.entries.length, 0);
@@ -92,21 +91,6 @@ test("Ctrl+N toggles Plan mode from TUI", async () => {
 	await toggle.handler(context.ctx);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
 	assert.equal(context.statuses.get("plan-mode"), undefined);
-	assert.equal(mock.sentUserMessages.length, 0);
-});
-
-test("Tab starts the inactive launch menu from TUI", async () => {
-	const mock = launchFixture();
-	const tui = createTuiHarness();
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-
-	const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
-	await waitForOpenCount(tui, 1, running);
-	tui.send("\t");
-	await running;
-
-	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
-	assert.equal(context.statuses.get("plan-mode"), "plan active");
 	assert.equal(mock.sentUserMessages.length, 0);
 });
 

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -115,6 +115,24 @@ test("customized plan-mode shortcut from settings toggles Plan mode", async () =
 	assert.equal(context.statuses.get("plan-mode"), undefined);
 });
 
+test("customized plan-mode shortcut from settings supports ctrl+alt+p", async () => {
+	const mock = launchFixtureWithSettings(async () => ({
+		kind: "loaded" as const,
+		settings: { thinkingLevel: "inherit", toggleShortcut: "ctrl+alt+p" },
+	}));
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const toggle = mock.shortcuts.get("ctrl+alt+p");
+	assert.ok(toggle, "custom shortcut should be registered");
+	toggle.handler(context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
+
+	toggle.handler(context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+});
+
 test("the inactive launch menu opens Settings without starting Plan mode", async () => {
 	const mock = launchFixture();
 	const tui = createTuiHarness();

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -78,11 +78,11 @@ test("inactive bare /plan opens a TUI launch menu without changing Plan state", 
 	assert.equal(mock.sentUserMessages.length, 0);
 });
 
-test("Ctrl+N toggles Plan mode from TUI", async () => {
+test("Ctrl+Alt+P toggles Plan mode from TUI", async () => {
 	const mock = launchFixture();
 	const context = createMockContext({ mode: "tui", hasUI: true });
-	const toggle = mock.shortcuts.get("ctrl+n");
-	assert.ok(toggle, "Ctrl+N shortcut should be registered");
+	const toggle = mock.shortcuts.get("ctrl+alt+p");
+	assert.ok(toggle, "Ctrl+Alt+P shortcut should be registered");
 
 	await toggle.handler(context.ctx);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -56,6 +56,15 @@ function launchFixture() {
 	return mock;
 }
 
+function launchFixtureWithSettings(readSettings: () => ReturnType<typeof readPlanModeSettings>) {
+	const mock = createMockPi({
+		activeTools: ["read", "write"],
+		allTools: [builtinTool("read"), builtinTool("write"), extensionTool("custom")],
+	});
+	planMode(mock.pi, { readSettings });
+	return mock;
+}
+
 test("inactive bare /plan opens a TUI launch menu without changing Plan state", async () => {
 	const mock = launchFixture();
 	const tui = createTuiHarness({ width: 42, rows: 18 });
@@ -78,11 +87,24 @@ test("inactive bare /plan opens a TUI launch menu without changing Plan state", 
 	assert.equal(mock.sentUserMessages.length, 0);
 });
 
-test("Ctrl+Alt+P toggles Plan mode from TUI", async () => {
+test("Plan mode has no shortcut by default unless configured", async () => {
 	const mock = launchFixture();
 	const context = createMockContext({ mode: "tui", hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	const toggle = mock.shortcuts.get("ctrl+alt+p");
-	assert.ok(toggle, "Ctrl+Alt+P shortcut should be registered");
+	assert.equal(toggle, undefined, "no global shortcut should be registered by default");
+});
+
+test("customized plan-mode shortcut from settings toggles Plan mode", async () => {
+	const mock = launchFixtureWithSettings(async () => ({
+		kind: "loaded" as const,
+		settings: { thinkingLevel: "inherit", toggleShortcut: "ctrl+shift+p" },
+	}));
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const toggle = mock.shortcuts.get("ctrl+shift+p");
+	assert.ok(toggle, "custom shortcut should be registered");
+	assert.equal(mock.shortcuts.has("ctrl+alt+p"), false);
 
 	await toggle.handler(context.ctx);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
@@ -91,7 +113,6 @@ test("Ctrl+Alt+P toggles Plan mode from TUI", async () => {
 	await toggle.handler(context.ctx);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
 	assert.equal(context.statuses.get("plan-mode"), undefined);
-	assert.equal(mock.sentUserMessages.length, 0);
 });
 
 test("the inactive launch menu opens Settings without starting Plan mode", async () => {

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -79,6 +79,22 @@ test("inactive bare /plan opens a TUI launch menu without changing Plan state", 
 	assert.equal(mock.sentUserMessages.length, 0);
 });
 
+test("Ctrl+N toggles Plan mode from TUI", async () => {
+	const mock = launchFixture();
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	const toggle = mock.shortcuts.get("ctrl+n");
+	assert.ok(toggle, "Ctrl+N shortcut should be registered");
+
+	await toggle.handler(context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
+
+	await toggle.handler(context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
 test("Tab starts the inactive launch menu from TUI", async () => {
 	const mock = launchFixture();
 	const tui = createTuiHarness();

--- a/packages/pi-plan-mode/test/settings-menu.test.ts
+++ b/packages/pi-plan-mode/test/settings-menu.test.ts
@@ -52,7 +52,7 @@ function menuOptions(
 	};
 }
 
-test("Plan settings show four flat workflow rows without materializing a missing file", async () => {
+test("Plan settings show five flat workflow rows without materializing a missing file", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
@@ -62,6 +62,7 @@ test("Plan settings show four flat workflow rows without materializing a missing
 		assert.match(frame, /Plan tools\s+Automatic safe built-ins/);
 		assert.match(frame, /After Implement\s+Keep plan active/);
 		assert.match(frame, /Export destination\s+PLAN\.md/);
+		assert.match(frame, /Plan mode shortcut\s+none/);
 		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
 		await assert.rejects(access(settingsPath));
 
@@ -221,6 +222,43 @@ test("After Implement cycles outcomes and export destination saves, previews, re
 	});
 });
 
+test("Plan mode shortcut can be set and reset in Settings", async () => {
+	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
+		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.type("ctrl+shift+p");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.toggleShortcut, "ctrl+shift+p");
+		const writtenShortcut = JSON.parse(await readFile(settingsPath, "utf8")) as {
+			toggleShortcut?: string;
+		};
+		assert.equal(writtenShortcut.toggleShortcut, "ctrl+shift+p");
+		assert.match(tui.render().join("\n"), /Plan mode shortcut\s+ctrl\+shift\+p/);
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.toggleShortcut, undefined);
+		const resetFile = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.equal(Object.hasOwn(resetFile, "toggleShortcut"), false);
+		assert.match(tui.render().join("\n"), /Plan mode shortcut\s+none/);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
 test("long export previews stay within narrow terminal widths", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const longPath = `plans/${"nested-".repeat(16)}PLAN.md`;
@@ -302,6 +340,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan tools (Automatic safe built-ins)",
 					"After Implement (Keep plan active)",
 					"Export destination (PLAN.md)",
+					"Plan mode shortcut (none)",
 					"Back",
 				],
 				response: "After Implement (Keep plan active)",
@@ -313,6 +352,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan tools (Automatic safe built-ins)",
 					"After Implement (Use plan for handoff only)",
 					"Export destination (PLAN.md)",
+					"Plan mode shortcut (none)",
 					"Back",
 				],
 				response: "Export destination (PLAN.md)",
@@ -329,6 +369,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan tools (Automatic safe built-ins)",
 					"After Implement (Use plan for handoff only)",
 					"Export destination (rpc/PLAN.md)",
+					"Plan mode shortcut (none)",
 					"Back",
 				],
 				response: undefined,
@@ -354,6 +395,7 @@ test("Plan settings adapt to RPC cancellation and disposal aborts an in-flight s
 				"Plan tools (Automatic safe built-ins)",
 				"After Implement (Keep plan active)",
 				"Export destination (PLAN.md)",
+				"Plan mode shortcut (none)",
 				"Back",
 			],
 			response: undefined,

--- a/packages/pi-plan-mode/test/settings.test.ts
+++ b/packages/pi-plan-mode/test/settings.test.ts
@@ -16,6 +16,7 @@ import {
 	awaitPlanModeSettingsWrites,
 	configuredImplementationPlanRetention,
 	configuredPlanExportPath,
+	configuredPlanModeToggleShortcut,
 	normalizePlanModeSettings,
 	readPlanModeSettings,
 	updatePlanModeSettings,
@@ -42,6 +43,18 @@ test("Plan-mode settings validate inherit and fixed thinking levels", async () =
 	} finally {
 		await rm(directory, { recursive: true, force: true });
 	}
+});
+
+test("Plan-mode settings normalize and configure toggle shortcut keys", () => {
+	assert.deepEqual(normalizePlanModeSettings({ toggleShortcut: "Ctrl+Alt+P" }), {
+		thinkingLevel: "inherit",
+		toggleShortcut: "ctrl+alt+p",
+	});
+	assert.equal(normalizePlanModeSettings({ toggleShortcut: "bad+key" }), undefined);
+	assert.equal(normalizePlanModeSettings({ toggleShortcut: 42 }), undefined);
+	const configured = normalizePlanModeSettings({});
+	assert.ok(configured);
+	assert.equal(configuredPlanModeToggleShortcut(configured), undefined);
 });
 
 test("Plan-mode settings normalize default tool names strictly", async () => {


### PR DESCRIPTION
## Summary

- Added a configurable global TUI shortcut for toggling Plan mode on and off.
- The shortcut is **disabled by default**; set `toggleShortcut` in settings to enable it.
- Added a **Plan mode shortcut** row to the Settings menu for interactive configuration.
- Settings file changes are now hot-reloaded during an active session, so the shortcut updates without a session restart.
- Unified the Plan mode disable notification into a shared helper used by both the `/plan exit` command and the new shortcut handler.
- Added `normalizeKeyId` validation: input is case-normalised, duplicate modifiers are rejected, and modifier+F-key combinations are blocked.

## Verification

- `npm run typecheck`
- `npm test -- packages/pi-plan-mode/test/launch-menu.test.ts packages/pi-plan-mode/test/settings-menu.test.ts packages/pi-plan-mode/test/settings.test.ts`

Closes #832