### PR TITLE
refactor: remove unused plan and goal helpers

### DIFF
--- a/packages/pi-goal/src/persistence.ts
+++ b/packages/pi-goal/src/persistence.ts
@@ -82,12 +82,6 @@ export function loadGoalStateFromSession(ctx: SessionContext): LoadedGoalState {
 	return legacyEntry ? loadLegacyGoalsState(legacyEntry.data) : emptyGoalState("none");
 }
 
-export function loadGoalFromSession(ctx: SessionContext): ActiveGoal | undefined {
-	const loaded = loadGoalStateFromSession(ctx);
-	if (loaded.legacyQueueState || loaded.goal?.status === "complete") return undefined;
-	return loaded.goal;
-}
-
 function loadCanonicalGoalState(data: unknown): LoadedGoalState {
 	if (!isRecord(data)) return emptyGoalState("canonical");
 	const rawGoal = data.goal;

--- a/packages/pi-goal/src/settings-ui.ts
+++ b/packages/pi-goal/src/settings-ui.ts
@@ -389,10 +389,6 @@ export function parseGoalLimit(value: string): number | undefined {
 	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
-export function formatGoalLimit(value: number | null) {
-	return value === null ? "Unlimited" : String(value);
-}
-
 async function resolveLimitSelection(
 	field: LimitField,
 	selection: LimitSelection,

--- a/packages/pi-goal/test/settings-ui.test.ts
+++ b/packages/pi-goal/test/settings-ui.test.ts
@@ -7,12 +7,7 @@ import { createMockContext, createMockPi } from "../../../test/support.js";
 import { GoalCommandController } from "../src/commands.js";
 import { createGoal, GoalRuntime } from "../src/runtime.js";
 import { DEFAULT_GOAL_SETTINGS, type GoalSettings } from "../src/settings.js";
-import {
-	applyGoalSettings,
-	formatGoalLimit,
-	parseGoalLimit,
-	showGoalSettings,
-} from "../src/settings-ui.js";
+import { applyGoalSettings, parseGoalLimit, showGoalSettings } from "../src/settings-ui.js";
 
 initTheme("dark", false);
 
@@ -48,8 +43,6 @@ test("goal setting custom limits accept only safe whole numbers greater than zer
 	]) {
 		assert.equal(parseGoalLimit(invalid), undefined);
 	}
-	assert.equal(formatGoalLimit(25), "25");
-	assert.equal(formatGoalLimit(null), "Unlimited");
 });
 
 test("applyGoalSettings saves before committing runtime settings and enforces lower limits", () => {

--- a/packages/pi-plan-mode/src/extension-runtime.ts
+++ b/packages/pi-plan-mode/src/extension-runtime.ts
@@ -1,20 +1,3 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { PlanModeFixedThinkingLevel } from "./settings.js";
-
-type AgentSettledHandler = (event: unknown, ctx: ExtensionContext) => unknown;
-
-export function onAgentSettled(pi: ExtensionAPI, handler: AgentSettledHandler) {
-	(
-		pi as unknown as {
-			on(event: "agent_settled", callback: AgentSettledHandler): void;
-		}
-	).on("agent_settled", handler);
-}
-
-export function setPlanThinkingLevel(pi: ExtensionAPI, level: PlanModeFixedThinkingLevel) {
-	(pi.setThinkingLevel as unknown as (level: PlanModeFixedThinkingLevel) => void)(level);
-}
-
 export function isStaleExtensionContextError(error: unknown) {
 	return (
 		error instanceof Error &&

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -14,11 +14,7 @@ import {
 	planModeCompleted,
 	renderPlanModeCompletion,
 } from "./completion-tool.js";
-import {
-	isStaleExtensionContextError,
-	onAgentSettled,
-	setPlanThinkingLevel,
-} from "./extension-runtime.js";
+import { isStaleExtensionContextError } from "./extension-runtime.js";
 import {
 	createFinalizationRequestCoordinator,
 	FINALIZE_PLAN_PROMPT,
@@ -671,7 +667,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		acceptCompletedPlan(parsedPlan.plan, "legacy_proposed_plan", ctx);
 	});
 
-	onAgentSettled(pi, async (_event, ctx) => {
+	pi.on("agent_settled", async (_event, ctx) => {
 		const settledImplementationId = implementationRetention.implementationSettled(
 			state.activeImplementation,
 		);
@@ -1279,7 +1275,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	function applyPlanThinkingLevel() {
 		if (state.manualThinkingLevel) {
 			if (pi.getThinkingLevel() !== state.manualThinkingLevel) {
-				setPlanThinkingLevel(pi, state.manualThinkingLevel);
+				pi.setThinkingLevel(state.manualThinkingLevel);
 			}
 			return;
 		}
@@ -1294,7 +1290,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 		const current = pi.getThinkingLevel();
 		if (!state.appliedThinkingLevel) state.previousThinkingLevel = current;
-		if (current !== configured) setPlanThinkingLevel(pi, configured);
+		if (current !== configured) pi.setThinkingLevel(configured);
 		state.appliedThinkingLevel = pi.getThinkingLevel();
 	}
 
@@ -1318,7 +1314,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			previousThinkingLevel &&
 			pi.getThinkingLevel() === appliedThinkingLevel
 		) {
-			setPlanThinkingLevel(pi, previousThinkingLevel);
+			pi.setThinkingLevel(previousThinkingLevel);
 		}
 		state = { ...state, appliedThinkingLevel: undefined, previousThinkingLevel: undefined };
 	}
@@ -1468,6 +1464,6 @@ export {
 } from "./mode-contract.js";
 export { buildPlanModePrompt } from "./prompt.js";
 export { normalizePlanModeQuestionParams } from "./question-tool.js";
-export { withoutPlanModeQuestionTool, withRequiredPlanModeTools } from "./required-tools.js";
+export { withRequiredPlanModeTools } from "./required-tools.js";
 export { normalizePlanModeSettings, readPlanModeSettings } from "./settings.js";
 export { canSelectToolInPlanMode, classifyPlanModeTool, isSafeCommand } from "./tool-policy.js";

--- a/packages/pi-plan-mode/src/required-tools.ts
+++ b/packages/pi-plan-mode/src/required-tools.ts
@@ -10,10 +10,6 @@ export function withRequiredPlanModeTools(toolNames: string[]) {
 	]);
 }
 
-export function withoutPlanModeQuestionTool(toolNames: string[]) {
-	return toolNames.filter((toolName) => toolName !== PLAN_MODE_QUESTION_TOOL_NAME);
-}
-
 export function withoutRequiredPlanModeTools(toolNames: string[]) {
 	return toolNames.filter(
 		(toolName) =>

--- a/packages/pi-plan-mode/test/tool-policy.test.ts
+++ b/packages/pi-plan-mode/test/tool-policy.test.ts
@@ -10,7 +10,6 @@ import planMode, {
 	canSelectToolInPlanMode,
 	classifyPlanModeTool,
 	isSafeCommand,
-	withoutPlanModeQuestionTool,
 	withRequiredPlanModeTools,
 } from "../src/plan-mode.js";
 import { findBlockedCommandSegment } from "../src/tool-policy.js";
@@ -26,7 +25,6 @@ test("tool selection allows safe built-ins and non-built-ins only", () => {
 		"plan_mode_question",
 		"plan_mode_complete",
 	]);
-	assert.deepEqual(withoutPlanModeQuestionTool(["read", "plan_mode_question"]), ["read"]);
 });
 
 test("isSafeCommand permits read-only command lists and rejects shell mutation", () => {


### PR DESCRIPTION
## Summary

- use Pi's typed `agent_settled` and thinking-level APIs directly in pi-plan-mode
- remove unreachable Plan tool-selection and Goal persistence helpers
- remove a Goal settings formatter and its self-contained assertions because no product path used it

The generated runtimes remain unchanged after rebuilding, so this is source and test cleanup only.
No Changeset is included because published behavior does not change.

## Verification

- `npm --workspace @narumitw/pi-plan-mode run check`
- `npm --workspace @narumitw/pi-goal run check`
- `npm run check`
- `npm test` (364 files, 3240 tests)
