### PR TITLE
feat(starship): add transparent configuration reload

### DIFF
--- a/.changeset/bright-stars-reload.md
+++ b/.changeset/bright-stars-reload.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-starship": minor
+---
+
+Add nested configuration views for effective public TOML and the exact loaded settings document, plus a validated preview-and-confirm reload workflow for external edits and file removal.

--- a/docs/roadmaps/2026-08-02_pi-starship-command-capabilities-roadmap.md
+++ b/docs/roadmaps/2026-08-02_pi-starship-command-capabilities-roadmap.md
@@ -8,7 +8,7 @@ the footer. Follow the useful intent of upstream Starship commands—especially 
 render, lifecycle, privacy, and settings boundaries.
 
 **Current roadmap status:** Phases 1–4 are delivered on `main` and available from the published package.
-Phase 5 has verified implementation in the current change but remains unchecked until merge evidence is recorded.
+Phase 5 has verified implementation in PR #863 but remains unchecked until merge evidence is recorded.
 Phases 6–8 remain planned and have no complete implementation.
 
 ## Objectives

--- a/docs/roadmaps/2026-08-02_pi-starship-command-capabilities-roadmap.md
+++ b/docs/roadmaps/2026-08-02_pi-starship-command-capabilities-roadmap.md
@@ -7,8 +7,9 @@ the footer. Follow the useful intent of upstream Starship commands—especially 
 `print-config`, `toggle`, and `bug-report`—without cloning shell-only commands or weakening Pi's
 render, lifecycle, privacy, and settings boundaries.
 
-**Current roadmap status:** Phases 1–4 are delivered on `main` and available from the published
-package. Phases 5–7 remain planned and have no complete implementation.
+**Current roadmap status:** Phases 1–4 are delivered on `main` and available from the published package.
+Phase 5 has verified implementation in the current change but remains unchecked until merge evidence is recorded.
+Phases 6–8 remain planned and have no complete implementation.
 
 ## Objectives
 
@@ -18,16 +19,14 @@ package. Phases 5–7 remain planned and have no complete implementation.
 - **Make all supported modules discoverable** — Success after Phase 3: every catalog module appears
   once with a non-color state, current preview when available, and an accurate reason when it is not
   showing.
-- **Make configuration state transparent** — Success after Phase 5: users can distinguish overview,
-  raw document, and computed public configuration; every read-only path creates zero files, and a
-  failed reload preserves the last valid effective footer.
+- **Make configuration state transparent** — Success after Phase 5: users can distinguish overview, the exact loaded settings text, and effective public configuration.
+  Every read-only path creates zero files, deleting the settings document can be previewed as a valid transition to built-in defaults, and every failed or cancelled reload preserves the last valid effective footer.
 - **Keep mutations truthful and recoverable** — Success after Phase 6: no action conflates module
   `disabled` state with root-format reachability, and every approved mutation retains preview,
   confirmation, atomic publication, rollback, and unknown-field protection.
-- **Improve support without collecting telemetry** — Success after Phase 7: users can review a
-  bounded, sanitized diagnostic report locally; performance data appears only if collector timing
-  can be measured and labelled accurately. Adoption targets remain TBD because the repository has no
-  telemetry or grounded usage baseline.
+- **Improve support without collecting telemetry** — Success after Phase 7: users can review a bounded, sanitized diagnostic report locally without an automatic network request.
+- **Keep performance claims truthful** — Success after Phase 8: an evidence-backed decision either delivers accurately labelled asynchronous collector health measurements or rejects the view as non-actionable.
+  Adoption targets remain TBD because the repository has no telemetry or grounded usage baseline.
 
 ## Current State
 
@@ -44,9 +43,8 @@ package. Phases 5–7 remain planned and have no complete implementation.
 - The renderer's grouped output feeds a catalog that owns module names, descriptions, variables,
   defaults, options, and ordering. One pure inspection model combines those entries with effective
   config, root reachability, and the current immutable runtime snapshot for Explain and Modules.
-- Configuration currently presents state, source, path, health, and bounded diagnostics.
-  Loading retains both normalized effective config and the original document, but there is no public
-  computed-config projection, raw-document viewer, or safe reload-from-disk workflow.
+- Configuration now separates Overview, Effective configuration, Settings document, and Reload from disk on one nested level.
+  The effective projection is catalog-ordered public TOML, the loaded UTF-8 document stays separate and terminal-safe at the display boundary, and reload previews a final revalidated disk snapshot without writing files.
 - `/starship settings`, `/starship status`, and `/starship help` remain the only direct routes.
   Print and JSON modes intentionally emit no ad hoc command output; RPC uses notifications rather
   than custom terminal UI.
@@ -131,44 +129,39 @@ that absence means disabled. The state model provides the prerequisite for hones
 **Outcome:** Users can safely start from recognizable visual styles without shell integration,
 remote data, hidden writes during browsing, or weaker recovery behavior.
 
-### Phase 5: Make configuration transparent
+### Phase 5: Separate written and effective configuration
 
-- [ ] **Configuration** becomes one coherent section containing Overview, Computed configuration,
-  Settings document, and Reload from disk while the top-level menu remains at seven or fewer goals.
-- [ ] Computed configuration deterministically projects only public TOML fields from normalized
-  effective state and clearly excludes comments and unknown fields; Settings document presents the
-  byte-preserving raw source through a terminal-safe read-only view and explains a healthy
-  missing-file state.
-- [ ] Reload from disk validates and previews external changes, applies only a valid current
-  generation, creates no file, and preserves the prior effective footer on absence, invalid input,
-  cancellation, replacement, shutdown, or apply failure.
+- [ ] **Configuration** becomes one coherent section containing Overview, Effective configuration, Settings document, and Reload from disk while the top-level menu remains at seven or fewer goals.
+- [ ] Effective configuration deterministically projects every recognized public TOML field from normalized effective state in stable catalog order and excludes comments, unknown fields, ASTs, and private runtime selectors.
+- [ ] Settings document presents the exact loaded UTF-8 text through a terminal-safe read-only view, sanitizes only at the display boundary, and explains the healthy state in which no settings document exists.
+- [ ] Reload from disk validates and previews the current external state, applies only after confirmation in a valid current generation, and creates no file.
+  A missing document is a valid previewable transition to built-in defaults, while read or parse failure, cancellation, replacement, shutdown, or apply failure preserves the prior effective footer.
 
-**Outcome:** Users can distinguish what they wrote from what pi-starship is using and can safely apply
-external edits without reloading the whole Pi session.
+**Outcome:** Users can distinguish what they wrote from what pi-starship is using and can safely apply external edits or deliberate file removal without reloading the whole Pi session.
 
-### Phase 6: Make module changes unambiguous
+### Phase 6: Decide whether module changes can be safe
 
-- [ ] A documented module-action contract decides separately how `disabled` and root-format
-  reachability change, including what happens to `$all`, duplicate references, comments, custom root
-  expressions, and modules whose collectors have lifecycle cost.
-- [ ] Only actions approved by that contract are exposed from module detail, with accurate resulting
-  state, adaptive preview, explicit confirmation, atomic publication, runtime apply, rollback,
-  cancellation, and stale-session protection.
+- [ ] A documented go/no-go module-action contract decides separately how `disabled` and root-format reachability change, including what happens to `$all`, duplicate references, comments, document layout, unknown fields, custom root expressions, and modules whose collectors have lifecycle cost.
+  The decision approves only actions supported by a verified lossless TOML mutation path or records that module browsing remains read-only.
+- [ ] Every approved action is exposed from module detail with accurate resulting state, adaptive preview, explicit confirmation, serialized atomic publication, runtime apply, rollback, cancellation, and stale-session protection.
+  If no action is approved, the phase closes with the documented no-go evidence instead of weakening document preservation.
 
-**Outcome:** Structured module actions can be trusted to produce the visible result they promise
-rather than copying upstream `toggle` into a different format/reachability model.
+**Outcome:** pi-starship either offers module actions that produce the visible result they promise without damaging the settings document or retains an explicitly read-only module browser.
 
 ### Phase 7: Make support evidence safe and actionable
 
-- [ ] **Help & support** can produce a local preview of a bounded diagnostic report containing only
-  allowlisted version, configuration-state, sanitized diagnostic, module-state, and collector-health
-  fields; sharing or opening an issue always requires a separate explicit user action.
-- [ ] A performance view is either delivered from bounded collector duration/age/failure
-  instrumentation or explicitly rejected after measurement proves it non-actionable; it is never
-  labelled as upstream-style module timings when it measures asynchronous Pi collectors.
+- [ ] **Help & support** can produce a local preview of a bounded diagnostic report containing only allowlisted version, configuration-state, sanitized diagnostic, module-state, and collector-health fields.
+- [ ] Sharing, opening documentation, or opening an issue always requires a separate explicit user action, and report generation makes no automatic network request.
 
-**Outcome:** Users can diagnose and report problems with useful local evidence without hidden
-telemetry, accidental disclosure, or misleading timing semantics.
+**Outcome:** Users can diagnose and report problems with useful local evidence without hidden telemetry or accidental disclosure.
+
+### Phase 8: Decide whether collector performance evidence is actionable
+
+- [ ] A demand and measurement review decides whether bounded collector duration, age, and failure instrumentation would produce actionable support evidence without adding render-time work.
+- [ ] The resulting decision either delivers accurately labelled asynchronous collector health measurements or records why the view is rejected.
+  Delivered measurements are never labelled as upstream-style module timings.
+
+**Outcome:** Performance information is either trustworthy and useful or deliberately absent rather than misleading.
 
 ## Proposed Information Architecture
 
@@ -180,7 +173,7 @@ telemetry, accidental disclosure, or misleading timing semantics.
 ├─ Modules
 ├─ Configuration
 │  ├─ Overview
-│  ├─ Computed configuration
+│  ├─ Effective configuration
 │  ├─ Settings document
 │  └─ Reload from disk
 ├─ Help & support
@@ -200,10 +193,10 @@ Prompt preview is not planned because Pi already displays the footer continuousl
 | `config` | Keep transactional Customize; add safe external reload | Existing / Phase 5 |
 | `explain` | Explain currently rendered Pi modules | Phase 2 |
 | `module` | Search, inspect, and preview one Pi module | Phase 3 |
-| `print-config` | Show a read-only public computed-config projection | Phase 5 |
+| `print-config` | Show a read-only public effective-config projection | Phase 5 |
 | `toggle` | Separate disabled state from root-format reachability | Phase 6 |
 | `bug-report` | Preview a sanitized local support report | Phase 7 |
-| `timings` | Measure Pi collectors only if instrumentation is actionable | Phase 7 gate |
+| `timings` | Decide whether asynchronous Pi collector measurements are actionable | Phase 8 gate |
 | `prompt` | Integrate current preview into Explain footer | Phase 2 |
 | `preset` | Browse and transactionally apply bundled Pi-native adaptations | Phase 4 |
 | `completions`, `init`, `session`, `statusline` | Exclude shell/provider lifecycle commands | Non-goal |
@@ -217,7 +210,8 @@ Prompt preview is not planned because Pi already displays the footer continuousl
 | I/O started by footer/explanation rendering | 0 | 0 | Source audit and collector-spy tests |
 | Files created by read-only command paths | 0 | 0 | Missing-directory/filesystem tests |
 | Files changed by preset browsing or cancellation | 0 | 0 | Preset UX and lifecycle tests |
-| Public computed-config fields | No projection | Public TOML fields only; no AST/private runtime data | Serialization contract tests |
+| Public effective-config fields | No projection | Every recognized public TOML field in stable catalog order; no AST/private runtime data | Serialization contract tests |
+| Missing-document reload | Not available | Previewable built-in transition with 0 files created | Settings/lifecycle tests |
 | Invalid/cancelled reload changes | Not available | 0 file bytes and 0 effective-state changes | Settings/lifecycle tests |
 | Sensitive or raw content in diagnostic report | No report | 0 excluded fields; 0 automatic network requests | Allowlist/redaction tests |
 | Adoption and task-completion rate | Unknown; no telemetry | TBD only if privacy-compatible evidence exists | No current measurement source |
@@ -228,9 +222,10 @@ Prompt preview is not planned because Pi already displays the footer continuousl
 | --- | --- | --- |
 | Catalog descriptions or state semantics drift from rendering | Explain and Modules could become inconsistent with the footer | Keep metadata catalog-owned and retain render/inspection parity plus exhaustive catalog tests. |
 | Per-module chunks do not alone explain root reachability or empty values | A browser could mislabel modules | Keep the shared inspection model derived from effective config, root variables, and the same rendered result. |
-| Computed config contains ASTs or private selectors internally | Output could expose invalid/non-public schema | Serialize through an explicit public projection; keep raw document as a separate byte-preserving view. |
+| Effective config contains ASTs or private selectors internally | Output could expose invalid/non-public schema | Serialize through an explicit public projection; keep the exact loaded UTF-8 settings text as a separate read-only view. |
 | `disabled` and explicit root format are independent | A copied `toggle` action could promise visibility without producing it | Gate Phase 6 on a documented two-axis action contract and preview the resulting footer. |
-| Collectors have asynchronous cost while rendering is pure | Upstream `timings` semantics would be misleading | Instrument collector age/duration separately or reject the feature. |
+| The current TOML parser does not provide lossless document mutation | Structured actions could erase comments, layout, or unknown fields | Require a verified lossless mutation path for every approved Phase 6 action; otherwise keep Modules read-only. |
+| Collectors have asynchronous cost while rendering is pure | Upstream `timings` semantics would be misleading | Use the Phase 8 demand and measurement gate to instrument collector health separately or reject the feature. |
 | Diagnostic context can contain paths, remotes, config, or terminal controls | Support output could leak data or inject terminal content | Use bounded allowlisted fields, sanitize at the display boundary, and preview before sharing. |
 | Applying a complete preset replaces custom settings, unknown fields, and comments | Users could lose document-specific customization | Preview the resulting footer, disclose complete replacement, require separate confirmation, and retain rollback on failure. |
 | Zero-major pi-tui-kit ranges intentionally do not follow workspace minors | Consumers can miss newer shared lifecycle and keybinding behavior | Raise each consumer's compatibility floor only through a manually reviewed dependency change and verify its resolved package. |
@@ -250,6 +245,8 @@ Prompt preview is not planned because Pi already displays the footer continuousl
 - **2026-08-08 — Deliver presets and release:** PR #629 adds the full bundled preset catalog and live
   preview workflow. The subsequent release publishes the current command surface, removing the prior
   source-versus-registry availability gap.
+- **2026-08-21 — Clarify the remaining gates:** Phase 5 now treats deliberate settings-file removal as a previewable transition to built-in defaults and describes the raw view as exact loaded UTF-8 text rather than byte-preserving storage.
+  Phase 6 requires verified lossless TOML mutation or an explicit no-go decision, and collector performance evidence moves to its own Phase 8 gate so safe local diagnostics do not depend on speculative instrumentation.
 
 ## Non-Goals
 
@@ -275,6 +272,6 @@ Prompt preview is not planned because Pi already displays the footer continuousl
 - Explainability and discovery are assumed to be more valuable and lower risk than immediate module
   mutation because they build on existing renderer/catalog data and do not write settings.
 - Demand for structured toggles, collector performance diagnostics, and issue creation is unknown.
-  Their scope must remain gated rather than inferred from upstream Starship's CLI.
+  Their scope must remain gated rather than inferred from upstream Starship's CLI; as of 2026-08-21, the repository has no open starship issue establishing those capabilities as urgent.
 - New direct routes such as `/starship explain` or `/starship module` are not assumed. Menu-first TUI
   delivery should precede any RPC/non-TUI protocol decision with a concrete automation use case.

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -82,8 +82,15 @@ Its textual states distinguish **Showing**, **Empty**, **Disabled**, **Not in fo
 Module detail shows the current preview when available, description, root reference and reachability, format variables, style fields, display rules, and the known reason for absent output.
 Both views are read-only and never create or update the settings document.
 
-Configuration combines state, source, path, health, and diagnostics.
+Configuration contains **Overview**, **Effective configuration**, **Settings document**, and **Reload from disk** on one nested level.
+Overview combines state, source, path, health, and bounded diagnostics.
+Effective configuration shows deterministic catalog-ordered public TOML from the normalized state currently in use; comments, unknown fields, parser ASTs, and private runtime selectors are excluded.
+Settings document shows the exact loaded UTF-8 text through a terminal-safe, cell-aware read-only review without changing the raw payload.
 A healthy missing file is shown as **Built-in defaults**, an exact bundled document is shown as its named preset, and **Built-in fallback** is reserved for read or parse errors.
+Reload from disk reads only after the explicit action, validates and previews the current external state from the existing runtime snapshot, and asks for separate confirmation before changing the active session.
+A deleted document is a valid previewable transition to built-in defaults and creates no file.
+An unchanged document is a no-op, while read or parse failure, cancellation, disposal, external changes after preview, session replacement, shutdown, or runtime apply failure preserves the prior effective footer and every file byte.
+Reload re-reads immediately after confirmation and rejects a different external snapshot; it does not claim cross-process locking or continuing synchronization with later edits.
 Restore is disabled when no settings document exists or the exact built-in document is already saved.
 For a custom or invalid document, Restore previews the result and warns that the complete document, including custom settings, unknown fields, and comments, will be replaced without a post-success backup before asking for confirmation.
 
@@ -655,11 +662,11 @@ Package's explicitly documented Cargo lookup is the only ancestor walk and is ca
 
 The standard main menu keeps seven goals on one level: **Customize footer**, **Presets**, **Explain footer**, **Modules**, **Configuration**, **Help**, and **Restore built-in…**.
 It shows whether the footer uses built-in defaults, a saved built-in document, a named preset, a custom document, or an error-driven fallback, together with the current health.
-Presets, Explain, and Modules are menu-only paths; they do not add textual subcommands or change RPC, print, or JSON protocols.
+Presets, Explain, Modules, and the nested Configuration capabilities are menu-only paths; they do not add textual subcommands or change RPC, print, or JSON protocols.
 Restore remains last and unavailable when there is no document to replace.
 
-The TOML editor, adaptive live footer previews, Explain view, and searchable module inspector remain specialized extension UI.
-Their hints follow Pi's injected keybindings; list and detail content stay bounded across terminal resize.
+The TOML editor, adaptive live footer previews, Explain view, searchable module inspector, and Configuration document reviews remain specialized extension UI.
+Their hints follow Pi's injected keybindings; list, detail, and exact-document content stay bounded across terminal resize.
 Escape returns from detail or to the main menu, while Ctrl+C closes the whole workflow.
 
 The direct routes accept no trailing arguments.
@@ -692,7 +699,9 @@ Keep `extension_status` last in the catalog so arbitrary third-party statuses fo
 - `src/pi-starship.ts` — authoritative extension lifecycle, cached refresh binding, live preview, and footer.
 - `src/usage.ts` — native-aligned session usage and cache aggregation.
 - `src/command-contract.ts` — lightweight command routes and completions loaded at startup.
-- `src/commands.ts` — lazily loaded menu, preview/confirmation flow, diagnostics, and compatibility routes.
+- `src/commands.ts` — lazily loaded top-level menu, preview/confirmation workflows, and compatibility routes.
+- `src/command-configuration.ts` — nested configuration presentation, exact document views, and safe runtime-only disk reload.
+- `src/effective-config.ts` — explicit catalog-ordered public TOML projection and deterministic serialization.
 - `src/command-preset-picker.ts` — lifecycle-owned preset cursor and temporary footer-preview UI.
 - `src/presets/` — bundled complete TOML documents and stable preset metadata.
 - `src/command-inspector.ts` — adaptive Explain and searchable read-only module inspection surfaces.

--- a/packages/pi-starship/src/command-configuration.ts
+++ b/packages/pi-starship/src/command-configuration.ts
@@ -1,0 +1,363 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
+import { type PreviewMenuResult, showPreviewActionMenu } from "./command-preview.js";
+import { BUILT_IN_EXAMPLE, type LoadedStarshipConfig, loadStarshipConfig } from "./config.js";
+import { serializeEffectiveConfig } from "./effective-config.js";
+import { presetForDocument } from "./presets/catalog.js";
+
+const RELOAD_ACTIONS = {
+	apply: "apply",
+	cancel: "cancel",
+} as const;
+
+export interface WorkflowOwner {
+	signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+export interface ConfigurationCommandOptions {
+	getLoaded(): LoadedStarshipConfig;
+	getLoadedRevision?(): number;
+	apply(loaded: LoadedStarshipConfig, ctx: ExtensionCommandContext): void;
+	settingsPath: string;
+	renderPreview?(
+		loaded: LoadedStarshipConfig,
+		width: number,
+		ctx: ExtensionCommandContext,
+	): string[];
+	read?: (settingsPath: string) => LoadedStarshipConfig;
+}
+
+export interface ConfigurationPresentation {
+	state: string;
+	source: string;
+	health: string;
+	restoreDisabled: boolean;
+	restoreDescription: string;
+}
+
+export function configurationPresentation(loaded: LoadedStarshipConfig): ConfigurationPresentation {
+	const healthyMissing = isHealthyMissing(loaded);
+	const savedBuiltIn = loaded.source === "user" && loaded.rawDocument === BUILT_IN_EXAMPLE;
+	const activePreset = presetForDocument(loaded.rawDocument);
+	const fallback = loaded.source === "built-in" && loaded.diagnostics.length > 0;
+	return {
+		state: healthyMissing
+			? "Built-in defaults"
+			: savedBuiltIn
+				? "Saved built-in configuration"
+				: activePreset
+					? `${activePreset.label} preset`
+					: fallback
+						? "Built-in fallback"
+						: "Custom configuration",
+		source: healthyMissing
+			? "No settings file"
+			: activePreset
+				? "Bundled preset"
+				: loaded.source === "user"
+					? "User file"
+					: "Built-in fallback",
+		health: configurationHealth(loaded),
+		restoreDisabled: healthyMissing || savedBuiltIn,
+		restoreDescription: healthyMissing
+			? "Already using defaults · no file to replace"
+			: savedBuiltIn
+				? "Built-in configuration already saved"
+				: fallback
+					? "Preview before replacing invalid settings"
+					: "Preview before replacing the document",
+	};
+}
+
+export function configurationMenuScreen(loaded: LoadedStarshipConfig) {
+	const presentation = configurationPresentation(loaded);
+	return {
+		kind: "actions" as const,
+		title: "Configuration",
+		lines: [`${presentation.state} · ${presentation.health}`],
+		items: [
+			{
+				id: "configuration-overview",
+				label: "Overview",
+				description: "State, source, path, health, and warnings",
+				to: "configuration-overview" as const,
+			},
+			{
+				id: "configuration-effective",
+				label: "Effective configuration",
+				description: "Normalized public TOML currently in use",
+				to: "configuration-effective" as const,
+			},
+			{
+				id: "configuration-document",
+				label: "Settings document",
+				description: isHealthyMissing(loaded)
+					? "No settings file · built-in defaults are active"
+					: "Exact loaded UTF-8 text · read-only",
+				to: "configuration-document" as const,
+			},
+			{
+				id: "configuration-reload",
+				label: "Reload from disk…",
+				description: "Validate and preview external changes",
+				action: "configuration-reload" as const,
+			},
+		],
+		hint: "back" as const,
+	};
+}
+
+export function configurationOverviewScreen(loaded: LoadedStarshipConfig, settingsPath: string) {
+	const presentation = configurationPresentation(loaded);
+	return {
+		kind: "detail" as const,
+		title: "Configuration overview",
+		lines: [
+			`State: ${presentation.state}`,
+			`Source: ${presentation.source}`,
+			`Path: ${sanitizeTerminalText(settingsPath)}`,
+			...diagnosticLines(loaded, true),
+		],
+		hint: "back" as const,
+	};
+}
+
+export function effectiveConfigurationScreen(loaded: LoadedStarshipConfig) {
+	const presentation = configurationPresentation(loaded);
+	return {
+		kind: "review" as const,
+		title: "Effective configuration",
+		lines: [
+			`${presentation.state} · ${presentation.health}`,
+			"Normalized public TOML; comments and unknown fields are intentionally excluded.",
+		],
+		content: serializeEffectiveConfig(loaded.config),
+		format: { kind: "code" as const, language: "toml" },
+		viewportSize: "adaptive" as const,
+		hint: "back" as const,
+	};
+}
+
+export function settingsDocumentScreen(loaded: LoadedStarshipConfig, settingsPath: string) {
+	const path = sanitizeTerminalText(settingsPath);
+	if (loaded.rawDocument !== undefined) {
+		return {
+			kind: "review" as const,
+			title: "Settings document",
+			lines: ["Exact loaded UTF-8 text · display controls sanitized · read-only", `Path: ${path}`],
+			content: loaded.rawDocument,
+			format: { kind: "code" as const, language: "toml" },
+			viewportSize: "adaptive" as const,
+			hint: "back" as const,
+		};
+	}
+	return {
+		kind: "detail" as const,
+		title: "Settings document",
+		lines: [
+			...(isHealthyMissing(loaded)
+				? [
+						"No settings document exists.",
+						"Built-in defaults are active; this read created no file.",
+					]
+				: ["The settings document could not be loaded.", ...diagnosticLines(loaded, false)]),
+			`Path: ${path}`,
+		],
+		hint: "back" as const,
+	};
+}
+
+export async function reloadConfiguration(
+	ctx: ExtensionCommandContext,
+	options: ConfigurationCommandOptions,
+	owner: WorkflowOwner,
+): Promise<"applied" | "stay" | "close"> {
+	if (!isCurrentOwner(owner)) return "stay";
+	const previous = options.getLoaded();
+	const revision = options.getLoadedRevision?.();
+	const candidate = readReloadCandidate(options);
+	if (!candidate.ok) {
+		ctx.ui.notify(`Footer reload was blocked: ${safeError(candidate.error)}`, "error");
+		return "stay";
+	}
+	if (sameLoadedDocument(previous, candidate.loaded)) {
+		ctx.ui.notify("The current disk configuration is already loaded.", "info");
+		return "stay";
+	}
+
+	const selection = await showPreviewActionMenu(
+		ctx,
+		"Reload preview",
+		(width) => reloadPreviewBody(ctx, options, candidate.loaded, width),
+		[
+			{ value: RELOAD_ACTIONS.apply, label: "Apply reloaded configuration…" },
+			{ value: RELOAD_ACTIONS.cancel, label: "Cancel" },
+		],
+		owner.signal,
+		owner.isCurrent,
+	);
+	if (!isCurrentOwner(owner) || activeRevisionChanged(options, revision)) return "stay";
+	if (selection?.kind === "closed") return "close";
+	if (selectedReloadAction(selection) !== RELOAD_ACTIONS.apply) return "stay";
+
+	const confirmed = await ctx.ui.confirm(
+		"Apply configuration from disk?",
+		candidate.loaded.rawDocument === undefined
+			? "Use built-in defaults for this session? No settings file will be created."
+			: "Apply the validated settings document to this session without changing its bytes?",
+	);
+	if (!isCurrentOwner(owner) || activeRevisionChanged(options, revision) || !confirmed) {
+		return "stay";
+	}
+
+	const fresh = readReloadCandidate(options);
+	if (!fresh.ok) {
+		ctx.ui.notify(
+			`Footer reload was blocked after confirmation: ${safeError(fresh.error)}. The previous footer remains active.`,
+			"error",
+		);
+		return "stay";
+	}
+	if (!sameLoadedDocument(candidate.loaded, fresh.loaded)) {
+		ctx.ui.notify(
+			"The settings document changed after preview. The previous footer remains active; reload again to review the latest version.",
+			"warning",
+		);
+		return "stay";
+	}
+
+	try {
+		options.apply(fresh.loaded, ctx);
+	} catch (error) {
+		let rollbackError: unknown;
+		try {
+			options.apply(previous, ctx);
+		} catch (rollback) {
+			rollbackError = rollback;
+		}
+		ctx.ui.notify(
+			rollbackError
+				? `Footer reload failed: ${safeError(error)}. Restoring the previous configuration also failed: ${safeError(rollbackError)}.`
+				: `Footer reload failed: ${safeError(error)}. The previous configuration was restored.`,
+			"error",
+		);
+		return "stay";
+	}
+
+	const warnings = fresh.loaded.diagnostics.length;
+	ctx.ui.notify(
+		warnings === 0
+			? "Footer configuration reloaded and applied."
+			: `Footer configuration reloaded and applied with ${warnings} warning${warnings === 1 ? "" : "s"}.`,
+		"info",
+	);
+	return "applied";
+}
+
+function readReloadCandidate(
+	options: ConfigurationCommandOptions,
+): { ok: true; loaded: LoadedStarshipConfig } | { ok: false; error: string } {
+	let loaded: LoadedStarshipConfig;
+	try {
+		loaded = (options.read ?? loadStarshipConfig)(options.settingsPath);
+	} catch (error) {
+		return { ok: false, error: formatError(error) };
+	}
+	const errors = loaded.diagnostics.filter((item) => item.severity === "error");
+	if (errors.length > 0) {
+		return { ok: false, error: errors.map((item) => item.message).join("; ") };
+	}
+	return { ok: true, loaded };
+}
+
+function reloadPreviewBody(
+	ctx: ExtensionCommandContext,
+	options: ConfigurationCommandOptions,
+	loaded: LoadedStarshipConfig,
+	width: number,
+): string[] {
+	const presentation = configurationPresentation(loaded);
+	let preview: string[];
+	try {
+		preview = options.renderPreview?.(loaded, width, ctx) ?? [
+			"Live preview is unavailable until the footer is ready.",
+		];
+	} catch (error) {
+		preview = [`Preview unavailable: ${safeError(formatError(error))}`];
+	}
+	return [
+		`Candidate: ${presentation.state}`,
+		`Source: ${presentation.source}`,
+		`Path: ${sanitizeTerminalText(options.settingsPath)}`,
+		loaded.rawDocument === undefined
+			? "Applying uses built-in defaults and creates no settings file."
+			: "Applying changes only the active session; the settings document bytes stay unchanged.",
+		...diagnosticLines(loaded, true),
+		"",
+		...preview,
+	];
+}
+
+export function diagnosticLines(loaded: LoadedStarshipConfig, includeSummary: boolean): string[] {
+	const diagnostics = loaded.diagnostics
+		.slice(0, 8)
+		.map(
+			(item) =>
+				`${sanitizeTerminalText(item.path || "root")}: ${sanitizeTerminalText(item.message)}`,
+		);
+	const remaining = loaded.diagnostics.length - diagnostics.length;
+	return [
+		...(includeSummary ? [`Health: ${configurationHealth(loaded)}`] : []),
+		...(diagnostics.length > 0 ? diagnostics : ["No configuration warnings."]),
+		...(remaining > 0 ? [`${remaining} additional warnings not shown.`] : []),
+	];
+}
+
+function configurationHealth(loaded: LoadedStarshipConfig): string {
+	const errors = loaded.diagnostics.filter((item) => item.severity === "error").length;
+	if (errors > 0) return `${errors} error${errors === 1 ? "" : "s"}`;
+	const warnings = loaded.diagnostics.length;
+	return warnings === 0 ? "Healthy" : `${warnings} warning${warnings === 1 ? "" : "s"}`;
+}
+
+function isHealthyMissing(loaded: LoadedStarshipConfig): boolean {
+	return (
+		loaded.source === "built-in" &&
+		loaded.rawDocument === undefined &&
+		loaded.diagnostics.length === 0
+	);
+}
+
+function sameLoadedDocument(left: LoadedStarshipConfig, right: LoadedStarshipConfig): boolean {
+	return (
+		left.source === right.source &&
+		left.rawDocument === right.rawDocument &&
+		JSON.stringify(left.diagnostics) === JSON.stringify(right.diagnostics)
+	);
+}
+
+function activeRevisionChanged(
+	options: ConfigurationCommandOptions,
+	revision: number | undefined,
+): boolean {
+	return revision !== undefined && options.getLoadedRevision?.() !== revision;
+}
+
+function isCurrentOwner(owner: WorkflowOwner): boolean {
+	return !owner.signal.aborted && owner.isCurrent();
+}
+
+function selectedReloadAction(
+	result: PreviewMenuResult<(typeof RELOAD_ACTIONS)[keyof typeof RELOAD_ACTIONS]> | undefined,
+) {
+	return result?.kind === "selected" ? result.value : null;
+}
+
+function safeError(value: unknown): string {
+	return sanitizeTerminalText(typeof value === "string" ? value : formatError(value));
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-starship/src/commands.ts
+++ b/packages/pi-starship/src/commands.ts
@@ -1,5 +1,15 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import {
+	type ConfigurationCommandOptions,
+	configurationMenuScreen,
+	configurationOverviewScreen,
+	configurationPresentation,
+	effectiveConfigurationScreen,
+	reloadConfiguration,
+	settingsDocumentScreen,
+	type WorkflowOwner,
+} from "./command-configuration.js";
 import { completeStarshipArguments, STARSHIP_SUBCOMMANDS } from "./command-contract.js";
 import { formatFooterExplanation } from "./command-inspector.js";
 import { showPresetPicker } from "./command-preset-picker.js";
@@ -36,26 +46,13 @@ const PREVIEW_ACTIONS = {
 	cancel: "cancel",
 } as const;
 
-export interface StarshipCommandOptions {
-	getLoaded(): LoadedStarshipConfig;
+export interface StarshipCommandOptions extends ConfigurationCommandOptions {
 	getInspection?(): StatuslineInspection | undefined;
-	apply(loaded: LoadedStarshipConfig, ctx: ExtensionCommandContext): void;
 	preview?(loaded: LoadedStarshipConfig | undefined, ctx: ExtensionCommandContext): void;
-	settingsPath: string;
-	renderPreview?(
-		loaded: LoadedStarshipConfig,
-		width: number,
-		ctx: ExtensionCommandContext,
-	): string[];
 	save?: (settingsPath: string, rawDocument: string) => LoadedStarshipConfig;
 	restore?: (settingsPath: string, rawDocument: string) => void;
 	validate?: (settingsPath: string, rawDocument: string) => LoadedStarshipConfig;
-	getMenuOwner?(): { signal: AbortSignal; isCurrent(): boolean };
-}
-
-interface WorkflowOwner {
-	signal: AbortSignal;
-	isCurrent(): boolean;
+	getMenuOwner?(): WorkflowOwner;
 }
 
 type ReviewIntent =
@@ -114,8 +111,16 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 		signal: fallbackController.signal,
 		isCurrent: () => !fallbackController.signal.aborted,
 	};
-	type Screen = "main" | "explain" | "modules" | "configuration" | "help";
-	type Action = "customize" | "presets" | "restore";
+	type Screen =
+		| "main"
+		| "explain"
+		| "modules"
+		| "configuration"
+		| "configuration-overview"
+		| "configuration-effective"
+		| "configuration-document"
+		| "help";
+	type Action = "customize" | "presets" | "configuration-reload" | "restore";
 	const menu = defineMenu<undefined, Screen, Action, ExtensionCommandContext>({
 		start: "main",
 		screens: {
@@ -210,21 +215,12 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 					hint: "back",
 				};
 			},
-			configuration: () => {
-				const loaded = options.getLoaded();
-				const presentation = configurationPresentation(loaded);
-				return {
-					kind: "detail",
-					title: "Configuration",
-					lines: [
-						`State: ${presentation.state}`,
-						`Source: ${presentation.source}`,
-						`Path: ${safeText(options.settingsPath)}`,
-						...diagnosticLines(loaded, true),
-					],
-					hint: "back",
-				};
-			},
+			configuration: () => configurationMenuScreen(options.getLoaded()),
+			"configuration-overview": () =>
+				configurationOverviewScreen(options.getLoaded(), options.settingsPath),
+			"configuration-effective": () => effectiveConfigurationScreen(options.getLoaded()),
+			"configuration-document": () =>
+				settingsDocumentScreen(options.getLoaded(), options.settingsPath),
 			help: () => ({
 				kind: "detail",
 				title: "pi-starship help",
@@ -233,7 +229,7 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 					"Presets live-previews the cursor in the footer; Enter confirms apply and e customizes first.",
 					"Explain footer breaks down the modules currently showing from the existing snapshot.",
 					"Modules searches every supported module and explains its current read-only state.",
-					"Configuration explains state, source, path, and warnings without changing the footer.",
+					"Configuration separates overview, effective TOML, loaded settings text, and safe disk reload.",
 					`Settings: ${safeText(options.settingsPath)}`,
 					"Docs: https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-starship",
 				],
@@ -248,6 +244,10 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StarshipComma
 			presets: async () => {
 				const result = await choosePreset(ctx, options, owner);
 				return result === "applied" || result === "close" ? { kind: "close" } : { kind: "stay" };
+			},
+			"configuration-reload": async () => {
+				const result = await reloadConfiguration(ctx, options, owner);
+				return result === "close" ? { kind: "close" } : { kind: "stay" };
 			},
 			restore: async () => {
 				const presentation = configurationPresentation(options.getLoaded());
@@ -672,70 +672,6 @@ function selectedPreviewAction<Value extends string>(
 	result: PreviewMenuResult<Value> | undefined,
 ): Value | null {
 	return result?.kind === "selected" ? result.value : null;
-}
-
-function diagnosticLines(loaded: LoadedStarshipConfig, includeSummary: boolean): string[] {
-	const diagnostics = loaded.diagnostics
-		.slice(0, 8)
-		.map((item) => `${safeText(item.path || "root")}: ${safeText(item.message)}`);
-	const remaining = loaded.diagnostics.length - diagnostics.length;
-	return [
-		...(includeSummary ? [`Health: ${configurationHealth(loaded)}`] : []),
-		...(diagnostics.length > 0 ? diagnostics : ["No configuration warnings."]),
-		...(remaining > 0 ? [`${remaining} additional warnings not shown.`] : []),
-	];
-}
-
-interface ConfigurationPresentation {
-	state: string;
-	source: string;
-	health: string;
-	restoreDisabled: boolean;
-	restoreDescription: string;
-}
-
-function configurationPresentation(loaded: LoadedStarshipConfig): ConfigurationPresentation {
-	const healthyMissing =
-		loaded.source === "built-in" &&
-		loaded.rawDocument === undefined &&
-		loaded.diagnostics.length === 0;
-	const savedBuiltIn = loaded.source === "user" && loaded.rawDocument === BUILT_IN_EXAMPLE;
-	const activePreset = presetForDocument(loaded.rawDocument);
-	const fallback = loaded.source === "built-in" && loaded.diagnostics.length > 0;
-	return {
-		state: healthyMissing
-			? "Built-in defaults"
-			: savedBuiltIn
-				? "Saved built-in configuration"
-				: activePreset
-					? `${activePreset.label} preset`
-					: fallback
-						? "Built-in fallback"
-						: "Custom configuration",
-		source: healthyMissing
-			? "No settings file"
-			: activePreset
-				? "Bundled preset"
-				: loaded.source === "user"
-					? "User file"
-					: "Built-in fallback",
-		health: configurationHealth(loaded),
-		restoreDisabled: healthyMissing || savedBuiltIn,
-		restoreDescription: healthyMissing
-			? "Already using defaults · no file to replace"
-			: savedBuiltIn
-				? "Built-in configuration already saved"
-				: fallback
-					? "Preview before replacing invalid settings"
-					: "Preview before replacing the document",
-	};
-}
-
-function configurationHealth(loaded: LoadedStarshipConfig): string {
-	const errors = loaded.diagnostics.filter((item) => item.severity === "error").length;
-	if (errors > 0) return `${errors} error${errors === 1 ? "" : "s"}`;
-	const warnings = loaded.diagnostics.length;
-	return warnings === 0 ? "Healthy" : `${warnings} warning${warnings === 1 ? "" : "s"}`;
 }
 
 function showStatus(ctx: ExtensionCommandContext, options: StarshipCommandOptions) {

--- a/packages/pi-starship/src/effective-config.ts
+++ b/packages/pi-starship/src/effective-config.ts
@@ -1,0 +1,65 @@
+import { stringify, type TomlTable, type TomlValue } from "smol-toml";
+import type { StarshipConfig } from "./config.js";
+import { MODULE_DEFINITIONS } from "./modules/catalog.js";
+import type { ModuleOptionValue } from "./modules/types.js";
+
+export function projectEffectiveConfig(config: StarshipConfig): TomlTable {
+	const projected: TomlTable = {
+		format: config.format,
+	};
+	if (config.palette !== undefined) projected.palette = config.palette;
+	projected.palettes = Object.fromEntries(
+		sortedEntries(config.palettes).map(([name, colors]) => [name, sortedRecord(colors)]),
+	);
+	for (const definition of MODULE_DEFINITIONS) {
+		const module = config.modules[definition.name];
+		const table: TomlTable = {
+			format: module.format,
+			symbol: module.symbol,
+		};
+		if (definition.styleDefaults) {
+			for (const field of Object.keys(definition.styleDefaults)) {
+				table[field] = module.styles[field] ?? "";
+			}
+		} else if (!definition.displayDefaults) {
+			table.style = module.style;
+		}
+		if (definition.displayDefaults) {
+			table.display = module.display.map((entry) => ({ ...entry }));
+		}
+		table.disabled = module.disabled;
+		for (const key of Object.keys(definition.options ?? {})) {
+			table[key] = cloneOptionValue(module.options[key]);
+		}
+		if (definition.name === "extension_status") {
+			table.separator = config.extensionStatus.separator;
+			table.max_statuses = config.extensionStatus.maxStatuses;
+			table.icons = sortedRecord(config.extensionStatus.icons);
+		}
+		projected[definition.name] = table;
+	}
+	return projected;
+}
+
+export function serializeEffectiveConfig(config: StarshipConfig): string {
+	return stringify(projectEffectiveConfig(config));
+}
+
+function cloneOptionValue(value: ModuleOptionValue | undefined): TomlValue {
+	if (value === undefined) throw new Error("Missing normalized module option");
+	if (Array.isArray(value)) return [...(value as readonly string[])];
+	if (typeof value === "object") {
+		return sortedRecord(value as Readonly<Record<string, string>>);
+	}
+	return value;
+}
+
+function sortedRecord(values: Readonly<Record<string, string>>): Record<string, string> {
+	return Object.fromEntries(sortedEntries(values));
+}
+
+function sortedEntries<Value>(values: Readonly<Record<string, Value>>): Array<[string, Value]> {
+	return Object.entries(values).sort(([left], [right]) =>
+		left < right ? -1 : left > right ? 1 : 0,
+	);
+}

--- a/packages/pi-starship/src/pi-starship.ts
+++ b/packages/pi-starship/src/pi-starship.ts
@@ -85,6 +85,7 @@ interface PiStarshipOptions {
 
 export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions = {}) {
 	let loaded: LoadedStarshipConfig | undefined;
+	let loadedRevision = 0;
 	let previewLoaded: LoadedStarshipConfig | undefined;
 	const runtime: RuntimeState = {
 		activeTools: new Map(),
@@ -348,6 +349,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 	const commandOptions: StarshipCommandOptions = {
 		settingsPath: configPath,
 		getLoaded: () => loaded ?? loadStarshipConfig(configPath),
+		getLoadedRevision: () => loadedRevision,
 		getInspection: () => {
 			const current = loaded ?? loadStarshipConfig(configPath);
 			return runtime.inspect?.(current);
@@ -365,6 +367,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 			}
 			previewLoaded = undefined;
 			loaded = next;
+			loadedRevision += 1;
 			const target = activeTarget;
 			if (target) {
 				restartLocalControllers(target);
@@ -399,6 +402,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 
 	pi.on("session_start", (_event, ctx) => {
 		loaded = loadStarshipConfig(configPath);
+		loadedRevision += 1;
 		if (loaded.diagnostics.length > 0 && (ctx.mode === "tui" || ctx.hasUI)) {
 			ctx.ui.notify(formatDiagnostics(loaded), "warning");
 		}

--- a/packages/pi-starship/test/command-configuration.test.ts
+++ b/packages/pi-starship/test/command-configuration.test.ts
@@ -1,0 +1,602 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { reloadConfiguration, settingsDocumentScreen } from "../src/command-configuration.js";
+import { registerStarshipCommand } from "../src/commands.js";
+import { type LoadedStarshipConfig, loadStarshipConfig } from "../src/config.js";
+
+const currentOwner = {
+	signal: new AbortController().signal,
+	isCurrent: () => true,
+};
+
+test("Configuration exposes four focused screens under seven top-level goals", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-configuration-menu-"));
+	const path = join(root, "pi-starship.toml");
+	const raw = "# retained comment\nformat = '$model'\nfuture = true\n";
+	writeFileSync(path, raw);
+	try {
+		const mock = createMockPi();
+		const loaded = loadStarshipConfig(path);
+		let inspectionCalls = 0;
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			getInspection() {
+				inspectionCalls += 1;
+				return undefined;
+			},
+			apply() {},
+			settingsPath: path,
+		});
+		const tui = createTuiHarness({ width: 64, rows: 18 });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		const main = tui.render().join("\n");
+		assert.equal(
+			[
+				"Customize footer",
+				"Presets",
+				"Explain footer",
+				"Modules",
+				"Configuration",
+				"Help",
+				"Restore built-in…",
+			].filter((label) => main.includes(label)).length,
+			7,
+		);
+
+		await openConfiguration(tui);
+		const configuration = tui.render().join("\n");
+		assert.match(configuration, /Overview/u);
+		assert.match(configuration, /Effective configuration/u);
+		assert.match(configuration, /Settings document/u);
+		assert.match(configuration, /Reload from disk…/u);
+
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const effective = tui.render().join("\n");
+		assert.match(effective, /Normalized public TOML/u);
+		assert.match(effective, /\[brand\]/u);
+		assert.doesNotMatch(effective, /future|retained comment|formatAst/u);
+		tui.press("tui.select.cancel");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /→ Effective configuration/u);
+
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const document = tui.render().join("\n");
+		assert.match(document, /retained comment/u);
+		assert.match(document, /future = true/u);
+		assert.equal(readFileSync(path, "utf8"), raw);
+		assert.equal(inspectionCalls, 0);
+		tui.press("ctrl+c");
+		await running;
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Settings document preserves raw payload while its review renders safely and within width", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-document-safe-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const base = loadStarshipConfig(path);
+		const raw = `# before\u001b[31mred\u001b[0m\u202eevil\n# tab\tcolumn and 中文 ${"x".repeat(80)}\nformat = '$model'\n`;
+		const loaded: LoadedStarshipConfig = {
+			...base,
+			source: "user",
+			rawDocument: raw,
+		};
+		const screen = settingsDocumentScreen(loaded, `${path}\u001b]8;;bad\u0007label`);
+		assert.equal(screen.kind, "review");
+		if (screen.kind === "review") assert.equal(screen.content, raw);
+
+		const mock = createMockPi();
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+		});
+		const tui = createTuiHarness({ width: 24, rows: 12 });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		await openConfiguration(tui);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		for (const dimensions of [
+			{ width: 24, rows: 12 },
+			{ width: 18, rows: 9 },
+			{ width: 40, rows: 16 },
+		]) {
+			const frame = tui.resize(dimensions);
+			assert.ok(frame.every((line) => visibleWidth(line) <= dimensions.width));
+			const text = stripVTControlCharacters(frame.join("\n"));
+			assert.match(text, /beforeredevil/u);
+			assert.equal(text.includes("\u202e"), false);
+			assert.doesNotMatch(text, /\]8;;|\[31m/u);
+		}
+		assert.equal(loaded.rawDocument, raw);
+		assert.equal(existsSync(path), false);
+		tui.press("ctrl+c");
+		await running;
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("healthy missing Settings document creates no file or parent directory", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-document-missing-"));
+	const parent = join(root, "missing");
+	const path = join(parent, "pi-starship.toml");
+	try {
+		const loaded = loadStarshipConfig(path);
+		const mock = createMockPi();
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply() {},
+			settingsPath: path,
+		});
+		const tui = createTuiHarness({ width: 44, rows: 14 });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		await openConfiguration(tui);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		const frame = tui.render().join("\n");
+		assert.match(frame, /No settings document exists/u);
+		assert.match(frame, /Built-in defaults are active/u);
+		assert.equal(existsSync(parent), false);
+		let applied = 0;
+		const reloadContext = createMockContext({ mode: "tui", hasUI: true });
+		assert.equal(
+			await reloadConfiguration(
+				reloadContext.ctx,
+				{
+					getLoaded: () => loaded,
+					apply() {
+						applied += 1;
+					},
+					settingsPath: path,
+				},
+				currentOwner,
+			),
+			"stay",
+		);
+		assert.equal(applied, 0);
+		assert.equal(existsSync(parent), false);
+		tui.press("ctrl+c");
+		await running;
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Configuration reload action returns to the updated section and restores focus", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-reload-menu-"));
+	const path = join(root, "pi-starship.toml");
+	writeFileSync(path, "format = '$model'\n");
+	try {
+		let loaded = loadStarshipConfig(path);
+		writeFileSync(path, "format = '$provider'\n");
+		const mock = createMockPi();
+		registerStarshipCommand(mock.pi, {
+			getLoaded: () => loaded,
+			apply(next) {
+				loaded = next;
+			},
+			settingsPath: path,
+			renderPreview: (candidate) => [`Preview: ${candidate.config.format}`],
+		});
+		const tui = createTuiHarness({ width: 64, rows: 20 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			confirm: async () => true,
+		});
+		const running = mock.commands.get("starship")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		await openConfiguration(tui);
+		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Reload preview/u);
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /→ Reload from disk…/u);
+		assert.equal(loaded.config.format, "$provider");
+		tui.press("ctrl+c");
+		await running;
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Reload applies a validated external edit without changing disk bytes", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-reload-valid-"));
+	const path = join(root, "pi-starship.toml");
+	writeFileSync(path, "format = '$model'\n");
+	try {
+		let loaded = loadStarshipConfig(path);
+		let revision = 1;
+		const external = "format = '$provider$directory'\nfuture = true\n";
+		writeFileSync(path, external);
+		let applied = 0;
+		const tui = createTuiHarness({ width: 80, rows: 30 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			confirm: async () => true,
+		});
+		const running = reloadConfiguration(
+			context.ctx,
+			{
+				getLoaded: () => loaded,
+				getLoadedRevision: () => revision,
+				apply(next) {
+					loaded = next;
+					revision += 1;
+					applied += 1;
+				},
+				settingsPath: path,
+				renderPreview: (candidate) => [`Preview: ${candidate.config.format}`],
+			},
+			currentOwner,
+		);
+		await tui.waitForOpen();
+		const preview = tui.render().join("\n");
+		assert.match(preview, /Reload preview/u);
+		assert.match(preview, /Custom configuration/u);
+		assert.match(preview, /Preview:.*provider.*directory/u);
+		tui.press("tui.select.confirm");
+		assert.equal(await running, "applied");
+		assert.equal(applied, 1);
+		assert.equal(loaded.config.format, "$provider$directory");
+		assert.equal(readFileSync(path, "utf8"), external);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Reload previews file removal and applies built-in defaults without creating a file", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-reload-missing-"));
+	const path = join(root, "pi-starship.toml");
+	writeFileSync(path, "format = '$provider'\n");
+	try {
+		let loaded = loadStarshipConfig(path);
+		unlinkSync(path);
+		const tui = createTuiHarness({ width: 50, rows: 16 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			confirm: async () => true,
+		});
+		const running = reloadConfiguration(
+			context.ctx,
+			{
+				getLoaded: () => loaded,
+				apply(next) {
+					loaded = next;
+				},
+				settingsPath: path,
+				renderPreview: (candidate) => [`Preview: ${candidate.config.format}`],
+			},
+			currentOwner,
+		);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Built-in defaults/u);
+		tui.press("tui.select.confirm");
+		assert.equal(await running, "applied");
+		assert.equal(loaded.source, "built-in");
+		assert.equal(loaded.rawDocument, undefined);
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Reload clears a recovered read-error fallback when the document is now missing", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-reload-recovered-missing-"));
+	const path = join(root, "pi-starship.toml");
+	try {
+		const healthy = loadStarshipConfig(path);
+		let loaded: LoadedStarshipConfig = {
+			...healthy,
+			diagnostics: [{ severity: "error", path: "", message: "Unable to read settings" }],
+		};
+		const tui = createTuiHarness({ width: 50, rows: 16 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			confirm: async () => true,
+		});
+		const running = reloadConfiguration(
+			context.ctx,
+			{
+				getLoaded: () => loaded,
+				apply(next) {
+					loaded = next;
+				},
+				settingsPath: path,
+			},
+			currentOwner,
+		);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Built-in defaults/u);
+		tui.press("tui.select.confirm");
+		assert.equal(await running, "applied");
+		assert.deepEqual(loaded.diagnostics, []);
+		assert.equal(existsSync(path), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Reload blocks unchanged, malformed, and read-error candidates without opening preview", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-reload-blocked-"));
+	const path = join(root, "pi-starship.toml");
+	writeFileSync(path, "format = '$model'\n");
+	try {
+		const loaded = loadStarshipConfig(path);
+		let applied = 0;
+		let confirmations = 0;
+		const unchanged = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			confirm: async () => {
+				confirmations += 1;
+				return true;
+			},
+		});
+		assert.equal(
+			await reloadConfiguration(
+				unchanged.ctx,
+				{
+					getLoaded: () => loaded,
+					apply() {
+						applied += 1;
+					},
+					settingsPath: path,
+				},
+				currentOwner,
+			),
+			"stay",
+		);
+		assert.equal(confirmations, 0);
+		assert.match(unchanged.notifications.at(-1)?.message ?? "", /already loaded/u);
+
+		writeFileSync(path, "format = [\n");
+		const malformed = createMockContext({ mode: "tui", hasUI: true });
+		await reloadConfiguration(
+			malformed.ctx,
+			{ getLoaded: () => loaded, apply() {}, settingsPath: path },
+			currentOwner,
+		);
+		assert.match(malformed.notifications.at(-1)?.message ?? "", /parse TOML/u);
+
+		const readError = createMockContext({ mode: "tui", hasUI: true });
+		await reloadConfiguration(
+			readError.ctx,
+			{
+				getLoaded: () => loaded,
+				apply() {},
+				settingsPath: path,
+				read: () => {
+					throw new Error("permission denied");
+				},
+			},
+			currentOwner,
+		);
+		assert.match(readError.notifications.at(-1)?.message ?? "", /permission denied/u);
+		assert.equal(applied, 0);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Reload cancellation and external preview disposal preserve state and disk", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-reload-cancel-"));
+	const path = join(root, "pi-starship.toml");
+	writeFileSync(path, "format = '$model'\n");
+	try {
+		const loaded = loadStarshipConfig(path);
+		const external = "format = '$provider'\n";
+		writeFileSync(path, external);
+		let applied = 0;
+		const options = {
+			getLoaded: () => loaded,
+			apply() {
+				applied += 1;
+			},
+			settingsPath: path,
+		};
+
+		const cancelledTui = createTuiHarness({ width: 44, rows: 14 });
+		const cancelled = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: cancelledTui.custom,
+		});
+		const cancelledRun = reloadConfiguration(cancelled.ctx, options, currentOwner);
+		await cancelledTui.waitForOpen();
+		cancelledTui.press("tui.select.down");
+		cancelledTui.press("tui.select.confirm");
+		assert.equal(await cancelledRun, "stay");
+
+		const disposedTui = createTuiHarness({ width: 44, rows: 14 });
+		const disposed = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: disposedTui.custom,
+		});
+		const disposedRun = reloadConfiguration(disposed.ctx, options, currentOwner);
+		await disposedTui.waitForOpen();
+		disposedTui.dispose();
+		assert.equal(await disposedRun, "stay");
+		assert.equal(disposedTui.isOpen, false);
+		assert.equal(applied, 0);
+		assert.equal(readFileSync(path, "utf8"), external);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Reload rejects disk and active-state changes after preview", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-reload-stale-"));
+	const path = join(root, "pi-starship.toml");
+	writeFileSync(path, "format = '$model'\n");
+	try {
+		const loaded = loadStarshipConfig(path);
+		writeFileSync(path, "format = '$provider'\n");
+		let applied = 0;
+		const tui = createTuiHarness({ width: 44, rows: 14 });
+		const staleDisk = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			confirm: async () => {
+				writeFileSync(path, "format = '$directory'\n");
+				return true;
+			},
+		});
+		const running = reloadConfiguration(
+			staleDisk.ctx,
+			{
+				getLoaded: () => loaded,
+				apply() {
+					applied += 1;
+				},
+				settingsPath: path,
+			},
+			currentOwner,
+		);
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		assert.equal(await running, "stay");
+		assert.equal(applied, 0);
+		assert.match(staleDisk.notifications.at(-1)?.message ?? "", /changed after preview/u);
+
+		writeFileSync(path, "format = '$provider'\n");
+		let revision = 1;
+		const activeTui = createTuiHarness({ width: 44, rows: 14 });
+		const staleActive = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: activeTui.custom,
+			confirm: async () => {
+				revision += 1;
+				return true;
+			},
+		});
+		const activeRunning = reloadConfiguration(
+			staleActive.ctx,
+			{
+				getLoaded: () => loaded,
+				getLoadedRevision: () => revision,
+				apply() {
+					applied += 1;
+				},
+				settingsPath: path,
+			},
+			currentOwner,
+		);
+		await activeTui.waitForOpen();
+		activeTui.press("tui.select.confirm");
+		assert.equal(await activeRunning, "stay");
+		assert.equal(applied, 0);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("Reload restores runtime state after apply failure and reports rollback failure", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-reload-rollback-"));
+	const path = join(root, "pi-starship.toml");
+	writeFileSync(path, "format = '$model'\n");
+	try {
+		const previous = loadStarshipConfig(path);
+		writeFileSync(path, "format = '$provider'\n");
+		let active = previous;
+		let calls = 0;
+		const tui = createTuiHarness({ width: 44, rows: 14 });
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: tui.custom,
+			confirm: async () => true,
+		});
+		const running = reloadConfiguration(
+			context.ctx,
+			{
+				getLoaded: () => active,
+				apply(next) {
+					calls += 1;
+					active = next;
+					if (calls === 1) throw new Error("apply failed");
+				},
+				settingsPath: path,
+			},
+			currentOwner,
+		);
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		assert.equal(await running, "stay");
+		assert.equal(calls, 2);
+		assert.equal(active.rawDocument, previous.rawDocument);
+		assert.match(
+			context.notifications.at(-1)?.message ?? "",
+			/previous configuration was restored/u,
+		);
+
+		active = previous;
+		const failedTui = createTuiHarness({ width: 44, rows: 14 });
+		const failed = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: failedTui.custom,
+			confirm: async () => true,
+		});
+		const failedRunning = reloadConfiguration(
+			failed.ctx,
+			{
+				getLoaded: () => active,
+				apply(next) {
+					active = next;
+					throw new Error(next === previous ? "rollback failed" : "apply failed");
+				},
+				settingsPath: path,
+			},
+			currentOwner,
+		);
+		await failedTui.waitForOpen();
+		failedTui.press("tui.select.confirm");
+		assert.equal(await failedRunning, "stay");
+		assert.match(failed.notifications.at(-1)?.message ?? "", /rollback failed/u);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+async function openConfiguration(tui: ReturnType<typeof createTuiHarness>) {
+	for (let index = 0; index < 4; index += 1) tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+}

--- a/packages/pi-starship/test/command-lifecycle.test.ts
+++ b/packages/pi-starship/test/command-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
@@ -310,6 +310,100 @@ test("session shutdown disposes an open preset preview without saving", async ()
 	}
 });
 
+test("session replacement disposes an open reload preview without applying stale work", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-replace-reload-preview-"));
+	const path = join(root, "pi-starship.toml");
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	writeFileSync(path, "format = '$model'\n");
+	try {
+		const mock = createMockPi();
+		(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () =>
+			gitResult();
+		piStarship(mock.pi);
+		const tui = createTuiHarness({ width: 52, rows: 18 });
+		const oldContext = createMockContext({ mode: "tui", custom: tui.custom });
+		await emit(mock.events, "session_start", {}, oldContext.ctx);
+		const external = "format = '$provider'\nfuture = true\n";
+		writeFileSync(path, external);
+		const command = Promise.resolve(mock.commands.get("starship")?.handler("", oldContext.ctx));
+		await tui.waitForOpen();
+		for (let index = 0; index < 4; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Reload preview/u);
+
+		const newContext = createMockContext({ mode: "tui", cwd: "/work/replacement" });
+		await emit(mock.events, "session_start", {}, newContext.ctx);
+		await command;
+		assert.equal(tui.isOpen, false);
+		assert.equal(readFileSync(path, "utf8"), external);
+		assert.doesNotMatch(
+			oldContext.notifications.map((item) => item.message).join("\n"),
+			/reloaded and applied/u,
+		);
+		await emit(mock.events, "session_shutdown", {}, newContext.ctx);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("session shutdown rejects a reload confirmation that resolves after ownership ends", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-starship-shutdown-reload-confirm-"));
+	const path = join(root, "pi-starship.toml");
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	writeFileSync(path, "format = '$model'\n");
+	try {
+		const mock = createMockPi();
+		(mock.rawPi as typeof mock.rawPi & { exec: () => Promise<ExecResult> }).exec = async () =>
+			gitResult();
+		piStarship(mock.pi);
+		const confirmation = deferred<boolean>();
+		const confirmationStarted = deferred<void>();
+		const tui = createTuiHarness({ width: 52, rows: 18 });
+		const context = createMockContext({
+			mode: "tui",
+			custom: tui.custom,
+			confirm: async () => {
+				confirmationStarted.resolve();
+				return confirmation.promise;
+			},
+		});
+		await emit(mock.events, "session_start", {}, context.ctx);
+		const external = "format = '$provider'\n";
+		writeFileSync(path, external);
+		const command = Promise.resolve(mock.commands.get("starship")?.handler("", context.ctx));
+		await tui.waitForOpen();
+		for (let index = 0; index < 4; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await confirmationStarted.promise;
+
+		await emit(mock.events, "session_shutdown", {}, context.ctx);
+		confirmation.resolve(true);
+		await command;
+		assert.equal(readFileSync(path, "utf8"), external);
+		assert.doesNotMatch(
+			context.notifications.map((item) => item.message).join("\n"),
+			/reloaded and applied/u,
+		);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 async function emit(
 	events: ReadonlyMap<string, Array<(...args: unknown[]) => unknown>>,
 	name: string,
@@ -338,4 +432,12 @@ async function flushAsync() {
 	await Promise.resolve();
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	await Promise.resolve();
+}
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((next) => {
+		resolve = next;
+	});
+	return { promise, resolve };
 }

--- a/packages/pi-starship/test/command-ux.test.ts
+++ b/packages/pi-starship/test/command-ux.test.ts
@@ -482,6 +482,8 @@ test("Configuration combines state, source, path, health, and diagnostics", asyn
 		for (let index = 0; index < 4; index += 1) tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
 		const frame = tui.render().join("\n");
 		assert.match(frame, /Configuration/u);
 		assert.match(frame, /State: Custom configuration/u);

--- a/packages/pi-starship/test/commands.test.ts
+++ b/packages/pi-starship/test/commands.test.ts
@@ -635,7 +635,11 @@ test("main and Configuration menus expose current state and a clear Back path", 
 		hasUI: true,
 		custom: async (factory: unknown) => {
 			const inputs =
-				call === 0 ? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"] : ["\u001b"];
+				call === 0
+					? ["\u001b[B", "\u001b[B", "\u001b[B", "\u001b[B", "\r"]
+					: call === 1
+						? ["\r"]
+						: ["\u001b"];
 			const driven = await driveTuiCustom(factory, inputs, 26);
 			screens[call++] = driven.renders.flat().join("\n");
 			assert.ok(driven.renders.flat().every((line) => visibleWidth(line) <= 26));
@@ -643,11 +647,11 @@ test("main and Configuration menus expose current state and a clear Back path", 
 		},
 	});
 	await mock.commands.get("starship")?.handler("", context.ctx);
-	assert.equal(call, 3);
+	assert.equal(call, 5);
 	assert.match(screens[1] ?? "", /Configuration/u);
-	assert.match(screens[1] ?? "", /State: Built-in defaults/u);
-	assert.match(screens[1] ?? "", /Source: No settings file/u);
-	assert.match(screens[2] ?? "", /Customize footer/u);
+	assert.match(screens[2] ?? "", /State: Built-in defaults/u);
+	assert.match(screens[2] ?? "", /Source: No settings file/u);
+	assert.match(screens[4] ?? "", /Customize footer/u);
 });
 
 test("Restore previews, confirms, and atomically applies the built-in footer", async () => {
@@ -798,7 +802,15 @@ test("Configuration and Help stay shallow and fit narrow terminals", async () =>
 			apply() {},
 			settingsPath: path,
 		});
-		const choices = ["Configuration", undefined, "Help", undefined, undefined];
+		const choices = [
+			"Configuration",
+			"Overview",
+			undefined,
+			undefined,
+			"Help",
+			undefined,
+			undefined,
+		];
 		const screens: string[] = [];
 		const context = createMockContext({
 			mode: "tui",
@@ -809,7 +821,7 @@ test("Configuration and Help stay shallow and fit narrow terminals", async () =>
 			},
 		});
 		await mock.commands.get("starship")?.handler("", context.ctx);
-		assert.equal(screens.length, 5);
+		assert.equal(screens.length, 7);
 		assert.match(screens.join("\n"), /1 warning/u);
 		assert.match(screens.join("\n"), /Configuration/u);
 		assert.match(screens.join("\n"), /pi-starship help/u);

--- a/packages/pi-starship/test/config.test.ts
+++ b/packages/pi-starship/test/config.test.ts
@@ -10,6 +10,7 @@ import fs, {
 import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { parse } from "smol-toml";
 import { test } from "vitest";
 import {
 	atomicSaveConfigDocument,
@@ -22,6 +23,8 @@ import {
 	settingsFilePath,
 	validateConfigDocument,
 } from "../src/config.js";
+import { projectEffectiveConfig, serializeEffectiveConfig } from "../src/effective-config.js";
+import { MODULE_DEFINITIONS } from "../src/modules/catalog.js";
 import { reachableModuleRequirements } from "../src/modules/index.js";
 import { presetForDocument, STARSHIP_PRESETS } from "../src/presets/catalog.js";
 
@@ -81,6 +84,46 @@ test("bundled presets are distinct, valid, and limited to local core modules", (
 		assert.equal(presetForDocument(`${preset.rawDocument}\n`), undefined);
 	}
 	assert.equal(presetForDocument(undefined), undefined);
+});
+
+test("effective configuration projects every public catalog field in stable order", () => {
+	const projected = projectEffectiveConfig(BUILT_IN_CONFIG);
+	assert.deepEqual(Object.keys(projected), ["format", "palettes", ...MODULE_NAMES]);
+	for (const definition of MODULE_DEFINITIONS) {
+		const table = projected[definition.name];
+		assert.equal(typeof table, "object", definition.name);
+		assert.equal(Array.isArray(table), false, definition.name);
+		assert.equal(Object.hasOwn(table as object, "formatAst"), false, definition.name);
+		assert.equal(Object.hasOwn(table as object, "format"), true, definition.name);
+		assert.equal(Object.hasOwn(table as object, "symbol"), true, definition.name);
+		assert.equal(Object.hasOwn(table as object, "disabled"), true, definition.name);
+		for (const option of Object.keys(definition.options ?? {})) {
+			assert.equal(Object.hasOwn(table as object, option), true, `${definition.name}.${option}`);
+		}
+	}
+	const serialized = serializeEffectiveConfig(BUILT_IN_CONFIG);
+	assert.equal(serialized, serializeEffectiveConfig(BUILT_IN_CONFIG));
+	assert.doesNotMatch(serialized, /formatAst|styleSelectors|maxStatuses/u);
+	assert.ok(serialized.indexOf("[brand]") < serialized.indexOf("[provider]"));
+	assert.ok(serialized.indexOf("[provider]") < serialized.indexOf("[model]"));
+	assert.deepEqual(normalizeConfig(parse(serialized)).config, BUILT_IN_CONFIG);
+});
+
+test("effective configuration normalizes custom public values without document-only data", () => {
+	const loaded = validateConfigDocument(
+		"/effective/pi-starship.toml",
+		`format = '$model$git_metrics$context$extension_status'\npalette = 'demo'\nfuture = 'document only'\n\n[palettes.demo]\nz = '#654321'\naccent = '#123456'\n\n[model]\nformat = '[$symbol$model]($style)'\nsymbol = 'M '\nstyle = 'bold accent'\ndisabled = false\ntruncation_length = 12\nmodel_aliases = { z = 'last', a = 'first' }\n\n[git_metrics]\nadded_style = 'green'\ndeleted_style = 'red'\ndisabled = false\n\n[[context.display]]\nthreshold = 0\nstyle = 'accent'\nhidden = false\n\n[extension_status]\nseparator = ' / '\nmax_statuses = 3\nicons = { demo = 'D' }\n`,
+	);
+	const serialized = serializeEffectiveConfig(loaded.config);
+	const reparsed = normalizeConfig(parse(serialized));
+	assert.deepEqual(reparsed.diagnostics, []);
+	assert.deepEqual(reparsed.config, loaded.config);
+	assert.doesNotMatch(serialized, /future|document only/u);
+	assert.match(serialized, /palette = "demo"/u);
+	assert.match(serialized, /max_statuses = 3/u);
+	assert.match(serialized, /truncation_length = 12/u);
+	assert.ok(serialized.indexOf('accent = "#123456"') < serialized.indexOf('z = "#654321"'));
+	assert.ok(serialized.indexOf('a = "first"') < serialized.indexOf('z = "last"'));
 });
 
 test("config path uses the agent directory and missing settings use built-in defaults", () => {


### PR DESCRIPTION
## Summary

- Add a nested Configuration section with Overview, Effective configuration, Settings document, and Reload from disk.
- Serialize normalized public TOML in stable catalog and map-key order without exposing comments, unknown fields, ASTs, or private runtime selectors.
- Reload a final revalidated disk snapshot after preview and confirmation, including deliberate file removal to built-in defaults, without writing settings.
- Preserve the prior runtime state on invalid, stale, cancelled, replaced, shut down, or failed reload flows.
- Update documentation, the command roadmap, lifecycle coverage, and release intent.

## Verification

- `npm --workspace @narumitw/pi-starship run check`
- `npm run check`
- `npm test` — 384 files and 3,643 tests passed.
- `just pack starship` — 102 intended files; generated split runtime included.
- Focused Phase 5, lifecycle, projection, and build-runtime tests — 55 tests passed after hardening.
- Signed commits verified with the configured SSH signing key.

## Audits and risks

- Audited against `docs/extension-conventions.md` and `docs/extension-settings.md` for command modes, stale generations, read/write ordering, invalid-file protection, cancellation, disposal, replacement, shutdown, and display safety.
- Read-only views derive only from the active snapshot, and reload performs no file mutation or collector work before successful runtime apply.
- Exact settings text remains raw in state while Pi TUI Kit sanitizes controls and hard-wraps by terminal cells at the display boundary.
- Interactive `pi -e` smoke was not opened because the coding harness forbids interactive TUI commands; deterministic TUI command and lifecycle harnesses cover the same paths.
- Phase 5 roadmap milestones remain unchecked until merge evidence is recorded.
- No package was published, no tag was created, and no release workflow was dispatched.
