### PR TITLE
feat(active-tool-status): add wrapped divider widget

### DIFF
--- a/.pi/extensions/active-tool-status/index.test.ts
+++ b/.pi/extensions/active-tool-status/index.test.ts
@@ -1,14 +1,28 @@
 import assert from "node:assert/strict";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, test, vi } from "vitest";
 import activeToolStatus, {
 	ACTIVE_TOOL_REFRESH_INTERVAL_MS,
 	formatActiveToolWidget,
+	renderActiveToolWidget,
 	sanitizeToolName,
 	WIDGET_KEY,
 } from "./index.js";
 
 type Handler = (event: never, ctx: ExtensionContext) => unknown;
+type WidgetFactory = (_tui: never, theme: Theme) => Component;
+type WidgetRecord = [
+	string,
+	string[] | WidgetFactory | undefined,
+	{ placement: "aboveEditor" } | undefined,
+];
+
+const DIVIDER = "─".repeat(80);
+const IDENTITY_THEME = {
+	fg: (_role: string, text: string) => text,
+} as unknown as Theme;
 
 afterEach(() => {
 	vi.useRealTimers();
@@ -37,18 +51,18 @@ function createHarness(initialTools: string[] = []) {
 	};
 }
 
-function createContext() {
-	const widgets: Array<[string, string[] | undefined, { placement: "aboveEditor" } | undefined]> =
-		[];
+function createContext(mode: ExtensionContext["mode"] = "tui") {
+	const widgets: WidgetRecord[] = [];
 	const sessionManager = {} as ExtensionContext["sessionManager"];
 	const ctx = {
+		mode,
 		hasUI: true,
 		isIdle: () => true,
 		sessionManager,
 		ui: {
 			setWidget(
 				key: string,
-				content: string[] | undefined,
+				content: string[] | WidgetFactory | undefined,
 				options?: { placement: "aboveEditor" },
 			) {
 				widgets.push([key, content, options]);
@@ -58,14 +72,27 @@ function createContext() {
 	return { ctx, widgets };
 }
 
+function renderWidgetRecord(
+	record: WidgetRecord | undefined,
+	width = 80,
+): WidgetRecord | undefined {
+	if (!record) return undefined;
+	const [key, content, options] = record;
+	const rendered =
+		typeof content === "function"
+			? content(undefined as never, IDENTITY_THEME).render(width)
+			: content;
+	return [key, rendered, options];
+}
+
 test("shows every active tool above the editor and refreshes when the set changes", async () => {
 	vi.useFakeTimers();
 	const harness = createHarness(["read", "bash"]);
 	const current = createContext();
 	await harness.emit("session_start", {}, current.ctx);
-	assert.deepEqual(current.widgets.at(-1), [
+	assert.deepEqual(renderWidgetRecord(current.widgets.at(-1)), [
 		WIDGET_KEY,
-		["Active tools (2)", "read · bash"],
+		[DIVIDER, "Active tools (2)", "read · bash"],
 		{ placement: "aboveEditor" },
 	]);
 
@@ -74,9 +101,9 @@ test("shows every active tool above the editor and refreshes when the set change
 
 	harness.setActiveTools(["read", "edit", "write"]);
 	await vi.advanceTimersByTimeAsync(ACTIVE_TOOL_REFRESH_INTERVAL_MS);
-	assert.deepEqual(current.widgets.at(-1), [
+	assert.deepEqual(renderWidgetRecord(current.widgets.at(-1)), [
 		WIDGET_KEY,
-		["Active tools (3)", "read · edit · write"],
+		[DIVIDER, "Active tools (3)", "read · edit · write"],
 		{ placement: "aboveEditor" },
 	]);
 
@@ -86,14 +113,14 @@ test("shows every active tool above the editor and refreshes when the set change
 		{ toolCallId: "loader", toolName: "firecrawl_load" },
 		current.ctx,
 	);
-	assert.deepEqual(current.widgets.at(-1), [
+	assert.deepEqual(renderWidgetRecord(current.widgets.at(-1)), [
 		WIDGET_KEY,
-		["Active tools (2)", "read · firecrawl_search"],
+		[DIVIDER, "Active tools (2)", "read · firecrawl_search"],
 		{ placement: "aboveEditor" },
 	]);
 
 	await harness.emit("session_shutdown", {}, current.ctx);
-	assert.deepEqual(current.widgets.at(-1), [WIDGET_KEY, undefined, undefined]);
+	assert.deepEqual(renderWidgetRecord(current.widgets.at(-1)), [WIDGET_KEY, undefined, undefined]);
 });
 
 test("session replacement ignores stale events and shutdown clears the owned widget", async () => {
@@ -105,21 +132,57 @@ test("session replacement ignores stale events and shutdown clears the owned wid
 	harness.setActiveTools(["edit"]);
 	await harness.emit("session_start", {}, current.ctx);
 	await harness.emit("before_agent_start", {}, previous.ctx);
-	assert.deepEqual(current.widgets.at(-1), [
+	assert.deepEqual(renderWidgetRecord(current.widgets.at(-1)), [
 		WIDGET_KEY,
-		["Active tool (1)", "edit"],
+		[DIVIDER, "Active tool (1)", "edit"],
 		{ placement: "aboveEditor" },
 	]);
 
 	await harness.emit("session_shutdown", {}, previous.ctx);
-	assert.deepEqual(current.widgets.at(-1), [
+	assert.deepEqual(renderWidgetRecord(current.widgets.at(-1)), [
 		WIDGET_KEY,
-		["Active tool (1)", "edit"],
+		[DIVIDER, "Active tool (1)", "edit"],
 		{ placement: "aboveEditor" },
 	]);
 
 	await harness.emit("session_shutdown", {}, current.ctx);
-	assert.deepEqual(current.widgets.at(-1), [WIDGET_KEY, undefined, undefined]);
+	assert.deepEqual(renderWidgetRecord(current.widgets.at(-1)), [WIDGET_KEY, undefined, undefined]);
+});
+
+test("keeps non-TUI widget content as plain strings", async () => {
+	const harness = createHarness(["read"]);
+	const rpc = createContext("rpc");
+	await harness.emit("session_start", {}, rpc.ctx);
+	assert.deepEqual(rpc.widgets.at(-1), [
+		WIDGET_KEY,
+		["Active tool (1)", "read"],
+		{ placement: "aboveEditor" },
+	]);
+	await harness.emit("session_shutdown", {}, rpc.ctx);
+});
+
+test("renders an editor-style divider and wraps every tool within the available width", () => {
+	const roles: string[] = [];
+	const theme = {
+		fg(role: string, text: string) {
+			roles.push(role);
+			return text;
+		},
+	} as unknown as Theme;
+	const lines = renderActiveToolWidget(
+		["Active tools (6)", "read · bash · edit · write · runtime_diagnostics · subagent_spawn"],
+		theme,
+		40,
+	);
+
+	assert.deepEqual(lines.map(stripTerminalSequences), [
+		"─".repeat(40),
+		"Active tools (6)",
+		"read · bash · edit · write ·",
+		"runtime_diagnostics · subagent_spawn",
+	]);
+	assert.deepEqual(roles, ["borderMuted"]);
+	assert.ok(lines.every((line) => visibleWidth(line) <= 40));
 });
 
 test("formats every tool as bounded safe display text", () => {

--- a/.pi/extensions/active-tool-status/index.ts
+++ b/.pi/extensions/active-tool-status/index.ts
@@ -1,4 +1,5 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import { wrapTextWithAnsi } from "@earendil-works/pi-tui";
 
 export const WIDGET_KEY = "active-tool-status";
 const MAX_TOOL_NAME_LENGTH = 32;
@@ -17,7 +18,14 @@ export default function activeToolStatus(pi: ExtensionAPI): void {
 		const content = formatActiveToolWidget(pi.getActiveTools());
 		const value = content?.join("\n");
 		if (hasPublished && value === publishedValue) return;
-		ctx.ui.setWidget(WIDGET_KEY, content, { placement: "aboveEditor" });
+		const widget =
+			content && ctx.mode === "tui"
+				? (_tui: unknown, theme: Theme) => ({
+						render: (width: number) => renderActiveToolWidget(content, theme, width),
+						invalidate: () => {},
+					})
+				: content;
+		ctx.ui.setWidget(WIDGET_KEY, widget, { placement: "aboveEditor" });
 		publishedValue = value;
 		hasPublished = true;
 	};
@@ -75,6 +83,19 @@ export function formatActiveToolWidget(toolNames: Iterable<string>): string[] | 
 	if (tools.length === 0) return undefined;
 	const label = tools.length === 1 ? "Active tool" : "Active tools";
 	return [`${label} (${tools.length})`, tools.join(" · ")];
+}
+
+export function renderActiveToolWidget(
+	lines: readonly string[],
+	theme: Theme,
+	width: number,
+): string[] {
+	const renderWidth = Math.max(0, width);
+	const contentLines =
+		renderWidth === 0
+			? lines.map(() => "")
+			: lines.flatMap((line) => wrapTextWithAnsi(line, renderWidth));
+	return [theme.fg("borderMuted", "─".repeat(renderWidth)), ...contentLines];
 }
 
 export function sanitizeToolName(value: string): string {


### PR DESCRIPTION
## Summary

- add a full-width divider above the active-tool widget using Pi editor's `borderMuted` theme role
- wrap long tool lists across width-safe lines instead of truncating them
- preserve plain string widgets outside TUI mode
- retain refresh, session replacement, and shutdown cleanup behavior

## Verification

- `npm run check`
- `npm test` (3265 tests)
- focused active-tool-status tests (5 tests)
- isolated extension load smoke
- trusted-project auto-discovery smoke

## Release

- no changeset because this is a project-local extension