### PR TITLE
feat(plan-mode): add top divider to widget

### DIFF
--- a/.changeset/calm-plans-divide.md
+++ b/.changeset/calm-plans-divide.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": patch
+---
+
+Add an editor-style divider above the Plan mode widget.

--- a/packages/pi-plan-mode/src/presentation.ts
+++ b/packages/pi-plan-mode/src/presentation.ts
@@ -1,8 +1,10 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, truncateToWidth } from "@earendil-works/pi-tui";
 import type { PlanModeState } from "./state.js";
 
 const STATUS_KEY = "plan-mode";
 const PLAN_WIDGET_KEY = "plan-mode-plan";
+const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/gu;
 
 export function updatePlanModeUi(
 	ctx: ExtensionContext,
@@ -10,30 +12,44 @@ export function updatePlanModeUi(
 	toolSummary: () => string,
 ) {
 	ctx.ui.setStatus(STATUS_KEY, formatStatus(state));
+	let lines: string[] | undefined;
 	if (state.enabled && state.latestPlan) {
-		ctx.ui.setWidget(PLAN_WIDGET_KEY, [
-			"Proposed plan ready",
-			"Use /plan to implement, save, revise, or exit Plan mode.",
-		]);
+		lines = ["Proposed plan ready", "Use /plan to implement, save, revise, or exit Plan mode."];
 	} else if (state.enabled) {
-		ctx.ui.setWidget(PLAN_WIDGET_KEY, [
+		lines = [
 			"Plan mode: planning",
 			toolSummary(),
 			"Finish with plan_mode_complete when decision-ready.",
-		]);
+		];
 	} else if (state.savedPlan) {
-		ctx.ui.setWidget(PLAN_WIDGET_KEY, [
-			"Plan saved for later",
-			"Use /plan to show, implement, or clear it.",
-		]);
+		lines = ["Plan saved for later", "Use /plan to show, implement, or clear it."];
 	} else if (state.activeImplementation) {
-		ctx.ui.setWidget(PLAN_WIDGET_KEY, [
-			"Implementation plan active",
-			"Use /plan to show, replace, or clear it.",
-		]);
-	} else {
-		ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
+		lines = ["Implementation plan active", "Use /plan to show, replace, or clear it."];
 	}
+
+	publishPlanModeWidget(ctx, lines);
+}
+
+export function renderPlanModeWidget(
+	lines: readonly string[],
+	theme: Theme,
+	width: number,
+): string[] {
+	const renderWidth = Math.max(0, width);
+	return [
+		theme.fg("borderMuted", "─".repeat(renderWidth)),
+		...lines.map((line) => truncateToWidth(sanitizePlanModeWidgetLine(line), renderWidth, "")),
+	];
+}
+
+export function sanitizePlanModeWidgetLine(value: string): string {
+	let text = "";
+	for (const character of stripTerminalSequences(value).replace(BIDI_CONTROLS, "")) {
+		const codePoint = character.codePointAt(0) ?? 0;
+		const isControl = codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+		text += isControl ? " " : character;
+	}
+	return text;
 }
 
 export function clearPlanModeUi(ctx: ExtensionContext) {
@@ -95,6 +111,23 @@ export function planModeStatusText(state: PlanModeState, toolSummary: () => stri
 	if (state.savedPlan) return "A plan is saved for later.";
 	if (state.activeImplementation) return "An implementation plan is active.";
 	return "Plan mode is off.";
+}
+
+function publishPlanModeWidget(ctx: ExtensionContext, lines: readonly string[] | undefined) {
+	if (!lines) {
+		ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
+		return;
+	}
+	if (ctx.mode !== "tui") {
+		ctx.ui.setWidget(PLAN_WIDGET_KEY, [...lines]);
+		return;
+	}
+
+	const snapshot = [...lines];
+	ctx.ui.setWidget(PLAN_WIDGET_KEY, (_tui, theme) => ({
+		render: (width) => renderPlanModeWidget(snapshot, theme, width),
+		invalidate: () => {},
+	}));
 }
 
 function formatStatus(state: PlanModeState) {

--- a/packages/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-471-repro.test.ts
@@ -8,6 +8,7 @@ import {
 import { PLAN_MODE_MAX_CHARS } from "../src/completion-tool.js";
 import planModeExtension from "../src/plan-mode.js";
 import { type ActiveImplementationPlan, restorePlanModeState } from "../src/state.js";
+import { renderMockWidget } from "./widget-support.js";
 
 const PLAN = `# Compaction-safe implementation
 
@@ -277,7 +278,7 @@ test("implementation transition rejects a busy run before committing and succeed
 	await mock.commands.get("plan")?.handler("implement", context.ctx);
 	assert.equal(context.statuses.get("plan-mode"), "plan implementing");
 	assert.match(
-		JSON.stringify(context.widgets.get("plan-mode-plan")),
+		renderMockWidget(context.widgets.get("plan-mode-plan")).join("\n"),
 		/implementation plan active/i,
 	);
 	assert.deepEqual(mock.rawPi.getActiveTools(), [

--- a/packages/pi-plan-mode/test/plan-mode.test.ts
+++ b/packages/pi-plan-mode/test/plan-mode.test.ts
@@ -16,6 +16,7 @@ import planMode, {
 	stripProposedPlanBlocks,
 	stripProposedPlanBlocksFromMessage,
 } from "../src/plan-mode.js";
+import { renderMockWidget } from "./widget-support.js";
 
 test("plan-mode registers question tools, command, and safety hooks without a CLI flag", () => {
 	const mock = createMockPi({ activeTools: ["read", "bash"] });
@@ -1300,7 +1301,8 @@ test("active Plan UI advertises the completion tool rather than legacy XML", asy
 		},
 	});
 	await mock.commands.get("plan")?.handler("start", context.ctx);
-	const widget = context.widgets.get("plan-mode-plan") as string[];
+	const widget = renderMockWidget(context.widgets.get("plan-mode-plan"));
+	assert.equal(widget[0], "─".repeat(80));
 	assert.match(widget.join("\n"), /plan_mode_complete/);
 	assert.doesNotMatch(widget.join("\n"), /proposed_plan/);
 	await mock.commands.get("plan")?.handler("", context.ctx);

--- a/packages/pi-plan-mode/test/presentation.test.ts
+++ b/packages/pi-plan-mode/test/presentation.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { renderPlanModeWidget, sanitizePlanModeWidgetLine } from "../src/presentation.js";
+
+test("renders an editor-style divider above bounded Plan mode content", () => {
+	const roles: string[] = [];
+	const theme = {
+		fg(role: string, text: string) {
+			roles.push(role);
+			return text;
+		},
+	} as unknown as Theme;
+
+	const lines = renderPlanModeWidget(["Plan mode: planning", "A longer status line"], theme, 12);
+
+	assert.deepEqual(lines.map(stripTerminalSequences), [
+		"─".repeat(12),
+		"Plan mode: p",
+		"A longer sta",
+	]);
+	assert.deepEqual(roles, ["borderMuted"]);
+	assert.ok(lines.every((line) => visibleWidth(line) <= 12));
+});
+
+test("sanitizes terminal and bidi controls before truncating Plan mode content", () => {
+	const hostile = "safe\u001b]8;;https://evil\u0007link\u001b]8;;\u0007\n界界\u202e";
+	assert.equal(sanitizePlanModeWidgetLine(hostile), "safelink 界界");
+});

--- a/packages/pi-plan-mode/test/saved-plan.test.ts
+++ b/packages/pi-plan-mode/test/saved-plan.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../test/support.js";
 import planMode, { completePlanArguments } from "../src/plan-mode.js";
 import { restorePlanModeState } from "../src/state.js";
+import { renderMockWidget } from "./widget-support.js";
 
 const PLAN = `# Saved implementation plan
 
@@ -107,7 +108,10 @@ test("plan save exits Plan mode, restores runtime state, and keeps the plan out 
 	await mock.commands.get("plan")?.handler("save", context.ctx);
 
 	assert.equal(context.statuses.get("plan-mode"), "plan saved");
-	assert.match(JSON.stringify(context.widgets.get("plan-mode-plan")), /saved for later/i);
+	assert.match(
+		renderMockWidget(context.widgets.get("plan-mode-plan")).join("\n"),
+		/saved for later/i,
+	);
 	assert.deepEqual(mock.rawPi.getActiveTools(), [
 		"read",
 		"edit",

--- a/packages/pi-plan-mode/test/widget-support.ts
+++ b/packages/pi-plan-mode/test/widget-support.ts
@@ -1,0 +1,14 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+
+type WidgetFactory = (_tui: never, theme: Theme) => Component;
+
+const IDENTITY_THEME = {
+	fg: (_role: string, text: string) => text,
+} as unknown as Theme;
+
+export function renderMockWidget(value: unknown, width = 80): string[] {
+	if (Array.isArray(value)) return value.map(String);
+	if (typeof value !== "function") throw new Error("Expected a widget factory or string array");
+	return (value as WidgetFactory)(undefined as never, IDENTITY_THEME).render(width);
+}


### PR DESCRIPTION
## Summary

- add a full-width divider above Plan mode widget content in TUI mode
- match Pi editor borders with the `borderMuted` theme role
- bound and sanitize custom-rendered widget lines while preserving non-TUI output
- cover planning, saved-plan, and active-implementation widget rendering

## Verification

- `npm run check`
- `npm test` (3265 tests)
- `npm --workspace @narumitw/pi-plan-mode run check`
- focused pi-plan-mode tests (83 tests)

## Release

- patch changeset for `@narumitw/pi-plan-mode`