### PR TITLE
chore: update dependencies

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 				"packages/*"
 			],
 			"devDependencies": {
-				"@biomejs/biome": "^2.5.8",
-				"@changesets/cli": "3.0.0",
+				"@biomejs/biome": "^2.5.9",
+				"@changesets/cli": "3.0.1",
 				"@earendil-works/pi-agent-core": "0.84.2",
 				"@earendil-works/pi-ai": "0.84.2",
 				"@earendil-works/pi-coding-agent": "0.84.2",
@@ -21,9 +21,9 @@
 				"concurrently": "^10.0.5",
 				"husky": "9.1.7",
 				"npm-check-updates": "23.0.2",
-				"typebox": "^1.3.14",
+				"typebox": "^1.3.16",
 				"typescript": "^7.0.2",
-				"vitest": "^4.1.10"
+				"vitest": "^4.1.11"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -488,9 +488,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.8.tgz",
-			"integrity": "sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.9.tgz",
+			"integrity": "sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -504,20 +504,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.8",
-				"@biomejs/cli-darwin-x64": "2.5.8",
-				"@biomejs/cli-linux-arm64": "2.5.8",
-				"@biomejs/cli-linux-arm64-musl": "2.5.8",
-				"@biomejs/cli-linux-x64": "2.5.8",
-				"@biomejs/cli-linux-x64-musl": "2.5.8",
-				"@biomejs/cli-win32-arm64": "2.5.8",
-				"@biomejs/cli-win32-x64": "2.5.8"
+				"@biomejs/cli-darwin-arm64": "2.5.9",
+				"@biomejs/cli-darwin-x64": "2.5.9",
+				"@biomejs/cli-linux-arm64": "2.5.9",
+				"@biomejs/cli-linux-arm64-musl": "2.5.9",
+				"@biomejs/cli-linux-x64": "2.5.9",
+				"@biomejs/cli-linux-x64-musl": "2.5.9",
+				"@biomejs/cli-win32-arm64": "2.5.9",
+				"@biomejs/cli-win32-x64": "2.5.9"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.8.tgz",
-			"integrity": "sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.9.tgz",
+			"integrity": "sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg==",
 			"cpu": [
 				"arm64"
 			],
@@ -532,9 +532,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.8.tgz",
-			"integrity": "sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.9.tgz",
+			"integrity": "sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg==",
 			"cpu": [
 				"x64"
 			],
@@ -549,9 +549,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.8.tgz",
-			"integrity": "sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.9.tgz",
+			"integrity": "sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -569,9 +569,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.8.tgz",
-			"integrity": "sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.9.tgz",
+			"integrity": "sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA==",
 			"cpu": [
 				"arm64"
 			],
@@ -589,9 +589,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.8.tgz",
-			"integrity": "sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.9.tgz",
+			"integrity": "sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg==",
 			"cpu": [
 				"x64"
 			],
@@ -609,9 +609,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.8.tgz",
-			"integrity": "sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.9.tgz",
+			"integrity": "sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw==",
 			"cpu": [
 				"x64"
 			],
@@ -629,9 +629,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.8.tgz",
-			"integrity": "sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.9.tgz",
+			"integrity": "sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -646,9 +646,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.8.tgz",
-			"integrity": "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.9.tgz",
+			"integrity": "sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw==",
 			"cpu": [
 				"x64"
 			],
@@ -713,9 +713,9 @@
 			}
 		},
 		"node_modules/@changesets/cli": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-3.0.0.tgz",
-			"integrity": "sha512-V7Gm+GP5OT3mJinMI2YcJD/JyO/a4WChnaMCCzTRhWHgu1zhtsyY7zCjP6n5W6zsgSjJKs+yPmvtREvE0F2g8A==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-3.0.1.tgz",
+			"integrity": "sha512-3IVpRSgiKDj2aRbBHKtWTXSRH2/iR3bWxau9iQUoEsZjDhRIj9nhl90k7FWMxZAJvLgJBbgMq8+qS0xQsenYsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -730,7 +730,7 @@
 				"@changesets/read": "^1.0.0",
 				"@changesets/should-skip-package": "^1.0.0",
 				"@changesets/types": "^7.0.0",
-				"@changesets/write": "^1.0.0",
+				"@changesets/write": "^1.0.1",
 				"@clack/prompts": "^1.7.0",
 				"@manypkg/get-packages": "^3.1.0",
 				"@pnpm/deps.graph-sequencer": "^1100.0.1",
@@ -891,9 +891,9 @@
 			}
 		},
 		"node_modules/@changesets/write": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@changesets/write/-/write-1.0.0.tgz",
-			"integrity": "sha512-xCK3/4C7Z7muQB/wguE6HcbjtY9iOtaK9orZKE+7xi573cMGD8rLZz7qlo6IvK7s+SIUIKajzj1l+F1QuP97tw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@changesets/write/-/write-1.0.1.tgz",
+			"integrity": "sha512-q/ThtP9gcnEP6xlv7LrY26C2mHqdGBti/MmOVngt/M/oIGYkssmQGxPK9WzBNt2juVcH/vml2WQ+ra8LXYOTaA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1292,9 +1292,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+			"integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1309,9 +1309,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+			"integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
 			"cpu": [
 				"arm"
 			],
@@ -1326,9 +1326,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+			"integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1343,9 +1343,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+			"integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
 			"cpu": [
 				"x64"
 			],
@@ -1360,9 +1360,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+			"integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1377,9 +1377,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+			"integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
 			"cpu": [
 				"x64"
 			],
@@ -1394,9 +1394,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1411,9 +1411,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+			"integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
 			"cpu": [
 				"x64"
 			],
@@ -1428,9 +1428,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+			"integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
 			"cpu": [
 				"arm"
 			],
@@ -1445,9 +1445,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+			"integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
 			"cpu": [
 				"arm64"
 			],
@@ -1462,9 +1462,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+			"integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1479,9 +1479,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+			"integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -1496,9 +1496,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+			"integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1513,9 +1513,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+			"integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1530,9 +1530,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+			"integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1547,9 +1547,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+			"integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
 			"cpu": [
 				"s390x"
 			],
@@ -1564,9 +1564,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+			"integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1581,9 +1581,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1598,9 +1598,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
 			"cpu": [
 				"x64"
 			],
@@ -1615,9 +1615,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1632,9 +1632,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
 			"cpu": [
 				"x64"
 			],
@@ -1649,9 +1649,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+			"integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1666,9 +1666,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+			"integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
 			"cpu": [
 				"x64"
 			],
@@ -1683,9 +1683,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+			"integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1700,9 +1700,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+			"integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1717,9 +1717,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+			"integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
 			"cpu": [
 				"x64"
 			],
@@ -1782,21 +1782,21 @@
 			"license": "MIT"
 		},
 		"node_modules/@langfuse/core": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.10.0.tgz",
-			"integrity": "sha512-XXz1DBEwGMpNXz8DZHFsixqo+3vBkfYpat3oLLldRMuT8ur6OWQ81Kgh5Obh0CZ31adaR4FrLTHh4N9eBXo64A==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.10.1.tgz",
+			"integrity": "sha512-W8UArizWSy1DdeLGTsTwJwl7bkA7OQQcGZW8RtoopXyJZ93O0rwG7wzzeiZjhjpj5OtWOUTEaJuNkwOrF31UDw==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.9.0"
 			}
 		},
 		"node_modules/@langfuse/otel": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.10.0.tgz",
-			"integrity": "sha512-q1expgCm3QwjWII0PeCJJSyEV5o96FQ4VNzL5hgziWGmCPCd9TrrWxWxHdSY7cpZWddEJCp71zdh1nq0xISOpQ==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.10.1.tgz",
+			"integrity": "sha512-F2153e4PoJ1cN+5tM/xnsS44aQCQwK3p0nPk4NEpITV5pMTqiQVyvpkAvly8GKQ5Qjjr7heJ1dFtghW43ysyPQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@langfuse/core": "^5.10.0"
+				"@langfuse/core": "^5.10.1"
 			},
 			"engines": {
 				"node": ">=20"
@@ -1809,12 +1809,12 @@
 			}
 		},
 		"node_modules/@langfuse/tracing": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.10.0.tgz",
-			"integrity": "sha512-//S9dcZszmEk2yx+h7eg10mEMswyU7MYLkGIJlO6gUfrXA+3Y5pvNiZNZU3cfDus94OAr16dHQpg3nNFiziZjg==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.10.1.tgz",
+			"integrity": "sha512-m2kK4D0MsH8g4Og6KpnlYk8NLdQTYe0JR5M4KKpfNj99XXLlbdpXE/g3uJSqkcrWFhpiIb+3cyS9+uV6wQ6WtA==",
 			"license": "MIT",
 			"dependencies": {
-				"@langfuse/core": "^5.10.0"
+				"@langfuse/core": "^5.10.1"
 			},
 			"engines": {
 				"node": ">=20"
@@ -2198,9 +2198,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-			"integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+			"version": "0.146.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+			"integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2277,10 +2277,27 @@
 			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/@rolldown/binding-android-arm-eabi": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+			"integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
-			"integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+			"integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
 			"cpu": [
 				"arm64"
 			],
@@ -2295,9 +2312,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
-			"integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+			"integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
 			"cpu": [
 				"arm64"
 			],
@@ -2312,9 +2329,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
-			"integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+			"integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
 			"cpu": [
 				"x64"
 			],
@@ -2329,9 +2346,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
-			"integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+			"integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
 			"cpu": [
 				"x64"
 			],
@@ -2346,9 +2363,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
-			"integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+			"integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
 			"cpu": [
 				"arm"
 			],
@@ -2363,9 +2380,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
-			"integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+			"integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2383,9 +2400,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
-			"integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+			"integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2403,9 +2420,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
-			"integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+			"integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -2423,9 +2440,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
-			"integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+			"integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -2443,9 +2460,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
-			"integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+			"integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2463,9 +2480,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
-			"integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+			"integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
 			"cpu": [
 				"x64"
 			],
@@ -2483,9 +2500,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
-			"integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+			"integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2500,9 +2517,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
-			"integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+			"integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2517,9 +2534,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
-			"integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+			"integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
 			"cpu": [
 				"x64"
 			],
@@ -3063,16 +3080,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+			"integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.10",
-				"@vitest/utils": "4.1.10",
+				"@vitest/spy": "4.1.11",
+				"@vitest/utils": "4.1.11",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -3081,13 +3098,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+			"integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.10",
+				"@vitest/spy": "4.1.11",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -3108,9 +3125,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+			"integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3121,13 +3138,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+			"integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.10",
+				"@vitest/utils": "4.1.11",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -3135,14 +3152,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+			"integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.10",
-				"@vitest/utils": "4.1.10",
+				"@vitest/pretty-format": "4.1.11",
+				"@vitest/utils": "4.1.11",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -3151,9 +3168,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+			"integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -3161,13 +3178,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+			"integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.10",
+				"@vitest/pretty-format": "4.1.11",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -3667,9 +3684,9 @@
 			}
 		},
 		"node_modules/dbus-native": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.15.1.tgz",
-			"integrity": "sha512-2Zdm+2eQuhmX08/Dyk3fltCqij5LGUwSx3Wj/ZN9IowlUw6eGfYZZXxkviUcN1iPOvWOQWUi74/nVnjZmg37vg==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.15.2.tgz",
+			"integrity": "sha512-J1IBi4LmbqrFhroN66Dj1tCCTP6TVbZgUKhWQZf3uS6t93yRWEcRRDjOZV9N6boGRhOp/BOjLliFm9vWu1QZOA==",
 			"license": "MIT",
 			"dependencies": {
 				"xml2js": "^0.6.2"
@@ -3761,9 +3778,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -3774,32 +3791,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.1",
-				"@esbuild/android-arm": "0.28.1",
-				"@esbuild/android-arm64": "0.28.1",
-				"@esbuild/android-x64": "0.28.1",
-				"@esbuild/darwin-arm64": "0.28.1",
-				"@esbuild/darwin-x64": "0.28.1",
-				"@esbuild/freebsd-arm64": "0.28.1",
-				"@esbuild/freebsd-x64": "0.28.1",
-				"@esbuild/linux-arm": "0.28.1",
-				"@esbuild/linux-arm64": "0.28.1",
-				"@esbuild/linux-ia32": "0.28.1",
-				"@esbuild/linux-loong64": "0.28.1",
-				"@esbuild/linux-mips64el": "0.28.1",
-				"@esbuild/linux-ppc64": "0.28.1",
-				"@esbuild/linux-riscv64": "0.28.1",
-				"@esbuild/linux-s390x": "0.28.1",
-				"@esbuild/linux-x64": "0.28.1",
-				"@esbuild/netbsd-arm64": "0.28.1",
-				"@esbuild/netbsd-x64": "0.28.1",
-				"@esbuild/openbsd-arm64": "0.28.1",
-				"@esbuild/openbsd-x64": "0.28.1",
-				"@esbuild/openharmony-arm64": "0.28.1",
-				"@esbuild/sunos-x64": "0.28.1",
-				"@esbuild/win32-arm64": "0.28.1",
-				"@esbuild/win32-ia32": "0.28.1",
-				"@esbuild/win32-x64": "0.28.1"
+				"@esbuild/aix-ppc64": "0.28.2",
+				"@esbuild/android-arm": "0.28.2",
+				"@esbuild/android-arm64": "0.28.2",
+				"@esbuild/android-x64": "0.28.2",
+				"@esbuild/darwin-arm64": "0.28.2",
+				"@esbuild/darwin-x64": "0.28.2",
+				"@esbuild/freebsd-arm64": "0.28.2",
+				"@esbuild/freebsd-x64": "0.28.2",
+				"@esbuild/linux-arm": "0.28.2",
+				"@esbuild/linux-arm64": "0.28.2",
+				"@esbuild/linux-ia32": "0.28.2",
+				"@esbuild/linux-loong64": "0.28.2",
+				"@esbuild/linux-mips64el": "0.28.2",
+				"@esbuild/linux-ppc64": "0.28.2",
+				"@esbuild/linux-riscv64": "0.28.2",
+				"@esbuild/linux-s390x": "0.28.2",
+				"@esbuild/linux-x64": "0.28.2",
+				"@esbuild/netbsd-arm64": "0.28.2",
+				"@esbuild/netbsd-x64": "0.28.2",
+				"@esbuild/openbsd-arm64": "0.28.2",
+				"@esbuild/openbsd-x64": "0.28.2",
+				"@esbuild/openharmony-arm64": "0.28.2",
+				"@esbuild/sunos-x64": "0.28.2",
+				"@esbuild/win32-arm64": "0.28.2",
+				"@esbuild/win32-ia32": "0.28.2",
+				"@esbuild/win32-x64": "0.28.2"
 			}
 		},
 		"node_modules/escalade": {
@@ -3897,9 +3914,9 @@
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.10.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
-			"integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.0.tgz",
+			"integrity": "sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==",
 			"funding": [
 				{
 					"type": "github",
@@ -3912,7 +3929,7 @@
 				"fast-xml-builder": "^1.2.0",
 				"is-unsafe": "^2.0.0",
 				"path-expression-matcher": "^1.6.2",
-				"strnum": "^2.4.1",
+				"strnum": "^2.4.2",
 				"xml-naming": "^0.3.0"
 			},
 			"bin": {
@@ -4140,9 +4157,9 @@
 			}
 		},
 		"node_modules/human-id": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
-			"integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.1.tgz",
+			"integrity": "sha512-zPGsiS+dWoTZtZ4AtpA9Y+BdSFSNWvnouNlWNoUFyAM6xHOHmdCvqO3k8AIbdamCOv4gUFUVNPf6rJFfc4UiJw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5063,13 +5080,13 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
-			"integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+			"integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.143.0",
+				"@oxc-project/types": "=0.146.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -5079,20 +5096,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.2.3",
-				"@rolldown/binding-darwin-arm64": "1.2.3",
-				"@rolldown/binding-darwin-x64": "1.2.3",
-				"@rolldown/binding-freebsd-x64": "1.2.3",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
-				"@rolldown/binding-linux-arm64-gnu": "1.2.3",
-				"@rolldown/binding-linux-arm64-musl": "1.2.3",
-				"@rolldown/binding-linux-ppc64-gnu": "1.2.3",
-				"@rolldown/binding-linux-s390x-gnu": "1.2.3",
-				"@rolldown/binding-linux-x64-gnu": "1.2.3",
-				"@rolldown/binding-linux-x64-musl": "1.2.3",
-				"@rolldown/binding-openharmony-arm64": "1.2.3",
-				"@rolldown/binding-win32-arm64-msvc": "1.2.3",
-				"@rolldown/binding-win32-x64-msvc": "1.2.3"
+				"@rolldown/binding-android-arm-eabi": "1.2.5",
+				"@rolldown/binding-android-arm64": "1.2.5",
+				"@rolldown/binding-darwin-arm64": "1.2.5",
+				"@rolldown/binding-darwin-x64": "1.2.5",
+				"@rolldown/binding-freebsd-x64": "1.2.5",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.5",
+				"@rolldown/binding-linux-arm64-musl": "1.2.5",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.5",
+				"@rolldown/binding-linux-x64-gnu": "1.2.5",
+				"@rolldown/binding-linux-x64-musl": "1.2.5",
+				"@rolldown/binding-openharmony-arm64": "1.2.5",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.5",
+				"@rolldown/binding-win32-x64-msvc": "1.2.5"
 			}
 		},
 		"node_modules/rxjs": {
@@ -5358,9 +5376,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
-			"integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+			"integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
 			"funding": [
 				{
 					"type": "github",
@@ -5500,9 +5518,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/typebox": {
-			"version": "1.3.14",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.14.tgz",
-			"integrity": "sha512-uD3FHZb4St/7E7eY0YANSt+yZABDDlbeJbXhUU17x2GZLyHUiQ6+mxSpZhZtnJSjKy/7PZ49r7SDZHG4F3JsLw==",
+			"version": "1.3.16",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.16.tgz",
+			"integrity": "sha512-Jac8dgnin+g2p1w1v9sk92Wvp49ZqsmSgNhrXDK+RqrovsjiORMZvYZ8t8id9b9XQp6LMfaAwnIRSHGsM+3FMw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5587,16 +5605,16 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-			"integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+			"integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.33.0",
 				"picomatch": "^4.0.5",
-				"postcss": "^8.5.25",
-				"rolldown": "~1.2.1",
+				"postcss": "^8.5.26",
+				"rolldown": "~1.2.4",
 				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
@@ -5613,7 +5631,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.4.0",
+				"@vitejs/devtools": "^0.4.0 || ^0.5.0",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -5665,19 +5683,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+			"integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.10",
-				"@vitest/mocker": "4.1.10",
-				"@vitest/pretty-format": "4.1.10",
-				"@vitest/runner": "4.1.10",
-				"@vitest/snapshot": "4.1.10",
-				"@vitest/spy": "4.1.10",
-				"@vitest/utils": "4.1.10",
+				"@vitest/expect": "4.1.11",
+				"@vitest/mocker": "4.1.11",
+				"@vitest/pretty-format": "4.1.11",
+				"@vitest/runner": "4.1.11",
+				"@vitest/snapshot": "4.1.11",
+				"@vitest/spy": "4.1.11",
+				"@vitest/utils": "4.1.11",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -5705,12 +5723,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.10",
-				"@vitest/browser-preview": "4.1.10",
-				"@vitest/browser-webdriverio": "4.1.10",
-				"@vitest/coverage-istanbul": "4.1.10",
-				"@vitest/coverage-v8": "4.1.10",
-				"@vitest/ui": "4.1.10",
+				"@vitest/browser-playwright": "4.1.11",
+				"@vitest/browser-preview": "4.1.11",
+				"@vitest/browser-webdriverio": "4.1.11",
+				"@vitest/coverage-istanbul": "4.1.11",
+				"@vitest/coverage-v8": "4.1.11",
+				"@vitest/ui": "4.1.11",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -5983,7 +6001,7 @@
 				"proper-lockfile": "^4.1.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-ai": "0.84.2",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@types/proper-lockfile": "^4.1.4",
@@ -6024,10 +6042,10 @@
 				"@narumitw/pi-tui-kit": "^0.51.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@types/node": "26.2.0",
-				"esbuild": "0.28.1",
+				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6064,11 +6082,11 @@
 				"@narumitw/pi-tui-kit": "^0.56.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-ai": "0.84.2",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
-				"esbuild": "0.28.1",
+				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6083,10 +6101,10 @@
 			"license": "MIT",
 			"dependencies": {
 				"@narumitw/pi-tui-kit": "^0.49.1",
-				"dbus-native": "^0.15.1"
+				"dbus-native": "^0.15.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@types/node": "26.2.0",
 				"typescript": "7.0.2"
@@ -6128,7 +6146,7 @@
 				"sodium-universal": "5.0.1"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
 				"@types/node": "26.2.0",
@@ -6169,10 +6187,10 @@
 				"@narumitw/pi-tui-kit": "^0.51.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
-				"esbuild": "0.28.1",
-				"typebox": "1.3.14",
+				"esbuild": "0.28.2",
+				"typebox": "1.3.16",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6210,7 +6228,7 @@
 				"@narumitw/pi-tui-kit": "^0.49.1"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-agent-core": "0.84.2",
 				"@earendil-works/pi-ai": "0.84.2",
 				"@earendil-works/pi-coding-agent": "0.84.2",
@@ -6253,10 +6271,10 @@
 				"@narumitw/pi-tui-kit": "^0.51.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
-				"esbuild": "0.28.1",
+				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6294,10 +6312,10 @@
 				"@narumitw/pi-tui-kit": "^0.49.1"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
-				"esbuild": "0.28.1",
-				"typebox": "1.3.14",
+				"esbuild": "0.28.2",
+				"typebox": "1.3.16",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6335,13 +6353,13 @@
 				"@narumitw/pi-tui-kit": "^0.56.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-ai": "0.84.2",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
 				"@types/node": "26.2.0",
-				"esbuild": "0.28.1",
-				"typebox": "1.3.14",
+				"esbuild": "0.28.2",
+				"typebox": "1.3.16",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6356,7 +6374,7 @@
 			"version": "0.49.4",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@types/node": "26.2.0",
 				"typescript": "7.0.2"
@@ -6370,12 +6388,12 @@
 				"@narumitw/pi-tui-kit": "^0.56.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-ai": "0.84.2",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
-				"esbuild": "0.28.1",
-				"typebox": "1.3.14",
+				"esbuild": "0.28.2",
+				"typebox": "1.3.16",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6390,8 +6408,8 @@
 			"version": "0.50.1",
 			"license": "MIT",
 			"dependencies": {
-				"@langfuse/otel": "^5.10.0",
-				"@langfuse/tracing": "^5.10.0",
+				"@langfuse/otel": "^5.10.1",
+				"@langfuse/tracing": "^5.10.1",
 				"@narumitw/pi-tui-kit": "^0.56.0",
 				"@opentelemetry/api": "^1.9.1",
 				"@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
@@ -6399,7 +6417,7 @@
 				"@opentelemetry/sdk-trace-node": "^2.10.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@types/node": "26.2.0",
 				"typescript": "7.0.2"
@@ -6422,11 +6440,11 @@
 			"version": "0.49.5",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@types/node": "26.2.0",
-				"esbuild": "0.28.1",
-				"typebox": "1.3.14",
+				"esbuild": "0.28.2",
+				"typebox": "1.3.16",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6442,10 +6460,10 @@
 				"@narumitw/pi-tui-kit": "^0.49.1"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
-				"esbuild": "0.28.1",
+				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6484,7 +6502,7 @@
 				"proper-lockfile": "^4.1.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
 				"@types/node": "26.2.0",
@@ -6504,7 +6522,7 @@
 				"@narumitw/pi-tui-kit": "^0.49.1"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
 				"@types/node": "26.2.0",
@@ -6547,11 +6565,11 @@
 				"yaml": "^2.9.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
 				"@types/node": "26.2.0",
-				"esbuild": "0.28.1",
+				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6567,11 +6585,11 @@
 				"@narumitw/pi-tui-kit": "^0.56.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
 				"@types/node": "26.2.0",
-				"esbuild": "0.28.1",
+				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6588,13 +6606,13 @@
 				"proper-lockfile": "^4.1.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-agent-core": "0.84.2",
 				"@earendil-works/pi-ai": "0.84.2",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
-				"esbuild": "0.28.1",
-				"typebox": "1.3.14",
+				"esbuild": "0.28.2",
+				"typebox": "1.3.16",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6611,15 +6629,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"@narumitw/pi-tui-kit": "^0.52.0",
-				"fast-xml-parser": "^5.10.1",
+				"fast-xml-parser": "^5.11.0",
 				"proper-lockfile": "^4.1.2"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
 				"@types/proper-lockfile": "^4.1.4",
-				"esbuild": "0.28.1",
+				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6657,7 +6675,7 @@
 				"@narumitw/pi-tui-kit": "^0.53.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@types/node": "26.2.0",
 				"typescript": "7.0.2"
@@ -6693,11 +6711,11 @@
 			"version": "0.56.0",
 			"license": "MIT",
 			"dependencies": {
-				"grok-mermaid": "0.2.2",
+				"grok-mermaid": "0.2.3",
 				"highlight.js": "11.12.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
 				"typescript": "7.0.2"
@@ -6715,13 +6733,22 @@
 				"@narumitw/pi-tui-kit": "^0.56.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@narumitw/pi-tui-kit": "^0.56.0",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*"
+			}
+		},
+		"packages/pi-tui-kit/node_modules/grok-mermaid": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.3.tgz",
+			"integrity": "sha512-/4KopAbsjvuRP9MdPtlDjOHUmUVEohOX73JNcsWpzAtFxh+bq5+Dhb6gzvRieLDwIPQIR3/vy8V1NNTuz4Zsmg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"packages/pi-tui-kit/node_modules/highlight.js": {
@@ -6741,11 +6768,11 @@
 				"@narumitw/pi-tui-kit": "^0.49.1"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-ai": "0.84.2",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@types/node": "26.2.0",
-				"esbuild": "0.28.1",
+				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6783,13 +6810,13 @@
 				"@narumitw/pi-tui-kit": "^0.49.1"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-ai": "0.84.2",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@earendil-works/pi-tui": "0.84.2",
 				"@types/node": "26.2.0",
-				"esbuild": "0.28.1",
-				"typebox": "1.3.14",
+				"esbuild": "0.28.2",
+				"typebox": "1.3.16",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
@@ -6829,7 +6856,7 @@
 				"@narumitw/pi-tui-kit": "^0.56.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.8",
+				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
 				"@types/node": "26.2.0",
 				"typescript": "7.0.2"

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
 		"pack:worktree": "npm --workspace @narumitw/pi-worktree pack --dry-run"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.8",
-		"@changesets/cli": "3.0.0",
+		"@biomejs/biome": "^2.5.9",
+		"@changesets/cli": "3.0.1",
 		"@earendil-works/pi-agent-core": "0.84.2",
 		"@earendil-works/pi-ai": "0.84.2",
 		"@earendil-works/pi-coding-agent": "0.84.2",
@@ -80,9 +80,9 @@
 		"concurrently": "^10.0.5",
 		"husky": "9.1.7",
 		"npm-check-updates": "23.0.2",
-		"typebox": "^1.3.14",
+		"typebox": "^1.3.16",
 		"typescript": "^7.0.2",
-		"vitest": "^4.1.10"
+		"vitest": "^4.1.11"
 	},
 	"overrides": {
 		"brace-expansion": "5.0.9",
@@ -90,7 +90,7 @@
 		"protobufjs": "7.6.5"
 	},
 	"allowScripts": {
-		"esbuild@0.28.1": true,
+		"esbuild@0.28.2": true,
 		"@google/genai": false,
 		"protobufjs": false
 	}

--- a/packages/pi-accounts/package.json
+++ b/packages/pi-accounts/package.json
@@ -43,7 +43,7 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-ai": "0.84.2",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@types/proper-lockfile": "^4.1.4",

--- a/packages/pi-analytics/package.json
+++ b/packages/pi-analytics/package.json
@@ -41,10 +41,10 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@types/node": "26.2.0",
-		"esbuild": "0.28.1",
+		"esbuild": "0.28.2",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-btw/package.json
+++ b/packages/pi-btw/package.json
@@ -34,11 +34,11 @@
 		"prepack": "npm run build"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-ai": "0.84.2",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
-		"esbuild": "0.28.1",
+		"esbuild": "0.28.2",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-caffeinate/package.json
+++ b/packages/pi-caffeinate/package.json
@@ -35,7 +35,7 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@types/node": "26.2.0",
 		"typescript": "7.0.2"
@@ -47,6 +47,6 @@
 	},
 	"dependencies": {
 		"@narumitw/pi-tui-kit": "^0.49.1",
-		"dbus-native": "^0.15.1"
+		"dbus-native": "^0.15.2"
 	}
 }

--- a/packages/pi-chat/package.json
+++ b/packages/pi-chat/package.json
@@ -42,7 +42,7 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
 		"@types/node": "26.2.0",

--- a/packages/pi-chrome-devtools/package.json
+++ b/packages/pi-chrome-devtools/package.json
@@ -39,10 +39,10 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
-		"esbuild": "0.28.1",
-		"typebox": "1.3.14",
+		"esbuild": "0.28.2",
+		"typebox": "1.3.16",
 		"typescript": "7.0.2"
 	},
 	"dependencies": {

--- a/packages/pi-codex-compact/package.json
+++ b/packages/pi-codex-compact/package.json
@@ -40,7 +40,7 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-agent-core": "0.84.2",
 		"@earendil-works/pi-ai": "0.84.2",
 		"@earendil-works/pi-coding-agent": "0.84.2",

--- a/packages/pi-file-context/package.json
+++ b/packages/pi-file-context/package.json
@@ -43,10 +43,10 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
-		"esbuild": "0.28.1",
+		"esbuild": "0.28.2",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-firecrawl/package.json
+++ b/packages/pi-firecrawl/package.json
@@ -39,10 +39,10 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
-		"esbuild": "0.28.1",
-		"typebox": "1.3.14",
+		"esbuild": "0.28.2",
+		"typebox": "1.3.16",
 		"typescript": "7.0.2"
 	},
 	"dependencies": {

--- a/packages/pi-fleet/package.json
+++ b/packages/pi-fleet/package.json
@@ -46,13 +46,13 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-ai": "0.84.2",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
 		"@types/node": "26.2.0",
-		"esbuild": "0.28.1",
-		"typebox": "1.3.14",
+		"esbuild": "0.28.2",
+		"typebox": "1.3.16",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-github-pr/package.json
+++ b/packages/pi-github-pr/package.json
@@ -32,7 +32,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@types/node": "26.2.0",
 		"typescript": "7.0.2"

--- a/packages/pi-goal/package.json
+++ b/packages/pi-goal/package.json
@@ -41,12 +41,12 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-ai": "0.84.2",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
-		"esbuild": "0.28.1",
-		"typebox": "1.3.14",
+		"esbuild": "0.28.2",
+		"typebox": "1.3.16",
 		"typescript": "7.0.2"
 	},
 	"dependencies": {

--- a/packages/pi-langfuse/package.json
+++ b/packages/pi-langfuse/package.json
@@ -35,14 +35,14 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@types/node": "26.2.0",
 		"typescript": "7.0.2"
 	},
 	"dependencies": {
-		"@langfuse/otel": "^5.10.0",
-		"@langfuse/tracing": "^5.10.0",
+		"@langfuse/otel": "^5.10.1",
+		"@langfuse/tracing": "^5.10.1",
 		"@narumitw/pi-tui-kit": "^0.56.0",
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.221.0",

--- a/packages/pi-lsp/package.json
+++ b/packages/pi-lsp/package.json
@@ -42,11 +42,11 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@types/node": "26.2.0",
-		"esbuild": "0.28.1",
-		"typebox": "1.3.14",
+		"esbuild": "0.28.2",
+		"typebox": "1.3.16",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-plan-mode/package.json
+++ b/packages/pi-plan-mode/package.json
@@ -38,10 +38,10 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
-		"esbuild": "0.28.1",
+		"esbuild": "0.28.2",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-recall/package.json
+++ b/packages/pi-recall/package.json
@@ -41,7 +41,7 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
 		"@types/node": "26.2.0",

--- a/packages/pi-stamp/package.json
+++ b/packages/pi-stamp/package.json
@@ -39,7 +39,7 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
 		"@types/node": "26.2.0",

--- a/packages/pi-starship/package.json
+++ b/packages/pi-starship/package.json
@@ -46,11 +46,11 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
 		"@types/node": "26.2.0",
-		"esbuild": "0.28.1",
+		"esbuild": "0.28.2",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-statusline/package.json
+++ b/packages/pi-statusline/package.json
@@ -38,11 +38,11 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
 		"@types/node": "26.2.0",
-		"esbuild": "0.28.1",
+		"esbuild": "0.28.2",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -42,13 +42,13 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-agent-core": "0.84.2",
 		"@earendil-works/pi-ai": "0.84.2",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
-		"esbuild": "0.28.1",
-		"typebox": "1.3.14",
+		"esbuild": "0.28.2",
+		"typebox": "1.3.16",
 		"typescript": "7.0.2"
 	},
 	"dependencies": {

--- a/packages/pi-sync/package.json
+++ b/packages/pi-sync/package.json
@@ -43,15 +43,15 @@
 	},
 	"dependencies": {
 		"@narumitw/pi-tui-kit": "^0.52.0",
-		"fast-xml-parser": "^5.10.1",
+		"fast-xml-parser": "^5.11.0",
 		"proper-lockfile": "^4.1.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
 		"@types/proper-lockfile": "^4.1.4",
-		"esbuild": "0.28.1",
+		"esbuild": "0.28.2",
 		"typescript": "7.0.2"
 	},
 	"peerDependencies": {

--- a/packages/pi-tool/package.json
+++ b/packages/pi-tool/package.json
@@ -38,7 +38,7 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@types/node": "26.2.0",
 		"typescript": "7.0.2"

--- a/packages/pi-tui-kit-showcase/package.json
+++ b/packages/pi-tui-kit-showcase/package.json
@@ -37,7 +37,7 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@narumitw/pi-tui-kit": "^0.56.0",
 		"typescript": "7.0.2"

--- a/packages/pi-tui-kit/package.json
+++ b/packages/pi-tui-kit/package.json
@@ -50,7 +50,7 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
 		"typescript": "7.0.2"
@@ -61,7 +61,7 @@
 		"directory": "packages/pi-tui-kit"
 	},
 	"dependencies": {
-		"grok-mermaid": "0.2.2",
+		"grok-mermaid": "0.2.3",
 		"highlight.js": "11.12.0"
 	}
 }

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -43,11 +43,11 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-ai": "0.84.2",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@types/node": "26.2.0",
-		"esbuild": "0.28.1",
+		"esbuild": "0.28.2",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-workflow/package.json
+++ b/packages/pi-workflow/package.json
@@ -46,13 +46,13 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-ai": "0.84.2",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@earendil-works/pi-tui": "0.84.2",
 		"@types/node": "26.2.0",
-		"esbuild": "0.28.1",
-		"typebox": "1.3.14",
+		"esbuild": "0.28.2",
+		"typebox": "1.3.16",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-worktree/package.json
+++ b/packages/pi-worktree/package.json
@@ -35,7 +35,7 @@
 		"@earendil-works/pi-coding-agent": "*"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.8",
+		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
 		"@types/node": "26.2.0",
 		"typescript": "7.0.2"


### PR DESCRIPTION
## Summary

- update Biome, Changesets, TypeBox, Vitest, esbuild, and selected runtime dependencies
- align the Biome schema and esbuild install-script approval with the updated versions
- refresh the npm lockfile

## Verification

- `just verify-update` (3,611 tests passed; all workspace package dry-runs succeeded)
- `npm audit --audit-level=high` (0 vulnerabilities)
- `npm install-scripts ls` (no unreviewed install scripts)
- pre-commit Biome and workspace typechecks

## Release

- no changeset required; dependency maintenance only
