### PR TITLE
docs: add bug and feature issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,99 @@
+name: Bug report
+description: Report a reproducible problem with a package in this repository.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+        Please search existing issues before submitting a new report and remove any secrets from logs or screenshots.
+
+  - type: input
+    id: package
+    attributes:
+      label: Package
+      description: Which package is affected?
+      placeholder: "@narumitw/pi-example"
+    validations:
+      required: true
+
+  - type: input
+    id: package-version
+    attributes:
+      label: Package version
+      description: Which version of the affected package are you using?
+      placeholder: "For example: 1.2.3"
+    validations:
+      required: true
+
+  - type: input
+    id: pi-version
+    attributes:
+      label: Pi version
+      description: Run `pi --version` and paste the result.
+      placeholder: "For example: 0.84.2"
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include your operating system, architecture, terminal, and relevant runtime versions.
+      placeholder: "For example: Ubuntu 24.04, x64, Ghostty, Node.js 22"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest set of steps or a minimal repository that reproduces the problem.
+      placeholder: |
+        1. Install ...
+        2. Configure ...
+        3. Run ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Add relevant output, stack traces, or screenshots after removing secrets and personal data.
+      render: shell
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other details that may help diagnose the problem.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+        - label: I removed API keys, tokens, credentials, and other sensitive data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Suggest an improvement or new capability for a package in this repository.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the project.
+        Please describe the need before proposing a specific implementation.
+
+  - type: input
+    id: package
+    attributes:
+      label: Package
+      description: Which existing package should own this feature, or are you proposing a new package?
+      placeholder: "For example: @narumitw/pi-example or new package"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem would this feature solve, and who would benefit from it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the desired behavior from a user's perspective.
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example usage
+      description: Show how the feature might be configured or used, if applicable.
+      render: shell
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workarounds or alternative approaches you considered.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add related issues, screenshots, references, or other useful details.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched the existing issues and did not find a duplicate request.
+          required: true
+        - label: This request describes one focused feature or improvement.
+          required: true


### PR DESCRIPTION
## Summary

- Add a bug report form with package, environment, reproduction, expected behavior, and sensitive-data checks.
- Add a feature request form focused on the problem, proposed behavior, example usage, and alternatives.
- Apply the existing `bug` and `enhancement` labels automatically.

## Checks

- Parsed both files as YAML and checked their basic GitHub Issue Form structure.
- Ran `git diff --cached --check`.
- Confirmed the referenced labels exist in the repository.
