### PR TITLE
fix(plan-mode): harden transition history

### DIFF
--- a/.changeset/safe-plan-transition-history.md
+++ b/.changeset/safe-plan-transition-history.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": patch
+---
+
+Keep unused resumed sessions free of mode contracts and reject `/tree` navigation to internal transition markers.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -56,7 +56,9 @@ Ordinary linear turns do not rewrite or duplicate these contracts.
 The `context` hook filters legacy repeated `plan-mode-context` artifacts but preserves current transition messages.
 When compaction removes the effective physical transition, the hook inserts one canonical fallback at a deterministic retained-history boundary.
 Repeated transforms leave that fallback in place instead of moving it to the newest turn.
+An inactive legacy state entry alone does not inject a Normal contract, so sessions that never entered Plan mode keep their ordinary context after resume or reload.
 Manual `/tree` navigation restores branch-owned Plan state and chooses the matching effective contract without navigating automatically or adding a branch summary.
+Pi currently lists hidden custom transition messages in `/tree`; Plan mode rejects those internal targets, so select an adjacent conversation entry instead.
 
 The extension keeps its base system prompt and ordered startup tool definitions unchanged across start, off, exit, save, export, and implementation transitions.
 This makes the reusable provider prefix stable; it does not guarantee a cache hit.

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -46,6 +46,7 @@ import {
 	createModeContractMessage,
 	hasModeContractArtifact,
 	latestModeContract,
+	MODE_CONTRACT_MESSAGE_TYPE,
 	type PlanModeContract,
 	reconcileModeContract,
 } from "./mode-contract.js";
@@ -459,14 +460,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		implementationRetention.reset();
 		settings = { thinkingLevel: "inherit" };
 		const branch = ctx.sessionManager.getBranch();
-		publishedContractMode = latestModeContract(branch)?.mode;
-		modeContractsRelevant =
-			hasModeContractArtifact(branch) ||
-			branch.some(
-				(entry: { type?: string; customType?: string }) =>
-					entry.type === "custom" && entry.customType === STATE_ENTRY_TYPE,
-			);
 		const restoredState = restorePlanModeState(branch, STATE_ENTRY_TYPE);
+		restoreModeContractTracking(branch, restoredState);
 		state = { enabled: false, awaitingAction: false };
 		await applyPlanModeSettings(generation, ctx, true);
 		if (generation !== menuGeneration || menuController.signal.aborted) return;
@@ -491,6 +486,20 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		updateUi(ctx);
 	});
 
+	pi.on("session_before_tree", (event, ctx) => {
+		const target = ctx.sessionManager.getEntry(event.preparation.targetId);
+		if (target?.type !== "custom_message" || target.customType !== MODE_CONTRACT_MESSAGE_TYPE) {
+			return;
+		}
+		if (ctx.hasUI) {
+			ctx.ui.notify(
+				"Plan mode transition markers are internal. Select the adjacent conversation entry instead.",
+				"warning",
+			);
+		}
+		return { cancel: true };
+	});
+
 	pi.on("session_tree", (_event, ctx) => {
 		advanceWorkflowGeneration();
 		menuGeneration += 1;
@@ -500,14 +509,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		latestCommandContext = undefined;
 		implementationRetention.reset();
 		const branch = ctx.sessionManager.getBranch();
-		publishedContractMode = latestModeContract(branch)?.mode;
-		modeContractsRelevant =
-			hasModeContractArtifact(branch) ||
-			branch.some(
-				(entry: { type?: string; customType?: string }) =>
-					entry.type === "custom" && entry.customType === STATE_ENTRY_TYPE,
-			);
-		if (!installRestoredState(restorePlanModeState(branch, STATE_ENTRY_TYPE), ctx)) return;
+		const restoredState = restorePlanModeState(branch, STATE_ENTRY_TYPE);
+		restoreModeContractTracking(branch, restoredState);
+		if (!installRestoredState(restoredState, ctx)) return;
 		implementationRetention.restore(state.activeImplementation);
 		startPlanModeSettingsWatch(menuGeneration);
 		updateUi(ctx);
@@ -630,14 +634,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			refreshStateBeforeFirstAgentStart = false;
 			implementationRetention.reset();
 			const branch = ctx.sessionManager.getBranch();
-			publishedContractMode = latestModeContract(branch)?.mode;
-			modeContractsRelevant =
-				hasModeContractArtifact(branch) ||
-				branch.some(
-					(entry: { type?: string; customType?: string }) =>
-						entry.type === "custom" && entry.customType === STATE_ENTRY_TYPE,
-				);
-			if (!installRestoredState(restorePlanModeState(branch, STATE_ENTRY_TYPE), ctx)) return;
+			const restoredState = restorePlanModeState(branch, STATE_ENTRY_TYPE);
+			restoreModeContractTracking(branch, restoredState);
+			if (!installRestoredState(restoredState, ctx)) return;
 			implementationRetention.restore(state.activeImplementation);
 			updateUi(ctx);
 		}
@@ -805,6 +804,15 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		updateUi(ctx);
 		if (wasEnabled) releaseWorkflowOwner();
 		return true;
+	}
+
+	function restoreModeContractTracking(branch: unknown[], restoredState: PlanModeState) {
+		publishedContractMode = latestModeContract(branch)?.mode;
+		modeContractsRelevant =
+			hasModeContractArtifact(branch) ||
+			restoredState.enabled ||
+			restoredState.savedPlan !== undefined ||
+			restoredState.activeImplementation !== undefined;
 	}
 
 	function publishModeContract(mode: PlanModeContract, ctx: ExtensionContext) {

--- a/packages/pi-plan-mode/test/mode-transition-lifecycle.test.ts
+++ b/packages/pi-plan-mode/test/mode-transition-lifecycle.test.ts
@@ -16,6 +16,69 @@ function contractEntry(mode: "plan" | "normal") {
 	return { type: "custom_message", ...message };
 }
 
+test("inactive state-only resume and reload leave ordinary context unchanged", async () => {
+	const source = createMockPi({ activeTools: ["read"] });
+	planMode(source.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const sourceContext = createMockContext();
+	await source.events.get("session_start")?.[0]?.({ reason: "startup" }, sourceContext.ctx);
+	await source.events.get("session_shutdown")?.[0]?.({ reason: "quit" }, sourceContext.ctx);
+	const persisted = source.entries.at(-1);
+	assert.ok(persisted);
+
+	const branch = [{ type: "custom", ...persisted }];
+	const sessionManager = {
+		getBranch: () => branch,
+		getEntries: () => branch,
+	};
+	const resumed = createMockPi({ activeTools: ["read"] });
+	planMode(resumed.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const resumedContext = createMockContext({ sessionManager });
+	const contextHook = resumed.events.get("context")?.[0];
+	assert.ok(contextHook);
+	const messages = [{ role: "user", content: "ordinary request" }];
+
+	for (const reason of ["resume", "reload"] as const) {
+		await resumed.events.get("session_start")?.[0]?.({ reason }, resumedContext.ctx);
+		const transformed = (await contextHook({ messages }, resumedContext.ctx)) as {
+			messages: unknown[];
+		};
+		assert.deepEqual(transformed.messages, messages, reason);
+	}
+});
+
+test("internal mode contracts cannot be selected as tree navigation targets", async () => {
+	const contract = contractEntry("plan");
+	const ordinary = { type: "message", message: { role: "assistant" } };
+	const sessionManager = {
+		getBranch: () => [],
+		getEntries: () => [],
+		getEntry: (id: string) => (id === "contract" ? contract : ordinary),
+	};
+	const mock = createMockPi({ activeTools: ["read"] });
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({ hasUI: true, sessionManager });
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const stateEntriesBefore = mock.entries.length;
+	const beforeTree = mock.events.get("session_before_tree")?.[0];
+	assert.ok(beforeTree);
+
+	const blocked = await beforeTree(
+		{ preparation: { targetId: "contract" }, signal: new AbortController().signal },
+		context.ctx,
+	);
+	assert.deepEqual(blocked, { cancel: true });
+	assert.equal(mock.entries.length, stateEntriesBefore);
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
+	assert.match(context.notifications.at(-1)?.message ?? "", /transition markers are internal/u);
+
+	const allowed = await beforeTree(
+		{ preparation: { targetId: "ordinary" }, signal: new AbortController().signal },
+		context.ctx,
+	);
+	assert.equal(allowed, undefined);
+});
+
 test("manual tree navigation restores branch-owned mode state without changing the tool envelope", async () => {
 	const branch: unknown[] = [];
 	const sessionManager = {


### PR DESCRIPTION
## Summary

- keep inactive state-only resume and reload paths free of unsolicited Normal contracts
- reject `/tree` navigation to internal mode-transition messages before branch state can diverge from the contract
- document the tree boundary and add a patch Changeset

## Verification

- `npm --workspace @narumitw/pi-plan-mode run check`
- `npx vitest run packages/pi-plan-mode/test test/plan-goal-coexistence.test.ts` — 23 files, 241 tests
- `npm run check`
- `npm test` — 363 files, 3,237 tests
- `just pack plan-mode` — 39 files inspected
- `pi --no-extensions -e ./packages/pi-plan-mode -p "/plan start"` — packaged generated entry loaded and exited successfully

## Convention audits

- audited `docs/extension-conventions.md`, `docs/extension-settings.md`, and Pi's extension/session/tree documentation
- `/tree` rejection is synchronous, owns no cancellable work, preserves state, and leaves ordinary targets available
- resume, reload, new-session refresh, manual tree navigation, shutdown, and context reconciliation use the same contract-tracking rule
- settings formats, reads, writes, precedence, and persistence are unchanged
- no required path remains unverified
