### PR TITLE
refactor(subagents): clarify runner boundaries

### DIFF
--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -1314,6 +1314,10 @@ packages/pi-subagents/
 │   ├── timeout-finalization.ts   # Abort-time bounded summary prompts and deadlines
 │   ├── timeout-checkpoint.ts     # Redacted deterministic termination evidence
 │   ├── turn-budget.ts            # Idle, assistant-turn, and tool-call enforcement
+│   ├── runner.ts                 # Blocking subprocess execution and progress capture
+│   ├── runner-types.ts           # Shared subprocess result and launch contracts
+│   ├── subagent-details.ts       # Composed tool-result and panel detail contracts
+│   ├── process-control.ts        # Reusable child-process termination and escalation
 │   ├── runner-usage.ts           # Bounded subprocess usage accumulation
 │   ├── runner-result.ts          # Shared subprocess result interpretation
 │   ├── stateful-limit-ui.ts      # Detached capacity settings and recovery previews

--- a/packages/pi-subagents/src/consult-resources.ts
+++ b/packages/pi-subagents/src/consult-resources.ts
@@ -1,7 +1,7 @@
 import type { ConsultResourcePolicy } from "./agents/types.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
 import { resolvePiPromptResources } from "./prompt-resources.js";
-import type { ChildLaunchPolicy } from "./runner.js";
+import type { ChildLaunchPolicy } from "./runner-types.js";
 
 const MINIMAL_CONSULT_SYSTEM_PROMPT =
 	"You are a read-only consultation assistant. Analyze the delegated task using only executor-provided capabilities and return a grounded answer.";

--- a/packages/pi-subagents/src/consult.ts
+++ b/packages/pi-subagents/src/consult.ts
@@ -34,20 +34,15 @@ import {
 	DEFAULT_MAX_STDERR_BYTES,
 	MAX_SUBAGENT_TIMEOUT_MS,
 } from "./limits.js";
-import {
-	type ChildLaunchPolicy,
-	getResultFinalOutput,
-	isResultError,
-	runSingleAgent,
-	type SingleResult,
-	type SubagentDetails,
-} from "./runner.js";
+import { getResultFinalOutput, isResultError, runSingleAgent } from "./runner.js";
+import type { ChildLaunchPolicy, SingleResult } from "./runner-types.js";
 import { boundedPrivateText, boundText, safeDisplayPath, safeTerminalLine } from "./safe-text.js";
 import {
 	DEFAULT_CONSULT_RESOURCE_POLICY,
 	DEFAULT_CONSULTATION_CWD_POLICY,
 } from "./settings/inspection.js";
 import { resolveSubagentThinkingLevel } from "./settings.js";
+import type { SubagentDetails } from "./subagent-details.js";
 
 export { registerSubagentConsult } from "./consult-registration.js";
 export type {

--- a/packages/pi-subagents/src/execution.ts
+++ b/packages/pi-subagents/src/execution.ts
@@ -65,17 +65,16 @@ import {
 	getResultFinalOutput,
 	isResultError,
 	mapWithConcurrencyLimit,
-	type OnUpdateCallback,
 	runSingleAgent,
-	type SingleResult,
-	type SubagentDetails,
 } from "./runner.js";
+import type { SingleResult } from "./runner-types.js";
 import { safeTerminalLine } from "./safe-text.js";
 import {
 	DEFAULT_DELEGATION_CWD_POLICY,
 	resolveBlockingMaxParallelTasks,
 } from "./settings/inspection.js";
 import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.js";
+import type { OnUpdateCallback, SubagentDetails } from "./subagent-details.js";
 import { isRetryableResult, runHedgedAttempt, supervisionDelay } from "./supervision.js";
 import { TimeoutProgressJournal, TURN_TERMINATION_VERSION } from "./timeout-checkpoint.js";
 import type { TurnLimits } from "./turn-budget.js";

--- a/packages/pi-subagents/src/orchestration-metrics.ts
+++ b/packages/pi-subagents/src/orchestration-metrics.ts
@@ -1,4 +1,4 @@
-import type { SingleResult } from "./runner.js";
+import type { SingleResult } from "./runner-types.js";
 import type { WorkItemLedgerSnapshot } from "./work-item-ledger.js";
 
 export interface OrchestrationMetrics {

--- a/packages/pi-subagents/src/panel-execution.ts
+++ b/packages/pi-subagents/src/panel-execution.ts
@@ -31,15 +31,14 @@ import { buildPanelReviewerPrompt, buildPanelSynthesisPrompt } from "./panel-pro
 import { reconcilePanel } from "./panel-reconciliation.js";
 import type { SubagentParams } from "./params.js";
 import {
-	type ChildLaunchPolicy,
 	getResultFinalOutput,
 	isResultError,
 	mapWithConcurrencyLimit,
 	runSingleAgent,
-	type SingleResult,
-	type SubagentDetails,
 } from "./runner.js";
+import type { ChildLaunchPolicy, SingleResult } from "./runner-types.js";
 import { boundedPrivateText, boundText } from "./safe-text.js";
+import type { SubagentDetails } from "./subagent-details.js";
 import { createSessionWorkItemPersistence } from "./work-item-persistence.js";
 import { assertWorkspaceIsolationReady } from "./workspace.js";
 

--- a/packages/pi-subagents/src/panel-failure.ts
+++ b/packages/pi-subagents/src/panel-failure.ts
@@ -1,4 +1,4 @@
-import type { SingleResult } from "./runner.js";
+import type { SingleResult } from "./runner-types.js";
 
 export const PANEL_FAILURE_KINDS = [
 	"transient-launch",

--- a/packages/pi-subagents/src/panel-render.ts
+++ b/packages/pi-subagents/src/panel-render.ts
@@ -2,7 +2,7 @@ import type { Theme } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import type { SubagentParams } from "./params.js";
 import { safeBlock, safeLine } from "./render-common.js";
-import type { SubagentDetails } from "./runner.js";
+import type { SubagentDetails } from "./subagent-details.js";
 
 export function renderPanelCall(args: SubagentParams, theme: Theme): Text | undefined {
 	const panel = args.panel;

--- a/packages/pi-subagents/src/process-control.ts
+++ b/packages/pi-subagents/src/process-control.ts
@@ -1,0 +1,43 @@
+import type { spawn } from "node:child_process";
+
+export const KILL_GRACE_MS = 5000;
+
+function signalProcess(proc: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
+	if (process.platform !== "win32" && proc.pid) {
+		try {
+			process.kill(-proc.pid, signal);
+			return;
+		} catch {
+			// Fall back to signaling the immediate child when process-group signaling is unavailable.
+		}
+	}
+	try {
+		proc.kill(signal);
+	} catch {
+		// The process may already have exited.
+	}
+}
+
+export function terminateProcess(
+	proc: ReturnType<typeof spawn>,
+	graceMs = KILL_GRACE_MS,
+): () => void {
+	const leaderExited = proc.exitCode !== null || proc.signalCode !== null;
+	const capturedOutputClosed = [proc.stdout, proc.stderr].every(
+		(stream) => !stream || stream.readableEnded || stream.destroyed,
+	);
+	let closed = leaderExited && capturedOutputClosed;
+	const onClose = () => {
+		closed = true;
+	};
+	proc.once("close", onClose);
+	if (!closed) signalProcess(proc, "SIGTERM");
+	const escalation = setTimeout(() => {
+		if (!closed) signalProcess(proc, "SIGKILL");
+	}, graceMs);
+	escalation.unref();
+	return () => {
+		clearTimeout(escalation);
+		proc.off("close", onClose);
+	};
+}

--- a/packages/pi-subagents/src/render.ts
+++ b/packages/pi-subagents/src/render.ts
@@ -11,8 +11,9 @@ import type { AgentScope } from "./agents/types.js";
 import { renderPanelCall, renderPanelResult } from "./panel-render.js";
 import { hasUsableAggregator, type SubagentParams } from "./params.js";
 import { expansionHint, formatToolActivity, safeBlock, safeLine } from "./render-common.js";
-import type { SingleResult, SubagentDetails } from "./runner.js";
 import { getResultFinalOutput, isResultError } from "./runner-outcome.js";
+import type { SingleResult } from "./runner-types.js";
+import type { SubagentDetails } from "./subagent-details.js";
 import { formatUsageStats } from "./usage-format.js";
 
 const COLLAPSED_ITEM_COUNT = 5;

--- a/packages/pi-subagents/src/rpc-transport.ts
+++ b/packages/pi-subagents/src/rpc-transport.ts
@@ -24,6 +24,7 @@ import {
 	peerBridgeEnvironment,
 } from "./peer-transport.js";
 import { type PiInvocation, resolvePiInvocation } from "./pi-invocation.js";
+import { terminateProcess } from "./process-control.js";
 import { resolvePiPromptResources } from "./prompt-resources.js";
 import { JsonLineDecoder } from "./protocol.js";
 import type { AgentMailboxMessage, ManagedAgent, TurnOutcome } from "./registry.js";
@@ -42,7 +43,6 @@ import {
 	observeRpcBudgetEvent,
 	snapshotRpcUsage,
 } from "./rpc-turn-capture.js";
-import { terminateProcess } from "./runner.js";
 import { safeTerminalText } from "./safe-text.js";
 import { readSubagentSettings } from "./settings.js";
 import { buildStatefulTurnPrompt, resolveStatefulTurnTimeout } from "./stateful-prompt.js";

--- a/packages/pi-subagents/src/runner-outcome.ts
+++ b/packages/pi-subagents/src/runner-outcome.ts
@@ -1,9 +1,9 @@
-import type { SingleResult } from "./runner.js";
 import {
 	formatResultFailure as formatBaseResultFailure,
 	getResultFinalOutput as getBaseResultFinalOutput,
 	isResultError as isBaseResultError,
 } from "./runner-result.js";
+import type { SingleResult } from "./runner-types.js";
 
 export function getResultFinalOutput(result: SingleResult): string {
 	return getBaseResultFinalOutput(result);

--- a/packages/pi-subagents/src/runner-result.ts
+++ b/packages/pi-subagents/src/runner-result.ts
@@ -1,6 +1,6 @@
 import type { Message } from "@earendil-works/pi-ai";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
-import type { SingleResult } from "./runner.js";
+import type { SingleResult } from "./runner-types.js";
 import { formatTimeoutCheckpoint } from "./timeout-checkpoint.js";
 
 export function getFinalOutput(messages: Message[]): string {

--- a/packages/pi-subagents/src/runner-types.ts
+++ b/packages/pi-subagents/src/runner-types.ts
@@ -1,0 +1,102 @@
+import type { Message } from "@earendil-works/pi-ai";
+import type { AgentSource, SubagentThinkingLevel } from "./agents/types.js";
+import type { CapabilityGrant } from "./capability-grant.js";
+import type { TargetPolicyAudit } from "./cwd-policy.js";
+import type { DelegationContract } from "./delegation-contract.js";
+import type { ExecutionPlan } from "./execution-plan.js";
+import type { ClassifiedSubagentOutcome } from "./outcome.js";
+import type { AnyStructuredSubagentResult, SubagentResultFormat } from "./result-contract.js";
+import type { UsageStats } from "./runner-usage.js";
+import type { TurnTerminationReport } from "./timeout-checkpoint.js";
+import type { TurnLimits } from "./turn-budget.js";
+
+export type RecentActivityItem =
+	| { type: "text"; text: string }
+	| { type: "toolCall"; name: string; args: Record<string, unknown> };
+
+export interface SingleResult {
+	agent: string;
+	agentSource: AgentSource | "unknown";
+	task: string;
+	exitCode: number;
+	messages: Message[];
+	stderr: string;
+	usage: UsageStats;
+	model?: string;
+	actualProvider?: string;
+	actualModel?: string;
+	recentActivity?: RecentActivityItem[];
+	recentActivityTotal?: number;
+	thinkingLevel?: SubagentThinkingLevel;
+	stopReason?: string;
+	errorMessage?: string;
+	step?: number;
+	finalOutput?: string;
+	partialOutput?: string;
+	timeoutSummary?: string;
+	timeoutSummaryError?: string;
+	termination?: TurnTerminationReport;
+	timedOut?: boolean;
+	timeoutMs?: number;
+	aborted?: boolean;
+	truncated?: boolean;
+	malformedEvents?: number;
+	launchFailed?: boolean;
+	processStarted?: boolean;
+	target?: TargetPolicyAudit;
+	policy?: {
+		inherited: string[];
+		overridden: string[];
+		unsupported: string[];
+	};
+	contract?: DelegationContract;
+	resultFormat?: SubagentResultFormat;
+	structuredResult?: AnyStructuredSubagentResult;
+	resultContractInvalid?: boolean;
+	outcome?: ClassifiedSubagentOutcome;
+	attemptCount?: number;
+	hedged?: boolean;
+	executionPlan?: ExecutionPlan;
+	capabilityGrant?: CapabilityGrant;
+}
+
+export interface ChildLaunchPolicy {
+	tools?: string[];
+	disableExtensions?: boolean;
+	disableSkills?: boolean;
+	disablePromptTemplates?: boolean;
+	disableContextFiles?: boolean;
+	projectTrust?: boolean;
+	baseSystemPrompt?: string;
+	appendSystemPromptPaths?: string[];
+	/** Package-owned explicit child extensions loaded even when unrelated extensions are disabled. */
+	extensionPaths?: string[];
+	/** Package-owned tools added to the child allowlist without changing delegated execution tools. */
+	additionalTools?: string[];
+	/** Ephemeral child-process environment consumed and cleared by a package-owned bridge. */
+	env?: NodeJS.ProcessEnv;
+	/** Internal timeout recovery control; omitted means enabled. */
+	finalizeOnTimeout?: boolean;
+	/** Internal hard deadline for the summary attempt. */
+	timeoutFinalizationMs?: number;
+	/** Optional stateful result contract retained during timeout finalization. */
+	timeoutResultFormat?: SubagentResultFormat;
+	/** Optional non-wall-clock limits for this turn. */
+	turnLimits?: TurnLimits;
+	/** Override the timeout reason when an orchestration deadline caps this child. */
+	workTimeoutReason?: "work_timeout" | "orchestration_timeout";
+	/** Public limit value reported when the effective child timeout is only the remaining budget. */
+	workTimeoutReportLimit?: number;
+	/** Absolute blocking-workflow deadline that also caps model finalization. */
+	orchestrationDeadlineAt?: number;
+	/** Completion contract requested for this turn. */
+	resultFormat?: SubagentResultFormat;
+	/** Normalized request contract retained in result details. */
+	contract?: DelegationContract;
+	/** Original task summary shown in result details when the executed prompt has contract metadata. */
+	displayTask?: string;
+	/** Immutable audit or enforcement decision made before launch. */
+	executionPlan?: ExecutionPlan;
+	/** Executor-owned authority lifetime bound to the accepted plan generation. */
+	capabilityGrant?: CapabilityGrant;
+}

--- a/packages/pi-subagents/src/runner.ts
+++ b/packages/pi-subagents/src/runner.ts
@@ -2,20 +2,10 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Message } from "@earendil-works/pi-ai";
 import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
-import type { SchedulingDecision } from "./adaptive-scheduler.js";
-import type {
-	AgentConfig,
-	AgentScope,
-	AgentSource,
-	SubagentThinkingLevel,
-} from "./agents/types.js";
-import { type CapabilityGrant, revokeCapabilityGrant } from "./capability-grant.js";
-import type { TargetPolicyAudit } from "./cwd-policy.js";
-import type { DelegationContract } from "./delegation-contract.js";
-import type { ExecutionPlan } from "./execution-plan.js";
+import type { AgentConfig, SubagentThinkingLevel } from "./agents/types.js";
+import { revokeCapabilityGrant } from "./capability-grant.js";
 import {
 	appendBounded,
 	DEFAULT_MAX_CONTEXT_BYTES,
@@ -25,138 +15,50 @@ import {
 	MAX_SUBAGENT_TIMEOUT_MS,
 	truncateUtf8,
 } from "./limits.js";
-import type { OrchestrationMetrics } from "./orchestration-metrics.js";
-import { type ClassifiedSubagentOutcome, classifyStructuredOutcome } from "./outcome.js";
-import type { PanelSynthesis } from "./panel-contract.js";
-import type { PanelEvidenceArtifact } from "./panel-evidence.js";
-import type { PanelFailure } from "./panel-failure.js";
-import type { PanelPhaseBudgets, PanelPreset } from "./panel-planning.js";
+import { classifyStructuredOutcome } from "./outcome.js";
 import { buildPiArgs } from "./pi-args.js";
 import { resolvePiInvocation } from "./pi-invocation.js";
+import { KILL_GRACE_MS, terminateProcess } from "./process-control.js";
 import { JsonLineDecoder } from "./protocol.js";
-import {
-	type AnyStructuredSubagentResult,
-	parseAnyStructuredSubagentResult,
-	type SubagentResultFormat,
-} from "./result-contract.js";
+import { parseAnyStructuredSubagentResult } from "./result-contract.js";
 import { formatResultFailure, getResultFinalOutput, isResultError } from "./runner-outcome.js";
 import { getFinalOutput } from "./runner-result.js";
+import type { ChildLaunchPolicy, RecentActivityItem, SingleResult } from "./runner-types.js";
 import {
 	addUsageValue,
 	mergeUsageStats,
 	protocolUsageCost,
 	protocolUsageCount,
-	type UsageStats,
 } from "./runner-usage.js";
+import type { OnUpdateCallback, SubagentDetails } from "./subagent-details.js";
 import {
 	formatTimeoutCheckpoint,
 	formatTurnTerminationMessage,
 	journalMessages,
 	TimeoutProgressJournal,
 	TURN_TERMINATION_VERSION,
-	type TurnTerminationReport,
 } from "./timeout-checkpoint.js";
 import {
 	buildTimeoutFinalizationPrompt,
 	resolveTimeoutFinalizationMs,
 } from "./timeout-finalization.js";
-import { TurnBudgetMonitor, type TurnBudgetStop, type TurnLimits } from "./turn-budget.js";
-import type { WorkItemLedgerSnapshot } from "./work-item-ledger.js";
-
-export const KILL_GRACE_MS = 5000;
+import { TurnBudgetMonitor, type TurnBudgetStop } from "./turn-budget.js";
 
 export type { PiArgsOptions } from "./pi-args.js";
 export { buildPiArgs } from "./pi-args.js";
+export { KILL_GRACE_MS, terminateProcess } from "./process-control.js";
 export {
 	formatResultFailure,
 	getResultFinalOutput,
 	isResultError,
 } from "./runner-outcome.js";
+export type { ChildLaunchPolicy, RecentActivityItem, SingleResult } from "./runner-types.js";
 export type { UsageStats } from "./runner-usage.js";
-export type RecentActivityItem =
-	| { type: "text"; text: string }
-	| { type: "toolCall"; name: string; args: Record<string, unknown> };
+export type { OnUpdateCallback, PanelDetails, SubagentDetails } from "./subagent-details.js";
 
 const MAX_RECENT_ACTIVITY_ITEMS = 10;
 const MAX_RECENT_ACTIVITY_BYTES = 8 * 1024;
 const MAX_RECENT_ACTIVITY_ARGUMENT_BYTES = 1024;
-
-export interface SingleResult {
-	agent: string;
-	agentSource: AgentSource | "unknown";
-	task: string;
-	exitCode: number;
-	messages: Message[];
-	stderr: string;
-	usage: UsageStats;
-	model?: string;
-	actualProvider?: string;
-	actualModel?: string;
-	recentActivity?: RecentActivityItem[];
-	recentActivityTotal?: number;
-	thinkingLevel?: SubagentThinkingLevel;
-	stopReason?: string;
-	errorMessage?: string;
-	step?: number;
-	finalOutput?: string;
-	partialOutput?: string;
-	timeoutSummary?: string;
-	timeoutSummaryError?: string;
-	termination?: TurnTerminationReport;
-	timedOut?: boolean;
-	timeoutMs?: number;
-	aborted?: boolean;
-	truncated?: boolean;
-	malformedEvents?: number;
-	launchFailed?: boolean;
-	processStarted?: boolean;
-	target?: TargetPolicyAudit;
-	policy?: {
-		inherited: string[];
-		overridden: string[];
-		unsupported: string[];
-	};
-	contract?: DelegationContract;
-	resultFormat?: SubagentResultFormat;
-	structuredResult?: AnyStructuredSubagentResult;
-	resultContractInvalid?: boolean;
-	outcome?: ClassifiedSubagentOutcome;
-	attemptCount?: number;
-	hedged?: boolean;
-	executionPlan?: ExecutionPlan;
-	capabilityGrant?: CapabilityGrant;
-}
-
-export interface PanelDetails {
-	id: string;
-	preset: PanelPreset;
-	sharedTaskPreview: string;
-	state: "running" | "completed" | "degraded" | "insufficient-panel" | "failed" | "cancelled";
-	reviewerIds: string[];
-	validReviewCount: number;
-	failedReviewCount: number;
-	blockingObjectionCount: number;
-	dissentCount: number;
-	budgets: PanelPhaseBudgets;
-	evidence: PanelEvidenceArtifact[];
-	failures: PanelFailure[];
-	synthesis?: PanelSynthesis;
-	synthesizerResult?: SingleResult;
-	cleanupComplete: boolean;
-}
-
-export interface SubagentDetails {
-	mode: "single" | "parallel" | "chain" | "workflow" | "panel";
-	agentScope: AgentScope;
-	projectAgentsDir: string | null;
-	results: SingleResult[];
-	aggregator?: SingleResult;
-	workflow?: WorkItemLedgerSnapshot;
-	schedulerDecisions?: SchedulingDecision[];
-	metrics?: OrchestrationMetrics;
-	panel?: PanelDetails;
-	isError?: boolean;
-}
 
 function boundMessageText(
 	message: Message,
@@ -336,89 +238,6 @@ async function writePromptToTempFile(
 		await fs.promises.writeFile(filePath, prompt, { encoding: "utf-8", mode: 0o600 });
 	});
 	return { dir: tmpDir, filePath };
-}
-
-function signalProcess(proc: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
-	if (process.platform !== "win32" && proc.pid) {
-		try {
-			process.kill(-proc.pid, signal);
-			return;
-		} catch {
-			// Fall back to signaling the immediate child when process-group signaling is unavailable.
-		}
-	}
-	try {
-		proc.kill(signal);
-	} catch {
-		// The process may already have exited.
-	}
-}
-
-export function terminateProcess(
-	proc: ReturnType<typeof spawn>,
-	graceMs = KILL_GRACE_MS,
-): () => void {
-	const leaderExited = proc.exitCode !== null || proc.signalCode !== null;
-	const capturedOutputClosed = [proc.stdout, proc.stderr].every(
-		(stream) => !stream || stream.readableEnded || stream.destroyed,
-	);
-	let closed = leaderExited && capturedOutputClosed;
-	const onClose = () => {
-		closed = true;
-	};
-	proc.once("close", onClose);
-	if (!closed) signalProcess(proc, "SIGTERM");
-	const escalation = setTimeout(() => {
-		if (!closed) signalProcess(proc, "SIGKILL");
-	}, graceMs);
-	escalation.unref();
-	return () => {
-		clearTimeout(escalation);
-		proc.off("close", onClose);
-	};
-}
-
-export type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void;
-
-export interface ChildLaunchPolicy {
-	tools?: string[];
-	disableExtensions?: boolean;
-	disableSkills?: boolean;
-	disablePromptTemplates?: boolean;
-	disableContextFiles?: boolean;
-	projectTrust?: boolean;
-	baseSystemPrompt?: string;
-	appendSystemPromptPaths?: string[];
-	/** Package-owned explicit child extensions loaded even when unrelated extensions are disabled. */
-	extensionPaths?: string[];
-	/** Package-owned tools added to the child allowlist without changing delegated execution tools. */
-	additionalTools?: string[];
-	/** Ephemeral child-process environment consumed and cleared by a package-owned bridge. */
-	env?: NodeJS.ProcessEnv;
-	/** Internal timeout recovery control; omitted means enabled. */
-	finalizeOnTimeout?: boolean;
-	/** Internal hard deadline for the summary attempt. */
-	timeoutFinalizationMs?: number;
-	/** Optional stateful result contract retained during timeout finalization. */
-	timeoutResultFormat?: SubagentResultFormat;
-	/** Optional non-wall-clock limits for this turn. */
-	turnLimits?: TurnLimits;
-	/** Override the timeout reason when an orchestration deadline caps this child. */
-	workTimeoutReason?: "work_timeout" | "orchestration_timeout";
-	/** Public limit value reported when the effective child timeout is only the remaining budget. */
-	workTimeoutReportLimit?: number;
-	/** Absolute blocking-workflow deadline that also caps model finalization. */
-	orchestrationDeadlineAt?: number;
-	/** Completion contract requested for this turn. */
-	resultFormat?: SubagentResultFormat;
-	/** Normalized request contract retained in result details. */
-	contract?: DelegationContract;
-	/** Original task summary shown in result details when the executed prompt has contract metadata. */
-	displayTask?: string;
-	/** Immutable audit or enforcement decision made before launch. */
-	executionPlan?: ExecutionPlan;
-	/** Executor-owned authority lifetime bound to the accepted plan generation. */
-	capabilityGrant?: CapabilityGrant;
 }
 
 export async function runSingleAgent(

--- a/packages/pi-subagents/src/subagent-details.ts
+++ b/packages/pi-subagents/src/subagent-details.ts
@@ -1,0 +1,43 @@
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import type { SchedulingDecision } from "./adaptive-scheduler.js";
+import type { AgentScope } from "./agents/types.js";
+import type { OrchestrationMetrics } from "./orchestration-metrics.js";
+import type { PanelSynthesis } from "./panel-contract.js";
+import type { PanelEvidenceArtifact } from "./panel-evidence.js";
+import type { PanelFailure } from "./panel-failure.js";
+import type { PanelPhaseBudgets, PanelPreset } from "./panel-planning.js";
+import type { SingleResult } from "./runner-types.js";
+import type { WorkItemLedgerSnapshot } from "./work-item-ledger.js";
+
+export interface PanelDetails {
+	id: string;
+	preset: PanelPreset;
+	sharedTaskPreview: string;
+	state: "running" | "completed" | "degraded" | "insufficient-panel" | "failed" | "cancelled";
+	reviewerIds: string[];
+	validReviewCount: number;
+	failedReviewCount: number;
+	blockingObjectionCount: number;
+	dissentCount: number;
+	budgets: PanelPhaseBudgets;
+	evidence: PanelEvidenceArtifact[];
+	failures: PanelFailure[];
+	synthesis?: PanelSynthesis;
+	synthesizerResult?: SingleResult;
+	cleanupComplete: boolean;
+}
+
+export interface SubagentDetails {
+	mode: "single" | "parallel" | "chain" | "workflow" | "panel";
+	agentScope: AgentScope;
+	projectAgentsDir: string | null;
+	results: SingleResult[];
+	aggregator?: SingleResult;
+	workflow?: WorkItemLedgerSnapshot;
+	schedulerDecisions?: SchedulingDecision[];
+	metrics?: OrchestrationMetrics;
+	panel?: PanelDetails;
+	isError?: boolean;
+}
+
+export type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void;

--- a/packages/pi-subagents/src/subagents-extension.ts
+++ b/packages/pi-subagents/src/subagents-extension.ts
@@ -39,7 +39,6 @@ import {
 import { MAX_BLOCKING_PARALLEL_CONCURRENCY } from "./limits.js";
 import { SubagentParams } from "./params.js";
 import { renderSubagentCall, renderSubagentResult } from "./render.js";
-import type { SubagentDetails } from "./runner.js";
 import {
 	consumeSubagentSettingsNotice,
 	DEFAULT_CONSULT_RESOURCE_POLICY,
@@ -50,6 +49,7 @@ import {
 	resolveBlockingMaxParallelTasks,
 } from "./settings-reader.js";
 import { registerStatefulSubagents } from "./stateful-registration.js";
+import type { SubagentDetails } from "./subagent-details.js";
 import type { SubagentTransport } from "./transport.js";
 import {
 	registerUsageRecording,

--- a/packages/pi-subagents/src/subprocess-transport.ts
+++ b/packages/pi-subagents/src/subprocess-transport.ts
@@ -8,9 +8,10 @@ import {
 } from "./peer-transport.js";
 import { resolvePiPromptResources } from "./prompt-resources.js";
 import type { ManagedAgent, TurnOutcome } from "./registry.js";
-import { getResultFinalOutput, runSingleAgent, type SubagentDetails } from "./runner.js";
+import { getResultFinalOutput, runSingleAgent } from "./runner.js";
 import { readSubagentSettings, resolveSubagentThinkingLevel } from "./settings.js";
 import { buildStatefulTurnPrompt, resolveStatefulTurnTimeout } from "./stateful-prompt.js";
+import type { SubagentDetails } from "./subagent-details.js";
 import type { SubagentTransport } from "./transport.js";
 import type { TransportProgressCallback, TransportTelemetry } from "./transport-types.js";
 

--- a/packages/pi-subagents/src/supervision.ts
+++ b/packages/pi-subagents/src/supervision.ts
@@ -1,4 +1,5 @@
-import { isResultError, type SingleResult } from "./runner.js";
+import { isResultError } from "./runner-outcome.js";
+import type { SingleResult } from "./runner-types.js";
 
 const HEDGE_LOSER_GRACE_MS = 5_000;
 

--- a/packages/pi-subagents/src/timeout-finalization.ts
+++ b/packages/pi-subagents/src/timeout-finalization.ts
@@ -1,7 +1,7 @@
 import { redactPrivateText } from "./context.js";
 import { DEFAULT_MAX_CONTEXT_BYTES, truncateUtf8 } from "./limits.js";
 import { appendResultInstruction, type SubagentResultFormat } from "./result-contract.js";
-import type { RecentActivityItem } from "./runner.js";
+import type { RecentActivityItem } from "./runner-types.js";
 import {
 	formatTimeoutCheckpoint,
 	type TimeoutCheckpoint,

--- a/packages/pi-subagents/src/verification-harness.ts
+++ b/packages/pi-subagents/src/verification-harness.ts
@@ -6,7 +6,7 @@ import * as path from "node:path";
 import { promisify } from "node:util";
 import { redactPrivateText } from "./context.js";
 import { appendBounded, truncateUtf8 } from "./limits.js";
-import { terminateProcess } from "./runner.js";
+import { terminateProcess } from "./process-control.js";
 import type { VerificationCheckReceipt } from "./verification-receipt.js";
 import {
 	captureWorkflowTreeIdentity,


### PR DESCRIPTION
## Summary

- extract shared runner result and launch contracts from `runner.ts`
- extract composed tool details and reusable process termination ownership
- preserve existing `runner.ts` source imports through compatibility re-exports
- reduce `runner.ts` from 1,047 to 866 lines without changing delegation behavior

## Verification

- `npm run check`
- `npm test` (3,321 tests)
- 40 focused runner, process termination, RPC transport, verification harness, rendering, and generated-runtime tests
- package-directory RPC-mode Pi load smoke through the generated Jiti runtime

## Semantic audit

- reviewed `docs/extension-conventions.md` and `docs/extension-settings.md`
- cancellation and process escalation behavior moved unchanged and remains covered by focused tests
- no asynchronous UI, lifecycle, settings, persistence, command, or tool behavior changed
- no Changeset because this is a behavior-preserving internal refactor
