### PR TITLE
fix(github-pr): avoid blocking session startup

### DIFF
--- a/.changeset/calm-pulls-start.md
+++ b/.changeset/calm-pulls-start.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-github-pr": patch
+---
+
+Start the initial pull request refresh in the background so GitHub CLI calls no longer delay Pi session startup.

--- a/packages/pi-github-pr/README.md
+++ b/packages/pi-github-pr/README.md
@@ -9,6 +9,7 @@ The extension reads only PR metadata and remains passive, with no command, model
 ## ✨ Features
 
 - Shows compact PR number, checks, review state, and combined comment/review count.
+- Starts the initial refresh in the background without delaying Pi startup.
 - Refreshes once per minute and after agent turns.
 - Uses GitHub CLI authentication and repository resolution without storing a token.
 - Never reads or displays discussion bodies, review text, or review threads.
@@ -71,11 +72,11 @@ The extension automatically shows the current branch's pull request status and d
 
 The extension runs passively:
 
-- On session start, it checks the current branch PR and sets a compact statusline entry.
+- On session start, it begins checking the current branch PR in the background and sets a compact statusline entry when the check completes.
 - On Git branch change, it clears the old PR immediately and refreshes the new current branch.
 - While the session remains open, it refreshes that same current branch PR every 60 seconds and after each agent turn.
 - When an agent turn is aborted, it keeps the last successful PR status instead of treating cancellation as a GitHub failure.
-- On branch change, session replacement, or session shutdown, it cancels the previous refresh timer and any in-flight periodic request.
+- On branch change, session replacement, or session shutdown, it cancels the previous refresh timer and applicable in-flight initialization or refresh request.
 - On session shutdown, it clears the statusline entry.
 - If the directory has no GitHub PR, the statusline entry stays empty.
 - If `gh` is missing or unauthenticated, the statusline shows a short hint such as `PR gh missing` or `PR gh auth`.

--- a/packages/pi-github-pr/src/github-pr.ts
+++ b/packages/pi-github-pr/src/github-pr.ts
@@ -108,6 +108,29 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 		}
 		return request;
 	};
+	const runCurrentRefresh = async (
+		ctx: ExtensionContext,
+		session: number,
+		generation: number,
+		controller: AbortController,
+	): Promise<boolean> => {
+		const sessionManager = ctx.sessionManager;
+		try {
+			const request = await refreshStatus(ctx, controller.signal, generation);
+			return (
+				!controller.signal.aborted &&
+				ownsSession(session, sessionManager) &&
+				generation === branchWatch.generation &&
+				request === branchWatch.request
+			);
+		} catch {
+			return false;
+		} finally {
+			if (branchWatch.refreshController === controller) {
+				branchWatch.refreshController = undefined;
+			}
+		}
+	};
 	const schedulePeriodicRefresh = (ctx: ExtensionContext, session: number) => {
 		cancelRefresh(branchWatch);
 		const generation = branchWatch.generation;
@@ -117,16 +140,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 			if (!ownsSession(session, sessionManager) || generation !== branchWatch.generation) return;
 			const controller = new AbortController();
 			branchWatch.refreshController = controller;
-			const request = await refreshStatus(ctx, controller.signal, generation);
-			if (branchWatch.refreshController === controller) {
-				branchWatch.refreshController = undefined;
-			}
-			if (
-				!controller.signal.aborted &&
-				ownsSession(session, sessionManager) &&
-				generation === branchWatch.generation &&
-				request === branchWatch.request
-			) {
+			if (await runCurrentRefresh(ctx, session, generation, controller)) {
 				schedulePeriodicRefresh(ctx, session);
 			}
 		}, refreshIntervalMs);
@@ -146,16 +160,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 			if (!ownsSession(session, sessionManager) || generation !== branchWatch.generation) return;
 			const controller = new AbortController();
 			branchWatch.refreshController = controller;
-			const request = await refreshStatus(ctx, controller.signal, generation);
-			if (branchWatch.refreshController === controller) {
-				branchWatch.refreshController = undefined;
-			}
-			if (
-				!controller.signal.aborted &&
-				ownsSession(session, sessionManager) &&
-				generation === branchWatch.generation &&
-				request === branchWatch.request
-			) {
+			if (await runCurrentRefresh(ctx, session, generation, controller)) {
 				schedulePeriodicRefresh(ctx, session);
 			}
 		}, BRANCH_REFRESH_DEBOUNCE_MS);
@@ -176,6 +181,7 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 		generation: number,
 		controller: AbortController,
 	) => {
+		if (controller.signal.aborted) return;
 		const sessionManager = ctx.sessionManager;
 		const watcher = await createBranchWatcher(pi, ctx.cwd, controller.signal, () => {
 			if (ownsSession(session, sessionManager)) scheduleBranchRefresh(ctx, session);
@@ -214,9 +220,15 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 		const generation = branchWatch.generation;
 		const controller = new AbortController();
 		branchWatch.initializationController = controller;
+		const stopForwardingAbort = forwardAbort(ctx.signal, controller);
+		branchWatch.initializationAbortCleanup = stopForwardingAbort;
 		const initializationTask = initializeSession(ctx, session, generation, controller)
 			.catch(() => undefined)
 			.finally(() => {
+				stopForwardingAbort();
+				if (branchWatch.initializationAbortCleanup === stopForwardingAbort) {
+					branchWatch.initializationAbortCleanup = undefined;
+				}
 				if (branchWatch.initializationController === controller) {
 					branchWatch.initializationController = undefined;
 				}
@@ -233,26 +245,18 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 		const generation = branchWatch.generation;
 		cancelRefresh(branchWatch);
 		const controller = new AbortController();
-		const abortFromContext = () => controller.abort(ctx.signal?.reason);
-		ctx.signal?.addEventListener("abort", abortFromContext, { once: true });
-		if (ctx.signal?.aborted) abortFromContext();
+		const stopForwardingAbort = forwardAbort(ctx.signal, controller);
+		branchWatch.refreshAbortCleanup = stopForwardingAbort;
 		branchWatch.refreshController = controller;
-		let request: number;
 		try {
-			request = await refreshStatus(ctx, controller.signal, generation);
-		} finally {
-			ctx.signal?.removeEventListener("abort", abortFromContext);
-			if (branchWatch.refreshController === controller) {
-				branchWatch.refreshController = undefined;
+			if (await runCurrentRefresh(ctx, session, generation, controller)) {
+				schedulePeriodicRefresh(ctx, session);
 			}
-		}
-		if (
-			!controller.signal.aborted &&
-			ownsSession(session, ctx.sessionManager) &&
-			generation === branchWatch.generation &&
-			request === branchWatch.request
-		) {
-			schedulePeriodicRefresh(ctx, session);
+		} finally {
+			stopForwardingAbort();
+			if (branchWatch.refreshAbortCleanup === stopForwardingAbort) {
+				branchWatch.refreshAbortCleanup = undefined;
+			}
 		}
 	});
 
@@ -272,11 +276,13 @@ interface BranchWatchState {
 	session: number;
 	sessionManager?: ExtensionContext["sessionManager"];
 	initializationController?: AbortController;
+	initializationAbortCleanup?: () => void;
 	initializationTask?: Promise<void>;
 	watcher?: FSWatcher;
 	timer?: ReturnType<typeof setTimeout>;
 	refreshTimer?: ReturnType<typeof setTimeout>;
 	refreshController?: AbortController;
+	refreshAbortCleanup?: () => void;
 	expiryTimer?: ReturnType<typeof setTimeout>;
 }
 
@@ -537,9 +543,24 @@ function pullRequestExpiresAt(status: PullRequestStatus): number | undefined {
 	return Number.isFinite(terminalAt) ? terminalAt + TERMINAL_PR_LIFETIME_MS : undefined;
 }
 
+function forwardAbort(source: AbortSignal | undefined, target: AbortController): () => void {
+	if (!source) return () => undefined;
+	let active = true;
+	const abort = () => target.abort(source.reason);
+	source.addEventListener("abort", abort, { once: true });
+	if (source.aborted) abort();
+	return () => {
+		if (!active) return;
+		active = false;
+		source.removeEventListener("abort", abort);
+	};
+}
+
 function cancelInitialization(branchWatch: BranchWatchState) {
 	branchWatch.initializationController?.abort();
 	branchWatch.initializationController = undefined;
+	branchWatch.initializationAbortCleanup?.();
+	branchWatch.initializationAbortCleanup = undefined;
 }
 
 function cancelRefresh(branchWatch: BranchWatchState) {
@@ -547,6 +568,8 @@ function cancelRefresh(branchWatch: BranchWatchState) {
 	branchWatch.refreshTimer = undefined;
 	branchWatch.refreshController?.abort();
 	branchWatch.refreshController = undefined;
+	branchWatch.refreshAbortCleanup?.();
+	branchWatch.refreshAbortCleanup = undefined;
 }
 
 function clearExpiryTimer(branchWatch: BranchWatchState) {

--- a/packages/pi-github-pr/src/github-pr.ts
+++ b/packages/pi-github-pr/src/github-pr.ts
@@ -83,6 +83,8 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 		throw new RangeError("refreshIntervalMs must be a positive finite number");
 	}
 	const branchWatch: BranchWatchState = { generation: 0, request: 0, session: 0 };
+	const ownsSession = (session: number, sessionManager: ExtensionContext["sessionManager"]) =>
+		session === branchWatch.session && sessionManager === branchWatch.sessionManager;
 	const refreshStatus = async (
 		ctx: ExtensionContext,
 		signal?: AbortSignal,
@@ -107,73 +109,149 @@ export default function githubPr(pi: ExtensionAPI, options: GithubPrOptions = {}
 		return request;
 	};
 	const schedulePeriodicRefresh = (ctx: ExtensionContext, session: number) => {
-		cancelPeriodicRefresh(branchWatch);
+		cancelRefresh(branchWatch);
+		const generation = branchWatch.generation;
+		const sessionManager = ctx.sessionManager;
 		branchWatch.refreshTimer = setTimeout(async () => {
 			branchWatch.refreshTimer = undefined;
-			if (session !== branchWatch.session) return;
+			if (!ownsSession(session, sessionManager) || generation !== branchWatch.generation) return;
 			const controller = new AbortController();
 			branchWatch.refreshController = controller;
-			const request = await refreshStatus(ctx, controller.signal);
+			const request = await refreshStatus(ctx, controller.signal, generation);
 			if (branchWatch.refreshController === controller) {
 				branchWatch.refreshController = undefined;
 			}
-			if (session === branchWatch.session && request === branchWatch.request) {
+			if (
+				!controller.signal.aborted &&
+				ownsSession(session, sessionManager) &&
+				generation === branchWatch.generation &&
+				request === branchWatch.request
+			) {
 				schedulePeriodicRefresh(ctx, session);
 			}
 		}, refreshIntervalMs);
 		branchWatch.refreshTimer.unref?.();
 	};
 	const scheduleBranchRefresh = (ctx: ExtensionContext, session: number) => {
+		cancelInitialization(branchWatch);
 		branchWatch.generation += 1;
 		const generation = branchWatch.generation;
-		cancelPeriodicRefresh(branchWatch);
+		const sessionManager = ctx.sessionManager;
+		cancelRefresh(branchWatch);
 		clearExpiryTimer(branchWatch);
 		clearStatus(ctx);
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
 		branchWatch.timer = setTimeout(async () => {
 			branchWatch.timer = undefined;
-			if (generation !== branchWatch.generation) return;
-			const request = await refreshStatus(ctx, ctx.signal, generation);
-			if (session === branchWatch.session && request === branchWatch.request) {
+			if (!ownsSession(session, sessionManager) || generation !== branchWatch.generation) return;
+			const controller = new AbortController();
+			branchWatch.refreshController = controller;
+			const request = await refreshStatus(ctx, controller.signal, generation);
+			if (branchWatch.refreshController === controller) {
+				branchWatch.refreshController = undefined;
+			}
+			if (
+				!controller.signal.aborted &&
+				ownsSession(session, sessionManager) &&
+				generation === branchWatch.generation &&
+				request === branchWatch.request
+			) {
 				schedulePeriodicRefresh(ctx, session);
 			}
 		}, BRANCH_REFRESH_DEBOUNCE_MS);
+		branchWatch.timer.unref?.();
 	};
 	const closeBranchWatcher = () => {
+		cancelInitialization(branchWatch);
 		if (branchWatch.timer) clearTimeout(branchWatch.timer);
 		branchWatch.timer = undefined;
-		cancelPeriodicRefresh(branchWatch);
+		cancelRefresh(branchWatch);
 		clearExpiryTimer(branchWatch);
 		branchWatch.watcher?.close();
 		branchWatch.watcher = undefined;
 	};
-
-	pi.on("session_start", async (_event, ctx) => {
-		branchWatch.generation += 1;
-		branchWatch.session += 1;
-		branchWatch.sessionManager = ctx.sessionManager;
-		const session = branchWatch.session;
-		closeBranchWatcher();
-		const watcher = await createBranchWatcher(pi, ctx.cwd, ctx.signal, () => {
-			if (session === branchWatch.session) scheduleBranchRefresh(ctx, session);
+	const initializeSession = async (
+		ctx: ExtensionContext,
+		session: number,
+		generation: number,
+		controller: AbortController,
+	) => {
+		const sessionManager = ctx.sessionManager;
+		const watcher = await createBranchWatcher(pi, ctx.cwd, controller.signal, () => {
+			if (ownsSession(session, sessionManager)) scheduleBranchRefresh(ctx, session);
 		});
-		if (session !== branchWatch.session) {
+		if (
+			controller.signal.aborted ||
+			branchWatch.initializationController !== controller ||
+			!ownsSession(session, sessionManager)
+		) {
 			watcher?.close();
 			return;
 		}
 		branchWatch.watcher = watcher;
-		const request = await refreshStatus(ctx, ctx.signal);
-		if (session === branchWatch.session && request === branchWatch.request) {
-			schedulePeriodicRefresh(ctx, session);
+		if (generation !== branchWatch.generation) return;
+
+		const request = await refreshStatus(ctx, controller.signal, generation);
+		if (
+			controller.signal.aborted ||
+			branchWatch.initializationController !== controller ||
+			!ownsSession(session, sessionManager) ||
+			generation !== branchWatch.generation ||
+			request !== branchWatch.request
+		) {
+			return;
 		}
+		schedulePeriodicRefresh(ctx, session);
+	};
+
+	pi.on("session_start", (_event, ctx) => {
+		closeBranchWatcher();
+		branchWatch.generation += 1;
+		branchWatch.session += 1;
+		branchWatch.sessionManager = ctx.sessionManager;
+		clearStatus(ctx);
+		const session = branchWatch.session;
+		const generation = branchWatch.generation;
+		const controller = new AbortController();
+		branchWatch.initializationController = controller;
+		const initializationTask = initializeSession(ctx, session, generation, controller)
+			.catch(() => undefined)
+			.finally(() => {
+				if (branchWatch.initializationController === controller) {
+					branchWatch.initializationController = undefined;
+				}
+				if (branchWatch.initializationTask === initializationTask) {
+					branchWatch.initializationTask = undefined;
+				}
+			});
+		branchWatch.initializationTask = initializationTask;
 	});
 
 	pi.on("agent_end", async (_event, ctx) => {
 		if (ctx.sessionManager !== branchWatch.sessionManager || ctx.signal?.aborted) return;
 		const session = branchWatch.session;
-		cancelPeriodicRefresh(branchWatch);
-		const request = await refreshStatus(ctx, ctx.signal);
-		if (session === branchWatch.session && request === branchWatch.request) {
+		const generation = branchWatch.generation;
+		cancelRefresh(branchWatch);
+		const controller = new AbortController();
+		const abortFromContext = () => controller.abort(ctx.signal?.reason);
+		ctx.signal?.addEventListener("abort", abortFromContext, { once: true });
+		if (ctx.signal?.aborted) abortFromContext();
+		branchWatch.refreshController = controller;
+		let request: number;
+		try {
+			request = await refreshStatus(ctx, controller.signal, generation);
+		} finally {
+			ctx.signal?.removeEventListener("abort", abortFromContext);
+			if (branchWatch.refreshController === controller) {
+				branchWatch.refreshController = undefined;
+			}
+		}
+		if (
+			!controller.signal.aborted &&
+			ownsSession(session, ctx.sessionManager) &&
+			generation === branchWatch.generation &&
+			request === branchWatch.request
+		) {
 			schedulePeriodicRefresh(ctx, session);
 		}
 	});
@@ -193,6 +271,8 @@ interface BranchWatchState {
 	request: number;
 	session: number;
 	sessionManager?: ExtensionContext["sessionManager"];
+	initializationController?: AbortController;
+	initializationTask?: Promise<void>;
 	watcher?: FSWatcher;
 	timer?: ReturnType<typeof setTimeout>;
 	refreshTimer?: ReturnType<typeof setTimeout>;
@@ -212,7 +292,7 @@ async function createBranchWatcher(
 			signal,
 			timeout: GIT_TIMEOUT_MS,
 		});
-		if (result.killed || result.code !== 0) return undefined;
+		if (signal?.aborted || result.killed || result.code !== 0) return undefined;
 
 		const gitHead = result.stdout.trim();
 		if (!gitHead) return undefined;
@@ -238,6 +318,7 @@ export async function runGhPrView(
 	const result = await execGh(pi, invocation.command, invocation.args, cwd, signal, "gh pr view");
 	if (result.killed) throw new Error("gh pr view timed out or was cancelled.");
 	if (result.code !== 0) throw new Error(formatGhFailure("gh pr view", result));
+	signal?.throwIfAborted();
 
 	let pr: JsonRecord;
 	try {
@@ -456,7 +537,12 @@ function pullRequestExpiresAt(status: PullRequestStatus): number | undefined {
 	return Number.isFinite(terminalAt) ? terminalAt + TERMINAL_PR_LIFETIME_MS : undefined;
 }
 
-function cancelPeriodicRefresh(branchWatch: BranchWatchState) {
+function cancelInitialization(branchWatch: BranchWatchState) {
+	branchWatch.initializationController?.abort();
+	branchWatch.initializationController = undefined;
+}
+
+function cancelRefresh(branchWatch: BranchWatchState) {
 	if (branchWatch.refreshTimer) clearTimeout(branchWatch.refreshTimer);
 	branchWatch.refreshTimer = undefined;
 	branchWatch.refreshController?.abort();
@@ -549,6 +635,7 @@ async function runGhPrCountQuery(
 
 	if (result.killed) throw new Error("gh api graphql timed out or was cancelled.");
 	if (result.code !== 0) throw new Error(formatGhFailure("gh api graphql", result));
+	signal?.throwIfAborted();
 
 	try {
 		const payload = objectRecord(JSON.parse(result.stdout));

--- a/packages/pi-github-pr/test/github-pr.test.ts
+++ b/packages/pi-github-pr/test/github-pr.test.ts
@@ -415,6 +415,120 @@ test("runGhPrView sends gh api graphql to the enterprise PR host", async () => {
 	]);
 });
 
+test("session start does not wait for initial commands before returning", async () => {
+	const mock = createMockPi();
+	const gitResult = deferred<ExecResult>();
+	let gitSignal: AbortSignal | undefined;
+	installExec(mock, async (command, args, options) => {
+		if (command === "git") {
+			gitSignal = options?.signal;
+			return gitResult.promise;
+		}
+		return okResult(args[0] === "pr" ? samplePr : sampleCounts);
+	});
+	githubPr(mock.pi);
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	const startupResult = sessionStart({}, context.ctx);
+	try {
+		assert.equal(startupResult, undefined);
+		assert.ok(gitSignal);
+		assert.equal(gitSignal.aborted, false);
+		assert.equal(context.statuses.get("github-pr"), undefined);
+
+		gitResult.resolve(textResult("", 128, "not a git repository"));
+		await waitFor(
+			() => (context.statuses.get("github-pr") ?? "").includes("#123"),
+			"background initialization publishes PR status",
+		);
+	} finally {
+		gitResult.resolve(textResult("", 128, "not a git repository"));
+		await sessionShutdown({}, context.ctx);
+	}
+});
+
+test("session shutdown aborts initial refresh and blocks late publication", async () => {
+	const mock = createMockPi();
+	const prView = deferred<ExecResult>();
+	let initialSignal: AbortSignal | undefined;
+	const calls = installExec(mock, async (command, args, options) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			initialSignal = options?.signal;
+			return prView.promise;
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 20 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	sessionStart({}, context.ctx);
+	await waitFor(() => initialSignal !== undefined, "initial PR refresh starts");
+	assert.ok(initialSignal);
+	assert.equal(initialSignal.aborted, false);
+
+	await sessionShutdown({}, context.ctx);
+	assert.equal(initialSignal.aborted, true);
+	prView.resolve(okResult(samplePr));
+	await drainMicrotasks();
+
+	assert.equal(calls.length, 2);
+	assert.equal(context.statuses.get("github-pr"), undefined);
+});
+
+test("session replacement aborts initial refresh and rejects its late result", async () => {
+	const mock = createMockPi();
+	const oldPrView = deferred<ExecResult>();
+	let oldSignal: AbortSignal | undefined;
+	installExec(mock, async (command, args, options) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr" && options?.cwd === "/repo-a") {
+			oldSignal = options.signal;
+			return oldPrView.promise;
+		}
+		if (args[0] === "pr") {
+			return okResult({
+				...samplePr,
+				number: 456,
+				url: "https://github.com/narumiruna/pi-extensions/pull/456",
+			});
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi);
+	const oldContext = createMockContext({ cwd: "/repo-a" });
+	const currentContext = createMockContext({ cwd: "/repo-b" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	sessionStart({}, oldContext.ctx);
+	await waitFor(() => oldSignal !== undefined, "old session initial refresh starts");
+	sessionStart({}, currentContext.ctx);
+	assert.ok(oldSignal);
+	assert.equal(oldSignal.aborted, true);
+	await waitFor(
+		() => (currentContext.statuses.get("github-pr") ?? "").includes("#456"),
+		"replacement session publishes its PR status",
+	);
+
+	oldPrView.resolve(okResult(samplePr));
+	await drainMicrotasks();
+	assert.match(currentContext.statuses.get("github-pr") ?? "", /#456/);
+	assert.equal(oldContext.statuses.get("github-pr"), undefined);
+
+	await sessionShutdown({}, currentContext.ctx);
+});
+
 test("lifecycle refresh sets and clears only statusline output", async () => {
 	const mock = createMockPi();
 	const calls = installExec(mock, async (_command, args) =>
@@ -432,6 +546,10 @@ test("lifecycle refresh sets and clears only statusline output", async () => {
 	assert.ok(sessionShutdown);
 
 	await sessionStart({}, context.ctx);
+	await waitFor(
+		() => (context.statuses.get("github-pr") ?? "").includes("#123"),
+		"initial lifecycle refresh publishes status",
+	);
 	assert.equal(
 		context.statuses.get("github-pr"),
 		`PR \x1b]8;;${samplePr.url}\x07#123\x1b]8;;\x07: checks failing (1), approved, 5 comments`,
@@ -442,7 +560,9 @@ test("lifecycle refresh sets and clears only statusline output", async () => {
 	await agentEnd({}, context.ctx);
 	assert.equal(calls.length, 5);
 	assert.deepEqual(calls[0]?.args, ["rev-parse", "--git-path", "HEAD"]);
-	assert.equal(calls[0]?.options?.signal, signal);
+	assert.ok(calls[0]?.options?.signal);
+	assert.notEqual(calls[0]?.options?.signal, signal);
+	assert.equal(calls[0]?.options?.signal?.aborted, false);
 	assert.equal(
 		context.statuses.get("github-pr"),
 		`PR \x1b]8;;${samplePr.url}\x07#123\x1b]8;;\x07: checks failing (1), approved, 5 comments`,
@@ -489,6 +609,11 @@ test("an aborted agent-end preserves the current status and periodic refresh sch
 
 	try {
 		await sessionStart({}, context.ctx);
+		await waitForMicrotasks(
+			() => (context.statuses.get("github-pr") ?? "").includes("#123"),
+			"initial status is visible before agent cancellation",
+		);
+		await drainMicrotasks();
 		const visibleStatus = context.statuses.get("github-pr");
 		assert.match(visibleStatus ?? "", /PR .*#123/);
 		vi.advanceTimersByTime(60);
@@ -531,6 +656,10 @@ test("a refresh aborted during agent-end preserves the current status", async ()
 
 	try {
 		await sessionStart({}, context.ctx);
+		await waitFor(
+			() => (context.statuses.get("github-pr") ?? "").includes("#123"),
+			"initial status is visible before agent-end refresh",
+		);
 		const visibleStatus = context.statuses.get("github-pr");
 		const agentEndPromise = agentEnd({}, context.ctx);
 		assert.equal(prViews, 2);
@@ -544,6 +673,50 @@ test("a refresh aborted during agent-end preserves the current status", async ()
 		abortedPrView.resolve({ stdout: "", stderr: "", code: 1, killed: true });
 		await sessionShutdown({}, context.ctx);
 	}
+});
+
+test("session shutdown aborts an in-flight agent-end refresh", async () => {
+	const mock = createMockPi();
+	const agentEndPrView = deferred<ExecResult>();
+	let agentEndSignal: AbortSignal | undefined;
+	let prViews = 0;
+	installExec(mock, async (command, args, options) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			prViews += 1;
+			if (prViews === 2) {
+				agentEndSignal = options?.signal;
+				return agentEndPrView.promise;
+			}
+		}
+		return okResult(args[0] === "pr" ? samplePr : sampleCounts);
+	});
+	githubPr(mock.pi, { refreshIntervalMs: 20 });
+	const context = createMockContext({ cwd: "/repo" });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(agentEnd);
+	assert.ok(sessionShutdown);
+
+	await sessionStart({}, context.ctx);
+	await waitFor(
+		() => (context.statuses.get("github-pr") ?? "").includes("#123"),
+		"initial status is visible before agent-end shutdown",
+	);
+	const agentEndPromise = agentEnd({}, context.ctx);
+	await waitFor(() => agentEndSignal !== undefined, "agent-end refresh starts");
+	assert.ok(agentEndSignal);
+	assert.equal(agentEndSignal.aborted, false);
+
+	await sessionShutdown({}, context.ctx);
+	assert.equal(agentEndSignal.aborted, true);
+	agentEndPrView.resolve(okResult(samplePr));
+	await agentEndPromise;
+
+	assert.equal(context.statuses.get("github-pr"), undefined);
+	assert.equal(prViews, 2);
 });
 
 test("rejects invalid periodic refresh intervals", () => {
@@ -584,6 +757,10 @@ test("periodically refreshes PR state while the session remains open", async () 
 
 	try {
 		await sessionStart({}, context.ctx);
+		await waitFor(
+			() => (context.statuses.get("github-pr") ?? "").includes("approved"),
+			"initial status is visible before periodic refresh",
+		);
 		assert.match(context.statuses.get("github-pr") ?? "", /approved/);
 		await waitFor(
 			() => (context.statuses.get("github-pr") ?? "").includes("changes requested"),
@@ -619,7 +796,13 @@ test("a replaced session's late lifecycle events cannot disrupt its replacement"
 
 	try {
 		await sessionStart({}, oldContext.ctx);
+		await waitForMicrotasks(() => prCwds.length === 1, "old session initial refresh starts");
 		await sessionStart({}, currentContext.ctx);
+		await waitForMicrotasks(
+			() => (currentContext.statuses.get("github-pr") ?? "").includes("#123"),
+			"replacement initial refresh completes",
+		);
+		await drainMicrotasks();
 		assert.deepEqual(prCwds, ["/repo-a", "/repo-b"]);
 
 		await sessionShutdown({}, oldContext.ctx);
@@ -627,8 +810,7 @@ test("a replaced session's late lifecycle events cannot disrupt its replacement"
 		assert.deepEqual(prCwds, ["/repo-a", "/repo-b"]);
 
 		vi.advanceTimersByTime(100);
-		await Promise.resolve();
-		await Promise.resolve();
+		await waitForMicrotasks(() => prCwds.length === 3, "replacement periodic refresh starts");
 		assert.deepEqual(prCwds, ["/repo-a", "/repo-b", "/repo-b"]);
 	} finally {
 		await sessionShutdown({}, currentContext.ctx);
@@ -654,6 +836,7 @@ test("agent-end after session shutdown cannot restart polling", async () => {
 	assert.ok(sessionShutdown);
 
 	await sessionStart({}, context.ctx);
+	await waitForMicrotasks(() => prViews === 1, "initial refresh starts before shutdown");
 	await sessionShutdown({}, context.ctx);
 	await agentEnd({}, context.ctx);
 	vi.advanceTimersByTime(100);
@@ -741,7 +924,13 @@ test("an older refresh cannot postpone a newer refresh timer", async () => {
 
 	try {
 		await sessionStart({}, context.ctx);
+		await waitForMicrotasks(
+			() => (context.statuses.get("github-pr") ?? "").includes("approved"),
+			"initial refresh completes before polling",
+		);
+		await drainMicrotasks();
 		vi.advanceTimersByTime(100);
+		await waitForMicrotasks(() => prViews === 2, "older periodic refresh starts");
 		assert.equal(prViews, 2);
 
 		await agentEnd({}, context.ctx);
@@ -866,6 +1055,10 @@ test("recent terminal pull request status clears when its 24-hour lifetime expir
 
 	try {
 		await sessionStart({}, context.ctx);
+		await waitFor(
+			() => (context.statuses.get("github-pr") ?? "").endsWith(": merged"),
+			"recent terminal PR status is visible",
+		);
 		assert.match(context.statuses.get("github-pr") ?? "", /: merged$/);
 		await waitFor(
 			() => context.statuses.get("github-pr") === undefined,
@@ -955,6 +1148,7 @@ test("session shutdown disposes the branch watcher and pending refresh", async (
 	assert.ok(sessionShutdown);
 
 	await sessionStart({}, context.ctx);
+	await waitFor(() => ghPrViews === 1, "initial refresh starts before watcher disposal");
 	assert.equal(ghPrViews, 1);
 
 	writeFileSync(headPath, "ref: refs/heads/main\n");
@@ -990,6 +1184,7 @@ test("queued branch refresh does not run after session shutdown", async () => {
 	assert.ok(sessionShutdown);
 
 	await sessionStart({}, context.ctx);
+	await waitFor(() => ghPrViews === 1, "initial refresh starts before queued branch refresh");
 	assert.equal(ghPrViews, 1);
 
 	const originalClearTimeout = globalThis.clearTimeout;
@@ -1023,6 +1218,10 @@ test("branch watcher failures stay non-intrusive", async () => {
 	assert.ok(sessionStart);
 
 	await sessionStart({}, context.ctx);
+	await waitFor(
+		() => (context.statuses.get("github-pr") ?? "").includes("#123"),
+		"branch watcher failure still allows status refresh",
+	);
 
 	assert.equal(
 		context.statuses.get("github-pr"),
@@ -1132,6 +1331,22 @@ function deferred<T>() {
 
 function wait(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function drainMicrotasks(iterations = 10): Promise<void> {
+	for (let index = 0; index < iterations; index += 1) await Promise.resolve();
+}
+
+async function waitForMicrotasks(
+	predicate: () => boolean,
+	message: string,
+	iterations = 20,
+): Promise<void> {
+	for (let index = 0; index < iterations; index += 1) {
+		if (predicate()) return;
+		await Promise.resolve();
+	}
+	assert.fail(message);
 }
 
 async function waitFor(predicate: () => boolean, message: string, timeoutMs = 1_000) {

--- a/packages/pi-github-pr/test/github-pr.test.ts
+++ b/packages/pi-github-pr/test/github-pr.test.ts
@@ -454,6 +454,8 @@ test("session start does not wait for initial commands before returning", async 
 test("session shutdown aborts initial refresh and blocks late publication", async () => {
 	const mock = createMockPi();
 	const prView = deferred<ExecResult>();
+	const sessionController = new AbortController();
+	const removeAbortListener = vi.spyOn(sessionController.signal, "removeEventListener");
 	let initialSignal: AbortSignal | undefined;
 	const calls = installExec(mock, async (command, args, options) => {
 		if (command === "git") return textResult("", 128, "not a git repository");
@@ -464,7 +466,7 @@ test("session shutdown aborts initial refresh and blocks late publication", asyn
 		return okResult(sampleCounts);
 	});
 	githubPr(mock.pi, { refreshIntervalMs: 20 });
-	const context = createMockContext({ cwd: "/repo" });
+	const context = createMockContext({ cwd: "/repo", signal: sessionController.signal });
 	const sessionStart = mock.events.get("session_start")?.[0];
 	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
 	assert.ok(sessionStart);
@@ -477,11 +479,69 @@ test("session shutdown aborts initial refresh and blocks late publication", asyn
 
 	await sessionShutdown({}, context.ctx);
 	assert.equal(initialSignal.aborted, true);
+	assert.equal(removeAbortListener.mock.calls.length, 1);
+	prView.resolve(okResult(samplePr));
+	await drainMicrotasks();
+
+	assert.equal(removeAbortListener.mock.calls.length, 1);
+	assert.equal(calls.length, 2);
+	assert.equal(context.statuses.get("github-pr"), undefined);
+});
+
+test("session cancellation aborts initial refresh and blocks late publication", async () => {
+	const mock = createMockPi();
+	const prView = deferred<ExecResult>();
+	const sessionController = new AbortController();
+	let initialSignal: AbortSignal | undefined;
+	const calls = installExec(mock, async (command, args, options) => {
+		if (command === "git") return textResult("", 128, "not a git repository");
+		if (args[0] === "pr") {
+			initialSignal = options?.signal;
+			return prView.promise;
+		}
+		return okResult(sampleCounts);
+	});
+	githubPr(mock.pi);
+	const context = createMockContext({ cwd: "/repo", signal: sessionController.signal });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	sessionStart({}, context.ctx);
+	await waitFor(() => initialSignal !== undefined, "initial refresh receives an abort signal");
+	assert.ok(initialSignal);
+	assert.notEqual(initialSignal, sessionController.signal);
+	assert.equal(initialSignal.aborted, false);
+
+	const reason = new Error("session cancelled");
+	sessionController.abort(reason);
+	assert.equal(initialSignal.aborted, true);
+	assert.equal(initialSignal.reason, reason);
 	prView.resolve(okResult(samplePr));
 	await drainMicrotasks();
 
 	assert.equal(calls.length, 2);
 	assert.equal(context.statuses.get("github-pr"), undefined);
+	await sessionShutdown({}, context.ctx);
+});
+
+test("a pre-aborted session does not start initialization commands", async () => {
+	const mock = createMockPi();
+	const calls = installExec(mock, async () => textResult("", 128, "not a git repository"));
+	githubPr(mock.pi);
+	const controller = new AbortController();
+	controller.abort(new Error("already cancelled"));
+	const context = createMockContext({ cwd: "/repo", signal: controller.signal });
+	const sessionStart = mock.events.get("session_start")?.[0];
+	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
+	assert.ok(sessionStart);
+	assert.ok(sessionShutdown);
+
+	assert.equal(sessionStart({}, context.ctx), undefined);
+	await drainMicrotasks();
+	assert.deepEqual(calls, []);
+	await sessionShutdown({}, context.ctx);
 });
 
 test("session replacement aborts initial refresh and rejects its late result", async () => {
@@ -678,6 +738,8 @@ test("a refresh aborted during agent-end preserves the current status", async ()
 test("session shutdown aborts an in-flight agent-end refresh", async () => {
 	const mock = createMockPi();
 	const agentEndPrView = deferred<ExecResult>();
+	const sessionController = new AbortController();
+	const removeAbortListener = vi.spyOn(sessionController.signal, "removeEventListener");
 	let agentEndSignal: AbortSignal | undefined;
 	let prViews = 0;
 	installExec(mock, async (command, args, options) => {
@@ -692,7 +754,7 @@ test("session shutdown aborts an in-flight agent-end refresh", async () => {
 		return okResult(args[0] === "pr" ? samplePr : sampleCounts);
 	});
 	githubPr(mock.pi, { refreshIntervalMs: 20 });
-	const context = createMockContext({ cwd: "/repo" });
+	const context = createMockContext({ cwd: "/repo", signal: sessionController.signal });
 	const sessionStart = mock.events.get("session_start")?.[0];
 	const agentEnd = mock.events.get("agent_end")?.[0];
 	const sessionShutdown = mock.events.get("session_shutdown")?.[0];
@@ -705,6 +767,8 @@ test("session shutdown aborts an in-flight agent-end refresh", async () => {
 		() => (context.statuses.get("github-pr") ?? "").includes("#123"),
 		"initial status is visible before agent-end shutdown",
 	);
+	const removalsBeforeAgentEnd = removeAbortListener.mock.calls.length;
+	assert.equal(removalsBeforeAgentEnd, 1);
 	const agentEndPromise = agentEnd({}, context.ctx);
 	await waitFor(() => agentEndSignal !== undefined, "agent-end refresh starts");
 	assert.ok(agentEndSignal);
@@ -712,9 +776,11 @@ test("session shutdown aborts an in-flight agent-end refresh", async () => {
 
 	await sessionShutdown({}, context.ctx);
 	assert.equal(agentEndSignal.aborted, true);
+	assert.equal(removeAbortListener.mock.calls.length, removalsBeforeAgentEnd + 1);
 	agentEndPrView.resolve(okResult(samplePr));
 	await agentEndPromise;
 
+	assert.equal(removeAbortListener.mock.calls.length, removalsBeforeAgentEnd + 1);
 	assert.equal(context.statuses.get("github-pr"), undefined);
 	assert.equal(prViews, 2);
 });


### PR DESCRIPTION
## Summary

- start the initial branch watcher and pull request refresh in a tracked background task so `session_start` returns immediately
- cancel initialization and refresh work across branch changes, session replacement, agent cancellation, and shutdown while rejecting stale continuations
- forward context cancellation into owned controllers, detach abort listeners immediately during cleanup, and contain unexpected refresh failures
- update lifecycle coverage, package documentation, and the patch changeset

## Performance

- built entrypoint before: 1069.04 ms first-response median
- hardened package entrypoint after: 516.13 ms first-response median
- same-session no-extension baseline: 485.27 ms median
- final extension overhead versus baseline: 30.86 ms

Each benchmark used one warm-up and five measured offline RPC runs.

## Verification

- `npx vitest run packages/pi-github-pr/test/github-pr.test.ts packages/pi-github-pr/test/build-runtime.test.ts` — 39 passed
- `npm run check` — passed
- `npm test` — 398 files and 3772 tests passed
- fenced-code-aware README heading audit — passed for all active package READMEs
- `npm run changeset:status` — selected the `pi-github-pr` patch changeset
- `npm run pack:github-pr` — inspected seven expected files including `dist/index.ts` and its source map
- package-directory offline RPC benchmark — loaded the declared `dist/index.ts` entrypoint without extension errors

## Risks and notes

- The initial status now appears asynchronously after startup instead of blocking session initialization.
- Lifecycle tests cover pre-aborted contexts, late completion, replacement, branch changes, agent cancellation, abort-listener cleanup, and shutdown cleanup.
- `changeset status` still reports pre-existing unrelated `pi-tui-kit` compatibility-floor warnings for other workspaces.
- No paths remain unverified, and no package was published.
