### PR TITLE
test(tool): allow room for framed catalog title

### DIFF
--- a/packages/pi-tool/test/tool.test.ts
+++ b/packages/pi-tool/test/tool.test.ts
@@ -600,7 +600,7 @@ test("an empty catalog remains bounded and can close", async () => {
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);
 	const command = mock.commands.get("tool");
 	assert.ok(command);
-	const tui = createTuiHarness({ width: 20, rows: 8 });
+	const tui = createTuiHarness({ width: 20, rows: 10 });
 	const base = createMockContext({
 		hasUI: true,
 		mode: "tui",


### PR DESCRIPTION
## Summary

- Increase the empty tool catalog test harness height so the title remains visible with horizontal framing.
- Keep the bounded empty-state and cancellation assertions intact.
- Fix the release PR CI failure in https://github.com/narumiruna/pi-extensions/actions/runs/32724356538/job/97422235255.

## Verification

- `npm run check`
- `npm test` (372 files, 3,298 tests)
- Targeted `pi-tool` test against the release dependency layout with `@narumitw/pi-tui-kit` 0.58.0