### PR TITLE
perf(workflow): defer cold plan actions

### DIFF
--- a/.changeset/quick-workflow-actions.md
+++ b/.changeset/quick-workflow-actions.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-workflow": patch
+---
+
+Reduce idle startup work by loading Plan export writes, saved-plan authentication preflight, and fresh-session implementation support only when their actions are used.

--- a/packages/pi-workflow/README.md
+++ b/packages/pi-workflow/README.md
@@ -15,7 +15,7 @@ Those packages intentionally share command, tool, event-channel, and session-sta
 ## ✨ Features
 
 - Provides `/workflow`, `/plan`, and `/goal` from one extension.
-- Registers Plan and Goal behavior eagerly while loading the combined manager and fresh-session handoff code only when those routes are used.
+- Registers required Plan and Goal lifecycle behavior eagerly while loading manager UI, Plan export writes, saved-plan authentication preflight, and fresh-session handoff code only when those routes are used.
 - Preserves Plan exploration, structured questions, completion, save, export, tool selection, and thinking-level control.
 - Supports an optional configurable global shortcut for toggling Plan mode, disabled by default.
 - Supports Plan alone, Goal alone, and approved Plan-to-Goal execution without adding a non-Goal implementation path.
@@ -355,7 +355,7 @@ packages/pi-workflow/
 │   ├── handoff.ts     # First-use fresh linked-session Plan-to-Goal transfer
 │   ├── menu.ts        # Standard /workflow TUI and RPC manager
 │   ├── settings.ts    # Unified validated and atomic settings store
-│   ├── plan/          # Package-owned Plan mode runtime
+│   ├── plan/          # Plan runtime with retryably loaded cold actions
 │   └── goal/          # Package-owned Goal runtime
 ├── test/
 ├── README.md

--- a/packages/pi-workflow/src/handoff.ts
+++ b/packages/pi-workflow/src/handoff.ts
@@ -3,11 +3,11 @@ import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { serializeGoalState } from "./goal/persistence.js";
 import { buildGoalPrompt } from "./goal/prompts.js";
 import { createGoal, GOAL_STATE_ENTRY_TYPE } from "./goal/runtime.js";
-import {
-	type FreshImplementationRequest,
-	type FreshImplementationResult,
-	formatImplementationHandoff,
+import type {
+	FreshImplementationRequest,
+	FreshImplementationResult,
 } from "./plan/fresh-implementation.js";
+import { formatImplementationHandoff } from "./plan/prompt.js";
 import type { PlanModeState } from "./plan/state.js";
 import { WORKFLOW_GOAL_OBJECTIVE } from "./workflow-contract.js";
 

--- a/packages/pi-workflow/src/plan/fresh-implementation.ts
+++ b/packages/pi-workflow/src/plan/fresh-implementation.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { formatImplementationHandoff } from "./prompt.js";
 import type { ImplementationPlanRetention } from "./settings.js";
 import type { PlanCompletionSource, PlanModeState } from "./state.js";
+
+export { formatImplementationHandoff } from "./prompt.js";
 
 type NewSessionOptions = Exclude<Parameters<ExtensionCommandContext["newSession"]>[0], undefined>;
 type ReplacementContext = Parameters<NonNullable<NewSessionOptions["withSession"]>>[0];
@@ -31,10 +34,6 @@ export type FreshImplementationResult =
 	| { kind: "partial" }
 	| { kind: "rejected" }
 	| { kind: "stale" };
-
-export function formatImplementationHandoff(plan: string) {
-	return `Plan mode is now disabled. Full tool access is restored. Implement this proposed plan now:\n\n${plan}`;
-}
 
 export async function startFreshImplementationFromState(
 	ctx: ExtensionContext,

--- a/packages/pi-workflow/src/plan/plan-export-controller.ts
+++ b/packages/pi-workflow/src/plan/plan-export-controller.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { exportStoredPlan, planExportDestination } from "./plan-export.js";
+import { exportStoredPlan } from "./plan-export.js";
+import { planExportDestination } from "./plan-export-path.js";
 import { configuredPlanExportPath, type PlanModeSettings } from "./settings.js";
 import type { PlanModeState } from "./state.js";
 

--- a/packages/pi-workflow/src/plan/plan-export-path.ts
+++ b/packages/pi-workflow/src/plan/plan-export-path.ts
@@ -1,0 +1,40 @@
+import { resolve } from "node:path";
+import { stripVTControlCharacters } from "node:util";
+
+export interface PlanExportDestination {
+	configuredPath: string;
+	resolvedPath: string;
+}
+
+export function planExportDestination(defaultPath: string, cwd: string): PlanExportDestination {
+	return {
+		configuredPath: safePlanExportNotification(defaultPath),
+		resolvedPath: safePlanExportNotification(resolvePlanExportPath(undefined, cwd, defaultPath)),
+	};
+}
+
+export function resolvePlanExportPath(
+	requestedPath: string | undefined,
+	cwd: string,
+	defaultPath: string,
+) {
+	const rawPath = requestedPath?.trim() || defaultPath;
+	const normalizedPath = rawPath.startsWith("@") ? rawPath.slice(1) : rawPath;
+	if (!normalizedPath.trim()) throw new Error("Plan export path must not be empty.");
+	if (normalizedPath.includes("\0")) {
+		throw new Error("Plan export path must not contain NUL bytes.");
+	}
+	return resolve(cwd, normalizedPath);
+}
+
+export function safePlanExportNotification(value: string) {
+	let sanitized = "";
+	for (const character of stripVTControlCharacters(value)) {
+		const codePoint = character.codePointAt(0);
+		sanitized +=
+			codePoint !== undefined && codePoint > 0x1f && !(codePoint >= 0x7f && codePoint <= 0x9f)
+				? character
+				: " ";
+	}
+	return sanitized;
+}

--- a/packages/pi-workflow/src/plan/plan-export.ts
+++ b/packages/pi-workflow/src/plan/plan-export.ts
@@ -1,19 +1,19 @@
 import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
-import { stripVTControlCharacters } from "node:util";
+import { dirname } from "node:path";
 import { type ExtensionContext, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import {
+	resolvePlanExportPath as resolveConfiguredPlanExportPath,
+	safePlanExportNotification,
+} from "./plan-export-path.js";
 import { DEFAULT_PLAN_EXPORT_PATH } from "./settings.js";
 import type { PlanModeState } from "./state.js";
 
+export type { PlanExportDestination } from "./plan-export-path.js";
+export { planExportDestination } from "./plan-export-path.js";
 export { DEFAULT_PLAN_EXPORT_PATH };
 
 export interface PlanExportResult {
 	path: string;
-}
-
-export interface PlanExportDestination {
-	configuredPath: string;
-	resolvedPath: string;
 }
 
 export interface PlanExportLifecycle {
@@ -60,7 +60,7 @@ export async function exportStoredPlan(
 		if (lifecycle?.signal.aborted || !isCurrent()) return false;
 		if (!ctx.hasUI) throw error;
 		const detail = error instanceof Error ? error.message : String(error);
-		ctx.ui.notify(safeNotification(`Unable to export plan: ${detail}`), "error");
+		ctx.ui.notify(safePlanExportNotification(`Unable to export plan: ${detail}`), "error");
 		return false;
 	}
 
@@ -69,8 +69,16 @@ export async function exportStoredPlan(
 		state.enabled && Boolean(state.latestPlan?.trim()) && lifecycle?.finishReady !== undefined;
 	if (finishedReady) lifecycle.finishReady?.();
 	const detail = finishedReady ? " Plan mode disabled." : "";
-	ctx.ui.notify(safeNotification(`Plan exported to ${result.path}.${detail}`), "info");
+	ctx.ui.notify(safePlanExportNotification(`Plan exported to ${result.path}.${detail}`), "info");
 	return true;
+}
+
+export function resolvePlanExportPath(
+	requestedPath: string | undefined,
+	cwd: string,
+	defaultPath = DEFAULT_PLAN_EXPORT_PATH,
+) {
+	return resolveConfiguredPlanExportPath(requestedPath, cwd, defaultPath);
 }
 
 export async function exportPlanToFile(
@@ -98,39 +106,6 @@ export async function exportPlanToFile(
 		}
 	});
 	return { path };
-}
-
-export function planExportDestination(defaultPath: string, cwd: string): PlanExportDestination {
-	return {
-		configuredPath: safeNotification(defaultPath),
-		resolvedPath: safeNotification(resolvePlanExportPath(undefined, cwd, defaultPath)),
-	};
-}
-
-export function resolvePlanExportPath(
-	requestedPath: string | undefined,
-	cwd: string,
-	defaultPath = DEFAULT_PLAN_EXPORT_PATH,
-) {
-	const rawPath = requestedPath?.trim() || defaultPath;
-	const normalizedPath = rawPath.startsWith("@") ? rawPath.slice(1) : rawPath;
-	if (!normalizedPath.trim()) throw new Error("Plan export path must not be empty.");
-	if (normalizedPath.includes("\0")) {
-		throw new Error("Plan export path must not contain NUL bytes.");
-	}
-	return resolve(cwd, normalizedPath);
-}
-
-function safeNotification(value: string) {
-	let sanitized = "";
-	for (const character of stripVTControlCharacters(value)) {
-		const codePoint = character.codePointAt(0);
-		sanitized +=
-			codePoint !== undefined && codePoint > 0x1f && !(codePoint >= 0x7f && codePoint <= 0x9f)
-				? character
-				: " ";
-	}
-	return sanitized;
 }
 
 function throwIfCancelled(signal: AbortSignal | undefined, isCurrent: () => boolean) {

--- a/packages/pi-workflow/src/plan/plan-mode.ts
+++ b/packages/pi-workflow/src/plan/plan-mode.ts
@@ -17,25 +17,21 @@ import {
 	onAgentSettled,
 	setPlanThinkingLevel,
 } from "./extension-runtime.js";
-import {
-	type FreshImplementationFromStateOptions,
-	formatImplementationHandoff,
-	startFreshImplementationFromState,
-} from "./fresh-implementation.js";
+import type { FreshImplementationFromStateOptions } from "./fresh-implementation.js";
 import {
 	createImplementationRetentionCoordinator,
 	implementationRetentionPreview,
 } from "./implementation-retention.js";
 import { invalidPlanMessage, latestAssistantText, parseProposedPlan } from "./message-transform.js";
 import { createPlanActionController } from "./plan-action-controller.js";
-import { createPlanExportController } from "./plan-export-controller.js";
+import { planExportDestination } from "./plan-export-path.js";
 import {
 	clearPlanModeUi,
 	planModeStatusText as formatPlanModeStatusText,
 	showStoredPlan,
 	updatePlanModeUi,
 } from "./presentation.js";
-import { buildPlanModePrompt } from "./prompt.js";
+import { buildPlanModePrompt, formatImplementationHandoff } from "./prompt.js";
 import {
 	answerPlanModeQuestions,
 	normalizePlanModeQuestionParams,
@@ -45,12 +41,9 @@ import {
 } from "./question-tool.js";
 import { withoutRequiredPlanModeTools, withRequiredPlanModeTools } from "./required-tools.js";
 import {
-	preflightSavedPlanImplementation,
-	savedPlanBlocksNewWorkflow,
-} from "./saved-plan-preflight.js";
-import {
 	awaitPlanModeSettingsWrites,
 	configuredImplementationPlanRetention,
+	configuredPlanExportPath,
 	configuredPlanModeToggleShortcut,
 	configuredThinkingLevel,
 	type ImplementationPlanRetention,
@@ -83,6 +76,15 @@ interface ReadyPresentationIntent {
 	source: PlanCompletionSource;
 }
 type InteractiveUi = typeof import("./interactive-ui.js");
+type FreshImplementationModule = Pick<
+	typeof import("./fresh-implementation.js"),
+	"startFreshImplementationFromState"
+>;
+type PlanExportModule = Pick<typeof import("./plan-export.js"), "exportStoredPlan">;
+type SavedPlanPreflightModule = Pick<
+	typeof import("./saved-plan-preflight.js"),
+	"preflightSavedPlanImplementation"
+>;
 
 export interface PlanImplementationHandoffRequest {
 	implementationId: string;
@@ -98,6 +100,9 @@ export interface PlanModeDependencies {
 	settingsPath?: string;
 	reportSettingsIssues?: boolean;
 	loadInteractiveUi?(): Promise<InteractiveUi>;
+	loadFreshImplementation?(): Promise<FreshImplementationModule>;
+	loadPlanExport?(): Promise<PlanExportModule>;
+	loadSavedPlanPreflight?(): Promise<SavedPlanPreflightModule>;
 	updateSettings?: typeof updatePlanModeSettings;
 	shouldAutoHandoff?(): boolean;
 	canStartPlan?(): string | undefined;
@@ -142,6 +147,15 @@ export default function planMode(
 		}
 		return interactiveUiPromise;
 	};
+	const loadFreshImplementation = cachedModuleLoader(
+		dependencies.loadFreshImplementation ?? (() => import("./fresh-implementation.js")),
+	);
+	const loadPlanExport = cachedModuleLoader(
+		dependencies.loadPlanExport ?? (() => import("./plan-export.js")),
+	);
+	const loadSavedPlanPreflight = cachedModuleLoader(
+		dependencies.loadSavedPlanPreflight ?? (() => import("./saved-plan-preflight.js")),
+	);
 	let state: PlanModeState = { enabled: false, awaitingAction: false };
 	let settings: PlanModeSettings = { thinkingLevel: "inherit" };
 	let toggleShortcut: ReturnType<typeof configuredPlanModeToggleShortcut>;
@@ -159,23 +173,19 @@ export default function planMode(
 	let menuController = new AbortController();
 	const implementationRetention = createImplementationRetentionCoordinator();
 	const persistState = () => pi.appendEntry<PlanModeState>(STATE_ENTRY_TYPE, state);
-	const planExports = createPlanExportController({
-		getState: () => state,
-		getSettings: () => settings,
-		finishReady: (ctx) => exitPlanMode(ctx),
-	});
 	const planActions = createPlanActionController({
 		loadInteractiveUi,
 		getState: () => state,
 		captureLifecycle: captureMenuLifecycle,
 		statusText: planStatusText,
 		implementationOutcome,
-		getExportDestination: (ctx) => planExports.getDestination(ctx),
+		getExportDestination: (ctx) =>
+			planExportDestination(configuredPlanExportPath(settings), ctx.cwd),
 		show: (ctx) => showStoredPlan(pi, ctx, state),
 		finalize: requestFinalPlan,
 		implementHere: startImplementation,
 		implementFresh: startFreshImplementation,
-		exportPlan: (ctx, path, signal, isCurrent) => planExports.export(path, ctx, signal, isCurrent),
+		exportPlan: (ctx, path, signal, isCurrent) => exportPlan(path, ctx, signal, isCurrent),
 		settings: showSettings,
 		save: savePlanForLater,
 		stay: updateUi,
@@ -302,7 +312,7 @@ export default function planMode(
 			const exportMatch = /^export(?:\s+([\s\S]+))?$/iu.exec(prompt);
 			if (exportMatch) {
 				const lifecycle = captureMenuLifecycle();
-				await planExports.export(exportMatch[1], ctx, lifecycle.signal, lifecycle.isCurrent);
+				await exportPlan(exportMatch[1], ctx, lifecycle.signal, lifecycle.isCurrent);
 				return;
 			}
 			if (command === "exit" || command === "off") {
@@ -747,11 +757,52 @@ export default function planMode(
 		ctx.ui.notify("Plan saved for later. Plan mode disabled.", "info");
 	}
 
+	async function exportPlan(
+		path: string | undefined,
+		ctx: ExtensionContext,
+		signal: AbortSignal,
+		isCurrent: () => boolean,
+	) {
+		const exportedState = state;
+		const defaultPath = configuredPlanExportPath(settings);
+		if (signal.aborted || !isCurrent()) return false;
+		let module: PlanExportModule;
+		try {
+			module = await loadPlanExport();
+		} catch (error) {
+			if (signal.aborted || !isCurrent() || state !== exportedState) return false;
+			throw error;
+		}
+		if (signal.aborted || !isCurrent() || state !== exportedState) return false;
+		return module.exportStoredPlan(
+			exportedState,
+			path,
+			ctx,
+			{
+				signal,
+				isCurrent,
+				getState: () => state,
+				finishReady: () => exitPlanMode(ctx),
+			},
+			defaultPath,
+		);
+	}
+
 	async function startFreshImplementation(ctx: ExtensionContext, menuIsCurrent: () => boolean) {
-		await startFreshImplementationFromState(ctx, {
+		const retention = effectiveImplementationPlanRetention();
+		if (!menuIsCurrent()) return;
+		let module: FreshImplementationModule;
+		try {
+			module = await loadFreshImplementation();
+		} catch (error) {
+			if (!menuIsCurrent()) return;
+			throw error;
+		}
+		if (!menuIsCurrent()) return;
+		await module.startFreshImplementationFromState(ctx, {
 			getState: () => state,
 			menuIsCurrent,
-			retention: effectiveImplementationPlanRetention(),
+			retention,
 			stateEntryType: STATE_ENTRY_TYPE,
 			...(dependencies.startFreshImplementation
 				? { startSession: dependencies.startFreshImplementation }
@@ -762,15 +813,18 @@ export default function planMode(
 	async function startImplementation(ctx: ExtensionContext) {
 		const savedPlan = state.enabled ? undefined : state.savedPlan;
 		if (savedPlan) {
-			const sessionGeneration = menuGeneration;
-			const planWorkflowGeneration = workflowGeneration;
+			const lifecycle = captureMenuLifecycle();
 			const isCurrent = () =>
-				sessionGeneration === menuGeneration &&
-				planWorkflowGeneration === workflowGeneration &&
-				!menuController.signal.aborted &&
-				!state.enabled &&
-				state.savedPlan === savedPlan;
-			if (!(await preflightSavedPlanImplementation(ctx, isCurrent))) return;
+				lifecycle.isCurrent() && !state.enabled && state.savedPlan === savedPlan;
+			let module: SavedPlanPreflightModule;
+			try {
+				module = await loadSavedPlanPreflight();
+			} catch (error) {
+				if (!isCurrent()) return;
+				throw error;
+			}
+			if (!isCurrent()) return;
+			if (!(await module.preflightSavedPlanImplementation(ctx, isCurrent))) return;
 		}
 		const plan = (state.enabled ? state.latestPlan : savedPlan?.plan)?.trim();
 		const source =
@@ -1017,11 +1071,12 @@ export default function planMode(
 		if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 		await ui.showActiveImplementationMenu(ctx, {
 			statusText: planStatusText(),
-			getExportDestination: () => planExports.getDestination(ctx),
+			getExportDestination: () =>
+				planExportDestination(configuredPlanExportPath(settings), ctx.cwd),
 			signal: lifecycle.signal,
 			isCurrent: lifecycle.isCurrent,
 			show: () => showStoredPlan(pi, ctx, state),
-			exportPlan: (path, signal) => planExports.export(path, ctx, signal, lifecycle.isCurrent),
+			exportPlan: (path, signal) => exportPlan(path, ctx, signal, lifecycle.isCurrent),
 			settings: (signal) => showSettings(ctx, signal, lifecycle.isCurrent),
 			...(state.activeImplementation?.goalId
 				? {
@@ -1078,12 +1133,15 @@ export default function planMode(
 		const sessionGeneration = menuGeneration;
 		const planWorkflowGeneration = workflowGeneration;
 		const controller = menuController;
+		const sessionManager = currentContext?.sessionManager;
 		return {
 			signal: controller.signal,
 			isCurrent: () =>
 				sessionGeneration === menuGeneration &&
 				planWorkflowGeneration === workflowGeneration &&
-				!controller.signal.aborted,
+				controller === menuController &&
+				!controller.signal.aborted &&
+				currentContext?.sessionManager === sessionManager,
 		};
 	}
 
@@ -1309,6 +1367,30 @@ export default function planMode(
 		recoverUnlinkedImplementation,
 		handleGoalState,
 		reconcileGoalState,
+	};
+}
+
+function savedPlanBlocksNewWorkflow(ctx: ExtensionContext, hasSavedPlan: boolean) {
+	if (!hasSavedPlan) return false;
+	const message =
+		"A plan is saved for later. Implement or clear it before starting another Plan-mode workflow.";
+	if (!ctx.hasUI) throw new Error(message);
+	ctx.ui.notify(message, "warning");
+	return true;
+}
+
+function cachedModuleLoader<Module>(load: () => Promise<Module>): () => Promise<Module> {
+	let pending: Promise<Module> | undefined;
+	return () => {
+		if (!pending) {
+			pending = Promise.resolve()
+				.then(load)
+				.catch((error) => {
+					pending = undefined;
+					throw error;
+				});
+		}
+		return pending;
 	};
 }
 

--- a/packages/pi-workflow/src/plan/prompt.ts
+++ b/packages/pi-workflow/src/plan/prompt.ts
@@ -1,5 +1,9 @@
 const PLAN_CONTEXT_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
 
+export function formatImplementationHandoff(plan: string) {
+	return `Plan mode is now disabled. Full tool access is restored. Implement this proposed plan now:\n\n${plan}`;
+}
+
 export function buildPlanModePrompt() {
 	return `${PLAN_CONTEXT_MARKER}
 # Plan Mode (Conversational)

--- a/packages/pi-workflow/test/lazy-loading.test.ts
+++ b/packages/pi-workflow/test/lazy-loading.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { builtinTool, createMockContext, createMockPi } from "../../../test/support.js";
-import workflow from "../src/workflow.js";
+import workflow from "../src/index.js";
+import planMode from "../src/plan/plan-mode.js";
 
 const BASE_TOOLS = ["read", "bash", "edit", "write"];
 const GOAL_TOOLS = ["goal_complete", "goal_blocked", "goal_wait"];
@@ -22,7 +23,20 @@ function createWorkflow() {
 	});
 }
 
-test("idle startup keeps Workflow manager and fresh handoff modules unloaded", async () => {
+async function enterReadyPlan(mock: ReturnType<typeof createMockPi>, ctx: unknown) {
+	await mock.commands.get("plan")?.handler("start", ctx as never);
+	const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete");
+	assert.ok(complete);
+	await (complete.execute as (...args: unknown[]) => Promise<unknown>)(
+		"complete-plan",
+		{ plan: "# Lazy action plan" },
+		undefined,
+		undefined,
+		ctx,
+	);
+}
+
+test("canonical entry synchronously registers runtime surfaces without loading cold modules", async () => {
 	const mock = createWorkflow();
 	let menuLoads = 0;
 	let handoffLoads = 0;
@@ -43,6 +57,10 @@ test("idle startup keeps Workflow manager and fresh handoff modules unloaded", a
 		mock.tools.map((tool) => tool.name),
 		["goal_complete", "goal_blocked", "goal_wait", "plan_mode_question", "plan_mode_complete"],
 	);
+	assert.ok(mock.flags.has("plan"));
+	for (const event of ["session_start", "session_shutdown", "context", "agent_end"]) {
+		assert.ok((mock.events.get(event)?.length ?? 0) > 0, `expected ${event} registration`);
+	}
 	const context = createMockContext({ mode: "tui", hasUI: true });
 	await emitAll(mock, "session_start", { reason: "startup" }, context.ctx);
 
@@ -166,4 +184,214 @@ test("session replacement while the fresh handoff loads prevents session replace
 	await pending;
 
 	assert.equal(handoffs, 0);
+});
+
+test("Plan export loader retries rejection and caches a successful module", async () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	let loads = 0;
+	let exports = 0;
+	planMode(mock.pi, {
+		loadPlanExport: async () => {
+			loads += 1;
+			if (loads === 1) throw new Error("temporary export module failure");
+			return {
+				exportStoredPlan: async () => {
+					exports += 1;
+					return true;
+				},
+			};
+		},
+	});
+	const context = createMockContext({ hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await enterReadyPlan(mock, context.ctx);
+
+	await assert.rejects(
+		mock.commands.get("plan")?.handler("export", context.ctx) as Promise<unknown>,
+		/temporary export module failure/u,
+	);
+	await mock.commands.get("plan")?.handler("export", context.ctx);
+	await mock.commands.get("plan")?.handler("export", context.ctx);
+
+	assert.equal(loads, 2);
+	assert.equal(exports, 2);
+});
+
+test("saved Plan preflight loader retries rejection and caches a successful module", async () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	let loads = 0;
+	let preflights = 0;
+	planMode(mock.pi, {
+		loadSavedPlanPreflight: async () => {
+			loads += 1;
+			if (loads === 1) throw new Error("temporary preflight module failure");
+			return {
+				preflightSavedPlanImplementation: async () => {
+					preflights += 1;
+					return false;
+				},
+			};
+		},
+	});
+	const context = createMockContext({ hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await enterReadyPlan(mock, context.ctx);
+	await mock.commands.get("plan")?.handler("save", context.ctx);
+
+	await assert.rejects(
+		mock.commands.get("plan")?.handler("implement", context.ctx) as Promise<unknown>,
+		/temporary preflight module failure/u,
+	);
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+
+	assert.equal(loads, 2);
+	assert.equal(preflights, 2);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("fresh implementation loader retries rejection and caches a successful module", async () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	let loads = 0;
+	let starts = 0;
+	planMode(mock.pi, {
+		loadFreshImplementation: async () => {
+			loads += 1;
+			if (loads === 1) throw new Error("temporary fresh module failure");
+			return {
+				startFreshImplementationFromState: async () => {
+					starts += 1;
+					return { kind: "started" as const };
+				},
+			};
+		},
+	});
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (_title: string, options: string[]) =>
+			options.includes("Start fresh with Goal") ? "Start fresh with Goal" : undefined,
+	});
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await enterReadyPlan(mock, context.ctx);
+
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("", context.ctx);
+	await mock.commands.get("plan")?.handler("", context.ctx);
+
+	assert.equal(loads, 2);
+	assert.ok(starts >= 2);
+});
+
+test("session shutdown while Plan export code loads prevents file execution", async () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	let release!: () => void;
+	let started!: () => void;
+	const loading = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let exports = 0;
+	planMode(mock.pi, {
+		loadPlanExport: async () => {
+			started();
+			await gate;
+			return {
+				exportStoredPlan: async () => {
+					exports += 1;
+					return true;
+				},
+			};
+		},
+	});
+	const context = createMockContext({ hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await enterReadyPlan(mock, context.ctx);
+	const pending = mock.commands.get("plan")?.handler("export", context.ctx);
+	await loading;
+	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+	release();
+	await pending;
+
+	assert.equal(exports, 0);
+});
+
+test("session replacement while saved preflight code loads prevents authentication", async () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	let release!: () => void;
+	let started!: () => void;
+	const loading = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let preflights = 0;
+	planMode(mock.pi, {
+		loadSavedPlanPreflight: async () => {
+			started();
+			await gate;
+			return {
+				preflightSavedPlanImplementation: async () => {
+					preflights += 1;
+					return true;
+				},
+			};
+		},
+	});
+	const context = createMockContext({ hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await enterReadyPlan(mock, context.ctx);
+	await mock.commands.get("plan")?.handler("save", context.ctx);
+	const pending = mock.commands.get("plan")?.handler("implement", context.ctx);
+	await loading;
+	const replacement = createMockContext({ hasUI: true });
+	await mock.events.get("session_start")?.[0]?.({ reason: "switch" }, replacement.ctx);
+	release();
+	await pending;
+
+	assert.equal(preflights, 0);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("session shutdown while fresh implementation code loads prevents replacement", async () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	let release!: () => void;
+	let started!: () => void;
+	const loading = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let starts = 0;
+	planMode(mock.pi, {
+		loadFreshImplementation: async () => {
+			started();
+			await gate;
+			return {
+				startFreshImplementationFromState: async () => {
+					starts += 1;
+					return { kind: "started" as const };
+				},
+			};
+		},
+	});
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (_title: string, options: string[]) =>
+			options.includes("Start fresh with Goal") ? "Start fresh with Goal" : undefined,
+	});
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await enterReadyPlan(mock, context.ctx);
+	const pending = mock.commands.get("plan")?.handler("", context.ctx);
+	await loading;
+	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+	release();
+	await pending;
+
+	assert.equal(starts, 0);
 });


### PR DESCRIPTION
## Summary

- Load Plan export writes, saved-plan authentication preflight, and standalone fresh implementation support only when their actions are used.
- Keep export destination previews, lifecycle registration, state restoration, tool policy, and Plan-to-Goal reconciliation eager.
- Preserve existing source-level imports through compatibility exports.
- Add retry, cache, replacement, shutdown, and synchronous-registration coverage plus a patch Changeset.

## Performance

Ten measured runs against base `3f589813`:

| Measurement | Base | Optimized | Change |
| --- | ---: | ---: | ---: |
| Eager local modules | 41 | 38 | -3 |
| Import median | 358.5 ms | 332 ms | -26.5 ms (-7.4%) |
| First-RPC median | 1,673.91 ms | 1,344.95 ms | -328.96 ms (-19.7%) |

## Verification

- `PI_EXTENSIONS_TEST_BASE=origin/main npm run check`: passed after commit with 44 affected files and 590 tests.
- `npx vitest run packages/pi-workflow/test --maxWorkers=1`: 42 files and 586 tests passed.
- `npm run test:runtime --workspace @narumitw/pi-workflow`: passed.
- `just pack workflow`: inspected 56 packaged files, including every cold module and `src/index.ts`.
- Isolated offline `pi -e ./packages/pi-workflow` RPC smoke discovered `/goal`, `/plan`, and `/workflow`.
- Ten-run startup benchmark and 38-module static trace passed the planned performance gates.

## Audits and risks

- `docs/extension-conventions.md`: lazy imports retry rejection and revalidate signal, state, controller, generation, and session-manager ownership before side effects.
- `docs/extension-settings.md`: settings and persistence implementations are unchanged; focused settings, linked-lifecycle, and workflow tests passed 104 tests.
- Public command, tool, renderer, setting, status, event-channel, and persistence contracts are unchanged.
- Two local all-package test attempts encountered unrelated Git-heavy 30-second timeouts while the machine was under high swap and endpoint scanning; the committed affected-test CI-equivalent gate passed cleanly.
