### PR TITLE
docs: allow built TypeScript extension entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,12 +58,13 @@ Run commands from the repository root unless a command says otherwise.
 - Share code only through Pi's public extension-neutral APIs or reusable non-extension libraries.
 - Do not make reusable libraries coordinate specific extensions.
 - Consume shared Pi APIs without extension-specific branches.
-- Give every active extension a thin `src/index.ts` default-export forwarder.
-- Declare exactly `"pi": { "extensions": ["./src/index.ts"] }` in every active extension manifest.
-- Keep extension implementation in descriptively named modules.
+- Give every active extension a thin `src/index.ts` default-export forwarder and keep authoritative implementation under `src/`.
+- Declare exactly one extension entrypoint in each active extension manifest: `./src/index.ts`, or a build-backed `./dist/index.ts` TypeScript bundle loaded by Pi's Jiti runtime.
+- Require a `dist/index.ts` entrypoint to stay within `dist`, externalize Pi-bundled peer dependencies, publish `dist`, and be built before packing or loading the package directory.
+- Keep extension implementation in descriptively named source modules.
 - Build and publish reusable libraries as JavaScript with declarations through their own build configuration and without `pi.extensions`.
 - Run `npm run check:boundaries` to verify package boundaries.
-- List every stable extension entrypoint in the root `package.json` under `pi.extensions`.
+- List every stable extension's `src/index.ts` repository entrypoint in the root `package.json` under `pi.extensions`.
 - Do not list experimental extension entrypoints in the root `package.json` under `pi.extensions`.
 - Add a root workspace script or recipe only for a workflow users must run from the repository root.
 - Use `@narumitw/pi-tui-kit` for new standard action, detail, settings, and multi-select menus.

--- a/README.md
+++ b/README.md
@@ -219,9 +219,10 @@ scripts/                 Shared checks, tests, versioning, and release helpers
 test/                    Root integration and repository tests
 ```
 
-Each active package contains its own `package.json`, `README.md`, `LICENSE`, `tsconfig.json`, and
-TypeScript source under `src/`. Extension `src/index.ts` files are thin Pi entrypoints and declare a
-stable or experimental lifecycle; reusable libraries publish built ESM and declarations from `dist/`.
+Each active package contains its own `package.json`, `README.md`, `LICENSE`, `tsconfig.json`, and TypeScript source under `src/`.
+Every extension keeps a thin `src/index.ts` source forwarder and declares a stable or experimental lifecycle.
+An extension package may load that source entrypoint directly or publish a build-backed `dist/index.ts` bundle for Pi's Jiti runtime.
+Reusable libraries publish built ESM and declarations from `dist/`.
 
 <details>
 <summary>Deprecated packages</summary>

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -55,8 +55,8 @@ it is not an API reference.
 - **MUST:** Treat installed extension code as fully privileged and load only trusted sources.
   **Verification:** `Review` of installation documentation and any code-loading path.
 
-A package may declare multiple entrypoints, but this repository deliberately uses one forwarding
-entrypoint per active package as described below.
+Pi packages may declare multiple entrypoints, but this repository deliberately declares exactly one entrypoint per active extension.
+The repository always keeps a source forwarder and may publish either that source entrypoint or a build-backed TypeScript bundle for Pi's Jiti loader, as described below.
 
 ### Factory and lifecycle
 
@@ -123,17 +123,16 @@ interactive work should expose cancellation.
 
 ### Package layout and boundaries
 
-- **MUST:** Keep every active extension and reusable publishable library under
-  `packages/<package>/`, and deprecated references under `deprecated/<package>/`. Give each extension
-  explicit `piExtension.lifecycle` metadata with value `stable` or `experimental`; omit that metadata
-  from libraries. The private root Pi manifest must list every stable extension entrypoint and no
-  experimental entrypoint so direct Git installation preserves the lifecycle boundary.
+- **MUST:** Keep every active extension and reusable publishable library under `packages/<package>/`, and deprecated references under `deprecated/<package>/`.
+  Give each extension explicit `piExtension.lifecycle` metadata with value `stable` or `experimental`; omit that metadata from libraries.
+  The private root Pi manifest must list every stable extension's `src/index.ts` repository entrypoint and no experimental entrypoint so direct Git installation preserves the lifecycle boundary without requiring generated package output.
   **Verification:** `Validator` via `npm run check:boundaries` plus `Review` of lifecycle moves.
-- **MUST:** Give every active extension a thin `src/index.ts` default-export forwarder and declare
-  exactly `"pi": { "extensions": ["./src/index.ts"] }`; keep implementation in descriptive modules.
-  Reusable libraries must not declare `pi.extensions` or `piExtension` and must publish built
-  JavaScript plus declarations. **Verification:** `Validator` via `npm run check:boundaries` and a
-  clean-build package smoke.
+- **MUST:** Give every active extension a thin `src/index.ts` default-export forwarder and keep authoritative implementation under `src/` in descriptive modules.
+  Declare exactly one package entrypoint: `"pi": { "extensions": ["./src/index.ts"] }` for direct source loading or `"pi": { "extensions": ["./dist/index.ts"] }` for a build-backed TypeScript bundle loaded by Pi's Jiti runtime.
+  A `dist/index.ts` entrypoint must be produced by the package build, must not forward back into `src/`, and must keep Pi-bundled peer dependencies external rather than embedding duplicate runtime copies.
+  A package that declares `dist/index.ts` must publish `dist`, run its build before packing, and document that an unbuilt local checkout must be built before loading the package directory.
+  Reusable libraries must not declare `pi.extensions` or `piExtension` and must publish built JavaScript plus declarations.
+  **Verification:** `Validator` via `npm run check:boundaries`, `Review` of the bundle boundary, and clean-build package and Pi load smokes.
 - **MUST:** Keep extension packages free of extension-to-extension dependencies. Extensions may
   depend on publishable helper libraries under `packages/`.
   **Verification:** `Validator` via `npm run check:boundaries`.
@@ -284,7 +283,7 @@ fragile regular expressions. Until then, label the real verification method hone
 
 - [ ] Place the package under `packages/`, declare the correct extension lifecycle when applicable,
       and keep it independently installable.
-- [ ] Add the thin `src/index.ts` forwarder and canonical `pi.extensions` manifest entry.
+- [ ] Add the thin `src/index.ts` forwarder and declare one supported `pi.extensions` entrypoint: direct `src/index.ts` or build-backed `dist/index.ts`.
 - [ ] Separate factory registration from session-owned startup and idempotent shutdown cleanup.
 - [ ] Choose the primary command and no-argument behavior from the extension's product role; use a
       menu-first manager unless a concrete reason supports another shape, and add direct routes only


### PR DESCRIPTION
## Summary

- allow extension packages to declare a build-backed `dist/index.ts` entrypoint for Pi's Jiti runtime
- retain `src/index.ts` as the authoritative source forwarder and root direct-Git entrypoint
- document bundle boundaries, packaging requirements, and local build expectations

## Verification

- `npm run check`
- signed pre-commit `biome:check` and workspace typechecks
- `git diff --check`

`npm test` was not completed because this is a documentation-only change and testing was stopped at the user's request.
No changeset is required for repository-only documentation.
The boundary validator remains unchanged for now and will be updated with the first `dist/index.ts` adopter.
