### PR TITLE
feat(workflow): configure the Plan mode toggle shortcut in settings

### DIFF
--- a/.changeset/workflow-plan-toggle-shortcut.md
+++ b/.changeset/workflow-plan-toggle-shortcut.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-workflow": minor
+---
+
+Add an optional configurable global shortcut for toggling Plan mode through `plan.toggleShortcut` and the **Plan mode shortcut** Settings row, disabled by default and guarded by the same Goal and saved-plan checks as `/plan`.

--- a/packages/pi-workflow/README.md
+++ b/packages/pi-workflow/README.md
@@ -17,6 +17,7 @@ Those packages intentionally share command, tool, event-channel, and session-sta
 - Provides `/workflow`, `/plan`, and `/goal` from one extension.
 - Registers Plan and Goal behavior eagerly while loading the combined manager and fresh-session handoff code only when those routes are used.
 - Preserves Plan exploration, structured questions, completion, save, export, tool selection, and thinking-level control.
+- Supports an optional configurable global shortcut for toggling Plan mode, disabled by default.
 - Supports Plan alone, Goal alone, and approved Plan-to-Goal execution without adding a non-Goal implementation path.
 - Preserves Goal completion, blocking, external waits, pause, resume, edit, clear, token budgets, continuation guards, optional ordered queues, and managed-run RPC.
 - Uses review-first handoff by default, matching Codex's authoritative-plan and explicit-approval workflow.
@@ -171,6 +172,8 @@ A new Plan cannot start while any unfinished Goal exists.
 
 Clear the Goal first so one runtime owns tool restrictions and automatic work.
 
+Plan mode has no global shortcut until `plan.toggleShortcut` configures one; the configured key then toggles Plan mode and respects the same Goal and saved-plan guards as `/plan`.
+
 ### Goal
 
 ```text
@@ -248,6 +251,7 @@ Example:
     "thinkingLevel": "inherit",
     "defaultPlanTools": ["read", "bash", "grep", "find", "ls"],
     "defaultPlanExportPath": "PLAN.md",
+    "toggleShortcut": "<your_key>",
     "safeSubcommands": {
       "git": ["status", "log", "diff", "show"]
     }
@@ -270,7 +274,17 @@ Example:
 
 `workflow.planHandoff` accepts `review` or `automatic`.
 
-The `plan` object accepts Plan thinking, tools, export destination, and reviewed shell-subcommand defaults.
+The `plan` object accepts Plan thinking, tools, export destination, Plan-mode shortcut, and reviewed shell-subcommand defaults.
+
+`plan.toggleShortcut` controls the global Plan-mode keybinding and accepts a Pi key identifier such as `ctrl+alt+p`.
+
+Omit it—or submit an empty value in **Plan mode shortcut**—to keep the shortcut disabled.
+
+Avoid values that conflict with editor shortcuts.
+
+An invalid key string makes the whole settings file read-only, so fix it before saving again.
+
+A shortcut saved through Settings is rebound immediately; a manual file edit applies on the next session start or `/reload`.
 
 The standalone `implementationPlanRetention` setting is not used by `pi-workflow` because every Implement action starts Goal and keeps the exact Plan until linked execution ends.
 

--- a/packages/pi-workflow/src/plan/plan-mode.ts
+++ b/packages/pi-workflow/src/plan/plan-mode.ts
@@ -51,6 +51,7 @@ import {
 import {
 	awaitPlanModeSettingsWrites,
 	configuredImplementationPlanRetention,
+	configuredPlanModeToggleShortcut,
 	configuredThinkingLevel,
 	type ImplementationPlanRetention,
 	type PlanModeSettings,
@@ -143,6 +144,8 @@ export default function planMode(
 	};
 	let state: PlanModeState = { enabled: false, awaitingAction: false };
 	let settings: PlanModeSettings = { thinkingLevel: "inherit" };
+	let toggleShortcut: ReturnType<typeof configuredPlanModeToggleShortcut>;
+	const clearPlanModeShortcutHandler = () => {};
 	let currentContext: ExtensionContext | undefined;
 	let sessionReady = true;
 	let handoffInFlightImplementationId: string | undefined;
@@ -304,13 +307,7 @@ export default function planMode(
 			}
 			if (command === "exit" || command === "off") {
 				if (linkedPlanExitBlocked(ctx)) return;
-				const notification = state.activeImplementation
-					? "Active implementation plan cleared."
-					: state.savedPlan
-						? "Saved plan cleared."
-						: state.latestPlan
-							? "Plan mode disabled. Proposed plan discarded."
-							: "Plan mode disabled.";
+				const notification = planModeDisableNotification();
 				exitPlanMode(ctx);
 				ctx.ui.notify(notification, "info");
 				return;
@@ -343,6 +340,28 @@ export default function planMode(
 		},
 	});
 
+	const applyPlanModeShortcut = (
+		nextShortcut: ReturnType<typeof configuredPlanModeToggleShortcut>,
+	) => {
+		if (toggleShortcut && toggleShortcut !== nextShortcut) {
+			pi.registerShortcut(toggleShortcut, {
+				handler: clearPlanModeShortcutHandler,
+			});
+		}
+		if (!nextShortcut) {
+			toggleShortcut = undefined;
+			return;
+		}
+		if (toggleShortcut === nextShortcut) return;
+		pi.registerShortcut(nextShortcut, {
+			description: "Toggle Plan mode",
+			handler: (ctx) => {
+				togglePlanMode(ctx);
+			},
+		});
+		toggleShortcut = nextShortcut;
+	};
+
 	pi.on("session_start", async (event, ctx) => {
 		const generation = ++menuGeneration;
 		sessionReady = false;
@@ -366,6 +385,7 @@ export default function planMode(
 		if (loadedSettings.notice && dependencies.reportSettingsIssues !== false) {
 			ctx.ui.notify(loadedSettings.notice, "warning");
 		}
+		applyPlanModeShortcut(configuredPlanModeToggleShortcut(settings));
 		const requestedFlagActivation = pi.getFlag("plan") === true && !state.enabled;
 		const flagBlocker = requestedFlagActivation ? dependencies.canStartPlan?.() : undefined;
 		if (flagBlocker) ctx.ui.notify(flagBlocker, "warning");
@@ -657,6 +677,33 @@ export default function planMode(
 
 	function readyPresentationIsCurrent(intent: ReadyPresentationIntent) {
 		return completedPlanIsCurrent(intent) && readyPresentationIntent?.nonce === intent.nonce;
+	}
+
+	function togglePlanMode(ctx: ExtensionContext) {
+		// Pi keeps a registered shortcut across sessions, so the handler stays inert while a session
+		// is starting, replaced, or shut down instead of mutating state the session does not own.
+		if (!sessionReady) return;
+		if (state.enabled) {
+			if (linkedPlanExitBlocked(ctx)) return;
+			const notification = planModeDisableNotification();
+			exitPlanMode(ctx);
+			ctx.ui.notify(notification, "info");
+			return;
+		}
+		if (planStartBlocked(ctx)) return;
+		if (savedPlanBlocksNewWorkflow(ctx, state.savedPlan !== undefined)) return;
+		enterPlanMode(ctx);
+		ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+	}
+
+	function planModeDisableNotification() {
+		return state.activeImplementation
+			? "Active implementation plan cleared."
+			: state.savedPlan
+				? "Saved plan cleared."
+				: state.latestPlan
+					? "Plan mode disabled. Proposed plan discarded."
+					: "Plan mode disabled.";
 	}
 
 	function requestFinalPlan(ctx: ExtensionContext) {
@@ -1016,7 +1063,9 @@ export default function planMode(
 			settingsPath: dependencies.settingsPath,
 			...(dependencies.updateSettings ? { updateSettings: dependencies.updateSettings } : {}),
 			onSaved: (saved) => {
-				if (isCurrent()) settings = saved;
+				if (!isCurrent()) return;
+				settings = saved;
+				applyPlanModeShortcut(configuredPlanModeToggleShortcut(saved));
 			},
 			...(dependencies.readSettings
 				? { readSettings: async () => dependencies.readSettings?.() ?? { kind: "missing" } }

--- a/packages/pi-workflow/src/plan/settings-menu.ts
+++ b/packages/pi-workflow/src/plan/settings-menu.ts
@@ -7,7 +7,9 @@ import { PLAN_MODE_QUESTION_TOOL_NAME } from "./question-tool.js";
 import {
 	configuredImplementationPlanRetention,
 	configuredPlanExportPath,
+	configuredPlanModeToggleShortcut,
 	IMPLEMENTATION_PLAN_RETENTIONS,
+	normalizeKeyId,
 	PLAN_MODE_THINKING_LEVELS,
 	type PlanModeSettings,
 	type PlanModeSettingsLoadResult,
@@ -42,7 +44,7 @@ export interface PlanModeSettingsMenuOptions {
 	onSaved(settings: PlanModeSettings): void;
 }
 
-type Screen = "settings" | "tools" | "export";
+type Screen = "settings" | "tools" | "export" | "shortcut";
 type Action =
 	| "set-thinking"
 	| "open-tools"
@@ -50,7 +52,9 @@ type Action =
 	| "reset-tools"
 	| "set-retention"
 	| "open-export"
-	| "set-export";
+	| "set-export"
+	| "open-shortcut"
+	| "set-shortcut";
 
 export async function showPlanModeSettings(
 	ctx: ExtensionContext,
@@ -130,6 +134,13 @@ export async function showPlanModeSettings(
 									currentValue: safeTerminalText(configuredPlanExportPath(state.settings)),
 									action: "open-export",
 								},
+								{
+									id: "toggleShortcut",
+									label: "Plan mode shortcut",
+									description: "Set the global shortcut used to toggle Plan mode.",
+									currentValue: configuredPlanModeToggleShortcut(state.settings) ?? "none",
+									action: "open-shortcut",
+								},
 							],
 						},
 			tools: ({ state }) => ({
@@ -168,6 +179,19 @@ export async function showPlanModeSettings(
 					hint: "back",
 				};
 			},
+			shortcut: ({ state }) => ({
+				kind: "input",
+				title: "Plan mode shortcut",
+				lines: [
+					`Configured: ${configuredPlanModeToggleShortcut(state.settings) ?? "none"}`,
+					"Use Pi key identifiers.",
+					"Submit an empty value to clear the shortcut.",
+					"When unset, Plan mode has no global shortcut.",
+				],
+				placeholder: configuredPlanModeToggleShortcut(state.settings) ?? "",
+				action: "set-shortcut",
+				hint: "back",
+			}),
 		},
 		actions: {
 			"set-thinking": async ({ ctx: actionCtx, value, signal }) => {
@@ -204,6 +228,27 @@ export async function showPlanModeSettings(
 					defaultPlanExportPath
 						? `Default Plan export destination: ${safeTerminalText(defaultPlanExportPath)}.`
 						: "Default Plan export destination reset to PLAN.md.",
+				);
+				return result.kind === "stay" ? { kind: "to", screen: "settings" } : result;
+			},
+			"open-shortcut": async () => ({ kind: "to", screen: "shortcut" }),
+			"set-shortcut": async ({ ctx: actionCtx, value, signal }) => {
+				const raw = value?.trim() || null;
+				if (raw && !normalizeKeyId(raw)) {
+					actionCtx.ui.notify(
+						`Invalid key identifier: ${safeTerminalText(raw)}. Use Pi key identifiers like ctrl+alt+p.`,
+						"warning",
+					);
+					return { kind: "stay" as const };
+				}
+				const toggleShortcut = raw as PlanModeSettingsPatch["toggleShortcut"];
+				const result = await savePatch(
+					actionCtx,
+					{ toggleShortcut },
+					signal,
+					toggleShortcut
+						? `Plan mode shortcut: ${safeTerminalText(toggleShortcut)}.`
+						: "Plan mode shortcut cleared (no global shortcut).",
 				);
 				return result.kind === "stay" ? { kind: "to", screen: "settings" } : result;
 			},

--- a/packages/pi-workflow/src/plan/settings.ts
+++ b/packages/pi-workflow/src/plan/settings.ts
@@ -3,6 +3,7 @@ import { constants } from "node:fs";
 import { mkdir, open, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { KeyId } from "@earendil-works/pi-tui";
 import {
 	SAFE_GH_SUBCOMMAND_PATHS,
 	SAFE_GIT_SUBCOMMANDS,
@@ -30,6 +31,60 @@ export const IMPLEMENTATION_PLAN_RETENTIONS = [
 	"clear-after-first-run",
 ] as const;
 export const DEFAULT_PLAN_EXPORT_PATH = "PLAN.md";
+const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
+const BASE_KEYS = new Set([
+	..."abcdefghijklmnopqrstuvwxyz0123456789",
+	"`",
+	"-",
+	"=",
+	"[",
+	"]",
+	"\\",
+	";",
+	"'",
+	",",
+	".",
+	"/",
+	"!",
+	"@",
+	"#",
+	"$",
+	"%",
+	"^",
+	"&",
+	"*",
+	"(",
+	")",
+	"_",
+	"+",
+	"|",
+	"~",
+	"{",
+	"}",
+	":",
+	"<",
+	">",
+	"?",
+	"escape",
+	"esc",
+	"enter",
+	"return",
+	"tab",
+	"space",
+	"backspace",
+	"delete",
+	"insert",
+	"clear",
+	"home",
+	"end",
+	"pageup",
+	"pagedown",
+	"up",
+	"down",
+	"left",
+	"right",
+	...Array.from({ length: 12 }, (_unused, index) => `f${index + 1}`),
+]);
 const MAX_PLAN_EXPORT_PATH_LENGTH = 4096;
 
 export type PlanModeThinkingLevel = (typeof PLAN_MODE_THINKING_LEVELS)[number];
@@ -41,12 +96,14 @@ export interface PlanModeSettings {
 	implementationPlanRetention?: ImplementationPlanRetention;
 	defaultPlanExportPath?: string;
 	safeSubcommands?: SafeSubcommands;
+	toggleShortcut?: KeyId;
 }
 export interface PlanModeSettingsPatch {
 	thinkingLevel?: PlanModeThinkingLevel;
 	defaultPlanTools?: readonly string[] | null;
 	implementationPlanRetention?: ImplementationPlanRetention;
 	defaultPlanExportPath?: string | null;
+	toggleShortcut?: KeyId | null;
 }
 export interface UpdatePlanModeSettingsOptions {
 	settingsPath?: string;
@@ -110,6 +167,11 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 		if (!defaultPlanExportPath) return undefined;
 		settings.defaultPlanExportPath = defaultPlanExportPath;
 	}
+	if (Object.hasOwn(value, "toggleShortcut")) {
+		const toggleShortcut = normalizeKeyId(Reflect.get(value, "toggleShortcut"));
+		if (!toggleShortcut) return undefined;
+		settings.toggleShortcut = toggleShortcut;
+	}
 	if (Object.hasOwn(value, "safeSubcommands")) {
 		const safeSubcommands = normalizeSafeSubcommands(Reflect.get(value, "safeSubcommands"));
 		if (!safeSubcommands) return undefined;
@@ -143,6 +205,27 @@ function normalizePlanExportPath(value: unknown) {
 		return undefined;
 	}
 	return normalized;
+}
+
+export function normalizeKeyId(value: unknown): KeyId | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().toLowerCase();
+	const base = [...BASE_KEYS]
+		.sort((left, right) => right.length - left.length)
+		.find((candidate) => normalized === candidate || normalized.endsWith(`+${candidate}`));
+	if (!base) return undefined;
+	const prefix = normalized.slice(0, normalized.length - base.length);
+	if (!prefix) return base as KeyId;
+	if (/^f(?:[1-9]|1[0-2])$/.test(base) || !prefix.endsWith("+")) return undefined;
+	const modifiers = prefix.slice(0, -1).split("+");
+	if (
+		modifiers.length === 0 ||
+		modifiers.some((modifier) => !MODIFIERS.has(modifier)) ||
+		new Set(modifiers).size !== modifiers.length
+	) {
+		return undefined;
+	}
+	return normalized as KeyId;
 }
 
 function normalizeSafeSubcommands(value: unknown): SafeSubcommands | undefined {
@@ -226,6 +309,10 @@ export function updatePlanModeSettings(
 		if (patch.defaultPlanExportPath === null) delete updated.defaultPlanExportPath;
 		else if (patch.defaultPlanExportPath !== undefined) {
 			updated.defaultPlanExportPath = patch.defaultPlanExportPath;
+		}
+		if (patch.toggleShortcut === null) delete updated.toggleShortcut;
+		else if (patch.toggleShortcut !== undefined) {
+			updated.toggleShortcut = patch.toggleShortcut;
 		}
 		const settings = normalizePlanModeSettings(updated);
 		if (!settings) throw invalidSettingsError(settingsPath, "invalid settings shape");
@@ -403,4 +490,8 @@ export function configuredImplementationPlanRetention(
 
 export function configuredPlanExportPath(settings: PlanModeSettings) {
 	return settings.defaultPlanExportPath ?? DEFAULT_PLAN_EXPORT_PATH;
+}
+
+export function configuredPlanModeToggleShortcut(settings: PlanModeSettings): KeyId | undefined {
+	return settings.toggleShortcut;
 }

--- a/packages/pi-workflow/src/settings.ts
+++ b/packages/pi-workflow/src/settings.ts
@@ -106,6 +106,8 @@ export async function updateWorkflowPlanSettings(
 	else if (patch.defaultPlanExportPath !== undefined) {
 		plan.defaultPlanExportPath = patch.defaultPlanExportPath;
 	}
+	if (patch.toggleShortcut === null) delete plan.toggleShortcut;
+	else if (patch.toggleShortcut !== undefined) plan.toggleShortcut = patch.toggleShortcut;
 	const normalized = normalizeWorkflowPlanSettings(plan);
 	if (!normalized) throw invalidSettingsError(settingsPath, "invalid Plan settings shape");
 	const document = { ...current, plan };

--- a/packages/pi-workflow/test/compat-plan-settings-menu.test.ts
+++ b/packages/pi-workflow/test/compat-plan-settings-menu.test.ts
@@ -52,7 +52,7 @@ function menuOptions(
 	};
 }
 
-test("Plan settings show four flat workflow rows without materializing a missing file", async () => {
+test("Plan settings show five flat workflow rows without materializing a missing file", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
@@ -62,6 +62,7 @@ test("Plan settings show four flat workflow rows without materializing a missing
 		assert.match(frame, /Plan tools\s+Automatic safe built-ins/);
 		assert.match(frame, /After Implement\s+Keep plan active/);
 		assert.match(frame, /Export destination\s+PLAN\.md/);
+		assert.match(frame, /Plan mode shortcut\s+none/);
 		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
 		await assert.rejects(access(settingsPath));
 
@@ -84,6 +85,7 @@ test("Workflow Plan settings hide standalone implementation retention", async ()
 		assert.match(frame, /Plan tools\s+Automatic safe built-ins/);
 		assert.doesNotMatch(frame, /After Implement/);
 		assert.match(frame, /Export destination\s+PLAN\.md/);
+		assert.match(frame, /Plan mode shortcut\s+none/);
 		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
 
 		tui.press("ctrl+c");
@@ -310,6 +312,49 @@ test("Invalid Plan settings are read-only and save failures roll back displayed 
 	});
 });
 
+test("Plan mode shortcut can be set, rejected, and reset in Settings", async () => {
+	await withSettingsMenu(async ({ settingsPath, tui, ctx, notifications, saved }) => {
+		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
+		await tui.waitForOpen();
+		for (let index = 0; index < 4; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.type("bad+key");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(notifications.at(-1)?.message ?? "", /Invalid key identifier/);
+		assert.equal(saved.length, 0);
+		await assert.rejects(access(settingsPath));
+
+		tui.type("ctrl+shift+p");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.toggleShortcut, "ctrl+shift+p");
+		assert.equal(
+			(JSON.parse(await readFile(settingsPath, "utf8")) as { toggleShortcut?: string })
+				.toggleShortcut,
+			"ctrl+shift+p",
+		);
+		assert.match(tui.render().join("\n"), /Plan mode shortcut\s+ctrl\+shift\+p/);
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.toggleShortcut, undefined);
+		const resetFile = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.equal(Object.hasOwn(resetFile, "toggleShortcut"), false);
+		assert.match(tui.render().join("\n"), /Plan mode shortcut\s+none/);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
 test("RPC Settings changes retention and export destination with the same flat navigation", async () => {
 	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-settings-rpc-"));
 	const settingsPath = join(directory, "pi-plan-mode.json");
@@ -322,6 +367,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan tools (Automatic safe built-ins)",
 					"After Implement (Keep plan active)",
 					"Export destination (PLAN.md)",
+					"Plan mode shortcut (none)",
 					"Back",
 				],
 				response: "After Implement (Keep plan active)",
@@ -333,6 +379,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan tools (Automatic safe built-ins)",
 					"After Implement (Use plan for handoff only)",
 					"Export destination (PLAN.md)",
+					"Plan mode shortcut (none)",
 					"Back",
 				],
 				response: "Export destination (PLAN.md)",
@@ -349,6 +396,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan tools (Automatic safe built-ins)",
 					"After Implement (Use plan for handoff only)",
 					"Export destination (rpc/PLAN.md)",
+					"Plan mode shortcut (none)",
 					"Back",
 				],
 				response: undefined,
@@ -374,6 +422,7 @@ test("Plan settings adapt to RPC cancellation and disposal aborts an in-flight s
 				"Plan tools (Automatic safe built-ins)",
 				"After Implement (Keep plan active)",
 				"Export destination (PLAN.md)",
+				"Plan mode shortcut (none)",
 				"Back",
 			],
 			response: undefined,

--- a/packages/pi-workflow/test/compat-plan-settings.test.ts
+++ b/packages/pi-workflow/test/compat-plan-settings.test.ts
@@ -16,6 +16,7 @@ import {
 	awaitPlanModeSettingsWrites,
 	configuredImplementationPlanRetention,
 	configuredPlanExportPath,
+	configuredPlanModeToggleShortcut,
 	normalizePlanModeSettings,
 	readPlanModeSettings,
 	updatePlanModeSettings,
@@ -42,6 +43,18 @@ test("Plan-mode settings validate inherit and fixed thinking levels", async () =
 	} finally {
 		await rm(directory, { recursive: true, force: true });
 	}
+});
+
+test("Plan-mode settings normalize and configure toggle shortcut keys", () => {
+	assert.deepEqual(normalizePlanModeSettings({ toggleShortcut: "Ctrl+Alt+P" }), {
+		thinkingLevel: "inherit",
+		toggleShortcut: "ctrl+alt+p",
+	});
+	assert.equal(normalizePlanModeSettings({ toggleShortcut: "bad+key" }), undefined);
+	assert.equal(normalizePlanModeSettings({ toggleShortcut: 42 }), undefined);
+	const configured = normalizePlanModeSettings({});
+	assert.ok(configured);
+	assert.equal(configuredPlanModeToggleShortcut(configured), undefined);
 });
 
 test("Plan-mode settings normalize default tool names strictly", async () => {

--- a/packages/pi-workflow/test/settings.test.ts
+++ b/packages/pi-workflow/test/settings.test.ts
@@ -261,3 +261,54 @@ test("Plan and Goal adapters expose only their normalized section", async () => 
 		await fixture.cleanup();
 	}
 });
+
+test("the Plan toggle shortcut round-trips through the workflow document", async () => {
+	const fixture = await temporarySettings();
+	try {
+		await writeFile(
+			fixture.path,
+			JSON.stringify({ plan: { thinkingLevel: "medium", futurePlan: { kept: true } } }),
+		);
+
+		const saved = await updateWorkflowPlanSettings(
+			{ toggleShortcut: "ctrl+alt+p" },
+			{ settingsPath: fixture.path },
+		);
+		assert.equal(saved.toggleShortcut, "ctrl+alt+p");
+		assert.deepEqual(readWorkflowPlanSettings(fixture.path), {
+			kind: "loaded",
+			settings: { thinkingLevel: "medium", toggleShortcut: "ctrl+alt+p" },
+		});
+
+		const cleared = await updateWorkflowPlanSettings(
+			{ toggleShortcut: null },
+			{ settingsPath: fixture.path },
+		);
+		assert.equal(cleared.toggleShortcut, undefined);
+		const document = JSON.parse(await readFile(fixture.path, "utf8")) as {
+			plan?: Record<string, unknown>;
+		};
+		assert.equal(Object.hasOwn(document.plan ?? {}, "toggleShortcut"), false);
+		assert.deepEqual(document.plan?.futurePlan, { kept: true });
+	} finally {
+		await fixture.cleanup();
+	}
+});
+
+test("an invalid Plan toggle shortcut blocks the workflow settings write", async () => {
+	const fixture = await temporarySettings();
+	try {
+		await writeFile(fixture.path, JSON.stringify({ plan: { toggleShortcut: "bad+key" } }));
+		assert.equal(readWorkflowSettings(fixture.path).kind, "invalid");
+		await assert.rejects(
+			updateWorkflowPlanSettings({ thinkingLevel: "high" }, { settingsPath: fixture.path }),
+			/invalid/,
+		);
+		assert.equal(
+			await readFile(fixture.path, "utf8"),
+			JSON.stringify({ plan: { toggleShortcut: "bad+key" } }),
+		);
+	} finally {
+		await fixture.cleanup();
+	}
+});

--- a/packages/pi-workflow/test/workflow.test.ts
+++ b/packages/pi-workflow/test/workflow.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
+import type { KeyId } from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import { builtinTool, createMockContext, createMockPi } from "../../../test/support.js";
 import { serializeGoalState } from "../src/goal/persistence.js";
 import { createGoal } from "../src/goal/runtime.js";
 import { DEFAULT_GOAL_SETTINGS } from "../src/goal/settings.js";
 import { startFreshWorkflowImplementation, WORKFLOW_GOAL_OBJECTIVE } from "../src/handoff.js";
+import type { WorkflowSettingsLoadResult } from "../src/settings.js";
 import workflow from "../src/workflow.js";
 
 const BASE_TOOLS = ["read", "bash", "edit", "write"];
@@ -1113,4 +1115,66 @@ test("a failed Goal kickoff restores the ready Plan and clears provisional Goal 
 	assert.equal(goalState.goal, null);
 	assert.equal(statuses.get("workflow:plan"), "plan ready");
 	assert.equal(statuses.get("workflow:goal"), undefined);
+});
+
+function workflowSettingsWithShortcut(toggleShortcut: KeyId): () => WorkflowSettingsLoadResult {
+	return () => ({
+		kind: "loaded",
+		settings: {
+			planHandoff: "review",
+			plan: { thinkingLevel: "inherit", toggleShortcut },
+			goal: structuredClone(DEFAULT_GOAL_SETTINGS),
+		},
+	});
+}
+
+test("Plan mode has no workflow shortcut unless settings configure one", async () => {
+	const { mock, ctx } = setup();
+	await emitAll(mock, "session_start", { reason: "startup" }, ctx);
+	assert.equal(mock.shortcuts.size, 0);
+});
+
+test("the configured workflow shortcut toggles Plan mode", async () => {
+	const { mock, ctx, statuses, notifications } = setup(
+		workflowSettingsWithShortcut("ctrl+shift+p"),
+	);
+	await emitAll(mock, "session_start", { reason: "startup" }, ctx);
+	const toggle = mock.shortcuts.get("ctrl+shift+p");
+	assert.ok(toggle, "the configured shortcut should be registered");
+	assert.equal(mock.shortcuts.has("ctrl+alt+p"), false);
+
+	await toggle.handler(ctx);
+	assert.equal(statuses.get("workflow:plan"), "plan active");
+	assert.match(notifications.at(-1)?.message ?? "", /Plan mode enabled/);
+
+	await toggle.handler(ctx);
+	assert.equal(statuses.get("workflow:plan"), undefined);
+	assert.match(notifications.at(-1)?.message ?? "", /Plan mode disabled/);
+});
+
+test("the workflow shortcut cannot start Plan mode while a Goal is active", async () => {
+	const fixture = setup(workflowSettingsWithShortcut("ctrl+alt+p"));
+	await emitAll(fixture.mock, "session_start", { reason: "startup" }, fixture.ctx);
+	await fixture.mock.commands.get("goal")?.handler("finish the release", fixture.ctx);
+	const toggle = fixture.mock.shortcuts.get("ctrl+alt+p");
+	assert.ok(toggle);
+
+	await toggle.handler(fixture.ctx);
+	assert.equal(fixture.statuses.get("workflow:plan"), undefined);
+	assert.match(fixture.notifications.at(-1)?.message ?? "", /clear.*Goal.*Plan/i);
+	assert.match(fixture.statuses.get("workflow:goal") ?? "", /^active/u);
+});
+
+test("the workflow shortcut cannot detach a linked Goal from its Plan", async () => {
+	const fixture = setup(workflowSettingsWithShortcut("ctrl+alt+p"));
+	await startLinkedWorkflow(fixture, "# Keep linked");
+	const toggle = fixture.mock.shortcuts.get("ctrl+alt+p");
+	assert.ok(toggle);
+
+	await toggle.handler(fixture.ctx);
+	const retainedPlan = fixture.mock.entries
+		.filter((entry) => entry.customType === "plan-mode-state")
+		.at(-1)?.data as { activeImplementation?: { goalId?: string } };
+	assert.ok(retainedPlan.activeImplementation?.goalId);
+	assert.match(fixture.notifications.at(-1)?.message ?? "", /clear.*Goal.*Plan/i);
 });


### PR DESCRIPTION
## Summary

`pi-workflow`'s package-owned Plan runtime had no global shortcut at all, while `pi-plan-mode` lets users configure or disable the Plan-mode toggle key. This ports that capability into `pi-workflow`.

- `src/plan/settings.ts`: restores `toggleShortcut`, `normalizeKeyId`, and `configuredPlanModeToggleShortcut`, so the file matches `packages/pi-plan-mode/src/settings.ts` again.
- `src/settings.ts`: `updateWorkflowPlanSettings` now applies and clears `plan.toggleShortcut`; without it a saved shortcut was silently dropped.
- `src/plan/settings-menu.ts`: adds the **Plan mode shortcut** row and its input screen; an invalid key identifier warns instead of writing.
- `src/plan/plan-mode.ts`: adds `applyPlanModeShortcut`, `togglePlanMode`, and a shared `planModeDisableNotification()`, applied at session start and immediately after a Settings save.
- README: documents the setting, the default-disabled behavior, and reload semantics.

The shortcut stays disabled unless configured. Because `pi-workflow` couples Plan with Goal, the shortcut path reuses the existing guards: it cannot start Plan mode while a Goal is active (`Clear the current Goal before starting Plan mode.`) and cannot detach a Plan linked to a running Goal. Pi keeps a registered shortcut across sessions, so the handler is inert while a session is starting, replaced, or shut down.

Configure via `/workflow` → Settings → Plan settings → **Plan mode shortcut**, or in `~/.pi/agent/pi-workflow.json`:

```json
{ "plan": { "toggleShortcut": "ctrl+alt+p" } }
```

## Verification

- `npm run check`: biome, boundaries, typecheck, 354 test files / 3496 tests pass.
- `npm run test:runtime --workspace @narumitw/pi-workflow` passes.
- New tests: 4 workflow-level (no shortcut by default, configured shortcut toggles Plan mode, blocked while a Goal is active, cannot detach a linked Goal), 2 settings (nested-document round trip and clear, invalid key blocks the write without overwriting the file), 1 settings-menu (set, reject invalid, reset), plus the ported normalization compat test.
