### PR TITLE
fix(codex-compact): clarify API eligibility wording

### DIFF
--- a/.changeset/clear-codex-api-eligibility.md
+++ b/.changeset/clear-codex-api-eligibility.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-codex-compact": patch
+---
+
+Clarify that Remote V2 eligibility comes from the active model's `openai-codex-responses` API declaration.

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -74,7 +74,7 @@ Escape or Ctrl+C closes without compacting, and an obsolete menu cannot trigger 
 **Settings** opens the bounded settings editor.
 In non-TUI modes, the command reports the manual settings path instead of opening custom UI or compacting.
 
-Pi's built-in `/compact` remains available and follows the same extension hook when the active model is compatible.
+Pi's built-in `/compact` remains available and follows the same extension hook when the active model uses `openai-codex-responses`.
 
 ## ⚙️ Settings
 
@@ -99,7 +99,7 @@ There is no environment-variable or project-level override.
 
 | Setting | Default | Accepted values | Behavior | Recommendation |
 | --- | ---: | --- | --- | --- |
-| `enabled` | `true` | Boolean | Attempt Remote V2 for a compatible model. | Keep enabled unless diagnosing provider behavior. |
+| `enabled` | `true` | Boolean | Attempt Remote V2 when the active model uses `openai-codex-responses`. | Keep enabled unless diagnosing provider behavior. |
 | `requestTimeoutMs` | `300000` | Integer from 30,000 to 600,000 ms | Bound one extension-owned remote request. | Keep five minutes; increase only for a consistently slow connection. |
 | `maxRetries` | `2` | Integer from 0 to 2 | Retry transient provider transport failures before Pi fallback. | Keep two; use zero when diagnosing the first failure. |
 | `replacementTokenBudget` | `64000` | Integer from 8,000 to 128,000 tokens | Bound approximate retained user-message text beside the opaque item. | Keep 64K; lower it to reduce session size or raise it only when recent user context is being lost. |
@@ -191,7 +191,7 @@ src/codex-compact.ts  Pi lifecycle, command, provider projection, and fallback
 src/remote.ts         Provider stream invocation, auth payload, timeout, and retry controls
 src/protocol.ts       Bounded SSE parsing and Remote V2 payload/output validation
 src/checkpoint.ts     Replacement history, fingerprints, persistence, and replay projection
-src/model-compatibility.ts  API-based Remote V2 model eligibility
+src/model-api.ts      Codex Responses API detection for Remote V2 eligibility
 src/settings.ts       Global settings validation and atomic persistence
 src/settings-menu.ts  First-use manual compaction and settings TUI
 

--- a/packages/pi-codex-compact/src/codex-compact.ts
+++ b/packages/pi-codex-compact/src/codex-compact.ts
@@ -18,7 +18,7 @@ import {
 	latestCheckpoint,
 	projectCheckpointContext,
 } from "./checkpoint.js";
-import { isCodexRemoteCompactionModel } from "./model-compatibility.js";
+import { usesCodexResponsesApi } from "./model-api.js";
 import { hasCheckpointMarker, rewriteCheckpointMarker } from "./protocol.js";
 import { requestRemoteCompaction } from "./remote.js";
 import {
@@ -38,7 +38,7 @@ function isCheckpointCompatible(
 	details: CodexCheckpointDetails,
 	model: Model<Api> | undefined,
 ): model is Model<"openai-codex-responses"> {
-	return isCodexRemoteCompactionModel(model) && model.id === details.modelId;
+	return usesCodexResponsesApi(model) && model.id === details.modelId;
 }
 
 function keptMessages(event: SessionBeforeCompactEvent): AgentMessage[] {
@@ -105,7 +105,7 @@ async function compactRemotely(
 	fetch?: typeof globalThis.fetch,
 ) {
 	const model = ctx.model;
-	if (!settings.enabled || !isCodexRemoteCompactionModel(model)) return undefined;
+	if (!settings.enabled || !usesCodexResponsesApi(model)) return undefined;
 	const sessionId = ctx.sessionManager.getSessionId();
 	ctx.ui.setStatus(STATUS_KEY, "Codex remote compaction…");
 	try {

--- a/packages/pi-codex-compact/src/model-api.ts
+++ b/packages/pi-codex-compact/src/model-api.ts
@@ -1,7 +1,7 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { hasApi } from "@earendil-works/pi-ai";
 
-export function isCodexRemoteCompactionModel(
+export function usesCodexResponsesApi(
 	model: Model<Api> | undefined,
 ): model is Model<"openai-codex-responses"> {
 	return model !== undefined && hasApi(model, "openai-codex-responses");

--- a/packages/pi-codex-compact/src/settings-menu.ts
+++ b/packages/pi-codex-compact/src/settings-menu.ts
@@ -1,6 +1,6 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { MenuDefinition } from "@narumitw/pi-tui-kit";
-import { isCodexRemoteCompactionModel } from "./model-compatibility.js";
+import { usesCodexResponsesApi } from "./model-api.js";
 import type {
 	CodexCompactSettings,
 	CodexCompactSettingsRuntime,
@@ -23,7 +23,7 @@ export interface SettingsMenuOwner {
 
 interface CompactMenuStatus {
 	model: string;
-	remoteCompatible: boolean;
+	remoteEligible: boolean;
 }
 
 function safeText(value: string): string {
@@ -103,7 +103,7 @@ export function createCodexCompactMenu(
 					{
 						id: "enabled",
 						label: "Remote compaction",
-						description: "Use Codex Remote V2 when the active model is compatible.",
+						description: "Use Codex Remote V2 when the model uses openai-codex-responses.",
 						currentValue: state.settings.enabled ? "On" : "Off",
 						values: ["On", "Off"],
 						action: "set-enabled",
@@ -222,7 +222,7 @@ export function compactMenuStatus(ctx: ExtensionCommandContext): CompactMenuStat
 	const model = ctx.model;
 	return {
 		model: model ? `${model.provider}/${model.id}` : "none",
-		remoteCompatible: isCodexRemoteCompactionModel(model),
+		remoteEligible: usesCodexResponsesApi(model),
 	};
 }
 
@@ -231,5 +231,5 @@ function compactRoute(
 	status: CompactMenuStatus | undefined,
 ): string {
 	if (!state.settings.enabled) return "Pi native (Remote V2 off)";
-	return status?.remoteCompatible ? "Codex Remote V2" : "Pi native (model not compatible)";
+	return status?.remoteEligible ? "Codex Remote V2" : "Pi native (requires openai-codex-responses)";
 }

--- a/packages/pi-codex-compact/test/settings-menu.test.ts
+++ b/packages/pi-codex-compact/test/settings-menu.test.ts
@@ -46,15 +46,14 @@ test("root menu makes manual compaction primary and exposes its effective route"
 	const customContext = createMockContext({ model: customModel }).ctx;
 	assert.deepEqual(compactMenuStatus(customContext), {
 		model: "company-codex-proxy/gpt-5.6",
-		remoteCompatible: true,
+		remoteEligible: true,
 	});
-	assert.equal(
-		compactMenuStatus(createMockContext({ model: { ...customModel, api: "openai-responses" } }).ctx)
-			.remoteCompatible,
-		false,
+	const ineligibleStatus = compactMenuStatus(
+		createMockContext({ model: { ...customModel, api: "openai-responses" } }).ctx,
 	);
+	assert.equal(ineligibleStatus.remoteEligible, false);
 	const menu = createCodexCompactMenu(current.runtime, {
-		status: { model: "openai-codex/gpt-5.6", remoteCompatible: true },
+		status: { model: "openai-codex/gpt-5.6", remoteEligible: true },
 	});
 	assert.equal(menu.start, "main");
 	const main = resolveMenuScreen(menu, "main", current.runtime.get());
@@ -66,6 +65,14 @@ test("root menu makes manual compaction primary and exposes its effective route"
 	);
 	assert.match(main.lines?.join("\n") ?? "", /openai-codex\/gpt-5\.6/);
 	assert.match(main.lines?.join("\n") ?? "", /Codex Remote V2/);
+	const ineligible = resolveMenuScreen(
+		createCodexCompactMenu(current.runtime, { status: ineligibleStatus }),
+		"main",
+		current.runtime.get(),
+	);
+	assert.equal(ineligible.kind, "actions");
+	if (ineligible.kind !== "actions") assert.fail("Expected ineligible actions screen");
+	assert.match(ineligible.lines?.join("\n") ?? "", /Pi native \(requires openai-codex-responses\)/);
 	const disabled = resolveMenuScreen(menu, "main", {
 		...current.runtime.get(),
 		settings: { ...current.runtime.get().settings, enabled: false },


### PR DESCRIPTION
## Summary

- rename the shared model predicate to `usesCodexResponsesApi` and its module to `model-api.ts`
- describe the menu gate as Remote V2 eligibility instead of verified model compatibility
- show the exact `openai-codex-responses` requirement in the menu and README
- add a patch changeset and cover the ineligible route label

## Verification

- `npm --workspace @narumitw/pi-codex-compact run check`
- `npx vitest run packages/pi-codex-compact/test/settings-menu.test.ts packages/pi-codex-compact/test/lifecycle.test.ts`
- `npm run check`
- `npm test` (364 files, 3240 tests)
- fenced-code-aware README heading audit
- `npm --workspace @narumitw/pi-codex-compact pack --dry-run --json`
- `PI_OFFLINE=1 pi --no-extensions -e ./packages/pi-codex-compact --list-models`

## Convention audit

Reviewed against `docs/extension-conventions.md` and `docs/readme-conventions.md`.
The change does not alter settings persistence, asynchronous UI ownership, cancellation, disposal, session replacement, or shutdown behavior.
