### PR TITLE
feat(goal): coordinate agent workflows

### DIFF
--- a/.changeset/calm-goals-coordinate.md
+++ b/.changeset/calm-goals-coordinate.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-goal": minor
+---
+
+Coordinate automatically executable Goals through Workflow Mutex Protocol v1 and stop Goal-owned work immediately at terminal limits.

--- a/docs/roadmaps/2026-08-22_pi-plan-goal-coexistence-roadmap.md
+++ b/docs/roadmaps/2026-08-22_pi-plan-goal-coexistence-roadmap.md
@@ -102,7 +102,7 @@ This is an advisory mutex among participating extensions, not a Pi-enforced lock
 ### Phase 2: Make Plan and Goal participate
 
 - [ ] Every transition from inactive to a Plan mutex-holding state performs final admission after all asynchronous preflight and before any state, persistence, prompt, or tool mutation.
-- [ ] Every Goal activation path, including direct start, queue activation, resume, retry recovery, and restored automatic continuation, respects one documented mutex-ownership rule.
+- [ ] Every Goal activation path, including direct start, resume, retry recovery, and restored automatic continuation, respects one documented mutex-ownership rule; queue activation is not applicable because the focused Goal keeps legacy queued state inert.
 - [ ] Plan reports the mutex as busy while planning, ready, or revising, and releases it after implementation handoff, save, export-and-exit, discard, or exit.
 - [ ] Goal reports the mutex as busy for every state that can execute or resume automatically and releases it only after its existing terminal, stop, clear, or non-resumable transition.
 - [ ] An inactive Goal path that would widen active tools performs the same final busy check and defers its tool change while another workflow holds the group.

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -13,7 +13,7 @@ Goal mode adds explicit completion, blocker, and external-wait tools so managed 
 - Uses explicit `goal_complete`, `goal_blocked`, and `goal_wait` tools with stale-goal guards and evidence requirements.
 - Tracks active, paused, blocked, usage-limited, budget-limited, waiting, and complete outcomes separately.
 - Pauses after a configurable response limit or repeated no-progress runs and offers a guided review before continuing.
-- Supports optional token budgets and a single guarded wrap-up when the budget is exhausted.
+- Supports optional token budgets that stop Goal-owned work immediately when exhausted.
 - Persists the goal in the current session across reload, resume, compatible forks, and compaction.
 - Rejects stale continuations and tool calls after replacement, pause, completion, limits, or other terminal state changes.
 - Optionally exposes a default-off run protocol for trusted sibling extensions to start, observe, and cancel one Goal lifecycle.
@@ -80,7 +80,7 @@ Custom number inputs reject zero, negative numbers, decimals, text, and unsafe i
 Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime.
 A successful change updates the visible state immediately.
 A failed save restores the prior value and reports the settings path so it can be retried.
-Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy; retry after Pi settles.
+Tool-visibility changes that would alter the active tool schema are rejected while Pi is busy or another cooperative workflow owns the session; retry after both conditions clear.
 Escape returns to the previous screen without reverting changes that were already saved.
 
 `toolVisibility` accepts:
@@ -126,10 +126,35 @@ In the TUI, Goal Settings becomes a read-only summary that identifies the invali
 Reload Pi after changing the file.
 If a live runtime reloads settings, switching `toolVisibility` to `"always"` restores only the exact tools that pi-goal previously hid, while switching to `"after-first-goal"` locks a runtime that has no unfinished goal.
 
+Inactive tool widening first takes temporary Workflow Mutex ownership and leaves settings, hidden-tool ownership, and active tools unchanged when another workflow is active.
 Tool visibility is a baseline, not ownership of Pi's global active-tool list.
 Plan mode or another restrictive policy may temporarily hide the tools. pi-goal does not fight that policy on restore or on every turn: activation is rejected if the required terminal tools cannot be made available, and an already-active goal is paused without automatic continuation if they disappear.
 A restrictive allowlist created before `goal_wait` existed can still run ordinary Goals with `goal_complete` and `goal_blocked`, but the model cannot enter external waiting until that allowlist also includes `goal_wait`.
 The pause aborts a Goal-owned kickoff, resume, active-edit, or automatic-continuation prompt, but it does not cancel or stale-block an unrelated user or extension turn, including startup follow-ups after a restrictive restore.
+
+## 🤝 Workflow coexistence
+
+Goal is independently installable and keeps its standalone behavior when no other protocol participant is present.
+On the characterized Pi `0.84.2` runtime, it participates in the anonymous `workflow:mutex:v1` `agent-workflow` group.
+An active Goal holds the group through ordinary work, external waiting, continuation delivery, compaction recovery, and provider retry.
+Paused, blocked, usage-limited, budget-limited, complete, cleared, and legacy-queue-only states do not hold it.
+
+Direct starts, menu starts, managed-run starts, stopped resumes, and stopped-goal edits use one final synchronous admission after validation and confirmation but before tool, Goal-state, persistence, prompt, queue, or status mutation.
+Replacing or editing an already active or waiting Goal retains its current owner.
+If admission is busy, TUI and RPC show an anonymous warning, print and JSON direct routes throw before mutation, and managed-run RPC emits one terminal `ACTIVATION_FAILED` event without creating a Goal.
+
+Restored active Goal state acquires before tool restoration, persistence publication, status, wait timers, retry state, or continuation work.
+If restoration is busy, the Goal moves only to its existing paused safe state, does not change active tools or schedule work, and can be resumed explicitly after the other workflow ends.
+Restored stopped Goals and inert legacy queues do not acquire or schedule automatic work.
+
+Inactive session-start restoration and live settings changes that could alter Goal tool visibility use temporary synchronous ownership.
+A busy result preserves the settings file, in-memory settings, active tools, and hidden-tool retry ownership.
+An active Goal still pauses if a non-participating restrictive policy later removes its required terminal tools.
+
+The coexistence guarantee is cooperative and applies only when every contender implements v1 on the characterized Pi runtime and shares its event bus and session-manager identity.
+A pre-v1, mixed-version, non-participating, forked, or otherwise uncharacterized counterpart remains unsupported for mutual exclusion.
+Goal does not identify, inspect, configure, start, stop, or depend on another extension.
+The reciprocal minimum package versions will be documented only after both products pass the coexistence release matrix.
 
 ## 💬 Commands
 
@@ -159,14 +184,14 @@ Arrow keys navigate, Enter selects or submits, Escape goes Back, and Ctrl+C clos
   Existing direct routes remain immediate for compatibility and automation.
 - `/goal <goal_to_complete>` starts goal mode.
   If another unfinished goal exists, Pi asks for confirmation before replacing it with a new active goal and resetting its usage counters.
-  Failed kickoff delivery clears a new goal or restores the prior goal; a previously active goal is restored as paused.
+  Failed kickoff delivery clears a new goal or restores the exact prior Goal and tool-policy snapshot; a previously active or waiting Goal keeps its existing workflow ownership.
 - `/goal --tokens 100k <goal_to_complete>` starts or replaces goal mode with a token budget.
   `k` and `m` suffixes are accepted, for example `100k` or `1.5m`.
 - `/goal edit <goal_to_complete>` updates the existing goal objective without resetting usage counters.
   A successful active edit rotates the stale-turn guard and starts a fresh safety epoch.
   Paused, blocked, and usage-limited goals stay stopped and retain their safety state until resume.
   A budget-limited goal reactivates only when `edit --tokens` raises its budget above current usage.
-  Failed prompt delivery restores the exact previous safety counters/cause; it restores a budget-limited goal or restores and pauses a previously active goal.
+  Failed prompt delivery restores the exact previous Goal, guard id, safety counters, cause, tool-policy snapshot, and active ownership when applicable.
 - `/goal pause` stops prompt injection and auto-continuation, aborts the current turn, and keeps the goal for later resume.
   Only active goals can be paused.
 - `/goal resume` resumes a paused, blocked, usage-limited, or budget-limited goal when its token budget allows it, rotates the stale-turn guard id, resets the automatic-response/repeat safety epoch when the queued resume prompt starts, clears a safety-pause cause, and reports the new finite epoch or explicit Unlimited state.
@@ -196,7 +221,7 @@ Goal state is stored as Pi session state, similar to Codex's thread-owned goals.
 `/reload` and reopening the same Pi session can restore that session's unfinished goal.
 An active restored goal already at or above its finite automatic-work limit pauses before another provider request and reports that progress is saved; use `/goal` to review and continue.
 A restored waiting Goal remains quiet, excludes offline and waiting wall time from active elapsed time, and restores only its absolute optional deadline timer.
-With `"after-first-goal"`, an unfinished restore marks the tools unlocked in the new extension runtime, but it does not widen an active-tool set already restricted by an earlier lifecycle handler; an active goal instead restores as paused when either terminal tool is missing.
+With `"after-first-goal"`, an admitted unfinished restore marks the tools unlocked in the new extension runtime, but it does not widen an active-tool set already restricted by an earlier lifecycle handler; an active goal instead restores as paused when admission is busy or either terminal tool is missing.
 If no unfinished goal remains, a fresh runtime starts locked again.
 Active elapsed time is checkpointed before shutdown and restarted after reload only when the Goal is not waiting, so offline and stopped wall-clock time is excluded.
 Automatic-response counts, repeat fingerprints, and safety-pause causes persist across reload and compaction.
@@ -243,10 +268,10 @@ It does not add `reasoning` because reasoning is already part of output, or `cac
 Goal usage is the current branch's cumulative assistant total minus the baseline captured when the goal started, clamped at zero after branch rewinds.
 
 Provider usage becomes authoritative only when an assistant message finishes, so a budget can overshoot by one model call.
-When completed tool activity first exposes exhaustion, the goal transitions once to `budget_limited`, cancels continuation, and queues one bounded custom wrap-up instruction before the next model call.
-The instruction permits only a concise progress/results/blockers summary; a substantive tool attempt is blocked and aborts the remaining wrap-up.
-A rejected `goal_complete` also terminates the wrap-up, while accepted completion still requires existing evidence that proves every requirement—budget exhaustion itself never means completion.
-If exhaustion is first visible at `agent_end` and no turn remains, the extension stops without creating another model turn.
+When completed tool activity first exposes exhaustion, the goal transitions once to `budget_limited`, cancels continuation, recovery, waits, and stale Goal-owned work, aborts the current turn, and releases workflow ownership.
+It does not queue a summary or another model turn after budget exhaustion.
+Stale Goal tool calls remain blocked until an unrelated user or extension turn begins or the Goal is explicitly reactivated.
+A budget-limited Goal cannot call `goal_complete`; raise its budget above current usage and resume or edit it first.
 
 The default 25-response automatic-work limit is a response-count boundary, not a fixed cost ceiling: context size, cache pricing, output length, and provider rates vary, and the final capped response is still retained.
 Pi derives displayed cost estimates from provider-reported token usage and local model pricing; pi-goal does not query a billing balance or enforce a dollar cap.
@@ -268,7 +293,7 @@ This prompt wording is a behavioral guardrail, not proof by itself: `pi-goal` ca
 
 To finish, the agent must call `goal_complete` with the exact current `goal_id` and a `summary` of completion evidence.
 Missing or stale `goal_id` values are rejected before summary validation.
-Paused, blocked, and usage-limited goals cannot be completed until resumed; a budget-limited goal permits completion only during its bounded in-flight wrap-up.
+Paused, blocked, usage-limited, and budget-limited goals cannot be completed until resumed.
 The summary is completion evidence, not the stale-turn safety token.
 
 If a turn ends before completion, `pi-goal` records usage and creates one continuation intent unless a circuit breaker pauses it first.

--- a/packages/pi-goal/src/commands.ts
+++ b/packages/pi-goal/src/commands.ts
@@ -76,15 +76,19 @@ export class GoalCommandController {
 			}
 		}
 
-		// Unlock lazy visibility only for a real activation. In always mode, a
-		// missing tool means another policy or allowlist intentionally removed it.
+		// Unlock lazy visibility only after final workflow admission. In always mode,
+		// a missing tool means another policy or allowlist intentionally removed it.
 		if (isRequestCurrent && !isRequestCurrent()) return;
+		const retainedOwner = this.runtime.ownsWorkflow(existingGoal);
+		if (!this.runtime.acquireWorkflow(ctx.sessionManager)) return this.reportWorkflowBusy(ctx);
+		const acquiredForRequest = !retainedOwner;
 		const goalToolVisibilityBeforeActivation = this.runtime.toolPolicy.snapshot();
 		try {
 			this.runtime.toolPolicy.prepareActivation(this.runtime.settings.toolVisibility, ctx);
 		} catch (error) {
 			notifyTerminal(ctx.ui, `Cannot start /goal: ${formatError(error)}`, "error");
 			if (existingGoal?.status === "active") this.runtime.pauseGoalForUnavailableTools(ctx);
+			else if (acquiredForRequest) this.runtime.releaseWorkflow();
 			return;
 		}
 
@@ -100,7 +104,7 @@ export class GoalCommandController {
 		if (!legacyQueueBeforeActivation) this.runtime.persistGoal(startedGoal);
 		if (
 			this.runtime.activeGoal?.id !== startedGoal.id ||
-			this.runtime.activeGoal.status !== "active"
+			!this.runtime.ownsWorkflow(this.runtime.activeGoal)
 		) {
 			return;
 		}
@@ -135,12 +139,12 @@ export class GoalCommandController {
 						this.runtime.updateStatus(ctx, existingGoal);
 						this.runtime.restoreGoalWaitTimer(ctx);
 					} else if (existingGoal.status === "active") {
-						this.runtime.stopActiveGoal(ctx, {
-							kind: "activation_rollback",
-							expectedGoalId: startedGoal.id,
-							restoreGoal: existingGoal,
-							abortTurn: true,
-						});
+						this.runtime.activeGoal = existingGoal;
+						this.runtime.clearStaleGoalToolCallBlock();
+						this.runtime.persistGoal(existingGoal);
+						if (this.runtime.activeGoal?.id === existingGoal.id) {
+							this.runtime.updateStatus(ctx, existingGoal);
+						}
 					} else {
 						this.runtime.activeGoal = existingGoal;
 						if (blocksStaleGoalToolCalls(this.runtime.activeGoal.status)) {
@@ -160,17 +164,20 @@ export class GoalCommandController {
 					this.runtime.clearStaleGoalToolCallBlock();
 					ctx.ui.setStatus(STATUS_KEY, undefined);
 				} else {
-					this.runtime.clearActiveGoal(ctx);
+					this.runtime.clearActiveGoal(ctx, "goal activation rolled back", false);
 				}
 			}
 			if (rolledBackStartedGoal) {
 				this.runtime.toolPolicy.restore(goalToolVisibilityBeforeActivation);
+				if (acquiredForRequest && !this.runtime.ownsWorkflow(existingGoal)) {
+					this.runtime.releaseWorkflow();
+				}
 			}
 			return;
 		}
 		if (
 			this.runtime.activeGoal?.id !== startedGoal.id ||
-			this.runtime.activeGoal.status !== "active"
+			!this.runtime.ownsWorkflow(this.runtime.activeGoal)
 		) {
 			return;
 		}
@@ -238,11 +245,16 @@ export class GoalCommandController {
 			);
 			return;
 		}
+		if (!this.runtime.acquireWorkflow(ctx.sessionManager)) {
+			this.reportWorkflowBusy(ctx);
+			return;
+		}
 		const goalToolVisibilityBeforeActivation = this.runtime.toolPolicy.snapshot();
 		try {
 			this.runtime.toolPolicy.prepareActivation(this.runtime.settings.toolVisibility, ctx);
 		} catch (error) {
 			notifyTerminal(ctx.ui, `Cannot resume /goal: ${formatError(error)}`, "error");
+			this.runtime.releaseWorkflow();
 			return;
 		}
 		const stoppedGoal = this.runtime.activeGoal;
@@ -255,8 +267,9 @@ export class GoalCommandController {
 			transitionGoal(nextGoalInstance(this.runtime.activeGoal), "active"),
 		);
 		this.runtime.persistGoal(this.runtime.activeGoal);
-		this.runtime.updateStatus(ctx, this.runtime.activeGoal);
 		if (this.runtime.activeGoal.status !== "active") {
+			this.runtime.updateStatus(ctx, this.runtime.activeGoal);
+			this.runtime.releaseWorkflow();
 			notifyTerminal(
 				ctx.ui,
 				`Goal token budget is still reached: ${formatBudget(this.runtime.activeGoal)}`,
@@ -264,6 +277,8 @@ export class GoalCommandController {
 			);
 			return;
 		}
+		if (!this.runtime.ownsWorkflow(this.runtime.activeGoal)) return;
+		this.runtime.updateStatus(ctx, this.runtime.activeGoal);
 		const resumedGoal = this.runtime.activeGoal;
 		const sent = await this.runtime.sendOwnedGoalPrompt(
 			ctx,
@@ -282,9 +297,11 @@ export class GoalCommandController {
 					this.runtime.blockStaleGoalToolCalls();
 				}
 				this.runtime.toolPolicy.restore(goalToolVisibilityBeforeActivation);
+				this.runtime.releaseWorkflow();
 			}
 			return;
 		}
+		if (!this.runtime.ownsWorkflow(resumedGoal)) return;
 		const automaticLimit = this.runtime.settings.continuationLimits.automaticTurns;
 		notifyTerminal(
 			ctx.ui,
@@ -301,6 +318,10 @@ export class GoalCommandController {
 		const waitingGoal = this.runtime.activeGoal;
 		const waiting = waitingGoal?.waiting;
 		if (waitingGoal?.status !== "active" || !waiting) return;
+		if (!this.runtime.acquireWorkflow(ctx.sessionManager)) {
+			this.reportWorkflowBusy(ctx);
+			return;
+		}
 		try {
 			this.runtime.toolPolicy.prepareActivation(this.runtime.settings.toolVisibility, ctx);
 		} catch (error) {
@@ -323,6 +344,7 @@ export class GoalCommandController {
 			}
 			return;
 		}
+		if (!this.runtime.ownsWorkflow(resumedGoal)) return;
 		notifyTerminal(ctx.ui, `Goal resumed from waiting: ${waitingGoal.text}`, "info");
 	}
 
@@ -360,19 +382,54 @@ export class GoalCommandController {
 			return;
 		}
 
-		this.runtime.recordGoalUsage(this.runtime.activeGoal, ctx);
-		const previousGoal = { ...this.runtime.activeGoal };
+		const currentGoal = this.runtime.activeGoal;
+		const effectiveTokenBudget = tokenBudget ?? currentGoal.tokenBudget;
+		if (
+			currentGoal.status === "budget_limited" &&
+			effectiveTokenBudget !== undefined &&
+			effectiveTokenBudget <= currentGoal.tokensUsed
+		) {
+			notifyTerminal(
+				ctx.ui,
+				`Goal token budget is still reached: ${formatBudget(currentGoal)}. Raise the budget above current usage before editing.`,
+				"warning",
+			);
+			return;
+		}
+		const previousStatus = currentGoal.status;
+		const intendsActive = editedGoalStatus(previousStatus) === "active";
+		const retainedOwner = this.runtime.ownsWorkflow(currentGoal);
+		if (intendsActive && !this.runtime.acquireWorkflow(ctx.sessionManager)) {
+			this.reportWorkflowBusy(ctx);
+			return;
+		}
+		const acquiredForEdit = intendsActive && !retainedOwner;
+		const goalToolVisibilityBeforeActivation = intendsActive
+			? this.runtime.toolPolicy.snapshot()
+			: undefined;
+		if (intendsActive) {
+			try {
+				this.runtime.toolPolicy.prepareActivation(this.runtime.settings.toolVisibility, ctx);
+			} catch (error) {
+				notifyTerminal(ctx.ui, `Cannot reactivate /goal: ${formatError(error)}`, "error");
+				if (currentGoal.status === "active") this.runtime.pauseGoalForUnavailableTools(ctx);
+				else if (acquiredForEdit) this.runtime.releaseWorkflow();
+				return;
+			}
+		}
+
+		this.runtime.recordGoalUsage(currentGoal, ctx);
+		const previousGoal = { ...currentGoal };
 		this.runtime.clearGoalWaitTimer();
 		this.runtime.cancelContinuationWork();
 		this.runtime.clearGoalRecovery();
 		this.runtime.clearBudgetWrapUp();
-		const previousStatus = this.runtime.activeGoal.status;
-		const rotatedGoal = nextGoalInstance(this.runtime.activeGoal);
+		const rotatedGoal = nextGoalInstance(currentGoal);
 		const transitionedGoal = transitionGoal(
 			{
 				...rotatedGoal,
 				text: objective,
-				tokenBudget: tokenBudget ?? this.runtime.activeGoal.tokenBudget,
+				tokenBudget: effectiveTokenBudget,
 				waiting: undefined,
 			},
 			editedGoalStatus(previousStatus),
@@ -381,25 +438,13 @@ export class GoalCommandController {
 			transitionedGoal.status === "active"
 				? queueGoalSafetyReset(transitionedGoal)
 				: transitionedGoal;
-		const goalToolVisibilityBeforeActivation =
-			nextGoal.status === "active" ? this.runtime.toolPolicy.snapshot() : undefined;
-		if (nextGoal.status === "active") {
-			try {
-				this.runtime.toolPolicy.prepareActivation(this.runtime.settings.toolVisibility, ctx);
-			} catch (error) {
-				notifyTerminal(ctx.ui, `Cannot reactivate /goal: ${formatError(error)}`, "error");
-				if (this.runtime.activeGoal?.status === "active") {
-					this.runtime.pauseGoalForUnavailableTools(ctx);
-				}
-				return;
-			}
-		}
 		this.runtime.activeGoal = nextGoal;
 		this.runtime.persistGoal(this.runtime.activeGoal);
 		this.runtime.updateStatus(ctx, this.runtime.activeGoal);
 		const editedGoal = this.runtime.activeGoal;
 		if (!editedGoal) return;
 		if (editedGoal.status === "active") {
+			if (!this.runtime.ownsWorkflow(editedGoal)) return;
 			this.runtime.clearStaleGoalToolCallBlock();
 			const sent = await this.runtime.sendOwnedGoalPrompt(
 				ctx,
@@ -415,12 +460,12 @@ export class GoalCommandController {
 						this.runtime.updateStatus(ctx, previousGoal);
 						this.runtime.restoreGoalWaitTimer(ctx);
 					} else if (previousStatus === "active") {
-						this.runtime.stopActiveGoal(ctx, {
-							kind: "activation_rollback",
-							expectedGoalId: editedGoal.id,
-							restoreGoal: previousGoal,
-							abortTurn: true,
-						});
+						this.runtime.activeGoal = previousGoal;
+						this.runtime.clearStaleGoalToolCallBlock();
+						this.runtime.persistGoal(previousGoal);
+						if (this.runtime.activeGoal?.id === previousGoal.id) {
+							this.runtime.updateStatus(ctx, previousGoal);
+						}
 					} else {
 						this.runtime.activeGoal = previousGoal;
 						if (blocksStaleGoalToolCalls(this.runtime.activeGoal.status)) {
@@ -434,15 +479,29 @@ export class GoalCommandController {
 					if (goalToolVisibilityBeforeActivation) {
 						this.runtime.toolPolicy.restore(goalToolVisibilityBeforeActivation);
 					}
+					if (acquiredForEdit && previousStatus !== "active") {
+						this.runtime.releaseWorkflow();
+					}
 				}
 				return;
 			}
+			if (!this.runtime.ownsWorkflow(editedGoal)) return;
 		} else if (blocksStaleGoalToolCalls(editedGoal.status)) {
 			this.runtime.blockStaleGoalToolCalls();
 		} else {
 			this.runtime.clearStaleGoalToolCallBlock();
 		}
+		if (editedGoal.status !== "active" && (retainedOwner || acquiredForEdit)) {
+			this.runtime.releaseWorkflow();
+		}
 		notifyTerminal(ctx.ui, `Goal updated: ${objective}`, "info");
+	}
+
+	private reportWorkflowBusy(ctx: StatusContext) {
+		const message = "Another workflow is active in this session. End it before starting Goal.";
+		if (ctx.mode === "print" || ctx.mode === "json") throw new Error(message);
+		notifyTerminal(ctx.ui, message, "warning");
+		return { kind: "busy" as const };
 	}
 
 	showGoal(ctx: StatusContext) {

--- a/packages/pi-goal/src/lifecycle.ts
+++ b/packages/pi-goal/src/lifecycle.ts
@@ -18,6 +18,7 @@ import {
 	resetGoalSafetyEpoch,
 	STATUS_KEY,
 	type StatusContext,
+	transitionGoal,
 	truncateNotification,
 } from "./runtime.js";
 import { hasAssistantToolCall } from "./safety.js";
@@ -39,6 +40,7 @@ export function registerGoalLifecycle(
 	options: GoalLifecycleOptions = {},
 ) {
 	pi.on("session_start", async (_event, ctx) => {
+		runtime.bindWorkflowSession(ctx.sessionManager);
 		runtime.replaceMenuSession();
 		runtime.clearCompletionStatusTimer();
 		runtime.clearContinuationTracking();
@@ -54,9 +56,16 @@ export function registerGoalLifecycle(
 		runtime.clearTerminalDetails();
 		const previousToolVisibility = runtime.settings.toolVisibility;
 		const settingsResult = readGoalSettings(options.settingsPath);
+		const loaded = loadGoalStateFromSession(ctx);
 		runtime.settings =
 			settingsResult.kind === "loaded" ? settingsResult.settings : DEFAULT_GOAL_SETTINGS;
 		runtime.settingsLoadIssue = settingsResult.kind === "invalid" ? settingsResult : undefined;
+		runtime.activeGoal = undefined;
+		runtime.legacyQueueState = loaded.legacyQueueState;
+		runtime.legacyExperimentalGoalsSetting =
+			settingsResult.kind !== "invalid" && settingsResult.legacyExperimentalGoals;
+		runController.bindSession(ctx);
+
 		if (settingsResult.kind === "invalid") {
 			notifyTerminal(
 				ctx.ui,
@@ -64,64 +73,103 @@ export function registerGoalLifecycle(
 				"warning",
 			);
 		}
-		runtime.legacyExperimentalGoalsSetting =
-			settingsResult.kind !== "invalid" && settingsResult.legacyExperimentalGoals;
+		if (runtime.legacyExperimentalGoalsSetting && !runtime.legacyQueueState) {
+			notifyTerminal(ctx.ui, REMOVED_QUEUE_SETTING_WARNING, "warning");
+		}
+
+		if (loaded.goal?.status === "active") {
+			if (!runtime.acquireWorkflow()) {
+				runtime.activeGoal = transitionGoal(loaded.goal, "paused");
+				runtime.persistGoal(runtime.activeGoal);
+				runtime.updateStatus(ctx, runtime.activeGoal);
+				notifyTerminal(
+					ctx.ui,
+					"Goal was paused during restore because another workflow is active in this session. Resume it after the other workflow ends.",
+					"warning",
+				);
+				return;
+			}
+			runtime.activeGoal = loaded.goal;
+			try {
+				runtime.toolPolicy.prepareSessionStart(
+					runtime.settings.toolVisibility,
+					previousToolVisibility,
+				);
+			} catch (error) {
+				notifyTerminal(
+					ctx.ui,
+					`Could not restore always-visible goal tools: ${formatError(error)}`,
+					"error",
+				);
+			}
+			if (runtime.activeGoal.safetyResetPending) {
+				// Resume/edit activation is persisted before its owned prompt starts. A
+				// reload must commit that promised reset before enforcing the old limits.
+				runtime.activeGoal = resetGoalSafetyEpoch(runtime.activeGoal);
+			}
+			runtime.recordGoalUsage(runtime.activeGoal, ctx);
+			if (runtime.limitActiveGoalForBudget(ctx, false)) return;
+			if (runtime.enforceAutomaticTurnLimit(ctx, false) || runtime.enforceNoProgressLimit(ctx)) {
+				return;
+			}
+			// On lazy restore, an earlier restrictive session-start policy still wins:
+			// reconciliation unlocks ownership without widening the active tool set.
+			runtime.toolPolicy.reconcileRestoredState(runtime.settings.toolVisibility, true);
+			if (!runtime.toolPolicy.toolsAvailable()) {
+				runtime.pauseGoalForUnavailableTools(ctx, false);
+				return;
+			}
+			runtime.persistGoal(runtime.activeGoal);
+			if (!runtime.ownsWorkflow(runtime.activeGoal)) return;
+			runtime.updateStatus(ctx, runtime.activeGoal);
+			runtime.restoreGoalWaitTimer(ctx);
+			return;
+		}
+
+		runtime.activeGoal = loaded.goal;
+		let appliedInactivePolicy = false;
+		let inactivePolicyFailed = false;
 		try {
-			runtime.toolPolicy.prepareSessionStart(
-				runtime.settings.toolVisibility,
-				previousToolVisibility,
-			);
+			appliedInactivePolicy = runtime.withTemporaryWorkflowAccess(() => {
+				runtime.toolPolicy.prepareSessionStart(
+					runtime.settings.toolVisibility,
+					previousToolVisibility,
+				);
+				runtime.toolPolicy.reconcileRestoredState(
+					runtime.settings.toolVisibility,
+					runtime.activeGoal !== undefined && runtime.legacyQueueState === undefined,
+				);
+			});
 		} catch (error) {
+			inactivePolicyFailed = true;
 			notifyTerminal(
 				ctx.ui,
 				`Could not restore always-visible goal tools: ${formatError(error)}`,
 				"error",
 			);
 		}
-
-		const loaded = loadGoalStateFromSession(ctx);
-		runtime.activeGoal = loaded.goal;
-		runtime.legacyQueueState = loaded.legacyQueueState;
-		runController.bindSession(ctx);
+		if (!appliedInactivePolicy && !inactivePolicyFailed) {
+			notifyTerminal(
+				ctx.ui,
+				"Goal tool visibility was deferred because another workflow is active in this session.",
+				"warning",
+			);
+		}
 		if (runtime.legacyQueueState) {
-			runtime.toolPolicy.reconcileRestoredState(runtime.settings.toolVisibility, false);
 			ctx.ui.setStatus(STATUS_KEY, undefined);
 			notifyTerminal(ctx.ui, REMOVED_PERSISTED_QUEUE_WARNING, "warning");
 			return;
 		}
-		if (runtime.legacyExperimentalGoalsSetting) {
-			notifyTerminal(ctx.ui, REMOVED_QUEUE_SETTING_WARNING, "warning");
-		}
-
 		if (runtime.activeGoal) {
-			if (runtime.activeGoal.status === "active" && runtime.activeGoal.safetyResetPending) {
-				// Resume/edit activation is persisted before its owned prompt starts. A
-				// reload must commit that promised reset before enforcing the old limits.
-				runtime.activeGoal = resetGoalSafetyEpoch(runtime.activeGoal);
-			}
-			if (runtime.activeGoal.status === "active") {
-				runtime.recordGoalUsage(runtime.activeGoal, ctx);
-				if (runtime.limitActiveGoalForBudget(ctx, false)) return;
-				if (runtime.enforceAutomaticTurnLimit(ctx, false) || runtime.enforceNoProgressLimit(ctx))
-					return;
-			}
-			// On lazy restore, an earlier restrictive session-start policy still wins:
-			// reconciliation unlocks ownership without widening the active tool set.
-			runtime.toolPolicy.reconcileRestoredState(runtime.settings.toolVisibility, true);
-			if (runtime.activeGoal.status === "active" && !runtime.toolPolicy.toolsAvailable()) {
-				runtime.pauseGoalForUnavailableTools(ctx, false);
-				return;
-			}
 			runtime.persistGoal(runtime.activeGoal);
 			runtime.updateStatus(ctx, runtime.activeGoal);
-			runtime.restoreGoalWaitTimer(ctx);
 		} else {
-			runtime.toolPolicy.reconcileRestoredState(runtime.settings.toolVisibility, false);
 			ctx.ui.setStatus(STATUS_KEY, undefined);
 		}
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
+		const shutdownSession = ctx.sessionManager;
 		runController.unbindSession();
 		runtime.closeMenuSession();
 		runtime.clearGoalWaitTimer();
@@ -144,6 +192,8 @@ export function registerGoalLifecycle(
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		runtime.clearCompletionStatusTimer();
 		runtime.clearTerminalDetails();
+		runtime.releaseWorkflow();
+		runtime.unbindWorkflowSession(shutdownSession);
 	});
 
 	pi.on("session_before_compact", (event, ctx) => {
@@ -151,7 +201,9 @@ export function registerGoalLifecycle(
 			if ((event as { willRetry?: boolean }).willRetry === true) return { cancel: true as const };
 			return;
 		}
-		if (runtime.activeGoal?.status !== "active") return;
+		if (runtime.activeGoal?.status !== "active" || !runtime.ownsWorkflow(runtime.activeGoal)) {
+			return;
+		}
 		if (!runtime.recordGoalUsage(runtime.activeGoal, ctx)) return;
 		runtime.cancelContinuationWork();
 		runtime.persistGoal(runtime.activeGoal);
@@ -160,7 +212,7 @@ export function registerGoalLifecycle(
 	});
 
 	pi.on("session_compact", async (event, ctx) => {
-		if (runtime.activeGoal?.status !== "active") {
+		if (runtime.activeGoal?.status !== "active" || !runtime.ownsWorkflow(runtime.activeGoal)) {
 			runtime.clearGoalRecovery();
 			return;
 		}
@@ -264,7 +316,10 @@ export function registerGoalLifecycle(
 			}
 			return;
 		}
-		if (runtime.activeGoal?.id !== ownedPrompt.goalId || runtime.activeGoal.status !== "active") {
+		if (
+			runtime.activeGoal?.id !== ownedPrompt.goalId ||
+			!runtime.ownsWorkflow(runtime.activeGoal)
+		) {
 			return;
 		}
 		if (runtime.agentRunGoalId !== undefined && runtime.agentRunGoalId !== ownedPrompt.goalId) {
@@ -333,7 +388,9 @@ export function registerGoalLifecycle(
 			runtime.queueBudgetWrapUp(ctx, runtime.activeGoal);
 			return;
 		}
-		if (runtime.activeGoal?.status !== "active") return;
+		if (runtime.activeGoal?.status !== "active" || !runtime.ownsWorkflow(runtime.activeGoal)) {
+			return;
+		}
 
 		// AgentSession persists assistant message_end before tool execution events,
 		// so the completed assistant call's usage is authoritative at this boundary.
@@ -372,6 +429,12 @@ export function registerGoalLifecycle(
 			runtime.supersedeOwnedInputCollision(event.prompt);
 			if (runtime.activeGoal?.waiting) runtime.clearGoalWait(ctx, runtime.activeGoal.id);
 		}
+		if (runtime.activeGoal?.status === "active" && !runtime.ownsWorkflow(runtime.activeGoal)) {
+			runtime.cancelContinuationWork();
+			runtime.clearGoalRecovery();
+			abortCurrentTurn(ctx);
+			return;
+		}
 		const runOrigin = continuationGoalId
 			? "automatic"
 			: activeGoalRecovery && runtime.goalRecovery?.automaticOwner
@@ -389,7 +452,9 @@ export function registerGoalLifecycle(
 			abortCurrentTurn(ctx);
 			return;
 		}
-		if (runtime.activeGoal?.status !== "active") return;
+		if (runtime.activeGoal?.status !== "active" || !runtime.ownsWorkflow(runtime.activeGoal)) {
+			return;
+		}
 		runtime.beginAgentRun(runtime.activeGoal.id, runOrigin);
 		if (!runtime.toolPolicy.toolsAvailable()) {
 			runtime.pauseGoalForUnavailableTools(ctx, ownedPromptGoalId !== undefined);
@@ -445,7 +510,9 @@ export function registerGoalLifecycle(
 			runtime.clearBudgetWrapUp();
 			return;
 		}
-		if (runtime.activeGoal.status !== "active") return;
+		if (runtime.activeGoal.status !== "active" || !runtime.ownsWorkflow(runtime.activeGoal)) {
+			return;
+		}
 
 		const goalId = runtime.activeGoal.id;
 		const alreadyAwaitingContinuation = runtime.hasContinuationWorkForGoal(goalId);
@@ -517,6 +584,12 @@ export function registerGoalLifecycle(
 	});
 
 	pi.on("agent_settled", (_event, ctx) => {
+		if (runtime.activeGoal?.status === "active" && !runtime.ownsWorkflow(runtime.activeGoal)) {
+			runtime.cancelContinuationWork();
+			runtime.clearGoalRecovery();
+			runtime.clearSettledSafetyTracking();
+			return;
+		}
 		runtime.finalizeSettledRecovery(ctx);
 		const resumedWait = runtime.dispatchDueGoalWait(ctx);
 		if (!resumedWait) runtime.dispatchContinuationIfSettled(ctx);

--- a/packages/pi-goal/src/run-protocol.ts
+++ b/packages/pi-goal/src/run-protocol.ts
@@ -223,7 +223,7 @@ export class GoalRunController {
 		this.usedRunIds.add(runId);
 
 		try {
-			await this.commands.startGoal(
+			const activation = await this.commands.startGoal(
 				parsed.objective,
 				parsed.tokenBudget,
 				session.ctx,
@@ -232,6 +232,16 @@ export class GoalRunController {
 				},
 				() => this.ownsRun(run, session.generation),
 			);
+			if (activation?.kind === "busy" && this.ownsRun(run, session.generation)) {
+				this.closeCurrentRun();
+				this.emitError(
+					runId,
+					"start",
+					"ACTIVATION_FAILED",
+					"Another workflow is active in this session. End it before starting Goal.",
+				);
+				return;
+			}
 		} catch (error) {
 			if (this.ownsRun(run, session.generation)) {
 				this.closeCurrentRun();

--- a/packages/pi-goal/src/runtime.ts
+++ b/packages/pi-goal/src/runtime.ts
@@ -31,6 +31,7 @@ import {
 } from "./settings.js";
 import { GoalToolPolicy, type GoalToolVisibilitySnapshot } from "./tool-policy.js";
 import { type GoalWait, GoalWaitTimer } from "./wait.js";
+import { WorkflowMutex, type WorkflowMutexOwner } from "./workflow-mutex.js";
 
 export {
 	GOAL_BLOCKED_TOOL,
@@ -230,6 +231,9 @@ export class GoalRuntime {
 	guardAbortGoalId?: string;
 	staleGoalToolCallsBlocked = false;
 	readonly toolPolicy: GoalToolPolicy;
+	private readonly workflowMutex: WorkflowMutex;
+	private workflowOwner?: WorkflowMutexOwner;
+	private workflowSession?: object;
 	pendingGoalPromptMarkers = new Map<string, PendingGoalPrompt>();
 	claimedGoalPromptMarkers = new Map<string, string>();
 	cancelledGoalPromptMarkers = new Map<string, string>();
@@ -243,7 +247,67 @@ export class GoalRuntime {
 
 	constructor(pi: ExtensionAPI) {
 		this.pi = pi;
+		this.workflowMutex = new WorkflowMutex(pi);
 		this.toolPolicy = new GoalToolPolicy(pi);
+	}
+
+	bindWorkflowSession(session: object) {
+		this.workflowSession = session;
+		this.workflowOwner = undefined;
+		this.workflowMutex.bindSession(session);
+	}
+
+	unbindWorkflowSession(session: object) {
+		if (this.workflowSession !== session) return;
+		this.workflowMutex.unbindSession(session);
+		this.workflowOwner = undefined;
+		this.workflowSession = undefined;
+	}
+
+	acquireWorkflow(session?: unknown) {
+		if (session && typeof session === "object" && this.workflowSession !== session) {
+			this.bindWorkflowSession(session);
+		}
+		if (this.workflowMutex.isOwner(this.workflowOwner)) return true;
+		const owner = this.workflowMutex.acquire();
+		if (!owner) return false;
+		this.workflowOwner = owner;
+		return true;
+	}
+
+	ownsWorkflow(goal: ActiveGoal | undefined = this.activeGoal) {
+		return goal?.status === "active" && this.workflowMutex.isOwner(this.workflowOwner);
+	}
+
+	releaseWorkflow() {
+		const owner = this.workflowOwner;
+		this.workflowMutex.release(owner);
+		if (!this.workflowMutex.isOwner(owner)) this.workflowOwner = undefined;
+	}
+
+	beginTemporaryWorkflowAccess(session?: unknown) {
+		if (session && typeof session === "object" && this.workflowSession !== session) {
+			this.bindWorkflowSession(session);
+		}
+		const alreadyOwned = this.workflowMutex.isOwner(this.workflowOwner);
+		if (!alreadyOwned && !this.acquireWorkflow()) return undefined;
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			if (!alreadyOwned) this.releaseWorkflow();
+		};
+	}
+
+	withTemporaryWorkflowAccess(action: () => void, session?: unknown) {
+		const release = this.beginTemporaryWorkflowAccess(session);
+		if (!release) return false;
+		try {
+			action();
+			return true;
+		} finally {
+			release();
+		}
 	}
 
 	hasLegacyQueueInterface() {
@@ -344,6 +408,7 @@ export class GoalRuntime {
 	}
 
 	requestContinuation(goal: ActiveGoal) {
+		if (!this.ownsWorkflow(goal)) return false;
 		if (goal.waiting || this.hasContinuationWorkForGoal(goal.id)) return false;
 		const marker = continuationMarker(goal);
 		this.continuationIntent = {
@@ -357,6 +422,10 @@ export class GoalRuntime {
 
 	dispatchContinuationIfSettled(ctx: StatusContext) {
 		const intent = this.continuationIntent;
+		if (!this.ownsWorkflow()) {
+			this.cancelContinuationWork();
+			return false;
+		}
 		if (!intent) return false;
 		if (this.activeGoal?.status === "active" && !this.toolPolicy.toolsAvailable()) {
 			this.pauseGoalForUnavailableTools(ctx);
@@ -402,7 +471,7 @@ export class GoalRuntime {
 
 	enterGoalWait(ctx: StatusContext, goalId: string, waiting: GoalWait) {
 		const goal = this.activeGoal;
-		if (!goal || goal.id !== goalId || goal.status !== "active") return undefined;
+		if (!goal || goal.id !== goalId || !this.ownsWorkflow(goal)) return undefined;
 		this.recordGoalUsage(goal, ctx, false);
 		this.cancelContinuationWork();
 		this.clearGoalRecoveryForGoal(goal.id);
@@ -421,7 +490,7 @@ export class GoalRuntime {
 
 	clearGoalWait(ctx: StatusContext, goalId: string) {
 		const goal = this.activeGoal;
-		if (!goal || goal.id !== goalId || goal.status !== "active" || !goal.waiting) return false;
+		if (!goal || goal.id !== goalId || !this.ownsWorkflow(goal) || !goal.waiting) return false;
 		this.clearGoalWaitTimer();
 		const { waiting: _waiting, ...nextGoal } = goal;
 		const now = Date.now();
@@ -436,6 +505,7 @@ export class GoalRuntime {
 	restoreGoalWaitTimer(ctx: StatusContext) {
 		this.clearGoalWaitTimer();
 		const goal = this.activeGoal;
+		if (!this.ownsWorkflow(goal)) return false;
 		const resumeAt = goal?.status === "active" ? goal.waiting?.resumeAt : undefined;
 		if (!goal || resumeAt === undefined) return false;
 		this.scheduleGoalWaitTimer(ctx, goal.id, resumeAt);
@@ -444,6 +514,7 @@ export class GoalRuntime {
 
 	dispatchDueGoalWait(ctx: StatusContext) {
 		const goal = this.activeGoal;
+		if (!this.ownsWorkflow(goal)) return false;
 		const waiting = goal?.status === "active" ? goal.waiting : undefined;
 		const resumeAt = waiting?.resumeAt;
 		if (!goal || !waiting || resumeAt === undefined) return false;
@@ -480,7 +551,13 @@ export class GoalRuntime {
 	private scheduleGoalWaitTimer(ctx: StatusContext, goalId: string, wakeAt: number) {
 		const generation = this.menuGeneration;
 		this.goalWaitTimer.schedule(wakeAt, () => {
-			if (generation !== this.menuGeneration || this.activeGoal?.id !== goalId) return;
+			if (
+				generation !== this.menuGeneration ||
+				this.activeGoal?.id !== goalId ||
+				!this.ownsWorkflow(this.activeGoal)
+			) {
+				return;
+			}
 			try {
 				this.dispatchDueGoalWait(ctx);
 			} catch (error) {
@@ -550,6 +627,8 @@ export class GoalRuntime {
 				this.cancelContinuationWork();
 				this.clearGoalRecoveryForGoal(goal.id);
 				this.clearBudgetWrapUp();
+				this.blockStaleGoalToolCalls();
+				abortCurrentTurn(ctx);
 				status = "budget_limited";
 				terminalReason = request.reason;
 				break;
@@ -618,6 +697,7 @@ export class GoalRuntime {
 		this.persistGoal(stoppedGoal);
 		if (this.activeGoal?.id === stoppedGoal.id && this.activeGoal.status === stoppedGoal.status) {
 			this.updateStatus(ctx, stoppedGoal);
+			this.releaseWorkflow();
 		}
 		return stoppedGoal;
 	}
@@ -676,6 +756,7 @@ export class GoalRuntime {
 	}
 
 	queueBudgetWrapUp(ctx: StatusContext, goal: ActiveGoal) {
+		if (!this.ownsWorkflow(goal)) return false;
 		if (!this.budgetWrapUp || this.budgetWrapUp.goalId !== goal.id) {
 			this.budgetWrapUp = { goalId: goal.id, delivered: false };
 		}
@@ -872,9 +953,15 @@ export class GoalRuntime {
 		resetSafetyEpoch = true,
 		isCurrent?: () => boolean,
 	) {
+		if (this.activeGoal?.id !== goalId || !this.ownsWorkflow(this.activeGoal)) return false;
 		const pending = this.rememberPendingGoalPrompt(goalId, prompt, resetSafetyEpoch);
 		const sent = await sendPrompt(this.pi, ctx, pending.prompt, isCurrent);
-		if (!sent || (isCurrent && !isCurrent())) {
+		if (
+			!sent ||
+			(isCurrent && !isCurrent()) ||
+			this.activeGoal?.id !== goalId ||
+			!this.ownsWorkflow(this.activeGoal)
+		) {
 			this.pendingGoalPromptMarkers.delete(pending.marker);
 			return false;
 		}
@@ -898,7 +985,7 @@ export class GoalRuntime {
 			if (
 				generation !== this.menuGeneration ||
 				this.activeGoal?.id !== goalId ||
-				this.activeGoal.status !== "active"
+				!this.ownsWorkflow(this.activeGoal)
 			) {
 				return;
 			}
@@ -1113,7 +1200,7 @@ export class GoalRuntime {
 		clearLegacyPersistedGoal(cwd);
 	}
 
-	clearActiveGoal(ctx: StatusContext, reason = "goal cleared") {
+	clearActiveGoal(ctx: StatusContext, reason = "goal cleared", releaseWorkflow = true) {
 		const clearedGoal = this.activeGoal;
 		this.clearGoalWaitTimer();
 		this.cancelContinuationWork();
@@ -1124,6 +1211,7 @@ export class GoalRuntime {
 		this.legacyQueueState = undefined;
 		this.clearPersistedGoal(ctx.cwd, clearedGoal, reason);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
+		if (releaseWorkflow) this.releaseWorkflow();
 		// Do not relock toolPolicy: after first activation, keep tools visible for the
 		// rest of this extension runtime to avoid repeated tool-schema churn.
 	}
@@ -1151,6 +1239,9 @@ export class GoalRuntime {
 	}
 
 	restoreSettingsApplicationState(snapshot: GoalSettingsRuntimeSnapshot) {
+		if (snapshot.activeGoal?.status === "active" && !this.acquireWorkflow()) {
+			throw new Error("another workflow became active before Goal settings could roll back");
+		}
 		this.settings = structuredClone(snapshot.settings);
 		this.activeGoal = snapshot.activeGoal ? structuredClone(snapshot.activeGoal) : undefined;
 		this.legacyQueueState = snapshot.legacyQueueState
@@ -1408,11 +1499,16 @@ export function abortCurrentTurn(ctx: StatusContext) {
 }
 
 export function blocksStaleGoalToolCalls(status: GoalStatus) {
-	return status === "paused" || status === "blocked" || status === "usage_limited";
+	return (
+		status === "paused" ||
+		status === "blocked" ||
+		status === "usage_limited" ||
+		status === "budget_limited"
+	);
 }
 
 export function isResumableGoalStatus(status: GoalStatus) {
-	return blocksStaleGoalToolCalls(status) || status === "budget_limited";
+	return blocksStaleGoalToolCalls(status);
 }
 
 export function stoppedStatusLabel(status: GoalStatus) {

--- a/packages/pi-goal/src/settings-ui.ts
+++ b/packages/pi-goal/src/settings-ui.ts
@@ -19,6 +19,8 @@ interface GoalSettingsApplyOptions {
 	save?: (settings: GoalSettings) => void;
 }
 
+class WorkflowBusyError extends Error {}
+
 type LimitField = "automaticTurns" | "noProgressTurns";
 type LimitSelection = "unlimited" | "default" | "custom" | "off";
 export async function showGoalSettings(
@@ -324,45 +326,59 @@ export function applyGoalSettings(
 	options: GoalSettingsApplyOptions = {},
 ) {
 	const snapshot = runtime.snapshotSettingsApplicationState();
+	const visibilityChanges = snapshot.settings.toolVisibility !== next.toolVisibility;
+	const releaseWorkflow = visibilityChanges
+		? runtime.beginTemporaryWorkflowAccess(ctx.sessionManager)
+		: () => undefined;
+	if (!releaseWorkflow) {
+		throw new WorkflowBusyError(
+			"Another workflow is active in this session. Goal tool visibility was not changed.",
+		);
+	}
+
 	let fileSaved = false;
 	try {
-		runtime.settings = structuredClone(next);
-		applyToolVisibility(runtime, snapshot.settings, next, ctx);
-		options.save?.(next);
-		fileSaved = options.save !== undefined;
-		const activeGoalId = runtime.activeGoal?.id;
-		const abortOwnedRun = activeGoalId !== undefined && runtime.agentRunGoalId === activeGoalId;
-		const pausedByAutomaticLimit = runtime.enforceAutomaticTurnLimit(ctx, abortOwnedRun);
-		if (!pausedByAutomaticLimit) runtime.enforceNoProgressLimit(ctx, abortOwnedRun);
-		if (runtime.activeGoal) {
-			runtime.updateStatus(ctx, runtime.activeGoal);
-		}
-	} catch (error) {
-		const rollbackErrors: unknown[] = [];
 		try {
-			runtime.restoreSettingsApplicationState(snapshot);
-		} catch (rollbackError) {
-			rollbackErrors.push(rollbackError);
-		}
-		if (fileSaved) {
+			applyToolVisibility(runtime, snapshot.settings, next, ctx);
+			runtime.settings = structuredClone(next);
+			options.save?.(next);
+			fileSaved = options.save !== undefined;
+			const activeGoalId = runtime.activeGoal?.id;
+			const abortOwnedRun = activeGoalId !== undefined && runtime.agentRunGoalId === activeGoalId;
+			const pausedByAutomaticLimit = runtime.enforceAutomaticTurnLimit(ctx, abortOwnedRun);
+			if (!pausedByAutomaticLimit) runtime.enforceNoProgressLimit(ctx, abortOwnedRun);
+			if (runtime.activeGoal) {
+				runtime.updateStatus(ctx, runtime.activeGoal);
+			}
+		} catch (error) {
+			const rollbackErrors: unknown[] = [];
 			try {
-				options.save?.(snapshot.settings);
+				runtime.restoreSettingsApplicationState(snapshot);
 			} catch (rollbackError) {
 				rollbackErrors.push(rollbackError);
 			}
-			try {
-				restorePersistedRuntime(runtime, ctx);
-			} catch (rollbackError) {
-				rollbackErrors.push(rollbackError);
+			if (fileSaved) {
+				try {
+					options.save?.(snapshot.settings);
+				} catch (rollbackError) {
+					rollbackErrors.push(rollbackError);
+				}
+				try {
+					restorePersistedRuntime(runtime, ctx);
+				} catch (rollbackError) {
+					rollbackErrors.push(rollbackError);
+				}
 			}
+			if (rollbackErrors.length > 0) {
+				throw new AggregateError(
+					[error, ...rollbackErrors],
+					`pi-goal settings application failed and rollback was incomplete: ${formatError(error)}`,
+				);
+			}
+			throw error;
 		}
-		if (rollbackErrors.length > 0) {
-			throw new AggregateError(
-				[error, ...rollbackErrors],
-				`pi-goal settings application failed and rollback was incomplete: ${formatError(error)}`,
-			);
-		}
-		throw error;
+	} finally {
+		releaseWorkflow();
 	}
 }
 
@@ -424,6 +440,7 @@ function applyToolVisibility(
 	next: GoalSettings,
 	ctx: ExtensionCommandContext,
 ) {
+	if (previous.toolVisibility === next.toolVisibility) return;
 	runtime.toolPolicy.applyVisibilityChange(
 		previous.toolVisibility,
 		next.toolVisibility,

--- a/packages/pi-goal/src/tool-policy.ts
+++ b/packages/pi-goal/src/tool-policy.ts
@@ -94,6 +94,8 @@ export class GoalToolPolicy {
 			this.reveal();
 			return;
 		}
+		if (this.hasHiddenTools()) this.restoreHidden();
+		this.unlock();
 		this.assertAvailable();
 	}
 

--- a/packages/pi-goal/src/tools.ts
+++ b/packages/pi-goal/src/tools.ts
@@ -100,6 +100,14 @@ export function registerGoalTools(pi: ExtensionAPI, runtime: GoalRuntime) {
 				};
 			}
 			const completingDuringBudgetWrapUp = runtime.hasActiveBudgetWrapUp();
+			if (completedGoal.status === "active" && !runtime.ownsWorkflow(completedGoal)) {
+				const rejection = "Goal completion rejected: active Goal no longer owns its workflow.";
+				notifyTerminal(ctx.ui, rejection, "warning");
+				return {
+					content: toolContent(rejection),
+					details: completionDetails(goal, requestedGoalId, summary),
+				};
+			}
 			if (!runtime.canRecordGoalUsage() && !completingDuringBudgetWrapUp) {
 				const rejection = "Goal completion rejected: current run does not own the active goal.";
 				notifyTerminal(ctx.ui, rejection, "warning");
@@ -237,6 +245,8 @@ export function registerGoalTools(pi: ExtensionAPI, runtime: GoalRuntime) {
 			if (blockedGoal.status !== "active") {
 				return reject(`goal is ${blockedGoal.status}, not active`);
 			}
+			if (!runtime.ownsWorkflow(blockedGoal))
+				return reject("active Goal no longer owns its workflow");
 			if (!reason) return reject("reason is empty");
 			if (reason.length > MAX_BLOCKER_REASON_LENGTH) return reject("reason is too long");
 			if (!evidence) return reject("evidence is empty");
@@ -317,6 +327,8 @@ export function registerGoalTools(pi: ExtensionAPI, runtime: GoalRuntime) {
 			if (activeGoal.status !== "active") {
 				return reject(`goal is ${activeGoal.status}, not active`);
 			}
+			if (!runtime.ownsWorkflow(activeGoal))
+				return reject("active Goal no longer owns its workflow");
 			if (activeGoal.waiting) return reject("goal is already waiting");
 			if (!reason) return reject("reason is empty");
 			if (reason.length > MAX_GOAL_WAIT_REASON_LENGTH) return reject("reason is too long");

--- a/packages/pi-goal/src/workflow-mutex.ts
+++ b/packages/pi-goal/src/workflow-mutex.ts
@@ -1,0 +1,89 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export const WORKFLOW_MUTEX_CHANNEL = "workflow:mutex:v1";
+export const AGENT_WORKFLOW_GROUP = "agent-workflow";
+
+export type WorkflowMutexOwner = symbol;
+
+interface WorkflowMutexAttemptV1 {
+	session: object;
+	group: string;
+	busy: boolean;
+}
+
+export class WorkflowMutex {
+	private session: object | undefined;
+	private readonly heldGroups = new Map<string, WorkflowMutexOwner>();
+	private generation = 0;
+	private readonly pi: Pick<ExtensionAPI, "events">;
+
+	constructor(pi: Pick<ExtensionAPI, "events">) {
+		this.pi = pi;
+		pi.events.on(WORKFLOW_MUTEX_CHANNEL, (payload) => {
+			this.answer(payload);
+		});
+	}
+
+	bindSession(session: object): void {
+		this.generation += 1;
+		this.heldGroups.clear();
+		this.session = session;
+	}
+
+	unbindSession(session: object): void {
+		if (this.session !== session) return;
+		this.generation += 1;
+		this.heldGroups.clear();
+		this.session = undefined;
+	}
+
+	acquire(group = AGENT_WORKFLOW_GROUP): WorkflowMutexOwner | undefined {
+		const session = this.session;
+		const generation = this.generation;
+		if (!session || this.heldGroups.has(group)) return undefined;
+
+		const attempt: WorkflowMutexAttemptV1 = { session, group, busy: false };
+		try {
+			this.pi.events.emit(WORKFLOW_MUTEX_CHANNEL, attempt);
+		} catch {
+			return undefined;
+		}
+		if (
+			this.session !== session ||
+			this.generation !== generation ||
+			attempt.session !== session ||
+			attempt.group !== group ||
+			attempt.busy !== false ||
+			this.heldGroups.has(group)
+		) {
+			return undefined;
+		}
+
+		const owner = Symbol(group);
+		this.heldGroups.set(group, owner);
+		return owner;
+	}
+
+	isOwner(owner: WorkflowMutexOwner | undefined, group = AGENT_WORKFLOW_GROUP): boolean {
+		return owner !== undefined && this.heldGroups.get(group) === owner;
+	}
+
+	release(owner: WorkflowMutexOwner | undefined, group = AGENT_WORKFLOW_GROUP): void {
+		if (!this.isOwner(owner, group)) return;
+		this.heldGroups.delete(group);
+	}
+
+	private answer(payload: unknown): void {
+		try {
+			if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return;
+			const attempt = payload as Partial<WorkflowMutexAttemptV1>;
+			if (attempt.session !== this.session) return;
+			if (attempt.group !== AGENT_WORKFLOW_GROUP) return;
+			if (typeof attempt.busy !== "boolean") return;
+			if (!this.heldGroups.has(attempt.group)) return;
+			attempt.busy = true;
+		} catch {
+			// Protocol listeners must ignore unusual objects without interrupting sibling listeners.
+		}
+	}
+}

--- a/packages/pi-goal/test/generated-entry.test.ts
+++ b/packages/pi-goal/test/generated-entry.test.ts
@@ -24,8 +24,28 @@ test("declared generated entry preserves registration and partial lifecycle clea
 		assert.ok(mock.commands.has("goal"));
 		assert.ok(mock.events.has("session_start"));
 		assert.ok(mock.events.has("session_shutdown"));
-		const context = createMockContext({ mode: "tui", cwd: root });
+		const sessionManager = {
+			getSessionId: () => "generated-goal-session",
+			getSessionName: () => undefined,
+			getBranch: () => [],
+			getEntries: () => [],
+		};
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			cwd: root,
+			sessionManager,
+		});
+		await emit(mock.events, "session_start", { reason: "startup" }, context.ctx);
+		await mock.commands.get("goal")?.handler("generated goal", context.ctx);
+		const activeAttempt = { session: sessionManager, group: "agent-workflow", busy: false };
+		mock.eventBus.emit("workflow:mutex:v1", activeAttempt);
+		assert.equal(activeAttempt.busy, true);
+
 		await emit(mock.events, "session_shutdown", { reason: "quit" }, context.ctx);
+		const releasedAttempt = { ...activeAttempt, busy: false };
+		mock.eventBus.emit("workflow:mutex:v1", releasedAttempt);
+		assert.equal(releasedAttempt.busy, false);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/packages/pi-goal/test/goal-budget-lifecycle.test.ts
+++ b/packages/pi-goal/test/goal-budget-lifecycle.test.ts
@@ -36,7 +36,7 @@ test("tool_execution_end pauses a goal before another turn when terminal tools d
 	);
 });
 
-test("tool_execution_end enforces budget once and injects one bounded wrap-up", async () => {
+test("tool_execution_end stops budget work, blocks stale tools, and releases the workflow", async () => {
 	const branch: Array<Record<string, unknown>> = [];
 	let aborts = 0;
 	const budgeted = await startGoalForTest(
@@ -62,21 +62,7 @@ test("tool_execution_end enforces budget once and injects one bounded wrap-up", 
 	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
 	assert.equal(requireLastGoal(budgeted.mock).tokensUsed, 12);
 	assert.equal(budgeted.statuses.get("goal"), "budget 12/10 · automatic 0/25");
-	assert.equal(budgeted.mock.sentMessages.length, 1);
-	const wrapUp = budgeted.mock.sentMessages[0];
-	assert.ok(wrapUp);
-	assert.deepEqual(wrapUp.options, { deliverAs: "steer" });
-	const wrapUpMessage = wrapUp.message as { customType?: string; content?: string };
-	assert.equal(wrapUpMessage.customType, "goal-budget-wrap-up");
-	assert.match(String(wrapUpMessage.content), /stop substantive work/i);
-	assert.match(String(wrapUpMessage.content), /do not call substantive tools/i);
-	assert.match(String(wrapUpMessage.content), /summarize progress/i);
-	assert.match(String(wrapUpMessage.content), /goal_complete.*evidence/i);
-	assert.match(String(wrapUpMessage.content), /completion as unproven/i);
-	assert.match(String(wrapUpMessage.content), /weak, indirect, or missing evidence/i);
-	assert.match(String(wrapUpMessage.content), /budget exhaustion.*not completion/i);
-	assert.ok(String(wrapUpMessage.content).length < 1_000);
-
+	assert.equal(budgeted.mock.sentMessages.length, 0);
 	await budgeted.mock.events.get("agent_settled")?.[0]?.({}, budgeted.ctx);
 	assert.equal(budgeted.mock.sentUserMessages.length, 1);
 	assert.deepEqual(
@@ -84,20 +70,9 @@ test("tool_execution_end enforces budget once and injects one bounded wrap-up", 
 			{ toolName: "bash", toolCallId: "substantive-after-budget", input: {} },
 			budgeted.ctx,
 		),
-		{
-			block: true,
-			reason: "Goal token budget is exhausted; only goal_complete is allowed during wrap-up.",
-		},
+		{ block: true, reason: STALE_GOAL_TOOL_REASON },
 	);
-	assert.equal(aborts, 1);
-	assert.equal(
-		budgeted.mock.events.get("tool_call")?.[0]?.(
-			{ toolName: "goal_complete", toolCallId: "complete-after-budget", input: {} },
-			budgeted.ctx,
-		),
-		undefined,
-	);
-
+	assert.equal(aborts, 2);
 	const completion = await requireGoalTool(budgeted.mock, "goal_complete").execute(
 		"complete-after-budget",
 		{ goal_id: goalId, summary: "All requirements were already implemented and verified." },
@@ -105,11 +80,18 @@ test("tool_execution_end enforces budget once and injects one bounded wrap-up", 
 		() => undefined,
 		budgeted.ctx,
 	);
-	assert.equal(completion.terminate, true);
-	assert.equal(lastGoalStatus(budgeted.mock), null);
+	assert.equal(completion.terminate, undefined);
+	assert.match(completion.content?.[0]?.text ?? "", /budget_limited, not active/i);
+	const released = {
+		session: (budgeted.ctx as unknown as { sessionManager: object }).sessionManager,
+		group: "agent-workflow",
+		busy: false,
+	};
+	budgeted.mock.eventBus.emit("workflow:mutex:v1", released);
+	assert.equal(released.busy, false);
 });
 
-test("rejected completion closes a budget wrap-up without another model call", async () => {
+test("rejected completion cannot revive a budget-limited goal", async () => {
 	const branch: Array<Record<string, unknown>> = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
@@ -129,7 +111,7 @@ test("rejected completion closes a budget wrap-up without another model call", a
 		() => undefined,
 		budgeted.ctx,
 	);
-	assert.equal(rejected.terminate, true);
+	assert.equal(rejected.terminate, undefined);
 	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
 
 	const retry = await requireGoalTool(budgeted.mock, "goal_complete").execute(
@@ -143,7 +125,7 @@ test("rejected completion closes a budget wrap-up without another model call", a
 	assert.match(retry.content?.[0]?.text ?? "", /budget_limited, not active/i);
 });
 
-test("stale completion also closes a budget wrap-up after recording final usage", async () => {
+test("stale completion cannot revive a budget-limited goal", async () => {
 	const branch: Array<Record<string, unknown>> = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
@@ -164,9 +146,9 @@ test("stale completion also closes a budget wrap-up after recording final usage"
 		() => undefined,
 		budgeted.ctx,
 	);
-	assert.equal(rejected.terminate, true);
+	assert.equal(rejected.terminate, undefined);
 	assert.match(rejected.content?.[0]?.text ?? "", /goal_id does not match/i);
-	assert.equal(requireLastGoal(budgeted.mock).tokensUsed, 15);
+	assert.equal(requireLastGoal(budgeted.mock).tokensUsed, 12);
 
 	const retry = await requireGoalTool(budgeted.mock, "goal_complete").execute(
 		"retry-after-stale-budget-completion",
@@ -178,7 +160,7 @@ test("stale completion also closes a budget wrap-up after recording final usage"
 	assert.match(retry.content?.[0]?.text ?? "", /budget_limited, not active/i);
 });
 
-test("failed budget wrap-up delivery retries once without duplicate accepted messages", async () => {
+test("budget exhaustion never queues or retries a follow-up wrap-up", async () => {
 	const branch: Array<Record<string, unknown>> = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
@@ -200,7 +182,7 @@ test("failed budget wrap-up delivery retries once without duplicate accepted mes
 	);
 	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
 	assert.equal(budgeted.mock.sentMessages.length, 0);
-	assert.match(budgeted.notifications.at(-1)?.message ?? "", /queue unavailable/i);
+	assert.match(budgeted.notifications.at(-1)?.message ?? "", /token budget reached/i);
 
 	await toolEnd?.(
 		{ toolCallId: "tool-2", toolName: "read", result: {}, isError: false },
@@ -210,8 +192,8 @@ test("failed budget wrap-up delivery retries once without duplicate accepted mes
 		{ toolCallId: "tool-3", toolName: "read", result: {}, isError: false },
 		budgeted.ctx,
 	);
-	assert.equal(attempts, 2);
-	assert.equal(budgeted.mock.sentMessages.length, 1);
+	assert.equal(attempts, 0);
+	assert.equal(budgeted.mock.sentMessages.length, 0);
 });
 
 test("budget wrap-up permission closes at agent_end and stale context is filtered", async () => {
@@ -253,7 +235,7 @@ test("budget wrap-up permission closes at agent_end and stale context is filtere
 	assert.deepEqual(contextResult?.messages, [{ role: "user", content: "keep" }]);
 });
 
-test("budget wrap-up does not consume a pending transformed follow-up", async () => {
+test("budget stop preserves a pending transformed follow-up without resuming Goal work", async () => {
 	const branch: Array<Record<string, unknown>> = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
@@ -275,34 +257,25 @@ test("budget wrap-up does not consume a pending transformed follow-up", async ()
 		budgeted.ctx,
 	);
 
-	assert.deepEqual(
-		budgeted.mock.events.get("tool_call")?.[0]?.(
-			{ toolName: "read", toolCallId: "wrap-up-read", input: {} },
-			budgeted.ctx,
-		),
-		{
-			block: true,
-			reason: "Goal token budget is exhausted; only goal_complete is allowed during wrap-up.",
-		},
-	);
 	assert.equal(
 		budgeted.mock.events.get("tool_call")?.[0]?.(
-			{ toolName: "goal_complete", toolCallId: "wrap-up-complete", input: {} },
+			{ toolName: "read", toolCallId: "after-budget-read", input: {} },
 			budgeted.ctx,
 		),
 		undefined,
 	);
 	const completion = await requireGoalTool(budgeted.mock, "goal_complete").execute(
-		"wrap-up-complete",
+		"after-budget-complete",
 		{ goal_id: goalId, summary: "All requirements were implemented and verified." },
 		new AbortController().signal,
 		() => undefined,
 		budgeted.ctx,
 	);
-	assert.equal(completion.terminate, true);
+	assert.equal(completion.terminate, undefined);
+	assert.match(completion.content?.[0]?.text ?? "", /current run does not own/i);
 });
 
-test("budget wrap-up custom message retains goal ownership through agent_end", async () => {
+test("budget stop queues no custom work and remains stopped through agent_end", async () => {
 	const branch: Array<Record<string, unknown>> = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
@@ -313,28 +286,18 @@ test("budget wrap-up custom message retains goal ownership through agent_end", a
 		{ toolCallId: "tool-1", toolName: "bash", result: {}, isError: false },
 		budgeted.ctx,
 	);
-	const queuedWrapUp = budgeted.mock.sentMessages[0]?.message as
-		| Record<string, unknown>
-		| undefined;
-	assert.ok(queuedWrapUp);
-	const wrapUpMessage = { role: "custom", ...queuedWrapUp };
-
-	budgeted.mock.events.get("before_agent_start")?.[0]?.(
-		{ prompt: "budget wrap-up", systemPrompt: "base" },
-		budgeted.ctx,
-	);
-	budgeted.mock.events.get("message_start")?.[0]?.({ message: wrapUpMessage }, budgeted.ctx);
+	assert.equal(budgeted.mock.sentMessages.length, 0);
 	await budgeted.mock.events.get("agent_end")?.[0]?.(
-		{ messages: [wrapUpMessage, { role: "assistant", stopReason: "stop", content: [] }] },
+		{ messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
 		budgeted.ctx,
 	);
-
-	assert.equal(
+	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
+	assert.deepEqual(
 		budgeted.mock.events.get("tool_call")?.[0]?.(
-			{ toolName: "read", toolCallId: "after-wrap-up", input: {} },
+			{ toolName: "read", toolCallId: "after-budget", input: {} },
 			budgeted.ctx,
 		),
-		undefined,
+		{ block: true, reason: STALE_GOAL_TOOL_REASON },
 	);
 });
 
@@ -363,7 +326,7 @@ test("compaction cancels before retry when persisted usage has exhausted the bud
 	assert.equal(budgeted.mock.sentUserMessages.length, 1);
 });
 
-test("budget edits require an actual increase before reactivating and rotate stale ids", async () => {
+test("budget edits require an actual increase before rotating the stale id", async () => {
 	const branch: Array<Record<string, unknown>> = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
@@ -380,17 +343,10 @@ test("budget edits require an actual increase before reactivating and rotate sta
 	await budgeted.mock.commands.get("goal")?.handler("edit unchanged budget", budgeted.ctx);
 	const unchanged = requireLastGoal(budgeted.mock);
 	assert.equal(unchanged.status, "budget_limited");
-	assert.notEqual(unchanged.id, exhaustedGoal.id);
+	assert.equal(unchanged.id, exhaustedGoal.id);
+	assert.equal(unchanged.text, exhaustedGoal.text);
 	assert.equal(budgeted.mock.sentUserMessages.length, 1);
-
-	const staleCompletion = await requireGoalTool(budgeted.mock, "goal_complete").execute(
-		"stale-budget-completion",
-		{ goal_id: exhaustedGoal.id, summary: "Stale completion." },
-		new AbortController().signal,
-		() => undefined,
-		budgeted.ctx,
-	);
-	assert.match(staleCompletion.content?.[0]?.text ?? "", /goal_id/i);
+	assert.match(budgeted.notifications.at(-1)?.message ?? "", /raise the budget/i);
 
 	await budgeted.mock.commands
 		.get("goal")

--- a/packages/pi-goal/test/goal-command-transitions.test.ts
+++ b/packages/pi-goal/test/goal-command-transitions.test.ts
@@ -539,9 +539,16 @@ test("failed start delivery clears a new goal and restores a replaced stopped go
 	const restoredActive = requireLastGoal(activeReplacement.mock);
 	assert.equal(restoredActive.id, activeOriginal.id);
 	assert.equal(restoredActive.text, activeOriginal.text);
-	assert.equal(restoredActive.status, "paused");
+	assert.equal(restoredActive.status, "active");
 	assert.equal(restoredActive.tokensUsed, 5);
-	assert.equal(activeReplacementAborts, 1);
+	assert.equal(activeReplacementAborts, 0);
+	const replacementOwner = {
+		session: (activeReplacement.ctx as unknown as { sessionManager: object }).sessionManager,
+		group: "agent-workflow",
+		busy: false,
+	};
+	activeReplacement.mock.eventBus.emit("workflow:mutex:v1", replacementOwner);
+	assert.equal(replacementOwner.busy, true);
 
 	const replacement = await startGoalForTest();
 	await replacement.mock.commands.get("goal")?.handler("pause", replacement.ctx);
@@ -563,7 +570,7 @@ test("failed start delivery clears a new goal and restores a replaced stopped go
 	);
 });
 
-test("failed active edit delivery restores and pauses the prior goal", async () => {
+test("failed active edit delivery restores the exact prior active goal", async () => {
 	let aborts = 0;
 	const edited = await startGoalForTest({ abort: () => aborts++ });
 	const original = requireLastGoal(edited.mock);
@@ -575,14 +582,21 @@ test("failed active edit delivery restores and pauses the prior goal", async () 
 	const restored = requireLastGoal(edited.mock);
 	assert.equal(restored.id, original.id);
 	assert.equal(restored.text, original.text);
-	assert.equal(restored.status, "paused");
-	assert.equal(aborts, 1);
-	assert.deepEqual(
+	assert.equal(restored.status, "active");
+	assert.equal(aborts, 0);
+	const editOwner = {
+		session: (edited.ctx as unknown as { sessionManager: object }).sessionManager,
+		group: "agent-workflow",
+		busy: false,
+	};
+	edited.mock.eventBus.emit("workflow:mutex:v1", editOwner);
+	assert.equal(editOwner.busy, true);
+	assert.equal(
 		edited.mock.events.get("tool_call")?.[0]?.(
 			{ toolName: "bash", toolCallId: "stale-after-edit-failure", input: {} },
 			edited.ctx,
 		),
-		{ block: true, reason: STALE_GOAL_TOOL_REASON },
+		undefined,
 	);
 });
 

--- a/packages/pi-goal/test/goal-factory-isolation.test.ts
+++ b/packages/pi-goal/test/goal-factory-isolation.test.ts
@@ -299,7 +299,7 @@ test("goal_blocked ownership stays on the root instance after child start", asyn
 	child.events.get("session_shutdown")?.[0]?.({}, childContext.ctx);
 });
 
-test("pending continuation and budget state survive later child startup", async () => {
+test("pending continuation and stopped budget state survive later child startup", async () => {
 	const rootBranch: Array<Record<string, unknown>> = [assistantUsageEntry({ totalTokens: 0 })];
 	const root = createMockPi();
 	registerGoal(root.pi);
@@ -327,29 +327,24 @@ test("pending continuation and budget state survive later child startup", async 
 	assert.match(staleContinuation, new RegExp(`<!-- pi-goal-continuation:${rootGoal.id}:`));
 	assert.equal(child.sentUserMessages.length, 0);
 
-	// Establish the parent budget wrap-up before another child starts. Its context marker
-	// must remain authorized by the parent runtime after that later child session_start.
+	// Exhaust the parent budget before another child starts. No follow-up work is queued,
+	// and a historical wrap-up marker remains stale after the child startup.
 	rootBranch.push(assistantUsageEntry({ totalTokens: 5 }));
 	root.events.get("tool_execution_end")?.[0]?.({}, rootContext.ctx);
 	assert.equal(lastGoalStatus(root), "budget_limited");
-	const wrapUp = root.sentMessages.at(-1)?.message as {
-		customType?: string;
-		details?: { goalId?: string };
-	};
-	assert.equal(wrapUp?.customType, "goal-budget-wrap-up");
-	assert.equal(wrapUp?.details?.goalId, rootGoal.id);
+	assert.equal(root.sentMessages.length, 0);
 
 	const laterChild = createMockPi();
 	registerGoal(laterChild.pi);
 	const laterChildContext = createMockContext();
 	laterChild.events.get("session_start")?.[0]?.({}, laterChildContext.ctx);
 	const contextMessages = [
-		{ role: "custom", customType: wrapUp.customType, details: wrapUp.details },
+		{ role: "custom", customType: "goal-budget-wrap-up", details: { goalId: rootGoal.id } },
 		{ role: "user", content: "continue" },
 	];
-	assert.equal(
+	assert.deepEqual(
 		root.events.get("context")?.[0]?.({ messages: contextMessages }, rootContext.ctx),
-		undefined,
+		{ messages: [{ role: "user", content: "continue" }] },
 	);
 	assert.equal(child.sentMessages.length, 0);
 	assert.equal(laterChild.sentMessages.length, 0);

--- a/packages/pi-goal/test/goal-runtime-smoke.mjs
+++ b/packages/pi-goal/test/goal-runtime-smoke.mjs
@@ -530,20 +530,17 @@ async function staleBlockedToolAbortScenario() {
 }
 
 async function budgetBoundaryScenario() {
-	const harness = await createHarness([
-		fauxAssistantMessage(fauxToolCall("budget_probe", {})),
-		(context) => {
-			const wrapUp = context.messages.find(
-				(message) => message.role === "custom" && message.customType === "goal-budget-wrap-up",
-			);
-			assert.match(String(wrapUp?.content), /stop substantive work/i);
-			return fauxAssistantMessage("Budget-limited progress summary.");
-		},
-	]);
+	const harness = await createHarness([fauxAssistantMessage(fauxToolCall("budget_probe", {}))]);
 	try {
 		await harness.session.prompt("/goal --tokens 1 budget boundary runtime smoke");
-		await waitFor(() => harness.faux.state.callCount === 2, "budget wrap-up response");
 		await harness.session.agent.waitForIdle();
+		assert.equal(harness.faux.state.callCount, 1, "budget stop must not queue another model call");
+		assert.equal(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "goal-budget-wrap-up",
+			),
+			false,
+		);
 		assert.equal(persistedGoalStatus(harness.session), "budget_limited");
 		assert.equal(
 			harness.lifecycleEvents.filter((event) => event === "tool_execution_end").length,
@@ -560,21 +557,11 @@ async function budgetBoundaryScenario() {
 }
 
 async function budgetViolationScenario() {
-	const harness = await createHarness([
-		fauxAssistantMessage(fauxToolCall("budget_probe", {})),
-		fauxAssistantMessage(fauxToolCall("budget_probe", {})),
-		(_context, options) => {
-			assert.equal(options?.signal?.aborted, true);
-			return fauxAssistantMessage("This aborted response must not start more work.");
-		},
-	]);
+	const harness = await createHarness([fauxAssistantMessage(fauxToolCall("budget_probe", {}))]);
 	try {
-		await harness.session.prompt("/goal --tokens 1 reject wrap-up tools at runtime");
+		await harness.session.prompt("/goal --tokens 1 stop budget tools at runtime");
 		await harness.session.agent.waitForIdle();
-		assert.ok(
-			harness.faux.state.callCount >= 2 && harness.faux.state.callCount <= 3,
-			"budget guard permits only an optional aborted cleanup call",
-		);
+		assert.equal(harness.faux.state.callCount, 1, "budget guard must not queue cleanup work");
 		assert.equal(
 			harness.lifecycleEvents.filter((event) => event === "budget_probe_execute").length,
 			1,
@@ -734,5 +721,5 @@ await managedRunRpcScenario();
 await managedRunDisabledScenario();
 await manualCompactionScenario();
 console.log(
-	"pi-goal runtime smoke: normal, runaway guards, retry and busy-edit ownership, queued input, pause, stale blocked-tool aborts, managed-run RPC, bounded budget behavior, and manual compaction passed",
+	"pi-goal runtime smoke: normal, runaway guards, retry and busy-edit ownership, queued input, pause, stale blocked-tool aborts, managed-run RPC, terminal budget stops, and manual compaction passed",
 );

--- a/packages/pi-goal/test/goal-transition.test.ts
+++ b/packages/pi-goal/test/goal-transition.test.ts
@@ -5,7 +5,10 @@ import { createGoal, GoalRuntime } from "../src/runtime.js";
 
 function runtime() {
 	const mock = createMockPi({ activeTools: ["goal_complete", "goal_blocked", "goal_wait"] });
-	return { mock, state: new GoalRuntime(mock.pi) };
+	const state = new GoalRuntime(mock.pi);
+	state.bindWorkflowSession({});
+	assert.equal(state.acquireWorkflow(), true);
+	return { mock, state };
 }
 
 test("stopped transition owner applies explicit-pause invariants once", () => {

--- a/packages/pi-goal/test/workflow-mutex.test.ts
+++ b/packages/pi-goal/test/workflow-mutex.test.ts
@@ -1,0 +1,384 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import goal from "../src/goal.js";
+import { GoalRuntime } from "../src/runtime.js";
+import { DEFAULT_GOAL_SETTINGS } from "../src/settings.js";
+import { applyGoalSettings } from "../src/settings-ui.js";
+import {
+	AGENT_WORKFLOW_GROUP,
+	WORKFLOW_MUTEX_CHANNEL,
+	WorkflowMutex,
+} from "../src/workflow-mutex.js";
+import {
+	ALWAYS_SETTINGS_PATH,
+	assistantUsageEntry,
+	lastGoalStatus,
+	registerGoalWithSettingsPath,
+	requireGoalTool,
+	requireLastGoal,
+	startGoalForTest,
+} from "./support/goal-fixture.js";
+
+function attempt(session: object, group = AGENT_WORKFLOW_GROUP) {
+	return { session, group, busy: false };
+}
+
+function blockAgentWorkflow(mock: ReturnType<typeof createMockPi>, session: object) {
+	return mock.eventBus.on(WORKFLOW_MUTEX_CHANNEL, (payload) => {
+		if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return;
+		const current = payload as { session?: object; group?: string; busy?: boolean };
+		if (current.session !== session || current.group !== AGENT_WORKFLOW_GROUP) return;
+		if (typeof current.busy !== "boolean") return;
+		current.busy = true;
+	});
+}
+
+test("workflow mutex ignores malformed, foreign-session, and foreign-group payloads", () => {
+	const mock = createMockPi();
+	const mutex = new WorkflowMutex(mock.pi);
+	const session = {};
+	mutex.bindSession(session);
+	assert.ok(mutex.acquire());
+
+	for (const payload of [undefined, null, [], "mutex", 1, { session }, { session, group: 1 }]) {
+		assert.doesNotThrow(() => mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, payload));
+	}
+	assert.doesNotThrow(() =>
+		mock.eventBus.emit(
+			WORKFLOW_MUTEX_CHANNEL,
+			new Proxy(
+				{},
+				{
+					get() {
+						throw new Error("hostile getter");
+					},
+				},
+			),
+		),
+	);
+
+	const anotherSession = attempt({});
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, anotherSession);
+	assert.equal(anotherSession.busy, false);
+	const anotherGroup = attempt(session, "other-workflow");
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, anotherGroup);
+	assert.equal(anotherGroup.busy, false);
+	const malformedBusy = { session, group: AGENT_WORKFLOW_GROUP, busy: "false" };
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, malformedBusy);
+	assert.equal(malformedBusy.busy, "false");
+});
+
+test("workflow mutex preserves monotonic busy and fails closed on errors or mutation", () => {
+	const mock = createMockPi();
+	const session = {};
+	mock.eventBus.on(WORKFLOW_MUTEX_CHANNEL, (payload) => {
+		(payload as { busy: boolean }).busy = true;
+	});
+	const mutex = new WorkflowMutex(mock.pi);
+	mutex.bindSession(session);
+	const current = attempt(session);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, current);
+	assert.equal(current.busy, true);
+	assert.equal(mutex.acquire(), undefined);
+
+	const throwing = new WorkflowMutex({
+		events: {
+			on: () => () => undefined,
+			emit() {
+				throw new Error("emit failed");
+			},
+		},
+	} as never);
+	throwing.bindSession({});
+	assert.equal(throwing.acquire(), undefined);
+
+	const mutatedMock = createMockPi();
+	mutatedMock.eventBus.on(WORKFLOW_MUTEX_CHANNEL, (payload) => {
+		(payload as { group: string }).group = "changed";
+	});
+	const mutated = new WorkflowMutex(mutatedMock.pi);
+	mutated.bindSession({});
+	assert.equal(mutated.acquire(), undefined);
+});
+
+test("workflow mutex rejects re-entry and stale release without clearing a new owner", () => {
+	const mock = createMockPi();
+	let mutex: WorkflowMutex;
+	let replaced = false;
+	const replacementSession = {};
+	mock.eventBus.on(WORKFLOW_MUTEX_CHANNEL, () => {
+		if (replaced) return;
+		replaced = true;
+		mutex.bindSession(replacementSession);
+	});
+	mutex = new WorkflowMutex(mock.pi);
+	mutex.bindSession({});
+	assert.equal(mutex.acquire(), undefined);
+	const oldOwner = mutex.acquire();
+	assert.ok(oldOwner);
+	mutex.release(oldOwner);
+	const currentOwner = mutex.acquire();
+	assert.ok(currentOwner);
+	mutex.release(oldOwner);
+	assert.equal(mutex.isOwner(currentOwner), true);
+
+	mutex.unbindSession(replacementSession);
+	const released = attempt(replacementSession);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, released);
+	assert.equal(released.busy, false);
+});
+
+test("active and waiting Goals hold while paused and budget-limited Goals release", async () => {
+	const active = await startGoalForTest();
+	const session = (active.ctx as unknown as { sessionManager: object }).sessionManager;
+	const activeAttempt = attempt(session);
+	active.mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, activeAttempt);
+	assert.equal(activeAttempt.busy, true);
+
+	const goalId = requireLastGoal(active.mock).id;
+	await requireGoalTool(active.mock, "goal_wait").execute(
+		"wait",
+		{ goal_id: goalId, reason: "external deployment" },
+		new AbortController().signal,
+		() => undefined,
+		active.ctx,
+	);
+	const waitingAttempt = attempt(session);
+	active.mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, waitingAttempt);
+	assert.equal(waitingAttempt.busy, true);
+
+	await active.mock.commands.get("goal")?.handler("pause", active.ctx);
+	const pausedAttempt = attempt(session);
+	active.mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, pausedAttempt);
+	assert.equal(pausedAttempt.busy, false);
+
+	const budgetBranch: Array<Record<string, unknown>> = [];
+	const budgetSession = { getBranch: () => budgetBranch, getEntries: () => budgetBranch };
+	const budget = await startGoalForTest({ sessionManager: budgetSession }, "--tokens 1 bounded");
+	budgetBranch.push(assistantUsageEntry({ totalTokens: 2 }));
+	await budget.mock.events.get("tool_execution_end")?.[0]?.(
+		{ toolCallId: "budget", toolName: "read", result: {}, isError: false },
+		budget.ctx,
+	);
+	const budgetAttempt = attempt(budgetSession);
+	budget.mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, budgetAttempt);
+	assert.equal(budgetAttempt.busy, false);
+});
+
+test("busy direct start and resume preserve Goal state in every command mode", async () => {
+	for (const mode of ["tui", "rpc", "print", "json"] as const) {
+		const sessionManager = { getBranch: () => [], getEntries: () => [] };
+		const mock = createMockPi({
+			activeTools: ["read", "goal_complete", "goal_blocked", "goal_wait"],
+		});
+		blockAgentWorkflow(mock, sessionManager);
+		registerGoalWithSettingsPath(mock.pi, ALWAYS_SETTINGS_PATH);
+		const context = createMockContext({
+			mode,
+			hasUI: mode === "tui" || mode === "rpc",
+			sessionManager,
+		});
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		const snapshot = {
+			tools: mock.rawPi.getActiveTools(),
+			entries: mock.entries.length,
+			messages: mock.sentUserMessages.length,
+			status: [...context.statuses],
+		};
+		const command = mock.commands.get("goal");
+		assert.ok(command);
+		if (mode === "print" || mode === "json") {
+			await assert.rejects(
+				async () => command.handler("blocked start", context.ctx),
+				/Another workflow is active/u,
+			);
+		} else {
+			await command.handler("blocked start", context.ctx);
+		}
+		assert.deepEqual(mock.rawPi.getActiveTools(), snapshot.tools);
+		assert.equal(mock.entries.length, snapshot.entries);
+		assert.equal(mock.sentUserMessages.length, snapshot.messages);
+		assert.deepEqual([...context.statuses], snapshot.status);
+		assert.equal(lastGoalStatus(mock), null);
+	}
+});
+
+test("busy active restore pauses safely without widening tools or scheduling work", async () => {
+	const restored = {
+		id: "restored-active",
+		text: "restore safely",
+		status: "active",
+		startedAt: 1,
+		updatedAt: 2,
+		iteration: 0,
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		baselineTokens: 0,
+		activeStartedAt: 1,
+		automaticModelTurns: 0,
+		toolFreeRepeatCount: 0,
+	};
+	const entry = { type: "custom", customType: "goal-state", data: { goal: restored } };
+	const sessionManager = { getBranch: () => [entry], getEntries: () => [entry] };
+	const mock = createMockPi({ activeTools: ["read"] });
+	let activeToolWrites = 0;
+	const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+	mock.rawPi.setActiveTools = (tools) => {
+		activeToolWrites += 1;
+		setActiveTools(tools);
+	};
+	blockAgentWorkflow(mock, sessionManager);
+	goal(mock.pi, { settingsPath: ALWAYS_SETTINGS_PATH });
+	const context = createMockContext({ mode: "tui", hasUI: true, sessionManager });
+
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	assert.equal(activeToolWrites, 0);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+	assert.equal(lastGoalStatus(mock), "paused");
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /paused during restore/u);
+	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("busy inactive visibility change preserves settings, hidden tools, and active tools", () => {
+	const sessionManager = {};
+	const mock = createMockPi({
+		activeTools: ["read", "goal_complete", "goal_blocked", "goal_wait"],
+	});
+	const unblock = blockAgentWorkflow(mock, sessionManager);
+	const runtime = new GoalRuntime(mock.pi);
+	runtime.bindWorkflowSession(sessionManager);
+	runtime.toolPolicy.hideIfLocked();
+	let activeToolWrites = 0;
+	const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+	mock.rawPi.setActiveTools = (tools) => {
+		activeToolWrites += 1;
+		setActiveTools(tools);
+	};
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		isIdle: () => true,
+		sessionManager,
+	});
+	const beforeTools = mock.rawPi.getActiveTools();
+	const beforeSettings = structuredClone(runtime.settings);
+	let saves = 0;
+
+	assert.throws(
+		() =>
+			applyGoalSettings(
+				runtime,
+				{ ...structuredClone(DEFAULT_GOAL_SETTINGS), toolVisibility: "always" },
+				context.ctx,
+				{ save: () => saves++ },
+			),
+		/Another workflow is active/u,
+	);
+	assert.deepEqual(runtime.settings, beforeSettings);
+	assert.deepEqual(mock.rawPi.getActiveTools(), beforeTools);
+	assert.equal(runtime.toolPolicy.hasHiddenTools(), true);
+	assert.equal(activeToolWrites, 0);
+	assert.equal(saves, 0);
+
+	unblock();
+	assert.equal(runtime.acquireWorkflow(sessionManager), true);
+	runtime.toolPolicy.prepareActivation("always", context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"read",
+		"goal_complete",
+		"goal_blocked",
+		"goal_wait",
+	]);
+	runtime.releaseWorkflow();
+});
+
+test("busy managed-run RPC emits one anonymous terminal activation error", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-goal-mutex-rpc-"));
+	try {
+		const settingsPath = join(root, "pi-goal.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify({ toolVisibility: "always", rpc: { enabled: true } }),
+			"utf8",
+		);
+		const sessionManager = { getBranch: () => [], getEntries: () => [] };
+		const mock = createMockPi({
+			activeTools: ["read", "goal_complete", "goal_blocked", "goal_wait"],
+		});
+		blockAgentWorkflow(mock, sessionManager);
+		goal(mock.pi, { settingsPath });
+		const context = createMockContext({ mode: "rpc", hasUI: true, sessionManager });
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		const events: unknown[] = [];
+		mock.eventBus.on("pi-goal:event:busy-run", (event) => events.push(event));
+
+		mock.eventBus.emit("pi-goal:start", { runId: "busy-run", objective: "blocked run" });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.deepEqual(events, [
+			{
+				type: "error",
+				runId: "busy-run",
+				operation: "start",
+				error: {
+					code: "ACTIVATION_FAILED",
+					message: "Another workflow is active in this session. End it before starting Goal.",
+				},
+			},
+		]);
+		assert.equal(mock.entries.length, 0);
+		assert.equal(mock.sentUserMessages.length, 0);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("pause, completion, clear, and shutdown release after Goal cleanup", async () => {
+	for (const action of ["pause", "complete", "clear", "shutdown"] as const) {
+		const fixture = await startGoalForTest();
+		const session = (fixture.ctx as unknown as { sessionManager: object }).sessionManager;
+		if (action === "complete") {
+			const activeGoal = requireLastGoal(fixture.mock);
+			await requireGoalTool(fixture.mock, "goal_complete").execute(
+				"complete",
+				{ goal_id: activeGoal.id, summary: "All requirements completed and verified." },
+				new AbortController().signal,
+				() => undefined,
+				fixture.ctx,
+			);
+		} else if (action === "shutdown") {
+			await fixture.mock.events.get("session_shutdown")?.[0]?.({ reason: "quit" }, fixture.ctx);
+		} else {
+			await fixture.mock.commands.get("goal")?.handler(action, fixture.ctx);
+		}
+		const released = attempt(session);
+		fixture.mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, released);
+		assert.equal(released.busy, false, `${action} should release after cleanup`);
+	}
+});
+
+test("active Goal replacement reuses its owner while stopped resume reacquires", async () => {
+	const active = await startGoalForTest({ confirm: async () => true });
+	const session = (active.ctx as unknown as { sessionManager: object }).sessionManager;
+	await active.mock.commands.get("goal")?.handler("replacement objective", active.ctx);
+	const replacementAttempt = attempt(session);
+	active.mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, replacementAttempt);
+	assert.equal(replacementAttempt.busy, true);
+
+	await active.mock.commands.get("goal")?.handler("pause", active.ctx);
+	blockAgentWorkflow(active.mock, session);
+	const beforeResume = requireLastGoal(active.mock);
+	const entryCount = active.mock.entries.length;
+	await active.mock.commands.get("goal")?.handler("resume", active.ctx);
+	assert.equal(requireLastGoal(active.mock).id, beforeResume.id);
+	assert.equal(lastGoalStatus(active.mock), "paused");
+	assert.equal(active.mock.entries.length, entryCount);
+	assert.match(active.notifications.at(-1)?.message ?? "", /Another workflow is active/u);
+});


### PR DESCRIPTION
## Summary

- add a package-local Workflow Mutex Protocol v1 participant with session, generation, and owner guards
- admit direct, menu, managed-run, resume, stopped-edit, restore, and inactive tool-visibility paths before Goal or active-tool mutation
- retain ownership for active and waiting Goals through continuation, wait deadlines, compaction, and provider retry
- make busy restore use the existing paused fallback without widening tools or scheduling work
- preserve exact active Goal/tool snapshots after failed replacement or edit delivery
- release stopped, terminal, clear, managed-cancel, replacement, and shutdown paths after cleanup
- stop Goal-owned work immediately at token-budget exhaustion instead of queuing a post-limit model wrap-up
- document standalone/cooperative behavior and record an independent minor release intent

## Verification

- focused mutex, command-transition, continuation, error-lifecycle, run-protocol, tool-policy, wait, and settings suites
- `npm exec -- vitest run packages/pi-goal/test` (21 files, 295 tests)
- `npm --workspace @narumitw/pi-goal run build`
- generated-entry and Jiti `DefaultResourceLoader` tests
- `npm --workspace @narumitw/pi-goal run test:runtime`
- `npm run check`
- `npm test` (401 files, 3,791 tests)
- `npm pack --workspace @narumitw/pi-goal --dry-run --json`
- `npm run changeset:status` (`@narumitw/pi-goal` -> `0.53.0` with current Changesets)

## Convention audit

- Factory/lifecycle: one synchronous listener registers without session work; all timers, waits, continuations, recovery, managed runs, replacement, and shutdown paths are owner- and generation-guarded.
- Commands/modes: established routes remain; TUI/RPC warnings, print/JSON errors, and managed-run terminal errors are covered.
- Settings: inactive active-tool changes use a synchronous temporary owner across apply, persistence, rollback, and release; busy paths make zero writes and preserve unknown-field-safe storage behavior.
- Package: no extension-to-extension import, dependency, identity, or control data was added; generated interactive modules remain lazy.
- README: ownership states, busy restore, tool-widening deferral, token-budget stopping, standalone support, and mixed-version limits are documented.
- Goal queue: legacy queue-only state remains inert and does not acquire or schedule work; roadmap queue activation is marked not applicable.

The isolated Pi loading evidence is the package's Jiti `DefaultResourceLoader` test plus its deterministic runtime smoke; no live provider was required.
No publication, visibility, tag, workflow dispatch, or deprecation action was performed.
