### PR TITLE
feat(btw): add fullscreen search and clipboard feedback

### DIFF
--- a/.changeset/calm-btw-search.md
+++ b/.changeset/calm-btw-search.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": minor
+---
+
+Add themed fullscreen transcript search and verified host clipboard feedback for mouse selections.

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -76,32 +76,29 @@ Opening and closing a thread without a new result does not reorder it.
 `/btw <question>` bypasses this menu and always starts a fresh side thread.
 Its answer opens above the side-thread editor.
 The side thread uses a dedicated full-screen terminal view.
-The main agent continues running in the background, but its screen rendering stays suspended until
-`/btw` closes, so new main-thread output cannot move a mouse selection inside the side thread.
-Drag the primary mouse button across side-thread text to select and copy it through Pi's terminal
-clipboard support. Returning from `/btw` redraws the main view with everything produced while it
-was hidden. A compact `btw · side thread` header stays fixed above the content so the ephemeral
-workspace remains recognizable while scrolling. Messages use Pi's normal
-user and assistant presentation without numbered turns or role labels. Type each question and press
-`Enter`; no follow-up shortcut is required.
-Previous side questions and answers remain available to the model and visible for that
-invocation. The side-thread header shows its current thinking level. Press Pi's configured
-`app.thinking.cycle` shortcut (`Shift+Tab` by default) in the composer to cycle the levels
-supported by the side-thread model; every later question uses the displayed level until it is
-changed again. When a fixed thinking level is selected, each shortcut change is also written to
-`pi-btw.json` for the next invocation by default. Turn **Remember thinking level changes** off in
-Settings to keep fixed-level changes local to the current side thread. When **Same as main thread** is
-selected, shortcut changes are always local to the current side thread. Neither path changes the main
-session's thinking level.
-While a response is running, the transcript and composer remain visible above an `Answering…`
-status.
-Type another question and press `Enter` to queue it as `Steering`; queued questions are shown in
-submission order and answered one at a time after the active response completes.
+The main agent continues running in the background, but its screen rendering stays suspended until `/btw` closes, so new main-thread output cannot move a mouse selection inside the side thread.
+Drag the primary mouse button across side-thread text to request a copy through Pi's host clipboard helper.
+The view reports `Copied!` when Pi accepts the copy and `Copy failed` when Pi reports failure; actual clipboard availability still depends on operating-system and terminal support.
+Returning from `/btw` redraws the main view with everything produced while it was hidden.
+A compact `btw · side thread` header stays fixed above the content so the ephemeral workspace remains recognizable while scrolling.
+Messages use Pi's normal user and assistant presentation without numbered turns or role labels.
+Type each question and press `Enter`; no follow-up shortcut is required.
+Press `Ctrl+Shift+F` to search completed or answering transcript content.
+Press `Enter` or `Ctrl+G` for the next match, `Shift+Enter` or `Ctrl+Shift+G` for the previous match, and `Escape` to close search.
+Search uses Pi's active theme, keeps the composer available after closing the search overlay, and does not include fixed header or footer chrome.
+Previous side questions and answers remain available to the model and visible for that invocation.
+The side-thread header shows its current thinking level.
+Press Pi's configured `app.thinking.cycle` shortcut (`Shift+Tab` by default) in the composer to cycle the levels supported by the side-thread model; every later question uses the displayed level until it is changed again.
+When a fixed thinking level is selected, each shortcut change is also written to `pi-btw.json` for the next invocation by default.
+Turn **Remember thinking level changes** off in Settings to keep fixed-level changes local to the current side thread.
+When **Same as main thread** is selected, shortcut changes are always local to the current side thread.
+Neither path changes the main session's thinking level.
+While a response is running, the transcript and composer remain visible above an `Answering…` status.
+Type another question and press `Enter` to queue it as `Steering`; queued questions are shown in submission order and answered one at a time after the active response completes.
 A queued question uses the side thread's thinking level when its turn begins.
 A failed active response is shown in the transcript and does not discard later steering questions.
 Use the mouse wheel or trackpad to scroll transcript history like Pi's main thread.
-Keyboard `PgUp`/`PgDn` history navigation remains available.
-It appears in the footer only when the transcript can scroll.
+Keyboard `PgUp`/`PgDn` history navigation remains available and appears in the footer only when the transcript can scroll.
 Press `Ctrl+C` to cancel the active response and discard the ephemeral side-thread draft and steering queue.
 Completed questions, answers, and visible errors remain available through Resume until the current extension instance ends.
 Steering remains entirely inside pi-btw and never appends to the main conversation or editor.

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -1,8 +1,9 @@
 import { spawn } from "node:child_process";
-import type {
-	ExtensionCommandContext,
-	KeybindingsManager,
-	Theme,
+import {
+	copyToClipboard as copyToHostClipboard,
+	type ExtensionCommandContext,
+	type KeybindingsManager,
+	type Theme,
 } from "@earendil-works/pi-coding-agent";
 import {
 	type Component,
@@ -30,11 +31,12 @@ export interface BtwFullscreenLayoutComponent extends Component {
 	getFullscreenLayout(): Component;
 }
 
-export type BtwFullscreenTuiFactory = (parent: TUI) => BtwFullscreenTui;
+export type BtwFullscreenTuiFactory = (parent: TUI, theme: Theme) => BtwFullscreenTui;
 
 export interface BtwFullscreenDependencies {
 	createTui?: BtwFullscreenTuiFactory;
 	openUrl?: (url: string) => void;
+	copyToClipboard?: (text: string) => Promise<void>;
 }
 
 export type RunBtwFullscreen = <T>(
@@ -58,7 +60,13 @@ export async function runBtwFullscreen<T>(
 ): Promise<T> {
 	const createTui =
 		dependencies.createTui ??
-		((parent: TUI) => createBtwFullscreenTui(parent, dependencies.openUrl ?? openUrlInBrowser));
+		((parent: TUI, theme: Theme) =>
+			createBtwFullscreenTui(
+				parent,
+				theme,
+				dependencies.openUrl ?? openUrlInBrowser,
+				dependencies.copyToClipboard ?? copyToHostClipboard,
+			));
 	let liveEditorText = ctx.ui.getEditorText();
 	let restoreEditor = false;
 	const outcome = await ctx.ui.custom<FullscreenOutcome<T>>(
@@ -92,10 +100,27 @@ export async function runBtwFullscreen<T>(
 	return outcome.value;
 }
 
-function createBtwFullscreenTui(parent: TUI, openUrl: (url: string) => void): BtwFullscreenTui {
+function createBtwFullscreenTui(
+	parent: TUI,
+	theme: Theme,
+	openUrl: (url: string) => void,
+	copyToClipboard: (text: string) => Promise<void>,
+): BtwFullscreenTui {
+	const styleSearchMatch = (text: string) =>
+		theme.bg("searchMatchBg", theme.fg("searchMatchText", text));
 	return new TuiAltScreen(parent.terminal, parent.getShowHardwareCursor(), undefined, {
 		mouse: true,
+		searchMatchStyle: (text) => theme.underline(styleSearchMatch(text)),
+		searchCurrentMatchStyle: (text) => theme.bold(theme.inverse(styleSearchMatch(text))),
 		openUrl,
+		copySelection: async (text) => {
+			try {
+				await copyToClipboard(text);
+				return true;
+			} catch {
+				return false;
+			}
+		},
 	});
 }
 
@@ -154,7 +179,7 @@ class BtwFullscreenHost<T> implements Component {
 			this.parent.stop({ preserveScreen: true });
 			parentStopped = true;
 			if (this.disposed) throw new FullscreenUiDisposedError();
-			this.fullscreen = this.createTui(this.parent);
+			this.fullscreen = this.createTui(this.parent, this.theme);
 			fullscreenCreated = true;
 			this.fullscreen.start();
 			outcome = { kind: "completed", value: await this.run(this.createContext()) };

--- a/packages/pi-btw/test/fullscreen-search.test.ts
+++ b/packages/pi-btw/test/fullscreen-search.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { runBtwFullscreen } from "../src/fullscreen-ui.js";
+import { BtwAnsweringView, BtwTranscriptPager } from "../src/transcript-pager.js";
+
+const OPEN_SEARCH = "\u001b[102;6u";
+const PREVIOUS_MATCH = "\u001b[13;2u";
+
+function response(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		stopReason: "stop",
+		timestamp: Date.now(),
+		api: "anthropic-messages",
+		provider: "test",
+		model: "side",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	} as AssistantMessage;
+}
+
+function createSearchHarness(rows = 14) {
+	const writes: string[] = [];
+	const styleCalls: string[] = [];
+	let handleInput: ((data: string) => void) | undefined;
+	const terminal = {
+		columns: 80,
+		rows,
+		start(onInput: (data: string) => void) {
+			handleInput = onInput;
+		},
+		stop() {},
+		write(data: string) {
+			writes.push(data);
+		},
+		hideCursor() {},
+		showCursor() {},
+	} as never;
+	const parent = {
+		mode: "regular",
+		terminal,
+		getShowHardwareCursor: () => false,
+		stop() {},
+		start() {},
+		renderNow() {},
+		requestRender() {},
+	} as unknown as TUI;
+	let outerDone: ((value: unknown) => void) | undefined;
+	let editorText = "main draft";
+	const theme = {
+		fg: (color: string, text: string) => {
+			if (color !== "searchMatchText") return text;
+			styleCalls.push(`fg:${text}`);
+			return `\u001b[31m${text}\u001b[39m`;
+		},
+		bg: (color: string, text: string) => {
+			assert.equal(color, "searchMatchBg");
+			styleCalls.push(`bg:${stripVTControlCharacters(text)}`);
+			return `\u001b[42m${text}\u001b[49m`;
+		},
+		underline: (text: string) => {
+			styleCalls.push(`underline:${stripVTControlCharacters(text)}`);
+			return `\u001b[4m${text}\u001b[24m`;
+		},
+		inverse: (text: string) => {
+			styleCalls.push(`inverse:${stripVTControlCharacters(text)}`);
+			return `\u001b[7m${text}\u001b[27m`;
+		},
+		bold: (text: string) => {
+			styleCalls.push(`bold:${stripVTControlCharacters(text)}`);
+			return `\u001b[1m${text}\u001b[22m`;
+		},
+	};
+	const ctx = {
+		ui: {
+			custom: async (factory: (...args: never[]) => Component) => {
+				const result = new Promise<unknown>((resolve) => {
+					outerDone = resolve;
+				});
+				factory(
+					parent as never,
+					theme as never,
+					{} as never,
+					((value: unknown) => outerDone?.(value)) as never,
+				);
+				return result;
+			},
+			getEditorText: () => editorText,
+			setEditorText: (value: string) => {
+				editorText = value;
+			},
+		},
+	} as never;
+	return {
+		ctx,
+		writes,
+		styleCalls,
+		get input() {
+			assert.ok(handleInput);
+			return handleInput;
+		},
+	};
+}
+
+async function flushAsyncWork(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function readSearchStatus(writes: readonly string[]): { index: number; count: number } {
+	const frame = stripVTControlCharacters(writes.join(""));
+	const match = /(\d+)\/(\d+)/u.exec(frame);
+	assert.ok(match, `search status was not rendered in ${JSON.stringify(frame)}`);
+	return { index: Number(match[1]), count: Number(match[2]) };
+}
+
+const cases = ["completed", "answering"] as const;
+
+test.each(cases)(
+	"%s side-thread fullscreen searches with callback-theme styles and preserves the composer",
+	async (kind) => {
+		initTheme("dark");
+		const harness = createSearchHarness();
+		const answer = Array.from(
+			{ length: 48 },
+			(_, index) => `needle ${kind} transcript row ${index + 1}`,
+		).join("\n");
+		let sideTui: TUI | undefined;
+		const running = runBtwFullscreen(harness.ctx, (fullscreenCtx) =>
+			fullscreenCtx.ui.custom<"closed">((tui, theme, _keys, done) => {
+				sideTui = tui;
+				const turns = [
+					{
+						question: `${kind} question`,
+						answer,
+						kind: "answered" as const,
+						response: response(answer),
+					},
+				];
+				if (kind === "completed") {
+					return new BtwTranscriptPager(
+						tui,
+						theme,
+						turns,
+						(action) => {
+							if (action.kind === "close") done("closed");
+						},
+						{ startAtBottom: true },
+					);
+				}
+				return new BtwAnsweringView(
+					tui,
+					theme,
+					turns,
+					"current question",
+					() => done("closed"),
+					undefined,
+					{ steering: { questions: [], onSubmit() {} } },
+				);
+			}),
+		);
+		await flushAsyncWork();
+		assert.ok(sideTui);
+		sideTui.renderNow(true);
+
+		harness.writes.length = 0;
+		harness.input(OPEN_SEARCH);
+		harness.input("needle");
+		sideTui.renderNow(true);
+		const initial = readSearchStatus(harness.writes);
+		assert.ok(initial.count > 2);
+		assert.ok(harness.styleCalls.some((call) => call.startsWith("underline:needle")));
+		assert.ok(harness.styleCalls.some((call) => call.startsWith("inverse:needle")));
+		assert.ok(harness.styleCalls.some((call) => call.startsWith("bold:needle")));
+		const searchFrame = stripVTControlCharacters(harness.writes.join(""));
+		assert.match(searchFrame, /Find transcript/);
+		assert.match(searchFrame, /btw · side thread/);
+		assert.match(searchFrame, kind === "completed" ? /Ctrl\+C/ : /Answering…/);
+
+		harness.writes.length = 0;
+		harness.input("\r");
+		sideTui.renderNow(true);
+		const next = readSearchStatus(harness.writes);
+		assert.equal(next.count, initial.count);
+		assert.equal(next.index, (initial.index % initial.count) + 1);
+
+		harness.writes.length = 0;
+		harness.input(PREVIOUS_MATCH);
+		sideTui.renderNow(true);
+		assert.deepEqual(readSearchStatus(harness.writes), initial);
+
+		harness.input("\u001b");
+		harness.input("composer still works");
+		harness.writes.length = 0;
+		sideTui.renderNow(true);
+		const composerFrame = stripVTControlCharacters(harness.writes.join(""));
+		assert.match(composerFrame, /composer still works/);
+		assert.doesNotMatch(composerFrame, /Find transcript/);
+
+		harness.input("\u0003");
+		assert.equal(await running, "closed");
+	},
+);

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -125,6 +125,110 @@ async function flushAsyncWork(): Promise<void> {
 	await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
+function createNativeFullscreenHarness() {
+	const events: string[] = [];
+	const writes: string[] = [];
+	let handleInput: ((data: string) => void) | undefined;
+	const terminal = {
+		columns: 80,
+		rows: 12,
+		start(onInput: (data: string) => void) {
+			handleInput = onInput;
+		},
+		stop() {},
+		write(data: string) {
+			writes.push(data);
+		},
+		hideCursor() {},
+		showCursor() {},
+	} as never;
+	const parent = {
+		mode: "regular",
+		terminal,
+		getShowHardwareCursor: () => false,
+		stop(options?: { preserveScreen?: boolean }) {
+			events.push(`parent.stop:${String(options?.preserveScreen)}`);
+		},
+		start() {
+			events.push("parent.start");
+		},
+		renderNow(force?: boolean) {
+			events.push(`parent.renderNow:${String(force)}`);
+		},
+		requestRender() {},
+	} as unknown as TUI;
+	let outerComponent: FakeComponent | undefined;
+	let outerDone: ((value: unknown) => void) | undefined;
+	let editorText = "main draft";
+	const theme = {
+		fg: (_color: string, text: string) => text,
+		bg: (_color: string, text: string) => text,
+		underline: (text: string) => text,
+		inverse: (text: string) => text,
+		bold: (text: string) => text,
+	};
+	const ctx = {
+		ui: {
+			custom: async (factory: (...args: never[]) => FakeComponent) => {
+				const result = new Promise<unknown>((resolve) => {
+					outerDone = resolve;
+				});
+				outerComponent = factory(
+					parent as never,
+					theme as never,
+					{} as never,
+					((value: unknown) => outerDone?.(value)) as never,
+				);
+				return result;
+			},
+			getEditorText: () => editorText,
+			setEditorText: (value: string) => {
+				editorText = value;
+			},
+		},
+	} as never;
+	return {
+		ctx,
+		events,
+		writes,
+		get outerComponent() {
+			return outerComponent;
+		},
+		get input() {
+			assert.ok(handleInput);
+			return handleInput;
+		},
+	};
+}
+
+async function startClipboardSelection(copy: (text: string) => Promise<void>) {
+	const harness = createNativeFullscreenHarness();
+	let sideTui: TUI | undefined;
+	let closeSide: (() => void) | undefined;
+	const running = runBtwFullscreen(
+		harness.ctx,
+		(fullscreenCtx) =>
+			fullscreenCtx.ui.custom<"closed">((tui, _theme, _keys, done) => {
+				sideTui = tui;
+				closeSide = () => done("closed");
+				return {
+					render: () => ["\u001b[31mcopy me\u001b[39m"],
+					invalidate() {},
+					dispose() {},
+				};
+			}),
+		{ copyToClipboard: copy },
+	);
+	await flushAsyncWork();
+	assert.ok(sideTui);
+	assert.ok(closeSide);
+	sideTui.renderNow(true);
+	harness.writes.length = 0;
+	harness.input("\u001b[<0;1;1M");
+	harness.input("\u001b[<0;7;1m");
+	return { harness, running, sideTui, closeSide };
+}
+
 test("default fullscreen enables application-owned mouse selection and restores terminal modes", async () => {
 	const writes: string[] = [];
 	let outerDone: ((value: unknown) => void) | undefined;
@@ -190,6 +294,106 @@ test("default fullscreen enables application-owned mouse selection and restores 
 			true,
 			`missing cleanup sequence ${JSON.stringify(sequence)}`,
 		);
+	}
+});
+
+test.each([
+	{
+		name: "successful host copy",
+		copy: async (text: string) => {
+			assert.equal(text, "copy me");
+		},
+		feedback: "Copied!",
+	},
+	{
+		name: "synchronous host failure",
+		copy: (_text: string): Promise<void> => {
+			throw new Error("clipboard unavailable");
+		},
+		feedback: "Copy failed",
+	},
+	{
+		name: "rejected host copy",
+		copy: async (_text: string) => {
+			throw new Error("clipboard rejected");
+		},
+		feedback: "Copy failed",
+	},
+])("default fullscreen reports $name and restores its parent", async ({ copy, feedback }) => {
+	const { harness, running, sideTui, closeSide } = await startClipboardSelection(copy);
+	await flushAsyncWork();
+	sideTui.renderNow(true);
+	const outputBeforeClose = harness.writes.join("");
+	assert.equal(outputBeforeClose.includes("\u001b]52;"), false);
+	assert.equal(outputBeforeClose.includes(feedback), true);
+	closeSide();
+
+	assert.equal(await running, "closed");
+	assert.deepEqual(harness.events, ["parent.stop:true", "parent.start", "parent.renderNow:false"]);
+});
+
+test.each(["resolve", "reject"] as const)(
+	"a host clipboard promise may %s after close without blocking restoration or rejecting outward",
+	async (settlement) => {
+		let settleCopy: ((settlement: "resolve" | "reject") => void) | undefined;
+		const copy = () =>
+			new Promise<void>((resolve, reject) => {
+				settleCopy = (result) => {
+					if (result === "resolve") resolve();
+					else reject(new Error("late clipboard failure"));
+				};
+			});
+		const unhandled: unknown[] = [];
+		const onUnhandled = (error: unknown) => unhandled.push(error);
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const { harness, running, closeSide } = await startClipboardSelection(copy);
+			await flushAsyncWork();
+			assert.ok(settleCopy);
+			closeSide();
+			assert.equal(await running, "closed");
+			assert.deepEqual(harness.events, [
+				"parent.stop:true",
+				"parent.start",
+				"parent.renderNow:false",
+			]);
+
+			settleCopy(settlement);
+			await flushAsyncWork();
+			assert.deepEqual(unhandled, []);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	},
+);
+
+test("disposal restores the parent while a clipboard copy is pending and contains its late rejection", async () => {
+	let rejectCopy: ((error: Error) => void) | undefined;
+	const copy = () =>
+		new Promise<void>((_resolve, reject) => {
+			rejectCopy = reject;
+		});
+	const unhandled: unknown[] = [];
+	const onUnhandled = (error: unknown) => unhandled.push(error);
+	process.on("unhandledRejection", onUnhandled);
+	try {
+		const { harness, running } = await startClipboardSelection(copy);
+		await flushAsyncWork();
+		assert.ok(rejectCopy);
+		assert.ok(harness.outerComponent);
+		harness.outerComponent.dispose();
+		await assert.rejects(running, /dedicated pi-btw UI was disposed/i);
+		assert.deepEqual(harness.events, [
+			"parent.stop:true",
+			"parent.start",
+			"parent.renderNow:false",
+		]);
+
+		rejectCopy(new Error("clipboard rejected after disposal"));
+		await flushAsyncWork();
+		assert.deepEqual(unhandled, []);
+	} finally {
+		process.off("unhandledRejection", onUnhandled);
 	}
 });
 


### PR DESCRIPTION
## Summary

- Add Pi-themed search for completed and answering side-thread transcripts through the native fullscreen `TuiAltScreen` search flow.
- Route mouse selections through Pi's host clipboard helper with verified success/failure feedback and failure-contained delayed settlement.
- Document search, clipboard, and history controls and add a minor pi-btw Changeset.

## Verification

- `npx vitest run packages/pi-btw/test/fullscreen-search.test.ts packages/pi-btw/test/fullscreen-ui.test.ts packages/pi-btw/test/mouse-wheel.test.ts packages/pi-btw/test/side-thread.test.ts packages/pi-btw/test/build-runtime.test.ts` — 5 files, 114 tests passed.
- `npm --workspace @narumitw/pi-btw run check` — passed.
- `npm run check` — passed build, Biome, boundaries, and workspace typechecks.
- `npm test` — 382 files, 3,618 tests passed.
- `just changeset-status` — selected only `@narumitw/pi-btw` for a minor bump; it also emitted pre-existing dependency-floor notices for unrelated packages.
- `just pack btw` — dry run contained the manifest, README, license, generated `dist`, and intended source files.
- Real-`TuiAltScreen` deterministic tests covered search input/navigation/styling and mouse clipboard selection without opening an interactive TUI.

## Risks and unverified paths

- Pi's `copySelection` contract has no abort signal, so an invoked host clipboard promise may settle after fullscreen closes; the adapter cannot reject outward, and delayed resolve, delayed reject, disposal, and parent restoration are covered deterministically.
- A live `pi -e ./packages/pi-btw` smoke was not run because this non-interactive harness cannot safely operate the terminal UI; real alternate-screen tests are the smoke substitute.
- Clipboard availability still depends on operating-system and terminal support.
- Root Biome checks retain the existing informational CLI/schema version mismatch notice.
