### PR TITLE
feat(pi-tui-kit): streamline single-question questionnaires

### DIFF
--- a/.changeset/quick-questions-submit.md
+++ b/.changeset/quick-questions-submit.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-tui-kit": patch
+"@narumitw/pi-plan-mode": patch
+"@narumitw/pi-workflow": patch
+---
+
+Simplify single-question TUI questionnaires with a plain header and immediate answer submission while retaining tabbed Review for multiple questions.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -122,11 +122,14 @@ Tests and builds may still write ignored caches or build artifacts and may execu
 This is extension-level risk reduction, not an OS sandbox.
 
 `plan_mode_question` follows Codex's `request_user_input` pattern: the agent can ask 1-3 concise questions, each with meaningful options and a free-form Other path.
-In TUI mode, one question appears at a time with question tabs and a final Review tab.
+In TUI mode, a single question shows its header as plain muted text, submits as soon as its preset or custom answer is confirmed, and does not show tabs, Review, or question-navigation controls.
+Add an optional note with `n` before confirming a single preset answer.
+With two or three questions, one question appears at a time with question tabs and a final Review tab.
 Use Tab, Shift+Tab, left, or right to visit any question or Review, including unanswered future questions.
-Use up and down to choose an option, Enter to record it and advance, or `n` to record the highlighted option and open its optional note editor. Press `n` again on an answered item to edit or clear its note.
+Use up and down to choose an option, Enter to record it and advance, or `n` to record the highlighted option and open its optional note editor.
+Press `n` again on an answered item to edit or clear its note.
 Revisit a question to replace its answer; changing the chosen option clears its prior note.
-Review lists every answer and note, lets up and down select an answer for note editing, and submits the ordered payload only after every question is answered.
+Review lists every answer and note, blocks incomplete submission, and requires returning to a question to edit its answer or note.
 Custom answers and notes retain their raw submitted text in the tool result, while terminal rendering is sanitized.
 The TUI rejects either field above 4,000 characters instead of truncating it.
 RPC keeps the existing sequential `select` and `editor` dialogs because Pi RPC cannot render custom TUI components.
@@ -220,7 +223,7 @@ During implementation, it removes both the original implementation handoff and t
 
 ## 🛠️ Tools
 
-- `plan_mode_question` asks up to three structured questions, supports optional answer notes, and reviews the ordered result before TUI submission.
+- `plan_mode_question` asks up to three structured questions, supports optional answer notes, submits one answer directly, and reviews multiple answers before TUI submission.
 - `plan_mode_complete` records the complete approved Markdown plan and terminates the planning turn when called alone.
 
 ## ⚙️ Settings

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -268,7 +268,8 @@ RPC deliberately degrades to a signal-aware ordinary selector: it never runs liv
 Print and JSON return `unsupported`.
 Results distinguish `selected`, `shortcut`, `closed`, `stale`, `unsupported`, and `error`.
 
-Use `runQuestionnaire()` for a bounded sequence of required choices with optional free-form answers, notes, and a final read-only review:
+Use `runQuestionnaire()` for a bounded sequence of required choices with optional free-form answers and notes.
+Single-question TUI flows submit immediately after answer confirmation, while multi-question flows end with a read-only review:
 
 ```ts
 import { runQuestionnaire } from "@narumitw/pi-tui-kit";
@@ -296,7 +297,9 @@ if (result.kind === "submitted") {
 }
 ```
 
-TUI preserves Pi selector framing, effective keybindings, Back versus Ctrl+C Close, exact editor input, optional notes, and a plain non-selectable review.
+TUI preserves Pi selector framing, effective keybindings, Back versus Ctrl+C Close, exact editor input, optional notes, and a plain non-selectable review for multiple questions.
+A single question renders its header as plain muted text, omits Review and question-navigation controls, labels answer confirmation as submission, and returns immediately after a preset or free-form answer is confirmed.
+Add an optional note before confirming a single preset answer because that confirmation submits the interaction.
 Free-form answers are enabled by default, notes require `allowNotes`, and `maxTextLength` applies to free-form answers and notes.
 RPC preserves the existing sequential `select()` and `editor()` fallback for choices and free-form answers, but does not collect TUI-only notes or show the final review.
 RPC preserves the editor response verbatim, including an empty string, for compatibility with existing Pi dialogs.
@@ -742,7 +745,7 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `runTask()` — runs typed abort-aware work with a cancellable TUI loader and direct non-TUI fallback.
 - `runConfirmation()` — preserves Confirmed, Back, Close, Stale, Unsupported, and Error for one standalone confirmation without owning the confirmed side effect.
 - `runLiveChoice()` — adapts a live-preview choice to TUI and ordinary RPC selection while preserving typed selection, confirmation-only gating, shortcuts, Back, Close, Stale, Unsupported, and Error.
-- `runQuestionnaire()` — adapts required multi-question choices, free-form answers, optional TUI notes, and read-only review to TUI and sequential RPC while preserving typed Submitted, Back, Close, Stale, Unsupported, and Error outcomes.
+- `runQuestionnaire()` — adapts required choices, free-form answers, optional TUI notes, direct single-question submission, multi-question read-only review, and sequential RPC while preserving typed Submitted, Back, Close, Stale, Unsupported, and Error outcomes.
 - `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and literal shortcut keys for specialized interaction hints; the lightweight `@narumitw/pi-tui-kit/interaction-hints` subpath exports it and its public types.
 - `sanitizeTerminalText()` — removes terminal and bidirectional display controls from untrusted single-line presentation text without mutating raw payloads; the lightweight `@narumitw/pi-tui-kit/terminal-text` subpath exports it.
 - `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending work draining, and typed results around one extension-owned custom TUI component.

--- a/packages/pi-tui-kit/src/components/questionnaire.ts
+++ b/packages/pi-tui-kit/src/components/questionnaire.ts
@@ -88,7 +88,7 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 		const padding = safeWidth > 1 ? " " : "";
 		const contentWidth = Math.max(1, safeWidth - visibleWidth(padding));
 		const border = this.border.render(safeWidth)[0] ?? "";
-		const lines = [border, "", ...this.renderTabs(contentWidth), ""];
+		const lines = [border, "", ...this.renderHeader(contentWidth), ""];
 		if (this.isReviewPage()) lines.push(...this.renderReview(contentWidth));
 		else lines.push(...this.renderQuestion(contentWidth));
 		if (this.message) {
@@ -191,12 +191,19 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 		const cancel = cancelHint(theme, keybindings);
 		if (this.editorKind) {
 			return [
-				keybindingHint(theme, keybindings, "tui.input.submit", "save"),
+				keybindingHint(
+					theme,
+					keybindings,
+					"tui.input.submit",
+					this.editorKind === "answer" && !this.hasReviewPage() ? "submit" : "save",
+				),
 				keybindingHint(theme, keybindings, "tui.input.newLine", "newline"),
 				cancel,
 			];
 		}
-		const questions = rawKeyHint(theme, questionNavigationKeys(keybindings), "questions");
+		const questions = this.hasReviewPage()
+			? rawKeyHint(theme, questionNavigationKeys(keybindings), "questions")
+			: "";
 		if (this.isReviewPage()) {
 			return [
 				keybindingHint(theme, keybindings, "tui.select.confirm", "submit"),
@@ -206,7 +213,12 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 		}
 		return [
 			rawKeyHint(theme, selectionNavigationKeys(keybindings), "navigate"),
-			keybindingHint(theme, keybindings, "tui.select.confirm", "select"),
+			keybindingHint(
+				theme,
+				keybindings,
+				"tui.select.confirm",
+				this.hasReviewPage() ? "select" : "submit",
+			),
 			cancel,
 			questions,
 			...(this.options.allowNotes && noteShortcutAvailable(keybindings)
@@ -216,7 +228,7 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 	}
 
 	private movePage(delta: number): void {
-		const pageCount = this.options.questions.length + 1;
+		const pageCount = this.options.questions.length + Number(this.hasReviewPage());
 		this.page = (this.page + delta + pageCount) % pageCount;
 		const answer = this.answers[this.page];
 		const question = this.options.questions[this.page];
@@ -228,6 +240,16 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 		this.message = undefined;
 	}
 
+	private renderHeader(width: number): string[] {
+		if (!this.hasReviewPage()) {
+			const question = this.options.questions[0];
+			if (!question) return [];
+			const header = sanitizeQuestionnaireText(question.header) || "Question 1";
+			return [this.options.theme.fg("muted", truncateToWidth(header, width, "…"))];
+		}
+		return this.renderTabs(width);
+	}
+
 	private renderTabs(width: number): string[] {
 		const reviewTab = sanitizeQuestionnaireText(this.options.labels.reviewTab) || "Review";
 		const tabs = [
@@ -236,7 +258,7 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 				const answered = this.answers[index] ? "✓ " : "";
 				return this.page === index ? `[${answered}${label}]` : `${answered}${label}`;
 			}),
-			this.isReviewPage() ? `[${reviewTab}]` : reviewTab,
+			...(this.hasReviewPage() ? [this.isReviewPage() ? `[${reviewTab}]` : reviewTab] : []),
 		];
 		const lines: string[] = [];
 		let line = "";
@@ -461,12 +483,23 @@ export class QuestionnaireComponent<QuestionId extends string> implements Compon
 	}
 
 	private advance(): void {
+		if (!this.hasReviewPage()) {
+			const answers = this.answers.filter(
+				(answer): answer is QuestionnaireAnswer<QuestionId> => answer !== undefined,
+			);
+			this.finish({ kind: "submitted", answers });
+			return;
+		}
 		this.page = Math.min(this.page + 1, this.options.questions.length);
 		this.message = undefined;
 	}
 
+	private hasReviewPage(): boolean {
+		return this.options.questions.length > 1;
+	}
+
 	private isReviewPage(): boolean {
-		return this.page === this.options.questions.length;
+		return this.hasReviewPage() && this.page === this.options.questions.length;
 	}
 
 	private finish(value: QuestionnaireInteractionValue<QuestionId>): void {

--- a/packages/pi-tui-kit/src/questionnaire.ts
+++ b/packages/pi-tui-kit/src/questionnaire.ts
@@ -66,7 +66,7 @@ const DEFAULT_LABELS: QuestionnaireLabels = {
 	note: "Note",
 };
 
-/** Run a standalone multi-question interaction with TUI and RPC adapters. */
+/** Run a standalone questionnaire interaction with TUI and RPC adapters. */
 export async function runQuestionnaire<
 	const QuestionId extends string,
 	Context extends MenuContext = ExtensionCommandContext,

--- a/packages/pi-tui-kit/test/questionnaire.test.ts
+++ b/packages/pi-tui-kit/test/questionnaire.test.ts
@@ -148,6 +148,111 @@ test("runQuestionnaire preserves select framing, theme hierarchy, and read-only 
 	assert.deepEqual(await running, { kind: "stale" });
 });
 
+test("runQuestionnaire renders and submits a single question without review chrome", async () => {
+	const singleQuestion = { ...questions[0], header: "Scope\u001b[31m" };
+	const foreground: Array<{ color: string; text: string }> = [];
+	const bold: string[] = [];
+	const presetTui = createTuiHarness({
+		width: 60,
+		rows: 30,
+		keybindings: new KeybindingsManager(TUI_KEYBINDINGS),
+		theme: {
+			fg: (color, text) => {
+				foreground.push({ color: String(color), text });
+				return text;
+			},
+			bold: (text) => {
+				bold.push(text);
+				return text;
+			},
+		},
+	});
+	const presetContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: presetTui.custom,
+	});
+	const presetRunning = runQuestionnaire(presetContext.ctx, {
+		questions: [singleQuestion],
+		allowNotes: true,
+		maxTextLength: MAX_TEXT_LENGTH,
+	});
+	await presetTui.waitForOpen();
+	presetTui.setFocused(true);
+	for (const width of [1, 8, 60]) {
+		for (const line of presetTui.resize({ width })) assert.ok(visibleWidth(line) <= width);
+	}
+	const frame = presetTui.render().join("\n");
+	assert.match(frame, /\n Scope\n/u);
+	assert.equal(frame.includes("\u001b"), false);
+	assert.match(frame, /enter submit/u);
+	assert.doesNotMatch(frame, /\[Scope\]|✓ Scope|Review| questions/u);
+	assert.ok(foreground.some(({ color, text }) => color === "muted" && text === "Scope"));
+	assert.ok(foreground.some(({ color, text }) => color === "accent" && text === "How broad?"));
+	assert.ok(bold.includes("How broad?"));
+	presetTui.press("tui.select.down");
+	presetTui.type("n");
+	presetTui.type("keep focused");
+	presetTui.press("tui.input.submit");
+	presetTui.press("tui.select.confirm");
+	assert.deepEqual(await presetRunning, {
+		kind: "submitted",
+		answers: [
+			{
+				questionId: "scope",
+				answer: "Broad",
+				wasCustom: false,
+				optionIndex: 2,
+				note: "keep focused",
+			},
+		],
+	});
+
+	const custom = tuiRun([questions[0]]);
+	await custom.tui.waitForOpen();
+	custom.tui.setFocused(true);
+	custom.tui.press("tui.select.up");
+	custom.tui.press("tui.select.confirm");
+	assert.match(custom.tui.render().join("\n"), /enter submit/u);
+	custom.tui.type("custom scope");
+	custom.tui.press("tui.input.submit");
+	assert.deepEqual(await custom.running, {
+		kind: "submitted",
+		answers: [{ questionId: "scope", answer: "custom scope", wasCustom: true }],
+	});
+});
+
+test("runQuestionnaire retains tabbed review for three questions", async () => {
+	const thirdQuestion = {
+		id: "risk",
+		header: "Risk",
+		prompt: "Which risk level?",
+		options: [
+			{ label: "Low", description: "Keep the change narrow." },
+			{ label: "High", description: "Accept broader impact." },
+		],
+	} as const satisfies QuestionnaireQuestion;
+	const { tui, running } = tuiRun([...questions, thirdQuestion], 80);
+	await tui.waitForOpen();
+	assert.match(tui.render().join("\n"), /\[Scope\] {2}Tests {2}Risk {2}Review/u);
+	tui.press("tui.select.confirm");
+	tui.press("tui.select.confirm");
+	tui.press("tui.select.confirm");
+	assert.match(
+		tui.render().join("\n"),
+		/1\. Scope — Small\n 2\. Tests — Focused\n 3\. Risk — Low/u,
+	);
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, {
+		kind: "submitted",
+		answers: [
+			{ questionId: "scope", answer: "Small", wasCustom: false, optionIndex: 1 },
+			{ questionId: "tests", answer: "Focused", wasCustom: false, optionIndex: 1 },
+			{ questionId: "risk", answer: "Low", wasCustom: false, optionIndex: 1 },
+		],
+	});
+});
+
 test("runQuestionnaire uses configured standard actions before additive shortcuts", async () => {
 	const bindings = {
 		"tui.input.newLine": { data: "\u001b[13;3u", key: "alt+enter" },
@@ -354,7 +459,7 @@ test("runQuestionnaire replaces answers, edits notes, accepts custom text, and s
 });
 
 test("runQuestionnaire restores the recorded answer cursor when revisiting a question", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
+	const { tui, running } = tuiRun();
 	await tui.waitForOpen();
 	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
@@ -369,7 +474,7 @@ test("runQuestionnaire restores the recorded answer cursor when revisiting a que
 });
 
 test("runQuestionnaire preserves a custom answer note while editing the answer", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
+	const { tui, running } = tuiRun();
 	await tui.waitForOpen();
 	tui.setFocused(true);
 	tui.press("tui.select.down");
@@ -386,6 +491,7 @@ test("runQuestionnaire preserves a custom answer note while editing the answer",
 	paste(tui, "edited answer");
 	tui.press("tui.input.submit");
 	tui.press("tui.select.confirm");
+	tui.press("tui.select.confirm");
 	assert.deepEqual(await running, {
 		kind: "submitted",
 		answers: [
@@ -395,6 +501,7 @@ test("runQuestionnaire preserves a custom answer note while editing the answer",
 				wasCustom: true,
 				note: "keep this note",
 			},
+			{ questionId: "tests", answer: "Focused", wasCustom: false, optionIndex: 1 },
 		],
 	});
 });
@@ -425,6 +532,7 @@ test("runQuestionnaire preserves raw pasted text while sanitizing every rendered
 				{ label: "other", description: "second" },
 			],
 		},
+		questions[1],
 	] as const;
 	const { tui, running } = tuiRun(malicious, 16);
 	await tui.waitForOpen();
@@ -456,6 +564,7 @@ test("runQuestionnaire preserves raw pasted text while sanitizing every rendered
 	tui.press("tui.input.submit");
 	tui.send("\u001b[C");
 	tui.press("tui.select.confirm");
+	tui.press("tui.select.confirm");
 	assert.deepEqual(await running, {
 		kind: "submitted",
 		answers: [
@@ -465,12 +574,13 @@ test("runQuestionnaire preserves raw pasted text while sanitizing every rendered
 				wasCustom: true,
 				note: unsafeNote,
 			},
+			{ questionId: "tests", answer: "Focused", wasCustom: false, optionIndex: 1 },
 		],
 	});
 });
 
 test("runQuestionnaire keeps Backspace as editing and forwards Editor focus", async () => {
-	const { tui, running } = tuiRun([questions[0]]);
+	const { tui, running } = tuiRun();
 	await tui.waitForOpen();
 	tui.setFocused(true);
 	tui.press("tui.select.down");
@@ -487,9 +597,13 @@ test("runQuestionnaire keeps Backspace as editing and forwards Editor focus", as
 	tui.press("tui.input.submit");
 	tui.send("\u001b[C");
 	tui.press("tui.select.confirm");
+	tui.press("tui.select.confirm");
 	assert.deepEqual(await running, {
 		kind: "submitted",
-		answers: [{ questionId: "scope", answer: "wrong", wasCustom: true, note: "note" }],
+		answers: [
+			{ questionId: "scope", answer: "wrong", wasCustom: true, note: "note" },
+			{ questionId: "tests", answer: "Focused", wasCustom: false, optionIndex: 1 },
+		],
 	});
 });
 
@@ -504,7 +618,7 @@ test("runQuestionnaire keeps configured newline distinct from submit", async (t)
 	setKeybindings(keybindings);
 	const tui = createTuiHarness({ keybindings });
 	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = runQuestionnaire(context.ctx, { questions: [questions[0]] });
+	const running = runQuestionnaire(context.ctx, { questions });
 	await tui.waitForOpen();
 	tui.setFocused(true);
 	tui.press("tui.select.down");
@@ -514,11 +628,15 @@ test("runQuestionnaire keeps configured newline distinct from submit", async (t)
 	tui.send("\u001b\r");
 	tui.type("second");
 	tui.send("\u0013");
+	tui.press("tui.select.confirm");
 	assert.match(tui.render().join("\n"), /first ↵ second/u);
 	tui.press("tui.select.confirm");
 	assert.deepEqual(await running, {
 		kind: "submitted",
-		answers: [{ questionId: "scope", answer: "first\nsecond", wasCustom: true }],
+		answers: [
+			{ questionId: "scope", answer: "first\nsecond", wasCustom: true },
+			{ questionId: "tests", answer: "Focused", wasCustom: false, optionIndex: 1 },
+		],
 	});
 });
 
@@ -558,7 +676,7 @@ test("runQuestionnaire applies a custom note label to editing and review", async
 	const tui = createTuiHarness({ keybindings: new KeybindingsManager(TUI_KEYBINDINGS) });
 	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 	const running = runQuestionnaire(context.ctx, {
-		questions: [questions[0]],
+		questions,
 		allowNotes: true,
 		labels: { note: "Context", optionalNote: "Optional context" },
 	});
@@ -569,6 +687,7 @@ test("runQuestionnaire applies a custom note label to editing and review", async
 	tui.type("why");
 	tui.press("tui.input.submit");
 	tui.press("tui.select.confirm");
+	tui.press("tui.select.confirm");
 	assert.match(tui.render().join("\n"), /Context: why/u);
 	tui.press("tui.select.confirm");
 	assert.equal((await running).kind, "submitted");
@@ -578,7 +697,7 @@ test("runQuestionnaire can disable custom answers and notes while applying gener
 	const tui = createTuiHarness({ keybindings: new KeybindingsManager(TUI_KEYBINDINGS) });
 	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 	const running = runQuestionnaire(context.ctx, {
-		questions: [questions[0]],
+		questions,
 		allowCustomAnswer: false,
 		allowNotes: false,
 		labels: { reviewTab: "Check", reviewTitle: "Check response" },
@@ -588,11 +707,15 @@ test("runQuestionnaire can disable custom answers and notes while applying gener
 	assert.match(questionFrame, /Check/u);
 	assert.doesNotMatch(questionFrame, /Other|n note/u);
 	tui.press("tui.select.confirm");
+	tui.press("tui.select.confirm");
 	assert.match(tui.render().join("\n"), /Check response/u);
 	tui.press("tui.select.confirm");
 	assert.deepEqual(await running, {
 		kind: "submitted",
-		answers: [{ questionId: "scope", answer: "Small", wasCustom: false, optionIndex: 1 }],
+		answers: [
+			{ questionId: "scope", answer: "Small", wasCustom: false, optionIndex: 1 },
+			{ questionId: "tests", answer: "Focused", wasCustom: false, optionIndex: 1 },
+		],
 	});
 });
 

--- a/packages/pi-workflow/README.md
+++ b/packages/pi-workflow/README.md
@@ -161,11 +161,14 @@ It works in TUI and RPC modes and rejects print and JSON modes before opening in
 
 `/plan` retains the Plan-mode read-only tool policy, structured `plan_mode_question` interaction, standalone `plan_mode_complete` completion contract, saved-plan slot, export safety, session persistence, and compaction-aware linked-Plan context.
 
-In TUI mode, `plan_mode_question` shows one question at a time with question tabs and a final Review tab.
+In TUI mode, a single `plan_mode_question` shows its header as plain muted text, submits as soon as its preset or custom answer is confirmed, and does not show tabs, Review, or question-navigation controls.
+Add an optional note with `n` before confirming a single preset answer.
+With two or three questions, the interaction shows one question at a time with question tabs and a final Review tab.
 Use Tab, Shift+Tab, left, or right to visit any question or Review, including unanswered future questions.
-Use up and down to choose an option, Enter to record it and advance, or `n` to record the highlighted option and open its optional note editor. Press `n` again on an answered item to edit or clear its note.
+Use up and down to choose an option, Enter to record it and advance, or `n` to record the highlighted option and open its optional note editor.
+Press `n` again on an answered item to edit or clear its note.
 Revisiting a question can replace its answer, and changing the selected option clears its prior note.
-Review lists every answer and note, supports note editing for the selected answer, blocks incomplete submission, and submits all answers together.
+Review lists every answer and note, blocks incomplete submission, and requires returning to a question to edit its answer or note.
 Custom answers and notes retain their raw submitted text in the tool result, while terminal rendering is sanitized.
 The TUI rejects either field above 4,000 characters instead of truncating it.
 RPC keeps the existing sequential `select` and `editor` dialogs because Pi RPC cannot render custom TUI components.


### PR DESCRIPTION
## Summary

- Submit single-question TUI questionnaires immediately without a Review step.
- Render the single header as plain muted text and omit tab and question-navigation chrome.
- Preserve optional preset notes, custom answers, cancellation, terminal sanitization, and multi-question Review.
- Document the behavior in Pi TUI Kit, Plan mode, and Workflow with patch Changesets.

## Verification

- `npx vitest run packages/pi-tui-kit/test/questionnaire.test.ts` — 24 tests passed.
- Mirrored Plan mode and Workflow focused tests — 16 tests passed.
- `npm run check` — passed.
- `npm test` — 397 files and 3,751 tests passed.
- Dry-run packs passed for `@narumitw/pi-tui-kit`, `@narumitw/pi-plan-mode`, and `@narumitw/pi-workflow`.

## Risks and notes

- Single preset answers must add an optional note before confirmation because confirmation now submits immediately.
- RPC and multi-question TUI behavior are unchanged.
- No runtime-loading smoke was needed because entrypoints, package metadata, and loading boundaries did not change.
- `changeset status` still reports unrelated existing stale Pi TUI Kit dependency floors in other packages.
