### PR TITLE
refactor(plan): reuse tui kit questionnaire runner

### DIFF
--- a/.changeset/calm-workflows-share.md
+++ b/.changeset/calm-workflows-share.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-workflow": patch
+---
+
+Reuse Pi TUI Kit's questionnaire runner for the integrated Plan mode question tool.

--- a/.changeset/quiet-plans-share.md
+++ b/.changeset/quiet-plans-share.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": patch
+---
+
+Reuse Pi TUI Kit's questionnaire runner while preserving Plan mode answer and lifecycle behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6463,7 +6463,7 @@
 			"version": "0.51.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1"
+				"@narumitw/pi-tui-kit": "^0.57.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.9",
@@ -6475,28 +6475,6 @@
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-plan-mode/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.49.3",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
-			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
-			"license": "MIT",
-			"dependencies": {
-				"highlight.js": "11.11.1"
-			},
-			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-plan-mode/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"packages/pi-recall": {
@@ -6816,7 +6794,7 @@
 			"version": "0.6.0",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1"
+				"@narumitw/pi-tui-kit": "^0.57.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.9",
@@ -6833,28 +6811,6 @@
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*",
 				"typebox": "*"
-			}
-		},
-		"packages/pi-workflow/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.49.3",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
-			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
-			"license": "MIT",
-			"dependencies": {
-				"highlight.js": "11.11.1"
-			},
-			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*"
-			}
-		},
-		"packages/pi-workflow/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"packages/pi-worktree": {

--- a/packages/pi-plan-mode/package.json
+++ b/packages/pi-plan-mode/package.json
@@ -50,6 +50,6 @@
 		"directory": "packages/pi-plan-mode"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1"
+		"@narumitw/pi-tui-kit": "^0.57.0"
 	}
 }

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -1,23 +1,12 @@
-import { stripVTControlCharacters } from "node:util";
-import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
-import {
-	type Component,
-	Editor,
-	type EditorTheme,
-	type Focusable,
-	Key,
-	matchesKey,
-	sliceByColumn,
-	type TUI,
-	truncateToWidth,
-	visibleWidth,
-} from "@earendil-works/pi-tui";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type {
+	QuestionnaireAnswer,
+	QuestionnaireQuestion,
+	RunQuestionnaireResult,
+} from "@narumitw/pi-tui-kit";
 
 export const PLAN_MODE_QUESTION_TOOL_NAME = "plan_mode_question";
 export const MAX_PLAN_MODE_RESPONSE_LENGTH = 4_000;
-
-const BRACKETED_PASTE_START = "\u001b[200~";
-const BRACKETED_PASTE_END = "\u001b[201~";
 
 export type PlanModeQuestionOption = {
 	label: string;
@@ -205,613 +194,74 @@ export async function askPlanModeQuestions(
 	ctx: ExtensionContext,
 	shouldContinue: () => boolean = () => true,
 ): Promise<PlanModeQuestionAnswer[] | undefined> {
-	if (ctx.mode === "tui") {
-		const answers = await ctx.ui.custom<PlanModeQuestionAnswer[] | undefined>(
-			(tui, theme, keybindings, done) =>
-				new PlanModeQuestionnaire({
-					questions,
-					tui,
-					theme,
-					keybindings,
-					shouldContinue,
-					signal: ctx.signal,
-					onDone: done,
-				}),
-		);
-		return shouldContinue() ? answers : undefined;
-	}
-	return askPlanModeQuestionsSequentially(questions, ctx, shouldContinue);
+	const { runQuestionnaire, sanitizeTerminalText } = await import("@narumitw/pi-tui-kit");
+	if (!shouldContinue()) return undefined;
+	const runnerQuestions: QuestionnaireQuestion<string>[] = questions.map((question, index) => ({
+		id: String(index),
+		header: displayText(question.header, `Question ${index + 1}`, sanitizeTerminalText),
+		prompt: displayText(question.question, `Question ${index + 1}`, sanitizeTerminalText),
+		options: question.options.map((option, optionIndex) => ({
+			...option,
+			label: displayText(option.label, `Option ${optionIndex + 1}`, sanitizeTerminalText),
+		})),
+	}));
+	const result = await runQuestionnaire(ctx, {
+		questions: runnerQuestions,
+		allowNotes: true,
+		maxTextLength: MAX_PLAN_MODE_RESPONSE_LENGTH,
+		signal: ctx.signal,
+		isCurrent: shouldContinue,
+	});
+	if (!shouldContinue()) return undefined;
+	return mapQuestionnaireResult(questions, result);
 }
 
-async function askPlanModeQuestionsSequentially(
+function mapQuestionnaireResult(
 	questions: PlanModeQuestion[],
-	ctx: ExtensionContext,
-	shouldContinue: () => boolean,
-): Promise<PlanModeQuestionAnswer[] | undefined> {
-	const answers: PlanModeQuestionAnswer[] = [];
-	for (const question of questions) {
-		const choices = question.options.map(formatPlanModeQuestionChoice);
-		const otherChoice = `${question.options.length + 1}. Other (free-form)`;
-		const choice = await ctx.ui.select(`${question.header}: ${question.question}`, [
-			...choices,
-			otherChoice,
-		]);
-		if (!shouldContinue() || !choice) return undefined;
-		if (choice === otherChoice) {
-			const customAnswer = await askCustomAnswer(question, ctx, shouldContinue);
-			if (customAnswer === undefined) return undefined;
-			answers.push(answerFor(question, customAnswer, { wasCustom: true }));
-			continue;
+	result: RunQuestionnaireResult<string>,
+): PlanModeQuestionAnswer[] | undefined {
+	if (result.kind !== "submitted") return undefined;
+	if (result.answers.length !== questions.length) {
+		throw new Error("Questionnaire returned an incomplete answer set");
+	}
+
+	const answers = new Map<number, QuestionnaireAnswer<string>>();
+	for (const answer of result.answers) {
+		const index = Number(answer.questionId);
+		if (!Number.isSafeInteger(index) || String(index) !== answer.questionId || !questions[index]) {
+			throw new Error("Questionnaire returned an answer for an unknown question");
 		}
-		const optionIndex = choices.indexOf(choice);
-		const option = question.options[optionIndex];
-		if (!option) return undefined;
-		answers.push(
-			answerFor(question, option.label, { wasCustom: false, optionIndex: optionIndex + 1 }),
-		);
-	}
-	return answers;
-}
-
-async function askCustomAnswer(
-	question: PlanModeQuestion,
-	ctx: ExtensionContext,
-	shouldContinue: () => boolean,
-): Promise<string | undefined> {
-	let draft = "";
-	for (;;) {
-		const customAnswer = await ctx.ui.editor(question.question, draft);
-		if (!shouldContinue() || !customAnswer?.trim()) return undefined;
-		if (customAnswer.length <= MAX_PLAN_MODE_RESPONSE_LENGTH) return customAnswer;
-		draft = customAnswer;
-		ctx.ui.notify("Custom answer must be 4,000 characters or fewer.", "warning");
-	}
-}
-
-interface QuestionnaireOptions {
-	questions: PlanModeQuestion[];
-	tui: TUI;
-	theme: Theme;
-	keybindings: KeybindingsManager;
-	shouldContinue(): boolean;
-	signal?: AbortSignal;
-	onDone(answers: PlanModeQuestionAnswer[] | undefined): void;
-}
-
-export class PlanModeQuestionnaire implements Component, Focusable {
-	private readonly options: QuestionnaireOptions;
-	private readonly editor: RawPreservingEditor;
-	private readonly answers: Array<PlanModeQuestionAnswer | undefined>;
-	private readonly selectedOptions: number[];
-	private page = 0;
-	private editorKind: "answer" | "note" | undefined;
-	private message: string | undefined;
-	private finished = false;
-	private removeAbort = () => {};
-	private _focused = false;
-
-	constructor(options: QuestionnaireOptions) {
-		this.options = options;
-		this.answers = options.questions.map(() => undefined);
-		this.selectedOptions = options.questions.map(() => 0);
-		const editorTheme: EditorTheme = {
-			borderColor: (text) => options.theme.fg("accent", text),
-			selectList: {
-				selectedPrefix: (text) => options.theme.fg("accent", text),
-				selectedText: (text) => options.theme.fg("accent", text),
-				description: (text) => options.theme.fg("muted", text),
-				scrollInfo: (text) => options.theme.fg("dim", text),
-				noMatch: (text) => options.theme.fg("warning", text),
-			},
-		};
-		this.editor = new RawPreservingEditor(options.tui, editorTheme);
-		this.editor.onChange = () => {
-			this.message = undefined;
-		};
-		this.editor.onSubmit = (text) => this.submitEditor(text);
-		if (options.signal) {
-			const abort = () => this.finish(undefined);
-			options.signal.addEventListener("abort", abort, { once: true });
-			this.removeAbort = () => options.signal?.removeEventListener("abort", abort);
-			if (options.signal.aborted) abort();
-		}
-	}
-
-	get focused(): boolean {
-		return this._focused;
-	}
-
-	set focused(value: boolean) {
-		this._focused = value;
-		this.editor.focused = value && this.editorKind !== undefined;
-	}
-
-	render(width: number): string[] {
-		const safeWidth = Math.max(1, width);
-		const padding = safeWidth > 1 ? " " : "";
-		const contentWidth = Math.max(1, safeWidth - visibleWidth(padding));
-		const border = this.options.theme.fg("border", "─".repeat(safeWidth));
-		const lines = [border, "", ...this.renderTabs(contentWidth), ""];
-		if (this.page === this.options.questions.length) lines.push(...this.renderReview(contentWidth));
-		else lines.push(...this.renderQuestion(contentWidth));
-		if (this.message)
-			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), contentWidth));
-		lines.push("");
-		lines.push(truncateToWidth(this.renderHints(), contentWidth), "", border);
-		return lines.map((line) => {
-			if (!line || line === border) return line;
-			return `${padding}${truncateToWidth(line, contentWidth)}`;
-		});
-	}
-
-	handleInput(data: string): void {
-		if (this.finished) return;
-		if (!this.options.shouldContinue() || this.isCancel(data)) {
-			this.finish(undefined);
-			return;
-		}
-		if (this.editorKind) this.handleEditorInput(data);
-		else this.handlePageInput(data);
-		this.options.tui.requestRender();
-	}
-
-	invalidate(): void {
-		this.editor.invalidate();
-	}
-
-	dispose(): void {
-		this.finish(undefined);
-	}
-
-	private isCancel(data: string): boolean {
-		return (
-			matchesKey(data, Key.ctrl("c")) || this.options.keybindings.matches(data, "tui.select.cancel")
-		);
-	}
-
-	private handleEditorInput(data: string): void {
-		const keybindings = this.options.keybindings;
-		if (keybindings.matches(data, "tui.input.newLine")) {
-			this.editor.handleInput(data);
-		} else if (keybindings.matches(data, "tui.input.submit")) {
-			this.submitEditor(this.editor.getExpandedText());
-		} else {
-			this.editor.handleInput(data);
-		}
-	}
-
-	private handlePageInput(data: string): void {
-		const keybindings = this.options.keybindings;
-		const review = this.page === this.options.questions.length;
-		if (keybindings.matches(data, "tui.select.up") || data === "k") {
-			if (!review) this.moveSelection(-1);
-			return;
-		}
-		if (keybindings.matches(data, "tui.select.down") || data === "j") {
-			if (!review) this.moveSelection(1);
-			return;
-		}
-		if (keybindings.matches(data, "tui.select.confirm")) {
-			this.submitPage();
-			return;
-		}
-		if (keybindings.matches(data, "tui.input.tab") || matchesKey(data, Key.right)) {
-			this.movePage(1);
-			return;
-		}
-		if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left)) {
-			this.movePage(-1);
-			return;
-		}
-		if (data.toLowerCase() === "n") {
-			if (review) this.message = "Return to a question to add or edit its note.";
-			else this.editNote();
-		}
-	}
-
-	private renderHints(): string {
-		const { keybindings, theme } = this.options;
-		const cancel = cancelHint(theme, keybindings);
-		if (this.editorKind) {
-			return [
-				keybindingHint(theme, keybindings, "tui.input.submit", "save"),
-				keybindingHint(theme, keybindings, "tui.input.newLine", "newline"),
-				cancel,
-			].join("  ");
-		}
-		const questions = rawKeyHint(theme, questionNavigationKeys(keybindings), "questions");
-		if (this.page === this.options.questions.length) {
-			return [
-				keybindingHint(theme, keybindings, "tui.select.confirm", "submit"),
-				cancel,
-				questions,
-			].join("  ");
-		}
-		return [
-			rawKeyHint(theme, selectionNavigationKeys(keybindings), "navigate"),
-			keybindingHint(theme, keybindings, "tui.select.confirm", "select"),
-			cancel,
-			questions,
-			rawKeyHint(theme, "n", "note"),
-		].join("  ");
-	}
-
-	private movePage(delta: number): void {
-		const pageCount = this.options.questions.length + 1;
-		this.page = (this.page + delta + pageCount) % pageCount;
-		const answer = this.answers[this.page];
-		const question = this.options.questions[this.page];
-		if (answer?.wasCustom && question) {
-			this.selectedOptions[this.page] = question.options.length;
-		} else if (answer?.optionIndex !== undefined) {
-			this.selectedOptions[this.page] = answer.optionIndex - 1;
-		}
-		this.message = undefined;
-	}
-
-	private renderTabs(width: number): string[] {
-		const tabs = [
-			...this.options.questions.map((question, index) => {
-				const label = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
-				const answered = this.answers[index] ? "✓ " : "";
-				return this.page === index ? `[${answered}${label}]` : `${answered}${label}`;
-			}),
-			this.page === this.options.questions.length ? "[Review]" : "Review",
-		];
-		const lines: string[] = [];
-		let line = "";
-		for (const tab of tabs) {
-			const boundedTab = truncateToWidth(tab, width, "…");
-			const candidate = line ? `${line}  ${boundedTab}` : boundedTab;
-			if (line && visibleWidth(candidate) > width) {
-				lines.push(this.options.theme.fg("accent", line));
-				line = boundedTab;
-			} else {
-				line = candidate;
+		if (answers.has(index)) throw new Error("Questionnaire returned duplicate answers");
+		if (answer.wasCustom) {
+			if (answer.optionIndex !== undefined) {
+				throw new Error("Questionnaire returned a custom answer with an option index");
 			}
-		}
-		if (line) lines.push(this.options.theme.fg("accent", line));
-		return lines;
-	}
-
-	private renderQuestion(width: number): string[] {
-		const question = this.options.questions[this.page];
-		if (!question) return [];
-		const lines = hardWrap(
-			this.options.theme.fg(
-				"accent",
-				this.options.theme.bold(sanitizeTerminalText(question.question)),
-			),
-			width,
-		);
-		lines.push("");
-		question.options.forEach((option, index) => {
-			const selected = this.selectedOptions[this.page] === index;
-			const cursor = selected ? "→" : " ";
-			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}`;
-			const chosen = this.answers[this.page]?.optionIndex === index + 1;
-			const description = option.description
-				? ` — ${sanitizeTerminalText(option.description)}`
-				: "";
-			const line = selected
-				? this.options.theme.fg("accent", `${label}${chosen ? " ✓" : ""}${description}`)
-				: `${this.options.theme.fg("text", label)}${
-						chosen ? this.options.theme.fg("success", " ✓") : ""
-					}${description ? this.options.theme.fg("muted", description) : ""}`;
-			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${cursor} ${index + 1}. `)));
-		});
-		const otherIndex = question.options.length;
-		const otherSelected = this.selectedOptions[this.page] === otherIndex;
-		const otherCursor = otherSelected ? "→" : " ";
-		const otherLabel = `${otherCursor} ${otherIndex + 1}. Other (free-form)`;
-		const otherChosen = this.answers[this.page]?.wasCustom === true;
-		lines.push(
-			otherSelected
-				? this.options.theme.fg("accent", `${otherLabel}${otherChosen ? " ✓" : ""}`)
-				: `${this.options.theme.fg("text", otherLabel)}${
-						otherChosen ? this.options.theme.fg("success", " ✓") : ""
-					}`,
-		);
-		const answer = this.answers[this.page];
-		if (answer?.wasCustom)
-			lines.push(...labeledRaw("Answer", answer.answer, width, this.options.theme));
-		if (answer?.note) lines.push(...labeledRaw("Note", answer.note, width, this.options.theme));
-		if (this.editorKind) {
-			lines.push("");
-			lines.push(
-				this.options.theme.fg(
-					"accent",
-					this.editorKind === "answer" ? "Custom answer" : "Optional note",
-				),
-			);
-			lines.push(...this.editor.render(width));
-		}
-		return lines;
-	}
-
-	private renderReview(width: number): string[] {
-		const lines = [this.options.theme.fg("accent", this.options.theme.bold("Review answers")), ""];
-		this.options.questions.forEach((question, index) => {
-			const answer = this.answers[index];
-			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
-			const label = `${index + 1}. ${header}`;
-			const summary = ` — ${inlineSummary(answer?.answer ?? "Unanswered")}${
-				answer?.note ? ` · Note: ${inlineSummary(answer.note)}` : ""
-			}`;
-			const line = `${this.options.theme.fg("text", label)}${this.options.theme.fg("muted", summary)}`;
-			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${index + 1}. `)));
-		});
-		return lines;
-	}
-
-	private moveSelection(delta: number): void {
-		const optionCount = (this.options.questions[this.page]?.options.length ?? 0) + 1;
-		this.selectedOptions[this.page] =
-			((this.selectedOptions[this.page] ?? 0) + delta + optionCount) % optionCount;
-	}
-
-	private submitPage(): void {
-		if (this.page === this.options.questions.length) {
-			const firstMissing = this.answers.findIndex((answer) => !answer);
-			if (firstMissing >= 0) {
-				this.message = "Answer every question before submitting.";
-				return;
-			}
-			this.finish(
-				this.answers.filter((answer): answer is PlanModeQuestionAnswer => answer !== undefined),
-			);
-			return;
-		}
-		const question = this.options.questions[this.page];
-		if (!question) return;
-		const selected = this.selectedOptions[this.page] ?? 0;
-		if (selected === question.options.length) {
-			this.beginEditor(
-				"answer",
-				this.answers[this.page]?.wasCustom ? this.answers[this.page]?.answer : "",
-			);
-			return;
-		}
-		const option = question.options[selected];
-		if (!option) return;
-		const previous = this.answers[this.page];
-		this.answers[this.page] = answerFor(question, option.label, {
-			wasCustom: false,
-			optionIndex: selected + 1,
-			note: previous?.optionIndex === selected + 1 ? previous.note : undefined,
-		});
-		this.advance();
-	}
-
-	private editNote(): void {
-		const index = this.page;
-		let answer = this.answers[index];
-		const question = this.options.questions[index];
-		const selected = this.selectedOptions[index] ?? 0;
-		if (question && selected === question.options.length && !answer?.wasCustom) {
-			this.beginEditor("answer", "");
-			return;
-		}
-		if (question && selected < question.options.length && answer?.optionIndex !== selected + 1) {
-			const option = question.options[selected];
-			if (option) {
-				answer = answerFor(question, option.label, {
-					wasCustom: false,
-					optionIndex: selected + 1,
-				});
-				this.answers[index] = answer;
-			}
-		}
-		if (!answer) {
-			this.message = "Select an answer before adding a note.";
-			return;
-		}
-		this.beginEditor("note", answer.note ?? "");
-	}
-
-	private beginEditor(kind: "answer" | "note", value: string | undefined): void {
-		this.editorKind = kind;
-		this.editor.setText(value ?? "");
-		this.editor.focused = this._focused;
-		this.message = undefined;
-	}
-
-	private submitEditor(value: string): void {
-		if (value.length > MAX_PLAN_MODE_RESPONSE_LENGTH) {
-			this.editor.setText(value);
-			this.message = `${this.editorKind === "answer" ? "Answer" : "Note"} must be 4,000 characters or fewer.`;
-			this.options.tui.requestRender();
-			return;
-		}
-		const index = this.page;
-		if (this.editorKind === "answer") {
-			if (!value.trim()) {
-				this.editor.setText(value);
-				this.message = "Custom answer cannot be empty.";
-				this.options.tui.requestRender();
-				return;
-			}
-			const question = this.options.questions[index];
-			if (!question) return;
-			const previous = this.answers[index];
-			this.answers[index] = answerFor(question, value, {
-				wasCustom: true,
-				note: previous?.wasCustom ? previous.note : undefined,
-			});
-			this.editor.setText("");
-			this.editorKind = undefined;
-			this.editor.focused = false;
-			this.advance();
-			return;
-		}
-		const answer = this.answers[index];
-		if (answer) answer.note = value.trim() ? value : undefined;
-		this.editor.setText("");
-		this.editorKind = undefined;
-		this.editor.focused = false;
-		this.message = value.trim() ? "Note saved." : "Note cleared.";
-		this.options.tui.requestRender();
-	}
-
-	private advance(): void {
-		this.page = Math.min(this.page + 1, this.options.questions.length);
-		this.message = undefined;
-	}
-
-	private finish(answers: PlanModeQuestionAnswer[] | undefined): void {
-		if (this.finished) return;
-		this.finished = true;
-		this.removeAbort();
-		this.removeAbort = () => {};
-		this.editor.focused = false;
-		this.options.onDone(answers);
-	}
-}
-
-class RawPreservingEditor implements Focusable {
-	private readonly editor: Editor;
-	private readonly rawByMarker = new Map<string, string>();
-	private markerCodePoint = 0xe000;
-	private pasteBuffer: string | undefined;
-
-	constructor(tui: TUI, theme: EditorTheme) {
-		this.editor = new Editor(tui, theme, { paddingX: 0 });
-	}
-
-	get focused(): boolean {
-		return this.editor.focused;
-	}
-
-	set focused(value: boolean) {
-		this.editor.focused = value;
-	}
-
-	set onChange(handler: ((value: string) => void) | undefined) {
-		this.editor.onChange = handler ? () => handler(this.getExpandedText()) : undefined;
-	}
-
-	set onSubmit(handler: ((value: string) => void) | undefined) {
-		this.editor.onSubmit = handler ? (value) => handler(this.decode(value)) : undefined;
-	}
-
-	handleInput(data: string): void {
-		if (this.pasteBuffer !== undefined) {
-			this.pasteBuffer += data;
-			this.flushPasteBuffer();
-			return;
-		}
-		if (matchesKey(data, Key.backspace)) {
-			this.editor.handleInput(data);
-			return;
-		}
-		const pasteStart = data.indexOf(BRACKETED_PASTE_START);
-		if (pasteStart >= 0) {
-			if (pasteStart > 0) this.editor.handleInput(data.slice(0, pasteStart));
-			this.pasteBuffer = data.slice(pasteStart + BRACKETED_PASTE_START.length);
-			this.flushPasteBuffer();
-			return;
-		}
-		if (
-			[...data].some(
-				(character) => isUnsafeDirectEditorCharacter(character) || this.rawByMarker.has(character),
-			)
+			if (!answer.answer.trim()) return undefined;
+		} else if (
+			answer.optionIndex === undefined ||
+			!questions[index]?.options[answer.optionIndex - 1]
 		) {
-			this.editor.handleInput(this.encode(data));
-			return;
+			throw new Error("Questionnaire returned an invalid selected option");
 		}
-		this.editor.handleInput(data);
+		answers.set(index, answer);
 	}
 
-	render(width: number): string[] {
-		return this.editor
-			.render(width)
-			.map((line) =>
-				[...line].map((character) => (this.rawByMarker.has(character) ? " " : character)).join(""),
-			);
-	}
-
-	invalidate(): void {
-		this.editor.invalidate();
-	}
-
-	setText(value: string): void {
-		this.rawByMarker.clear();
-		this.markerCodePoint = 0xe000;
-		this.pasteBuffer = undefined;
-		this.editor.setText(this.encode(value));
-	}
-
-	getExpandedText(): string {
-		return this.decode(this.editor.getExpandedText());
-	}
-
-	private flushPasteBuffer(): void {
-		if (this.pasteBuffer === undefined) return;
-		const pasteEnd = this.pasteBuffer.indexOf(BRACKETED_PASTE_END);
-		if (pasteEnd < 0) return;
-		const raw = this.pasteBuffer.slice(0, pasteEnd);
-		const remaining = this.pasteBuffer.slice(pasteEnd + BRACKETED_PASTE_END.length);
-		this.pasteBuffer = undefined;
-		this.editor.handleInput(`${BRACKETED_PASTE_START}${this.encode(raw)}${BRACKETED_PASTE_END}`);
-		if (remaining) this.handleInput(remaining);
-	}
-
-	private encode(value: string): string {
-		const forbidden = new Set([
-			...value,
-			...this.editor.getExpandedText(),
-			...this.rawByMarker.keys(),
-		]);
-		return [...value]
-			.map((character) => {
-				if (!isUnsafeEditorCharacter(character) && !this.rawByMarker.has(character)) {
-					return character;
-				}
-				const marker = this.nextMarker(forbidden);
-				this.rawByMarker.set(marker, character);
-				forbidden.add(marker);
-				return marker;
-			})
-			.join("");
-	}
-
-	private decode(value: string): string {
-		return [...value].map((character) => this.rawByMarker.get(character) ?? character).join("");
-	}
-
-	private nextMarker(forbidden: ReadonlySet<string>): string {
-		for (;;) {
-			if (this.markerCodePoint === 0xf900) this.markerCodePoint = 0xf0000;
-			if (this.markerCodePoint === 0xffffe) this.markerCodePoint = 0x100000;
-			if (this.markerCodePoint > 0x10fffd) {
-				throw new Error("Plan-mode editor exhausted its safe input markers.");
-			}
-			const marker = String.fromCodePoint(this.markerCodePoint++);
-			if (!forbidden.has(marker)) return marker;
-		}
-	}
+	return questions.map((question, index) => {
+		const answer = answers.get(index);
+		if (!answer) throw new Error("Questionnaire returned an incomplete answer set");
+		const answerText = answer.wasCustom
+			? answer.answer
+			: (question.options[(answer.optionIndex ?? 0) - 1]?.label ?? answer.answer);
+		return answerFor(question, answerText, {
+			wasCustom: answer.wasCustom,
+			optionIndex: answer.optionIndex,
+			note: answer.note,
+		});
+	});
 }
 
-function isUnsafeDirectEditorCharacter(character: string): boolean {
-	const codePoint = character.codePointAt(0) ?? 0;
-	return (
-		(codePoint >= 0x7f && codePoint <= 0x9f) ||
-		codePoint === 0x2028 ||
-		codePoint === 0x2029 ||
-		isBidiControl(codePoint)
-	);
-}
-
-function isUnsafeEditorCharacter(character: string): boolean {
-	const codePoint = character.codePointAt(0) ?? 0;
-	return (
-		character !== "\n" &&
-		(codePoint <= 0x1f ||
-			(codePoint >= 0x7f && codePoint <= 0x9f) ||
-			codePoint === 0x2028 ||
-			codePoint === 0x2029 ||
-			isBidiControl(codePoint))
-	);
+function displayText(value: string, fallback: string, sanitize: (value: string) => string): string {
+	return sanitize(value).trim() ? value : fallback;
 }
 
 function answerFor(
@@ -829,10 +279,6 @@ function answerFor(
 	if (options.optionIndex !== undefined) result.optionIndex = options.optionIndex;
 	if (options.note !== undefined) result.note = options.note;
 	return result;
-}
-
-function formatPlanModeQuestionChoice(option: PlanModeQuestionOption, index: number) {
-	return `${index + 1}. ${option.label}${option.description ? ` — ${option.description}` : ""}`;
 }
 
 export function planModeQuestionAnswered(
@@ -870,126 +316,6 @@ function formatPlanModeQuestionPayload(payload: {
 	answers?: PlanModeQuestionAnswer[];
 }) {
 	return JSON.stringify(payload, null, 2);
-}
-
-export function sanitizeTerminalText(value: string): string {
-	return [...stripVTControlCharacters(value)]
-		.map((character) => {
-			const codePoint = character.codePointAt(0) ?? 0;
-			return codePoint <= 0x1f ||
-				(codePoint >= 0x7f && codePoint <= 0x9f) ||
-				codePoint === 0x2028 ||
-				codePoint === 0x2029 ||
-				isBidiControl(codePoint)
-				? " "
-				: character;
-		})
-		.join("");
-}
-
-function isBidiControl(codePoint: number): boolean {
-	return (
-		codePoint === 0x061c ||
-		codePoint === 0x200e ||
-		codePoint === 0x200f ||
-		(codePoint >= 0x202a && codePoint <= 0x202e) ||
-		(codePoint >= 0x2066 && codePoint <= 0x2069)
-	);
-}
-
-type QuestionnaireKeybinding = Parameters<KeybindingsManager["getKeys"]>[0];
-
-function keybindingHint(
-	theme: Theme,
-	keybindings: KeybindingsManager,
-	keybinding: QuestionnaireKeybinding,
-	description: string,
-): string {
-	return rawKeyHint(theme, formatHintKeys(keybindings.getKeys(keybinding)), description);
-}
-
-function rawKeyHint(theme: Theme, keys: string, description: string): string {
-	return `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}`;
-}
-
-function cancelHint(theme: Theme, keybindings: KeybindingsManager): string {
-	return rawKeyHint(
-		theme,
-		formatHintKeys([...keybindings.getKeys("tui.select.cancel"), "ctrl+c"]),
-		"cancel",
-	);
-}
-
-function selectionNavigationKeys(keybindings: KeybindingsManager): string {
-	const up = keybindings.getKeys("tui.select.up");
-	const down = keybindings.getKeys("tui.select.down");
-	if (up.includes("up") && down.includes("down")) {
-		return formatHintKeys([
-			"↑↓",
-			...up.filter((key) => key !== "up"),
-			...down.filter((key) => key !== "down"),
-		]);
-	}
-	return formatHintKeys([...up, ...down]);
-}
-
-function questionNavigationKeys(keybindings: KeybindingsManager): string {
-	return formatHintKeys([...keybindings.getKeys("tui.input.tab"), "shift+tab", "←→"]);
-}
-
-function formatHintKeys(keys: readonly string[]): string {
-	return [...new Set(keys)].map(formatHintKey).join("/");
-}
-
-function formatHintKey(key: string): string {
-	return key
-		.split("+")
-		.map((part) =>
-			process.platform === "darwin" && part.toLowerCase() === "alt" ? "option" : part,
-		)
-		.join("+");
-}
-
-function inlineSummary(value: string): string {
-	return value.split("\n").map(sanitizeTerminalText).join(" ↵ ");
-}
-
-function labeledRaw(label: string, value: string, width: number, theme: Theme): string[] {
-	const prefix = `${label}: `;
-	const safe = sanitizeTerminalText(value);
-	const lines = hardWrap(safe, Math.max(1, width - visibleWidth(prefix)));
-	return lines.map((line, index) =>
-		index === 0 ? `${theme.fg("muted", prefix)}${line}` : `${" ".repeat(prefix.length)}${line}`,
-	);
-}
-
-function hardWrapWithIndent(value: string, width: number, indent: number): string[] {
-	const safeWidth = Math.max(1, width);
-	const safeIndent = Math.min(Math.max(0, indent), Math.max(0, safeWidth - 1));
-	const continuationWidth = Math.max(1, safeWidth - safeIndent);
-	const columns = visibleWidth(value);
-	if (columns <= safeWidth) return [value];
-	const output = [sliceByColumn(value, 0, safeWidth)];
-	for (let column = safeWidth; column < columns; column += continuationWidth) {
-		output.push(`${" ".repeat(safeIndent)}${sliceByColumn(value, column, continuationWidth)}`);
-	}
-	return output;
-}
-
-function hardWrap(value: string, width: number): string[] {
-	const safeWidth = Math.max(1, width);
-	if (!value) return [""];
-	const output: string[] = [];
-	for (const sourceLine of value.split("\n")) {
-		const columns = visibleWidth(sourceLine);
-		if (columns === 0) output.push("");
-		else {
-			for (let column = 0; column < columns; column += safeWidth) {
-				output.push(sliceByColumn(sourceLine, column, safeWidth));
-			}
-		}
-	}
-	return output;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/pi-plan-mode/src/question-tool.ts
+++ b/packages/pi-plan-mode/src/question-tool.ts
@@ -261,7 +261,8 @@ function mapQuestionnaireResult(
 }
 
 function displayText(value: string, fallback: string, sanitize: (value: string) => string): string {
-	return sanitize(value).trim() ? value : fallback;
+	const sanitized = sanitize(value);
+	return sanitized.trim() ? sanitized : fallback;
 }
 
 function answerFor(

--- a/packages/pi-plan-mode/test/build-runtime.test.ts
+++ b/packages/pi-plan-mode/test/build-runtime.test.ts
@@ -164,6 +164,18 @@ test("runtime builds are deterministic, mapped, external, and remove stale outpu
 			assert.doesNotMatch(source, /["']\.\.?\/[^"']*src\//u);
 			assert.ok(files.includes(`${runtimePath}.map`), `missing map for ${runtimePath}`);
 		}
+		const kitImports = Object.values(firstMetadata.outputs ?? {})
+			.flatMap((output) => output.imports ?? [])
+			.filter((imported) => imported.path === "@narumitw/pi-tui-kit");
+		assert.ok(kitImports.length > 0, "generated runtime must import Pi TUI Kit");
+		assert.ok(
+			kitImports.every((imported) => imported.external),
+			"Pi TUI Kit must remain external",
+		);
+		assert.ok(
+			kitImports.some((imported) => imported.kind === "dynamic-import"),
+			"the questionnaire runner must remain a first-use import",
+		);
 		for (const output of Object.values(firstMetadata.outputs ?? {})) {
 			for (const input of Object.keys(output.inputs ?? {})) {
 				assert.equal(input.includes("node_modules/"), false, `bundled package input: ${input}`);

--- a/packages/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-471-repro.test.ts
@@ -421,6 +421,7 @@ test("a Plan-mode question cannot commit or open its next prompt after Plan mode
 	const mock = createMockPi({ activeTools: ["read"] });
 	planMode(mock.pi);
 	const context = createMockContext({
+		mode: "rpc",
 		hasUI: true,
 		select: async () => {
 			selectCalls += 1;

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -1,21 +1,13 @@
 import assert from "node:assert/strict";
-import { stripVTControlCharacters } from "node:util";
-import {
-	CURSOR_MARKER,
-	KeybindingsManager,
-	TUI_KEYBINDINGS,
-	visibleWidth,
-} from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import planMode, { normalizePlanModeQuestionParams } from "../src/plan-mode.js";
 import {
+	answerPlanModeQuestions,
 	askPlanModeQuestions,
 	MAX_PLAN_MODE_RESPONSE_LENGTH,
 	type PlanModeQuestion,
-	planModeQuestionAnswered,
-	sanitizeTerminalText,
 } from "../src/question-tool.js";
 
 const questions: PlanModeQuestion[] = [
@@ -38,17 +30,6 @@ const questions: PlanModeQuestion[] = [
 		],
 	},
 ];
-
-function tuiRun(customQuestions = questions, width = 60) {
-	const tui = createTuiHarness({
-		width,
-		rows: 30,
-		keybindings: new KeybindingsManager(TUI_KEYBINDINGS),
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions(customQuestions, context.ctx);
-	return { tui, running };
-}
 
 function paste(tui: ReturnType<typeof createTuiHarness>, text: string) {
 	tui.send(`\u001b[200~${text}\u001b[201~`);
@@ -83,254 +64,38 @@ test("normalizePlanModeQuestionParams validates question shape without changing 
 	});
 });
 
-test("TUI previews future questions and navigates back before answering", async () => {
-	const { tui, running } = tuiRun();
+test("the Kit runner preserves domain fields, notes, raw answers, and duplicate domain ids", async () => {
+	const duplicateIds = questions.map((question) => ({ ...question, id: "decision" }));
+	const tui = createTuiHarness({ width: 60, rows: 30 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions(duplicateIds, context.ctx);
 	await tui.waitForOpen();
 	tui.setFocused(true);
-	assert.match(tui.render().join("\n"), /\[Scope\].*Tests.*Review/u);
-	tui.send("\t");
-	assert.match(tui.render().join("\n"), /Scope.*\[Tests\].*Review[\s\S]*Which checks\?/u);
-	tui.send("\u001b[Z");
-	assert.match(tui.render().join("\n"), /\[Scope\][\s\S]*How broad\?/u);
-	tui.press("tui.select.cancel");
-	assert.equal(await running, undefined);
-});
 
-test("TUI frames the questionnaire with select-style separator borders", async () => {
-	const { tui, running } = tuiRun([questions[0]], 40);
-	await tui.waitForOpen();
-	const frame = tui.render();
-	assert.equal(frame[0], "─".repeat(40));
-	assert.equal(frame[1], "");
-	assert.equal(frame.at(-2), "");
-	assert.equal(frame.at(-1), "─".repeat(40));
-	assert.match(frame.join("\n"), /^ How broad\?$/mu);
-	tui.dispose();
-	assert.equal(await running, undefined);
-});
-
-test("TUI applies legacy selector emphasis to borders, title, and selected option", async () => {
-	const foreground: Array<{ color: string; text: string }> = [];
-	const bold: string[] = [];
-	const tui = createTuiHarness({
-		width: 60,
-		rows: 30,
-		theme: {
-			fg: (color, text) => {
-				foreground.push({ color: String(color), text });
-				return text;
-			},
-			bold: (text) => {
-				bold.push(text);
-				return text;
-			},
-		},
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions([questions[0]], context.ctx);
-	await tui.waitForOpen();
-	tui.render();
-	assert.ok(foreground.some(({ color, text }) => color === "border" && text === "─".repeat(60)));
-	assert.ok(
-		foreground.some(
-			({ color, text }) => color === "accent" && text === "→ 1. Small — Only the bug.",
-		),
-	);
-	assert.ok(
-		foreground.some(({ color, text }) => color === "muted" && text === " — Include cleanup."),
-	);
-	assert.ok(bold.includes("How broad?"));
-	assert.match(tui.render().join("\n"), /↑↓ navigate {2}enter select {2}escape\/ctrl\+c cancel/u);
-	tui.dispose();
-	assert.equal(await running, undefined);
-});
-
-test("Review renders plain summaries without selection affordances", async () => {
-	const foreground: Array<{ color: string; text: string }> = [];
-	const bold: string[] = [];
-	const tui = createTuiHarness({
-		width: 60,
-		rows: 30,
-		theme: {
-			fg: (color, text) => {
-				foreground.push({ color: String(color), text });
-				return text;
-			},
-			bold: (text) => {
-				bold.push(text);
-				return text;
-			},
-		},
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions(questions, context.ctx);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.send("\u001b[C");
-	tui.send("\u001b[C");
-	foreground.length = 0;
-	bold.length = 0;
-	const frame = tui.render().join("\n");
-	assert.match(frame, /\n 1\. Scope — Unanswered\n 2\. Tests — Unanswered/u);
-	assert.doesNotMatch(frame, /→ [12]\./u);
-	assert.match(frame, /enter submit/u);
-	assert.doesNotMatch(frame, /↑\/↓ select|n note/u);
-	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "1. Scope"));
-	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "2. Tests"));
-	assert.ok(foreground.some(({ color, text }) => color === "muted" && text === " — Unanswered"));
-	assert.equal(
-		foreground.some(
-			({ color, text }) => color === "accent" && /(?:→ )?[12]\. (?:Scope|Tests)/u.test(text),
-		),
-		false,
-	);
-	assert.ok(bold.includes("Review answers"));
-	const unchanged = tui.render().join("\n");
 	tui.press("tui.select.down");
-	assert.equal(tui.render().join("\n"), unchanged);
-	tui.dispose();
-	assert.equal(await running, undefined);
-});
-
-test("TUI uses configured selector keybindings and legacy j/k aliases", async () => {
-	const bindings = {
-		"tui.input.newLine": { data: "\u001b[13;3u", key: "alt+enter" },
-		"tui.input.submit": { data: "\u0013", key: "ctrl+s" },
-		"tui.input.tab": { data: "t", key: "t" },
-		"tui.select.cancel": { data: "q", key: "q" },
-		"tui.select.confirm": { data: "x", key: "x" },
-		"tui.select.down": { data: "s", key: "s" },
-		"tui.select.up": { data: "w", key: "w" },
-	} as const;
-	const tui = createTuiHarness({
-		width: 120,
-		rows: 30,
-		keybindings: {
-			matches: (data, binding) => bindings[binding as keyof typeof bindings]?.data === data,
-			getKeys: (binding) => {
-				const configured = bindings[binding as keyof typeof bindings];
-				return configured ? [configured.key] : [];
-			},
-		},
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions(questions, context.ctx);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	assert.match(
-		tui.render().join("\n"),
-		/w\/s navigate {2}x select {2}q\/ctrl\+c cancel {2}t\/shift\+tab\/←→ questions {2}n note/u,
-	);
-	tui.send("j");
-	assert.match(tui.render().join("\n"), /→ 2\. Broad/u);
-	tui.send("k");
-	assert.match(tui.render().join("\n"), /→ 1\. Small/u);
-	tui.send("s");
-	tui.send("t");
-	assert.match(tui.render().join("\n"), /\[Tests\]/u);
-	tui.send("\u001b[D");
-	tui.send("x");
-	tui.send("x");
-	assert.match(tui.render().join("\n"), /x submit {2}q\/ctrl\+c cancel/u);
-	tui.send("\n");
-	assert.equal(tui.isOpen, true);
-	assert.match(tui.render().join("\n"), /\[Review\]/u);
-	tui.send("q");
-	assert.equal(await running, undefined);
-});
-
-test("TUI keeps Ctrl+C as a hard cancel when it is not configured", async () => {
-	const tui = createTuiHarness({
-		keybindings: {
-			matches: (data, binding) => binding === "tui.select.cancel" && data === "q",
-			getKeys: (binding) => (binding === "tui.select.cancel" ? ["q"] : []),
-		},
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions([questions[0]], context.ctx);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	assert.match(tui.render().join("\n"), /q\/ctrl\+c cancel/u);
-	tui.send("\u0003");
-	assert.equal(await running, undefined);
-});
-
-test("TUI uses numbered select styling and restores the recorded answer cursor", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	let frame = tui.render().join("\n");
-	assert.match(frame, /→ 1\. Small — Only the bug\./u);
-	assert.doesNotMatch(frame, /[○●]/u);
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	tui.send("\u001b[D");
-	frame = tui.render().join("\n");
-	assert.match(frame, /→ 2\. Broad ✓/u);
-	tui.press("tui.select.up");
-	tui.send("\u001b[C");
-	tui.send("\u001b[D");
-	assert.match(tui.render().join("\n"), /→ 2\. Broad ✓/u);
-	tui.press("tui.select.cancel");
-	assert.equal(await running, undefined);
-});
-
-test("TUI replaces answers, manages notes, accepts Other, and submits ordered raw payload", async () => {
-	const { tui, running } = tuiRun();
-	await tui.waitForOpen();
-	tui.setFocused(true);
-
-	// Note shortcut selects the highlighted answer before opening the editor.
 	tui.type("n");
-	paste(tui, "initial note");
+	paste(tui, "keep this note");
 	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /initial note/u);
-
-	// Replacing the selected option clears its old note.
-	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
-	tui.send("\u001b[D");
-	assert.doesNotMatch(tui.render().join("\n"), /initial note/u);
-	tui.send("\u001b[C");
-
-	// Other keeps exact user text in the answer payload.
 	tui.press("tui.select.down");
 	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
 	paste(tui, "  custom answer  ");
 	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /Review answers[\s\S]*Broad[\s\S]*custom answer/u);
-
-	// Notes remain editable from their question page, not from the plain Review summary.
-	tui.send("\u001b[D");
-	tui.send("\u001b[D");
-	tui.type("n");
-	paste(tui, "draft note");
-	tui.press("tui.input.submit");
-	tui.type("n");
-	tui.send("\u0015");
-	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /Note cleared/u);
-	tui.type("n");
-	paste(tui, "final note");
-	tui.press("tui.input.submit");
-	tui.send("\u001b[C");
-	tui.send("\u001b[C");
-	assert.match(tui.render().join("\n"), /1\. Scope — Broad · Note: final note/u);
 	tui.press("tui.select.confirm");
 
 	assert.deepEqual(await running, [
 		{
-			id: "scope",
+			id: "decision",
 			header: "Scope",
 			question: "How broad?",
 			answer: "Broad",
 			wasCustom: false,
 			optionIndex: 2,
-			note: "final note",
+			note: "keep this note",
 		},
 		{
-			id: "tests",
+			id: "decision",
 			header: "Tests",
 			question: "Which checks?",
 			answer: "  custom answer  ",
@@ -339,102 +104,136 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	]);
 });
 
-test("Review blocks incomplete submission and directs note edits back to questions", async () => {
-	const { tui, running } = tuiRun();
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.send("\u001b[C");
-	tui.send("\u001b[C");
-	tui.press("tui.select.confirm");
-	assert.match(tui.render().join("\n"), /Answer every question before submitting/u);
-	tui.press("tui.select.down");
-	assert.doesNotMatch(tui.render().join("\n"), /→ [12]\./u);
-	tui.type("n");
-	assert.match(tui.render().join("\n"), /Return to a question to add or edit its note/u);
-	tui.press("tui.select.cancel");
-	assert.equal(await running, undefined);
-});
-
-test("TUI preserves raw custom answers and notes while sanitizing editor rendering", async () => {
-	const unsafeAnswer = "raw\u007f\u001b]8;;https://evil.example\u0007text\u202ereversed";
-	const unsafeNote = "note\u009bcontrol\u202aspoofed";
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.press("tui.select.down");
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	paste(tui, unsafeAnswer);
-	const answerDraft = tui.render().join("\n");
-	assert.equal(answerDraft.includes("\u202e"), false);
-	assert.equal(answerDraft.includes("\u001b]8;;https://evil.example"), false);
-	tui.press("tui.input.submit");
-	tui.send("\u001b[D");
-	tui.type("n");
-	paste(tui, unsafeNote);
-	const noteDraft = tui.render().join("\n");
-	assert.equal(noteDraft.includes("\u009b"), false);
-	assert.equal(noteDraft.includes("\u202a"), false);
-	tui.press("tui.input.submit");
-	tui.send("\u001b[C");
-	const review = tui.render().join("\n");
-	assert.equal(review.includes("\u202e") || review.includes("\u202a"), false);
-	tui.press("tui.select.confirm");
-
-	assert.deepEqual(await running, [
+test("the Kit RPC runner preserves limits, ordering, and answer metadata", async () => {
+	const selections = ["1. Small — Only the bug.", "3. Other (free-form)"];
+	const editorAnswers = ["x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1), "rpc custom"];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => selections.shift(),
+		editor: async () => editorAnswers.shift(),
+		custom: async () => assert.fail("RPC must not open custom TUI"),
+	});
+	assert.deepEqual(await askPlanModeQuestions(questions, context.ctx), [
 		{
 			id: "scope",
 			header: "Scope",
 			question: "How broad?",
-			answer: unsafeAnswer,
+			answer: "Small",
+			wasCustom: false,
+			optionIndex: 1,
+		},
+		{
+			id: "tests",
+			header: "Tests",
+			question: "Which checks?",
+			answer: "rpc custom",
 			wasCustom: true,
-			note: unsafeNote,
 		},
 	]);
+	assert.ok(context.notifications.some(({ message }) => message.includes("4,000")));
 });
 
-test("editing an existing Other answer preserves its note", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.press("tui.select.down");
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	paste(tui, "first answer");
-	tui.press("tui.input.submit");
-	tui.send("\u001b[D");
-	tui.type("n");
-	paste(tui, "keep this note");
-	tui.press("tui.input.submit");
-	tui.press("tui.select.confirm");
-	tui.send("\u0015");
-	paste(tui, "edited answer");
-	tui.press("tui.input.submit");
-	tui.press("tui.select.confirm");
-
-	assert.equal((await running)?.[0]?.note, "keep this note");
-});
-
-test("narrow TUI rendering keeps every question and Review tab visible", async () => {
-	const longQuestions = [
-		{ ...questions[0], header: "LongHeader12" },
-		{ ...questions[1], header: "SecondHeader" },
-		{ ...questions[0], id: "risk", header: "ThirdHeader3" },
+test("the adapter uses safe display fallbacks without mutating selected option answers", async () => {
+	const control = "\u001b[31m";
+	const unsafeQuestions: PlanModeQuestion[] = [
+		{
+			id: "unsafe",
+			header: control,
+			question: control,
+			options: [
+				{ label: control, description: "First choice." },
+				{ label: "Safe", description: "Second choice." },
+			],
+		},
 	];
-	const { tui, running } = tuiRun(longQuestions, 24);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	for (let index = 0; index < longQuestions.length; index += 1) tui.send("\u001b[C");
-	const frame = stripVTControlCharacters(tui.render().join("\n"));
-	assert.match(frame, /LongHeader12/u);
-	assert.match(frame, /SecondHeader/u);
-	assert.match(frame, /ThirdHeader3/u);
-	assert.match(frame, /\[Review\]/u);
-	tui.dispose();
-	assert.equal(await running, undefined);
+	let offeredTitle = "";
+	let offeredChoices: string[] = [];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (title: string, choices: string[]) => {
+			offeredTitle = title;
+			offeredChoices = choices;
+			return choices[0];
+		},
+	});
+	const answers = await askPlanModeQuestions(unsafeQuestions, context.ctx);
+	assert.equal(offeredTitle, "Question 1: Question 1");
+	assert.equal(offeredChoices[0], "1. Option 1 — First choice.");
+	assert.equal(answers?.[0]?.answer, control);
+	assert.equal(answers?.[0]?.header, control);
+	assert.equal(answers?.[0]?.question, control);
 });
 
-test("TUI abort signal closes the questionnaire without answers", async () => {
+test("the adapter maps closed, stale, unsupported, error, and blank RPC results to cancellation", async () => {
+	const closed = createMockContext({ mode: "rpc", hasUI: true, select: async () => undefined });
+	assert.equal(await askPlanModeQuestions([questions[0]], closed.ctx), undefined);
+
+	let current = true;
+	const stale = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			current = false;
+			return "1. Small — Only the bug.";
+		},
+	});
+	assert.equal(await askPlanModeQuestions([questions[0]], stale.ctx, () => current), undefined);
+
+	const unsupported = createMockContext({ mode: "print", hasUI: false });
+	assert.equal(await askPlanModeQuestions([questions[0]], unsupported.ctx), undefined);
+
+	const invalid = createMockContext({ mode: "rpc", hasUI: true });
+	assert.equal(await askPlanModeQuestions([], invalid.ctx), undefined);
+	assert.match(invalid.notifications[0]?.message ?? "", /at least one question/u);
+
+	const blank = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => "3. Other (free-form)",
+		editor: async () => "   ",
+	});
+	assert.equal(await askPlanModeQuestions([questions[0]], blank.ctx), undefined);
+});
+
+test("answerPlanModeQuestions revalidates session and Plan mode after the runner", async () => {
+	let current = true;
+	const replaced = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			current = false;
+			return "1. Small — Only the bug.";
+		},
+	});
+	const staleResult = await answerPlanModeQuestions([questions[0]], replaced.ctx, {
+		isCurrent: () => current,
+		isEnabled: () => true,
+	});
+	assert.ok("reason" in staleResult.details);
+	assert.equal(staleResult.details.reason, "cancelled");
+	assert.match(staleResult.content[0]?.text ?? "", /session changed/u);
+
+	let enabled = true;
+	const deactivated = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			enabled = false;
+			return "1. Small — Only the bug.";
+		},
+	});
+	const inactiveResult = await answerPlanModeQuestions([questions[0]], deactivated.ctx, {
+		isCurrent: () => true,
+		isEnabled: () => enabled,
+	});
+	assert.ok("reason" in inactiveResult.details);
+	assert.equal(inactiveResult.details.reason, "plan_mode_inactive");
+	assert.match(inactiveResult.content[0]?.text ?? "", /no longer active/u);
+});
+
+test("owner abort closes the Kit interaction without publishing answers", async () => {
 	const controller = new AbortController();
 	const tui = createTuiHarness({ width: 60, rows: 30 });
 	const context = createMockContext({
@@ -445,125 +244,7 @@ test("TUI abort signal closes the questionnaire without answers", async () => {
 	});
 	const running = askPlanModeQuestions(questions, context.ctx);
 	await tui.waitForOpen();
-	controller.abort();
+	controller.abort(new DOMException("Session replaced", "AbortError"));
 	assert.equal(await running, undefined);
 	assert.equal(tui.isOpen, false);
-});
-
-test("Other editor treats Backspace as deletion instead of raw text", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.press("tui.select.down");
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	tui.type("wrongx");
-	tui.send("\u007f");
-	tui.press("tui.input.submit");
-	tui.press("tui.select.confirm");
-
-	assert.equal((await running)?.[0]?.answer, "wrong");
-});
-
-test("Optional note editor treats Backspace as deletion instead of raw text", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.type("n");
-	tui.type("note!");
-	tui.send("\u007f");
-	tui.press("tui.input.submit");
-	tui.press("tui.select.confirm");
-	tui.press("tui.select.confirm");
-
-	assert.equal((await running)?.[0]?.note, "note");
-});
-
-test("Other editor rejects oversized input and forwards focus", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.press("tui.select.down");
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	tui.setFocused(true);
-	assert.equal(tui.render().join("\n").includes(CURSOR_MARKER), true);
-	paste(tui, "x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1));
-	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /4,000 characters or fewer/u);
-	assert.equal(tui.isOpen, true);
-	tui.press("ctrl+c");
-	assert.equal(await running, undefined);
-});
-
-test("Note editor rejects oversized input and stays open", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.type("n");
-	const oversized = "z".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1);
-	paste(tui, oversized);
-	tui.press("tui.input.submit");
-	const frame = tui.render().join("\n");
-	assert.match(frame, /Note must be 4,000 characters or fewer/u);
-	assert.equal(tui.isOpen, true);
-	tui.press("ctrl+c");
-	assert.equal(await running, undefined);
-});
-
-test("TUI sanitizes rendering, preserves raw result text, and respects narrow widths", async () => {
-	const unsafe = "raw\u001b]8;;https://evil.example\u0007text\u001b]8;;\u0007";
-	const malicious: PlanModeQuestion[] = [
-		{
-			id: "unsafe",
-			header: `Head\u001b[31m`,
-			question: unsafe,
-			options: [
-				{ label: unsafe, description: "first" },
-				{ label: "safe", description: "second" },
-			],
-		},
-	];
-	const { tui, running } = tuiRun(malicious, 16);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	const frame = tui.render();
-	const plain = stripVTControlCharacters(frame.join("\n"));
-	assert.doesNotMatch(plain, /evil\.example/u);
-	assert.equal(plain.includes("\u0007") || plain.includes("\u001b"), false);
-	for (const line of frame) assert.ok(visibleWidth(line) <= 16);
-	assert.equal(sanitizeTerminalText(unsafe), "rawtext");
-	const answered = planModeQuestionAnswered(malicious, [
-		{
-			id: "unsafe",
-			header: malicious[0]?.header ?? "",
-			question: unsafe,
-			answer: unsafe,
-			wasCustom: true,
-		},
-	]);
-	assert.match(answered.content[0]?.text ?? "", /evil\.example/u);
-	tui.dispose();
-	assert.equal(await running, undefined);
-});
-
-test("RPC retains sequential select/editor fallback and retries oversized answers", async () => {
-	const selections = ["1. Small — Only the bug.", "3. Other (free-form)"];
-	const editorAnswers = ["x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1), "rpc custom"];
-	const context = createMockContext({
-		mode: "rpc",
-		hasUI: true,
-		select: async () => selections.shift(),
-		editor: async () => editorAnswers.shift(),
-		custom: async () => assert.fail("RPC must not open custom TUI"),
-	});
-	const answers = await askPlanModeQuestions(questions, context.ctx);
-	assert.deepEqual(
-		answers?.map(({ answer, wasCustom }) => ({ answer, wasCustom })),
-		[
-			{ answer: "Small", wasCustom: false },
-			{ answer: "rpc custom", wasCustom: true },
-		],
-	);
-	assert.ok(context.notifications.some(({ message }) => message.includes("4,000")));
 });

--- a/packages/pi-plan-mode/test/question-tool.test.ts
+++ b/packages/pi-plan-mode/test/question-tool.test.ts
@@ -134,15 +134,17 @@ test("the Kit RPC runner preserves limits, ordering, and answer metadata", async
 	assert.ok(context.notifications.some(({ message }) => message.includes("4,000")));
 });
 
-test("the adapter uses safe display fallbacks without mutating selected option answers", async () => {
+test("the adapter sanitizes mixed display text without mutating raw domain answers", async () => {
 	const control = "\u001b[31m";
+	const rawHeader = `Visible${control}`;
+	const rawLabel = `Unsafe${control}`;
 	const unsafeQuestions: PlanModeQuestion[] = [
 		{
 			id: "unsafe",
-			header: control,
+			header: rawHeader,
 			question: control,
 			options: [
-				{ label: control, description: "First choice." },
+				{ label: rawLabel, description: "First choice." },
 				{ label: "Safe", description: "Second choice." },
 			],
 		},
@@ -159,10 +161,10 @@ test("the adapter uses safe display fallbacks without mutating selected option a
 		},
 	});
 	const answers = await askPlanModeQuestions(unsafeQuestions, context.ctx);
-	assert.equal(offeredTitle, "Question 1: Question 1");
-	assert.equal(offeredChoices[0], "1. Option 1 — First choice.");
-	assert.equal(answers?.[0]?.answer, control);
-	assert.equal(answers?.[0]?.header, control);
+	assert.equal(offeredTitle, "Visible: Question 1");
+	assert.equal(offeredChoices[0], "1. Unsafe — First choice.");
+	assert.equal(answers?.[0]?.answer, rawLabel);
+	assert.equal(answers?.[0]?.header, rawHeader);
 	assert.equal(answers?.[0]?.question, control);
 });
 

--- a/packages/pi-workflow/package.json
+++ b/packages/pi-workflow/package.json
@@ -37,7 +37,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1"
+		"@narumitw/pi-tui-kit": "^0.57.0"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",

--- a/packages/pi-workflow/scripts/build-runtime.mjs
+++ b/packages/pi-workflow/scripts/build-runtime.mjs
@@ -93,6 +93,7 @@ export function validateEagerGraph(metadata) {
 		for (const imported of output.imports ?? []) {
 			if (
 				imported.external &&
+				imported.kind !== "dynamic-import" &&
 				FORBIDDEN_EAGER_EXTERNALS.some(
 					(dependency) =>
 						imported.path === dependency || imported.path.startsWith(`${dependency}/`),

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -1,23 +1,12 @@
-import { stripVTControlCharacters } from "node:util";
-import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
-import {
-	type Component,
-	Editor,
-	type EditorTheme,
-	type Focusable,
-	Key,
-	matchesKey,
-	sliceByColumn,
-	type TUI,
-	truncateToWidth,
-	visibleWidth,
-} from "@earendil-works/pi-tui";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type {
+	QuestionnaireAnswer,
+	QuestionnaireQuestion,
+	RunQuestionnaireResult,
+} from "@narumitw/pi-tui-kit";
 
 export const PLAN_MODE_QUESTION_TOOL_NAME = "plan_mode_question";
 export const MAX_PLAN_MODE_RESPONSE_LENGTH = 4_000;
-
-const BRACKETED_PASTE_START = "\u001b[200~";
-const BRACKETED_PASTE_END = "\u001b[201~";
 
 export type PlanModeQuestionOption = {
 	label: string;
@@ -205,613 +194,74 @@ export async function askPlanModeQuestions(
 	ctx: ExtensionContext,
 	shouldContinue: () => boolean = () => true,
 ): Promise<PlanModeQuestionAnswer[] | undefined> {
-	if (ctx.mode === "tui") {
-		const answers = await ctx.ui.custom<PlanModeQuestionAnswer[] | undefined>(
-			(tui, theme, keybindings, done) =>
-				new PlanModeQuestionnaire({
-					questions,
-					tui,
-					theme,
-					keybindings,
-					shouldContinue,
-					signal: ctx.signal,
-					onDone: done,
-				}),
-		);
-		return shouldContinue() ? answers : undefined;
-	}
-	return askPlanModeQuestionsSequentially(questions, ctx, shouldContinue);
+	const { runQuestionnaire, sanitizeTerminalText } = await import("@narumitw/pi-tui-kit");
+	if (!shouldContinue()) return undefined;
+	const runnerQuestions: QuestionnaireQuestion<string>[] = questions.map((question, index) => ({
+		id: String(index),
+		header: displayText(question.header, `Question ${index + 1}`, sanitizeTerminalText),
+		prompt: displayText(question.question, `Question ${index + 1}`, sanitizeTerminalText),
+		options: question.options.map((option, optionIndex) => ({
+			...option,
+			label: displayText(option.label, `Option ${optionIndex + 1}`, sanitizeTerminalText),
+		})),
+	}));
+	const result = await runQuestionnaire(ctx, {
+		questions: runnerQuestions,
+		allowNotes: true,
+		maxTextLength: MAX_PLAN_MODE_RESPONSE_LENGTH,
+		signal: ctx.signal,
+		isCurrent: shouldContinue,
+	});
+	if (!shouldContinue()) return undefined;
+	return mapQuestionnaireResult(questions, result);
 }
 
-async function askPlanModeQuestionsSequentially(
+function mapQuestionnaireResult(
 	questions: PlanModeQuestion[],
-	ctx: ExtensionContext,
-	shouldContinue: () => boolean,
-): Promise<PlanModeQuestionAnswer[] | undefined> {
-	const answers: PlanModeQuestionAnswer[] = [];
-	for (const question of questions) {
-		const choices = question.options.map(formatPlanModeQuestionChoice);
-		const otherChoice = `${question.options.length + 1}. Other (free-form)`;
-		const choice = await ctx.ui.select(`${question.header}: ${question.question}`, [
-			...choices,
-			otherChoice,
-		]);
-		if (!shouldContinue() || !choice) return undefined;
-		if (choice === otherChoice) {
-			const customAnswer = await askCustomAnswer(question, ctx, shouldContinue);
-			if (customAnswer === undefined) return undefined;
-			answers.push(answerFor(question, customAnswer, { wasCustom: true }));
-			continue;
+	result: RunQuestionnaireResult<string>,
+): PlanModeQuestionAnswer[] | undefined {
+	if (result.kind !== "submitted") return undefined;
+	if (result.answers.length !== questions.length) {
+		throw new Error("Questionnaire returned an incomplete answer set");
+	}
+
+	const answers = new Map<number, QuestionnaireAnswer<string>>();
+	for (const answer of result.answers) {
+		const index = Number(answer.questionId);
+		if (!Number.isSafeInteger(index) || String(index) !== answer.questionId || !questions[index]) {
+			throw new Error("Questionnaire returned an answer for an unknown question");
 		}
-		const optionIndex = choices.indexOf(choice);
-		const option = question.options[optionIndex];
-		if (!option) return undefined;
-		answers.push(
-			answerFor(question, option.label, { wasCustom: false, optionIndex: optionIndex + 1 }),
-		);
-	}
-	return answers;
-}
-
-async function askCustomAnswer(
-	question: PlanModeQuestion,
-	ctx: ExtensionContext,
-	shouldContinue: () => boolean,
-): Promise<string | undefined> {
-	let draft = "";
-	for (;;) {
-		const customAnswer = await ctx.ui.editor(question.question, draft);
-		if (!shouldContinue() || !customAnswer?.trim()) return undefined;
-		if (customAnswer.length <= MAX_PLAN_MODE_RESPONSE_LENGTH) return customAnswer;
-		draft = customAnswer;
-		ctx.ui.notify("Custom answer must be 4,000 characters or fewer.", "warning");
-	}
-}
-
-interface QuestionnaireOptions {
-	questions: PlanModeQuestion[];
-	tui: TUI;
-	theme: Theme;
-	keybindings: KeybindingsManager;
-	shouldContinue(): boolean;
-	signal?: AbortSignal;
-	onDone(answers: PlanModeQuestionAnswer[] | undefined): void;
-}
-
-export class PlanModeQuestionnaire implements Component, Focusable {
-	private readonly options: QuestionnaireOptions;
-	private readonly editor: RawPreservingEditor;
-	private readonly answers: Array<PlanModeQuestionAnswer | undefined>;
-	private readonly selectedOptions: number[];
-	private page = 0;
-	private editorKind: "answer" | "note" | undefined;
-	private message: string | undefined;
-	private finished = false;
-	private removeAbort = () => {};
-	private _focused = false;
-
-	constructor(options: QuestionnaireOptions) {
-		this.options = options;
-		this.answers = options.questions.map(() => undefined);
-		this.selectedOptions = options.questions.map(() => 0);
-		const editorTheme: EditorTheme = {
-			borderColor: (text) => options.theme.fg("accent", text),
-			selectList: {
-				selectedPrefix: (text) => options.theme.fg("accent", text),
-				selectedText: (text) => options.theme.fg("accent", text),
-				description: (text) => options.theme.fg("muted", text),
-				scrollInfo: (text) => options.theme.fg("dim", text),
-				noMatch: (text) => options.theme.fg("warning", text),
-			},
-		};
-		this.editor = new RawPreservingEditor(options.tui, editorTheme);
-		this.editor.onChange = () => {
-			this.message = undefined;
-		};
-		this.editor.onSubmit = (text) => this.submitEditor(text);
-		if (options.signal) {
-			const abort = () => this.finish(undefined);
-			options.signal.addEventListener("abort", abort, { once: true });
-			this.removeAbort = () => options.signal?.removeEventListener("abort", abort);
-			if (options.signal.aborted) abort();
-		}
-	}
-
-	get focused(): boolean {
-		return this._focused;
-	}
-
-	set focused(value: boolean) {
-		this._focused = value;
-		this.editor.focused = value && this.editorKind !== undefined;
-	}
-
-	render(width: number): string[] {
-		const safeWidth = Math.max(1, width);
-		const padding = safeWidth > 1 ? " " : "";
-		const contentWidth = Math.max(1, safeWidth - visibleWidth(padding));
-		const border = this.options.theme.fg("border", "─".repeat(safeWidth));
-		const lines = [border, "", ...this.renderTabs(contentWidth), ""];
-		if (this.page === this.options.questions.length) lines.push(...this.renderReview(contentWidth));
-		else lines.push(...this.renderQuestion(contentWidth));
-		if (this.message)
-			lines.push(...hardWrap(this.options.theme.fg("warning", this.message), contentWidth));
-		lines.push("");
-		lines.push(truncateToWidth(this.renderHints(), contentWidth), "", border);
-		return lines.map((line) => {
-			if (!line || line === border) return line;
-			return `${padding}${truncateToWidth(line, contentWidth)}`;
-		});
-	}
-
-	handleInput(data: string): void {
-		if (this.finished) return;
-		if (!this.options.shouldContinue() || this.isCancel(data)) {
-			this.finish(undefined);
-			return;
-		}
-		if (this.editorKind) this.handleEditorInput(data);
-		else this.handlePageInput(data);
-		this.options.tui.requestRender();
-	}
-
-	invalidate(): void {
-		this.editor.invalidate();
-	}
-
-	dispose(): void {
-		this.finish(undefined);
-	}
-
-	private isCancel(data: string): boolean {
-		return (
-			matchesKey(data, Key.ctrl("c")) || this.options.keybindings.matches(data, "tui.select.cancel")
-		);
-	}
-
-	private handleEditorInput(data: string): void {
-		const keybindings = this.options.keybindings;
-		if (keybindings.matches(data, "tui.input.newLine")) {
-			this.editor.handleInput(data);
-		} else if (keybindings.matches(data, "tui.input.submit")) {
-			this.submitEditor(this.editor.getExpandedText());
-		} else {
-			this.editor.handleInput(data);
-		}
-	}
-
-	private handlePageInput(data: string): void {
-		const keybindings = this.options.keybindings;
-		const review = this.page === this.options.questions.length;
-		if (keybindings.matches(data, "tui.select.up") || data === "k") {
-			if (!review) this.moveSelection(-1);
-			return;
-		}
-		if (keybindings.matches(data, "tui.select.down") || data === "j") {
-			if (!review) this.moveSelection(1);
-			return;
-		}
-		if (keybindings.matches(data, "tui.select.confirm")) {
-			this.submitPage();
-			return;
-		}
-		if (keybindings.matches(data, "tui.input.tab") || matchesKey(data, Key.right)) {
-			this.movePage(1);
-			return;
-		}
-		if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left)) {
-			this.movePage(-1);
-			return;
-		}
-		if (data.toLowerCase() === "n") {
-			if (review) this.message = "Return to a question to add or edit its note.";
-			else this.editNote();
-		}
-	}
-
-	private renderHints(): string {
-		const { keybindings, theme } = this.options;
-		const cancel = cancelHint(theme, keybindings);
-		if (this.editorKind) {
-			return [
-				keybindingHint(theme, keybindings, "tui.input.submit", "save"),
-				keybindingHint(theme, keybindings, "tui.input.newLine", "newline"),
-				cancel,
-			].join("  ");
-		}
-		const questions = rawKeyHint(theme, questionNavigationKeys(keybindings), "questions");
-		if (this.page === this.options.questions.length) {
-			return [
-				keybindingHint(theme, keybindings, "tui.select.confirm", "submit"),
-				cancel,
-				questions,
-			].join("  ");
-		}
-		return [
-			rawKeyHint(theme, selectionNavigationKeys(keybindings), "navigate"),
-			keybindingHint(theme, keybindings, "tui.select.confirm", "select"),
-			cancel,
-			questions,
-			rawKeyHint(theme, "n", "note"),
-		].join("  ");
-	}
-
-	private movePage(delta: number): void {
-		const pageCount = this.options.questions.length + 1;
-		this.page = (this.page + delta + pageCount) % pageCount;
-		const answer = this.answers[this.page];
-		const question = this.options.questions[this.page];
-		if (answer?.wasCustom && question) {
-			this.selectedOptions[this.page] = question.options.length;
-		} else if (answer?.optionIndex !== undefined) {
-			this.selectedOptions[this.page] = answer.optionIndex - 1;
-		}
-		this.message = undefined;
-	}
-
-	private renderTabs(width: number): string[] {
-		const tabs = [
-			...this.options.questions.map((question, index) => {
-				const label = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
-				const answered = this.answers[index] ? "✓ " : "";
-				return this.page === index ? `[${answered}${label}]` : `${answered}${label}`;
-			}),
-			this.page === this.options.questions.length ? "[Review]" : "Review",
-		];
-		const lines: string[] = [];
-		let line = "";
-		for (const tab of tabs) {
-			const boundedTab = truncateToWidth(tab, width, "…");
-			const candidate = line ? `${line}  ${boundedTab}` : boundedTab;
-			if (line && visibleWidth(candidate) > width) {
-				lines.push(this.options.theme.fg("accent", line));
-				line = boundedTab;
-			} else {
-				line = candidate;
+		if (answers.has(index)) throw new Error("Questionnaire returned duplicate answers");
+		if (answer.wasCustom) {
+			if (answer.optionIndex !== undefined) {
+				throw new Error("Questionnaire returned a custom answer with an option index");
 			}
-		}
-		if (line) lines.push(this.options.theme.fg("accent", line));
-		return lines;
-	}
-
-	private renderQuestion(width: number): string[] {
-		const question = this.options.questions[this.page];
-		if (!question) return [];
-		const lines = hardWrap(
-			this.options.theme.fg(
-				"accent",
-				this.options.theme.bold(sanitizeTerminalText(question.question)),
-			),
-			width,
-		);
-		lines.push("");
-		question.options.forEach((option, index) => {
-			const selected = this.selectedOptions[this.page] === index;
-			const cursor = selected ? "→" : " ";
-			const label = `${cursor} ${index + 1}. ${sanitizeTerminalText(option.label)}`;
-			const chosen = this.answers[this.page]?.optionIndex === index + 1;
-			const description = option.description
-				? ` — ${sanitizeTerminalText(option.description)}`
-				: "";
-			const line = selected
-				? this.options.theme.fg("accent", `${label}${chosen ? " ✓" : ""}${description}`)
-				: `${this.options.theme.fg("text", label)}${
-						chosen ? this.options.theme.fg("success", " ✓") : ""
-					}${description ? this.options.theme.fg("muted", description) : ""}`;
-			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${cursor} ${index + 1}. `)));
-		});
-		const otherIndex = question.options.length;
-		const otherSelected = this.selectedOptions[this.page] === otherIndex;
-		const otherCursor = otherSelected ? "→" : " ";
-		const otherLabel = `${otherCursor} ${otherIndex + 1}. Other (free-form)`;
-		const otherChosen = this.answers[this.page]?.wasCustom === true;
-		lines.push(
-			otherSelected
-				? this.options.theme.fg("accent", `${otherLabel}${otherChosen ? " ✓" : ""}`)
-				: `${this.options.theme.fg("text", otherLabel)}${
-						otherChosen ? this.options.theme.fg("success", " ✓") : ""
-					}`,
-		);
-		const answer = this.answers[this.page];
-		if (answer?.wasCustom)
-			lines.push(...labeledRaw("Answer", answer.answer, width, this.options.theme));
-		if (answer?.note) lines.push(...labeledRaw("Note", answer.note, width, this.options.theme));
-		if (this.editorKind) {
-			lines.push("");
-			lines.push(
-				this.options.theme.fg(
-					"accent",
-					this.editorKind === "answer" ? "Custom answer" : "Optional note",
-				),
-			);
-			lines.push(...this.editor.render(width));
-		}
-		return lines;
-	}
-
-	private renderReview(width: number): string[] {
-		const lines = [this.options.theme.fg("accent", this.options.theme.bold("Review answers")), ""];
-		this.options.questions.forEach((question, index) => {
-			const answer = this.answers[index];
-			const header = sanitizeTerminalText(question.header) || `Question ${index + 1}`;
-			const label = `${index + 1}. ${header}`;
-			const summary = ` — ${inlineSummary(answer?.answer ?? "Unanswered")}${
-				answer?.note ? ` · Note: ${inlineSummary(answer.note)}` : ""
-			}`;
-			const line = `${this.options.theme.fg("text", label)}${this.options.theme.fg("muted", summary)}`;
-			lines.push(...hardWrapWithIndent(line, width, visibleWidth(`${index + 1}. `)));
-		});
-		return lines;
-	}
-
-	private moveSelection(delta: number): void {
-		const optionCount = (this.options.questions[this.page]?.options.length ?? 0) + 1;
-		this.selectedOptions[this.page] =
-			((this.selectedOptions[this.page] ?? 0) + delta + optionCount) % optionCount;
-	}
-
-	private submitPage(): void {
-		if (this.page === this.options.questions.length) {
-			const firstMissing = this.answers.findIndex((answer) => !answer);
-			if (firstMissing >= 0) {
-				this.message = "Answer every question before submitting.";
-				return;
-			}
-			this.finish(
-				this.answers.filter((answer): answer is PlanModeQuestionAnswer => answer !== undefined),
-			);
-			return;
-		}
-		const question = this.options.questions[this.page];
-		if (!question) return;
-		const selected = this.selectedOptions[this.page] ?? 0;
-		if (selected === question.options.length) {
-			this.beginEditor(
-				"answer",
-				this.answers[this.page]?.wasCustom ? this.answers[this.page]?.answer : "",
-			);
-			return;
-		}
-		const option = question.options[selected];
-		if (!option) return;
-		const previous = this.answers[this.page];
-		this.answers[this.page] = answerFor(question, option.label, {
-			wasCustom: false,
-			optionIndex: selected + 1,
-			note: previous?.optionIndex === selected + 1 ? previous.note : undefined,
-		});
-		this.advance();
-	}
-
-	private editNote(): void {
-		const index = this.page;
-		let answer = this.answers[index];
-		const question = this.options.questions[index];
-		const selected = this.selectedOptions[index] ?? 0;
-		if (question && selected === question.options.length && !answer?.wasCustom) {
-			this.beginEditor("answer", "");
-			return;
-		}
-		if (question && selected < question.options.length && answer?.optionIndex !== selected + 1) {
-			const option = question.options[selected];
-			if (option) {
-				answer = answerFor(question, option.label, {
-					wasCustom: false,
-					optionIndex: selected + 1,
-				});
-				this.answers[index] = answer;
-			}
-		}
-		if (!answer) {
-			this.message = "Select an answer before adding a note.";
-			return;
-		}
-		this.beginEditor("note", answer.note ?? "");
-	}
-
-	private beginEditor(kind: "answer" | "note", value: string | undefined): void {
-		this.editorKind = kind;
-		this.editor.setText(value ?? "");
-		this.editor.focused = this._focused;
-		this.message = undefined;
-	}
-
-	private submitEditor(value: string): void {
-		if (value.length > MAX_PLAN_MODE_RESPONSE_LENGTH) {
-			this.editor.setText(value);
-			this.message = `${this.editorKind === "answer" ? "Answer" : "Note"} must be 4,000 characters or fewer.`;
-			this.options.tui.requestRender();
-			return;
-		}
-		const index = this.page;
-		if (this.editorKind === "answer") {
-			if (!value.trim()) {
-				this.editor.setText(value);
-				this.message = "Custom answer cannot be empty.";
-				this.options.tui.requestRender();
-				return;
-			}
-			const question = this.options.questions[index];
-			if (!question) return;
-			const previous = this.answers[index];
-			this.answers[index] = answerFor(question, value, {
-				wasCustom: true,
-				note: previous?.wasCustom ? previous.note : undefined,
-			});
-			this.editor.setText("");
-			this.editorKind = undefined;
-			this.editor.focused = false;
-			this.advance();
-			return;
-		}
-		const answer = this.answers[index];
-		if (answer) answer.note = value.trim() ? value : undefined;
-		this.editor.setText("");
-		this.editorKind = undefined;
-		this.editor.focused = false;
-		this.message = value.trim() ? "Note saved." : "Note cleared.";
-		this.options.tui.requestRender();
-	}
-
-	private advance(): void {
-		this.page = Math.min(this.page + 1, this.options.questions.length);
-		this.message = undefined;
-	}
-
-	private finish(answers: PlanModeQuestionAnswer[] | undefined): void {
-		if (this.finished) return;
-		this.finished = true;
-		this.removeAbort();
-		this.removeAbort = () => {};
-		this.editor.focused = false;
-		this.options.onDone(answers);
-	}
-}
-
-class RawPreservingEditor implements Focusable {
-	private readonly editor: Editor;
-	private readonly rawByMarker = new Map<string, string>();
-	private markerCodePoint = 0xe000;
-	private pasteBuffer: string | undefined;
-
-	constructor(tui: TUI, theme: EditorTheme) {
-		this.editor = new Editor(tui, theme, { paddingX: 0 });
-	}
-
-	get focused(): boolean {
-		return this.editor.focused;
-	}
-
-	set focused(value: boolean) {
-		this.editor.focused = value;
-	}
-
-	set onChange(handler: ((value: string) => void) | undefined) {
-		this.editor.onChange = handler ? () => handler(this.getExpandedText()) : undefined;
-	}
-
-	set onSubmit(handler: ((value: string) => void) | undefined) {
-		this.editor.onSubmit = handler ? (value) => handler(this.decode(value)) : undefined;
-	}
-
-	handleInput(data: string): void {
-		if (this.pasteBuffer !== undefined) {
-			this.pasteBuffer += data;
-			this.flushPasteBuffer();
-			return;
-		}
-		if (matchesKey(data, Key.backspace)) {
-			this.editor.handleInput(data);
-			return;
-		}
-		const pasteStart = data.indexOf(BRACKETED_PASTE_START);
-		if (pasteStart >= 0) {
-			if (pasteStart > 0) this.editor.handleInput(data.slice(0, pasteStart));
-			this.pasteBuffer = data.slice(pasteStart + BRACKETED_PASTE_START.length);
-			this.flushPasteBuffer();
-			return;
-		}
-		if (
-			[...data].some(
-				(character) => isUnsafeDirectEditorCharacter(character) || this.rawByMarker.has(character),
-			)
+			if (!answer.answer.trim()) return undefined;
+		} else if (
+			answer.optionIndex === undefined ||
+			!questions[index]?.options[answer.optionIndex - 1]
 		) {
-			this.editor.handleInput(this.encode(data));
-			return;
+			throw new Error("Questionnaire returned an invalid selected option");
 		}
-		this.editor.handleInput(data);
+		answers.set(index, answer);
 	}
 
-	render(width: number): string[] {
-		return this.editor
-			.render(width)
-			.map((line) =>
-				[...line].map((character) => (this.rawByMarker.has(character) ? " " : character)).join(""),
-			);
-	}
-
-	invalidate(): void {
-		this.editor.invalidate();
-	}
-
-	setText(value: string): void {
-		this.rawByMarker.clear();
-		this.markerCodePoint = 0xe000;
-		this.pasteBuffer = undefined;
-		this.editor.setText(this.encode(value));
-	}
-
-	getExpandedText(): string {
-		return this.decode(this.editor.getExpandedText());
-	}
-
-	private flushPasteBuffer(): void {
-		if (this.pasteBuffer === undefined) return;
-		const pasteEnd = this.pasteBuffer.indexOf(BRACKETED_PASTE_END);
-		if (pasteEnd < 0) return;
-		const raw = this.pasteBuffer.slice(0, pasteEnd);
-		const remaining = this.pasteBuffer.slice(pasteEnd + BRACKETED_PASTE_END.length);
-		this.pasteBuffer = undefined;
-		this.editor.handleInput(`${BRACKETED_PASTE_START}${this.encode(raw)}${BRACKETED_PASTE_END}`);
-		if (remaining) this.handleInput(remaining);
-	}
-
-	private encode(value: string): string {
-		const forbidden = new Set([
-			...value,
-			...this.editor.getExpandedText(),
-			...this.rawByMarker.keys(),
-		]);
-		return [...value]
-			.map((character) => {
-				if (!isUnsafeEditorCharacter(character) && !this.rawByMarker.has(character)) {
-					return character;
-				}
-				const marker = this.nextMarker(forbidden);
-				this.rawByMarker.set(marker, character);
-				forbidden.add(marker);
-				return marker;
-			})
-			.join("");
-	}
-
-	private decode(value: string): string {
-		return [...value].map((character) => this.rawByMarker.get(character) ?? character).join("");
-	}
-
-	private nextMarker(forbidden: ReadonlySet<string>): string {
-		for (;;) {
-			if (this.markerCodePoint === 0xf900) this.markerCodePoint = 0xf0000;
-			if (this.markerCodePoint === 0xffffe) this.markerCodePoint = 0x100000;
-			if (this.markerCodePoint > 0x10fffd) {
-				throw new Error("Plan-mode editor exhausted its safe input markers.");
-			}
-			const marker = String.fromCodePoint(this.markerCodePoint++);
-			if (!forbidden.has(marker)) return marker;
-		}
-	}
+	return questions.map((question, index) => {
+		const answer = answers.get(index);
+		if (!answer) throw new Error("Questionnaire returned an incomplete answer set");
+		const answerText = answer.wasCustom
+			? answer.answer
+			: (question.options[(answer.optionIndex ?? 0) - 1]?.label ?? answer.answer);
+		return answerFor(question, answerText, {
+			wasCustom: answer.wasCustom,
+			optionIndex: answer.optionIndex,
+			note: answer.note,
+		});
+	});
 }
 
-function isUnsafeDirectEditorCharacter(character: string): boolean {
-	const codePoint = character.codePointAt(0) ?? 0;
-	return (
-		(codePoint >= 0x7f && codePoint <= 0x9f) ||
-		codePoint === 0x2028 ||
-		codePoint === 0x2029 ||
-		isBidiControl(codePoint)
-	);
-}
-
-function isUnsafeEditorCharacter(character: string): boolean {
-	const codePoint = character.codePointAt(0) ?? 0;
-	return (
-		character !== "\n" &&
-		(codePoint <= 0x1f ||
-			(codePoint >= 0x7f && codePoint <= 0x9f) ||
-			codePoint === 0x2028 ||
-			codePoint === 0x2029 ||
-			isBidiControl(codePoint))
-	);
+function displayText(value: string, fallback: string, sanitize: (value: string) => string): string {
+	return sanitize(value).trim() ? value : fallback;
 }
 
 function answerFor(
@@ -829,10 +279,6 @@ function answerFor(
 	if (options.optionIndex !== undefined) result.optionIndex = options.optionIndex;
 	if (options.note !== undefined) result.note = options.note;
 	return result;
-}
-
-function formatPlanModeQuestionChoice(option: PlanModeQuestionOption, index: number) {
-	return `${index + 1}. ${option.label}${option.description ? ` — ${option.description}` : ""}`;
 }
 
 export function planModeQuestionAnswered(
@@ -870,126 +316,6 @@ function formatPlanModeQuestionPayload(payload: {
 	answers?: PlanModeQuestionAnswer[];
 }) {
 	return JSON.stringify(payload, null, 2);
-}
-
-export function sanitizeTerminalText(value: string): string {
-	return [...stripVTControlCharacters(value)]
-		.map((character) => {
-			const codePoint = character.codePointAt(0) ?? 0;
-			return codePoint <= 0x1f ||
-				(codePoint >= 0x7f && codePoint <= 0x9f) ||
-				codePoint === 0x2028 ||
-				codePoint === 0x2029 ||
-				isBidiControl(codePoint)
-				? " "
-				: character;
-		})
-		.join("");
-}
-
-function isBidiControl(codePoint: number): boolean {
-	return (
-		codePoint === 0x061c ||
-		codePoint === 0x200e ||
-		codePoint === 0x200f ||
-		(codePoint >= 0x202a && codePoint <= 0x202e) ||
-		(codePoint >= 0x2066 && codePoint <= 0x2069)
-	);
-}
-
-type QuestionnaireKeybinding = Parameters<KeybindingsManager["getKeys"]>[0];
-
-function keybindingHint(
-	theme: Theme,
-	keybindings: KeybindingsManager,
-	keybinding: QuestionnaireKeybinding,
-	description: string,
-): string {
-	return rawKeyHint(theme, formatHintKeys(keybindings.getKeys(keybinding)), description);
-}
-
-function rawKeyHint(theme: Theme, keys: string, description: string): string {
-	return `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}`;
-}
-
-function cancelHint(theme: Theme, keybindings: KeybindingsManager): string {
-	return rawKeyHint(
-		theme,
-		formatHintKeys([...keybindings.getKeys("tui.select.cancel"), "ctrl+c"]),
-		"cancel",
-	);
-}
-
-function selectionNavigationKeys(keybindings: KeybindingsManager): string {
-	const up = keybindings.getKeys("tui.select.up");
-	const down = keybindings.getKeys("tui.select.down");
-	if (up.includes("up") && down.includes("down")) {
-		return formatHintKeys([
-			"↑↓",
-			...up.filter((key) => key !== "up"),
-			...down.filter((key) => key !== "down"),
-		]);
-	}
-	return formatHintKeys([...up, ...down]);
-}
-
-function questionNavigationKeys(keybindings: KeybindingsManager): string {
-	return formatHintKeys([...keybindings.getKeys("tui.input.tab"), "shift+tab", "←→"]);
-}
-
-function formatHintKeys(keys: readonly string[]): string {
-	return [...new Set(keys)].map(formatHintKey).join("/");
-}
-
-function formatHintKey(key: string): string {
-	return key
-		.split("+")
-		.map((part) =>
-			process.platform === "darwin" && part.toLowerCase() === "alt" ? "option" : part,
-		)
-		.join("+");
-}
-
-function inlineSummary(value: string): string {
-	return value.split("\n").map(sanitizeTerminalText).join(" ↵ ");
-}
-
-function labeledRaw(label: string, value: string, width: number, theme: Theme): string[] {
-	const prefix = `${label}: `;
-	const safe = sanitizeTerminalText(value);
-	const lines = hardWrap(safe, Math.max(1, width - visibleWidth(prefix)));
-	return lines.map((line, index) =>
-		index === 0 ? `${theme.fg("muted", prefix)}${line}` : `${" ".repeat(prefix.length)}${line}`,
-	);
-}
-
-function hardWrapWithIndent(value: string, width: number, indent: number): string[] {
-	const safeWidth = Math.max(1, width);
-	const safeIndent = Math.min(Math.max(0, indent), Math.max(0, safeWidth - 1));
-	const continuationWidth = Math.max(1, safeWidth - safeIndent);
-	const columns = visibleWidth(value);
-	if (columns <= safeWidth) return [value];
-	const output = [sliceByColumn(value, 0, safeWidth)];
-	for (let column = safeWidth; column < columns; column += continuationWidth) {
-		output.push(`${" ".repeat(safeIndent)}${sliceByColumn(value, column, continuationWidth)}`);
-	}
-	return output;
-}
-
-function hardWrap(value: string, width: number): string[] {
-	const safeWidth = Math.max(1, width);
-	if (!value) return [""];
-	const output: string[] = [];
-	for (const sourceLine of value.split("\n")) {
-		const columns = visibleWidth(sourceLine);
-		if (columns === 0) output.push("");
-		else {
-			for (let column = 0; column < columns; column += safeWidth) {
-				output.push(sliceByColumn(sourceLine, column, safeWidth));
-			}
-		}
-	}
-	return output;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/pi-workflow/src/plan/question-tool.ts
+++ b/packages/pi-workflow/src/plan/question-tool.ts
@@ -261,7 +261,8 @@ function mapQuestionnaireResult(
 }
 
 function displayText(value: string, fallback: string, sanitize: (value: string) => string): string {
-	return sanitize(value).trim() ? value : fallback;
+	const sanitized = sanitize(value);
+	return sanitized.trim() ? sanitized : fallback;
 }
 
 function answerFor(

--- a/packages/pi-workflow/test/build-runtime.test.ts
+++ b/packages/pi-workflow/test/build-runtime.test.ts
@@ -67,7 +67,7 @@ function validMetadata(): BuildMetadata {
 				inputs: { "src/index.ts": {}, "src/workflow.ts": {} },
 			},
 			"dist/chunks/eager.ts": {
-				imports: [],
+				imports: [{ path: "@narumitw/pi-tui-kit", kind: "dynamic-import", external: true }],
 				inputs: { "src/goal/goal.ts": {}, "src/plan/plan-mode.ts": {} },
 			},
 			"dist/chunks/menu.ts": {
@@ -201,6 +201,18 @@ test("runtime builds are deterministic, mapped, external, and remove stale chunk
 			assert.ok(files.includes(`${runtimePath}.map`), `missing source map for ${runtimePath}`);
 		}
 
+		const kitImports = Object.values(firstMetadata.outputs ?? {})
+			.flatMap((output) => output.imports ?? [])
+			.filter((imported) => imported.path === "@narumitw/pi-tui-kit");
+		assert.ok(kitImports.length > 0, "generated runtime must import Pi TUI Kit");
+		assert.ok(
+			kitImports.every((imported) => imported.external),
+			"Pi TUI Kit must remain external",
+		);
+		assert.ok(
+			kitImports.some((imported) => imported.kind === "dynamic-import"),
+			"the questionnaire runner must remain a first-use import",
+		);
 		for (const output of Object.values(firstMetadata.outputs ?? {})) {
 			for (const input of Object.keys(output.inputs ?? {})) {
 				assert.equal(input.includes("node_modules/"), false, `bundled package input: ${input}`);

--- a/packages/pi-workflow/test/compat-plan-issue-471-repro.test.ts
+++ b/packages/pi-workflow/test/compat-plan-issue-471-repro.test.ts
@@ -418,6 +418,7 @@ test("a Plan-mode question cannot commit or open its next prompt after Plan mode
 	const mock = createMockPi({ activeTools: ["read"] });
 	planMode(mock.pi);
 	const context = createMockContext({
+		mode: "rpc",
 		hasUI: true,
 		select: async () => {
 			selectCalls += 1;

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -1,21 +1,13 @@
 import assert from "node:assert/strict";
-import { stripVTControlCharacters } from "node:util";
-import {
-	CURSOR_MARKER,
-	KeybindingsManager,
-	TUI_KEYBINDINGS,
-	visibleWidth,
-} from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import planMode, { normalizePlanModeQuestionParams } from "../src/plan/plan-mode.js";
 import {
+	answerPlanModeQuestions,
 	askPlanModeQuestions,
 	MAX_PLAN_MODE_RESPONSE_LENGTH,
 	type PlanModeQuestion,
-	planModeQuestionAnswered,
-	sanitizeTerminalText,
 } from "../src/plan/question-tool.js";
 
 const questions: PlanModeQuestion[] = [
@@ -38,17 +30,6 @@ const questions: PlanModeQuestion[] = [
 		],
 	},
 ];
-
-function tuiRun(customQuestions = questions, width = 60) {
-	const tui = createTuiHarness({
-		width,
-		rows: 30,
-		keybindings: new KeybindingsManager(TUI_KEYBINDINGS),
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions(customQuestions, context.ctx);
-	return { tui, running };
-}
 
 function paste(tui: ReturnType<typeof createTuiHarness>, text: string) {
 	tui.send(`\u001b[200~${text}\u001b[201~`);
@@ -83,254 +64,38 @@ test("normalizePlanModeQuestionParams validates question shape without changing 
 	});
 });
 
-test("TUI previews future questions and navigates back before answering", async () => {
-	const { tui, running } = tuiRun();
+test("the Kit runner preserves domain fields, notes, raw answers, and duplicate domain ids", async () => {
+	const duplicateIds = questions.map((question) => ({ ...question, id: "decision" }));
+	const tui = createTuiHarness({ width: 60, rows: 30 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = askPlanModeQuestions(duplicateIds, context.ctx);
 	await tui.waitForOpen();
 	tui.setFocused(true);
-	assert.match(tui.render().join("\n"), /\[Scope\].*Tests.*Review/u);
-	tui.send("\t");
-	assert.match(tui.render().join("\n"), /Scope.*\[Tests\].*Review[\s\S]*Which checks\?/u);
-	tui.send("\u001b[Z");
-	assert.match(tui.render().join("\n"), /\[Scope\][\s\S]*How broad\?/u);
-	tui.press("tui.select.cancel");
-	assert.equal(await running, undefined);
-});
 
-test("TUI frames the questionnaire with select-style separator borders", async () => {
-	const { tui, running } = tuiRun([questions[0]], 40);
-	await tui.waitForOpen();
-	const frame = tui.render();
-	assert.equal(frame[0], "─".repeat(40));
-	assert.equal(frame[1], "");
-	assert.equal(frame.at(-2), "");
-	assert.equal(frame.at(-1), "─".repeat(40));
-	assert.match(frame.join("\n"), /^ How broad\?$/mu);
-	tui.dispose();
-	assert.equal(await running, undefined);
-});
-
-test("TUI applies legacy selector emphasis to borders, title, and selected option", async () => {
-	const foreground: Array<{ color: string; text: string }> = [];
-	const bold: string[] = [];
-	const tui = createTuiHarness({
-		width: 60,
-		rows: 30,
-		theme: {
-			fg: (color, text) => {
-				foreground.push({ color: String(color), text });
-				return text;
-			},
-			bold: (text) => {
-				bold.push(text);
-				return text;
-			},
-		},
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions([questions[0]], context.ctx);
-	await tui.waitForOpen();
-	tui.render();
-	assert.ok(foreground.some(({ color, text }) => color === "border" && text === "─".repeat(60)));
-	assert.ok(
-		foreground.some(
-			({ color, text }) => color === "accent" && text === "→ 1. Small — Only the bug.",
-		),
-	);
-	assert.ok(
-		foreground.some(({ color, text }) => color === "muted" && text === " — Include cleanup."),
-	);
-	assert.ok(bold.includes("How broad?"));
-	assert.match(tui.render().join("\n"), /↑↓ navigate {2}enter select {2}escape\/ctrl\+c cancel/u);
-	tui.dispose();
-	assert.equal(await running, undefined);
-});
-
-test("Review renders plain summaries without selection affordances", async () => {
-	const foreground: Array<{ color: string; text: string }> = [];
-	const bold: string[] = [];
-	const tui = createTuiHarness({
-		width: 60,
-		rows: 30,
-		theme: {
-			fg: (color, text) => {
-				foreground.push({ color: String(color), text });
-				return text;
-			},
-			bold: (text) => {
-				bold.push(text);
-				return text;
-			},
-		},
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions(questions, context.ctx);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.send("\u001b[C");
-	tui.send("\u001b[C");
-	foreground.length = 0;
-	bold.length = 0;
-	const frame = tui.render().join("\n");
-	assert.match(frame, /\n 1\. Scope — Unanswered\n 2\. Tests — Unanswered/u);
-	assert.doesNotMatch(frame, /→ [12]\./u);
-	assert.match(frame, /enter submit/u);
-	assert.doesNotMatch(frame, /↑\/↓ select|n note/u);
-	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "1. Scope"));
-	assert.ok(foreground.some(({ color, text }) => color === "text" && text === "2. Tests"));
-	assert.ok(foreground.some(({ color, text }) => color === "muted" && text === " — Unanswered"));
-	assert.equal(
-		foreground.some(
-			({ color, text }) => color === "accent" && /(?:→ )?[12]\. (?:Scope|Tests)/u.test(text),
-		),
-		false,
-	);
-	assert.ok(bold.includes("Review answers"));
-	const unchanged = tui.render().join("\n");
 	tui.press("tui.select.down");
-	assert.equal(tui.render().join("\n"), unchanged);
-	tui.dispose();
-	assert.equal(await running, undefined);
-});
-
-test("TUI uses configured selector keybindings and legacy j/k aliases", async () => {
-	const bindings = {
-		"tui.input.newLine": { data: "\u001b[13;3u", key: "alt+enter" },
-		"tui.input.submit": { data: "\u0013", key: "ctrl+s" },
-		"tui.input.tab": { data: "t", key: "t" },
-		"tui.select.cancel": { data: "q", key: "q" },
-		"tui.select.confirm": { data: "x", key: "x" },
-		"tui.select.down": { data: "s", key: "s" },
-		"tui.select.up": { data: "w", key: "w" },
-	} as const;
-	const tui = createTuiHarness({
-		width: 120,
-		rows: 30,
-		keybindings: {
-			matches: (data, binding) => bindings[binding as keyof typeof bindings]?.data === data,
-			getKeys: (binding) => {
-				const configured = bindings[binding as keyof typeof bindings];
-				return configured ? [configured.key] : [];
-			},
-		},
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions(questions, context.ctx);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	assert.match(
-		tui.render().join("\n"),
-		/w\/s navigate {2}x select {2}q\/ctrl\+c cancel {2}t\/shift\+tab\/←→ questions {2}n note/u,
-	);
-	tui.send("j");
-	assert.match(tui.render().join("\n"), /→ 2\. Broad/u);
-	tui.send("k");
-	assert.match(tui.render().join("\n"), /→ 1\. Small/u);
-	tui.send("s");
-	tui.send("t");
-	assert.match(tui.render().join("\n"), /\[Tests\]/u);
-	tui.send("\u001b[D");
-	tui.send("x");
-	tui.send("x");
-	assert.match(tui.render().join("\n"), /x submit {2}q\/ctrl\+c cancel/u);
-	tui.send("\n");
-	assert.equal(tui.isOpen, true);
-	assert.match(tui.render().join("\n"), /\[Review\]/u);
-	tui.send("q");
-	assert.equal(await running, undefined);
-});
-
-test("TUI keeps Ctrl+C as a hard cancel when it is not configured", async () => {
-	const tui = createTuiHarness({
-		keybindings: {
-			matches: (data, binding) => binding === "tui.select.cancel" && data === "q",
-			getKeys: (binding) => (binding === "tui.select.cancel" ? ["q"] : []),
-		},
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = askPlanModeQuestions([questions[0]], context.ctx);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	assert.match(tui.render().join("\n"), /q\/ctrl\+c cancel/u);
-	tui.send("\u0003");
-	assert.equal(await running, undefined);
-});
-
-test("TUI uses numbered select styling and restores the recorded answer cursor", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	let frame = tui.render().join("\n");
-	assert.match(frame, /→ 1\. Small — Only the bug\./u);
-	assert.doesNotMatch(frame, /[○●]/u);
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	tui.send("\u001b[D");
-	frame = tui.render().join("\n");
-	assert.match(frame, /→ 2\. Broad ✓/u);
-	tui.press("tui.select.up");
-	tui.send("\u001b[C");
-	tui.send("\u001b[D");
-	assert.match(tui.render().join("\n"), /→ 2\. Broad ✓/u);
-	tui.press("tui.select.cancel");
-	assert.equal(await running, undefined);
-});
-
-test("TUI replaces answers, manages notes, accepts Other, and submits ordered raw payload", async () => {
-	const { tui, running } = tuiRun();
-	await tui.waitForOpen();
-	tui.setFocused(true);
-
-	// Note shortcut selects the highlighted answer before opening the editor.
 	tui.type("n");
-	paste(tui, "initial note");
+	paste(tui, "keep this note");
 	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /initial note/u);
-
-	// Replacing the selected option clears its old note.
-	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
-	tui.send("\u001b[D");
-	assert.doesNotMatch(tui.render().join("\n"), /initial note/u);
-	tui.send("\u001b[C");
-
-	// Other keeps exact user text in the answer payload.
 	tui.press("tui.select.down");
 	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
 	paste(tui, "  custom answer  ");
 	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /Review answers[\s\S]*Broad[\s\S]*custom answer/u);
-
-	// Notes remain editable from their question page, not from the plain Review summary.
-	tui.send("\u001b[D");
-	tui.send("\u001b[D");
-	tui.type("n");
-	paste(tui, "draft note");
-	tui.press("tui.input.submit");
-	tui.type("n");
-	tui.send("\u0015");
-	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /Note cleared/u);
-	tui.type("n");
-	paste(tui, "final note");
-	tui.press("tui.input.submit");
-	tui.send("\u001b[C");
-	tui.send("\u001b[C");
-	assert.match(tui.render().join("\n"), /1\. Scope — Broad · Note: final note/u);
 	tui.press("tui.select.confirm");
 
 	assert.deepEqual(await running, [
 		{
-			id: "scope",
+			id: "decision",
 			header: "Scope",
 			question: "How broad?",
 			answer: "Broad",
 			wasCustom: false,
 			optionIndex: 2,
-			note: "final note",
+			note: "keep this note",
 		},
 		{
-			id: "tests",
+			id: "decision",
 			header: "Tests",
 			question: "Which checks?",
 			answer: "  custom answer  ",
@@ -339,102 +104,136 @@ test("TUI replaces answers, manages notes, accepts Other, and submits ordered ra
 	]);
 });
 
-test("Review blocks incomplete submission and directs note edits back to questions", async () => {
-	const { tui, running } = tuiRun();
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.send("\u001b[C");
-	tui.send("\u001b[C");
-	tui.press("tui.select.confirm");
-	assert.match(tui.render().join("\n"), /Answer every question before submitting/u);
-	tui.press("tui.select.down");
-	assert.doesNotMatch(tui.render().join("\n"), /→ [12]\./u);
-	tui.type("n");
-	assert.match(tui.render().join("\n"), /Return to a question to add or edit its note/u);
-	tui.press("tui.select.cancel");
-	assert.equal(await running, undefined);
-});
-
-test("TUI preserves raw custom answers and notes while sanitizing editor rendering", async () => {
-	const unsafeAnswer = "raw\u007f\u001b]8;;https://evil.example\u0007text\u202ereversed";
-	const unsafeNote = "note\u009bcontrol\u202aspoofed";
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.press("tui.select.down");
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	paste(tui, unsafeAnswer);
-	const answerDraft = tui.render().join("\n");
-	assert.equal(answerDraft.includes("\u202e"), false);
-	assert.equal(answerDraft.includes("\u001b]8;;https://evil.example"), false);
-	tui.press("tui.input.submit");
-	tui.send("\u001b[D");
-	tui.type("n");
-	paste(tui, unsafeNote);
-	const noteDraft = tui.render().join("\n");
-	assert.equal(noteDraft.includes("\u009b"), false);
-	assert.equal(noteDraft.includes("\u202a"), false);
-	tui.press("tui.input.submit");
-	tui.send("\u001b[C");
-	const review = tui.render().join("\n");
-	assert.equal(review.includes("\u202e") || review.includes("\u202a"), false);
-	tui.press("tui.select.confirm");
-
-	assert.deepEqual(await running, [
+test("the Kit RPC runner preserves limits, ordering, and answer metadata", async () => {
+	const selections = ["1. Small — Only the bug.", "3. Other (free-form)"];
+	const editorAnswers = ["x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1), "rpc custom"];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => selections.shift(),
+		editor: async () => editorAnswers.shift(),
+		custom: async () => assert.fail("RPC must not open custom TUI"),
+	});
+	assert.deepEqual(await askPlanModeQuestions(questions, context.ctx), [
 		{
 			id: "scope",
 			header: "Scope",
 			question: "How broad?",
-			answer: unsafeAnswer,
+			answer: "Small",
+			wasCustom: false,
+			optionIndex: 1,
+		},
+		{
+			id: "tests",
+			header: "Tests",
+			question: "Which checks?",
+			answer: "rpc custom",
 			wasCustom: true,
-			note: unsafeNote,
 		},
 	]);
+	assert.ok(context.notifications.some(({ message }) => message.includes("4,000")));
 });
 
-test("editing an existing Other answer preserves its note", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.press("tui.select.down");
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	paste(tui, "first answer");
-	tui.press("tui.input.submit");
-	tui.send("\u001b[D");
-	tui.type("n");
-	paste(tui, "keep this note");
-	tui.press("tui.input.submit");
-	tui.press("tui.select.confirm");
-	tui.send("\u0015");
-	paste(tui, "edited answer");
-	tui.press("tui.input.submit");
-	tui.press("tui.select.confirm");
-
-	assert.equal((await running)?.[0]?.note, "keep this note");
-});
-
-test("narrow TUI rendering keeps every question and Review tab visible", async () => {
-	const longQuestions = [
-		{ ...questions[0], header: "LongHeader12" },
-		{ ...questions[1], header: "SecondHeader" },
-		{ ...questions[0], id: "risk", header: "ThirdHeader3" },
+test("the adapter uses safe display fallbacks without mutating selected option answers", async () => {
+	const control = "\u001b[31m";
+	const unsafeQuestions: PlanModeQuestion[] = [
+		{
+			id: "unsafe",
+			header: control,
+			question: control,
+			options: [
+				{ label: control, description: "First choice." },
+				{ label: "Safe", description: "Second choice." },
+			],
+		},
 	];
-	const { tui, running } = tuiRun(longQuestions, 24);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	for (let index = 0; index < longQuestions.length; index += 1) tui.send("\u001b[C");
-	const frame = stripVTControlCharacters(tui.render().join("\n"));
-	assert.match(frame, /LongHeader12/u);
-	assert.match(frame, /SecondHeader/u);
-	assert.match(frame, /ThirdHeader3/u);
-	assert.match(frame, /\[Review\]/u);
-	tui.dispose();
-	assert.equal(await running, undefined);
+	let offeredTitle = "";
+	let offeredChoices: string[] = [];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async (title: string, choices: string[]) => {
+			offeredTitle = title;
+			offeredChoices = choices;
+			return choices[0];
+		},
+	});
+	const answers = await askPlanModeQuestions(unsafeQuestions, context.ctx);
+	assert.equal(offeredTitle, "Question 1: Question 1");
+	assert.equal(offeredChoices[0], "1. Option 1 — First choice.");
+	assert.equal(answers?.[0]?.answer, control);
+	assert.equal(answers?.[0]?.header, control);
+	assert.equal(answers?.[0]?.question, control);
 });
 
-test("TUI abort signal closes the questionnaire without answers", async () => {
+test("the adapter maps closed, stale, unsupported, error, and blank RPC results to cancellation", async () => {
+	const closed = createMockContext({ mode: "rpc", hasUI: true, select: async () => undefined });
+	assert.equal(await askPlanModeQuestions([questions[0]], closed.ctx), undefined);
+
+	let current = true;
+	const stale = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			current = false;
+			return "1. Small — Only the bug.";
+		},
+	});
+	assert.equal(await askPlanModeQuestions([questions[0]], stale.ctx, () => current), undefined);
+
+	const unsupported = createMockContext({ mode: "print", hasUI: false });
+	assert.equal(await askPlanModeQuestions([questions[0]], unsupported.ctx), undefined);
+
+	const invalid = createMockContext({ mode: "rpc", hasUI: true });
+	assert.equal(await askPlanModeQuestions([], invalid.ctx), undefined);
+	assert.match(invalid.notifications[0]?.message ?? "", /at least one question/u);
+
+	const blank = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => "3. Other (free-form)",
+		editor: async () => "   ",
+	});
+	assert.equal(await askPlanModeQuestions([questions[0]], blank.ctx), undefined);
+});
+
+test("answerPlanModeQuestions revalidates session and Plan mode after the runner", async () => {
+	let current = true;
+	const replaced = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			current = false;
+			return "1. Small — Only the bug.";
+		},
+	});
+	const staleResult = await answerPlanModeQuestions([questions[0]], replaced.ctx, {
+		isCurrent: () => current,
+		isEnabled: () => true,
+	});
+	assert.ok("reason" in staleResult.details);
+	assert.equal(staleResult.details.reason, "cancelled");
+	assert.match(staleResult.content[0]?.text ?? "", /session changed/u);
+
+	let enabled = true;
+	const deactivated = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: async () => {
+			enabled = false;
+			return "1. Small — Only the bug.";
+		},
+	});
+	const inactiveResult = await answerPlanModeQuestions([questions[0]], deactivated.ctx, {
+		isCurrent: () => true,
+		isEnabled: () => enabled,
+	});
+	assert.ok("reason" in inactiveResult.details);
+	assert.equal(inactiveResult.details.reason, "plan_mode_inactive");
+	assert.match(inactiveResult.content[0]?.text ?? "", /no longer active/u);
+});
+
+test("owner abort closes the Kit interaction without publishing answers", async () => {
 	const controller = new AbortController();
 	const tui = createTuiHarness({ width: 60, rows: 30 });
 	const context = createMockContext({
@@ -445,125 +244,7 @@ test("TUI abort signal closes the questionnaire without answers", async () => {
 	});
 	const running = askPlanModeQuestions(questions, context.ctx);
 	await tui.waitForOpen();
-	controller.abort();
+	controller.abort(new DOMException("Session replaced", "AbortError"));
 	assert.equal(await running, undefined);
 	assert.equal(tui.isOpen, false);
-});
-
-test("Other editor treats Backspace as deletion instead of raw text", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.press("tui.select.down");
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	tui.type("wrongx");
-	tui.send("\u007f");
-	tui.press("tui.input.submit");
-	tui.press("tui.select.confirm");
-
-	assert.equal((await running)?.[0]?.answer, "wrong");
-});
-
-test("Optional note editor treats Backspace as deletion instead of raw text", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.type("n");
-	tui.type("note!");
-	tui.send("\u007f");
-	tui.press("tui.input.submit");
-	tui.press("tui.select.confirm");
-	tui.press("tui.select.confirm");
-
-	assert.equal((await running)?.[0]?.note, "note");
-});
-
-test("Other editor rejects oversized input and forwards focus", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.press("tui.select.down");
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	tui.setFocused(true);
-	assert.equal(tui.render().join("\n").includes(CURSOR_MARKER), true);
-	paste(tui, "x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1));
-	tui.press("tui.input.submit");
-	assert.match(tui.render().join("\n"), /4,000 characters or fewer/u);
-	assert.equal(tui.isOpen, true);
-	tui.press("ctrl+c");
-	assert.equal(await running, undefined);
-});
-
-test("Note editor rejects oversized input and stays open", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	tui.type("n");
-	const oversized = "z".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1);
-	paste(tui, oversized);
-	tui.press("tui.input.submit");
-	const frame = tui.render().join("\n");
-	assert.match(frame, /Note must be 4,000 characters or fewer/u);
-	assert.equal(tui.isOpen, true);
-	tui.press("ctrl+c");
-	assert.equal(await running, undefined);
-});
-
-test("TUI sanitizes rendering, preserves raw result text, and respects narrow widths", async () => {
-	const unsafe = "raw\u001b]8;;https://evil.example\u0007text\u001b]8;;\u0007";
-	const malicious: PlanModeQuestion[] = [
-		{
-			id: "unsafe",
-			header: `Head\u001b[31m`,
-			question: unsafe,
-			options: [
-				{ label: unsafe, description: "first" },
-				{ label: "safe", description: "second" },
-			],
-		},
-	];
-	const { tui, running } = tuiRun(malicious, 16);
-	await tui.waitForOpen();
-	tui.setFocused(true);
-	const frame = tui.render();
-	const plain = stripVTControlCharacters(frame.join("\n"));
-	assert.doesNotMatch(plain, /evil\.example/u);
-	assert.equal(plain.includes("\u0007") || plain.includes("\u001b"), false);
-	for (const line of frame) assert.ok(visibleWidth(line) <= 16);
-	assert.equal(sanitizeTerminalText(unsafe), "rawtext");
-	const answered = planModeQuestionAnswered(malicious, [
-		{
-			id: "unsafe",
-			header: malicious[0]?.header ?? "",
-			question: unsafe,
-			answer: unsafe,
-			wasCustom: true,
-		},
-	]);
-	assert.match(answered.content[0]?.text ?? "", /evil\.example/u);
-	tui.dispose();
-	assert.equal(await running, undefined);
-});
-
-test("RPC retains sequential select/editor fallback and retries oversized answers", async () => {
-	const selections = ["1. Small — Only the bug.", "3. Other (free-form)"];
-	const editorAnswers = ["x".repeat(MAX_PLAN_MODE_RESPONSE_LENGTH + 1), "rpc custom"];
-	const context = createMockContext({
-		mode: "rpc",
-		hasUI: true,
-		select: async () => selections.shift(),
-		editor: async () => editorAnswers.shift(),
-		custom: async () => assert.fail("RPC must not open custom TUI"),
-	});
-	const answers = await askPlanModeQuestions(questions, context.ctx);
-	assert.deepEqual(
-		answers?.map(({ answer, wasCustom }) => ({ answer, wasCustom })),
-		[
-			{ answer: "Small", wasCustom: false },
-			{ answer: "rpc custom", wasCustom: true },
-		],
-	);
-	assert.ok(context.notifications.some(({ message }) => message.includes("4,000")));
 });

--- a/packages/pi-workflow/test/compat-plan-question-tool.test.ts
+++ b/packages/pi-workflow/test/compat-plan-question-tool.test.ts
@@ -134,15 +134,17 @@ test("the Kit RPC runner preserves limits, ordering, and answer metadata", async
 	assert.ok(context.notifications.some(({ message }) => message.includes("4,000")));
 });
 
-test("the adapter uses safe display fallbacks without mutating selected option answers", async () => {
+test("the adapter sanitizes mixed display text without mutating raw domain answers", async () => {
 	const control = "\u001b[31m";
+	const rawHeader = `Visible${control}`;
+	const rawLabel = `Unsafe${control}`;
 	const unsafeQuestions: PlanModeQuestion[] = [
 		{
 			id: "unsafe",
-			header: control,
+			header: rawHeader,
 			question: control,
 			options: [
-				{ label: control, description: "First choice." },
+				{ label: rawLabel, description: "First choice." },
 				{ label: "Safe", description: "Second choice." },
 			],
 		},
@@ -159,10 +161,10 @@ test("the adapter uses safe display fallbacks without mutating selected option a
 		},
 	});
 	const answers = await askPlanModeQuestions(unsafeQuestions, context.ctx);
-	assert.equal(offeredTitle, "Question 1: Question 1");
-	assert.equal(offeredChoices[0], "1. Option 1 — First choice.");
-	assert.equal(answers?.[0]?.answer, control);
-	assert.equal(answers?.[0]?.header, control);
+	assert.equal(offeredTitle, "Visible: Question 1");
+	assert.equal(offeredChoices[0], "1. Unsafe — First choice.");
+	assert.equal(answers?.[0]?.answer, rawLabel);
+	assert.equal(answers?.[0]?.header, rawHeader);
 	assert.equal(answers?.[0]?.question, control);
 });
 


### PR DESCRIPTION
## Summary

- Replace duplicated Plan Mode and Workflow questionnaire TUI/RPC state machines with the published `@narumitw/pi-tui-kit` runner.
- Preserve extension-owned schema validation, lifecycle revalidation, response limits, raw domain answers, notes, and cancellation results.
- Raise both consumer dependency floors to `^0.57.0`, keep Kit external in generated runtimes, and add patch changesets.

## Verification

- Confirmed npm release workflow 32556201652 published `@narumitw/pi-tui-kit@0.57.0`.
- Installed `0.57.0` in a clean temporary npm project and imported its JavaScript function and root declarations without workspace hoisting.
- Built Pi TUI Kit before consumer tests.
- Passed 70 focused adapter, lifecycle, and generated-runtime tests across both consumers.
- Passed `npm run check` for builds, Biome, boundaries, and workspace typechecks.
- Passed `npm test`: 396 files and 3,730 tests.
- Passed `just pack plan-mode` and `just pack workflow`; inspected manifests, dependency ranges, required files, generated dynamic imports, and absence of duplicated questionnaire code.
- Passed offline non-interactive Pi package loads for `./packages/pi-plan-mode` and `./packages/pi-workflow`.
- Confirmed `npm run changeset:status` reports only patch releases for the two migrated consumers.

## Semantic audit

- Audited against `docs/extension-conventions.md`.
- Pi TUI Kit owns cancellation, component disposal, editor focus, paste behavior, terminal sanitization, width handling, keybindings, and RPC interaction loops.
- Each adapter passes the tool signal, checks current owner state after awaited imports and interaction, uses internal unique runner ids, and restores original domain fields in submitted answers.
- No compatibility deviations were introduced.

## Risks and unverified paths

- A manual real-terminal interactive smoke was not run; deterministic TUI/RPC harnesses cover the interaction, and offline `pi -e` help loads cover both package entrypoints without opening a TUI.
- One earlier full-suite run hit an unrelated transient `pi-worktree` timing assertion; its focused rerun and the final full suite passed.
- Changesets reports pre-existing compatibility-floor warnings for other Kit consumers, while the release set remains limited to these two packages.
- No package publication, version tag, or release workflow was triggered by this pull request.
