### PR TITLE
fix(pi-tui-kit): keep questionnaire hints accurate

### DIFF
--- a/.changeset/neat-questionnaire-hints.md
+++ b/.changeset/neat-questionnaire-hints.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": patch
+---
+
+Keep questionnaire hints visible at narrow widths and omit conflicting additive page keys.

--- a/packages/pi-tui-kit/src/components/questionnaire.ts
+++ b/packages/pi-tui-kit/src/components/questionnaire.ts
@@ -94,7 +94,7 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 		if (this.message) {
 			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), contentWidth));
 		}
-		lines.push("", truncateToWidth(this.renderHints(), contentWidth), "", border);
+		lines.push("", ...wrapHintGroups(this.renderHintGroups(), contentWidth), "", border);
 		return lines.map((line) => {
 			if (!line || line === border) return line;
 			return `${padding}${truncateToWidth(line, contentWidth)}`;
@@ -186,7 +186,7 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 		}
 	}
 
-	private renderHints(): string {
+	private renderHintGroups(): string[] {
 		const { keybindings, theme } = this.options;
 		const cancel = cancelHint(theme, keybindings);
 		if (this.editorKind) {
@@ -194,7 +194,7 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 				keybindingHint(theme, keybindings, "tui.input.submit", "save"),
 				keybindingHint(theme, keybindings, "tui.input.newLine", "newline"),
 				cancel,
-			].join("  ");
+			];
 		}
 		const questions = rawKeyHint(theme, questionNavigationKeys(keybindings), "questions");
 		if (this.isReviewPage()) {
@@ -202,7 +202,7 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 				keybindingHint(theme, keybindings, "tui.select.confirm", "submit"),
 				cancel,
 				questions,
-			].join("  ");
+			];
 		}
 		return [
 			rawKeyHint(theme, selectionNavigationKeys(keybindings), "navigate"),
@@ -212,7 +212,7 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 			...(this.options.allowNotes && noteShortcutAvailable(keybindings)
 				? [rawKeyHint(theme, "n", "note")]
 				: []),
-		].join("  ");
+		];
 	}
 
 	private movePage(delta: number): void {
@@ -699,7 +699,21 @@ function selectionNavigationKeys(keybindings: KeybindingsManager): string {
 }
 
 function questionNavigationKeys(keybindings: KeybindingsManager): string {
-	return formatHintKeys([...keybindings.getKeys("tui.input.tab"), "shift+tab", "←→"]);
+	const conflictingKeys = new Set(
+		["tui.select.cancel", "tui.select.up", "tui.select.down", "tui.select.confirm"].flatMap(
+			(binding) => keybindings.getKeys(binding as QuestionnaireKeybinding),
+		),
+	);
+	const keys: string[] = keybindings
+		.getKeys("tui.input.tab")
+		.filter((key) => !conflictingKeys.has(key));
+	const left = !conflictingKeys.has("left");
+	const right = !conflictingKeys.has("right");
+	if (!conflictingKeys.has("shift+tab")) keys.push("shift+tab");
+	if (left && right) keys.push("←→");
+	else if (left) keys.push("←");
+	else if (right) keys.push("→");
+	return formatHintKeys(keys);
 }
 
 function noteShortcutAvailable(keybindings: KeybindingsManager): boolean {
@@ -739,6 +753,28 @@ function labeledRaw(label: string, value: string, width: number, theme: Theme): 
 			? `${theme.fg("muted", prefix)}${line}`
 			: `${" ".repeat(visibleWidth(prefix))}${line}`,
 	);
+}
+
+function wrapHintGroups(groups: readonly string[], width: number): string[] {
+	const safeWidth = Math.max(1, width);
+	const lines: string[] = [];
+	let line = "";
+	for (const group of groups) {
+		const candidate = line ? `${line}  ${group}` : group;
+		if (line && visibleWidth(candidate) > safeWidth) {
+			lines.push(line);
+			line = "";
+		}
+		if (visibleWidth(group) <= safeWidth) {
+			line = line ? `${line}  ${group}` : group;
+			continue;
+		}
+		const wrapped = hardWrap(group, safeWidth);
+		lines.push(...wrapped.slice(0, -1));
+		line = wrapped.at(-1) ?? "";
+	}
+	if (line) lines.push(line);
+	return lines.length > 0 ? lines : [""];
 }
 
 function hardWrapWithIndent(value: string, width: number, indent: number): string[] {

--- a/packages/pi-tui-kit/src/components/questionnaire.ts
+++ b/packages/pi-tui-kit/src/components/questionnaire.ts
@@ -674,6 +674,7 @@ function keybindingHint(
 }
 
 function rawKeyHint(theme: Theme, keys: string, description: string): string {
+	if (!keys) return "";
 	return `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}`;
 }
 
@@ -760,6 +761,7 @@ function wrapHintGroups(groups: readonly string[], width: number): string[] {
 	const lines: string[] = [];
 	let line = "";
 	for (const group of groups) {
+		if (!group) continue;
 		const candidate = line ? `${line}  ${group}` : group;
 		if (line && visibleWidth(candidate) > safeWidth) {
 			lines.push(line);

--- a/packages/pi-tui-kit/test/questionnaire.test.ts
+++ b/packages/pi-tui-kit/test/questionnaire.test.ts
@@ -126,6 +126,7 @@ test("runQuestionnaire preserves select framing, theme hierarchy, and read-only 
 	);
 	assert.ok(bold.includes("How broad?"));
 	assert.match(questionFrame.join("\n"), /↑↓ navigate {2}enter select {2}escape\/ctrl\+c cancel/u);
+	assert.match(questionFrame.join("\n"), /tab\/shift\+tab\/←→ questions {2}n note/u);
 	assert.doesNotMatch(questionFrame.join("\n"), /[○●]/u);
 	tui.invalidate();
 	assert.deepEqual(tui.render(), questionFrame);
@@ -191,6 +192,25 @@ test("runQuestionnaire uses configured standard actions before additive shortcut
 	assert.equal(tui.isOpen, true);
 	tui.send("q");
 	assert.deepEqual(await running, { kind: "closed", reason: "back" });
+});
+
+test("runQuestionnaire omits additive page keys that conflict with standard actions", async () => {
+	const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+		"tui.select.confirm": "right",
+	});
+	const tui = createTuiHarness({ width: 80, rows: 30, keybindings });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runQuestionnaire(context.ctx, { questions });
+	await tui.waitForOpen();
+	const frame = tui.render().join("\n");
+	assert.match(frame, /right select/u);
+	assert.match(frame, /tab\/shift\+tab\/← questions/u);
+	assert.doesNotMatch(frame, /←→ questions/u);
+
+	tui.send("\u001b[C");
+	assert.match(tui.render().join("\n"), /✓ Scope {2}\[Tests\]/u);
+	tui.press("ctrl+c");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
 });
 
 test("runQuestionnaire gives configured standard actions priority over additive shortcuts", async () => {

--- a/packages/pi-tui-kit/test/questionnaire.test.ts
+++ b/packages/pi-tui-kit/test/questionnaire.test.ts
@@ -213,6 +213,22 @@ test("runQuestionnaire omits additive page keys that conflict with standard acti
 	assert.deepEqual(await running, { kind: "closed", reason: "close" });
 });
 
+test("runQuestionnaire omits question navigation when every additive key conflicts", async () => {
+	const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+		"tui.select.confirm": ["tab", "shift+tab", "left", "right"],
+	});
+	const tui = createTuiHarness({ width: 120, rows: 30, keybindings });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runQuestionnaire(context.ctx, { questions });
+	await tui.waitForOpen();
+	const frame = tui.render().join("\n");
+	assert.match(frame, /tab\/shift\+tab\/left\/right select/u);
+	assert.doesNotMatch(frame, / questions/u);
+
+	tui.press("ctrl+c");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+});
+
 test("runQuestionnaire gives configured standard actions priority over additive shortcuts", async () => {
 	const bindings = {
 		"tui.input.tab": { data: "j", key: "j" },


### PR DESCRIPTION
## Summary

- Wrap questionnaire hint groups instead of truncating later actions at common terminal widths.
- Omit additive page-navigation keys from the hint when an effective standard action has priority for that key.
- Omit hint groups whose effective key set is empty.
- Add regression coverage for 60-column hints, a remapped Right-arrow confirmation key, and fully unavailable additive navigation.

Follow-up to #879.

## Verification

- `npm --workspace @narumitw/pi-tui-kit run check`
- `npx vitest run packages/pi-tui-kit/test/questionnaire.test.ts packages/pi-tui-kit/test/custom-interaction.test.ts packages/pi-tui-kit/test/package-exports.test.ts packages/pi-tui-kit/test/menu-model.test.ts` (4 files, 46 tests passed)
- `npm run check`
- `PI_EXTENSIONS_BUILD_READY=1 npm test` (396 files, 3,756 tests passed on final run)
- `npm run changeset:status`
- `just pack tui-kit` (69 files; built JavaScript, declarations, README, license, and metadata inspected)

## Audit

Back, Close, owner abort, disposal, stale checks, editor input, and RPC behavior are unchanged.
The unrelated consumer migration plan remains untracked and is not part of this pull request.
