### PR TITLE
feat(cache-hit-monitor): show live prompt cache metrics

### DIFF
--- a/.pi/extensions/cache-hit-monitor/README.md
+++ b/.pi/extensions/cache-hit-monitor/README.md
@@ -19,7 +19,9 @@ The command accepts no arguments and is available in TUI and RPC modes.
 - `re-billed` estimates reusable-prefix tokens not covered by the current `cacheRead` count.
 - `cache saved` estimates the price difference between uncached input and cache-read pricing.
 - `miss premium` estimates the extra price of re-billed tokens compared with cache-read pricing.
+- `start gap` is the elapsed time between the previous and current provider request start timestamps.
 - `Session` reports weighted active-branch totals and does not average request percentages.
+- Session totals include provider usage reported by compaction and branch-summary calls.
 - `Trend` shows the latest eight request hit rates from oldest to newest.
 
 ## Runtime behavior
@@ -35,5 +37,5 @@ It does not add model-visible tools, messages, system instructions, or provider 
 
 All values depend on provider-reported Pi usage fields and can remain unavailable when a provider omits cache accounting.
 `re-billed` compares token counts and cannot prove which exact serialized prefix bytes the provider cached.
-Cost values are estimates based on reported usage costs or the matching Pi model rates, and subscription billing can differ.
+Cost values use reported usage costs with matching Pi model rates as component fallbacks, and subscription billing can differ.
 Cache writes are included in the repository-standard hit-rate denominator but are not labeled as uncached input.

--- a/.pi/extensions/cache-hit-monitor/README.md
+++ b/.pi/extensions/cache-hit-monitor/README.md
@@ -36,6 +36,7 @@ It does not add model-visible tools, messages, system instructions, or provider 
 ## Limitations
 
 All values depend on provider-reported Pi usage fields and can remain unavailable when a provider omits cache accounting.
+The monitor does not interpret normalized all-zero cache fields as a complete miss until that provider reports cache-read or cache-write activity.
 `re-billed` compares token counts and cannot prove which exact serialized prefix bytes the provider cached.
 Cost values use reported usage costs with Pi's effective model tiers and cache-write retention pricing as component fallbacks, and subscription billing can differ.
 Cache writes are included in the repository-standard hit-rate denominator but are not labeled as uncached input.

--- a/.pi/extensions/cache-hit-monitor/README.md
+++ b/.pi/extensions/cache-hit-monitor/README.md
@@ -1,0 +1,33 @@
+# Cache hit monitor
+
+This project-local Pi extension displays live prompt-cache diagnostics above the editor.
+Pi discovers it automatically after the project is trusted, and `/reload` activates source changes.
+
+## Displayed metrics
+
+- `hit` is `cacheRead / (input + cacheRead + cacheWrite)` for the latest provider response.
+- `Δ` is the signed percentage-point change from the previous comparable request.
+- `loss` is only the downward part of that hit-rate change.
+- `uncached` is the latest `input` share and token count.
+- `eligible` is the smaller prompt-token count between the previous and current request.
+- `re-billed` estimates reusable-prefix tokens not covered by the current `cacheRead` count.
+- `cache saved` estimates the price difference between uncached input and cache-read pricing.
+- `miss premium` estimates the extra price of re-billed tokens compared with cache-read pricing.
+- `Session` reports weighted active-branch totals and does not average request percentages.
+- `Trend` shows the latest eight request hit rates from oldest to newest.
+
+## Runtime behavior
+
+The widget updates from `message_update` as soon as the provider reports usage and finalizes on `message_end`.
+Cache comparisons reset across compaction and branch-summary boundaries because those events create a new cache prefix epoch.
+Session totals continue to include usage records visible on the active branch.
+The extension rebuilds state after session start, compaction, and tree navigation.
+It clears its widget during session shutdown and ignores events from replaced sessions.
+It does not add model-visible tools, messages, system instructions, or provider payload changes.
+
+## Limitations
+
+All values depend on provider-reported Pi usage fields and can remain unavailable when a provider omits cache accounting.
+`re-billed` compares token counts and cannot prove which exact serialized prefix bytes the provider cached.
+Cost values are estimates based on reported usage costs or the matching Pi model rates, and subscription billing can differ.
+Cache writes are included in the repository-standard hit-rate denominator but are not labeled as uncached input.

--- a/.pi/extensions/cache-hit-monitor/README.md
+++ b/.pi/extensions/cache-hit-monitor/README.md
@@ -2,6 +2,12 @@
 
 This project-local Pi extension displays live prompt-cache diagnostics above the editor.
 Pi discovers it automatically after the project is trusted, and `/reload` activates source changes.
+The widget starts hidden in every session.
+
+## Command
+
+Run `/cache-hit-monitor` to show or hide the widget.
+The command accepts no arguments and is available in TUI and RPC modes.
 
 ## Displayed metrics
 
@@ -18,7 +24,7 @@ Pi discovers it automatically after the project is trusted, and `/reload` activa
 
 ## Runtime behavior
 
-The widget updates from `message_update` as soon as the provider reports usage and finalizes on `message_end`.
+While visible, the widget updates from `message_update` as soon as the provider reports usage and finalizes on `message_end`.
 Cache comparisons reset across compaction and branch-summary boundaries because those events create a new cache prefix epoch.
 Session totals continue to include usage records visible on the active branch.
 The extension rebuilds state after session start, compaction, and tree navigation.

--- a/.pi/extensions/cache-hit-monitor/README.md
+++ b/.pi/extensions/cache-hit-monitor/README.md
@@ -37,5 +37,5 @@ It does not add model-visible tools, messages, system instructions, or provider 
 
 All values depend on provider-reported Pi usage fields and can remain unavailable when a provider omits cache accounting.
 `re-billed` compares token counts and cannot prove which exact serialized prefix bytes the provider cached.
-Cost values use reported usage costs with matching Pi model rates as component fallbacks, and subscription billing can differ.
+Cost values use reported usage costs with Pi's effective model tiers and cache-write retention pricing as component fallbacks, and subscription billing can differ.
 Cache writes are included in the repository-standard hit-rate denominator but are not labeled as uncached input.

--- a/.pi/extensions/cache-hit-monitor/index.test.ts
+++ b/.pi/extensions/cache-hit-monitor/index.test.ts
@@ -153,9 +153,9 @@ test("stays hidden by default, then previews and finalizes detailed metrics when
 
 	await harness.command("", current.ctx);
 	assert.deepEqual(current.notifications, [["Cache hit monitor shown.", "info"]]);
-	assert.deepEqual(renderWidget(current.widgets.at(-1))?.slice(1), [
-		"Prompt cache · waiting for provider usage",
-		"Hit = cacheRead / (input + cacheRead + cacheWrite). Live updates begin when usage is reported.",
+	assert.deepEqual(renderWidget(current.widgets.at(-1), 160)?.slice(1), [
+		"Prompt cache · waiting for provider cache usage",
+		"Hit = cacheRead / (input + cacheRead + cacheWrite). All-zero cache fields remain unknown until this provider reports cache activity.",
 	]);
 
 	const first = assistant(200, 800);
@@ -185,6 +185,31 @@ test("stays hidden by default, then previews and finalizes detailed metrics when
 	assert.match(compared, /loss 25\.5 pp/);
 	assert.match(compared, /re-billed 400 \(40\.0%\)/);
 	assert.match(compared, /miss premium ~\$0\.0044/);
+});
+
+test("does not display all-zero cache fields until the provider reports cache activity", async () => {
+	const harness = createHarness();
+	const current = createContext();
+	await harness.emit("session_start", {}, current.ctx);
+	await harness.command("", current.ctx);
+	const waitingCount = current.widgets.length;
+
+	await harness.emit("message_update", { message: assistant(1_000, 0) }, current.ctx);
+	assert.equal(current.widgets.length, waitingCount);
+	assert.match(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /waiting/);
+
+	const cached = assistant(200, 800);
+	await harness.emit("message_update", { message: cached }, current.ctx);
+	await harness.emit("message_end", { message: cached }, current.ctx);
+	await harness.emit(
+		"message_update",
+		{ message: assistant(1_000, 0, 0, { timestamp: 2_000 }) },
+		current.ctx,
+	);
+	const rendered = renderWidget(current.widgets.at(-1), 120)?.join("\n") ?? "";
+	assert.match(rendered, /hit 0\.0%/);
+	assert.match(rendered, /re-billed 1k \(100\.0%\)/);
+	assert.match(rendered, /miss premium ~\$0\.0090/);
 });
 
 test("the command toggles the widget closed and rejects arguments", async () => {
@@ -217,7 +242,7 @@ test("clears a partial live preview if an agent run ends without a final message
 	assert.doesNotMatch(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /LIVE/);
 	assert.match(
 		renderWidget(current.widgets.at(-1))?.join("\n") ?? "",
-		/waiting for provider usage/,
+		/waiting for provider cache usage/,
 	);
 });
 
@@ -253,6 +278,25 @@ test("restores active-branch history and resets comparison at the compaction bou
 	assert.match(rendered, /no comparable request in the current cache epoch/);
 	assert.match(rendered, /Session {2}3 req/);
 	assert.match(rendered, /re-billed\s+400/);
+});
+
+test("renders restored totals for a summary-only branch", async () => {
+	const summary = assistant(100, 900);
+	const harness = createHarness();
+	const current = createContext("tui", [
+		{
+			type: "branch_summary",
+			id: "branch-summary",
+			parentId: null,
+			usage: summary.usage,
+		} as SessionEntry,
+	]);
+	await harness.emit("session_start", {}, current.ctx);
+	await harness.command("", current.ctx);
+
+	const rendered = renderWidget(current.widgets.at(-1), 120)?.join("\n") ?? "";
+	assert.match(rendered, /summary usage only/);
+	assert.match(rendered, /Session {2}1 req.*hit 90\.0%/);
 });
 
 test("clears replacement UI and ignores stale replacement-session events", async () => {

--- a/.pi/extensions/cache-hit-monitor/index.test.ts
+++ b/.pi/extensions/cache-hit-monitor/index.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import type { AssistantMessage, ModelCostRates } from "@earendil-works/pi-ai";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	SessionEntry,
+	Theme,
+} from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import cacheHitMonitor, { renderCacheMonitor, WIDGET_KEY } from "./index.js";
+import { createCacheMonitorView, createCacheSample } from "./metrics.js";
+
+const RATES: ModelCostRates = { input: 10, output: 20, cacheRead: 1, cacheWrite: 20 };
+const THEME = {
+	fg: (_role: string, text: string) => text,
+	bold: (text: string) => text,
+} as unknown as Theme;
+
+type Handler = (event: never, ctx: ExtensionContext) => unknown;
+type WidgetFactory = (_tui: never, theme: Theme) => Component;
+type WidgetRecord = [
+	string,
+	string[] | WidgetFactory | undefined,
+	{ placement: "aboveEditor" } | undefined,
+];
+
+function assistant(
+	input: number,
+	cacheRead: number,
+	cacheWrite = 0,
+	overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "openai-responses",
+		provider: "test-provider",
+		model: "test-model",
+		content: [],
+		stopReason: "stop",
+		timestamp: 1_000,
+		usage: {
+			input,
+			output: 10,
+			cacheRead,
+			cacheWrite,
+			totalTokens: input + cacheRead + cacheWrite + 10,
+			cost: {
+				input: (input * RATES.input) / 1_000_000,
+				output: (10 * RATES.output) / 1_000_000,
+				cacheRead: (cacheRead * RATES.cacheRead) / 1_000_000,
+				cacheWrite: (cacheWrite * RATES.cacheWrite) / 1_000_000,
+				total: 0,
+			},
+		},
+		...overrides,
+	};
+}
+
+function messageEntry(message: AssistantMessage): SessionEntry {
+	return { type: "message", id: crypto.randomUUID(), parentId: null, message } as SessionEntry;
+}
+
+function createHarness() {
+	const handlers = new Map<string, Handler[]>();
+	const pi = {
+		on(event: string, handler: Handler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+	} as unknown as ExtensionAPI;
+	cacheHitMonitor(pi);
+	return {
+		async emit(event: string, payload: Record<string, unknown>, ctx: ExtensionContext) {
+			for (const handler of handlers.get(event) ?? []) await handler(payload as never, ctx);
+		},
+	};
+}
+
+function createContext(
+	mode: ExtensionContext["mode"] = "tui",
+	initialEntries: SessionEntry[] = [],
+) {
+	let entries = initialEntries;
+	const widgets: WidgetRecord[] = [];
+	const sessionManager = {
+		getBranch: () => entries,
+	} as unknown as ExtensionContext["sessionManager"];
+	const ctx = {
+		mode,
+		hasUI: mode === "tui" || mode === "rpc",
+		sessionManager,
+		modelRegistry: {
+			find: () => ({ cost: RATES }),
+		},
+		ui: {
+			setWidget(
+				key: string,
+				content: string[] | WidgetFactory | undefined,
+				options?: { placement: "aboveEditor" },
+			) {
+				widgets.push([key, content, options]);
+			},
+		},
+	} as unknown as ExtensionContext;
+	return {
+		ctx,
+		widgets,
+		setEntries(next: SessionEntry[]) {
+			entries = next;
+		},
+	};
+}
+
+function renderWidget(record: WidgetRecord | undefined, width = 100): string[] | undefined {
+	if (!record) return undefined;
+	const content = record[1];
+	return typeof content === "function" ? content(undefined as never, THEME).render(width) : content;
+}
+
+test("publishes waiting state, previews streaming usage, and finalizes detailed metrics", async () => {
+	const harness = createHarness();
+	const current = createContext();
+	await harness.emit("session_start", {}, current.ctx);
+	assert.deepEqual(renderWidget(current.widgets.at(-1))?.slice(1), [
+		"Prompt cache · waiting for provider usage",
+		"Hit = cacheRead / (input + cacheRead + cacheWrite). Live updates begin when usage is reported.",
+	]);
+
+	const first = assistant(200, 800);
+	await harness.emit("message_update", { message: first, assistantMessageEvent: {} }, current.ctx);
+	const live = renderWidget(current.widgets.at(-1));
+	assert.match(live?.join("\n") ?? "", /LIVE.*hit 80\.0%/s);
+	const updateCount = current.widgets.length;
+	await harness.emit("message_update", { message: first, assistantMessageEvent: {} }, current.ctx);
+	assert.equal(current.widgets.length, updateCount);
+
+	await harness.emit("message_end", { message: first }, current.ctx);
+	assert.doesNotMatch(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /LIVE/);
+
+	const second = assistant(400, 600, 100, { timestamp: 3_000 });
+	await harness.emit("message_update", { message: second, assistantMessageEvent: {} }, current.ctx);
+	const compared = renderWidget(current.widgets.at(-1), 120)?.join("\n") ?? "";
+	assert.match(compared, /loss 25\.5 pp/);
+	assert.match(compared, /re-billed 400 \(40\.0%\)/);
+	assert.match(compared, /miss premium ~\$0\.0044/);
+});
+
+test("clears a partial live preview if an agent run ends without a final message", async () => {
+	const harness = createHarness();
+	const current = createContext();
+	await harness.emit("session_start", {}, current.ctx);
+	await harness.emit("message_update", { message: assistant(200, 800) }, current.ctx);
+	assert.match(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /LIVE/);
+
+	await harness.emit("agent_end", { messages: [] }, current.ctx);
+	assert.doesNotMatch(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /LIVE/);
+	assert.match(
+		renderWidget(current.widgets.at(-1))?.join("\n") ?? "",
+		/waiting for provider usage/,
+	);
+});
+
+test("restores active-branch history and resets comparison after compaction", async () => {
+	const first = assistant(200, 800);
+	const harness = createHarness();
+	const current = createContext("tui", [messageEntry(first)]);
+	await harness.emit("session_start", {}, current.ctx);
+	assert.match(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /request #1.*hit 80\.0%/s);
+
+	const afterCompaction = assistant(900, 100, 0, { timestamp: 4_000 });
+	current.setEntries([
+		messageEntry(first),
+		{ type: "compaction", id: "compact", parentId: null } as SessionEntry,
+		messageEntry(afterCompaction),
+	]);
+	await harness.emit("session_compact", {}, current.ctx);
+	const rendered = renderWidget(current.widgets.at(-1), 120)?.join("\n") ?? "";
+	assert.match(rendered, /request #2.*hit 10\.0%/s);
+	assert.match(rendered, /no comparable request in the current cache epoch/);
+	assert.match(rendered, /Session {2}2 req/);
+	assert.match(rendered, /re-billed 0/);
+});
+
+test("ignores stale replacement-session events and clears only the owned widget", async () => {
+	const harness = createHarness();
+	const previous = createContext();
+	const current = createContext();
+	await harness.emit("session_start", {}, previous.ctx);
+	await harness.emit("session_start", {}, current.ctx);
+	const currentCount = current.widgets.length;
+
+	await harness.emit("message_update", { message: assistant(100, 900) }, previous.ctx);
+	await harness.emit("session_shutdown", {}, previous.ctx);
+	assert.equal(current.widgets.length, currentCount);
+
+	await harness.emit("session_shutdown", {}, current.ctx);
+	assert.deepEqual(current.widgets.at(-1), [WIDGET_KEY, undefined, undefined]);
+});
+
+test("uses plain string widgets in RPC mode and remains silent without UI", async () => {
+	const harness = createHarness();
+	const rpc = createContext("rpc", [messageEntry(assistant(200, 800))]);
+	await harness.emit("session_start", {}, rpc.ctx);
+	const rpcContent = rpc.widgets.at(-1)?.[1];
+	assert.ok(Array.isArray(rpcContent));
+	assert.match(rpcContent.join("\n"), /hit 80\.0%/);
+
+	const json = createContext("json", [messageEntry(assistant(200, 800))]);
+	await harness.emit("session_start", {}, json.ctx);
+	assert.equal(json.widgets.length, 0);
+});
+
+test("renders every line within narrow widths and strips unsafe model text", () => {
+	const sample = createCacheSample(
+		assistant(200, 800, 0, {
+			provider: "\u001b]8;;bad\u0007provider",
+			model: "model\n\u202eunsafe",
+		}),
+		0,
+		RATES,
+	);
+	assert.ok(sample);
+	const lines = renderCacheMonitor(createCacheMonitorView([sample]), THEME, 32);
+	const plain = lines.map(stripTerminalSequences);
+
+	assert.ok(lines.every((line) => visibleWidth(line) <= 32));
+	assert.match(plain.join("\n"), /provider\/model unsafe/);
+	assert.ok(
+		plain.every((line) =>
+			[...line].every((character) => {
+				const codePoint = character.codePointAt(0) ?? 0;
+				return (codePoint >= 32 || character === "\n") && codePoint !== 127 && codePoint !== 0x202e;
+			}),
+		),
+	);
+});

--- a/.pi/extensions/cache-hit-monitor/index.test.ts
+++ b/.pi/extensions/cache-hit-monitor/index.test.ts
@@ -9,7 +9,7 @@ import type {
 import type { Component } from "@earendil-works/pi-tui";
 import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
-import cacheHitMonitor, { renderCacheMonitor, WIDGET_KEY } from "./index.js";
+import cacheHitMonitor, { COMMAND_NAME, renderCacheMonitor, WIDGET_KEY } from "./index.js";
 import { createCacheMonitorView, createCacheSample } from "./metrics.js";
 
 const RATES: ModelCostRates = { input: 10, output: 20, cacheRead: 1, cacheWrite: 20 };
@@ -19,6 +19,7 @@ const THEME = {
 } as unknown as Theme;
 
 type Handler = (event: never, ctx: ExtensionContext) => unknown;
+type CommandHandler = (args: string, ctx: ExtensionContext) => unknown;
 type WidgetFactory = (_tui: never, theme: Theme) => Component;
 type WidgetRecord = [
 	string,
@@ -64,15 +65,24 @@ function messageEntry(message: AssistantMessage): SessionEntry {
 
 function createHarness() {
 	const handlers = new Map<string, Handler[]>();
+	const commands = new Map<string, CommandHandler>();
 	const pi = {
 		on(event: string, handler: Handler) {
 			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		registerCommand(name: string, options: { handler: CommandHandler }) {
+			commands.set(name, options.handler);
 		},
 	} as unknown as ExtensionAPI;
 	cacheHitMonitor(pi);
 	return {
 		async emit(event: string, payload: Record<string, unknown>, ctx: ExtensionContext) {
 			for (const handler of handlers.get(event) ?? []) await handler(payload as never, ctx);
+		},
+		async command(args: string, ctx: ExtensionContext) {
+			const handler = commands.get(COMMAND_NAME);
+			assert.ok(handler);
+			await handler(args, ctx);
 		},
 	};
 }
@@ -83,6 +93,7 @@ function createContext(
 ) {
 	let entries = initialEntries;
 	const widgets: WidgetRecord[] = [];
+	const notifications: Array<[string, "info" | "warning" | "error" | undefined]> = [];
 	const sessionManager = {
 		getBranch: () => entries,
 	} as unknown as ExtensionContext["sessionManager"];
@@ -94,6 +105,9 @@ function createContext(
 			find: () => ({ cost: RATES }),
 		},
 		ui: {
+			notify(message: string, level?: "info" | "warning" | "error") {
+				notifications.push([message, level]);
+			},
 			setWidget(
 				key: string,
 				content: string[] | WidgetFactory | undefined,
@@ -105,6 +119,7 @@ function createContext(
 	} as unknown as ExtensionContext;
 	return {
 		ctx,
+		notifications,
 		widgets,
 		setEntries(next: SessionEntry[]) {
 			entries = next;
@@ -118,10 +133,14 @@ function renderWidget(record: WidgetRecord | undefined, width = 100): string[] |
 	return typeof content === "function" ? content(undefined as never, THEME).render(width) : content;
 }
 
-test("publishes waiting state, previews streaming usage, and finalizes detailed metrics", async () => {
+test("stays hidden by default, then previews and finalizes detailed metrics when shown", async () => {
 	const harness = createHarness();
 	const current = createContext();
 	await harness.emit("session_start", {}, current.ctx);
+	assert.equal(current.widgets.length, 0);
+
+	await harness.command("", current.ctx);
+	assert.deepEqual(current.notifications, [["Cache hit monitor shown.", "info"]]);
 	assert.deepEqual(renderWidget(current.widgets.at(-1))?.slice(1), [
 		"Prompt cache · waiting for provider usage",
 		"Hit = cacheRead / (input + cacheRead + cacheWrite). Live updates begin when usage is reported.",
@@ -146,10 +165,29 @@ test("publishes waiting state, previews streaming usage, and finalizes detailed 
 	assert.match(compared, /miss premium ~\$0\.0044/);
 });
 
+test("the command toggles the widget closed and rejects arguments", async () => {
+	const harness = createHarness();
+	const current = createContext("tui", [messageEntry(assistant(200, 800))]);
+	await harness.emit("session_start", {}, current.ctx);
+	await harness.command("", current.ctx);
+	assert.match(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /hit 80\.0%/);
+
+	await harness.command("", current.ctx);
+	assert.deepEqual(current.widgets.at(-1), [WIDGET_KEY, undefined, undefined]);
+	assert.deepEqual(current.notifications, [
+		["Cache hit monitor shown.", "info"],
+		["Cache hit monitor hidden.", "info"],
+	]);
+	await assert.rejects(() => harness.command("unexpected", current.ctx), {
+		message: `Usage: /${COMMAND_NAME}`,
+	});
+});
+
 test("clears a partial live preview if an agent run ends without a final message", async () => {
 	const harness = createHarness();
 	const current = createContext();
 	await harness.emit("session_start", {}, current.ctx);
+	await harness.command("", current.ctx);
 	await harness.emit("message_update", { message: assistant(200, 800) }, current.ctx);
 	assert.match(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /LIVE/);
 
@@ -166,6 +204,7 @@ test("restores active-branch history and resets comparison after compaction", as
 	const harness = createHarness();
 	const current = createContext("tui", [messageEntry(first)]);
 	await harness.emit("session_start", {}, current.ctx);
+	await harness.command("", current.ctx);
 	assert.match(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /request #1.*hit 80\.0%/s);
 
 	const afterCompaction = assistant(900, 100, 0, { timestamp: 4_000 });
@@ -188,6 +227,7 @@ test("ignores stale replacement-session events and clears only the owned widget"
 	const current = createContext();
 	await harness.emit("session_start", {}, previous.ctx);
 	await harness.emit("session_start", {}, current.ctx);
+	await harness.command("", current.ctx);
 	const currentCount = current.widgets.length;
 
 	await harness.emit("message_update", { message: assistant(100, 900) }, previous.ctx);
@@ -202,6 +242,8 @@ test("uses plain string widgets in RPC mode and remains silent without UI", asyn
 	const harness = createHarness();
 	const rpc = createContext("rpc", [messageEntry(assistant(200, 800))]);
 	await harness.emit("session_start", {}, rpc.ctx);
+	assert.equal(rpc.widgets.length, 0);
+	await harness.command("", rpc.ctx);
 	const rpcContent = rpc.widgets.at(-1)?.[1];
 	assert.ok(Array.isArray(rpcContent));
 	assert.match(rpcContent.join("\n"), /hit 80\.0%/);
@@ -209,6 +251,9 @@ test("uses plain string widgets in RPC mode and remains silent without UI", asyn
 	const json = createContext("json", [messageEntry(assistant(200, 800))]);
 	await harness.emit("session_start", {}, json.ctx);
 	assert.equal(json.widgets.length, 0);
+	await assert.rejects(() => harness.command("", json.ctx), {
+		message: `/${COMMAND_NAME} requires TUI or RPC mode.`,
+	});
 });
 
 test("renders every line within narrow widths and strips unsafe model text", () => {

--- a/.pi/extensions/cache-hit-monitor/index.test.ts
+++ b/.pi/extensions/cache-hit-monitor/index.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import type { AssistantMessage, ModelCostRates } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Model, ModelCostRates } from "@earendil-works/pi-ai";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -13,6 +13,18 @@ import cacheHitMonitor, { COMMAND_NAME, renderCacheMonitor, WIDGET_KEY } from ".
 import { createCacheMonitorView, createCacheSample } from "./metrics.js";
 
 const RATES: ModelCostRates = { input: 10, output: 20, cacheRead: 1, cacheWrite: 20 };
+const MODEL: Model<Api> = {
+	id: "test-model",
+	name: "Test model",
+	api: "openai-responses",
+	provider: "test-provider",
+	baseUrl: "https://example.test",
+	reasoning: false,
+	input: ["text"],
+	cost: RATES,
+	contextWindow: 200_000,
+	maxTokens: 10_000,
+};
 const THEME = {
 	fg: (_role: string, text: string) => text,
 	bold: (text: string) => text,
@@ -102,7 +114,7 @@ function createContext(
 		hasUI: mode === "tui" || mode === "rpc",
 		sessionManager,
 		modelRegistry: {
-			find: () => ({ cost: RATES }),
+			find: () => MODEL,
 		},
 		ui: {
 			notify(message: string, level?: "info" | "warning" | "error") {
@@ -287,7 +299,7 @@ test("renders every line within narrow widths and strips unsafe model text", () 
 			model: "model\n\u202eunsafe",
 		}),
 		0,
-		RATES,
+		MODEL,
 	);
 	assert.ok(sample);
 	const lines = renderCacheMonitor(createCacheMonitorView([sample]), THEME, 32);

--- a/.pi/extensions/cache-hit-monitor/index.test.ts
+++ b/.pi/extensions/cache-hit-monitor/index.test.ts
@@ -151,7 +151,17 @@ test("stays hidden by default, then previews and finalizes detailed metrics when
 	const live = renderWidget(current.widgets.at(-1));
 	assert.match(live?.join("\n") ?? "", /LIVE.*hit 80\.0%/s);
 	const updateCount = current.widgets.length;
-	await harness.emit("message_update", { message: first, assistantMessageEvent: {} }, current.ctx);
+	const outputDelta = assistant(200, 800, 0, {
+		content: [{ type: "text", text: "more generated text" }],
+	});
+	outputDelta.usage.output = 20;
+	outputDelta.usage.totalTokens += 10;
+	outputDelta.usage.cost.output = (20 * RATES.output) / 1_000_000;
+	await harness.emit(
+		"message_update",
+		{ message: outputDelta, assistantMessageEvent: {} },
+		current.ctx,
+	);
 	assert.equal(current.widgets.length, updateCount);
 
 	await harness.emit("message_end", { message: first }, current.ctx);
@@ -199,34 +209,48 @@ test("clears a partial live preview if an agent run ends without a final message
 	);
 });
 
-test("restores active-branch history and resets comparison after compaction", async () => {
+test("restores active-branch history and resets comparison at the compaction boundary", async () => {
 	const first = assistant(200, 800);
+	const second = assistant(400, 600, 0, { timestamp: 2_000 });
 	const harness = createHarness();
-	const current = createContext("tui", [messageEntry(first)]);
+	const current = createContext("tui", [messageEntry(first), messageEntry(second)]);
 	await harness.emit("session_start", {}, current.ctx);
 	await harness.command("", current.ctx);
-	assert.match(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /request #1.*hit 80\.0%/s);
+	assert.match(renderWidget(current.widgets.at(-1))?.join("\n") ?? "", /Reuse vs #1/);
+
+	current.setEntries([
+		messageEntry(first),
+		messageEntry(second),
+		{ type: "compaction", id: "compact", parentId: null } as SessionEntry,
+	]);
+	await harness.emit("session_compact", {}, current.ctx);
+	let rendered = renderWidget(current.widgets.at(-1), 120)?.join("\n") ?? "";
+	assert.match(rendered, /request #2.*hit 60\.0%/s);
+	assert.match(rendered, /no comparable request in the current cache epoch/);
 
 	const afterCompaction = assistant(900, 100, 0, { timestamp: 4_000 });
 	current.setEntries([
 		messageEntry(first),
+		messageEntry(second),
 		{ type: "compaction", id: "compact", parentId: null } as SessionEntry,
 		messageEntry(afterCompaction),
 	]);
 	await harness.emit("session_compact", {}, current.ctx);
-	const rendered = renderWidget(current.widgets.at(-1), 120)?.join("\n") ?? "";
-	assert.match(rendered, /request #2.*hit 10\.0%/s);
+	rendered = renderWidget(current.widgets.at(-1), 120)?.join("\n") ?? "";
+	assert.match(rendered, /request #3.*hit 10\.0%/s);
 	assert.match(rendered, /no comparable request in the current cache epoch/);
-	assert.match(rendered, /Session {2}2 req/);
-	assert.match(rendered, /re-billed 0/);
+	assert.match(rendered, /Session {2}3 req/);
+	assert.match(rendered, /re-billed\s+400/);
 });
 
-test("ignores stale replacement-session events and clears only the owned widget", async () => {
+test("clears replacement UI and ignores stale replacement-session events", async () => {
 	const harness = createHarness();
 	const previous = createContext();
 	const current = createContext();
 	await harness.emit("session_start", {}, previous.ctx);
+	await harness.command("", previous.ctx);
 	await harness.emit("session_start", {}, current.ctx);
+	assert.deepEqual(current.widgets.at(-1), [WIDGET_KEY, undefined, undefined]);
 	await harness.command("", current.ctx);
 	const currentCount = current.widgets.length;
 

--- a/.pi/extensions/cache-hit-monitor/index.ts
+++ b/.pi/extensions/cache-hit-monitor/index.ts
@@ -20,6 +20,7 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 	let activeSession: ExtensionContext["sessionManager"] | undefined;
 	let finalizedSamples: CacheSample[] = [];
 	let summaryRecords: CacheUsageRecord[] = [];
+	const cacheReportingProviders = new Set<string>();
 	let currentEpoch = 0;
 	let streamingSample: CacheSample | undefined;
 	let publishedSignature: string | undefined;
@@ -36,6 +37,12 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 		);
 		finalizedSamples = restored.samples;
 		summaryRecords = restored.summaryRecords;
+		cacheReportingProviders.clear();
+		for (const sample of finalizedSamples) {
+			if (sample.cacheRead > 0 || sample.cacheWrite > 0) {
+				cacheReportingProviders.add(sample.provider);
+			}
+		}
 		currentEpoch = restored.currentEpoch;
 		streamingSample = undefined;
 	};
@@ -45,6 +52,7 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 			message,
 			currentEpoch,
 			resolveCostModel(ctx, message.provider, message.model),
+			cacheReportingProviders.has(message.provider),
 		);
 
 	const clearWidget = (ctx: ExtensionContext): void => {
@@ -120,6 +128,9 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 		if (!ownsSession(ctx) || event.message.role !== "assistant") return;
 		const sample = sampleMessage(event.message, ctx);
 		if (!sample || (streamingSample && cacheSamplesEqual(streamingSample, sample))) return;
+		if (sample.cacheRead > 0 || sample.cacheWrite > 0) {
+			cacheReportingProviders.add(sample.provider);
+		}
 		streamingSample = sample;
 		publish(ctx);
 	});
@@ -128,7 +139,12 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 		if (!ownsSession(ctx) || event.message.role !== "assistant") return;
 		const sample = sampleMessage(event.message, ctx);
 		streamingSample = undefined;
-		if (sample) finalizedSamples.push(sample);
+		if (sample) {
+			if (sample.cacheRead > 0 || sample.cacheWrite > 0) {
+				cacheReportingProviders.add(sample.provider);
+			}
+			finalizedSamples.push(sample);
+		}
 		publish(ctx);
 	});
 
@@ -156,6 +172,7 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 		activeSession = undefined;
 		finalizedSamples = [];
 		summaryRecords = [];
+		cacheReportingProviders.clear();
 		streamingSample = undefined;
 		visible = false;
 	});

--- a/.pi/extensions/cache-hit-monitor/index.ts
+++ b/.pi/extensions/cache-hit-monitor/index.ts
@@ -11,6 +11,7 @@ import {
 	type MonitorLine,
 } from "./metrics.js";
 
+export const COMMAND_NAME = "cache-hit-monitor";
 export const WIDGET_KEY = "cache-hit-monitor";
 
 export default function cacheHitMonitor(pi: ExtensionAPI): void {
@@ -19,6 +20,7 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 	let currentEpoch = 0;
 	let streamingSample: CacheSample | undefined;
 	let publishedSignature: string | undefined;
+	let visible = false;
 
 	const ownsSession = (ctx: ExtensionContext): boolean => ctx.sessionManager === activeSession;
 
@@ -41,8 +43,13 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 			resolveCostRates(ctx, message.provider, message.model),
 		);
 
+	const clearWidget = (ctx: ExtensionContext): void => {
+		if (ctx.hasUI && ownsSession(ctx)) ctx.ui.setWidget(WIDGET_KEY, undefined);
+		publishedSignature = undefined;
+	};
+
 	const publish = (ctx: ExtensionContext): void => {
-		if (!ctx.hasUI || !ownsSession(ctx)) return;
+		if (!visible || !ctx.hasUI || !ownsSession(ctx)) return;
 		const view = createCacheMonitorView(finalizedSamples, streamingSample);
 		const lines = formatMonitorLines(view);
 		const signature = JSON.stringify(lines);
@@ -66,11 +73,31 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 		publishedSignature = signature;
 	};
 
+	pi.registerCommand(COMMAND_NAME, {
+		description: "Show or hide live prompt-cache diagnostics",
+		handler: async (args, ctx) => {
+			if (args.trim()) {
+				throw new Error(`Usage: /${COMMAND_NAME}`);
+			}
+			if (!ctx.hasUI) {
+				throw new Error(`/${COMMAND_NAME} requires TUI or RPC mode.`);
+			}
+			if (!ownsSession(ctx)) {
+				throw new Error(`/${COMMAND_NAME} is unavailable for a stale session.`);
+			}
+
+			visible = !visible;
+			if (visible) publish(ctx);
+			else clearWidget(ctx);
+			ctx.ui.notify(`Cache hit monitor ${visible ? "shown" : "hidden"}.`, "info");
+		},
+	});
+
 	pi.on("session_start", (_event, ctx) => {
 		activeSession = ctx.sessionManager;
+		visible = false;
 		publishedSignature = undefined;
 		restore(ctx);
-		publish(ctx);
 	});
 
 	pi.on("message_start", (event, ctx) => {
@@ -115,11 +142,11 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (!ownsSession(ctx)) return;
-		if (ctx.hasUI) ctx.ui.setWidget(WIDGET_KEY, undefined);
+		clearWidget(ctx);
 		activeSession = undefined;
 		finalizedSamples = [];
 		streamingSample = undefined;
-		publishedSignature = undefined;
+		visible = false;
 	});
 }
 

--- a/.pi/extensions/cache-hit-monitor/index.ts
+++ b/.pi/extensions/cache-hit-monitor/index.ts
@@ -4,6 +4,8 @@ import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works
 import {
 	type CacheMonitorView,
 	type CacheSample,
+	type CacheUsageRecord,
+	cacheSamplesEqual,
 	collectCacheSamples,
 	createCacheMonitorView,
 	createCacheSample,
@@ -17,6 +19,7 @@ export const WIDGET_KEY = "cache-hit-monitor";
 export default function cacheHitMonitor(pi: ExtensionAPI): void {
 	let activeSession: ExtensionContext["sessionManager"] | undefined;
 	let finalizedSamples: CacheSample[] = [];
+	let summaryRecords: CacheUsageRecord[] = [];
 	let currentEpoch = 0;
 	let streamingSample: CacheSample | undefined;
 	let publishedSignature: string | undefined;
@@ -32,6 +35,7 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 			resolveCostRates(ctx, provider, model),
 		);
 		finalizedSamples = restored.samples;
+		summaryRecords = restored.summaryRecords;
 		currentEpoch = restored.currentEpoch;
 		streamingSample = undefined;
 	};
@@ -50,7 +54,10 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 
 	const publish = (ctx: ExtensionContext): void => {
 		if (!visible || !ctx.hasUI || !ownsSession(ctx)) return;
-		const view = createCacheMonitorView(finalizedSamples, streamingSample);
+		const view = createCacheMonitorView(finalizedSamples, streamingSample, {
+			activeEpoch: currentEpoch,
+			summaryRecords,
+		});
 		const lines = formatMonitorLines(view);
 		const signature = JSON.stringify(lines);
 		if (signature === publishedSignature) return;
@@ -94,6 +101,9 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
+		if (visible && activeSession !== ctx.sessionManager && ctx.hasUI) {
+			ctx.ui.setWidget(WIDGET_KEY, undefined);
+		}
 		activeSession = ctx.sessionManager;
 		visible = false;
 		publishedSignature = undefined;
@@ -109,7 +119,7 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 	pi.on("message_update", (event, ctx) => {
 		if (!ownsSession(ctx) || event.message.role !== "assistant") return;
 		const sample = sampleMessage(event.message, ctx);
-		if (!sample) return;
+		if (!sample || (streamingSample && cacheSamplesEqual(streamingSample, sample))) return;
 		streamingSample = sample;
 		publish(ctx);
 	});
@@ -145,6 +155,7 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 		clearWidget(ctx);
 		activeSession = undefined;
 		finalizedSamples = [];
+		summaryRecords = [];
 		streamingSample = undefined;
 		visible = false;
 	});

--- a/.pi/extensions/cache-hit-monitor/index.ts
+++ b/.pi/extensions/cache-hit-monitor/index.ts
@@ -1,0 +1,154 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import {
+	type CacheMonitorView,
+	type CacheSample,
+	collectCacheSamples,
+	createCacheMonitorView,
+	createCacheSample,
+	formatMonitorLines,
+	type MonitorLine,
+} from "./metrics.js";
+
+export const WIDGET_KEY = "cache-hit-monitor";
+
+export default function cacheHitMonitor(pi: ExtensionAPI): void {
+	let activeSession: ExtensionContext["sessionManager"] | undefined;
+	let finalizedSamples: CacheSample[] = [];
+	let currentEpoch = 0;
+	let streamingSample: CacheSample | undefined;
+	let publishedSignature: string | undefined;
+
+	const ownsSession = (ctx: ExtensionContext): boolean => ctx.sessionManager === activeSession;
+
+	const resolveCostRates = (ctx: ExtensionContext, provider: string, model: string) =>
+		ctx.modelRegistry.find(provider, model)?.cost;
+
+	const restore = (ctx: ExtensionContext): void => {
+		const restored = collectCacheSamples(ctx.sessionManager.getBranch(), (provider, model) =>
+			resolveCostRates(ctx, provider, model),
+		);
+		finalizedSamples = restored.samples;
+		currentEpoch = restored.currentEpoch;
+		streamingSample = undefined;
+	};
+
+	const sampleMessage = (message: AssistantMessage, ctx: ExtensionContext): CacheSample | null =>
+		createCacheSample(
+			message,
+			currentEpoch,
+			resolveCostRates(ctx, message.provider, message.model),
+		);
+
+	const publish = (ctx: ExtensionContext): void => {
+		if (!ctx.hasUI || !ownsSession(ctx)) return;
+		const view = createCacheMonitorView(finalizedSamples, streamingSample);
+		const lines = formatMonitorLines(view);
+		const signature = JSON.stringify(lines);
+		if (signature === publishedSignature) return;
+		if (ctx.mode === "tui") {
+			ctx.ui.setWidget(
+				WIDGET_KEY,
+				(_tui, theme) => ({
+					render: (width: number) => renderCacheMonitor(view, theme, width),
+					invalidate: () => {},
+				}),
+				{ placement: "aboveEditor" },
+			);
+		} else {
+			ctx.ui.setWidget(
+				WIDGET_KEY,
+				lines.map(({ text }) => text),
+				{ placement: "aboveEditor" },
+			);
+		}
+		publishedSignature = signature;
+	};
+
+	pi.on("session_start", (_event, ctx) => {
+		activeSession = ctx.sessionManager;
+		publishedSignature = undefined;
+		restore(ctx);
+		publish(ctx);
+	});
+
+	pi.on("message_start", (event, ctx) => {
+		if (!ownsSession(ctx) || event.message.role !== "assistant") return;
+		streamingSample = undefined;
+		publish(ctx);
+	});
+
+	pi.on("message_update", (event, ctx) => {
+		if (!ownsSession(ctx) || event.message.role !== "assistant") return;
+		const sample = sampleMessage(event.message, ctx);
+		if (!sample) return;
+		streamingSample = sample;
+		publish(ctx);
+	});
+
+	pi.on("message_end", (event, ctx) => {
+		if (!ownsSession(ctx) || event.message.role !== "assistant") return;
+		const sample = sampleMessage(event.message, ctx);
+		streamingSample = undefined;
+		if (sample) finalizedSamples.push(sample);
+		publish(ctx);
+	});
+
+	pi.on("agent_end", (_event, ctx) => {
+		if (!ownsSession(ctx) || !streamingSample) return;
+		streamingSample = undefined;
+		publish(ctx);
+	});
+
+	pi.on("session_compact", (_event, ctx) => {
+		if (!ownsSession(ctx)) return;
+		restore(ctx);
+		publish(ctx);
+	});
+
+	pi.on("session_tree", (_event, ctx) => {
+		if (!ownsSession(ctx)) return;
+		restore(ctx);
+		publish(ctx);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		if (!ownsSession(ctx)) return;
+		if (ctx.hasUI) ctx.ui.setWidget(WIDGET_KEY, undefined);
+		activeSession = undefined;
+		finalizedSamples = [];
+		streamingSample = undefined;
+		publishedSignature = undefined;
+	});
+}
+
+export function renderCacheMonitor(view: CacheMonitorView, theme: Theme, width: number): string[] {
+	const renderWidth = Math.max(0, width);
+	if (renderWidth === 0) return formatMonitorLines(view).map(() => "");
+	const divider = theme.fg("borderMuted", "─".repeat(renderWidth));
+	const rendered = formatMonitorLines(view).flatMap((line) => {
+		const styled = styleLine(line, theme);
+		return wrapTextWithAnsi(styled, renderWidth);
+	});
+	return [divider, ...rendered].map((line) =>
+		visibleWidth(line) <= renderWidth ? line : truncateToWidth(line, renderWidth, ""),
+	);
+}
+
+function styleLine(line: MonitorLine, theme: Theme): string {
+	switch (line.role) {
+		case "title":
+			return theme.fg("accent", theme.bold(line.text));
+		case "good":
+			return theme.fg("success", line.text);
+		case "warning":
+			return theme.fg("warning", line.text);
+		case "bad":
+			return theme.fg("error", line.text);
+		case "muted":
+			return theme.fg("muted", line.text);
+		case "dim":
+			return theme.fg("dim", line.text);
+	}
+}

--- a/.pi/extensions/cache-hit-monitor/index.ts
+++ b/.pi/extensions/cache-hit-monitor/index.ts
@@ -27,12 +27,12 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 
 	const ownsSession = (ctx: ExtensionContext): boolean => ctx.sessionManager === activeSession;
 
-	const resolveCostRates = (ctx: ExtensionContext, provider: string, model: string) =>
-		ctx.modelRegistry.find(provider, model)?.cost;
+	const resolveCostModel = (ctx: ExtensionContext, provider: string, model: string) =>
+		ctx.modelRegistry.find(provider, model);
 
 	const restore = (ctx: ExtensionContext): void => {
 		const restored = collectCacheSamples(ctx.sessionManager.getBranch(), (provider, model) =>
-			resolveCostRates(ctx, provider, model),
+			resolveCostModel(ctx, provider, model),
 		);
 		finalizedSamples = restored.samples;
 		summaryRecords = restored.summaryRecords;
@@ -44,7 +44,7 @@ export default function cacheHitMonitor(pi: ExtensionAPI): void {
 		createCacheSample(
 			message,
 			currentEpoch,
-			resolveCostRates(ctx, message.provider, message.model),
+			resolveCostModel(ctx, message.provider, message.model),
 		);
 
 	const clearWidget = (ctx: ExtensionContext): void => {

--- a/.pi/extensions/cache-hit-monitor/metrics.test.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.test.ts
@@ -93,6 +93,49 @@ test("calculates hit rate, downward loss, re-billed tokens, and estimated cost i
 	assert.equal(comparison.requestStartGapMs, 2_500);
 });
 
+test("requires provider cache evidence and prices a confirmed zero-read miss", () => {
+	const completeMiss = assistant(1_000, 0, 0, { timestamp: 2_000 });
+	completeMiss.usage.cost = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	};
+	assert.equal(createCacheSample(completeMiss, 0, MODEL), null);
+
+	const tieredModel: Model<Api> = {
+		...MODEL,
+		cost: {
+			...RATES,
+			tiers: [
+				{
+					inputTokensAbove: 900,
+					input: 20,
+					output: 40,
+					cacheRead: 2,
+					cacheWrite: 30,
+				},
+			],
+		},
+	};
+	const previous = createCacheSample(assistant(200, 800, 0), 0, tieredModel);
+	const current = createCacheSample(completeMiss, 0, tieredModel, true);
+	assert.ok(previous && current);
+	assert.equal(current.hitRatePercent, 0);
+	assert.equal(current.estimatedSavings, 0);
+	assert.ok(Math.abs((current.cacheReadUnitCost ?? 0) - 0.000_002) < 0.000_000_001);
+	assert.ok(
+		Math.abs((compareCacheSamples(previous, current, 1)?.estimatedMissPremium ?? 0) - 0.018) <
+			0.000_000_1,
+	);
+	const rendered = formatMonitorLines(createCacheMonitorView([previous, current]))
+		.map(({ text }) => text)
+		.join("\n");
+	assert.match(rendered, /cache saved ~\$0\.0000/);
+	assert.match(rendered, /miss premium ~\$0\.018/);
+});
+
 test("uses weighted session totals and excludes cross-compaction comparisons", () => {
 	const first = createCacheSample(assistant(200, 800, 0), 0, MODEL);
 	const second = createCacheSample(assistant(400, 600, 100), 0, MODEL);
@@ -108,6 +151,25 @@ test("uses weighted session totals and excludes cross-compaction comparisons", (
 	assert.equal(aggregate.rebilledTokens, 400);
 	assert.ok(Math.abs((aggregate.estimatedMissPremium ?? 0) - 0.0044) < 0.000_000_1);
 	assert.equal(compareCacheSamples(second, afterCompaction, 2), null);
+});
+
+test("marks a session premium unknown when any nonzero miss lacks pricing", () => {
+	const first = createCacheSample(assistant(200, 800, 0), 0, MODEL);
+	const unpricedMessage = assistant(400, 600, 100, { timestamp: 2_000 });
+	unpricedMessage.usage.cost = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	};
+	const unpriced = createCacheSample(unpricedMessage, 0);
+	const priced = createCacheSample(assistant(500, 500, 0, { timestamp: 3_000 }), 0, MODEL);
+	assert.ok(first && unpriced && priced);
+
+	const aggregate = aggregateCacheSamples([first, unpriced, priced]);
+	assert.ok(aggregate.rebilledTokens > 0);
+	assert.equal(aggregate.estimatedMissPremium, null);
 });
 
 test("reconstructs cache epochs and includes summarization usage in session totals", () => {
@@ -149,6 +211,52 @@ test("reconstructs cache epochs and includes summarization usage in session tota
 	assert.equal(view.session.cacheRead, 2_700);
 	assert.ok(Math.abs((view.session.promptCost ?? 0) - 0.0157) < 0.000_000_1);
 	assert.ok(Math.abs((view.session.estimatedSavings ?? 0) - 0.0243) < 0.000_000_1);
+});
+
+test("does not reconstruct all-zero usage as a miss without provider evidence", () => {
+	const supportedProviderMiss = assistant(1_000, 0, 0, {
+		provider: "test-provider",
+		timestamp: 2_000,
+	});
+	const unsupportedProviderUsage = assistant(1_000, 0, 0, {
+		provider: "other-provider",
+		timestamp: 3_000,
+	});
+	const restored = collectCacheSamples(
+		[
+			messageEntry(assistant(200, 800, 0)),
+			messageEntry(supportedProviderMiss),
+			messageEntry(unsupportedProviderUsage),
+		],
+		() => MODEL,
+	);
+
+	assert.deepEqual(
+		restored.samples.map(({ provider, hitRatePercent }) => [provider, hitRatePercent]),
+		[
+			["test-provider", 80],
+			["test-provider", 0],
+		],
+	);
+});
+
+test("renders session totals when a branch contains only summary usage", () => {
+	const summaryMessage = assistant(100, 900, 0);
+	const restored = collectCacheSamples([
+		{
+			type: "branch_summary",
+			id: "branch-summary",
+			parentId: null,
+			usage: summaryMessage.usage,
+		},
+	] as SessionEntry[]);
+	const lines = formatMonitorLines(
+		createCacheMonitorView([], undefined, { summaryRecords: restored.summaryRecords }),
+	).map(({ text }) => text);
+
+	assert.match(lines[0] ?? "", /summary usage only/);
+	assert.match(lines[1] ?? "", /Session {2}1 req.*hit 90\.0%.*read 900.*uncached 100/);
+	assert.match(lines[2] ?? "", /Latest request metrics are unavailable/);
 });
 
 test("suppresses a pre-boundary comparison until the active epoch receives usage", () => {

--- a/.pi/extensions/cache-hit-monitor/metrics.test.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.test.ts
@@ -78,7 +78,7 @@ test("calculates hit rate, downward loss, re-billed tokens, and estimated cost i
 	assert.ok(Math.abs((comparison.estimatedMissPremium ?? 0) - 0.0044) < 0.000_000_1);
 	assert.equal(comparison.promptTokenDelta, 100);
 	assert.equal(comparison.cacheReadDelta, -200);
-	assert.equal(comparison.idleMs, 2_500);
+	assert.equal(comparison.requestStartGapMs, 2_500);
 });
 
 test("uses weighted session totals and excludes cross-compaction comparisons", () => {
@@ -98,25 +98,91 @@ test("uses weighted session totals and excludes cross-compaction comparisons", (
 	assert.equal(compareCacheSamples(second, afterCompaction, 2), null);
 });
 
-test("reconstructs cache epochs from the active branch", () => {
+test("reconstructs cache epochs and includes summarization usage in session totals", () => {
+	const summaryMessage = assistant(100, 900, 0);
 	const entries = [
 		messageEntry(assistant(200, 800, 0)),
-		{ type: "compaction", id: "compact", parentId: null },
+		{
+			type: "compaction",
+			id: "compact",
+			parentId: null,
+			usage: summaryMessage.usage,
+		},
+		{
+			type: "branch_summary",
+			id: "branch-summary",
+			parentId: null,
+			usage: summaryMessage.usage,
+		},
 		messageEntry(assistant(900, 100, 0, { timestamp: 2_000 })),
 	] as SessionEntry[];
 	const restored = collectCacheSamples(entries, () => RATES);
 
-	assert.equal(restored.currentEpoch, 1);
+	assert.equal(restored.currentEpoch, 2);
+	assert.equal(restored.summaryRecords.length, 2);
 	assert.deepEqual(
 		restored.samples.map(({ epoch, hitRatePercent }) => [epoch, hitRatePercent]),
 		[
 			[0, 80],
-			[1, 10],
+			[2, 10],
 		],
 	);
-	const view = createCacheMonitorView(restored.samples);
+	const view = createCacheMonitorView(restored.samples, undefined, {
+		activeEpoch: restored.currentEpoch,
+		summaryRecords: restored.summaryRecords,
+	});
 	assert.equal(view.comparison, null);
-	assert.equal(view.session.requestCount, 2);
+	assert.equal(view.session.requestCount, 4);
+	assert.equal(view.session.input, 1_300);
+	assert.equal(view.session.cacheRead, 2_700);
+	assert.ok(Math.abs((view.session.promptCost ?? 0) - 0.0157) < 0.000_000_1);
+	assert.ok(Math.abs((view.session.estimatedSavings ?? 0) - 0.0243) < 0.000_000_1);
+});
+
+test("suppresses a pre-boundary comparison until the active epoch receives usage", () => {
+	const first = createCacheSample(assistant(200, 800, 0), 0, RATES);
+	const second = createCacheSample(assistant(400, 600, 0, { timestamp: 2_000 }), 0, RATES);
+	assert.ok(first && second);
+
+	assert.ok(createCacheMonitorView([first, second], undefined, { activeEpoch: 0 }).comparison);
+	assert.equal(
+		createCacheMonitorView([first, second], undefined, { activeEpoch: 1 }).comparison,
+		null,
+	);
+});
+
+test("keeps raw model identities for comparison and sanitizes only rendered labels", () => {
+	const sharedPrefix = "x".repeat(70);
+	const previous = createCacheSample(
+		assistant(200, 800, 0, { provider: `${sharedPrefix}a` }),
+		0,
+		RATES,
+	);
+	const current = createCacheSample(
+		assistant(200, 800, 0, { provider: `${sharedPrefix}b`, timestamp: 2_000 }),
+		0,
+		RATES,
+	);
+	assert.ok(previous && current);
+
+	assert.notEqual(previous.provider, current.provider);
+	assert.equal(sanitizeDisplayLabel(previous.provider), sanitizeDisplayLabel(current.provider));
+	assert.equal(compareCacheSamples(previous, current, 1)?.modelChanged, true);
+});
+
+test("uses model rates when reported prompt-cost components are unavailable", () => {
+	const message = assistant(200, 800, 100);
+	message.usage.cost = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	};
+
+	const sample = createCacheSample(message, 0, RATES);
+	assert.ok(sample);
+	assert.ok(Math.abs((sample.promptCost ?? 0) - 0.0048) < 0.000_000_1);
 });
 
 test("formats a detailed live report with both rate and token loss", () => {
@@ -130,7 +196,10 @@ test("formats a detailed live report with both rate and token loss", () => {
 	assert.match(lines[0] ?? "", /Prompt cache · LIVE · request #2/);
 	assert.match(lines[1] ?? "", /hit 54\.5%.*Δ -25\.5 pp.*loss 25\.5 pp.*uncached 36\.4%/);
 	assert.match(lines[2] ?? "", /prompt 1\.1k.*read 600.*write 100.*uncached 400/);
-	assert.match(lines[3] ?? "", /eligible 1k.*re-billed 400 \(40\.0%\).*read Δ -200/);
+	assert.match(
+		lines[3] ?? "",
+		/eligible 1k.*re-billed 400 \(40\.0%\).*read Δ -200.*start gap 2\.5s/,
+	);
 	assert.match(lines[4] ?? "", /cache saved ~\$0\.0054.*miss premium ~\$0\.0044/);
 	assert.match(lines[5] ?? "", /Session {2}2 req.*re-billed 400/);
 	assert.match(lines[6] ?? "", /80\.0% → 54\.5%/);

--- a/.pi/extensions/cache-hit-monitor/metrics.test.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import type { AssistantMessage, ModelCostRates } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Model, ModelCostRates } from "@earendil-works/pi-ai";
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import {
@@ -17,6 +17,18 @@ const RATES: ModelCostRates = {
 	output: 20,
 	cacheRead: 1,
 	cacheWrite: 20,
+};
+const MODEL: Model<Api> = {
+	id: "test-model",
+	name: "Test model",
+	api: "openai-responses",
+	provider: "test-provider",
+	baseUrl: "https://example.test",
+	reasoning: false,
+	input: ["text"],
+	cost: RATES,
+	contextWindow: 200_000,
+	maxTokens: 10_000,
 };
 
 function assistant(
@@ -61,8 +73,8 @@ function messageEntry(message: AssistantMessage): SessionEntry {
 }
 
 test("calculates hit rate, downward loss, re-billed tokens, and estimated cost impact", () => {
-	const previous = createCacheSample(assistant(200, 800, 0), 0, RATES);
-	const current = createCacheSample(assistant(400, 600, 100, { timestamp: 3_500 }), 0, RATES);
+	const previous = createCacheSample(assistant(200, 800, 0), 0, MODEL);
+	const current = createCacheSample(assistant(400, 600, 100, { timestamp: 3_500 }), 0, MODEL);
 	assert.ok(previous);
 	assert.ok(current);
 
@@ -82,9 +94,9 @@ test("calculates hit rate, downward loss, re-billed tokens, and estimated cost i
 });
 
 test("uses weighted session totals and excludes cross-compaction comparisons", () => {
-	const first = createCacheSample(assistant(200, 800, 0), 0, RATES);
-	const second = createCacheSample(assistant(400, 600, 100), 0, RATES);
-	const afterCompaction = createCacheSample(assistant(900, 100, 0), 1, RATES);
+	const first = createCacheSample(assistant(200, 800, 0), 0, MODEL);
+	const second = createCacheSample(assistant(400, 600, 100), 0, MODEL);
+	const afterCompaction = createCacheSample(assistant(900, 100, 0), 1, MODEL);
 	assert.ok(first && second && afterCompaction);
 
 	const aggregate = aggregateCacheSamples([first, second, afterCompaction]);
@@ -116,7 +128,7 @@ test("reconstructs cache epochs and includes summarization usage in session tota
 		},
 		messageEntry(assistant(900, 100, 0, { timestamp: 2_000 })),
 	] as SessionEntry[];
-	const restored = collectCacheSamples(entries, () => RATES);
+	const restored = collectCacheSamples(entries, () => MODEL);
 
 	assert.equal(restored.currentEpoch, 2);
 	assert.equal(restored.summaryRecords.length, 2);
@@ -140,8 +152,8 @@ test("reconstructs cache epochs and includes summarization usage in session tota
 });
 
 test("suppresses a pre-boundary comparison until the active epoch receives usage", () => {
-	const first = createCacheSample(assistant(200, 800, 0), 0, RATES);
-	const second = createCacheSample(assistant(400, 600, 0, { timestamp: 2_000 }), 0, RATES);
+	const first = createCacheSample(assistant(200, 800, 0), 0, MODEL);
+	const second = createCacheSample(assistant(400, 600, 0, { timestamp: 2_000 }), 0, MODEL);
 	assert.ok(first && second);
 
 	assert.ok(createCacheMonitorView([first, second], undefined, { activeEpoch: 0 }).comparison);
@@ -156,12 +168,12 @@ test("keeps raw model identities for comparison and sanitizes only rendered labe
 	const previous = createCacheSample(
 		assistant(200, 800, 0, { provider: `${sharedPrefix}a` }),
 		0,
-		RATES,
+		MODEL,
 	);
 	const current = createCacheSample(
 		assistant(200, 800, 0, { provider: `${sharedPrefix}b`, timestamp: 2_000 }),
 		0,
-		RATES,
+		MODEL,
 	);
 	assert.ok(previous && current);
 
@@ -180,14 +192,66 @@ test("uses model rates when reported prompt-cost components are unavailable", ()
 		total: 0,
 	};
 
-	const sample = createCacheSample(message, 0, RATES);
+	const sample = createCacheSample(message, 0, MODEL);
 	assert.ok(sample);
 	assert.ok(Math.abs((sample.promptCost ?? 0) - 0.0048) < 0.000_000_1);
 });
 
+test("applies Pi pricing tiers and one-hour cache-write rates to fallbacks", () => {
+	const tieredModel: Model<Api> = {
+		...MODEL,
+		cost: {
+			...RATES,
+			tiers: [
+				{
+					inputTokensAbove: 1_000,
+					input: 20,
+					output: 40,
+					cacheRead: 2,
+					cacheWrite: 30,
+				},
+			],
+		},
+	};
+	const previousMessage = assistant(200, 1_000, 0);
+	previousMessage.usage.cost = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	};
+	const currentMessage = assistant(200, 800, 200, { timestamp: 2_000 });
+	currentMessage.usage.cacheWrite1h = 100;
+	currentMessage.usage.cost = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	};
+
+	const previous = createCacheSample(previousMessage, 0, tieredModel);
+	const current = createCacheSample(currentMessage, 0, tieredModel);
+	assert.ok(previous && current);
+	assert.deepEqual(currentMessage.usage.cost, {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	});
+	assert.ok(Math.abs((current.promptCost ?? 0) - 0.0126) < 0.000_000_1);
+	assert.ok(Math.abs((current.estimatedSavings ?? 0) - 0.0144) < 0.000_000_1);
+	assert.ok(
+		Math.abs((compareCacheSamples(previous, current, 1)?.estimatedMissPremium ?? 0) - 0.0102) <
+			0.000_000_1,
+	);
+});
+
 test("formats a detailed live report with both rate and token loss", () => {
-	const previous = createCacheSample(assistant(200, 800, 0), 0, RATES);
-	const current = createCacheSample(assistant(400, 600, 100, { timestamp: 3_500 }), 0, RATES);
+	const previous = createCacheSample(assistant(200, 800, 0), 0, MODEL);
+	const current = createCacheSample(assistant(400, 600, 100, { timestamp: 3_500 }), 0, MODEL);
 	assert.ok(previous && current);
 	const lines = formatMonitorLines(createCacheMonitorView([previous], current)).map(
 		({ text }) => text,

--- a/.pi/extensions/cache-hit-monitor/metrics.test.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import type { AssistantMessage, ModelCostRates } from "@earendil-works/pi-ai";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import {
+	aggregateCacheSamples,
+	collectCacheSamples,
+	compareCacheSamples,
+	createCacheMonitorView,
+	createCacheSample,
+	formatMonitorLines,
+	sanitizeDisplayLabel,
+} from "./metrics.js";
+
+const RATES: ModelCostRates = {
+	input: 10,
+	output: 20,
+	cacheRead: 1,
+	cacheWrite: 20,
+};
+
+function assistant(
+	input: number,
+	cacheRead: number,
+	cacheWrite: number,
+	overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "openai-responses",
+		provider: "test-provider",
+		model: "test-model",
+		content: [],
+		stopReason: "stop",
+		timestamp: 1_000,
+		usage: {
+			input,
+			output: 10,
+			cacheRead,
+			cacheWrite,
+			totalTokens: input + cacheRead + cacheWrite + 10,
+			cost: {
+				input: (input * RATES.input) / 1_000_000,
+				output: (10 * RATES.output) / 1_000_000,
+				cacheRead: (cacheRead * RATES.cacheRead) / 1_000_000,
+				cacheWrite: (cacheWrite * RATES.cacheWrite) / 1_000_000,
+				total:
+					(input * RATES.input +
+						10 * RATES.output +
+						cacheRead * RATES.cacheRead +
+						cacheWrite * RATES.cacheWrite) /
+					1_000_000,
+			},
+		},
+		...overrides,
+	};
+}
+
+function messageEntry(message: AssistantMessage): SessionEntry {
+	return { type: "message", id: crypto.randomUUID(), parentId: null, message } as SessionEntry;
+}
+
+test("calculates hit rate, downward loss, re-billed tokens, and estimated cost impact", () => {
+	const previous = createCacheSample(assistant(200, 800, 0), 0, RATES);
+	const current = createCacheSample(assistant(400, 600, 100, { timestamp: 3_500 }), 0, RATES);
+	assert.ok(previous);
+	assert.ok(current);
+
+	const comparison = compareCacheSamples(previous, current, 1);
+	assert.ok(comparison);
+	assert.equal(previous.hitRatePercent, 80);
+	assert.ok(Math.abs(current.hitRatePercent - 54.545_454) < 0.000_01);
+	assert.ok(Math.abs(comparison.hitRateDeltaPercent + 25.454_545) < 0.000_01);
+	assert.ok(Math.abs(comparison.hitRateLossPercent - 25.454_545) < 0.000_01);
+	assert.equal(comparison.reusablePrefixTokens, 1_000);
+	assert.equal(comparison.rebilledTokens, 400);
+	assert.equal(comparison.rebilledPercent, 40);
+	assert.ok(Math.abs((comparison.estimatedMissPremium ?? 0) - 0.0044) < 0.000_000_1);
+	assert.equal(comparison.promptTokenDelta, 100);
+	assert.equal(comparison.cacheReadDelta, -200);
+	assert.equal(comparison.idleMs, 2_500);
+});
+
+test("uses weighted session totals and excludes cross-compaction comparisons", () => {
+	const first = createCacheSample(assistant(200, 800, 0), 0, RATES);
+	const second = createCacheSample(assistant(400, 600, 100), 0, RATES);
+	const afterCompaction = createCacheSample(assistant(900, 100, 0), 1, RATES);
+	assert.ok(first && second && afterCompaction);
+
+	const aggregate = aggregateCacheSamples([first, second, afterCompaction]);
+	assert.equal(aggregate.requestCount, 3);
+	assert.equal(aggregate.input, 1_500);
+	assert.equal(aggregate.cacheRead, 1_500);
+	assert.equal(aggregate.cacheWrite, 100);
+	assert.ok(Math.abs((aggregate.hitRatePercent ?? 0) - (1_500 / 3_100) * 100) < 0.000_01);
+	assert.equal(aggregate.rebilledTokens, 400);
+	assert.ok(Math.abs((aggregate.estimatedMissPremium ?? 0) - 0.0044) < 0.000_000_1);
+	assert.equal(compareCacheSamples(second, afterCompaction, 2), null);
+});
+
+test("reconstructs cache epochs from the active branch", () => {
+	const entries = [
+		messageEntry(assistant(200, 800, 0)),
+		{ type: "compaction", id: "compact", parentId: null },
+		messageEntry(assistant(900, 100, 0, { timestamp: 2_000 })),
+	] as SessionEntry[];
+	const restored = collectCacheSamples(entries, () => RATES);
+
+	assert.equal(restored.currentEpoch, 1);
+	assert.deepEqual(
+		restored.samples.map(({ epoch, hitRatePercent }) => [epoch, hitRatePercent]),
+		[
+			[0, 80],
+			[1, 10],
+		],
+	);
+	const view = createCacheMonitorView(restored.samples);
+	assert.equal(view.comparison, null);
+	assert.equal(view.session.requestCount, 2);
+});
+
+test("formats a detailed live report with both rate and token loss", () => {
+	const previous = createCacheSample(assistant(200, 800, 0), 0, RATES);
+	const current = createCacheSample(assistant(400, 600, 100, { timestamp: 3_500 }), 0, RATES);
+	assert.ok(previous && current);
+	const lines = formatMonitorLines(createCacheMonitorView([previous], current)).map(
+		({ text }) => text,
+	);
+
+	assert.match(lines[0] ?? "", /Prompt cache · LIVE · request #2/);
+	assert.match(lines[1] ?? "", /hit 54\.5%.*Δ -25\.5 pp.*loss 25\.5 pp.*uncached 36\.4%/);
+	assert.match(lines[2] ?? "", /prompt 1\.1k.*read 600.*write 100.*uncached 400/);
+	assert.match(lines[3] ?? "", /eligible 1k.*re-billed 400 \(40\.0%\).*read Δ -200/);
+	assert.match(lines[4] ?? "", /cache saved ~\$0\.0054.*miss premium ~\$0\.0044/);
+	assert.match(lines[5] ?? "", /Session {2}2 req.*re-billed 400/);
+	assert.match(lines[6] ?? "", /80\.0% → 54\.5%/);
+	assert.match(lines[7] ?? "", /re-billed=max/);
+});
+
+test("sanitizes terminal controls and bounds provider/model labels", () => {
+	assert.equal(sanitizeDisplayLabel("\u001b]8;;bad\u0007provider\n\u202emodel"), "provider model");
+	assert.equal(sanitizeDisplayLabel("\u001b\u0007"), "unknown");
+	assert.equal(sanitizeDisplayLabel("x".repeat(80)), `${"x".repeat(60)}…`);
+});

--- a/.pi/extensions/cache-hit-monitor/metrics.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.ts
@@ -94,6 +94,7 @@ export function collectCacheSamples(
 ): CollectedCacheSamples {
 	const samples: CacheSample[] = [];
 	const summaryRecords: CacheUsageRecord[] = [];
+	const cacheReportingProviders = new Set<string>();
 	let currentEpoch = 0;
 	for (const entry of entries) {
 		if (entry.type === "compaction" || entry.type === "branch_summary") {
@@ -107,8 +108,14 @@ export function collectCacheSamples(
 			entry.message,
 			currentEpoch,
 			resolveCostModel(entry.message.provider, entry.message.model),
+			cacheReportingProviders.has(entry.message.provider),
 		);
-		if (sample) samples.push(sample);
+		if (sample) {
+			if (sample.cacheRead > 0 || sample.cacheWrite > 0) {
+				cacheReportingProviders.add(sample.provider);
+			}
+			samples.push(sample);
+		}
 	}
 	return { samples, summaryRecords, currentEpoch };
 }
@@ -117,8 +124,9 @@ export function createCacheSample(
 	message: AssistantMessage,
 	epoch: number,
 	costModel?: Model<Api>,
+	cacheAccountingKnown = false,
 ): CacheSample | null {
-	const calculation = calculateCacheUsage(message.usage, costModel);
+	const calculation = calculateCacheUsage(message.usage, costModel, cacheAccountingKnown);
 	if (!calculation) return null;
 
 	return {
@@ -219,7 +227,8 @@ export function aggregateCacheSamples(
 	let savingsKnown = true;
 	let rebilledTokens = 0;
 	let estimatedMissPremium = 0;
-	let missPremiumKnown = false;
+	let hasRebilledTokens = false;
+	let missPremiumComplete = true;
 	let bestHitRatePercent: number | null = null;
 	let worstHitRatePercent: number | null = null;
 
@@ -254,10 +263,10 @@ export function aggregateCacheSamples(
 		const comparison = compareCacheSamples(previous, sample, previousIndex + 1);
 		if (!comparison) continue;
 		rebilledTokens += comparison.rebilledTokens;
-		if (comparison.estimatedMissPremium !== null) {
-			estimatedMissPremium += comparison.estimatedMissPremium;
-			missPremiumKnown = true;
-		}
+		if (comparison.rebilledTokens <= 0) continue;
+		hasRebilledTokens = true;
+		if (comparison.estimatedMissPremium === null) missPremiumComplete = false;
+		else estimatedMissPremium += comparison.estimatedMissPremium;
 	}
 
 	const requestCount = samples.length + additionalRecords.length;
@@ -272,7 +281,7 @@ export function aggregateCacheSamples(
 		promptCost: promptCostKnown ? promptCost : null,
 		estimatedSavings: requestCount > 0 && savingsKnown ? estimatedSavings : null,
 		rebilledTokens,
-		estimatedMissPremium: missPremiumKnown ? estimatedMissPremium : null,
+		estimatedMissPremium: hasRebilledTokens && missPremiumComplete ? estimatedMissPremium : null,
 		bestHitRatePercent,
 		worstHitRatePercent,
 	};
@@ -280,11 +289,21 @@ export function aggregateCacheSamples(
 
 export function formatMonitorLines(view: CacheMonitorView): MonitorLine[] {
 	if (!view.latest) {
+		if (view.session.requestCount > 0) {
+			return [
+				{ role: "title", text: "Prompt cache · summary usage only" },
+				formatSessionLine(view.session),
+				{
+					role: "dim",
+					text: "Latest request metrics are unavailable on this branch.",
+				},
+			];
+		}
 		return [
-			{ role: "title", text: "Prompt cache · waiting for provider usage" },
+			{ role: "title", text: "Prompt cache · waiting for provider cache usage" },
 			{
 				role: "dim",
-				text: "Hit = cacheRead / (input + cacheRead + cacheWrite). Live updates begin when usage is reported.",
+				text: "Hit = cacheRead / (input + cacheRead + cacheWrite). All-zero cache fields remain unknown until this provider reports cache activity.",
 			},
 		];
 	}
@@ -347,19 +366,7 @@ export function formatMonitorLines(view: CacheMonitorView): MonitorLine[] {
 				`miss premium ~${formatNullableMoney(comparison?.estimatedMissPremium ?? null)}`,
 			].join("  ·  "),
 		},
-		{
-			role: "muted",
-			text: [
-				`Session  ${session.requestCount} req`,
-				`hit ${formatNullablePercent(session.hitRatePercent)}`,
-				`read ${formatTokens(session.cacheRead)}`,
-				`uncached ${formatTokens(session.input)}`,
-				`write ${formatTokens(session.cacheWrite)}`,
-				`cost ${formatNullableMoney(session.promptCost)}`,
-				`saved ~${formatNullableMoney(session.estimatedSavings)}`,
-				`re-billed ${formatTokens(session.rebilledTokens)} (~${formatNullableMoney(session.estimatedMissPremium)})`,
-			].join("  ·  "),
-		},
+		formatSessionLine(session),
 		{
 			role: "dim",
 			text: `Trend old→new  ${view.trend.map(formatPercent).join(" → ")}`,
@@ -370,6 +377,22 @@ export function formatMonitorLines(view: CacheMonitorView): MonitorLine[] {
 		},
 	);
 	return lines;
+}
+
+function formatSessionLine(session: CacheAggregate): MonitorLine {
+	return {
+		role: "muted",
+		text: [
+			`Session  ${session.requestCount} req`,
+			`hit ${formatNullablePercent(session.hitRatePercent)}`,
+			`read ${formatTokens(session.cacheRead)}`,
+			`uncached ${formatTokens(session.input)}`,
+			`write ${formatTokens(session.cacheWrite)}`,
+			`cost ${formatNullableMoney(session.promptCost)}`,
+			`saved ~${formatNullableMoney(session.estimatedSavings)}`,
+			`re-billed ${formatTokens(session.rebilledTokens)} (~${formatNullableMoney(session.estimatedMissPremium)})`,
+		].join("  ·  "),
+	};
 }
 
 export function sanitizeDisplayLabel(value: string): string {
@@ -391,12 +414,18 @@ interface CacheUsageCalculation {
 	paidPromptUnitCost: number | null;
 }
 
-function calculateCacheUsage(usage: Usage, costModel?: Model<Api>): CacheUsageCalculation | null {
+function calculateCacheUsage(
+	usage: Usage,
+	costModel?: Model<Api>,
+	cacheAccountingKnown = false,
+): CacheUsageCalculation | null {
 	const input = finiteNumber(usage.input);
 	const cacheRead = finiteNumber(usage.cacheRead);
 	const cacheWrite = finiteNumber(usage.cacheWrite);
 	const promptTokens = input + cacheRead + cacheWrite;
-	if (promptTokens <= 0) return null;
+	if (promptTokens <= 0 || (cacheRead === 0 && cacheWrite === 0 && !cacheAccountingKnown)) {
+		return null;
+	}
 
 	const fallbackCosts = costModel
 		? calculateCost(costModel, normalizedUsageCopy(usage, input, cacheRead, cacheWrite))
@@ -413,7 +442,10 @@ function calculateCacheUsage(usage: Usage, costModel?: Model<Api>): CacheUsageCa
 		fallbackCosts?.cacheWrite,
 	);
 	const inputUnitCost = unitCost(input, inputCost);
-	const cacheReadUnitCost = unitCost(cacheRead, cacheReadCost);
+	const cacheReadUnitCost =
+		cacheRead > 0
+			? unitCost(cacheRead, cacheReadCost)
+			: effectiveCacheReadUnitCost(costModel, usage, input, cacheWrite);
 	const paidPromptUnitCost = unitCost(
 		input + cacheWrite,
 		sumKnownCosts([inputCost, cacheWriteCost]),
@@ -429,14 +461,32 @@ function calculateCacheUsage(usage: Usage, costModel?: Model<Api>): CacheUsageCa
 			uncachedRatePercent: (input / promptTokens) * 100,
 			promptCost: sumKnownCosts([inputCost, cacheReadCost, cacheWriteCost]),
 			estimatedSavings:
-				inputUnitCost !== null && cacheReadUnitCost !== null
-					? cacheRead * Math.max(0, inputUnitCost - cacheReadUnitCost)
-					: null,
+				cacheRead === 0
+					? 0
+					: inputUnitCost !== null && cacheReadUnitCost !== null
+						? cacheRead * Math.max(0, inputUnitCost - cacheReadUnitCost)
+						: null,
 		},
 		inputUnitCost,
 		cacheReadUnitCost,
 		paidPromptUnitCost,
 	};
+}
+
+function effectiveCacheReadUnitCost(
+	costModel: Model<Api> | undefined,
+	usage: Usage,
+	input: number,
+	cacheWrite: number,
+): number | null {
+	if (!costModel) return null;
+	const probeTokens = Math.min(1, input + cacheWrite);
+	if (probeTokens <= 0) return null;
+	const probeInput = Math.max(0, input - probeTokens);
+	const shiftedFromInput = input - probeInput;
+	const probeCacheWrite = Math.max(0, cacheWrite - (probeTokens - shiftedFromInput));
+	const probeUsage = normalizedUsageCopy(usage, probeInput, probeTokens, probeCacheWrite);
+	return calculateCost(costModel, probeUsage).cacheRead / probeTokens;
 }
 
 function normalizedUsageCopy(

--- a/.pi/extensions/cache-hit-monitor/metrics.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.ts
@@ -1,4 +1,10 @@
-import type { AssistantMessage, ModelCostRates, Usage } from "@earendil-works/pi-ai";
+import {
+	type Api,
+	type AssistantMessage,
+	calculateCost,
+	type Model,
+	type Usage,
+} from "@earendil-works/pi-ai";
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 import { stripTerminalSequences } from "@earendil-works/pi-tui";
 
@@ -80,19 +86,19 @@ export interface CacheMonitorViewOptions {
 	summaryRecords?: readonly CacheUsageRecord[];
 }
 
-type CostRateResolver = (provider: string, model: string) => ModelCostRates | undefined;
+type CostModelResolver = (provider: string, model: string) => Model<Api> | undefined;
 
 export function collectCacheSamples(
 	entries: readonly SessionEntry[],
-	resolveCostRates: CostRateResolver = () => undefined,
+	resolveCostModel: CostModelResolver = () => undefined,
 ): CollectedCacheSamples {
 	const samples: CacheSample[] = [];
 	const summaryRecords: CacheUsageRecord[] = [];
 	let currentEpoch = 0;
 	for (const entry of entries) {
 		if (entry.type === "compaction" || entry.type === "branch_summary") {
-			const summaryRecord = entry.usage ? createCacheUsageRecord(entry.usage) : null;
-			if (summaryRecord) summaryRecords.push(summaryRecord);
+			const summaryCalculation = entry.usage ? calculateCacheUsage(entry.usage) : null;
+			if (summaryCalculation) summaryRecords.push(summaryCalculation.record);
 			currentEpoch += 1;
 			continue;
 		}
@@ -100,7 +106,7 @@ export function collectCacheSamples(
 		const sample = createCacheSample(
 			entry.message,
 			currentEpoch,
-			resolveCostRates(entry.message.provider, entry.message.model),
+			resolveCostModel(entry.message.provider, entry.message.model),
 		);
 		if (sample) samples.push(sample);
 	}
@@ -110,50 +116,20 @@ export function collectCacheSamples(
 export function createCacheSample(
 	message: AssistantMessage,
 	epoch: number,
-	costRates?: ModelCostRates,
+	costModel?: Model<Api>,
 ): CacheSample | null {
-	const usageRecord = createCacheUsageRecord(message.usage, costRates);
-	if (!usageRecord) return null;
-
-	const inputUnitCost = unitCost(
-		usageRecord.input,
-		finiteNumber(message.usage.cost?.input),
-		costRates?.input,
-	);
-	const cacheReadUnitCost = unitCost(
-		usageRecord.cacheRead,
-		finiteNumber(message.usage.cost?.cacheRead),
-		costRates?.cacheRead,
-	);
-	const paidPromptTokens = usageRecord.input + usageRecord.cacheWrite;
-	const paidPromptCost = sumKnownCosts([
-		componentCost(usageRecord.input, finiteNumber(message.usage.cost?.input), costRates?.input),
-		componentCost(
-			usageRecord.cacheWrite,
-			finiteNumber(message.usage.cost?.cacheWrite),
-			costRates?.cacheWrite,
-		),
-	]);
-	const paidPromptUnitCost =
-		paidPromptCost === null
-			? null
-			: unitCost(
-					paidPromptTokens,
-					paidPromptCost,
-					costRates
-						? weightedPaidRate(usageRecord.input, usageRecord.cacheWrite, costRates)
-						: undefined,
-				);
+	const calculation = calculateCacheUsage(message.usage, costModel);
+	if (!calculation) return null;
 
 	return {
-		...usageRecord,
+		...calculation.record,
 		epoch,
 		timestamp: finiteNumber(message.timestamp),
 		provider: message.provider,
 		model: message.model,
-		inputUnitCost,
-		cacheReadUnitCost,
-		paidPromptUnitCost,
+		inputUnitCost: calculation.inputUnitCost,
+		cacheReadUnitCost: calculation.cacheReadUnitCost,
+		paidPromptUnitCost: calculation.paidPromptUnitCost,
 	};
 }
 
@@ -408,35 +384,79 @@ export function sanitizeDisplayLabel(value: string): string {
 		: stripped;
 }
 
-function createCacheUsageRecord(usage: Usage, costRates?: ModelCostRates): CacheUsageRecord | null {
+interface CacheUsageCalculation {
+	record: CacheUsageRecord;
+	inputUnitCost: number | null;
+	cacheReadUnitCost: number | null;
+	paidPromptUnitCost: number | null;
+}
+
+function calculateCacheUsage(usage: Usage, costModel?: Model<Api>): CacheUsageCalculation | null {
 	const input = finiteNumber(usage.input);
 	const cacheRead = finiteNumber(usage.cacheRead);
 	const cacheWrite = finiteNumber(usage.cacheWrite);
 	const promptTokens = input + cacheRead + cacheWrite;
 	if (promptTokens <= 0) return null;
 
-	const inputCost = finiteNumber(usage.cost?.input);
-	const cacheReadCost = finiteNumber(usage.cost?.cacheRead);
-	const cacheWriteCost = finiteNumber(usage.cost?.cacheWrite);
-	const inputUnitCost = unitCost(input, inputCost, costRates?.input);
-	const cacheReadUnitCost = unitCost(cacheRead, cacheReadCost, costRates?.cacheRead);
+	const fallbackCosts = costModel
+		? calculateCost(costModel, normalizedUsageCopy(usage, input, cacheRead, cacheWrite))
+		: undefined;
+	const inputCost = componentCost(input, finiteNumber(usage.cost?.input), fallbackCosts?.input);
+	const cacheReadCost = componentCost(
+		cacheRead,
+		finiteNumber(usage.cost?.cacheRead),
+		fallbackCosts?.cacheRead,
+	);
+	const cacheWriteCost = componentCost(
+		cacheWrite,
+		finiteNumber(usage.cost?.cacheWrite),
+		fallbackCosts?.cacheWrite,
+	);
+	const inputUnitCost = unitCost(input, inputCost);
+	const cacheReadUnitCost = unitCost(cacheRead, cacheReadCost);
+	const paidPromptUnitCost = unitCost(
+		input + cacheWrite,
+		sumKnownCosts([inputCost, cacheWriteCost]),
+	);
 
 	return {
+		record: {
+			input,
+			cacheRead,
+			cacheWrite,
+			promptTokens,
+			hitRatePercent: (cacheRead / promptTokens) * 100,
+			uncachedRatePercent: (input / promptTokens) * 100,
+			promptCost: sumKnownCosts([inputCost, cacheReadCost, cacheWriteCost]),
+			estimatedSavings:
+				inputUnitCost !== null && cacheReadUnitCost !== null
+					? cacheRead * Math.max(0, inputUnitCost - cacheReadUnitCost)
+					: null,
+		},
+		inputUnitCost,
+		cacheReadUnitCost,
+		paidPromptUnitCost,
+	};
+}
+
+function normalizedUsageCopy(
+	usage: Usage,
+	input: number,
+	cacheRead: number,
+	cacheWrite: number,
+): Usage {
+	return {
+		...usage,
 		input,
+		output: finiteNumber(usage.output),
 		cacheRead,
 		cacheWrite,
-		promptTokens,
-		hitRatePercent: (cacheRead / promptTokens) * 100,
-		uncachedRatePercent: (input / promptTokens) * 100,
-		promptCost: sumKnownCosts([
-			componentCost(input, inputCost, costRates?.input),
-			componentCost(cacheRead, cacheReadCost, costRates?.cacheRead),
-			componentCost(cacheWrite, cacheWriteCost, costRates?.cacheWrite),
-		]),
-		estimatedSavings:
-			inputUnitCost !== null && cacheReadUnitCost !== null
-				? cacheRead * Math.max(0, inputUnitCost - cacheReadUnitCost)
-				: null,
+		cacheWrite1h:
+			usage.cacheWrite1h === undefined
+				? undefined
+				: Math.min(cacheWrite, finiteNumber(usage.cacheWrite1h)),
+		totalTokens: finiteNumber(usage.totalTokens),
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 }
 
@@ -454,16 +474,10 @@ function findPreviousComparableIndex(
 	return -1;
 }
 
-function weightedPaidRate(input: number, cacheWrite: number, rates: ModelCostRates): number {
-	const tokens = input + cacheWrite;
-	if (tokens <= 0) return rates.input;
-	return (input * rates.input + cacheWrite * rates.cacheWrite) / tokens;
-}
-
-function componentCost(tokens: number, reportedCost: number, fallbackRate?: number): number | null {
+function componentCost(tokens: number, reportedCost: number, fallbackCost?: number): number | null {
 	if (tokens <= 0) return 0;
 	if (reportedCost > 0) return reportedCost;
-	return fallbackRate === undefined ? null : (tokens * fallbackRate) / 1_000_000;
+	return fallbackCost === undefined ? null : fallbackCost;
 }
 
 function sumKnownCosts(costs: readonly (number | null)[]): number | null {
@@ -472,9 +486,8 @@ function sumKnownCosts(costs: readonly (number | null)[]): number | null {
 		: null;
 }
 
-function unitCost(tokens: number, cost: number, fallbackRate?: number): number | null {
-	if (tokens > 0 && cost > 0) return cost / tokens;
-	return fallbackRate === undefined ? null : fallbackRate / 1_000_000;
+function unitCost(tokens: number, cost: number | null): number | null {
+	return tokens > 0 && cost !== null ? cost / tokens : null;
 }
 
 function formatPercent(value: number): string {

--- a/.pi/extensions/cache-hit-monitor/metrics.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.ts
@@ -1,0 +1,440 @@
+import type { AssistantMessage, ModelCostRates } from "@earendil-works/pi-ai";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences } from "@earendil-works/pi-tui";
+
+const TREND_SAMPLE_COUNT = 8;
+const MAX_LABEL_LENGTH = 60;
+
+export interface CacheSample {
+	epoch: number;
+	timestamp: number;
+	provider: string;
+	model: string;
+	input: number;
+	cacheRead: number;
+	cacheWrite: number;
+	promptTokens: number;
+	hitRatePercent: number;
+	uncachedRatePercent: number;
+	promptCost: number;
+	estimatedSavings: number | null;
+	inputUnitCost: number | null;
+	cacheReadUnitCost: number | null;
+	paidPromptUnitCost: number | null;
+}
+
+export interface CacheComparison {
+	previousRequestNumber: number;
+	hitRateDeltaPercent: number;
+	hitRateLossPercent: number;
+	promptTokenDelta: number;
+	cacheReadDelta: number;
+	reusablePrefixTokens: number;
+	rebilledTokens: number;
+	rebilledPercent: number | null;
+	estimatedMissPremium: number | null;
+	modelChanged: boolean;
+	idleMs: number;
+}
+
+export interface CacheAggregate {
+	requestCount: number;
+	input: number;
+	cacheRead: number;
+	cacheWrite: number;
+	promptTokens: number;
+	hitRatePercent: number | null;
+	promptCost: number;
+	estimatedSavings: number | null;
+	rebilledTokens: number;
+	estimatedMissPremium: number | null;
+	bestHitRatePercent: number | null;
+	worstHitRatePercent: number | null;
+}
+
+export interface CacheMonitorView {
+	streaming: boolean;
+	requestNumber: number;
+	latest: CacheSample | null;
+	comparison: CacheComparison | null;
+	session: CacheAggregate;
+	trend: number[];
+}
+
+export interface MonitorLine {
+	role: "title" | "good" | "warning" | "bad" | "muted" | "dim";
+	text: string;
+}
+
+export interface CollectedCacheSamples {
+	samples: CacheSample[];
+	currentEpoch: number;
+}
+
+type CostRateResolver = (provider: string, model: string) => ModelCostRates | undefined;
+
+export function collectCacheSamples(
+	entries: readonly SessionEntry[],
+	resolveCostRates: CostRateResolver = () => undefined,
+): CollectedCacheSamples {
+	const samples: CacheSample[] = [];
+	let currentEpoch = 0;
+	for (const entry of entries) {
+		if (entry.type === "compaction" || entry.type === "branch_summary") {
+			currentEpoch += 1;
+			continue;
+		}
+		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+		const sample = createCacheSample(
+			entry.message,
+			currentEpoch,
+			resolveCostRates(entry.message.provider, entry.message.model),
+		);
+		if (sample) samples.push(sample);
+	}
+	return { samples, currentEpoch };
+}
+
+export function createCacheSample(
+	message: AssistantMessage,
+	epoch: number,
+	costRates?: ModelCostRates,
+): CacheSample | null {
+	const input = finiteNumber(message.usage.input);
+	const cacheRead = finiteNumber(message.usage.cacheRead);
+	const cacheWrite = finiteNumber(message.usage.cacheWrite);
+	const promptTokens = input + cacheRead + cacheWrite;
+	if (promptTokens <= 0) return null;
+
+	const inputCost = finiteNumber(message.usage.cost?.input);
+	const cacheReadCost = finiteNumber(message.usage.cost?.cacheRead);
+	const cacheWriteCost = finiteNumber(message.usage.cost?.cacheWrite);
+	const inputUnitCost = unitCost(input, inputCost, costRates?.input);
+	const cacheReadUnitCost = unitCost(cacheRead, cacheReadCost, costRates?.cacheRead);
+	const paidPromptTokens = input + cacheWrite;
+	const paidPromptCost = inputCost + cacheWriteCost;
+	const paidPromptUnitCost = unitCost(
+		paidPromptTokens,
+		paidPromptCost,
+		costRates ? weightedPaidRate(input, cacheWrite, costRates) : undefined,
+	);
+	const pricingKnown = costRates !== undefined || inputCost + cacheReadCost + cacheWriteCost > 0;
+
+	return {
+		epoch,
+		timestamp: finiteNumber(message.timestamp),
+		provider: sanitizeDisplayLabel(message.provider),
+		model: sanitizeDisplayLabel(message.model),
+		input,
+		cacheRead,
+		cacheWrite,
+		promptTokens,
+		hitRatePercent: (cacheRead / promptTokens) * 100,
+		uncachedRatePercent: (input / promptTokens) * 100,
+		promptCost: inputCost + cacheReadCost + cacheWriteCost,
+		estimatedSavings:
+			pricingKnown && inputUnitCost !== null && cacheReadUnitCost !== null
+				? cacheRead * Math.max(0, inputUnitCost - cacheReadUnitCost)
+				: null,
+		inputUnitCost,
+		cacheReadUnitCost,
+		paidPromptUnitCost,
+	};
+}
+
+export function createCacheMonitorView(
+	finalizedSamples: readonly CacheSample[],
+	streamingSample?: CacheSample,
+): CacheMonitorView {
+	const samples = streamingSample ? [...finalizedSamples, streamingSample] : [...finalizedSamples];
+	const latest = samples.at(-1) ?? null;
+	const previousIndex = latest
+		? findPreviousComparableIndex(samples, samples.length - 1, latest.epoch)
+		: -1;
+	const previous = previousIndex >= 0 ? samples[previousIndex] : undefined;
+
+	return {
+		streaming: streamingSample !== undefined,
+		requestNumber: samples.length,
+		latest,
+		comparison:
+			latest && previous ? compareCacheSamples(previous, latest, previousIndex + 1) : null,
+		session: aggregateCacheSamples(samples),
+		trend: samples.slice(-TREND_SAMPLE_COUNT).map((sample) => sample.hitRatePercent),
+	};
+}
+
+export function compareCacheSamples(
+	previous: CacheSample,
+	current: CacheSample,
+	previousRequestNumber: number,
+): CacheComparison | null {
+	if (previous.epoch !== current.epoch) return null;
+	const reusablePrefixTokens = Math.min(previous.promptTokens, current.promptTokens);
+	const reusedTokens = Math.min(current.cacheRead, reusablePrefixTokens);
+	const rebilledTokens = Math.max(0, reusablePrefixTokens - reusedTokens);
+	const hitRateDeltaPercent = current.hitRatePercent - previous.hitRatePercent;
+	const unitPremium =
+		current.paidPromptUnitCost !== null && current.cacheReadUnitCost !== null
+			? Math.max(0, current.paidPromptUnitCost - current.cacheReadUnitCost)
+			: null;
+
+	return {
+		previousRequestNumber,
+		hitRateDeltaPercent,
+		hitRateLossPercent: Math.max(0, -hitRateDeltaPercent),
+		promptTokenDelta: current.promptTokens - previous.promptTokens,
+		cacheReadDelta: current.cacheRead - previous.cacheRead,
+		reusablePrefixTokens,
+		rebilledTokens,
+		rebilledPercent:
+			reusablePrefixTokens > 0 ? (rebilledTokens / reusablePrefixTokens) * 100 : null,
+		estimatedMissPremium: unitPremium === null ? null : rebilledTokens * unitPremium,
+		modelChanged: previous.provider !== current.provider || previous.model !== current.model,
+		idleMs: Math.max(0, current.timestamp - previous.timestamp),
+	};
+}
+
+export function aggregateCacheSamples(samples: readonly CacheSample[]): CacheAggregate {
+	let input = 0;
+	let cacheRead = 0;
+	let cacheWrite = 0;
+	let promptCost = 0;
+	let estimatedSavings = 0;
+	let savingsKnown = false;
+	let rebilledTokens = 0;
+	let estimatedMissPremium = 0;
+	let missPremiumKnown = false;
+	let bestHitRatePercent: number | null = null;
+	let worstHitRatePercent: number | null = null;
+
+	for (let index = 0; index < samples.length; index += 1) {
+		const sample = samples[index];
+		if (!sample) continue;
+		input += sample.input;
+		cacheRead += sample.cacheRead;
+		cacheWrite += sample.cacheWrite;
+		promptCost += sample.promptCost;
+		if (sample.estimatedSavings !== null) {
+			estimatedSavings += sample.estimatedSavings;
+			savingsKnown = true;
+		}
+		bestHitRatePercent = Math.max(
+			bestHitRatePercent ?? sample.hitRatePercent,
+			sample.hitRatePercent,
+		);
+		worstHitRatePercent = Math.min(
+			worstHitRatePercent ?? sample.hitRatePercent,
+			sample.hitRatePercent,
+		);
+
+		const previousIndex = findPreviousComparableIndex(samples, index, sample.epoch);
+		if (previousIndex < 0) continue;
+		const previous = samples[previousIndex];
+		if (!previous) continue;
+		const comparison = compareCacheSamples(previous, sample, previousIndex + 1);
+		if (!comparison) continue;
+		rebilledTokens += comparison.rebilledTokens;
+		if (comparison.estimatedMissPremium !== null) {
+			estimatedMissPremium += comparison.estimatedMissPremium;
+			missPremiumKnown = true;
+		}
+	}
+
+	const promptTokens = input + cacheRead + cacheWrite;
+	return {
+		requestCount: samples.length,
+		input,
+		cacheRead,
+		cacheWrite,
+		promptTokens,
+		hitRatePercent: promptTokens > 0 ? (cacheRead / promptTokens) * 100 : null,
+		promptCost,
+		estimatedSavings: savingsKnown ? estimatedSavings : null,
+		rebilledTokens,
+		estimatedMissPremium: missPremiumKnown ? estimatedMissPremium : null,
+		bestHitRatePercent,
+		worstHitRatePercent,
+	};
+}
+
+export function formatMonitorLines(view: CacheMonitorView): MonitorLine[] {
+	if (!view.latest) {
+		return [
+			{ role: "title", text: "Prompt cache · waiting for provider usage" },
+			{
+				role: "dim",
+				text: "Hit = cacheRead / (input + cacheRead + cacheWrite). Live updates begin when usage is reported.",
+			},
+		];
+	}
+
+	const latest = view.latest;
+	const comparison = view.comparison;
+	const session = view.session;
+	const live = view.streaming ? " · LIVE" : "";
+	const lines: MonitorLine[] = [
+		{
+			role: "title",
+			text: `Prompt cache${live} · request #${view.requestNumber} · ${latest.provider}/${latest.model}`,
+		},
+		{
+			role: latest.hitRatePercent >= 80 ? "good" : latest.hitRatePercent >= 50 ? "warning" : "bad",
+			text: [
+				`Latest  hit ${formatPercent(latest.hitRatePercent)}`,
+				comparison ? `Δ ${formatSignedPercent(comparison.hitRateDeltaPercent)}` : "Δ n/a",
+				comparison ? `loss ${formatPercentagePoints(comparison.hitRateLossPercent)}` : "loss n/a",
+				`uncached ${formatPercent(latest.uncachedRatePercent)}`,
+			].join("  ·  "),
+		},
+		{
+			role: "muted",
+			text: [
+				`Tokens  prompt ${formatTokens(latest.promptTokens)}`,
+				`read ${formatTokens(latest.cacheRead)}`,
+				`write ${formatTokens(latest.cacheWrite)}`,
+				`uncached ${formatTokens(latest.input)}`,
+				comparison ? `prompt Δ ${formatSignedTokens(comparison.promptTokenDelta)}` : "prompt Δ n/a",
+			].join("  ·  "),
+		},
+	];
+
+	if (comparison) {
+		lines.push({
+			role: comparison.rebilledTokens > 0 ? "warning" : "good",
+			text: [
+				`Reuse vs #${comparison.previousRequestNumber}`,
+				`eligible ${formatTokens(comparison.reusablePrefixTokens)}`,
+				`re-billed ${formatTokens(comparison.rebilledTokens)} (${formatNullablePercent(comparison.rebilledPercent)})`,
+				`read Δ ${formatSignedTokens(comparison.cacheReadDelta)}`,
+				comparison.modelChanged ? "model changed" : "same model",
+				`idle ${formatDuration(comparison.idleMs)}`,
+			].join("  ·  "),
+		});
+	} else {
+		lines.push({
+			role: "dim",
+			text: "Reuse  no comparable request in the current cache epoch (session start or compaction boundary).",
+		});
+	}
+
+	lines.push(
+		{
+			role: "muted",
+			text: [
+				`Cost  prompt ${formatMoney(latest.promptCost)}`,
+				`cache saved ~${formatNullableMoney(latest.estimatedSavings)}`,
+				`miss premium ~${formatNullableMoney(comparison?.estimatedMissPremium ?? null)}`,
+			].join("  ·  "),
+		},
+		{
+			role: "muted",
+			text: [
+				`Session  ${session.requestCount} req`,
+				`hit ${formatNullablePercent(session.hitRatePercent)}`,
+				`read ${formatTokens(session.cacheRead)}`,
+				`uncached ${formatTokens(session.input)}`,
+				`write ${formatTokens(session.cacheWrite)}`,
+				`re-billed ${formatTokens(session.rebilledTokens)} (~${formatNullableMoney(session.estimatedMissPremium)})`,
+			].join("  ·  "),
+		},
+		{
+			role: "dim",
+			text: `Trend old→new  ${view.trend.map(formatPercent).join(" → ")}`,
+		},
+		{
+			role: "dim",
+			text: "Formula  hit=read/prompt · re-billed=max(0, min(previous prompt, current prompt) - current read); costs are estimates from reported/model rates.",
+		},
+	);
+	return lines;
+}
+
+export function sanitizeDisplayLabel(value: string): string {
+	const stripped = stripTerminalSequences(value)
+		.replace(/[^\p{L}\p{N}_.:/@+\- ]+/gu, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+	if (!stripped) return "unknown";
+	const characters = [...stripped];
+	return characters.length > MAX_LABEL_LENGTH
+		? `${characters.slice(0, MAX_LABEL_LENGTH).join("")}…`
+		: stripped;
+}
+
+function findPreviousComparableIndex(
+	samples: readonly CacheSample[],
+	currentIndex: number,
+	epoch: number,
+): number {
+	for (let index = currentIndex - 1; index >= 0; index -= 1) {
+		const candidate = samples[index];
+		if (!candidate) continue;
+		if (candidate.epoch === epoch) return index;
+		if (candidate.epoch < epoch) return -1;
+	}
+	return -1;
+}
+
+function weightedPaidRate(input: number, cacheWrite: number, rates: ModelCostRates): number {
+	const tokens = input + cacheWrite;
+	if (tokens <= 0) return rates.input;
+	return (input * rates.input + cacheWrite * rates.cacheWrite) / tokens;
+}
+
+function unitCost(tokens: number, cost: number, fallbackRate?: number): number | null {
+	if (tokens > 0 && cost > 0) return cost / tokens;
+	return fallbackRate === undefined ? null : fallbackRate / 1_000_000;
+}
+
+function formatPercent(value: number): string {
+	return `${value.toFixed(1)}%`;
+}
+
+function formatNullablePercent(value: number | null): string {
+	return value === null ? "n/a" : formatPercent(value);
+}
+
+function formatSignedPercent(value: number): string {
+	const sign = value > 0 ? "+" : "";
+	return `${sign}${formatPercentagePoints(value)}`;
+}
+
+function formatPercentagePoints(value: number): string {
+	return `${value.toFixed(1)} pp`;
+}
+
+function formatTokens(value: number): string {
+	const absolute = Math.abs(value);
+	if (absolute < 1_000) return Math.round(value).toLocaleString("en-US");
+	if (absolute < 1_000_000) return `${trimFixed(value / 1_000)}k`;
+	return `${trimFixed(value / 1_000_000)}m`;
+}
+
+function formatSignedTokens(value: number): string {
+	return `${value > 0 ? "+" : ""}${formatTokens(value)}`;
+}
+
+function trimFixed(value: number): string {
+	return value.toFixed(Math.abs(value) >= 100 ? 0 : 1).replace(/\.0$/, "");
+}
+
+function formatMoney(value: number): string {
+	if (value === 0) return "$0.0000";
+	if (value < 0.0001) return "<$0.0001";
+	return `$${value.toFixed(value < 0.01 ? 4 : 3)}`;
+}
+
+function formatNullableMoney(value: number | null): string {
+	return value === null ? "n/a" : formatMoney(value);
+}
+
+function formatDuration(milliseconds: number): string {
+	if (milliseconds < 1_000) return `${Math.round(milliseconds)}ms`;
+	if (milliseconds < 60_000) return `${trimFixed(milliseconds / 1_000)}s`;
+	return `${trimFixed(milliseconds / 60_000)}m`;
+}
+
+function finiteNumber(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}

--- a/.pi/extensions/cache-hit-monitor/metrics.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.ts
@@ -1,23 +1,26 @@
-import type { AssistantMessage, ModelCostRates } from "@earendil-works/pi-ai";
+import type { AssistantMessage, ModelCostRates, Usage } from "@earendil-works/pi-ai";
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 import { stripTerminalSequences } from "@earendil-works/pi-tui";
 
 const TREND_SAMPLE_COUNT = 8;
 const MAX_LABEL_LENGTH = 60;
 
-export interface CacheSample {
-	epoch: number;
-	timestamp: number;
-	provider: string;
-	model: string;
+export interface CacheUsageRecord {
 	input: number;
 	cacheRead: number;
 	cacheWrite: number;
 	promptTokens: number;
 	hitRatePercent: number;
 	uncachedRatePercent: number;
-	promptCost: number;
+	promptCost: number | null;
 	estimatedSavings: number | null;
+}
+
+export interface CacheSample extends CacheUsageRecord {
+	epoch: number;
+	timestamp: number;
+	provider: string;
+	model: string;
 	inputUnitCost: number | null;
 	cacheReadUnitCost: number | null;
 	paidPromptUnitCost: number | null;
@@ -34,7 +37,7 @@ export interface CacheComparison {
 	rebilledPercent: number | null;
 	estimatedMissPremium: number | null;
 	modelChanged: boolean;
-	idleMs: number;
+	requestStartGapMs: number;
 }
 
 export interface CacheAggregate {
@@ -44,7 +47,7 @@ export interface CacheAggregate {
 	cacheWrite: number;
 	promptTokens: number;
 	hitRatePercent: number | null;
-	promptCost: number;
+	promptCost: number | null;
 	estimatedSavings: number | null;
 	rebilledTokens: number;
 	estimatedMissPremium: number | null;
@@ -68,7 +71,13 @@ export interface MonitorLine {
 
 export interface CollectedCacheSamples {
 	samples: CacheSample[];
+	summaryRecords: CacheUsageRecord[];
 	currentEpoch: number;
+}
+
+export interface CacheMonitorViewOptions {
+	activeEpoch?: number;
+	summaryRecords?: readonly CacheUsageRecord[];
 }
 
 type CostRateResolver = (provider: string, model: string) => ModelCostRates | undefined;
@@ -78,9 +87,12 @@ export function collectCacheSamples(
 	resolveCostRates: CostRateResolver = () => undefined,
 ): CollectedCacheSamples {
 	const samples: CacheSample[] = [];
+	const summaryRecords: CacheUsageRecord[] = [];
 	let currentEpoch = 0;
 	for (const entry of entries) {
 		if (entry.type === "compaction" || entry.type === "branch_summary") {
+			const summaryRecord = entry.usage ? createCacheUsageRecord(entry.usage) : null;
+			if (summaryRecord) summaryRecords.push(summaryRecord);
 			currentEpoch += 1;
 			continue;
 		}
@@ -92,7 +104,7 @@ export function collectCacheSamples(
 		);
 		if (sample) samples.push(sample);
 	}
-	return { samples, currentEpoch };
+	return { samples, summaryRecords, currentEpoch };
 }
 
 export function createCacheSample(
@@ -100,57 +112,80 @@ export function createCacheSample(
 	epoch: number,
 	costRates?: ModelCostRates,
 ): CacheSample | null {
-	const input = finiteNumber(message.usage.input);
-	const cacheRead = finiteNumber(message.usage.cacheRead);
-	const cacheWrite = finiteNumber(message.usage.cacheWrite);
-	const promptTokens = input + cacheRead + cacheWrite;
-	if (promptTokens <= 0) return null;
+	const usageRecord = createCacheUsageRecord(message.usage, costRates);
+	if (!usageRecord) return null;
 
-	const inputCost = finiteNumber(message.usage.cost?.input);
-	const cacheReadCost = finiteNumber(message.usage.cost?.cacheRead);
-	const cacheWriteCost = finiteNumber(message.usage.cost?.cacheWrite);
-	const inputUnitCost = unitCost(input, inputCost, costRates?.input);
-	const cacheReadUnitCost = unitCost(cacheRead, cacheReadCost, costRates?.cacheRead);
-	const paidPromptTokens = input + cacheWrite;
-	const paidPromptCost = inputCost + cacheWriteCost;
-	const paidPromptUnitCost = unitCost(
-		paidPromptTokens,
-		paidPromptCost,
-		costRates ? weightedPaidRate(input, cacheWrite, costRates) : undefined,
+	const inputUnitCost = unitCost(
+		usageRecord.input,
+		finiteNumber(message.usage.cost?.input),
+		costRates?.input,
 	);
-	const pricingKnown = costRates !== undefined || inputCost + cacheReadCost + cacheWriteCost > 0;
+	const cacheReadUnitCost = unitCost(
+		usageRecord.cacheRead,
+		finiteNumber(message.usage.cost?.cacheRead),
+		costRates?.cacheRead,
+	);
+	const paidPromptTokens = usageRecord.input + usageRecord.cacheWrite;
+	const paidPromptCost = sumKnownCosts([
+		componentCost(usageRecord.input, finiteNumber(message.usage.cost?.input), costRates?.input),
+		componentCost(
+			usageRecord.cacheWrite,
+			finiteNumber(message.usage.cost?.cacheWrite),
+			costRates?.cacheWrite,
+		),
+	]);
+	const paidPromptUnitCost =
+		paidPromptCost === null
+			? null
+			: unitCost(
+					paidPromptTokens,
+					paidPromptCost,
+					costRates
+						? weightedPaidRate(usageRecord.input, usageRecord.cacheWrite, costRates)
+						: undefined,
+				);
 
 	return {
+		...usageRecord,
 		epoch,
 		timestamp: finiteNumber(message.timestamp),
-		provider: sanitizeDisplayLabel(message.provider),
-		model: sanitizeDisplayLabel(message.model),
-		input,
-		cacheRead,
-		cacheWrite,
-		promptTokens,
-		hitRatePercent: (cacheRead / promptTokens) * 100,
-		uncachedRatePercent: (input / promptTokens) * 100,
-		promptCost: inputCost + cacheReadCost + cacheWriteCost,
-		estimatedSavings:
-			pricingKnown && inputUnitCost !== null && cacheReadUnitCost !== null
-				? cacheRead * Math.max(0, inputUnitCost - cacheReadUnitCost)
-				: null,
+		provider: message.provider,
+		model: message.model,
 		inputUnitCost,
 		cacheReadUnitCost,
 		paidPromptUnitCost,
 	};
 }
 
+export function cacheSamplesEqual(left: CacheSample, right: CacheSample): boolean {
+	return (
+		left.epoch === right.epoch &&
+		left.timestamp === right.timestamp &&
+		left.provider === right.provider &&
+		left.model === right.model &&
+		left.input === right.input &&
+		left.cacheRead === right.cacheRead &&
+		left.cacheWrite === right.cacheWrite &&
+		left.promptCost === right.promptCost &&
+		left.estimatedSavings === right.estimatedSavings &&
+		left.inputUnitCost === right.inputUnitCost &&
+		left.cacheReadUnitCost === right.cacheReadUnitCost &&
+		left.paidPromptUnitCost === right.paidPromptUnitCost
+	);
+}
+
 export function createCacheMonitorView(
 	finalizedSamples: readonly CacheSample[],
 	streamingSample?: CacheSample,
+	options: CacheMonitorViewOptions = {},
 ): CacheMonitorView {
 	const samples = streamingSample ? [...finalizedSamples, streamingSample] : [...finalizedSamples];
 	const latest = samples.at(-1) ?? null;
-	const previousIndex = latest
-		? findPreviousComparableIndex(samples, samples.length - 1, latest.epoch)
-		: -1;
+	const activeEpoch = options.activeEpoch ?? latest?.epoch;
+	const previousIndex =
+		latest && latest.epoch === activeEpoch
+			? findPreviousComparableIndex(samples, samples.length - 1, latest.epoch)
+			: -1;
 	const previous = previousIndex >= 0 ? samples[previousIndex] : undefined;
 
 	return {
@@ -159,7 +194,7 @@ export function createCacheMonitorView(
 		latest,
 		comparison:
 			latest && previous ? compareCacheSamples(previous, latest, previousIndex + 1) : null,
-		session: aggregateCacheSamples(samples),
+		session: aggregateCacheSamples(samples, options.summaryRecords),
 		trend: samples.slice(-TREND_SAMPLE_COUNT).map((sample) => sample.hitRatePercent),
 	};
 }
@@ -191,43 +226,51 @@ export function compareCacheSamples(
 			reusablePrefixTokens > 0 ? (rebilledTokens / reusablePrefixTokens) * 100 : null,
 		estimatedMissPremium: unitPremium === null ? null : rebilledTokens * unitPremium,
 		modelChanged: previous.provider !== current.provider || previous.model !== current.model,
-		idleMs: Math.max(0, current.timestamp - previous.timestamp),
+		requestStartGapMs: Math.max(0, current.timestamp - previous.timestamp),
 	};
 }
 
-export function aggregateCacheSamples(samples: readonly CacheSample[]): CacheAggregate {
+export function aggregateCacheSamples(
+	samples: readonly CacheSample[],
+	additionalRecords: readonly CacheUsageRecord[] = [],
+): CacheAggregate {
 	let input = 0;
 	let cacheRead = 0;
 	let cacheWrite = 0;
 	let promptCost = 0;
+	let promptCostKnown = true;
 	let estimatedSavings = 0;
-	let savingsKnown = false;
+	let savingsKnown = true;
 	let rebilledTokens = 0;
 	let estimatedMissPremium = 0;
 	let missPremiumKnown = false;
 	let bestHitRatePercent: number | null = null;
 	let worstHitRatePercent: number | null = null;
 
+	const addUsage = (record: CacheUsageRecord): void => {
+		input += record.input;
+		cacheRead += record.cacheRead;
+		cacheWrite += record.cacheWrite;
+		if (record.promptCost === null) promptCostKnown = false;
+		else promptCost += record.promptCost;
+		if (record.estimatedSavings === null) savingsKnown = false;
+		else estimatedSavings += record.estimatedSavings;
+		bestHitRatePercent = Math.max(
+			bestHitRatePercent ?? record.hitRatePercent,
+			record.hitRatePercent,
+		);
+		worstHitRatePercent = Math.min(
+			worstHitRatePercent ?? record.hitRatePercent,
+			record.hitRatePercent,
+		);
+	};
+
+	for (const sample of samples) addUsage(sample);
+	for (const record of additionalRecords) addUsage(record);
+
 	for (let index = 0; index < samples.length; index += 1) {
 		const sample = samples[index];
 		if (!sample) continue;
-		input += sample.input;
-		cacheRead += sample.cacheRead;
-		cacheWrite += sample.cacheWrite;
-		promptCost += sample.promptCost;
-		if (sample.estimatedSavings !== null) {
-			estimatedSavings += sample.estimatedSavings;
-			savingsKnown = true;
-		}
-		bestHitRatePercent = Math.max(
-			bestHitRatePercent ?? sample.hitRatePercent,
-			sample.hitRatePercent,
-		);
-		worstHitRatePercent = Math.min(
-			worstHitRatePercent ?? sample.hitRatePercent,
-			sample.hitRatePercent,
-		);
-
 		const previousIndex = findPreviousComparableIndex(samples, index, sample.epoch);
 		if (previousIndex < 0) continue;
 		const previous = samples[previousIndex];
@@ -241,16 +284,17 @@ export function aggregateCacheSamples(samples: readonly CacheSample[]): CacheAgg
 		}
 	}
 
+	const requestCount = samples.length + additionalRecords.length;
 	const promptTokens = input + cacheRead + cacheWrite;
 	return {
-		requestCount: samples.length,
+		requestCount,
 		input,
 		cacheRead,
 		cacheWrite,
 		promptTokens,
 		hitRatePercent: promptTokens > 0 ? (cacheRead / promptTokens) * 100 : null,
-		promptCost,
-		estimatedSavings: savingsKnown ? estimatedSavings : null,
+		promptCost: promptCostKnown ? promptCost : null,
+		estimatedSavings: requestCount > 0 && savingsKnown ? estimatedSavings : null,
 		rebilledTokens,
 		estimatedMissPremium: missPremiumKnown ? estimatedMissPremium : null,
 		bestHitRatePercent,
@@ -276,7 +320,7 @@ export function formatMonitorLines(view: CacheMonitorView): MonitorLine[] {
 	const lines: MonitorLine[] = [
 		{
 			role: "title",
-			text: `Prompt cache${live} · request #${view.requestNumber} · ${latest.provider}/${latest.model}`,
+			text: `Prompt cache${live} · request #${view.requestNumber} · ${sanitizeDisplayLabel(latest.provider)}/${sanitizeDisplayLabel(latest.model)}`,
 		},
 		{
 			role: latest.hitRatePercent >= 80 ? "good" : latest.hitRatePercent >= 50 ? "warning" : "bad",
@@ -308,7 +352,7 @@ export function formatMonitorLines(view: CacheMonitorView): MonitorLine[] {
 				`re-billed ${formatTokens(comparison.rebilledTokens)} (${formatNullablePercent(comparison.rebilledPercent)})`,
 				`read Δ ${formatSignedTokens(comparison.cacheReadDelta)}`,
 				comparison.modelChanged ? "model changed" : "same model",
-				`idle ${formatDuration(comparison.idleMs)}`,
+				`start gap ${formatDuration(comparison.requestStartGapMs)}`,
 			].join("  ·  "),
 		});
 	} else {
@@ -322,7 +366,7 @@ export function formatMonitorLines(view: CacheMonitorView): MonitorLine[] {
 		{
 			role: "muted",
 			text: [
-				`Cost  prompt ${formatMoney(latest.promptCost)}`,
+				`Cost  prompt ${formatNullableMoney(latest.promptCost)}`,
 				`cache saved ~${formatNullableMoney(latest.estimatedSavings)}`,
 				`miss premium ~${formatNullableMoney(comparison?.estimatedMissPremium ?? null)}`,
 			].join("  ·  "),
@@ -335,6 +379,8 @@ export function formatMonitorLines(view: CacheMonitorView): MonitorLine[] {
 				`read ${formatTokens(session.cacheRead)}`,
 				`uncached ${formatTokens(session.input)}`,
 				`write ${formatTokens(session.cacheWrite)}`,
+				`cost ${formatNullableMoney(session.promptCost)}`,
+				`saved ~${formatNullableMoney(session.estimatedSavings)}`,
 				`re-billed ${formatTokens(session.rebilledTokens)} (~${formatNullableMoney(session.estimatedMissPremium)})`,
 			].join("  ·  "),
 		},
@@ -362,6 +408,38 @@ export function sanitizeDisplayLabel(value: string): string {
 		: stripped;
 }
 
+function createCacheUsageRecord(usage: Usage, costRates?: ModelCostRates): CacheUsageRecord | null {
+	const input = finiteNumber(usage.input);
+	const cacheRead = finiteNumber(usage.cacheRead);
+	const cacheWrite = finiteNumber(usage.cacheWrite);
+	const promptTokens = input + cacheRead + cacheWrite;
+	if (promptTokens <= 0) return null;
+
+	const inputCost = finiteNumber(usage.cost?.input);
+	const cacheReadCost = finiteNumber(usage.cost?.cacheRead);
+	const cacheWriteCost = finiteNumber(usage.cost?.cacheWrite);
+	const inputUnitCost = unitCost(input, inputCost, costRates?.input);
+	const cacheReadUnitCost = unitCost(cacheRead, cacheReadCost, costRates?.cacheRead);
+
+	return {
+		input,
+		cacheRead,
+		cacheWrite,
+		promptTokens,
+		hitRatePercent: (cacheRead / promptTokens) * 100,
+		uncachedRatePercent: (input / promptTokens) * 100,
+		promptCost: sumKnownCosts([
+			componentCost(input, inputCost, costRates?.input),
+			componentCost(cacheRead, cacheReadCost, costRates?.cacheRead),
+			componentCost(cacheWrite, cacheWriteCost, costRates?.cacheWrite),
+		]),
+		estimatedSavings:
+			inputUnitCost !== null && cacheReadUnitCost !== null
+				? cacheRead * Math.max(0, inputUnitCost - cacheReadUnitCost)
+				: null,
+	};
+}
+
 function findPreviousComparableIndex(
 	samples: readonly CacheSample[],
 	currentIndex: number,
@@ -380,6 +458,18 @@ function weightedPaidRate(input: number, cacheWrite: number, rates: ModelCostRat
 	const tokens = input + cacheWrite;
 	if (tokens <= 0) return rates.input;
 	return (input * rates.input + cacheWrite * rates.cacheWrite) / tokens;
+}
+
+function componentCost(tokens: number, reportedCost: number, fallbackRate?: number): number | null {
+	if (tokens <= 0) return 0;
+	if (reportedCost > 0) return reportedCost;
+	return fallbackRate === undefined ? null : (tokens * fallbackRate) / 1_000_000;
+}
+
+function sumKnownCosts(costs: readonly (number | null)[]): number | null {
+	return costs.every((cost) => cost !== null)
+		? costs.reduce<number>((total, cost) => total + (cost ?? 0), 0)
+		: null;
 }
 
 function unitCost(tokens: number, cost: number, fallbackRate?: number): number | null {

--- a/.pi/extensions/cache-hit-monitor/tsconfig.json
+++ b/.pi/extensions/cache-hit-monitor/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["*.ts"]
+}

--- a/.pi/extensions/cache-hit-monitor/vitest.config.ts
+++ b/.pi/extensions/cache-hit-monitor/vitest.config.ts
@@ -1,0 +1,12 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	root: dirname(fileURLToPath(import.meta.url)),
+	test: {
+		environment: "node",
+		include: ["*.test.ts"],
+		testTimeout: 5_000,
+	},
+});


### PR DESCRIPTION
## Summary

- Add a project-local cache hit monitor that calculates metrics as provider usage arrives.
- Keep the widget hidden by default and toggle it with the argument-free `/cache-hit-monitor` command in TUI or RPC mode.
- Show hit-rate deltas, cache loss, uncached and re-billed tokens, estimated cost impact, session totals, and recent trends.
- Restore active-branch state across sessions and reset request comparisons at compaction boundaries.
- Keep provider/model labels terminal-safe and render width-bounded TUI output with plain RPC fallback.

## Verification

- `npx tsc -p .pi/extensions/cache-hit-monitor/tsconfig.json`
- `npx vitest run --config .pi/extensions/cache-hit-monitor/vitest.config.ts` (22 tests)
- `npm run check`
- `npm test` (3,372 tests)
- Isolated extension entrypoint load with `pi --no-extensions -e ./.pi/extensions/cache-hit-monitor/index.ts --list-models`
- Trusted-project auto-discovery startup with `pi --list-models`

## Release

No Changeset is required because this is a repository-only project-local extension.

