### PR TITLE
feat(plan-mode): default to conversation history

### DIFF
--- a/.changeset/calm-plans-use-history.md
+++ b/.changeset/calm-plans-use-history.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Make conversation-history-only implementation the default, use Codex-style kickoff prompts without active-plan injection, and clarify Plan availability wording.

--- a/.changeset/calm-plans-use-history.md
+++ b/.changeset/calm-plans-use-history.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-plan-mode": minor
 ---
 
-Make conversation-history-only implementation the default, use Codex-style kickoff prompts without active-plan injection, and clarify Plan availability wording.
+Make conversation-history-only implementation the default, use Codex-style kickoff prompts without active-plan injection, and clarify Plan reinjection controls.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -14,7 +14,7 @@ This independently installable extension adds a Codex-like `/plan` collaboration
 - Reviews the complete plan before implementation, export, save, continued planning, or discard.
 - Starts implementation in the planning session or a fresh linked session with the exact approved plan.
 - Persists Plan state and one saved plan across resume and compaction.
-- Exposes statusline state and configurable tool visibility, export destination, handoff behavior, shortcut, and thinking level.
+- Exposes statusline state and configurable tool visibility, export destination, plan availability, shortcut, and thinking level.
 - Cooperates anonymously with Workflow Mutex Protocol v1 participants so only one agent workflow starts in a session.
 
 ## 📦 Install
@@ -156,8 +156,8 @@ That compatibility path remains accepted, but it is not the primary workflow.
 Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and produce a warning.
 
 After completion, `/plan` opens the ready actions when interactive UI is available.
-The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews how long the approved plan will remain active.
-**Implement here**—and the compatibility route `/plan implement`—disables Plan mode, restores full tool access, captures the current **After Implement** policy, and starts implementation in the current session with its planning conversation.
+The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews the selected **Plan availability** policy.
+**Implement here**—and the compatibility route `/plan implement`—disables Plan mode, restores full tool access, captures the current policy, and starts implementation in the current session with its planning conversation.
 **Start fresh and implement** waits for the source session to become idle, verifies the selected model and authentication, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
 The destination still loads its normal `AGENTS.md`, skills, project resources, and extensions.
 Choosing **Export plan…** asks for a destination, writes the plan, restores normal tools and thinking, and leaves Plan mode without starting a model turn.
@@ -168,9 +168,11 @@ A successful fresh handoff does not delete or consume the source planning sessio
 Resume it later to inspect or hand off the ready/saved plan again; this deliberate duplication is the recovery path if the destination work is abandoned.
 In-memory sessions create an unlinked fresh session because no parent file exists.
 Escape, Ctrl+C, menu disposal, source replacement/shutdown, model/auth failure, or cancellation by another extension before replacement leaves the source plan unchanged.
-Once replacement succeeds, the destination persists active-plan state before kickoff.
-If persistence fails, the complete request is placed in the destination editor and the source remains resumable.
-If kickoff fails, the destination retains the active plan; send a message to continue, use `/plan exit` to clear it, or resume the parent planning session.
+Under **Conversation history only**, the destination receives the complete plan in its initial user prompt and does not persist active-plan state.
+If that kickoff fails, the complete request remains in the destination editor and the source remains resumable.
+Under either guaranteed-plan policy, the destination persists active-plan state before kickoff.
+If guaranteed-plan persistence fails, the complete request is placed in the destination editor and the source remains resumable.
+If a guaranteed-plan kickoff fails, the destination retains the active plan; send a message to continue, use `/plan exit` to clear it, or resume the parent planning session.
 
 A saved plan appears as `plan saved` and remains available after reload, resume, branch-local fork, and compaction in that session.
 It does not expire automatically, cross into a new session, or participate in ordinary model context.
@@ -187,20 +189,24 @@ Successful export is observable through the created file; exporting a ready plan
 An existing target or missing plan fails the command without changing state.
 These modes reject saved-plan display and implementation before changing state because Pi provides neither printable custom-message output nor acknowledged extension-triggered turns; resume the session in TUI or RPC to show or implement it.
 
-Both implementation paths apply the current **After Implement** policy in their destination; the fresh-session choice does not change retention semantics.
-With the default **Keep plan active** policy, the exact accepted plan remains active across later turns, session resume, and manual or automatic compaction without depending on the compaction summary.
-Plan mode avoids a duplicate context block while the original implementation handoff remains available and injects one hidden canonical copy after that handoff is compacted away.
-This can consume up to the existing 50,000-character plan limit in model context when reinjection is needed.
-**Use plan for handoff only** clears retained state immediately after the first implementation request receives the complete plan.
-**Clear after first implementation run** keeps the plan through that run, including retries, compaction retries, and queued continuation, then clears it at `agent_settled`.
+Both implementation paths apply the current **Plan availability** policy in their destination.
+The default **Conversation history only** policy does not create active-plan state or inject a hidden plan context.
+Implement here sends `Implement the plan.` and leaves the accepted plan in ordinary planning history.
+Start fresh and implement, or implementing a saved plan here, puts the complete plan in one ordinary initial user prompt because no reliable planning conversation is present.
+Later model calls then rely on Pi's normal conversation history and compaction behavior.
+**First implementation run** guarantees the exact plan throughout the first implementation run, including retries, compaction retries, and queued continuation, then clears active-plan state at `agent_settled`.
+**Until manually cleared** guarantees the exact plan across later turns, resume, and manual or automatic compaction until `/plan exit` or supersession.
+The guaranteed policies avoid a duplicate context block while the original implementation handoff remains available and inject one hidden canonical copy after that handoff is compacted away.
+Reinjection can consume up to the existing 50,000-character plan limit in model context.
 Cleanup is bound to the matching implementation, so an older run settling cannot clear a newer handoff.
 
-While implementation is active, `/plan show` displays the accepted plan.
+While a guaranteed plan is active, `/plan show` displays the accepted plan.
 Interactive `/plan` offers Show, Export plan…, Settings, Start a new plan, and Clear; `/plan exit` and `/plan off` are the direct clear routes.
-Settings changes never alter the policy already captured by the active implementation.
-Automatic cleanup has the same observable result as clearing: its active status and future injected plan context disappear, while the implementation request that triggered cleanup still receives the complete plan.
-Starting a new Plan-mode workflow or implementing a replacement plan supersedes the previous active plan.
-The extension deliberately does not infer completion from assistant prose or agent settlement, so clear the active plan when the implementation no longer applies.
+Settings changes never alter the policy already captured by an active guaranteed-plan implementation.
+Automatic first-run cleanup removes the active status and future injected context after the triggering implementation run has received the complete plan.
+Starting a new Plan-mode workflow or implementing a replacement plan supersedes an active guaranteed plan.
+The extension deliberately does not infer completion from assistant prose or agent settlement under **Until manually cleared**, so clear the active plan when it no longer applies.
+Under **Conversation history only**, implementation messages remain ordinary conversation history and there is no active plan for `/plan exit` to remove.
 Choosing Stay before implementation keeps the plan ready.
 Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives.
 For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable.
@@ -212,11 +218,11 @@ With `@narumitw/pi-statusline`, this appears in the extension status area:
 - `plan active`: Plan mode is enabled and still gathering context or drafting a plan.
 - `plan ready`: A completed plan is stored until you implement it, export it, save it, continue planning, or exit Plan mode.
 - `plan saved`: One completed plan is stored outside model context in the current session until you implement or clear it.
-- `plan implementing`: The exact accepted plan is currently retained under its captured **After Implement** policy.
+- `plan implementing`: The exact accepted plan is guaranteed under **First implementation run** or **Until manually cleared**.
 
 You can also exit directly.
 Before implementation, direct exit discards the latest proposed plan; while a plan is saved, it clears that saved plan.
-During implementation, it removes both the original implementation handoff and the extension's canonical active-plan block from later model calls; an earlier Pi-generated compaction summary may still describe prior work:
+During a guaranteed-plan implementation, it removes both the original implementation handoff and the extension's canonical active-plan block from later model calls; an earlier Pi-generated compaction summary may still describe prior work:
 
 ```text
 /plan exit
@@ -258,7 +264,7 @@ Guaranteed coexistence with Goal requires `@narumitw/pi-goal` `0.53.0` or newer 
 
 ## ⚙️ Settings
 
-Open **Settings** from an inactive `/plan` menu to edit one flat group of five workflow choices: **Plan thinking**, **Plan tools**, **After Implement**, **Export destination**, and **Plan mode shortcut**.
+Open **Settings** from an inactive `/plan` menu to edit one flat group of five workflow choices: **Plan thinking**, **Plan tools**, **Plan availability**, **Export destination**, and **Plan mode shortcut**.
 You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually.
 `safeSubcommands` remains JSON-only.
 You can change the Plan-mode shortcut with `toggleShortcut` as long as the file remains JSON-only and uses a valid key string.
@@ -268,7 +274,7 @@ When omitted, the shortcut is disabled by default.
 {
   "thinkingLevel": "inherit",
   "defaultPlanTools": ["read", "bash", "grep", "find", "ls"],
-  "implementationPlanRetention": "keep",
+  "implementationPlanRetention": "clear-on-start",
   "defaultPlanExportPath": "PLAN.md",
   "safeSubcommands": {
     "git": ["status", "log", "rev-parse", "blame"],
@@ -297,18 +303,20 @@ A selection accepted through **Choose tools, then start…** or `/plan tools` is
 The global setting remains the baseline for fresh sessions and sessions without an explicit selection.
 Settings saves immediately, but the saved tools and thinking level apply only when a later Plan workflow starts; they never mutate a workflow already in progress.
 
-### After Implement
+### Plan availability
 
-`implementationPlanRetention` controls the result of the next Implement action.
-Omit it or use `keep` for **Keep plan active**, the backward-compatible behavior that retains and reinjects the exact plan until `/plan exit` or supersession.
-Use `clear-on-start` for **Use plan for handoff only**: the first matching implementation request receives the complete plan, then retained state clears before later requests.
-Use `clear-after-first-run` to retain the plan until that implementation's first fully settled run ends.
-A resumed cleanup policy re-arms against the first context in the replacement session.
+The stable JSON field `implementationPlanRetention` controls how the next Implement action supplies the approved plan to model context.
+Omit it or use `clear-on-start` for **Conversation history only**, the default Codex-like behavior with no active-plan state or hidden context injection.
+In the planning session, this policy sends `Implement the plan.` and relies on the accepted plan already present in ordinary conversation history.
+A fresh session or saved-plan implementation instead places the complete plan in one ordinary kickoff prompt because its planning history is unavailable or intentionally excluded.
+Use `clear-after-first-run` for **First implementation run** to guarantee the exact plan until that implementation's first fully settled run ends.
+Use `keep` for **Until manually cleared** to guarantee and reinject the exact plan until `/plan exit` or supersession.
+A resumed guaranteed-plan cleanup policy re-arms against the first context in the replacement session.
 Failed handoff delivery restores the ready or saved plan and does not run automatic cleanup.
 
 Changing this setting applies to the next Implement action only.
-Each active implementation stores its effective policy, so a later Settings save cannot shorten or extend an implementation already in progress.
-`/plan exit` remains available under every policy.
+Each guaranteed-plan implementation stores its effective policy, so a later Settings save cannot shorten or extend an implementation already in progress.
+Conversation-history-only implementation has no active Plan-mode state to show, export, or clear after kickoff.
 
 ### Export destination
 
@@ -396,7 +404,7 @@ A missing file stays absent until an explicit save.
 Invalid JSON, invalid values, oversized content, non-regular files, and read failures make Settings read-only; the existing bytes and previous effective settings remain.
 This in-process queue is not a cross-process lock, so concurrent separate Pi processes can still race.
 
-Invalid settings produce a warning and fall back to inherited thinking, available safe-built-in tool defaults, `keep`, and `PLAN.md`.
+Invalid settings produce a warning and fall back to inherited thinking, available safe-built-in tool defaults, `clear-on-start`, and `PLAN.md`.
 Compatibility: a valid legacy `plan-mode.json` remains readable with a warning and is never modified automatically.
 If Settings is explicitly saved while only that legacy file exists, the extension creates canonical `pi-plan-mode.json` from the complete legacy document, applies the selected change, preserves unknown fields, and leaves the legacy file untouched.
 If both files exist, the canonical filename takes precedence.
@@ -410,7 +418,8 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 - The agent should use `plan_mode_question` for important non-discoverable preferences or tradeoffs before finalizing.
 - The agent completes with a standalone `plan_mode_complete` tool call instead of relying on semantic prose detection.
 - `update_plan` checklist use is blocked while Plan mode is active.
-- The implementation boundary is explicit: Plan mode restores tools before saving or starting implementation, saving keeps the plan outside ordinary model context, choosing implementation immediately triggers a normal agent turn with full tool access, and the accepted plan follows the captured `keep`, `clear-on-start`, or `clear-after-first-run` lifecycle.
+- The implementation boundary is explicit: Plan mode restores tools before saving or starting implementation, saving keeps the plan outside ordinary model context, and choosing implementation immediately triggers a normal agent turn with full tool access.
+- The default `clear-on-start` policy follows Codex by using ordinary conversation history only; `clear-after-first-run` and `keep` add explicit exact-plan guarantees.
 - Pi extension safety is approximated with tool classification and fail-closed filtering for every effective tool named `bash`; other non-built-in tools remain user-selected at user risk because Pi does not expose standardized tool mutability metadata.
 - Unlike native Codex, this extension uses a terminating Pi tool plus an `agent_settled` ready flow; Pi cannot provide sandbox-level enforcement.
 

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -14,7 +14,7 @@ This independently installable extension adds a Codex-like `/plan` collaboration
 - Reviews the complete plan before implementation, export, save, continued planning, or discard.
 - Starts implementation in the planning session or a fresh linked session with the exact approved plan.
 - Persists Plan state and one saved plan across resume and compaction.
-- Exposes statusline state and configurable tool visibility, export destination, plan availability, shortcut, and thinking level.
+- Exposes statusline state and configurable tool visibility, export destination, plan reinjection, shortcut, and thinking level.
 - Cooperates anonymously with Workflow Mutex Protocol v1 participants so only one agent workflow starts in a session.
 
 ## 📦 Install
@@ -156,7 +156,7 @@ That compatibility path remains accepted, but it is not the primary workflow.
 Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and produce a warning.
 
 After completion, `/plan` opens the ready actions when interactive UI is available.
-The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews the selected **Plan availability** policy.
+The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews the selected **Plan reinjection** policy.
 **Implement here**—and the compatibility route `/plan implement`—disables Plan mode, restores full tool access, captures the current policy, and starts implementation in the current session with its planning conversation.
 **Start fresh and implement** waits for the source session to become idle, verifies the selected model and authentication, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
 The destination still loads its normal `AGENTS.md`, skills, project resources, and extensions.
@@ -168,7 +168,7 @@ A successful fresh handoff does not delete or consume the source planning sessio
 Resume it later to inspect or hand off the ready/saved plan again; this deliberate duplication is the recovery path if the destination work is abandoned.
 In-memory sessions create an unlinked fresh session because no parent file exists.
 Escape, Ctrl+C, menu disposal, source replacement/shutdown, model/auth failure, or cancellation by another extension before replacement leaves the source plan unchanged.
-Under **Conversation history only**, the destination receives the complete plan in its initial user prompt and does not persist active-plan state.
+Under **Off — conversation history only**, the destination receives the complete plan in its initial user prompt and does not persist active-plan state.
 If that kickoff fails, the complete request remains in the destination editor and the source remains resumable.
 Under either guaranteed-plan policy, the destination persists active-plan state before kickoff.
 If guaranteed-plan persistence fails, the complete request is placed in the destination editor and the source remains resumable.
@@ -189,12 +189,12 @@ Successful export is observable through the created file; exporting a ready plan
 An existing target or missing plan fails the command without changing state.
 These modes reject saved-plan display and implementation before changing state because Pi provides neither printable custom-message output nor acknowledged extension-triggered turns; resume the session in TUI or RPC to show or implement it.
 
-Both implementation paths apply the current **Plan availability** policy in their destination.
-The default **Conversation history only** policy does not create active-plan state or inject a hidden plan context.
+Both implementation paths apply the current **Plan reinjection** policy in their destination.
+The default **Off — conversation history only** policy does not create active-plan state or inject a hidden plan context.
 Implement here sends `Implement the plan.` and leaves the accepted plan in ordinary planning history.
 Start fresh and implement, or implementing a saved plan here, puts the complete plan in one ordinary initial user prompt because no reliable planning conversation is present.
 Later model calls then rely on Pi's normal conversation history and compaction behavior.
-**First implementation run** guarantees the exact plan throughout the first implementation run, including retries, compaction retries, and queued continuation, then clears active-plan state at `agent_settled`.
+**Through first implementation run** guarantees the exact plan throughout that run, including retries, compaction retries, and queued continuation, then clears active-plan state at `agent_settled`.
 **Until manually cleared** guarantees the exact plan across later turns, resume, and manual or automatic compaction until `/plan exit` or supersession.
 The guaranteed policies avoid a duplicate context block while the original implementation handoff remains available and inject one hidden canonical copy after that handoff is compacted away.
 Reinjection can consume up to the existing 50,000-character plan limit in model context.
@@ -206,7 +206,7 @@ Settings changes never alter the policy already captured by an active guaranteed
 Automatic first-run cleanup removes the active status and future injected context after the triggering implementation run has received the complete plan.
 Starting a new Plan-mode workflow or implementing a replacement plan supersedes an active guaranteed plan.
 The extension deliberately does not infer completion from assistant prose or agent settlement under **Until manually cleared**, so clear the active plan when it no longer applies.
-Under **Conversation history only**, implementation messages remain ordinary conversation history and there is no active plan for `/plan exit` to remove.
+Under **Off — conversation history only**, implementation messages remain ordinary conversation history and there is no active plan for `/plan exit` to remove.
 Choosing Stay before implementation keeps the plan ready.
 Revision feedback starts another Plan-mode turn and clears the previous implementable plan until an updated completion arrives.
 For clarification-only follow-ups, the agent answers and resubmits the complete unchanged plan so it remains implementable.
@@ -218,7 +218,7 @@ With `@narumitw/pi-statusline`, this appears in the extension status area:
 - `plan active`: Plan mode is enabled and still gathering context or drafting a plan.
 - `plan ready`: A completed plan is stored until you implement it, export it, save it, continue planning, or exit Plan mode.
 - `plan saved`: One completed plan is stored outside model context in the current session until you implement or clear it.
-- `plan implementing`: The exact accepted plan is guaranteed under **First implementation run** or **Until manually cleared**.
+- `plan implementing`: The exact accepted plan is guaranteed under **Through first implementation run** or **Until manually cleared**.
 
 You can also exit directly.
 Before implementation, direct exit discards the latest proposed plan; while a plan is saved, it clears that saved plan.
@@ -264,7 +264,7 @@ Guaranteed coexistence with Goal requires `@narumitw/pi-goal` `0.53.0` or newer 
 
 ## ⚙️ Settings
 
-Open **Settings** from an inactive `/plan` menu to edit one flat group of five workflow choices: **Plan thinking**, **Plan tools**, **Plan availability**, **Export destination**, and **Plan mode shortcut**.
+Open **Settings** from an inactive `/plan` menu to edit one flat group of five workflow choices: **Plan thinking**, **Plan tools**, **Plan reinjection**, **Export destination**, and **Plan mode shortcut**.
 You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually.
 `safeSubcommands` remains JSON-only.
 You can change the Plan-mode shortcut with `toggleShortcut` as long as the file remains JSON-only and uses a valid key string.
@@ -303,13 +303,13 @@ A selection accepted through **Choose tools, then start…** or `/plan tools` is
 The global setting remains the baseline for fresh sessions and sessions without an explicit selection.
 Settings saves immediately, but the saved tools and thinking level apply only when a later Plan workflow starts; they never mutate a workflow already in progress.
 
-### Plan availability
+### Plan reinjection
 
-The stable JSON field `implementationPlanRetention` controls how the next Implement action supplies the approved plan to model context.
-Omit it or use `clear-on-start` for **Conversation history only**, the default Codex-like behavior with no active-plan state or hidden context injection.
+The stable JSON field `implementationPlanRetention` controls whether and how long the `context` hook restores the exact approved plan when ordinary model context no longer contains it.
+Omit it or use `clear-on-start` for **Off — conversation history only**, the default Codex-like behavior with no active-plan state or hidden context injection.
 In the planning session, this policy sends `Implement the plan.` and relies on the accepted plan already present in ordinary conversation history.
 A fresh session or saved-plan implementation instead places the complete plan in one ordinary kickoff prompt because its planning history is unavailable or intentionally excluded.
-Use `clear-after-first-run` for **First implementation run** to guarantee the exact plan until that implementation's first fully settled run ends.
+Use `clear-after-first-run` for **Through first implementation run** to guarantee the exact plan until that implementation's first fully settled run ends.
 Use `keep` for **Until manually cleared** to guarantee and reinject the exact plan until `/plan exit` or supersession.
 A resumed guaranteed-plan cleanup policy re-arms against the first context in the replacement session.
 Failed handoff delivery restores the ready or saved plan and does not run automatic cleanup.

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -115,7 +115,7 @@ export async function startFreshImplementationSession(
 	let setupError: string | undefined;
 	let kickoffError: string | undefined;
 
-	if (ctx.mode === "rpc") ctx.ui.notify("Starting fresh implementation session…", "info");
+	if (ctx.mode === "rpc") safeNotify(ctx, "Starting fresh implementation session…", "info");
 
 	let result: Awaited<ReturnType<ExtensionCommandContext["newSession"]>>;
 	try {
@@ -139,20 +139,26 @@ export async function startFreshImplementationSession(
 				}
 				try {
 					await replacementCtx.sendUserMessage(handoff);
-					replacementCtx.ui.notify(
-						"Fresh implementation session started. Only the approved plan was transferred.",
-						"info",
-					);
 				} catch (error: unknown) {
 					kickoffError = safeErrorDetail(error);
-					if (usesConversationHistory) replacementCtx.ui.setEditorText(handoff);
-					replacementCtx.ui.notify(
+					const recoveredInEditor =
+						usesConversationHistory && safeSetEditorText(replacementCtx, handoff);
+					safeNotify(
+						replacementCtx,
 						usesConversationHistory
-							? `Fresh session created, but implementation did not start: ${kickoffError}. The implementation request is in the editor; submit it or resume the parent planning session.`
+							? recoveredInEditor
+								? `Fresh session created, but implementation did not start: ${kickoffError}. The implementation request is in the editor; submit it or resume the parent planning session.`
+								: `Fresh session created, but implementation did not start: ${kickoffError}. The implementation request could not be restored to the editor; resume the parent planning session.`
 							: `Fresh session created, but implementation did not start: ${kickoffError}. Send a message to continue, use /plan exit to clear the active plan, or resume the parent planning session.`,
 						"error",
 					);
+					return;
 				}
+				safeNotify(
+					replacementCtx,
+					"Fresh implementation session started. Only the approved plan was transferred.",
+					"info",
+				);
 			},
 		});
 	} catch (error: unknown) {
@@ -165,7 +171,7 @@ export async function startFreshImplementationSession(
 	}
 
 	if (result.cancelled) {
-		ctx.ui.notify("Fresh implementation cancelled. The plan remains available.", "info");
+		safeNotify(ctx, "Fresh implementation cancelled. The plan remains available.", "info");
 		return { kind: "cancelled" };
 	}
 	return setupError || kickoffError ? { kind: "partial" } : { kind: "started" };
@@ -195,22 +201,35 @@ async function preflightModel(ctx: ExtensionCommandContext, isCurrent: () => boo
 }
 
 function recoverSetupFailure(ctx: ReplacementContext, handoff: string, setupError: string) {
-	ctx.ui.setEditorText(handoff);
-	ctx.ui.notify(
-		`Fresh session created, but the active plan could not be saved: ${setupError}. The implementation request is in the editor; submit it to continue or resume the parent planning session.`,
+	const recoveredInEditor = safeSetEditorText(ctx, handoff);
+	safeNotify(
+		ctx,
+		recoveredInEditor
+			? `Fresh session created, but the active plan could not be saved: ${setupError}. The implementation request is in the editor; submit it to continue or resume the parent planning session.`
+			: `Fresh session created, but the active plan could not be saved: ${setupError}. The implementation request could not be restored to the editor; resume the parent planning session.`,
 		"error",
 	);
 }
 
+function safeSetEditorText(ctx: Pick<ExtensionContext, "ui">, text: string) {
+	try {
+		ctx.ui.setEditorText(text);
+		return true;
+	} catch {
+		// A replacement context can become stale while Pi reports a partial handoff.
+		return false;
+	}
+}
+
 function safeNotify(
-	ctx: ExtensionCommandContext,
+	ctx: Pick<ExtensionContext, "ui">,
 	message: string,
 	level: "info" | "warning" | "error",
 ) {
 	try {
 		ctx.ui.notify(message, level);
 	} catch {
-		// The source context can become stale if Pi fails after replacement teardown.
+		// A source or replacement context can become stale during session replacement.
 	}
 }
 

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { PLAN_HISTORY_IMPLEMENTATION_PROMPT } from "./message-transform.js";
 import type { ImplementationPlanRetention } from "./settings.js";
 import type { PlanCompletionSource, PlanModeState } from "./state.js";
 
@@ -30,6 +31,15 @@ export type FreshImplementationResult =
 
 export function formatImplementationHandoff(plan: string) {
 	return `Plan mode is now disabled. Full tool access is restored. Implement this proposed plan now:\n\n${plan}`;
+}
+
+export function formatHistoryImplementationPrompt() {
+	return PLAN_HISTORY_IMPLEMENTATION_PROMPT;
+}
+
+export function formatTransferredPlanPrompt(plan: string, fresh: boolean) {
+	const destination = fresh ? " in a fresh context" : "";
+	return `A previous agent produced the plan below to accomplish the user's task. Implement the plan${destination}. Treat the plan as the source of user intent, re-read files as needed, and carry the work through implementation and verification.\n\n${plan}`;
 }
 
 export async function startFreshImplementationFromState(
@@ -84,19 +94,23 @@ export async function startFreshImplementationSession(
 	if (!(await preflightModel(ctx, request.isCurrent))) return { kind: "rejected" };
 	if (!request.isCurrent()) return { kind: "stale" };
 
-	const activeImplementation = {
-		id: randomUUID(),
-		plan: request.plan,
-		source: request.source,
-		startedAt: Date.now(),
-		retention: request.retention,
-	};
-	const destinationState: PlanModeState = {
-		enabled: false,
-		awaitingAction: false,
-		activeImplementation,
-	};
-	const handoff = formatImplementationHandoff(request.plan);
+	const usesConversationHistory = request.retention === "clear-on-start";
+	const destinationState: PlanModeState | undefined = usesConversationHistory
+		? undefined
+		: {
+				enabled: false,
+				awaitingAction: false,
+				activeImplementation: {
+					id: randomUUID(),
+					plan: request.plan,
+					source: request.source,
+					startedAt: Date.now(),
+					retention: request.retention,
+				},
+			};
+	const handoff = usesConversationHistory
+		? formatTransferredPlanPrompt(request.plan, true)
+		: formatImplementationHandoff(request.plan);
 	const parentSession = ctx.sessionManager.getSessionFile();
 	let setupError: string | undefined;
 	let kickoffError: string | undefined;
@@ -107,13 +121,17 @@ export async function startFreshImplementationSession(
 	try {
 		result = await ctx.newSession({
 			...(parentSession ? { parentSession } : {}),
-			setup: async (sessionManager) => {
-				try {
-					sessionManager.appendCustomEntry(request.stateEntryType, destinationState);
-				} catch (error: unknown) {
-					setupError = safeErrorDetail(error);
-				}
-			},
+			...(destinationState
+				? {
+						setup: async (sessionManager) => {
+							try {
+								sessionManager.appendCustomEntry(request.stateEntryType, destinationState);
+							} catch (error: unknown) {
+								setupError = safeErrorDetail(error);
+							}
+						},
+					}
+				: {}),
 			withSession: async (replacementCtx) => {
 				if (setupError) {
 					recoverSetupFailure(replacementCtx, handoff, setupError);
@@ -127,8 +145,11 @@ export async function startFreshImplementationSession(
 					);
 				} catch (error: unknown) {
 					kickoffError = safeErrorDetail(error);
+					if (usesConversationHistory) replacementCtx.ui.setEditorText(handoff);
 					replacementCtx.ui.notify(
-						`Fresh session created, but implementation did not start: ${kickoffError}. Send a message to continue, use /plan exit to clear the active plan, or resume the parent planning session.`,
+						usesConversationHistory
+							? `Fresh session created, but implementation did not start: ${kickoffError}. The implementation request is in the editor; submit it or resume the parent planning session.`
+							: `Fresh session created, but implementation did not start: ${kickoffError}. Send a message to continue, use /plan exit to clear the active plan, or resume the parent planning session.`,
 						"error",
 					);
 				}

--- a/packages/pi-plan-mode/src/implementation-retention.ts
+++ b/packages/pi-plan-mode/src/implementation-retention.ts
@@ -80,6 +80,10 @@ export function createImplementationRetentionCoordinator(): ImplementationRetent
 			const historyArtifactMessage = historyArtifact
 				? inactiveMessages[historyArtifact.messageIndex]
 				: undefined;
+			const historyToolCallMessage =
+				historyArtifact?.toolCallMessageIndex !== undefined
+					? inactiveMessages[historyArtifact.toolCallMessageIndex]
+					: undefined;
 			const filteredMessages = inactiveMessages
 				.filter(
 					(message) =>
@@ -91,7 +95,10 @@ export function createImplementationRetentionCoordinator(): ImplementationRetent
 						: stripProposedPlanBlocksFromMessage(message),
 				)
 				.map((message) =>
-					stripPlanModeCompletionCallsFromMessage(message, historyArtifact?.toolCallId),
+					stripPlanModeCompletionCallsFromMessage(
+						message,
+						message === historyToolCallMessage ? historyArtifact?.toolCallId : undefined,
+					),
 				)
 				.filter((message) => !isEmptyAssistantMessage(message));
 			if (!activeImplementation) return { messages: filteredMessages };

--- a/packages/pi-plan-mode/src/implementation-retention.ts
+++ b/packages/pi-plan-mode/src/implementation-retention.ts
@@ -15,18 +15,17 @@ import type { ActiveImplementationPlan, PlanModeState } from "./state.js";
 
 export function retentionLabel(retention: ImplementationPlanRetention) {
 	return {
-		"clear-on-start": "Conversation history only",
-		"clear-after-first-run": "First implementation run",
+		"clear-on-start": "Off — conversation history only",
+		"clear-after-first-run": "Through first implementation run",
 		keep: "Until manually cleared",
 	}[retention];
 }
 
 export function implementationRetentionPreview(retention: ImplementationPlanRetention) {
 	return {
-		"clear-on-start": "Plan availability: Use conversation history only.",
-		"clear-after-first-run":
-			"Plan availability: Guarantee the exact plan through the first implementation run.",
-		keep: "Plan availability: Guarantee the exact plan until /plan exit.",
+		"clear-on-start": "Plan reinjection: Off; use conversation history only.",
+		"clear-after-first-run": "Plan reinjection: Through the first implementation run.",
+		keep: "Plan reinjection: Until /plan exit.",
 	}[retention];
 }
 

--- a/packages/pi-plan-mode/src/implementation-retention.ts
+++ b/packages/pi-plan-mode/src/implementation-retention.ts
@@ -1,4 +1,5 @@
 import {
+	findHistoryImplementationArtifact,
 	injectActiveImplementationContext,
 	isEmptyAssistantMessage,
 	messageContainsExactPlanModeImplementationHandoff,
@@ -14,18 +15,18 @@ import type { ActiveImplementationPlan, PlanModeState } from "./state.js";
 
 export function retentionLabel(retention: ImplementationPlanRetention) {
 	return {
-		keep: "Keep plan active",
-		"clear-on-start": "Use plan for handoff only",
-		"clear-after-first-run": "Clear after first implementation run",
+		"clear-on-start": "Conversation history only",
+		"clear-after-first-run": "First implementation run",
+		keep: "Until manually cleared",
 	}[retention];
 }
 
 export function implementationRetentionPreview(retention: ImplementationPlanRetention) {
 	return {
-		keep: "After Implement: Keep plan active until /plan exit.",
-		"clear-on-start":
-			"After Implement: Use the plan for the implementation handoff only, then clear it.",
-		"clear-after-first-run": "After Implement: Clear after the first implementation run settles.",
+		"clear-on-start": "Plan availability: Use conversation history only.",
+		"clear-after-first-run":
+			"Plan availability: Guarantee the exact plan through the first implementation run.",
+		keep: "Plan availability: Guarantee the exact plan until /plan exit.",
 	}[retention];
 }
 
@@ -74,10 +75,25 @@ export function createImplementationRetentionCoordinator(): ImplementationRetent
 				: messagesWithoutPlanContext.filter(
 						(message) => !messageContainsPlanModeImplementationHandoff(message),
 					);
+			const historyArtifact = activeImplementation
+				? undefined
+				: findHistoryImplementationArtifact(inactiveMessages);
+			const historyArtifactMessage = historyArtifact
+				? inactiveMessages[historyArtifact.messageIndex]
+				: undefined;
 			const filteredMessages = inactiveMessages
-				.filter((message) => !messageContainsInactivePlanModeArtifact(message))
-				.map(stripProposedPlanBlocksFromMessage)
-				.map(stripPlanModeCompletionCallsFromMessage)
+				.filter(
+					(message) =>
+						message === historyArtifactMessage || !messageContainsInactivePlanModeArtifact(message),
+				)
+				.map((message) =>
+					message === historyArtifactMessage && historyArtifact?.kind === "legacy"
+						? message
+						: stripProposedPlanBlocksFromMessage(message),
+				)
+				.map((message) =>
+					stripPlanModeCompletionCallsFromMessage(message, historyArtifact?.toolCallId),
+				)
 				.filter((message) => !isEmptyAssistantMessage(message));
 			if (!activeImplementation) return { messages: filteredMessages };
 

--- a/packages/pi-plan-mode/src/message-transform.ts
+++ b/packages/pi-plan-mode/src/message-transform.ts
@@ -125,32 +125,49 @@ interface HistoryImplementationArtifact {
 	messageIndex: number;
 	kind: "completion" | "legacy" | "presentation";
 	toolCallId?: string;
+	toolCallMessageIndex?: number;
 }
 
+// The kickoff text is intentionally generic, so only trust a plan artifact in the same
+// uninterrupted user/summary segment and require a complete tool-call/result pair.
 export function findHistoryImplementationArtifact(
 	messages: unknown[],
 ): HistoryImplementationArtifact | undefined {
-	let kickoffIndex = -1;
 	for (let index = messages.length - 1; index >= 0; index -= 1) {
 		const candidate = unwrapSessionMessage(messages[index]);
 		if (
-			candidate.role === "user" &&
-			contentText(candidate.content).trim() === PLAN_HISTORY_IMPLEMENTATION_PROMPT
+			candidate.role !== "user" ||
+			contentText(candidate.content).trim() !== PLAN_HISTORY_IMPLEMENTATION_PROMPT
 		) {
-			kickoffIndex = index;
-			break;
+			continue;
 		}
+		const artifact = findHistoryImplementationArtifactBeforeKickoff(messages, index);
+		if (artifact) return artifact;
 	}
-	if (kickoffIndex < 0) return undefined;
+	return undefined;
+}
 
+function findHistoryImplementationArtifactBeforeKickoff(
+	messages: unknown[],
+	kickoffIndex: number,
+): HistoryImplementationArtifact | undefined {
 	for (let index = kickoffIndex - 1; index >= 0; index -= 1) {
 		const candidate = unwrapSessionMessage(messages[index]);
+		if (candidate.role === "user" || isSummaryMessage(messages[index])) return undefined;
 		if (candidate.role === "toolResult" && candidate.toolName === PLAN_MODE_COMPLETE_TOOL_NAME) {
-			return {
-				messageIndex: index,
-				kind: "completion",
-				toolCallId: candidate.toolCallId,
-			};
+			const toolCallId = candidate.toolCallId;
+			const toolCallMessageIndex = toolCallId
+				? findPlanModeCompletionCallMessageIndex(messages, index, toolCallId)
+				: undefined;
+			if (toolCallId && toolCallMessageIndex !== undefined) {
+				return {
+					messageIndex: index,
+					kind: "completion",
+					toolCallId,
+					toolCallMessageIndex,
+				};
+			}
+			continue;
 		}
 		if (candidate.customType === PROPOSED_PLAN_MESSAGE_TYPE) {
 			return { messageIndex: index, kind: "presentation" };
@@ -160,6 +177,31 @@ export function findHistoryImplementationArtifact(
 			contentText(candidate.content).match(PROPOSED_PLAN_BLOCK_PATTERN)
 		) {
 			return { messageIndex: index, kind: "legacy" };
+		}
+	}
+	return undefined;
+}
+
+function findPlanModeCompletionCallMessageIndex(
+	messages: unknown[],
+	endIndex: number,
+	toolCallId: string,
+) {
+	for (let index = endIndex - 1; index >= 0; index -= 1) {
+		const candidate = unwrapSessionMessage(messages[index]);
+		if (candidate.role === "user" || isSummaryMessage(messages[index])) return undefined;
+		if (!Array.isArray(candidate.content)) continue;
+		if (
+			candidate.content.some((block) => {
+				const toolCall = block as { type?: string; id?: string; name?: string };
+				return (
+					toolCall.type === "toolCall" &&
+					toolCall.id === toolCallId &&
+					toolCall.name === PLAN_MODE_COMPLETE_TOOL_NAME
+				);
+			})
+		) {
+			return index;
 		}
 	}
 	return undefined;

--- a/packages/pi-plan-mode/src/message-transform.ts
+++ b/packages/pi-plan-mode/src/message-transform.ts
@@ -6,6 +6,7 @@ export const PLAN_IMPLEMENTATION_CONTEXT_MESSAGE_TYPE = "plan-mode-implementatio
 const PROPOSED_PLAN_MESSAGE_TYPE = "proposed-plan";
 const PLAN_IMPLEMENTATION_HANDOFF_PREFIX =
 	"Plan mode is now disabled. Full tool access is restored. Implement this proposed plan now:";
+export const PLAN_HISTORY_IMPLEMENTATION_PROMPT = "Implement the plan.";
 const PROPOSED_PLAN_PATTERN =
 	/^<proposed_plan>[\t ]*\r?\n([\s\S]*?)\r?\n<\/proposed_plan>[\t ]*$/gm;
 const PROPOSED_PLAN_BLOCK_PATTERN =
@@ -120,6 +121,50 @@ export function messageContainsInactivePlanModeArtifact(message: unknown) {
 	);
 }
 
+interface HistoryImplementationArtifact {
+	messageIndex: number;
+	kind: "completion" | "legacy" | "presentation";
+	toolCallId?: string;
+}
+
+export function findHistoryImplementationArtifact(
+	messages: unknown[],
+): HistoryImplementationArtifact | undefined {
+	let kickoffIndex = -1;
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const candidate = unwrapSessionMessage(messages[index]);
+		if (
+			candidate.role === "user" &&
+			contentText(candidate.content).trim() === PLAN_HISTORY_IMPLEMENTATION_PROMPT
+		) {
+			kickoffIndex = index;
+			break;
+		}
+	}
+	if (kickoffIndex < 0) return undefined;
+
+	for (let index = kickoffIndex - 1; index >= 0; index -= 1) {
+		const candidate = unwrapSessionMessage(messages[index]);
+		if (candidate.role === "toolResult" && candidate.toolName === PLAN_MODE_COMPLETE_TOOL_NAME) {
+			return {
+				messageIndex: index,
+				kind: "completion",
+				toolCallId: candidate.toolCallId,
+			};
+		}
+		if (candidate.customType === PROPOSED_PLAN_MESSAGE_TYPE) {
+			return { messageIndex: index, kind: "presentation" };
+		}
+		if (
+			candidate.role === "assistant" &&
+			contentText(candidate.content).match(PROPOSED_PLAN_BLOCK_PATTERN)
+		) {
+			return { messageIndex: index, kind: "legacy" };
+		}
+	}
+	return undefined;
+}
+
 export function messageContainsPlanModeImplementationHandoff(message: unknown) {
 	const candidate = unwrapSessionMessage(message);
 	return (
@@ -146,12 +191,19 @@ export function stripProposedPlanBlocksFromMessage<T>(message: T): T {
 	return replaceAssistantContent(message, stripProposedPlanBlocksFromContent);
 }
 
-export function stripPlanModeCompletionCallsFromMessage<T>(message: T): T {
+export function stripPlanModeCompletionCallsFromMessage<T>(
+	message: T,
+	preservedToolCallId?: string,
+): T {
 	return replaceAssistantContent(message, (content) => {
 		if (!Array.isArray(content)) return content;
 		const nextContent = content.filter((block) => {
-			const candidate = block as { type?: string; name?: string };
-			return !(candidate.type === "toolCall" && candidate.name === PLAN_MODE_COMPLETE_TOOL_NAME);
+			const candidate = block as { type?: string; id?: string; name?: string };
+			return !(
+				candidate.type === "toolCall" &&
+				candidate.name === PLAN_MODE_COMPLETE_TOOL_NAME &&
+				(!preservedToolCallId || candidate.id !== preservedToolCallId)
+			);
 		});
 		return nextContent.length === content.length ? content : nextContent;
 	});
@@ -185,6 +237,7 @@ function unwrapSessionMessage(message: unknown) {
 		role?: string;
 		customType?: string;
 		toolName?: string;
+		toolCallId?: string;
 		content?: unknown;
 	};
 }

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -20,7 +20,9 @@ import {
 	setPlanThinkingLevel,
 } from "./extension-runtime.js";
 import {
+	formatHistoryImplementationPrompt,
 	formatImplementationHandoff,
+	formatTransferredPlanPrompt,
 	startFreshImplementationFromState,
 } from "./fresh-implementation.js";
 import {
@@ -837,6 +839,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		const previousIntent = readyPresentationIntent;
 		const previousToolSnapshot = previousTools;
 		const wasEnabled = state.enabled;
+		const retention = configuredImplementationPlanRetention(settings);
+		const usesConversationHistory = retention === "clear-on-start";
 		readyPresentationIntent = undefined;
 		state = {
 			...state,
@@ -845,13 +849,15 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			latestPlanSource: undefined,
 			awaitingAction: false,
 			savedPlan: undefined,
-			activeImplementation: {
-				id: randomUUID(),
-				plan,
-				source,
-				startedAt: Date.now(),
-				retention: configuredImplementationPlanRetention(settings),
-			},
+			activeImplementation: usesConversationHistory
+				? undefined
+				: {
+						id: randomUUID(),
+						plan,
+						source,
+						startedAt: Date.now(),
+						retention,
+					},
 			manualThinkingLevel: undefined,
 		};
 		if (wasEnabled) {
@@ -862,7 +868,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		persistState();
 		updateUi(ctx);
 
-		const sent = sendPlanModeUserMessage(formatImplementationHandoff(plan), ctx);
+		const handoff = usesConversationHistory
+			? wasEnabled
+				? formatHistoryImplementationPrompt()
+				: formatTransferredPlanPrompt(plan, false)
+			: formatImplementationHandoff(plan);
+		const sent = sendPlanModeUserMessage(handoff, ctx);
 		if (!sent) {
 			state = previousState;
 			readyPresentationIntent = previousIntent;

--- a/packages/pi-plan-mode/src/settings-menu.ts
+++ b/packages/pi-plan-mode/src/settings-menu.ts
@@ -113,9 +113,9 @@ export async function showPlanModeSettings(
 								},
 								{
 									id: "implementationPlanRetention",
-									label: "Plan availability",
+									label: "Plan reinjection",
 									description:
-										"Choose whether implementation relies on conversation history or guaranteed plan context.",
+										"Choose how long Plan mode restores the exact plan when ordinary context no longer contains it.",
 									currentValue: retentionLabel(
 										configuredImplementationPlanRetention(state.settings),
 									),
@@ -210,7 +210,7 @@ export async function showPlanModeSettings(
 					actionCtx,
 					{ implementationPlanRetention },
 					signal,
-					`Plan availability: ${retentionLabel(implementationPlanRetention)}. Applies to the next Implement action.`,
+					`Plan reinjection: ${retentionLabel(implementationPlanRetention)}. Applies to the next Implement action.`,
 				);
 			},
 			"open-export": async () => ({ kind: "to", screen: "export" }),
@@ -311,7 +311,7 @@ export async function showPlanModeSettings(
 function settingsLines(settingsPath: string, notice: string | undefined) {
 	return [
 		`User settings · ${safeTerminalText(settingsPath)}`,
-		"Plan defaults apply to the next workflow; plan availability and export choices apply to their next action.",
+		"Plan defaults apply to the next workflow; reinjection and export choices apply to their next action.",
 		...(notice ? [safeTerminalText(notice)] : []),
 	];
 }

--- a/packages/pi-plan-mode/src/settings-menu.ts
+++ b/packages/pi-plan-mode/src/settings-menu.ts
@@ -113,8 +113,9 @@ export async function showPlanModeSettings(
 								},
 								{
 									id: "implementationPlanRetention",
-									label: "After Implement",
-									description: "Choose how long the accepted plan keeps guiding implementation.",
+									label: "Plan availability",
+									description:
+										"Choose whether implementation relies on conversation history or guaranteed plan context.",
 									currentValue: retentionLabel(
 										configuredImplementationPlanRetention(state.settings),
 									),
@@ -209,7 +210,7 @@ export async function showPlanModeSettings(
 					actionCtx,
 					{ implementationPlanRetention },
 					signal,
-					`After Implement: ${retentionLabel(implementationPlanRetention)}. Applies to the next Implement action.`,
+					`Plan availability: ${retentionLabel(implementationPlanRetention)}. Applies to the next Implement action.`,
 				);
 			},
 			"open-export": async () => ({ kind: "to", screen: "export" }),
@@ -310,7 +311,7 @@ export async function showPlanModeSettings(
 function settingsLines(settingsPath: string, notice: string | undefined) {
 	return [
 		`User settings · ${safeTerminalText(settingsPath)}`,
-		"Plan defaults apply to the next workflow; handoff and export choices apply to their next action.",
+		"Plan defaults apply to the next workflow; plan availability and export choices apply to their next action.",
 		...(notice ? [safeTerminalText(notice)] : []),
 	];
 }

--- a/packages/pi-plan-mode/src/settings.ts
+++ b/packages/pi-plan-mode/src/settings.ts
@@ -26,9 +26,9 @@ export const PLAN_MODE_THINKING_LEVELS = [
 	"max",
 ] as const;
 export const IMPLEMENTATION_PLAN_RETENTIONS = [
-	"keep",
 	"clear-on-start",
 	"clear-after-first-run",
+	"keep",
 ] as const;
 export const DEFAULT_PLAN_EXPORT_PATH = "PLAN.md";
 const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
@@ -485,7 +485,7 @@ export function configuredThinkingLevel(
 export function configuredImplementationPlanRetention(
 	settings: PlanModeSettings,
 ): ImplementationPlanRetention {
-	return settings.implementationPlanRetention ?? "keep";
+	return settings.implementationPlanRetention ?? "clear-on-start";
 }
 
 export function configuredPlanExportPath(settings: PlanModeSettings) {

--- a/packages/pi-plan-mode/test/default-tools.test.ts
+++ b/packages/pi-plan-mode/test/default-tools.test.ts
@@ -376,7 +376,7 @@ test("implementation handoff restores tools after using configured defaults", as
 		await execute("complete", { plan: "# Configured handoff" }, undefined, undefined, context.ctx);
 		await mock.commands.get("plan")?.handler("implement", context.ctx);
 		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write", "custom"]);
-		assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /# Configured handoff/);
+		assert.equal(mock.sentUserMessages.at(-1)?.text, "Implement the plan.");
 	});
 });
 

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../test/support.js";
 import {
 	formatImplementationHandoff,
+	formatTransferredPlanPrompt,
 	startFreshImplementationFromState,
 	startFreshImplementationSession,
 } from "../src/fresh-implementation.js";
@@ -93,7 +94,8 @@ test("ready choice descriptions stay bounded and cancellation has no side effect
 		await showReadyPlanMenu(context.ctx, {
 			signal: owner.signal,
 			isCurrent: () => !owner.signal.aborted,
-			implementationOutcome: () => "After Implement: Keep plan active\u001b]8;;unsafe\u0007.",
+			implementationOutcome: () =>
+				"Plan availability: Guarantee the exact plan until /plan exit\u001b]8;;unsafe\u0007.",
 			getExportDestination: () => ({ configuredPath: "PLAN.md", resolvedPath: "/tmp/PLAN.md" }),
 			implementHere: () => {
 				actionCalls += 1;
@@ -247,6 +249,7 @@ test("saved plans can start fresh without consuming the source session state", a
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi, MISSING_SETTINGS);
 	let destinationState: unknown;
+	let replacementMessage = "";
 	let newSessionCalls = 0;
 	const context = createMockContext({
 		mode: "rpc",
@@ -272,7 +275,11 @@ test("saved plans can start fresh without consuming the source session state", a
 					return "destination-state";
 				},
 			});
-			await options.withSession?.({ sendUserMessage: async () => undefined });
+			await options.withSession?.({
+				sendUserMessage: async (message) => {
+					replacementMessage = message;
+				},
+			});
 			return { cancelled: false };
 		},
 	});
@@ -282,10 +289,9 @@ test("saved plans can start fresh without consuming the source session state", a
 	assert.equal(newSessionCalls, 1);
 	assert.equal(context.statuses.get("plan-mode"), "plan saved");
 	assert.equal(mock.entries.length, 0);
-	assert.equal(
-		(destinationState as { activeImplementation?: { plan?: string } }).activeImplementation?.plan,
-		PLAN,
-	);
+	assert.equal(destinationState, undefined);
+	assert.match(replacementMessage, /Implement the plan in a fresh context/);
+	assert.match(replacementMessage, /Fresh implementation plan/);
 });
 
 test("fresh menu work stops after source session shutdown while waiting for idle", async () => {
@@ -329,8 +335,8 @@ test("fresh menu work stops after source session shutdown while waiting for idle
 	assert.equal(persisted.latestPlan, PLAN);
 });
 
-test("fresh destination adopts setup state before the first kickoff context for every retention", async () => {
-	for (const retention of ["keep", "clear-on-start", "clear-after-first-run"] as const) {
+test("fresh destination adopts setup state before kickoff for guaranteed-plan policies", async () => {
+	for (const retention of ["keep", "clear-after-first-run"] as const) {
 		const entries: Array<{ type: "custom"; customType: string; data: unknown }> = [];
 		const mock = createMockPi({ activeTools: ["read", "edit"] });
 		planMode(mock.pi, MISSING_SETTINGS);
@@ -370,17 +376,55 @@ test("fresh destination adopts setup state before the first kickoff context for 
 			context.ctx,
 		)) as { messages: unknown[] };
 		assert.match(JSON.stringify(firstContext.messages), /Fresh implementation plan/);
-		if (retention === "clear-on-start") {
-			assert.equal(context.statuses.get("plan-mode"), undefined);
-		} else {
-			assert.equal(context.statuses.get("plan-mode"), "plan implementing");
-		}
+		assert.equal(context.statuses.get("plan-mode"), "plan implementing");
 		await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
 		assert.equal(
 			context.statuses.get("plan-mode"),
 			retention === "keep" ? "plan implementing" : undefined,
 		);
 	}
+});
+
+test("conversation-history fresh kickoff skips active state and recovers in the editor", async () => {
+	let setupCalls = 0;
+	const replacement = createMockContext({ mode: "rpc", hasUI: true });
+	const source = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: { provider: "test-provider", id: "test-model" },
+		modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
+		sessionManager: { getSessionFile: () => "/sessions/planning.jsonl" },
+		newSession: async (options: {
+			setup?: () => Promise<void>;
+			withSession?: (ctx: unknown) => Promise<void>;
+		}) => {
+			if (options.setup) {
+				setupCalls += 1;
+				await options.setup();
+			}
+			await options.withSession?.({
+				...(replacement.ctx as object),
+				async sendUserMessage() {
+					throw new Error("kickoff failed");
+				},
+			});
+			return { cancelled: false };
+		},
+	});
+
+	const result = await startFreshImplementationSession(source.ctx, {
+		plan: PLAN,
+		source: "plan_mode_complete",
+		retention: "clear-on-start",
+		stateEntryType: STATE_ENTRY_TYPE,
+		isCurrent: () => true,
+	});
+
+	assert.equal(result.kind, "partial");
+	assert.equal(setupCalls, 0);
+	assert.equal(replacement.editorText, formatTransferredPlanPrompt(PLAN, true));
+	assert.match(replacement.notifications.at(-1)?.message ?? "", /request is in the editor/i);
+	assert.doesNotMatch(replacement.notifications.at(-1)?.message ?? "", /active plan/i);
 });
 
 test("fresh replacement reports recoverable setup and kickoff failures as partial", async () => {

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -426,6 +426,92 @@ test("conversation-history fresh kickoff skips active state and recovers in the 
 	assert.doesNotMatch(replacement.notifications.at(-1)?.message ?? "", /active plan/i);
 });
 
+test("fresh success notification failures do not downgrade or duplicate kickoff", async () => {
+	let kickoffCalls = 0;
+	const replacement = createMockContext({ mode: "tui", hasUI: true });
+	const replacementUi = (
+		replacement.ctx as unknown as {
+			ui: { notify(message: string, level?: string): void };
+		}
+	).ui;
+	replacementUi.notify = () => {
+		throw new Error("replacement notification is stale");
+	};
+	const source = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		model: { provider: "test-provider", id: "test-model" },
+		modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
+		sessionManager: { getSessionFile: () => "/sessions/planning.jsonl" },
+		newSession: async (options: { withSession?: (ctx: unknown) => Promise<void> }) => {
+			await options.withSession?.({
+				...(replacement.ctx as object),
+				async sendUserMessage() {
+					kickoffCalls += 1;
+				},
+			});
+			return { cancelled: false };
+		},
+	});
+
+	const result = await startFreshImplementationSession(source.ctx, {
+		plan: PLAN,
+		source: "plan_mode_complete",
+		retention: "clear-on-start",
+		stateEntryType: STATE_ENTRY_TYPE,
+		isCurrent: () => true,
+	});
+
+	assert.equal(result.kind, "started");
+	assert.equal(kickoffCalls, 1);
+	assert.equal(replacement.editorText, "");
+});
+
+test("fresh recovery reports when a stale editor cannot accept the request", async () => {
+	const replacement = createMockContext({ mode: "tui", hasUI: true });
+	const replacementUi = (
+		replacement.ctx as unknown as {
+			ui: { setEditorText(value: string): void };
+		}
+	).ui;
+	replacementUi.setEditorText = () => {
+		throw new Error("replacement editor is stale");
+	};
+	const source = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		model: { provider: "test-provider", id: "test-model" },
+		modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
+		sessionManager: { getSessionFile: () => "/sessions/planning.jsonl" },
+		newSession: async (options: {
+			setup?: (sessionManager: {
+				appendCustomEntry(customType: string, data: unknown): string;
+			}) => Promise<void>;
+			withSession?: (ctx: unknown) => Promise<void>;
+		}) => {
+			await options.setup?.({
+				appendCustomEntry() {
+					throw new Error("state persistence failed");
+				},
+			});
+			await options.withSession?.(replacement.ctx);
+			return { cancelled: false };
+		},
+	});
+
+	const result = await startFreshImplementationSession(source.ctx, {
+		plan: PLAN,
+		source: "plan_mode_complete",
+		retention: "keep",
+		stateEntryType: STATE_ENTRY_TYPE,
+		isCurrent: () => true,
+	});
+
+	assert.equal(result.kind, "partial");
+	assert.match(replacement.notifications.at(-1)?.message ?? "", /could not be restored/i);
+	assert.doesNotMatch(replacement.notifications.at(-1)?.message ?? "", /request is in the editor/i);
+});
+
 test("fresh replacement reports recoverable setup and kickoff failures as partial", async () => {
 	for (const failure of ["setup", "kickoff"] as const) {
 		let appendedState: unknown;

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -94,8 +94,7 @@ test("ready choice descriptions stay bounded and cancellation has no side effect
 		await showReadyPlanMenu(context.ctx, {
 			signal: owner.signal,
 			isCurrent: () => !owner.signal.aborted,
-			implementationOutcome: () =>
-				"Plan availability: Guarantee the exact plan until /plan exit\u001b]8;;unsafe\u0007.",
+			implementationOutcome: () => "Plan reinjection: Until /plan exit\u001b]8;;unsafe\u0007.",
 			getExportDestination: () => ({ configuredPath: "PLAN.md", resolvedPath: "/tmp/PLAN.md" }),
 			implementHere: () => {
 				actionCalls += 1;

--- a/packages/pi-plan-mode/test/implementation-retention.test.ts
+++ b/packages/pi-plan-mode/test/implementation-retention.test.ts
@@ -163,14 +163,92 @@ test("conversation-history context keeps only the latest completed plan before k
 		},
 	];
 	const oldCompletion = completion("old-plan", "# Old plan");
+	const duplicateCurrentCall = {
+		role: "assistant",
+		content: [
+			{
+				type: "toolCall",
+				id: "current-plan",
+				name: "plan_mode_complete",
+				arguments: { plan: "# Corrupt duplicate" },
+			},
+		],
+	};
 	const currentCompletion = completion("current-plan", PLAN);
 	const kickoff = { role: "user", content: "Implement the plan." };
 	const transformed = (await contextHook(
-		{ messages: [...oldCompletion, ...currentCompletion, kickoff] },
+		{ messages: [...oldCompletion, duplicateCurrentCall, ...currentCompletion, kickoff] },
 		context.ctx,
 	)) as { messages: unknown[] };
 
 	assert.deepEqual(transformed.messages, [...currentCompletion, kickoff]);
+});
+
+test("conversation-history context does not revive plans across user or summary boundaries", async () => {
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(mock.pi);
+	const context = createMockContext();
+	const contextHook = mock.events.get("context")?.[0];
+	assert.ok(contextHook);
+	const planCall = {
+		role: "assistant",
+		content: [{ type: "toolCall", id: "complete-plan", name: "plan_mode_complete", arguments: {} }],
+	};
+	const planResult = {
+		role: "toolResult",
+		toolCallId: "complete-plan",
+		toolName: "plan_mode_complete",
+		content: [{ type: "text", text: PLAN }],
+	};
+	const kickoff = { role: "user", content: "Implement the plan." };
+	const completedWork = { role: "assistant", content: "Implementation finished." };
+	const unrelated = { role: "user", content: "Do unrelated work." };
+	const laterKickoff = { role: "user", content: "Implement the plan." };
+	const afterUserBoundary = (await contextHook(
+		{ messages: [planCall, planResult, unrelated, completedWork, laterKickoff] },
+		context.ctx,
+	)) as { messages: unknown[] };
+	assert.deepEqual(afterUserBoundary.messages, [unrelated, completedWork, laterKickoff]);
+
+	const followUp = { role: "user", content: "Continue with verification." };
+	const naturalHistory = (await contextHook(
+		{ messages: [planCall, planResult, kickoff, completedWork, followUp] },
+		context.ctx,
+	)) as { messages: unknown[] };
+	assert.deepEqual(naturalHistory.messages, [
+		planCall,
+		planResult,
+		kickoff,
+		completedWork,
+		followUp,
+	]);
+
+	const summary = { role: "compactionSummary", summary: "The older plan is summarized." };
+	const afterSummaryBoundary = (await contextHook(
+		{ messages: [planCall, planResult, summary, laterKickoff] },
+		context.ctx,
+	)) as { messages: unknown[] };
+	assert.deepEqual(afterSummaryBoundary.messages, [summary, laterKickoff]);
+});
+
+test("conversation-history context drops orphaned completion results", async () => {
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(mock.pi);
+	const context = createMockContext();
+	const contextHook = mock.events.get("context")?.[0];
+	assert.ok(contextHook);
+	const orphanedResult = {
+		role: "toolResult",
+		toolCallId: "missing-call",
+		toolName: "plan_mode_complete",
+		content: [{ type: "text", text: PLAN }],
+	};
+	const kickoff = { role: "user", content: "Implement the plan." };
+	const transformed = (await contextHook({ messages: [orphanedResult, kickoff] }, context.ctx)) as {
+		messages: unknown[];
+	};
+
+	assert.deepEqual(transformed.messages, [kickoff]);
 });
 
 test("conversation-history context preserves a legacy proposed plan without reinjection", async () => {

--- a/packages/pi-plan-mode/test/implementation-retention.test.ts
+++ b/packages/pi-plan-mode/test/implementation-retention.test.ts
@@ -101,27 +101,95 @@ test("keep leaves the accepted plan active after context and settlement", async 
 	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
 });
 
-test("handoff-only waits for the exact queued handoff, preserves its first context, then clears", async () => {
+test("conversation-history implementation uses a short prompt without active-plan injection", async () => {
 	const { mock, context, handoff } = await beginImplementation("clear-on-start", { idle: false });
 	const contextHook = mock.events.get("context")?.[0];
 	assert.ok(contextHook);
-
-	await contextHook({ messages: [{ role: "user", content: "Older queued work" }] }, context.ctx);
-	assert.equal(latestState(mock).activeImplementation?.retention, "clear-on-start");
-
-	const firstImplementationContext = (await contextHook(
-		{ messages: [{ role: "user", content: handoff }] },
-		context.ctx,
-	)) as { messages: unknown[] };
-	assert.match(JSON.stringify(firstImplementationContext.messages), /Retained plan/);
+	assert.equal(handoff, "Implement the plan.");
 	assert.equal(latestState(mock).activeImplementation, undefined);
 	assert.equal(context.statuses.get("plan-mode"), undefined);
 
-	const later = (await contextHook(
-		{ messages: [{ role: "user", content: handoff }] },
+	const older = (await contextHook(
+		{ messages: [{ role: "user", content: "Older queued work" }] },
 		context.ctx,
 	)) as { messages: unknown[] };
-	assert.doesNotMatch(JSON.stringify(later.messages), /Retained plan/);
+	assert.doesNotMatch(JSON.stringify(older.messages), /Retained plan/);
+
+	const planCall = {
+		role: "assistant",
+		content: [
+			{
+				type: "toolCall",
+				id: "complete-plan",
+				name: "plan_mode_complete",
+				arguments: { plan: PLAN },
+			},
+		],
+	};
+	const planResult = {
+		role: "toolResult",
+		toolCallId: "complete-plan",
+		toolName: "plan_mode_complete",
+		content: [{ type: "text", text: `**Proposed Plan**\n\n${PLAN}` }],
+		details: { version: 1, source: "plan_mode_complete", plan: PLAN },
+	};
+	const messages = [planCall, planResult, { role: "user", content: handoff }];
+	for (let call = 0; call < 2; call += 1) {
+		const transformed = (await contextHook({ messages }, context.ctx)) as { messages: unknown[] };
+		assert.deepEqual(transformed.messages, messages);
+		assert.doesNotMatch(JSON.stringify(transformed.messages), /plan-mode-implementation-context/);
+	}
+	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+	assert.equal(latestState(mock).activeImplementation, undefined);
+});
+
+test("conversation-history context keeps only the latest completed plan before kickoff", async () => {
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(mock.pi);
+	const context = createMockContext();
+	const contextHook = mock.events.get("context")?.[0];
+	assert.ok(contextHook);
+	const completion = (id: string, plan: string) => [
+		{
+			role: "assistant",
+			content: [{ type: "toolCall", id, name: "plan_mode_complete", arguments: { plan } }],
+		},
+		{
+			role: "toolResult",
+			toolCallId: id,
+			toolName: "plan_mode_complete",
+			content: [{ type: "text", text: `**Proposed Plan**\n\n${plan}` }],
+			details: { version: 1, source: "plan_mode_complete", plan },
+		},
+	];
+	const oldCompletion = completion("old-plan", "# Old plan");
+	const currentCompletion = completion("current-plan", PLAN);
+	const kickoff = { role: "user", content: "Implement the plan." };
+	const transformed = (await contextHook(
+		{ messages: [...oldCompletion, ...currentCompletion, kickoff] },
+		context.ctx,
+	)) as { messages: unknown[] };
+
+	assert.deepEqual(transformed.messages, [...currentCompletion, kickoff]);
+});
+
+test("conversation-history context preserves a legacy proposed plan without reinjection", async () => {
+	const mock = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(mock.pi);
+	const context = createMockContext();
+	const contextHook = mock.events.get("context")?.[0];
+	assert.ok(contextHook);
+	const proposedPlan = {
+		role: "assistant",
+		content: `<proposed_plan>\n${PLAN}\n</proposed_plan>`,
+	};
+	const kickoff = { role: "user", content: "Implement the plan." };
+	const transformed = (await contextHook({ messages: [proposedPlan, kickoff] }, context.ctx)) as {
+		messages: unknown[];
+	};
+
+	assert.deepEqual(transformed.messages, [proposedPlan, kickoff]);
+	assert.doesNotMatch(JSON.stringify(transformed.messages), /plan-mode-implementation-context/);
 });
 
 test("first-run ignores older settlement and clears only after its handoff context settles", async () => {
@@ -174,9 +242,9 @@ test("an armed older implementation cannot clear a superseding implementation", 
 
 test("Implement menus preview each configured retention outcome before confirmation", async () => {
 	for (const [retention, preview] of [
-		["keep", "Keep plan active until /plan exit"],
-		["clear-on-start", "Use the plan for the implementation handoff only"],
-		["clear-after-first-run", "Clear after the first implementation run settles"],
+		["clear-on-start", "Use conversation history only"],
+		["clear-after-first-run", "Guarantee the exact plan through the first implementation run"],
+		["keep", "Guarantee the exact plan until /plan exit"],
 	] as const) {
 		let menuTitle = "";
 		const mock = createMockPi({ activeTools: ["read"] });
@@ -235,7 +303,7 @@ test("changing Settings does not retroactively change an active implementation",
 				}
 				if (changedSetting) return undefined;
 				changedSetting = true;
-				return options.find((option) => option.startsWith("After Implement"));
+				return options.find((option) => option.startsWith("Plan availability"));
 			},
 		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);

--- a/packages/pi-plan-mode/test/implementation-retention.test.ts
+++ b/packages/pi-plan-mode/test/implementation-retention.test.ts
@@ -242,9 +242,9 @@ test("an armed older implementation cannot clear a superseding implementation", 
 
 test("Implement menus preview each configured retention outcome before confirmation", async () => {
 	for (const [retention, preview] of [
-		["clear-on-start", "Use conversation history only"],
-		["clear-after-first-run", "Guarantee the exact plan through the first implementation run"],
-		["keep", "Guarantee the exact plan until /plan exit"],
+		["clear-on-start", "Off; use conversation history only"],
+		["clear-after-first-run", "Through the first implementation run"],
+		["keep", "Until /plan exit"],
 	] as const) {
 		let menuTitle = "";
 		const mock = createMockPi({ activeTools: ["read"] });
@@ -303,7 +303,7 @@ test("changing Settings does not retroactively change an active implementation",
 				}
 				if (changedSetting) return undefined;
 				changedSetting = true;
-				return options.find((option) => option.startsWith("Plan availability"));
+				return options.find((option) => option.startsWith("Plan reinjection"));
 			},
 		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);

--- a/packages/pi-plan-mode/test/issue-302-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-302-repro.test.ts
@@ -3,7 +3,7 @@ import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import planMode from "../src/plan-mode.js";
 
-test("issue 302: re-entered Plan Mode hides the previous implementation handoff", async () => {
+test("issue 302: history-only implementation stays ordinary context when Plan Mode restarts", async () => {
 	const mock = createMockPi({ activeTools: ["read", "bash", "custom"] });
 	planMode(mock.pi);
 	const context = createMockContext();
@@ -22,9 +22,8 @@ test("issue 302: re-entered Plan Mode hides the previous implementation handoff"
 
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
 	const implementationHandoff = mock.sentUserMessages.at(-1)?.text ?? "";
-	assert.match(implementationHandoff, /Plan mode is now disabled/);
-	assert.match(implementationHandoff, /Implement this proposed plan now/);
-	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+	assert.equal(implementationHandoff, "Implement the plan.");
+	assert.equal(context.statuses.get("plan-mode"), undefined);
 
 	const contextHook = mock.events.get("context")?.[0];
 	assert.ok(contextHook);
@@ -61,13 +60,6 @@ test("issue 302: re-entered Plan Mode hides the previous implementation handoff"
 		messages: unknown[];
 	};
 
-	assert.deepEqual(activeContext.messages, [
-		implementationMessages[0],
-		implementationMessages[2],
-		activeMessages[3],
-	]);
-	assert.doesNotMatch(
-		JSON.stringify(activeContext.messages),
-		/Plan mode is now disabled\. Full tool access is restored/,
-	);
+	assert.deepEqual(activeContext.messages, activeMessages);
+	assert.match(JSON.stringify(activeContext.messages), /Implement the plan\./);
 });

--- a/packages/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-471-repro.test.ts
@@ -6,7 +6,7 @@ import {
 	createMockPi,
 } from "../../../test/support.js";
 import { PLAN_MODE_MAX_CHARS } from "../src/completion-tool.js";
-import planMode from "../src/plan-mode.js";
+import planModeExtension from "../src/plan-mode.js";
 import { type ActiveImplementationPlan, restorePlanModeState } from "../src/state.js";
 
 const PLAN = `# Compaction-safe implementation
@@ -16,6 +16,22 @@ Marker: PLAN-PERSIST-TEST-42
 1. Preserve the exact approved plan.
 2. Verify it after compaction.`;
 const STATE_ENTRY_TYPE = "plan-mode-state";
+const KEEP_SETTINGS = {
+	readSettings: async () => ({
+		kind: "loaded" as const,
+		settings: {
+			thinkingLevel: "inherit" as const,
+			implementationPlanRetention: "keep" as const,
+		},
+	}),
+};
+
+function planMode(
+	pi: Parameters<typeof planModeExtension>[0],
+	options?: Parameters<typeof planModeExtension>[1],
+) {
+	return planModeExtension(pi, options ?? KEEP_SETTINGS);
+}
 
 function stateEntry(data: Record<string, unknown>) {
 	return { type: "custom", customType: STATE_ENTRY_TYPE, data };
@@ -185,6 +201,7 @@ test("issue 471: an active implementation plan is restored after compaction remo
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
@@ -226,6 +243,7 @@ test("implementation transition persists active state before a busy follow-up an
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext({ isIdle: () => false });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
@@ -296,6 +314,7 @@ test("a failed superseding prompt restores the exact active implementation", asy
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
@@ -322,6 +341,7 @@ test("active context avoids exact handoff duplication and replaces stale injecte
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
@@ -397,6 +417,7 @@ test("active plans can be shown and cleared through existing direct routes", asy
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
@@ -553,6 +574,7 @@ test("the active-plan menu shows without superseding and cancellation is read-on
 			select: async (_title: string, options: string[]) =>
 				selection ? options.find((option) => option.startsWith(selection)) : undefined,
 		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		await mock.commands.get("plan")?.handler("start", context.ctx);
 		const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 			?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
@@ -589,6 +611,7 @@ test("active-plan menu actions work in TUI and RPC without hidden route changes"
 				return options.find((option) => option.startsWith(scenario.selection));
 			},
 		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		await mock.commands.get("plan")?.handler("start", context.ctx);
 		const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 			?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
@@ -606,6 +629,7 @@ test("/plan start supersedes an active implementation without starting a model t
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
@@ -625,6 +649,7 @@ test("starting a new Plan-mode workflow supersedes the active implementation", a
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;

--- a/packages/pi-plan-mode/test/plan-export.test.ts
+++ b/packages/pi-plan-mode/test/plan-export.test.ts
@@ -150,7 +150,10 @@ test("an active Settings save changes the next export without changing active st
 			settingsPath,
 			readSettings: async () => ({
 				kind: "loaded" as const,
-				settings: { thinkingLevel: "inherit" as const },
+				settings: {
+					thinkingLevel: "inherit" as const,
+					implementationPlanRetention: "keep" as const,
+				},
 			}),
 		});
 		let openedSettings = false;
@@ -429,6 +432,7 @@ test("completion and management TUI menus preview and use the configured export 
 					kind: "loaded" as const,
 					settings: {
 						thinkingLevel: "inherit" as const,
+						implementationPlanRetention: "keep" as const,
 						defaultPlanExportPath: expectedPath,
 					},
 				}),

--- a/packages/pi-plan-mode/test/plan-mode.test.ts
+++ b/packages/pi-plan-mode/test/plan-mode.test.ts
@@ -533,11 +533,8 @@ test("Plan lifecycle enters with a prompt and hands a valid plan to implementati
 	]);
 	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "custom"]);
-	assert.match(
-		mock.sentUserMessages.at(-1)?.text ?? "",
-		/Implement this proposed plan now:\n\n# Ship it/,
-	);
-	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+	assert.equal(mock.sentUserMessages.at(-1)?.text, "Implement the plan.");
+	assert.equal(context.statuses.get("plan-mode"), undefined);
 });
 
 test("plan show displays only a stored plan without triggering a model turn", async () => {
@@ -633,9 +630,9 @@ test("plan implement fails closed without a plan and hands off a stored plan", a
 	assert.ok(execute);
 	await execute("complete", { plan: "# Implement me" }, undefined, undefined, context.ctx);
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
-	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+	assert.equal(context.statuses.get("plan-mode"), undefined);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "custom"]);
-	assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /# Implement me/);
+	assert.equal(mock.sentUserMessages.at(-1)?.text, "Implement the plan.");
 });
 
 test("failed finalize delivery keeps Plan mode active", async () => {

--- a/packages/pi-plan-mode/test/saved-plan.test.ts
+++ b/packages/pi-plan-mode/test/saved-plan.test.ts
@@ -165,7 +165,7 @@ test("automatic and manual ready menus expose Save for later", async () => {
 		const context = createMockContext({
 			hasUI: true,
 			select: async (title: string, options: string[]) => {
-				assert.match(title, /Plan availability: Use conversation history only/i);
+				assert.match(title, /Plan reinjection: Off; use conversation history only/i);
 				assert.deepEqual(
 					options.filter((option) => option !== "Close"),
 					automatic
@@ -223,7 +223,7 @@ test("saved Plan management can show, implement, clear, or cancel", async () => 
 				getEntries: () => [savedEntry],
 			},
 			select: async (title: string, options: string[]) => {
-				assert.match(title, /Plan availability: Use conversation history only/i);
+				assert.match(title, /Plan reinjection: Off; use conversation history only/i);
 				assert.deepEqual(
 					options.filter((option) => option !== "Close"),
 					[

--- a/packages/pi-plan-mode/test/saved-plan.test.ts
+++ b/packages/pi-plan-mode/test/saved-plan.test.ts
@@ -165,7 +165,7 @@ test("automatic and manual ready menus expose Save for later", async () => {
 		const context = createMockContext({
 			hasUI: true,
 			select: async (title: string, options: string[]) => {
-				assert.match(title, /After Implement: Keep plan active until \/plan exit/i);
+				assert.match(title, /Plan availability: Use conversation history only/i);
 				assert.deepEqual(
 					options.filter((option) => option !== "Close"),
 					automatic
@@ -203,7 +203,7 @@ test("automatic and manual ready menus expose Save for later", async () => {
 test("saved Plan management can show, implement, clear, or cancel", async () => {
 	for (const scenario of [
 		{ mode: "tui", selection: "Show saved plan", expected: "saved" },
-		{ mode: "rpc", selection: "Implement here", expected: "implementing" },
+		{ mode: "rpc", selection: "Implement here", expected: "history" },
 		{ mode: "tui", selection: "Clear saved plan", expected: "cleared" },
 		{ mode: "tui", selection: undefined, expected: "saved" },
 	] as const) {
@@ -223,7 +223,7 @@ test("saved Plan management can show, implement, clear, or cancel", async () => 
 				getEntries: () => [savedEntry],
 			},
 			select: async (title: string, options: string[]) => {
-				assert.match(title, /After Implement: Keep plan active until \/plan exit/i);
+				assert.match(title, /Plan availability: Use conversation history only/i);
 				assert.deepEqual(
 					options.filter((option) => option !== "Close"),
 					[
@@ -254,11 +254,11 @@ test("saved Plan management can show, implement, clear, or cancel", async () => 
 			}
 			await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
 			assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
-		} else if (scenario.expected === "implementing") {
-			assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+		} else if (scenario.expected === "history") {
+			assert.equal(context.statuses.get("plan-mode"), undefined);
 			assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /Saved implementation plan/);
 			assert.equal(latestState(mock.entries)?.savedPlan, undefined);
-			assert.equal(latestState(mock.entries)?.activeImplementation?.plan, PLAN);
+			assert.equal(latestState(mock.entries)?.activeImplementation, undefined);
 		} else {
 			assert.equal(context.statuses.get("plan-mode"), undefined);
 			assert.equal(latestState(mock.entries)?.savedPlan, undefined);
@@ -334,10 +334,11 @@ test("saved Plan direct routes show, implement, roll back failures, and clear", 
 		mock.sentUserMessages.push({ text, options });
 	};
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
-	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
+	assert.equal(context.statuses.get("plan-mode"), undefined);
 	assert.deepEqual(mock.sentUserMessages.at(-1)?.options, { deliverAs: "followUp" });
+	assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /Saved implementation plan/);
 	assert.equal(latestState(mock.entries)?.savedPlan, undefined);
-	assert.equal(latestState(mock.entries)?.activeImplementation?.plan, PLAN);
+	assert.equal(latestState(mock.entries)?.activeImplementation, undefined);
 
 	const clearMock = createMockPi({ activeTools: ["read"] });
 	planMode(clearMock.pi);

--- a/packages/pi-plan-mode/test/settings-menu.test.ts
+++ b/packages/pi-plan-mode/test/settings-menu.test.ts
@@ -60,7 +60,7 @@ test("Plan settings show five flat workflow rows without materializing a missing
 		assert.match(frame, /Plan Mode Settings/);
 		assert.match(frame, /Plan thinking\s+inherit/);
 		assert.match(frame, /Plan tools\s+Automatic safe built-ins/);
-		assert.match(frame, /After Implement\s+Keep plan active/);
+		assert.match(frame, /Plan availability\s+Conversation history only/);
 		assert.match(frame, /Export destination\s+PLAN\.md/);
 		assert.match(frame, /Plan mode shortcut\s+none/);
 		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
@@ -166,7 +166,7 @@ test("Default tools retain configured names that are unavailable in the current 
 	});
 });
 
-test("After Implement cycles outcomes and export destination saves, previews, resets, and cancels", async () => {
+test("Plan availability cycles outcomes and export destination saves, previews, resets, and cancels", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
@@ -175,8 +175,8 @@ test("After Implement cycles outcomes and export destination saves, previews, re
 		tui.press("tui.select.confirm");
 		await tui.waitForPending();
 		await tui.waitForOpen();
-		assert.equal(saved.at(-1)?.implementationPlanRetention, "clear-on-start");
-		assert.match(tui.render().join("\n"), /After Implement\s+Use plan for handoff only/);
+		assert.equal(saved.at(-1)?.implementationPlanRetention, "clear-after-first-run");
+		assert.match(tui.render().join("\n"), /Plan availability\s+First implementation run/);
 
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
@@ -338,19 +338,19 @@ test("RPC Settings changes retention and export destination with the same flat n
 				options: [
 					"Plan thinking (inherit)",
 					"Plan tools (Automatic safe built-ins)",
-					"After Implement (Keep plan active)",
+					"Plan availability (Conversation history only)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
 					"Back",
 				],
-				response: "After Implement (Keep plan active)",
+				response: "Plan availability (Conversation history only)",
 			},
 			{
 				kind: "select",
 				options: [
 					"Plan thinking (inherit)",
 					"Plan tools (Automatic safe built-ins)",
-					"After Implement (Use plan for handoff only)",
+					"Plan availability (First implementation run)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
 					"Back",
@@ -367,7 +367,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 				options: [
 					"Plan thinking (inherit)",
 					"Plan tools (Automatic safe built-ins)",
-					"After Implement (Use plan for handoff only)",
+					"Plan availability (First implementation run)",
 					"Export destination (rpc/PLAN.md)",
 					"Plan mode shortcut (none)",
 					"Back",
@@ -379,7 +379,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 		const saved: PlanModeSettings[] = [];
 		await showPlanModeSettings(context.ctx, menuOptions(settingsPath, saved));
 		rpc.assertConsumed();
-		assert.equal(saved.at(-1)?.implementationPlanRetention, "clear-on-start");
+		assert.equal(saved.at(-1)?.implementationPlanRetention, "clear-after-first-run");
 		assert.equal(saved.at(-1)?.defaultPlanExportPath, "rpc/PLAN.md");
 	} finally {
 		await rm(directory, { recursive: true, force: true });
@@ -393,7 +393,7 @@ test("Plan settings adapt to RPC cancellation and disposal aborts an in-flight s
 			options: [
 				"Plan thinking (inherit)",
 				"Plan tools (Automatic safe built-ins)",
-				"After Implement (Keep plan active)",
+				"Plan availability (Conversation history only)",
 				"Export destination (PLAN.md)",
 				"Plan mode shortcut (none)",
 				"Back",

--- a/packages/pi-plan-mode/test/settings-menu.test.ts
+++ b/packages/pi-plan-mode/test/settings-menu.test.ts
@@ -60,7 +60,7 @@ test("Plan settings show five flat workflow rows without materializing a missing
 		assert.match(frame, /Plan Mode Settings/);
 		assert.match(frame, /Plan thinking\s+inherit/);
 		assert.match(frame, /Plan tools\s+Automatic safe built-ins/);
-		assert.match(frame, /Plan availability\s+Conversation history only/);
+		assert.match(frame, /Plan reinjection\s+Off — conversation history only/);
 		assert.match(frame, /Export destination\s+PLAN\.md/);
 		assert.match(frame, /Plan mode shortcut\s+none/);
 		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
@@ -166,7 +166,7 @@ test("Default tools retain configured names that are unavailable in the current 
 	});
 });
 
-test("Plan availability cycles outcomes and export destination saves, previews, resets, and cancels", async () => {
+test("Plan reinjection cycles outcomes and export destination saves, previews, resets, and cancels", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
@@ -176,7 +176,7 @@ test("Plan availability cycles outcomes and export destination saves, previews, 
 		await tui.waitForPending();
 		await tui.waitForOpen();
 		assert.equal(saved.at(-1)?.implementationPlanRetention, "clear-after-first-run");
-		assert.match(tui.render().join("\n"), /Plan availability\s+First implementation run/);
+		assert.match(tui.render().join("\n"), /Plan reinjection\s+Through first implementation run/);
 
 		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
@@ -338,19 +338,19 @@ test("RPC Settings changes retention and export destination with the same flat n
 				options: [
 					"Plan thinking (inherit)",
 					"Plan tools (Automatic safe built-ins)",
-					"Plan availability (Conversation history only)",
+					"Plan reinjection (Off — conversation history only)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
 					"Back",
 				],
-				response: "Plan availability (Conversation history only)",
+				response: "Plan reinjection (Off — conversation history only)",
 			},
 			{
 				kind: "select",
 				options: [
 					"Plan thinking (inherit)",
 					"Plan tools (Automatic safe built-ins)",
-					"Plan availability (First implementation run)",
+					"Plan reinjection (Through first implementation run)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
 					"Back",
@@ -367,7 +367,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 				options: [
 					"Plan thinking (inherit)",
 					"Plan tools (Automatic safe built-ins)",
-					"Plan availability (First implementation run)",
+					"Plan reinjection (Through first implementation run)",
 					"Export destination (rpc/PLAN.md)",
 					"Plan mode shortcut (none)",
 					"Back",
@@ -393,7 +393,7 @@ test("Plan settings adapt to RPC cancellation and disposal aborts an in-flight s
 			options: [
 				"Plan thinking (inherit)",
 				"Plan tools (Automatic safe built-ins)",
-				"Plan availability (Conversation history only)",
+				"Plan reinjection (Off — conversation history only)",
 				"Export destination (PLAN.md)",
 				"Plan mode shortcut (none)",
 				"Back",

--- a/packages/pi-plan-mode/test/settings.test.ts
+++ b/packages/pi-plan-mode/test/settings.test.ts
@@ -119,7 +119,7 @@ test("Plan-mode settings validate implementation retention and export defaults",
 	assert.equal(configuredPlanExportPath(normalizedPath), "docs/PLAN.md");
 	const defaults = normalizePlanModeSettings({});
 	assert.ok(defaults);
-	assert.equal(configuredImplementationPlanRetention(defaults), "keep");
+	assert.equal(configuredImplementationPlanRetention(defaults), "clear-on-start");
 	assert.equal(configuredPlanExportPath(defaults), "PLAN.md");
 	for (const defaultPlanExportPath of [
 		"",


### PR DESCRIPTION
## Summary

- Rename the confusing **After Implement** setting to **Plan reinjection** so the UI exposes the `context` hook mechanism directly.
- Label the policies as **Off — conversation history only**, **Through first implementation run**, and **Until manually cleared**.
- Make reinjection-off behavior the default while preserving the stable `implementationPlanRetention` key and accepted values.
- Match Codex-style implementation handoff behavior: current-session implementation sends `Implement the plan.`, while fresh or saved-plan implementation transfers the complete plan once in an ordinary user prompt.
- Keep the two reinjection policies as explicit exact-plan guarantees with their existing lifecycle protections.
- Harden history artifact provenance, provider tool-call/result pairing, duplicate call IDs, compaction and user boundaries, stale replacement UI, and fresh kickoff recovery.
- Add a minor changeset and update package documentation, TUI/RPC expectations, context filtering, failure recovery, and lifecycle tests.

## Verification

- `npm run check`
- `npm test` — 3,220 tests passed across 359 files
- `npm exec -- vitest run packages/pi-plan-mode/test` — 210 tests passed
- `npm exec -- vitest run packages/pi-plan-mode/test/build-runtime.test.ts packages/pi-plan-mode/test/generated-entry.test.ts` — 6 tests passed
- `just pack plan-mode` — dry-run tarball contained the expected 37 published files

## Semantic audit

- Reviewed against `docs/extension-conventions.md` and `docs/extension-settings.md`.
- Verified missing and invalid settings behavior, explicit-value compatibility, unknown-field preservation, atomic settings saves, legacy active-state restoration, queued handoffs, session replacement, cancellation, kickoff rollback, editor recovery, resume, and `agent_settled` cleanup.
- Verified that generic kickoff text cannot revive a plan across unrelated user or summary boundaries, orphaned completion results stay filtered, only the exact paired completion call survives duplicate IDs, and UI notification failures cannot downgrade a successful kickoff.
- Did not run the interactive `pi -e` TUI smoke; deterministic Pi Jiti resource-loader tests and TUI/RPC harness tests cover entry loading and the changed interaction paths.
