### PR TITLE
feat(subagents): improve async runtime quality

### DIFF
--- a/.changeset/brave-subagents-runtime.md
+++ b/.changeset/brave-subagents-runtime.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Add exact required-run tracking for detached completion dependencies, preserve usable budget-stopped evidence as typed partial outcomes, and provide a paired async-versus-sync quality benchmark.

--- a/justfile
+++ b/justfile
@@ -91,6 +91,10 @@ benchmark-subagents samples="7":
 benchmark-codex-compact *args:
     node packages/pi-codex-compact/benchmark/run.mjs {{ args }}
 
+# Preview or explicitly run the paired synchronous/asynchronous subagent benchmark
+benchmark-async-subagents *args:
+    node scripts/benchmark-async-subagents.ts {{ args }}
+
 # Install dependencies, build local package artifacts, and start every local extension package
 # pi-statusline and pi-tui-kit are intentionally excluded from Pi extension loading
 # PI_TIMING reports startup timing and PI_CODING_AGENT_DIR isolates local development state

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -85,7 +85,7 @@ Concurrent Pi processes use separate opaque writer files and never append to one
 Validated writer files older than 30 days are removed after recording starts.
 Disabling recording stops new events immediately; existing files remain until the retention window expires or the user removes the directory while Pi is stopped.
 
-Stored fields are limited to extension-generated runtime, session, turn, tool, child, run, and completion ordinals; the effective delegation surface; lifecycle states; completion-delivery transitions; bounded usage numbers; errors as booleans; and monotonic timing or durations.
+Stored fields are limited to extension-generated runtime, session, turn, tool, child, run, and completion ordinals; the effective delegation surface; lifecycle and typed outcome states; bounded executor-owned termination reasons; runtime-versus-explicit budget-source labels; completion-delivery transitions; bounded usage numbers; errors as booleans; and monotonic timing or durations.
 The recorder does not store prompts, delegated tasks, responses, thinking, tool arguments or results, code, paths, commands, mailbox or steering content, raw errors, provider/model identity, credentials, Pi session identifiers, or a persistent device identifier.
 Raw child, run, completion, and provider tool-call identifiers are replaced with runtime-local ordinals before publication.
 
@@ -192,6 +192,7 @@ Common controls:
 - `thinkingLevel` — request `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` thinking for the spawned Pi process or retained child.
 - `idempotencyKey` — make an exact `subagent_spawn` retry return the existing retained `agentId`; reuse with different parameters fails before confirmation, worktree creation, or child launch.
 - `resultFormat` — keep bounded text by default, request legacy `structured-v1`, or request `structured-v2` with explicit outcome status, reason code, claims, artifacts, verification, limitations, and unresolved dependencies.
+- `completionRequirement` — mark one detached spawn or follow-up as `background` (default) or `required` for the parent final answer; required mode tracks the accepted run ID and generation until its exact completion is visible or terminal.
 - `totalTimeoutMs` — bound a whole explicit blocking workflow; no new task starts after the budget is exhausted.
 
 For `subagent_spawn`, the root agent selects the lowest thinking level and shortest realistic work deadline sufficient for the delegated task.
@@ -251,7 +252,7 @@ Delegation guidance:
 - A single worker without concurrent main-agent work remains available when the user explicitly requests a specialist model, tool profile, or isolation boundary.
 - With default `completionDelivery: "next-turn"`, use detached work only when the current response does not depend on its result because an idle root is not awakened.
 - With `completionDelivery: "auto-resume"`, detached work may affect the final answer because completion steers into active work or requests a later synthesis turn from idle.
-- Track every final-answer-dependent spawn by its returned ID or path, treat interim output as progress, and synthesize only after every corresponding completion message is visible.
+- Mark every final-answer-dependent spawn with `completionRequirement: "required"`, retain its returned ID or path, treat interim output as progress, and synthesize only after every corresponding completion is visible or terminal.
 - After `subagent_spawn` returns, immediately continue the identified local task instead of merely announcing the spawn, waiting, polling, duplicating the child task, or ending while useful local work remains.
 - Do not duplicate a running child's assigned work; use a bounded parent fallback only after completion reports failure or insufficient evidence.
 - Use multiple workers only for truly independent slices with disjoint write ownership and safe workspace concurrency, and keep integration in the main agent.
@@ -276,7 +277,8 @@ The main agent owns `src/parser.ts`, immediately continues that work after spawn
 ```json
 {
   "agent": "worker",
-  "task": "Implement the approved formatter slice only in src/formatter.ts and test/formatter.test.ts. Do not edit src/parser.ts. Report changed paths, checks, and remaining risks."
+  "task": "Implement the approved formatter slice only in src/formatter.ts and test/formatter.test.ts. Do not edit src/parser.ts. Report changed paths, checks, and remaining risks.",
+  "completionRequirement": "required"
 }
 ```
 
@@ -637,6 +639,11 @@ Legacy v1 and v2 records without acceptance fields retain their prior completed 
 Stateful lifecycle tools are available by default.
 `subagent_spawn` is detached: it schedules work, returns immediately with an opaque `agentId` plus canonical `taskPath`, and later delivers a bounded completion to its intended parent.
 Every turn receives an executor-owned `runId`, monotonically increasing agent-local generation, and unique `completionId`.
+A caller can set `completionRequirement: "required"` on a spawn or follow-up to bind final-answer dependency state to that exact run and generation.
+Required state moves from `pending` to `available` after durable terminal completion and to `visible` only after the intended parent context observes the exact completion ID.
+Interruption, close, stale restore, and shutdown terminalize unfinished requirements explicitly instead of silently dropping them.
+Tool-result details preserve fork-sensitive requirement evidence, inspection projects bounded requirement state, and one canonical hidden context block replaces older copies.
+The runtime rejects a sixty-fifth unresolved required run before acceptance so every unresolved exact identity fits in the bounded parent context.
 The terminal completion and recipient are persisted before delivery, simultaneous root completions are batched, and the root broker allows at most one in-flight wake until that parent turn starts.
 In TUI mode, completion messages show a compact task and payload summary while collapsed; use the configured tool-output expansion action (`Ctrl+O` by default) to show or hide the complete message globally.
 
@@ -644,7 +651,7 @@ Detached work follows a non-polling policy.
 Before one ordinary `subagent_spawn`, identify useful non-overlapping main-agent work that starts immediately and a supported completion integration path.
 With default `next-turn` delivery, the current response must not depend on the result because an idle root is not awakened.
 With opt-in `auto-resume`, detached work may affect the final answer because completion steers into an active parent before its next model call or requests a synthesis turn from idle.
-Track every final-answer-dependent spawn by its returned ID or path, treat interim output as progress, and synthesize only after every corresponding completion message is visible.
+Mark every final-answer-dependent spawn with `completionRequirement: "required"`, retain its returned ID or path, treat interim output as progress, and synthesize only after every corresponding completion is visible or terminal.
 When local work finishes before required children, emit at most one brief progress sentence and end the turn rather than repeating waiting updates or using the requested final format, verdict, or conclusion.
 After spawning, immediately continue the identified local task instead of merely announcing the spawn, waiting, polling `subagent_inspect` or `subagent_mailbox`, duplicating the child task, or ending while useful local work remains.
 Do not duplicate a running child's assigned work; use a bounded parent fallback only after completion reports failure or insufficient evidence.
@@ -667,7 +674,11 @@ Simple and immediate critical-path work should stay in the main agent.
 - `"auto-resume"` sends completion to an active root with `deliverAs: "steer"` and no turn trigger, so Pi places it after the current assistant turn and before the next model call.
   An idle root with no pending user or extension input receives at most one in-flight synthesis wake; pending input suppresses that wake, and simultaneous idle completions share one turn.
 
-Completion delivery makes results visible in model context but does not enforce model obedience, rewrite premature assistant output, or provide a hard final-answer barrier.
+Completion delivery and required-run context make dependencies visible to the model but do not enforce model obedience, rewrite premature assistant output, or provide a hard final-answer barrier.
+The supported Pi extension API exposes no hook for buffering assistant deltas before display and no replay-safe steering activity for a cross-mode interruptible join.
+`message_end` replacement can repair finalized persistence but cannot retract already displayed streaming output.
+The package therefore keeps `subagent_await` as the accurately documented blocking fallback and does not claim an extension-only hard barrier.
+The repository protocol note at `docs/async-runtime-protocol.md` records the exact state machine and unavailable core guarantees; this work does not modify or publish Pi core packages.
 The bounded persisted completion outbox provides ordered at-least-once delivery across process restart without replaying the child turn.
 A top-level completion targets `/root`; a nested completion enters the direct retained parent's mailbox and is not duplicated into the root transcript.
 If the direct parent cannot own delivery, routing walks toward the nearest live retained ancestor and uses `/root` only as the final fallback.
@@ -1144,6 +1155,10 @@ Fresh subprocess summaries run with no tools or project resources.
 Retained RPC and in-process summaries reuse their child context and are explicitly instructed not to call tools; the current child APIs do not support replacing an existing session's tool set for one turn, so their separate deadline and abort path remain the enforcement boundary.
 Before a retained RPC summary starts, validated in-flight usage from the interrupted work attempt is committed so the summary adds to it exactly once.
 The deterministic checkpoint remains available when finalization or the provider fails, and results retain exit `124` plus a structured termination reason and finalization status.
+When bounded finalization succeeds with non-empty usable output, detached registry state reports a typed `partial` outcome with the exact budget reason instead of collapsing that evidence into an undifferentiated failure.
+Malformed required structured output, empty or failed finalization, and transport failure remain non-success.
+Partial evidence never satisfies mutating acceptance, required evidence, or independent verification.
+Inspection and opt-in content-free telemetry distinguish runtime-owned omitted limits from explicit per-turn limits.
 Explicit parent or user abort stops immediately, never starts finalization, and is not mislabeled as a budget stop.
 
 This release does not claim a cooperative soft-wrap-up phase because print-mode subprocess children cannot receive steering while they are running.
@@ -1173,6 +1188,24 @@ Queue time starts when the registry accepts work, transport startup starts when 
 Subprocess and in-process timing fields use the nearest public lifecycle boundary and may be coarser than RPC.
 Timing and progress are current-session diagnostics and are not persisted.
 The benchmark measures transport overhead rather than model latency or output quality.
+
+Preview the paired quality benchmark without making provider requests:
+
+```bash
+just benchmark-async-subagents --model provider/model
+```
+
+Run three paired trials with isolated sync-only and async-only tool surfaces, fixed model and thinking settings, redacted raw records, and a hard per-trial deadline:
+
+```bash
+just benchmark-async-subagents --run --mode quick --model provider/model --output /tmp/subagent-quick.json
+```
+
+Use `--mode extended` for ten paired trials before any further sync deprecation decision.
+The runner alternates arm order, starts work deadlines only after RPC readiness, runs at most three pairs concurrently, and reports completion coverage, evidence score, premature finals, terminal outcomes, median and P95 latency, and cost when available.
+Quick mode targets completion within five minutes under normal provider capacity but reports external timeouts and entitlement failures rather than silently reducing the sample.
+Live results remain provider- and model-dependent evidence rather than deterministic CI or proof of causality.
+The synchronous `subagent` tool remains available whenever a quality gate fails or detached chain, fan-in, panel, or workflow compatibility is unmatched.
 
 While the `subagent` tool is running, `pi-subagents` publishes compact activity status with `ctx.ui.setStatus("subagents", "...")`.
 Any statusline extension that reads Pi's generic extension status API can display it; no package-to-package dependency is required.
@@ -1213,6 +1246,8 @@ Downgrading is safe: older extension versions ignore this separate state directo
 ```txt
 packages/pi-subagents/
 ├── dist/                         # Generated split TypeScript runtime loaded through Pi's Jiti loader
+├── docs/
+│   └── async-runtime-protocol.md # Required-run state machine and unavailable core guarantees
 ├── scripts/
 │   └── build-runtime.mjs         # Deterministic bundler and eager-boundary validator
 ├── src/
@@ -1241,6 +1276,7 @@ packages/pi-subagents/
 │   ├── usage-recording.ts        # Opt-in content-free event collection and local identities
 │   ├── usage-recording-store.ts  # Private per-runtime JSONL writers and retention pruning
 │   ├── completion-delivery.ts    # Top-level completion batching and optional idle-root wake
+│   ├── completion-requirement.ts # Exact required-run tracking and canonical context contract
 │   ├── completion-routing.ts     # Direct-parent and live-ancestor recipient selection
 │   ├── task-path.ts              # Canonical retained-agent task identity and resolution
 │   ├── peer-communication.ts     # Session peer routing and authenticated loopback broker
@@ -1258,6 +1294,7 @@ packages/pi-subagents/
 │   ├── verification-harness.ts   # Disposable deterministic check execution
 │   ├── verification-receipt.ts   # Strict executor-owned managed receipts
 │   ├── verified-execution-benchmark.ts # Matched offline acceptance/cost fixture
+│   ├── async-subagent-benchmark.ts # Paired live-quality planning, scoring, and summaries
 │   ├── workflow-tree-identity.ts # Bounded exact Git-visible tree identities
 │   ├── integration-controller.ts # Fail-closed canonical integration admission
 │   ├── adaptive-scheduler.ts     # Dependency, capacity, budget, and conflict scheduling

--- a/packages/pi-subagents/docs/async-runtime-protocol.md
+++ b/packages/pi-subagents/docs/async-runtime-protocol.md
@@ -1,0 +1,69 @@
+# Async runtime protocol
+
+This document defines `pi-subagents:completion-requirement:v1` and the current runtime boundary for final-answer-dependent detached work.
+
+## Requirement identity
+
+A caller marks one `subagent_spawn` or `subagent_send` turn with `completionRequirement: "required"`.
+The runtime binds that requirement to the accepted `agentId`, executor-owned `runId`, and monotonically increasing turn generation.
+Agent names and task paths are display and addressing aids and never replace exact run identity.
+Omitting the field or using `background` preserves prior behavior and does not create a final-answer dependency.
+
+## State ownership
+
+`AgentRegistry` owns requirement transitions with the child turn and persisted completion outbox.
+Tool-result `details.agent.completionRequirements` provides fork-sensitive branch evidence.
+Session restoration retains exact requirements found on the active branch and treats sessions without visible subagent state as a possible compacted continuation.
+The `context` hook owns one canonical hidden `pi-subagent-required-completions` block and replaces any older copy on every provider context assembly.
+`CompletionDeliveryBroker` owns exact completion visibility acknowledgement and asks the registry to mark the corresponding requirement visible.
+No timer, waiter, or UI object owns requirement truth.
+
+## States
+
+A newly accepted exact run enters `pending`.
+A durably persisted terminal completion moves the exact run to `available` and records its completion ID and terminal child state.
+Observation of that exact completion ID in the intended parent context moves the run to `visible`.
+Interruption, close, restore of a non-running owner, or shutdown moves an unfinished requirement to `cancelled` with an explicit terminal state.
+Duplicate completion delivery and acknowledgement are idempotent.
+A follow-up receives a new run ID and generation and creates a requirement only when that follow-up explicitly requests one.
+The runtime bounds retained requirement records per agent and rejects a sixty-fifth unresolved required run before acceptance so every unresolved exact identity fits in the canonical parent context.
+
+## Parent behavior
+
+Pending and available requirements remain final-answer dependencies.
+Visible requirements no longer appear in the canonical context block.
+Cancelled requirements are terminal and must be reported rather than silently treated as successful evidence.
+A failed, partial, interrupted, stale, or cancelled child never satisfies mutating acceptance or independent-verification requirements merely because its turn settled.
+
+## Budget termination
+
+Omitted limits use runtime or agent policy and are recorded as runtime-sourced telemetry.
+Explicit timeout, idle, turn, and tool-call limits remain compatible and are recorded as explicit sources.
+A limit stop with non-empty successful bounded finalization becomes a typed `partial` outcome with the exact termination reason.
+Empty finalization, failed finalization, malformed required structured output, and transport failures remain failed or contract-invalid.
+Partial evidence is available to the parent but is not successful verification or mutating acceptance.
+
+## Pi core boundary
+
+The inspected supported Pi runtime emits provider `message_update` events before the TUI, RPC, JSON, and SDK surfaces display them.
+An extension `message_end` handler can replace the finalized same-role message but cannot retract previously displayed deltas.
+Steering is queued after the extension `input` event, direct RPC steering bypasses that event, and tool abort signals do not observe every accepted steer.
+Therefore an extension cannot provide a hard pre-display final-answer barrier or a reliably steer-interruptible join across all supported modes.
+`subagent_await` remains the bounded non-polling compatibility join and accurately states that queued steering is blocked until the tool settles.
+
+A future core implementation would need replay-safe post-enqueue input activity, exact session-owned blocker handles, pre-display buffering or suppression, bounded timeout, and abort, replacement, reload, shutdown, and headless-mode semantics.
+This repository does not modify or publish Pi core packages for this work.
+
+## Codex reference
+
+Codex `wait_agent` uses replay-safe pending activity plus an event-driven watch receiver for mailbox and steering activity.
+Codex completion context uses a typed `FINAL_ANSWER` envelope with explicit task, sender, and payload fields.
+Codex rollout budgets use shared runtime-owned accounting and acknowledge reminders only after context insertion.
+These patterns inform waiting, completion identity, and budget ownership, but Codex also does not provide an absolute pre-display final-answer barrier.
+
+## Compatibility fallback
+
+Older persisted agents without requirement metadata behave as background work.
+Current Pi versions continue using bounded persisted at-least-once completion delivery and optional idle-root auto-resume.
+The package must not claim that prompt guidance, context injection, automatic delivery, or finalized-message replacement is a hard barrier.
+The deprecated synchronous `subagent` tool remains available for unmatched chain, fan-in, panel, workflow, and compatibility callers.

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -16,6 +16,7 @@
 	"files": [
 		"src",
 		"dist",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/pi-subagents/src/async-subagent-benchmark.ts
+++ b/packages/pi-subagents/src/async-subagent-benchmark.ts
@@ -1,0 +1,532 @@
+export const ASYNC_SUBAGENT_BENCHMARK_VERSION = "pi-subagents:async-surface-benchmark:v1" as const;
+
+export const BENCHMARK_RESULT_PREFIX = "BENCHMARK_RESULT_JSON:";
+export const BENCHMARK_MODES = ["quick", "extended"] as const;
+export const BENCHMARK_ARMS = ["sync", "async"] as const;
+export const BENCHMARK_THINKING_LEVELS = [
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const;
+
+export type AsyncSubagentBenchmarkMode = (typeof BENCHMARK_MODES)[number];
+export type AsyncSubagentBenchmarkArm = (typeof BENCHMARK_ARMS)[number];
+export type AsyncSubagentBenchmarkThinkingLevel = (typeof BENCHMARK_THINKING_LEVELS)[number];
+export type AsyncSubagentTerminalOutcome =
+	| "completed"
+	| "invalid-output"
+	| "timed-out"
+	| "readiness-timeout"
+	| "process-error"
+	| "protocol-error";
+
+export const FIXED_BENCHMARK_TASK = [
+	"Inspect only packages/pi-subagents/src/registry.ts, packages/pi-subagents/src/completion-delivery.ts, and packages/pi-subagents/src/stateful-registration.ts.",
+	"Report what AgentRegistry.wait races, how completion IDs prevent duplicate delivery, and which session hook closes retained completion delivery state.",
+	"Cite each finding with its repository-relative source path and exact symbol or operation.",
+	"Do not modify files.",
+].join("\n");
+
+export const FIXED_EVIDENCE_RUBRIC = [
+	{
+		id: "registry-wait-race",
+		terms: ["packages/pi-subagents/src/registry.ts", "promise.race"],
+	},
+	{
+		id: "completion-id-deduplication",
+		terms: ["packages/pi-subagents/src/completion-delivery.ts", "completionid"],
+	},
+	{
+		id: "session-shutdown-cleanup",
+		terms: ["packages/pi-subagents/src/stateful-registration.ts", "session_shutdown"],
+	},
+] as const;
+
+export interface AsyncSubagentBenchmarkOptions {
+	mode: AsyncSubagentBenchmarkMode;
+	model: string;
+	thinkingLevel: AsyncSubagentBenchmarkThinkingLevel;
+	timeoutMs: number;
+	readinessTimeoutMs: number;
+	outputPath?: string;
+	run: boolean;
+	piCommand: string;
+	workspace?: string;
+	extension?: string;
+}
+
+export interface AsyncSubagentBenchmarkTrialPlan {
+	pairIndex: number;
+	orderIndex: number;
+	arm: AsyncSubagentBenchmarkArm;
+}
+
+export interface AsyncSubagentEventAnalysis {
+	completionObserved: boolean;
+	evidenceScore: number;
+	matchedEvidence: string[];
+	prematureFinalCount: number;
+	finalAnswer?: string;
+	resultMarker?: Record<string, unknown>;
+}
+
+export interface AsyncSubagentBenchmarkTrialRecord extends AsyncSubagentEventAnalysis {
+	version: typeof ASYNC_SUBAGENT_BENCHMARK_VERSION;
+	pairIndex: number;
+	orderIndex: number;
+	arm: AsyncSubagentBenchmarkArm;
+	outcome: AsyncSubagentTerminalOutcome;
+	readinessMs: number;
+	elapsedMs: number;
+	cost: number | null;
+	startedAt: string;
+	completedAt: string;
+	events: unknown[];
+	stderr?: string;
+	error?: string;
+}
+
+export interface DistributionSummary {
+	median: number;
+	p95: number;
+}
+
+export interface AsyncSubagentArmSummary {
+	trials: number;
+	completionCoverage: number;
+	evidenceScore: number;
+	prematureFinalCount: number;
+	terminalOutcomes: Record<AsyncSubagentTerminalOutcome, number>;
+	latencyMs: DistributionSummary | null;
+	cost: {
+		available: number;
+		total: number;
+		median: number;
+		p95: number;
+	} | null;
+}
+
+export interface AsyncSubagentBenchmarkSummary {
+	version: typeof ASYNC_SUBAGENT_BENCHMARK_VERSION;
+	pairs: number;
+	arms: Record<AsyncSubagentBenchmarkArm, AsyncSubagentArmSummary>;
+}
+
+export class BenchmarkDeadlineError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "BenchmarkDeadlineError";
+	}
+}
+
+export function parseAsyncSubagentBenchmarkArgs(
+	args: readonly string[],
+): AsyncSubagentBenchmarkOptions {
+	let mode: AsyncSubagentBenchmarkMode = "quick";
+	let model = "";
+	let thinkingLevel: AsyncSubagentBenchmarkThinkingLevel = "medium";
+	let timeoutMs = 120_000;
+	let readinessTimeoutMs = 15_000;
+	let outputPath: string | undefined;
+	let run = false;
+	let piCommand = "pi";
+	let workspace: string | undefined;
+	let extension: string | undefined;
+
+	for (let index = 0; index < args.length; index++) {
+		const argument = args[index];
+		if (argument === "--run") {
+			run = true;
+			continue;
+		}
+		const value = args[index + 1];
+		if (!value || value.startsWith("--")) throw new Error(`${argument} requires a value`);
+		index++;
+		switch (argument) {
+			case "--mode":
+				if (!isOneOf(value, BENCHMARK_MODES)) throw new Error("--mode must be quick or extended");
+				mode = value;
+				break;
+			case "--model":
+				model = value.trim();
+				break;
+			case "--thinking":
+				if (!isOneOf(value, BENCHMARK_THINKING_LEVELS)) {
+					throw new Error(`Unsupported thinking level: ${value}`);
+				}
+				thinkingLevel = value;
+				break;
+			case "--timeout-ms":
+				timeoutMs = positiveInteger(value, "--timeout-ms");
+				break;
+			case "--readiness-timeout-ms":
+				readinessTimeoutMs = positiveInteger(value, "--readiness-timeout-ms");
+				break;
+			case "--output":
+				outputPath = value;
+				break;
+			case "--pi":
+				piCommand = value;
+				break;
+			case "--workspace":
+				workspace = value;
+				break;
+			case "--extension":
+				extension = value;
+				break;
+			default:
+				throw new Error(`Unknown benchmark argument: ${argument}`);
+		}
+	}
+	if (!model) throw new Error("--model is required so every paired trial uses one fixed model");
+	if (run && !outputPath) throw new Error("--output is required with --run");
+	return {
+		mode,
+		model,
+		thinkingLevel,
+		timeoutMs,
+		readinessTimeoutMs,
+		outputPath,
+		run,
+		piCommand,
+		...(workspace ? { workspace } : {}),
+		...(extension ? { extension } : {}),
+	};
+}
+
+export function benchmarkPairCount(mode: AsyncSubagentBenchmarkMode): number {
+	return mode === "quick" ? 3 : 10;
+}
+
+export function createAlternatingTrialPlan(
+	mode: AsyncSubagentBenchmarkMode,
+): AsyncSubagentBenchmarkTrialPlan[] {
+	const trials: AsyncSubagentBenchmarkTrialPlan[] = [];
+	for (let pairIndex = 0; pairIndex < benchmarkPairCount(mode); pairIndex++) {
+		const order: readonly AsyncSubagentBenchmarkArm[] =
+			pairIndex % 2 === 0 ? ["sync", "async"] : ["async", "sync"];
+		for (const [orderIndex, arm] of order.entries()) {
+			trials.push({ pairIndex, orderIndex, arm });
+		}
+	}
+	return trials;
+}
+
+export function buildAsyncSubagentBenchmarkPrompt(
+	arm: AsyncSubagentBenchmarkArm,
+	thinkingLevel: AsyncSubagentBenchmarkThinkingLevel = "medium",
+): string {
+	const orchestration =
+		arm === "sync"
+			? [
+					"Use the deprecated subagent tool in single mode exactly once with agent explorer.",
+					`Set thinkingLevel to ${thinkingLevel}, pass the fixed task below, and wait for the blocking result.`,
+				]
+			: [
+					"Use subagent_spawn exactly once with agent explorer, context none, and completionRequirement required.",
+					`Set thinkingLevel to ${thinkingLevel}, continue only useful non-overlapping local work, and rely on automatic completion delivery without calling any blocking or inspection tool.`,
+					"Do not provide the benchmark result before the retained completion is visible or terminal.",
+				];
+	return [
+		"This is a non-interactive paired benchmark.",
+		...orchestration,
+		"Use the configured model without changing it.",
+		"Fixed child task:",
+		FIXED_BENCHMARK_TASK,
+		"After observing the child result, answer concisely with all three requested findings.",
+		`End with one single-line marker in this exact form: ${BENCHMARK_RESULT_PREFIX} {"complete":true}`,
+	].join("\n\n");
+}
+
+export function parseBenchmarkJsonLines(source: string): unknown[] {
+	const values: unknown[] = [];
+	for (const [index, rawLine] of source.split("\n").entries()) {
+		const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+		if (!line) continue;
+		try {
+			values.push(JSON.parse(line));
+		} catch {
+			throw new Error(`Invalid benchmark JSONL at line ${index + 1}`);
+		}
+	}
+	return values;
+}
+
+export function analyzeBenchmarkEvents(
+	arm: AsyncSubagentBenchmarkArm,
+	events: readonly unknown[],
+): AsyncSubagentEventAnalysis {
+	let completionIndex = -1;
+	let spawnObserved = false;
+	let prematureFinalCount = 0;
+	let finalAnswer: string | undefined;
+	let resultMarker: Record<string, unknown> | undefined;
+	let finalIndex = -1;
+
+	for (const [index, value] of events.entries()) {
+		if (!isRecord(value)) continue;
+		const message =
+			value.type === "message_end" && isRecord(value.message) ? value.message : undefined;
+		if (!message) continue;
+		if (message.role === "custom" && message.customType === "pi-subagent-completion") {
+			if (completionIndex < 0) completionIndex = index;
+			continue;
+		}
+		if (message.role === "toolResult") {
+			const toolName = typeof message.toolName === "string" ? message.toolName : "";
+			const details = isRecord(message.details) ? message.details : undefined;
+			if (toolName === "subagent_spawn" && message.isError !== true) spawnObserved = true;
+			if (
+				message.isError !== true &&
+				details?.timedOut !== true &&
+				((arm === "sync" && toolName === "subagent") ||
+					(arm === "async" && toolName === "subagent_await"))
+			) {
+				if (completionIndex < 0) completionIndex = index;
+			}
+			continue;
+		}
+		if (message.role !== "assistant") continue;
+		const content = Array.isArray(message.content) ? message.content : [];
+		const hasToolCall = content.some(
+			(item) => isRecord(item) && item.type === "toolCall" && typeof item.name === "string",
+		);
+		if (
+			content.some(
+				(item) => isRecord(item) && item.type === "toolCall" && item.name === "subagent_spawn",
+			)
+		) {
+			spawnObserved = true;
+		}
+		const text = messageText(message);
+		const marker = extractResultMarker(text);
+		if (marker) {
+			if (arm === "async" && spawnObserved && completionIndex < 0) prematureFinalCount++;
+			finalAnswer = text;
+			resultMarker = marker;
+			finalIndex = index;
+		} else if (
+			arm === "async" &&
+			spawnObserved &&
+			completionIndex < 0 &&
+			text.trim() &&
+			!hasToolCall &&
+			scoreBenchmarkEvidence(text).score > 0
+		) {
+			prematureFinalCount++;
+		}
+	}
+
+	const score = scoreBenchmarkEvidence(finalAnswer ?? "");
+	return {
+		completionObserved: completionIndex >= 0 && (finalIndex < 0 || completionIndex < finalIndex),
+		evidenceScore: score.score,
+		matchedEvidence: score.matched,
+		prematureFinalCount,
+		...(finalAnswer ? { finalAnswer } : {}),
+		...(resultMarker ? { resultMarker } : {}),
+	};
+}
+
+export function scoreBenchmarkEvidence(text: string): { score: number; matched: string[] } {
+	const normalized = text.toLowerCase().replaceAll("`", "");
+	const matched = FIXED_EVIDENCE_RUBRIC.filter((item) =>
+		item.terms.every((term) => normalized.includes(term.toLowerCase())),
+	).map((item) => item.id);
+	return {
+		score: round(matched.length / FIXED_EVIDENCE_RUBRIC.length),
+		matched,
+	};
+}
+
+export function percentile(values: readonly number[], quantile: number): number {
+	if (values.length === 0) throw new Error("Cannot calculate a percentile without values");
+	if (!Number.isFinite(quantile) || quantile < 0 || quantile > 1) {
+		throw new Error("Percentile quantile must be between zero and one");
+	}
+	const sorted = [...values].sort((left, right) => left - right);
+	const position = (sorted.length - 1) * quantile;
+	const lower = Math.floor(position);
+	const upper = Math.ceil(position);
+	if (lower === upper) return round(sorted[lower]);
+	return round(sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower));
+}
+
+export function summarizeAsyncSubagentBenchmark(
+	records: readonly AsyncSubagentBenchmarkTrialRecord[],
+): AsyncSubagentBenchmarkSummary {
+	const summarizeArm = (arm: AsyncSubagentBenchmarkArm): AsyncSubagentArmSummary => {
+		const selected = records.filter((record) => record.arm === arm);
+		const completed = selected.filter((record) => record.outcome === "completed");
+		const costs = selected.flatMap((record) => (record.cost === null ? [] : [record.cost]));
+		const terminalOutcomes = emptyTerminalOutcomes();
+		for (const record of selected) terminalOutcomes[record.outcome]++;
+		return {
+			trials: selected.length,
+			completionCoverage:
+				selected.length === 0
+					? 0
+					: round(selected.filter((record) => record.completionObserved).length / selected.length),
+			evidenceScore:
+				selected.length === 0
+					? 0
+					: round(
+							selected.reduce((sum, record) => sum + record.evidenceScore, 0) / selected.length,
+						),
+			prematureFinalCount: selected.reduce((sum, record) => sum + record.prematureFinalCount, 0),
+			terminalOutcomes,
+			latencyMs:
+				completed.length === 0
+					? null
+					: {
+							median: percentile(
+								completed.map((record) => record.elapsedMs),
+								0.5,
+							),
+							p95: percentile(
+								completed.map((record) => record.elapsedMs),
+								0.95,
+							),
+						},
+			cost:
+				costs.length === 0
+					? null
+					: {
+							available: costs.length,
+							total: round(costs.reduce((sum, value) => sum + value, 0)),
+							median: percentile(costs, 0.5),
+							p95: percentile(costs, 0.95),
+						},
+		};
+	};
+	return {
+		version: ASYNC_SUBAGENT_BENCHMARK_VERSION,
+		pairs: new Set(records.map((record) => record.pairIndex)).size,
+		arms: { sync: summarizeArm("sync"), async: summarizeArm("async") },
+	};
+}
+
+export async function runAfterReadinessWithDeadline<T>(
+	readiness: Promise<unknown>,
+	run: () => Promise<T>,
+	timeoutMs: number,
+): Promise<T> {
+	await readiness;
+	return await withDeadline(run(), timeoutMs, "Benchmark trial timed out");
+}
+
+export async function withDeadline<T>(
+	operation: Promise<T>,
+	timeoutMs: number,
+	message: string,
+): Promise<T> {
+	if (!Number.isFinite(timeoutMs) || timeoutMs < 1) throw new Error("Deadline must be positive");
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			operation,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new BenchmarkDeadlineError(message)), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+export function redactBenchmarkValue(value: unknown): unknown {
+	return redactValue(value, new WeakSet<object>());
+}
+
+function extractResultMarker(text: string): Record<string, unknown> | undefined {
+	for (const line of text.split("\n").reverse()) {
+		const markerIndex = line.indexOf(BENCHMARK_RESULT_PREFIX);
+		if (markerIndex < 0) continue;
+		const source = line.slice(markerIndex + BENCHMARK_RESULT_PREFIX.length).trim();
+		try {
+			const parsed: unknown = JSON.parse(source);
+			if (isRecord(parsed) && parsed.complete === true) return parsed;
+		} catch {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
+function messageText(message: Record<string, unknown>): string {
+	if (typeof message.content === "string") return message.content;
+	if (!Array.isArray(message.content)) return "";
+	return message.content
+		.flatMap((item) =>
+			isRecord(item) && item.type === "text" && typeof item.text === "string" ? [item.text] : [],
+		)
+		.join("\n");
+}
+
+function emptyTerminalOutcomes(): Record<AsyncSubagentTerminalOutcome, number> {
+	return {
+		completed: 0,
+		"invalid-output": 0,
+		"timed-out": 0,
+		"readiness-timeout": 0,
+		"process-error": 0,
+		"protocol-error": 0,
+	};
+}
+
+function redactValue(value: unknown, seen: WeakSet<object>): unknown {
+	if (typeof value === "string") return redactString(value);
+	if (Array.isArray(value)) return value.map((item) => redactValue(item, seen));
+	if (!isRecord(value)) return value;
+	if (seen.has(value)) return "[circular]";
+	seen.add(value);
+	const redacted: Record<string, unknown> = {};
+	for (const [key, item] of Object.entries(value)) {
+		redacted[key] = sensitiveKey(key) ? "[redacted]" : redactValue(item, seen);
+	}
+	return redacted;
+}
+
+function redactString(value: string): string {
+	const home = process.env.HOME;
+	let redacted = value.replace(/<private>[\s\S]*?<\/private>/giu, "[private content omitted]");
+	redacted = redacted.replace(/\bBearer\s+[A-Za-z0-9._~+/-]+=*/giu, "Bearer [redacted]");
+	redacted = redacted.replace(/\b(sk-[A-Za-z0-9_-]{12,})\b/gu, "[redacted-key]");
+	redacted = redacted.replace(
+		/\b([A-Z][A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY))=([^\s]+)/gu,
+		"$1=[redacted]",
+	);
+	if (home) redacted = redacted.split(home).join("$HOME");
+	const limit = 16 * 1024;
+	return redacted.length <= limit ? redacted : `${redacted.slice(0, limit)}\n[truncated]`;
+}
+
+function sensitiveKey(key: string): boolean {
+	return /^(?:authorization|api[-_]?key|token|secret|password|headers|environment|env)$/iu.test(
+		key,
+	);
+}
+
+function positiveInteger(value: string, name: string): number {
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 2_147_483_647) {
+		throw new Error(`${name} must be a positive integer`);
+	}
+	return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isOneOf<const T extends readonly string[]>(value: string, values: T): value is T[number] {
+	return values.includes(value);
+}
+
+function round(value: number): number {
+	return Number(value.toFixed(3));
+}

--- a/packages/pi-subagents/src/completion-delivery.ts
+++ b/packages/pi-subagents/src/completion-delivery.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { CompletionDelivery } from "./agents/types.js";
 import { SUBAGENT_COMPLETION_MESSAGE_TYPE } from "./completion-render.js";
+import { requirementForCompletion } from "./completion-requirement.js";
 import { redactPrivateText } from "./context.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, MAX_TOOL_MESSAGE_BYTES, truncateUtf8 } from "./limits.js";
 import type { AgentTurnCompletion, ManagedAgent } from "./registry.js";
@@ -27,6 +28,7 @@ interface CompletionMetadata {
 	structuredResult?: ManagedAgent["structuredResult"];
 	outcome?: ManagedAgent["outcome"];
 	capabilityGrant?: ManagedAgent["capabilityGrant"];
+	completionRequirement?: NonNullable<ManagedAgent["completionRequirements"]>[number];
 }
 
 interface CompletionMessage {
@@ -339,6 +341,7 @@ function buildCompletionMessage(completions: AgentTurnCompletion[]): CompletionM
 }
 
 function completionMetadata(completion: AgentTurnCompletion): CompletionMetadata {
+	const completionRequirement = requirementForCompletion(completion.agent, completion.completionId);
 	return {
 		protocol: PI_SUBAGENTS_RPC_PROTOCOL,
 		completionId: completion.completionId,
@@ -360,6 +363,7 @@ function completionMetadata(completion: AgentTurnCompletion): CompletionMetadata
 		...(completion.agent.capabilityGrant
 			? { capabilityGrant: completion.agent.capabilityGrant }
 			: {}),
+		...(completionRequirement ? { completionRequirement } : {}),
 	};
 }
 

--- a/packages/pi-subagents/src/completion-render.ts
+++ b/packages/pi-subagents/src/completion-render.ts
@@ -139,6 +139,7 @@ function renderStatus(state: string): RenderStatus {
 			return "interrupted";
 		case "closed":
 			return "closed";
+		case "partial":
 		case "blocked":
 		case "needs-input":
 		case "abstained":

--- a/packages/pi-subagents/src/completion-requirement.ts
+++ b/packages/pi-subagents/src/completion-requirement.ts
@@ -1,0 +1,308 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { ContextEvent } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
+import type { AgentLifecycleState, ManagedAgent } from "./registry-types.js";
+
+export const COMPLETION_REQUIREMENT_MODES = ["background", "required"] as const;
+export type CompletionRequirementMode = (typeof COMPLETION_REQUIREMENT_MODES)[number];
+
+export const CompletionRequirementModeSchema = StringEnum(COMPLETION_REQUIREMENT_MODES, {
+	description:
+		"Mark this exact turn as background (default) or required for the parent final answer. Required results are tracked until their exact completion becomes visible, but current Pi versions do not provide a hard pre-display final-answer barrier.",
+	default: "background",
+});
+
+export const COMPLETION_REQUIREMENT_VERSION = "pi-subagents:completion-requirement:v1" as const;
+export const COMPLETION_REQUIREMENT_CONTEXT_TYPE = "pi-subagent-required-completions";
+const MAX_REQUIREMENTS_PER_AGENT = 20;
+export const MAX_UNRESOLVED_REQUIRED_COMPLETIONS = 64;
+
+export type CompletionRequirementState = "pending" | "available" | "visible" | "cancelled";
+
+export interface CompletionRequirementRecord {
+	version: typeof COMPLETION_REQUIREMENT_VERSION;
+	runId: string;
+	generation: number;
+	state: CompletionRequirementState;
+	createdAt: number;
+	updatedAt: number;
+	completionId?: string;
+	terminalState?: AgentLifecycleState;
+}
+
+export function beginCompletionRequirement(
+	records: readonly CompletionRequirementRecord[] | undefined,
+	input: { runId: string; generation: number; createdAt: number },
+): CompletionRequirementRecord[] {
+	const retained = (records ?? []).filter(
+		(record) => record.runId !== input.runId || record.generation !== input.generation,
+	);
+	retained.push({
+		version: COMPLETION_REQUIREMENT_VERSION,
+		runId: input.runId,
+		generation: input.generation,
+		state: "pending",
+		createdAt: input.createdAt,
+		updatedAt: input.createdAt,
+	});
+	return retained.slice(-MAX_REQUIREMENTS_PER_AGENT);
+}
+
+export function makeCompletionAvailable(
+	records: readonly CompletionRequirementRecord[] | undefined,
+	input: {
+		runId: string;
+		generation: number;
+		completionId: string;
+		terminalState: AgentLifecycleState;
+		updatedAt: number;
+	},
+): CompletionRequirementRecord[] | undefined {
+	return updateExact(records, input.runId, input.generation, (record) => ({
+		...record,
+		state: "available",
+		completionId: input.completionId,
+		terminalState: input.terminalState,
+		updatedAt: input.updatedAt,
+	}));
+}
+
+export function makeCompletionVisible(
+	records: readonly CompletionRequirementRecord[] | undefined,
+	completionId: string,
+	updatedAt: number,
+): CompletionRequirementRecord[] | undefined {
+	if (!records?.some((record) => record.completionId === completionId)) {
+		return records?.map((record) => ({ ...record }));
+	}
+	return records.map((record) =>
+		record.completionId === completionId
+			? { ...record, state: "visible" as const, updatedAt }
+			: { ...record },
+	);
+}
+
+export function cancelPendingCompletionRequirements(
+	records: readonly CompletionRequirementRecord[] | undefined,
+	terminalState: AgentLifecycleState,
+	updatedAt: number,
+): CompletionRequirementRecord[] | undefined {
+	if (!records?.some((record) => record.state === "pending")) {
+		return records?.map((record) => ({ ...record }));
+	}
+	return records.map((record) =>
+		record.state === "pending"
+			? {
+					...record,
+					state: "cancelled" as const,
+					terminalState,
+					updatedAt,
+				}
+			: { ...record },
+	);
+}
+
+export function requirementForCompletion(
+	agent: Pick<ManagedAgent, "completionRequirements">,
+	completionId: string,
+): CompletionRequirementRecord | undefined {
+	return agent.completionRequirements?.find((record) => record.completionId === completionId);
+}
+
+export interface BranchCompletionRequirementState {
+	observedState: boolean;
+	records: Map<string, CompletionRequirementRecord>;
+	keys: Set<string>;
+}
+
+export function completionRequirementKey(
+	record: Pick<CompletionRequirementRecord, "runId" | "generation">,
+): string {
+	return `${record.runId}\u0000${record.generation}`;
+}
+
+export function completionRequirementsFromBranch(
+	entries: readonly unknown[],
+): BranchCompletionRequirementState {
+	const records = new Map<string, CompletionRequirementRecord>();
+	let observedState = false;
+	for (const entry of entries) {
+		if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+		const candidate = entry as Record<string, unknown>;
+		const message =
+			candidate.type === "message" && candidate.message && typeof candidate.message === "object"
+				? (candidate.message as Record<string, unknown>)
+				: candidate;
+		if (
+			message.role === "toolResult" &&
+			["subagent_spawn", "subagent_send", "subagent_await", "subagent_manage"].includes(
+				String(message.toolName),
+			)
+		) {
+			observedState = true;
+			const details = message.details;
+			if (!details || typeof details !== "object" || Array.isArray(details)) continue;
+			const detailsRecord = details as Record<string, unknown>;
+			const agents = [
+				detailsRecord.agent,
+				...(Array.isArray(detailsRecord.agents) ? detailsRecord.agents : []),
+			];
+			for (const agent of agents) {
+				if (!agent || typeof agent !== "object" || Array.isArray(agent)) continue;
+				const requirements = (agent as Record<string, unknown>).completionRequirements;
+				if (!Array.isArray(requirements)) continue;
+				for (const requirement of requirements) {
+					if (isCompletionRequirementRecord(requirement)) {
+						records.set(completionRequirementKey(requirement), { ...requirement });
+					}
+				}
+			}
+			continue;
+		}
+		if (message.role !== "custom" || message.customType !== "pi-subagent-completion") continue;
+		const details = message.details;
+		if (!details || typeof details !== "object" || Array.isArray(details)) continue;
+		const detailRecord = details as Record<string, unknown>;
+		const completionRecords = Array.isArray(detailRecord.completions)
+			? detailRecord.completions
+			: [detailRecord];
+		for (const completion of completionRecords) {
+			if (!completion || typeof completion !== "object" || Array.isArray(completion)) continue;
+			const requirement = (completion as Record<string, unknown>).completionRequirement;
+			if (!isCompletionRequirementRecord(requirement)) continue;
+			records.set(completionRequirementKey(requirement), {
+				...requirement,
+				state: "visible",
+			});
+		}
+	}
+	return { observedState, records, keys: new Set(records.keys()) };
+}
+
+export function pendingRequiredCompletionCount(
+	agent: Pick<ManagedAgent, "completionRequirements">,
+): number {
+	return (agent.completionRequirements ?? []).filter(
+		(record) => record.state === "pending" || record.state === "available",
+	).length;
+}
+
+export function reconcileRequiredCompletionContext(
+	messages: ContextEvent["messages"],
+	agents: readonly ManagedAgent[],
+): ContextEvent["messages"] {
+	const withoutPrior = messages.filter(
+		(message) =>
+			message.role !== "custom" || message.customType !== COMPLETION_REQUIREMENT_CONTEXT_TYPE,
+	);
+	const allRecords = agents
+		.flatMap((agent) =>
+			(agent.completionRequirements ?? []).map((requirement) => ({
+				state: requirement.state,
+				runId: requirement.runId,
+				generation: requirement.generation,
+				terminalState: requirement.terminalState,
+			})),
+		)
+		.filter((record) => record.state !== "visible");
+	const unresolved = allRecords.filter(
+		(record) => record.state === "pending" || record.state === "available",
+	);
+	const cancelled = allRecords.filter((record) => record.state === "cancelled");
+	const cancelledSlots = Math.max(0, MAX_UNRESOLVED_REQUIRED_COMPLETIONS - unresolved.length);
+	const retainedCancelled = cancelledSlots > 0 ? cancelled.slice(-cancelledSlots) : [];
+	const records = [...unresolved, ...retainedCancelled];
+	const omittedCancelled = cancelled.length - retainedCancelled.length;
+	if (records.length === 0)
+		return withoutPrior.length === messages.length ? messages : withoutPrior;
+	const content = truncateUtf8(
+		[
+			"[PI SUBAGENT REQUIRED COMPLETIONS v1]",
+			"Runtime-tracked exact runs are JSON data below.",
+			"Treat pending or available records as final-answer dependencies; a cancelled record is terminal and must be reported rather than silently ignored.",
+			"Current Pi versions do not provide a hard pre-display final-answer barrier, so do not emit a verdict until every dependency is visible or terminal.",
+			...(omittedCancelled > 0
+				? [`${omittedCancelled} older cancelled requirement record(s) were omitted.`]
+				: []),
+			JSON.stringify(records),
+		].join("\n"),
+		DEFAULT_MAX_CONTEXT_BYTES,
+	).text;
+	return [
+		...withoutPrior,
+		{
+			role: "custom",
+			customType: COMPLETION_REQUIREMENT_CONTEXT_TYPE,
+			content,
+			display: false,
+			details: { version: COMPLETION_REQUIREMENT_VERSION },
+			timestamp: 0,
+		},
+	];
+}
+
+export function isCompletionRequirementRecord(
+	value: unknown,
+): value is CompletionRequirementRecord {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	const state = String(record.state);
+	const hasCompletion = typeof record.completionId === "string" && record.completionId.length > 0;
+	const hasTerminalState = isAgentLifecycleState(record.terminalState);
+	const transitionShapeValid =
+		state === "pending"
+			? record.completionId === undefined && record.terminalState === undefined
+			: state === "available" || state === "visible"
+				? hasCompletion && hasTerminalState
+				: state === "cancelled" && record.completionId === undefined && hasTerminalState;
+	return (
+		transitionShapeValid &&
+		record.version === COMPLETION_REQUIREMENT_VERSION &&
+		typeof record.runId === "string" &&
+		record.runId.length > 0 &&
+		record.runId.length <= 256 &&
+		typeof record.generation === "number" &&
+		Number.isSafeInteger(record.generation) &&
+		record.generation >= 1 &&
+		["pending", "available", "visible", "cancelled"].includes(state) &&
+		typeof record.createdAt === "number" &&
+		Number.isFinite(record.createdAt) &&
+		typeof record.updatedAt === "number" &&
+		Number.isFinite(record.updatedAt) &&
+		record.updatedAt >= record.createdAt &&
+		(record.completionId === undefined ||
+			(typeof record.completionId === "string" && record.completionId.length <= 256)) &&
+		(record.terminalState === undefined || isAgentLifecycleState(record.terminalState))
+	);
+}
+
+function updateExact(
+	records: readonly CompletionRequirementRecord[] | undefined,
+	runId: string,
+	generation: number,
+	update: (record: CompletionRequirementRecord) => CompletionRequirementRecord,
+): CompletionRequirementRecord[] | undefined {
+	if (!records?.some((record) => record.runId === runId && record.generation === generation)) {
+		return records?.map((record) => ({ ...record }));
+	}
+	return records.map((record) =>
+		record.runId === runId && record.generation === generation ? update(record) : { ...record },
+	);
+}
+
+function isAgentLifecycleState(value: unknown): value is AgentLifecycleState {
+	return [
+		"starting",
+		"running",
+		"idle",
+		"completed",
+		"partial",
+		"blocked",
+		"needs-input",
+		"abstained",
+		"stale",
+		"interrupted",
+		"failed",
+		"closed",
+	].includes(String(value));
+}

--- a/packages/pi-subagents/src/inspect.ts
+++ b/packages/pi-subagents/src/inspect.ts
@@ -347,6 +347,9 @@ function projectRunSummary(run: AgentRunInspectionSummary): Record<string, unkno
 		unreadMessages: run.unreadMessages,
 		turnGeneration: run.turnGeneration,
 		pendingCompletionCount: run.pendingCompletionCount,
+		...(run.pendingRequiredCompletionCount === undefined
+			? {}
+			: { pendingRequiredCompletionCount: run.pendingRequiredCompletionCount }),
 	};
 }
 
@@ -382,6 +385,9 @@ function projectRun(run: AgentRunInspectionDetail, ctx: ExtensionContext): Recor
 				}
 			: undefined,
 		resultFormat: run.resultFormat ?? "text",
+		completionRequirements: (run.completionRequirements ?? []).map((requirement) => ({
+			...requirement,
+		})),
 		structuredResult: run.structuredResult,
 		termination: run.termination,
 		outcome: run.outcome,

--- a/packages/pi-subagents/src/persistence.ts
+++ b/packages/pi-subagents/src/persistence.ts
@@ -5,6 +5,7 @@ import { getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-ag
 import { projectAgentRecords } from "./agent-projection.js";
 import { isThinkingLevel } from "./agents/types.js";
 import { isCapabilityGrant, revokeCapabilityGrant } from "./capability-grant.js";
+import { isCompletionRequirementRecord } from "./completion-requirement.js";
 import { redactPrivateText } from "./context.js";
 import { normalizeDelegationContract } from "./delegation-contract.js";
 import { copyExecutionPlan, isExecutionPlan } from "./execution-plan.js";
@@ -171,6 +172,10 @@ function sanitizeAgent(agent: ManagedAgent): ManagedAgent {
 				output: redactPrivateText(completion.output),
 				error: completion.error ? redactPrivateText(completion.error) : undefined,
 			})),
+		completionRequirements: (agent.completionRequirements ?? [])
+			.filter(isCompletionRequirementRecord)
+			.slice(-MAX_STORED_COMPLETIONS_PER_AGENT)
+			.map((record) => ({ ...record })),
 		currentTimeoutMs: undefined,
 		currentIdleTimeoutMs: undefined,
 		currentMaxTurns: undefined,
@@ -261,6 +266,10 @@ function isStoredState(value: unknown): value is StoredState {
 			(record.turnGeneration === undefined || isNonNegativeInteger(record.turnGeneration)) &&
 			(record.pendingCompletions === undefined ||
 				isCompletionOutbox(record.pendingCompletions, record.turnGeneration ?? 0)) &&
+			(record.completionRequirements === undefined ||
+				(Array.isArray(record.completionRequirements) &&
+					record.completionRequirements.length <= MAX_STORED_COMPLETIONS_PER_AGENT &&
+					record.completionRequirements.every(isCompletionRequirementRecord))) &&
 			(record.spawnIdempotencyKey === undefined ||
 				(typeof record.spawnIdempotencyKey === "string" &&
 					record.spawnIdempotencyKey.length > 0 &&

--- a/packages/pi-subagents/src/registry-types.ts
+++ b/packages/pi-subagents/src/registry-types.ts
@@ -1,5 +1,6 @@
 import type { SubagentThinkingLevel } from "./agents/types.js";
 import type { CapabilityGrant } from "./capability-grant.js";
+import type { CompletionRequirementRecord } from "./completion-requirement.js";
 import type { TargetPolicyAudit } from "./cwd-policy.js";
 import type { DelegationContract } from "./delegation-contract.js";
 import type { ExecutionPlan } from "./execution-plan.js";
@@ -14,6 +15,7 @@ export type AgentLifecycleState =
 	| "running"
 	| "idle"
 	| "completed"
+	| "partial"
 	| "blocked"
 	| "needs-input"
 	| "abstained"
@@ -85,6 +87,7 @@ export interface ManagedAgent {
 	currentRunId?: string;
 	currentTurnGeneration?: number;
 	pendingCompletions?: PersistedAgentCompletion[];
+	completionRequirements?: CompletionRequirementRecord[];
 	history: AgentTurn[];
 	error?: string;
 	context?: string;
@@ -123,6 +126,7 @@ export interface AgentRunInspectionSummary {
 	unreadMessages: number;
 	turnGeneration: number;
 	pendingCompletionCount: number;
+	pendingRequiredCompletionCount?: number;
 }
 
 export interface AgentRunInspectionDetail extends AgentRunInspectionSummary {
@@ -156,6 +160,7 @@ export interface AgentRunInspectionDetail extends AgentRunInspectionSummary {
 	semanticSnapshot?: SemanticSnapshot;
 	semanticCompatibility?: SemanticCompatibility;
 	termination?: TurnTerminationReport;
+	completionRequirements?: CompletionRequirementRecord[];
 	telemetry?: TransportTelemetry;
 }
 

--- a/packages/pi-subagents/src/registry.ts
+++ b/packages/pi-subagents/src/registry.ts
@@ -10,6 +10,16 @@ import {
 	isCapabilityGrantActive,
 	revokeCapabilityGrant,
 } from "./capability-grant.js";
+import {
+	beginCompletionRequirement,
+	type CompletionRequirementMode,
+	cancelPendingCompletionRequirements,
+	completionRequirementKey,
+	MAX_UNRESOLVED_REQUIRED_COMPLETIONS,
+	makeCompletionAvailable,
+	makeCompletionVisible,
+	pendingRequiredCompletionCount,
+} from "./completion-requirement.js";
 import { resolveCompletionRecipient } from "./completion-routing.js";
 import type { TargetPolicyAudit } from "./cwd-policy.js";
 import type { DelegationContract } from "./delegation-contract.js";
@@ -259,8 +269,19 @@ export class AgentRegistry {
 				mailbox: (record.mailbox ?? [])
 					.slice(-this.maxMailboxMessages)
 					.map((message) => ({ ...message, recipientId: record.id })),
+				completionRequirements: (record.completionRequirements ?? []).map((item) => ({
+					...item,
+				})),
 				history: record.history.slice(-this.maxHistoryTurns).map((turn) => ({ ...turn })),
 			});
+			const restored = this.agents.get(record.id);
+			if (restored && restored.state !== "running" && restored.state !== "starting") {
+				restored.completionRequirements = cancelPendingCompletionRequirements(
+					restored.completionRequirements,
+					restored.state,
+					this.now(),
+				);
+			}
 		}
 		for (const agent of this.agents.values()) {
 			if (agent.parentId) {
@@ -291,6 +312,7 @@ export class AgentRegistry {
 		idleTimeoutMs?: number;
 		maxTurns?: number;
 		maxToolCalls?: number;
+		completionRequirement?: CompletionRequirementMode;
 		parentId?: string;
 		context?: string;
 		contextSourceIds?: string[];
@@ -316,6 +338,7 @@ export class AgentRegistry {
 			input.spawnRequestHash,
 		);
 		if (existing) return existing;
+		this.assertRequiredCompletionCapacity(input.completionRequirement);
 		const task = truncateUtf8(input.task, this.maxTaskBytes).text;
 		const expired = this.evictExpired();
 		let expiryReleaseError: unknown;
@@ -369,6 +392,7 @@ export class AgentRegistry {
 			currentTask: task,
 			turnGeneration: 0,
 			pendingCompletions: [],
+			completionRequirements: [],
 			history: [],
 			mailbox: [],
 			context: input.context,
@@ -393,7 +417,7 @@ export class AgentRegistry {
 			parent.updatedAt = now;
 		}
 		await this.changed();
-		this.startTurn(record, task, input);
+		this.startTurn(record, task, input, input.completionRequirement);
 		return this.copy(record);
 	}
 
@@ -417,7 +441,10 @@ export class AgentRegistry {
 	async followUp(
 		id: string,
 		task: string,
-		options: TurnLimits & { timeoutMs?: number } = {},
+		options: TurnLimits & {
+			timeoutMs?: number;
+			completionRequirement?: CompletionRequirementMode;
+		} = {},
 	): Promise<ManagedAgent> {
 		if (!task.trim()) throw new Error("Subagent tasks cannot be empty");
 		if (options.timeoutMs !== undefined) validateTurnTimeout(options.timeoutMs);
@@ -428,6 +455,7 @@ export class AgentRegistry {
 			![
 				"idle",
 				"completed",
+				"partial",
 				"blocked",
 				"needs-input",
 				"abstained",
@@ -438,9 +466,10 @@ export class AgentRegistry {
 		) {
 			throw new Error(`Agent ${id} cannot accept follow-up while ${agent.state}`);
 		}
+		this.assertRequiredCompletionCapacity(options.completionRequirement);
 		const unread = agent.mailbox.filter((message) => !message.readAt).slice(-20);
 		agent.currentMailboxMessageIds = unread.map((message) => message.id);
-		this.startTurn(agent, boundedTask, options);
+		this.startTurn(agent, boundedTask, options, options.completionRequirement);
 		return this.copy(agent);
 	}
 
@@ -628,6 +657,13 @@ export class AgentRegistry {
 					createdAt: this.completionCreatedAt(),
 				};
 				agent.state = "interrupted";
+				agent.completionRequirements = makeCompletionAvailable(agent.completionRequirements, {
+					runId: persistedCompletion.runId,
+					generation: persistedCompletion.generation,
+					completionId: persistedCompletion.completionId,
+					terminalState: agent.state,
+					updatedAt: persistedCompletion.createdAt,
+				});
 				agent.pendingCompletions = [...(agent.pendingCompletions ?? []), persistedCompletion];
 				this.enqueueCompletionMessage(agent, persistedCompletion, persistedCompletion.error);
 				clearCurrentTurn(agent);
@@ -698,6 +734,11 @@ export class AgentRegistry {
 		await this.running.get(agentId)?.catch(() => undefined);
 		agent.state = "closed";
 		agent.updatedAt = this.now();
+		agent.completionRequirements = cancelPendingCompletionRequirements(
+			agent.completionRequirements,
+			agent.state,
+			agent.updatedAt,
+		);
 		if (agent.parentId) {
 			const parent = this.agents.get(agent.parentId);
 			if (parent) parent.children = parent.children.filter((childId) => childId !== agentId);
@@ -766,6 +807,11 @@ export class AgentRegistry {
 				if (agent.state === "running" || agent.state === "starting") {
 					agent.state = "interrupted";
 				}
+				agent.completionRequirements = cancelPendingCompletionRequirements(
+					agent.completionRequirements,
+					agent.state,
+					this.now(),
+				);
 				clearCurrentTurn(agent);
 			}
 		}
@@ -814,6 +860,9 @@ export class AgentRegistry {
 			currentTask: agent.currentTask,
 			currentRunId: agent.currentRunId,
 			currentTurnGeneration: agent.currentTurnGeneration,
+			completionRequirements: (agent.completionRequirements ?? []).map((record) => ({
+				...record,
+			})),
 			error: agent.error,
 			workspaceMode: agent.workspaceMode,
 			contextTurns: agent.contextTurns,
@@ -864,6 +913,37 @@ export class AgentRegistry {
 		return agent ? this.copy(agent) : undefined;
 	}
 
+	reconcileCompletionRequirements(
+		activeRecords: ReadonlyMap<
+			string,
+			import("./completion-requirement.js").CompletionRequirementRecord
+		>,
+		observedState: boolean,
+	): void {
+		if (!observedState) return;
+		for (const agent of this.agents.values()) {
+			agent.completionRequirements = (agent.completionRequirements ?? []).flatMap((record) => {
+				const restored = activeRecords.get(completionRequirementKey(record));
+				if (!restored) return [];
+				if (
+					restored.state === "pending" &&
+					agent.state !== "running" &&
+					agent.state !== "starting"
+				) {
+					return [
+						{
+							...restored,
+							state: "cancelled" as const,
+							terminalState: "interrupted" as const,
+							updatedAt: Math.max(restored.updatedAt, this.now()),
+						},
+					];
+				}
+				return [{ ...restored }];
+			});
+		}
+	}
+
 	listPendingCompletions(): AgentTurnCompletion[] {
 		return [...this.agents.values()]
 			.flatMap((agent) =>
@@ -889,6 +969,11 @@ export class AgentRegistry {
 			(completion) => completion.completionId === completionId,
 		);
 		if (!acknowledged) return;
+		agent.completionRequirements = makeCompletionVisible(
+			agent.completionRequirements,
+			completionId,
+			deliveredAt,
+		);
 		agent.pendingCompletions = (agent.pendingCompletions ?? []).filter(
 			(completion) => completion.completionId !== completionId,
 		);
@@ -903,6 +988,11 @@ export class AgentRegistry {
 		try {
 			await this.changed(true);
 		} catch (error) {
+			agent.completionRequirements = (agent.completionRequirements ?? []).map((record) =>
+				record.completionId === completionId && record.state === "visible"
+					? { ...record, state: "available", updatedAt: acknowledged.createdAt }
+					: record,
+			);
 			if (
 				!agent.pendingCompletions?.some(
 					(completion) => completion.completionId === acknowledged.completionId,
@@ -937,6 +1027,7 @@ export class AgentRegistry {
 		agent: ManagedAgent,
 		task: string,
 		limits: TurnLimits & { timeoutMs?: number } = {},
+		completionRequirement: CompletionRequirementMode = "background",
 	): void {
 		if ((agent.pendingCompletions?.length ?? 0) >= MAX_PENDING_COMPLETIONS_PER_AGENT) {
 			throw new Error(
@@ -946,6 +1037,13 @@ export class AgentRegistry {
 		agent.turnGeneration = (agent.turnGeneration ?? 0) + 1;
 		agent.currentTurnGeneration = agent.turnGeneration;
 		agent.currentRunId = `run:${agent.id}:${randomUUID()}`;
+		if (completionRequirement === "required") {
+			agent.completionRequirements = beginCompletionRequirement(agent.completionRequirements, {
+				runId: agent.currentRunId,
+				generation: agent.currentTurnGeneration,
+				createdAt: this.now(),
+			});
+		}
 		agent.state = "starting";
 		agent.error = undefined;
 		agent.currentTask = task;
@@ -962,6 +1060,12 @@ export class AgentRegistry {
 			queuePosition: this.queue.length + 1,
 			updatedAt: agent.updatedAt,
 			timing: { queuedAt: agent.updatedAt },
+			budgetSource: {
+				timeout: agent.currentTimeoutMs === undefined ? "runtime" : "explicit",
+				idleTimeout: agent.currentIdleTimeoutMs === undefined ? "runtime" : "explicit",
+				turnLimit: agent.currentMaxTurns === undefined ? "runtime" : "explicit",
+				toolCallLimit: agent.currentMaxToolCalls === undefined ? "runtime" : "explicit",
+			},
 		};
 		let resolveQueued!: (agent: ManagedAgent) => void;
 		const completion = new Promise<ManagedAgent>((resolve) => {
@@ -1007,6 +1111,13 @@ export class AgentRegistry {
 				error: truncateUtf8(agent.error, 512).text,
 				createdAt: this.completionCreatedAt(),
 			};
+			agent.completionRequirements = makeCompletionAvailable(agent.completionRequirements, {
+				runId: persistedCompletion.runId,
+				generation: persistedCompletion.generation,
+				completionId: persistedCompletion.completionId,
+				terminalState: agent.state,
+				updatedAt: persistedCompletion.createdAt,
+			});
 			agent.pendingCompletions = [...(agent.pendingCompletions ?? []), persistedCompletion];
 			this.enqueueCompletionMessage(agent, persistedCompletion, persistedCompletion.error ?? "");
 			clearCurrentTurn(agent);
@@ -1078,20 +1189,25 @@ export class AgentRegistry {
 				agent.history = agent.history.slice(-this.maxHistoryTurns);
 				agent.structuredResult =
 					outcome.structuredResult ?? parseAnyStructuredSubagentResult(output, agent.resultFormat);
-				agent.outcome =
-					outcome.outcome ??
-					(outcome.aborted
-						? classifyStructuredOutcome("interrupted", "transport-aborted")
-						: agent.structuredResult?.version === "pi-subagents:result:v2"
-							? classifyStructuredOutcome(
-									agent.structuredResult.status,
-									agent.structuredResult.reasonCode,
-								)
-							: agent.resultFormat !== undefined &&
-									agent.resultFormat !== "text" &&
-									agent.structuredResult === undefined
-								? classifyStructuredOutcome("contract-invalid", "malformed-structured-result")
-								: undefined);
+				const malformedStructuredResult =
+					agent.resultFormat !== undefined &&
+					agent.resultFormat !== "text" &&
+					agent.structuredResult === undefined;
+				const finalizedPartial =
+					outcome.termination?.finalization.status === "completed" && output.trim().length > 0;
+				agent.outcome = outcome.aborted
+					? classifyStructuredOutcome("interrupted", "transport-aborted")
+					: malformedStructuredResult
+						? classifyStructuredOutcome("contract-invalid", "malformed-structured-result")
+						: finalizedPartial
+							? classifyStructuredOutcome("partial", outcome.termination?.reason)
+							: (outcome.outcome ??
+								(agent.structuredResult?.version === "pi-subagents:result:v2"
+									? classifyStructuredOutcome(
+											agent.structuredResult.status,
+											agent.structuredResult.reasonCode,
+										)
+									: undefined));
 				const staleGeneration = Boolean(
 					acceptedPlanId && agent.executionPlan?.id !== acceptedPlanId,
 				);
@@ -1102,7 +1218,7 @@ export class AgentRegistry {
 					? "stale"
 					: outcome.aborted
 						? "interrupted"
-						: outcome.exitCode !== 0
+						: outcome.exitCode !== 0 && agent.outcome?.status !== "partial"
 							? "failed"
 							: lifecycleStateForOutcome(agent.outcome?.status);
 				agent.error = error;
@@ -1121,6 +1237,7 @@ export class AgentRegistry {
 								queuedAt: agent.telemetry?.timing.queuedAt,
 								...outcome.telemetry.timing,
 							},
+							budgetSource: outcome.telemetry.budgetSource ?? agent.telemetry?.budgetSource,
 						}
 					: agent.telemetry;
 				agent.termination = outcome.termination
@@ -1195,6 +1312,13 @@ export class AgentRegistry {
 					error: completionError ? truncateUtf8(completionError, 512).text : undefined,
 					createdAt: this.completionCreatedAt(),
 				};
+				agent.completionRequirements = makeCompletionAvailable(agent.completionRequirements, {
+					runId,
+					generation: turnGeneration,
+					completionId: persistedCompletion.completionId,
+					terminalState: agent.state,
+					updatedAt: persistedCompletion.createdAt,
+				});
 				agent.pendingCompletions = [...(agent.pendingCompletions ?? []), persistedCompletion];
 				this.enqueueCompletionMessage(agent, persistedCompletion, completionContent);
 				clearCurrentTurn(agent);
@@ -1357,6 +1481,19 @@ export class AgentRegistry {
 		return { taskName, taskPath };
 	}
 
+	private assertRequiredCompletionCapacity(mode: CompletionRequirementMode | undefined): void {
+		if (mode !== "required") return;
+		const unresolved = [...this.agents.values()].reduce(
+			(sum, agent) => sum + pendingRequiredCompletionCount(agent),
+			0,
+		);
+		if (unresolved >= MAX_UNRESOLVED_REQUIRED_COMPLETIONS) {
+			throw new Error(
+				`Required subagent completion capacity reached (${MAX_UNRESOLVED_REQUIRED_COMPLETIONS}); wait for exact completion visibility or terminalize an existing requirement`,
+			);
+		}
+	}
+
 	private retainedCount(): number {
 		return [...this.agents.values()].filter((agent) => agent.state !== "closed").length;
 	}
@@ -1479,6 +1616,7 @@ export class AgentRegistry {
 			unreadMessages,
 			turnGeneration: agent.turnGeneration ?? 0,
 			pendingCompletionCount: agent.pendingCompletions?.length ?? 0,
+			pendingRequiredCompletionCount: pendingRequiredCompletionCount(agent),
 		};
 	}
 
@@ -1492,6 +1630,9 @@ export class AgentRegistry {
 				: undefined,
 			pendingCompletions: (agent.pendingCompletions ?? []).map((completion) => ({
 				...completion,
+			})),
+			completionRequirements: (agent.completionRequirements ?? []).map((record) => ({
+				...record,
 			})),
 			history: agent.history.map((turn) => ({ ...turn })),
 			mailbox: agent.mailbox.map((message) => ({ ...message })),
@@ -1526,6 +1667,8 @@ function lifecycleStateForOutcome(
 	status: import("./result-contract.js").SubagentOutcomeStatus | undefined,
 ): AgentLifecycleState {
 	switch (status) {
+		case "partial":
+			return "partial";
 		case "blocked":
 		case "needs-input":
 		case "abstained":
@@ -1550,5 +1693,6 @@ function copyTelemetry(value: TransportTelemetry): TransportTelemetry {
 		...value,
 		timing: { ...value.timing },
 		usage: value.usage ? { ...value.usage } : undefined,
+		budgetSource: value.budgetSource ? { ...value.budgetSource } : undefined,
 	};
 }

--- a/packages/pi-subagents/src/spawn-idempotency.ts
+++ b/packages/pi-subagents/src/spawn-idempotency.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { AgentScope, SubagentThinkingLevel } from "./agents/types.js";
+import type { CompletionRequirementMode } from "./completion-requirement.js";
 import type { DelegationContract } from "./delegation-contract.js";
 import type { SubagentResultFormat } from "./result-contract.js";
 
@@ -23,6 +24,7 @@ export interface CanonicalSpawnRequest {
 	allowConcurrentWrites: boolean;
 	contract?: DelegationContract;
 	resultFormat: SubagentResultFormat;
+	completionRequirement?: CompletionRequirementMode;
 }
 
 export function hashSpawnRequest(request: CanonicalSpawnRequest): string {
@@ -48,6 +50,9 @@ export function hashSpawnRequest(request: CanonicalSpawnRequest): string {
 				allowConcurrentWrites: request.allowConcurrentWrites,
 				...(request.contract === undefined ? {} : { contract: request.contract }),
 				resultFormat: request.resultFormat,
+				...(request.completionRequirement === "required"
+					? { completionRequirement: "required" }
+					: {}),
 			}),
 		)
 		.digest("hex");

--- a/packages/pi-subagents/src/stateful-agent-view.ts
+++ b/packages/pi-subagents/src/stateful-agent-view.ts
@@ -45,6 +45,9 @@ export function summarizeStatefulAgent(agent: ManagedAgent) {
 			truncated: agent.contextTruncated === true,
 		},
 		resultFormat: agent.resultFormat ?? "text",
+		completionRequirements: (agent.completionRequirements ?? []).map((record) => ({
+			...record,
+		})),
 		structuredResult: agent.structuredResult,
 		termination: agent.termination,
 		outcome: agent.outcome,

--- a/packages/pi-subagents/src/stateful-guidance.ts
+++ b/packages/pi-subagents/src/stateful-guidance.ts
@@ -24,7 +24,7 @@ export function createSpawnPromptGuidelines(
 		deliveryGuidance,
 		...(completionDelivery === "auto-resume"
 			? [
-					"Track every final-answer-dependent subagent_spawn by its returned agentId or taskPath, treat interim output as progress, and synthesize only after every corresponding completion message is visible.",
+					'Track every final-answer-dependent subagent_spawn by setting completionRequirement to "required" and retaining its returned agentId or taskPath; treat interim output as progress, and synthesize only after every corresponding completion message is visible or terminal.',
 				]
 			: []),
 		"Keep ordinary review in the main agent with a review skill and deterministic checks; use subagent_spawn for detached review only when consequential independent verification has concrete parallel value.",
@@ -38,7 +38,7 @@ export function createSpawnPromptGuidelines(
 			: []),
 		"Add another subagent_spawn only for truly independent work with safe workspace concurrency and disjoint write ownership; shared workspaces permit concurrent writes by default, so use workspaceMode worktree when repository isolation is required. The main agent still owns integration.",
 		"After subagent_spawn returns, immediately continue the identified local task; do not merely announce the spawn, wait, poll, or end the response while useful local work remains.",
-		"When final-answer-dependent subagent_spawn work remains active after local work is exhausted, emit at most one brief progress sentence and end the turn; do not repeat waiting updates or use the requested final format, verdict, or conclusion until every required completion is visible.",
+		"When completionRequirement required subagent_spawn work remains active after local work is exhausted, emit at most one brief progress sentence and end the turn; do not repeat waiting updates or use the requested final format, verdict, or conclusion until every required completion is visible or terminal. Current Pi versions do not enforce a hard pre-display barrier.",
 		"Do not duplicate assigned work from subagent_spawn while its retained agent is running; use a bounded parent fallback only after its completion reports failure or insufficient evidence.",
 		'Consume and synthesize available subagent_spawn completion messages; use subagent_manage with action "interrupt" or "close" for agents that are no longer needed.',
 		'Completion from subagent_spawn is delivered automatically. Do not poll with subagent_inspect or subagent_mailbox action "read", repeatedly check progress, or duplicate the delegated work.',

--- a/packages/pi-subagents/src/stateful-registration.ts
+++ b/packages/pi-subagents/src/stateful-registration.ts
@@ -17,6 +17,11 @@ import {
 	THINKING_LEVELS,
 } from "./agents/types.js";
 import type { CompletionDeliveryBroker } from "./completion-delivery.js";
+import {
+	CompletionRequirementModeSchema,
+	completionRequirementsFromBranch,
+	reconcileRequiredCompletionContext,
+} from "./completion-requirement.js";
 import type { ContextMode } from "./context.js";
 import type { CreateStatefulTransportOptions } from "./create-stateful-transport.js";
 import { DelegationContractSchema } from "./delegation-contract.js";
@@ -381,7 +386,7 @@ export function registerStatefulSubagents(
 		if (!registry) throw new Error("Stateful subagents are not initialized for this session");
 		return registry;
 	};
-	pi.on("session_start", async (_event, ctx) => {
+	pi.on("session_start", async (event, ctx) => {
 		const generation = ++runtimeGeneration;
 		completionBroker?.close();
 		completionBroker = undefined;
@@ -577,6 +582,26 @@ export function registerStatefulSubagents(
 				for (const message of agent.mailbox) seenMessageIds.add(message.id);
 			}
 			nextRegistry.restore(restored);
+			const branchRequirements = completionRequirementsFromBranch(ctx.sessionManager.getBranch());
+			const branchOwnsRequirementState =
+				branchRequirements.observedState || event.reason === "fork" || event.reason === "new";
+			nextRegistry.reconcileCompletionRequirements(
+				branchRequirements.records,
+				branchOwnsRequirementState,
+			);
+			if (branchOwnsRequirementState) {
+				try {
+					await sessionPersistence.save(nextRegistry.list(true));
+				} catch (error) {
+					if (generation === runtimeGeneration && ctx.hasUI) {
+						const reason = error instanceof Error ? error.message : String(error);
+						ctx.ui.notify(
+							`Subagent requirement reconciliation could not be persisted yet: ${reason}`,
+							"warning",
+						);
+					}
+				}
+			}
 			if (generation !== runtimeGeneration) {
 				sessionBroker.close();
 				await sessionPeerBroker.close();
@@ -616,6 +641,9 @@ export function registerStatefulSubagents(
 
 	pi.on("context", (event) => {
 		completionBroker?.onParentContext(event.messages);
+		const agents = registry?.list() ?? [];
+		const messages = reconcileRequiredCompletionContext(event.messages, agents);
+		if (messages !== event.messages) return { messages };
 	});
 
 	pi.on("agent_settled", () => {
@@ -716,6 +744,7 @@ export function registerStatefulSubagents(
 						"Use text (default), structured-v1, or the evidence-preserving structured-v2 completion contract.",
 				}),
 			),
+			completionRequirement: Type.Optional(CompletionRequirementModeSchema),
 		}),
 		...createStatefulToolRenderer("spawn"),
 		async execute(_id, params, signal, _update, ctx) {
@@ -807,6 +836,7 @@ export function registerStatefulSubagents(
 				allowConcurrentWrites: params.allowConcurrentWrites ?? false,
 				contract,
 				resultFormat,
+				completionRequirement: params.completionRequirement ?? "background",
 			});
 			if (!capturedRegistry) {
 				throw new Error("Stateful subagents are not initialized for this session");
@@ -900,6 +930,7 @@ export function registerStatefulSubagents(
 						spawnRequestHash: params.idempotencyKey ? requestHash : undefined,
 						contract,
 						resultFormat: resultFormat === "text" ? undefined : resultFormat,
+						completionRequirement: params.completionRequirement ?? "background",
 						executionPlan,
 						capabilityGrant,
 						semanticSnapshot,
@@ -921,9 +952,13 @@ export function registerStatefulSubagents(
 					completionDelivery === "auto-resume"
 						? "Auto-resume steers completions into active parent work or requests synthesis when idle. Treat this response as progress, not final synthesis, until every final-answer-required completion message is visible. If local work is exhausted while required children remain active, emit at most one brief progress sentence and end the turn; do not repeat waiting updates or use the requested final format, verdict, or conclusion. Do not redo a running child's assigned work."
 						: "The current response must not depend on the result because next-turn delivery will not wake an idle root.";
+				const requirementNote =
+					params.completionRequirement === "required"
+						? "This exact run is runtime-tracked as required until its completion becomes visible or reaches an explicit terminal state. Current Pi versions still cannot prevent already-streamed premature output."
+						: "This run is background work and does not block the parent final answer.";
 				return result(
 					agent,
-					`Spawned ${agent.agent} as ${agent.taskPath ?? agent.id} (${agent.id}). Continue the identified non-overlapping local work immediately; do not merely announce the spawn or end while useful local work remains. Only an explicit user-requested specialist model, tool-profile, or isolation exception may lack concurrent local work. ${deliveryNote} Do not poll for progress.`,
+					`Spawned ${agent.agent} as ${agent.taskPath ?? agent.id} (${agent.id}). ${requirementNote} Continue the identified non-overlapping local work immediately; do not merely announce the spawn or end while useful local work remains. Only an explicit user-requested specialist model, tool-profile, or isolation exception may lack concurrent local work. ${deliveryNote} Do not poll for progress.`,
 				);
 			} catch (error) {
 				rejectPending?.(error);
@@ -964,6 +999,7 @@ export function registerStatefulSubagents(
 				}),
 			),
 			...StatefulTurnLimitFields,
+			completionRequirement: Type.Optional(CompletionRequirementModeSchema),
 			revalidate: Type.Optional(
 				Type.Boolean({
 					description:
@@ -1082,6 +1118,7 @@ export function registerStatefulSubagents(
 				idleTimeoutMs: params.idleTimeoutMs,
 				maxTurns: params.maxTurns,
 				maxToolCalls: params.maxToolCalls,
+				completionRequirement: params.completionRequirement ?? "background",
 			});
 			assertCurrentSpawn(signal, generation, runtimeGeneration);
 			return result(agent, `Started follow-up for ${agent.id}.`);

--- a/packages/pi-subagents/src/stateful-render.ts
+++ b/packages/pi-subagents/src/stateful-render.ts
@@ -300,6 +300,7 @@ function lifecycleStatus(state: string): RenderStatus {
 			return "running";
 		case "idle":
 			return "idle";
+		case "partial":
 		case "blocked":
 		case "needs-input":
 		case "abstained":

--- a/packages/pi-subagents/src/transport-types.ts
+++ b/packages/pi-subagents/src/transport-types.ts
@@ -50,6 +50,12 @@ export interface TransportTelemetry {
 	model?: string;
 	thinkingLevel?: SubagentThinkingLevel;
 	usage?: TransportUsage;
+	budgetSource?: {
+		timeout: "runtime" | "explicit";
+		idleTimeout: "runtime" | "explicit";
+		turnLimit: "runtime" | "explicit";
+		toolCallLimit: "runtime" | "explicit";
+	};
 	failurePhase?: TransportProgressPhase;
 }
 

--- a/packages/pi-subagents/src/usage-recording.ts
+++ b/packages/pi-subagents/src/usage-recording.ts
@@ -267,6 +267,20 @@ export function registerUsageRecording(
 				runId,
 				generation: completion.generation,
 				state: completion.agent.state,
+				...(completion.agent.outcome?.status
+					? { outcomeStatus: completion.agent.outcome.status }
+					: {}),
+				...(completion.agent.termination?.reason
+					? { terminationReason: completion.agent.termination.reason }
+					: {}),
+				...(completion.agent.telemetry?.budgetSource
+					? {
+							timeoutBudgetSource: completion.agent.telemetry.budgetSource.timeout,
+							idleTimeoutBudgetSource: completion.agent.telemetry.budgetSource.idleTimeout,
+							turnLimitBudgetSource: completion.agent.telemetry.budgetSource.turnLimit,
+							toolCallLimitBudgetSource: completion.agent.telemetry.budgetSource.toolCallLimit,
+						}
+					: {}),
 				...(timing?.startedAt !== undefined && timing.settledAt !== undefined
 					? { durationMs: Math.max(0, timing.settledAt - timing.startedAt) }
 					: {}),

--- a/packages/pi-subagents/test/async-runtime-quality.test.ts
+++ b/packages/pi-subagents/test/async-runtime-quality.test.ts
@@ -1,0 +1,295 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	beginCompletionRequirement,
+	completionRequirementKey,
+	completionRequirementsFromBranch,
+	reconcileRequiredCompletionContext,
+} from "../src/completion-requirement.js";
+import { AgentRegistry, type TurnOutcome } from "../src/registry.js";
+import { TURN_TERMINATION_VERSION } from "../src/timeout-checkpoint.js";
+
+function finalizedLimitOutcome(
+	output: string,
+	finalizationStatus: "completed" | "failed" | "timed_out" = "completed",
+): TurnOutcome {
+	return {
+		output,
+		exitCode: 124,
+		error: "Subagent exceeded its tool-call limit",
+		termination: {
+			version: TURN_TERMINATION_VERSION,
+			reason: "tool_call_limit",
+			limit: 2,
+			checkpoint: {
+				version: "pi-subagents:checkpoint:v1",
+				task: "inspect",
+				assistantNotes: [],
+				completedTools: [],
+				changedFiles: [],
+				sideEffectsMayHaveOccurred: false,
+				truncated: false,
+			},
+			finalization: {
+				attempted: true,
+				status: finalizationStatus,
+				durationMs: 10,
+			},
+		},
+	};
+}
+
+test("required completion tracks an exact run through availability and visibility", async () => {
+	const registry = new AgentRegistry({
+		kind: "fake",
+		runTurn: async () => ({ output: "evidence", exitCode: 0 }),
+	});
+	const spawned = await registry.spawn({
+		agent: "explorer",
+		task: "inspect",
+		cwd: process.cwd(),
+		completionRequirement: "required",
+	});
+	const pending = registry.get(spawned.id)?.completionRequirements?.[0];
+	assert.equal(pending?.state, "pending");
+	assert.equal(pending?.runId, spawned.currentRunId);
+	assert.equal(pending?.generation, spawned.currentTurnGeneration);
+
+	const settled = await registry.wait(spawned.id, 1_000);
+	assert.equal(settled.timedOut, false);
+	const available = settled.agent.completionRequirements?.[0];
+	assert.equal(available?.state, "available");
+	assert.equal(available?.terminalState, "completed");
+	assert.ok(available?.completionId);
+	assert.equal(registry.getInspection(spawned.id)?.pendingRequiredCompletionCount, 1);
+
+	await registry.markCompletionDelivered(available.completionId, Date.now());
+	await registry.markCompletionDelivered(available.completionId, Date.now() + 1);
+	const visible = registry.get(spawned.id)?.completionRequirements?.[0];
+	assert.equal(visible?.state, "visible");
+	assert.equal(registry.getInspection(spawned.id)?.pendingRequiredCompletionCount, 0);
+
+	const followUp = await registry.followUp(spawned.id, "inspect again", {
+		completionRequirement: "required",
+	});
+	assert.notEqual(followUp.currentRunId, available.runId);
+	assert.equal(followUp.completionRequirements?.at(-1)?.generation, 2);
+	await registry.wait(spawned.id, 1_000);
+});
+
+test("branch reconstruction keeps exact required runs and drops forked-away runs", () => {
+	const requirement = beginCompletionRequirement(undefined, {
+		runId: "run:required",
+		generation: 1,
+		createdAt: 10,
+	})[0];
+	const branch = [
+		{
+			type: "message",
+			message: {
+				role: "toolResult",
+				toolName: "subagent_spawn",
+				details: { agent: { completionRequirements: [requirement] } },
+			},
+		},
+	];
+	const restored = completionRequirementsFromBranch(branch);
+	assert.equal(restored.observedState, true);
+	assert.deepEqual([...restored.keys], [completionRequirementKey(requirement)]);
+	assert.equal(restored.records.get(completionRequirementKey(requirement))?.state, "pending");
+	const visibleRequirement = {
+		...requirement,
+		state: "available" as const,
+		completionId: "completion:required",
+		terminalState: "completed" as const,
+		updatedAt: 11,
+	};
+	const visibleBranch = completionRequirementsFromBranch([
+		...branch,
+		{
+			type: "message",
+			message: {
+				role: "custom",
+				customType: "pi-subagent-completion",
+				details: { completionRequirement: visibleRequirement },
+			},
+		},
+	]);
+	assert.equal(visibleBranch.records.get(completionRequirementKey(requirement))?.state, "visible");
+
+	const registry = new AgentRegistry({
+		kind: "fake",
+		runTurn: async () => ({ output: "unused", exitCode: 0 }),
+	});
+	registry.restore([
+		{
+			id: "sa_restored",
+			taskName: "restored",
+			taskPath: "/root/restored",
+			agent: "explorer",
+			rootId: "sa_restored",
+			depth: 0,
+			children: [],
+			state: "completed",
+			createdAt: 1,
+			updatedAt: 2,
+			cwd: process.cwd(),
+			turnGeneration: 1,
+			pendingCompletions: [],
+			completionRequirements: [requirement],
+			history: [],
+			mailbox: [],
+		},
+	]);
+	assert.equal(
+		registry.get("sa_restored")?.completionRequirements?.[0]?.state,
+		"cancelled",
+		"restoring a non-running owner must terminalize a stale pending requirement",
+	);
+	registry.reconcileCompletionRequirements(restored.records, true);
+	assert.equal(registry.get("sa_restored")?.completionRequirements?.[0]?.state, "cancelled");
+	assert.equal(
+		registry.get("sa_restored")?.completionRequirements?.[0]?.terminalState,
+		"interrupted",
+		"forking before completion must not inherit a future branch's visible success",
+	);
+	registry.reconcileCompletionRequirements(new Map(), true);
+	assert.deepEqual(registry.get("sa_restored")?.completionRequirements, []);
+});
+
+test("required completion capacity fails before an unrepresentable dependency is accepted", async () => {
+	const registry = new AgentRegistry(
+		{ kind: "fake", runTurn: async () => ({ output: "done", exitCode: 0 }) },
+		{ maxAgents: 65 },
+	);
+	for (let index = 0; index < 64; index++) {
+		const spawned = await registry.spawn({
+			agent: "explorer",
+			taskName: `required_${index}`,
+			task: "inspect",
+			cwd: process.cwd(),
+			completionRequirement: "required",
+		});
+		await registry.wait(spawned.id, 1_000);
+	}
+	await assert.rejects(
+		() =>
+			registry.spawn({
+				agent: "explorer",
+				taskName: "required_overflow",
+				task: "inspect",
+				cwd: process.cwd(),
+				completionRequirement: "required",
+			}),
+		/required subagent completion capacity reached/i,
+	);
+	assert.equal(registry.list().length, 64);
+});
+
+test("required completion context is canonical, bounded, and omits visible records", () => {
+	const requirement = beginCompletionRequirement(undefined, {
+		runId: "run:required",
+		generation: 1,
+		createdAt: 10,
+	})[0];
+	const agent = {
+		id: "sa_required",
+		taskName: "required",
+		taskPath: "/root/required",
+		agent: "explorer",
+		rootId: "sa_required",
+		depth: 0,
+		children: [],
+		state: "running" as const,
+		createdAt: 1,
+		updatedAt: 2,
+		cwd: process.cwd(),
+		completionRequirements: [requirement],
+		history: [],
+		mailbox: [],
+	};
+	assert.deepEqual(
+		reconcileRequiredCompletionContext([], [{ ...agent, completionRequirements: [] }]),
+		[],
+		"background agents must not create a final-answer dependency block",
+	);
+	const first = reconcileRequiredCompletionContext([], [agent]);
+	assert.equal(first.length, 1);
+	const firstContent = String((first[0] as { content?: unknown } | undefined)?.content ?? "");
+	assert.match(firstContent, /PI SUBAGENT REQUIRED COMPLETIONS/);
+	assert.match(firstContent, /run:required/);
+	const second = reconcileRequiredCompletionContext(first, [agent]);
+	assert.equal(second.length, 1, "the canonical block must replace rather than duplicate itself");
+
+	agent.completionRequirements = [{ ...requirement, state: "visible" }];
+	assert.deepEqual(reconcileRequiredCompletionContext(second, [agent]), []);
+});
+
+test("successful budget finalization produces partial evidence, not success or failure", async () => {
+	const registry = new AgentRegistry({
+		kind: "fake",
+		runTurn: async () => finalizedLimitOutcome("bounded partial evidence"),
+	});
+	const spawned = await registry.spawn({
+		agent: "explorer",
+		task: "inspect",
+		cwd: process.cwd(),
+		maxToolCalls: 2,
+	});
+	const settled = await registry.wait(spawned.id, 1_000);
+	assert.equal(settled.agent.state, "partial");
+	assert.equal(settled.agent.outcome?.status, "partial");
+	assert.equal(settled.agent.outcome?.reasonCode, "tool_call_limit");
+	assert.equal(settled.agent.termination?.finalization.status, "completed");
+	assert.equal(settled.agent.telemetry?.budgetSource?.toolCallLimit, "explicit");
+});
+
+test("empty, failed, timed-out, and transport finalization paths remain failed", async () => {
+	for (const outcome of [
+		finalizedLimitOutcome(""),
+		finalizedLimitOutcome("checkpoint only", "failed"),
+		finalizedLimitOutcome("checkpoint only", "timed_out"),
+	]) {
+		const registry = new AgentRegistry({ kind: "fake", runTurn: async () => outcome });
+		const spawned = await registry.spawn({
+			agent: "explorer",
+			task: "inspect",
+			cwd: process.cwd(),
+		});
+		const settled = await registry.wait(spawned.id, 1_000);
+		assert.equal(settled.agent.state, "failed");
+		assert.notEqual(settled.agent.outcome?.status, "partial");
+	}
+
+	const transportFailure = new AgentRegistry({
+		kind: "fake",
+		runTurn: async () => {
+			throw new Error("transport failed");
+		},
+	});
+	const spawned = await transportFailure.spawn({
+		agent: "explorer",
+		task: "inspect",
+		cwd: process.cwd(),
+	});
+	const settled = await transportFailure.wait(spawned.id, 1_000);
+	assert.equal(settled.agent.state, "failed");
+	assert.equal(settled.agent.outcome?.reasonCode, "transport-error");
+});
+
+test("malformed structured finalization remains contract-invalid", async () => {
+	const registry = new AgentRegistry({
+		kind: "fake",
+		runTurn: async () => finalizedLimitOutcome("not-json"),
+	});
+	const spawned = await registry.spawn({
+		agent: "explorer",
+		task: "inspect",
+		cwd: process.cwd(),
+		resultFormat: "structured-v2",
+	});
+	const settled = await registry.wait(spawned.id, 1_000);
+	assert.equal(settled.agent.state, "failed");
+	assert.equal(settled.agent.outcome?.status, "contract-invalid");
+	assert.equal(settled.agent.outcome?.reasonCode, "malformed-structured-result");
+});

--- a/packages/pi-subagents/test/async-subagent-benchmark.test.ts
+++ b/packages/pi-subagents/test/async-subagent-benchmark.test.ts
@@ -1,0 +1,372 @@
+import assert from "node:assert/strict";
+import { execFile, spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { promisify } from "node:util";
+import { test } from "vitest";
+import {
+	ASYNC_SUBAGENT_BENCHMARK_VERSION,
+	type AsyncSubagentBenchmarkTrialRecord,
+	analyzeBenchmarkEvents,
+	BenchmarkDeadlineError,
+	createAlternatingTrialPlan,
+	parseAsyncSubagentBenchmarkArgs,
+	parseBenchmarkJsonLines,
+	percentile,
+	redactBenchmarkValue,
+	runAfterReadinessWithDeadline,
+	scoreBenchmarkEvidence,
+	summarizeAsyncSubagentBenchmark,
+} from "../src/async-subagent-benchmark.js";
+
+const execFileAsync = promisify(execFile);
+
+function assistant(content: unknown[]): Record<string, unknown> {
+	return { type: "message_end", message: { role: "assistant", content } };
+}
+
+function toolResult(toolName: string, details?: Record<string, unknown>): Record<string, unknown> {
+	return {
+		type: "message_end",
+		message: { role: "toolResult", toolName, isError: false, content: [], details },
+	};
+}
+
+function trial(
+	arm: "sync" | "async",
+	overrides: Partial<AsyncSubagentBenchmarkTrialRecord> = {},
+): AsyncSubagentBenchmarkTrialRecord {
+	return {
+		version: ASYNC_SUBAGENT_BENCHMARK_VERSION,
+		pairIndex: 0,
+		orderIndex: arm === "sync" ? 0 : 1,
+		arm,
+		outcome: "completed",
+		readinessMs: 5,
+		elapsedMs: arm === "sync" ? 10 : 20,
+		cost: arm === "sync" ? 1 : 2,
+		startedAt: "2026-01-01T00:00:00.000Z",
+		completedAt: "2026-01-01T00:00:01.000Z",
+		completionObserved: true,
+		evidenceScore: 1,
+		matchedEvidence: [
+			"registry-wait-race",
+			"completion-id-deduplication",
+			"session-shutdown-cleanup",
+		],
+		prematureFinalCount: 0,
+		events: [],
+		...overrides,
+	};
+}
+
+test("benchmark argument and JSONL parsers reject ambiguous input", () => {
+	assert.deepEqual(
+		parseAsyncSubagentBenchmarkArgs([
+			"--mode",
+			"extended",
+			"--model",
+			"provider/model",
+			"--thinking",
+			"high",
+			"--timeout-ms",
+			"123",
+			"--readiness-timeout-ms",
+			"45",
+			"--output",
+			"result.json",
+			"--run",
+		]),
+		{
+			mode: "extended",
+			model: "provider/model",
+			thinkingLevel: "high",
+			timeoutMs: 123,
+			readinessTimeoutMs: 45,
+			outputPath: "result.json",
+			run: true,
+			piCommand: "pi",
+		},
+	);
+	assert.deepEqual(parseBenchmarkJsonLines('{"type":"one"}\r\n{"type":"two"}\n'), [
+		{ type: "one" },
+		{ type: "two" },
+	]);
+	assert.throws(() => parseAsyncSubagentBenchmarkArgs(["--mode", "quick"]), /--model is required/i);
+	assert.throws(() => parseBenchmarkJsonLines('{"ok":true}\nnot-json\n'), /line 2/i);
+});
+
+test("event analysis scores evidence, completion visibility, and premature finals", () => {
+	const finalText = [
+		"packages/pi-subagents/src/registry.ts uses Promise.race.",
+		"packages/pi-subagents/src/completion-delivery.ts tracks completionId.",
+		"packages/pi-subagents/src/stateful-registration.ts handles session_shutdown.",
+		'BENCHMARK_RESULT_JSON: {"complete":true}',
+	].join("\n");
+	const events = [
+		assistant([{ type: "toolCall", id: "spawn", name: "subagent_spawn", arguments: {} }]),
+		toolResult("subagent_spawn"),
+		assistant([
+			{
+				type: "text",
+				text: "packages/pi-subagents/src/registry.ts already proves Promise.race before the child result.",
+			},
+		]),
+		toolResult("subagent_await"),
+		assistant([{ type: "text", text: finalText }]),
+	];
+	assert.deepEqual(analyzeBenchmarkEvents("async", events), {
+		completionObserved: true,
+		evidenceScore: 1,
+		matchedEvidence: [
+			"registry-wait-race",
+			"completion-id-deduplication",
+			"session-shutdown-cleanup",
+		],
+		prematureFinalCount: 1,
+		finalAnswer: finalText,
+		resultMarker: { complete: true },
+	});
+	assert.deepEqual(scoreBenchmarkEvidence("packages/pi-subagents/src/registry.ts Promise.race"), {
+		score: 0.333,
+		matched: ["registry-wait-race"],
+	});
+	assert.equal(
+		analyzeBenchmarkEvents("async", [toolResult("subagent_await", { timedOut: true })])
+			.completionObserved,
+		false,
+	);
+	assert.equal(
+		analyzeBenchmarkEvents("async", [
+			assistant([{ type: "toolCall", id: "spawn", name: "subagent_spawn", arguments: {} }]),
+			assistant([{ type: "text", text: "The required inspection is still in progress." }]),
+		]).prematureFinalCount,
+		0,
+	);
+});
+
+test("paired order alternates without changing quick and extended sample counts", () => {
+	const quick = createAlternatingTrialPlan("quick");
+	assert.equal(quick.length, 6);
+	assert.deepEqual(
+		quick.map(({ pairIndex, arm }) => [pairIndex, arm]),
+		[
+			[0, "sync"],
+			[0, "async"],
+			[1, "async"],
+			[1, "sync"],
+			[2, "sync"],
+			[2, "async"],
+		],
+	);
+	assert.equal(createAlternatingTrialPlan("extended").length, 20);
+});
+
+test("hard work deadline starts only after readiness and reports timeout", async () => {
+	const readyThenFast = await runAfterReadinessWithDeadline(
+		delay(20),
+		async () => {
+			await delay(2);
+			return "ok";
+		},
+		10,
+	);
+	assert.equal(readyThenFast, "ok");
+	await assert.rejects(
+		() => runAfterReadinessWithDeadline(Promise.resolve(), () => delay(30), 5),
+		BenchmarkDeadlineError,
+	);
+});
+
+test("statistics summarize coverage, outcomes, latency, P95, and available cost", () => {
+	assert.equal(percentile([40, 10, 30, 20], 0.5), 25);
+	assert.equal(percentile([40, 10, 30, 20], 0.95), 38.5);
+	const summary = summarizeAsyncSubagentBenchmark([
+		trial("sync", { pairIndex: 0, elapsedMs: 10, cost: 1 }),
+		trial("async", { pairIndex: 0, elapsedMs: 20, cost: 2, prematureFinalCount: 1 }),
+		trial("sync", {
+			pairIndex: 1,
+			orderIndex: 1,
+			outcome: "timed-out",
+			completionObserved: false,
+			evidenceScore: 0,
+			elapsedMs: 40,
+			cost: null,
+		}),
+		trial("async", { pairIndex: 1, orderIndex: 0, elapsedMs: 30, cost: 4 }),
+	]);
+	assert.equal(summary.pairs, 2);
+	assert.deepEqual(summary.arms.sync, {
+		trials: 2,
+		completionCoverage: 0.5,
+		evidenceScore: 0.5,
+		prematureFinalCount: 0,
+		terminalOutcomes: {
+			completed: 1,
+			"invalid-output": 0,
+			"timed-out": 1,
+			"readiness-timeout": 0,
+			"process-error": 0,
+			"protocol-error": 0,
+		},
+		latencyMs: { median: 10, p95: 10 },
+		cost: { available: 1, total: 1, median: 1, p95: 1 },
+	});
+	assert.deepEqual(summary.arms.async.latencyMs, { median: 25, p95: 29.5 });
+	assert.deepEqual(summary.arms.async.cost, {
+		available: 2,
+		total: 6,
+		median: 3,
+		p95: 3.9,
+	});
+	assert.equal(summary.arms.async.prematureFinalCount, 1);
+});
+
+test("manual runner handles RPC lifecycle and cleans isolated agent directories", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "pi-async-benchmark-script-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	const output = path.join(root, "result.json");
+	const sourceAgentDir = path.join(root, "source-agent");
+	await writeFile(
+		fakePi,
+		[
+			"#!/usr/bin/env node",
+			'import fs from "node:fs";',
+			'import readline from "node:readline";',
+			'const settings=JSON.parse(fs.readFileSync(process.env.PI_CODING_AGENT_DIR+"/pi-subagents.json","utf8"));',
+			"const asyncArm=settings.blocking?.enabled===false;",
+			'const finalText=["packages/pi-subagents/src/registry.ts uses Promise.race.","packages/pi-subagents/src/completion-delivery.ts tracks completionId.","packages/pi-subagents/src/stateful-registration.ts handles session_shutdown.",\'BENCHMARK_RESULT_JSON: {"complete":true}\'].join("\\n");',
+			'const send=(value)=>process.stdout.write(JSON.stringify(value)+"\\n");',
+			"const lines=readline.createInterface({input:process.stdin});",
+			'lines.on("line",(line)=>{const request=JSON.parse(line);if(request.type==="get_state"){send({id:request.id,type:"response",success:true,data:{}});return;}if(request.type==="prompt"){if(asyncArm){send({type:"message_end",message:{role:"custom",customType:"pi-subagent-completion",content:"done",details:{completionId:"completion:fake"}}});}else{send({type:"message_end",message:{role:"toolResult",toolName:"subagent",isError:false,content:[],details:{}}});}send({type:"message_end",message:{role:"assistant",content:[{type:"text",text:finalText}]}});send({id:request.id,type:"response",success:true,data:{}});return;}if(request.type==="get_session_stats"){send({id:request.id,type:"response",success:true,data:{cost:0.01}});}});',
+		].join("\n"),
+		{ mode: 0o700 },
+	);
+	await mkdir(sourceAgentDir);
+	try {
+		await execFileAsync(
+			process.execPath,
+			[
+				"scripts/benchmark-async-subagents.ts",
+				"--run",
+				"--mode",
+				"quick",
+				"--model",
+				"fake/model",
+				"--pi",
+				fakePi,
+				"--timeout-ms",
+				"1000",
+				"--readiness-timeout-ms",
+				"1000",
+				"--output",
+				output,
+			],
+			{
+				cwd: path.resolve(import.meta.dirname, "../../.."),
+				env: {
+					...process.env,
+					PI_CODING_AGENT_DIR: sourceAgentDir,
+					TMPDIR: root,
+				},
+				timeout: 4_000,
+			},
+		);
+		const result = JSON.parse(await readFile(output, "utf8")) as {
+			rawRecords: unknown[];
+			summary: { pairs: number; arms: { sync: { trials: number }; async: { trials: number } } };
+		};
+		assert.equal(result.rawRecords.length, 6);
+		assert.equal(result.summary.pairs, 3);
+		assert.equal(result.summary.arms.sync.trials, 3);
+		assert.equal(result.summary.arms.async.trials, 3);
+		assert.equal(
+			(await readdir(root)).some((name) => name.startsWith("pi-subagent-benchmark-")),
+			false,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("manual runner cleans credential directories when its pane receives SIGHUP", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "pi-async-benchmark-sighup-"));
+	const fakePi = path.join(root, "fake-pi.mjs");
+	const output = path.join(root, "result.json");
+	const sourceAgentDir = path.join(root, "source-agent");
+	await mkdir(sourceAgentDir);
+	await writeFile(
+		fakePi,
+		[
+			"#!/usr/bin/env node",
+			'import readline from "node:readline";',
+			'const send=(value)=>process.stdout.write(JSON.stringify(value)+"\\n");',
+			"const lines=readline.createInterface({input:process.stdin});",
+			'lines.on("line",(line)=>{const request=JSON.parse(line);if(request.type==="get_state")send({id:request.id,type:"response",success:true,data:{}});});',
+		].join("\n"),
+		{ mode: 0o700 },
+	);
+	const runner = spawn(
+		process.execPath,
+		[
+			"scripts/benchmark-async-subagents.ts",
+			"--run",
+			"--mode",
+			"quick",
+			"--model",
+			"fake/model",
+			"--pi",
+			fakePi,
+			"--timeout-ms",
+			"1000",
+			"--readiness-timeout-ms",
+			"1000",
+			"--output",
+			output,
+		],
+		{
+			cwd: path.resolve(import.meta.dirname, "../../.."),
+			env: {
+				...process.env,
+				PI_CODING_AGENT_DIR: sourceAgentDir,
+				TMPDIR: root,
+			},
+			stdio: "ignore",
+		},
+	);
+	try {
+		const deadline = Date.now() + 1_000;
+		while (
+			!(await readdir(root)).some((name) => name.startsWith("pi-subagent-benchmark-")) &&
+			Date.now() < deadline
+		) {
+			await delay(10);
+		}
+		assert.equal(
+			(await readdir(root)).some((name) => name.startsWith("pi-subagent-benchmark-")),
+			true,
+		);
+		runner.kill("SIGHUP");
+		const [code] = (await once(runner, "exit")) as [number | null, NodeJS.Signals | null];
+		assert.equal(code, 129);
+		assert.equal(
+			(await readdir(root)).some((name) => name.startsWith("pi-subagent-benchmark-")),
+			false,
+		);
+	} finally {
+		if (runner.exitCode === null) runner.kill("SIGKILL");
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("raw record redaction removes credentials, private blocks, and home paths", () => {
+	const redacted = redactBenchmarkValue({
+		authorization: "Bearer secret",
+		text: `path=${process.env.HOME}/repo <private>hidden</private> API_TOKEN=abc`,
+	}) as Record<string, unknown>;
+	assert.equal(redacted.authorization, "[redacted]");
+	assert.equal(redacted.text, "path=$HOME/repo [private content omitted] API_TOKEN=[redacted]");
+});

--- a/packages/pi-subagents/test/completion-delivery.test.ts
+++ b/packages/pi-subagents/test/completion-delivery.test.ts
@@ -165,6 +165,33 @@ test("next-turn completion delivery never wakes an idle root", () => {
 	broker.close();
 });
 
+test("completion metadata carries the exact required run record", () => {
+	const harness = deliveryHarness();
+	const required = completion("sa_required");
+	required.agent.completionRequirements = [
+		{
+			version: "pi-subagents:completion-requirement:v1",
+			runId: required.runId,
+			generation: required.generation,
+			state: "available",
+			createdAt: 1,
+			updatedAt: 2,
+			completionId: required.completionId,
+			terminalState: "completed",
+		},
+	];
+	const broker = new CompletionDeliveryBroker(harness.pi as never, harness.ctx, "next-turn");
+	broker.enqueue(required);
+	broker.flush();
+	const sent = harness.sent[0];
+	assert.ok(sent);
+	assert.deepEqual(
+		(sent.message.details as Record<string, unknown>).completionRequirement,
+		required.agent.completionRequirements[0],
+	);
+	broker.close();
+});
+
 test("active-turn next-turn delivery queues once for context acknowledgement", () => {
 	const queuedSteering: Record<string, unknown>[] = [];
 	const insertedImmediately: Record<string, unknown>[] = [];

--- a/packages/pi-subagents/test/registry-persistence.test.ts
+++ b/packages/pi-subagents/test/registry-persistence.test.ts
@@ -73,6 +73,18 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 				},
 			],
 			turnGeneration: 2,
+			completionRequirements: [
+				{
+					version: "pi-subagents:completion-requirement:v1",
+					runId: "run:two",
+					generation: 2,
+					state: "available",
+					createdAt: 2,
+					updatedAt: 3,
+					completionId: "completion:two",
+					terminalState: "completed",
+				},
+			],
 			pendingCompletions: [
 				{
 					completionId: "completion:one",
@@ -126,6 +138,18 @@ test("AgentPersistence atomically saves, restores, redacts, deletes, and quarant
 	assert.equal(restoredState?.telemetry, undefined);
 	assert.equal(restoredState?.structuredResult?.summary, "ephemeral");
 	assert.equal(restoredState?.turnGeneration, 2);
+	assert.deepEqual(restoredState?.completionRequirements, [
+		{
+			version: "pi-subagents:completion-requirement:v1",
+			runId: "run:two",
+			generation: 2,
+			state: "available",
+			createdAt: 2,
+			updatedAt: 3,
+			completionId: "completion:two",
+			terminalState: "completed",
+		},
+	]);
 	assert.deepEqual(
 		restoredState?.pendingCompletions?.map((completion) => ({
 			completionId: completion.completionId,

--- a/packages/pi-subagents/test/registry-spawn-and-inspection.test.ts
+++ b/packages/pi-subagents/test/registry-spawn-and-inspection.test.ts
@@ -23,6 +23,14 @@ test("spawn idempotency includes retained execution budgets", () => {
 	assert.notEqual(hashSpawnRequest(request), hashSpawnRequest({ ...request, maxToolCalls: 4 }));
 	assert.notEqual(
 		hashSpawnRequest(request),
+		hashSpawnRequest({ ...request, completionRequirement: "required" }),
+	);
+	assert.equal(
+		hashSpawnRequest(request),
+		hashSpawnRequest({ ...request, completionRequirement: "background" }),
+	);
+	assert.notEqual(
+		hashSpawnRequest(request),
 		hashSpawnRequest({ ...request, taskName: "research" }),
 	);
 	const { timeoutMs: _omitted, ...withoutTimeout } = request;
@@ -184,6 +192,7 @@ test("AgentRegistry exposes metadata-only inspection snapshots", async () => {
 		unreadMessages: 1,
 		turnGeneration: 1,
 		pendingCompletionCount: 0,
+		pendingRequiredCompletionCount: 0,
 	});
 	assert.doesNotMatch(JSON.stringify(listed), /private/);
 

--- a/packages/pi-subagents/test/stateful-session-lifecycle.test.ts
+++ b/packages/pi-subagents/test/stateful-session-lifecycle.test.ts
@@ -1,11 +1,39 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { registerStatefulSubagents } from "../src/stateful.js";
 import type { WorkspaceManager } from "../src/workspace.js";
+
+test("requirement reconciliation persistence failure remains observable without leaking startup", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-requirement-save-failure-"));
+	const originalDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	writeFileSync(path.join(root, "pi-subagents-state"), "blocks state directory creation");
+	try {
+		const mock = createMockPi();
+		const controller = registerStatefulSubagents(mock.pi);
+		const context = createMockContext({ hasUI: true });
+		await mock.events.get("session_start")?.[0]?.({ reason: "fork" }, context.ctx);
+		assert.equal(controller.getRuntimeStatus().initialized, true);
+		assert.equal(
+			context.notifications.some(
+				(notification) =>
+					notification.level === "warning" &&
+					/requirement reconciliation could not be persisted yet/i.test(notification.message),
+			),
+			true,
+		);
+		await mock.events.get("session_shutdown")?.[0]?.({}, context.ctx);
+		assert.equal(controller.getRuntimeStatus().initialized, false);
+	} finally {
+		if (originalDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalDir;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
 
 test("stateful worktree spawn revalidates session ownership and cleans stale work", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-stale-worktree-"));

--- a/packages/pi-subagents/test/stateful-tool-registration.test.ts
+++ b/packages/pi-subagents/test/stateful-tool-registration.test.ts
@@ -58,7 +58,9 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			name: string;
 			description: string;
 			promptGuidelines: string[];
-			parameters: { properties?: Record<string, { description?: string; maximum?: number }> };
+			parameters: {
+				properties?: Record<string, { description?: string; maximum?: number; enum?: string[] }>;
+			};
 		};
 		controller.setAgentCatalog(
 			'Available agent definitions\n- api-reviewer [source: user; agentScope: "user"] — Reviews APIs',
@@ -111,7 +113,9 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		const send = mock.tools.find((tool) => tool.name === "subagent_send") as {
 			description: string;
 			promptSnippet?: string;
-			parameters: { properties?: Record<string, { description?: string; maximum?: number }> };
+			parameters: {
+				properties?: Record<string, { description?: string; maximum?: number; enum?: string[] }>;
+			};
 		};
 		assert.match(
 			send.parameters.properties?.timeoutMs?.description ?? "",
@@ -124,6 +128,10 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			send.parameters.properties?.revalidate?.description ?? "",
 			/semantic resource snapshot/i,
 		);
+		assert.deepEqual(send.parameters.properties?.completionRequirement?.enum, [
+			"background",
+			"required",
+		]);
 		assert.match(
 			send.parameters.properties?.allowConcurrentWrites?.description ?? "",
 			/deprecated compatibility field.*allowed by default/i,
@@ -380,6 +388,14 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 			"structured-v1",
 			"structured-v2",
 		]);
+		assert.deepEqual(spawnTool.parameters.properties?.completionRequirement?.enum, [
+			"background",
+			"required",
+		]);
+		assert.match(
+			spawnTool.parameters.properties?.completionRequirement?.description ?? "",
+			/hard pre-display.*barrier/i,
+		);
 		assert.ok(spawnTool.parameters.properties?.contract);
 		const contractSchema = JSON.stringify(spawnTool.parameters.properties?.contract);
 		assert.match(contractSchema, /ordinary delegation.*omit/i);
@@ -541,7 +557,7 @@ test("stateful tools are available by default, disable cleanly, and expose the l
 		assert.match(autoResumeGuidance, /even when.*final answer.*depends/i);
 		assert.match(
 			autoResumeGuidance,
-			/every final-answer-dependent subagent_spawn.*completion message.*visible/i,
+			/every final-answer-dependent subagent_spawn.*completionRequirement.*required.*visible.*terminal/i,
 		);
 		assert.match(
 			autoResumeGuidance,

--- a/packages/pi-subagents/test/usage-recording.test.ts
+++ b/packages/pi-subagents/test/usage-recording.test.ts
@@ -201,8 +201,27 @@ test("usage recording stays dormant until opt-in and stores only bounded metadat
 		isError: false,
 		result: { content: [{ type: "text", text: "private result" }] },
 	});
-	recorder.observeAgents([managedAgent()]);
-	const agent = { ...managedAgent(), state: "completed" as const };
+	const baseAgent = managedAgent();
+	recorder.observeAgents([baseAgent]);
+	const agent: ManagedAgent = {
+		...baseAgent,
+		state: "partial" as const,
+		outcome: {
+			status: "partial" as const,
+			reasonCode: "tool_call_limit",
+			recoveryActions: [],
+			retryable: false,
+		},
+		telemetry: {
+			...(baseAgent.telemetry as NonNullable<ManagedAgent["telemetry"]>),
+			budgetSource: {
+				timeout: "runtime" as const,
+				idleTimeout: "runtime" as const,
+				turnLimit: "runtime" as const,
+				toolCallLimit: "explicit" as const,
+			},
+		},
+	};
 	const completion = {
 		completionId: "raw-completion-secret",
 		runId: "raw-run-secret",
@@ -252,6 +271,8 @@ test("usage recording stays dormant until opt-in and stores only bounded metadat
 	assert.match(serialized, /delivery_attempt/);
 	assert.match(serialized, /visible/);
 	assert.match(serialized, /"totalTokens":37/);
+	assert.match(serialized, /"outcomeStatus":"partial"/);
+	assert.match(serialized, /"toolCallLimitBudgetSource":"explicit"/);
 	assert.ok(
 		MemoryUsageStore.events.every((event) => {
 			const record = event as Record<string, unknown>;

--- a/scripts/benchmark-async-subagents.ts
+++ b/scripts/benchmark-async-subagents.ts
@@ -1,0 +1,592 @@
+#!/usr/bin/env node
+
+import { type ChildProcessWithoutNullStreams, execFileSync, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+	chmodSync,
+	copyFileSync,
+	lstatSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import {
+	ASYNC_SUBAGENT_BENCHMARK_VERSION,
+	type AsyncSubagentBenchmarkOptions,
+	type AsyncSubagentBenchmarkTrialPlan,
+	type AsyncSubagentBenchmarkTrialRecord,
+	analyzeBenchmarkEvents,
+	BenchmarkDeadlineError,
+	benchmarkPairCount,
+	buildAsyncSubagentBenchmarkPrompt,
+	createAlternatingTrialPlan,
+	FIXED_BENCHMARK_TASK,
+	FIXED_EVIDENCE_RUBRIC,
+	parseAsyncSubagentBenchmarkArgs,
+	redactBenchmarkValue,
+	runAfterReadinessWithDeadline,
+	summarizeAsyncSubagentBenchmark,
+	withDeadline,
+} from "../packages/pi-subagents/src/async-subagent-benchmark.ts";
+
+const help = `Usage:
+  just benchmark-async-subagents --model <provider/model> [options]
+  just benchmark-async-subagents --run --model <provider/model> --output <file> [options]
+
+Options:
+  --mode <quick|extended>       Run 3 or 10 paired trials (default: quick)
+  --model <provider/model>      Fixed parent and child model (required)
+  --thinking <level>            Fixed thinking level (default: medium)
+  --timeout-ms <ms>             Hard deadline after readiness (default: 120000)
+  --readiness-timeout-ms <ms>   RPC readiness deadline (default: 15000)
+  --output <file>               Redacted JSON record path (required with --run)
+  --pi <command>                Pi executable (default: pi)
+  --workspace <path>            Benchmark target workspace (default: repository root)
+  --extension <path>            Extension entrypoint (default: target pi-subagents source)
+  --run                         Execute live-provider trials; otherwise preview only
+`;
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+	process.stdout.write(help);
+	process.exit(0);
+}
+
+const sourceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const options = parseAsyncSubagentBenchmarkArgs(process.argv.slice(2));
+const root = path.resolve(options.workspace ?? sourceRoot);
+const extensionPath = options.extension
+	? path.resolve(root, options.extension)
+	: path.join(root, "packages/pi-subagents/src/index.ts");
+const plan = createAlternatingTrialPlan(options.mode);
+const configuration = {
+	version: ASYNC_SUBAGENT_BENCHMARK_VERSION,
+	mode: options.mode,
+	pairs: benchmarkPairCount(options.mode),
+	model: options.model,
+	thinkingLevel: options.thinkingLevel,
+	agent: "explorer",
+	context: "parent context files disabled; detached child context none",
+	task: FIXED_BENCHMARK_TASK,
+	evidenceRubric: FIXED_EVIDENCE_RUBRIC,
+	timeoutMs: options.timeoutMs,
+	readinessTimeoutMs: options.readinessTimeoutMs,
+	pairConcurrency: 3,
+	environment: {
+		node: process.version,
+		platform: process.platform,
+		architecture: process.arch,
+		piCommand: options.piCommand,
+		repository: repositoryIdentity(root),
+		extensionPath: displayPath(extensionPath, root),
+	},
+	order: plan,
+};
+
+if (!options.run) {
+	process.stdout.write(
+		`${JSON.stringify(
+			{
+				...configuration,
+				preview: true,
+				note: "No provider request was made. Add --run and --output to execute the benchmark.",
+			},
+			null,
+			2,
+		)}\n`,
+	);
+	process.exit(0);
+}
+
+const outputPath = path.resolve(options.outputPath as string);
+const activeClients = new Set<RpcBenchmarkClient>();
+let signalCleanupStarted = false;
+for (const signal of ["SIGHUP", "SIGINT", "SIGTERM"] as const) {
+	process.once(signal, () => {
+		if (signalCleanupStarted) return;
+		signalCleanupStarted = true;
+		void Promise.allSettled([...activeClients].map((client) => client.stop())).finally(() => {
+			process.exit(signal === "SIGHUP" ? 129 : signal === "SIGINT" ? 130 : 143);
+		});
+	});
+}
+const records: AsyncSubagentBenchmarkTrialRecord[] = [];
+let writeChain = Promise.resolve();
+const persist = async (): Promise<void> => {
+	const sorted = [...records].sort(
+		(left, right) => left.pairIndex - right.pairIndex || left.orderIndex - right.orderIndex,
+	);
+	const document = {
+		...configuration,
+		preview: false,
+		generatedAt: new Date().toISOString(),
+		rawRecords: sorted,
+		summary: summarizeAsyncSubagentBenchmark(sorted),
+	};
+	await mkdir(path.dirname(outputPath), { recursive: true });
+	const temporaryPath = `${outputPath}.${process.pid}.tmp`;
+	await writeFile(temporaryPath, `${JSON.stringify(document, null, 2)}\n`, { mode: 0o600 });
+	await rename(temporaryPath, outputPath);
+};
+const saveRecord = async (record: AsyncSubagentBenchmarkTrialRecord): Promise<void> => {
+	records.push(record);
+	writeChain = writeChain.then(persist);
+	await writeChain;
+};
+
+await persist();
+const pairs = groupPairs(plan);
+await runPool(pairs, 3, async (pair) => {
+	for (const trial of pair) {
+		if (signalCleanupStarted) return;
+		const record = await runTrial(options, trial, extensionPath, root);
+		await saveRecord(record);
+		process.stderr.write(
+			`pair ${trial.pairIndex + 1}/${configuration.pairs} ${trial.arm}: ${record.outcome}, evidence=${record.evidenceScore}, completion=${record.completionObserved}\n`,
+		);
+	}
+});
+await writeChain;
+process.stdout.write(
+	`${JSON.stringify(
+		{
+			outputPath,
+			summary: summarizeAsyncSubagentBenchmark(records),
+		},
+		null,
+		2,
+	)}\n`,
+);
+
+async function runTrial(
+	options: AsyncSubagentBenchmarkOptions,
+	trial: AsyncSubagentBenchmarkTrialPlan,
+	extension: string,
+	cwd: string,
+): Promise<AsyncSubagentBenchmarkTrialRecord> {
+	const launchedAt = performance.now();
+	const launchedTimestamp = new Date().toISOString();
+	const events: unknown[] = [];
+	let client: RpcBenchmarkClient | undefined;
+	let readinessMs = 0;
+	let elapsedMs = 0;
+	let cost: number | null = null;
+	let outcome: AsyncSubagentBenchmarkTrialRecord["outcome"] = "process-error";
+	let readinessTimedOut = false;
+	let error: string | undefined;
+
+	try {
+		client = startRpcClient(options, trial.arm, extension, cwd, (value) => events.push(value));
+		activeClients.add(client);
+		try {
+			await withDeadline(
+				client.request("get_state"),
+				options.readinessTimeoutMs,
+				"Pi RPC readiness timed out",
+			);
+		} catch (readinessError) {
+			readinessMs = performance.now() - launchedAt;
+			readinessTimedOut = readinessError instanceof BenchmarkDeadlineError;
+			throw readinessError;
+		}
+		readinessMs = performance.now() - launchedAt;
+		const trialStarted = performance.now();
+		await runAfterReadinessWithDeadline(
+			Promise.resolve(),
+			async () => {
+				await client?.request("prompt", {
+					message: buildAsyncSubagentBenchmarkPrompt(trial.arm, options.thinkingLevel),
+				});
+				while (!analyzeBenchmarkEvents(trial.arm, events).resultMarker) {
+					await client?.waitForEvent("message_end");
+				}
+				const stats = await client?.request("get_session_stats");
+				cost = benchmarkCost(stats);
+			},
+			options.timeoutMs,
+		);
+		elapsedMs = performance.now() - trialStarted;
+		const analysis = analyzeBenchmarkEvents(trial.arm, events);
+		outcome = analysis.resultMarker ? "completed" : "invalid-output";
+	} catch (caught) {
+		if (readinessMs > 0 && elapsedMs === 0 && !readinessTimedOut) {
+			elapsedMs = Math.max(0, performance.now() - launchedAt - readinessMs);
+		}
+		outcome = readinessTimedOut
+			? "readiness-timeout"
+			: caught instanceof BenchmarkDeadlineError
+				? "timed-out"
+				: classifyError(caught);
+		error = errorText(caught);
+	} finally {
+		await client?.stop();
+		if (client) activeClients.delete(client);
+	}
+
+	const analysis = redactBenchmarkValue(analyzeBenchmarkEvents(trial.arm, events)) as ReturnType<
+		typeof analyzeBenchmarkEvents
+	>;
+	return {
+		version: ASYNC_SUBAGENT_BENCHMARK_VERSION,
+		pairIndex: trial.pairIndex,
+		orderIndex: trial.orderIndex,
+		arm: trial.arm,
+		outcome,
+		readinessMs: round(readinessMs),
+		elapsedMs: round(elapsedMs),
+		cost,
+		startedAt: launchedTimestamp,
+		completedAt: new Date().toISOString(),
+		...analysis,
+		events: redactBenchmarkValue(events) as unknown[],
+		...(client?.stderr ? { stderr: String(redactBenchmarkValue(client.stderr)) } : {}),
+		...(error ? { error: String(redactBenchmarkValue(error)) } : {}),
+	};
+}
+
+function rpcProtocolError(message: string): Error {
+	const error = new Error(message);
+	error.name = "RpcProtocolError";
+	return error;
+}
+
+interface RpcResponse extends Record<string, unknown> {
+	type: "response";
+	success: boolean;
+	id?: string;
+}
+
+interface RpcBenchmarkClient {
+	request(type: string, payload?: Record<string, unknown>): Promise<RpcResponse>;
+	waitForEvent(type: string): Promise<Record<string, unknown>>;
+	stop(): Promise<void>;
+	readonly stderr: string;
+}
+
+function startRpcClient(
+	options: AsyncSubagentBenchmarkOptions,
+	arm: AsyncSubagentBenchmarkTrialPlan["arm"],
+	extension: string,
+	cwd: string,
+	onRecord: (value: unknown) => void,
+): RpcBenchmarkClient {
+	const agentDir = mkdtempSync(path.join(os.tmpdir(), `pi-subagent-benchmark-${arm}-`));
+	copyBenchmarkAuthentication(agentDir);
+	writeFileSync(
+		path.join(agentDir, "pi-subagents.json"),
+		`${JSON.stringify(
+			arm === "sync"
+				? { blocking: { enabled: true }, stateful: { enabled: false } }
+				: {
+						blocking: { enabled: false },
+						stateful: { enabled: true, completionDelivery: "auto-resume" },
+					},
+			null,
+			2,
+		)}\n`,
+		{ mode: 0o600 },
+	);
+	const child = spawn(
+		options.piCommand,
+		[
+			"--mode",
+			"rpc",
+			"--no-session",
+			"--model",
+			options.model,
+			"--thinking",
+			options.thinkingLevel,
+			"--no-extensions",
+			"-e",
+			extension,
+			"--no-skills",
+			"--no-prompt-templates",
+			"--no-context-files",
+			"--no-approve",
+		],
+		{
+			cwd,
+			detached: process.platform !== "win32",
+			env: { ...process.env, NO_COLOR: "1", PI_CODING_AGENT_DIR: agentDir },
+			shell: false,
+			stdio: ["pipe", "pipe", "pipe"],
+		},
+	);
+	return createRpcClient(child, onRecord, () => rmSync(agentDir, { recursive: true, force: true }));
+}
+
+function createRpcClient(
+	child: ChildProcessWithoutNullStreams,
+	onRecord: (value: unknown) => void,
+	cleanup: () => void,
+): RpcBenchmarkClient {
+	let buffer = "";
+	let stderr = "";
+	let nextId = 0;
+	let closed = false;
+	let protocolError: Error | undefined;
+	const pending = new Map<
+		string,
+		{ resolve: (response: RpcResponse) => void; reject: (error: Error) => void }
+	>();
+	const eventWaiters = new Map<
+		string,
+		Array<{ resolve: (event: Record<string, unknown>) => void; reject: (error: Error) => void }>
+	>();
+
+	const fail = (failure: Error): void => {
+		protocolError ??= failure;
+		for (const request of pending.values()) request.reject(failure);
+		pending.clear();
+		for (const waiters of eventWaiters.values()) {
+			for (const waiter of waiters) waiter.reject(failure);
+		}
+		eventWaiters.clear();
+	};
+	const handleLine = (rawLine: string): void => {
+		const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+		if (!line) return;
+		let value: unknown;
+		try {
+			value = JSON.parse(line);
+		} catch {
+			fail(rpcProtocolError("Pi RPC emitted malformed JSONL"));
+			return;
+		}
+		onRecord(value);
+		if (!isRecord(value) || typeof value.type !== "string") return;
+		if (value.type === "response" && typeof value.id === "string") {
+			const request = pending.get(value.id);
+			if (!request) return;
+			pending.delete(value.id);
+			const response = value as RpcResponse;
+			if (response.success) request.resolve(response);
+			else request.reject(rpcProtocolError(String(response.error ?? "RPC request failed")));
+			return;
+		}
+		const waiters = eventWaiters.get(value.type);
+		const waiter = waiters?.shift();
+		if (waiter) waiter.resolve(value);
+		if (waiters?.length === 0) eventWaiters.delete(value.type);
+	};
+
+	child.stdout.on("data", (chunk: Buffer) => {
+		buffer += chunk.toString("utf8");
+		while (true) {
+			const newline = buffer.indexOf("\n");
+			if (newline < 0) break;
+			const line = buffer.slice(0, newline);
+			buffer = buffer.slice(newline + 1);
+			handleLine(line);
+		}
+	});
+	child.stderr.on("data", (chunk: Buffer) => {
+		stderr = `${stderr}${chunk.toString("utf8")}`.slice(-16 * 1024);
+	});
+	child.once("error", (caught) => fail(caught));
+	child.once("close", (code, signal) => {
+		closed = true;
+		if (buffer) handleLine(buffer);
+		fail(
+			protocolError ??
+				new Error(
+					`Pi RPC exited before completion (code=${code ?? "null"}, signal=${signal ?? "null"})`,
+				),
+		);
+	});
+
+	const request = (type: string, payload: Record<string, unknown> = {}): Promise<RpcResponse> => {
+		if (closed || protocolError)
+			return Promise.reject(protocolError ?? new Error("Pi RPC is closed"));
+		const id = `async_benchmark_${++nextId}`;
+		return new Promise((resolve, reject) => {
+			pending.set(id, { resolve, reject });
+			child.stdin.write(`${JSON.stringify({ id, type, ...payload })}\n`, (caught) => {
+				if (!caught) return;
+				pending.delete(id);
+				reject(caught);
+			});
+		});
+	};
+	const waitForEvent = (type: string): Promise<Record<string, unknown>> => {
+		if (closed || protocolError)
+			return Promise.reject(protocolError ?? new Error("Pi RPC is closed"));
+		return new Promise((resolve, reject) => {
+			const waiters = eventWaiters.get(type) ?? [];
+			waiters.push({ resolve, reject });
+			eventWaiters.set(type, waiters);
+		});
+	};
+	const waitForClose = (timeoutMs: number): Promise<boolean> =>
+		new Promise((resolve) => {
+			if (closed) {
+				resolve(true);
+				return;
+			}
+			const timer = setTimeout(() => {
+				child.off("close", onClose);
+				resolve(false);
+			}, timeoutMs);
+			const onClose = (): void => {
+				clearTimeout(timer);
+				resolve(true);
+			};
+			child.once("close", onClose);
+		});
+	let stopPromise: Promise<void> | undefined;
+	const stop = (): Promise<void> => {
+		stopPromise ??= (async () => {
+			try {
+				if (!closed) {
+					child.stdin.end();
+					signalProcessGroup(child, "SIGTERM");
+					if (!(await waitForClose(500))) {
+						signalProcessGroup(child, "SIGKILL");
+						await waitForClose(500);
+					}
+				}
+			} finally {
+				cleanup();
+			}
+		})();
+		return stopPromise;
+	};
+	return {
+		request,
+		waitForEvent,
+		stop,
+		get stderr() {
+			return stderr;
+		},
+	};
+}
+
+function signalProcessGroup(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
+	if (process.platform !== "win32" && child.pid) {
+		try {
+			process.kill(-child.pid, signal);
+			return;
+		} catch {
+			// Fall back to the immediate process.
+		}
+	}
+	try {
+		child.kill(signal);
+	} catch {
+		// The process may already be gone.
+	}
+}
+
+function benchmarkCost(response: RpcResponse | undefined): number | null {
+	const data = response && isRecord(response.data) ? response.data : undefined;
+	return data && typeof data.cost === "number" && Number.isFinite(data.cost) ? data.cost : null;
+}
+
+function classifyError(error: unknown): AsyncSubagentBenchmarkTrialRecord["outcome"] {
+	return error instanceof Error && error.name === "RpcProtocolError"
+		? "protocol-error"
+		: "process-error";
+}
+
+function errorText(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function groupPairs(
+	plan: readonly AsyncSubagentBenchmarkTrialPlan[],
+): AsyncSubagentBenchmarkTrialPlan[][] {
+	const pairs = new Map<number, AsyncSubagentBenchmarkTrialPlan[]>();
+	for (const trial of plan) {
+		const pair = pairs.get(trial.pairIndex) ?? [];
+		pair.push(trial);
+		pairs.set(trial.pairIndex, pair);
+	}
+	return [...pairs.values()].map((pair) =>
+		pair.sort((left, right) => left.orderIndex - right.orderIndex),
+	);
+}
+
+async function runPool<T>(
+	items: readonly T[],
+	concurrency: number,
+	worker: (item: T) => Promise<void>,
+): Promise<void> {
+	let nextIndex = 0;
+	await Promise.all(
+		Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+			while (nextIndex < items.length) {
+				const item = items[nextIndex++];
+				await worker(item);
+			}
+		}),
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function copyBenchmarkAuthentication(targetDir: string): void {
+	const sourceDir = process.env.PI_CODING_AGENT_DIR ?? path.join(os.homedir(), ".pi", "agent");
+	for (const name of ["auth.json", "pi-accounts.json", "models-store.json"] as const) {
+		const source = path.join(sourceDir, name);
+		try {
+			if (!lstatSync(source).isFile()) continue;
+			const target = path.join(targetDir, name);
+			copyFileSync(source, target);
+			chmodSync(target, 0o600);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	}
+}
+
+function displayPath(value: string, cwd: string): string {
+	const relative = path.relative(cwd, value);
+	if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) return relative;
+	return path.basename(value);
+}
+
+function repositoryIdentity(cwd: string): {
+	commit: string | null;
+	dirty: boolean;
+	stateDigest: string | null;
+} {
+	try {
+		const runGit = (args: string[]): Buffer =>
+			execFileSync("git", args, {
+				cwd,
+				encoding: "buffer",
+				maxBuffer: 32 * 1024 * 1024,
+				stdio: ["ignore", "pipe", "ignore"],
+			});
+		const commit = runGit(["rev-parse", "HEAD"]).toString("utf8").trim();
+		const status = runGit(["status", "--porcelain=v1", "-z"]);
+		const hash = createHash("sha256")
+			.update(status)
+			.update(runGit(["diff", "--binary", "HEAD"]));
+		const untracked = runGit(["ls-files", "--others", "--exclude-standard", "-z"])
+			.toString("utf8")
+			.split("\0")
+			.filter(Boolean)
+			.sort();
+		for (const relativePath of untracked) {
+			hash
+				.update(relativePath)
+				.update("\0")
+				.update(readFileSync(path.join(cwd, relativePath)));
+		}
+		return { commit, dirty: status.length > 0, stateDigest: hash.digest("hex") };
+	} catch {
+		return { commit: null, dirty: true, stateDigest: null };
+	}
+}
+
+function round(value: number): number {
+	return Number(value.toFixed(3));
+}


### PR DESCRIPTION
## Summary

- add exact `background | required` detached-run tracking with persisted, fork-aware completion visibility and bounded canonical context
- preserve successful budget-stop finalization as typed `partial` evidence without treating it as mutating or verification success
- add an isolated paired sync/async benchmark with quick and extended modes, redacted raw records, hard deadlines, and signal-safe credential cleanup
- document the unsupported hard pre-display barrier and retain deprecated sync compatibility routes

No Pi core package was changed and no Pi core pull request is proposed.

## Verification

- `npm --workspace @narumitw/pi-subagents run check`
- focused package suite: 81 files, 495 tests
- `npm run check`
- `npm test`: 375 files, 3,321 tests
- fenced-code-aware README heading audit: 27 packages passed
- `just pack subagents`: 284 files; protocol and new runtime modules included
- Pi RPC package-load and lazy `/subagents status` smoke passed
- `git diff --check`

`npm run check` reports only the existing informational Biome schema 2.5.10 versus CLI 2.5.9 notice.

## Benchmark evidence

Final extended run: 10 paired trials, fixed `openai-codex/gpt-5.6-sol`, high thinking, recorded working-tree digest `9b2a56761be42860416c74c8e88b7069f757c840d8d691442f3680afa933c168`.

| Metric | Sync | Async |
| --- | ---: | ---: |
| Completion visibility | 100% | 100% |
| Evidence score | 100% | 100% |
| Measured premature verdicts | 0 | 0 |
| Completed trials | 10/10 | 10/10 |
| Median latency | 44.4s | 76.4s |
| P95 latency | 71.6s | 96.5s |
| Total available cost | 0.737 | 1.346 |

Async median latency was 72.0% slower in this sample, so the deprecation gate fails and sync remains available.
The benchmark is provider-dependent evidence, not deterministic CI or proof of causality.

## Risks and limitations

- Pi's supported extension API still cannot suppress already-streamed output or expose replay-safe steering to a tool, so there is no hard final-answer barrier or cross-mode steer-interruptible join.
- `subagent_await` remains a blocking compatibility fallback.
- Required-run tracking rejects a sixty-fifth unresolved dependency so every exact identity remains representable in bounded context.
- Live benchmark raw records remain local, mode-0600 artifacts and are not committed because they contain model output.
- Chain, fan-in, panel, and workflow callers still lack one-for-one detached replacements.
