### PR TITLE
feat: add project-local pi debug extension

### DIFF
--- a/.pi/extensions/pi-debug/index.ts
+++ b/.pi/extensions/pi-debug/index.ts
@@ -1,0 +1,327 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import {
+	extractProviderRequestDiagnostic,
+	isProviderRequestDiagnostic,
+	type ProviderRequestDiagnostic,
+} from "./provider-request.js";
+import {
+	createRuntimeReport,
+	createRuntimeSnapshot,
+	RUNTIME_ENTRY_TYPE,
+	type RuntimeSnapshotReason,
+	runtimeStateSignature,
+} from "./snapshot.js";
+
+export const PROVIDER_REQUEST_ENTRY_TYPE = "pi-debug:provider-request";
+export const CONTROL_ENTRY_TYPE = "pi-debug:control";
+const TOOL_NAME = "pi_debug";
+const MAX_SHOW_RECORDS = 20;
+const MAX_OUTPUT_BYTES = 50 * 1024;
+const EXPERIMENTAL_WARNING =
+	"pi-debug is experimental and records privacy-filtered diagnostics in the current Pi session.";
+const PROVIDER_HOOK_LIMITATIONS = [
+	"before_provider_request exposes the serialized payload at this extension's position in handler load order; later extensions can still replace it.",
+	"The hook does not prove that the provider accepted or executed the exposed tools.",
+	"ExtensionAPI cannot enumerate passive event-only extensions, so extension visibility is limited to public tool and command surfaces.",
+];
+
+const ACTIONS = ["status", "enable", "disable", "latest", "show", "compare", "clear"] as const;
+type DebugAction = (typeof ACTIONS)[number];
+
+interface DebugDependencies {
+	now(): number;
+}
+
+interface ControlEntry {
+	version: 1;
+	capturedAt: number;
+	action: "enable" | "disable" | "clear";
+}
+
+interface ProviderCaptureState {
+	enabled: boolean;
+	records: ProviderRequestDiagnostic[];
+	nextRequestIndex: number;
+}
+
+export function createDebugExtension(
+	dependencies: Partial<DebugDependencies> = {},
+): (pi: ExtensionAPI) => void {
+	const now = dependencies.now ?? Date.now;
+	return function debugExtension(pi: ExtensionAPI): void {
+		let capture: ProviderCaptureState = { enabled: true, records: [], nextRequestIndex: 1 };
+		let lastRuntimeSignature: string | undefined;
+
+		pi.registerTool({
+			name: TOOL_NAME,
+			label: "Pi Debug",
+			description:
+				"Inspect and control privacy-filtered Pi runtime diagnostics for provider/model selection, prompt-cache hit rates, active/inactive tools, visible extension surfaces, and provider-request tool exposure.",
+			promptSnippet:
+				"Inspect Pi provider, model, cache, tool, extension-surface, and provider-request diagnostics",
+			promptGuidelines: [
+				"Use pi_debug when provider, model, prompt caching, tool activation, deferred tool loading, or extension registration may be misconfigured.",
+			],
+			parameters: Type.Object({
+				action: Type.Optional(
+					StringEnum(ACTIONS, {
+						description:
+							"status (default), enable/disable provider-request capture, latest, show, compare, or clear captured provider-request diagnostics",
+					}),
+				),
+				limit: Type.Optional(
+					Type.Integer({
+						minimum: 1,
+						maximum: MAX_SHOW_RECORDS,
+						description: "Maximum provider-request records returned by show",
+					}),
+				),
+			}),
+			async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+				signal?.throwIfAborted();
+				const action: DebugAction = params.action ?? "status";
+				applyControl(action);
+				recordRuntime(ctx, "diagnostic_tool", false);
+				const response = createToolResponse(action, params.limit ?? 10, pi, ctx, capture, now());
+				const bounded = boundResponse(response);
+				return {
+					content: [{ type: "text", text: bounded.text }],
+					details: bounded.value,
+				};
+			},
+		});
+
+		pi.on("session_start", (_event, ctx) => {
+			capture = restoreCaptureState(ctx.sessionManager.getBranch());
+			lastRuntimeSignature = undefined;
+			if (ctx.hasUI) ctx.ui.notify(EXPERIMENTAL_WARNING, "warning");
+			recordRuntime(ctx, "session_start", true);
+		});
+
+		pi.on("model_select", (_event, ctx) => {
+			recordRuntime(ctx, "model_select", false);
+		});
+
+		pi.on("before_agent_start", (_event, ctx) => {
+			recordRuntime(ctx, "before_agent_start", false);
+		});
+
+		pi.on("tool_execution_end", (_event, ctx) => {
+			recordRuntime(ctx, "tools_changed", false);
+		});
+
+		pi.on("message_end", (event, ctx) => {
+			if (event.message.role !== "assistant") return;
+			const snapshot = createRuntimeSnapshot(pi, ctx, "assistant_message", now(), {
+				provider: event.message.provider,
+				model: event.message.model,
+				usage: event.message.usage,
+			});
+			lastRuntimeSignature = runtimeStateSignature(snapshot);
+			pi.appendEntry(RUNTIME_ENTRY_TYPE, snapshot);
+		});
+
+		pi.on("before_provider_request", (event, ctx) => {
+			if (!capture.enabled) return;
+			const diagnostic = extractProviderRequestDiagnostic(event.payload, {
+				requestIndex: capture.nextRequestIndex,
+				capturedAt: now(),
+				sessionId: ctx.sessionManager.getSessionId(),
+				provider: ctx.model?.provider,
+				model: ctx.model?.id,
+			});
+			capture.nextRequestIndex += 1;
+			capture.records.push(diagnostic);
+			pi.appendEntry(PROVIDER_REQUEST_ENTRY_TYPE, diagnostic);
+		});
+
+		function recordRuntime(
+			ctx: ExtensionContext,
+			reason: RuntimeSnapshotReason,
+			force: boolean,
+		): void {
+			const snapshot = createRuntimeSnapshot(pi, ctx, reason, now());
+			const signature = runtimeStateSignature(snapshot);
+			if (!force && signature === lastRuntimeSignature) return;
+			lastRuntimeSignature = signature;
+			pi.appendEntry(RUNTIME_ENTRY_TYPE, snapshot);
+		}
+
+		function applyControl(action: DebugAction): void {
+			if (action !== "enable" && action !== "disable" && action !== "clear") return;
+			if (action === "enable") capture.enabled = true;
+			if (action === "disable") capture.enabled = false;
+			if (action === "clear") capture.records = [];
+			const control: ControlEntry = { version: 1, capturedAt: now(), action };
+			pi.appendEntry(CONTROL_ENTRY_TYPE, control);
+		}
+	};
+}
+
+function createToolResponse(
+	action: DebugAction,
+	limit: number,
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	capture: ProviderCaptureState,
+	capturedAt: number,
+) {
+	const recent = action === "show" ? capture.records.slice(-limit) : [];
+	const latest =
+		action === "latest" || action === "status" || action === "enable" || action === "disable"
+			? (capture.records.at(-1) ?? null)
+			: null;
+	const comparisonRecords = selectComparisonRecords(action, recent, capture.records);
+	return {
+		action,
+		providerRequestCapture: {
+			enabled: capture.enabled,
+			recordCountSinceClear: capture.records.length,
+			latest,
+			recent,
+			comparison:
+				comparisonRecords.length === 2
+					? compareProviderRequests(comparisonRecords[0], comparisonRecords[1])
+					: null,
+		},
+		runtime: createRuntimeReport(pi, ctx, capturedAt),
+		privacy:
+			"Records contain only timestamp, session ID, provider/model IDs, the plan marker boolean, and extracted tool names. Prompts, schemas, arguments, headers, credentials, and message contents are not retained.",
+		limitations: PROVIDER_HOOK_LIMITATIONS,
+	};
+}
+
+function selectComparisonRecords(
+	action: DebugAction,
+	recent: readonly ProviderRequestDiagnostic[],
+	all: readonly ProviderRequestDiagnostic[],
+): readonly ProviderRequestDiagnostic[] {
+	if (all.length < 2) return [];
+	if (action === "compare") return [all[0], all[all.length - 1]];
+	if (action === "show" && recent.length >= 2) {
+		return [recent[0], recent[recent.length - 1]];
+	}
+	return all.slice(-2);
+}
+
+function compareProviderRequests(from: ProviderRequestDiagnostic, to: ProviderRequestDiagnostic) {
+	return {
+		fromRequestIndex: from.requestIndex,
+		toRequestIndex: to.requestIndex,
+		providerChanged: from.provider !== to.provider,
+		modelChanged: from.model !== to.model,
+		planModeMarkerChanged: from.planModeMarkerPresent !== to.planModeMarkerPresent,
+		topLevelTools: diffNames(from.topLevelToolNames, to.topLevelToolNames),
+		transcriptTools: diffNames(from.transcriptToolNames, to.transcriptToolNames),
+	};
+}
+
+function diffNames(from: readonly string[], to: readonly string[]) {
+	const previous = new Set(from);
+	const current = new Set(to);
+	return {
+		added: to.filter((name) => !previous.has(name)),
+		removed: from.filter((name) => !current.has(name)),
+	};
+}
+
+function restoreCaptureState(entries: readonly SessionEntry[]): ProviderCaptureState {
+	const state: ProviderCaptureState = { enabled: true, records: [], nextRequestIndex: 1 };
+	let maximumRequestIndex = 0;
+	for (const entry of entries) {
+		if (entry.type !== "custom") continue;
+		if (
+			entry.customType === PROVIDER_REQUEST_ENTRY_TYPE &&
+			isProviderRequestDiagnostic(entry.data)
+		) {
+			maximumRequestIndex = Math.max(maximumRequestIndex, entry.data.requestIndex);
+			state.records.push(entry.data);
+			continue;
+		}
+		if (entry.customType !== CONTROL_ENTRY_TYPE || !isControlEntry(entry.data)) continue;
+		if (entry.data.action === "enable") state.enabled = true;
+		if (entry.data.action === "disable") state.enabled = false;
+		if (entry.data.action === "clear") state.records = [];
+	}
+	state.nextRequestIndex = maximumRequestIndex + 1;
+	return state;
+}
+
+function isControlEntry(value: unknown): value is ControlEntry {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	return (
+		record.version === 1 &&
+		typeof record.capturedAt === "number" &&
+		(record.action === "enable" || record.action === "disable" || record.action === "clear")
+	);
+}
+
+function boundResponse(value: ReturnType<typeof createToolResponse>): {
+	value: unknown;
+	text: string;
+} {
+	let text = JSON.stringify(value, null, 2);
+	if (Buffer.byteLength(text, "utf8") <= MAX_OUTPUT_BYTES) return { value, text };
+
+	const compact = {
+		...value,
+		providerRequestCapture: {
+			...value.providerRequestCapture,
+			recent: value.providerRequestCapture.recent.slice(-2).map(compactProviderRecord),
+			latest: value.providerRequestCapture.latest
+				? compactProviderRecord(value.providerRequestCapture.latest)
+				: null,
+		},
+		runtime: {
+			...value.runtime,
+			extensions: {
+				...value.runtime.extensions,
+				surfaces: [],
+				outputNote: "Extension surface details omitted to keep tool output below 50 KB.",
+			},
+			recentRuntimeRecords: value.runtime.recentRuntimeRecords.slice(-5),
+		},
+		outputNote: "Large diagnostic arrays were compacted to keep tool output below 50 KB.",
+	};
+	text = JSON.stringify(compact, null, 2);
+	if (Buffer.byteLength(text, "utf8") <= MAX_OUTPUT_BYTES) return { value: compact, text };
+
+	const minimal = {
+		action: value.action,
+		providerRequestCapture: {
+			enabled: value.providerRequestCapture.enabled,
+			recordCountSinceClear: value.providerRequestCapture.recordCountSinceClear,
+			latest: value.providerRequestCapture.latest
+				? compactProviderRecord(value.providerRequestCapture.latest)
+				: null,
+			comparison: value.providerRequestCapture.comparison,
+		},
+		runtime: {
+			capturedAt: value.runtime.capturedAt,
+			sessionId: value.runtime.sessionId,
+			current: value.runtime.current,
+			cache: value.runtime.cache,
+			tools: value.runtime.tools,
+			issues: value.runtime.issues,
+		},
+		privacy: value.privacy,
+		limitations: value.limitations,
+		outputNote: "Only the bounded diagnostic summary is shown.",
+	};
+	return { value: minimal, text: JSON.stringify(minimal, null, 2) };
+}
+
+function compactProviderRecord(record: ProviderRequestDiagnostic) {
+	return {
+		...record,
+		topLevelToolCount: record.topLevelToolNames.length,
+		topLevelToolNames: record.topLevelToolNames.slice(0, 20),
+		transcriptToolCount: record.transcriptToolNames.length,
+		transcriptToolNames: record.transcriptToolNames.slice(0, 20),
+	};
+}
+
+export default createDebugExtension();

--- a/.pi/extensions/pi-debug/provider-request.ts
+++ b/.pi/extensions/pi-debug/provider-request.ts
@@ -1,0 +1,124 @@
+const PLAN_MODE_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
+const MAX_TOOL_NAMES = 200;
+const MAX_TOOL_NAME_LENGTH = 128;
+
+export interface ProviderRequestDiagnostic {
+	version: 1;
+	requestIndex: number;
+	capturedAt: number;
+	sessionId: string;
+	provider: string | null;
+	model: string | null;
+	planModeMarkerPresent: boolean;
+	topLevelToolNames: string[];
+	transcriptToolNames: string[];
+}
+
+export interface ProviderRequestIdentity {
+	requestIndex: number;
+	capturedAt: number;
+	sessionId: string;
+	provider?: string;
+	model?: string;
+}
+
+export function extractProviderRequestDiagnostic(
+	payload: unknown,
+	identity: ProviderRequestIdentity,
+): ProviderRequestDiagnostic {
+	const root = asRecord(payload);
+	return {
+		version: 1,
+		requestIndex: identity.requestIndex,
+		capturedAt: identity.capturedAt,
+		sessionId: identity.sessionId,
+		provider: identity.provider ?? null,
+		model: identity.model ?? null,
+		planModeMarkerPresent: containsMarker(root?.instructions),
+		topLevelToolNames: extractToolNames(root?.tools),
+		transcriptToolNames: extractTranscriptToolNames(root?.input),
+	};
+}
+
+export function isProviderRequestDiagnostic(value: unknown): value is ProviderRequestDiagnostic {
+	const record = asRecord(value);
+	return (
+		record?.version === 1 &&
+		typeof record.requestIndex === "number" &&
+		Number.isInteger(record.requestIndex) &&
+		typeof record.capturedAt === "number" &&
+		typeof record.sessionId === "string" &&
+		(record.provider === null || typeof record.provider === "string") &&
+		(record.model === null || typeof record.model === "string") &&
+		typeof record.planModeMarkerPresent === "boolean" &&
+		isStringArray(record.topLevelToolNames) &&
+		isStringArray(record.transcriptToolNames)
+	);
+}
+
+function extractTranscriptToolNames(input: unknown): string[] {
+	if (!Array.isArray(input)) return [];
+	const names: string[] = [];
+	for (const item of input) {
+		const record = asRecord(item);
+		if (record?.type !== "additional_tools" && record?.type !== "tool_search_output") {
+			continue;
+		}
+		names.push(...extractToolNames(record.tools));
+		if (record.type === "tool_search_output") {
+			const output = asRecord(record.output);
+			names.push(...extractToolNames(Array.isArray(record.output) ? record.output : output?.tools));
+		}
+	}
+	return uniqueNames(names);
+}
+
+function extractToolNames(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const names: string[] = [];
+	for (const candidate of value) {
+		const record = asRecord(candidate);
+		if (!record) continue;
+		const functionDefinition = asRecord(record.function);
+		const customDefinition = asRecord(record.custom);
+		const name = firstName(record.name, functionDefinition?.name, customDefinition?.name);
+		if (name) names.push(name);
+	}
+	return uniqueNames(names);
+}
+
+function containsMarker(value: unknown): boolean {
+	if (typeof value === "string") return value.includes(PLAN_MODE_MARKER);
+	if (Array.isArray(value)) return value.some(containsMarker);
+	const record = asRecord(value);
+	if (!record) return false;
+	return containsMarker(record.text) || containsMarker(record.content);
+}
+
+function firstName(...values: unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value !== "string") continue;
+		const normalized = value.trim();
+		if (!normalized) continue;
+		return normalized.length > MAX_TOOL_NAME_LENGTH
+			? `${normalized.slice(0, MAX_TOOL_NAME_LENGTH - 1)}…`
+			: normalized;
+	}
+	return undefined;
+}
+
+function uniqueNames(names: readonly string[]): string[] {
+	return [...new Set(names)]
+		.sort((left, right) => left.localeCompare(right))
+		.slice(0, MAX_TOOL_NAMES);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}

--- a/.pi/extensions/pi-debug/snapshot.ts
+++ b/.pi/extensions/pi-debug/snapshot.ts
@@ -1,0 +1,313 @@
+import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent";
+
+export const RUNTIME_ENTRY_TYPE = "pi-debug:runtime-snapshot";
+const MAX_TOOL_NAMES = 200;
+const MAX_EXTENSION_SURFACES = 100;
+const MAX_CACHE_SAMPLES = 20;
+const MAX_RUNTIME_RECORDS = 20;
+
+export type RuntimeSnapshotReason =
+	| "session_start"
+	| "model_select"
+	| "before_agent_start"
+	| "tools_changed"
+	| "assistant_message"
+	| "diagnostic_tool";
+
+interface UsageLike {
+	input?: number;
+	cacheRead?: number;
+	cacheWrite?: number;
+}
+
+export interface ResponseCacheSample {
+	capturedAt: number;
+	provider: string | null;
+	model: string | null;
+	input: number;
+	cacheRead: number;
+	cacheWrite: number;
+	promptTokens: number;
+	hitRatePercent: number | null;
+}
+
+export interface RuntimeSnapshot {
+	version: 1;
+	capturedAt: number;
+	reason: RuntimeSnapshotReason;
+	sessionId: string;
+	provider: string | null;
+	model: string | null;
+	thinkingLevel: string;
+	cache: ResponseCacheSample | null;
+	tools: ToolState;
+}
+
+export interface ToolState {
+	configuredCount: number;
+	activeCount: number;
+	inactiveCount: number;
+	active: string[];
+	inactive: string[];
+	unknownActive: string[];
+	omittedCount: number;
+}
+
+export interface RuntimeDiagnosticReport {
+	capturedAt: number;
+	sessionId: string;
+	current: {
+		provider: string | null;
+		model: string | null;
+		thinkingLevel: string;
+	};
+	cache: {
+		requestCount: number;
+		input: number;
+		cacheRead: number;
+		cacheWrite: number;
+		promptTokens: number;
+		hitRatePercent: number | null;
+		latest: ResponseCacheSample | null;
+		recent: ResponseCacheSample[];
+	};
+	tools: ToolState;
+	extensions: {
+		visibility: string;
+		visibleCount: number;
+		omittedCount: number;
+		surfaces: ExtensionSurface[];
+	};
+	issues: string[];
+	recentRuntimeRecords: RuntimeSnapshot[];
+}
+
+interface ExtensionSurface {
+	path: string;
+	source: string;
+	scope: string;
+	origin: string;
+	tools: string[];
+	commands: string[];
+}
+
+interface ResponseIdentity {
+	provider?: string;
+	model?: string;
+	usage: UsageLike;
+}
+
+export function createRuntimeSnapshot(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	reason: RuntimeSnapshotReason,
+	capturedAt: number,
+	response?: ResponseIdentity,
+): RuntimeSnapshot {
+	return {
+		version: 1,
+		capturedAt,
+		reason,
+		sessionId: ctx.sessionManager.getSessionId(),
+		provider: ctx.model?.provider ?? null,
+		model: ctx.model?.id ?? null,
+		thinkingLevel: pi.getThinkingLevel(),
+		cache: response
+			? createCacheSample(response.usage, capturedAt, response.provider, response.model)
+			: null,
+		tools: collectToolState(pi),
+	};
+}
+
+export function runtimeStateSignature(snapshot: RuntimeSnapshot): string {
+	return JSON.stringify({
+		provider: snapshot.provider,
+		model: snapshot.model,
+		thinkingLevel: snapshot.thinkingLevel,
+		tools: snapshot.tools,
+	});
+}
+
+export function createRuntimeReport(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	capturedAt: number,
+): RuntimeDiagnosticReport {
+	const entries = ctx.sessionManager.getBranch();
+	const tools = collectToolState(pi);
+	const issues: string[] = [];
+	if (!ctx.model) issues.push("No active model is available in the extension context.");
+	if (tools.unknownActive.length > 0) {
+		issues.push(
+			`Active tools missing from the configured catalog: ${tools.unknownActive.join(", ")}.`,
+		);
+	}
+
+	return {
+		capturedAt,
+		sessionId: ctx.sessionManager.getSessionId(),
+		current: {
+			provider: ctx.model?.provider ?? null,
+			model: ctx.model?.id ?? null,
+			thinkingLevel: pi.getThinkingLevel(),
+		},
+		cache: collectCacheMetrics(entries),
+		tools,
+		extensions: collectExtensionSurfaces(pi),
+		issues,
+		recentRuntimeRecords: collectRuntimeRecords(entries),
+	};
+}
+
+function collectToolState(pi: ExtensionAPI): ToolState {
+	const configured = [...pi.getAllTools()].sort((left, right) =>
+		left.name.localeCompare(right.name),
+	);
+	const configuredNames = new Set(configured.map(({ name }) => name));
+	const activeNames = [...new Set(pi.getActiveTools())].sort((left, right) =>
+		left.localeCompare(right),
+	);
+	const knownActive = activeNames.filter((name) => configuredNames.has(name));
+	const inactive = configured.map(({ name }) => name).filter((name) => !activeNames.includes(name));
+	const unknownActive = activeNames.filter((name) => !configuredNames.has(name));
+	const visible = [...knownActive, ...inactive].slice(0, MAX_TOOL_NAMES);
+	const visibleSet = new Set(visible);
+
+	return {
+		configuredCount: configured.length,
+		activeCount: knownActive.length,
+		inactiveCount: inactive.length,
+		active: knownActive.filter((name) => visibleSet.has(name)),
+		inactive: inactive.filter((name) => visibleSet.has(name)),
+		unknownActive,
+		omittedCount: Math.max(0, knownActive.length + inactive.length - visible.length),
+	};
+}
+
+function collectCacheMetrics(entries: readonly SessionEntry[]): RuntimeDiagnosticReport["cache"] {
+	const samples: ResponseCacheSample[] = [];
+	let input = 0;
+	let cacheRead = 0;
+	let cacheWrite = 0;
+	for (const entry of entries) {
+		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+		const sample = createCacheSample(
+			entry.message.usage,
+			entry.message.timestamp,
+			entry.message.provider,
+			entry.message.model,
+		);
+		samples.push(sample);
+		input += sample.input;
+		cacheRead += sample.cacheRead;
+		cacheWrite += sample.cacheWrite;
+	}
+	const promptTokens = input + cacheRead + cacheWrite;
+	return {
+		requestCount: samples.length,
+		input,
+		cacheRead,
+		cacheWrite,
+		promptTokens,
+		hitRatePercent: promptTokens > 0 ? (cacheRead / promptTokens) * 100 : null,
+		latest: samples.at(-1) ?? null,
+		recent: samples.slice(-MAX_CACHE_SAMPLES),
+	};
+}
+
+function createCacheSample(
+	usage: UsageLike,
+	capturedAt: number,
+	provider?: string,
+	model?: string,
+): ResponseCacheSample {
+	const input = finiteNumber(usage.input);
+	const cacheRead = finiteNumber(usage.cacheRead);
+	const cacheWrite = finiteNumber(usage.cacheWrite);
+	const promptTokens = input + cacheRead + cacheWrite;
+	return {
+		capturedAt,
+		provider: provider ?? null,
+		model: model ?? null,
+		input,
+		cacheRead,
+		cacheWrite,
+		promptTokens,
+		hitRatePercent: promptTokens > 0 ? (cacheRead / promptTokens) * 100 : null,
+	};
+}
+
+function collectRuntimeRecords(entries: readonly SessionEntry[]): RuntimeSnapshot[] {
+	return entries
+		.filter(
+			(entry): entry is Extract<SessionEntry, { type: "custom" }> =>
+				entry.type === "custom" && entry.customType === RUNTIME_ENTRY_TYPE,
+		)
+		.map(({ data }) => data)
+		.filter(isRuntimeSnapshot)
+		.slice(-MAX_RUNTIME_RECORDS);
+}
+
+function collectExtensionSurfaces(pi: ExtensionAPI): RuntimeDiagnosticReport["extensions"] {
+	const surfaces = new Map<string, ExtensionSurface>();
+	const add = (
+		sourceInfo: { path: string; source: string; scope: string; origin: string },
+		kind: "tools" | "commands",
+		name: string,
+	) => {
+		const key = `${sourceInfo.path}\u0000${sourceInfo.source}`;
+		const surface = surfaces.get(key) ?? {
+			path: sourceInfo.path,
+			source: sourceInfo.source,
+			scope: sourceInfo.scope,
+			origin: sourceInfo.origin,
+			tools: [],
+			commands: [],
+		};
+		surface[kind].push(name);
+		surfaces.set(key, surface);
+	};
+
+	for (const tool of pi.getAllTools()) {
+		if (tool.sourceInfo.source === "builtin" || tool.sourceInfo.source === "sdk") continue;
+		add(tool.sourceInfo, "tools", tool.name);
+	}
+	for (const command of pi.getCommands()) {
+		if (command.source !== "extension") continue;
+		add(command.sourceInfo, "commands", command.name);
+	}
+
+	const all = [...surfaces.values()]
+		.map((surface) => ({
+			...surface,
+			tools: [...new Set(surface.tools)].sort(),
+			commands: [...new Set(surface.commands)].sort(),
+		}))
+		.sort((left, right) => left.path.localeCompare(right.path));
+	return {
+		visibility:
+			"Only extensions exposing public tools or slash commands are visible; passive event-only extensions are not enumerable through ExtensionAPI.",
+		visibleCount: all.length,
+		omittedCount: Math.max(0, all.length - MAX_EXTENSION_SURFACES),
+		surfaces: all.slice(0, MAX_EXTENSION_SURFACES),
+	};
+}
+
+function isRuntimeSnapshot(value: unknown): value is RuntimeSnapshot {
+	if (!isRecord(value)) return false;
+	return (
+		value.version === 1 &&
+		typeof value.capturedAt === "number" &&
+		typeof value.reason === "string" &&
+		typeof value.sessionId === "string" &&
+		isRecord(value.tools)
+	);
+}
+
+function finiteNumber(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,17 @@
 
 ## Repository structure
 
-- This Node.js and TypeScript monorepo contains Pi extensions and reusable libraries.
-- Keep active package source under `packages/<package>/src/`.
+- This Node.js and TypeScript monorepo contains Pi extension packages, project-local Pi extensions, and reusable libraries.
+- Keep publishable extension packages and reusable libraries under `packages/<package>/`.
+- Keep package implementation source under `packages/<package>/src/`.
+- Keep small repository-only Pi extensions and their supporting implementation files under `.pi/extensions/<extension>/`, with `index.ts` as the entrypoint.
 - Each package owns its manifest, README, license, and TypeScript configuration.
-- Set each extension's `piExtension.lifecycle` to `stable` or `experimental`.
+- Set each extension package's `piExtension.lifecycle` to `stable` or `experimental`.
+- Treat `.pi/extensions/` as a self-contained project-resource boundary unrelated to extension packages under `packages/`.
+- Keep a project-local extension's implementation, helpers, documentation, and any requested tests inside its own `.pi/extensions/<extension>/` directory.
+- Do not add or modify package manifests, workspaces, Changesets, package tests, root test support, or shared TypeScript configuration for a project-local extension unless the user explicitly asks.
+- Project-local extensions do not require package manifests, lifecycle metadata, Changesets, publication files, or packaged-extension verification gates.
+- Promote a project-local extension into `packages/` only when the user explicitly requests independent installation, reuse, versioning, or publication.
 - Omit `piExtension` from reusable libraries.
 - Keep deprecated reference packages under `deprecated/`, which active checks exclude.
 - Root files such as `package.json`, `package-lock.json`, `biome.json`, `tsconfig.json`, `justfile`, and `.github/workflows/*` own shared tooling.
@@ -51,7 +58,8 @@ Run commands from the repository root unless a command says otherwise.
 - Add dependencies only for current package needs.
 - Use a Pi core function when Pi already provides the required behavior.
 - Upgrade an outdated dependency instead of hiding its type errors by removing or downgrading code.
-- Keep every extension independently installable and functional by itself.
+- Keep every extension package independently installable and functional by itself.
+- Keep every project-local extension functional through Pi's project auto-discovery without another extension package.
 - Do not import or depend on another extension package.
 - Do not assume private or extension-specific details of another extension, including its names, schemas, settings, events, installation state, version, or behavior.
 - Extensions may participate in documented, versioned, extension-neutral protocols over Pi's public APIs only when the protocol does not identify or require a specific extension and the absence of other participants preserves standalone behavior.
@@ -59,14 +67,16 @@ Run commands from the repository root unless a command says otherwise.
 - Share code only through Pi's public extension-neutral APIs or reusable non-extension libraries.
 - Do not make reusable libraries coordinate specific extensions.
 - Consume shared Pi APIs without extension-specific branches.
-- Give every active extension a thin `src/index.ts` default-export forwarder and keep authoritative implementation under `src/`.
-- Declare exactly one extension entrypoint in each active extension manifest: `./src/index.ts`, or a build-backed `./dist/index.ts` TypeScript bundle loaded by Pi's Jiti runtime.
+- Give every packaged extension a thin `src/index.ts` default-export forwarder and keep authoritative implementation under `src/`.
+- A project-local extension may use `.pi/extensions/<extension>/index.ts` as its authoritative implementation.
+- Declare exactly one extension entrypoint in each packaged extension manifest: `./src/index.ts`, or a build-backed `./dist/index.ts` TypeScript bundle loaded by Pi's Jiti runtime.
 - Require a `dist/index.ts` entrypoint to stay within `dist`, externalize Pi-bundled peer dependencies, publish `dist`, and be built before packing or loading the package directory.
 - Keep extension implementation in descriptively named source modules.
 - Build and publish reusable libraries as JavaScript with declarations through their own build configuration and without `pi.extensions`.
 - Run `npm run check:boundaries` to verify package boundaries.
-- List every stable extension's `src/index.ts` repository entrypoint in the root `package.json` under `pi.extensions`.
-- Do not list experimental extension entrypoints in the root `package.json` under `pi.extensions`.
+- List every stable extension package's `src/index.ts` repository entrypoint in the root `package.json` under `pi.extensions`.
+- Do not list experimental extension package entrypoints in the root `package.json` under `pi.extensions`.
+- Do not list `.pi/extensions/` entrypoints in the root `package.json`; Pi discovers them after the project is trusted.
 - Add a root workspace script or recipe only for a workflow users must run from the repository root.
 - Choose the first TUI layer that fully supports the flow: Pi core `ctx.ui` APIs and `@earendil-works/pi-tui` components, then `@narumitw/pi-tui-kit`, and finally an extension-owned custom component.
 - Create a new custom component only when the earlier layers cannot preserve the required state, interaction, or lifecycle behavior.
@@ -125,7 +135,8 @@ Run commands from the repository root unless a command says otherwise.
 - Run `npm test` or `just test` separately for active tests.
 - CI and release verification must run both gates.
 - Run `just pack <unscoped-name>` and inspect the tarball after package metadata or publishing changes.
-- After extension runtime-loading changes, run `npm --workspace @narumitw/pi-<unscoped-name> run build --if-present`, then smoke with `pi -e ./packages/pi-<unscoped-name>`; record why and what remains unverified if the smoke is impractical.
+- After packaged extension runtime-loading changes, run `npm --workspace @narumitw/pi-<unscoped-name> run build --if-present`, then smoke with `pi -e ./packages/pi-<unscoped-name>`; record why and what remains unverified if the smoke is impractical.
+- After project-local extension changes, smoke it in isolation with `pi --no-extensions -e ./.pi/extensions/<extension>/index.ts`, then verify trusted-project auto-discovery and `/reload` when practical.
 - Start subprocess timing deadlines only after a child readiness handshake.
 - Synchronize concurrent HTTP tests on a server-observable response or callback instead of a fixed sleep after `fetch()`.
 - Set `PI_CODING_AGENT_DIR` before importing an extension in lifecycle tests and use fresh imports for module-cached paths.


### PR DESCRIPTION
## Summary

- add a trusted project-local `pi_debug` tool under `.pi/extensions/pi-debug/`
- record provider/model, cache hit rates, and active/inactive tool snapshots in session entries
- capture privacy-filtered provider-request tool exposure, including OpenAI Responses deferred tools
- add enable, disable, latest, show, compare, and clear controls for Plan re-entry diagnosis
- clarify the repository boundary between project-local resources and publishable extension packages

## Privacy and limitations

The provider-request diagnostic retains only timestamps, session IDs, provider/model IDs, the Plan marker boolean, and tool names.
It does not retain prompts, schemas, arguments, headers, credentials, payloads, or message contents.
`before_provider_request` observes the payload at this extension's point in handler load order; later extensions and transport internals may still change it.

## Verification

- `npm run biome:check`
- `npm run typecheck`
- isolated TypeScript check for `.pi/extensions/pi-debug/`
- provider-request extraction, malformed-payload, deferred-tool, and privacy smoke assertions
- Pi Jiti explicit-load smoke
- trusted-project auto-discovery and reload smoke

Automated test files were not added because `.pi/extensions/` is a self-contained project-resource boundary outside the package test suite.
