### PR TITLE
test: prove plan and goal coexistence

### DIFF
--- a/docs/api/workflow-mutex-v1.md
+++ b/docs/api/workflow-mutex-v1.md
@@ -1,6 +1,6 @@
 # Workflow Mutex Protocol v1
 
-- **Status:** Draft protocol for implementation and characterization.
+- **Status:** Implemented protocol with release-ready Plan and Goal conformance evidence.
 - **Transport:** Pi's process-local `pi.events` bus.
 - **Purpose:** Ensure at most one participating agent workflow is active in the same Pi session.
 
@@ -243,6 +243,8 @@ A dual-version migration requires a separate specification because emitting mult
 
 Packages MUST document the minimum counterpart versions required for guaranteed coexistence.
 
+The first release-intent versions derived from the repository Changesets are `@narumitw/pi-plan-mode@0.52.0` and `@narumitw/pi-goal@0.53.0`.
+These are compatibility floors, not evidence that either package has been published.
 A v1 participant operating beside a pre-v1 extension remains standalone-compatible but cannot claim mutual exclusion.
 
 ## Required Pi behavior
@@ -267,6 +269,14 @@ The characterization proves shared delivery across inline extension factories, s
 These properties MUST have deterministic characterization tests before a package claims v1 support.
 
 If a supported Pi version stops satisfying any property, participants MUST fail safe and withdraw the coexistence claim until the protocol is revised.
+
+## Product conformance
+
+`@narumitw/pi-plan-mode` and `@narumitw/pi-goal` each implement v1 in a package-local module without importing, identifying, or depending on the other extension.
+[`test/plan-goal-coexistence.test.ts`](../../test/plan-goal-coexistence.test.ts) covers both source load orders, both acquisition orders, restoration, tool-write rejection, release and reacquisition, standalone parity, and built generated entries on one public Pi event bus.
+Package-focused mutex suites cover each participant's activation, rollback, waiting, continuation, settings, managed-run, and lifecycle boundaries.
+The coexistence claim applies only at or above both documented package floors on the characterized Pi runtime.
+No publication, tag, visibility change, or release workflow is implied by this conformance status.
 
 ## Conformance tests
 

--- a/docs/implementation-notes/2026-08-22_plan-goal-coexistence-release-readiness.md
+++ b/docs/implementation-notes/2026-08-22_plan-goal-coexistence-release-readiness.md
@@ -1,0 +1,76 @@
+# Plan and Goal coexistence release readiness
+
+## Outcome
+
+Workflow Mutex Protocol v1 is characterized on `@earendil-works/pi-coding-agent@0.84.2` and implemented independently by Plan mode and Goal.
+The current Changesets produce the first v1 release-intent versions `@narumitw/pi-plan-mode@0.52.0` and `@narumitw/pi-goal@0.53.0`.
+No package was published and no tag, visibility change, release workflow, or deprecation action was performed.
+
+## Coexistence matrix
+
+| Evidence | Result |
+| --- | --- |
+| Plan-first load, Plan-first acquisition | Plan holds and Goal rejects without state, prompt, status, thinking, or active-tool writes. |
+| Plan-first load, Goal-first acquisition | Goal holds and Plan rejects without state, prompt, status, thinking, or active-tool writes. |
+| Goal-first load, Plan-first acquisition | Plan holds and Goal rejects without state, prompt, status, thinking, or active-tool writes. |
+| Goal-first load, Goal-first acquisition | Goal holds and Plan rejects without state, prompt, status, thinking, or active-tool writes. |
+| Plan planning, ready review, and revision | Goal direct and managed starts remain rejected while the Plan tool set stays unchanged. |
+| Goal active and waiting | Plan direct, prompted, launch-menu, selected-tool, shortcut, and startup-flag starts remain rejected. |
+| Both persisted states active | Lifecycle registration order selects one holder and the loser enters its documented non-running fallback. |
+| Release and reacquisition | Goal starts only after Plan cleanup, and Plan starts only after Goal cleanup. |
+| Standalone load | Plan and Goal each retain representative start, stop, persistence, tools, status, and shutdown behavior. |
+| Generated entries | Both built `dist/index.ts` entries load through Pi's Jiti resource loader on one event bus, and runtime invalidation removes their tracked mutex listeners. |
+
+Focused package suites additionally cover Plan save, export, implementation handoff, fresh-session cancellation, replacement, and shutdown.
+Focused Goal suites additionally cover pause, blocker, completion, clear, managed cancel, safety and budget limits, tool loss, waits, continuations, provider retries, settings rollback, replacement, and shutdown.
+Legacy Goal queue-only state remains inert, does not acquire the mutex, and cannot schedule automatic work.
+
+## Compatibility
+
+| Installation | Result |
+| --- | --- |
+| Plan mode without another participant | Supported standalone behavior. |
+| Goal without another participant | Supported standalone behavior. |
+| Plan mode `>=0.52.0` with Goal `>=0.53.0` on Pi `0.84.2` | Guaranteed cooperative v1 mutual exclusion. |
+| Either package below its floor | Standalone behavior only; mutual exclusion is unsupported. |
+| Another Pi version, process, event bus, or non-v1 participant | Outside the characterized v1 guarantee. |
+
+The mutex is cooperative and does not protect against a trusted non-participant that starts work or replaces Pi's active-tool array.
+The packages do not import, identify, configure, start, stop, or depend on one another.
+
+## Verification evidence
+
+- `npm exec -- vitest run test/workflow-mutex-runtime.test.ts test/plan-goal-coexistence.test.ts` passed 17 tests.
+- `npm exec -- vitest run packages/pi-plan-mode/test` passed 203 tests across 18 files.
+- `npm exec -- vitest run packages/pi-goal/test` passed 295 tests across 21 files.
+- `npm --workspace @narumitw/pi-plan-mode run build` passed.
+- `npm --workspace @narumitw/pi-goal run build` passed.
+- Both package build-runtime and generated-entry tests plus the dual-entry loader test passed 26 tests across five files.
+- `npm --workspace @narumitw/pi-goal run test:runtime` passed normal, guard, retry, ownership, pause, managed-run, terminal-budget, and manual-compaction scenarios.
+- `npm run check` passed build, Biome, package-boundary, and workspace-typecheck gates.
+- `npm test` passed 3,805 tests across 402 files on the final run.
+- One preceding full-suite run hit a transient `pi-subagents` semantic-resource revalidation failure; its focused 25-test rerun and the complete final rerun passed without a code change.
+- Both `npm pack --workspace <package> --dry-run --json` inspections included `dist/index.ts`, source, `src/workflow-mutex.ts`, README, and license.
+- `npm run changeset:status` reported Plan `0.52.0` and Goal `0.53.0` release intent.
+
+Changesets status also reported pre-existing `pi-tui-kit` range warnings for unrelated packages.
+Those warnings do not change either mutex package's resolved release intent.
+
+## Convention audit
+
+The implementation was reviewed against `docs/extension-conventions.md`, `docs/extension-settings.md`, `docs/readme-conventions.md`, both package `AGENTS.md` files, and the protocol conformance list.
+Factory registration performs no session-owned background work.
+Session replacement and shutdown cancel or invalidate menus, questionnaires, waits, continuations, retries, managed runs, timers, prompts, statuses, and local owners.
+Every changed asynchronous path revalidates its session, generation, Goal or Plan identity, and workflow ownership after `await`.
+Busy command behavior is observable in TUI, RPC, print, and JSON modes without ad hoc protocol output.
+Inactive Goal tool visibility holds temporary ownership across runtime application, persistence, rollback, and release.
+Settings validation, unknown-field preservation, invalid-file protection, atomic publication, and rollback semantics remain covered.
+Generated runtimes preserve lazy interactive imports and external Pi peer dependencies.
+Package boundaries report no extension-to-extension dependency or import.
+README headings, standalone behavior, compatibility floors, restore fallbacks, and mixed-version limits were reviewed against implementation and tests.
+
+## Deviations and unverified paths
+
+No live-provider `pi -e` chat smoke was run because it would require provider credentials and external model execution.
+The deterministic Jiti `DefaultResourceLoader`, generated-entry lifecycle, and Goal runtime smokes cover the changed runtime-loading boundary without a provider.
+No external publication state was changed, so registry installation of the future compatibility-floor versions remains intentionally unverified until an approved release.

--- a/docs/roadmaps/2026-08-22_pi-plan-goal-coexistence-roadmap.md
+++ b/docs/roadmaps/2026-08-22_pi-plan-goal-coexistence-roadmap.md
@@ -101,25 +101,25 @@ This is an advisory mutex among participating extensions, not a Pi-enforced lock
 
 ### Phase 2: Make Plan and Goal participate
 
-- [ ] Every transition from inactive to a Plan mutex-holding state performs final admission after all asynchronous preflight and before any state, persistence, prompt, or tool mutation.
-- [ ] Every Goal activation path, including direct start, resume, retry recovery, and restored automatic continuation, respects one documented mutex-ownership rule; queue activation is not applicable because the focused Goal keeps legacy queued state inert.
-- [ ] Plan reports the mutex as busy while planning, ready, or revising, and releases it after implementation handoff, save, export-and-exit, discard, or exit.
-- [ ] Goal reports the mutex as busy for every state that can execute or resume automatically and releases it only after its existing terminal, stop, clear, or non-resumable transition.
-- [ ] An inactive Goal path that would widen active tools performs the same final busy check and defers its tool change while another workflow holds the group.
-- [ ] Restored active state holds the mutex before it can schedule work, and an unsupported legacy collision falls back to the existing restrictive-wins pause behavior without starting autonomous work.
-- [ ] A rejected start is observable in every supported command mode and preserves the exact prior state and active tools.
-- [ ] Loading either package alone preserves its current commands, tools, settings, persistence, and runtime behavior.
+- [x] Every transition from inactive to a Plan mutex-holding state performs final admission after all asynchronous preflight and before any state, persistence, prompt, or tool mutation.
+- [x] Every Goal activation path, including direct start, resume, retry recovery, and restored automatic continuation, respects one documented mutex-ownership rule; queue activation is not applicable because the focused Goal keeps legacy queued state inert.
+- [x] Plan reports the mutex as busy while planning, ready, or revising, and releases it after implementation handoff, save, export-and-exit, discard, or exit.
+- [x] Goal reports the mutex as busy for every state that can execute or resume automatically and releases it only after its existing terminal, stop, clear, or non-resumable transition.
+- [x] An inactive Goal path that would widen active tools performs the same final busy check and defers its tool change while another workflow holds the group.
+- [x] Restored active state holds the mutex before it can schedule work, and an unsupported legacy collision falls back to the existing restrictive-wins pause behavior without starting autonomous work.
+- [x] A rejected start is observable in every supported command mode and preserves the exact prior state and active tools.
+- [x] Loading either package alone preserves its current commands, tools, settings, persistence, and runtime behavior.
 
 **Outcome:** Supported Plan and Goal versions coexist without becoming active at the same time and without importing or identifying one another.
 
 ### Phase 3: Prove lifecycle and tool safety
 
-- [ ] Co-installation tests cover both extension load orders and both acquisition orders.
-- [ ] Tests cover session restore, queued Goal activation, continuation, retry, Plan ready and revision states, cancellation, replacement, reload, shutdown, and stale callbacks.
-- [ ] Tests prove that a busy result never invokes `setActiveTools()`, Goal visibility changes cannot widen an active Plan tool set, and Plan restores the exact pre-Plan set when it exits.
-- [ ] The current restrictive-wins Goal fail-safe remains as defense in depth for unsupported or non-participating tool policies.
-- [ ] Package documentation states the minimum counterpart versions for guaranteed coexistence and distinguishes standalone support from mixed-version guarantees.
-- [ ] Both repository gates, focused package tests, package dry runs, and isolated Pi loading smokes pass before release readiness is claimed.
+- [x] Co-installation tests cover both extension load orders and both acquisition orders.
+- [x] Tests cover session restore, inert legacy queue state, continuation, retry, Plan ready and revision states, cancellation, replacement, reload, shutdown, and stale callbacks; focused Goal queue activation is not applicable.
+- [x] Tests prove that a busy result never invokes `setActiveTools()`, Goal visibility changes cannot widen an active Plan tool set, and Plan restores the exact pre-Plan set when it exits.
+- [x] The current restrictive-wins Goal fail-safe remains as defense in depth for unsupported or non-participating tool policies.
+- [x] Package documentation states the minimum counterpart versions for guaranteed coexistence and distinguishes standalone support from mixed-version guarantees.
+- [x] Both repository gates, focused package tests, package dry runs, and isolated Pi loading smokes pass before release readiness is claimed.
 
 **Outcome:** Coexistence is supported by deterministic lifecycle evidence rather than event timing assumptions alone.
 

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -154,7 +154,13 @@ An active Goal still pauses if a non-participating restrictive policy later remo
 The coexistence guarantee is cooperative and applies only when every contender implements v1 on the characterized Pi runtime and shares its event bus and session-manager identity.
 A pre-v1, mixed-version, non-participating, forked, or otherwise uncharacterized counterpart remains unsupported for mutual exclusion.
 Goal does not identify, inspect, configure, start, stop, or depend on another extension.
-The reciprocal minimum package versions will be documented only after both products pass the coexistence release matrix.
+Guaranteed coexistence with Plan mode requires `@narumitw/pi-plan-mode` `0.52.0` or newer and this package at `0.53.0` or newer on the characterized Pi `0.84.2` runtime.
+
+| Installation | Support |
+| --- | --- |
+| Goal without another workflow participant | Supported standalone behavior |
+| Goal `>=0.53.0` with Plan mode `>=0.52.0` on Pi `0.84.2` | Workflow Mutex v1 coexistence guarantee |
+| Either package below its floor, or another Pi runtime | Standalone behavior only; mutual exclusion unsupported |
 
 ## 💬 Commands
 

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -243,7 +243,13 @@ Successful session replacement relies on source-session shutdown to clean up and
 The coexistence guarantee is cooperative and applies only when every contender implements v1 on the characterized Pi runtime and shares its event bus and session-manager identity.
 A pre-v1, mixed-version, non-participating, forked, or otherwise uncharacterized counterpart remains unsupported for mutual exclusion.
 Plan mode does not identify, inspect, configure, start, stop, or depend on another extension.
-The reciprocal minimum package versions will be documented only after both products pass the coexistence release matrix.
+Guaranteed coexistence with Goal requires `@narumitw/pi-goal` `0.53.0` or newer and this package at `0.52.0` or newer on the characterized Pi `0.84.2` runtime.
+
+| Installation | Support |
+| --- | --- |
+| Plan mode without another workflow participant | Supported standalone behavior |
+| Plan mode `>=0.52.0` with Goal `>=0.53.0` on Pi `0.84.2` | Workflow Mutex v1 coexistence guarantee |
+| Either package below its floor, or another Pi runtime | Standalone behavior only; mutual exclusion unsupported |
 
 ## 🛠️ Tools
 

--- a/test/plan-goal-coexistence.test.ts
+++ b/test/plan-goal-coexistence.test.ts
@@ -1,0 +1,536 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	createEventBus,
+	DefaultResourceLoader,
+	ExtensionRunner,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { afterAll, test } from "vitest";
+import goal from "../packages/pi-goal/src/goal.js";
+import planMode from "../packages/pi-plan-mode/src/plan-mode.js";
+import { builtinTool, createMockContext, createMockPi, extensionTool } from "./support.js";
+
+const WORKFLOW_MUTEX_CHANNEL = "workflow:mutex:v1";
+const AGENT_WORKFLOW_GROUP = "agent-workflow";
+const root = mkdtempSync(join(tmpdir(), "plan-goal-coexistence-"));
+const goalSettingsPath = join(root, "pi-goal.json");
+const goalRpcSettingsPath = join(root, "pi-goal-rpc.json");
+writeFileSync(goalSettingsPath, '{"toolVisibility":"always"}\n');
+writeFileSync(goalRpcSettingsPath, '{"toolVisibility":"always","rpc":{"enabled":true}}\n');
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+type LoadOrder = "plan-first" | "goal-first";
+
+type CapturedPlanUi = {
+	launch?: {
+		start(signal: AbortSignal): void;
+		startWithTools(names: string[], signal: AbortSignal): void;
+	};
+};
+
+function workflowAttempt(session: object) {
+	return { session, group: AGENT_WORKFLOW_GROUP, busy: false };
+}
+
+function planEntry(data: Record<string, unknown>) {
+	return { type: "custom", customType: "plan-mode-state", data };
+}
+
+function goalEntry(goalState: Record<string, unknown>) {
+	return { type: "custom", customType: "goal-state", data: { goal: goalState } };
+}
+
+function activeGoal(id = "restored-goal", waiting?: { reason: string; resumeAt?: number }) {
+	return {
+		id,
+		text: `Goal ${id}`,
+		status: "active",
+		startedAt: 1,
+		updatedAt: 2,
+		iteration: 0,
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		baselineTokens: 0,
+		activeStartedAt: waiting ? undefined : 1,
+		automaticModelTurns: 0,
+		toolFreeRepeatCount: 0,
+		...(waiting ? { waiting } : {}),
+	};
+}
+
+function latestStateEntry(
+	entries: Array<{ customType: string; data: unknown }>,
+	customType: string,
+) {
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		if (entries[index]?.customType === customType) {
+			return entries[index]?.data as Record<string, unknown> | undefined;
+		}
+	}
+	return undefined;
+}
+
+function goalStatus(entries: Array<{ customType: string; data: unknown }>) {
+	const data = latestStateEntry(entries, "goal-state");
+	const stored = data?.goal as { status?: string } | null | undefined;
+	return stored?.status ?? null;
+}
+
+async function emitLifecycle(
+	events: ReadonlyMap<string, Array<(...args: unknown[]) => unknown>>,
+	name: string,
+	...args: unknown[]
+) {
+	let result: unknown;
+	for (const handler of events.get(name) ?? []) result = await handler(...args);
+	return result;
+}
+
+function createFixture(
+	loadOrder: LoadOrder,
+	options: {
+		branch?: Array<Record<string, unknown>>;
+		goalRpc?: boolean;
+		planShortcut?: boolean;
+		capturePlanUi?: CapturedPlanUi;
+	} = {},
+) {
+	const branch = options.branch ?? [];
+	const sessionManager = {
+		getSessionId: () => "coexistence-session",
+		getSessionName: () => undefined,
+		getSessionFile: () => undefined,
+		getBranch: () => branch,
+		getEntries: () => branch,
+	};
+	const mock = createMockPi({
+		activeTools: ["read", "bash", "write", "goal_complete", "goal_blocked", "goal_wait"],
+		allTools: [
+			builtinTool("read"),
+			builtinTool("bash"),
+			builtinTool("write"),
+			extensionTool("goal_complete"),
+			extensionTool("goal_blocked"),
+			extensionTool("goal_wait"),
+		],
+		thinkingLevel: "low",
+	});
+	const activeToolWrites: string[][] = [];
+	const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+	mock.rawPi.setActiveTools = (names) => {
+		activeToolWrites.push([...names]);
+		setActiveTools(names);
+	};
+	const captured = options.capturePlanUi;
+	const registerPlan = () =>
+		planMode(mock.pi, {
+			readSettings: async () =>
+				options.planShortcut
+					? {
+							kind: "loaded" as const,
+							settings: { thinkingLevel: "inherit" as const, toggleShortcut: "ctrl+shift+p" },
+						}
+					: { kind: "missing" as const },
+			...(captured
+				? {
+						loadInteractiveUi: async () =>
+							({
+								showPlanLaunchMenu: async (_ctx: unknown, launch: CapturedPlanUi["launch"]) => {
+									captured.launch = launch;
+								},
+							}) as never,
+					}
+				: {}),
+		});
+	const registerGoal = () =>
+		goal(mock.pi, {
+			settingsPath: options.goalRpc ? goalRpcSettingsPath : goalSettingsPath,
+		});
+	if (loadOrder === "plan-first") {
+		registerPlan();
+		registerGoal();
+	} else {
+		registerGoal();
+		registerPlan();
+	}
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		cwd: root,
+		sessionManager,
+		confirm: async () => true,
+		model: {},
+		modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true }) },
+	});
+	return { mock, context, sessionManager, activeToolWrites, captured };
+}
+
+async function startSession(fixture: ReturnType<typeof createFixture>, reason = "startup") {
+	await emitLifecycle(fixture.mock.events, "session_start", { reason }, fixture.context.ctx);
+}
+
+async function startPlan(fixture: ReturnType<typeof createFixture>, prompt?: string) {
+	await fixture.mock.commands
+		.get("plan")
+		?.handler(prompt === undefined ? "start" : prompt, fixture.context.ctx);
+}
+
+async function startGoal(fixture: ReturnType<typeof createFixture>, objective = "integrated goal") {
+	await fixture.mock.commands.get("goal")?.handler(objective, fixture.context.ctx);
+}
+
+function assertOneHolder(fixture: ReturnType<typeof createFixture>) {
+	const current = workflowAttempt(fixture.sessionManager);
+	fixture.mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, current);
+	assert.equal(current.busy, true);
+}
+
+for (const loadOrder of ["plan-first", "goal-first"] as const) {
+	for (const acquisitionOrder of ["plan-first", "goal-first"] as const) {
+		test(`${loadOrder} load and ${acquisitionOrder} acquisition produce one holder`, async () => {
+			const fixture = createFixture(loadOrder);
+			await startSession(fixture);
+			if (acquisitionOrder === "plan-first") await startPlan(fixture);
+			else await startGoal(fixture);
+			const writesBeforeRejection = fixture.activeToolWrites.length;
+			const entriesBeforeRejection = fixture.mock.entries.length;
+			const promptsBeforeRejection = fixture.mock.sentUserMessages.length;
+			const thinkingBeforeRejection = fixture.mock.thinkingLevels.length;
+
+			if (acquisitionOrder === "plan-first") await startGoal(fixture, "losing Goal");
+			else await startPlan(fixture);
+
+			assertOneHolder(fixture);
+			assert.equal(fixture.activeToolWrites.length, writesBeforeRejection);
+			assert.equal(fixture.mock.entries.length, entriesBeforeRejection);
+			assert.equal(fixture.mock.sentUserMessages.length, promptsBeforeRejection);
+			assert.equal(fixture.mock.thinkingLevels.length, thinkingBeforeRejection);
+			if (acquisitionOrder === "plan-first") {
+				assert.equal(
+					(latestStateEntry(fixture.mock.entries, "plan-mode-state") as { enabled?: boolean })
+						?.enabled,
+					true,
+				);
+				assert.equal(goalStatus(fixture.mock.entries), null);
+				assert.equal(fixture.context.statuses.get("plan-mode"), "plan active");
+			} else {
+				assert.equal(latestStateEntry(fixture.mock.entries, "plan-mode-state"), undefined);
+				assert.equal(goalStatus(fixture.mock.entries), "active");
+				assert.match(fixture.context.statuses.get("goal") ?? "", /^active/u);
+			}
+			assert.match(fixture.context.notifications.at(-1)?.message ?? "", /Another workflow/u);
+		});
+	}
+}
+
+test("Plan ready and revision states reject Goal without changing Plan tools", async () => {
+	const fixture = createFixture("plan-first");
+	await startSession(fixture);
+	await startPlan(fixture);
+	const complete = fixture.mock.tools.find((tool) => tool.name === "plan_mode_complete")
+		?.execute as (...args: unknown[]) => Promise<unknown>;
+	await complete(
+		"complete-plan",
+		{ plan: "# Integrated ready plan" },
+		undefined,
+		undefined,
+		fixture.context.ctx,
+	);
+	const readyTools = fixture.mock.rawPi.getActiveTools();
+	const writesBeforeReadyRejection = fixture.activeToolWrites.length;
+	await startGoal(fixture, "Goal rejected during ready review");
+	assert.deepEqual(fixture.mock.rawPi.getActiveTools(), readyTools);
+	assert.equal(fixture.activeToolWrites.length, writesBeforeReadyRejection);
+	assert.equal(fixture.context.statuses.get("plan-mode"), "plan ready");
+
+	await emitLifecycle(
+		fixture.mock.events,
+		"before_agent_start",
+		{ prompt: "revise", systemPrompt: "base" },
+		fixture.context.ctx,
+	);
+	const writesBeforeRevisionRejection = fixture.activeToolWrites.length;
+	await startGoal(fixture, "Goal rejected during revision");
+	assert.equal(fixture.activeToolWrites.length, writesBeforeRevisionRejection);
+	assert.equal(fixture.context.statuses.get("plan-mode"), "plan active");
+	assertOneHolder(fixture);
+});
+
+test("paused Goal cannot resume or widen tools while Plan holds", async () => {
+	const fixture = createFixture("goal-first");
+	await startSession(fixture);
+	await startGoal(fixture, "Goal to pause");
+	await fixture.mock.commands.get("goal")?.handler("pause", fixture.context.ctx);
+	await startPlan(fixture);
+	const planTools = fixture.mock.rawPi.getActiveTools();
+	const writesBeforeResume = fixture.activeToolWrites.length;
+	const entriesBeforeResume = fixture.mock.entries.length;
+	await fixture.mock.commands.get("goal")?.handler("resume", fixture.context.ctx);
+	assert.equal(goalStatus(fixture.mock.entries), "paused");
+	assert.equal(fixture.activeToolWrites.length, writesBeforeResume);
+	assert.equal(fixture.mock.entries.length, entriesBeforeResume);
+	assert.deepEqual(fixture.mock.rawPi.getActiveTools(), planTools);
+	assert.match(fixture.context.notifications.at(-1)?.message ?? "", /Another workflow/u);
+});
+
+test("waiting Goal rejects Plan direct, prompted, menu, selected-tool, and shortcut starts", async () => {
+	const captured: CapturedPlanUi = {};
+	const fixture = createFixture("goal-first", {
+		capturePlanUi: captured,
+		planShortcut: true,
+	});
+	await startSession(fixture);
+	await startGoal(fixture, "Goal waiting for an external event");
+	const activeGoal = latestStateEntry(fixture.mock.entries, "goal-state")?.goal as {
+		id: string;
+	};
+	const waitTool = fixture.mock.tools.find((tool) => tool.name === "goal_wait")?.execute as (
+		...args: unknown[]
+	) => Promise<unknown>;
+	await waitTool(
+		"wait",
+		{ goal_id: activeGoal.id, reason: "external review" },
+		undefined,
+		undefined,
+		fixture.context.ctx,
+	);
+	const goalTools = fixture.mock.rawPi.getActiveTools();
+	const writesBefore = fixture.activeToolWrites.length;
+	const entriesBefore = fixture.mock.entries.length;
+	const promptsBefore = fixture.mock.sentUserMessages.length;
+
+	await startPlan(fixture);
+	await startPlan(fixture, "prompted Plan start");
+	await fixture.mock.commands.get("plan")?.handler("", fixture.context.ctx);
+	assert.ok(captured.launch);
+	captured.launch.start(new AbortController().signal);
+	captured.launch.startWithTools(["read"], new AbortController().signal);
+	await fixture.mock.shortcuts.get("ctrl+shift+p")?.handler(fixture.context.ctx);
+
+	assert.equal(fixture.activeToolWrites.length, writesBefore);
+	assert.equal(fixture.mock.entries.length, entriesBefore);
+	assert.equal(fixture.mock.sentUserMessages.length, promptsBefore);
+	assert.deepEqual(fixture.mock.rawPi.getActiveTools(), goalTools);
+	assert.equal(goalStatus(fixture.mock.entries), "active");
+	assertOneHolder(fixture);
+});
+
+test("Plan holder rejects managed-run Goal activation with one terminal error", async () => {
+	const fixture = createFixture("plan-first", { goalRpc: true });
+	await startSession(fixture);
+	await startPlan(fixture);
+	const events: unknown[] = [];
+	fixture.mock.eventBus.on("pi-goal:event:coexistence-run", (event) => events.push(event));
+	const writesBefore = fixture.activeToolWrites.length;
+	const entriesBefore = fixture.mock.entries.length;
+	fixture.mock.eventBus.emit("pi-goal:start", {
+		runId: "coexistence-run",
+		objective: "managed Goal blocked by Plan",
+	});
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(events, [
+		{
+			type: "error",
+			runId: "coexistence-run",
+			operation: "start",
+			error: {
+				code: "ACTIVATION_FAILED",
+				message: "Another workflow is active in this session. End it before starting Goal.",
+			},
+		},
+	]);
+	assert.equal(fixture.activeToolWrites.length, writesBefore);
+	assert.equal(fixture.mock.entries.length, entriesBefore);
+	assert.equal(goalStatus(fixture.mock.entries), null);
+	assertOneHolder(fixture);
+});
+
+test("restored Goal rejects --plan startup activation without a Plan commit", async () => {
+	const branch = [goalEntry(activeGoal("flag-holder"))];
+	const fixture = createFixture("goal-first", { branch });
+	const flag = fixture.mock.flags.get("plan");
+	assert.ok(flag);
+	flag.value = true;
+	await startSession(fixture, "resume");
+	assert.equal(goalStatus(fixture.mock.entries), "active");
+	assert.equal(latestStateEntry(fixture.mock.entries, "plan-mode-state"), undefined);
+	assert.equal(fixture.context.statuses.get("plan-mode"), undefined);
+	assert.match(fixture.context.notifications.at(-1)?.message ?? "", /was not restored/u);
+	assertOneHolder(fixture);
+});
+
+for (const loadOrder of ["plan-first", "goal-first"] as const) {
+	test(`${loadOrder} simultaneous restore selects one safe holder`, async () => {
+		const branch = [planEntry({ enabled: true, awaitingAction: false }), goalEntry(activeGoal())];
+		const fixture = createFixture(loadOrder, { branch });
+		await startSession(fixture, "resume");
+		assertOneHolder(fixture);
+		if (loadOrder === "plan-first") {
+			assert.equal(fixture.context.statuses.get("plan-mode"), "plan active");
+			assert.equal(goalStatus(fixture.mock.entries), "paused");
+			assert.deepEqual(fixture.mock.rawPi.getActiveTools(), [
+				"bash",
+				"read",
+				"plan_mode_question",
+				"plan_mode_complete",
+			]);
+		} else {
+			assert.equal(fixture.context.statuses.get("plan-mode"), undefined);
+			assert.equal(goalStatus(fixture.mock.entries), "active");
+			assert.match(fixture.context.statuses.get("goal") ?? "", /^active/u);
+			assert.deepEqual(fixture.mock.rawPi.getActiveTools(), [
+				"read",
+				"bash",
+				"write",
+				"goal_complete",
+				"goal_blocked",
+				"goal_wait",
+			]);
+		}
+	});
+}
+
+test("each workflow can acquire only after the other finishes cleanup", async () => {
+	const fixture = createFixture("plan-first");
+	await startSession(fixture);
+	await startPlan(fixture);
+	await fixture.mock.commands.get("plan")?.handler("exit", fixture.context.ctx);
+	await startGoal(fixture, "Goal after Plan cleanup");
+	assert.equal(goalStatus(fixture.mock.entries), "active");
+	assertOneHolder(fixture);
+
+	await fixture.mock.commands.get("goal")?.handler("pause", fixture.context.ctx);
+	await startPlan(fixture);
+	assert.equal(
+		(latestStateEntry(fixture.mock.entries, "plan-mode-state") as { enabled?: boolean })?.enabled,
+		true,
+	);
+	assertOneHolder(fixture);
+});
+
+test("standalone Plan and Goal preserve representative lifecycle behavior", async () => {
+	const planMock = createMockPi({ activeTools: ["read", "write"] });
+	planMode(planMock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const planContext = createMockContext({ mode: "tui", hasUI: true });
+	await emitLifecycle(planMock.events, "session_start", { reason: "startup" }, planContext.ctx);
+	await planMock.commands.get("plan")?.handler("start", planContext.ctx);
+	assert.equal(planContext.statuses.get("plan-mode"), "plan active");
+	await planMock.commands.get("plan")?.handler("exit", planContext.ctx);
+	assert.equal(planContext.statuses.get("plan-mode"), undefined);
+
+	const goalMock = createMockPi({
+		activeTools: ["read", "goal_complete", "goal_blocked", "goal_wait"],
+	});
+	goal(goalMock.pi, { settingsPath: goalSettingsPath });
+	const goalContext = createMockContext({ mode: "tui", hasUI: true });
+	await emitLifecycle(goalMock.events, "session_start", { reason: "startup" }, goalContext.ctx);
+	await goalMock.commands.get("goal")?.handler("standalone Goal", goalContext.ctx);
+	assert.equal(goalStatus(goalMock.entries), "active");
+	await goalMock.commands.get("goal")?.handler("pause", goalContext.ctx);
+	assert.equal(goalStatus(goalMock.entries), "paused");
+});
+
+test("built generated entries share one Pi bus and stale invalidation removes both listeners", async () => {
+	const agentDir = join(root, "generated-agent");
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		const eventBus = createEventBus();
+		const loader = new DefaultResourceLoader({
+			cwd: root,
+			agentDir,
+			settingsManager: SettingsManager.inMemory({}),
+			eventBus,
+			additionalExtensionPaths: [
+				join(process.cwd(), "packages/pi-plan-mode/dist/index.ts"),
+				join(process.cwd(), "packages/pi-goal/dist/index.ts"),
+			],
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+			noContextFiles: true,
+		});
+		await loader.reload();
+		const loaded = loader.getExtensions();
+		assert.deepEqual(loaded.errors, []);
+		assert.equal(loaded.extensions.length, 2);
+		assert.ok(loaded.extensions.some((extension) => extension.commands.has("plan")));
+		assert.ok(loaded.extensions.some((extension) => extension.commands.has("goal")));
+		assert.ok(loaded.extensions.some((extension) => extension.tools.has("plan_mode_complete")));
+		assert.ok(loaded.extensions.some((extension) => extension.tools.has("goal_complete")));
+
+		let activeTools = ["read", "write", "goal_complete", "goal_blocked", "goal_wait"];
+		const sessionManager = {
+			getSessionId: () => "generated-coexistence",
+			getSessionName: () => undefined,
+			getSessionFile: () => undefined,
+			getBranch: () => [],
+			getEntries: () => [],
+		};
+		const runner = new ExtensionRunner(
+			loaded.extensions,
+			loaded.runtime,
+			root,
+			sessionManager as never,
+			{} as never,
+		);
+		runner.bindCore(
+			{
+				sendMessage: () => undefined,
+				sendUserMessage: () => undefined,
+				appendEntry: () => undefined,
+				setSessionName: () => undefined,
+				getSessionName: () => undefined,
+				setLabel: () => undefined,
+				getActiveTools: () => [...activeTools],
+				getAllTools: () => [
+					builtinTool("read"),
+					builtinTool("write"),
+					extensionTool("goal_complete"),
+					extensionTool("goal_blocked"),
+					extensionTool("goal_wait"),
+				],
+				setActiveTools: (names: string[]) => {
+					activeTools = [...names];
+				},
+				refreshTools: () => undefined,
+				getCommands: () => [],
+				setModel: async () => true,
+				getThinkingLevel: () => "off",
+				setThinkingLevel: () => undefined,
+			} as never,
+			{
+				getModel: () => undefined,
+				getScopedModels: () => [],
+				isIdle: () => true,
+				isProjectTrusted: () => true,
+				getSignal: () => undefined,
+				abort: () => undefined,
+				hasPendingMessages: () => false,
+				shutdown: () => undefined,
+				getContextUsage: () => undefined,
+				compact: () => undefined,
+				getSystemPrompt: () => "",
+				getSystemPromptOptions: () => ({ cwd: root }),
+			} as never,
+		);
+		const goalCommand = runner.getCommand("goal");
+		assert.ok(goalCommand);
+		await goalCommand.handler("generated shared-bus goal", runner.createCommandContext());
+		const active = workflowAttempt(sessionManager);
+		eventBus.emit(WORKFLOW_MUTEX_CHANNEL, active);
+		assert.equal(active.busy, true);
+
+		loaded.runtime.invalidate("generated coexistence reload");
+		const stale = workflowAttempt(sessionManager);
+		eventBus.emit(WORKFLOW_MUTEX_CHANNEL, stale);
+		assert.equal(stale.busy, false);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	}
+});


### PR DESCRIPTION
## Summary

- prove both source load orders and both acquisition orders select exactly one workflow holder
- cover Plan ready/revision, Goal waiting, managed-run rejection, startup-flag rejection, simultaneous restoration, release/reacquisition, and standalone parity
- load both generated package entries through Pi's Jiti resource loader on one event bus and prove stale listener cleanup
- derive reciprocal compatibility floors from Changesets: Plan mode `0.52.0`, Goal `0.53.0`, on characterized Pi `0.84.2`
- advance protocol and roadmap status only to the level supported by the final evidence
- add a durable release-readiness handoff without publishing

## Verification

- runtime characterization and coexistence suites: 17 tests
- Plan package suite: 203 tests across 18 files
- Goal package suite: 295 tests across 21 files
- both package builds and generated-entry/Jiti loader tests
- Goal deterministic runtime smoke
- `npm run check`
- `npm test` (402 files, 3,805 tests)
- both package dry-run pack inspections
- `npm run changeset:status` confirms Plan `0.52.0` and Goal `0.53.0` release intent

One preceding full-suite run hit a transient `pi-subagents` semantic-resource revalidation failure; its focused 25-test retry and the complete final rerun passed without a code change.

## Release readiness

The complete matrix, compatibility limits, guide audit, pack evidence, deviations, and unverified paths are recorded in `docs/implementation-notes/2026-08-22_plan-goal-coexistence-release-readiness.md`.

No package publication, npm visibility change, tag, GitHub release, release-workflow dispatch, or `pi-workflow` deprecation was performed.
