### PR TITLE
feat(plan-mode): add lazy helper visibility

### DIFF
--- a/.changeset/lazy-plans-reveal-tools.md
+++ b/.changeset/lazy-plans-reveal-tools.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Add configurable Plan helper visibility and default to revealing the helper tools on the first successful Plan activation.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -9,7 +9,7 @@ This independently installable extension adds a Codex-like `/plan` collaboration
 ## ✨ Features
 
 - Starts and manages Plan mode through `/plan`, `/plan start`, or `/plan <prompt>`.
-- Keeps one stable model-visible tool envelope while a runtime Plan policy blocks mutations and unsafe shell forms.
+- Defers Plan helper schemas until first use by default, then keeps the unlocked tool envelope stable while runtime policy blocks mutations and unsafe shell forms.
 - Requires structured questions for important ambiguity and explicit completion for a decision-ready plan.
 - Reviews the complete plan before implementation, export, save, continued planning, or discard.
 - Starts implementation in the planning session or a fresh linked session with the exact approved plan.
@@ -60,11 +60,13 @@ An inactive legacy state entry alone does not inject a Normal contract, so sessi
 Manual `/tree` navigation restores branch-owned Plan state and chooses the matching effective contract without navigating automatically or adding a branch summary.
 Pi currently lists hidden custom transition messages in `/tree`; Plan mode rejects those internal targets, so select an adjacent conversation entry instead.
 
-The extension keeps its base system prompt and ordered startup tool definitions unchanged across start, off, exit, save, export, and implementation transitions.
-This makes the reusable provider prefix stable; it does not guarantee a cache hit.
-Provider serialization, cache lifetime, minimum cacheable prefix, implementation details, and session affinity still control reuse.
+The default `toolVisibility: "after-first-plan"` keeps `plan_mode_question` and `plan_mode_complete` registered but inactive until the first successful Plan activation in an extension runtime.
+That activation appends the two helpers in canonical order and may cause one provider-prefix cache miss because `/plan` is a slash-command transition rather than a model-called deferred-tool loader.
+The helpers and their active-only prompt metadata remain visible after that boundary across off, exit, save, export, implementation, and same-runtime session starts.
+Failed, cancelled, stale, or workflow-busy activation restores the exact prior active-tool list and does not consume the first-activation boundary.
+Choose `toolVisibility: "always"` to expose both helpers at session startup and preserve the previous stable-prefix behavior from the first request.
+Neither choice guarantees a cache hit because provider serialization, cache lifetime, minimum cacheable prefix, implementation details, and session affinity still control reuse.
 A user, Pi, or another extension can change the active tool set outside this extension's guarantee.
-Upgrading an older session may incur one initial miss because the two Plan helper definitions become part of the always-active startup envelope.
 
 The default `thinkingLevel: "inherit"` path also avoids a Plan-specific reasoning-parameter change.
 Choosing a fixed Plan thinking level remains supported, but switching reasoning parameters can prevent provider-side state reuse even when system instructions and tool schemas are stable.
@@ -118,7 +120,7 @@ Relative paths resolve from the command's current `ctx.cwd` at export time, abso
 Explicit `/plan export <path>` input always wins over the setting.
 Export never overwrites an existing file, directory, or symbolic link: choose another path or remove the existing target first.
 A successful export adds one trailing newline but otherwise preserves the accepted Markdown exactly.
-After a ready plan is written, Plan mode ends, its thinking level is restored, the stable tool envelope is retained, and the ready state is cleared without starting a model turn.
+After a ready plan is written, Plan mode ends, its thinking level is restored, the current helper visibility is retained, and the ready state is cleared without starting a model turn.
 Exporting a saved or active implementation plan leaves that state unchanged.
 Failed or cancelled exports leave every Plan-mode state unchanged.
 The resulting file is available to the agent through its normal file-reading tools.
@@ -137,14 +139,15 @@ The agent may inspect files and run read-only commands, but it should not edit f
 It should explore first, then use structured questions when your preference or a tradeoff materially changes the plan.
 Configure persistent defaults or a one-workflow tool override before activation; Planning and ready menus deliberately keep those controls locked.
 
-At `session_start`, Plan mode appends `plan_mode_question` and `plan_mode_complete` once, in that order, to Pi's existing active tool names.
-The resulting ordered names and definitions remain model-visible in both Normal and Plan mode.
-Plan transitions never call `setActiveTools()`.
+Plan mode registers `plan_mode_question` and `plan_mode_complete` during extension load.
+With the default **After first plan** visibility, `session_start` leaves both helpers inactive until the first admitted Plan workflow appends them in that order.
+With **Always**, `session_start` appends missing helpers in the same canonical order.
+Once revealed, ordinary Plan transitions never remove them during that extension runtime.
 By default, the Plan policy allows active safe built-ins such as `read`, limited `bash`, `grep`, `find`, and `ls`.
 Built-in `edit` and `write`, `update_plan`, inactive tools, and deselected tools are blocked at execution time even though active schemas remain visible.
 Extension and custom tools are denied by default because Pi tools do not expose standardized mutability metadata; allow an already active custom tool before starting only when you accept the risk.
 For example, you can opt into an active `firecrawl_scrape`, `firecrawl_search`, or `lsp_diagnostics` tool when you want to use it during planning.
-The Plan-only helpers remain visible in Normal mode, but their handlers and the `tool_call` policy reject calls unless Plan mode owns the active workflow.
+After they become visible, the Plan-only helpers remain visible in Normal mode, but their handlers and the `tool_call` policy reject calls unless Plan mode owns the active workflow.
 
 Limited `bash` uses a fail-closed policy, including when an extension overrides the canonical `bash` tool name.
 It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`.
@@ -273,11 +276,11 @@ Saved plans and ordinary implementation after Plan handoff do not hold the group
 Every inactive start performs one final synchronous admission after asynchronous preflight and before changing Plan state, persistence, prompts, tools, thinking level, queues, or status.
 If another participant is active, TUI and RPC show an anonymous warning that another workflow is active.
 Print and JSON direct routes throw the same anonymous error before mutation.
-Launch-menu, selected-tool, shortcut, startup-flag, active-implementation **Start a new plan**, and restored activation use the same admission boundary.
+Launch-menu, selected-tool, shortcut, active-implementation **Start a new plan**, and restored activation use the same admission boundary.
 A rejected selected-tool launch does not save its draft choices.
 
 Restored active Plan state acquires before restoring restrictive tools, thinking, status, or model hooks.
-If restoration is busy, Plan mode stays non-running, leaves persisted history untouched, performs no tool change beyond the session-start helper envelope, and requires a later reload or explicit new start after the other workflow ends.
+If restoration is busy, Plan mode stays non-running, leaves persisted history and active tools untouched, and requires a later reload or explicit new start after the other workflow ends.
 Planning-session cancellation during a fresh implementation preflight keeps the source Plan and its ownership.
 Successful session replacement relies on source-session shutdown to clean up and release; the destination's ordinary active implementation does not acquire the Plan mutex.
 
@@ -299,7 +302,7 @@ Guaranteed coexistence with Goal requires `@narumitw/pi-goal` `0.53.0` or newer 
 
 ## ⚙️ Settings
 
-Open **Settings** from an inactive `/plan` menu to edit one flat group of five workflow choices: **Plan thinking**, **Plan policy tools**, **Plan reinjection**, **Export destination**, and **Plan mode shortcut**.
+Open **Settings** from an inactive `/plan` menu to edit one flat group of six workflow choices: **Plan thinking**, **Plan policy tools**, **Plan reinjection**, **Export destination**, **Plan mode shortcut**, and **Plan tools**.
 You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually.
 `safeSubcommands` remains JSON-only.
 You can change the Plan-mode shortcut with `toggleShortcut` as long as the file remains JSON-only and uses a valid key string.
@@ -308,6 +311,7 @@ When omitted, the shortcut is disabled by default.
 ```json
 {
   "thinkingLevel": "inherit",
+  "toolVisibility": "after-first-plan",
   "defaultPlanTools": ["read", "bash", "grep", "find", "ls"],
   "implementationPlanRetention": "clear-on-start",
   "defaultPlanExportPath": "PLAN.md",
@@ -319,6 +323,18 @@ When omitted, the shortcut is disabled by default.
 }
 ```
 
+### Plan helper visibility
+
+`toolVisibility` accepts `"after-first-plan"` or `"always"`.
+Omit it—or choose **After first plan**—to keep both Plan helpers out of model requests until the first successful Plan activation in that extension runtime.
+A successful activation keeps the helpers visible for the rest of that runtime; changing the setting back to **After first plan** while inactive resets and hides them at an idle, mutex-admitted boundary.
+Choose **Always** to make the helpers model-visible at session startup and avoid the lazy first-use prefix change.
+Settings-menu changes apply and persist immediately only after idle and Workflow Mutex admission; failure restores the prior runtime and displayed value.
+Manual file changes reload automatically and apply visibility when the session is inactive, idle, and mutex-admitted.
+An unsafe manual reload keeps the current tool envelope until the next session start or successful Plan activation.
+A restored active Plan reveals its helpers only after acquiring workflow ownership, while a busy restore leaves active tools untouched.
+This setting uses ordinary active-tool activation and does not claim Pi native deferred loading.
+
 ### Default Plan policy tools
 
 `defaultPlanTools` defines the initial runtime allowlist when a session has no stored pre-start selection.
@@ -329,7 +345,7 @@ Neither setting changes model-visible tool schemas.
 Tool names must be non-empty strings; duplicates are removed in first-seen order.
 Unknown, inactive, and Plan-mode-blocked names are unavailable to the policy and never become active merely by entering Plan mode.
 Settings retains configured inactive names and shows them as unavailable; resetting to automatic removes the entire override.
-A tool registered or activated after the startup baseline is outside the current workflow policy; start a later session to include it in this extension's stable envelope guarantee.
+An ordinary tool registered or activated after the startup baseline is outside the current workflow policy; start a later session to include it in the selectable baseline.
 Non-built-in names in this global setting are an explicit user-risk opt-in, just like selecting them in the pre-start workflow selector.
 Plan mode does not interpret a selected custom tool's arguments or actions: allowing one trusts the whole effective tool.
 Pi resolves tools by name, so if an extension overrides a built-in name, the effective extension tool is selected instead.
@@ -440,7 +456,7 @@ A missing file stays absent until an explicit save.
 Invalid JSON, invalid values, oversized content, non-regular files, and read failures make Settings read-only; the existing bytes and previous effective settings remain.
 This in-process queue is not a cross-process lock, so concurrent separate Pi processes can still race.
 
-Invalid settings produce a warning and fall back to inherited thinking, available safe-built-in tool defaults, `clear-on-start`, and `PLAN.md`.
+Invalid settings produce a warning and fall back to inherited thinking, `after-first-plan` helper visibility, available safe-built-in tool defaults, `clear-on-start`, and `PLAN.md`.
 Compatibility: a valid legacy `plan-mode.json` remains readable with a warning and is never modified automatically.
 If Settings is explicitly saved while only that legacy file exists, the extension creates canonical `pi-plan-mode.json` from the complete legacy document, applies the selected change, preserves unknown fields, and leaves the legacy file untouched.
 If both files exist, the canonical filename takes precedence.
@@ -454,10 +470,10 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 - The agent should use `plan_mode_question` for important non-discoverable preferences or tradeoffs before finalizing.
 - The agent completes with a standalone `plan_mode_complete` tool call instead of relying on semantic prose detection.
 - `update_plan` checklist use is blocked while Plan mode is active.
-- The implementation boundary is explicit: Plan mode appends the Normal contract and lifts its runtime allowlist before saving or starting implementation, while the session tool envelope remains stable.
+- The implementation boundary is explicit: Plan mode appends the Normal contract and lifts its runtime allowlist before saving or starting implementation, while revealed helpers remain active.
 - The default `clear-on-start` policy follows Codex by using ordinary conversation history only; `clear-after-first-run` and `keep` add explicit exact-plan guarantees.
 - Pi extension safety is approximated with tool classification and fail-closed filtering for every effective tool named `bash`; other non-built-in tools remain user-selected at user risk because Pi does not expose standardized tool mutability metadata.
-- Plan and Normal instructions are append-only conversation contracts while the base system prompt and tool schemas stay stable; providers can therefore reuse the retained prefix when their own cache rules permit it.
+- Plan and Normal instructions are append-only conversation contracts; **Always** keeps tool schemas stable from startup, while **After first plan** intentionally changes the helper schema and prompt-metadata prefix once before keeping it stable.
 - Unlike native Codex, this extension uses a terminating Pi tool plus an `agent_settled` ready flow; Pi cannot provide sandbox-level enforcement.
 
 ## 🗂️ Package layout

--- a/packages/pi-plan-mode/src/helper-tool-visibility.ts
+++ b/packages/pi-plan-mode/src/helper-tool-visibility.ts
@@ -1,0 +1,142 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { PLAN_MODE_COMPLETE_TOOL_NAME } from "./completion-tool.js";
+import { PLAN_MODE_QUESTION_TOOL_NAME } from "./question-tool.js";
+import type { PlanModeToolVisibility } from "./settings.js";
+
+export const PLAN_MODE_HELPER_TOOL_NAMES = [
+	PLAN_MODE_QUESTION_TOOL_NAME,
+	PLAN_MODE_COMPLETE_TOOL_NAME,
+] as const;
+
+export interface PlanModeHelperVisibilitySnapshot {
+	activeTools: string[];
+	helperToolsUnlocked: boolean;
+	helperToolsHiddenByPolicy: string[];
+}
+
+interface ToolVisibilityContext {
+	isIdle?: () => boolean;
+}
+
+export class PlanModeHelperVisibilityPolicy {
+	private unlocked = false;
+	private readonly hiddenByPolicy = new Set<string>();
+
+	constructor(private readonly pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools">) {}
+
+	isUnlocked() {
+		return this.unlocked;
+	}
+
+	hasHiddenTools() {
+		return this.hiddenByPolicy.size > 0;
+	}
+
+	toolsAvailable() {
+		const active = new Set(this.pi.getActiveTools());
+		return PLAN_MODE_HELPER_TOOL_NAMES.every((name) => active.has(name));
+	}
+
+	prepareSessionStart(visibility: PlanModeToolVisibility, previous: PlanModeToolVisibility) {
+		if (visibility === "after-first-plan" && previous === "always") this.lock();
+		if (visibility === "always") this.reveal();
+	}
+
+	reconcileInactiveState(visibility: PlanModeToolVisibility) {
+		if (visibility === "after-first-plan" && !this.unlocked) this.hideIfLocked();
+	}
+
+	deferVisibilityChange(visibility: PlanModeToolVisibility) {
+		if (visibility === "after-first-plan") this.lock();
+	}
+
+	prepareActivation(ctx: ToolVisibilityContext) {
+		if (!this.toolsAvailable() && ctx.isIdle?.() !== true) {
+			throw new Error("wait until Pi is idle before revealing the Plan tools");
+		}
+		this.reveal();
+	}
+
+	applyVisibilityChange(
+		previous: PlanModeToolVisibility,
+		next: PlanModeToolVisibility,
+		ctx: ToolVisibilityContext,
+	) {
+		if (previous === next) return;
+		if (next === "always") {
+			if (!this.toolsAvailable() && ctx.isIdle?.() !== true) {
+				throw new Error("Wait for Pi to become idle before revealing Plan tools.");
+			}
+			this.reveal();
+			return;
+		}
+		if (ctx.isIdle?.() !== true) {
+			throw new Error("Wait for Pi to become idle before hiding Plan tools.");
+		}
+		this.lock();
+		this.hideIfLocked();
+	}
+
+	hideIfLocked() {
+		if (this.unlocked) return;
+		const active = this.pi.getActiveTools();
+		const hidden = active.filter((name) => this.isHelperTool(name));
+		if (hidden.length === 0) return;
+		this.pi.setActiveTools(active.filter((name) => !this.isHelperTool(name)));
+		for (const name of hidden) this.hiddenByPolicy.add(name);
+	}
+
+	snapshot(): PlanModeHelperVisibilitySnapshot {
+		return {
+			activeTools: this.pi.getActiveTools(),
+			helperToolsUnlocked: this.unlocked,
+			helperToolsHiddenByPolicy: [...this.hiddenByPolicy],
+		};
+	}
+
+	restore(snapshot: PlanModeHelperVisibilitySnapshot) {
+		this.pi.setActiveTools(snapshot.activeTools);
+		this.unlocked = snapshot.helperToolsUnlocked;
+		this.hiddenByPolicy.clear();
+		for (const name of snapshot.helperToolsHiddenByPolicy) this.hiddenByPolicy.add(name);
+	}
+
+	private reveal() {
+		const snapshot = this.snapshot();
+		try {
+			const active = this.pi.getActiveTools();
+			const canonical = [
+				...active.filter((name) => !this.isHelperTool(name)),
+				...PLAN_MODE_HELPER_TOOL_NAMES,
+			];
+			if (
+				canonical.length !== active.length ||
+				canonical.some((name, index) => name !== active[index])
+			) {
+				this.pi.setActiveTools(canonical);
+			}
+			if (!this.toolsAvailable()) {
+				throw new Error(
+					"plan_mode_question and plan_mode_complete are unavailable; leave the restrictive tool mode before starting Plan mode",
+				);
+			}
+			this.unlockAndForgetHidden();
+		} catch (error) {
+			this.restore(snapshot);
+			throw error;
+		}
+	}
+
+	private lock() {
+		this.unlocked = false;
+	}
+
+	private unlockAndForgetHidden() {
+		this.unlocked = true;
+		this.hiddenByPolicy.clear();
+	}
+
+	private isHelperTool(name: string) {
+		return (PLAN_MODE_HELPER_TOOL_NAMES as readonly string[]).includes(name);
+	}
+}

--- a/packages/pi-plan-mode/src/plan-launch-menu.ts
+++ b/packages/pi-plan-mode/src/plan-launch-menu.ts
@@ -46,7 +46,7 @@ export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLau
 				kind: "multiSelect",
 				title: "Choose Plan policy allowlist",
 				lines: [
-					"Changes apply only when you start Plan mode; model-visible tools stay unchanged.",
+					"Policy changes apply only when you start Plan mode; first use may also reveal Plan helpers.",
 					"Only tools already active in Pi can be allowed; non-built-ins run at user risk.",
 				],
 				enableSearch: true,

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -28,6 +28,10 @@ import {
 	startFreshImplementationFromState,
 } from "./fresh-implementation.js";
 import {
+	PlanModeHelperVisibilityPolicy,
+	type PlanModeHelperVisibilitySnapshot,
+} from "./helper-tool-visibility.js";
+import {
 	createImplementationRetentionCoordinator,
 	implementationRetentionPreview,
 } from "./implementation-retention.js";
@@ -70,10 +74,15 @@ import {
 	awaitPlanModeSettingsWrites,
 	configuredImplementationPlanRetention,
 	configuredPlanModeToggleShortcut,
+	configuredPlanModeToolVisibility,
 	configuredThinkingLevel,
 	type PlanModeSettings,
+	type PlanModeSettingsPatch,
+	type PlanModeToolVisibility,
 	planModeSettingsPath,
 	readPlanModeSettings,
+	type UpdatePlanModeSettingsOptions,
+	updatePlanModeSettings,
 } from "./settings.js";
 import { type PlanCompletionSource, type PlanModeState, restorePlanModeState } from "./state.js";
 import {
@@ -103,6 +112,10 @@ type InteractiveUi = typeof import("./interactive-ui.js");
 
 interface PlanModeDependencies {
 	readSettings?(): ReturnType<typeof readPlanModeSettings>;
+	updateSettings?(
+		patch: PlanModeSettingsPatch,
+		options?: UpdatePlanModeSettingsOptions,
+	): ReturnType<typeof updatePlanModeSettings>;
 	settingsPath?: string;
 	loadInteractiveUi?(): Promise<InteractiveUi>;
 }
@@ -111,8 +124,10 @@ interface PlanModeDependencies {
 // activation path cannot bypass the same atomic transition by crossing module-owned state.
 export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDependencies = {}) {
 	const workflowMutex = new WorkflowMutex(pi);
+	const helperVisibility = new PlanModeHelperVisibilityPolicy(pi);
 	let workflowOwner: WorkflowMutexOwner | undefined;
 	let currentSession: object | undefined;
+	let currentSessionContext: ExtensionContext | undefined;
 	let interactiveUiPromise: Promise<InteractiveUi> | undefined;
 	const loadInteractiveUi = () => {
 		if (dependencies.loadInteractiveUi) return dependencies.loadInteractiveUi();
@@ -372,16 +387,21 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		generation: number,
 		ctx: ExtensionContext | undefined,
 		showWarnings: boolean,
+		applyWatchedVisibility = false,
 	) => {
 		const loadedSettings = await readPlanModeRuntimeSettings();
 		if (generation !== menuGeneration || menuController.signal.aborted) {
 			return undefined;
 		}
-		if (loadedSettings.kind === "loaded") {
-			settings = loadedSettings.settings;
-		} else {
-			settings = { thinkingLevel: "inherit" };
+		const previousSettings = settings;
+		const nextSettings =
+			loadedSettings.kind === "loaded"
+				? loadedSettings.settings
+				: ({ thinkingLevel: "inherit" } satisfies PlanModeSettings);
+		if (applyWatchedVisibility && ctx) {
+			applyWatchedHelperVisibility(previousSettings, nextSettings, ctx);
 		}
+		settings = nextSettings;
 		applyPlanModeShortcut(configuredPlanModeToggleShortcut(settings));
 		if (!ctx || !showWarnings) return loadedSettings;
 		if (loadedSettings.kind === "invalid") {
@@ -409,7 +429,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 		settingsReloadTimer = setTimeout(() => {
 			settingsReloadTimer = undefined;
-			void applyPlanModeSettings(generation, undefined, false);
+			void applyPlanModeSettings(generation, currentSessionContext, false, true);
 		}, 75);
 	};
 
@@ -436,11 +456,13 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	pi.on("session_start", async (event, ctx) => {
 		const generation = ++menuGeneration;
+		const previousToolVisibility = configuredPlanModeToolVisibility(settings);
 		finalizationRequest.reset();
 		currentSession = ctx.sessionManager;
+		currentSessionContext = ctx;
 		workflowOwner = undefined;
 		workflowMutex.bindSession(ctx.sessionManager);
-		establishStableToolEnvelope();
+		captureToolBaseline();
 		refreshStateBeforeFirstAgentStart = event.reason === "new";
 		menuController.abort(new DOMException("Plan-mode session replaced", "AbortError"));
 		menuController = new AbortController();
@@ -456,7 +478,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		await applyPlanModeSettings(generation, ctx, true);
 		if (generation !== menuGeneration || menuController.signal.aborted) return;
 		startPlanModeSettingsWatch(generation);
-		if (!installRestoredState(restoredState, ctx)) return;
+		if (restoredState.enabled) {
+			if (!installRestoredState(restoredState, ctx, previousToolVisibility)) return;
+		} else {
+			reconcileInactiveHelperVisibility(previousToolVisibility, ctx);
+			if (!installRestoredState(restoredState, ctx)) return;
+		}
 		implementationRetention.restore(state.activeImplementation);
 		updateUi(ctx);
 	});
@@ -526,7 +553,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		clearUi(ctx);
 		releaseWorkflowOwner();
 		workflowMutex.unbindSession(ctx.sessionManager);
-		if (currentSession === ctx.sessionManager) currentSession = undefined;
+		if (currentSession === ctx.sessionManager) {
+			currentSession = undefined;
+			currentSessionContext = undefined;
+		}
 	});
 
 	pi.on("tool_call", async (event) => {
@@ -707,14 +737,18 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		workflowOwner = owner;
 
 		const previousState = state;
+		const previousHelperVisibility = helperVisibility.snapshot();
 		try {
+			helperVisibility.prepareActivation(ctx);
 			if (!publishModeContract("plan", ctx)) {
+				helperVisibility.restore(previousHelperVisibility);
 				releaseWorkflowOwner();
 				return false;
 			}
 		} catch (error: unknown) {
+			helperVisibility.restore(previousHelperVisibility);
 			releaseWorkflowOwner();
-			throw error;
+			return reportHelperActivationFailure(ctx, error);
 		}
 		advanceWorkflowGeneration();
 		try {
@@ -734,7 +768,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			updateUi(ctx);
 			return true;
 		} catch (error: unknown) {
-			rollbackNewActivation(previousState, ctx);
+			rollbackNewActivation(previousState, ctx, undefined, previousHelperVisibility);
 			throw error;
 		}
 	}
@@ -742,6 +776,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	function enterPlanModeWithPrompt(prompt: string, ctx: ExtensionContext) {
 		const previousState = state;
 		const previousOwner = workflowOwner;
+		const previousHelperVisibility = helperVisibility.snapshot();
 		const wasEnabled = state.enabled;
 		if (!enterPlanMode(ctx)) return;
 		if (!wasEnabled) {
@@ -749,7 +784,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 		if (sendPlanModeUserMessage(prompt, ctx)) return;
 		if (wasEnabled) return;
-		rollbackNewActivation(previousState, ctx, previousOwner);
+		rollbackNewActivation(previousState, ctx, previousOwner, previousHelperVisibility);
 	}
 
 	function exitPlanMode(ctx: ExtensionContext) {
@@ -799,7 +834,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			modeContractsRelevant = true;
 			return true;
 		} catch (error: unknown) {
-			const detail = error instanceof Error ? error.message : String(error);
+			const detail = safeTerminalText(error instanceof Error ? error.message : String(error));
 			const notification = `Unable to publish the ${mode === "plan" ? "Plan" : "Normal"} mode contract: ${detail}`;
 			if (!ctx.hasUI) throw new Error(notification, { cause: error });
 			ctx.ui.notify(notification, "error");
@@ -813,7 +848,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			else pi.sendUserMessage(message, { deliverAs: "followUp" });
 			return true;
 		} catch (error: unknown) {
-			const detail = error instanceof Error ? error.message : String(error);
+			const detail = safeTerminalText(error instanceof Error ? error.message : String(error));
 			ctx.ui.notify(`Unable to send Plan-mode message: ${detail}`, "error");
 			return false;
 		}
@@ -1049,7 +1084,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 		const tools = selectableTools();
 		await ui.showPlanLaunchMenu(ctx, {
-			statusText: "Status: Off — the session tool envelope is already stable.",
+			statusText: helperVisibility.toolsAvailable()
+				? "Status: Off — Plan helper tools are visible for this runtime."
+				: "Status: Off — Plan helper tools load on the first Plan start.",
 			initialScreen,
 			getSelectedNames: () => snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot()),
 			toolSummary: (selectedNames) => {
@@ -1146,6 +1183,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			signal,
 			isCurrent,
 			settingsPath: dependencies.settingsPath,
+			updateSettings: (patch, options) => updateSettingsWithRuntime(patch, options, ctx, isCurrent),
 			onSaved: (saved) => {
 				if (!isCurrent()) return;
 				settings = saved;
@@ -1156,6 +1194,63 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				: {}),
 		});
 		return result.kind === "closed" && "reason" in result && result.reason === "close";
+	}
+
+	async function updateSettingsWithRuntime(
+		patch: PlanModeSettingsPatch,
+		options: UpdatePlanModeSettingsOptions | undefined,
+		ctx: ExtensionContext,
+		isCurrent: () => boolean,
+	) {
+		const previousVisibility = configuredPlanModeToolVisibility(settings);
+		const nextVisibility = patch.toolVisibility ?? previousVisibility;
+		const persistSettings = dependencies.updateSettings ?? updatePlanModeSettings;
+		if (nextVisibility === previousVisibility) {
+			return persistSettings(patch, options);
+		}
+		if (!ctx.isIdle()) {
+			throw new Error("Wait for Pi to become idle before changing Plan tool visibility.");
+		}
+		bindWorkflowSessionIfNeeded(ctx);
+		const applicationSession = ctx.sessionManager;
+		const applicationGeneration = menuGeneration;
+		const applicationIsCurrent = () =>
+			currentSession === applicationSession &&
+			menuGeneration === applicationGeneration &&
+			isCurrent();
+		const retainedOwner = workflowMutex.isOwner(workflowOwner);
+		const temporaryOwner = retainedOwner ? workflowOwner : workflowMutex.acquire();
+		if (!temporaryOwner) {
+			throw new Error(
+				"Another workflow is active in this session. Plan tool visibility was not changed.",
+			);
+		}
+		const visibilitySnapshot = helperVisibility.snapshot();
+		try {
+			helperVisibility.applyVisibilityChange(previousVisibility, nextVisibility, ctx);
+			const saved = await persistSettings(patch, options);
+			if (!applicationIsCurrent()) {
+				throw new DOMException("Plan settings session replaced", "AbortError");
+			}
+			settings = saved;
+			applyPlanModeShortcut(configuredPlanModeToggleShortcut(saved));
+			return saved;
+		} catch (error) {
+			if (applicationIsCurrent()) {
+				try {
+					helperVisibility.restore(visibilitySnapshot);
+				} catch (rollbackError) {
+					throw new AggregateError(
+						[error, rollbackError],
+						"Plan tool visibility settings failed and runtime rollback was incomplete.",
+					);
+				}
+			}
+			throw error;
+		} finally {
+			if (!retainedOwner) workflowMutex.release(temporaryOwner);
+			if (!isCurrent()) latestCommandContext = undefined;
+		}
 	}
 
 	function allowModeTransition(ctx: ExtensionContext, action: string) {
@@ -1193,16 +1288,84 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		};
 	}
 
-	function establishStableToolEnvelope() {
-		const activeTools = safeGetActiveTools();
-		const stableTools = withRequiredPlanModeTools(activeTools);
-		if (
-			stableTools.length !== activeTools.length ||
-			stableTools.some((toolName, index) => toolName !== activeTools[index])
-		) {
-			pi.setActiveTools(stableTools);
+	function captureToolBaseline() {
+		activeToolBaseline = withRequiredPlanModeTools(safeGetActiveTools());
+	}
+
+	function applyWatchedHelperVisibility(
+		previousSettings: PlanModeSettings,
+		nextSettings: PlanModeSettings,
+		ctx: ExtensionContext,
+	) {
+		const previousVisibility = configuredPlanModeToolVisibility(previousSettings);
+		const nextVisibility = configuredPlanModeToolVisibility(nextSettings);
+		if (previousVisibility === nextVisibility) return;
+		if (state.enabled) {
+			helperVisibility.deferVisibilityChange(nextVisibility);
+			return;
 		}
-		activeToolBaseline = stableTools;
+		try {
+			if (!ctx.isIdle()) {
+				helperVisibility.deferVisibilityChange(nextVisibility);
+				return;
+			}
+		} catch {
+			helperVisibility.deferVisibilityChange(nextVisibility);
+			return;
+		}
+		const owner = workflowMutex.acquire();
+		if (!owner) {
+			helperVisibility.deferVisibilityChange(nextVisibility);
+			return;
+		}
+		const snapshot = helperVisibility.snapshot();
+		try {
+			helperVisibility.applyVisibilityChange(previousVisibility, nextVisibility, ctx);
+		} catch (error: unknown) {
+			helperVisibility.restore(snapshot);
+			helperVisibility.deferVisibilityChange(nextVisibility);
+			if (ctx.hasUI) {
+				const detail = safeTerminalText(error instanceof Error ? error.message : String(error));
+				ctx.ui.notify(
+					`Could not apply reloaded Plan tool visibility; the current tool envelope remains unchanged until a later safe boundary: ${detail}`,
+					"warning",
+				);
+			}
+		} finally {
+			workflowMutex.release(owner);
+		}
+	}
+
+	function reconcileInactiveHelperVisibility(
+		previousVisibility: PlanModeToolVisibility,
+		ctx: ExtensionContext,
+	) {
+		const owner = workflowMutex.acquire();
+		if (!owner) {
+			if (ctx.hasUI) {
+				ctx.ui.notify(
+					"Plan tool visibility was deferred because another workflow is active in this session.",
+					"warning",
+				);
+			}
+			return false;
+		}
+		const snapshot = helperVisibility.snapshot();
+		try {
+			const visibility = configuredPlanModeToolVisibility(settings);
+			helperVisibility.prepareSessionStart(visibility, previousVisibility);
+			helperVisibility.reconcileInactiveState(visibility);
+			return true;
+		} catch (error: unknown) {
+			helperVisibility.restore(snapshot);
+			if (ctx.hasUI) {
+				const detail = safeTerminalText(error instanceof Error ? error.message : String(error));
+				ctx.ui.notify(`Could not apply Plan tool visibility: ${detail}`, "error");
+			}
+			return false;
+		} finally {
+			workflowMutex.release(owner);
+		}
 	}
 
 	function planModePolicyToolNames() {
@@ -1306,10 +1469,15 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 	}
 
-	function installRestoredState(candidate: PlanModeState, ctx: ExtensionContext) {
+	function installRestoredState(
+		candidate: PlanModeState,
+		ctx: ExtensionContext,
+		previousToolVisibility?: PlanModeToolVisibility,
+	) {
 		const previousState = state;
 		const previousWorkflowAllowedToolNames = workflowAllowedToolNames;
 		const previousOwner = workflowOwner;
+		const previousHelperVisibility = helperVisibility.snapshot();
 		const wasEnabled = state.enabled;
 		if (candidate.enabled && !workflowMutex.isOwner(workflowOwner)) {
 			const owner = workflowMutex.acquire();
@@ -1323,6 +1491,27 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 
 		try {
+			if (candidate.enabled) {
+				const visibility = configuredPlanModeToolVisibility(settings);
+				if (previousToolVisibility === undefined) {
+					helperVisibility.prepareActivation(ctx);
+				} else {
+					try {
+						helperVisibility.prepareSessionStart(visibility, previousToolVisibility);
+						helperVisibility.prepareActivation(ctx);
+					} catch {
+						helperVisibility.restore(previousHelperVisibility);
+						state = { enabled: false, awaitingAction: false };
+						workflowAllowedToolNames = undefined;
+						if (workflowOwner !== previousOwner) {
+							workflowMutex.release(workflowOwner);
+							workflowOwner = previousOwner;
+						}
+						reportRestoredHelpersUnavailable(ctx);
+						return false;
+					}
+				}
+			}
 			if (wasEnabled && !candidate.enabled) {
 				readyPresentationIntent = undefined;
 				restoreThinkingLevel();
@@ -1338,6 +1527,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			} finally {
 				state = previousState;
 				workflowAllowedToolNames = previousWorkflowAllowedToolNames;
+				helperVisibility.restore(previousHelperVisibility);
 				if (workflowOwner !== previousOwner) {
 					workflowMutex.release(workflowOwner);
 					workflowOwner = previousOwner;
@@ -1351,6 +1541,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		previousState: PlanModeState,
 		ctx: ExtensionContext,
 		previousOwner?: WorkflowMutexOwner,
+		previousHelperVisibility?: PlanModeHelperVisibilitySnapshot,
 	) {
 		const activatedOwner = workflowOwner;
 		readyPresentationIntent = undefined;
@@ -1363,6 +1554,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			state = previousState;
 			workflowAllowedToolNames = undefined;
 			try {
+				if (previousHelperVisibility) helperVisibility.restore(previousHelperVisibility);
 				persistState();
 				updateUi(ctx);
 			} finally {
@@ -1402,6 +1594,22 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		);
 	}
 
+	function reportRestoredHelpersUnavailable(ctx: ExtensionContext) {
+		if (!ctx.hasUI) return;
+		ctx.ui.notify(
+			"Plan mode was not restored because its helper tools are unavailable under the active tool policy.",
+			"warning",
+		);
+	}
+
+	function reportHelperActivationFailure(ctx: ExtensionContext, error: unknown) {
+		const detail = safeTerminalText(error instanceof Error ? error.message : String(error));
+		const message = `Cannot start Plan mode: ${detail}.`;
+		if (!ctx.hasUI) throw new Error(message, { cause: error });
+		ctx.ui.notify(message, "error");
+		return false;
+	}
+
 	function updateUi(ctx: ExtensionContext) {
 		updatePlanModeUi(ctx, state, formatToolSummary);
 	}
@@ -1425,6 +1633,16 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	function toolByName(toolName: string) {
 		return safeGetAllTools().find((candidate) => candidate.name === toolName);
+	}
+
+	function safeTerminalText(value: string) {
+		return [...value]
+			.map((character) => {
+				const codePoint = character.codePointAt(0) ?? 0;
+				return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+			})
+			.join("")
+			.trim();
 	}
 }
 

--- a/packages/pi-plan-mode/src/settings-menu.ts
+++ b/packages/pi-plan-mode/src/settings-menu.ts
@@ -8,9 +8,11 @@ import {
 	configuredImplementationPlanRetention,
 	configuredPlanExportPath,
 	configuredPlanModeToggleShortcut,
+	configuredPlanModeToolVisibility,
 	IMPLEMENTATION_PLAN_RETENTIONS,
 	normalizeKeyId,
 	PLAN_MODE_THINKING_LEVELS,
+	PLAN_MODE_TOOL_VISIBILITIES,
 	type PlanModeSettings,
 	type PlanModeSettingsLoadResult,
 	type PlanModeSettingsPatch,
@@ -47,6 +49,7 @@ export interface PlanModeSettingsMenuOptions {
 type Screen = "settings" | "tools" | "export" | "shortcut";
 type Action =
 	| "set-thinking"
+	| "set-tool-visibility"
 	| "open-tools"
 	| "toggle-tool"
 	| "reset-tools"
@@ -140,6 +143,17 @@ export async function showPlanModeSettings(
 									currentValue: configuredPlanModeToggleShortcut(state.settings) ?? "none",
 									action: "open-shortcut",
 								},
+								{
+									id: "toolVisibility",
+									label: "Plan tools",
+									description:
+										"Keep Plan helper tools visible, or reveal them after the first plan.",
+									currentValue: toolVisibilityLabel(
+										configuredPlanModeToolVisibility(state.settings),
+									),
+									values: PLAN_MODE_TOOL_VISIBILITIES.map(toolVisibilityLabel),
+									action: "set-tool-visibility",
+								},
 							],
 						},
 			tools: ({ state }) => ({
@@ -204,6 +218,16 @@ export async function showPlanModeSettings(
 					{ thinkingLevel: value as PlanModeSettings["thinkingLevel"] },
 					signal,
 					`Plan mode thinking level: ${value}. Applies to the next Plan workflow.`,
+				);
+			},
+			"set-tool-visibility": async ({ ctx: actionCtx, value, signal }) => {
+				const toolVisibility = toolVisibilityFromLabel(value);
+				if (!toolVisibility) return { kind: "rejected" };
+				return savePatch(
+					actionCtx,
+					{ toolVisibility },
+					signal,
+					`Plan tools: ${toolVisibilityLabel(toolVisibility)}.`,
 				);
 			},
 			"open-tools": async () => ({ kind: "to", screen: "tools" }),
@@ -337,6 +361,16 @@ function invalidScreen(settingsPath: string, state: SettingsMenuState) {
 
 function retentionFromLabel(value: string | undefined) {
 	return IMPLEMENTATION_PLAN_RETENTIONS.find((retention) => retentionLabel(retention) === value);
+}
+
+function toolVisibilityLabel(value: PlanModeSettings["toolVisibility"] | "after-first-plan") {
+	return value === "always" ? "Always" : "After first plan";
+}
+
+function toolVisibilityFromLabel(value: string | undefined) {
+	return PLAN_MODE_TOOL_VISIBILITIES.find(
+		(visibility) => toolVisibilityLabel(visibility) === value,
+	);
 }
 
 function defaultToolsValue(configured: string[] | undefined) {

--- a/packages/pi-plan-mode/src/settings.ts
+++ b/packages/pi-plan-mode/src/settings.ts
@@ -30,6 +30,8 @@ export const IMPLEMENTATION_PLAN_RETENTIONS = [
 	"clear-after-first-run",
 	"keep",
 ] as const;
+export const PLAN_MODE_TOOL_VISIBILITIES = ["always", "after-first-plan"] as const;
+export const DEFAULT_PLAN_MODE_TOOL_VISIBILITY = "after-first-plan";
 export const DEFAULT_PLAN_EXPORT_PATH = "PLAN.md";
 const MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
 const BASE_KEYS = new Set([
@@ -89,9 +91,11 @@ const MAX_PLAN_EXPORT_PATH_LENGTH = 4096;
 
 export type PlanModeThinkingLevel = (typeof PLAN_MODE_THINKING_LEVELS)[number];
 export type ImplementationPlanRetention = (typeof IMPLEMENTATION_PLAN_RETENTIONS)[number];
+export type PlanModeToolVisibility = (typeof PLAN_MODE_TOOL_VISIBILITIES)[number];
 export type PlanModeFixedThinkingLevel = Exclude<PlanModeThinkingLevel, "inherit">;
 export interface PlanModeSettings {
 	thinkingLevel: PlanModeThinkingLevel;
+	toolVisibility?: PlanModeToolVisibility;
 	defaultPlanTools?: string[];
 	implementationPlanRetention?: ImplementationPlanRetention;
 	defaultPlanExportPath?: string;
@@ -100,6 +104,7 @@ export interface PlanModeSettings {
 }
 export interface PlanModeSettingsPatch {
 	thinkingLevel?: PlanModeThinkingLevel;
+	toolVisibility?: PlanModeToolVisibility;
 	defaultPlanTools?: readonly string[] | null;
 	implementationPlanRetention?: ImplementationPlanRetention;
 	defaultPlanExportPath?: string | null;
@@ -143,6 +148,13 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 	const settings: PlanModeSettings = {
 		thinkingLevel: thinkingLevel as PlanModeThinkingLevel,
 	};
+	if (Object.hasOwn(value, "toolVisibility")) {
+		const toolVisibility = Reflect.get(value, "toolVisibility");
+		if (!PLAN_MODE_TOOL_VISIBILITIES.includes(toolVisibility as PlanModeToolVisibility)) {
+			return undefined;
+		}
+		settings.toolVisibility = toolVisibility as PlanModeToolVisibility;
+	}
 	if (Object.hasOwn(value, "defaultPlanTools")) {
 		const defaultPlanTools = normalizeToolNames(Reflect.get(value, "defaultPlanTools"));
 		if (!defaultPlanTools) return undefined;
@@ -299,6 +311,7 @@ export function updatePlanModeSettings(
 		const current = await readSettingsDocumentForUpdate(settingsPath, legacySettingsPath);
 		const updated: SettingsDocument = { ...current };
 		if (patch.thinkingLevel !== undefined) updated.thinkingLevel = patch.thinkingLevel;
+		if (patch.toolVisibility !== undefined) updated.toolVisibility = patch.toolVisibility;
 		if (patch.defaultPlanTools === null) delete updated.defaultPlanTools;
 		else if (patch.defaultPlanTools !== undefined) {
 			updated.defaultPlanTools = [...patch.defaultPlanTools];
@@ -480,6 +493,12 @@ export function configuredThinkingLevel(
 	settings: PlanModeSettings,
 ): PlanModeFixedThinkingLevel | undefined {
 	return settings.thinkingLevel === "inherit" ? undefined : settings.thinkingLevel;
+}
+
+export function configuredPlanModeToolVisibility(
+	settings: PlanModeSettings,
+): PlanModeToolVisibility {
+	return settings.toolVisibility ?? DEFAULT_PLAN_MODE_TOOL_VISIBILITY;
 }
 
 export function configuredImplementationPlanRetention(

--- a/packages/pi-plan-mode/test/cache-contract.test.ts
+++ b/packages/pi-plan-mode/test/cache-contract.test.ts
@@ -8,6 +8,11 @@ interface CapturedRequest {
 	activeTools: string[];
 	systemPrompt: string;
 	messages: unknown[];
+	activePromptMetadata: Array<{
+		name: string;
+		promptSnippet: unknown;
+		promptGuidelines: unknown;
+	}>;
 	providerPayload: {
 		instructions: string;
 		tools: Array<{ name: string; description: unknown; parameters: unknown }>;
@@ -47,6 +52,14 @@ async function captureRequest(
 		activeTools,
 		systemPrompt,
 		messages: visibleMessages,
+		activePromptMetadata: activeTools.map((name) => {
+			const tool = toolByName.get(name);
+			return {
+				name,
+				promptSnippet: tool?.promptSnippet,
+				promptGuidelines: tool?.promptGuidelines,
+			};
+		}),
 		providerPayload: {
 			instructions: systemPrompt,
 			tools: orderedDefinitions,
@@ -63,7 +76,7 @@ async function completePlan(mock: ReturnType<typeof createMockPi>, ctx: unknown)
 	await complete("complete", { plan: "# Cache-stable plan" }, undefined, undefined, ctx);
 }
 
-test("cache-contract fixture keeps request fields stable while history extends across modes", async () => {
+test("always-visible cache contract keeps request fields stable across modes", async () => {
 	const allTools = [
 		builtinTool("read"),
 		builtinTool("bash"),
@@ -71,7 +84,12 @@ test("cache-contract fixture keeps request fields stable while history extends a
 		builtinTool("write"),
 	];
 	const mock = createMockPi({ activeTools: ["read", "bash", "edit", "write"], allTools });
-	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: { thinkingLevel: "inherit" as const, toolVisibility: "always" as const },
+		}),
+	});
 	const context = createMockContext();
 	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
 
@@ -102,6 +120,8 @@ test("cache-contract fixture keeps request fields stable while history extends a
 	assert.equal(implementation.systemPrompt, normal.systemPrompt);
 	assert.deepEqual(plan.providerPayload.tools, normal.providerPayload.tools);
 	assert.deepEqual(implementation.providerPayload.tools, normal.providerPayload.tools);
+	assert.deepEqual(plan.activePromptMetadata, normal.activePromptMetadata);
+	assert.deepEqual(implementation.activePromptMetadata, normal.activePromptMetadata);
 	assert.equal(plan.providerPayload.instructions, normal.providerPayload.instructions);
 	assert.equal(implementation.providerPayload.instructions, normal.providerPayload.instructions);
 	assert.match(JSON.stringify(plan.messages), /CONTRACT v1: PLAN/u);
@@ -113,4 +133,54 @@ test("cache-contract fixture keeps request fields stable while history extends a
 			.map((message) => (message as { content?: unknown }).content),
 		["A", "B", "Implement the plan."],
 	);
+});
+
+test("after-first-plan changes helper definitions once and keeps the unlocked prefix stable", async () => {
+	const allTools = [
+		builtinTool("read"),
+		builtinTool("bash"),
+		builtinTool("edit"),
+		builtinTool("write"),
+	];
+	const mock = createMockPi({ activeTools: ["read", "bash", "edit", "write"], allTools });
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+
+	const normal = await captureRequest("normal", mock, context.ctx, [
+		{ role: "user", content: "A" },
+	]);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	const planContract = mock.sentMessages.at(-1)?.message;
+	const plan = await captureRequest("plan", mock, context.ctx, [
+		{ role: "user", content: "A" },
+		planContract,
+		{ role: "user", content: "B" },
+	]);
+	await completePlan(mock, context.ctx);
+	await mock.commands.get("plan")?.handler("implement", context.ctx);
+	const implementation = await captureRequest("implementation", mock, context.ctx, [
+		{ role: "user", content: "A" },
+		planContract,
+		{ role: "user", content: "B" },
+		mock.sentMessages.at(-1)?.message,
+		{ role: "user", content: "Implement the plan." },
+	]);
+
+	assert.deepEqual(normal.activeTools, ["read", "bash", "edit", "write"]);
+	assert.deepEqual(plan.activeTools, [
+		"read",
+		"bash",
+		"edit",
+		"write",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
+	assert.deepEqual(implementation.activeTools, plan.activeTools);
+	assert.notDeepEqual(plan.providerPayload.tools, normal.providerPayload.tools);
+	assert.deepEqual(implementation.providerPayload.tools, plan.providerPayload.tools);
+	assert.notDeepEqual(plan.activePromptMetadata, normal.activePromptMetadata);
+	assert.deepEqual(implementation.activePromptMetadata, plan.activePromptMetadata);
+	assert.equal(plan.systemPrompt, normal.systemPrompt);
+	assert.equal(implementation.systemPrompt, plan.systemPrompt);
 });

--- a/packages/pi-plan-mode/test/default-tools.test.ts
+++ b/packages/pi-plan-mode/test/default-tools.test.ts
@@ -28,8 +28,9 @@ async function callTool(
 	return mock.events.get("tool_call")?.[0]?.({ toolName, input }, context.ctx);
 }
 
-test("session startup appends helpers once and every Plan transition keeps the exact baseline", async () => {
-	const baseline = ["read", "bash", "edit", "write", "custom", ...HELPERS];
+test("lazy startup omits helpers, first activation appends them once, and later transitions stay stable", async () => {
+	const ordinaryTools = ["read", "bash", "edit", "write", "custom"];
+	const baseline = [...ordinaryTools, ...HELPERS];
 	const mock = createMockPi({
 		activeTools: ["read", "bash", "edit", "write", "custom"],
 		allTools: [
@@ -50,18 +51,76 @@ test("session startup appends helpers once and every Plan transition keeps the e
 	const context = createMockContext();
 
 	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
-	assert.deepEqual(mock.rawPi.getActiveTools(), baseline);
-	assert.deepEqual(writes, [baseline]);
-	await mock.events.get("session_start")?.[0]?.({ reason: "reload" }, context.ctx);
-	assert.deepEqual(writes, [baseline]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ordinaryTools);
+	assert.deepEqual(writes, []);
 
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	assert.deepEqual(mock.rawPi.getActiveTools(), baseline);
+	assert.deepEqual(writes, [baseline]);
 	await mock.commands.get("plan")?.handler("exit", context.ctx);
 	assert.deepEqual(mock.rawPi.getActiveTools(), baseline);
 	await mock.events.get("session_shutdown")?.[0]?.({ reason: "quit" }, context.ctx);
 	assert.deepEqual(mock.rawPi.getActiveTools(), baseline);
 	assert.deepEqual(writes, [baseline]);
+	await mock.events.get("session_start")?.[0]?.({ reason: "reload" }, context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), baseline);
+	assert.deepEqual(writes, [baseline]);
+});
+
+test("always visibility appends helpers during session startup", async () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: { thinkingLevel: "inherit" as const, toolVisibility: "always" as const },
+		}),
+	});
+	const context = createMockContext();
+
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...HELPERS]);
+});
+
+test("watched visibility changes apply at safe idle boundaries", async () => {
+	await withAgentDir(async (agentDir) => {
+		const settingsPath = join(agentDir, "pi-plan-mode.json");
+		const mock = createMockPi({ activeTools: ["read", ...HELPERS] });
+		planMode(mock.pi, { settingsPath });
+		const context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+
+		await writeFile(settingsPath, '{"toolVisibility":"always"}\n');
+		await waitForTools(mock, ["read", ...HELPERS]);
+		await writeFile(settingsPath, '{"toolVisibility":"after-first-plan"}\n');
+		await waitForTools(mock, ["read"]);
+		await mock.events.get("session_shutdown")?.[0]?.({ reason: "quit" }, context.ctx);
+	});
+});
+
+test("busy watched lazy visibility defers narrowing until the next session boundary", async () => {
+	await withAgentDir(async (agentDir) => {
+		const settingsPath = join(agentDir, "pi-plan-mode.json");
+		await writeFile(settingsPath, '{"toolVisibility":"always"}\n');
+		let idle = false;
+		const mock = createMockPi({ activeTools: ["read", ...HELPERS] });
+		planMode(mock.pi, { settingsPath });
+		const context = createMockContext({ isIdle: () => idle });
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...HELPERS]);
+
+		await writeFile(
+			settingsPath,
+			'{"toolVisibility":"after-first-plan","toggleShortcut":"ctrl+shift+p"}\n',
+		);
+		await waitForCondition(() => mock.shortcuts.has("ctrl+shift+p"));
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...HELPERS]);
+
+		idle = true;
+		await mock.events.get("session_start")?.[0]?.({ reason: "reload" }, context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+		await mock.events.get("session_shutdown")?.[0]?.({ reason: "quit" }, context.ctx);
+	});
 });
 
 test("configured Plan tools are an allowlist over active tools, not an activation request", async () => {
@@ -207,6 +266,22 @@ test("branch-restored selections constrain policy while helpers remain model-vis
 		true,
 	);
 });
+
+async function waitForTools(mock: ReturnType<typeof createMockPi>, expected: string[]) {
+	await waitForCondition(
+		() => JSON.stringify(mock.rawPi.getActiveTools()) === JSON.stringify(expected),
+	);
+	assert.deepEqual(mock.rawPi.getActiveTools(), expected);
+}
+
+async function waitForCondition(condition: () => boolean) {
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		if (condition()) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+	}
+	assert.equal(condition(), true);
+}
 
 async function withAgentDir(run: (agentDir: string) => Promise<void>) {
 	const agentDir = await mkdtemp(join(tmpdir(), "pi-plan-mode-default-tools-"));

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -385,12 +385,7 @@ test("fresh destination adopts setup state before kickoff for guaranteed-plan po
 			context.ctx,
 		);
 		assert.equal(context.statuses.get("plan-mode"), "plan implementing");
-		assert.deepEqual(mock.rawPi.getActiveTools(), [
-			"read",
-			"edit",
-			"plan_mode_question",
-			"plan_mode_complete",
-		]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
 
 		const firstContext = (await mock.events.get("context")?.[0]?.(
 			{ messages: [{ role: "user", content: handoff }] },

--- a/packages/pi-plan-mode/test/helper-tool-visibility.test.ts
+++ b/packages/pi-plan-mode/test/helper-tool-visibility.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	PLAN_MODE_HELPER_TOOL_NAMES,
+	PlanModeHelperVisibilityPolicy,
+} from "../src/helper-tool-visibility.js";
+
+const HELPERS = [...PLAN_MODE_HELPER_TOOL_NAMES];
+
+test("lazy visibility hides only Plan helpers it owns and restores them in canonical order", () => {
+	const mock = createMockPi({
+		activeTools: ["read", "plan_mode_complete", "custom", "plan_mode_question"],
+	});
+	const policy = new PlanModeHelperVisibilityPolicy(mock.pi);
+
+	policy.reconcileInactiveState("after-first-plan");
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "custom"]);
+	assert.equal(policy.hasHiddenTools(), true);
+
+	mock.rawPi.setActiveTools(["read", "custom", "external"]);
+	policy.prepareActivation(createMockContext().ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "custom", "external", ...HELPERS]);
+	assert.equal(policy.hasHiddenTools(), false);
+	assert.equal(policy.isUnlocked(), true);
+});
+
+test("lazy visibility stays unlocked after activation and across session reconciliation", () => {
+	const mock = createMockPi({ activeTools: ["read", ...HELPERS] });
+	const policy = new PlanModeHelperVisibilityPolicy(mock.pi);
+	const context = createMockContext();
+
+	policy.reconcileInactiveState("after-first-plan");
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+	policy.prepareActivation(context.ctx);
+	policy.reconcileInactiveState("after-first-plan");
+
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...HELPERS]);
+	assert.equal(policy.isUnlocked(), true);
+});
+
+test("always visibility canonicalizes helpers while lazy setting changes reset an inactive runtime", () => {
+	const mock = createMockPi({
+		activeTools: ["read", "plan_mode_complete", "plan_mode_question"],
+	});
+	const policy = new PlanModeHelperVisibilityPolicy(mock.pi);
+	const context = createMockContext();
+
+	policy.prepareSessionStart("always", "after-first-plan");
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...HELPERS]);
+	policy.applyVisibilityChange("always", "after-first-plan", context.ctx);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+	assert.equal(policy.isUnlocked(), false);
+});
+
+test("deferred lazy visibility keeps the current envelope and locks the next safe boundary", () => {
+	const mock = createMockPi({ activeTools: ["read", ...HELPERS] });
+	const policy = new PlanModeHelperVisibilityPolicy(mock.pi);
+	policy.prepareSessionStart("always", "after-first-plan");
+
+	policy.deferVisibilityChange("after-first-plan");
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...HELPERS]);
+	policy.prepareSessionStart("after-first-plan", "after-first-plan");
+	policy.reconcileInactiveState("after-first-plan");
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+});
+
+test("busy visibility changes and activations preserve the exact external tool state", () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	const policy = new PlanModeHelperVisibilityPolicy(mock.pi);
+	const busy = createMockContext({ isIdle: () => false });
+
+	assert.throws(() => policy.prepareActivation(busy.ctx), /wait until Pi is idle/i);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+
+	policy.prepareSessionStart("always", "after-first-plan");
+	assert.throws(
+		() => policy.applyVisibilityChange("always", "after-first-plan", busy.ctx),
+		/idle before hiding/i,
+	);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", ...HELPERS]);
+});
+
+test("failed activation restores active tools and policy ownership exactly", () => {
+	const mock = createMockPi({ activeTools: ["read"] });
+	const policy = new PlanModeHelperVisibilityPolicy(mock.pi);
+	const snapshot = policy.snapshot();
+	const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+	mock.rawPi.setActiveTools = (names) => {
+		setActiveTools(names.filter((name) => name !== "plan_mode_complete"));
+	};
+
+	assert.throws(
+		() => policy.prepareActivation(createMockContext().ctx),
+		/plan_mode_question and plan_mode_complete are unavailable/i,
+	);
+	mock.rawPi.setActiveTools = setActiveTools;
+	assert.deepEqual(policy.snapshot(), snapshot);
+});

--- a/packages/pi-plan-mode/test/issue-302-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-302-repro.test.ts
@@ -41,7 +41,13 @@ test("issue 302: history-only implementation stays ordinary context when Plan Mo
 
 	await mock.commands.get("plan")?.handler("start", context.ctx);
 	assert.equal(context.statuses.get("plan-mode"), "plan active");
-	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "custom"]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"read",
+		"bash",
+		"custom",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
 
 	const beforeStart = mock.events.get("before_agent_start")?.[0];
 	assert.ok(beforeStart);

--- a/packages/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-471-repro.test.ts
@@ -321,7 +321,12 @@ test("failed implementation delivery restores ready state without retained imple
 
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
 	assert.equal(context.statuses.get("plan-mode"), "plan ready");
-	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "custom"]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"read",
+		"custom",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
 	const restored = latestState(mock.entries);
 	assert.equal(restored?.latestPlan, PLAN);
 	assert.equal(restored?.activeImplementation, undefined);

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
@@ -14,7 +14,8 @@ import planMode from "../src/plan-mode.js";
 import { readPlanModeSettings } from "../src/settings.js";
 
 const REQUIRED_PLAN_TOOLS = ["plan_mode_question", "plan_mode_complete"];
-const STABLE_TOOLS = ["read", "write", "custom", ...REQUIRED_PLAN_TOOLS];
+const STARTUP_TOOLS = ["read", "write", "custom"];
+const STABLE_TOOLS = [...STARTUP_TOOLS, ...REQUIRED_PLAN_TOOLS];
 
 async function settleWithin<T>(promise: Promise<T>, label: string): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
@@ -132,7 +133,7 @@ test("customized plan-mode shortcut rejects mode changes during an active run", 
 	assert.ok(toggle);
 
 	await toggle.handler(context.ctx);
-	assert.deepEqual(mock.rawPi.getActiveTools(), STABLE_TOOLS);
+	assert.deepEqual(mock.rawPi.getActiveTools(), STARTUP_TOOLS);
 	assert.equal(mock.entries.length, 0);
 	assert.match(context.notifications.at(-1)?.message ?? "", /run is active.*retry/i);
 
@@ -186,6 +187,118 @@ test("the inactive launch menu opens Settings without starting Plan mode", async
 
 	tui.press("ctrl+c");
 	await settleWithin(running, "launch Settings close");
+});
+
+test("Plan tools setting applies immediately and rolls back when persistence fails", async () => {
+	for (const shouldFail of [false, true]) {
+		const agentDir = await mkdtemp(join(tmpdir(), "pi-plan-mode-visibility-settings-"));
+		const settingsPath = join(agentDir, "pi-plan-mode.json");
+		const mock = createMockPi({
+			activeTools: STABLE_TOOLS,
+			allTools: [builtinTool("read"), builtinTool("write"), extensionTool("custom")],
+		});
+		planMode(mock.pi, {
+			readSettings: () => readPlanModeSettings(settingsPath),
+			settingsPath,
+			...(shouldFail
+				? {
+						updateSettings: async () => {
+							throw new Error("mock persistence failure");
+						},
+					}
+				: {}),
+		});
+		const tui = createTuiHarness();
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		try {
+			await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+			assert.deepEqual(mock.rawPi.getActiveTools(), STARTUP_TOOLS);
+
+			const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+			await waitForOpenCount(tui, 1, running);
+			tui.press("tui.select.down");
+			tui.press("tui.select.down");
+			tui.press("tui.select.confirm");
+			await settleWithin(tui.waitForPending(), "the visibility Settings transition");
+			await waitForOpenCount(tui, 2, running);
+			for (let index = 0; index < 5; index += 1) tui.press("tui.select.down");
+			tui.press("tui.select.confirm");
+			await settleWithin(tui.waitForPending(), "the visibility Settings save");
+			await tui.waitForOpen();
+
+			if (shouldFail) {
+				assert.deepEqual(mock.rawPi.getActiveTools(), STARTUP_TOOLS);
+				assert.match(tui.render().join("\n"), /Plan tools\s+After first plan/);
+				assert.match(context.notifications.at(-1)?.message ?? "", /previous value remains/i);
+			} else {
+				assert.deepEqual(mock.rawPi.getActiveTools(), STABLE_TOOLS);
+				assert.match(tui.render().join("\n"), /Plan tools\s+Always/);
+				assert.equal(
+					(JSON.parse(await readFile(settingsPath, "utf8")) as { toolVisibility?: string })
+						.toolVisibility,
+					"always",
+				);
+			}
+			tui.press("ctrl+c");
+			await settleWithin(running, "the visibility Settings close");
+		} finally {
+			tui.dispose();
+			await rm(agentDir, { recursive: true, force: true });
+		}
+	}
+});
+
+test("busy Plan tools setting preserves runtime and persisted visibility", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "pi-plan-mode-busy-visibility-"));
+	const settingsPath = join(agentDir, "pi-plan-mode.json");
+	await writeFile(settingsPath, '{"toolVisibility":"always"}\n');
+	const sessionManager = { getBranch: () => [], getEntries: () => [] };
+	const mock = createMockPi({
+		activeTools: STABLE_TOOLS,
+		allTools: [builtinTool("read"), builtinTool("write"), extensionTool("custom")],
+	});
+	mock.eventBus.on("workflow:mutex:v1", (payload: unknown) => {
+		const attempt = payload as { session?: unknown; group?: string; busy?: boolean };
+		if (attempt.session === sessionManager && attempt.group === "agent-workflow") {
+			attempt.busy = true;
+		}
+	});
+	planMode(mock.pi, { settingsPath, readSettings: () => readPlanModeSettings(settingsPath) });
+	const tui = createTuiHarness();
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+		sessionManager,
+	});
+	try {
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+		await waitForOpenCount(tui, 1, running);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await settleWithin(tui.waitForPending(), "the busy Settings transition");
+		await waitForOpenCount(tui, 2, running);
+		for (let index = 0; index < 5; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await settleWithin(tui.waitForPending(), "the busy visibility rejection");
+		await tui.waitForOpen();
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), STABLE_TOOLS);
+		assert.equal(
+			(JSON.parse(await readFile(settingsPath, "utf8")) as { toolVisibility?: string })
+				.toolVisibility,
+			"always",
+		);
+		assert.match(tui.render().join("\n"), /Plan tools\s+Always/);
+		assert.match(context.notifications.at(-1)?.message ?? "", /Another workflow is active/i);
+		tui.press("ctrl+c");
+		await settleWithin(running, "the busy Settings close");
+	} finally {
+		tui.dispose();
+		await rm(agentDir, { recursive: true, force: true });
+	}
 });
 
 test("persisted Settings become the baseline for the next Plan workflow", async () => {
@@ -250,7 +363,7 @@ test("launch tool choices remain draft-only until Done starts Plan mode", async 
 	tui.press("tui.select.confirm");
 	await settleWithin(tui.waitForPending(), "the staged tool toggle");
 	await waitForOpenCount(tui, 3, running);
-	assert.deepEqual(mock.rawPi.getActiveTools(), STABLE_TOOLS);
+	assert.deepEqual(mock.rawPi.getActiveTools(), STARTUP_TOOLS);
 	assert.equal(mock.entries.length, 0);
 	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
@@ -278,7 +391,7 @@ test("launch tool drafts and help navigation cancel without side effects", async
 	await waitForOpenCount(tui, 3, running);
 	tui.press("tui.select.cancel");
 	await waitForOpenCount(tui, 4, running);
-	assert.deepEqual(mock.rawPi.getActiveTools(), STABLE_TOOLS);
+	assert.deepEqual(mock.rawPi.getActiveTools(), STARTUP_TOOLS);
 	assert.equal(mock.entries.length, 0);
 
 	tui.press("tui.select.down");
@@ -291,7 +404,7 @@ test("launch tool drafts and help navigation cancel without side effects", async
 	tui.press("tui.select.cancel");
 	await running;
 
-	assert.deepEqual(mock.rawPi.getActiveTools(), STABLE_TOOLS);
+	assert.deepEqual(mock.rawPi.getActiveTools(), STARTUP_TOOLS);
 	assert.equal(mock.entries.length, 0);
 	assert.equal(mock.thinkingLevels.length, 0);
 	assert.equal(mock.sentUserMessages.length, 0);
@@ -313,7 +426,7 @@ test("inactive bare /plan adapts the launch menu to RPC", async () => {
 	rpc.assertConsumed();
 	assert.equal(
 		rpc.dialogs[0]?.title,
-		"Plan mode\nStatus: Off — the session tool envelope is already stable.\nPlan policy will allow: read.",
+		"Plan mode\nStatus: Off — Plan helper tools load on the first Plan start.\nPlan policy will allow: read.",
 	);
 	assert.deepEqual(rpc.dialogs[0]?.options, [
 		"Start Plan mode",
@@ -391,7 +504,7 @@ test("session replacement and shutdown discard staged launch tools", async () =>
 		} else await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
 		await settleWithin(running, `${ending} launch cancellation`);
 
-		assert.deepEqual(mock.rawPi.getActiveTools(), STABLE_TOOLS);
+		assert.deepEqual(mock.rawPi.getActiveTools(), STARTUP_TOOLS);
 		assert.equal(mock.thinkingLevels.length, 0);
 		assert.equal(mock.sentUserMessages.length, 0);
 		const latest = mock.entries.at(-1)?.data as { selectedToolNames?: string[] } | undefined;

--- a/packages/pi-plan-mode/test/mode-transition-lifecycle.test.ts
+++ b/packages/pi-plan-mode/test/mode-transition-lifecycle.test.ts
@@ -100,7 +100,7 @@ test("manual tree navigation restores branch-owned mode state without changing t
 	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
 	const tree = mock.events.get("session_tree")?.[0];
 	assert.ok(tree);
-	assert.deepEqual(mock.rawPi.getActiveTools(), BASELINE);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "edit", "write"]);
 
 	branch.splice(
 		0,

--- a/packages/pi-plan-mode/test/plan-mode.test.ts
+++ b/packages/pi-plan-mode/test/plan-mode.test.ts
@@ -177,12 +177,7 @@ test("malformed persisted Plan state fails closed", async () => {
 		});
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		assert.equal(context.statuses.get("plan-mode"), undefined);
-		assert.deepEqual(mock.rawPi.getActiveTools(), [
-			"read",
-			"write",
-			"plan_mode_question",
-			"plan_mode_complete",
-		]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
@@ -261,6 +256,36 @@ test("session resume restores active Plan state and required tools", async () =>
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		await rm(directory, { recursive: true, force: true });
 	}
+});
+
+test("session restore fails closed when required Plan helpers cannot be activated", async () => {
+	const restoredState = {
+		type: "custom",
+		customType: "plan-mode-state",
+		data: { enabled: true, awaitingAction: false },
+	};
+	const mock = createMockPi({ activeTools: ["read"] });
+	const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+	mock.rawPi.setActiveTools = (names) => {
+		setActiveTools(names.filter((name) => name !== "plan_mode_complete"));
+	};
+	planMode(mock.pi);
+	const context = createMockContext({
+		hasUI: true,
+		sessionManager: {
+			getBranch: () => [restoredState],
+			getEntries: () => [restoredState],
+		},
+	});
+
+	await mock.events.get("session_start")?.[0]?.({ reason: "resume" }, context.ctx);
+	assert.equal(context.statuses.get("plan-mode"), undefined);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+	assert.match(context.notifications.at(-1)?.message ?? "", /helper tools are unavailable/i);
+
+	mock.rawPi.setActiveTools = setActiveTools;
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	assert.equal(context.statuses.get("plan-mode"), "plan active");
 });
 
 test("session restore uses only the active branch state", async () => {
@@ -469,14 +494,14 @@ test("Plan thinking level restores only while the extension owns the applied val
 	}
 });
 
-test("Plan mode restores an intentionally empty active-tool set", async () => {
+test("Plan activation adds only its helpers to an intentionally empty active-tool set", async () => {
 	const mock = createMockPi({ activeTools: [], allTools: [] });
 	planMode(mock.pi);
 	const context = createMockContext();
 	await mock.commands.get("plan")?.handler("start", context.ctx);
-	assert.deepEqual(mock.rawPi.getActiveTools(), []);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["plan_mode_question", "plan_mode_complete"]);
 	await mock.commands.get("plan")?.handler("exit", context.ctx);
-	assert.deepEqual(mock.rawPi.getActiveTools(), []);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["plan_mode_question", "plan_mode_complete"]);
 });
 
 test("manual thinking changes survive active Plan-mode shutdown and resume", async () => {
@@ -521,15 +546,33 @@ test("Plan lifecycle enters with a prompt and hands a valid plan to implementati
 	});
 	await mock.commands.get("plan")?.handler("design it", context.ctx);
 	assert.deepEqual(mock.sentUserMessages[0], { text: "design it", options: undefined });
-	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "custom"]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"read",
+		"bash",
+		"custom",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
 
 	await mock.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", content: "<proposed_plan>\n# Ship it\n</proposed_plan>" }] },
 		context.ctx,
 	);
-	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "custom"]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"read",
+		"bash",
+		"custom",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
 	await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
-	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash", "custom"]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"read",
+		"bash",
+		"custom",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
 	assert.equal(mock.sentUserMessages.at(-1)?.text, "Implement the plan.");
 	assert.equal(context.statuses.get("plan-mode"), undefined);
 });
@@ -661,12 +704,7 @@ test("busy inactive Plan starts fail observably without changing state in every 
 					/run is active.*retry/i,
 				);
 			}
-			assert.deepEqual(mock.rawPi.getActiveTools(), [
-				"read",
-				"write",
-				"plan_mode_question",
-				"plan_mode_complete",
-			]);
+			assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "write"]);
 			assert.equal(mock.entries.length, 0);
 			assert.equal(mock.sentUserMessages.length, 0);
 		}
@@ -875,7 +913,12 @@ test("plan implement fails closed without a plan and hands off a stored plan", a
 	await execute("complete", { plan: "# Implement me" }, undefined, undefined, context.ctx);
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
 	assert.equal(context.statuses.get("plan-mode"), undefined);
-	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "custom"]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"read",
+		"custom",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
 	assert.equal(mock.sentUserMessages.at(-1)?.text, "Implement the plan.");
 });
 
@@ -903,6 +946,44 @@ test("inline prompt delivery failure rolls back newly entered Plan mode", async 
 	assert.equal(context.statuses.get("plan-mode"), undefined);
 	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "bash"]);
 	assert.match(context.notifications.at(-1)?.message ?? "", /no longer active/);
+});
+
+test("failed activation contract and state commits restore lazy helper visibility", async () => {
+	for (const failure of ["contract", "state"] as const) {
+		const mock = createMockPi({ activeTools: ["read"] });
+		planMode(mock.pi);
+		const context = createMockContext({ hasUI: true });
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+
+		if (failure === "contract") {
+			mock.rawPi.sendMessage = () => {
+				throw new Error("mock contract failure\u001b]52;c;payload\u0007");
+			};
+			await mock.commands.get("plan")?.handler("start", context.ctx);
+			const message = context.notifications.at(-1)?.message ?? "";
+			assert.equal(
+				[...message].some((character) => {
+					const code = character.charCodeAt(0);
+					return code <= 31 || (code >= 127 && code <= 159);
+				}),
+				false,
+			);
+		} else {
+			const appendEntry = mock.rawPi.appendEntry.bind(mock.rawPi);
+			mock.rawPi.appendEntry = () => {
+				throw new Error("mock state failure");
+			};
+			await assert.rejects(
+				mock.commands.get("plan")?.handler("start", context.ctx) as Promise<unknown>,
+				/mock state failure/,
+			);
+			mock.rawPi.appendEntry = appendEntry;
+		}
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read"]);
+		assert.equal(context.statuses.get("plan-mode"), undefined);
+	}
 });
 
 test("invalid proposed plans remain unready and notify the user", async () => {

--- a/packages/pi-plan-mode/test/saved-plan.test.ts
+++ b/packages/pi-plan-mode/test/saved-plan.test.ts
@@ -442,12 +442,7 @@ test("saved Plan survives resume and blocks replacement workflows", async () => 
 	await mock.commands.get("plan")?.handler("design something else", context.ctx);
 	await mock.commands.get("plan")?.handler("tools", context.ctx);
 	assert.equal(mock.sentUserMessages.length, 0);
-	assert.deepEqual(mock.rawPi.getActiveTools(), [
-		"read",
-		"edit",
-		"plan_mode_question",
-		"plan_mode_complete",
-	]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
 	assert.equal(context.statuses.get("plan-mode"), "plan saved");
 	assert.match(context.notifications.at(-1)?.message ?? "", /implement or clear/i);
 	await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
@@ -493,12 +488,7 @@ test("saved Plan no-UI management is observable without changing state", async (
 			/saved plan.*print|print.*saved plan/i,
 		);
 		assert.equal(context.statuses.get("plan-mode"), "plan saved");
-		assert.deepEqual(mock.rawPi.getActiveTools(), [
-			"read",
-			"edit",
-			"plan_mode_question",
-			"plan_mode_complete",
-		]);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
 		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
 		assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
 	}
@@ -573,12 +563,7 @@ test("session shutdown disposes a saved Plan menu without a late transition", as
 
 	assert.ok(menuHarness);
 	assert.equal(context.statuses.get("plan-mode"), undefined);
-	assert.deepEqual(mock.rawPi.getActiveTools(), [
-		"read",
-		"edit",
-		"plan_mode_question",
-		"plan_mode_complete",
-	]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["read", "edit"]);
 	assert.equal(latestState(mock.entries)?.savedPlan?.plan, PLAN);
 	assert.equal(mock.sentMessages.length, 0);
 	assert.equal(mock.sentUserMessages.length, 0);

--- a/packages/pi-plan-mode/test/settings-menu.test.ts
+++ b/packages/pi-plan-mode/test/settings-menu.test.ts
@@ -52,7 +52,7 @@ function menuOptions(
 	};
 }
 
-test("Plan settings show five flat workflow rows without materializing a missing file", async () => {
+test("Plan settings show six flat workflow rows without materializing a missing file", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
@@ -63,6 +63,7 @@ test("Plan settings show five flat workflow rows without materializing a missing
 		assert.match(frame, /Plan reinjection\s+Off — conversation history only/);
 		assert.match(frame, /Export destination\s+PLAN\.md/);
 		assert.match(frame, /Plan mode shortcut\s+none/);
+		assert.match(frame, /Plan tools\s+After first plan/);
 		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
 		await assert.rejects(access(settingsPath));
 
@@ -87,6 +88,27 @@ test("Plan settings save thinking immediately for the next workflow", async () =
 		);
 		assert.equal(saved.at(-1)?.thinkingLevel, "off");
 		assert.match(tui.render().join("\n"), /Plan thinking\s+off/);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("Plan helper visibility saves immediately", async () => {
+	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
+		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
+		await tui.waitForOpen();
+		for (let index = 0; index < 5; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+
+		assert.equal(saved.at(-1)?.toolVisibility, "always");
+		assert.equal(
+			(JSON.parse(await readFile(settingsPath, "utf8")) as { toolVisibility?: string })
+				.toolVisibility,
+			"always",
+		);
+		assert.match(tui.render().join("\n"), /Plan tools\s+Always/);
 		tui.press("ctrl+c");
 		await running;
 	});
@@ -341,6 +363,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan reinjection (Off — conversation history only)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
+					"Plan tools (After first plan)",
 					"Back",
 				],
 				response: "Plan reinjection (Off — conversation history only)",
@@ -353,6 +376,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan reinjection (Through first implementation run)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
+					"Plan tools (After first plan)",
 					"Back",
 				],
 				response: "Export destination (PLAN.md)",
@@ -370,6 +394,7 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan reinjection (Through first implementation run)",
 					"Export destination (rpc/PLAN.md)",
 					"Plan mode shortcut (none)",
+					"Plan tools (After first plan)",
 					"Back",
 				],
 				response: undefined,
@@ -396,6 +421,7 @@ test("Plan settings adapt to RPC cancellation and disposal aborts an in-flight s
 				"Plan reinjection (Off — conversation history only)",
 				"Export destination (PLAN.md)",
 				"Plan mode shortcut (none)",
+				"Plan tools (After first plan)",
 				"Back",
 			],
 			response: undefined,

--- a/packages/pi-plan-mode/test/settings.test.ts
+++ b/packages/pi-plan-mode/test/settings.test.ts
@@ -17,6 +17,7 @@ import {
 	configuredImplementationPlanRetention,
 	configuredPlanExportPath,
 	configuredPlanModeToggleShortcut,
+	configuredPlanModeToolVisibility,
 	normalizePlanModeSettings,
 	readPlanModeSettings,
 	updatePlanModeSettings,
@@ -39,6 +40,33 @@ test("Plan-mode settings validate inherit and fixed thinking levels", async () =
 		assert.deepEqual(await readPlanModeSettings(path), {
 			kind: "loaded",
 			settings: { thinkingLevel: "high" },
+		});
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("Plan-mode settings default and validate helper tool visibility", async () => {
+	const defaults = normalizePlanModeSettings({});
+	assert.ok(defaults);
+	assert.equal(configuredPlanModeToolVisibility(defaults), "after-first-plan");
+	for (const toolVisibility of ["always", "after-first-plan"] as const) {
+		const normalized = normalizePlanModeSettings({ toolVisibility });
+		assert.ok(normalized);
+		assert.equal(configuredPlanModeToolVisibility(normalized), toolVisibility);
+	}
+	assert.equal(normalizePlanModeSettings({ toolVisibility: "sometimes" }), undefined);
+
+	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-visibility-test-"));
+	try {
+		const settingsPath = join(directory, "pi-plan-mode.json");
+		await updatePlanModeSettings({ toolVisibility: "always" }, { settingsPath });
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			toolVisibility: "always",
+		});
+		assert.deepEqual(await readPlanModeSettings(settingsPath), {
+			kind: "loaded",
+			settings: { thinkingLevel: "inherit", toolVisibility: "always" },
 		});
 	} finally {
 		await rm(directory, { recursive: true, force: true });

--- a/packages/pi-plan-mode/test/workflow-mutex.test.ts
+++ b/packages/pi-plan-mode/test/workflow-mutex.test.ts
@@ -241,7 +241,7 @@ test("busy direct starts preserve state in every command mode", async () => {
 	}
 });
 
-test("busy restored activation performs only the startup envelope write", async () => {
+test("busy restored activation does not widen the startup tool envelope", async () => {
 	const entry = persistedPlanState({ enabled: true, awaitingAction: false });
 	const sessionManager = { getBranch: () => [entry], getEntries: () => [entry] };
 	const mock = createMockPi({ activeTools: ["goal_complete"], thinkingLevel: "high" });
@@ -256,12 +256,8 @@ test("busy restored activation performs only the startup envelope write", async 
 	const context = createMockContext({ mode: "tui", hasUI: true, sessionManager });
 
 	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
-	assert.equal(activeToolWrites, 1);
-	assert.deepEqual(mock.rawPi.getActiveTools(), [
-		"goal_complete",
-		"plan_mode_question",
-		"plan_mode_complete",
-	]);
+	assert.equal(activeToolWrites, 0);
+	assert.deepEqual(mock.rawPi.getActiveTools(), ["goal_complete"]);
 	assert.equal(mock.thinkingLevel, "high");
 	assert.equal(mock.thinkingLevels.length, 0);
 	assert.equal(mock.entries.length, 0);
@@ -322,12 +318,7 @@ test("busy menu, selected-tool, shortcut, and active-implementation starts stay 
 	});
 	await shortcutMock.events.get("session_start")?.[0]?.({ reason: "startup" }, shortcutContext.ctx);
 	await shortcutMock.shortcuts.get("ctrl+shift+p")?.handler(shortcutContext.ctx);
-	assert.deepEqual(shortcutMock.rawPi.getActiveTools(), [
-		"read",
-		"write",
-		"plan_mode_question",
-		"plan_mode_complete",
-	]);
+	assert.deepEqual(shortcutMock.rawPi.getActiveTools(), ["read", "write"]);
 	assert.equal(shortcutMock.entries.length, 0);
 	assert.match(shortcutContext.notifications.at(-1)?.message ?? "", /Another workflow/u);
 
@@ -365,12 +356,7 @@ test("busy menu, selected-tool, shortcut, and active-implementation starts stay 
 	await activeMock.commands.get("plan")?.handler("", activeContext.ctx);
 	assert.ok(startNew);
 	startNew();
-	assert.deepEqual(activeMock.rawPi.getActiveTools(), [
-		"read",
-		"write",
-		"plan_mode_question",
-		"plan_mode_complete",
-	]);
+	assert.deepEqual(activeMock.rawPi.getActiveTools(), ["read", "write"]);
 	assert.equal(activeMock.entries.length, 0);
 	assert.deepEqual([...activeContext.statuses], statusSnapshot);
 });

--- a/test/plan-goal-coexistence.test.ts
+++ b/test/plan-goal-coexistence.test.ts
@@ -226,6 +226,33 @@ for (const loadOrder of ["plan-first", "goal-first"] as const) {
 	}
 }
 
+for (const loadOrder of ["plan-first", "goal-first"] as const) {
+	test(`${loadOrder} lazy Plan activation appends only Plan helpers`, async () => {
+		const fixture = createFixture(loadOrder);
+		await startSession(fixture);
+		assert.deepEqual(fixture.mock.rawPi.getActiveTools(), [
+			"read",
+			"bash",
+			"write",
+			"goal_complete",
+			"goal_blocked",
+			"goal_wait",
+		]);
+
+		await startPlan(fixture);
+		assert.deepEqual(fixture.mock.rawPi.getActiveTools(), [
+			"read",
+			"bash",
+			"write",
+			"goal_complete",
+			"goal_blocked",
+			"goal_wait",
+			"plan_mode_question",
+			"plan_mode_complete",
+		]);
+	});
+}
+
 test("Plan ready and revision states reject Goal without changing Plan tools", async () => {
 	const fixture = createFixture("plan-first");
 	await startSession(fixture);
@@ -389,8 +416,6 @@ for (const loadOrder of ["plan-first", "goal-first"] as const) {
 				"goal_complete",
 				"goal_blocked",
 				"goal_wait",
-				"plan_mode_question",
-				"plan_mode_complete",
 			]);
 		}
 	});


### PR DESCRIPTION
## Summary

- add `Plan tools` visibility with `Always` and default `After first plan` settings
- reveal Plan helpers atomically on the first admitted Plan workflow, then keep them active for the runtime
- protect startup, restore, hot reload, and Settings changes with idle checks, Workflow Mutex admission, stale-session guards, and exact rollback
- document the intentional one-time lazy cache-prefix change and add a minor Changeset

## Verification

- focused Plan/coexistence verification: 24 files, 258 tests passed
- `npm run check`
- `npm test`: 365 files, 3,257 tests passed
- `npm --workspace @narumitw/pi-plan-mode run build`
- `npm pack --workspace @narumitw/pi-plan-mode --dry-run --json`: 40 files inspected, required source/runtime artifacts present
- fenced-code-aware README heading audit: 26 active publishable packages passed
- isolated RPC package smokes verified helpers are hidden before default lazy activation, visible after `/plan start`, and visible at startup with `Always`

## Risk

- `After first plan` intentionally changes the provider tool/prompt prefix once on first use and is not Pi native deferred loading.
- No required verification paths remain unverified.
