### PR TITLE
test(fleet): remove redundant factory assertion

### DIFF
--- a/packages/pi-fleet/test/startup-imports.test.ts
+++ b/packages/pi-fleet/test/startup-imports.test.ts
@@ -1,8 +1,0 @@
-import assert from "node:assert/strict";
-import { test } from "vitest";
-
-import extension from "../src/index.js";
-
-test("Pi Fleet exports an extension factory", () => {
-	assert.equal(typeof extension, "function");
-});


### PR DESCRIPTION
## Summary

- remove the Pi Fleet test that only checked whether the source entrypoint exported a function
- rely on the stronger registration, build-runtime, and generated-entry tests that execute the factory at the owning package boundary

## Verification

- `npx vitest run packages/pi-fleet/test/pi-fleet.test.ts packages/pi-fleet/test/build-runtime.test.ts packages/pi-fleet/test/generated-entry.test.ts` (3 files, 9 tests)
- `npm run check`
- `npm test` (381 files, 3,610 tests)

No changeset is needed because this only removes redundant test coverage and does not change published behavior.
