### PR TITLE
feat(file-context): add folder explorer

### DIFF
--- a/.changeset/bright-folders-browse.md
+++ b/.changeset/bright-folders-browse.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": patch
+---
+
+Browse discovered project folders hierarchically while keeping global file and content search.

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -13,7 +13,7 @@ Browse project files inside Pi, select exact lines or Git changes, and review ev
 ## ✨ Features
 
 - Opens from `/file-context` or a configurable shortcut that defaults to `F8`.
-- Searches file names or file contents and previews bounded text with line numbers.
+- Browses discovered project folders hierarchically, searches file names or contents globally, and previews bounded text with line numbers.
 - Adds whole-file references, exact line ranges, changed hunks, revisions, or Git diffs without using the clipboard.
 - Shows Git state, blame, bounded file history, provenance, and a deterministic token estimate before attachment.
 - Reviews and removes exact queued snapshots before the next prompt.
@@ -53,8 +53,10 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
 1. Run `/file-context` and choose **Add context snippet**.
    Press `F8` or run `/file-context browse` to open the browser directly.
    Every route shows the same cancellable project scan before browsing.
-2. Type to fuzzy-search file names in relevance order and use `Up`/`Down` to navigate.
-   Press `Tab` to insert a normal whole-file `@path` reference, or `Enter` to preview a file for quoting.
+2. Use `Up`/`Down` to select an immediate child folder or file, and press `Enter` to open it.
+   `Escape`, `Left`, or `Backspace` returns to the parent folder when the search field is empty.
+   Type to fuzzy-search file names across every discovered folder in relevance order.
+   Press `Tab` on a file to insert a normal whole-file `@path` reference, or `Enter` to preview it for quoting.
 3. Press `Ctrl+F` to switch between file-name and content search.
    Content search is literal and case-insensitive by default; `Alt+C` toggles case sensitivity and `Alt+F` toggles ordered fuzzy matching.
    The current states remain visible above the results.
@@ -71,9 +73,10 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
    `Escape` goes back without changing selected context, while `Ctrl+C` closes File Context.
    Write the question and submit normally; selected snippets are attached in order and cleared together.
 
-`Escape` returns from a preview to its originating file-name or content results.
-When the browser was opened from the menu, `Escape` from a root search returns to the menu.
-Direct browser routes cancel instead.
+`Escape` returns from a preview to its originating folder, file-search results, or content results.
+With an empty file-search field, `Escape` from a nested folder returns to its parent.
+When the browser was opened from the menu, `Escape` from the root folder returns to the menu.
+Direct browser routes cancel at the root instead.
 `Ctrl+C` closes menus and browsers.
 During project scanning, either cancel key stops the scan; menu-owned scans return to the menu and direct scans close without opening a stale explorer.
 
@@ -170,7 +173,9 @@ src/index.ts                   Thin Pi entrypoint
 src/file-context.ts            Lifecycle, routes, filesystem boundaries, selected state, prompt injection
 src/file-context-menu.ts       Standard Add, selected-context review, Help, and removal flow
 src/file-context-settings.ts   User shortcut loading and validation
-src/file-context-explorer.ts   File, content, Git, and line-range interaction controller
+src/file-context-explorer.ts   Folder, file, content, Git, and line-range interaction controller
+src/file-browser.ts            Safe hierarchy model for discovered project paths
+src/file-browser-ui.ts         Width-safe folder and file list rendering with effective key hints
 src/file-context-preview-ui.ts Width-safe preview, capacity, and progressive action help
 src/content-search.ts          Bounded literal and fuzzy content matching
 src/content-search-session.ts  Search input, toggles, navigation, and cancellation
@@ -181,6 +186,7 @@ src/git-context.ts             Bounded read-only Git status, diff, blame, histor
 test/content-search.test.ts     Content matcher behavior and limits
 test/content-search-ui.test.ts  Content interaction, rendering, and lifecycle tests
 test/file-context-search.test.ts  File-name ranking, typo tolerance, and query-bound tests
+test/file-context-folder-browser.test.ts  Folder hierarchy, navigation, keybinding, and terminal-safety tests
 test/file-context.test.ts       Filesystem, prompt, lifecycle, shortcut, and explorer tests
 test/file-context-selection.test.ts  Add-and-continue, capacity, and progressive-help tests
 test/file-context-menu.test.ts  Menu states, exact review, removal, limits, and responsive rendering tests

--- a/packages/pi-file-context/src/file-browser-ui.ts
+++ b/packages/pi-file-context/src/file-browser-ui.ts
@@ -1,0 +1,139 @@
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+import type { ProjectBrowserItem } from "./file-browser.js";
+import { safeTerminalText } from "./file-browser.js";
+
+interface FileBrowserRenderOptions {
+	theme: Theme;
+	keybindings: KeybindingsManager;
+	width: number;
+	height: number;
+	items: readonly ProjectBrowserItem[];
+	selectedIndex: number;
+	scrollOffset: number;
+	currentDirectory: string;
+	searchLine: string;
+	searchActive: boolean;
+	repositoryLabel: string;
+	statuses?: ReadonlyMap<string, { code: string }>;
+	loading: boolean;
+	error?: string;
+}
+
+export function renderFileBrowser(options: FileBrowserRenderOptions): string[] {
+	const location = options.currentDirectory ? `/${options.currentDirectory}` : "/";
+	const title = options.theme.fg(
+		"accent",
+		options.theme.bold(`File Context · files · ${location}${options.repositoryLabel}`),
+	);
+	const visibleItems = options.items.slice(
+		options.scrollOffset,
+		options.scrollOffset + options.height,
+	);
+	const itemLines = visibleItems.map((item, visibleIndex) => {
+		const index = options.scrollOffset + visibleIndex;
+		const prefix = index === options.selectedIndex ? "> " : "  ";
+		const status = item.kind === "file" ? (options.statuses?.get(item.path)?.code ?? "  ") : "  ";
+		const suffix = item.kind === "directory" ? "/" : "";
+		const line = `${prefix}${status} ${item.label}${suffix}`;
+		return truncateToWidth(
+			index === options.selectedIndex
+				? options.theme.bg("selectedBg", options.theme.fg("text", line))
+				: line,
+			options.width,
+			"",
+		);
+	});
+	if (itemLines.length === 0) {
+		itemLines.push(
+			truncateToWidth(options.theme.fg("muted", "  No matching files"), options.width, ""),
+		);
+	}
+	const state = options.loading
+		? options.theme.fg("warning", "Loading…")
+		: options.error
+			? options.theme.fg("error", safeTerminalText(options.error))
+			: options.theme.fg("muted", formatFileBrowserHint(options));
+	return [
+		truncateToWidth(title, options.width, ""),
+		truncateToWidth(options.searchLine, options.width, ""),
+		...itemLines,
+		truncateToWidth(state, options.width, ""),
+	];
+}
+
+function formatFileBrowserHint(options: FileBrowserRenderOptions): string {
+	const selected = options.items[options.selectedIndex];
+	const countLabel = options.searchActive
+		? `${options.items.length} matching ${options.items.length === 1 ? "file" : "files"}`
+		: `${options.items.length} ${options.items.length === 1 ? "item" : "items"}`;
+	const navigation = navigationHint(options.keybindings);
+	const confirm = bindingHint(options.keybindings, "tui.select.confirm", ["enter"]);
+	const tab = bindingHint(options.keybindings, "tui.input.tab", ["tab"]);
+	const cancel = uniqueKeys([
+		...bindingKeys(options.keybindings, "tui.select.cancel", ["escape"]),
+		formatHintKey("ctrl+c"),
+	]).join("/");
+	return [
+		countLabel,
+		`${navigation} navigate`,
+		`${confirm} ${selected?.kind === "directory" ? "open folder" : "preview"}`,
+		...(selected?.kind === "file" ? [`${tab} reference`] : []),
+		"Ctrl+F contents",
+		`${cancel} ${options.currentDirectory && !options.searchActive ? "back" : "cancel"}`,
+	].join(" · ");
+}
+
+function navigationHint(keybindings: KeybindingsManager): string {
+	const up = bindingKeys(keybindings, "tui.select.up", ["up"]);
+	const down = bindingKeys(keybindings, "tui.select.down", ["down"]);
+	if (up.includes("↑") && down.includes("↓")) {
+		return uniqueKeys([
+			"↑↓",
+			...up.filter((key) => key !== "↑"),
+			...down.filter((key) => key !== "↓"),
+		]).join("/");
+	}
+	return uniqueKeys([...up, ...down]).join("/");
+}
+
+function bindingHint(
+	keybindings: KeybindingsManager,
+	binding: Parameters<KeybindingsManager["getKeys"]>[0],
+	fallback: readonly string[],
+): string {
+	return bindingKeys(keybindings, binding, fallback).join("/");
+}
+
+function bindingKeys(
+	keybindings: KeybindingsManager,
+	binding: Parameters<KeybindingsManager["getKeys"]>[0],
+	fallback: readonly string[],
+): string[] {
+	const getKeys = keybindings.getKeys?.bind(keybindings);
+	const keys = getKeys?.(binding) ?? fallback;
+	return uniqueKeys(keys.map(formatHintKey));
+}
+
+function uniqueKeys(keys: readonly string[]): string[] {
+	return [...new Set(keys.filter(Boolean))];
+}
+
+function formatHintKey(key: string): string {
+	const normalized = safeTerminalText(key).toLowerCase();
+	if (normalized === "up") return "↑";
+	if (normalized === "down") return "↓";
+	if (normalized === "left") return "←";
+	if (normalized === "right") return "→";
+	if (normalized === "return" || normalized === "enter") return "Enter";
+	if (normalized === "escape" || normalized === "esc") return "Esc";
+	if (normalized === "tab") return "Tab";
+	return normalized
+		.split("+")
+		.map((part, index) =>
+			part === "ctrl" || part === "alt" || part === "shift" || (index > 0 && part.length === 1)
+				? `${part[0]?.toUpperCase()}${part.slice(1)}`
+				: part,
+		)
+		.join("+");
+}

--- a/packages/pi-file-context/src/file-browser.ts
+++ b/packages/pi-file-context/src/file-browser.ts
@@ -1,0 +1,79 @@
+interface IndexedProjectFile {
+	path: string;
+	displayPath: string;
+	segments: readonly string[];
+}
+
+export type ProjectBrowserItem =
+	| { kind: "directory"; path: string; label: string }
+	| { kind: "file"; path: string; label: string };
+
+export class ProjectFileBrowser {
+	private readonly files: readonly IndexedProjectFile[];
+	private readonly filesByPath: ReadonlyMap<string, IndexedProjectFile>;
+
+	constructor(paths: readonly string[]) {
+		this.files = paths.map((path) => {
+			const displayPath = safeTerminalText(path);
+			return { path, displayPath, segments: displayPath.split("/") };
+		});
+		this.filesByPath = new Map(this.files.map((file) => [file.path, file]));
+	}
+
+	list(directory: string): ProjectBrowserItem[] {
+		const directorySegments = directory ? directory.split("/") : [];
+		const directories = new Map<string, ProjectBrowserItem>();
+		const files: ProjectBrowserItem[] = [];
+
+		for (const file of this.files) {
+			if (!startsWithSegments(file.segments, directorySegments)) continue;
+			const childIndex = directorySegments.length;
+			const label = file.segments[childIndex];
+			if (!label) continue;
+			if (file.segments.length > childIndex + 1) {
+				const path = [...directorySegments, label].join("/");
+				directories.set(path, { kind: "directory", path, label });
+				continue;
+			}
+			files.push({ kind: "file", path: file.path, label });
+		}
+
+		return [
+			...[...directories.values()].sort(compareBrowserItems),
+			...files.sort(compareBrowserItems),
+		];
+	}
+
+	searchResults(paths: readonly string[]): ProjectBrowserItem[] {
+		return paths.flatMap((path) => {
+			const file = this.filesByPath.get(path);
+			return file ? [{ kind: "file" as const, path: file.path, label: file.displayPath }] : [];
+		});
+	}
+}
+
+export function parentProjectDirectory(directory: string): string {
+	const separator = directory.lastIndexOf("/");
+	return separator < 0 ? "" : directory.slice(0, separator);
+}
+
+export function safeTerminalText(text: string): string {
+	return [...text]
+		.map((character) => {
+			if (character === "\t") return "    ";
+			const code = character.charCodeAt(0);
+			if (code <= 31 || (code >= 127 && code <= 159)) {
+				return `\\x${code.toString(16).padStart(2, "0")}`;
+			}
+			return character;
+		})
+		.join("");
+}
+
+function startsWithSegments(path: readonly string[], prefix: readonly string[]): boolean {
+	return prefix.every((segment, index) => path[index] === segment);
+}
+
+function compareBrowserItems(left: ProjectBrowserItem, right: ProjectBrowserItem): number {
+	return left.label < right.label ? -1 : left.label > right.label ? 1 : 0;
+}

--- a/packages/pi-file-context/src/file-context-explorer.ts
+++ b/packages/pi-file-context/src/file-context-explorer.ts
@@ -12,6 +12,13 @@ import {
 import type { ContentSearchMatch } from "./content-search.js";
 import { ContentSearchSession } from "./content-search-session.js";
 import {
+	safeTerminalText as escapeTerminalControls,
+	type ProjectBrowserItem,
+	ProjectFileBrowser,
+	parentProjectDirectory,
+} from "./file-browser.js";
+import { renderFileBrowser } from "./file-browser-ui.js";
+import {
 	createFileQuote,
 	createFileQuoteSnapshot,
 	type FileQuote,
@@ -62,7 +69,10 @@ export class FileQuoteExplorer implements Component, Focusable {
 	private readonly contentSearch: ContentSearchSession;
 	private readonly revisionInput = new Input();
 	private readonly fileSearch: ProjectFileSearch;
-	private filteredFiles: string[];
+	private readonly fileBrowser: ProjectFileBrowser;
+	private fileItems: ProjectBrowserItem[];
+	private currentDirectory = "";
+	private readonly directoryPositions = new Map<string, { index: number; offset: number }>();
 	private selectedFileIndex = 0;
 	private fileScrollOffset = 0;
 	private mode:
@@ -99,7 +109,8 @@ export class FileQuoteExplorer implements Component, Focusable {
 
 	constructor(private readonly options: FileQuoteExplorerOptions) {
 		this.fileSearch = new ProjectFileSearch(options.files);
-		this.filteredFiles = [...options.files];
+		this.fileBrowser = new ProjectFileBrowser(options.files);
+		this.fileItems = this.fileBrowser.list("");
 		this.contentSearch = new ContentSearchSession({
 			tui: options.tui,
 			theme: options.theme,
@@ -184,53 +195,26 @@ export class FileQuoteExplorer implements Component, Focusable {
 		const repositoryLabel = project
 			? ` · ${escapeTerminalControls(project.branch)}@${project.head.slice(0, 12)}${project.dirty ? " · dirty" : ""}`
 			: "";
-		const title = this.options.theme.fg(
-			"accent",
-			this.options.theme.bold(`File Context · files${repositoryLabel}`),
-		);
 		const queryLabel = this.options.theme.fg("muted", "Search: ");
 		const queryWidth = Math.max(1, width - visibleWidth(queryLabel));
 		const searchLine = `${queryLabel}${this.search.render(queryWidth)[0] ?? ""}`;
-		const visibleFiles = this.filteredFiles.slice(
-			this.fileScrollOffset,
-			this.fileScrollOffset + listHeight,
-		);
-		const fileLines = visibleFiles.map((file, visibleIndex) => {
-			const index = this.fileScrollOffset + visibleIndex;
-			const prefix = index === this.selectedFileIndex ? "> " : "  ";
-			const status = this.options.gitContext?.statuses.get(file)?.code ?? "  ";
-			const line = `${prefix}${status} ${escapeTerminalControls(file)}`;
-			return truncateToWidth(
-				index === this.selectedFileIndex
-					? this.options.theme.bg("selectedBg", this.options.theme.fg("text", line))
-					: line,
-				width,
-				"",
-			);
-		});
-		if (fileLines.length === 0) {
-			fileLines.push(
-				truncateToWidth(this.options.theme.fg("muted", "  No matching files"), width, ""),
-			);
-		}
-		const state = this.loading
-			? this.options.theme.fg("warning", "Loading…")
-			: this.error
-				? this.options.theme.fg(
-						"error",
-						truncateToWidth(escapeTerminalControls(this.error), width, ""),
-					)
-				: this.options.theme.fg(
-						"muted",
-						`${this.filteredFiles.length} files · ↑↓ navigate · Enter preview · Tab reference · Ctrl+F contents · Esc cancel`,
-					);
 		return fitRows(
-			[
-				truncateToWidth(title, width, ""),
-				truncateToWidth(searchLine, width, ""),
-				...fileLines,
-				truncateToWidth(state, width, ""),
-			],
+			renderFileBrowser({
+				theme: this.options.theme,
+				keybindings: this.options.keybindings,
+				width,
+				height: listHeight,
+				items: this.fileItems,
+				selectedIndex: this.selectedFileIndex,
+				scrollOffset: this.fileScrollOffset,
+				currentDirectory: this.currentDirectory,
+				searchLine,
+				searchActive: this.isFileSearchActive(),
+				repositoryLabel,
+				statuses: this.options.gitContext?.statuses,
+				loading: this.loading,
+				error: this.error,
+			}),
 			availableRows,
 		);
 	}
@@ -372,12 +356,16 @@ export class FileQuoteExplorer implements Component, Focusable {
 	}
 
 	private handleFileInput(data: string): void {
+		if (this.options.keybindings.matches(data, "tui.select.cancel")) {
+			this.cancelFileList();
+			return;
+		}
 		if (matchesKey(data, Key.ctrl("f"))) {
 			this.showContentSearch();
 			return;
 		}
 		if (matchesKey(data, Key.escape)) {
-			this.finish(this.rootExit("back"));
+			this.cancelFileList();
 			return;
 		}
 		if (this.loading) return;
@@ -387,7 +375,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 		}
 		if (this.options.keybindings.matches(data, "tui.select.down")) {
 			this.selectedFileIndex = Math.min(
-				Math.max(0, this.filteredFiles.length - 1),
+				Math.max(0, this.fileItems.length - 1),
 				this.selectedFileIndex + 1,
 			);
 			return;
@@ -398,19 +386,31 @@ export class FileQuoteExplorer implements Component, Focusable {
 		}
 		if (this.options.keybindings.matches(data, "tui.select.pageDown")) {
 			this.selectedFileIndex = Math.min(
-				Math.max(0, this.filteredFiles.length - 1),
+				Math.max(0, this.fileItems.length - 1),
 				this.selectedFileIndex + 10,
 			);
 			return;
 		}
 		if (this.options.keybindings.matches(data, "tui.select.confirm")) {
-			const path = this.filteredFiles[this.selectedFileIndex];
-			if (path) void this.openFile(path);
+			this.openSelectedFileItem();
 			return;
 		}
 		if (this.options.keybindings.matches(data, "tui.input.tab")) {
-			const path = this.filteredFiles[this.selectedFileIndex];
-			if (path) this.finish({ kind: "reference", path });
+			const item = this.fileItems[this.selectedFileIndex];
+			if (item?.kind === "file") this.finish({ kind: "reference", path: item.path });
+			return;
+		}
+		if (
+			!this.isFileSearchActive() &&
+			this.currentDirectory &&
+			(matchesKey(data, Key.left) || matchesKey(data, Key.backspace))
+		) {
+			this.showParentDirectory();
+			return;
+		}
+		if (!this.isFileSearchActive() && matchesKey(data, Key.right)) {
+			const item = this.fileItems[this.selectedFileIndex];
+			if (item?.kind === "directory") this.showDirectory(item.path);
 			return;
 		}
 
@@ -418,7 +418,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.search.handleInput(data);
 		const query = this.search.getValue();
 		if (query !== previousQuery) {
-			this.filteredFiles = this.fileSearch.search(query);
+			this.refreshFileItems(query);
 			this.selectedFileIndex = 0;
 			this.fileScrollOffset = 0;
 			this.error = undefined;
@@ -810,6 +810,56 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.error = undefined;
 	}
 
+	private openSelectedFileItem(): void {
+		const item = this.fileItems[this.selectedFileIndex];
+		if (item?.kind === "directory") {
+			this.showDirectory(item.path);
+			return;
+		}
+		if (item?.kind === "file") void this.openFile(item.path);
+	}
+
+	private showDirectory(directory: string): void {
+		this.directoryPositions.set(this.currentDirectory, {
+			index: this.selectedFileIndex,
+			offset: this.fileScrollOffset,
+		});
+		this.currentDirectory = directory;
+		this.refreshFileItems("");
+		const position = this.directoryPositions.get(directory);
+		this.selectedFileIndex = Math.min(position?.index ?? 0, Math.max(0, this.fileItems.length - 1));
+		this.fileScrollOffset = Math.min(position?.offset ?? 0, this.selectedFileIndex);
+		this.error = undefined;
+	}
+
+	private showParentDirectory(): void {
+		this.cancelOpenRequest();
+		this.currentDirectory = parentProjectDirectory(this.currentDirectory);
+		this.refreshFileItems("");
+		const position = this.directoryPositions.get(this.currentDirectory);
+		this.selectedFileIndex = Math.min(position?.index ?? 0, Math.max(0, this.fileItems.length - 1));
+		this.fileScrollOffset = Math.min(position?.offset ?? 0, this.selectedFileIndex);
+		this.error = undefined;
+	}
+
+	private refreshFileItems(query: string): void {
+		this.fileItems = this.isFileSearchActive(query)
+			? this.fileBrowser.searchResults(this.fileSearch.search(query))
+			: this.fileBrowser.list(this.currentDirectory);
+	}
+
+	private isFileSearchActive(query = this.search.getValue()): boolean {
+		return escapeTerminalControls(query).trim().length > 0;
+	}
+
+	private cancelFileList(): void {
+		if (this.currentDirectory && !this.isFileSearchActive()) {
+			this.showParentDirectory();
+			return;
+		}
+		this.finish(this.rootExit("back"));
+	}
+
 	private cancelOpenRequest(): void {
 		this.openRequest += 1;
 		this.openController?.abort();
@@ -923,19 +973,6 @@ function fitRows(lines: string[], height: number): string[] {
 	if (lines.length <= height) return lines;
 	if (height <= 1) return lines.slice(0, 1);
 	return [...lines.slice(0, height - 1), lines.at(-1) ?? ""];
-}
-
-function escapeTerminalControls(text: string): string {
-	return [...text]
-		.map((character) => {
-			if (character === "\t") return "    ";
-			const code = character.charCodeAt(0);
-			if (code <= 31 || (code >= 127 && code <= 159)) {
-				return `\\x${code.toString(16).padStart(2, "0")}`;
-			}
-			return character;
-		})
-		.join("");
 }
 
 function formatHistoryDate(authorTime: number): string {

--- a/packages/pi-file-context/src/file-search.ts
+++ b/packages/pi-file-context/src/file-search.ts
@@ -1,3 +1,5 @@
+import { safeTerminalText } from "./file-browser.js";
+
 const MAX_SEARCH_QUERY_LENGTH = 256;
 const MAX_SEARCH_QUERY_PARTS = 8;
 const PATH_SCORE_PENALTY = 50;
@@ -33,7 +35,7 @@ export class ProjectFileSearch {
 	constructor(files: readonly string[]) {
 		this.files = [...files];
 		this.entries = this.files.map((path, originalIndex) => {
-			const normalizedPath = path.toLowerCase();
+			const normalizedPath = safeTerminalText(path).toLowerCase();
 			const normalizedBasename = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1);
 			return {
 				path,
@@ -47,7 +49,7 @@ export class ProjectFileSearch {
 	}
 
 	search(query: string): string[] {
-		const trimmedQuery = query.trim();
+		const trimmedQuery = safeTerminalText(query).trim();
 		if (!trimmedQuery) return [...this.files];
 		if (trimmedQuery.length > MAX_SEARCH_QUERY_LENGTH) return [];
 		const normalizedQuery = trimmedQuery.toLowerCase();

--- a/packages/pi-file-context/test/file-context-folder-browser.test.ts
+++ b/packages/pi-file-context/test/file-context-folder-browser.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { ProjectFileBrowser, parentProjectDirectory } from "../src/file-browser.js";
+import { FileQuoteExplorer } from "../src/file-context-explorer.js";
+
+const files = ["README.md", "src/main.ts", "src/nested/value.ts", "test/main.test.ts"];
+
+function createExplorer(
+	cancelInput = "q",
+	loadFile: (
+		path: string,
+		signal?: AbortSignal,
+	) => Promise<{ path: string; lines: string[] }> = async (path) => ({ path, lines: [path] }),
+) {
+	let result: unknown = "pending";
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 14 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, binding: string) {
+				return (
+					(data === "k" && binding === "tui.select.up") ||
+					(data === "j" && binding === "tui.select.down") ||
+					(data === "o" && binding === "tui.select.confirm") ||
+					(data === cancelInput && binding === "tui.select.cancel") ||
+					(data === "t" && binding === "tui.input.tab")
+				);
+			},
+			getKeys(binding: string) {
+				return (
+					{
+						"tui.select.up": ["k"],
+						"tui.select.down": ["j"],
+						"tui.select.confirm": ["o"],
+						"tui.select.cancel": ["q"],
+						"tui.input.tab": ["t"],
+					}[binding] ?? []
+				);
+			},
+		} as never,
+		files,
+		loadFile,
+		rootNavigation: true,
+		done: (value) => {
+			result = value;
+		},
+	});
+	return { explorer, getResult: () => result };
+}
+
+test("derives safe immediate folder entries while preserving raw file paths", () => {
+	const unsafePath = "src/unsafe\u001b[31m.ts";
+	const browser = new ProjectFileBrowser([...files, unsafePath]);
+	assert.deepEqual(browser.list(""), [
+		{ kind: "directory", path: "src", label: "src" },
+		{ kind: "directory", path: "test", label: "test" },
+		{ kind: "file", path: "README.md", label: "README.md" },
+	]);
+	assert.deepEqual(browser.list("src"), [
+		{ kind: "directory", path: "src/nested", label: "nested" },
+		{ kind: "file", path: "src/main.ts", label: "main.ts" },
+		{ kind: "file", path: unsafePath, label: "unsafe\\x1b[31m.ts" },
+	]);
+	assert.deepEqual(browser.searchResults([unsafePath]), [
+		{ kind: "file", path: unsafePath, label: "src/unsafe\\x1b[31m.ts" },
+	]);
+	assert.equal(parentProjectDirectory("src/nested"), "src");
+	assert.equal(parentProjectDirectory("src"), "");
+});
+
+test("browses folders with effective keybindings and keeps folder rows non-referenceable", () => {
+	const { explorer, getResult } = createExplorer();
+	let frame = explorer.render(44);
+	assert.ok(frame.every((line) => visibleWidth(line) <= 44));
+	assert.match(frame.join("\n"), /src\//u);
+	assert.match(frame.join("\n"), /test\//u);
+	assert.match(frame.join("\n"), /k\/j navigate/u);
+	assert.match(frame.join("\n"), /o open folder/u);
+	assert.match(explorer.render(100).join("\n"), /q\/Ctrl\+C cancel/u);
+
+	explorer.handleInput("o");
+	frame = explorer.render(44);
+	assert.match(frame.join("\n"), /File Context · files · \/src/u);
+	assert.match(frame.join("\n"), /nested\//u);
+	assert.match(frame.join("\n"), /main\.ts/u);
+	assert.match(explorer.render(100).join("\n"), /q\/Ctrl\+C back/u);
+	explorer.handleInput("t");
+	assert.equal(getResult(), "pending");
+
+	explorer.handleInput("\u001b[D");
+	assert.equal(explorer.render(44)[0], "File Context · files · /");
+	explorer.handleInput("o");
+	explorer.handleInput("\u007f");
+	assert.equal(explorer.render(44)[0], "File Context · files · /");
+	explorer.handleInput("o");
+	explorer.handleInput("q");
+	assert.equal(explorer.render(44)[0], "File Context · files · /");
+	explorer.handleInput("q");
+	assert.deepEqual(getResult(), { kind: "back" });
+});
+
+test("cancels a pending nested file open when returning to the parent folder", async () => {
+	let openSignal: AbortSignal | undefined;
+	let resolveOpen: ((value: { path: string; lines: string[] }) => void) | undefined;
+	const { explorer } = createExplorer(
+		"q",
+		(_path, signal) =>
+			new Promise((resolve) => {
+				openSignal = signal;
+				resolveOpen = resolve;
+			}),
+	);
+
+	explorer.handleInput("o");
+	explorer.handleInput("j");
+	explorer.handleInput("o");
+	await Promise.resolve();
+	explorer.handleInput("q");
+	assert.equal(openSignal?.aborted, true);
+	assert.equal(explorer.render(60)[0], "File Context · files · /");
+	resolveOpen?.({ path: "src/main.ts", lines: ["stale"] });
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(explorer.render(60)[0], "File Context · files · /");
+});
+
+test("prioritizes a remapped cancel binding over the additive content-search shortcut", () => {
+	const { explorer, getResult } = createExplorer("\u0006");
+
+	explorer.handleInput("\u0006");
+	assert.deepEqual(getResult(), { kind: "back" });
+});
+
+test("keeps fuzzy search global while browsing a folder", () => {
+	const { explorer, getResult } = createExplorer();
+	explorer.handleInput("o");
+	explorer.handleInput("value");
+	const frame = explorer.render(60).join("\n");
+	assert.match(frame, /src\/nested\/value\.ts/u);
+	assert.match(frame, /1 matching file/u);
+	explorer.handleInput("t");
+	assert.deepEqual(getResult(), { kind: "reference", path: "src/nested/value.ts" });
+});

--- a/packages/pi-file-context/test/file-context-search.test.ts
+++ b/packages/pi-file-context/test/file-context-search.test.ts
@@ -28,6 +28,14 @@ test("ranks fuzzy file matches and tolerates typos", () => {
 	assert.deepEqual(search.search("  "), files);
 });
 
+test("searches terminal-safe copies without changing returned raw paths", () => {
+	const unsafePath = "src/unsafe\u001b[31m.ts";
+	const search = new ProjectFileSearch([unsafePath]);
+
+	assert.deepEqual(search.search("unsafe\\x1b"), [unsafePath]);
+	assert.deepEqual(search.search("unsafe\u001b"), [unsafePath]);
+});
+
 test("bounds fuzzy search before scoring overlong pasted queries", () => {
 	const maximumQuery = "a".repeat(256);
 	const overlongQuery = `${maximumQuery}a`;

--- a/packages/pi-file-context/test/file-context-selection.test.ts
+++ b/packages/pi-file-context/test/file-context-selection.test.ts
@@ -179,6 +179,7 @@ test("explorer adds exact context and keeps browsing with visible capacity and a
 	});
 
 	explorer.handleInput("enter");
+	explorer.handleInput("enter");
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	explorer.handleInput(" ");
 	explorer.handleInput("down");

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -223,6 +223,7 @@ test("explorer previews a file, selects a range, and keeps rendered rows width-s
 	assert.ok(fileRows.every((line) => !line.includes("\u001b[31m")));
 	assert.ok(fileRows.every((line) => visibleWidth(line) <= 32));
 	explorer.handleInput("enter");
+	explorer.handleInput("enter");
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	explorer.handleInput(" ");
 	explorer.handleInput("down");
@@ -250,6 +251,7 @@ test("explorer previews a file, selects a range, and keeps rendered rows width-s
 			result = value;
 		},
 	});
+	referenceExplorer.handleInput("enter");
 	referenceExplorer.handleInput("tab");
 	assert.deepEqual(result, { kind: "reference", path: "src/reference.ts" });
 
@@ -386,6 +388,7 @@ test("explorer shows Git status and provenance and selects changed hunks", async
 		},
 	});
 
+	explorer.handleInput("enter");
 	assert.ok(explorer.render(80).some((line) => line.includes(" M") && line.includes("changed.ts")));
 	explorer.handleInput("enter");
 	await new Promise<void>((resolve) => setImmediate(resolve));
@@ -470,6 +473,7 @@ test("explorer discloses current-line blame and bounded file history", async () 
 	});
 
 	explorer.handleInput("enter");
+	explorer.handleInput("enter");
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	explorer.handleInput("b");
 	await new Promise<void>((resolve) => setImmediate(resolve));
@@ -535,6 +539,7 @@ test("explorer cancellation releases detail loading and empty history stays widt
 		done() {},
 	});
 
+	explorer.handleInput("enter");
 	explorer.handleInput("enter");
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	explorer.handleInput("h");
@@ -639,6 +644,7 @@ test("explorer loads validated revisions and attaches explicit Git diff context"
 
 	const revisionExplorer = makeExplorer();
 	revisionExplorer.handleInput("enter");
+	revisionExplorer.handleInput("enter");
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	revisionExplorer.handleInput("r");
 	revisionExplorer.handleInput("HEAD~1");
@@ -659,6 +665,7 @@ test("explorer loads validated revisions and attaches explicit Git diff context"
 	);
 
 	const diffExplorer = makeExplorer();
+	diffExplorer.handleInput("enter");
 	diffExplorer.handleInput("enter");
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	diffExplorer.handleInput("d");

--- a/packages/pi-file-context/test/pending-quotes.test.ts
+++ b/packages/pi-file-context/test/pending-quotes.test.ts
@@ -49,7 +49,7 @@ async function stageQuote(
 	const running = Promise.resolve(command?.handler("browse", context.ctx));
 	await waitForText(tui, "File Context");
 	assert.equal(path.startsWith("src/"), true);
-	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
 	tui.press("tui.select.confirm");
 	await waitForText(tui, "Enter add");
 	assert.match(tui.render().join("\n"), new RegExp(text, "u"));


### PR DESCRIPTION
## Summary

- Add hierarchical browsing for discovered project folders while preserving global fuzzy file search and content search.
- Support folder entry and parent navigation with effective keybinding hints, width-safe rendering, and non-referenceable folder rows.
- Cancel stale nested file opens, sanitize paths before hierarchy and search processing, and preserve raw paths for loading and references.
- Update documentation and add a patch changeset for `@narumitw/pi-file-context`.

## Verification

- `npm --workspace @narumitw/pi-file-context run check`
- `npx vitest run packages/pi-file-context/test` — 82 tests passed
- `npm run check`
- `npm test` — 3,736 tests passed
- Fenced-code-aware README heading audit
- `just pack file-context` — 18 files inspected
- Pi RPC package load smoke with `get_state`
