### PR TITLE
feat: show active tools above editor

### DIFF
--- a/.pi/extensions/active-tool-status/index.test.ts
+++ b/.pi/extensions/active-tool-status/index.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { afterEach, test, vi } from "vitest";
+import activeToolStatus, {
+	ACTIVE_TOOL_REFRESH_INTERVAL_MS,
+	formatActiveToolWidget,
+	sanitizeToolName,
+	WIDGET_KEY,
+} from "./index.js";
+
+type Handler = (event: never, ctx: ExtensionContext) => unknown;
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function createHarness(initialTools: string[] = []) {
+	const handlers = new Map<string, Handler[]>();
+	let activeTools = initialTools;
+	const pi = {
+		on(event: string, handler: Handler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		getActiveTools() {
+			return [...activeTools];
+		},
+	} as unknown as ExtensionAPI;
+	activeToolStatus(pi);
+
+	return {
+		setActiveTools(toolNames: string[]) {
+			activeTools = toolNames;
+		},
+		async emit(event: string, payload: Record<string, unknown>, ctx: ExtensionContext) {
+			for (const handler of handlers.get(event) ?? []) await handler(payload as never, ctx);
+		},
+	};
+}
+
+function createContext() {
+	const widgets: Array<[string, string[] | undefined, { placement: "aboveEditor" } | undefined]> =
+		[];
+	const sessionManager = {} as ExtensionContext["sessionManager"];
+	const ctx = {
+		hasUI: true,
+		isIdle: () => true,
+		sessionManager,
+		ui: {
+			setWidget(
+				key: string,
+				content: string[] | undefined,
+				options?: { placement: "aboveEditor" },
+			) {
+				widgets.push([key, content, options]);
+			},
+		},
+	} as unknown as ExtensionContext;
+	return { ctx, widgets };
+}
+
+test("shows every active tool above the editor and refreshes when the set changes", async () => {
+	vi.useFakeTimers();
+	const harness = createHarness(["read", "bash"]);
+	const current = createContext();
+	await harness.emit("session_start", {}, current.ctx);
+	assert.deepEqual(current.widgets.at(-1), [
+		WIDGET_KEY,
+		["Active tools (2)", "read · bash"],
+		{ placement: "aboveEditor" },
+	]);
+
+	await vi.advanceTimersByTimeAsync(ACTIVE_TOOL_REFRESH_INTERVAL_MS);
+	assert.equal(current.widgets.length, 1);
+
+	harness.setActiveTools(["read", "edit", "write"]);
+	await vi.advanceTimersByTimeAsync(ACTIVE_TOOL_REFRESH_INTERVAL_MS);
+	assert.deepEqual(current.widgets.at(-1), [
+		WIDGET_KEY,
+		["Active tools (3)", "read · edit · write"],
+		{ placement: "aboveEditor" },
+	]);
+
+	harness.setActiveTools(["read", "firecrawl_search"]);
+	await harness.emit(
+		"tool_execution_end",
+		{ toolCallId: "loader", toolName: "firecrawl_load" },
+		current.ctx,
+	);
+	assert.deepEqual(current.widgets.at(-1), [
+		WIDGET_KEY,
+		["Active tools (2)", "read · firecrawl_search"],
+		{ placement: "aboveEditor" },
+	]);
+
+	await harness.emit("session_shutdown", {}, current.ctx);
+	assert.deepEqual(current.widgets.at(-1), [WIDGET_KEY, undefined, undefined]);
+});
+
+test("session replacement ignores stale events and shutdown clears the owned widget", async () => {
+	const harness = createHarness(["read"]);
+	const previous = createContext();
+	const current = createContext();
+	await harness.emit("session_start", {}, previous.ctx);
+
+	harness.setActiveTools(["edit"]);
+	await harness.emit("session_start", {}, current.ctx);
+	await harness.emit("before_agent_start", {}, previous.ctx);
+	assert.deepEqual(current.widgets.at(-1), [
+		WIDGET_KEY,
+		["Active tool (1)", "edit"],
+		{ placement: "aboveEditor" },
+	]);
+
+	await harness.emit("session_shutdown", {}, previous.ctx);
+	assert.deepEqual(current.widgets.at(-1), [
+		WIDGET_KEY,
+		["Active tool (1)", "edit"],
+		{ placement: "aboveEditor" },
+	]);
+
+	await harness.emit("session_shutdown", {}, current.ctx);
+	assert.deepEqual(current.widgets.at(-1), [WIDGET_KEY, undefined, undefined]);
+});
+
+test("formats every tool as bounded safe display text", () => {
+	assert.deepEqual(formatActiveToolWidget(["read", "bash", "edit", "write"]), [
+		"Active tools (4)",
+		"read · bash · edit · write",
+	]);
+	assert.deepEqual(formatActiveToolWidget(["read\n\u001b[31m"]), ["Active tool (1)", "read31m"]);
+	assert.equal(sanitizeToolName("\u001b]8;;bad\u0007read\n\u202efile"), "8badreadfile");
+	assert.equal(sanitizeToolName("\u001b\u0007"), "tool");
+	assert.equal(sanitizeToolName("x".repeat(40)), `${"x".repeat(32)}…`);
+});

--- a/.pi/extensions/active-tool-status/index.ts
+++ b/.pi/extensions/active-tool-status/index.ts
@@ -1,0 +1,87 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+export const WIDGET_KEY = "active-tool-status";
+const MAX_TOOL_NAME_LENGTH = 32;
+export const ACTIVE_TOOL_REFRESH_INTERVAL_MS = 500;
+
+export default function activeToolStatus(pi: ExtensionAPI): void {
+	let activeSession: ExtensionContext["sessionManager"] | undefined;
+	let refreshTimer: ReturnType<typeof setInterval> | undefined;
+	let publishedValue: string | undefined;
+	let hasPublished = false;
+
+	const ownsSession = (ctx: ExtensionContext) => ctx.sessionManager === activeSession;
+
+	const publish = (ctx: ExtensionContext): void => {
+		if (!ctx.hasUI) return;
+		const content = formatActiveToolWidget(pi.getActiveTools());
+		const value = content?.join("\n");
+		if (hasPublished && value === publishedValue) return;
+		ctx.ui.setWidget(WIDGET_KEY, content, { placement: "aboveEditor" });
+		publishedValue = value;
+		hasPublished = true;
+	};
+
+	const stopRefreshing = (): void => {
+		if (!refreshTimer) return;
+		clearInterval(refreshTimer);
+		refreshTimer = undefined;
+	};
+
+	const clear = (ctx: ExtensionContext): void => {
+		if (ctx.hasUI) ctx.ui.setWidget(WIDGET_KEY, undefined);
+		publishedValue = undefined;
+		hasPublished = false;
+	};
+
+	pi.on("session_start", (_event, ctx) => {
+		stopRefreshing();
+		activeSession = ctx.sessionManager;
+		hasPublished = false;
+		publish(ctx);
+		if (ctx.hasUI) {
+			refreshTimer = setInterval(() => {
+				if (ownsSession(ctx)) publish(ctx);
+			}, ACTIVE_TOOL_REFRESH_INTERVAL_MS);
+		}
+	});
+
+	pi.on("before_agent_start", (_event, ctx) => {
+		if (ownsSession(ctx)) publish(ctx);
+	});
+
+	pi.on("model_select", (_event, ctx) => {
+		if (ownsSession(ctx)) publish(ctx);
+	});
+
+	pi.on("tool_execution_end", (_event, ctx) => {
+		if (ownsSession(ctx)) publish(ctx);
+	});
+
+	pi.on("agent_settled", (_event, ctx) => {
+		if (ownsSession(ctx) && ctx.isIdle()) publish(ctx);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		if (!ownsSession(ctx)) return;
+		stopRefreshing();
+		clear(ctx);
+		activeSession = undefined;
+	});
+}
+
+export function formatActiveToolWidget(toolNames: Iterable<string>): string[] | undefined {
+	const tools = [...toolNames].map(sanitizeToolName);
+	if (tools.length === 0) return undefined;
+	const label = tools.length === 1 ? "Active tool" : "Active tools";
+	return [`${label} (${tools.length})`, tools.join(" · ")];
+}
+
+export function sanitizeToolName(value: string): string {
+	const printable = value.replace(/[^\p{L}\p{N}_.:/-]+/gu, "");
+	if (!printable) return "tool";
+	const characters = [...printable];
+	return characters.length > MAX_TOOL_NAME_LENGTH
+		? `${characters.slice(0, MAX_TOOL_NAME_LENGTH).join("")}…`
+		: printable;
+}

--- a/.pi/extensions/active-tool-status/vitest.config.ts
+++ b/.pi/extensions/active-tool-status/vitest.config.ts
@@ -1,0 +1,12 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	root: dirname(fileURLToPath(import.meta.url)),
+	test: {
+		environment: "node",
+		include: ["index.test.ts"],
+		testTimeout: 5_000,
+	},
+});


### PR DESCRIPTION
## Summary

- add a project-local extension that shows every currently active Pi tool above the editor
- refresh the widget when tool availability changes while suppressing unchanged renders
- sanitize displayed tool names and clean up session-owned timers and UI across replacement and shutdown
- add focused lifecycle, refresh, rendering, and terminal-safety tests

## Verification

- `npx vitest run --config .pi/extensions/active-tool-status/vitest.config.ts`
- `npm run check`
- `npm test` — 363 files and 3,235 tests passed
- isolated RPC load with `pi --mode rpc --no-extensions -e ./.pi/extensions/active-tool-status/index.ts`
- trusted-project auto-discovery RPC smoke

## Release

No changeset is needed because this is a repository-local extension under `.pi/extensions/`.
