### PR TITLE
feat(todo-widget): show agent todos above editor

### DIFF
--- a/.pi/extensions/todo-widget/index.test.ts
+++ b/.pi/extensions/todo-widget/index.test.ts
@@ -1,0 +1,292 @@
+import assert from "node:assert/strict";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	SessionEntry,
+	Theme,
+} from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import todoWidgetExtension, {
+	renderTodoWidget,
+	sanitizeTodoText,
+	TODO_DETAILS_VERSION,
+	TOOL_NAME,
+	type TodoDetails,
+	type TodoItem,
+	WIDGET_KEY,
+} from "./index.js";
+
+type Handler = (event: never, ctx: ExtensionContext) => unknown;
+type WidgetFactory = (_tui: never, theme: Theme) => Component;
+
+interface RegisteredTool {
+	execute(
+		toolCallId: string,
+		params: { items: TodoItem[] },
+		signal: AbortSignal | undefined,
+		onUpdate: undefined,
+		ctx: ExtensionContext,
+	): Promise<{ content: Array<{ type: string; text: string }>; details: TodoDetails }>;
+}
+
+function createHarness() {
+	const handlers = new Map<string, Handler[]>();
+	let tool: RegisteredTool | undefined;
+	const pi = {
+		on(event: string, handler: Handler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		registerTool(definition: RegisteredTool) {
+			tool = definition;
+		},
+	} as unknown as ExtensionAPI;
+	todoWidgetExtension(pi);
+
+	return {
+		get tool(): RegisteredTool {
+			assert.ok(tool);
+			return tool;
+		},
+		async emit(event: string, ctx: ExtensionContext) {
+			for (const handler of handlers.get(event) ?? []) await handler({} as never, ctx);
+		},
+	};
+}
+
+function createContext(options: { mode?: ExtensionContext["mode"]; branch?: SessionEntry[] } = {}) {
+	const widgets: Array<{
+		key: string;
+		content: WidgetFactory | undefined;
+		options: { placement: "aboveEditor" } | undefined;
+	}> = [];
+	const branch = options.branch ?? [];
+	const sessionManager = {
+		getBranch: () => branch,
+	} as unknown as ExtensionContext["sessionManager"];
+	const ctx = {
+		mode: options.mode ?? "tui",
+		hasUI: options.mode !== "print" && options.mode !== "json",
+		sessionManager,
+		ui: {
+			setWidget(
+				key: string,
+				content: WidgetFactory | undefined,
+				widgetOptions?: { placement: "aboveEditor" },
+			) {
+				widgets.push({ key, content, options: widgetOptions });
+			},
+		},
+	} as unknown as ExtensionContext;
+	return { branch, ctx, widgets };
+}
+
+function identityTheme() {
+	const calls: Array<[string, string]> = [];
+	const theme = {
+		fg(role: string, text: string) {
+			calls.push(["fg", role]);
+			return text;
+		},
+		bold(text: string) {
+			calls.push(["style", "bold"]);
+			return text;
+		},
+		strikethrough(text: string) {
+			calls.push(["style", "strikethrough"]);
+			return text;
+		},
+	} as unknown as Theme;
+	return { calls, theme };
+}
+
+function toolResultEntry(details: TodoDetails): SessionEntry {
+	return {
+		type: "message",
+		id: "tool-result",
+		parentId: null,
+		timestamp: new Date(0).toISOString(),
+		message: {
+			role: "toolResult",
+			toolCallId: "todo-call",
+			toolName: TOOL_NAME,
+			content: [{ type: "text", text: "updated" }],
+			details,
+			isError: false,
+			timestamp: 0,
+		},
+	} as SessionEntry;
+}
+
+async function setTodos(
+	harness: ReturnType<typeof createHarness>,
+	ctx: ExtensionContext,
+	items: TodoItem[],
+) {
+	return harness.tool.execute("todo-call", { items }, undefined, undefined, ctx);
+}
+
+test("renders completed, current, and pending tasks with themed semantic symbols", () => {
+	const { calls, theme } = identityTheme();
+	const lines = renderTodoWidget(
+		[
+			{ text: "done", status: "completed" },
+			{ text: "working", status: "in_progress" },
+			{ text: "later", status: "pending" },
+		],
+		theme,
+		80,
+	);
+
+	assert.deepEqual(lines, ["Tasks 1/3", "✓ done", "▶ working", "○ later"]);
+	assert.ok(calls.some(([kind, role]) => kind === "fg" && role === "success"));
+	assert.ok(calls.some(([kind, role]) => kind === "fg" && role === "accent"));
+	assert.ok(calls.some(([kind, role]) => kind === "fg" && role === "dim"));
+	assert.ok(calls.some(([kind, role]) => kind === "style" && role === "bold"));
+	assert.ok(calls.some(([kind, role]) => kind === "style" && role === "strikethrough"));
+});
+
+test("sanitizes terminal and bidi controls and bounds every rendered line", () => {
+	const hostile = "safe\u001b]8;;https://evil\u0007link\u001b]8;;\u0007\n界界\u202e";
+	assert.equal(sanitizeTodoText(hostile), "safelink 界界");
+
+	const { theme } = identityTheme();
+	const lines = renderTodoWidget([{ text: hostile, status: "in_progress" }], theme, 6);
+	for (const line of lines) assert.ok(visibleWidth(line) <= 6);
+	const unsafeSequences = [
+		`${String.fromCharCode(0x1b)}]`,
+		String.fromCharCode(0x07),
+		String.fromCodePoint(0x202e),
+	];
+	assert.equal(
+		lines.some((line) => unsafeSequences.some((sequence) => line.includes(sequence))),
+		false,
+	);
+});
+
+test("tool replaces the complete list, updates the widget, clears it, and rejects invalid state", async () => {
+	const harness = createHarness();
+	const current = createContext();
+	await harness.emit("session_start", current.ctx);
+
+	const cancelled = new AbortController();
+	cancelled.abort();
+	await assert.rejects(
+		harness.tool.execute("todo-call", { items: [] }, cancelled.signal, undefined, current.ctx),
+		/aborted/iu,
+	);
+
+	const result = await setTodos(harness, current.ctx, [
+		{ text: "task 1", status: "completed" },
+		{ text: "task 2", status: "in_progress" },
+		{ text: "task 3", status: "pending" },
+	]);
+	assert.equal(result.content[0]?.text, "Todo widget updated: 1/3 completed, 1 in progress.");
+	assert.deepEqual(result.details, {
+		version: TODO_DETAILS_VERSION,
+		items: [
+			{ text: "task 1", status: "completed" },
+			{ text: "task 2", status: "in_progress" },
+			{ text: "task 3", status: "pending" },
+		],
+	});
+
+	const widget = current.widgets.at(-1);
+	assert.equal(widget?.key, WIDGET_KEY);
+	assert.equal(widget?.options?.placement, "aboveEditor");
+	assert.equal(typeof widget?.content, "function");
+	const { theme } = identityTheme();
+	assert.deepEqual(widget?.content?.(undefined as never, theme).render(80), [
+		"Tasks 1/3",
+		"✓ task 1",
+		"▶ task 2",
+		"○ task 3",
+	]);
+
+	await assert.rejects(
+		setTodos(harness, current.ctx, [
+			{ text: "one", status: "in_progress" },
+			{ text: "two", status: "in_progress" },
+		]),
+		/at most one in_progress/u,
+	);
+	await assert.rejects(
+		setTodos(harness, current.ctx, [{ text: " \n ", status: "pending" }]),
+		/non-whitespace text/u,
+	);
+
+	const cleared = await setTodos(harness, current.ctx, []);
+	assert.equal(cleared.content[0]?.text, "Todo widget cleared.");
+	assert.deepEqual(current.widgets.at(-1), {
+		key: WIDGET_KEY,
+		content: undefined,
+		options: undefined,
+	});
+});
+
+test("restores branch-local state on startup and tree navigation", async () => {
+	const initial: TodoDetails = {
+		version: TODO_DETAILS_VERSION,
+		items: [{ text: "restored", status: "in_progress" }],
+	};
+	const harness = createHarness();
+	const current = createContext({ branch: [toolResultEntry(initial)] });
+	await harness.emit("session_start", current.ctx);
+
+	const { theme } = identityTheme();
+	assert.deepEqual(
+		current.widgets
+			.at(-1)
+			?.content?.(undefined as never, theme)
+			.render(80),
+		["Tasks 0/1", "▶ restored"],
+	);
+
+	current.branch.push(
+		toolResultEntry({
+			version: TODO_DETAILS_VERSION,
+			items: [{ text: "finished branch", status: "completed" }],
+		}),
+	);
+	await harness.emit("session_tree", current.ctx);
+	assert.deepEqual(
+		current.widgets
+			.at(-1)
+			?.content?.(undefined as never, theme)
+			.render(80),
+		["Tasks 1/1", "✓ finished branch"],
+	);
+});
+
+test("guards component widgets to TUI mode and ignores stale session shutdown", async () => {
+	const harness = createHarness();
+	const previous = createContext();
+	const current = createContext();
+	await harness.emit("session_start", previous.ctx);
+	await setTodos(harness, previous.ctx, [{ text: "old", status: "in_progress" }]);
+	await harness.emit("session_start", current.ctx);
+	await setTodos(harness, current.ctx, [{ text: "current", status: "in_progress" }]);
+	const currentWidgetCount = current.widgets.length;
+
+	await harness.emit("session_shutdown", previous.ctx);
+	assert.equal(current.widgets.length, currentWidgetCount);
+	await assert.rejects(
+		setTodos(harness, previous.ctx, [{ text: "stale", status: "pending" }]),
+		/session changed/u,
+	);
+
+	await harness.emit("session_shutdown", current.ctx);
+	assert.deepEqual(current.widgets.at(-1), {
+		key: WIDGET_KEY,
+		content: undefined,
+		options: undefined,
+	});
+
+	const rpcHarness = createHarness();
+	const rpc = createContext({ mode: "rpc" });
+	await rpcHarness.emit("session_start", rpc.ctx);
+	const result = await setTodos(rpcHarness, rpc.ctx, [{ text: "headless", status: "in_progress" }]);
+	assert.equal(result.details.items[0]?.text, "headless");
+	assert.equal(rpc.widgets.length, 0);
+});

--- a/.pi/extensions/todo-widget/index.ts
+++ b/.pi/extensions/todo-widget/index.ts
@@ -1,0 +1,227 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	SessionEntry,
+	Theme,
+} from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, truncateToWidth } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+
+export const TOOL_NAME = "todo_widget";
+export const WIDGET_KEY = "todo-widget";
+export const TODO_DETAILS_VERSION = 1;
+export const MAX_TODO_ITEMS = 50;
+export const MAX_TODO_TEXT_LENGTH = 300;
+
+const TODO_STATUSES = ["pending", "in_progress", "completed"] as const;
+const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/gu;
+
+type TodoStatus = (typeof TODO_STATUSES)[number];
+
+export interface TodoItem {
+	text: string;
+	status: TodoStatus;
+}
+
+export interface TodoDetails {
+	version: typeof TODO_DETAILS_VERSION;
+	items: TodoItem[];
+}
+
+const TodoParameters = Type.Object({
+	items: Type.Array(
+		Type.Object({
+			text: Type.String({
+				minLength: 1,
+				maxLength: MAX_TODO_TEXT_LENGTH,
+				description: "Task text",
+			}),
+			status: StringEnum(TODO_STATUSES, {
+				description: "Task status",
+			}),
+		}),
+		{
+			maxItems: MAX_TODO_ITEMS,
+			description: "The complete authoritative todo list; an empty list clears the widget",
+		},
+	),
+});
+
+export default function todoWidgetExtension(pi: ExtensionAPI): void {
+	let activeSession: ExtensionContext["sessionManager"] | undefined;
+	let items: TodoItem[] = [];
+
+	const ownsSession = (ctx: ExtensionContext): boolean => ctx.sessionManager === activeSession;
+
+	const publish = (ctx: ExtensionContext): void => {
+		if (!ownsSession(ctx) || ctx.mode !== "tui") return;
+		if (items.length === 0) {
+			ctx.ui.setWidget(WIDGET_KEY, undefined);
+			return;
+		}
+
+		const snapshot = cloneItems(items);
+		ctx.ui.setWidget(
+			WIDGET_KEY,
+			(_tui, theme) => ({
+				render: (width) => renderTodoWidget(snapshot, theme, width),
+				invalidate: () => {},
+			}),
+			{ placement: "aboveEditor" },
+		);
+	};
+
+	pi.registerTool({
+		name: TOOL_NAME,
+		label: "Todo Widget",
+		description:
+			"Replace the session todo list shown above the editor. Always send the complete list, use one in_progress item at most, and send an empty list to clear it.",
+		promptSnippet: "Create and update the session todo list shown above the editor",
+		promptGuidelines: [
+			"Use todo_widget for multi-step coding work: send the complete list, keep at most one item in_progress, and update statuses when work advances.",
+		],
+		parameters: TodoParameters,
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			signal?.throwIfAborted();
+			if (!ownsSession(ctx)) {
+				throw new Error("Cannot update the todo widget because the session changed.");
+			}
+			validateItems(params.items);
+
+			items = cloneItems(params.items);
+			publish(ctx);
+
+			const details: TodoDetails = {
+				version: TODO_DETAILS_VERSION,
+				items: cloneItems(items),
+			};
+			if (items.length === 0) {
+				return {
+					content: [{ type: "text", text: "Todo widget cleared." }],
+					details,
+				};
+			}
+
+			const completed = items.filter((item) => item.status === "completed").length;
+			const inProgress = items.some((item) => item.status === "in_progress");
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Todo widget updated: ${completed}/${items.length} completed${inProgress ? ", 1 in progress" : ""}.`,
+					},
+				],
+				details,
+			};
+		},
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		activeSession = ctx.sessionManager;
+		items = reconstructItems(ctx.sessionManager.getBranch());
+		publish(ctx);
+	});
+
+	pi.on("session_tree", (_event, ctx) => {
+		if (!ownsSession(ctx)) return;
+		items = reconstructItems(ctx.sessionManager.getBranch());
+		publish(ctx);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		if (!ownsSession(ctx)) return;
+		if (ctx.mode === "tui") ctx.ui.setWidget(WIDGET_KEY, undefined);
+		items = [];
+		activeSession = undefined;
+	});
+}
+
+export function renderTodoWidget(
+	items: readonly TodoItem[],
+	theme: Theme,
+	width: number,
+): string[] {
+	const completed = items.filter((item) => item.status === "completed").length;
+	const lines = [theme.fg("muted", `Tasks ${completed}/${items.length}`)];
+
+	for (const item of items) {
+		const text = sanitizeTodoText(item.text);
+		switch (item.status) {
+			case "completed":
+				lines.push(theme.fg("success", "✓ ") + theme.fg("muted", theme.strikethrough(text)));
+				break;
+			case "in_progress":
+				lines.push(theme.fg("accent", "▶ ") + theme.fg("accent", theme.bold(text)));
+				break;
+			case "pending":
+				lines.push(theme.fg("dim", "○ ") + theme.fg("text", text));
+				break;
+		}
+	}
+
+	return lines.map((line) => truncateToWidth(line, Math.max(0, width), ""));
+}
+
+export function sanitizeTodoText(value: string): string {
+	let text = "";
+	for (const character of stripTerminalSequences(value).replace(BIDI_CONTROLS, "")) {
+		const codePoint = character.codePointAt(0) ?? 0;
+		const isControl = codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+		text += isControl ? " " : character;
+	}
+	return text.replace(/\s+/gu, " ").trim();
+}
+
+function validateItems(items: readonly TodoItem[]): void {
+	for (const [index, item] of items.entries()) {
+		if (item.text.trim().length === 0) {
+			throw new Error(`Todo item ${index + 1} must contain non-whitespace text.`);
+		}
+	}
+
+	const currentCount = items.filter((item) => item.status === "in_progress").length;
+	if (currentCount > 1) {
+		throw new Error("Todo list can contain at most one in_progress item.");
+	}
+}
+
+function reconstructItems(entries: readonly SessionEntry[]): TodoItem[] {
+	let restored: TodoItem[] = [];
+	for (const entry of entries) {
+		if (entry.type !== "message") continue;
+		const message = entry.message;
+		if (message.role !== "toolResult" || message.toolName !== TOOL_NAME) continue;
+		if (!isTodoDetails(message.details)) continue;
+		restored = cloneItems(message.details.items);
+	}
+	return restored;
+}
+
+function isTodoDetails(value: unknown): value is TodoDetails {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	if (record.version !== TODO_DETAILS_VERSION || !Array.isArray(record.items)) return false;
+	if (record.items.length > MAX_TODO_ITEMS) return false;
+
+	let currentCount = 0;
+	for (const item of record.items) {
+		if (typeof item !== "object" || item === null || Array.isArray(item)) return false;
+		const candidate = item as Record<string, unknown>;
+		if (
+			typeof candidate.text !== "string" ||
+			candidate.text.length === 0 ||
+			candidate.text.length > MAX_TODO_TEXT_LENGTH ||
+			candidate.text.trim().length === 0 ||
+			!TODO_STATUSES.includes(candidate.status as TodoStatus)
+		) {
+			return false;
+		}
+		if (candidate.status === "in_progress") currentCount += 1;
+	}
+	return currentCount <= 1;
+}
+
+function cloneItems(items: readonly TodoItem[]): TodoItem[] {
+	return items.map((item) => ({ text: item.text, status: item.status }));
+}

--- a/.pi/extensions/todo-widget/tsconfig.json
+++ b/.pi/extensions/todo-widget/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["./index.ts", "./index.test.ts", "./vitest.config.ts"]
+}

--- a/.pi/extensions/todo-widget/vitest.config.ts
+++ b/.pi/extensions/todo-widget/vitest.config.ts
@@ -1,0 +1,12 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	root: dirname(fileURLToPath(import.meta.url)),
+	test: {
+		environment: "node",
+		include: ["index.test.ts"],
+		testTimeout: 5_000,
+	},
+});


### PR DESCRIPTION
## Summary

- add the project-local `todo_widget` tool for replacing the current session todo list
- render completed, in-progress, and pending tasks above the editor with semantic symbols and theme roles
- restore branch-local state across session startup and tree navigation, and clear owned UI during shutdown
- sanitize terminal-facing task text and bound rendered lines

## Verification

- `npm exec -- biome check .pi/extensions/todo-widget`
- `npm exec -- tsc -p .pi/extensions/todo-widget/tsconfig.json`
- `npm exec -- vitest run --config .pi/extensions/todo-widget/vitest.config.ts` (5 tests)
- `npm run check`
- `npm test` (365 files, 3257 tests)
- `pi --no-extensions -e ./.pi/extensions/todo-widget/index.ts --list-models`

## Notes

- No Changeset is needed because this is a project-local extension under `.pi/extensions/`.
- Interactive trusted-project auto-discovery and `/reload` remain manual TUI checks.
