### PR TITLE
feat(todo): rename tool to update_todo_list

### DIFF
--- a/.changeset/bright-todos-progress.md
+++ b/.changeset/bright-todos-progress.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-todo": minor
 ---
 
-Add the Todo Widget extension with branch-aware task lists, proactive progress reminders, and an above-editor display.
+Add the Todo Widget extension with branch-aware task lists managed by `update_todo_list`, proactive progress reminders, and an above-editor display.

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -10,7 +10,7 @@ The list follows the active session branch and disappears cleanly when no tracke
 
 ## ✨ Features
 
-- Registers one `todo_widget` tool with clear guidance for meaningful multi-step work.
+- Registers one `update_todo_list` tool with clear guidance for meaningful multi-step work.
 - Keeps task text concise and action-oriented, with at most one task in progress.
 - Shows a compact themed task list and completion count above the editor in TUI mode.
 - Restores the latest valid list when Pi starts a session or navigates between branches.
@@ -44,7 +44,7 @@ Pi extensions run with the user's permissions, so install only trusted code.
 
 Ask Pi to perform work with multiple meaningful steps.
 
-The agent can create a concise list through `todo_widget`, mark one task `in_progress`, and revise the list when the plan changes.
+The agent can create a concise list through `update_todo_list`, mark one task `in_progress`, and revise the list when the plan changes.
 
 While a list is active, the extension reminds the agent to update it immediately after task status changes and to reconcile it before progress reports or the final response.
 
@@ -52,7 +52,7 @@ The agent sends the complete current list with every update and sends an empty l
 
 ## 🛠️ Tools
 
-### `todo_widget`
+### `update_todo_list`
 
 Replace the complete current todo list for the active session.
 
@@ -70,6 +70,8 @@ Accepted statuses are `pending`, `in_progress`, and `completed`.
 A list may contain up to 50 items, each item may contain up to 300 characters, and at most one item may be `in_progress`.
 
 The tool result stores a versioned snapshot in the session branch so branch navigation can reconstruct the latest valid list.
+
+Branch reconstruction also accepts valid results stored under the previous `todo_widget` name, but the extension only registers `update_todo_list` for new calls.
 
 Before each model call, the extension appends one hidden, non-persistent context reminder containing the current list as JSON data.
 
@@ -94,7 +96,7 @@ Terminal escape sequences, control characters, and bidirectional display control
 - The visual widget uses a fixed position above the editor and is available only in TUI mode.
 - The extension provides a model tool rather than a slash command or manual task editor.
 - The extension reminds the model to update statuses but cannot infer task completion or force a tool call.
-- Branch reconstruction uses only valid versioned `todo_widget` tool results on the active branch.
+- Branch reconstruction uses only valid versioned `update_todo_list` or legacy `todo_widget` tool results on the active branch.
 - Long task text is shown on one bounded terminal line and may be truncated to the available width.
 
 ## 🗂️ Package layout

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -9,15 +9,16 @@ import type {
 import { stripTerminalSequences, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
-export const TOOL_NAME = "todo_widget";
+export const TOOL_NAME = "update_todo_list";
 export const WIDGET_KEY = "todo";
-export const TODO_CONTEXT_MESSAGE_TYPE = "todo-widget-status";
+export const TODO_CONTEXT_MESSAGE_TYPE = "todo-list-status";
 export const TODO_CONTEXT_VERSION = 1;
 export const TODO_DETAILS_VERSION = 1;
 export const MAX_TODO_ITEMS = 50;
 export const MAX_TODO_TEXT_LENGTH = 300;
 
 const WIDGET_OPTIONS = { placement: "aboveEditor" } as const;
+const LEGACY_TOOL_NAME = "todo_widget";
 const TODO_STATUSES = ["pending", "in_progress", "completed"] as const;
 const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/gu;
 
@@ -80,13 +81,13 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 		name: TOOL_NAME,
 		label: "Todo List",
 		description:
-			"Replace the current session todo list. Send the complete list on every call, keep at most one item in_progress, and send an empty list to clear it.",
-		promptSnippet: "Track progress on multi-step work with a session todo list",
+			"Replace the current session todo list with the complete supplied list. Call update_todo_list whenever actual task state changes; keep at most one item in_progress and send an empty list to clear it.",
+		promptSnippet: "Maintain the complete session todo list as multi-step work progresses",
 		promptGuidelines: [
-			"Use todo_widget when work has multiple meaningful steps; skip it for simple, single-step tasks.",
-			"Keep todo_widget synchronized with actual work. Mark one task in_progress before starting it, update the list immediately after its status changes, and revise the list when the plan changes.",
-			"Before a progress report or final response, reconcile todo_widget with actual work; do not report completion while finished work remains pending or in_progress.",
-			"Send the complete current list on every todo_widget call, keep at most one task in_progress, and send an empty list when no tracked work remains.",
+			"Use update_todo_list to track work with multiple meaningful steps; skip it for simple, single-step tasks.",
+			"Use update_todo_list to keep the list aligned with actual work: mark a task in_progress before starting it, mark it completed as soon as it finishes, and revise the list before continuing when the plan changes.",
+			"Before a progress report or final response, call update_todo_list to reconcile every item with actual work; do not report completion while the list is stale.",
+			"On every update_todo_list call, send the complete current list, keep at most one task in_progress, and send an empty list when no tracked work remains.",
 		],
 		parameters: TodoParameters,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
@@ -220,8 +221,8 @@ export function sanitizeTodoText(value: string): string {
 function todoContextContent(items: readonly TodoItem[]): string {
 	return `[PI TODO STATUS v${TODO_CONTEXT_VERSION}]
 An active todo list follows as JSON data.
-Keep it synchronized with actual work: call todo_widget immediately after a task status changes and before beginning a different task.
-Before a progress report or final response, reconcile every item; do not report completion while the list is stale.
+Keep it aligned with actual work: call update_todo_list before starting a task, as soon as a task finishes, and whenever the plan changes.
+Before a progress report or final response, call update_todo_list to reconcile every item; do not report completion while the list is stale.
 Active todo list:
 ${JSON.stringify(items)}`;
 }
@@ -250,7 +251,12 @@ function reconstructItems(entries: readonly SessionEntry[]): TodoItem[] {
 	for (const entry of entries) {
 		if (entry.type !== "message") continue;
 		const message = entry.message;
-		if (message.role !== "toolResult" || message.toolName !== TOOL_NAME) continue;
+		if (
+			message.role !== "toolResult" ||
+			(message.toolName !== TOOL_NAME && message.toolName !== LEGACY_TOOL_NAME)
+		) {
+			continue;
+		}
 		if (!isTodoDetails(message.details)) continue;
 		restored = cloneItems(message.details.items);
 	}

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -25,6 +25,7 @@ type Handler = (event: never, ctx: ExtensionContext) => unknown;
 type WidgetFactory = (_tui: never, theme: Theme) => Component;
 
 interface RegisteredTool {
+	name: string;
 	label: string;
 	description: string;
 	promptSnippet: string;
@@ -118,7 +119,7 @@ function identityTheme() {
 	return { calls, theme };
 }
 
-function toolResultEntry(details: TodoDetails): SessionEntry {
+function toolResultEntry(details: TodoDetails, toolName = TOOL_NAME): SessionEntry {
 	return {
 		type: "message",
 		id: "tool-result",
@@ -127,7 +128,7 @@ function toolResultEntry(details: TodoDetails): SessionEntry {
 		message: {
 			role: "toolResult",
 			toolCallId: "todo-call",
-			toolName: TOOL_NAME,
+			toolName,
 			content: [{ type: "text", text: "updated" }],
 			details,
 			isError: false,
@@ -147,14 +148,15 @@ async function setTodos(
 test("registers concise guidance for using and maintaining the todo list", () => {
 	const { tool } = createHarness();
 
+	assert.equal(tool.name, "update_todo_list");
 	assert.equal(tool.label, "Todo List");
-	assert.match(tool.description, /complete list on every call/u);
-	assert.match(tool.promptSnippet, /multi-step work/u);
+	assert.match(tool.description, /whenever actual task state changes/u);
+	assert.match(tool.promptSnippet, /multi-step work progresses/u);
 	assert.deepEqual(tool.promptGuidelines, [
-		"Use todo_widget when work has multiple meaningful steps; skip it for simple, single-step tasks.",
-		"Keep todo_widget synchronized with actual work. Mark one task in_progress before starting it, update the list immediately after its status changes, and revise the list when the plan changes.",
-		"Before a progress report or final response, reconcile todo_widget with actual work; do not report completion while finished work remains pending or in_progress.",
-		"Send the complete current list on every todo_widget call, keep at most one task in_progress, and send an empty list when no tracked work remains.",
+		"Use update_todo_list to track work with multiple meaningful steps; skip it for simple, single-step tasks.",
+		"Use update_todo_list to keep the list aligned with actual work: mark a task in_progress before starting it, mark it completed as soon as it finishes, and revise the list before continuing when the plan changes.",
+		"Before a progress report or final response, call update_todo_list to reconcile every item with actual work; do not report completion while the list is stale.",
+		"On every update_todo_list call, send the complete current list, keep at most one task in_progress, and send an empty list when no tracked work remains.",
 	]);
 });
 
@@ -183,7 +185,7 @@ test("keeps one current todo reminder at the end of model context", async () => 
 	assert.equal(reminder.customType, TODO_CONTEXT_MESSAGE_TYPE);
 	assert.equal(reminder.display, false);
 	assert.deepEqual(reminder.details, { version: TODO_CONTEXT_VERSION });
-	assert.match(reminder.content as string, /call todo_widget immediately/u);
+	assert.match(reminder.content as string, /call update_todo_list before starting/u);
 	assert.match(reminder.content as string, /Before a progress report or final response/u);
 	assert.ok(
 		(reminder.content as string).includes(
@@ -318,13 +320,13 @@ test("tool replaces the complete list, updates the widget, clears it, and reject
 	});
 });
 
-test("restores branch-local state on startup and tree navigation", async () => {
+test("restores current and legacy branch-local state on startup and tree navigation", async () => {
 	const initial: TodoDetails = {
 		version: TODO_DETAILS_VERSION,
 		items: [{ text: "restored", status: "in_progress" }],
 	};
 	const harness = createHarness();
-	const current = createContext({ branch: [toolResultEntry(initial)] });
+	const current = createContext({ branch: [toolResultEntry(initial, "todo_widget")] });
 	await harness.emit("session_start", current.ctx);
 
 	const { theme } = identityTheme();


### PR DESCRIPTION
## Summary

- rename the public todo tool from `todo_widget` to `update_todo_list`
- revise the description, prompt snippet, guidelines, and active-list reminder around explicit task transitions
- preserve branch reconstruction for valid tool results stored under the legacy `todo_widget` name
- update documentation, focused tests, and the existing release note

## Testing

- `npm run check`
- `npm test` — 367 files and 3266 tests passed
- `npx vitest run packages/pi-todo/test/todo-widget.test.ts` — 7 tests passed

## Notes

- `npm run changeset:status` still reports pre-existing `pi-tui-kit` dependency-floor warnings; the private `pi-todo` package is not included in its bump output.
- A live-provider smoke was not run because the extension entrypoint and loading metadata are unchanged; deterministic registration, context, reconstruction, and lifecycle tests cover this change.