### PR TITLE
chore: build local artifacts before dev

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,12 +97,12 @@ benchmark-subagents samples="7":
 benchmark-codex-compact *args:
     node packages/pi-codex-compact/benchmark/run.mjs {{ args }}
 
-# Install dependencies, build the shared TUI library, and start every local extension package
+# Install dependencies, build local package artifacts, and start every local extension package
 # pi-statusline and pi-tui-kit are intentionally excluded from Pi extension loading
 # PI_TIMING reports startup timing and PI_CODING_AGENT_DIR isolates local development state
 dev:
     npm install
-    npm --workspace @narumitw/pi-tui-kit run build
+    npm run build
     PI_TIMING=1 PI_CODING_AGENT_DIR=./.pi/agent pi \
         -e ./packages/pi-accounts \
         -e ./packages/pi-analytics \


### PR DESCRIPTION
## Summary

- make `just dev` run the root workspace build before loading local extensions
- generate every build-backed extension runtime, including `pi-workflow`, from a clean checkout
- reuse the existing root build script instead of maintaining a duplicate workspace list

## Verification

- `just --list`
- `just --dry-run dev`
- `just --dry-run try workflow`
- `npm run build`
- `npm run check`
- `npm test` — 361 files and 3,544 tests passed
- `npm --workspace @narumitw/pi-workflow run test:runtime`

No Changeset is needed because this only changes a repository-local development workflow.
