### PR TITLE
fix(plan-mode): align transitions with run boundaries

### DIFF
--- a/.changeset/steady-plans-settle.md
+++ b/.changeset/steady-plans-settle.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": patch
+---
+
+Prevent active agent runs from mixing Plan and Normal tool contracts, and retry explicit structured finalization once after settlement when the model responds with prose only.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -83,6 +83,10 @@ Completed and saved plan menus offer **Implement here**, which continues with th
 The direct `/plan implement` compatibility route remains equivalent to **Implement here** and never opens a selector.
 A successful ready-plan export also leaves Plan mode; saved and active implementation exports retain their existing state.
 `show`, `save`, `export`, and `implement` fail closed when no applicable plan is stored; `finalize` requires active Plan mode.
+Pi executes extension commands immediately during streaming, but changing Plan state or handing off implementation during an active run would mix the run's existing system prompt with a new tool contract.
+Plan mode therefore rejects busy start, exit, save, ready-plan export, implementation, state-changing menu action, and configured-shortcut transitions without changing state; wait for the run to settle and retry.
+Prompts submitted while Plan mode is already active remain ordinary Plan follow-ups, and `/plan finalize` remains available as a Plan-preserving follow-up.
+TUI and RPC show a warning for a rejected busy transition, while print and JSON routes throw an observable error.
 
 `/plan export` uses the configured **Export destination**, which defaults to `PLAN.md`.
 Supply a path to override that default for one export.
@@ -148,8 +152,11 @@ Its visible result contains the full plan, and versioned result details let the 
 `plan_mode_complete` uses Pi's `terminate: true` hint.
 Termination is best effort: if a model puts it in a parallel tool batch, Pi terminates the batch early only when every finalized sibling tool also terminates.
 The prompt therefore requires the completion call to be standalone and last.
-The extension deliberately does not infer completion from phrases such as “I will present the plan,” and it does not automatically retry a turn with no plan because research and clarification turns may legitimately remain unfinished.
-If a turn ends without a plan, Plan mode stays active; use `/plan finalize` for explicit recovery.
+The extension deliberately does not infer completion from phrases such as “I will present the plan,” and ordinary research or clarification turns never trigger automatic retries.
+`/plan finalize` and its exact canonical finalization prompt are explicit recovery requests.
+If one of those requests ends normally without a valid structured question or completed plan, Plan mode waits for `agent_settled` and retries once with stronger tool guidance.
+A valid question, accepted completion, user cancellation, explicit exit, workflow supersession, reload, session replacement, or shutdown cancels the retry.
+A second prose-only failure leaves Plan mode active, warns in interactive modes, and requires another explicit `/plan finalize` request.
 
 Legacy sessions and models may still submit one non-empty `<proposed_plan>` block with tags on their own lines.
 That compatibility path remains accepted, but it is not the primary workflow.
@@ -421,6 +428,7 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 - The implementation boundary is explicit: Plan mode restores tools before saving or starting implementation, saving keeps the plan outside ordinary model context, and choosing implementation immediately triggers a normal agent turn with full tool access.
 - The default `clear-on-start` policy follows Codex by using ordinary conversation history only; `clear-after-first-run` and `keep` add explicit exact-plan guarantees.
 - Pi extension safety is approximated with tool classification and fail-closed filtering for every effective tool named `bash`; other non-built-in tools remain user-selected at user risk because Pi does not expose standardized tool mutability metadata.
+- Plan and Normal mode intentionally use different instructions and tool schemas, so the first provider request after a genuine mode transition may miss the prompt cache; later requests can reuse the new stable prefix.
 - Unlike native Codex, this extension uses a terminating Pi tool plus an `agent_settled` ready flow; Pi cannot provide sandbox-level enforcement.
 
 ## 🗂️ Package layout

--- a/packages/pi-plan-mode/src/finalization-request.ts
+++ b/packages/pi-plan-mode/src/finalization-request.ts
@@ -1,0 +1,57 @@
+export const FINALIZE_PLAN_PROMPT =
+	"Finalize the current implementation plan now. If any material decision remains, use plan_mode_question instead. Otherwise call plan_mode_complete alone as your final action with the complete decision-ready plan.";
+
+export const RETRY_FINALIZE_PLAN_PROMPT =
+	"Your previous finalization response did not call plan_mode_question or plan_mode_complete. Both tools are available in the current Plan-mode request. If a material decision remains, call plan_mode_question now. Otherwise call plan_mode_complete alone with the complete decision-ready plan. Do not respond with prose about tool availability.";
+
+export type FinalizationRunOutcome = "normal" | "cancelled" | "error";
+export type FinalizationSettlementAction = "retry" | "failed" | undefined;
+
+interface PendingFinalizationRequest {
+	workflowGeneration: number;
+	retryCount: number;
+	awaitingSettlement: boolean;
+}
+
+export function createFinalizationRequestCoordinator() {
+	let pending: PendingFinalizationRequest | undefined;
+
+	return {
+		request(workflowGeneration: number) {
+			pending = { workflowGeneration, retryCount: 0, awaitingSettlement: false };
+		},
+		satisfy() {
+			pending = undefined;
+		},
+		observeRunEnd(workflowGeneration: number, outcome: FinalizationRunOutcome) {
+			if (!pending || pending.workflowGeneration !== workflowGeneration) return;
+			if (outcome !== "normal") {
+				pending = undefined;
+				return;
+			}
+			pending.awaitingSettlement = true;
+		},
+		settle(workflowGeneration: number): FinalizationSettlementAction {
+			if (
+				!pending ||
+				pending.workflowGeneration !== workflowGeneration ||
+				!pending.awaitingSettlement
+			) {
+				return undefined;
+			}
+			if (pending.retryCount === 0) {
+				pending.retryCount = 1;
+				pending.awaitingSettlement = false;
+				return "retry";
+			}
+			pending = undefined;
+			return "failed";
+		},
+		reset() {
+			pending = undefined;
+		},
+		hasPendingRequest() {
+			return pending !== undefined;
+		},
+	};
+}

--- a/packages/pi-plan-mode/src/message-transform.ts
+++ b/packages/pi-plan-mode/src/message-transform.ts
@@ -23,6 +23,7 @@ export type ProposedPlanParseResult =
 type SessionMessage = {
 	role?: string;
 	content?: unknown;
+	stopReason?: string;
 };
 
 type TextBlock = {
@@ -68,6 +69,21 @@ export function latestAssistantText(messages: unknown) {
 		if (text) return text;
 	}
 	return "";
+}
+
+export function latestAssistantStopReason(messages: unknown) {
+	if (!Array.isArray(messages)) return undefined;
+	for (const entry of [...messages].reverse()) {
+		const message = (entry as { message?: SessionMessage })?.message ?? (entry as SessionMessage);
+		if (message?.role === "assistant") return message.stopReason;
+	}
+	return undefined;
+}
+
+export function messageTextContent(message: unknown) {
+	return messageText(
+		(message as { message?: SessionMessage })?.message ?? (message as SessionMessage),
+	);
 }
 
 export function messageContainsLegacyPlanModeContextArtifact(message: unknown) {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -20,6 +20,12 @@ import {
 	setPlanThinkingLevel,
 } from "./extension-runtime.js";
 import {
+	createFinalizationRequestCoordinator,
+	FINALIZE_PLAN_PROMPT,
+	type FinalizationRunOutcome,
+	RETRY_FINALIZE_PLAN_PROMPT,
+} from "./finalization-request.js";
+import {
 	formatHistoryImplementationPrompt,
 	formatImplementationHandoff,
 	formatTransferredPlanPrompt,
@@ -29,7 +35,13 @@ import {
 	createImplementationRetentionCoordinator,
 	implementationRetentionPreview,
 } from "./implementation-retention.js";
-import { invalidPlanMessage, latestAssistantText, parseProposedPlan } from "./message-transform.js";
+import {
+	invalidPlanMessage,
+	latestAssistantStopReason,
+	latestAssistantText,
+	messageTextContent,
+	parseProposedPlan,
+} from "./message-transform.js";
 import { createPlanActionController } from "./plan-action-controller.js";
 import { createPlanExportController } from "./plan-export-controller.js";
 import {
@@ -126,11 +138,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let settingsWatch: ReturnType<typeof watch> | undefined;
 	let settingsReloadTimer: ReturnType<typeof setTimeout> | undefined;
 	const implementationRetention = createImplementationRetentionCoordinator();
+	const finalizationRequest = createFinalizationRequestCoordinator();
 	const persistState = () => pi.appendEntry<PlanModeState>(STATE_ENTRY_TYPE, state);
 	const planExports = createPlanExportController({
 		getState: () => state,
 		getSettings: () => settings,
-		finishReady: (ctx) => exitPlanMode(ctx),
+		finishReady: (ctx) => {
+			exitPlanMode(ctx);
+		},
 	});
 	const planActions = createPlanActionController({
 		loadInteractiveUi,
@@ -143,17 +158,17 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		finalize: requestFinalPlan,
 		implementHere: startImplementation,
 		implementFresh: startFreshImplementation,
-		exportPlan: (ctx, path, signal, isCurrent) => planExports.export(path, ctx, signal, isCurrent),
+		exportPlan: exportPlan,
 		settings: showSettings,
 		save: savePlanForLater,
 		stay: updateUi,
 		exitReady: (ctx) => {
-			exitPlanMode(ctx);
-			ctx.ui.notify("Plan mode disabled. Proposed plan discarded.", "info");
+			if (exitPlanMode(ctx)) {
+				ctx.ui.notify("Plan mode disabled. Proposed plan discarded.", "info");
+			}
 		},
 		clearSaved: (ctx) => {
-			exitPlanMode(ctx);
-			ctx.ui.notify("Saved plan cleared.", "info");
+			if (exitPlanMode(ctx)) ctx.ui.notify("Saved plan cleared.", "info");
 		},
 	});
 
@@ -186,6 +201,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			if (!parsed.ok) {
 				return planModeQuestionCancelled([], "invalid_input", `Error: ${parsed.error}`);
 			}
+			finalizationRequest.satisfy();
 
 			if (!ctx.hasUI) {
 				return planModeQuestionCancelled(
@@ -276,12 +292,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			const exportMatch = /^export(?:\s+([\s\S]+))?$/iu.exec(prompt);
 			if (exportMatch) {
 				const lifecycle = captureMenuLifecycle();
-				await planExports.export(exportMatch[1], ctx, lifecycle.signal, lifecycle.isCurrent);
+				await exportPlan(ctx, exportMatch[1], lifecycle.signal, lifecycle.isCurrent);
 				return;
 			}
 			if (command === "exit" || command === "off") {
-				ctx.ui.notify(planModeDisableNotification(), "info");
-				exitPlanMode(ctx);
+				const notification = planModeDisableNotification();
+				if (exitPlanMode(ctx)) ctx.ui.notify(notification, "info");
 				return;
 			}
 			if (command === "tools") {
@@ -421,6 +437,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	pi.on("session_start", async (event, ctx) => {
 		const generation = ++menuGeneration;
+		finalizationRequest.reset();
 		currentSession = ctx.sessionManager;
 		workflowOwner = undefined;
 		workflowMutex.bindSession(ctx.sessionManager);
@@ -472,6 +489,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		const shutdownSession = ctx.sessionManager;
+		finalizationRequest.reset();
 		menuGeneration += 1;
 		menuController.abort(new DOMException("Plan-mode session shut down", "AbortError"));
 		readyPresentationIntent = undefined;
@@ -530,6 +548,16 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 	});
 
+	pi.on("message_start", (event) => {
+		if (
+			state.enabled &&
+			event.message.role === "user" &&
+			messageTextContent(event.message).trim() === FINALIZE_PLAN_PROMPT
+		) {
+			finalizationRequest.request(workflowGeneration);
+		}
+	});
+
 	pi.on("context", async (event, ctx) => {
 		const result = implementationRetention.transformContext(event.messages, state);
 		if (result.clearActiveImplementationId) {
@@ -570,6 +598,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		const text = latestAssistantText(event.messages);
 		const parsedPlan = parseProposedPlan(text);
 		if (parsedPlan.kind !== "valid") {
+			finalizationRequest.observeRunEnd(workflowGeneration, finalizationRunOutcome(event.messages));
 			if (parsedPlan.kind !== "absent") {
 				ctx.ui.notify(invalidPlanMessage(parsedPlan.kind), "warning");
 			}
@@ -585,6 +614,25 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			state.activeImplementation,
 		);
 		if (settledImplementationId) clearActiveImplementation(settledImplementationId, ctx);
+
+		if (
+			finalizationRequest.hasPendingRequest() &&
+			state.enabled &&
+			workflowMutex.isOwner(workflowOwner)
+		) {
+			if (!ctx.isIdle() || ctx.hasPendingMessages()) return;
+			const action = finalizationRequest.settle(workflowGeneration);
+			if (action === "retry") {
+				if (sendPlanModeUserMessage(RETRY_FINALIZE_PLAN_PROMPT, ctx)) return;
+				finalizationRequest.reset();
+			}
+			if (action === "failed") {
+				ctx.ui.notify(
+					"Plan finalization ended twice without a structured question or completed plan. Plan mode remains active; revise the plan or run /plan finalize again.",
+					"warning",
+				);
+			}
+		}
 
 		const intent = readyPresentationIntent;
 		if (!intent || !readyPresentationIsCurrent(intent)) return;
@@ -614,6 +662,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		ctx: ExtensionContext,
 		candidate: Pick<PlanModeState, "selectedToolNames" | "selectedToolKeys"> = state,
 	) {
+		if (!state.enabled && !allowModeTransition(ctx, "start Plan mode")) return false;
 		bindWorkflowSessionIfNeeded(ctx);
 		if (state.enabled) return workflowMutex.isOwner(workflowOwner);
 		const owner = workflowMutex.acquire();
@@ -622,7 +671,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 		const previousState = state;
 		const previousToolSnapshot = previousTools;
-		workflowGeneration += 1;
+		advanceWorkflowGeneration();
 		try {
 			previousTools = withoutRequiredPlanModeTools(safeGetActiveTools());
 			state = {
@@ -660,7 +709,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	}
 
 	function exitPlanMode(ctx: ExtensionContext) {
-		workflowGeneration += 1;
+		if (!allowModeTransition(ctx, "leave or clear Plan mode")) return false;
+		advanceWorkflowGeneration();
 		const wasEnabled = state.enabled;
 		readyPresentationIntent = undefined;
 		state = {
@@ -681,6 +731,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		persistState();
 		updateUi(ctx);
 		if (wasEnabled) releaseWorkflowOwner();
+		return true;
 	}
 
 	function sendPlanModeUserMessage(message: string, ctx: ExtensionContext) {
@@ -703,6 +754,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			updateUi(ctx);
 			return;
 		}
+		finalizationRequest.satisfy();
 		if (
 			state.enabled &&
 			state.awaitingAction &&
@@ -742,8 +794,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	function togglePlanMode(ctx: ExtensionContext) {
 		if (state.enabled) {
-			ctx.ui.notify(planModeDisableNotification(), "info");
-			exitPlanMode(ctx);
+			const notification = planModeDisableNotification();
+			if (exitPlanMode(ctx)) ctx.ui.notify(notification, "info");
 			return;
 		}
 		if (savedPlanBlocksNewWorkflow(ctx, state.savedPlan !== undefined)) return;
@@ -767,10 +819,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			ctx.ui.notify("Plan mode is not active. Use /plan first.", "warning");
 			return;
 		}
-		sendPlanModeUserMessage(
-			"Finalize the current implementation plan now. If any material decision remains, use plan_mode_question instead. Otherwise call plan_mode_complete alone as your final action with the complete decision-ready plan.",
-			ctx,
-		);
+		finalizationRequest.request(workflowGeneration);
+		if (!sendPlanModeUserMessage(FINALIZE_PLAN_PROMPT, ctx)) finalizationRequest.reset();
 	}
 
 	function savePlanForLater(ctx: ExtensionContext) {
@@ -782,8 +832,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			return;
 		}
 		const source = state.latestPlanSource ?? "legacy_proposed_plan";
+		if (!allowModeTransition(ctx, "save the plan and leave Plan mode")) return;
 
-		workflowGeneration += 1;
+		advanceWorkflowGeneration();
 		readyPresentationIntent = undefined;
 		state = {
 			...state,
@@ -815,6 +866,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	async function startImplementation(ctx: ExtensionContext) {
 		const savedPlan = state.enabled ? undefined : state.savedPlan;
+		const initialPlan = (state.enabled ? state.latestPlan : savedPlan?.plan)?.trim();
+		if (!initialPlan) {
+			ctx.ui.notify("Plan mode disabled. No proposed plan is available to implement.", "warning");
+			return;
+		}
+		if (!allowModeTransition(ctx, "start plan implementation")) return;
 		if (savedPlan) {
 			const sessionGeneration = menuGeneration;
 			const planWorkflowGeneration = workflowGeneration;
@@ -825,16 +882,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				!state.enabled &&
 				state.savedPlan === savedPlan;
 			if (!(await preflightSavedPlanImplementation(ctx, isCurrent))) return;
+			if (!allowModeTransition(ctx, "start plan implementation")) return;
 		}
 		const plan = (state.enabled ? state.latestPlan : savedPlan?.plan)?.trim();
 		const source =
 			(state.enabled ? state.latestPlanSource : savedPlan?.source) ?? "legacy_proposed_plan";
-		if (!plan) {
-			ctx.ui.notify("Plan mode disabled. No proposed plan is available to implement.", "warning");
-			return;
-		}
+		if (!plan) return;
 
-		workflowGeneration += 1;
+		advanceWorkflowGeneration();
 		const previousState = state;
 		const previousIntent = readyPresentationIntent;
 		const previousToolSnapshot = previousTools;
@@ -891,11 +946,26 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	function clearActiveImplementation(id: string, ctx: ExtensionContext) {
 		if (state.activeImplementation?.id !== id) return false;
-		workflowGeneration += 1;
+		advanceWorkflowGeneration();
 		state = { ...state, activeImplementation: undefined };
 		persistState();
 		updateUi(ctx);
 		return true;
+	}
+
+	async function exportPlan(
+		ctx: ExtensionContext,
+		path: string | undefined,
+		signal: AbortSignal,
+		isCurrent: () => boolean,
+	) {
+		const exitsReadyPlan = state.enabled && Boolean(state.latestPlan?.trim());
+		if (exitsReadyPlan && !allowModeTransition(ctx, "export the ready plan and leave Plan mode")) {
+			return false;
+		}
+		return planExports.export(path, ctx, signal, () => {
+			return isCurrent() && (!exitsReadyPlan || ctx.isIdle());
+		});
 	}
 
 	async function showLaunchMenu(ctx: ExtensionContext, initialScreen: "main" | "tools" = "main") {
@@ -969,8 +1039,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				}
 			},
 			clear: () => {
-				exitPlanMode(ctx);
-				ctx.ui.notify("Active implementation plan cleared.", "info");
+				if (exitPlanMode(ctx)) ctx.ui.notify("Active implementation plan cleared.", "info");
 			},
 		});
 	}
@@ -998,6 +1067,26 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				: {}),
 		});
 		return result.kind === "closed" && "reason" in result && result.reason === "close";
+	}
+
+	function allowModeTransition(ctx: ExtensionContext, action: string) {
+		if (ctx.isIdle()) return true;
+		const message = `Cannot ${action} while an agent run is active. Wait for the run to settle, then retry.`;
+		if (!ctx.hasUI) throw new Error(message);
+		ctx.ui.notify(message, "warning");
+		return false;
+	}
+
+	function advanceWorkflowGeneration() {
+		workflowGeneration += 1;
+		finalizationRequest.reset();
+	}
+
+	function finalizationRunOutcome(messages: unknown): FinalizationRunOutcome {
+		const stopReason = latestAssistantStopReason(messages);
+		if (stopReason === undefined || stopReason === "stop") return "normal";
+		if (stopReason === "aborted") return "cancelled";
+		return "error";
 	}
 
 	function captureMenuLifecycle() {

--- a/packages/pi-plan-mode/src/prompt.ts
+++ b/packages/pi-plan-mode/src/prompt.ts
@@ -30,6 +30,8 @@ You are in Plan Mode, a Codex-like collaboration mode for producing a decision-c
 
 - Once intent is stable, keep asking until the spec is decision-complete: approach, interfaces, data flow, edge cases/failure modes, testing and acceptance criteria, and any migration or compatibility constraints.
 - Use plan_mode_question for important preferences, tradeoffs, or assumption locks that cannot be discovered by non-mutating exploration. Ask 1-3 concise questions with 2-4 meaningful options. Do not include filler options.
+- Treat plan_mode_question and plan_mode_complete as callable when they are listed in the current request's active tools. Do not infer that they are unavailable from earlier modes or conversation history.
+- If a Plan tool call returns an actual error, respond to that error. Do not replace an available structured tool call with prose claiming that the tool is unavailable.
 - If plan_mode_question returns cancelled or ui_unavailable, do not jump straight to a final plan when the missing answer is high impact. Ask one concise plain-text question or proceed only with a clearly stated low-risk assumption.
 
 ## Ending each turn

--- a/packages/pi-plan-mode/test/finalization-request.test.ts
+++ b/packages/pi-plan-mode/test/finalization-request.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	createFinalizationRequestCoordinator,
+	FINALIZE_PLAN_PROMPT,
+	RETRY_FINALIZE_PLAN_PROMPT,
+} from "../src/finalization-request.js";
+
+test("finalization request retries one normal prose-only run after settlement", () => {
+	const coordinator = createFinalizationRequestCoordinator();
+	coordinator.request(7);
+	coordinator.observeRunEnd(7, "normal");
+
+	assert.equal(coordinator.settle(7), "retry");
+	assert.equal(coordinator.hasPendingRequest(), true);
+
+	coordinator.observeRunEnd(7, "normal");
+	assert.equal(coordinator.settle(7), "failed");
+	assert.equal(coordinator.hasPendingRequest(), false);
+	assert.equal(coordinator.settle(7), undefined);
+});
+
+test("finalization request ignores duplicate run ends before settlement", () => {
+	const coordinator = createFinalizationRequestCoordinator();
+	coordinator.request(3);
+	coordinator.observeRunEnd(3, "normal");
+	coordinator.observeRunEnd(3, "normal");
+
+	assert.equal(coordinator.settle(3), "retry");
+	assert.equal(coordinator.settle(3), undefined);
+});
+
+test("finalization request clears on success, cancellation, error, reset, and generation change", () => {
+	for (const outcome of ["cancelled", "error"] as const) {
+		const coordinator = createFinalizationRequestCoordinator();
+		coordinator.request(1);
+		coordinator.observeRunEnd(1, outcome);
+		assert.equal(coordinator.hasPendingRequest(), false);
+		assert.equal(coordinator.settle(1), undefined);
+	}
+
+	const satisfied = createFinalizationRequestCoordinator();
+	satisfied.request(1);
+	satisfied.satisfy();
+	assert.equal(satisfied.hasPendingRequest(), false);
+
+	const reset = createFinalizationRequestCoordinator();
+	reset.request(1);
+	reset.reset();
+	assert.equal(reset.hasPendingRequest(), false);
+
+	const stale = createFinalizationRequestCoordinator();
+	stale.request(1);
+	stale.observeRunEnd(2, "normal");
+	assert.equal(stale.settle(2), undefined);
+	assert.equal(stale.hasPendingRequest(), true);
+});
+
+test("finalization prompts name the structured outcomes and bound the retry", () => {
+	assert.match(FINALIZE_PLAN_PROMPT, /plan_mode_question/);
+	assert.match(FINALIZE_PLAN_PROMPT, /plan_mode_complete/);
+	assert.match(RETRY_FINALIZE_PLAN_PROMPT, /previous finalization response/);
+	assert.match(RETRY_FINALIZE_PLAN_PROMPT, /Do not respond with prose/);
+});

--- a/packages/pi-plan-mode/test/implementation-retention.test.ts
+++ b/packages/pi-plan-mode/test/implementation-retention.test.ts
@@ -25,10 +25,7 @@ function latestState(mock: ReturnType<typeof createMockPi>) {
 	};
 }
 
-async function beginImplementation(
-	retention: ImplementationPlanRetention,
-	options: { idle?: boolean } = {},
-) {
+async function beginImplementation(retention: ImplementationPlanRetention) {
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi, {
 		readSettings: async () => ({
@@ -39,7 +36,7 @@ async function beginImplementation(
 			},
 		}),
 	});
-	const context = createMockContext({ isIdle: () => options.idle ?? true });
+	const context = createMockContext();
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as
@@ -102,7 +99,7 @@ test("keep leaves the accepted plan active after context and settlement", async 
 });
 
 test("conversation-history implementation uses a short prompt without active-plan injection", async () => {
-	const { mock, context, handoff } = await beginImplementation("clear-on-start", { idle: false });
+	const { mock, context, handoff } = await beginImplementation("clear-on-start");
 	const contextHook = mock.events.get("context")?.[0];
 	assert.ok(contextHook);
 	assert.equal(handoff, "Implement the plan.");
@@ -271,9 +268,7 @@ test("conversation-history context preserves a legacy proposed plan without rein
 });
 
 test("first-run ignores older settlement and clears only after its handoff context settles", async () => {
-	const { mock, context, handoff } = await beginImplementation("clear-after-first-run", {
-		idle: false,
-	});
+	const { mock, context, handoff } = await beginImplementation("clear-after-first-run");
 	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
 	assert.equal(latestState(mock).activeImplementation?.retention, "clear-after-first-run");
 

--- a/packages/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-471-repro.test.ts
@@ -239,17 +239,39 @@ test("issue 471: an active implementation plan is restored after compaction remo
 	assert.equal(persisted.activeImplementation?.plan, PLAN);
 });
 
-test("implementation transition persists active state before a busy follow-up and rejects repeats", async () => {
+test("implementation transition rejects a busy run before committing and succeeds when idle", async () => {
+	let idle = true;
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
-	const context = createMockContext({ isIdle: () => false });
+	const context = createMockContext({ mode: "tui", hasUI: true, isIdle: () => idle });
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
 		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
 	assert.ok(complete);
 	await complete("complete", { plan: PLAN }, undefined, undefined, context.ctx);
+	const entriesBeforeBusyAttempt = mock.entries.length;
 
+	idle = false;
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	assert.equal(context.statuses.get("plan-mode"), "plan ready");
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"read",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
+	assert.equal(mock.entries.length, entriesBeforeBusyAttempt);
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /run is active.*retry/i);
+	const heldAttempt = {
+		session: (context.ctx as unknown as { sessionManager: object }).sessionManager,
+		group: "agent-workflow",
+		busy: false,
+	};
+	mock.eventBus.emit("workflow:mutex:v1", heldAttempt);
+	assert.equal(heldAttempt.busy, true);
+
+	idle = true;
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
 	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
 	assert.match(
@@ -257,7 +279,7 @@ test("implementation transition persists active state before a busy follow-up an
 		/implementation plan active/i,
 	);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
-	assert.deepEqual(mock.sentUserMessages.at(-1)?.options, { deliverAs: "followUp" });
+	assert.equal(mock.sentUserMessages.at(-1)?.options, undefined);
 	const activeState = latestState(mock.entries);
 	assert.equal(activeState?.activeImplementation?.plan, PLAN);
 	assert.equal(activeState.activeImplementation?.source, "plan_mode_complete");

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -115,6 +115,39 @@ test("customized plan-mode shortcut from settings toggles Plan mode", async () =
 	assert.equal(context.statuses.get("plan-mode"), undefined);
 });
 
+test("customized plan-mode shortcut rejects mode changes during an active run", async () => {
+	let idle = false;
+	const mock = launchFixtureWithSettings(async () => ({
+		kind: "loaded" as const,
+		settings: { thinkingLevel: "inherit", toggleShortcut: "ctrl+shift+p" },
+	}));
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		isIdle: () => idle,
+	});
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	const toggle = mock.shortcuts.get("ctrl+shift+p");
+	assert.ok(toggle);
+
+	await toggle.handler(context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+	assert.equal(mock.entries.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /run is active.*retry/i);
+
+	idle = true;
+	await toggle.handler(context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+	const entriesAfterStart = mock.entries.length;
+
+	idle = false;
+	await toggle.handler(context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...REQUIRED_PLAN_TOOLS]);
+	assert.equal(mock.entries.length, entriesAfterStart);
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
+	assert.match(context.notifications.at(-1)?.message ?? "", /run is active.*retry/i);
+});
+
 test("customized plan-mode shortcut from settings supports ctrl+alt+p", async () => {
 	const mock = launchFixtureWithSettings(async () => ({
 		kind: "loaded" as const,

--- a/packages/pi-plan-mode/test/plan-mode.test.ts
+++ b/packages/pi-plan-mode/test/plan-mode.test.ts
@@ -6,6 +6,7 @@ import { initTheme } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { planModeCompleted } from "../src/completion-tool.js";
+import { FINALIZE_PLAN_PROMPT, RETRY_FINALIZE_PLAN_PROMPT } from "../src/finalization-request.js";
 import planMode, {
 	buildPlanModePrompt,
 	completePlanArguments,
@@ -588,12 +589,250 @@ test("plan finalize requires active mode and uses idle-safe delivery", async () 
 
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	await mock.commands.get("plan")?.handler("finalize", context.ctx);
-	assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /plan_mode_complete/);
+	assert.equal(mock.sentUserMessages.at(-1)?.text, FINALIZE_PLAN_PROMPT);
 	assert.equal(mock.sentUserMessages.at(-1)?.options, undefined);
 
 	idle = false;
 	await mock.commands.get("plan")?.handler("finalize", context.ctx);
 	assert.deepEqual(mock.sentUserMessages.at(-1)?.options, { deliverAs: "followUp" });
+});
+
+test("busy mode-changing commands fail closed while Plan follow-ups remain available", async () => {
+	let idle = true;
+	const mock = createMockPi({ activeTools: ["read", "write"], thinkingLevel: "low" });
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		isIdle: () => idle,
+	});
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
+		?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
+	assert.ok(complete);
+	await complete("ready", { plan: "# Ready" }, undefined, undefined, context.ctx);
+
+	idle = false;
+	const snapshot = {
+		entries: mock.entries.length,
+		tools: mock.rawPi.getActiveTools(),
+		thinking: mock.thinkingLevel,
+		status: context.statuses.get("plan-mode"),
+		messages: mock.sentUserMessages.length,
+	};
+	for (const command of ["exit", "save", "implement", "export busy-plan.md"]) {
+		await mock.commands.get("plan")?.handler(command, context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /run is active.*retry/i);
+		assert.equal(mock.entries.length, snapshot.entries);
+		assert.deepEqual(mock.rawPi.getActiveTools(), snapshot.tools);
+		assert.equal(mock.thinkingLevel, snapshot.thinking);
+		assert.equal(context.statuses.get("plan-mode"), snapshot.status);
+		assert.equal(mock.sentUserMessages.length, snapshot.messages);
+	}
+
+	await mock.commands.get("plan")?.handler("revise the ready plan", context.ctx);
+	assert.equal(mock.sentUserMessages.at(-1)?.text, "revise the ready plan");
+	assert.deepEqual(mock.sentUserMessages.at(-1)?.options, { deliverAs: "followUp" });
+	await mock.commands.get("plan")?.handler("finalize", context.ctx);
+	assert.equal(mock.sentUserMessages.at(-1)?.text, FINALIZE_PLAN_PROMPT);
+	assert.deepEqual(mock.sentUserMessages.at(-1)?.options, { deliverAs: "followUp" });
+});
+
+test("busy inactive Plan starts fail observably without changing state in every command mode", async () => {
+	for (const mode of ["tui", "rpc", "print", "json"] as const) {
+		const mock = createMockPi({ activeTools: ["read", "write"] });
+		planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+		const context = createMockContext({
+			mode,
+			hasUI: mode === "tui" || mode === "rpc",
+			isIdle: () => false,
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		const command = mock.commands.get("plan");
+		assert.ok(command);
+
+		for (const input of ["start", "design a release"]) {
+			if (mode === "tui" || mode === "rpc") {
+				await command.handler(input, context.ctx);
+				assert.match(context.notifications.at(-1)?.message ?? "", /run is active.*retry/i);
+			} else {
+				await assert.rejects(
+					async () => command.handler(input, context.ctx),
+					/run is active.*retry/i,
+				);
+			}
+			assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
+			assert.equal(mock.entries.length, 0);
+			assert.equal(mock.sentUserMessages.length, 0);
+		}
+	}
+});
+
+test("busy active Plan exits fail observably without releasing tools in every command mode", async () => {
+	for (const mode of ["tui", "rpc", "print", "json"] as const) {
+		let idle = true;
+		const mock = createMockPi({ activeTools: ["read", "write"] });
+		planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+		const context = createMockContext({
+			mode,
+			hasUI: mode === "tui" || mode === "rpc",
+			isIdle: () => idle,
+		});
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		const command = mock.commands.get("plan");
+		assert.ok(command);
+		await command.handler("start", context.ctx);
+		const entriesAfterStart = mock.entries.length;
+
+		idle = false;
+		if (mode === "tui" || mode === "rpc") {
+			await command.handler("exit", context.ctx);
+			assert.match(context.notifications.at(-1)?.message ?? "", /run is active.*retry/i);
+		} else {
+			await assert.rejects(
+				async () => command.handler("exit", context.ctx),
+				/run is active.*retry/i,
+			);
+		}
+		assert.deepEqual(mock.rawPi.getActiveTools(), [
+			"read",
+			"plan_mode_question",
+			"plan_mode_complete",
+		]);
+		assert.equal(mock.entries.length, entriesAfterStart);
+		assert.equal(context.statuses.get("plan-mode"), "plan active");
+	}
+});
+
+test("explicit finalization retries once after settlement and then fails visibly", async () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	planMode(mock.pi);
+	const context = createMockContext({ mode: "tui", hasUI: true });
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	await mock.commands.get("plan")?.handler("finalize", context.ctx);
+
+	const agentEnd = mock.events.get("agent_end")?.[0];
+	const agentSettled = mock.events.get("agent_settled")?.[0];
+	assert.ok(agentEnd);
+	assert.ok(agentSettled);
+	await agentEnd(
+		{ messages: [{ role: "assistant", content: "The tool is unavailable.", stopReason: "stop" }] },
+		context.ctx,
+	);
+	await agentSettled({}, context.ctx);
+	assert.equal(mock.sentUserMessages.at(-1)?.text, RETRY_FINALIZE_PLAN_PROMPT);
+	assert.equal(mock.sentUserMessages.length, 2);
+
+	await agentEnd(
+		{ messages: [{ role: "assistant", content: "Still unavailable.", stopReason: "stop" }] },
+		context.ctx,
+	);
+	await agentSettled({}, context.ctx);
+	assert.equal(mock.sentUserMessages.length, 2);
+	assert.match(context.notifications.at(-1)?.message ?? "", /ended twice/i);
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
+});
+
+test("structured finalization outcomes and cancellation suppress extension retries", async () => {
+	for (const outcome of ["question", "complete", "aborted", "error", "ordinary"] as const) {
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext();
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		if (outcome !== "ordinary") await mock.commands.get("plan")?.handler("finalize", context.ctx);
+
+		if (outcome === "question") {
+			const question = mock.tools.find((candidate) => candidate.name === "plan_mode_question")
+				?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
+			assert.ok(question);
+			await question(
+				"question",
+				{
+					questions: [
+						{
+							id: "choice",
+							header: "Choice",
+							question: "Choose one?",
+							options: [
+								{ label: "A", description: "Choose A." },
+								{ label: "B", description: "Choose B." },
+							],
+						},
+					],
+				},
+				undefined,
+				undefined,
+				context.ctx,
+			);
+		}
+		if (outcome === "complete") {
+			const complete = mock.tools.find((candidate) => candidate.name === "plan_mode_complete")
+				?.execute as ((...args: unknown[]) => Promise<unknown>) | undefined;
+			assert.ok(complete);
+			await complete("complete", { plan: "# Done" }, undefined, undefined, context.ctx);
+		}
+
+		await mock.events.get("agent_end")?.[0]?.(
+			{
+				messages: [
+					{
+						role: "assistant",
+						content: "No structured result.",
+						stopReason: outcome === "aborted" ? "aborted" : outcome === "error" ? "error" : "stop",
+					},
+				],
+			},
+			context.ctx,
+		);
+		await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		assert.equal(mock.sentUserMessages.length, outcome === "ordinary" ? 0 : 1);
+	}
+});
+
+test("exact canonical user prompt is tracked for one bounded retry", async () => {
+	let pending = true;
+	const mock = createMockPi({ activeTools: ["read"] });
+	planMode(mock.pi);
+	const context = createMockContext({ hasPendingMessages: () => pending });
+	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	await mock.events.get("message_start")?.[0]?.(
+		{ message: { role: "user", content: FINALIZE_PLAN_PROMPT } },
+		context.ctx,
+	);
+	await mock.events.get("agent_end")?.[0]?.(
+		{ messages: [{ role: "assistant", content: "No tool.", stopReason: "stop" }] },
+		context.ctx,
+	);
+	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+	assert.equal(mock.sentUserMessages.length, 0);
+
+	pending = false;
+	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+	assert.equal(mock.sentUserMessages.at(-1)?.text, RETRY_FINALIZE_PLAN_PROMPT);
+});
+
+test("session shutdown and explicit exit cancel pending finalization retries", async () => {
+	for (const cancellation of ["shutdown", "exit"] as const) {
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await mock.commands.get("plan")?.handler("finalize", context.ctx);
+		await mock.events.get("agent_end")?.[0]?.(
+			{ messages: [{ role: "assistant", content: "No tool.", stopReason: "stop" }] },
+			context.ctx,
+		);
+		if (cancellation === "shutdown") {
+			await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+		} else {
+			await mock.commands.get("plan")?.handler("exit", context.ctx);
+		}
+		await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		assert.equal(mock.sentUserMessages.length, 1);
+	}
 });
 
 test("/plan start is a no-op while an active Plan workflow is already ready", async () => {
@@ -782,7 +1021,7 @@ test("legacy plan completion is presented once only after settlement", async () 
 });
 
 test("settled plan presentation waits for idle without pending messages", async () => {
-	let idle = false;
+	let idle = true;
 	let pending = false;
 	let selectCalls = 0;
 	const mock = createMockPi({ activeTools: ["read"] });
@@ -802,6 +1041,7 @@ test("settled plan presentation waits for idle without pending messages", async 
 	assert.ok(execute);
 	await execute("complete", { plan: "# Wait" }, undefined, undefined, context.ctx);
 
+	idle = false;
 	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
 	idle = true;
 	pending = true;
@@ -1040,6 +1280,8 @@ test("Plan prompt requires the standalone completion contract", () => {
 	assert.match(prompt, /alone as (?:your )?(?:final|last) action/i);
 	assert.match(prompt, /end.*plan_mode_question.*plan_mode_complete/is);
 	assert.match(prompt, /clarification.*plan_mode_complete.*unchanged/is);
+	assert.match(prompt, /listed in the current request's active tools/i);
+	assert.match(prompt, /actual error/i);
 	assert.match(prompt, /behavior-level/i);
 	assert.doesNotMatch(prompt, /<proposed_plan>/i);
 });

--- a/packages/pi-plan-mode/test/saved-plan.test.ts
+++ b/packages/pi-plan-mode/test/saved-plan.test.ts
@@ -295,7 +295,8 @@ test("failed ready implementation restores a manual Plan thinking level", async 
 	assert.match(context.notifications.at(-1)?.message ?? "", /ready handoff failed/);
 });
 
-test("saved Plan direct routes show, implement, roll back failures, and clear", async () => {
+test("saved Plan direct routes show, reject busy implementation, roll back failures, and clear", async () => {
+	let idle = true;
 	const savedEntry = stateEntry({
 		enabled: false,
 		awaitingAction: false,
@@ -304,7 +305,9 @@ test("saved Plan direct routes show, implement, roll back failures, and clear", 
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi);
 	const context = createMockContext({
-		isIdle: () => false,
+		mode: "tui",
+		hasUI: true,
+		isIdle: () => idle,
 		model: MODEL,
 		modelRegistry: AVAILABLE_MODEL_REGISTRY,
 		sessionManager: {
@@ -333,9 +336,16 @@ test("saved Plan direct routes show, implement, roll back failures, and clear", 
 	mock.rawPi.sendUserMessage = (text: string, options?: unknown) => {
 		mock.sentUserMessages.push({ text, options });
 	};
+	idle = false;
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	assert.equal(context.statuses.get("plan-mode"), "plan saved");
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.match(context.notifications.at(-1)?.message ?? "", /run is active.*retry/i);
+
+	idle = true;
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
 	assert.equal(context.statuses.get("plan-mode"), undefined);
-	assert.deepEqual(mock.sentUserMessages.at(-1)?.options, { deliverAs: "followUp" });
+	assert.equal(mock.sentUserMessages.at(-1)?.options, undefined);
 	assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /Saved implementation plan/);
 	assert.equal(latestState(mock.entries)?.savedPlan, undefined);
 	assert.equal(latestState(mock.entries)?.activeImplementation, undefined);

--- a/packages/pi-plan-mode/test/workflow-mutex.test.ts
+++ b/packages/pi-plan-mode/test/workflow-mutex.test.ts
@@ -142,10 +142,16 @@ test("workflow mutex stale release cannot clear a replacement owner", () => {
 });
 
 test("Plan holds the workflow mutex through planning, ready review, and revision", async () => {
+	let idle = true;
 	const mock = createMockPi({ activeTools: ["read", "write"] });
 	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
 	const sessionManager = { getBranch: () => [], getEntries: () => [] };
-	const context = createMockContext({ mode: "tui", hasUI: true, sessionManager });
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		isIdle: () => idle,
+		sessionManager,
+	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 
@@ -169,6 +175,14 @@ test("Plan holds the workflow mutex through planning, ready review, and revision
 	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, revision);
 	assert.equal(revision.busy, true);
 
+	idle = false;
+	await mock.commands.get("plan")?.handler("exit", context.ctx);
+	const stillHeld = attempt(sessionManager);
+	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, stillHeld);
+	assert.equal(stillHeld.busy, true);
+	assert.match(context.notifications.at(-1)?.message ?? "", /run is active.*retry/i);
+
+	idle = true;
 	await mock.commands.get("plan")?.handler("exit", context.ctx);
 	const released = attempt(sessionManager);
 	mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, released);


### PR DESCRIPTION
## Summary

- Reject Plan-mode state and tool-contract changes while an agent run is active, preserving the current run until it settles.
- Retry explicit structured finalization once at `agent_settled` when the model responds with prose instead of a Plan tool.
- Harden prompt guidance, lifecycle cleanup, compatibility tests, documentation, and release notes.

## Verification

- `npm --workspace @narumitw/pi-plan-mode run check`
- `npx vitest run packages/pi-plan-mode/test` — 222 tests passed
- `npm run check`
- `npm test` — 3,232 tests passed across 360 files
- `just pack plan-mode` — 38 expected files
- Non-interactive Pi RPC smoke with `openai-codex/gpt-5.6-sol` — three coherent Plan requests and one coherent Normal request

One full-suite run had an unrelated `pi-subagents` resource-fingerprint failure; the test passed immediately in isolation and the complete suite then passed cleanly.

## Risks

- Busy state-changing Plan commands and shortcuts now require the user to retry after the active run settles.
- Genuine Plan/Normal transitions still change the prompt and tool schemas, so their first provider request may miss the prompt cache.
- No paths remain unverified.
