### PR TITLE
feat(file-context): promote extension to stable

### DIFF
--- a/.changeset/stable-file-context.md
+++ b/.changeset/stable-file-context.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-file-context": minor
+---
+
+Promote the extension to stable, include it in root Git installations, and remove its experimental startup warning.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ pi -e npm:@narumitw/pi-goal \
 | Package | Use it for | Install |
 | --- | --- | --- |
 | [`pi-codex-compact`](./packages/pi-codex-compact) | Use OpenAI Codex Remote Compaction V2 to persist and replay bounded opaque checkpoints, with `/codex-compact` manual controls and safe Pi-native fallback. | `pi install npm:@narumitw/pi-codex-compact` |
+| [`pi-file-context`](./packages/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it with configurable `Ctrl+Shift+X` or `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
 | [`pi-lsp`](./packages/pi-lsp) | Language-server diagnostics and code actions across JavaScript, TypeScript, Python, Rust, Go, Ruby, C/C++, JVM, .NET, Swift, shell, infrastructure formats, and more. | `pi install npm:@narumitw/pi-lsp` |
 | [`pi-plan-mode`](./packages/pi-plan-mode) | Codex-like, read-only `/plan` collaboration before implementation begins. | `pi install npm:@narumitw/pi-plan-mode` |
 | [`pi-subagents`](./packages/pi-subagents) | Delegate isolated work in single, parallel, or chained execution modes. | `pi install npm:@narumitw/pi-subagents` |
@@ -103,7 +104,6 @@ commands, settings persistence, confirmations, and specialized UI.
 | --- | --- | --- |
 | [`pi-analytics`](./packages/pi-analytics) | Review private, content-free local metrics for model calls, skills, tools, response cycles, and observed provider reliability through `/analytics`. | `pi install npm:@narumitw/pi-analytics` |
 | [`pi-chat`](./packages/pi-chat) | Join ephemeral peer-to-peer chat rooms that stay separate from Pi sessions, prompts, and model context. | `pi install npm:@narumitw/pi-chat` |
-| [`pi-file-context`](./packages/pi-file-context) | Browse project files, preview text, select exact lines or Git diff hunks, and attach immutable snapshots with Git provenance to the next prompt. Open it with configurable `F8` or `/file-context`. | `pi install npm:@narumitw/pi-file-context` |
 | [`pi-fleet`](./packages/pi-fleet) | Start a separate Pi process in a Ghostty split and connect explicit local Pi sessions for bounded messages and one-turn requests. | `pi install npm:@narumitw/pi-fleet` |
 | [`pi-recall`](./packages/pi-recall) | Save selected text messages locally and preview or quote them across Pi sessions. | `pi install npm:@narumitw/pi-recall` |
 
@@ -165,7 +165,7 @@ npm --workspace @narumitw/pi-goal run build --if-present
 pi -e ./packages/pi-goal
 just pack goal
 
-# Experimental packages use the same local flow and pack recipe
+# Another build-backed package uses the same local flow and pack recipe
 npm --workspace @narumitw/pi-file-context run build --if-present
 pi -e ./packages/pi-file-context
 just pack file-context

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 			"./packages/pi-caffeinate/src/index.ts",
 			"./packages/pi-chrome-devtools/src/index.ts",
 			"./packages/pi-codex-compact/src/index.ts",
+			"./packages/pi-file-context/src/index.ts",
 			"./packages/pi-firecrawl/src/index.ts",
 			"./packages/pi-github-pr/src/index.ts",
 			"./packages/pi-goal/src/index.ts",

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -4,10 +4,6 @@
 [![Pi Extension](https://img.shields.io/badge/Pi-extension-blue)](https://github.com/earendil-works/pi)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> [!WARNING]
-> This extension is experimental.
-> Its interaction model and package API may change between releases.
-
 Browse project files inside Pi, select exact lines or Git changes, and review every snapshot before it is attached to the next prompt.
 
 ## ✨ Features

--- a/packages/pi-file-context/package.json
+++ b/packages/pi-file-context/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-file-context",
 	"version": "0.53.3",
-	"description": "Experimental Pi extension for attaching file ranges and Git provenance as context.",
+	"description": "Pi extension for attaching file ranges and Git provenance as context.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -26,7 +26,7 @@
 		]
 	},
 	"piExtension": {
-		"lifecycle": "experimental"
+		"lifecycle": "stable"
 	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",

--- a/packages/pi-file-context/src/file-context.ts
+++ b/packages/pi-file-context/src/file-context.ts
@@ -665,13 +665,6 @@ export async function registerFileQuoteExtension(
 		if (loadedSettings.warning && ctx.hasUI) {
 			ctx.ui.notify(escapeTerminalControls(loadedSettings.warning), "warning");
 		}
-		if (ctx.mode !== "tui") return;
-		ctx.ui.notify(
-			registeredOpenShortcut
-				? `Experimental File Context loaded. Press ${registeredOpenShortcut} to browse or run /file-context to review selected context.`
-				: "Experimental File Context loaded. Run /file-context to add or review selected context.",
-			"warning",
-		);
 	});
 
 	pi.on("before_agent_start", (_event, ctx) => {

--- a/packages/pi-file-context/test/file-context.test.ts
+++ b/packages/pi-file-context/test/file-context.test.ts
@@ -767,12 +767,14 @@ test("allows disabling the shortcut and reports settings warnings after session 
 
 	const context = createMockContext({ mode: "tui", hasUI: true });
 	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	assert.ok(context.notifications.some(({ message }) => message.includes("Invalid File Context")));
+	assert.equal(context.notifications.length, 1);
+	assert.ok(context.notifications[0]?.message.includes("Invalid File Context"));
 	assert.ok(context.notifications.every(({ message }) => !message.includes("\u001b")));
 
 	const rpc = createMockContext({ mode: "rpc", hasUI: true });
 	await mock.events.get("session_start")?.[0]?.({}, rpc.ctx);
-	assert.ok(rpc.notifications.some(({ message }) => message.includes("Invalid File Context")));
+	assert.equal(rpc.notifications.length, 1);
+	assert.ok(rpc.notifications[0]?.message.includes("Invalid File Context"));
 });
 
 test("captures an exact normalized line snapshot and formats one focused prompt", () => {


### PR DESCRIPTION
## Summary

- Promote `@narumitw/pi-file-context` from experimental to stable.
- Include its source entrypoint in root Git installations and move it into the stable extension catalog.
- Remove the experimental README and startup warnings while preserving settings warnings.
- Add a minor Changeset for the stable release.

## Verification

- `npm run check`
- `npm test` — 363 test files and 3,237 tests passed.
- `npm pack --workspace @narumitw/pi-file-context --dry-run --json`
- Isolated package Pi load smoke through `dist/index.ts`.
- Root Git package Pi load smoke through `src/index.ts`.
- Fenced-code-aware README heading audit.

## Audit

- Reviewed `docs/extension-conventions.md` and `docs/readme-conventions.md`.
- Audited lifecycle cancellation, disposal, session replacement, shutdown, and settings behavior; this promotion does not alter those flows.
- No deviations or unverified paths remain.
