### PR TITLE
chore: remove stale Biome exclusions

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,13 +6,7 @@
 		"useIgnoreFile": true
 	},
 	"files": {
-		"includes": [
-			"**",
-			"!deprecated",
-			"!package-lock.json",
-			"!packages/pi-image-drop/src/web/{app.js,state.js,styles.css}",
-			"!packages/pi-webui/src/web/{app.css,app.js,image-drag.js,markdown.js,state.js,transcript.js}"
-		]
+		"includes": ["**", "!deprecated", "!package-lock.json"]
 	},
 	"formatter": {
 		"enabled": true,


### PR DESCRIPTION
## Summary

- remove Biome exclusions for the deprecated `pi-image-drop` and `pi-webui` package paths
- retain the root `deprecated` exclusion that already covers both archived packages

## Checks

- `npm run check`
- pre-commit `npm run biome:check && npm run typecheck`
