### PR TITLE
feat(plan-mode): implement from clean tree branches

### DIFF
--- a/.changeset/clean-plans-branch.md
+++ b/.changeset/clean-plans-branch.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Run active Plan-mode implementation from a clean same-session tree branch that restores the prior Normal tool contract and transfers only the approved plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Run commands from the repository root unless a command says otherwise.
 ## Runtime and lifecycle constraints
 
 - Do not call Pi action methods such as `getThinkingLevel()` during extension factory load; defer them until `session_start` or later.
-- Keep the active tool list and tool definitions stable across extension mode transitions to preserve the provider's cached prompt prefix.
+- Preserve the provider's cached prompt prefix on continuing branches by keeping the active tool list and tool definitions stable, or isolate a mode-specific contract to a disposable branch or session before continuing.
 - Treat `agent_end` as a run boundary and `agent_settled` as the idle boundary for retries, final cleanup, and next-item activation.
 - Treat `pi.appendEntry()` as branch persistence only; inject compaction-sensitive model contracts through one canonical `context` hook block after the original handoff disappears.
 - Key headless session-owned resources by `sessionManager`, not `ctx.ui`, because headless runners can share one no-op UI object.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -12,7 +12,7 @@ This independently installable extension adds a Codex-like `/plan` collaboration
 - Enables read-only exploration tools while blocking mutating tools and unsafe shell forms by default.
 - Requires structured questions for important ambiguity and explicit completion for a decision-ready plan.
 - Reviews the complete plan before implementation, export, save, continued planning, or discard.
-- Starts implementation in the planning session or a fresh linked session with the exact approved plan.
+- Starts implementation on a clean same-session branch or in a fresh linked session with the exact approved plan.
 - Persists Plan state and one saved plan across resume and compaction.
 - Exposes statusline state and configurable tool visibility, export destination, plan reinjection, shortcut, and thinking level.
 - Cooperates anonymously with Workflow Mutex Protocol v1 participants so only one agent workflow starts in a session.
@@ -79,8 +79,10 @@ Exit and start a new workflow if a different tool set is required.
 The `plan_mode_question` tool keeps a dedicated model-requested questionnaire instead of using command-menu navigation.
 `/plan show` displays the stored plan without starting a model turn, including the accepted plan while implementation is active.
 `/plan finalize` explicitly asks the agent to complete the plan or ask one remaining material question, `/plan save` stores a completed ready plan for later and leaves Plan mode, and `/plan export [path]` writes a ready, saved, or active implementation plan to Markdown.
-Completed and saved plan menus offer **Implement here**, which continues with the planning conversation, and **Start fresh and implement**, which opens a new session and transfers only the approved plan.
-The direct `/plan implement` compatibility route remains equivalent to **Implement here** and never opens a selector.
+A completed active Plan offers **Implement here**, which returns to where Plan mode started and transfers only the approved plan onto a clean same-session branch.
+A saved plan has no active Plan branch point, so its **Implement here** action continues from the current branch for compatibility.
+**Start fresh and implement** opens a new session and transfers only the approved plan.
+The direct `/plan implement` compatibility route remains equivalent to the applicable **Implement here** behavior and never opens a selector.
 A successful ready-plan export also leaves Plan mode; saved and active implementation exports retain their existing state.
 `show`, `save`, `export`, and `implement` fail closed when no applicable plan is stored; `finalize` requires active Plan mode.
 Pi executes extension commands immediately during streaming, but changing Plan state or handing off implementation during an active run would mix the run's existing system prompt with a new tool contract.
@@ -164,13 +166,18 @@ Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and 
 
 After completion, `/plan` opens the ready actions when interactive UI is available.
 The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews the selected **Plan reinjection** policy.
-**Implement here**—and the compatibility route `/plan implement`—disables Plan mode, restores full tool access, captures the current policy, and starts implementation in the current session with its planning conversation.
+For plans started by this version, **Implement here**—and the compatibility route `/plan implement`—waits for idle, navigates without a branch summary to a context-free marker created immediately before Plan activation, restores the exact ordered Normal tools, and transfers the approved plan onto a new same-session implementation branch.
+The abandoned Plan conversation, question calls, completion call, and tool results remain inspectable through `/tree` but are absent from the implementation branch and model context.
+A restored legacy ready plan without branch metadata uses the previous linear same-session handoff so an upgrade never makes an existing plan unimplementable.
+A saved plan also uses the linear compatibility path because it can be resumed independently of its original Plan branch.
 **Start fresh and implement** waits for the source session to become idle, verifies the selected model and authentication, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
 The destination still loads its normal `AGENTS.md`, skills, project resources, and extensions.
+Cancellation or failure before clean-branch navigation leaves the completed plan ready on the Plan branch.
+If delivery fails after navigation commits, the exact implementation request is restored to an empty editor when possible and the plan remains saved or active on the new branch.
 Choosing **Export plan…** asks for a destination, writes the plan, restores normal tools and thinking, and leaves Plan mode without starting a model turn.
 Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session before leaving Plan mode.
 
-When a workflow was started only with `--plan` and no `/plan` command has run in that session, the automatic menu cannot obtain Pi's command-only session replacement capability; choosing fresh asks you to reopen `/plan`, where the same action is available.
+When a workflow was started only with `--plan` and no `/plan` command has run in that session, the automatic menu cannot obtain Pi's command-only tree-navigation or session-replacement capability; choosing either implementation handoff asks you to reopen `/plan`, where the same action is available.
 A successful fresh handoff does not delete or consume the source planning session.
 Resume it later to inspect or hand off the ready/saved plan again; this deliberate duplication is the recovery path if the destination work is abandoned.
 In-memory sessions create an unlinked fresh session because no parent file exists.
@@ -198,8 +205,8 @@ These modes reject saved-plan display and implementation before changing state b
 
 Both implementation paths apply the current **Plan reinjection** policy in their destination.
 The default **Off — conversation history only** policy does not create active-plan state or inject a hidden plan context.
-Implement here sends `Implement the plan.` and leaves the accepted plan in ordinary planning history.
-Start fresh and implement, or implementing a saved plan here, puts the complete plan in one ordinary initial user prompt because no reliable planning conversation is present.
+Clean-branch implementation, fresh implementation, and saved-plan implementation put the complete plan in one ordinary initial user prompt because the Plan conversation is absent or not a reliable canonical source.
+Legacy linear implementation keeps its established `Implement the plan.` handoff while the accepted plan remains in ordinary planning history.
 Later model calls then rely on Pi's normal conversation history and compaction behavior.
 **Through first implementation run** guarantees the exact plan throughout that run, including retries, compaction retries, and queued continuation, then clears active-plan state at `agent_settled`.
 **Until manually cleared** guarantees the exact plan across later turns, resume, and manual or automatic compaction until `/plan exit` or supersession.
@@ -425,10 +432,10 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 - The agent should use `plan_mode_question` for important non-discoverable preferences or tradeoffs before finalizing.
 - The agent completes with a standalone `plan_mode_complete` tool call instead of relying on semantic prose detection.
 - `update_plan` checklist use is blocked while Plan mode is active.
-- The implementation boundary is explicit: Plan mode restores tools before saving or starting implementation, saving keeps the plan outside ordinary model context, and choosing implementation immediately triggers a normal agent turn with full tool access.
+- The implementation boundary is explicit: active Plan implementation restores the exact ordered Normal tools on a clean branch before the handoff, saving keeps the plan outside ordinary model context, and choosing implementation immediately triggers a normal agent turn with full tool access.
 - The default `clear-on-start` policy follows Codex by using ordinary conversation history only; `clear-after-first-run` and `keep` add explicit exact-plan guarantees.
 - Pi extension safety is approximated with tool classification and fail-closed filtering for every effective tool named `bash`; other non-built-in tools remain user-selected at user risk because Pi does not expose standardized tool mutability metadata.
-- Plan and Normal mode intentionally use different instructions and tool schemas, so the first provider request after a genuine mode transition may miss the prompt cache; later requests can reuse the new stable prefix.
+- Plan and Normal mode intentionally use different instructions and tool schemas, so the first provider request on the disposable Plan branch may miss the prompt cache; clean-branch implementation restores the prior Normal contract and may reuse its cached prefix when the provider, model, cache lifetime, and session-affinity policy permit it.
 - Unlike native Codex, this extension uses a terminating Pi tool plus an `agent_settled` ready flow; Pi cannot provide sandbox-level enforcement.
 
 ## 🗂️ Package layout

--- a/packages/pi-plan-mode/src/plan-action-controller.ts
+++ b/packages/pi-plan-mode/src/plan-action-controller.ts
@@ -18,7 +18,7 @@ interface PlanActionControllerOptions {
 	getExportDestination(ctx: ExtensionContext): PlanExportDestination;
 	show(ctx: ExtensionContext): void;
 	finalize(ctx: ExtensionContext): void;
-	implementHere(ctx: ExtensionContext): void | Promise<void>;
+	implementHere(ctx: ExtensionContext, signal: AbortSignal): void | Promise<void>;
 	implementFresh(ctx: ExtensionContext, isCurrent: () => boolean): void | Promise<void>;
 	exportPlan(
 		ctx: ExtensionContext,
@@ -50,7 +50,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				signal: lifecycle.signal,
 				isCurrent: lifecycle.isCurrent,
 				show: () => options.show(ctx),
-				implementHere: () => options.implementHere(ctx),
+				implementHere: () => options.implementHere(ctx, lifecycle.signal),
 				implementFresh: (signal) => freshAction(ctx, lifecycle, signal),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				settings: (signal) => options.settings(ctx, signal, lifecycle.isCurrent),
@@ -74,7 +74,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				...lifecycle,
 				show: () => options.show(ctx),
 				finalize: () => options.finalize(ctx),
-				implementHere: () => options.implementHere(ctx),
+				implementHere: (signal) => options.implementHere(ctx, signal),
 				implementFresh: (signal) => freshAction(ctx, lifecycle, signal),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				save: () => options.save(ctx),
@@ -91,7 +91,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				...lifecycle,
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),
-				implementHere: () => options.implementHere(ctx),
+				implementHere: (signal) => options.implementHere(ctx, signal),
 				implementFresh: (signal) => freshAction(ctx, lifecycle, signal),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				save: () => options.save(ctx),

--- a/packages/pi-plan-mode/src/plan-action-menus.ts
+++ b/packages/pi-plan-mode/src/plan-action-menus.ts
@@ -8,7 +8,7 @@ interface MenuLifecycle {
 }
 
 const IMPLEMENTATION_CONTEXT_LINES = [
-	"Implement here keeps this planning conversation.",
+	"Implement here returns to where Plan mode started and transfers only the approved plan.",
 	"Start fresh transfers only the approved plan to a new session.",
 ] as const;
 
@@ -19,7 +19,7 @@ interface PlanMenuOptions extends MenuLifecycle {
 	getExportDestination: PlanExportDestinationProvider;
 	show(): void;
 	finalize(): void;
-	implementHere(): void | Promise<void>;
+	implementHere(signal: AbortSignal): void | Promise<void>;
 	implementFresh(signal: AbortSignal): void | Promise<void>;
 	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	save(): void;
@@ -56,7 +56,7 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 							{
 								id: "implement-here",
 								label: "Implement here",
-								description: "Continue in this session with the planning conversation.",
+								description: "Return to the Plan start and implement on a clean branch.",
 								action: "implement-here",
 							},
 							{
@@ -89,8 +89,8 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 				options.finalize();
 				return { kind: "close" };
 			},
-			"implement-here": async () => {
-				await options.implementHere();
+			"implement-here": async ({ signal }) => {
+				await options.implementHere(signal);
 				return { kind: "close" };
 			},
 			"implement-fresh": async ({ signal }) => {
@@ -123,7 +123,7 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 interface ReadyPlanMenuOptions extends MenuLifecycle {
 	implementationOutcome(): string;
 	getExportDestination: PlanExportDestinationProvider;
-	implementHere(): void | Promise<void>;
+	implementHere(signal: AbortSignal): void | Promise<void>;
 	implementFresh(signal: AbortSignal): void | Promise<void>;
 	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	save(): void;
@@ -145,7 +145,7 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 					{
 						id: "implement-here",
 						label: "Implement here",
-						description: "Continue in this session with the planning conversation.",
+						description: "Return to the Plan start and implement on a clean branch.",
 						action: "implement-here",
 					},
 					{
@@ -165,8 +165,8 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 			export: () => planExportInputScreen(options.getExportDestination),
 		},
 		actions: {
-			"implement-here": async () => {
-				await options.implementHere();
+			"implement-here": async ({ signal }) => {
+				await options.implementHere(signal);
 				return { kind: "close" };
 			},
 			"implement-fresh": async ({ signal }) => {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -86,6 +86,10 @@ import {
 	snapshotPlanModeToolNames,
 	toolPolicyLabel,
 } from "./tool-selection.js";
+import {
+	capturePlanModeBranchPoint,
+	createTreeImplementationController,
+} from "./tree-implementation.js";
 import { WorkflowMutex, type WorkflowMutexOwner } from "./workflow-mutex.js";
 
 const STATE_ENTRY_TYPE = "plan-mode-state";
@@ -107,6 +111,8 @@ interface PlanModeDependencies {
 
 // Keep session state, persistence, tool, thinking, and mutex commits in this one closure so an
 // activation path cannot bypass the same atomic transition by crossing module-owned state.
+// This lifecycle owner stays over 1,000 lines for that atomic boundary; tree handoff orchestration
+// lives in tree-implementation.ts so provider navigation and recovery do not remain in this closure.
 export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDependencies = {}) {
 	const workflowMutex = new WorkflowMutex(pi);
 	let workflowOwner: WorkflowMutexOwner | undefined;
@@ -140,6 +146,34 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	const implementationRetention = createImplementationRetentionCoordinator();
 	const finalizationRequest = createFinalizationRequestCoordinator();
 	const persistState = () => pi.appendEntry<PlanModeState>(STATE_ENTRY_TYPE, state);
+	const treeImplementation = createTreeImplementationController({
+		getState: () => state,
+		getCurrentSession: () => currentSession,
+		getWorkflowGeneration: () => workflowGeneration,
+		getRetention: () => configuredImplementationPlanRetention(settings),
+		restoreNormalRuntime: (tools) => {
+			pi.setActiveTools([...tools]);
+			previousTools = undefined;
+			if (state.enabled) {
+				restoreThinkingLevel();
+				releaseWorkflowOwner();
+			}
+			advanceWorkflowGeneration();
+		},
+		publishImplementation: (nextState, activeImplementation, ctx) => {
+			state = nextState;
+			implementationRetention.reset();
+			implementationRetention.restore(activeImplementation);
+			persistState();
+			updateUi(ctx);
+		},
+		publishRecovery: (nextState, ctx) => {
+			state = nextState;
+			persistState();
+			updateUi(ctx);
+		},
+		sendUserMessage: sendPlanModeUserMessage,
+	});
 	const planExports = createPlanExportController({
 		getState: () => state,
 		getSettings: () => settings,
@@ -156,7 +190,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		getExportDestination: (ctx) => planExports.getDestination(ctx),
 		show: (ctx) => showStoredPlan(pi, ctx, state),
 		finalize: requestFinalPlan,
-		implementHere: startImplementation,
+		implementHere: (ctx, signal) => startImplementation(ctx, signal),
 		implementFresh: startFreshImplementation,
 		exportPlan: exportPlan,
 		settings: showSettings,
@@ -445,6 +479,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		menuController.abort(new DOMException("Plan-mode session replaced", "AbortError"));
 		menuController = new AbortController();
 		readyPresentationIntent = undefined;
+		treeImplementation.cancel();
 		latestCommandContext = undefined;
 		previousTools = undefined;
 		implementationRetention.reset();
@@ -455,7 +490,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (generation !== menuGeneration || menuController.signal.aborted) return;
 		startPlanModeSettingsWatch(generation);
 		const persistFlagActivation = pi.getFlag("plan") === true && !restoredState.enabled;
-		const candidate = persistFlagActivation
+		const activationCandidate = persistFlagActivation
 			? restoredState.savedPlan
 				? {
 						...restoredState,
@@ -468,9 +503,32 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 					}
 				: { ...restoredState, enabled: true, activeImplementation: undefined }
 			: restoredState;
+		const candidate =
+			persistFlagActivation && activationCandidate.enabled
+				? addPlanModeBranchPoint(activationCandidate, ctx)
+				: activationCandidate;
 		if (!installRestoredState(candidate, ctx)) return;
 		implementationRetention.restore(state.activeImplementation);
 		if (persistFlagActivation && state.enabled) persistState();
+		updateUi(ctx);
+	});
+
+	pi.on("session_tree", (event, ctx) => {
+		if (currentSession !== ctx.sessionManager) return;
+		treeImplementation.acceptsTreeEvent(event, ctx);
+
+		finalizationRequest.reset();
+		workflowGeneration += 1;
+		const generation = ++menuGeneration;
+		menuController.abort(new DOMException("Plan-mode branch changed", "AbortError"));
+		menuController = new AbortController();
+		readyPresentationIntent = undefined;
+		refreshStateBeforeFirstAgentStart = false;
+		implementationRetention.reset();
+		stopPlanModeSettingsWatch();
+		startPlanModeSettingsWatch(generation);
+		if (!installRestoredState(readRestoredState(ctx), ctx)) return;
+		implementationRetention.restore(state.activeImplementation);
 		updateUi(ctx);
 	});
 
@@ -493,6 +551,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		menuGeneration += 1;
 		menuController.abort(new DOMException("Plan-mode session shut down", "AbortError"));
 		readyPresentationIntent = undefined;
+		treeImplementation.cancel();
 		latestCommandContext = undefined;
 		refreshStateBeforeFirstAgentStart = false;
 		implementationRetention.reset();
@@ -674,15 +733,19 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		advanceWorkflowGeneration();
 		try {
 			previousTools = withoutRequiredPlanModeTools(safeGetActiveTools());
-			state = {
-				...state,
-				enabled: true,
-				awaitingAction: false,
-				savedPlan: undefined,
-				activeImplementation: undefined,
-				selectedToolNames: candidate.selectedToolNames,
-				selectedToolKeys: candidate.selectedToolKeys,
-			};
+			state = addPlanModeBranchPoint(
+				{
+					...state,
+					enabled: true,
+					awaitingAction: false,
+					savedPlan: undefined,
+					activeImplementation: undefined,
+					selectedToolNames: candidate.selectedToolNames,
+					selectedToolKeys: candidate.selectedToolKeys,
+				},
+				ctx,
+				previousTools,
+			);
 			activatePlanModeTools();
 			applyPlanThinkingLevel();
 			persistState();
@@ -692,6 +755,21 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			rollbackNewActivation(previousState, previousToolSnapshot, ctx);
 			throw error;
 		}
+	}
+
+	function addPlanModeBranchPoint(
+		candidate: PlanModeState,
+		ctx: ExtensionContext,
+		tools = withoutRequiredPlanModeTools(safeGetActiveTools()),
+	) {
+		const branchPoint = capturePlanModeBranchPoint(pi, ctx, tools);
+		return branchPoint
+			? {
+					...candidate,
+					branchPointId: branchPoint.id,
+					toolsBeforePlanMode: branchPoint.tools,
+				}
+			: candidate;
 	}
 
 	function enterPlanModeWithPrompt(prompt: string, ctx: ExtensionContext) {
@@ -722,6 +800,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			savedPlan: undefined,
 			activeImplementation: undefined,
 			manualThinkingLevel: undefined,
+			branchPointId: undefined,
+			toolsBeforePlanMode: undefined,
 		};
 		if (wasEnabled) {
 			restoreTools();
@@ -845,6 +925,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			savedPlan: { plan, source },
 			activeImplementation: undefined,
 			manualThinkingLevel: undefined,
+			branchPointId: undefined,
+			toolsBeforePlanMode: undefined,
 		};
 		restoreTools();
 		restoreThinkingLevel();
@@ -864,7 +946,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		});
 	}
 
-	async function startImplementation(ctx: ExtensionContext) {
+	async function startImplementation(ctx: ExtensionContext, signal?: AbortSignal) {
 		const savedPlan = state.enabled ? undefined : state.savedPlan;
 		const initialPlan = (state.enabled ? state.latestPlan : savedPlan?.plan)?.trim();
 		if (!initialPlan) {
@@ -888,6 +970,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		const source =
 			(state.enabled ? state.latestPlanSource : savedPlan?.source) ?? "legacy_proposed_plan";
 		if (!plan) return;
+		if (state.enabled && state.branchPointId) {
+			await startTreeImplementation(ctx, plan, source, signal);
+			return;
+		}
 
 		advanceWorkflowGeneration();
 		const previousState = state;
@@ -914,6 +1000,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 						retention,
 					},
 			manualThinkingLevel: undefined,
+			branchPointId: undefined,
+			toolsBeforePlanMode: undefined,
 		};
 		if (wasEnabled) {
 			restoreTools();
@@ -942,6 +1030,15 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			return;
 		}
 		if (wasEnabled) releaseWorkflowOwner();
+	}
+
+	async function startTreeImplementation(
+		ctx: ExtensionContext,
+		plan: string,
+		source: PlanCompletionSource,
+		signal?: AbortSignal,
+	) {
+		await treeImplementation.start(ctx, { plan, source, signal });
 	}
 
 	function clearActiveImplementation(id: string, ctx: ExtensionContext) {
@@ -1158,7 +1255,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	}
 
 	function restoreTools() {
-		const restoredTools = previousTools ?? DEFAULT_TOOLS;
+		const restoredTools = previousTools ?? state.toolsBeforePlanMode ?? DEFAULT_TOOLS;
 		pi.setActiveTools(withoutRequiredPlanModeTools(restoredTools));
 		previousTools = undefined;
 	}
@@ -1254,7 +1351,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			}
 			state = candidate;
 			if (state.enabled) {
-				if (!wasEnabled) previousTools = withoutRequiredPlanModeTools(safeGetActiveTools());
+				if (!wasEnabled) {
+					previousTools =
+						state.toolsBeforePlanMode ?? withoutRequiredPlanModeTools(safeGetActiveTools());
+				}
 				activatePlanModeTools();
 				applyPlanThinkingLevel();
 			} else {

--- a/packages/pi-plan-mode/src/state.ts
+++ b/packages/pi-plan-mode/src/state.ts
@@ -37,9 +37,12 @@ export interface PlanModeState {
 	previousThinkingLevel?: PlanModeFixedThinkingLevel;
 	appliedThinkingLevel?: PlanModeFixedThinkingLevel;
 	manualThinkingLevel?: PlanModeFixedThinkingLevel;
+	branchPointId?: string;
+	toolsBeforePlanMode?: string[];
 }
 
 type SessionEntry = {
+	id?: string;
 	type?: string;
 	customType?: string;
 	data?: unknown;
@@ -91,6 +94,8 @@ export function restorePlanModeState(entries: unknown[], stateEntryType: string)
 			: undefined,
 		appliedThinkingLevel: enabled ? fixedThinkingLevel(entry.data.appliedThinkingLevel) : undefined,
 		manualThinkingLevel: enabled ? fixedThinkingLevel(entry.data.manualThinkingLevel) : undefined,
+		branchPointId: enabled ? entryId(entry.data.branchPointId) : undefined,
+		toolsBeforePlanMode: enabled ? stringArray(entry.data.toolsBeforePlanMode) : undefined,
 	};
 }
 
@@ -146,6 +151,10 @@ function planCompletionSource(value: unknown): PlanCompletionSource | undefined 
 	return value === PLAN_MODE_COMPLETE_TOOL_NAME || value === "legacy_proposed_plan"
 		? value
 		: undefined;
+}
+
+function entryId(value: unknown) {
+	return typeof value === "string" && /^[A-Za-z0-9._:-]{1,128}$/u.test(value) ? value : undefined;
 }
 
 function fixedThinkingLevel(value: unknown): PlanModeFixedThinkingLevel | undefined {

--- a/packages/pi-plan-mode/src/tree-implementation.ts
+++ b/packages/pi-plan-mode/src/tree-implementation.ts
@@ -1,0 +1,347 @@
+import { randomUUID } from "node:crypto";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+	SessionTreeEvent,
+} from "@earendil-works/pi-coding-agent";
+import {
+	formatImplementationHandoff,
+	formatTransferredPlanPrompt,
+} from "./fresh-implementation.js";
+import type { ImplementationPlanRetention } from "./settings.js";
+import type { ActiveImplementationPlan, PlanCompletionSource, PlanModeState } from "./state.js";
+
+export const PLAN_MODE_BRANCH_POINT_ENTRY_TYPE = "plan-mode-branch-point";
+
+interface BranchPointEntry {
+	id?: string;
+	type?: string;
+	customType?: string;
+}
+
+interface BranchPointSessionManager {
+	getLeafId?(): string | null;
+	getEntry?(id: string): BranchPointEntry | undefined;
+}
+
+export interface PlanModeBranchPoint {
+	id: string;
+	tools: string[];
+}
+
+interface PendingTreeHandoff {
+	branchPointId: string;
+	sourceLeafId: string | null;
+	session: object;
+}
+
+interface TreeImplementationOwner {
+	getState(): PlanModeState;
+	getCurrentSession(): object | undefined;
+	getWorkflowGeneration(): number;
+	getRetention(): ImplementationPlanRetention;
+	restoreNormalRuntime(tools: readonly string[]): void;
+	publishImplementation(
+		state: PlanModeState,
+		active: ActiveImplementationPlan | undefined,
+		ctx: ExtensionContext,
+	): void;
+	publishRecovery(state: PlanModeState, ctx: ExtensionContext): void;
+	sendUserMessage(message: string, ctx: ExtensionContext): boolean;
+}
+
+export function capturePlanModeBranchPoint(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	tools: readonly string[],
+): PlanModeBranchPoint | undefined {
+	const sessionManager = ctx.sessionManager as unknown as BranchPointSessionManager;
+	if (!sessionManager.getLeafId || !sessionManager.getEntry) return undefined;
+
+	pi.appendEntry(PLAN_MODE_BRANCH_POINT_ENTRY_TYPE, { version: 1 });
+	const id = sessionManager.getLeafId();
+	if (!id || !isPlanModeBranchPoint(sessionManager.getEntry(id), id)) return undefined;
+	return { id, tools: [...tools] };
+}
+
+export function createTreeImplementationController(owner: TreeImplementationOwner) {
+	let pending: PendingTreeHandoff | undefined;
+
+	return {
+		acceptsTreeEvent(event: SessionTreeEvent, ctx: ExtensionContext) {
+			const accepted =
+				pending?.session === ctx.sessionManager &&
+				pending.sourceLeafId === event.oldLeafId &&
+				pending.branchPointId === event.newLeafId;
+			if (!accepted) pending = undefined;
+			return accepted;
+		},
+		cancel() {
+			pending = undefined;
+		},
+		async start(
+			ctx: ExtensionContext,
+			request: {
+				plan: string;
+				source: PlanCompletionSource;
+				signal?: AbortSignal;
+			},
+		) {
+			const initialState = owner.getState();
+			const branchPointId = initialState.branchPointId;
+			const toolsBeforePlanMode = initialState.toolsBeforePlanMode;
+			if (!branchPointId || !toolsBeforePlanMode) {
+				report(
+					ctx,
+					"This completed plan has no restorable Normal-mode tool snapshot. The plan remains ready in the current branch.",
+					"warning",
+				);
+				return;
+			}
+			if (!isValidPlanModeBranchPoint(ctx, branchPointId)) {
+				report(
+					ctx,
+					"This completed plan has no valid branch point. The plan remains ready in the current branch.",
+					"warning",
+				);
+				return;
+			}
+
+			const sourceSession = ctx.sessionManager;
+			const sourceWorkflowGeneration = owner.getWorkflowGeneration();
+			const handoff: PendingTreeHandoff = {
+				branchPointId,
+				sourceLeafId: sourceSession.getLeafId(),
+				session: sourceSession,
+			};
+			pending = handoff;
+			const navigation = await navigateToPlanModeBranchPoint(ctx, {
+				branchPointId,
+				signal: request.signal,
+				isCurrent: () => {
+					const currentState = owner.getState();
+					return (
+						pending === handoff &&
+						owner.getCurrentSession() === sourceSession &&
+						owner.getWorkflowGeneration() === sourceWorkflowGeneration &&
+						sourceSession.getLeafId() === handoff.sourceLeafId &&
+						currentState.enabled &&
+						currentState.latestPlan === initialState.latestPlan &&
+						currentState.latestPlanSource === initialState.latestPlanSource
+					);
+				},
+			});
+			if (navigation !== "navigated") {
+				if (pending === handoff) pending = undefined;
+				return;
+			}
+
+			let message: string | undefined;
+			try {
+				if (
+					pending !== handoff ||
+					owner.getCurrentSession() !== sourceSession ||
+					sourceSession.getLeafId() !== branchPointId
+				) {
+					return;
+				}
+
+				const retention = owner.getRetention();
+				const activeImplementation = createActiveImplementation(request, retention);
+				owner.restoreNormalRuntime(toolsBeforePlanMode);
+				owner.publishImplementation(
+					implementationState(owner.getState(), activeImplementation),
+					activeImplementation,
+					ctx,
+				);
+				message =
+					retention === "clear-on-start"
+						? formatTransferredPlanPrompt(request.plan, false)
+						: formatImplementationHandoff(request.plan);
+				if (!owner.sendUserMessage(message, ctx)) recover(owner, ctx, request, message);
+			} catch {
+				recover(owner, ctx, request, message);
+			} finally {
+				if (pending === handoff) pending = undefined;
+			}
+		},
+	};
+}
+
+function createActiveImplementation(
+	request: { plan: string; source: PlanCompletionSource },
+	retention: ImplementationPlanRetention,
+): ActiveImplementationPlan | undefined {
+	return retention === "clear-on-start"
+		? undefined
+		: {
+				id: randomUUID(),
+				plan: request.plan,
+				source: request.source,
+				startedAt: Date.now(),
+				retention,
+			};
+}
+
+function implementationState(
+	state: PlanModeState,
+	activeImplementation: ActiveImplementationPlan | undefined,
+): PlanModeState {
+	return {
+		...state,
+		enabled: false,
+		latestPlan: undefined,
+		latestPlanSource: undefined,
+		awaitingAction: false,
+		savedPlan: undefined,
+		activeImplementation,
+		manualThinkingLevel: undefined,
+		branchPointId: undefined,
+		toolsBeforePlanMode: undefined,
+	};
+}
+
+function recover(
+	owner: TreeImplementationOwner,
+	ctx: ExtensionContext,
+	request: { plan: string; source: PlanCompletionSource },
+	handoff: string | undefined,
+) {
+	const currentState = owner.getState();
+	const currentPlanIsRecoverable =
+		currentState.activeImplementation?.plan === request.plan &&
+		currentState.activeImplementation.source === request.source;
+	if (!currentPlanIsRecoverable) {
+		try {
+			owner.publishRecovery(
+				{
+					...implementationState(currentState, undefined),
+					savedPlan: { plan: request.plan, source: request.source },
+				},
+				ctx,
+			);
+		} catch {
+			// The editor recovery below still retains the exact plan when persistence is unavailable.
+		}
+	}
+
+	const message = handoff ?? formatTransferredPlanPrompt(request.plan, false);
+	let restoredInEditor = false;
+	try {
+		if (!ctx.ui.getEditorText().trim()) {
+			ctx.ui.setEditorText(message);
+			restoredInEditor = true;
+		}
+	} catch {
+		// A stale context cannot own editor recovery after session replacement.
+	}
+	try {
+		ctx.ui.notify(
+			restoredInEditor
+				? "The clean implementation branch is ready, but implementation did not start. The complete request is in the editor."
+				: "The clean implementation branch is ready, but implementation did not start. The approved plan remains saved in this branch.",
+			"error",
+		);
+	} catch {
+		// A stale context cannot receive recovery notifications.
+	}
+}
+
+function isValidPlanModeBranchPoint(ctx: ExtensionContext, id: string) {
+	try {
+		return isPlanModeBranchPoint(ctx.sessionManager.getEntry(id), id);
+	} catch {
+		return false;
+	}
+}
+
+async function navigateToPlanModeBranchPoint(
+	ctx: ExtensionContext,
+	options: {
+		branchPointId: string;
+		signal?: AbortSignal;
+		isCurrent(): boolean;
+	},
+): Promise<"navigated" | "cancelled" | "rejected" | "stale"> {
+	if (ctx.mode === "print" || ctx.mode === "json") {
+		throw new Error(
+			"Clean-branch Plan implementation is unavailable in print/JSON mode. Resume the session in TUI or RPC.",
+		);
+	}
+	if (!isCommandContext(ctx)) {
+		report(
+			ctx,
+			"Clean-branch implementation requires the interactive /plan command. Reopen /plan and try again.",
+			"warning",
+		);
+		return "rejected";
+	}
+
+	try {
+		await ctx.waitForIdle();
+	} catch (error: unknown) {
+		report(
+			ctx,
+			`Unable to prepare clean-branch implementation: ${safeErrorDetail(error)}. The completed plan remains ready in the current branch.`,
+			"error",
+		);
+		return "rejected";
+	}
+	if (options.signal?.aborted || !options.isCurrent()) return "stale";
+	if (!isValidPlanModeBranchPoint(ctx, options.branchPointId)) {
+		report(
+			ctx,
+			"The Plan-mode branch point is unavailable. The completed plan remains ready in the current branch.",
+			"warning",
+		);
+		return "rejected";
+	}
+
+	try {
+		const result = await ctx.navigateTree(options.branchPointId, { summarize: false });
+		return result.cancelled ? "cancelled" : "navigated";
+	} catch (error: unknown) {
+		report(
+			ctx,
+			`Unable to return to the Plan-mode branch point: ${safeErrorDetail(error)}. The completed plan remains ready in the current branch.`,
+			"error",
+		);
+		return "rejected";
+	}
+}
+
+function isCommandContext(ctx: ExtensionContext): ctx is ExtensionCommandContext {
+	return (
+		typeof (ctx as Partial<ExtensionCommandContext>).waitForIdle === "function" &&
+		typeof (ctx as Partial<ExtensionCommandContext>).navigateTree === "function"
+	);
+}
+
+function isPlanModeBranchPoint(entry: BranchPointEntry | undefined, id: string) {
+	return (
+		entry?.id === id &&
+		entry.type === "custom" &&
+		entry.customType === PLAN_MODE_BRANCH_POINT_ENTRY_TYPE
+	);
+}
+
+function report(ctx: ExtensionContext, message: string, level: "warning" | "error") {
+	if (!ctx.hasUI) throw new Error(message);
+	ctx.ui.notify(message, level);
+}
+
+function safeErrorDetail(error: unknown) {
+	const detail = error instanceof Error ? error.message : String(error);
+	const normalized =
+		[...detail]
+			.map((character) => {
+				const codePoint = character.codePointAt(0) ?? 0;
+				return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+			})
+			.join("")
+			.replace(/\s+/gu, " ")
+			.trim() || "unknown error";
+	const characters = [...normalized];
+	return characters.length > 500 ? `${characters.slice(0, 499).join("")}…` : normalized;
+}

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -35,8 +35,13 @@ async function completePlan(mock: ReturnType<typeof createMockPi>, ctx: unknown)
 const IMPLEMENTATION_CHOICES = ["Implement here", "Start fresh and implement"];
 const MISSING_SETTINGS = { readSettings: async () => ({ kind: "missing" as const }) };
 
-function assertImplementationChoiceCopy(title: string, options: string[]) {
-	assert.match(title, /Implement here keeps this planning conversation/i);
+function assertImplementationChoiceCopy(title: string, options: string[], cleanBranch = true) {
+	assert.match(
+		title,
+		cleanBranch
+			? /Implement here returns to where Plan mode started/i
+			: /Implement here keeps this planning conversation/i,
+	);
 	assert.match(title, /Start fresh transfers only the approved plan/i);
 	assert.deepEqual(
 		options.filter((option) => IMPLEMENTATION_CHOICES.includes(option)),
@@ -83,7 +88,7 @@ test("ready choice descriptions stay bounded and cancellation has no side effect
 					const lines = harness.render(width);
 					assert.ok(lines.every((line) => visibleWidth(line) <= width));
 				}
-				assert.match(harness.render().join("\n"), /Continue in this session/i);
+				assert.match(harness.render().join("\n"), /Return to the Plan start/i);
 				harness.handleInput("tui.select.down");
 				assert.match(harness.render(40).join("\n"), /Open a new linked session/i);
 				assert.match(harness.render(24).join("\n"), /Start fresh and implement/i);
@@ -118,6 +123,53 @@ test("ready choice descriptions stay bounded and cancellation has no side effect
 		});
 		assert.equal(actionCalls, 0);
 	}
+});
+
+test("ready menu honors configured cancellation without running an action", async () => {
+	let actionCalls = 0;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 60, {
+				matches(data, key) {
+					return key === "tui.select.cancel" && data === "q";
+				},
+				getKeys(key) {
+					return key === "tui.select.cancel" ? ["q"] : [];
+				},
+			});
+			assert.match(harness.render().join("\n"), /q close/i);
+			harness.handleInput("q");
+			return harness.resultPromise;
+		},
+	});
+	await showReadyPlanMenu(context.ctx, {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+		implementationOutcome: () => "Plan reinjection: Off.",
+		getExportDestination: () => ({ configuredPath: "PLAN.md", resolvedPath: "/tmp/PLAN.md" }),
+		implementHere: () => {
+			actionCalls += 1;
+		},
+		implementFresh: () => {
+			actionCalls += 1;
+		},
+		exportPlan: async () => {
+			actionCalls += 1;
+			return true;
+		},
+		save: () => {
+			actionCalls += 1;
+		},
+		stay: () => {
+			actionCalls += 1;
+		},
+		exit: () => {
+			actionCalls += 1;
+		},
+	});
+	assert.equal(actionCalls, 0);
 });
 
 test("automatic completion presents the ready menu without a model turn exactly once", async () => {
@@ -659,6 +711,6 @@ test("saved-plan RPC menu keeps both implementation choices understandable witho
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 	await mock.commands.get("plan")?.handler("", context.ctx);
 	assert.ok(observedMenu);
-	assertImplementationChoiceCopy(observedMenu.title, observedMenu.options);
+	assertImplementationChoiceCopy(observedMenu.title, observedMenu.options, false);
 	assert.ok(observedMenu.options.includes("Show saved plan"));
 });

--- a/packages/pi-plan-mode/test/tree-implementation.test.ts
+++ b/packages/pi-plan-mode/test/tree-implementation.test.ts
@@ -1,0 +1,558 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	builtinTool,
+	createMockContext,
+	createMockPi,
+	extensionTool,
+} from "../../../test/support.js";
+import planMode from "../src/plan-mode.js";
+import type { ImplementationPlanRetention } from "../src/settings.js";
+import { restorePlanModeState } from "../src/state.js";
+import {
+	capturePlanModeBranchPoint,
+	PLAN_MODE_BRANCH_POINT_ENTRY_TYPE,
+} from "../src/tree-implementation.js";
+
+const PLAN = `# Clean branch plan
+
+1. Return to the Normal-mode prefix.
+2. Implement from the exact approved plan.`;
+const STATE_ENTRY_TYPE = "plan-mode-state";
+
+type TreeEntry = {
+	id: string;
+	parentId: string | null;
+	type: "message" | "custom";
+	customType?: string;
+	data?: unknown;
+	message?: { role: string; content?: string; toolName?: string; details?: unknown };
+};
+
+class FaithfulSessionTree {
+	readonly entries: TreeEntry[] = [];
+	leafId: string | null = null;
+	private nextId = 1;
+
+	constructor() {
+		this.appendMessage({ role: "user", content: "A" }, "aaaaaaaa");
+		this.appendMessage({ role: "assistant", content: "B" }, "bbbbbbbb");
+	}
+
+	getLeafId() {
+		return this.leafId;
+	}
+
+	getEntry(id: string) {
+		return this.entries.find((entry) => entry.id === id);
+	}
+
+	getEntries() {
+		return [...this.entries];
+	}
+
+	getBranch(fromId = this.leafId) {
+		const branch: TreeEntry[] = [];
+		let id = fromId;
+		while (id) {
+			const entry = this.getEntry(id);
+			if (!entry) break;
+			branch.push(entry);
+			id = entry.parentId;
+		}
+		return branch.reverse();
+	}
+
+	appendCustom(customType: string, data: unknown) {
+		return this.append({ type: "custom", customType, data });
+	}
+
+	appendMessage(message: TreeEntry["message"], fixedId?: string) {
+		return this.append({ type: "message", message }, fixedId);
+	}
+
+	branch(id: string) {
+		assert.ok(this.getEntry(id), `missing branch target ${id}`);
+		this.leafId = id;
+	}
+
+	private append(entry: Omit<TreeEntry, "id" | "parentId">, fixedId?: string) {
+		const id = fixedId ?? this.nextEntryId();
+		this.entries.push({ ...entry, id, parentId: this.leafId });
+		this.leafId = id;
+		return id;
+	}
+
+	private nextEntryId() {
+		const id = this.nextId.toString(16).padStart(8, "0");
+		this.nextId += 1;
+		return id;
+	}
+}
+
+function setupTreePlanMode(
+	options: {
+		failDelivery?: boolean;
+		thinkingLevel?: string;
+		retention?: ImplementationPlanRetention;
+	} = {},
+) {
+	const tree = new FaithfulSessionTree();
+	const normalTools = ["read", "write", "custom"];
+	const mock = createMockPi({
+		activeTools: normalTools,
+		thinkingLevel: options.thinkingLevel ?? "low",
+		allTools: [builtinTool("read"), builtinTool("write"), extensionTool("custom")],
+	});
+	const appendEntry = mock.rawPi.appendEntry.bind(mock.rawPi);
+	mock.rawPi.appendEntry = (customType, data) => {
+		appendEntry(customType, data);
+		tree.appendCustom(customType, data);
+	};
+	const sendUserMessage = mock.rawPi.sendUserMessage.bind(mock.rawPi);
+	mock.rawPi.sendUserMessage = (text, messageOptions) => {
+		if (options.failDelivery && /previous agent produced|Plan mode is now disabled/iu.test(text)) {
+			throw new Error("delivery failed");
+		}
+		sendUserMessage(text, messageOptions);
+		tree.appendMessage({ role: "user", content: text });
+	};
+
+	let context!: ReturnType<typeof createMockContext>;
+	context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		sessionManager: tree,
+		navigateTree: async (targetId: string, navigationOptions?: { summarize?: boolean }) => {
+			assert.equal(navigationOptions?.summarize, false);
+			const oldLeafId = tree.getLeafId();
+			tree.branch(targetId);
+			await mock.events.get("session_tree")?.[0]?.(
+				{ type: "session_tree", oldLeafId, newLeafId: targetId },
+				context.ctx,
+			);
+			return { cancelled: false };
+		},
+	});
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: {
+				thinkingLevel: options.thinkingLevel ? ("medium" as const) : ("inherit" as const),
+				implementationPlanRetention: options.retention ?? ("clear-on-start" as const),
+			},
+		}),
+	});
+	return { context, mock, normalTools, tree };
+}
+
+async function completePlan(
+	mock: ReturnType<typeof createMockPi>,
+	tree: FaithfulSessionTree,
+	ctx: unknown,
+) {
+	tree.appendMessage({ role: "user", content: "Plan C" });
+	tree.appendMessage({ role: "assistant", content: "Research C" });
+	const complete = mock.tools.find((tool) => tool.name === "plan_mode_complete")?.execute as
+		| ((...args: unknown[]) => Promise<{ details?: unknown }>)
+		| undefined;
+	assert.ok(complete);
+	const result = await complete("complete", { plan: PLAN }, undefined, undefined, ctx);
+	return tree.appendMessage({
+		role: "toolResult",
+		toolName: "plan_mode_complete",
+		details: result.details,
+	});
+}
+
+function contextMessages(tree: FaithfulSessionTree) {
+	return tree
+		.getBranch()
+		.filter((entry) => entry.type === "message")
+		.map((entry) => entry.message?.content ?? entry.message?.toolName);
+}
+
+test("branch-point markers preserve empty, user, assistant, and tool-result model context", () => {
+	for (const leafRole of [null, "user", "assistant", "toolResult"] as const) {
+		const tree = new FaithfulSessionTree();
+		tree.entries.splice(0);
+		tree.leafId = null;
+		if (leafRole) {
+			tree.appendMessage({
+				role: leafRole,
+				content: leafRole === "toolResult" ? undefined : leafRole,
+				toolName: leafRole === "toolResult" ? "read" : undefined,
+			});
+		}
+		const mock = createMockPi({ activeTools: ["write", "read"] });
+		const appendEntry = mock.rawPi.appendEntry.bind(mock.rawPi);
+		mock.rawPi.appendEntry = (customType, data) => {
+			appendEntry(customType, data);
+			tree.appendCustom(customType, data);
+		};
+		const context = createMockContext({ sessionManager: tree });
+		const messagesBefore = contextMessages(tree);
+		const previousLeafId = tree.getLeafId();
+
+		const point = capturePlanModeBranchPoint(mock.pi, context.ctx, ["write", "read"]);
+
+		assert.ok(point);
+		assert.deepEqual(point.tools, ["write", "read"]);
+		const marker = tree.getEntry(point.id);
+		assert.equal(marker?.type, "custom");
+		assert.equal(marker?.parentId, previousLeafId);
+		assert.deepEqual(contextMessages(tree), messagesBefore);
+	}
+});
+
+test("the startup flag captures a context-free branch point before Plan activation", async () => {
+	const { context, mock, normalTools, tree } = setupTreePlanMode();
+	const flag = mock.flags.get("plan");
+	assert.ok(flag);
+	flag.value = true;
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+
+	const branchPoint = tree.entries.find(
+		(entry) => entry.type === "custom" && entry.customType === PLAN_MODE_BRANCH_POINT_ENTRY_TYPE,
+	);
+	assert.ok(branchPoint);
+	const activeState = tree.entries.at(-1)?.data as {
+		branchPointId?: string;
+		toolsBeforePlanMode?: string[];
+	};
+	assert.equal(activeState.branchPointId, branchPoint.id);
+	assert.deepEqual(activeState.toolsBeforePlanMode, normalTools);
+	assert.deepEqual(contextMessages(tree), ["A", "B"]);
+});
+
+test("active Plan implementation returns to its branch point with the exact Normal tool order", async () => {
+	const { context, mock, normalTools, tree } = setupTreePlanMode();
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+
+	const branchPoint = tree.entries.find(
+		(entry) => entry.type === "custom" && entry.customType === PLAN_MODE_BRANCH_POINT_ENTRY_TYPE,
+	);
+	assert.ok(branchPoint);
+	const persistedActivation = tree.entries.find(
+		(entry) =>
+			entry.type === "custom" &&
+			entry.customType === STATE_ENTRY_TYPE &&
+			(entry.data as { enabled?: boolean }).enabled,
+	);
+	assert.ok(persistedActivation);
+	assert.deepEqual(
+		(persistedActivation.data as { toolsBeforePlanMode?: string[] }).toolsBeforePlanMode,
+		normalTools,
+	);
+
+	const planLeafId = await completePlan(mock, tree, context.ctx);
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+
+	assert.deepEqual(mock.rawPi.getActiveTools(), normalTools);
+	assert.deepEqual(contextMessages(tree).slice(0, 3), [
+		"A",
+		"B",
+		mock.sentUserMessages.at(-1)?.text,
+	]);
+	assert.match(mock.sentUserMessages.at(-1)?.text ?? "", /Clean branch plan/);
+	assert.ok(!tree.getBranch().some((entry) => entry.id === planLeafId));
+	assert.ok(tree.getEntry(planLeafId), "the disposable Plan branch remains in the session tree");
+	assert.equal(
+		tree.getBranch().some((entry) => entry.id === branchPoint.id),
+		true,
+	);
+
+	const beforeAgentStart = mock.events.get("before_agent_start")?.[0];
+	assert.ok(beforeAgentStart);
+	assert.equal(
+		await beforeAgentStart({ systemPrompt: "normal", prompt: "implement" }, context.ctx),
+		undefined,
+	);
+});
+
+test("clean tree handoff preserves each guaranteed Plan-retention policy without duplication", async () => {
+	for (const retention of ["clear-after-first-run", "keep"] as const) {
+		const { context, mock, tree } = setupTreePlanMode({ retention });
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await completePlan(mock, tree, context.ctx);
+		await mock.commands.get("plan")?.handler("implement", context.ctx);
+
+		const handoff = mock.sentUserMessages.at(-1)?.text ?? "";
+		const contextHook = mock.events.get("context")?.[0];
+		assert.ok(contextHook);
+		const initial = (await contextHook(
+			{ messages: [{ role: "user", content: handoff }] },
+			context.ctx,
+		)) as { messages: unknown[] };
+		assert.equal(JSON.stringify(initial.messages).split("Clean branch plan").length - 1, 1);
+		assert.doesNotMatch(JSON.stringify(initial.messages), /plan-mode-implementation-context/);
+
+		const compacted = (await contextHook(
+			{ messages: [{ role: "compactionSummary", summary: "Earlier implementation context." }] },
+			context.ctx,
+		)) as { messages: unknown[] };
+		assert.match(JSON.stringify(compacted.messages), /plan-mode-implementation-context/);
+		assert.match(JSON.stringify(compacted.messages), /Clean branch plan/);
+
+		const activeState = tree
+			.getBranch()
+			.filter((entry) => entry.customType === STATE_ENTRY_TYPE)
+			.at(-1)?.data as { activeImplementation?: { retention?: string } };
+		assert.equal(activeState.activeImplementation?.retention, retention);
+		await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		const settledState = tree
+			.getBranch()
+			.filter((entry) => entry.customType === STATE_ENTRY_TYPE)
+			.at(-1)?.data as { activeImplementation?: { retention?: string } };
+		assert.equal(
+			settledState.activeImplementation?.retention,
+			retention === "keep" ? "keep" : undefined,
+		);
+	}
+});
+
+test("manual tree navigation restores Plan and Normal runtime state symmetrically", async () => {
+	const { context, mock, normalTools, tree } = setupTreePlanMode({ thinkingLevel: "low" });
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const planLeafId = await completePlan(mock, tree, context.ctx);
+	const branchPoint = tree.entries.find(
+		(entry) => entry.type === "custom" && entry.customType === PLAN_MODE_BRANCH_POINT_ENTRY_TYPE,
+	);
+	assert.ok(branchPoint);
+
+	await (
+		context.ctx as { navigateTree(id: string, options: unknown): Promise<unknown> }
+	).navigateTree(branchPoint.id, { summarize: false });
+	assert.deepEqual(mock.rawPi.getActiveTools(), normalTools);
+	assert.equal(mock.thinkingLevel, "low");
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+
+	await (
+		context.ctx as { navigateTree(id: string, options: unknown): Promise<unknown> }
+	).navigateTree(planLeafId, { summarize: false });
+	assert.ok(mock.rawPi.getActiveTools().includes("plan_mode_complete"));
+	assert.ok(!mock.rawPi.getActiveTools().includes("write"));
+	assert.equal(mock.thinkingLevel, "medium");
+	assert.equal(context.statuses.get("plan-mode"), "plan ready");
+});
+
+test("reload, resume, fork, and compaction restore branch-owned Plan metadata", async () => {
+	for (const reason of ["reload", "resume", "fork"] as const) {
+		const { context, mock, tree } = setupTreePlanMode({ thinkingLevel: "low" });
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await completePlan(mock, tree, context.ctx);
+		tree.appendMessage({ role: "compactionSummary", content: "Compacted Plan research." });
+
+		await mock.events.get("session_shutdown")?.[0]?.({ reason }, context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write", "custom"]);
+		await mock.events.get("session_start")?.[0]?.({ reason }, context.ctx);
+
+		assert.ok(mock.rawPi.getActiveTools().includes("plan_mode_complete"));
+		assert.ok(!mock.rawPi.getActiveTools().includes("write"));
+		assert.equal(mock.thinkingLevel, "medium");
+		const restored = tree
+			.getBranch()
+			.filter((entry) => entry.customType === STATE_ENTRY_TYPE)
+			.at(-1)?.data as { branchPointId?: string; toolsBeforePlanMode?: string[] };
+		assert.ok(restored.branchPointId);
+		assert.deepEqual(restored.toolsBeforePlanMode, ["read", "write", "custom"]);
+	}
+});
+
+test("cancelled and stale clean-branch navigation leave the completed Plan branch ready", async () => {
+	for (const stale of [false, true]) {
+		const { context, mock, tree } = setupTreePlanMode();
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await completePlan(mock, tree, context.ctx);
+		const planLeafId = tree.getLeafId();
+		(context.ctx as { navigateTree(): Promise<{ cancelled: boolean }> }).navigateTree =
+			async () => ({
+				cancelled: !stale,
+			});
+		if (stale) {
+			(context.ctx as { waitForIdle(): Promise<void> }).waitForIdle = async () => {
+				await mock.events.get("session_shutdown")?.[0]?.({ reason: "resume" }, context.ctx);
+			};
+		}
+
+		await mock.commands.get("plan")?.handler("implement", context.ctx);
+		assert.ok(tree.getBranch().some((entry) => entry.id === planLeafId));
+		if (stale) {
+			assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write", "custom"]);
+		} else {
+			assert.ok(mock.rawPi.getActiveTools().includes("plan_mode_complete"));
+		}
+		assert.equal(mock.sentUserMessages.length, 0);
+	}
+});
+
+test("print and JSON modes reject clean-branch implementation before navigation", async () => {
+	for (const mode of ["print", "json"] as const) {
+		const { context, mock, tree } = setupTreePlanMode();
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await completePlan(mock, tree, context.ctx);
+		const planLeafId = tree.getLeafId();
+		(context.ctx as { mode: string; hasUI: boolean }).mode = mode;
+		(context.ctx as { mode: string; hasUI: boolean }).hasUI = false;
+
+		await assert.rejects(
+			mock.commands.get("plan")?.handler("implement", context.ctx) as Promise<unknown>,
+			/print\/JSON mode/i,
+		);
+		assert.equal(tree.getLeafId(), planLeafId);
+		assert.ok(mock.rawPi.getActiveTools().includes("plan_mode_complete"));
+		assert.equal(mock.sentUserMessages.length, 0);
+	}
+});
+
+test("missing command context and invalid branch points fail before leaving the Plan branch", async () => {
+	for (const invalidBranchPoint of [false, true]) {
+		const { context, mock, tree } = setupTreePlanMode();
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await completePlan(mock, tree, context.ctx);
+		const planLeafId = tree.getLeafId();
+		if (invalidBranchPoint) {
+			const marker = tree.entries.find(
+				(entry) => entry.customType === PLAN_MODE_BRANCH_POINT_ENTRY_TYPE,
+			);
+			assert.ok(marker);
+			marker.customType = "invalid-branch-point";
+		} else {
+			Reflect.deleteProperty(context.ctx as object, "navigateTree");
+		}
+
+		await mock.commands.get("plan")?.handler("implement", context.ctx);
+		assert.equal(tree.getLeafId(), planLeafId);
+		assert.ok(mock.rawPi.getActiveTools().includes("plan_mode_complete"));
+		assert.equal(mock.sentUserMessages.length, 0);
+		assert.match(
+			context.notifications.at(-1)?.message ?? "",
+			invalidBranchPoint ? /no valid branch point/i : /reopen \/plan/i,
+		);
+	}
+});
+
+test("session replacement after navigation cannot publish the staged Plan into a stale destination", async () => {
+	const { context, mock, tree } = setupTreePlanMode();
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const planLeafId = await completePlan(mock, tree, context.ctx);
+	const branchPoint = tree.entries.find(
+		(entry) => entry.customType === PLAN_MODE_BRANCH_POINT_ENTRY_TYPE,
+	);
+	assert.ok(branchPoint);
+	(context.ctx as { navigateTree(id: string): Promise<{ cancelled: boolean }> }).navigateTree =
+		async (targetId) => {
+			const oldLeafId = tree.getLeafId();
+			tree.branch(targetId);
+			await mock.events.get("session_tree")?.[0]?.(
+				{ type: "session_tree", oldLeafId, newLeafId: targetId },
+				context.ctx,
+			);
+			await mock.events.get("session_shutdown")?.[0]?.({ reason: "resume" }, context.ctx);
+			return { cancelled: false };
+		};
+
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	assert.equal(mock.sentUserMessages.length, 0);
+	assert.ok(tree.getEntry(planLeafId));
+	const destinationStates = tree
+		.getBranch()
+		.filter((entry) => entry.customType === STATE_ENTRY_TYPE)
+		.map((entry) => entry.data as { savedPlan?: unknown; activeImplementation?: unknown });
+	assert.ok(destinationStates.every((entry) => !entry.savedPlan && !entry.activeImplementation));
+});
+
+test("idle-wait and navigation errors retain the ready Plan branch", async () => {
+	for (const failure of ["wait", "navigate"] as const) {
+		const { context, mock, tree } = setupTreePlanMode();
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await completePlan(mock, tree, context.ctx);
+		const planLeafId = tree.getLeafId();
+		if (failure === "wait") {
+			(context.ctx as { waitForIdle(): Promise<void> }).waitForIdle = async () => {
+				throw new Error("wait failed");
+			};
+		} else {
+			(context.ctx as { navigateTree(): Promise<unknown> }).navigateTree = async () => {
+				throw new Error("navigation failed");
+			};
+		}
+
+		await mock.commands.get("plan")?.handler("implement", context.ctx);
+		assert.equal(tree.getLeafId(), planLeafId);
+		assert.ok(mock.rawPi.getActiveTools().includes("plan_mode_complete"));
+		assert.equal(mock.sentUserMessages.length, 0);
+		assert.match(context.notifications.at(-1)?.message ?? "", /plan remains ready|remains ready/i);
+	}
+});
+
+test("delivery failure preserves the exact Plan on the clean destination branch", async () => {
+	const { context, mock, normalTools, tree } = setupTreePlanMode({ failDelivery: true });
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	await completePlan(mock, tree, context.ctx);
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+
+	assert.deepEqual(mock.rawPi.getActiveTools(), normalTools);
+	assert.match(context.editorText, /Clean branch plan/);
+	const recovered = tree
+		.getBranch()
+		.filter((entry) => entry.customType === STATE_ENTRY_TYPE)
+		.at(-1)?.data as { savedPlan?: { plan?: string } };
+	assert.equal(recovered.savedPlan?.plan, PLAN);
+	assert.match(context.notifications.at(-1)?.message ?? "", /complete request is in the editor/i);
+});
+
+test("branch metadata restores only for enabled valid state shapes", () => {
+	const marker = {
+		id: "11111111",
+		type: "custom",
+		customType: PLAN_MODE_BRANCH_POINT_ENTRY_TYPE,
+		data: { version: 1 },
+	};
+	const restored = restorePlanModeState(
+		[
+			marker,
+			{
+				type: "custom",
+				customType: STATE_ENTRY_TYPE,
+				data: {
+					enabled: true,
+					awaitingAction: false,
+					branchPointId: marker.id,
+					toolsBeforePlanMode: ["write", "read", "write"],
+				},
+			},
+		],
+		STATE_ENTRY_TYPE,
+	);
+	assert.equal(restored.branchPointId, marker.id);
+	assert.deepEqual(restored.toolsBeforePlanMode, ["write", "read"]);
+
+	const malformed = restorePlanModeState(
+		[
+			{
+				type: "custom",
+				customType: STATE_ENTRY_TYPE,
+				data: {
+					enabled: true,
+					awaitingAction: false,
+					branchPointId: "bad\u001b-id",
+					toolsBeforePlanMode: ["read", 7],
+				},
+			},
+		],
+		STATE_ENTRY_TYPE,
+	);
+	assert.equal(malformed.branchPointId, undefined);
+	assert.equal(malformed.toolsBeforePlanMode, undefined);
+});


### PR DESCRIPTION
## Summary
- create a context-free branch marker before Plan activation and return to it for active-plan `Implement here`
- restore the exact ordered Normal tool contract, transfer only the approved plan, and keep Plan history on an alternate `/tree` branch
- reconcile branch-owned state across manual tree navigation and harden cancellation, replacement, delivery-failure, legacy, saved-plan, and non-interactive paths
- document provider-dependent cache behavior and add a minor Changeset

## Verification
- `npm run check`
- `npm test` — 361 files, 3,246 tests
- `npx vitest run packages/pi-plan-mode/test` — 20 files, 236 tests
- generated-entry and build-runtime tests — 6 tests
- `just pack plan-mode` — 39 expected files, including generated runtime and `src/tree-implementation.ts`
- isolated RPC smoke with the built package in a temporary directory — Plan and implementation runs settled, the Plan tool branch remained in `/tree`, and the active implementation context contained only the transferred plan and implementation response
- signed commit verified with the configured SSH signing key

## Audit and risks
- audited against `docs/extension-conventions.md`; `docs/extension-settings.md` is not applicable because settings behavior did not change
- audited user cancellation, component disposal, manual tree navigation, session replacement, shutdown, stale continuations, compaction, reload, resume, fork, and partial handoff recovery
- provider cache reuse remains dependent on exact serialization, model/provider behavior, cache lifetime, and session affinity; the extension does not promise a cache hit
- saved plans and legacy ready plans without branch metadata retain the prior linear compatibility path
- no publish, tag, visibility, or release workflow action was performed