### PR TITLE
feat(file-context): add shortcut settings

### DIFF
--- a/.changeset/brave-files-open.md
+++ b/.changeset/brave-files-open.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": patch
+---
+
+Use Ctrl+X as the default browser shortcut and configure it immediately from the File Context Settings menu.

--- a/.changeset/brave-files-open.md
+++ b/.changeset/brave-files-open.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-file-context": patch
 ---
 
-Use Ctrl+X as the default browser shortcut and configure it immediately from the File Context Settings menu.
+Use Ctrl+Shift+X as the default browser shortcut and configure it safely from the File Context Settings menu.

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -12,7 +12,7 @@ Browse project files inside Pi, select exact lines or Git changes, and review ev
 
 ## ✨ Features
 
-- Opens from `/file-context` or a configurable shortcut that defaults to `Ctrl+X`.
+- Opens from `/file-context` or a configurable shortcut that defaults to `Ctrl+Shift+X`.
 - Browses discovered project folders hierarchically, searches file names or contents globally, and previews bounded text with line numbers.
 - Adds whole-file references, exact line ranges, changed hunks, revisions, or Git diffs without using the clipboard.
 - Shows Git state, blame, bounded file history, provenance, and a deterministic token estimate before attachment.
@@ -44,14 +44,14 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
 
 ## 🚀 Quick start
 
-1. Press `Ctrl+X` or run `/file-context browse`.
+1. Press `Ctrl+Shift+X` or run `/file-context browse`.
 2. Find a file, preview it, select the exact lines or Git change, and press `Enter` to attach the snapshot.
 3. Review queued snapshots from `/file-context`, write the request, and submit normally.
 
 ## 🧭 Browser workflow
 
 1. Run `/file-context` and choose **Add context snippet**.
-   Press `Ctrl+X` or run `/file-context browse` to open the browser directly.
+   Press `Ctrl+Shift+X` or run `/file-context browse` to open the browser directly.
    Every route shows the same cancellable project scan before browsing.
 2. Use `Up`/`Down` to select an immediate child folder or file, and press `Enter` to open it.
    `Escape`, `Left`, or `Backspace` returns to the parent folder when the search field is empty.
@@ -102,24 +102,28 @@ File Context reads optional user settings from `~/.pi/agent/pi-file-context.json
 The file is not created when defaults are used.
 
 Open `/file-context`, choose **Settings**, then choose **Open shortcut** to change or disable it.
-Menu changes are saved and applied immediately in the current Pi session.
+The Settings action is unavailable while context snippets are selected because applying the shortcut reloads Pi and would otherwise discard those in-memory selections.
+A successful menu save reloads Pi automatically so the new shortcut becomes active.
 
 ```json
 {
-  "openShortcut": "ctrl+x"
+  "openShortcut": "ctrl+shift+x"
 }
 ```
 
 Set `openShortcut` to any valid Pi key identifier, or set it to `null` to disable the direct browser shortcut and use `/file-context browse`.
-Run `/reload` after editing the JSON file manually; menu changes do not require reload.
+Run `/reload` after editing the JSON file manually.
 
-Missing settings use `Ctrl+X` without creating the file.
-Invalid JSON or values leave the source file unchanged, use the safe default on load, show a warning, and make the Settings screen read-only until the file is fixed.
+Missing settings use `Ctrl+Shift+X` without creating the file.
+`Ctrl+Shift+X` requires a terminal that reports shifted control keys through the Kitty keyboard protocol or modifyOtherKeys; use `F8` if the terminal cannot distinguish it from `Ctrl+X`.
+Invalid JSON or values leave the source file unchanged, use the safe default on load, show a warning, and make the Settings screen read-only until the file is fixed and Pi is reloaded.
 Failed saves preserve the previous effective shortcut.
+If an automatic reload fails after a successful save, run `/reload` to apply the saved value.
 Interactive saves preserve unknown fields, run in request order within the Pi process, and publish atomically with private file permissions.
 
 Choose a shortcut that does not conflict with Pi or another extension; `Ctrl+F` is already File Context's internal search-mode toggle.
-Explicit `F8` and `Ctrl+Alt+F` values remain supported, but the default is now `Ctrl+X`.
+Pi reserves `Ctrl+X` for `app.message.copy` by default, so remap that built-in action before assigning `Ctrl+X` to File Context.
+Explicit `F8` and `Ctrl+Alt+F` values remain supported, but the default is now `Ctrl+Shift+X`.
 
 ## 💬 Commands
 

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -12,7 +12,7 @@ Browse project files inside Pi, select exact lines or Git changes, and review ev
 
 ## ✨ Features
 
-- Opens from `/file-context` or a configurable shortcut that defaults to `F8`.
+- Opens from `/file-context` or a configurable shortcut that defaults to `Ctrl+X`.
 - Browses discovered project folders hierarchically, searches file names or contents globally, and previews bounded text with line numbers.
 - Adds whole-file references, exact line ranges, changed hunks, revisions, or Git diffs without using the clipboard.
 - Shows Git state, blame, bounded file history, provenance, and a deterministic token estimate before attachment.
@@ -44,14 +44,14 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
 
 ## 🚀 Quick start
 
-1. Press `F8` or run `/file-context browse`.
+1. Press `Ctrl+X` or run `/file-context browse`.
 2. Find a file, preview it, select the exact lines or Git change, and press `Enter` to attach the snapshot.
 3. Review queued snapshots from `/file-context`, write the request, and submit normally.
 
 ## 🧭 Browser workflow
 
 1. Run `/file-context` and choose **Add context snippet**.
-   Press `F8` or run `/file-context browse` to open the browser directly.
+   Press `Ctrl+X` or run `/file-context browse` to open the browser directly.
    Every route shows the same cancellable project scan before browsing.
 2. Use `Up`/`Down` to select an immediate child folder or file, and press `Enter` to open it.
    `Escape`, `Left`, or `Backspace` returns to the parent folder when the search field is empty.
@@ -101,28 +101,31 @@ File Context reads optional user settings from `~/.pi/agent/pi-file-context.json
 
 The file is not created when defaults are used.
 
+Open `/file-context`, choose **Settings**, then choose **Open shortcut** to change or disable it.
+Menu changes are saved and applied immediately in the current Pi session.
+
 ```json
 {
-  "openShortcut": "f8"
+  "openShortcut": "ctrl+x"
 }
 ```
 
-Set `openShortcut` to any valid Pi key identifier, or set it to `null` to disable the direct browser shortcut and use the `/file-context` menu.
+Set `openShortcut` to any valid Pi key identifier, or set it to `null` to disable the direct browser shortcut and use `/file-context browse`.
+Run `/reload` after editing the JSON file manually; menu changes do not require reload.
 
-Run `/reload` after editing the file because Pi registers extension shortcuts during extension loading.
+Missing settings use `Ctrl+X` without creating the file.
+Invalid JSON or values leave the source file unchanged, use the safe default on load, show a warning, and make the Settings screen read-only until the file is fixed.
+Failed saves preserve the previous effective shortcut.
+Interactive saves preserve unknown fields, run in request order within the Pi process, and publish atomically with private file permissions.
 
-Invalid JSON or values leave the source file unchanged, use the default shortcut, and produce a warning.
-
-Choose a shortcut that does not conflict with Pi or another extension; `Ctrl+F` is already Pi's cursor-right binding and File Context's internal search-mode toggle.
-
-The previous `Ctrl+Alt+F` default depended on terminal modifier support and may not reach Pi.
-An explicit `"openShortcut": "ctrl+alt+f"` value remains supported but is not migrated automatically; replace it with `"f8"` and run `/reload` to adopt the reliable default.
+Choose a shortcut that does not conflict with Pi or another extension; `Ctrl+F` is already File Context's internal search-mode toggle.
+Explicit `F8` and `Ctrl+Alt+F` values remain supported, but the default is now `Ctrl+X`.
 
 ## 💬 Commands
 
 | Command | Mode | Description |
 | --- | --- | --- |
-| `/file-context` | TUI only | Open the Add, Review, and Help menu. |
+| `/file-context` | TUI only | Open the Add, Review, Settings, Status, and Help menu. |
 | `/file-context browse` | TUI only | Scan and open the file explorer directly. |
 | `/file-context remove` | TUI only | Open selected-context review directly for compatibility. |
 
@@ -171,8 +174,8 @@ dist/                         Generated TypeScript runtime loaded by Jiti
 scripts/build-runtime.mjs      Deterministic runtime builder and boundary validator
 src/index.ts                   Thin Pi entrypoint
 src/file-context.ts            Lifecycle, routes, filesystem boundaries, selected state, prompt injection
-src/file-context-menu.ts       Standard Add, selected-context review, Help, and removal flow
-src/file-context-settings.ts   User shortcut loading and validation
+src/file-context-menu.ts       Add, review, Settings, Status, Help, and removal flow
+src/file-context-settings.ts   Shortcut validation, coordinated reads, and atomic persistence
 src/file-context-explorer.ts   Folder, file, content, Git, and line-range interaction controller
 src/file-browser.ts            Safe hierarchy model for discovered project paths
 src/file-browser-ui.ts         Width-safe folder and file list rendering with effective key hints
@@ -189,10 +192,10 @@ test/file-context-search.test.ts  File-name ranking, typo tolerance, and query-b
 test/file-context-folder-browser.test.ts  Folder hierarchy, navigation, keybinding, and terminal-safety tests
 test/file-context.test.ts       Filesystem, prompt, lifecycle, shortcut, and explorer tests
 test/file-context-selection.test.ts  Add-and-continue, capacity, and progressive-help tests
-test/file-context-menu.test.ts  Menu states, exact review, removal, limits, and responsive rendering tests
+test/file-context-menu.test.ts  Menu, shortcut settings, exact review, removal, and rendering tests
 test/file-context-command-menu.test.ts  Command routes, loading, and direct browser compatibility tests
 test/pending-quotes.test.ts     Exact selected-context removal, cancellation, and stale-flow tests
-test/file-context-settings.test.ts  Shortcut settings defaults and validation tests
+test/file-context-settings.test.ts  Shortcut defaults, validation, ordering, and atomic-write tests
 test/git-context.test.ts        Git repository behavior and parser tests
 ```
 

--- a/packages/pi-file-context/src/file-context-menu.ts
+++ b/packages/pi-file-context/src/file-context-menu.ts
@@ -1,5 +1,7 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { KeyId } from "@earendil-works/pi-tui";
 import type { RunMenuResult } from "@narumitw/pi-tui-kit";
+import { normalizeKeyId } from "./file-context-settings.js";
 
 export interface FileContextMenuQuote {
 	id: string;
@@ -15,6 +17,8 @@ export interface FileContextMenuState {
 	maximumQuotes: number;
 	maximumBytes: number;
 	totalBytes: number;
+	settingsPath: string;
+	settingsInvalidReason?: string;
 }
 
 export type FileContextMenuAddResult = "stay" | "close";
@@ -33,10 +37,11 @@ export interface FileContextMenuOptions {
 		id: string,
 		signal: AbortSignal,
 	): FileContextMenuRemovalResult | Promise<FileContextMenuRemovalResult>;
+	saveShortcut(shortcut: KeyId | null, signal: AbortSignal): void | Promise<void>;
 }
 
-type Screen = "main" | "selected" | "quote" | "help";
-type Action = "add" | "review" | "remove";
+type Screen = "main" | "selected" | "quote" | "settings" | "shortcut" | "status" | "help";
+type Action = "add" | "review" | "remove" | "open-shortcut" | "set-shortcut";
 
 export async function showFileContextMenu(
 	ctx: ExtensionCommandContext,
@@ -75,6 +80,18 @@ export async function showFileContextMenu(
 						disabled: state.quotes.length === 0,
 						disabledReason:
 							state.quotes.length === 0 ? "No context selected for the next prompt" : undefined,
+					},
+					{
+						id: "settings",
+						label: "Settings",
+						description: "Configure the shortcut used to open File Context",
+						to: "settings",
+					},
+					{
+						id: "status",
+						label: "Status",
+						description: "Review selected context, limits, and active settings",
+						to: "status",
 					},
 					{
 						id: "help",
@@ -139,6 +156,61 @@ export async function showFileContextMenu(
 					hint: "back",
 				};
 			},
+			settings: ({ state }) =>
+				state.settingsInvalidReason
+					? {
+							kind: "detail",
+							title: "File Context Settings · Read only",
+							lines: [
+								`Invalid settings file. Fix ${safeTerminalText(state.settingsPath)} before saving.`,
+								safeTerminalText(state.settingsInvalidReason),
+							],
+							hint: "back",
+						}
+					: {
+							kind: "settings",
+							title: "File Context Settings",
+							lines: [
+								`User settings · ${safeTerminalText(state.settingsPath)}`,
+								"Shortcut changes apply immediately in the current Pi session.",
+							],
+							items: [
+								{
+									id: "openShortcut",
+									label: "Open shortcut",
+									description: "Set the global shortcut used to open the file browser.",
+									currentValue: state.shortcut ?? "none",
+									action: "open-shortcut",
+								},
+							],
+							hint: "back",
+						},
+			shortcut: ({ state }) => ({
+				kind: "input",
+				title: "File Context shortcut",
+				lines: [
+					`Configured: ${state.shortcut ?? "none"}`,
+					"Use a Pi key identifier such as ctrl+x or f8.",
+					"Submit an empty value to disable the shortcut.",
+				],
+				placeholder: state.shortcut ?? "",
+				action: "set-shortcut",
+				hint: "back",
+			}),
+			status: ({ state }) => ({
+				kind: "detail",
+				title: "File Context Status",
+				lines: [
+					`Next prompt context: ${state.quotes.length}/${state.maximumQuotes} snippets`,
+					`Estimated context: ~${estimateTokens(state.totalBytes)} tokens · ${state.totalBytes}/${state.maximumBytes} bytes`,
+					`Open shortcut: ${state.shortcut ?? "none"}`,
+					`User settings: ${safeTerminalText(state.settingsPath)}`,
+					...(state.settingsInvalidReason
+						? [`Settings warning: ${safeTerminalText(state.settingsInvalidReason)}`]
+						: []),
+				],
+				hint: "back",
+			}),
 			help: () => ({
 				kind: "detail",
 				title: "File Context help",
@@ -147,6 +219,7 @@ export async function showFileContextMenu(
 					"Selected context is attached in order to your next prompt, then cleared together.",
 					"Review selected context opens each exact snapshot before offering removal.",
 					"The configured shortcut and /file-context browse open the browser directly.",
+					"Settings changes or disables the shortcut immediately; Status shows active limits and configuration.",
 					"Escape goes back. Ctrl+C closes File Context. Cancelling never changes selected context.",
 				],
 				hint: "back",
@@ -160,6 +233,38 @@ export async function showFileContextMenu(
 			review: ({ itemId }) => {
 				selectedQuoteId = itemId;
 				return { kind: "to", screen: "quote" };
+			},
+			"open-shortcut": async () => ({ kind: "to", screen: "shortcut" }),
+			"set-shortcut": async ({ ctx: actionCtx, value, signal }) => {
+				const raw = value?.trim() || null;
+				const normalized = raw ? normalizeKeyId(raw) : undefined;
+				if (raw && !normalized) {
+					actionCtx.ui.notify(
+						`Invalid key identifier: ${safeTerminalText(raw)}. Use a Pi key identifier like ctrl+x.`,
+						"warning",
+					);
+					return { kind: "stay" };
+				}
+				const shortcut = normalized ?? null;
+				try {
+					await options.saveShortcut(shortcut, signal);
+					if (signal.aborted || !options.isCurrent()) return { kind: "close" };
+					actionCtx.ui.notify(
+						shortcut
+							? `File Context shortcut: ${safeTerminalText(shortcut)}.`
+							: "File Context shortcut disabled; use /file-context browse.",
+						"info",
+					);
+					return { kind: "to", screen: "settings" };
+				} catch (error: unknown) {
+					if (!signal.aborted && options.isCurrent()) {
+						actionCtx.ui.notify(
+							`Could not save File Context settings; the previous shortcut remains: ${safeTerminalText(formatError(error))}`,
+							"error",
+						);
+					}
+					return { kind: "stay" };
+				}
 			},
 			remove: async ({ signal }) => {
 				const itemId = selectedQuoteId;

--- a/packages/pi-file-context/src/file-context-menu.ts
+++ b/packages/pi-file-context/src/file-context-menu.ts
@@ -86,6 +86,11 @@ export async function showFileContextMenu(
 						label: "Settings",
 						description: "Configure the shortcut used to open File Context",
 						to: "settings",
+						disabled: state.quotes.length > 0,
+						disabledReason:
+							state.quotes.length > 0
+								? "Submit or remove selected context first; applying a shortcut reloads Pi"
+								: undefined,
 					},
 					{
 						id: "status",
@@ -172,7 +177,7 @@ export async function showFileContextMenu(
 							title: "File Context Settings",
 							lines: [
 								`User settings · ${safeTerminalText(state.settingsPath)}`,
-								"Shortcut changes apply immediately in the current Pi session.",
+								"Saving reloads Pi so the new shortcut becomes active.",
 							],
 							items: [
 								{
@@ -190,7 +195,7 @@ export async function showFileContextMenu(
 				title: "File Context shortcut",
 				lines: [
 					`Configured: ${state.shortcut ?? "none"}`,
-					"Use a Pi key identifier such as ctrl+x or f8.",
+					"Use a Pi key identifier such as ctrl+shift+x or f8.",
 					"Submit an empty value to disable the shortcut.",
 				],
 				placeholder: state.shortcut ?? "",
@@ -219,7 +224,7 @@ export async function showFileContextMenu(
 					"Selected context is attached in order to your next prompt, then cleared together.",
 					"Review selected context opens each exact snapshot before offering removal.",
 					"The configured shortcut and /file-context browse open the browser directly.",
-					"Settings changes or disables the shortcut immediately; Status shows active limits and configuration.",
+					"Settings saves the shortcut and reloads Pi; Status shows active limits and configuration.",
 					"Escape goes back. Ctrl+C closes File Context. Cancelling never changes selected context.",
 				],
 				hint: "back",
@@ -240,7 +245,7 @@ export async function showFileContextMenu(
 				const normalized = raw ? normalizeKeyId(raw) : undefined;
 				if (raw && !normalized) {
 					actionCtx.ui.notify(
-						`Invalid key identifier: ${safeTerminalText(raw)}. Use a Pi key identifier like ctrl+x.`,
+						`Invalid key identifier: ${safeTerminalText(raw)}. Use a Pi key identifier like ctrl+shift+x.`,
 						"warning",
 					);
 					return { kind: "stay" };
@@ -248,14 +253,6 @@ export async function showFileContextMenu(
 				const shortcut = normalized ?? null;
 				try {
 					await options.saveShortcut(shortcut, signal);
-					if (signal.aborted || !options.isCurrent()) return { kind: "close" };
-					actionCtx.ui.notify(
-						shortcut
-							? `File Context shortcut: ${safeTerminalText(shortcut)}.`
-							: "File Context shortcut disabled; use /file-context browse.",
-						"info",
-					);
-					return { kind: "to", screen: "settings" };
 				} catch (error: unknown) {
 					if (!signal.aborted && options.isCurrent()) {
 						actionCtx.ui.notify(
@@ -264,6 +261,25 @@ export async function showFileContextMenu(
 						);
 					}
 					return { kind: "stay" };
+				}
+				if (signal.aborted || !options.isCurrent()) return { kind: "close" };
+				actionCtx.ui.notify(
+					shortcut
+						? `Saved File Context shortcut ${safeTerminalText(shortcut)}. Reloading Pi…`
+						: "Disabled the File Context shortcut. Reloading Pi…",
+					"info",
+				);
+				try {
+					await actionCtx.reload();
+					return { kind: "close" };
+				} catch (error: unknown) {
+					if (!signal.aborted && options.isCurrent()) {
+						actionCtx.ui.notify(
+							`File Context settings were saved, but Pi could not reload; run /reload to apply them: ${safeTerminalText(formatError(error))}`,
+							"error",
+						);
+					}
+					return { kind: "close" };
 				}
 			},
 			remove: async ({ signal }) => {

--- a/packages/pi-file-context/src/file-context-settings.ts
+++ b/packages/pi-file-context/src/file-context-settings.ts
@@ -25,7 +25,7 @@ export interface UpdateFileContextSettingsOptions {
 }
 
 export const DEFAULT_FILE_CONTEXT_SETTINGS: FileContextSettings = {
-	openShortcut: "ctrl+x",
+	openShortcut: "ctrl+shift+x",
 };
 
 const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
@@ -247,9 +247,7 @@ async function readSettingsContents(settingsPath: string): Promise<string> {
 			throw new Error(`settings file exceeds ${MAX_SETTINGS_BYTES} bytes`);
 		}
 		try {
-			return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
-				buffer.subarray(0, offset),
-			);
+			return new TextDecoder("utf-8", { fatal: true }).decode(buffer.subarray(0, offset));
 		} catch {
 			throw new Error("settings file is not valid UTF-8");
 		}

--- a/packages/pi-file-context/src/file-context-settings.ts
+++ b/packages/pi-file-context/src/file-context-settings.ts
@@ -1,5 +1,12 @@
-import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { mkdir, open, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { KeyId } from "@earendil-works/pi-tui";
+
+export const FILE_CONTEXT_SETTINGS_FILE = "pi-file-context.json";
+const MAX_SETTINGS_BYTES = 64 * 1024;
 
 export interface FileContextSettings {
 	openShortcut: KeyId | null;
@@ -8,10 +15,17 @@ export interface FileContextSettings {
 export interface LoadedFileContextSettings {
 	settings: FileContextSettings;
 	warning?: string;
+	invalidReason?: string;
+}
+
+export interface UpdateFileContextSettingsOptions {
+	settingsPath?: string;
+	signal?: AbortSignal;
+	beforeRename?: (temporaryPath: string, settingsPath: string) => Promise<void>;
 }
 
 export const DEFAULT_FILE_CONTEXT_SETTINGS: FileContextSettings = {
-	openShortcut: "f8",
+	openShortcut: "ctrl+x",
 };
 
 const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
@@ -66,50 +80,67 @@ const BASE_KEYS = new Set([
 	"down",
 	"left",
 	"right",
-	...Array.from({ length: 12 }, (_, index) => `f${index + 1}`),
+	...Array.from({ length: 12 }, (_unused, index) => `f${index + 1}`),
 ]);
 
-export async function loadFileContextSettings(
-	settingsPath: string,
-): Promise<LoadedFileContextSettings> {
-	let source: string;
-	try {
-		source = await readFile(settingsPath, "utf8");
-	} catch (error: unknown) {
-		if (isNodeError(error) && error.code === "ENOENT") {
-			return { settings: { ...DEFAULT_FILE_CONTEXT_SETTINGS } };
-		}
-		return defaultWithWarning(`Cannot read File Context settings: ${formatError(error)}`);
-	}
+type SettingsDocument = Record<string, unknown>;
+type SettingsSnapshot =
+	| { kind: "missing" }
+	| { kind: "invalid"; reason: string; warning: string }
+	| { kind: "loaded"; document: SettingsDocument; settings: FileContextSettings };
 
-	let document: unknown;
-	try {
-		document = JSON.parse(source);
-	} catch (error: unknown) {
-		return defaultWithWarning(`Cannot parse File Context settings: ${formatError(error)}`);
-	}
-	if (!isRecord(document)) {
-		return defaultWithWarning("File Context settings must contain a JSON object.");
-	}
-	if (!("openShortcut" in document)) {
-		return { settings: { ...DEFAULT_FILE_CONTEXT_SETTINGS } };
-	}
-	if (document.openShortcut === null) {
-		return { settings: { openShortcut: null } };
-	}
-	if (typeof document.openShortcut !== "string") {
-		return defaultWithWarning('File Context setting "openShortcut" must be a key string or null.');
-	}
-	const shortcut = normalizeKeyId(document.openShortcut);
-	if (!shortcut) {
-		return defaultWithWarning(
-			`File Context setting "openShortcut" is invalid: ${JSON.stringify(document.openShortcut)}.`,
-		);
-	}
-	return { settings: { openShortcut: shortcut } };
+const mutationQueues = new Map<string, Promise<void>>();
+
+export function fileContextSettingsPath(): string {
+	return join(getAgentDir(), FILE_CONTEXT_SETTINGS_FILE);
 }
 
-function normalizeKeyId(value: string): KeyId | undefined {
+export async function loadFileContextSettings(
+	settingsPath = fileContextSettingsPath(),
+): Promise<LoadedFileContextSettings> {
+	await awaitFileContextSettingsWrites(settingsPath);
+	const snapshot = await readSettingsSnapshot(settingsPath);
+	if (snapshot.kind === "loaded") return { settings: snapshot.settings };
+	if (snapshot.kind === "missing") {
+		return { settings: { ...DEFAULT_FILE_CONTEXT_SETTINGS } };
+	}
+	return {
+		settings: { ...DEFAULT_FILE_CONTEXT_SETTINGS },
+		warning: snapshot.warning,
+		invalidReason: snapshot.reason,
+	};
+}
+
+export function updateFileContextSettings(
+	openShortcut: KeyId | null,
+	options: UpdateFileContextSettingsOptions = {},
+): Promise<FileContextSettings> {
+	const settingsPath = options.settingsPath ?? fileContextSettingsPath();
+	return enqueueMutation(settingsPath, async () => {
+		options.signal?.throwIfAborted();
+		const snapshot = await readSettingsSnapshot(settingsPath);
+		if (snapshot.kind === "invalid") {
+			throw new Error(`File Context settings are invalid: ${snapshot.reason}`);
+		}
+		const updated: SettingsDocument = {
+			...(snapshot.kind === "loaded" ? snapshot.document : {}),
+			openShortcut,
+		};
+		const settings = normalizeFileContextSettings(updated);
+		if (!settings) throw new Error("File Context settings update is invalid");
+		await publishSettings(settingsPath, updated, options);
+		return settings;
+	});
+}
+
+export async function awaitFileContextSettingsWrites(
+	settingsPath = fileContextSettingsPath(),
+): Promise<void> {
+	await mutationQueues.get(settingsPath);
+}
+
+export function normalizeKeyId(value: unknown): KeyId | undefined {
+	if (typeof value !== "string") return undefined;
 	const normalized = value.trim().toLowerCase();
 	const base = [...BASE_KEYS]
 		.sort((left, right) => right.length - left.length)
@@ -129,16 +160,147 @@ function normalizeKeyId(value: string): KeyId | undefined {
 	return normalized as KeyId;
 }
 
-function defaultWithWarning(warning: string): LoadedFileContextSettings {
-	return { settings: { ...DEFAULT_FILE_CONTEXT_SETTINGS }, warning };
+function normalizeFileContextSettings(value: unknown): FileContextSettings | undefined {
+	if (!isSettingsDocument(value)) return undefined;
+	if (!Object.hasOwn(value, "openShortcut")) {
+		return { ...DEFAULT_FILE_CONTEXT_SETTINGS };
+	}
+	const openShortcut = Reflect.get(value, "openShortcut");
+	if (openShortcut === null) return { openShortcut: null };
+	const normalized = normalizeKeyId(openShortcut);
+	return normalized ? { openShortcut: normalized } : undefined;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function enqueueMutation<T>(settingsPath: string, mutation: () => Promise<T>): Promise<T> {
+	const previous = mutationQueues.get(settingsPath) ?? Promise.resolve();
+	const result = previous.then(mutation, mutation);
+	const settled = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	mutationQueues.set(settingsPath, settled);
+	void settled.finally(() => {
+		if (mutationQueues.get(settingsPath) === settled) mutationQueues.delete(settingsPath);
+	});
+	return result;
+}
+
+async function readSettingsSnapshot(settingsPath: string): Promise<SettingsSnapshot> {
+	let source: string;
+	try {
+		source = await readSettingsContents(settingsPath);
+	} catch (error: unknown) {
+		if (isNodeError(error) && error.code === "ENOENT") return { kind: "missing" };
+		const reason = safeReadError(error);
+		return {
+			kind: "invalid",
+			reason,
+			warning: `Cannot read File Context settings: ${reason}`,
+		};
+	}
+
+	let document: unknown;
+	try {
+		document = JSON.parse(source) as unknown;
+	} catch (error: unknown) {
+		return {
+			kind: "invalid",
+			reason: "invalid JSON",
+			warning: `Cannot parse File Context settings: ${formatError(error)}`,
+		};
+	}
+	if (!isSettingsDocument(document)) {
+		return {
+			kind: "invalid",
+			reason: "settings must contain a JSON object",
+			warning: "File Context settings must contain a JSON object.",
+		};
+	}
+	const settings = normalizeFileContextSettings(document);
+	if (!settings) {
+		return {
+			kind: "invalid",
+			reason: 'setting "openShortcut" must be a valid Pi key string or null',
+			warning: 'File Context setting "openShortcut" must be a valid Pi key string or null.',
+		};
+	}
+	return { kind: "loaded", document, settings };
+}
+
+async function readSettingsContents(settingsPath: string): Promise<string> {
+	const flags = constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0);
+	const handle = await open(settingsPath, flags);
+	try {
+		const stats = await handle.stat();
+		if (!stats.isFile()) throw new Error("settings path is not a regular file");
+		if (stats.size > MAX_SETTINGS_BYTES) {
+			throw new Error(`settings file exceeds ${MAX_SETTINGS_BYTES} bytes`);
+		}
+		const buffer = Buffer.alloc(MAX_SETTINGS_BYTES + 1);
+		let offset = 0;
+		while (offset < buffer.byteLength) {
+			const { bytesRead } = await handle.read(buffer, offset, buffer.byteLength - offset, offset);
+			if (bytesRead === 0) break;
+			offset += bytesRead;
+		}
+		if (offset > MAX_SETTINGS_BYTES) {
+			throw new Error(`settings file exceeds ${MAX_SETTINGS_BYTES} bytes`);
+		}
+		try {
+			return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+				buffer.subarray(0, offset),
+			);
+		} catch {
+			throw new Error("settings file is not valid UTF-8");
+		}
+	} finally {
+		await handle.close();
+	}
+}
+
+async function publishSettings(
+	settingsPath: string,
+	document: SettingsDocument,
+	options: UpdateFileContextSettingsOptions,
+): Promise<void> {
+	options.signal?.throwIfAborted();
+	const contents = `${JSON.stringify(document, null, 2)}\n`;
+	if (Buffer.byteLength(contents, "utf8") > MAX_SETTINGS_BYTES) {
+		throw new Error(`settings document exceeds ${MAX_SETTINGS_BYTES} bytes`);
+	}
+	const directory = dirname(settingsPath);
+	await mkdir(directory, { recursive: true });
+	options.signal?.throwIfAborted();
+	const temporaryPath = join(
+		directory,
+		`.${basename(settingsPath)}.${process.pid}.${randomUUID()}.tmp`,
+	);
+	try {
+		await writeFile(temporaryPath, contents, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: 0o600,
+			signal: options.signal,
+		});
+		await options.beforeRename?.(temporaryPath, settingsPath);
+		options.signal?.throwIfAborted();
+		await rename(temporaryPath, settingsPath);
+	} finally {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+	}
+}
+
+function isSettingsDocument(value: unknown): value is SettingsDocument {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-	return error instanceof Error;
+	return error instanceof Error && "code" in error;
+}
+
+function safeReadError(error: unknown): string {
+	if (isNodeError(error) && error.code === "ELOOP") return "settings path is not a regular file";
+	return formatError(error);
 }
 
 function formatError(error: unknown): string {

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -11,7 +11,6 @@ import { FileQuoteExplorer, type FileQuoteExplorerResult } from "./file-context-
 import { type FileContextMenuQuote, showFileContextMenu } from "./file-context-menu.js";
 import {
 	awaitFileContextSettingsWrites,
-	type FileContextSettings,
 	fileContextSettingsPath,
 	type LoadedFileContextSettings,
 	loadFileContextSettings,
@@ -525,26 +524,14 @@ export async function registerFileQuoteExtension(
 		return launch.promise;
 	};
 
-	let registeredOpenShortcut: FileContextSettings["openShortcut"];
-	const clearFileContextShortcutHandler = () => {};
-	const applyOpenShortcut = (nextShortcut: FileContextSettings["openShortcut"]) => {
-		if (registeredOpenShortcut && registeredOpenShortcut !== nextShortcut) {
-			pi.registerShortcut(registeredOpenShortcut, {
-				handler: clearFileContextShortcutHandler,
-			});
-		}
-		if (!nextShortcut) {
-			registeredOpenShortcut = null;
-			return;
-		}
-		if (registeredOpenShortcut === nextShortcut) return;
-		pi.registerShortcut(nextShortcut, {
+	// Pi snapshots extension shortcuts when the TUI binds them, so settings changes reload Pi.
+	const registeredOpenShortcut = loadedSettings.settings.openShortcut;
+	if (registeredOpenShortcut) {
+		pi.registerShortcut(registeredOpenShortcut, {
 			description: "Open File Context",
 			handler: openExplorer,
 		});
-		registeredOpenShortcut = nextShortcut;
-	};
-	applyOpenShortcut(loadedSettings.settings.openShortcut);
+	}
 
 	const openMenu = (
 		ctx: ExtensionCommandContext,
@@ -594,7 +581,6 @@ export async function registerFileQuoteExtension(
 				}
 				const saved = await updateSettings(shortcut, { settingsPath, signal });
 				if (!isCurrent() || signal.aborted) return;
-				applyOpenShortcut(saved.openShortcut);
 				loadedSettings = { settings: saved };
 			},
 			removeQuote: (id, signal) => {
@@ -666,15 +652,13 @@ export async function registerFileQuoteExtension(
 			return;
 		}
 		loadedSettings = refreshedSettings;
-		applyOpenShortcut(loadedSettings.settings.openShortcut);
 		if (loadedSettings.warning && ctx.hasUI) {
 			ctx.ui.notify(escapeTerminalControls(loadedSettings.warning), "warning");
 		}
 		if (ctx.mode !== "tui") return;
-		const shortcut = loadedSettings.settings.openShortcut;
 		ctx.ui.notify(
-			shortcut
-				? `Experimental File Context loaded. Press ${shortcut} to browse or run /file-context to review selected context.`
+			registeredOpenShortcut
+				? `Experimental File Context loaded. Press ${registeredOpenShortcut} to browse or run /file-context to review selected context.`
 				: "Experimental File Context loaded. Run /file-context to add or review selected context.",
 			"warning",
 		);

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -1,18 +1,21 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import { lstat, open, readdir, realpath } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve, sep } from "node:path";
-import {
-	type ExtensionAPI,
-	type ExtensionCommandContext,
-	type ExtensionContext,
-	getAgentDir,
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import { FileQuoteExplorer, type FileQuoteExplorerResult } from "./file-context-explorer.js";
 import { type FileContextMenuQuote, showFileContextMenu } from "./file-context-menu.js";
 import {
+	awaitFileContextSettingsWrites,
+	type FileContextSettings,
+	fileContextSettingsPath,
 	type LoadedFileContextSettings,
 	loadFileContextSettings,
+	updateFileContextSettings,
 } from "./file-context-settings.js";
 import { createGitContext } from "./git-context.js";
 
@@ -292,7 +295,9 @@ export function formatQuoteContext(quotes: readonly FileQuote[]): string {
 }
 
 interface FileQuoteExtensionDependencies {
+	settingsPath?: string;
 	loadSettings?: () => Promise<LoadedFileContextSettings>;
+	updateSettings?: typeof updateFileContextSettings;
 	discoverFiles?: typeof discoverProjectFiles;
 	createGit?: typeof createGitContext;
 }
@@ -301,10 +306,10 @@ export async function registerFileQuoteExtension(
 	pi: ExtensionAPI,
 	dependencies: FileQuoteExtensionDependencies = {},
 ): Promise<void> {
-	const loadedSettings = await (
-		dependencies.loadSettings ??
-		(() => loadFileContextSettings(join(getAgentDir(), "pi-file-context.json")))
-	)();
+	const settingsPath = dependencies.settingsPath ?? fileContextSettingsPath();
+	const loadSettings = dependencies.loadSettings ?? (() => loadFileContextSettings(settingsPath));
+	const updateSettings = dependencies.updateSettings ?? updateFileContextSettings;
+	let loadedSettings = await loadSettings();
 	const discoverFiles = dependencies.discoverFiles ?? discoverProjectFiles;
 	const createGit = dependencies.createGit ?? createGitContext;
 	let pendingQuotes: PendingQuote[] = [];
@@ -520,6 +525,27 @@ export async function registerFileQuoteExtension(
 		return launch.promise;
 	};
 
+	let registeredOpenShortcut: FileContextSettings["openShortcut"];
+	const clearFileContextShortcutHandler = () => {};
+	const applyOpenShortcut = (nextShortcut: FileContextSettings["openShortcut"]) => {
+		if (registeredOpenShortcut && registeredOpenShortcut !== nextShortcut) {
+			pi.registerShortcut(registeredOpenShortcut, {
+				handler: clearFileContextShortcutHandler,
+			});
+		}
+		if (!nextShortcut) {
+			registeredOpenShortcut = null;
+			return;
+		}
+		if (registeredOpenShortcut === nextShortcut) return;
+		pi.registerShortcut(nextShortcut, {
+			description: "Open File Context",
+			handler: openExplorer,
+		});
+		registeredOpenShortcut = nextShortcut;
+	};
+	applyOpenShortcut(loadedSettings.settings.openShortcut);
+
 	const openMenu = (
 		ctx: ExtensionCommandContext,
 		start: "main" | "remove" = "main",
@@ -557,9 +583,20 @@ export async function registerFileQuoteExtension(
 						(total, quote) => total + Buffer.byteLength(quote.text, "utf8"),
 						0,
 					),
+					settingsPath,
+					settingsInvalidReason: loadedSettings.invalidReason,
 				};
 			},
 			addQuote: (signal) => runExplorer(ctx, { menuOwned: true, signal }),
+			saveShortcut: async (shortcut, signal) => {
+				if (!isCurrent() || signal.aborted) {
+					throw new DOMException("File Context session replaced", "AbortError");
+				}
+				const saved = await updateSettings(shortcut, { settingsPath, signal });
+				if (!isCurrent() || signal.aborted) return;
+				applyOpenShortcut(saved.openShortcut);
+				loadedSettings = { settings: saved };
+			},
 			removeQuote: (id, signal) => {
 				if (!isCurrent() || signal.aborted) return { kind: "missing" };
 				const index = pendingQuotes.findIndex((item) => item.id === id);
@@ -611,22 +648,28 @@ export async function registerFileQuoteExtension(
 		},
 		handler: handleFileContextCommand,
 	});
-	if (loadedSettings.settings.openShortcut) {
-		pi.registerShortcut(loadedSettings.settings.openShortcut, {
-			description: "Open File Context",
-			handler: openExplorer,
-		});
-	}
-
-	pi.on("session_start", (_event, ctx) => {
+	pi.on("session_start", async (_event, ctx) => {
 		sessionController.abort(new DOMException("File Context session replaced", "AbortError"));
 		sessionController = new AbortController();
+		const ownerController = sessionController;
 		activeMenuLaunch = undefined;
 		cancelExplorers();
 		activeSessionManager = ctx.sessionManager;
-		sessionGeneration += 1;
+		const generation = ++sessionGeneration;
 		clearPending(ctx);
-		if (loadedSettings.warning && ctx.hasUI) ctx.ui.notify(loadedSettings.warning, "warning");
+		const refreshedSettings = await loadSettings();
+		if (
+			!isCurrentSession(ctx.sessionManager, generation) ||
+			ownerController !== sessionController ||
+			ownerController.signal.aborted
+		) {
+			return;
+		}
+		loadedSettings = refreshedSettings;
+		applyOpenShortcut(loadedSettings.settings.openShortcut);
+		if (loadedSettings.warning && ctx.hasUI) {
+			ctx.ui.notify(escapeTerminalControls(loadedSettings.warning), "warning");
+		}
 		if (ctx.mode !== "tui") return;
 		const shortcut = loadedSettings.settings.openShortcut;
 		ctx.ui.notify(
@@ -650,12 +693,13 @@ export async function registerFileQuoteExtension(
 		};
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => {
+	pi.on("session_shutdown", async (_event, ctx) => {
 		if (ctx.sessionManager !== activeSessionManager) return;
 		sessionController.abort(new DOMException("File Context session shut down", "AbortError"));
 		activeMenuLaunch = undefined;
 		cancelExplorers();
 		clearPending(ctx);
+		await awaitFileContextSettingsWrites(settingsPath);
 	});
 }
 

--- a/packages/pi-file-context/test/file-context-command-menu.test.ts
+++ b/packages/pi-file-context/test/file-context-command-menu.test.ts
@@ -72,11 +72,12 @@ test("makes the no-argument command a menu and advertises compatibility routes",
 	});
 });
 
-test("reloads and applies shortcut settings immediately from the main menu", async () => {
+test("saves shortcut settings and reloads instead of mutating stale TUI bindings", async () => {
 	await withTempProject(async (root) => {
 		const mock = createMockPi();
-		let storedShortcut: "ctrl+x" | "f8" | "ctrl+y" | null = "ctrl+x";
+		let storedShortcut: "ctrl+shift+x" | "ctrl+y" | null = "ctrl+shift+x";
 		const saved: Array<string | null> = [];
+		let reloadCalls = 0;
 		await registerFileQuoteExtension(mock.pi, {
 			settingsPath: join(root, "pi-file-context.json"),
 			loadSettings: async () => ({ settings: { openShortcut: storedShortcut } }),
@@ -88,11 +89,17 @@ test("reloads and applies shortcut settings immediately from the main menu", asy
 				return { openShortcut: shortcut };
 			},
 		});
-		assert.equal(mock.shortcuts.get("ctrl+x")?.description, "Open File Context");
+		assert.equal(mock.shortcuts.get("ctrl+shift+x")?.description, "Open File Context");
 
-		storedShortcut = "f8";
 		const tui = createTuiHarness({ width: 52, rows: 16 });
-		const base = createMockContext({ mode: "tui", hasUI: true, cwd: root });
+		const base = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			async reload() {
+				reloadCalls += 1;
+			},
+		});
 		const baseCtx = base.ctx as unknown as { ui: Record<string, unknown> } & Record<
 			string,
 			unknown
@@ -102,8 +109,6 @@ test("reloads and applies shortcut settings immediately from the main menu", asy
 			ui: { ...baseCtx.ui, custom: tui.custom },
 		} as never;
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
-		assert.equal(mock.shortcuts.get("ctrl+x")?.description, undefined);
-		assert.equal(mock.shortcuts.get("f8")?.description, "Open File Context");
 
 		const running = Promise.resolve(mock.commands.get("file-context")?.handler("", ctx));
 		await tui.waitForOpen();
@@ -111,29 +116,20 @@ test("reloads and applies shortcut settings immediately from the main menu", asy
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForOpen();
-		assert.match(tui.render().join("\n"), /Open shortcut\s+f8/u);
+		assert.match(tui.render().join("\n"), /Open shortcut\s+ctrl\+shift\+x/u);
 		tui.press("tui.select.confirm");
 		await tui.waitForPending();
 		await tui.waitForOpen();
 		tui.type("ctrl+y");
 		tui.press("tui.input.submit");
 		await tui.waitForPending();
-		await tui.waitForOpen();
+		await running;
 
 		assert.deepEqual(saved, ["ctrl+y"]);
-		assert.equal(mock.shortcuts.get("f8")?.description, undefined);
-		assert.equal(mock.shortcuts.get("ctrl+y")?.description, "Open File Context");
-
-		tui.press("tui.select.confirm");
-		await tui.waitForPending();
-		await tui.waitForOpen();
-		tui.press("tui.input.submit");
-		await tui.waitForPending();
-		await tui.waitForOpen();
-		assert.deepEqual(saved, ["ctrl+y", null]);
-		assert.equal(mock.shortcuts.get("ctrl+y")?.description, undefined);
+		assert.equal(reloadCalls, 1);
+		assert.equal(mock.shortcuts.get("ctrl+shift+x")?.description, "Open File Context");
+		assert.equal(mock.shortcuts.has("ctrl+y"), false);
 		await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
-		await running;
 	});
 });
 

--- a/packages/pi-file-context/test/file-context-command-menu.test.ts
+++ b/packages/pi-file-context/test/file-context-command-menu.test.ts
@@ -65,7 +65,74 @@ test("makes the no-argument command a menu and advertises compatibility routes",
 		assert.match(frame, /File Context/u);
 		assert.match(frame, /Add context snippet/u);
 		assert.match(frame, /Review selected context \(0\)/u);
+		assert.match(frame, /Settings/u);
+		assert.match(frame, /Status/u);
 		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("reloads and applies shortcut settings immediately from the main menu", async () => {
+	await withTempProject(async (root) => {
+		const mock = createMockPi();
+		let storedShortcut: "ctrl+x" | "f8" | "ctrl+y" | null = "ctrl+x";
+		const saved: Array<string | null> = [];
+		await registerFileQuoteExtension(mock.pi, {
+			settingsPath: join(root, "pi-file-context.json"),
+			loadSettings: async () => ({ settings: { openShortcut: storedShortcut } }),
+			updateSettings: async (shortcut, options) => {
+				assert.equal(options?.settingsPath, join(root, "pi-file-context.json"));
+				assert.equal(options?.signal?.aborted, false);
+				storedShortcut = shortcut as typeof storedShortcut;
+				saved.push(shortcut);
+				return { openShortcut: shortcut };
+			},
+		});
+		assert.equal(mock.shortcuts.get("ctrl+x")?.description, "Open File Context");
+
+		storedShortcut = "f8";
+		const tui = createTuiHarness({ width: 52, rows: 16 });
+		const base = createMockContext({ mode: "tui", hasUI: true, cwd: root });
+		const baseCtx = base.ctx as unknown as { ui: Record<string, unknown> } & Record<
+			string,
+			unknown
+		>;
+		const ctx = {
+			...baseCtx,
+			ui: { ...baseCtx.ui, custom: tui.custom },
+		} as never;
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		assert.equal(mock.shortcuts.get("ctrl+x")?.description, undefined);
+		assert.equal(mock.shortcuts.get("f8")?.description, "Open File Context");
+
+		const running = Promise.resolve(mock.commands.get("file-context")?.handler("", ctx));
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Open shortcut\s+f8/u);
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.type("ctrl+y");
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+
+		assert.deepEqual(saved, ["ctrl+y"]);
+		assert.equal(mock.shortcuts.get("f8")?.description, undefined);
+		assert.equal(mock.shortcuts.get("ctrl+y")?.description, "Open File Context");
+
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.press("tui.input.submit");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.deepEqual(saved, ["ctrl+y", null]);
+		assert.equal(mock.shortcuts.get("ctrl+y")?.description, undefined);
+		await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 		await running;
 	});
 });

--- a/packages/pi-file-context/test/file-context-menu.test.ts
+++ b/packages/pi-file-context/test/file-context-menu.test.ts
@@ -29,10 +29,11 @@ function state(
 ): FileContextMenuState {
 	return {
 		quotes,
-		shortcut: "f8",
+		shortcut: "ctrl+x",
 		maximumQuotes: 8,
 		maximumBytes: 100_000,
 		totalBytes: quotes.reduce((total, item) => total + Buffer.byteLength(item.text), 0),
+		settingsPath: "/tmp/pi-file-context.json",
 		...overrides,
 	};
 }
@@ -61,6 +62,7 @@ function options(
 		signal: new AbortController().signal,
 		addQuote: async () => "close" as const,
 		removeQuote: () => ({ kind: "missing" }),
+		saveShortcut() {},
 		...overrides,
 	};
 }
@@ -91,8 +93,10 @@ test("shows the primary menu immediately with visible state and disabled reasons
 	const initial = tui.render().join("\n");
 	assert.match(initial, /File Context/u);
 	assert.match(initial, /Next prompt context: 0\/8 snippets/u);
-	assert.match(initial, /Shortcut: F8/u);
+	assert.match(initial, /Shortcut: CTRL\+X/u);
 	assert.match(initial, /Add context snippet/u);
+	assert.match(initial, /Settings/u);
+	assert.match(initial, /Status/u);
 
 	tui.press("tui.select.down");
 	const disabled = tui.render().join("\n");
@@ -125,6 +129,27 @@ test("closes the menu before handing off to Add", async () => {
 	assert.equal(menuWasOpenDuringAdd, false);
 });
 
+test("opens Status with current limits and settings", async () => {
+	const { tui, ctx } = menuContext(44, 14);
+	const running = showFileContextMenu(
+		ctx,
+		options(() => state([quote("quote-1")])),
+	);
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	const frame = tui.render().join("\n");
+	assert.match(frame, /File Context Status/u);
+	assert.match(frame, /Next prompt context: 1\/8 snippets/u);
+	assert.match(frame, /Open shortcut: ctrl\+x/u);
+	assert.match(frame, /pi-file-context\.json/u);
+	tui.press("ctrl+c");
+	await running;
+});
+
 test("opens Help from the menu and Escape returns without side effects", async () => {
 	const { tui, ctx } = menuContext();
 	let addCalls = 0;
@@ -140,6 +165,8 @@ test("opens Help from the menu and Escape returns without side effects", async (
 	await tui.waitForOpen();
 	tui.press("tui.select.down");
 	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
 	await tui.waitForOpen();
 	assert.match(tui.render().join("\n"), /Selected context is attached.*next prompt/u);
@@ -149,6 +176,142 @@ test("opens Help from the menu and Escape returns without side effects", async (
 	assert.equal(addCalls, 0);
 	tui.press("ctrl+c");
 	await running;
+});
+
+test("Settings changes and disables the open shortcut immediately", async () => {
+	const { tui, ctx, notifications } = menuContext(44, 14);
+	let current = state();
+	const saved: Array<string | null> = [];
+	const controller = new AbortController();
+	const running = showFileContextMenu(
+		ctx,
+		options(() => current, {
+			signal: controller.signal,
+			saveShortcut: (shortcut) => {
+				saved.push(shortcut);
+				current = state([], { shortcut });
+			},
+		}),
+	);
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	assert.match(tui.render().join("\n"), /File Context Settings/u);
+	assert.match(tui.render().join("\n"), /Open shortcut\s+ctrl\+x/u);
+	assert.ok(tui.render(28).every((line) => visibleWidth(line) <= 28));
+
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.type("ctrl+y");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.deepEqual(saved, ["ctrl+y"]);
+	assert.match(tui.render().join("\n"), /Open shortcut\s+ctrl\+y/u);
+
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.deepEqual(saved, ["ctrl+y", null]);
+	assert.match(tui.render().join("\n"), /Open shortcut\s+none/u);
+
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.type("ctrl+not-a-key");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	assert.deepEqual(saved, ["ctrl+y", null]);
+	assert.match(notifications.at(-1)?.message ?? "", /Invalid key identifier/u);
+	controller.abort();
+	tui.dispose();
+	await running;
+});
+
+test("invalid settings are read-only and save failures preserve the displayed shortcut", async () => {
+	for (const failure of ["invalid", "save"] as const) {
+		const { tui, ctx, notifications } = menuContext(48, 14);
+		const current = state(
+			[],
+			failure === "invalid" ? { settingsInvalidReason: "invalid JSON" } : {},
+		);
+		const controller = new AbortController();
+		const running = showFileContextMenu(
+			ctx,
+			options(() => current, {
+				signal: controller.signal,
+				saveShortcut: async () => {
+					throw new Error("disk full\u001b]52;c;payload\u0007");
+				},
+			}),
+		);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		if (failure === "invalid") {
+			assert.match(tui.render().join("\n"), /Read only/u);
+			assert.match(tui.render().join("\n"), /invalid JSON/u);
+		} else {
+			tui.press("tui.select.confirm");
+			await tui.waitForPending();
+			await tui.waitForOpen();
+			tui.type("ctrl+y");
+			tui.press("tui.input.submit");
+			await tui.waitForPending();
+			assert.match(notifications.at(-1)?.message ?? "", /previous shortcut remains/u);
+			assert.ok(!(notifications.at(-1)?.message ?? "").includes("\u001b"));
+		}
+		controller.abort();
+		tui.dispose();
+		await running;
+	}
+});
+
+test("Settings disposal aborts an in-flight shortcut save without reporting a stale error", async () => {
+	const { tui, ctx, notifications } = menuContext(48, 14);
+	const controller = new AbortController();
+	let saveSignal: AbortSignal | undefined;
+	let markStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		markStarted = resolve;
+	});
+	const running = showFileContextMenu(
+		ctx,
+		options(() => state(), {
+			signal: controller.signal,
+			saveShortcut: async (_shortcut, signal) => {
+				saveSignal = signal;
+				markStarted();
+				return new Promise<void>((_resolve, reject) => {
+					signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+				});
+			},
+		}),
+	);
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.type("ctrl+y");
+	tui.press("tui.input.submit");
+	await started;
+	controller.abort();
+	tui.dispose();
+	await running;
+	assert.equal(saveSignal?.aborted, true);
+	assert.deepEqual(notifications, []);
 });
 
 test("reviews exact snippets before repeatedly removing them by stable ID", async () => {

--- a/packages/pi-file-context/test/file-context-menu.test.ts
+++ b/packages/pi-file-context/test/file-context-menu.test.ts
@@ -29,7 +29,7 @@ function state(
 ): FileContextMenuState {
 	return {
 		quotes,
-		shortcut: "ctrl+x",
+		shortcut: "ctrl+shift+x",
 		maximumQuotes: 8,
 		maximumBytes: 100_000,
 		totalBytes: quotes.reduce((total, item) => total + Buffer.byteLength(item.text), 0),
@@ -38,13 +38,24 @@ function state(
 	};
 }
 
-function menuContext(width = 80, rows = 24) {
+function menuContext(width = 80, rows = 24, reload: () => Promise<void> = async () => {}) {
 	const tui = createTuiHarness({ width, rows });
-	const base = createMockContext({ mode: "tui", hasUI: true });
+	let reloadCalls = 0;
+	const base = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		async reload() {
+			reloadCalls += 1;
+			await reload();
+		},
+	});
 	const baseCtx = base.ctx as unknown as { ui: Record<string, unknown> } & Record<string, unknown>;
 	return {
 		tui,
 		notifications: base.notifications,
+		get reloadCalls() {
+			return reloadCalls;
+		},
 		ctx: {
 			...baseCtx,
 			ui: { ...baseCtx.ui, custom: tui.custom },
@@ -93,7 +104,7 @@ test("shows the primary menu immediately with visible state and disabled reasons
 	const initial = tui.render().join("\n");
 	assert.match(initial, /File Context/u);
 	assert.match(initial, /Next prompt context: 0\/8 snippets/u);
-	assert.match(initial, /Shortcut: CTRL\+X/u);
+	assert.match(initial, /Shortcut: CTRL\+SHIFT\+X/u);
 	assert.match(initial, /Add context snippet/u);
 	assert.match(initial, /Settings/u);
 	assert.match(initial, /Status/u);
@@ -144,7 +155,7 @@ test("opens Status with current limits and settings", async () => {
 	const frame = tui.render().join("\n");
 	assert.match(frame, /File Context Status/u);
 	assert.match(frame, /Next prompt context: 1\/8 snippets/u);
-	assert.match(frame, /Open shortcut: ctrl\+x/u);
+	assert.match(frame, /Open shortcut: ctrl\+shift\+x/u);
 	assert.match(frame, /pi-file-context\.json/u);
 	tui.press("ctrl+c");
 	await running;
@@ -178,59 +189,92 @@ test("opens Help from the menu and Escape returns without side effects", async (
 	await running;
 });
 
-test("Settings changes and disables the open shortcut immediately", async () => {
-	const { tui, ctx, notifications } = menuContext(44, 14);
-	let current = state();
+test("Settings saves or disables the shortcut and reloads Pi", async () => {
+	for (const scenario of [
+		{ input: "ctrl+y", expected: "ctrl+y" },
+		{ input: "", expected: null },
+	] as const) {
+		const menu = menuContext(44, 14);
+		const saved: Array<string | null> = [];
+		const running = showFileContextMenu(
+			menu.ctx,
+			options(() => state(), {
+				saveShortcut: (shortcut) => {
+					saved.push(shortcut);
+				},
+			}),
+		);
+		await menu.tui.waitForOpen();
+		menu.tui.press("tui.select.down");
+		menu.tui.press("tui.select.down");
+		menu.tui.press("tui.select.confirm");
+		await menu.tui.waitForOpen();
+		assert.match(menu.tui.render().join("\n"), /File Context Settings/u);
+		assert.match(menu.tui.render().join("\n"), /Open shortcut\s+ctrl\+shift\+x/u);
+		assert.ok(menu.tui.render(28).every((line) => visibleWidth(line) <= 28));
+
+		menu.tui.press("tui.select.confirm");
+		await menu.tui.waitForPending();
+		await menu.tui.waitForOpen();
+		if (scenario.input) menu.tui.type(scenario.input);
+		menu.tui.press("tui.input.submit");
+		await menu.tui.waitForPending();
+		await running;
+
+		assert.deepEqual(saved, [scenario.expected]);
+		assert.equal(menu.reloadCalls, 1);
+		assert.match(menu.notifications.at(-1)?.message ?? "", /Reloading Pi/u);
+	}
+});
+
+test("Settings rejects invalid keys without saving or reloading", async () => {
+	const menu = menuContext(44, 14);
 	const saved: Array<string | null> = [];
 	const controller = new AbortController();
 	const running = showFileContextMenu(
-		ctx,
-		options(() => current, {
+		menu.ctx,
+		options(() => state(), {
 			signal: controller.signal,
 			saveShortcut: (shortcut) => {
 				saved.push(shortcut);
-				current = state([], { shortcut });
 			},
 		}),
+	);
+	await menu.tui.waitForOpen();
+	menu.tui.press("tui.select.down");
+	menu.tui.press("tui.select.down");
+	menu.tui.press("tui.select.confirm");
+	await menu.tui.waitForOpen();
+	menu.tui.press("tui.select.confirm");
+	await menu.tui.waitForPending();
+	await menu.tui.waitForOpen();
+	menu.tui.type("ctrl+not-a-key");
+	menu.tui.press("tui.input.submit");
+	await menu.tui.waitForPending();
+	assert.deepEqual(saved, []);
+	assert.equal(menu.reloadCalls, 0);
+	assert.match(menu.notifications.at(-1)?.message ?? "", /Invalid key identifier/u);
+	controller.abort();
+	menu.tui.dispose();
+	await running;
+});
+
+test("Settings is unavailable while selected context would be lost by reload", async () => {
+	const { tui, ctx } = menuContext(52, 14);
+	const running = showFileContextMenu(
+		ctx,
+		options(() => state([quote("quote-1")])),
 	);
 	await tui.waitForOpen();
 	tui.press("tui.select.down");
 	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	await tui.waitForOpen();
-	assert.match(tui.render().join("\n"), /File Context Settings/u);
-	assert.match(tui.render().join("\n"), /Open shortcut\s+ctrl\+x/u);
-	assert.ok(tui.render(28).every((line) => visibleWidth(line) <= 28));
-
+	const frame = tui.render().join("\n");
+	assert.match(frame, /\[-\].*Settings/u);
+	assert.match(frame, /Submit or remove selected context\s+first/u);
 	tui.press("tui.select.confirm");
 	await tui.waitForPending();
-	await tui.waitForOpen();
-	tui.type("ctrl+y");
-	tui.press("tui.input.submit");
-	await tui.waitForPending();
-	await tui.waitForOpen();
-	assert.deepEqual(saved, ["ctrl+y"]);
-	assert.match(tui.render().join("\n"), /Open shortcut\s+ctrl\+y/u);
-
-	tui.press("tui.select.confirm");
-	await tui.waitForPending();
-	await tui.waitForOpen();
-	tui.press("tui.input.submit");
-	await tui.waitForPending();
-	await tui.waitForOpen();
-	assert.deepEqual(saved, ["ctrl+y", null]);
-	assert.match(tui.render().join("\n"), /Open shortcut\s+none/u);
-
-	tui.press("tui.select.confirm");
-	await tui.waitForPending();
-	await tui.waitForOpen();
-	tui.type("ctrl+not-a-key");
-	tui.press("tui.input.submit");
-	await tui.waitForPending();
-	assert.deepEqual(saved, ["ctrl+y", null]);
-	assert.match(notifications.at(-1)?.message ?? "", /Invalid key identifier/u);
-	controller.abort();
-	tui.dispose();
+	assert.equal(tui.isOpen, true);
+	tui.press("ctrl+c");
 	await running;
 });
 
@@ -273,6 +317,37 @@ test("invalid settings are read-only and save failures preserve the displayed sh
 		tui.dispose();
 		await running;
 	}
+});
+
+test("a reload failure keeps the saved value and gives a safe recovery instruction", async () => {
+	const menu = menuContext(48, 14, async () => {
+		throw new Error("reload failed\u001b]52;c;payload\u0007");
+	});
+	const saved: Array<string | null> = [];
+	const running = showFileContextMenu(
+		menu.ctx,
+		options(() => state(), {
+			saveShortcut: (shortcut) => {
+				saved.push(shortcut);
+			},
+		}),
+	);
+	await menu.tui.waitForOpen();
+	menu.tui.press("tui.select.down");
+	menu.tui.press("tui.select.down");
+	menu.tui.press("tui.select.confirm");
+	await menu.tui.waitForOpen();
+	menu.tui.press("tui.select.confirm");
+	await menu.tui.waitForPending();
+	await menu.tui.waitForOpen();
+	menu.tui.type("ctrl+y");
+	menu.tui.press("tui.input.submit");
+	await menu.tui.waitForPending();
+	await running;
+	assert.deepEqual(saved, ["ctrl+y"]);
+	assert.equal(menu.reloadCalls, 1);
+	assert.match(menu.notifications.at(-1)?.message ?? "", /settings were saved.*run \/reload/iu);
+	assert.ok(!(menu.notifications.at(-1)?.message ?? "").includes("\u001b"));
 });
 
 test("Settings disposal aborts an in-flight shortcut save without reporting a stale error", async () => {

--- a/packages/pi-file-context/test/file-context-settings.test.ts
+++ b/packages/pi-file-context/test/file-context-settings.test.ts
@@ -30,10 +30,10 @@ async function withTempSettings(
 	}
 }
 
-test("missing settings use Ctrl+X without creating a file", async () => {
+test("missing settings use Ctrl+Shift+X without creating a file", async () => {
 	await withTempSettings(async (settingsPath) => {
 		const result = await loadFileContextSettings(settingsPath);
-		assert.deepEqual(result, { settings: { openShortcut: "ctrl+x" } });
+		assert.deepEqual(result, { settings: { openShortcut: "ctrl+shift+x" } });
 		await assert.rejects(access(settingsPath), { code: "ENOENT" });
 	});
 });
@@ -50,7 +50,20 @@ test("settings normalize a custom shortcut and allow disabling it", async () => 
 			settings: { openShortcut: null },
 		});
 		assert.equal(normalizeKeyId(" Ctrl+Shift+P "), "ctrl+shift+p");
+		assert.equal(normalizeKeyId("ctrl+f1"), undefined);
 		assert.equal(normalizeKeyId("ctrl+not-a-key"), undefined);
+	});
+});
+
+test("accepts a UTF-8 BOM without weakening strict decoding", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await writeFile(
+			settingsPath,
+			Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from('{"openShortcut":"f8"}')]),
+		);
+		assert.deepEqual(await loadFileContextSettings(settingsPath), {
+			settings: { openShortcut: "f8" },
+		});
 	});
 });
 

--- a/packages/pi-file-context/test/file-context-settings.test.ts
+++ b/packages/pi-file-context/test/file-context-settings.test.ts
@@ -1,27 +1,40 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+	access,
+	lstat,
+	mkdtemp,
+	readdir,
+	readFile,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "vitest";
 import {
 	DEFAULT_FILE_CONTEXT_SETTINGS,
 	loadFileContextSettings,
+	normalizeKeyId,
+	updateFileContextSettings,
 } from "../src/file-context-settings.js";
 
-async function withTempSettings(run: (settingsPath: string) => Promise<void>): Promise<void> {
+async function withTempSettings(
+	run: (settingsPath: string, directory: string) => Promise<void>,
+): Promise<void> {
 	const root = await mkdtemp(join(tmpdir(), "pi-file-context-settings-test-"));
 	try {
-		await run(join(root, "pi-file-context.json"));
+		await run(join(root, "pi-file-context.json"), root);
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}
 }
 
-test("missing settings use F8 without creating a file", async () => {
+test("missing settings use Ctrl+X without creating a file", async () => {
 	await withTempSettings(async (settingsPath) => {
 		const result = await loadFileContextSettings(settingsPath);
-		assert.deepEqual(result, { settings: { openShortcut: "f8" } });
-		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+		assert.deepEqual(result, { settings: { openShortcut: "ctrl+x" } });
+		await assert.rejects(access(settingsPath), { code: "ENOENT" });
 	});
 });
 
@@ -36,22 +49,116 @@ test("settings normalize a custom shortcut and allow disabling it", async () => 
 		assert.deepEqual(await loadFileContextSettings(settingsPath), {
 			settings: { openShortcut: null },
 		});
+		assert.equal(normalizeKeyId(" Ctrl+Shift+P "), "ctrl+shift+p");
+		assert.equal(normalizeKeyId("ctrl+not-a-key"), undefined);
 	});
 });
 
-test("malformed or invalid settings keep the default and return an observable warning", async () => {
+test("malformed or invalid settings keep the default and block writes", async () => {
 	await withTempSettings(async (settingsPath) => {
-		await writeFile(settingsPath, "{broken");
-		const malformed = await loadFileContextSettings(settingsPath);
-		assert.deepEqual(malformed.settings, DEFAULT_FILE_CONTEXT_SETTINGS);
-		assert.match(malformed.warning ?? "", /cannot parse/i);
-		assert.equal(await readFile(settingsPath, "utf8"), "{broken");
-
-		for (const openShortcut of ["ctrl+not-a-key", "ctrl+f1"]) {
-			await writeFile(settingsPath, JSON.stringify({ openShortcut }));
+		for (const contents of ["{broken", JSON.stringify({ openShortcut: "ctrl+not-a-key" })]) {
+			await writeFile(settingsPath, contents);
 			const invalid = await loadFileContextSettings(settingsPath);
 			assert.deepEqual(invalid.settings, DEFAULT_FILE_CONTEXT_SETTINGS);
-			assert.match(invalid.warning ?? "", /openShortcut/);
+			assert.ok(invalid.invalidReason);
+			assert.ok(invalid.warning);
+			await assert.rejects(
+				updateFileContextSettings("ctrl+y", { settingsPath }),
+				/settings are invalid/i,
+			);
+			assert.equal(await readFile(settingsPath, "utf8"), contents);
 		}
+	});
+});
+
+test("explicit saves create a private file and preserve unknown fields", async () => {
+	await withTempSettings(async (settingsPath) => {
+		await updateFileContextSettings("ctrl+y", { settingsPath });
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			openShortcut: "ctrl+y",
+		});
+		assert.equal((await lstat(settingsPath)).mode & 0o777, 0o600);
+
+		await writeFile(
+			settingsPath,
+			JSON.stringify({ openShortcut: "f8", future: { enabled: true } }),
+		);
+		await updateFileContextSettings(null, { settingsPath });
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			openShortcut: null,
+			future: { enabled: true },
+		});
+	});
+});
+
+test("failed atomic publication keeps the previous file and does not poison later saves", async () => {
+	await withTempSettings(async (settingsPath, directory) => {
+		const original = '{"openShortcut":"f8","future":true}\n';
+		await writeFile(settingsPath, original);
+		await assert.rejects(
+			updateFileContextSettings("ctrl+y", {
+				settingsPath,
+				beforeRename: async () => {
+					throw new Error("rename blocked");
+				},
+			}),
+			/rename blocked/,
+		);
+		assert.equal(await readFile(settingsPath, "utf8"), original);
+		assert.deepEqual((await readdir(directory)).sort(), ["pi-file-context.json"]);
+
+		const controller = new AbortController();
+		await assert.rejects(
+			updateFileContextSettings("ctrl+y", {
+				settingsPath,
+				signal: controller.signal,
+				beforeRename: async () => controller.abort(),
+			}),
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+		assert.equal(await readFile(settingsPath, "utf8"), original);
+		assert.deepEqual((await readdir(directory)).sort(), ["pi-file-context.json"]);
+
+		await updateFileContextSettings("ctrl+z", { settingsPath });
+		assert.equal((await loadFileContextSettings(settingsPath)).settings.openShortcut, "ctrl+z");
+	});
+});
+
+test("reads wait for serialized writes and observe the latest requested value", async () => {
+	await withTempSettings(async (settingsPath) => {
+		let markStarted!: () => void;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const first = updateFileContextSettings("ctrl+a", {
+			settingsPath,
+			beforeRename: async () => {
+				markStarted();
+				await gate;
+			},
+		});
+		await started;
+		const second = updateFileContextSettings("ctrl+b", { settingsPath });
+		const coordinatedRead = loadFileContextSettings(settingsPath);
+		release();
+		await Promise.all([first, second]);
+		assert.equal((await coordinatedRead).settings.openShortcut, "ctrl+b");
+	});
+});
+
+test("symbolic-link settings are invalid and never overwrite their target", async () => {
+	await withTempSettings(async (settingsPath, directory) => {
+		const target = join(directory, "target.json");
+		const original = '{"openShortcut":"f8"}\n';
+		await writeFile(target, original);
+		await symlink(target, settingsPath);
+		const loaded = await loadFileContextSettings(settingsPath);
+		assert.ok(loaded.invalidReason);
+		await assert.rejects(updateFileContextSettings("ctrl+y", { settingsPath }), /invalid/i);
+		assert.equal(await readFile(target, "utf8"), original);
 	});
 });

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -760,7 +760,7 @@ test("allows disabling the shortcut and reports settings warnings after session 
 	await registerFileQuoteExtension(mock.pi, {
 		loadSettings: async () => ({
 			settings: { openShortcut: null },
-			warning: "Invalid File Context settings; using the default.",
+			warning: "Invalid File Context settings\u001b]52;c;payload\u0007; using the default.",
 		}),
 	});
 	assert.equal(mock.shortcuts.size, 0);
@@ -768,6 +768,7 @@ test("allows disabling the shortcut and reports settings warnings after session 
 	const context = createMockContext({ mode: "tui", hasUI: true });
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	assert.ok(context.notifications.some(({ message }) => message.includes("Invalid File Context")));
+	assert.ok(context.notifications.every(({ message }) => !message.includes("\u001b")));
 
 	const rpc = createMockContext({ mode: "rpc", hasUI: true });
 	await mock.events.get("session_start")?.[0]?.({}, rpc.ctx);


### PR DESCRIPTION
## Summary

- Use `Ctrl+Shift+X` as the default File Context browser shortcut because Pi reserves `Ctrl+X` for `app.message.copy`.
- Add Settings and Status actions to `/file-context`, including shortcut changes and disabling from the menu.
- Save shortcut changes atomically, then reload Pi so its snapshotted TUI shortcut map actually updates.
- Disable Settings while context snippets are selected so the required reload cannot discard pending context.
- Add coordinated, bounded settings reads and serialized atomic writes that preserve unknown fields and reject invalid or symbolic-link settings.
- Reload settings on session start, wait for writes during shutdown, sanitize warnings, accept UTF-8 BOM files, and add a patch changeset.

## Verification

- `npm --workspace @narumitw/pi-file-context run check`
- `npx vitest run packages/pi-file-context/test` — 95 tests passed
- `npm run check`
- `npm test` — 3,749 tests passed
- `just pack file-context` — 18 files inspected
- Pi RPC package-load smoke with `get_state`

## Audits

- Reviewed shortcut conflicts and Pi's shortcut snapshot behavior against the installed Pi implementation.
- Reviewed settings ordering, invalid-file protection, unknown-field preservation, atomic publication, cancellation, disposal, session replacement, shutdown durability, terminal safety, and TUI width behavior against `docs/extension-conventions.md` and `docs/extension-settings.md`.
- Verified that successful reload is terminal for the old menu action and reload failure gives a sanitized `/reload` recovery instruction.
