### PR TITLE
fix(pi-goal): preserve provider cache prefixes

### DIFF
--- a/.changeset/quiet-goals-cache.md
+++ b/.changeset/quiet-goals-cache.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-goal": patch
 ---
 
-Preserve retained conversation cache prefixes by persisting Goal contracts after existing history and removing only stale Goal-era contracts across identity and lifecycle transitions.
+Preserve retained conversation cache prefixes with append-only superseding Goal contracts, atomic handoff-boundary persistence, and current-state restoration after lifecycle transitions and compaction.

--- a/.changeset/quiet-goals-cache.md
+++ b/.changeset/quiet-goals-cache.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-goal": patch
+---
+
+Preserve retained conversation cache prefixes by persisting Goal contracts after existing history and removing only stale Goal-era contracts across identity and lifecycle transitions.

--- a/docs/implementation-notes/pi-goal-interruption-research.md
+++ b/docs/implementation-notes/pi-goal-interruption-research.md
@@ -96,10 +96,11 @@ uses the common idle dispatcher. Old queue metadata in `goal-state` or legacy `g
 is treated as inert legacy data and never dispatches automatic work.
 
 Goal prompts and compacted context use the same objective trust boundary, stale goal id, full-scope rule, and requirement-by-requirement completion audit.
-A newly activated Goal persists one versioned hidden `goal-contract` immediately before its Goal handoff, after retained pre-Goal conversation history.
-The matching contract stays at that position until Goal identity changes or the Goal becomes inactive.
-The `context` hook removes stale contracts and inserts a missing post-compaction contract after leading summaries.
-Session restore appends a missing active-Goal contract after retained history without waking an external wait.
+The first accepted handoff for a Goal identity and its versioned hidden `goal-contract` are persisted together at the agent-start boundary after retained conversation history.
+Every active or inactive contract explicitly supersedes earlier contracts, and historical contracts remain in their appended positions so provider input grows monotonically.
+Failed Goal handoff delivery persists no contract.
+Stopped transitions persist one inactive revision, while the `context` hook supplies a missing current revision after leading summaries as a correctness fallback.
+Compaction and session restore persist a missing current revision without waking an external wait.
 Mutable accounting remains outside the retained provider prompt prefix.
 Prompt wording is a guardrail; current files, commands, tests, runtime behavior, and external state remain the completion evidence.
 

--- a/docs/implementation-notes/pi-goal-interruption-research.md
+++ b/docs/implementation-notes/pi-goal-interruption-research.md
@@ -96,8 +96,11 @@ uses the common idle dispatcher. Old queue metadata in `goal-state` or legacy `g
 is treated as inert legacy data and never dispatches automatic work.
 
 Goal prompts and compacted context use the same objective trust boundary, stale goal id, full-scope rule, and requirement-by-requirement completion audit.
-The runtime constructs one versioned hidden `goal-contract` message at a fixed `context` hook boundary after leading summaries.
-It restores Goal instructions when persisted active state has no retained handoff and keeps mutable accounting out of the leading provider prompt prefix.
+A newly activated Goal persists one versioned hidden `goal-contract` immediately before its Goal handoff, after retained pre-Goal conversation history.
+The matching contract stays at that position until Goal identity changes or the Goal becomes inactive.
+The `context` hook removes stale contracts and inserts a missing post-compaction contract after leading summaries.
+Session restore appends a missing active-Goal contract after retained history without waking an external wait.
+Mutable accounting remains outside the retained provider prompt prefix.
 Prompt wording is a guardrail; current files, commands, tests, runtime behavior, and external state remain the completion evidence.
 
 ## Usage, elapsed time, and circuit breakers

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -296,10 +296,13 @@ Kickoff, resume, edited-objective, wait-resume, and automatic-continuation promp
 They treat the current worktree, command output, tests, runtime behavior, PR state, rendered artifacts, and external state as authoritative; previous conversation and plans are context rather than proof.
 
 With the default `toolVisibility: "after-first-goal"`, the first accepted Goal activation intentionally reveals the three Goal tools and changes the tool-definition prefix once.
-After that activation boundary, pi-goal does not change the base system instructions or ordered active tools merely for continuation, token accounting, or wait resume.
+Choosing `toolVisibility: "always"` avoids that activation-time tool change, while both visibility modes use the same Goal contract flow.
+After activation, pi-goal does not change the base system instructions or ordered active tools merely for continuation, token accounting, or wait resume.
 Current token-budget usage is carried by the newly appended Goal prompt instead of rewriting leading system instructions.
-For every active Goal, one deterministic hidden Goal contract occupies a fixed leading boundary and excludes mutable token, iteration, and elapsed-time counters.
-This contract follows leading summaries after compaction and also restores Goal instructions when persisted active state has no retained handoff.
+Each newly activated Goal persists one deterministic hidden Goal contract immediately before its Goal handoff, after previously retained conversation history.
+The matching contract stays at that history position while the same Goal remains active and excludes mutable token, iteration, and elapsed-time counters.
+Editing, replacing, stopped-state resume, completion, or clearing removes stale contracts without moving the conversation that predates the first Goal contract.
+After compaction, a missing current contract follows leading summaries, and restoring an active Goal appends a missing contract after retained history without waking a waiting Goal.
 These structural guarantees make provider prefix reuse possible, but the provider still decides cache eligibility, cache hits, pricing, and billing.
 
 Before completion, the shared audit tells the agent to treat completion as unproven, inspect requirement-by-requirement evidence for every named artifact, command, test, gate, invariant, and deliverable, and match each check's scope to the requirement it supports.

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -299,10 +299,10 @@ With the default `toolVisibility: "after-first-goal"`, the first accepted Goal a
 Choosing `toolVisibility: "always"` avoids that activation-time tool change, while both visibility modes use the same Goal contract flow.
 After activation, pi-goal does not change the base system instructions or ordered active tools merely for continuation, token accounting, or wait resume.
 Current token-budget usage is carried by the newly appended Goal prompt instead of rewriting leading system instructions.
-Each newly activated Goal persists one deterministic hidden Goal contract immediately before its Goal handoff, after previously retained conversation history.
-The matching contract stays at that history position while the same Goal remains active and excludes mutable token, iteration, and elapsed-time counters.
-Editing, replacing, stopped-state resume, completion, or clearing removes stale contracts without moving the conversation that predates the first Goal contract.
-After compaction, a missing current contract follows leading summaries, and restoring an active Goal appends a missing contract after retained history without waking a waiting Goal.
+The first accepted handoff for each Goal identity persists one deterministic hidden Goal contract at the same agent-start boundary, after previously retained conversation history.
+The contract explicitly supersedes earlier Goal contracts, excludes mutable token, iteration, and elapsed-time counters, and stays at its appended history position.
+Editing, replacing, and stopped-state resume append a new superseding active contract without deleting earlier provider input; failed handoff delivery appends no contract.
+Completion, clearing, and stopped transitions append one inactive superseding contract, while compaction and session restore append a missing current-state contract without waking a waiting Goal.
 These structural guarantees make provider prefix reuse possible, but the provider still decides cache eligibility, cache hits, pricing, and billing.
 
 Before completion, the shared audit tells the agent to treat completion as unproven, inspect requirement-by-requirement evidence for every named artifact, command, test, gate, invariant, and deliverable, and match each check's scope to the requirement it supports.

--- a/packages/pi-goal/src/goal-contract.ts
+++ b/packages/pi-goal/src/goal-contract.ts
@@ -10,6 +10,11 @@ interface ContractMessage {
 	content?: unknown;
 }
 
+interface ContractSessionEntry extends ContractMessage {
+	type?: string;
+	message?: unknown;
+}
+
 export function createGoalContextContract(goal: GoalPromptContext) {
 	return {
 		role: "custom" as const,
@@ -22,28 +27,44 @@ export function createGoalContextContract(goal: GoalPromptContext) {
 }
 
 export function reconcileGoalContextContract(messages: unknown[], goal: GoalPromptContext) {
-	const summaryBoundary = leadingSummaryBoundary(messages);
 	const expected = createGoalContextContract(goal);
-	const contractIndexes = messages.flatMap((message, index) =>
-		unwrapMessage(message).customType === GOAL_CONTRACT_MESSAGE_TYPE ? [index] : [],
+	const matchingContractIndex = messages.findIndex(
+		(message) => goalContractContent(message) === expected.content,
 	);
-	if (
-		contractIndexes.length === 1 &&
-		contractIndexes[0] === summaryBoundary &&
-		unwrapMessage(messages[summaryBoundary]).content === expected.content
-	) {
-		return messages;
+	if (matchingContractIndex >= 0) {
+		if (messages.filter(isGoalContextContract).length === 1) return messages;
+		return messages.filter(
+			(message, index) => !isGoalContextContract(message) || index === matchingContractIndex,
+		);
 	}
 
-	const withoutContracts = messages.filter(
-		(message) => unwrapMessage(message).customType !== GOAL_CONTRACT_MESSAGE_TYPE,
-	);
-	const insertionIndex = leadingSummaryBoundary(withoutContracts);
+	const withoutContracts = removeGoalContextContracts(messages);
+	const summaryBoundary = leadingSummaryBoundary(withoutContracts);
+	const insertionIndex = summaryBoundary > 0 ? summaryBoundary : withoutContracts.length;
 	return [
 		...withoutContracts.slice(0, insertionIndex),
 		expected,
 		...withoutContracts.slice(insertionIndex),
 	];
+}
+
+export function removeGoalContextContracts(messages: unknown[]) {
+	return messages.some(isGoalContextContract)
+		? messages.filter((message) => !isGoalContextContract(message))
+		: messages;
+}
+
+export function hasGoalContextContract(entries: unknown[], goal: GoalPromptContext) {
+	const expectedContent = createGoalContextContract(goal).content;
+	return entries.some((entry) => goalContractContent(entry) === expectedContent);
+}
+
+export function isGoalContextContract(message: unknown) {
+	return unwrapMessage(message).customType === GOAL_CONTRACT_MESSAGE_TYPE;
+}
+
+function goalContractContent(message: unknown) {
+	return isGoalContextContract(message) ? unwrapMessage(message).content : undefined;
 }
 
 function leadingSummaryBoundary(messages: readonly unknown[]) {
@@ -57,6 +78,7 @@ function leadingSummaryBoundary(messages: readonly unknown[]) {
 }
 
 function unwrapMessage(message: unknown): ContractMessage {
-	const entry = message as { message?: unknown } | undefined;
+	const entry = message as ContractSessionEntry | undefined;
+	if (entry?.type === "custom_message") return entry;
 	return (entry?.message ?? message ?? {}) as ContractMessage;
 }

--- a/packages/pi-goal/src/goal-contract.ts
+++ b/packages/pi-goal/src/goal-contract.ts
@@ -2,7 +2,13 @@ import type { GoalPromptContext } from "./prompts.js";
 import { buildGoalContextPrompt } from "./prompts.js";
 
 export const GOAL_CONTRACT_MESSAGE_TYPE = "goal-contract";
-export const GOAL_CONTRACT_VERSION = 1;
+export const GOAL_CONTRACT_VERSION = 2;
+
+const INACTIVE_GOAL_CONTRACT_CONTENT = [
+	"Goal mode is inactive.",
+	"This Goal contract supersedes every earlier goal-contract message.",
+	"Do not treat an earlier Goal objective, goal_id, Goal-mode rule, or summary of them as current unless a later Goal contract explicitly reactivates Goal mode.",
+].join("\n");
 
 interface ContractMessage {
 	role?: string;
@@ -19,52 +25,77 @@ export function createGoalContextContract(goal: GoalPromptContext) {
 	return {
 		role: "custom" as const,
 		customType: GOAL_CONTRACT_MESSAGE_TYPE,
-		content: buildGoalContextPrompt(goal),
+		content: [
+			"This Goal contract supersedes every earlier goal-contract message.",
+			"Only the objective and goal_id in this latest Goal contract are current.",
+			buildGoalContextPrompt(goal),
+		].join("\n\n"),
 		display: false,
-		details: { version: GOAL_CONTRACT_VERSION, goalId: goal.id },
+		details: { version: GOAL_CONTRACT_VERSION, state: "active", goalId: goal.id },
+		timestamp: 0,
+	};
+}
+
+export function createInactiveGoalContextContract() {
+	return {
+		role: "custom" as const,
+		customType: GOAL_CONTRACT_MESSAGE_TYPE,
+		content: INACTIVE_GOAL_CONTRACT_CONTENT,
+		display: false,
+		details: { version: GOAL_CONTRACT_VERSION, state: "inactive" },
 		timestamp: 0,
 	};
 }
 
 export function reconcileGoalContextContract(messages: unknown[], goal: GoalPromptContext) {
-	const expected = createGoalContextContract(goal);
-	const matchingContractIndex = messages.findIndex(
-		(message) => goalContractContent(message) === expected.content,
-	);
-	if (matchingContractIndex >= 0) {
-		if (messages.filter(isGoalContextContract).length === 1) return messages;
-		return messages.filter(
-			(message, index) => !isGoalContextContract(message) || index === matchingContractIndex,
-		);
-	}
-
-	const withoutContracts = removeGoalContextContracts(messages);
-	const summaryBoundary = leadingSummaryBoundary(withoutContracts);
-	const insertionIndex = summaryBoundary > 0 ? summaryBoundary : withoutContracts.length;
-	return [
-		...withoutContracts.slice(0, insertionIndex),
-		expected,
-		...withoutContracts.slice(insertionIndex),
-	];
+	return reconcileContract(messages, createGoalContextContract(goal));
 }
 
-export function removeGoalContextContracts(messages: unknown[]) {
-	return messages.some(isGoalContextContract)
-		? messages.filter((message) => !isGoalContextContract(message))
-		: messages;
+export function reconcileInactiveGoalContextContract(messages: unknown[]) {
+	return reconcileContract(messages, createInactiveGoalContextContract());
 }
 
 export function hasGoalContextContract(entries: unknown[], goal: GoalPromptContext) {
-	const expectedContent = createGoalContextContract(goal).content;
-	return entries.some((entry) => goalContractContent(entry) === expectedContent);
+	return latestGoalContractContent(entries) === createGoalContextContract(goal).content;
+}
+
+export function hasInactiveGoalContextContract(entries: unknown[]) {
+	return latestGoalContractContent(entries) === INACTIVE_GOAL_CONTRACT_CONTENT;
+}
+
+export function hasGoalContextContractHistory(entries: unknown[]) {
+	return entries.some(isGoalContextContract);
 }
 
 export function isGoalContextContract(message: unknown) {
 	return unwrapMessage(message).customType === GOAL_CONTRACT_MESSAGE_TYPE;
 }
 
-function goalContractContent(message: unknown) {
-	return isGoalContextContract(message) ? unwrapMessage(message).content : undefined;
+function reconcileContract(
+	messages: unknown[],
+	expected: {
+		role: "custom";
+		customType: string;
+		content: string;
+		display: boolean;
+		details: object;
+		timestamp: number;
+	},
+) {
+	if (latestGoalContractContent(messages) === expected.content) return messages;
+	const summaryBoundary = leadingSummaryBoundary(messages);
+	if (!hasGoalContextContractHistory(messages) && summaryBoundary > 0) {
+		return [...messages.slice(0, summaryBoundary), expected, ...messages.slice(summaryBoundary)];
+	}
+	return [...messages, expected];
+}
+
+function latestGoalContractContent(messages: readonly unknown[]) {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		if (isGoalContextContract(message)) return unwrapMessage(message).content;
+	}
+	return undefined;
 }
 
 function leadingSummaryBoundary(messages: readonly unknown[]) {

--- a/packages/pi-goal/src/lifecycle.ts
+++ b/packages/pi-goal/src/lifecycle.ts
@@ -3,8 +3,9 @@ import { currentTokenTotal } from "./accounting.js";
 import { notifyTerminal } from "./errors.js";
 import {
 	GOAL_CONTRACT_MESSAGE_TYPE,
+	isGoalContextContract,
 	reconcileGoalContextContract,
-	removeGoalContextContracts,
+	reconcileInactiveGoalContextContract,
 } from "./goal-contract.js";
 import { type ActiveGoal, loadGoalStateFromSession } from "./persistence.js";
 import type { GoalRunController } from "./run-protocol.js";
@@ -85,6 +86,7 @@ export function registerGoalLifecycle(
 			if (!runtime.acquireWorkflow()) {
 				runtime.activeGoal = transitionGoal(loaded.goal, "paused");
 				runtime.persistGoal(runtime.activeGoal);
+				runtime.ensureInactiveGoalContextContract(ctx);
 				runtime.updateStatus(ctx, runtime.activeGoal);
 				notifyTerminal(
 					ctx.ui,
@@ -175,8 +177,10 @@ export function registerGoalLifecycle(
 		}
 		if (runtime.activeGoal) {
 			runtime.persistGoal(runtime.activeGoal);
+			runtime.ensureInactiveGoalContextContract(ctx);
 			runtime.updateStatus(ctx, runtime.activeGoal);
 		} else {
+			runtime.ensureInactiveGoalContextContract(ctx);
 			ctx.ui.setStatus(STATUS_KEY, undefined);
 		}
 	});
@@ -239,8 +243,17 @@ export function registerGoalLifecycle(
 			runtime.persistGoal(runtime.activeGoal);
 			runtime.updateStatus(ctx, runtime.activeGoal);
 		}
-		if (!usageRecorded) return;
 		if (runtime.limitActiveGoalForBudget(ctx, false)) return;
+		const compactedGoalId = runtime.activeGoal.id;
+		runtime.ensureGoalContextContract(ctx, runtime.activeGoal);
+		if (
+			runtime.activeGoal?.id !== compactedGoalId ||
+			runtime.activeGoal.status !== "active" ||
+			!runtime.ownsWorkflow(runtime.activeGoal)
+		) {
+			return;
+		}
+		if (!usageRecorded) return;
 
 		const wasPiRetry = runtime.isPiOwnedCompactionRetry(event, runtime.activeGoal.id);
 		if (wasPiRetry) return;
@@ -354,10 +367,14 @@ export function registerGoalLifecycle(
 		const keptMessages = event.messages.filter((message) =>
 			runtime.keepBudgetWrapUpMessage(message),
 		);
+		const hasGoalContractHistory =
+			keptMessages.some(isGoalContextContract) || runtime.hasGoalContextContractHistory(ctx);
 		const messages =
 			runtime.activeGoal?.status === "active" && runtime.ownsWorkflow(runtime.activeGoal)
 				? reconcileGoalContextContract(keptMessages, runtime.activeGoal)
-				: removeGoalContextContracts(keptMessages);
+				: hasGoalContractHistory
+					? reconcileInactiveGoalContextContract(keptMessages)
+					: keptMessages;
 		if (
 			runtime.activeGoal?.status === "paused" &&
 			runtime.guardAbortGoalId === runtime.activeGoal.id
@@ -464,7 +481,7 @@ export function registerGoalLifecycle(
 				: "manual";
 		if (activeBudgetWrapUp && runtime.activeGoal) {
 			runtime.beginAgentRun(runtime.activeGoal.id, "manual");
-			return;
+			return goalContractBoundaryResult(ctx);
 		}
 		if (ownedPromptGoalId && ownedPromptGoalId !== runtime.activeGoal?.id) {
 			runtime.beginAgentRun(ownedPromptGoalId, runOrigin);
@@ -475,18 +492,19 @@ export function registerGoalLifecycle(
 			return;
 		}
 		if (runtime.activeGoal?.status !== "active" || !runtime.ownsWorkflow(runtime.activeGoal)) {
-			return;
+			return goalContractBoundaryResult(ctx);
 		}
 		runtime.beginAgentRun(runtime.activeGoal.id, runOrigin);
 		if (!runtime.toolPolicy.toolsAvailable()) {
 			runtime.pauseGoalForUnavailableTools(ctx, ownedPromptGoalId !== undefined);
-			return;
+			return goalContractBoundaryResult(ctx);
 		}
 		if (goalPrompt?.resetSafetyEpoch && goalPromptGoalId === runtime.activeGoal.id) {
 			runtime.activeGoal = resetGoalSafetyEpoch(runtime.activeGoal);
 			runtime.persistGoal(runtime.activeGoal);
 			runtime.updateStatus(ctx, runtime.activeGoal);
 		}
+		return goalContractBoundaryResult(ctx, runtime.activeGoal);
 	});
 
 	pi.on("agent_start", (_event, _ctx) => {
@@ -613,6 +631,11 @@ export function registerGoalLifecycle(
 		if (!resumedWait) runtime.dispatchContinuationIfSettled(ctx);
 		runtime.clearSettledSafetyTracking();
 	});
+
+	function goalContractBoundaryResult(ctx: StatusContext, goal?: ActiveGoal) {
+		const message = runtime.goalContextContractForPrompt(ctx, goal);
+		return message ? { message } : undefined;
+	}
 
 	function beginNonGoalFollowUp(ctx: StatusContext, resetSafetyEpoch: boolean) {
 		runtime.clearGoalRecovery();

--- a/packages/pi-goal/src/lifecycle.ts
+++ b/packages/pi-goal/src/lifecycle.ts
@@ -1,7 +1,11 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { currentTokenTotal } from "./accounting.js";
 import { notifyTerminal } from "./errors.js";
-import { reconcileGoalContextContract } from "./goal-contract.js";
+import {
+	GOAL_CONTRACT_MESSAGE_TYPE,
+	reconcileGoalContextContract,
+	removeGoalContextContracts,
+} from "./goal-contract.js";
 import { type ActiveGoal, loadGoalStateFromSession } from "./persistence.js";
 import type { GoalRunController } from "./run-protocol.js";
 import {
@@ -121,6 +125,15 @@ export function registerGoalLifecycle(
 			}
 			runtime.persistGoal(runtime.activeGoal);
 			if (!runtime.ownsWorkflow(runtime.activeGoal)) return;
+			const restoredGoalId = runtime.activeGoal.id;
+			runtime.ensureGoalContextContract(ctx, runtime.activeGoal);
+			if (
+				runtime.activeGoal?.id !== restoredGoalId ||
+				runtime.activeGoal.status !== "active" ||
+				!runtime.ownsWorkflow(runtime.activeGoal)
+			) {
+				return;
+			}
 			runtime.updateStatus(ctx, runtime.activeGoal);
 			runtime.restoreGoalWaitTimer(ctx);
 			return;
@@ -287,6 +300,7 @@ export function registerGoalLifecycle(
 			return;
 		}
 		if (message.role === "custom") {
+			if (Reflect.get(message, "customType") === GOAL_CONTRACT_MESSAGE_TYPE) return;
 			if (runtime.isActiveBudgetWrapUpMessage(message)) return;
 			if (runtime.activeGoal?.waiting) runtime.clearGoalWait(ctx, runtime.activeGoal.id);
 			if (runtime.guardAbortGoalId === runtime.activeGoal?.id) {
@@ -343,7 +357,7 @@ export function registerGoalLifecycle(
 		const messages =
 			runtime.activeGoal?.status === "active" && runtime.ownsWorkflow(runtime.activeGoal)
 				? reconcileGoalContextContract(keptMessages, runtime.activeGoal)
-				: keptMessages;
+				: removeGoalContextContracts(keptMessages);
 		if (
 			runtime.activeGoal?.status === "paused" &&
 			runtime.guardAbortGoalId === runtime.activeGoal.id

--- a/packages/pi-goal/src/runtime.ts
+++ b/packages/pi-goal/src/runtime.ts
@@ -7,6 +7,7 @@ import {
 	updateGoalUsage,
 } from "./accounting.js";
 import { formatError, notifyTerminal, safeGoalMenuText, truncateNotification } from "./errors.js";
+import { createGoalContextContract, hasGoalContextContract } from "./goal-contract.js";
 import {
 	appendGoalPromptMarker,
 	extractContinuationMarker,
@@ -960,6 +961,23 @@ export class GoalRuntime {
 		this.pendingNonGoalInputs = [];
 	}
 
+	ensureGoalContextContract(ctx: StatusContext, goal: ActiveGoal) {
+		const sessionManager = ctx.sessionManager as
+			| {
+					buildContextEntries?: () => unknown[];
+					getBranch?: () => unknown[];
+					getEntries?: () => unknown[];
+			  }
+			| undefined;
+		const entries =
+			sessionManager?.buildContextEntries?.() ??
+			sessionManager?.getBranch?.() ??
+			sessionManager?.getEntries?.() ??
+			[];
+		if (hasGoalContextContract(entries, goal)) return;
+		this.pi.sendMessage(createGoalContextContract(goal), { triggerTurn: false });
+	}
+
 	async sendOwnedGoalPrompt(
 		ctx: StatusContext,
 		goalId: string,
@@ -967,6 +985,8 @@ export class GoalRuntime {
 		resetSafetyEpoch = true,
 		isCurrent?: () => boolean,
 	) {
+		if (this.activeGoal?.id !== goalId || !this.ownsWorkflow(this.activeGoal)) return false;
+		this.ensureGoalContextContract(ctx, this.activeGoal);
 		if (this.activeGoal?.id !== goalId || !this.ownsWorkflow(this.activeGoal)) return false;
 		const pending = this.rememberPendingGoalPrompt(goalId, prompt, resetSafetyEpoch);
 		const sent = await sendPrompt(this.pi, ctx, pending.prompt, isCurrent);

--- a/packages/pi-goal/src/runtime.ts
+++ b/packages/pi-goal/src/runtime.ts
@@ -7,7 +7,13 @@ import {
 	updateGoalUsage,
 } from "./accounting.js";
 import { formatError, notifyTerminal, safeGoalMenuText, truncateNotification } from "./errors.js";
-import { createGoalContextContract, hasGoalContextContract } from "./goal-contract.js";
+import {
+	createGoalContextContract,
+	createInactiveGoalContextContract,
+	hasGoalContextContract,
+	hasGoalContextContractHistory,
+	hasInactiveGoalContextContract,
+} from "./goal-contract.js";
 import {
 	appendGoalPromptMarker,
 	extractContinuationMarker,
@@ -696,6 +702,7 @@ export class GoalRuntime {
 		if (terminalReason !== undefined) this.setTerminalReason(this.activeGoal.id, terminalReason);
 		const stoppedGoal = this.activeGoal;
 		this.persistGoal(stoppedGoal);
+		this.ensureInactiveGoalContextContract(ctx);
 		if (this.activeGoal?.id === stoppedGoal.id && this.activeGoal.status === stoppedGoal.status) {
 			this.updateStatus(ctx, stoppedGoal);
 			this.releaseWorkflow();
@@ -962,20 +969,34 @@ export class GoalRuntime {
 	}
 
 	ensureGoalContextContract(ctx: StatusContext, goal: ActiveGoal) {
-		const sessionManager = ctx.sessionManager as
-			| {
-					buildContextEntries?: () => unknown[];
-					getBranch?: () => unknown[];
-					getEntries?: () => unknown[];
-			  }
-			| undefined;
-		const entries =
-			sessionManager?.buildContextEntries?.() ??
-			sessionManager?.getBranch?.() ??
-			sessionManager?.getEntries?.() ??
-			[];
-		if (hasGoalContextContract(entries, goal)) return;
-		this.pi.sendMessage(createGoalContextContract(goal), { triggerTurn: false });
+		const contract = this.goalContextContractForPrompt(ctx, goal);
+		if (contract) this.pi.sendMessage(contract, { triggerTurn: false });
+	}
+
+	ensureInactiveGoalContextContract(ctx: StatusContext) {
+		const contract = this.goalContextContractForPrompt(ctx);
+		if (contract) this.pi.sendMessage(contract, { triggerTurn: false });
+	}
+
+	goalContextContractForPrompt(ctx: StatusContext, goal?: ActiveGoal) {
+		const { contextEntries, historyEntries } = goalContractEntries(ctx);
+		if (goal) {
+			return hasGoalContextContract(contextEntries, goal)
+				? undefined
+				: createGoalContextContract(goal);
+		}
+		const hasHistory =
+			hasGoalContextContractHistory(contextEntries) ||
+			hasGoalContextContractHistory(historyEntries);
+		if (!hasHistory || hasInactiveGoalContextContract(contextEntries)) return undefined;
+		return createInactiveGoalContextContract();
+	}
+
+	hasGoalContextContractHistory(ctx: StatusContext) {
+		const { contextEntries, historyEntries } = goalContractEntries(ctx);
+		return (
+			hasGoalContextContractHistory(contextEntries) || hasGoalContextContractHistory(historyEntries)
+		);
 	}
 
 	async sendOwnedGoalPrompt(
@@ -985,8 +1006,6 @@ export class GoalRuntime {
 		resetSafetyEpoch = true,
 		isCurrent?: () => boolean,
 	) {
-		if (this.activeGoal?.id !== goalId || !this.ownsWorkflow(this.activeGoal)) return false;
-		this.ensureGoalContextContract(ctx, this.activeGoal);
 		if (this.activeGoal?.id !== goalId || !this.ownsWorkflow(this.activeGoal)) return false;
 		const pending = this.rememberPendingGoalPrompt(goalId, prompt, resetSafetyEpoch);
 		const sent = await sendPrompt(this.pi, ctx, pending.prompt, isCurrent);
@@ -1244,6 +1263,7 @@ export class GoalRuntime {
 		this.activeGoal = undefined;
 		this.legacyQueueState = undefined;
 		this.clearPersistedGoal(ctx.cwd, clearedGoal, reason);
+		this.ensureInactiveGoalContextContract(ctx);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		if (releaseWorkflow) this.releaseWorkflow();
 		// Do not relock toolPolicy: after first activation, keep tools visible for the
@@ -1573,6 +1593,25 @@ function inputFingerprint(prompt: unknown) {
 	return createHash("sha256")
 		.update(typeof prompt === "string" ? prompt : "", "utf8")
 		.digest("hex");
+}
+
+function goalContractEntries(ctx: StatusContext) {
+	const sessionManager = ctx.sessionManager as
+		| {
+				buildContextEntries?: () => unknown[];
+				buildSessionContext?: () => { messages?: unknown[] };
+				getBranch?: () => unknown[];
+				getEntries?: () => unknown[];
+		  }
+		| undefined;
+	const historyEntries = sessionManager?.getBranch?.() ?? sessionManager?.getEntries?.() ?? [];
+	return {
+		contextEntries:
+			sessionManager?.buildSessionContext?.().messages ??
+			sessionManager?.buildContextEntries?.() ??
+			historyEntries,
+		historyEntries,
+	};
 }
 
 async function sendPrompt(

--- a/packages/pi-goal/test/goal-budget-lifecycle.test.ts
+++ b/packages/pi-goal/test/goal-budget-lifecycle.test.ts
@@ -4,6 +4,7 @@ import {
 	assertPromptHasGoalId,
 	assistantUsageEntry,
 	lastGoalStatus,
+	nonGoalContractSentMessages,
 	requireGoalTool,
 	requireLastGoal,
 	STALE_GOAL_TOOL_REASON,
@@ -62,7 +63,7 @@ test("tool_execution_end stops budget work, blocks stale tools, and releases the
 	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
 	assert.equal(requireLastGoal(budgeted.mock).tokensUsed, 12);
 	assert.equal(budgeted.statuses.get("goal"), "budget 12/10 · automatic 0/25");
-	assert.equal(budgeted.mock.sentMessages.length, 0);
+	assert.equal(nonGoalContractSentMessages(budgeted.mock).length, 0);
 	await budgeted.mock.events.get("agent_settled")?.[0]?.({}, budgeted.ctx);
 	assert.equal(budgeted.mock.sentUserMessages.length, 1);
 	assert.deepEqual(
@@ -181,7 +182,7 @@ test("budget exhaustion never queues or retries a follow-up wrap-up", async () =
 		budgeted.ctx,
 	);
 	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
-	assert.equal(budgeted.mock.sentMessages.length, 0);
+	assert.equal(nonGoalContractSentMessages(budgeted.mock).length, 0);
 	assert.match(budgeted.notifications.at(-1)?.message ?? "", /token budget reached/i);
 
 	await toolEnd?.(
@@ -193,7 +194,7 @@ test("budget exhaustion never queues or retries a follow-up wrap-up", async () =
 		budgeted.ctx,
 	);
 	assert.equal(attempts, 0);
-	assert.equal(budgeted.mock.sentMessages.length, 0);
+	assert.equal(nonGoalContractSentMessages(budgeted.mock).length, 0);
 });
 
 test("budget wrap-up permission closes at agent_end and stale context is filtered", async () => {
@@ -286,7 +287,7 @@ test("budget stop queues no custom work and remains stopped through agent_end", 
 		{ toolCallId: "tool-1", toolName: "bash", result: {}, isError: false },
 		budgeted.ctx,
 	);
-	assert.equal(budgeted.mock.sentMessages.length, 0);
+	assert.equal(nonGoalContractSentMessages(budgeted.mock).length, 0);
 	await budgeted.mock.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", stopReason: "stop", content: [] }] },
 		budgeted.ctx,
@@ -315,7 +316,7 @@ test("compaction cancels before retry when persisted usage has exhausted the bud
 	);
 	assert.deepEqual(result, { cancel: true });
 	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
-	assert.equal(budgeted.mock.sentMessages.length, 0);
+	assert.equal(nonGoalContractSentMessages(budgeted.mock).length, 0);
 	assert.equal(budgeted.mock.sentUserMessages.length, 1);
 
 	await budgeted.mock.events.get("session_compact")?.[0]?.(
@@ -409,7 +410,7 @@ test("budget exhaustion between agent_end and agent_settled cancels continuation
 		budgeted.ctx,
 	);
 	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
-	assert.equal(budgeted.mock.sentMessages.length, 0);
+	assert.equal(nonGoalContractSentMessages(budgeted.mock).length, 0);
 
 	await budgeted.mock.events.get("agent_settled")?.[0]?.({}, budgeted.ctx);
 	assert.equal(budgeted.mock.sentUserMessages.length, 1);

--- a/packages/pi-goal/test/goal-cache-contract.test.ts
+++ b/packages/pi-goal/test/goal-cache-contract.test.ts
@@ -33,16 +33,18 @@ async function captureRequest(
 	const beforeResult = (await mock.events.get("before_agent_start")?.[0]?.(
 		{ prompt, systemPrompt: baseSystemPrompt },
 		ctx,
-	)) as { systemPrompt?: string } | undefined;
-	const contextResult = (await mock.events.get("context")?.[0]?.({ messages }, ctx)) as
-		| { messages?: unknown[] }
-		| undefined;
+	)) as { message?: unknown; systemPrompt?: string } | undefined;
+	const boundaryMessages = beforeResult?.message ? [...messages, beforeResult.message] : messages;
+	const contextResult = (await mock.events.get("context")?.[0]?.(
+		{ messages: boundaryMessages },
+		ctx,
+	)) as { messages?: unknown[] } | undefined;
 	const activeTools = mock.rawPi.getActiveTools();
 	const allTools = [...mock.rawPi.getAllTools(), ...mock.tools];
 	const toolByName = new Map(
 		allTools.map((tool) => [(tool as { name: string }).name, tool as Record<string, unknown>]),
 	);
-	const transformedMessages = contextResult?.messages ?? messages;
+	const transformedMessages = contextResult?.messages ?? boundaryMessages;
 	return {
 		activeTools,
 		instructions: beforeResult?.systemPrompt ?? baseSystemPrompt,
@@ -108,20 +110,23 @@ function assistantMessage(content: string) {
 	};
 }
 
-function latestGoalContract(mock: ReturnType<typeof createMockPi>) {
-	const message = mock.sentMessages
-		.map((sent) => sent.message as { customType?: string })
-		.filter((candidate) => candidate.customType === "goal-contract")
+function latestGoalContract(messages: unknown[]) {
+	const message = messages
+		.filter((candidate) => (candidate as { customType?: string }).customType === "goal-contract")
 		.at(-1);
 	assert.ok(message, "expected a persisted Goal contract");
-	return message;
+	return message as { content?: string; customType?: string; details?: unknown };
+}
+
+function restoredGoalContract(mock: ReturnType<typeof createMockPi>) {
+	return latestGoalContract(mock.sentMessages.map((sent) => sent.message));
 }
 
 test.each([
 	{ settingsPath: ALWAYS_SETTINGS_PATH, visibility: "always", changesTools: false },
 	{ settingsPath: LAZY_SETTINGS_PATH, visibility: "after-first-goal", changesTools: true },
 ])(
-	"$visibility activation appends the Goal contract after retained history",
+	"$visibility activation appends the Goal contract at the accepted handoff boundary",
 	async ({ settingsPath, changesTools }) => {
 		const allTools = [builtinTool("read"), builtinTool("bash")];
 		const mock = createMockPi({ activeTools: ["read", "bash"], allTools });
@@ -141,12 +146,11 @@ test.each([
 
 		await mock.commands.get("goal")?.handler("preserve retained provider history", context.ctx);
 		const kickoffPrompt = mock.sentUserMessages.at(-1)?.text ?? "";
-		const contract = latestGoalContract(mock);
 		const kickoff = await captureRequest(mock, context.ctx, kickoffPrompt, [
 			...retainedHistory,
-			contract,
 			userMessage(kickoffPrompt),
 		]);
+		const contract = latestGoalContract(kickoff.messages);
 
 		assert.deepEqual(
 			kickoff.serializedInput.slice(0, beforeGoal.serializedInput.length),
@@ -160,7 +164,7 @@ test.each([
 			kickoffProviderInput.slice(0, beforeProviderInput.length),
 			beforeProviderInput,
 		);
-		assert.equal(kickoff.messages[retainedHistory.length], contract);
+		assert.equal(kickoff.messages[retainedHistory.length + 1], contract);
 		assert.equal(kickoff.activeTools.length !== beforeGoal.activeTools.length, changesTools);
 		assert.equal(
 			JSON.stringify(kickoffProviderRequest.tools) !== JSON.stringify(beforeProviderRequest.tools),
@@ -184,8 +188,16 @@ test("token-budgeted continuation and wait resume preserve the post-activation r
 		.get("goal")
 		?.handler("--tokens 10k preserve the provider prefix", context.ctx);
 	const kickoffPrompt = mock.sentUserMessages.at(-1)?.text ?? "";
-	const kickoffMessages = [latestGoalContract(mock), userMessage(kickoffPrompt)];
-	const kickoff = await captureRequest(mock, context.ctx, kickoffPrompt, kickoffMessages);
+	const kickoff = await captureRequest(mock, context.ctx, kickoffPrompt, [
+		userMessage(kickoffPrompt),
+	]);
+	const kickoffMessages = kickoff.messages;
+	const kickoffContract = latestGoalContract(kickoffMessages);
+	branch.push({
+		type: "custom_message",
+		customType: kickoffContract.customType,
+		content: kickoffContract.content,
+	});
 	assert.deepEqual(kickoff.activeTools, [
 		"read",
 		"bash",
@@ -264,11 +276,14 @@ test("token-budgeted continuation and wait resume preserve the post-activation r
 	assert.match(resumePrompt, /Token budget: 750\/10k used\./u);
 });
 
-test("Goal identity rotation and clearing preserve the pre-Goal serialized history", async () => {
+test("Goal identity rotation and clearing preserve the full serialized history", async () => {
+	const branch: Array<Record<string, unknown>> = [];
 	const allTools = [builtinTool("read"), builtinTool("bash")];
 	const mock = createMockPi({ activeTools: ["read", "bash"], allTools });
 	registerGoalWithSettingsPath(mock.pi, ALWAYS_SETTINGS_PATH);
-	const context = createMockContext();
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
 	const retainedHistory = [
 		userMessage("Retained request before Goal identity rotation"),
@@ -282,59 +297,80 @@ test("Goal identity rotation and clearing preserve the pre-Goal serialized histo
 	);
 
 	await mock.commands.get("goal")?.handler("initial objective", context.ctx);
-	const initialContract = latestGoalContract(mock);
 	const initialPrompt = mock.sentUserMessages.at(-1)?.text ?? "";
-	const initialMessages = [
+	const initial = await captureRequest(mock, context.ctx, initialPrompt, [
 		...retainedHistory,
-		initialContract,
 		userMessage(initialPrompt),
+	]);
+	const initialContract = latestGoalContract(initial.messages);
+	branch.push({
+		type: "custom_message",
+		customType: initialContract.customType,
+		content: initialContract.content,
+	});
+	const initialMessages = [
+		...initial.messages,
 		assistantMessage("Initial objective remains incomplete"),
 	];
 
 	await mock.commands.get("goal")?.handler("edit updated objective", context.ctx);
-	const updatedContract = latestGoalContract(mock);
 	const updatedPrompt = mock.sentUserMessages.at(-1)?.text ?? "";
-	const updatedMessages = [...initialMessages, updatedContract, userMessage(updatedPrompt)];
-	const updated = await captureRequest(mock, context.ctx, updatedPrompt, updatedMessages);
-	assert.deepEqual(updated.messages.slice(0, retainedHistory.length), retainedHistory);
-	assert.ok(!updated.messages.includes(initialContract));
+	const updated = await captureRequest(mock, context.ctx, updatedPrompt, [
+		...initialMessages,
+		userMessage(updatedPrompt),
+	]);
+	const updatedContract = latestGoalContract(updated.messages);
+	branch.push({
+		type: "custom_message",
+		customType: updatedContract.customType,
+		content: updatedContract.content,
+	});
+	assert.deepEqual(updated.messages.slice(0, initial.messages.length), initial.messages);
+	assert.ok(updated.messages.includes(initialContract));
 	assert.ok(updated.messages.includes(updatedContract));
-	assert.ok(
-		updated.messages.indexOf(updatedContract) <
-			updated.messages.findIndex(
-				(message) =>
-					(message as { role?: string; content?: unknown }).role === "user" &&
-					JSON.stringify((message as { content?: unknown }).content).includes("updated objective"),
-			),
-	);
+	assert.equal(updated.messages.at(-1), updatedContract);
+	assert.match(updatedContract.content ?? "", /supersedes every earlier goal-contract/u);
 
 	await mock.commands.get("goal")?.handler("clear", context.ctx);
+	assert.match(
+		restoredGoalContract(mock).content ?? "",
+		/Goal mode is inactive.*supersedes every earlier goal-contract/su,
+	);
 	const cleared = (await mock.events.get("context")?.[0]?.(
-		{ messages: updatedMessages },
+		{ messages: updated.messages },
 		context.ctx,
 	)) as { messages?: unknown[] } | undefined;
 	assert.ok(cleared?.messages);
-	assert.deepEqual(cleared.messages.slice(0, retainedHistory.length), retainedHistory);
-	assert.ok(
-		cleared.messages.every(
-			(message) => (message as { customType?: string }).customType !== "goal-contract",
-		),
+	assert.deepEqual(cleared.messages.slice(0, updated.messages.length), updated.messages);
+	assert.match(
+		latestGoalContract(cleared.messages).content ?? "",
+		/Goal mode is inactive.*supersedes every earlier goal-contract/su,
 	);
-	const updatedProviderRequest = await serializeProviderRequest(updated);
+
 	const clearedRequest = await captureRequest(mock, context.ctx, "ordinary work after clear", [
-		...updatedMessages,
+		...updated.messages,
 		userMessage("ordinary work after clear"),
 	]);
 	const beforeProviderRequest = await serializeProviderRequest(beforeGoal);
+	const initialProviderRequest = await serializeProviderRequest(initial);
+	const updatedProviderRequest = await serializeProviderRequest(updated);
 	const clearedProviderRequest = await serializeProviderRequest(clearedRequest);
 	const beforeProviderInput = beforeProviderRequest.input as unknown[];
+	const initialProviderInput = initialProviderRequest.input as unknown[];
 	const updatedProviderInput = updatedProviderRequest.input as unknown[];
 	const clearedProviderInput = clearedProviderRequest.input as unknown[];
-	assert.deepEqual(updatedProviderInput.slice(0, beforeProviderInput.length), beforeProviderInput);
-	assert.deepEqual(clearedProviderInput.slice(0, beforeProviderInput.length), beforeProviderInput);
+	assert.deepEqual(initialProviderInput.slice(0, beforeProviderInput.length), beforeProviderInput);
+	assert.deepEqual(
+		updatedProviderInput.slice(0, initialProviderInput.length),
+		initialProviderInput,
+	);
+	assert.deepEqual(
+		clearedProviderInput.slice(0, updatedProviderInput.length),
+		updatedProviderInput,
+	);
 });
 
-test("failed Goal delivery filters the undelivered contract and restores the previous one", async () => {
+test("failed Goal delivery persists no undelivered contract", async () => {
 	const allTools = [builtinTool("read"), builtinTool("bash")];
 	const fresh = createMockPi({ activeTools: ["read", "bash"], allTools });
 	registerGoalWithSettingsPath(fresh.pi, ALWAYS_SETTINGS_PATH);
@@ -344,41 +380,51 @@ test("failed Goal delivery filters the undelivered contract and restores the pre
 		throw new Error("fresh delivery failed");
 	};
 	await fresh.commands.get("goal")?.handler("undelivered fresh objective", freshContext.ctx);
-	const undeliveredContract = latestGoalContract(fresh);
-	const retainedHistory = [userMessage("retained before failed activation")];
-	const freshFiltered = (await fresh.events.get("context")?.[0]?.(
-		{ messages: [...retainedHistory, undeliveredContract] },
-		freshContext.ctx,
-	)) as { messages?: unknown[] } | undefined;
-	assert.deepEqual(freshFiltered?.messages, retainedHistory);
+	assert.equal(fresh.sentMessages.length, 0);
+	assert.equal(
+		fresh.events.get("context")?.[0]?.(
+			{ messages: [userMessage("retained before failed activation")] },
+			freshContext.ctx,
+		),
+		undefined,
+	);
 
+	const branch: Array<Record<string, unknown>> = [];
 	const edited = createMockPi({ activeTools: ["read", "bash"], allTools });
 	registerGoalWithSettingsPath(edited.pi, ALWAYS_SETTINGS_PATH);
-	const editedContext = createMockContext();
+	const editedContext = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+	});
 	await edited.events.get("session_start")?.[0]?.({ reason: "startup" }, editedContext.ctx);
 	await edited.commands.get("goal")?.handler("retained objective", editedContext.ctx);
-	const retainedContract = latestGoalContract(edited);
 	const retainedPrompt = edited.sentUserMessages.at(-1)?.text ?? "";
+	const retainedBoundary = (await edited.events.get("before_agent_start")?.[0]?.(
+		{ prompt: retainedPrompt, systemPrompt: "base" },
+		editedContext.ctx,
+	)) as { message?: unknown } | undefined;
+	assert.ok(retainedBoundary?.message);
+	const retainedContract = retainedBoundary.message as {
+		content?: string;
+		customType?: string;
+	};
+	branch.push({
+		type: "custom_message",
+		customType: retainedContract.customType,
+		content: retainedContract.content,
+	});
 	edited.rawPi.sendUserMessage = () => {
 		throw new Error("edit delivery failed");
 	};
 	await edited.commands.get("goal")?.handler("edit undelivered objective", editedContext.ctx);
-	const staleContract = latestGoalContract(edited);
-	assert.notEqual(staleContract, retainedContract);
-	const messages = [
-		...retainedHistory,
-		retainedContract,
-		userMessage(retainedPrompt),
-		staleContract,
-	];
-	const editedFiltered = (await edited.events.get("context")?.[0]?.(
-		{ messages },
-		editedContext.ctx,
-	)) as { messages?: unknown[] } | undefined;
-	assert.ok(editedFiltered?.messages);
-	assert.deepEqual(editedFiltered.messages.slice(0, retainedHistory.length), retainedHistory);
-	assert.ok(editedFiltered.messages.includes(retainedContract));
-	assert.ok(!editedFiltered.messages.includes(staleContract));
+	assert.equal(requireLastGoal(edited).text, "retained objective");
+	assert.equal(edited.sentMessages.length, 0);
+	assert.equal(
+		edited.events.get("context")?.[0]?.(
+			{ messages: [retainedContract, userMessage(retainedPrompt)] },
+			editedContext.ctx,
+		),
+		undefined,
+	);
 });
 
 test("restored active Goal persists a contract after retained history", async () => {
@@ -397,7 +443,7 @@ test("restored active Goal persists a contract after retained history", async ()
 		userMessage("retained request before restore"),
 		assistantMessage("retained response before restore"),
 	];
-	const contract = latestGoalContract(restored.mock) as {
+	const contract = restoredGoalContract(restored.mock) as {
 		customType?: string;
 		content?: string;
 	};
@@ -439,6 +485,35 @@ test("restoring a retained matching Goal contract does not append a duplicate", 
 	assert.equal(restored.mock.sentMessages.length, 0);
 });
 
+test("restoring an inactive Goal appends one superseding inactive contract", () => {
+	const pausedGoal = {
+		id: "restored-paused-contract",
+		text: "retain inactive history",
+		status: "paused" as const,
+		startedAt: 1,
+		updatedAt: 2,
+		iteration: 1,
+		tokensUsed: 25,
+		timeUsedSeconds: 2,
+		baselineTokens: 0,
+	};
+	const activeContract = createGoalContextContract({ ...pausedGoal, status: "active" });
+	const restored = restoreStoredGoalForTest(pausedGoal, [
+		{
+			type: "custom_message",
+			customType: activeContract.customType,
+			content: activeContract.content,
+			display: activeContract.display,
+			details: activeContract.details,
+		},
+	]);
+	assert.equal(restored.mock.sentMessages.length, 1);
+	assert.match(
+		restoredGoalContract(restored.mock).content ?? "",
+		/Goal mode is inactive.*supersedes every earlier goal-contract/su,
+	);
+});
+
 test("persisting a restored waiting Goal contract does not wake the Goal", async () => {
 	const restored = restoreStoredGoalForTest({
 		id: "restored-waiting-contract",
@@ -452,7 +527,7 @@ test("persisting a restored waiting Goal contract does not wake the Goal", async
 		baselineTokens: 0,
 		waiting: { reason: "external event pending" },
 	});
-	const contract = latestGoalContract(restored.mock);
+	const contract = restoredGoalContract(restored.mock);
 	await restored.mock.events.get("message_start")?.[0]?.({ message: contract }, restored.ctx);
 	assert.deepEqual(requireLastGoal(restored.mock).waiting, {
 		reason: "external event pending",
@@ -493,6 +568,12 @@ test("compacted active Goal receives one cache-stable contract after summary mes
 		context.ctx,
 	);
 	assert.equal(requireLastGoal(mock).tokensUsed, 500);
+	await mock.events.get("session_compact")?.[0]?.(
+		{ reason: "threshold", willRetry: true },
+		context.ctx,
+	);
+	const persistedAfterCompaction = restoredGoalContract(mock);
+	assertPromptHasGoalId(persistedAfterCompaction.content ?? "", goal.id);
 	const second = (await contextHook?.({ messages: compactedMessages }, context.ctx)) as
 		| { messages?: unknown[] }
 		| undefined;

--- a/packages/pi-goal/test/goal-cache-contract.test.ts
+++ b/packages/pi-goal/test/goal-cache-contract.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import { builtinTool, createMockContext, createMockPi } from "../../../test/support.js";
+import { createGoalContextContract } from "../src/goal-contract.js";
 import {
+	ALWAYS_SETTINGS_PATH,
 	assertHardenedGoalPrompt,
 	assertPromptHasGoalId,
 	assistantUsageEntry,
@@ -16,6 +19,7 @@ interface CapturedRequest {
 	activeTools: string[];
 	instructions: string;
 	messages: unknown[];
+	serializedInput: unknown[];
 	toolDefinitions: Array<{ name: string; description: unknown; parameters: unknown }>;
 }
 
@@ -38,15 +42,58 @@ async function captureRequest(
 	const toolByName = new Map(
 		allTools.map((tool) => [(tool as { name: string }).name, tool as Record<string, unknown>]),
 	);
+	const transformedMessages = contextResult?.messages ?? messages;
 	return {
 		activeTools,
 		instructions: beforeResult?.systemPrompt ?? baseSystemPrompt,
-		messages: contextResult?.messages ?? messages,
+		messages: transformedMessages,
+		serializedInput: convertToLlm(transformedMessages as never),
 		toolDefinitions: activeTools.map((name) => {
 			const tool = toolByName.get(name);
-			return { name, description: tool?.description, parameters: tool?.parameters };
+			return {
+				name,
+				description: tool?.description ?? name,
+				parameters: tool?.parameters ?? { type: "object", properties: {} },
+			};
 		}),
 	};
+}
+
+async function serializeProviderRequest(request: CapturedRequest) {
+	const apiModule = "@earendil-works/pi-ai/api/openai-responses";
+	const { streamSimple } = await import(apiModule);
+	let payload: Record<string, unknown> | undefined;
+	const stream = streamSimple(
+		{
+			id: "cache-contract-test",
+			name: "Cache contract test",
+			api: "openai-responses",
+			provider: "cache-contract-test",
+			baseUrl: "http://provider-request-capture.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 100_000,
+			maxTokens: 1_000,
+		},
+		{
+			systemPrompt: request.instructions,
+			messages: request.serializedInput,
+			tools: request.toolDefinitions,
+		},
+		{
+			apiKey: "provider-request-capture",
+			onPayload(value: unknown) {
+				payload = value as Record<string, unknown>;
+				throw new Error("provider request captured");
+			},
+		},
+	);
+	for await (const event of stream) {
+		if (event.type === "error") break;
+	}
+	assert.ok(payload, "expected a serialized provider request");
+	return payload;
 }
 
 function userMessage(content: string) {
@@ -54,8 +101,73 @@ function userMessage(content: string) {
 }
 
 function assistantMessage(content: string) {
-	return { role: "assistant", content, stopReason: "stop" };
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: content }],
+		stopReason: "stop",
+	};
 }
+
+function latestGoalContract(mock: ReturnType<typeof createMockPi>) {
+	const message = mock.sentMessages
+		.map((sent) => sent.message as { customType?: string })
+		.filter((candidate) => candidate.customType === "goal-contract")
+		.at(-1);
+	assert.ok(message, "expected a persisted Goal contract");
+	return message;
+}
+
+test.each([
+	{ settingsPath: ALWAYS_SETTINGS_PATH, visibility: "always", changesTools: false },
+	{ settingsPath: LAZY_SETTINGS_PATH, visibility: "after-first-goal", changesTools: true },
+])(
+	"$visibility activation appends the Goal contract after retained history",
+	async ({ settingsPath, changesTools }) => {
+		const allTools = [builtinTool("read"), builtinTool("bash")];
+		const mock = createMockPi({ activeTools: ["read", "bash"], allTools });
+		registerGoalWithSettingsPath(mock.pi, settingsPath);
+		const context = createMockContext();
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		const retainedHistory = [
+			userMessage("Retained request before Goal activation"),
+			assistantMessage("Retained response before Goal activation"),
+		];
+		const beforeGoal = await captureRequest(
+			mock,
+			context.ctx,
+			"Retained request before Goal activation",
+			retainedHistory,
+		);
+
+		await mock.commands.get("goal")?.handler("preserve retained provider history", context.ctx);
+		const kickoffPrompt = mock.sentUserMessages.at(-1)?.text ?? "";
+		const contract = latestGoalContract(mock);
+		const kickoff = await captureRequest(mock, context.ctx, kickoffPrompt, [
+			...retainedHistory,
+			contract,
+			userMessage(kickoffPrompt),
+		]);
+
+		assert.deepEqual(
+			kickoff.serializedInput.slice(0, beforeGoal.serializedInput.length),
+			beforeGoal.serializedInput,
+		);
+		const beforeProviderRequest = await serializeProviderRequest(beforeGoal);
+		const kickoffProviderRequest = await serializeProviderRequest(kickoff);
+		const beforeProviderInput = beforeProviderRequest.input as unknown[];
+		const kickoffProviderInput = kickoffProviderRequest.input as unknown[];
+		assert.deepEqual(
+			kickoffProviderInput.slice(0, beforeProviderInput.length),
+			beforeProviderInput,
+		);
+		assert.equal(kickoff.messages[retainedHistory.length], contract);
+		assert.equal(kickoff.activeTools.length !== beforeGoal.activeTools.length, changesTools);
+		assert.equal(
+			JSON.stringify(kickoffProviderRequest.tools) !== JSON.stringify(beforeProviderRequest.tools),
+			changesTools,
+		);
+	},
+);
 
 test("token-budgeted continuation and wait resume preserve the post-activation request prefix", async () => {
 	const branch: Array<Record<string, unknown>> = [];
@@ -72,7 +184,7 @@ test("token-budgeted continuation and wait resume preserve the post-activation r
 		.get("goal")
 		?.handler("--tokens 10k preserve the provider prefix", context.ctx);
 	const kickoffPrompt = mock.sentUserMessages.at(-1)?.text ?? "";
-	const kickoffMessages = [userMessage(kickoffPrompt)];
+	const kickoffMessages = [latestGoalContract(mock), userMessage(kickoffPrompt)];
 	const kickoff = await captureRequest(mock, context.ctx, kickoffPrompt, kickoffMessages);
 	assert.deepEqual(kickoff.activeTools, [
 		"read",
@@ -132,11 +244,144 @@ test("token-budgeted continuation and wait resume preserve the post-activation r
 	assert.deepEqual(resumed.toolDefinitions, kickoff.toolDefinitions);
 	assert.deepEqual(continuation.messages.slice(0, kickoff.messages.length), kickoff.messages);
 	assert.deepEqual(resumed.messages.slice(0, continuation.messages.length), continuation.messages);
+	const kickoffProviderRequest = await serializeProviderRequest(kickoff);
+	const continuationProviderRequest = await serializeProviderRequest(continuation);
+	const resumedProviderRequest = await serializeProviderRequest(resumed);
+	const kickoffProviderInput = kickoffProviderRequest.input as unknown[];
+	const continuationProviderInput = continuationProviderRequest.input as unknown[];
+	const resumedProviderInput = resumedProviderRequest.input as unknown[];
+	assert.deepEqual(
+		continuationProviderInput.slice(0, kickoffProviderInput.length),
+		kickoffProviderInput,
+	);
+	assert.deepEqual(
+		resumedProviderInput.slice(0, continuationProviderInput.length),
+		continuationProviderInput,
+	);
+	assert.deepEqual(continuationProviderRequest.tools, kickoffProviderRequest.tools);
+	assert.deepEqual(resumedProviderRequest.tools, continuationProviderRequest.tools);
 	assert.match(continuationPrompt, /Token budget: 500\/10k used\./u);
 	assert.match(resumePrompt, /Token budget: 750\/10k used\./u);
 });
 
-test("restored active Goal without a retained handoff receives the Goal contract", async () => {
+test("Goal identity rotation and clearing preserve the pre-Goal serialized history", async () => {
+	const allTools = [builtinTool("read"), builtinTool("bash")];
+	const mock = createMockPi({ activeTools: ["read", "bash"], allTools });
+	registerGoalWithSettingsPath(mock.pi, ALWAYS_SETTINGS_PATH);
+	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	const retainedHistory = [
+		userMessage("Retained request before Goal identity rotation"),
+		assistantMessage("Retained response before Goal identity rotation"),
+	];
+	const beforeGoal = await captureRequest(
+		mock,
+		context.ctx,
+		"Retained request before Goal identity rotation",
+		retainedHistory,
+	);
+
+	await mock.commands.get("goal")?.handler("initial objective", context.ctx);
+	const initialContract = latestGoalContract(mock);
+	const initialPrompt = mock.sentUserMessages.at(-1)?.text ?? "";
+	const initialMessages = [
+		...retainedHistory,
+		initialContract,
+		userMessage(initialPrompt),
+		assistantMessage("Initial objective remains incomplete"),
+	];
+
+	await mock.commands.get("goal")?.handler("edit updated objective", context.ctx);
+	const updatedContract = latestGoalContract(mock);
+	const updatedPrompt = mock.sentUserMessages.at(-1)?.text ?? "";
+	const updatedMessages = [...initialMessages, updatedContract, userMessage(updatedPrompt)];
+	const updated = await captureRequest(mock, context.ctx, updatedPrompt, updatedMessages);
+	assert.deepEqual(updated.messages.slice(0, retainedHistory.length), retainedHistory);
+	assert.ok(!updated.messages.includes(initialContract));
+	assert.ok(updated.messages.includes(updatedContract));
+	assert.ok(
+		updated.messages.indexOf(updatedContract) <
+			updated.messages.findIndex(
+				(message) =>
+					(message as { role?: string; content?: unknown }).role === "user" &&
+					JSON.stringify((message as { content?: unknown }).content).includes("updated objective"),
+			),
+	);
+
+	await mock.commands.get("goal")?.handler("clear", context.ctx);
+	const cleared = (await mock.events.get("context")?.[0]?.(
+		{ messages: updatedMessages },
+		context.ctx,
+	)) as { messages?: unknown[] } | undefined;
+	assert.ok(cleared?.messages);
+	assert.deepEqual(cleared.messages.slice(0, retainedHistory.length), retainedHistory);
+	assert.ok(
+		cleared.messages.every(
+			(message) => (message as { customType?: string }).customType !== "goal-contract",
+		),
+	);
+	const updatedProviderRequest = await serializeProviderRequest(updated);
+	const clearedRequest = await captureRequest(mock, context.ctx, "ordinary work after clear", [
+		...updatedMessages,
+		userMessage("ordinary work after clear"),
+	]);
+	const beforeProviderRequest = await serializeProviderRequest(beforeGoal);
+	const clearedProviderRequest = await serializeProviderRequest(clearedRequest);
+	const beforeProviderInput = beforeProviderRequest.input as unknown[];
+	const updatedProviderInput = updatedProviderRequest.input as unknown[];
+	const clearedProviderInput = clearedProviderRequest.input as unknown[];
+	assert.deepEqual(updatedProviderInput.slice(0, beforeProviderInput.length), beforeProviderInput);
+	assert.deepEqual(clearedProviderInput.slice(0, beforeProviderInput.length), beforeProviderInput);
+});
+
+test("failed Goal delivery filters the undelivered contract and restores the previous one", async () => {
+	const allTools = [builtinTool("read"), builtinTool("bash")];
+	const fresh = createMockPi({ activeTools: ["read", "bash"], allTools });
+	registerGoalWithSettingsPath(fresh.pi, ALWAYS_SETTINGS_PATH);
+	const freshContext = createMockContext();
+	await fresh.events.get("session_start")?.[0]?.({ reason: "startup" }, freshContext.ctx);
+	fresh.rawPi.sendUserMessage = () => {
+		throw new Error("fresh delivery failed");
+	};
+	await fresh.commands.get("goal")?.handler("undelivered fresh objective", freshContext.ctx);
+	const undeliveredContract = latestGoalContract(fresh);
+	const retainedHistory = [userMessage("retained before failed activation")];
+	const freshFiltered = (await fresh.events.get("context")?.[0]?.(
+		{ messages: [...retainedHistory, undeliveredContract] },
+		freshContext.ctx,
+	)) as { messages?: unknown[] } | undefined;
+	assert.deepEqual(freshFiltered?.messages, retainedHistory);
+
+	const edited = createMockPi({ activeTools: ["read", "bash"], allTools });
+	registerGoalWithSettingsPath(edited.pi, ALWAYS_SETTINGS_PATH);
+	const editedContext = createMockContext();
+	await edited.events.get("session_start")?.[0]?.({ reason: "startup" }, editedContext.ctx);
+	await edited.commands.get("goal")?.handler("retained objective", editedContext.ctx);
+	const retainedContract = latestGoalContract(edited);
+	const retainedPrompt = edited.sentUserMessages.at(-1)?.text ?? "";
+	edited.rawPi.sendUserMessage = () => {
+		throw new Error("edit delivery failed");
+	};
+	await edited.commands.get("goal")?.handler("edit undelivered objective", editedContext.ctx);
+	const staleContract = latestGoalContract(edited);
+	assert.notEqual(staleContract, retainedContract);
+	const messages = [
+		...retainedHistory,
+		retainedContract,
+		userMessage(retainedPrompt),
+		staleContract,
+	];
+	const editedFiltered = (await edited.events.get("context")?.[0]?.(
+		{ messages },
+		editedContext.ctx,
+	)) as { messages?: unknown[] } | undefined;
+	assert.ok(editedFiltered?.messages);
+	assert.deepEqual(editedFiltered.messages.slice(0, retainedHistory.length), retainedHistory);
+	assert.ok(editedFiltered.messages.includes(retainedContract));
+	assert.ok(!editedFiltered.messages.includes(staleContract));
+});
+
+test("restored active Goal persists a contract after retained history", async () => {
 	const restored = restoreStoredGoalForTest({
 		id: "restored-without-handoff",
 		text: "finish the restored objective",
@@ -148,25 +393,72 @@ test("restored active Goal without a retained handoff receives the Goal contract
 		timeUsedSeconds: 2,
 		baselineTokens: 0,
 	});
-	const beforeStart = await restored.mock.events.get("before_agent_start")?.[0]?.(
-		{ prompt: "ordinary restored turn", systemPrompt: "base" },
-		restored.ctx,
-	);
-	assert.equal(beforeStart, undefined);
-
+	const retainedHistory = [
+		userMessage("retained request before restore"),
+		assistantMessage("retained response before restore"),
+	];
+	const contract = latestGoalContract(restored.mock) as {
+		customType?: string;
+		content?: string;
+	};
 	const ordinaryMessage = userMessage("ordinary restored turn");
+	const messages = [...retainedHistory, contract, ordinaryMessage];
 	const transformed = (await restored.mock.events.get("context")?.[0]?.(
-		{ messages: [ordinaryMessage] },
+		{ messages },
 		restored.ctx,
 	)) as { messages?: unknown[] } | undefined;
-	assert.ok(transformed?.messages);
-	assert.equal(transformed.messages.length, 2);
-	assert.equal(transformed.messages[1], ordinaryMessage);
-	const contract = transformed.messages[0] as { customType?: string; content?: string };
+	assert.equal(transformed, undefined);
 	assert.equal(contract.customType, "goal-contract");
 	assertPromptHasGoalId(contract.content ?? "", "restored-without-handoff");
 	assertHardenedGoalPrompt(contract.content ?? "");
 	assert.match(contract.content ?? "", /finish the restored objective/u);
+});
+
+test("restoring a retained matching Goal contract does not append a duplicate", () => {
+	const sessionGoal = {
+		id: "restored-retained-contract",
+		text: "retain one contract",
+		status: "active" as const,
+		startedAt: 1,
+		updatedAt: 2,
+		iteration: 1,
+		tokensUsed: 25,
+		timeUsedSeconds: 2,
+		baselineTokens: 0,
+	};
+	const contract = createGoalContextContract(sessionGoal);
+	const restored = restoreStoredGoalForTest(sessionGoal, [
+		{
+			type: "custom_message",
+			customType: contract.customType,
+			content: contract.content,
+			display: contract.display,
+			details: contract.details,
+		},
+	]);
+	assert.equal(restored.mock.sentMessages.length, 0);
+});
+
+test("persisting a restored waiting Goal contract does not wake the Goal", async () => {
+	const restored = restoreStoredGoalForTest({
+		id: "restored-waiting-contract",
+		text: "wait without waking",
+		status: "active",
+		startedAt: 1,
+		updatedAt: 2,
+		iteration: 1,
+		tokensUsed: 25,
+		timeUsedSeconds: 2,
+		baselineTokens: 0,
+		waiting: { reason: "external event pending" },
+	});
+	const contract = latestGoalContract(restored.mock);
+	await restored.mock.events.get("message_start")?.[0]?.({ message: contract }, restored.ctx);
+	assert.deepEqual(requireLastGoal(restored.mock).waiting, {
+		reason: "external event pending",
+	});
+	await restored.mock.events.get("agent_settled")?.[0]?.({}, restored.ctx);
+	assert.equal(restored.mock.sentUserMessages.length, 0);
 });
 
 test("compacted active Goal receives one cache-stable contract after summary messages", async () => {

--- a/packages/pi-goal/test/goal-contracts.test.ts
+++ b/packages/pi-goal/test/goal-contracts.test.ts
@@ -463,8 +463,10 @@ test("all goal prompt paths share the goal_id guard and hardened audit", async (
 	const beforeStart = started.mock.events.get("before_agent_start")?.[0]?.(
 		{ prompt: initialPrompt, systemPrompt: "base" },
 		started.ctx,
-	);
-	assert.equal(beforeStart, undefined);
+	) as { message?: { content?: string; customType?: string } } | undefined;
+	assert.equal(beforeStart?.message?.customType, "goal-contract");
+	assertPromptHasGoalId(beforeStart?.message?.content ?? "", initialGoal.id);
+	assertHardenedGoalPrompt(beforeStart?.message?.content ?? "");
 
 	await started.mock.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", stopReason: "stop" }] },

--- a/packages/pi-goal/test/goal-error-lifecycle.test.ts
+++ b/packages/pi-goal/test/goal-error-lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
 	assistantUsageEntry,
 	LOW_LIMITS_SETTINGS_PATH,
 	lastGoalStatus,
+	nonGoalContractSentMessages,
 	requireGoalTool,
 	requireLastGoal,
 	restoreStoredGoalForTest,
@@ -535,7 +536,7 @@ test("an exhausted goal does not remain active for a retryable provider error", 
 	);
 
 	assert.equal(lastGoalStatus(budgeted.mock), "budget_limited");
-	assert.equal(budgeted.mock.sentMessages.length, 0);
+	assert.equal(nonGoalContractSentMessages(budgeted.mock).length, 0);
 	assert.deepEqual(
 		await budgeted.mock.events.get("session_before_compact")?.[0]?.(
 			{ reason: "overflow", willRetry: true },

--- a/packages/pi-goal/test/goal-factory-isolation.test.ts
+++ b/packages/pi-goal/test/goal-factory-isolation.test.ts
@@ -6,6 +6,7 @@ import {
 	findPersistedGoal,
 	lastGoal,
 	lastGoalStatus,
+	nonGoalContractSentMessages,
 	registerGoal,
 	requireGoalTool,
 	requireLastGoal,
@@ -332,7 +333,7 @@ test("pending continuation and stopped budget state survive later child startup"
 	rootBranch.push(assistantUsageEntry({ totalTokens: 5 }));
 	root.events.get("tool_execution_end")?.[0]?.({}, rootContext.ctx);
 	assert.equal(lastGoalStatus(root), "budget_limited");
-	assert.equal(root.sentMessages.length, 0);
+	assert.equal(nonGoalContractSentMessages(root).length, 0);
 
 	const laterChild = createMockPi();
 	registerGoal(laterChild.pi);

--- a/packages/pi-goal/test/goal-safety.test.ts
+++ b/packages/pi-goal/test/goal-safety.test.ts
@@ -867,8 +867,8 @@ test("queued non-goal follow-up does not inherit automatic recovery ownership", 
 	const followUpStart = active.mock.events.get("before_agent_start")?.[0]?.(
 		{ prompt: "unrelated follow-up", systemPrompt: "base" },
 		active.ctx,
-	);
-	assert.equal(followUpStart, undefined);
+	) as { message?: { customType?: string } } | undefined;
+	assert.equal(followUpStart?.message?.customType, "goal-contract");
 	active.mock.events.get("turn_end")?.[0]?.(
 		{ message: { role: "assistant", stopReason: "stop", content: [] }, toolResults: [] },
 		active.ctx,

--- a/packages/pi-goal/test/goal-tool-policy.test.ts
+++ b/packages/pi-goal/test/goal-tool-policy.test.ts
@@ -576,8 +576,8 @@ test("a later restrictive tool policy pauses the goal at agent_end without conti
 	const promptResult = mock.events.get("before_agent_start")?.[0]?.(
 		{ prompt: "continue work", systemPrompt: "base" },
 		context.ctx,
-	);
-	assert.equal(promptResult, undefined);
+	) as { message?: { customType?: string } } | undefined;
+	assert.equal(promptResult?.message?.customType, "goal-contract");
 	mock.rawPi.setActiveTools(["read", "bash"]);
 	mock.events.get("agent_end")?.[0]?.(
 		{ messages: [{ role: "assistant", stopReason: "stop" }] },

--- a/packages/pi-goal/test/goal-wait.test.ts
+++ b/packages/pi-goal/test/goal-wait.test.ts
@@ -98,8 +98,8 @@ test("an external message quoting an owned prompt still wakes the goal and super
 	const startResult = waiting.mock.events.get("before_agent_start")?.[0]?.(
 		{ prompt: externalMessage, systemPrompt: "base" },
 		waiting.ctx,
-	);
-	assert.equal(startResult, undefined);
+	) as { message?: { customType?: string } } | undefined;
+	assert.equal(startResult?.message?.customType, "goal-contract");
 	assert.deepEqual(
 		waiting.mock.events.get("input")?.[0]?.(
 			{ source: "extension", text: ownedKickoff, streamingBehavior: "followUp" },
@@ -125,9 +125,9 @@ test("a custom follow-up quoting an owned prompt wakes without an input event", 
 	const startResult = waiting.mock.events.get("before_agent_start")?.[0]?.(
 		{ prompt: customPrompt, systemPrompt: "base" },
 		waiting.ctx,
-	);
+	) as { message?: { customType?: string } } | undefined;
 	assert.equal(requireLastGoal(waiting.mock).waiting, undefined);
-	assert.equal(startResult, undefined);
+	assert.equal(startResult?.message?.customType, "goal-contract");
 	assert.deepEqual(
 		waiting.mock.events.get("input")?.[0]?.(
 			{ source: "extension", text: ownedKickoff, streamingBehavior: "followUp" },

--- a/packages/pi-goal/test/support/goal-fixture.ts
+++ b/packages/pi-goal/test/support/goal-fixture.ts
@@ -144,6 +144,12 @@ export function escapeRegExp(value: string) {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+export function nonGoalContractSentMessages(mock: ReturnType<typeof createMockPi>) {
+	return mock.sentMessages.filter(
+		(sent) => (sent.message as { customType?: string }).customType !== "goal-contract",
+	);
+}
+
 export function requireGoalTool(mock: ReturnType<typeof createMockPi>, name: string) {
 	const tool = mock.tools.find((tool) => tool.name === name);
 	assert.ok(tool, `expected ${name} to be registered`);


### PR DESCRIPTION
## Summary

- persist the active Goal contract after retained conversation history instead of moving it to the leading prompt boundary
- remove stale Goal contracts across edits, restores, compaction, completion, and failed delivery while preserving both `toolVisibility` modes
- add request-level OpenAI Responses serialization regressions for activation, continuation, wait resume, identity rotation, clearing, restore, failure, and compaction
- document the cache behavior and add a patch changeset

## Verification

- `npm run check`
- `npm test` (381 files, 3,364 tests)
- `npm --workspace @narumitw/pi-goal run test:runtime`
- focused pi-goal cache and lifecycle tests (77 tests)
- `git diff --check`

## Semantic audit

- reviewed `docs/extension-conventions.md` and the pi-goal scoped guidance
- audited cancellation, disposal, session replacement, shutdown, stale Goal identity, and post-`await` ownership checks
- settings persistence is unchanged
- both `toolVisibility: "always"` and `toolVisibility: "after-first-goal"` remain supported

Live provider cache eligibility and billing remain provider-dependent; deterministic provider request serialization is covered without a network call.
