### PR TITLE
feat(plan-mode)!: remove startup flag

### DIFF
--- a/.changeset/remove-plan-startup-flag.md
+++ b/.changeset/remove-plan-startup-flag.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Remove the `--plan` startup flag. Start Plan mode after launch with `/plan start` or begin with a prompt through `/plan <prompt>`.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -8,7 +8,7 @@ This independently installable extension adds a Codex-like `/plan` collaboration
 
 ## ✨ Features
 
-- Starts and manages Plan mode through `/plan`, `/plan <prompt>`, or the `--plan` startup flag.
+- Starts and manages Plan mode through `/plan`, `/plan start`, or `/plan <prompt>`.
 - Keeps one stable model-visible tool envelope while a runtime Plan policy blocks mutations and unsafe shell forms.
 - Requires structured questions for important ambiguity and explicit completion for a decision-ready plan.
 - Reviews the complete plan before implementation, export, save, continued planning, or discard.
@@ -92,7 +92,7 @@ Launch-menu policy changes remain a draft until **Done — start with this polic
 Use `/plan start` when you want to enter Plan mode directly without sending a model message.
 Use `/plan <prompt>` to enter Plan mode and immediately submit `<prompt>` as the first Plan-mode user message.
 The exact argument `start` is reserved for direct activation; longer text such as `/plan start a migration` remains an inline planning prompt.
-`--plan` also remains a direct activation path.
+The extension does not register a startup flag; run `/plan start` after launch for direct activation.
 
 Use **Choose tools, then start…** or the `/plan tools` compatibility shortcut to choose a session-specific Plan policy override before Planning starts.
 Both routes use the same draft selector: **Done — start with this policy** stores the allowlist and starts the workflow, while cancellation leaves Plan mode off and changes nothing.
@@ -198,7 +198,7 @@ The destination still loads its normal `AGENTS.md`, skills, project resources, a
 Choosing **Export plan…** asks for a destination, writes the plan, appends the Normal contract, restores inherited thinking, and leaves Plan mode without starting a model turn or changing active tools.
 Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session before leaving Plan mode.
 
-When a workflow was started only with `--plan` and no `/plan` command has run in that session, the automatic menu cannot obtain Pi's command-only session replacement capability; choosing fresh asks you to reopen `/plan`, where the same action is available.
+When a resumed active Plan workflow completes before `/plan` has run in that resumed session, the automatic menu cannot obtain Pi's command-only session replacement capability; choosing fresh asks you to reopen `/plan`, where the same action is available.
 A successful fresh handoff does not delete or consume the source planning session.
 Resume it later to inspect or hand off the ready/saved plan again; this deliberate duplication is the recovery path if the destination work is abandoned.
 In-memory sessions create an unlinked fresh session because no parent file exists.
@@ -214,7 +214,7 @@ It does not expire automatically, cross into a new session, or participate in or
 Open `/plan` to Show, Implement here, Start fresh and implement, Export, open Settings, or Clear it; `/plan show`, `/plan implement`, `/plan export [path]`, and `/plan exit`/`off` retain their direct routes in TUI and RPC.
 Fresh implementation checks idle state, the selected model, and authentication before session replacement; Implement here keeps its established preflight behavior.
 Starting another workflow with `/plan start`, `/plan <prompt>`, or `/plan tools` is blocked until the saved plan is implemented or cleared, so the single saved slot is never silently overwritten.
-Resuming that session with `--plan` moves the saved plan back to ready Plan mode.
+Resuming that session keeps the plan saved; open `/plan` to review, implement, export, or clear it.
 Cancellation or failed implementation preflight leaves it unchanged.
 
 Text print and JSON modes cannot display the bare `/plan` menu and reject that route before changing state; use `/plan start` for direct no-prompt activation or `/plan <prompt>` to start planning with a prompt.

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -177,12 +177,6 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		},
 	});
 
-	pi.registerFlag("plan", {
-		description: "Start in Codex-like Plan mode",
-		type: "boolean",
-		default: false,
-	});
-
 	pi.registerTool({
 		name: PLAN_MODE_QUESTION_TOOL_NAME,
 		label: "Plan question",
@@ -462,23 +456,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		await applyPlanModeSettings(generation, ctx, true);
 		if (generation !== menuGeneration || menuController.signal.aborted) return;
 		startPlanModeSettingsWatch(generation);
-		const persistFlagActivation = pi.getFlag("plan") === true && !restoredState.enabled;
-		const candidate = persistFlagActivation
-			? restoredState.savedPlan
-				? {
-						...restoredState,
-						enabled: true,
-						latestPlan: restoredState.savedPlan.plan,
-						latestPlanSource: restoredState.savedPlan.source,
-						awaitingAction: true,
-						savedPlan: undefined,
-						activeImplementation: undefined,
-					}
-				: { ...restoredState, enabled: true, activeImplementation: undefined }
-			: restoredState;
-		if (!installRestoredState(candidate, ctx)) return;
+		if (!installRestoredState(restoredState, ctx)) return;
 		implementationRetention.restore(state.activeImplementation);
-		if (persistFlagActivation && state.enabled) persistState();
 		updateUi(ctx);
 	});
 

--- a/packages/pi-plan-mode/test/generated-entry.test.ts
+++ b/packages/pi-plan-mode/test/generated-entry.test.ts
@@ -21,6 +21,7 @@ test("declared generated entry preserves registration and partial lifecycle clea
 		const { default: extension } = await import("../dist/index.js");
 		const mock = createMockPi();
 		await extension(mock.pi);
+		assert.equal(mock.flags.has("plan"), false);
 		assert.ok(mock.commands.has("plan"));
 		assert.ok(mock.events.has("session_start"));
 		assert.ok(mock.events.has("session_shutdown"));

--- a/packages/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-471-repro.test.ts
@@ -757,38 +757,6 @@ test("a superseded session start cannot publish stale settings or UI state", asy
 	assert.deepEqual(transformed.messages, [{ role: "branchSummary", summary: "current session" }]);
 });
 
-test("the --plan flag supersedes a resumed active implementation", async () => {
-	const activeImplementation: ActiveImplementationPlan = {
-		id: "implementation-1",
-		plan: PLAN,
-		source: "plan_mode_complete",
-		startedAt: 42,
-	};
-	const resumedEntry = stateEntry({
-		enabled: false,
-		awaitingAction: false,
-		activeImplementation,
-	});
-	const mock = createMockPi({ activeTools: ["read", "edit"] });
-	planMode(mock.pi);
-	const planFlag = mock.flags.get("plan");
-	assert.ok(planFlag);
-	planFlag.value = true;
-	const context = createMockContext({
-		sessionManager: {
-			getBranch: () => [resumedEntry],
-			getEntries: () => [resumedEntry],
-		},
-	});
-
-	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	assert.equal(context.statuses.get("plan-mode"), "plan active");
-	assert.equal(latestState(mock.entries)?.enabled, true);
-	assert.equal(latestState(mock.entries)?.activeImplementation, undefined);
-	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
-	assert.equal(latestState(mock.entries)?.activeImplementation, undefined);
-});
-
 test("resume and shutdown retain branch-local implementation state while clearing session UI", async () => {
 	const activeImplementation: ActiveImplementationPlan = {
 		id: "implementation-1",

--- a/packages/pi-plan-mode/test/plan-mode.test.ts
+++ b/packages/pi-plan-mode/test/plan-mode.test.ts
@@ -17,11 +17,11 @@ import planMode, {
 	stripProposedPlanBlocksFromMessage,
 } from "../src/plan-mode.js";
 
-test("plan-mode registers flag, question tool, command, and safety hooks", () => {
+test("plan-mode registers question tools, command, and safety hooks without a CLI flag", () => {
 	const mock = createMockPi({ activeTools: ["read", "bash"] });
 	planMode(mock.pi);
 
-	assert.ok(mock.flags.has("plan"));
+	assert.equal(mock.flags.has("plan"), false);
 	assert.deepEqual(
 		mock.tools.map((tool) => tool.name),
 		["plan_mode_question", "plan_mode_complete"],

--- a/packages/pi-plan-mode/test/saved-plan.test.ts
+++ b/packages/pi-plan-mode/test/saved-plan.test.ts
@@ -422,7 +422,7 @@ test("saved Plan implementation preflight retains state on auth failure or sessi
 	assert.equal(latestState(replaced.entries)?.savedPlan?.plan, PLAN);
 });
 
-test("saved Plan blocks replacement workflows and --plan restores it as ready", async () => {
+test("saved Plan survives resume and blocks replacement workflows", async () => {
 	const savedEntry = stateEntry({
 		enabled: false,
 		awaitingAction: false,
@@ -452,28 +452,6 @@ test("saved Plan blocks replacement workflows and --plan restores it as ready", 
 	assert.match(context.notifications.at(-1)?.message ?? "", /implement or clear/i);
 	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
 	assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
-
-	const flagged = createMockPi({ activeTools: ["read", "edit"] });
-	planMode(flagged.pi);
-	const flag = flagged.flags.get("plan");
-	assert.ok(flag);
-	flag.value = true;
-	const flaggedContext = createMockContext({
-		sessionManager: {
-			getBranch: () => [savedEntry],
-			getEntries: () => [savedEntry],
-		},
-	});
-	await flagged.events.get("session_start")?.[0]?.({}, flaggedContext.ctx);
-	assert.equal(flaggedContext.statuses.get("plan-mode"), "plan ready");
-	assert.equal(latestState(flagged.entries)?.latestPlan, PLAN);
-	assert.equal(latestState(flagged.entries)?.savedPlan, undefined);
-	assert.deepEqual(flagged.rawPi.getActiveTools(), [
-		"read",
-		"edit",
-		"plan_mode_question",
-		"plan_mode_complete",
-	]);
 });
 
 test("saved Plan no-UI management is observable without changing state", async () => {

--- a/packages/pi-plan-mode/test/workflow-mutex.test.ts
+++ b/packages/pi-plan-mode/test/workflow-mutex.test.ts
@@ -241,49 +241,39 @@ test("busy direct starts preserve state in every command mode", async () => {
 	}
 });
 
-test("busy restored and --plan activation performs only the startup envelope write", async () => {
-	for (const restoredData of [
-		{ enabled: true, awaitingAction: false },
-		{ enabled: false, awaitingAction: false },
-	]) {
-		const entry = persistedPlanState(restoredData);
-		const sessionManager = { getBranch: () => [entry], getEntries: () => [entry] };
-		const mock = createMockPi({ activeTools: ["goal_complete"], thinkingLevel: "high" });
-		let activeToolWrites = 0;
-		const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
-		mock.rawPi.setActiveTools = (names) => {
-			activeToolWrites += 1;
-			setActiveTools(names);
-		};
-		blockAgentWorkflow(mock, sessionManager);
-		planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
-		if (!restoredData.enabled) {
-			const flag = mock.flags.get("plan");
-			assert.ok(flag);
-			flag.value = true;
-		}
-		const context = createMockContext({ mode: "tui", hasUI: true, sessionManager });
+test("busy restored activation performs only the startup envelope write", async () => {
+	const entry = persistedPlanState({ enabled: true, awaitingAction: false });
+	const sessionManager = { getBranch: () => [entry], getEntries: () => [entry] };
+	const mock = createMockPi({ activeTools: ["goal_complete"], thinkingLevel: "high" });
+	let activeToolWrites = 0;
+	const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+	mock.rawPi.setActiveTools = (names) => {
+		activeToolWrites += 1;
+		setActiveTools(names);
+	};
+	blockAgentWorkflow(mock, sessionManager);
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({ mode: "tui", hasUI: true, sessionManager });
 
-		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
-		assert.equal(activeToolWrites, 1);
-		assert.deepEqual(mock.rawPi.getActiveTools(), [
-			"goal_complete",
-			"plan_mode_question",
-			"plan_mode_complete",
-		]);
-		assert.equal(mock.thinkingLevel, "high");
-		assert.equal(mock.thinkingLevels.length, 0);
-		assert.equal(mock.entries.length, 0);
-		assert.equal(context.statuses.get("plan-mode"), undefined);
-		assert.match(context.notifications[0]?.message ?? "", /was not restored/u);
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	assert.equal(activeToolWrites, 1);
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"goal_complete",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
+	assert.equal(mock.thinkingLevel, "high");
+	assert.equal(mock.thinkingLevels.length, 0);
+	assert.equal(mock.entries.length, 0);
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+	assert.match(context.notifications[0]?.message ?? "", /was not restored/u);
 
-		const beforeStart = await mock.events.get("before_agent_start")?.[0]?.(
-			{ systemPrompt: "base", prompt: "continue" },
-			context.ctx,
-		);
-		assert.equal(beforeStart, undefined);
-		assert.equal(mock.sentUserMessages.length, 0);
-	}
+	const beforeStart = await mock.events.get("before_agent_start")?.[0]?.(
+		{ systemPrompt: "base", prompt: "continue" },
+		context.ctx,
+	);
+	assert.equal(beforeStart, undefined);
+	assert.equal(mock.sentUserMessages.length, 0);
 });
 
 test("busy menu, selected-tool, shortcut, and active-implementation starts stay atomic", async () => {

--- a/test/plan-goal-coexistence.test.ts
+++ b/test/plan-goal-coexistence.test.ts
@@ -349,17 +349,13 @@ test("Plan holder rejects managed-run Goal activation with one terminal error", 
 	assertOneHolder(fixture);
 });
 
-test("restored Goal rejects --plan startup activation without a Plan commit", async () => {
-	const branch = [goalEntry(activeGoal("flag-holder"))];
+test("restored Goal leaves inactive Plan state uncommitted", async () => {
+	const branch = [goalEntry(activeGoal("restored-holder"))];
 	const fixture = createFixture("goal-first", { branch });
-	const flag = fixture.mock.flags.get("plan");
-	assert.ok(flag);
-	flag.value = true;
 	await startSession(fixture, "resume");
 	assert.equal(goalStatus(fixture.mock.entries), "active");
 	assert.equal(latestStateEntry(fixture.mock.entries, "plan-mode-state"), undefined);
 	assert.equal(fixture.context.statuses.get("plan-mode"), undefined);
-	assert.match(fixture.context.notifications.at(-1)?.message ?? "", /was not restored/u);
 	assertOneHolder(fixture);
 });
 


### PR DESCRIPTION
## Summary

- remove the `--plan` extension flag and its `session_start` activation path
- preserve saved plans and active implementation state exactly as stored on resume
- update flag-specific unit, generated-entry, and Plan/Goal coexistence coverage
- document `/plan start` and `/plan <prompt>` as the supported migration and add a minor Changeset

## History and migration

`--plan` shipped with the original extension in `d5435c65` on 2026-05-17.
After this change, Pi reports `Unknown option: --plan`.
Use `/plan start` after launch for no-prompt activation, or `/plan <prompt>` to activate and send the first planning request.

## Verification

- `npm --workspace @narumitw/pi-plan-mode run check`
- focused pi-plan-mode and Plan/Goal coexistence tests (240 tests)
- `npm run check`
- `npm test` (364 files, 3239 tests)
- `just pack plan-mode` and tarball inspection
- isolated Pi smoke: generated package entry accepts `/plan start` with exit 0
- isolated Pi smoke: `--plan` exits 1 with `Unknown option: --plan`
