### PR TITLE
feat(todo): wrap tasks on narrow terminals

### DIFF
--- a/.changeset/bright-todos-progress.md
+++ b/.changeset/bright-todos-progress.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-todo": minor
 ---
 
-Add the Todo Widget extension with branch-aware task lists managed by `update_todo_list`, proactive progress reminders, and an above-editor display.
+Add the Todo Widget extension with branch-aware task lists managed by `update_todo_list`, proactive progress reminders, and an above-editor display that wraps long task text to the available width.

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -80,6 +80,7 @@ The reminder is kept at the end of model context, survives compaction through br
 In TUI mode, updates appear immediately in a widget above the editor.
 
 The widget header shows completed and total task counts, followed by themed completed, in-progress, and pending rows.
+Long task text wraps to the available terminal width with continuation lines aligned beneath the text.
 
 In RPC, print, and JSON modes, the tool still returns structured details but does not create a visual widget.
 
@@ -97,7 +98,7 @@ Terminal escape sequences, control characters, and bidirectional display control
 - The extension provides a model tool rather than a slash command or manual task editor.
 - The extension reminds the model to update statuses but cannot infer task completion or force a tool call.
 - Branch reconstruction uses only valid versioned `update_todo_list` or legacy `todo_widget` tool results on the active branch.
-- Long task text is shown on one bounded terminal line and may be truncated to the available width.
+- The widget has no independent scrolling or height-based collapsing, so Pi may clip later rows when terminal height is constrained.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -6,7 +6,7 @@ import type {
 	SessionEntry,
 	Theme,
 } from "@earendil-works/pi-coding-agent";
-import { stripTerminalSequences, truncateToWidth } from "@earendil-works/pi-tui";
+import { stripTerminalSequences, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
 export const TOOL_NAME = "update_todo_list";
@@ -160,22 +160,36 @@ export function renderTodoWidget(
 	const divider = theme.fg("borderMuted", "─".repeat(Math.max(0, width)));
 	const lines = [divider, theme.fg("muted", `Todo · ${completed}/${items.length} complete`)];
 
+	const renderWidth = Math.max(0, width);
 	for (const item of items) {
 		const text = sanitizeTodoText(item.text);
+		let prefix: string;
+		let styledText: string;
 		switch (item.status) {
 			case "completed":
-				lines.push(theme.fg("success", "✓ ") + theme.fg("muted", theme.strikethrough(text)));
+				prefix = theme.fg("success", "✓ ");
+				styledText = theme.fg("muted", theme.strikethrough(text));
 				break;
 			case "in_progress":
-				lines.push(theme.fg("accent", "▶ ") + theme.fg("accent", theme.bold(text)));
+				prefix = theme.fg("accent", "▶ ");
+				styledText = theme.fg("accent", theme.bold(text));
 				break;
 			case "pending":
-				lines.push(theme.fg("dim", "○ ") + theme.fg("text", text));
+				prefix = theme.fg("dim", "○ ");
+				styledText = theme.fg("text", text);
 				break;
 		}
+
+		if (renderWidth <= 2) {
+			lines.push(prefix);
+			continue;
+		}
+
+		const wrappedText = wrapTextWithAnsi(styledText, renderWidth - 2);
+		lines.push(...wrappedText.map((line, index) => `${index === 0 ? prefix : "  "}${line}`));
 	}
 
-	return lines.map((line) => truncateToWidth(line, Math.max(0, width), ""));
+	return lines.map((line) => truncateToWidth(line, renderWidth, ""));
 }
 
 export function reconcileTodoContext(

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -241,6 +241,28 @@ test("renders completed, current, and pending tasks with themed semantic symbols
 	assert.ok(calls.some(([kind, role]) => kind === "style" && role === "strikethrough"));
 });
 
+test("wraps task text with hanging indentation at narrow widths", () => {
+	const { theme } = identityTheme();
+	const wrappedWords = renderTodoWidget(
+		[{ text: "alpha beta gamma", status: "in_progress" }],
+		theme,
+		10,
+	);
+	assert.deepEqual(wrappedWords.slice(2), ["▶ alpha", "  beta", "  gamma"]);
+
+	const wrappedCjk = renderTodoWidget([{ text: "界界界", status: "pending" }], theme, 6);
+	assert.deepEqual(wrappedCjk.slice(2), ["○ 界界", "  界"]);
+
+	for (const width of [0, 1, 2]) {
+		const lines = renderTodoWidget(
+			[{ text: "hidden until enough room", status: "completed" }],
+			theme,
+			width,
+		);
+		for (const line of lines) assert.ok(visibleWidth(line) <= width);
+	}
+});
+
 test("sanitizes terminal and bidi controls and bounds every rendered line", () => {
 	const hostile = "safe\u001b]8;;https://evil\u0007link\u001b]8;;\u0007\n界界\u202e";
 	assert.equal(sanitizeTodoText(hostile), "safelink 界界");


### PR DESCRIPTION
## Summary

- wrap long todo text to the available terminal width with hanging indentation
- preserve bounded rendering for CJK text and extremely narrow terminals
- document constrained-height clipping and update the existing release changeset

## Verification

- `npm run check`
- `npm test` (372 files, 3300 tests)
- README heading audit
- `npm pack --workspace @narumitw/pi-todo --dry-run --json`

## Smokes

- Live interactive terminal resize was not run; deterministic renderer tests cover narrow widths.
