### PR TITLE
feat(file-context): edit preview files externally

### DIFF
--- a/.changeset/calm-editors-preview.md
+++ b/.changeset/calm-editors-preview.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": patch
+---
+
+Open current worktree files in Pi's configured external editor from File Preview and show effective preview shortcuts.

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -15,6 +15,7 @@ Browse project files inside Pi, select exact lines or Git changes, and review ev
 - Opens from `/file-context` or a configurable shortcut that defaults to `Ctrl+Shift+X`.
 - Browses discovered project folders hierarchically, searches file names or contents globally, and previews bounded text with line numbers.
 - Adds whole-file references, exact line ranges, changed hunks, revisions, or Git diffs without using the clipboard.
+- Opens the current worktree file in Pi's configured external editor from the preview and reloads it after editing.
 - Shows Git state, blame, bounded file history, provenance, and a deterministic token estimate before attachment.
 - Reviews and removes exact queued snapshots before the next prompt.
 - Preserves selection order, supports repeated browsing, skips common generated directories, and never follows symlinks during discovery.
@@ -45,7 +46,7 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
 ## 🚀 Quick start
 
 1. Press `Ctrl+Shift+X` or run `/file-context browse`.
-2. Find a file, preview it, select the exact lines or Git change, and press `Enter` to attach the snapshot.
+2. Find a file, use the visible preview hints to edit or select exact lines or Git changes, and press `Enter` to attach the snapshot.
 3. Review queued snapshots from `/file-context`, write the request, and submit normally.
 
 ## 🧭 Browser workflow
@@ -64,11 +65,15 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
    Press `Tab` for a whole-file reference or `Enter` to preview the file at that line.
    `Escape` from the preview restores the query, result selection, and scroll position.
 5. In the preview, press `Space` to anchor the selection and extend the range with `Up`/`Down`.
-   The footer shows the selected lines, estimated tokens, and resulting next-prompt capacity.
+   The adaptive footer shows line selection, capacity, navigation, Git actions, external editing, and the `?` help action.
    Press `Enter` to add and close, or press `a` to add and return to the originating file or content results so you can keep browsing.
-6. Press `?` in the preview to review all actions.
+6. Use Pi's `app.editor.external` action, `Ctrl+G` by default, to open the current worktree file in the configured external editor.
+   File Context pauses its TUI, waits for the editor to exit, reloads bounded text and Git state, and keeps a reload failure visible in the preview.
+   A customized binding is matched and displayed directly, takes priority over File Context's additive letter shortcuts, and does not leave the old `Ctrl+G` active.
+7. Press `?` in the preview to review all actions.
    In a Git worktree, `[`/`]` selects changed hunks, `b` shows current-line blame, `h` opens file history, `r` opens a commit/branch/tag, and `d` reviews and adds explicit diff context.
-7. Open `/file-context` and choose **Review selected context** to inspect each exact snapshot.
+   Historical revision previews are read-only and never overwrite the current worktree through the external-editor action.
+8. Open `/file-context` and choose **Review selected context** to inspect each exact snapshot.
    `Enter` opens the snapshot first and then offers **Remove from next prompt**.
    `Escape` goes back without changing selected context, while `Ctrl+C` closes File Context.
    Write the question and submit normally; selected snippets are attached in order and cleared together.
@@ -112,6 +117,9 @@ A successful menu save reloads Pi automatically so the new shortcut becomes acti
 ```
 
 Set `openShortcut` to any valid Pi key identifier, or set it to `null` to disable the direct browser shortcut and use `/file-context browse`.
+External editing uses Pi's own `app.editor.external` keybinding and `externalEditor` setting rather than a File Context setting.
+Customize those through Pi's `keybindings.json` and `settings.json`; File Context reads the effective values and does not register a competing external-editor shortcut.
+Use an editor wait option such as `code --wait` when the editor command would otherwise return before editing finishes.
 Run `/reload` after editing the JSON file manually.
 
 Missing settings use `Ctrl+Shift+X` without creating the file.
@@ -141,6 +149,8 @@ JSON and print modes do not enter interactive UI.
 
 - Extensions run with the user's full permissions; install only trusted code.
 - File paths and symlink targets are checked against the real project root before reading.
+- External editing accepts only a canonical project-contained regular worktree file, rejects a final symlink, and serializes the full editing period with Pi's file mutation queue.
+- The configured external editor runs with the user's full permissions and may modify other files or access external services according to that program's behavior.
 - Preview files are limited to 1 MB and NUL-containing files are treated as binary.
 - Discovery is limited to 5,000 files, skips symlinks, and prioritizes shallow files before deeper files.
 - File-name and content-search queries are limited to 256 characters.
@@ -161,6 +171,8 @@ JSON and print modes do not enter interactive UI.
 ## 🚧 Limitations
 
 - Keyboard line selection only; mouse drag selection is not implemented.
+- External editing is available only from a current worktree File Preview, not from historical revisions, Git diffs, history lists, revision input, file lists, or search results.
+- On Windows, File Context rejects editor target paths containing command-shell metacharacters instead of passing an unsafe path through Pi's shell-compatible editor launch.
 - Up to eight selected snippets; exact review and repeated removal are supported, but there are not yet bulk clear, undo, or reorder actions.
 - Selected context does not survive `/reload`, session replacement, or shutdown.
 - The configurable shortcut is registered without replacing another extension's custom editor; `/file-context` remains available if the shortcut is disabled or conflicts.
@@ -180,7 +192,8 @@ src/index.ts                   Thin Pi entrypoint
 src/file-context.ts            Lifecycle, routes, filesystem boundaries, selected state, prompt injection
 src/file-context-menu.ts       Add, review, Settings, Status, Help, and removal flow
 src/file-context-settings.ts   Shortcut validation, coordinated reads, and atomic persistence
-src/file-context-explorer.ts   Folder, file, content, Git, and line-range interaction controller
+src/external-editor.ts          Safe configured-editor process, path, queue, and TUI lifecycle
+src/file-context-explorer.ts   Folder, file, content, Git, editing, and line-range controller
 src/file-browser.ts            Safe hierarchy model for discovered project paths
 src/file-browser-ui.ts         Width-safe folder and file list rendering with effective key hints
 src/file-context-preview-ui.ts Width-safe preview, capacity, and progressive action help
@@ -200,6 +213,7 @@ test/file-context-menu.test.ts  Menu, shortcut settings, exact review, removal, 
 test/file-context-command-menu.test.ts  Command routes, loading, and direct browser compatibility tests
 test/pending-quotes.test.ts     Exact selected-context removal, cancellation, and stale-flow tests
 test/file-context-settings.test.ts  Shortcut defaults, validation, ordering, and atomic-write tests
+test/external-editor.test.ts    External process, path, queue, and cancellation tests
 test/git-context.test.ts        Git repository behavior and parser tests
 ```
 

--- a/packages/pi-file-context/src/external-editor.ts
+++ b/packages/pi-file-context/src/external-editor.ts
@@ -1,0 +1,170 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { lstat, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import {
+	getAgentDir,
+	SettingsManager,
+	withFileMutationQueue,
+} from "@earendil-works/pi-coding-agent";
+import type { TUI } from "@earendil-works/pi-tui";
+
+export interface ExternalEditorProcess {
+	readonly killed: boolean;
+	kill(): boolean;
+	once(event: "close", listener: (code: number | null) => void): this;
+	once(event: "error", listener: (error: Error) => void): this;
+}
+
+export type SpawnExternalEditorProcess = (
+	command: string,
+	args: readonly string[],
+) => ExternalEditorProcess;
+
+export interface EditProjectFileInExternalEditorOptions {
+	root: string;
+	projectPath: string;
+	tui: TUI;
+	projectTrusted: boolean;
+	signal?: AbortSignal;
+	isCurrent?: () => boolean;
+	agentDir?: string;
+	command?: string;
+	spawnProcess?: SpawnExternalEditorProcess;
+}
+
+export async function editProjectFileInExternalEditor(
+	options: EditProjectFileInExternalEditorOptions,
+): Promise<void> {
+	options.signal?.throwIfAborted();
+	const target = await resolveEditableProjectFile(
+		options.root,
+		options.projectPath,
+		options.signal,
+	);
+	options.signal?.throwIfAborted();
+	const command =
+		options.command ??
+		SettingsManager.create(options.root, options.agentDir ?? getAgentDir(), {
+			projectTrusted: options.projectTrusted,
+		}).getExternalEditorCommand();
+	const [editor, ...editorArgs] = command.trim().split(/\s+/u);
+	if (!editor) throw new Error("External editor command is empty");
+	assertEditorTargetSafeForPlatform(target);
+
+	await withFileMutationQueue(target, async () => {
+		options.signal?.throwIfAborted();
+		let stopped = false;
+		try {
+			options.tui.stop();
+			stopped = true;
+			process.stdout.write("Launching external editor. Pi will resume when the editor exits.\n");
+			await runExternalEditorProcess(
+				editor,
+				[...editorArgs, target],
+				options.signal,
+				options.spawnProcess,
+			);
+			options.signal?.throwIfAborted();
+		} finally {
+			if (
+				stopped &&
+				!options.signal?.aborted &&
+				(options.isCurrent === undefined || options.isCurrent())
+			) {
+				options.tui.start();
+				options.tui.requestRender(true);
+			}
+		}
+	});
+}
+
+export async function resolveEditableProjectFile(
+	root: string,
+	projectPath: string,
+	signal?: AbortSignal,
+): Promise<string> {
+	signal?.throwIfAborted();
+	if (!projectPath || isAbsolute(projectPath) || projectPath.includes("\0")) {
+		throw new Error("File path is outside the project");
+	}
+	const canonicalRoot = await realpath(root);
+	signal?.throwIfAborted();
+	const candidate = resolve(canonicalRoot, projectPath);
+	if (!isInside(canonicalRoot, candidate)) throw new Error("File path is outside the project");
+	const candidateInfo = await lstat(candidate);
+	signal?.throwIfAborted();
+	if (candidateInfo.isSymbolicLink()) throw new Error(`${projectPath} is a symbolic link`);
+	const canonicalFile = await realpath(candidate);
+	signal?.throwIfAborted();
+	if (!isInside(canonicalRoot, canonicalFile)) throw new Error("File path is outside the project");
+	const info = await lstat(canonicalFile);
+	signal?.throwIfAborted();
+	if (!info.isFile()) throw new Error(`${projectPath} is not a regular file`);
+	return canonicalFile;
+}
+
+async function runExternalEditorProcess(
+	command: string,
+	args: readonly string[],
+	signal: AbortSignal | undefined,
+	spawnProcess: SpawnExternalEditorProcess = defaultSpawnExternalEditorProcess,
+): Promise<void> {
+	signal?.throwIfAborted();
+	const child = spawnProcess(command, args);
+	await new Promise<void>((resolvePromise, reject) => {
+		let settled = false;
+		let aborted = signal?.aborted ?? false;
+		const finish = (error?: Error) => {
+			if (settled) return;
+			settled = true;
+			signal?.removeEventListener("abort", abort);
+			if (error) reject(error);
+			else resolvePromise();
+		};
+		const abort = () => {
+			aborted = true;
+			if (!child.killed) child.kill();
+		};
+		child.once("error", (error) => finish(aborted ? abortError() : error));
+		child.once("close", (code) => {
+			if (aborted) {
+				finish(abortError());
+				return;
+			}
+			if (code === 0) {
+				finish();
+				return;
+			}
+			finish(new Error(`External editor exited with code ${code ?? "unknown"}`));
+		});
+		signal?.addEventListener("abort", abort, { once: true });
+		if (signal?.aborted) abort();
+	});
+}
+
+export function assertEditorTargetSafeForPlatform(
+	target: string,
+	platform: NodeJS.Platform = process.platform,
+): void {
+	if (platform === "win32" && /[\r\n"&|<>^()%!]/u.test(target)) {
+		throw new Error("File path contains characters unsafe for the Windows external-editor shell");
+	}
+}
+
+function defaultSpawnExternalEditorProcess(command: string, args: readonly string[]): ChildProcess {
+	return spawn(command, [...args], {
+		stdio: "inherit",
+		shell: process.platform === "win32",
+	});
+}
+
+function isInside(root: string, candidate: string): boolean {
+	const result = relative(root, candidate);
+	return (
+		result === "" || (!result.startsWith(`..${sep}`) && result !== ".." && !isAbsolute(result))
+	);
+}
+
+function abortError(): DOMException {
+	return new DOMException("External editor cancelled", "AbortError");
+}

--- a/packages/pi-file-context/src/file-browser-ui.ts
+++ b/packages/pi-file-context/src/file-browser-ui.ts
@@ -97,7 +97,7 @@ function navigationHint(keybindings: KeybindingsManager): string {
 	return uniqueKeys([...up, ...down]).join("/");
 }
 
-function bindingHint(
+export function bindingHint(
 	keybindings: KeybindingsManager,
 	binding: Parameters<KeybindingsManager["getKeys"]>[0],
 	fallback: readonly string[],

--- a/packages/pi-file-context/src/file-context-explorer.ts
+++ b/packages/pi-file-context/src/file-context-explorer.ts
@@ -56,6 +56,7 @@ interface FileQuoteExplorerOptions {
 	files: readonly string[];
 	cwd?: string;
 	loadFile: (path: string, signal?: AbortSignal) => Promise<LoadedProjectTextFile>;
+	editFile?: (path: string, signal?: AbortSignal) => Promise<void>;
 	gitContext?: GitContext;
 	rootNavigation?: boolean;
 	getSelectedContextState?: () => SelectedContextState;
@@ -64,6 +65,10 @@ interface FileQuoteExplorerOptions {
 	done: (result: FileQuoteExplorerResult | undefined) => void;
 }
 
+/**
+ * Keeps the explorer's coupled mode transitions and request generations in one controller so every
+ * cancellation path invalidates the same state instead of coordinating lifecycle across components.
+ */
 export class FileQuoteExplorer implements Component, Focusable {
 	private readonly search = new Input();
 	private readonly contentSearch: ContentSearchSession;
@@ -101,6 +106,8 @@ export class FileQuoteExplorer implements Component, Focusable {
 	private detailController: AbortController | undefined;
 	private openRequest = 0;
 	private openController: AbortController | undefined;
+	private editRequest = 0;
+	private editController: AbortController | undefined;
 	private loading = false;
 	private error: string | undefined;
 	private finished = false;
@@ -181,6 +188,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.contentSearch.dispose();
 		this.cancelOpenRequest();
 		this.cancelDetailRequest();
+		this.cancelEditRequest();
 		if (!this.finished) {
 			this.finished = true;
 			this.options.done(undefined);
@@ -229,6 +237,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 		if (!this.loadedFile) return [this.options.theme.fg("warning", "Loading preview…")];
 		return renderFilePreview({
 			theme: this.options.theme,
+			keybindings: this.options.keybindings,
 			width,
 			availableRows,
 			file: this.loadedFile,
@@ -243,12 +252,19 @@ export class FileQuoteExplorer implements Component, Focusable {
 			error: this.error,
 			selectedContext: this.options.getSelectedContextState?.(),
 			canContinue: this.options.onAddAndContinue !== undefined,
+			canEdit: this.options.editFile !== undefined && this.loadedRevision === undefined,
 		});
 	}
 
 	private renderPreviewHelp(width: number): string[] {
 		const availableRows = Math.max(1, this.options.tui.terminal.rows - RESERVED_APP_ROWS);
-		return renderFilePreviewHelp(this.options.theme, width, availableRows);
+		return renderFilePreviewHelp(
+			this.options.theme,
+			this.options.keybindings,
+			width,
+			availableRows,
+			this.options.editFile !== undefined && this.loadedRevision === undefined,
+		);
 	}
 
 	private renderRevisionInput(width: number): string[] {
@@ -435,6 +451,16 @@ export class FileQuoteExplorer implements Component, Focusable {
 		const loadedFile = this.loadedFile;
 		if (!loadedFile) return;
 		const lines = loadedFile.lines;
+		if (this.options.keybindings.matches(data, "app.editor.external")) {
+			if (this.loadedRevision) {
+				this.error = "Historical revisions are read-only; return to the worktree preview to edit";
+			} else if (this.options.editFile && !this.loading) {
+				void this.editCurrentFile();
+			} else if (!this.options.editFile) {
+				this.error = "External editing is unavailable";
+			}
+			return;
+		}
 		if (matchesKey(data, Key.escape)) {
 			this.returnToOrigin();
 			return;
@@ -628,6 +654,57 @@ export class FileQuoteExplorer implements Component, Focusable {
 			} catch (error: unknown) {
 				this.error = formatError(error);
 			}
+		}
+	}
+
+	private async editCurrentFile(): Promise<void> {
+		const path = this.loadedFile?.path;
+		const editFile = this.options.editFile;
+		if (!path || !editFile || this.loadedRevision) return;
+		this.cancelOpenRequest();
+		this.cancelDetailRequest();
+		this.cancelEditRequest();
+		const request = this.editRequest;
+		const controller = new AbortController();
+		this.editController = controller;
+		this.loading = true;
+		this.error = undefined;
+		this.options.tui.requestRender();
+		try {
+			await editFile(path, controller.signal);
+			if (!this.isCurrentEditRequest(request, controller, path)) return;
+			const gitContext = this.options.gitContext;
+			const [loadedFile, loadedGit] = await Promise.all([
+				this.options.loadFile(path, controller.signal),
+				gitContext
+					? (gitContext.refreshFileContext?.(path, controller.signal) ??
+						gitContext.getFileContext(path, controller.signal))
+					: undefined,
+			]);
+			if (!this.isCurrentEditRequest(request, controller, path)) return;
+			const maximumIndex = Math.max(0, loadedFile.lines.length - 1);
+			this.loadedFile = loadedFile;
+			this.loadedGit = loadedGit;
+			this.previewCursor = Math.min(this.previewCursor, maximumIndex);
+			if (this.previewAnchor !== undefined) {
+				this.previewAnchor = Math.min(this.previewAnchor, maximumIndex);
+			}
+			this.previewScrollOffset = Math.min(this.previewScrollOffset, maximumIndex);
+			this.activeContentMatch = undefined;
+			this.hunkIndex = -1;
+			this.blame = undefined;
+			this.history = [];
+			this.error = undefined;
+		} catch (error: unknown) {
+			if (this.isCurrentEditRequest(request, controller, path) && !isAbortError(error)) {
+				this.error = formatError(error);
+			}
+		} finally {
+			if (request === this.editRequest && this.editController === controller) {
+				this.loading = false;
+				this.editController = undefined;
+			}
+			if (!this.finished && !this.disposed) this.options.tui.requestRender(true);
 		}
 	}
 
@@ -877,6 +954,23 @@ export class FileQuoteExplorer implements Component, Focusable {
 		);
 	}
 
+	private isCurrentEditRequest(
+		request: number,
+		controller: AbortController,
+		path: string,
+	): boolean {
+		return (
+			!this.finished &&
+			!this.disposed &&
+			this.mode === "preview" &&
+			this.loadedRevision === undefined &&
+			this.loadedFile?.path === path &&
+			request === this.editRequest &&
+			this.editController === controller &&
+			!controller.signal.aborted
+		);
+	}
+
 	private beginDetailRequest(): { request: number; signal: AbortSignal } {
 		this.cancelDetailRequest();
 		const request = this.detailRequest;
@@ -898,6 +992,13 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.detailRequest += 1;
 		this.detailController?.abort();
 		this.detailController = undefined;
+		this.loading = false;
+	}
+
+	private cancelEditRequest(): void {
+		this.editRequest += 1;
+		this.editController?.abort();
+		this.editController = undefined;
 		this.loading = false;
 	}
 
@@ -937,6 +1038,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 	private returnToOrigin(): void {
 		this.cancelDetailRequest();
 		this.cancelOpenRequest();
+		this.cancelEditRequest();
 		this.mode = this.previewReturnMode;
 		this.loadedFile = undefined;
 		this.loadedGit = undefined;
@@ -953,6 +1055,7 @@ export class FileQuoteExplorer implements Component, Focusable {
 		this.contentSearch.dispose();
 		this.cancelOpenRequest();
 		this.cancelDetailRequest();
+		this.cancelEditRequest();
 		this.options.done(result);
 	}
 

--- a/packages/pi-file-context/src/file-context-preview-ui.ts
+++ b/packages/pi-file-context/src/file-context-preview-ui.ts
@@ -1,7 +1,8 @@
-import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import type { ContentSearchMatch } from "./content-search.js";
 import { highlightContentRanges } from "./content-search-ui.js";
+import { bindingHint } from "./file-browser-ui.js";
 import type { LoadedProjectTextFile } from "./file-context.js";
 import type {
 	GitBlameInfo,
@@ -21,6 +22,7 @@ export interface SelectedContextState {
 
 interface FilePreviewRenderOptions {
 	theme: Theme;
+	keybindings: KeybindingsManager;
 	width: number;
 	availableRows: number;
 	file: LoadedProjectTextFile;
@@ -35,6 +37,7 @@ interface FilePreviewRenderOptions {
 	error?: string;
 	selectedContext?: SelectedContextState;
 	canContinue: boolean;
+	canEdit: boolean;
 }
 
 export function renderFilePreview(options: FilePreviewRenderOptions): string[] {
@@ -43,8 +46,9 @@ export function renderFilePreview(options: FilePreviewRenderOptions): string[] {
 	const selectedText = file.lines.slice(range.start, range.end + 1).join("\n");
 	const selectedBytes = Buffer.byteLength(selectedText, "utf8");
 	const estimatedTokens = Math.max(1, Math.ceil(selectedBytes / 4));
-	const footerLines = options.error
-		? [escapeTerminalControls(options.error)]
+	const externalEditorKey = bindingHint(options.keybindings, "app.editor.external", []);
+	const footer = options.error
+		? { lines: [escapeTerminalControls(options.error)], primaryIndexes: [0] }
 		: previewFooterLines(
 				width,
 				range.start + 1,
@@ -53,10 +57,11 @@ export function renderFilePreview(options: FilePreviewRenderOptions): string[] {
 				selectedBytes,
 				options.selectedContext,
 				options.canContinue,
+				options.canEdit ? externalEditorKey : "",
 			);
 	const previewHeight = Math.max(
 		1,
-		options.availableRows - 1 - (options.blame ? 1 : 0) - footerLines.length,
+		options.availableRows - 1 - (options.blame ? 1 : 0) - footer.lines.length,
 	);
 	const scrollOffset = visiblePreviewOffset(options.scrollOffset, options.cursor, previewHeight);
 	const digits = String(Math.max(1, file.lines.length)).length;
@@ -113,7 +118,7 @@ export function renderFilePreview(options: FilePreviewRenderOptions): string[] {
 	const blameLine = blameLabel
 		? truncateToWidth(theme.fg("muted", blameLabel), width, "")
 		: undefined;
-	const renderedFooter = footerLines.map((line) =>
+	const renderedFooter = footer.lines.map((line) =>
 		truncateToWidth(theme.fg(options.error ? "error" : "muted", line), width, ""),
 	);
 	return fitPreviewRows(
@@ -121,16 +126,29 @@ export function renderFilePreview(options: FilePreviewRenderOptions): string[] {
 		blameLine,
 		previewLines,
 		renderedFooter,
-		options.error ? 0 : Math.min(1, renderedFooter.length - 1),
+		footer.primaryIndexes,
 		options.availableRows,
 	);
 }
 
 export function renderFilePreviewHelp(
 	theme: Theme,
+	keybindings: KeybindingsManager,
 	width: number,
 	availableRows: number,
+	canEdit: boolean,
 ): string[] {
+	const externalEditorKey = bindingHint(keybindings, "app.editor.external", []);
+	const editDetailed = canEdit
+		? externalEditorKey
+			? `${externalEditorKey.padEnd(6, " ")} Edit the current worktree file in the external editor`
+			: "Edit   External editor action is unbound"
+		: "Edit   Historical revisions are read-only";
+	const editCompact = canEdit
+		? externalEditorKey
+			? `${externalEditorKey} edit worktree`
+			: "External editor unbound"
+		: "Historical revision · read-only";
 	const detailed = [
 		theme.fg("accent", theme.bold("Preview actions")),
 		"Enter  Add selected lines and close File Context",
@@ -141,6 +159,7 @@ export function renderFilePreviewHelp(
 		"H      History: browse earlier versions of this file",
 		"R      Revision: open a commit, branch, or tag",
 		"D      Git diff: review and add one explicit changed hunk",
+		editDetailed,
 		"Esc    Return to the preview without changing selected context",
 	];
 	const compact = [
@@ -148,6 +167,7 @@ export function renderFilePreviewHelp(
 		"Enter add · A keep browsing · Space range",
 		"↑↓ extend · [/] hunk · B blame",
 		"H history · R revision · D Git diff",
+		editCompact,
 		"Esc back without changing context",
 	];
 	const lines = availableRows < detailed.length ? compact : detailed;
@@ -165,7 +185,8 @@ function previewFooterLines(
 	selectedBytes: number,
 	state: SelectedContextState | undefined,
 	canContinue: boolean,
-): string[] {
+	externalEditorKey: string,
+): { lines: string[]; primaryIndexes: number[] } {
 	const nextCount = state ? state.count + 1 : undefined;
 	const nextBytes = state ? state.totalBytes + selectedBytes : undefined;
 	const selectedLines = endLine - startLine + 1;
@@ -185,11 +206,17 @@ function previewFooterLines(
 	if (width < 74) {
 		const selection = `L${startLine}-${endLine} · ~${tokens} tok`;
 		const capacity = state ? (warning ?? `Next ${nextCount}/${state.maximumCount}`) : undefined;
-		return [
+		const lines = [
 			[selection, capacity].filter(Boolean).join(" · "),
 			canContinue ? "Enter add · A keep browsing" : "Enter add & close",
-			"Space range · ? actions · Esc back",
+			"↑↓ move · Space range · Esc back",
+			[externalEditorKey ? `${externalEditorKey} edit` : "", "? actions"]
+				.filter(Boolean)
+				.join(" · "),
+			"B blame · H history · R revision",
+			"D diff · [/] hunk",
 		];
+		return { lines, primaryIndexes: [1, 3] };
 	}
 	const selection = `Lines ${startLine}-${endLine} · ~${tokens} tokens`;
 	const capacity = state
@@ -199,10 +226,21 @@ function previewFooterLines(
 				? "Next prompt limit exceeded; shorten the range or review selected context"
 				: `Next prompt: ${nextCount}/${state.maximumCount} snippets · ~${estimateTokens(nextBytes ?? 0)} tokens`
 		: undefined;
-	const actions = canContinue
-		? "Enter add & close · A add & continue · Space range · ? actions · Esc back"
-		: "Enter add & close · Space range · ? actions · Esc back";
-	return [[selection, capacity].filter(Boolean).join(" · "), actions];
+	const primaryActions = canContinue
+		? "Enter add & close · A add & continue · ↑↓ move · Space range · Esc back"
+		: "Enter add & close · ↑↓ move · Space range · Esc back";
+	const editActions = [externalEditorKey ? `${externalEditorKey} edit` : "", "? actions"]
+		.filter(Boolean)
+		.join(" · ");
+	return {
+		lines: [
+			[selection, capacity].filter(Boolean).join(" · "),
+			primaryActions,
+			editActions,
+			"B blame · H history · R revision · D diff · [/] hunk",
+		],
+		primaryIndexes: [1, 2],
+	};
 }
 
 function selectionRange(anchor: number | undefined, cursor: number) {
@@ -228,7 +266,7 @@ function fitPreviewRows(
 	blame: string | undefined,
 	previewLines: readonly string[],
 	footerLines: readonly string[],
-	primaryFooterIndex: number,
+	primaryFooterIndexes: readonly number[],
 	height: number,
 ): string[] {
 	let visibleTitle: string | undefined = title;
@@ -236,7 +274,7 @@ function fitPreviewRows(
 	const visiblePreview = [...previewLines];
 	const visibleFooter = footerLines.map((line, index) => ({
 		line,
-		primary: index === primaryFooterIndex,
+		primary: primaryFooterIndexes.includes(index),
 	}));
 	const rowCount = () =>
 		(visibleTitle ? 1 : 0) + (visibleBlame ? 1 : 0) + visiblePreview.length + visibleFooter.length;

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -7,6 +7,7 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import { editProjectFileInExternalEditor } from "./external-editor.js";
 import { FileQuoteExplorer, type FileQuoteExplorerResult } from "./file-context-explorer.js";
 import { type FileContextMenuQuote, showFileContextMenu } from "./file-context-menu.js";
 import {
@@ -447,6 +448,15 @@ export async function registerFileQuoteExtension(
 						loadFile: (path, signal) =>
 							loadProjectTextFile(ctx.cwd, path, {
 								signal: signal ? AbortSignal.any([signal, interactionSignal]) : interactionSignal,
+							}),
+						editFile: (path, signal) =>
+							editProjectFileInExternalEditor({
+								root: ctx.cwd,
+								projectPath: path,
+								tui,
+								projectTrusted: ctx.isProjectTrusted(),
+								signal: signal ? AbortSignal.any([signal, interactionSignal]) : interactionSignal,
+								isCurrent: () => isCurrentSession(owner, generation) && !interactionSignal.aborted,
 							}),
 						gitContext,
 						rootNavigation: options.menuOwned,

--- a/packages/pi-file-context/src/git-context.ts
+++ b/packages/pi-file-context/src/git-context.ts
@@ -67,11 +67,19 @@ export interface GitRevisionFile {
 }
 
 export class GitContext {
+	private readonly statusMap: Map<string, GitFileStatus>;
+
 	constructor(
 		readonly projectRoot: string,
 		readonly project: GitProjectInfo,
-		readonly statuses: ReadonlyMap<string, GitFileStatus>,
-	) {}
+		statuses: ReadonlyMap<string, GitFileStatus>,
+	) {
+		this.statusMap = new Map(statuses);
+	}
+
+	get statuses(): ReadonlyMap<string, GitFileStatus> {
+		return this.statusMap;
+	}
 
 	async getFileContext(projectPath: string, signal?: AbortSignal): Promise<GitFileContext> {
 		this.assertProjectPath(projectPath);
@@ -85,10 +93,38 @@ export class GitContext {
 		]);
 		signal?.throwIfAborted();
 		return {
-			status: this.statuses.get(projectPath),
+			status: this.statusMap.get(projectPath),
 			blob: blobResult.ok ? blobResult.stdout.trim() || undefined : undefined,
 			hunks: diffResult.ok ? parseUnifiedDiff(diffResult.stdout) : [],
 		};
+	}
+
+	async refreshFileContext(projectPath: string, signal?: AbortSignal): Promise<GitFileContext> {
+		const [fileContext, statusResult] = await Promise.all([
+			this.getFileContext(projectPath, signal),
+			this.run(
+				[
+					"-c",
+					"status.relativePaths=true",
+					"status",
+					"--porcelain=v1",
+					"-z",
+					"--untracked-files=all",
+					"--ignored=traditional",
+					"--",
+					".",
+				],
+				true,
+				signal,
+			),
+		]);
+		signal?.throwIfAborted();
+		if (!statusResult.ok) return fileContext;
+		const statuses = parseStatuses(statusResult.stdout, this.project.projectPrefix);
+		this.statusMap.clear();
+		for (const [path, status] of statuses) this.statusMap.set(path, status);
+		this.project.dirty = [...statuses.values()].some((status) => !status.ignored);
+		return { ...fileContext, status: this.statusMap.get(projectPath) };
 	}
 
 	async getBlame(

--- a/packages/pi-file-context/test/external-editor.test.ts
+++ b/packages/pi-file-context/test/external-editor.test.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import {
+	assertEditorTargetSafeForPlatform,
+	type ExternalEditorProcess,
+	editProjectFileInExternalEditor,
+	resolveEditableProjectFile,
+} from "../src/external-editor.js";
+
+async function withTempProject(run: (root: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-file-context-editor-test-"));
+	try {
+		await run(root);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+function createTui(events: string[]) {
+	return {
+		stop() {
+			events.push("stop");
+		},
+		start() {
+			events.push("start");
+		},
+		requestRender(force?: boolean) {
+			events.push(`render:${String(force)}`);
+		},
+	} as never;
+}
+
+function createProcess(
+	onListen: (listeners: {
+		close: (code: number | null) => void;
+		error: (error: Error) => void;
+		process: ExternalEditorProcess;
+	}) => void,
+): ExternalEditorProcess {
+	const listeners: {
+		close?: (code: number | null) => void;
+		error?: (error: Error) => void;
+	} = {};
+	const child: ExternalEditorProcess = {
+		killed: false,
+		kill() {
+			Object.defineProperty(child, "killed", { value: true, configurable: true });
+			return true;
+		},
+		once(event, listener) {
+			listeners[event] = listener as never;
+			if (listeners.close && listeners.error) {
+				onListen({ close: listeners.close, error: listeners.error, process: child });
+			}
+			return child;
+		},
+	};
+	return child;
+}
+
+test("resolves only regular project files and rejects outside paths and symlinks", async () => {
+	await withTempProject(async (root) => {
+		await mkdir(join(root, "src"));
+		await writeFile(join(root, "src", "safe.ts"), "safe\n");
+		await symlink(join(root, "src", "safe.ts"), join(root, "linked.ts"));
+		assert.equal(
+			await resolveEditableProjectFile(root, "src/safe.ts"),
+			join(root, "src", "safe.ts"),
+		);
+		await assert.rejects(resolveEditableProjectFile(root, "../outside.ts"), /outside the project/u);
+		await assert.rejects(resolveEditableProjectFile(root, "linked.ts"), /symbolic link/u);
+		await assert.rejects(resolveEditableProjectFile(root, "src"), /not a regular file/u);
+	});
+});
+
+test("rejects Windows shell metacharacters in editor target paths", () => {
+	assert.doesNotThrow(() =>
+		assertEditorTargetSafeForPlatform("C:\\project files\\safe.ts", "win32"),
+	);
+	assert.throws(
+		() => assertEditorTargetSafeForPlatform("C:\\project\\unsafe&calc.ts", "win32"),
+		/unsafe for the Windows external-editor shell/u,
+	);
+	assert.doesNotThrow(() =>
+		assertEditorTargetSafeForPlatform("/project/valid&literal.ts", "linux"),
+	);
+});
+
+test("uses Pi settings, serializes the mutation, and restores the current TUI", async () => {
+	await withTempProject(async (root) => {
+		const target = join(root, "file.ts");
+		const agentDir = join(root, "agent");
+		await mkdir(agentDir);
+		await writeFile(target, "before\n");
+		await writeFile(join(agentDir, "settings.json"), '{"externalEditor":"code --wait"}\n');
+		const events: string[] = [];
+		let releaseQueue: (() => void) | undefined;
+		let queueReady: (() => void) | undefined;
+		const ready = new Promise<void>((resolve) => {
+			queueReady = resolve;
+		});
+		const blocker = withFileMutationQueue(
+			target,
+			() =>
+				new Promise<void>((resolve) => {
+					releaseQueue = resolve;
+					queueReady?.();
+				}),
+		);
+		await ready;
+		const editing = editProjectFileInExternalEditor({
+			root,
+			projectPath: "file.ts",
+			tui: createTui(events),
+			projectTrusted: false,
+			agentDir,
+			isCurrent: () => true,
+			spawnProcess(command, args) {
+				events.push(`spawn:${command}:${args.join("|")}`);
+				return createProcess(({ close }) => queueMicrotask(() => close(0)));
+			},
+		});
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		assert.deepEqual(events, []);
+		releaseQueue?.();
+		await Promise.all([blocker, editing]);
+		assert.deepEqual(events, ["stop", `spawn:code:--wait|${target}`, "start", "render:true"]);
+	});
+});
+
+test("restores the TUI after editor failure and reports the exit code", async () => {
+	await withTempProject(async (root) => {
+		await writeFile(join(root, "file.ts"), "before\n");
+		const events: string[] = [];
+		await assert.rejects(
+			editProjectFileInExternalEditor({
+				root,
+				projectPath: "file.ts",
+				tui: createTui(events),
+				projectTrusted: false,
+				command: "false",
+				spawnProcess() {
+					return createProcess(({ close }) => queueMicrotask(() => close(7)));
+				},
+			}),
+			/exited with code 7/u,
+		);
+		assert.deepEqual(events, ["stop", "start", "render:true"]);
+	});
+});
+
+test("cancellation terminates the editor and does not restart a stale TUI", async () => {
+	await withTempProject(async (root) => {
+		await writeFile(join(root, "file.ts"), "before\n");
+		const events: string[] = [];
+		const controller = new AbortController();
+		let started: (() => void) | undefined;
+		const ready = new Promise<void>((resolve) => {
+			started = resolve;
+		});
+		let child: ExternalEditorProcess | undefined;
+		const editing = editProjectFileInExternalEditor({
+			root,
+			projectPath: "file.ts",
+			tui: createTui(events),
+			projectTrusted: false,
+			command: "editor",
+			signal: controller.signal,
+			isCurrent: () => false,
+			spawnProcess() {
+				child = createProcess(({ close, process }) => {
+					const originalKill = process.kill.bind(process);
+					process.kill = () => {
+						const killed = originalKill();
+						queueMicrotask(() => close(null));
+						return killed;
+					};
+					started?.();
+				});
+				return child;
+			},
+		});
+		await ready;
+		controller.abort();
+		await assert.rejects(editing, (error: unknown) => {
+			return error instanceof Error && error.name === "AbortError";
+		});
+		assert.equal(child?.killed, true);
+		assert.deepEqual(events, ["stop"]);
+	});
+});

--- a/packages/pi-file-context/test/file-context-selection.test.ts
+++ b/packages/pi-file-context/test/file-context-selection.test.ts
@@ -223,6 +223,327 @@ test("explorer adds exact context and keeps browsing with visible capacity and a
 	});
 });
 
+test("preview uses the effective external-editor binding and reloads edited content", async () => {
+	let lines = ["one", "two", "three"];
+	let editCount = 0;
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 16 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return (
+					(data === "enter" && key === "tui.select.confirm") ||
+					(data === "down" && key === "tui.select.down") ||
+					(data === "alt-e" && key === "app.editor.external")
+				);
+			},
+			getKeys(key: string) {
+				return key === "app.editor.external" ? ["alt+e"] : [];
+			},
+		} as never,
+		files: ["src/edit.ts"],
+		loadFile: async () => ({ path: "src/edit.ts", lines }),
+		editFile: async (path) => {
+			assert.equal(path, "src/edit.ts");
+			editCount += 1;
+			lines = ["edited"];
+		},
+		done() {},
+	});
+
+	explorer.handleInput("enter");
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput("down");
+	explorer.handleInput(" ");
+	explorer.handleInput("down");
+	const preview = explorer.render(80).join("\n");
+	assert.match(preview, /Alt\+E edit/u);
+	assert.match(preview, /B blame · H history · R revision · D diff · \[\/\] hunk/u);
+	assert.doesNotMatch(preview, /Ctrl\+G/u);
+	const narrow = explorer.render(36);
+	assert.ok(narrow.every((line) => visibleWidth(line) <= 36));
+	assert.match(narrow.join("\n"), /Alt\+E edit/u);
+	explorer.handleInput("ctrl-g");
+	assert.equal(editCount, 0);
+	explorer.handleInput("alt-e");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(editCount, 1);
+	assert.match(explorer.render(80).join("\n"), /> 1 │ edited/u);
+});
+
+test("preview invokes the default external-editor action and explains an unbound action", async () => {
+	let edits = 0;
+	const keybindings = {
+		matches(data: string, key: string) {
+			return (
+				(data === "enter" && key === "tui.select.confirm") ||
+				(data === "ctrl-g" && key === "app.editor.external")
+			);
+		},
+		getKeys(key: string) {
+			return key === "app.editor.external" ? ["ctrl+g"] : [];
+		},
+	};
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 16 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: keybindings as never,
+		files: ["edit.ts"],
+		loadFile: async () => ({ path: "edit.ts", lines: ["one"] }),
+		editFile: async () => {
+			edits += 1;
+		},
+		done() {},
+	});
+
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.match(explorer.render(80).join("\n"), /Ctrl\+G edit/u);
+	explorer.handleInput("ctrl-g");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(edits, 1);
+
+	const unbound = new FileQuoteExplorer({
+		tui: { terminal: { rows: 16 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return data === "enter" && key === "tui.select.confirm";
+			},
+			getKeys() {
+				return [];
+			},
+		} as never,
+		files: ["edit.ts"],
+		loadFile: async () => ({ path: "edit.ts", lines: ["one"] }),
+		editFile: async () => {},
+		done() {},
+	});
+	unbound.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	unbound.handleInput("?");
+	assert.match(unbound.render(80).join("\n"), /External editor action is unbound/u);
+});
+
+test("configured external-editor action takes priority over preview-owned shortcuts", async () => {
+	let edits = 0;
+	let historyLoads = 0;
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 16 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return (
+					(data === "enter" && key === "tui.select.confirm") ||
+					(data === "h" && key === "app.editor.external")
+				);
+			},
+			getKeys(key: string) {
+				return key === "app.editor.external" ? ["h"] : [];
+			},
+		} as never,
+		files: ["src/edit.ts"],
+		loadFile: async () => ({ path: "src/edit.ts", lines: ["one"] }),
+		editFile: async () => {
+			edits += 1;
+		},
+		gitContext: {
+			async getFileContext() {
+				return { status: undefined, blob: undefined, hunks: [] };
+			},
+			async getHistory() {
+				historyLoads += 1;
+				return [];
+			},
+		} as never,
+		done() {},
+	});
+
+	explorer.handleInput("enter");
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput("h");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(edits, 1);
+	assert.equal(historyLoads, 0);
+});
+
+for (const reloadError of [
+	"Cannot open src/edit.ts: file was deleted",
+	"src/edit.ts appears to be binary",
+	"src/edit.ts exceeds 1000000 bytes",
+]) {
+	test(`preview keeps reload failure visible after external editing: ${reloadError}`, async () => {
+		let loads = 0;
+		const explorer = new FileQuoteExplorer({
+			tui: { terminal: { rows: 16 }, requestRender() {} } as never,
+			theme: {
+				fg: (_color: string, text: string) => text,
+				bg: (_color: string, text: string) => text,
+				bold: (text: string) => text,
+			} as never,
+			keybindings: {
+				matches(data: string, key: string) {
+					return (
+						(data === "enter" && key === "tui.select.confirm") ||
+						(data === "edit" && key === "app.editor.external")
+					);
+				},
+				getKeys(key: string) {
+					return key === "app.editor.external" ? ["ctrl+g"] : [];
+				},
+			} as never,
+			files: ["src/edit.ts"],
+			loadFile: async () => {
+				loads += 1;
+				if (loads > 1) throw new Error(reloadError);
+				return { path: "src/edit.ts", lines: ["original"] };
+			},
+			editFile: async () => {},
+			done() {},
+		});
+
+		explorer.handleInput("enter");
+		explorer.handleInput("enter");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		explorer.handleInput("edit");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		assert.match(explorer.render(100).join("\n"), new RegExp(reloadError, "u"));
+	});
+}
+
+test("disposing a preview aborts external editing and rejects its stale continuation", async () => {
+	let resolveEdit: (() => void) | undefined;
+	let editSignal: AbortSignal | undefined;
+	let loads = 0;
+	let result: unknown = "pending";
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 16 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return (
+					(data === "enter" && key === "tui.select.confirm") ||
+					(data === "edit" && key === "app.editor.external")
+				);
+			},
+			getKeys() {
+				return ["ctrl+g"];
+			},
+		} as never,
+		files: ["src/edit.ts"],
+		loadFile: async () => {
+			loads += 1;
+			return { path: "src/edit.ts", lines: ["original"] };
+		},
+		editFile: (_path, signal) => {
+			editSignal = signal;
+			return new Promise<void>((resolve) => {
+				resolveEdit = resolve;
+			});
+		},
+		done(value) {
+			result = value;
+		},
+	});
+
+	explorer.handleInput("enter");
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput("edit");
+	explorer.dispose();
+	assert.equal(editSignal?.aborted, true);
+	resolveEdit?.();
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(loads, 1);
+	assert.equal(result, undefined);
+});
+
+test("historical revision previews remain read-only", async () => {
+	let edits = 0;
+	const explorer = new FileQuoteExplorer({
+		tui: { terminal: { rows: 16 }, requestRender() {} } as never,
+		theme: {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as never,
+		keybindings: {
+			matches(data: string, key: string) {
+				return (
+					(data === "enter" && key === "tui.select.confirm") ||
+					(data === "edit" && key === "app.editor.external")
+				);
+			},
+			getKeys(key: string) {
+				return key === "app.editor.external" ? ["ctrl+g"] : [];
+			},
+		} as never,
+		files: ["src/edit.ts"],
+		loadFile: async () => ({ path: "src/edit.ts", lines: ["worktree"] }),
+		editFile: async () => {
+			edits += 1;
+		},
+		gitContext: {
+			project: {
+				repositoryRoot: "/repo",
+				projectPrefix: "",
+				branch: "main",
+				head: "a".repeat(40),
+				dirty: false,
+			},
+			statuses: new Map(),
+			async getFileContext() {
+				return { status: undefined, blob: undefined, hunks: [] };
+			},
+			async loadRevision() {
+				return {
+					path: "src/edit.ts",
+					lines: ["historical"],
+					revision: "HEAD~1",
+					commit: "b".repeat(40),
+					blob: "c".repeat(40),
+				};
+			},
+		} as never,
+		done() {},
+	});
+
+	explorer.handleInput("enter");
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput("r");
+	explorer.handleInput("enter");
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	explorer.handleInput("?");
+	assert.match(explorer.render(100).join("\n"), /Historical revisions are read-only/u);
+	explorer.handleInput("\u001b");
+	explorer.handleInput("edit");
+	assert.equal(edits, 0);
+	assert.match(explorer.render(100).join("\n"), /Historical revisions are read-only/u);
+});
+
 test("short narrow previews keep primary add controls visible", async () => {
 	const explorer = new FileQuoteExplorer({
 		tui: { terminal: { rows: 8 }, requestRender() {} } as never,
@@ -235,9 +556,13 @@ test("short narrow previews keep primary add controls visible", async () => {
 			matches(data: string, key: string) {
 				return data === "enter" && key === "tui.select.confirm";
 			},
+			getKeys(key: string) {
+				return key === "app.editor.external" ? ["ctrl+g"] : [];
+			},
 		} as never,
 		files: ["short.ts"],
 		loadFile: async () => ({ path: "short.ts", lines: ["short"] }),
+		editFile: async () => {},
 		onAddAndContinue() {},
 		done() {},
 	});
@@ -248,6 +573,8 @@ test("short narrow previews keep primary add controls visible", async () => {
 	assert.ok(preview.every((line) => visibleWidth(line) <= 36));
 	assert.match(preview.join("\n"), /Enter add/u);
 	assert.match(preview.join("\n"), /A keep browsing/u);
+	assert.match(preview.join("\n"), /Ctrl\+G edit/u);
+	assert.match(preview.join("\n"), /\? actions/u);
 });
 
 test("compact preview help keeps every advanced action visible on short terminals", async () => {

--- a/packages/pi-file-context/test/git-context.test.ts
+++ b/packages/pi-file-context/test/git-context.test.ts
@@ -63,6 +63,20 @@ test("captures deterministic repository identity and staged, unstaged, and untra
 	});
 });
 
+test("refreshes file and repository status when a preview is reloaded", async () => {
+	await withGitProject(async (root) => {
+		const context = await createGitContext(root);
+		assert.ok(context);
+		assert.equal(context.project.dirty, false);
+		assert.equal(context.statuses.get("tracked.ts"), undefined);
+		await writeFile(join(root, "tracked.ts"), "edited\ntwo\nthree\n");
+		const fileContext = await context.refreshFileContext("tracked.ts");
+		assert.equal(fileContext.status?.label, "modified (unstaged)");
+		assert.equal(context.statuses.get("tracked.ts")?.label, "modified (unstaged)");
+		assert.equal(context.project.dirty, true);
+	});
+});
+
 test("reports ignored files without marking an otherwise clean repository dirty", async () => {
 	await withGitProject(async (root) => {
 		await writeFile(join(root, ".gitignore"), "ignored.ts\n");


### PR DESCRIPTION
## Summary

- honor Pi's effective `app.editor.external` binding and `externalEditor` command in File Preview
- suspend and safely restore the TUI around a serialized, cancellable worktree edit, then reload bounded text and Git status
- show adaptive preview shortcuts, keep historical revisions read-only, document safety constraints, and add a patch changeset

## Verification

- `npm --workspace @narumitw/pi-file-context run build --if-present`
- focused package suite: 15 files and 109 tests passed
- `npm run check`
- `npm test`: 398 files and 3,763 tests passed
- README heading audit passed for every publishable active package
- `just pack file-context`: 19 expected files, including `dist/index.ts`, `src/external-editor.ts`, README, and license

The first final `npm test` attempt hit an unrelated `pi-subagents` semantic-resource race in `registered detached spawn auto-resumes without exposing a wait tool`.
That exact test passed on rerun, and the complete `npm test` gate then passed.

## Risks and unverified paths

- The configured external editor runs with the user's permissions and should use a wait option such as `code --wait`.
- Windows target paths containing command-shell metacharacters are rejected instead of entering Pi's shell-compatible launch path.
- A real interactive external-editor smoke was not run because this agent has no safe interactive TTY; deterministic process, cancellation, generated-entry, package, and full repository tests cover the flow.
- The installed Pi keybinding audit found no concurrent conflict: fullscreen transcript-search `Ctrl+G` is scoped to transcript search, while File Preview owns input and uses `app.editor.external` directly.
