### PR TITLE
test: characterize workflow mutex runtime

### DIFF
--- a/docs/api/workflow-mutex-v1.md
+++ b/docs/api/workflow-mutex-v1.md
@@ -247,6 +247,11 @@ A v1 participant operating beside a pre-v1 extension remains standalone-compatib
 
 ## Required Pi behavior
 
+The deterministic characterization in [`test/workflow-mutex-runtime.test.ts`](../../test/workflow-mutex-runtime.test.ts) covers the repository's exact installed Pi version, `@earendil-works/pi-coding-agent@0.84.2`.
+The root `package.json` and `package-lock.json` pin that version, and the test imports only public package-root APIs.
+V1 coexistence is supported only on this characterized version.
+Earlier releases, later releases, forks, and separately loaded Pi runtimes are uncharacterized and cannot receive the v1 coexistence guarantee until the same evidence passes for them.
+
 V1 depends on these Pi runtime properties:
 
 1. Loaded extensions share one process-local event bus.
@@ -254,9 +259,10 @@ V1 depends on these Pi runtime properties:
 3. All extension contexts for one active session expose the same `sessionManager` object identity.
 4. Stale extension runtimes unsubscribe their tracked event-bus listeners.
 
-The current installed Pi implementation uses Node's synchronous `EventEmitter` dispatch behind an async error-catching wrapper.
+The characterized Pi runtime uses Node's synchronous `EventEmitter` dispatch behind an async error-catching wrapper.
 
-Only mutations performed before a listener returns are visible to the requester before `emit()` returns.
+Only mutations performed before a listener first yields are visible to the requester before `emit()` returns.
+The characterization proves shared delivery across inline extension factories, synchronous listener start and mutation, exact `sessionManager` identity across runner contexts, and tracked-listener cleanup after runtime invalidation.
 
 These properties MUST have deterministic characterization tests before a package claims v1 support.
 

--- a/docs/roadmaps/2026-08-22_pi-plan-goal-coexistence-roadmap.md
+++ b/docs/roadmaps/2026-08-22_pi-plan-goal-coexistence-roadmap.md
@@ -94,7 +94,7 @@ This is an advisory mutex among participating extensions, not a Pi-enforced lock
 - [x] Repository guidance permits documented, versioned, extension-neutral protocols that preserve standalone behavior.
 - [x] [Workflow Mutex Protocol v1](../api/workflow-mutex-v1.md) defines the channel, schema, synchronous critical section, session scoping, mutex groups, ownership states, malformed-input behavior, and version policy.
 - [x] The v1 contract explicitly prohibits participant identity, workflow control, state transfer, start or cancel RPC, plan handoff, and completion forwarding.
-- [ ] Pi's current synchronous listener-start behavior is characterized by a deterministic test, and any unsupported runtime version is stated explicitly.
+- [x] [`test/workflow-mutex-runtime.test.ts`](../../test/workflow-mutex-runtime.test.ts) characterizes Pi `0.84.2` listener start, shared delivery, session identity, and stale-listener cleanup; the protocol explicitly excludes uncharacterized runtimes without claiming product conformance.
 - [x] The v1 version policy states that pre-protocol Plan or Goal releases cannot provide guaranteed coexistence with a protocol-aware peer.
 
 **Outcome:** Any workflow extension can implement the same small mutex without knowing which other extensions are installed.

--- a/test/workflow-mutex-runtime.test.ts
+++ b/test/workflow-mutex-runtime.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import {
+	createEventBus,
+	DefaultResourceLoader,
+	ExtensionRunner,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+
+// Keep the transport shape local to this characterization test.
+// The protocol is repository documentation, not a Pi-owned exported type.
+type WorkflowMutexAttemptV1 = {
+	session: object;
+	group: string;
+	busy: boolean;
+	listenerStarts: string[];
+	synchronousMutation?: boolean;
+	afterAwaitMutation?: boolean;
+};
+
+test("createEventBus starts every listener synchronously and exposes only pre-await mutations", async () => {
+	const eventBus = createEventBus();
+	let releaseAsyncListener!: () => void;
+	let finishAsyncListener!: () => void;
+	const asyncGate = new Promise<void>((resolve) => {
+		releaseAsyncListener = resolve;
+	});
+	const asyncFinished = new Promise<void>((resolve) => {
+		finishAsyncListener = resolve;
+	});
+	const session = {};
+	const attempt: WorkflowMutexAttemptV1 = {
+		session,
+		group: "agent-workflow",
+		busy: false,
+		listenerStarts: [],
+	};
+
+	eventBus.on("workflow:mutex:v1", (data) => {
+		const current = data as WorkflowMutexAttemptV1;
+		current.listenerStarts.push("holder");
+		current.busy = true;
+	});
+	eventBus.on("workflow:mutex:v1", (data) => {
+		const current = data as WorkflowMutexAttemptV1;
+		current.listenerStarts.push("later-participant");
+		if (current.session === session && current.group === "agent-workflow" && !current.busy) {
+			current.busy = true;
+		}
+	});
+	eventBus.on("workflow:mutex:v1", async (data) => {
+		const current = data as WorkflowMutexAttemptV1;
+		current.listenerStarts.push("async-participant");
+		current.synchronousMutation = true;
+		await asyncGate;
+		current.afterAwaitMutation = true;
+		finishAsyncListener();
+	});
+
+	eventBus.emit("workflow:mutex:v1", attempt);
+
+	assert.deepEqual(attempt.listenerStarts, ["holder", "later-participant", "async-participant"]);
+	assert.equal(attempt.busy, true);
+	assert.equal(attempt.synchronousMutation, true);
+	assert.equal(attempt.afterAwaitMutation, undefined);
+
+	releaseAsyncListener();
+	await asyncFinished;
+	assert.equal(attempt.afterAwaitMutation, true);
+});
+
+test("inline extension factories share one explicit bus and stale runtimes unsubscribe", async () => {
+	const eventBus = createEventBus();
+	const observations: string[] = [];
+	const loader = new DefaultResourceLoader({
+		cwd: process.cwd(),
+		agentDir: process.cwd(),
+		settingsManager: SettingsManager.inMemory({}),
+		eventBus,
+		noExtensions: true,
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+		extensionFactories: [
+			{
+				name: "runtime-characterization-sender",
+				factory(pi) {
+					pi.events.on("runtime-characterization", (data) => {
+						observations.push("first");
+						(data as { delivered?: boolean }).delivered = true;
+					});
+				},
+			},
+			{
+				name: "runtime-characterization-receiver",
+				factory(pi) {
+					pi.events.on("runtime-characterization", (data) => {
+						assert.equal((data as { delivered?: boolean }).delivered, true);
+						observations.push("second");
+					});
+				},
+			},
+		],
+	});
+
+	await loader.reload();
+	const loaded = loader.getExtensions();
+	assert.deepEqual(loaded.errors, []);
+	assert.equal(loaded.extensions.length, 2);
+
+	eventBus.emit("runtime-characterization", {});
+	assert.deepEqual(observations, ["first", "second"]);
+
+	loaded.runtime.invalidate("runtime characterization cleanup");
+	eventBus.emit("runtime-characterization", {});
+	assert.deepEqual(observations, ["first", "second"]);
+});
+
+test("ExtensionRunner contexts preserve one sessionManager object identity", async () => {
+	const eventBus = createEventBus();
+	const loader = new DefaultResourceLoader({
+		cwd: process.cwd(),
+		agentDir: process.cwd(),
+		settingsManager: SettingsManager.inMemory({}),
+		eventBus,
+		noExtensions: true,
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+		extensionFactories: [
+			(pi) => {
+				pi.on("session_start", (_event, ctx) => {
+					observedSessionManagers.push(ctx.sessionManager);
+				});
+			},
+		],
+	});
+	const observedSessionManagers: object[] = [];
+	const sessionManager = {};
+
+	await loader.reload();
+	const loaded = loader.getExtensions();
+	const runner = new ExtensionRunner(
+		loaded.extensions,
+		loaded.runtime,
+		process.cwd(),
+		sessionManager as never,
+		{} as never,
+	);
+
+	assert.equal(runner.createContext().sessionManager, sessionManager);
+	assert.equal(runner.createCommandContext().sessionManager, sessionManager);
+	await runner.emit({ type: "session_start", reason: "startup" });
+	assert.deepEqual(observedSessionManagers, [sessionManager]);
+});


### PR DESCRIPTION
## Summary

- characterize synchronous event-bus dispatch and pre-await payload mutation on Pi 0.84.2
- prove inline extension factories share one bus and stale runtimes remove tracked listeners
- prove runner contexts preserve exact session-manager identity
- document the exact supported runtime boundary and complete roadmap Phase 1 evidence

## Verification

- `npm exec -- vitest run test/workflow-mutex-runtime.test.ts`
- `npm exec -- tsc -p tsconfig.test.json --noEmit`
- `npm run check`
- `npm test` (399 files, 3,769 tests)

No package behavior, metadata, Changeset, publication, or deprecation action is included.
