### PR TITLE
feat(pi-tui-kit): add questionnaire runner

### DIFF
--- a/.changeset/calm-questions-flow.md
+++ b/.changeset/calm-questions-flow.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add a generic lifecycle-safe questionnaire runner for TUI and RPC interactions.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -268,6 +268,43 @@ RPC deliberately degrades to a signal-aware ordinary selector: it never runs liv
 Print and JSON return `unsupported`.
 Results distinguish `selected`, `shortcut`, `closed`, `stale`, `unsupported`, and `error`.
 
+Use `runQuestionnaire()` for a bounded sequence of required choices with optional free-form answers, notes, and a final read-only review:
+
+```ts
+import { runQuestionnaire } from "@narumitw/pi-tui-kit";
+
+const result = await runQuestionnaire(ctx, {
+  questions: [
+    {
+      id: "scope",
+      header: "Scope",
+      prompt: "How broad should this change be?",
+      options: [
+        { label: "Focused", description: "Change only the requested behavior." },
+        { label: "Broad", description: "Include compatible cleanup." },
+      ],
+    },
+  ],
+  allowNotes: true,
+  maxTextLength: 4_000,
+  signal: currentSessionSignal(),
+  isCurrent: () => generation === currentGeneration(),
+});
+
+if (result.kind === "submitted") {
+  await saveDomainAnswers(result.answers);
+}
+```
+
+TUI preserves Pi selector framing, effective keybindings, Back versus Ctrl+C Close, exact editor input, optional notes, and a plain non-selectable review.
+Free-form answers are enabled by default, notes require `allowNotes`, and `maxTextLength` applies to free-form answers and notes.
+RPC preserves the existing sequential `select()` and `editor()` fallback for choices and free-form answers, but does not collect TUI-only notes or show the final review.
+RPC preserves the editor response verbatim, including an empty string, for compatibility with existing Pi dialogs.
+Pi's RPC editor API has no abort signal, so owner cancellation during an open editor is classified as stale after that editor closes.
+Print and JSON return `unsupported`.
+Owner abort, stale state, external disposal, invalid options, and UI failures remain distinct typed results.
+The caller owns question-count and option-count policy, domain validation, side effects, result persistence, and mapping answer IDs back to domain objects.
+
 `formatInteractionHints()` is available for other specialized components.
 Pass the callback-injected keybindings plus binding-backed or literal-key hint groups; the formatter normalizes arrows, Enter/Escape names, sanitizes controls, applies exclusions, de-duplicates keys, and supports a custom separator.
 
@@ -705,6 +742,7 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `runTask()` — runs typed abort-aware work with a cancellable TUI loader and direct non-TUI fallback.
 - `runConfirmation()` — preserves Confirmed, Back, Close, Stale, Unsupported, and Error for one standalone confirmation without owning the confirmed side effect.
 - `runLiveChoice()` — adapts a live-preview choice to TUI and ordinary RPC selection while preserving typed selection, confirmation-only gating, shortcuts, Back, Close, Stale, Unsupported, and Error.
+- `runQuestionnaire()` — adapts required multi-question choices, free-form answers, optional TUI notes, and read-only review to TUI and sequential RPC while preserving typed Submitted, Back, Close, Stale, Unsupported, and Error outcomes.
 - `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and literal shortcut keys for specialized interaction hints; the lightweight `@narumitw/pi-tui-kit/interaction-hints` subpath exports it and its public types.
 - `sanitizeTerminalText()` — removes terminal and bidirectional display controls from untrusted single-line presentation text without mutating raw payloads; the lightweight `@narumitw/pi-tui-kit/terminal-text` subpath exports it.
 - `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending work draining, and typed results around one extension-owned custom TUI component.
@@ -712,7 +750,8 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `createMenuNavigator()` — lower-level stack and selection state helper.
 - exported screen, item, action, transition, runtime option, `BrowseDetailDocument`, `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`, strict scripts, and their public testing types; it is not re-exported from the production root.
-- `PI_EXTENSION_MENU_API_VERSION` — current API version (`13`).
+- `PI_EXTENSION_MENU_API_VERSION` — current API version (`14`).
+Version 14 adds the standalone `runQuestionnaire()` interaction while version-13 menu definitions remain valid.
 Version 13 adds opt-in Markdown, LaTeX, and Mermaid document formatting while version-12 menu definitions remain valid.
 Version 12 added optional searchable `choice` fields, version 11 added Live Choice confirmation-only gating, version 10 added exact browse detail documents, version 9 added `runLiveChoice()` and `formatInteractionHints()`, version 8 added disabled action reasons and adaptive action-label columns, version 7 added `runConfirmation()`, and version 6 added the read-only `browse` screen and `runCustomInteraction()`.
 
@@ -724,6 +763,7 @@ Version 12 added optional searchable `choice` fields, version 11 added Live Choi
 - `src/task.ts` — standalone and menu-shared task lifecycle orchestration
 - `src/confirmation.ts` — standalone confirmation mode adaptation and lifecycle results
 - `src/live-choice.ts` — standalone live-choice TUI/RPC adaptation and preview-work ownership
+- `src/questionnaire.ts` — standalone questionnaire TUI/RPC adaptation and public result contract
 - `src/interaction-hints.ts` — injected-key and literal-shortcut hint formatting, published through the lightweight `/interaction-hints` subpath
 - `src/terminal-text.ts` — terminal display sanitization published through the lightweight `/terminal-text` subpath
 - `src/custom-interaction.ts` — lifecycle ownership for specialized public custom components

--- a/packages/pi-tui-kit/src/components/questionnaire.ts
+++ b/packages/pi-tui-kit/src/components/questionnaire.ts
@@ -1,0 +1,775 @@
+import { stripVTControlCharacters } from "node:util";
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import {
+	type Component,
+	Editor,
+	type EditorTheme,
+	type Focusable,
+	Key,
+	matchesKey,
+	sliceByColumn,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import type {
+	QuestionnaireAnswer,
+	QuestionnaireLabels,
+	QuestionnaireQuestion,
+} from "../questionnaire.js";
+import type { MenuCloseReason } from "../types.js";
+import { DynamicBorder } from "./dynamic-border.js";
+
+const BRACKETED_PASTE_START = "\u001b[200~";
+const BRACKETED_PASTE_END = "\u001b[201~";
+
+export type QuestionnaireInteractionValue<QuestionId extends string> =
+	| { kind: "submitted"; answers: QuestionnaireAnswer<QuestionId>[] }
+	| { kind: "closed"; reason: MenuCloseReason };
+
+export interface QuestionnaireComponentOptions<QuestionId extends string> {
+	questions: readonly QuestionnaireQuestion<QuestionId>[];
+	allowCustomAnswer: boolean;
+	allowNotes: boolean;
+	maxTextLength?: number;
+	labels: QuestionnaireLabels;
+	tui: TUI;
+	theme: Theme;
+	keybindings: KeybindingsManager;
+	isCurrent(): boolean;
+	onDone(value: QuestionnaireInteractionValue<QuestionId>): void;
+}
+
+export class QuestionnaireComponent<QuestionId extends string> implements Component, Focusable {
+	private readonly options: QuestionnaireComponentOptions<QuestionId>;
+	private readonly border: DynamicBorder;
+	private readonly editor: RawPreservingEditor;
+	private readonly answers: Array<QuestionnaireAnswer<QuestionId> | undefined>;
+	private readonly selectedOptions: number[];
+	private page = 0;
+	private editorKind: "answer" | "note" | undefined;
+	private message: string | undefined;
+	private finished = false;
+	private _focused = false;
+
+	constructor(options: QuestionnaireComponentOptions<QuestionId>) {
+		this.options = options;
+		this.border = new DynamicBorder((text) => options.theme.fg("border", text));
+		this.answers = options.questions.map(() => undefined);
+		this.selectedOptions = options.questions.map(() => 0);
+		const editorTheme: EditorTheme = {
+			borderColor: (text) => options.theme.fg("accent", text),
+			selectList: {
+				selectedPrefix: (text) => options.theme.fg("accent", text),
+				selectedText: (text) => options.theme.fg("accent", text),
+				description: (text) => options.theme.fg("muted", text),
+				scrollInfo: (text) => options.theme.fg("dim", text),
+				noMatch: (text) => options.theme.fg("warning", text),
+			},
+		};
+		this.editor = new RawPreservingEditor(options.tui, editorTheme);
+		this.editor.onChange = () => {
+			this.message = undefined;
+		};
+		this.editor.onSubmit = (text) => this.submitEditor(text);
+	}
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	set focused(value: boolean) {
+		this._focused = value;
+		this.editor.focused = value && this.editorKind !== undefined;
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const padding = safeWidth > 1 ? " " : "";
+		const contentWidth = Math.max(1, safeWidth - visibleWidth(padding));
+		const border = this.border.render(safeWidth)[0] ?? "";
+		const lines = [border, "", ...this.renderTabs(contentWidth), ""];
+		if (this.isReviewPage()) lines.push(...this.renderReview(contentWidth));
+		else lines.push(...this.renderQuestion(contentWidth));
+		if (this.message) {
+			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), contentWidth));
+		}
+		lines.push("", truncateToWidth(this.renderHints(), contentWidth), "", border);
+		return lines.map((line) => {
+			if (!line || line === border) return line;
+			return `${padding}${truncateToWidth(line, contentWidth)}`;
+		});
+	}
+
+	handleInput(data: string): void {
+		if (this.finished) return;
+		if (!this.options.isCurrent()) {
+			this.finish({ kind: "closed", reason: "back" });
+			return;
+		}
+		if (matchesKey(data, Key.ctrl("c"))) {
+			this.finish({ kind: "closed", reason: "close" });
+			return;
+		}
+		if (this.options.keybindings.matches(data, "tui.select.cancel")) {
+			this.finish({ kind: "closed", reason: "back" });
+			return;
+		}
+		if (this.editorKind) this.handleEditorInput(data);
+		else this.handlePageInput(data);
+		this.options.tui.requestRender();
+	}
+
+	invalidate(): void {
+		this.border.invalidate();
+		this.editor.invalidate();
+	}
+
+	dispose(): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.editor.focused = false;
+	}
+
+	private handleEditorInput(data: string): void {
+		const keybindings = this.options.keybindings;
+		if (keybindings.matches(data, "tui.input.newLine")) {
+			this.editor.handleInput(data);
+		} else if (keybindings.matches(data, "tui.input.submit")) {
+			this.submitEditor(this.editor.getExpandedText());
+		} else {
+			this.editor.handleInput(data);
+		}
+	}
+
+	private handlePageInput(data: string): void {
+		const keybindings = this.options.keybindings;
+		if (keybindings.matches(data, "tui.select.up")) {
+			if (!this.isReviewPage()) this.moveSelection(-1);
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.down")) {
+			if (!this.isReviewPage()) this.moveSelection(1);
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.confirm")) {
+			this.submitPage();
+			return;
+		}
+		if (keybindings.matches(data, "tui.input.tab")) {
+			this.movePage(1);
+			return;
+		}
+		if (data === "k") {
+			if (!this.isReviewPage()) this.moveSelection(-1);
+			return;
+		}
+		if (data === "j") {
+			if (!this.isReviewPage()) this.moveSelection(1);
+			return;
+		}
+		if (matchesKey(data, Key.right)) {
+			this.movePage(1);
+			return;
+		}
+		if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left)) {
+			this.movePage(-1);
+			return;
+		}
+		if (
+			this.options.allowNotes &&
+			noteShortcutAvailable(keybindings) &&
+			data.toLowerCase() === "n"
+		) {
+			if (this.isReviewPage()) this.message = "Return to a question to add or edit its note.";
+			else this.editNote();
+		}
+	}
+
+	private renderHints(): string {
+		const { keybindings, theme } = this.options;
+		const cancel = cancelHint(theme, keybindings);
+		if (this.editorKind) {
+			return [
+				keybindingHint(theme, keybindings, "tui.input.submit", "save"),
+				keybindingHint(theme, keybindings, "tui.input.newLine", "newline"),
+				cancel,
+			].join("  ");
+		}
+		const questions = rawKeyHint(theme, questionNavigationKeys(keybindings), "questions");
+		if (this.isReviewPage()) {
+			return [
+				keybindingHint(theme, keybindings, "tui.select.confirm", "submit"),
+				cancel,
+				questions,
+			].join("  ");
+		}
+		return [
+			rawKeyHint(theme, selectionNavigationKeys(keybindings), "navigate"),
+			keybindingHint(theme, keybindings, "tui.select.confirm", "select"),
+			cancel,
+			questions,
+			...(this.options.allowNotes && noteShortcutAvailable(keybindings)
+				? [rawKeyHint(theme, "n", "note")]
+				: []),
+		].join("  ");
+	}
+
+	private movePage(delta: number): void {
+		const pageCount = this.options.questions.length + 1;
+		this.page = (this.page + delta + pageCount) % pageCount;
+		const answer = this.answers[this.page];
+		const question = this.options.questions[this.page];
+		if (answer?.wasCustom && question) {
+			this.selectedOptions[this.page] = question.options.length;
+		} else if (answer?.optionIndex !== undefined) {
+			this.selectedOptions[this.page] = answer.optionIndex - 1;
+		}
+		this.message = undefined;
+	}
+
+	private renderTabs(width: number): string[] {
+		const reviewTab = sanitizeQuestionnaireText(this.options.labels.reviewTab) || "Review";
+		const tabs = [
+			...this.options.questions.map((question, index) => {
+				const label = sanitizeQuestionnaireText(question.header) || `Question ${index + 1}`;
+				const answered = this.answers[index] ? "✓ " : "";
+				return this.page === index ? `[${answered}${label}]` : `${answered}${label}`;
+			}),
+			this.isReviewPage() ? `[${reviewTab}]` : reviewTab,
+		];
+		const lines: string[] = [];
+		let line = "";
+		for (const tab of tabs) {
+			const boundedTab = truncateToWidth(tab, width, "…");
+			const candidate = line ? `${line}  ${boundedTab}` : boundedTab;
+			if (line && visibleWidth(candidate) > width) {
+				lines.push(this.options.theme.fg("accent", line));
+				line = boundedTab;
+			} else {
+				line = candidate;
+			}
+		}
+		if (line) lines.push(this.options.theme.fg("accent", line));
+		return lines;
+	}
+
+	private renderQuestion(width: number): string[] {
+		const question = this.options.questions[this.page];
+		if (!question) return [];
+		const lines = hardWrap(
+			this.options.theme.fg(
+				"accent",
+				this.options.theme.bold(sanitizeQuestionnaireText(question.prompt)),
+			),
+			width,
+		);
+		lines.push("");
+		question.options.forEach((option, index) => {
+			const selected = this.selectedOptions[this.page] === index;
+			const cursor = selected ? "→" : " ";
+			const label = `${cursor} ${index + 1}. ${sanitizeQuestionnaireText(option.label)}`;
+			const chosen = this.answers[this.page]?.optionIndex === index + 1;
+			const description = option.description
+				? ` — ${sanitizeQuestionnaireText(option.description)}`
+				: "";
+			const line = selected
+				? this.options.theme.fg("accent", `${label}${chosen ? " ✓" : ""}${description}`)
+				: `${this.options.theme.fg("text", label)}${
+						chosen ? this.options.theme.fg("success", " ✓") : ""
+					}${description ? this.options.theme.fg("muted", description) : ""}`;
+			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${cursor} ${index + 1}. `)));
+		});
+		if (this.options.allowCustomAnswer) lines.push(...this.renderCustomOption(question));
+		const answer = this.answers[this.page];
+		if (answer?.wasCustom) {
+			lines.push(
+				...labeledRaw(this.options.labels.answer, answer.answer, width, this.options.theme),
+			);
+		}
+		if (answer?.note) {
+			lines.push(...labeledRaw(this.options.labels.note, answer.note, width, this.options.theme));
+		}
+		if (this.editorKind) {
+			lines.push(
+				"",
+				this.options.theme.fg(
+					"accent",
+					sanitizeQuestionnaireText(
+						this.editorKind === "answer"
+							? this.options.labels.customAnswer
+							: this.options.labels.optionalNote,
+					),
+				),
+				...this.editor.render(width),
+			);
+		}
+		return lines;
+	}
+
+	private renderCustomOption(question: QuestionnaireQuestion<QuestionId>): string[] {
+		const customIndex = question.options.length;
+		const selected = this.selectedOptions[this.page] === customIndex;
+		const cursor = selected ? "→" : " ";
+		const label = `${cursor} ${customIndex + 1}. ${sanitizeQuestionnaireText(this.options.labels.otherOption)}`;
+		const chosen = this.answers[this.page]?.wasCustom === true;
+		return [
+			selected
+				? this.options.theme.fg("accent", `${label}${chosen ? " ✓" : ""}`)
+				: `${this.options.theme.fg("text", label)}${
+						chosen ? this.options.theme.fg("success", " ✓") : ""
+					}`,
+		];
+	}
+
+	private renderReview(width: number): string[] {
+		const reviewTitle =
+			sanitizeQuestionnaireText(this.options.labels.reviewTitle) || "Review answers";
+		const lines = [this.options.theme.fg("accent", this.options.theme.bold(reviewTitle)), ""];
+		const noteLabel = sanitizeQuestionnaireText(this.options.labels.note) || "Note";
+		this.options.questions.forEach((question, index) => {
+			const answer = this.answers[index];
+			const header = sanitizeQuestionnaireText(question.header) || `Question ${index + 1}`;
+			const label = `${index + 1}. ${header}`;
+			const summary = ` — ${inlineSummary(answer?.answer ?? "Unanswered")}${
+				answer?.note ? ` · ${noteLabel}: ${inlineSummary(answer.note)}` : ""
+			}`;
+			const line = `${this.options.theme.fg("text", label)}${this.options.theme.fg("muted", summary)}`;
+			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${index + 1}. `)));
+		});
+		return lines;
+	}
+
+	private moveSelection(delta: number): void {
+		const question = this.options.questions[this.page];
+		const optionCount = (question?.options.length ?? 0) + Number(this.options.allowCustomAnswer);
+		if (optionCount === 0) return;
+		this.selectedOptions[this.page] =
+			((this.selectedOptions[this.page] ?? 0) + delta + optionCount) % optionCount;
+	}
+
+	private submitPage(): void {
+		if (this.isReviewPage()) {
+			if (this.answers.some((answer) => !answer)) {
+				this.message = "Answer every question before submitting.";
+				return;
+			}
+			this.finish({
+				kind: "submitted",
+				answers: this.answers.filter(
+					(answer): answer is QuestionnaireAnswer<QuestionId> => answer !== undefined,
+				),
+			});
+			return;
+		}
+		const question = this.options.questions[this.page];
+		if (!question) return;
+		const selected = this.selectedOptions[this.page] ?? 0;
+		if (this.options.allowCustomAnswer && selected === question.options.length) {
+			this.beginEditor(
+				"answer",
+				this.answers[this.page]?.wasCustom ? this.answers[this.page]?.answer : "",
+			);
+			return;
+		}
+		const option = question.options[selected];
+		if (!option) return;
+		const previous = this.answers[this.page];
+		this.answers[this.page] = answerFor(question.id, option.label, {
+			wasCustom: false,
+			optionIndex: selected + 1,
+			note: previous?.optionIndex === selected + 1 ? previous.note : undefined,
+		});
+		this.advance();
+	}
+
+	private editNote(): void {
+		const index = this.page;
+		let answer = this.answers[index];
+		const question = this.options.questions[index];
+		const selected = this.selectedOptions[index] ?? 0;
+		if (
+			question &&
+			this.options.allowCustomAnswer &&
+			selected === question.options.length &&
+			!answer?.wasCustom
+		) {
+			this.beginEditor("answer", "");
+			return;
+		}
+		if (question && selected < question.options.length && answer?.optionIndex !== selected + 1) {
+			const option = question.options[selected];
+			if (option) {
+				answer = answerFor(question.id, option.label, {
+					wasCustom: false,
+					optionIndex: selected + 1,
+				});
+				this.answers[index] = answer;
+			}
+		}
+		if (!answer) {
+			this.message = "Select an answer before adding a note.";
+			return;
+		}
+		this.beginEditor("note", answer.note ?? "");
+	}
+
+	private beginEditor(kind: "answer" | "note", value: string | undefined): void {
+		this.editorKind = kind;
+		this.editor.setText(value ?? "");
+		this.editor.focused = this._focused;
+		this.message = undefined;
+	}
+
+	private submitEditor(value: string): void {
+		if (this.options.maxTextLength !== undefined && value.length > this.options.maxTextLength) {
+			this.editor.setText(value);
+			this.message = `${this.editorKind === "answer" ? "Answer" : "Note"} must be ${formatLimit(
+				this.options.maxTextLength,
+			)} characters or fewer.`;
+			this.options.tui.requestRender();
+			return;
+		}
+		const index = this.page;
+		if (this.editorKind === "answer") {
+			if (!value.trim()) {
+				this.editor.setText(value);
+				this.message = "Custom answer cannot be empty.";
+				this.options.tui.requestRender();
+				return;
+			}
+			const question = this.options.questions[index];
+			if (!question) return;
+			const previous = this.answers[index];
+			this.answers[index] = answerFor(question.id, value, {
+				wasCustom: true,
+				note: previous?.wasCustom ? previous.note : undefined,
+			});
+			this.editor.setText("");
+			this.editorKind = undefined;
+			this.editor.focused = false;
+			this.advance();
+			return;
+		}
+		const answer = this.answers[index];
+		if (answer) answer.note = value.trim() ? value : undefined;
+		this.editor.setText("");
+		this.editorKind = undefined;
+		this.editor.focused = false;
+		this.message = value.trim() ? "Note saved." : "Note cleared.";
+		this.options.tui.requestRender();
+	}
+
+	private advance(): void {
+		this.page = Math.min(this.page + 1, this.options.questions.length);
+		this.message = undefined;
+	}
+
+	private isReviewPage(): boolean {
+		return this.page === this.options.questions.length;
+	}
+
+	private finish(value: QuestionnaireInteractionValue<QuestionId>): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.editor.focused = false;
+		this.options.onDone(value);
+	}
+}
+
+class RawPreservingEditor implements Focusable {
+	private readonly editor: Editor;
+	private readonly rawByMarker = new Map<string, string>();
+	private markerCodePoint = 0xe000;
+	private pasteBuffer: string | undefined;
+
+	constructor(tui: TUI, theme: EditorTheme) {
+		this.editor = new Editor(tui, theme, { paddingX: 0 });
+	}
+
+	get focused(): boolean {
+		return this.editor.focused;
+	}
+
+	set focused(value: boolean) {
+		this.editor.focused = value;
+	}
+
+	set onChange(handler: ((value: string) => void) | undefined) {
+		this.editor.onChange = handler ? () => handler(this.getExpandedText()) : undefined;
+	}
+
+	set onSubmit(handler: ((value: string) => void) | undefined) {
+		this.editor.onSubmit = handler ? (value) => handler(this.decode(value)) : undefined;
+	}
+
+	handleInput(data: string): void {
+		if (this.pasteBuffer !== undefined) {
+			this.pasteBuffer += data;
+			this.flushPasteBuffer();
+			return;
+		}
+		if (matchesKey(data, Key.backspace)) {
+			this.editor.handleInput(data);
+			return;
+		}
+		const pasteStart = data.indexOf(BRACKETED_PASTE_START);
+		if (pasteStart >= 0) {
+			if (pasteStart > 0) this.editor.handleInput(data.slice(0, pasteStart));
+			this.pasteBuffer = data.slice(pasteStart + BRACKETED_PASTE_START.length);
+			this.flushPasteBuffer();
+			return;
+		}
+		if (
+			[...data].some(
+				(character) => isUnsafeDirectEditorCharacter(character) || this.rawByMarker.has(character),
+			)
+		) {
+			this.editor.handleInput(this.encode(data));
+			return;
+		}
+		this.editor.handleInput(data);
+	}
+
+	render(width: number): string[] {
+		return this.editor
+			.render(width)
+			.map((line) =>
+				[...line].map((character) => (this.rawByMarker.has(character) ? " " : character)).join(""),
+			);
+	}
+
+	invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	setText(value: string): void {
+		this.rawByMarker.clear();
+		this.markerCodePoint = 0xe000;
+		this.pasteBuffer = undefined;
+		this.editor.setText(this.encode(value));
+	}
+
+	getExpandedText(): string {
+		return this.decode(this.editor.getExpandedText());
+	}
+
+	private flushPasteBuffer(): void {
+		if (this.pasteBuffer === undefined) return;
+		const pasteEnd = this.pasteBuffer.indexOf(BRACKETED_PASTE_END);
+		if (pasteEnd < 0) return;
+		const raw = this.pasteBuffer.slice(0, pasteEnd);
+		const remaining = this.pasteBuffer.slice(pasteEnd + BRACKETED_PASTE_END.length);
+		this.pasteBuffer = undefined;
+		this.editor.handleInput(`${BRACKETED_PASTE_START}${this.encode(raw)}${BRACKETED_PASTE_END}`);
+		if (remaining) this.handleInput(remaining);
+	}
+
+	private encode(value: string): string {
+		const forbidden = new Set([
+			...value,
+			...this.editor.getExpandedText(),
+			...this.rawByMarker.keys(),
+		]);
+		return [...value]
+			.map((character) => {
+				if (!isUnsafeEditorCharacter(character) && !this.rawByMarker.has(character)) {
+					return character;
+				}
+				const marker = this.nextMarker(forbidden);
+				this.rawByMarker.set(marker, character);
+				forbidden.add(marker);
+				return marker;
+			})
+			.join("");
+	}
+
+	private decode(value: string): string {
+		return [...value].map((character) => this.rawByMarker.get(character) ?? character).join("");
+	}
+
+	private nextMarker(forbidden: ReadonlySet<string>): string {
+		for (;;) {
+			if (this.markerCodePoint === 0xf900) this.markerCodePoint = 0xf0000;
+			if (this.markerCodePoint === 0xffffe) this.markerCodePoint = 0x100000;
+			if (this.markerCodePoint > 0x10fffd) {
+				throw new Error("Questionnaire editor exhausted its safe input markers");
+			}
+			const marker = String.fromCodePoint(this.markerCodePoint++);
+			if (!forbidden.has(marker)) return marker;
+		}
+	}
+}
+
+function isUnsafeDirectEditorCharacter(character: string): boolean {
+	const codePoint = character.codePointAt(0) ?? 0;
+	return (
+		(codePoint >= 0x7f && codePoint <= 0x9f) ||
+		codePoint === 0x2028 ||
+		codePoint === 0x2029 ||
+		isBidiControl(codePoint)
+	);
+}
+
+function isUnsafeEditorCharacter(character: string): boolean {
+	const codePoint = character.codePointAt(0) ?? 0;
+	return (
+		character !== "\n" &&
+		(codePoint <= 0x1f ||
+			(codePoint >= 0x7f && codePoint <= 0x9f) ||
+			codePoint === 0x2028 ||
+			codePoint === 0x2029 ||
+			isBidiControl(codePoint))
+	);
+}
+
+function isBidiControl(codePoint: number): boolean {
+	return (
+		codePoint === 0x061c ||
+		codePoint === 0x200e ||
+		codePoint === 0x200f ||
+		(codePoint >= 0x202a && codePoint <= 0x202e) ||
+		(codePoint >= 0x2066 && codePoint <= 0x2069)
+	);
+}
+
+function sanitizeQuestionnaireText(value: string): string {
+	return [...stripVTControlCharacters(value)]
+		.map((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f ||
+				(codePoint >= 0x7f && codePoint <= 0x9f) ||
+				codePoint === 0x2028 ||
+				codePoint === 0x2029 ||
+				isBidiControl(codePoint)
+				? " "
+				: character;
+		})
+		.join("");
+}
+
+function answerFor<QuestionId extends string>(
+	questionId: QuestionId,
+	answer: string,
+	options: { wasCustom: boolean; optionIndex?: number; note?: string },
+): QuestionnaireAnswer<QuestionId> {
+	return {
+		questionId,
+		answer,
+		wasCustom: options.wasCustom,
+		...(options.optionIndex === undefined ? {} : { optionIndex: options.optionIndex }),
+		...(options.note === undefined ? {} : { note: options.note }),
+	};
+}
+
+type QuestionnaireKeybinding = Parameters<KeybindingsManager["getKeys"]>[0];
+
+function keybindingHint(
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	keybinding: QuestionnaireKeybinding,
+	description: string,
+): string {
+	return rawKeyHint(theme, formatHintKeys(keybindings.getKeys(keybinding)), description);
+}
+
+function rawKeyHint(theme: Theme, keys: string, description: string): string {
+	return `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}`;
+}
+
+function cancelHint(theme: Theme, keybindings: KeybindingsManager): string {
+	return rawKeyHint(
+		theme,
+		formatHintKeys([...keybindings.getKeys("tui.select.cancel"), "ctrl+c"]),
+		"cancel",
+	);
+}
+
+function selectionNavigationKeys(keybindings: KeybindingsManager): string {
+	const up = keybindings.getKeys("tui.select.up");
+	const down = keybindings.getKeys("tui.select.down");
+	if (up.includes("up") && down.includes("down")) {
+		return formatHintKeys([
+			"↑↓",
+			...up.filter((key) => key !== "up"),
+			...down.filter((key) => key !== "down"),
+		]);
+	}
+	return formatHintKeys([...up, ...down]);
+}
+
+function questionNavigationKeys(keybindings: KeybindingsManager): string {
+	return formatHintKeys([...keybindings.getKeys("tui.input.tab"), "shift+tab", "←→"]);
+}
+
+function noteShortcutAvailable(keybindings: KeybindingsManager): boolean {
+	return ![
+		"tui.select.cancel",
+		"tui.select.up",
+		"tui.select.down",
+		"tui.select.confirm",
+		"tui.input.tab",
+	].some((binding) => keybindings.getKeys(binding as QuestionnaireKeybinding).includes("n"));
+}
+
+function formatHintKeys(keys: readonly string[]): string {
+	return [...new Set(keys)].map(formatHintKey).join("/");
+}
+
+function formatHintKey(key: string): string {
+	return key
+		.split("+")
+		.map((part) =>
+			process.platform === "darwin" && part.toLowerCase() === "alt" ? "option" : part,
+		)
+		.join("+");
+}
+
+function inlineSummary(value: string): string {
+	return value.split("\n").map(sanitizeQuestionnaireText).join(" ↵ ");
+}
+
+function labeledRaw(label: string, value: string, width: number, theme: Theme): string[] {
+	const safeLabel = sanitizeQuestionnaireText(label);
+	const prefix = `${safeLabel}: `;
+	const safe = sanitizeQuestionnaireText(value);
+	const lines = hardWrap(safe, Math.max(1, width - visibleWidth(prefix)));
+	return lines.map((line, index) =>
+		index === 0
+			? `${theme.fg("muted", prefix)}${line}`
+			: `${" ".repeat(visibleWidth(prefix))}${line}`,
+	);
+}
+
+function hardWrapWithIndent(value: string, width: number, indent: number): string[] {
+	const safeWidth = Math.max(1, width);
+	const safeIndent = Math.min(Math.max(0, indent), Math.max(0, safeWidth - 1));
+	const continuationWidth = Math.max(1, safeWidth - safeIndent);
+	const columns = visibleWidth(value);
+	if (columns <= safeWidth) return [value];
+	const output = [sliceByColumn(value, 0, safeWidth)];
+	for (let column = safeWidth; column < columns; column += continuationWidth) {
+		output.push(`${" ".repeat(safeIndent)}${sliceByColumn(value, column, continuationWidth)}`);
+	}
+	return output;
+}
+
+function hardWrap(value: string, width: number): string[] {
+	const safeWidth = Math.max(1, width);
+	if (!value) return [""];
+	const output: string[] = [];
+	for (const sourceLine of value.split("\n")) {
+		const columns = visibleWidth(sourceLine);
+		if (columns === 0) output.push("");
+		else {
+			for (let column = 0; column < columns; column += safeWidth) {
+				output.push(sliceByColumn(sourceLine, column, safeWidth));
+			}
+		}
+	}
+	return output;
+}
+
+function formatLimit(value: number): string {
+	return String(value).replace(/\B(?=(\d{3})+(?!\d))/gu, ",");
+}

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -26,6 +26,15 @@ export {
 } from "./live-choice.js";
 export { defineMenu, resolveMenuScreen } from "./model.js";
 export { createMenuNavigator, type MenuNavigator } from "./navigator.js";
+export {
+	type QuestionnaireAnswer,
+	type QuestionnaireLabels,
+	type QuestionnaireOption,
+	type QuestionnaireQuestion,
+	type RunQuestionnaireOptions,
+	type RunQuestionnaireResult,
+	runQuestionnaire,
+} from "./questionnaire.js";
 export { type RunMenuOptions, type RunMenuResult, runMenu } from "./runtime.js";
 export { type RunTaskOptions, type RunTaskResult, runTask } from "./task.js";
 export { sanitizeTerminalText } from "./terminal-text.js";
@@ -58,4 +67,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 13;
+export const PI_EXTENSION_MENU_API_VERSION = 14;

--- a/packages/pi-tui-kit/src/questionnaire.ts
+++ b/packages/pi-tui-kit/src/questionnaire.ts
@@ -1,0 +1,339 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { runCustomInteraction } from "./custom-interaction.js";
+import { sanitizeTerminalText } from "./terminal-text.js";
+import type { MenuCloseReason, MenuContext } from "./types.js";
+
+export interface QuestionnaireOption {
+	label: string;
+	description?: string;
+}
+
+export interface QuestionnaireQuestion<QuestionId extends string = string> {
+	id: QuestionId;
+	header: string;
+	prompt: string;
+	options: readonly QuestionnaireOption[];
+}
+
+export interface QuestionnaireAnswer<QuestionId extends string = string> {
+	questionId: QuestionId;
+	answer: string;
+	wasCustom: boolean;
+	/** One-based index matching the numbered option shown to the user. */
+	optionIndex?: number;
+	note?: string;
+}
+
+export interface QuestionnaireLabels {
+	reviewTab: string;
+	reviewTitle: string;
+	otherOption: string;
+	customAnswer: string;
+	optionalNote: string;
+	answer: string;
+	note: string;
+}
+
+export interface RunQuestionnaireOptions<
+	QuestionId extends string = string,
+	Context extends MenuContext = ExtensionCommandContext,
+> {
+	questions: readonly QuestionnaireQuestion<QuestionId>[];
+	allowCustomAnswer?: boolean;
+	allowNotes?: boolean;
+	maxTextLength?: number;
+	labels?: Partial<QuestionnaireLabels>;
+	signal?: AbortSignal;
+	isCurrent?(): boolean;
+	onError?(ctx: Context, error: unknown): void | Promise<void>;
+	onUnsupportedMode?(ctx: Context, mode: MenuContext["mode"]): void | Promise<void>;
+}
+
+export type RunQuestionnaireResult<QuestionId extends string = string> =
+	| { kind: "submitted"; answers: QuestionnaireAnswer<QuestionId>[] }
+	| { kind: "closed"; reason: MenuCloseReason }
+	| { kind: "stale" }
+	| { kind: "unsupported"; mode: MenuContext["mode"] }
+	| { kind: "error"; error: unknown };
+
+const DEFAULT_LABELS: QuestionnaireLabels = {
+	reviewTab: "Review",
+	reviewTitle: "Review answers",
+	otherOption: "Other (free-form)",
+	customAnswer: "Custom answer",
+	optionalNote: "Optional note",
+	answer: "Answer",
+	note: "Note",
+};
+
+/** Run a standalone multi-question interaction with TUI and RPC adapters. */
+export async function runQuestionnaire<
+	const QuestionId extends string,
+	Context extends MenuContext = ExtensionCommandContext,
+>(
+	ctx: Context,
+	options: RunQuestionnaireOptions<QuestionId, Context>,
+): Promise<RunQuestionnaireResult<QuestionId>> {
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	const validationError = validateOptions(options);
+	if (validationError) return questionnaireError(ctx, options, validationError);
+	const resolved = resolveOptions(options);
+	if (ctx.mode === "tui" && ctx.hasUI) return runTuiQuestionnaire(ctx, options, resolved);
+	if (ctx.mode === "rpc" && ctx.hasUI) return runRpcQuestionnaire(ctx, options, resolved);
+
+	try {
+		await options.onUnsupportedMode?.(ctx, ctx.mode);
+	} catch (error) {
+		return questionnaireError(ctx, options, error);
+	}
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	return { kind: "unsupported", mode: ctx.mode };
+}
+
+interface ResolvedQuestionnaireOptions<QuestionId extends string> {
+	questions: readonly QuestionnaireQuestion<QuestionId>[];
+	allowCustomAnswer: boolean;
+	allowNotes: boolean;
+	maxTextLength?: number;
+	labels: QuestionnaireLabels;
+}
+
+async function runTuiQuestionnaire<QuestionId extends string, Context extends MenuContext>(
+	ctx: Context,
+	options: RunQuestionnaireOptions<QuestionId, Context>,
+	resolved: ResolvedQuestionnaireOptions<QuestionId>,
+): Promise<RunQuestionnaireResult<QuestionId>> {
+	let QuestionnaireComponent: typeof import("./components/questionnaire.js")["QuestionnaireComponent"];
+	try {
+		({ QuestionnaireComponent } = await import("./components/questionnaire.js"));
+	} catch (error) {
+		return questionnaireError(ctx, options, error);
+	}
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	const result = await runCustomInteraction<
+		| { kind: "submitted"; answers: QuestionnaireAnswer<QuestionId>[] }
+		| { kind: "closed"; reason: MenuCloseReason },
+		Context
+	>(ctx, {
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+		onError: (currentCtx, error) => reportQuestionnaireError(currentCtx, options, error),
+		create: ({ tui, theme, keybindings, complete }) =>
+			new QuestionnaireComponent({
+				...resolved,
+				tui,
+				theme,
+				keybindings,
+				isCurrent: () => isCurrent(options),
+				onDone: complete,
+			}),
+	});
+	return result.kind === "completed" ? result.value : result;
+}
+
+async function runRpcQuestionnaire<QuestionId extends string, Context extends MenuContext>(
+	ctx: Context,
+	options: RunQuestionnaireOptions<QuestionId, Context>,
+	resolved: ResolvedQuestionnaireOptions<QuestionId>,
+): Promise<RunQuestionnaireResult<QuestionId>> {
+	const answers: QuestionnaireAnswer<QuestionId>[] = [];
+	for (const question of resolved.questions) {
+		const rows: Array<
+			| { kind: "option"; index: number; label: string }
+			| { kind: "custom"; index: number; label: string }
+		> = question.options.map((option, index) => ({
+			kind: "option",
+			index,
+			label: formatRpcOption(option, index),
+		}));
+		if (resolved.allowCustomAnswer) {
+			rows.push({
+				kind: "custom" as const,
+				index: question.options.length,
+				label: `${question.options.length + 1}. ${sanitizeTerminalText(resolved.labels.otherOption)}`,
+			});
+		}
+		let selection: string | undefined;
+		try {
+			selection = await uiFor(ctx).select(
+				`${sanitizeTerminalText(question.header)}: ${sanitizeTerminalText(question.prompt)}`,
+				rows.map((row) => row.label),
+				{ signal: options.signal },
+			);
+		} catch (error) {
+			return questionnaireError(ctx, options, error);
+		}
+		if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+		if (selection === undefined) return { kind: "closed", reason: "back" };
+		const row = rows.find((candidate) => candidate.label === selection);
+		if (!row) {
+			return questionnaireError(
+				ctx,
+				options,
+				new Error("Questionnaire dialog returned an option that was not offered"),
+			);
+		}
+		if (row.kind === "custom") {
+			const custom = await askRpcCustomAnswer(ctx, options, resolved, question);
+			if (custom.kind !== "answered") return custom.result;
+			answers.push({ questionId: question.id, answer: custom.answer, wasCustom: true });
+			continue;
+		}
+		const option = question.options[row.index];
+		if (!option) {
+			return questionnaireError(ctx, options, new Error("Questionnaire option disappeared"));
+		}
+		answers.push({
+			questionId: question.id,
+			answer: option.label,
+			wasCustom: false,
+			optionIndex: row.index + 1,
+		});
+	}
+	return { kind: "submitted", answers };
+}
+
+async function askRpcCustomAnswer<QuestionId extends string, Context extends MenuContext>(
+	ctx: Context,
+	options: RunQuestionnaireOptions<QuestionId, Context>,
+	resolved: ResolvedQuestionnaireOptions<QuestionId>,
+	question: QuestionnaireQuestion<QuestionId>,
+): Promise<
+	| { kind: "answered"; answer: string }
+	| { kind: "finished"; result: RunQuestionnaireResult<QuestionId> }
+> {
+	let draft = "";
+	for (;;) {
+		let answer: string | undefined;
+		try {
+			answer = await uiFor(ctx).editor(sanitizeTerminalText(question.prompt), draft);
+		} catch (error) {
+			return { kind: "finished", result: await questionnaireError(ctx, options, error) };
+		}
+		if (!isCurrent(options) || options.signal?.aborted) {
+			return { kind: "finished", result: { kind: "stale" } };
+		}
+		if (answer === undefined) {
+			return { kind: "finished", result: { kind: "closed", reason: "back" } };
+		}
+		if (resolved.maxTextLength !== undefined && answer.length > resolved.maxTextLength) {
+			try {
+				uiFor(ctx).notify(
+					`Custom answer must be ${formatLimit(resolved.maxTextLength)} characters or fewer.`,
+					"warning",
+				);
+			} catch (error) {
+				return { kind: "finished", result: await questionnaireError(ctx, options, error) };
+			}
+			draft = answer;
+			continue;
+		}
+		return { kind: "answered", answer };
+	}
+}
+
+function resolveOptions<QuestionId extends string, Context extends MenuContext>(
+	options: RunQuestionnaireOptions<QuestionId, Context>,
+): ResolvedQuestionnaireOptions<QuestionId> {
+	return {
+		questions: options.questions,
+		allowCustomAnswer: options.allowCustomAnswer ?? true,
+		allowNotes: options.allowNotes ?? false,
+		maxTextLength: options.maxTextLength,
+		labels: { ...DEFAULT_LABELS, ...options.labels },
+	};
+}
+
+function validateOptions<QuestionId extends string, Context extends MenuContext>(
+	options: RunQuestionnaireOptions<QuestionId, Context>,
+): Error | undefined {
+	if (options.questions.length === 0)
+		return new Error("Questionnaire requires at least one question");
+	if (
+		options.maxTextLength !== undefined &&
+		(!Number.isInteger(options.maxTextLength) || options.maxTextLength <= 0)
+	) {
+		return new Error("Questionnaire maxTextLength must be a positive integer");
+	}
+	const ids = new Set<string>();
+	for (const question of options.questions) {
+		if (!question.id.trim()) return new Error("Questionnaire question ids must not be blank");
+		if (ids.has(question.id))
+			return new Error(`Duplicate questionnaire question id: ${question.id}`);
+		ids.add(question.id);
+		if (!sanitizeTerminalText(question.header).trim()) {
+			return new Error(`Questionnaire question ${question.id} requires a displayable header`);
+		}
+		if (!sanitizeTerminalText(question.prompt).trim()) {
+			return new Error(`Questionnaire question ${question.id} requires a displayable prompt`);
+		}
+		if (question.options.length === 0) {
+			return new Error(`Questionnaire question ${question.id} requires at least one option`);
+		}
+		for (const option of question.options) {
+			if (!sanitizeTerminalText(option.label).trim()) {
+				return new Error(`Questionnaire question ${question.id} has a blank option label`);
+			}
+		}
+	}
+	for (const [name, label] of Object.entries(options.labels ?? {})) {
+		if (!sanitizeTerminalText(label).trim()) {
+			return new Error(`Questionnaire label ${name} must be displayable`);
+		}
+	}
+	return undefined;
+}
+
+function formatRpcOption(option: QuestionnaireOption, index: number): string {
+	const label = sanitizeTerminalText(option.label);
+	const description = option.description ? ` — ${sanitizeTerminalText(option.description)}` : "";
+	return `${index + 1}. ${label}${description}`;
+}
+
+async function questionnaireError<QuestionId extends string, Context extends MenuContext>(
+	ctx: Context,
+	options: RunQuestionnaireOptions<QuestionId, Context>,
+	error: unknown,
+): Promise<RunQuestionnaireResult<QuestionId>> {
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	await reportQuestionnaireError(ctx, options, error);
+	if (!isCurrent(options) || options.signal?.aborted) return { kind: "stale" };
+	return { kind: "error", error };
+}
+
+async function reportQuestionnaireError<QuestionId extends string, Context extends MenuContext>(
+	ctx: Context,
+	options: RunQuestionnaireOptions<QuestionId, Context>,
+	error: unknown,
+): Promise<void> {
+	let reported = false;
+	if (options.onError) {
+		try {
+			await options.onError(ctx, error);
+			reported = true;
+		} catch {
+			// Fall through to Pi's notifier when a custom reporter is unavailable.
+		}
+	}
+	if (reported || !ctx.hasUI || !isCurrent(options) || options.signal?.aborted) return;
+	const message = error instanceof Error ? error.message : String(error);
+	try {
+		uiFor(ctx).notify(`Questionnaire failed: ${sanitizeTerminalText(message)}`, "error");
+	} catch {
+		// Error reporting must not change the typed result.
+	}
+}
+
+function isCurrent<QuestionId extends string, Context extends MenuContext>(
+	options: RunQuestionnaireOptions<QuestionId, Context>,
+): boolean {
+	return options.isCurrent?.() ?? true;
+}
+
+function formatLimit(value: number): string {
+	return String(value).replace(/\B(?=(\d{3})+(?!\d))/gu, ",");
+}
+
+function uiFor(ctx: MenuContext): ExtensionCommandContext["ui"] {
+	return ctx.ui as ExtensionCommandContext["ui"];
+}

--- a/packages/pi-tui-kit/test/context-usage.ts
+++ b/packages/pi-tui-kit/test/context-usage.ts
@@ -5,16 +5,19 @@ import {
 	type InputScreen,
 	type LiveChoiceItem,
 	type MenuCloseReason,
+	type QuestionnaireQuestion,
 	type ReviewScreen,
 	type RunConfirmationResult,
 	type RunCustomInteractionResult,
 	type RunLiveChoiceResult,
 	type RunMenuResult,
+	type RunQuestionnaireResult,
 	type RunTaskResult,
 	runConfirmation,
 	runCustomInteraction,
 	runLiveChoice,
 	runMenu,
+	runQuestionnaire,
 	runTask,
 } from "../src/index.js";
 
@@ -189,6 +192,32 @@ void runCustomInteraction(lifecycleContext, {
 		// @ts-expect-error Lifecycle custom interactions must not gain command-only session methods.
 		handleInput: () => void ctx.waitForIdle(),
 	}),
+});
+
+const questionnaireQuestions = [
+	{
+		id: "scope",
+		header: "Scope",
+		prompt: "How broad?",
+		options: [{ label: "Small", description: "Only the bug" }],
+	},
+] as const satisfies readonly QuestionnaireQuestion[];
+const commandQuestionnaire: Promise<RunQuestionnaireResult<"scope">> = runQuestionnaire(
+	commandContext,
+	{
+		questions: questionnaireQuestions,
+		onUnsupportedMode: async (ctx) => ctx.waitForIdle(),
+	},
+);
+void commandQuestionnaire;
+
+void runQuestionnaire(lifecycleContext, {
+	questions: questionnaireQuestions,
+	onUnsupportedMode: async (ctx) => {
+		ctx.isIdle();
+		// @ts-expect-error Lifecycle questionnaires must not gain command-only session methods.
+		await ctx.waitForIdle();
+	},
 });
 
 const confirmationGatedItem: LiveChoiceItem<"one"> = {

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -41,7 +41,7 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("package exposes API version 13 and Markdown document types", () => {
+test("package exposes API version 14 and Markdown document types", () => {
 	const markdown: ReviewFormat = {
 		kind: "markdown",
 		renderLatex: false,
@@ -56,9 +56,9 @@ test("package exposes API version 13 and Markdown document types", () => {
 		label: "Schema",
 		detailDocument: document,
 	};
-	const apiVersion: 13 = PI_EXTENSION_MENU_API_VERSION;
+	const apiVersion: 14 = PI_EXTENSION_MENU_API_VERSION;
 	assert.equal(item.detailDocument, document);
-	assert.equal(apiVersion, 13);
+	assert.equal(apiVersion, 14);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/package-exports.test.ts
+++ b/packages/pi-tui-kit/test/package-exports.test.ts
@@ -15,12 +15,13 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 	const interactionHints = await import(interactionHintsSpecifier);
 	const terminalText = await import(terminalTextSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 13);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 14);
 	assert.equal(typeof production.sanitizeTerminalText, "function");
 	assert.equal(typeof production.formatInteractionHints, "function");
 	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");
 	assert.equal(typeof production.runLiveChoice, "function");
+	assert.equal(typeof production.runQuestionnaire, "function");
 	assert.equal("createTuiHarness" in production, false);
 	assert.equal("createRpcHarness" in production, false);
 	assert.deepEqual(Object.keys(interactionHints), ["formatInteractionHints"]);
@@ -33,11 +34,11 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 	t.onTestFinished(() => rmSync(fixture, { recursive: true, force: true }));
 	writeFileSync(
 		path.join(fixture, "usage.ts"),
-		`import { PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type ChoiceScreen, type LiveChoiceItem, type MenuBrowseItem, type ReviewFormat } from "@narumitw/pi-tui-kit";\n` +
+		`import { PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type ChoiceScreen, type LiveChoiceItem, type MenuBrowseItem, type QuestionnaireAnswer, type QuestionnaireQuestion, type ReviewFormat, type RunQuestionnaireResult } from "@narumitw/pi-tui-kit";\n` +
 			`import { formatInteractionHints, type FormatInteractionHintsOptions, type InteractionHint, type InteractionKeybindings } from "@narumitw/pi-tui-kit/interaction-hints";\n` +
 			`import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 13 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const version: 14 = PI_EXTENSION_MENU_API_VERSION;\n` +
 			`const keybindings: InteractionKeybindings<"confirm"> = { getKeys: () => ["return"] };\n` +
 			`const hints: InteractionHint<"confirm">[] = [{ bindings: ["confirm"], label: sanitizeTerminalText("apply") }];\n` +
 			`const hintOptions: FormatInteractionHintsOptions = { separator: "·" };\n` +
@@ -47,7 +48,10 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 			`const item: MenuBrowseItem = { id: "one", label: "One", detailDocument: document };\n` +
 			`const choice: LiveChoiceItem = { id: "active", label: "Active", confirmationDisabled: true, confirmationDisabledReason: "Already active" };\n` +
 			`const screen: ChoiceScreen<"select"> = { kind: "choice", title: "Records", enableSearch: true, items: [{ id: "one", label: "One", searchText: "alias" }], action: "select" };\n` +
-			`void version;\nvoid formattedHints;\nvoid item;\nvoid choice;\nvoid screen;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
+			`const question: QuestionnaireQuestion<"scope"> = { id: "scope", header: "Scope", prompt: "How broad?", options: [{ label: "Small" }] };\n` +
+			`const answer: QuestionnaireAnswer<"scope"> = { questionId: "scope", answer: "Small", wasCustom: false, optionIndex: 1 };\n` +
+			`const questionnaireResult: RunQuestionnaireResult<"scope"> = { kind: "submitted", answers: [answer] };\n` +
+			`void version;\nvoid formattedHints;\nvoid item;\nvoid choice;\nvoid screen;\nvoid question;\nvoid questionnaireResult;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
 	);
 	writeFileSync(
 		path.join(fixture, "tsconfig.json"),

--- a/packages/pi-tui-kit/test/questionnaire.test.ts
+++ b/packages/pi-tui-kit/test/questionnaire.test.ts
@@ -1,0 +1,691 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import {
+	CURSOR_MARKER,
+	getKeybindings,
+	type KeybindingsConfig,
+	KeybindingsManager,
+	setKeybindings,
+	TUI_KEYBINDINGS,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { type QuestionnaireQuestion, runQuestionnaire } from "../src/questionnaire.js";
+import { createTuiHarness } from "../src/testing/index.js";
+
+const questions = [
+	{
+		id: "scope",
+		header: "Scope",
+		prompt: "How broad?",
+		options: [
+			{ label: "Small", description: "Only the bug." },
+			{ label: "Broad", description: "Include cleanup." },
+		],
+	},
+	{
+		id: "tests",
+		header: "Tests",
+		prompt: "Which checks?",
+		options: [
+			{ label: "Focused", description: "Run focused checks." },
+			{ label: "Full", description: "Run all checks." },
+		],
+	},
+] as const satisfies readonly QuestionnaireQuestion[];
+
+const MAX_TEXT_LENGTH = 4_000;
+
+function tuiRun(customQuestions: readonly QuestionnaireQuestion[] = questions, width = 60) {
+	const tui = createTuiHarness({
+		width,
+		rows: 30,
+		keybindings: new KeybindingsManager(TUI_KEYBINDINGS),
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runQuestionnaire(context.ctx, {
+		questions: customQuestions,
+		allowNotes: true,
+		maxTextLength: MAX_TEXT_LENGTH,
+	});
+	return { tui, context, running };
+}
+
+function paste(tui: ReturnType<typeof createTuiHarness>, text: string) {
+	tui.send(`\u001b[200~${text}\u001b[201~`);
+}
+
+test("runQuestionnaire validates generic input and unsupported modes", async () => {
+	const invalidContext = createMockContext({ mode: "tui", hasUI: true });
+	const invalid = await runQuestionnaire(invalidContext.ctx, { questions: [] });
+	assert.equal(invalid.kind, "error");
+	assert.match(invalidContext.notifications[0]?.message ?? "", /at least one question/u);
+
+	const duplicate = await runQuestionnaire(invalidContext.ctx, {
+		questions: [questions[0], questions[0]],
+	});
+	assert.equal(duplicate.kind, "error");
+	assert.match(invalidContext.notifications.at(-1)?.message ?? "", /Duplicate questionnaire/u);
+
+	const invisible = await runQuestionnaire(invalidContext.ctx, {
+		questions: [{ ...questions[0], prompt: "\u001b[31m" }],
+	});
+	assert.equal(invisible.kind, "error");
+	assert.match(invalidContext.notifications.at(-1)?.message ?? "", /displayable prompt/u);
+
+	const modes: string[] = [];
+	const printContext = createMockContext({ mode: "print", hasUI: false });
+	assert.deepEqual(
+		await runQuestionnaire(printContext.ctx, {
+			questions,
+			onUnsupportedMode: (_ctx, mode) => {
+				modes.push(mode);
+			},
+		}),
+		{ kind: "unsupported", mode: "print" },
+	);
+	assert.deepEqual(modes, ["print"]);
+});
+
+test("runQuestionnaire preserves select framing, theme hierarchy, and read-only review", async () => {
+	const foreground: Array<{ color: string; text: string }> = [];
+	const bold: string[] = [];
+	const tui = createTuiHarness({
+		width: 60,
+		rows: 30,
+		keybindings: new KeybindingsManager(TUI_KEYBINDINGS),
+		theme: {
+			fg: (color, text) => {
+				foreground.push({ color: String(color), text });
+				return text;
+			},
+			bold: (text) => {
+				bold.push(text);
+				return text;
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runQuestionnaire(context.ctx, {
+		questions,
+		allowNotes: true,
+	});
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	const questionFrame = tui.render();
+	assert.equal(questionFrame[0], "─".repeat(60));
+	assert.equal(questionFrame.at(-1), "─".repeat(60));
+	assert.ok(
+		foreground.some(
+			({ color, text }) => color === "accent" && text === "→ 1. Small — Only the bug.",
+		),
+	);
+	assert.ok(
+		foreground.some(({ color, text }) => color === "muted" && text === " — Include cleanup."),
+	);
+	assert.ok(bold.includes("How broad?"));
+	assert.match(questionFrame.join("\n"), /↑↓ navigate {2}enter select {2}escape\/ctrl\+c cancel/u);
+	assert.doesNotMatch(questionFrame.join("\n"), /[○●]/u);
+	tui.invalidate();
+	assert.deepEqual(tui.render(), questionFrame);
+
+	tui.send("\u001b[C");
+	tui.send("\u001b[C");
+	foreground.length = 0;
+	bold.length = 0;
+	const review = tui.render().join("\n");
+	assert.match(review, /\n 1\. Scope — Unanswered\n 2\. Tests — Unanswered/u);
+	assert.doesNotMatch(review, /→ [12]\./u);
+	assert.match(review, /enter submit/u);
+	assert.doesNotMatch(review, /n note/u);
+	assert.ok(bold.includes("Review answers"));
+	const unchanged = tui.render().join("\n");
+	tui.press("tui.select.down");
+	assert.equal(tui.render().join("\n"), unchanged);
+	tui.dispose();
+	assert.deepEqual(await running, { kind: "stale" });
+});
+
+test("runQuestionnaire uses configured standard actions before additive shortcuts", async () => {
+	const bindings = {
+		"tui.input.newLine": { data: "\u001b[13;3u", key: "alt+enter" },
+		"tui.input.submit": { data: "\u0013", key: "ctrl+s" },
+		"tui.input.tab": { data: "t", key: "t" },
+		"tui.select.cancel": { data: "q", key: "q" },
+		"tui.select.confirm": { data: "x", key: "x" },
+		"tui.select.down": { data: "s", key: "s" },
+		"tui.select.up": { data: "w", key: "w" },
+	} as const;
+	const tui = createTuiHarness({
+		width: 120,
+		rows: 30,
+		keybindings: {
+			matches: (data, binding) => bindings[binding as keyof typeof bindings]?.data === data,
+			getKeys: (binding) => {
+				const configured = bindings[binding as keyof typeof bindings];
+				return configured ? [configured.key] : [];
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runQuestionnaire(context.ctx, { questions, allowNotes: true });
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	assert.match(
+		tui.render().join("\n"),
+		/w\/s navigate {2}x select {2}q\/ctrl\+c cancel {2}t\/shift\+tab\/←→ questions {2}n note/u,
+	);
+	tui.send("j");
+	assert.match(tui.render().join("\n"), /→ 2\. Broad/u);
+	tui.send("k");
+	assert.match(tui.render().join("\n"), /→ 1\. Small/u);
+	tui.send("s");
+	tui.send("t");
+	assert.match(tui.render().join("\n"), /\[Tests\]/u);
+	tui.send("\u001b[D");
+	tui.send("x");
+	tui.send("x");
+	assert.match(tui.render().join("\n"), /x submit {2}q\/ctrl\+c cancel/u);
+	tui.send("\n");
+	assert.equal(tui.isOpen, true);
+	tui.send("q");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});
+
+test("runQuestionnaire gives configured standard actions priority over additive shortcuts", async () => {
+	const bindings = {
+		"tui.input.tab": { data: "j", key: "j" },
+		"tui.select.cancel": { data: "q", key: "q" },
+		"tui.select.confirm": { data: "x", key: "x" },
+		"tui.select.down": { data: "n", key: "n" },
+		"tui.select.up": { data: "w", key: "w" },
+	} as const;
+	const tui = createTuiHarness({
+		keybindings: {
+			matches: (data, binding) => bindings[binding as keyof typeof bindings]?.data === data,
+			getKeys: (binding) => {
+				const configured = bindings[binding as keyof typeof bindings];
+				return configured ? [configured.key] : [];
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runQuestionnaire(context.ctx, { questions, allowNotes: true });
+	await tui.waitForOpen();
+	assert.doesNotMatch(tui.render().join("\n"), /n note/u);
+	tui.send("j");
+	assert.match(tui.render().join("\n"), /\[Tests\]/u);
+	tui.send("\u001b[D");
+	tui.send("n");
+	assert.match(tui.render().join("\n"), /→ 2\. Broad/u);
+	assert.doesNotMatch(tui.render().join("\n"), /Optional note/u);
+	tui.send("q");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});
+
+test("runQuestionnaire distinguishes Back, Close, owner abort, disposal, and stale owners", async () => {
+	async function drive(exit: "tui.select.cancel" | "ctrl+c") {
+		const { tui, running } = tuiRun([questions[0]]);
+		await tui.waitForOpen();
+		tui.press(exit);
+		return running;
+	}
+	assert.deepEqual(await drive("tui.select.cancel"), { kind: "closed", reason: "back" });
+	assert.deepEqual(await drive("ctrl+c"), { kind: "closed", reason: "close" });
+
+	const owner = new AbortController();
+	const abortTui = createTuiHarness();
+	const abortContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: abortTui.custom,
+	});
+	const aborted = runQuestionnaire(abortContext.ctx, {
+		questions,
+		signal: owner.signal,
+	});
+	await abortTui.waitForOpen();
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await aborted, { kind: "stale" });
+	assert.equal(abortTui.isOpen, false);
+
+	const disposedTui = createTuiHarness();
+	const disposedContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: disposedTui.custom,
+	});
+	const disposed = runQuestionnaire(disposedContext.ctx, { questions });
+	await disposedTui.waitForOpen();
+	disposedTui.dispose();
+	assert.deepEqual(await disposed, { kind: "stale" });
+
+	let current = true;
+	const staleTui = createTuiHarness();
+	const staleContext = createMockContext({ mode: "tui", hasUI: true, custom: staleTui.custom });
+	const stale = runQuestionnaire(staleContext.ctx, {
+		questions,
+		isCurrent: () => current,
+	});
+	await staleTui.waitForOpen();
+	current = false;
+	staleTui.press("tui.select.confirm");
+	assert.deepEqual(await stale, { kind: "stale" });
+});
+
+test("runQuestionnaire replaces answers, edits notes, accepts custom text, and submits in order", async () => {
+	const { tui, running } = tuiRun();
+	await tui.waitForOpen();
+	tui.setFocused(true);
+
+	tui.type("n");
+	paste(tui, "initial note");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.send("\u001b[D");
+	assert.doesNotMatch(tui.render().join("\n"), /initial note/u);
+	tui.send("\u001b[C");
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	paste(tui, "  custom answer  ");
+	tui.press("tui.input.submit");
+	tui.send("\u001b[D");
+	tui.send("\u001b[D");
+	tui.type("n");
+	paste(tui, "final note");
+	tui.press("tui.input.submit");
+	tui.send("\u001b[C");
+	tui.send("\u001b[C");
+	assert.match(tui.render().join("\n"), /1\. Scope — Broad · Note: final note/u);
+	tui.press("tui.select.confirm");
+
+	assert.deepEqual(await running, {
+		kind: "submitted",
+		answers: [
+			{
+				questionId: "scope",
+				answer: "Broad",
+				wasCustom: false,
+				optionIndex: 2,
+				note: "final note",
+			},
+			{ questionId: "tests", answer: "  custom answer  ", wasCustom: true },
+		],
+	});
+});
+
+test("runQuestionnaire restores the recorded answer cursor when revisiting a question", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.send("\u001b[D");
+	assert.match(tui.render().join("\n"), /→ 2\. Broad ✓/u);
+	tui.press("tui.select.up");
+	tui.send("\u001b[C");
+	tui.send("\u001b[D");
+	assert.match(tui.render().join("\n"), /→ 2\. Broad ✓/u);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});
+
+test("runQuestionnaire preserves a custom answer note while editing the answer", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	paste(tui, "first answer");
+	tui.press("tui.input.submit");
+	tui.send("\u001b[D");
+	tui.type("n");
+	paste(tui, "keep this note");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+	tui.send("\u0015");
+	paste(tui, "edited answer");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, {
+		kind: "submitted",
+		answers: [
+			{
+				questionId: "scope",
+				answer: "edited answer",
+				wasCustom: true,
+				note: "keep this note",
+			},
+		],
+	});
+});
+
+test("runQuestionnaire blocks incomplete review submission and keeps note edits on questions", async () => {
+	const { tui, running } = tuiRun();
+	await tui.waitForOpen();
+	tui.send("\u001b[C");
+	tui.send("\u001b[C");
+	tui.press("tui.select.confirm");
+	assert.match(tui.render().join("\n"), /Answer every question before submitting/u);
+	tui.type("n");
+	assert.match(tui.render().join("\n"), /Return to a question to add or edit its note/u);
+	tui.press("tui.select.cancel");
+	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});
+
+test("runQuestionnaire preserves raw pasted text while sanitizing every rendered width", async () => {
+	const unsafeAnswer = "raw\u007f\u001b]8;;https://evil.example\u0007text\u202ereversed";
+	const unsafeNote = "note\u009bcontrol\u202aspoofed";
+	const malicious = [
+		{
+			id: "unsafe",
+			header: "Head\u001b[31m",
+			prompt: "Prompt\u001b]8;;https://evil.example\u0007text",
+			options: [
+				{ label: "safe", description: "first" },
+				{ label: "other", description: "second" },
+			],
+		},
+	] as const;
+	const { tui, running } = tuiRun(malicious, 16);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	for (const width of [1, 8, 16, 24]) {
+		const frame = tui.resize({ width });
+		for (const line of frame) assert.ok(visibleWidth(line) <= width);
+		assert.equal(stripVTControlCharacters(frame.join("\n")).includes("evil.example"), false);
+	}
+	tui.resize({ width: 40 });
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	paste(tui, unsafeAnswer);
+	assert.equal(tui.render().join("\n").includes("\u202e"), false);
+	for (const width of [1, 8, 16]) {
+		for (const line of tui.resize({ width })) assert.ok(visibleWidth(line) <= width);
+	}
+	tui.resize({ width: 40 });
+	tui.press("tui.input.submit");
+	for (const width of [1, 8, 16]) {
+		for (const line of tui.resize({ width })) assert.ok(visibleWidth(line) <= width);
+	}
+	tui.resize({ width: 40 });
+	tui.send("\u001b[D");
+	tui.type("n");
+	paste(tui, unsafeNote);
+	assert.equal(tui.render().join("\n").includes("\u202a"), false);
+	tui.press("tui.input.submit");
+	tui.send("\u001b[C");
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, {
+		kind: "submitted",
+		answers: [
+			{
+				questionId: "unsafe",
+				answer: unsafeAnswer,
+				wasCustom: true,
+				note: unsafeNote,
+			},
+		],
+	});
+});
+
+test("runQuestionnaire keeps Backspace as editing and forwards Editor focus", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	assert.equal(tui.render().join("\n").includes(CURSOR_MARKER), true);
+	tui.type("wrongx");
+	tui.send("\u007f");
+	tui.press("tui.input.submit");
+	tui.send("\u001b[D");
+	tui.type("n");
+	tui.type("note!");
+	tui.send("\u007f");
+	tui.press("tui.input.submit");
+	tui.send("\u001b[C");
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, {
+		kind: "submitted",
+		answers: [{ questionId: "scope", answer: "wrong", wasCustom: true, note: "note" }],
+	});
+});
+
+test("runQuestionnaire keeps configured newline distinct from submit", async (t) => {
+	const previous = getKeybindings();
+	t.onTestFinished(() => setKeybindings(previous));
+	const userBindings = {
+		"tui.input.newLine": "alt+enter",
+		"tui.input.submit": "ctrl+s",
+	} satisfies KeybindingsConfig;
+	const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, userBindings);
+	setKeybindings(keybindings);
+	const tui = createTuiHarness({ keybindings });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runQuestionnaire(context.ctx, { questions: [questions[0]] });
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.type("first");
+	tui.send("\u001b\r");
+	tui.type("second");
+	tui.send("\u0013");
+	assert.match(tui.render().join("\n"), /first ↵ second/u);
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, {
+		kind: "submitted",
+		answers: [{ questionId: "scope", answer: "first\nsecond", wasCustom: true }],
+	});
+});
+
+test("runQuestionnaire rejects empty and oversized custom text without closing", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	tui.type("   ");
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /cannot be empty/u);
+	tui.send("\u0015");
+	paste(tui, "x".repeat(MAX_TEXT_LENGTH + 1));
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /4,000 characters or fewer/u);
+	assert.equal(tui.isOpen, true);
+	tui.press("ctrl+c");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+});
+
+test("runQuestionnaire rejects oversized optional notes without closing", async () => {
+	const { tui, running } = tuiRun([questions[0]]);
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("n");
+	paste(tui, "x".repeat(MAX_TEXT_LENGTH + 1));
+	tui.press("tui.input.submit");
+	assert.match(tui.render().join("\n"), /Note must be 4,000 characters or fewer/u);
+	assert.equal(tui.isOpen, true);
+	tui.press("ctrl+c");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+});
+
+test("runQuestionnaire applies a custom note label to editing and review", async () => {
+	const tui = createTuiHarness({ keybindings: new KeybindingsManager(TUI_KEYBINDINGS) });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runQuestionnaire(context.ctx, {
+		questions: [questions[0]],
+		allowNotes: true,
+		labels: { note: "Context", optionalNote: "Optional context" },
+	});
+	await tui.waitForOpen();
+	tui.setFocused(true);
+	tui.type("n");
+	assert.match(tui.render().join("\n"), /Optional context/u);
+	tui.type("why");
+	tui.press("tui.input.submit");
+	tui.press("tui.select.confirm");
+	assert.match(tui.render().join("\n"), /Context: why/u);
+	tui.press("tui.select.confirm");
+	assert.equal((await running).kind, "submitted");
+});
+
+test("runQuestionnaire can disable custom answers and notes while applying generic labels", async () => {
+	const tui = createTuiHarness({ keybindings: new KeybindingsManager(TUI_KEYBINDINGS) });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runQuestionnaire(context.ctx, {
+		questions: [questions[0]],
+		allowCustomAnswer: false,
+		allowNotes: false,
+		labels: { reviewTab: "Check", reviewTitle: "Check response" },
+	});
+	await tui.waitForOpen();
+	const questionFrame = tui.render().join("\n");
+	assert.match(questionFrame, /Check/u);
+	assert.doesNotMatch(questionFrame, /Other|n note/u);
+	tui.press("tui.select.confirm");
+	assert.match(tui.render().join("\n"), /Check response/u);
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, {
+		kind: "submitted",
+		answers: [{ questionId: "scope", answer: "Small", wasCustom: false, optionIndex: 1 }],
+	});
+});
+
+test("runQuestionnaire preserves the sequential RPC fallback and retries custom answers", async () => {
+	const selections = ["1. Small — Only the bug.", "3. Other (free-form)"];
+	const editorAnswers = ["x".repeat(MAX_TEXT_LENGTH + 1), "rpc custom"];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => selections.shift(),
+		editor: async () => editorAnswers.shift(),
+		custom: async () => assert.fail("RPC must not open custom TUI"),
+	});
+	const result = await runQuestionnaire(context.ctx, {
+		questions,
+		allowNotes: true,
+		maxTextLength: MAX_TEXT_LENGTH,
+	});
+	assert.deepEqual(result, {
+		kind: "submitted",
+		answers: [
+			{ questionId: "scope", answer: "Small", wasCustom: false, optionIndex: 1 },
+			{ questionId: "tests", answer: "rpc custom", wasCustom: true },
+		],
+	});
+	assert.ok(context.notifications.some(({ message }) => message.includes("4,000")));
+});
+
+test("runQuestionnaire preserves an empty custom answer returned by the RPC editor", async () => {
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => "3. Other (free-form)",
+		editor: async () => "",
+	});
+	assert.deepEqual(
+		await runQuestionnaire(context.ctx, {
+			questions: [questions[0]],
+			maxTextLength: MAX_TEXT_LENGTH,
+		}),
+		{
+			kind: "submitted",
+			answers: [{ questionId: "scope", answer: "", wasCustom: true }],
+		},
+	);
+});
+
+test("runQuestionnaire aborts an owned pending RPC selector", async () => {
+	const owner = new AbortController();
+	let observedSignal: AbortSignal | undefined;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (_title: string, _options: string[], dialog?: { signal?: AbortSignal }) => {
+			observedSignal = dialog?.signal;
+			await new Promise<void>((resolve) => {
+				if (dialog?.signal?.aborted) resolve();
+				else dialog?.signal?.addEventListener("abort", () => resolve(), { once: true });
+			});
+			return undefined;
+		},
+	});
+	const running = runQuestionnaire(context.ctx, { questions, signal: owner.signal });
+	await Promise.resolve();
+	owner.abort(new DOMException("Session replaced", "AbortError"));
+	assert.deepEqual(await running, { kind: "stale" });
+	assert.equal(observedSignal, owner.signal);
+});
+
+test("runQuestionnaire handles RPC cancellation, stale awaits, dialog errors, and invalid responses", async () => {
+	const cancelledContext = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => undefined,
+	});
+	assert.deepEqual(await runQuestionnaire(cancelledContext.ctx, { questions }), {
+		kind: "closed",
+		reason: "back",
+	});
+
+	let current = true;
+	const staleContext = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			current = false;
+			return "1. Small — Only the bug.";
+		},
+	});
+	assert.deepEqual(
+		await runQuestionnaire(staleContext.ctx, { questions, isCurrent: () => current }),
+		{ kind: "stale" },
+	);
+
+	let editorCurrent = true;
+	const staleEditorContext = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => "3. Other (free-form)",
+		editor: async () => {
+			editorCurrent = false;
+			return "late answer";
+		},
+	});
+	assert.deepEqual(
+		await runQuestionnaire(staleEditorContext.ctx, {
+			questions: [questions[0]],
+			isCurrent: () => editorCurrent,
+		}),
+		{ kind: "stale" },
+	);
+
+	const failedContext = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			throw new Error("dialog unavailable");
+		},
+	});
+	const failed = await runQuestionnaire(failedContext.ctx, { questions });
+	assert.equal(failed.kind, "error");
+	assert.match(failedContext.notifications[0]?.message ?? "", /dialog unavailable/u);
+
+	const invalidContext = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => "not offered",
+	});
+	const invalid = await runQuestionnaire(invalidContext.ctx, { questions });
+	assert.equal(invalid.kind, "error");
+	assert.match(invalidContext.notifications[0]?.message ?? "", /not offered/u);
+});

--- a/packages/pi-tui-kit/test/readme-usage.ts
+++ b/packages/pi-tui-kit/test/readme-usage.ts
@@ -9,9 +9,11 @@ import {
 	type MultiSelectScreen,
 	type ReviewScreen,
 	type RunLiveChoiceResult,
+	type RunQuestionnaireResult,
 	runCustomInteraction,
 	runLiveChoice,
 	runMenu,
+	runQuestionnaire,
 } from "../src/index.js";
 import { createRpcHarness, createTuiHarness } from "../src/testing/index.js";
 
@@ -192,6 +194,29 @@ export function showSpecializedView(ctx: ExtensionCommandContext, generation: nu
 				},
 			};
 		},
+	});
+}
+
+export async function askReleaseQuestions(
+	ctx: ExtensionCommandContext,
+	generation: number,
+): Promise<RunQuestionnaireResult<"scope">> {
+	return runQuestionnaire(ctx, {
+		questions: [
+			{
+				id: "scope",
+				header: "Scope",
+				prompt: "How broad should this release be?",
+				options: [
+					{ label: "Patch", description: "Ship only the fix" },
+					{ label: "Minor", description: "Include compatible features" },
+				],
+			},
+		],
+		allowNotes: true,
+		maxTextLength: 4_000,
+		signal: currentSessionSignal(),
+		isCurrent: () => generation === currentGeneration(),
 	});
 }
 


### PR DESCRIPTION
## Summary

- Add a generic `runQuestionnaire()` API with typed Submitted, Back, Close, Stale, Unsupported, and Error outcomes.
- Preserve Pi selector styling, effective keybindings, raw editor input, optional notes, read-only review, terminal safety, and width-safe rendering in TUI mode.
- Preserve the existing sequential `select()` and `editor()` RPC behavior while keeping domain validation and result mapping consumer-owned.
- Export API version 14, document the runner, and add a minor Kit changeset.

## API admission

`pi-plan-mode` and `pi-workflow` provide two independently published compatible consumers, and their current questionnaire source implementations are byte-identical.
This pull request adds only the Kit API and does not raise either consumer's compatibility floor.
Consumer migration remains blocked until a later explicitly approved Kit publication is visible on npm.

## Verification

- `npm --workspace @narumitw/pi-tui-kit run check`
- `npx vitest run packages/pi-tui-kit/test/questionnaire.test.ts packages/pi-tui-kit/test/custom-interaction.test.ts packages/pi-tui-kit/test/package-exports.test.ts packages/pi-tui-kit/test/menu-model.test.ts` (4 files and 44 tests passed)
- `npm run check`
- `PI_EXTENSIONS_BUILD_READY=1 npm test` (396 files and 3,754 tests passed)
- `npm run changeset:status` (the new changeset names only `@narumitw/pi-tui-kit`; existing main-branch changesets remain visible)
- `just pack tui-kit` (69 files; built JavaScript, declarations, README, license, and metadata inspected)
- Built questionnaire output contains no runtime `pi-coding-agent` import and lazy-loads the specialized component only for TUI use.

## Risk

Pi's RPC editor API does not accept an abort signal, so owner cancellation while that editor is open is classified as stale after the editor closes.
This limitation is documented and covered by stale-after-await behavior.

## Release

No package was published, no version tag was created, and no release workflow was dispatched.
