### PR TITLE
feat(todo): refine wording and widget presentation

### DIFF
--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -1,19 +1,19 @@
-# ✅ pi-todo — Keep Coding Tasks Visible
+# ✅ pi-todo — Keep Multi-Step Work Visible
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-todo)](https://www.npmjs.com/package/@narumitw/pi-todo)
 [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Give coding agents a structured todo tool and show the current task list above Pi's editor.
+Give coding agents a focused todo list for tracking multi-step work above Pi's editor.
 
-The list follows the active session branch and disappears cleanly when it is empty or the session ends.
+The list follows the active session branch and disappears cleanly when no tracked work remains or the session ends.
 
 ## ✨ Features
 
-- Registers one `todo_widget` tool with pending, in-progress, and completed task states.
-- Shows a compact themed task list above the editor in TUI mode.
+- Registers one `todo_widget` tool with clear guidance for meaningful multi-step work.
+- Keeps task text concise and action-oriented, with at most one task in progress.
+- Shows a compact themed task list and completion count above the editor in TUI mode.
 - Restores the latest valid list when Pi starts a session or navigates between branches.
-- Keeps at most one task in progress and validates non-empty task text.
 - Sanitizes terminal and bidirectional controls before rendering model-provided text.
 - Works without settings, files, network access, or external services.
 
@@ -41,17 +41,17 @@ Pi extensions run with the user's permissions, so install only trusted code.
 
 ## 🚀 Quick start
 
-Ask Pi to perform a multi-step coding task.
+Ask Pi to perform work with multiple meaningful steps.
 
-The agent can create a list through `todo_widget`, keep the current step marked `in_progress`, and update the complete list as work advances.
+The agent can create a concise list through `todo_widget`, mark one task `in_progress`, complete tasks promptly, and revise the list when the plan changes.
 
-Send an empty list through the tool to clear the widget.
+The agent sends the complete current list with every update and sends an empty list when no tracked work remains.
 
 ## 🛠️ Tools
 
 ### `todo_widget`
 
-Replace the complete authoritative todo list for the active session.
+Replace the complete current todo list for the active session.
 
 Each item has this shape:
 
@@ -68,7 +68,9 @@ A list may contain up to 50 items, each item may contain up to 300 characters, a
 
 The tool result stores a versioned snapshot in the session branch so branch navigation can reconstruct the latest valid list.
 
-In TUI mode, updates appear above the editor immediately.
+In TUI mode, updates appear immediately in a widget above the editor.
+
+The widget header shows completed and total task counts, followed by themed completed, in-progress, and pending rows.
 
 In RPC, print, and JSON modes, the tool still returns structured details but does not create a visual widget.
 
@@ -82,7 +84,7 @@ Terminal escape sequences, control characters, and bidirectional display control
 
 ## 🚧 Limitations
 
-- The visual widget is available only in TUI mode.
+- The visual widget uses a fixed position above the editor and is available only in TUI mode.
 - The extension provides a model tool rather than a slash command or manual task editor.
 - Branch reconstruction uses only valid versioned `todo_widget` tool results on the active branch.
 - Long task text is shown on one bounded terminal line and may be truncated to the available width.

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -14,6 +14,7 @@ export const TODO_DETAILS_VERSION = 1;
 export const MAX_TODO_ITEMS = 50;
 export const MAX_TODO_TEXT_LENGTH = 300;
 
+const WIDGET_OPTIONS = { placement: "aboveEditor" } as const;
 const TODO_STATUSES = ["pending", "in_progress", "completed"] as const;
 const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/gu;
 
@@ -35,15 +36,15 @@ const TodoParameters = Type.Object({
 			text: Type.String({
 				minLength: 1,
 				maxLength: MAX_TODO_TEXT_LENGTH,
-				description: "Task text",
+				description: "A concise, action-oriented task",
 			}),
 			status: StringEnum(TODO_STATUSES, {
-				description: "Task status",
+				description: "The task's current status",
 			}),
 		}),
 		{
 			maxItems: MAX_TODO_ITEMS,
-			description: "The complete authoritative todo list; an empty list clears the widget",
+			description: "The complete current todo list; send an empty list to clear it",
 		},
 	),
 });
@@ -68,24 +69,26 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 				render: (width) => renderTodoWidget(snapshot, theme, width),
 				invalidate: () => {},
 			}),
-			{ placement: "aboveEditor" },
+			WIDGET_OPTIONS,
 		);
 	};
 
 	pi.registerTool({
 		name: TOOL_NAME,
-		label: "Todo Widget",
+		label: "Todo List",
 		description:
-			"Replace the session todo list shown above the editor. Always send the complete list, use one in_progress item at most, and send an empty list to clear it.",
-		promptSnippet: "Create and update the session todo list shown above the editor",
+			"Replace the current session todo list. Send the complete list on every call, keep at most one item in_progress, and send an empty list to clear it.",
+		promptSnippet: "Track progress on multi-step work with a session todo list",
 		promptGuidelines: [
-			"Use todo_widget for multi-step coding work: send the complete list, keep at most one item in_progress, and update statuses when work advances.",
+			"Use todo_widget when work has multiple meaningful steps; skip it for simple, single-step tasks.",
+			"Keep tasks concise and action-oriented. Mark one task in_progress before starting it, complete tasks promptly, and revise the list when the plan changes.",
+			"Send the complete current list on every call, keep at most one task in_progress, and send an empty list when no tracked work remains.",
 		],
 		parameters: TodoParameters,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			signal?.throwIfAborted();
 			if (!ownsSession(ctx)) {
-				throw new Error("Cannot update the todo widget because the session changed.");
+				throw new Error("Cannot update the todo list because the session changed.");
 			}
 			validateItems(params.items);
 
@@ -98,7 +101,7 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 			};
 			if (items.length === 0) {
 				return {
-					content: [{ type: "text", text: "Todo widget cleared." }],
+					content: [{ type: "text", text: "Todo list cleared." }],
 					details,
 				};
 			}
@@ -109,7 +112,7 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 				content: [
 					{
 						type: "text",
-						text: `Todo widget updated: ${completed}/${items.length} completed${inProgress ? ", 1 in progress" : ""}.`,
+						text: `Todo list updated: ${completed} of ${items.length} complete${inProgress ? "; 1 in progress" : ""}.`,
 					},
 				],
 				details,
@@ -143,7 +146,7 @@ export function renderTodoWidget(
 	width: number,
 ): string[] {
 	const completed = items.filter((item) => item.status === "completed").length;
-	const lines = [theme.fg("muted", `Tasks ${completed}/${items.length}`)];
+	const lines = [theme.fg("muted", `Todo · ${completed}/${items.length} complete`)];
 
 	for (const item of items) {
 		const text = sanitizeTodoText(item.text);

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -22,6 +22,10 @@ type Handler = (event: never, ctx: ExtensionContext) => unknown;
 type WidgetFactory = (_tui: never, theme: Theme) => Component;
 
 interface RegisteredTool {
+	label: string;
+	description: string;
+	promptSnippet: string;
+	promptGuidelines: string[];
 	execute(
 		toolCallId: string,
 		params: { items: TodoItem[] },
@@ -127,6 +131,19 @@ async function setTodos(
 	return harness.tool.execute("todo-call", { items }, undefined, undefined, ctx);
 }
 
+test("registers concise guidance for using and maintaining the todo list", () => {
+	const { tool } = createHarness();
+
+	assert.equal(tool.label, "Todo List");
+	assert.match(tool.description, /complete list on every call/u);
+	assert.match(tool.promptSnippet, /multi-step work/u);
+	assert.deepEqual(tool.promptGuidelines, [
+		"Use todo_widget when work has multiple meaningful steps; skip it for simple, single-step tasks.",
+		"Keep tasks concise and action-oriented. Mark one task in_progress before starting it, complete tasks promptly, and revise the list when the plan changes.",
+		"Send the complete current list on every call, keep at most one task in_progress, and send an empty list when no tracked work remains.",
+	]);
+});
+
 test("renders completed, current, and pending tasks with themed semantic symbols", () => {
 	const { calls, theme } = identityTheme();
 	const lines = renderTodoWidget(
@@ -139,7 +156,7 @@ test("renders completed, current, and pending tasks with themed semantic symbols
 		80,
 	);
 
-	assert.deepEqual(lines, ["Tasks 1/3", "✓ done", "▶ working", "○ later"]);
+	assert.deepEqual(lines, ["Todo · 1/3 complete", "✓ done", "▶ working", "○ later"]);
 	assert.ok(calls.some(([kind, role]) => kind === "fg" && role === "success"));
 	assert.ok(calls.some(([kind, role]) => kind === "fg" && role === "accent"));
 	assert.ok(calls.some(([kind, role]) => kind === "fg" && role === "dim"));
@@ -182,7 +199,7 @@ test("tool replaces the complete list, updates the widget, clears it, and reject
 		{ text: "task 2", status: "in_progress" },
 		{ text: "task 3", status: "pending" },
 	]);
-	assert.equal(result.content[0]?.text, "Todo widget updated: 1/3 completed, 1 in progress.");
+	assert.equal(result.content[0]?.text, "Todo list updated: 1 of 3 complete; 1 in progress.");
 	assert.deepEqual(result.details, {
 		version: TODO_DETAILS_VERSION,
 		items: [
@@ -194,11 +211,11 @@ test("tool replaces the complete list, updates the widget, clears it, and reject
 
 	const widget = current.widgets.at(-1);
 	assert.equal(widget?.key, WIDGET_KEY);
-	assert.equal(widget?.options?.placement, "aboveEditor");
+	assert.deepEqual(widget?.options, { placement: "aboveEditor" });
 	assert.equal(typeof widget?.content, "function");
 	const { theme } = identityTheme();
 	assert.deepEqual(widget?.content?.(undefined as never, theme).render(80), [
-		"Tasks 1/3",
+		"Todo · 1/3 complete",
 		"✓ task 1",
 		"▶ task 2",
 		"○ task 3",
@@ -217,7 +234,7 @@ test("tool replaces the complete list, updates the widget, clears it, and reject
 	);
 
 	const cleared = await setTodos(harness, current.ctx, []);
-	assert.equal(cleared.content[0]?.text, "Todo widget cleared.");
+	assert.equal(cleared.content[0]?.text, "Todo list cleared.");
 	assert.deepEqual(current.widgets.at(-1), {
 		key: WIDGET_KEY,
 		content: undefined,
@@ -240,7 +257,7 @@ test("restores branch-local state on startup and tree navigation", async () => {
 			.at(-1)
 			?.content?.(undefined as never, theme)
 			.render(80),
-		["Tasks 0/1", "▶ restored"],
+		["Todo · 0/1 complete", "▶ restored"],
 	);
 
 	current.branch.push(
@@ -255,7 +272,7 @@ test("restores branch-local state on startup and tree navigation", async () => {
 			.at(-1)
 			?.content?.(undefined as never, theme)
 			.render(80),
-		["Tasks 1/1", "✓ finished branch"],
+		["Todo · 1/1 complete", "✓ finished branch"],
 	);
 });
 


### PR DESCRIPTION
## Summary

- clarify when and how the agent should maintain the session todo list
- use consistent todo-list wording in tool metadata, results, and documentation
- make the widget header more descriptive while preserving its above-editor placement
- add focused coverage for tool guidance, widget configuration, and rendered wording

## Verification

- `npm run check`
- `npm test` (3263 tests passed)
- `npx vitest run packages/pi-todo/test/todo-widget.test.ts`
- README heading audit
- `npm pack --workspace @narumitw/pi-todo --dry-run --json`
- `git diff --check`
