### PR TITLE
chore(todo): make package private

### DIFF
--- a/packages/pi-todo/package.json
+++ b/packages/pi-todo/package.json
@@ -4,7 +4,7 @@
 	"description": "Pi extension that gives coding agents a persistent session todo widget.",
 	"type": "module",
 	"license": "MIT",
-	"private": false,
+	"private": true,
 	"keywords": [
 		"pi-package",
 		"pi-extension",


### PR DESCRIPTION
## Summary

- mark `@narumitw/pi-todo` as a private workspace package
- prevent the package from being published through the release workflow

## Verification

- `npm run check`
- `npm pack --workspace @narumitw/pi-todo --dry-run --json`
- `npm test` (3261/3262 tests passed; one unrelated `pi-subagents` telemetry assertion was flaky)
- `npx vitest run packages/pi-subagents/test/rpc-transport.test.ts` (passed on focused rerun)
