### PR TITLE
docs: standardize package README sections

### DIFF
--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -263,6 +263,8 @@ restore the latest remaining activity rather than letting one completion clear i
 
 ### Documentation and verification
 
+[`docs/readme-conventions.md`](readme-conventions.md) owns the shared structure, labels, applicability rules, and verification checklist for active package READMEs.
+
 Package READMEs **SHOULD** remain practical and scannable: capabilities, installation, usage,
 commands/tools/settings, operational behavior, package layout, keywords, and license. Apply these
 shared presentation conventions:

--- a/docs/readme-conventions.md
+++ b/docs/readme-conventions.md
@@ -1,0 +1,83 @@
+# Package README conventions
+
+This guide defines the shared structure for active package READMEs under `packages/`.
+It keeps package documentation predictable without forcing irrelevant sections onto every extension or reusable library.
+
+## Required foundation
+
+Every active package README must present these elements in this order:
+
+1. An emoji title with the package name and a concise purpose.
+2. The package's npm and license badges, plus the Pi extension badge for extension packages.
+3. A short summary that states what the package does.
+4. `## ✨ Features`.
+5. `## 📦 Install`.
+6. `## 🚀 Quick start`.
+7. Applicable interface and operational sections.
+8. `## 🗂️ Package layout`.
+9. `## 🔎 Keywords`.
+10. `## 📄 License`.
+
+Experimental packages must show a user-facing warning near the introduction.
+Reusable libraries omit the Pi extension badge and may make Quick start an import example rather than a Pi command.
+
+## Standard section labels
+
+Use these exact labels when the subject applies:
+
+- `## ✨ Features` for a concise capability overview.
+- `## 📦 Install` for persistent installation, temporary execution, and local-checkout instructions that apply to the package.
+- `## 🚀 Quick start` for the shortest successful first use.
+- `## 💬 Commands` for user-facing slash commands.
+- `## 🛠️ Tools` for tools registered for the model.
+- `## ⚙️ Settings` for configuration sources, defaults, precedence, persistence, and interactive settings.
+- `## 🔒 Security and privacy` for permissions, credentials, external data, or other material trust boundaries.
+- `## 🚧 Limitations` for known unsupported behavior and important constraints.
+- `## 🗂️ Package layout` for the package's maintained source and publication structure.
+- `## 🔎 Keywords` for a short searchable summary.
+- `## 📄 License` for the license name and a link to the package license.
+
+Use one standard heading instead of variants such as `Usage`, `Command`, `Configuration`, `Pi tools`, `Known limits`, `📁 Package layout`, or `🏷️ Keywords`.
+Keep a more specific heading when it describes a separate package concept rather than the standard subject.
+For example, `Model and thinking level` may remain separate after the general Quick start section.
+
+## Applicability
+
+Commands, Tools, Settings, Security and privacy, and Limitations are conditional sections.
+Do not add an empty section or claim an interface that the package does not provide.
+A passive extension may omit Commands and Tools.
+A package with no user-owned settings may omit Settings.
+Split safety, privacy, recovery, and limitations into separate headings when users need that distinction.
+
+Package-specific sections belong between the common interface sections and Package layout.
+Order them from first-use information to deeper behavior, lifecycle, recovery, limitations, and development material.
+Do not remove supported behavior, compatibility guidance, or safety details merely to shorten a README.
+
+## Content rules
+
+Write user-facing prose in English.
+Put each prose sentence on its own source line.
+Keep the introduction and Features section concise enough to scan before installation.
+Document only commands, tools, settings, modes, and guarantees implemented by the package.
+Treat model IDs, paths, session text, and pasted text shown in examples as untrusted terminal input where relevant.
+Use stable absolute GitHub and npm links when referring to another package in this monorepo.
+Describe borrowed syntax as inspired by another project unless compatibility is guaranteed.
+
+Installation instructions must state that extensions run with Pi's permissions when that warning is material to the package's install flow.
+Build-backed packages must explain that an unbuilt local checkout needs its build before package-directory loading.
+Document security, privacy, precedence, persistence, failure, cancellation, recovery, or lifecycle behavior when users need it for safe operation.
+
+## Verification
+
+For every README change:
+
+1. Review the documented interfaces against the package implementation and tests.
+2. Run a fenced-code-aware heading audit over `packages/*/README.md`.
+3. Confirm every active package has Features, Install, Quick start, Package layout, Keywords, and License.
+4. Confirm standard labels and emojis are used where applicable.
+5. Run `npm run check`.
+6. Run `npm test`.
+
+Run a package dry-run pack when package metadata or published contents change.
+Run the package build and local Pi loading smoke when extension runtime loading changes.
+Documentation-only section organization does not require either smoke and does not require a changeset.

--- a/packages/pi-accounts/README.md
+++ b/packages/pi-accounts/README.md
@@ -52,7 +52,12 @@ Try this package locally from the repository root:
 pi -e ./packages/pi-accounts
 ```
 
-## 🚀 Usage
+## 🚀 Quick start
+
+Run `/accounts` in TUI or RPC mode, then choose a provider action from the account manager.
+Use the manager to log in, switch accounts, restore Pi's default login, or remove a saved account.
+
+## 💬 Commands
 
 Open the interactive account manager:
 

--- a/packages/pi-analytics/README.md
+++ b/packages/pi-analytics/README.md
@@ -91,7 +91,7 @@ A tool call starts at Pi's `tool_execution_start` event and finishes at `tool_ex
 
 Pi exposes HTTP responses and final assistant failures, not every provider-SDK transport retry. The dashboard therefore labels these values as **observed provider errors**. It reports HTTP 429 and 5xx counts; conservative DNS, timeout, connection, TLS, network, and provider categories; recovered errors; and terminal failures. Error messages are classified in memory and discarded.
 
-## 💬 Command
+## 💬 Commands
 
 ```text
 /analytics

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -44,7 +44,12 @@ pi -e ./packages/pi-btw
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
-## 🚀 Usage
+## 🚀 Quick start
+
+Run `/btw <question>` to start a side thread immediately, or run `/btw` to choose context and settings first.
+Side-thread questions and answers remain separate from the main conversation unless you explicitly bring selected context back.
+
+## 💬 Commands
 
 Open the pi-btw menu or provide the first question immediately:
 
@@ -131,7 +136,7 @@ conversation. Non-empty threads remain only in memory for Resume within the curr
 `/new`, Pi `/resume`, `/reload`, extension replacement, and process restart discard every retained
 thread. Unsent drafts, steering queues, interrupted answers, and model credentials are never retained.
 
-## ⚙️ Model and thinking level
+## ⚙️ Settings
 
 By default, `/btw` uses the current session model. To use an independent model for side
 questions, create:

--- a/packages/pi-caffeinate/README.md
+++ b/packages/pi-caffeinate/README.md
@@ -38,6 +38,12 @@ Try this package locally from the repository root:
 pi -e ./packages/pi-caffeinate
 ```
 
+## 🚀 Quick start
+
+Load the extension and use Pi normally.
+During an agent run, pi-caffeinate uses the saved keep-awake mode and defaults to keeping both the system and display awake.
+Run `/caffeinate` to open the controls or `/caffeinate status` to inspect the current state.
+
 ## 🖥️ Supported platforms
 
 The default mode is `display` on every supported OS. That means pi-caffeinate prevents system sleep, suspend, or hibernate and keeps the screen/display awake.
@@ -66,7 +72,7 @@ closing its session-bus connection.
 
 If no supported inhibitor is available, the extension stays loaded and reports that caffeinate is unavailable.
 
-## 🚀 Commands
+## 💬 Commands
 
 ```text
 /caffeinate
@@ -105,7 +111,7 @@ Opens the standard keep-awake mode selector in TUI or RPC mode. Escape closes th
 
 Releases any active inhibitor until Pi starts another agent run.
 
-## ⚙️ Configuration
+## ⚙️ Settings
 
 ### Persisted settings
 

--- a/packages/pi-chat/README.md
+++ b/packages/pi-chat/README.md
@@ -265,7 +265,7 @@ UI resource. A new TUI session then restores the remembered room. Explicit **Lea
 atomically removes resume state before disconnecting; if that save fails, the room stays connected
 and remembered with an actionable error.
 
-## 🧪 Experimental limitations
+## 🚧 Limitations
 
 The current experimental release intentionally omits:
 

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -54,7 +54,7 @@ pi -e ./packages/pi-chrome-devtools
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
-## 🚀 Browser startup
+## 🚀 Quick start
 
 Without unpacked extensions, the extension first tries `browser.endpoint`, defaulting to
 `http://127.0.0.1:9222`. If that local endpoint is unavailable and `browser.autoLaunch` is `true`, it
@@ -157,7 +157,7 @@ google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/pi-chrome-devtoo
 On session shutdown, the extension terminates only browser processes it started and best-effort
 removes their temporary profiles. It never closes user-started browsers or remote endpoints.
 
-## 🛠️ Pi tools
+## 🛠️ Tools
 
 - `chrome_devtools_load` — find and load browser capabilities relevant to a task.
 - `chrome_devtools_list_pages` — list inspectable Chrome tabs/pages.
@@ -211,7 +211,7 @@ replaced. The tool result includes the resolved path, byte count, and an inline 
 the active model/provider can consume images. If the model cannot inspect the inline image, ask it
 to read the saved path, for example `read({ path: "artifacts/homepage.png" })`.
 
-## 💬 Command
+## 💬 Commands
 
 ```text
 /chrome-devtools

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -59,7 +59,7 @@ and the local workspace at the same time.
 
 When the active model is unsupported, compaction remains entirely Pi-native.
 
-## 💬 Command
+## 💬 Commands
 
 ```text
 /codex-compact
@@ -184,7 +184,7 @@ An individually oversized media item is dropped rather than making the session e
 oldest fitting text item may be partially truncated to preserve newer context. These hard byte
 ceilings are intentionally not configurable.
 
-## 🚧 Known limitations
+## 🚧 Limitations
 
 - The wire contract is undocumented and can change independently of Pi or this package. Keep
   backups of important sessions.

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -115,7 +115,7 @@ Unknown and trailing arguments are rejected. RPC receives an observable warning.
 - Each snippet stores the text visible at selection time. It does not silently reread changed content when the prompt is submitted.
 - A snippet is limited to 500 lines and 50 KB. At most eight selected snippets and 100 KB of aggregate context text are accepted.
 
-## 🧪 Experimental limitations
+## 🚧 Limitations
 
 - Keyboard line selection only; mouse drag selection is not implemented.
 - Up to eight selected snippets; exact review and repeated removal are supported, but there are not yet bulk clear, undo, or reorder actions.

--- a/packages/pi-firecrawl/README.md
+++ b/packages/pi-firecrawl/README.md
@@ -43,7 +43,12 @@ FIRECRAWL_API_KEY=fc-... pi -e ./packages/pi-firecrawl
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
-## ⚙️ Configuration
+## 🚀 Quick start
+
+Set `FIRECRAWL_API_KEY`, start Pi with the extension, and ask the agent to load the Firecrawl capability needed for the task.
+Use `/firecrawl` to review configuration and control which capability tools may be loaded.
+
+## ⚙️ Settings
 
 Set a Firecrawl API key before running Pi:
 
@@ -59,7 +64,7 @@ export FIRECRAWL_API_URL=https://api.firecrawl.dev/v1
 
 `FIRECRAWL_BASE_URL` is also accepted for compatibility. The extension never logs or displays the API key.
 
-## 🛠️ Pi tools
+## 🛠️ Tools
 
 - `firecrawl_load` — find and load Firecrawl capabilities relevant to a web research task.
 - `firecrawl_scrape` — scrape a single URL and return requested formats such as markdown, HTML, links, screenshots, or JSON.
@@ -103,7 +108,7 @@ removed during session shutdown or reload. Tool-result metadata contains only si
 information rather than a duplicate of the raw Firecrawl response. Oversized Firecrawl error bodies
 are bounded in the same way.
 
-## 💬 Command
+## 💬 Commands
 
 ```text
 /firecrawl
@@ -170,7 +175,7 @@ The first subsequent settings save writes the canonical file. If both files exis
 `pi-firecrawl.json` wins and the legacy file is ignored. The legacy filename is
 deprecated and will be removed in a future major release.
 
-## 🚀 Examples
+## 🧪 Examples
 
 Scrape a page as markdown:
 

--- a/packages/pi-fleet/README.md
+++ b/packages/pi-fleet/README.md
@@ -79,7 +79,7 @@ After the required consent and optional launch confirmation, Pi Fleet:
 
 If the terminal creates a split but the child does not become ready, Pi Fleet leaves the visible split open and reports a partial launch instead of closing a potentially useful pane.
 
-## 🧰 Tools
+## 🛠️ Tools
 
 ### `session_spawn`
 
@@ -187,7 +187,7 @@ Right and down use Zellij's native split directions.
 Left and up create the corresponding native pane and then use pane-targeted `move-pane` placement.
 A placement failure is a partial launch because the child pane may already be running and remains visible.
 
-## ⚙️ Settings and lifecycle
+## ⚙️ Settings
 
 Open `/fleet` and choose **Settings**.
 Pi Fleet stores user settings in `<getAgentDir()>/pi-fleet.json`, normally `~/.pi/agent/pi-fleet.json`:
@@ -250,7 +250,7 @@ Enabling them permits trusted invite holders to start paid model turns that may 
 - A same-user process or another privileged Pi extension is outside the security boundary and may inspect process arguments, private runtime files, memory, or environment.
 - Pi Fleet provides explicit group separation, not a sandbox against the operating-system user.
 
-## 🧪 Experimental limitations
+## 🚧 Limitations
 
 - Local same-user communication only.
 - POSIX Unix-socket transport only.

--- a/packages/pi-github-pr/README.md
+++ b/packages/pi-github-pr/README.md
@@ -61,6 +61,11 @@ gh auth login --hostname github.example.com:8443
 
 The extension shells out to `gh`; GitHub Enterprise hosts and credential storage are delegated to `gh`. It uses the PR URL host (including any port) for follow-up API calls, so no manual `GH_HOST` is required.
 
+## 🚀 Quick start
+
+Start Pi inside a Git worktree after authenticating `gh`.
+The extension automatically shows the current branch's pull request status and does not register a command or model tool.
+
 ## 💬 Behavior
 
 The extension runs passively:
@@ -74,7 +79,7 @@ The extension runs passively:
 - If the directory has no GitHub PR, the statusline entry stays empty.
 - If `gh` is missing or unauthenticated, the statusline shows a short hint such as `PR gh missing` or `PR gh auth`.
 
-## Known limits
+## 🚧 Limitations
 
 - Requires `gh`; there is no direct GitHub API, `GITHUB_TOKEN` fallback, or manual `GH_HOST` requirement.
 - Only the current branch PR is shown; there is no command or tool for arbitrary PR lookup.
@@ -82,7 +87,7 @@ The extension runs passively:
 - It does not read PR comment bodies, review bodies, inline diff comments, or unresolved review-thread text.
 - While a session is open, refresh runs every 60 seconds in addition to session start, branch changes, and agent turns; each refresh invokes `gh pr view` and one GraphQL count query.
 
-## 📁 Package layout
+## 🗂️ Package layout
 
 ```text
 packages/pi-github-pr/
@@ -95,7 +100,7 @@ packages/pi-github-pr/
 └── tsconfig.json
 ```
 
-## 🏷️ Keywords
+## 🔎 Keywords
 
 `pi-package`, `pi-extension`, `github`, `pull-request`, `statusline`, `gh`
 

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -58,7 +58,12 @@ pi -e ./packages/pi-goal
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
-## ⚙️ Configuration
+## 🚀 Quick start
+
+Run `/goal <objective>` to start working toward an objective, or run `/goal` to open the state-aware manager.
+Use the manager to review status, pause, resume, edit, or clear the current goal.
+
+## ⚙️ Settings
 
 Settings are optional. When `~/.pi/agent/pi-goal.json` is absent, pi-goal uses these
 built-in defaults without creating the file:
@@ -109,7 +114,7 @@ restores only the exact tools that pi-goal previously hid, while switching to
 
 Tool visibility is a baseline, not ownership of Pi's global active-tool list. Plan mode or another restrictive policy may temporarily hide the tools. pi-goal does not fight that policy on restore or on every turn: activation is rejected if the required terminal tools cannot be made available, and an already-active goal is paused without automatic continuation if they disappear. A restrictive allowlist created before `goal_wait` existed can still run ordinary Goals with `goal_complete` and `goal_blocked`, but the model cannot enter external waiting until that allowlist also includes `goal_wait`. The pause aborts a Goal-owned kickoff, resume, active-edit, or automatic-continuation prompt, but it does not cancel or stale-block an unrelated user or extension turn, including startup follow-ups after a restrictive restore.
 
-## 🚀 Commands
+## 💬 Commands
 
 ```text
 /goal
@@ -152,6 +157,12 @@ Former queue command words such as `add`, `prioritize`, `drop-last`, `skip`, `pu
 If a session still has legacy queue settings or persisted queue state, those words show a migration warning instead of replacing the active Goal.
 
 Goal objectives are limited to 4,000 characters. Put longer instructions in a file and reference the file path from `/goal`.
+
+## 🛠️ Tools
+
+- `goal_complete` records completion only for the exact active goal id and requires an evidence-based summary.
+- `goal_blocked` records a true repeated impasse with the exact goal id, reason, evidence, and repeated-turn count.
+- `goal_wait` pauses automatic continuation after the agent arranges an external wake source, with an optional bounded resume deadline.
 
 ## 🔁 Session and reload behavior
 

--- a/packages/pi-langfuse/README.md
+++ b/packages/pi-langfuse/README.md
@@ -40,7 +40,12 @@ pi -e ./packages/pi-langfuse
 
 The Langfuse v4 SDK requires Node.js 20 or newer.
 
-## ⚙️ Configuration
+## 🚀 Quick start
+
+Run `/langfuse`, choose the setup action, enter the Langfuse credentials, and restart Pi.
+Subsequent agent runs are traced according to the saved content-capture and metadata settings.
+
+## ⚙️ Settings
 
 Run the interactive manager, then choose **Set up Langfuse for this Pi agent directory** or **Update Langfuse for this Pi agent directory**:
 
@@ -139,7 +144,7 @@ At run start, the extension performs bounded, non-shell Git lookups in `ctx.cwd`
 
 Completed observations are exported in batches while Pi remains live. Neither `agent_end` nor `agent_settled` waits for Langfuse network I/O. To wait for completed exports, run `/langfuse` and choose **Flush completed traces for this session**; quit shutdown also drains the provider.
 
-## 💬 Command
+## 💬 Commands
 
 ```text
 /langfuse

--- a/packages/pi-lsp/README.md
+++ b/packages/pi-lsp/README.md
@@ -76,7 +76,12 @@ pi -e ./packages/pi-lsp
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
-## ⚙️ Configuration
+## 🚀 Quick start
+
+Install at least one supported language server on `PATH`, then run `/lsp` to inspect command availability.
+The agent can call `lsp_diagnostics` for targeted diagnostics and `lsp_fix` for supported source actions.
+
+## ⚙️ Settings
 
 If no config is provided, pi-lsp ships a broad catalog of direct-command defaults. Servers are started only when matching files are requested. pi-lsp does not download language servers, so install the commands you need and make them available on `PATH`. During no-config diagnostics, unavailable default commands are filtered before workspace discovery. If none can run, diagnostics completes successfully and reports the skipped servers. Explicitly selected or custom-configured missing commands still report an error.
 
@@ -241,7 +246,7 @@ For example, run the configured Ruff server through the project's uv environment
 
 Use project formatters or shell commands for formatting workflows.
 
-## 🛠️ Pi tools
+## 🛠️ Tools
 
 ### `lsp_diagnostics`
 
@@ -266,7 +271,7 @@ Parameters:
 - `write?`: write fixed text back to the file. Defaults to false.
 - `server?`: optional configured server name.
 
-## 💬 Command
+## 💬 Commands
 
 ```text
 /lsp

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -45,7 +45,12 @@ pi -e ./packages/pi-plan-mode
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
-## 🚀 Usage
+## 🚀 Quick start
+
+Run `/plan` to open the state-aware menu, then start Plan mode and ask the agent to inspect and design the change.
+Run `/plan <prompt>` when the first planning request is already known.
+
+## 💬 Commands
 
 ```text
 /plan
@@ -164,6 +169,11 @@ You can also exit directly. Before implementation, direct exit discards the late
 ```text
 /plan exit
 ```
+
+## 🛠️ Tools
+
+- `plan_mode_question` asks up to three structured questions for material preferences or tradeoffs.
+- `plan_mode_complete` records the complete approved Markdown plan and terminates the planning turn when called alone.
 
 ## ⚙️ Settings
 

--- a/packages/pi-recall/README.md
+++ b/packages/pi-recall/README.md
@@ -133,7 +133,7 @@ Deleting a message removes it from canonical `pi-recall.jsonl`. It is not secure
 
 Terminal controls are removed from labels, previews, metadata, and errors before display. Full review content is passed through Pi TUI Kit's sanitized review renderer. The raw stored text is not modified merely for display.
 
-## 🚧 Experimental limitations
+## 🚧 Limitations
 
 - No tags, saved-query persistence, message editing, reordering, batch deletion, import/export, automatic expiry, or automatic context injection.
 - No cross-session transcript browser: only previously saved records can be recalled across sessions.

--- a/packages/pi-stamp/README.md
+++ b/packages/pi-stamp/README.md
@@ -70,6 +70,11 @@ Close
 Settings save immediately. Mounted compatible stamps reformat on the next render, and future stamps
 use the same effective values.
 
+## 💬 Commands
+
+Run `/stamp` in TUI or RPC mode to open the presentation, status, and help menu.
+The command accepts no arguments and rejects print and JSON modes without changing settings.
+
 ## ⚙️ Settings
 
 The `/stamp` Settings screen provides these controls:

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -45,7 +45,12 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
 
 Do not enable this together with `@narumitw/pi-statusline`: both own Pi's footer, and Pi does not arbitrate that conflict.
 
-## ⚙️ Configuration
+## 🚀 Quick start
+
+Start Pi with the extension to use the built-in footer without creating a settings file.
+Run `/starship` to inspect the footer, choose a preset, or customize the configuration.
+
+## ⚙️ Settings
 
 The only configuration source is:
 

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -77,7 +77,20 @@ Keep **All delegation methods** when an explicit blocking workflow or synchronou
 
 Async-first delegation still requires useful parallel main-agent work, clear worker ownership, and a supported completion path.
 
-## 🛠️ Pi tool
+## 💬 Commands
+
+- `/subagents` opens the current-session manager in TUI mode and reports bounded status in RPC mode.
+- `/subagents settings` configures target locations, trusted resources, and async completion delivery.
+- `/subagents status` shows current-session and configured values with their sources.
+- `/subagents help` summarizes the command surface and isolation limits.
+
+## ⚙️ Settings
+
+Use `/subagents settings` for target location, trust, consultation resource, and detached-completion preferences.
+Use `/subagents` → **Advanced settings** for delegation workflow, agent tool permissions, and runtime limits.
+Settings are stored in `~/.pi/agent/pi-subagents.json`; the detailed sections below document precedence, reload requirements, and safety behavior.
+
+## 🛠️ Tools
 
 `pi-subagents` registers seven tools by default. Run `/subagents`, choose **Change delegation**, review the concrete tool changes, then select **Save and reload** to apply one of these workflows:
 

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -11,6 +11,14 @@ standard rendering, navigation, mode adaptation, cancellation, and lifecycle beh
 provides standalone task, confirmation, and live-choice interactions plus lifecycle ownership for
 specialized custom components.
 
+## ✨ Features
+
+- Provides typed declarative action, detail, settings, choice, review, and document screens.
+- Adapts shared interaction flows across Pi TUI and RPC modes.
+- Owns standard navigation, cancellation, disposal, and width-safe rendering behavior.
+- Exposes focused helpers for tasks, confirmations, live choices, terminal text, interaction hints, and testing.
+- Publishes built ESM and TypeScript declarations for independently installable extensions.
+
 ## 📦 Install
 
 Add the library as a runtime dependency of the extension package:
@@ -64,7 +72,7 @@ node scripts/benchmark-tui-kit-runtime.mjs --runs 5
 The benchmark reports medians, median absolute deviations, resolved package URLs, and graph-presence
 flags so a fast import cannot hide the same dependency cost in the first interaction.
 
-## 🚀 Example
+## 🚀 Quick start
 
 ```ts
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
@@ -770,6 +778,10 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `src/custom-interaction.ts` — lifecycle ownership for specialized public custom components
 - `dist/` — generated ESM and declarations included in the npm package
 - `test/` — contract, renderer, navigation, lifecycle, and public testing-entrypoint coverage
+
+## 🔎 Keywords
+
+Pi library, Pi extension development, terminal UI, declarative menus, lifecycle-safe interactions, TypeScript.
 
 ## 📄 License
 

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -43,7 +43,12 @@ pi -e ./packages/pi-usage
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
-## 🚀 Usage
+## 🚀 Quick start
+
+Run `/usage` in TUI or RPC mode to inspect the current provider, refresh usage, or choose another configured provider.
+Use `/fast` separately to toggle Fast mode for a supported current Codex model.
+
+## 💬 Commands
 
 Run:
 
@@ -77,6 +82,8 @@ replacement or shutdown still aborts owned work. A transport failure offers **Tr
 same redemption request ID so the backend can treat an uncertain retry idempotently. Successful,
 already-completed, not-needed, and no-credit outcomes are reported separately, then usage and the
 statusline are refreshed for the still-current account.
+
+## ⚙️ Settings
 
 ### Codex Fast mode
 

--- a/packages/pi-worktree/README.md
+++ b/packages/pi-worktree/README.md
@@ -41,7 +41,12 @@ Try this package locally from the repository root:
 pi -e ./packages/pi-worktree
 ```
 
-## 💬 Usage
+## 🚀 Quick start
+
+Run `/worktree` in TUI or RPC mode and choose the worktree action you need.
+Every mutation shows package-owned safety checks and an exact confirmation before Git changes the worktree state.
+
+## 💬 Commands
 
 Run the command without arguments:
 
@@ -94,7 +99,7 @@ Leave the path input blank to accept the suggestion. A custom absolute path is u
 
 The MVP does not expose `--force`, `-B`, `--detach`, `--orphan`, or lock options.
 
-## ⚙️ Worktree root settings
+## ⚙️ Settings
 
 The machine-local user settings file is:
 
@@ -146,7 +151,7 @@ A successfully created Git worktree is never rolled back merely because Pi sessi
 
 Use Git directly when you intentionally need force removal, branch deletion, custom prune expiry, detach/orphan creation, move, repair, lock, unlock, or remote refresh behavior.
 
-## Requirements and limits
+## 🚧 Limitations
 
 - Git must be installed and the current Pi cwd must be inside a non-bare Git worktree.
 - The command requires a UI-capable Pi mode; print and JSON modes cannot drive its dialogs.


### PR DESCRIPTION
## Summary

- add a repository-wide package README convention with shared structure, labels, applicability rules, and verification guidance
- standardize common headings across all 27 active package READMEs
- add missing quick-start, command, tool, feature, settings, keyword, and limitation sections where applicable
- preserve passive-extension and reusable-library exceptions

## Verification

- fenced-code-aware README heading audit: 27/27 passed
- command and tool headings matched source registrations
- lifecycle badge and experimental-warning audit passed
- `npm run check`
- `npm test` — 382 files and 3,618 tests passed
- `git diff --check`

## Release and smokes

- no changeset: documentation-only change
- package pack and Pi runtime smokes not applicable because package metadata and runtime loading are unchanged
