### PR TITLE
feat(todo): prompt proactive progress updates

### DIFF
--- a/.changeset/bright-todos-progress.md
+++ b/.changeset/bright-todos-progress.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-todo": minor
 ---
 
-Add the Todo Widget extension for branch-aware coding task lists shown above Pi's editor.
+Add the Todo Widget extension with branch-aware task lists, proactive progress reminders, and an above-editor display.

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -14,6 +14,7 @@ The list follows the active session branch and disappears cleanly when no tracke
 - Keeps task text concise and action-oriented, with at most one task in progress.
 - Shows a compact themed task list and completion count above the editor in TUI mode.
 - Restores the latest valid list when Pi starts a session or navigates between branches.
+- Reminds the model of the current list before every model call so progress stays visible after compaction.
 - Sanitizes terminal and bidirectional controls before rendering model-provided text.
 - Works without settings, files, network access, or external services.
 
@@ -43,7 +44,9 @@ Pi extensions run with the user's permissions, so install only trusted code.
 
 Ask Pi to perform work with multiple meaningful steps.
 
-The agent can create a concise list through `todo_widget`, mark one task `in_progress`, complete tasks promptly, and revise the list when the plan changes.
+The agent can create a concise list through `todo_widget`, mark one task `in_progress`, and revise the list when the plan changes.
+
+While a list is active, the extension reminds the agent to update it immediately after task status changes and to reconcile it before progress reports or the final response.
 
 The agent sends the complete current list with every update and sends an empty list when no tracked work remains.
 
@@ -68,6 +71,10 @@ A list may contain up to 50 items, each item may contain up to 300 characters, a
 
 The tool result stores a versioned snapshot in the session branch so branch navigation can reconstruct the latest valid list.
 
+Before each model call, the extension appends one hidden, non-persistent context reminder containing the current list as JSON data.
+
+The reminder is kept at the end of model context, survives compaction through branch reconstruction, and is removed when the list is cleared.
+
 In TUI mode, updates appear immediately in a widget above the editor.
 
 The widget header shows completed and total task counts, followed by themed completed, in-progress, and pending rows.
@@ -86,6 +93,7 @@ Terminal escape sequences, control characters, and bidirectional display control
 
 - The visual widget uses a fixed position above the editor and is available only in TUI mode.
 - The extension provides a model tool rather than a slash command or manual task editor.
+- The extension reminds the model to update statuses but cannot infer task completion or force a tool call.
 - Branch reconstruction uses only valid versioned `todo_widget` tool results on the active branch.
 - Long task text is shown on one bounded terminal line and may be truncated to the available width.
 

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -1,5 +1,6 @@
 import { StringEnum } from "@earendil-works/pi-ai";
 import type {
+	ContextEvent,
 	ExtensionAPI,
 	ExtensionContext,
 	SessionEntry,
@@ -10,6 +11,8 @@ import { Type } from "typebox";
 
 export const TOOL_NAME = "todo_widget";
 export const WIDGET_KEY = "todo";
+export const TODO_CONTEXT_MESSAGE_TYPE = "todo-widget-status";
+export const TODO_CONTEXT_VERSION = 1;
 export const TODO_DETAILS_VERSION = 1;
 export const MAX_TODO_ITEMS = 50;
 export const MAX_TODO_TEXT_LENGTH = 300;
@@ -81,8 +84,9 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 		promptSnippet: "Track progress on multi-step work with a session todo list",
 		promptGuidelines: [
 			"Use todo_widget when work has multiple meaningful steps; skip it for simple, single-step tasks.",
-			"Keep tasks concise and action-oriented. Mark one task in_progress before starting it, complete tasks promptly, and revise the list when the plan changes.",
-			"Send the complete current list on every call, keep at most one task in_progress, and send an empty list when no tracked work remains.",
+			"Keep todo_widget synchronized with actual work. Mark one task in_progress before starting it, update the list immediately after its status changes, and revise the list when the plan changes.",
+			"Before a progress report or final response, reconcile todo_widget with actual work; do not report completion while finished work remains pending or in_progress.",
+			"Send the complete current list on every todo_widget call, keep at most one task in_progress, and send an empty list when no tracked work remains.",
 		],
 		parameters: TodoParameters,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
@@ -126,6 +130,12 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 		publish(ctx);
 	});
 
+	pi.on("context", (event, ctx) => {
+		if (!ownsSession(ctx)) return;
+		const messages = reconcileTodoContext(event.messages, items);
+		if (messages !== event.messages) return { messages };
+	});
+
 	pi.on("session_tree", (_event, ctx) => {
 		if (!ownsSession(ctx)) return;
 		items = reconstructItems(ctx.sessionManager.getBranch());
@@ -167,6 +177,36 @@ export function renderTodoWidget(
 	return lines.map((line) => truncateToWidth(line, Math.max(0, width), ""));
 }
 
+export function reconcileTodoContext(
+	messages: ContextEvent["messages"],
+	items: readonly TodoItem[],
+): ContextEvent["messages"] {
+	const existing = messages.filter(isTodoContextMessage);
+	const content = items.length > 0 ? todoContextContent(items) : undefined;
+	if (
+		existing.length === 1 &&
+		messages.at(-1) === existing[0] &&
+		existing[0]?.content === content
+	) {
+		return messages;
+	}
+	if (existing.length === 0 && content === undefined) return messages;
+
+	const withoutExisting = messages.filter((message) => !isTodoContextMessage(message));
+	if (content === undefined) return withoutExisting;
+	return [
+		...withoutExisting,
+		{
+			role: "custom",
+			customType: TODO_CONTEXT_MESSAGE_TYPE,
+			content,
+			display: false,
+			details: { version: TODO_CONTEXT_VERSION },
+			timestamp: 0,
+		},
+	];
+}
+
 export function sanitizeTodoText(value: string): string {
 	let text = "";
 	for (const character of stripTerminalSequences(value).replace(BIDI_CONTROLS, "")) {
@@ -175,6 +215,21 @@ export function sanitizeTodoText(value: string): string {
 		text += isControl ? " " : character;
 	}
 	return text.replace(/\s+/gu, " ").trim();
+}
+
+function todoContextContent(items: readonly TodoItem[]): string {
+	return `[PI TODO STATUS v${TODO_CONTEXT_VERSION}]
+An active todo list follows as JSON data.
+Keep it synchronized with actual work: call todo_widget immediately after a task status changes and before beginning a different task.
+Before a progress report or final response, reconcile every item; do not report completion while the list is stale.
+Active todo list:
+${JSON.stringify(items)}`;
+}
+
+function isTodoContextMessage(
+	message: ContextEvent["messages"][number],
+): message is ContextEvent["messages"][number] & { content: string } {
+	return message.role === "custom" && message.customType === TODO_CONTEXT_MESSAGE_TYPE;
 }
 
 function validateItems(items: readonly TodoItem[]): void {

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import type {
+	ContextEvent,
 	ExtensionAPI,
 	ExtensionContext,
 	SessionEntry,
@@ -11,6 +12,8 @@ import { test } from "vitest";
 import todoWidgetExtension, {
 	renderTodoWidget,
 	sanitizeTodoText,
+	TODO_CONTEXT_MESSAGE_TYPE,
+	TODO_CONTEXT_VERSION,
 	TODO_DETAILS_VERSION,
 	TOOL_NAME,
 	type TodoDetails,
@@ -55,6 +58,16 @@ function createHarness() {
 		},
 		async emit(event: string, ctx: ExtensionContext) {
 			for (const handler of handlers.get(event) ?? []) await handler({} as never, ctx);
+		},
+		async context(messages: ContextEvent["messages"], ctx: ExtensionContext) {
+			let current = messages;
+			for (const handler of handlers.get("context") ?? []) {
+				const result = (await handler({ messages: current } as never, ctx)) as
+					| { messages?: ContextEvent["messages"] }
+					| undefined;
+				current = result?.messages ?? current;
+			}
+			return current;
 		},
 	};
 }
@@ -139,9 +152,64 @@ test("registers concise guidance for using and maintaining the todo list", () =>
 	assert.match(tool.promptSnippet, /multi-step work/u);
 	assert.deepEqual(tool.promptGuidelines, [
 		"Use todo_widget when work has multiple meaningful steps; skip it for simple, single-step tasks.",
-		"Keep tasks concise and action-oriented. Mark one task in_progress before starting it, complete tasks promptly, and revise the list when the plan changes.",
-		"Send the complete current list on every call, keep at most one task in_progress, and send an empty list when no tracked work remains.",
+		"Keep todo_widget synchronized with actual work. Mark one task in_progress before starting it, update the list immediately after its status changes, and revise the list when the plan changes.",
+		"Before a progress report or final response, reconcile todo_widget with actual work; do not report completion while finished work remains pending or in_progress.",
+		"Send the complete current list on every todo_widget call, keep at most one task in_progress, and send an empty list when no tracked work remains.",
 	]);
+});
+
+test("keeps one current todo reminder at the end of model context", async () => {
+	const harness = createHarness();
+	const current = createContext();
+	await harness.emit("session_start", current.ctx);
+	await setTodos(harness, current.ctx, [
+		{ text: "inspect", status: "completed" },
+		{ text: "implement", status: "in_progress" },
+	]);
+
+	const base = [
+		{
+			role: "compactionSummary" as const,
+			summary: "Earlier work was compacted.",
+			tokensBefore: 100,
+			timestamp: 0,
+		},
+	];
+	const transformed = await harness.context(base, current.ctx);
+	assert.equal(transformed.length, 2);
+	const reminder = transformed.at(-1);
+	assert.equal(reminder?.role, "custom");
+	if (reminder?.role !== "custom") assert.fail("Expected a custom todo reminder");
+	assert.equal(reminder.customType, TODO_CONTEXT_MESSAGE_TYPE);
+	assert.equal(reminder.display, false);
+	assert.deepEqual(reminder.details, { version: TODO_CONTEXT_VERSION });
+	assert.match(reminder.content as string, /call todo_widget immediately/u);
+	assert.match(reminder.content as string, /Before a progress report or final response/u);
+	assert.ok(
+		(reminder.content as string).includes(
+			'[{"text":"inspect","status":"completed"},{"text":"implement","status":"in_progress"}]',
+		),
+	);
+
+	const unchanged = await harness.context(transformed, current.ctx);
+	assert.equal(unchanged, transformed);
+
+	await setTodos(harness, current.ctx, [{ text: "implement", status: "completed" }]);
+	const updated = await harness.context(transformed, current.ctx);
+	assert.equal(
+		updated.filter(
+			(message) => message.role === "custom" && message.customType === TODO_CONTEXT_MESSAGE_TYPE,
+		).length,
+		1,
+	);
+	const updatedReminder = updated.at(-1);
+	assert.equal(updatedReminder?.role, "custom");
+	if (updatedReminder?.role !== "custom") assert.fail("Expected an updated todo reminder");
+	assert.match(updatedReminder.content as string, /"implement","status":"completed"/u);
+	assert.doesNotMatch(updatedReminder.content as string, /"inspect"/u);
+
+	await setTodos(harness, current.ctx, []);
+	assert.deepEqual(await harness.context(updated, current.ctx), base);
 });
 
 test("renders completed, current, and pending tasks with themed semantic symbols", () => {
@@ -293,6 +361,10 @@ test("guards component widgets to TUI mode and ignores stale session shutdown", 
 	await harness.emit("session_start", current.ctx);
 	await setTodos(harness, current.ctx, [{ text: "current", status: "in_progress" }]);
 	const currentWidgetCount = current.widgets.length;
+	const staleMessages = [
+		{ role: "user" as const, content: [{ type: "text" as const, text: "old" }], timestamp: 0 },
+	];
+	assert.equal(await harness.context(staleMessages, previous.ctx), staleMessages);
 
 	await harness.emit("session_shutdown", previous.ctx);
 	assert.equal(current.widgets.length, currentWidgetCount);


### PR DESCRIPTION
## Summary

- append one hidden current-list reminder at the end of model context while todos are active
- strengthen tool guidance so task status changes are reconciled before progress and final responses
- remove stale reminders on updates, clears, and session replacement, with focused lifecycle coverage
- document the reminder behavior and update the existing release note

## Testing

- `npm run check`
- `npm test` — 367 files and 3266 tests passed
- `npx vitest run packages/pi-todo/test/todo-widget.test.ts` — 7 tests passed

## Notes

- `npm run changeset:status` still reports pre-existing `pi-tui-kit` dependency-floor warnings; the private `pi-todo` package is not included in its bump output.
- A live-provider smoke was not run because the extension entrypoint and loading metadata are unchanged; deterministic context and lifecycle tests cover this behavior.