### PR TITLE
chore(plan-mode): add the missing shortcut changeset

### DIFF
--- a/.changeset/plan-mode-toggle-shortcut.md
+++ b/.changeset/plan-mode-toggle-shortcut.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Add an optional `toggleShortcut` setting and a **Plan mode shortcut** Settings row so the global Plan-mode keybinding can be chosen, and keep it disabled while the setting is omitted. Reload the settings file automatically when it changes and rebind the configured shortcut immediately after a Settings save.


### PR DESCRIPTION
## Summary

PR #833 landed the configurable Plan-mode shortcut for `@narumitw/pi-plan-mode` with no changeset, so `changeset status` on `main` listed only `@narumitw/pi-workflow`. Without this file the next release publishes the shortcut behavior with no version bump and no changelog entry.

Unreleased `pi-plan-mode` commits since `4b8bcf9a` (`chore(release): version packages`, v0.49.3):

- `45167258` feat: add tab confirm shortcut to launch menu
- `ee7977c2` feat: add ctrl+n shortcut to toggle plan mode
- `58ebb68a` chore: remove tab launch binding
- `fa296c68` feat: switch toggle shortcut to ctrl+alt+p
- `a4ac049c` feat: allow disabling default shortcut and configure it via settings
- `d0249ba1` fix: rebind shortcut immediately after settings save
- `4412895b` fix: unify disable notification and simplify shortcut guard
- `c0aea4b1` fix: remove recommended shortcut guidance

Net user-facing effect versus the released 0.49.3, which registered no shortcut at all: a new optional `toggleShortcut` setting plus the **Plan mode shortcut** Settings row, disabled while unset, and the settings file is now watched so external edits reload and an in-menu save rebinds immediately. The intermediate tab and `ctrl+n` bindings do not survive in the net diff, so `minor` covers the shipped behavior.

## Verification

- `npx changeset status` now lists `@narumitw/pi-plan-mode` (minor) alongside `@narumitw/pi-workflow`.
- Changeset-only change; `biome:check` and `typecheck` ran in the commit hook.
