### PR TITLE
feat(pi-tui-kit-showcase): add questionnaire demo

### DIFF
--- a/packages/pi-tui-kit-showcase/README.md
+++ b/packages/pi-tui-kit-showcase/README.md
@@ -13,7 +13,7 @@ The showcase uses only in-memory state and stores no settings.
 ## ✨ Features
 
 - Demonstrates action, detail, browse, choice, settings, input, review, and multi-select screens.
-- Demonstrates standalone task, confirmation, and live-choice interactions from the same menu.
+- Demonstrates standalone questionnaire, task, confirmation, and live-choice interactions from the same menu.
 - Covers disabled rows, busy labels, search, exact documents, adaptive review, bulk actions, and row descriptions.
 - Keeps all effects in memory inside the demo process.
 - Loads the Kit runtime only after `/tui-kit-showcase` runs.
@@ -44,7 +44,7 @@ Run this command in Pi TUI mode:
 
 Choose any row to inspect a presentation pattern.
 
-The standalone task, confirmation, and live-choice rows close the menu, show the standalone interaction, then reopen the menu when the interaction finishes.
+The standalone questionnaire, task, confirmation, and live-choice rows close the menu, show the standalone interaction, then reopen the menu when the interaction finishes.
 
 RPC mode reports that the showcase requires TUI mode.
 

--- a/packages/pi-tui-kit-showcase/src/menu.ts
+++ b/packages/pi-tui-kit-showcase/src/menu.ts
@@ -22,9 +22,14 @@ export type ShowcaseAction =
 	| "resetFeatures"
 	| "openTask"
 	| "openConfirmation"
-	| "openLiveChoice";
+	| "openLiveChoice"
+	| "openQuestionnaire";
 
-export type ShowcaseStandaloneInteraction = "task" | "confirmation" | "liveChoice";
+export type ShowcaseStandaloneInteraction =
+	| "task"
+	| "confirmation"
+	| "liveChoice"
+	| "questionnaire";
 
 export interface ShowcaseState {
 	profile: "Minimal" | "Balanced" | "Verbose";
@@ -118,6 +123,12 @@ export function createShowcaseMenu(
 						label: "Multi-select screen",
 						description: "Toggles, search, and bulk actions",
 						to: "multiSelect",
+					},
+					{
+						id: "questionnaire",
+						label: "Questionnaire",
+						description: "Closes this menu, shows runQuestionnaire(), then reopens",
+						action: "openQuestionnaire",
 					},
 					{
 						id: "task",
@@ -408,6 +419,10 @@ export function createShowcaseMenu(
 			},
 			openLiveChoice: () => {
 				runtime.requestStandalone("liveChoice");
+				return { kind: "close" };
+			},
+			openQuestionnaire: () => {
+				runtime.requestStandalone("questionnaire");
 				return { kind: "close" };
 			},
 		},

--- a/packages/pi-tui-kit-showcase/src/runtime.ts
+++ b/packages/pi-tui-kit-showcase/src/runtime.ts
@@ -1,5 +1,11 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { runConfirmation, runLiveChoice, runMenu, runTask } from "@narumitw/pi-tui-kit";
+import {
+	runConfirmation,
+	runLiveChoice,
+	runMenu,
+	runQuestionnaire,
+	runTask,
+} from "@narumitw/pi-tui-kit";
 import {
 	appendLog,
 	createInitialShowcaseState,
@@ -69,6 +75,7 @@ async function runStandaloneInteraction(
 			task: ({ signal }) => delay(250, signal),
 			onError: (_ctx, error) => notify(ctx, safeError(error), "error"),
 		});
+		if (options.signal.aborted || !options.isCurrent()) return;
 		if (result.kind === "completed") {
 			appendLog(state, "Standalone task completed.");
 			notify(ctx, "Showcase task completed.", "info");
@@ -86,11 +93,50 @@ async function runStandaloneInteraction(
 			isCurrent: options.isCurrent,
 			onError: (_ctx, error) => notify(ctx, safeError(error), "error"),
 		});
+		if (options.signal.aborted || !options.isCurrent()) return;
 		if (result.kind === "confirmed") {
 			appendLog(state, "Standalone confirmation accepted.");
 			notify(ctx, "Confirmation recorded.", "info");
 		} else if (result.kind === "closed") {
 			appendLog(state, `Standalone confirmation closed with ${result.reason}.`);
+		}
+		return;
+	}
+
+	if (interaction === "questionnaire") {
+		const result = await runQuestionnaire(ctx, {
+			questions: [
+				{
+					id: "layout",
+					header: "Layout",
+					prompt: "Which layout should this demo prefer?",
+					options: [
+						{ label: "Compact", description: "Keep the presentation concise." },
+						{ label: "Spacious", description: "Leave more room for explanations." },
+					],
+				},
+				{
+					id: "validation",
+					header: "Validation",
+					prompt: "How should the demo validate input?",
+					options: [
+						{ label: "Strict", description: "Reject invalid input immediately." },
+						{ label: "Flexible", description: "Accept broader demonstration input." },
+					],
+				},
+			],
+			allowNotes: true,
+			maxTextLength: 200,
+			signal: options.signal,
+			isCurrent: options.isCurrent,
+			onError: (_ctx, error) => notify(ctx, safeError(error), "error"),
+		});
+		if (options.signal.aborted || !options.isCurrent()) return;
+		if (result.kind === "submitted") {
+			appendLog(state, `Standalone questionnaire submitted ${result.answers.length} answers.`);
+			notify(ctx, "Questionnaire submitted.", "info");
+		} else if (result.kind === "closed") {
+			appendLog(state, `Standalone questionnaire closed with ${result.reason}.`);
 		}
 		return;
 	}
@@ -115,6 +161,7 @@ async function runStandaloneInteraction(
 		},
 		onError: (_ctx, error) => notify(ctx, safeError(error), "error"),
 	});
+	if (options.signal.aborted || !options.isCurrent()) return;
 
 	if (result.kind === "selected" && isShowcaseProfile(result.itemId)) {
 		state.profile = result.itemId;

--- a/packages/pi-tui-kit-showcase/test/showcase.test.ts
+++ b/packages/pi-tui-kit-showcase/test/showcase.test.ts
@@ -1,7 +1,10 @@
 import { resolveMenuScreen } from "@narumitw/pi-tui-kit";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { describe, expect, test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
 import extension from "../src/index.js";
 import { createInitialShowcaseState, createShowcaseMenu } from "../src/menu.js";
+import { showTuiKitShowcase } from "../src/runtime.js";
 import { createPiTuiKitShowcaseExtension } from "../src/showcase.js";
 
 describe("Pi TUI Kit showcase", () => {
@@ -37,8 +40,46 @@ describe("Pi TUI Kit showcase", () => {
 		expect(main.kind).toBe("actions");
 		if (main.kind !== "actions") return;
 		expect(main.items.map((item) => item.label)).toEqual(
-			expect.arrayContaining(["Task loader", "Confirmation", "Live choice"]),
+			expect.arrayContaining(["Questionnaire", "Task loader", "Confirmation", "Live choice"]),
 		);
+	});
+
+	test("runs the questionnaire interaction and reopens the showcase menu", async () => {
+		const tui = createTuiHarness({ width: 100, rows: 30 });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const owner = new AbortController();
+		const running = showTuiKitShowcase(context.ctx, {
+			signal: owner.signal,
+			isCurrent: () => !owner.signal.aborted,
+		});
+
+		await tui.waitForOpen();
+		const main = resolveMenuScreen(
+			createShowcaseMenu({ requestStandalone: () => {} }),
+			"main",
+			createInitialShowcaseState(),
+		);
+		const questionnaireIndex =
+			main.kind === "actions" ? main.items.findIndex((item) => item.id === "questionnaire") : -1;
+		expect(questionnaireIndex).toBeGreaterThanOrEqual(0);
+		for (let index = 0; index < questionnaireIndex; index += 1) {
+			tui.press("tui.select.down");
+		}
+		tui.press("tui.select.confirm");
+		await tui.waitForOpen();
+		expect(tui.render().join("\n")).toMatch(/\[Layout\] {2}Validation {2}Review/u);
+		tui.press("tui.select.confirm");
+		tui.press("tui.select.confirm");
+		expect(tui.render().join("\n")).toMatch(/1\. Layout — Compact[\s\S]*2\. Validation — Strict/u);
+		tui.press("tui.select.confirm");
+
+		await tui.waitForOpen();
+		expect(context.notifications.map(({ message }) => message)).toContain(
+			"Questionnaire submitted.",
+		);
+		owner.abort();
+		await running;
+		expect(tui.isOpen).toBe(false);
 	});
 
 	test("registers one TUI-only showcase command and rejects arguments", async () => {


### PR DESCRIPTION
## Summary

- Add a Questionnaire row to the private Pi TUI Kit showcase.
- Run a two-question interaction with choices, free-form answers, optional notes, and Review before reopening the menu.
- Record submitted or closed outcomes in in-memory showcase state.
- Revalidate the session owner after every standalone interaction await before mutating demo state.
- Document and test the complete menu-to-questionnaire-to-menu flow.

## Verification

- `npm --workspace @narumitw/pi-tui-kit-showcase run typecheck` — passed.
- `npx vitest run packages/pi-tui-kit-showcase/test/showcase.test.ts` — 5 tests passed.
- `npm run check` — passed.
- `npm test` — 398 files and 3,766 tests passed.

## Risks and notes

- The showcase remains private, experimental, and in-memory, so no Changeset is required.
- RPC behavior remains TUI-only and unchanged.
- No live TUI smoke was run because the deterministic harness exercises opening, submitting, reopening, and owner cancellation without an interactive terminal.
