### PR TITLE
feat(codex-compact): support Codex provider aliases

### DIFF
--- a/.changeset/codex-provider-aliases.md
+++ b/.changeset/codex-provider-aliases.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-codex-compact": patch
+---
+
+Support `pi-multi-account` Codex provider aliases such as `openai-codex-account-2`.

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-codex-compact)](https://www.npmjs.com/package/@narumitw/pi-codex-compact) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Use OpenAI Codex Remote Compaction V2 in Pi instead of generating a local plaintext summary for compatible `openai-codex` sessions.
+Use OpenAI Codex Remote Compaction V2 in Pi instead of generating a local plaintext summary for compatible `openai-codex` sessions, including `pi-multi-account` aliases such as `openai-codex-account-2`.
 
 The extension requests and stores an opaque server-generated checkpoint, then safely replays it in later Codex Responses requests.
 
@@ -10,7 +10,7 @@ Pi still decides when compaction runs and retains its normal `/compact`, thresho
 
 ## ✨ Features
 
-- Uses the active `openai-codex` OAuth credentials without persisting tokens or request headers.
+- Uses the active `openai-codex` OAuth credentials (including `openai-codex-*` provider aliases) without persisting tokens or request headers.
 - Handles manual, threshold, and overflow compaction through Pi's existing lifecycle.
 - Validates and persists one bounded opaque checkpoint that survives compatible reloads, resumes, and forks.
 - Replays the latest checkpoint while preserving newer conversation and extension context.
@@ -46,7 +46,7 @@ Avoid loading a global npm installation and the local workspace at the same time
 ## 🚀 Quick start
 
 1. Sign in through Pi's built-in OpenAI Codex OAuth provider.
-2. Select a model whose provider is `openai-codex` and API is `openai-codex-responses`.
+2. Select a model whose provider is `openai-codex` or an `openai-codex-*` alias and whose API is `openai-codex-responses`.
 3. Work normally.
    Pi's automatic compaction and built-in `/compact` continue to operate.
 4. Run `/codex-compact` to inspect the effective route or choose **Compact now**.
@@ -129,11 +129,11 @@ This extension does **not** read `~/.codex/config.toml`.
 ## ✅ Requirements and compatibility
 
 - Pi APIs compatible with the package's declared peer dependencies.
-- The built-in provider `openai-codex`.
+- The built-in provider `openai-codex`, or a compatible `openai-codex-*` alias such as those created by `pi-multi-account`.
 - API `openai-codex-responses` on the active model.
 - A working OpenAI Codex OAuth login and Remote V2 entitlement.
 
-OpenAI API-key, Azure, GitHub Copilot, proxies, and arbitrary Responses-compatible providers are not supported.
+OpenAI API-key, Azure, GitHub Copilot, proxies, and arbitrary Responses-compatible providers are not supported. Checkpoints remain bound to the exact provider alias that created them, so switching between Codex accounts does not replay one account's opaque checkpoint through another account.
 Switching to another provider or model leaves Pi's visible fallback marker plus retained recent messages in context.
 Switching back to the checkpoint's original compatible model restores opaque replay.
 

--- a/packages/pi-codex-compact/src/checkpoint.ts
+++ b/packages/pi-codex-compact/src/checkpoint.ts
@@ -9,11 +9,21 @@ export const REPLACEMENT_TOKEN_BUDGET = 64_000;
 export const REPLACEMENT_BYTE_BUDGET = 8 * 1024 * 1024;
 const MAX_MEDIA_ITEM_BYTES = 2 * 1024 * 1024;
 
+export type CodexProvider = "openai-codex" | `openai-codex-${string}`;
+
+export function isCodexProvider(value: unknown): value is CodexProvider {
+	return (
+		typeof value === "string" &&
+		(value === "openai-codex" ||
+			(value.startsWith("openai-codex-") && value.length > "openai-codex-".length))
+	);
+}
+
 export interface CodexCheckpointDetails {
 	kind: typeof CHECKPOINT_KIND;
 	version: typeof CHECKPOINT_VERSION;
 	checkpointId: string;
-	provider: "openai-codex";
+	provider: CodexProvider;
 	api: "openai-codex-responses";
 	modelId: string;
 	protocol: "remote-compaction-v2";
@@ -77,7 +87,7 @@ export function parseCheckpointDetails(value: unknown): CodexCheckpointDetails |
 		value.version !== CHECKPOINT_VERSION ||
 		typeof value.checkpointId !== "string" ||
 		value.checkpointId.length < 8 ||
-		value.provider !== "openai-codex" ||
+		!isCodexProvider(value.provider) ||
 		value.api !== "openai-codex-responses" ||
 		typeof value.modelId !== "string" ||
 		value.protocol !== "remote-compaction-v2" ||
@@ -254,6 +264,7 @@ export function buildReplacementHistory(
 }
 
 export function createCheckpointDetails(input: {
+	provider: CodexProvider;
 	modelId: string;
 	replacementHistory: JsonObject[];
 	keptMessages: readonly AgentMessage[];
@@ -264,7 +275,7 @@ export function createCheckpointDetails(input: {
 		kind: CHECKPOINT_KIND,
 		version: CHECKPOINT_VERSION,
 		checkpointId: input.checkpointId ?? randomUUID(),
-		provider: "openai-codex",
+		provider: input.provider,
 		api: "openai-codex-responses",
 		modelId: input.modelId,
 		protocol: "remote-compaction-v2",

--- a/packages/pi-codex-compact/src/codex-compact.ts
+++ b/packages/pi-codex-compact/src/codex-compact.ts
@@ -13,9 +13,11 @@ import {
 import {
 	buildReplacementHistory,
 	type CodexCheckpointDetails,
+	type CodexProvider,
 	checkpointMarker,
 	createCheckpointDetails,
 	fallbackSummary,
+	isCodexProvider,
 	latestCheckpoint,
 	projectCheckpointContext,
 } from "./checkpoint.js";
@@ -30,8 +32,10 @@ import {
 
 const STATUS_KEY = "codex-compact";
 
-function isSupportedModel(model: Model<Api> | undefined): model is Model<"openai-codex-responses"> {
-	return model?.provider === "openai-codex" && hasApi(model, "openai-codex-responses");
+type CodexModel = Model<"openai-codex-responses"> & { provider: CodexProvider };
+
+function isSupportedModel(model: Model<Api> | undefined): model is CodexModel {
+	return isCodexProvider(model?.provider) && hasApi(model, "openai-codex-responses");
 }
 
 function activeCheckpoint(ctx: ExtensionContext) {
@@ -41,8 +45,10 @@ function activeCheckpoint(ctx: ExtensionContext) {
 function isCheckpointCompatible(
 	details: CodexCheckpointDetails,
 	model: Model<Api> | undefined,
-): model is Model<"openai-codex-responses"> {
-	return isSupportedModel(model) && model.id === details.modelId;
+): model is CodexModel {
+	return (
+		isSupportedModel(model) && model.provider === details.provider && model.id === details.modelId
+	);
 }
 
 function keptMessages(event: SessionBeforeCompactEvent): AgentMessage[] {
@@ -77,8 +83,8 @@ function projectedCurrentMessages(
 	const session = buildSessionContext(event.branchEntries, leafId);
 	const prior = latestCheckpoint(event.branchEntries)?.details;
 	if (!prior) return { messages: session.messages };
-	if (prior.modelId !== model.id) {
-		throw new Error("The active opaque checkpoint belongs to a different Codex model");
+	if (prior.provider !== model.provider || prior.modelId !== model.id) {
+		throw new Error("The active opaque checkpoint belongs to a different Codex provider or model");
 	}
 	const projected = projectCheckpointContext(session.messages, prior);
 	if (!projected) {
@@ -149,6 +155,7 @@ async function compactRemotely(
 			tokenBudget: settings.replacementTokenBudget,
 		});
 		const details = createCheckpointDetails({
+			provider: model.provider,
 			modelId: model.id,
 			replacementHistory,
 			keptMessages: keptMessages(event),

--- a/packages/pi-codex-compact/src/settings-menu.ts
+++ b/packages/pi-codex-compact/src/settings-menu.ts
@@ -1,5 +1,6 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { MenuDefinition } from "@narumitw/pi-tui-kit";
+import { isCodexProvider } from "./checkpoint.js";
 import type {
 	CodexCompactSettings,
 	CodexCompactSettingsRuntime,
@@ -221,7 +222,7 @@ function compactMenuStatus(ctx: ExtensionCommandContext): CompactMenuStatus {
 	const model = ctx.model;
 	return {
 		model: model ? `${model.provider}/${model.id}` : "none",
-		remoteCompatible: model?.provider === "openai-codex" && model.api === "openai-codex-responses",
+		remoteCompatible: isCodexProvider(model?.provider) && model.api === "openai-codex-responses",
 	};
 }
 

--- a/packages/pi-codex-compact/test/checkpoint.test.ts
+++ b/packages/pi-codex-compact/test/checkpoint.test.ts
@@ -29,6 +29,7 @@ const opaque = { type: "compaction", encrypted_content: "opaque" };
 
 function checkpoint(kept: AgentMessage[] = [user("kept", 2)], id = "checkpoint-123") {
 	return createCheckpointDetails({
+		provider: "openai-codex",
 		modelId: "gpt-5.6",
 		replacementHistory: [rawUser("old"), opaque],
 		keptMessages: kept,
@@ -113,6 +114,11 @@ test("drops media that cannot fit the checkpoint byte budget", () => {
 test("validates versioned details and rejects malformed or unbounded persisted data", () => {
 	const details = checkpoint();
 	assert.deepEqual(parseCheckpointDetails(details), details);
+	assert.equal(
+		parseCheckpointDetails({ ...details, provider: "openai-codex-account-2" })?.provider,
+		"openai-codex-account-2",
+	);
+	assert.equal(parseCheckpointDetails({ ...details, provider: "openai" }), undefined);
 	assert.equal(parseCheckpointDetails({ ...details, version: 2 }), undefined);
 	assert.equal(parseCheckpointDetails({ ...details, replacementHistory: [] }), undefined);
 	assert.equal(parseCheckpointDetails({ ...details, keptMessageFingerprints: ["bad"] }), undefined);

--- a/packages/pi-codex-compact/test/lifecycle.test.ts
+++ b/packages/pi-codex-compact/test/lifecycle.test.ts
@@ -29,6 +29,11 @@ const model = {
 	maxTokens: 10_000,
 } as Model<"openai-codex-responses">;
 
+const accountModel = {
+	...model,
+	provider: "openai-codex-account-2",
+} as Model<"openai-codex-responses">;
+
 const usage = {
 	input: 20,
 	output: 1,
@@ -269,6 +274,26 @@ test("registers the settings command and returns a versioned Remote V2 compactio
 	)) as { input: Array<Record<string, unknown>> };
 	assert.equal(rewritten.input.at(-2)?.type, "compaction");
 	assert.match(JSON.stringify(rewritten.input.at(-1)), /later/);
+
+	const crossAlias = createMockContext({
+		model: accountModel,
+		getSystemPrompt: () => "system",
+		sessionManager: {
+			getSessionId: () => "session",
+			getBranch: () => [...entries, compactionEntry],
+		},
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "secret-oauth" }),
+			getProvider: () => fakeProvider(),
+		},
+		hasUI: true,
+	});
+	const crossAliasResult = await handler?.(
+		{ ...event(), branchEntries: [...entries, compactionEntry] },
+		crossAlias.ctx,
+	);
+	assert.equal(crossAliasResult, undefined);
+	assert.match(crossAlias.notifications.at(-1)?.message ?? "", /different Codex provider or model/);
 });
 
 test("valid session startup reloads settings without a package warning", async () => {
@@ -354,6 +379,14 @@ test("disabled, unsupported, auth-failed, and aborted compaction paths remain sa
 		};
 	};
 	assert.equal((await run({ settings: settingsRuntime({ enabled: false }) })).result, undefined);
+	const account = await run({
+		model: accountModel,
+		auth: { ok: true, apiKey: "secret-oauth" },
+	});
+	const accountDetails = parseCheckpointDetails(
+		(account.result as { compaction?: { details?: unknown } } | undefined)?.compaction?.details,
+	);
+	assert.equal(accountDetails?.provider, accountModel.provider);
 	assert.equal(
 		(
 			await run({


### PR DESCRIPTION
## Summary

- accept `openai-codex-*` provider aliases such as `openai-codex-account-2`
- retain the `openai-codex-responses` API requirement
- bind persisted checkpoints to the exact provider alias that created them
- prevent opaque checkpoints from replaying across Codex accounts
- update menu compatibility detection and package documentation
- add a patch Changeset for `@narumitw/pi-codex-compact`

## Verification

- `npm run --workspace @narumitw/pi-codex-compact build`
- `npm run --workspace @narumitw/pi-codex-compact typecheck`
- `pi --list-models` confirms the account aliases are available
- `/codex-compact` recognizes `openai-codex-account-2` and selects Codex Remote V2
- `git diff --check`
- Pi startup/package loading smoke passed

### Manual verification

<img width="771" height="261" alt="The Codex Remote Compaction menu recognizes an openai-codex account alias and selects Codex Remote V2" src="https://github.com/user-attachments/assets/7892e852-8230-41f4-9926-3f7e4ddb8857" />

## Release scope

This is a patch release for `@narumitw/pi-codex-compact` through the repository's Changesets release workflow.
