### PR TITLE
refactor(tooling): separate checks from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,10 @@ jobs:
           test "$installed_version" = "$expected_version"
           test "$cli_version" = "$expected_version"
 
-      - name: Run checks and affected tests
+      - name: Run checks
+        run: npm run check
+
+      - name: Run affected tests
         env:
           PI_EXTENSIONS_TEST_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
-        run: npm run check
+        run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate packages
+      - name: Run checks
         run: npm run check
+
+      - name: Run tests
+        run: npm test
 
       - name: Create version pull request or publish to npm
         id: changesets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ Run commands from the repository root unless a command says otherwise.
 - Run `npm run format` or `just format` to format with Biome.
 - Run `npm run typecheck` to typecheck every workspace.
 - Run `just --list` before adding or documenting a workflow command.
+- Put repository workflows intended for manual use in `justfile`, and keep recipes as thin command entrypoints.
+- Put complex Bash or TypeScript workflow implementations under `scripts/`, then invoke them from recipes or automation.
+- Keep npm scripts as composable package and automation primitives.
 
 ## Tooling and dependency safety
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,9 @@ Run commands from the repository root unless a command says otherwise.
 
 - Keep active tests under `packages/<package>/test/*.test.ts` and run them with `npm test`.
 - Keep archived tests under `deprecated/` and outside active checks.
-- Use `npm run check` or `just check` as the CI-equivalent gate for Biome, boundaries, typechecks, and tests.
+- Run `npm run check` or `just check` for the build, Biome, boundaries, and workspace typechecks.
+- Run `npm test` or `just test` separately for active tests.
+- CI and release verification must run both gates.
 - Run `just pack <unscoped-name>` and inspect the tarball after package metadata or publishing changes.
 - Run `just try <unscoped-name>` or an equivalent `pi -e` smoke after extension runtime-loading changes; record why and what remains unverified if the smoke is impractical.
 - Start subprocess timing deadlines only after a child readiness handshake.

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -271,9 +271,10 @@ to use the extension safely.
   requires a real Pi runtime or external service, record and run the smallest representative smoke
   instead. **Verification:** `Test` through root `npm test`, `Smoke` for the stated runtime path, and
   `Review` of any intentionally untested behavior.
-- **MUST:** Run the repository CI-equivalent gate before completing a change, and add an npm pack dry
-  run or local Pi load when package metadata or runtime loading changed. **Verification:** `Validator`
-  via `npm run check`; applicable `Smoke` evidence in the change handoff.
+- **MUST:** Run both repository verification gates before completing a change, and add an npm pack
+  dry run or local Pi load when package metadata or runtime loading changed. **Verification:**
+  `Validator` via `npm run check`, `Test` via `npm test`, and applicable `Smoke` evidence in the change
+  handoff.
 
 Do not create a validator merely because a convention is written down. Add one when a new or touched
 area has a stable, low-false-positive rule that can be checked without encoding product semantics in
@@ -293,7 +294,7 @@ fragile regular expressions. Until then, label the real verification method hone
 - [ ] Follow `docs/extension-settings.md` for every user or project setting.
 - [ ] Bound tool output, cancellation, state persistence, and file mutation where applicable.
 - [ ] Document installation, behavior, settings, security, limitations, and source responsibilities.
-- [ ] Add deterministic tests and run `npm run check`.
+- [ ] Add deterministic tests, run `npm run check`, and run `npm test`.
 - [ ] Inspect `npm pack --workspace <name> --dry-run --json` and load the declared entrypoint with Pi.
 
 ## Touched-area checklist
@@ -304,6 +305,6 @@ fragile regular expressions. Until then, label the real verification method hone
 - [ ] For command-surface changes, preserve established routes or explicitly own an approved breaking
       migration, and test every claimed execution mode.
 - [ ] Update focused tests and run the verification method named by each relevant MUST.
-- [ ] Run `npm run check`; add pack or Pi runtime smokes when metadata or loading changed.
+- [ ] Run `npm run check` and `npm test`; add pack or Pi runtime smokes when metadata or loading changed.
 - [ ] Report any skipped check, accepted exception, or follow-up validator opportunity in the change
       handoff.

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 default:
     @just --list
 
-# Run the CI-equivalent verification gate
+# Run build, formatting, boundary, and type checks
 check:
     npm run check
 
@@ -30,6 +30,7 @@ verify-update:
     # Rebuild generated web assets only in workspaces that provide build:web
     npm --workspaces --if-present run build:web
     npm run check
+    npm test
     npm pack --workspaces --dry-run
 
 # Update, clean-install, rebuild, test, and pack all npm workspaces

--- a/scripts/run-checks.mjs
+++ b/scripts/run-checks.mjs
@@ -2,7 +2,7 @@
 
 import concurrently from "concurrently";
 
-const checks = ["biome:check", "check:boundaries", "typecheck", "test"];
+const checks = ["biome:check", "check:boundaries", "typecheck"];
 const env = { ...process.env, PI_EXTENSIONS_BUILD_READY: "1" };
 
 console.log(`Running checks in parallel: ${checks.join(", ")}`);

--- a/test/check-test-separation.test.ts
+++ b/test/check-test-separation.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "vitest";
+
+const root = resolve(import.meta.dirname, "..");
+
+function read(relativePath: string) {
+	return readFileSync(resolve(root, relativePath), "utf8");
+}
+
+test("check and test remain separate repository gates", () => {
+	const runChecks = read("scripts/run-checks.mjs");
+	const checksMatch = /const checks = (\[[^\n]+\]);/u.exec(runChecks);
+	assert.ok(checksMatch, "run-checks must declare its task list");
+	assert.deepEqual(JSON.parse(checksMatch[1] ?? "[]"), [
+		"biome:check",
+		"check:boundaries",
+		"typecheck",
+	]);
+
+	const manifest = JSON.parse(read("package.json")) as { scripts?: Record<string, string> };
+	assert.match(manifest.scripts?.check ?? "", /run-checks\.mjs/u);
+	assert.match(manifest.scripts?.test ?? "", /run-tests\.mjs/u);
+	assert.doesNotMatch(manifest.scripts?.check ?? "", /npm (?:run )?test/u);
+
+	for (const workflow of [".github/workflows/ci.yml", ".github/workflows/publish.yml"]) {
+		const contents = read(workflow);
+		const checkIndex = contents.indexOf("run: npm run check");
+		const testIndex = contents.indexOf("run: npm test");
+		assert.ok(checkIndex >= 0, `${workflow} must run checks`);
+		assert.ok(testIndex > checkIndex, `${workflow} must run tests after checks`);
+	}
+});


### PR DESCRIPTION
## Summary

- Remove tests from `npm run check` so it runs build, Biome, package boundaries, and workspace typechecks only.
- Keep `npm test` as the explicit Vitest gate.
- Run both commands as separate CI and release workflow steps.
- Keep `just check` and `just test` as thin user-facing manual recipes.
- Document that complex Bash or TypeScript workflow implementations belong under `scripts/`.
- Add a Vitest regression test for the gate and workflow separation.

## Verification

- `npm run check`: passed and reported only `biome:check`, `check:boundaries`, and `typecheck` after the build.
- `npx vitest run test/check-test-separation.test.ts`: 1 file and 1 test passed.
- `just --list`: passed with separate `check` and `test` recipes.
- Signed pre-commit gates: Biome and every workspace typecheck passed for both commits.
- `git diff --check`: passed.

## Risk

The full test suite was not rerun locally because this change intentionally separates it from `check` and the current machine was causing unrelated Git-heavy timeout failures under memory and endpoint-scanning pressure.
CI invokes `npm test` explicitly in a separate step, and the publish workflow also requires it before release work.
