### PR TITLE
feat: add axiv CLI research skill

### DIFF
--- a/.pi/skills/using-axiv-cli/SKILL.md
+++ b/.pi/skills/using-axiv-cli/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: using-axiv-cli
+description: Use when discovering or reading alphaXiv papers, asking questions against paper PDFs, exploring paper-linked GitHub code, or listing and managing an authenticated alphaXiv personal library through the axiv CLI.
+---
+
+# Using axiv CLI
+
+Use only the published `axiv` CLI commands in this repository.
+
+Use an installed `axiv` executable when available.
+
+From this source checkout, fall back to `uv run axiv` as the command prefix when `axiv` is not installed.
+
+Read [references/installation.md](references/installation.md) when neither command prefix can show CLI help.
+
+Stop and report the installation error when the installation instructions do not produce a working command prefix.
+
+Do not select or retry MCP transports manually because `axiv` handles streamable HTTP to SSE fallback only before tool dispatch.
+
+When an authenticated command reports an unexpected runtime, MCP connection, initialization, or breaking tool drift error, update `axiv` by following [references/installation.md](references/installation.md) before troubleshooting.
+
+After updating, rerun only non-quota, read-only checks such as `axiv --help` or `axiv auth status --json`.
+
+Treat a surfaced tool-call transport error as terminal because the remote outcome may be ambiguous.
+
+Do not automatically retry a quota-consuming command or remote library write after updating.
+
+Do not invoke `mcp2cli`, call alphaXiv REST or MCP endpoints directly, or import private Python client methods.
+
+Run the resolved command prefix with `auth status --json` before any authenticated research or library workflow.
+
+Stop and report the error when the API key is missing, authentication fails, a reviewed tool is missing or changes schema, or alphaXiv returns `403`.
+
+Read [references/command-map.md](references/command-map.md) to select the exact command and understand its authentication, quota, and remote effects.
+
+Prefer `--json` whenever another tool or agent will consume the result.
+
+Preserve the user's question and keywords instead of silently expanding acronyms or inventing search terms.
+
+Tell the user that discover, content, query, and code commands consume Assistant quota before calling one unless their request already clearly authorizes that research action.
+
+Stop and report quota exhaustion instead of retrying or substituting another quota-consuming command.
+
+Use `axiv library list --json` to obtain current opaque folder IDs before planning a library change.
+
+Before every remote library write, state the exact CLI operation, folder IDs or names, and paper IDs or URLs that will change.
+
+Obtain explicit user authorization for those exact targets before adding `--yes`.
+
+Treat `--yes` only as CLI confirmation and never as evidence that the user authorized the write.
+
+Do not combine separately authorized writes or broaden a target after authorization.
+
+For folder deletion, explicitly state that folder memberships will be removed before requesting authorization.
+
+Stop when a write target is missing, ambiguous, destructive intent is unclear, or authorization does not match the final command.
+
+Read [references/workflows.md](references/workflows.md) when coordinating literature review, paper analysis, PDF evidence, code verification, or library organization.
+
+Verify success from the command's JSON result and report partial or failed outcomes without automatically retrying writes.

--- a/.pi/skills/using-axiv-cli/references/command-map.md
+++ b/.pi/skills/using-axiv-cli/references/command-map.md
@@ -1,0 +1,32 @@
+# axiv CLI Command Map
+
+Run authenticated commands only after `axiv auth status --json` succeeds.
+
+Prefer `--json` for agent-readable output.
+
+| User need | CLI command | Backend | Authentication | Quota | Remote effect | Primary failure handling |
+| --- | --- | --- | --- | --- | --- | --- |
+| Check MCP access | `axiv auth status --json` | MCP initialize and tools/list | API key required | None | Read only | Update on a surfaced connection, initialization, or breaking drift error, then rerun this check once. |
+| Discover papers | `axiv research discover QUESTION --keyword KEYWORD --json` | `discover_papers` | API key required | Assistant | Read only | Stop on quota exhaustion and do not invent keywords. |
+| Read paper content | `axiv paper content PAPER --json` | `get_paper_content` | API key required | Assistant | Read only | Stop on quota exhaustion or an unsupported paper URL. |
+| Read full extracted text | `axiv paper content PAPER --full-text --json` | `get_paper_content` | API key required | Assistant | Read only | Stop on quota exhaustion or an unsupported paper URL. |
+| Ask PDF questions | `axiv paper query PAPER --query QUESTION --json` | `answer_pdf_queries` | API key required | Assistant | Read only | Batch all questions for one paper and stop on quota exhaustion. |
+| Inspect linked code | `axiv paper code REPOSITORY PATH --json` | `read_files_from_github_repository` | API key required | Assistant | Read only | Require an HTTPS GitHub repository and stop on inaccessible files. |
+| List folders | `axiv library list --json` | `list_library` | API key required | None | Read only | Stop on authentication failure and use returned folder IDs. |
+| List folder papers | `axiv library list --include-papers --json` | `list_library` | API key required | None | Read only | Request paper loading only when needed. |
+| Save papers | `axiv library save FOLDER PAPER... --yes --json` | `save_papers_to_folder` | API key required | None | Writes memberships | Require authorization for the exact folder and papers. |
+| Remove papers | `axiv library remove FOLDER PAPER... --yes --json` | `remove_papers_from_folder` | API key required | None | Removes memberships | Require authorization for the exact folder and papers. |
+| Move papers | `axiv library move SOURCE TARGET PAPER... --yes --json` | `move_papers_between_folders` | API key required | None | Moves memberships | Require authorization for both folders and every paper. |
+| Create folder | `axiv library folder create NAME --yes --json` | `create_folder` | API key required | None | Creates a folder | Require authorization for the exact name and optional parent. |
+| Rename folder | `axiv library folder rename FOLDER NAME --yes --json` | `rename_folder` | API key required | None | Renames a folder | Require authorization for the exact folder ID and new name. |
+| Delete folder | `axiv library folder delete FOLDER --yes --json` | `delete_folder` | API key required | None | Deletes folder memberships | Require destructive authorization for the exact folder ID. |
+
+Never use `--yes` until the user has authorized the exact write described in the final command.
+
+Let `axiv` handle streamable HTTP to SSE fallback internally before tool dispatch.
+
+Never invoke `mcp2cli` or another generic MCP client as a fallback.
+
+Stop rather than retry when the response reports a missing key, `403`, breaking tool drift after updating, quota exhaustion, or an ambiguous tool-call outcome.
+
+Treat additional advertised tools as compatible because the CLI cannot dispatch tools outside its static reviewed contracts.

--- a/.pi/skills/using-axiv-cli/references/installation.md
+++ b/.pi/skills/using-axiv-cli/references/installation.md
@@ -1,0 +1,47 @@
+# axiv CLI Installation
+
+## Install with uv
+
+Use an existing `axiv` executable when `axiv --help` succeeds.
+
+If the command is unavailable, install the published package with `uv tool install axiv`.
+
+Do not use `sudo` for the installation.
+
+Run `axiv --help` to verify that the installed executable is available.
+
+Use `uv tool update-shell` and start a new shell when installation succeeds but `axiv` is not on `PATH`.
+
+## Update before troubleshooting
+
+When an authenticated command reports an unexpected runtime, MCP connection, initialization, or breaking tool drift error, first run `uv tool upgrade axiv` before diagnosing it.
+
+Do not upgrade for invalid input, a missing API key, `401`, `403`, quota exhaustion, or an expected not-found response.
+
+If uv reports that the tool is not installed, run `uv tool install axiv` instead.
+
+Verify the updated published executable with `axiv --help` and `axiv auth status --json`.
+
+If the error came from `uv run axiv` in a source checkout, use the updated published executable for verification before changing source code.
+
+Do not automatically repeat quota-consuming research commands, remote library writes, or tool calls with ambiguous outcomes after updating.
+
+## Run from a source checkout
+
+From the repository root, use `uv run axiv --help` to create the project environment and verify the source CLI.
+
+Use `uv run axiv` as the command prefix for subsequent commands in that checkout.
+
+## Authentication setup
+
+Set `ALPHAXIV_API_KEY` in the environment before using authenticated research or library commands.
+
+Never pass the API key as a command argument or write it into the Skill files.
+
+Verify authenticated access with `axiv auth status --json`, or with `uv run axiv auth status --json` from a source checkout.
+
+## Failure handling
+
+Stop and report the installation output when `uv` is unavailable, package installation fails, or neither command prefix can show help.
+
+Do not bypass an installation failure by calling alphaXiv endpoints or importing private client code.

--- a/.pi/skills/using-axiv-cli/references/workflows.md
+++ b/.pi/skills/using-axiv-cli/references/workflows.md
@@ -1,0 +1,57 @@
+# axiv CLI Workflows
+
+## Literature Review
+
+Run `axiv auth status --json` and stop if authentication or tool compatibility fails.
+
+Confirm that the user wants a quota-consuming discovery call when their request does not already make that intent clear.
+
+Run `axiv research discover` with only the user's question, stated keywords, requested dates, difficulty, and priority.
+
+Use `axiv paper query` once per selected paper with every question for that paper batched as repeated `--query` options.
+
+Synthesize only claims supported by returned paper content and identify gaps without silently spending more quota.
+
+## Single-Paper Research
+
+Use `axiv paper content PAPER --json` for the intermediate report.
+
+Use `--full-text` only when raw extracted text is necessary or the report is insufficient.
+
+Use `axiv paper query` for page-level evidence and batch related questions in one call.
+
+Stop on an unresolved paper, quota exhaustion, or content that does not support the requested conclusion.
+
+## PDF Evidence Extraction
+
+Keep all questions about one paper in one `axiv paper query` command.
+
+Preserve the returned page identifiers when citing evidence.
+
+Do not claim that filtered pages represent the entire paper.
+
+Run another quota-consuming query only after the user authorizes the additional research when the original request did not cover it.
+
+## Code Verification
+
+Obtain the paper's actual GitHub URL from a paper result or from the user.
+
+Run `axiv paper code REPOSITORY / --json` to inspect the repository tree and top-level files.
+
+Read only the specific files or directories needed to verify the claim.
+
+Stop if the repository is not on HTTPS GitHub, the path is ambiguous, or the code cannot support the claim.
+
+## Personal Library Organization
+
+Run `axiv library list --json` to resolve folder names to opaque folder IDs.
+
+Draft the exact write command without `--yes` and state every target folder and paper.
+
+Ask the user to authorize that exact save, remove, move, create, rename, or delete operation.
+
+Add `--yes --json` only after authorization matches the final command.
+
+Inspect the stable result and report partial outcomes without automatically retrying.
+
+For deletion, remind the user that the folder and its paper memberships will be removed while the papers remain elsewhere.


### PR DESCRIPTION
## Summary

- add a project-local skill for alphaXiv research through the reviewed `axiv` CLI
- document installation, authentication, quota, and failure-handling rules
- document read-only research and explicitly authorized library-write workflows

## Verification

- `npx biome check .pi/skills/using-axiv-cli`
- `npm run check`
- `npm test` (373 files, 3303 tests)
- verified documented command shapes against `axiv 0.0.3 --help`

## Release

- no changeset: repository-only project skill