### PR TITLE
feat(tool): add active-tool status widget

### DIFF
--- a/.changeset/tidy-tools-glow.md
+++ b/.changeset/tidy-tools-glow.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tool": minor
+---
+
+Add a default-off active-tool widget with `/tool` and `pi-tool.json` controls.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6660,12 +6660,14 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.5.9",
 				"@earendil-works/pi-coding-agent": "0.84.2",
+				"@earendil-works/pi-tui": "0.84.2",
 				"@types/node": "26.2.0",
 				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*"
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"packages/pi-tool/node_modules/@narumitw/pi-tui-kit": {

--- a/packages/pi-tool/README.md
+++ b/packages/pi-tool/README.md
@@ -50,7 +50,7 @@ Run:
 ```
 
 Choose **Browse tools** to search the catalog and inspect a tool.
-Choose **Settings** to turn the active-tool widget on or off.
+Choose **Active tool status** directly from the main menu to turn the widget on or off.
 The widget is off until you enable it.
 
 The command works in TUI and RPC modes.
@@ -63,7 +63,7 @@ It rejects arguments and rejects print or JSON modes because Pi does not provide
 | `/tool` | Browse configured tools and configure the active-tool widget. |
 
 `/tool` intentionally accepts no arguments and does not enable, disable, or execute tools.
-Its menu provides Browse tools, Settings, Status, and Help screens.
+Its menu provides Browse tools, a direct active-tool status toggle, Status, and Help.
 
 ## ⚙️ Settings
 
@@ -79,7 +79,7 @@ Use this document to enable the widget manually:
 
 `activeToolStatus` accepts `true` or `false` and defaults to `false` when absent.
 Manual edits apply after `/reload` or the next session start.
-The `/tool` Settings screen applies changes immediately and persists them with an atomic file replacement.
+The `/tool` menu toggle applies changes immediately and persists them with an atomic file replacement.
 Settings writes preserve unknown fields so newer configuration is not erased.
 Malformed JSON or an invalid value is ignored with a warning and is never overwritten by the menu.
 Writes are ordered within one Pi process, but separate Pi processes do not share a settings lock.

--- a/packages/pi-tool/README.md
+++ b/packages/pi-tool/README.md
@@ -1,8 +1,8 @@
-# 🧰 pi-tool — Browse Pi Tools and Their Schemas
+# 🧰 pi-tool — Browse Pi Tools and Track Active Tools
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-tool)](https://www.npmjs.com/package/@narumitw/pi-tool) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Browse every tool configured in the current Pi session and inspect its active state, description, origin, schema, and prompt guidance through one read-only `/tool` command.
+Browse every tool configured in the current Pi session and optionally show the active tool set above the editor.
 
 ## ✨ Features
 
@@ -11,7 +11,10 @@ Browse every tool configured in the current Pi session and inspect its active st
 - Displays the complete JSON parameter schema and prompt guidelines exposed by Pi.
 - Shows the effective system-prompt snippet for each active tool.
 - Refreshes metadata every time the catalog opens.
-- Never changes tools, settings, files, or session data.
+- Optionally shows the current active tools above the editor.
+- Keeps the active-tool widget off by default.
+- Persists widget changes in the extension-owned `pi-tool.json` settings file.
+- Never enables, disables, or executes Pi tools.
 
 ## 📦 Install
 
@@ -46,8 +49,9 @@ Run:
 /tool
 ```
 
-Type to filter the list, move to a tool, and press Enter to open its details.
-Escape returns to the list and then closes the catalog.
+Choose **Browse tools** to search the catalog and inspect a tool.
+Choose **Settings** to turn the active-tool widget on or off.
+The widget is off until you enable it.
 
 The command works in TUI and RPC modes.
 It rejects arguments and rejects print or JSON modes because Pi does not provide an observable interactive command surface there.
@@ -56,9 +60,36 @@ It rejects arguments and rejects print or JSON modes because Pi does not provide
 
 | Command | Description |
 | --- | --- |
-| `/tool` | Browse configured tools and inspect their exposed metadata. |
+| `/tool` | Browse configured tools and configure the active-tool widget. |
 
 `/tool` intentionally accepts no arguments and does not enable, disable, or execute tools.
+Its menu provides Browse tools, Settings, Status, and Help screens.
+
+## ⚙️ Settings
+
+The active user settings file is `<getAgentDir()>/pi-tool.json`, normally `~/.pi/agent/pi-tool.json`.
+The file is not created when the widget remains at its default.
+Use this document to enable the widget manually:
+
+```json
+{
+  "activeToolStatus": true
+}
+```
+
+`activeToolStatus` accepts `true` or `false` and defaults to `false` when absent.
+Manual edits apply after `/reload` or the next session start.
+The `/tool` Settings screen applies changes immediately and persists them with an atomic file replacement.
+Settings writes preserve unknown fields so newer configuration is not erased.
+Malformed JSON or an invalid value is ignored with a warning and is never overwritten by the menu.
+Writes are ordered within one Pi process, but separate Pi processes do not share a settings lock.
+
+## ℹ️ Active-tool widget
+
+When enabled, the widget shows every name returned by Pi's public `pi.getActiveTools()` API above the editor.
+It refreshes when relevant lifecycle events fire and polls for changes made by other extensions.
+It clears immediately when disabled and during session replacement, reload, or shutdown.
+Tool names are sanitized and bounded before terminal rendering.
 
 ## ℹ️ Metadata limits
 
@@ -72,9 +103,11 @@ Pi does not expose a tool's implementation, runtime secrets, or label through th
 ```text
 packages/pi-tool/
 ├── src/
-│   ├── index.ts         # Thin repository entrypoint
-│   ├── tool.ts          # Command and session lifecycle ownership
-│   └── tool-catalog.ts  # Lazy browse menu and exact detail projection
+│   ├── index.ts               # Thin repository entrypoint
+│   ├── tool.ts                # Command, settings, and session lifecycle ownership
+│   ├── tool-catalog.ts        # Lazy menu and exact catalog detail projection
+│   ├── active-tool-status.ts  # Widget formatting, refresh, and cleanup
+│   └── settings.ts            # pi-tool.json validation and atomic persistence
 ├── dist/                # Generated Jiti runtime and lazy catalog chunk
 ├── scripts/build-runtime.mjs
 ├── test/
@@ -86,7 +119,7 @@ packages/pi-tool/
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, tool browser, tool catalog, tool schema, prompt guidelines, TypeScript Pi package.
+Pi extension, Pi coding agent, tool browser, active tools, tool status, tool catalog, tool schema, TypeScript Pi package.
 
 ## 📄 License
 

--- a/packages/pi-tool/package.json
+++ b/packages/pi-tool/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-tool",
 	"version": "0.2.3",
-	"description": "Browse configured Pi tools and inspect their exposed metadata.",
+	"description": "Browse configured Pi tools and optionally show the active tool set.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -38,11 +38,13 @@
 		"@narumitw/pi-tui-kit": "^0.53.0"
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-coding-agent": "*"
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.9",
 		"@earendil-works/pi-coding-agent": "0.84.2",
+		"@earendil-works/pi-tui": "0.84.2",
 		"@types/node": "26.2.0",
 		"typescript": "7.0.2",
 		"esbuild": "0.28.2"

--- a/packages/pi-tool/src/active-tool-status.ts
+++ b/packages/pi-tool/src/active-tool-status.ts
@@ -1,0 +1,135 @@
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import { wrapTextWithAnsi } from "@earendil-works/pi-tui";
+
+export const ACTIVE_TOOL_WIDGET_KEY = "tool:active-tools";
+export const ACTIVE_TOOL_REFRESH_INTERVAL_MS = 500;
+const MAX_TOOL_NAME_LENGTH = 32;
+
+export interface ActiveToolStatusController {
+	start(ctx: ExtensionContext, enabled: boolean): void;
+	setEnabled(ctx: ExtensionContext, enabled: boolean): void;
+	refresh(ctx: ExtensionContext): void;
+	shutdown(ctx: ExtensionContext): void;
+	isEnabled(): boolean;
+}
+
+export function createActiveToolStatusController(pi: ExtensionAPI): ActiveToolStatusController {
+	let activeContext: ExtensionContext | undefined;
+	let activeSession: ExtensionContext["sessionManager"] | undefined;
+	let refreshTimer: ReturnType<typeof setInterval> | undefined;
+	let enabled = false;
+	let publishedValue: string | undefined;
+	let hasPublished = false;
+
+	const ownsSession = (ctx: ExtensionContext) => ctx.sessionManager === activeSession;
+
+	const stopRefreshing = (): void => {
+		if (!refreshTimer) return;
+		clearInterval(refreshTimer);
+		refreshTimer = undefined;
+	};
+
+	const clear = (ctx: ExtensionContext): void => {
+		if (ctx.hasUI) ctx.ui.setWidget(ACTIVE_TOOL_WIDGET_KEY, undefined);
+		publishedValue = undefined;
+		hasPublished = false;
+	};
+
+	const publish = (ctx: ExtensionContext): void => {
+		if (!enabled || !ctx.hasUI || !ownsSession(ctx)) return;
+		const content = formatActiveToolWidget(pi.getActiveTools());
+		const value = content?.join("\n");
+		if (hasPublished && value === publishedValue) return;
+		if (content && ctx.mode === "tui") {
+			ctx.ui.setWidget(
+				ACTIVE_TOOL_WIDGET_KEY,
+				(_tui, theme) => ({
+					render: (width: number) => renderActiveToolWidget(content, theme, width),
+					invalidate: () => {},
+				}),
+				{ placement: "aboveEditor" },
+			);
+		} else {
+			ctx.ui.setWidget(ACTIVE_TOOL_WIDGET_KEY, content, { placement: "aboveEditor" });
+		}
+		publishedValue = value;
+		hasPublished = true;
+	};
+
+	const startRefreshing = (ctx: ExtensionContext): void => {
+		stopRefreshing();
+		if (!enabled || !ctx.hasUI) return;
+		refreshTimer = setInterval(() => {
+			if (ownsSession(ctx)) publish(ctx);
+		}, ACTIVE_TOOL_REFRESH_INTERVAL_MS);
+	};
+
+	return {
+		start(ctx, nextEnabled) {
+			stopRefreshing();
+			if (activeContext) clear(activeContext);
+			activeContext = ctx;
+			activeSession = ctx.sessionManager;
+			enabled = nextEnabled;
+			publishedValue = undefined;
+			hasPublished = false;
+			if (!enabled) return;
+			publish(ctx);
+			startRefreshing(ctx);
+		},
+		setEnabled(ctx, nextEnabled) {
+			if (!ownsSession(ctx) || enabled === nextEnabled) return;
+			enabled = nextEnabled;
+			if (!enabled) {
+				stopRefreshing();
+				clear(ctx);
+				return;
+			}
+			publish(ctx);
+			startRefreshing(ctx);
+		},
+		refresh(ctx) {
+			publish(ctx);
+		},
+		shutdown(ctx) {
+			if (!ownsSession(ctx)) return;
+			stopRefreshing();
+			clear(ctx);
+			activeContext = undefined;
+			activeSession = undefined;
+			enabled = false;
+		},
+		isEnabled() {
+			return enabled;
+		},
+	};
+}
+
+export function formatActiveToolWidget(toolNames: Iterable<string>): string[] | undefined {
+	const tools = [...toolNames].map(sanitizeToolName);
+	if (tools.length === 0) return undefined;
+	const label = tools.length === 1 ? "Active tool" : "Active tools";
+	return [`${label} (${tools.length})`, tools.join(" · ")];
+}
+
+export function renderActiveToolWidget(
+	lines: readonly string[],
+	theme: Theme,
+	width: number,
+): string[] {
+	const renderWidth = Math.max(0, width);
+	const contentLines =
+		renderWidth === 0
+			? lines.map(() => "")
+			: lines.flatMap((line) => wrapTextWithAnsi(line, renderWidth));
+	return [theme.fg("borderMuted", "─".repeat(renderWidth)), ...contentLines];
+}
+
+export function sanitizeToolName(value: string): string {
+	const printable = value.replace(/[^\p{L}\p{N}_.:/-]+/gu, "");
+	if (!printable) return "tool";
+	const characters = [...printable];
+	return characters.length > MAX_TOOL_NAME_LENGTH
+		? `${characters.slice(0, MAX_TOOL_NAME_LENGTH).join("")}…`
+		: printable;
+}

--- a/packages/pi-tool/src/settings.ts
+++ b/packages/pi-tool/src/settings.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export const TOOL_SETTINGS_FILE = "pi-tool.json";
+const MAX_SETTINGS_BYTES = 64 * 1024;
+
+export interface ToolSettings {
+	activeToolStatus: boolean;
+}
+
+export type ToolSettingsLoadResult =
+	| { kind: "missing"; settings: ToolSettings }
+	| { kind: "invalid"; reason: string; settings: ToolSettings }
+	| { kind: "loaded"; settings: ToolSettings };
+
+export interface UpdateToolSettingsOptions {
+	settingsPath?: string;
+	beforeRename?: (temporaryPath: string, settingsPath: string) => Promise<void>;
+}
+
+type SettingsDocument = Record<string, unknown>;
+const DEFAULT_SETTINGS: ToolSettings = { activeToolStatus: false };
+const queues = new Map<string, Promise<void>>();
+
+export function toolSettingsPath(): string {
+	return join(getAgentDir(), TOOL_SETTINGS_FILE);
+}
+
+export function normalizeToolSettings(value: unknown): ToolSettings | undefined {
+	if (!isRecord(value)) return undefined;
+	if (Object.hasOwn(value, "activeToolStatus") && typeof value.activeToolStatus !== "boolean") {
+		return undefined;
+	}
+	return {
+		activeToolStatus:
+			typeof value.activeToolStatus === "boolean"
+				? value.activeToolStatus
+				: DEFAULT_SETTINGS.activeToolStatus,
+	};
+}
+
+export function readToolSettings(
+	settingsPath = toolSettingsPath(),
+): Promise<ToolSettingsLoadResult> {
+	return enqueue(settingsPath, async () => {
+		let document: SettingsDocument;
+		try {
+			document = await readSettingsDocument(settingsPath);
+		} catch (error) {
+			if (isNodeError(error) && error.code === "ENOENT") {
+				return { kind: "missing", settings: { ...DEFAULT_SETTINGS } };
+			}
+			return {
+				kind: "invalid",
+				reason: `${settingsPath}: ${safeError(error)}`,
+				settings: { ...DEFAULT_SETTINGS },
+			};
+		}
+		const settings = normalizeToolSettings(document);
+		return settings
+			? { kind: "loaded", settings }
+			: {
+					kind: "invalid",
+					reason: `${settingsPath}: invalid settings shape`,
+					settings: { ...DEFAULT_SETTINGS },
+				};
+	});
+}
+
+export function updateToolSettings(
+	patch: Partial<ToolSettings>,
+	options: UpdateToolSettingsOptions = {},
+): Promise<ToolSettings> {
+	const settingsPath = options.settingsPath ?? toolSettingsPath();
+	return enqueue(settingsPath, async () => {
+		const current = await readDocumentForUpdate(settingsPath);
+		const updated = { ...current, ...patch };
+		const settings = normalizeToolSettings(updated);
+		if (!settings) throw new Error(`Pi Tool settings at ${settingsPath} have an invalid shape.`);
+		await publishSettings(settingsPath, updated, options);
+		return settings;
+	});
+}
+
+export async function awaitToolSettingsWrites(settingsPath = toolSettingsPath()): Promise<void> {
+	await queues.get(settingsPath);
+}
+
+function enqueue<T>(path: string, operation: () => Promise<T>): Promise<T> {
+	const previous = queues.get(path) ?? Promise.resolve();
+	const result = previous.then(operation, operation);
+	const settled = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	queues.set(path, settled);
+	void settled.finally(() => {
+		if (queues.get(path) === settled) queues.delete(path);
+	});
+	return result;
+}
+
+async function readDocumentForUpdate(path: string): Promise<SettingsDocument> {
+	try {
+		const document = await readSettingsDocument(path);
+		if (!normalizeToolSettings(document)) throw new Error("invalid settings shape");
+		return document;
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") return {};
+		throw new Error(`Pi Tool settings at ${path} are invalid: ${safeError(error)}`);
+	}
+}
+
+async function readSettingsDocument(path: string): Promise<SettingsDocument> {
+	const pathStats = await lstat(path);
+	if (pathStats.isSymbolicLink() || !pathStats.isFile()) {
+		throw new Error("settings path is not a regular file");
+	}
+	if (pathStats.size > MAX_SETTINGS_BYTES) {
+		throw new Error(`settings file exceeds ${MAX_SETTINGS_BYTES} bytes`);
+	}
+	const noFollow = constants.O_NOFOLLOW ?? 0;
+	const handle = await open(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | noFollow);
+	try {
+		const stats = await handle.stat();
+		if (!stats.isFile() || stats.dev !== pathStats.dev || stats.ino !== pathStats.ino) {
+			throw new Error("settings path changed while opening");
+		}
+		const buffer = Buffer.alloc(MAX_SETTINGS_BYTES + 1);
+		let offset = 0;
+		while (offset < buffer.length) {
+			const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+			if (bytesRead === 0) break;
+			offset += bytesRead;
+		}
+		if (offset > MAX_SETTINGS_BYTES) {
+			throw new Error(`settings file exceeds ${MAX_SETTINGS_BYTES} bytes`);
+		}
+		let contents: string;
+		try {
+			contents = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+				buffer.subarray(0, offset),
+			);
+		} catch {
+			throw new Error("settings file is not valid UTF-8");
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(contents) as unknown;
+		} catch {
+			throw new Error("invalid JSON");
+		}
+		if (!isRecord(parsed)) throw new Error("settings document must be a JSON object");
+		return parsed;
+	} finally {
+		await handle.close();
+	}
+}
+
+async function publishSettings(
+	path: string,
+	document: SettingsDocument,
+	options: UpdateToolSettingsOptions,
+): Promise<void> {
+	const contents = `${JSON.stringify(document, null, 2)}\n`;
+	if (Buffer.byteLength(contents) > MAX_SETTINGS_BYTES) {
+		throw new Error(`Pi Tool settings document exceeds ${MAX_SETTINGS_BYTES} bytes.`);
+	}
+	const directory = dirname(path);
+	await mkdir(directory, { recursive: true });
+	const temporaryPath = join(directory, `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+	try {
+		await writeFile(temporaryPath, contents, { encoding: "utf8", flag: "wx", mode: 0o600 });
+		await options.beforeRename?.(temporaryPath, path);
+		await rename(temporaryPath, path);
+	} catch (error) {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+		throw error;
+	}
+}
+
+function isRecord(value: unknown): value is SettingsDocument {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function safeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-tool/src/tool-catalog.ts
+++ b/packages/pi-tool/src/tool-catalog.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { MenuDefinition } from "@narumitw/pi-tui-kit";
 
 export interface ToolCatalogState {
@@ -76,10 +76,38 @@ export function createToolCatalog(
 	return { title: `Tools · ${activeCount}/${tools.length} active`, items };
 }
 
-export function createToolMenu(catalog: ToolCatalog): MenuDefinition<undefined, "tools", never> {
+type ToolMenuScreen = "main" | "tools" | "settings" | "status" | "help";
+type ToolMenuAction = "toggleActiveToolStatus";
+
+export interface ToolMenuOptions {
+	settingsPath: string;
+	isActiveToolStatusEnabled(): boolean;
+	toggleActiveToolStatus(ctx: ExtensionCommandContext, enabled: boolean): Promise<boolean>;
+}
+
+export function createToolMenu(
+	catalog: ToolCatalog,
+	options: ToolMenuOptions,
+): MenuDefinition<undefined, ToolMenuScreen, ToolMenuAction> {
 	return {
-		start: "tools",
+		start: "main",
 		screens: {
+			main: () => ({
+				kind: "actions",
+				title: "Tools",
+				lines: [
+					catalog.title,
+					`Active tool status: ${options.isActiveToolStatusEnabled() ? "on" : "off"}`,
+				],
+				items: [
+					{ id: "tools", label: "Browse tools", to: "tools" },
+					{ id: "settings", label: "Settings", to: "settings" },
+					{ id: "status", label: "Status", to: "status" },
+					{ id: "help", label: "Help", to: "help" },
+					{ id: "close", label: "Close", close: true },
+				],
+				hint: "close",
+			}),
 			tools: () => ({
 				kind: "browse",
 				title: catalog.title,
@@ -95,9 +123,51 @@ export function createToolMenu(catalog: ToolCatalog): MenuDefinition<undefined, 
 					},
 				})),
 				viewportSize: "adaptive",
-				hint: "close",
+				hint: "back",
+			}),
+			settings: () => ({
+				kind: "settings",
+				title: "Tool Settings",
+				lines: [`Saved in ${options.settingsPath}`],
+				items: [
+					{
+						id: "active-tool-status",
+						label: "Active tool status",
+						description: "Show active tools above the editor",
+						currentValue: options.isActiveToolStatusEnabled() ? "On" : "Off",
+						values: ["Off", "On"],
+						action: "toggleActiveToolStatus",
+					},
+				],
+			}),
+			status: () => ({
+				kind: "detail",
+				title: "Tool Status",
+				lines: [
+					catalog.title,
+					`Active tool status: ${options.isActiveToolStatusEnabled() ? "on" : "off"}`,
+					`Settings file: ${options.settingsPath}`,
+				],
+				hint: "back",
+			}),
+			help: () => ({
+				kind: "detail",
+				title: "Tool Help",
+				lines: [
+					"Browse tools to inspect their metadata and schemas.",
+					"Use Settings to show or hide the active-tool widget.",
+					"Manual pi-tool.json changes apply after /reload or the next session start.",
+				],
+				hint: "back",
 			}),
 		},
-		actions: {},
+		actions: {
+			toggleActiveToolStatus: async ({ ctx, value }) => {
+				const enabled = value === "On";
+				return (await options.toggleActiveToolStatus(ctx, enabled))
+					? { kind: "stay" }
+					: { kind: "rejected" };
+			},
+		},
 	};
 }

--- a/packages/pi-tool/src/tool-catalog.ts
+++ b/packages/pi-tool/src/tool-catalog.ts
@@ -76,7 +76,7 @@ export function createToolCatalog(
 	return { title: `Tools · ${activeCount}/${tools.length} active`, items };
 }
 
-type ToolMenuScreen = "main" | "tools" | "settings" | "status" | "help";
+type ToolMenuScreen = "main" | "tools" | "status" | "help";
 type ToolMenuAction = "toggleActiveToolStatus";
 
 export interface ToolMenuOptions {
@@ -101,7 +101,12 @@ export function createToolMenu(
 				],
 				items: [
 					{ id: "tools", label: "Browse tools", to: "tools" },
-					{ id: "settings", label: "Settings", to: "settings" },
+					{
+						id: "active-tool-status",
+						label: `Active tool status: ${options.isActiveToolStatusEnabled() ? "On" : "Off"}`,
+						description: "Show or hide active tools above the editor",
+						action: "toggleActiveToolStatus",
+					},
 					{ id: "status", label: "Status", to: "status" },
 					{ id: "help", label: "Help", to: "help" },
 					{ id: "close", label: "Close", close: true },
@@ -125,21 +130,6 @@ export function createToolMenu(
 				viewportSize: "adaptive",
 				hint: "back",
 			}),
-			settings: () => ({
-				kind: "settings",
-				title: "Tool Settings",
-				lines: [`Saved in ${options.settingsPath}`],
-				items: [
-					{
-						id: "active-tool-status",
-						label: "Active tool status",
-						description: "Show active tools above the editor",
-						currentValue: options.isActiveToolStatusEnabled() ? "On" : "Off",
-						values: ["Off", "On"],
-						action: "toggleActiveToolStatus",
-					},
-				],
-			}),
 			status: () => ({
 				kind: "detail",
 				title: "Tool Status",
@@ -155,15 +145,15 @@ export function createToolMenu(
 				title: "Tool Help",
 				lines: [
 					"Browse tools to inspect their metadata and schemas.",
-					"Use Settings to show or hide the active-tool widget.",
+					"Toggle Active tool status from the main /tool menu.",
 					"Manual pi-tool.json changes apply after /reload or the next session start.",
 				],
 				hint: "back",
 			}),
 		},
 		actions: {
-			toggleActiveToolStatus: async ({ ctx, value }) => {
-				const enabled = value === "On";
+			toggleActiveToolStatus: async ({ ctx }) => {
+				const enabled = !options.isActiveToolStatusEnabled();
 				return (await options.toggleActiveToolStatus(ctx, enabled))
 					? { kind: "stay" }
 					: { kind: "rejected" };

--- a/packages/pi-tool/src/tool.ts
+++ b/packages/pi-tool/src/tool.ts
@@ -1,27 +1,121 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { stripVTControlCharacters } from "node:util";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createActiveToolStatusController } from "./active-tool-status.js";
+import {
+	awaitToolSettingsWrites,
+	readToolSettings,
+	toolSettingsPath,
+	updateToolSettings,
+} from "./settings.js";
 
 const COMMAND_NAME = "tool";
 
-export default function toolExtension(pi: ExtensionAPI) {
+export interface ToolExtensionOptions {
+	settingsPath?: string;
+	readSettings?: typeof readToolSettings;
+	updateSettings?: typeof updateToolSettings;
+	awaitSettingsWrites?: typeof awaitToolSettingsWrites;
+}
+
+export default function toolExtension(pi: ExtensionAPI, options: ToolExtensionOptions = {}) {
+	const settingsPath = options.settingsPath ?? toolSettingsPath();
+	const loadSettings = options.readSettings ?? readToolSettings;
+	const saveSettings = options.updateSettings ?? updateToolSettings;
+	const flushSettings = options.awaitSettingsWrites ?? awaitToolSettingsWrites;
+	const activeToolStatus = createActiveToolStatusController(pi);
 	let generation = 0;
 	let sessionController = new AbortController();
+	let activeContext: ExtensionContext | undefined;
+	let activeSession: ExtensionContext["sessionManager"] | undefined;
+	let activeToolStatusEnabled = false;
 
-	const replaceSessionOwner = () => {
-		sessionController.abort(new DOMException("Tool catalog session replaced", "AbortError"));
+	const replaceSessionOwner = (ctx: ExtensionContext) => {
+		if (activeContext) activeToolStatus.shutdown(activeContext);
+		sessionController.abort(new DOMException("Tool session replaced", "AbortError"));
 		sessionController = new AbortController();
 		generation += 1;
+		activeContext = ctx;
+		activeSession = ctx.sessionManager;
+		activeToolStatusEnabled = false;
 	};
 
-	pi.on("session_start", () => {
-		replaceSessionOwner();
+	const ownsSession = (ctx: ExtensionContext) => ctx.sessionManager === activeSession;
+	const isCurrent = (expectedGeneration: number) =>
+		expectedGeneration === generation && !sessionController.signal.aborted;
+
+	pi.on("session_start", async (_event, ctx) => {
+		replaceSessionOwner(ctx);
+		const startGeneration = generation;
+		const loaded = await loadSettings(settingsPath);
+		if (!isCurrent(startGeneration) || !ownsSession(ctx)) return;
+		activeToolStatusEnabled = loaded.settings.activeToolStatus;
+		activeToolStatus.start(ctx, activeToolStatusEnabled);
+		if (loaded.kind === "invalid" && ctx.hasUI) {
+			ctx.ui.notify(
+				safeDisplayText(
+					`Pi Tool ignored invalid settings and kept the widget off: ${loaded.reason}`,
+				),
+				"warning",
+			);
+		}
 	});
 
-	pi.on("session_shutdown", () => {
-		sessionController.abort(new DOMException("Tool catalog session ended", "AbortError"));
+	pi.on("before_agent_start", (_event, ctx) => {
+		if (ownsSession(ctx)) activeToolStatus.refresh(ctx);
 	});
+
+	pi.on("model_select", (_event, ctx) => {
+		if (ownsSession(ctx)) activeToolStatus.refresh(ctx);
+	});
+
+	pi.on("tool_execution_end", (_event, ctx) => {
+		if (ownsSession(ctx)) activeToolStatus.refresh(ctx);
+	});
+
+	pi.on("agent_settled", (_event, ctx) => {
+		if (ownsSession(ctx) && ctx.isIdle()) activeToolStatus.refresh(ctx);
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		if (!ownsSession(ctx)) return;
+		sessionController.abort(new DOMException("Tool session ended", "AbortError"));
+		activeToolStatus.shutdown(ctx);
+		activeContext = undefined;
+		activeSession = undefined;
+		await flushSettings(settingsPath);
+	});
+
+	const setActiveToolStatus = async (
+		ctx: ExtensionContext,
+		enabled: boolean,
+		expectedGeneration: number,
+	): Promise<boolean> => {
+		const ownerContext = activeContext;
+		if (!isCurrent(expectedGeneration) || !ownerContext) return false;
+		const previous = activeToolStatusEnabled;
+		if (enabled === previous) return true;
+		activeToolStatusEnabled = enabled;
+		activeToolStatus.setEnabled(ownerContext, enabled);
+		try {
+			await saveSettings({ activeToolStatus: enabled }, { settingsPath });
+		} catch (error) {
+			if (isCurrent(expectedGeneration) && activeContext === ownerContext) {
+				activeToolStatusEnabled = previous;
+				activeToolStatus.setEnabled(ownerContext, previous);
+				ctx.ui.notify(
+					safeDisplayText(
+						`Pi Tool settings were not saved; the widget was restored: ${formatError(error)}`,
+					),
+					"warning",
+				);
+			}
+			return false;
+		}
+		return true;
+	};
 
 	pi.registerCommand(COMMAND_NAME, {
-		description: "Browse configured tools and inspect their metadata",
+		description: "Browse tools and configure the active-tool status widget",
 		handler: async (args, ctx) => {
 			if (args.trim()) throw new Error("/tool does not accept arguments.");
 			if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
@@ -30,31 +124,53 @@ export default function toolExtension(pi: ExtensionAPI) {
 
 			const commandGeneration = generation;
 			const signal = sessionController.signal;
-			const isCurrent = () => commandGeneration === generation && !signal.aborted;
+			const commandIsCurrent = () => isCurrent(commandGeneration);
 			const [{ runMenu }, { createToolCatalog, createToolMenu }] = await Promise.all([
 				import("@narumitw/pi-tui-kit"),
 				import("./tool-catalog.js"),
 			]);
-			if (!isCurrent()) return;
+			if (!commandIsCurrent()) return;
 			const catalog = createToolCatalog(
 				pi.getAllTools(),
 				pi.getActiveTools(),
 				ctx.getSystemPromptOptions().toolSnippets ?? {},
 			);
+			const menu = createToolMenu(catalog, {
+				settingsPath,
+				isActiveToolStatusEnabled: () => activeToolStatusEnabled,
+				toggleActiveToolStatus: (actionCtx, enabled) =>
+					setActiveToolStatus(actionCtx, enabled, commandGeneration),
+			});
 			const onError = (errorCtx: typeof ctx) => {
-				if (isCurrent()) errorCtx.ui.notify("The tool catalog could not be displayed.", "error");
+				if (commandIsCurrent())
+					errorCtx.ui.notify("The tool menu could not be displayed.", "error");
 			};
 			const onUnsupportedMode = (_unsupportedCtx: typeof ctx, mode: typeof ctx.mode) => {
 				throw new Error(`/tool is unavailable in ${mode} mode; use TUI or RPC mode.`);
 			};
 
-			await runMenu(ctx, createToolMenu(catalog), {
+			await runMenu(ctx, menu, {
 				getState: () => undefined,
 				signal,
-				isCurrent,
+				isCurrent: commandIsCurrent,
 				onError,
 				onUnsupportedMode,
 			});
 		},
 	});
+}
+
+function safeDisplayText(value: string): string {
+	return Array.from(stripVTControlCharacters(value), (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return (codePoint >= 0 && codePoint <= 8) ||
+			(codePoint >= 11 && codePoint <= 31) ||
+			(codePoint >= 127 && codePoint <= 159)
+			? "�"
+			: character;
+	}).join("");
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }

--- a/packages/pi-tool/test/active-tool-status.test.ts
+++ b/packages/pi-tool/test/active-tool-status.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { afterEach, test, vi } from "vitest";
+import {
+	ACTIVE_TOOL_REFRESH_INTERVAL_MS,
+	ACTIVE_TOOL_WIDGET_KEY,
+	createActiveToolStatusController,
+	formatActiveToolWidget,
+	renderActiveToolWidget,
+	sanitizeToolName,
+} from "../src/active-tool-status.js";
+
+type WidgetFactory = (_tui: never, theme: Theme) => Component;
+type WidgetRecord = [
+	string,
+	string[] | WidgetFactory | undefined,
+	{ placement: "aboveEditor" } | undefined,
+];
+
+const DIVIDER = "─".repeat(80);
+const IDENTITY_THEME = {
+	fg: (_role: string, text: string) => text,
+} as unknown as Theme;
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function createHarness(initialTools: string[] = []) {
+	let activeTools = initialTools;
+	const pi = {
+		getActiveTools() {
+			return [...activeTools];
+		},
+	} as unknown as ExtensionAPI;
+	return {
+		controller: createActiveToolStatusController(pi),
+		setActiveTools(toolNames: string[]) {
+			activeTools = toolNames;
+		},
+	};
+}
+
+function createContext(mode: ExtensionContext["mode"] = "tui", hasUI = true) {
+	const widgets: WidgetRecord[] = [];
+	const sessionManager = {} as ExtensionContext["sessionManager"];
+	const ctx = {
+		mode,
+		hasUI,
+		sessionManager,
+		ui: {
+			setWidget(
+				key: string,
+				content: string[] | WidgetFactory | undefined,
+				options?: { placement: "aboveEditor" },
+			) {
+				widgets.push([key, content, options]);
+			},
+		},
+	} as unknown as ExtensionContext;
+	return { ctx, widgets };
+}
+
+function renderWidgetRecord(
+	record: WidgetRecord | undefined,
+	width = 80,
+): WidgetRecord | undefined {
+	if (!record) return undefined;
+	const [key, content, options] = record;
+	const rendered =
+		typeof content === "function"
+			? content(undefined as never, IDENTITY_THEME).render(width)
+			: content;
+	return [key, rendered, options];
+}
+
+test("stays off by default and can start, refresh, and stop in the owned session", async () => {
+	vi.useFakeTimers();
+	const harness = createHarness(["read", "bash"]);
+	const current = createContext();
+	harness.controller.start(current.ctx, false);
+	assert.deepEqual(current.widgets, []);
+
+	harness.controller.setEnabled(current.ctx, true);
+	assert.deepEqual(renderWidgetRecord(current.widgets.at(-1)), [
+		ACTIVE_TOOL_WIDGET_KEY,
+		[DIVIDER, "Active tools (2)", "read · bash"],
+		{ placement: "aboveEditor" },
+	]);
+
+	harness.setActiveTools(["read", "edit", "write"]);
+	await vi.advanceTimersByTimeAsync(ACTIVE_TOOL_REFRESH_INTERVAL_MS);
+	assert.deepEqual(renderWidgetRecord(current.widgets.at(-1)), [
+		ACTIVE_TOOL_WIDGET_KEY,
+		[DIVIDER, "Active tools (3)", "read · edit · write"],
+		{ placement: "aboveEditor" },
+	]);
+
+	harness.controller.setEnabled(current.ctx, false);
+	assert.deepEqual(current.widgets.at(-1), [ACTIVE_TOOL_WIDGET_KEY, undefined, undefined]);
+	const countAfterDisable = current.widgets.length;
+	await vi.advanceTimersByTimeAsync(ACTIVE_TOOL_REFRESH_INTERVAL_MS * 2);
+	assert.equal(current.widgets.length, countAfterDisable);
+});
+
+test("session replacement clears the old widget and ignores stale shutdown", () => {
+	const harness = createHarness(["read"]);
+	const previous = createContext();
+	const current = createContext();
+	harness.controller.start(previous.ctx, true);
+	harness.controller.start(current.ctx, true);
+	assert.deepEqual(previous.widgets.at(-1), [ACTIVE_TOOL_WIDGET_KEY, undefined, undefined]);
+
+	harness.controller.shutdown(previous.ctx);
+	assert.equal(harness.controller.isEnabled(), true);
+	harness.controller.shutdown(current.ctx);
+	assert.deepEqual(current.widgets.at(-1), [ACTIVE_TOOL_WIDGET_KEY, undefined, undefined]);
+});
+
+test("keeps RPC widget content as plain strings and does nothing without UI", () => {
+	const harness = createHarness(["read"]);
+	const rpc = createContext("rpc");
+	harness.controller.start(rpc.ctx, true);
+	assert.deepEqual(rpc.widgets.at(-1), [
+		ACTIVE_TOOL_WIDGET_KEY,
+		["Active tool (1)", "read"],
+		{ placement: "aboveEditor" },
+	]);
+	const print = createContext("print", false);
+	harness.controller.start(print.ctx, true);
+	assert.deepEqual(print.widgets, []);
+	harness.controller.shutdown(print.ctx);
+});
+
+test("renders a muted divider and wraps every safe tool name within the available width", () => {
+	const roles: string[] = [];
+	const theme = {
+		fg(role: string, text: string) {
+			roles.push(role);
+			return text;
+		},
+	} as unknown as Theme;
+	const lines = renderActiveToolWidget(
+		["Active tools (6)", "read · bash · edit · write · runtime_diagnostics · subagent_spawn"],
+		theme,
+		40,
+	);
+
+	assert.deepEqual(lines.map(stripTerminalSequences), [
+		"─".repeat(40),
+		"Active tools (6)",
+		"read · bash · edit · write ·",
+		"runtime_diagnostics · subagent_spawn",
+	]);
+	assert.deepEqual(roles, ["borderMuted"]);
+	assert.ok(lines.every((line) => visibleWidth(line) <= 40));
+});
+
+test("formats every tool as bounded safe display text", () => {
+	assert.deepEqual(formatActiveToolWidget(["read", "bash", "edit", "write"]), [
+		"Active tools (4)",
+		"read · bash · edit · write",
+	]);
+	assert.deepEqual(formatActiveToolWidget(["read\n\u001b[31m"]), ["Active tool (1)", "read31m"]);
+	assert.equal(sanitizeToolName("\u001b]8;;bad\u0007read\n\u202efile"), "8badreadfile");
+	assert.equal(sanitizeToolName("\u001b\u0007"), "tool");
+	assert.equal(sanitizeToolName("x".repeat(40)), `${"x".repeat(32)}…`);
+});

--- a/packages/pi-tool/test/settings.test.ts
+++ b/packages/pi-tool/test/settings.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { lstat, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import { readToolSettings, TOOL_SETTINGS_FILE, updateToolSettings } from "../src/settings.js";
+
+async function withSettings(run: (path: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-tool-settings-"));
+	try {
+		await run(join(root, "nested", TOOL_SETTINGS_FILE));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("missing settings are side-effect free and default the widget to off", async () => {
+	await withSettings(async (path) => {
+		assert.deepEqual(await readToolSettings(path), {
+			kind: "missing",
+			settings: { activeToolStatus: false },
+		});
+		await assert.rejects(lstat(path), { code: "ENOENT" });
+	});
+});
+
+test("loads explicit booleans and treats an absent field as off", async () => {
+	await withSettings(async (path) => {
+		await updateToolSettings({ activeToolStatus: true }, { settingsPath: path });
+		assert.deepEqual(await readToolSettings(path), {
+			kind: "loaded",
+			settings: { activeToolStatus: true },
+		});
+		await writeFile(path, JSON.stringify({ future: { keep: true } }), "utf8");
+		assert.deepEqual(await readToolSettings(path), {
+			kind: "loaded",
+			settings: { activeToolStatus: false },
+		});
+	});
+});
+
+test("ordered atomic saves preserve unknown fields", async () => {
+	await withSettings(async (path) => {
+		await updateToolSettings({ activeToolStatus: false }, { settingsPath: path });
+		await writeFile(
+			path,
+			JSON.stringify({ activeToolStatus: false, future: { keep: true } }),
+			"utf8",
+		);
+		const first = updateToolSettings({ activeToolStatus: true }, { settingsPath: path });
+		const second = updateToolSettings({ activeToolStatus: false }, { settingsPath: path });
+		await Promise.all([first, second]);
+		const document = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+		assert.equal(document.activeToolStatus, false);
+		assert.deepEqual(document.future, { keep: true });
+		if (process.platform !== "win32") assert.equal((await lstat(path)).mode & 0o777, 0o600);
+	});
+});
+
+test("reads wait for earlier writes to publish the latest snapshot", async () => {
+	await withSettings(async (path) => {
+		await updateToolSettings({ activeToolStatus: false }, { settingsPath: path });
+		let releaseRename!: () => void;
+		const renameGate = new Promise<void>((resolve) => {
+			releaseRename = resolve;
+		});
+		const update = updateToolSettings(
+			{ activeToolStatus: true },
+			{ settingsPath: path, beforeRename: async () => renameGate },
+		);
+		const read = readToolSettings(path);
+		releaseRename();
+		await update;
+		assert.equal((await read).settings.activeToolStatus, true);
+	});
+});
+
+test("malformed and invalid files stay untouched and block saves", async () => {
+	await withSettings(async (path) => {
+		await updateToolSettings({ activeToolStatus: false }, { settingsPath: path });
+		for (const contents of ["{broken", '{"activeToolStatus":"yes"}']) {
+			await writeFile(path, contents, "utf8");
+			const loaded = await readToolSettings(path);
+			assert.equal(loaded.kind, "invalid");
+			assert.equal(loaded.settings.activeToolStatus, false);
+			await assert.rejects(
+				updateToolSettings({ activeToolStatus: true }, { settingsPath: path }),
+				/invalid/u,
+			);
+			assert.equal(await readFile(path, "utf8"), contents);
+		}
+	});
+});
+
+test("publication failure preserves the previous valid document and queue recovery", async () => {
+	await withSettings(async (path) => {
+		await updateToolSettings({ activeToolStatus: false }, { settingsPath: path });
+		const before = await readFile(path, "utf8");
+		await assert.rejects(
+			updateToolSettings(
+				{ activeToolStatus: true },
+				{
+					settingsPath: path,
+					beforeRename: async () => Promise.reject(new Error("injected stop")),
+				},
+			),
+			/injected stop/u,
+		);
+		assert.equal(await readFile(path, "utf8"), before);
+		await updateToolSettings({ activeToolStatus: true }, { settingsPath: path });
+		assert.equal((await readToolSettings(path)).settings.activeToolStatus, true);
+	});
+});

--- a/packages/pi-tool/test/tool.test.ts
+++ b/packages/pi-tool/test/tool.test.ts
@@ -41,6 +41,27 @@ const configuredTools = [
 	},
 ] as const;
 
+const TEST_SETTINGS = {
+	settingsPath: "/test/pi-tool.json",
+	readSettings: async () => ({
+		kind: "missing" as const,
+		settings: { activeToolStatus: false },
+	}),
+	updateSettings: async (patch: { activeToolStatus?: boolean }) => ({
+		activeToolStatus: patch.activeToolStatus ?? false,
+	}),
+	awaitSettingsWrites: async () => {},
+};
+
+function startToolExtension(pi: Parameters<typeof toolExtension>[0]) {
+	toolExtension(pi, TEST_SETTINGS);
+}
+
+async function openToolCatalog(tui: ReturnType<typeof createTuiHarness>) {
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+}
+
 test("catalog lists every tool alphabetically with active state and complete exposed metadata", () => {
 	const catalog = createToolCatalog(configuredTools as never, ["read"], {
 		read: "Read file contents from the current workspace",
@@ -80,7 +101,7 @@ test("catalog lists every tool alphabetically with active state and complete exp
 
 test("TUI browser searches across exposed tool metadata", async () => {
 	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
@@ -95,6 +116,7 @@ test("TUI browser searches across exposed tool metadata", async () => {
 	};
 	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
 	await tui.waitForOpen();
+	await openToolCatalog(tui);
 	for (const size of [
 		{ width: 60, rows: 16 },
 		{ width: 24, rows: 8 },
@@ -119,7 +141,7 @@ test("TUI browser searches across exposed tool metadata", async () => {
 
 test("exact detail documents do not become implicit browse search metadata", async () => {
 	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
@@ -134,6 +156,7 @@ test("exact detail documents do not become implicit browse search metadata", asy
 	};
 	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
 	await tui.waitForOpen();
+	await openToolCatalog(tui);
 	tui.type("Parameter schema");
 	assert.match(stripVTControlCharacters(tui.render().join("\n")), /No matching items/u);
 	tui.press("ctrl+c");
@@ -142,17 +165,19 @@ test("exact detail documents do not become implicit browse search metadata", asy
 
 test("/tool supports RPC list and detail navigation", async () => {
 	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
 	const rpc = createRpcHarness([
+		{ kind: "select", response: "Browse tools" },
 		{ kind: "select", response: "read [active]" },
 		{ kind: "select", response: "Next" },
 		{ kind: "select", response: "Next" },
 		{ kind: "select", response: "Next" },
 		{ kind: "select", response: "Back" },
-		{ kind: "select", response: "Done" },
+		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Close" },
 	]);
 	let promptOptionReads = 0;
 	const base = createMockContext({
@@ -172,10 +197,10 @@ test("/tool supports RPC list and detail navigation", async () => {
 	};
 	await command.handler("", { ...base, ui: { ...base.ui, ...rpc.ui } });
 	rpc.assertConsumed();
-	assert.deepEqual(rpc.dialogs[0]?.options, ["deploy [inactive]", "read [active]", "Done"]);
-	assert.doesNotMatch(rpc.dialogs[0]?.options?.join("\n") ?? "", /Parameter schema|File path/u);
+	assert.deepEqual(rpc.dialogs[1]?.options, ["deploy [inactive]", "read [active]", "Back"]);
+	assert.doesNotMatch(rpc.dialogs[1]?.options?.join("\n") ?? "", /Parameter schema|File path/u);
 	const detailPages = rpc.dialogs
-		.slice(1, 5)
+		.slice(2, 6)
 		.map(({ title }) => title)
 		.join("\n");
 	assert.match(detailPages, /Parameter schema/u);
@@ -186,9 +211,186 @@ test("/tool supports RPC list and detail navigation", async () => {
 	assert.equal(promptOptionReads, 1);
 });
 
+test("session start applies manual settings and warns when invalid settings are ignored", async () => {
+	const enabledMock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(enabledMock.pi, {
+		...TEST_SETTINGS,
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: { activeToolStatus: true },
+		}),
+	});
+	const enabledContext = createMockContext({ hasUI: true, mode: "tui" });
+	await enabledMock.events.get("session_start")?.[0]?.({}, enabledContext.ctx);
+	assert.equal(typeof enabledContext.widgets.get("tool:active-tools"), "function");
+	await enabledMock.events.get("session_shutdown")?.[0]?.({}, enabledContext.ctx);
+
+	const invalidMock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(invalidMock.pi, {
+		...TEST_SETTINGS,
+		readSettings: async () => ({
+			kind: "invalid" as const,
+			reason: "/test/pi-tool.json: invalid JSON",
+			settings: { activeToolStatus: false },
+		}),
+	});
+	const invalidContext = createMockContext({ hasUI: true, mode: "tui" });
+	await invalidMock.events.get("session_start")?.[0]?.({}, invalidContext.ctx);
+	assert.match(invalidContext.notifications[0]?.message ?? "", /ignored invalid settings/u);
+	assert.equal(invalidContext.widgets.has("tool:active-tools"), false);
+	await invalidMock.events.get("session_shutdown")?.[0]?.({}, invalidContext.ctx);
+});
+
+test("a delayed settings load cannot overwrite a replacement session", async () => {
+	let resolveFirst!: (value: { kind: "loaded"; settings: { activeToolStatus: boolean } }) => void;
+	let reads = 0;
+	const firstLoad = new Promise<{
+		kind: "loaded";
+		settings: { activeToolStatus: boolean };
+	}>((resolve) => {
+		resolveFirst = resolve;
+	});
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi, {
+		...TEST_SETTINGS,
+		readSettings: async () => {
+			reads += 1;
+			return reads === 1
+				? firstLoad
+				: { kind: "loaded" as const, settings: { activeToolStatus: true } };
+		},
+	});
+	const previous = createMockContext({ hasUI: true, mode: "tui" });
+	const current = createMockContext({ hasUI: true, mode: "tui" });
+	const start = mock.events.get("session_start")?.[0];
+	assert.ok(start);
+	const previousStart = Promise.resolve(start({}, previous.ctx));
+	await Promise.resolve();
+	await start({}, current.ctx);
+	assert.equal(typeof current.widgets.get("tool:active-tools"), "function");
+	resolveFirst({ kind: "loaded", settings: { activeToolStatus: false } });
+	await previousStart;
+	assert.equal(typeof current.widgets.get("tool:active-tools"), "function");
+	assert.equal(previous.widgets.has("tool:active-tools"), false);
+	await mock.events.get("session_shutdown")?.[0]?.({}, current.ctx);
+});
+
+test("/tool toggles and persists the active-tool widget in TUI mode", async () => {
+	const saved: boolean[] = [];
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi, {
+		settingsPath: "/test/pi-tool.json",
+		readSettings: TEST_SETTINGS.readSettings,
+		updateSettings: async (patch) => {
+			saved.push(patch.activeToolStatus ?? false);
+			return { activeToolStatus: patch.activeToolStatus ?? false };
+		},
+		awaitSettingsWrites: TEST_SETTINGS.awaitSettingsWrites,
+	});
+	const lifecycle = createMockContext({ hasUI: true, mode: "tui" });
+	await mock.events.get("session_start")?.[0]?.({}, lifecycle.ctx);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
+	const tui = createTuiHarness({ width: 80, rows: 20 });
+	const base = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		getSystemPromptOptions: () => ({ cwd: "/home/test/project", toolSnippets: {} }),
+	}).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
+	await tui.waitForOpen();
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	assert.match(stripVTControlCharacters(tui.render().join("\n")), /Active tool status.*Off/u);
+	tui.press("tui.select.confirm");
+	await tui.waitForOpen();
+	assert.match(stripVTControlCharacters(tui.render().join("\n")), /Active tool status.*On/u);
+	assert.deepEqual(saved, [true]);
+	assert.equal(typeof lifecycle.widgets.get("tool:active-tools"), "function");
+	tui.press("ctrl+c");
+	await running;
+	await mock.events.get("session_shutdown")?.[0]?.({}, lifecycle.ctx);
+	assert.equal(lifecycle.widgets.get("tool:active-tools"), undefined);
+});
+
+test("/tool toggles and persists the active-tool widget in RPC mode", async () => {
+	const saved: boolean[] = [];
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi, {
+		settingsPath: "/test/pi-tool.json",
+		readSettings: TEST_SETTINGS.readSettings,
+		updateSettings: async (patch) => {
+			saved.push(patch.activeToolStatus ?? false);
+			return { activeToolStatus: patch.activeToolStatus ?? false };
+		},
+		awaitSettingsWrites: TEST_SETTINGS.awaitSettingsWrites,
+	});
+	const lifecycle = createMockContext({ hasUI: true, mode: "rpc" });
+	await mock.events.get("session_start")?.[0]?.({}, lifecycle.ctx);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
+	const rpc = createRpcHarness([
+		{ kind: "select", response: "Settings" },
+		{ kind: "select", response: "Active tool status (Off)" },
+		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Close" },
+	]);
+	const base = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		getSystemPromptOptions: () => ({ cwd: "/home/test/project", toolSnippets: {} }),
+	}).ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	await command.handler("", { ...base, ui: { ...base.ui, ...rpc.ui } });
+	rpc.assertConsumed();
+	assert.deepEqual(saved, [true]);
+	assert.deepEqual(lifecycle.widgets.get("tool:active-tools"), ["Active tool (1)", "read"]);
+	await mock.events.get("session_shutdown")?.[0]?.({}, lifecycle.ctx);
+});
+
+test("a failed settings save restores the previous widget state", async () => {
+	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
+	toolExtension(mock.pi, {
+		settingsPath: "/test/pi-tool.json",
+		readSettings: TEST_SETTINGS.readSettings,
+		updateSettings: async () => Promise.reject(new Error("injected save failure")),
+		awaitSettingsWrites: TEST_SETTINGS.awaitSettingsWrites,
+	});
+	const lifecycle = createMockContext({ hasUI: true, mode: "rpc" });
+	await mock.events.get("session_start")?.[0]?.({}, lifecycle.ctx);
+	const command = mock.commands.get("tool");
+	assert.ok(command);
+	const rpc = createRpcHarness([
+		{ kind: "select", response: "Settings" },
+		{ kind: "select", response: "Active tool status (Off)" },
+		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Close" },
+	]);
+	const base = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		getSystemPromptOptions: () => ({ cwd: "/home/test/project", toolSnippets: {} }),
+	});
+	const context = base.ctx as unknown as {
+		ui: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	await command.handler("", { ...context, ui: { ...context.ui, ...rpc.ui } });
+	rpc.assertConsumed();
+	assert.equal(lifecycle.widgets.get("tool:active-tools"), undefined);
+	assert.match(base.notifications[0]?.message ?? "", /widget was restored.*injected save failure/u);
+	await mock.events.get("session_shutdown")?.[0]?.({}, lifecycle.ctx);
+});
+
 test("/tool rejects arguments and noninteractive modes before opening the catalog", async () => {
 	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
 	await assert.rejects(async () => {
@@ -203,7 +405,7 @@ test("/tool rejects arguments and noninteractive modes before opening the catalo
 
 test("nested parameter schema indentation survives the TUI detail boundary", async () => {
 	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
@@ -218,10 +420,11 @@ test("nested parameter schema indentation survives the TUI detail boundary", asy
 	};
 	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
 	await tui.waitForOpen();
+	await openToolCatalog(tui);
 	tui.type("builtin temporary");
 	tui.press("tui.select.confirm");
 	await tui.waitForOpen();
-	assert.equal(tui.openCount, 1, "browse details must stay in one standard menu interaction");
+	assert.equal(tui.openCount, 2, "browse details must stay in one standard menu interaction");
 	const frame = stripVTControlCharacters(tui.render().join("\n"));
 	assert.match(frame, /^ {2}"type": "object",$/mu);
 	assert.match(frame, /^ {4}"path": \{$/mu);
@@ -240,7 +443,7 @@ test("nested parameter schema indentation survives the TUI detail boundary", asy
 	assert.match(finalDetailFrame, /Columns\s+stay aligned/u);
 	tui.press("tui.select.cancel");
 	await tui.waitForOpen();
-	assert.equal(tui.openCount, 1, "returning from details must not remount the browser");
+	assert.equal(tui.openCount, 2, "returning from details must not remount the browser");
 	assert.match(stripVTControlCharacters(tui.render().join("\n")), /Search: > builtin temporary/u);
 	tui.press("ctrl+c");
 	await running;
@@ -255,7 +458,7 @@ test("terminal controls are stripped by the browse display boundary", async () =
 		},
 	];
 	const mock = createMockPi({ allTools: unsafeTools as never, activeTools: [] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
@@ -270,6 +473,7 @@ test("terminal controls are stripped by the browse display boundary", async () =
 	};
 	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
 	await tui.waitForOpen();
+	await openToolCatalog(tui);
 	let frame = tui.render().join("\n");
 	assert.equal(frame.includes("\u001b]0;owned"), false);
 	assert.equal(frame.includes("\u0007"), false);
@@ -285,9 +489,11 @@ test("terminal controls are stripped by the browse display boundary", async () =
 	await running;
 
 	const rpc = createRpcHarness([
+		{ kind: "select", response: "Browse tools" },
 		{ kind: "select", response: "read [inactive]" },
 		{ kind: "select", response: "Back" },
-		{ kind: "select", response: "Done" },
+		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Close" },
 	]);
 	await command.handler("", { ...base, mode: "rpc", ui: { ...base.ui, ...rpc.ui } });
 	rpc.assertConsumed();
@@ -318,14 +524,16 @@ test("duplicate sanitized labels keep stable raw tool identity in RPC", async ()
 		.find((line) => line.startsWith("Path: "));
 	assert.ok(secondPath);
 	const mock = createMockPi({ allTools: duplicateTools as never, activeTools: [] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
 	const rpc = createRpcHarness([
+		{ kind: "select", response: "Browse tools" },
 		{ kind: "select", response: "same [inactive] [2]" },
 		{ kind: "select", response: "Back" },
-		{ kind: "select", response: "Done" },
+		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Close" },
 	]);
 	const base = createMockContext({
 		hasUI: true,
@@ -337,13 +545,13 @@ test("duplicate sanitized labels keep stable raw tool identity in RPC", async ()
 	};
 	await command.handler("", { ...base, ui: { ...base.ui, ...rpc.ui } });
 	rpc.assertConsumed();
-	assert.deepEqual(rpc.dialogs[0]?.options, ["same [inactive]", "same [inactive] [2]", "Done"]);
-	assert.match(rpc.dialogs[1]?.title ?? "", new RegExp(escapeRegExp(secondPath), "u"));
+	assert.deepEqual(rpc.dialogs[1]?.options, ["same [inactive]", "same [inactive] [2]", "Back"]);
+	assert.match(rpc.dialogs[2]?.title ?? "", new RegExp(escapeRegExp(secondPath), "u"));
 });
 
 test("session replacement aborts and disposes an open menu", async () => {
 	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	const lifecycle = createMockContext({ hasUI: true, mode: "tui" }).ctx;
 	await mock.events.get("session_start")?.[0]?.({}, lifecycle);
 	const command = mock.commands.get("tool");
@@ -359,6 +567,7 @@ test("session replacement aborts and disposes an open menu", async () => {
 	};
 	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
 	await tui.waitForOpen();
+	await openToolCatalog(tui);
 	tui.press("tui.select.confirm");
 	assert.match(stripVTControlCharacters(tui.render().join("\n")), /Parameter schema/u);
 	await mock.events.get("session_start")?.[0]?.({}, lifecycle);
@@ -369,7 +578,7 @@ test("session replacement aborts and disposes an open menu", async () => {
 
 test("session shutdown aborts and disposes an open menu", async () => {
 	const mock = createMockPi({ allTools: [...configuredTools], activeTools: ["read"] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	const lifecycle = createMockContext({ hasUI: true, mode: "tui" }).ctx;
 	await mock.events.get("session_start")?.[0]?.({}, lifecycle);
 	const command = mock.commands.get("tool");
@@ -393,7 +602,7 @@ test("session shutdown aborts and disposes an open menu", async () => {
 
 test("an empty catalog remains bounded and can close", async () => {
 	const mock = createMockPi({ allTools: [], activeTools: [] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
@@ -408,6 +617,7 @@ test("an empty catalog remains bounded and can close", async () => {
 	};
 	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
 	await tui.waitForOpen();
+	await openToolCatalog(tui);
 	const frame = stripVTControlCharacters(tui.render().join("\n"));
 	assert.match(frame, /Tools · 0\/0 active/u);
 	assert.match(frame, /No items available/u);
@@ -418,7 +628,7 @@ test("an empty catalog remains bounded and can close", async () => {
 test("each command reads a fresh sorted catalog and active state", async () => {
 	const allTools: Array<(typeof configuredTools)[number]> = [configuredTools[0]];
 	const mock = createMockPi({ allTools, activeTools: [] });
-	toolExtension(mock.pi);
+	startToolExtension(mock.pi);
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
@@ -431,17 +641,25 @@ test("each command reads a fresh sorted catalog and active state", async () => {
 		[key: string]: unknown;
 	};
 
-	const first = createRpcHarness([{ kind: "select", response: "Done" }]);
+	const first = createRpcHarness([
+		{ kind: "select", response: "Browse tools" },
+		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Close" },
+	]);
 	await command.handler("", { ...base, ui: { ...base.ui, ...first.ui } });
 	first.assertConsumed();
-	assert.deepEqual(first.dialogs[0]?.options, ["read [inactive]", "Done"]);
+	assert.deepEqual(first.dialogs[1]?.options, ["read [inactive]", "Back"]);
 
 	allTools.push(configuredTools[1]);
 	mock.rawPi.setActiveTools(["deploy"]);
-	const second = createRpcHarness([{ kind: "select", response: "Done" }]);
+	const second = createRpcHarness([
+		{ kind: "select", response: "Browse tools" },
+		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Close" },
+	]);
 	await command.handler("", { ...base, ui: { ...base.ui, ...second.ui } });
 	second.assertConsumed();
-	assert.deepEqual(second.dialogs[0]?.options, ["deploy [active]", "read [inactive]", "Done"]);
+	assert.deepEqual(second.dialogs[1]?.options, ["deploy [active]", "read [inactive]", "Back"]);
 });
 
 function escapeRegExp(value: string): string {

--- a/packages/pi-tool/test/tool.test.ts
+++ b/packages/pi-tool/test/tool.test.ts
@@ -302,10 +302,8 @@ test("/tool toggles and persists the active-tool widget in TUI mode", async () =
 	};
 	const running = command.handler("", { ...base, ui: { ...base.ui, custom: tui.custom } });
 	await tui.waitForOpen();
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
-	await tui.waitForOpen();
 	assert.match(stripVTControlCharacters(tui.render().join("\n")), /Active tool status.*Off/u);
+	tui.press("tui.select.down");
 	tui.press("tui.select.confirm");
 	await tui.waitForOpen();
 	assert.match(stripVTControlCharacters(tui.render().join("\n")), /Active tool status.*On/u);
@@ -334,9 +332,7 @@ test("/tool toggles and persists the active-tool widget in RPC mode", async () =
 	const command = mock.commands.get("tool");
 	assert.ok(command);
 	const rpc = createRpcHarness([
-		{ kind: "select", response: "Settings" },
-		{ kind: "select", response: "Active tool status (Off)" },
-		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Active tool status: Off" },
 		{ kind: "select", response: "Close" },
 	]);
 	const base = createMockContext({
@@ -367,9 +363,7 @@ test("a failed settings save restores the previous widget state", async () => {
 	const command = mock.commands.get("tool");
 	assert.ok(command);
 	const rpc = createRpcHarness([
-		{ kind: "select", response: "Settings" },
-		{ kind: "select", response: "Active tool status (Off)" },
-		{ kind: "select", response: "Back" },
+		{ kind: "select", response: "Active tool status: Off" },
 		{ kind: "select", response: "Close" },
 	]);
 	const base = createMockContext({


### PR DESCRIPTION
## Summary

- add a default-off active-tool widget to `pi-tool`
- add a direct active-tool toggle, Status, and Help to `/tool` while preserving the tool catalog
- persist `activeToolStatus` in `pi-tool.json` with validated, ordered, atomic writes
- document the setting and add a minor Changeset

## Verification

- `npm run check`
- `npm test` — 369 test files and 3,281 tests passed
- `npm pack --workspace @narumitw/pi-tool --dry-run --json`
- Pi RPC package-loading smoke with `get_commands`
- package README heading audit

## Notes

- the existing project-local `active-tool-status` extension remains available; this change does not deprecate it
