### PR TITLE
perf(tui-kit): defer syntax highlighter loading

### DIFF
--- a/.changeset/quick-tools-wait.md
+++ b/.changeset/quick-tools-wait.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": patch
+---
+
+Defer syntax highlighter initialization until a code review first requests it.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -43,7 +43,9 @@ Publish a new Kit API before raising a consumer's compatibility floor to use it,
 
 The Kit's production JavaScript imports Pi TUI at runtime but keeps Pi Coding Agent imports type-only.
 This prevents a source-loaded extension from evaluating a second heavyweight coding-agent runtime when its menu first opens.
-Borders and task loaders compose public Pi TUI primitives with the theme and keybindings supplied by the active UI callback; review syntax coloring uses the Kit's declared highlighter dependency and the same callback theme.
+Borders and task loaders compose public Pi TUI primitives with the theme and keybindings supplied by the active UI callback.
+Review syntax coloring synchronously loads the Kit's complete declared highlighter dependency on first use and applies the same callback theme.
+Root imports, ordinary menus, task frames, and Markdown-only reviews do not evaluate that highlighter.
 Mermaid rendering lazy-loads its declared renderer only before the first screen containing an enabled Mermaid fence.
 
 The `terminal-text` and `interaction-hints` subpaths expose only their focused ESM and declaration graphs, while the package root keeps every existing export for compatibility.
@@ -55,7 +57,7 @@ npm run build --workspace @narumitw/pi-tui-kit
 node scripts/benchmark-tui-kit-runtime.mjs --runs 5
 ```
 
-The benchmark reports medians, median absolute deviations, resolved package URLs, and graph-presence flags so a fast import cannot hide the same dependency cost in the first interaction.
+The benchmark reports medians, median absolute deviations, resolved package URLs, syntax-color evidence, and graph-presence flags so a fast import cannot hide the same dependency cost in the first interaction.
 
 ## 🚀 Quick start
 

--- a/packages/pi-tui-kit/src/components/syntax-highlighting.ts
+++ b/packages/pi-tui-kit/src/components/syntax-highlighting.ts
@@ -1,5 +1,9 @@
+import { createRequire } from "node:module";
 import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
-import hljs from "highlight.js";
+import type { HLJSApi } from "highlight.js";
+
+const require = createRequire(import.meta.url);
+let highlighter: HLJSApi | undefined;
 
 export type SyntaxTheme = Pick<Theme, "fg" | "bold"> & Partial<Pick<Theme, "italic" | "underline">>;
 
@@ -101,15 +105,40 @@ export function highlightCode(
 	language: string | undefined,
 	theme: SyntaxTheme,
 ): string {
-	if (!language || !hljs.getLanguage(language)) {
-		return theme.fg("mdCodeBlock", theme.fg("mdCodeBlock", code));
-	}
+	if (!language) return plainCode(code, theme);
+	const hljs = loadHighlighter();
+	if (!hljs.getLanguage(language)) return plainCode(code, theme);
 	try {
 		const html = hljs.highlight(code, { language, ignoreIllegals: true }).value;
 		return theme.fg("mdCodeBlock", renderHighlightedHtml(html, syntaxFormatters(theme)));
 	} catch {
 		return theme.fg("mdCodeBlock", code);
 	}
+}
+
+function loadHighlighter(): HLJSApi {
+	if (highlighter) return highlighter;
+	const loaded = require("highlight.js") as unknown;
+	const candidate = highlightApi(loaded) ?? highlightApi(moduleDefault(loaded));
+	if (!candidate) throw new TypeError("highlight.js did not expose its expected API");
+	highlighter = candidate;
+	return candidate;
+}
+
+function highlightApi(value: unknown): HLJSApi | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const candidate = value as Partial<HLJSApi>;
+	return typeof candidate.getLanguage === "function" && typeof candidate.highlight === "function"
+		? (candidate as HLJSApi)
+		: undefined;
+}
+
+function moduleDefault(value: unknown): unknown {
+	return value && typeof value === "object" && "default" in value ? value.default : undefined;
+}
+
+function plainCode(code: string, theme: SyntaxTheme): string {
+	return theme.fg("mdCodeBlock", theme.fg("mdCodeBlock", code));
 }
 
 function syntaxFormatters(theme: SyntaxTheme): Readonly<Record<string, Formatter>> {

--- a/packages/pi-tui-kit/test/lazy-syntax-highlighting.test.ts
+++ b/packages/pi-tui-kit/test/lazy-syntax-highlighting.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { test } from "vitest";
+
+interface BenchmarkWorkerResult {
+	firstFrameMs?: number;
+	highlightJsLoaded: boolean;
+	packageUrls: string[];
+	scenario: string;
+	syntaxHighlighted: boolean;
+}
+
+const benchmarkScript = path.resolve("scripts/benchmark-tui-kit-runtime.mjs");
+
+test("fresh Kit processes load syntax highlighting only for code review", () => {
+	const rootImport = runWorker("import");
+	const actions = runWorker("actions");
+	const review = runWorker("review");
+
+	assert.equal(rootImport.highlightJsLoaded, false);
+	assert.equal(kitHighlighterLoaded(rootImport), false);
+	assert.equal(actions.highlightJsLoaded, false);
+	assert.equal(actions.syntaxHighlighted, false);
+	assert.equal(kitHighlighterLoaded(actions), false);
+	assert.equal(typeof actions.firstFrameMs, "number");
+	assert.equal(review.highlightJsLoaded, true);
+	assert.equal(review.syntaxHighlighted, true);
+	assert.equal(kitHighlighterLoaded(review), true);
+	assert.equal(typeof review.firstFrameMs, "number");
+});
+
+function runWorker(scenario: "actions" | "import" | "review"): BenchmarkWorkerResult {
+	return JSON.parse(
+		execFileSync(process.execPath, [benchmarkScript, "--worker", scenario], {
+			encoding: "utf8",
+		}),
+	) as BenchmarkWorkerResult;
+}
+
+function kitHighlighterLoaded(result: BenchmarkWorkerResult): boolean {
+	return result.packageUrls.some((url) => url.includes("/pi-tui-kit/node_modules/highlight.js/"));
+}

--- a/scripts/benchmark-tui-kit-runtime.mjs
+++ b/scripts/benchmark-tui-kit-runtime.mjs
@@ -60,6 +60,7 @@ if (options.worker) {
 				mermaidRendererLoaded: measurements[scenario].some(
 					(result) => result.mermaidRendererLoaded,
 				),
+				syntaxHighlighted: measurements[scenario].some((result) => result.syntaxHighlighted),
 			},
 		]),
 	);
@@ -106,29 +107,30 @@ async function runWorker(scenario) {
 		initTheme("dark", false);
 	}
 	let firstFrameMs;
+	let syntaxHighlighted = false;
 	if (scenario === "actions") {
-		firstFrameMs = await runMenuFrame(kit, startedAt, {
+		({ firstFrameMs, syntaxHighlighted } = await runMenuFrame(kit, startedAt, {
 			kind: "actions",
 			title: "Benchmark actions",
 			items: [{ id: "close", label: "Close", close: true }],
 			hint: "close",
-		});
+		}));
 	} else if (scenario === "review") {
-		firstFrameMs = await runMenuFrame(kit, startedAt, {
+		({ firstFrameMs, syntaxHighlighted } = await runMenuFrame(kit, startedAt, {
 			kind: "review",
 			title: "Benchmark review",
 			content: "const answer: number = 42;",
 			format: { kind: "code", filePath: "benchmark.ts" },
 			hint: "close",
-		});
+		}));
 	} else if (scenario === "mermaid") {
-		firstFrameMs = await runMenuFrame(kit, startedAt, {
+		({ firstFrameMs, syntaxHighlighted } = await runMenuFrame(kit, startedAt, {
 			kind: "review",
 			title: "Benchmark Mermaid",
 			content: "```mermaid\nflowchart LR\n A[Start] --> B[Done]\n```",
 			format: { kind: "markdown" },
 			hint: "close",
-		});
+		}));
 	} else if (scenario === "task") {
 		const context = benchmarkContext(
 			(elapsed) => {
@@ -166,6 +168,7 @@ async function runWorker(scenario) {
 			),
 			highlightJsLoaded: packageUrls.some((url) => url.includes("/highlight.js/")),
 			mermaidRendererLoaded: packageUrls.some((url) => url.includes("/grok-mermaid/")),
+			syntaxHighlighted,
 			packageUrls,
 		})}\n`,
 	);
@@ -181,8 +184,10 @@ function kitDistRelativePath(url) {
 
 async function runMenuFrame(kit, startedAt, screen) {
 	let firstFrameMs;
-	const context = benchmarkContext((elapsed) => {
+	let syntaxHighlighted = false;
+	const context = benchmarkContext((elapsed, frame) => {
 		firstFrameMs ??= elapsed;
+		syntaxHighlighted ||= frame.syntaxHighlighted;
 	}, startedAt);
 	const menu = kit.defineMenu({
 		start: "main",
@@ -192,12 +197,16 @@ async function runMenuFrame(kit, startedAt, screen) {
 	const result = await kit.runMenu(context, menu, { getState: () => undefined });
 	if (result.kind !== "closed") throw new Error(`Unexpected menu result: ${result.kind}`);
 	if (firstFrameMs === undefined) throw new Error("Menu did not render a frame");
-	return firstFrameMs;
+	return { firstFrameMs, syntaxHighlighted };
 }
 
 function benchmarkContext(onFirstFrame, startedAt, closeAfterFirstFrame = true) {
+	let syntaxHighlighted = false;
 	const theme = {
-		fg: (_color, text) => text,
+		fg: (color, text) => {
+			syntaxHighlighted ||= color.startsWith("syntax");
+			return text;
+		},
 		bold: (text) => text,
 		italic: (text) => text,
 		underline: (text) => text,
@@ -224,7 +233,7 @@ function benchmarkContext(onFirstFrame, startedAt, closeAfterFirstFrame = true) 
 				});
 				const component = factory(tui, theme, keybindings, resolveResult);
 				component.render(80);
-				onFirstFrame(performance.now() - startedAt);
+				onFirstFrame(performance.now() - startedAt, { syntaxHighlighted });
 				if (closeAfterFirstFrame) resolveResult(undefined);
 				const result = await resultPromise;
 				component.dispose?.();


### PR DESCRIPTION
## Summary

- Load the Kit-owned `highlight.js` graph only when a code review first requests syntax coloring.
- Preserve the complete highlighter language catalog, aliases, callback theme formatting, and public exports.
- Add fresh-process graph coverage, syntax-color benchmark evidence, runtime documentation, and a patch Changeset.

## Performance

Five measured runs after warm-up on Node v26.5.0 produced these medians:

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Root import | 113.73 ms | 53.77 ms | -59.96 ms |
| Actions first frame | 113.13 ms | 56.89 ms | -56.24 ms |
| Mermaid first frame | 127.91 ms | 73.69 ms | -54.22 ms |
| Task first frame | 113.38 ms | 57.04 ms | -56.34 ms |
| Code-review first frame | 126.27 ms | 125.12 ms | -1.15 ms |

Root, actions, Mermaid, and task scenarios no longer load the Kit-owned highlighter.
The code-review scenario still loads it and records syntax-color use.

## Verification

- `npm exec -- vitest run packages/pi-tui-kit/test/lazy-syntax-highlighting.test.ts packages/pi-tui-kit/test/review-screen.test.ts` — 20 tests passed.
- `node scripts/benchmark-tui-kit-runtime.mjs --runs 5` — completed with medians, median absolute deviations, graph flags, resolved URLs, and syntax-color evidence.
- `npm run changeset:status` — passed and reports the Kit patch intent.
- `npm run check` — passed build, Biome, boundaries, and all workspace typechecks.
- `npm test` — 385 files and 3,644 tests passed.
- `just pack tui-kit` — passed and inspected 65 publishable files.

## Audit and risks

The diff was audited against `docs/extension-conventions.md` and `packages/pi-tui-kit/AGENTS.md`.
It does not change public exports, package dependencies, settings, terminal-input boundaries, asynchronous UI flows, cancellation, disposal, session replacement, or shutdown behavior.
The first syntax-colored code review intentionally retains the complete highlighter initialization cost to avoid narrowing language compatibility.
There are no skipped checks or unverified paths.
No package was published and no release workflow was dispatched.
