### PR TITLE
feat: add bash timeout extension

### DIFF
--- a/.pi/extensions/bash-timeout/index.test.ts
+++ b/.pi/extensions/bash-timeout/index.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import bashTimeout, { MAX_BASH_TIMEOUT_SECONDS } from "./index.js";
+
+type ToolCallEvent = {
+	toolCallId: string;
+	toolName: string;
+	input: Record<string, unknown>;
+};
+
+type ToolCallHandler = (event: ToolCallEvent) => unknown;
+
+function createHarness(): ToolCallHandler {
+	let toolCallHandler: ToolCallHandler | undefined;
+	const pi = {
+		on(event: string, handler: ToolCallHandler) {
+			if (event === "tool_call") toolCallHandler = handler;
+		},
+	} as unknown as ExtensionAPI;
+	bashTimeout(pi);
+	assert.ok(toolCallHandler);
+	return toolCallHandler;
+}
+
+test("adds the maximum timeout when bash omits one", () => {
+	const handleToolCall = createHarness();
+	const event: ToolCallEvent = {
+		toolCallId: "bash-1",
+		toolName: "bash",
+		input: { command: "sleep 999" },
+	};
+
+	handleToolCall(event);
+
+	assert.equal(event.input.timeout, MAX_BASH_TIMEOUT_SECONDS);
+});
+
+test("caps longer bash timeouts and preserves shorter ones", () => {
+	const handleToolCall = createHarness();
+	const longer = {
+		toolCallId: "bash-1",
+		toolName: "bash",
+		input: { command: "sleep 999", timeout: 600 },
+	};
+	const shorter = {
+		toolCallId: "bash-2",
+		toolName: "bash",
+		input: { command: "sleep 1", timeout: 10 },
+	};
+
+	handleToolCall(longer);
+	handleToolCall(shorter);
+
+	assert.equal(longer.input.timeout, MAX_BASH_TIMEOUT_SECONDS);
+	assert.equal(shorter.input.timeout, 10);
+});
+
+test("ignores non-bash tools", () => {
+	const handleToolCall = createHarness();
+	const event = { toolCallId: "read-1", toolName: "read", input: { path: "README.md" } };
+
+	handleToolCall(event);
+
+	assert.deepEqual(event.input, { path: "README.md" });
+});

--- a/.pi/extensions/bash-timeout/index.ts
+++ b/.pi/extensions/bash-timeout/index.ts
@@ -1,0 +1,14 @@
+import { type ExtensionAPI, isToolCallEventType } from "@earendil-works/pi-coding-agent";
+
+export const MAX_BASH_TIMEOUT_SECONDS = 300;
+
+export default function bashTimeout(pi: ExtensionAPI): void {
+	pi.on("tool_call", (event) => {
+		if (!isToolCallEventType("bash", event)) return;
+
+		event.input.timeout = Math.min(
+			event.input.timeout ?? MAX_BASH_TIMEOUT_SECONDS,
+			MAX_BASH_TIMEOUT_SECONDS,
+		);
+	});
+}

--- a/.pi/extensions/bash-timeout/vitest.config.ts
+++ b/.pi/extensions/bash-timeout/vitest.config.ts
@@ -1,0 +1,12 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	root: dirname(fileURLToPath(import.meta.url)),
+	test: {
+		environment: "node",
+		include: ["index.test.ts"],
+		testTimeout: 5_000,
+	},
+});


### PR DESCRIPTION
## Summary

- add a project-local extension that gives every model-issued `bash` call a 300-second timeout
- preserve explicitly requested shorter timeouts while capping longer values
- add focused tests for defaulting, capping, and non-bash calls

## Verification

- `npx vitest --config .pi/extensions/bash-timeout/vitest.config.ts run`
- focused TypeScript check with `tsc --ignoreConfig`
- `npm run check`
- `npm test` (371 files, 3292 tests)
- isolated extension load and trusted-project auto-discovery smokes