### PR TITLE
feat(subagents): add local usage recording

### DIFF
--- a/.changeset/quiet-subagents-observe.md
+++ b/.changeset/quiet-subagents-observe.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Add opt-in, local-only, content-free usage recording with a 30-day retention window and status reporting.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -19,6 +19,7 @@ The compatibility default exposes every delegation method, while **Async only** 
 - Routes nested completion and peer communication through authenticated session-scoped channels.
 - Provides `/subagents` settings, status, help, tool-surface selection, and recovery diagnostics.
 - Returns concise model-visible results with complete bounded details and sanitized terminal rendering.
+- Optionally records content-free local lifecycle and timing events for evaluating delegation behavior.
 - Loads a generated split runtime while preserving lazy execution, UI, inspection, and transport chunks.
 
 ## 📦 Install
@@ -59,15 +60,40 @@ Async-first delegation still requires useful parallel main-agent work, clear wor
 ## 💬 Commands
 
 - `/subagents` opens the current-session manager in TUI mode and reports bounded status in RPC mode.
-- `/subagents settings` configures target locations, trusted resources, and async completion delivery.
+- `/subagents settings` configures target locations, trusted resources, async completion delivery, and local usage recording.
 - `/subagents status` shows current-session and configured values with their sources.
 - `/subagents help` summarizes the command surface and isolation limits.
 
 ## ⚙️ Settings
 
-Use `/subagents settings` for target location, trust, consultation resource, and detached-completion preferences.
+Use `/subagents settings` for target location, trust, consultation resource, detached-completion preferences, and local usage recording.
 Use `/subagents` → **Advanced settings** for delegation workflow, agent tool permissions, and runtime limits.
 Settings are stored in `~/.pi/agent/pi-subagents.json`; the detailed sections below document precedence, reload requirements, and safety behavior.
+
+## 📊 Local usage recording
+
+Local usage recording is disabled by default and creates no usage storage until the user selects **On · local only** in `/subagents settings`.
+The setting applies immediately and persists as `usageRecording.enabled` in the user settings file.
+No network connection, upload, remote identifier, or project attribution is used.
+
+Records are stored below `<pi-agent-directory>/pi-subagents-usage/` as private per-runtime JSONL writer files.
+Directories use mode `0700` and files use mode `0600` on POSIX systems.
+Each event is versioned, bounded to 8 KiB, and ends with a newline so a crash-truncated final frame can be distinguished from completed records.
+Concurrent Pi processes use separate opaque writer files and never append to one shared file.
+Validated writer files older than 30 days are removed after recording starts.
+Disabling recording stops new events immediately; existing files remain until the retention window expires or the user removes the directory while Pi is stopped.
+
+Stored fields are limited to extension-generated runtime, session, turn, tool, child, run, and completion ordinals; the effective delegation surface; lifecycle states; completion-delivery transitions; bounded usage numbers; errors as booleans; and monotonic timing or durations.
+The recorder does not store prompts, delegated tasks, responses, thinking, tool arguments or results, code, paths, commands, mailbox or steering content, raw errors, provider/model identity, credentials, Pi session identifiers, or a persistent device identifier.
+Raw child, run, completion, and provider tool-call identifiers are replaced with runtime-local ordinals before publication.
+
+The events can describe blocking versus async tool selection, operational errors, parent/child overlap, child terminal states, completion attempts and visibility, turns, tokens, and wall-clock durations within one runtime.
+They cannot establish semantic task success, whether delegation was appropriate, whether parent work was useful, or whether a completion was understood by the model.
+Opt-in field data describes only users who enabled recording and does not prove causal effects between tool surfaces.
+Use a controlled benchmark before interpreting future `subagent_await` immediate-join or blocking-choice hypotheses causally.
+
+`/subagents status` reports whether recording is active, the current-session event count, retention, and the local path.
+A failed write drops that event, reports one bounded warning, and retries on later events without exposing filesystem details.
 
 ## 🛠️ Tools
 
@@ -283,7 +309,7 @@ It never starts a child, sends or acknowledges mailbox messages, interrupts or c
 | `get_workflow` | Required `workflowId` | Bounded task states, generations, dependencies, plan identities, artifact metadata, verification state, and outcome reasons without artifact contents |
 | `list_models` | Optional `limit` (default 50, maximum 100) | Session-scoped models, or the already-loaded available snapshot |
 | `preview_context` | Optional `context` and `contextEntryIds` | Selected mode, user turns, source count, UTF-8 bytes, and truncation without returning context text |
-| `status` | No additional fields | Effective workflow, runtime counts/transport, detached limit values, completion delivery, consultation resources, and configured/runtime settings with per-field sources |
+| `status` | No additional fields | Effective workflow, runtime counts/transport, detached limit values, completion delivery, local usage-recording state, consultation resources, and configured/runtime settings with per-field sources |
 | `diagnose` | No additional fields | Structured `pass`, `warning`, and `fail` checks; failed checks are report data rather than a tool error |
 
 The schema rejects fields that do not belong to the selected action.
@@ -685,6 +711,9 @@ Manual edits use `~/.pi/agent/pi-subagents.json` and take effect after reloading
   },
   "consult": {
     "resources": "project-context"
+  },
+  "usageRecording": {
+    "enabled": false
   }
 }
 ```
@@ -1185,6 +1214,8 @@ packages/pi-subagents/
 │   ├── rpc-turn-capture.ts       # RPC evidence capture, usage, and budget events
 │   ├── auto-transport.ts         # Deterministic preflight transport routing
 │   ├── transport-types.ts        # Bounded pi-subagents:v1 progress and telemetry contract
+│   ├── usage-recording.ts        # Opt-in content-free event collection and local identities
+│   ├── usage-recording-store.ts  # Private per-runtime JSONL writers and retention pruning
 │   ├── completion-delivery.ts    # Top-level completion batching and optional idle-root wake
 │   ├── completion-routing.ts     # Direct-parent and live-ancestor recipient selection
 │   ├── task-path.ts              # Canonical retained-agent task identity and resolution
@@ -1240,7 +1271,7 @@ The package build bundles that source graph into split `.ts` files under `dist` 
 `subagents.ts` and `stateful.ts` preserve existing source-level utility imports without making those utility graphs part of Pi startup.
 Workflow settings remain backward compatible: older files without `blocking.enabled` receive the eight-tool default, and an absent `blocking.maxParallelTasks` keeps the previous eight-worker limit.
 Existing `stateful.enabled: false` files expose blocking delegation plus inspection/consultation.
-Older package releases ignore and preserve the optional `blocking.maxParallelTasks`, `consult`, and `cwdPolicy` fields.
+Older package releases ignore and preserve the optional `blocking.maxParallelTasks`, `consult`, `cwdPolicy`, and `usageRecording` fields.
 The package exposes its Pi extension through `package.json`:
 
 ```json

--- a/packages/pi-subagents/src/agents/types.ts
+++ b/packages/pi-subagents/src/agents/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AgentCapabilityManifest } from "../capabilities.js";
+import type { SubagentUsageRecordingSettings } from "../usage-recording-config.js";
 
 export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
@@ -95,4 +96,5 @@ export interface SubagentSettings {
 	stateful?: SubagentRuntimeSettings;
 	consult?: SubagentConsultSettings;
 	cwdPolicy?: SubagentCwdPolicySettings;
+	usageRecording?: SubagentUsageRecordingSettings;
 }

--- a/packages/pi-subagents/src/completion-delivery.ts
+++ b/packages/pi-subagents/src/completion-delivery.ts
@@ -45,6 +45,14 @@ type CompletionPi = Pick<ExtensionAPI, "sendMessage">;
 
 export interface CompletionDeliveryBrokerOptions {
 	onDeliveryError?: (error: unknown) => void;
+	onDeliveryAttempt?: (
+		completions: readonly AgentTurnCompletion[],
+		input: {
+			delivery: "steer" | "nextTurn";
+			triggerTurn: boolean;
+			outcome: "accepted" | "failed";
+		},
+	) => void;
 	onAcknowledged?: (completions: readonly AgentTurnCompletion[], acknowledgedAt: number) => void;
 	now?: () => number;
 }
@@ -116,14 +124,34 @@ export class CompletionDeliveryBroker {
 					deliverAs: "steer",
 					...(triggerTurn ? { triggerTurn: true } : {}),
 				});
+				this.notifyDeliveryAttempt(batch, {
+					delivery: "steer",
+					triggerTurn,
+					outcome: "accepted",
+				});
 			} catch (primaryError) {
+				this.notifyDeliveryAttempt(batch, {
+					delivery: "steer",
+					triggerTurn,
+					outcome: "failed",
+				});
 				this.removeAwaiting(batch);
 				if (triggerTurn) this.wakeInFlight = false;
 				canWake = false;
 				this.awaitingParentAck.push(...batch);
 				try {
 					this.pi.sendMessage(message, { deliverAs: "nextTurn", triggerTurn: false });
+					this.notifyDeliveryAttempt(batch, {
+						delivery: "nextTurn",
+						triggerTurn: false,
+						outcome: "accepted",
+					});
 				} catch (fallbackError) {
+					this.notifyDeliveryAttempt(batch, {
+						delivery: "nextTurn",
+						triggerTurn: false,
+						outcome: "failed",
+					});
 					this.removeAwaiting(batch);
 					this.pending = [...batches.slice(index).flat(), ...this.pending];
 					try {
@@ -185,6 +213,21 @@ export class CompletionDeliveryBroker {
 		this.awaitingParentAck = this.awaitingParentAck.filter(
 			(completion) => !removed.has(completion.completionId),
 		);
+	}
+
+	private notifyDeliveryAttempt(
+		completions: readonly AgentTurnCompletion[],
+		input: {
+			delivery: "steer" | "nextTurn";
+			triggerTurn: boolean;
+			outcome: "accepted" | "failed";
+		},
+	): void {
+		try {
+			this.options.onDeliveryAttempt?.(completions, input);
+		} catch {
+			// Delivery already succeeded, so an observer cannot retract it.
+		}
 	}
 
 	private isRootIdle(): boolean {

--- a/packages/pi-subagents/src/config-status.ts
+++ b/packages/pi-subagents/src/config-status.ts
@@ -16,6 +16,7 @@ import {
 	inspectDelegationWorkflowSettings,
 	inspectStatefulLimitSettings,
 	inspectStatefulTransportSettings,
+	inspectUsageRecordingSettings,
 } from "./settings.js";
 import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
 import {
@@ -24,6 +25,7 @@ import {
 	formatDetachedLimitSummary,
 } from "./stateful-limit-ui.js";
 import { STATEFUL_LIMIT_DEFINITIONS } from "./stateful-limits.js";
+import { USAGE_RECORDING_RETENTION_DAYS } from "./usage-recording-config.js";
 import { workflowLabel } from "./workflow-ui.js";
 
 export function showSubagentStatus(
@@ -72,6 +74,7 @@ export function helpLines(runtime: SubagentSettingsRuntime): string[] {
 		`Configured parallel limit: ${parallelLimit.value} (${parallelLimit.source})`,
 		`Detached limits: ${formatDetachedLimitSummary(runtime.getRuntimeStatus())}`,
 		`Configured transport: ${transport.value} (${transport.source})`,
+		`Local usage recording: ${runtime.getUsageRecordingEnabled?.() ? "enabled" : "disabled"} · ${USAGE_RECORDING_RETENTION_DAYS}-day retention`,
 		...(detachedLimits.values
 			? [`Configured detached limits: ${formatConfiguredDetachedLimits(detachedLimits.values)}`]
 			: ["Configured detached limits: unavailable; repair user settings"]),
@@ -102,6 +105,7 @@ export function formatManagerSummary(
 		`Parallel workers: max ${runtime.getMaxParallelTasks()} per blocking call`,
 		`Detached limits: ${formatDetachedLimitSummary(status)}`,
 		`Transport: ${status.transport}`,
+		`Usage recording: ${runtime.getUsageRecordingEnabled?.() ? "On · local only" : "Off"}`,
 		`Configured transport: ${transport.value} · ${transport.source}`,
 		`Configured consult target: ${consultationCwdLabel(cwdPolicy.consultation.value)} · ${cwdPolicy.consultation.source}`,
 		`Configured delegation target: ${delegationCwdLabel(cwdPolicy.delegation.value)} · ${cwdPolicy.delegation.source}`,
@@ -129,7 +133,9 @@ function formatStatus(
 	const parallelLimit = inspectBlockingParallelLimitSettings();
 	const detachedLimits = inspectStatefulLimitSettings();
 	const transport = inspectStatefulTransportSettings();
+	const usageRecording = inspectUsageRecordingSettings();
 	const current = runtime ? currentWorkflow(runtime, status) : configuredWorkflow.value;
+	const usageStatus = runtime?.getUsageRecordingStatus?.();
 	return [
 		"Current session",
 		`  Delegation: ${workflowLabel(current)}`,
@@ -143,6 +149,10 @@ function formatStatus(
 		`  Maximum parallel workers: ${runtime?.getMaxParallelTasks() ?? parallelLimit.value} per blocking call`,
 		`  Detached limits: ${formatDetachedLimitSummary(status)}`,
 		`  Agents: ${status.activeAgents} active, ${status.retainedAgents} retained`,
+		`  Local usage recording: ${usageStatus?.enabled ? "enabled" : "disabled"}`,
+		`  Recorded events this session: ${usageStatus?.recordedEvents ?? 0}`,
+		`  Usage retention: ${usageStatus?.retentionDays ?? USAGE_RECORDING_RETENTION_DAYS} days`,
+		`  Usage path: ${safeTerminalText(usageStatus?.path ?? "unavailable")}`,
 		"User settings",
 		`  Delegation source: ${configuredWorkflow.source}`,
 		`  Configured delegation: ${workflowLabel(configuredWorkflow.value)}`,
@@ -162,14 +172,17 @@ function formatStatus(
 		`  Delegation target source: ${cwdPolicy.delegation.source}`,
 		`  Configured consultation resources: ${consultResourceLabel(consult.value)}`,
 		`  Consultation resource source: ${consult.source}`,
+		`  Configured usage recording: ${usageRecording.enabled ? "enabled" : "disabled"}`,
+		`  Usage recording source: ${usageRecording.source}`,
 		`  Path: ${safeTerminalText(snapshot.path)}`,
 		configuredWorkflow.error ||
 		snapshot.error ||
 		cwdPolicy.error ||
 		parallelLimit.error ||
 		detachedLimits.error ||
-		transport.error
-			? `  Warning: ${safeTerminalText(configuredWorkflow.error ?? snapshot.error ?? cwdPolicy.error ?? parallelLimit.error ?? detachedLimits.error ?? transport.error ?? "invalid settings")}`
+		transport.error ||
+		usageRecording.error
+			? `  Warning: ${safeTerminalText(configuredWorkflow.error ?? snapshot.error ?? cwdPolicy.error ?? parallelLimit.error ?? detachedLimits.error ?? transport.error ?? usageRecording.error ?? "invalid settings")}`
 			: "  Warning: none",
 		configuredWorkflow.value !== current
 			? "Configured delegation differs from this session. Run /reload to apply it."

--- a/packages/pi-subagents/src/config-ui.ts
+++ b/packages/pi-subagents/src/config-ui.ts
@@ -44,6 +44,7 @@ import {
 	inspectConsultResourceSettings,
 	inspectCwdPolicySettings,
 	inspectDelegationWorkflowSettings,
+	inspectUsageRecordingSettings,
 	readSubagentSettings,
 	sameToolSet,
 	uniqueToolNames,
@@ -52,6 +53,7 @@ import {
 	updateConsultResourceSetting,
 	updateCwdPolicySetting,
 	updateDelegationWorkflowSetting,
+	updateUsageRecordingSetting,
 } from "./settings.js";
 import { formatStatefulAgentLine, type StatefulSubagentRuntimeStatus } from "./stateful.js";
 import {
@@ -67,6 +69,8 @@ import {
 	responsivenessSetupScreen,
 	transportSettingsScreen,
 } from "./transport-ui.js";
+import type { UsageRecordingStatus } from "./usage-recording.js";
+import { USAGE_RECORDING_RETENTION_DAYS } from "./usage-recording-config.js";
 import { showWorkflowPreview, workflowLabel } from "./workflow-ui.js";
 
 const SUBCOMMANDS = [
@@ -83,6 +87,9 @@ export interface SubagentSettingsRuntime {
 	getConsultResourcePolicy(): ConsultResourcePolicy;
 	getConsultationCwdPolicy(): ConsultationCwdPolicy;
 	getDelegationCwdPolicy(): DelegationCwdPolicy;
+	getUsageRecordingEnabled?(): boolean;
+	getUsageRecordingStatus?(): UsageRecordingStatus;
+	setUsageRecordingEnabled?(value: boolean): Promise<void>;
 	setMaxParallelTasks(value: number): void;
 	setCompletionDelivery(value: CompletionDelivery): void;
 	setConsultResourcePolicy(value: ConsultResourcePolicy): void;
@@ -222,6 +229,7 @@ export async function showSubagentManager(
 		| "set-consult-resources"
 		| "set-consultation-cwd"
 		| "set-delegation-cwd"
+		| "set-usage-recording"
 		| "load-agent-picker"
 		| "pick-agent"
 		| "toggle-tool"
@@ -600,6 +608,8 @@ export async function showSubagentManager(
 				applyConsultResourceSetting(value, ctx, runtime),
 			"set-consultation-cwd": async ({ value }) => applyConsultationCwdSetting(value, ctx, runtime),
 			"set-delegation-cwd": async ({ value }) => applyDelegationCwdSetting(value, ctx, runtime),
+			"set-usage-recording": async ({ value, signal }) =>
+				applyUsageRecordingSetting(value, ctx, runtime, { signal, isCurrent }),
 			"load-agent-picker": async () => {
 				availableAgents = discoverAgents(ctx.cwd, "user", readSubagentSettings() ?? {}).agents;
 				if (availableAgents.length === 0) {
@@ -698,7 +708,8 @@ export async function showSubagentSettings(
 		| "set-completion"
 		| "set-consult-resources"
 		| "set-consultation-cwd"
-		| "set-delegation-cwd";
+		| "set-delegation-cwd"
+		| "set-usage-recording";
 	const menu = defineMenu<undefined, "settings", SettingsAction, ExtensionCommandContext>({
 		start: "settings",
 		screens: { settings: () => subagentSettingsScreen(runtime) },
@@ -708,6 +719,8 @@ export async function showSubagentSettings(
 				applyConsultResourceSetting(value, ctx, runtime),
 			"set-consultation-cwd": async ({ value }) => applyConsultationCwdSetting(value, ctx, runtime),
 			"set-delegation-cwd": async ({ value }) => applyDelegationCwdSetting(value, ctx, runtime),
+			"set-usage-recording": async ({ value, signal }) =>
+				applyUsageRecordingSetting(value, ctx, runtime, { signal, isCurrent }),
 		},
 	});
 	await runMenu(ctx, menu, {
@@ -721,7 +734,8 @@ function subagentSettingsScreen(runtime: SubagentSettingsRuntime) {
 	const completion = inspectCompletionDeliverySettings();
 	const consult = inspectConsultResourceSettings();
 	const cwdPolicy = inspectCwdPolicySettings();
-	const error = completion.error ?? consult.error ?? cwdPolicy.error;
+	const usageRecording = inspectUsageRecordingSettings();
+	const error = completion.error ?? consult.error ?? cwdPolicy.error ?? usageRecording.error;
 	return {
 		kind: "settings" as const,
 		title: error ? "Subagent User Settings · Read only" : "Subagent User Settings",
@@ -775,8 +789,65 @@ function subagentSettingsScreen(runtime: SubagentSettingsRuntime) {
 						values: ["Wait until my next turn", "Resume automatically when finished"],
 						action: "set-completion" as const,
 					},
+					{
+						id: "usageRecording",
+						label: "Local usage recording",
+						description: `Opt in to content-free lifecycle and timing events kept locally for ${USAGE_RECORDING_RETENTION_DAYS} days.`,
+						currentValue: runtime.getUsageRecordingEnabled?.() ? "On · local only" : "Off",
+						values: ["Off", "On · local only"],
+						action: "set-usage-recording" as const,
+					},
 				],
 	};
+}
+
+async function applyUsageRecordingSetting(
+	value: string | undefined,
+	ctx: ExtensionCommandContext,
+	runtime: SubagentSettingsRuntime,
+	options: { signal: AbortSignal; isCurrent: () => boolean },
+) {
+	if (options.signal.aborted || !options.isCurrent()) return { kind: "close" as const };
+	const previous = runtime.getUsageRecordingEnabled?.() ?? false;
+	const next = value === "On · local only";
+	if (next === previous) return { kind: "stay" as const };
+	if (!runtime.setUsageRecordingEnabled) {
+		ctx.ui.notify("Usage recording is unavailable in this session.", "error");
+		return { kind: "rejected" as const };
+	}
+	try {
+		updateUsageRecordingSetting(next);
+	} catch (error) {
+		ctx.ui.notify(`Subagent settings were not saved: ${formatError(error)}`, "error");
+		return { kind: "rejected" as const };
+	}
+	try {
+		await runtime.setUsageRecordingEnabled(next);
+		if (options.signal.aborted || !options.isCurrent()) return { kind: "close" as const };
+		ctx.ui.notify(
+			next
+				? `Local content-free usage recording enabled. Records stay on this device for ${USAGE_RECORDING_RETENTION_DAYS} days.`
+				: "Local usage recording disabled. Existing records expire under the retention policy.",
+			"info",
+		);
+		return { kind: "stay" as const };
+	} catch (error) {
+		if (options.signal.aborted || !options.isCurrent()) return { kind: "close" as const };
+		try {
+			updateUsageRecordingSetting(previous);
+			await runtime.setUsageRecordingEnabled(previous);
+			if (options.signal.aborted || !options.isCurrent()) return { kind: "close" as const };
+		} catch (rollbackError) {
+			if (options.signal.aborted || !options.isCurrent()) return { kind: "close" as const };
+			ctx.ui.notify(
+				`Usage recording could not be applied or rolled back: ${formatError(new AggregateError([error, rollbackError]))}`,
+				"error",
+			);
+			return { kind: "rejected" as const };
+		}
+		ctx.ui.notify(`Subagent settings were not applied: ${formatError(error)}`, "error");
+		return { kind: "rejected" as const };
+	}
 }
 
 function applyCompletionSetting(

--- a/packages/pi-subagents/src/inspect.ts
+++ b/packages/pi-subagents/src/inspect.ts
@@ -25,8 +25,10 @@ import {
 	inspectStatefulLimitSettings,
 	inspectStatefulTransportSettings,
 	inspectSubagentSettings,
+	inspectUsageRecordingSettings,
 } from "./settings.js";
 import type { StatefulSubagentRuntimeStatus } from "./stateful.js";
+import type { UsageRecordingStatus } from "./usage-recording.js";
 import type { WorkItemLedgerSnapshot } from "./work-item-ledger.js";
 import { inspectSessionWorkflows } from "./work-item-persistence.js";
 
@@ -41,6 +43,7 @@ export interface SubagentInspectRuntime {
 	getConsultResourcePolicy(): "project-context" | "none" | "all";
 	getConsultationCwdPolicy(): ConsultationCwdPolicy;
 	getDelegationCwdPolicy(): DelegationCwdPolicy;
+	getUsageRecordingStatus?(): UsageRecordingStatus;
 	getRuntimeStatus(): StatefulSubagentRuntimeStatus;
 	listRunInspection(includeClosed?: boolean): AgentRunInspectionSummary[];
 	getRunInspection(agentId: string): AgentRunInspectionDetail | undefined;
@@ -577,6 +580,8 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 	const parallelLimit = inspectBlockingParallelLimitSettings();
 	const detachedLimits = inspectStatefulLimitSettings();
 	const transport = inspectStatefulTransportSettings();
+	const usageRecording = inspectUsageRecordingSettings();
+	const usageStatus = runtime.getUsageRecordingStatus?.();
 	const configuredDetachedLimits = detachedLimits.values
 		? Object.fromEntries(
 				Object.entries(detachedLimits.values).map(([field, snapshot]) => [field, snapshot.value]),
@@ -599,6 +604,16 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 		configuredStatefulLimitSources: configuredDetachedLimitSources,
 		configuredCompletionDelivery: completion.value,
 		configuredCompletionDeliverySource: completion.source,
+		usageRecording: usageStatus
+			? {
+					enabled: usageStatus.enabled,
+					retentionDays: usageStatus.retentionDays,
+					recordedEvents: usageStatus.recordedEvents,
+					writeFailure: usageStatus.writeFailure,
+				}
+			: { enabled: false },
+		configuredUsageRecording: usageRecording.enabled,
+		configuredUsageRecordingSource: usageRecording.source,
 		maxParallelTasks: runtime.getMaxParallelTasks(),
 		configuredMaxParallelTasks: parallelLimit.value,
 		configuredMaxParallelTasksSource: parallelLimit.source,
@@ -619,7 +634,8 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 			completion.error ||
 			parallelLimit.error ||
 			detachedLimits.error ||
-			transport.error
+			transport.error ||
+			usageRecording.error
 				? boundedPrivateText(
 						configured.error ??
 							resources.error ??
@@ -628,6 +644,7 @@ function projectStatus(runtime: SubagentInspectRuntime): Record<string, unknown>
 							parallelLimit.error ??
 							detachedLimits.error ??
 							transport.error ??
+							usageRecording.error ??
 							"",
 						2 * 1024,
 					)

--- a/packages/pi-subagents/src/settings-reader.ts
+++ b/packages/pi-subagents/src/settings-reader.ts
@@ -12,6 +12,7 @@ import {
 	buildStatefulLimitSettingsSnapshot,
 	buildStatefulTransportSettingsSnapshot,
 	buildSubagentSettingsSnapshot,
+	buildUsageRecordingSettingsSnapshot,
 	type CompletionDeliverySettingsSnapshot,
 	type ConsultResourceSettingsSnapshot,
 	type CwdPolicySettingsSnapshot,
@@ -20,6 +21,7 @@ import {
 	type StatefulLimitSettingsSnapshot,
 	type StatefulTransportSettingsSnapshot,
 	type SubagentSettingsSnapshot,
+	type UsageRecordingSettingsSnapshot,
 } from "./settings/inspection.js";
 import { isPlainObject, normalizeSubagentSettings } from "./settings/schema.js";
 
@@ -40,6 +42,7 @@ export {
 	type StatefulLimitSettingsSnapshot,
 	type StatefulTransportSettingsSnapshot,
 	type SubagentSettingsSnapshot,
+	type UsageRecordingSettingsSnapshot,
 } from "./settings/inspection.js";
 export { hasOwn, normalizeAgentSettings, normalizeSubagentSettings } from "./settings/schema.js";
 
@@ -160,6 +163,10 @@ export function inspectDelegationWorkflowSettings(): DelegationWorkflowSettingsS
 
 export function inspectCompletionDeliverySettings(): CompletionDeliverySettingsSnapshot {
 	return buildCompletionDeliverySettingsSnapshot(inspectSubagentSettingsDocument());
+}
+
+export function inspectUsageRecordingSettings(): UsageRecordingSettingsSnapshot {
+	return buildUsageRecordingSettingsSnapshot(inspectSubagentSettingsDocument());
 }
 
 export function inspectStatefulTransportSettings(): StatefulTransportSettingsSnapshot {

--- a/packages/pi-subagents/src/settings.ts
+++ b/packages/pi-subagents/src/settings.ts
@@ -57,6 +57,7 @@ export {
 	inspectStatefulLimitSettings,
 	inspectStatefulTransportSettings,
 	inspectSubagentSettings,
+	inspectUsageRecordingSettings,
 	normalizeAgentSettings,
 	normalizeSubagentSettings,
 	readSubagentSettings,
@@ -67,6 +68,7 @@ export {
 	type StatefulTransportSettingsSnapshot,
 	type SubagentSettingsSnapshot,
 	subagentSettingsFilePath,
+	type UsageRecordingSettingsSnapshot,
 } from "./settings-reader.js";
 
 const SETTINGS_FILE = SUBAGENT_SETTINGS_FILE;
@@ -156,6 +158,24 @@ export function updateCompletionDeliverySetting(value: CompletionDelivery): void
 					...(stateful ?? {}),
 					completionDelivery: value,
 				},
+			},
+			update.replaceCanonical,
+		);
+	});
+}
+
+export function updateUsageRecordingSetting(enabled: boolean): void {
+	withSettingsMutationLock(() => {
+		const update = readSettingsObjectForUpdate();
+		const raw = update.document;
+		const usageRecording = raw.usageRecording;
+		if (usageRecording !== undefined && !isPlainObject(usageRecording)) {
+			throw new Error(`Cannot update invalid ${SETTINGS_FILE} usageRecording settings`);
+		}
+		writeSettingsObjectUnlocked(
+			{
+				...raw,
+				usageRecording: { ...(usageRecording ?? {}), enabled },
 			},
 			update.replaceCanonical,
 		);

--- a/packages/pi-subagents/src/settings/inspection.ts
+++ b/packages/pi-subagents/src/settings/inspection.ts
@@ -96,6 +96,13 @@ export interface SubagentSettingsSnapshot {
 	error?: string;
 }
 
+export interface UsageRecordingSettingsSnapshot {
+	path: string;
+	enabled: boolean;
+	source: SettingsSource;
+	error?: string;
+}
+
 export function resolveDelegationWorkflow(
 	blockingEnabled: boolean,
 	statefulEnabled: boolean,
@@ -118,6 +125,26 @@ export function buildSubagentSettingsSnapshot(
 		settings: inspected.settings,
 		source: inspected.settings ? "user settings" : "default",
 		...(inspected.error ? { error: inspected.error } : {}),
+	};
+}
+
+export function buildUsageRecordingSettingsSnapshot(
+	inspected: InspectedSubagentSettingsDocument,
+): UsageRecordingSettingsSnapshot {
+	if (!inspected.raw || !inspected.settings) {
+		return {
+			path: inspected.path,
+			enabled: false,
+			source: "default",
+			...(inspected.error ? { error: inspected.error } : {}),
+		};
+	}
+	const explicit =
+		isPlainObject(inspected.raw.usageRecording) && hasOwn(inspected.raw.usageRecording, "enabled");
+	return {
+		path: inspected.path,
+		enabled: inspected.settings.usageRecording?.enabled === true,
+		source: explicit ? "user settings" : "default",
 	};
 }
 

--- a/packages/pi-subagents/src/settings/schema.ts
+++ b/packages/pi-subagents/src/settings/schema.ts
@@ -182,5 +182,14 @@ export function normalizeSubagentSettings(value: unknown): SubagentSettings | un
 		}
 		settings.cwdPolicy = cwdPolicy;
 	}
+	if (hasOwn(value, "usageRecording")) {
+		if (!isPlainObject(value.usageRecording)) return undefined;
+		const usageRecording: NonNullable<SubagentSettings["usageRecording"]> = {};
+		if (hasOwn(value.usageRecording, "enabled")) {
+			if (typeof value.usageRecording.enabled !== "boolean") return undefined;
+			usageRecording.enabled = value.usageRecording.enabled;
+		}
+		settings.usageRecording = usageRecording;
+	}
 	return settings;
 }

--- a/packages/pi-subagents/src/stateful-registration.ts
+++ b/packages/pi-subagents/src/stateful-registration.ts
@@ -56,6 +56,7 @@ import {
 } from "./stateful-tool-params.js";
 import { MAX_TASK_NAME_LENGTH } from "./task-path.js";
 import { MAX_SUBAGENT_TOOL_CALLS, MAX_SUBAGENT_TURNS } from "./turn-budget.js";
+import type { UsageRecordingController } from "./usage-recording.js";
 import type { WorkspaceManager } from "./workspace.js";
 
 type CwdPolicyModule = typeof import("./cwd-policy.js");
@@ -227,6 +228,7 @@ export interface StatefulSubagentDependencies {
 	settings?: SubagentRuntimeSettings;
 	getSettings?: () => SubagentSettings | undefined;
 	loadTransport?: CreateStatefulTransportOptions["loadTransport"];
+	usageRecording?: UsageRecordingController;
 }
 
 export interface StatefulSubagentRuntimeStatus {
@@ -415,9 +417,16 @@ export function registerStatefulSubagents(
 						const reason = error instanceof Error ? error.message : String(error);
 						ctx.ui.notify(`Subagent completion delivery failed: ${reason}`, "warning");
 					},
+					onDeliveryAttempt: (completions, input) => {
+						if (generation !== runtimeGeneration) return;
+						for (const completion of completions) {
+							dependencies.usageRecording?.recordCompletionDeliveryAttempt(completion, input);
+						}
+					},
 					onAcknowledged: (completions, deliveredAt) => {
 						if (generation !== runtimeGeneration) return;
 						for (const completion of completions) {
+							dependencies.usageRecording?.recordCompletionVisible(completion);
 							void nextRegistry
 								.markCompletionDelivered(completion.completionId, deliveredAt)
 								.catch((error: unknown) => {
@@ -479,6 +488,7 @@ export function registerStatefulSubagents(
 					if (generation !== runtimeGeneration) return;
 					await sessionPersistence.save(agents);
 					if (generation !== runtimeGeneration) return;
+					dependencies.usageRecording?.observeAgents(agents);
 					for (const agent of agents) {
 						for (const message of agent.mailbox) {
 							if (seenMessageIds.has(message.id)) continue;
@@ -506,9 +516,9 @@ export function registerStatefulSubagents(
 					}
 				},
 				onTurnComplete: (completion) => {
-					if (generation === runtimeGeneration && completion.recipientId === "root") {
-						sessionBroker.enqueue(completion);
-					}
+					if (generation !== runtimeGeneration) return;
+					dependencies.usageRecording?.recordChildCompletion(completion);
+					if (completion.recipientId === "root") sessionBroker.enqueue(completion);
 				},
 			});
 			const persisted = sessionPersistence.load();

--- a/packages/pi-subagents/src/subagents-extension.ts
+++ b/packages/pi-subagents/src/subagents-extension.ts
@@ -51,6 +51,12 @@ import {
 } from "./settings-reader.js";
 import { registerStatefulSubagents } from "./stateful-registration.js";
 import type { SubagentTransport } from "./transport.js";
+import {
+	registerUsageRecording,
+	type UsageRecordingDependencies,
+	type UsageSurfaceArm,
+} from "./usage-recording.js";
+import { resolveUsageRecordingEnabled } from "./usage-recording-config.js";
 
 type BlockingExecutionModule = Pick<typeof import("./execution.js"), "executeSubagent">;
 
@@ -60,6 +66,7 @@ export interface SubagentsDependencies {
 	config?: ConfigRegistrationDependencies;
 	consult?: ConsultRegistrationDependencies;
 	inspect?: InspectRegistrationDependencies;
+	usageRecording?: Partial<UsageRecordingDependencies>;
 }
 
 export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies = {}) {
@@ -68,6 +75,7 @@ export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies =
 		dependencies.loadBlockingExecution ?? (() => import("./execution.js")),
 	);
 	const configOwner = registerSubagentConfigLifecycle(pi);
+	const usageRecording = registerUsageRecording(pi, dependencies.usageRecording);
 	const settings = readSubagentSettings();
 	let currentSettings: SubagentSettings | undefined = settings;
 	let currentCatalog = "";
@@ -78,7 +86,7 @@ export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies =
 	let refreshStatefulCatalog: (catalog: string) => void = () => undefined;
 	let refreshConsultCatalog: (catalog: string) => void = () => undefined;
 
-	pi.on("session_start", (_event, ctx) => {
+	pi.on("session_start", async (event, ctx) => {
 		// Preserve a one-shot migration notice from extension load while refreshing
 		// validation against settings that may have changed before this session.
 		const loadNotice = consumeSubagentSettingsNotice();
@@ -96,6 +104,14 @@ export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies =
 		refreshBlockingCatalog(currentCatalog);
 		refreshStatefulCatalog(currentCatalog);
 		refreshConsultCatalog(currentCatalog);
+		await usageRecording.startSession({
+			enabled: resolveUsageRecordingEnabled(currentSettings?.usageRecording),
+			surfaceArm: usageSurfaceArm(blockingEnabled, statefulRuntime.getRuntimeStatus().enabled),
+			reason: event.reason,
+			onWarning: (message) => {
+				if (ctx.hasUI) ctx.ui.notify(message, "warning");
+			},
+		});
 	});
 
 	const statefulRuntime = registerStatefulSubagents(pi, {
@@ -103,6 +119,7 @@ export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies =
 		settings: settings?.stateful,
 		getSettings: () => currentSettings,
 		loadTransport: dependencies.loadStatefulTransport,
+		usageRecording,
 	});
 	refreshStatefulCatalog = statefulRuntime.setAgentCatalog;
 	const getBlockingEnabled = () => blockingEnabled;
@@ -122,6 +139,7 @@ export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies =
 			getConsultResourcePolicy,
 			getConsultationCwdPolicy,
 			getDelegationCwdPolicy,
+			getUsageRecordingStatus: () => usageRecording.getStatus(),
 		},
 		dependencies.inspect,
 	);
@@ -141,6 +159,15 @@ export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies =
 			getConsultResourcePolicy,
 			getConsultationCwdPolicy,
 			getDelegationCwdPolicy,
+			getUsageRecordingEnabled: () => usageRecording.getStatus().enabled,
+			getUsageRecordingStatus: () => usageRecording.getStatus(),
+			setUsageRecordingEnabled: async (value: boolean) => {
+				await usageRecording.setEnabled(value);
+				currentSettings = {
+					...(currentSettings ?? {}),
+					usageRecording: { ...(currentSettings?.usageRecording ?? {}), enabled: value },
+				};
+			},
 			setMaxParallelTasks(value: number) {
 				const previousSettings = currentSettings;
 				currentSettings = {
@@ -188,6 +215,14 @@ export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies =
 		configOwner,
 		dependencies.config,
 	);
+	pi.on("session_shutdown", (event) => usageRecording.shutdown(event.reason));
+}
+
+function usageSurfaceArm(blockingEnabled: boolean, statefulEnabled: boolean): UsageSurfaceArm {
+	if (blockingEnabled && statefulEnabled) return "all";
+	if (statefulEnabled) return "async-only";
+	if (blockingEnabled) return "blocking-only";
+	return "disabled";
 }
 
 function registerBlockingSubagent(

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -11,6 +11,7 @@ export {
 	inspectDelegationWorkflowSettings,
 	inspectStatefulLimitSettings,
 	inspectSubagentSettings,
+	inspectUsageRecordingSettings,
 	normalizeAgentSettings,
 	normalizeSubagentSettings,
 	readSubagentSettings,
@@ -27,6 +28,7 @@ export {
 	updateCwdPolicySetting,
 	updateDelegationWorkflowSetting,
 	updateStatefulLimitSetting,
+	updateUsageRecordingSetting,
 } from "./settings.js";
 export { default, type SubagentsDependencies } from "./subagents-extension.js";
 export { formatTokens, formatUsageStats } from "./usage-format.js";

--- a/packages/pi-subagents/src/usage-recording-config.ts
+++ b/packages/pi-subagents/src/usage-recording-config.ts
@@ -1,0 +1,13 @@
+export const USAGE_RECORDING_DIRECTORY = "pi-subagents-usage";
+export const USAGE_RECORDING_RETENTION_DAYS = 30;
+export const USAGE_RECORDING_STUDY_ID = "pi-subagents-surface-v1";
+
+export interface SubagentUsageRecordingSettings {
+	enabled?: boolean;
+}
+
+export function resolveUsageRecordingEnabled(
+	settings: SubagentUsageRecordingSettings | undefined,
+): boolean {
+	return settings?.enabled === true;
+}

--- a/packages/pi-subagents/src/usage-recording-store.ts
+++ b/packages/pi-subagents/src/usage-recording-store.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import { chmod, lstat, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const WRITER_PATTERN =
+	/^runtime-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jsonl$/u;
+const MAX_EVENT_BYTES = 8 * 1024;
+const WRITE_TIMEOUT_MS = 2_000;
+
+export interface UsageEventStorePort {
+	readonly path: string;
+	append(event: unknown): Promise<void>;
+	prune(retentionDays: number): Promise<void>;
+	close(): Promise<void>;
+}
+
+export class UsageEventStore implements UsageEventStorePort {
+	readonly path: string;
+	private readonly writerPath: string;
+	private mutationTail: Promise<void> = Promise.resolve();
+	private readonly lifecycle = new AbortController();
+	private closed = false;
+
+	constructor(rootPath: string, options: { createId?: () => string; now?: () => number } = {}) {
+		this.path = rootPath;
+		this.createId = options.createId ?? randomUUID;
+		this.now = options.now ?? Date.now;
+		this.writerPath = path.join(rootPath, `runtime-${validId(this.createId())}.jsonl`);
+	}
+
+	private readonly createId: () => string;
+	private readonly now: () => number;
+
+	append(event: unknown): Promise<void> {
+		if (this.closed) return Promise.reject(new Error("Usage recording storage is closed."));
+		const frame = encodeEvent(event);
+		return this.enqueue(() =>
+			withTimeout(
+				(signal) => this.appendFrame(frame, signal),
+				this.lifecycle.signal,
+				WRITE_TIMEOUT_MS,
+				"Usage recording write timed out",
+			),
+		);
+	}
+
+	prune(retentionDays: number): Promise<void> {
+		if (this.closed) return Promise.reject(new Error("Usage recording storage is closed."));
+		return this.enqueue(() =>
+			withTimeout(
+				async (signal) => {
+					await ensurePrivateDirectory(this.path);
+					signal.throwIfAborted();
+					const cutoff = this.now() - retentionDays * 24 * 60 * 60 * 1000;
+					for (const entry of await readdir(this.path, { withFileTypes: true })) {
+						signal.throwIfAborted();
+						if (!entry.isFile() || !WRITER_PATTERN.test(entry.name)) continue;
+						const candidate = path.join(this.path, entry.name);
+						if (candidate === this.writerPath) continue;
+						let metadata: Awaited<ReturnType<typeof lstat>>;
+						try {
+							metadata = await lstat(candidate);
+						} catch (error) {
+							if (isNodeError(error) && error.code === "ENOENT") continue;
+							throw error;
+						}
+						if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.mtimeMs >= cutoff) {
+							continue;
+						}
+						await rm(candidate, { force: true });
+					}
+				},
+				this.lifecycle.signal,
+				WRITE_TIMEOUT_MS,
+				"Usage recording retention cleanup timed out",
+			),
+		);
+	}
+
+	async close(): Promise<void> {
+		if (this.closed) return;
+		this.closed = true;
+		this.lifecycle.abort(new DOMException("Usage recording storage closed", "AbortError"));
+		await this.mutationTail;
+	}
+
+	private enqueue(operation: () => Promise<void>): Promise<void> {
+		const result = this.mutationTail.then(operation);
+		this.mutationTail = result.catch(() => undefined);
+		return result;
+	}
+
+	private async appendFrame(frame: string, signal: AbortSignal): Promise<void> {
+		await ensurePrivateDirectory(this.path);
+		signal.throwIfAborted();
+		await assertOptionalPrivateRegularFile(this.writerPath);
+		signal.throwIfAborted();
+		await writeFile(this.writerPath, frame, {
+			encoding: "utf8",
+			flag: "a",
+			mode: 0o600,
+			signal,
+		});
+		if (process.platform !== "win32") await chmod(this.writerPath, 0o600);
+	}
+}
+
+export function encodeEvent(event: unknown): string {
+	const frame = `${JSON.stringify(event)}\n`;
+	if (Buffer.byteLength(frame) > MAX_EVENT_BYTES) {
+		throw new Error("Usage recording event exceeds the storage bound.");
+	}
+	return frame;
+}
+
+async function ensurePrivateDirectory(directoryPath: string): Promise<void> {
+	try {
+		const metadata = await lstat(directoryPath);
+		if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+			throw new Error("Usage recording storage must be a regular directory, not a link.");
+		}
+	} catch (error) {
+		if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+		await mkdir(directoryPath, { recursive: true, mode: 0o700 });
+		const metadata = await lstat(directoryPath);
+		if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+			throw new Error("Usage recording storage must be a regular directory, not a link.");
+		}
+	}
+	if (process.platform !== "win32") await chmod(directoryPath, 0o700);
+}
+
+async function assertOptionalPrivateRegularFile(filePath: string): Promise<void> {
+	try {
+		const metadata = await lstat(filePath);
+		if (!metadata.isFile() || metadata.isSymbolicLink()) {
+			throw new Error("Usage recording writers must be regular files, not links.");
+		}
+		if (process.platform !== "win32") await chmod(filePath, 0o600);
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") return;
+		throw error;
+	}
+}
+
+async function withTimeout<T>(
+	operation: (signal: AbortSignal) => Promise<T>,
+	lifecycleSignal: AbortSignal,
+	timeoutMs: number,
+	message: string,
+): Promise<T> {
+	lifecycleSignal.throwIfAborted();
+	const controller = new AbortController();
+	const abortLifecycle = () =>
+		controller.abort(
+			lifecycleSignal.reason ?? new DOMException("Usage recording storage closed", "AbortError"),
+		);
+	lifecycleSignal.addEventListener("abort", abortLifecycle, { once: true });
+	const timer = setTimeout(
+		() => controller.abort(new DOMException(message, "TimeoutError")),
+		timeoutMs,
+	);
+	try {
+		return await operation(controller.signal);
+	} catch (error) {
+		if (controller.signal.aborted) throw controller.signal.reason;
+		throw error;
+	} finally {
+		clearTimeout(timer);
+		lifecycleSignal.removeEventListener("abort", abortLifecycle);
+	}
+}
+
+function validId(value: string): string {
+	if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u.test(value)) {
+		throw new Error("Usage recording storage received an invalid writer identity.");
+	}
+	return value;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}

--- a/packages/pi-subagents/src/usage-recording.ts
+++ b/packages/pi-subagents/src/usage-recording.ts
@@ -1,0 +1,464 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { type ExtensionAPI, getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { AgentTurnCompletion, ManagedAgent } from "./registry-types.js";
+import type { TransportUsage } from "./transport-types.js";
+import {
+	USAGE_RECORDING_DIRECTORY,
+	USAGE_RECORDING_RETENTION_DAYS,
+	USAGE_RECORDING_STUDY_ID,
+} from "./usage-recording-config.js";
+import type { UsageEventStorePort } from "./usage-recording-store.js";
+
+const SHUTDOWN_FLUSH_MS = 2_500;
+
+const SUBAGENT_TOOLS = new Set([
+	"subagent",
+	"subagent_spawn",
+	"subagent_send",
+	"subagent_manage",
+	"subagent_mailbox",
+	"subagent_inspect",
+	"subagent_consult",
+	"subagent_await",
+]);
+
+export type UsageSurfaceArm = "all" | "async-only" | "blocking-only" | "disabled";
+
+type UsageEventType =
+	| "study_exposure"
+	| "parent_turn_start"
+	| "parent_turn_end"
+	| "tool_start"
+	| "tool_end"
+	| "child_run_start"
+	| "child_run_end"
+	| "completion_transition"
+	| "lifecycle";
+
+interface UsageEvent {
+	schemaVersion: 1;
+	studyId: typeof USAGE_RECORDING_STUDY_ID;
+	surfaceArm: UsageSurfaceArm;
+	logicalSession: string;
+	runtimeInstance: string;
+	branchEpoch: number;
+	turnId?: string;
+	eventSequence: number;
+	monotonicOffsetMs: number;
+	eventType: UsageEventType;
+	data: Record<string, boolean | number | string>;
+}
+
+export interface UsageRecordingStatus {
+	enabled: boolean;
+	initialized: boolean;
+	retentionDays: number;
+	path: string;
+	recordedEvents: number;
+	writeFailure: boolean;
+}
+
+export interface UsageRecordingController {
+	startSession(input: {
+		enabled: boolean;
+		surfaceArm: UsageSurfaceArm;
+		reason: "startup" | "reload" | "new" | "resume" | "fork";
+		onWarning?: (message: string) => void;
+	}): Promise<void>;
+	shutdown(reason: "quit" | "reload" | "new" | "resume" | "fork"): Promise<void>;
+	setEnabled(value: boolean): Promise<void>;
+	getStatus(): UsageRecordingStatus;
+	observeAgents(agents: readonly ManagedAgent[]): void;
+	recordChildCompletion(completion: AgentTurnCompletion): void;
+	recordCompletionDeliveryAttempt(
+		completion: AgentTurnCompletion,
+		input: {
+			delivery: "steer" | "nextTurn";
+			triggerTurn: boolean;
+			outcome: "accepted" | "failed";
+		},
+	): void;
+	recordCompletionVisible(completion: AgentTurnCompletion): void;
+}
+
+export interface UsageRecordingDependencies {
+	createId(): string;
+	monotonicNow(): number;
+	getAgentDir(): string;
+	loadStore(): Promise<{
+		UsageEventStore: new (path: string) => UsageEventStorePort;
+	}>;
+}
+
+export function registerUsageRecording(
+	pi: ExtensionAPI,
+	dependencies: Partial<UsageRecordingDependencies> = {},
+): UsageRecordingController {
+	const deps: UsageRecordingDependencies = {
+		createId: dependencies.createId ?? randomUUID,
+		monotonicNow: dependencies.monotonicNow ?? performance.now.bind(performance),
+		getAgentDir: dependencies.getAgentDir ?? getAgentDir,
+		loadStore: dependencies.loadStore ?? (() => import("./usage-recording-store.js")),
+	};
+	const pathValue = path.join(deps.getAgentDir(), USAGE_RECORDING_DIRECTORY);
+	const runtimeInstance = deps.createId();
+	let logicalSession = deps.createId();
+	let branchEpoch = 0;
+	let surfaceArm: UsageSurfaceArm = "disabled";
+	let sessionStartedAt = deps.monotonicNow();
+	let enabled = false;
+	let eventSequence = 0;
+	let recordedEvents = 0;
+	let writeFailure = false;
+	let warningActive = false;
+	let onWarning: ((message: string) => void) | undefined;
+	let storePromise: Promise<UsageEventStorePort> | undefined;
+	let writeGeneration = 0;
+	let writeTail: Promise<void> = Promise.resolve();
+	let transitionTail: Promise<void> = Promise.resolve();
+	let currentTurnId: string | undefined;
+	let turnOrdinal = 0;
+	let operationOrdinal = 0;
+	let childOrdinal = 0;
+	let runOrdinal = 0;
+	let completionOrdinal = 0;
+	const operations = new Map<string, { id: string; startedAt: number }>();
+	const children = new Map<string, string>();
+	const runs = new Map<string, string>();
+	const completions = new Map<string, string>();
+	const agentStates = new Map<string, string>();
+	const activeRuns = new Map<string, string>();
+
+	pi.on("agent_start", () => record("lifecycle", { phase: "parent_agent_start" }));
+	pi.on("agent_settled", () => record("lifecycle", { phase: "parent_agent_settled" }));
+	pi.on("turn_start", () => {
+		currentTurnId = `turn-${++turnOrdinal}`;
+		record("parent_turn_start", { turnOrdinal }, currentTurnId);
+	});
+	pi.on("turn_end", (event) => {
+		record(
+			"parent_turn_end",
+			{
+				turnOrdinal,
+				...usageNumbers(event.message.role === "assistant" ? event.message.usage : undefined),
+			},
+			currentTurnId,
+		);
+		currentTurnId = undefined;
+	});
+	pi.on("tool_execution_start", (event) => {
+		if (!SUBAGENT_TOOLS.has(event.toolName)) return;
+		const operationId = `tool-${++operationOrdinal}`;
+		operations.set(event.toolCallId, { id: operationId, startedAt: offset() });
+		record("tool_start", { operationId, tool: event.toolName }, currentTurnId);
+	});
+	pi.on("tool_execution_end", (event) => {
+		if (!SUBAGENT_TOOLS.has(event.toolName)) return;
+		const operation = operations.get(event.toolCallId);
+		operations.delete(event.toolCallId);
+		record(
+			"tool_end",
+			{
+				operationId: operation?.id ?? `tool-${++operationOrdinal}`,
+				tool: event.toolName,
+				isError: event.isError,
+				...(operation ? { durationMs: Math.max(0, offset() - operation.startedAt) } : {}),
+				...usageNumbers(event.result?.usage),
+			},
+			currentTurnId,
+		);
+	});
+
+	const controller: UsageRecordingController = {
+		startSession(input) {
+			return serializeTransition(async () => {
+				enabled = false;
+				await closeStore();
+				logicalSession = deps.createId();
+				branchEpoch += 1;
+				surfaceArm = input.surfaceArm;
+				sessionStartedAt = deps.monotonicNow();
+				eventSequence = 0;
+				recordedEvents = 0;
+				writeFailure = false;
+				warningActive = false;
+				onWarning = input.onWarning;
+				currentTurnId = undefined;
+				turnOrdinal = 0;
+				operationOrdinal = 0;
+				childOrdinal = 0;
+				runOrdinal = 0;
+				completionOrdinal = 0;
+				operations.clear();
+				children.clear();
+				runs.clear();
+				completions.clear();
+				agentStates.clear();
+				activeRuns.clear();
+				enabled = input.enabled;
+				if (!enabled) return;
+				record("study_exposure", { reason: input.reason });
+				record("lifecycle", { phase: "session_start", reason: input.reason });
+				enqueue(async (store) => store.prune(USAGE_RECORDING_RETENTION_DAYS));
+				await writeTail;
+			});
+		},
+		shutdown(reason) {
+			return serializeTransition(async () => {
+				if (enabled) record("lifecycle", { phase: "session_shutdown", reason });
+				enabled = false;
+				await flushWithin(SHUTDOWN_FLUSH_MS);
+				await closeStore();
+			});
+		},
+		setEnabled(value) {
+			return serializeTransition(async () => {
+				if (value === enabled) return;
+				if (value) {
+					enabled = true;
+					record("study_exposure", { reason: "enabled_in_settings" });
+					record("lifecycle", { phase: "recording_enabled" });
+					enqueue(async (store) => store.prune(USAGE_RECORDING_RETENTION_DAYS));
+					await writeTail;
+					return;
+				}
+				record("lifecycle", { phase: "recording_disabled" });
+				enabled = false;
+				await flushWithin(SHUTDOWN_FLUSH_MS);
+				await closeStore();
+			});
+		},
+		getStatus() {
+			return {
+				enabled,
+				initialized: storePromise !== undefined,
+				retentionDays: USAGE_RECORDING_RETENTION_DAYS,
+				path: pathValue,
+				recordedEvents,
+				writeFailure,
+			};
+		},
+		observeAgents(agents) {
+			if (!enabled) return;
+			for (const agent of agents) {
+				const childId = localChildId(agent.id);
+				if (agentStates.get(agent.id) !== agent.state) {
+					agentStates.set(agent.id, agent.state);
+					record("lifecycle", { phase: "child_state", childId, state: agent.state });
+				}
+				if (agent.currentRunId && activeRuns.get(agent.id) !== agent.currentRunId) {
+					activeRuns.set(agent.id, agent.currentRunId);
+					record("child_run_start", {
+						childId,
+						runId: localRunId(agent.currentRunId),
+						generation: agent.currentTurnGeneration ?? agent.turnGeneration ?? 0,
+					});
+				}
+			}
+		},
+		recordChildCompletion(completion) {
+			if (!enabled) return;
+			const childId = localChildId(completion.agent.id);
+			const runId = localRunId(completion.runId);
+			const timing = completion.agent.telemetry?.timing;
+			record("child_run_end", {
+				childId,
+				runId,
+				generation: completion.generation,
+				state: completion.agent.state,
+				...(timing?.startedAt !== undefined && timing.settledAt !== undefined
+					? { durationMs: Math.max(0, timing.settledAt - timing.startedAt) }
+					: {}),
+				...transportUsageNumbers(completion.agent.telemetry?.usage),
+			});
+			recordCompletion(completion, "persisted");
+		},
+		recordCompletionDeliveryAttempt(completion, input) {
+			recordCompletion(completion, "delivery_attempt", {
+				delivery: input.delivery,
+				triggerTurn: input.triggerTurn,
+				outcome: input.outcome,
+			});
+		},
+		recordCompletionVisible(completion) {
+			recordCompletion(completion, "visible");
+		},
+	};
+
+	return controller;
+
+	function record(
+		eventType: UsageEventType,
+		data: UsageEvent["data"],
+		turnId = currentTurnId,
+	): void {
+		if (!enabled) return;
+		const event: UsageEvent = {
+			schemaVersion: 1,
+			studyId: USAGE_RECORDING_STUDY_ID,
+			surfaceArm,
+			logicalSession,
+			runtimeInstance,
+			branchEpoch,
+			...(turnId ? { turnId } : {}),
+			eventSequence: ++eventSequence,
+			monotonicOffsetMs: offset(),
+			eventType,
+			data,
+		};
+		enqueue(async (store) => store.append(event), true);
+	}
+
+	function recordCompletion(
+		completion: AgentTurnCompletion,
+		transition: "persisted" | "delivery_attempt" | "visible",
+		extra: UsageEvent["data"] = {},
+	): void {
+		if (!enabled) return;
+		record("completion_transition", {
+			completionId: localCompletionId(completion.completionId),
+			childId: localChildId(completion.agent.id),
+			runId: localRunId(completion.runId),
+			generation: completion.generation,
+			transition,
+			...extra,
+		});
+	}
+
+	function enqueue(
+		operation: (store: UsageEventStorePort) => Promise<void>,
+		countsAsEvent = false,
+	): void {
+		const generation = writeGeneration;
+		const task = writeTail.then(async () => {
+			if (generation !== writeGeneration) return false;
+			await operation(await ensureStore());
+			return true;
+		});
+		writeTail = task.then(
+			(completed) => {
+				if (completed && countsAsEvent) recordedEvents += 1;
+				writeFailure = false;
+				warningActive = false;
+			},
+			() => {
+				writeFailure = true;
+				if (!warningActive) {
+					warningActive = true;
+					safeWarn("Local subagent usage recording could not save an event; recording will retry.");
+				}
+			},
+		);
+	}
+
+	async function ensureStore(): Promise<UsageEventStorePort> {
+		storePromise ??= deps
+			.loadStore()
+			.then(({ UsageEventStore }) => new UsageEventStore(pathValue))
+			.catch((error: unknown) => {
+				storePromise = undefined;
+				throw error;
+			});
+		return storePromise;
+	}
+
+	function serializeTransition(operation: () => Promise<void>): Promise<void> {
+		const result = transitionTail.then(operation, operation);
+		transitionTail = result.catch(() => undefined);
+		return result;
+	}
+
+	async function flushWithin(timeoutMs: number): Promise<void> {
+		let timer: NodeJS.Timeout | undefined;
+		try {
+			await Promise.race([
+				writeTail,
+				new Promise<void>((resolve) => {
+					timer = setTimeout(resolve, timeoutMs);
+				}),
+			]);
+		} finally {
+			if (timer) clearTimeout(timer);
+		}
+	}
+
+	async function closeStore(): Promise<void> {
+		writeGeneration += 1;
+		const active = storePromise;
+		storePromise = undefined;
+		if (active) await active.then((store) => store.close()).catch(() => undefined);
+		await writeTail;
+		writeTail = Promise.resolve();
+	}
+
+	function localChildId(value: string): string {
+		return localId(children, value, "child", () => ++childOrdinal);
+	}
+
+	function localRunId(value: string): string {
+		return localId(runs, value, "run", () => ++runOrdinal);
+	}
+
+	function localCompletionId(value: string): string {
+		return localId(completions, value, "completion", () => ++completionOrdinal);
+	}
+
+	function offset(): number {
+		return Math.max(0, Math.round(deps.monotonicNow() - sessionStartedAt));
+	}
+
+	function safeWarn(message: string): void {
+		try {
+			onWarning?.(message);
+		} catch {
+			// A replaced UI cannot receive storage feedback.
+		}
+	}
+}
+
+function localId(
+	values: Map<string, string>,
+	raw: string,
+	prefix: string,
+	next: () => number,
+): string {
+	const existing = values.get(raw);
+	if (existing) return existing;
+	const created = `${prefix}-${next()}`;
+	values.set(raw, created);
+	return created;
+}
+
+function usageNumbers(value: unknown): Record<string, number> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	const record = value as Record<string, unknown>;
+	return numericFields(record, ["input", "output", "cacheRead", "cacheWrite"]);
+}
+
+function transportUsageNumbers(value: TransportUsage | undefined): Record<string, number> {
+	if (!value) return {};
+	return numericFields(value as unknown as Record<string, unknown>, [
+		"input",
+		"output",
+		"cacheRead",
+		"cacheWrite",
+		"totalTokens",
+		"cost",
+		"turns",
+	]);
+}
+
+function numericFields(
+	record: Record<string, unknown>,
+	fields: readonly string[],
+): Record<string, number> {
+	return Object.fromEntries(
+		fields.flatMap((field) => {
+			const value = record[field];
+			return typeof value === "number" && Number.isFinite(value) && value >= 0
+				? [[field, value] as const]
+				: [];
+		}),
+	);
+}

--- a/packages/pi-subagents/test/completion-delivery.test.ts
+++ b/packages/pi-subagents/test/completion-delivery.test.ts
@@ -67,6 +67,53 @@ test("completion delivery acknowledges one deterministic timestamp when the pare
 	broker.close();
 });
 
+test("completion delivery reports accepted and failed send attempts", () => {
+	const attempts: Array<{
+		ids: string[];
+		delivery: string;
+		triggerTurn: boolean;
+		outcome: string;
+	}> = [];
+	let sends = 0;
+	const broker = new CompletionDeliveryBroker(
+		{
+			sendMessage() {
+				sends += 1;
+				if (sends === 1) throw new Error("primary failed");
+			},
+		} as never,
+		{ isIdle: () => true, hasPendingMessages: () => false },
+		"next-turn",
+		{
+			onDeliveryAttempt: (completions, input) => {
+				attempts.push({
+					ids: completions.map((value) => value.completionId),
+					delivery: input.delivery,
+					triggerTurn: input.triggerTurn,
+					outcome: input.outcome,
+				});
+			},
+		},
+	);
+	broker.enqueue(completion("sa_fallback"));
+	broker.flush();
+	assert.deepEqual(attempts, [
+		{
+			ids: ["completion:sa_fallback:1"],
+			delivery: "steer",
+			triggerTurn: false,
+			outcome: "failed",
+		},
+		{
+			ids: ["completion:sa_fallback:1"],
+			delivery: "nextTurn",
+			triggerTurn: false,
+			outcome: "accepted",
+		},
+	]);
+	broker.close();
+});
+
 test("an unobserved asynchronous injection remains pending for retry", () => {
 	const harness = deliveryHarness();
 	const acknowledged: string[] = [];

--- a/packages/pi-subagents/test/inspect.test.ts
+++ b/packages/pi-subagents/test/inspect.test.ts
@@ -424,6 +424,9 @@ test("subagent_inspect uses scoped model snapshots and structured diagnostics wi
 	assert.equal(statusDetails.configuredWorkflowSource, "default");
 	assert.equal(statusDetails.configuredCompletionDelivery, "next-turn");
 	assert.equal(statusDetails.configuredCompletionDeliverySource, "default");
+	assert.deepEqual(statusDetails.usageRecording, { enabled: false });
+	assert.equal(statusDetails.configuredUsageRecording, false);
+	assert.equal(statusDetails.configuredUsageRecordingSource, "default");
 	assert.equal(statusDetails.maxParallelTasks, 8);
 	assert.equal(statusDetails.configuredMaxParallelTasks, 8);
 	assert.equal(statusDetails.configuredMaxParallelTasksSource, "default");

--- a/packages/pi-subagents/test/settings.test.ts
+++ b/packages/pi-subagents/test/settings.test.ts
@@ -11,6 +11,7 @@ import {
 	inspectStatefulLimitSettings,
 	inspectStatefulTransportSettings,
 	inspectSubagentSettings,
+	inspectUsageRecordingSettings,
 	normalizeSubagentSettings,
 	readSubagentSettings,
 	updateBlockingMaxParallelTasksSetting,
@@ -18,6 +19,7 @@ import {
 	updateCwdPolicySetting,
 	updateStatefulLimitSetting,
 	updateStatefulTransportSetting,
+	updateUsageRecordingSetting,
 } from "../src/settings.js";
 import { resolveStatefulLimits } from "../src/stateful-limits.js";
 
@@ -58,6 +60,39 @@ test("stateful RPC and automatic transports are opt-in and preserve unknown sett
 			value: "rpc",
 			source: "user settings",
 		});
+	});
+});
+
+test("usage recording is strict, opt-in, and preserves unknown settings", () => {
+	withAgentDir(() => {
+		assert.deepEqual(normalizeSubagentSettings({ usageRecording: { enabled: true } }), {
+			usageRecording: { enabled: true },
+		});
+		assert.equal(normalizeSubagentSettings({ usageRecording: { enabled: "yes" } }), undefined);
+
+		const missing = inspectUsageRecordingSettings();
+		assert.equal(missing.enabled, false);
+		assert.equal(missing.source, "default");
+		assert.throws(() => readFileSync(missing.path, "utf8"), /ENOENT/);
+
+		writeFileSync(
+			missing.path,
+			JSON.stringify({ future: true, usageRecording: { futureUsage: "keep" } }),
+		);
+		updateUsageRecordingSetting(true);
+		assert.deepEqual(JSON.parse(readFileSync(missing.path, "utf8")), {
+			future: true,
+			usageRecording: { futureUsage: "keep", enabled: true },
+		});
+		assert.deepEqual(inspectUsageRecordingSettings(), {
+			path: missing.path,
+			enabled: true,
+			source: "user settings",
+		});
+
+		writeFileSync(missing.path, "{ malformed");
+		assert.throws(() => updateUsageRecordingSetting(false), /malformed/i);
+		assert.equal(readFileSync(missing.path, "utf8"), "{ malformed");
 	});
 });
 

--- a/packages/pi-subagents/test/subagents-settings-ui.test.ts
+++ b/packages/pi-subagents/test/subagents-settings-ui.test.ts
@@ -870,6 +870,54 @@ test("subagent settings UI preserves unknown JSON and applies completion deliver
 	}
 });
 
+test("subagent settings UI explicitly enables local-only usage recording", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-usage-settings-ui-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	try {
+		const settingsPath = path.join(directory, "pi-subagents.json");
+		writeFileSync(settingsPath, JSON.stringify({ future: true }));
+		const mock = createMockPi();
+		subagents(mock.pi);
+		const command = mock.commands.get("subagents");
+		assert.ok(command);
+		let rendered = "";
+		let customCalls = 0;
+		const context = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const harness = createCustomSelectorHarness(factory, 90);
+				rendered = stripVTControlCharacters(harness.render().join("\n"));
+				if (customCalls++ === 0) {
+					for (let index = 0; index < 4; index++) harness.handleInput("tui.select.down");
+					harness.handleInput("tui.select.confirm");
+					await harness.waitForPending();
+				} else {
+					harness.handleInput("\u0003");
+				}
+				return harness.result;
+			},
+		});
+		await command.handler("settings", context.ctx);
+		assert.match(rendered, /Local usage recording/);
+		assert.match(rendered, /content-free.*30 days/i);
+		assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+			future: true,
+			usageRecording: { enabled: true },
+		});
+		assert.match(context.notifications.at(-1)?.message ?? "", /local.*recording enabled/i);
+		await command.handler("status", context.ctx);
+		assert.match(context.notifications.at(-1)?.message ?? "", /Local usage recording: enabled/i);
+		assert.match(context.notifications.at(-1)?.message ?? "", /Usage retention: 30 days/i);
+		assert.ok(existsSync(path.join(directory, "pi-subagents-usage")));
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
 test("subagent settings UI exposes and immediately applies both cwd policies", async () => {
 	const directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-cwd-settings-ui-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;

--- a/packages/pi-subagents/test/usage-recording-store.test.ts
+++ b/packages/pi-subagents/test/usage-recording-store.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import {
+	chmod,
+	lstat,
+	mkdtemp,
+	readdir,
+	readFile,
+	symlink,
+	utimes,
+	writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "vitest";
+import { encodeEvent, UsageEventStore } from "../src/usage-recording-store.js";
+
+const FIRST_ID = "00000000-0000-4000-8000-000000000001";
+const SECOND_ID = "00000000-0000-4000-8000-000000000002";
+
+test("usage event stores isolate writers and publish private newline frames", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-subagents-usage-store-"));
+	const root = path.join(directory, "usage");
+	const first = new UsageEventStore(root, { createId: () => FIRST_ID });
+	const second = new UsageEventStore(root, { createId: () => SECOND_ID });
+	try {
+		await Promise.all([
+			first.append({ schemaVersion: 1, eventType: "tool_start", data: { tool: "subagent" } }),
+			second.append({ schemaVersion: 1, eventType: "tool_end", data: { isError: false } }),
+		]);
+		await Promise.all([first.close(), second.close()]);
+		const entries = (await readdir(root)).sort();
+		assert.deepEqual(entries, [`runtime-${FIRST_ID}.jsonl`, `runtime-${SECOND_ID}.jsonl`]);
+		for (const entry of entries) {
+			const filePath = path.join(root, entry);
+			const contents = await readFile(filePath, "utf8");
+			assert.ok(contents.endsWith("\n"));
+			assert.doesNotThrow(() => JSON.parse(contents.trim()));
+			if (process.platform !== "win32") {
+				assert.equal((await lstat(filePath)).mode & 0o777, 0o600);
+			}
+		}
+		if (process.platform !== "win32") assert.equal((await lstat(root)).mode & 0o777, 0o700);
+	} finally {
+		await first.close().catch(() => undefined);
+		await second.close().catch(() => undefined);
+		await import("node:fs/promises").then(({ rm }) =>
+			rm(directory, { recursive: true, force: true }),
+		);
+	}
+});
+
+test("usage retention prunes only old validated writer files", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-subagents-usage-prune-"));
+	const root = path.join(directory, "usage");
+	const now = Date.UTC(2026, 7, 24);
+	const store = new UsageEventStore(root, { createId: () => FIRST_ID, now: () => now });
+	try {
+		await store.append({ schemaVersion: 1, eventType: "study_exposure", data: {} });
+		const oldWriter = path.join(root, `runtime-${SECOND_ID}.jsonl`);
+		const unrelated = path.join(root, "keep.txt");
+		await writeFile(oldWriter, "{}\n", { mode: 0o600 });
+		await writeFile(unrelated, "keep", { mode: 0o600 });
+		const old = new Date(now - 31 * 24 * 60 * 60 * 1000);
+		await utimes(oldWriter, old, old);
+		await utimes(unrelated, old, old);
+		await store.prune(30);
+		assert.deepEqual((await readdir(root)).sort(), ["keep.txt", `runtime-${FIRST_ID}.jsonl`]);
+	} finally {
+		await store.close().catch(() => undefined);
+		await import("node:fs/promises").then(({ rm }) =>
+			rm(directory, { recursive: true, force: true }),
+		);
+	}
+});
+
+test("usage storage rejects linked roots and oversized frames", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-subagents-usage-link-"));
+	const outside = await mkdtemp(path.join(os.tmpdir(), "pi-subagents-usage-outside-"));
+	const linked = path.join(directory, "usage");
+	try {
+		await chmod(outside, 0o700);
+		await symlink(outside, linked, "dir");
+		const store = new UsageEventStore(linked, { createId: () => FIRST_ID });
+		await assert.rejects(() => store.append({ eventType: "tool_start" }), /regular directory/i);
+		await store.close();
+		assert.throws(() => encodeEvent({ data: "x".repeat(9 * 1024) }), /storage bound/i);
+	} finally {
+		const { rm } = await import("node:fs/promises");
+		await rm(directory, { recursive: true, force: true });
+		await rm(outside, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-subagents/test/usage-recording.test.ts
+++ b/packages/pi-subagents/test/usage-recording.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { lstat, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "vitest";
+import { createMockPi } from "../../../test/support.js";
+import type { ManagedAgent } from "../src/registry-types.js";
+import { registerUsageRecording } from "../src/usage-recording.js";
+import type { UsageEventStorePort } from "../src/usage-recording-store.js";
+
+class MemoryUsageStore implements UsageEventStorePort {
+	static events: unknown[] = [];
+	static created = 0;
+	static closed = 0;
+	readonly path: string;
+
+	constructor(path: string) {
+		this.path = path;
+		MemoryUsageStore.created += 1;
+	}
+
+	async append(event: unknown): Promise<void> {
+		MemoryUsageStore.events.push(structuredClone(event));
+	}
+
+	async prune(): Promise<void> {}
+
+	async close(): Promise<void> {
+		MemoryUsageStore.closed += 1;
+	}
+}
+
+async function emit(
+	mock: ReturnType<typeof createMockPi>,
+	name: string,
+	...args: unknown[]
+): Promise<void> {
+	for (const handler of mock.events.get(name) ?? []) await handler(...args);
+}
+
+function managedAgent(): ManagedAgent {
+	return {
+		id: "raw-agent-secret",
+		agent: "private-agent-name",
+		rootId: "raw-agent-secret",
+		depth: 0,
+		children: [],
+		state: "running",
+		createdAt: 100,
+		updatedAt: 110,
+		cwd: "/private/project/path",
+		currentTask: "private task contents",
+		currentRunId: "raw-run-secret",
+		currentTurnGeneration: 3,
+		turnGeneration: 3,
+		history: [],
+		mailbox: [],
+		telemetry: {
+			phase: "running",
+			updatedAt: 110,
+			timing: { startedAt: 100, settledAt: 200 },
+			usage: {
+				input: 10,
+				output: 20,
+				cacheRead: 3,
+				cacheWrite: 4,
+				totalTokens: 37,
+				cost: 0.1,
+				turns: 2,
+			},
+		},
+	};
+}
+
+test("local usage recording enables and shuts down without background waits", async () => {
+	const directory = await mkdtemp(path.join(os.tmpdir(), "pi-subagents-usage-runtime-"));
+	const mock = createMockPi();
+	const recorder = registerUsageRecording(mock.pi, { getAgentDir: () => directory });
+	try {
+		await recorder.startSession({ enabled: false, surfaceArm: "all", reason: "startup" });
+		await assert.rejects(() => lstat(path.join(directory, "pi-subagents-usage")), /ENOENT/);
+		await recorder.setEnabled(true);
+		assert.equal(recorder.getStatus().enabled, true);
+		assert.equal(recorder.getStatus().recordedEvents, 2);
+		await recorder.shutdown("quit");
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("usage recording separates replacement sessions and closes each writer", async () => {
+	MemoryUsageStore.events = [];
+	MemoryUsageStore.created = 0;
+	MemoryUsageStore.closed = 0;
+	const mock = createMockPi();
+	let id = 0;
+	const recorder = registerUsageRecording(mock.pi, {
+		createId: () => `replacement-${++id}`,
+		monotonicNow: () => id,
+		getAgentDir: () => "/agent",
+		loadStore: async () => ({ UsageEventStore: MemoryUsageStore }),
+	});
+	await recorder.startSession({ enabled: true, surfaceArm: "all", reason: "startup" });
+	await recorder.startSession({ enabled: true, surfaceArm: "async-only", reason: "fork" });
+	await recorder.shutdown("quit");
+
+	assert.equal(MemoryUsageStore.created, 2);
+	assert.equal(MemoryUsageStore.closed, 2);
+	const exposures = MemoryUsageStore.events.filter(
+		(event) => (event as { eventType?: string }).eventType === "study_exposure",
+	) as Array<{
+		logicalSession: string;
+		runtimeInstance: string;
+		branchEpoch: number;
+		surfaceArm: string;
+	}>;
+	assert.equal(exposures.length, 2);
+	assert.notEqual(exposures[0]?.logicalSession, exposures[1]?.logicalSession);
+	assert.equal(exposures[0]?.runtimeInstance, exposures[1]?.runtimeInstance);
+	assert.deepEqual(
+		exposures.map((event) => [event.branchEpoch, event.surfaceArm]),
+		[
+			[1, "all"],
+			[2, "async-only"],
+		],
+	);
+});
+
+test("usage recording serializes enable with concurrent shutdown", async () => {
+	let releaseWrite: (() => void) | undefined;
+	let startedWrite: (() => void) | undefined;
+	const started = new Promise<void>((resolve) => {
+		startedWrite = resolve;
+	});
+	const release = new Promise<void>((resolve) => {
+		releaseWrite = resolve;
+	});
+	class DelayedStore extends MemoryUsageStore {
+		override async append(event: unknown): Promise<void> {
+			startedWrite?.();
+			await release;
+			await super.append(event);
+		}
+	}
+	MemoryUsageStore.events = [];
+	MemoryUsageStore.closed = 0;
+	const mock = createMockPi();
+	const recorder = registerUsageRecording(mock.pi, {
+		createId: () => "local-runtime",
+		monotonicNow: () => 1,
+		getAgentDir: () => "/agent",
+		loadStore: async () => ({ UsageEventStore: DelayedStore }),
+	});
+	const enabling = recorder.setEnabled(true);
+	await started;
+	const shuttingDown = recorder.shutdown("quit");
+	releaseWrite?.();
+	await Promise.all([enabling, shuttingDown]);
+	assert.equal(recorder.getStatus().enabled, false);
+	assert.equal(MemoryUsageStore.closed, 1);
+});
+
+test("usage recording stays dormant until opt-in and stores only bounded metadata", async () => {
+	MemoryUsageStore.events = [];
+	MemoryUsageStore.created = 0;
+	MemoryUsageStore.closed = 0;
+	const mock = createMockPi();
+	let monotonic = 0;
+	let id = 0;
+	const recorder = registerUsageRecording(mock.pi, {
+		createId: () => `local-${++id}`,
+		monotonicNow: () => ++monotonic,
+		getAgentDir: () => "/agent",
+		loadStore: async () => ({ UsageEventStore: MemoryUsageStore }),
+	});
+
+	await recorder.startSession({
+		enabled: false,
+		surfaceArm: "all",
+		reason: "startup",
+	});
+	await emit(mock, "tool_execution_start", {
+		toolCallId: "provider-tool-secret",
+		toolName: "subagent",
+		args: { task: "private prompt", cwd: "/private/path" },
+	});
+	assert.equal(MemoryUsageStore.created, 0);
+	assert.deepEqual(MemoryUsageStore.events, []);
+
+	await recorder.setEnabled(true);
+	await emit(mock, "agent_start", {});
+	await emit(mock, "turn_start", { turnIndex: 0, timestamp: 999 });
+	await emit(mock, "tool_execution_start", {
+		toolCallId: "provider-tool-secret",
+		toolName: "subagent_spawn",
+		args: { task: "private prompt", cwd: "/private/path" },
+	});
+	await emit(mock, "tool_execution_end", {
+		toolCallId: "provider-tool-secret",
+		toolName: "subagent_spawn",
+		isError: false,
+		result: { content: [{ type: "text", text: "private result" }] },
+	});
+	recorder.observeAgents([managedAgent()]);
+	const agent = { ...managedAgent(), state: "completed" as const };
+	const completion = {
+		completionId: "raw-completion-secret",
+		runId: "raw-run-secret",
+		generation: 3,
+		task: "private task contents",
+		output: "private child output",
+		createdAt: 200,
+		agent,
+	};
+	recorder.recordChildCompletion(completion);
+	recorder.recordCompletionDeliveryAttempt(completion, {
+		delivery: "steer",
+		triggerTurn: true,
+		outcome: "accepted",
+	});
+	recorder.recordCompletionVisible(completion);
+	await emit(mock, "turn_end", {
+		message: {
+			role: "assistant",
+			usage: { input: 11, output: 12, cacheRead: 1, cacheWrite: 2 },
+		},
+	});
+	await emit(mock, "agent_settled", {});
+	await recorder.shutdown("quit");
+
+	assert.equal(MemoryUsageStore.created, 1);
+	assert.equal(MemoryUsageStore.closed, 1);
+	const serialized = JSON.stringify(MemoryUsageStore.events);
+	for (const prohibited of [
+		"private prompt",
+		"private result",
+		"private task contents",
+		"private child output",
+		"/private/project/path",
+		"/private/path",
+		"provider-tool-secret",
+		"raw-agent-secret",
+		"raw-run-secret",
+		"raw-completion-secret",
+		"private-agent-name",
+	]) {
+		assert.doesNotMatch(serialized, new RegExp(prohibited.replaceAll("/", "\\/")));
+	}
+	assert.match(serialized, /subagent_spawn/);
+	assert.match(serialized, /child_run_start/);
+	assert.match(serialized, /child_run_end/);
+	assert.match(serialized, /delivery_attempt/);
+	assert.match(serialized, /visible/);
+	assert.match(serialized, /"totalTokens":37/);
+	assert.ok(
+		MemoryUsageStore.events.every((event) => {
+			const record = event as Record<string, unknown>;
+			return record.schemaVersion === 1 && record.studyId === "pi-subagents-surface-v1";
+		}),
+	);
+});


### PR DESCRIPTION
## Summary

- add opt-in, local-only, content-free usage recording to `/subagents settings`
- record bounded lifecycle, timing, usage, child-run, and completion-delivery events in private per-runtime JSONL files
- expose recording state and health through status/inspection, with 30-day retention and lifecycle-safe cleanup
- document privacy boundaries and add a minor Changeset

## Checks

- `npm run check`
- `npm test` (369 files, 3275 tests)
- `npx vitest run packages/pi-subagents/test/usage-recording-store.test.ts packages/pi-subagents/test/usage-recording.test.ts packages/pi-subagents/test/completion-delivery.test.ts packages/pi-subagents/test/inspect.test.ts packages/pi-subagents/test/settings.test.ts packages/pi-subagents/test/subagents-settings-ui.test.ts` (55 tests, post-rebase)
- `just pack subagents`
- `PI_CODING_AGENT_DIR="$tmp" pi --no-extensions -e ./packages/pi-subagents --list-models`
