### PR TITLE
docs: polish package README content

### DIFF
--- a/packages/pi-accounts/README.md
+++ b/packages/pi-accounts/README.md
@@ -1,24 +1,19 @@
-# 🔐 pi-accounts — Subscription OAuth Account Switcher for Pi
+# 🔐 pi-accounts — Switch Between Subscription OAuth Accounts
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-accounts)](https://www.npmjs.com/package/@narumitw/pi-accounts) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-accounts` is a native [Pi coding agent](https://pi.dev) extension for keeping and switching named subscription OAuth accounts independently across supported providers.
+Save and switch named OpenAI Codex, Anthropic, and GitHub Copilot subscription accounts without replacing Pi's built-in provider integrations.
 
-It uses Pi's built-in providers and provider-owned OAuth implementations. A named account temporarily overrides only that provider's runtime auth; selecting `default` restores Pi's normal `/login`, `auth.json`, or environment-based resolution without deleting the named account.
+Each selection overrides only the chosen provider, and selecting `default` restores Pi's normal authentication without deleting saved accounts.
 
 ## ✨ Features
 
-- Manages OpenAI Codex, Anthropic Claude Pro/Max, and GitHub Copilot OAuth accounts through one interactive `/accounts` command.
-- Keeps an independent active named account—or Pi's built-in login—for every provider.
-- Stores complete provider-owned OAuth credentials, including GitHub Enterprise and available-model metadata.
-- Refreshes rotating OAuth credentials under a cross-process file lock.
-- Writes `~/.pi/agent/pi-accounts.json` atomically with private directory and `0600` file permissions.
-- Applies provider-specific runtime API keys, headers, endpoints, and Copilot model availability.
-- Verifies effective runtime auth before reporting activation success.
-- Fails closed and aborts only the affected provider's turn after refresh or activation failure.
-- Restores the exact provider registration that existed before the account overlay.
-- Invalidates cached Codex WebSockets only when the applied Codex identity changes.
-- Migrates released `pi-codex-accounts.json` state without deleting the rollback source.
+- Manages named OpenAI Codex, Anthropic Claude Pro/Max, and GitHub Copilot OAuth accounts through `/accounts`.
+- Keeps an independent selected account—or Pi's default login—for each provider.
+- Applies provider-specific credentials, endpoints, headers, and model availability through Pi's built-in providers.
+- Refreshes rotating credentials safely and verifies effective runtime authentication before reporting success.
+- Stores credentials atomically in a private local file and fails closed for the affected provider on activation errors.
+- Migrates legacy `pi-codex-accounts.json` data while preserving its rollback source.
 
 ## 🔌 Supported providers
 
@@ -29,11 +24,14 @@ It uses Pi's built-in providers and provider-owned OAuth implementations. A name
 | GitHub Copilot | `github-copilot` | Individual or Enterprise login, credential-derived API endpoint, and account-specific available models |
 
 > [!WARNING]
-> Anthropic currently treats Claude Pro/Max use through third-party harnesses as **extra usage billed per token**, rather than consumption of the normal plan allowance. Review your Anthropic billing and extra-usage settings before using a named Anthropic account.
+> Anthropic currently treats Claude Pro/Max use through third-party harnesses as **extra usage billed per token**, rather than consumption of the normal plan allowance.
+> Review your Anthropic billing and extra-usage settings before using a named Anthropic account.
 
 ## 📦 Install
 
-`pi-codex-accounts` is deprecated and its source is archived under `deprecated/`. Do not load both packages together; they can manage and refresh the same rotating Codex credential independently. To migrate one Pi installation:
+`pi-codex-accounts` is deprecated and its source is archived under `deprecated/`.
+Do not load both packages together; they can manage and refresh the same rotating Codex credential independently.
+To migrate one Pi installation:
 
 ```bash
 pi uninstall npm:@narumitw/pi-codex-accounts
@@ -65,11 +63,10 @@ Open the interactive account manager:
 /accounts
 ```
 
-The standard manager runs in TUI or RPC mode; Back returns through provider/account screens and
-Escape closes the root. Print and JSON modes reject it observably. Any extra text after `/accounts`
-is ignored so the entry point stays singular. Provider-owned OAuth challenges, account-name text
-input, and exact replacement/removal confirmations remain specialized dialogs because they carry
-credential and destructive-action policy rather than ordinary navigation.
+The standard manager runs in TUI or RPC mode; Back returns through provider/account screens and Escape closes the root.
+Print and JSON modes reject it observably.
+Any extra text after `/accounts` is ignored so the entry point stays singular.
+Provider-owned OAuth challenges, account-name text input, and exact replacement/removal confirmations remain specialized dialogs because they carry credential and destructive-action policy rather than ordinary navigation.
 
 When no accounts are saved yet, the menu starts with login:
 
@@ -108,19 +105,29 @@ RPC mode uses Pi's standard extension UI requests for the same OAuth contract.
 `default` is reserved for Pi's built-in login.
 Reusing an existing provider/account name asks before replacing the stored credential.
 
-Switching the current model provider is the primary flow. Switching a different provider is explicit: choose **Switch another provider’s account**, choose the provider, then choose the account. Choosing `default` restores Pi's built-in login for that provider. `/accounts` manages account identity only; it does not switch models except when login succeeds while the current model is still `unknown`, where it selects that provider's default model as onboarding help.
+Switching the current model provider is the primary flow.
+Switching a different provider is explicit: choose **Switch another provider’s account**, choose the provider, then choose the account.
+Choosing `default` restores Pi's built-in login for that provider.
+`/accounts` manages account identity only; it does not switch models except when login succeeds while the current model is still `unknown`, where it selects that provider's default model as onboarding help.
 
-Removing an account lists named accounts as `Provider · account`, asks for confirmation, then removes the credential. Removing an active account automatically restores that provider to Pi's built-in login.
+Removing an account lists named accounts as `Provider · account`, asks for confirmation, then removes the credential.
+Removing an active account automatically restores that provider to Pi's built-in login.
 
 ## 🔐 Auth and fail-closed behavior
 
-Each selected account is refreshed through the provider's own OAuth `refresh()` implementation and converted through `toAuth()`. The extension then applies the returned API key, headers, and endpoint, verifies the effective runtime state, and reports success.
+Each selected account is refreshed through the provider's own OAuth `refresh()` implementation and converted through `toAuth()`.
+The extension then applies the returned API key, headers, and endpoint, verifies the effective runtime state, and reports success.
 
-If refresh, conversion, provider overlay, or verification fails, the extension installs a non-secret failing runtime credential and aborts turns for that provider. It does not silently fall back to Pi's built-in login, an environment API key, or another named account. Other providers remain independent and usable.
+If refresh, conversion, provider overlay, or verification fails, the extension installs a non-secret failing runtime credential and aborts turns for that provider.
+It does not silently fall back to Pi's built-in login, an environment API key, or another named account.
+Other providers remain independent and usable.
 
-Selecting `default` removes the package-owned runtime override and restores the exact provider registration that existed before activation. Pi's built-in credentials are never deleted.
+Selecting `default` removes the package-owned runtime override and restores the exact provider registration that existed before activation.
+Pi's built-in credentials are never deleted.
 
-GitHub Copilot's `availableModelIds` are projected into the active provider model list. Switching Copilot accounts rebuilds the projection from the complete pre-overlay model catalog. A currently selected model that is unavailable to the named account is rejected before the turn starts.
+GitHub Copilot's `availableModelIds` are projected into the active provider model list.
+Switching Copilot accounts rebuilds the projection from the complete pre-overlay model catalog.
+A currently selected model that is unavailable to the named account is rejected before the turn starts.
 
 ## 🗄️ Storage and migration
 
@@ -130,11 +137,10 @@ The canonical file is:
 ~/.pi/agent/pi-accounts.json
 ```
 
-When `PI_CODING_AGENT_DIR` is set, the file is stored at
-`$PI_CODING_AGENT_DIR/pi-accounts.json` instead. Its versioned structure keeps account maps and
-active names under separate provider IDs. Credential values are private and must not be committed.
-When neither canonical nor legacy storage exists, reads use an empty in-memory store without creating
-an agent directory or file; the first account mutation creates the private canonical file.
+When `PI_CODING_AGENT_DIR` is set, the file is stored at `$PI_CODING_AGENT_DIR/pi-accounts.json` instead.
+Its versioned structure keeps account maps and active names under separate provider IDs.
+Credential values are private and must not be committed.
+When neither canonical nor legacy storage exists, reads use an empty in-memory store without creating an agent directory or file; the first account mutation creates the private canonical file.
 
 On first load, if `pi-accounts.json` does not exist and released `pi-codex-accounts.json` does, the extension:
 
@@ -144,7 +150,8 @@ On first load, if `pi-accounts.json` does not exist and released `pi-codex-accou
 4. Atomically installs private `pi-accounts.json`.
 5. Retains the private legacy file for rollback.
 
-If both files exist, `pi-accounts.json` is canonical and the legacy file is not imported again. The retained legacy refresh token may become stale after `pi-accounts` rotates it, so rollback can require a new Codex login.
+If both files exist, `pi-accounts.json` is canonical and the legacy file is not imported again.
+The retained legacy refresh token may become stale after `pi-accounts` rotates it, so rollback can require a new Codex login.
 
 ### Rollback
 
@@ -153,11 +160,13 @@ If both files exist, `pi-accounts.json` is canonical and the legacy file is not 
 3. Reinstall the deprecated `@narumitw/pi-codex-accounts` package only if necessary.
 4. Reauthenticate Codex if the retained legacy refresh token was rotated.
 
-The repository preserves the predecessor implementation under `deprecated/pi-codex-accounts` for reference. It is excluded from active workspace checks, version bumps, and publishing.
+The repository preserves the predecessor implementation under `deprecated/pi-codex-accounts` for reference.
+It is excluded from active workspace checks, version bumps, and publishing.
 
-## 🚧 Limitations and non-goals
+## 🚧 Limitations
 
-- This package manages only subscription OAuth accounts. It does not store or switch API-key profiles.
+- This package manages only subscription OAuth accounts.
+  It does not store or switch API-key profiles.
 - Continue using Pi's `auth.json`, environment variables, or `!command` secret-manager resolution for API keys.
 - It does not rotate accounts automatically, evade quotas, or report usage.
 - It does not support arbitrary custom providers in the first release.
@@ -199,4 +208,5 @@ Pi extension, Pi coding agent, OAuth accounts, OpenAI Codex, ChatGPT Plus, ChatG
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-analytics/README.md
+++ b/packages/pi-analytics/README.md
@@ -1,23 +1,21 @@
-# 📈 pi-analytics — Local Analytics for Pi
+# 📈 pi-analytics — Understand Pi Activity Without Sending Data Away
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-analytics)](https://www.npmjs.com/package/@narumitw/pi-analytics) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 > [!WARNING]
-> This extension is experimental. Its metrics, storage format, and dashboard may change between releases.
+> This extension is experimental.
+> Its metrics, storage format, and dashboard may change between releases.
 
-`@narumitw/pi-analytics` is a local-first [Pi coding agent](https://pi.dev) extension that counts model calls, skill activations, tool activity, and observed provider errors without storing conversation or tool content.
+See local model, skill, tool, and provider reliability metrics without storing conversation or tool content or sending analytics elsewhere.
 
 ## ✨ Features
 
-- Starts collecting settled Pi response cycles after installation with no configuration or startup I/O.
-- Breaks skill activations down by explicit user invocation, model loading, provider, and model.
-- Counts tool calls, failures, average duration, and model attribution.
-- Reports logical LLM calls per response with average, median, P95, maximum, and distribution buckets.
-- Separates HTTP 429/5xx responses, conservative connection-error categories, recovered errors, and terminal provider failures.
-- Offers Today, rolling 7-day, rolling 30-day, and all-time views through one `/analytics` TUI/RPC dashboard.
-- Stores only content-free metadata in private, versioned JSON Lines files.
-- Uses one writer file per Pi runtime, so concurrent Pi processes never share a routine writer lock.
-- Never starts a server or sends analytics anywhere.
+- Collects content-free metrics automatically after installation.
+- Counts settled response cycles, logical LLM calls, skill activations, tool activity, and observed provider errors.
+- Breaks down tool failures, duration, model attribution, and response-level call distributions.
+- Distinguishes recovered provider errors from terminal failures.
+- Provides Today, rolling 7-day, rolling 30-day, and all-time views through `/analytics`.
+- Stores private versioned JSONL locally, isolates concurrent writers, and never starts an analytics server.
 
 ## 📦 Install
 
@@ -67,29 +65,41 @@ Provider errors                     4
 Recovered errors                    3
 ```
 
-Use the menu to change the time range or browse Skills, Tools, Provider reliability, Response cycles, and Data & privacy. Only fully settled cycles are included; active work is omitted.
+Use the menu to change the time range or browse Skills, Tools, Provider reliability, Response cycles, and Data & privacy.
+Only fully settled cycles are included; active work is omitted.
 
 ## 📐 Metric definitions
 
 ### Response cycles and LLM calls
 
-A **response cycle** starts when Pi begins agent work and ends at `agent_settled`. Automatic retries, overflow-compaction recovery, tool follow-ups, and queued continuations before settlement stay in that cycle.
+A **response cycle** starts when Pi begins agent work and ends at `agent_settled`.
+Automatic retries, overflow-compaction recovery, tool follow-ups, and queued continuations before settlement stay in that cycle.
 
-An **LLM call** is one logical provider generation. A provider may make several HTTP attempts inside it, so `429 → 429 → 200` is one LLM call, three observed HTTP responses, two provider errors, and a recovered generation.
+An **LLM call** is one logical provider generation.
+A provider may make several HTTP attempts inside it, so `429 → 429 → 200` is one LLM call, three observed HTTP responses, two provider errors, and a recovered generation.
 
 ### Skills
 
-An activation is **User initiated** when an observed interactive or RPC `/skill:<name>` input is associated with an active or subsequently started response cycle. This includes skill commands queued while Pi is streaming. It is **Model initiated** when the built-in `read` tool successfully loads the exact canonical `SKILL.md` path Pi discovered. A skill is counted at most once per response cycle, and explicit user use takes precedence.
+An activation is **User initiated** when an observed interactive or RPC `/skill:<name>` input is associated with an active or subsequently started response cycle.
+This includes skill commands queued while Pi is streaming.
+It is **Model initiated** when the built-in `read` tool successfully loads the exact canonical `SKILL.md` path Pi discovered.
+A skill is counted at most once per response cycle, and explicit user use takes precedence.
 
-Pi does not expose a first-class skill-invocation event or a post-chain acceptance event for input observers. Non-standard loading such as `bash` plus `cat SKILL.md`, unsuccessful reads, and provider behavior invisible to Pi are not counted.
+Pi does not expose a first-class skill-invocation event or a post-chain acceptance event for input observers.
+Non-standard loading such as `bash` plus `cat SKILL.md`, unsuccessful reads, and provider behavior invisible to Pi are not counted.
 
 ### Tools
 
-A tool call starts at Pi's `tool_execution_start` event and finishes at `tool_execution_end`. The extension stores the tool name, model attribution, timing, completion state, and final error flag. It cannot reliably distinguish another extension blocking a call from every other tool error, so both appear as errors.
+A tool call starts at Pi's `tool_execution_start` event and finishes at `tool_execution_end`.
+The extension stores the tool name, model attribution, timing, completion state, and final error flag.
+It cannot reliably distinguish another extension blocking a call from every other tool error, so both appear as errors.
 
 ### Provider reliability
 
-Pi exposes HTTP responses and final assistant failures, not every provider-SDK transport retry. The dashboard therefore labels these values as **observed provider errors**. It reports HTTP 429 and 5xx counts; conservative DNS, timeout, connection, TLS, network, and provider categories; recovered errors; and terminal failures. Error messages are classified in memory and discarded.
+Pi exposes HTTP responses and final assistant failures, not every provider-SDK transport retry.
+The dashboard therefore labels these values as **observed provider errors**.
+It reports HTTP 429 and 5xx counts; conservative DNS, timeout, connection, TLS, network, and provider categories; recovered errors; and terminal failures.
+Error messages are classified in memory and discarded.
 
 ## 💬 Commands
 
@@ -97,11 +107,17 @@ Pi exposes HTTP responses and final assistant failures, not every provider-SDK t
 /analytics
 ```
 
-The command accepts no arguments. TUI mode uses the full dashboard; RPC mode adapts the same standard screens to dialogs. Print and JSON modes reject the interactive command observably instead of writing ad hoc protocol output.
+The command accepts no arguments.
+TUI mode uses the full dashboard; RPC mode adapts the same standard screens to dialogs.
+Print and JSON modes reject the interactive command observably instead of writing ad hoc protocol output.
 
-The root menu contains Change time range, Skills, Tools, Provider reliability, Response cycles, Data & privacy, and Close. Skills and Tools are searchable browse views with details and model breakdowns. Escape goes Back from nested screens and closes the root. Ctrl+C closes the menu. Data deletion uses Pi TUI Kit's standalone confirmation: Back keeps the dashboard open, Ctrl+C closes it in TUI mode, and cancellation never clears data.
+The root menu contains Change time range, Skills, Tools, Provider reliability, Response cycles, Data & privacy, and Close.
+Skills and Tools are searchable browse views with details and model breakdowns.
+Escape goes Back from nested screens and closes the root.
+Ctrl+C closes the menu.
+Data deletion uses Pi TUI Kit's standalone confirmation: Back keeps the dashboard open, Ctrl+C closes it in TUI mode, and cancellation never clears data.
 
-## 🔐 Local data and privacy
+## 🔒 Security and privacy
 
 Current analytics live under:
 
@@ -113,21 +129,32 @@ Current analytics live under:
         └── <opaque-writer-id>.jsonl
 ```
 
-The opaque IDs are storage coordination identifiers generated by the extension; they are not Pi session IDs. On Unix, directories are restricted to mode `0700` and files to `0600`. Linked storage roots, markers, and writer files are rejected.
+The opaque IDs are storage coordination identifiers generated by the extension; they are not Pi session IDs.
+On Unix, directories are restricted to mode `0700` and files to `0600`.
+Linked storage roots, markers, and writer files are rejected.
 
-Stored fields are limited to timestamps and durations; extension-generated record IDs; provider/model IDs and thinking level; tool and skill names; user/model skill source; counts, outcomes, and completion states; HTTP status codes; and classified provider-error categories. Provider-supplied tool-call IDs are replaced with local ordinals before publication.
+Stored fields are limited to timestamps and durations; extension-generated record IDs; provider/model IDs and thinking level; tool and skill names; user/model skill source; counts, outcomes, and completion states; HTTP status codes; and classified provider-error categories.
+Provider-supplied tool-call IDs are replaced with local ordinals before publication.
 
 The extension does **not** store prompts, responses, thinking content, tool arguments or results, raw error messages, HTTP headers, cwd/project/file paths, session names or IDs, or credentials.
 
-Each settled response is one versioned, newline-terminated frame. Frames larger than 1 MiB are dropped. Local writes receive a 500 ms cancellation deadline; Node filesystem cancellation is best-effort, so an operating-system request that has already begun may still finish. The extension reports the first failed or timed-out write and a later recovery without exposing filesystem errors.
+Each settled response is one versioned, newline-terminated frame.
+Frames larger than 1 MiB are dropped.
+Local writes receive a 500 ms cancellation deadline; Node filesystem cancellation is best-effort, so an operating-system request that has already begun may still finish.
+The extension reports the first failed or timed-out write and a later recovery without exposing filesystem errors.
 
-`/analytics` streams and validates the active generation, checks cancellation between files and records, and periodically yields to the event loop. A crash-truncated final frame is ignored; completed malformed frames and unsupported format versions fail closed without replacing existing files.
+`/analytics` streams and validates the active generation, checks cancellation between files and records, and periodically yields to the event loop.
+A crash-truncated final frame is ignored; completed malformed frames and unsupported format versions fail closed without replacing existing files.
 
 ### Clear analytics data
 
-Choose **Data & privacy → Clear analytics data…** to atomically publish a fresh active generation. Other Pi processes observe that generation before their next write. Records racing with Clear may land immediately before or after the generation switch.
+Choose **Data & privacy → Clear analytics data…** to atomically publish a fresh active generation.
+Other Pi processes observe that generation before their next write.
+Records racing with Clear may land immediately before or after the generation switch.
 
-The extension then removes the previous generation. If another process still has an obsolete file in use, Clear remains logically complete and reports that physical cleanup is incomplete; stop other Pi processes and clear again. Clearing files is not a secure-erasure guarantee for underlying storage media.
+The extension then removes the previous generation.
+If another process still has an obsolete file in use, Clear remains logically complete and reports that physical cleanup is incomplete; stop other Pi processes and clear again.
+Clearing files is not a secure-erasure guarantee for underlying storage media.
 
 ## 🧭 Legacy SQLite data
 
@@ -138,14 +165,18 @@ Versions that used Turso/SQLite stored data in:
 <pi-agent-directory>/pi-analytics.db-wal
 ```
 
-The JSONL version deliberately does not open, import, migrate, delete, or rewrite those files, so startup cannot re-enter the old native database path. New analytics start empty.
+The JSONL version deliberately does not open, import, migrate, delete, or rewrite those files, so startup cannot re-enter the old native database path.
+New analytics start empty.
 
-If legacy history matters, stop every old Pi process first and preserve both files together. If it does not matter, stop every old Pi process before deleting both files manually. Never copy or remove only the main DB while an old process may still own its WAL.
+If legacy history matters, stop every old Pi process first and preserve both files together.
+If it does not matter, stop every old Pi process before deleting both files manually.
+Never copy or remove only the main DB while an old process may still own its WAL.
 
 ## 🚧 Limitations
 
 - There are no retention settings; records remain until explicitly cleared.
-- Analytics are best-effort derived metadata. A failed or interrupted local write may be omitted.
+- Analytics are best-effort derived metadata.
+  A failed or interrupted local write may be omitted.
 - Large all-time histories require scanning the active JSONL generation when the dashboard opens.
 - Prometheus, JSON/CSV export, cloud sync, browser dashboards, token/cost reporting, and project attribution are not included.
 - Statistics cover only events visible through Pi's public extension API.
@@ -185,4 +216,5 @@ Pi extension, Pi coding agent, local analytics, agent skills, tool usage, model 
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -1,27 +1,19 @@
-# 💬 pi-btw — Side Questions for the Pi Coding Agent
+# 💬 pi-btw — Ask Side Questions Without Derailing the Main Task
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-btw)](https://www.npmjs.com/package/@narumitw/pi-btw) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-btw` is a native [Pi coding agent](https://pi.dev) extension that adds `/btw`, a side-question command for quick clarifications that should not interrupt or pollute the main agent conversation.
+Ask temporary questions in a separate side thread while the main Pi conversation and coding task stay focused.
 
-Use it when you want to ask a temporary question, inspect context, or get a short explanation while keeping the primary coding task focused.
+Bring back only the answer or context you explicitly choose.
 
 ## ✨ Features
 
-- Adds a `/btw` menu for starting or resuming an in-memory side thread, choosing context from the main session tree, or changing pi-btw settings.
-- Starts a fresh side thread from any persisted main-session branch without switching the main branch.
-- Keeps `/btw <question>` as a direct fast path that always starts a fresh side thread.
-- Answers side questions in a dedicated, scrollable full-screen UI.
-- Keeps mouse-drag copying stable while the main agent continues running in the background.
-- Supports follow-up questions in the same ephemeral side thread.
-- Resumes any non-empty side thread retained by the current Pi session, listed by its first question.
-- Queues Pi-style `Steering` questions while an answer is running and processes them one at a time.
-- Optionally brings the latest answer, a question-to-end suffix, an exact line range, or the entire side thread into the main editor.
-- Uses the current session branch as context.
-- Uses Pi's current model or an independent model selected in `pi-btw.json`.
-- Uses a pi-btw thinking level that can either start from the main thread or use a fixed remembered value.
-- Does not append the side question or answer to the main conversation.
-- Works as an independently installable npm Pi extension package.
+- Starts a fresh side thread immediately with `/btw <question>` or opens the manager with `/btw`.
+- Uses any persisted main-session branch as context without switching that branch.
+- Supports scrollable answers, follow-up questions, queued steering, and resumable in-memory threads.
+- Keeps side questions and answers out of the main conversation by default.
+- Brings back only the latest answer, a selected range, a question suffix, or the complete side thread when requested.
+- Uses Pi's current model and thinking level or independent saved choices.
 
 ## 📦 Install
 
@@ -108,45 +100,43 @@ Press `Ctrl+C` to cancel the active response and discard the ephemeral side-thre
 Completed questions, answers, and visible errors remain available through Resume until the current extension instance ends.
 Steering remains entirely inside pi-btw and never appends to the main conversation or editor.
 
-After at least one successful answer, press `Ctrl+R` to bring selected context to the main
-editor. The scope menu shows the size of the latest question and answer and the entire side
-thread before you choose. Bring the latest question and answer, everything from a chosen
-question onward, an exact text range, or the entire side thread. Question-suffix, exact-range,
-and entire-thread choices preview the exact editable context block before the side thread closes;
+After at least one successful answer, press `Ctrl+R` to bring selected context to the main editor.
+The scope menu shows the size of the latest question and answer and the entire side thread before you choose.
+Bring the latest question and answer, everything from a chosen question onward, an exact text range, or the entire side thread.
+Question-suffix, exact-range, and entire-thread choices preview the exact editable context block before the side thread closes;
 `Escape` returns and `Ctrl+C` closes without bringing anything to main.
 
 The text-range selector supports both fast line selection and editor-style character selection.
-It reports whether anything is selected plus the selected line, message, and approximate token
-counts. Press `Space` to select the current raw source line, then use `Up`/`Down` to extend by
-whole lines; press `Space` again to clear it. Alternatively, use the arrow keys to move the cursor
-and `Shift`+arrow keys to extend a character-level selection. Starting a Shift selection replaces
-any active line selection. Selected lines include a visible `●` marker in addition to highlighting.
-Pi's configured keys control vertical navigation, bringing, and going back (`Up`/`Down`, `Enter`,
-and `Escape` by default), and the selector displays the active keys. Selection follows raw source
-text rather than terminal-wrapped visual rows.
+It reports whether anything is selected plus the selected line, message, and approximate token counts.
+Press `Space` to select the current raw source line, then use `Up`/`Down` to extend by whole lines; press `Space` again to clear it.
+Alternatively, use the arrow keys to move the cursor and `Shift`+arrow keys to extend a character-level selection.
+Starting a Shift selection replaces any active line selection.
+Selected lines include a visible `●` marker in addition to highlighting.
+Pi's configured keys control vertical navigation, bringing, and going back (`Up`/`Down`, `Enter`, and `Escape` by default), and the selector displays the active keys.
+Selection follows raw source text rather than terminal-wrapped visual rows.
 
-Bringing context to main closes the side thread and loads a deterministic, editable context block
-into Pi's main editor. It never sends the draft automatically. If the main editor already has a
-draft, append is the recommended default. Replace is labeled as destructive and requires a second
-confirmation; Cancel returns to the side thread without changing either draft. Concurrent editor
-updates made while these menus are open are preserved. A success message reports whether context
-was loaded, appended, or replaced and its approximate size.
-Without an explicit bring-to-main action, closing `/btw` never adds the side thread to the main
-conversation. Non-empty threads remain only in memory for Resume within the current Pi session.
-`/new`, Pi `/resume`, `/reload`, extension replacement, and process restart discard every retained
-thread. Unsent drafts, steering queues, interrupted answers, and model credentials are never retained.
+Bringing context to main closes the side thread and loads a deterministic, editable context block into Pi's main editor.
+It never sends the draft automatically.
+If the main editor already has a draft, append is the recommended default.
+Replace is labeled as destructive and requires a second confirmation; Cancel returns to the side thread without changing either draft.
+Concurrent editor updates made while these menus are open are preserved.
+A success message reports whether context was loaded, appended, or replaced and its approximate size.
+Without an explicit bring-to-main action, closing `/btw` never adds the side thread to the main conversation.
+Non-empty threads remain only in memory for Resume within the current Pi session.
+`/new`, Pi `/resume`, `/reload`, extension replacement, and process restart discard every retained thread.
+Unsent drafts, steering queues, interrupted answers, and model credentials are never retained.
 
 ## ⚙️ Settings
 
-By default, `/btw` uses the current session model. To use an independent model for side
-questions, create:
+By default, `/btw` uses the current session model.
+To use an independent model for side questions, create:
 
 ```text
 $PI_CODING_AGENT_DIR/pi-btw.json
 ```
 
-The normal location is `~/.pi/agent/pi-btw.json`. `PI_CODING_AGENT_DIR` is an existing Pi
-setting; pi-btw does not add any environment variables.
+The normal location is `~/.pi/agent/pi-btw.json`.
+`PI_CODING_AGENT_DIR` is an existing Pi setting; pi-btw does not add any environment variables.
 
 ```json
 {
@@ -156,42 +146,41 @@ setting; pi-btw does not add any environment variables.
 }
 ```
 
-The `model` value uses `provider/model-id` format. Only the first `/` is the separator, so
-model IDs may contain additional slashes, such as `openrouter/anthropic/claude-sonnet`.
-The configured model must exist in Pi's model registry and have usable credentials. If it
-cannot be found or authenticated, pi-btw warns and falls back to the current session model.
-If neither model is available, `/btw` reports an error and stops. This selection affects only
-`/btw`; it does not change the main session model.
+The `model` value uses `provider/model-id` format.
+Only the first `/` is the separator, so model IDs may contain additional slashes, such as `openrouter/anthropic/claude-sonnet`.
+The configured model must exist in Pi's model registry and have usable credentials.
+If it cannot be found or authenticated, pi-btw warns and falls back to the current session model.
+If neither model is available, `/btw` reports an error and stops.
+This selection affects only `/btw`; it does not change the main session model.
 
-Pi calls its reasoning setting the **thinking level**. In Settings, choose **Same as main thread**
-to start each new side thread from the main thread's current thinking level. This is stored by
-omitting `thinkingLevel` from `pi-btw.json`.
+Pi calls its reasoning setting the **thinking level**.
+In Settings, choose **Same as main thread** to start each new side thread from the main thread's current thinking level.
+This is stored by omitting `thinkingLevel` from `pi-btw.json`.
 
-Set `thinkingLevel` only when you want a fixed pi-btw starting level. Accepted fixed values are
-`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. The initial value and shortcut cycle
-are clamped to the selected side model's capabilities using Pi's model rules. Resumed side threads
-keep their own local thinking level instead of re-syncing with the main thread. Pi-btw does not read,
-write, or change the main session's `defaultThinkingLevel`.
+Set `thinkingLevel` only when you want a fixed pi-btw starting level.
+Accepted fixed values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
+The initial value and shortcut cycle are clamped to the selected side model's capabilities using Pi's model rules.
+Resumed side threads keep their own local thinking level instead of re-syncing with the main thread.
+Pi-btw does not read, write, or change the main session's `defaultThinkingLevel`.
 
-`rememberThinkingLevelChanges` controls only persistence for fixed thinking levels and defaults to
-`true` when omitted. A side-thread shortcut always changes that side thread immediately. When a fixed
-thinking level is selected and remembering is on, the concrete level is written for the next
-invocation; when off, `pi-btw.json` stays unchanged. When **Same as main thread** is selected,
-shortcut changes stay local even when remembering is on. If a shortcut write fails, the local change
-remains active and pi-btw warns that it was not remembered. A failed Settings-screen save instead
-restores the previous displayed value.
+`rememberThinkingLevelChanges` controls only persistence for fixed thinking levels and defaults to `true` when omitted.
+A side-thread shortcut always changes that side thread immediately.
+When a fixed thinking level is selected and remembering is on, the concrete level is written for the next invocation; when off, `pi-btw.json` stays unchanged.
+When **Same as main thread** is selected, shortcut changes stay local even when remembering is on.
+If a shortcut write fails, the local change remains active and pi-btw warns that it was not remembered.
+A failed Settings-screen save instead restores the previous displayed value.
 
-A missing settings file is a side-effect-free read: pi-btw creates it only after a Settings change
-or a remembered shortcut change. Saves are ordered within the Pi process and published atomically
-with a same-directory temporary file and rename. They preserve `model` and unknown fields; malformed
-or invalid files block saves and remain unchanged. Settings must be valid UTF-8 and no larger than
-64 KiB, so unexpectedly large or invalidly encoded files are rejected without being rewritten.
-Separate Pi processes and external editors are outside this in-process ordering boundary. The file
-is read for each `/btw` invocation, so edits apply without `/reload`.
+A missing settings file is a side-effect-free read: pi-btw creates it only after a Settings change or a remembered shortcut change.
+Saves are ordered within the Pi process and published atomically with a same-directory temporary file and rename.
+They preserve `model` and unknown fields; malformed or invalid files block saves and remain unchanged.
+Settings must be valid UTF-8 and no larger than 64 KiB, so unexpectedly large or invalidly encoded files are rejected without being rewritten.
+Separate Pi processes and external editors are outside this in-process ordering boundary.
+The file is read for each `/btw` invocation, so edits apply without `/reload`.
 
 ## 🧠 Why use pi-btw?
 
-Normal assistant messages become part of the main Pi conversation and can distract the coding agent from the task. `pi-btw` creates a lightweight side channel for context-aware questions, making it useful for pair programming, debugging, code review, and repository exploration.
+Normal assistant messages become part of the main Pi conversation and can distract the coding agent from the task.
+`pi-btw` creates a lightweight side channel for context-aware questions, making it useful for pair programming, debugging, code review, and repository exploration.
 
 ## 🗂️ Package layout
 
@@ -234,4 +223,5 @@ Pi extension, Pi coding agent, AI coding agent, side question command, agent cha
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -103,8 +103,8 @@ Steering remains entirely inside pi-btw and never appends to the main conversati
 After at least one successful answer, press `Ctrl+R` to bring selected context to the main editor.
 The scope menu shows the size of the latest question and answer and the entire side thread before you choose.
 Bring the latest question and answer, everything from a chosen question onward, an exact text range, or the entire side thread.
-Question-suffix, exact-range, and entire-thread choices preview the exact editable context block before the side thread closes;
-`Escape` returns and `Ctrl+C` closes without bringing anything to main.
+Question-suffix, exact-range, and entire-thread choices preview the exact editable context block before the side thread closes.
+Pressing `Escape` returns, while `Ctrl+C` closes without bringing anything to main.
 
 The text-range selector supports both fast line selection and editor-style character selection.
 It reports whether anything is selected plus the selected line, message, and approximate token counts.

--- a/packages/pi-caffeinate/README.md
+++ b/packages/pi-caffeinate/README.md
@@ -1,24 +1,16 @@
-# ☕ pi-caffeinate — Keep Your Computer Awake While Pi Works
+# ☕ pi-caffeinate — Keep Your Computer Awake While Pi Runs
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-caffeinate)](https://www.npmjs.com/package/@narumitw/pi-caffeinate) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-caffeinate` is a cross-platform [Pi coding agent](https://pi.dev) extension that prevents your computer from sleeping while the Pi agent is processing a prompt.
-
-It is designed for long-running coding, refactoring, debugging, web research, and autonomous agent workflows where a suspended laptop or desktop would interrupt progress.
+Prevent system or display sleep while Pi is processing a prompt, then release the inhibitor as soon as the run ends.
 
 ## ✨ Features
 
-- Starts an OS sleep inhibitor when Pi begins processing (`agent_start`).
-- Releases the inhibitor when processing ends (`agent_end`) or the session shuts down.
-- Publishes the active keep-awake mode as status while an inhibitor is active, unless quiet mode is enabled.
-- Supports macOS, Windows, WSL, and Linux.
-- Defaults to display-awake mode on every supported OS: prevent system sleep and keep the screen/display awake.
-- Provides a single `/caffeinate` command with menu-based controls and direct subcommands.
-- Persists the selected keep-awake mode and optional quiet mode in a small JSON settings file.
-- Allows a custom inhibitor command through environment configuration.
-- Emits plain status text; `@narumitw/pi-statusline` can add or suppress the status icon from JSON config.
-- Uses the standard `org.freedesktop.ScreenSaver` D-Bus idle-inhibition service for Linux `display` mode.
-- Fails safely when no supported inhibitor is available.
+- Starts an OS sleep inhibitor when a Pi run begins and releases it when the run or session ends.
+- Supports macOS, Windows, WSL, and Linux with a display-awake default.
+- Provides `/caffeinate` controls for the keep-awake mode, current status, and quiet mode.
+- Persists preferences locally and accepts an optional custom inhibitor command.
+- Shows activity only while the inhibitor is active and fails safely when no supported mechanism is available.
 
 ## 📦 Install
 
@@ -46,7 +38,8 @@ Run `/caffeinate` to open the controls or `/caffeinate status` to inspect the cu
 
 ## 🖥️ Supported platforms
 
-The default mode is `display` on every supported OS. That means pi-caffeinate prevents system sleep, suspend, or hibernate and keeps the screen/display awake.
+The default mode is `display` on every supported OS.
+That means pi-caffeinate prevents system sleep, suspend, or hibernate and keeps the screen/display awake.
 
 Use `/caffeinate sleep` if you want to prevent system sleep while allowing normal display idle behavior such as screen blanking or monitor power-off.
 
@@ -58,17 +51,13 @@ Use `/caffeinate sleep` if you want to prevent system sleep while allowing norma
 | Linux with systemd | `systemd-inhibit --what=sleep ... sleep infinity` | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `systemd-inhibit --what=idle:sleep ... sleep infinity` |
 | Linux without systemd | `caffeinate -ims` when available | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `caffeinate -dimsu` when available; D-Bus only otherwise |
 
-On Linux, `display` mode requests idle inhibition through the standard `org.freedesktop.ScreenSaver`
-D-Bus service, trying both `/org/freedesktop/ScreenSaver` and `/ScreenSaver` for desktop compatibility.
+On Linux, `display` mode requests idle inhibition through the standard `org.freedesktop.ScreenSaver` D-Bus service, trying both `/org/freedesktop/ScreenSaver` and `/ScreenSaver` for desktop compatibility.
 The session-bus connection stays open for the whole agent turn.
 The inhibition ends when `UnInhibit` is called or the connection closes.
 `systemd-inhibit --what=idle:sleep` runs alongside it to preserve logind idle and sleep inhibition.
-If no ScreenSaver service is available, pi-caffeinate keeps the systemd blocker or `caffeinate`
-fallback and reports a partial-activation warning.
-If only D-Bus is available, pi-caffeinate reports partial activation because desktop idle is
-inhibited but direct system suspend may remain possible.
-D-Bus method calls use short deadlines, and stop or shutdown aborts an in-flight acquisition before
-closing its session-bus connection.
+If no ScreenSaver service is available, pi-caffeinate keeps the systemd blocker or `caffeinate` fallback and reports a partial-activation warning.
+If only D-Bus is available, pi-caffeinate reports partial activation because desktop idle is inhibited but direct system suspend may remain possible.
+D-Bus method calls use short deadlines, and stop or shutdown aborts an in-flight acquisition before closing its session-bus connection.
 
 If no supported inhibitor is available, the extension stays loaded and reports that caffeinate is unavailable.
 
@@ -78,32 +67,36 @@ If no supported inhibitor is available, the extension stays loaded and reports t
 /caffeinate
 ```
 
-Opens standard keep-awake controls in TUI or RPC mode. Print and JSON modes reject the interactive
-menu observably; use the direct `status`, `sleep`, `display`, `stop`, or `help` routes instead.
+Opens standard keep-awake controls in TUI or RPC mode.
+Print and JSON modes reject the interactive menu observably; use the direct `status`, `sleep`, `display`, `stop`, or `help` routes instead.
 
 ```text
 /caffeinate display
 ```
 
-Keeps the system and screen/display awake. If an inhibitor is currently active, it is restarted so the new mode applies immediately.
+Keeps the system and screen/display awake.
+If an inhibitor is currently active, it is restarted so the new mode applies immediately.
 
 ```text
 /caffeinate sleep
 ```
 
-Keeps the system awake while allowing normal display sleep. If an inhibitor is currently active, it is restarted so the new mode applies immediately.
+Keeps the system awake while allowing normal display sleep.
+If an inhibitor is currently active, it is restarted so the new mode applies immediately.
 
 ```text
 /caffeinate status
 ```
 
-Shows whether an inhibitor is active, unavailable, disabled, or idle. The status includes the current mode, quiet mode, and settings file path.
+Shows whether an inhibitor is active, unavailable, disabled, or idle.
+The status includes the current mode, quiet mode, and settings file path.
 
 ```text
 /caffeinate mode
 ```
 
-Opens the standard keep-awake mode selector in TUI or RPC mode. Escape closes the selector.
+Opens the standard keep-awake mode selector in TUI or RPC mode.
+Escape closes the selector.
 
 ```text
 /caffeinate stop
@@ -131,25 +124,22 @@ Example:
 }
 ```
 
-Set `"quiet": true` to hide the routine `Keeping computer awake (...)` and
-`Released pi-caffeinate (agent finished)` lifecycle notifications and keep the `caffeinate` status
-item clear while active or unavailable. Quiet mode does not hide warnings or explicit feedback from
-`/caffeinate` commands such as `status`, mode changes, help, and manual stop. It defaults to `false`
-when omitted. The file is read at startup and on `/reload`; run `/reload` after editing it in a
-running Pi session before using mode commands.
+Set `"quiet": true` to hide the routine `Keeping computer awake (...)` and `Released pi-caffeinate (agent finished)` lifecycle notifications and keep the `caffeinate` status item clear while active or unavailable.
+Quiet mode does not hide warnings or explicit feedback from `/caffeinate` commands such as `status`, mode changes, help, and manual stop.
+It defaults to `false` when omitted.
+The file is read at startup and on `/reload`; run `/reload` after editing it in a running Pi session before using mode commands.
 
-Missing, invalid, or deleted settings default back to `display` mode with quiet mode disabled on
-every supported OS. A missing file stays absent until the first successful mode change. Within one Pi process, mode saves run in invocation order, reread the latest valid document, and preserve unknown fields. Malformed
-JSON or an invalid recognized field blocks mode saves until repaired instead of being overwritten.
-A failed save keeps the prior runtime mode; if restarting an active inhibitor fails after publication,
-the extension restores the prior saved mode and inhibitor behavior or reports an explicit rollback
-failure.
+Missing, invalid, or deleted settings default back to `display` mode with quiet mode disabled on every supported OS.
+A missing file stays absent until the first successful mode change.
+Within one Pi process, mode saves run in invocation order, reread the latest valid document, and preserve unknown fields.
+Malformed JSON or an invalid recognized field blocks mode saves until repaired instead of being overwritten.
+A failed save keeps the prior runtime mode; if restarting an active inhibitor fails after publication, the extension restores the prior saved mode and inhibitor behavior or reports an explicit rollback failure.
 
-Compatibility: older versions used `pi-caffeinate-settings.json`. A legacy-only file remains
-readable with a warning and is never modified automatically; rename it to `pi-caffeinate.json`.
-The first subsequent settings save writes the canonical file. If both files exist,
-`pi-caffeinate.json` wins and the legacy file is ignored. The legacy filename is deprecated
-and will be removed in a future major release.
+Compatibility: older versions used `pi-caffeinate-settings.json`.
+A legacy-only file remains readable with a warning and is never modified automatically; rename it to `pi-caffeinate.json`.
+The first subsequent settings save writes the canonical file.
+If both files exist, `pi-caffeinate.json` wins and the legacy file is ignored.
+The legacy filename is deprecated and will be removed in a future major release.
 
 ### Environment variables
 
@@ -165,9 +155,11 @@ Use a custom inhibitor command:
 PI_CAFFEINATE_COMMAND='systemd-inhibit --what=idle:sleep --why="pi running" --mode=block sleep infinity' pi
 ```
 
-The custom command is parsed with shell-like quoting and is run directly without a shell. `PI_CAFFEINATE_COMMAND` takes precedence over the saved mode; `/caffeinate status` reports when a custom command is active.
+The custom command is parsed with shell-like quoting and is run directly without a shell.
+`PI_CAFFEINATE_COMMAND` takes precedence over the saved mode; `/caffeinate status` reports when a custom command is active.
 
-Deprecated: `PI_CAFFEINATE_ICON` still works for now. If you use `@narumitw/pi-statusline`, move the icon to `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline.json`:
+Deprecated: `PI_CAFFEINATE_ICON` still works for now.
+If you use `@narumitw/pi-statusline`, move the icon to `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline.json`:
 
 ```json
 {
@@ -177,18 +169,20 @@ Deprecated: `PI_CAFFEINATE_ICON` still works for now. If you use `@narumitw/pi-s
 }
 ```
 
-Without `@narumitw/pi-statusline`, keep using `PI_CAFFEINATE_ICON` during the compatibility window. In `pi-statusline.json`, use an empty string to show the caffeinate status without an icon.
+Without `@narumitw/pi-statusline`, keep using `PI_CAFFEINATE_ICON` during the compatibility window.
+In `pi-statusline.json`, use an empty string to show the caffeinate status without an icon.
 
 ## 🧠 Why use pi-caffeinate?
 
-AI coding agents often run tool-heavy tasks that take several minutes. `pi-caffeinate` keeps your machine awake during active Pi work, helping browser automation, local builds, test runs, code generation, and long prompts finish reliably.
+AI coding agents often run tool-heavy tasks that take several minutes.
+`pi-caffeinate` keeps your machine awake during active Pi work, helping browser automation, local builds, test runs, code generation, and long prompts finish reliably.
 
-The default display-awake mode prioritizes uninterrupted long-running Pi work across platforms, including Linux desktops that require idle inhibition to prevent automatic suspend. Use `/caffeinate sleep` (shown as `system-awake` in status output) when you prefer normal screen power saving and your system does not need idle inhibition to keep Pi running.
+The default display-awake mode prioritizes uninterrupted long-running Pi work across platforms, including Linux desktops that require idle inhibition to prevent automatic suspend.
+Use `/caffeinate sleep` (shown as `system-awake` in status output) when you prefer normal screen power saving and your system does not need idle inhibition to keep Pi running.
 
 ## 📦 Dependencies
 
-On Linux, `display` mode uses the `dbus-native` package (pure JavaScript, no native build step) to
-call `org.freedesktop.ScreenSaver` on the session bus.
+On Linux, `display` mode uses the `dbus-native` package (pure JavaScript, no native build step) to call `org.freedesktop.ScreenSaver` on the session bus.
 
 ## 🗂️ Package layout
 
@@ -212,4 +206,5 @@ Pi extension, Pi coding agent, caffeinate, prevent sleep, keep awake, sleep inhi
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-chat/README.md
+++ b/packages/pi-chat/README.md
@@ -1,35 +1,24 @@
-# 💬 Pi Chat — Experimental P2P Developer Chat for Pi
+# 💬 Pi Chat — Talk to Peers Without Leaving Pi
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-chat)](https://www.npmjs.com/package/@narumitw/pi-chat) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 > [!WARNING]
-> Pi Chat is experimental. Its protocol, identity format, networking behavior, and interaction flow
-> may change between releases. It is not an anonymous or reliable messaging service.
+> Pi Chat is experimental.
+> Its protocol, identity format, networking behavior, and interaction flow may change between releases.
+> It is not an anonymous or reliable messaging service.
 
-`@narumitw/pi-chat` adds an ephemeral peer-to-peer chat room beside your Pi coding workflow. It uses
-Hyperswarm and HyperDHT to discover peers and opens encrypted Noise streams directly between them.
-Chat messages remain separate from Pi sessions, prompts, model context, repositories, and agent
-output.
+Join ephemeral peer-to-peer chat rooms beside your Pi workflow without putting chat messages into prompts, model context, repositories, or agent output.
+
+Pi Chat discovers peers with Hyperswarm and HyperDHT and connects them through encrypted Noise streams.
 
 ## ✨ Features
 
-- Creates random private rooms shared through bearer invite codes.
-- Browses currently discovered public rooms by estimated active participants, or joins a known
-  lowercase slug directly.
-- Shows every nickname with a stable public-key fingerprint such as
-  `Mika~7K2P-9D4M-HQ3T`.
-- Relays signed chat and presence events through a sparse P2P gossip overlay and suppresses duplicate
-  display and forwarding inside a bounded deduplication window.
-- Keeps an adaptive joined-room dock visible above the Pi editor with explicit input-target status.
-- Opens a focused, scrollable full-size chat composer with multiline IME support.
-- Preserves chat drafts when returning to Pi or when no direct neighbor can accept a message.
-- Restores a remembered room and the last intentional chat/Pi surface when Pi restarts.
-- Uses authenticated direct streams, origin signatures, and an invite-derived private-room handshake.
-- Limits neighbors, participants, frames, messages, hops, catalogs, transcript entries, reconnect
-  work, and per-neighbor/per-origin message rates.
-- Keeps identity settings local with private permissions and atomic publication.
-- Cleans up discovery, sockets, timers, status, and widgets on leave, reload, session replacement,
-  or shutdown.
+- Creates private rooms with bearer invites or joins discoverable public rooms by slug.
+- Shows stable public-key fingerprints beside nicknames so peers can verify identities.
+- Keeps chat in a dedicated composer and visible dock beside the normal Pi editor.
+- Preserves drafts and optionally restores a remembered room and the last selected surface.
+- Signs and relays bounded events over authenticated encrypted peer connections.
+- Stores identity settings privately and cleans up all networking and UI resources on leave or shutdown.
 
 ## 📦 Install
 
@@ -51,43 +40,37 @@ Try the extension from a local checkout:
 pi --no-extensions --no-skills --no-session -e ./packages/pi-chat
 ```
 
-Load the package only once per Pi process. Repeating `-e ./packages/pi-chat` creates duplicate
-extension instances and suffixed commands such as `/chat:1` and `/chat:2`.
+Load the package only once per Pi process.
+Repeating `-e ./packages/pi-chat` creates duplicate extension instances and suffixed commands such as `/chat:1` and `/chat:2`.
 
-Pi extensions execute with your user permissions. Review source before installing third-party
-packages.
+Pi extensions execute with your user permissions.
+Review source before installing third-party packages.
 
 ## 🚀 Quick start
 
-Run:
+Run `/chat`, choose a public or private room, set a nickname, and start chatting.
+Press `Escape` or `Ctrl+C` to return to the Pi editor without leaving the room or losing the chat draft.
 
-```text
-/chat
-```
+## 🧭 Rooms and composer
 
-Then choose one of these actions:
+The `/chat` menu offers these entry actions:
 
-- **Browse public rooms** queries a best-effort P2P directory, sorts discovered rooms by estimated
-  active participants and then slug, and keeps Refresh plus manual slug entry available.
-- **Join public room** accepts a lowercase slug such as `pi-dev`, remembers it after the public-room
-  warning is confirmed, and opens the chat composer.
-- **Join with invite** accepts a private-room invite, then offers **Join and remember**, **Join once**,
-  or **Cancel** before networking starts.
-- **Create private room** generates a random `pichat:v2:…` bearer invite and uses the same explicit
-  persistence choice. Existing `pichat:v1` invite text remains accepted as v2 room input.
+- **Browse public rooms** queries a best-effort P2P directory, sorts discovered rooms by estimated active participants and then slug, and keeps Refresh plus manual slug entry available.
+- **Join public room** accepts a lowercase slug such as `pi-dev`, remembers it after the public-room warning is confirmed, and opens the chat composer.
+- **Join with invite** accepts a private-room invite, then offers **Join and remember**, **Join once**, or **Cancel** before networking starts.
+- **Create private room** generates a random `pichat:v2:…` bearer invite and uses the same explicit persistence choice.
+  Existing `pichat:v1` invite text remains accepted as v2 room input.
 
-The first join asks for a nickname and joined-room display mode, then previews the generated
-identity fingerprint and display choice before one atomic save. Pi Chat does not read your OS
-username, Git identity, cwd, repository, or Pi session to fill these values. Cancelling creates
-neither identity settings nor network activity.
+The first join asks for a nickname and joined-room display mode, then previews the generated identity fingerprint and display choice before one atomic save.
+Pi Chat does not read your OS username, Git identity, cwd, repository, or Pi session to fill these values.
+Cancelling creates neither identity settings nor network activity.
 
-A successful remembered join stores the room and `chat` surface atomically. On the next Pi start,
-Pi Chat reconnects and reopens the full composer without another command. If you intentionally press
-Escape or Ctrl+C to return to Pi, it remembers the `pi` surface instead: the next start reconnects in
-the background and leaves the Pi editor focused.
+A successful remembered join stores the room and `chat` surface atomically.
+On the next Pi start, Pi Chat reconnects and reopens the full composer without another command.
+If you intentionally press Escape or Ctrl+C to return to Pi, it remembers the `pi` surface instead: the next start reconnects in the background and leaves the Pi editor focused.
 
-While connected, `/chat` opens the state-aware manager. **Open chat in <room>** is selected first,
-followed by participants, private invite, settings, status, help, and **Leave and forget room** last.
+While connected, `/chat` opens the state-aware manager.
+**Open chat in <room>** is selected first, followed by participants, private invite, settings, status, help, and **Leave and forget room** last.
 The persistent dock continues showing room state while the normal Pi editor targets Pi/LLM.
 
 Inside the dedicated chat composer:
@@ -98,11 +81,10 @@ Inside the dedicated chat composer:
 - `PageUp` and `PageDown` scroll transcript history.
 - `Escape` or `Ctrl+C` returns to Pi/LLM without leaving the room or discarding the chat draft.
 
-The composer retains the draft when no authenticated direct neighbor is available or a relay reaches
-zero neighbors. A successful local message reports how many direct neighbors accepted the first
-relay; it does not claim room-wide delivery. Signed events may arrive over multiple paths, but each
-client displays and forwards one `originPublicKey:eventId` only once while it remains in the bounded
-deduplication window. Pi Chat never claims exactly-once delivery, delivery receipts, or offline retry.
+The composer retains the draft when no authenticated direct neighbor is available or a relay reaches zero neighbors.
+A successful local message reports how many direct neighbors accepted the first relay; it does not claim room-wide delivery.
+Signed events may arrive over multiple paths, but each client displays and forwards one `originPublicKey:eventId` only once while it remains in the bounded deduplication window.
+Pi Chat never claims exactly-once delivery, delivery receipts, or offline retry.
 
 ## 💬 Commands
 
@@ -123,18 +105,18 @@ The display format is:
 nickname~7K2P-9D4M-HQ3T
 ```
 
-The nickname is editable. The 12-character identity tag is the first 60 bits of the SHA-256 digest
-of the authenticated DHT public key, encoded with Crockford Base32 and grouped `4-4-4`. The complete
-public key remains the protocol identity. If short tags collide in one room, the UI can extend them;
+The nickname is editable.
+The 12-character identity tag is the first 60 bits of the SHA-256 digest of the authenticated DHT public key, encoded with Crockford Base32 and grouped `4-4-4`.
+The complete public key remains the protocol identity.
+If short tags collide in one room, the UI can extend them;
 the short tag is never an authorization boundary.
 
-A fingerprint establishes continuity for one pseudonymous key. It does **not** prove a person's
-real-world identity, prevent a user from creating many identities, or recover trust after the local
-identity is reset or lost.
+A fingerprint establishes continuity for one pseudonymous key.
+It does **not** prove a person's real-world identity, prevent a user from creating many identities, or recover trust after the local identity is reset or lost.
 
-Nicknames are NFKC-normalized, trimmed, and limited to 24 grapheme clusters. Terminal, C0/C1, and
-bidirectional control characters are rejected. Remote display text is sanitized again before
-wrapping or rendering.
+Nicknames are NFKC-normalized, trimmed, and limited to 24 grapheme clusters.
+Terminal, C0/C1, and bidirectional control characters are rejected.
+Remote display text is sanitized again before wrapping or rendering.
 
 ## ⚙️ Settings
 
@@ -144,8 +126,8 @@ Pi Chat uses this user-owned file:
 <getAgentDir()>/pi-chat.json
 ```
 
-The usual location is `~/.pi/agent/pi-chat.json`. Pi Chat does not add environment variables or read
-project-local settings because the identity material is user-owned and secret.
+The usual location is `~/.pi/agent/pi-chat.json`.
+Pi Chat does not add environment variables or read project-local settings because the identity material is user-owned and secret.
 
 Example with a remembered public room:
 
@@ -168,9 +150,10 @@ Example with a remembered public room:
 }
 ```
 
-`resume.rooms` is a bounded catalog designed to permit future multi-room expansion. This release
-connects only `activeRoomId`. `surface` is `chat` when the user last kept the composer open and `pi`
-after an intentional return to Pi/LLM. Transcripts, drafts, peers, and unread counts are never stored.
+`resume.rooms` is a bounded catalog designed to permit future multi-room expansion.
+This release connects only `activeRoomId`.
+`surface` is `chat` when the user last kept the composer open and `pi` after an intentional return to Pi/LLM.
+Transcripts, drafts, peers, and unread counts are never stored.
 
 `widgetMode` accepts:
 
@@ -179,26 +162,24 @@ after an intentional return to Pi/LLM. Transcripts, drafts, peers, and unread co
 - `count`: room, direct-peer, and unread status only, without message text.
 - `off`: hides the persistent widget.
 
-New identities choose a mode before confirmation, with **Room dock** listed first. Existing settings
-retain their stored mode; an older document without `widgetMode` continues to default to `count`, so
-an upgrade does not expose message text unexpectedly.
+New identities choose a mode before confirmation, with **Room dock** listed first.
+Existing settings retain their stored mode; an older document without `widgetMode` continues to default to `count`, so an upgrade does not expose message text unexpectedly.
 
-Public rooms are remembered only after their existing risk confirmation. A private room is remembered
-only when **Join and remember** is selected; this stores its bearer invite in `pi-chat.json`.
-**Join once** stores no room material, and Cancel starts neither persistence nor networking. An older
-file without `resume` remains disconnected until the next confirmed remembered join. Stored v1 public
-or private room ids are normalized to v2 in memory without rewriting the file during load; the next
-explicit resume save publishes v2 ids while preserving unknown room and resume fields.
+Public rooms are remembered only after their existing risk confirmation.
+A private room is remembered only when **Join and remember** is selected; this stores its bearer invite in `pi-chat.json`.
+**Join once** stores no room material, and Cancel starts neither persistence nor networking.
+An older file without `resume` remains disconnected until the next confirmed remembered join.
+Stored v1 public or private room ids are normalized to v2 in memory without rewriting the file during load; the next explicit resume save publishes v2 ids while preserving unknown room and resume fields.
 
 The identity seed and stored private invites are redacted from UI, notifications, status, and errors.
-On POSIX, settings are published with `0600` permissions. A missing file is a side-effect-free read;
-it is created only after an explicit first-use confirmation or settings change. Saves are ordered
-within one Pi process, preserve unknown top-level and nested resume fields, and use a same-directory
-temporary file plus rename. Malformed, invalid, symlinked, non-regular, invalid UTF-8, or oversized
-files fail closed and remain unchanged.
+On POSIX, settings are published with `0600` permissions.
+A missing file is a side-effect-free read;
+it is created only after an explicit first-use confirmation or settings change.
+Saves are ordered within one Pi process, preserve unknown top-level and nested resume fields, and use a same-directory temporary file plus rename.
+Malformed, invalid, symlinked, non-regular, invalid UTF-8, or oversized files fail closed and remain unchanged.
 
-**Reset identity** previews the old and candidate fingerprints and requires confirmation. Resetting
-changes your fingerprint everywhere, forgets startup restore, and leaves the active room.
+**Reset identity** previews the old and candidate fingerprints and requires confirmation.
+Resetting changes your fingerprint everywhere, forgets startup restore, and leaves the active room.
 
 ## 🌐 Network and protocol behavior
 
@@ -208,62 +189,56 @@ Pi Chat protocol v2 uses one versioned 32-byte discovery topic per room:
 - A public topic is deterministically derived from the public room slug.
 - A separate global topic carries only bounded public-room directory presence.
 
-Each peer announces and looks up its topics through HyperDHT. Hyperswarm establishes authenticated,
-encrypted Noise streams. The room handshake binds the room proof, nickname, and both neighbor public
-keys. Each client keeps at most **8 direct neighbors** instead of completing a full mesh.
+Each peer announces and looks up its topics through HyperDHT.
+Hyperswarm establishes authenticated, encrypted Noise streams.
+The room handshake binds the room proof, nickname, and both neighbor public keys.
+Each client keeps at most **8 direct neighbors** instead of completing a full mesh.
 
-Chat and presence payloads carry the room id, origin public key, event id, issued time, content, and an
-Ed25519 signature from the origin identity. A mutable hop budget is decremented at each relay. After
-validation, the first copy updates local state and is forwarded to authenticated neighbors other than
-the ingress connection; later copies with the same `originPublicKey:eventId` are dropped. Deduplication,
-rate-limit, participant, and presence state are all bounded and expire locally.
+Chat and presence payloads carry the room id, origin public key, event id, issued time, content, and an Ed25519 signature from the origin identity.
+A mutable hop budget is decremented at each relay.
+After validation, the first copy updates local state and is forwarded to authenticated neighbors other than the ingress connection; later copies with the same `originPublicKey:eventId` are dropped.
+Deduplication, rate-limit, participant, and presence state are all bounded and expire locally.
 
-The active-participant catalog supports up to **256 remote identities** and expires presence that has
-not refreshed for 90 seconds. This is an approximate local view: sparse-overlay partitions, churn,
-clock differences, and Sybil identities can change it. Messages are limited to 4 KiB, protocol frames
-to 16 KiB, gossip to 8 hops, and the local transcript to 256 entries.
+The active-participant catalog supports up to **256 remote identities** and expires presence that has not refreshed for 90 seconds.
+This is an approximate local view: sparse-overlay partitions, churn, clock differences, and Sybil identities can change it.
+Messages are limited to 4 KiB, protocol frames to 16 KiB, gossip to 8 hops, and the local transcript to 256 entries.
 
-Public-room browsing uses signed room-scoped pseudonyms so honest clients do not expose one stable chat
-identity across directory rooms. Directory nodes gossip bounded recent presence and browsers sort
-unique scoped origins by estimated count descending, then slug ascending. Results can be empty,
-stale, or partial; HyperDHT cannot enumerate every unknown topic, so the UI never calls the list or
-count authoritative.
+Public-room browsing uses signed room-scoped pseudonyms so honest clients do not expose one stable chat identity across directory rooms.
+Directory nodes gossip bounded recent presence and browsers sort unique scoped origins by estimated count descending, then slug ascending.
+Results can be empty, stale, or partial; HyperDHT cannot enumerate every unknown topic, so the UI never calls the list or count authoritative.
 
-`pichat:v1` invite text and stored v1 secrets are accepted and mapped to a v2 private room. Newly
-created invites use `pichat:v2`. Protocol-v1 full-mesh clients do not interoperate with the v2 gossip
-overlay.
+`pichat:v1` invite text and stored v1 secrets are accepted and mapped to a v2 private room.
+Newly created invites use `pichat:v2`.
+Protocol-v1 full-mesh clients do not interoperate with the v2 gossip overlay.
 
-Hyperswarm's default DHT depends on public bootstrap infrastructure. “P2P” does not mean
-infrastructure-free. NAT, UDP blocking, enterprise firewalls, bootstrap availability, peer churn, or
-a partitioned sparse overlay can prevent connectivity or delivery. Pi Chat performs bounded refresh
-and reconnect work but cannot promise a connection or room-wide delivery.
+Hyperswarm's default DHT depends on public bootstrap infrastructure. “P2P” does not mean infrastructure-free.
+NAT, UDP blocking, enterprise firewalls, bootstrap availability, peer churn, or a partitioned sparse overlay can prevent connectivity or delivery.
+Pi Chat performs bounded refresh and reconnect work but cannot promise a connection or room-wide delivery.
 
 ## 🔒 Privacy, security, and recovery
 
-- Noise encrypts direct transport, but DHT infrastructure and direct peers may observe IP addresses,
-  timing, and topic participation metadata. Pi Chat does not provide anonymity.
-- Anyone holding a private invite can join. There is no member revocation in the initial protocol;
+- Noise encrypts direct transport, but DHT infrastructure and direct peers may observe IP addresses, timing, and topic participation metadata.
+  Pi Chat does not provide anonymity.
+- Anyone holding a private invite can join.
+  There is no member revocation in the initial protocol;
   create a new room after an invite leak.
-- Public slugs are guessable. Anyone may join, record, or repost public-room content.
-- A local session mute hides one signed origin while still forwarding valid events so a local
-  preference does not partition the room. It does not stop Sybil identities.
-- Remote peers can save or copy messages. Leaving or clearing the local transcript cannot withdraw
-  copies from their devices.
-- Pi Chat never sends cwd, repository data, Git remotes, Pi sessions, prompts, models, files, or agent
-  output unless a user manually types that information into chat.
+- Public slugs are guessable.
+  Anyone may join, record, or repost public-room content.
+- A local session mute hides one signed origin while still forwarding valid events so a local preference does not partition the room.
+  It does not stop Sybil identities.
+- Remote peers can save or copy messages.
+  Leaving or clearing the local transcript cannot withdraw copies from their devices.
+- Pi Chat never sends cwd, repository data, Git remotes, Pi sessions, prompts, models, files, or agent output unless a user manually types that information into chat.
 - Chat messages never call Pi message APIs and never enter model context or the main transcript.
-- Deleting `pi-chat.json` loses identity continuity and produces a new fingerprint on the next
-  confirmed join.
+- Deleting `pi-chat.json` loses identity continuity and produces a new fingerprint on the next confirmed join.
 
-If an ordinary join fails, Pi Chat tears down partially opened discovery and sockets and preserves
-the previous valid settings. If startup restore fails, the remembered room is kept and `/chat` shows
-Retry, Join another room, and Forget recovery actions instead of retrying forever. Invalid settings
-must be fixed manually before a save can proceed.
+If an ordinary join fails, Pi Chat tears down partially opened discovery and sockets and preserves the previous valid settings.
+If startup restore fails, the remembered room is kept and `/chat` shows Retry, Join another room, and Forget recovery actions instead of retrying forever.
+Invalid settings must be fixed manually before a save can proceed.
 
-Reloading, replacing the Pi session, or shutting down still releases every session-owned network and
-UI resource. A new TUI session then restores the remembered room. Explicit **Leave and forget room**
-atomically removes resume state before disconnecting; if that save fails, the room stays connected
-and remembered with an actionable error.
+Reloading, replacing the Pi session, or shutting down still releases every session-owned network and UI resource.
+A new TUI session then restores the remembered room.
+Explicit **Leave and forget room** atomically removes resume state before disconnecting; if that save fails, the room stays connected and remembered with an actionable error.
 
 ## 🚧 Limitations
 
@@ -279,19 +254,18 @@ The current experimental release intentionally omits:
 - more than 256 tracked remote participants or 8 direct neighbors per client;
 - automatic transfer of chat content into the Pi editor, transcript, or model context.
 
-The joined room uses a persistent read-only widget while the normal Pi view is active. Selecting
-**Reply in <room>** temporarily opens the full custom chat view instead of a small floating window.
-Closing it returns to Pi and the dock without leaving the room. The dock and composer reduce message
-rows before hiding room, connectivity, or input-target status.
+The joined room uses a persistent read-only widget while the normal Pi view is active.
+Selecting **Reply in <room>** temporarily opens the full custom chat view instead of a small floating window.
+Closing it returns to Pi and the dock without leaving the room.
+The dock and composer reduce message rows before hiding room, connectivity, or input-target status.
 
-Pi's public extension widget API does not provide generic mouse hit-testing, so the dock is not
-clickable and Pi Chat registers no global shortcut. `/chat` remains the menu-first entrypoint.
+Pi's public extension widget API does not provide generic mouse hit-testing, so the dock is not clickable and Pi Chat registers no global shortcut.
+`/chat` remains the menu-first entrypoint.
 
 ## 🧪 Local network smoke
 
 The normal repository test suite mocks Pi Chat's network transports and does not open DHT sockets.
-Run the opt-in smoke from a local checkout to exercise real local DHT nodes, sparse relay, retries,
-process-boundary discovery and delivery, public-room discovery, and resource cleanup:
+Run the opt-in smoke from a local checkout to exercise real local DHT nodes, sparse relay, retries, process-boundary discovery and delivery, public-room discovery, and resource cleanup:
 
 ```bash
 npm run smoke:chat-network
@@ -332,9 +306,9 @@ packages/pi-chat/
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, peer-to-peer chat, P2P developer chat, Hyperswarm, HyperDHT, terminal
-chat, TypeScript Pi package.
+Pi extension, Pi coding agent, peer-to-peer chat, P2P developer chat, Hyperswarm, HyperDHT, terminal chat, TypeScript Pi package.
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-chat/README.md
+++ b/packages/pi-chat/README.md
@@ -108,8 +108,8 @@ nickname~7K2P-9D4M-HQ3T
 The nickname is editable.
 The 12-character identity tag is the first 60 bits of the SHA-256 digest of the authenticated DHT public key, encoded with Crockford Base32 and grouped `4-4-4`.
 The complete public key remains the protocol identity.
-If short tags collide in one room, the UI can extend them;
-the short tag is never an authorization boundary.
+If short tags collide in one room, the UI can extend them.
+The short tag is never an authorization boundary.
 
 A fingerprint establishes continuity for one pseudonymous key.
 It does **not** prove a person's real-world identity, prevent a user from creating many identities, or recover trust after the local identity is reset or lost.
@@ -173,8 +173,8 @@ Stored v1 public or private room ids are normalized to v2 in memory without rewr
 
 The identity seed and stored private invites are redacted from UI, notifications, status, and errors.
 On POSIX, settings are published with `0600` permissions.
-A missing file is a side-effect-free read;
-it is created only after an explicit first-use confirmation or settings change.
+A missing file is a side-effect-free read.
+It is created only after an explicit first-use confirmation or settings change.
 Saves are ordered within one Pi process, preserve unknown top-level and nested resume fields, and use a same-directory temporary file plus rename.
 Malformed, invalid, symlinked, non-regular, invalid UTF-8, or oversized files fail closed and remain unchanged.
 
@@ -220,8 +220,8 @@ Pi Chat performs bounded refresh and reconnect work but cannot promise a connect
 - Noise encrypts direct transport, but DHT infrastructure and direct peers may observe IP addresses, timing, and topic participation metadata.
   Pi Chat does not provide anonymity.
 - Anyone holding a private invite can join.
-  There is no member revocation in the initial protocol;
-  create a new room after an invite leak.
+  There is no member revocation in the initial protocol.
+  Create a new room after an invite leak.
 - Public slugs are guessable.
   Anyone may join, record, or repost public-room content.
 - A local session mute hides one signed origin while still forwarding valid events so a local preference does not partition the room.

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -1,37 +1,22 @@
-# 🌐 pi-chrome-devtools — Chrome DevTools Tools for Pi Agents
+# 🌐 pi-chrome-devtools — Inspect and Control Chrome from Pi
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-chrome-devtools)](https://www.npmjs.com/package/@narumitw/pi-chrome-devtools) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-chrome-devtools` is a native [Pi coding agent](https://pi.dev) extension that exposes Chrome DevTools Protocol (CDP) automation as Pi tools.
+Let Pi inspect browser tabs, navigate pages, evaluate JavaScript, and capture screenshots through native Chrome DevTools Protocol tools.
 
-Use it to let the Pi agent inspect browser tabs, navigate pages, evaluate JavaScript, and capture screenshots while debugging web apps or validating UI behavior.
+Use it for web debugging, UI validation, and browser-assisted investigation without running an MCP server.
 
-This package is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp), but it is implemented as native Pi tools instead of an MCP server.
+The design is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp), not guaranteed to be compatible with it.
 
 ## ✨ Features
 
-- Lists inspectable Chrome tabs and pages.
-- Selects an active Chrome page for later tool calls.
-- Navigates Chrome to a target URL, creating an inspectable page when none exists.
-- Recovers from stale active page selections by falling back to an available page.
-- Evaluates JavaScript in the selected page.
-- Captures PNG screenshots, including optional full-page screenshots, and saves them to disk.
-- Renders compact tool results that expand/collapse with Pi's default output toggle (`Ctrl+O`).
-- Reuses an existing Chrome DevTools Protocol endpoint when one is already available.
-- Lazily auto-launches a Chromium-family browser for missing local endpoints, with Chrome,
-  Chromium, Brave, and Edge fallbacks.
-- Loads one or more user-approved unpacked extensions into an isolated managed Chrome for Testing
-  or Chromium browser.
-- Uses a dynamic managed DevTools port by default to avoid port conflicts, while preserving
-  explicit endpoint overrides.
-- Retries briefly while Chrome is starting and reports actionable endpoint errors.
-- Shows statusline activity only while Chrome DevTools tools are running.
-- Keeps one loader tool active and exposes matching browser capabilities only when the agent needs them.
-- Provides a state-first `/chrome-devtools` menu for tool availability, editable browser settings,
-  browser status, setup, and help.
-- Stages menu-based availability changes for exact review before one confirmed apply.
-- Uses `@narumitw/pi-tui-kit` for width-safe TUI menus and equivalent RPC dialogs.
-- Persists the Chrome DevTools lazy-load catalog across Pi restarts.
+- Lists and selects inspectable pages, navigates URLs, evaluates JavaScript, and captures PNG screenshots.
+- Reuses an existing CDP endpoint or lazily launches an isolated Chromium-family browser.
+- Recovers from stale page selections and reports actionable browser startup or endpoint errors.
+- Loads explicitly approved unpacked extensions only in an extension-owned Chrome for Testing or Chromium process.
+- Keeps browser tools lazy and exposes availability, setup, status, and help through `/chrome-devtools`.
+- Shows compact expandable results and activity only while browser tools are running.
+- Persists reviewed tool availability while keeping browser connection settings machine-owned.
 
 ## 📦 Install
 
@@ -56,13 +41,17 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
 
 ## 🚀 Quick start
 
-Without unpacked extensions, the extension first tries `browser.endpoint`, defaulting to
-`http://127.0.0.1:9222`. If that local endpoint is unavailable and `browser.autoLaunch` is `true`, it
-lazily launches an extension-owned Chromium-family browser with an isolated temp profile and retries
-the CDP request. Existing endpoints are reused and are never terminated by the extension.
+Start Pi and ask the agent to load the Chrome DevTools capability needed for the task.
+The extension first tries `http://127.0.0.1:9222` and otherwise launches an isolated local Chromium-family browser by default.
+Run `/chrome-devtools` to review browser status, settings, help, and available tools.
 
-Configure the canonical user file at
-`${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json`:
+## 🌐 Browser setup
+
+Without unpacked extensions, the extension first tries `browser.endpoint`, defaulting to `http://127.0.0.1:9222`.
+If that endpoint is unavailable and `browser.autoLaunch` is `true`, it lazily launches an extension-owned browser with an isolated temporary profile and retries the CDP request.
+Existing endpoints are reused and never terminated by the extension.
+
+Configure the canonical user file at `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json`:
 
 ```json
 {
@@ -74,21 +63,21 @@ Configure the canonical user file at
 }
 ```
 
-`browser.endpoint` must be an HTTP origin with an explicit port and no credentials, path, query, or
-fragment. Omitting it keeps attach-first behavior on `127.0.0.1:9222` and lets a managed launch use
-Chrome's dynamic DevTools port mode (`--remote-debugging-port=0`). Explicitly saving an endpoint pins
-managed launches to that port. `browser.autoLaunch` defaults to `true`. `browser.executablePath` is
-optional and must be an absolute path; when absent, normal browser discovery applies.
+`browser.endpoint` must be an HTTP origin with an explicit port and no credentials, path, query, or fragment.
+Omitting it keeps attach-first behavior on `127.0.0.1:9222` and lets a managed launch use Chrome's dynamic DevTools port mode (`--remote-debugging-port=0`).
+Explicitly saving an endpoint pins managed launches to that port.
+`browser.autoLaunch` defaults to `true`.
+`browser.executablePath` is optional and must be an absolute path; when absent, normal browser discovery applies.
 
-The configured endpoint must expose the standard CDP HTTP discovery routes such as `/json/version`
-and `/json/list`. Chrome's newer built-in permission flow can listen on port `9222` while returning
-`404` from those routes; setting the same HTTP origin does not by itself make that flow compatible.
+The configured endpoint must expose the standard CDP HTTP discovery routes such as `/json/version` and `/json/list`.
+Chrome's newer built-in permission flow can listen on port `9222` while returning `404` from those routes; setting the same HTTP origin does not by itself make that flow compatible.
 
 ### Unpacked extensions
 
 > [!WARNING]
-> An unpacked extension executes privileged browser code. Load only code you trust. Project settings
-> are honored only when Pi reports the project as trusted.
+> An unpacked extension executes privileged browser code.
+> Load only code you trust.
+> Project settings are honored only when Pi reports the project as trusted.
 
 Add trusted unpacked-extension paths to the same canonical user file:
 
@@ -104,14 +93,13 @@ Add trusted unpacked-extension paths to the same canonical user file:
 }
 ```
 
-Every user-file path must be absolute. Each extension path must resolve to a directory containing a
-valid `manifest.json` and cannot contain a comma because Chrome uses commas to separate multiple
-startup paths. For extension-configured sessions, `executablePath` must identify Chrome for
-Testing or Chromium. Branded Google Chrome is rejected because tested releases can silently ignore
-unpacked-extension startup flags.
+Every user-file path must be absolute.
+Each extension path must resolve to a directory containing a valid `manifest.json` and cannot contain a comma because Chrome uses commas to separate multiple startup paths.
+For extension-configured sessions, `executablePath` must identify Chrome for Testing or Chromium.
+Branded Google Chrome is rejected because tested releases can silently ignore unpacked-extension startup flags.
 
-A trusted project can replace the user extension list in
-`<workspace>/.pi/pi-chrome-devtools.json`. Relative paths resolve from the workspace (`ctx.cwd`):
+A trusted project can replace the user extension list in `<workspace>/.pi/pi-chrome-devtools.json`.
+Relative paths resolve from the workspace (`ctx.cwd`):
 
 ```json
 {
@@ -121,41 +109,35 @@ A trusted project can replace the user extension list in
 }
 ```
 
-Project `extensionPaths` replace, rather than append to, the user array. A project file cannot
-override `browser.endpoint`, `browser.autoLaunch`, or `browser.executablePath`; browser connection
-settings remain machine-owned user configuration. Effective precedence is defaults, user settings,
-trusted project extension paths, then deprecated environment overrides. No new environment variable
-is required.
+Project `extensionPaths` replace, rather than append to, the user array.
+A project file cannot override `browser.endpoint`, `browser.autoLaunch`, or `browser.executablePath`; browser connection settings remain machine-owned user configuration.
+Effective precedence is defaults, user settings, trusted project extension paths, then deprecated environment overrides.
+No new environment variable is required.
 
-When `extensionPaths` is non-empty, the extension skips attach-first behavior and starts an isolated,
-extension-owned managed browser with `--disable-extensions-except` and `--load-extension`. It fails
-before spawning when the endpoint is remote, auto-launch is disabled, an explicit port is occupied,
-the executable is missing, or the browser product is unsupported. It never adds extensions to,
-modifies, restarts, or closes an external browser.
+When `extensionPaths` is non-empty, the extension skips attach-first behavior and starts an isolated, extension-owned managed browser with `--disable-extensions-except` and `--load-extension`.
+It fails before spawning when the endpoint is remote, auto-launch is disabled, an explicit port is occupied, the executable is missing, or the browser product is unsupported.
+It never adds extensions to, modifies, restarts, or closes an external browser.
 
-Settings are loaded on session start. After editing JSON, use `/reload` or replace the session; the
-old managed browser is closed before the new configuration is applied. Missing files preserve the
-existing no-extension behavior. Invalid JSON, invalid browser values, and missing manifests are left
-unchanged and ignored with an actionable warning.
+Settings are loaded on session start.
+After editing JSON, use `/reload` or replace the session; the old managed browser is closed before the new configuration is applied.
+Missing files preserve the existing no-extension behavior.
+Invalid JSON, invalid browser values, and missing manifests are left unchanged and ignored with an actionable warning.
 
 ### Deprecated environment overrides and manual endpoints
 
-The existing `PI_CHROME_DEVTOOLS_HOST`, `PI_CHROME_DEVTOOLS_PORT`,
-`PI_CHROME_DEVTOOLS_AUTO_LAUNCH`, and `PI_CHROME_DEVTOOLS_BROWSER` variables remain temporary
-compatibility overrides. They still take precedence over JSON, but every session that sees one emits
-a deprecation warning. Move their values to `browser.endpoint`, `browser.autoLaunch`, and
-`browser.executablePath`; the variables will be removed in a future version.
+The existing `PI_CHROME_DEVTOOLS_HOST`, `PI_CHROME_DEVTOOLS_PORT`, `PI_CHROME_DEVTOOLS_AUTO_LAUNCH`, and `PI_CHROME_DEVTOOLS_BROWSER` variables remain temporary compatibility overrides.
+They still take precedence over JSON, but every session that sees one emits a deprecation warning.
+Move their values to `browser.endpoint`, `browser.autoLaunch`, and `browser.executablePath`; the variables will be removed in a future version.
 
-Without unpacked extensions, browser discovery still checks platform-specific Chrome, Chromium,
-Brave, and Microsoft Edge candidates. Manual launch remains available when no unpacked extensions are
-configured:
+Without unpacked extensions, browser discovery still checks platform-specific Chrome, Chromium, Brave, and Microsoft Edge candidates.
+Manual launch remains available when no unpacked extensions are configured:
 
 ```bash
 google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/pi-chrome-devtools
 ```
 
-On session shutdown, the extension terminates only browser processes it started and best-effort
-removes their temporary profiles. It never closes user-started browsers or remote endpoints.
+On session shutdown, the extension terminates only browser processes it started and best-effort removes their temporary profiles.
+It never closes user-started browsers or remote endpoints.
 
 ## 🛠️ Tools
 
@@ -186,8 +168,8 @@ An empty array leaves the loader active but makes every browser capability unava
 
 ### Screenshot files
 
-`chrome_devtools_screenshot` always saves the captured PNG to disk. If `savePath` is omitted,
-the extension writes a unique temp file such as:
+`chrome_devtools_screenshot` always saves the captured PNG to disk.
+If `savePath` is omitted, the extension writes a unique temp file such as:
 
 ```text
 /tmp/pi-chrome-devtools-screenshot-<uuid>.png
@@ -202,14 +184,13 @@ chrome_devtools_screenshot({
 });
 ```
 
-Relative `savePath` values resolve from Pi's current working directory. A single leading `@`
-is stripped to match Pi file-mention paths. Absolute paths are accepted only when they stay
-inside the current working directory or the OS temp directory. Paths containing `..` segments,
-NUL bytes, symlinked parent directories, directories as targets, final symbolic-link targets, or
-other non-regular file targets are rejected. Existing regular files at the target path are
-replaced. The tool result includes the resolved path, byte count, and an inline image block when
-the active model/provider can consume images. If the model cannot inspect the inline image, ask it
-to read the saved path, for example `read({ path: "artifacts/homepage.png" })`.
+Relative `savePath` values resolve from Pi's current working directory.
+A single leading `@` is stripped to match Pi file-mention paths.
+Absolute paths are accepted only when they stay inside the current working directory or the OS temp directory.
+Paths containing `..` segments, NUL bytes, symlinked parent directories, directories as targets, final symbolic-link targets, or other non-regular file targets are rejected.
+Existing regular files at the target path are replaced.
+The tool result includes the resolved path, byte count, and an inline image block when the active model/provider can consume images.
+If the model cannot inspect the inline image, ask it to read the saved path, for example `read({ path: "artifacts/homepage.png" })`.
 
 ## 💬 Commands
 
@@ -217,28 +198,21 @@ to read the saved path, for example `read({ path: "artifacts/homepage.png" })`.
 /chrome-devtools
 ```
 
-Opens a menu that shows the lazy catalog size, whether that catalog is saved, the configured
-endpoint, the observed managed-browser state, and any settings or launch warning before you choose
-an action. The five actions stay on one level:
+Opens a menu that shows the lazy catalog size, whether that catalog is saved, the configured endpoint, the observed managed-browser state, and any settings or launch warning before you choose an action.
+The five actions stay on one level:
 
-- **Choose available browser tools…** — stage any combination of the five capabilities, then review
-  the exact available/unavailable result before selecting **Apply tool changes**.
-- **Make all browser tools available…** or **Make all browser tools unavailable…** — preview the
-  context-appropriate bulk change before applying it.
-- **Browser status** — inspect runtime, endpoint, launch mode, and the last launch attempt without
-  probing the endpoint or starting Chrome.
+- **Choose available browser tools…** — stage any combination of the five capabilities, then review the exact available/unavailable result before selecting **Apply tool changes**.
+- **Make all browser tools available…** or **Make all browser tools unavailable…** — preview the context-appropriate bulk change before applying it.
+- **Browser status** — inspect runtime, endpoint, launch mode, and the last launch attempt without probing the endpoint or starting Chrome.
 - **Browser settings** — immediately save the endpoint, auto-launch policy, or browser executable;
-  inspect unpacked-extension paths and effective sources. A deprecated environment override remains
-  effective until removed even when its underlying JSON value changes.
+inspect unpacked-extension paths and effective sources.
+A deprecated environment override remains effective until removed even when its underlying JSON value changes.
 - **Help** — view command usage and return to the menu.
 
-In the tool screen, **Select all** and **Select none** are unambiguous shortcuts; individual rows use
-friendly task labels while retaining their raw `chrome_devtools_*` identity in the description.
-Toggles remain a command-local draft. **Review changes** previews the exact effect, **Apply tool
-changes** saves it, and Cancel, Escape, Ctrl+C, disposal, or session replacement discards an
-unconfirmed draft without changing runtime tools or settings. A failed apply restores the previous
-availability and loaded-tool state, preserves the settings file, retains the draft for retry, and
-reports how to recover.
+In the tool screen, **Select all** and **Select none** are unambiguous shortcuts; individual rows use friendly task labels while retaining their raw `chrome_devtools_*` identity in the description.
+Toggles remain a command-local draft.
+**Review changes** previews the exact effect, **Apply tool changes** saves it, and Cancel, Escape, Ctrl+C, disposal, or session replacement discards an unconfirmed draft without changing runtime tools or settings.
+A failed apply restores the previous availability and loaded-tool state, preserves the settings file, retains the draft for retry, and reports how to recover.
 
 Direct subcommands are also available:
 
@@ -253,28 +227,22 @@ Direct subcommands are also available:
 /chrome-devtools disable
 ```
 
-Compatibility aliases remain available: `toggle` and `select` mean `tools`, `on` means `enable`, and
-`off` means `disable`.
+Compatibility aliases remain available: `toggle` and `select` mean `tools`, `on` means `enable`, and `off` means `disable`.
 
 - `help` shows command usage.
-- `quickstart` shows the configured CDP endpoint, endpoint source, auto-launch mode, browser
-  candidates, last launch attempt, and launch hints.
-- `status` shows available and loaded capability counts, loader state, the persisted catalog,
-  settings file path, endpoint source, launch mode, last launch attempt, and active non-Chrome tool
-  count.
+- `quickstart` shows the configured CDP endpoint, endpoint source, auto-launch mode, browser candidates, last launch attempt, and launch hints.
+- `status` shows available and loaded capability counts, loader state, the persisted catalog, settings file path, endpoint source, launch mode, last launch attempt, and active non-Chrome tool count.
 - `settings` opens the same immediate-save browser settings flow used by the menu.
 - `tools` opens the same staged, width-safe availability and review flow used by the menu.
 - `toggle` and `select` are compatibility aliases for `tools`.
-- `enable` makes all five capability tools available to the loader and saves that catalog; `on` is a
-  compatibility alias.
-- `disable` makes all five capability tools unavailable and saves the empty catalog; `off` is a
-  compatibility alias. The slash command and `chrome_devtools_load` remain available.
+- `enable` makes all five capability tools available to the loader and saves that catalog; `on` is a compatibility alias.
+- `disable` makes all five capability tools unavailable and saves the empty catalog; `off` is a compatibility alias.
+  The slash command and `chrome_devtools_load` remain available.
 
-The menu, `settings`, `tools`, `help`, `quickstart`, and `status` require TUI or RPC mode so their
-result is observable. TUI uses keyboard navigation and injected Pi keybindings; RPC receives
-equivalent standard dialogs. In print and JSON modes, interactive and informational routes reject
-explicitly instead of silently opening unavailable UI. The immediate `enable`/`disable` routes remain
-available for deterministic non-interactive use.
+The menu, `settings`, `tools`, `help`, `quickstart`, and `status` require TUI or RPC mode so their result is observable.
+TUI uses keyboard navigation and injected Pi keybindings; RPC receives equivalent standard dialogs.
+In print and JSON modes, interactive and informational routes reject explicitly instead of silently opening unavailable UI.
+The immediate `enable`/`disable` routes remain available for deterministic non-interactive use.
 
 ## ⚙️ Settings
 
@@ -284,25 +252,22 @@ The available capability names are saved to:
 ${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json
 ```
 
-The same file owns `browser.endpoint`, `browser.autoLaunch`, `browser.executablePath`, and
-`browser.extensionPaths`. Browser connection fields are machine-owned user settings; trusted project
-files may replace only `browser.extensionPaths`. Confirmed menu changes apply before the next browser
-connection and close only an extension-owned managed browser. Manual JSON edits and unpacked-extension
-changes apply after `/reload` or session replacement.
+The same file owns `browser.endpoint`, `browser.autoLaunch`, `browser.executablePath`, and `browser.extensionPaths`.
+Browser connection fields are machine-owned user settings; trusted project files may replace only `browser.extensionPaths`.
+Confirmed menu changes apply before the next browser connection and close only an extension-owned managed browser.
+Manual JSON edits and unpacked-extension changes apply after `/reload` or session replacement.
 
-When the file is missing or invalid, the extension preserves Pi's current Chrome DevTools
-availability policy instead of replacing it. A valid saved catalog is restored on Pi startup and
-`/reload`, while its capability definitions remain deferred. A missing file is created by the first
-confirmed browser or tool setting. Within one Pi process, all browser and tool saves run in invocation
-order, reread the latest valid document, publish by temporary-file rename, and preserve unknown
-fields. Malformed JSON or invalid recognized fields make menu mutation unavailable and block direct
-saves without replacement; a failed save restores the prior displayed and effective state.
+When the file is missing or invalid, the extension preserves Pi's current Chrome DevTools availability policy instead of replacing it.
+A valid saved catalog is restored on Pi startup and `/reload`, while its capability definitions remain deferred.
+A missing file is created by the first confirmed browser or tool setting.
+Within one Pi process, all browser and tool saves run in invocation order, reread the latest valid document, publish by temporary-file rename, and preserve unknown fields.
+Malformed JSON or invalid recognized fields make menu mutation unavailable and block direct saves without replacement; a failed save restores the prior displayed and effective state.
 
-Compatibility: older versions used `pi-chrome-devtools-settings.json`. A legacy-only file remains
-readable with a warning and is never modified automatically; rename it to
-`pi-chrome-devtools.json`. The first subsequent settings save writes the canonical file. If both
-files exist, `pi-chrome-devtools.json` wins and the legacy file is ignored. The legacy
-filename is deprecated and will be removed in a future major release.
+Compatibility: older versions used `pi-chrome-devtools-settings.json`.
+A legacy-only file remains readable with a warning and is never modified automatically; rename it to `pi-chrome-devtools.json`.
+The first subsequent settings save writes the canonical file.
+If both files exist, `pi-chrome-devtools.json` wins and the legacy file is ignored.
+The legacy filename is deprecated and will be removed in a future major release.
 
 ## 🧠 Use cases
 
@@ -330,7 +295,8 @@ packages/pi-chrome-devtools/
 └── package.json
 ```
 
-`index.ts` is the Pi entrypoint and forwards to `chrome-devtools.ts`; the other source modules are internal. The package exposes its Pi extension through `package.json`:
+`index.ts` is the Pi entrypoint and forwards to `chrome-devtools.ts`; the other source modules are internal.
+The package exposes its Pi extension through `package.json`:
 
 ```json
 {
@@ -348,4 +314,5 @@ Pi extension, Pi coding agent, Chrome DevTools Protocol, CDP, browser automation
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -204,8 +204,8 @@ The five actions stay on one level:
 - **Choose available browser tools…** — stage any combination of the five capabilities, then review the exact available/unavailable result before selecting **Apply tool changes**.
 - **Make all browser tools available…** or **Make all browser tools unavailable…** — preview the context-appropriate bulk change before applying it.
 - **Browser status** — inspect runtime, endpoint, launch mode, and the last launch attempt without probing the endpoint or starting Chrome.
-- **Browser settings** — immediately save the endpoint, auto-launch policy, or browser executable;
-inspect unpacked-extension paths and effective sources.
+- **Browser settings** — immediately save the endpoint, auto-launch policy, or browser executable.
+  Inspect unpacked-extension paths and effective sources.
 A deprecated environment override remains effective until removed even when its underlying JSON value changes.
 - **Help** — view command usage and return to the menu.
 

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -1,30 +1,22 @@
-# 🗜️ pi-codex-compact — Remote Compaction V2 for Pi
+# 🗜️ pi-codex-compact — Use Codex Remote Compaction in Pi
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-codex-compact)](https://www.npmjs.com/package/@narumitw/pi-codex-compact) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-codex-compact` adds Codex Remote Compaction V2 to the
-[Pi Coding Agent](https://pi.dev) for the built-in `openai-codex` OAuth provider. It replaces Pi's
-plaintext summary-generation call with a server-generated opaque compaction item and safely replays
-that item in later OpenAI Codex Responses requests.
+Use OpenAI Codex Remote Compaction V2 in Pi instead of generating a local plaintext summary for compatible `openai-codex` sessions.
 
-Pi remains responsible for deciding when compaction runs, including automatic thresholds, the
-built-in `/compact` command, overflow retries, retained-message selection, and append-only session
-publication. This package owns only the Remote V2 request, checkpoint persistence, and later payload
-replay.
+The extension requests and stores an opaque server-generated checkpoint, then safely replays it in later Codex Responses requests.
+
+Pi still decides when compaction runs and retains its normal `/compact`, threshold, overflow, and session-publication behavior.
 
 ## ✨ Features
 
 - Uses the active `openai-codex` OAuth credentials without persisting tokens or request headers.
-- Handles Pi's manual, threshold, and overflow compaction reasons through the same lifecycle hook.
-- Validates one bounded opaque `compaction` item from a completed Responses SSE stream.
-- Persists a versioned checkpoint in `CompactionEntry.details` and restores it after reload, resume,
-  or a fork that retains the checkpoint.
-- Replays the newest compatible checkpoint while preserving later conversation and extension-added
-  context.
-- Supports repeated compaction by carrying the previous opaque item into the next Remote V2 request.
-- Falls back to Pi's native plaintext compaction after authentication, transport, protocol, or
-  validation failure; user cancellation does not launch the fallback.
-- Provides `/codex-compact` for manual compaction, effective-route visibility, and bounded settings.
+- Handles manual, threshold, and overflow compaction through Pi's existing lifecycle.
+- Validates and persists one bounded opaque checkpoint that survives compatible reloads, resumes, and forks.
+- Replays the latest checkpoint while preserving newer conversation and extension context.
+- Supports repeated compaction by carrying the previous checkpoint into the next request.
+- Falls back to Pi's native plaintext compaction on non-cancellation failures.
+- Provides `/codex-compact` for route status, settings, and manual compaction.
 
 ## 📦 Install
 
@@ -46,14 +38,15 @@ Try a local checkout from the repository root:
 pi -e ./packages/pi-codex-compact
 ```
 
-Loading the package enables Remote V2 with safe defaults. Avoid loading a global npm installation
-and the local workspace at the same time.
+Loading the package enables Remote V2 with safe defaults.
+Avoid loading a global npm installation and the local workspace at the same time.
 
 ## 🚀 Quick start
 
 1. Sign in through Pi's built-in OpenAI Codex OAuth provider.
 2. Select a model whose provider is `openai-codex` and API is `openai-codex-responses`.
-3. Work normally. Pi's automatic compaction and built-in `/compact` continue to operate.
+3. Work normally.
+   Pi's automatic compaction and built-in `/compact` continue to operate.
 4. Run `/codex-compact` to inspect the effective route or choose **Compact now**.
 5. After compaction, continue the session normally; compatible requests replay the opaque checkpoint.
 
@@ -65,8 +58,8 @@ When the active model is unsupported, compaction remains entirely Pi-native.
 /codex-compact
 ```
 
-In TUI mode, the root menu shows whether Remote V2 is enabled, the active model, and whether a
-manual compact will use **Codex Remote V2** or **Pi native**. It contains:
+In TUI mode, the root menu shows whether Remote V2 is enabled, the active model, and whether a manual compact will use **Codex Remote V2** or **Pi native**.
+It contains:
 
 ```text
 Compact now
@@ -74,13 +67,12 @@ Settings
 Close
 ```
 
-**Compact now** closes the menu before asking Pi to compact the active session. Escape or Ctrl+C
-closes without compacting, and an obsolete menu cannot trigger work after session replacement or
-shutdown. **Settings** opens the bounded settings editor. In non-TUI modes, the command reports the
-manual settings path instead of opening custom UI or compacting.
+**Compact now** closes the menu before asking Pi to compact the active session.
+Escape or Ctrl+C closes without compacting, and an obsolete menu cannot trigger work after session replacement or shutdown.
+**Settings** opens the bounded settings editor.
+In non-TUI modes, the command reports the manual settings path instead of opening custom UI or compacting.
 
-Pi's built-in `/compact` remains available and follows the same extension hook when the active model
-is compatible.
+Pi's built-in `/compact` remains available and follows the same extension hook when the active model is compatible.
 
 ## ⚙️ Settings
 
@@ -90,8 +82,8 @@ The extension has one optional, global-only JSON settings file:
 <getAgentDir()>/pi-codex-compact.json
 ```
 
-The normal path is `~/.pi/agent/pi-codex-compact.json`. There is no environment-variable or
-project-level override.
+The normal path is `~/.pi/agent/pi-codex-compact.json`.
+There is no environment-variable or project-level override.
 
 ```json
 {
@@ -111,15 +103,14 @@ project-level override.
 | `replacementTokenBudget` | `64000` | Integer from 8,000 to 128,000 tokens | Bound approximate retained user-message text beside the opaque item. | Keep 64K; lower it to reduce session size or raise it only when recent user context is being lost. |
 | `notifyOnFallback` | `true` | Boolean | Warn when Remote V2 fails and Pi-native compaction takes over. | Keep enabled so silent fallback does not hide protocol or entitlement problems. |
 
-Missing fields use defaults. Settings reload on every `session_start`, including `/reload`, resume,
-and fork. Menu writes apply immediately, preserve unknown JSON fields, serialize within the current
-Pi process, and use a final conflict check plus same-directory atomic rename. On Unix, temporary
-files use mode `0600`.
+Missing fields use defaults.
+Settings reload on every `session_start`, including `/reload`, resume, and fork.
+Menu writes apply immediately, preserve unknown JSON fields, serialize within the current Pi process, and use a final conflict check plus same-directory atomic rename.
+On Unix, temporary files use mode `0600`.
 
-Malformed, invalid, oversized, or symlinked settings files are never overwritten. Safe defaults stay
-active, and the menu provides read-only repair guidance until the file is fixed and Pi is reloaded.
-Separate Pi processes do not share a mutation lock; a detected concurrent edit is rejected so the
-user can reopen Settings and retry.
+Malformed, invalid, oversized, or symlinked settings files are never overwritten.
+Safe defaults stay active, and the menu provides read-only repair guidance until the file is fixed and Pi is reloaded.
+Separate Pi processes do not share a mutation lock; a detected concurrent edit is rejected so the user can reopen Settings and retry.
 
 ### Relationship to Codex configuration
 
@@ -140,35 +131,27 @@ This extension does **not** read `~/.codex/config.toml`.
 - API `openai-codex-responses` on the active model.
 - A working OpenAI Codex OAuth login and Remote V2 entitlement.
 
-OpenAI API-key, Azure, GitHub Copilot, proxies, and arbitrary Responses-compatible providers are not
-supported. Switching to another provider or model leaves Pi's visible fallback marker plus retained
-recent messages in context. Switching back to the checkpoint's original compatible model restores
-opaque replay.
+OpenAI API-key, Azure, GitHub Copilot, proxies, and arbitrary Responses-compatible providers are not supported.
+Switching to another provider or model leaves Pi's visible fallback marker plus retained recent messages in context.
+Switching back to the checkpoint's original compatible model restores opaque replay.
 
 ## 🔄 How it works
 
 1. Pi prepares compaction and selects the recent message suffix it will retain.
-2. The extension projects an earlier compatible checkpoint, if present, into the current Responses
-   input.
-3. It appends exactly one final `compaction_trigger` and sends a normal authenticated Codex Responses
-   SSE request with cache retention disabled.
+2. The extension projects an earlier compatible checkpoint, if present, into the current Responses input.
+3. It appends exactly one final `compaction_trigger` and sends a normal authenticated Codex Responses SSE request with cache retention disabled.
 4. It requires a completed response containing exactly one non-empty opaque `compaction` item.
-5. It constructs bounded replacement history from recent raw user-role Responses items followed by
-   the opaque item.
-6. It stores that history and fingerprints of Pi's retained suffix in versioned
-   `CompactionEntry.details`.
-7. On later compatible requests, it replaces an exactly validated marker with the persisted
-   replacement history immediately before provider dispatch.
+5. It constructs bounded replacement history from recent raw user-role Responses items followed by the opaque item.
+6. It stores that history and fingerprints of Pi's retained suffix in versioned `CompactionEntry.details`.
+7. On later compatible requests, it replaces an exactly validated marker with the persisted replacement history immediately before provider dispatch.
 
-If fingerprints, model identity, payload shape, or marker count do not match exactly, the extension
-leaves Pi's visible fallback context unchanged instead of guessing.
+If fingerprints, model identity, payload shape, or marker count do not match exactly, the extension leaves Pi's visible fallback context unchanged instead of guessing.
 
-## 🔐 Privacy, storage, and limits
+## 🔒 Security and privacy
 
-Remote compaction sends the active conversation context, system prompt, and active tool schemas to
-the same OpenAI Codex backend used by the selected model. The Pi session stores the encrypted
-compaction item and bounded recent user-role Responses items. It does not store OAuth tokens,
-authorization headers, or request headers in checkpoint details.
+Remote compaction sends the active conversation context, system prompt, and active tool schemas to the same OpenAI Codex backend used by the selected model.
+The Pi session stores the encrypted compaction item and bounded recent user-role Responses items.
+It does not store OAuth tokens, authorization headers, or request headers in checkpoint details.
 
 | Boundary | Limit |
 | --- | ---: |
@@ -180,22 +163,19 @@ authorization headers, or request headers in checkpoint details.
 | Transport retries | At most 2 |
 | Request timeout | At most 10 minutes |
 
-An individually oversized media item is dropped rather than making the session entry unbounded. The
-oldest fitting text item may be partially truncated to preserve newer context. These hard byte
-ceilings are intentionally not configurable.
+An individually oversized media item is dropped rather than making the session entry unbounded.
+The oldest fitting text item may be partially truncated to preserve newer context.
+These hard byte ceilings are intentionally not configurable.
 
 ## 🚧 Limitations
 
-- The wire contract is undocumented and can change independently of Pi or this package. Keep
-  backups of important sessions.
-- Full older history depends on this extension and the same compatible model. Removing the extension
-  exposes only the portability fallback marker and Pi-retained recent messages.
-- The package does not reproduce Codex core's context-window UUID/number lineage, previous-model
-  compatibility fallback, exact pre-turn ordering, or exact mid-turn model-session ownership.
-- Remote failure falls back to Pi's plaintext summary, so a session can contain both remote opaque
-  and native compaction entries over time.
-- Settings concurrency is coordinated only within one Pi process; separate processes rely on the
-  final conflict check.
+- The wire contract is undocumented and can change independently of Pi or this package.
+  Keep backups of important sessions.
+- Full older history depends on this extension and the same compatible model.
+  Removing the extension exposes only the portability fallback marker and Pi-retained recent messages.
+- The package does not reproduce Codex core's context-window UUID/number lineage, previous-model compatibility fallback, exact pre-turn ordering, or exact mid-turn model-session ownership.
+- Remote failure falls back to Pi's plaintext summary, so a session can contain both remote opaque and native compaction entries over time.
+- Settings concurrency is coordinated only within one Pi process; separate processes rely on the final conflict check.
 
 ## 🗂️ Package layout
 
@@ -214,18 +194,13 @@ test/                 Protocol, checkpoint, lifecycle, remote, settings, and men
 
 ## 📊 Benchmark
 
-The repository includes a seeded three-arm benchmark for uncompressed full context, Pi-native
-plaintext compaction, and this extension's Codex Remote Compaction V2 path.
+The repository includes a seeded three-arm benchmark for uncompressed full context, Pi-native plaintext compaction, and this extension's Codex Remote Compaction V2 path.
 
-It holds history length nearly fixed while varying information density across five state categories
-and ten history epochs.
+It holds history length nearly fixed while varying information density across five state categories and ten history epochs.
 
-Benchmark v3 uses repeated artifacts, isolated evaluator probes, seed-level paired statistics, one Pi
-SDK estimator for dry and live fixtures, and committed protocol manifests for confirmatory
-candidates.
+Benchmark v3 uses repeated artifacts, isolated evaluator probes, seed-level paired statistics, one Pi SDK estimator for dry and live fixtures, and committed protocol manifests for confirmatory candidates.
 
-It never treats nominal Pi 20K and Codex 20K settings as equal information capacity or automatically
-claims that protocol-conformant evidence was genuinely held out.
+It never treats nominal Pi 20K and Codex 20K settings as equal information capacity or automatically claims that protocol-conformant evidence was genuinely held out.
 
 Preview its exploratory diagnostic without making a provider request:
 
@@ -233,15 +208,11 @@ Preview its exploratory diagnostic without making a provider request:
 just benchmark-codex-compact
 ```
 
-A live run requires an explicit `--live` flag, reviewed request and cost exposure, OpenAI Codex OAuth,
-and Remote V2 entitlement.
+A live run requires an explicit `--live` flag, reviewed request and cost exposure, OpenAI Codex OAuth, and Remote V2 entitlement.
 
-The repository preserves the explicitly labeled v2 matched-tail diagnostic and the v3 calibration
-evidence, while seeds 301–304 remain consumed and unavailable for future confirmatory protocols.
+The repository preserves the explicitly labeled v2 matched-tail diagnostic and the v3 calibration evidence, while seeds 301–304 remain consumed and unavailable for future confirmatory protocols.
 
-See the
-[benchmark guide](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-codex-compact/benchmark)
-for manifests, repetitions, commands, privacy, cost semantics, and interpretation limits.
+See the [benchmark guide](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-codex-compact/benchmark) for manifests, repetitions, commands, privacy, cost semantics, and interpretation limits.
 
 ## 🧪 Development
 
@@ -253,14 +224,11 @@ npm test
 just pack codex-compact
 ```
 
-See
-[`docs/implementation-notes/codex-compaction-mechanism.md`](../../docs/implementation-notes/codex-compaction-mechanism.md)
-for the underlying Codex mechanism research and the extension boundary.
+See [`docs/implementation-notes/codex-compaction-mechanism.md`](../../docs/implementation-notes/codex-compaction-mechanism.md) for the underlying Codex mechanism research and the extension boundary.
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, OpenAI Codex, OAuth, Remote Compaction V2, opaque checkpoint,
-Responses API, context compaction.
+Pi extension, Pi coding agent, OpenAI Codex, OAuth, Remote Compaction V2, opaque checkpoint, Responses API, context compaction.
 
 ## 📄 License
 

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -1,25 +1,23 @@
-# 🗂️ pi-file-context
+# 🗂️ pi-file-context — Browse and Attach Exact File Context
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-file-context)](https://www.npmjs.com/package/@narumitw/pi-file-context)
 [![Pi Extension](https://img.shields.io/badge/Pi-extension-blue)](https://github.com/earendil-works/pi)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 > [!WARNING]
-> This extension is experimental. Its interaction model and package API may change between releases.
+> This extension is experimental.
+> Its interaction model and package API may change between releases.
 
-Browse project files inside Pi, select exact snapshots, and review the context queued for the next prompt.
+Browse project files inside Pi, select exact lines or Git changes, and review every snapshot before it is attached to the next prompt.
 
 ## ✨ Features
 
-- Opens the file explorer directly with a configurable shortcut that defaults to `F8`.
-- Provides a `/file-context` menu for adding context snippets, reviewing exact selected snapshots before removal, and opening help without replacing Pi's normal editor.
-- Fuzzy-searches project file names with typo tolerance and relevance ranking, preserves normal whole-file `@path` references, and previews bounded text files with line numbers.
-- Switches with `Ctrl+F` to cancellable cwd content search with highlighted result cards, literal case-insensitive matching by default, and visible case-sensitive and fuzzy toggles.
-- Shows textual staged, unstaged, untracked, ignored, and conflict status plus branch, HEAD, and dirty state when Git is available.
-- Selects a contiguous line range or changed hunk without using the system clipboard and shows a deterministic token estimate before attachment.
-- Discloses current-line blame and bounded file history, opens a validated commit/branch/tag version, and attaches explicit Git diff hunks.
-- Shows selected snippets and capacity as next-prompt context, supports adding one and closing or adding repeatedly without leaving the browser, and injects snapshots in selection order.
-- Skips common dependency, VCS, build, and coverage directories and does not follow symlinks during discovery.
+- Opens from `/file-context` or a configurable shortcut that defaults to `F8`.
+- Searches file names or file contents and previews bounded text with line numbers.
+- Adds whole-file references, exact line ranges, changed hunks, revisions, or Git diffs without using the clipboard.
+- Shows Git state, blame, bounded file history, provenance, and a deterministic token estimate before attachment.
+- Reviews and removes exact queued snapshots before the next prompt.
+- Preserves selection order, supports repeated browsing, skips common generated directories, and never follows symlinks during discovery.
 
 ## 📦 Install
 
@@ -46,15 +44,38 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
 
 ## 🚀 Quick start
 
-1. Run `/file-context` and choose **Add context snippet**. Press `F8` or run `/file-context browse` to open the browser directly. Every route shows the same cancellable project scan before browsing.
-2. Type to fuzzy-search file names in relevance order and use `Up`/`Down` to navigate. Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
-3. Press `Ctrl+F` to switch between file-name and content search. Content search is literal and case-insensitive by default; `Alt+C` toggles case sensitivity and `Alt+F` toggles ordered fuzzy matching. The current states remain visible above the results.
-4. In content results, use `Up`/`Down` to choose a highlighted path-and-line card. Press `Tab` for a whole-file reference or `Enter` to preview the file at that line. `Escape` from the preview restores the query, result selection, and scroll position.
-5. In the preview, press `Space` to anchor the selection and extend the range with `Up`/`Down`. The footer shows the selected lines, estimated tokens, and resulting next-prompt capacity. Press `Enter` to add and close, or press `a` to add and return to the originating file or content results so you can keep browsing.
-6. Press `?` in the preview to review all actions. In a Git worktree, `[`/`]` selects changed hunks, `b` shows current-line blame, `h` opens file history, `r` opens a commit/branch/tag, and `d` reviews and adds explicit diff context.
-7. Open `/file-context` and choose **Review selected context** to inspect each exact snapshot. `Enter` opens the snapshot first and then offers **Remove from next prompt**. `Escape` goes back without changing selected context, while `Ctrl+C` closes File Context. Write the question and submit normally; selected snippets are attached in order and cleared together.
+1. Press `F8` or run `/file-context browse`.
+2. Find a file, preview it, select the exact lines or Git change, and press `Enter` to attach the snapshot.
+3. Review queued snapshots from `/file-context`, write the request, and submit normally.
 
-`Escape` returns from a preview to its originating file-name or content results. When the browser was opened from the menu, `Escape` from a root search returns to the menu. Direct browser routes cancel instead. `Ctrl+C` closes menus and browsers. During project scanning, either cancel key stops the scan; menu-owned scans return to the menu and direct scans close without opening a stale explorer.
+## 🧭 Browser workflow
+
+1. Run `/file-context` and choose **Add context snippet**.
+   Press `F8` or run `/file-context browse` to open the browser directly.
+   Every route shows the same cancellable project scan before browsing.
+2. Type to fuzzy-search file names in relevance order and use `Up`/`Down` to navigate.
+   Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
+3. Press `Ctrl+F` to switch between file-name and content search.
+   Content search is literal and case-insensitive by default; `Alt+C` toggles case sensitivity and `Alt+F` toggles ordered fuzzy matching.
+   The current states remain visible above the results.
+4. In content results, use `Up`/`Down` to choose a highlighted path-and-line card.
+   Press `Tab` for a whole-file reference or `Enter` to preview the file at that line.
+   `Escape` from the preview restores the query, result selection, and scroll position.
+5. In the preview, press `Space` to anchor the selection and extend the range with `Up`/`Down`.
+   The footer shows the selected lines, estimated tokens, and resulting next-prompt capacity.
+   Press `Enter` to add and close, or press `a` to add and return to the originating file or content results so you can keep browsing.
+6. Press `?` in the preview to review all actions.
+   In a Git worktree, `[`/`]` selects changed hunks, `b` shows current-line blame, `h` opens file history, `r` opens a commit/branch/tag, and `d` reviews and adds explicit diff context.
+7. Open `/file-context` and choose **Review selected context** to inspect each exact snapshot.
+   `Enter` opens the snapshot first and then offers **Remove from next prompt**.
+   `Escape` goes back without changing selected context, while `Ctrl+C` closes File Context.
+   Write the question and submit normally; selected snippets are attached in order and cleared together.
+
+`Escape` returns from a preview to its originating file-name or content results.
+When the browser was opened from the menu, `Escape` from a root search returns to the menu.
+Direct browser routes cancel instead.
+`Ctrl+C` closes menus and browsers.
+During project scanning, either cancel key stops the scan; menu-owned scans return to the menu and direct scans close without opening a stale explorer.
 
 The agent receives an explicit block similar to:
 
@@ -64,9 +85,12 @@ selected content
 </user_file_quote>
 ```
 
-Non-Git quotes retain the original `path` and `lines` attributes exactly. Git-backed quotes add ordered optional provenance: the repository HEAD at selection time, branch, file status, selected revision or baseline, tracked blob when available, source kind (`worktree`, `revision`, or `git_diff`), and SHA-256 of the exact attached text. HEAD alone does not identify uncommitted content; `content_sha256` identifies the actual snapshot.
+Non-Git quotes retain the original `path` and `lines` attributes exactly.
+Git-backed quotes add ordered optional provenance: the repository HEAD at selection time, branch, file status, selected revision or baseline, tracked blob when available, source kind (`worktree`, `revision`, or `git_diff`), and SHA-256 of the exact attached text.
+HEAD alone does not identify uncommitted content; `content_sha256` identifies the actual snapshot.
 
-Token counts are deterministic byte-based estimates (`ceil(UTF-8 bytes / 4)`), not provider billing guarantees. Diff context is never attached automatically.
+Token counts are deterministic byte-based estimates (`ceil(UTF-8 bytes / 4)`), not provider billing guarantees.
+Diff context is never attached automatically.
 
 ## ⚙️ Settings
 
@@ -88,7 +112,8 @@ Invalid JSON or values leave the source file unchanged, use the default shortcut
 
 Choose a shortcut that does not conflict with Pi or another extension; `Ctrl+F` is already Pi's cursor-right binding and File Context's internal search-mode toggle.
 
-The previous `Ctrl+Alt+F` default depended on terminal modifier support and may not reach Pi. An explicit `"openShortcut": "ctrl+alt+f"` value remains supported but is not migrated automatically; replace it with `"f8"` and run `/reload` to adopt the reliable default.
+The previous `Ctrl+Alt+F` default depended on terminal modifier support and may not reach Pi.
+An explicit `"openShortcut": "ctrl+alt+f"` value remains supported but is not migrated automatically; replace it with `"f8"` and run `/reload` to adopt the reliable default.
 
 ## 💬 Commands
 
@@ -98,22 +123,30 @@ The previous `Ctrl+Alt+F` default depended on terminal modifier support and may 
 | `/file-context browse` | TUI only | Scan and open the file explorer directly. |
 | `/file-context remove` | TUI only | Open selected-context review directly for compatibility. |
 
-Unknown and trailing arguments are rejected. RPC receives an observable warning. JSON and print modes do not enter interactive UI.
+Unknown and trailing arguments are rejected.
+RPC receives an observable warning.
+JSON and print modes do not enter interactive UI.
 
-## 🔒 Security and limits
+## 🔒 Security and privacy
 
 - Extensions run with the user's full permissions; install only trusted code.
 - File paths and symlink targets are checked against the real project root before reading.
 - Preview files are limited to 1 MB and NUL-containing files are treated as binary.
 - Discovery is limited to 5,000 files, skips symlinks, and prioritizes shallow files before deeper files.
-- File-name and content-search queries are limited to 256 characters. Content search returns at most 100 cards and reports truncation and unreadable, oversized, or binary files as skipped.
-- Content search uses the same 5,000-file, 1 MB-per-file, real-project-path, and no-symlink boundaries as preview loading. Superseded searches and file opens are cancelled.
+- File-name and content-search queries are limited to 256 characters.
+  Content search returns at most 100 cards and reports truncation and unreadable, oversized, or binary files as skipped.
+- Content search uses the same 5,000-file, 1 MB-per-file, real-project-path, and no-symlink boundaries as preview loading.
+  Superseded searches and file opens are cancelled.
 - Terminal control characters are escaped before file names, Git refs, authors, summaries, search context, or file contents are rendered.
 - Git is invoked read-only without a shell, pager, external diff, or text conversion; commands time out after 5 seconds and output is bounded to 1.1 MB.
-- Revision names are resolved to a commit before file loading. Historical files remain subject to the 1 MB and binary guards.
-- Blame shows the author name but not author email. Commit summaries and diffs can still contain sensitive project text; inspect selections before attachment.
-- Each snippet stores the text visible at selection time. It does not silently reread changed content when the prompt is submitted.
-- A snippet is limited to 500 lines and 50 KB. At most eight selected snippets and 100 KB of aggregate context text are accepted.
+- Revision names are resolved to a commit before file loading.
+  Historical files remain subject to the 1 MB and binary guards.
+- Blame shows the author name but not author email.
+  Commit summaries and diffs can still contain sensitive project text; inspect selections before attachment.
+- Each snippet stores the text visible at selection time.
+  It does not silently reread changed content when the prompt is submitted.
+- A snippet is limited to 500 lines and 50 KB.
+  At most eight selected snippets and 100 KB of aggregate context text are accepted.
 
 ## 🚧 Limitations
 
@@ -125,7 +158,8 @@ Unknown and trailing arguments are rejected. RPC receives an observable warning.
 - Content search scans discovered files natively and sequentially; large projects or queries with no matches may take longer than indexed or external search tools.
 - Fuzzy content search matches query characters in order on one line; it is not semantic search and does not cross line boundaries.
 - Git integration degrades to the original filesystem-only workflow outside a repository or when Git metadata cannot be read.
-- File history is limited to the 20 most recent commits. Untracked files have status and provenance but no HEAD diff hunk until Git tracks them.
+- File history is limited to the 20 most recent commits.
+  Untracked files have status and provenance but no HEAD diff hunk until Git tracks them.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-firecrawl/README.md
+++ b/packages/pi-firecrawl/README.md
@@ -1,26 +1,18 @@
-# 🔥 pi-firecrawl — Firecrawl Web Scraping Tools for Pi Agents
+# 🔥 pi-firecrawl — Scrape and Research the Web from Pi
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-firecrawl)](https://www.npmjs.com/package/@narumitw/pi-firecrawl) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-firecrawl` is a native [Pi coding agent](https://pi.dev) extension that exposes [Firecrawl](https://www.firecrawl.dev/) scraping, crawling, URL discovery, and search APIs as Pi tools.
-
-Use it to give your AI coding agent reliable web research capabilities for documentation lookup, website audits, competitive research, content extraction, and retrieval-friendly markdown scraping.
+Give Pi on-demand [Firecrawl](https://www.firecrawl.dev/) tools for web search, scraping, crawling, URL discovery, and retrieval-friendly content extraction.
 
 ## ✨ Features
 
-- Scrape a single URL into markdown, HTML, raw HTML, links, screenshots, or JSON.
-- Start Firecrawl crawl jobs from Pi.
-- Check crawl job status and retrieve completed crawl data.
-- Discover URLs with Firecrawl map.
-- Search the web and optionally scrape search result pages.
-- Supports Firecrawl API endpoint overrides.
-- Shows statusline activity only while Firecrawl tools are running.
-- Keeps one loader tool active and exposes matching Firecrawl capabilities only when needed.
-- Provides a `/firecrawl` menu with configuration help and availability controls.
-- Uses `@narumitw/pi-tui-kit` for width-safe menus and individual tool selection.
-- Persists the Firecrawl lazy-load catalog across Pi restarts.
-- Bounds tool output to Pi's 50 KB or 2,000-line limit while preserving oversized responses in private temporary files.
-- Never logs, displays, or stores your Firecrawl API key.
+- Scrapes a URL into markdown, HTML, links, screenshots, or structured JSON.
+- Starts crawl jobs, checks their status, and retrieves completed crawl data.
+- Discovers site URLs and searches the web with optional result-page scraping.
+- Loads only the Firecrawl capabilities needed for the task and manages availability through `/firecrawl`.
+- Supports custom Firecrawl endpoints and shows activity only while a tool is running.
+- Bounds model-visible output while preserving oversized responses in private temporary files.
+- Reads the API key from the environment and never logs, displays, or stores it.
 
 ## 📦 Install
 
@@ -62,7 +54,8 @@ Optional API endpoint override:
 export FIRECRAWL_API_URL=https://api.firecrawl.dev/v1
 ```
 
-`FIRECRAWL_BASE_URL` is also accepted for compatibility. The extension never logs or displays the API key.
+`FIRECRAWL_BASE_URL` is also accepted for compatibility.
+The extension never logs or displays the API key.
 
 ## 🛠️ Tools
 
@@ -101,12 +94,11 @@ An empty array leaves the loader active but makes every Firecrawl API capability
 
 Every API capability fails with a clear configuration error when `FIRECRAWL_API_KEY` is missing, and the always-active loader guidance tells the agent not to retry repeatedly.
 
-Tool output is limited to 50 KB or 2,000 lines, whichever is reached first. When a response is
-truncated, the result reports the original and displayed sizes and the path to a complete temporary
-JSON file. These files use private permissions, remain available for the current session, and are
-removed during session shutdown or reload. Tool-result metadata contains only size and artifact
-information rather than a duplicate of the raw Firecrawl response. Oversized Firecrawl error bodies
-are bounded in the same way.
+Tool output is limited to 50 KB or 2,000 lines, whichever is reached first.
+When a response is truncated, the result reports the original and displayed sizes and the path to a complete temporary JSON file.
+These files use private permissions, remain available for the current session, and are removed during session shutdown or reload.
+Tool-result metadata contains only size and artifact information rather than a duplicate of the raw Firecrawl response.
+Oversized Firecrawl error bodies are bounded in the same way.
 
 ## 💬 Commands
 
@@ -114,8 +106,7 @@ are bounded in the same way.
 /firecrawl
 ```
 
-Opens a menu with configuration quick start, command usage, lazy-catalog status, controls for making
-all Firecrawl capabilities available or unavailable, and a selector for choosing individual tools.
+Opens a menu with configuration quick start, command usage, lazy-catalog status, controls for making all Firecrawl capabilities available or unavailable, and a selector for choosing individual tools.
 
 Direct subcommands are also available:
 
@@ -133,19 +124,16 @@ Direct subcommands are also available:
 - `help` shows command usage.
 - `config` shows API-key presence and API URL without displaying the API key value.
 - `quickstart` is an alias for `config`.
-- `status` shows available and loaded capability counts, loader state, the persisted catalog,
-  settings file path, API-key presence, API URL, and active non-Firecrawl tool count.
+- `status` shows available and loaded capability counts, loader state, the persisted catalog, settings file path, API-key presence, API URL, and active non-Firecrawl tool count.
 - `tools` opens a width-safe immediate-save selector for choosing capabilities available to lazy-load.
 - `toggle` is an alias for `tools`.
 - `enable` makes all five API capabilities available but leaves newly available definitions deferred.
 - `disable` makes all five API capabilities unavailable and unloads affected active definitions.
   The slash command and `firecrawl_load` remain available.
 
-The menu, `tools`, `help`, `config`, `quickstart`, and `status` routes require TUI or RPC mode so their
-results are observable.
+The menu, `tools`, `help`, `config`, `quickstart`, and `status` routes require TUI or RPC mode so their results are observable.
 
-Print and JSON modes reject those routes and unknown commands explicitly instead of entering
-unavailable UI or silently notifying a no-op channel.
+Print and JSON modes reject those routes and unknown commands explicitly instead of entering unavailable UI or silently notifying a no-op channel.
 
 The deterministic `enable` and `disable` routes remain available in every mode.
 
@@ -159,21 +147,19 @@ The available capability names are saved to:
 ${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-firecrawl.json
 ```
 
-When the file is missing or invalid, the extension preserves Pi's current Firecrawl availability
-policy instead of replacing it. An unsaved catalog remains stable across runtime reloads. A valid
-saved catalog is restored on Pi startup and `/reload`, while its capability definitions remain
-deferred. A missing file is created by the first successful
-availability change. Within one Pi process, catalog saves run in invocation order, reread the latest
-valid document, and preserve unknown fields. Malformed JSON or invalid recognized fields block the
-save without replacement; a failed save restores both the prior availability and loaded capability
-state while preserving other extensions' active tools. The settings file stores only tool names and
-a timestamp; it never stores `FIRECRAWL_API_KEY`, request headers, or other secrets.
+When the file is missing or invalid, the extension preserves Pi's current Firecrawl availability policy instead of replacing it.
+An unsaved catalog remains stable across runtime reloads.
+A valid saved catalog is restored on Pi startup and `/reload`, while its capability definitions remain deferred.
+A missing file is created by the first successful availability change.
+Within one Pi process, catalog saves run in invocation order, reread the latest valid document, and preserve unknown fields.
+Malformed JSON or invalid recognized fields block the save without replacement; a failed save restores both the prior availability and loaded capability state while preserving other extensions' active tools.
+The settings file stores only tool names and a timestamp; it never stores `FIRECRAWL_API_KEY`, request headers, or other secrets.
 
-Compatibility: older versions used `pi-firecrawl-settings.json`. A legacy-only file remains
-readable with a warning and is never modified automatically; rename it to `pi-firecrawl.json`.
-The first subsequent settings save writes the canonical file. If both files exist,
-`pi-firecrawl.json` wins and the legacy file is ignored. The legacy filename is
-deprecated and will be removed in a future major release.
+Compatibility: older versions used `pi-firecrawl-settings.json`.
+A legacy-only file remains readable with a warning and is never modified automatically; rename it to `pi-firecrawl.json`.
+The first subsequent settings save writes the canonical file.
+If both files exist, `pi-firecrawl.json` wins and the legacy file is ignored.
+The legacy filename is deprecated and will be removed in a future major release.
 
 ## 🧪 Examples
 
@@ -243,4 +229,5 @@ Pi extension, Pi coding agent, Firecrawl, web scraping, web crawling, URL discov
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-fleet/README.md
+++ b/packages/pi-fleet/README.md
@@ -1,4 +1,4 @@
-# 🚀 Pi Fleet — Experimental Local Pi Sessions
+# 🚀 Pi Fleet — Launch and Connect Local Pi Sessions
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-fleet)](https://www.npmjs.com/package/@narumitw/pi-fleet) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
@@ -6,25 +6,19 @@
 > Pi Fleet is experimental.
 > Its local protocol, terminal automation, tool schemas, and agent-request behavior may change between releases.
 
-`@narumitw/pi-fleet` starts a separate Pi process in a terminal split while preserving the parent session.
-Its built-in default automatically selects the current tmux, Zellij, or Ghostty context, while users can pin a backend in Settings or per tool call.
-It also lets explicitly joined Pi sessions owned by the same operating-system user exchange bounded local messages and one-turn requests.
+Start another Pi process in a terminal split without replacing the current session, then optionally connect trusted local Pi sessions for bounded messages and one-turn requests.
+
+Pi Fleet automatically detects tmux, Zellij, or Ghostty, and lets you pin a backend when needed.
 
 ## ✨ Features
 
-- Starts a distinct Pi process with automatic or pinned tmux, Ghostty, or Zellij selection.
-- Resolves the current supported terminal from bounded environment signatures before launch side effects.
-- Preserves the parent Pi session instead of replacing it with `ctx.newSession()`.
-- Inherits the parent cwd, model identity, thinking level, and an optional first task.
-- Lets users keep or skip the final launch preview while retaining one-time experimental consent.
-- Waits for an authenticated child endpoint before reporting that the new session is ready.
-- Connects explicit sessions through owner-only Unix sockets and ephemeral bearer invites.
-- Authenticates strict version-2 manifests and frames with separate HMAC-SHA-256 domains.
-- Binds every live process instance to a random endpoint id as well as its logical Pi session id.
-- Bounds frames, messages, directory scans, peers, concurrent probes, connections, deliveries, rates, deadlines, diagnostics, and deduplication state.
-- Delivers notify messages without starting a model turn.
-- Starts at most one turn for an allowed request or parent-capability launch kickoff, while replies do not trigger another automatic turn.
-- Cleans sockets, manifests, connections, launchers, tasks, timers, and status on leave, replacement, reload, and shutdown.
+- Opens a distinct Pi process in tmux, Ghostty, or Zellij while preserving the parent session.
+- Inherits the cwd, model, thinking level, and an optional first task after a reviewed launch flow.
+- Waits for the child to authenticate before reporting that the new session is ready.
+- Connects explicitly joined same-user sessions through owner-only local sockets and ephemeral invites.
+- Delivers notifications without a model turn and bounds each allowed request to one turn.
+- Authenticates and bounds local protocol traffic, peers, retries, rates, deadlines, and diagnostics.
+- Cleans all sockets, launchers, tasks, timers, and status on leave, reload, replacement, or shutdown.
 
 ## 📦 Install
 
@@ -57,19 +51,15 @@ Review extension source before installing it.
 
 ## 🚀 Quick start
 
-Run:
+Run `/fleet`, choose **New Pi session…**, select a split direction, and optionally provide the first task.
+Pi Fleet asks for one-time experimental consent and shows the configured launch confirmation before creating a split.
 
-```text
-/fleet
-```
+## 🧭 Launch flow
 
 Choose **Settings** first when you want to pin a terminal backend or change final launch confirmation.
-Then choose **New Pi session…**.
-Pi Fleet resolves the configured terminal preference and asks for a split direction and an optional first task.
-It always requires one-time experimental consent.
-When **Confirm new sessions** is **Ask**, it also shows an exact launch preview before creating any socket or split.
+Pi Fleet otherwise resolves the current supported terminal automatically.
 
-After the required consent and optional launch confirmation, Pi Fleet:
+After consent and any configured launch confirmation, Pi Fleet:
 
 1. Creates or reuses an ephemeral local group.
 2. Creates the selected terminal split.

--- a/packages/pi-github-pr/README.md
+++ b/packages/pi-github-pr/README.md
@@ -1,21 +1,18 @@
-# 🔎 pi-github-pr — GitHub Pull Request Statusline for Pi Agents
+# 🔎 pi-github-pr — See Current Pull Request Status in Pi
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-github-pr)](https://www.npmjs.com/package/@narumitw/pi-github-pr) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-github-pr` is a passive [Pi coding agent](https://pi.dev) extension that shows the current branch GitHub pull request status in Pi's statusline.
+See the current branch's GitHub pull request number, checks, review state, and discussion count directly in Pi's statusline.
 
-It only reads PR metadata for the current branch. It counts comments and reviews, but does not fetch or display comment bodies, review text, or review-thread content.
-
-It is intentionally ambient: no slash command, no custom tool, no widget, and no comment injection.
+The extension reads only PR metadata and remains passive, with no command, model tool, widget, or injected content.
 
 ## ✨ Features
 
-- Automatically shows compact PR status in Pi's statusline.
-- Refreshes the current branch PR every minute and after agent turns.
-- Shows PR number, GitHub checks state, review state, and comment/review count.
-- Does not read or expose PR discussion text; use `gh pr view --comments` or GitHub directly when you need the conversation.
-- Uses GitHub CLI auth and repository resolution; the extension stores no GitHub token.
-- No slash commands, LLM tools, widgets, webhook server, or separate runtime service.
+- Shows compact PR number, checks, review state, and combined comment/review count.
+- Refreshes once per minute and after agent turns.
+- Uses GitHub CLI authentication and repository resolution without storing a token.
+- Never reads or displays discussion bodies, review text, or review threads.
+- Runs without commands, model tools, widgets, webhooks, or a separate service.
 
 Example statusline text:
 
@@ -26,9 +23,9 @@ PR #123: checks pending (5), commented, 12 comments
 PR #123: no checks, draft, no comments
 ```
 
-The check wording follows GitHub's Checks terminology. The trailing comment count is the
-combined comments + reviews count. When rendered by `pi-statusline`, the `github-pr` icon comes
-from pi-statusline icon settings.
+The check wording follows GitHub's Checks terminology.
+The trailing comment count is the combined comments + reviews count.
+When rendered by `pi-statusline`, the `github-pr` icon comes from pi-statusline icon settings.
 
 ## 📦 Install
 
@@ -59,7 +56,8 @@ gh auth login
 gh auth login --hostname github.example.com:8443
 ```
 
-The extension shells out to `gh`; GitHub Enterprise hosts and credential storage are delegated to `gh`. It uses the PR URL host (including any port) for follow-up API calls, so no manual `GH_HOST` is required.
+The extension shells out to `gh`; GitHub Enterprise hosts and credential storage are delegated to `gh`.
+It uses the PR URL host (including any port) for follow-up API calls, so no manual `GH_HOST` is required.
 
 ## 🚀 Quick start
 

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -1,39 +1,22 @@
-# 🎯 pi-goal — Goal Mode for the Pi Coding Agent
+# 🎯 pi-goal — Keep Pi Working Toward a Goal
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-goal)](https://www.npmjs.com/package/@narumitw/pi-goal) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-goal` is a native [Pi coding agent](https://pi.dev) extension that adds session-scoped `/goal` commands, a `goal_complete({ goal_id, summary })` completion tool, a strict `goal_blocked({ goal_id, reason, evidence, repeated_turns })` impasse tool, and a `goal_wait({ goal_id, reason, resume_after_ms? })` tool for external-event waits.
+Give Pi a session-scoped objective and let it continue from each fully settled idle boundary until the work completes, pauses, waits, or reaches a safety limit.
 
-Goal mode uses Codex-like persistence instructions and sends guarded continuation messages from Pi's fully settled idle boundary until the agent completes the goal, explicitly waits for an external event, the user pauses or clears it, a safety circuit breaker trips, a true blocker or provider usage limit stops it, or an optional token budget is reached.
+Goal mode adds explicit completion, blocker, and external-wait tools so managed execution stops for a clear reason instead of looping blindly.
 
 ## ✨ Features
 
-- Adds `/goal <goal_to_complete>` to start goal mode, with confirmation before replacing an existing goal.
-- Bare `/goal` opens a standard current-state manager in the TUI, with guided start, pause,
-  resume, edit, settings, status, help, and destructive-action confirmation; RPC mode retains
-  observable status notifications.
-- Keeps direct goal management available through `/goal` subcommands: `status`, `pause`, `resume`, `clear`, and `edit`.
-- Exposes only one top-level command: `/goal`.
-- Pauses automatic work after 25 Goal-owned model responses by default, preserves progress, and provides a guided review-and-continue flow; custom finite limits and confirmed Unlimited mode remain available.
-- Pauses after three consecutive empty or normalized-identical tool-free automatic runs, while distinct short output and tool activity reset the repeat detector.
-- Supports optional token budgets such as `/goal --tokens 100k <goal>`, using provider-reported total-token accounting with a cache-inclusive compatibility fallback.
-- Tracks distinct `active`, `paused`, `blocked`, `usage_limited`, `budget_limited`, and `complete` states.
-- Stores goal state in the current Pi session, following Codex's thread-owned goal model instead of using a global per-directory goal.
-- Registers a `goal_complete({ goal_id, summary })` tool for explicit completion, requiring the current goal id and rejecting missing/stale ids plus plainly contradictory summaries such as “not complete” or “tests still fail”.
-- Registers `goal_blocked({ goal_id, reason, evidence, repeated_turns })` for true impasses only; it requires the current goal id, concrete evidence, and the same blocker recurring for at least three consecutive goal turns.
-- Registers `goal_wait({ goal_id, reason, resume_after_ms? })` for an active Goal that has arranged an external wake message; waiting suppresses automatic continuation while preserving the objective, accounting, and managed-run ownership.
-- Starts all three Goal tools inactive by default, reveals them for the first accepted `/goal` activation or an unfinished-goal restore, and keeps them desired for the rest of that extension runtime without overriding a restrictive restore policy. Optional `"always"` visibility keeps them active from session startup.
-- Records continuation intent, then triggers exactly one next turn only after Pi reports the agent fully settled, idle, and free of pending messages; an explicit wait remains quiet until non-Goal work or its optional deadline wakes it, and missing terminal tools still pause before another model turn.
-- Lets retry, compaction, steering, follow-up, and other queued work settle before automatic goal continuation.
-- Separates user interruption (`paused`), true impasse or terminal non-usage error (`blocked`), provider/account quota exhaustion (`usage_limited`), and user token budget exhaustion (`budget_limited`).
-- Detects budget exhaustion after completed tool activity when assistant usage is persisted, then injects at most one non-user-authored wrap-up instruction and blocks further substantive tools.
-- Keeps retryable provider interruptions and Pi compaction retries active without enqueueing duplicate goal continuations while Pi retries, then marks a matching unresolved error `blocked` only when `agent_settled` proves no retry, compaction, or follow-up remains.
-- Preserves active goals across manual, threshold, and overflow compaction.
-- Guards auto-follow-ups and Goal-owned kickoff deliveries so duplicate, replaced, stopped, cleared, completed, budget-limited, or stale prompts cannot continue or overwrite a newer goal.
-- Rotates the completion guard id when a goal is resumed or edited so delayed old turns cannot complete the newer goal instance.
-- Blocks stale tool calls after in-flight work pauses, blocks, or reaches a usage limit, until fresh non-goal user work, successful reactivation/replacement, or clear.
-- Applies one evidence-based completion audit across kickoff, resume, edit, system, continuation, and budget-wrap-up prompts.
-- Optionally exposes a default-off, run-scoped `pi.events` protocol for trusted sibling extensions to start, observe, and cancel one Goal lifecycle without emulating `/goal` input.
+- Starts or manages a session goal through one `/goal` command and direct status, pause, resume, edit, or clear routes.
+- Continues exactly once from Pi's settled idle boundary after queued work, retries, and compaction have finished.
+- Uses explicit `goal_complete`, `goal_blocked`, and `goal_wait` tools with stale-goal guards and evidence requirements.
+- Tracks active, paused, blocked, usage-limited, budget-limited, waiting, and complete outcomes separately.
+- Pauses after a configurable response limit or repeated no-progress runs and offers a guided review before continuing.
+- Supports optional token budgets and a single guarded wrap-up when the budget is exhausted.
+- Persists the goal in the current session across reload, resume, compatible forks, and compaction.
+- Rejects stale continuations and tool calls after replacement, pause, completion, limits, or other terminal state changes.
+- Optionally exposes a default-off run protocol for trusted sibling extensions to start, observe, and cancel one Goal lifecycle.
 
 ## 📦 Install
 
@@ -65,8 +48,8 @@ Use the manager to review status, pause, resume, edit, or clear the current goal
 
 ## ⚙️ Settings
 
-Settings are optional. When `~/.pi/agent/pi-goal.json` is absent, pi-goal uses these
-built-in defaults without creating the file:
+Settings are optional.
+When `~/.pi/agent/pi-goal.json` is absent, pi-goal uses these built-in defaults without creating the file:
 
 ```json
 {
@@ -81,38 +64,72 @@ built-in defaults without creating the file:
 }
 ```
 
-Use `/goal` → **Settings…** in the TUI to create or update the file interactively, or create
-and edit it directly. The standard Settings screen keeps all four controls on one level in task
-order; the two safety limits open standard choice screens:
+Use `/goal` → **Settings…** in the TUI to create or update the file interactively, or create and edit it directly.
+The standard Settings screen keeps all four controls on one level in task order; the two safety limits open standard choice screens:
 
-- **Automatic-work limit** shows the exact response limit or **Unlimited**. Choose **Set response limit…** to edit the current finite value (or the built-in default of 25 when switching from Unlimited), or choose **Unlimited…**. Unlimited requires confirmation that tool loops may continue consuming tokens and provider cost without a response-count cap.
-- **No-progress guard** shows **_N_ runs** or **Off**. Choose the default threshold, **Off**, or **Set threshold…** and enter a safe whole number greater than zero.
+- **Automatic-work limit** shows the exact response limit or **Unlimited**.
+  Choose **Set response limit…** to edit the current finite value (or the built-in default of 25 when switching from Unlimited), or choose **Unlimited…**.
+  Unlimited requires confirmation that tool loops may continue consuming tokens and provider cost without a response-count cap.
+- **No-progress guard** shows **_N_ runs** or **Off**.
+  Choose the default threshold, **Off**, or **Set threshold…** and enter a safe whole number greater than zero.
 - **Goal tools** controls whether all Goal tools are always visible or appear after the first goal.
-- **Managed run RPC** controls whether trusted installed extensions may start and cancel managed Goal runs. It defaults to **Off** and is a cooperation setting, not an extension security sandbox.
+- **Managed run RPC** controls whether trusted installed extensions may start and cancel managed Goal runs.
+  It defaults to **Off** and is a cooperation setting, not an extension security sandbox.
 
-Custom number inputs reject zero, negative numbers, decimals, text, and unsafe integers without saving; use the explicit **Unlimited** or **Off** choice instead. Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime. A successful change updates the visible state immediately. A failed save restores the prior value and reports the settings path so it can be retried. Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy; retry after Pi settles. Escape returns to the previous screen without reverting changes that were already saved.
+Custom number inputs reject zero, negative numbers, decimals, text, and unsafe integers without saving; use the explicit **Unlimited** or **Off** choice instead.
+Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime.
+A successful change updates the visible state immediately.
+A failed save restores the prior value and reports the settings path so it can be retried.
+Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy; retry after Pi settles.
+Escape returns to the previous screen without reverting changes that were already saved.
 
 `toolVisibility` accepts:
 
 - `"always"` — pi-goal does not proactively hide `goal_complete`, `goal_blocked`, or `goal_wait`, keeping the Goal tool schema stable from session startup.
-- `"after-first-goal"` (default) — hides all three Goal tools at fresh runtime startup, reveals them for the first accepted Goal activation, and treats an unfinished-goal restore as unlocked for the remainder of that extension runtime. On restore, pi-goal uses the active tools already established by earlier lifecycle handlers; it does not re-add missing terminal tools over a restrictive policy. Failed kickoff, replacement, resume, or reactivating-edit delivery restores the exact pre-activation tool set, including Goal tools exposed by another extension. If revealing the tools would widen an already-running turn, wait for Pi to become idle and retry `/goal`.
+- `"after-first-goal"` (default) — hides all three Goal tools at fresh runtime startup, reveals them for the first accepted Goal activation, and treats an unfinished-goal restore as unlocked for the remainder of that extension runtime.
+  On restore, pi-goal uses the active tools already established by earlier lifecycle handlers; it does not re-add missing terminal tools over a restrictive policy.
+  Failed kickoff, replacement, resume, or reactivating-edit delivery restores the exact pre-activation tool set, including Goal tools exposed by another extension.
+  If revealing the tools would widen an already-running turn, wait for Pi to become idle and retry `/goal`.
 
-`experimental.goals` is a removed legacy setting. If it remains `true`, pi-goal accepts the settings file, ignores the old queue feature, and shows an affected-user warning that recommends `/goal edit` when an active objective exists or `/goal <objectives>` when no active goal exists. Later settings saves preserve unknown legacy fields instead of deleting them.
+`experimental.goals` is a removed legacy setting.
+If it remains `true`, pi-goal accepts the settings file, ignores the old queue feature, and shows an affected-user warning that recommends `/goal edit` when an active objective exists or `/goal <objectives>` when no active goal exists.
+Later settings saves preserve unknown legacy fields instead of deleting them.
 
-`rpc.enabled` accepts a boolean and defaults to `false`. When disabled, a valid managed-run start receives `RPC_DISABLED`; manual and restored Goals remain unchanged. A Settings-menu change applies immediately after its atomic save. Disabling rejects new starts but lets an already accepted run continue publishing its exact state and accept its exact cancellation until terminal, avoiding stranded work. Reload, replacement, and shutdown clear that in-memory ownership.
+`rpc.enabled` accepts a boolean and defaults to `false`.
+When disabled, a valid managed-run start receives `RPC_DISABLED`; manual and restored Goals remain unchanged.
+A Settings-menu change applies immediately after its atomic save.
+Disabling rejects new starts but lets an already accepted run continue publishing its exact state and accept its exact cancellation until terminal, avoiding stranded work.
+Reload, replacement, and shutdown clear that in-memory ownership.
 
 `continuationLimits` controls the runaway guards:
 
-- `automaticTurns` accepts a positive safe integer or `null` and defaults to `25`. It counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries. The user-triggered kickoff, resume, edit, and ordinary user runs are not charged. At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted before a 26th normal response starts. Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work. Set this field explicitly to `null` to opt into Unlimited mode; existing explicit `null` values remain compatible.
-- `noProgressTurns` is a positive safe integer and defaults to `3`. At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercasing, control-character removal, and whitespace collapse. Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent. Consecutive empty or identical tool-free outputs increment the repeat count. Different non-empty output starts a new run at one, and any attempted tool call resets it. Set this field to `null` to disable only this heuristic.
+- `automaticTurns` accepts a positive safe integer or `null` and defaults to `25`.
+  It counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries.
+  The user-triggered kickoff, resume, edit, and ordinary user runs are not charged.
+  At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted before a 26th normal response starts.
+  Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work.
+  Set this field explicitly to `null` to opt into Unlimited mode; existing explicit `null` values remain compatible.
+- `noProgressTurns` is a positive safe integer and defaults to `3`.
+  At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercasing, control-character removal, and whitespace collapse.
+  Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent.
+  Consecutive empty or identical tool-free outputs increment the repeat count.
+  Different non-empty output starts a new run at one, and any attempted tool call resets it.
+  Set this field to `null` to disable only this heuristic.
 
-Settings are reread at Pi startup, session replacement, and `/reload`; direct external file edits are not watched live, while changes made through the Goal menu apply immediately. A missing file remains absent and uses the built-in defaults. The first successful settings change creates the file atomically; later saves preserve unknown fields.
+Settings are reread at Pi startup, session replacement, and `/reload`; direct external file edits are not watched live, while changes made through the Goal menu apply immediately.
+A missing file remains absent and uses the built-in defaults.
+The first successful settings change creates the file atomically; later saves preserve unknown fields.
 
-Omitted fields use the defaults above. Invalid or malformed existing settings are never overwritten; they produce a warning and fall back to all defaults. In the TUI, Goal Settings becomes a read-only summary that identifies the invalid file and directs the user to fix it and run `/reload`. Reload Pi after changing the file. If a live runtime reloads settings, switching `toolVisibility` to `"always"`
-restores only the exact tools that pi-goal previously hid, while switching to
-`"after-first-goal"` locks a runtime that has no unfinished goal.
+Omitted fields use the defaults above.
+Invalid or malformed existing settings are never overwritten; they produce a warning and fall back to all defaults.
+In the TUI, Goal Settings becomes a read-only summary that identifies the invalid file and directs the user to fix it and run `/reload`.
+Reload Pi after changing the file.
+If a live runtime reloads settings, switching `toolVisibility` to `"always"` restores only the exact tools that pi-goal previously hid, while switching to `"after-first-goal"` locks a runtime that has no unfinished goal.
 
-Tool visibility is a baseline, not ownership of Pi's global active-tool list. Plan mode or another restrictive policy may temporarily hide the tools. pi-goal does not fight that policy on restore or on every turn: activation is rejected if the required terminal tools cannot be made available, and an already-active goal is paused without automatic continuation if they disappear. A restrictive allowlist created before `goal_wait` existed can still run ordinary Goals with `goal_complete` and `goal_blocked`, but the model cannot enter external waiting until that allowlist also includes `goal_wait`. The pause aborts a Goal-owned kickoff, resume, active-edit, or automatic-continuation prompt, but it does not cancel or stale-block an unrelated user or extension turn, including startup follow-ups after a restrictive restore.
+Tool visibility is a baseline, not ownership of Pi's global active-tool list.
+Plan mode or another restrictive policy may temporarily hide the tools. pi-goal does not fight that policy on restore or on every turn: activation is rejected if the required terminal tools cannot be made available, and an already-active goal is paused without automatic continuation if they disappear.
+A restrictive allowlist created before `goal_wait` existed can still run ordinary Goals with `goal_complete` and `goal_blocked`, but the model cannot enter external waiting until that allowlist also includes `goal_wait`.
+The pause aborts a Goal-owned kickoff, resume, active-edit, or automatic-continuation prompt, but it does not cancel or stale-block an unrelated user or extension turn, including startup follow-ups after a restrictive restore.
 
 ## 💬 Commands
 
@@ -127,26 +144,34 @@ Tool visibility is a baseline, not ownership of Pi's global active-tool list. Pl
 /goal clear
 ```
 
-- In the TUI, `/goal` opens a standard state-aware manager. Its first action follows the current
-  state: start when empty, pause when active, review a reached automatic-work limit, resume for other
-  stopped states, or increase an exhausted token budget. Active and paused views show **Automatic
-  work: _used_ of _limit_ responses** with the remaining count, or explicitly show **Unlimited**.
-  A hard-cap pause opens **Review and continue…**, which states that objective, cumulative usage,
-  and active time are preserved and previews that Continue resets the counter to zero and
-  allows up to one more configured epoch. **Change automatic-work limit…** opens that setting while
-  leaving the goal paused; Back and Escape make no change. **Start with token budget…** first offers
-  `25k`, a suggested `100k`, `300k`, and **Set a custom budget…**, then collects the objective with
-  the selected budget still visible. Custom input accepts examples such as `300000`, `300k`, `2.5k`,
-  and `1.5m`; invalid input retains its draft for correction. Status, Settings, Help,
-  invalid-settings guidance, Clear, and Close remain shallow, labeled routes. Arrow keys
-  navigate, Enter selects or submits, Escape goes Back, and Ctrl+C closes the full flow.
-- In RPC mode, bare `/goal` and `/goal status` report the current summary through an observable notification without opening terminal UI. Pi exposes no extension-command output channel in print or JSON mode, so those routes reject with an explicit unsupported-mode error instead of misreporting stderr as status output.
-- Menu-driven Replace and Clear actions preview the exact affected goal and require confirmation. Existing direct routes remain immediate for compatibility and automation.
-- `/goal <goal_to_complete>` starts goal mode. If another unfinished goal exists, Pi asks for confirmation before replacing it with a new active goal and resetting its usage counters. Failed kickoff delivery clears a new goal or restores the prior goal; a previously active goal is restored as paused.
-- `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget. `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
-- `/goal edit <goal_to_complete>` updates the existing goal objective without resetting usage counters. A successful active edit rotates the stale-turn guard and starts a fresh safety epoch. Paused, blocked, and usage-limited goals stay stopped and retain their safety state until resume. A budget-limited goal reactivates only when `edit --tokens` raises its budget above current usage. Failed prompt delivery restores the exact previous safety counters/cause; it restores a budget-limited goal or restores and pauses a previously active goal.
-- `/goal pause` stops prompt injection and auto-continuation, aborts the current turn, and keeps the goal for later resume. Only active goals can be paused.
-- `/goal resume` resumes a paused, blocked, usage-limited, or budget-limited goal when its token budget allows it, rotates the stale-turn guard id, resets the automatic-response/repeat safety epoch when the queued resume prompt starts, clears a safety-pause cause, and reports the new finite epoch or explicit Unlimited state. Objective, cumulative usage, and elapsed time are preserved. If prompt delivery fails, the original stopped state, guard id, counters, fingerprint, and cause are restored.
+- In the TUI, `/goal` opens a standard state-aware manager.
+  Its first action follows the current state: start when empty, pause when active, review a reached automatic-work limit, resume for other stopped states, or increase an exhausted token budget.
+  Active and paused views show **Automatic work: _used_ of _limit_ responses** with the remaining count, or explicitly show **Unlimited**.
+A hard-cap pause opens **Review and continue…**, which states that objective, cumulative usage, and active time are preserved and previews that Continue resets the counter to zero and allows up to one more configured epoch.
+**Change automatic-work limit…** opens that setting while leaving the goal paused; Back and Escape make no change.
+**Start with token budget…** first offers `25k`, a suggested `100k`, `300k`, and **Set a custom budget…**, then collects the objective with the selected budget still visible.
+Custom input accepts examples such as `300000`, `300k`, `2.5k`, and `1.5m`; invalid input retains its draft for correction.
+Status, Settings, Help, invalid-settings guidance, Clear, and Close remain shallow, labeled routes.
+Arrow keys navigate, Enter selects or submits, Escape goes Back, and Ctrl+C closes the full flow.
+- In RPC mode, bare `/goal` and `/goal status` report the current summary through an observable notification without opening terminal UI.
+  Pi exposes no extension-command output channel in print or JSON mode, so those routes reject with an explicit unsupported-mode error instead of misreporting stderr as status output.
+- Menu-driven Replace and Clear actions preview the exact affected goal and require confirmation.
+  Existing direct routes remain immediate for compatibility and automation.
+- `/goal <goal_to_complete>` starts goal mode.
+  If another unfinished goal exists, Pi asks for confirmation before replacing it with a new active goal and resetting its usage counters.
+  Failed kickoff delivery clears a new goal or restores the prior goal; a previously active goal is restored as paused.
+- `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget.
+  `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
+- `/goal edit <goal_to_complete>` updates the existing goal objective without resetting usage counters.
+  A successful active edit rotates the stale-turn guard and starts a fresh safety epoch.
+  Paused, blocked, and usage-limited goals stay stopped and retain their safety state until resume.
+  A budget-limited goal reactivates only when `edit --tokens` raises its budget above current usage.
+  Failed prompt delivery restores the exact previous safety counters/cause; it restores a budget-limited goal or restores and pauses a previously active goal.
+- `/goal pause` stops prompt injection and auto-continuation, aborts the current turn, and keeps the goal for later resume.
+  Only active goals can be paused.
+- `/goal resume` resumes a paused, blocked, usage-limited, or budget-limited goal when its token budget allows it, rotates the stale-turn guard id, resets the automatic-response/repeat safety epoch when the queued resume prompt starts, clears a safety-pause cause, and reports the new finite epoch or explicit Unlimited state.
+  Objective, cumulative usage, and elapsed time are preserved.
+  If prompt delivery fails, the original stopped state, guard id, counters, fingerprint, and cause are restored.
 - `/goal clear` clears the current goal, status, pending continuation, inert legacy queue state, and legacy persisted state for the current working directory without aborting unrelated in-flight work.
 
 The experimental ordered-goal queue has been removed.
@@ -156,7 +181,8 @@ For example, if `task b` is complete and `task c` is in progress, edit the objec
 Former queue command words such as `add`, `prioritize`, `drop-last`, `skip`, `push`, `unshift`, `pop`, and `shift` are ordinary objective text for unaffected users.
 If a session still has legacy queue settings or persisted queue state, those words show a migration warning instead of replacing the active Goal.
 
-Goal objectives are limited to 4,000 characters. Put longer instructions in a file and reference the file path from `/goal`.
+Goal objectives are limited to 4,000 characters.
+Put longer instructions in a file and reference the file path from `/goal`.
 
 ## 🛠️ Tools
 
@@ -166,17 +192,31 @@ Goal objectives are limited to 4,000 characters. Put longer instructions in a fi
 
 ## 🔁 Session and reload behavior
 
-Goal state is stored as Pi session state, similar to Codex's thread-owned goals. `/reload` and reopening the same Pi session can restore that session's unfinished goal. An active restored goal already at or above its finite automatic-work limit pauses before another provider request and reports that progress is saved; use `/goal` to review and continue. A restored waiting Goal remains quiet, excludes offline and waiting wall time from active elapsed time, and restores only its absolute optional deadline timer. With `"after-first-goal"`, an unfinished restore marks the tools unlocked in the new extension runtime, but it does not widen an active-tool set already restricted by an earlier lifecycle handler; an active goal instead restores as paused when either terminal tool is missing. If no unfinished goal remains, a fresh runtime starts locked again. Active elapsed time is checkpointed before shutdown and restarted after reload only when the Goal is not waiting, so offline and stopped wall-clock time is excluded. Automatic-response counts, repeat fingerprints, and safety-pause causes persist across reload and compaction. A direct non-`/goal` user/RPC input resets the safety epoch only while the goal is active and reclassifies the in-flight run as manual; extension input and messages sent while stopped do not reset it. Starting a new Pi session in the same working directory does not inherit the old goal.
+Goal state is stored as Pi session state, similar to Codex's thread-owned goals.
+`/reload` and reopening the same Pi session can restore that session's unfinished goal.
+An active restored goal already at or above its finite automatic-work limit pauses before another provider request and reports that progress is saved; use `/goal` to review and continue.
+A restored waiting Goal remains quiet, excludes offline and waiting wall time from active elapsed time, and restores only its absolute optional deadline timer.
+With `"after-first-goal"`, an unfinished restore marks the tools unlocked in the new extension runtime, but it does not widen an active-tool set already restricted by an earlier lifecycle handler; an active goal instead restores as paused when either terminal tool is missing.
+If no unfinished goal remains, a fresh runtime starts locked again.
+Active elapsed time is checkpointed before shutdown and restarted after reload only when the Goal is not waiting, so offline and stopped wall-clock time is excluded.
+Automatic-response counts, repeat fingerprints, and safety-pause causes persist across reload and compaction.
+A direct non-`/goal` user/RPC input resets the safety epoch only while the goal is active and reclassifies the in-flight run as manual; extension input and messages sent while stopped do not reset it.
+Starting a new Pi session in the same working directory does not inherit the old goal.
 
-The legacy `{ goal }` shape remains valid, and missing safety fields normalize to zero/defaults. Sessions created by the former standalone `pi-goals` experiment can still restore exactly one ordinary unfinished goal when no canonical `goal-state` entry exists.
+The legacy `{ goal }` shape remains valid, and missing safety fields normalize to zero/defaults.
+Sessions created by the former standalone `pi-goals` experiment can still restore exactly one ordinary unfinished goal when no canonical `goal-state` entry exists.
 
-If a session still contains old queue metadata, multiple legacy goals, a queued head, or a pending queue transition, pi-goal treats that state as inert legacy data. It does not inject Goal prompts, advance the queue, or run any retained item automatically. Affected users receive a warning that recommends starting one merged objective with `/goal <objectives>`, or using `/goal clear` to discard the old queue state.
+If a session still contains old queue metadata, multiple legacy goals, a queued head, or a pending queue transition, pi-goal treats that state as inert legacy data.
+It does not inject Goal prompts, advance the queue, or run any retained item automatically.
+Affected users receive a warning that recommends starting one merged objective with `/goal <objectives>`, or using `/goal clear` to discard the old queue state.
 
-Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed by working directory. This version no longer reads that global file, and `/goal clear` removes any legacy entry for the current working directory.
+Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed by working directory.
+This version no longer reads that global file, and `/goal clear` removes any legacy entry for the current working directory.
 
 ## 📊 Statusline states
 
-`pi-goal` writes compact plain status strings for statusline extensions. `@narumitw/pi-statusline` adds the default `🎯` icon unless configured otherwise:
+`pi-goal` writes compact plain status strings for statusline extensions.
+`@narumitw/pi-statusline` adds the default `🎯` icon unless configured otherwise:
 
 - `active 3m · automatic 12/25` — an active goal without a token budget; elapsed time counts only periods when its status is active and not waiting.
 - `waiting review monitor · automatic 12/25` — an active Goal is quiet until non-Goal work or its optional deadline wakes it; the displayed reason is sanitized and bounded.
@@ -191,33 +231,54 @@ Older versions wrote unfinished goals to `~/.pi/agent/pi-goal-state.json` keyed 
 
 ## 💰 Token budgets and elapsed time
 
-The TUI budget chooser describes token budgets as cumulative Goal usage, warns that the final model
-call may exceed the chosen value, and keeps the independent automatic-work response limit visible.
-It is not a dollar-cost cap. Choosing a preset or entering a custom value remains provisional until
-the objective is submitted; cancelling the chooser, custom input, or objective editor creates no
-Goal. **Increase budget and resume…** shows the exact current budget and usage, requires a new total
-above current usage, previews the new total plus automatic-work epoch, and resumes only after
-confirmation. If the goal or its usage changes while that dialog is open, no change is applied.
+The TUI budget chooser describes token budgets as cumulative Goal usage, warns that the final model call may exceed the chosen value, and keeps the independent automatic-work response limit visible.
+It is not a dollar-cost cap.
+Choosing a preset or entering a custom value remains provisional until the objective is submitted; cancelling the chooser, custom input, or objective editor creates no Goal.
+**Increase budget and resume…** shows the exact current budget and usage, requires a new total above current usage, previews the new total plus automatic-work epoch, and resumes only after confirmation.
+If the goal or its usage changes while that dialog is open, no change is applied.
 
-For each persisted assistant message, `pi-goal` uses finite, non-negative `usage.totalTokens` when available. For compatibility with older or partial records, it otherwise sums finite, non-negative `input + output + cacheRead + cacheWrite`. It does not add `reasoning` because reasoning is already part of output, or `cacheWrite1h` because that is a subset of cache writes. Goal usage is the current branch's cumulative assistant total minus the baseline captured when the goal started, clamped at zero after branch rewinds.
+For each persisted assistant message, `pi-goal` uses finite, non-negative `usage.totalTokens` when available.
+For compatibility with older or partial records, it otherwise sums finite, non-negative `input + output + cacheRead + cacheWrite`.
+It does not add `reasoning` because reasoning is already part of output, or `cacheWrite1h` because that is a subset of cache writes.
+Goal usage is the current branch's cumulative assistant total minus the baseline captured when the goal started, clamped at zero after branch rewinds.
 
-Provider usage becomes authoritative only when an assistant message finishes, so a budget can overshoot by one model call. When completed tool activity first exposes exhaustion, the goal transitions once to `budget_limited`, cancels continuation, and queues one bounded custom wrap-up instruction before the next model call. The instruction permits only a concise progress/results/blockers summary; a substantive tool attempt is blocked and aborts the remaining wrap-up. A rejected `goal_complete` also terminates the wrap-up, while accepted completion still requires existing evidence that proves every requirement—budget exhaustion itself never means completion. If exhaustion is first visible at `agent_end` and no turn remains, the extension stops without creating another model turn.
+Provider usage becomes authoritative only when an assistant message finishes, so a budget can overshoot by one model call.
+When completed tool activity first exposes exhaustion, the goal transitions once to `budget_limited`, cancels continuation, and queues one bounded custom wrap-up instruction before the next model call.
+The instruction permits only a concise progress/results/blockers summary; a substantive tool attempt is blocked and aborts the remaining wrap-up.
+A rejected `goal_complete` also terminates the wrap-up, while accepted completion still requires existing evidence that proves every requirement—budget exhaustion itself never means completion.
+If exhaustion is first visible at `agent_end` and no turn remains, the extension stops without creating another model turn.
 
-The default 25-response automatic-work limit is a response-count boundary, not a fixed cost ceiling: context size, cache pricing, output length, and provider rates vary, and the final capped response is still retained. Pi derives displayed cost estimates from provider-reported token usage and local model pricing; pi-goal does not query a billing balance or enforce a dollar cap. For tighter token control, choose a smaller `automaticTurns` value and/or use `/goal --tokens`; choosing Unlimited removes only the response-count boundary.
+The default 25-response automatic-work limit is a response-count boundary, not a fixed cost ceiling: context size, cache pricing, output length, and provider rates vary, and the final capped response is still retained.
+Pi derives displayed cost estimates from provider-reported token usage and local model pricing; pi-goal does not query a billing balance or enforce a dollar cap.
+For tighter token control, choose a smaller `automaticTurns` value and/or use `/goal --tokens`; choosing Unlimited removes only the response-count boundary.
 
-Elapsed time is accumulated only while status is `active`. Pause, blocked, usage-limited, budget-limited, shutdown, and offline periods do not increase it. Legacy session entries are migrated by preserving their accumulated seconds and starting a fresh active clock when loaded.
+Elapsed time is accumulated only while status is `active`.
+Pause, blocked, usage-limited, budget-limited, shutdown, and offline periods do not increase it.
+Legacy session entries are migrated by preserving their accumulated seconds and starting a fresh active clock when loaded.
 
 ## ✅ How completion works
 
-While a goal is active, `pi-goal` injects persistence rules, a `<goal_id>` stale-turn guard, and exposes `goal_complete`. Kickoff, resume, edited-objective, system, and automatic-continuation prompts all place a trust boundary before the escaped objective, identifying it as user-provided task data; they preserve its full scope across turns and require the agent to derive concrete requirements from the objective and referenced artifacts. They treat the current worktree, command output, tests, runtime behavior, PR state, rendered artifacts, and external state as authoritative; previous conversation and plans are context rather than proof.
+While a goal is active, `pi-goal` injects persistence rules, a `<goal_id>` stale-turn guard, and exposes `goal_complete`.
+Kickoff, resume, edited-objective, system, and automatic-continuation prompts all place a trust boundary before the escaped objective, identifying it as user-provided task data; they preserve its full scope across turns and require the agent to derive concrete requirements from the objective and referenced artifacts.
+They treat the current worktree, command output, tests, runtime behavior, PR state, rendered artifacts, and external state as authoritative; previous conversation and plans are context rather than proof.
 
-Before completion, the shared audit tells the agent to treat completion as unproven, inspect requirement-by-requirement evidence for every named artifact, command, test, gate, invariant, and deliverable, and match each check's scope to the requirement it supports. Weak, indirect, missing, or merely consistent evidence means work must continue. This prompt wording is a behavioral guardrail, not proof by itself: `pi-goal` can enforce the current goal id and reject empty or plainly contradictory summaries, but it cannot independently prove that external work is complete.
+Before completion, the shared audit tells the agent to treat completion as unproven, inspect requirement-by-requirement evidence for every named artifact, command, test, gate, invariant, and deliverable, and match each check's scope to the requirement it supports.
+Weak, indirect, missing, or merely consistent evidence means work must continue.
+This prompt wording is a behavioral guardrail, not proof by itself: `pi-goal` can enforce the current goal id and reject empty or plainly contradictory summaries, but it cannot independently prove that external work is complete.
 
-To finish, the agent must call `goal_complete` with the exact current `goal_id` and a `summary` of completion evidence. Missing or stale `goal_id` values are rejected before summary validation. Paused, blocked, and usage-limited goals cannot be completed until resumed; a budget-limited goal permits completion only during its bounded in-flight wrap-up. The summary is completion evidence, not the stale-turn safety token.
+To finish, the agent must call `goal_complete` with the exact current `goal_id` and a `summary` of completion evidence.
+Missing or stale `goal_id` values are rejected before summary validation.
+Paused, blocked, and usage-limited goals cannot be completed until resumed; a budget-limited goal permits completion only during its bounded in-flight wrap-up.
+The summary is completion evidence, not the stale-turn safety token.
 
-If a turn ends before completion, `pi-goal` records usage and creates one continuation intent unless a circuit breaker pauses it first. It dispatches that continuation only from Pi's `agent_settled` lifecycle after retries, automatic compaction, steering, and follow-up work have drained, `ctx.isIdle()` is true, and no messages are pending. Repeated settled events cannot dispatch the same intent twice. Goal-owned kickoff, resume, active-edit, and automatic-continuation deliveries are bound to the goal instance that created them; a delayed prompt from a replaced goal is aborted without rolling back, injecting, or stopping the newer goal. Plain assistant text never marks a goal complete—even an exact-reply objective pauses safely when the model repeatedly omits `goal_complete`.
+If a turn ends before completion, `pi-goal` records usage and creates one continuation intent unless a circuit breaker pauses it first.
+It dispatches that continuation only from Pi's `agent_settled` lifecycle after retries, automatic compaction, steering, and follow-up work have drained, `ctx.isIdle()` is true, and no messages are pending.
+Repeated settled events cannot dispatch the same intent twice.
+Goal-owned kickoff, resume, active-edit, and automatic-continuation deliveries are bound to the goal instance that created them; a delayed prompt from a replaced goal is aborted without rolling back, injecting, or stopping the newer goal.
+Plain assistant text never marks a goal complete—even an exact-reply objective pauses safely when the model repeatedly omits `goal_complete`.
 
-Manual compaction does not emit `agent_settled`, so its completion hook uses the same single-flight dispatcher as a narrow idle-only fallback. Pi extensions cannot reserve an idle turn atomically like Codex core; another extension can still win the race after the idle check, and its newer turn supersedes the old continuation intent.
+Manual compaction does not emit `agent_settled`, so its completion hook uses the same single-flight dispatcher as a narrow idle-only fallback.
+Pi extensions cannot reserve an idle turn atomically like Codex core; another extension can still win the race after the idle check, and its newer turn supersedes the old continuation intent.
 
 ## ⏳ External waiting
 
@@ -231,31 +292,59 @@ goal_wait({
 })
 ```
 
-`goal_id` must match the current active Goal, `reason` must contain 1–1,000 characters, and the optional `resume_after_ms` must be a whole number from 1 through 2,147,483,647. The deadline is a safety wake-up rather than a polling interval. Requests below 10,000 milliseconds are accepted for compatibility but clamped to an effective 10,000-millisecond deadline; the tool result reports both the requested and effective values. Prefer deadlines measured in minutes instead of repeated short wakes. Omitting `resume_after_ms` intentionally permits an indefinite quiet wait.
+`goal_id` must match the current active Goal, `reason` must contain 1–1,000 characters, and the optional `resume_after_ms` must be a whole number from 1 through 2,147,483,647.
+The deadline is a safety wake-up rather than a polling interval.
+Requests below 10,000 milliseconds are accepted for compatibility but clamped to an effective 10,000-millisecond deadline; the tool result reports both the requested and effective values.
+Prefer deadlines measured in minutes instead of repeated short wakes.
+Omitting `resume_after_ms` intentionally permits an indefinite quiet wait.
 
-An accepted call keeps the canonical Goal status active, checkpoints active elapsed time, cancels pending continuation work, persists the reason and absolute optional deadline, and terminates the normal single-tool run. Call `goal_wait` alone because Pi only guarantees early termination when every finalized result in a parallel tool batch terminates.
+An accepted call keeps the canonical Goal status active, checkpoints active elapsed time, cancels pending continuation work, persists the reason and absolute optional deadline, and terminates the normal single-tool run.
+Call `goal_wait` alone because Pi only guarantees early termination when every finalized result in a parallel tool batch terminates.
 
-Interactive input, RPC input, another extension's `sendUserMessage()` input, and supported non-Goal custom follow-ups clear the wait before their turn runs. pi-goal-owned kickoff, resume, edit, continuation, stale, or cancelled prompts do not count as external wake-ups. Pi does not expose the sending extension's identity, so any non-Goal extension message is treated as a wake signal.
+Interactive input, RPC input, another extension's `sendUserMessage()` input, and supported non-Goal custom follow-ups clear the wait before their turn runs. pi-goal-owned kickoff, resume, edit, continuation, stale, or cancelled prompts do not count as external wake-ups.
+Pi does not expose the sending extension's identity, so any non-Goal extension message is treated as a wake signal.
 
-After a waking turn ends, ordinary continuation rules apply again. The agent can complete or block the Goal, continue working, or call `goal_wait` again after arranging the next wake source. `/goal resume` also clears waiting and sends one manual resume prompt without resetting cumulative usage or the safety epoch. `/goal pause`, clear, edit, replace, completion, blocking, terminal limits, tool loss, session replacement, and shutdown cancel the in-memory deadline owner.
+After a waking turn ends, ordinary continuation rules apply again.
+The agent can complete or block the Goal, continue working, or call `goal_wait` again after arranging the next wake source.
+`/goal resume` also clears waiting and sends one manual resume prompt without resetting cumulative usage or the safety epoch.
+`/goal pause`, clear, edit, replace, completion, blocking, terminal limits, tool loss, session replacement, and shutdown cancel the in-memory deadline owner.
 
-A future deadline is restored from its absolute timestamp after reload. Reload never restarts, extends, or newly clamps an already-persisted absolute deadline, including a short deadline written by an older version. An already-due deadline waits for Pi's settled, idle, no-pending-message boundary and then requests exactly one continuation through the normal dispatcher. If that delivery throws, pi-goal restores the wait, retries once after one second, and leaves the Goal visibly waiting after a second failure instead of retry-looping. A deadline never sends a prompt directly from a stale timer.
+A future deadline is restored from its absolute timestamp after reload.
+Reload never restarts, extends, or newly clamps an already-persisted absolute deadline, including a short deadline written by an older version.
+An already-due deadline waits for Pi's settled, idle, no-pending-message boundary and then requests exactly one continuation through the normal dispatcher.
+If that delivery throws, pi-goal restores the wait, retries once after one second, and leaves the Goal visibly waiting after a second failure instead of retry-looping.
+A deadline never sends a prompt directly from a stale timer.
 
-Waiting time is excluded from **Active elapsed**, while tokens, iteration, automatic-response count, no-progress state, managed-run ownership remain preserved. The managed-run protocol continues reporting `active` because waiting is non-terminal. Editing or replacing a waiting Goal clears the previous wait so the updated objective performs a fresh external-state check.
+Waiting time is excluded from **Active elapsed**, while tokens, iteration, automatic-response count, no-progress state, managed-run ownership remain preserved.
+The managed-run protocol continues reporting `active` because waiting is non-terminal.
+Editing or replacing a waiting Goal clears the previous wait so the updated objective performs a fresh external-state check.
 
 ## 🚧 Blocked goals
 
-`goal_blocked` is intentionally narrower than completion or ordinary clarification. Every goal-mode prompt repeats the blocked audit: the model must provide the exact current `goal_id`, a specific reason describing the user or external action required (up to 1,000 characters), concrete evidence from the failed resolution attempts (up to 4,000 characters), and `repeated_turns` showing the same blocker recurred for at least three consecutive goal turns. A resumed goal starts a fresh blocker audit. Empty or oversized reasons/evidence, stale ids, non-whole turn counts, stopped goals, and fewer than three turns are rejected. Accepted blocker reports set `blocked`, stop automatic continuation, and terminate the tool batch when Pi can do so safely.
+`goal_blocked` is intentionally narrower than completion or ordinary clarification.
+Every goal-mode prompt repeats the blocked audit: the model must provide the exact current `goal_id`, a specific reason describing the user or external action required (up to 1,000 characters), concrete evidence from the failed resolution attempts (up to 4,000 characters), and `repeated_turns` showing the same blocker recurred for at least three consecutive goal turns.
+A resumed goal starts a fresh blocker audit.
+Empty or oversized reasons/evidence, stale ids, non-whole turn counts, stopped goals, and fewer than three turns are rejected.
+Accepted blocker reports set `blocked`, stop automatic continuation, and terminate the tool batch when Pi can do so safely.
 
-Do not use `goal_blocked` merely because work is difficult, incomplete, uncertain, awaiting normal clarification, or affected by a recoverable tool/provider failure. The user can resolve the external condition and run `/goal resume` to rotate the goal id and continue.
+Do not use `goal_blocked` merely because work is difficult, incomplete, uncertain, awaiting normal clarification, or affected by a recoverable tool/provider failure.
+The user can resolve the external condition and run `/goal resume` to rotate the goal id and continue.
 
 ## 🛑 Interruption and queued-input behavior
 
-A user pause or aborted turn produces `paused`; a terminal provider/account quota error produces `usage_limited`; another non-retryable agent error produces `blocked`. Each stopped transition cancels pending continuation intent or delivery, aborts stale work when applicable, and blocks stale tool calls until the next non-goal user prompt, successful reactivation/replacement, or `/goal clear`. On `/goal clear`, the extension clears goal state, continuation markers, and any stale tool-call block without aborting an unrelated in-flight turn. Retryable provider interruptions and overflow compaction retries stay `active` while Pi retries; no extra continuation is queued, and automatic ownership remains charged through retry `agent_start` events. If matching recovery still exists at `agent_settled`, retries are exhausted and the goal becomes `blocked` before any continuation dispatches. Stale recovery cannot block a replacement goal. User and extension work that starts before settlement supersedes the older continuation intent, and pending messages always take priority.
+A user pause or aborted turn produces `paused`; a terminal provider/account quota error produces `usage_limited`; another non-retryable agent error produces `blocked`.
+Each stopped transition cancels pending continuation intent or delivery, aborts stale work when applicable, and blocks stale tool calls until the next non-goal user prompt, successful reactivation/replacement, or `/goal clear`.
+On `/goal clear`, the extension clears goal state, continuation markers, and any stale tool-call block without aborting an unrelated in-flight turn.
+Retryable provider interruptions and overflow compaction retries stay `active` while Pi retries; no extra continuation is queued, and automatic ownership remains charged through retry `agent_start` events.
+If matching recovery still exists at `agent_settled`, retries are exhausted and the goal becomes `blocked` before any continuation dispatches.
+Stale recovery cannot block a replacement goal.
+User and extension work that starts before settlement supersedes the older continuation intent, and pending messages always take priority.
 
 ## 🤝 Managed run RPC
 
-With `rpc.enabled: true`, pi-goal exposes a session-local, dependency-free protocol over Pi's shared `pi.events` bus. It is intended for trusted sibling extensions that need to start, observe, and cancel one Goal lifecycle without driving the `/goal` command. Installed Pi extensions remain fully privileged: this setting controls only whether pi-goal cooperates with these channels and is not authentication or sandboxing.
+With `rpc.enabled: true`, pi-goal exposes a session-local, dependency-free protocol over Pi's shared `pi.events` bus.
+It is intended for trusted sibling extensions that need to start, observe, and cancel one Goal lifecycle without driving the `/goal` command.
+Installed Pi extensions remain fully privileged: this setting controls only whether pi-goal cooperates with these channels and is not authentication or sandboxing.
 
 The public channels are:
 
@@ -265,7 +354,8 @@ pi-goal:cancel
 pi-goal:event:${runId}
 ```
 
-The protocol intentionally has no separate version field or versioned channel namespace. Before starting, the caller must generate a session-unique `runId`, subscribe to its event channel, and then emit:
+The protocol intentionally has no separate version field or versioned channel namespace.
+Before starting, the caller must generate a session-unique `runId`, subscribe to its event channel, and then emit:
 
 ```ts
 pi.events.emit("pi-goal:start", {
@@ -275,7 +365,9 @@ pi.events.emit("pi-goal:start", {
 });
 ```
 
-`runId` must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`; UUIDs are recommended. It is a correlation identifier, not a secret or authenticated caller identity. The objective uses the same 4,000-character validation as `/goal`, and `tokenBudget` is an absolute positive integer rather than a `k`/`m` string.
+`runId` must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`; UUIDs are recommended.
+It is a correlation identifier, not a secret or authenticated caller identity.
+The objective uses the same 4,000-character validation as `/goal`, and `tokenBudget` is an absolute positive integer rather than a `k`/`m` string.
 
 A successful start produces canonical state on `pi-goal:event:${runId}`:
 
@@ -288,9 +380,15 @@ A successful start produces canonical state on `pi-goal:event:${runId}`:
 }
 ```
 
-Subsequent state events use `active`, `complete`, `blocked`, `paused`, `usage_limited`, `budget_limited`, or `cleared`. `complete` is the only successful terminal outcome. A matching completion may include `summary`; other terminal outcomes may include `reason`. Events come only from canonical Goal persistence and only for the matching managed run. Manual and restored Goals are not adopted or broadcast, unchanged persistence does not duplicate a status, and each run emits at most one terminal event.
+Subsequent state events use `active`, `complete`, `blocked`, `paused`, `usage_limited`, `budget_limited`, or `cleared`.
+`complete` is the only successful terminal outcome.
+A matching completion may include `summary`; other terminal outcomes may include `reason`.
+Events come only from canonical Goal persistence and only for the matching managed run.
+Manual and restored Goals are not adopted or broadcast, unchanged persistence does not duplicate a status, and each run emits at most one terminal event.
 
-Terminal events are dispatched after the underlying Goal transition settles, so a listener can start the next managed run directly after `complete` without re-entering completion cleanup. Other terminal statuses leave a stopped Goal that must be resolved or cleared first. If a manual edit, replacement, or edit transition rotates the Goal id, the prior managed run ends as `cleared` with a superseded reason; the replacement remains outside that run.
+Terminal events are dispatched after the underlying Goal transition settles, so a listener can start the next managed run directly after `complete` without re-entering completion cleanup.
+Other terminal statuses leave a stopped Goal that must be resolved or cleared first.
+If a manual edit, replacement, or edit transition rotates the Goal id, the prior managed run ends as `cleared` with a superseded reason; the replacement remains outside that run.
 
 To cancel before or after activation, emit the same `runId`:
 
@@ -301,7 +399,10 @@ pi.events.emit("pi-goal:cancel", {
 });
 ```
 
-Cancellation uses the normal Goal pause transition. It cannot affect a manual, restored, stale, or different run. The resulting `paused` state is the cancellation result; there is no separate reply envelope. A caller must not reopen a terminal `runId`, and a later manual `/goal resume` is outside that completed managed run.
+Cancellation uses the normal Goal pause transition.
+It cannot affect a manual, restored, stale, or different run.
+The resulting `paused` state is the cancellation result; there is no separate reply envelope.
+A caller must not reopen a terminal `runId`, and a later manual `/goal resume` is outside that completed managed run.
 
 Rejected operations emit a structured error on the same run event channel:
 
@@ -317,11 +418,16 @@ Rejected operations emit a structured error on the same run event channel:
 }
 ```
 
-Stable codes are `RPC_DISABLED`, `INVALID_REQUEST`, `NO_ACTIVE_SESSION`, `RUN_ID_IN_USE`, `RUN_NOT_FOUND`, `GOAL_ALREADY_EXISTS`, `ACTIVATION_FAILED`, and `SUPERSEDED`. Consumers branch on `code`; `message` is diagnostic. An unsafe or missing `runId` is ignored because there is no safe response channel.
+Stable codes are `RPC_DISABLED`, `INVALID_REQUEST`, `NO_ACTIVE_SESSION`, `RUN_ID_IN_USE`, `RUN_NOT_FOUND`, `GOAL_ALREADY_EXISTS`, `ACTIVATION_FAILED`, and `SUPERSEDED`.
+Consumers branch on `code`; `message` is diagnostic.
+An unsafe or missing `runId` is ignored because there is no safe response channel.
 
-Start never prompts for replacement: any pre-existing Goal is rejected. The protocol binds only after current settings and restored Goal state load, and unbinds before session shutdown. A caller must not assume that `emit()` waits for Goal completion; it should wait for a terminal run event and participate in its own session-shutdown cleanup.
+Start never prompts for replacement: any pre-existing Goal is rejected.
+The protocol binds only after current settings and restored Goal state load, and unbinds before session shutdown.
+A caller must not assume that `emit()` waits for Goal completion; it should wait for a terminal run event and participate in its own session-shutdown cleanup.
 
-This breaking contract replaces and removes `pi-goal:rpc:start`, `pi-goal:rpc:pause`, request-scoped start replies, and the global `pi-goal:state` broadcast. No compatibility aliases are registered.
+This breaking contract replaces and removes `pi-goal:rpc:start`, `pi-goal:rpc:pause`, request-scoped start replies, and the global `pi-goal:state` broadcast.
+No compatibility aliases are registered.
 
 ## 🧠 Use cases
 
@@ -359,7 +465,8 @@ packages/pi-goal/
 └── package.json
 ```
 
-`index.ts` is the Pi entrypoint and forwards to `goal.ts`; the other source modules are internal. The package exposes its Pi extension through `package.json`:
+`index.ts` is the Pi entrypoint and forwards to `goal.ts`; the other source modules are internal.
+The package exposes its Pi extension through `package.json`:
 
 ```json
 {
@@ -377,4 +484,5 @@ Pi extension, Pi coding agent, goal mode, autonomous coding agent, AI agent work
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-langfuse/README.md
+++ b/packages/pi-langfuse/README.md
@@ -1,24 +1,18 @@
-# 🪢 pi-langfuse — Langfuse Observability for Pi
+# 🪢 pi-langfuse — Trace Pi Runs in Langfuse
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-langfuse)](https://www.npmjs.com/package/@narumitw/pi-langfuse) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-langfuse` is a [Pi coding agent](https://pi.dev) extension that sends Pi LLM generations, agent runs, and tool executions to [Langfuse](https://langfuse.com/) through OpenTelemetry.
+Trace Pi agent runs, model generations, retries, tools, compaction, usage, and timing in [Langfuse](https://langfuse.com/) through OpenTelemetry.
 
 ## ✨ Features
 
-- Names each Langfuse trace `pi.trace` and uses a native `pi.agent` as its root observation.
-- Keeps the root agent open until settlement, with indexed `pi.attempt` spans for retries and queued continuations.
-- Records bounded provider-request snapshots, finalized assistant outputs, requested/response identity, TTFT, usage, and known cost buckets.
-- Retains ordered HTTP response history and safe diagnostic headers without marking recovered requests as errors.
-- Records final tool inputs and outputs, progress timing, duration, and failures without exporting partial-result content.
-- Records active compactions structurally without exporting generated summary text.
-- Groups traces with Pi's session id and adds bounded session/context snapshots and aggregate counters.
-- Adds the run-start Git branch and commit as metadata plus a filterable branch tag.
-- Reads Langfuse credentials and options only from a private `pi-langfuse.json` file.
-- Batches routine exports without delaying normal Pi agent completion.
-- Keeps its OpenTelemetry provider isolated so it coexists with other tracing extensions.
-- Redacts Langfuse public and secret keys from exported trace data.
+- Groups each settled agent run into one trace with indexed attempt spans for retries and queued continuations.
+- Records bounded provider requests, final assistant output, identity, TTFT, usage, known costs, and safe response diagnostics.
+- Captures final tool inputs and outputs, progress timing, duration, failures, and structural compaction events.
+- Adds session, context, Git branch, commit, and aggregate counters as searchable metadata.
 - Supports metadata-only tracing when content capture is disabled.
+- Reads credentials only from a private local settings file and redacts them from exported data.
+- Batches exports without delaying normal completion and isolates its OpenTelemetry provider from other extensions.
 
 ## 📦 Install
 
@@ -53,9 +47,18 @@ Run the interactive manager, then choose **Set up Langfuse for this Pi agent dir
 /langfuse
 ```
 
-The setup flow prompts for the secret key, public key, and base URL in the same order Langfuse presents them. Leave either key blank to preserve its existing value when updating a valid config. Leave the base URL blank to use `https://us.cloud.langfuse.com`. The first successful setup creates the file. Within one Pi process, updates run in invocation order, reread the latest valid private document, preserve unknown fields, and save atomically with mode `0600`. Malformed JSON or invalid recognized fields block setup and update writes until repaired; errors redact entered and stored credentials. A failed save leaves the current session and prior file unchanged.
+The setup flow prompts for the secret key, public key, and base URL in the same order Langfuse presents them.
+Leave either key blank to preserve its existing value when updating a valid config.
+Leave the base URL blank to use `https://us.cloud.langfuse.com`.
+The first successful setup creates the file.
+Within one Pi process, updates run in invocation order, reread the latest valid private document, preserve unknown fields, and save atomically with mode `0600`.
+Malformed JSON or invalid recognized fields block setup and update writes until repaired; errors redact entered and stored credentials.
+A failed save leaves the current session and prior file unchanged.
 
-Configuration belongs to the displayed Pi agent directory, not just the current conversation. Restart each running Pi process after saving; the new connection applies to subsequent sessions in that process. `/reload` is not sufficient because the isolated Langfuse runtime is initialized once per process. In print or JSON mode, edit the file manually because the interactive manager is unavailable.
+Configuration belongs to the displayed Pi agent directory, not just the current conversation.
+Restart each running Pi process after saving; the new connection applies to subsequent sessions in that process.
+`/reload` is not sufficient because the isolated Langfuse runtime is initialized once per process.
+In print or JSON mode, edit the file manually because the interactive manager is unavailable.
 
 You can also create the file manually:
 
@@ -71,17 +74,26 @@ You can also create the file manually:
 }
 ```
 
-`publicKey` and `secretKey` are required literal strings. Environment-variable and command interpolation are intentionally unsupported. `baseUrl` defaults to `https://us.cloud.langfuse.com`; regional and self-hosted HTTP or HTTPS endpoints are supported. Prefer HTTPS because HTTP sends Langfuse credentials and trace content without transport encryption.
+`publicKey` and `secretKey` are required literal strings.
+Environment-variable and command interpolation are intentionally unsupported.
+`baseUrl` defaults to `https://us.cloud.langfuse.com`; regional and self-hosted HTTP or HTTPS endpoints are supported.
+Prefer HTTPS because HTTP sends Langfuse credentials and trace content without transport encryption.
 
-`environment`, `release`, and `userId` are optional Langfuse trace attributes. An environment must match Langfuse's contract: at most 40 lowercase letters, numbers, hyphens, or underscores, and it cannot start with `langfuse`. `userId` populates the Langfuse user dimension, which is what the Sessions and Traces views group by; Langfuse accepts at most 200 characters, and leaving it unset reports no user. Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata without sending prompts, provider-request snapshots, responses, or tool content.
+`environment`, `release`, and `userId` are optional Langfuse trace attributes.
+An environment must match Langfuse's contract: at most 40 lowercase letters, numbers, hyphens, or underscores, and it cannot start with `langfuse`.
+`userId` populates the Langfuse user dimension, which is what the Sessions and Traces views group by; Langfuse accepts at most 200 characters, and leaving it unset reports no user.
+Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata without sending prompts, provider-request snapshots, responses, or tool content.
 
-The extension automatically restricts an existing config file to mode `0600` and refuses to load credentials if that protection cannot be enforced. You can also set it explicitly:
+The extension automatically restricts an existing config file to mode `0600` and refuses to load credentials if that protection cannot be enforced.
+You can also set it explicitly:
 
 ```bash
 chmod 600 ~/.pi/agent/pi-langfuse.json
 ```
 
-Restart Pi after changing credentials, endpoint, environment, release, or `captureContent`. Changes to `userId` apply to new sessions without restarting Pi. The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
+Restart Pi after changing credentials, endpoint, environment, release, or `captureContent`.
+Changes to `userId` apply to new sessions without restarting Pi.
+The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
 
 ## 🔭 What is traced
 
@@ -98,20 +110,27 @@ pi.trace
     └── pi.attempt ...
 ```
 
-All observations and the trace use schema version `2`. Schema version 2 adds indexed `pi.attempt` observations and active `pi.compaction` spans beneath the root agent.
+All observations and the trace use schema version `2`.
+Schema version 2 adds indexed `pi.attempt` observations and active `pi.compaction` spans beneath the root agent.
 
 ### Trace and attempt fields
 
-The trace and root `pi.agent` retain the submitted prompt, final assistant output, Pi session id, working directory, mode, initial provider/model, and optional Git context. Root metadata includes:
+The trace and root `pi.agent` retain the submitted prompt, final assistant output, Pi session id, working directory, mode, initial provider/model, and optional Git context.
+Root metadata includes:
 
 - `pi.trace.schema_version`, `pi.trace.outcome`, and `pi.trace.stop_reason`;
 - `pi.trace.attempt_count`, `pi.trace.turn_count`, `pi.trace.generation_count`, `pi.trace.tool_count`, `pi.trace.tool_error_count`, `pi.trace.compaction_count`, and `pi.trace.recovered_error_count`;
 - `pi.trace.start_leaf_id`, `pi.trace.end_leaf_id`, `pi.trace.start_context_tokens`, `pi.trace.end_context_tokens`, `pi.trace.start_context_window`, `pi.trace.end_context_window`, `pi.trace.start_context_percent`, and `pi.trace.end_context_percent` when Pi knows them;
 - `pi.git.branch`, `pi.git.commit`, and `pi.git.detached`, plus a `branch:<branch-name>` tag or `git:detached` tag.
 
-Outcomes are `success`, `recovered_success`, `error`, `aborted`, `length`, or `interrupted`. `pi.trace.recovered_error_count` includes recovered provider responses, tool failures handled by a later generation, and failed attempts followed by final success. Errors use Langfuse `ERROR`; aborts, output limits, shutdown, replacement, and other interruption closures use `WARNING`. High-cardinality correlation values stay in metadata rather than tags.
+Outcomes are `success`, `recovered_success`, `error`, `aborted`, `length`, or `interrupted`.
+`pi.trace.recovered_error_count` includes recovered provider responses, tool failures handled by a later generation, and failed attempts followed by final success.
+Errors use Langfuse `ERROR`; aborts, output limits, shutdown, replacement, and other interruption closures use `WARNING`.
+High-cardinality correlation values stay in metadata rather than tags.
 
-Each `pi.attempt` records `pi.attempt.index`, final `pi.attempt.outcome`, and `pi.attempt.stop_reason`. An attempt immediately following overflow compaction also sets `pi.attempt.reason` to `post_compaction`. Failed attempts remain errors even when a later attempt makes the root a recovered success.
+Each `pi.attempt` records `pi.attempt.index`, final `pi.attempt.outcome`, and `pi.attempt.stop_reason`.
+An attempt immediately following overflow compaction also sets `pi.attempt.reason` to `post_compaction`.
+Failed attempts remain errors even when a later attempt makes the root a recovered success.
 
 ### Generation fields
 
@@ -122,27 +141,50 @@ Each `pi.llm` generation records:
 - the Langfuse-native response model plus `pi.response.provider`, `pi.response.api`, `pi.response.model`, and `pi.response.id` when Pi reports them;
 - Langfuse-native `completionStartTime` from the first non-empty text, thinking, or tool-call delta;
 - ordered `http.response.status_codes`, final `http.response.status_code`, `http.response.attempt_count`, and `http.response.retry_count`;
-- allowlisted `http.response.headers`: request ids, `cf-ray`, `retry-after`, and the supported OpenAI/Anthropic rate-limit headers. Authorization, cookies, and unrecognized headers are never exported;
+- allowlisted `http.response.headers`: request ids, `cf-ray`, `retry-after`, and the supported OpenAI/Anthropic rate-limit headers.
+  Authorization, cookies, and unrecognized headers are never exported;
 - additive input, output, cache-read, cache-write, and total token usage plus known positive input, output, cache-read, cache-write, and total cost buckets;
 - non-additive `pi.usage.reasoning_tokens` and `pi.usage.cache_write_1h_tokens` in metadata so subsets are not double-counted.
 
-The request snapshot is the payload visible at this handler, not a guaranteed final wire payload: later extensions can still replace it. Final assistant content is reconciled from `turn_end` and `agent_end` after message transformation. A recovered sequence such as `429 -> 200` remains queryable in HTTP metadata but is not an error; the final assistant outcome decides generation severity.
+The request snapshot is the payload visible at this handler, not a guaranteed final wire payload: later extensions can still replace it.
+Final assistant content is reconciled from `turn_end` and `agent_end` after message transformation.
+A recovered sequence such as `429 -> 200` remains queryable in HTTP metadata but is not an error; the final assistant outcome decides generation severity.
 
 ### Tool and compaction fields
 
-A `pi.tool.<tool-name>` observation starts with raw `tool_execution_start` arguments as a fallback for calls that never execute, including calls blocked during `tool_call`. For executed calls, it uses the `tool_result` input as authoritative after all argument mutations. It captures final transformed output from `tool_execution_end`, final error state, `pi.tool.progress_update_count`, and `pi.tool.time_to_first_progress_ms` when progress occurs. An unrecovered tool failure also makes the attempt and root errors. Existing `pi.tool.call_id` and `pi.tool.name` correlation fields remain. `tool_execution_update` partial-result bodies are never captured. Duplicate, parallel, failed, no-progress, and interrupted tools are closed independently.
+A `pi.tool.<tool-name>` observation starts with raw `tool_execution_start` arguments as a fallback for calls that never execute, including calls blocked during `tool_call`.
+For executed calls, it uses the `tool_result` input as authoritative after all argument mutations.
+It captures final transformed output from `tool_execution_end`, final error state, `pi.tool.progress_update_count`, and `pi.tool.time_to_first_progress_ms` when progress occurs.
+An unrecovered tool failure also makes the attempt and root errors.
+Existing `pi.tool.call_id` and `pi.tool.name` correlation fields remain.
+`tool_execution_update` partial-result bodies are never captured.
+Duplicate, parallel, failed, no-progress, and interrupted tools are closed independently.
 
-An active `pi.compaction` records `pi.compaction.reason`, `pi.compaction.will_retry`, `pi.compaction.from_extension`, `pi.compaction.tokens_before`, `pi.compaction.messages_to_summarize`, `pi.compaction.turn_prefix_messages`, `pi.compaction.branch_entries`, and `pi.compaction.is_split_turn`. It adds `pi.compaction.read_file_count`, `pi.compaction.modified_file_count`, and `pi.compaction.usage.*` / `pi.compaction.cost.*` when Pi reports them. It never records the summary, custom instructions, or message bodies. Manual compaction outside an active agent trace is ignored; incomplete compaction closes as a warning at settlement or shutdown.
+An active `pi.compaction` records `pi.compaction.reason`, `pi.compaction.will_retry`, `pi.compaction.from_extension`, `pi.compaction.tokens_before`, `pi.compaction.messages_to_summarize`, `pi.compaction.turn_prefix_messages`, `pi.compaction.branch_entries`, and `pi.compaction.is_split_turn`.
+It adds `pi.compaction.read_file_count`, `pi.compaction.modified_file_count`, and `pi.compaction.usage.*` / `pi.compaction.cost.*` when Pi reports them.
+It never records the summary, custom instructions, or message bodies.
+Manual compaction outside an active agent trace is ignored; incomplete compaction closes as a warning at settlement or shutdown.
 
 ### Boundaries and export
 
-Images and embedded base64 data URIs are represented without their payloads, including provider data URLs. Opaque `thinkingSignature`, `textSignature`, and `thoughtSignature` continuity values are always removed. Every captured input or output has one cumulative 64 KiB serialized UTF-8 budget, bounded object/array traversal, and deterministic truncation markers. Langfuse credentials are masked again in the span processor before network export.
+Images and embedded base64 data URIs are represented without their payloads, including provider data URLs.
+Opaque `thinkingSignature`, `textSignature`, and `thoughtSignature` continuity values are always removed.
+Every captured input or output has one cumulative 64 KiB serialized UTF-8 budget, bounded object/array traversal, and deterministic truncation markers.
+Langfuse credentials are masked again in the span processor before network export.
 
-The root agent begins before the first agent loop and remains open across retries, overflow-compaction recovery, and queued continuations. `agent_end` closes only the current attempt; `agent_settled` closes the root after no automatic work remains. Activity that unexpectedly arrives without a submitted prompt gets a fallback root input labeled `[automatic continuation]`. Session replacement, reload, quit, and a new unexpected prompt close all descendants defensively and idempotently.
+The root agent begins before the first agent loop and remains open across retries, overflow-compaction recovery, and queued continuations.
+`agent_end` closes only the current attempt; `agent_settled` closes the root after no automatic work remains.
+Activity that unexpectedly arrives without a submitted prompt gets a fallback root input labeled `[automatic continuation]`.
+Session replacement, reload, quit, and a new unexpected prompt close all descendants defensively and idempotently.
 
-At run start, the extension performs bounded, non-shell Git lookups in `ctx.cwd`. A branch switch therefore applies to the next run. Detached HEADs retain only commit/detached metadata and the `git:detached` tag. Missing Git, non-repositories, timeouts, and lookup failures silently omit Git context without affecting tracing.
+At run start, the extension performs bounded, non-shell Git lookups in `ctx.cwd`.
+A branch switch therefore applies to the next run.
+Detached HEADs retain only commit/detached metadata and the `git:detached` tag.
+Missing Git, non-repositories, timeouts, and lookup failures silently omit Git context without affecting tracing.
 
-Completed observations are exported in batches while Pi remains live. Neither `agent_end` nor `agent_settled` waits for Langfuse network I/O. To wait for completed exports, run `/langfuse` and choose **Flush completed traces for this session**; quit shutdown also drains the provider.
+Completed observations are exported in batches while Pi remains live.
+Neither `agent_end` nor `agent_settled` waits for Langfuse network I/O.
+To wait for completed exports, run `/langfuse` and choose **Flush completed traces for this session**; quit shutdown also drains the provider.
 
 ## 💬 Commands
 
@@ -150,11 +192,11 @@ Completed observations are exported in batches while Pi remains live. Neither `a
 /langfuse
 ```
 
-The command opens one context-aware standard menu in TUI or RPC mode. Its state lines show the
-current session's tracing state, endpoint, content-capture mode, initialization failure when
-applicable, and private configuration path. It never displays credentials. Escape closes the menu.
-Credential and endpoint text inputs remain extension-owned because they enforce secret-preserving
-setup/update semantics rather than standard navigation.
+The command opens one context-aware standard menu in TUI or RPC mode.
+Its state lines show the current session's tracing state, endpoint, content-capture mode, initialization failure when applicable, and private configuration path.
+It never displays credentials.
+Escape closes the menu.
+Credential and endpoint text inputs remain extension-owned because they enforce secret-preserving setup/update semantics rather than standard navigation.
 
 Available actions depend on that state:
 
@@ -163,18 +205,23 @@ Available actions depend on that state:
 - **Update Langfuse for this Pi agent directory** appears when a valid config exists.
 - **Show setup and privacy help** explains the agent-directory scope, manual configuration path, and content-capture risk.
 
-Connection actions state their agent-directory scope and per-process restart requirement before
-selection. Command arguments are intentionally ignored so remembered subcommands cannot silently
-bypass the menu. Print and JSON modes reject the interactive command with an observable error that
-includes current tracing state and the manual configuration path.
+Connection actions state their agent-directory scope and per-process restart requirement before selection.
+Command arguments are intentionally ignored so remembered subcommands cannot silently bypass the menu.
+Print and JSON modes reject the interactive command with an observable error that includes current tracing state and the manual configuration path.
 
-## 🔐 Privacy
+## 🔒 Security and privacy
 
-With content capture enabled, traces can contain user prompts, model responses, tool arguments, and tool results. These may include source code, file contents, shell output, or other sensitive project data. Review your Langfuse retention and access controls before enabling this extension.
+With content capture enabled, traces can contain user prompts, model responses, tool arguments, and tool results.
+These may include source code, file contents, shell output, or other sensitive project data.
+Review your Langfuse retention and access controls before enabling this extension.
 
-Git branch names, commit ids, working directory, session/leaf ids, the configured `userId`, model identity, usage/cost, aggregate counts, and allowlisted response-header values are metadata. They remain exported when `captureContent` is `false`; branch names and diagnostic header values can themselves contain operational details, and a `userId` may itself be personally identifying if you set it to an email address or a real name. Choose a pseudonymous value when that matters, or leave `userId` unset to export no user at all.
+Git branch names, commit ids, working directory, session/leaf ids, the configured `userId`, model identity, usage/cost, aggregate counts, and allowlisted response-header values are metadata.
+They remain exported when `captureContent` is `false`; branch names and diagnostic header values can themselves contain operational details, and a `userId` may itself be personally identifying if you set it to an email address or a real name.
+Choose a pseudonymous value when that matters, or leave `userId` unset to export no user at all.
 
-The built-in mask specifically protects Langfuse credentials; it is not a general secret scanner. Set `"captureContent": false` in `pi-langfuse.json` when prompts, provider-request snapshots, responses, and tool content must remain local. Compaction summaries, tool partial results, opaque continuation signatures, authorization headers, cookies, and unapproved response headers are never exported in either mode.
+The built-in mask specifically protects Langfuse credentials; it is not a general secret scanner.
+Set `"captureContent": false` in `pi-langfuse.json` when prompts, provider-request snapshots, responses, and tool content must remain local.
+Compaction summaries, tool partial results, opaque continuation signatures, authorization headers, cookies, and unapproved response headers are never exported in either mode.
 
 ## 🗂️ Package layout
 
@@ -202,4 +249,5 @@ Pi extension, Pi coding agent, Langfuse, LLM observability, OpenTelemetry, traci
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-lsp/README.md
+++ b/packages/pi-lsp/README.md
@@ -42,8 +42,8 @@ A practical workflow is:
 - A clean LSP result does not replace the project's formatter, linter, type checker, build, or tests.
 - This project has not yet demonstrated through benchmarks that LSP improves agent task success, latency, or tool usage.
 
-This outcome-first framing is informed by [Eric Traut's comment on LSP integration for coding agents](https://github.com/openai/codex/issues/8745#issuecomment-3713058579):
-the protocol was not designed specifically for coding agents, and repository-native checks may already provide much of the desired verification value.
+This outcome-first framing is informed by [Eric Traut's comment on LSP integration for coding agents](https://github.com/openai/codex/issues/8745#issuecomment-3713058579).
+The comment explains that the protocol was not designed specifically for coding agents and that repository-native checks may already provide much of the desired verification value.
 
 ## 📦 Install
 

--- a/packages/pi-lsp/README.md
+++ b/packages/pi-lsp/README.md
@@ -1,35 +1,31 @@
-# 🧠 pi-lsp — Configurable Language Server Tools for Pi
+# 🧠 pi-lsp — Run Targeted LSP Diagnostics and Fixes
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-lsp)](https://www.npmjs.com/package/@narumitw/pi-lsp) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-lsp` is a native [Pi coding agent](https://pi.dev) extension that exposes diagnostics and source-fix tools through configurable Language Server Protocol routes.
+Give Pi targeted Language Server Protocol diagnostics and source fixes without running a full-project check for every intermediate edit.
 
-The extension is language-agnostic: servers are selected by config and file extension instead of hard-coded language families.
+Configure any language server by command and file extension instead of using hard-coded language families.
 
 ## ✨ Features
 
-- Configure LSP servers with simple JSON keyed by server name.
-- Routes diagnostics and source fixes by configured file extensions.
-- Supports multiple servers for the same extension, for example `ty` and `ruff` for `.py`/`.pyi` diagnostics.
-- Uses one internal LSP runner for JSON-RPC framing, subprocess lifecycle, diagnostics, code actions, and workspace edit application.
-- Supports workspace roots, file limits, recursive file discovery, server overrides, and write-or-preview edits.
-- Starts language servers only for tool calls, then shuts them down.
-- Shows statusline activity only while LSP tools are running.
+- Configures language servers in JSON and routes files by extension.
+- Runs multiple servers for the same file type when complementary diagnostics are useful.
+- Exposes `lsp_diagnostics` for exact ranges and `lsp_fix` for supported source actions.
+- Supports workspace roots, bounded discovery, per-call server overrides, and preview-or-write edits.
+- Starts servers only for tool calls, shuts them down afterward, and shows activity only while they run.
 
 ## 🎯 When to use pi-lsp
 
-Use pi-lsp when an LSP can answer a targeted question about the files being edited faster than the
-project's authoritative validation commands. It is most useful when:
+Use pi-lsp when an LSP can answer a targeted question about the files being edited faster than the project's authoritative validation commands.
+It is most useful when:
 
 - a full-project lint or typecheck is slow, but only a few files need intermediate feedback;
 - structured diagnostics with exact ranges and severity are easier to act on than CLI output;
-- a language server provides a useful source action such as `source.fixAll` or
-  `source.organizeImports`;
+- a language server provides a useful source action such as `source.fixAll` or `source.organizeImports`;
 - a multi-language repository benefits from one configurable interface for targeted diagnostics.
 
-For most repositories, first document the authoritative format, lint, typecheck, build, and test
-commands in `AGENTS.md`, then enforce them with pre-commit hooks or CI where appropriate. If those
-commands are already fast and reliable, pi-lsp may add little value.
+For most repositories, first document the authoritative format, lint, typecheck, build, and test commands in `AGENTS.md`, then enforce them with pre-commit hooks or CI where appropriate.
+If those commands are already fast and reliable, pi-lsp may add little value.
 
 A practical workflow is:
 
@@ -40,20 +36,14 @@ A practical workflow is:
 
 ### Current limitations
 
-- Diagnostics are not continuously injected into the conversation; the agent must call
-  `lsp_diagnostics`.
-- Language servers start and stop for each tool call, so pi-lsp does not retain an editor-like
-  incremental session.
-- The current tools expose diagnostics and source code actions, not symbol navigation, references,
-  or semantic rename.
+- Diagnostics are not continuously injected into the conversation; the agent must call `lsp_diagnostics`.
+- Language servers start and stop for each tool call, so pi-lsp does not retain an editor-like incremental session.
+- The current tools expose diagnostics and source code actions, not symbol navigation, references, or semantic rename.
 - A clean LSP result does not replace the project's formatter, linter, type checker, build, or tests.
-- This project has not yet demonstrated through benchmarks that LSP improves agent task success,
-  latency, or tool usage.
+- This project has not yet demonstrated through benchmarks that LSP improves agent task success, latency, or tool usage.
 
-This outcome-first framing is informed by
-[Eric Traut's comment on LSP integration for coding agents](https://github.com/openai/codex/issues/8745#issuecomment-3713058579):
-the protocol was not designed specifically for coding agents, and repository-native checks may
-already provide much of the desired verification value.
+This outcome-first framing is informed by [Eric Traut's comment on LSP integration for coding agents](https://github.com/openai/codex/issues/8745#issuecomment-3713058579):
+the protocol was not designed specifically for coding agents, and repository-native checks may already provide much of the desired verification value.
 
 ## 📦 Install
 
@@ -83,7 +73,11 @@ The agent can call `lsp_diagnostics` for targeted diagnostics and `lsp_fix` for 
 
 ## ⚙️ Settings
 
-If no config is provided, pi-lsp ships a broad catalog of direct-command defaults. Servers are started only when matching files are requested. pi-lsp does not download language servers, so install the commands you need and make them available on `PATH`. During no-config diagnostics, unavailable default commands are filtered before workspace discovery. If none can run, diagnostics completes successfully and reports the skipped servers. Explicitly selected or custom-configured missing commands still report an error.
+If no config is provided, pi-lsp ships a broad catalog of direct-command defaults.
+Servers are started only when matching files are requested. pi-lsp does not download language servers, so install the commands you need and make them available on `PATH`.
+During no-config diagnostics, unavailable default commands are filtered before workspace discovery.
+If none can run, diagnostics completes successfully and reports the skipped servers.
+Explicitly selected or custom-configured missing commands still report an error.
 
 | Language or format | Default server | Startup command | Extensions |
 | --- | --- | --- | --- |
@@ -131,11 +125,15 @@ Custom config is resolved in this order:
 2. `~/.pi/agent/pi-lsp.json`
 3. the built-in server catalog
 
-An untrusted project's canonical and legacy files are ignored. A `root` passed to an LSP tool selects files and the server working directory; it does not grant that directory authority to provide project settings. Project settings always come from the trusted Pi session workspace.
+An untrusted project's canonical and legacy files are ignored.
+A `root` passed to an LSP tool selects files and the server working directory; it does not grant that directory authority to provide project settings.
+Project settings always come from the trusted Pi session workspace.
 
-Compatibility: user-scoped `lsp.json` and trusted project-scoped `.pi/lsp.json` remain readable with a warning and are never modified automatically; rename them to their canonical `pi-lsp.json` names. New paths take precedence when both names exist.
+Compatibility: user-scoped `lsp.json` and trusted project-scoped `.pi/lsp.json` remain readable with a warning and are never modified automatically; rename them to their canonical `pi-lsp.json` names.
+New paths take precedence when both names exist.
 
-pi-lsp-specific environment settings have been removed. Move their values into canonical JSON:
+pi-lsp-specific environment settings have been removed.
+Move their values into canonical JSON:
 
 | Removed setting | JSON replacement |
 | --- | --- |
@@ -145,7 +143,8 @@ pi-lsp-specific environment settings have been removed. Move their values into c
 
 `servers[].env` remains supported because it configures the launched LSP child process rather than pi-lsp itself.
 
-Providing custom config replaces the default server map. The following `pi-lsp.json` example intentionally keeps five selected servers:
+Providing custom config replaces the default server map.
+The following `pi-lsp.json` example intentionally keeps five selected servers:
 
 ```json
 {
@@ -211,16 +210,25 @@ Each server entry supports:
 
 - `command`: argv array used to start the LSP server.
 - `extensions`: file extensions that should route to this server.
-- `env`: environment overrides for the LSP server process. The child inherits Pi's environment, then applies these values; an `env.PATH` value is also used to resolve `command[0]`.
+- `env`: environment overrides for the LSP server process.
+  The child inherits Pi's environment, then applies these values; an `env.PATH` value is also used to resolve `command[0]`.
 - `initialization`: LSP initialization options and workspace configuration values.
-- `skipDirectories`: additional directory names to exclude from recursive discovery. Explicitly requested paths remain available.
-- `diagnosticsSettleMs`: positive number of milliseconds without another push-diagnostics publication before using the latest result. Defaults to `800`; the built-in intelephense route uses `4000`. The global timeout remains the upper bound.
-- `pushDiagnosticsGraceMs`: positive number of milliseconds to wait for the first publication from a push-only server. It is unset by default, so a silent push-only server waits for the global timeout. The built-in Lua and Haskell routes use `3000`; Dart, Terraform, Gleam, and Tinymist use `2000`. This lets clean files finish after bounded silence without returning before a late error publication.
-- `pullDiagnosticsGraceMs`: positive number of milliseconds to wait for a newer push publication after a server returns an empty pull-diagnostics result. It is unset by default; the built-in rust-analyzer route uses `5000` because initial workspace analysis can finish after an early empty pull response.
+- `skipDirectories`: additional directory names to exclude from recursive discovery.
+  Explicitly requested paths remain available.
+- `diagnosticsSettleMs`: positive number of milliseconds without another push-diagnostics publication before using the latest result.
+  Defaults to `800`; the built-in intelephense route uses `4000`.
+  The global timeout remains the upper bound.
+- `pushDiagnosticsGraceMs`: positive number of milliseconds to wait for the first publication from a push-only server.
+  It is unset by default, so a silent push-only server waits for the global timeout.
+  The built-in Lua and Haskell routes use `3000`; Dart, Terraform, Gleam, and Tinymist use `2000`.
+  This lets clean files finish after bounded silence without returning before a late error publication.
+- `pullDiagnosticsGraceMs`: positive number of milliseconds to wait for a newer push publication after a server returns an empty pull-diagnostics result.
+  It is unset by default; the built-in rust-analyzer route uses `5000` because initial workspace analysis can finish after an early empty pull response.
 
 Global options:
 
-- `timeout`: request timeout in milliseconds. Defaults to `20000`.
+- `timeout`: request timeout in milliseconds.
+  Defaults to `20000`.
 
 pi-lsp infers `languageId` from common extensions and falls back to the extension without the leading dot.
 
@@ -254,21 +262,28 @@ Run diagnostics through configured servers.
 
 Parameters:
 
-- `paths?`: files or directories to check. Defaults to the workspace root.
-- `root?`: workspace root. Defaults to cwd.
+- `paths?`: files or directories to check.
+  Defaults to the workspace root.
+- `root?`: workspace root.
+  Defaults to cwd.
 - `limit?`: maximum files to open per selected server.
-- `server?`: configured server name, or an array of names. Defaults to all matching servers.
+- `server?`: configured server name, or an array of names.
+  Defaults to all matching servers.
 
 ### `lsp_fix`
 
-Apply source fixes or import organization through a configured server that matches its extension. If multiple servers match, pass `server` explicitly.
+Apply source fixes or import organization through a configured server that matches its extension.
+If multiple servers match, pass `server` explicitly.
 
 Parameters:
 
 - `path`: file to fix.
-- `root?`: workspace root. Defaults to cwd.
-- `kind?`: source action kind. Defaults to `source.fixAll`.
-- `write?`: write fixed text back to the file. Defaults to false.
+- `root?`: workspace root.
+  Defaults to cwd.
+- `kind?`: source action kind.
+  Defaults to `source.fixAll`.
+- `write?`: write fixed text back to the file.
+  Defaults to false.
 - `server?`: optional configured server name.
 
 ## 💬 Commands
@@ -311,4 +326,5 @@ Pi extension, Pi Coding Agent, Language Server Protocol, LSP diagnostics, code a
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -1,26 +1,20 @@
-# 🧭 pi-plan-mode — Codex-like Plan Mode for Pi
+# 🧭 pi-plan-mode — Plan Before Pi Edits Code
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-plan-mode)](https://www.npmjs.com/package/@narumitw/pi-plan-mode) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-plan-mode` adds a Codex-like `/plan` collaboration mode to Pi. Plan mode is for read-only exploration, clarifying questions, and a structured implementation-ready plan before any code mutation happens.
+Explore a codebase, resolve important questions, and produce an implementation-ready plan before Pi is allowed to edit files.
 
-Pi core intentionally does not ship a built-in plan mode; this package provides one as an independently installable extension.
+This independently installable extension adds a Codex-like `/plan` collaboration mode that Pi core does not provide.
 
 ## ✨ Features
 
-- Adds a state-aware `/plan` launch and management menu, plus `/plan start` for direct activation.
-- Adds `--plan` to start a session in Plan mode.
-- Enables built-in read-only tools by default while Plan mode is active.
-- Disables extension and custom tools by default, with persistent pre-start Settings and a staged `/plan tools` compatibility shortcut for explicit user-risk opt-in.
-- Blocks `update_plan`, mutating built-in tools, and unsafe `bash` forms such as writes, substitutions, background jobs, dependency installs, and mutating Git commands.
-- Injects Codex-like Plan mode instructions: explore first, ask decision questions for high-impact ambiguity, do not mutate files, and finalize only when decision-complete.
-- Adds required `plan_mode_question` and `plan_mode_complete` tools for structured questions and completion.
-- Presents the complete plan and lets you implement with the planning conversation or start a fresh linked session carrying only the approved plan, as well as export, save, stay, or discard.
-- Exports ready, saved, or active implementation plans with `/plan export [path]` without overwriting existing paths; the omitted-path destination is configurable, and exporting a ready plan completes and exits Plan mode.
-- Lets each accepted plan remain active, serve only as the first implementation handoff, or clear after the first implementation run; the current retained-plan behavior remains the default.
-- Keeps legacy `<proposed_plan>` responses compatible without advertising XML as the primary workflow.
-- Shows Plan mode state in Pi's statusline as `plan active`, `plan ready`, `plan saved`, or `plan implementing`; `@narumitw/pi-statusline` adds the default `📝` icon unless configured otherwise.
-- Persists Plan mode, one session-local saved plan, and active implementation state so resume and compaction retain the exact accepted plan.
+- Starts and manages Plan mode through `/plan`, `/plan <prompt>`, or the `--plan` startup flag.
+- Enables read-only exploration tools while blocking mutating tools and unsafe shell forms by default.
+- Requires structured questions for important ambiguity and explicit completion for a decision-ready plan.
+- Reviews the complete plan before implementation, export, save, continued planning, or discard.
+- Starts implementation in the planning session or a fresh linked session with the exact approved plan.
+- Persists Plan state and one saved plan across resume and compaction.
+- Exposes statusline state and configurable tool visibility, export destination, handoff behavior, shortcut, and thinking level.
 
 ## 📦 Install
 
@@ -65,106 +59,152 @@ Run `/plan <prompt>` when the first planning request is already known.
 /plan exit
 ```
 
-In TUI and RPC, use bare `/plan` to open the menu for the current Plan state. When Plan mode is off
-and no plan is stored, the launch menu shows the effective next-start tools and offers **Start Plan
-mode**, **Choose tools, then start…**, **Settings**, and **How Plan mode works**. Settings edits the
-persistent defaults for later workflows. Launch-menu tool changes remain a draft until **Done — start
-Plan mode** is selected; Back, Escape, Ctrl+C, disposal, session replacement, and shutdown discard
-the draft without changing Plan state, active tools, thinking, or the stored selection.
+In TUI and RPC, use bare `/plan` to open the menu for the current Plan state.
+When Plan mode is off and no plan is stored, the launch menu shows the effective next-start tools and offers **Start Plan mode**, **Choose tools, then start…**, **Settings**, and **How Plan mode works**.
+Settings edits the persistent defaults for later workflows.
+Launch-menu tool changes remain a draft until **Done — start Plan mode** is selected; Back, Escape, Ctrl+C, disposal, session replacement, and shutdown discard the draft without changing Plan state, active tools, thinking, or the stored selection.
 
-Use `/plan start` when you want to enter Plan mode directly without sending a model message. Use
-`/plan <prompt>` to enter Plan mode and immediately submit `<prompt>` as the first Plan-mode user
-message. The exact argument `start` is reserved for direct activation; longer text such as `/plan
-start a migration` remains an inline planning prompt. `--plan` also remains a direct activation path.
+Use `/plan start` when you want to enter Plan mode directly without sending a model message.
+Use `/plan <prompt>` to enter Plan mode and immediately submit `<prompt>` as the first Plan-mode user message.
+The exact argument `start` is reserved for direct activation; longer text such as `/plan start a migration` remains an inline planning prompt.
+`--plan` also remains a direct activation path.
 
-Use **Choose tools, then start…** or the `/plan tools` compatibility shortcut to choose a
-session-specific override before Planning starts. Both routes use the same draft selector: **Done —
-start Plan mode** stores the selection and starts the workflow, while cancellation leaves Plan mode
-off and changes nothing. The bounded multi-select shows 10 rows at a time, supports viewport paging,
-descriptions, and explicit unavailable rows for blocked tools. In TUI mode, type to fuzzy-search tool
-names, descriptions, policy, and source metadata; RPC keeps the complete unfiltered list. Once Plan
-mode is active, tools are locked: `/plan` no longer offers tool or Settings actions, and `/plan tools`
-rejects the request. Exit and start a new workflow if a different tool set is required. The
-`plan_mode_question` tool keeps its one-off question/choice dialog because it is a model-requested
-planning interaction, not command-menu navigation. `/plan show` displays the stored
-plan without starting a model turn, including the accepted plan while implementation is active.
-`/plan finalize` explicitly asks the agent to complete the plan or ask one remaining material
-question, `/plan save` stores a completed ready plan for later and leaves Plan mode, and `/plan
-export [path]` writes a ready, saved, or active implementation plan to Markdown. Completed and saved
-plan menus offer **Implement here**, which continues with the planning conversation, and **Start
-fresh and implement**, which opens a new session and transfers only the approved plan. The direct
-`/plan implement` compatibility route remains equivalent to **Implement here** and never opens a
-selector. A successful ready-plan export also leaves Plan mode; saved and active implementation
-exports retain their existing state. `show`, `save`, `export`, and `implement` fail closed when no
-applicable plan is stored; `finalize` requires active Plan mode.
+Use **Choose tools, then start…** or the `/plan tools` compatibility shortcut to choose a session-specific override before Planning starts.
+Both routes use the same draft selector: **Done — start Plan mode** stores the selection and starts the workflow, while cancellation leaves Plan mode off and changes nothing.
+The bounded multi-select shows 10 rows at a time, supports viewport paging, descriptions, and explicit unavailable rows for blocked tools.
+In TUI mode, type to fuzzy-search tool names, descriptions, policy, and source metadata; RPC keeps the complete unfiltered list.
+Once Plan mode is active, tools are locked: `/plan` no longer offers tool or Settings actions, and `/plan tools` rejects the request.
+Exit and start a new workflow if a different tool set is required.
+The `plan_mode_question` tool keeps its one-off question/choice dialog because it is a model-requested planning interaction, not command-menu navigation.
+`/plan show` displays the stored plan without starting a model turn, including the accepted plan while implementation is active.
+`/plan finalize` explicitly asks the agent to complete the plan or ask one remaining material question, `/plan save` stores a completed ready plan for later and leaves Plan mode, and `/plan export [path]` writes a ready, saved, or active implementation plan to Markdown.
+Completed and saved plan menus offer **Implement here**, which continues with the planning conversation, and **Start fresh and implement**, which opens a new session and transfers only the approved plan.
+The direct `/plan implement` compatibility route remains equivalent to **Implement here** and never opens a selector.
+A successful ready-plan export also leaves Plan mode; saved and active implementation exports retain their existing state.
+`show`, `save`, `export`, and `implement` fail closed when no applicable plan is stored; `finalize` requires active Plan mode.
 
-`/plan export` uses the configured **Export destination**, which defaults to `PLAN.md`. Supply a path
-to override that default for one export. Relative paths resolve from the command's current `ctx.cwd`
-at export time, absolute paths remain absolute, a leading `@` is accepted for Pi path compatibility,
-and missing parent directories are created. Explicit `/plan export <path>` input always wins over the
-setting. Export never overwrites an existing file, directory, or symbolic
-link: choose another path or remove the existing target first. A successful export adds one trailing
-newline but otherwise preserves the accepted Markdown exactly. After a ready plan is written, Plan
-mode ends, its tools and thinking level are restored, and the ready state is cleared without starting
-a model turn. Exporting a saved or active implementation plan leaves that state unchanged. Failed or
-cancelled exports leave every Plan-mode state unchanged. The resulting file is available to the agent
-through its normal file-reading tools. Export is an explicit user-requested file mutation;
+`/plan export` uses the configured **Export destination**, which defaults to `PLAN.md`.
+Supply a path to override that default for one export.
+Relative paths resolve from the command's current `ctx.cwd` at export time, absolute paths remain absolute, a leading `@` is accepted for Pi path compatibility, and missing parent directories are created.
+Explicit `/plan export <path>` input always wins over the setting.
+Export never overwrites an existing file, directory, or symbolic link: choose another path or remove the existing target first.
+A successful export adds one trailing newline but otherwise preserves the accepted Markdown exactly.
+After a ready plan is written, Plan mode ends, its tools and thinking level are restored, and the ready state is cleared without starting a model turn.
+Exporting a saved or active implementation plan leaves that state unchanged.
+Failed or cancelled exports leave every Plan-mode state unchanged.
+The resulting file is available to the agent through its normal file-reading tools.
+Export is an explicit user-requested file mutation;
 model-initiated Plan-mode writes remain blocked.
 
-In TUI and RPC, **Export plan…** opens a single-line path input from every ready, saved, or active
-plan menu. The input shows both the configured value and its currently resolved path. Submit an empty
-value to use the configured destination, or enter a relative or absolute one-off path. A failed TUI
-export retains the draft for correction; RPC reopens its input dialog. Escape returns to
-the owning menu without writing a file. A successful ready-plan export closes the menu and ends Plan
-mode; saved and active implementation menus close without changing their stored state.
+In TUI and RPC, **Export plan…** opens a single-line path input from every ready, saved, or active plan menu.
+The input shows both the configured value and its currently resolved path.
+Submit an empty value to use the configured destination, or enter a relative or absolute one-off path.
+A failed TUI export retains the draft for correction; RPC reopens its input dialog.
+Escape returns to the owning menu without writing a file.
+A successful ready-plan export closes the menu and ends Plan mode; saved and active implementation menus close without changing their stored state.
 
-When Plan mode is active, ask the agent to design the change. The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation. It should explore first, then use structured questions when your preference or a tradeoff materially changes the plan. Configure persistent defaults or a one-workflow tool override before activation; Planning and ready menus deliberately keep those controls locked.
+When Plan mode is active, ask the agent to design the change.
+The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation.
+It should explore first, then use structured questions when your preference or a tradeoff materially changes the plan.
+Configure persistent defaults or a one-workflow tool override before activation; Planning and ready menus deliberately keep those controls locked.
 
-By default, Plan mode manages only Pi's built-in tools: `read`, limited `bash`, available read-only built-ins such as `grep`, `find`, and `ls`, plus the required `plan_mode_question` and `plan_mode_complete` tools. Built-in `edit` and `write` are blocked. `update_plan` is also blocked because it tracks execution progress rather than conversational planning. Extension and custom tools are disabled by default because Pi tools do not expose standardized mutability metadata; enable them before starting from Settings or the staged workflow selector only when you accept the risk. For example, you can opt into `firecrawl_scrape`, `firecrawl_search`, or `lsp_diagnostics` if those extensions are loaded and you want to use them during planning.
+By default, Plan mode manages only Pi's built-in tools: `read`, limited `bash`, available read-only built-ins such as `grep`, `find`, and `ls`, plus the required `plan_mode_question` and `plan_mode_complete` tools.
+Built-in `edit` and `write` are blocked.
+`update_plan` is also blocked because it tracks execution progress rather than conversational planning.
+Extension and custom tools are disabled by default because Pi tools do not expose standardized mutability metadata; enable them before starting from Settings or the staged workflow selector only when you accept the risk.
+For example, you can opt into `firecrawl_scrape`, `firecrawl_search`, or `lsp_diagnostics` if those extensions are loaded and you want to use them during planning.
 
-Limited `bash` uses a fail-closed policy, including when an extension overrides the canonical `bash` tool name. It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`. It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, mutating flags, dependency changes, editors, and unknown commands. A rejected parsed command list or pipeline identifies its first blocked command segment; malformed or unsupported shell syntax reports the complete submitted input instead. Tests and builds may still write ignored caches or build artifacts and may execute project-defined hooks; enable or invoke them only when the repository is trusted. This is extension-level risk reduction, not an OS sandbox.
+Limited `bash` uses a fail-closed policy, including when an extension overrides the canonical `bash` tool name.
+It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`.
+It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, mutating flags, dependency changes, editors, and unknown commands.
+A rejected parsed command list or pipeline identifies its first blocked command segment; malformed or unsupported shell syntax reports the complete submitted input instead.
+Tests and builds may still write ignored caches or build artifacts and may execute project-defined hooks; enable or invoke them only when the repository is trusted.
+This is extension-level risk reduction, not an OS sandbox.
 
-`plan_mode_question` follows Codex's `request_user_input` pattern: the agent can ask 1-3 concise questions, each with meaningful options and a free-form Other path. If you cancel or no interactive UI is available, the agent should ask a concise plain-text question or proceed only with a clearly stated low-risk assumption instead of prematurely producing a final plan.
+`plan_mode_question` follows Codex's `request_user_input` pattern: the agent can ask 1-3 concise questions, each with meaningful options and a free-form Other path.
+If you cancel or no interactive UI is available, the agent should ask a concise plain-text question or proceed only with a clearly stated low-risk assumption instead of prematurely producing a final plan.
 
-Pi activates tools by tool name. The pre-start selector stores accepted session selections by name
-and shows each effective tool's source from Pi metadata, such as `built-in`, a user extension path,
-or a project extension path. If an extension overrides a built-in tool with the same name, Pi exposes the effective tool for that name and the selector shows that source.
+Pi activates tools by tool name.
+The pre-start selector stores accepted session selections by name and shows each effective tool's source from Pi metadata, such as `built-in`, a user extension path, or a project extension path.
+If an extension overrides a built-in tool with the same name, Pi exposes the effective tool for that name and the selector shows that source.
 
-A complete Plan mode answer should appear only after the agent has resolved discoverable facts and high-impact user decisions. The agent must call `plan_mode_complete({ plan })` alone as its final action, passing the complete Markdown plan. The tool rejects empty or whitespace-only plans and plans longer than 50,000 JavaScript characters; it does not truncate. Its visible result contains the full plan, and versioned result details let the extension restore it safely from the active session branch.
+A complete Plan mode answer should appear only after the agent has resolved discoverable facts and high-impact user decisions.
+The agent must call `plan_mode_complete({ plan })` alone as its final action, passing the complete Markdown plan.
+The tool rejects empty or whitespace-only plans and plans longer than 50,000 JavaScript characters; it does not truncate.
+Its visible result contains the full plan, and versioned result details let the extension restore it safely from the active session branch.
 
-`plan_mode_complete` uses Pi's `terminate: true` hint. Termination is best effort: if a model puts it in a parallel tool batch, Pi terminates the batch early only when every finalized sibling tool also terminates. The prompt therefore requires the completion call to be standalone and last. The extension deliberately does not infer completion from phrases such as “I will present the plan,” and it does not automatically retry a turn with no plan because research and clarification turns may legitimately remain unfinished. If a turn ends without a plan, Plan mode stays active; use `/plan finalize` for explicit recovery.
+`plan_mode_complete` uses Pi's `terminate: true` hint.
+Termination is best effort: if a model puts it in a parallel tool batch, Pi terminates the batch early only when every finalized sibling tool also terminates.
+The prompt therefore requires the completion call to be standalone and last.
+The extension deliberately does not infer completion from phrases such as “I will present the plan,” and it does not automatically retry a turn with no plan because research and clarification turns may legitimately remain unfinished.
+If a turn ends without a plan, Plan mode stays active; use `/plan finalize` for explicit recovery.
 
-Legacy sessions and models may still submit one non-empty `<proposed_plan>` block with tags on their own lines. That compatibility path remains accepted, but it is not the primary workflow. Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and produce a warning.
+Legacy sessions and models may still submit one non-empty `<proposed_plan>` block with tags on their own lines.
+That compatibility path remains accepted, but it is not the primary workflow.
+Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and produce a warning.
 
-After completion, `/plan` opens the ready actions when interactive UI is available. The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews how long the approved plan will remain active. **Implement here**—and the compatibility route `/plan implement`—disables Plan mode, restores full tool access, captures the current **After Implement** policy, and starts implementation in the current session with its planning conversation. **Start fresh and implement** waits for the source session to become idle, verifies the selected model and authentication, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries. The destination still loads its normal `AGENTS.md`, skills, project resources, and extensions. Choosing **Export plan…** asks for a destination, writes the plan, restores normal tools and thinking, and leaves Plan mode without starting a model turn. Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session before leaving Plan mode.
+After completion, `/plan` opens the ready actions when interactive UI is available.
+The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews how long the approved plan will remain active.
+**Implement here**—and the compatibility route `/plan implement`—disables Plan mode, restores full tool access, captures the current **After Implement** policy, and starts implementation in the current session with its planning conversation.
+**Start fresh and implement** waits for the source session to become idle, verifies the selected model and authentication, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
+The destination still loads its normal `AGENTS.md`, skills, project resources, and extensions.
+Choosing **Export plan…** asks for a destination, writes the plan, restores normal tools and thinking, and leaves Plan mode without starting a model turn.
+Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session before leaving Plan mode.
 
-When a workflow was started only with `--plan` and no `/plan` command has run in that session, the automatic menu cannot obtain Pi's command-only session replacement capability; choosing fresh asks you to reopen `/plan`, where the same action is available. A successful fresh handoff does not delete or consume the source planning session. Resume it later to inspect or hand off the ready/saved plan again; this deliberate duplication is the recovery path if the destination work is abandoned. In-memory sessions create an unlinked fresh session because no parent file exists. Escape, Ctrl+C, menu disposal, source replacement/shutdown, model/auth failure, or cancellation by another extension before replacement leaves the source plan unchanged. Once replacement succeeds, the destination persists active-plan state before kickoff. If persistence fails, the complete request is placed in the destination editor and the source remains resumable. If kickoff fails, the destination retains the active plan; send a message to continue, use `/plan exit` to clear it, or resume the parent planning session.
+When a workflow was started only with `--plan` and no `/plan` command has run in that session, the automatic menu cannot obtain Pi's command-only session replacement capability; choosing fresh asks you to reopen `/plan`, where the same action is available.
+A successful fresh handoff does not delete or consume the source planning session.
+Resume it later to inspect or hand off the ready/saved plan again; this deliberate duplication is the recovery path if the destination work is abandoned.
+In-memory sessions create an unlinked fresh session because no parent file exists.
+Escape, Ctrl+C, menu disposal, source replacement/shutdown, model/auth failure, or cancellation by another extension before replacement leaves the source plan unchanged.
+Once replacement succeeds, the destination persists active-plan state before kickoff.
+If persistence fails, the complete request is placed in the destination editor and the source remains resumable.
+If kickoff fails, the destination retains the active plan; send a message to continue, use `/plan exit` to clear it, or resume the parent planning session.
 
-A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session. It does not expire automatically, cross into a new session, or participate in ordinary model context. Open `/plan` to Show, Implement here, Start fresh and implement, Export, open Settings, or Clear it; `/plan show`, `/plan implement`, `/plan export [path]`, and `/plan exit`/`off` retain their direct routes in TUI and RPC. Fresh implementation checks idle state, the selected model, and authentication before session replacement; Implement here keeps its established preflight behavior. Starting another workflow with `/plan start`, `/plan <prompt>`, or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten. Resuming that session with `--plan` moves the saved plan back to ready Plan mode. Cancellation or failed implementation preflight leaves it unchanged.
+A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session.
+It does not expire automatically, cross into a new session, or participate in ordinary model context.
+Open `/plan` to Show, Implement here, Start fresh and implement, Export, open Settings, or Clear it; `/plan show`, `/plan implement`, `/plan export [path]`, and `/plan exit`/`off` retain their direct routes in TUI and RPC.
+Fresh implementation checks idle state, the selected model, and authentication before session replacement; Implement here keeps its established preflight behavior.
+Starting another workflow with `/plan start`, `/plan <prompt>`, or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten.
+Resuming that session with `--plan` moves the saved plan back to ready Plan mode.
+Cancellation or failed implementation preflight leaves it unchanged.
 
-Text print and JSON modes cannot display the bare `/plan` menu and reject that route before changing
-state; use `/plan start` for direct no-prompt activation or `/plan <prompt>` to start planning with a
-prompt. `/plan tools` also rejects before changing state because its staged selector requires TUI or
-RPC. These modes can export any stored plan with `/plan export [path]`, save a ready plan with
-`/plan save`, and clear it with `/plan exit` or `/plan off`. Successful export is observable through
-the created file; exporting a ready plan also leaves Plan mode, while saved and active implementation
-state remains unchanged. An existing target or missing plan fails the command without changing state.
-These modes reject saved-plan display and implementation before changing state because Pi provides
-neither printable custom-message output nor acknowledged extension-triggered turns; resume the
-session in TUI or RPC to show or implement it.
+Text print and JSON modes cannot display the bare `/plan` menu and reject that route before changing state; use `/plan start` for direct no-prompt activation or `/plan <prompt>` to start planning with a prompt.
+`/plan tools` also rejects before changing state because its staged selector requires TUI or RPC.
+These modes can export any stored plan with `/plan export [path]`, save a ready plan with `/plan save`, and clear it with `/plan exit` or `/plan off`.
+Successful export is observable through the created file; exporting a ready plan also leaves Plan mode, while saved and active implementation state remains unchanged.
+An existing target or missing plan fails the command without changing state.
+These modes reject saved-plan display and implementation before changing state because Pi provides neither printable custom-message output nor acknowledged extension-triggered turns; resume the session in TUI or RPC to show or implement it.
 
-Both implementation paths apply the current **After Implement** policy in their destination; the fresh-session choice does not change retention semantics. With the default **Keep plan active** policy, the exact accepted plan remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary. Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away. This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed. **Use plan for handoff only** clears retained state immediately after the first implementation request receives the complete plan. **Clear after first implementation run** keeps the plan through that run, including retries, compaction retries, and queued continuation, then clears it at `agent_settled`. Cleanup is bound to the matching implementation, so an older run settling cannot clear a newer handoff.
+Both implementation paths apply the current **After Implement** policy in their destination; the fresh-session choice does not change retention semantics.
+With the default **Keep plan active** policy, the exact accepted plan remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary.
+Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away.
+This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed.
+**Use plan for handoff only** clears retained state immediately after the first implementation request receives the complete plan.
+**Clear after first implementation run** keeps the plan through that run, including retries, compaction retries, and queued continuation, then clears it at `agent_settled`.
+Cleanup is bound to the matching implementation, so an older run settling cannot clear a newer handoff.
 
-While implementation is active, `/plan show` displays the accepted plan. Interactive `/plan` offers Show, Export plan…, Settings, Start a new plan, and Clear; `/plan exit` and `/plan off` are the direct clear routes. Settings changes never alter the policy already captured by the active implementation. Automatic cleanup has the same observable result as clearing: its active status and future injected plan context disappear, while the implementation request that triggered cleanup still receives the complete plan. Starting a new Plan-mode workflow or implementing a replacement plan supersedes the previous active plan. The extension deliberately does not infer completion from assistant prose or agent settlement, so clear the active plan when the implementation no longer applies. Choosing Stay before implementation keeps the plan ready. Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives. For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable. Before saving or implementation, exit/off discards the ready plan and removes its completion result from later non-Plan model context.
+While implementation is active, `/plan show` displays the accepted plan.
+Interactive `/plan` offers Show, Export plan…, Settings, Start a new plan, and Clear; `/plan exit` and `/plan off` are the direct clear routes.
+Settings changes never alter the policy already captured by the active implementation.
+Automatic cleanup has the same observable result as clearing: its active status and future injected plan context disappear, while the implementation request that triggered cleanup still receives the complete plan.
+Starting a new Plan-mode workflow or implementing a replacement plan supersedes the previous active plan.
+The extension deliberately does not infer completion from assistant prose or agent settlement, so clear the active plan when the implementation no longer applies.
+Choosing Stay before implementation keeps the plan ready.
+Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives.
+For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable.
+Before saving or implementation, exit/off discards the ready plan and removes its completion result from later non-Plan model context.
 
-While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines. With `@narumitw/pi-statusline`, this appears in the extension status area:
+While Plan mode is enabled, the extension also publishes a compact status for Pi statuslines.
+With `@narumitw/pi-statusline`, this appears in the extension status area:
 
 - `plan active`: Plan mode is enabled and still gathering context or drafting a plan.
 - `plan ready`: A completed plan is stored until you implement it, export it, save it, continue planning, or exit Plan mode.
 - `plan saved`: One completed plan is stored outside model context in the current session until you implement or clear it.
 - `plan implementing`: The exact accepted plan is currently retained under its captured **After Implement** policy.
 
-You can also exit directly. Before implementation, direct exit discards the latest proposed plan; while a plan is saved, it clears that saved plan. During implementation, it removes both the original implementation handoff and the extension's canonical active-plan block from later model calls; an earlier Pi-generated compaction summary may still describe prior work:
+You can also exit directly.
+Before implementation, direct exit discards the latest proposed plan; while a plan is saved, it clears that saved plan.
+During implementation, it removes both the original implementation handoff and the extension's canonical active-plan block from later model calls; an earlier Pi-generated compaction summary may still describe prior work:
 
 ```text
 /plan exit
@@ -199,23 +239,48 @@ When omitted, the shortcut is disabled by default.
 
 ### Default Plan tools
 
-`defaultPlanTools` defines the initial tool selection when a session has no stored pre-start selection. Omit it—or choose **Use automatic safe built-ins**—to keep the available safe built-ins as the default. An explicit empty array appears as **Required tools only** and enables only `plan_mode_question` and `plan_mode_complete`.
+`defaultPlanTools` defines the initial tool selection when a session has no stored pre-start selection.
+Omit it—or choose **Use automatic safe built-ins**—to keep the available safe built-ins as the default.
+An explicit empty array appears as **Required tools only** and enables only `plan_mode_question` and `plan_mode_complete`.
 
-Tool names must be non-empty strings; duplicates are removed in first-seen order. Unknown, unavailable, and Plan-mode-blocked names are ignored when tools are activated. Settings retains configured unavailable names and shows them as unavailable; resetting to automatic removes the entire override. A tool registered after Plan mode is already active is not added automatically; exit and start a new Plan workflow to apply another set. Non-built-in tools named in this global setting are an explicit user-risk opt-in, just like selecting them in the pre-start workflow selector. Plan mode does not interpret their arguments or actions: enabling one trusts the whole effective tool. Pi resolves tools by name, so if an extension overrides a built-in name, the effective extension tool is selected instead. An effective tool named `bash` remains subject to the limited-shell policy regardless of its source metadata.
+Tool names must be non-empty strings; duplicates are removed in first-seen order.
+Unknown, unavailable, and Plan-mode-blocked names are ignored when tools are activated.
+Settings retains configured unavailable names and shows them as unavailable; resetting to automatic removes the entire override.
+A tool registered after Plan mode is already active is not added automatically; exit and start a new Plan workflow to apply another set.
+Non-built-in tools named in this global setting are an explicit user-risk opt-in, just like selecting them in the pre-start workflow selector.
+Plan mode does not interpret their arguments or actions: enabling one trusts the whole effective tool.
+Pi resolves tools by name, so if an extension overrides a built-in name, the effective extension tool is selected instead.
+An effective tool named `bash` remains subject to the limited-shell policy regardless of its source metadata.
 
-A selection accepted through **Choose tools, then start…** or `/plan tools` is stored in that Pi session and takes precedence over `defaultPlanTools` when the session resumes. The global setting remains the baseline for fresh sessions and sessions without an explicit selection. Settings saves immediately, but the saved tools and thinking level apply only when a later Plan workflow starts; they never mutate a workflow already in progress.
+A selection accepted through **Choose tools, then start…** or `/plan tools` is stored in that Pi session and takes precedence over `defaultPlanTools` when the session resumes.
+The global setting remains the baseline for fresh sessions and sessions without an explicit selection.
+Settings saves immediately, but the saved tools and thinking level apply only when a later Plan workflow starts; they never mutate a workflow already in progress.
 
 ### After Implement
 
-`implementationPlanRetention` controls the result of the next Implement action. Omit it or use `keep` for **Keep plan active**, the backward-compatible behavior that retains and reinjects the exact plan until `/plan exit` or supersession. Use `clear-on-start` for **Use plan for handoff only**: the first matching implementation request receives the complete plan, then retained state clears before later requests. Use `clear-after-first-run` to retain the plan until that implementation's first fully settled run ends. A resumed cleanup policy re-arms against the first context in the replacement session. Failed handoff delivery restores the ready or saved plan and does not run automatic cleanup.
+`implementationPlanRetention` controls the result of the next Implement action.
+Omit it or use `keep` for **Keep plan active**, the backward-compatible behavior that retains and reinjects the exact plan until `/plan exit` or supersession.
+Use `clear-on-start` for **Use plan for handoff only**: the first matching implementation request receives the complete plan, then retained state clears before later requests.
+Use `clear-after-first-run` to retain the plan until that implementation's first fully settled run ends.
+A resumed cleanup policy re-arms against the first context in the replacement session.
+Failed handoff delivery restores the ready or saved plan and does not run automatic cleanup.
 
-Changing this setting applies to the next Implement action only. Each active implementation stores its effective policy, so a later Settings save cannot shorten or extend an implementation already in progress. `/plan exit` remains available under every policy.
+Changing this setting applies to the next Implement action only.
+Each active implementation stores its effective policy, so a later Settings save cannot shorten or extend an implementation already in progress.
+`/plan exit` remains available under every policy.
 
 ### Export destination
 
-`defaultPlanExportPath` controls only exports that omit a path. Omit it—or submit an empty value in Settings—to use `PLAN.md`. The value must be a non-empty string of at most 4,096 characters without terminal control characters or NUL. Relative values are resolved against the current working directory at export time; the Settings detail and every export input preview the concrete resolved destination. An explicit `/plan export <path>` is a one-off override and does not edit Settings. Saving a new destination affects the next export immediately, including export of a currently active implementation.
+`defaultPlanExportPath` controls only exports that omit a path.
+Omit it—or submit an empty value in Settings—to use `PLAN.md`.
+The value must be a non-empty string of at most 4,096 characters without terminal control characters or NUL.
+Relative values are resolved against the current working directory at export time; the Settings detail and every export input preview the concrete resolved destination.
+An explicit `/plan export <path>` is a one-off override and does not edit Settings.
+Saving a new destination affects the next export immediately, including export of a currently active implementation.
 
-The existing no-overwrite, cancellation, and atomic Plan-state behavior is unchanged. A failed save rolls the row back to its previous value; a failed or cancelled export preserves the plan and target. Long previews wrap or truncate to the available terminal width without changing the raw path used by the action.
+The existing no-overwrite, cancellation, and atomic Plan-state behavior is unchanged.
+A failed save rolls the row back to its previous value; a failed or cancelled export preserves the plan and target.
+Long previews wrap or truncate to the available terminal width without changing the raw path used by the action.
 
 ### Toggle shortcut
 
@@ -226,12 +291,17 @@ Avoid values that conflict with editor shortcuts.
 
 ### Safe shell subcommands
 
-`safeSubcommands` adds reviewed command validators to limited `bash`; it is not a raw shell allowlist. Only the following exact values are accepted:
+`safeSubcommands` adds reviewed command validators to limited `bash`; it is not a raw shell allowlist.
+Only the following exact values are accepted:
 
 - `git`: `status`, `log`, `diff`, `show`, `branch`, `remote`, `ls-files`, `grep`, `rev-parse`, `blame`, `describe`, `merge-base`, `ls-tree`, and `cat-file`.
 - `gh`: `pr view`, `pr list`, `issue view`, and `issue list`.
 
-The first eight Git validators are built in and remain enabled when omitted, so listing them is valid but redundant. The other six Git validators and every `gh` path require an explicit opt-in. Git entries select one exact subcommand; `gh` entries select one exact two-word path, so `"pr view"` never enables `pr merge`, `pr close`, or `pr edit`. Omitted `safeSubcommands`, an empty object, and empty arrays preserve the default policy. Duplicate values are removed in first-seen order.
+The first eight Git validators are built in and remain enabled when omitted, so listing them is valid but redundant.
+The other six Git validators and every `gh` path require an explicit opt-in.
+Git entries select one exact subcommand; `gh` entries select one exact two-word path, so `"pr view"` never enables `pr merge`, `pr close`, or `pr edit`.
+Omitted `safeSubcommands`, an empty object, and empty arrays preserve the default policy.
+Duplicate values are removed in first-seen order.
 
 With the example configuration above, commands such as these are accepted:
 
@@ -261,17 +331,34 @@ gh pr view 218 > pr.txt
 gh pr list --json number,title && gh pr merge 218
 ```
 
-Redirects, shell expansion and substitution, explicit pager or browser requests, explicit external diff/textconv/filter/signature helpers, output flags, malformed command layouts, and any chain containing an unsafe segment fail closed. Read-dominant Git validators accept ordinary inspection flags without requiring `--no-textconv` or `--no-ext-diff`; Git may therefore invoke a helper configured by the user or trusted repository even when the command does not request one explicitly. Use the negative flags when you want to suppress those configured helpers. Mixed read/write surfaces remain narrower: use `git remote show -n` to avoid invoking a transport helper, while mutating `branch` and `remote` forms remain blocked. GitHub CLI read paths require `--json <fields>` output so Plan mode does not rely on `GH_PAGER`, `PAGER`, or gh pager configuration. Unknown `safeSubcommands` keys or values, non-array values, and non-string entries invalidate the entire settings file and trigger the normal warning/default fallback on session start.
+Redirects, shell expansion and substitution, explicit pager or browser requests, explicit external diff/textconv/filter/signature helpers, output flags, malformed command layouts, and any chain containing an unsafe segment fail closed.
+Read-dominant Git validators accept ordinary inspection flags without requiring `--no-textconv` or `--no-ext-diff`; Git may therefore invoke a helper configured by the user or trusted repository even when the command does not request one explicitly.
+Use the negative flags when you want to suppress those configured helpers.
+Mixed read/write surfaces remain narrower: use `git remote show -n` to avoid invoking a transport helper, while mutating `branch` and `remote` forms remain blocked.
+GitHub CLI read paths require `--json <fields>` output so Plan mode does not rely on `GH_PAGER`, `PAGER`, or gh pager configuration.
+Unknown `safeSubcommands` keys or values, non-array values, and non-string entries invalidate the entire settings file and trigger the normal warning/default fallback on session start.
 
-Read-only does not mean private: Git inspection can expose repository history and tracked secrets, while `gh` queries can expose remote repository, pull request, and issue data available to your authenticated account. The policy reduces accidental mutation and explicit helper execution; it is not a sandbox or a confidentiality boundary.
+Read-only does not mean private: Git inspection can expose repository history and tracked secrets, while `gh` queries can expose remote repository, pull request, and issue data available to your authenticated account.
+The policy reduces accidental mutation and explicit helper execution; it is not a sandbox or a confidentiality boundary.
 
 ### Thinking level
 
-Plan mode inherits Pi's current thinking level by default. Set `thinkingLevel` to request a fixed level only while Plan mode is active. Supported values are `inherit`, `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. The extension snapshots the prior level and restores it on exit only if the level still matches the value it applied; a manual change made during Plan mode is preserved. A Settings save does not change Pi's current or default thinking level and takes effect only when the next Plan workflow starts.
+Plan mode inherits Pi's current thinking level by default.
+Set `thinkingLevel` to request a fixed level only while Plan mode is active.
+Supported values are `inherit`, `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
+The extension snapshots the prior level and restores it on exit only if the level still matches the value it applied; a manual change made during Plan mode is preserved.
+A Settings save does not change Pi's current or default thinking level and takes effect only when the next Plan workflow starts.
 
-Settings saves are serialized in invocation order inside one Pi process. Each save re-reads the latest valid document, preserves unknown top-level fields and unedited `safeSubcommands`, then publishes through a same-directory temporary file and rename. A missing file stays absent until an explicit save. Invalid JSON, invalid values, oversized content, non-regular files, and read failures make Settings read-only; the existing bytes and previous effective settings remain. This in-process queue is not a cross-process lock, so concurrent separate Pi processes can still race.
+Settings saves are serialized in invocation order inside one Pi process.
+Each save re-reads the latest valid document, preserves unknown top-level fields and unedited `safeSubcommands`, then publishes through a same-directory temporary file and rename.
+A missing file stays absent until an explicit save.
+Invalid JSON, invalid values, oversized content, non-regular files, and read failures make Settings read-only; the existing bytes and previous effective settings remain.
+This in-process queue is not a cross-process lock, so concurrent separate Pi processes can still race.
 
-Invalid settings produce a warning and fall back to inherited thinking, available safe-built-in tool defaults, `keep`, and `PLAN.md`. Compatibility: a valid legacy `plan-mode.json` remains readable with a warning and is never modified automatically. If Settings is explicitly saved while only that legacy file exists, the extension creates canonical `pi-plan-mode.json` from the complete legacy document, applies the selected change, preserves unknown fields, and leaves the legacy file untouched. If both files exist, the canonical filename takes precedence.
+Invalid settings produce a warning and fall back to inherited thinking, available safe-built-in tool defaults, `keep`, and `PLAN.md`.
+Compatibility: a valid legacy `plan-mode.json` remains readable with a warning and is never modified automatically.
+If Settings is explicitly saved while only that legacy file exists, the extension creates canonical `pi-plan-mode.json` from the complete legacy document, applies the selected change, preserves unknown fields, and leaves the legacy file untouched.
+If both files exist, the canonical filename takes precedence.
 
 ## 🧠 Codex-like behavior
 
@@ -304,7 +391,8 @@ packages/pi-plan-mode/
 └── package.json
 ```
 
-`index.ts` is the Pi entrypoint and forwards to `plan-mode.ts`; the other source modules are internal. The package exposes its Pi extension through `package.json`:
+`index.ts` is the Pi entrypoint and forwards to `plan-mode.ts`; the other source modules are internal.
+The package exposes its Pi extension through `package.json`:
 
 ```json
 {
@@ -322,4 +410,5 @@ Pi extension, Pi coding agent, plan mode, Codex-like plan mode, AI coding workfl
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -93,8 +93,8 @@ After a ready plan is written, Plan mode ends, its tools and thinking level are 
 Exporting a saved or active implementation plan leaves that state unchanged.
 Failed or cancelled exports leave every Plan-mode state unchanged.
 The resulting file is available to the agent through its normal file-reading tools.
-Export is an explicit user-requested file mutation;
-model-initiated Plan-mode writes remain blocked.
+Export is an explicit user-requested file mutation.
+Model-initiated Plan-mode writes remain blocked.
 
 In TUI and RPC, **Export plan…** opens a single-line path input from every ready, saved, or active plan menu.
 The input shows both the configured value and its currently resolved path.

--- a/packages/pi-recall/README.md
+++ b/packages/pi-recall/README.md
@@ -1,24 +1,24 @@
-# 🧠 Pi Recall — Saved Messages for Pi
+# 🧠 Pi Recall — Save and Reuse Messages Across Sessions
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-recall)](https://www.npmjs.com/package/@narumitw/pi-recall) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 > [!WARNING]
-> Pi Recall is experimental. Its storage format and interaction flow may change between releases.
+> Pi Recall is experimental.
+> Its storage format and interaction flow may change between releases.
 
-`@narumitw/pi-recall` saves selected text messages from the active Pi session branch and lets you preview or quote them in another session. Saved content remains local until you explicitly insert a quote into a draft and submit it.
+Save selected user or assistant messages, find them in another Pi session, and quote only the text you choose into a new draft.
+
+Saved content stays local until you explicitly submit a recalled quote.
 
 ## ✨ Features
 
-- Saves any eligible user or assistant text message from the current active session branch—not only the latest message.
-- Recalls saved messages across sessions using **Current cwd**, **All**, or **Current session** scope.
-- Cycles TUI scope with `Tab` and `Shift+Tab`, with the active scope and result count always visible.
-- Cycles **All messages**, **User only**, and **Assistant only** views with Pi's configured `/tree` filter-cycle bindings.
-- Fuzzy-searches saved message text, role, and session name after applying the active scope and view.
-- Deletes the selected TUI result with `Ctrl+D` after confirmation, then restores the same scope, view, and query.
-- Previews the complete saved text before use.
-- Inserts an XML-marked quote at the TUI editor cursor without submitting it automatically.
-- Stores versioned JSONL locally with cross-process locking, private permissions, and atomic replacement.
-- Fails closed when storage is malformed, unsupported, oversized, symlinked, or not a regular file.
+- Saves any eligible user or assistant text message from the active session branch.
+- Recalls by current cwd, current session, or all saved messages.
+- Filters by role and fuzzy-searches message text, role, and session name.
+- Previews the full message before inserting an XML-marked quote at the editor cursor.
+- Never submits recalled text automatically and confirms deletion before changing storage.
+- Stores private versioned JSONL with cross-process locking and atomic replacement.
+- Fails closed for malformed, unsupported, oversized, symlinked, or non-file storage.
 
 ## 📦 Install
 
@@ -42,14 +42,18 @@ pi -e ./packages/pi-recall
 
 ## 🚀 Quick start
 
-1. Run `/recall`.
-2. Choose **Save a message** and select a text user or assistant message from the active branch.
-3. In any later session, run `/recall` and choose **Recall a saved message**.
-4. In TUI mode, type to fuzzy-search, press `Tab` / `Shift+Tab` to change scope, or use the configured `/tree` filter-cycle keys to change the message view.
-5. The default view keys are `Ctrl+O` and `Ctrl+Shift+O`, and the picker shows the active bindings in its help text.
-6. Press `Enter` to open the selected message, or press `Ctrl+D` to review and confirm its deletion directly from the TUI picker.
-7. Preview the message or choose **Quote into draft**.
-8. Add your question or instruction, then submit the draft normally.
+1. Run `/recall`, choose **Save a message**, and select a user or assistant message.
+2. In any later session, run `/recall` and choose **Recall a saved message**.
+3. Preview the result, quote it into the draft, add your instruction, and submit normally.
+
+## 🧭 Recall workflow
+
+1. Type to fuzzy-search saved messages.
+2. Press `Tab` or `Shift+Tab` to change scope, or use the configured `/tree` filter-cycle keys to change the message view.
+3. The default view keys are `Ctrl+O` and `Ctrl+Shift+O`, and the picker shows the active bindings in its help text.
+4. Press `Enter` to open the selected message, or press `Ctrl+D` to review and confirm its deletion directly from the TUI picker.
+5. Preview the message or choose **Quote into draft**.
+6. Add your question or instruction, then submit the draft normally.
 
 A quoted draft uses this form:
 
@@ -69,15 +73,20 @@ The quote sent to the editor omits cwd, session IDs, entry IDs, session files, a
 | --- | --- | --- |
 | `/recall` | TUI, RPC | Open the Pi Recall manager. Arguments are rejected. |
 
-Print and JSON modes reject `/recall` before opening an interactive flow. TUI and RPC expose the same save, preview, quote, delete, status, and help capabilities; RPC uses explicit dialogs instead of terminal shortcuts. In RPC, quoting emits Pi's `set_editor_text` extension UI request.
+Print and JSON modes reject `/recall` before opening an interactive flow.
+TUI and RPC expose the same save, preview, quote, delete, status, and help capabilities; RPC uses explicit dialogs instead of terminal shortcuts.
+In RPC, quoting emits Pi's `set_editor_text` extension UI request.
 
 ## 🧭 Recall scopes
 
-- **Current cwd** — saved messages whose normalized absolute source cwd matches the current cwd. This is the default for each new `/recall` interaction.
+- **Current cwd** — saved messages whose normalized absolute source cwd matches the current cwd.
+  This is the default for each new `/recall` interaction.
 - **All** — every valid record in the current Pi agent directory.
 - **Current session** — records whose source session ID exactly matches the current session.
 
-Scope applies only when recalling already saved messages. The save picker intentionally reads only `ctx.sessionManager.getBranch()` from the current session and never scans other session files. TUI scope switching keeps the selected saved record when it remains visible in the new scope; otherwise it selects the first fuzzy-ranked result or the newest result when the query is empty.
+Scope applies only when recalling already saved messages.
+The save picker intentionally reads only `ctx.sessionManager.getBranch()` from the current session and never scans other session files.
+TUI scope switching keeps the selected saved record when it remains visible in the new scope; otherwise it selects the first fuzzy-ranked result or the newest result when the query is empty.
 
 ## 👁️ Recall views
 
@@ -87,19 +96,38 @@ The saved-message TUI has three flat display views:
 - **User only** — only saved user messages in the active scope.
 - **Assistant only** — only saved assistant messages in the active scope.
 
-The view uses Pi's injected `app.tree.filter.cycleForward` and `app.tree.filter.cycleBackward` bindings, which default to `Ctrl+O` and `Ctrl+Shift+O`. Pi Recall does not reuse `/tree`'s direct filter bindings because `Ctrl+D` remains the Recall delete action. The active view, filtered count, cursor position, and configured cycle keys remain visible in the picker.
+The view uses Pi's injected `app.tree.filter.cycleForward` and `app.tree.filter.cycleBackward` bindings, which default to `Ctrl+O` and `Ctrl+Shift+O`.
+Pi Recall does not reuse `/tree`'s direct filter bindings because `Ctrl+D` remains the Recall delete action.
+The active view, filtered count, cursor position, and configured cycle keys remain visible in the picker.
 
-Picker scope, view, and query survive record opening plus cancelled, successful, and failed direct deletion during one `/recall` flow. Selection is retained when possible and moves to a neighboring visible record after successful deletion. A new `/recall` starts with **Current cwd**, **All messages**, and an empty query. RPC continues to ask for scope explicitly and shows the complete scoped list without simulating TUI-only view or search shortcuts.
+Picker scope, view, and query survive record opening plus cancelled, successful, and failed direct deletion during one `/recall` flow.
+Selection is retained when possible and moves to a neighboring visible record after successful deletion.
+A new `/recall` starts with **Current cwd**, **All messages**, and an empty query.
+RPC continues to ask for scope explicitly and shows the complete scoped list without simulating TUI-only view or search shortcuts.
 
 ## 🔍 TUI fuzzy search
 
-The TUI picker has a visible `Search:` input. It applies scope first, then the active message view, then fuzzy search. Search matches complete saved message text, the `user` or `assistant` role, and the optional session name. Matching is case-insensitive and requires every whitespace- or slash-separated token as an ordered subsequence. It ranks closer matches first but does not perform typo-edit-distance correction.
+The TUI picker has a visible `Search:` input.
+It applies scope first, then the active message view, then fuzzy search.
+Search matches complete saved message text, the `user` or `assistant` role, and the optional session name.
+Matching is case-insensitive and requires every whitespace- or slash-separated token as an ordered subsequence.
+It ranks closer matches first but does not perform typo-edit-distance correction.
 
-The scope, view, query, and current selection survive selected-message navigation during one `/recall` interaction. Scope and view changes retain the selected record when it remains visible; otherwise the picker chooses the first ranked or newest visible result. A new `/recall` starts with an empty query, **Current cwd**, and **All messages**. Queries are limited to 256 UTF-16 code units; an overlong query shows an error and runs no matching. Terminal controls are replaced before matching or display, while ordinary spaces remain available for multi-token queries.
+The scope, view, query, and current selection survive selected-message navigation during one `/recall` interaction.
+Scope and view changes retain the selected record when it remains visible; otherwise the picker chooses the first ranked or newest visible result.
+A new `/recall` starts with an empty query, **Current cwd**, and **All messages**.
+Queries are limited to 256 UTF-16 code units; an overlong query shows an error and runs no matching.
+Terminal controls are replaced before matching or display, while ordinary spaces remain available for multi-token queries.
 
-`Ctrl+D`—or the configured `app.session.delete` binding—opens a confirmation identifying the selected record and showing a bounded preview. Cancellation returns to the unchanged picker. After confirmation, Pi Recall shows non-cancellable deletion progress, applies the existing locked atomic JSONL mutation, and returns to the same scope, view, and query with a neighboring result selected. A failure keeps the previous list visible and reports how to retry; a record concurrently removed elsewhere is reconciled as already absent. Plain `Delete` remains available for forward editing in the search input. The existing `Enter` → **Delete…** route remains available when a complete saved-text review is preferred.
+`Ctrl+D`—or the configured `app.session.delete` binding—opens a confirmation identifying the selected record and showing a bounded preview.
+Cancellation returns to the unchanged picker.
+After confirmation, Pi Recall shows non-cancellable deletion progress, applies the existing locked atomic JSONL mutation, and returns to the same scope, view, and query with a neighboring result selected.
+A failure keeps the previous list visible and reports how to retry; a record concurrently removed elsewhere is reconciled as already absent.
+Plain `Delete` remains available for forward editing in the search input.
+The existing `Enter` → **Delete…** route remains available when a complete saved-text review is preferred.
 
-RPC continues to show the complete scoped list through explicit dialogs and does not simulate a hidden fuzzy query or terminal shortcut. Message timestamps, cwd, session IDs, entry IDs, and local paths are not searchable.
+RPC continues to show the complete scoped list through explicit dialogs and does not simulate a hidden fuzzy query or terminal shortcut.
+Message timestamps, cwd, session IDs, entry IDs, and local paths are not searchable.
 
 ## 🔒 Storage, privacy, and recovery
 
@@ -109,36 +137,49 @@ The canonical user file is:
 ~/.pi/agent/pi-recall.jsonl
 ```
 
-Pi's configured agent directory replaces `~/.pi/agent` when applicable. Each line is one active versioned `recall_message` record. Records contain the text, role, saved time, original message time, source cwd, source session ID, source entry ID, and optional session name. This provenance is shown locally but is excluded from generated quote payloads except for role and original message time.
+Pi's configured agent directory replaces `~/.pi/agent` when applicable.
+Each line is one active versioned `recall_message` record.
+Records contain the text, role, saved time, original message time, source cwd, source session ID, source entry ID, and optional session name.
+This provenance is shown locally but is excluded from generated quote payloads except for role and original message time.
 
-Pi Recall does not create settings, session custom entries, tools, background processes, watchers, or automatic model context. It reads storage only when `/recall` needs it.
+Pi Recall does not create settings, session custom entries, tools, background processes, watchers, or automatic model context.
+It reads storage only when `/recall` needs it.
 
-Save and delete operations acquire one cross-process lock, reread canonical storage under that lock, and publish a complete JSONL replacement through a unique same-directory `0600` temporary file. Lock waiting is abort-aware. The canonical file is required to be a regular non-symlink file and is kept at `0600`.
+Save and delete operations acquire one cross-process lock, reread canonical storage under that lock, and publish a complete JSONL replacement through a unique same-directory `0600` temporary file.
+Lock waiting is abort-aware.
+The canonical file is required to be a regular non-symlink file and is kept at `0600`.
 
-Malformed JSON, duplicate IDs, unknown record types or versions, invalid records, symlinks, and limit violations make storage read-only. Fix or move the reported file, then reopen `/recall`; Pi Recall never overwrites invalid storage. Unknown fields on otherwise valid version-1 records survive later rewrites.
+Malformed JSON, duplicate IDs, unknown record types or versions, invalid records, symlinks, and limit violations make storage read-only.
+Fix or move the reported file, then reopen `/recall`; Pi Recall never overwrites invalid storage.
+Unknown fields on otherwise valid version-1 records survive later rewrites.
 
-Deleting a message removes it from canonical `pi-recall.jsonl`. It is not secure erasure of filesystem blocks, backups, snapshots, temporary copies left by an operating-system failure, or content already quoted into a session.
+Deleting a message removes it from canonical `pi-recall.jsonl`.
+It is not secure erasure of filesystem blocks, backups, snapshots, temporary copies left by an operating-system failure, or content already quoted into a session.
 
 ## 📝 Message semantics and limits
 
 - Eligible sources are `message` entries with role `user` or `assistant` on the active branch.
 - User strings and text blocks are kept; multiple text blocks are joined in source order with newlines.
 - Thinking, tool calls, tool results, images/base64, custom messages, image-only messages, empty text, and abandoned branches are not saved.
-- Markdown, indentation, Unicode, and original line breaks are preserved. Oversized messages are excluded rather than truncated.
+- Markdown, indentation, Unicode, and original line breaks are preserved.
+  Oversized messages are excluded rather than truncated.
 - A source message can be saved only once for the same source session ID and entry ID.
 - At most 200 messages may be saved.
 - One message text may contain at most 50,000 UTF-8 bytes.
 - Canonical JSONL may contain at most 12 MiB.
 - Records are never evicted automatically.
 
-Terminal controls are removed from labels, previews, metadata, and errors before display. Full review content is passed through Pi TUI Kit's sanitized review renderer. The raw stored text is not modified merely for display.
+Terminal controls are removed from labels, previews, metadata, and errors before display.
+Full review content is passed through Pi TUI Kit's sanitized review renderer.
+The raw stored text is not modified merely for display.
 
 ## 🚧 Limitations
 
 - No tags, saved-query persistence, message editing, reordering, batch deletion, import/export, automatic expiry, or automatic context injection.
 - No cross-session transcript browser: only previously saved records can be recalled across sessions.
 - Text only; images and tool payloads are deliberately omitted.
-- The custom TUI picker is keyboard-operated. RPC uses sequential dialogs.
+- The custom TUI picker is keyboard-operated.
+  RPC uses sequential dialogs.
 - Scope, view, and search preferences are not persisted; every new `/recall` interaction starts at **Current cwd**, **All messages**, and an empty query.
 
 ## 🗂️ Package layout
@@ -170,4 +211,5 @@ Pi extension, saved messages, message recall, cross-session context, quote manag
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-stamp/README.md
+++ b/packages/pi-stamp/README.md
@@ -217,8 +217,8 @@ Message entry compatibility is cumulative:
 - Version 1 stores role and creation timestamp.
 - Version 2 adds the previous message-stamp timestamp for live date-boundary formatting.
 - Version 3 assistant entries add completion and optional first-content observations.
-- Version 4 assistant entries add a sanitized metadata snapshot when metadata capture is enabled;
-  timing remains optional so a valid metadata stamp survives a backwards timing clock.
+- Version 4 assistant entries add a sanitized metadata snapshot when metadata capture is enabled.
+  Timing remains optional so a valid metadata stamp survives a backwards timing clock.
 - Version 1 tool entries store only bounded association/timing/outcome data.
 
 Existing versions remain readable.

--- a/packages/pi-stamp/README.md
+++ b/packages/pi-stamp/README.md
@@ -1,26 +1,20 @@
-# 🕒 pi-stamp — Transcript Metadata for Pi
+# 🕒 pi-stamp — Add Timestamps and Timing to Pi's Transcript
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-stamp)](https://www.npmjs.com/package/@narumitw/pi-stamp) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-stamp` is a quiet [Pi coding agent](https://pi.dev) extension that adds a
-right-aligned timestamp after each user and assistant message in the interactive transcript. Opt-in
-settings can add response timing, assistant provenance and usage, or tool duration and outcome.
+Add a quiet right-aligned timestamp after each user and assistant message in Pi's interactive transcript.
+
+Optional details can show response timing, assistant provenance and usage, or tool duration and outcome.
 
 ## ✨ Features
 
-- Shows each message's recorded creation time on a dim, right-aligned transcript row.
-- Supports 12/24-hour clocks, optional seconds, automatic date context, locales, and time zones.
-- Optionally shows assistant response duration and detailed first-content/total timing.
-- Optionally shows reported assistant model, API/provider, stop reason, token usage, and estimated
-  cost without querying a provider.
-- Keeps response IDs and bounded diagnostic summaries behind explicit metadata opt-in plus Pi's
-  transcript-expansion control; never includes raw diagnostics or opaque signatures.
-- Optionally records tool duration and success/error after the complete tool block, paired strictly
-  by tool-call ID even when tools run in parallel.
-- Stores exact versioned custom session entries that survive reload and resume.
-- Keeps every stamp entry outside LLM context, so stamp text is never sent to the model.
-- Uses Pi's current theme, remains width-safe in narrow terminals, and owns no timer, process,
-  watcher, network request, custom tool, or persistent status item.
+- Shows each message's recorded creation time on a dim right-aligned row.
+- Supports 12/24-hour clocks, seconds, automatic date context, locales, and time zones.
+- Optionally shows response latency, model and provider identity, stop reason, tokens, and estimated cost.
+- Optionally records tool duration and success or error after each complete tool block.
+- Keeps sensitive response IDs and bounded diagnostics behind explicit opt-in and transcript expansion.
+- Persists exact session entries across reload and resume while keeping every stamp outside model context.
+- Remains width-safe and owns no timer, process, watcher, network request, model tool, or persistent status.
 
 ## 📦 Install
 
@@ -44,8 +38,8 @@ pi -e ./packages/pi-stamp
 
 ## 🚀 Quick start
 
-Load the extension and use Pi normally. Each new user and assistant message receives a separate dim
-stamp aligned to the terminal's right edge:
+Load the extension and use Pi normally.
+Each new user and assistant message receives a separate dim stamp aligned to the terminal's right edge:
 
 ```text
 Your message
@@ -67,8 +61,8 @@ Help
 Close
 ```
 
-Settings save immediately. Mounted compatible stamps reformat on the next render, and future stamps
-use the same effective values.
+Settings save immediately.
+Mounted compatible stamps reformat on the next render, and future stamps use the same effective values.
 
 ## 💬 Commands
 
@@ -90,9 +84,9 @@ The `/stamp` Settings screen provides these controls:
 | `assistantMetadata` | `"off"`, `"compact"`, `"expanded"` | `"off"` | Captures and shows no assistant metadata, a compact model/total/cost summary, or all supported reported fields. |
 | `toolStamps` | boolean | `false` | Records and shows duration plus success/error for newly observed tools. |
 
-The compatibility defaults produce local `HH:mm:ss` for ordinary same-day messages. `invariant`
-uses Gregorian ISO dates, Latin digits, and English `AM`/`PM`. `system` uses the operating system
-locale; examples of explicit locales are `en-US`, `fr-FR`, and `zh-TW`.
+The compatibility defaults produce local `HH:mm:ss` for ordinary same-day messages.
+`invariant` uses Gregorian ISO dates, Latin digits, and English `AM`/`PM`.
+`system` uses the operating system locale; examples of explicit locales are `en-US`, `fr-FR`, and `zh-TW`.
 
 The canonical user file is:
 
@@ -100,9 +94,9 @@ The canonical user file is:
 ~/.pi/agent/pi-stamp.json
 ```
 
-Pi's configured agent directory replaces `~/.pi/agent` when applicable. The file is a partial JSON
-object. This example shows 12-hour Taipei time without seconds, compact assistant metadata, and tool
-stamps:
+Pi's configured agent directory replaces `~/.pi/agent` when applicable.
+The file is a partial JSON object.
+This example shows 12-hour Taipei time without seconds, compact assistant metadata, and tool stamps:
 
 ```json
 {
@@ -121,19 +115,18 @@ Settings precedence is intentionally:
 built-in defaults -> user pi-stamp.json
 ```
 
-Presentation is a personal preference, so `pi-stamp` does not read project settings or
-extension-specific environment variables. Missing settings do not create a file or directory.
+Presentation is a personal preference, so `pi-stamp` does not read project settings or extension-specific environment variables.
+Missing settings do not create a file or directory.
 Updates preserve unknown fields and publish through a private temporary file plus atomic rename.
-Malformed or invalid files become read-only and are never overwritten; fix the reported file and run
-`/reload`. A fresh process uses defaults while the file is invalid, and a running process retains its
-last valid settings.
+Malformed or invalid files become read-only and are never overwritten; fix the reported file and run `/reload`.
+A fresh process uses defaults while the file is invalid, and a running process retains its last valid settings.
 
-Reads and writes are serialized within one Pi process. Separate Pi processes do not share a lock, so
-concurrent saves are last-writer-wins even though each process rereads immediately before atomic
-publication.
+Reads and writes are serialized within one Pi process.
+Separate Pi processes do not share a lock, so concurrent saves are last-writer-wins even though each process rereads immediately before atomic publication.
 
-`/stamp` supports TUI and RPC dialog modes. Print and JSON command invocations reject without writing
-ad hoc protocol output. Transcript stamps themselves are appended only in TUI mode.
+`/stamp` supports TUI and RPC dialog modes.
+Print and JSON command invocations reject without writing ad hoc protocol output.
+Transcript stamps themselves are appended only in TUI mode.
 
 ## 🕰️ Timestamp and response-timing semantics
 
@@ -146,33 +139,29 @@ ad hoc protocol output. Transcript stamps themselves are appended only in TUI mo
   14:32:08 · 3.2s
   ```
 
-- `responseTiming: "detailed"` distinguishes the first meaningful streamed content observed by Pi
-  from total completion:
+- `responseTiming: "detailed"` distinguishes the first meaningful streamed content observed by Pi from total completion:
 
   ```text
   14:32:08 · first 0.8s · total 3.2s
   ```
 
-  First content is the first non-empty text, thinking, or tool-call update—not a provider-server
-  timestamp or guaranteed time-to-first-token. `first n/a` means Pi finalized the response without
-  such an update; completion time is never substituted.
-- If an assistant message invokes tools, response timing ends at the assistant's `message_end` and
-  excludes tool execution even though the assistant stamp appears after the complete tool block.
-- Error and aborted assistant messages use the same local completion boundary. Invalid or backwards
-  clock observations degrade to timestamp-only data rather than showing a negative or clamped value.
-- `dateContext: "day-change"` compares each newly recorded message stamp with its persisted
-  predecessor in the selected time zone. The first known stamp stays time-only.
-- Changing presentation settings re-renders compatible recorded stamps without rewriting session
-  files.
+First content is the first non-empty text, thinking, or tool-call update—not a provider-server timestamp or guaranteed time-to-first-token.
+`first n/a` means Pi finalized the response without such an update; completion time is never substituted.
+- If an assistant message invokes tools, response timing ends at the assistant's `message_end` and excludes tool execution even though the assistant stamp appears after the complete tool block.
+- Error and aborted assistant messages use the same local completion boundary.
+  Invalid or backwards clock observations degrade to timestamp-only data rather than showing a negative or clamped value.
+- `dateContext: "day-change"` compares each newly recorded message stamp with its persisted predecessor in the selected time zone.
+  The first known stamp stays time-only.
+- Changing presentation settings re-renders compatible recorded stamps without rewriting session files.
 
-Timing labels are local Pi lifecycle observations, not provider latency telemetry. They require no
-network request or refresh task. Relative labels such as `3m ago` remain unavailable because they
-would require periodic background refresh and lifecycle cleanup.
+Timing labels are local Pi lifecycle observations, not provider latency telemetry.
+They require no network request or refresh task.
+Relative labels such as `3m ago` remain unavailable because they would require periodic background refresh and lifecycle cleanup.
 
 ## 🧾 Assistant provenance and usage
 
-Assistant metadata is captured only when `assistantMetadata` is `"compact"` or `"expanded"` as the
-assistant stamp is finalized. A compact stamp can look like:
+Assistant metadata is captured only when `assistantMetadata` is `"compact"` or `"expanded"` as the assistant stamp is finalized.
+A compact stamp can look like:
 
 ```text
 14:32:08 · 3.2s
@@ -185,47 +174,43 @@ When Pi reports a response model different from the requested model, compact mod
 requested-alias → provider-response-model · 842 tok
 ```
 
-Expanded mode adds labeled rows for API, provider, requested model, provider-reported response model,
-stop reason, and each individually reported input/output/reasoning/cache-read/cache-write/total token
-or estimated-cost field. Missing values stay absent; `pi-stamp` never derives a token total, response
-model, cost, or diagnostic message.
+Expanded mode adds labeled rows for API, provider, requested model, provider-reported response model, stop reason, and each individually reported input/output/reasoning/cache-read/cache-write/total token or estimated-cost field.
+Missing values stay absent; `pi-stamp` never derives a token total, response model, cost, or diagnostic message.
 
 Pi's transcript expansion action (`app.tools.expand`, `Ctrl+O` by default) is the explicit debug view.
-With assistant metadata enabled, it may additionally show the sanitized response ID and at most five
-diagnostic summaries. A summary contains only diagnostic type, error name, and error code. Stamp data
-never copies diagnostic messages, stacks, details, raw payloads, message content, tool arguments, or
-`textSignature`, `thinkingSignature`, and `thoughtSignature` fields. Terminal controls are removed
-and retained text is bounded before persistence.
+With assistant metadata enabled, it may additionally show the sanitized response ID and at most five diagnostic summaries.
+A summary contains only diagnostic type, error name, and error code.
+Stamp data never copies diagnostic messages, stacks, details, raw payloads, message content, tool arguments, or `textSignature`, `thinkingSignature`, and `thoughtSignature` fields.
+Terminal controls are removed and retained text is bounded before persistence.
 
-Provider support varies. Every optional field is shown only when present and valid on that finalized
-assistant message. The cost label says `est` because Pi's message value is an estimate based on the
-provider/model usage data available to Pi; the extension performs no price lookup.
+Provider support varies.
+Every optional field is shown only when present and valid on that finalized assistant message.
+The cost label says `est` because Pi's message value is an estimate based on the provider/model usage data available to Pi; the extension performs no price lookup.
 
 ## 🛠️ Tool timing
 
-With `toolStamps: true`, the extension observes `tool_execution_start` and `tool_execution_end`,
-pairs them by exact `toolCallId`, and appends entries in `turn_end.toolResults` source order:
+With `toolStamps: true`, the extension observes `tool_execution_start` and `tool_execution_end`, pairs them by exact `toolCallId`, and appends entries in `turn_end.toolResults` source order:
 
 ```text
 tool read · 1.3s · success
 tool bash · 2.5s · error
 ```
 
-The duration is the extension's local start-to-end observation. Outcome is Pi's final `isError`
-state; it is not inferred from tool text. Tool arguments, output, result details, and IDs are never
-shown. Because Pi's public API cannot decorate built-in tool rows, stamps appear as separate rows
-after the complete tool block.
+The duration is the extension's local start-to-end observation.
+Outcome is Pi's final `isError` state; it is not inferred from tool text.
+Tool arguments, output, result details, and IDs are never shown.
+Because Pi's public API cannot decorate built-in tool rows, stamps appear as separate rows after the complete tool block.
 
-The tracker owns at most 256 observations in one turn. Duplicate, unmatched, malformed, backwards,
-or excess observations are ignored. Pending state is cleared on a new turn, agent cancellation/end,
-session replacement, reload, and shutdown. Tools that were not observed while tool stamps were
-enabled are not backfilled.
+The tracker owns at most 256 observations in one turn.
+Duplicate, unmatched, malformed, backwards, or excess observations are ignored.
+Pending state is cleared on a new turn, agent cancellation/end, session replacement, reload, and shutdown.
+Tools that were not observed while tool stamps were enabled are not backfilled.
 
 ## 🔒 Context and persistence
 
-Stamps use Pi custom session entries. Pi renders those entries in the interactive transcript but
-excludes them from model context. The extension does not modify user, assistant, or tool-result
-message content.
+Stamps use Pi custom session entries.
+Pi renders those entries in the interactive transcript but excludes them from model context.
+The extension does not modify user, assistant, or tool-result message content.
 
 Message entry compatibility is cumulative:
 
@@ -236,19 +221,16 @@ Message entry compatibility is cumulative:
   timing remains optional so a valid metadata stamp survives a backwards timing clock.
 - Version 1 tool entries store only bounded association/timing/outcome data.
 
-Existing versions remain readable. Changing settings never rewrites session history. Once recorded,
-a stamp survives `/reload` and session resume while the extension remains loaded. Messages and tools
-created before `pi-stamp` recorded them are not backfilled because Pi's current public API cannot
-insert a new custom entry into an older position in the session tree.
+Existing versions remain readable.
+Changing settings never rewrites session history.
+Once recorded, a stamp survives `/reload` and session resume while the extension remains loaded.
+Messages and tools created before `pi-stamp` recorded them are not backfilled because Pi's current public API cannot insert a new custom entry into an older position in the session tree.
 
 ## 🚧 Limitations
 
-- Pi does not currently expose a public decorator for built-in message or tool rows, so stamps appear
-  as separate transcript rows rather than inside the original bubble/block.
-- Another extension can append transcript entries at the same lifecycle boundary, so strict visual
-  adjacency between independently loaded extensions is not guaranteed.
-- There are no arbitrary format strings, relative labels, provider-server latency, token/cost
-  estimation beyond Pi's message fields, aggregates, raw diagnostics, or analytics dashboard.
+- Pi does not currently expose a public decorator for built-in message or tool rows, so stamps appear as separate transcript rows rather than inside the original bubble/block.
+- Another extension can append transcript entries at the same lifecycle boundary, so strict visual adjacency between independently loaded extensions is not guaranteed.
+- There are no arbitrary format strings, relative labels, provider-server latency, token/cost estimation beyond Pi's message fields, aggregates, raw diagnostics, or analytics dashboard.
 
 ## 🗂️ Package layout
 
@@ -276,9 +258,9 @@ packages/pi-stamp/
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, message timestamps, assistant provenance, token usage, tool timing,
-transcript metadata, TUI metadata, TypeScript Pi package.
+Pi extension, Pi coding agent, message timestamps, assistant provenance, token usage, tool timing, transcript metadata, TUI metadata, TypeScript Pi package.
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -1,26 +1,23 @@
-# 🚀 pi-starship — Native Starship-style Statusline for Pi
+# 🚀 pi-starship — Build Pi's Footer with Starship-style TOML
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-starship)](https://www.npmjs.com/package/@narumitw/pi-starship) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-A native Pi footer configured with Starship-style TOML. It parses and renders formats itself—no `starship` executable or shell prompt required.
+Build a deeply customizable Pi footer with Starship-style TOML, native Pi modules, conditional formats, palettes, and responsive multiline layout.
 
-> **Different package:** the unscoped npm package `pi-starship` delegates to the Starship binary. This package is `@narumitw/pi-starship` and renders Pi-specific modules natively.
+No `starship` executable or shell prompt is required because this extension parses and renders the footer itself.
+
+> **Different package:** The unscoped npm package `pi-starship` delegates to the Starship binary.
+> This package is `@narumitw/pi-starship` and renders Pi-specific modules natively.
 
 ## ✨ Features
 
-- Loads a generated split TypeScript runtime through Pi's Jiti loader to reduce package startup work.
-- Uses a readable, palette-free Starship-style built-in configuration until settings are saved.
-- Starship-style root/module formats, conditional groups, `$all`, styles, and opt-in palettes.
-- Pi modules for model, thinking, activity, context, tokens, prompt cache, cost, turn, and extension statuses.
-- Cached Git branch, commit, operation state, line metrics, detailed status, and linked-worktree identity.
-- Native current-branch GitHub pull request links, checks, review state, and terminal-state retention.
-- Opt-in package, language, development-shell, deployment, cloud, and execution-context modules.
-- Width-aware `$fill` alignment for native multiline left/right layouts.
-- Footer rendering is pure: no subprocess, network, filesystem, timer, or environment work runs from `render()`.
-- Multiline output wraps to the terminal width instead of truncating.
-- Goal-oriented `/starship` menu with every Starship 1.26 preset style plus a Pi-native Minimal
-  preset, footer explanation, searchable module inspection, configuration health, transactional
-  preview, and recovery.
+- Starts with a readable built-in footer and offers Starship presets plus a Pi-native Minimal preset.
+- Supports root and module formats, conditional groups, `$all`, styles, palettes, and width-aware `$fill` alignment.
+- Provides Pi, model, usage, Git, pull request, package, language, environment, deployment, cloud, and execution modules.
+- Wraps native multiline layouts to terminal width instead of truncating them.
+- Keeps rendering pure while refreshing filesystem, process, and network-derived data through bounded caches.
+- Uses `/starship` for presets, preview, configuration health, searchable module details, customization, and recovery.
+- Loads a generated split runtime to reduce Pi package startup work.
 
 ## 📦 Install
 
@@ -58,11 +55,10 @@ The only configuration source is:
 <getAgentDir()>/pi-starship.toml
 ```
 
-When this file is absent, the extension uses its readable palette-free default without creating the
-file or parent directory. The built-in root is the explicit sequence `$brand$model$thinking$directory`
-`$git_branch$git_status$activity$context$time`; it does not start the opt-in GitHub PR query. The first
-successful settings save creates the file atomically. Existing malformed documents are never
-overwritten.
+When this file is absent, the extension uses its readable palette-free default without creating the file or parent directory.
+The built-in root is the explicit sequence `$brand$model$thinking$directory` `$git_branch$git_status$activity$context$time`; it does not start the opt-in GitHub PR query.
+The first successful settings save creates the file atomically.
+Existing malformed documents are never overwritten.
 
 The extension does **not** read project overrides, `pi-statusline.json`, `PI_STATUSLINE_PRESET`, or `~/.config/starship.toml`, and does not migrate statusline settings.
 
@@ -72,38 +68,30 @@ Open the interactive menu in TUI mode:
 /starship
 ```
 
-Choose **Customize footer** to edit the TOML. Closing the editor validates the draft and opens an
-adaptive, scrollable preview whose **Apply changes…**, **Continue editing**, and **Discard draft**
-actions remain reachable in short or narrow terminals. Saving happens only after a separate
-confirmation. Confirmed changes are atomically saved and applied immediately. Manual TOML edits load
-on the next `session_start`, including `/reload` and session replacement. Editor cancellation, preview
-cancellation, component disposal, invalid drafts, write failures, and runtime application failures
-preserve the previous file and effective footer.
+Choose **Customize footer** to edit the TOML.
+Closing the editor validates the draft and opens an adaptive, scrollable preview whose **Apply changes…**, **Continue editing**, and **Discard draft** actions remain reachable in short or narrow terminals.
+Saving happens only after a separate confirmation.
+Confirmed changes are atomically saved and applied immediately.
+Manual TOML edits load on the next `session_start`, including `/reload` and session replacement.
+Editor cancellation, preview cancellation, component disposal, invalid drafts, write failures, and runtime application failures preserve the previous file and effective footer.
 
-The shallow main menu also exposes **Presets**, **Explain footer**, **Modules**, **Configuration**,
-**Help**, and **Restore built-in…**. Explain footer uses the current immutable runtime snapshot to list
-each currently showing non-empty module once with its rendered value and description; it starts no new
-collection work. Modules opens a bounded searchable inspector for every registered module. Its
-textual states distinguish **Showing**, **Empty**, **Disabled**, **Not in format**, and
-**Unavailable** only when the current footer cannot provide an inspection snapshot. Module detail
-shows the current preview when available, description, root reference and reachability, format
-variables, style fields, display rules, and the known reason for absent output. Both views are
-read-only and never create or update the settings document.
+The shallow main menu also exposes **Presets**, **Explain footer**, **Modules**, **Configuration**, **Help**, and **Restore built-in…**.
+Explain footer uses the current immutable runtime snapshot to list each currently showing non-empty module once with its rendered value and description; it starts no new collection work.
+Modules opens a bounded searchable inspector for every registered module.
+Its textual states distinguish **Showing**, **Empty**, **Disabled**, **Not in format**, and **Unavailable** only when the current footer cannot provide an inspection snapshot.
+Module detail shows the current preview when available, description, root reference and reachability, format variables, style fields, display rules, and the known reason for absent output.
+Both views are read-only and never create or update the settings document.
 
-Configuration combines state, source, path, health, and diagnostics. A healthy missing file is shown
-as **Built-in defaults**, an exact bundled document is shown as its named preset, and **Built-in
-fallback** is reserved for read or parse errors. Restore is disabled when no settings document exists
-or the exact built-in document is already saved. For a custom or invalid document, Restore previews
-the result and warns that the complete document,
-including custom settings, unknown fields, and comments, will be replaced without a post-success
-backup before asking for confirmation.
+Configuration combines state, source, path, health, and diagnostics.
+A healthy missing file is shown as **Built-in defaults**, an exact bundled document is shown as its named preset, and **Built-in fallback** is reserved for read or parse errors.
+Restore is disabled when no settings document exists or the exact built-in document is already saved.
+For a custom or invalid document, Restore previews the result and warns that the complete document, including custom settings, unknown fields, and comments, will be replaced without a post-success backup before asking for confirmation.
 
 ### 🎛️ Presets
 
-Choose **Presets** from `/starship` to browse complete Pi-native starting points. The catalog adapts
-all styles listed by `starship preset --list` in Starship 1.26.0, plus a Pi-specific Minimal option.
-Colors, separators, typography, and layout follow the named Starship preset; modules are deliberately
-selected for Pi's model, thinking, workspace, Git, activity, context, and time snapshots.
+Choose **Presets** from `/starship` to browse complete Pi-native starting points.
+The catalog adapts all styles listed by `starship preset --list` in Starship 1.26.0, plus a Pi-specific Minimal option.
+Colors, separators, typography, and layout follow the named Starship preset; modules are deliberately selected for Pi's model, thinking, workspace, Git, activity, context, and time snapshots.
 
 | Preset | Adapted visual treatment | Font requirement |
 | --- | --- | --- |
@@ -121,25 +109,21 @@ selected for Pi's model, thinking, workspace, Git, activity, context, and time s
 | **Pure Preset** | Clean two-line workspace and session context | Standard Unicode |
 | **Tokyo Night** | Connected cool blue Tokyo Night blocks | Nerd Font |
 
-The preset cursor is a live footer preview. Opening the picker and moving with Up/Down, Page Up/Down,
-Home, or End temporarily renders the selected preset in the actual footer without writing settings or
-starting new collectors. Press Enter to start the named preset's replacement confirmation, or press
-`e` to customize the selected complete TOML document before its normal editor preview and
-confirmation. Escape returns to the main menu, while Ctrl+C closes the complete workflow; both restore
-the previously effective footer.
+The preset cursor is a live footer preview.
+Opening the picker and moving with Up/Down, Page Up/Down, Home, or End temporarily renders the selected preset in the actual footer without writing settings or starting new collectors.
+Press Enter to start the named preset's replacement confirmation, or press `e` to customize the selected complete TOML document before its normal editor preview and confirmation.
+Escape returns to the main menu, while Ctrl+C closes the complete workflow; both restore the previously effective footer.
 
-Presets are complete documents, not overlays. Applying one replaces `pi-starship.toml`, including
-custom settings, unknown fields, and comments, only after a separate confirmation; no post-success
-backup is kept. Cursor movement, confirmation cancellation, disposal, validation failure, write
-failure, and runtime-apply failure retain the previous valid document and effective footer. Exact
-unedited matches are shown as **Currently applied** and cannot be redundantly selected; editing any
-byte makes the document custom again. **Restore built-in…** remains the deterministic recovery path.
+Presets are complete documents, not overlays.
+Applying one replaces `pi-starship.toml`, including custom settings, unknown fields, and comments, only after a separate confirmation; no post-success backup is kept.
+Cursor movement, confirmation cancellation, disposal, validation failure, write failure, and runtime-apply failure retain the previous valid document and effective footer.
+Exact unedited matches are shown as **Currently applied** and cannot be redundantly selected; editing any byte makes the document custom again.
+**Restore built-in…** remains the deterministic recovery path.
 
-The bundled presets use only pi-starship's local Pi and Git snapshot modules. They do not enable the
-GitHub PR query, cloud/deployment readers, or optional command-backed workspace collectors. They are
-Pi-native adaptations of the color and format treatments emitted by Starship 1.26.0; they do not copy
-Starship's module selections because Pi exposes different runtime information. There is no
-`/starship preset` textual route and no remote preset download.
+The bundled presets use only pi-starship's local Pi and Git snapshot modules.
+They do not enable the GitHub PR query, cloud/deployment readers, or optional command-backed workspace collectors.
+They are Pi-native adaptations of the color and format treatments emitted by Starship 1.26.0; they do not copy Starship's module selections because Pi exposes different runtime information.
+There is no `/starship preset` textual route and no remote preset download.
 
 ### 📝 Example
 
@@ -206,37 +190,35 @@ format = "([$statuses ]($style))"
 icons = { "foo:*" = "🧪", "third_party/key" = "◎", fallback = "•" }
 ```
 
-Every module table supports `format`, `symbol`, and `disabled`. Most modules also support one `style`.
-The exceptions are `git_metrics` (`added_style` and `deleted_style`), `username` (`style_user` and
-`style_root`), and the threshold-selected `context` and `cost` `display` arrays described below.
+Every module table supports `format`, `symbol`, and `disabled`.
+Most modules also support one `style`.
+The exceptions are `git_metrics` (`added_style` and `deleted_style`), `username` (`style_user` and `style_root`), and the threshold-selected `context` and `cost` `display` arrays described below.
 Module-specific options are catalog-owned and type-checked; unknown options warn and stay inactive.
-Version formats replace `$raw`. Detection arrays replace defaults when non-empty and inspect only one
-listing of the current directory. A leading `!` is supported by language detection arrays and rejects
-a matching project.
-`[extension_status].icons` accepts arbitrary exact Pi status keys and explicit colon namespace
-wildcards such as `foo:*`; `fallback` controls unmatched statuses. Icon matching uses the exact key,
-the longest `:*` wildcard, a leading status emoji, then `fallback`/`🔌`. An empty configured icon
-suppresses only the icon. `foo:*` matches `foo:server` but not `foo`, `foobar`, or `foo/server`.
+Version formats replace `$raw`.
+Detection arrays replace defaults when non-empty and inspect only one listing of the current directory.
+A leading `!` is supported by language detection arrays and rejects a matching project.
+`[extension_status].icons` accepts arbitrary exact Pi status keys and explicit colon namespace wildcards such as `foo:*`; `fallback` controls unmatched statuses.
+Icon matching uses the exact key, the longest `:*` wildcard, a leading status emoji, then `fallback`/`🔌`.
+An empty configured icon suppresses only the icon.
+`foo:*` matches `foo:server` but not `foo`, `foobar`, or `foo/server`.
 
-Pi does not expose which package owns a status, so exact raw keys are the reliable third-party
-contract. pi-starship does not inspect installed packages, infer package aliases, assign icons to
-known extensions, or bridge compatibility keys. Extension authors may adopt `<extension-id>` or
-`<extension-id>:<stable-slot>` for interoperability, but pi-starship does not require that convention.
+Pi does not expose which package owns a status, so exact raw keys are the reliable third-party contract. pi-starship does not inspect installed packages, infer package aliases, assign icons to known extensions, or bridge compatibility keys.
+Extension authors may adopt `<extension-id>` or `<extension-id>:<stable-slot>` for interoperability, but pi-starship does not require that convention.
 
-**Icon migration:** configurations that relied on package-ID aliases, built-in known-extension icons,
-or compatibility mappings must use an exact raw status key, an explicit namespace wildcard, a
-leading emoji in the status value, or `fallback`.
+**Icon migration:** configurations that relied on package-ID aliases, built-in known-extension icons, or compatibility mappings must use an exact raw status key, an explicit namespace wildcard, a leading emoji in the status value, or `fallback`.
 
 ## 🧩 Format grammar
 
-- Variables: `$name` and `${name}`. Unknown variables render empty and produce a warning when loaded from TOML.
+- Variables: `$name` and `${name}`.
+  Unknown variables render empty and produce a warning when loaded from TOML.
 - Escapes: `\\$`, `\\[`, `\\]`, `\\(`, `\\)`, and `\\\\` render functional characters literally.
 - Styled groups: `[format string](style string)`.
 - Conditional groups: `(format string)` render only when a nested variable has a non-empty value.
 - Nested groups are supported.
 - `$all` expands enabled modules in the default order and omits modules already referenced explicitly.
 
-Module formats can use `$style` in a style expression. Module output keeps its own style when embedded in an outer styled group.
+Module formats can use `$style` in a style expression.
+Module output keeps its own style when embedded in an outer styled group.
 
 ## 🎨 Styles and palettes
 
@@ -247,15 +229,13 @@ Style expressions support:
 - `fg:<color>` and `bg:<color>`; an unprefixed color is foreground.
 - `bold`, `dimmed`, `italic`, `underline`, `blink`, `inverted`, `hidden`, and `strikethrough`.
 - `none` and `fg:none`, which make the complete expression unstyled regardless of position.
-- `bg:none`, which clears only the absolute background; an unknown `bg:<value>` has the same
-  Starship-compatible reset behavior.
-- `prev_fg` and `prev_bg`, which use the previous rendered chunk's colors when present and retain any
-  absolute foreground/background in the expression as the no-previous fallback.
+- `bg:none`, which clears only the absolute background; an unknown `bg:<value>` has the same Starship-compatible reset behavior.
+- `prev_fg` and `prev_bg`, which use the previous rendered chunk's colors when present and retain any absolute foreground/background in the expression as the no-previous fallback.
 - Direct color names from one explicitly selected `[palettes.<name>]` table.
 
-There is no built-in or fallback palette. A custom palette is active only when its table is explicitly
-selected, and its values must be direct named, ANSI, or RGB colors—palette entries cannot reference
-other entries. Palette names override terminal color names such as `blue`:
+There is no built-in or fallback palette.
+A custom palette is active only when its table is explicitly selected, and its values must be direct named, ANSI, or RGB colors—palette entries cannot reference other entries.
+Palette names override terminal color names such as `blue`:
 
 ```toml
 palette = "company"
@@ -269,29 +249,24 @@ style = "bold blue"
 ```
 
 Style tokens are case-insensitive and ordinary foreground/background colors are last-wins.
-`prev_fg`/`prev_bg` override their absolute fallback only when a previous chunk exists. Empty styled
-groups still advance previous-color state. Invalid literal style expressions warn and render
-unstyled. An invalid root format falls back to the built-in root format; an invalid module format or
-catalog-owned style field falls back only at that field's module scope. `/starship status` reports
-warnings.
+`prev_fg`/`prev_bg` override their absolute fallback only when a previous chunk exists.
+Empty styled groups still advance previous-color state.
+Invalid literal style expressions warn and render unstyled.
+An invalid root format falls back to the built-in root format; an invalid module format or catalog-owned style field falls back only at that field's module scope.
+`/starship status` reports warnings.
 
-The background-free direct defaults are: `brand = "bold white"`, `provider`/`model` = `"bold blue"`,
-`thinking`/`git_branch`/`turn` = `"bold purple"`, `directory`/`git_worktree` = `"cyan bold"`,
-`github_pr = "bold blue"`, `git_commit = "green bold"`, `git_state`/`activity`/`time` =
-`"bold yellow"`, `git_status = "red bold"`, `tokens = "bold cyan"`, `cache = "bold green"`,
-`extension_status = "dimmed white"`, `direnv = "bold bright-yellow"`, and `fill = "bold black"`.
+The background-free direct defaults are: `brand = "bold white"`, `provider`/`model` = `"bold blue"`, `thinking`/`git_branch`/`turn` = `"bold purple"`, `directory`/`git_worktree` = `"cyan bold"`, `github_pr = "bold blue"`, `git_commit = "green bold"`, `git_state`/`activity`/`time` = `"bold yellow"`, `git_status = "red bold"`, `tokens = "bold cyan"`, `cache = "bold green"`, `extension_status = "dimmed white"`, `direnv = "bold bright-yellow"`, and `fill = "bold black"`.
 Context, cost, Git metrics, and username use the state/multi-style defaults below.
 
 ### State-selected styles
 
-`context` and `cost` select the last entry at the highest threshold less than or equal to the current
-value. A later entry wins when thresholds are equal. Each display entry requires a finite `threshold`,
-a valid `style`, and boolean `hidden`. Invalid entries warn and are ignored; module defaults are used
-if none remain.
+`context` and `cost` select the last entry at the highest threshold less than or equal to the current value.
+A later entry wins when thresholds are equal.
+Each display entry requires a finite `threshold`, a valid `style`, and boolean `hidden`.
+Invalid entries warn and are ignored; module defaults are used if none remain.
 
-The default context thresholds are hidden at `0`, `bold green` at `30`, `bold yellow` at `60`, and
-`bold red` at `80`. The default cost thresholds are hidden at `0`, `bold yellow` at `1`, and `bold red`
-at `5`:
+The default context thresholds are hidden at `0`, `bold green` at `30`, `bold yellow` at `60`, and `bold red` at `80`.
+The default cost thresholds are hidden at `0`, `bold yellow` at `1`, and `bold red` at `5`:
 
 ```toml
 [[cost.display]]
@@ -310,25 +285,20 @@ style = "bold red"
 hidden = false
 ```
 
-`git_metrics` exposes `$added_style` and `$deleted_style` in its module format. `username` still uses
-`$style` in its format, but selects `style_user` or `style_root` from private execution metadata; the
-selector is not a format variable.
+`git_metrics` exposes `$added_style` and `$deleted_style` in its module format.
+`username` still uses `$style` in its format, but selects `style_user` or `style_root` from private execution metadata; the selector is not a format variable.
 
 ### Breaking palette migration
 
-The previous implicit `tokyo-night` palette and its `lead`, `header`, `header_fg`, `directory`,
-`directory_fg`, `git`, `git_fg`, `runtime`, `runtime_fg`, `meter`, `meter_fg`, and `extension` aliases
-were removed. Existing files are not rewritten. Old alias-based module styles warn and fall back to
-the module's new direct-color default; alias-based literal Powerline groups warn and render unstyled.
+The previous implicit `tokyo-night` palette and its `lead`, `header`, `header_fg`, `directory`, `directory_fg`, `git`, `git_fg`, `runtime`, `runtime_fg`, `meter`, `meter_fg`, and `extension` aliases were removed.
+Existing files are not rewritten.
+Old alias-based module styles warn and fall back to the module's new direct-color default; alias-based literal Powerline groups warn and render unstyled.
 
 Choose one migration:
 
-1. Replace old aliases with direct styles such as `cyan bold`, `bold bright-yellow`, or
-   `fg:#e3e5e5 bg:#769ff0`.
-2. Define every needed alias under your own `[palettes.<name>]` table and explicitly select it with
-   `palette = "<name>"`.
-3. Use **Restore built-in…** from `/starship` to review and replace the complete document with the new
-   plain nine-module configuration.
+1. Replace old aliases with direct styles such as `cyan bold`, `bold bright-yellow`, or `fg:#e3e5e5 bg:#769ff0`.
+2. Define every needed alias under your own `[palettes.<name>]` table and explicitly select it with `palette = "<name>"`.
+3. Use **Restore built-in…** from `/starship` to review and replace the complete document with the new plain nine-module configuration.
 
 There is no hidden compatibility overlay or automatic migration.
 
@@ -384,20 +354,20 @@ There is no hidden compatibility overlay or automatic migration.
 ### Usage semantics
 
 - `tokens`, `cache`, and `cost` total every usage-bearing session entry, matching Pi's native footer:
-  assistant messages, nested-LLM tool results, compactions, and branch summaries, including abandoned
-  branches retained in the session.
-- Cache `$read` and `$write` are cumulative. `$rate` uses only the latest assistant prompt:
-  `cacheRead / (input + cacheRead + cacheWrite) * 100`. The module is empty when Pi has reported no
-  cache reads or writes.
-- `cache` is disabled and absent from the built-in root. Enable it and add `$cache` to a custom root
-  format (or use `$all`) to display it.
-- Context `$percentage` uses native one-decimal precision. Its default display hides values below 30%;
-  customize `[[context.display]]` when lower values should remain visible. The module name remains
-  `context`, not `context_usage`.
-- Subscription-backed OAuth models and `kimi-coding` set cost `$subscription` to `(sub)`. The dollar
-  value is usage cost, not proof of an amount billed under a subscription.
-- Pi's public extension API does not expose the current auto-compaction toggle, so pi-starship cannot
-  reliably provide the native `(auto)` marker.
+  assistant messages, nested-LLM tool results, compactions, and branch summaries, including abandoned branches retained in the session.
+- Cache `$read` and `$write` are cumulative.
+  `$rate` uses only the latest assistant prompt:
+`cacheRead / (input + cacheRead + cacheWrite) * 100`.
+The module is empty when Pi has reported no cache reads or writes.
+- `cache` is disabled and absent from the built-in root.
+  Enable it and add `$cache` to a custom root format (or use `$all`) to display it.
+- Context `$percentage` uses native one-decimal precision.
+  Its default display hides values below 30%;
+customize `[[context.display]]` when lower values should remain visible.
+The module name remains `context`, not `context_usage`.
+- Subscription-backed OAuth models and `kimi-coding` set cost `$subscription` to `(sub)`.
+  The dollar value is usage cost, not proof of an amount billed under a subscription.
+- Pi's public extension API does not expose the current auto-compaction toggle, so pi-starship cannot reliably provide the native `(auto)` marker.
 
 ### Directory, Git, and environment contraction
 
@@ -428,29 +398,26 @@ truncation_length = 1
 trim_at = "." # set to "" to keep the complete hostname
 ```
 
-Directory `$path` contracts the home directory and, by default, the current Git repository root
-before retaining the last three path components. `$full_path` remains the unmodified absolute cwd.
-A positive `fish_style_pwd_dir_length` abbreviates otherwise omitted parent components when no
-substitution is configured. `substitutions` is an ordered TOML string table of literal replacements.
-Pi exposes one cwd rather than separate logical and physical paths, and pi-starship does not implement
-Starship's regex substitution array or repo-root-specific split style/format fields. Directory
-rendering reads only immutable home and repository-root snapshot data and performs no filesystem or
-Git work.
+Directory `$path` contracts the home directory and, by default, the current Git repository root before retaining the last three path components.
+`$full_path` remains the unmodified absolute cwd.
+A positive `fish_style_pwd_dir_length` abbreviates otherwise omitted parent components when no substitution is configured.
+`substitutions` is an ordered TOML string table of literal replacements.
+Pi exposes one cwd rather than separate logical and physical paths, and pi-starship does not implement Starship's regex substitution array or repo-root-specific split style/format fields.
+Directory rendering reads only immutable home and repository-root snapshot data and performs no filesystem or Git work.
 
-Git branch truncation retains the first `N` grapheme clusters and appends the first grapheme of
-`truncation_symbol` only when truncation occurs. The same rule applies independently to `$branch`,
-`$remote_name`, and `$remote_branch`. Upstream Starship represents its unlimited default as
-`2^63 - 1`; pi-starship uses `0` for the same behavior because its settings integers are deliberately
-bounded. `commit_hash_length` accepts 0 through 64.
+Git branch truncation retains the first `N` grapheme clusters and appends the first grapheme of `truncation_symbol` only when truncation occurs.
+The same rule applies independently to `$branch`, `$remote_name`, and `$remote_branch`.
+Upstream Starship represents its unlimited default as `2^63 - 1`; pi-starship uses `0` for the same behavior because its settings integers are deliberately bounded.
+`commit_hash_length` accepts 0 through 64.
 
-Conda retains the last path component by default; `0` keeps the complete environment path. Hostname
-trimming runs before exact alias lookup, matching Starship. These are display transformations only:
+Conda retains the last path component by default; `0` keeps the complete environment path.
+Hostname trimming runs before exact alias lookup, matching Starship.
+These are display transformations only:
 collectors retain bounded, control-sanitized source metadata.
 
 ### Model aliases and truncation
 
-The model module accepts exact `model_aliases`, Starship-style `truncation_length` and
-`truncation_symbol` options, plus the Pi-specific `truncation_direction` option:
+The model module accepts exact `model_aliases`, Starship-style `truncation_length` and `truncation_symbol` options, plus the Pi-specific `truncation_direction` option:
 
 ```toml
 [model]
@@ -460,30 +427,29 @@ truncation_symbol = "…"
 truncation_direction = "middle"
 ```
 
-An exact alias is selected before the built-in Claude/GPT shortening rules, then the resulting label
-is subject to the configured truncation. `truncation_length` counts model grapheme clusters retained
-before the symbol; `0` disables
-truncation and is the default. The direction names the removed portion: `start` retains the suffix,
-`end` retains the prefix and is the default, and `middle` retains both ends. When no alias matches,
-truncation runs after the built-in Claude/GPT shortening rules. It always changes display only—the
-provider model ID is untouched.
-Terminal control sequences in model IDs and truncation symbols are removed at render time. An empty
-symbol truncates without a marker. For example, `middle` can retain both a Hugging Face model
-family and its variant, while `start` is useful when a llama.cpp server reports an absolute model path.
-pi-starship treats model IDs as opaque strings and does not parse paths, repositories, GGUF suffixes,
-or quantization names.
+An exact alias is selected before the built-in Claude/GPT shortening rules, then the resulting label is subject to the configured truncation.
+`truncation_length` counts model grapheme clusters retained before the symbol; `0` disables truncation and is the default.
+The direction names the removed portion: `start` retains the suffix, `end` retains the prefix and is the default, and `middle` retains both ends.
+When no alias matches, truncation runs after the built-in Claude/GPT shortening rules.
+It always changes display only—the provider model ID is untouched.
+Terminal control sequences in model IDs and truncation symbols are removed at render time.
+An empty symbol truncates without a marker.
+For example, `middle` can retain both a Hugging Face model family and its variant, while `start` is useful when a llama.cpp server reports an absolute model path.
+pi-starship treats model IDs as opaque strings and does not parse paths, repositories, GGUF suffixes, or quantization names.
 
-`truncation_direction` is a pi-starship adaptation; upstream Starship has no model module or generic
-truncation-direction setting.
+`truncation_direction` is a pi-starship adaptation; upstream Starship has no model module or generic truncation-direction setting.
 
-`git_worktree` is empty in the primary worktree. In a linked worktree it defaults to the top-level directory name; use `$path` when the full absolute path is needed.
+`git_worktree` is empty in the primary worktree.
+In a linked worktree it defaults to the top-level directory name; use `$path` when the full absolute path is needed.
 
-`git_commit`, `git_state`, and `git_metrics` are intentionally not present in the built-in root format. Add their variables to `format` to opt in; also set `[git_metrics].disabled = false`, matching Starship's opt-in metrics default. `$tag` resolves only an exact tag on HEAD and is queried only when the configured `git_commit` format references it.
+`git_commit`, `git_state`, and `git_metrics` are intentionally not present in the built-in root format.
+Add their variables to `format` to opt in; also set `[git_metrics].disabled = false`, matching Starship's opt-in metrics default.
+`$tag` resolves only an exact tag on HEAD and is queried only when the configured `git_commit` format references it.
 
 ### 🔎 Native GitHub pull requests
 
-`$github_pr` is independent of `pi-github-pr`; installing that extension is not required. It runs one
-bounded GitHub CLI query for the current branch:
+`$github_pr` is independent of `pi-github-pr`; installing that extension is not required.
+It runs one bounded GitHub CLI query for the current branch:
 
 ```text
 gh pr view --json number,isDraft,url,state,closedAt,mergedAt,reviewDecision,statusCheckRollup
@@ -495,11 +461,8 @@ Install and authenticate `gh` first:
 gh auth login
 ```
 
-For GitHub Enterprise Server, authenticate the repository host and keep that host in the repository
-remote, for example `gh auth login --hostname github.example.com`. pi-starship starts `gh` directly
-with child-only environment data that omits ambient `GH_HOST` and `GH_REPO` overrides, so `gh` resolves
-the correct repository and host from the current checkout. It never mutates Pi's environment, calls
-the GitHub API directly, or manages tokens.
+For GitHub Enterprise Server, authenticate the repository host and keep that host in the repository remote, for example `gh auth login --hostname github.example.com`. pi-starship starts `gh` directly with child-only environment data that omits ambient `GH_HOST` and `GH_REPO` overrides, so `gh` resolves the correct repository and host from the current checkout.
+It never mutates Pi's environment, calls the GitHub API directly, or manages tokens.
 
 Variables have these values:
 
@@ -507,10 +470,8 @@ Variables have these values:
 - `$link`: an OSC 8 `#123` link for a safe HTTP(S) URL, otherwise plain `#123`.
 - `$state`: `open`, `draft`, `merged`, or `closed`.
 - `$checks`: all non-zero check counts in passed, failed, pending order, or `-` when no checks exist.
-- `$review`: `R✓` for approved, `R×` for changes requested, `R?` for review required, or empty
-  when unknown.
-- `$status`: one result selected in this order: merged, closed, draft, failing checks, changes
-  requested, pending checks, approved, review required, passing checks, then no checks.
+- `$review`: `R✓` for approved, `R×` for changes requested, `R?` for review required, or empty when unknown.
+- `$status`: one result selected in this order: merged, closed, draft, failing checks, changes requested, pending checks, approved, review required, passing checks, then no checks.
 
 The compact symbols are font-safe and distinct from Git's default `$`, `!`, and `?` worktree markers:
 
@@ -533,8 +494,7 @@ PR #123 · R✓
 PR #123 · M
 ```
 
-Use the existing `$checks` and `$review` variables together when every check category and the review
-result should remain visible:
+Use the existing `$checks` and `$review` variables together when every check category and the review result should remain visible:
 
 ```toml
 [github_pr]
@@ -559,30 +519,26 @@ This is a breaking display migration for custom formats that use these variables
 The old English values have no verbose aliases.
 The variable names and default module format remain unchanged, so no TOML field migration is needed.
 
-The query runs only in TUI sessions when the enabled module is reachable from the root format. It
-refreshes at session start, immediately after a branch change, after each agent run, after accepted
-settings changes, and every 60 seconds. Each query has a 10-second timeout. Branch changes clear the
-old PR before querying the new branch. Closed and merged PRs remain visible for 24 hours, then expire
-without waiting for the next refresh. Missing `gh`, missing authentication, no current PR, timeout,
-malformed or oversized output, and network failures all render an empty module without exposing raw
-errors or credentials.
+The query runs only in TUI sessions when the enabled module is reachable from the root format.
+It refreshes at session start, immediately after a branch change, after each agent run, after accepted settings changes, and every 60 seconds.
+Each query has a 10-second timeout.
+Branch changes clear the old PR before querying the new branch.
+Closed and merged PRs remain visible for 24 hours, then expire without waiting for the next refresh.
+Missing `gh`, missing authentication, no current PR, timeout, malformed or oversized output, and network failures all render an empty module without exposing raw errors or credentials.
 
-The query sends the repository/current-branch context through authenticated `gh` to the GitHub host
-configured by the repository. It requests only the fields above—never comments, review bodies,
-inline comments, or review threads. Footer rendering and previews read only the immutable cached
-snapshot and perform no network or subprocess work.
+The query sends the repository/current-branch context through authenticated `gh` to the GitHub host configured by the repository.
+It requests only the fields above—never comments, review bodies, inline comments, or review threads.
+Footer rendering and previews read only the immutable cached snapshot and perform no network or subprocess work.
 
-**Breaking migration:** `$git_branch.$pr` has been removed without a compatibility alias or automatic
-migration. Replace it with root `$github_pr` and an optional `[github_pr]` table. If `pi-github-pr`
-remains installed, its independent `github-pr` status can also appear under `$extension_status`;
+**Breaking migration:** `$git_branch.$pr` has been removed without a compatibility alias or automatic migration.
+Replace it with root `$github_pr` and an optional `[github_pr]` table.
+If `pi-github-pr` remains installed, its independent `github-pr` status can also appear under `$extension_status`;
 disable or remove that extension when adopting the native module to avoid duplicate information.
 
 ### 📦 Package and language modules
 
-Module behavior is inspired by Starship pinned at
-`9f4d07ed45804e280d6884bb8ced7ea3d3033093`; formatter style semantics and the approved
-multi/state-style surfaces are aligned with the checked-in Starship source at `cad50cd8`. This is not
-complete Starship module or configuration compatibility.
+Module behavior is inspired by Starship pinned at `9f4d07ed45804e280d6884bb8ced7ea3d3033093`; formatter style semantics and the approved multi/state-style surfaces are aligned with the checked-in Starship source at `cad50cd8`.
+This is not complete Starship module or configuration compatibility.
 
 | Area | Adopted | Adapted | Intentionally omitted |
 | --- | --- | --- | --- |
@@ -594,10 +550,9 @@ complete Starship module or configuration compatibility.
 | Bun / Deno | Direct markers and `bun --version` / `deno -V` | Negative detection avoids overlapping Node defaults | Runtime installation and recursive source detection |
 
 All runtime commands use argv execution in `ctx.cwd`, a 2-second timeout, and 64 KiB accepted output.
-Commands run only when the reachable module format references the command-backed variable. Missing,
-killed, oversized, or malformed commands clear that value independently. `version_format`,
-`detect_files`, `detect_extensions`, and `detect_folders` are available on language modules; package
-supports `version_format`.
+Commands run only when the reachable module format references the command-backed variable.
+Missing, killed, oversized, or malformed commands clear that value independently.
+`version_format`, `detect_files`, `detect_extensions`, and `detect_folders` are available on language modules; package supports `version_format`.
 
 ### 🧰 Development environments
 
@@ -610,48 +565,47 @@ supports `version_format`.
 | `nix_shell` | `IN_NIX_SHELL`, `NIX_SHELL_NAME`, `NIX_SHELL_LEVEL` | None | None |
 | `guix_shell` | Presence of `GUIX_ENVIRONMENT` | None | None |
 
-The extension never enumerates the process environment, activates a shell, evaluates Nix, lists
-installed tools, or publishes arbitrary environment values. Names and paths are control-sanitized and
-bounded before publication.
+The extension never enumerates the process environment, activates a shell, evaluates Nix, lists installed tools, or publishes arbitrary environment values.
+Names and paths are control-sanitized and bounded before publication.
 
 ### 🚢 Deployment and cloud context
 
-These modules read inert local metadata only. They do **not** contact Docker, a Kubernetes cluster,
-a Terraform/OpenTofu backend, a cloud API, an OAuth flow, a credential helper, or a metadata service.
-The deployment/cloud safety review retained opt-in root behavior: context labels may be sensitive and
-there is no usage evidence justifying more default footer density.
+These modules read inert local metadata only.
+They do **not** contact Docker, a Kubernetes cluster, a Terraform/OpenTofu backend, a cloud API, an OAuth flow, a credential helper, or a metadata service.
+The deployment/cloud safety review retained opt-in root behavior: context labels may be sensitive and there is no usage evidence justifying more default footer density.
 
 - `docker_context`: `DOCKER_CONTEXT`, then `DOCKER_CONFIG/config.json` or `~/.docker/config.json`;
-  `default` is suppressed. `only_with_files` and detection arrays are supported.
-- `kubernetes`: at most `max_config_files` (default 8) from `KUBECONFIG` or `~/.kube/config`, with
-  first-wins merge semantics. Only context, namespace, cluster name, and user name are selected.
+`default` is suppressed.
+`only_with_files` and detection arrays are supported.
+- `kubernetes`: at most `max_config_files` (default 8) from `KUBECONFIG` or `~/.kube/config`, with first-wins merge semantics.
+  Only context, namespace, cluster name, and user name are selected.
   Exact `context_aliases`, `namespace_aliases`, `cluster_aliases`, and `user_aliases` apply.
-- `terraform`: direct `.tf`, `.tfplan`, `.tfstate`, or `.terraform`; workspace precedence is
-  `TF_WORKSPACE` → `TF_DATA_DIR/environment` → `.terraform/environment`. `terraform version`, then
-  `tofu version`, runs only for `$version`. Workspace, init, provider, and state commands never run.
-- `aws`: `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`, `AWS_REGION`/`AWS_DEFAULT_REGION`, then the selected AWS
-  config section. The credentials file is never read. Exact profile/region aliases are supported.
-- `gcloud`: active selector plus allowlisted `core.account`, `core.project`, and `compute.region` INI
-  keys. Exact project/region aliases are supported.
-- `azure`: the default local `azureProfile.json` subscription name. `show_username` defaults to
-  `false`; exact subscription aliases are supported.
+- `terraform`: direct `.tf`, `.tfplan`, `.tfstate`, or `.terraform`; workspace precedence is `TF_WORKSPACE` → `TF_DATA_DIR/environment` → `.terraform/environment`.
+  `terraform version`, then `tofu version`, runs only for `$version`.
+  Workspace, init, provider, and state commands never run.
+- `aws`: `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`, `AWS_REGION`/`AWS_DEFAULT_REGION`, then the selected AWS config section.
+  The credentials file is never read.
+  Exact profile/region aliases are supported.
+- `gcloud`: active selector plus allowlisted `core.account`, `core.project`, and `compute.region` INI keys.
+  Exact project/region aliases are supported.
+- `azure`: the default local `azureProfile.json` subscription name.
+  `show_username` defaults to `false`; exact subscription aliases are supported.
 - `openstack`: `OS_CLOUD`, `OS_PROJECT_NAME`, or the selected `clouds.yaml` `auth.project_name` only;
   exact cloud/project aliases are supported.
 
-Cloud files often colocate credentials with labels. Parsers allowlist fields while reading and
-discard source documents; token, key, password, auth URL, tenant, and credential-derived duration
-fields never enter snapshots, diagnostics, notifications, or rendered output. Presence indicates only
-selected local metadata—not valid credentials or connectivity.
+Cloud files often colocate credentials with labels.
+Parsers allowlist fields while reading and discard source documents; token, key, password, auth URL, tenant, and credential-derived duration fields never enter snapshots, diagnostics, notifications, or rendered output.
+Presence indicates only selected local metadata—not valid credentials or connectivity.
 
 ### 🖥️ Execution context
 
-`hostname` is SSH-only by default and supports `ssh_only`, `trim_at`, and exact `aliases`. `username`
-appears only for `show_always`, SSH, root/Administrator, a login-user mismatch, or configured
-`detect_env_vars`; it supports exact aliases. Negated username detection names are rejected. `os` is
-disabled by default and supports an exact `symbols` map. `container` uses only Dev Container/Codespaces
-markers, WSL metadata, `/.dockerenv`, `/run/.containerenv`, and `/run/systemd/container`; it does not
-scan process tables or cgroups. Ordinary local hostname/username sessions stay empty. All identity
-labels are bounded and stripped of C0/C1 controls, ANSI, newlines, and OSC control bytes.
+`hostname` is SSH-only by default and supports `ssh_only`, `trim_at`, and exact `aliases`.
+`username` appears only for `show_always`, SSH, root/Administrator, a login-user mismatch, or configured `detect_env_vars`; it supports exact aliases.
+Negated username detection names are rejected.
+`os` is disabled by default and supports an exact `symbols` map.
+`container` uses only Dev Container/Codespaces markers, WSL metadata, `/.dockerenv`, `/run/.containerenv`, and `/run/systemd/container`; it does not scan process tables or cgroups.
+Ordinary local hostname/username sessions stay empty.
+All identity labels are bounded and stripped of C0/C1 controls, ANSI, newlines, and OSC control bytes.
 
 ### ↔️ Fill layout
 
@@ -665,31 +619,30 @@ symbol = " " # native invisible default; use "·" for a visible pattern
 style = "dimmed"
 ```
 
-Fill resolves independently on each logical line before ANSI serialization and wrapping. Multiple
-fills divide remaining cells left-to-right; complete positive-width patterns repeat and any remainder
-uses styled spaces. Empty/zero-width patterns become spaces. Fixed content is never truncated: when it
-already meets or exceeds the width, fill contributes zero and normal ANSI-aware wrapping applies.
-Unicode wide/combining symbols, palettes, `prev_fg`/`prev_bg`, ANSI, and OSC hyperlinks use Pi TUI
-visible-width semantics. `$all` deliberately includes enabled fill, so use `$all` only when that
-whole-catalog layout is intended. There is no `line_break` module; use literal newlines in `format`.
+Fill resolves independently on each logical line before ANSI serialization and wrapping.
+Multiple fills divide remaining cells left-to-right; complete positive-width patterns repeat and any remainder uses styled spaces.
+Empty/zero-width patterns become spaces.
+Fixed content is never truncated: when it already meets or exceeds the width, fill contributes zero and normal ANSI-aware wrapping applies.
+Unicode wide/combining symbols, palettes, `prev_fg`/`prev_bg`, ANSI, and OSC hyperlinks use Pi TUI visible-width semantics.
+`$all` deliberately includes enabled fill, so use `$all` only when that whole-catalog layout is intended.
+There is no `line_break` module; use literal newlines in `format`.
 
 ### 🔄 Cached refresh lifecycle
 
-Workspace, Git, and GitHub PR readers start only in TUI sessions and only for reachable enabled
-modules. Root format reachability, `$all`, module `disabled`, and module-format variables determine
-file and command requirements. Workspace/Git refreshes run at session start, after accepted settings,
-branch changes, tool/turn completion, and a 30-second fallback. GitHub PR uses the narrower lifecycle
-and 60-second network refresh described above. One read runs with at most one latest pending refresh;
+Workspace, Git, and GitHub PR readers start only in TUI sessions and only for reachable enabled modules.
+Root format reachability, `$all`, module `disabled`, and module-format variables determine file and command requirements.
+Workspace/Git refreshes run at session start, after accepted settings, branch changes, tool/turn completion, and a 30-second fallback.
+GitHub PR uses the narrower lifecycle and 60-second network refresh described above.
+One read runs with at most one latest pending refresh;
 immutable snapshot equality suppresses redraws, and session/request generations reject stale results.
-Shutdown, replacement, footer disposal, branch changes, and accepted settings abort active command
-work before starting replacements; disabling `github_pr` also stops its query and timers. Bounded local
-filesystem operations may finish, but stale generations cannot publish them. Execution identity is
-retained rather than re-read by the periodic fallback. Render and live preview consume snapshots
-synchronously and perform zero reads or commands.
+Shutdown, replacement, footer disposal, branch changes, and accepted settings abort active command work before starting replacements; disabling `github_pr` also stops its query and timers.
+Bounded local filesystem operations may finish, but stale generations cannot publish them.
+Execution identity is retained rather than re-read by the periodic fallback.
+Render and live preview consume snapshots synchronously and perform zero reads or commands.
 
 Missing, unreadable, malformed, oversized, timed-out, or unavailable sources fail to empty values.
-Workspace/Git readers cap direct files at 64 KiB, use one bounded current-directory listing, never
-recurse, and make no network calls. The native GitHub PR query is the documented network exception.
+Workspace/Git readers cap direct files at 64 KiB, use one bounded current-directory listing, never recurse, and make no network calls.
+The native GitHub PR query is the documented network exception.
 Package's explicitly documented Cargo lookup is the only ancestor walk and is capped at eight parents.
 
 ## 💬 Commands
@@ -701,39 +654,34 @@ Package's explicitly documented Cargo lookup is the only ancestor walk and is ca
 | `/starship status` | Show config source/path and diagnostics |
 | `/starship help` | Show command and configuration help |
 
-The standard main menu keeps seven goals on one level: **Customize footer**, **Presets**,
-**Explain footer**, **Modules**, **Configuration**, **Help**, and **Restore built-in…**. It shows whether
-the footer uses built-in defaults, a saved built-in document, a named preset, a custom document, or an
-error-driven fallback,
-together with the current health. Presets, Explain, and Modules are menu-only paths; they do not add
-textual subcommands or change RPC, print, or JSON protocols. Restore remains last and unavailable
-when there is no document to replace.
+The standard main menu keeps seven goals on one level: **Customize footer**, **Presets**, **Explain footer**, **Modules**, **Configuration**, **Help**, and **Restore built-in…**.
+It shows whether the footer uses built-in defaults, a saved built-in document, a named preset, a custom document, or an error-driven fallback, together with the current health.
+Presets, Explain, and Modules are menu-only paths; they do not add textual subcommands or change RPC, print, or JSON protocols.
+Restore remains last and unavailable when there is no document to replace.
 
-The TOML editor, adaptive live footer previews, Explain view, and searchable module inspector remain
-specialized extension UI. Their hints follow Pi's injected keybindings; list and detail content stay
-bounded across terminal resize. Escape returns from detail or to the main menu, while Ctrl+C closes
-the whole workflow.
+The TOML editor, adaptive live footer previews, Explain view, and searchable module inspector remain specialized extension UI.
+Their hints follow Pi's injected keybindings; list and detail content stay bounded across terminal resize.
+Escape returns from detail or to the main menu, while Ctrl+C closes the whole workflow.
 
-The direct routes accept no trailing arguments. Status and help remain safe in TUI, RPC, JSON, and
-print modes. RPC receives notifications but never opens custom terminal UI; print and JSON modes
-produce no ad hoc output. Footer/timer/Git lifecycle work starts only in TUI mode.
+The direct routes accept no trailing arguments.
+Status and help remain safe in TUI, RPC, JSON, and print modes.
+RPC receives notifications but never opens custom terminal UI; print and JSON modes produce no ad hoc output.
+Footer/timer/Git lifecycle work starts only in TUI mode.
 
 ## 📐 Scope
 
-The formatter, style concepts, and selected contextual modules are Starship-inspired, while Pi owns
-the lifecycle, snapshots, privacy boundary, and footer layout. This extension does not load
-`starship.toml`, claim complete module/config compatibility, invoke the Starship binary, run custom
-shell modules, or expose unrestricted `env_var` behavior. JVM/.NET, other long-tail languages,
-alternative VCS, system-monitor, and additional DevOps modules remain demand-gated; the first-wave
-review found no issue/discussion evidence for a coherent follow-up batch, so no second wave is added.
+The formatter, style concepts, and selected contextual modules are Starship-inspired, while Pi owns the lifecycle, snapshots, privacy boundary, and footer layout.
+This extension does not load `starship.toml`, claim complete module/config compatibility, invoke the Starship binary, run custom shell modules, or expose unrestricted `env_var` behavior.
+JVM/.NET, other long-tail languages, alternative VCS, system-monitor, and additional DevOps modules remain demand-gated; the first-wave review found no issue/discussion evidence for a coherent follow-up batch, so no second wave is added.
 
-Pi-native model, context, cache, cost, Git metrics, and activity remain owned by the existing modules. The
-lifecycle design rejects provider-specific duplicates and ambiguous `turn_duration`/`last_result`
-modules until separately approved semantics exist.
+Pi-native model, context, cache, cost, Git metrics, and activity remain owned by the existing modules.
+The lifecycle design rejects provider-specific duplicates and ambiguous `turn_duration`/`last_result` modules until separately approved semantics exist.
 
 ## ➕ Adding a module
 
-Create `src/modules/<name>.ts` with its format variables, defaults, and runtime value resolver, then register it in display order in `src/modules/catalog.ts`. Configuration names, validation variables, defaults, and `$all` ordering are derived from that catalog. Add the module to the built-in root format when it should be visible by default, then document and test its user-facing values.
+Create `src/modules/<name>.ts` with its format variables, defaults, and runtime value resolver, then register it in display order in `src/modules/catalog.ts`.
+Configuration names, validation variables, defaults, and `$all` ordering are derived from that catalog.
+Add the module to the built-in root format when it should be visible by default, then document and test its user-facing values.
 
 Keep `extension_status` last in the catalog so arbitrary third-party statuses follow native module output.
 
@@ -760,9 +708,10 @@ Keep `extension_status` last in the catalog so arbitrary third-party statuses fo
 
 ## 🔎 Keywords
 
-Pi Coding Agent, Starship statusline, Starship TOML, terminal footer, native statusline, GitHub pull
-request, prompt cache, cache hit rate, Pi extension
+Pi Coding Agent, Starship statusline, Starship TOML, terminal footer, native statusline, GitHub pull request, prompt cache, cache hit rate, Pi extension
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE). Starship attribution and its ISC license are included in [`NOTICES.md`](./NOTICES.md).
+MIT.
+See [`LICENSE`](./LICENSE).
+Starship attribution and its ISC license are included in [`NOTICES.md`](./NOTICES.md).

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -353,18 +353,17 @@ There is no hidden compatibility overlay or automatic migration.
 
 ### Usage semantics
 
-- `tokens`, `cache`, and `cost` total every usage-bearing session entry, matching Pi's native footer:
-  assistant messages, nested-LLM tool results, compactions, and branch summaries, including abandoned branches retained in the session.
+- `tokens`, `cache`, and `cost` total every usage-bearing session entry, matching Pi's native footer.
+  This includes assistant messages, nested-LLM tool results, compactions, and branch summaries, including abandoned branches retained in the session.
 - Cache `$read` and `$write` are cumulative.
-  `$rate` uses only the latest assistant prompt:
-`cacheRead / (input + cacheRead + cacheWrite) * 100`.
-The module is empty when Pi has reported no cache reads or writes.
+  `$rate` uses only the latest assistant prompt with `cacheRead / (input + cacheRead + cacheWrite) * 100`.
+  The module is empty when Pi has reported no cache reads or writes.
 - `cache` is disabled and absent from the built-in root.
   Enable it and add `$cache` to a custom root format (or use `$all`) to display it.
 - Context `$percentage` uses native one-decimal precision.
-  Its default display hides values below 30%;
-customize `[[context.display]]` when lower values should remain visible.
-The module name remains `context`, not `context_usage`.
+  Its default display hides values below 30%.
+  Customize `[[context.display]]` when lower values should remain visible.
+  The module name remains `context`, not `context_usage`.
 - Subscription-backed OAuth models and `kimi-coding` set cost `$subscription` to `(sub)`.
   The dollar value is usage cost, not proof of an amount billed under a subscription.
 - Pi's public extension API does not expose the current auto-compaction toggle, so pi-starship cannot reliably provide the native `(auto)` marker.
@@ -412,8 +411,8 @@ Upstream Starship represents its unlimited default as `2^63 - 1`; pi-starship us
 
 Conda retains the last path component by default; `0` keeps the complete environment path.
 Hostname trimming runs before exact alias lookup, matching Starship.
-These are display transformations only:
-collectors retain bounded, control-sanitized source metadata.
+These transformations affect display only.
+Collectors retain bounded, control-sanitized source metadata.
 
 ### Model aliases and truncation
 
@@ -532,8 +531,8 @@ Footer rendering and previews read only the immutable cached snapshot and perfor
 
 **Breaking migration:** `$git_branch.$pr` has been removed without a compatibility alias or automatic migration.
 Replace it with root `$github_pr` and an optional `[github_pr]` table.
-If `pi-github-pr` remains installed, its independent `github-pr` status can also appear under `$extension_status`;
-disable or remove that extension when adopting the native module to avoid duplicate information.
+If `pi-github-pr` remains installed, its independent `github-pr` status can also appear under `$extension_status`.
+Disable or remove that extension when adopting the native module to avoid duplicate information.
 
 ### 📦 Package and language modules
 
@@ -574,9 +573,9 @@ These modules read inert local metadata only.
 They do **not** contact Docker, a Kubernetes cluster, a Terraform/OpenTofu backend, a cloud API, an OAuth flow, a credential helper, or a metadata service.
 The deployment/cloud safety review retained opt-in root behavior: context labels may be sensitive and there is no usage evidence justifying more default footer density.
 
-- `docker_context`: `DOCKER_CONTEXT`, then `DOCKER_CONFIG/config.json` or `~/.docker/config.json`;
-`default` is suppressed.
-`only_with_files` and detection arrays are supported.
+- `docker_context`: `DOCKER_CONTEXT`, then `DOCKER_CONFIG/config.json` or `~/.docker/config.json`.
+  The `default` context is suppressed.
+  `only_with_files` and detection arrays are supported.
 - `kubernetes`: at most `max_config_files` (default 8) from `KUBECONFIG` or `~/.kube/config`, with first-wins merge semantics.
   Only context, namespace, cluster name, and user name are selected.
   Exact `context_aliases`, `namespace_aliases`, `cluster_aliases`, and `user_aliases` apply.
@@ -590,8 +589,8 @@ The deployment/cloud safety review retained opt-in root behavior: context labels
   Exact project/region aliases are supported.
 - `azure`: the default local `azureProfile.json` subscription name.
   `show_username` defaults to `false`; exact subscription aliases are supported.
-- `openstack`: `OS_CLOUD`, `OS_PROJECT_NAME`, or the selected `clouds.yaml` `auth.project_name` only;
-  exact cloud/project aliases are supported.
+- `openstack`: `OS_CLOUD`, `OS_PROJECT_NAME`, or the selected `clouds.yaml` `auth.project_name` only.
+  Exact cloud/project aliases are supported.
 
 Cloud files often colocate credentials with labels.
 Parsers allowlist fields while reading and discard source documents; token, key, password, auth URL, tenant, and credential-derived duration fields never enter snapshots, diagnostics, notifications, or rendered output.
@@ -633,8 +632,8 @@ Workspace, Git, and GitHub PR readers start only in TUI sessions and only for re
 Root format reachability, `$all`, module `disabled`, and module-format variables determine file and command requirements.
 Workspace/Git refreshes run at session start, after accepted settings, branch changes, tool/turn completion, and a 30-second fallback.
 GitHub PR uses the narrower lifecycle and 60-second network refresh described above.
-One read runs with at most one latest pending refresh;
-immutable snapshot equality suppresses redraws, and session/request generations reject stale results.
+One read runs with at most one latest pending refresh.
+Immutable snapshot equality suppresses redraws, and session or request generations reject stale results.
 Shutdown, replacement, footer disposal, branch changes, and accepted settings abort active command work before starting replacements; disabling `github_pr` also stops its query and timers.
 Bounded local filesystem operations may finish, but stale generations cannot publish them.
 Execution identity is retained rather than re-read by the periodic fallback.

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -1,9 +1,8 @@
-# ✨ pi-statusline — A Beautiful, Practical Footer for Pi
+# ✨ pi-statusline — Add a Ready-to-Use Powerline Footer to Pi
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-statusline)](https://www.npmjs.com/package/@narumitw/pi-statusline) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-statusline` gives [Pi](https://pi.dev) an opinionated powerline footer that looks good
-without setup and keeps useful context visible as the terminal narrows.
+Add an opinionated Powerline-style footer that works without setup and keeps the most useful Pi, workspace, Git, usage, and time context visible as the terminal narrows.
 
 A representative uncolored layout:
 
@@ -13,20 +12,19 @@ A representative uncolored layout:
 
 ## ✨ Features
 
-- **Fast package startup:** Pi's Jiti loader reads a generated split TypeScript runtime.
-- **Zero-config default:** model, thinking, workspace, Git/PR state, context use, and local time.
-- **Responsive:** removes lower-priority segments before important information gets clipped.
-- **Quiet when idle:** activity appears only while Pi is streaming or running tools.
-- **Native-aligned usage:** optional token, prompt-cache, subscription, and cost details.
-- **Easy choices:** three information levels and seven previewable color presets.
-- **Still flexible:** custom layouts, multiline rows, colors, labels, separators, and status icons stay
-  available under **Advanced**.
+- Works immediately with a balanced default for model, thinking, workspace, Git, context, activity, and time.
+- Removes lower-priority segments before important information is clipped.
+- Shows activity only while Pi is streaming or running tools.
+- Adds optional token, prompt-cache, provider usage, and cost details.
+- Offers three information levels, seven previewable palettes, and advanced custom layouts.
+- Loads a generated split runtime to reduce Pi package startup work.
 
-> **Need more customization?** See
-> [`pi-starship`](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-starship)
-> ([npm](https://www.npmjs.com/package/@narumitw/pi-starship)). It uses a
-> [Starship-inspired](https://starship.rs/) TOML format and style syntax for deeper control over
-> layout, modules, and colors. Choose `pi-statusline` for practical defaults and quick setup.
+> **Need more customization?**
+> See
+> [`pi-starship`](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-starship) ([npm](https://www.npmjs.com/package/@narumitw/pi-starship)).
+> It uses a
+> [Starship-inspired](https://starship.rs/) TOML format and style syntax for deeper control over layout, modules, and colors.
+> Choose `pi-statusline` for practical defaults and quick setup.
 >
 > Do not enable both extensions at the same time because both own Pi's footer.
 
@@ -55,10 +53,10 @@ For the best result, use a terminal font that includes Powerline glyphs and emoj
 
 ## 🚀 Quick start
 
-1. Install the extension and start Pi.
-2. Run `/statusline`.
-3. Use the standard Main/Advanced navigation, then choose an appearance or information level;
-   appearance previews update the extension-owned footer before you apply a choice.
+Install the extension and start Pi to use the balanced default immediately.
+Run `/statusline` to preview and apply an appearance or information level.
+
+## 🎛️ Menu and information levels
 
 ```text
 Appearance (tokyo-night)
@@ -78,8 +76,8 @@ Help
 
 ### Information levels
 
-Selecting a level replaces only the `segments` array. Unknown and unrelated JSON fields are
-preserved.
+Selecting a level replaces only the `segments` array.
+Unknown and unrelated JSON fields are preserved.
 
 | Level | Included segments |
 | --- | --- |
@@ -88,8 +86,8 @@ preserved.
 | **Detailed** | `provider model thinking cwd branch tools context tokens cache cost time` |
 | **Custom** | Any other segment order, including explicit line breaks |
 
-The `tools` segment takes no space while idle. `cache` takes no space when Pi has reported no cache
-reads or writes.
+The `tools` segment takes no space while idle.
+`cache` takes no space when Pi has reported no cache reads or writes.
 
 ## 💬 Commands
 
@@ -100,34 +98,33 @@ reads or writes.
 | `/statusline status` | Show the effective settings and diagnostics |
 | `/statusline help` | Show command and schema guidance |
 
-The direct `settings`, `status`, and `help` routes remain for compatibility. The root standard menu
-is TUI-only; Escape returns from Advanced or closes Main. RPC receives observable notifications
-instead of TUI-only controls. Unknown subcommands and trailing arguments are rejected. The standard
-palette picker owns navigation and cleanup while pi-statusline still owns footer previews, settings,
-and rollback. The width-aware layout editor and JSON editor remain specialized UI.
+The direct `settings`, `status`, and `help` routes remain for compatibility.
+The root standard menu is TUI-only; Escape returns from Advanced or closes Main.
+RPC receives observable notifications instead of TUI-only controls.
+Unknown subcommands and trailing arguments are rejected.
+The standard palette picker owns navigation and cleanup while pi-statusline still owns footer previews, settings, and rollback.
+The width-aware layout editor and JSON editor remain specialized UI.
 
 ## 📐 Runtime behavior
 
 ### Responsive fitting
 
-Each row keeps its configured segment order. If it is too wide, pi-statusline removes the
-lowest-priority segment, recomputes the powerline transitions, and repeats until the row fits.
+Each row keeps its configured segment order.
+If it is too wide, pi-statusline removes the lowest-priority segment, recomputes the powerline transitions, and repeats until the row fits.
 Retention priority is highest to lowest:
 
 ```text
 context model branch tools cwd thinking cost provider cache tokens time turn brand
 ```
 
-Explicit `line_break` entries remain row boundaries. If the last remaining segment is itself wider
-than the row, that row renders empty rather than emitting an over-width line.
+Explicit `line_break` entries remain row boundaries.
+If the last remaining segment is itself wider than the row, that row renders empty rather than emitting an over-width line.
 
 ### Directory, activity, Git, and PR state
 
-- `cwd` uses Starship's directory presentation defaults: contract the home directory to `~`, contract
-  to the Git repository root when available, then retain at most the last three path components. This
-  changes display only; the configured segment list and Pi working directory are untouched.
-- Repository-root discovery is cached with Git status outside footer rendering; a failed root query
-  falls back to home/path-component contraction without hiding the segment.
+- `cwd` uses Starship's directory presentation defaults: contract the home directory to `~`, contract to the Git repository root when available, then retain at most the last three path components.
+  This changes display only; the configured segment list and Pi working directory are untouched.
+- Repository-root discovery is cached with Git status outside footer rendering; a failed root query falls back to home/path-component contraction without hiding the segment.
 - During active work, `tools` shows `💭 thinking` or `⚙ <tool>` with parallel counts.
 - Activity disappears after the agent settles and resets across session replacement or shutdown.
 - Clean repositories show no Git counters.
@@ -139,17 +136,15 @@ than the row, that row renders empty rather than emitting an over-width line.
 
 ### Usage and context
 
-- `context` renders one-decimal current usage and the model window, such as `2.4%/272k`. After
-  compaction it can temporarily render `?/272k` until the next valid assistant response.
+- `context` renders one-decimal current usage and the model window, such as `2.4%/272k`.
+  After compaction it can temporarily render `?/272k` until the next valid assistant response.
 - `tokens`, `cache`, and `cost` total every usage-bearing session entry, matching Pi's native footer:
-  assistant messages, nested-LLM tool results, compactions, and branch summaries, including abandoned
-  branches retained in the session.
-- Cache tokens are `R<read>`, `W<write>`, and `CH<rate>`. `R` and `W` are cumulative; `CH` uses only
-  the latest assistant prompt: `cacheRead / (input + cacheRead + cacheWrite) * 100`.
-- Subscription-backed OAuth models and `kimi-coding` append `(sub)` to cost. The dollar value is
-  usage cost, not proof of an amount billed under a subscription.
-- Pi's public extension API does not expose the current auto-compaction toggle, so this footer cannot
-  reliably show the native `(auto)` marker.
+  assistant messages, nested-LLM tool results, compactions, and branch summaries, including abandoned branches retained in the session.
+- Cache tokens are `R<read>`, `W<write>`, and `CH<rate>`.
+  `R` and `W` are cumulative; `CH` uses only the latest assistant prompt: `cacheRead / (input + cacheRead + cacheWrite) * 100`.
+- Subscription-backed OAuth models and `kimi-coding` append `(sub)` to cost.
+  The dollar value is usage cost, not proof of an amount billed under a subscription.
+- Pi's public extension API does not expose the current auto-compaction toggle, so this footer cannot reliably show the native `(auto)` marker.
 
 ## ⚙️ Settings
 
@@ -159,13 +154,14 @@ The extension uses one user-level file:
 <getAgentDir()>/pi-statusline.json
 ```
 
-There are no project or environment overrides. When the file is absent, pi-statusline uses its
-built-in defaults without creating the file or parent directory. The first successful settings save
-creates a complete editable document atomically. Malformed or unreadable settings are never
-overwritten. Settings reload on startup, `/reload`, and session replacement.
+There are no project or environment overrides.
+When the file is absent, pi-statusline uses its built-in defaults without creating the file or parent directory.
+The first successful settings save creates a complete editable document atomically.
+Malformed or unreadable settings are never overwritten.
+Settings reload on startup, `/reload`, and session replacement.
 
-A valid legacy `pi-statusline-settings.json` remains readable with a warning and is never modified
-automatically; rename it to `pi-statusline.json`. If both files exist, `pi-statusline.json` wins.
+A valid legacy `pi-statusline-settings.json` remains readable with a warning and is never modified automatically; rename it to `pi-statusline.json`.
+If both files exist, `pi-statusline.json` wins.
 
 ### Settings reference
 
@@ -179,9 +175,10 @@ automatically; rename it to `pi-statusline.json`. If both files exist, `pi-statu
 | `segmentText` | Per-segment `prefix` and `suffix`; model truncation fields | Format Pi-owned dynamic values |
 | `extensionStatusIcons` | Raw status key or `namespace:*` to icon string | Customize extension status icons |
 
-All fields are optional in an existing document. Missing fields use defaults. Unknown fields produce a
-warning but are preserved by menu saves. Invalid recognized values block saving, leaving the previous
-file and live footer unchanged.
+All fields are optional in an existing document.
+Missing fields use defaults.
+Unknown fields produce a warning but are preserved by menu saves.
+Invalid recognized values block saving, leaving the previous file and live footer unchanged.
 
 A compact customization example:
 
@@ -206,13 +203,12 @@ A compact customization example:
 }
 ```
 
-Use **Advanced → Edit settings JSON** or `/statusline settings` to edit, validate, atomically save, and
-apply the file.
+Use **Advanced → Edit settings JSON** or `/statusline settings` to edit, validate, atomically save, and apply the file.
 
 ## 🎨 Appearance
 
-Named palettes provide contrast-checked color ramps. Appearance previews update while the picker
-moves, but save only when Enter is pressed; Escape restores the saved palette.
+Named palettes provide contrast-checked color ramps.
+Appearance previews update while the picker moves, but save only when Enter is pressed; Escape restores the saved palette.
 
 When `palettePreset` is `custom`, `palette` maps segment names to foreground/background colors:
 
@@ -234,8 +230,8 @@ When `palettePreset` is `custom`, `palette` maps segment names to foreground/bac
 - Missing custom colors remain unstyled instead of inheriting Tokyo Night.
 - Adjacent segments with identical colors share one block; transitions use ``.
 
-`segmentText` values must be single-line text without terminal control characters. Use `line_break`
-for another row rather than inserting a newline into a prefix or suffix.
+`segmentText` values must be single-line text without terminal control characters.
+Use `line_break` for another row rather than inserting a newline into a prefix or suffix.
 
 ### Model truncation
 
@@ -253,20 +249,19 @@ Long model IDs are truncated out of the box so the balanced footer can retain us
 }
 ```
 
-`truncationLength` counts model grapheme clusters retained before the symbol. The built-in value is
-`36`; set it to `0` to display the complete ID. The direction names the removed portion:
+`truncationLength` counts model grapheme clusters retained before the symbol.
+The built-in value is `36`; set it to `0` to display the complete ID.
+The direction names the removed portion:
 
-- `start` retains the suffix and is the default, which is useful for long llama.cpp paths and model
-  variants.
+- `start` retains the suffix and is the default, which is useful for long llama.cpp paths and model variants.
 - `middle` retains both ends.
 - `end` retains the prefix.
 
-Truncation runs after the built-in Claude/GPT shortening rules but before the configured model prefix
-and suffix. It changes display only—the provider model ID is untouched. Terminal control sequences
-in model IDs are removed at render time, and unsafe configured symbols are rejected. An empty
-`truncationSymbol` truncates without a marker. pi-statusline treats model IDs as opaque strings and
-does not parse paths, repositories, GGUF suffixes, or quantization names. At very narrow widths, the
-existing responsive priorities may still omit the model rather than overflow the terminal.
+Truncation runs after the built-in Claude/GPT shortening rules but before the configured model prefix and suffix.
+It changes display only—the provider model ID is untouched.
+Terminal control sequences in model IDs are removed at render time, and unsafe configured symbols are rejected.
+An empty `truncationSymbol` truncates without a marker. pi-statusline treats model IDs as opaque strings and does not parse paths, repositories, GGUF suffixes, or quantization names.
+At very narrow widths, the existing responsive priorities may still omit the model rather than overflow the terminal.
 
 ## 🧩 Advanced layout
 
@@ -291,10 +286,11 @@ Available data segments:
 brand provider model thinking cwd branch tools context tokens cache cost time turn
 ```
 
-Data segments must be unique. `line_break` may repeat when data segments separate occurrences, but
-consecutive breaks are invalid. It has no `segmentText` entry. The menu cleans up leading, trailing,
-and newly consecutive breaks after visibility changes. Manually authored leading/trailing breaks
-represent empty rows.
+Data segments must be unique.
+`line_break` may repeat when data segments separate occurrences, but consecutive breaks are invalid.
+It has no `segmentText` entry.
+The menu cleans up leading, trailing, and newly consecutive breaks after visibility changes.
+Manually authored leading/trailing breaks represent empty rows.
 
 ```json
 {
@@ -302,13 +298,13 @@ represent empty rows.
 }
 ```
 
-An empty `segments` array hides the main powerline while extension statuses can still render. The
-extension intentionally has no variable or format language; use `pi-starship` when you need one.
+An empty `segments` array hides the main powerline while extension statuses can still render.
+The extension intentionally has no variable or format language; use `pi-starship` when you need one.
 
 ## 🔌 Extension statuses and icons
 
-Other extension statuses appear below the main powerline, wrap to terminal width, and are limited to
-five items. Icons resolve in this order:
+Other extension statuses appear below the main powerline, wrap to terminal width, and are limited to five items.
+Icons resolve in this order:
 
 1. Exact configured raw key, such as `goal` or `foo:server`.
 2. Longest configured colon wildcard, such as `foo:*` or `foo:server:*`.
@@ -317,9 +313,10 @@ five items. Icons resolve in this order:
 5. Built-in icon.
 6. Generic `🔌` fallback.
 
-Set an icon to `""` to hide only the icon. Wildcards match colon namespaces, not slash-delimited keys;
-configure slash keys exactly. Compatibility fallbacks retain `codex-usage`, `pisync`, and
-`unknown-error-retry`; an explicit canonical key wins.
+Set an icon to `""` to hide only the icon.
+Wildcards match colon namespaces, not slash-delimited keys;
+configure slash keys exactly.
+Compatibility fallbacks retain `codex-usage`, `pisync`, and `unknown-error-retry`; an explicit canonical key wins.
 
 For interoperable extensions, prefer one aggregated key or a stable coexistence slot:
 
@@ -333,12 +330,9 @@ Put transient activity in the value and always clear the same complete key.
 ## 🛠️ Troubleshooting
 
 - **Powerline symbols look wrong:** use a font with Powerline glyphs; emoji support is also recommended.
-- **The footer reports settings warnings:** run `/statusline status`, then `/statusline settings` to fix
-  invalid recognized fields.
-- **The footer appears to be replaced:** disable `pi-starship` or another extension that also calls
-  Pi's `setFooter()`.
-- **A custom segment disappears on a narrow terminal:** check the responsive priority above or add an
-  explicit `line_break`.
+- **The footer reports settings warnings:** run `/statusline status`, then `/statusline settings` to fix invalid recognized fields.
+- **The footer appears to be replaced:** disable `pi-starship` or another extension that also calls Pi's `setFooter()`.
+- **A custom segment disappears on a narrow terminal:** check the responsive priority above or add an explicit `line_break`.
 
 ## 🗂️ Package layout
 
@@ -375,9 +369,9 @@ The package build emits the sole declared Pi entrypoint at `dist/index.ts` witho
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, statusline, Tokyo Night, powerline, responsive terminal footer,
-context usage, prompt cache, cache hit rate, model status.
+Pi extension, Pi coding agent, statusline, Tokyo Night, powerline, responsive terminal footer, context usage, prompt cache, cache hit rate, model status.
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -138,8 +138,8 @@ If the last remaining segment is itself wider than the row, that row renders emp
 
 - `context` renders one-decimal current usage and the model window, such as `2.4%/272k`.
   After compaction it can temporarily render `?/272k` until the next valid assistant response.
-- `tokens`, `cache`, and `cost` total every usage-bearing session entry, matching Pi's native footer:
-  assistant messages, nested-LLM tool results, compactions, and branch summaries, including abandoned branches retained in the session.
+- `tokens`, `cache`, and `cost` total every usage-bearing session entry, matching Pi's native footer.
+  This includes assistant messages, nested-LLM tool results, compactions, and branch summaries, including abandoned branches retained in the session.
 - Cache tokens are `R<read>`, `W<write>`, and `CH<rate>`.
   `R` and `W` are cumulative; `CH` uses only the latest assistant prompt: `cacheRead / (input + cacheRead + cacheWrite) * 100`.
 - Subscription-backed OAuth models and `kimi-coding` append `(sub)` to cost.
@@ -314,8 +314,8 @@ Icons resolve in this order:
 6. Generic `🔌` fallback.
 
 Set an icon to `""` to hide only the icon.
-Wildcards match colon namespaces, not slash-delimited keys;
-configure slash keys exactly.
+Wildcards match colon namespaces, not slash-delimited keys.
+Configure slash keys exactly.
 Compatibility fallbacks retain `codex-usage`, `pisync`, and `unknown-error-retry`; an explicit canonical key wins.
 
 For interoperable extensions, prefer one aggregated key or a stable coexistence slot:

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -1,46 +1,25 @@
-# 🧑‍🤝‍🧑 pi-subagents — Isolated Subagents for the Pi Coding Agent
+# 🧑‍🤝‍🧑 pi-subagents — Delegate Work to Specialized Agents
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-subagents)](https://www.npmjs.com/package/@narumitw/pi-subagents) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-subagents` is a native [Pi coding agent](https://pi.dev) extension for delegating work to specialized agents.
-By default, it exposes seven capability-specific tools: blocking batches, four detached lifecycle tools, side-effect-free inspection, and synchronous read-only consultation.
-The compatibility default remains **All delegation methods**, while **Async only** is the recommended smaller surface for normal async-first use.
+Delegate bounded research or implementation work to isolated specialist agents while the main Pi agent retains planning, integration, verification, and the final answer.
 
-The main agent decides whether to delegate and retains overall planning, immediate critical-path work, integration, final verification, and the final answer.
-Use `explorer` for bounded read-only evidence and `worker` for a bounded implementation slice with clear ownership when delegation creates real parallelism.
-One ordinary async worker requires named non-overlapping main-agent work that starts immediately after spawn plus a supported delivery and integration path.
+Use the built-in `explorer` for read-only evidence and `worker` for a clearly owned implementation slice.
+
+The compatibility default exposes every delegation method, while **Async only** is the recommended smaller surface for normal parallel work.
 
 ## ✨ Features
 
-- Loads a generated split TypeScript runtime through Pi's Jiti loader while preserving first-use execution, UI, inspection, and transport chunks.
-- Keeps all delegation methods as the compatibility default while recommending async-only for a smaller responsive surface.
-- Adds `subagent_inspect` for bounded metadata without child launch, mailbox-content access, acknowledgement, or mutation.
-- Adds `subagent_consult` for one synchronous ephemeral child constrained to built-in `read`, `grep`, `find`, and `ls` tools (or a narrower agent allow-list).
-- Keeps batch workers isolated in `pi --mode json -p --no-session` subprocesses.
-- Lets users set a blocking parallel call's maximum worker count from 1 through 64 while keeping four-at-a-time execution.
-- Registers detached stateful lifecycle tools by default; completion can stay queued for the next turn or opt into an idle root synthesis turn.
-- Supports an opt-in public-SDK `in-process` stateful transport with one reusable child `AgentSession` per `agentId`.
-- Supports an opt-in persistent `rpc` transport with one isolated Pi RPC process per active retained agent and `pi-subagents:v1` lifecycle metadata.
-- Supports deterministic opt-in `auto` routing: read-only built-ins use in-process, write-capable built-ins use RPC, and custom tools use the compatibility subprocess path.
-- Supports built-in `explorer` and `worker` agents.
-- Loads custom user agents from `~/.pi/agent/agents/*.md`.
-- Optionally loads project agents from `.pi/agents/*.md` with confirmation.
-- Provides a current-session-first `/subagents` manager, direct `settings|status|help` routes, and compatibility aliases for agent tools and retained agents.
-- Supports trust-aware per-task `cwd` policies, task-selected work, workflow, idle, turn, and tool-call budgets, deterministic timeout checkpoints, bounded abort-then-summary recovery, progress telemetry, and per-agent execution defaults.
-- Uses Pi-native tool rows throughout; blocking and consultation calls add bounded custom live activity.
-- Bounds JSON lines, captured messages, stderr, final output, chain substitution, and fan-in context.
-- Enforces a recursion-depth guard and deterministic process-group termination.
-- Gives every retained agent both an opaque durable `agentId` and a session-scoped canonical `taskPath`, while preserving ID compatibility across lifecycle and inspection tools.
-- Gives retained children authenticated `subagent_peer_send` and `subagent_peer_list` tools for bounded queue-only communication with `/root` or any retained peer in the same session.
-- Routes nested completions to the direct retained parent first, while top-level completions continue through the root completion broker.
-- Provides addressable stateful agents with follow-up, consolidated mailbox/management actions, idempotent spawn retries, context selection and preview, versioned structured outcomes, and persistence.
-- Publishes built-in and custom agent capability manifests, then records the executor-owned `ExecutionPlan` that resolves requested authority to effective tools, model, thinking, timeout, transport, trust, and workspace controls.
-- Runs explicit dependency workflows through a persistent `WorkItem` ledger, dependency-aware scheduler, declared scope-conflict checks, artifact provenance, stale-result invalidation, and bounded overall deadlines.
-- Runs first-class blocking panels with two or more independent reviewers, incremental bounded evidence artifacts, preserved blockers and dissent, a minimum-valid-review barrier, reserved synthesis and cleanup budgets, and one evidence-preserving synthesis.
-- Supports bounded retries only for explicitly idempotent work and hedged execution only for explicitly read-only work.
-- Detects retained-agent semantic skew across agent definitions, role prompts, tools, model resolution, transport, trust, repository generation, artifacts, and scheduler policy before follow-up work starts.
-- Publishes transient runtime status through Pi's generic extension status API while subagents are running.
-- Returns complete bounded worker output in tool details and a concise result for the main agent.
+- Provides blocking batches, detached reusable agents, read-only consultation, metadata inspection, and queue-only mailboxes.
+- Includes `explorer` and `worker` definitions and loads optional user or confirmed project agents.
+- Keeps detached agents addressable by durable IDs and task paths across follow-ups and recovery.
+- Supports subprocess, in-process, RPC, and deterministic automatic transport choices for different trust and tool needs.
+- Applies trust-aware cwd policy, capability contracts, dependency workflows, context bounds, deadlines, turn limits, tool limits, and deterministic termination.
+- Persists accepted lifecycle and workflow state, preserves evidence and dissent, and rejects stale work after semantic or session changes.
+- Routes nested completion and peer communication through authenticated session-scoped channels.
+- Provides `/subagents` settings, status, help, tool-surface selection, and recovery diagnostics.
+- Returns concise model-visible results with complete bounded details and sanitized terminal rendering.
+- Loads a generated split runtime while preserving lazy execution, UI, inspection, and transport chunks.
 
 ## 📦 Install
 
@@ -92,7 +71,8 @@ Settings are stored in `~/.pi/agent/pi-subagents.json`; the detailed sections be
 
 ## 🛠️ Tools
 
-`pi-subagents` registers seven tools by default. Run `/subagents`, choose **Change delegation**, review the concrete tool changes, then select **Save and reload** to apply one of these workflows:
+`pi-subagents` registers seven tools by default.
+Run `/subagents`, choose **Change delegation**, review the concrete tool changes, then select **Save and reload** to apply one of these workflows:
 
 | Workflow | Registered tools |
 | --- | --- |
@@ -105,35 +85,44 @@ Settings are stored in `~/.pi/agent/pi-subagents.json`; the detailed sections be
 The four async lifecycle tools stay separate because starting work, sending follow-ups, managing lifecycle, and queueing mailbox messages have different contracts.
 Any default change, tool removal, or lifecycle consolidation requires a separately approved compatibility migration.
 
-The preview compares the selection with the tools registered in the current session, even when a manual settings edit is pending, and remains read-only until confirmation. Escape or **Cancel** leaves settings unchanged. Tool removal requires an extension reload because Pi does not expose extension tool unregistration. To avoid aborting work or removing isolated worktrees during `session_shutdown`, workflow changes are blocked while detached agents are retained; finish or clear them through **Current agents** first. Pi owns reload-error reporting and does not return a success result to extensions, so the save notification also tells users to run `/reload` if the tool surface does not refresh.
+The preview compares the selection with the tools registered in the current session, even when a manual settings edit is pending, and remains read-only until confirmation.
+Escape or **Cancel** leaves settings unchanged.
+Tool removal requires an extension reload because Pi does not expose extension tool unregistration.
+To avoid aborting work or removing isolated worktrees during `session_shutdown`, workflow changes are blocked while detached agents are retained; finish or clear them through **Current agents** first.
+Pi owns reload-error reporting and does not return a success result to extensions, so the save notification also tells users to run `/reload` if the tool surface does not refresh.
 
 The available tools are:
 
-- `subagent` — delegate blocking single, parallel, fan-in, chained, panel-review, or explicit dependency-workflow tasks. The main agent cannot process queued steering until the call returns.
+- `subagent` — delegate blocking single, parallel, fan-in, chained, panel-review, or explicit dependency-workflow tasks.
+  The main agent cannot process queued steering until the call returns.
 - `subagent_spawn` and related lifecycle tools — when enabled, start reusable detached work, return immediately, and receive bounded completion messages automatically.
 - `subagent_inspect` — inspect agent/model/run/runtime metadata without launching work or changing state.
 - `subagent_consult` — run one ephemeral read-only consultation and wait for its answer.
 
 ### Interactive tool rows
 
-In Pi's interactive TUI, every registered tool uses Pi's native tool shell and theme. Call rows identify the action, agent or retained id, scope, and a bounded task/message preview. Result rows use explicit `Starting`, `Running`, `Completed`, `Failed`, `Cancelled`, `Interrupted`, or `Closed` text in addition to icons and color.
+In Pi's interactive TUI, every registered tool uses Pi's native tool shell and theme.
+Call rows identify the action, agent or retained id, scope, and a bounded task/message preview.
+Result rows use explicit `Starting`, `Running`, `Completed`, `Failed`, `Cancelled`, `Interrupted`, or `Closed` text in addition to icons and color.
 
-Collapsed rows stay scan-friendly: consultation and blocking calls show recent activity while running, completed answers show up to three lines, and list actions show up to five items. Use Pi's configured `app.tools.expand` keybinding (Ctrl+O by default) for the additional bounded task, policy, activity, answer, usage, inspection, or mailbox details available to that tool. The hint follows the user's keybinding rather than assuming Ctrl+O.
+Collapsed rows stay scan-friendly: consultation and blocking calls show recent activity while running, completed answers show up to three lines, and list actions show up to five items.
+Use Pi's configured `app.tools.expand` keybinding (Ctrl+O by default) for the additional bounded task, policy, activity, answer, usage, inspection, or mailbox details available to that tool.
+The hint follows the user's keybinding rather than assuming Ctrl+O.
 
-`subagent_consult` emits an initial starting update before launching its child and then reports the actual provider/model, thinking request, usage, and a safe projection of recent `read`, `grep`, `find`, and `ls` activity. Progress never includes full child messages, prompts, credentials, headers, or environment values. Tool-row previews remove terminal controls and redact private text.
+`subagent_consult` emits an initial starting update before launching its child and then reports the actual provider/model, thinking request, usage, and a safe projection of recent `read`, `grep`, `find`, and `ls` activity.
+Progress never includes full child messages, prompts, credentials, headers, or environment values.
+Tool-row previews remove terminal controls and redact private text.
 
-`subagent_spawn` remains deliberately detached and non-polling: its tool row ends after returning the new `agentId` and initial retained state. It does not pretend to stream the background child after the tool call has completed; the existing completion message and configured delivery policy report eventual completion.
+`subagent_spawn` remains deliberately detached and non-polling: its tool row ends after returning the new `agentId` and initial retained state.
+It does not pretend to stream the background child after the tool call has completed; the existing completion message and configured delivery policy report eventual completion.
 
-Custom transcript rendering is TUI presentation only. Tool names, parameter schemas, model-facing final content/details, errors, completion delivery, and print/JSON/RPC final output remain unchanged; JSON/RPC observers may see additive bounded consultation partial-progress details.
+Custom transcript rendering is TUI presentation only.
+Tool names, parameter schemas, model-facing final content/details, errors, completion delivery, and print/JSON/RPC final output remain unchanged; JSON/RPC observers may see additive bounded consultation partial-progress details.
 
-After each session starts, the descriptions of the registered `subagent`, `subagent_spawn`, and
-`subagent_consult` tools include the same bounded parent-facing catalog of the agents available in
-that session. Entries show the source (`built-in`, `user`, or `project`), required `agentScope`,
-declared capability identifiers, configured tools, filesystem authority, and supported result
-formats; the `agent` parameters remain unconstrained strings for cwd and scope flexibility. The
-catalog also warns that enforced path, network, and secret guarantees are unsupported. It is rebuilt on
-`/reload` or the next session start, and omitted entries are reported explicitly when the catalog
-exceeds its metadata bounds.
+After each session starts, the descriptions of the registered `subagent`, `subagent_spawn`, and `subagent_consult` tools include the same bounded parent-facing catalog of the agents available in that session.
+Entries show the source (`built-in`, `user`, or `project`), required `agentScope`, declared capability identifiers, configured tools, filesystem authority, and supported result formats; the `agent` parameters remain unconstrained strings for cwd and scope flexibility.
+The catalog also warns that enforced path, network, and secret guarantees are unsupported.
+It is rebuilt on `/reload` or the next session start, and omitted entries are reported explicitly when the catalog exceeds its metadata bounds.
 
 Choose the API by lifecycle:
 
@@ -171,11 +160,15 @@ Common controls:
 - `resultFormat` — keep bounded text by default, request legacy `structured-v1`, or request `structured-v2` with explicit outcome status, reason code, claims, artifacts, verification, limitations, and unresolved dependencies.
 - `totalTimeoutMs` — bound a whole explicit blocking workflow; no new task starts after the budget is exhausted.
 
-For `subagent_spawn`, the root agent selects the lowest thinking level and shortest realistic work deadline sufficient for the delegated task. These are tool-argument decisions made from the task already in context; `pi-subagents` does not run a string heuristic or an extra classifier model call.
+For `subagent_spawn`, the root agent selects the lowest thinking level and shortest realistic work deadline sufficient for the delegated task.
+These are tool-argument decisions made from the task already in context; `pi-subagents` does not run a string heuristic or an extra classifier model call.
 
 ## 🔐 Working-directory trust policy
 
-Pi records saved project trust in `~/.pi/agent/trust.json`. The closest saved decision for the canonical target or one of its parents wins, so trusting a worktree parent covers worktrees below it while a nearer `false` overrides a trusted parent. `pi-subagents` reads this through Pi's public `ProjectTrustStore`; it never parses, writes, or migrates the file. Open Pi in a folder and use `/trust` to manage trust, then restart Pi before expecting retained-runtime behavior to change.
+Pi records saved project trust in `~/.pi/agent/trust.json`.
+The closest saved decision for the canonical target or one of its parents wins, so trusting a worktree parent covers worktrees below it while a nearer `false` overrides a trusted parent.
+`pi-subagents` reads this through Pi's public `ProjectTrustStore`; it never parses, writes, or migrates the file.
+Open Pi in a folder and use `/trust` to manage trust, then restart Pi before expecting retained-runtime behavior to change.
 
 The default target policies are:
 
@@ -184,32 +177,35 @@ The default target policies are:
 | `cwdPolicy.consultation` | `"anywhere"`, `"current-workspace"` | `"anywhere"`: consultation may start in any existing directory, but a target without effective trust is forced to `resources: "none"` |
 | `cwdPolicy.delegation` | `"trusted-targets"`, `"current-workspace"`, `"anywhere"` | `"trusted-targets"`: blocking and detached delegation may target the current workspace or an external folder covered by a saved `true` decision |
 
-All paths are resolved relative to the current session workspace and canonicalized before containment and trust checks. Missing paths, non-directories, sibling paths, and symlink escapes cannot bypass the policy. Blocking parallel, chain, panel, and fan-in calls preflight every target before any child starts. A generated `workspaceMode: "worktree"` inherits the resolved trust of its approved base cwd.
+All paths are resolved relative to the current session workspace and canonicalized before containment and trust checks.
+Missing paths, non-directories, sibling paths, and symlink escapes cannot bypass the policy.
+Blocking parallel, chain, panel, and fan-in calls preflight every target before any child starts.
+A generated `workspaceMode: "worktree"` inherits the resolved trust of its approved base cwd.
 
-`"anywhere"` for general delegation restores the previous external-target flexibility. An external target without effective trust starts with `projectTrusted: false`, so Pi-protected project settings, packages, extensions, skills, prompts, and system resources stay disabled. General agents still have their configured tools and ordinary Pi/OS permissions, and Pi may still load `AGENTS.md` or `CLAUDE.md` because those context files are not protected by project trust. Resource-free consultation is stricter: it also passes `--no-context-files`, `--no-skills`, `--no-prompt-templates`, `--no-approve`, and `--no-extensions`.
+`"anywhere"` for general delegation restores the previous external-target flexibility.
+An external target without effective trust starts with `projectTrusted: false`, so Pi-protected project settings, packages, extensions, skills, prompts, and system resources stay disabled.
+General agents still have their configured tools and ordinary Pi/OS permissions, and Pi may still load `AGENTS.md` or `CLAUDE.md` because those context files are not protected by project trust.
+Resource-free consultation is stricter: it also passes `--no-context-files`, `--no-skills`, `--no-prompt-templates`, `--no-approve`, and `--no-extensions`.
 
-These controls govern child starting directories and automatically loaded resources. They do **not** restrict absolute paths, shell commands, custom tools, network access, extension code, or filesystem access available to the Pi process. For real isolation, run Pi in a container, VM, micro-VM, or OS sandbox with only the required paths and credentials mounted.
+These controls govern child starting directories and automatically loaded resources.
+They do **not** restrict absolute paths, shell commands, custom tools, network access, extension code, or filesystem access available to the Pi process.
+For real isolation, run Pi in a container, VM, micro-VM, or OS sandbox with only the required paths and credentials mounted.
 
 ## 🧭 Proactive use
 
-When registered, the blocking `subagent` tool advertises only blocking guidance. When stateful lifecycle tools
-are registered, `subagent_spawn` adds detached guidance for the active completion-delivery policy.
+When registered, the blocking `subagent` tool advertises only blocking guidance.
+When stateful lifecycle tools are registered, `subagent_spawn` adds detached guidance for the active completion-delivery policy.
 Changing the policy through `/subagents settings` refreshes that guidance immediately.
 
-The `subagent`, `subagent_spawn`, and `subagent_consult` descriptions advertise the current agent
-catalog automatically; no preliminary list call is needed. Each entry exposes the exact declared
-capability and tool identifiers needed by an enforced contract, plus filesystem authority and result
-formats. Agents without a valid capability manifest are labeled `undeclared` instead of implying
-support. Built-ins and user agents appear under the default `agentScope: "user"`. Trusted project
-agents appear separately and explicitly require
-`agentScope: "project"` or `"both"`; project-authored names and descriptions are not read into
-metadata for untrusted projects. If a project definition
-shares a name with a user or built-in definition, the user version is the default and the project
-version is used only for `"project"`/`"both"`. A user override of a built-in also shows the
-built-in fallback available with `agentScope: "project"`; `"both"` keeps the user definition. The
-catalog is bounded and reports its omission count; metadata discovery also caps files and bytes read
-per scope. Refreshed metadata replaces the previous session's catalog rather than accumulating stale
-entries.
+The `subagent`, `subagent_spawn`, and `subagent_consult` descriptions advertise the current agent catalog automatically; no preliminary list call is needed.
+Each entry exposes the exact declared capability and tool identifiers needed by an enforced contract, plus filesystem authority and result formats.
+Agents without a valid capability manifest are labeled `undeclared` instead of implying support.
+Built-ins and user agents appear under the default `agentScope: "user"`.
+Trusted project agents appear separately and explicitly require `agentScope: "project"` or `"both"`; project-authored names and descriptions are not read into metadata for untrusted projects.
+If a project definition shares a name with a user or built-in definition, the user version is the default and the project version is used only for `"project"`/`"both"`.
+A user override of a built-in also shows the built-in fallback available with `agentScope: "project"`; `"both"` keeps the user definition.
+The catalog is bounded and reports its omission count; metadata discovery also caps files and bytes read per scope.
+Refreshed metadata replaces the previous session's catalog rather than accumulating stale entries.
 
 Delegation guidance:
 
@@ -274,7 +270,8 @@ A blocking fan-out is reserved for output that must be synthesized before the ma
 
 ## 🔎 Read-only inspection
 
-`subagent_inspect` is registered in every workflow, including disabled delegation. It never starts a child, sends or acknowledges mailbox messages, interrupts or closes a run, changes settings, refreshes providers, resolves credentials, or modifies files.
+`subagent_inspect` is registered in every workflow, including disabled delegation.
+It never starts a child, sends or acknowledges mailbox messages, interrupts or closes a run, changes settings, refreshes providers, resolves credentials, or modifies files.
 
 | Action | Parameters | Result |
 | --- | --- | --- |
@@ -289,9 +286,14 @@ A blocking fan-out is reserved for output that must be synthesized before the ma
 | `status` | No additional fields | Effective workflow, runtime counts/transport, detached limit values, completion delivery, consultation resources, and configured/runtime settings with per-field sources |
 | `diagnose` | No additional fields | Structured `pass`, `warning`, and `fail` checks; failed checks are report data rather than a tool error |
 
-The schema rejects fields that do not belong to the selected action. Explicit `project` or `both` scope fails before project-agent discovery unless Pi already trusts the project. Run inspection never returns history output, stored context, or mailbox content; unread counts come from a metadata-only snapshot and do not acknowledge messages. Workflow inspection reads validated, redacted snapshots without quarantining or rewriting invalid files. Paths beneath the Pi agent directory use `~`, project paths are workspace-relative, model objects are projected through an allow-list, and model-facing text is bounded to 50 KiB or 2,000 lines.
+The schema rejects fields that do not belong to the selected action.
+Explicit `project` or `both` scope fails before project-agent discovery unless Pi already trusts the project.
+Run inspection never returns history output, stored context, or mailbox content; unread counts come from a metadata-only snapshot and do not acknowledge messages.
+Workflow inspection reads validated, redacted snapshots without quarantining or rewriting invalid files.
+Paths beneath the Pi agent directory use `~`, project paths are workspace-relative, model objects are projected through an allow-list, and model-facing text is bounded to 50 KiB or 2,000 lines.
 
-`subagent_manage` no longer accepts its former compatibility `list` action. Use `subagent_inspect({ "action": "list_runs", "includeClosed": true })` for metadata-only discovery and `get_run` for detail.
+`subagent_manage` no longer accepts its former compatibility `list` action.
+Use `subagent_inspect({ "action": "list_runs", "includeClosed": true })` for metadata-only discovery and `get_run` for detail.
 
 ## 📖 Read-only consultation
 
@@ -310,15 +312,12 @@ The executor policy remains authoritative even when the task or agent prompt ask
 }
 ```
 
-The actionless schema requires `agent` and `task` and accepts optional `agentScope`,
-`confirmProjectAgents`, `cwd`, `timeoutMs`, and `thinkingLevel`. Any agent resolved from that scope may
-be selected; consultation always intersects its configured tools with the enforced read-only
-allow-list rather than defining a separate read-only agent category. An unknown name fails before
-launch with a bounded name/source list for the requested scope. Project scope is rejected before
-discovery when the project is untrusted. A trusted project agent still asks for confirmation by
-default; non-interactive calls fail closed unless they explicitly send
-`confirmProjectAgents: false`. Declining an interactive confirmation returns a normal cancelled result
-without launching or charging a child.
+The actionless schema requires `agent` and `task` and accepts optional `agentScope`, `confirmProjectAgents`, `cwd`, `timeoutMs`, and `thinkingLevel`.
+Any agent resolved from that scope may be selected; consultation always intersects its configured tools with the enforced read-only allow-list rather than defining a separate read-only agent category.
+An unknown name fails before launch with a bounded name/source list for the requested scope.
+Project scope is rejected before discovery when the project is untrusted.
+A trusted project agent still asks for confirmation by default; non-interactive calls fail closed unless they explicitly send `confirmProjectAgents: false`.
+Declining an interactive confirmation returns a normal cancelled result without launching or charging a child.
 
 `consult.resources` controls automatically inherited instruction resources:
 
@@ -328,17 +327,30 @@ without launching or charging a child.
 | `"none"` | Use only the package consultation base, selected agent prompt, and enforced read-only instruction |
 | `"all"` | Keep ordinarily discoverable trusted context/system/append-system files, skills, and prompt templates |
 
-Extensions remain disabled for all three values. Pi core owns system-prompt source precedence: a trusted project prompt wins over the global prompt, with the global prompt used as fallback. A selected Pi prompt source must be a readable regular file; directories, FIFOs, devices, sockets, and unreadable sources fail before child launch. A current target uses the session's effective project trust, including session-only or CLI overrides. An external target uses the nearest saved trust decision. For an untrusted, explicitly denied, unsaved, or trust-error target, consultation remains available when `cwdPolicy.consultation` permits it but automatically downgrades to `resources: "none"`. This also disables context files because Pi does not protect `AGENTS.md` and `CLAUDE.md` with project trust alone. A saved-trusted external target uses the configured resource policy and discovers `SYSTEM.md`, `APPEND_SYSTEM.md`, and ordinary child context from that target rather than the parent workspace.
+Extensions remain disabled for all three values.
+Pi core owns system-prompt source precedence: a trusted project prompt wins over the global prompt, with the global prompt used as fallback.
+A selected Pi prompt source must be a readable regular file; directories, FIFOs, devices, sockets, and unreadable sources fail before child launch.
+A current target uses the session's effective project trust, including session-only or CLI overrides.
+An external target uses the nearest saved trust decision.
+For an untrusted, explicitly denied, unsaved, or trust-error target, consultation remains available when `cwdPolicy.consultation` permits it but automatically downgrades to `resources: "none"`.
+This also disables context files because Pi does not protect `AGENTS.md` and `CLAUDE.md` with project trust alone.
+A saved-trusted external target uses the configured resource policy and discovers `SYSTEM.md`, `APPEND_SYSTEM.md`, and ordinary child context from that target rather than the parent workspace.
 
-Both settings are user-owned in `~/.pi/agent/pi-subagents.json`; projects cannot override them. `cwdPolicy.consultation: "current-workspace"` rejects every canonical external target before agent discovery or launch even when that target is saved-trusted. This is not a path sandbox: read-only tools can still read an explicitly requested accessible absolute path.
+Both settings are user-owned in `~/.pi/agent/pi-subagents.json`; projects cannot override them.
+`cwdPolicy.consultation: "current-workspace"` rejects every canonical external target before agent discovery or launch even when that target is saved-trusted.
+This is not a path sandbox: read-only tools can still read an explicitly requested accessible absolute path.
 
-Result details report the canonical safe cwd, current/external boundary, bounded target-trust decision/source/warning, requested and effective tools/resources, downgrade reason, agent/model/thinking/timeout metadata, and the facts that extensions, session persistence, and retained-agent state are disabled. They never dump prompt contents or the full trust store. Nested model usage is returned through Pi's usage field, so footer, `/session`, and RPC totals include consultation cost. Validation, disallowed targets, and launch failures throw. Failures after model launch preserve bounded partial evidence and usage while the finalized Pi tool result is marked as an error. Explicit abort, session replacement, and shutdown use the existing process-tree termination and temporary-file cleanup path; a work timeout additionally makes one separately bounded, tool-less summary attempt after abort.
+Result details report the canonical safe cwd, current/external boundary, bounded target-trust decision/source/warning, requested and effective tools/resources, downgrade reason, agent/model/thinking/timeout metadata, and the facts that extensions, session persistence, and retained-agent state are disabled.
+They never dump prompt contents or the full trust store.
+Nested model usage is returned through Pi's usage field, so footer, `/session`, and RPC totals include consultation cost.
+Validation, disallowed targets, and launch failures throw.
+Failures after model launch preserve bounded partial evidence and usage while the finalized Pi tool result is marked as an error.
+Explicit abort, session replacement, and shutdown use the existing process-tree termination and temporary-file cleanup path; a work timeout additionally makes one separately bounded, tool-less summary attempt after abort.
 
 ## 🚀 Blocking batch examples
 
-Every example in this section calls `subagent` and keeps the main agent unavailable until the batch
-finishes. Use `subagent_spawn` instead when the work can complete asynchronously and its configured
-completion policy supports when synthesis is needed.
+Every example in this section calls `subagent` and keeps the main agent unavailable until the batch finishes.
+Use `subagent_spawn` instead when the work can complete asynchronously and its configured completion policy supports when synthesis is needed.
 
 Run one read-only reconnaissance agent:
 
@@ -372,9 +384,8 @@ Run multiple agents in parallel with a shared thinking level and one per-task ov
 }
 ```
 
-Omit `aggregator` entirely when parallel worker outputs should return directly. Do not send `null`,
-empty strings, or an empty object for an unused optional field; for compatibility, an aggregator with
-an empty or whitespace-only `agent` or `task` is treated as absent.
+Omit `aggregator` entirely when parallel worker outputs should return directly.
+Do not send `null`, empty strings, or an empty object for an unused optional field; for compatibility, an aggregator with an empty or whitespace-only `agent` or `task` is treated as absent.
 
 Run parallel workers, then aggregate their results:
 
@@ -587,7 +598,10 @@ Legacy v1 and v2 records without acceptance fields retain their prior completed 
 
 ## 🔁 Stateful agents
 
-Stateful lifecycle tools are available by default. `subagent_spawn` is detached: it schedules work, returns immediately with an opaque `agentId` plus canonical `taskPath`, and later delivers a bounded completion to its intended parent. Every turn receives an executor-owned `runId`, monotonically increasing agent-local generation, and unique `completionId`. The terminal completion and recipient are persisted before delivery, simultaneous root completions are batched, and the root broker allows at most one in-flight wake until that parent turn starts.
+Stateful lifecycle tools are available by default.
+`subagent_spawn` is detached: it schedules work, returns immediately with an opaque `agentId` plus canonical `taskPath`, and later delivers a bounded completion to its intended parent.
+Every turn receives an executor-owned `runId`, monotonically increasing agent-local generation, and unique `completionId`.
+The terminal completion and recipient are persisted before delivery, simultaneous root completions are batched, and the root broker allows at most one in-flight wake until that parent turn starts.
 In TUI mode, completion messages show a compact task and payload summary while collapsed; use the configured tool-output expansion action (`Ctrl+O` by default) to show or hide the complete message globally.
 
 Detached work follows a non-polling policy.
@@ -604,10 +618,20 @@ Simple and immediate critical-path work should stay in the main agent.
 
 `stateful.completionDelivery` controls settled completion delivery:
 
-- `"next-turn"` (default) sends `deliverAs: "steer"` without a turn trigger. Pi queues it into an active root's context, while an idle root records it without waking.
-- `"auto-resume"` holds completion while the root is active, then requests one synthesis turn after the parent settles when no user or extension messages are already pending. Simultaneous completions share that turn, active work is not interrupted, and pending input suppresses the automatic wake.
+- `"next-turn"` (default) sends `deliverAs: "steer"` without a turn trigger.
+  Pi queues it into an active root's context, while an idle root records it without waking.
+- `"auto-resume"` holds completion while the root is active, then requests one synthesis turn after the parent settles when no user or extension messages are already pending.
+  Simultaneous completions share that turn, active work is not interrupted, and pending input suppresses the automatic wake.
 
-The bounded persisted completion outbox provides ordered at-least-once delivery across process restart without replaying the child turn. A top-level completion targets `/root`; a nested completion enters the direct retained parent's mailbox and is not duplicated into the root transcript. If the direct parent cannot own delivery, routing walks toward the nearest live retained ancestor and uses `/root` only as the final fallback. An idle parent remains asleep, and inspection exposes its unread and pending-completion counts until a later turn consumes the envelope. When state must be reduced to its storage bound, persistence drops roots without pending completions first and trims old history rather than discarding an outbox-owned root. A completion is acknowledged only after the intended recipient context observes its exact `completionId`; an injection that returns synchronously but never reaches context remains pending for retry. If the process exits after context assembly but before acknowledgement is persisted, the same ID can be delivered again and consumers must deduplicate it. Auto-resume applies only to `/root`; nested delivery never silently starts the parent. Transient terminal-persistence failures retry with bounded exponential backoff and keep the run pending; shutdown cancels retry waits and reports a final persistence failure instead of silently resolving unsaved work.
+The bounded persisted completion outbox provides ordered at-least-once delivery across process restart without replaying the child turn.
+A top-level completion targets `/root`; a nested completion enters the direct retained parent's mailbox and is not duplicated into the root transcript.
+If the direct parent cannot own delivery, routing walks toward the nearest live retained ancestor and uses `/root` only as the final fallback.
+An idle parent remains asleep, and inspection exposes its unread and pending-completion counts until a later turn consumes the envelope.
+When state must be reduced to its storage bound, persistence drops roots without pending completions first and trims old history rather than discarding an outbox-owned root.
+A completion is acknowledged only after the intended recipient context observes its exact `completionId`; an injection that returns synchronously but never reaches context remains pending for retry.
+If the process exits after context assembly but before acknowledgement is persisted, the same ID can be delivered again and consumers must deduplicate it.
+Auto-resume applies only to `/root`; nested delivery never silently starts the parent.
+Transient terminal-persistence failures retry with bounded exponential backoff and keep the run pending; shutdown cancels retry waits and reports a final persistence failure instead of silently resolving unsaved work.
 
 The default `subprocess` transport preserves compatibility: each turn starts a fresh isolated `pi --mode json -p --no-session` child and receives sanitized, bounded history.
 Pi loads one generated split TypeScript runtime and registers every Subagents tool and command during startup, but loads blocking execution, manager UI, inspection work, and the selected detached transport implementation only on first use.
@@ -630,7 +654,10 @@ Detached-limit saves are durable immediately but apply to the runtime after `/re
 Escape returns from a nested screen to a newly refreshed manager, while Ctrl+C closes the full flow.
 Exact workflow/reload and project-agent safety confirmations remain extension-owned because they guard live agent and trust-boundary policy rather than ordinary navigation.
 
-The direct routes remain predictable: `/subagents settings` changes both target policies, consultation resources, and completion delivery and applies them immediately, including refreshing model-facing tool guidance; `/subagents status` reports current-session runtime values separately from configured values, per-field sources, and path; `/subagents help` summarizes the single-command interface and the non-sandbox limitation. In RPC mode, bare `/subagents` emits the same bounded status through Pi's notification protocol instead of opening a custom TUI. JSON and print modes do not emit ad hoc command output. Manual edits use `~/.pi/agent/pi-subagents.json` and take effect after reloading Pi:
+The direct routes remain predictable: `/subagents settings` changes both target policies, consultation resources, and completion delivery and applies them immediately, including refreshing model-facing tool guidance; `/subagents status` reports current-session runtime values separately from configured values, per-field sources, and path; `/subagents help` summarizes the single-command interface and the non-sandbox limitation.
+In RPC mode, bare `/subagents` emits the same bounded status through Pi's notification protocol instead of opening a custom TUI.
+JSON and print modes do not emit ad hoc command output.
+Manual edits use `~/.pi/agent/pi-subagents.json` and take effect after reloading Pi:
 
 ```json
 {
@@ -691,7 +718,8 @@ This avoids lifecycle-driven tool-schema churn and preserves a stable provider p
 | `subagent_manage` | Use `"interrupt"` to retain an agent after aborting active work or `"close"` to release it; both actions accept optional `subtree`. Use `subagent_inspect` for all list and detail operations. |
 | `subagent_mailbox` | Use `action: "send"` for queue-only messages that do not start a turn, or `"read"` to read and optionally acknowledge unread messages. |
 
-The action schemas are flat for provider compatibility and reject parameters that belong to another action. For example:
+The action schemas are flat for provider compatibility and reject parameters that belong to another action.
+For example:
 
 ```json
 {
@@ -747,7 +775,8 @@ Older records require no manual migration because missing paths and recipients a
 
 ### Migrating from the previous seven-tool lifecycle surface
 
-The five replaced names are intentionally not registered as aliases. Update explicit prompts and integrations as follows:
+The five replaced names are intentionally not registered as aliases.
+Update explicit prompts and integrations as follows:
 
 | Previous call | Fixed-surface call |
 | --- | --- |
@@ -758,7 +787,10 @@ The five replaced names are intentionally not registered as aliases. Update expl
 | `subagent_message({ agentId, message, ... })` | `subagent_mailbox({ action: "send", agentId, message, ... })` |
 | `subagent_messages({ agentId, acknowledge, limit })` | `subagent_mailbox({ action: "read", agentId, acknowledge, limit })` |
 
-Persisted agent and mailbox records require no manual migration; older records load with an empty completion outbox and generation zero. If an explicit prompt in a resumed conversation keeps requesting an old name, update it with the mapping above or start a fresh conversation. To roll back after an upgrade, pin the package version used before the upgrade; for this migration, use `pi install npm:@narumitw/pi-subagents@0.26.0`. The previous release can read the same state directory.
+Persisted agent and mailbox records require no manual migration; older records load with an empty completion outbox and generation zero.
+If an explicit prompt in a resumed conversation keeps requesting an old name, update it with the mapping above or start a fresh conversation.
+To roll back after an upgrade, pin the package version used before the upgrade; for this migration, use `pi install npm:@narumitw/pi-subagents@0.26.0`.
+The previous release can read the same state directory.
 
 A spawn can request a thinking level explicitly:
 
@@ -771,7 +803,9 @@ A spawn can request a thinking level explicitly:
 }
 ```
 
-The requested level and spawn `timeoutMs`, `idleTimeoutMs`, `maxTurns`, and `maxToolCalls` are stored with the stateful agent and remain in effect for all follow-ups and after persisted restore. The same fields on `subagent_send` override only that follow-up turn. `subagent_send` does not provide a per-turn thinking override; create a new agent when a later task needs a different level.
+The requested level and spawn `timeoutMs`, `idleTimeoutMs`, `maxTurns`, and `maxToolCalls` are stored with the stateful agent and remain in effect for all follow-ups and after persisted restore.
+The same fields on `subagent_send` override only that follow-up turn.
+`subagent_send` does not provide a per-turn thinking override; create a new agent when a later task needs a different level.
 
 An exact retry can use a bounded session-owned idempotency key:
 
@@ -807,18 +841,28 @@ Stable source IDs are retained so repeated follow-ups do not need to duplicate p
 Use `subagent_inspect` with `action: "preview_context"` to inspect selected turns, source count, UTF-8 bytes, and truncation before spawning without returning the context text.
 The byte count is not a provider token estimate.
 
-Reasoning, tool results, custom transport messages, and non-text parts are excluded. Text inside `<private>...</private>` and lines containing `[subagent-private]` are omitted before context, mailbox content, or history is persisted.
+Reasoning, tool results, custom transport messages, and non-text parts are excluded.
+Text inside `<private>...</private>` and lines containing `[subagent-private]` are omitted before context, mailbox content, or history is persisted.
 
 Stateful execution uses a transport boundary:
 
 - `subprocess` is the default compatibility and rollback path and starts a fresh child for every turn.
-- `in-process` uses only public Pi SDK APIs: `createAgentSessionServices()`, `createAgentSessionFromServices()`, `SessionManager.inMemory()`, and normal session lifecycle methods. It isolates conversation/tool selection, not memory or crashes; child failures share the parent Node.js process.
-- `rpc` uses strict bounded JSONL over one lazy child process per active retained agent. A `get_state` response proves readiness, prompt response means accepted only, and `agent_settled` is the completion boundary after retry or compaction.
-- `auto` selects one transport before launch and retains the choice for that agent's runtime lifetime. It never retries through another transport after startup or accepted work.
-- In-process and RPC child resource loading disables user and project extensions to prevent recursive `pi-subagents` loading and duplicate extension side effects while retaining trust-eligible context/skill resources and the selected agent prompt. All transports add only the package-owned peer bridge and its two communication tools; the bridge does not add filesystem, shell, model, network-destination, or user-extension authority. The compatibility subprocess path retains its recursion-depth guard and configured execution tools. Transports receive the same resolved target-trust boolean through their public SDK or explicit CLI trust controls.
-- Agent model strings use Pi core's CLI resolver, including provider/model patterns, fuzzy matching, custom provider model IDs, and `:<thinking>` suffixes. Thinking level and built-in tool allow-list overrides are applied when the child is created. Parent model/thinking changes are snapshotted for subsequently created children; an existing child keeps its own session configuration.
+- `in-process` uses only public Pi SDK APIs: `createAgentSessionServices()`, `createAgentSessionFromServices()`, `SessionManager.inMemory()`, and normal session lifecycle methods.
+  It isolates conversation/tool selection, not memory or crashes; child failures share the parent Node.js process.
+- `rpc` uses strict bounded JSONL over one lazy child process per active retained agent.
+  A `get_state` response proves readiness, prompt response means accepted only, and `agent_settled` is the completion boundary after retry or compaction.
+- `auto` selects one transport before launch and retains the choice for that agent's runtime lifetime.
+  It never retries through another transport after startup or accepted work.
+- In-process and RPC child resource loading disables user and project extensions to prevent recursive `pi-subagents` loading and duplicate extension side effects while retaining trust-eligible context/skill resources and the selected agent prompt.
+  All transports add only the package-owned peer bridge and its two communication tools; the bridge does not add filesystem, shell, model, network-destination, or user-extension authority.
+  The compatibility subprocess path retains its recursion-depth guard and configured execution tools.
+  Transports receive the same resolved target-trust boolean through their public SDK or explicit CLI trust controls.
+- Agent model strings use Pi core's CLI resolver, including provider/model patterns, fuzzy matching, custom provider model IDs, and `:<thinking>` suffixes.
+  Thinking level and built-in tool allow-list overrides are applied when the child is created.
+  Parent model/thinking changes are snapshotted for subsequently created children; an existing child keeps its own session configuration.
 - Extension/custom tool names are rejected by in-process and RPC v1 before child creation; automatic mode selects `subprocess` for them, and permissions are never silently widened.
-- Timeout, parent abort, close, expiry, and session shutdown abort/dispose owned child sessions or process groups. A child that does not settle after abort grace is discarded rather than reused.
+- Timeout, parent abort, close, expiry, and session shutdown abort or dispose owned child sessions or process groups.
+  A child that does not settle after abort grace is discarded rather than reused.
 - RPC progress uses `pi-subagents:v1` metadata and reports only bounded phase, queue, timing, effective model/thinking, and validated usage fields.
   Successive Pi 0.84.2 `message_update.usage` values replace one cumulative in-flight snapshot, while a valid final `message_end.message.usage` remains authoritative.
   Missing or invalid final usage falls back to the latest valid streaming snapshot, and an interrupted attempt is committed before retry or timeout-summary usage is added.
@@ -826,7 +870,8 @@ Stateful execution uses a transport boundary:
   The `turns` field still counts finalized assistant messages only, not interrupted attempts or tool-result messages.
   Telemetry never exposes raw prompts, assistant content, reasoning, credentials, headers, environment values, or full RPC events.
 - A successful RPC prompt response is never treated as completion, and accepted or ambiguously accepted work is never replayed automatically.
-- In-process startup failures do not silently retry through subprocesses, preventing duplicate side effects. If the loaded Pi core lacks public `createAgentSessionServices()`, `createAgentSessionFromServices()`, or `resolveCliModel()` support, startup fails with an actionable instruction to select `stateful.transport: "subprocess"`.
+- In-process startup failures do not silently retry through subprocesses, preventing duplicate side effects.
+  If the loaded Pi core lacks public `createAgentSessionServices()`, `createAgentSessionFromServices()`, or `resolveCliModel()` support, startup fails with an actionable instruction to select `stateful.transport: "subprocess"`.
 
 No private Pi imports, runtime casts, or `ExtensionAPI` monkey-patching are used.
 The package uses public Pi root RPC types but owns exact CLI resolution, bounded framing, readiness, stderr, cancellation, and process-group cleanup because the stock client does not provide those package-specific guarantees.
@@ -839,7 +884,11 @@ Use isolated worktrees when repository-write isolation is required.
 The deprecated `allowConcurrentWrites` field remains accepted for compatibility but no longer changes admission behavior.
 Use the blocking batch only when synchronous outputs justify making the main agent unavailable.
 
-Set `workspaceMode: "worktree"` to opt into a disposable detached Git worktree; this requires a clean repository and the worktree is removed on close or session shutdown. The generated path inherits the approved base cwd's trust snapshot. Retained records mark disposable worktrees explicitly, so they are never restored even if cleanup could not remove the generated directory. Shared-workspace retained records store an additive bounded target-trust snapshot for transport and inspection parity; session restore canonicalizes the retained cwd and re-resolves current/saved trust rather than blindly trusting the persisted value. Older records without either field remain readable.
+Set `workspaceMode: "worktree"` to opt into a disposable detached Git worktree; this requires a clean repository and the worktree is removed on close or session shutdown.
+The generated path inherits the approved base cwd's trust snapshot.
+Retained records mark disposable worktrees explicitly, so they are never restored even if cleanup could not remove the generated directory.
+Shared-workspace retained records store an additive bounded target-trust snapshot for transport and inspection parity; session restore canonicalizes the retained cwd and re-resolves current/saved trust rather than blindly trusting the persisted value.
+Older records without either field remain readable.
 
 ## 📜 Compatibility and failure contract
 
@@ -861,10 +910,15 @@ The intentional compatibility change is that an external target without saved tr
 | Workflow | Deterministic dependency-ready and critical-path order, with results returned in declared task order. | Invalid graphs fail before launch; blocked or failed dependencies prevent downstream start; bounded retry and hedging require explicit side-effect contracts. |
 | Panel | Reviewer declaration order, then at most one synthesizer. | Invalid or failed reviews remain visible; synthesis requires `minValidReviews`; insufficient panels preserve partial evidence without a consensus claim; synthesis contract failure marks the tool result as an error. |
 
-An aggregator whose `agent` or `task` is empty or whitespace-only is treated as absent, so successful
-parallel outputs remain available instead of being replaced by a malformed fan-in failure.
+An aggregator whose `agent` or `task` is empty or whitespace-only is treated as absent, so successful parallel outputs remain available instead of being replaced by a malformed fan-in failure.
 
-Blocking work-timeout precedence remains: task/step/aggregator → call → agent setting → `PI_SUBAGENT_TIMEOUT_MS` → 600000 ms, then `totalTimeoutMs` caps the effective remaining time. Blocking idle, turn, and tool-call precedence is task/step/aggregator → call → omitted. Stateful budget precedence is the explicit `subagent_send` field for one follow-up → retained `subagent_spawn` field → timeout-only agent/environment fallback where applicable. Blocking thinking precedence remains: task/step/aggregator → call → agent setting → child default. Stateful spawn thinking precedence is: `subagent_spawn.thinkingLevel` → agent setting → transport fallback. Project-agent resolution and confirmation behavior is unchanged after target preflight. Blocking and retained result/inspection details add bounded target, budget, termination, and effective trust metadata.
+Blocking work-timeout precedence remains: task/step/aggregator → call → agent setting → `PI_SUBAGENT_TIMEOUT_MS` → 600000 ms, then `totalTimeoutMs` caps the effective remaining time.
+Blocking idle, turn, and tool-call precedence is task/step/aggregator → call → omitted.
+Stateful budget precedence is the explicit `subagent_send` field for one follow-up → retained `subagent_spawn` field → timeout-only agent/environment fallback where applicable.
+Blocking thinking precedence remains: task/step/aggregator → call → agent setting → child default.
+Stateful spawn thinking precedence is: `subagent_spawn.thinkingLevel` → agent setting → transport fallback.
+Project-agent resolution and confirmation behavior is unchanged after target preflight.
+Blocking and retained result/inspection details add bounded target, budget, termination, and effective trust metadata.
 
 ## 🤖 Built-in agents
 
@@ -885,25 +939,24 @@ Users who need shell-assisted read-mostly work can define a custom agent, but `b
 
 ## ⚙️ Configure agent tools
 
-Open `/subagents`, choose **Advanced settings**, then **Agent tool permissions** in an interactive
-Pi session to edit the tools each subagent may use.
-Choose **Performance and execution** → **Agent execution defaults** to edit provider-neutral inherited model patterns, thinking levels, and timeouts without changing tools. The standard bounded multi-select keeps a
-one-save draft: toggles do not write until **Save changes**, Escape leaves the draft without writing,
-and unavailable configured tool names remain visible and preserved. In TUI mode, type to fuzzy-search
-tool names and availability metadata; Save and Discard remain pinned below the matches. These are user
-settings stored in `~/.pi/agent/pi-subagents.json` and affect future sessions.
+Open `/subagents`, choose **Advanced settings**, then **Agent tool permissions** in an interactive Pi session to edit the tools each subagent may use.
+Choose **Performance and execution** → **Agent execution defaults** to edit provider-neutral inherited model patterns, thinking levels, and timeouts without changing tools.
+The standard bounded multi-select keeps a one-save draft: toggles do not write until **Save changes**, Escape leaves the draft without writing, and unavailable configured tool names remain visible and preserved.
+In TUI mode, type to fuzzy-search tool names and availability metadata; Save and Discard remain pinned below the matches.
+These are user settings stored in `~/.pi/agent/pi-subagents.json` and affect future sessions.
 
-Compatibility: a valid legacy `pi-subagents-config.json` remains readable with a warning and is never modified automatically; rename it to `pi-subagents.json`. The first subsequent settings save writes the canonical file. If both files exist, the new filename takes precedence.
+Compatibility: a valid legacy `pi-subagents-config.json` remains readable with a warning and is never modified automatically; rename it to `pi-subagents.json`.
+The first subsequent settings save writes the canonical file.
+If both files exist, the new filename takes precedence.
 A saved `agents.scout` override from earlier releases applies to the renamed built-in `explorer` only when no explicit `agents.explorer` override exists and no custom `scout` agent is available.
 
 - Select an agent, then press Enter or Space to toggle tools.
-- Choose **Save changes** to write the draft, choose **Discard draft** to abandon it, or press Esc to
-  return to agent selection without writing.
+- Choose **Save changes** to write the draft, choose **Discard draft** to abandon it, or press Esc to return to agent selection without writing.
 - Save the default selection to remove a custom override and use the agent defaults again.
-- Deselect every tool and save to run that agent with no tools. An explicit empty list remains distinct from an absent list; blank `tools:` or `tools: []` in agent frontmatter also means no tools.
+- Deselect every tool and save to run that agent with no tools.
+  An explicit empty list remains distinct from an absent list; blank `tools:` or `tools: []` in agent frontmatter also means no tools.
 
-Configured tool names that are not currently registered are preserved, so settings for tools from
-other extension sessions are not silently dropped.
+Configured tool names that are not currently registered are preserved, so settings for tools from other extension sessions are not silently dropped.
 
 ## 🧩 Custom agents
 
@@ -938,7 +991,8 @@ You are an API review subagent. Do not edit files. Check compatibility,
 test coverage, and migration risks. Report PASS/FAIL/PARTIAL with evidence.
 ```
 
-`tools` accepts either the comma-separated form above or a YAML string array such as `tools: [read, grep]`. An omitted field keeps the agent's default tools; blank, `null`, or `[]` explicitly selects no tools.
+`tools` accepts either the comma-separated form above or a YAML string array such as `tools: [read, grep]`.
+An omitted field keeps the agent's default tools; blank, `null`, or `[]` explicitly selects no tools.
 
 `capabilityManifest` is optional for legacy custom agents and never grants authority by itself.
 Explicit workflow routing can match declared capabilities, configured tools, filesystem authority, verification roles, and low/medium/high cost or latency hints.
@@ -946,11 +1000,11 @@ A missing or malformed manifest remains unknown and cannot satisfy a capability-
 The parent-facing catalog exposes contract-relevant declarations before the first delegation decision.
 Use those identifiers exactly; enforced `readPaths`, `writePaths`, network, and secret guarantees are currently unsupported and require an external enforcement boundary.
 
-`agentScope` is a top-level tool argument supplied per invocation. It is not a setting in
-`~/.pi/agent/pi-subagents.json` and does not belong in agent frontmatter. The parent-facing tool
-metadata discovers these definitions after session start and labels their source and required scope.
-Edit agent files and run `/reload` (or start a new session) to refresh the catalog; there is no live
-filesystem watcher. The scope selects which custom agent directories are loaded; built-in agents remain available in every scope:
+`agentScope` is a top-level tool argument supplied per invocation.
+It is not a setting in `~/.pi/agent/pi-subagents.json` and does not belong in agent frontmatter.
+The parent-facing tool metadata discovers these definitions after session start and labels their source and required scope.
+Edit agent files and run `/reload` (or start a new session) to refresh the catalog; there is no live filesystem watcher.
+The scope selects which custom agent directories are loaded; built-in agents remain available in every scope:
 
 | `agentScope` | Custom agents loaded |
 | --- | --- |
@@ -978,13 +1032,12 @@ Or select the scope when creating a stateful agent with `subagent_spawn`:
 }
 ```
 
-A stateful agent retains the scope selected by `subagent_spawn` for its follow-ups. Every new
-blocking `subagent` invocation or `subagent_spawn` call that needs project agents must supply
-`agentScope: "project"` or `"both"` again.
+A stateful agent retains the scope selected by `subagent_spawn` for its follow-ups.
+Every new blocking `subagent` invocation or `subagent_spawn` call that needs project agents must supply `agentScope: "project"` or `"both"` again.
 
-Project-local agents require a trusted Pi project. Interactive sessions also ask for confirmation
-before using them by default. Passing `confirmProjectAgents: false` as another top-level tool
-argument skips that confirmation dialog, but it does not bypass the project trust requirement.
+Project-local agents require a trusted Pi project.
+Interactive sessions also ask for confirmation before using them by default.
+Passing `confirmProjectAgents: false` as another top-level tool argument skips that confirmation dialog, but it does not bypass the project trust requirement.
 
 ## ⏱️ Runtime limits and thinking levels
 
@@ -994,7 +1047,8 @@ Every turn can combine main-agent-selected wall-clock, idle, assistant-turn, and
 - The worker-count limit defaults to 8 and does not change the fixed four-at-a-time execution concurrency.
 - Set `timeoutMs` on the top-level blocking call to apply a work deadline to all jobs.
 - Set `timeoutMs` on a task, chain step, or aggregator to override it locally.
-- Set top-level blocking `totalTimeoutMs` to cap model work across the whole call; each child receives at most the remaining budget, queued work is not started after expiry, fan-in receives only remaining time, and an orchestration-expired child skips model finalization. Bounded process-cleanup grace may follow the deadline.
+- Set top-level blocking `totalTimeoutMs` to cap model work across the whole call; each child receives at most the remaining budget, queued work is not started after expiry, fan-in receives only remaining time, and an orchestration-expired child skips model finalization.
+  Bounded process-cleanup grace may follow the deadline.
 - Set `idleTimeoutMs` to stop a turn that has produced no completed assistant turn or tool result within that interval.
 - Set `maxTurns` or `maxToolCalls` to stop unfinished repeated work; a terminal answer at the exact turn limit remains successful.
 - Set spawn budgets as retained defaults, or the same fields on `subagent_send` to override one follow-up turn.
@@ -1004,7 +1058,8 @@ Every turn can combine main-agent-selected wall-clock, idle, assistant-turn, and
 - `maxTurns` and `maxToolCalls` accept integers from 1 through 1,000,000.
 - If `timeoutMs` is omitted, the default is the retained or agent setting, then `PI_SUBAGENT_TIMEOUT_MS`, or `600000` milliseconds (10 minutes) when unset; the other new budgets remain opt-in.
 
-Set `thinkingLevel` to request one of Pi's supported levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Blocking subprocess calls pass the resolved value through `--thinking <level>`.
+Set `thinkingLevel` to request one of Pi's supported levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
+Blocking subprocess calls pass the resolved value through `--thinking <level>`.
 
 For `subagent_spawn`, the root agent should choose the lowest sufficient level:
 
@@ -1025,7 +1080,9 @@ In-process delegates configured model parsing to loaded Pi core and then uses th
 RPC passes the selected CLI model and thinking controls before its readiness handshake and reports the effective state returned by Pi.
 An explicit spawn value is retained for the agent lifecycle and wins over every fallback.
 
-Omit `thinkingLevel` to preserve existing behavior. Reported stateful details show the requested level, not a guarantee of the provider's effective value. Pi still owns model capability clamping; `pi-subagents` does not duplicate capability detection.
+Omit `thinkingLevel` to preserve existing behavior.
+Reported stateful details show the requested level, not a guarantee of the provider's effective value.
+Pi still owns model capability clamping; `pi-subagents` does not duplicate capability detection.
 
 When any execution budget expires, the extension aborts the active run first and creates a versioned, bounded, redacted checkpoint containing partial assistant notes, completed tool evidence, changed-file hints, and whether side effects may already have occurred.
 After authoritative settlement it may make one concise summary attempt over that checkpoint without replaying the stopped task.
@@ -1036,15 +1093,19 @@ Before a retained RPC summary starts, validated in-flight usage from the interru
 The deterministic checkpoint remains available when finalization or the provider fails, and results retain exit `124` plus a structured termination reason and finalization status.
 Explicit parent or user abort stops immediately, never starts finalization, and is not mislabeled as a budget stop.
 
-This release does not claim a cooperative soft-wrap-up phase because print-mode subprocess children cannot receive steering while they are running. It also does not retry budget-stopped work automatically because file or external side effects may already have occurred.
+This release does not claim a cooperative soft-wrap-up phase because print-mode subprocess children cannot receive steering while they are running.
+It also does not retry budget-stopped work automatically because file or external side effects may already have occurred.
 
-The child event protocol limits each JSON line to 256 KiB. Captured output uses these defaults:
+The child event protocol limits each JSON line to 256 KiB.
+Captured output uses these defaults:
 
 - final output and fan-in/chain context: 50 KiB;
 - stderr: 16 KiB;
 - captured messages: 200.
 
-Truncated text includes a `truncated by pi-subagents` marker and details expose `truncated: true`. Inspection and consultation model-facing content also stops at 2,000 lines, whichever limit is reached first. `PI_SUBAGENT_MAX_DEPTH` controls nested delegation depth and defaults to 1; child processes receive `PI_SUBAGENT_DEPTH` automatically.
+Truncated text includes a `truncated by pi-subagents` marker and details expose `truncated: true`.
+Inspection and consultation model-facing content also stops at 2,000 lines, whichever limit is reached first.
+`PI_SUBAGENT_MAX_DEPTH` controls nested delegation depth and defaults to 1; child processes receive `PI_SUBAGENT_DEPTH` automatically.
 
 ## 📡 Runtime status
 
@@ -1060,11 +1121,16 @@ Subprocess and in-process timing fields use the nearest public lifecycle boundar
 Timing and progress are current-session diagnostics and are not persisted.
 The benchmark measures transport overhead rather than model latency or output quality.
 
-While the `subagent` tool is running, `pi-subagents` publishes compact activity status with `ctx.ui.setStatus("subagents", "...")`. Any statusline extension that reads Pi's generic extension status API can display it; no package-to-package dependency is required.
+While the `subagent` tool is running, `pi-subagents` publishes compact activity status with `ctx.ui.setStatus("subagents", "...")`.
+Any statusline extension that reads Pi's generic extension status API can display it; no package-to-package dependency is required.
 
-## 🔒 Safety notes
+## 🔒 Security and privacy
 
-Subagents have separate processes and context windows, but they are **not security sandboxes**. They run as the same OS user, share the host filesystem and network access, and may conflict if they edit the same files. Tool allow-lists reduce available Pi tools but do not reduce operating-system permissions. `subagent_consult` prevents writes through its Pi tool surface and disables extensions, but it can read accessible paths, call the configured model over the network, and incur cost; its instruction-resource policy is not a filesystem or confidentiality boundary. Panel write-capable reviewers use separate disposable Git worktrees, but those worktrees provide repository-write isolation only.
+Subagents have separate processes and context windows, but they are **not security sandboxes**.
+They run as the same OS user, share the host filesystem and network access, and may conflict if they edit the same files.
+Tool allow-lists reduce available Pi tools but do not reduce operating-system permissions.
+`subagent_consult` prevents writes through its Pi tool surface and disables extensions, but it can read accessible paths, call the configured model over the network, and incur cost; its instruction-resource policy is not a filesystem or confidentiality boundary.
+Panel write-capable reviewers use separate disposable Git worktrees, but those worktrees provide repository-write isolation only.
 
 Every contracted execution records a hashed immutable `ExecutionPlan` and an executor-owned capability grant bound to its task generation, effective tools, issuance time, and expiry.
 Interrupt, close, shutdown, replacement, persistence, and restore revoke active grants before signalling work or accepting another generation, and late old-plan results become `stale` diagnostic evidence.
@@ -1075,7 +1141,8 @@ The runner explicitly reports policy continuity in result details:
 - overridden when selected: cwd, model, thinking level, and tool list;
 - unsupported guarantees: parent approval policy, sandbox profile, and provider headers.
 
-Treat project-local agent prompts like executable project configuration: only enable them in trusted repositories. Stateful project agents require Pi's project trust; interactive use also keeps confirmation enabled by default.
+Treat project-local agent prompts like executable project configuration: only enable them in trusted repositories.
+Stateful project agents require Pi's project trust; interactive use also keeps confirmation enabled by default.
 
 Stateful records are stored as versioned mode-0600 JSON under `~/.pi/agent/pi-subagents-state/` (or the configured Pi agent directory).
 Explicit blocking-workflow snapshots use separate mode-0600 files under `~/.pi/agent/pi-subagents-workflows/`, retain at most 64 workflows per session for 30 days, and are available only through current-session workflow inspection.
@@ -1190,4 +1257,5 @@ Pi extension, Pi coding agent, subagents, agent delegation, parallel agents, rev
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -1,20 +1,20 @@
-# ☁️ pi-sync — Git/WebDAV/R2/S3 Pi Settings Sync
+# ☁️ pi-sync — Sync Pi Settings Across Machines
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-sync)](https://www.npmjs.com/package/@narumitw/pi-sync) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-sync` syncs selected Pi content through Git, WebDAV, Cloudflare R2, or other S3-compatible storage. A reusable **storage connection** holds access configuration. A named **sync setup** selects one connection, one exact remote storage path, included content, and automatic-sync behavior.
+Sync selected Pi settings and content across machines through Git, WebDAV, Cloudflare R2, or another S3-compatible store.
+
+Reusable storage connections hold credentials, while named sync setups define the exact remote path, included content, and automatic-sync behavior.
 
 ## ✨ Features
 
-- A generated split TypeScript runtime that reduces Pi's Jiti startup work while preserving first-use UI and backend chunks.
-- A goal-oriented `/sync` manager with symmetric **Sync setups** and **Storage connections** list/detail flows.
-- S3-compatible storage, a Cloudflare R2 setup preset, Git, and WebDAV.
-- Immutable snapshots, secret scanning, local locks, conflict checks, pull backups, transactional apply, and recovery journals.
-- Exact reviewed storage paths that do not change when a local sync setup is renamed.
-- One ordered `sync.include` list for Pi roots, safe agent-relative paths, and the privacy-sensitive `sessions` root.
-- Portable, credential-free snapshot selection with explicit cross-environment review and adoption.
-- Atomic private settings writes that preserve unknown fields and reject stale concurrent edits.
-- Fail-closed validation for missing references, mixed backend fields, duplicate remote locations, unsafe or oversized selection policies, malformed credentials, and credential-bearing Git URLs.
+- Manages Git, WebDAV, Cloudflare R2, and general S3-compatible backends through `/sync`.
+- Separates reusable storage connections from named sync setups and exact reviewed remote paths.
+- Selects Pi roots, safe agent-relative paths, and the privacy-sensitive sessions root through one ordered include list.
+- Protects changes with immutable snapshots, secret scanning, locks, conflict checks, pull backups, transactional apply, and recovery journals.
+- Keeps snapshot selection portable and credential-free across environments.
+- Writes settings atomically, preserves unknown fields, rejects stale edits, and fails closed on unsafe configuration.
+- Loads a generated split runtime while preserving lazy UI and backend chunks.
 
 ## 📦 Install
 
@@ -41,13 +41,11 @@ An unbuilt checkout still declares `dist/index.ts`, but the generated entrypoint
 
 ## 🚀 Quick start
 
-Run:
+Run `/sync`, choose **Set up sync**, and review the storage connection, exact remote path, included content, automatic-sync choice, and masked credentials before saving.
+Buckets and remote repositories must already exist.
+Git uses existing non-interactive SSH or credential-helper configuration and never stores Git credentials.
 
-```text
-/sync
-```
-
-Choose **Set up sync**, then review the storage connection, exact storage path, included content, automatic-sync choice, and masked credentials before saving. Buckets and remote repositories must already exist. Git uses the user's existing non-interactive SSH or credential-helper configuration and never stores Git credentials.
+## 🧭 Manager, conflicts, and recovery
 
 The manager shows local state without contacting remote storage:
 
@@ -59,34 +57,25 @@ Automatic sync: On
 Remote status: Not checked
 ```
 
-Primary actions include **Sync now**, **Switch sync setup**, **Status & changes**, **Settings**, and
-**More…**. When pi-sync has already detected a synced-content-list mismatch, the manager instead
-shows **Sync status: Review needed**, puts **Review synced content (recommended)** first, and keeps
-**Sync now** visibly unavailable until the choice is reviewed. Opening the manager still performs no
-new remote request. The standard manager also owns setup and connection lists/details plus history
-and recovery. Secondary screens provide **Back**; Escape goes back and Ctrl+C closes the flow.
-Destructive, credential-bearing, and externally visible operations retain exact specialized previews
-and confirmations.
+Primary actions include **Sync now**, **Switch sync setup**, **Status & changes**, **Settings**, and **More…**.
+When pi-sync has already detected a synced-content-list mismatch, the manager instead shows **Sync status: Review needed**, puts **Review synced content (recommended)** first, and keeps **Sync now** visibly unavailable until the choice is reviewed.
+Opening the manager still performs no new remote request.
+The standard manager also owns setup and connection lists/details plus history and recovery.
+Secondary screens provide **Back**; Escape goes back and Ctrl+C closes the flow.
+Destructive, credential-bearing, and externally visible operations retain exact specialized previews and confirmations.
 
 ### Restore sync access
 
-When an operation is currently running, the manager shows its command and process ID, keeps sync and
-settings changes unavailable, and puts **Refresh operation status** first.
-When lock metadata is still protected by an active guard, the manager explains that another pi-sync
-process may be starting or finishing and asks the user to wait before refreshing.
+When an operation is currently running, the manager shows its command and process ID, keeps sync and settings changes unavailable, and puts **Refresh operation status** first.
+When lock metadata is still protected by an active guard, the manager explains that another pi-sync process may be starting or finishing and asks the user to wait before refreshing.
 It never offers lock removal while an owner or guard may still be active.
 
-When a previous operation appears to have stopped without releasing its local lock, the manager shows
-**Sync paused** and puts **Restore sync access… (recommended)** first instead of hiding recovery
-inside **History & recovery…**.
+When a previous operation appears to have stopped without releasing its local lock, the manager shows **Sync paused** and puts **Restore sync access… (recommended)** first instead of hiding recovery inside **History & recovery…**.
 Unreadable metadata receives a stronger warning because pi-sync cannot verify who owns it.
-Close every other Pi session that may still be syncing, review the local-lock-only confirmation, then
-choose **Remove local lock and continue**.
-The guarded recovery path rechecks metadata and ownership before removal, changes no settings, local
-files, sync state, or remote data, and returns directly to the normal manager when access is restored.
+Close every other Pi session that may still be syncing, review the local-lock-only confirmation, then choose **Remove local lock and continue**.
+The guarded recovery path rechecks metadata and ownership before removal, changes no settings, local files, sync state, or remote data, and returns directly to the normal manager when access is restored.
 Cancellation leaves the lock unchanged.
-If ownership changes or a guard is still expiring, pi-sync refuses removal and keeps actionable status
-available for refresh or retry.
+If ownership changes or a guard is still expiring, pi-sync refuses removal and keeps actionable status available for refresh or retry.
 The deterministic fallback remains `/sync unlock --stale` after the same no-other-sync verification.
 
 ### Resolve conflicts in the manager
@@ -106,36 +95,30 @@ Then choose one action:
 - **Keep this device's content list and update remote…** opens the existing `push --force` preparation and exact confirmation without `--yes`.
   Cancelling preparation or confirmation returns to the content-list choice without changing remote data.
 - **Cancel** returns to the manager without changing settings, files, remote data, or sync state.
-- **Later** appears when automatic startup sync detected the mismatch and returns immediately to the
-  Pi editor without changing anything.
+- **Later** appears when automatic startup sync detected the mismatch and returns immediately to the Pi editor without changing anything.
 
 Choose **Review differences (recommended)** in an ordinary file-direction conflict to inspect the exact affected paths without changing local files, remote data, or sync state.
 Then choose one reviewed direction:
 
-- **Keep local content and replace remote…** uses the existing forced-push path. It scans managed
-  local files for secrets, shows the exact remote publication effect, re-reads a changed remote head,
-  and asks again if the reviewed plan changed.
-- **Use remote content and replace local…** uses the existing forced-pull path. It shows exact local
-  writes and deletions, protects the live session, and creates a local backup before applying.
-- First sync uses **Use local as initial source…** and **Use remote as initial source…** labels. An
-  empty remote offers **Push local content…** only.
+- **Keep local content and replace remote…** uses the existing forced-push path.
+  It scans managed local files for secrets, shows the exact remote publication effect, re-reads a changed remote head, and asks again if the reviewed plan changed.
+- **Use remote content and replace local…** uses the existing forced-pull path.
+  It shows exact local writes and deletions, protects the live session, and creates a local backup before applying.
+- First sync uses **Use local as initial source…** and **Use remote as initial source…** labels.
+  An empty remote offers **Push local content…** only.
 
 Cancelling a preparation or confirmation returns to conflict resolution with no side effects.
 Back returns to the sync manager, and Ctrl+C closes the complete flow.
 
-When automatic startup sync detects an explicit content-list mismatch in TUI mode, it opens
-**Synced content differs** once for that session instead of ending at a warning. Choosing **Later** or
-closing the flow leaves a compact **Pi Sync needs review** widget above the editor and a
-**review needed** footer status. The attention state is in memory only, contains no credentials or
-file contents, and is revalidated before any settings or remote mutation. It clears after verified
-resolution, invalidation, session replacement, or shutdown.
+When automatic startup sync detects an explicit content-list mismatch in TUI mode, it opens **Synced content differs** once for that session instead of ending at a warning.
+Choosing **Later** or closing the flow leaves a compact **Pi Sync needs review** widget above the editor and a **review needed** footer status.
+The attention state is in memory only, contains no credentials or file contents, and is revalidated before any settings or remote mutation.
+It clears after verified resolution, invalidation, session replacement, or shutdown.
 
-Interactive TUI `/sync sync`, `/sync pull`, and `/sync push` routes without `--yes` open the same
-review flow when they detect the mismatch. Explicit `--yes` routes remain non-interactive and report
-exact remote-only, device-only, or order-only guidance while leaving visible attention for later
-review. Shutdown automatic sync never opens a dialog because Pi is exiting.
-RPC startup and direct routes remain read-only and notification-based, while print and JSON modes
-remain unsupported for `/sync` because their UI output is not observable.
+Interactive TUI `/sync sync`, `/sync pull`, and `/sync push` routes without `--yes` open the same review flow when they detect the mismatch.
+Explicit `--yes` routes remain non-interactive and report exact remote-only, device-only, or order-only guidance while leaving visible attention for later review.
+Shutdown automatic sync never opens a dialog because Pi is exiting.
+RPC startup and direct routes remain read-only and notification-based, while print and JSON modes remain unsupported for `/sync` because their UI output is not observable.
 
 ## ⚙️ Settings
 
@@ -145,9 +128,15 @@ The canonical private user file is:
 ~/.pi/agent/pi-sync.json
 ```
 
-Pi's configured agent directory replaces `~/.pi/agent` when applicable. Missing settings load as unconfigured without creating an agent directory, file, temporary, or lock. An explicit setup creates the file atomically. On POSIX, pi-sync creates and replaces it with mode `0600`. Pi-sync processes coordinate settings access through `pi-sync.json.mutation-lock`; lock-unaware editors are outside that serialization boundary and should not save the file while a pi-sync settings operation is running. Credentials stay in this canonical private file and are never shown in menus, reviews, status, notifications, errors, logs, or completion metadata.
+Pi's configured agent directory replaces `~/.pi/agent` when applicable.
+Missing settings load as unconfigured without creating an agent directory, file, temporary, or lock.
+An explicit setup creates the file atomically.
+On POSIX, pi-sync creates and replaces it with mode `0600`.
+Pi-sync processes coordinate settings access through `pi-sync.json.mutation-lock`; lock-unaware editors are outside that serialization boundary and should not save the file while a pi-sync settings operation is running.
+Credentials stay in this canonical private file and are never shown in menus, reviews, status, notifications, errors, logs, or completion metadata.
 
-An existing private `pi-sync.local.json` containing a valid version 3 document is copied byte-for-byte to `pi-sync.json`; the old file remains as a recovery copy. If both paths exist, `pi-sync.json` wins and the other path remains untouched.
+An existing private `pi-sync.local.json` containing a valid version 3 document is copied byte-for-byte to `pi-sync.json`; the old file remains as a recovery copy.
+If both paths exist, `pi-sync.json` wins and the other path remains untouched.
 
 ### Complete version 3 example
 
@@ -216,7 +205,8 @@ An existing private `pi-sync.local.json` containing a valid version 3 document i
 }
 ```
 
-Cloudflare R2 is persisted as `"type": "s3"`; R2 is a setup preset, not another schema type. Temporary S3 credentials may additionally include `credentials.sessionToken`.
+Cloudflare R2 is persisted as `"type": "s3"`; R2 is a setup preset, not another schema type.
+Temporary S3 credentials may additionally include `credentials.sessionToken`.
 
 ### Required backend shapes
 
@@ -227,7 +217,11 @@ Cloudflare R2 is persisted as `"type": "s3"`; R2 is a setup preset, not another 
 - **WebDAV connection:** `type`, HTTPS `url`, and `credentials.username` / `credentials.password`.
 - **WebDAV setup storage:** `connection` and complete relative `path`; `bucket` and `branch` are rejected.
 
-Every setup requires `sync.include` and explicit `sync.automatic`. `activeSyncSetup` must reference an own-property setup when any setups exist and must be absent when the setup catalog is empty. A referenced connection cannot be removed. The current setup must be switched before removal. Two setups cannot resolve to the same normalized backend location.
+Every setup requires `sync.include` and explicit `sync.automatic`.
+`activeSyncSetup` must reference an own-property setup when any setups exist and must be absent when the setup catalog is empty.
+A referenced connection cannot be removed.
+The current setup must be switched before removal.
+Two setups cannot resolve to the same normalized backend location.
 
 `onSwitch` accepts:
 
@@ -237,24 +231,26 @@ Every setup requires `sync.include` and explicit `sync.automatic`. `activeSyncSe
 
 ### Included content
 
-`sync.include` is ordered and duplicate-free. Supported Pi roots are:
+`sync.include` is ordered and duplicate-free.
+Supported Pi roots are:
 
 ```text
 settings.json, keybindings.json, models.json, AGENTS.md, APPEND_SYSTEM.md,
 skills, prompts, themes, extensions, sessions
 ```
 
-Safe agent-relative custom files or directories may also be included. Absolute paths, `..`, backslashes, controls, denied secret/settings paths, duplicate case variants, and ambiguous nested paths under reserved roots are rejected.
+Safe agent-relative custom files or directories may also be included.
+Absolute paths, `..`, backslashes, controls, denied secret/settings paths, duplicate case variants, and ambiguous nested paths under reserved roots are rejected.
 
-An empty array is valid. It means no useful transfer is selected: **Sync now** reports the condition and does not claim that the setup is up to date. Unselected content remains unmanaged locally and is preserved when republishing existing remote snapshots.
+An empty array is valid.
+It means no useful transfer is selected: **Sync now** reports the condition and does not claim that the setup is up to date.
+Unselected content remains unmanaged locally and is preserved when republishing existing remote snapshots.
 
-The Included Content editor is a standard bounded multi-select backed by one in-memory draft. Toggles
-never write settings. **Add custom path…** accepts a safe agent-relative file or directory even when
-it does not exist locally yet, allowing a new environment to select content that exists only in the
-remote snapshot. Leaving the editor opens an exact Include/Exclude review with **Save changes**,
-**Discard changes**, and **Continue editing**; only reviewed Save publishes, while Continue preserves
-the draft and Discard/cancellation preserves the settings bytes. RPC remains a read-only summary with
-the manual `sync.include` path.
+The Included Content editor is a standard bounded multi-select backed by one in-memory draft.
+Toggles never write settings.
+**Add custom path…** accepts a safe agent-relative file or directory even when it does not exist locally yet, allowing a new environment to select content that exists only in the remote snapshot.
+Leaving the editor opens an exact Include/Exclude review with **Save changes**, **Discard changes**, and **Continue editing**; only reviewed Save publishes, while Continue preserves the draft and Discard/cancellation preserves the settings bytes.
+RPC remains a read-only summary with the manual `sync.include` path.
 
 Every new snapshot stores the normalized included-content selection separately from the files that happened to exist.
 This preserves selected-but-missing paths without syncing `pi-sync.json`, storage credentials, automatic-sync preferences, or setup names.
@@ -266,15 +262,18 @@ Keeping this device's list opens the reviewed force-push path and explicitly rep
 
 Automatic sync and pull, including forced pull, pause on an explicit remote-policy difference rather than silently expanding local scope.
 Status reports matches and exact local-only/remote-only paths.
-Old snapshots remain readable. Because they have no authoritative selection, pi-sync offers only a
-clearly labeled read-only partial discovery from safe remote file roots; selected-but-missing and
-preserved-unmanaged intent cannot be reconstructed. Use **Add custom path…** for any needed path.
+Old snapshots remain readable.
+Because they have no authoritative selection, pi-sync offers only a clearly labeled read-only partial discovery from safe remote file roots; selected-but-missing and preserved-unmanaged intent cannot be reconstructed.
+Use **Add custom path…** for any needed path.
 
-Adding `sessions` requires a privacy acknowledgement in interactive flows. Session JSONL can contain prompts, tool output, file paths, images, and secrets. Automatic apply protects the currently open session file; restart Pi or resume a pulled session to use newly synchronized conversations.
+Adding `sessions` requires a privacy acknowledgement in interactive flows.
+Session JSONL can contain prompts, tool output, file paths, images, and secrets.
+Automatic apply protects the currently open session file; restart Pi or resume a pulled session to use newly synchronized conversations.
 
 ### Unsupported old settings and recovery
 
-Version 1, version 2, and non-empty unversioned documents are intentionally unsupported by this breaking schema reset. pi-sync does **not** migrate, partially interpret, downgrade, or overwrite them. Automatic sync pauses and reports an actionable version 3 error without displaying secrets.
+Version 1, version 2, and non-empty unversioned documents are intentionally unsupported by this breaking schema reset. pi-sync does **not** migrate, partially interpret, downgrade, or overwrite them.
+Automatic sync pauses and reports an actionable version 3 error without displaying secrets.
 
 Recovery:
 
@@ -284,7 +283,8 @@ Recovery:
 4. run `/sync doctor`, inspect the exact storage path, and review the first pull or push;
 5. restore the retained file and a compatible older package only if rolling back.
 
-Malformed, invalid, unsupported, symlinked, or concurrently changed documents remain untouched. Failed UI saves keep the previous file and displayed/effective state.
+Malformed, invalid, unsupported, symlinked, or concurrently changed documents remain untouched.
+Failed UI saves keep the previous file and displayed/effective state.
 
 ## 💬 Commands
 
@@ -313,11 +313,13 @@ The menu is preferred, while deterministic routes remain available:
 - `--force` accepts a reviewed content conflict but never disables backend concurrency protection.
 - `--stale` requests guarded stale-lock recovery.
 
-The former version 2 setup-addressing flag is rejected. Unknown flags, unknown commands, trailing values, and missing setup/snapshot values are rejected. Completion includes known setup names and preserves preceding command tokens.
+The former version 2 setup-addressing flag is rejected.
+Unknown flags, unknown commands, trailing values, and missing setup/snapshot values are rejected.
+Completion includes known setup names and preserves preceding command tokens.
 
-TUI mode uses standard manager, settings, resource, and included-content screens plus specialized
-secret, wizard, confirmation, and commit-aware loader components. RPC uses Pi's supported
-dialog/notification protocol and does not gain settings mutation. Print and JSON modes never enter TUI-only screens; unsupported interactive routes reject or remain protocol-safe rather than relying on no-op output.
+TUI mode uses standard manager, settings, resource, and included-content screens plus specialized secret, wizard, confirmation, and commit-aware loader components.
+RPC uses Pi's supported dialog/notification protocol and does not gain settings mutation.
+Print and JSON modes never enter TUI-only screens; unsupported interactive routes reject or remain protocol-safe rather than relying on no-op output.
 
 ## 🔄 Backend and recovery model
 
@@ -327,29 +329,47 @@ dialog/notification protocol and does not gain settings mutation. Print and JSON
 | WebDAV | Verified strong conditional requests | Private settings username/app password | `<url>/<storage.path>` |
 | R2/S3 | Read-check-write-verify | Private settings credentials | `<bucket>/<storage.path>` |
 
-Git requires Git 2.30 or newer and a SHA-1-format remote repository. HTTPS userinfo, URL passwords, local paths, `file`, `git`, `ext`, and remote-helper transports are rejected. When editing a Git setup, changing its storage path also requires a new owned branch so the existing branch remains readable at its reviewed path. The private bare cache under `<agent-dir>/pi-sync/git/` is rebuildable.
+Git requires Git 2.30 or newer and a SHA-1-format remote repository.
+HTTPS userinfo, URL passwords, local paths, `file`, `git`, `ext`, and remote-helper transports are rejected.
+When editing a Git setup, changing its storage path also requires a new owned branch so the existing branch remains readable at its reviewed path.
+The private bare cache under `<agent-dir>/pi-sync/git/` is rebuildable.
 
-WebDAV requires HTTPS except loopback tests. URL credentials, query strings, fragments, unsafe redirects, weak/missing ETags, and ignored conditional headers fail closed. `/sync doctor` verifies collection and conditional-write behavior with an isolated probe.
+WebDAV requires HTTPS except loopback tests.
+URL credentials, query strings, fragments, unsafe redirects, weak/missing ETags, and ignored conditional headers fail closed.
+`/sync doctor` verifies collection and conditional-write behavior with an isolated probe.
 
-S3/R2 stages immutable bundles, rechecks the visible head before publication, and verifies afterward. Unlike Git/WebDAV, generic S3 does not provide an atomic compare-and-swap for `latest.json`; status review remains important for simultaneous writers.
+S3/R2 stages immutable bundles, rechecks the visible head before publication, and verifies afterward.
+Unlike Git/WebDAV, generic S3 does not provide an atomic compare-and-swap for `latest.json`; status review remains important for simultaneous writers.
 
-Before pull or rollback, pi-sync writes a backup under `<agent-dir>/pi-sync/backups/`. Apply preflights paths and checksums, journals all mutations, restores the prior state after failures, and recovers interrupted journals on startup. Removing a local setup or connection never deletes remote data.
+Before pull or rollback, pi-sync writes a backup under `<agent-dir>/pi-sync/backups/`.
+Apply preflights paths and checksums, journals all mutations, restores the prior state after failures, and recovers interrupted journals on startup.
+Removing a local setup or connection never deletes remote data.
 
-The operational state root is `<agent-dir>/pi-sync/`. An existing installation continues using `<agent-dir>/.pisync/` and shows migration guidance on startup; it is never moved merely because no sync is active. Close every other Pi process, then run `/sync migrate-state` and confirm the review (or pass `--yes` for an already reviewed RPC workflow). The command serializes against every upgraded state/cache user and atomically renames `.pisync/` only when no legacy sync lock or guard is active. Close Pi instances running older pi-sync versions during the migration because they do not understand the migration guard. If both roots exist, or either root is a symlink or non-directory, pi-sync refuses stateful work instead of merging, following, or deleting data. Preserve both roots before manual recovery; with every Pi process closed and no destination conflict, rollback is an atomic rename from `pi-sync/` back to `.pisync/`.
+The operational state root is `<agent-dir>/pi-sync/`.
+An existing installation continues using `<agent-dir>/.pisync/` and shows migration guidance on startup; it is never moved merely because no sync is active.
+Close every other Pi process, then run `/sync migrate-state` and confirm the review (or pass `--yes` for an already reviewed RPC workflow).
+The command serializes against every upgraded state/cache user and atomically renames `.pisync/` only when no legacy sync lock or guard is active.
+Close Pi instances running older pi-sync versions during the migration because they do not understand the migration guard.
+If both roots exist, or either root is a symlink or non-directory, pi-sync refuses stateful work instead of merging, following, or deleting data.
+Preserve both roots before manual recovery; with every Pi process closed and no destination conflict, rollback is an atomic rename from `pi-sync/` back to `.pisync/`.
 
-## 🛡️ Safety notes
+## 🔒 Security and privacy
 
 - Canonical, legacy, temporary, and recovery settings paths are denied from snapshots; both `pi-sync/` and `.pisync/` state roots are permanently denied.
 - Push scans managed local content for common secret patterns.
 - Remote snapshot references, checksums, paths, manifests, response sizes, and publication revisions are validated.
 - Symlink parents, path escapes, duplicate paths, and unsafe file/directory replacement fail before local mutation.
 - Live locks block mutation; stale recovery rechecks process and guard ownership.
-- Cancellation aborts preparation and dialogs. Publication/apply commit boundaries finish with bounded signals and report ambiguous outcomes explicitly.
+- Cancellation aborts preparation and dialogs.
+  Publication/apply commit boundaries finish with bounded signals and report ambiguous outcomes explicitly.
 - Terminal-bound names, paths, metadata, and errors are control-character sanitized.
 
 ## ♿ Conditional terminal accessibility smoke
 
-Pi exposes terminal components rather than a semantic/ARIA tree. Release validation checks textual state, keyboard operation, Escape/Back, control escaping, and narrow rendering. Critical meaning appears in text such as `(current)`, `Review needed`, `Later`, `Warning`, `Invalid`, `Saved`, `Cancelled`, and `Applied`; color is supplementary. The attention widget is informational and does not pretend to be a clickable control.
+Pi exposes terminal components rather than a semantic/ARIA tree.
+Release validation checks textual state, keyboard operation, Escape/Back, control escaping, and narrow rendering.
+Critical meaning appears in text such as `(current)`, `Review needed`, `Later`, `Warning`, `Invalid`, `Saved`, `Cancelled`, and `Applied`; color is supplementary.
+The attention widget is informational and does not pretend to be a clickable control.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-tool/README.md
+++ b/packages/pi-tool/README.md
@@ -1,18 +1,17 @@
-# 🧰 pi-tool — Tool Browser for Pi
+# 🧰 pi-tool — Browse Pi Tools and Their Schemas
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-tool)](https://www.npmjs.com/package/@narumitw/pi-tool) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-tool` adds one read-only `/tool` command for browsing every tool configured in the current Pi session and inspecting the metadata Pi exposes for it.
+Browse every tool configured in the current Pi session and inspect its active state, description, origin, schema, and prompt guidance through one read-only `/tool` command.
 
 ## ✨ Features
 
 - Lists built-in, SDK-provided, and extension-provided tools in one searchable catalog.
-- Shows whether each tool is currently active.
-- Shows the tool description, source, scope, origin, path, and optional base directory.
-- Shows the complete JSON parameter schema and every prompt guideline exposed by `pi.getAllTools()`.
-- Shows the effective prompt snippet exposed for an active tool by `ctx.getSystemPromptOptions()`.
-- Reads fresh tool and system-prompt metadata each time the catalog opens.
-- Changes no tools, settings, files, or session data.
+- Shows active state, description, source, scope, origin, path, and optional base directory.
+- Displays the complete JSON parameter schema and prompt guidelines exposed by Pi.
+- Shows the effective system-prompt snippet for each active tool.
+- Refreshes metadata every time the catalog opens.
+- Never changes tools, settings, files, or session data.
 
 ## 📦 Install
 

--- a/packages/pi-tui-kit-showcase/README.md
+++ b/packages/pi-tui-kit-showcase/README.md
@@ -1,4 +1,4 @@
-# 🧭 Pi TUI Kit Showcase
+# 🧭 Pi TUI Kit Showcase — Preview Standard Pi Interactions
 
 [![private](https://img.shields.io/badge/npm-private-lightgrey)](./package.json) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
@@ -6,19 +6,17 @@
 > Pi TUI Kit Showcase is experimental and private.
 > It is a local maintainer demo, not a published extension.
 
-`@narumitw/pi-tui-kit-showcase` opens an interactive local demo of public `@narumitw/pi-tui-kit` screens and standalone interactions.
+Preview the public `@narumitw/pi-tui-kit` screens and standalone interactions in one local interactive demo.
 
-It stores no persistent settings.
-
-It uses only in-memory state for the current demo session.
+The showcase uses only in-memory state and stores no settings.
 
 ## ✨ Features
 
-- Shows `actions`, `detail`, `browse`, `choice`, `settings`, `input`, `review`, and `multiSelect` menu screens.
-- Shows standalone `runTask()`, `runConfirmation()`, and `runLiveChoice()` interactions from the same entry menu.
-- Demonstrates disabled rows, busy labels, searchable choices, exact browse documents, adaptive review, bulk multi-select actions, and selected-row descriptions.
-- Keeps all side effects inside the demo process.
-- Lazy-loads the Kit runtime only after the command runs.
+- Demonstrates action, detail, browse, choice, settings, input, review, and multi-select screens.
+- Demonstrates standalone task, confirmation, and live-choice interactions from the same menu.
+- Covers disabled rows, busy labels, search, exact documents, adaptive review, bulk actions, and row descriptions.
+- Keeps all effects in memory inside the demo process.
+- Loads the Kit runtime only after `/tui-kit-showcase` runs.
 
 ## 📦 Install
 

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -1,22 +1,18 @@
-# 🧭 Pi TUI Kit
+# 🧭 Pi TUI Kit — Build Consistent Pi Extension Interfaces
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-tui-kit)](https://www.npmjs.com/package/@narumitw/pi-tui-kit)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Reusable navigation helpers and typed, declarative interaction flows for independently installable
-[Pi](https://pi.dev) extensions, built on
-[`@earendil-works/pi-tui`](https://www.npmjs.com/package/@earendil-works/pi-tui). The initial
-high-level API lets extensions describe menu screens and domain actions while this package owns
-standard rendering, navigation, mode adaptation, cancellation, and lifecycle behavior. It also
-provides standalone task, confirmation, and live-choice interactions plus lifecycle ownership for
-specialized custom components.
+Build consistent typed menus and interactions for independently installable [Pi](https://pi.dev) extensions without reimplementing navigation, rendering, cancellation, or mode adaptation.
+
+Pi TUI Kit provides declarative screens, standalone task and confirmation flows, live choices, terminal-text helpers, and lifecycle ownership for specialized components.
 
 ## ✨ Features
 
-- Provides typed declarative action, detail, settings, choice, review, and document screens.
-- Adapts shared interaction flows across Pi TUI and RPC modes.
-- Owns standard navigation, cancellation, disposal, and width-safe rendering behavior.
-- Exposes focused helpers for tasks, confirmations, live choices, terminal text, interaction hints, and testing.
+- Defines typed action, detail, settings, choice, review, multi-select, and document screens.
+- Adapts shared flows across Pi TUI and RPC modes.
+- Owns standard navigation, cancellation, disposal, lifecycle, and width-safe rendering.
+- Provides focused task, confirmation, live-choice, custom-interaction, terminal-text, hint, and testing helpers.
 - Publishes built ESM and TypeScript declarations for independently installable extensions.
 
 ## 📦 Install
@@ -27,52 +23,67 @@ Add the library as a runtime dependency of the extension package:
 npm install @narumitw/pi-tui-kit
 ```
 
-The published package contains built ESM and declarations in `dist/`; consumers do not need a
-TypeScript loader for dependencies.
+The published package contains built ESM and declarations in `dist/`; consumers do not need a TypeScript loader for dependencies.
 
 The package root remains the supported entrypoint for menus and interaction runners.
-Import lightweight display helpers from `@narumitw/pi-tui-kit/terminal-text` or
-`@narumitw/pi-tui-kit/interaction-hints` when a startup path does not otherwise need the full Kit
-runtime.
+Import lightweight display helpers from `@narumitw/pi-tui-kit/terminal-text` or `@narumitw/pi-tui-kit/interaction-hints` when a startup path does not otherwise need the full Kit runtime.
 
 ### Compatibility floor
 
-Pi TUI Kit is still a zero-major package, so caret ranges are minor-bounded: for example,
-`^0.40.0` accepts releases from `0.40.0` up to, but not including, `0.41.0`. When an extension adopts
-an API introduced in a later Kit minor, raise that extension's minimum compatible minor rather than
-using a broad `<1` range. Otherwise an existing npm lock can retain an older Kit that lacks the
-screen or contract the extension expects.
+Pi TUI Kit is still a zero-major package, so caret ranges are minor-bounded: for example, `^0.40.0` accepts releases from `0.40.0` up to, but not including, `0.41.0`.
+When an extension adopts an API introduced in a later Kit minor, raise that extension's minimum compatible minor rather than using a broad `<1` range.
+Otherwise an existing npm lock can retain an older Kit that lacks the screen or contract the extension expects.
 
-Compatibility ranges are consumer-owned. Review each extension against the APIs it imports and keep
-its tested minimum; do not automatically synchronize every consumer range with the current Kit
-version. Pi TUI Kit and its consumers version independently through Changesets. Publish a new Kit API
-before raising a consumer's compatibility floor to use it, and declare the dependency in the
-consuming package so local hoisting cannot hide an incompatible or missing published dependency.
+Compatibility ranges are consumer-owned.
+Review each extension against the APIs it imports and keep its tested minimum; do not automatically synchronize every consumer range with the current Kit version.
+Pi TUI Kit and its consumers version independently through Changesets.
+Publish a new Kit API before raising a consumer's compatibility floor to use it, and declare the dependency in the consuming package so local hoisting cannot hide an incompatible or missing published dependency.
 
 ## ⚡ Runtime performance
 
 The Kit's production JavaScript imports Pi TUI at runtime but keeps Pi Coding Agent imports type-only.
-This prevents a source-loaded extension from evaluating a second heavyweight coding-agent runtime
-when its menu first opens. Borders and task loaders compose public Pi TUI primitives with the theme
-and keybindings supplied by the active UI callback; review syntax coloring uses the Kit's declared
-highlighter dependency and the same callback theme. Mermaid rendering lazy-loads its declared
-renderer only before the first screen containing an enabled Mermaid fence.
+This prevents a source-loaded extension from evaluating a second heavyweight coding-agent runtime when its menu first opens.
+Borders and task loaders compose public Pi TUI primitives with the theme and keybindings supplied by the active UI callback; review syntax coloring uses the Kit's declared highlighter dependency and the same callback theme.
+Mermaid rendering lazy-loads its declared renderer only before the first screen containing an enabled Mermaid fence.
 
-The `terminal-text` and `interaction-hints` subpaths expose only their focused ESM and declaration
-graphs, while the package root keeps every existing export for compatibility.
+The `terminal-text` and `interaction-hints` subpaths expose only their focused ESM and declaration graphs, while the package root keeps every existing export for compatibility.
 
-Repository maintainers can measure cold root and lightweight-subpath imports plus first actions,
-code-review, Mermaid, and task frames in fresh serial processes:
+Repository maintainers can measure cold root and lightweight-subpath imports plus first actions, code-review, Mermaid, and task frames in fresh serial processes:
 
 ```bash
 npm run build --workspace @narumitw/pi-tui-kit
 node scripts/benchmark-tui-kit-runtime.mjs --runs 5
 ```
 
-The benchmark reports medians, median absolute deviations, resolved package URLs, and graph-presence
-flags so a fast import cannot hide the same dependency cost in the first interaction.
+The benchmark reports medians, median absolute deviations, resolved package URLs, and graph-presence flags so a fast import cannot hide the same dependency cost in the first interaction.
 
 ## 🚀 Quick start
+
+Define a typed screen and let Pi TUI Kit own its navigation and mode adaptation:
+
+```ts
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+
+const menu = defineMenu<undefined, "main", "unused">({
+  start: "main",
+  screens: {
+    main: () => ({
+      kind: "detail",
+      title: "Example extension",
+      lines: ["Ready"],
+      hint: "close",
+    }),
+  },
+  actions: { unused: async () => ({ kind: "stay" }) },
+});
+
+export function showMenu(ctx: ExtensionCommandContext) {
+  return runMenu(ctx, menu, { getState: () => undefined });
+}
+```
+
+## 🧭 Complete menu example
 
 ```ts
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
@@ -148,18 +159,15 @@ export async function showMenu(ctx: ExtensionCommandContext, generation: number)
 }
 ```
 
-The state loader runs again whenever a screen is entered or refreshed, so screen factories can
-remain pure projections of current extension state. An ordinary terminal result is
-`{ kind: "closed", reason: "back" | "close" }`: root Back reports `back`; Ctrl+C, a Close hint,
-a close row, or an accepted action that returns Close reports `close`. Nested Back remains inside the
-menu. RPC preserves each adapter's existing transition: a generic cancelled selector applies Back,
-while input and review cancellation follow their declared hint. Owner replacement remains `stale`
-and takes precedence over any racing Close event.
+The state loader runs again whenever a screen is entered or refreshed, so screen factories can remain pure projections of current extension state.
+An ordinary terminal result is `{ kind: "closed", reason: "back" | "close" }`: root Back reports `back`; Ctrl+C, a Close hint, a close row, or an accepted action that returns Close reports `close`.
+Nested Back remains inside the menu.
+RPC preserves each adapter's existing transition: a generic cancelled selector applies Back, while input and review cancellation follow their declared hint.
+Owner replacement remains `stale` and takes precedence over any racing Close event.
 
-For abort-aware work outside a menu, use `runTask()`. TUI mode shows the Kit's Pi-styled cancellable
-bordered loader; RPC, print, and JSON execute the same task directly. User cancellation, owner
-replacement, external component disposal, errors, and successful completion remain distinct typed
-results.
+For abort-aware work outside a menu, use `runTask()`.
+TUI mode shows the Kit's Pi-styled cancellable bordered loader; RPC, print, and JSON execute the same task directly.
+User cancellation, owner replacement, external component disposal, errors, and successful completion remain distinct typed results.
 
 ```ts
 import { runTask } from "@narumitw/pi-tui-kit";
@@ -175,11 +183,10 @@ const result = await runTask(ctx, {
 if (result.kind === "completed") ctx.ui.notify("Refreshed", "info");
 ```
 
-A task must honor its supplied signal. The runner aborts and drains owned work before returning; it
-does not hide an uncooperative task behind an arbitrary timeout.
+A task must honor its supplied signal.
+The runner aborts and drains owned work before returning; it does not hide an uncooperative task behind an arbitrary timeout.
 
-For a confirmation nested inside a larger flow, use `runConfirmation()` when Escape must return to
-the caller while Ctrl+C closes the whole TUI interaction:
+For a confirmation nested inside a larger flow, use `runConfirmation()` when Escape must return to the caller while Ctrl+C closes the whole TUI interaction:
 
 ```ts
 import { runConfirmation } from "@narumitw/pi-tui-kit";
@@ -198,17 +205,14 @@ if (confirmation.kind === "confirmed") await deleteDomainData();
 else if (confirmation.kind === "closed" && confirmation.reason === "close") return;
 ```
 
-TUI confirmation uses the standard bounded actions presentation: selecting the cancel row or pressing
-Escape returns `{ kind: "closed", reason: "back" }`, while Ctrl+C returns the same result with reason
-`"close"`. RPC uses one signal-aware `select()` request with explicit confirm and cancel rows;
-explicit cancel and protocol cancellation deterministically map to Back because Pi RPC does not expose
-a separate Ctrl+C dialog outcome. Print and JSON return `unsupported`. Owner abort, session
-replacement, external TUI disposal, and failures remain distinct `stale` or `error` results. The Kit
-owns only this interaction lifecycle—the caller performs every confirmed side effect and must abort
-its owner signal on replacement or shutdown.
+TUI confirmation uses the standard bounded actions presentation: selecting the cancel row or pressing Escape returns `{ kind: "closed", reason: "back" }`, while Ctrl+C returns the same result with reason `"close"`.
+RPC uses one signal-aware `select()` request with explicit confirm and cancel rows;
+explicit cancel and protocol cancellation deterministically map to Back because Pi RPC does not expose a separate Ctrl+C dialog outcome.
+Print and JSON return `unsupported`.
+Owner abort, session replacement, external TUI disposal, and failures remain distinct `stale` or `error` results.
+The Kit owns only this interaction lifecycle—the caller performs every confirmed side effect and must abort its owner signal on replacement or shutdown.
 
-For a choice whose cursor drives an extension-owned preview, use `runLiveChoice()` instead of making
-a declarative `choice` screen side-effecting:
+For a choice whose cursor drives an extension-owned preview, use `runLiveChoice()` instead of making a declarative `choice` screen side-effecting:
 
 ```ts
 import { runLiveChoice } from "@narumitw/pi-tui-kit";
@@ -249,27 +253,21 @@ else if (choice?.kind === "shortcut") await customizePreset(choice.itemId);
 
 TUI calls `onSelectionChange` for the initial cursor and later focused rows, including disabled rows.
 A fully `disabled` row blocks both primary confirmation and shortcuts.
-Set `confirmationDisabled` with an optional `confirmationDisabledReason` when only the primary action
-must be inert while shortcuts remain available, such as allowing Customize for an already-active
-preset that cannot be applied again.
+Set `confirmationDisabled` with an optional `confirmationDisabledReason` when only the primary action must be inert while shortcuts remain available, such as allowing Customize for an already-active preset that cannot be applied again.
 If both states are present, full `disabled` behavior and its reason take precedence.
-Shortcut keys use Pi `KeyId` values; keys that conflict with current standard choice controls are
-omitted from shortcut hints and dispatch.
+Shortcut keys use Pi `KeyId` values; keys that conflict with current standard choice controls are omitted from shortcut hints and dispatch.
 Synchronous previews run immediately.
-While an asynchronous preview is pending, newer cursor changes coalesce to the latest row. Completion,
-Back, Close, owner cancellation, external disposal, and errors abort the callback signal and drain
-owned preview work before returning. The callback must honor that signal. The caller still owns its
-preview snapshot, rollback, persistence, confirmation, and final apply policy.
+While an asynchronous preview is pending, newer cursor changes coalesce to the latest row.
+Completion, Back, Close, owner cancellation, external disposal, and errors abort the callback signal and drain owned preview work before returning.
+The callback must honor that signal.
+The caller still owns its preview snapshot, rollback, persistence, confirmation, and final apply policy.
 
-RPC deliberately degrades to a signal-aware ordinary selector: it never runs live previews or custom
-shortcuts, disabled and confirmation-disabled rows remain explanatory and inert, and cancellation
-follows the requested Back/Close hint. Print and JSON return `unsupported`. Results distinguish
-`selected`, `shortcut`, `closed`, `stale`, `unsupported`, and `error`.
+RPC deliberately degrades to a signal-aware ordinary selector: it never runs live previews or custom shortcuts, disabled and confirmation-disabled rows remain explanatory and inert, and cancellation follows the requested Back/Close hint.
+Print and JSON return `unsupported`.
+Results distinguish `selected`, `shortcut`, `closed`, `stale`, `unsupported`, and `error`.
 
-`formatInteractionHints()` is available for other specialized components. Pass the callback-injected
-keybindings plus binding-backed or literal-key hint groups; the formatter normalizes arrows,
-Enter/Escape names, sanitizes controls, applies exclusions, de-duplicates keys, and supports a custom
-separator.
+`formatInteractionHints()` is available for other specialized components.
+Pass the callback-injected keybindings plus binding-backed or literal-key hint groups; the formatter normalizes arrows, Enter/Escape names, sanitizes controls, applies exclusions, de-duplicates keys, and supports a custom separator.
 
 ```ts
 import { formatInteractionHints } from "@narumitw/pi-tui-kit/interaction-hints";
@@ -281,12 +279,10 @@ const hint = formatInteractionHints(keybindings, [
 ]);
 ```
 
-For a specialized custom component that does not belong in the declarative screen union, use
-`runCustomInteraction()`.  It supplies an interaction-owned signal, classifies owner replacement and
-external component disposal as stale, disposes exactly once, and drains optional `waitForPending()`
-work before returning. The consumer still owns the component, its Back/Close value, and every domain
-side effect. Async factories and pending work must honor the supplied signal; the helper drains them
-but does not hide uncooperative work behind a timeout.
+For a specialized custom component that does not belong in the declarative screen union, use `runCustomInteraction()`.
+It supplies an interaction-owned signal, classifies owner replacement and external component disposal as stale, disposes exactly once, and drains optional `waitForPending()` work before returning.
+The consumer still owns the component, its Back/Close value, and every domain side effect.
+Async factories and pending work must honor the supplied signal; the helper drains them but does not hide uncooperative work behind a timeout.
 
 Use `sanitizeTerminalText()` when a specialized component must place an untrusted model label, path, or other value on one terminal line.
 It removes complete and unterminated terminal control sequences, C0/C1 controls, and bidirectional display controls; line separators become spaces.
@@ -320,32 +316,23 @@ const result = await runCustomInteraction<{ kind: "back" | "close" }>(ctx, {
 
 `defineMenu()` supports eight standard screen kinds:
 
-- **`actions`** — navigation targets, domain actions, close rows, optional cancellable busy labels,
-  adaptive long-label columns, and disabled explanations.
+- **`actions`** — navigation targets, domain actions, close rows, optional cancellable busy labels, adaptive long-label columns, and disabled explanations.
 - **`detail`** — read-only wrapped text with Back or Close behavior.
-- **`browse`** — a read-only searchable catalog with textual status, adaptive list/detail views,
-  stable selection restoration, legacy prose or exact document details, and paginated RPC details.
+- **`browse`** — a read-only searchable catalog with textual status, adaptive list/detail views, stable selection restoration, legacy prose or exact document details, and paginated RPC details.
 - **`choice`** — one confirmed value from a static list, with separate current and initial items, selected details, disabled explanations, an optional TUI search field, and a bounded viewport.
-- **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes,
-  serialized saves, and rollback when an action rejects.
-- **`input`** — single-line text entry inside the menu stack with IME focus, serialized submission,
-  rejected-draft retention, and TUI/RPC adaptation.
-- **`review`** — fixed or terminal-adaptive scrollable exact text, code, or diff content with an
-  optional primary confirmation action and paginated RPC fallback.
-- **`multiSelect`** — optimistic toggles with stable cursor restoration, serialized saves, rollback,
-  selected-row descriptions, optional fuzzy search and bulk action rows, and a bounded TUI viewport.
+- **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes, serialized saves, and rollback when an action rejects.
+- **`input`** — single-line text entry inside the menu stack with IME focus, serialized submission, rejected-draft retention, and TUI/RPC adaptation.
+- **`review`** — fixed or terminal-adaptive scrollable exact text, code, or diff content with an optional primary confirmation action and paginated RPC fallback.
+- **`multiSelect`** — optimistic toggles with stable cursor restoration, serialized saves, rollback, selected-row descriptions, optional fuzzy search and bulk action rows, and a bounded TUI viewport.
 
-All standard TUI screens use Pi's injected keybindings, sanitize display text, rebuild themed
-content after invalidation, and bound rendered output to the supplied terminal width. Escape follows
-the screen's Back/Close hint; `Ctrl+C` closes the menu.
+All standard TUI screens use Pi's injected keybindings, sanitize display text, rebuild themed content after invalidation, and bound rendered output to the supplied terminal width.
+Escape follows the screen's Back/Close hint; `Ctrl+C` closes the menu.
 
-Disabled action rows stay visible and focusable for context but never navigate, close, or invoke a
-domain action. Set `disabledReason` to explain why. TUI prefixes the semantic label with `[-]`, keeps
-a supplied unavailable reason visible below the selected row at every width, and adapts the primary
-column to available width; unavoidable action-label truncation uses an ellipsis. When a reason is
-supplied, RPC adds the unavailable state and reason to its selector label; legacy disabled rows
-without a reason keep
-their existing RPC label. This contract also applies to action rows under `multiSelect.actions`.
+Disabled action rows stay visible and focusable for context but never navigate, close, or invoke a domain action.
+Set `disabledReason` to explain why.
+TUI prefixes the semantic label with `[-]`, keeps a supplied unavailable reason visible below the selected row at every width, and adapts the primary column to available width; unavoidable action-label truncation uses an ellipsis.
+When a reason is supplied, RPC adds the unavailable state and reason to its selector label; legacy disabled rows without a reason keep their existing RPC label.
+This contract also applies to action rows under `multiSelect.actions`.
 
 ```ts
 const resetAction = {
@@ -358,13 +345,13 @@ const resetAction = {
 };
 ```
 
-Choice screens are for bounded static alternatives rather than actions that run while the cursor
-moves. `currentItemId` adds the textual current marker; `initialItemId` controls the first cursor when
-there is no remembered selection. They remain separate so a custom or legacy current value can focus
-a safe fallback. A confirmed row invokes the screen action with its raw `itemId`; moving the cursor
-only changes selected details. Rejected or thrown actions retain the selection. Disabled rows stay
-focusable for their explanation but never invoke the action. RPC flattens choice rows to unique dialog
-labels while preserving raw identity.
+Choice screens are for bounded static alternatives rather than actions that run while the cursor moves.
+`currentItemId` adds the textual current marker; `initialItemId` controls the first cursor when there is no remembered selection.
+They remain separate so a custom or legacy current value can focus a safe fallback.
+A confirmed row invokes the screen action with its raw `itemId`; moving the cursor only changes selected details.
+Rejected or thrown actions retain the selection.
+Disabled rows stay focusable for their explanation but never invoke the action.
+RPC flattens choice rows to unique dialog labels while preserving raw identity.
 
 ```ts
 const profileScreen = {
@@ -398,31 +385,25 @@ Details and raw IDs are not searched implicitly.
 RPC deliberately keeps one deterministic unfiltered selector and ignores interactive search metadata.
 
 Keep preview snapshots, rollback, persistence, and confirmation policy in the consuming extension.
-Use standalone `runLiveChoice()` when its list-and-shortcut contract fits; keep a fully specialized UI
-local only when cursor behavior needs more than that contract.
+Use standalone `runLiveChoice()` when its list-and-shortcut contract fits; keep a fully specialized UI local only when cursor behavior needs more than that contract.
 
-Browse screens are read-only and invoke no action. TUI fuzzy-searches each sanitized label, textual
-`statusText`, description, and optional non-rendered `searchText`. Enter opens an adaptive scrolling
-detail view; Escape returns to the list without losing the query or selected raw id, then returns to
-the parent, while Ctrl+C closes the menu. Omitted or `"adaptive"` viewport size uses the live terminal
-row budget; a positive number caps item rows without disabling terminal bounds. RPC intentionally
-keeps one deterministic unfiltered list, then presents bounded detail pages; `searchText` is never
-rendered.
+Browse screens are read-only and invoke no action.
+TUI fuzzy-searches each sanitized label, textual `statusText`, description, and optional non-rendered `searchText`.
+Enter opens an adaptive scrolling detail view; Escape returns to the list without losing the query or selected raw id, then returns to the parent, while Ctrl+C closes the menu.
+Omitted or `"adaptive"` viewport size uses the live terminal row budget; a positive number caps item rows without disabling terminal bounds.
+RPC intentionally keeps one deterministic unfiltered list, then presents bounded detail pages; `searchText` is never rendered.
 
-Use `details` for legacy prose lines. The Kit normalizes their whitespace and prepends available
-status and description text. Use `detailDocument` for a complete body such as JSON, source code, a
-diff, or Markdown. Text, code, and diff formats preserve indentation, expand tabs to four-column
-stops, hard-wrap by terminal cells, and strip terminal plus bidirectional display controls. Markdown
-format applies the same safety boundary but then renders semantic Markdown rather than preserving
-exact source whitespace. When both fields are
-present, `detailDocument` is the complete body and takes precedence over `details`, status, and
-description inside the detail body. The item label still names the detail, while status and
-description remain available in list presentation. RPC retains the existing status-bearing selector
-label as the dialog title for compatibility, but does not prepend a second status line to the body.
+Use `details` for legacy prose lines.
+The Kit normalizes their whitespace and prepends available status and description text.
+Use `detailDocument` for a complete body such as JSON, source code, a diff, or Markdown.
+Text, code, and diff formats preserve indentation, expand tabs to four-column stops, hard-wrap by terminal cells, and strip terminal plus bidirectional display controls.
+Markdown format applies the same safety boundary but then renders semantic Markdown rather than preserving exact source whitespace.
+When both fields are present, `detailDocument` is the complete body and takes precedence over `details`, status, and description inside the detail body.
+The item label still names the detail, while status and description remain available in list presentation.
+RPC retains the existing status-bearing selector label as the dialog title for compatibility, but does not prepend a second status line to the body.
 
-Exact document content is never added to fuzzy-search metadata or RPC selector labels. Copy only safe,
-intentional aliases or metadata into `searchText`; do not copy a large or sensitive document merely
-to make it searchable.
+Exact document content is never added to fuzzy-search metadata or RPC selector labels.
+Copy only safe, intentional aliases or metadata into `searchText`; do not copy a large or sensitive document merely to make it searchable.
 
 ```ts
 const modulesScreen = {
@@ -457,19 +438,18 @@ const schemasScreen = {
 };
 ```
 
-Use `choice` when confirmation invokes a domain action; use `browse` when selection only reveals
-information. Domain status meaning, catalog construction, and data freshness remain consumer-owned.
+Use `choice` when confirmation invokes a domain action; use `browse` when selection only reveals information.
+Domain status meaning, catalog construction, and data freshness remain consumer-owned.
 
-TUI settings screens retain the extension title and supporting context above Pi's familiar search
-field, aligned label/value columns, ten-row viewport, position indicator, selected-row description,
-and keyboard hint. Typing fuzzy-filters labels, arrows navigate, and Enter or Space changes the
-selected value. Changes save immediately, so Back or Close never implies rollback. The embedded
-search input forwards focus for IME positioning. The kit owns this adapter because Pi's public
-`SettingsList` does not currently expose restored-cursor, disabled-row, async rollback, and search
-focus behavior together.
+TUI settings screens retain the extension title and supporting context above Pi's familiar search field, aligned label/value columns, ten-row viewport, position indicator, selected-row description, and keyboard hint.
+Typing fuzzy-filters labels, arrows navigate, and Enter or Space changes the selected value.
+Changes save immediately, so Back or Close never implies rollback.
+The embedded search input forwards focus for IME positioning.
+The kit owns this adapter because Pi's public `SettingsList` does not currently expose restored-cursor, disabled-row, async rollback, and search focus behavior together.
 
-Input screens submit through the existing action `value`. Validation, normalization, persistence,
-and product copy remain extension-owned. Rejection keeps the TUI draft available for correction;
+Input screens submit through the existing action `value`.
+Validation, normalization, persistence, and product copy remain extension-owned.
+Rejection keeps the TUI draft available for correction;
 RPC reopens its signal-aware input dialog.
 
 ```ts
@@ -482,10 +462,10 @@ const inputScreen = {
 };
 ```
 
-Review screens preserve indentation and hard-wrap by terminal cells rather than prose words. Their
-viewport supports Up, Down, Page Up, Page Down, Home, and End. RPC sends bounded pages instead of one
-unbounded dialog title. Treat `content` as untrusted display input; the kit strips terminal and
-bidirectional display controls before formatting it.
+Review screens preserve indentation and hard-wrap by terminal cells rather than prose words.
+Their viewport supports Up, Down, Page Up, Page Down, Home, and End.
+RPC sends bounded pages instead of one unbounded dialog title.
+Treat `content` as untrusted display input; the kit strips terminal and bidirectional display controls before formatting it.
 
 ```ts
 const reviewScreen = {
@@ -498,17 +478,15 @@ const reviewScreen = {
 };
 ```
 
-Review formats are `{ kind: "text" }`, `{ kind: "code", language?, filePath? }`,
-`{ kind: "diff", filePath? }`, and
-`{ kind: "markdown", renderLatex?, renderMermaid? }`. Choosing Markdown is opt-in; both rich
-renderers default to `true`, and either can be disabled explicitly. TUI uses Pi's Markdown renderer
-for headings, emphasis, links, lists, code highlighting, and supported inline or block LaTeX.
+Review formats are `{ kind: "text" }`, `{ kind: "code", language?, filePath? }`, `{ kind: "diff", filePath? }`, and `{ kind: "markdown", renderLatex?, renderMermaid? }`.
+Choosing Markdown is opt-in; both rich renderers default to `true`, and either can be disabled explicitly.
+TUI uses Pi's Markdown renderer for headings, emphasis, links, lists, code highlighting, and supported inline or block LaTeX.
 
-Enabled top-level `mermaid` fences render locally as themed Unicode when a warning-free flowchart,
-state, class, entity-relationship, or sequence diagram fits the current width. Partial parses retain
-the fenced source and add a warning. Unsupported, oversized, unavailable, or disabled rendering
-retains readable fenced source. Resizing can switch between source and art. The Kit options are
-independent of Pi's transcript-only Mermaid setting and use no browser, image, SVG, or network.
+Enabled top-level `mermaid` fences render locally as themed Unicode when a warning-free flowchart, state, class, entity-relationship, or sequence diagram fits the current width.
+Partial parses retain the fenced source and add a warning.
+Unsupported, oversized, unavailable, or disabled rendering retains readable fenced source.
+Resizing can switch between source and art.
+The Kit options are independent of Pi's transcript-only Mermaid setting and use no browser, image, SVG, or network.
 
 ```ts
 const markdownReviewScreen = {
@@ -520,20 +498,18 @@ const markdownReviewScreen = {
 };
 ```
 
-Rich Markdown rendering is TUI-only. RPC keeps sanitized, bounded source pages, and a host without
-Pi's public rich-Markdown capability safely displays readable source for unsupported rich elements.
-Omitted `viewportSize` keeps the fixed 14-row TUI viewport, and numeric values remain fixed integers
-from 1 through 50. Set `viewportSize: "adaptive"` to recompute from the live terminal height on every
-TUI render. Adaptive review reserves three terminal rows for Pi-owned UI and keeps the complete frame
-within `max(1, floor(terminal rows) - 3)` rows; this mode is not capped at the numeric 50-row maximum.
+Rich Markdown rendering is TUI-only.
+RPC keeps sanitized, bounded source pages, and a host without Pi's public rich-Markdown capability safely displays readable source for unsupported rich elements.
+Omitted `viewportSize` keeps the fixed 14-row TUI viewport, and numeric values remain fixed integers from 1 through 50.
+Set `viewportSize: "adaptive"` to recompute from the live terminal height on every TUI render.
+Adaptive review reserves three terminal rows for Pi-owned UI and keeps the complete frame within `max(1, floor(terminal rows) - 3)` rows; this mode is not capped at the numeric 50-row maximum.
 
-At constrained heights, adaptive review prioritizes one content row, then a compact title, then a
-compact confirmation/Back-or-Close/navigation hint. From four available rows it shows position when
-content scrolls; additional space restores wrapped title and supporting context, the full keyboard
-hint, and the separator before enlarging the content viewport. Fixed and omitted review rendering is
-unchanged. RPC does not read terminal dimensions: adaptive and omitted reviews use deterministic
-pages of at most eight rows, while numeric values retain the existing eight-row cap. A review without
-`confirm` is read-only. Escape follows Back/Close and `Ctrl+C` closes the whole menu.
+At constrained heights, adaptive review prioritizes one content row, then a compact title, then a compact confirmation/Back-or-Close/navigation hint.
+From four available rows it shows position when content scrolls; additional space restores wrapped title and supporting context, the full keyboard hint, and the separator before enlarging the content viewport.
+Fixed and omitted review rendering is unchanged.
+RPC does not read terminal dimensions: adaptive and omitted reviews use deterministic pages of at most eight rows, while numeric values retain the existing eight-row cap.
+A review without `confirm` is read-only.
+Escape follows Back/Close and `Ctrl+C` closes the whole menu.
 
 Action handlers return one of these results:
 
@@ -545,24 +521,22 @@ Action handlers return one of these results:
 { kind: "rejected", error?: unknown }
 ```
 
-A rejected settings or multi-select action restores the last accepted value. Throwing has the same
-recovery behavior and is routed through `onError`.
+A rejected settings or multi-select action restores the last accepted value.
+Throwing has the same recovery behavior and is routed through `onError`.
 
-For a large multi-select, set `viewportSize` to the maximum number of toggle and action rows rendered
-at once. Up and Down wrap; Page Up and Page Down move by one viewport and clamp at the first or last
-row. Descriptions for the selected row appear below the viewport.
+For a large multi-select, set `viewportSize` to the maximum number of toggle and action rows rendered at once.
+Up and Down wrap; Page Up and Page Down move by one viewport and clamp at the first or last row.
+Descriptions for the selected row appear below the viewport.
 
-Set `enableSearch: true` when toggle rows can become difficult to scan. TUI typing fuzzy-filters each
-sanitized label plus optional non-rendered `searchText`; use that field for source, policy, aliases, or
-other useful metadata without parsing display labels or raw IDs. The query is local to the current
-screen instance. Rows in `actions` remain pinned below the matches, including when there are no
-matching toggle rows, so Save, Discard, and bulk workflows stay reachable. Clearing the query restores
-a valid stable-ID selection. The embedded public Pi `Input` forwards focus for IME positioning and
-sanitizes pasted terminal controls before filtering.
+Set `enableSearch: true` when toggle rows can become difficult to scan.
+TUI typing fuzzy-filters each sanitized label plus optional non-rendered `searchText`; use that field for source, policy, aliases, or other useful metadata without parsing display labels or raw IDs.
+The query is local to the current screen instance.
+Rows in `actions` remain pinned below the matches, including when there are no matching toggle rows, so Save, Discard, and bulk workflows stay reachable.
+Clearing the query restores a valid stable-ID selection.
+The embedded public Pi `Input` forwards focus for IME positioning and sanitizes pasted terminal controls before filtering.
 
-Search and the viewport affect TUI presentation only. RPC deliberately keeps one flat, unfiltered
-list of unique dialog choices, preserving raw identity, disabled rows, toggle semantics, and action
-rows without introducing a second query protocol.
+Search and the viewport affect TUI presentation only.
+RPC deliberately keeps one flat, unfiltered list of unique dialog choices, preserving raw identity, disabled rows, toggle semantics, and action rows without introducing a second query protocol.
 
 ```ts
 const tools = {
@@ -587,10 +561,9 @@ const tools = {
 };
 ```
 
-Disabled multi-select rows stay visible and focusable, use a textual `[-]`/`unavailable` marker, show
-`disabledReason` with the selected description, and never invoke the toggle handler. RPC exposes the
-same unavailable reason and safely returns to the screen when the row is selected. Keep policy and
-bulk-set validation in the consuming extension and revalidate it again before mutation.
+Disabled multi-select rows stay visible and focusable, use a textual `[-]`/`unavailable` marker, show `disabledReason` with the selected description, and never invoke the toggle handler.
+RPC exposes the same unavailable reason and safely returns to the screen when the row is selected.
+Keep policy and bulk-set validation in the consuming extension and revalidate it again before mutation.
 
 ## 🔌 Runtime and mode behavior
 
@@ -602,13 +575,13 @@ bulk-set validation in the consuming extension and revalidate it again before mu
 - `onError(ctx, error)` customizes observable failure reporting.
 - `onUnsupportedMode(ctx, mode)` provides print/JSON fallback behavior.
 
-In TUI mode the runtime uses `ctx.ui.custom()`. In RPC mode it adapts standard screens to
-`ctx.ui.select()` dialogs. Print and JSON modes never attempt custom UI and instead call the
-unsupported-mode hook. `runMenu()` resolves to `closed`, `unsupported`, `stale`, or `error`; only the
-`closed` result carries the mandatory interaction-level `reason`.
+In TUI mode the runtime uses `ctx.ui.custom()`.
+In RPC mode it adapts standard screens to `ctx.ui.select()` dialogs.
+Print and JSON modes never attempt custom UI and instead call the unsupported-mode hook.
+`runMenu()` resolves to `closed`, `unsupported`, `stale`, or `error`; only the `closed` result carries the mandatory interaction-level `reason`.
 
-Lifecycle handlers can opt into the shared `ExtensionContext` surface without a cast. Existing
-three-generic command menus keep `ExtensionCommandContext`, including command-only methods.
+Lifecycle handlers can opt into the shared `ExtensionContext` surface without a cast.
+Existing three-generic command menus keep `ExtensionCommandContext`, including command-only methods.
 
 ```ts
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
@@ -627,24 +600,20 @@ pi.on("agent_settled", async (_event, ctx) => {
 });
 ```
 
-The consumer must own and abort the session signal, check its generation or equivalent identity after
-every await, and never retain or use an `ExtensionContext` after session replacement, reload, or
-shutdown. The kit does not create lifecycle ownership for the extension. `input` uses a signal-aware
-RPC dialog; a multi-line `editor` screen is intentionally deferred because Pi's current RPC editor
-contract does not accept an `AbortSignal`.
+The consumer must own and abort the session signal, check its generation or equivalent identity after every await, and never retain or use an `ExtensionContext` after session replacement, reload, or shutdown.
+The kit does not create lifecycle ownership for the extension.
+`input` uses a signal-aware RPC dialog; a multi-line `editor` screen is intentionally deferred because Pi's current RPC editor contract does not accept an `AbortSignal`.
 
 ## 🧩 Ownership boundary
 
 Reuse Pi primitives and domain components from their package root whenever their public contract fits.
-Use non-exported Pi composites only as interaction references; never deep-import Pi's `dist/*`
-implementation paths. The kit owns a composite only when public controls do not provide the complete
-cross-mode and lifecycle contract shared by multiple extensions.
+Use non-exported Pi composites only as interaction references; never deep-import Pi's `dist/*` implementation paths.
+The kit owns a composite only when public controls do not provide the complete cross-mode and lifecycle contract shared by multiple extensions.
 
 The library owns:
 
 - standalone task-mode adaptation, cancellation, stale checks, error routing, and draining;
-- lifecycle ownership, disposal, and pending-work draining around live-choice and specialized custom
-  interactions;
+- lifecycle ownership, disposal, and pending-work draining around live-choice and specialized custom interactions;
 - width-safe standard rendering and injected keybindings;
 - screen-stack navigation, Back/Close semantics, and per-screen cursor memory;
 - serial settings and multi-select updates, optimistic rollback, and pending-update draining;
@@ -660,17 +629,15 @@ The consuming extension still owns:
 - transactional persistence and preservation of unknown settings fields;
 - confirmations and product-specific copy;
 - session generation and shutdown policy supplied through `isCurrent()`;
-- preview snapshots, rollback and persistence, multi-line editors, secret inputs, multi-field forms,
-  or other specialized custom TUI.
+- preview snapshots, rollback and persistence, multi-line editors, secret inputs, multi-field forms, or other specialized custom TUI.
 
 Keep specialized UI local rather than adding package hooks that expose Pi TUI internals.
 
 ## 🧪 Supported testing entrypoint
 
-The same npm package exposes test-only drivers from `@narumitw/pi-tui-kit/testing`; there is no
-second package to install. Keep production imports on the main entrypoint and import harnesses only
-from test code. The testing entrypoint drives Kit behavior through Pi's public custom-factory and RPC
-dialog boundaries without returning a raw component or creating a general `ExtensionContext` mock.
+The same npm package exposes test-only drivers from `@narumitw/pi-tui-kit/testing`; there is no second package to install.
+Keep production imports on the main entrypoint and import harnesses only from test code.
+The testing entrypoint drives Kit behavior through Pi's public custom-factory and RPC dialog boundaries without returning a raw component or creating a general `ExtensionContext` mock.
 
 Compose `createTuiHarness()` with the consumer's own context fixture:
 
@@ -697,11 +664,9 @@ const frame = tui.render();
 const result = await running;
 ```
 
-The TUI harness supports semantic Kit bindings, explicit raw input, Ctrl+C/Home/End, focus,
-invalidation, live width/row changes, render-request observations, pending-action draining,
-sequential screens, result observation, and external disposal. `done`, disposal, factory failure,
-and obsolete async openings settle exactly once; input after closure is inert. Supply optional
-callback-compatible theme/keybinding overrides only when a test needs them.
+The TUI harness supports semantic Kit bindings, explicit raw input, Ctrl+C/Home/End, focus, invalidation, live width/row changes, render-request observations, pending-action draining, sequential screens, result observation, and external disposal.
+`done`, disposal, factory failure, and obsolete async openings settle exactly once; input after closure is inert.
+Supply optional callback-compatible theme/keybinding overrides only when a test needs them.
 
 Use strict scripts for RPC:
 
@@ -724,12 +689,11 @@ await runMenu(rpcCtx, menu, options);
 rpc.assertConsumed();
 ```
 
-RPC steps match call kind and optional exact title, placeholder, or choices. Responses are exact raw
-strings or `undefined` cancellation; the harness never fuzzy-matches labels. A `waitForAbort: true`
-step supports owner-abort tests without a timer. Dialog records are immutable, unexpected or leftover
-steps fail observably, and any RPC request for custom TUI throws. The current Kit runtime uses only
-signal-aware `input()` and `select()` in RPC, so the testing entrypoint deliberately does not mock
-confirmations, editors, notifications, sessions, models, settings, filesystems, clocks, or networks.
+RPC steps match call kind and optional exact title, placeholder, or choices.
+Responses are exact raw strings or `undefined` cancellation; the harness never fuzzy-matches labels.
+A `waitForAbort: true` step supports owner-abort tests without a timer.
+Dialog records are immutable, unexpected or leftover steps fail observably, and any RPC request for custom TUI throws.
+The current Kit runtime uses only signal-aware `input()` and `select()` in RPC, so the testing entrypoint deliberately does not mock confirmations, editors, notifications, sessions, models, settings, filesystems, clocks, or networks.
 Consumer fixtures continue to own domain state, persistence, generation checks, and owner signals.
 
 ## 📚 Public API
@@ -737,31 +701,18 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `defineMenu()` — validates and returns a typed menu definition.
 - `runMenu()` — runs the definition in the current Pi mode and preserves root Back versus Close.
 - `runTask()` — runs typed abort-aware work with a cancellable TUI loader and direct non-TUI fallback.
-- `runConfirmation()` — preserves Confirmed, Back, Close, Stale, Unsupported, and Error for one
-  standalone confirmation without owning the confirmed side effect.
-- `runLiveChoice()` — adapts a live-preview choice to TUI and ordinary RPC selection while preserving
-  typed selection, confirmation-only gating, shortcuts, Back, Close, Stale, Unsupported, and Error.
-- `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and
-  literal shortcut keys for specialized interaction hints; the lightweight
-  `@narumitw/pi-tui-kit/interaction-hints` subpath exports it and its public types.
-- `sanitizeTerminalText()` — removes terminal and bidirectional display controls from untrusted
-  single-line presentation text without mutating raw payloads; the lightweight
-  `@narumitw/pi-tui-kit/terminal-text` subpath exports it.
-- `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending
-  work draining, and typed results around one extension-owned custom TUI component.
+- `runConfirmation()` — preserves Confirmed, Back, Close, Stale, Unsupported, and Error for one standalone confirmation without owning the confirmed side effect.
+- `runLiveChoice()` — adapts a live-preview choice to TUI and ordinary RPC selection while preserving typed selection, confirmation-only gating, shortcuts, Back, Close, Stale, Unsupported, and Error.
+- `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and literal shortcut keys for specialized interaction hints; the lightweight `@narumitw/pi-tui-kit/interaction-hints` subpath exports it and its public types.
+- `sanitizeTerminalText()` — removes terminal and bidirectional display controls from untrusted single-line presentation text without mutating raw payloads; the lightweight `@narumitw/pi-tui-kit/terminal-text` subpath exports it.
+- `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending work draining, and typed results around one extension-owned custom TUI component.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
 - `createMenuNavigator()` — lower-level stack and selection state helper.
-- exported screen, item, action, transition, runtime option, `BrowseDetailDocument`,
-  `MenuCloseReason`, and result types.
-- `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`,
-  strict scripts, and their public testing types; it is not re-exported from the production root.
+- exported screen, item, action, transition, runtime option, `BrowseDetailDocument`, `MenuCloseReason`, and result types.
+- `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`, strict scripts, and their public testing types; it is not re-exported from the production root.
 - `PI_EXTENSION_MENU_API_VERSION` — current API version (`13`).
-  Version 13 adds opt-in Markdown, LaTeX, and Mermaid document formatting while version-12 menu
-  definitions remain valid. Version 12 added optional searchable `choice` fields, version 11 added
-  Live Choice confirmation-only gating, version 10 added exact browse detail documents, version 9
-  added `runLiveChoice()` and `formatInteractionHints()`, version 8 added disabled action reasons and
-  adaptive action-label columns, version 7 added `runConfirmation()`, and version 6 added the
-  read-only `browse` screen and `runCustomInteraction()`.
+Version 13 adds opt-in Markdown, LaTeX, and Mermaid document formatting while version-12 menu definitions remain valid.
+Version 12 added optional searchable `choice` fields, version 11 added Live Choice confirmation-only gating, version 10 added exact browse detail documents, version 9 added `runLiveChoice()` and `formatInteractionHints()`, version 8 added disabled action reasons and adaptive action-label columns, version 7 added `runConfirmation()`, and version 6 added the read-only `browse` screen and `runCustomInteraction()`.
 
 ## 🗂️ Package layout
 
@@ -771,10 +722,8 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `src/task.ts` — standalone and menu-shared task lifecycle orchestration
 - `src/confirmation.ts` — standalone confirmation mode adaptation and lifecycle results
 - `src/live-choice.ts` — standalone live-choice TUI/RPC adaptation and preview-work ownership
-- `src/interaction-hints.ts` — injected-key and literal-shortcut hint formatting, published through
-  the lightweight `/interaction-hints` subpath
-- `src/terminal-text.ts` — terminal display sanitization published through the lightweight
-  `/terminal-text` subpath
+- `src/interaction-hints.ts` — injected-key and literal-shortcut hint formatting, published through the lightweight `/interaction-hints` subpath
+- `src/terminal-text.ts` — terminal display sanitization published through the lightweight `/terminal-text` subpath
 - `src/custom-interaction.ts` — lifecycle ownership for specialized public custom components
 - `dist/` — generated ESM and declarations included in the npm package
 - `test/` — contract, renderer, navigation, lifecycle, and public testing-entrypoint coverage

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -206,8 +206,8 @@ else if (confirmation.kind === "closed" && confirmation.reason === "close") retu
 ```
 
 TUI confirmation uses the standard bounded actions presentation: selecting the cancel row or pressing Escape returns `{ kind: "closed", reason: "back" }`, while Ctrl+C returns the same result with reason `"close"`.
-RPC uses one signal-aware `select()` request with explicit confirm and cancel rows;
-explicit cancel and protocol cancellation deterministically map to Back because Pi RPC does not expose a separate Ctrl+C dialog outcome.
+RPC uses one signal-aware `select()` request with explicit confirm and cancel rows.
+Explicit cancel and protocol cancellation deterministically map to Back because Pi RPC does not expose a separate Ctrl+C dialog outcome.
 Print and JSON return `unsupported`.
 Owner abort, session replacement, external TUI disposal, and failures remain distinct `stale` or `error` results.
 The Kit owns only this interaction lifecycle—the caller performs every confirmed side effect and must abort its owner signal on replacement or shutdown.
@@ -449,7 +449,7 @@ The kit owns this adapter because Pi's public `SettingsList` does not currently 
 
 Input screens submit through the existing action `value`.
 Validation, normalization, persistence, and product copy remain extension-owned.
-Rejection keeps the TUI draft available for correction;
+Rejection keeps the TUI draft available for correction.
 RPC reopens its signal-aware input dialog.
 
 ```ts

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -1,24 +1,21 @@
-# 📊 pi-usage — Provider Usage for Pi
+# 📊 pi-usage — Check Provider Usage and Codex Fast Mode
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-usage)](https://www.npmjs.com/package/@narumitw/pi-usage) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-usage` is a native [Pi coding agent](https://pi.dev) extension that adds an interactive `/usage` command for reading usage from the account Pi is actually using and a `/fast` shortcut for supported OpenAI Codex models. It supports Codex ChatGPT subscription windows, GitHub Copilot allowances, and OpenRouter API-key spend limits without pretending those limits have the same semantics.
+Check the limits and usage for the provider account Pi is actually using, and toggle Fast mode for supported OpenAI Codex models.
+
+The extension reports each provider's native semantics instead of presenting unlike quotas as equivalent.
 
 ## ✨ Features
 
-- Opens one interactive `/usage` menu with current state and next actions.
-- Automatically queries the selected model provider and active runtime account.
-- Supports OpenAI Codex subscription windows, resets, credits, and model-specific buckets.
-- Toggles persistent Codex Fast routing through `/fast` or the contextual `/usage` action.
-- Redeems earned Codex usage-limit resets for the active, matching Pi OAuth account with fresh availability, explicit confirmation, and idempotent retry.
-- Supports GitHub Copilot AI Credits, legacy premium requests, Free chat quota, additional usage, percentage, and reset time.
-- Supports OpenRouter per-key credit limits plus daily, weekly, monthly, and all-time spend.
-- Provides explicit refresh, another-provider, and all-configured-provider actions.
-- Runs manually requested all-provider queries with concurrency limited to two and preserves partial results.
-- Labels only the selected model provider as `Current`; other results are `Configured`.
-- Keeps the compact statusline scoped to the current provider and runtime account.
-- Isolates its five-minute in-memory cache by provider and a process-salted credential fingerprint.
-- Resolves runtime credentials through Pi; for Copilot only, reads Pi's stored OAuth credential through Pi's public credential API and verifies that it matches the active runtime account.
+- Shows current-account usage and next actions through `/usage`.
+- Supports OpenAI Codex subscription windows, credits, resets, and model-specific buckets.
+- Supports GitHub Copilot allowances and OpenRouter per-key limits and spend windows.
+- Toggles persistent Codex Fast routing through `/fast` or the contextual usage menu.
+- Redeems eligible Codex resets only after fresh account matching and explicit confirmation.
+- Refreshes one or all configured providers with bounded concurrency and partial-result preservation.
+- Keeps statusline and cache data scoped to the current provider and runtime account.
+- Resolves credentials through Pi and validates the effective provider endpoint before sending them.
 
 ## 📦 Install
 
@@ -56,8 +53,7 @@ Run:
 /usage
 ```
 
-In TUI or RPC mode, the standard menu first queries the current model provider and presents its state
-with these actions:
+In TUI or RPC mode, the standard menu first queries the current model provider and presents its state with these actions:
 
 ```text
 Refresh current usage
@@ -69,19 +65,16 @@ Close
 ```
 
 There are intentionally no `/usage --refresh`, `/usage <provider>`, or `/usage --all` argument paths.
-Cross-provider traffic requires an explicit interactive choice. Escape returns from provider selection
-and closes the root menu. Print and JSON modes reject `/usage` observably because they cannot host the
-interactive flow. The cancellable live-query progress view remains extension-owned because it streams
-provider work and supports in-flight abort rather than presenting a standard menu screen.
+Cross-provider traffic requires an explicit interactive choice.
+Escape returns from provider selection and closes the root menu.
+Print and JSON modes reject `/usage` observably because they cannot host the interactive flow.
+The cancellable live-query progress view remains extension-owned because it streams provider work and supports in-flight abort rather than presenting a standard menu screen.
 
-For the current OpenAI Codex provider, **Redeem usage limit reset…** checks fresh earned-reset
-details, lets you select a reset when details are available, and shows the exact reset before asking
-for confirmation. **No, go back** is the safe default and cancellation before confirmation sends no
-mutation. After confirmation, the reset operation cannot be cancelled from its progress view; session
-replacement or shutdown still aborts owned work. A transport failure offers **Try again** with the
-same redemption request ID so the backend can treat an uncertain retry idempotently. Successful,
-already-completed, not-needed, and no-credit outcomes are reported separately, then usage and the
-statusline are refreshed for the still-current account.
+For the current OpenAI Codex provider, **Redeem usage limit reset…** checks fresh earned-reset details, lets you select a reset when details are available, and shows the exact reset before asking for confirmation.
+**No, go back** is the safe default and cancellation before confirmation sends no mutation.
+After confirmation, the reset operation cannot be cancelled from its progress view; session replacement or shutdown still aborts owned work.
+A transport failure offers **Try again** with the same redemption request ID so the backend can treat an uncertain retry idempotently.
+Successful, already-completed, not-needed, and no-credit outcomes are reported separately, then usage and the statusline are refreshed for the still-current account.
 
 ## ⚙️ Settings
 
@@ -115,13 +108,13 @@ Repair or remove an invalid file, then run `/reload` before trying the toggle ag
 - Reset mutation: `POST /wham/rate-limit-reset-credits/consume` with a unique redemption request ID and, when available, the selected opaque credit ID
 - Statusline examples: `codex 59% 5h 61% wk`, `codex fast 59% 5h`, or `codex spark 100% 5h`
 
-The statusline selects a returned bucket that matches the current Codex model when one is available. Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.
+The statusline selects a returned bucket that matches the current Codex model when one is available.
+Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.
 
-Reset redemption is available only when Codex is the current provider and Pi's freshly resolved access
-token exactly matches its stored OpenAI Codex OAuth credential. `pi-usage` forwards only the bearer
-authorization and matching `chatgpt-account-id` to the official ChatGPT origin. API-key credentials,
-configured-but-not-current Codex accounts, account changes during the flow, and custom/proxy origins
-fail before mutation. Backend-provided titles and descriptions are sanitized for terminal display;
+Reset redemption is available only when Codex is the current provider and Pi's freshly resolved access token exactly matches its stored OpenAI Codex OAuth credential.
+`pi-usage` forwards only the bearer authorization and matching `chatgpt-account-id` to the official ChatGPT origin.
+API-key credentials, configured-but-not-current Codex accounts, account changes during the flow, and custom/proxy origins fail before mutation.
+Backend-provided titles and descriptions are sanitized for terminal display;
 opaque credit and account IDs are never shown or persisted by the extension.
 
 ### GitHub Copilot
@@ -132,7 +125,10 @@ opaque credit and account IDs are never shown or persisted by the extension.
 - Displayed data: entitlement, remaining allowance, percentage, reset time, plan, and any additional usage beyond the included allowance
 - Statusline examples: `copilot credits 1200/1500 80%`, `copilot 245/300 82%`, or `copilot chat 40/50 80%`
 
-GitHub's quota endpoint requires the original GitHub OAuth token rather than the short-lived Copilot inference token exposed by runtime auth. `pi-usage` therefore supports Copilot accounts created through Pi's `/login` flow, reads that stored credential through Pi's public API, and uses it only when its short-lived access token matches the active runtime credential. API-key credentials, account mismatches, GitHub Enterprise accounts, and proxy/custom provider origins fail closed. The detailed report follows the endpoint's `token_based_billing` marker so AI credits are not mislabeled as legacy premium requests, and it reports overage without treating a negative included balance as a malformed response.
+GitHub's quota endpoint requires the original GitHub OAuth token rather than the short-lived Copilot inference token exposed by runtime auth.
+`pi-usage` therefore supports Copilot accounts created through Pi's `/login` flow, reads that stored credential through Pi's public API, and uses it only when its short-lived access token matches the active runtime credential.
+API-key credentials, account mismatches, GitHub Enterprise accounts, and proxy/custom provider origins fail closed.
+The detailed report follows the endpoint's `token_based_billing` marker so AI credits are not mislabeled as legacy premium requests, and it reports overage without treating a negative included balance as a malformed response.
 
 ### OpenRouter
 
@@ -142,7 +138,8 @@ GitHub's quota endpoint requires the original GitHub OAuth token rather than the
 - Displayed data: key label when safely returned, optional per-key limit and remaining amount, reset period, and daily/weekly/monthly/all-time spend
 - Statusline examples: `openrouter $74.50 left` or `openrouter $25.50 used`
 
-The extension does not call OpenRouter's account-level `/credits` endpoint because that operation requires a separate management key. OpenRouter documents the distinction between credit and rate limits in its [API limits guide](https://openrouter.ai/docs/api_reference/limits).
+The extension does not call OpenRouter's account-level `/credits` endpoint because that operation requires a separate management key.
+OpenRouter documents the distinction between credit and rate limits in its [API limits guide](https://openrouter.ai/docs/api_reference/limits).
 
 ### OpenCode Go (Zen)
 
@@ -156,19 +153,25 @@ The usage endpoint is derived from the model's base URL (`…/zen/go/v1/usage`) 
 
 ## 🧭 Current and configured accounts
 
-`Current` means the provider and credential used by Pi's selected model. `Configured` means Pi reports runtime auth for another supported provider; it does not mean that provider is active.
+`Current` means the provider and credential used by Pi's selected model.
+`Configured` means Pi reports runtime auth for another supported provider; it does not mean that provider is active.
 
-The extension does not enumerate multiple accounts inside one provider and does not switch accounts. Account selection remains owned by Pi or an account-management extension. After the active runtime credential changes, the next command, turn, or scheduled refresh resolves auth again and cannot reuse another account's cached report.
+The extension does not enumerate multiple accounts inside one provider and does not switch accounts.
+Account selection remains owned by Pi or an account-management extension.
+After the active runtime credential changes, the next command, turn, or scheduled refresh resolves auth again and cannot reuse another account's cached report.
 
 ## 📊 Statusline behavior
 
-The `usage` status item is active only for the selected model provider. It refreshes every five minutes while the session remains on a supported provider and is cleared when the model changes to an unsupported provider.
+The `usage` status item is active only for the selected model provider.
+It refreshes every five minutes while the session remains on a supported provider and is cleared when the model changes to an unsupported provider.
 
-Manual another-provider and all-provider queries never publish to the statusline. `@narumitw/pi-statusline` supplies the default `📊` icon; `pi-usage` publishes text-only values.
+Manual another-provider and all-provider queries never publish to the statusline.
+`@narumitw/pi-statusline` supplies the default `📊` icon; `pi-usage` publishes text-only values.
 
 ## 🔄 Migrating from pi-codex-usage
 
-`pi-codex-usage` is deprecated and its source is archived under `deprecated/`. To migrate one installation:
+`pi-codex-usage` is deprecated and its source is archived under `deprecated/`.
+To migrate one installation:
 
 ```bash
 pi remove npm:@narumitw/pi-codex-usage
@@ -192,7 +195,8 @@ Behavior changes:
 - Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
-- A provider may not return a safe human-readable account identity. In that case the provider and runtime credential state remain visible without exposing secrets.
+- A provider may not return a safe human-readable account identity.
+  In that case the provider and runtime credential state remain visible without exposing secrets.
 - Immediate account-change events are not available from Pi; auth is re-resolved before commands, turns, and scheduled refreshes.
 - Fast model support is intentionally conservative and may require an extension update when Codex adds or removes service tiers.
 - Another later-loaded extension can replace the final provider payload, so arbitrary third-party payload-rewrite conflicts cannot be prevented.
@@ -234,4 +238,5 @@ Pi extension, Pi coding agent, usage, quota, OpenAI Codex usage, ChatGPT subscri
 
 ## 📄 License
 
-MIT. See [`LICENSE`](./LICENSE).
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -114,8 +114,8 @@ Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback 
 Reset redemption is available only when Codex is the current provider and Pi's freshly resolved access token exactly matches its stored OpenAI Codex OAuth credential.
 `pi-usage` forwards only the bearer authorization and matching `chatgpt-account-id` to the official ChatGPT origin.
 API-key credentials, configured-but-not-current Codex accounts, account changes during the flow, and custom/proxy origins fail before mutation.
-Backend-provided titles and descriptions are sanitized for terminal display;
-opaque credit and account IDs are never shown or persisted by the extension.
+Backend-provided titles and descriptions are sanitized for terminal display.
+Opaque credit and account IDs are never shown or persisted by the extension.
 
 ### GitHub Copilot
 

--- a/packages/pi-workflow/README.md
+++ b/packages/pi-workflow/README.md
@@ -1,33 +1,25 @@
-# 🧭 pi-workflow — Integrated Plan and Goal Workflow for Pi
+# 🧭 pi-workflow — Plan First, Then Execute with Goal Mode
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-workflow)](https://www.npmjs.com/package/@narumitw/pi-workflow) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-workflow` is a Pi extension that combines Codex-like Plan mode and persistent Goal execution in one independently installable package.
+Explore and approve an implementation plan, then hand the exact plan to persistent Goal execution in the same session or a fresh linked session.
 
-It keeps the established `/plan` and `/goal` command surfaces while making the approved Plan-to-Goal handoff one owned, recoverable transition.
+The extension combines the established `/plan` and `/goal` workflows into one recoverable Plan-to-Goal transition.
 
-Do not load this package together with `@narumitw/pi-plan-mode` or `@narumitw/pi-goal`.
-
-Those packages intentionally share command, tool, event-channel, and session-state compatibility names with this combined replacement.
+> [!IMPORTANT]
+> Do not load this package with `@narumitw/pi-plan-mode` or `@narumitw/pi-goal` because they intentionally share commands, tools, event channels, and session-state names.
 
 ## ✨ Features
 
-- Provides `/workflow`, `/plan`, and `/goal` from one extension.
-- Loads a generated split TypeScript runtime through Pi's Jiti loader, reducing startup module work while preserving first-use manager UI, Plan export, saved-plan preflight, and fresh-session handoff chunks.
-- Preserves Plan exploration, structured questions, completion, save, export, tool selection, and thinking-level control.
-- Supports an optional configurable global shortcut for toggling Plan mode, disabled by default.
-- Supports Plan alone, Goal alone, and approved Plan-to-Goal execution without adding a non-Goal implementation path.
-- Preserves Goal completion, blocking, external waits, pause, resume, edit, clear, token budgets, continuation guards, optional ordered queues, and managed-run RPC.
-- Uses review-first handoff by default, matching Codex's authoritative-plan and explicit-approval workflow.
-- Offers **Run with Goal** and **Start fresh with Goal** as the primary completed-plan actions.
-- Supports explicitly pre-authorized automatic handoff from Plan completion to Goal execution.
-- Sends one current-session implementation request containing the exact approved plan and Goal stale-turn contract.
-- Creates linked Plan and Goal state before a fresh-session kickoff.
-- Restores a ready Plan and clears provisional Goal state when current-session activation or delivery fails.
-- Leaves the source Plan resumable when fresh-session creation is cancelled or partially fails.
-- Prevents Plan and Goal from competing for active tools or automatic turns in one session.
-- Uses one optional, atomically published `pi-workflow.json` settings file.
-- Shows independent `workflow:plan` and `workflow:goal` status channels.
+- Provides `/workflow`, `/plan`, and `/goal` from one independently installable extension.
+- Supports planning alone, Goal execution alone, or an explicit approved Plan-to-Goal handoff.
+- Preserves structured Plan questions, completion, save, export, tool selection, and thinking-level control.
+- Preserves Goal completion, blockers, external waits, pause, resume, edit, clear, budgets, queues, and managed-run RPC.
+- Reviews handoffs by default and offers execution in the current conversation or a fresh linked session.
+- Restores the ready Plan when activation, delivery, or fresh-session creation fails or is cancelled.
+- Prevents Plan and Goal from competing for tools or automatic turns.
+- Stores optional settings atomically and reports Plan and Goal status independently.
+- Loads a generated split runtime while preserving lazy manager, export, preflight, and handoff chunks.
 
 ## 📦 Install
 
@@ -325,7 +317,7 @@ Fresh-session handoff serializes both states before sending the implementation r
 
 Session replacement, reload, and shutdown abort owned menus and release timers, statuses, widgets, pending prompts, and continuation work.
 
-## ⚠️ Safety and limitations
+## 🔒 Security and privacy
 
 Plan mode's shell policy reduces accidental mutation but is not an operating-system sandbox.
 
@@ -336,6 +328,8 @@ Goal completion relies on the model's evidence audit plus stale-ID and contradic
 Automatic Goal work can consume substantial tokens and provider cost.
 
 Keep finite safety limits unless unlimited execution is an informed choice.
+
+## 🚧 Limitations
 
 This package owns source snapshots of the stable Plan and Goal implementations so it remains independently installable.
 

--- a/packages/pi-worktree/README.md
+++ b/packages/pi-worktree/README.md
@@ -1,27 +1,20 @@
-# 🌳 pi-worktree — Safe Git Worktree Management for Pi
+# 🌳 pi-worktree — Create, Switch, and Remove Git Worktrees in Pi
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-worktree)](https://www.npmjs.com/package/@narumitw/pi-worktree) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-`@narumitw/pi-worktree` adds one interactive `/worktree` command for common Git worktree operations and Pi workspace switching.
+Create, inspect, switch, remove, and prune Git worktrees through one guarded `/worktree` manager.
 
-Pi cannot change its parent process working directory with `cd`. This extension performs the safe equivalent: it prepares a Pi session whose cwd is the selected worktree and switches to that session, preserving the current conversation when it has already been persisted.
+Because Pi cannot change its parent process directory with `cd`, the extension switches to a prepared Pi session whose cwd is the selected worktree and preserves the current conversation when possible.
 
 ## ✨ Features
 
-- Shows compact main, linked, current, detached, locked, and prunable state in worktree selectors.
-- Provides an on-demand, searchable status snapshot with staged, unstaged, untracked, conflict, upstream, and last-commit details.
-- Creates a new branch worktree or attaches an existing unoccupied local branch.
-- Previews the exact local base source and full commit OID before creation.
-- Rejects occupied targets and unresolvable symbolic-link ancestors before Git can create a branch.
-- Suggests `~/.worktrees/<main-worktree-name>/<branch>` by default and lets the user configure the root interactively.
-- Optionally switches Pi into a newly created worktree while continuing the current conversation.
-- Switches among existing registered worktrees through Pi's public session replacement API.
-- Removes unlocked, non-current linked worktrees and preserves their branches.
-- Refuses removal when tracked, untracked, manually index-flagged, submodule, or current unreachable detached-commit data may be lost.
-- Allows ignored-only data such as `node_modules/` after listing it in the destructive confirmation.
-- Names recovery-only administrative commits in the destructive confirmation instead of making ordinary rebase/reset history block cleanup forever.
-- Always previews stale metadata before pruning it and revalidates the preview after confirmation.
-- Runs Git through argv-based subprocess calls, without interpolating user input into shell commands.
+- Lists main, linked, current, detached, locked, and prunable worktrees with searchable status details.
+- Creates a worktree from a new branch or an unoccupied local branch after previewing the exact base commit.
+- Suggests a configurable path under `~/.worktrees/` and rejects unsafe, occupied, or ambiguous targets.
+- Switches Pi to an existing or newly created worktree while preserving the conversation when possible.
+- Removes only non-current unlocked worktrees after checking tracked, untracked, index, submodule, and detached-commit risk.
+- Previews ignored files and stale metadata before confirmed removal or pruning, then revalidates the plan.
+- Runs Git with argument arrays and never interpolates user input into shell commands.
 
 ## 📦 Install
 
@@ -63,28 +56,31 @@ Choose one action:
 - **Prune stale metadata** — inspect Git's dry-run output, then optionally run the matching prune.
 - **Configure worktree root** — set a machine-local default root or submit a blank value to restore `~/.worktrees`.
 
-The standard root menu shows the registered count, current path, effective worktree root, its source,
-and any settings warning. Escape closes it. `/worktree` intentionally does not accept text
-subcommands or expose argument autocomplete. Every change is initiated and confirmed through TUI or
-RPC dialogs; print and JSON modes reject the command observably. Operation-specific branch/path
-inputs, searchable worktree identity selectors, preflight previews, and destructive confirmations remain
-extension-owned because they carry Git safety and commit-aware revalidation.
+The standard root menu shows the registered count, current path, effective worktree root, its source, and any settings warning.
+Escape closes it.
+`/worktree` intentionally does not accept text subcommands or expose argument autocomplete.
+Every change is initiated and confirmed through TUI or RPC dialogs; print and JSON modes reject the command observably.
+Operation-specific branch/path inputs, searchable worktree identity selectors, preflight previews, and destructive confirmations remain extension-owned because they carry Git safety and commit-aware revalidation.
 
-The status browser runs only when selected and has no watcher, timer, persistent cache, or network
-fetch. Each card shows textual current/main/detached state, full snapshot HEAD, aggregate working-tree
-counts, configured upstream ahead/behind, and the last commit timestamp and subject. A missing
-upstream is reported as **not configured**; it is not treated as proof that no commits are unpushed.
+The status browser runs only when selected and has no watcher, timer, persistent cache, or network fetch.
+Each card shows textual current/main/detached state, full snapshot HEAD, aggregate working-tree counts, configured upstream ahead/behind, and the last commit timestamp and subject.
+A missing upstream is reported as **not configured**; it is not treated as proof that no commits are unpushed.
 Bare, missing, prunable, or individually failing worktrees remain visible with an unavailable reason.
-The snapshot is informational and can become stale immediately, so Remove still performs its stricter
-inventory and identity checks.
+The snapshot is informational and can become stale immediately, so Remove still performs its stricter inventory and identity checks.
 
 ## 🌿 Add defaults
 
-For a new branch, the current symbolic branch is the default start point. If Pi is running from detached HEAD, the command requires an explicit commit-ish. Git must resolve the start point to exactly one commit.
+For a new branch, the current symbolic branch is the default start point.
+If Pi is running from detached HEAD, the command requires an explicit commit-ish.
+Git must resolve the start point to exactly one commit.
 
-Before mutation, Add identifies whether the branch is new or existing and displays the provenance as the current branch, an explicit commit-ish, or an existing local branch together with its full resolved OID and target path. New branches are created from that approved OID even if the source ref later moves. Existing branches are checked again immediately before mutation and the created worktree HEAD is verified afterward. Git has no atomic compare-and-add operation for attaching an existing branch, so a post-add mismatch is retained for inspection rather than rolled back.
+Before mutation, Add identifies whether the branch is new or existing and displays the provenance as the current branch, an explicit commit-ish, or an existing local branch together with its full resolved OID and target path.
+New branches are created from that approved OID even if the source ref later moves.
+Existing branches are checked again immediately before mutation and the created worktree HEAD is verified afterward.
+Git has no atomic compare-and-add operation for attaching an existing branch, so a post-add mismatch is retained for inspection rather than rolled back.
 
-The default root is `~/.worktrees`, where `~` is Node's platform home directory. Suggestions use the registered main worktree's directory name, not the current linked-worktree cwd:
+The default root is `~/.worktrees`, where `~` is Node's platform home directory.
+Suggestions use the registered main worktree's directory name, not the current linked-worktree cwd:
 
 ```text
 main worktree: /home/user/workspace/project
@@ -93,9 +89,14 @@ root:          /home/user/.worktrees
 suggested:     /home/user/.worktrees/project/feat-login
 ```
 
-On Windows, the equivalent default is such as `C:\Users\Alice\.worktrees`. Branch `/` characters become `-`. The extension does not add hashes or collision suffixes: if two normalized paths collide or the target already exists, Add stops before Git mutation.
+On Windows, the equivalent default is such as `C:\Users\Alice\.worktrees`.
+Branch `/` characters become `-`.
+The extension does not add hashes or collision suffixes: if two normalized paths collide or the target already exists, Add stops before Git mutation.
 
-Leave the path input blank to accept the suggestion. A custom absolute path is used directly; a custom relative path is resolved from the current Pi cwd. The target itself must not exist, and its nearest existing ancestor must resolve without a broken or looping symbolic link. Existing registered worktrees are never moved when this default changes.
+Leave the path input blank to accept the suggestion.
+A custom absolute path is used directly; a custom relative path is resolved from the current Pi cwd.
+The target itself must not exist, and its nearest existing ancestor must resolve without a broken or looping symbolic link.
+Existing registered worktrees are never moved when this default changes.
 
 The MVP does not expose `--force`, `-B`, `--detach`, `--orphan`, or lock options.
 
@@ -107,7 +108,8 @@ The machine-local user settings file is:
 <getAgentDir()>/pi-worktree.json
 ```
 
-For a default Pi installation this is typically `~/.pi/agent/pi-worktree.json`. Configure it through **Configure worktree root** or edit it manually:
+For a default Pi installation this is typically `~/.pi/agent/pi-worktree.json`.
+Configure it through **Configure worktree root** or edit it manually:
 
 ```json
 {
@@ -115,37 +117,54 @@ For a default Pi installation this is typically `~/.pi/agent/pi-worktree.json`. 
 }
 ```
 
-`worktreeRoot` accepts `~`, a home-prefixed path such as `~/worktrees`, or a native-platform absolute path. It does not expand `$VAR`, `%VAR%`, or other shell syntax. Empty, relative, NUL-containing, non-string, and invalid paths are rejected. There is no project override or extension-specific environment variable.
+`worktreeRoot` accepts `~`, a home-prefixed path such as `~/worktrees`, or a native-platform absolute path.
+It does not expand `$VAR`, `%VAR%`, or other shell syntax.
+Empty, relative, NUL-containing, non-string, and invalid paths are rejected.
+There is no project override or extension-specific environment variable.
 
-A missing `worktreeRoot` uses `~/.worktrees`; the settings file is created only by a successful interactive change. Submitting a blank value in the interactive action removes the override. Within one Pi process, queued saves run in invocation order, reread the latest valid document immediately before merging `worktreeRoot`, and preserve concurrent unknown-field edits. Settings reload on every `session_start`, including `/reload` and workspace replacement; a successful interactive save applies immediately to the next Add flow.
+A missing `worktreeRoot` uses `~/.worktrees`; the settings file is created only by a successful interactive change.
+Submitting a blank value in the interactive action removes the override.
+Within one Pi process, queued saves run in invocation order, reread the latest valid document immediately before merging `worktreeRoot`, and preserve concurrent unknown-field edits.
+Settings reload on every `session_start`, including `/reload` and workspace replacement; a successful interactive save applies immediately to the next Add flow.
 
-Malformed or invalid settings are warned about but never overwritten, including an invalid edit made while a settings action is open. An initial failure uses `~/.worktrees`; a later failure retains the last valid effective root. Interactive configuration remains blocked until the invalid file is fixed manually. Failed publication leaves the prior file and effective runtime root unchanged, and the save queue remains usable after rejection.
+Malformed or invalid settings are warned about but never overwritten, including an invalid edit made while a settings action is open.
+An initial failure uses `~/.worktrees`; a later failure retains the last valid effective root.
+Interactive configuration remains blocked until the invalid file is fixed manually.
+Failed publication leaves the prior file and effective runtime root unchanged, and the save queue remains usable after rejection.
 
 ## 🔀 Pi workspace switching
 
 Switching uses Pi's public `SessionManager` and `ctx.switchSession()` APIs:
 
 1. The command waits for Pi to become fully idle so the current assistant/tool results are persisted.
-2. A linear persisted session is forked into the target worktree. If `/tree` currently points at an older branch, the documented session entries for that active branch are written to the target instead, so switching cannot jump to a newer serialized leaf.
+2. A linear persisted session is forked into the target worktree.
+   If `/tree` currently points at an older branch, the documented session entries for that active branch are written to the target instead, so switching cannot jump to a newer serialized leaf.
 3. Pi tears down the old cwd-bound runtime and creates the target runtime.
 4. The extension reports success only through the fresh replacement-session context.
 
-If the current session is completely empty, the extension creates a valid empty Pi session for the target. If the current session is ephemeral (`--no-session`), the extension copies its active conversation branch into a persisted target session so the workspace switch does not lose context.
+If the current session is completely empty, the extension creates a valid empty Pi session for the target.
+If the current session is ephemeral (`--no-session`), the extension copies its active conversation branch into a persisted target session so the workspace switch does not lose context.
 
-A successfully created Git worktree is never rolled back merely because Pi session switching fails. Re-run `/worktree` and choose **Switch worktree** after resolving the reported Pi/session issue.
+A successfully created Git worktree is never rolled back merely because Pi session switching fails.
+Re-run `/worktree` and choose **Switch worktree** after resolving the reported Pi/session issue.
 
 ## 🛡️ Safety boundaries
 
 - The main worktree and current worktree cannot be removed.
 - Locked or stale worktrees cannot be removed through this extension.
-- Dirty, untracked, initialized-submodule, and intentional `assume-unchanged`/`skip-worktree` index state causes removal to fail closed. Sparse-checkout-managed `skip-worktree` entries outside the active sparsity rules are allowed when Git's rule checker can confirm them; clear other intentional index flags before removing the worktree.
-- Ignored-only files and directories do not block removal. The confirmation lists them, and the extension rechecks the exact ignored inventory before Git deletes the worktree.
+- Dirty, untracked, initialized-submodule, and intentional `assume-unchanged`/`skip-worktree` index state causes removal to fail closed.
+  Sparse-checkout-managed `skip-worktree` entries outside the active sparsity rules are allowed when Git's rule checker can confirm them; clear other intentional index flags before removing the worktree.
+- Ignored-only files and directories do not block removal.
+  The confirmation lists them, and the extension rechecks the exact ignored inventory before Git deletes the worktree.
 - A detached HEAD must be reachable from a local branch, tag, or remote ref before removal or prune.
-- Removal and prune inspect reflogs, pseudorefs, per-worktree refs, and `FETCH_HEAD`. Historical commits reachable only through this administrative recovery state are listed by full OID in the destructive confirmation; approval removes those recovery pointers, so Git may later garbage-collect the commits. Create a branch or tag instead when any listed commit should survive.
+- Removal and prune inspect reflogs, pseudorefs, per-worktree refs, and `FETCH_HEAD`.
+  Historical commits reachable only through this administrative recovery state are listed by full OID in the destructive confirmation; approval removes those recovery pointers, so Git may later garbage-collect the commits.
+  Create a branch or tag instead when any listed commit should survive.
 - Staged-only administrative index state, a missing attached branch ref, or an unreachable current detached HEAD still blocks prune without an override.
 - Removal never deletes a branch and never uses `--force`.
 - Remove invokes only argv-based `git worktree remove <path>`; production runtime never invokes a shell, `rm`, `rm -rf`, or a Node filesystem directory-deletion API for worktrees.
-- Prune always runs `git worktree prune --dry-run --verbose` before confirmation, inspects candidates omitted from porcelain, rechecks the exact preview and recovery-risk set after confirmation, and uses Git's default expiry. Remove likewise rechecks worktree identity, inventory, administrative path, and the approved recovery-risk set before mutation.
+- Prune always runs `git worktree prune --dry-run --verbose` before confirmation, inspects candidates omitted from porcelain, rechecks the exact preview and recovery-risk set after confirmation, and uses Git's default expiry.
+  Remove likewise rechecks worktree identity, inventory, administrative path, and the approved recovery-risk set before mutation.
 - The status browser uses only local Git state and never fetches a remote; its cards never authorize Remove or Prune.
 - The extension does not commit, push, fetch, rebase, repair, move, lock, or unlock worktrees.
 


### PR DESCRIPTION
## Summary

- rewrite every active package README title and introduction so users can identify the package purpose immediately
- condense Features sections to 5–10 outcome-focused bullets while preserving detailed behavior, compatibility, safety, recovery, and lifecycle guidance
- shorten dense Quick start sections and move deeper workflows into clearly named follow-up sections
- normalize applicable Security and privacy and Limitations headings
- format prose with one sentence per source line across all 27 READMEs

## Verification

- fenced-code-aware structure and section-order audit: 27/27 passed
- purpose-title, concise-Features, and one-sentence-per-line audits passed
- command and tool headings match source registrations
- experimental lifecycle warning audit passed
- `npm run format`
- `npm run check`
- `npm test` — 383 files and 3,628 tests passed
- `git diff --check`

## Release and smokes

- no changeset because this is documentation-only
- package pack and Pi runtime smokes are not applicable because package metadata and runtime loading are unchanged
