### PR TITLE
fix(subagents): support llama.cpp tool schemas

### DIFF
--- a/.changeset/safe-subagents-llama.md
+++ b/.changeset/safe-subagents-llama.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": patch
+---
+
+Keep `subagent` and `subagent_spawn` tool schemas compatible with llama.cpp by omitting large nested string repetitions while retaining runtime input bounds.

--- a/packages/pi-subagents/src/params.ts
+++ b/packages/pi-subagents/src/params.ts
@@ -5,6 +5,7 @@ import { DelegationContractSchema } from "./delegation-contract.js";
 import { MAX_CONFIGURABLE_PARALLEL_TASKS, MAX_SUBAGENT_TIMEOUT_MS } from "./limits.js";
 import { PANEL_PRESETS } from "./panel-presets.js";
 import { SUBAGENT_RESULT_FORMATS } from "./result-contract.js";
+import { grammarSafeToolObject } from "./tool-schema-compatibility.js";
 import { MAX_SUBAGENT_TOOL_CALLS, MAX_SUBAGENT_TURNS } from "./turn-budget.js";
 import { VerifiedExecutionContractSchema } from "./verified-execution-schema.js";
 
@@ -202,7 +203,7 @@ const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
 	default: "user",
 });
 
-export const SubagentParams = Type.Object({
+export const SubagentParams = grammarSafeToolObject({
 	agent: Type.Optional(
 		Type.String({ description: "Name of the agent to invoke (for single mode)" }),
 	),

--- a/packages/pi-subagents/src/stateful-registration.ts
+++ b/packages/pi-subagents/src/stateful-registration.ts
@@ -60,6 +60,7 @@ import {
 	validateManageParams,
 } from "./stateful-tool-params.js";
 import { MAX_TASK_NAME_LENGTH } from "./task-path.js";
+import { grammarSafeToolObject } from "./tool-schema-compatibility.js";
 import { MAX_SUBAGENT_TOOL_CALLS, MAX_SUBAGENT_TURNS } from "./turn-budget.js";
 import type { UsageRecordingController } from "./usage-recording.js";
 import type { WorkspaceManager } from "./workspace.js";
@@ -694,7 +695,7 @@ export function registerStatefulSubagents(
 		description: appendAgentCatalog(baseSpawnDescription(), agentCatalog),
 		promptSnippet: "Start a reusable detached subagent; completion is delivered asynchronously",
 		promptGuidelines: createSpawnPromptGuidelines(completionDelivery, blockingEnabled),
-		parameters: Type.Object({
+		parameters: grammarSafeToolObject({
 			agent: Type.String({ minLength: 1 }),
 			taskName: Type.Optional(
 				Type.String({

--- a/packages/pi-subagents/src/tool-schema-compatibility.ts
+++ b/packages/pi-subagents/src/tool-schema-compatibility.ts
@@ -1,0 +1,73 @@
+import { type TObject, type TObjectOptions, type TProperties, type TSchema, Type } from "typebox";
+
+const LLAMA_CPP_MAX_REPETITION_THRESHOLD = 2_000;
+
+/**
+ * Remove large nested string repetitions that llama.cpp cannot compile into GBNF.
+ *
+ * Runtime normalization and validation continue to bound these inputs.
+ * See https://github.com/ggml-org/llama.cpp/issues/25746.
+ */
+export function grammarSafeToolObject<Properties extends TProperties>(
+	properties: Properties,
+	options?: TObjectOptions,
+): TObject<Properties> {
+	return makeGrammarSafeToolSchema(Type.Object(properties, options));
+}
+
+function makeGrammarSafeToolSchema<Schema extends TSchema>(schema: Schema): Schema {
+	return cloneSchema(schema, 0) as Schema;
+}
+
+function cloneSchema(schema: unknown, depth: number): unknown {
+	if (!isRecord(schema)) return schema;
+	const clone = cloneWithDescriptors(schema);
+	if (
+		depth > 1 &&
+		clone.type === "string" &&
+		typeof clone.maxLength === "number" &&
+		clone.maxLength >= LLAMA_CPP_MAX_REPETITION_THRESHOLD
+	) {
+		delete clone.maxLength;
+	}
+	if (isRecord(clone.properties)) {
+		clone.properties = mapSchemas(clone.properties, depth + 1);
+	}
+	if (clone.items !== undefined) {
+		clone.items = Array.isArray(clone.items)
+			? clone.items.map((item) => cloneSchema(item, depth + 1))
+			: cloneSchema(clone.items, depth + 1);
+	}
+	if (Array.isArray(clone.prefixItems)) {
+		clone.prefixItems = clone.prefixItems.map((item) => cloneSchema(item, depth + 1));
+	}
+	for (const keyword of ["allOf", "anyOf", "oneOf"] as const) {
+		if (Array.isArray(clone[keyword])) {
+			clone[keyword] = clone[keyword].map((item) => cloneSchema(item, depth));
+		}
+	}
+	if (isRecord(clone.patternProperties)) {
+		clone.patternProperties = mapSchemas(clone.patternProperties, depth + 1);
+	}
+	if (isRecord(clone.additionalProperties)) {
+		clone.additionalProperties = cloneSchema(clone.additionalProperties, depth + 1);
+	}
+	return clone;
+}
+
+function mapSchemas(schemas: Record<string, unknown>, depth: number): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(schemas).map(([name, schema]) => [name, cloneSchema(schema, depth)]),
+	);
+}
+
+function cloneWithDescriptors(value: Record<string, unknown>): Record<string, unknown> {
+	return Object.defineProperties(
+		Object.create(Object.getPrototypeOf(value)),
+		Object.getOwnPropertyDescriptors(value),
+	) as Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/pi-subagents/test/delegation-contract.test.ts
+++ b/packages/pi-subagents/test/delegation-contract.test.ts
@@ -31,6 +31,16 @@ test("delegation contract normalizes bounded request semantics", () => {
 	assert.equal(contract?.dependencies[0]?.artifactId, "design");
 	assert.deepEqual(contract?.requestedAuthority?.tools, ["read", "edit"]);
 	assert.equal(contract?.budget?.timeoutMs, 60_000);
+
+	const oversizedItem = normalizeDelegationContract({
+		version: "pi-subagents:delegation:v2",
+		level: "minimal",
+		taskId: "bounded-item",
+		objective: "Bound the evidence",
+		requiredEvidence: ["界".repeat(4_096)],
+	});
+	assert.ok(oversizedItem);
+	assert.ok(Buffer.byteLength(oversizedItem.requiredEvidence[0] ?? "", "utf8") <= 4 * 1024);
 });
 
 test("delegation contract rejects malformed versions, duplicate identifiers, and invalid bounds", () => {

--- a/packages/pi-subagents/test/tool-schema-compatibility.test.ts
+++ b/packages/pi-subagents/test/tool-schema-compatibility.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { afterAll, test } from "vitest";
+import { createMockPi } from "../../../test/support.js";
+import subagents from "../src/subagents.js";
+import { installSubagentsTestEnvironment } from "./subagents-test-helpers.js";
+
+const restoreTestEnvironment = installSubagentsTestEnvironment();
+afterAll(restoreTestEnvironment);
+
+const LLAMA_CPP_MAX_REPETITION_THRESHOLD = 2_000;
+
+test("subagent tool schemas avoid large nested string repetitions", () => {
+	const mock = createMockPi();
+	subagents(mock.pi);
+
+	for (const toolName of ["subagent", "subagent_spawn"]) {
+		const tool = mock.tools.find((candidate) => candidate.name === toolName);
+		assert.ok(tool, `missing ${toolName} tool`);
+		assert.deepEqual(findUnsafeNestedStringBounds(tool.parameters), []);
+	}
+});
+
+function findUnsafeNestedStringBounds(schema: unknown): string[] {
+	const unsafe: string[] = [];
+	visitSchema(schema, "$", 0, unsafe);
+	return unsafe;
+}
+
+function visitSchema(schema: unknown, path: string, depth: number, unsafe: string[]): void {
+	if (!isRecord(schema)) return;
+	if (
+		depth > 1 &&
+		schema.type === "string" &&
+		typeof schema.maxLength === "number" &&
+		schema.maxLength >= LLAMA_CPP_MAX_REPETITION_THRESHOLD
+	) {
+		unsafe.push(`${path} (maxLength ${schema.maxLength})`);
+	}
+	if (isRecord(schema.properties)) {
+		for (const [name, child] of Object.entries(schema.properties)) {
+			visitSchema(child, `${path}.${name}`, depth + 1, unsafe);
+		}
+	}
+	if (schema.items !== undefined) {
+		if (Array.isArray(schema.items)) {
+			schema.items.forEach((child, index) => {
+				visitSchema(child, `${path}.items[${index}]`, depth + 1, unsafe);
+			});
+		} else {
+			visitSchema(schema.items, `${path}.items`, depth + 1, unsafe);
+		}
+	}
+	for (const keyword of ["allOf", "anyOf", "oneOf"] as const) {
+		const children = schema[keyword];
+		if (!Array.isArray(children)) continue;
+		children.forEach((child, index) => {
+			visitSchema(child, `${path}.${keyword}[${index}]`, depth, unsafe);
+		});
+	}
+	if (Array.isArray(schema.prefixItems)) {
+		schema.prefixItems.forEach((child, index) => {
+			visitSchema(child, `${path}.prefixItems[${index}]`, depth + 1, unsafe);
+		});
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

- omit `maxLength >= 2000` from nested strings in the provider-facing `subagent` and `subagent_spawn` schemas
- preserve TypeBox metadata, top-level bounds, and runtime normalization or validation
- add a recursive regression test and a patch changeset

Addresses #969 without closing it.

## Verification

- `npm run check`
- focused schema, registration, and runtime-bound tests: 8 passed
- generated runtime, startup import, and schema tests: 21 passed
- `npm --workspace @narumitw/pi-subagents run build`
- `npm run pack:subagents`
- `pi --no-extensions -e ./packages/pi-subagents --print "Reply with exactly OK."`

`npm test` was also attempted for the affected workspace. The final run completed with 503 passing and 36 failing tests, predominantly existing 5-second timeouts and subprocess-readiness failures in resource-heavy Git/worktree, benchmark, workflow, and runtime-build tests on this host. The focused changed-path tests pass.

A live llama.cpp endpoint was not available, so the provider-specific end-to-end smoke remains unverified. The regression test directly inventories both emitted tool schemas against llama.cpp's 2,000-repetition threshold.

## Convention audit

- Reviewed `docs/extension-conventions.md` and the package `AGENTS.md`.
- Tool names and the active tool list remain unchanged.
- Runtime input bounds remain in the existing delegation, panel, workflow, and verification paths.
- No settings, UI, asynchronous lifecycle, cancellation, session replacement, or shutdown flow changed.
