### PR TITLE
fix(todo): avoid redundant context reminders

### DIFF
--- a/.changeset/bright-todos-progress.md
+++ b/.changeset/bright-todos-progress.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-todo": minor
 ---
 
-Add the Todo Widget extension with branch-aware task lists managed by `update_todo_list`, proactive progress reminders, and an above-editor display that wraps long task text to the available width.
+Add the Todo Widget extension with branch-aware task lists managed by `update_todo_list`, compaction-aware context fallback, and an above-editor display that wraps long task text to the available width.

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -14,7 +14,7 @@ The list follows the active session branch and disappears cleanly when no tracke
 - Keeps task text concise and action-oriented, with at most one task in progress.
 - Shows a compact themed task list and completion count above the editor in TUI mode.
 - Restores the latest valid list when Pi starts a session or navigates between branches.
-- Reminds the model of the current list before every model call so progress stays visible after compaction.
+- Restores the exact current list to model context only when compaction removes its latest visible successful tool update.
 - Sanitizes terminal and bidirectional controls before rendering model-provided text.
 - Works without settings, files, network access, or external services.
 
@@ -46,7 +46,7 @@ Ask Pi to perform work with multiple meaningful steps.
 
 The agent can create a concise list through `update_todo_list`, mark one task `in_progress`, and revise the list when the plan changes.
 
-While a list is active, the extension reminds the agent to update it immediately after task status changes and to reconcile it before progress reports or the final response.
+Stable tool guidance tells the agent to update the list immediately after task status changes and to reconcile it before progress reports or the final response.
 
 The agent sends the complete current list with every update and sends an empty list when no tracked work remains.
 
@@ -73,9 +73,11 @@ The tool result stores a versioned snapshot in the session branch so branch navi
 
 Branch reconstruction also accepts valid results stored under the previous `todo_widget` name, but the extension only registers `update_todo_list` for new calls.
 
-Before each model call, the extension appends one hidden, non-persistent context reminder containing the current list as JSON data.
+During ordinary turns, the model reads the complete list from the persisted `update_todo_list` assistant tool call, while its successful result confirms the active state and preserves append-only prompt history.
 
-The reminder is kept at the end of model context, survives compaction through branch reconstruction, and is removed when the list is cleared.
+If compaction or branch context construction removes that matching call/result pair, the extension appends one hidden, non-persistent state-only fallback containing the current list as JSON data.
+
+The fallback stays at the end of model context until a later valid todo tool call and successful result become visible, and it is omitted when the list is cleared.
 
 In TUI mode, updates appear immediately in a widget above the editor.
 

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -197,7 +197,11 @@ export function reconcileTodoContext(
 	items: readonly TodoItem[],
 ): ContextEvent["messages"] {
 	const existing = messages.filter(isTodoContextMessage);
-	const content = items.length > 0 ? todoContextContent(items) : undefined;
+	const withoutExisting = messages.filter((message) => !isTodoContextMessage(message));
+	const content =
+		items.length > 0 && !hasModelVisibleTodoState(withoutExisting, items)
+			? todoContextContent(items)
+			: undefined;
 	if (
 		existing.length === 1 &&
 		messages.at(-1) === existing[0] &&
@@ -207,7 +211,6 @@ export function reconcileTodoContext(
 	}
 	if (existing.length === 0 && content === undefined) return messages;
 
-	const withoutExisting = messages.filter((message) => !isTodoContextMessage(message));
 	if (content === undefined) return withoutExisting;
 	return [
 		...withoutExisting,
@@ -234,11 +237,44 @@ export function sanitizeTodoText(value: string): string {
 
 function todoContextContent(items: readonly TodoItem[]): string {
 	return `[PI TODO STATUS v${TODO_CONTEXT_VERSION}]
-An active todo list follows as JSON data.
-Keep it aligned with actual work: call update_todo_list before starting a task, as soon as a task finishes, and whenever the plan changes.
-Before a progress report or final response, call update_todo_list to reconcile every item; do not report completion while the list is stale.
-Active todo list:
+Current todo list as JSON data:
 ${JSON.stringify(items)}`;
+}
+
+function hasModelVisibleTodoState(
+	messages: ContextEvent["messages"],
+	items: readonly TodoItem[],
+): boolean {
+	const currentResults = new Map<string, string>();
+	for (const message of messages) {
+		if (
+			message.role === "toolResult" &&
+			!message.isError &&
+			(message.toolName === TOOL_NAME || message.toolName === LEGACY_TOOL_NAME) &&
+			isTodoDetails(message.details) &&
+			todoItemsEqual(message.details.items, items)
+		) {
+			currentResults.set(message.toolCallId, message.toolName);
+		}
+	}
+	if (currentResults.size === 0) return false;
+
+	return messages.some(
+		(message) =>
+			message.role === "assistant" &&
+			message.content.some(
+				(content) =>
+					content.type === "toolCall" &&
+					currentResults.get(content.id) === content.name &&
+					isTodoToolArguments(content.arguments) &&
+					todoItemsEqual(content.arguments.items, items),
+			),
+	);
+}
+
+function isTodoToolArguments(value: unknown): value is { items: TodoItem[] } {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	return isTodoItems((value as Record<string, unknown>).items);
 }
 
 function isTodoContextMessage(
@@ -280,11 +316,14 @@ function reconstructItems(entries: readonly SessionEntry[]): TodoItem[] {
 function isTodoDetails(value: unknown): value is TodoDetails {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
 	const record = value as Record<string, unknown>;
-	if (record.version !== TODO_DETAILS_VERSION || !Array.isArray(record.items)) return false;
-	if (record.items.length > MAX_TODO_ITEMS) return false;
+	return record.version === TODO_DETAILS_VERSION && isTodoItems(record.items);
+}
+
+function isTodoItems(value: unknown): value is TodoItem[] {
+	if (!Array.isArray(value) || value.length > MAX_TODO_ITEMS) return false;
 
 	let currentCount = 0;
-	for (const item of record.items) {
+	for (const item of value) {
 		if (typeof item !== "object" || item === null || Array.isArray(item)) return false;
 		const candidate = item as Record<string, unknown>;
 		if (
@@ -299,6 +338,15 @@ function isTodoDetails(value: unknown): value is TodoDetails {
 		if (candidate.status === "in_progress") currentCount += 1;
 	}
 	return currentCount <= 1;
+}
+
+function todoItemsEqual(left: readonly TodoItem[], right: readonly TodoItem[]): boolean {
+	return (
+		left.length === right.length &&
+		left.every(
+			(item, index) => item.text === right[index]?.text && item.status === right[index]?.status,
+		)
+	);
 }
 
 function cloneItems(items: readonly TodoItem[]): TodoItem[] {

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -119,21 +119,59 @@ function identityTheme() {
 	return { calls, theme };
 }
 
+function todoToolResultMessage(
+	details: TodoDetails,
+	toolName = TOOL_NAME,
+	isError = false,
+): ContextEvent["messages"][number] {
+	return {
+		role: "toolResult",
+		toolCallId: "todo-call",
+		toolName,
+		content: [{ type: "text", text: "updated" }],
+		details,
+		isError,
+		timestamp: 0,
+	};
+}
+
+function todoToolCallMessage(
+	items: unknown,
+	toolName = TOOL_NAME,
+): ContextEvent["messages"][number] {
+	return {
+		role: "assistant",
+		content: [
+			{
+				type: "toolCall",
+				id: "todo-call",
+				name: toolName,
+				arguments: { items },
+			},
+		],
+		api: "openai-responses",
+		provider: "test",
+		model: "test",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 0,
+	};
+}
+
 function toolResultEntry(details: TodoDetails, toolName = TOOL_NAME): SessionEntry {
 	return {
 		type: "message",
 		id: "tool-result",
 		parentId: null,
 		timestamp: new Date(0).toISOString(),
-		message: {
-			role: "toolResult",
-			toolCallId: "todo-call",
-			toolName,
-			content: [{ type: "text", text: "updated" }],
-			details,
-			isError: false,
-			timestamp: 0,
-		},
+		message: todoToolResultMessage(details, toolName),
 	} as SessionEntry;
 }
 
@@ -160,18 +198,19 @@ test("registers concise guidance for using and maintaining the todo list", () =>
 	]);
 });
 
-test("keeps one current todo reminder at the end of model context", async () => {
+test("uses visible todo calls and injects only missing current state", async () => {
 	const harness = createHarness();
 	const current = createContext();
 	await harness.emit("session_start", current.ctx);
-	await setTodos(harness, current.ctx, [
+	const items: TodoItem[] = [
 		{ text: "inspect", status: "completed" },
 		{ text: "implement", status: "in_progress" },
-	]);
+	];
+	await setTodos(harness, current.ctx, items);
 
-	const base = [
+	const base: ContextEvent["messages"] = [
 		{
-			role: "compactionSummary" as const,
+			role: "compactionSummary",
 			summary: "Earlier work was compacted.",
 			tokensBefore: 100,
 			timestamp: 0,
@@ -185,33 +224,65 @@ test("keeps one current todo reminder at the end of model context", async () => 
 	assert.equal(reminder.customType, TODO_CONTEXT_MESSAGE_TYPE);
 	assert.equal(reminder.display, false);
 	assert.deepEqual(reminder.details, { version: TODO_CONTEXT_VERSION });
-	assert.match(reminder.content as string, /call update_todo_list before starting/u);
-	assert.match(reminder.content as string, /Before a progress report or final response/u);
-	assert.ok(
-		(reminder.content as string).includes(
-			'[{"text":"inspect","status":"completed"},{"text":"implement","status":"in_progress"}]',
-		),
+	assert.equal(
+		reminder.content,
+		`[PI TODO STATUS v${TODO_CONTEXT_VERSION}]\nCurrent todo list as JSON data:\n${JSON.stringify(items)}`,
 	);
+	assert.doesNotMatch(reminder.content as string, /call update_todo_list/u);
 
 	const unchanged = await harness.context(transformed, current.ctx);
 	assert.equal(unchanged, transformed);
 
-	await setTodos(harness, current.ctx, [{ text: "implement", status: "completed" }]);
-	const updated = await harness.context(transformed, current.ctx);
-	assert.equal(
-		updated.filter(
+	for (const toolName of [TOOL_NAME, "todo_widget"]) {
+		const details: TodoDetails = { version: TODO_DETAILS_VERSION, items };
+		const visible = [
+			...base,
+			todoToolCallMessage(items, toolName),
+			todoToolResultMessage(details, toolName),
+		];
+		assert.equal(await harness.context(visible, current.ctx), visible);
+	}
+
+	const details: TodoDetails = { version: TODO_DETAILS_VERSION, items };
+	const incompleteContexts = [
+		[...base, todoToolCallMessage("invalid")],
+		[...base, todoToolCallMessage([{ text: "stale", status: "pending" }])],
+		[...base, todoToolCallMessage(items)],
+		[...base, todoToolResultMessage(details)],
+		[...base, todoToolCallMessage(items), todoToolResultMessage(details, TOOL_NAME, true)],
+	];
+	for (const incomplete of incompleteContexts) {
+		const fallback = await harness.context(incomplete, current.ctx);
+		const reminders = fallback.filter(
 			(message) => message.role === "custom" && message.customType === TODO_CONTEXT_MESSAGE_TYPE,
-		).length,
-		1,
+		);
+		assert.equal(reminders.length, 1);
+		const fallbackReminder = reminders[0];
+		assert.equal(fallbackReminder?.role, "custom");
+		if (fallbackReminder?.role !== "custom") assert.fail("Expected a custom todo reminder");
+		assert.equal(fallbackReminder.content, reminder.content);
+	}
+
+	const replacementItems: TodoItem[] = [{ text: "implement", status: "completed" }];
+	await setTodos(harness, current.ctx, replacementItems);
+	const replacementDetails: TodoDetails = {
+		version: TODO_DETAILS_VERSION,
+		items: replacementItems,
+	};
+	const replacement = [
+		...transformed,
+		todoToolCallMessage(replacementItems),
+		todoToolResultMessage(replacementDetails),
+	];
+	assert.deepEqual(
+		await harness.context(replacement, current.ctx),
+		replacement.filter(
+			(message) => message.role !== "custom" || message.customType !== TODO_CONTEXT_MESSAGE_TYPE,
+		),
 	);
-	const updatedReminder = updated.at(-1);
-	assert.equal(updatedReminder?.role, "custom");
-	if (updatedReminder?.role !== "custom") assert.fail("Expected an updated todo reminder");
-	assert.match(updatedReminder.content as string, /"implement","status":"completed"/u);
-	assert.doesNotMatch(updatedReminder.content as string, /"inspect"/u);
 
 	await setTodos(harness, current.ctx, []);
-	assert.deepEqual(await harness.context(updated, current.ctx), base);
+	assert.deepEqual(await harness.context(transformed, current.ctx), base);
 });
 
 test("renders completed, current, and pending tasks with themed semantic symbols", () => {


### PR DESCRIPTION
## Summary

- reuse the persisted `update_todo_list` call/result pair during ordinary turns instead of appending a duplicate reminder
- inject one bounded state-only fallback when compaction or branch context removes the current successful update
- validate current and legacy calls, fail closed for malformed, orphaned, or failed updates, and document the cache behavior

## Verification

- `npm --workspace @narumitw/pi-todo run check`
- `npx vitest run packages/pi-todo/test/todo-widget.test.ts` — 8 tests passed
- `npm run check`
- `npm test` — 373 files and 3,302 tests passed
- `just pack todo` — inspected five intended package files

## Risks and unverified paths

- A live-provider cache-hit percentage was not measured because cache accounting is provider-dependent.
- The post-compaction fallback remains an uncached prompt-tail item until a later successful todo update becomes visible.
- No package was published and no release workflow was dispatched.
