### PR TITLE
feat(plan): add navigable question review

### DIFF
--- a/.changeset/bright-plans-navigate.md
+++ b/.changeset/bright-plans-navigate.md
@@ -1,0 +1,6 @@
+---
+"@narumitw/pi-plan-mode": minor
+"@narumitw/pi-workflow": minor
+---
+
+Add tabbed TUI Plan questions with answer notes and final review.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -75,7 +75,7 @@ The bounded multi-select shows 10 rows at a time, supports viewport paging, desc
 In TUI mode, type to fuzzy-search tool names, descriptions, policy, and source metadata; RPC keeps the complete unfiltered list.
 Once Plan mode is active, tools are locked: `/plan` no longer offers tool or Settings actions, and `/plan tools` rejects the request.
 Exit and start a new workflow if a different tool set is required.
-The `plan_mode_question` tool keeps its one-off question/choice dialog because it is a model-requested planning interaction, not command-menu navigation.
+The `plan_mode_question` tool keeps a dedicated model-requested questionnaire instead of using command-menu navigation.
 `/plan show` displays the stored plan without starting a model turn, including the accepted plan while implementation is active.
 `/plan finalize` explicitly asks the agent to complete the plan or ask one remaining material question, `/plan save` stores a completed ready plan for later and leaves Plan mode, and `/plan export [path]` writes a ready, saved, or active implementation plan to Markdown.
 Completed and saved plan menus offer **Implement here**, which continues with the planning conversation, and **Start fresh and implement**, which opens a new session and transfers only the approved plan.
@@ -122,6 +122,14 @@ Tests and builds may still write ignored caches or build artifacts and may execu
 This is extension-level risk reduction, not an OS sandbox.
 
 `plan_mode_question` follows Codex's `request_user_input` pattern: the agent can ask 1-3 concise questions, each with meaningful options and a free-form Other path.
+In TUI mode, one question appears at a time with question tabs and a final Review tab.
+Use Tab, Shift+Tab, left, or right to visit any question or Review, including unanswered future questions.
+Use up and down to choose an option, Enter to record it and advance, or `n` to record the highlighted option and open its optional note editor. Press `n` again on an answered item to edit or clear its note.
+Revisit a question to replace its answer; changing the chosen option clears its prior note.
+Review lists every answer and note, lets up and down select an answer for note editing, and submits the ordered payload only after every question is answered.
+Custom answers and notes retain their raw submitted text in the tool result, while terminal rendering is sanitized.
+The TUI rejects either field above 4,000 characters instead of truncating it.
+RPC keeps the existing sequential `select` and `editor` dialogs because Pi RPC cannot render custom TUI components.
 If you cancel or no interactive UI is available, the agent should ask a concise plain-text question or proceed only with a clearly stated low-risk assumption instead of prematurely producing a final plan.
 
 Pi activates tools by tool name.
@@ -212,7 +220,7 @@ During implementation, it removes both the original implementation handoff and t
 
 ## 🛠️ Tools
 
-- `plan_mode_question` asks up to three structured questions for material preferences or tradeoffs.
+- `plan_mode_question` asks up to three structured questions, supports optional answer notes, and reviews the ordered result before TUI submission.
 - `plan_mode_complete` records the complete approved Markdown plan and terminates the planning turn when called alone.
 
 ## ⚙️ Settings

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -1,6 +1,20 @@
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { stripVTControlCharacters } from "node:util";
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import {
+	type Component,
+	Editor,
+	type EditorTheme,
+	type Focusable,
+	Key,
+	matchesKey,
+	sliceByColumn,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 
 export const PLAN_MODE_QUESTION_TOOL_NAME = "plan_mode_question";
+export const MAX_PLAN_MODE_RESPONSE_LENGTH = 4_000;
 
 export type PlanModeQuestionOption = {
 	label: string;
@@ -14,13 +28,14 @@ export type PlanModeQuestion = {
 	options: PlanModeQuestionOption[];
 };
 
-type PlanModeQuestionAnswer = {
+export type PlanModeQuestionAnswer = {
 	id: string;
 	header: string;
 	question: string;
 	answer: string;
 	wasCustom: boolean;
 	optionIndex?: number;
+	note?: string;
 };
 
 type PlanModeQuestionReason =
@@ -187,6 +202,28 @@ export async function askPlanModeQuestions(
 	ctx: ExtensionContext,
 	shouldContinue: () => boolean = () => true,
 ): Promise<PlanModeQuestionAnswer[] | undefined> {
+	if (ctx.mode === "tui") {
+		const answers = await ctx.ui.custom<PlanModeQuestionAnswer[] | undefined>(
+			(tui, theme, _keybindings, done) =>
+				new PlanModeQuestionnaire({
+					questions,
+					tui,
+					theme,
+					shouldContinue,
+					signal: ctx.signal,
+					onDone: done,
+				}),
+		);
+		return shouldContinue() ? answers : undefined;
+	}
+	return askPlanModeQuestionsSequentially(questions, ctx, shouldContinue);
+}
+
+async function askPlanModeQuestionsSequentially(
+	questions: PlanModeQuestion[],
+	ctx: ExtensionContext,
+	shouldContinue: () => boolean,
+): Promise<PlanModeQuestionAnswer[] | undefined> {
 	const answers: PlanModeQuestionAnswer[] = [];
 	for (const question of questions) {
 		const choices = question.options.map(formatPlanModeQuestionChoice);
@@ -197,30 +234,394 @@ export async function askPlanModeQuestions(
 		]);
 		if (!shouldContinue() || !choice) return undefined;
 		if (choice === otherChoice) {
-			const customAnswer = (await ctx.ui.editor(question.question, ""))?.trim();
-			if (!shouldContinue() || !customAnswer) return undefined;
-			answers.push({
-				id: question.id,
-				header: question.header,
-				question: question.question,
-				answer: customAnswer,
-				wasCustom: true,
-			});
+			const customAnswer = await askCustomAnswer(question, ctx, shouldContinue);
+			if (customAnswer === undefined) return undefined;
+			answers.push(answerFor(question, customAnswer, { wasCustom: true }));
 			continue;
 		}
 		const optionIndex = choices.indexOf(choice);
 		const option = question.options[optionIndex];
 		if (!option) return undefined;
-		answers.push({
-			id: question.id,
-			header: question.header,
-			question: question.question,
-			answer: option.label,
-			wasCustom: false,
-			optionIndex: optionIndex + 1,
-		});
+		answers.push(
+			answerFor(question, option.label, { wasCustom: false, optionIndex: optionIndex + 1 }),
+		);
 	}
 	return answers;
+}
+
+async function askCustomAnswer(
+	question: PlanModeQuestion,
+	ctx: ExtensionContext,
+	shouldContinue: () => boolean,
+): Promise<string | undefined> {
+	let draft = "";
+	for (;;) {
+		const customAnswer = await ctx.ui.editor(question.question, draft);
+		if (!shouldContinue() || !customAnswer?.trim()) return undefined;
+		if (customAnswer.length <= MAX_PLAN_MODE_RESPONSE_LENGTH) return customAnswer;
+		draft = customAnswer;
+		ctx.ui.notify("Custom answer must be 4,000 characters or fewer.", "warning");
+	}
+}
+
+interface QuestionnaireOptions {
+	questions: PlanModeQuestion[];
+	tui: TUI;
+	theme: Theme;
+	shouldContinue(): boolean;
+	signal?: AbortSignal;
+	onDone(answers: PlanModeQuestionAnswer[] | undefined): void;
+}
+
+export class PlanModeQuestionnaire implements Component, Focusable {
+	private readonly options: QuestionnaireOptions;
+	private readonly editor: Editor;
+	private readonly answers: Array<PlanModeQuestionAnswer | undefined>;
+	private readonly selectedOptions: number[];
+	private page = 0;
+	private reviewSelection = 0;
+	private editorKind: "answer" | "note" | undefined;
+	private message: string | undefined;
+	private finished = false;
+	private removeAbort = () => {};
+	private _focused = false;
+
+	constructor(options: QuestionnaireOptions) {
+		this.options = options;
+		this.answers = options.questions.map(() => undefined);
+		this.selectedOptions = options.questions.map(() => 0);
+		const editorTheme: EditorTheme = {
+			borderColor: (text) => options.theme.fg("accent", text),
+			selectList: {
+				selectedPrefix: (text) => options.theme.fg("accent", text),
+				selectedText: (text) => options.theme.fg("accent", text),
+				description: (text) => options.theme.fg("muted", text),
+				scrollInfo: (text) => options.theme.fg("dim", text),
+				noMatch: (text) => options.theme.fg("warning", text),
+			},
+		};
+		this.editor = new Editor(options.tui, editorTheme, { paddingX: 0 });
+		this.editor.onChange = () => {
+			this.message = undefined;
+		};
+		this.editor.onSubmit = (text) => this.submitEditor(text);
+		if (options.signal) {
+			const abort = () => this.finish(undefined);
+			options.signal.addEventListener("abort", abort, { once: true });
+			this.removeAbort = () => options.signal?.removeEventListener("abort", abort);
+			if (options.signal.aborted) abort();
+		}
+	}
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	set focused(value: boolean) {
+		this._focused = value;
+		this.editor.focused = value && this.editorKind !== undefined;
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const lines = [this.renderTabs(safeWidth), ""];
+		if (this.page === this.options.questions.length) lines.push(...this.renderReview(safeWidth));
+		else lines.push(...this.renderQuestion(safeWidth));
+		if (this.message)
+			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), safeWidth));
+		lines.push("");
+		lines.push(
+			truncateToWidth(
+				this.options.theme.fg(
+					"dim",
+					this.editorKind
+						? "Enter save · Esc/Ctrl+C cancel questionnaire"
+						: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer/submit · n note · Esc cancel",
+				),
+				safeWidth,
+			),
+		);
+		return lines.map((line) => truncateToWidth(line, safeWidth));
+	}
+
+	handleInput(data: string): void {
+		if (this.finished) return;
+		if (!this.options.shouldContinue() || this.isCancel(data)) {
+			this.finish(undefined);
+			return;
+		}
+		if (this.editorKind) this.handleEditorInput(data);
+		else this.handlePageInput(data);
+		this.options.tui.requestRender();
+	}
+
+	invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	dispose(): void {
+		this.finish(undefined);
+	}
+
+	private isCancel(data: string): boolean {
+		return matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"));
+	}
+
+	private handleEditorInput(data: string): void {
+		if (matchesKey(data, Key.enter)) this.submitEditor(this.editor.getExpandedText());
+		else this.editor.handleInput(data);
+	}
+
+	private handlePageInput(data: string): void {
+		if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
+			this.movePage(1);
+			return;
+		}
+		if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left)) {
+			this.movePage(-1);
+			return;
+		}
+		if (matchesKey(data, Key.up)) {
+			this.moveSelection(-1);
+			return;
+		}
+		if (matchesKey(data, Key.down)) {
+			this.moveSelection(1);
+			return;
+		}
+		if (data.toLowerCase() === "n") {
+			this.editNote();
+			return;
+		}
+		if (matchesKey(data, Key.enter)) this.submitPage();
+	}
+
+	private movePage(delta: number): void {
+		const pageCount = this.options.questions.length + 1;
+		this.page = (this.page + delta + pageCount) % pageCount;
+		this.message = undefined;
+	}
+
+	private renderTabs(width: number): string {
+		const tabs = [
+			...this.options.questions.map((question, index) => {
+				const label = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
+				const answered = this.answers[index] ? "✓ " : "";
+				return this.page === index ? `[${answered}${label}]` : `${answered}${label}`;
+			}),
+			this.page === this.options.questions.length ? "[Review]" : "Review",
+		];
+		return truncateToWidth(this.options.theme.fg("accent", tabs.join("  ")), width, "…");
+	}
+
+	private renderQuestion(width: number): string[] {
+		const question = this.options.questions[this.page];
+		if (!question) return [];
+		const lines = hardWrap(
+			this.options.theme.fg("text", sanitizeTerminalText(question.question)),
+			width,
+		);
+		lines.push("");
+		question.options.forEach((option, index) => {
+			const cursor = this.selectedOptions[this.page] === index ? "›" : " ";
+			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? "●" : "○";
+			const label = `${cursor} ${chosen} ${sanitizeTerminalText(option.label)}`;
+			lines.push(...hardWrap(this.options.theme.fg("text", label), width));
+			if (option.description) {
+				lines.push(
+					...hardWrap(
+						`    ${this.options.theme.fg("muted", sanitizeTerminalText(option.description))}`,
+						width,
+					),
+				);
+			}
+		});
+		const otherIndex = question.options.length;
+		const otherCursor = this.selectedOptions[this.page] === otherIndex ? "›" : " ";
+		const otherChosen = this.answers[this.page]?.wasCustom ? "●" : "○";
+		lines.push(`${otherCursor} ${otherChosen} Other (free-form)`);
+		const answer = this.answers[this.page];
+		if (answer?.wasCustom)
+			lines.push(...labeledRaw("Answer", answer.answer, width, this.options.theme));
+		if (answer?.note) lines.push(...labeledRaw("Note", answer.note, width, this.options.theme));
+		if (this.editorKind) {
+			lines.push("");
+			lines.push(
+				this.options.theme.fg(
+					"accent",
+					this.editorKind === "answer" ? "Custom answer" : "Optional note",
+				),
+			);
+			lines.push(...this.editor.render(width));
+		}
+		return lines;
+	}
+
+	private renderReview(width: number): string[] {
+		const lines = [this.options.theme.fg("text", "Review answers")];
+		this.options.questions.forEach((question, index) => {
+			const answer = this.answers[index];
+			const cursor = this.reviewSelection === index ? "›" : " ";
+			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
+			lines.push("");
+			lines.push(`${cursor} ${this.options.theme.fg("accent", header)}`);
+			lines.push(
+				...labeledRaw("Answer", answer?.answer ?? "Unanswered", width, this.options.theme),
+			);
+			if (answer?.note) lines.push(...labeledRaw("Note", answer.note, width, this.options.theme));
+		});
+		if (this.editorKind === "note") {
+			lines.push("");
+			lines.push(this.options.theme.fg("accent", "Optional note"));
+			lines.push(...this.editor.render(width));
+		}
+		return lines;
+	}
+
+	private moveSelection(delta: number): void {
+		if (this.page === this.options.questions.length) {
+			this.reviewSelection =
+				(this.reviewSelection + delta + this.options.questions.length) %
+				this.options.questions.length;
+			return;
+		}
+		const optionCount = (this.options.questions[this.page]?.options.length ?? 0) + 1;
+		this.selectedOptions[this.page] =
+			((this.selectedOptions[this.page] ?? 0) + delta + optionCount) % optionCount;
+	}
+
+	private submitPage(): void {
+		if (this.page === this.options.questions.length) {
+			const firstMissing = this.answers.findIndex((answer) => !answer);
+			if (firstMissing >= 0) {
+				this.message = "Answer every question before submitting.";
+				return;
+			}
+			this.finish(
+				this.answers.filter((answer): answer is PlanModeQuestionAnswer => answer !== undefined),
+			);
+			return;
+		}
+		const question = this.options.questions[this.page];
+		if (!question) return;
+		const selected = this.selectedOptions[this.page] ?? 0;
+		if (selected === question.options.length) {
+			this.beginEditor(
+				"answer",
+				this.answers[this.page]?.wasCustom ? this.answers[this.page]?.answer : "",
+			);
+			return;
+		}
+		const option = question.options[selected];
+		if (!option) return;
+		const previous = this.answers[this.page];
+		this.answers[this.page] = answerFor(question, option.label, {
+			wasCustom: false,
+			optionIndex: selected + 1,
+			note: previous?.optionIndex === selected + 1 ? previous.note : undefined,
+		});
+		this.advance();
+	}
+
+	private editNote(): void {
+		const review = this.page === this.options.questions.length;
+		const index = review ? this.reviewSelection : this.page;
+		let answer = this.answers[index];
+		if (!review) {
+			const question = this.options.questions[index];
+			const selected = this.selectedOptions[index] ?? 0;
+			if (question && selected === question.options.length && !answer?.wasCustom) {
+				this.beginEditor("answer", "");
+				return;
+			}
+			if (question && selected < question.options.length && answer?.optionIndex !== selected + 1) {
+				const option = question.options[selected];
+				if (option) {
+					answer = answerFor(question, option.label, {
+						wasCustom: false,
+						optionIndex: selected + 1,
+					});
+					this.answers[index] = answer;
+				}
+			}
+		}
+		if (!answer) {
+			this.message = "Select an answer before adding a note.";
+			return;
+		}
+		this.beginEditor("note", answer.note ?? "");
+	}
+
+	private beginEditor(kind: "answer" | "note", value: string | undefined): void {
+		this.editorKind = kind;
+		this.editor.setText(value ?? "");
+		this.editor.focused = this._focused;
+		this.message = undefined;
+	}
+
+	private submitEditor(value: string): void {
+		if (value.length > MAX_PLAN_MODE_RESPONSE_LENGTH) {
+			this.editor.setText(value);
+			this.message = `${this.editorKind === "answer" ? "Answer" : "Note"} must be 4,000 characters or fewer.`;
+			this.options.tui.requestRender();
+			return;
+		}
+		const index = this.page === this.options.questions.length ? this.reviewSelection : this.page;
+		if (this.editorKind === "answer") {
+			if (!value.trim()) {
+				this.editor.setText(value);
+				this.message = "Custom answer cannot be empty.";
+				this.options.tui.requestRender();
+				return;
+			}
+			const question = this.options.questions[index];
+			if (!question) return;
+			this.answers[index] = answerFor(question, value, { wasCustom: true });
+			this.editor.setText("");
+			this.editorKind = undefined;
+			this.editor.focused = false;
+			this.advance();
+			return;
+		}
+		const answer = this.answers[index];
+		if (answer) answer.note = value.trim() ? value : undefined;
+		this.editor.setText("");
+		this.editorKind = undefined;
+		this.editor.focused = false;
+		this.message = value.trim() ? "Note saved." : "Note cleared.";
+		this.options.tui.requestRender();
+	}
+
+	private advance(): void {
+		this.page = Math.min(this.page + 1, this.options.questions.length);
+		this.message = undefined;
+	}
+
+	private finish(answers: PlanModeQuestionAnswer[] | undefined): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.removeAbort();
+		this.removeAbort = () => {};
+		this.editor.focused = false;
+		this.options.onDone(answers);
+	}
+}
+
+function answerFor(
+	question: PlanModeQuestion,
+	answer: string,
+	options: { wasCustom: boolean; optionIndex?: number; note?: string },
+): PlanModeQuestionAnswer {
+	const result: PlanModeQuestionAnswer = {
+		id: question.id,
+		header: question.header,
+		question: question.question,
+		answer,
+		wasCustom: options.wasCustom,
+	};
+	if (options.optionIndex !== undefined) result.optionIndex = options.optionIndex;
+	if (options.note !== undefined) result.note = options.note;
+	return result;
 }
 
 function formatPlanModeQuestionChoice(option: PlanModeQuestionOption, index: number) {
@@ -262,6 +663,56 @@ function formatPlanModeQuestionPayload(payload: {
 	answers?: PlanModeQuestionAnswer[];
 }) {
 	return JSON.stringify(payload, null, 2);
+}
+
+export function sanitizeTerminalText(value: string): string {
+	return [...stripVTControlCharacters(value)]
+		.map((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f ||
+				(codePoint >= 0x7f && codePoint <= 0x9f) ||
+				codePoint === 0x2028 ||
+				codePoint === 0x2029 ||
+				isBidiControl(codePoint)
+				? " "
+				: character;
+		})
+		.join("");
+}
+
+function isBidiControl(codePoint: number): boolean {
+	return (
+		codePoint === 0x061c ||
+		codePoint === 0x200e ||
+		codePoint === 0x200f ||
+		(codePoint >= 0x202a && codePoint <= 0x202e) ||
+		(codePoint >= 0x2066 && codePoint <= 0x2069)
+	);
+}
+
+function labeledRaw(label: string, value: string, width: number, theme: Theme): string[] {
+	const prefix = `${label}: `;
+	const safe = sanitizeTerminalText(value);
+	const lines = hardWrap(safe, Math.max(1, width - visibleWidth(prefix)));
+	return lines.map((line, index) =>
+		index === 0 ? `${theme.fg("muted", prefix)}${line}` : `${" ".repeat(prefix.length)}${line}`,
+	);
+}
+
+function hardWrap(value: string, width: number): string[] {
+	const safeWidth = Math.max(1, width);
+	if (!value) return [""];
+	const output: string[] = [];
+	for (const sourceLine of value.split("\n")) {
+		const columns = visibleWidth(sourceLine);
+		if (columns === 0) output.push("");
+		else {
+			for (let column = 0; column < columns; column += safeWidth) {
+				output.push(sliceByColumn(sourceLine, column, safeWidth));
+			}
+		}
+	}
+	return output;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -1,7 +1,49 @@
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import planMode, { normalizePlanModeQuestionParams } from "../src/plan-mode.js";
+import {
+	askPlanModeQuestions,
+	MAX_PLAN_MODE_RESPONSE_LENGTH,
+	type PlanModeQuestion,
+	planModeQuestionAnswered,
+	sanitizeTerminalText,
+} from "../src/question-tool.js";
+
+const questions: PlanModeQuestion[] = [
+	{
+		id: "scope",
+		header: "Scope",
+		question: "How broad?",
+		options: [
+			{ label: "Small", description: "Only the bug." },
+			{ label: "Broad", description: "Include cleanup." },
+		],
+	},
+	{
+		id: "tests",
+		header: "Tests",
+		question: "Which checks?",
+		options: [
+			{ label: "Focused", description: "Run focused checks." },
+			{ label: "Full", description: "Run all checks." },
+		],
+	},
+];
+
+function tuiRun(customQuestions = questions, width = 60) {
+	const tui = createTuiHarness({ width, rows: 30 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions(customQuestions, context.ctx);
+	return { tui, running };
+}
+
+function paste(tui: ReturnType<typeof createTuiHarness>, text: string) {
+	tui.send(`\u001b[200~${text}\u001b[201~`);
+}
 
 test("plan_mode_question reports non-interactive cancellation", async () => {
 	const mock = createMockPi();
@@ -14,19 +56,7 @@ test("plan_mode_question reports non-interactive cancellation", async () => {
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const result = await execute(
 		"call-1",
-		{
-			questions: [
-				{
-					id: "scope",
-					header: "Scope",
-					question: "How broad?",
-					options: [
-						{ label: "Small", description: "Only the bug." },
-						{ label: "Broad", description: "Include cleanup." },
-					],
-				},
-			],
-		},
+		{ questions: [questions[0]] },
 		undefined,
 		undefined,
 		context.ctx,
@@ -34,25 +64,173 @@ test("plan_mode_question reports non-interactive cancellation", async () => {
 	assert.equal(result.details?.reason, "ui_unavailable");
 });
 
-test("normalizePlanModeQuestionParams validates question shape", () => {
-	const result = normalizePlanModeQuestionParams({
-		questions: [
-			{
-				id: "scope",
-				header: "Scope",
-				question: "How broad?",
-				options: [
-					{ label: "Small", description: "Only the bug." },
-					{ label: "Broad", description: "Include nearby cleanup." },
-				],
-			},
-		],
-	});
-
+test("normalizePlanModeQuestionParams validates question shape without changing schema", () => {
+	const result = normalizePlanModeQuestionParams({ questions: [questions[0]] });
 	assert.equal(result.ok, true);
 	if (result.ok) assert.equal(result.questions[0]?.options[1]?.label, "Broad");
 	assert.deepEqual(normalizePlanModeQuestionParams({ questions: [] }), {
 		ok: false,
 		error: "questions must contain 1-3 items",
 	});
+});
+
+test("TUI previews future questions and navigates back before answering", async () => {
+	const { tui, running } = tuiRun();
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	assert.match(tui.render().join("\n"), /\[Scope\].*Tests.*Review/u);
+	tui.send("\t");
+	assert.match(tui.render().join("\n"), /Scope.*\[Tests\].*Review[\s\S]*Which checks\?/u);
+	tui.send("\u001b[Z");
+	assert.match(tui.render().join("\n"), /\[Scope\][\s\S]*How broad\?/u);
+	tui.press("tui.select.cancel");
+	assert.equal(await running, undefined);
+});
+
+test("TUI replaces answers, manages notes, accepts Other, and submits ordered raw payload", async () => {
+	const { tui, running } = tuiRun();
+	await tui.waitForOpen();
+	tui.setFocused(true);
+
+	// Note shortcut selects the highlighted answer before opening the editor.
+	tui.type("n");
+	paste(tui, "initial note");
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /initial note/u);
+
+	// Replacing the selected option clears its old note.
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.send("\u001b[D");
+	assert.doesNotMatch(tui.render().join("\n"), /initial note/u);
+	tui.send("\u001b[C");
+
+	// Other keeps exact user text in the answer payload.
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	paste(tui, "  custom answer  ");
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /Review answers[\s\S]*Broad[\s\S]*custom answer/u);
+
+	// Review selects answers for note add/edit/clear.
+	tui.type("n");
+	paste(tui, "draft note");
+	tui.press("tui.input.submit");
+	tui.type("n");
+	tui.send("\u0015");
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /Note cleared/u);
+	tui.type("n");
+	paste(tui, "final note");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+
+	assert.deepEqual(await running, [
+		{
+			id: "scope",
+			header: "Scope",
+			question: "How broad?",
+			answer: "Broad",
+			wasCustom: false,
+			optionIndex: 2,
+			note: "final note",
+		},
+		{
+			id: "tests",
+			header: "Tests",
+			question: "Which checks?",
+			answer: "  custom answer  ",
+			wasCustom: true,
+		},
+	]);
+});
+
+test("Review blocks incomplete submission and lets selected answer receive a note", async () => {
+	const { tui, running } = tuiRun();
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.send("\u001b[C");
+	tui.send("\u001b[C");
+	tui.press("tui.select.confirm");
+	assert.match(tui.render().join("\n"), /Answer every question before submitting/u);
+	tui.press("tui.select.down");
+	tui.type("n");
+	assert.match(tui.render().join("\n"), /Select an answer before adding a note/u);
+	tui.press("tui.select.cancel");
+	assert.equal(await running, undefined);
+});
+
+test("Other editor rejects oversized input and forwards focus", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.setFocused(true);
+	assert.equal(tui.render().join("\n").includes(CURSOR_MARKER), true);
+	paste(tui, "x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1));
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /4,000 characters or fewer/u);
+	assert.equal(tui.isOpen, true);
+	tui.press("ctrl+c");
+	assert.equal(await running, undefined);
+});
+
+test("TUI sanitizes rendering, preserves raw result text, and respects narrow widths", async () => {
+	const unsafe = "raw\u001b]8;;https://evil.example\u0007text\u001b]8;;\u0007";
+	const malicious: PlanModeQuestion[] = [
+		{
+			id: "unsafe",
+			header: `Head\u001b[31m`,
+			question: unsafe,
+			options: [
+				{ label: unsafe, description: "first" },
+				{ label: "safe", description: "second" },
+			],
+		},
+	];
+	const { tui, running } = tuiRun(malicious, 16);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	const frame = tui.render();
+	const plain = stripVTControlCharacters(frame.join("\n"));
+	assert.doesNotMatch(plain, /evil\.example/u);
+	assert.equal(plain.includes("\u0007") || plain.includes("\u001b"), false);
+	for (const line of frame) assert.ok(visibleWidth(line) <= 16);
+	assert.equal(sanitizeTerminalText(unsafe), "rawtext");
+	const answered = planModeQuestionAnswered(malicious, [
+		{
+			id: "unsafe",
+			header: malicious[0]?.header ?? "",
+			question: unsafe,
+			answer: unsafe,
+			wasCustom: true,
+		},
+	]);
+	assert.match(answered.content[0]?.text ?? "", /evil\.example/u);
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
+test("RPC retains sequential select/editor fallback and retries oversized answers", async () => {
+	const selections = ["1. Small — Only the bug.", "3. Other (free-form)"];
+	const editorAnswers = ["x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1), "rpc custom"];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => selections.shift(),
+		editor: async () => editorAnswers.shift(),
+		custom: async () => assert.fail("RPC must not open custom TUI"),
+	});
+	const answers = await askPlanModeQuestions(questions, context.ctx);
+	assert.deepEqual(
+		answers?.map(({ answer, wasCustom }) => ({ answer, wasCustom })),
+		[
+			{ answer: "Small", wasCustom: false },
+			{ answer: "rpc custom", wasCustom: true },
+		],
+	);
+	assert.ok(context.notifications.some(({ message }) => message.includes("4,000")));
 });

--- a/packages/pi-workflow/README.md
+++ b/packages/pi-workflow/README.md
@@ -161,6 +161,15 @@ It works in TUI and RPC modes and rejects print and JSON modes before opening in
 
 `/plan` retains the Plan-mode read-only tool policy, structured `plan_mode_question` interaction, standalone `plan_mode_complete` completion contract, saved-plan slot, export safety, session persistence, and compaction-aware linked-Plan context.
 
+In TUI mode, `plan_mode_question` shows one question at a time with question tabs and a final Review tab.
+Use Tab, Shift+Tab, left, or right to visit any question or Review, including unanswered future questions.
+Use up and down to choose an option, Enter to record it and advance, or `n` to record the highlighted option and open its optional note editor. Press `n` again on an answered item to edit or clear its note.
+Revisiting a question can replace its answer, and changing the selected option clears its prior note.
+Review lists every answer and note, supports note editing for the selected answer, blocks incomplete submission, and submits all answers together.
+Custom answers and notes retain their raw submitted text in the tool result, while terminal rendering is sanitized.
+The TUI rejects either field above 4,000 characters instead of truncating it.
+RPC keeps the existing sequential `select` and `editor` dialogs because Pi RPC cannot render custom TUI components.
+
 `/plan implement` is the direct compatibility route for starting the ready or saved Plan as Goal in the current session.
 
 A new Plan cannot start while any unfinished Goal exists.

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -1,6 +1,20 @@
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { stripVTControlCharacters } from "node:util";
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import {
+	type Component,
+	Editor,
+	type EditorTheme,
+	type Focusable,
+	Key,
+	matchesKey,
+	sliceByColumn,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 
 export const PLAN_MODE_QUESTION_TOOL_NAME = "plan_mode_question";
+export const MAX_PLAN_MODE_RESPONSE_LENGTH = 4_000;
 
 export type PlanModeQuestionOption = {
 	label: string;
@@ -14,13 +28,14 @@ export type PlanModeQuestion = {
 	options: PlanModeQuestionOption[];
 };
 
-type PlanModeQuestionAnswer = {
+export type PlanModeQuestionAnswer = {
 	id: string;
 	header: string;
 	question: string;
 	answer: string;
 	wasCustom: boolean;
 	optionIndex?: number;
+	note?: string;
 };
 
 type PlanModeQuestionReason =
@@ -187,6 +202,28 @@ export async function askPlanModeQuestions(
 	ctx: ExtensionContext,
 	shouldContinue: () => boolean = () => true,
 ): Promise<PlanModeQuestionAnswer[] | undefined> {
+	if (ctx.mode === "tui") {
+		const answers = await ctx.ui.custom<PlanModeQuestionAnswer[] | undefined>(
+			(tui, theme, _keybindings, done) =>
+				new PlanModeQuestionnaire({
+					questions,
+					tui,
+					theme,
+					shouldContinue,
+					signal: ctx.signal,
+					onDone: done,
+				}),
+		);
+		return shouldContinue() ? answers : undefined;
+	}
+	return askPlanModeQuestionsSequentially(questions, ctx, shouldContinue);
+}
+
+async function askPlanModeQuestionsSequentially(
+	questions: PlanModeQuestion[],
+	ctx: ExtensionContext,
+	shouldContinue: () => boolean,
+): Promise<PlanModeQuestionAnswer[] | undefined> {
 	const answers: PlanModeQuestionAnswer[] = [];
 	for (const question of questions) {
 		const choices = question.options.map(formatPlanModeQuestionChoice);
@@ -197,30 +234,394 @@ export async function askPlanModeQuestions(
 		]);
 		if (!shouldContinue() || !choice) return undefined;
 		if (choice === otherChoice) {
-			const customAnswer = (await ctx.ui.editor(question.question, ""))?.trim();
-			if (!shouldContinue() || !customAnswer) return undefined;
-			answers.push({
-				id: question.id,
-				header: question.header,
-				question: question.question,
-				answer: customAnswer,
-				wasCustom: true,
-			});
+			const customAnswer = await askCustomAnswer(question, ctx, shouldContinue);
+			if (customAnswer === undefined) return undefined;
+			answers.push(answerFor(question, customAnswer, { wasCustom: true }));
 			continue;
 		}
 		const optionIndex = choices.indexOf(choice);
 		const option = question.options[optionIndex];
 		if (!option) return undefined;
-		answers.push({
-			id: question.id,
-			header: question.header,
-			question: question.question,
-			answer: option.label,
-			wasCustom: false,
-			optionIndex: optionIndex + 1,
-		});
+		answers.push(
+			answerFor(question, option.label, { wasCustom: false, optionIndex: optionIndex + 1 }),
+		);
 	}
 	return answers;
+}
+
+async function askCustomAnswer(
+	question: PlanModeQuestion,
+	ctx: ExtensionContext,
+	shouldContinue: () => boolean,
+): Promise<string | undefined> {
+	let draft = "";
+	for (;;) {
+		const customAnswer = await ctx.ui.editor(question.question, draft);
+		if (!shouldContinue() || !customAnswer?.trim()) return undefined;
+		if (customAnswer.length <= MAX_PLAN_MODE_RESPONSE_LENGTH) return customAnswer;
+		draft = customAnswer;
+		ctx.ui.notify("Custom answer must be 4,000 characters or fewer.", "warning");
+	}
+}
+
+interface QuestionnaireOptions {
+	questions: PlanModeQuestion[];
+	tui: TUI;
+	theme: Theme;
+	shouldContinue(): boolean;
+	signal?: AbortSignal;
+	onDone(answers: PlanModeQuestionAnswer[] | undefined): void;
+}
+
+export class PlanModeQuestionnaire implements Component, Focusable {
+	private readonly options: QuestionnaireOptions;
+	private readonly editor: Editor;
+	private readonly answers: Array<PlanModeQuestionAnswer | undefined>;
+	private readonly selectedOptions: number[];
+	private page = 0;
+	private reviewSelection = 0;
+	private editorKind: "answer" | "note" | undefined;
+	private message: string | undefined;
+	private finished = false;
+	private removeAbort = () => {};
+	private _focused = false;
+
+	constructor(options: QuestionnaireOptions) {
+		this.options = options;
+		this.answers = options.questions.map(() => undefined);
+		this.selectedOptions = options.questions.map(() => 0);
+		const editorTheme: EditorTheme = {
+			borderColor: (text) => options.theme.fg("accent", text),
+			selectList: {
+				selectedPrefix: (text) => options.theme.fg("accent", text),
+				selectedText: (text) => options.theme.fg("accent", text),
+				description: (text) => options.theme.fg("muted", text),
+				scrollInfo: (text) => options.theme.fg("dim", text),
+				noMatch: (text) => options.theme.fg("warning", text),
+			},
+		};
+		this.editor = new Editor(options.tui, editorTheme, { paddingX: 0 });
+		this.editor.onChange = () => {
+			this.message = undefined;
+		};
+		this.editor.onSubmit = (text) => this.submitEditor(text);
+		if (options.signal) {
+			const abort = () => this.finish(undefined);
+			options.signal.addEventListener("abort", abort, { once: true });
+			this.removeAbort = () => options.signal?.removeEventListener("abort", abort);
+			if (options.signal.aborted) abort();
+		}
+	}
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	set focused(value: boolean) {
+		this._focused = value;
+		this.editor.focused = value && this.editorKind !== undefined;
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const lines = [this.renderTabs(safeWidth), ""];
+		if (this.page === this.options.questions.length) lines.push(...this.renderReview(safeWidth));
+		else lines.push(...this.renderQuestion(safeWidth));
+		if (this.message)
+			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), safeWidth));
+		lines.push("");
+		lines.push(
+			truncateToWidth(
+				this.options.theme.fg(
+					"dim",
+					this.editorKind
+						? "Enter save · Esc/Ctrl+C cancel questionnaire"
+						: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer/submit · n note · Esc cancel",
+				),
+				safeWidth,
+			),
+		);
+		return lines.map((line) => truncateToWidth(line, safeWidth));
+	}
+
+	handleInput(data: string): void {
+		if (this.finished) return;
+		if (!this.options.shouldContinue() || this.isCancel(data)) {
+			this.finish(undefined);
+			return;
+		}
+		if (this.editorKind) this.handleEditorInput(data);
+		else this.handlePageInput(data);
+		this.options.tui.requestRender();
+	}
+
+	invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	dispose(): void {
+		this.finish(undefined);
+	}
+
+	private isCancel(data: string): boolean {
+		return matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"));
+	}
+
+	private handleEditorInput(data: string): void {
+		if (matchesKey(data, Key.enter)) this.submitEditor(this.editor.getExpandedText());
+		else this.editor.handleInput(data);
+	}
+
+	private handlePageInput(data: string): void {
+		if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
+			this.movePage(1);
+			return;
+		}
+		if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left)) {
+			this.movePage(-1);
+			return;
+		}
+		if (matchesKey(data, Key.up)) {
+			this.moveSelection(-1);
+			return;
+		}
+		if (matchesKey(data, Key.down)) {
+			this.moveSelection(1);
+			return;
+		}
+		if (data.toLowerCase() === "n") {
+			this.editNote();
+			return;
+		}
+		if (matchesKey(data, Key.enter)) this.submitPage();
+	}
+
+	private movePage(delta: number): void {
+		const pageCount = this.options.questions.length + 1;
+		this.page = (this.page + delta + pageCount) % pageCount;
+		this.message = undefined;
+	}
+
+	private renderTabs(width: number): string {
+		const tabs = [
+			...this.options.questions.map((question, index) => {
+				const label = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
+				const answered = this.answers[index] ? "✓ " : "";
+				return this.page === index ? `[${answered}${label}]` : `${answered}${label}`;
+			}),
+			this.page === this.options.questions.length ? "[Review]" : "Review",
+		];
+		return truncateToWidth(this.options.theme.fg("accent", tabs.join("  ")), width, "…");
+	}
+
+	private renderQuestion(width: number): string[] {
+		const question = this.options.questions[this.page];
+		if (!question) return [];
+		const lines = hardWrap(
+			this.options.theme.fg("text", sanitizeTerminalText(question.question)),
+			width,
+		);
+		lines.push("");
+		question.options.forEach((option, index) => {
+			const cursor = this.selectedOptions[this.page] === index ? "›" : " ";
+			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? "●" : "○";
+			const label = `${cursor} ${chosen} ${sanitizeTerminalText(option.label)}`;
+			lines.push(...hardWrap(this.options.theme.fg("text", label), width));
+			if (option.description) {
+				lines.push(
+					...hardWrap(
+						`    ${this.options.theme.fg("muted", sanitizeTerminalText(option.description))}`,
+						width,
+					),
+				);
+			}
+		});
+		const otherIndex = question.options.length;
+		const otherCursor = this.selectedOptions[this.page] === otherIndex ? "›" : " ";
+		const otherChosen = this.answers[this.page]?.wasCustom ? "●" : "○";
+		lines.push(`${otherCursor} ${otherChosen} Other (free-form)`);
+		const answer = this.answers[this.page];
+		if (answer?.wasCustom)
+			lines.push(...labeledRaw("Answer", answer.answer, width, this.options.theme));
+		if (answer?.note) lines.push(...labeledRaw("Note", answer.note, width, this.options.theme));
+		if (this.editorKind) {
+			lines.push("");
+			lines.push(
+				this.options.theme.fg(
+					"accent",
+					this.editorKind === "answer" ? "Custom answer" : "Optional note",
+				),
+			);
+			lines.push(...this.editor.render(width));
+		}
+		return lines;
+	}
+
+	private renderReview(width: number): string[] {
+		const lines = [this.options.theme.fg("text", "Review answers")];
+		this.options.questions.forEach((question, index) => {
+			const answer = this.answers[index];
+			const cursor = this.reviewSelection === index ? "›" : " ";
+			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
+			lines.push("");
+			lines.push(`${cursor} ${this.options.theme.fg("accent", header)}`);
+			lines.push(
+				...labeledRaw("Answer", answer?.answer ?? "Unanswered", width, this.options.theme),
+			);
+			if (answer?.note) lines.push(...labeledRaw("Note", answer.note, width, this.options.theme));
+		});
+		if (this.editorKind === "note") {
+			lines.push("");
+			lines.push(this.options.theme.fg("accent", "Optional note"));
+			lines.push(...this.editor.render(width));
+		}
+		return lines;
+	}
+
+	private moveSelection(delta: number): void {
+		if (this.page === this.options.questions.length) {
+			this.reviewSelection =
+				(this.reviewSelection + delta + this.options.questions.length) %
+				this.options.questions.length;
+			return;
+		}
+		const optionCount = (this.options.questions[this.page]?.options.length ?? 0) + 1;
+		this.selectedOptions[this.page] =
+			((this.selectedOptions[this.page] ?? 0) + delta + optionCount) % optionCount;
+	}
+
+	private submitPage(): void {
+		if (this.page === this.options.questions.length) {
+			const firstMissing = this.answers.findIndex((answer) => !answer);
+			if (firstMissing >= 0) {
+				this.message = "Answer every question before submitting.";
+				return;
+			}
+			this.finish(
+				this.answers.filter((answer): answer is PlanModeQuestionAnswer => answer !== undefined),
+			);
+			return;
+		}
+		const question = this.options.questions[this.page];
+		if (!question) return;
+		const selected = this.selectedOptions[this.page] ?? 0;
+		if (selected === question.options.length) {
+			this.beginEditor(
+				"answer",
+				this.answers[this.page]?.wasCustom ? this.answers[this.page]?.answer : "",
+			);
+			return;
+		}
+		const option = question.options[selected];
+		if (!option) return;
+		const previous = this.answers[this.page];
+		this.answers[this.page] = answerFor(question, option.label, {
+			wasCustom: false,
+			optionIndex: selected + 1,
+			note: previous?.optionIndex === selected + 1 ? previous.note : undefined,
+		});
+		this.advance();
+	}
+
+	private editNote(): void {
+		const review = this.page === this.options.questions.length;
+		const index = review ? this.reviewSelection : this.page;
+		let answer = this.answers[index];
+		if (!review) {
+			const question = this.options.questions[index];
+			const selected = this.selectedOptions[index] ?? 0;
+			if (question && selected === question.options.length && !answer?.wasCustom) {
+				this.beginEditor("answer", "");
+				return;
+			}
+			if (question && selected < question.options.length && answer?.optionIndex !== selected + 1) {
+				const option = question.options[selected];
+				if (option) {
+					answer = answerFor(question, option.label, {
+						wasCustom: false,
+						optionIndex: selected + 1,
+					});
+					this.answers[index] = answer;
+				}
+			}
+		}
+		if (!answer) {
+			this.message = "Select an answer before adding a note.";
+			return;
+		}
+		this.beginEditor("note", answer.note ?? "");
+	}
+
+	private beginEditor(kind: "answer" | "note", value: string | undefined): void {
+		this.editorKind = kind;
+		this.editor.setText(value ?? "");
+		this.editor.focused = this._focused;
+		this.message = undefined;
+	}
+
+	private submitEditor(value: string): void {
+		if (value.length > MAX_PLAN_MODE_RESPONSE_LENGTH) {
+			this.editor.setText(value);
+			this.message = `${this.editorKind === "answer" ? "Answer" : "Note"} must be 4,000 characters or fewer.`;
+			this.options.tui.requestRender();
+			return;
+		}
+		const index = this.page === this.options.questions.length ? this.reviewSelection : this.page;
+		if (this.editorKind === "answer") {
+			if (!value.trim()) {
+				this.editor.setText(value);
+				this.message = "Custom answer cannot be empty.";
+				this.options.tui.requestRender();
+				return;
+			}
+			const question = this.options.questions[index];
+			if (!question) return;
+			this.answers[index] = answerFor(question, value, { wasCustom: true });
+			this.editor.setText("");
+			this.editorKind = undefined;
+			this.editor.focused = false;
+			this.advance();
+			return;
+		}
+		const answer = this.answers[index];
+		if (answer) answer.note = value.trim() ? value : undefined;
+		this.editor.setText("");
+		this.editorKind = undefined;
+		this.editor.focused = false;
+		this.message = value.trim() ? "Note saved." : "Note cleared.";
+		this.options.tui.requestRender();
+	}
+
+	private advance(): void {
+		this.page = Math.min(this.page + 1, this.options.questions.length);
+		this.message = undefined;
+	}
+
+	private finish(answers: PlanModeQuestionAnswer[] | undefined): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.removeAbort();
+		this.removeAbort = () => {};
+		this.editor.focused = false;
+		this.options.onDone(answers);
+	}
+}
+
+function answerFor(
+	question: PlanModeQuestion,
+	answer: string,
+	options: { wasCustom: boolean; optionIndex?: number; note?: string },
+): PlanModeQuestionAnswer {
+	const result: PlanModeQuestionAnswer = {
+		id: question.id,
+		header: question.header,
+		question: question.question,
+		answer,
+		wasCustom: options.wasCustom,
+	};
+	if (options.optionIndex !== undefined) result.optionIndex = options.optionIndex;
+	if (options.note !== undefined) result.note = options.note;
+	return result;
 }
 
 function formatPlanModeQuestionChoice(option: PlanModeQuestionOption, index: number) {
@@ -262,6 +663,56 @@ function formatPlanModeQuestionPayload(payload: {
 	answers?: PlanModeQuestionAnswer[];
 }) {
 	return JSON.stringify(payload, null, 2);
+}
+
+export function sanitizeTerminalText(value: string): string {
+	return [...stripVTControlCharacters(value)]
+		.map((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f ||
+				(codePoint >= 0x7f && codePoint <= 0x9f) ||
+				codePoint === 0x2028 ||
+				codePoint === 0x2029 ||
+				isBidiControl(codePoint)
+				? " "
+				: character;
+		})
+		.join("");
+}
+
+function isBidiControl(codePoint: number): boolean {
+	return (
+		codePoint === 0x061c ||
+		codePoint === 0x200e ||
+		codePoint === 0x200f ||
+		(codePoint >= 0x202a && codePoint <= 0x202e) ||
+		(codePoint >= 0x2066 && codePoint <= 0x2069)
+	);
+}
+
+function labeledRaw(label: string, value: string, width: number, theme: Theme): string[] {
+	const prefix = `${label}: `;
+	const safe = sanitizeTerminalText(value);
+	const lines = hardWrap(safe, Math.max(1, width - visibleWidth(prefix)));
+	return lines.map((line, index) =>
+		index === 0 ? `${theme.fg("muted", prefix)}${line}` : `${" ".repeat(prefix.length)}${line}`,
+	);
+}
+
+function hardWrap(value: string, width: number): string[] {
+	const safeWidth = Math.max(1, width);
+	if (!value) return [""];
+	const output: string[] = [];
+	for (const sourceLine of value.split("\n")) {
+		const columns = visibleWidth(sourceLine);
+		if (columns === 0) output.push("");
+		else {
+			for (let column = 0; column < columns; column += safeWidth) {
+				output.push(sliceByColumn(sourceLine, column, safeWidth));
+			}
+		}
+	}
+	return output;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -1,7 +1,49 @@
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import planMode, { normalizePlanModeQuestionParams } from "../src/plan/plan-mode.js";
+import {
+	askPlanModeQuestions,
+	MAX_PLAN_MODE_RESPONSE_LENGTH,
+	type PlanModeQuestion,
+	planModeQuestionAnswered,
+	sanitizeTerminalText,
+} from "../src/plan/question-tool.js";
+
+const questions: PlanModeQuestion[] = [
+	{
+		id: "scope",
+		header: "Scope",
+		question: "How broad?",
+		options: [
+			{ label: "Small", description: "Only the bug." },
+			{ label: "Broad", description: "Include cleanup." },
+		],
+	},
+	{
+		id: "tests",
+		header: "Tests",
+		question: "Which checks?",
+		options: [
+			{ label: "Focused", description: "Run focused checks." },
+			{ label: "Full", description: "Run all checks." },
+		],
+	},
+];
+
+function tuiRun(customQuestions = questions, width = 60) {
+	const tui = createTuiHarness({ width, rows: 30 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions(customQuestions, context.ctx);
+	return { tui, running };
+}
+
+function paste(tui: ReturnType<typeof createTuiHarness>, text: string) {
+	tui.send(`\u001b[200~${text}\u001b[201~`);
+}
 
 test("plan_mode_question reports non-interactive cancellation", async () => {
 	const mock = createMockPi();
@@ -14,19 +56,7 @@ test("plan_mode_question reports non-interactive cancellation", async () => {
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const result = await execute(
 		"call-1",
-		{
-			questions: [
-				{
-					id: "scope",
-					header: "Scope",
-					question: "How broad?",
-					options: [
-						{ label: "Small", description: "Only the bug." },
-						{ label: "Broad", description: "Include cleanup." },
-					],
-				},
-			],
-		},
+		{ questions: [questions[0]] },
 		undefined,
 		undefined,
 		context.ctx,
@@ -34,25 +64,173 @@ test("plan_mode_question reports non-interactive cancellation", async () => {
 	assert.equal(result.details?.reason, "ui_unavailable");
 });
 
-test("normalizePlanModeQuestionParams validates question shape", () => {
-	const result = normalizePlanModeQuestionParams({
-		questions: [
-			{
-				id: "scope",
-				header: "Scope",
-				question: "How broad?",
-				options: [
-					{ label: "Small", description: "Only the bug." },
-					{ label: "Broad", description: "Include nearby cleanup." },
-				],
-			},
-		],
-	});
-
+test("normalizePlanModeQuestionParams validates question shape without changing schema", () => {
+	const result = normalizePlanModeQuestionParams({ questions: [questions[0]] });
 	assert.equal(result.ok, true);
 	if (result.ok) assert.equal(result.questions[0]?.options[1]?.label, "Broad");
 	assert.deepEqual(normalizePlanModeQuestionParams({ questions: [] }), {
 		ok: false,
 		error: "questions must contain 1-3 items",
 	});
+});
+
+test("TUI previews future questions and navigates back before answering", async () => {
+	const { tui, running } = tuiRun();
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	assert.match(tui.render().join("\n"), /\[Scope\].*Tests.*Review/u);
+	tui.send("\t");
+	assert.match(tui.render().join("\n"), /Scope.*\[Tests\].*Review[\s\S]*Which checks\?/u);
+	tui.send("\u001b[Z");
+	assert.match(tui.render().join("\n"), /\[Scope\][\s\S]*How broad\?/u);
+	tui.press("tui.select.cancel");
+	assert.equal(await running, undefined);
+});
+
+test("TUI replaces answers, manages notes, accepts Other, and submits ordered raw payload", async () => {
+	const { tui, running } = tuiRun();
+	await tui.waitForOpen();
+	tui.setFocused(true);
+
+	// Note shortcut selects the highlighted answer before opening the editor.
+	tui.type("n");
+	paste(tui, "initial note");
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /initial note/u);
+
+	// Replacing the selected option clears its old note.
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.send("\u001b[D");
+	assert.doesNotMatch(tui.render().join("\n"), /initial note/u);
+	tui.send("\u001b[C");
+
+	// Other keeps exact user text in the answer payload.
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	paste(tui, "  custom answer  ");
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /Review answers[\s\S]*Broad[\s\S]*custom answer/u);
+
+	// Review selects answers for note add/edit/clear.
+	tui.type("n");
+	paste(tui, "draft note");
+	tui.press("tui.input.submit");
+	tui.type("n");
+	tui.send("\u0015");
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /Note cleared/u);
+	tui.type("n");
+	paste(tui, "final note");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+
+	assert.deepEqual(await running, [
+		{
+			id: "scope",
+			header: "Scope",
+			question: "How broad?",
+			answer: "Broad",
+			wasCustom: false,
+			optionIndex: 2,
+			note: "final note",
+		},
+		{
+			id: "tests",
+			header: "Tests",
+			question: "Which checks?",
+			answer: "  custom answer  ",
+			wasCustom: true,
+		},
+	]);
+});
+
+test("Review blocks incomplete submission and lets selected answer receive a note", async () => {
+	const { tui, running } = tuiRun();
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.send("\u001b[C");
+	tui.send("\u001b[C");
+	tui.press("tui.select.confirm");
+	assert.match(tui.render().join("\n"), /Answer every question before submitting/u);
+	tui.press("tui.select.down");
+	tui.type("n");
+	assert.match(tui.render().join("\n"), /Select an answer before adding a note/u);
+	tui.press("tui.select.cancel");
+	assert.equal(await running, undefined);
+});
+
+test("Other editor rejects oversized input and forwards focus", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.setFocused(true);
+	assert.equal(tui.render().join("\n").includes(CURSOR_MARKER), true);
+	paste(tui, "x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1));
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /4,000 characters or fewer/u);
+	assert.equal(tui.isOpen, true);
+	tui.press("ctrl+c");
+	assert.equal(await running, undefined);
+});
+
+test("TUI sanitizes rendering, preserves raw result text, and respects narrow widths", async () => {
+	const unsafe = "raw\u001b]8;;https://evil.example\u0007text\u001b]8;;\u0007";
+	const malicious: PlanModeQuestion[] = [
+		{
+			id: "unsafe",
+			header: `Head\u001b[31m`,
+			question: unsafe,
+			options: [
+				{ label: unsafe, description: "first" },
+				{ label: "safe", description: "second" },
+			],
+		},
+	];
+	const { tui, running } = tuiRun(malicious, 16);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	const frame = tui.render();
+	const plain = stripVTControlCharacters(frame.join("\n"));
+	assert.doesNotMatch(plain, /evil\.example/u);
+	assert.equal(plain.includes("\u0007") || plain.includes("\u001b"), false);
+	for (const line of frame) assert.ok(visibleWidth(line) <= 16);
+	assert.equal(sanitizeTerminalText(unsafe), "rawtext");
+	const answered = planModeQuestionAnswered(malicious, [
+		{
+			id: "unsafe",
+			header: malicious[0]?.header ?? "",
+			question: unsafe,
+			answer: unsafe,
+			wasCustom: true,
+		},
+	]);
+	assert.match(answered.content[0]?.text ?? "", /evil\.example/u);
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
+test("RPC retains sequential select/editor fallback and retries oversized answers", async () => {
+	const selections = ["1. Small — Only the bug.", "3. Other (free-form)"];
+	const editorAnswers = ["x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1), "rpc custom"];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => selections.shift(),
+		editor: async () => editorAnswers.shift(),
+		custom: async () => assert.fail("RPC must not open custom TUI"),
+	});
+	const answers = await askPlanModeQuestions(questions, context.ctx);
+	assert.deepEqual(
+		answers?.map(({ answer, wasCustom }) => ({ answer, wasCustom })),
+		[
+			{ answer: "Small", wasCustom: false },
+			{ answer: "rpc custom", wasCustom: true },
+		],
+	);
+	assert.ok(context.notifications.some(({ message }) => message.includes("4,000")));
 });


### PR DESCRIPTION
## Summary

- replace sequential Plan questionnaires with tabbed, freely navigable TUI flows in `pi-plan-mode` and `pi-workflow`
- support answer replacement, `Other`, optional notes, and final review before one ordered submission
- preserve raw payload text while sanitizing terminal output, enforce 4,000-character UI limits, and retain lifecycle cancellation checks
- keep RPC on its existing sequential `select`/`editor` fallback

Closes #871.

## Verification

- `npm run check`
- `npm exec -- vitest run packages/pi-plan-mode/test packages/pi-workflow/test --maxWorkers=1` (60 files, 790 tests)
- dry-run packed both packages and loaded both package directories through Pi with isolated agent directories
- manually exercised a three-question TUI, including future-question navigation, backtracking, `Other`, note shortcut, and Review submission

Full parallel `npm test` was also attempted locally: 3,688 tests passed and 18 unrelated timeout/concurrency-sensitive tests failed under load. Both changed package suites pass in full with one worker.
