### PR TITLE
chore: remove just try recipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Run commands from the repository root unless a command says otherwise.
 - Run `npm test` or `just test` separately for active tests.
 - CI and release verification must run both gates.
 - Run `just pack <unscoped-name>` and inspect the tarball after package metadata or publishing changes.
-- Run `just try <unscoped-name>` or an equivalent `pi -e` smoke after extension runtime-loading changes; record why and what remains unverified if the smoke is impractical.
+- After extension runtime-loading changes, run `npm --workspace @narumitw/pi-<unscoped-name> run build --if-present`, then smoke with `pi -e ./packages/pi-<unscoped-name>`; record why and what remains unverified if the smoke is impractical.
 - Start subprocess timing deadlines only after a child readiness handshake.
 - Synchronize concurrent HTTP tests on a server-observable response or callback instead of a fixed sleep after `fetch()`.
 - Set `PI_CODING_AGENT_DIR` before importing an extension in lifecycle tests and use fresh imports for module-cached paths.

--- a/README.md
+++ b/README.md
@@ -156,14 +156,16 @@ npm run check
 
 `npm test` typechecks the test sources and runs the root and workspace suites with Vitest.
 
-Use the generic Just recipes with an unscoped extension name:
+Build generated entries before loading local packages, and use the generic Just pack recipe with an unscoped package name:
 
 ```bash
-just try goal
+npm --workspace @narumitw/pi-goal run build --if-present
+pi -e ./packages/pi-goal
 just pack goal
 
-# Experimental packages use the same recipes
-just try file-context
+# Experimental packages use the same local flow and pack recipe
+npm --workspace @narumitw/pi-file-context run build --if-present
+pi -e ./packages/pi-file-context
 just pack file-context
 
 # Libraries use the same generic pack recipe

--- a/justfile
+++ b/justfile
@@ -74,12 +74,6 @@ _validate-package-name name:
 pack name: (_validate-package-name name)
     npm --workspace {{ quote("@narumitw/pi-" + name) }} pack --dry-run
 
-# Try an extension package from this working tree as a temporary pi package
-# Usage: just try subagents
-try name: (_validate-package-name name)
-    npm --workspace {{ quote("@narumitw/pi-" + name) }} run build --if-present
-    pi -e {{ quote("./packages/pi-" + name) }}
-
 # Open the private Pi TUI Kit showcase extension from this working tree
 showcase-tui-kit:
     npm --workspace @narumitw/pi-tui-kit run build

--- a/packages/pi-analytics/README.md
+++ b/packages/pi-analytics/README.md
@@ -33,17 +33,16 @@ Try the published package without installing:
 pi -e npm:@narumitw/pi-analytics
 ```
 
-Try a local checkout from the repository root:
+Build and try a local checkout from the repository root:
 
 ```bash
+npm --workspace @narumitw/pi-analytics run build
 pi -e ./packages/pi-analytics
 ```
 
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
+
 The storage implementation uses Node's built-in filesystem APIs and has no native database dependency.
-
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-analytics run build` before Pi loads the package directory.
-
-`just try analytics` runs that build automatically.
 
 ## 🚀 Quick start
 

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -35,15 +35,14 @@ Try without installing permanently:
 pi -e npm:@narumitw/pi-btw
 ```
 
-Try this package locally from the repository root:
+Build and try this package locally from the repository root:
 
 ```bash
+npm --workspace @narumitw/pi-btw run build
 pi -e ./packages/pi-btw
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-btw run build` before Pi loads the package directory.
-
-`just try btw` runs that build automatically.
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 ## 🚀 Usage
 

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -45,15 +45,14 @@ Try without installing permanently:
 pi -e npm:@narumitw/pi-chrome-devtools
 ```
 
-Try this package locally from the repository root:
+Build and try this package locally from the repository root:
 
 ```bash
+npm --workspace @narumitw/pi-chrome-devtools run build
 pi -e ./packages/pi-chrome-devtools
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-chrome-devtools run build` before Pi loads the package directory.
-
-`just try chrome-devtools` runs that build automatically.
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 ## 🚀 Browser startup
 

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -44,8 +44,6 @@ Try a local checkout from the repository root:
 
 ```bash
 pi -e ./packages/pi-codex-compact
-# or
-just try codex-compact
 ```
 
 Loading the package enables Remote V2 with safe defaults. Avoid loading a global npm installation

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -35,15 +35,14 @@ Try from npm without installing permanently:
 pi -e npm:@narumitw/pi-file-context
 ```
 
-Try the local working tree from this repository checkout:
+Build and try the local working tree from this repository checkout:
 
 ```bash
+npm --workspace @narumitw/pi-file-context run build
 pi -e ./packages/pi-file-context
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-file-context run build` before Pi loads the package directory.
-
-`just try file-context` runs that build automatically.
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 ## 🚀 Quick start
 

--- a/packages/pi-firecrawl/README.md
+++ b/packages/pi-firecrawl/README.md
@@ -34,15 +34,14 @@ Try without installing permanently:
 FIRECRAWL_API_KEY=fc-... pi -e npm:@narumitw/pi-firecrawl
 ```
 
-Try this package locally from the repository root:
+Build and try this package locally from the repository root:
 
 ```bash
+npm --workspace @narumitw/pi-firecrawl run build
 FIRECRAWL_API_KEY=fc-... pi -e ./packages/pi-firecrawl
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-firecrawl run build` before Pi loads the package directory.
-
-`just try firecrawl` runs that build automatically.
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 ## ⚙️ Configuration
 

--- a/packages/pi-fleet/README.md
+++ b/packages/pi-fleet/README.md
@@ -40,21 +40,20 @@ Try the published package without a permanent install:
 pi -e npm:@narumitw/pi-fleet
 ```
 
-Load the extension from a local checkout:
+Build and load the extension from a local checkout:
 
 ```bash
+npm --workspace @narumitw/pi-fleet run build
 pi --no-extensions --no-skills --no-session -e ./packages/pi-fleet
 ```
+
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 A child started in any supported terminal backend uses normal Pi extension discovery.
 Install Pi Fleet persistently before testing the complete split-and-auto-join flow because a parent's temporary `-e` argument is not copied into the child process.
 
 Pi extensions execute with your user permissions.
 Review extension source before installing it.
-
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-fleet run build` before Pi loads the package directory.
-
-`just try fleet` runs that build automatically.
 
 ## 🚀 Quick start
 

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -49,15 +49,14 @@ Try without installing permanently:
 pi -e npm:@narumitw/pi-goal
 ```
 
-Try this package locally from the repository root:
+Build and try this package locally from the repository root:
 
 ```bash
+npm --workspace @narumitw/pi-goal run build
 pi -e ./packages/pi-goal
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-goal run build` before Pi loads the package directory.
-
-`just try goal` runs that build automatically.
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 ## ⚙️ Configuration
 

--- a/packages/pi-lsp/README.md
+++ b/packages/pi-lsp/README.md
@@ -67,15 +67,14 @@ Try without installing permanently:
 pi -e npm:@narumitw/pi-lsp
 ```
 
-Try this package locally from the repository root:
+Build and try this package locally from the repository root:
 
 ```bash
+npm --workspace @narumitw/pi-lsp run build
 pi -e ./packages/pi-lsp
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-lsp run build` before Pi loads the package directory.
-
-`just try lsp` runs that build automatically.
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 ## ⚙️ Configuration
 

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -36,15 +36,14 @@ Try without installing permanently:
 pi -e npm:@narumitw/pi-plan-mode
 ```
 
-Try this package locally from the repository root:
+Build and try this package locally from the repository root:
 
 ```bash
+npm --workspace @narumitw/pi-plan-mode run build
 pi -e ./packages/pi-plan-mode
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-plan-mode run build` before Pi loads the package directory.
-
-`just try plan-mode` runs that build automatically.
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 ## 🚀 Usage
 

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -37,12 +37,11 @@ pi -e npm:@narumitw/pi-starship
 Build the generated runtime and try the local package from this repository:
 
 ```bash
-just try starship
+npm --workspace @narumitw/pi-starship run build
+pi -e ./packages/pi-starship
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-starship run build` before Pi loads the package directory.
-
-`just try starship` runs that build automatically.
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 Do not enable this together with `@narumitw/pi-statusline`: both own Pi's footer, and Pi does not arbitrate that conflict.
 

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -46,11 +46,10 @@ Build the generated runtime and try the local package from this repository:
 
 ```bash
 npm --workspace @narumitw/pi-statusline run build
-just try statusline
+pi -e ./packages/pi-statusline
 ```
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
-`just try statusline` runs that build automatically.
 
 For the best result, use a terminal font that includes Powerline glyphs and emoji.
 

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -57,11 +57,11 @@ pi -e npm:@narumitw/pi-subagents
 Build and try this package locally from the repository root:
 
 ```bash
-just try subagents
+npm --workspace @narumitw/pi-subagents run build
+pi -e ./packages/pi-subagents
 ```
 
-The published package declares `dist/index.ts`, and `just try` runs its build before loading the package directory.
-For an explicit local flow, run `npm --workspace @narumitw/pi-subagents run build` before `pi -e ./packages/pi-subagents`.
+The published package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 An unbuilt checkout intentionally has no declared generated entrypoint.
 
 ## 🚀 Quick start

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -34,15 +34,14 @@ Try without installing permanently:
 pi -e npm:@narumitw/pi-usage
 ```
 
-Try this package locally from the repository root:
+Build and try this package locally from the repository root:
 
 ```bash
+npm --workspace @narumitw/pi-usage run build
 pi -e ./packages/pi-usage
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run `npm --workspace @narumitw/pi-usage run build` before Pi loads the package directory.
-
-`just try usage` runs that build automatically.
+The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 ## 🚀 Usage
 

--- a/packages/pi-worktree/README.md
+++ b/packages/pi-worktree/README.md
@@ -38,8 +38,7 @@ pi -e npm:@narumitw/pi-worktree
 Try this package locally from the repository root:
 
 ```bash
-just try worktree
-# or: pi -e ./packages/pi-worktree
+pi -e ./packages/pi-worktree
 ```
 
 ## 💬 Usage


### PR DESCRIPTION
## Summary

- remove the generic `just try <name>` recipe
- replace repository and package guidance with explicit build and `pi -e` commands
- preserve build-before-load instructions for all generated extension entrypoints

## Verification

- `just --list`
- manifest/README audit for 13 build-backed and 2 source-loaded packages
- repository-wide stale-reference scan
- `git diff --check`
- `npm run check`
- `npm test` (382 files, 3,611 tests)
- signed commit pre-commit hook (`biome:check` and workspace typechecks)

## Risks and unverified paths

The command removal is intentional and its direct replacement is documented.
No package metadata or runtime-loading behavior changed, so package pack and live Pi load smokes were not applicable.
No paths remain unverified.
