### PR TITLE
fix(plan): honor configured questionnaire keys

### DIFF
--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -1,5 +1,5 @@
 import { stripVTControlCharacters } from "node:util";
-import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import {
 	type Component,
 	Editor,
@@ -207,11 +207,12 @@ export async function askPlanModeQuestions(
 ): Promise<PlanModeQuestionAnswer[] | undefined> {
 	if (ctx.mode === "tui") {
 		const answers = await ctx.ui.custom<PlanModeQuestionAnswer[] | undefined>(
-			(tui, theme, _keybindings, done) =>
+			(tui, theme, keybindings, done) =>
 				new PlanModeQuestionnaire({
 					questions,
 					tui,
 					theme,
+					keybindings,
 					shouldContinue,
 					signal: ctx.signal,
 					onDone: done,
@@ -271,6 +272,7 @@ interface QuestionnaireOptions {
 	questions: PlanModeQuestion[];
 	tui: TUI;
 	theme: Theme;
+	keybindings: KeybindingsManager;
 	shouldContinue(): boolean;
 	signal?: AbortSignal;
 	onDone(answers: PlanModeQuestionAnswer[] | undefined): void;
@@ -335,21 +337,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		if (this.message)
 			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), contentWidth));
 		lines.push("");
-		lines.push(
-			truncateToWidth(
-				this.options.theme.fg(
-					"dim",
-					this.editorKind
-						? "Enter save · Esc/Ctrl+C cancel questionnaire"
-						: this.page === this.options.questions.length
-							? "Tab/Shift+Tab or ←/→ navigate · Enter submit · Esc cancel"
-							: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer · n note · Esc cancel",
-				),
-				contentWidth,
-			),
-			"",
-			border,
-		);
+		lines.push(truncateToWidth(this.renderHints(), contentWidth), "", border);
 		return lines.map((line) => {
 			if (!line || line === border) return line;
 			return `${padding}${truncateToWidth(line, contentWidth)}`;
@@ -376,16 +364,36 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	}
 
 	private isCancel(data: string): boolean {
-		return matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"));
+		return this.options.keybindings.matches(data, "tui.select.cancel");
 	}
 
 	private handleEditorInput(data: string): void {
-		if (matchesKey(data, Key.enter)) this.submitEditor(this.editor.getExpandedText());
-		else this.editor.handleInput(data);
+		const keybindings = this.options.keybindings;
+		if (keybindings.matches(data, "tui.input.newLine")) {
+			this.editor.handleInput(data);
+		} else if (keybindings.matches(data, "tui.input.submit")) {
+			this.submitEditor(this.editor.getExpandedText());
+		} else {
+			this.editor.handleInput(data);
+		}
 	}
 
 	private handlePageInput(data: string): void {
-		if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
+		const keybindings = this.options.keybindings;
+		const review = this.page === this.options.questions.length;
+		if (keybindings.matches(data, "tui.select.up") || data === "k") {
+			if (!review) this.moveSelection(-1);
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.down") || data === "j") {
+			if (!review) this.moveSelection(1);
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.confirm") || data === "\n") {
+			this.submitPage();
+			return;
+		}
+		if (keybindings.matches(data, "tui.input.tab") || matchesKey(data, Key.right)) {
 			this.movePage(1);
 			return;
 		}
@@ -393,21 +401,37 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			this.movePage(-1);
 			return;
 		}
-		const review = this.page === this.options.questions.length;
-		if (matchesKey(data, Key.up)) {
-			if (!review) this.moveSelection(-1);
-			return;
-		}
-		if (matchesKey(data, Key.down)) {
-			if (!review) this.moveSelection(1);
-			return;
-		}
 		if (data.toLowerCase() === "n") {
 			if (review) this.message = "Return to a question to add or edit its note.";
 			else this.editNote();
-			return;
 		}
-		if (matchesKey(data, Key.enter)) this.submitPage();
+	}
+
+	private renderHints(): string {
+		const { keybindings, theme } = this.options;
+		const cancel = keybindingHint(theme, keybindings, "tui.select.cancel", "cancel");
+		if (this.editorKind) {
+			return [
+				keybindingHint(theme, keybindings, "tui.input.submit", "save"),
+				keybindingHint(theme, keybindings, "tui.input.newLine", "newline"),
+				cancel,
+			].join("  ");
+		}
+		const questions = rawKeyHint(theme, questionNavigationKeys(keybindings), "questions");
+		if (this.page === this.options.questions.length) {
+			return [
+				keybindingHint(theme, keybindings, "tui.select.confirm", "submit"),
+				cancel,
+				questions,
+			].join("  ");
+		}
+		return [
+			rawKeyHint(theme, selectionNavigationKeys(keybindings), "navigate"),
+			keybindingHint(theme, keybindings, "tui.select.confirm", "select"),
+			cancel,
+			questions,
+			rawKeyHint(theme, "n", "note"),
+		].join("  ");
 	}
 
 	private movePage(delta: number): void {
@@ -869,6 +893,51 @@ function isBidiControl(codePoint: number): boolean {
 		(codePoint >= 0x202a && codePoint <= 0x202e) ||
 		(codePoint >= 0x2066 && codePoint <= 0x2069)
 	);
+}
+
+type QuestionnaireKeybinding = Parameters<KeybindingsManager["getKeys"]>[0];
+
+function keybindingHint(
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	keybinding: QuestionnaireKeybinding,
+	description: string,
+): string {
+	return rawKeyHint(theme, formatHintKeys(keybindings.getKeys(keybinding)), description);
+}
+
+function rawKeyHint(theme: Theme, keys: string, description: string): string {
+	return `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}`;
+}
+
+function selectionNavigationKeys(keybindings: KeybindingsManager): string {
+	const up = keybindings.getKeys("tui.select.up");
+	const down = keybindings.getKeys("tui.select.down");
+	if (up.includes("up") && down.includes("down")) {
+		return formatHintKeys([
+			"↑↓",
+			...up.filter((key) => key !== "up"),
+			...down.filter((key) => key !== "down"),
+		]);
+	}
+	return formatHintKeys([...up, ...down]);
+}
+
+function questionNavigationKeys(keybindings: KeybindingsManager): string {
+	return formatHintKeys([...keybindings.getKeys("tui.input.tab"), "shift+tab", "←→"]);
+}
+
+function formatHintKeys(keys: readonly string[]): string {
+	return [...new Set(keys)].map(formatHintKey).join("/");
+}
+
+function formatHintKey(key: string): string {
+	return key
+		.split("+")
+		.map((part) =>
+			process.platform === "darwin" && part.toLowerCase() === "alt" ? "option" : part,
+		)
+		.join("+");
 }
 
 function inlineSummary(value: string): string {

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -364,7 +364,9 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	}
 
 	private isCancel(data: string): boolean {
-		return this.options.keybindings.matches(data, "tui.select.cancel");
+		return (
+			matchesKey(data, Key.ctrl("c")) || this.options.keybindings.matches(data, "tui.select.cancel")
+		);
 	}
 
 	private handleEditorInput(data: string): void {
@@ -389,7 +391,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			if (!review) this.moveSelection(1);
 			return;
 		}
-		if (keybindings.matches(data, "tui.select.confirm") || data === "\n") {
+		if (keybindings.matches(data, "tui.select.confirm")) {
 			this.submitPage();
 			return;
 		}
@@ -409,7 +411,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 
 	private renderHints(): string {
 		const { keybindings, theme } = this.options;
-		const cancel = keybindingHint(theme, keybindings, "tui.select.cancel", "cancel");
+		const cancel = cancelHint(theme, keybindings);
 		if (this.editorKind) {
 			return [
 				keybindingHint(theme, keybindings, "tui.input.submit", "save"),
@@ -908,6 +910,14 @@ function keybindingHint(
 
 function rawKeyHint(theme: Theme, keys: string, description: string): string {
 	return `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}`;
+}
+
+function cancelHint(theme: Theme, keybindings: KeybindingsManager): string {
+	return rawKeyHint(
+		theme,
+		formatHintKeys([...keybindings.getKeys("tui.select.cancel"), "ctrl+c"]),
+		"cancel",
+	);
 }
 
 function selectionNavigationKeys(keybindings: KeybindingsManager): string {

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { stripVTControlCharacters } from "node:util";
-import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	CURSOR_MARKER,
+	KeybindingsManager,
+	TUI_KEYBINDINGS,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
@@ -35,7 +40,11 @@ const questions: PlanModeQuestion[] = [
 ];
 
 function tuiRun(customQuestions = questions, width = 60) {
-	const tui = createTuiHarness({ width, rows: 30 });
+	const tui = createTuiHarness({
+		width,
+		rows: 30,
+		keybindings: new KeybindingsManager(TUI_KEYBINDINGS),
+	});
 	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 	const running = askPlanModeQuestions(customQuestions, context.ctx);
 	return { tui, running };
@@ -131,6 +140,7 @@ test("TUI applies legacy selector emphasis to borders, title, and selected optio
 		foreground.some(({ color, text }) => color === "muted" && text === " — Include cleanup."),
 	);
 	assert.ok(bold.includes("How broad?"));
+	assert.match(tui.render().join("\n"), /↑↓ navigate {2}enter select {2}escape\/ctrl\+c cancel/u);
 	tui.dispose();
 	assert.equal(await running, undefined);
 });
@@ -163,7 +173,7 @@ test("Review renders plain summaries without selection affordances", async () =>
 	const frame = tui.render().join("\n");
 	assert.match(frame, /\n 1\. Scope — Unanswered\n 2\. Tests — Unanswered/u);
 	assert.doesNotMatch(frame, /→ [12]\./u);
-	assert.match(frame, /Enter submit/u);
+	assert.match(frame, /enter submit/u);
 	assert.doesNotMatch(frame, /↑\/↓ select|n note/u);
 	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "1. Scope"));
 	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "2. Tests"));
@@ -179,6 +189,50 @@ test("Review renders plain summaries without selection affordances", async () =>
 	tui.press("tui.select.down");
 	assert.equal(tui.render().join("\n"), unchanged);
 	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
+test("TUI uses configured selector keybindings and legacy j/k aliases", async () => {
+	const bindings = {
+		"tui.input.newLine": { data: "\u001b[13;3u", key: "alt+enter" },
+		"tui.input.submit": { data: "\u0013", key: "ctrl+s" },
+		"tui.input.tab": { data: "t", key: "t" },
+		"tui.select.cancel": { data: "q", key: "q" },
+		"tui.select.confirm": { data: "x", key: "x" },
+		"tui.select.down": { data: "s", key: "s" },
+		"tui.select.up": { data: "w", key: "w" },
+	} as const;
+	const tui = createTuiHarness({
+		width: 120,
+		rows: 30,
+		keybindings: {
+			matches: (data, binding) => bindings[binding as keyof typeof bindings]?.data === data,
+			getKeys: (binding) => {
+				const configured = bindings[binding as keyof typeof bindings];
+				return configured ? [configured.key] : [];
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions(questions, context.ctx);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	assert.match(
+		tui.render().join("\n"),
+		/w\/s navigate {2}x select {2}q cancel {2}t\/shift\+tab\/←→ questions {2}n note/u,
+	);
+	tui.send("j");
+	assert.match(tui.render().join("\n"), /→ 2\. Broad/u);
+	tui.send("k");
+	assert.match(tui.render().join("\n"), /→ 1\. Small/u);
+	tui.send("s");
+	tui.send("t");
+	assert.match(tui.render().join("\n"), /\[Tests\]/u);
+	tui.send("\u001b[D");
+	tui.send("x");
+	tui.send("x");
+	assert.match(tui.render().join("\n"), /x submit {2}q cancel/u);
+	tui.send("q");
 	assert.equal(await running, undefined);
 });
 

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -219,7 +219,7 @@ test("TUI uses configured selector keybindings and legacy j/k aliases", async ()
 	tui.setFocused(true);
 	assert.match(
 		tui.render().join("\n"),
-		/w\/s navigate {2}x select {2}q cancel {2}t\/shift\+tab\/←→ questions {2}n note/u,
+		/w\/s navigate {2}x select {2}q\/ctrl\+c cancel {2}t\/shift\+tab\/←→ questions {2}n note/u,
 	);
 	tui.send("j");
 	assert.match(tui.render().join("\n"), /→ 2\. Broad/u);
@@ -231,8 +231,27 @@ test("TUI uses configured selector keybindings and legacy j/k aliases", async ()
 	tui.send("\u001b[D");
 	tui.send("x");
 	tui.send("x");
-	assert.match(tui.render().join("\n"), /x submit {2}q cancel/u);
+	assert.match(tui.render().join("\n"), /x submit {2}q\/ctrl\+c cancel/u);
+	tui.send("\n");
+	assert.equal(tui.isOpen, true);
+	assert.match(tui.render().join("\n"), /\[Review\]/u);
 	tui.send("q");
+	assert.equal(await running, undefined);
+});
+
+test("TUI keeps Ctrl+C as a hard cancel when it is not configured", async () => {
+	const tui = createTuiHarness({
+		keybindings: {
+			matches: (data, binding) => binding === "tui.select.cancel" && data === "q",
+			getKeys: (binding) => (binding === "tui.select.cancel" ? ["q"] : []),
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions([questions[0]], context.ctx);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	assert.match(tui.render().join("\n"), /q\/ctrl\+c cancel/u);
+	tui.send("\u0003");
 	assert.equal(await running, undefined);
 });
 

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -1,5 +1,5 @@
 import { stripVTControlCharacters } from "node:util";
-import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import {
 	type Component,
 	Editor,
@@ -207,11 +207,12 @@ export async function askPlanModeQuestions(
 ): Promise<PlanModeQuestionAnswer[] | undefined> {
 	if (ctx.mode === "tui") {
 		const answers = await ctx.ui.custom<PlanModeQuestionAnswer[] | undefined>(
-			(tui, theme, _keybindings, done) =>
+			(tui, theme, keybindings, done) =>
 				new PlanModeQuestionnaire({
 					questions,
 					tui,
 					theme,
+					keybindings,
 					shouldContinue,
 					signal: ctx.signal,
 					onDone: done,
@@ -271,6 +272,7 @@ interface QuestionnaireOptions {
 	questions: PlanModeQuestion[];
 	tui: TUI;
 	theme: Theme;
+	keybindings: KeybindingsManager;
 	shouldContinue(): boolean;
 	signal?: AbortSignal;
 	onDone(answers: PlanModeQuestionAnswer[] | undefined): void;
@@ -335,21 +337,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 		if (this.message)
 			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), contentWidth));
 		lines.push("");
-		lines.push(
-			truncateToWidth(
-				this.options.theme.fg(
-					"dim",
-					this.editorKind
-						? "Enter save · Esc/Ctrl+C cancel questionnaire"
-						: this.page === this.options.questions.length
-							? "Tab/Shift+Tab or ←/→ navigate · Enter submit · Esc cancel"
-							: "Tab/Shift+Tab or ←/→ navigate · ↑/↓ select · Enter answer · n note · Esc cancel",
-				),
-				contentWidth,
-			),
-			"",
-			border,
-		);
+		lines.push(truncateToWidth(this.renderHints(), contentWidth), "", border);
 		return lines.map((line) => {
 			if (!line || line === border) return line;
 			return `${padding}${truncateToWidth(line, contentWidth)}`;
@@ -376,16 +364,36 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	}
 
 	private isCancel(data: string): boolean {
-		return matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"));
+		return this.options.keybindings.matches(data, "tui.select.cancel");
 	}
 
 	private handleEditorInput(data: string): void {
-		if (matchesKey(data, Key.enter)) this.submitEditor(this.editor.getExpandedText());
-		else this.editor.handleInput(data);
+		const keybindings = this.options.keybindings;
+		if (keybindings.matches(data, "tui.input.newLine")) {
+			this.editor.handleInput(data);
+		} else if (keybindings.matches(data, "tui.input.submit")) {
+			this.submitEditor(this.editor.getExpandedText());
+		} else {
+			this.editor.handleInput(data);
+		}
 	}
 
 	private handlePageInput(data: string): void {
-		if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
+		const keybindings = this.options.keybindings;
+		const review = this.page === this.options.questions.length;
+		if (keybindings.matches(data, "tui.select.up") || data === "k") {
+			if (!review) this.moveSelection(-1);
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.down") || data === "j") {
+			if (!review) this.moveSelection(1);
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.confirm") || data === "\n") {
+			this.submitPage();
+			return;
+		}
+		if (keybindings.matches(data, "tui.input.tab") || matchesKey(data, Key.right)) {
 			this.movePage(1);
 			return;
 		}
@@ -393,21 +401,37 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			this.movePage(-1);
 			return;
 		}
-		const review = this.page === this.options.questions.length;
-		if (matchesKey(data, Key.up)) {
-			if (!review) this.moveSelection(-1);
-			return;
-		}
-		if (matchesKey(data, Key.down)) {
-			if (!review) this.moveSelection(1);
-			return;
-		}
 		if (data.toLowerCase() === "n") {
 			if (review) this.message = "Return to a question to add or edit its note.";
 			else this.editNote();
-			return;
 		}
-		if (matchesKey(data, Key.enter)) this.submitPage();
+	}
+
+	private renderHints(): string {
+		const { keybindings, theme } = this.options;
+		const cancel = keybindingHint(theme, keybindings, "tui.select.cancel", "cancel");
+		if (this.editorKind) {
+			return [
+				keybindingHint(theme, keybindings, "tui.input.submit", "save"),
+				keybindingHint(theme, keybindings, "tui.input.newLine", "newline"),
+				cancel,
+			].join("  ");
+		}
+		const questions = rawKeyHint(theme, questionNavigationKeys(keybindings), "questions");
+		if (this.page === this.options.questions.length) {
+			return [
+				keybindingHint(theme, keybindings, "tui.select.confirm", "submit"),
+				cancel,
+				questions,
+			].join("  ");
+		}
+		return [
+			rawKeyHint(theme, selectionNavigationKeys(keybindings), "navigate"),
+			keybindingHint(theme, keybindings, "tui.select.confirm", "select"),
+			cancel,
+			questions,
+			rawKeyHint(theme, "n", "note"),
+		].join("  ");
 	}
 
 	private movePage(delta: number): void {
@@ -869,6 +893,51 @@ function isBidiControl(codePoint: number): boolean {
 		(codePoint >= 0x202a && codePoint <= 0x202e) ||
 		(codePoint >= 0x2066 && codePoint <= 0x2069)
 	);
+}
+
+type QuestionnaireKeybinding = Parameters<KeybindingsManager["getKeys"]>[0];
+
+function keybindingHint(
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	keybinding: QuestionnaireKeybinding,
+	description: string,
+): string {
+	return rawKeyHint(theme, formatHintKeys(keybindings.getKeys(keybinding)), description);
+}
+
+function rawKeyHint(theme: Theme, keys: string, description: string): string {
+	return `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}`;
+}
+
+function selectionNavigationKeys(keybindings: KeybindingsManager): string {
+	const up = keybindings.getKeys("tui.select.up");
+	const down = keybindings.getKeys("tui.select.down");
+	if (up.includes("up") && down.includes("down")) {
+		return formatHintKeys([
+			"↑↓",
+			...up.filter((key) => key !== "up"),
+			...down.filter((key) => key !== "down"),
+		]);
+	}
+	return formatHintKeys([...up, ...down]);
+}
+
+function questionNavigationKeys(keybindings: KeybindingsManager): string {
+	return formatHintKeys([...keybindings.getKeys("tui.input.tab"), "shift+tab", "←→"]);
+}
+
+function formatHintKeys(keys: readonly string[]): string {
+	return [...new Set(keys)].map(formatHintKey).join("/");
+}
+
+function formatHintKey(key: string): string {
+	return key
+		.split("+")
+		.map((part) =>
+			process.platform === "darwin" && part.toLowerCase() === "alt" ? "option" : part,
+		)
+		.join("+");
 }
 
 function inlineSummary(value: string): string {

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -364,7 +364,9 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 	}
 
 	private isCancel(data: string): boolean {
-		return this.options.keybindings.matches(data, "tui.select.cancel");
+		return (
+			matchesKey(data, Key.ctrl("c")) || this.options.keybindings.matches(data, "tui.select.cancel")
+		);
 	}
 
 	private handleEditorInput(data: string): void {
@@ -389,7 +391,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 			if (!review) this.moveSelection(1);
 			return;
 		}
-		if (keybindings.matches(data, "tui.select.confirm") || data === "\n") {
+		if (keybindings.matches(data, "tui.select.confirm")) {
 			this.submitPage();
 			return;
 		}
@@ -409,7 +411,7 @@ export class PlanModeQuestionnaire implements Component, Focusable {
 
 	private renderHints(): string {
 		const { keybindings, theme } = this.options;
-		const cancel = keybindingHint(theme, keybindings, "tui.select.cancel", "cancel");
+		const cancel = cancelHint(theme, keybindings);
 		if (this.editorKind) {
 			return [
 				keybindingHint(theme, keybindings, "tui.input.submit", "save"),
@@ -908,6 +910,14 @@ function keybindingHint(
 
 function rawKeyHint(theme: Theme, keys: string, description: string): string {
 	return `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}`;
+}
+
+function cancelHint(theme: Theme, keybindings: KeybindingsManager): string {
+	return rawKeyHint(
+		theme,
+		formatHintKeys([...keybindings.getKeys("tui.select.cancel"), "ctrl+c"]),
+		"cancel",
+	);
 }
 
 function selectionNavigationKeys(keybindings: KeybindingsManager): string {

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { stripVTControlCharacters } from "node:util";
-import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	CURSOR_MARKER,
+	KeybindingsManager,
+	TUI_KEYBINDINGS,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
@@ -35,7 +40,11 @@ const questions: PlanModeQuestion[] = [
 ];
 
 function tuiRun(customQuestions = questions, width = 60) {
-	const tui = createTuiHarness({ width, rows: 30 });
+	const tui = createTuiHarness({
+		width,
+		rows: 30,
+		keybindings: new KeybindingsManager(TUI_KEYBINDINGS),
+	});
 	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 	const running = askPlanModeQuestions(customQuestions, context.ctx);
 	return { tui, running };
@@ -131,6 +140,7 @@ test("TUI applies legacy selector emphasis to borders, title, and selected optio
 		foreground.some(({ color, text }) => color === "muted" && text === " — Include cleanup."),
 	);
 	assert.ok(bold.includes("How broad?"));
+	assert.match(tui.render().join("\n"), /↑↓ navigate {2}enter select {2}escape\/ctrl\+c cancel/u);
 	tui.dispose();
 	assert.equal(await running, undefined);
 });
@@ -163,7 +173,7 @@ test("Review renders plain summaries without selection affordances", async () =>
 	const frame = tui.render().join("\n");
 	assert.match(frame, /\n 1\. Scope — Unanswered\n 2\. Tests — Unanswered/u);
 	assert.doesNotMatch(frame, /→ [12]\./u);
-	assert.match(frame, /Enter submit/u);
+	assert.match(frame, /enter submit/u);
 	assert.doesNotMatch(frame, /↑\/↓ select|n note/u);
 	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "1. Scope"));
 	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "2. Tests"));
@@ -179,6 +189,50 @@ test("Review renders plain summaries without selection affordances", async () =>
 	tui.press("tui.select.down");
 	assert.equal(tui.render().join("\n"), unchanged);
 	tui.dispose();
+	assert.equal(await running, undefined);
+});
+
+test("TUI uses configured selector keybindings and legacy j/k aliases", async () => {
+	const bindings = {
+		"tui.input.newLine": { data: "\u001b[13;3u", key: "alt+enter" },
+		"tui.input.submit": { data: "\u0013", key: "ctrl+s" },
+		"tui.input.tab": { data: "t", key: "t" },
+		"tui.select.cancel": { data: "q", key: "q" },
+		"tui.select.confirm": { data: "x", key: "x" },
+		"tui.select.down": { data: "s", key: "s" },
+		"tui.select.up": { data: "w", key: "w" },
+	} as const;
+	const tui = createTuiHarness({
+		width: 120,
+		rows: 30,
+		keybindings: {
+			matches: (data, binding) => bindings[binding as keyof typeof bindings]?.data === data,
+			getKeys: (binding) => {
+				const configured = bindings[binding as keyof typeof bindings];
+				return configured ? [configured.key] : [];
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions(questions, context.ctx);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	assert.match(
+		tui.render().join("\n"),
+		/w\/s navigate {2}x select {2}q cancel {2}t\/shift\+tab\/←→ questions {2}n note/u,
+	);
+	tui.send("j");
+	assert.match(tui.render().join("\n"), /→ 2\. Broad/u);
+	tui.send("k");
+	assert.match(tui.render().join("\n"), /→ 1\. Small/u);
+	tui.send("s");
+	tui.send("t");
+	assert.match(tui.render().join("\n"), /\[Tests\]/u);
+	tui.send("\u001b[D");
+	tui.send("x");
+	tui.send("x");
+	assert.match(tui.render().join("\n"), /x submit {2}q cancel/u);
+	tui.send("q");
 	assert.equal(await running, undefined);
 });
 

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -219,7 +219,7 @@ test("TUI uses configured selector keybindings and legacy j/k aliases", async ()
 	tui.setFocused(true);
 	assert.match(
 		tui.render().join("\n"),
-		/w\/s navigate {2}x select {2}q cancel {2}t\/shift\+tab\/←→ questions {2}n note/u,
+		/w\/s navigate {2}x select {2}q\/ctrl\+c cancel {2}t\/shift\+tab\/←→ questions {2}n note/u,
 	);
 	tui.send("j");
 	assert.match(tui.render().join("\n"), /→ 2\. Broad/u);
@@ -231,8 +231,27 @@ test("TUI uses configured selector keybindings and legacy j/k aliases", async ()
 	tui.send("\u001b[D");
 	tui.send("x");
 	tui.send("x");
-	assert.match(tui.render().join("\n"), /x submit {2}q cancel/u);
+	assert.match(tui.render().join("\n"), /x submit {2}q\/ctrl\+c cancel/u);
+	tui.send("\n");
+	assert.equal(tui.isOpen, true);
+	assert.match(tui.render().join("\n"), /\[Review\]/u);
 	tui.send("q");
+	assert.equal(await running, undefined);
+});
+
+test("TUI keeps Ctrl+C as a hard cancel when it is not configured", async () => {
+	const tui = createTuiHarness({
+		keybindings: {
+			matches: (data, binding) => binding === "tui.select.cancel" && data === "q",
+			getKeys: (binding) => (binding === "tui.select.cancel" ? ["q"] : []),
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions([questions[0]], context.ctx);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	assert.match(tui.render().join("\n"), /q\/ctrl\+c cancel/u);
+	tui.send("\u0003");
 	assert.equal(await running, undefined);
 });
 


### PR DESCRIPTION
## Summary

- use the `ctx.ui.custom()` keybindings manager for questionnaire selection, confirmation, cancellation, tab navigation, and editor submission
- render hints from the effective configured bindings while preserving the legacy selector defaults and wording
- retain the legacy `j`/`k` selection aliases and layer question navigation and notes after existing selector actions
- keep raw editor submission untrimmed and preserve the existing lifecycle, Review, and RPC behavior

## Verification

- `npm run check`
- `PI_EXTENSIONS_BUILD_READY=1 npm test` (395 files, 3,732 tests)
- focused questionnaire tests (2 files, 42 tests)
- synchronized `pi-plan-mode` and `pi-workflow` implementations and compatibility tests

## Notes

This is a stacked follow-up to #873 and intentionally targets `narumi/fix/plan-question-review`.
The parent PR already carries the release changeset.
A live interactive Pi smoke was not run; deterministic TUI coverage verifies default hints, configured bindings, legacy aliases, navigation, cancellation, and raw editor submission.

