### PR TITLE
feat(plan): add safe navigable question review

### DIFF
--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -459,30 +459,29 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		question.options.forEach((option, index) => {
 			const selected = this.selectedOptions[this.page] === index;
 			const cursor = selected ? "→" : " ";
-			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? " ✓" : "";
-			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}${chosen}`;
-			lines.push(...hardWrap(this.options.theme.fg(selected ? "accent" : "text", label), width));
-			if (option.description) {
-				lines.push(
-					...hardWrap(
-						`    ${this.options.theme.fg(
-							selected ? "accent" : "muted",
-							sanitizeTerminalText(option.description),
-						)}`,
-						width,
-					),
-				);
-			}
+			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}`;
+			const chosen = this.answers[this.page]?.optionIndex === index + 1;
+			const description = option.description
+				? ` — ${sanitizeTerminalText(option.description)}`
+				: "";
+			const line = selected
+				? this.options.theme.fg("accent", `${label}${chosen ? " ✓" : ""}${description}`)
+				: `${this.options.theme.fg("text", label)}${
+						chosen ? this.options.theme.fg("success", " ✓") : ""
+					}${description ? this.options.theme.fg("muted", description) : ""}`;
+			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${cursor} ${index + 1}. `)));
 		});
 		const otherIndex = question.options.length;
 		const otherSelected = this.selectedOptions[this.page] === otherIndex;
 		const otherCursor = otherSelected ? "→" : " ";
-		const otherChosen = this.answers[this.page]?.wasCustom ? " ✓" : "";
+		const otherLabel = `${otherCursor} ${otherIndex + 1}. Other (free-form)`;
+		const otherChosen = this.answers[this.page]?.wasCustom === true;
 		lines.push(
-			this.options.theme.fg(
-				otherSelected ? "accent" : "text",
-				`${otherCursor} ${otherIndex + 1}. Other (free-form)${otherChosen}`,
-			),
+			otherSelected
+				? this.options.theme.fg("accent", `${otherLabel}${otherChosen ? " ✓" : ""}`)
+				: `${this.options.theme.fg("text", otherLabel)}${
+						otherChosen ? this.options.theme.fg("success", " ✓") : ""
+					}`,
 		);
 		const answer = this.answers[this.page];
 		if (answer?.wasCustom)
@@ -887,6 +886,19 @@ function labeledRaw(label: string, value: string, width: number, theme: Theme): 
 	return lines.map((line, index) =>
 		index === 0 ? `${theme.fg("muted", prefix)}${line}` : `${" ".repeat(prefix.length)}${line}`,
 	);
+}
+
+function hardWrapWithIndent(value: string, width: number, indent: number): string[] {
+	const safeWidth = Math.max(1, width);
+	const safeIndent = Math.min(Math.max(0, indent), Math.max(0, safeWidth - 1));
+	const continuationWidth = Math.max(1, safeWidth - safeIndent);
+	const columns = visibleWidth(value);
+	if (columns <= safeWidth) return [value];
+	const output = [sliceByColumn(value, 0, safeWidth)];
+	for (let column = safeWidth; column < columns; column += continuationWidth) {
+		output.push(`${" ".repeat(safeIndent)}${sliceByColumn(value, column, continuationWidth)}`);
+	}
+	return output;
 }
 
 function hardWrap(value: string, width: number): string[] {

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -282,7 +282,6 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	private readonly answers: Array<PlanModeQuestionAnswer | undefined>;
 	private readonly selectedOptions: number[];
 	private page = 0;
-	private reviewSelection = 0;
 	private editorKind: "answer" | "note" | undefined;
 	private message: string | undefined;
 	private finished = false;
@@ -342,7 +341,9 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 					"dim",
 					this.editorKind
 						? "Enter save · Esc/Ctrl+C cancel questionnaire"
-						: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer/submit · n note · Esc cancel",
+						: this.page === this.options.questions.length
+							? "Tab/Shift+Tab or ←/→ navigate · Enter submit · Esc cancel"
+							: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer · n note · Esc cancel",
 				),
 				contentWidth,
 			),
@@ -392,16 +393,18 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			this.movePage(-1);
 			return;
 		}
+		const review = this.page === this.options.questions.length;
 		if (matchesKey(data, Key.up)) {
-			this.moveSelection(-1);
+			if (!review) this.moveSelection(-1);
 			return;
 		}
 		if (matchesKey(data, Key.down)) {
-			this.moveSelection(1);
+			if (!review) this.moveSelection(1);
 			return;
 		}
 		if (data.toLowerCase() === "n") {
-			this.editNote();
+			if (review) this.message = "Return to a question to add or edit its note.";
+			else this.editNote();
 			return;
 		}
 		if (matchesKey(data, Key.enter)) this.submitPage();
@@ -504,33 +507,18 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		const lines = [this.options.theme.fg("accent", this.options.theme.bold("Review answers")), ""];
 		this.options.questions.forEach((question, index) => {
 			const answer = this.answers[index];
-			const selected = this.reviewSelection === index;
-			const cursor = selected ? "→" : " ";
 			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
-			const label = `${cursor} ${index + 1}. ${header}`;
+			const label = `${index + 1}. ${header}`;
 			const summary = ` — ${inlineSummary(answer?.answer ?? "Unanswered")}${
 				answer?.note ? ` · Note: ${inlineSummary(answer.note)}` : ""
 			}`;
-			const line = selected
-				? this.options.theme.fg("accent", `${label}${summary}`)
-				: `${this.options.theme.fg("text", label)}${this.options.theme.fg("muted", summary)}`;
-			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${cursor} ${index + 1}. `)));
+			const line = `${this.options.theme.fg("text", label)}${this.options.theme.fg("muted", summary)}`;
+			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${index + 1}. `)));
 		});
-		if (this.editorKind === "note") {
-			lines.push("");
-			lines.push(this.options.theme.fg("accent", "Optional note"));
-			lines.push(...this.editor.render(width));
-		}
 		return lines;
 	}
 
 	private moveSelection(delta: number): void {
-		if (this.page === this.options.questions.length) {
-			this.reviewSelection =
-				(this.reviewSelection + delta + this.options.questions.length) %
-				this.options.questions.length;
-			return;
-		}
 		const optionCount = (this.options.questions[this.page]?.options.length ?? 0) + 1;
 		this.selectedOptions[this.page] =
 			((this.selectedOptions[this.page] ?? 0) + delta + optionCount) % optionCount;
@@ -570,25 +558,22 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	}
 
 	private editNote(): void {
-		const review = this.page === this.options.questions.length;
-		const index = review ? this.reviewSelection : this.page;
+		const index = this.page;
 		let answer = this.answers[index];
-		if (!review) {
-			const question = this.options.questions[index];
-			const selected = this.selectedOptions[index] ?? 0;
-			if (question && selected === question.options.length && !answer?.wasCustom) {
-				this.beginEditor("answer", "");
-				return;
-			}
-			if (question && selected < question.options.length && answer?.optionIndex !== selected + 1) {
-				const option = question.options[selected];
-				if (option) {
-					answer = answerFor(question, option.label, {
-						wasCustom: false,
-						optionIndex: selected + 1,
-					});
-					this.answers[index] = answer;
-				}
+		const question = this.options.questions[index];
+		const selected = this.selectedOptions[index] ?? 0;
+		if (question && selected === question.options.length && !answer?.wasCustom) {
+			this.beginEditor("answer", "");
+			return;
+		}
+		if (question && selected < question.options.length && answer?.optionIndex !== selected + 1) {
+			const option = question.options[selected];
+			if (option) {
+				answer = answerFor(question, option.label, {
+					wasCustom: false,
+					optionIndex: selected + 1,
+				});
+				this.answers[index] = answer;
 			}
 		}
 		if (!answer) {
@@ -612,7 +597,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			this.options.tui.requestRender();
 			return;
 		}
-		const index = this.page === this.options.questions.length ? this.reviewSelection : this.page;
+		const index = this.page;
 		if (this.editorKind === "answer") {
 			if (!value.trim()) {
 				this.editor.setText(value);

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -501,17 +501,20 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	}
 
 	private renderReview(width: number): string[] {
-		const lines = [this.options.theme.fg("text", "Review answers")];
+		const lines = [this.options.theme.fg("accent", this.options.theme.bold("Review answers")), ""];
 		this.options.questions.forEach((question, index) => {
 			const answer = this.answers[index];
-			const cursor = this.reviewSelection === index ? "→" : " ";
+			const selected = this.reviewSelection === index;
+			const cursor = selected ? "→" : " ";
 			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
-			lines.push("");
-			lines.push(`${cursor} ${this.options.theme.fg("accent", header)}`);
-			lines.push(
-				...labeledRaw("Answer", answer?.answer ?? "Unanswered", width, this.options.theme),
-			);
-			if (answer?.note) lines.push(...labeledRaw("Note", answer.note, width, this.options.theme));
+			const label = `${cursor} ${index + 1}. ${header}`;
+			const summary = ` — ${inlineSummary(answer?.answer ?? "Unanswered")}${
+				answer?.note ? ` · Note: ${inlineSummary(answer.note)}` : ""
+			}`;
+			const line = selected
+				? this.options.theme.fg("accent", `${label}${summary}`)
+				: `${this.options.theme.fg("text", label)}${this.options.theme.fg("muted", summary)}`;
+			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${cursor} ${index + 1}. `)));
 		});
 		if (this.editorKind === "note") {
 			lines.push("");
@@ -877,6 +880,10 @@ function isBidiControl(codePoint: number): boolean {
 		(codePoint >= 0x202a && codePoint <= 0x202e) ||
 		(codePoint >= 0x2066 && codePoint <= 0x2069)
 	);
+}
+
+function inlineSummary(value: string): string {
+	return value.split("\n").map(sanitizeTerminalText).join(" ↵ ");
 }
 
 function labeledRaw(label: string, value: string, width: number, theme: Theme): string[] {

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -327,7 +327,8 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const lines = [...this.renderTabs(safeWidth), ""];
+		const border = this.options.theme.fg("accent", "─".repeat(safeWidth));
+		const lines = [border, ...this.renderTabs(safeWidth), ""];
 		if (this.page === this.options.questions.length) lines.push(...this.renderReview(safeWidth));
 		else lines.push(...this.renderQuestion(safeWidth));
 		if (this.message)
@@ -343,6 +344,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 				),
 				safeWidth,
 			),
+			border,
 		);
 		return lines.map((line) => truncateToWidth(line, safeWidth));
 	}

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -327,12 +327,14 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const border = this.options.theme.fg("accent", "─".repeat(safeWidth));
-		const lines = [border, ...this.renderTabs(safeWidth), ""];
-		if (this.page === this.options.questions.length) lines.push(...this.renderReview(safeWidth));
-		else lines.push(...this.renderQuestion(safeWidth));
+		const padding = safeWidth > 1 ? " " : "";
+		const contentWidth = Math.max(1, safeWidth - visibleWidth(padding));
+		const border = this.options.theme.fg("border", "─".repeat(safeWidth));
+		const lines = [border, "", ...this.renderTabs(contentWidth), ""];
+		if (this.page === this.options.questions.length) lines.push(...this.renderReview(contentWidth));
+		else lines.push(...this.renderQuestion(contentWidth));
 		if (this.message)
-			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), safeWidth));
+			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), contentWidth));
 		lines.push("");
 		lines.push(
 			truncateToWidth(
@@ -342,11 +344,15 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 						? "Enter save · Esc/Ctrl+C cancel questionnaire"
 						: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer/submit · n note · Esc cancel",
 				),
-				safeWidth,
+				contentWidth,
 			),
+			"",
 			border,
 		);
-		return lines.map((line) => truncateToWidth(line, safeWidth));
+		return lines.map((line) => {
+			if (!line || line === border) return line;
+			return `${padding}${truncateToWidth(line, contentWidth)}`;
+		});
 	}
 
 	handleInput(data: string): void {
@@ -443,28 +449,41 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		const question = this.options.questions[this.page];
 		if (!question) return [];
 		const lines = hardWrap(
-			this.options.theme.fg("text", sanitizeTerminalText(question.question)),
+			this.options.theme.fg(
+				"accent",
+				this.options.theme.bold(sanitizeTerminalText(question.question)),
+			),
 			width,
 		);
 		lines.push("");
 		question.options.forEach((option, index) => {
-			const cursor = this.selectedOptions[this.page] === index ? "›" : " ";
+			const selected = this.selectedOptions[this.page] === index;
+			const cursor = selected ? "→" : " ";
 			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? " ✓" : "";
 			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}${chosen}`;
-			lines.push(...hardWrap(this.options.theme.fg("text", label), width));
+			lines.push(...hardWrap(this.options.theme.fg(selected ? "accent" : "text", label), width));
 			if (option.description) {
 				lines.push(
 					...hardWrap(
-						`    ${this.options.theme.fg("muted", sanitizeTerminalText(option.description))}`,
+						`    ${this.options.theme.fg(
+							selected ? "accent" : "muted",
+							sanitizeTerminalText(option.description),
+						)}`,
 						width,
 					),
 				);
 			}
 		});
 		const otherIndex = question.options.length;
-		const otherCursor = this.selectedOptions[this.page] === otherIndex ? "›" : " ";
+		const otherSelected = this.selectedOptions[this.page] === otherIndex;
+		const otherCursor = otherSelected ? "→" : " ";
 		const otherChosen = this.answers[this.page]?.wasCustom ? " ✓" : "";
-		lines.push(`${otherCursor} ${otherIndex + 1}. Other (free-form)${otherChosen}`);
+		lines.push(
+			this.options.theme.fg(
+				otherSelected ? "accent" : "text",
+				`${otherCursor} ${otherIndex + 1}. Other (free-form)${otherChosen}`,
+			),
+		);
 		const answer = this.answers[this.page];
 		if (answer?.wasCustom)
 			lines.push(...labeledRaw("Answer", answer.answer, width, this.options.theme));
@@ -486,7 +505,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		const lines = [this.options.theme.fg("text", "Review answers")];
 		this.options.questions.forEach((question, index) => {
 			const answer = this.answers[index];
-			const cursor = this.reviewSelection === index ? "›" : " ";
+			const cursor = this.reviewSelection === index ? "→" : " ";
 			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
 			lines.push("");
 			lines.push(`${cursor} ${this.options.theme.fg("accent", header)}`);

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -402,6 +402,13 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	private movePage(delta: number): void {
 		const pageCount = this.options.questions.length + 1;
 		this.page = (this.page + delta + pageCount) % pageCount;
+		const answer = this.answers[this.page];
+		const question = this.options.questions[this.page];
+		if (answer?.wasCustom && question) {
+			this.selectedOptions[this.page] = question.options.length;
+		} else if (answer?.optionIndex !== undefined) {
+			this.selectedOptions[this.page] = answer.optionIndex - 1;
+		}
 		this.message = undefined;
 	}
 
@@ -440,8 +447,8 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		lines.push("");
 		question.options.forEach((option, index) => {
 			const cursor = this.selectedOptions[this.page] === index ? "›" : " ";
-			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? "●" : "○";
-			const label = `${cursor} ${chosen} ${sanitizeTerminalText(option.label)}`;
+			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? " ✓" : "";
+			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}${chosen}`;
 			lines.push(...hardWrap(this.options.theme.fg("text", label), width));
 			if (option.description) {
 				lines.push(
@@ -454,8 +461,8 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		});
 		const otherIndex = question.options.length;
 		const otherCursor = this.selectedOptions[this.page] === otherIndex ? "›" : " ";
-		const otherChosen = this.answers[this.page]?.wasCustom ? "●" : "○";
-		lines.push(`${otherCursor} ${otherChosen} Other (free-form)`);
+		const otherChosen = this.answers[this.page]?.wasCustom ? " ✓" : "";
+		lines.push(`${otherCursor} ${otherIndex + 1}. Other (free-form)${otherChosen}`);
 		const answer = this.answers[this.page];
 		if (answer?.wasCustom)
 			lines.push(...labeledRaw("Answer", answer.answer, width, this.options.theme));

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -674,6 +674,10 @@ class RawPreservingEditor implements Focusable {
 			this.flushPasteBuffer();
 			return;
 		}
+		if (matchesKey(data, Key.backspace)) {
+			this.editor.handleInput(data);
+			return;
+		}
 		const pasteStart = data.indexOf(BRACKETED_PASTE_START);
 		if (pasteStart >= 0) {
 			if (pasteStart > 0) this.editor.handleInput(data.slice(0, pasteStart));

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -16,6 +16,9 @@ import {
 export const PLAN_MODE_QUESTION_TOOL_NAME = "plan_mode_question";
 export const MAX_PLAN_MODE_RESPONSE_LENGTH = 4_000;
 
+const BRACKETED_PASTE_START = "\u001b[200~";
+const BRACKETED_PASTE_END = "\u001b[201~";
+
 export type PlanModeQuestionOption = {
 	label: string;
 	description?: string;
@@ -275,7 +278,7 @@ interface QuestionnaireOptions {
 
 export class PlanModeQuestionnaire implements Component, Focusable {
 	private readonly options: QuestionnaireOptions;
-	private readonly editor: Editor;
+	private readonly editor: RawPreservingEditor;
 	private readonly answers: Array<PlanModeQuestionAnswer | undefined>;
 	private readonly selectedOptions: number[];
 	private page = 0;
@@ -300,7 +303,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 				noMatch: (text) => options.theme.fg("warning", text),
 			},
 		};
-		this.editor = new Editor(options.tui, editorTheme, { paddingX: 0 });
+		this.editor = new RawPreservingEditor(options.tui, editorTheme);
 		this.editor.onChange = () => {
 			this.message = undefined;
 		};
@@ -324,7 +327,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const lines = [this.renderTabs(safeWidth), ""];
+		const lines = [...this.renderTabs(safeWidth), ""];
 		if (this.page === this.options.questions.length) lines.push(...this.renderReview(safeWidth));
 		else lines.push(...this.renderQuestion(safeWidth));
 		if (this.message)
@@ -402,7 +405,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		this.message = undefined;
 	}
 
-	private renderTabs(width: number): string {
+	private renderTabs(width: number): string[] {
 		const tabs = [
 			...this.options.questions.map((question, index) => {
 				const label = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
@@ -411,7 +414,20 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			}),
 			this.page === this.options.questions.length ? "[Review]" : "Review",
 		];
-		return truncateToWidth(this.options.theme.fg("accent", tabs.join("  ")), width, "…");
+		const lines: string[] = [];
+		let line = "";
+		for (const tab of tabs) {
+			const boundedTab = truncateToWidth(tab, width, "…");
+			const candidate = line ? `${line}  ${boundedTab}` : boundedTab;
+			if (line && visibleWidth(candidate) > width) {
+				lines.push(this.options.theme.fg("accent", line));
+				line = boundedTab;
+			} else {
+				line = candidate;
+			}
+		}
+		if (line) lines.push(this.options.theme.fg("accent", line));
+		return lines;
 	}
 
 	private renderQuestion(width: number): string[] {
@@ -576,7 +592,11 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			}
 			const question = this.options.questions[index];
 			if (!question) return;
-			this.answers[index] = answerFor(question, value, { wasCustom: true });
+			const previous = this.answers[index];
+			this.answers[index] = answerFor(question, value, {
+				wasCustom: true,
+				note: previous?.wasCustom ? previous.note : undefined,
+			});
 			this.editor.setText("");
 			this.editorKind = undefined;
 			this.editor.focused = false;
@@ -605,6 +625,148 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		this.editor.focused = false;
 		this.options.onDone(answers);
 	}
+}
+
+class RawPreservingEditor implements Focusable {
+	private readonly editor: Editor;
+	private readonly rawByMarker = new Map<string, string>();
+	private markerCodePoint = 0xe000;
+	private pasteBuffer: string | undefined;
+
+	constructor(tui: TUI, theme: EditorTheme) {
+		this.editor = new Editor(tui, theme, { paddingX: 0 });
+	}
+
+	get focused(): boolean {
+		return this.editor.focused;
+	}
+
+	set focused(value: boolean) {
+		this.editor.focused = value;
+	}
+
+	set onChange(handler: ((value: string) => void) | undefined) {
+		this.editor.onChange = handler ? () => handler(this.getExpandedText()) : undefined;
+	}
+
+	set onSubmit(handler: ((value: string) => void) | undefined) {
+		this.editor.onSubmit = handler ? (value) => handler(this.decode(value)) : undefined;
+	}
+
+	handleInput(data: string): void {
+		if (this.pasteBuffer !== undefined) {
+			this.pasteBuffer += data;
+			this.flushPasteBuffer();
+			return;
+		}
+		const pasteStart = data.indexOf(BRACKETED_PASTE_START);
+		if (pasteStart >= 0) {
+			if (pasteStart > 0) this.editor.handleInput(data.slice(0, pasteStart));
+			this.pasteBuffer = data.slice(pasteStart + BRACKETED_PASTE_START.length);
+			this.flushPasteBuffer();
+			return;
+		}
+		if (
+			[...data].some(
+				(character) => isUnsafeDirectEditorCharacter(character) || this.rawByMarker.has(character),
+			)
+		) {
+			this.editor.handleInput(this.encode(data));
+			return;
+		}
+		this.editor.handleInput(data);
+	}
+
+	render(width: number): string[] {
+		return this.editor
+			.render(width)
+			.map((line) =>
+				[...line].map((character) => (this.rawByMarker.has(character) ? " " : character)).join(""),
+			);
+	}
+
+	invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	setText(value: string): void {
+		this.rawByMarker.clear();
+		this.markerCodePoint = 0xe000;
+		this.pasteBuffer = undefined;
+		this.editor.setText(this.encode(value));
+	}
+
+	getExpandedText(): string {
+		return this.decode(this.editor.getExpandedText());
+	}
+
+	private flushPasteBuffer(): void {
+		if (this.pasteBuffer === undefined) return;
+		const pasteEnd = this.pasteBuffer.indexOf(BRACKETED_PASTE_END);
+		if (pasteEnd < 0) return;
+		const raw = this.pasteBuffer.slice(0, pasteEnd);
+		const remaining = this.pasteBuffer.slice(pasteEnd + BRACKETED_PASTE_END.length);
+		this.pasteBuffer = undefined;
+		this.editor.handleInput(`${BRACKETED_PASTE_START}${this.encode(raw)}${BRACKETED_PASTE_END}`);
+		if (remaining) this.handleInput(remaining);
+	}
+
+	private encode(value: string): string {
+		const forbidden = new Set([
+			...value,
+			...this.editor.getExpandedText(),
+			...this.rawByMarker.keys(),
+		]);
+		return [...value]
+			.map((character) => {
+				if (!isUnsafeEditorCharacter(character) && !this.rawByMarker.has(character)) {
+					return character;
+				}
+				const marker = this.nextMarker(forbidden);
+				this.rawByMarker.set(marker, character);
+				forbidden.add(marker);
+				return marker;
+			})
+			.join("");
+	}
+
+	private decode(value: string): string {
+		return [...value].map((character) => this.rawByMarker.get(character) ?? character).join("");
+	}
+
+	private nextMarker(forbidden: ReadonlySet<string>): string {
+		for (;;) {
+			if (this.markerCodePoint === 0xf900) this.markerCodePoint = 0xf0000;
+			if (this.markerCodePoint === 0xffffe) this.markerCodePoint = 0x100000;
+			if (this.markerCodePoint > 0x10fffd) {
+				throw new Error("Plan-mode editor exhausted its safe input markers.");
+			}
+			const marker = String.fromCodePoint(this.markerCodePoint++);
+			if (!forbidden.has(marker)) return marker;
+		}
+	}
+}
+
+function isUnsafeDirectEditorCharacter(character: string): boolean {
+	const codePoint = character.codePointAt(0) ?? 0;
+	return (
+		(codePoint >= 0x7f && codePoint <= 0x9f) ||
+		codePoint === 0x2028 ||
+		codePoint === 0x2029 ||
+		isBidiControl(codePoint)
+	);
+}
+
+function isUnsafeEditorCharacter(character: string): boolean {
+	const codePoint = character.codePointAt(0) ?? 0;
+	return (
+		character !== "\n" &&
+		(codePoint <= 0x1f ||
+			(codePoint >= 0x7f && codePoint <= 0x9f) ||
+			codePoint === 0x2028 ||
+			codePoint === 0x2029 ||
+			isBidiControl(codePoint))
+	);
 }
 
 function answerFor(

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -122,8 +122,14 @@ test("TUI applies legacy selector emphasis to borders, title, and selected optio
 	await tui.waitForOpen();
 	tui.render();
 	assert.ok(foreground.some(({ color, text }) => color === "border" && text === "─".repeat(60)));
-	assert.ok(foreground.some(({ color, text }) => color === "accent" && /→ 1\. Small/u.test(text)));
-	assert.ok(foreground.some(({ color, text }) => color === "accent" && text === "Only the bug."));
+	assert.ok(
+		foreground.some(
+			({ color, text }) => color === "accent" && text === "→ 1. Small — Only the bug.",
+		),
+	);
+	assert.ok(
+		foreground.some(({ color, text }) => color === "muted" && text === " — Include cleanup."),
+	);
 	assert.ok(bold.includes("How broad?"));
 	tui.dispose();
 	assert.equal(await running, undefined);
@@ -134,7 +140,7 @@ test("TUI uses numbered select styling and restores the recorded answer cursor",
 	await tui.waitForOpen();
 	tui.setFocused(true);
 	let frame = tui.render().join("\n");
-	assert.match(frame, /→ 1\. Small/u);
+	assert.match(frame, /→ 1\. Small — Only the bug\./u);
 	assert.doesNotMatch(frame, /[○●]/u);
 	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -135,6 +135,41 @@ test("TUI applies legacy selector emphasis to borders, title, and selected optio
 	assert.equal(await running, undefined);
 });
 
+test("Review uses the same numbered selector emphasis as question options", async () => {
+	const foreground: Array<{ color: string; text: string }> = [];
+	const bold: string[] = [];
+	const tui = createTuiHarness({
+		width: 60,
+		rows: 30,
+		theme: {
+			fg: (color, text) => {
+				foreground.push({ color: String(color), text });
+				return text;
+			},
+			bold: (text) => {
+				bold.push(text);
+				return text;
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions(questions, context.ctx);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.send("\u001b[C");
+	tui.send("\u001b[C");
+	const frame = tui.render().join("\n");
+	assert.match(frame, /\n → 1\. Scope — Unanswered\n {3}2\. Tests — Unanswered/u);
+	assert.ok(
+		foreground.some(({ color, text }) => color === "accent" && text === "→ 1. Scope — Unanswered"),
+	);
+	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "  2. Tests"));
+	assert.ok(foreground.some(({ color, text }) => color === "muted" && text === " — Unanswered"));
+	assert.ok(bold.includes("Review answers"));
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
 test("TUI uses numbered select styling and restores the recorded answer cursor", async () => {
 	const { tui, running } = tuiRun([questions[0]]);
 	await tui.waitForOpen();
@@ -192,6 +227,7 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	tui.type("n");
 	paste(tui, "final note");
 	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /→ 1\. Scope — Broad · Note: final note/u);
 	tui.press("tui.select.confirm");
 
 	assert.deepEqual(await running, [

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -161,6 +161,99 @@ test("Review blocks incomplete submission and lets selected answer receive a not
 	assert.equal(await running, undefined);
 });
 
+test("TUI preserves raw custom answers and notes while sanitizing editor rendering", async () => {
+	const unsafeAnswer = "raw\u001b]8;;https://evil.example\u0007text\u202ereversed";
+	const unsafeNote = "note\u009bcontrol\u202aspoofed";
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	paste(tui, unsafeAnswer);
+	const answerDraft = tui.render().join("\n");
+	assert.equal(answerDraft.includes("\u202e"), false);
+	assert.equal(answerDraft.includes("\u001b]8;;https://evil.example"), false);
+	tui.press("tui.input.submit");
+	tui.type("n");
+	paste(tui, unsafeNote);
+	const noteDraft = tui.render().join("\n");
+	assert.equal(noteDraft.includes("\u009b"), false);
+	assert.equal(noteDraft.includes("\u202a"), false);
+	tui.press("tui.input.submit");
+	const review = tui.render().join("\n");
+	assert.equal(review.includes("\u202e") || review.includes("\u202a"), false);
+	tui.press("tui.select.confirm");
+
+	assert.deepEqual(await running, [
+		{
+			id: "scope",
+			header: "Scope",
+			question: "How broad?",
+			answer: unsafeAnswer,
+			wasCustom: true,
+			note: unsafeNote,
+		},
+	]);
+});
+
+test("editing an existing Other answer preserves its note", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	paste(tui, "first answer");
+	tui.press("tui.input.submit");
+	tui.type("n");
+	paste(tui, "keep this note");
+	tui.press("tui.input.submit");
+	tui.send("\u001b[D");
+	tui.press("tui.select.confirm");
+	tui.send("\u0015");
+	paste(tui, "edited answer");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+
+	assert.equal((await running)?.[0]?.note, "keep this note");
+});
+
+test("narrow TUI rendering keeps every question and Review tab visible", async () => {
+	const longQuestions = [
+		{ ...questions[0], header: "LongHeader12" },
+		{ ...questions[1], header: "SecondHeader" },
+		{ ...questions[0], id: "risk", header: "ThirdHeader3" },
+	];
+	const { tui, running } = tuiRun(longQuestions, 24);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	for (let index = 0; index < longQuestions.length; index += 1) tui.send("\u001b[C");
+	const frame = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(frame, /LongHeader12/u);
+	assert.match(frame, /SecondHeader/u);
+	assert.match(frame, /ThirdHeader3/u);
+	assert.match(frame, /\[Review\]/u);
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
+test("TUI abort signal closes the questionnaire without answers", async () => {
+	const controller = new AbortController();
+	const tui = createTuiHarness({ width: 60, rows: 30 });
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+		signal: controller.signal,
+	});
+	const running = askPlanModeQuestions(questions, context.ctx);
+	await tui.waitForOpen();
+	controller.abort();
+	assert.equal(await running, undefined);
+	assert.equal(tui.isOpen, false);
+});
+
 test("Other editor rejects oversized input and forwards focus", async () => {
 	const { tui, running } = tuiRun([questions[0]]);
 	await tui.waitForOpen();
@@ -173,6 +266,21 @@ test("Other editor rejects oversized input and forwards focus", async () => {
 	paste(tui, "x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1));
 	tui.press("tui.input.submit");
 	assert.match(tui.render().join("\n"), /4,000 characters or fewer/u);
+	assert.equal(tui.isOpen, true);
+	tui.press("ctrl+c");
+	assert.equal(await running, undefined);
+});
+
+test("Note editor rejects oversized input and stays open", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("n");
+	const oversized = "z".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1);
+	paste(tui, oversized);
+	tui.press("tui.input.submit");
+	const frame = tui.render().join("\n");
+	assert.match(frame, /Note must be 4,000 characters or fewer/u);
 	assert.equal(tui.isOpen, true);
 	tui.press("ctrl+c");
 	assert.equal(await running, undefined);

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -135,7 +135,7 @@ test("TUI applies legacy selector emphasis to borders, title, and selected optio
 	assert.equal(await running, undefined);
 });
 
-test("Review uses the same numbered selector emphasis as question options", async () => {
+test("Review renders plain summaries without selection affordances", async () => {
 	const foreground: Array<{ color: string; text: string }> = [];
 	const bold: string[] = [];
 	const tui = createTuiHarness({
@@ -158,14 +158,26 @@ test("Review uses the same numbered selector emphasis as question options", asyn
 	tui.setFocused(true);
 	tui.send("\u001b[C");
 	tui.send("\u001b[C");
+	foreground.length = 0;
+	bold.length = 0;
 	const frame = tui.render().join("\n");
-	assert.match(frame, /\n → 1\. Scope — Unanswered\n {3}2\. Tests — Unanswered/u);
-	assert.ok(
-		foreground.some(({ color, text }) => color === "accent" && text === "→ 1. Scope — Unanswered"),
-	);
-	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "  2. Tests"));
+	assert.match(frame, /\n 1\. Scope — Unanswered\n 2\. Tests — Unanswered/u);
+	assert.doesNotMatch(frame, /→ [12]\./u);
+	assert.match(frame, /Enter submit/u);
+	assert.doesNotMatch(frame, /↑\/↓ select|n note/u);
+	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "1. Scope"));
+	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "2. Tests"));
 	assert.ok(foreground.some(({ color, text }) => color === "muted" && text === " — Unanswered"));
+	assert.equal(
+		foreground.some(
+			({ color, text }) => color === "accent" && /(?:→ )?[12]\. (?:Scope|Tests)/u.test(text),
+		),
+		false,
+	);
 	assert.ok(bold.includes("Review answers"));
+	const unchanged = tui.render().join("\n");
+	tui.press("tui.select.down");
+	assert.equal(tui.render().join("\n"), unchanged);
 	tui.dispose();
 	assert.equal(await running, undefined);
 });
@@ -216,7 +228,9 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	tui.press("tui.input.submit");
 	assert.match(tui.render().join("\n"), /Review answers[\s\S]*Broad[\s\S]*custom answer/u);
 
-	// Review selects answers for note add/edit/clear.
+	// Notes remain editable from their question page, not from the plain Review summary.
+	tui.send("\u001b[D");
+	tui.send("\u001b[D");
 	tui.type("n");
 	paste(tui, "draft note");
 	tui.press("tui.input.submit");
@@ -227,7 +241,9 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	tui.type("n");
 	paste(tui, "final note");
 	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /→ 1\. Scope — Broad · Note: final note/u);
+	tui.send("\u001b[C");
+	tui.send("\u001b[C");
+	assert.match(tui.render().join("\n"), /1\. Scope — Broad · Note: final note/u);
 	tui.press("tui.select.confirm");
 
 	assert.deepEqual(await running, [
@@ -250,7 +266,7 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	]);
 });
 
-test("Review blocks incomplete submission and lets selected answer receive a note", async () => {
+test("Review blocks incomplete submission and directs note edits back to questions", async () => {
 	const { tui, running } = tuiRun();
 	await tui.waitForOpen();
 	tui.setFocused(true);
@@ -259,8 +275,9 @@ test("Review blocks incomplete submission and lets selected answer receive a not
 	tui.press("tui.select.confirm");
 	assert.match(tui.render().join("\n"), /Answer every question before submitting/u);
 	tui.press("tui.select.down");
+	assert.doesNotMatch(tui.render().join("\n"), /→ [12]\./u);
 	tui.type("n");
-	assert.match(tui.render().join("\n"), /Select an answer before adding a note/u);
+	assert.match(tui.render().join("\n"), /Return to a question to add or edit its note/u);
 	tui.press("tui.select.cancel");
 	assert.equal(await running, undefined);
 });
@@ -279,12 +296,14 @@ test("TUI preserves raw custom answers and notes while sanitizing editor renderi
 	assert.equal(answerDraft.includes("\u202e"), false);
 	assert.equal(answerDraft.includes("\u001b]8;;https://evil.example"), false);
 	tui.press("tui.input.submit");
+	tui.send("\u001b[D");
 	tui.type("n");
 	paste(tui, unsafeNote);
 	const noteDraft = tui.render().join("\n");
 	assert.equal(noteDraft.includes("\u009b"), false);
 	assert.equal(noteDraft.includes("\u202a"), false);
 	tui.press("tui.input.submit");
+	tui.send("\u001b[C");
 	const review = tui.render().join("\n");
 	assert.equal(review.includes("\u202e") || review.includes("\u202a"), false);
 	tui.press("tui.select.confirm");
@@ -310,10 +329,10 @@ test("editing an existing Other answer preserves its note", async () => {
 	tui.press("tui.select.confirm");
 	paste(tui, "first answer");
 	tui.press("tui.input.submit");
+	tui.send("\u001b[D");
 	tui.type("n");
 	paste(tui, "keep this note");
 	tui.press("tui.input.submit");
-	tui.send("\u001b[D");
 	tui.press("tui.select.confirm");
 	tui.send("\u0015");
 	paste(tui, "edited answer");

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -87,6 +87,26 @@ test("TUI previews future questions and navigates back before answering", async 
 	assert.equal(await running, undefined);
 });
 
+test("TUI uses numbered select styling and restores the recorded answer cursor", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	let frame = tui.render().join("\n");
+	assert.match(frame, /› 1\. Small/u);
+	assert.doesNotMatch(frame, /[○●]/u);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.send("\u001b[D");
+	frame = tui.render().join("\n");
+	assert.match(frame, /› 2\. Broad ✓/u);
+	tui.press("tui.select.up");
+	tui.send("\u001b[C");
+	tui.send("\u001b[D");
+	assert.match(tui.render().join("\n"), /› 2\. Broad ✓/u);
+	tui.press("tui.select.cancel");
+	assert.equal(await running, undefined);
+});
+
 test("TUI replaces answers, manages notes, accepts Other, and submits ordered raw payload", async () => {
 	const { tui, running } = tuiRun();
 	await tui.waitForOpen();

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -87,6 +87,16 @@ test("TUI previews future questions and navigates back before answering", async 
 	assert.equal(await running, undefined);
 });
 
+test("TUI frames the questionnaire with select-style separator borders", async () => {
+	const { tui, running } = tuiRun([questions[0]], 40);
+	await tui.waitForOpen();
+	const frame = tui.render();
+	assert.equal(frame[0], "─".repeat(40));
+	assert.equal(frame.at(-1), "─".repeat(40));
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
 test("TUI uses numbered select styling and restores the recorded answer cursor", async () => {
 	const { tui, running } = tuiRun([questions[0]]);
 	await tui.waitForOpen();

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -283,7 +283,7 @@ test("Review blocks incomplete submission and directs note edits back to questio
 });
 
 test("TUI preserves raw custom answers and notes while sanitizing editor rendering", async () => {
-	const unsafeAnswer = "raw\u001b]8;;https://evil.example\u0007text\u202ereversed";
+	const unsafeAnswer = "raw\u007f\u001b]8;;https://evil.example\u0007text\u202ereversed";
 	const unsafeNote = "note\u009bcontrol\u202aspoofed";
 	const { tui, running } = tuiRun([questions[0]]);
 	await tui.waitForOpen();
@@ -375,6 +375,35 @@ test("TUI abort signal closes the questionnaire without answers", async () => {
 	controller.abort();
 	assert.equal(await running, undefined);
 	assert.equal(tui.isOpen, false);
+});
+
+test("Other editor treats Backspace as deletion instead of raw text", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.type("wrongx");
+	tui.send("\u007f");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+
+	assert.equal((await running)?.[0]?.answer, "wrong");
+});
+
+test("Optional note editor treats Backspace as deletion instead of raw text", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("n");
+	tui.type("note!");
+	tui.send("\u007f");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+	tui.press("tui.select.confirm");
+
+	assert.equal((await running)?.[0]?.note, "note");
 });
 
 test("Other editor rejects oversized input and forwards focus", async () => {

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -92,7 +92,39 @@ test("TUI frames the questionnaire with select-style separator borders", async (
 	await tui.waitForOpen();
 	const frame = tui.render();
 	assert.equal(frame[0], "─".repeat(40));
+	assert.equal(frame[1], "");
+	assert.equal(frame.at(-2), "");
 	assert.equal(frame.at(-1), "─".repeat(40));
+	assert.match(frame.join("\n"), /^ How broad\?$/mu);
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
+test("TUI applies legacy selector emphasis to borders, title, and selected option", async () => {
+	const foreground: Array<{ color: string; text: string }> = [];
+	const bold: string[] = [];
+	const tui = createTuiHarness({
+		width: 60,
+		rows: 30,
+		theme: {
+			fg: (color, text) => {
+				foreground.push({ color: String(color), text });
+				return text;
+			},
+			bold: (text) => {
+				bold.push(text);
+				return text;
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions([questions[0]], context.ctx);
+	await tui.waitForOpen();
+	tui.render();
+	assert.ok(foreground.some(({ color, text }) => color === "border" && text === "─".repeat(60)));
+	assert.ok(foreground.some(({ color, text }) => color === "accent" && /→ 1\. Small/u.test(text)));
+	assert.ok(foreground.some(({ color, text }) => color === "accent" && text === "Only the bug."));
+	assert.ok(bold.includes("How broad?"));
 	tui.dispose();
 	assert.equal(await running, undefined);
 });
@@ -102,17 +134,17 @@ test("TUI uses numbered select styling and restores the recorded answer cursor",
 	await tui.waitForOpen();
 	tui.setFocused(true);
 	let frame = tui.render().join("\n");
-	assert.match(frame, /› 1\. Small/u);
+	assert.match(frame, /→ 1\. Small/u);
 	assert.doesNotMatch(frame, /[○●]/u);
 	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
 	tui.send("\u001b[D");
 	frame = tui.render().join("\n");
-	assert.match(frame, /› 2\. Broad ✓/u);
+	assert.match(frame, /→ 2\. Broad ✓/u);
 	tui.press("tui.select.up");
 	tui.send("\u001b[C");
 	tui.send("\u001b[D");
-	assert.match(tui.render().join("\n"), /› 2\. Broad ✓/u);
+	assert.match(tui.render().join("\n"), /→ 2\. Broad ✓/u);
 	tui.press("tui.select.cancel");
 	assert.equal(await running, undefined);
 });

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -459,30 +459,29 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		question.options.forEach((option, index) => {
 			const selected = this.selectedOptions[this.page] === index;
 			const cursor = selected ? "→" : " ";
-			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? " ✓" : "";
-			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}${chosen}`;
-			lines.push(...hardWrap(this.options.theme.fg(selected ? "accent" : "text", label), width));
-			if (option.description) {
-				lines.push(
-					...hardWrap(
-						`    ${this.options.theme.fg(
-							selected ? "accent" : "muted",
-							sanitizeTerminalText(option.description),
-						)}`,
-						width,
-					),
-				);
-			}
+			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}`;
+			const chosen = this.answers[this.page]?.optionIndex === index + 1;
+			const description = option.description
+				? ` — ${sanitizeTerminalText(option.description)}`
+				: "";
+			const line = selected
+				? this.options.theme.fg("accent", `${label}${chosen ? " ✓" : ""}${description}`)
+				: `${this.options.theme.fg("text", label)}${
+						chosen ? this.options.theme.fg("success", " ✓") : ""
+					}${description ? this.options.theme.fg("muted", description) : ""}`;
+			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${cursor} ${index + 1}. `)));
 		});
 		const otherIndex = question.options.length;
 		const otherSelected = this.selectedOptions[this.page] === otherIndex;
 		const otherCursor = otherSelected ? "→" : " ";
-		const otherChosen = this.answers[this.page]?.wasCustom ? " ✓" : "";
+		const otherLabel = `${otherCursor} ${otherIndex + 1}. Other (free-form)`;
+		const otherChosen = this.answers[this.page]?.wasCustom === true;
 		lines.push(
-			this.options.theme.fg(
-				otherSelected ? "accent" : "text",
-				`${otherCursor} ${otherIndex + 1}. Other (free-form)${otherChosen}`,
-			),
+			otherSelected
+				? this.options.theme.fg("accent", `${otherLabel}${otherChosen ? " ✓" : ""}`)
+				: `${this.options.theme.fg("text", otherLabel)}${
+						otherChosen ? this.options.theme.fg("success", " ✓") : ""
+					}`,
 		);
 		const answer = this.answers[this.page];
 		if (answer?.wasCustom)
@@ -887,6 +886,19 @@ function labeledRaw(label: string, value: string, width: number, theme: Theme): 
 	return lines.map((line, index) =>
 		index === 0 ? `${theme.fg("muted", prefix)}${line}` : `${" ".repeat(prefix.length)}${line}`,
 	);
+}
+
+function hardWrapWithIndent(value: string, width: number, indent: number): string[] {
+	const safeWidth = Math.max(1, width);
+	const safeIndent = Math.min(Math.max(0, indent), Math.max(0, safeWidth - 1));
+	const continuationWidth = Math.max(1, safeWidth - safeIndent);
+	const columns = visibleWidth(value);
+	if (columns <= safeWidth) return [value];
+	const output = [sliceByColumn(value, 0, safeWidth)];
+	for (let column = safeWidth; column < columns; column += continuationWidth) {
+		output.push(`${" ".repeat(safeIndent)}${sliceByColumn(value, column, continuationWidth)}`);
+	}
+	return output;
 }
 
 function hardWrap(value: string, width: number): string[] {

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -282,7 +282,6 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	private readonly answers: Array<PlanModeQuestionAnswer | undefined>;
 	private readonly selectedOptions: number[];
 	private page = 0;
-	private reviewSelection = 0;
 	private editorKind: "answer" | "note" | undefined;
 	private message: string | undefined;
 	private finished = false;
@@ -342,7 +341,9 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 					"dim",
 					this.editorKind
 						? "Enter save · Esc/Ctrl+C cancel questionnaire"
-						: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer/submit · n note · Esc cancel",
+						: this.page === this.options.questions.length
+							? "Tab/Shift+Tab or ←/→ navigate · Enter submit · Esc cancel"
+							: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer · n note · Esc cancel",
 				),
 				contentWidth,
 			),
@@ -392,16 +393,18 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			this.movePage(-1);
 			return;
 		}
+		const review = this.page === this.options.questions.length;
 		if (matchesKey(data, Key.up)) {
-			this.moveSelection(-1);
+			if (!review) this.moveSelection(-1);
 			return;
 		}
 		if (matchesKey(data, Key.down)) {
-			this.moveSelection(1);
+			if (!review) this.moveSelection(1);
 			return;
 		}
 		if (data.toLowerCase() === "n") {
-			this.editNote();
+			if (review) this.message = "Return to a question to add or edit its note.";
+			else this.editNote();
 			return;
 		}
 		if (matchesKey(data, Key.enter)) this.submitPage();
@@ -504,33 +507,18 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		const lines = [this.options.theme.fg("accent", this.options.theme.bold("Review answers")), ""];
 		this.options.questions.forEach((question, index) => {
 			const answer = this.answers[index];
-			const selected = this.reviewSelection === index;
-			const cursor = selected ? "→" : " ";
 			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
-			const label = `${cursor} ${index + 1}. ${header}`;
+			const label = `${index + 1}. ${header}`;
 			const summary = ` — ${inlineSummary(answer?.answer ?? "Unanswered")}${
 				answer?.note ? ` · Note: ${inlineSummary(answer.note)}` : ""
 			}`;
-			const line = selected
-				? this.options.theme.fg("accent", `${label}${summary}`)
-				: `${this.options.theme.fg("text", label)}${this.options.theme.fg("muted", summary)}`;
-			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${cursor} ${index + 1}. `)));
+			const line = `${this.options.theme.fg("text", label)}${this.options.theme.fg("muted", summary)}`;
+			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${index + 1}. `)));
 		});
-		if (this.editorKind === "note") {
-			lines.push("");
-			lines.push(this.options.theme.fg("accent", "Optional note"));
-			lines.push(...this.editor.render(width));
-		}
 		return lines;
 	}
 
 	private moveSelection(delta: number): void {
-		if (this.page === this.options.questions.length) {
-			this.reviewSelection =
-				(this.reviewSelection + delta + this.options.questions.length) %
-				this.options.questions.length;
-			return;
-		}
 		const optionCount = (this.options.questions[this.page]?.options.length ?? 0) + 1;
 		this.selectedOptions[this.page] =
 			((this.selectedOptions[this.page] ?? 0) + delta + optionCount) % optionCount;
@@ -570,25 +558,22 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	}
 
 	private editNote(): void {
-		const review = this.page === this.options.questions.length;
-		const index = review ? this.reviewSelection : this.page;
+		const index = this.page;
 		let answer = this.answers[index];
-		if (!review) {
-			const question = this.options.questions[index];
-			const selected = this.selectedOptions[index] ?? 0;
-			if (question && selected === question.options.length && !answer?.wasCustom) {
-				this.beginEditor("answer", "");
-				return;
-			}
-			if (question && selected < question.options.length && answer?.optionIndex !== selected + 1) {
-				const option = question.options[selected];
-				if (option) {
-					answer = answerFor(question, option.label, {
-						wasCustom: false,
-						optionIndex: selected + 1,
-					});
-					this.answers[index] = answer;
-				}
+		const question = this.options.questions[index];
+		const selected = this.selectedOptions[index] ?? 0;
+		if (question && selected === question.options.length && !answer?.wasCustom) {
+			this.beginEditor("answer", "");
+			return;
+		}
+		if (question && selected < question.options.length && answer?.optionIndex !== selected + 1) {
+			const option = question.options[selected];
+			if (option) {
+				answer = answerFor(question, option.label, {
+					wasCustom: false,
+					optionIndex: selected + 1,
+				});
+				this.answers[index] = answer;
 			}
 		}
 		if (!answer) {
@@ -612,7 +597,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			this.options.tui.requestRender();
 			return;
 		}
-		const index = this.page === this.options.questions.length ? this.reviewSelection : this.page;
+		const index = this.page;
 		if (this.editorKind === "answer") {
 			if (!value.trim()) {
 				this.editor.setText(value);

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -501,17 +501,20 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	}
 
 	private renderReview(width: number): string[] {
-		const lines = [this.options.theme.fg("text", "Review answers")];
+		const lines = [this.options.theme.fg("accent", this.options.theme.bold("Review answers")), ""];
 		this.options.questions.forEach((question, index) => {
 			const answer = this.answers[index];
-			const cursor = this.reviewSelection === index ? "→" : " ";
+			const selected = this.reviewSelection === index;
+			const cursor = selected ? "→" : " ";
 			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
-			lines.push("");
-			lines.push(`${cursor} ${this.options.theme.fg("accent", header)}`);
-			lines.push(
-				...labeledRaw("Answer", answer?.answer ?? "Unanswered", width, this.options.theme),
-			);
-			if (answer?.note) lines.push(...labeledRaw("Note", answer.note, width, this.options.theme));
+			const label = `${cursor} ${index + 1}. ${header}`;
+			const summary = ` — ${inlineSummary(answer?.answer ?? "Unanswered")}${
+				answer?.note ? ` · Note: ${inlineSummary(answer.note)}` : ""
+			}`;
+			const line = selected
+				? this.options.theme.fg("accent", `${label}${summary}`)
+				: `${this.options.theme.fg("text", label)}${this.options.theme.fg("muted", summary)}`;
+			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${cursor} ${index + 1}. `)));
 		});
 		if (this.editorKind === "note") {
 			lines.push("");
@@ -877,6 +880,10 @@ function isBidiControl(codePoint: number): boolean {
 		(codePoint >= 0x202a && codePoint <= 0x202e) ||
 		(codePoint >= 0x2066 && codePoint <= 0x2069)
 	);
+}
+
+function inlineSummary(value: string): string {
+	return value.split("\n").map(sanitizeTerminalText).join(" ↵ ");
 }
 
 function labeledRaw(label: string, value: string, width: number, theme: Theme): string[] {

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -327,7 +327,8 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const lines = [...this.renderTabs(safeWidth), ""];
+		const border = this.options.theme.fg("accent", "─".repeat(safeWidth));
+		const lines = [border, ...this.renderTabs(safeWidth), ""];
 		if (this.page === this.options.questions.length) lines.push(...this.renderReview(safeWidth));
 		else lines.push(...this.renderQuestion(safeWidth));
 		if (this.message)
@@ -343,6 +344,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 				),
 				safeWidth,
 			),
+			border,
 		);
 		return lines.map((line) => truncateToWidth(line, safeWidth));
 	}

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -327,12 +327,14 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const border = this.options.theme.fg("accent", "─".repeat(safeWidth));
-		const lines = [border, ...this.renderTabs(safeWidth), ""];
-		if (this.page === this.options.questions.length) lines.push(...this.renderReview(safeWidth));
-		else lines.push(...this.renderQuestion(safeWidth));
+		const padding = safeWidth > 1 ? " " : "";
+		const contentWidth = Math.max(1, safeWidth - visibleWidth(padding));
+		const border = this.options.theme.fg("border", "─".repeat(safeWidth));
+		const lines = [border, "", ...this.renderTabs(contentWidth), ""];
+		if (this.page === this.options.questions.length) lines.push(...this.renderReview(contentWidth));
+		else lines.push(...this.renderQuestion(contentWidth));
 		if (this.message)
-			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), safeWidth));
+			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), contentWidth));
 		lines.push("");
 		lines.push(
 			truncateToWidth(
@@ -342,11 +344,15 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 						? "Enter save · Esc/Ctrl+C cancel questionnaire"
 						: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer/submit · n note · Esc cancel",
 				),
-				safeWidth,
+				contentWidth,
 			),
+			"",
 			border,
 		);
-		return lines.map((line) => truncateToWidth(line, safeWidth));
+		return lines.map((line) => {
+			if (!line || line === border) return line;
+			return `${padding}${truncateToWidth(line, contentWidth)}`;
+		});
 	}
 
 	handleInput(data: string): void {
@@ -443,28 +449,41 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		const question = this.options.questions[this.page];
 		if (!question) return [];
 		const lines = hardWrap(
-			this.options.theme.fg("text", sanitizeTerminalText(question.question)),
+			this.options.theme.fg(
+				"accent",
+				this.options.theme.bold(sanitizeTerminalText(question.question)),
+			),
 			width,
 		);
 		lines.push("");
 		question.options.forEach((option, index) => {
-			const cursor = this.selectedOptions[this.page] === index ? "›" : " ";
+			const selected = this.selectedOptions[this.page] === index;
+			const cursor = selected ? "→" : " ";
 			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? " ✓" : "";
 			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}${chosen}`;
-			lines.push(...hardWrap(this.options.theme.fg("text", label), width));
+			lines.push(...hardWrap(this.options.theme.fg(selected ? "accent" : "text", label), width));
 			if (option.description) {
 				lines.push(
 					...hardWrap(
-						`    ${this.options.theme.fg("muted", sanitizeTerminalText(option.description))}`,
+						`    ${this.options.theme.fg(
+							selected ? "accent" : "muted",
+							sanitizeTerminalText(option.description),
+						)}`,
 						width,
 					),
 				);
 			}
 		});
 		const otherIndex = question.options.length;
-		const otherCursor = this.selectedOptions[this.page] === otherIndex ? "›" : " ";
+		const otherSelected = this.selectedOptions[this.page] === otherIndex;
+		const otherCursor = otherSelected ? "→" : " ";
 		const otherChosen = this.answers[this.page]?.wasCustom ? " ✓" : "";
-		lines.push(`${otherCursor} ${otherIndex + 1}. Other (free-form)${otherChosen}`);
+		lines.push(
+			this.options.theme.fg(
+				otherSelected ? "accent" : "text",
+				`${otherCursor} ${otherIndex + 1}. Other (free-form)${otherChosen}`,
+			),
+		);
 		const answer = this.answers[this.page];
 		if (answer?.wasCustom)
 			lines.push(...labeledRaw("Answer", answer.answer, width, this.options.theme));
@@ -486,7 +505,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		const lines = [this.options.theme.fg("text", "Review answers")];
 		this.options.questions.forEach((question, index) => {
 			const answer = this.answers[index];
-			const cursor = this.reviewSelection === index ? "›" : " ";
+			const cursor = this.reviewSelection === index ? "→" : " ";
 			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
 			lines.push("");
 			lines.push(`${cursor} ${this.options.theme.fg("accent", header)}`);

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -402,6 +402,13 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	private movePage(delta: number): void {
 		const pageCount = this.options.questions.length + 1;
 		this.page = (this.page + delta + pageCount) % pageCount;
+		const answer = this.answers[this.page];
+		const question = this.options.questions[this.page];
+		if (answer?.wasCustom && question) {
+			this.selectedOptions[this.page] = question.options.length;
+		} else if (answer?.optionIndex !== undefined) {
+			this.selectedOptions[this.page] = answer.optionIndex - 1;
+		}
 		this.message = undefined;
 	}
 
@@ -440,8 +447,8 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		lines.push("");
 		question.options.forEach((option, index) => {
 			const cursor = this.selectedOptions[this.page] === index ? "›" : " ";
-			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? "●" : "○";
-			const label = `${cursor} ${chosen} ${sanitizeTerminalText(option.label)}`;
+			const chosen = this.answers[this.page]?.optionIndex === index + 1 ? " ✓" : "";
+			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}${chosen}`;
 			lines.push(...hardWrap(this.options.theme.fg("text", label), width));
 			if (option.description) {
 				lines.push(
@@ -454,8 +461,8 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		});
 		const otherIndex = question.options.length;
 		const otherCursor = this.selectedOptions[this.page] === otherIndex ? "›" : " ";
-		const otherChosen = this.answers[this.page]?.wasCustom ? "●" : "○";
-		lines.push(`${otherCursor} ${otherChosen} Other (free-form)`);
+		const otherChosen = this.answers[this.page]?.wasCustom ? " ✓" : "";
+		lines.push(`${otherCursor} ${otherIndex + 1}. Other (free-form)${otherChosen}`);
 		const answer = this.answers[this.page];
 		if (answer?.wasCustom)
 			lines.push(...labeledRaw("Answer", answer.answer, width, this.options.theme));

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -674,6 +674,10 @@ class RawPreservingEditor implements Focusable {
 			this.flushPasteBuffer();
 			return;
 		}
+		if (matchesKey(data, Key.backspace)) {
+			this.editor.handleInput(data);
+			return;
+		}
 		const pasteStart = data.indexOf(BRACKETED_PASTE_START);
 		if (pasteStart >= 0) {
 			if (pasteStart > 0) this.editor.handleInput(data.slice(0, pasteStart));

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -16,6 +16,9 @@ import {
 export const PLAN_MODE_QUESTION_TOOL_NAME = "plan_mode_question";
 export const MAX_PLAN_MODE_RESPONSE_LENGTH = 4_000;
 
+const BRACKETED_PASTE_START = "\u001b[200~";
+const BRACKETED_PASTE_END = "\u001b[201~";
+
 export type PlanModeQuestionOption = {
 	label: string;
 	description?: string;
@@ -275,7 +278,7 @@ interface QuestionnaireOptions {
 
 export class PlanModeQuestionnaire implements Component, Focusable {
 	private readonly options: QuestionnaireOptions;
-	private readonly editor: Editor;
+	private readonly editor: RawPreservingEditor;
 	private readonly answers: Array<PlanModeQuestionAnswer | undefined>;
 	private readonly selectedOptions: number[];
 	private page = 0;
@@ -300,7 +303,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 				noMatch: (text) => options.theme.fg("warning", text),
 			},
 		};
-		this.editor = new Editor(options.tui, editorTheme, { paddingX: 0 });
+		this.editor = new RawPreservingEditor(options.tui, editorTheme);
 		this.editor.onChange = () => {
 			this.message = undefined;
 		};
@@ -324,7 +327,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const lines = [this.renderTabs(safeWidth), ""];
+		const lines = [...this.renderTabs(safeWidth), ""];
 		if (this.page === this.options.questions.length) lines.push(...this.renderReview(safeWidth));
 		else lines.push(...this.renderQuestion(safeWidth));
 		if (this.message)
@@ -402,7 +405,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		this.message = undefined;
 	}
 
-	private renderTabs(width: number): string {
+	private renderTabs(width: number): string[] {
 		const tabs = [
 			...this.options.questions.map((question, index) => {
 				const label = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
@@ -411,7 +414,20 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			}),
 			this.page === this.options.questions.length ? "[Review]" : "Review",
 		];
-		return truncateToWidth(this.options.theme.fg("accent", tabs.join("  ")), width, "…");
+		const lines: string[] = [];
+		let line = "";
+		for (const tab of tabs) {
+			const boundedTab = truncateToWidth(tab, width, "…");
+			const candidate = line ? `${line}  ${boundedTab}` : boundedTab;
+			if (line && visibleWidth(candidate) > width) {
+				lines.push(this.options.theme.fg("accent", line));
+				line = boundedTab;
+			} else {
+				line = candidate;
+			}
+		}
+		if (line) lines.push(this.options.theme.fg("accent", line));
+		return lines;
 	}
 
 	private renderQuestion(width: number): string[] {
@@ -576,7 +592,11 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			}
 			const question = this.options.questions[index];
 			if (!question) return;
-			this.answers[index] = answerFor(question, value, { wasCustom: true });
+			const previous = this.answers[index];
+			this.answers[index] = answerFor(question, value, {
+				wasCustom: true,
+				note: previous?.wasCustom ? previous.note : undefined,
+			});
 			this.editor.setText("");
 			this.editorKind = undefined;
 			this.editor.focused = false;
@@ -605,6 +625,148 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		this.editor.focused = false;
 		this.options.onDone(answers);
 	}
+}
+
+class RawPreservingEditor implements Focusable {
+	private readonly editor: Editor;
+	private readonly rawByMarker = new Map<string, string>();
+	private markerCodePoint = 0xe000;
+	private pasteBuffer: string | undefined;
+
+	constructor(tui: TUI, theme: EditorTheme) {
+		this.editor = new Editor(tui, theme, { paddingX: 0 });
+	}
+
+	get focused(): boolean {
+		return this.editor.focused;
+	}
+
+	set focused(value: boolean) {
+		this.editor.focused = value;
+	}
+
+	set onChange(handler: ((value: string) => void) | undefined) {
+		this.editor.onChange = handler ? () => handler(this.getExpandedText()) : undefined;
+	}
+
+	set onSubmit(handler: ((value: string) => void) | undefined) {
+		this.editor.onSubmit = handler ? (value) => handler(this.decode(value)) : undefined;
+	}
+
+	handleInput(data: string): void {
+		if (this.pasteBuffer !== undefined) {
+			this.pasteBuffer += data;
+			this.flushPasteBuffer();
+			return;
+		}
+		const pasteStart = data.indexOf(BRACKETED_PASTE_START);
+		if (pasteStart >= 0) {
+			if (pasteStart > 0) this.editor.handleInput(data.slice(0, pasteStart));
+			this.pasteBuffer = data.slice(pasteStart + BRACKETED_PASTE_START.length);
+			this.flushPasteBuffer();
+			return;
+		}
+		if (
+			[...data].some(
+				(character) => isUnsafeDirectEditorCharacter(character) || this.rawByMarker.has(character),
+			)
+		) {
+			this.editor.handleInput(this.encode(data));
+			return;
+		}
+		this.editor.handleInput(data);
+	}
+
+	render(width: number): string[] {
+		return this.editor
+			.render(width)
+			.map((line) =>
+				[...line].map((character) => (this.rawByMarker.has(character) ? " " : character)).join(""),
+			);
+	}
+
+	invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	setText(value: string): void {
+		this.rawByMarker.clear();
+		this.markerCodePoint = 0xe000;
+		this.pasteBuffer = undefined;
+		this.editor.setText(this.encode(value));
+	}
+
+	getExpandedText(): string {
+		return this.decode(this.editor.getExpandedText());
+	}
+
+	private flushPasteBuffer(): void {
+		if (this.pasteBuffer === undefined) return;
+		const pasteEnd = this.pasteBuffer.indexOf(BRACKETED_PASTE_END);
+		if (pasteEnd < 0) return;
+		const raw = this.pasteBuffer.slice(0, pasteEnd);
+		const remaining = this.pasteBuffer.slice(pasteEnd + BRACKETED_PASTE_END.length);
+		this.pasteBuffer = undefined;
+		this.editor.handleInput(`${BRACKETED_PASTE_START}${this.encode(raw)}${BRACKETED_PASTE_END}`);
+		if (remaining) this.handleInput(remaining);
+	}
+
+	private encode(value: string): string {
+		const forbidden = new Set([
+			...value,
+			...this.editor.getExpandedText(),
+			...this.rawByMarker.keys(),
+		]);
+		return [...value]
+			.map((character) => {
+				if (!isUnsafeEditorCharacter(character) && !this.rawByMarker.has(character)) {
+					return character;
+				}
+				const marker = this.nextMarker(forbidden);
+				this.rawByMarker.set(marker, character);
+				forbidden.add(marker);
+				return marker;
+			})
+			.join("");
+	}
+
+	private decode(value: string): string {
+		return [...value].map((character) => this.rawByMarker.get(character) ?? character).join("");
+	}
+
+	private nextMarker(forbidden: ReadonlySet<string>): string {
+		for (;;) {
+			if (this.markerCodePoint === 0xf900) this.markerCodePoint = 0xf0000;
+			if (this.markerCodePoint === 0xffffe) this.markerCodePoint = 0x100000;
+			if (this.markerCodePoint > 0x10fffd) {
+				throw new Error("Plan-mode editor exhausted its safe input markers.");
+			}
+			const marker = String.fromCodePoint(this.markerCodePoint++);
+			if (!forbidden.has(marker)) return marker;
+		}
+	}
+}
+
+function isUnsafeDirectEditorCharacter(character: string): boolean {
+	const codePoint = character.codePointAt(0) ?? 0;
+	return (
+		(codePoint >= 0x7f && codePoint <= 0x9f) ||
+		codePoint === 0x2028 ||
+		codePoint === 0x2029 ||
+		isBidiControl(codePoint)
+	);
+}
+
+function isUnsafeEditorCharacter(character: string): boolean {
+	const codePoint = character.codePointAt(0) ?? 0;
+	return (
+		character !== "\n" &&
+		(codePoint <= 0x1f ||
+			(codePoint >= 0x7f && codePoint <= 0x9f) ||
+			codePoint === 0x2028 ||
+			codePoint === 0x2029 ||
+			isBidiControl(codePoint))
+	);
 }
 
 function answerFor(

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -122,8 +122,14 @@ test("TUI applies legacy selector emphasis to borders, title, and selected optio
 	await tui.waitForOpen();
 	tui.render();
 	assert.ok(foreground.some(({ color, text }) => color === "border" && text === "─".repeat(60)));
-	assert.ok(foreground.some(({ color, text }) => color === "accent" && /→ 1\. Small/u.test(text)));
-	assert.ok(foreground.some(({ color, text }) => color === "accent" && text === "Only the bug."));
+	assert.ok(
+		foreground.some(
+			({ color, text }) => color === "accent" && text === "→ 1. Small — Only the bug.",
+		),
+	);
+	assert.ok(
+		foreground.some(({ color, text }) => color === "muted" && text === " — Include cleanup."),
+	);
 	assert.ok(bold.includes("How broad?"));
 	tui.dispose();
 	assert.equal(await running, undefined);
@@ -134,7 +140,7 @@ test("TUI uses numbered select styling and restores the recorded answer cursor",
 	await tui.waitForOpen();
 	tui.setFocused(true);
 	let frame = tui.render().join("\n");
-	assert.match(frame, /→ 1\. Small/u);
+	assert.match(frame, /→ 1\. Small — Only the bug\./u);
 	assert.doesNotMatch(frame, /[○●]/u);
 	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -135,6 +135,41 @@ test("TUI applies legacy selector emphasis to borders, title, and selected optio
 	assert.equal(await running, undefined);
 });
 
+test("Review uses the same numbered selector emphasis as question options", async () => {
+	const foreground: Array<{ color: string; text: string }> = [];
+	const bold: string[] = [];
+	const tui = createTuiHarness({
+		width: 60,
+		rows: 30,
+		theme: {
+			fg: (color, text) => {
+				foreground.push({ color: String(color), text });
+				return text;
+			},
+			bold: (text) => {
+				bold.push(text);
+				return text;
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions(questions, context.ctx);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.send("\u001b[C");
+	tui.send("\u001b[C");
+	const frame = tui.render().join("\n");
+	assert.match(frame, /\n → 1\. Scope — Unanswered\n {3}2\. Tests — Unanswered/u);
+	assert.ok(
+		foreground.some(({ color, text }) => color === "accent" && text === "→ 1. Scope — Unanswered"),
+	);
+	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "  2. Tests"));
+	assert.ok(foreground.some(({ color, text }) => color === "muted" && text === " — Unanswered"));
+	assert.ok(bold.includes("Review answers"));
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
 test("TUI uses numbered select styling and restores the recorded answer cursor", async () => {
 	const { tui, running } = tuiRun([questions[0]]);
 	await tui.waitForOpen();
@@ -192,6 +227,7 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	tui.type("n");
 	paste(tui, "final note");
 	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /→ 1\. Scope — Broad · Note: final note/u);
 	tui.press("tui.select.confirm");
 
 	assert.deepEqual(await running, [

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -161,6 +161,99 @@ test("Review blocks incomplete submission and lets selected answer receive a not
 	assert.equal(await running, undefined);
 });
 
+test("TUI preserves raw custom answers and notes while sanitizing editor rendering", async () => {
+	const unsafeAnswer = "raw\u001b]8;;https://evil.example\u0007text\u202ereversed";
+	const unsafeNote = "note\u009bcontrol\u202aspoofed";
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	paste(tui, unsafeAnswer);
+	const answerDraft = tui.render().join("\n");
+	assert.equal(answerDraft.includes("\u202e"), false);
+	assert.equal(answerDraft.includes("\u001b]8;;https://evil.example"), false);
+	tui.press("tui.input.submit");
+	tui.type("n");
+	paste(tui, unsafeNote);
+	const noteDraft = tui.render().join("\n");
+	assert.equal(noteDraft.includes("\u009b"), false);
+	assert.equal(noteDraft.includes("\u202a"), false);
+	tui.press("tui.input.submit");
+	const review = tui.render().join("\n");
+	assert.equal(review.includes("\u202e") || review.includes("\u202a"), false);
+	tui.press("tui.select.confirm");
+
+	assert.deepEqual(await running, [
+		{
+			id: "scope",
+			header: "Scope",
+			question: "How broad?",
+			answer: unsafeAnswer,
+			wasCustom: true,
+			note: unsafeNote,
+		},
+	]);
+});
+
+test("editing an existing Other answer preserves its note", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	paste(tui, "first answer");
+	tui.press("tui.input.submit");
+	tui.type("n");
+	paste(tui, "keep this note");
+	tui.press("tui.input.submit");
+	tui.send("\u001b[D");
+	tui.press("tui.select.confirm");
+	tui.send("\u0015");
+	paste(tui, "edited answer");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+
+	assert.equal((await running)?.[0]?.note, "keep this note");
+});
+
+test("narrow TUI rendering keeps every question and Review tab visible", async () => {
+	const longQuestions = [
+		{ ...questions[0], header: "LongHeader12" },
+		{ ...questions[1], header: "SecondHeader" },
+		{ ...questions[0], id: "risk", header: "ThirdHeader3" },
+	];
+	const { tui, running } = tuiRun(longQuestions, 24);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	for (let index = 0; index < longQuestions.length; index += 1) tui.send("\u001b[C");
+	const frame = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(frame, /LongHeader12/u);
+	assert.match(frame, /SecondHeader/u);
+	assert.match(frame, /ThirdHeader3/u);
+	assert.match(frame, /\[Review\]/u);
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
+test("TUI abort signal closes the questionnaire without answers", async () => {
+	const controller = new AbortController();
+	const tui = createTuiHarness({ width: 60, rows: 30 });
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+		signal: controller.signal,
+	});
+	const running = askPlanModeQuestions(questions, context.ctx);
+	await tui.waitForOpen();
+	controller.abort();
+	assert.equal(await running, undefined);
+	assert.equal(tui.isOpen, false);
+});
+
 test("Other editor rejects oversized input and forwards focus", async () => {
 	const { tui, running } = tuiRun([questions[0]]);
 	await tui.waitForOpen();
@@ -173,6 +266,21 @@ test("Other editor rejects oversized input and forwards focus", async () => {
 	paste(tui, "x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1));
 	tui.press("tui.input.submit");
 	assert.match(tui.render().join("\n"), /4,000 characters or fewer/u);
+	assert.equal(tui.isOpen, true);
+	tui.press("ctrl+c");
+	assert.equal(await running, undefined);
+});
+
+test("Note editor rejects oversized input and stays open", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("n");
+	const oversized = "z".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1);
+	paste(tui, oversized);
+	tui.press("tui.input.submit");
+	const frame = tui.render().join("\n");
+	assert.match(frame, /Note must be 4,000 characters or fewer/u);
 	assert.equal(tui.isOpen, true);
 	tui.press("ctrl+c");
 	assert.equal(await running, undefined);

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -135,7 +135,7 @@ test("TUI applies legacy selector emphasis to borders, title, and selected optio
 	assert.equal(await running, undefined);
 });
 
-test("Review uses the same numbered selector emphasis as question options", async () => {
+test("Review renders plain summaries without selection affordances", async () => {
 	const foreground: Array<{ color: string; text: string }> = [];
 	const bold: string[] = [];
 	const tui = createTuiHarness({
@@ -158,14 +158,26 @@ test("Review uses the same numbered selector emphasis as question options", asyn
 	tui.setFocused(true);
 	tui.send("\u001b[C");
 	tui.send("\u001b[C");
+	foreground.length = 0;
+	bold.length = 0;
 	const frame = tui.render().join("\n");
-	assert.match(frame, /\n → 1\. Scope — Unanswered\n {3}2\. Tests — Unanswered/u);
-	assert.ok(
-		foreground.some(({ color, text }) => color === "accent" && text === "→ 1. Scope — Unanswered"),
-	);
-	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "  2. Tests"));
+	assert.match(frame, /\n 1\. Scope — Unanswered\n 2\. Tests — Unanswered/u);
+	assert.doesNotMatch(frame, /→ [12]\./u);
+	assert.match(frame, /Enter submit/u);
+	assert.doesNotMatch(frame, /↑\/↓ select|n note/u);
+	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "1. Scope"));
+	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "2. Tests"));
 	assert.ok(foreground.some(({ color, text }) => color === "muted" && text === " — Unanswered"));
+	assert.equal(
+		foreground.some(
+			({ color, text }) => color === "accent" && /(?:→ )?[12]\. (?:Scope|Tests)/u.test(text),
+		),
+		false,
+	);
 	assert.ok(bold.includes("Review answers"));
+	const unchanged = tui.render().join("\n");
+	tui.press("tui.select.down");
+	assert.equal(tui.render().join("\n"), unchanged);
 	tui.dispose();
 	assert.equal(await running, undefined);
 });
@@ -216,7 +228,9 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	tui.press("tui.input.submit");
 	assert.match(tui.render().join("\n"), /Review answers[\s\S]*Broad[\s\S]*custom answer/u);
 
-	// Review selects answers for note add/edit/clear.
+	// Notes remain editable from their question page, not from the plain Review summary.
+	tui.send("\u001b[D");
+	tui.send("\u001b[D");
 	tui.type("n");
 	paste(tui, "draft note");
 	tui.press("tui.input.submit");
@@ -227,7 +241,9 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	tui.type("n");
 	paste(tui, "final note");
 	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /→ 1\. Scope — Broad · Note: final note/u);
+	tui.send("\u001b[C");
+	tui.send("\u001b[C");
+	assert.match(tui.render().join("\n"), /1\. Scope — Broad · Note: final note/u);
 	tui.press("tui.select.confirm");
 
 	assert.deepEqual(await running, [
@@ -250,7 +266,7 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	]);
 });
 
-test("Review blocks incomplete submission and lets selected answer receive a note", async () => {
+test("Review blocks incomplete submission and directs note edits back to questions", async () => {
 	const { tui, running } = tuiRun();
 	await tui.waitForOpen();
 	tui.setFocused(true);
@@ -259,8 +275,9 @@ test("Review blocks incomplete submission and lets selected answer receive a not
 	tui.press("tui.select.confirm");
 	assert.match(tui.render().join("\n"), /Answer every question before submitting/u);
 	tui.press("tui.select.down");
+	assert.doesNotMatch(tui.render().join("\n"), /→ [12]\./u);
 	tui.type("n");
-	assert.match(tui.render().join("\n"), /Select an answer before adding a note/u);
+	assert.match(tui.render().join("\n"), /Return to a question to add or edit its note/u);
 	tui.press("tui.select.cancel");
 	assert.equal(await running, undefined);
 });
@@ -279,12 +296,14 @@ test("TUI preserves raw custom answers and notes while sanitizing editor renderi
 	assert.equal(answerDraft.includes("\u202e"), false);
 	assert.equal(answerDraft.includes("\u001b]8;;https://evil.example"), false);
 	tui.press("tui.input.submit");
+	tui.send("\u001b[D");
 	tui.type("n");
 	paste(tui, unsafeNote);
 	const noteDraft = tui.render().join("\n");
 	assert.equal(noteDraft.includes("\u009b"), false);
 	assert.equal(noteDraft.includes("\u202a"), false);
 	tui.press("tui.input.submit");
+	tui.send("\u001b[C");
 	const review = tui.render().join("\n");
 	assert.equal(review.includes("\u202e") || review.includes("\u202a"), false);
 	tui.press("tui.select.confirm");
@@ -310,10 +329,10 @@ test("editing an existing Other answer preserves its note", async () => {
 	tui.press("tui.select.confirm");
 	paste(tui, "first answer");
 	tui.press("tui.input.submit");
+	tui.send("\u001b[D");
 	tui.type("n");
 	paste(tui, "keep this note");
 	tui.press("tui.input.submit");
-	tui.send("\u001b[D");
 	tui.press("tui.select.confirm");
 	tui.send("\u0015");
 	paste(tui, "edited answer");

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -87,6 +87,26 @@ test("TUI previews future questions and navigates back before answering", async 
 	assert.equal(await running, undefined);
 });
 
+test("TUI uses numbered select styling and restores the recorded answer cursor", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	let frame = tui.render().join("\n");
+	assert.match(frame, /› 1\. Small/u);
+	assert.doesNotMatch(frame, /[○●]/u);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.send("\u001b[D");
+	frame = tui.render().join("\n");
+	assert.match(frame, /› 2\. Broad ✓/u);
+	tui.press("tui.select.up");
+	tui.send("\u001b[C");
+	tui.send("\u001b[D");
+	assert.match(tui.render().join("\n"), /› 2\. Broad ✓/u);
+	tui.press("tui.select.cancel");
+	assert.equal(await running, undefined);
+});
+
 test("TUI replaces answers, manages notes, accepts Other, and submits ordered raw payload", async () => {
 	const { tui, running } = tuiRun();
 	await tui.waitForOpen();

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -87,6 +87,16 @@ test("TUI previews future questions and navigates back before answering", async 
 	assert.equal(await running, undefined);
 });
 
+test("TUI frames the questionnaire with select-style separator borders", async () => {
+	const { tui, running } = tuiRun([questions[0]], 40);
+	await tui.waitForOpen();
+	const frame = tui.render();
+	assert.equal(frame[0], "─".repeat(40));
+	assert.equal(frame.at(-1), "─".repeat(40));
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
 test("TUI uses numbered select styling and restores the recorded answer cursor", async () => {
 	const { tui, running } = tuiRun([questions[0]]);
 	await tui.waitForOpen();

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -283,7 +283,7 @@ test("Review blocks incomplete submission and directs note edits back to questio
 });
 
 test("TUI preserves raw custom answers and notes while sanitizing editor rendering", async () => {
-	const unsafeAnswer = "raw\u001b]8;;https://evil.example\u0007text\u202ereversed";
+	const unsafeAnswer = "raw\u007f\u001b]8;;https://evil.example\u0007text\u202ereversed";
 	const unsafeNote = "note\u009bcontrol\u202aspoofed";
 	const { tui, running } = tuiRun([questions[0]]);
 	await tui.waitForOpen();
@@ -375,6 +375,35 @@ test("TUI abort signal closes the questionnaire without answers", async () => {
 	controller.abort();
 	assert.equal(await running, undefined);
 	assert.equal(tui.isOpen, false);
+});
+
+test("Other editor treats Backspace as deletion instead of raw text", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.type("wrongx");
+	tui.send("\u007f");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+
+	assert.equal((await running)?.[0]?.answer, "wrong");
+});
+
+test("Optional note editor treats Backspace as deletion instead of raw text", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("n");
+	tui.type("note!");
+	tui.send("\u007f");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+	tui.press("tui.select.confirm");
+
+	assert.equal((await running)?.[0]?.note, "note");
 });
 
 test("Other editor rejects oversized input and forwards focus", async () => {

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -92,7 +92,39 @@ test("TUI frames the questionnaire with select-style separator borders", async (
 	await tui.waitForOpen();
 	const frame = tui.render();
 	assert.equal(frame[0], "─".repeat(40));
+	assert.equal(frame[1], "");
+	assert.equal(frame.at(-2), "");
 	assert.equal(frame.at(-1), "─".repeat(40));
+	assert.match(frame.join("\n"), /^ How broad\?$/mu);
+	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
+test("TUI applies legacy selector emphasis to borders, title, and selected option", async () => {
+	const foreground: Array<{ color: string; text: string }> = [];
+	const bold: string[] = [];
+	const tui = createTuiHarness({
+		width: 60,
+		rows: 30,
+		theme: {
+			fg: (color, text) => {
+				foreground.push({ color: String(color), text });
+				return text;
+			},
+			bold: (text) => {
+				bold.push(text);
+				return text;
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions([questions[0]], context.ctx);
+	await tui.waitForOpen();
+	tui.render();
+	assert.ok(foreground.some(({ color, text }) => color === "border" && text === "─".repeat(60)));
+	assert.ok(foreground.some(({ color, text }) => color === "accent" && /→ 1\. Small/u.test(text)));
+	assert.ok(foreground.some(({ color, text }) => color === "accent" && text === "Only the bug."));
+	assert.ok(bold.includes("How broad?"));
 	tui.dispose();
 	assert.equal(await running, undefined);
 });
@@ -102,17 +134,17 @@ test("TUI uses numbered select styling and restores the recorded answer cursor",
 	await tui.waitForOpen();
 	tui.setFocused(true);
 	let frame = tui.render().join("\n");
-	assert.match(frame, /› 1\. Small/u);
+	assert.match(frame, /→ 1\. Small/u);
 	assert.doesNotMatch(frame, /[○●]/u);
 	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
 	tui.send("\u001b[D");
 	frame = tui.render().join("\n");
-	assert.match(frame, /› 2\. Broad ✓/u);
+	assert.match(frame, /→ 2\. Broad ✓/u);
 	tui.press("tui.select.up");
 	tui.send("\u001b[C");
 	tui.send("\u001b[D");
-	assert.match(tui.render().join("\n"), /› 2\. Broad ✓/u);
+	assert.match(tui.render().join("\n"), /→ 2\. Broad ✓/u);
 	tui.press("tui.select.cancel");
 	assert.equal(await running, undefined);
 });


### PR DESCRIPTION
## Summary

- replace sequential TUI Plan questions with tabbed navigation and final review in `pi-plan-mode` and `pi-workflow`
- match Pi's numbered select style on question pages with inline muted descriptions, hanging wraps, border spacing, padding, accent emphasis, and bold titles
- mark recorded answers with `✓`, restore their cursor when revisiting a question, and present Review as a read-only text summary without selection affordances
- support answer replacement, free-form answers, optional notes from question pages, and incomplete-review blocking
- preserve raw custom answers and notes while sanitizing every terminal rendering path, without intercepting Backspace editing
- keep all tabs visible on narrow terminals and retain notes when editing the same custom answer
- preserve the existing sequential RPC fallback and lifecycle cancellation behavior

Closes #871.

## Verification

- `npm run check`
- `PI_EXTENSIONS_BUILD_READY=1 npm test` (395 files, 3,728 tests)
- focused questionnaire tests (2 files, 38 tests)
- `just pack plan-mode`
- `just pack workflow`

## Notes

This branch includes the original #872 implementation and addresses the review findings found against it.
One full-suite run hit an unrelated `pi-subagents` semantic-resource race; its isolated rerun and the complete rerun both passed.
A live interactive Pi smoke was not repeated for this follow-up; deterministic TUI harness coverage exercises navigation, select styling, read-only review behavior, raw input handling, notes, narrow rendering, cancellation, and disposal.

