### PR TITLE
feat(workflow): promote extension to stable

### DIFF
--- a/.changeset/stable-workflow.md
+++ b/.changeset/stable-workflow.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-workflow": minor
+---
+
+Promote the extension to stable, include it in root Git installations, and remove its experimental startup warning.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ pi -e npm:@narumitw/pi-goal \
 | [`pi-btw`](./packages/pi-btw) | Ask a quick `/btw` side question without adding it to the main conversation. | `pi install npm:@narumitw/pi-btw` |
 | [`pi-caffeinate`](./packages/pi-caffeinate) | Prevent system sleep while Pi processes a long-running prompt. | `pi install npm:@narumitw/pi-caffeinate` |
 | [`pi-goal`](./packages/pi-goal) | Keep the agent working until a goal is verified complete; optionally enable an experimental ordered queue. | `pi install npm:@narumitw/pi-goal` |
+| [`pi-workflow`](./packages/pi-workflow) | Combine `/plan` and `/goal` in one package with an integrated, recoverable Plan-to-Goal handoff. | `pi install npm:@narumitw/pi-workflow` |
 | [`pi-worktree`](./packages/pi-worktree) | Create, switch, remove, and prune Git worktrees while carrying the Pi session into another workspace. | `pi install npm:@narumitw/pi-worktree` |
 
 ### Accounts and data
@@ -103,7 +104,6 @@ commands, settings persistence, confirmations, and specialized UI.
 | [`pi-file-context`](./packages/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it with configurable `F8` or `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
 | [`pi-fleet`](./packages/pi-fleet) | Start a separate Pi process in a Ghostty split and connect explicit local Pi sessions for bounded messages and one-turn requests. | `pi install npm:@narumitw/pi-fleet` |
 | [`pi-recall`](./packages/pi-recall) | Save selected text messages locally and preview or quote them across Pi sessions. | `pi install npm:@narumitw/pi-recall` |
-| [`pi-workflow`](./packages/pi-workflow) | Combine `/plan` and `/goal` in one experimental package with an integrated, recoverable Plan-to-Goal handoff. | `pi install npm:@narumitw/pi-workflow` |
 
 ## 🔧 Advanced installation
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ pi -e npm:@narumitw/pi-goal \
 | [`pi-workflow`](./packages/pi-workflow) | Combine `/plan` and `/goal` in one package with an integrated, recoverable Plan-to-Goal handoff. | `pi install npm:@narumitw/pi-workflow` |
 | [`pi-worktree`](./packages/pi-worktree) | Create, switch, remove, and prune Git worktrees while carrying the Pi session into another workspace. | `pi install npm:@narumitw/pi-worktree` |
 
+If you use both `pi-plan-mode` and `pi-goal`, consider replacing them with `pi-workflow` for one integrated Plan-to-Goal experience.
+Do not install `pi-workflow` together with either `pi-plan-mode` or `pi-goal`.
+`pi-workflow` includes the Plan and Goal interfaces from those packages and intentionally reuses their commands, tools, flags, event channels, and session-state names, so loading it with either package would register duplicate handlers and create competing state owners.
+
 ### Accounts and data
 
 | Package | Use it for | Install |

--- a/docs/roadmaps/2026-08-03_pi-workflow-engine-roadmap.md
+++ b/docs/roadmaps/2026-08-03_pi-workflow-engine-roadmap.md
@@ -53,8 +53,8 @@ same stage engine only when concrete consumer evidence supports their semantics.
 
 ## Current State
 
-- No `pi-workflow-engine` package, shared workflow engine, or standalone `pi-workflow` extension
-  exists.
+- No `pi-workflow-engine` package or shared workflow engine exists.
+- `pi-workflow` exists as a stable, independently installable combined extension that currently owns package-local Plan and Goal source snapshots instead of consuming the planned engine.
 - `pi-plan-mode` owns planning, approval, restrictive tools, exact plan persistence,
   compaction-safe active-plan context, and manual implementation clearing. Its accepted plan can be
   up to 50,000 characters.
@@ -207,9 +207,8 @@ remains the sole agent, session, compaction, retry, generic RPC, and UI runtime.
 
 ### Phase 2: Build packages/pi-workflow from both stages
 
-- [ ] `packages/pi-workflow` exists as an independently installable extension with a visible
-  experimental warning, unique `/workflow` command and tool namespace, one state-aware manager, and
-  no dependency on another extension package.
+- [x] `packages/pi-workflow` exists as an independently installable stable extension with a `/workflow` command, one state-aware manager, and no dependency on another extension package.
+  It currently uses package-local Plan and Goal source snapshots as an interim architecture.
 - [ ] The extension binds its commands, tools, and TUI to the same engine service without adding a
   dedicated Workflow RPC setting, public event channel, or automation protocol.
 - [ ] Service-level coverage proves start, snapshots, planning answers, approval or revision,
@@ -251,7 +250,7 @@ internal service boundary remains available if future automation evidence justif
   logic is removed rather than retained in parallel.
 
 **Outcome:** pi-goal becomes a focused product adapter over the same managed-execution stage already
-proven by experimental pi-workflow.
+proven by pi-workflow.
 
 ### Phase 4: Make pi-plan-mode use the planning stage
 
@@ -273,7 +272,7 @@ proven by experimental pi-workflow.
 **Outcome:** Both focused extensions share the engine with pi-workflow while keeping distinct product
 roles: planning-only, goal-only, and combined end-to-end workflow.
 
-### Phase 5: Soak pi-workflow and decide whether it is the primary successor
+### Phase 5: Validate stable coexistence and decide the successor role
 
 - [ ] Co-installation tests cover every supported combination of pi-workflow, pi-plan-mode, and
   pi-goal; unique commands and tools remain distinguishable, restrictive policy is never widened, and
@@ -281,24 +280,20 @@ roles: planning-only, goal-only, and combined end-to-end workflow.
 - [ ] Representative real tasks establish whether pi-workflow improves completion, recovery, and
   cleanup without making focused planning or direct Goal usage harder; unsupported adoption targets
   remain explicit unknowns.
-- [ ] Menu structure, defaults, pause/resume behavior, settings ownership, status language,
-  compatibility, and migration guidance receive an explicit stable-product decision based on soak
-  evidence.
+- [x] Maintainers approve `pi-workflow` as a stable extension with its current menu, defaults, settings ownership, status language, and compatibility surface.
 - [ ] Real consumers determine whether blocked-proposal review, continuation leases, or any additional
   supervision authority from the earlier pi-goal cross-extension proposal belongs in the shared
   workflow service; absent evidence, those hooks remain deferred.
 - [ ] Process-level automation evidence determines whether the internal service is sufficient or a
   separately proposed RPC adapter or upstream Pi capability is justified; the engine does not add a
   second JSONL server to close that platform gap.
-- [ ] Maintainers explicitly decide whether pi-workflow becomes the primary successor, remains a third
-  focused option, or stays experimental. pi-plan-mode and pi-goal remain active throughout the soak
-  and are deprecated only by a separate approved decision.
+- [x] Maintainers designate pi-workflow as a stable third option while pi-plan-mode and pi-goal remain active.
+  Any primary-successor selection or predecessor deprecation still requires a separate approved decision.
 - [ ] Engine, extension, and compatibility checks plus package dry runs and representative Pi smokes
   establish release readiness without implying publication, tags, visibility changes, or version
   changes.
 
-**Outcome:** The repository has an evidence-backed decision on whether pi-workflow should become the
-primary product, with a deliberate coexistence or migration path for both focused predecessors.
+**Outcome:** The repository supports pi-workflow as a stable combined product while gathering evidence for any later primary-successor or predecessor-migration decision.
 
 ### Future option: Decide whether Workflow RPC is justified
 
@@ -383,14 +378,13 @@ validated usage baseline.
 - A dedicated Workflow RPC is not part of the current engine or pi-workflow delivery scope. It may be
   reconsidered only after a concrete consumer establishes the caller, process boundary, operations,
   transport, ownership, and recovery requirements.
-- `packages/pi-workflow` is the approved initial combined product and must show a user-facing
-  warning while its command, settings, workflow behavior, and persisted state remain experimental.
+- `packages/pi-workflow` is an approved stable combined product and no longer shows a package-level experimental warning.
 - pi-plan-mode remains focused on planning and retains its existing ordinary implementation handoff;
   it does not become a second complete Plan-to-Execution product.
 - It is unknown whether overlapping `/workflow`, `/goal`, and `/plan` runs should be rejected globally
   or serialized. Phase 5 requires an explicit decision and verification.
-- It is unknown whether pi-workflow should become the primary successor, remain a third option, or
-  stay experimental. No predecessor deprecation is implied before Phase 5 evidence and approval.
+- It is unknown whether pi-workflow should become the primary successor or remain a stable third option.
+  No predecessor deprecation is implied without separate evidence and approval.
 - Broader workflows are deferred beyond this roadmap until concrete consumer demand proves reusable
   stage semantics.
 - No delivery dates, owners, staffing assumptions, publication schedule, or release commitment were
@@ -419,6 +413,7 @@ validated usage baseline.
   justify a public automation contract. Keep one clean internal workflow service, preserve the
   existing pi-goal managed-run contract only as compatibility behavior, and reconsider a Workflow
   RPC adapter after concrete consumer and transport evidence receives a separate approved proposal.
+- **2026-08-20 — Promote pi-workflow to stable:** Treat the combined extension as a stable third option, remove its package-level experimental warning, and keep pi-plan-mode and pi-goal active pending any separate successor decision.
 - **2026-08-03 — Reuse supervision lessons without reviving stale channels:** Carry forward PR #464's
   provenance, exact ownership, structured replies, timeout fallback, and real-consumer gates. Defer
   blocked review and continuation leases, and do not restore removed `pi-goal:rpc:*` channels.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 			"./packages/pi-sync/src/index.ts",
 			"./packages/pi-tool/src/index.ts",
 			"./packages/pi-usage/src/index.ts",
+			"./packages/pi-workflow/src/index.ts",
 			"./packages/pi-worktree/src/index.ts"
 		]
 	},

--- a/packages/pi-workflow/README.md
+++ b/packages/pi-workflow/README.md
@@ -2,11 +2,9 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-workflow)](https://www.npmjs.com/package/@narumitw/pi-workflow) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-workflow` is an experimental Pi extension that combines Codex-like Plan mode and persistent Goal execution in one independently installable package.
+`@narumitw/pi-workflow` is a Pi extension that combines Codex-like Plan mode and persistent Goal execution in one independently installable package.
 
 It keeps the established `/plan` and `/goal` command surfaces while making the approved Plan-to-Goal handoff one owned, recoverable transition.
-
-> **Experimental:** Workflow behavior, settings, and integrated persistence may change between releases.
 
 Do not load this package together with `@narumitw/pi-plan-mode` or `@narumitw/pi-goal`.
 
@@ -339,13 +337,11 @@ Automatic Goal work can consume substantial tokens and provider cost.
 
 Keep finite safety limits unless unlimited execution is an informed choice.
 
-This experimental package owns source snapshots of the stable Plan and Goal implementations so it remains independently installable.
-
-This is an explicit prototype deviation from the existing shared workflow-engine roadmap.
-
-The package must migrate to one shared engine, or receive a superseding architecture decision, before promotion to stable.
+This package owns source snapshots of the stable Plan and Goal implementations so it remains independently installable.
 
 It does not import or depend on another extension package.
+
+The shared workflow engine remains a planned maintainability improvement rather than a stability prerequisite.
 
 Behavioral updates to either stable predecessor must be intentionally synchronized and reverified here.
 

--- a/packages/pi-workflow/package.json
+++ b/packages/pi-workflow/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-workflow",
 	"version": "0.4.2",
-	"description": "Experimental Pi extension combining Plan mode and Goal execution with an integrated handoff.",
+	"description": "Pi extension combining Plan mode and Goal execution with an integrated handoff.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -26,7 +26,7 @@
 		]
 	},
 	"piExtension": {
-		"lifecycle": "experimental"
+		"lifecycle": "stable"
 	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",

--- a/packages/pi-workflow/src/menu.ts
+++ b/packages/pi-workflow/src/menu.ts
@@ -40,7 +40,7 @@ export function createWorkflowMenu(controller: WorkflowMenuController) {
 		screens: {
 			main: ({ state }) => ({
 				kind: "actions",
-				title: "Workflow · Experimental",
+				title: "Workflow",
 				lines: summaryLines(state),
 				items: [
 					{

--- a/packages/pi-workflow/src/workflow.ts
+++ b/packages/pi-workflow/src/workflow.ts
@@ -178,10 +178,6 @@ export default function workflow(pi: ExtensionAPI, dependencies: WorkflowDepende
 		if (settingsIssue) {
 			ctx.ui.notify(`pi-workflow settings ignored: ${safeTerminalText(settingsIssue)}`, "warning");
 		}
-		ctx.ui.notify(
-			"pi-workflow is experimental. Workflow behavior and persisted integration state may change.",
-			"warning",
-		);
 	});
 	pi.on("session_shutdown", (_event, ctx) => {
 		workflowGeneration += 1;
@@ -221,7 +217,7 @@ export default function workflow(pi: ExtensionAPI, dependencies: WorkflowDepende
 	};
 
 	pi.registerCommand("workflow", {
-		description: "Manage the experimental Plan-to-Goal workflow",
+		description: "Manage the Plan-to-Goal workflow",
 		handler: async (args, ctx) => {
 			if (args.trim()) {
 				reportWorkflowError("/workflow does not accept arguments.", ctx);

--- a/packages/pi-workflow/test/workflow.test.ts
+++ b/packages/pi-workflow/test/workflow.test.ts
@@ -86,7 +86,8 @@ test("workflow command is menu-only with observable mode handling", async () => 
 	});
 	await emitAll(mock, "session_start", { reason: "startup" }, tui.ctx);
 	await mock.commands.get("workflow")?.handler("", tui.ctx);
-	assert.ok(tui.notifications.some((notice) => /experimental/i.test(notice.message)));
+	assert.equal(mock.commands.get("workflow")?.description, "Manage the Plan-to-Goal workflow");
+	assert.equal(tui.notifications.length, 0);
 
 	await mock.commands.get("workflow")?.handler("unknown", tui.ctx);
 	assert.match(tui.notifications.at(-1)?.message ?? "", /does not accept arguments/u);


### PR DESCRIPTION
## Summary

- promote `@narumitw/pi-workflow` from experimental to stable and include it in root Git installations
- recommend `pi-workflow` when users would otherwise install both standalone Plan and Goal extensions
- document that `pi-workflow` must not be co-loaded with either standalone extension because their commands, tools, flags, Goal event channels, and session-state names overlap
- remove package-level experimental warnings while preserving the optional ordered Goal queue's experimental safeguards
- update package, repository, and roadmap documentation and add a minor changeset

## Verification

- `npm run check`
- `npm test` — 382 files and 3,611 tests passed
- `npm --workspace @narumitw/pi-workflow run test:runtime`
- `npm pack --workspace @narumitw/pi-workflow --dry-run --json` with manifest, source entry, generated entry, README, and license inspection
- pre-commit Biome and workspace typechecks after the README follow-up

## Review notes

- Audited the lifecycle move against `docs/extension-conventions.md`.
- No settings, cancellation, disposal, session replacement, or shutdown ownership changed.
- A live interactive `pi -e` smoke was not run; the generated-runtime loader and lifecycle smoke passed.
