### PR TITLE
feat(plan-mode): coordinate agent workflows

### DIFF
--- a/.changeset/fair-plans-coordinate.md
+++ b/.changeset/fair-plans-coordinate.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Coordinate Plan-mode activation through Workflow Mutex Protocol v1 so cooperating agent workflows cannot start in the same Pi session.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -15,6 +15,7 @@ This independently installable extension adds a Codex-like `/plan` collaboration
 - Starts implementation in the planning session or a fresh linked session with the exact approved plan.
 - Persists Plan state and one saved plan across resume and compaction.
 - Exposes statusline state and configurable tool visibility, export destination, handoff behavior, shortcut, and thinking level.
+- Cooperates anonymously with Workflow Mutex Protocol v1 participants so only one agent workflow starts in a session.
 
 ## 📦 Install
 
@@ -220,6 +221,29 @@ During implementation, it removes both the original implementation handoff and t
 ```text
 /plan exit
 ```
+
+## 🤝 Workflow coexistence
+
+Plan mode is independently installable and keeps its standalone behavior when no other protocol participant is present.
+On the characterized Pi `0.84.2` runtime, it participates in the anonymous `workflow:mutex:v1` `agent-workflow` group.
+It holds the group while Planning is active, while a completed plan awaits review, and while revision is underway.
+Saved plans and ordinary implementation after Plan handoff do not hold the group.
+
+Every inactive start performs one final synchronous admission after asynchronous preflight and before changing Plan state, persistence, prompts, tools, thinking level, queues, or status.
+If another participant is active, TUI and RPC show an anonymous warning that another workflow is active.
+Print and JSON direct routes throw the same anonymous error before mutation.
+Launch-menu, selected-tool, shortcut, startup-flag, active-implementation **Start a new plan**, and restored activation use the same admission boundary.
+A rejected selected-tool launch does not save its draft choices.
+
+Restored active Plan state acquires before restoring restrictive tools, thinking, status, or model hooks.
+If restoration is busy, Plan mode stays non-running, leaves persisted history untouched, does not alter active tools, and requires a later reload or explicit new start after the other workflow ends.
+Planning-session cancellation during a fresh implementation preflight keeps the source Plan and its ownership.
+Successful session replacement relies on source-session shutdown to clean up and release; the destination's ordinary active implementation does not acquire the Plan mutex.
+
+The coexistence guarantee is cooperative and applies only when every contender implements v1 on the characterized Pi runtime and shares its event bus and session-manager identity.
+A pre-v1, mixed-version, non-participating, forked, or otherwise uncharacterized counterpart remains unsupported for mutual exclusion.
+Plan mode does not identify, inspect, configure, start, stop, or depend on another extension.
+The reciprocal minimum package versions will be documented only after both products pass the coexistence release matrix.
 
 ## 🛠️ Tools
 

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -72,6 +72,7 @@ import {
 	snapshotPlanModeToolNames,
 	toolPolicyLabel,
 } from "./tool-selection.js";
+import { WorkflowMutex, type WorkflowMutexOwner } from "./workflow-mutex.js";
 
 const STATE_ENTRY_TYPE = "plan-mode-state";
 const PROPOSED_PLAN_MESSAGE_TYPE = "proposed-plan";
@@ -89,7 +90,13 @@ interface PlanModeDependencies {
 	settingsPath?: string;
 	loadInteractiveUi?(): Promise<InteractiveUi>;
 }
+
+// Keep session state, persistence, tool, thinking, and mutex commits in this one closure so an
+// activation path cannot bypass the same atomic transition by crossing module-owned state.
 export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDependencies = {}) {
+	const workflowMutex = new WorkflowMutex(pi);
+	let workflowOwner: WorkflowMutexOwner | undefined;
+	let currentSession: object | undefined;
 	let interactiveUiPromise: Promise<InteractiveUi> | undefined;
 	const loadInteractiveUi = () => {
 		if (dependencies.loadInteractiveUi) return dependencies.loadInteractiveUi();
@@ -165,7 +172,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		],
 		parameters: PLAN_MODE_QUESTION_PARAMS,
 		async execute(_toolCallId, params: unknown, _signal, _onUpdate, ctx) {
-			if (!state.enabled) {
+			if (!state.enabled || !workflowMutex.isOwner(workflowOwner)) {
 				return planModeQuestionCancelled(
 					[],
 					"plan_mode_inactive",
@@ -188,9 +195,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 			const sessionGeneration = menuGeneration;
 			const questionWorkflowGeneration = workflowGeneration;
+			const questionOwner = workflowOwner;
 			return answerPlanModeQuestions(parsed.questions, ctx, {
 				isCurrent: () =>
-					sessionGeneration === menuGeneration && questionWorkflowGeneration === workflowGeneration,
+					sessionGeneration === menuGeneration &&
+					questionWorkflowGeneration === workflowGeneration &&
+					workflowMutex.isOwner(questionOwner),
 				isEnabled: () => state.enabled,
 			});
 		},
@@ -208,7 +218,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		parameters: PLAN_MODE_COMPLETE_PARAMS,
 		renderResult: renderPlanModeCompletion,
 		async execute(_toolCallId, params: unknown, _signal, _onUpdate, ctx) {
-			if (!state.enabled) {
+			if (!state.enabled || !workflowMutex.isOwner(workflowOwner)) {
 				throw new Error("plan_mode_complete is only available while Plan mode is active");
 			}
 			const parsed = normalizePlanModeCompletion(params);
@@ -233,8 +243,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 					ctx.ui.notify("Plan mode is already active.", "info");
 					return;
 				}
-				enterPlanMode(ctx);
-				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+				if (enterPlanMode(ctx)) {
+					ctx.ui.notify(
+						"Plan mode enabled. I will explore and plan, but not modify files.",
+						"info",
+					);
+				}
 				return;
 			}
 			if (command === "show") {
@@ -405,37 +419,39 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	pi.on("session_start", async (event, ctx) => {
 		const generation = ++menuGeneration;
+		currentSession = ctx.sessionManager;
+		workflowOwner = undefined;
+		workflowMutex.bindSession(ctx.sessionManager);
 		refreshStateBeforeFirstAgentStart = event.reason === "new";
 		menuController.abort(new DOMException("Plan-mode session replaced", "AbortError"));
 		menuController = new AbortController();
 		readyPresentationIntent = undefined;
 		latestCommandContext = undefined;
+		previousTools = undefined;
 		implementationRetention.reset();
 		settings = { thinkingLevel: "inherit" };
-		restoreState(ctx);
-		implementationRetention.restore(state.activeImplementation);
+		const restoredState = readRestoredState(ctx);
+		state = { enabled: false, awaitingAction: false };
 		await applyPlanModeSettings(generation, ctx, true);
 		if (generation !== menuGeneration || menuController.signal.aborted) return;
 		startPlanModeSettingsWatch(generation);
-		const persistFlagActivation = pi.getFlag("plan") === true && !state.enabled;
-		if (persistFlagActivation) {
-			state = state.savedPlan
+		const persistFlagActivation = pi.getFlag("plan") === true && !restoredState.enabled;
+		const candidate = persistFlagActivation
+			? restoredState.savedPlan
 				? {
-						...state,
+						...restoredState,
 						enabled: true,
-						latestPlan: state.savedPlan.plan,
-						latestPlanSource: state.savedPlan.source,
+						latestPlan: restoredState.savedPlan.plan,
+						latestPlanSource: restoredState.savedPlan.source,
 						awaitingAction: true,
 						savedPlan: undefined,
 						activeImplementation: undefined,
 					}
-				: { ...state, enabled: true, activeImplementation: undefined };
-		}
-		if (state.enabled) {
-			activatePlanModeTools();
-			applyPlanThinkingLevel();
-		} else deactivatePlanModeQuestionTool();
-		if (persistFlagActivation) persistState();
+				: { ...restoredState, enabled: true, activeImplementation: undefined }
+			: restoredState;
+		if (!installRestoredState(candidate, ctx)) return;
+		implementationRetention.restore(state.activeImplementation);
+		if (persistFlagActivation && state.enabled) persistState();
 		updateUi(ctx);
 	});
 
@@ -453,6 +469,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
+		const shutdownSession = ctx.sessionManager;
 		menuGeneration += 1;
 		menuController.abort(new DOMException("Plan-mode session shut down", "AbortError"));
 		readyPresentationIntent = undefined;
@@ -460,6 +477,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		refreshStateBeforeFirstAgentStart = false;
 		implementationRetention.reset();
 		await awaitPlanModeSettingsWrites(dependencies.settingsPath);
+		if (currentSession !== undefined && currentSession !== shutdownSession) {
+			workflowMutex.unbindSession(shutdownSession);
+			return;
+		}
 		captureManualThinkingLevel();
 		persistState();
 		if (state.enabled) {
@@ -468,10 +489,13 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 		stopPlanModeSettingsWatch();
 		clearUi(ctx);
+		releaseWorkflowOwner();
+		workflowMutex.unbindSession(ctx.sessionManager);
+		if (currentSession === ctx.sessionManager) currentSession = undefined;
 	});
 
 	pi.on("tool_call", async (event) => {
-		if (!state.enabled) return;
+		if (!state.enabled || !workflowMutex.isOwner(workflowOwner)) return;
 		if (event.toolName === "update_plan") {
 			return {
 				block: true,
@@ -515,16 +539,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	pi.on("before_agent_start", (event, ctx) => {
 		if (refreshStateBeforeFirstAgentStart) {
 			refreshStateBeforeFirstAgentStart = false;
-			restoreState(ctx);
 			implementationRetention.reset();
+			if (!installRestoredState(readRestoredState(ctx), ctx)) return;
 			implementationRetention.restore(state.activeImplementation);
-			if (state.enabled) {
-				activatePlanModeTools();
-				applyPlanThinkingLevel();
-			} else deactivatePlanModeQuestionTool();
 			updateUi(ctx);
 		}
-		if (!state.enabled) return;
+		if (!state.enabled || !workflowMutex.isOwner(workflowOwner)) return;
 		if (state.latestPlan || state.awaitingAction) {
 			readyPresentationIntent = undefined;
 			state = {
@@ -543,7 +563,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	pi.on("agent_end", async (event, ctx) => {
-		if (!state.enabled) return;
+		if (!state.enabled || !workflowMutex.isOwner(workflowOwner)) return;
 
 		const text = latestAssistantText(event.messages);
 		const parsedPlan = parseProposedPlan(text);
@@ -588,37 +608,53 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 	});
 
-	function enterPlanMode(ctx: ExtensionContext) {
+	function enterPlanMode(
+		ctx: ExtensionContext,
+		candidate: Pick<PlanModeState, "selectedToolNames" | "selectedToolKeys"> = state,
+	) {
+		bindWorkflowSessionIfNeeded(ctx);
+		if (state.enabled) return workflowMutex.isOwner(workflowOwner);
+		const owner = workflowMutex.acquire();
+		if (!owner) return reportWorkflowBusy(ctx);
+		workflowOwner = owner;
+
+		const previousState = state;
+		const previousToolSnapshot = previousTools;
 		workflowGeneration += 1;
-		if (!state.enabled) previousTools = withoutRequiredPlanModeTools(safeGetActiveTools());
-		state = {
-			...state,
-			enabled: true,
-			awaitingAction: false,
-			savedPlan: undefined,
-			activeImplementation: undefined,
-		};
-		activatePlanModeTools();
-		applyPlanThinkingLevel();
-		persistState();
-		updateUi(ctx);
+		try {
+			previousTools = withoutRequiredPlanModeTools(safeGetActiveTools());
+			state = {
+				...state,
+				enabled: true,
+				awaitingAction: false,
+				savedPlan: undefined,
+				activeImplementation: undefined,
+				selectedToolNames: candidate.selectedToolNames,
+				selectedToolKeys: candidate.selectedToolKeys,
+			};
+			activatePlanModeTools();
+			applyPlanThinkingLevel();
+			persistState();
+			updateUi(ctx);
+			return true;
+		} catch (error: unknown) {
+			rollbackNewActivation(previousState, previousToolSnapshot, ctx);
+			throw error;
+		}
 	}
 
 	function enterPlanModeWithPrompt(prompt: string, ctx: ExtensionContext) {
 		const previousState = state;
+		const previousOwner = workflowOwner;
+		const previousToolSnapshot = previousTools;
 		const wasEnabled = state.enabled;
-		enterPlanMode(ctx);
+		if (!enterPlanMode(ctx)) return;
 		if (!wasEnabled) {
 			ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
 		}
 		if (sendPlanModeUserMessage(prompt, ctx)) return;
-		if (!previousState.enabled) {
-			restoreTools();
-			restoreThinkingLevel();
-		}
-		state = previousState;
-		persistState();
-		updateUi(ctx);
+		if (wasEnabled) return;
+		rollbackNewActivation(previousState, previousToolSnapshot, ctx, previousOwner);
 	}
 
 	function exitPlanMode(ctx: ExtensionContext) {
@@ -642,6 +678,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 		persistState();
 		updateUi(ctx);
+		if (wasEnabled) releaseWorkflowOwner();
 	}
 
 	function sendPlanModeUserMessage(message: string, ctx: ExtensionContext) {
@@ -690,6 +727,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	function completedPlanIsCurrent(intent: ReadyPresentationIntent) {
 		return (
 			state.enabled &&
+			workflowMutex.isOwner(workflowOwner) &&
 			state.awaitingAction &&
 			state.latestPlan === intent.plan &&
 			state.latestPlanSource === intent.source
@@ -707,8 +745,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			return;
 		}
 		if (savedPlanBlocksNewWorkflow(ctx, state.savedPlan !== undefined)) return;
-		enterPlanMode(ctx);
-		ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+		if (enterPlanMode(ctx)) {
+			ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+		}
 	}
 
 	function planModeDisableNotification() {
@@ -759,6 +798,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		state = { ...state, manualThinkingLevel: undefined };
 		persistState();
 		updateUi(ctx);
+		releaseWorkflowOwner();
 		ctx.ui.notify("Plan saved for later. Plan mode disabled.", "info");
 	}
 
@@ -794,6 +834,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 		workflowGeneration += 1;
 		const previousState = state;
+		const previousIntent = readyPresentationIntent;
+		const previousToolSnapshot = previousTools;
 		const wasEnabled = state.enabled;
 		readyPresentationIntent = undefined;
 		state = {
@@ -822,16 +864,18 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 		const sent = sendPlanModeUserMessage(formatImplementationHandoff(plan), ctx);
 		if (!sent) {
-			if (savedPlan) {
-				state = previousState;
-			} else {
-				enterPlanMode(ctx);
-				state = previousState;
+			state = previousState;
+			readyPresentationIntent = previousIntent;
+			if (wasEnabled) {
+				previousTools = previousToolSnapshot;
+				applyPlanModeTools();
 				applyPlanThinkingLevel();
 			}
 			persistState();
 			updateUi(ctx);
+			return;
 		}
+		if (wasEnabled) releaseWorkflowOwner();
 	}
 
 	function clearActiveImplementation(id: string, ctx: ExtensionContext) {
@@ -870,18 +914,19 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			...lifecycle,
 			start: (signal) => {
 				if (signal.aborted || !lifecycle.isCurrent()) return;
-				enterPlanMode(ctx);
-				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+				if (enterPlanMode(ctx)) {
+					ctx.ui.notify(
+						"Plan mode enabled. I will explore and plan, but not modify files.",
+						"info",
+					);
+				}
 			},
 			startWithTools: (names, signal) => {
 				if (signal.aborted || !lifecycle.isCurrent()) return;
-				state = {
-					...state,
-					selectedToolNames: filterAvailableSelectedToolNames(names, tools),
-					selectedToolKeys: undefined,
-				};
-				enterPlanMode(ctx);
-				ctx.ui.notify("Plan mode enabled with the selected tools.", "info");
+				const selectedToolNames = filterAvailableSelectedToolNames(names, tools);
+				if (enterPlanMode(ctx, { selectedToolNames, selectedToolKeys: undefined })) {
+					ctx.ui.notify("Plan mode enabled with the selected tools.", "info");
+				}
 			},
 			settings: (signal) => showSettings(ctx, signal, lifecycle.isCurrent),
 		});
@@ -905,8 +950,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			exportPlan: (path, signal) => planExports.export(path, ctx, signal, lifecycle.isCurrent),
 			settings: (signal) => showSettings(ctx, signal, lifecycle.isCurrent),
 			startNew: () => {
-				enterPlanMode(ctx);
-				ctx.ui.notify("Plan mode enabled. I will explore and plan, but not modify files.", "info");
+				if (enterPlanMode(ctx)) {
+					ctx.ui.notify(
+						"Plan mode enabled. I will explore and plan, but not modify files.",
+						"info",
+					);
+				}
 			},
 			clear: () => {
 				exitPlanMode(ctx);
@@ -943,13 +992,15 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	function captureMenuLifecycle() {
 		const sessionGeneration = menuGeneration;
 		const planWorkflowGeneration = workflowGeneration;
+		const owner = workflowOwner;
 		const controller = menuController;
 		return {
 			signal: controller.signal,
 			isCurrent: () =>
 				sessionGeneration === menuGeneration &&
 				planWorkflowGeneration === workflowGeneration &&
-				!controller.signal.aborted,
+				!controller.signal.aborted &&
+				(!state.enabled || workflowMutex.isOwner(owner)),
 		};
 	}
 
@@ -1075,8 +1126,120 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 	}
 
-	function restoreState(ctx: ExtensionContext) {
-		state = restorePlanModeState(ctx.sessionManager.getBranch(), STATE_ENTRY_TYPE);
+	function readRestoredState(ctx: ExtensionContext) {
+		return restorePlanModeState(ctx.sessionManager.getBranch(), STATE_ENTRY_TYPE);
+	}
+
+	function installRestoredState(candidate: PlanModeState, ctx: ExtensionContext) {
+		const previousState = state;
+		const previousToolSnapshot = previousTools;
+		const previousOwner = workflowOwner;
+		const wasEnabled = state.enabled;
+		if (candidate.enabled && !workflowMutex.isOwner(workflowOwner)) {
+			const owner = workflowMutex.acquire();
+			if (!owner) {
+				state = { enabled: false, awaitingAction: false };
+				previousTools = undefined;
+				reportRestoredWorkflowBusy(ctx);
+				return false;
+			}
+			workflowOwner = owner;
+		}
+
+		try {
+			if (wasEnabled && !candidate.enabled) {
+				readyPresentationIntent = undefined;
+				restoreTools();
+				restoreThinkingLevel();
+			}
+			state = candidate;
+			if (state.enabled) {
+				if (!wasEnabled) previousTools = withoutRequiredPlanModeTools(safeGetActiveTools());
+				activatePlanModeTools();
+				applyPlanThinkingLevel();
+			} else {
+				deactivatePlanModeQuestionTool();
+				if (wasEnabled) releaseWorkflowOwner();
+			}
+			return true;
+		} catch (error: unknown) {
+			try {
+				if (!wasEnabled && state.enabled) {
+					try {
+						restoreTools();
+					} finally {
+						restoreThinkingLevel();
+					}
+				}
+			} finally {
+				state = previousState;
+				previousTools = previousToolSnapshot;
+				if (workflowOwner !== previousOwner) {
+					workflowMutex.release(workflowOwner);
+					workflowOwner = previousOwner;
+				}
+			}
+			throw error;
+		}
+	}
+
+	function rollbackNewActivation(
+		previousState: PlanModeState,
+		previousToolSnapshot: string[] | undefined,
+		ctx: ExtensionContext,
+		previousOwner?: WorkflowMutexOwner,
+	) {
+		const activatedOwner = workflowOwner;
+		readyPresentationIntent = undefined;
+		try {
+			if (state.enabled) {
+				try {
+					restoreTools();
+				} finally {
+					restoreThinkingLevel();
+				}
+			}
+		} finally {
+			state = previousState;
+			previousTools = previousToolSnapshot;
+			try {
+				persistState();
+				updateUi(ctx);
+			} finally {
+				if (activatedOwner !== previousOwner) {
+					workflowMutex.release(activatedOwner);
+					workflowOwner = previousOwner;
+				}
+			}
+		}
+	}
+
+	function bindWorkflowSessionIfNeeded(ctx: ExtensionContext) {
+		if (currentSession === ctx.sessionManager) return;
+		currentSession = ctx.sessionManager;
+		workflowOwner = undefined;
+		workflowMutex.bindSession(ctx.sessionManager);
+	}
+
+	function releaseWorkflowOwner() {
+		const owner = workflowOwner;
+		workflowMutex.release(owner);
+		if (!workflowMutex.isOwner(owner)) workflowOwner = undefined;
+	}
+
+	function reportWorkflowBusy(ctx: ExtensionContext) {
+		const message = "Another workflow is active in this session. End it before starting Plan mode.";
+		if (!ctx.hasUI) throw new Error(message);
+		ctx.ui.notify(message, "warning");
+		return false;
+	}
+
+	function reportRestoredWorkflowBusy(ctx: ExtensionContext) {
+		if (!ctx.hasUI) return;
+		ctx.ui.notify(
+			"Plan mode was not restored because another workflow is active in this session. Reload or start Plan mode after it ends.",
+			"warning",
+		);
 	}
 
 	function updateUi(ctx: ExtensionContext) {

--- a/packages/pi-plan-mode/src/workflow-mutex.ts
+++ b/packages/pi-plan-mode/src/workflow-mutex.ts
@@ -1,0 +1,87 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export const WORKFLOW_MUTEX_CHANNEL = "workflow:mutex:v1";
+export const AGENT_WORKFLOW_GROUP = "agent-workflow";
+
+export type WorkflowMutexOwner = symbol;
+
+interface WorkflowMutexAttemptV1 {
+	session: object;
+	group: string;
+	busy: boolean;
+}
+
+export class WorkflowMutex {
+	private session: object | undefined;
+	private readonly heldGroups = new Map<string, WorkflowMutexOwner>();
+	private generation = 0;
+
+	constructor(private readonly pi: Pick<ExtensionAPI, "events">) {
+		pi.events.on(WORKFLOW_MUTEX_CHANNEL, (payload) => {
+			this.answer(payload);
+		});
+	}
+
+	bindSession(session: object): void {
+		this.generation += 1;
+		this.heldGroups.clear();
+		this.session = session;
+	}
+
+	unbindSession(session: object): void {
+		if (this.session !== session) return;
+		this.generation += 1;
+		this.heldGroups.clear();
+		this.session = undefined;
+	}
+
+	acquire(group = AGENT_WORKFLOW_GROUP): WorkflowMutexOwner | undefined {
+		const session = this.session;
+		const generation = this.generation;
+		if (!session || this.heldGroups.has(group)) return undefined;
+
+		const attempt: WorkflowMutexAttemptV1 = { session, group, busy: false };
+		try {
+			this.pi.events.emit(WORKFLOW_MUTEX_CHANNEL, attempt);
+		} catch {
+			return undefined;
+		}
+		if (
+			this.session !== session ||
+			this.generation !== generation ||
+			attempt.session !== session ||
+			attempt.group !== group ||
+			attempt.busy !== false ||
+			this.heldGroups.has(group)
+		) {
+			return undefined;
+		}
+
+		const owner = Symbol(group);
+		this.heldGroups.set(group, owner);
+		return owner;
+	}
+
+	isOwner(owner: WorkflowMutexOwner | undefined, group = AGENT_WORKFLOW_GROUP): boolean {
+		return owner !== undefined && this.heldGroups.get(group) === owner;
+	}
+
+	release(owner: WorkflowMutexOwner | undefined, group = AGENT_WORKFLOW_GROUP): void {
+		if (!this.isOwner(owner, group)) return;
+		this.heldGroups.delete(group);
+	}
+
+	private answer(payload: unknown): void {
+		try {
+			if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return;
+			const attempt = payload as Partial<WorkflowMutexAttemptV1>;
+			if (attempt.session !== this.session) return;
+			if (attempt.group !== AGENT_WORKFLOW_GROUP) return;
+			if (typeof attempt.busy !== "boolean") return;
+			if (!this.heldGroups.has(attempt.group)) return;
+			attempt.busy = true;
+		} catch {
+			// Protocol listeners must ignore unusual objects without interrupting sibling listeners.
+		}
+	}
+}

--- a/packages/pi-plan-mode/test/generated-entry.test.ts
+++ b/packages/pi-plan-mode/test/generated-entry.test.ts
@@ -24,8 +24,32 @@ test("declared generated entry preserves registration and partial lifecycle clea
 		assert.ok(mock.commands.has("plan"));
 		assert.ok(mock.events.has("session_start"));
 		assert.ok(mock.events.has("session_shutdown"));
-		const context = createMockContext({ mode: "tui", cwd: root });
+		const sessionManager = {
+			getSessionId: () => "generated-entry-session",
+			getSessionName: () => undefined,
+			getBranch: () => [],
+			getEntries: () => [],
+		};
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			sessionManager,
+		});
+		await emit(mock.events, "session_start", { reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		const activeAttempt = {
+			session: sessionManager,
+			group: "agent-workflow",
+			busy: false,
+		};
+		mock.eventBus.emit("workflow:mutex:v1", activeAttempt);
+		assert.equal(activeAttempt.busy, true);
+
 		await emit(mock.events, "session_shutdown", { reason: "quit" }, context.ctx);
+		const releasedAttempt = { ...activeAttempt, busy: false };
+		mock.eventBus.emit("workflow:mutex:v1", releasedAttempt);
+		assert.equal(releasedAttempt.busy, false);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/packages/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-471-repro.test.ts
@@ -245,6 +245,13 @@ test("implementation transition persists active state before a busy follow-up an
 	assert.equal(activeState.activeImplementation?.source, "plan_mode_complete");
 	assert.match(activeState.activeImplementation?.id ?? "", /^[0-9a-f-]{36}$/u);
 	assert.ok((activeState.activeImplementation?.startedAt ?? -1) >= 0);
+	const releasedAttempt = {
+		session: (context.ctx as unknown as { sessionManager: object }).sessionManager,
+		group: "agent-workflow",
+		busy: false,
+	};
+	mock.eventBus.emit("workflow:mutex:v1", releasedAttempt);
+	assert.equal(releasedAttempt.busy, false);
 
 	const sendsBeforeRepeat = mock.sentUserMessages.length;
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
@@ -276,6 +283,13 @@ test("failed implementation delivery restores ready state without retained imple
 	assert.equal(restored?.latestPlan, PLAN);
 	assert.equal(restored?.activeImplementation, undefined);
 	assert.match(context.notifications.at(-1)?.message ?? "", /no longer active/);
+	const retainedAttempt = {
+		session: (context.ctx as unknown as { sessionManager: object }).sessionManager,
+		group: "agent-workflow",
+		busy: false,
+	};
+	mock.eventBus.emit("workflow:mutex:v1", retainedAttempt);
+	assert.equal(retainedAttempt.busy, true);
 });
 
 test("a failed superseding prompt restores the exact active implementation", async () => {

--- a/packages/pi-plan-mode/test/workflow-mutex.test.ts
+++ b/packages/pi-plan-mode/test/workflow-mutex.test.ts
@@ -1,0 +1,477 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import planMode from "../src/plan-mode.js";
+import {
+	AGENT_WORKFLOW_GROUP,
+	WORKFLOW_MUTEX_CHANNEL,
+	WorkflowMutex,
+} from "../src/workflow-mutex.js";
+
+function attempt(session: object, group = AGENT_WORKFLOW_GROUP) {
+	return { session, group, busy: false };
+}
+
+function blockAgentWorkflow(mock: ReturnType<typeof createMockPi>, session: object) {
+	mock.eventBus.on(WORKFLOW_MUTEX_CHANNEL, (payload) => {
+		if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return;
+		const current = payload as { session?: object; group?: string; busy?: boolean };
+		if (current.session !== session || current.group !== AGENT_WORKFLOW_GROUP) return;
+		if (typeof current.busy !== "boolean") return;
+		current.busy = true;
+	});
+}
+
+function persistedPlanState(data: Record<string, unknown>) {
+	return {
+		type: "custom",
+		customType: "plan-mode-state",
+		data,
+	};
+}
+
+test("workflow mutex ignores malformed, foreign-session, and foreign-group payloads", () => {
+	const mock = createMockPi();
+	const mutex = new WorkflowMutex(mock.pi);
+	const session = {};
+	mutex.bindSession(session);
+	assert.ok(mutex.acquire());
+
+	for (const payload of [undefined, null, [], "mutex", 1, { session }, { session, group: 1 }]) {
+		assert.doesNotThrow(() => mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, payload));
+	}
+	assert.doesNotThrow(() =>
+		mock.eventBus.emit(
+			WORKFLOW_MUTEX_CHANNEL,
+			new Proxy(
+				{},
+				{
+					get() {
+						throw new Error("hostile getter");
+					},
+				},
+			),
+		),
+	);
+
+	const anotherSession = attempt({});
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, anotherSession);
+	assert.equal(anotherSession.busy, false);
+	const anotherGroup = attempt(session, "other-workflow");
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, anotherGroup);
+	assert.equal(anotherGroup.busy, false);
+	const malformedBusy = { session, group: AGENT_WORKFLOW_GROUP, busy: "false" };
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, malformedBusy);
+	assert.equal(malformedBusy.busy, "false");
+});
+
+test("workflow mutex reports a matching holder without erasing an earlier busy result", () => {
+	const mock = createMockPi();
+	const session = {};
+	mock.eventBus.on(WORKFLOW_MUTEX_CHANNEL, (payload) => {
+		(payload as { busy: boolean }).busy = true;
+	});
+	const mutex = new WorkflowMutex(mock.pi);
+	mutex.bindSession(session);
+
+	const current = attempt(session);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, current);
+	assert.equal(current.busy, true);
+	assert.equal(mutex.acquire(), undefined);
+});
+
+test("workflow mutex fails closed on emit errors and unexpected payload mutation", () => {
+	const throwing = new WorkflowMutex({
+		events: {
+			on: () => () => undefined,
+			emit() {
+				throw new Error("emit failed");
+			},
+		},
+	} as never);
+	throwing.bindSession({});
+	assert.equal(throwing.acquire(), undefined);
+
+	const mock = createMockPi();
+	mock.eventBus.on(WORKFLOW_MUTEX_CHANNEL, (payload) => {
+		(payload as { group: string }).group = "changed";
+	});
+	const mutated = new WorkflowMutex(mock.pi);
+	mutated.bindSession({});
+	assert.equal(mutated.acquire(), undefined);
+});
+
+test("workflow mutex rejects synchronous re-entry that replaces the session", () => {
+	const mock = createMockPi();
+	let mutex: WorkflowMutex;
+	let replaced = false;
+	const replacementSession = {};
+	mock.eventBus.on(WORKFLOW_MUTEX_CHANNEL, () => {
+		if (replaced) return;
+		replaced = true;
+		mutex.bindSession(replacementSession);
+	});
+	mutex = new WorkflowMutex(mock.pi);
+	mutex.bindSession({});
+
+	assert.equal(mutex.acquire(), undefined);
+	const replacementOwner = mutex.acquire();
+	assert.ok(replacementOwner);
+	assert.equal(mutex.isOwner(replacementOwner), true);
+});
+
+test("workflow mutex stale release cannot clear a replacement owner", () => {
+	const mock = createMockPi();
+	const mutex = new WorkflowMutex(mock.pi);
+	const session = {};
+	mutex.bindSession(session);
+	const oldOwner = mutex.acquire();
+	assert.ok(oldOwner);
+	mutex.release(oldOwner);
+	const currentOwner = mutex.acquire();
+	assert.ok(currentOwner);
+
+	mutex.release(oldOwner);
+	assert.equal(mutex.isOwner(currentOwner), true);
+	const current = attempt(session);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, current);
+	assert.equal(current.busy, true);
+});
+
+test("Plan holds the workflow mutex through planning, ready review, and revision", async () => {
+	const mock = createMockPi({ activeTools: ["read", "write"] });
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const sessionManager = { getBranch: () => [], getEntries: () => [] };
+	const context = createMockContext({ mode: "tui", hasUI: true, sessionManager });
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+
+	const planning = attempt(sessionManager);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, planning);
+	assert.equal(planning.busy, true);
+
+	const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as (
+		...args: unknown[]
+	) => Promise<unknown>;
+	await complete("call", { plan: "# Ready plan" }, undefined, undefined, context.ctx);
+	const ready = attempt(sessionManager);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, ready);
+	assert.equal(ready.busy, true);
+
+	await mock.events.get("before_agent_start")?.[0]?.(
+		{ systemPrompt: "base", prompt: "revise" },
+		context.ctx,
+	);
+	const revision = attempt(sessionManager);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, revision);
+	assert.equal(revision.busy, true);
+
+	await mock.commands.get("plan")?.handler("exit", context.ctx);
+	const released = attempt(sessionManager);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, released);
+	assert.equal(released.busy, false);
+});
+
+test("busy direct starts preserve state in every command mode", async () => {
+	for (const mode of ["tui", "rpc", "print", "json"] as const) {
+		const sessionManager = { getBranch: () => [], getEntries: () => [] };
+		const mock = createMockPi({ activeTools: ["read", "write"], thinkingLevel: "low" });
+		blockAgentWorkflow(mock, sessionManager);
+		planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+		const context = createMockContext({
+			mode,
+			hasUI: mode === "tui" || mode === "rpc",
+			sessionManager,
+		});
+		const command = mock.commands.get("plan");
+		assert.ok(command);
+		const snapshot = {
+			activeTools: mock.rawPi.getActiveTools(),
+			entries: mock.entries.length,
+			messages: mock.sentUserMessages.length,
+			thinking: mock.thinkingLevel,
+			thinkingWrites: mock.thinkingLevels.length,
+			statuses: [...context.statuses],
+		};
+
+		for (const input of ["start", "design a release"]) {
+			if (mode === "print" || mode === "json") {
+				await assert.rejects(
+					async () => command.handler(input, context.ctx),
+					/Another workflow is active/u,
+				);
+			} else {
+				await command.handler(input, context.ctx);
+			}
+			assert.deepEqual(mock.rawPi.getActiveTools(), snapshot.activeTools);
+			assert.equal(mock.entries.length, snapshot.entries);
+			assert.equal(mock.sentUserMessages.length, snapshot.messages);
+			assert.equal(mock.thinkingLevel, snapshot.thinking);
+			assert.equal(mock.thinkingLevels.length, snapshot.thinkingWrites);
+			assert.deepEqual([...context.statuses], snapshot.statuses);
+		}
+		if (mode === "tui" || mode === "rpc") {
+			assert.equal(context.notifications.length, 2);
+			assert.ok(
+				context.notifications.every(
+					(notification) =>
+						notification.level === "warning" &&
+						notification.message ===
+							"Another workflow is active in this session. End it before starting Plan mode.",
+				),
+			);
+		}
+	}
+});
+
+test("busy restored and --plan activation start no Plan work and perform no tool writes", async () => {
+	for (const restoredData of [
+		{ enabled: true, awaitingAction: false },
+		{ enabled: false, awaitingAction: false },
+	]) {
+		const entry = persistedPlanState(restoredData);
+		const sessionManager = { getBranch: () => [entry], getEntries: () => [entry] };
+		const mock = createMockPi({ activeTools: ["goal_complete"], thinkingLevel: "high" });
+		let activeToolWrites = 0;
+		const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+		mock.rawPi.setActiveTools = (names) => {
+			activeToolWrites += 1;
+			setActiveTools(names);
+		};
+		blockAgentWorkflow(mock, sessionManager);
+		planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+		if (!restoredData.enabled) {
+			const flag = mock.flags.get("plan");
+			assert.ok(flag);
+			flag.value = true;
+		}
+		const context = createMockContext({ mode: "tui", hasUI: true, sessionManager });
+
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		assert.equal(activeToolWrites, 0);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["goal_complete"]);
+		assert.equal(mock.thinkingLevel, "high");
+		assert.equal(mock.thinkingLevels.length, 0);
+		assert.equal(mock.entries.length, 0);
+		assert.equal(context.statuses.get("plan-mode"), undefined);
+		assert.match(context.notifications[0]?.message ?? "", /was not restored/u);
+
+		const beforeStart = await mock.events.get("before_agent_start")?.[0]?.(
+			{ systemPrompt: "base", prompt: "continue" },
+			context.ctx,
+		);
+		assert.equal(beforeStart, undefined);
+		assert.equal(mock.sentUserMessages.length, 0);
+	}
+});
+
+test("busy menu, selected-tool, shortcut, and active-implementation starts stay atomic", async () => {
+	for (const mode of ["tui", "rpc"] as const) {
+		const sessionManager = { getBranch: () => [], getEntries: () => [] };
+		const mock = createMockPi({ activeTools: ["read", "write"] });
+		blockAgentWorkflow(mock, sessionManager);
+		let launchOptions:
+			| {
+					start(signal: AbortSignal): void;
+					startWithTools(names: string[], signal: AbortSignal): void;
+			  }
+			| undefined;
+		planMode(mock.pi, {
+			readSettings: async () => ({ kind: "missing" as const }),
+			loadInteractiveUi: async () =>
+				({
+					showPlanLaunchMenu: async (_ctx: unknown, options: typeof launchOptions) => {
+						launchOptions = options;
+					},
+				}) as never,
+		});
+		const context = createMockContext({ mode, hasUI: true, sessionManager });
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.ok(launchOptions);
+		launchOptions.start(new AbortController().signal);
+		launchOptions.startWithTools(["read"], new AbortController().signal);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+		assert.equal(mock.entries.length, 0);
+		assert.equal(context.notifications.length, 2);
+	}
+
+	const shortcutSession = { getBranch: () => [], getEntries: () => [] };
+	const shortcutMock = createMockPi({ activeTools: ["read", "write"] });
+	blockAgentWorkflow(shortcutMock, shortcutSession);
+	planMode(shortcutMock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: { thinkingLevel: "inherit" as const, toggleShortcut: "ctrl+shift+p" },
+		}),
+	});
+	const shortcutContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		sessionManager: shortcutSession,
+	});
+	await shortcutMock.events.get("session_start")?.[0]?.({ reason: "startup" }, shortcutContext.ctx);
+	await shortcutMock.shortcuts.get("ctrl+shift+p")?.handler(shortcutContext.ctx);
+	assert.deepEqual(shortcutMock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(shortcutMock.entries.length, 0);
+	assert.match(shortcutContext.notifications.at(-1)?.message ?? "", /Another workflow/u);
+
+	const activeEntry = persistedPlanState({
+		enabled: false,
+		awaitingAction: false,
+		activeImplementation: {
+			id: "active-plan",
+			plan: "# Existing plan",
+			source: "plan_mode_complete",
+			startedAt: 1,
+			retention: "keep",
+		},
+	});
+	const activeSession = { getBranch: () => [activeEntry], getEntries: () => [activeEntry] };
+	const activeMock = createMockPi({ activeTools: ["read", "write"] });
+	blockAgentWorkflow(activeMock, activeSession);
+	let startNew: (() => void) | undefined;
+	planMode(activeMock.pi, {
+		readSettings: async () => ({ kind: "missing" as const }),
+		loadInteractiveUi: async () =>
+			({
+				showActiveImplementationMenu: async (_ctx: unknown, options: { startNew(): void }) => {
+					startNew = options.startNew;
+				},
+			}) as never,
+	});
+	const activeContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		sessionManager: activeSession,
+	});
+	await activeMock.events.get("session_start")?.[0]?.({ reason: "startup" }, activeContext.ctx);
+	const statusSnapshot = [...activeContext.statuses];
+	await activeMock.commands.get("plan")?.handler("", activeContext.ctx);
+	assert.ok(startNew);
+	startNew();
+	assert.deepEqual(activeMock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(activeMock.entries.length, 0);
+	assert.deepEqual([...activeContext.statuses], statusSnapshot);
+});
+
+test("Plan releases only after exit, save, export, implementation handoff, and shutdown cleanup", async () => {
+	const exportRoot = await mkdtemp(join(tmpdir(), "pi-plan-mutex-release-"));
+	try {
+		for (const action of ["exit", "save", "export", "implement", "shutdown"] as const) {
+			const sessionManager = { getBranch: () => [], getEntries: () => [] };
+			const mock = createMockPi({ activeTools: ["read", "write"] });
+			planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+			const context = createMockContext({
+				mode: "tui",
+				hasUI: true,
+				cwd: exportRoot,
+				sessionManager,
+			});
+			await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+			await mock.commands.get("plan")?.handler("start", context.ctx);
+			if (action === "save" || action === "export" || action === "implement") {
+				const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as (
+					...args: unknown[]
+				) => Promise<unknown>;
+				await complete("call", { plan: `# ${action} plan` }, undefined, undefined, context.ctx);
+			}
+
+			if (action === "shutdown") {
+				await mock.events.get("session_shutdown")?.[0]?.({ reason: "quit" }, context.ctx);
+			} else if (action === "export") {
+				await mock.commands
+					.get("plan")
+					?.handler(`export ${join(exportRoot, `${action}.md`)}`, context.ctx);
+			} else {
+				await mock.commands.get("plan")?.handler(action, context.ctx);
+			}
+
+			const released = attempt(sessionManager);
+			mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, released);
+			assert.equal(released.busy, false, `${action} should release after cleanup`);
+			assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+		}
+	} finally {
+		await rm(exportRoot, { recursive: true, force: true });
+	}
+});
+
+test("fresh-session cancellation and pre-shutdown success preserve the source owner", async () => {
+	for (const cancelled of [true, false]) {
+		const sessionManager = {
+			getBranch: () => [],
+			getEntries: () => [],
+			getSessionFile: () => undefined,
+		};
+		const mock = createMockPi({ activeTools: ["read", "write"] });
+		let implementFresh: ((signal: AbortSignal) => Promise<void>) | undefined;
+		planMode(mock.pi, {
+			readSettings: async () => ({ kind: "missing" as const }),
+			loadInteractiveUi: async () =>
+				({
+					showPlanModeMenu: async (
+						_ctx: unknown,
+						options: { implementFresh(signal: AbortSignal): Promise<void> },
+					) => {
+						implementFresh = options.implementFresh;
+					},
+				}) as never,
+		});
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			sessionManager,
+			model: {},
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => ({ ok: true }),
+			},
+			waitForIdle: async () => undefined,
+			newSession: async () => ({ cancelled }),
+		});
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as (
+			...args: unknown[]
+		) => Promise<unknown>;
+		await complete("call", { plan: "# Ready plan" }, undefined, undefined, context.ctx);
+		await mock.commands.get("plan")?.handler("", context.ctx);
+		assert.ok(implementFresh);
+		await implementFresh(new AbortController().signal);
+
+		const beforeShutdown = attempt(sessionManager);
+		mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, beforeShutdown);
+		assert.equal(beforeShutdown.busy, true);
+		if (!cancelled) {
+			await mock.events.get("session_shutdown")?.[0]?.({ reason: "new" }, context.ctx);
+			const afterShutdown = attempt(sessionManager);
+			mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, afterShutdown);
+			assert.equal(afterShutdown.busy, false);
+		}
+	}
+});
+
+test("workflow mutex replacement and shutdown clear only the bound session", () => {
+	const mock = createMockPi();
+	const mutex = new WorkflowMutex(mock.pi);
+	const firstSession = {};
+	const secondSession = {};
+	mutex.bindSession(firstSession);
+	assert.ok(mutex.acquire());
+
+	mutex.bindSession(secondSession);
+	const firstAttempt = attempt(firstSession);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, firstAttempt);
+	assert.equal(firstAttempt.busy, false);
+	const secondOwner = mutex.acquire();
+	assert.ok(secondOwner);
+
+	mutex.unbindSession(firstSession);
+	assert.equal(mutex.isOwner(secondOwner), true);
+	mutex.unbindSession(secondSession);
+	const secondAttempt = attempt(secondSession);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, secondAttempt);
+	assert.equal(secondAttempt.busy, false);
+});


### PR DESCRIPTION
## Summary

- add a package-local Workflow Mutex Protocol v1 participant with session, generation, and owner guards
- centralize every inactive Plan activation behind one synchronous admission boundary
- retain ownership through Planning, ready review, revision, fresh-session preflight, and failed handoff rollback
- reject busy command, menu, selected-tool, shortcut, startup-flag, active-plan, and restore paths without workflow side effects
- release after Plan cleanup on exit, save, export, implementation handoff, replacement, and shutdown
- document standalone/cooperative behavior and record an independent minor release intent

## Verification

- `npm exec -- vitest run packages/pi-plan-mode/test/workflow-mutex.test.ts packages/pi-plan-mode/test/plan-mode.test.ts packages/pi-plan-mode/test/launch-menu.test.ts`
- `npm exec -- vitest run packages/pi-plan-mode/test` (18 files, 203 tests)
- `npm --workspace @narumitw/pi-plan-mode run build`
- generated-entry and `DefaultResourceLoader` tests
- `npm run check`
- `npm test` (400 files, 3,781 tests)
- `npm pack --workspace @narumitw/pi-plan-mode --dry-run --json`
- `npm run changeset:status` (`@narumitw/pi-plan-mode` -> `0.52.0` with current Changesets)

## Convention audit

- Factory/lifecycle: the listener registers synchronously without session work; session replacement, shutdown, delayed menus, questionnaires, exports, and fresh-session callbacks are stale-guarded and cleaned up.
- Commands/TUI: established routes and all four command modes remain covered; busy reporting is anonymous and mode-observable.
- Settings: schemas and writes are unchanged; session reads complete before final admission and are generation-checked after `await`.
- Package: no extension-to-extension import, dependency, identity, or control data was added; the generated runtime remains split and interactive UI stays lazy.
- README: required headings remain and protocol limits are documented.

The isolated Pi loading evidence is the package's Jiti `DefaultResourceLoader` test; no live provider smoke was used.
No publication, visibility, tag, workflow dispatch, or deprecation action was performed.
