### PR TITLE
fix(subagents): preserve streaming RPC usage

### DIFF
--- a/.changeset/calm-badgers-count.md
+++ b/.changeset/calm-badgers-count.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": patch
+---
+
+Preserve accurate cumulative RPC usage telemetry during streaming, interruption, and timeout finalization.

--- a/docs/implementation-notes/pi-subagents-rpc-v1.md
+++ b/docs/implementation-notes/pi-subagents-rpc-v1.md
@@ -28,6 +28,28 @@ A breaking lifecycle or envelope change requires another protocol identifier.
 
 Raw prompts, chain-of-thought, credentials, headers, environment values, full stderr, and raw tool arguments never enter the envelope.
 
+## Usage accounting
+
+Pi 0.84.2 RPC `message_update.usage` values are cumulative for the current assistant message.
+
+RPC v1 keeps the latest validated update as one replaceable in-flight snapshot instead of adding successive updates together.
+
+A valid `message_end.message.usage` is authoritative for the finalized assistant message.
+
+When final usage has no valid token or total-cost field, RPC v1 commits the latest valid in-flight snapshot instead.
+
+A new assistant `message_start` commits usage from an interrupted prior attempt before tracking the new cumulative stream.
+
+Timeout finalization commits the interrupted work snapshot before clearing captured output and starting the bounded summary attempt.
+
+Progress and terminal outcomes expose the safe sum of committed usage plus the current in-flight snapshot.
+
+Only non-negative finite values no larger than `Number.MAX_SAFE_INTEGER` enter telemetry, and `totalTokens` is derived from valid components only when no valid reported total exists.
+
+The `turns` field continues to count finalized assistant messages only, so interrupted attempts and tool-result messages do not increment it.
+
+Usage progress contains only normalized token counts, total cost, and finalized-turn count, and never adds raw RPC events, prompts, content, reasoning, credentials, headers, or environment values to the envelope.
+
 ## Lifecycle
 
 One retained `agentId` lazily owns at most one RPC child.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -806,7 +806,12 @@ Stateful execution uses a transport boundary:
 - Agent model strings use Pi core's CLI resolver, including provider/model patterns, fuzzy matching, custom provider model IDs, and `:<thinking>` suffixes. Thinking level and built-in tool allow-list overrides are applied when the child is created. Parent model/thinking changes are snapshotted for subsequently created children; an existing child keeps its own session configuration.
 - Extension/custom tool names are rejected by in-process and RPC v1 before child creation; automatic mode selects `subprocess` for them, and permissions are never silently widened.
 - Timeout, parent abort, close, expiry, and session shutdown abort/dispose owned child sessions or process groups. A child that does not settle after abort grace is discarded rather than reused.
-- RPC progress uses `pi-subagents:v1` metadata and reports only bounded phase, queue, timing, effective model/thinking, and validated usage fields; it never exposes raw prompts, reasoning, credentials, environment values, or full RPC events.
+- RPC progress uses `pi-subagents:v1` metadata and reports only bounded phase, queue, timing, effective model/thinking, and validated usage fields.
+  Successive Pi 0.84.2 `message_update.usage` values replace one cumulative in-flight snapshot, while a valid final `message_end.message.usage` remains authoritative.
+  Missing or invalid final usage falls back to the latest valid streaming snapshot, and an interrupted attempt is committed before retry or timeout-summary usage is added.
+  Usage progress and terminal outcomes therefore retain partial token and total-cost evidence without double counting cumulative updates.
+  The `turns` field still counts finalized assistant messages only, not interrupted attempts or tool-result messages.
+  Telemetry never exposes raw prompts, assistant content, reasoning, credentials, headers, environment values, or full RPC events.
 - A successful RPC prompt response is never treated as completion, and accepted or ambiguously accepted work is never replayed automatically.
 - In-process startup failures do not silently retry through subprocesses, preventing duplicate side effects. If the loaded Pi core lacks public `createAgentSessionServices()`, `createAgentSessionFromServices()`, or `resolveCliModel()` support, startup fails with an actionable instruction to select `stateful.transport: "subprocess"`.
 
@@ -1009,7 +1014,14 @@ An explicit spawn value is retained for the agent lifecycle and wins over every 
 
 Omit `thinkingLevel` to preserve existing behavior. Reported stateful details show the requested level, not a guarantee of the provider's effective value. Pi still owns model capability clamping; `pi-subagents` does not duplicate capability detection.
 
-When any execution budget expires, the extension aborts the active run first and creates a versioned, bounded, redacted checkpoint containing partial assistant notes, completed tool evidence, changed-file hints, and whether side effects may already have occurred. After authoritative settlement it may make one concise summary attempt over that checkpoint without replaying the stopped task. The summary attempt has its own extension-owned model-work deadline of at most 45 seconds, followed only by bounded abort and process-cleanup grace. Fresh subprocess summaries run with no tools or project resources. Retained RPC and in-process summaries reuse their child context and are explicitly instructed not to call tools; the current child APIs do not support replacing an existing session's tool set for one turn, so their separate deadline and abort path remain the enforcement boundary. The deterministic checkpoint remains available when finalization or the provider fails, and results retain exit `124` plus a structured termination reason and finalization status. Explicit parent or user abort stops immediately, never starts finalization, and is not mislabeled as a budget stop.
+When any execution budget expires, the extension aborts the active run first and creates a versioned, bounded, redacted checkpoint containing partial assistant notes, completed tool evidence, changed-file hints, and whether side effects may already have occurred.
+After authoritative settlement it may make one concise summary attempt over that checkpoint without replaying the stopped task.
+The summary attempt has its own extension-owned model-work deadline of at most 45 seconds, followed only by bounded abort and process-cleanup grace.
+Fresh subprocess summaries run with no tools or project resources.
+Retained RPC and in-process summaries reuse their child context and are explicitly instructed not to call tools; the current child APIs do not support replacing an existing session's tool set for one turn, so their separate deadline and abort path remain the enforcement boundary.
+Before a retained RPC summary starts, validated in-flight usage from the interrupted work attempt is committed so the summary adds to it exactly once.
+The deterministic checkpoint remains available when finalization or the provider fails, and results retain exit `124` plus a structured termination reason and finalization status.
+Explicit parent or user abort stops immediately, never starts finalization, and is not mislabeled as a budget stop.
 
 This release does not claim a cooperative soft-wrap-up phase because print-mode subprocess children cannot receive steering while they are running. It also does not retry budget-stopped work automatically because file or external side effects may already have occurred.
 

--- a/packages/pi-subagents/src/rpc-transport.ts
+++ b/packages/pi-subagents/src/rpc-transport.ts
@@ -37,8 +37,10 @@ import {
 } from "./rpc-transport-metadata.js";
 import {
 	captureRpcEvent,
+	commitRpcInFlightUsage,
 	createRpcTurnCapture,
 	observeRpcBudgetEvent,
+	snapshotRpcUsage,
 } from "./rpc-turn-capture.js";
 import { terminateProcess } from "./runner.js";
 import { safeTerminalText } from "./safe-text.js";
@@ -501,11 +503,17 @@ export class RpcTransport implements SubagentTransport {
 		});
 		void settled.catch(() => undefined);
 		const unsubscribeEvent = child.client.onEvent((event) => {
-			captureRpcEvent(event, capture);
+			const usageChanged = captureRpcEvent(event, capture);
 			observeRpcBudgetEvent(event, budgetMonitor);
 			if (!capture.firstActivityAt && isActivityEvent(event)) {
 				capture.firstActivityAt = Date.now();
-				publish({ phase: "running", timing: { firstActivityAt: capture.firstActivityAt } });
+				publish({
+					phase: "running",
+					timing: { firstActivityAt: capture.firstActivityAt },
+					...(usageChanged ? { usage: snapshotRpcUsage(capture) } : {}),
+				});
+			} else if (usageChanged) {
+				publish({ usage: snapshotRpcUsage(capture) });
 			}
 			const type = eventType(event);
 			if (type === "auto_retry_start") publish({ phase: "retrying" });
@@ -572,7 +580,7 @@ export class RpcTransport implements SubagentTransport {
 						phase: explicitAbort ? "interrupted" : "failed",
 						failurePhase: "running",
 						timing: { settledAt: Date.now() },
-						usage: capture.usage,
+						usage: snapshotRpcUsage(capture),
 					});
 					const checkpointOutput = termination
 						? formatTimeoutCheckpoint(termination.checkpoint)
@@ -591,7 +599,11 @@ export class RpcTransport implements SubagentTransport {
 					};
 				}
 
-				publish({ phase: "finalizing", failurePhase: "running" });
+				publish({
+					phase: "finalizing",
+					failurePhase: "running",
+					usage: snapshotRpcUsage(capture),
+				});
 				const finalizationStartedAt = Date.now();
 				const summary = await finalizeTimedOutRpcTurn({
 					client: child.client,
@@ -605,6 +617,7 @@ export class RpcTransport implements SubagentTransport {
 					finalizationTimeoutMs: this.options.timeoutFinalizationMs,
 					abortGraceMs: this.options.abortGraceMs ?? ABORT_GRACE_MS,
 					resetCapture() {
+						commitRpcInFlightUsage(capture);
 						capture.output = "";
 						capture.partial = "";
 						capture.stopReason = undefined;
@@ -625,7 +638,7 @@ export class RpcTransport implements SubagentTransport {
 					phase: "failed",
 					failurePhase: "running",
 					timing: { settledAt: Date.now() },
-					usage: capture.usage,
+					usage: snapshotRpcUsage(capture),
 				});
 				const checkpointOutput = termination ? formatTimeoutCheckpoint(termination.checkpoint) : "";
 				return {
@@ -651,7 +664,7 @@ export class RpcTransport implements SubagentTransport {
 				timing: { settledAt: Date.now() },
 				provider: capture.provider ?? telemetry.provider,
 				model: capture.model ?? telemetry.model,
-				usage: capture.usage,
+				usage: snapshotRpcUsage(capture),
 			});
 			return {
 				output: output.text,
@@ -686,6 +699,7 @@ export class RpcTransport implements SubagentTransport {
 				phase: signal.aborted ? "interrupted" : "failed",
 				failurePhase: accepted ? "running" : "ready",
 				timing: { settledAt: Date.now() },
+				usage: snapshotRpcUsage(capture),
 			});
 			return {
 				output:

--- a/packages/pi-subagents/src/rpc-turn-capture.ts
+++ b/packages/pi-subagents/src/rpc-turn-capture.ts
@@ -12,6 +12,7 @@ export interface RpcTurnCapture {
 	provider?: string;
 	model?: string;
 	usage: TransportUsage;
+	inFlightUsage?: TransportUsage;
 	firstActivityAt?: number;
 	journal: TimeoutProgressJournal;
 }
@@ -25,8 +26,9 @@ export function createRpcTurnCapture(): RpcTurnCapture {
 	};
 }
 
-export function captureRpcEvent(event: unknown, capture: RpcTurnCapture): void {
-	if (!isRecord(event)) return;
+export function captureRpcEvent(event: unknown, capture: RpcTurnCapture): boolean {
+	if (!isRecord(event)) return false;
+	const previousUsage = snapshotRpcUsage(capture);
 	if (event.type === "tool_execution_start") {
 		capture.journal.recordToolCall(
 			typeof event.toolCallId === "string" ? event.toolCallId : "",
@@ -42,7 +44,12 @@ export function captureRpcEvent(event: unknown, capture: RpcTurnCapture): void {
 			{ content: result.content, isError: event.isError },
 		);
 	}
+	if (event.type === "message_start" && isRecord(event.message)) {
+		if (event.message.role === "assistant") commitRpcInFlightUsage(capture);
+	}
 	if (event.type === "message_update") {
+		const usage = normalizeUsage(event.usage);
+		if (usage) capture.inFlightUsage = usage;
 		const delta = event.assistantMessageEvent;
 		if (isRecord(delta) && delta.type === "text_delta" && typeof delta.delta === "string") {
 			capture.partial = truncateUtf8(
@@ -51,10 +58,28 @@ export function captureRpcEvent(event: unknown, capture: RpcTurnCapture): void {
 			).text;
 		}
 	}
-	if (event.type !== "message_end" || !isRecord(event.message)) return;
-	const candidate = event.message;
-	if (candidate.role !== "toolResult") journalMessages(capture.journal, [candidate]);
-	if (candidate.role !== "assistant") return;
+	if (event.type === "message_end" && isRecord(event.message)) {
+		const candidate = event.message;
+		if (candidate.role !== "toolResult") journalMessages(capture.journal, [candidate]);
+		if (candidate.role === "assistant") captureAssistantEnd(candidate, capture);
+	}
+	return !sameUsage(previousUsage, snapshotRpcUsage(capture));
+}
+
+export function snapshotRpcUsage(capture: RpcTurnCapture): TransportUsage {
+	const usage = { ...capture.usage };
+	if (capture.inFlightUsage) addUsage(usage, capture.inFlightUsage);
+	return usage;
+}
+
+export function commitRpcInFlightUsage(capture: RpcTurnCapture): boolean {
+	if (!capture.inFlightUsage) return false;
+	addUsage(capture.usage, capture.inFlightUsage);
+	capture.inFlightUsage = undefined;
+	return true;
+}
+
+function captureAssistantEnd(candidate: Record<string, unknown>, capture: RpcTurnCapture): void {
 	capture.output = truncateUtf8(
 		assistantText(candidate.content) || capture.partial,
 		DEFAULT_MAX_OUTPUT_BYTES,
@@ -76,8 +101,11 @@ export function captureRpcEvent(event: unknown, capture: RpcTurnCapture): void {
 				? candidate.model
 				: undefined;
 	capture.model = responseModel ? boundedPrivateText(responseModel, 256) : undefined;
-	capture.usage.turns++;
-	addUsage(capture.usage, candidate.usage);
+	const finalUsage = normalizeUsage(candidate.usage);
+	const completedUsage = finalUsage ?? capture.inFlightUsage;
+	if (completedUsage) addUsage(capture.usage, completedUsage);
+	capture.inFlightUsage = undefined;
+	capture.usage.turns = addUsageValue(capture.usage.turns, 1);
 }
 
 export function observeRpcBudgetEvent(event: unknown, monitor: TurnBudgetMonitor): void {
@@ -101,29 +129,76 @@ function assistantToolCallCount(content: unknown): number {
 	return content.filter((part) => isRecord(part) && part.type === "toolCall").length;
 }
 
-function addUsage(target: TransportUsage, value: unknown): void {
-	if (!isRecord(value)) return;
-	target.input += safeNonNegative(value.input);
-	target.output += safeNonNegative(value.output);
-	target.cacheRead += safeNonNegative(value.cacheRead);
-	target.cacheWrite += safeNonNegative(value.cacheWrite);
+function normalizeUsage(value: unknown): TransportUsage | undefined {
+	if (!isRecord(value)) return undefined;
+	const input = safeNonNegative(value.input);
+	const output = safeNonNegative(value.output);
+	const cacheRead = safeNonNegative(value.cacheRead);
+	const cacheWrite = safeNonNegative(value.cacheWrite);
 	const reportedTotal = safeNonNegative(value.totalTokens);
-	target.totalTokens +=
-		reportedTotal ||
-		safeNonNegative(value.input) +
-			safeNonNegative(value.output) +
-			safeNonNegative(value.cacheRead) +
-			safeNonNegative(value.cacheWrite);
-	if (isRecord(value.cost)) target.cost += safeNonNegative(value.cost.total);
+	const cost = isRecord(value.cost) ? safeNonNegative(value.cost.total) : undefined;
+	if (
+		input === undefined &&
+		output === undefined &&
+		cacheRead === undefined &&
+		cacheWrite === undefined &&
+		reportedTotal === undefined &&
+		cost === undefined
+	) {
+		return undefined;
+	}
+	const components = [input, output, cacheRead, cacheWrite].reduce<number>(
+		(total, current) => addUsageValue(total, current ?? 0),
+		0,
+	);
+	return {
+		input: input ?? 0,
+		output: output ?? 0,
+		cacheRead: cacheRead ?? 0,
+		cacheWrite: cacheWrite ?? 0,
+		totalTokens: reportedTotal ?? components,
+		cost: cost ?? 0,
+		turns: 0,
+	};
 }
 
-function safeNonNegative(value: unknown): number {
+function addUsage(target: TransportUsage, value: TransportUsage): void {
+	for (const key of [
+		"input",
+		"output",
+		"cacheRead",
+		"cacheWrite",
+		"totalTokens",
+		"cost",
+		"turns",
+	] as const) {
+		target[key] = addUsageValue(target[key], value[key]);
+	}
+}
+
+function addUsageValue(current: number, addition: number): number {
+	return Math.min(Number.MAX_SAFE_INTEGER, current + addition);
+}
+
+function safeNonNegative(value: unknown): number | undefined {
 	return typeof value === "number" &&
 		Number.isFinite(value) &&
 		value >= 0 &&
 		value <= Number.MAX_SAFE_INTEGER
 		? value
-		: 0;
+		: undefined;
+}
+
+function sameUsage(left: TransportUsage, right: TransportUsage): boolean {
+	return (
+		left.input === right.input &&
+		left.output === right.output &&
+		left.cacheRead === right.cacheRead &&
+		left.cacheWrite === right.cacheWrite &&
+		left.totalTokens === right.totalTokens &&
+		left.cost === right.cost &&
+		left.turns === right.turns
+	);
 }
 
 function assistantText(value: unknown): string {

--- a/packages/pi-subagents/test/rpc-transport.test.ts
+++ b/packages/pi-subagents/test/rpc-transport.test.ts
@@ -6,7 +6,7 @@ import { test } from "vitest";
 import type { ManagedAgent } from "../src/registry.js";
 import { finalizeTimedOutRpcTurn } from "../src/rpc-timeout-finalization.js";
 import { buildRpcArgs, RpcProtocolClient, RpcTransport } from "../src/rpc-transport.js";
-import { PI_SUBAGENTS_RPC_PROTOCOL } from "../src/transport-types.js";
+import { PI_SUBAGENTS_RPC_PROTOCOL, type TransportTelemetry } from "../src/transport-types.js";
 
 test("RPC timeout finalization never prompts after an explicit parent abort", async () => {
 	const controller = new AbortController();
@@ -75,7 +75,7 @@ function fixtureScript(root: string): string {
 			'import { StringDecoder } from "node:string_decoder";',
 			"const decoder=new StringDecoder('utf8');let buffer='';let turns=0;let pendingPrompt;",
 			"const send=(value)=>process.stdout.write(JSON.stringify(value)+'\\n');",
-			"const finishPrompt=()=>{const command=pendingPrompt;pendingPrompt=undefined;send({id:command.id,type:'response',command:'prompt',success:true});send({type:'agent_start'});send({type:'message_update',assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'turn '+turns}});send({type:'agent_end',messages:[],willRetry:false});send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'turn '+turns}],provider:'fake',model:'rpc-model',usage:{input:turns,output:2,cacheRead:0,cacheWrite:0,totalTokens:turns+2,cost:{total:0}},stopReason:'stop'}});send({type:'agent_settled'});};const handle=(line)=>{const command=JSON.parse(line);",
+			"const finishPrompt=()=>{const command=pendingPrompt;pendingPrompt=undefined;const firstUsage={input:turns,output:1,cacheRead:0,cacheWrite:0,totalTokens:turns+1,cost:{total:0.125}};const finalUsage={input:turns,output:2,cacheRead:0,cacheWrite:0,totalTokens:turns+2,cost:{total:0.25}};send({id:command.id,type:'response',command:'prompt',success:true});send({type:'agent_start'});send({type:'message_start',message:{role:'assistant',content:[]}});send({type:'message_update',usage:firstUsage,assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'turn '}});send({type:'message_update',usage:firstUsage,assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:''}});send({type:'message_update',usage:finalUsage,assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:String(turns)}});send({type:'agent_end',messages:[],willRetry:false});send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'turn '+turns}],provider:'fake',model:'rpc-model',usage:finalUsage,stopReason:'stop'}});send({type:'agent_settled'});};const handle=(line)=>{const command=JSON.parse(line);",
 			"if(command.type==='get_state'){send({id:command.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'rpc-model'},thinkingLevel:'medium',isStreaming:false,isCompacting:false,steeringMode:'one-at-a-time',followUpMode:'one-at-a-time',sessionId:'fake-session',autoCompactionEnabled:true,messageCount:turns*2,pendingMessageCount:0}});return;}",
 			"if(command.type==='abort'){send({id:command.id,type:'response',command:'abort',success:true});send({type:'agent_settled'});return;}",
 			"if(command.type==='extension_ui_response'){if(command.id==='ui-'+turns&&command.cancelled===true)finishPrompt();return;}",
@@ -342,12 +342,34 @@ test("RpcTransport retains one child across turns and reports pi-subagents:v1 te
 			},
 		});
 		const agent = { ...managedAgent(), cwd: root };
-		const first = await transport.runTurn(agent, "first", new AbortController().signal);
+		const progress: TransportTelemetry[] = [];
+		const first = await transport.runTurn(agent, "first", new AbortController().signal, (update) =>
+			progress.push(update),
+		);
 		assert.equal(first.output, "turn 1");
 		assert.equal(first.exitCode, 0);
 		assert.equal(first.telemetry?.protocol, PI_SUBAGENTS_RPC_PROTOCOL);
+		assert.equal(first.telemetry?.provider, "fake");
 		assert.equal(first.telemetry?.model, "rpc-model");
-		assert.equal(first.telemetry?.usage?.input, 1);
+		assert.equal(first.telemetry?.phase, "settled");
+		assert.deepEqual(first.telemetry?.usage, {
+			input: 1,
+			output: 2,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 3,
+			cost: 0.25,
+			turns: 1,
+		});
+		assert.deepEqual(
+			progress
+				.filter((update) => update.phase === "running" && update.usage && update.usage.turns === 0)
+				.map((update) => [update.usage?.totalTokens, update.usage?.cost, update.usage?.turns]),
+			[
+				[2, 0.125, 0],
+				[3, 0.25, 0],
+			],
+		);
 		assert.deepEqual(resourceRequests, [{ cwd: root, trusted: true }]);
 		assert.ok(rolePromptPath && existsSync(rolePromptPath));
 		const second = await transport.runTurn(
@@ -466,7 +488,7 @@ test("RpcTransport waits for agent_settled after agent_end and times out without
 				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');",
 				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
 				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
-				"if(c.type==='prompt'){send({id:c.id,type:'response',command:'prompt',success:true});send({type:'agent_end',messages:[],willRetry:true});setTimeout(()=>{send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'after retry'}],provider:'fake',model:'model',usage:{},stopReason:'stop'}});send({type:'agent_settled'});},30);}",
+				"if(c.type==='prompt'){send({id:c.id,type:'response',command:'prompt',success:true});send({type:'message_start',message:{role:'assistant',content:[]}});send({type:'message_update',usage:{input:3,output:1,cacheRead:0,cacheWrite:0,totalTokens:4,cost:{total:0.25}},assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'before retry'}});send({type:'agent_end',messages:[],willRetry:true});setTimeout(()=>{send({type:'compaction_start'});send({type:'compaction_end'});send({type:'message_start',message:{role:'assistant',content:[]}});send({type:'message_update',usage:{input:2,output:1,cacheRead:0,cacheWrite:0,totalTokens:3,cost:{total:0.125}},assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'after retry'}});send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'after retry'}],provider:'fake',model:'model',usage:{input:2,output:2,cacheRead:0,cacheWrite:0,totalTokens:4,cost:{total:0.5}},stopReason:'stop'}});send({type:'agent_settled'});},30);}",
 				"if(c.type==='abort'){send({id:c.id,type:'response',command:'abort',success:true});send({type:'agent_settled'});}",
 				"}});",
 			].join(""),
@@ -488,6 +510,15 @@ test("RpcTransport waits for agent_settled after agent_end and times out without
 			new AbortController().signal,
 		);
 		assert.equal(result.output, "after retry");
+		assert.deepEqual(result.telemetry?.usage, {
+			input: 5,
+			output: 3,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 8,
+			cost: 0.75,
+			turns: 1,
+		});
 		assert.ok(Date.now() - started >= 20, "agent_end must not settle the turn");
 		await transport.shutdown();
 
@@ -498,7 +529,7 @@ test("RpcTransport waits for agent_settled after agent_end and times out without
 				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');let prompts=0;",
 				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
 				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
-				"if(c.type==='prompt'){prompts++;send({id:c.id,type:'response',command:'prompt',success:true});send({type:'agent_end',messages:[],willRetry:false});}",
+				"if(c.type==='prompt'){prompts++;send({id:c.id,type:'response',command:'prompt',success:true});send({type:'message_start',message:{role:'assistant',content:[]}});send({type:'message_update',usage:{input:9,output:1,cacheRead:0,cacheWrite:0,totalTokens:10,cost:{total:0.5}},assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'PARTIAL_HANG'}});send({type:'agent_end',messages:[],willRetry:false});}",
 				"if(c.type==='abort')send({id:c.id,type:'response',command:'abort',success:true});",
 				"}});",
 			].join(""),
@@ -520,9 +551,72 @@ test("RpcTransport waits for agent_settled after agent_end and times out without
 			new AbortController().signal,
 		);
 		assert.equal(timedOut.exitCode, 124);
+		assert.equal(timedOut.output, "PARTIAL_HANG");
 		assert.match(timedOut.error ?? "", /timed out/);
 		assert.equal(timedOut.telemetry?.failurePhase, "running");
+		assert.deepEqual(timedOut.telemetry?.usage, {
+			input: 9,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 10,
+			cost: 0.5,
+			turns: 0,
+		});
 		await timeoutTransport.shutdown();
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("RPC explicit abort preserves streaming usage after the child settles", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-abort-usage-"));
+	try {
+		const script = path.join(root, "abort-usage.mjs");
+		writeFileSync(
+			script,
+			[
+				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');",
+				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
+				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
+				"if(c.type==='prompt'){send({id:c.id,type:'response',command:'prompt',success:true});send({type:'message_start',message:{role:'assistant',content:[]}});send({type:'message_update',usage:{input:4,output:2,cacheRead:0,cacheWrite:0,totalTokens:6,cost:{total:0.25}},assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'PARTIAL_ABORT'}});}",
+				"if(c.type==='abort'){send({id:c.id,type:'response',command:'abort',success:true});send({type:'agent_settled'});}",
+				"}});",
+			].join(""),
+		);
+		const transport = new RpcTransport({
+			getParentRuntime: () => ({ model: undefined, thinkingLevel: "low" }),
+			defaultTimeoutMs: 1_000,
+			abortGraceMs: 20,
+			createClient: (options) =>
+				new RpcProtocolClient({
+					...options,
+					terminationGraceMs: 10,
+					invocation: { command: process.execPath, args: [script] },
+				}),
+		});
+		const controller = new AbortController();
+		const result = await transport.runTurn(
+			{ ...managedAgent(), cwd: root },
+			"abort",
+			controller.signal,
+			(update) => {
+				if (update.usage?.totalTokens === 6 && update.usage.turns === 0) controller.abort();
+			},
+		);
+		assert.equal(result.exitCode, 130);
+		assert.equal(result.aborted, true);
+		assert.equal(result.output, "PARTIAL_ABORT");
+		assert.deepEqual(result.telemetry?.usage, {
+			input: 4,
+			output: 2,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 6,
+			cost: 0.25,
+			turns: 0,
+		});
+		await transport.shutdown();
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -532,13 +626,15 @@ test("RPC timeout aborts the work turn and requests a bounded summary after sett
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-rpc-timeout-summary-"));
 	try {
 		const script = path.join(root, "timeout-summary.mjs");
+		const marker = path.join(root, "prompts.log");
 		writeFileSync(
 			script,
 			[
+				'import { appendFileSync } from "node:fs";',
 				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');let prompts=0;",
 				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
 				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
-				"if(c.type==='prompt'){prompts++;send({id:c.id,type:'response',command:'prompt',success:true});if(prompts===1){send({type:'tool_execution_start',toolCallId:'read-1',toolName:'read',args:{path:'src/rpc.ts'}});send({type:'tool_execution_end',toolCallId:'read-1',toolName:'read',result:{content:[{type:'text',text:'RPC_TOOL_EVIDENCE'}]},isError:false});send({type:'message_end',message:{role:'toolResult',toolCallId:'read-1',toolName:'read',content:[{type:'text',text:'RPC_TOOL_EVIDENCE'}],isError:false}});send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'PARTIAL_RPC'}],provider:'fake',model:'model',usage:{},stopReason:'toolUse'}});}else{send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'SUMMARY_RPC'}],provider:'fake',model:'model',usage:{},stopReason:'stop'}});send({type:'agent_settled'});}}",
+				`if(c.type==='prompt'){appendFileSync(${JSON.stringify(marker)},'prompt\\n');prompts++;send({id:c.id,type:'response',command:'prompt',success:true});if(prompts===1){send({type:'message_start',message:{role:'assistant',content:[]}});send({type:'message_update',usage:{input:5,output:1,cacheRead:0,cacheWrite:0,totalTokens:6,cost:{total:0.25}},assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'PARTIAL_RPC'}});send({type:'tool_execution_start',toolCallId:'read-1',toolName:'read',args:{path:'src/rpc.ts'}});send({type:'tool_execution_end',toolCallId:'read-1',toolName:'read',result:{content:[{type:'text',text:'RPC_TOOL_EVIDENCE'}]},isError:false});send({type:'message_end',message:{role:'toolResult',toolCallId:'read-1',toolName:'read',content:[{type:'text',text:'RPC_TOOL_EVIDENCE'}],isError:false}});}else{send({type:'message_start',message:{role:'assistant',content:[]}});send({type:'message_update',usage:{input:2,output:1,cacheRead:0,cacheWrite:0,totalTokens:3,cost:{total:0.125}},assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'SUMMARY_RPC'}});send({type:'message_end',message:{role:'assistant',content:[{type:'text',text:'SUMMARY_RPC'}],provider:'fake',model:'model',usage:{input:2,output:2,cacheRead:0,cacheWrite:0,totalTokens:4,cost:{total:0.5}},stopReason:'stop'}});send({type:'agent_settled'});}}`,
 				"if(c.type==='abort'){send({id:c.id,type:'response',command:'abort',success:true});send({type:'agent_settled'});}",
 				"}});",
 			].join(""),
@@ -571,6 +667,16 @@ test("RPC timeout aborts the work turn and requests a bounded summary after sett
 		);
 		assert.equal(result.termination?.checkpoint.completedTools.length, 1);
 		assert.equal(result.telemetry?.phase, "failed");
+		assert.deepEqual(result.telemetry?.usage, {
+			input: 7,
+			output: 3,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 10,
+			cost: 0.75,
+			turns: 1,
+		});
+		assert.equal(readFileSync(marker, "utf8"), "prompt\nprompt\n");
 		await transport.shutdown();
 	} finally {
 		rmSync(root, { recursive: true, force: true });
@@ -700,7 +806,7 @@ test("RPC prompt acceptance timeout discards the child without replay", async ()
 				"let buffer='';const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');",
 				"process.stdin.on('data',chunk=>{buffer+=chunk;let i;while((i=buffer.indexOf('\\n'))>=0){const line=buffer.slice(0,i);buffer=buffer.slice(i+1);if(!line)continue;const c=JSON.parse(line);",
 				"if(c.type==='get_state')send({id:c.id,type:'response',command:'get_state',success:true,data:{model:{provider:'fake',id:'model'},thinkingLevel:'low',sessionId:'s'}});",
-				`if(c.type==='prompt'){appendFileSync(${JSON.stringify(crashMarker)},'prompt\\n');send({id:c.id,type:'response',command:'prompt',success:true});setImmediate(()=>process.exit(7));}`,
+				`if(c.type==='prompt'){appendFileSync(${JSON.stringify(crashMarker)},'prompt\\n');send({id:c.id,type:'response',command:'prompt',success:true});send({type:'message_start',message:{role:'assistant',content:[]}});send({type:'message_update',usage:{input:8,output:1,cacheRead:0,cacheWrite:0,totalTokens:9,cost:{total:0.5}},assistantMessageEvent:{type:'text_delta',contentIndex:0,delta:'PARTIAL_CRASH'}});setImmediate(()=>process.exit(7));}`,
 				"}});",
 			].join(""),
 		);
@@ -721,7 +827,17 @@ test("RPC prompt acceptance timeout discards the child without replay", async ()
 			new AbortController().signal,
 		);
 		assert.equal(crashed.exitCode, 1);
+		assert.equal(crashed.output, "PARTIAL_CRASH");
 		assert.match(crashed.error ?? "", /exited/);
+		assert.deepEqual(crashed.telemetry?.usage, {
+			input: 8,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 9,
+			cost: 0.5,
+			turns: 0,
+		});
 		assert.equal(readFileSync(crashMarker, "utf8"), "prompt\n");
 		await crashTransport.shutdown();
 	} finally {

--- a/packages/pi-subagents/test/rpc-turn-capture.test.ts
+++ b/packages/pi-subagents/test/rpc-turn-capture.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	captureRpcEvent,
+	commitRpcInFlightUsage,
+	createRpcTurnCapture,
+	snapshotRpcUsage,
+} from "../src/rpc-turn-capture.js";
+
+function updateUsage(usage: unknown, delta = ""): Record<string, unknown> {
+	return {
+		type: "message_update",
+		usage,
+		assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta },
+	};
+}
+
+function assistantStart(): Record<string, unknown> {
+	return { type: "message_start", message: { role: "assistant", content: [] } };
+}
+
+function assistantEnd(usage?: unknown): Record<string, unknown> {
+	return {
+		type: "message_end",
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: "done" }],
+			provider: "fake",
+			model: "model",
+			...(usage === undefined ? {} : { usage }),
+			stopReason: "stop",
+		},
+	};
+}
+
+const firstUsage = {
+	input: 10,
+	output: 1,
+	cacheRead: 2,
+	cacheWrite: 3,
+	totalTokens: 16,
+	cost: { total: 0.1 },
+};
+
+const secondUsage = {
+	input: 10,
+	output: 4,
+	cacheRead: 2,
+	cacheWrite: 3,
+	totalTokens: 19,
+	cost: { total: 0.2 },
+};
+
+test("RPC capture replaces cumulative in-flight usage and deduplicates identical updates", () => {
+	const capture = createRpcTurnCapture();
+	assert.equal(captureRpcEvent(updateUsage(firstUsage, "a"), capture), true);
+	assert.deepEqual(snapshotRpcUsage(capture), { ...firstUsage, cost: 0.1, turns: 0 });
+	assert.equal(captureRpcEvent(updateUsage(firstUsage, "b"), capture), false);
+	assert.equal(captureRpcEvent(updateUsage(secondUsage, "c"), capture), true);
+	assert.deepEqual(snapshotRpcUsage(capture), { ...secondUsage, cost: 0.2, turns: 0 });
+	assert.equal(capture.partial, "abc");
+});
+
+test("RPC capture reconciles one authoritative final usage without double counting", () => {
+	const capture = createRpcTurnCapture();
+	captureRpcEvent(updateUsage(firstUsage), capture);
+	assert.equal(
+		captureRpcEvent(
+			assistantEnd({
+				input: 12,
+				output: 5,
+				cacheRead: 2,
+				cacheWrite: 3,
+				totalTokens: 22,
+				cost: { total: 0.3 },
+			}),
+			capture,
+		),
+		true,
+	);
+	assert.deepEqual(snapshotRpcUsage(capture), {
+		input: 12,
+		output: 5,
+		cacheRead: 2,
+		cacheWrite: 3,
+		totalTokens: 22,
+		cost: 0.3,
+		turns: 1,
+	});
+});
+
+test("RPC capture falls back to streaming usage when final usage is absent or invalid", () => {
+	for (const usage of [undefined, {}, { input: -1, output: Number.POSITIVE_INFINITY }]) {
+		const capture = createRpcTurnCapture();
+		captureRpcEvent(updateUsage(firstUsage), capture);
+		captureRpcEvent(assistantEnd(usage), capture);
+		assert.deepEqual(snapshotRpcUsage(capture), {
+			...firstUsage,
+			cost: 0.1,
+			turns: 1,
+		});
+	}
+});
+
+test("RPC capture treats valid zero final fields as authoritative over streaming usage", () => {
+	const capture = createRpcTurnCapture();
+	captureRpcEvent(updateUsage(firstUsage), capture);
+	captureRpcEvent(assistantEnd({ input: 0, output: "bad", cost: { total: 0 } }), capture);
+	assert.deepEqual(snapshotRpcUsage(capture), {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: 0,
+		turns: 1,
+	});
+});
+
+test("RPC capture ignores malformed fields and derives totals only when no valid total exists", () => {
+	const capture = createRpcTurnCapture();
+	assert.equal(
+		captureRpcEvent(
+			updateUsage({
+				input: 4,
+				output: "5",
+				cacheRead: -1,
+				cacheWrite: Number.MAX_SAFE_INTEGER + 1,
+				totalTokens: Number.NaN,
+				cost: { total: Number.NEGATIVE_INFINITY },
+			}),
+			capture,
+		),
+		true,
+	);
+	assert.deepEqual(snapshotRpcUsage(capture), {
+		input: 4,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 4,
+		cost: 0,
+		turns: 0,
+	});
+	assert.equal(
+		captureRpcEvent(
+			updateUsage({ input: -1, output: Number.POSITIVE_INFINITY, cost: { total: "bad" } }),
+			capture,
+		),
+		false,
+	);
+	assert.equal(captureRpcEvent(updateUsage({ input: 4, totalTokens: 0 }), capture), true);
+	assert.equal(snapshotRpcUsage(capture).totalTokens, 0);
+});
+
+test("RPC capture aggregates multiple finalized assistant turns", () => {
+	const capture = createRpcTurnCapture();
+	captureRpcEvent(assistantStart(), capture);
+	captureRpcEvent(
+		updateUsage({ input: 3, output: 1, totalTokens: 4, cost: { total: 0.125 } }),
+		capture,
+	);
+	captureRpcEvent(
+		assistantEnd({ input: 3, output: 2, totalTokens: 5, cost: { total: 0.25 } }),
+		capture,
+	);
+	captureRpcEvent(assistantStart(), capture);
+	captureRpcEvent(
+		updateUsage({ input: 7, output: 1, totalTokens: 8, cost: { total: 0.375 } }),
+		capture,
+	);
+	captureRpcEvent(
+		assistantEnd({ input: 7, output: 3, totalTokens: 10, cost: { total: 0.5 } }),
+		capture,
+	);
+	assert.deepEqual(snapshotRpcUsage(capture), {
+		input: 10,
+		output: 5,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 15,
+		cost: 0.75,
+		turns: 2,
+	});
+});
+
+test("RPC capture rolls interrupted usage into the next assistant attempt without adding a turn", () => {
+	const capture = createRpcTurnCapture();
+	captureRpcEvent(
+		updateUsage({ input: 5, output: 2, totalTokens: 7, cost: { total: 0.25 } }),
+		capture,
+	);
+	assert.equal(captureRpcEvent(assistantStart(), capture), false);
+	assert.deepEqual(snapshotRpcUsage(capture), {
+		input: 5,
+		output: 2,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 7,
+		cost: 0.25,
+		turns: 0,
+	});
+	captureRpcEvent(
+		updateUsage({ input: 3, output: 1, totalTokens: 4, cost: { total: 0.375 } }),
+		capture,
+	);
+	captureRpcEvent(
+		assistantEnd({ input: 3, output: 2, totalTokens: 5, cost: { total: 0.5 } }),
+		capture,
+	);
+	assert.deepEqual(snapshotRpcUsage(capture), {
+		input: 8,
+		output: 4,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 12,
+		cost: 0.75,
+		turns: 1,
+	});
+});
+
+test("RPC capture explicitly commits in-flight usage without mutating finalized-turn count", () => {
+	const capture = createRpcTurnCapture();
+	captureRpcEvent(updateUsage(firstUsage), capture);
+	assert.equal(commitRpcInFlightUsage(capture), true);
+	assert.equal(commitRpcInFlightUsage(capture), false);
+	assert.deepEqual(snapshotRpcUsage(capture), { ...firstUsage, cost: 0.1, turns: 0 });
+});
+
+test("RPC capture does not count tool-result messages as assistant turns", () => {
+	const capture = createRpcTurnCapture();
+	captureRpcEvent(
+		{
+			type: "message_end",
+			message: { role: "toolResult", content: [{ type: "text", text: "result" }] },
+		},
+		capture,
+	);
+	assert.deepEqual(snapshotRpcUsage(capture), {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: 0,
+		turns: 0,
+	});
+});


### PR DESCRIPTION
## Summary

- reconcile cumulative RPC `message_update.usage` snapshots with authoritative final usage without double counting
- preserve validated partial usage across retries, aborts, process failures, and timeout-summary finalization
- publish changed bounded usage through existing `pi-subagents:v1` telemetry and document the unchanged privacy and turn-counting contract
- add a patch Changeset and deterministic capture/transport regressions

## Verification

- `npx vitest run packages/pi-subagents/test/rpc-turn-capture.test.ts packages/pi-subagents/test/rpc-transport.test.ts packages/pi-subagents/test/runner-budgets-and-output.test.ts packages/pi-subagents/test/build-runtime.test.ts` — 35 tests passed
- `npm --workspace @narumitw/pi-subagents run check` — passed
- `npm run check` — passed build, Biome, boundaries, and workspace typechecks
- `npm test` — 3,620 tests passed in 382 files
- `just changeset-status` — reports the intended `@narumitw/pi-subagents` patch; also prints pre-existing unrelated pi-tui-kit range notices
- `just pack subagents` — dry-run contents inspected; manifest, README, license, generated `dist`, and intended `src` included
- `just benchmark-subagents 1` — deterministic fake retained-RPC turns and isolated real Pi readiness/commands passed without a provider request
- final diff audited against `docs/extension-conventions.md` and `packages/pi-subagents/AGENTS.md`

## Risks and unverified paths

- Streaming usage can increase in-memory progress callback frequency only when the validated combined snapshot changes; no timers or persistence writes were added.
- `rpc-transport.ts` remains above 1,000 lines because this change keeps only narrow composition wiring there and owns accounting in `rpc-turn-capture.ts`.
- No live-provider request was attempted under repository policy.
- No protocol, setting, budget, dependency, entrypoint, or transport-selection behavior changed.
