### PR TITLE
feat(plan-mode): support native PowerShell inspections

### DIFF
--- a/.changeset/gentle-plans-powershell.md
+++ b/.changeset/gentle-plans-powershell.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Allow Pi's active native PowerShell tool to run reviewed read-only file, directory, Git, and GitHub inspections in Plan mode while blocking mutation and unsupported dynamic syntax.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -158,7 +158,7 @@ It rejects output/input redirects, shell expansion, substitutions, subshells, ba
 Limited `powershell` uses a separate fail-closed PowerShell policy, including when an extension overrides the canonical `powershell` tool name.
 It accepts canonical inspection cmdlets such as `Get-ChildItem`, `Get-Content`, `Get-Item`, `Get-Location`, `Resolve-Path`, `Select-String`, `Test-Path`, `Measure-Object`, `Sort-Object`, `Format-List`, `Format-Table`, `Out-String`, and `Write-Output`.
 It also accepts the same reviewed `git` and configured `gh` queries as limited Bash, including pipelines and semicolon-delimited command lists composed entirely of accepted commands.
-It rejects redirects, variables, substitutions, script blocks, call operators, type or method expressions, stop-parsing tokens, multiline input, aliases, mutating cmdlets, and unknown commands.
+It rejects redirects, variables, substitutions, script blocks, call operators, type or method expressions, stop-parsing tokens, multiline input, non-ASCII quotation delimiters, aliases, mutating cmdlets, and unknown commands.
 Use canonical cmdlet names because PowerShell aliases are intentionally outside the reviewed policy.
 
 A rejected parsed command list or pipeline identifies its first blocked command segment; malformed or unsupported shell syntax reports the complete submitted input instead.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -14,12 +14,13 @@ This independently installable extension adds a Codex-like `/plan` collaboration
 - Reviews the complete plan before implementation, export, save, continued planning, or discard.
 - Starts implementation in the planning session or a fresh linked session with the exact approved plan.
 - Persists Plan state and one saved plan across resume and compaction.
-- Exposes statusline state and a configurable Plan tool allowlist, export destination, plan reinjection, shortcut, and thinking level.
+- Exposes statusline state and a configurable Plan tool allowlist, including reviewed native PowerShell inspection on Windows, plus export destination, plan reinjection, shortcut, and thinking level.
 - Cooperates anonymously with Workflow Mutex Protocol v1 participants so only one agent workflow starts in a session.
 
 ## 📦 Install
 
 This release requires Pi 0.80.6 or newer.
+Native PowerShell tool support requires Pi 0.84.3 or newer on Windows; earlier Pi versions omit that optional tool and retain the existing Plan policy.
 
 ```bash
 pi install npm:@narumitw/pi-plan-mode
@@ -143,18 +144,26 @@ Plan mode registers `plan_mode_question` and `plan_mode_complete` during extensi
 With the default **After first plan** visibility, `session_start` leaves both helpers inactive until the first admitted Plan workflow appends them in that order.
 With **Always**, `session_start` appends missing helpers in the same canonical order.
 Once revealed, ordinary Plan transitions never remove them during that extension runtime.
-By default, the Plan policy allows active safe built-ins such as `read`, limited `bash`, `grep`, `find`, and `ls`.
+By default, the Plan policy allows active safe built-ins such as `read`, limited `bash`, limited `powershell`, `grep`, `find`, and `ls`.
+The optional native `powershell` tool must already be active, for example through Pi's Windows `defaultTools` setting, before Plan mode can select it.
 Built-in `edit` and `write`, `update_plan`, inactive tools, and deselected tools are blocked at execution time even though active schemas remain visible.
 Extension and custom tools are denied by default because Pi tools do not expose standardized mutability metadata; allow an already active custom tool before starting only when you accept the risk.
 For example, you can opt into an active `firecrawl_scrape`, `firecrawl_search`, or `lsp_diagnostics` tool when you want to use it during planning.
 After they become visible, the Plan-only helpers remain visible in Normal mode, but their handlers and the `tool_call` policy reject calls unless Plan mode owns the active workflow.
 
-Limited `bash` uses a fail-closed policy, including when an extension overrides the canonical `bash` tool name.
+Limited `bash` uses a fail-closed Bash policy, including when an extension overrides the canonical `bash` tool name.
 It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`.
 It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, mutating flags, dependency changes, editors, and unknown commands.
+
+Limited `powershell` uses a separate fail-closed PowerShell policy, including when an extension overrides the canonical `powershell` tool name.
+It accepts canonical inspection cmdlets such as `Get-ChildItem`, `Get-Content`, `Get-Item`, `Get-Location`, `Resolve-Path`, `Select-String`, `Test-Path`, `Measure-Object`, `Sort-Object`, `Format-List`, `Format-Table`, `Out-String`, and `Write-Output`.
+It also accepts the same reviewed `git` and configured `gh` queries as limited Bash, including pipelines and semicolon-delimited command lists composed entirely of accepted commands.
+It rejects redirects, variables, substitutions, script blocks, call operators, type or method expressions, stop-parsing tokens, multiline input, aliases, mutating cmdlets, and unknown commands.
+Use canonical cmdlet names because PowerShell aliases are intentionally outside the reviewed policy.
+
 A rejected parsed command list or pipeline identifies its first blocked command segment; malformed or unsupported shell syntax reports the complete submitted input instead.
 Tests and builds may still write ignored caches or build artifacts and may execute project-defined hooks; enable or invoke them only when the repository is trusted.
-This is extension-level risk reduction, not an OS sandbox.
+Both limited-shell policies are extension-level risk reduction, not an OS sandbox or confidentiality boundary.
 
 `plan_mode_question` follows Codex's `request_user_input` pattern: the agent can ask 1-3 concise questions, each with meaningful options and a free-form Other path.
 In TUI mode, a single question shows its header as plain muted text, submits as soon as its preset or custom answer is confirmed, and does not show tabs, Review, or question-navigation controls.
@@ -349,7 +358,7 @@ An ordinary tool registered or activated after the startup baseline is outside t
 Non-built-in names in this global setting are an explicit user-risk opt-in, just like selecting them in the pre-start workflow selector.
 Plan mode does not interpret a selected custom tool's arguments or actions: allowing one trusts the whole effective tool.
 Pi resolves tools by name, so if an extension overrides a built-in name, the effective extension tool is selected instead.
-An effective active tool named `bash` remains subject to the limited-shell policy regardless of its source metadata.
+An effective active tool named `bash` or `powershell` remains subject to its limited-shell policy regardless of its source metadata.
 
 A selection accepted through **Choose tools, then start…** or `/plan tools` is stored in that Pi session and takes precedence over `defaultPlanTools` when the session resumes.
 The global setting remains the policy baseline for fresh sessions and sessions without an explicit selection.
@@ -392,7 +401,7 @@ Avoid values that conflict with editor shortcuts.
 
 ### Safe shell subcommands
 
-`safeSubcommands` adds reviewed command validators to limited `bash`; it is not a raw shell allowlist.
+`safeSubcommands` adds reviewed command validators to limited `bash` and `powershell`; it is not a raw shell allowlist.
 Only the following exact values are accepted:
 
 - `git`: `status`, `log`, `diff`, `show`, `branch`, `remote`, `ls-files`, `grep`, `rev-parse`, `blame`, `describe`, `merge-base`, `ls-tree`, and `cat-file`.
@@ -472,7 +481,7 @@ This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 - `update_plan` checklist use is blocked while Plan mode is active.
 - The implementation boundary is explicit: Plan mode appends the Normal contract and lifts its runtime allowlist before saving or starting implementation, while revealed helpers remain active.
 - The default `clear-on-start` policy follows Codex by using ordinary conversation history only; `clear-after-first-run` and `keep` add explicit exact-plan guarantees.
-- Pi extension safety is approximated with tool classification and fail-closed filtering for every effective tool named `bash`; other non-built-in tools remain user-selected at user risk because Pi does not expose standardized tool mutability metadata.
+- Pi extension safety is approximated with tool classification and separate fail-closed filtering for every effective tool named `bash` or `powershell`; other non-built-in tools remain user-selected at user risk because Pi does not expose standardized tool mutability metadata.
 - Plan and Normal instructions are append-only conversation contracts; **Always** keeps tool schemas stable from startup, while **After first plan** intentionally changes the helper schema and prompt-metadata prefix once before keeping it stable.
 - Unlike native Codex, this extension uses a terminating Pi tool plus an `agent_settled` ready flow; Pi cannot provide sandbox-level enforcement.
 

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -89,6 +89,7 @@ import {
 	canSelectToolInPlanMode,
 	classifyPlanModeTool,
 	findBlockedCommandSegment,
+	findBlockedPowerShellCommandSegment,
 	readCommand,
 } from "./tool-policy.js";
 import {
@@ -601,14 +602,26 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				reason: `Plan mode blocks tool '${event.toolName}' because its safe policy metadata is unavailable.`,
 			};
 		}
-		if (event.toolName !== "bash") return;
-
-		const blocked = findBlockedCommandSegment(readCommand(event.input), settings.safeSubcommands);
-		if (blocked !== undefined) {
-			return {
-				block: true,
-				reason: `Plan mode blocks bash commands outside its reviewed inspection policy or containing explicitly unsafe arguments.\nBlocked command: ${blocked}`,
-			};
+		if (event.toolName === "bash") {
+			const blocked = findBlockedCommandSegment(readCommand(event.input), settings.safeSubcommands);
+			if (blocked !== undefined) {
+				return {
+					block: true,
+					reason: `Plan mode blocks bash commands outside its reviewed inspection policy or containing explicitly unsafe arguments.\nBlocked command: ${blocked}`,
+				};
+			}
+		}
+		if (event.toolName === "powershell") {
+			const blocked = findBlockedPowerShellCommandSegment(
+				readCommand(event.input),
+				settings.safeSubcommands,
+			);
+			if (blocked !== undefined) {
+				return {
+					block: true,
+					reason: `Plan mode blocks PowerShell commands outside its reviewed inspection policy or containing explicitly unsafe syntax.\nBlocked command: ${blocked}`,
+				};
+			}
 		}
 	});
 

--- a/packages/pi-plan-mode/src/tool-policy.ts
+++ b/packages/pi-plan-mode/src/tool-policy.ts
@@ -171,7 +171,7 @@ export function isSafePowerShellCommand(command: string, safeSubcommands: SafeSu
 
 function splitPowerShellSegments(command: string): string[] | undefined {
 	const trimmed = command.trim();
-	if (!trimmed || /[\n\r`]/.test(trimmed)) return undefined;
+	if (!trimmed || /[\n\r`\u2018-\u201e]/.test(trimmed)) return undefined;
 
 	const segments: string[] = [];
 	let quote: "'" | '"' | undefined;
@@ -200,17 +200,8 @@ function splitPowerShellSegments(command: string): string[] | undefined {
 			return undefined;
 		}
 		const next = trimmed[index + 1];
-		if (character === "&" && next !== "&") return undefined;
-		const separatorLength =
-			character === ";"
-				? 1
-				: character === "|" || character === "&"
-					? next === character
-						? 2
-						: character === "|"
-							? 1
-							: 0
-					: 0;
+		if (character === "&" || (character === "|" && next === "|")) return undefined;
+		const separatorLength = character === ";" || character === "|" ? 1 : 0;
 		if (separatorLength === 0) continue;
 		const segment = trimmed.slice(start, index).trim();
 		if (!segment) return undefined;

--- a/packages/pi-plan-mode/src/tool-policy.ts
+++ b/packages/pi-plan-mode/src/tool-policy.ts
@@ -33,7 +33,14 @@ export interface SafeSubcommands {
 	gh?: SafeGhSubcommandPath[];
 }
 
-export const SAFE_BUILTIN_PLAN_TOOLS = new Set(["read", "bash", "grep", "find", "ls"]);
+export const SAFE_BUILTIN_PLAN_TOOLS = new Set([
+	"read",
+	"bash",
+	"powershell",
+	"grep",
+	"find",
+	"ls",
+]);
 export type PlanModeToolPolicy = "read-only" | "limited" | "user-opt-in" | "blocked";
 
 const BLOCKED_BUILTIN_TOOLS = new Set(["edit", "write"]);
@@ -64,6 +71,21 @@ const MUTATING_COMMANDS = new Set([
 	"emacs",
 	"code",
 	"subl",
+]);
+const READ_ONLY_POWERSHELL_COMMANDS = new Set([
+	"format-list",
+	"format-table",
+	"get-childitem",
+	"get-content",
+	"get-item",
+	"get-location",
+	"measure-object",
+	"out-string",
+	"resolve-path",
+	"select-string",
+	"sort-object",
+	"test-path",
+	"write-output",
 ]);
 const READ_ONLY_COMMANDS = new Set([
 	"cat",
@@ -108,7 +130,7 @@ export function isBuiltinTool(tool: ToolInfo) {
 export function classifyPlanModeTool(tool: ToolInfo): PlanModeToolPolicy {
 	if (!isBuiltinTool(tool)) return "user-opt-in";
 	if (BLOCKED_BUILTIN_TOOLS.has(tool.name)) return "blocked";
-	if (tool.name === "bash") return "limited";
+	if (tool.name === "bash" || tool.name === "powershell") return "limited";
 	return SAFE_BUILTIN_PLAN_TOOLS.has(tool.name) ? "read-only" : "blocked";
 }
 
@@ -132,6 +154,128 @@ export function findBlockedCommandSegment(
 
 export function isSafeCommand(command: string, safeSubcommands: SafeSubcommands = {}) {
 	return findBlockedCommandSegment(command, safeSubcommands) === undefined;
+}
+
+export function findBlockedPowerShellCommandSegment(
+	command: string,
+	safeSubcommands: SafeSubcommands = {},
+): string | undefined {
+	const segments = splitPowerShellSegments(command);
+	if (!segments || segments.length === 0) return command.trim() || "(empty command)";
+	return segments.find((segment) => !isSafePowerShellSegment(segment, safeSubcommands));
+}
+
+export function isSafePowerShellCommand(command: string, safeSubcommands: SafeSubcommands = {}) {
+	return findBlockedPowerShellCommandSegment(command, safeSubcommands) === undefined;
+}
+
+function splitPowerShellSegments(command: string): string[] | undefined {
+	const trimmed = command.trim();
+	if (!trimmed || /[\n\r`]/.test(trimmed)) return undefined;
+
+	const segments: string[] = [];
+	let quote: "'" | '"' | undefined;
+	let start = 0;
+	for (let index = 0; index < trimmed.length; index += 1) {
+		const character = trimmed[index];
+		if (quote === "'") {
+			if (character !== "'") continue;
+			if (trimmed[index + 1] === "'") {
+				index += 1;
+				continue;
+			}
+			quote = undefined;
+			continue;
+		}
+		if (quote === '"') {
+			if (character === "$" || character === "`") return undefined;
+			if (character === '"') quote = undefined;
+			continue;
+		}
+		if (character === "'" || character === '"') {
+			quote = character;
+			continue;
+		}
+		if (["$", "@", "#", "!", "?", "{", "}", "(", ")", "[", "]", ">", "<"].includes(character)) {
+			return undefined;
+		}
+		const next = trimmed[index + 1];
+		if (character === "&" && next !== "&") return undefined;
+		const separatorLength =
+			character === ";"
+				? 1
+				: character === "|" || character === "&"
+					? next === character
+						? 2
+						: character === "|"
+							? 1
+							: 0
+					: 0;
+		if (separatorLength === 0) continue;
+		const segment = trimmed.slice(start, index).trim();
+		if (!segment) return undefined;
+		segments.push(segment);
+		index += separatorLength - 1;
+		start = index + 1;
+	}
+	if (quote) return undefined;
+	const finalSegment = trimmed.slice(start).trim();
+	if (!finalSegment) return undefined;
+	segments.push(finalSegment);
+	return segments;
+}
+
+function isSafePowerShellSegment(segment: string, safeSubcommands: SafeSubcommands) {
+	const tokens = powerShellWords(segment);
+	if (!tokens || tokens.length === 0 || tokens.includes("--%")) return false;
+	const command = tokens[0]?.toLowerCase();
+	if (!command) return false;
+	const args = tokens.slice(1);
+	if (READ_ONLY_POWERSHELL_COMMANDS.has(command)) return true;
+	if (command !== "git" && command !== "gh") return false;
+	return isSafeStructuredCommand(command, args, safeSubcommands);
+}
+
+function powerShellWords(segment: string): string[] | undefined {
+	const words: string[] = [];
+	let word = "";
+	let hasWord = false;
+	let quote: "'" | '"' | undefined;
+	for (let index = 0; index < segment.length; index += 1) {
+		const character = segment[index];
+		if (quote === "'") {
+			if (character !== "'") {
+				word += character;
+				continue;
+			}
+			if (segment[index + 1] === "'") {
+				word += "'";
+				index += 1;
+				continue;
+			}
+			quote = undefined;
+			continue;
+		}
+		if (quote === '"') {
+			if (character === '"') quote = undefined;
+			else word += character;
+			continue;
+		}
+		if (character === "'" || character === '"') {
+			quote = character;
+			hasWord = true;
+		} else if (/\s/.test(character)) {
+			if (hasWord) words.push(word);
+			word = "";
+			hasWord = false;
+		} else {
+			word += character;
+			hasWord = true;
+		}
+	}
+	if (quote) return undefined;
+	if (hasWord) words.push(word);
+	return words;
 }
 
 function splitShellSegments(command: string): string[] | undefined {

--- a/packages/pi-plan-mode/test/default-tools.test.ts
+++ b/packages/pi-plan-mode/test/default-tools.test.ts
@@ -156,6 +156,38 @@ test("configured Plan tools are an allowlist over active tools, not an activatio
 	});
 });
 
+test("active PowerShell is an automatic safe built-in without changing tool schemas", async () => {
+	const baseline = ["read", "powershell", "write", ...HELPERS];
+	const mock = createMockPi({
+		activeTools: ["read", "powershell", "write"],
+		allTools: [builtinTool("read"), builtinTool("powershell"), builtinTool("write")],
+	});
+	planMode(mock.pi);
+	const context = createMockContext();
+
+	assert.equal(
+		await callTool(mock, context, "powershell", { command: "Remove-Item README.md" }),
+		undefined,
+		"inactive Plan mode must not enforce its PowerShell policy",
+	);
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+
+	assert.deepEqual(mock.rawPi.getActiveTools(), baseline);
+	assert.equal(
+		await callTool(mock, context, "powershell", { command: "Get-ChildItem -Force" }),
+		undefined,
+	);
+	assert.equal(
+		(
+			(await callTool(mock, context, "powershell", {
+				command: "Set-Content README.md changed",
+			})) as { block?: boolean }
+		).block,
+		true,
+	);
+});
+
 test("active selected custom tools execute while deselected and mutating tools fail closed", async () => {
 	const baseline = ["read", "bash", "write", "custom", ...HELPERS];
 	const mock = createMockPi({

--- a/packages/pi-plan-mode/test/safe-subcommands.test.ts
+++ b/packages/pi-plan-mode/test/safe-subcommands.test.ts
@@ -111,6 +111,58 @@ test("active Plan mode enforces limited policy for effective bash overrides", as
 	});
 });
 
+test("active Plan mode enforces limited policy for effective PowerShell overrides", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, "pi-plan-mode.json"),
+			JSON.stringify({
+				defaultPlanTools: ["powershell"],
+				safeSubcommands: { git: ["rev-parse"] },
+			}),
+		);
+		const mock = createMockPi({
+			activeTools: ["powershell"],
+			allTools: [extensionTool("powershell")],
+		});
+		planMode(mock.pi);
+		const context = createMockContext();
+		const hook = mock.events.get("tool_call")?.[0];
+		assert.ok(hook);
+
+		assert.equal(
+			await hook(
+				{ toolName: "powershell", input: { command: "Remove-Item README.md" } },
+				context.ctx,
+			),
+			undefined,
+			"inactive Plan mode must not enforce its PowerShell policy",
+		);
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		assert.equal(
+			await hook(
+				{ toolName: "powershell", input: { command: "git rev-parse --show-toplevel" } },
+				context.ctx,
+			),
+			undefined,
+		);
+		assert.deepEqual(
+			await hook(
+				{
+					toolName: "powershell",
+					input: { command: "Get-ChildItem; Remove-Item README.md; Get-Location" },
+				},
+				context.ctx,
+			),
+			{
+				block: true,
+				reason:
+					"Plan mode blocks PowerShell commands outside its reviewed inspection policy or containing explicitly unsafe syntax.\nBlocked command: Remove-Item README.md",
+			},
+		);
+	});
+});
+
 test("session reload removes stale or invalid safe subcommand policy", async () => {
 	await withAgentDir(async (agentDir) => {
 		const settingsPath = join(agentDir, "pi-plan-mode.json");

--- a/packages/pi-plan-mode/test/tool-policy.test.ts
+++ b/packages/pi-plan-mode/test/tool-policy.test.ts
@@ -182,6 +182,25 @@ test("PowerShell policy rejects mutation and dynamic execution syntax", () => {
 	}
 });
 
+test("PowerShell policy rejects unsupported quote and statement syntax", () => {
+	for (let codePoint = 0x2018; codePoint <= 0x201e; codePoint += 1) {
+		const quote = String.fromCodePoint(codePoint);
+		const command = `Write-Output ${quote}safe${quote}`;
+		assert.equal(isSafePowerShellCommand(command), false, command);
+		assert.equal(findBlockedPowerShellCommandSegment(command), command);
+	}
+
+	for (const command of [
+		'Write-Output "safe\u201d; Remove-Item README.md \u201c"',
+		"Write-Output 'safe\u2019; Remove-Item README.md \u2018'",
+		"Write-Output one && Write-Output two",
+		"Write-Output one || Write-Output two",
+	]) {
+		assert.equal(isSafePowerShellCommand(command), false, command);
+		assert.equal(findBlockedPowerShellCommandSegment(command), command);
+	}
+});
+
 test("PowerShell diagnostics identify the first rejected segment", () => {
 	const accepted = "Get-ChildItem -Force; git status --short | Select-String modified";
 	const blocked = "Get-ChildItem; git status --short | Remove-Item README.md; Get-Location";

--- a/packages/pi-plan-mode/test/tool-policy.test.ts
+++ b/packages/pi-plan-mode/test/tool-policy.test.ts
@@ -12,11 +12,16 @@ import planMode, {
 	isSafeCommand,
 	withRequiredPlanModeTools,
 } from "../src/plan-mode.js";
-import { findBlockedCommandSegment } from "../src/tool-policy.js";
+import {
+	findBlockedCommandSegment,
+	findBlockedPowerShellCommandSegment,
+	isSafePowerShellCommand,
+} from "../src/tool-policy.js";
 
 test("tool selection allows safe built-ins and non-built-ins only", () => {
 	type PlanTool = Parameters<typeof canSelectToolInPlanMode>[0];
 	assert.equal(canSelectToolInPlanMode(builtinTool("read") as PlanTool), true);
+	assert.equal(canSelectToolInPlanMode(builtinTool("powershell") as PlanTool), true);
 	assert.equal(canSelectToolInPlanMode(builtinTool("edit") as PlanTool), false);
 	assert.equal(canSelectToolInPlanMode(extensionTool("custom") as PlanTool), true);
 	assert.equal(canSelectToolInPlanMode(extensionTool("edit") as PlanTool), true);
@@ -117,6 +122,94 @@ test("blocked command diagnostics identify the first rejected segment", () => {
 	for (const command of [accepted, singleBlocked, compoundBlocked, unsupportedSyntax, "   "]) {
 		assert.equal(isSafeCommand(command), findBlockedCommandSegment(command) === undefined, command);
 	}
+});
+
+test("PowerShell policy permits reviewed inspection commands", () => {
+	for (const command of [
+		"Get-ChildItem -Filter *.ts",
+		"Get-Content -LiteralPath 'README file.md'",
+		"gEt-LoCaTiOn",
+		"Get-Item Env:PI_MODEL",
+		"Get-Location",
+		"Resolve-Path .",
+		"Select-String -Path README.md -Pattern 'Plan mode'",
+		"Test-Path packages\\pi-plan-mode",
+		"Get-Content README.md | Select-String -Pattern Plan",
+		"Get-ChildItem packages; Measure-Object",
+		"Get-ChildItem | Sort-Object Name | Format-Table Name",
+		"Write-Output 'safe; Remove-Item README.md'",
+		"Write-Output '$env:PI_MODEL'",
+		"Write-Output 'status'; git status --short",
+		"git log -1 --oneline",
+	]) {
+		assert.equal(isSafePowerShellCommand(command), true, command);
+	}
+});
+
+test("PowerShell policy rejects mutation and dynamic execution syntax", () => {
+	for (const command of [
+		"Remove-Item README.md",
+		"Set-Content README.md changed",
+		"New-Item output.txt",
+		"Copy-Item source target",
+		"Invoke-Expression 'Get-ChildItem'",
+		"Start-Process git",
+		"Get-Content README.md > copy.md",
+		"Get-Content $env:PI_SESSION_FILE",
+		"Get-Content $(Get-Location)",
+		"Get-ChildItem | ForEach-Object { Remove-Item $_ }",
+		"& 'git' status",
+		"[System.IO.File]::Delete('README.md')",
+		'Get-Content `"README.md`"',
+		"git reset --hard",
+		"git status; Remove-Item README.md",
+		"Get-ChildItem && Remove-Item README.md",
+		"Get-ChildItem || Set-Content README.md changed",
+		"Get-Content README.md | Tee-Object copy.md",
+		"Test-Path README.md ? Get-Content README.md : Remove-Item README.md",
+		"Get-ChildItem ?? Remove-Item README.md",
+		"Get-ChildItem ! Remove-Item README.md",
+		"git --% status; Remove-Item README.md",
+		"Get-ChildItem # comment",
+		"npm test",
+		"node --version",
+		"cmd /c dir",
+		"powershell -Command Get-ChildItem",
+		"Get-Content README.md\nRemove-Item README.md",
+		"",
+	]) {
+		assert.equal(isSafePowerShellCommand(command), false, command);
+	}
+});
+
+test("PowerShell diagnostics identify the first rejected segment", () => {
+	const accepted = "Get-ChildItem -Force; git status --short | Select-String modified";
+	const blocked = "Get-ChildItem; git status --short | Remove-Item README.md; Get-Location";
+	const unsupported = " Get-Content README.md > copy.md ";
+
+	assert.equal(findBlockedPowerShellCommandSegment(accepted), undefined);
+	assert.equal(findBlockedPowerShellCommandSegment(blocked), "Remove-Item README.md");
+	assert.equal(findBlockedPowerShellCommandSegment(unsupported), unsupported.trim());
+	assert.equal(findBlockedPowerShellCommandSegment("   "), "(empty command)");
+});
+
+test("PowerShell policy reuses configured Git and gh validators", () => {
+	assert.equal(isSafePowerShellCommand("git rev-parse --show-toplevel"), false);
+	assert.equal(
+		isSafePowerShellCommand("git rev-parse --show-toplevel", { git: ["rev-parse"] }),
+		true,
+	);
+	assert.equal(isSafePowerShellCommand("gh issue view 973 --json number,title"), false);
+	assert.equal(
+		isSafePowerShellCommand("gh issue view 973 --json number,title", { gh: ["issue view"] }),
+		true,
+	);
+	assert.equal(
+		isSafePowerShellCommand("gh issue view 973 --json number,title; git reset --hard", {
+			gh: ["issue view"],
+		}),
+		false,
+	);
 });
 
 test("configured Git validators are additive and exact", () => {
@@ -304,6 +397,7 @@ test("tool policy classifies built-ins and extension tools consistently", () => 
 	type PlanTool = Parameters<typeof classifyPlanModeTool>[0];
 	assert.equal(classifyPlanModeTool(builtinTool("read") as PlanTool), "read-only");
 	assert.equal(classifyPlanModeTool(builtinTool("bash") as PlanTool), "limited");
+	assert.equal(classifyPlanModeTool(builtinTool("powershell") as PlanTool), "limited");
 	assert.equal(classifyPlanModeTool(builtinTool("write") as PlanTool), "blocked");
 	assert.equal(classifyPlanModeTool(extensionTool("custom") as PlanTool), "user-opt-in");
 });


### PR DESCRIPTION
## Summary

- treat Pi's active native `powershell` tool as a limited automatic Plan-mode built-in
- enforce a dedicated fail-closed PowerShell parser for reviewed canonical inspection cmdlets and shared Git/GitHub validators
- document compatibility and security limits, add adversarial regressions, and record a minor Changeset

## Verification

- `npm exec vitest -- run packages/pi-plan-mode/test/tool-policy.test.ts packages/pi-plan-mode/test/default-tools.test.ts packages/pi-plan-mode/test/safe-subcommands.test.ts` — 27 passed
- `npm run check` — passed build, Biome, boundaries, and workspace typechecks
- `npm test` — 381 files and 3,364 tests passed
- `npm run changeset:status` — reports the intended `@narumitw/pi-plan-mode` minor target; existing unrelated workspace dependency-floor warnings remain
- `just pack plan-mode` — dry run contains the expected 40 files

## Risks and unverified paths

- Native Windows execution was not run because this Linux environment has no `pwsh` or Windows PowerShell executable; Pi 0.84.3 tool metadata and deterministic extension-boundary tests were verified.
- The policy intentionally rejects aliases and unsupported dynamic PowerShell syntax.
- The policy reduces mutation risk but is not an OS sandbox or confidentiality boundary.

Closes #973
