### PR TITLE
chore: ignore project-local skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,7 @@ vite.config.ts.timestamp-*
 
 # Project
 .pi/agent/
+.pi/skills/
 **/.pi-*-build-test-*/
 **/.pi-*-dist-*/
 docs/plans/archived/


### PR DESCRIPTION
## Summary

- Ignore project-local skill files under `.pi/skills/`.

## Verification

- `npm run biome:check`
- `npm run typecheck`
- `git check-ignore -q .pi/skills/example/SKILL.md`