### PR TITLE
feat(runtime-diagnostics): expand runtime insights

### DIFF
--- a/.pi/extensions/runtime-diagnostics/README.md
+++ b/.pi/extensions/runtime-diagnostics/README.md
@@ -8,7 +8,7 @@ The default response is concise, while selected sections and sanitized bundles p
 
 - Reports the active provider, model, thinking level, Node.js version, platform, architecture, and resolved Pi Coding Agent version.
 - Aggregates prompt-cache usage and reports cautious findings when repeated requests have no cache reads.
-- Lists active and inactive tools, definition sizes, provenance, and the limitations of Pi's inactive-state API.
+- Lists active and inactive tools, lower-bound definition sizes, provenance, and the limitations of Pi's tool-inspection API.
 - Lists visible extension tool and command surfaces with owning package versions when a package manifest is discoverable.
 - Captures provider-visible tool names, numeric request sizes, HTTP status, and response-header latency without retaining payload content.
 - Compares provider requests and runtime snapshots with explicit added, removed, and changed fields.
@@ -30,7 +30,7 @@ Call `runtime_diagnostics` with no arguments to receive a concise status summary
 | `disable` | Disables provider-request capture for the active session branch. |
 | `clear` | Clears records from the active reporting window. |
 | `configure` | Updates session-scoped `maxRecords` or `maxAgeMinutes`. |
-| `bundle` | Returns every detail section as a sanitized shareable JSON bundle. |
+| `bundle` | Returns every detail section as a sanitized shareable JSON bundle, regardless of `sections`. |
 
 Set `detail` to `full` to include every section with an ordinary action.
 Set `sections` to any combination of `provider`, `cache`, `tools`, `extensions`, `environment`, `timeline`, and `privacy` for targeted evidence.
@@ -60,26 +60,29 @@ Provider request records retain only a timestamp, session ID, provider and model
 The extension does not retain prompts, instructions, message content, tool schemas, tool arguments, HTTP headers, response bodies, credentials, API keys, or authorization values.
 Request and tool-definition sizes are retained as numbers rather than serialized content.
 Captured display strings are stripped of terminal controls, bidirectional controls, and newlines before retention.
-Bundle exports replace every non-virtual tool and extension source path with `[redacted-local-path]`.
+Bundle exports replace every non-virtual source path, every package source reference, and every other path-like source reference with `[redacted-local-path]`.
 Ordinary targeted diagnostics keep sanitized source paths available for local troubleshooting.
-The `privacy` section reports the provider-field allowlist and bundle path-redaction audit results.
+The `privacy` section reports the provider-field allowlist and bundle source-redaction audit results.
 
 ## Limitations
 
 The `before_provider_request` hook exposes the payload at this extension's handler position, so a later extension can still replace it.
 A captured payload does not prove that the provider accepted or executed the exposed tools.
 Response latency ends when headers arrive and does not measure stream completion.
+The installed `google-generative-ai` and `google-vertex` adapters do not emit response-header telemetry, so their requests are marked `unsupported` rather than `pending`.
 Provider responses are matched to requests by event order because the hook exposes no request identifier.
 Unmatched request indexes are discarded at `agent_end` so a failed run cannot offset response attribution in a later run.
 Extension visibility includes only public tool and slash-command surfaces, so passive event-only extensions cannot be enumerated.
 Inactive tools include an honest generic explanation because Pi does not expose the configuration, filter, or deferred-loading reason.
+Per-tool definition sizes are lower bounds over the provider-visible name, description, and parameters because `ExtensionAPI.getAllTools()` does not expose `constrainedSampling`.
+Captured provider-request totals measure the actual serialized tool container and include adapter-specific strictness or grammar effects.
 A cache finding cannot prove provider cache support and should be interpreted with the selected provider and model documentation.
 
 ## Source layout
 
 - `index.ts` registers the tool, command, lifecycle hooks, and provider hooks.
 - `capture-state.ts` owns session reconstruction, controls, and retention pruning.
-- `provider-request.ts` owns privacy-filtered provider extraction and response timing.
+- `provider-request.ts` owns privacy-filtered provider extraction across supported payload shapes and response-telemetry state.
 - `snapshot.ts` owns runtime, cache, tool, extension, environment, and timeline snapshots.
 - `report.ts` owns findings, comparisons, privacy audits, presentation, and output bounds.
 - `text.ts` owns terminal-safe diagnostic string normalization.

--- a/.pi/extensions/runtime-diagnostics/README.md
+++ b/.pi/extensions/runtime-diagnostics/README.md
@@ -13,7 +13,7 @@ The default response is concise, while selected sections and sanitized bundles p
 - Captures provider-visible tool names, numeric request sizes, HTTP status, and response-header latency without retaining payload content.
 - Compares provider requests and runtime snapshots with explicit added, removed, and changed fields.
 - Produces actionable findings and deduplicated recommendations.
-- Audits every retained provider record against an allowlist before marking a diagnostic bundle shareable.
+- Audits retained provider fields and bundle source-path redaction before marking a diagnostic bundle shareable.
 - Bounds every tool result to 50 KB and 2,000 lines.
 
 ## Tool
@@ -60,7 +60,9 @@ Provider request records retain only a timestamp, session ID, provider and model
 The extension does not retain prompts, instructions, message content, tool schemas, tool arguments, HTTP headers, response bodies, credentials, API keys, or authorization values.
 Request and tool-definition sizes are retained as numbers rather than serialized content.
 Captured display strings are stripped of terminal controls, bidirectional controls, and newlines before retention.
-The `privacy` section reports the allowlist audit result and every excluded data class.
+Bundle exports replace every non-virtual tool and extension source path with `[redacted-local-path]`.
+Ordinary targeted diagnostics keep sanitized source paths available for local troubleshooting.
+The `privacy` section reports the provider-field allowlist and bundle path-redaction audit results.
 
 ## Limitations
 
@@ -68,6 +70,7 @@ The `before_provider_request` hook exposes the payload at this extension's handl
 A captured payload does not prove that the provider accepted or executed the exposed tools.
 Response latency ends when headers arrive and does not measure stream completion.
 Provider responses are matched to requests by event order because the hook exposes no request identifier.
+Unmatched request indexes are discarded at `agent_end` so a failed run cannot offset response attribution in a later run.
 Extension visibility includes only public tool and slash-command surfaces, so passive event-only extensions cannot be enumerated.
 Inactive tools include an honest generic explanation because Pi does not expose the configuration, filter, or deferred-loading reason.
 A cache finding cannot prove provider cache support and should be interpreted with the selected provider and model documentation.

--- a/.pi/extensions/runtime-diagnostics/README.md
+++ b/.pi/extensions/runtime-diagnostics/README.md
@@ -10,7 +10,7 @@ The default response is concise, while selected sections and sanitized bundles p
 - Aggregates prompt-cache usage and reports cautious findings when repeated requests have no cache reads.
 - Lists active and inactive tools, lower-bound definition sizes, provenance, and the limitations of Pi's tool-inspection API.
 - Lists visible extension tool and command surfaces with owning package versions when a package manifest is discoverable.
-- Captures provider-visible tool names, numeric request sizes, HTTP status, and response-header latency without retaining payload content.
+- Captures provider-visible tool names across installed adapter payload shapes, numeric request sizes, final HTTP status, and response-header latency without retaining payload content.
 - Compares provider requests and runtime snapshots with explicit added, removed, and changed fields.
 - Produces actionable findings and deduplicated recommendations.
 - Audits retained provider fields and bundle source-path redaction before marking a diagnostic bundle shareable.
@@ -70,7 +70,9 @@ The `before_provider_request` hook exposes the payload at this extension's handl
 A captured payload does not prove that the provider accepted or executed the exposed tools.
 Response latency ends when headers arrive and does not measure stream completion.
 The installed `google-generative-ai` and `google-vertex` adapters do not emit response-header telemetry, so their requests are marked `unsupported` rather than `pending`.
+Restored requests without retained response telemetry are marked `unavailable` because a future response cannot complete a historical capture.
 Provider responses are matched to requests by event order because the hook exposes no request identifier.
+Failed HTTP attempts remain associated with the same request until a successful retry replaces them or `agent_end` ends the run.
 Unmatched request indexes are discarded at `agent_end` so a failed run cannot offset response attribution in a later run.
 Extension visibility includes only public tool and slash-command surfaces, so passive event-only extensions cannot be enumerated.
 Inactive tools include an honest generic explanation because Pi does not expose the configuration, filter, or deferred-loading reason.

--- a/.pi/extensions/runtime-diagnostics/README.md
+++ b/.pi/extensions/runtime-diagnostics/README.md
@@ -1,0 +1,96 @@
+# Runtime Diagnostics
+
+Runtime Diagnostics is a project-local Pi extension for privacy-filtered runtime inspection.
+It is optimized for the `runtime_diagnostics` tool because an agent is its primary consumer.
+The default response is concise, while selected sections and sanitized bundles provide evidence only when needed.
+
+## Capabilities
+
+- Reports the active provider, model, thinking level, Node.js version, platform, architecture, and resolved Pi Coding Agent version.
+- Aggregates prompt-cache usage and reports cautious findings when repeated requests have no cache reads.
+- Lists active and inactive tools, definition sizes, provenance, and the limitations of Pi's inactive-state API.
+- Lists visible extension tool and command surfaces with owning package versions when a package manifest is discoverable.
+- Captures provider-visible tool names, numeric request sizes, HTTP status, and response-header latency without retaining payload content.
+- Compares provider requests and runtime snapshots with explicit added, removed, and changed fields.
+- Produces actionable findings and deduplicated recommendations.
+- Audits every retained provider record against an allowlist before marking a diagnostic bundle shareable.
+- Bounds every tool result to 50 KB and 2,000 lines.
+
+## Tool
+
+Call `runtime_diagnostics` with no arguments to receive a concise status summary.
+
+| Action | Behavior |
+| --- | --- |
+| `status` | Returns summary health, findings, recommendations, and requested sections. |
+| `latest` | Adds the latest provider request record. |
+| `show` | Adds recent provider request records up to `limit`. |
+| `compare` | Compares the first and latest retained provider and runtime records. |
+| `enable` | Enables provider-request capture for the active session branch. |
+| `disable` | Disables provider-request capture for the active session branch. |
+| `clear` | Clears records from the active reporting window. |
+| `configure` | Updates session-scoped `maxRecords` or `maxAgeMinutes`. |
+| `bundle` | Returns every detail section as a sanitized shareable JSON bundle. |
+
+Set `detail` to `full` to include every section with an ordinary action.
+Set `sections` to any combination of `provider`, `cache`, `tools`, `extensions`, `environment`, `timeline`, and `privacy` for targeted evidence.
+The `limit` parameter accepts 1 through 20 records for `show` and `bundle`.
+The `maxRecords` parameter accepts 1 through 500 records with `configure`.
+The `maxAgeMinutes` parameter accepts 1 through 10,080 minutes with `configure`.
+
+## Command
+
+`/runtime-diagnostics` provides a concise human-readable status in TUI and RPC modes.
+It accepts exactly one optional route: `status`, `provider`, `cache`, `tools`, `extensions`, `privacy`, or `help`.
+Known routes have argument completion, and unknown or trailing arguments are rejected.
+Print and JSON modes reject the command observably because notifications are unavailable there.
+Use the tool for machine-readable output, capture controls, retention configuration, comparisons, and bundles.
+
+## Retention
+
+Capture defaults to 100 records and a 1,440-minute active reporting window.
+Retention controls are stored as custom session entries and rebuild from the active branch after reload, resume, or fork.
+Automatic pruning and `clear` remove records from the in-memory reporting window.
+Pi session custom entries are append-only, so pruning and `clear` do not erase historical custom entries already present in an existing session file.
+No extension settings file, external log, timer, watcher, or background cleanup task is created.
+
+## Privacy
+
+Provider request records retain only a timestamp, session ID, provider and model IDs, a plan marker boolean, numeric byte counts, bounded tool names, HTTP status, and response-header latency.
+The extension does not retain prompts, instructions, message content, tool schemas, tool arguments, HTTP headers, response bodies, credentials, API keys, or authorization values.
+Request and tool-definition sizes are retained as numbers rather than serialized content.
+Captured display strings are stripped of terminal controls, bidirectional controls, and newlines before retention.
+The `privacy` section reports the allowlist audit result and every excluded data class.
+
+## Limitations
+
+The `before_provider_request` hook exposes the payload at this extension's handler position, so a later extension can still replace it.
+A captured payload does not prove that the provider accepted or executed the exposed tools.
+Response latency ends when headers arrive and does not measure stream completion.
+Provider responses are matched to requests by event order because the hook exposes no request identifier.
+Extension visibility includes only public tool and slash-command surfaces, so passive event-only extensions cannot be enumerated.
+Inactive tools include an honest generic explanation because Pi does not expose the configuration, filter, or deferred-loading reason.
+A cache finding cannot prove provider cache support and should be interpreted with the selected provider and model documentation.
+
+## Source layout
+
+- `index.ts` registers the tool, command, lifecycle hooks, and provider hooks.
+- `capture-state.ts` owns session reconstruction, controls, and retention pruning.
+- `provider-request.ts` owns privacy-filtered provider extraction and response timing.
+- `snapshot.ts` owns runtime, cache, tool, extension, environment, and timeline snapshots.
+- `report.ts` owns findings, comparisons, privacy audits, presentation, and output bounds.
+- `text.ts` owns terminal-safe diagnostic string normalization.
+- `index.test.ts` covers capture, controls, privacy, commands, bundles, and output bounds.
+- `tsconfig.json` and `vitest.config.ts` provide extension-local verification boundaries.
+
+## Verification
+
+Run the focused checks from the repository root:
+
+```bash
+npx tsc -p .pi/extensions/runtime-diagnostics/tsconfig.json
+npx vitest run --config .pi/extensions/runtime-diagnostics/vitest.config.ts
+pi --no-extensions -e ./.pi/extensions/runtime-diagnostics/index.ts
+```
+
+Trusted projects auto-discover `.pi/extensions/runtime-diagnostics/index.ts` and can reload it with `/reload`.

--- a/.pi/extensions/runtime-diagnostics/capture-state.ts
+++ b/.pi/extensions/runtime-diagnostics/capture-state.ts
@@ -2,8 +2,8 @@ import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 import {
 	attachProviderResponse,
 	isProviderResponseDiagnostic,
-	normalizeProviderRequestDiagnostic,
 	type ProviderRequestDiagnostic,
+	restoreProviderRequestDiagnostic,
 } from "./provider-request.js";
 
 export const PROVIDER_REQUEST_ENTRY_TYPE = "pi-debug:provider-request";
@@ -65,7 +65,7 @@ export function restoreCaptureState(
 	for (const entry of entries) {
 		if (entry.type !== "custom") continue;
 		if (entry.customType === PROVIDER_REQUEST_ENTRY_TYPE) {
-			const record = normalizeProviderRequestDiagnostic(entry.data);
+			const record = restoreProviderRequestDiagnostic(entry.data);
 			if (!record) continue;
 			maximumRequestIndex = Math.max(maximumRequestIndex, record.requestIndex);
 			state.records.push(record);

--- a/.pi/extensions/runtime-diagnostics/capture-state.ts
+++ b/.pi/extensions/runtime-diagnostics/capture-state.ts
@@ -1,0 +1,200 @@
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import {
+	attachProviderResponse,
+	isProviderResponseDiagnostic,
+	normalizeProviderRequestDiagnostic,
+	type ProviderRequestDiagnostic,
+} from "./provider-request.js";
+
+export const PROVIDER_REQUEST_ENTRY_TYPE = "pi-debug:provider-request";
+export const PROVIDER_RESPONSE_ENTRY_TYPE = "pi-debug:provider-response";
+export const CONTROL_ENTRY_TYPE = "pi-debug:control";
+export const DEFAULT_CAPTURE_POLICY: CapturePolicy = {
+	maxRecords: 100,
+	maxAgeMinutes: 24 * 60,
+};
+export const MAX_CAPTURE_RECORDS = 500;
+export const MAX_CAPTURE_AGE_MINUTES = 7 * 24 * 60;
+
+export interface CapturePolicy {
+	maxRecords: number;
+	maxAgeMinutes: number;
+}
+
+export interface ProviderCaptureState {
+	enabled: boolean;
+	records: ProviderRequestDiagnostic[];
+	pendingRequestIndexes: number[];
+	nextRequestIndex: number;
+	policy: CapturePolicy;
+	prunedRecordCount: number;
+}
+
+export type CaptureControlAction = "enable" | "disable" | "clear" | "configure";
+
+interface LegacyControlEntry {
+	version: 1;
+	capturedAt: number;
+	action: "enable" | "disable" | "clear";
+}
+
+export interface ControlEntry {
+	version: 2;
+	capturedAt: number;
+	action: CaptureControlAction;
+	policy: CapturePolicy;
+}
+
+export function createCaptureState(): ProviderCaptureState {
+	return {
+		enabled: true,
+		records: [],
+		pendingRequestIndexes: [],
+		nextRequestIndex: 1,
+		policy: { ...DEFAULT_CAPTURE_POLICY },
+		prunedRecordCount: 0,
+	};
+}
+
+export function restoreCaptureState(
+	entries: readonly SessionEntry[],
+	capturedAt: number,
+): ProviderCaptureState {
+	const state = createCaptureState();
+	let maximumRequestIndex = 0;
+	for (const entry of entries) {
+		if (entry.type !== "custom") continue;
+		if (entry.customType === PROVIDER_REQUEST_ENTRY_TYPE) {
+			const record = normalizeProviderRequestDiagnostic(entry.data);
+			if (!record) continue;
+			maximumRequestIndex = Math.max(maximumRequestIndex, record.requestIndex);
+			state.records.push(record);
+			continue;
+		}
+		if (entry.customType === PROVIDER_RESPONSE_ENTRY_TYPE) {
+			const response = entry.data;
+			if (!isProviderResponseDiagnostic(response)) continue;
+			const request = state.records.find((record) => record.requestIndex === response.requestIndex);
+			if (request) attachProviderResponse(request, response);
+			continue;
+		}
+		if (entry.customType !== CONTROL_ENTRY_TYPE) continue;
+		const control = normalizeControlEntry(entry.data);
+		if (!control) continue;
+		const policy = "policy" in control ? control.policy : state.policy;
+		applyControlToState(state, control.action, policy);
+		pruneCaptureState(state, control.capturedAt);
+	}
+	state.nextRequestIndex = maximumRequestIndex + 1;
+	pruneCaptureState(state, capturedAt);
+	return state;
+}
+
+export function createControlEntry(
+	state: ProviderCaptureState,
+	action: CaptureControlAction,
+	capturedAt: number,
+	policyPatch: Partial<CapturePolicy> = {},
+): ControlEntry {
+	const policy = normalizePolicy({
+		maxRecords: policyPatch.maxRecords ?? state.policy.maxRecords,
+		maxAgeMinutes: policyPatch.maxAgeMinutes ?? state.policy.maxAgeMinutes,
+	});
+	applyControlToState(state, action, policy);
+	pruneCaptureState(state, capturedAt);
+	return { version: 2, capturedAt, action, policy: { ...state.policy } };
+}
+
+export function pruneCaptureState(state: ProviderCaptureState, capturedAt: number): void {
+	const previousLength = state.records.length;
+	const oldestAllowed = capturedAt - state.policy.maxAgeMinutes * 60_000;
+	state.records = state.records
+		.filter((record) => record.capturedAt >= oldestAllowed)
+		.slice(-state.policy.maxRecords);
+	const retainedIndexes = new Set(state.records.map(({ requestIndex }) => requestIndex));
+	state.pendingRequestIndexes = state.pendingRequestIndexes.filter((requestIndex) =>
+		retainedIndexes.has(requestIndex),
+	);
+	state.prunedRecordCount += previousLength - state.records.length;
+}
+
+function applyControlToState(
+	state: ProviderCaptureState,
+	action: CaptureControlAction,
+	policy: CapturePolicy,
+): void {
+	state.policy = { ...policy };
+	if (action === "enable") state.enabled = true;
+	if (action === "disable") state.enabled = false;
+	if (action === "clear") {
+		state.records = [];
+		state.pendingRequestIndexes = [];
+	}
+}
+
+function normalizeControlEntry(value: unknown): ControlEntry | LegacyControlEntry | undefined {
+	if (!isRecord(value) || !Number.isFinite(value.capturedAt)) return undefined;
+	if (
+		value.version === 1 &&
+		(value.action === "enable" || value.action === "disable" || value.action === "clear")
+	) {
+		return value as unknown as LegacyControlEntry;
+	}
+	if (
+		value.version !== 2 ||
+		(value.action !== "enable" &&
+			value.action !== "disable" &&
+			value.action !== "clear" &&
+			value.action !== "configure") ||
+		!isCapturePolicy(value.policy)
+	) {
+		return undefined;
+	}
+	return {
+		version: 2,
+		capturedAt: value.capturedAt as number,
+		action: value.action,
+		policy: normalizePolicy(value.policy),
+	};
+}
+
+function normalizePolicy(policy: Partial<CapturePolicy>): CapturePolicy {
+	return {
+		maxRecords: clampInteger(
+			policy.maxRecords,
+			DEFAULT_CAPTURE_POLICY.maxRecords,
+			1,
+			MAX_CAPTURE_RECORDS,
+		),
+		maxAgeMinutes: clampInteger(
+			policy.maxAgeMinutes,
+			DEFAULT_CAPTURE_POLICY.maxAgeMinutes,
+			1,
+			MAX_CAPTURE_AGE_MINUTES,
+		),
+	};
+}
+
+function isCapturePolicy(value: unknown): value is CapturePolicy {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.maxRecords === "number" &&
+		Number.isInteger(value.maxRecords) &&
+		typeof value.maxAgeMinutes === "number" &&
+		Number.isInteger(value.maxAgeMinutes)
+	);
+}
+
+function clampInteger(
+	value: number | undefined,
+	fallback: number,
+	minimum: number,
+	maximum: number,
+): number {
+	if (typeof value !== "number" || !Number.isInteger(value)) return fallback;
+	return Math.min(maximum, Math.max(minimum, value));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/.pi/extensions/runtime-diagnostics/index.test.ts
+++ b/.pi/extensions/runtime-diagnostics/index.test.ts
@@ -1,0 +1,481 @@
+import assert from "node:assert/strict";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+	SessionEntry,
+} from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import {
+	CONTROL_ENTRY_TYPE,
+	createCaptureState,
+	createControlEntry,
+	PROVIDER_REQUEST_ENTRY_TYPE,
+	PROVIDER_RESPONSE_ENTRY_TYPE,
+	pruneCaptureState,
+	restoreCaptureState,
+} from "./capture-state.js";
+import { createDebugExtension } from "./index.js";
+import {
+	attachProviderResponse,
+	createProviderResponseDiagnostic,
+	extractProviderRequestDiagnostic,
+} from "./provider-request.js";
+
+interface ToolResult {
+	content: Array<{ type: "text"; text: string }>;
+	details: unknown;
+}
+
+interface RegisteredTool {
+	name: string;
+	description: string;
+	parameters: unknown;
+	promptGuidelines?: string[];
+	execute(
+		toolCallId: string,
+		params: {
+			action?: string;
+			detail?: string;
+			sections?: string[];
+			limit?: number;
+			maxRecords?: number;
+			maxAgeMinutes?: number;
+		},
+		signal: AbortSignal,
+		onUpdate: undefined,
+		ctx: ExtensionContext,
+	): Promise<ToolResult>;
+}
+
+interface RegisteredCommand {
+	description: string;
+	getArgumentCompletions(prefix: string): Array<{ value: string; label: string }> | null;
+	handler(args: string, ctx: ExtensionCommandContext): Promise<void>;
+}
+
+type Handler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+function customEntry(customType: string, data: unknown): SessionEntry {
+	return {
+		type: "custom",
+		id: `${customType}-${Math.random()}`,
+		parentId: null,
+		timestamp: 0,
+		customType,
+		data,
+	} as unknown as SessionEntry;
+}
+
+function createHarness(options: { extraToolCount?: number } = {}) {
+	let currentTime = 1_000;
+	const handlers = new Map<string, Handler[]>();
+	const tools: RegisteredTool[] = [];
+	const commands = new Map<string, RegisteredCommand>();
+	const entries: SessionEntry[] = [];
+	const notifications: string[] = [];
+	const extraTools = Array.from({ length: options.extraToolCount ?? 0 }, (_, index) => ({
+		name: `extra_tool_${index}`,
+		description: "x".repeat(4_000),
+		parameters: { type: "object", description: "x".repeat(4_000) },
+		promptGuidelines: [],
+		sourceInfo: {
+			path: `/very/long/${"p".repeat(800)}/${index}/index.ts`,
+			source: `npm:@example/extension-${index}`,
+			scope: "user",
+			origin: "package",
+		},
+	}));
+	const builtinRead = {
+		name: "read",
+		description: "Read files",
+		parameters: { type: "object" },
+		promptGuidelines: [],
+		sourceInfo: {
+			path: "<builtin:read>",
+			source: "builtin",
+			scope: "temporary",
+			origin: "top-level",
+		},
+	};
+	const pi = {
+		registerTool(tool: RegisteredTool) {
+			tools.push(tool);
+		},
+		registerCommand(name: string, command: RegisteredCommand) {
+			commands.set(name, command);
+		},
+		on(event: string, handler: Handler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		appendEntry(customType: string, data: unknown) {
+			entries.push(customEntry(customType, structuredClone(data)));
+		},
+		getThinkingLevel() {
+			return "high";
+		},
+		getActiveTools() {
+			return ["read", "runtime_diagnostics", ...extraTools.map(({ name }) => name)];
+		},
+		getAllTools() {
+			return [
+				builtinRead,
+				...tools.map((tool) => ({
+					...tool,
+					sourceInfo: {
+						path: "/project/.pi/extensions/runtime-diagnostics/index.ts",
+						source: "auto",
+						scope: "project",
+						origin: "top-level",
+					},
+				})),
+				...extraTools,
+			];
+		},
+		getCommands() {
+			return [...commands.entries()].map(([name, command]) => ({
+				name,
+				description: command.description,
+				source: "extension",
+				sourceInfo: {
+					path: "/project/.pi/extensions/runtime-diagnostics/index.ts",
+					source: "auto",
+					scope: "project",
+					origin: "top-level",
+				},
+			}));
+		},
+	} as unknown as ExtensionAPI;
+	const sessionManager = {
+		getSessionId: () => "session-1",
+		getBranch: () => entries,
+	} as unknown as ExtensionContext["sessionManager"];
+	const context = {
+		mode: "tui",
+		hasUI: true,
+		model: { provider: "openai", id: "gpt-test" },
+		sessionManager,
+		ui: {
+			notify(message: string) {
+				notifications.push(message);
+			},
+		},
+	} as unknown as ExtensionCommandContext;
+	createDebugExtension({ now: () => currentTime })(pi);
+
+	return {
+		entries,
+		notifications,
+		context,
+		tool: () => {
+			const tool = tools.find(({ name }) => name === "runtime_diagnostics");
+			assert.ok(tool);
+			return tool;
+		},
+		command: () => {
+			const command = commands.get("runtime-diagnostics");
+			assert.ok(command);
+			return command;
+		},
+		setTime(value: number) {
+			currentTime = value;
+		},
+		async emit(event: string, payload: unknown) {
+			for (const handler of handlers.get(event) ?? []) await handler(payload, context);
+		},
+	};
+}
+
+function parseToolResult(result: ToolResult) {
+	return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+test("captures only sanitized provider metadata, byte counts, status, and header latency", () => {
+	const request = extractProviderRequestDiagnostic(
+		{
+			instructions: "\u001b[31m[CODEX-LIKE PLAN MODE ACTIVE] secret prompt",
+			tools: [
+				{ type: "function", name: "read\n" },
+				{ type: "function", function: { name: "bash" }, description: "secret schema" },
+			],
+			input: [{ type: "additional_tools", tools: [{ name: "edit" }] }],
+			messages: [{ role: "user", content: "private message" }],
+		},
+		{
+			requestIndex: 1,
+			capturedAt: 100,
+			sessionId: "session\u001b[31m",
+			provider: "openai\n",
+			model: "gpt-test\u202e",
+		},
+	);
+	assert.equal(request.planModeMarkerPresent, true);
+	assert.deepEqual(request.topLevelToolNames, ["bash", "read"]);
+	assert.deepEqual(request.transcriptToolNames, ["edit"]);
+	assert.ok((request.requestBytes ?? 0) > (request.toolDefinitionBytes ?? 0));
+	assert.equal(JSON.stringify(request).includes("private message"), false);
+	assert.equal(JSON.stringify(request).includes("secret schema"), false);
+	assert.equal(JSON.stringify(request).includes("secret prompt"), false);
+
+	const response = createProviderResponseDiagnostic(request, 429, 175);
+	attachProviderResponse(request, response);
+	assert.deepEqual(request.response, {
+		version: 1,
+		requestIndex: 1,
+		capturedAt: 175,
+		status: 429,
+		responseHeaderLatencyMs: 75,
+	});
+});
+
+test("restores fork-sensitive controls and prunes the active reporting window", () => {
+	const first = extractProviderRequestDiagnostic(
+		{},
+		{
+			requestIndex: 1,
+			capturedAt: 1_000,
+			sessionId: "session",
+		},
+	);
+	const second = extractProviderRequestDiagnostic(
+		{},
+		{
+			requestIndex: 2,
+			capturedAt: 2_000,
+			sessionId: "session",
+		},
+	);
+	const state = createCaptureState();
+	const control = createControlEntry(state, "configure", 2_500, {
+		maxRecords: 1,
+		maxAgeMinutes: 60,
+	});
+	const response = createProviderResponseDiagnostic(second, 200, 2_100);
+	const restored = restoreCaptureState(
+		[
+			customEntry(PROVIDER_REQUEST_ENTRY_TYPE, first),
+			customEntry(PROVIDER_REQUEST_ENTRY_TYPE, second),
+			customEntry(PROVIDER_RESPONSE_ENTRY_TYPE, response),
+			customEntry(CONTROL_ENTRY_TYPE, control),
+		],
+		3_000,
+	);
+	assert.equal(restored.records.length, 1);
+	assert.equal(restored.records[0].requestIndex, 2);
+	assert.equal(restored.records[0].response?.status, 200);
+	assert.deepEqual(restored.policy, { maxRecords: 1, maxAgeMinutes: 60 });
+	assert.equal(restored.nextRequestIndex, 3);
+	assert.deepEqual(restored.pendingRequestIndexes, []);
+
+	pruneCaptureState(restored, 2_000 + 61 * 60_000);
+	assert.equal(restored.records.length, 0);
+});
+
+test("defaults to a concise agent report and supports targeted, control, bundle, and command routes", async () => {
+	const harness = createHarness();
+	await harness.emit("session_start", {});
+	harness.setTime(2_000);
+	await harness.emit("before_provider_request", {
+		payload: {
+			tools: [{ name: "read" }, { name: "runtime_diagnostics" }],
+			input: [],
+		},
+	});
+	harness.setTime(2_050);
+	await harness.emit("after_provider_response", {
+		status: 200,
+		headers: { authorization: "secret" },
+	});
+
+	const concise = parseToolResult(
+		await harness
+			.tool()
+			.execute("call-1", {}, new AbortController().signal, undefined, harness.context),
+	);
+	assert.equal(concise.format, "runtime-diagnostics/v2");
+	assert.deepEqual(concise.details, {});
+	assert.equal(JSON.stringify(concise).includes("authorization"), false);
+
+	const targeted = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-2",
+				{ sections: ["provider", "privacy", "environment"] },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	const details = targeted.details as Record<string, unknown>;
+	assert.ok(details.providerRequestCapture);
+	assert.ok(details.privacy);
+	assert.ok(details.environment);
+	assert.equal((details.privacy as { passed: boolean }).passed, true);
+
+	await harness
+		.tool()
+		.execute(
+			"call-3",
+			{ action: "configure", maxRecords: 2, maxAgeMinutes: 30 },
+			new AbortController().signal,
+			undefined,
+			harness.context,
+		);
+	await assert.rejects(
+		harness
+			.tool()
+			.execute(
+				"call-4",
+				{ action: "configure" },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+		/requires maxRecords or maxAgeMinutes/,
+	);
+
+	const disabled = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-5",
+				{ action: "disable" },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	assert.equal(
+		((disabled.summary as Record<string, unknown>).capture as { enabled: boolean }).enabled,
+		false,
+	);
+	harness.setTime(3_000);
+	await harness.emit("before_provider_request", { payload: { tools: [{ name: "read" }] } });
+	await harness
+		.tool()
+		.execute(
+			"call-6",
+			{ action: "enable" },
+			new AbortController().signal,
+			undefined,
+			harness.context,
+		);
+	harness.setTime(4_000);
+	await harness.emit("before_provider_request", {
+		payload: { tools: [{ name: "read" }, { name: "runtime_diagnostics" }] },
+	});
+	harness.setTime(4_025);
+	await harness.emit("after_provider_response", { status: 201, headers: {} });
+
+	const shown = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-7",
+				{ action: "show", limit: 1 },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	const shownProvider = (shown.details as Record<string, unknown>).providerRequestCapture as {
+		recent: unknown[];
+	};
+	assert.equal(shownProvider.recent.length, 1);
+	const compared = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-8",
+				{ action: "compare" },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	assert.ok(
+		(
+			(compared.details as Record<string, unknown>).providerRequestCapture as {
+				comparison: unknown;
+			}
+		).comparison,
+	);
+
+	const bundle = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-9",
+				{ action: "bundle" },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	assert.equal((bundle.export as { sanitized: boolean }).sanitized, true);
+	assert.ok((bundle.details as Record<string, unknown>).timeline);
+
+	const cleared = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-10",
+				{ action: "clear" },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	assert.equal(
+		(
+			(cleared.summary as Record<string, unknown>).capture as {
+				retainedRecordCount: number;
+			}
+		).retainedRecordCount,
+		0,
+	);
+
+	const command = harness.command();
+	assert.ok(command.getArgumentCompletions("pri")?.some(({ value }) => value === "privacy"));
+	for (const route of [
+		"",
+		"status",
+		"provider",
+		"cache",
+		"tools",
+		"extensions",
+		"privacy",
+		"help",
+	]) {
+		await command.handler(route, harness.context);
+	}
+	assert.equal(harness.notifications.length, 8);
+	await assert.rejects(command.handler("tools trailing", harness.context), /Unknown/);
+	await assert.rejects(
+		command.handler("status", {
+			...harness.context,
+			mode: "print",
+			hasUI: false,
+		} as ExtensionCommandContext),
+		/TUI and RPC modes only/,
+	);
+});
+
+test("bounds a full diagnostic bundle below Pi tool output limits", async () => {
+	const harness = createHarness({ extraToolCount: 120 });
+	await harness.emit("session_start", {});
+	const result = await harness
+		.tool()
+		.execute(
+			"call-large",
+			{ action: "bundle", limit: 20 },
+			new AbortController().signal,
+			undefined,
+			harness.context,
+		);
+	const text = result.content[0].text;
+	assert.ok(Buffer.byteLength(text, "utf8") <= 50 * 1024);
+	assert.ok(text.split("\n").length <= 2_000);
+	assert.match(text, /Detailed sections were omitted/);
+});

--- a/.pi/extensions/runtime-diagnostics/index.test.ts
+++ b/.pi/extensions/runtime-diagnostics/index.test.ts
@@ -21,7 +21,9 @@ import {
 	createProviderResponseDiagnostic,
 	extractProviderRequestDiagnostic,
 } from "./provider-request.js";
+import { DIAGNOSTIC_SECTIONS } from "./report.js";
 import { RUNTIME_ENTRY_TYPE } from "./snapshot.js";
+import { sanitizeDiagnosticText } from "./text.js";
 
 interface ToolResult {
 	content: Array<{ type: "text"; text: string }>;
@@ -68,7 +70,9 @@ function customEntry(customType: string, data: unknown): SessionEntry {
 	} as unknown as SessionEntry;
 }
 
-function createHarness(options: { extraToolCount?: number } = {}) {
+function createHarness(
+	options: { extraToolCount?: number; modelApi?: string; provider?: string } = {},
+) {
 	let currentTime = 1_000;
 	const handlers = new Map<string, Handler[]>();
 	const tools: RegisteredTool[] = [];
@@ -124,10 +128,10 @@ function createHarness(options: { extraToolCount?: number } = {}) {
 				...tools.map((tool) => ({
 					...tool,
 					sourceInfo: {
-						path: "/project/.pi/extensions/runtime-diagnostics/index.ts",
-						source: "auto",
+						path: "/home/alice/private-extension/index.ts",
+						source: "/home/alice/private-extension",
 						scope: "project",
-						origin: "top-level",
+						origin: "package",
 					},
 				})),
 				...extraTools,
@@ -139,10 +143,10 @@ function createHarness(options: { extraToolCount?: number } = {}) {
 				description: command.description,
 				source: "extension",
 				sourceInfo: {
-					path: "/project/.pi/extensions/runtime-diagnostics/index.ts",
-					source: "auto",
+					path: "/home/alice/private-extension/index.ts",
+					source: "/home/alice/private-extension",
 					scope: "project",
-					origin: "top-level",
+					origin: "package",
 				},
 			}));
 		},
@@ -154,7 +158,11 @@ function createHarness(options: { extraToolCount?: number } = {}) {
 	const context = {
 		mode: "tui",
 		hasUI: true,
-		model: { provider: "openai", id: "gpt-test" },
+		model: {
+			provider: options.provider ?? "openai",
+			id: "gpt-test",
+			api: options.modelApi ?? "openai-responses",
+		},
 		sessionManager,
 		ui: {
 			notify(message: string) {
@@ -220,6 +228,7 @@ test("captures only sanitized provider metadata, byte counts, status, and header
 
 	const response = createProviderResponseDiagnostic(request, 429, 175);
 	attachProviderResponse(request, response);
+	assert.equal(request.responseTelemetry, "received");
 	assert.deepEqual(request.response, {
 		version: 1,
 		requestIndex: 1,
@@ -227,6 +236,57 @@ test("captures only sanitized provider metadata, byte counts, status, and header
 		status: 429,
 		responseHeaderLatencyMs: 75,
 	});
+});
+
+test("extracts provider-visible tools from Google and Bedrock payloads", () => {
+	const googleTools = [
+		{
+			functionDeclarations: [
+				{ name: "read", parametersJsonSchema: { type: "object" } },
+				{ name: "edit", parametersJsonSchema: { type: "object" } },
+			],
+		},
+	];
+	const google = extractProviderRequestDiagnostic(
+		{
+			config: {
+				systemInstruction: "[CODEX-LIKE PLAN MODE ACTIVE]",
+				tools: googleTools,
+			},
+		},
+		{
+			requestIndex: 1,
+			capturedAt: 100,
+			sessionId: "session",
+			api: "google-generative-ai",
+		},
+	);
+	assert.deepEqual(google.topLevelToolNames, ["edit", "read"]);
+	assert.equal(google.toolDefinitionBytes, Buffer.byteLength(JSON.stringify(googleTools)));
+	assert.equal(google.planModeMarkerPresent, true);
+	assert.equal(google.responseTelemetry, "unsupported");
+
+	const bedrockTools = [
+		{ toolSpec: { name: "bash", inputSchema: { json: { type: "object" } } } },
+		{ toolSpec: { name: "write", inputSchema: { json: { type: "object" } } } },
+	];
+	const bedrock = extractProviderRequestDiagnostic(
+		{ toolConfig: { tools: bedrockTools } },
+		{
+			requestIndex: 2,
+			capturedAt: 200,
+			sessionId: "session",
+			api: "bedrock-converse-stream",
+		},
+	);
+	assert.deepEqual(bedrock.topLevelToolNames, ["bash", "write"]);
+	assert.equal(bedrock.toolDefinitionBytes, Buffer.byteLength(JSON.stringify(bedrockTools)));
+	assert.equal(bedrock.responseTelemetry, "pending");
+});
+
+test("strips every Unicode bidirectional formatting control", () => {
+	const controls = "\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069";
+	assert.equal(sanitizeDiagnosticText(`left${controls}right`), "leftright");
 });
 
 test("restores fork-sensitive controls and prunes the active reporting window", () => {
@@ -408,7 +468,7 @@ test("defaults to a concise agent report and supports targeted, control, bundle,
 			.tool()
 			.execute(
 				"call-9",
-				{ action: "bundle" },
+				{ action: "bundle", sections: ["provider"] },
 				new AbortController().signal,
 				undefined,
 				harness.context,
@@ -416,8 +476,11 @@ test("defaults to a concise agent report and supports targeted, control, bundle,
 	);
 	assert.equal((bundle.export as { sanitized: boolean }).sanitized, true);
 	const bundleDetails = bundle.details as Record<string, unknown>;
-	assert.ok(bundleDetails.timeline);
-	assert.equal(JSON.stringify(bundle).includes("/project/"), false);
+	for (const section of DIAGNOSTIC_SECTIONS) {
+		const key = section === "provider" ? "providerRequestCapture" : section;
+		assert.ok(bundleDetails[key], `bundle omitted ${section}`);
+	}
+	assert.equal(JSON.stringify(bundle).includes("/home/alice/"), false);
 	assert.deepEqual(
 		(
 			bundleDetails.tools as {
@@ -428,14 +491,35 @@ test("defaults to a concise agent report and supports targeted, control, bundle,
 	);
 	assert.deepEqual(
 		(
+			bundleDetails.tools as {
+				catalog: Array<{ source: { source: string } }>;
+			}
+		).catalog.map(({ source }) => source.source),
+		["builtin", "[redacted-local-path]"],
+	);
+	assert.match(
+		(bundleDetails.tools as { definitionSizeBasis: string }).definitionSizeBasis,
+		/constrainedSampling/,
+	);
+	assert.equal("definitionBytes" in (bundleDetails.tools as object), false);
+	assert.deepEqual(
+		(
 			bundleDetails.extensions as {
 				surfaces: Array<{ path: string }>;
 			}
 		).surfaces.map(({ path }) => path),
 		["[redacted-local-path]"],
 	);
+	assert.deepEqual(
+		(
+			bundleDetails.extensions as {
+				surfaces: Array<{ source: string }>;
+			}
+		).surfaces.map(({ source }) => source),
+		["[redacted-local-path]"],
+	);
 	assert.equal(
-		(bundleDetails.privacy as { bundlePathRedaction: string }).bundlePathRedaction,
+		(bundleDetails.privacy as { bundleSourceRedaction: string }).bundleSourceRedaction,
 		"passed",
 	);
 
@@ -521,6 +605,115 @@ test("clears unmatched provider requests before attributing responses in a later
 		status: 200,
 		responseHeaderLatencyMs: 25,
 	});
+});
+
+test("marks Google response telemetry unsupported instead of pending", async () => {
+	const harness = createHarness({ modelApi: "google-generative-ai", provider: "google" });
+	await harness.emit("session_start", {});
+	harness.setTime(2_000);
+	await harness.emit("before_provider_request", {
+		payload: {
+			config: {
+				tools: [{ functionDeclarations: [{ name: "read" }] }],
+			},
+		},
+	});
+	await harness.emit("agent_end", { messages: [] });
+
+	const shown = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-google",
+				{ action: "show" },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	const provider = (shown.details as Record<string, unknown>).providerRequestCapture as {
+		latest: { responseTelemetry: string; response: unknown };
+		performance: {
+			completedRequestCount: number;
+			pendingRequestCount: number;
+			unsupportedRequestCount: number;
+			averageResponseHeaderLatencyMs: number | null;
+		};
+	};
+	assert.equal(provider.latest.responseTelemetry, "unsupported");
+	assert.equal(provider.latest.response, null);
+	assert.equal(provider.performance.completedRequestCount, 0);
+	assert.equal(provider.performance.pendingRequestCount, 0);
+	assert.equal(provider.performance.unsupportedRequestCount, 1);
+	assert.equal(provider.performance.averageResponseHeaderLatencyMs, null);
+	assert.ok(
+		(shown.findings as Array<{ code: string }>).some(
+			({ code }) => code === "response-telemetry-unsupported",
+		),
+	);
+});
+
+test("rebuilds fork-sensitive diagnostics after session tree navigation", async () => {
+	const harness = createHarness();
+	await harness.emit("session_start", {});
+	harness.setTime(2_000);
+	await harness.emit("before_provider_request", { payload: { tools: [{ name: "read" }] } });
+
+	const retained = extractProviderRequestDiagnostic(
+		{ tools: [{ name: "read" }] },
+		{
+			requestIndex: 7,
+			capturedAt: 3_000,
+			sessionId: "session-1",
+			provider: "openai",
+			model: "gpt-test",
+			api: "openai-responses",
+		},
+	);
+	const branchState = createCaptureState();
+	const branchControl = createControlEntry(branchState, "configure", 3_500, {
+		maxRecords: 5,
+		maxAgeMinutes: 60,
+	});
+	harness.entries.splice(
+		0,
+		harness.entries.length,
+		customEntry(PROVIDER_REQUEST_ENTRY_TYPE, retained),
+		customEntry(CONTROL_ENTRY_TYPE, branchControl),
+	);
+	harness.setTime(4_000);
+	await harness.emit("session_tree", { newLeafId: "branch", oldLeafId: "abandoned" });
+	await harness.emit("before_provider_request", { payload: { tools: [{ name: "read" }] } });
+
+	const shown = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-tree",
+				{ action: "show", limit: 20 },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	const provider = (shown.details as Record<string, unknown>).providerRequestCapture as {
+		recent: Array<{ requestIndex: number }>;
+		policy: { maxRecords: number; maxAgeMinutes: number };
+	};
+	const recent = provider.recent;
+	assert.deepEqual(provider.policy, { maxRecords: 5, maxAgeMinutes: 60 });
+	assert.deepEqual(
+		recent.map(({ requestIndex }) => requestIndex),
+		[7, 8],
+	);
+	assert.ok(
+		harness.entries.some(
+			(entry) =>
+				entry.type === "custom" &&
+				entry.customType === RUNTIME_ENTRY_TYPE &&
+				(entry.data as { reason?: string }).reason === "session_tree",
+		),
+	);
 });
 
 test("ignores malformed restored runtime snapshots before comparison", async () => {

--- a/.pi/extensions/runtime-diagnostics/index.test.ts
+++ b/.pi/extensions/runtime-diagnostics/index.test.ts
@@ -21,6 +21,7 @@ import {
 	createProviderResponseDiagnostic,
 	extractProviderRequestDiagnostic,
 } from "./provider-request.js";
+import { RUNTIME_ENTRY_TYPE } from "./snapshot.js";
 
 interface ToolResult {
 	content: Array<{ type: "text"; text: string }>;
@@ -414,7 +415,29 @@ test("defaults to a concise agent report and supports targeted, control, bundle,
 			),
 	);
 	assert.equal((bundle.export as { sanitized: boolean }).sanitized, true);
-	assert.ok((bundle.details as Record<string, unknown>).timeline);
+	const bundleDetails = bundle.details as Record<string, unknown>;
+	assert.ok(bundleDetails.timeline);
+	assert.equal(JSON.stringify(bundle).includes("/project/"), false);
+	assert.deepEqual(
+		(
+			bundleDetails.tools as {
+				catalog: Array<{ source: { path: string } }>;
+			}
+		).catalog.map(({ source }) => source.path),
+		["<builtin:read>", "[redacted-local-path]"],
+	);
+	assert.deepEqual(
+		(
+			bundleDetails.extensions as {
+				surfaces: Array<{ path: string }>;
+			}
+		).surfaces.map(({ path }) => path),
+		["[redacted-local-path]"],
+	);
+	assert.equal(
+		(bundleDetails.privacy as { bundlePathRedaction: string }).bundlePathRedaction,
+		"passed",
+	);
 
 	const cleared = parseToolResult(
 		await harness
@@ -460,6 +483,82 @@ test("defaults to a concise agent report and supports targeted, control, bundle,
 		} as ExtensionCommandContext),
 		/TUI and RPC modes only/,
 	);
+});
+
+test("clears unmatched provider requests before attributing responses in a later run", async () => {
+	const harness = createHarness();
+	await harness.emit("session_start", {});
+	harness.setTime(2_000);
+	await harness.emit("before_provider_request", { payload: { tools: [{ name: "read" }] } });
+	await harness.emit("agent_end", { messages: [] });
+
+	harness.setTime(3_000);
+	await harness.emit("before_provider_request", { payload: { tools: [{ name: "read" }] } });
+	harness.setTime(3_025);
+	await harness.emit("after_provider_response", { status: 200, headers: {} });
+
+	const shown = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-show",
+				{ action: "show", limit: 2 },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	const records = (
+		(shown.details as Record<string, unknown>).providerRequestCapture as {
+			recent: Array<{ response: null | { status: number; responseHeaderLatencyMs: number } }>;
+		}
+	).recent;
+	assert.equal(records[0].response, null);
+	assert.deepEqual(records[1].response, {
+		version: 1,
+		requestIndex: 2,
+		capturedAt: 3_025,
+		status: 200,
+		responseHeaderLatencyMs: 25,
+	});
+});
+
+test("ignores malformed restored runtime snapshots before comparison", async () => {
+	const harness = createHarness();
+	await harness.emit("session_start", {});
+	for (const capturedAt of [2_000, 3_000]) {
+		harness.entries.push(
+			customEntry(RUNTIME_ENTRY_TYPE, {
+				version: 1,
+				capturedAt,
+				reason: "assistant_message",
+				sessionId: "session-1",
+				provider: "openai",
+				model: "gpt-test",
+				thinkingLevel: "high",
+				cache: null,
+				tools: { active: null, inactive: {} },
+			}),
+		);
+	}
+
+	const compared = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-compare",
+				{ action: "compare" },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	const timeline = (compared.details as Record<string, unknown>).timeline as {
+		recentRuntimeRecords: unknown[];
+		comparison: unknown;
+	};
+	assert.equal(timeline.recentRuntimeRecords.length, 1);
+	assert.equal(timeline.comparison, null);
 });
 
 test("bounds a full diagnostic bundle below Pi tool output limits", async () => {

--- a/.pi/extensions/runtime-diagnostics/index.test.ts
+++ b/.pi/extensions/runtime-diagnostics/index.test.ts
@@ -238,7 +238,7 @@ test("captures only sanitized provider metadata, byte counts, status, and header
 	});
 });
 
-test("extracts provider-visible tools from Google and Bedrock payloads", () => {
+test("extracts provider-visible tools from Google, Bedrock, and pi-messages payloads", () => {
 	const googleTools = [
 		{
 			functionDeclarations: [
@@ -282,6 +282,30 @@ test("extracts provider-visible tools from Google and Bedrock payloads", () => {
 	assert.deepEqual(bedrock.topLevelToolNames, ["bash", "write"]);
 	assert.equal(bedrock.toolDefinitionBytes, Buffer.byteLength(JSON.stringify(bedrockTools)));
 	assert.equal(bedrock.responseTelemetry, "pending");
+
+	const piMessageTools = [
+		{ name: "read", description: "Read files", parameters: { type: "object" } },
+		{ name: "write", description: "Write files", parameters: { type: "object" } },
+	];
+	const piMessages = extractProviderRequestDiagnostic(
+		{
+			model: "radius-test",
+			context: {
+				systemPrompt: "[CODEX-LIKE PLAN MODE ACTIVE]",
+				tools: piMessageTools,
+			},
+			options: {},
+		},
+		{
+			requestIndex: 3,
+			capturedAt: 300,
+			sessionId: "session",
+			api: "pi-messages",
+		},
+	);
+	assert.deepEqual(piMessages.topLevelToolNames, ["read", "write"]);
+	assert.equal(piMessages.toolDefinitionBytes, Buffer.byteLength(JSON.stringify(piMessageTools)));
+	assert.equal(piMessages.planModeMarkerPresent, true);
 });
 
 test("strips every Unicode bidirectional formatting control", () => {
@@ -330,6 +354,64 @@ test("restores fork-sensitive controls and prunes the active reporting window", 
 
 	pruneCaptureState(restored, 2_000 + 61 * 60_000);
 	assert.equal(restored.records.length, 0);
+});
+
+test("marks restored response-less captures unavailable instead of pending", async () => {
+	const harness = createHarness();
+	const legacyRequest = {
+		version: 1,
+		requestIndex: 4,
+		capturedAt: 900,
+		sessionId: "session-1",
+		provider: "openai",
+		model: "legacy-model",
+		planModeMarkerPresent: false,
+		topLevelToolNames: ["read"],
+		transcriptToolNames: [],
+	};
+	const persistedPendingRequest = extractProviderRequestDiagnostic(
+		{ tools: [{ name: "read" }] },
+		{
+			requestIndex: 5,
+			capturedAt: 950,
+			sessionId: "session-1",
+			provider: "openai",
+			model: "gpt-test",
+			api: "openai-responses",
+		},
+	);
+	harness.entries.push(
+		customEntry(PROVIDER_REQUEST_ENTRY_TYPE, legacyRequest),
+		customEntry(PROVIDER_REQUEST_ENTRY_TYPE, persistedPendingRequest),
+	);
+	await harness.emit("session_start", {});
+
+	const shown = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-restored",
+				{ action: "show", limit: 2 },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	const provider = (shown.details as Record<string, unknown>).providerRequestCapture as {
+		recent: Array<{ responseTelemetry: string }>;
+		performance: { pendingRequestCount: number; unavailableRequestCount: number };
+	};
+	assert.deepEqual(
+		provider.recent.map(({ responseTelemetry }) => responseTelemetry),
+		["unavailable", "unavailable"],
+	);
+	assert.equal(provider.performance.pendingRequestCount, 0);
+	assert.equal(provider.performance.unavailableRequestCount, 2);
+	assert.ok(
+		(shown.findings as Array<{ code: string }>).some(
+			({ code }) => code === "response-telemetry-unavailable",
+		),
+	);
 });
 
 test("defaults to a concise agent report and supports targeted, control, bundle, and command routes", async () => {
@@ -605,6 +687,54 @@ test("clears unmatched provider requests before attributing responses in a later
 		status: 200,
 		responseHeaderLatencyMs: 25,
 	});
+});
+
+test("keeps retry responses attached until the final provider response", async () => {
+	const harness = createHarness({ modelApi: "openai-codex-responses" });
+	await harness.emit("session_start", {});
+	harness.setTime(2_000);
+	await harness.emit("before_provider_request", { payload: { tools: [{ name: "read" }] } });
+	harness.setTime(2_010);
+	await harness.emit("after_provider_response", { status: 429, headers: {} });
+	harness.setTime(2_050);
+	await harness.emit("after_provider_response", { status: 200, headers: {} });
+
+	const shown = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-retry",
+				{ action: "show" },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	const provider = (shown.details as Record<string, unknown>).providerRequestCapture as {
+		latest: {
+			requestIndex: number;
+			responseTelemetry: string;
+			response: { status: number; responseHeaderLatencyMs: number };
+		};
+		performance: {
+			completedRequestCount: number;
+			pendingRequestCount: number;
+			statusCounts: Record<string, number>;
+		};
+	};
+	assert.equal(provider.latest.requestIndex, 1);
+	assert.equal(provider.latest.responseTelemetry, "received");
+	assert.equal(provider.latest.response.status, 200);
+	assert.equal(provider.latest.response.responseHeaderLatencyMs, 50);
+	assert.equal(provider.performance.completedRequestCount, 1);
+	assert.equal(provider.performance.pendingRequestCount, 0);
+	assert.deepEqual(provider.performance.statusCounts, { "200": 1 });
+	assert.equal(
+		harness.entries.filter(
+			(entry) => entry.type === "custom" && entry.customType === PROVIDER_RESPONSE_ENTRY_TYPE,
+		).length,
+		2,
+	);
 });
 
 test("marks Google response telemetry unsupported instead of pending", async () => {

--- a/.pi/extensions/runtime-diagnostics/index.ts
+++ b/.pi/extensions/runtime-diagnostics/index.ts
@@ -1,47 +1,59 @@
 import { StringEnum } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import {
+	type CaptureControlAction,
+	CONTROL_ENTRY_TYPE,
+	createCaptureState,
+	createControlEntry,
+	MAX_CAPTURE_AGE_MINUTES,
+	MAX_CAPTURE_RECORDS,
+	PROVIDER_REQUEST_ENTRY_TYPE,
+	PROVIDER_RESPONSE_ENTRY_TYPE,
+	type ProviderCaptureState,
+	pruneCaptureState,
+	restoreCaptureState,
+} from "./capture-state.js";
+import {
+	attachProviderResponse,
+	createProviderResponseDiagnostic,
 	extractProviderRequestDiagnostic,
-	isProviderRequestDiagnostic,
-	type ProviderRequestDiagnostic,
 } from "./provider-request.js";
 import {
-	createRuntimeReport,
+	boundDiagnosticResponse,
+	createDiagnosticResponse,
+	DIAGNOSTIC_ACTIONS,
+	DIAGNOSTIC_DETAILS,
+	DIAGNOSTIC_SECTIONS,
+	type DiagnosticAction,
+	type DiagnosticSection,
+	formatCommandSummary,
+} from "./report.js";
+import {
 	createRuntimeSnapshot,
 	RUNTIME_ENTRY_TYPE,
 	type RuntimeSnapshotReason,
 	runtimeStateSignature,
 } from "./snapshot.js";
 
-export const PROVIDER_REQUEST_ENTRY_TYPE = "pi-debug:provider-request";
-export const CONTROL_ENTRY_TYPE = "pi-debug:control";
-const TOOL_NAME = "runtime_diagnostics";
-const MAX_SHOW_RECORDS = 20;
-const MAX_OUTPUT_BYTES = 50 * 1024;
-const PROVIDER_HOOK_LIMITATIONS = [
-	"before_provider_request exposes the serialized payload at this extension's position in handler load order; later extensions can still replace it.",
-	"The hook does not prove that the provider accepted or executed the exposed tools.",
-	"ExtensionAPI cannot enumerate passive event-only extensions, so extension visibility is limited to public tool and command surfaces.",
-];
+export { CONTROL_ENTRY_TYPE, PROVIDER_REQUEST_ENTRY_TYPE, PROVIDER_RESPONSE_ENTRY_TYPE };
 
-const ACTIONS = ["status", "enable", "disable", "latest", "show", "compare", "clear"] as const;
-type DebugAction = (typeof ACTIONS)[number];
+const TOOL_NAME = "runtime_diagnostics";
+const COMMAND_NAME = "runtime-diagnostics";
+const MAX_SHOW_RECORDS = 20;
+const COMMAND_ROUTES = [
+	"status",
+	"provider",
+	"cache",
+	"tools",
+	"extensions",
+	"privacy",
+	"help",
+] as const;
+type CommandRoute = (typeof COMMAND_ROUTES)[number];
 
 interface DebugDependencies {
 	now(): number;
-}
-
-interface ControlEntry {
-	version: 1;
-	capturedAt: number;
-	action: "enable" | "disable" | "clear";
-}
-
-interface ProviderCaptureState {
-	enabled: boolean;
-	records: ProviderRequestDiagnostic[];
-	nextRequestIndex: number;
 }
 
 export function createDebugExtension(
@@ -49,41 +61,85 @@ export function createDebugExtension(
 ): (pi: ExtensionAPI) => void {
 	const now = dependencies.now ?? Date.now;
 	return function debugExtension(pi: ExtensionAPI): void {
-		let capture: ProviderCaptureState = { enabled: true, records: [], nextRequestIndex: 1 };
+		let capture: ProviderCaptureState = createCaptureState();
 		let lastRuntimeSignature: string | undefined;
 
 		pi.registerTool({
 			name: TOOL_NAME,
 			label: "Runtime Diagnostics",
 			description:
-				"Inspect and manage privacy-filtered runtime diagnostics for model routing, prompt-cache performance, tool availability, visible extension surfaces, and tools exposed in provider requests.",
+				"Inspect and manage privacy-filtered runtime diagnostics for model routing, cache performance, tool availability and provenance, visible extension surfaces, provider request exposure and timing, retention, comparisons, and shareable bundles. Output is bounded to 50 KB and 2,000 lines.",
 			promptSnippet:
 				"Inspect model, cache, tool, extension-surface, and provider-request diagnostics",
 			promptGuidelines: [
-				"Use runtime_diagnostics when model routing, prompt caching, tool availability, deferred tool loading, or extension registration may be misconfigured.",
+				"Use runtime_diagnostics when model routing, prompt caching, tool availability, deferred tool loading, provider exposure, or extension registration may be misconfigured.",
+				"Start with runtime_diagnostics status and request full or selected sections only when the concise findings need more evidence.",
 			],
 			parameters: Type.Object({
 				action: Type.Optional(
-					StringEnum(ACTIONS, {
+					StringEnum(DIAGNOSTIC_ACTIONS, {
 						description:
-							"status (default), enable/disable provider-request capture, latest, show, compare, or clear captured provider-request diagnostics",
+							"status (default), capture controls, latest/show/compare, retention configure, or a full sanitized bundle",
+					}),
+				),
+				detail: Type.Optional(
+					StringEnum(DIAGNOSTIC_DETAILS, {
+						description: "summary (default) or full diagnostic detail",
+					}),
+				),
+				sections: Type.Optional(
+					Type.Array(StringEnum(DIAGNOSTIC_SECTIONS), {
+						uniqueItems: true,
+						maxItems: DIAGNOSTIC_SECTIONS.length,
+						description: "Optional detail sections to include without requesting the full report",
 					}),
 				),
 				limit: Type.Optional(
 					Type.Integer({
 						minimum: 1,
 						maximum: MAX_SHOW_RECORDS,
-						description: "Maximum provider-request records returned by show",
+						description: "Maximum provider-request records returned by show or bundle",
+					}),
+				),
+				maxRecords: Type.Optional(
+					Type.Integer({
+						minimum: 1,
+						maximum: MAX_CAPTURE_RECORDS,
+						description: "configure only: maximum records in the active reporting window",
+					}),
+				),
+				maxAgeMinutes: Type.Optional(
+					Type.Integer({
+						minimum: 1,
+						maximum: MAX_CAPTURE_AGE_MINUTES,
+						description: "configure only: maximum record age in the active reporting window",
 					}),
 				),
 			}),
 			async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 				signal?.throwIfAborted();
-				const action: DebugAction = params.action ?? "status";
-				applyControl(action);
+				const action: DiagnosticAction = params.action ?? "status";
+				validateRetentionParameters(action, params.maxRecords, params.maxAgeMinutes);
+				if (isControlAction(action)) {
+					const control = createControlEntry(capture, action, now(), {
+						maxRecords: params.maxRecords,
+						maxAgeMinutes: params.maxAgeMinutes,
+					});
+					pi.appendEntry(CONTROL_ENTRY_TYPE, control);
+				}
+				pruneCaptureState(capture, now());
 				recordRuntime(ctx, "diagnostic_tool", false);
-				const response = createToolResponse(action, params.limit ?? 10, pi, ctx, capture, now());
-				const bounded = boundResponse(response);
+				const response = createDiagnosticResponse({
+					action,
+					detail: params.detail ?? "summary",
+					sections: params.sections ?? [],
+					limit: params.limit ?? 10,
+					pi,
+					ctx,
+					capture,
+					capturedAt: now(),
+				});
+				const bounded = boundDiagnosticResponse(response);
 				return {
 					content: [{ type: "text", text: bounded.text }],
 					details: bounded.value,
@@ -91,8 +147,48 @@ export function createDebugExtension(
 			},
 		});
 
+		pi.registerCommand(COMMAND_NAME, {
+			description: "Show a concise privacy-filtered runtime diagnostic summary",
+			getArgumentCompletions(prefix) {
+				const normalized = prefix.trimStart();
+				if (normalized.includes(" ")) return null;
+				const matches = COMMAND_ROUTES.filter((route) => route.startsWith(normalized)).map(
+					(route) => ({ value: route, label: route }),
+				);
+				return matches.length > 0 ? matches : null;
+			},
+			async handler(args, ctx) {
+				if (!ctx.hasUI) {
+					throw new Error(
+						`/${COMMAND_NAME} supports TUI and RPC modes only; use the ${TOOL_NAME} tool for machine-readable diagnostics.`,
+					);
+				}
+				const route = parseCommandRoute(args);
+				const sections: DiagnosticSection[] =
+					route === "provider" ||
+					route === "cache" ||
+					route === "tools" ||
+					route === "extensions" ||
+					route === "privacy"
+						? [route]
+						: [];
+				pruneCaptureState(capture, now());
+				const response = createDiagnosticResponse({
+					action: "status",
+					detail: "summary",
+					sections,
+					limit: 5,
+					pi,
+					ctx,
+					capture,
+					capturedAt: now(),
+				});
+				ctx.ui.notify(formatCommandSummary(response, route), "info");
+			},
+		});
+
 		pi.on("session_start", (_event, ctx) => {
-			capture = restoreCaptureState(ctx.sessionManager.getBranch());
+			capture = restoreCaptureState(ctx.sessionManager.getBranch(), now());
 			lastRuntimeSignature = undefined;
 			recordRuntime(ctx, "session_start", true);
 		});
@@ -131,7 +227,19 @@ export function createDebugExtension(
 			});
 			capture.nextRequestIndex += 1;
 			capture.records.push(diagnostic);
+			capture.pendingRequestIndexes.push(diagnostic.requestIndex);
+			pruneCaptureState(capture, now());
 			pi.appendEntry(PROVIDER_REQUEST_ENTRY_TYPE, diagnostic);
+		});
+
+		pi.on("after_provider_response", (event) => {
+			const requestIndex = capture.pendingRequestIndexes.shift();
+			if (requestIndex === undefined) return;
+			const request = capture.records.find((record) => record.requestIndex === requestIndex);
+			if (!request) return;
+			const response = createProviderResponseDiagnostic(request, event.status, now());
+			attachProviderResponse(request, response);
+			pi.appendEntry(PROVIDER_RESPONSE_ENTRY_TYPE, response);
 		});
 
 		function recordRuntime(
@@ -145,180 +253,41 @@ export function createDebugExtension(
 			lastRuntimeSignature = signature;
 			pi.appendEntry(RUNTIME_ENTRY_TYPE, snapshot);
 		}
-
-		function applyControl(action: DebugAction): void {
-			if (action !== "enable" && action !== "disable" && action !== "clear") return;
-			if (action === "enable") capture.enabled = true;
-			if (action === "disable") capture.enabled = false;
-			if (action === "clear") capture.records = [];
-			const control: ControlEntry = { version: 1, capturedAt: now(), action };
-			pi.appendEntry(CONTROL_ENTRY_TYPE, control);
-		}
 	};
 }
 
-function createToolResponse(
-	action: DebugAction,
-	limit: number,
-	pi: ExtensionAPI,
-	ctx: ExtensionContext,
-	capture: ProviderCaptureState,
-	capturedAt: number,
-) {
-	const recent = action === "show" ? capture.records.slice(-limit) : [];
-	const latest =
-		action === "latest" || action === "status" || action === "enable" || action === "disable"
-			? (capture.records.at(-1) ?? null)
-			: null;
-	const comparisonRecords = selectComparisonRecords(action, recent, capture.records);
-	return {
-		action,
-		providerRequestCapture: {
-			enabled: capture.enabled,
-			recordCountSinceClear: capture.records.length,
-			latest,
-			recent,
-			comparison:
-				comparisonRecords.length === 2
-					? compareProviderRequests(comparisonRecords[0], comparisonRecords[1])
-					: null,
-		},
-		runtime: createRuntimeReport(pi, ctx, capturedAt),
-		privacy:
-			"Records contain only timestamp, session ID, provider/model IDs, the plan marker boolean, and extracted tool names. Prompts, schemas, arguments, headers, credentials, and message contents are not retained.",
-		limitations: PROVIDER_HOOK_LIMITATIONS,
-	};
-}
-
-function selectComparisonRecords(
-	action: DebugAction,
-	recent: readonly ProviderRequestDiagnostic[],
-	all: readonly ProviderRequestDiagnostic[],
-): readonly ProviderRequestDiagnostic[] {
-	if (all.length < 2) return [];
-	if (action === "compare") return [all[0], all[all.length - 1]];
-	if (action === "show" && recent.length >= 2) {
-		return [recent[0], recent[recent.length - 1]];
-	}
-	return all.slice(-2);
-}
-
-function compareProviderRequests(from: ProviderRequestDiagnostic, to: ProviderRequestDiagnostic) {
-	return {
-		fromRequestIndex: from.requestIndex,
-		toRequestIndex: to.requestIndex,
-		providerChanged: from.provider !== to.provider,
-		modelChanged: from.model !== to.model,
-		planModeMarkerChanged: from.planModeMarkerPresent !== to.planModeMarkerPresent,
-		topLevelTools: diffNames(from.topLevelToolNames, to.topLevelToolNames),
-		transcriptTools: diffNames(from.transcriptToolNames, to.transcriptToolNames),
-	};
-}
-
-function diffNames(from: readonly string[], to: readonly string[]) {
-	const previous = new Set(from);
-	const current = new Set(to);
-	return {
-		added: to.filter((name) => !previous.has(name)),
-		removed: from.filter((name) => !current.has(name)),
-	};
-}
-
-function restoreCaptureState(entries: readonly SessionEntry[]): ProviderCaptureState {
-	const state: ProviderCaptureState = { enabled: true, records: [], nextRequestIndex: 1 };
-	let maximumRequestIndex = 0;
-	for (const entry of entries) {
-		if (entry.type !== "custom") continue;
-		if (
-			entry.customType === PROVIDER_REQUEST_ENTRY_TYPE &&
-			isProviderRequestDiagnostic(entry.data)
-		) {
-			maximumRequestIndex = Math.max(maximumRequestIndex, entry.data.requestIndex);
-			state.records.push(entry.data);
-			continue;
-		}
-		if (entry.customType !== CONTROL_ENTRY_TYPE || !isControlEntry(entry.data)) continue;
-		if (entry.data.action === "enable") state.enabled = true;
-		if (entry.data.action === "disable") state.enabled = false;
-		if (entry.data.action === "clear") state.records = [];
-	}
-	state.nextRequestIndex = maximumRequestIndex + 1;
-	return state;
-}
-
-function isControlEntry(value: unknown): value is ControlEntry {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-	const record = value as Record<string, unknown>;
+function isControlAction(action: DiagnosticAction): action is CaptureControlAction {
 	return (
-		record.version === 1 &&
-		typeof record.capturedAt === "number" &&
-		(record.action === "enable" || record.action === "disable" || record.action === "clear")
+		action === "enable" || action === "disable" || action === "clear" || action === "configure"
 	);
 }
 
-function boundResponse(value: ReturnType<typeof createToolResponse>): {
-	value: unknown;
-	text: string;
-} {
-	let text = JSON.stringify(value, null, 2);
-	if (Buffer.byteLength(text, "utf8") <= MAX_OUTPUT_BYTES) return { value, text };
-
-	const compact = {
-		...value,
-		providerRequestCapture: {
-			...value.providerRequestCapture,
-			recent: value.providerRequestCapture.recent.slice(-2).map(compactProviderRecord),
-			latest: value.providerRequestCapture.latest
-				? compactProviderRecord(value.providerRequestCapture.latest)
-				: null,
-		},
-		runtime: {
-			...value.runtime,
-			extensions: {
-				...value.runtime.extensions,
-				surfaces: [],
-				outputNote: "Extension surface details omitted to keep tool output below 50 KB.",
-			},
-			recentRuntimeRecords: value.runtime.recentRuntimeRecords.slice(-5),
-		},
-		outputNote: "Large diagnostic arrays were compacted to keep tool output below 50 KB.",
-	};
-	text = JSON.stringify(compact, null, 2);
-	if (Buffer.byteLength(text, "utf8") <= MAX_OUTPUT_BYTES) return { value: compact, text };
-
-	const minimal = {
-		action: value.action,
-		providerRequestCapture: {
-			enabled: value.providerRequestCapture.enabled,
-			recordCountSinceClear: value.providerRequestCapture.recordCountSinceClear,
-			latest: value.providerRequestCapture.latest
-				? compactProviderRecord(value.providerRequestCapture.latest)
-				: null,
-			comparison: value.providerRequestCapture.comparison,
-		},
-		runtime: {
-			capturedAt: value.runtime.capturedAt,
-			sessionId: value.runtime.sessionId,
-			current: value.runtime.current,
-			cache: value.runtime.cache,
-			tools: value.runtime.tools,
-			issues: value.runtime.issues,
-		},
-		privacy: value.privacy,
-		limitations: value.limitations,
-		outputNote: "Only the bounded diagnostic summary is shown.",
-	};
-	return { value: minimal, text: JSON.stringify(minimal, null, 2) };
+function validateRetentionParameters(
+	action: DiagnosticAction,
+	maxRecords: number | undefined,
+	maxAgeMinutes: number | undefined,
+): void {
+	const hasPolicy = maxRecords !== undefined || maxAgeMinutes !== undefined;
+	if (action === "configure" && !hasPolicy) {
+		throw new Error("runtime_diagnostics configure requires maxRecords or maxAgeMinutes.");
+	}
+	if (action !== "configure" && hasPolicy) {
+		throw new Error(
+			"runtime_diagnostics maxRecords and maxAgeMinutes are accepted only with action configure.",
+		);
+	}
 }
 
-function compactProviderRecord(record: ProviderRequestDiagnostic) {
-	return {
-		...record,
-		topLevelToolCount: record.topLevelToolNames.length,
-		topLevelToolNames: record.topLevelToolNames.slice(0, 20),
-		transcriptToolCount: record.transcriptToolNames.length,
-		transcriptToolNames: record.transcriptToolNames.slice(0, 20),
-	};
+function parseCommandRoute(args: string): CommandRoute {
+	const normalized = args.trim();
+	if (!normalized) return "status";
+	const parts = normalized.split(/\s+/);
+	if (parts.length !== 1 || !COMMAND_ROUTES.includes(parts[0] as CommandRoute)) {
+		throw new Error(
+			`Unknown /${COMMAND_NAME} route. Expected one of: ${COMMAND_ROUTES.join(", ")}.`,
+		);
+	}
+	return parts[0] as CommandRoute;
 }
 
 export default createDebugExtension();

--- a/.pi/extensions/runtime-diagnostics/index.ts
+++ b/.pi/extensions/runtime-diagnostics/index.ts
@@ -242,13 +242,16 @@ export function createDebugExtension(
 		});
 
 		pi.on("after_provider_response", (event) => {
-			const requestIndex = capture.pendingRequestIndexes.shift();
+			const requestIndex = capture.pendingRequestIndexes[0];
 			if (requestIndex === undefined) return;
 			const request = capture.records.find((record) => record.requestIndex === requestIndex);
 			if (!request) return;
 			const response = createProviderResponseDiagnostic(request, event.status, now());
 			attachProviderResponse(request, response);
 			pi.appendEntry(PROVIDER_RESPONSE_ENTRY_TYPE, response);
+			if (event.status >= 200 && event.status < 300) {
+				capture.pendingRequestIndexes.shift();
+			}
 		});
 
 		function restoreBranchState(

--- a/.pi/extensions/runtime-diagnostics/index.ts
+++ b/.pi/extensions/runtime-diagnostics/index.ts
@@ -188,9 +188,11 @@ export function createDebugExtension(
 		});
 
 		pi.on("session_start", (_event, ctx) => {
-			capture = restoreCaptureState(ctx.sessionManager.getBranch(), now());
-			lastRuntimeSignature = undefined;
-			recordRuntime(ctx, "session_start", true);
+			restoreBranchState(ctx, "session_start");
+		});
+
+		pi.on("session_tree", (_event, ctx) => {
+			restoreBranchState(ctx, "session_tree");
 		});
 
 		pi.on("model_select", (_event, ctx) => {
@@ -228,10 +230,13 @@ export function createDebugExtension(
 				sessionId: ctx.sessionManager.getSessionId(),
 				provider: ctx.model?.provider,
 				model: ctx.model?.id,
+				api: ctx.model?.api,
 			});
 			capture.nextRequestIndex += 1;
 			capture.records.push(diagnostic);
-			capture.pendingRequestIndexes.push(diagnostic.requestIndex);
+			if (diagnostic.responseTelemetry === "pending") {
+				capture.pendingRequestIndexes.push(diagnostic.requestIndex);
+			}
 			pruneCaptureState(capture, now());
 			pi.appendEntry(PROVIDER_REQUEST_ENTRY_TYPE, diagnostic);
 		});
@@ -245,6 +250,15 @@ export function createDebugExtension(
 			attachProviderResponse(request, response);
 			pi.appendEntry(PROVIDER_RESPONSE_ENTRY_TYPE, response);
 		});
+
+		function restoreBranchState(
+			ctx: ExtensionContext,
+			reason: "session_start" | "session_tree",
+		): void {
+			capture = restoreCaptureState(ctx.sessionManager.getBranch(), now());
+			lastRuntimeSignature = undefined;
+			recordRuntime(ctx, reason, true);
+		}
 
 		function recordRuntime(
 			ctx: ExtensionContext,

--- a/.pi/extensions/runtime-diagnostics/index.ts
+++ b/.pi/extensions/runtime-diagnostics/index.ts
@@ -205,6 +205,10 @@ export function createDebugExtension(
 			recordRuntime(ctx, "tools_changed", false);
 		});
 
+		pi.on("agent_end", () => {
+			capture.pendingRequestIndexes = [];
+		});
+
 		pi.on("message_end", (event, ctx) => {
 			if (event.message.role !== "assistant") return;
 			const snapshot = createRuntimeSnapshot(pi, ctx, "assistant_message", now(), {

--- a/.pi/extensions/runtime-diagnostics/provider-request.ts
+++ b/.pi/extensions/runtime-diagnostics/provider-request.ts
@@ -1,17 +1,30 @@
+import { sanitizeDiagnosticText } from "./text.js";
+
 const PLAN_MODE_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
 const MAX_TOOL_NAMES = 200;
 const MAX_TOOL_NAME_LENGTH = 128;
 
 export interface ProviderRequestDiagnostic {
-	version: 1;
+	version: 2;
 	requestIndex: number;
 	capturedAt: number;
 	sessionId: string;
 	provider: string | null;
 	model: string | null;
 	planModeMarkerPresent: boolean;
+	requestBytes: number | null;
+	toolDefinitionBytes: number | null;
 	topLevelToolNames: string[];
 	transcriptToolNames: string[];
+	response: ProviderResponseDiagnostic | null;
+}
+
+export interface ProviderResponseDiagnostic {
+	version: 1;
+	requestIndex: number;
+	capturedAt: number;
+	status: number;
+	responseHeaderLatencyMs: number;
 }
 
 export interface ProviderRequestIdentity {
@@ -28,25 +41,109 @@ export function extractProviderRequestDiagnostic(
 ): ProviderRequestDiagnostic {
 	const root = asRecord(payload);
 	return {
-		version: 1,
+		version: 2,
 		requestIndex: identity.requestIndex,
 		capturedAt: identity.capturedAt,
-		sessionId: identity.sessionId,
-		provider: identity.provider ?? null,
-		model: identity.model ?? null,
+		sessionId: sanitizeDiagnosticText(identity.sessionId, 128),
+		provider: identity.provider ? sanitizeDiagnosticText(identity.provider, 128) : null,
+		model: identity.model ? sanitizeDiagnosticText(identity.model, 256) : null,
 		planModeMarkerPresent: containsMarker(root?.instructions),
+		requestBytes: jsonByteLength(payload),
+		toolDefinitionBytes: jsonByteLength(root?.tools),
 		topLevelToolNames: extractToolNames(root?.tools),
 		transcriptToolNames: extractTranscriptToolNames(root?.input),
+		response: null,
 	};
 }
 
-export function isProviderRequestDiagnostic(value: unknown): value is ProviderRequestDiagnostic {
+export function createProviderResponseDiagnostic(
+	request: ProviderRequestDiagnostic,
+	status: number,
+	capturedAt: number,
+): ProviderResponseDiagnostic {
+	return {
+		version: 1,
+		requestIndex: request.requestIndex,
+		capturedAt,
+		status: Number.isInteger(status) ? status : 0,
+		responseHeaderLatencyMs: Math.max(0, capturedAt - request.capturedAt),
+	};
+}
+
+export function normalizeProviderRequestDiagnostic(
+	value: unknown,
+): ProviderRequestDiagnostic | undefined {
+	const record = asRecord(value);
+	if (!isProviderRequestBase(record)) return undefined;
+	if (record.version === 1) {
+		return {
+			version: 2,
+			requestIndex: record.requestIndex as number,
+			capturedAt: record.capturedAt as number,
+			sessionId: sanitizeDiagnosticText(record.sessionId as string, 128),
+			provider:
+				typeof record.provider === "string" ? sanitizeDiagnosticText(record.provider, 128) : null,
+			model: typeof record.model === "string" ? sanitizeDiagnosticText(record.model, 256) : null,
+			planModeMarkerPresent: record.planModeMarkerPresent as boolean,
+			requestBytes: null,
+			toolDefinitionBytes: null,
+			topLevelToolNames: normalizeNames(record.topLevelToolNames as string[]),
+			transcriptToolNames: normalizeNames(record.transcriptToolNames as string[]),
+			response: null,
+		};
+	}
+	if (
+		record.version !== 2 ||
+		!isNullableFiniteNumber(record.requestBytes) ||
+		!isNullableFiniteNumber(record.toolDefinitionBytes) ||
+		!(record.response === null || isProviderResponseDiagnostic(record.response))
+	) {
+		return undefined;
+	}
+	return {
+		version: 2,
+		requestIndex: record.requestIndex as number,
+		capturedAt: record.capturedAt as number,
+		sessionId: sanitizeDiagnosticText(record.sessionId as string, 128),
+		provider:
+			typeof record.provider === "string" ? sanitizeDiagnosticText(record.provider, 128) : null,
+		model: typeof record.model === "string" ? sanitizeDiagnosticText(record.model, 256) : null,
+		planModeMarkerPresent: record.planModeMarkerPresent as boolean,
+		requestBytes: record.requestBytes as number | null,
+		toolDefinitionBytes: record.toolDefinitionBytes as number | null,
+		topLevelToolNames: normalizeNames(record.topLevelToolNames as string[]),
+		transcriptToolNames: normalizeNames(record.transcriptToolNames as string[]),
+		response: record.response as ProviderResponseDiagnostic | null,
+	};
+}
+
+export function isProviderResponseDiagnostic(value: unknown): value is ProviderResponseDiagnostic {
 	const record = asRecord(value);
 	return (
 		record?.version === 1 &&
-		typeof record.requestIndex === "number" &&
-		Number.isInteger(record.requestIndex) &&
-		typeof record.capturedAt === "number" &&
+		isNonNegativeInteger(record.requestIndex) &&
+		isFiniteNumber(record.capturedAt) &&
+		isNonNegativeInteger(record.status) &&
+		isFiniteNumber(record.responseHeaderLatencyMs) &&
+		record.responseHeaderLatencyMs >= 0
+	);
+}
+
+export function attachProviderResponse(
+	request: ProviderRequestDiagnostic,
+	response: ProviderResponseDiagnostic,
+): void {
+	if (request.requestIndex !== response.requestIndex) return;
+	request.response = response;
+}
+
+function isProviderRequestBase(
+	record: Record<string, unknown> | undefined,
+): record is Record<string, unknown> {
+	return (
+		(record?.version === 1 || record?.version === 2) &&
+		isNonNegativeInteger(record.requestIndex) &&
+		isFiniteNumber(record.capturedAt) &&
 		typeof record.sessionId === "string" &&
 		(record.provider === null || typeof record.provider === "string") &&
 		(record.model === null || typeof record.model === "string") &&
@@ -70,7 +167,7 @@ function extractTranscriptToolNames(input: unknown): string[] {
 			names.push(...extractToolNames(Array.isArray(record.output) ? record.output : output?.tools));
 		}
 	}
-	return uniqueNames(names);
+	return normalizeNames(names);
 }
 
 function extractToolNames(value: unknown): string[] {
@@ -84,7 +181,7 @@ function extractToolNames(value: unknown): string[] {
 		const name = firstName(record.name, functionDefinition?.name, customDefinition?.name);
 		if (name) names.push(name);
 	}
-	return uniqueNames(names);
+	return normalizeNames(names);
 }
 
 function containsMarker(value: unknown): boolean {
@@ -98,23 +195,42 @@ function containsMarker(value: unknown): boolean {
 function firstName(...values: unknown[]): string | undefined {
 	for (const value of values) {
 		if (typeof value !== "string") continue;
-		const normalized = value.trim();
-		if (!normalized) continue;
-		return normalized.length > MAX_TOOL_NAME_LENGTH
-			? `${normalized.slice(0, MAX_TOOL_NAME_LENGTH - 1)}…`
-			: normalized;
+		const normalized = sanitizeDiagnosticText(value, MAX_TOOL_NAME_LENGTH);
+		if (normalized) return normalized;
 	}
 	return undefined;
 }
 
-function uniqueNames(names: readonly string[]): string[] {
-	return [...new Set(names)]
+function normalizeNames(names: readonly string[]): string[] {
+	return [...new Set(names.map((name) => sanitizeDiagnosticText(name, MAX_TOOL_NAME_LENGTH)))]
+		.filter(Boolean)
 		.sort((left, right) => left.localeCompare(right))
 		.slice(0, MAX_TOOL_NAMES);
 }
 
+function jsonByteLength(value: unknown): number | null {
+	if (value === undefined) return 0;
+	try {
+		return Buffer.byteLength(JSON.stringify(value), "utf8");
+	} catch {
+		return null;
+	}
+}
+
 function isStringArray(value: unknown): value is string[] {
 	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNullableFiniteNumber(value: unknown): value is number | null {
+	return value === null || isFiniteNumber(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/.pi/extensions/runtime-diagnostics/provider-request.ts
+++ b/.pi/extensions/runtime-diagnostics/provider-request.ts
@@ -4,8 +4,10 @@ const PLAN_MODE_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
 const MAX_TOOL_NAMES = 200;
 const MAX_TOOL_NAME_LENGTH = 128;
 
+export type ResponseTelemetryState = "pending" | "received" | "unsupported";
+
 export interface ProviderRequestDiagnostic {
-	version: 2;
+	version: 3;
 	requestIndex: number;
 	capturedAt: number;
 	sessionId: string;
@@ -16,6 +18,7 @@ export interface ProviderRequestDiagnostic {
 	toolDefinitionBytes: number | null;
 	topLevelToolNames: string[];
 	transcriptToolNames: string[];
+	responseTelemetry: ResponseTelemetryState;
 	response: ProviderResponseDiagnostic | null;
 }
 
@@ -33,6 +36,7 @@ export interface ProviderRequestIdentity {
 	sessionId: string;
 	provider?: string;
 	model?: string;
+	api?: string;
 }
 
 export function extractProviderRequestDiagnostic(
@@ -40,18 +44,23 @@ export function extractProviderRequestDiagnostic(
 	identity: ProviderRequestIdentity,
 ): ProviderRequestDiagnostic {
 	const root = asRecord(payload);
+	const config = asRecord(root?.config);
 	return {
-		version: 2,
+		version: 3,
 		requestIndex: identity.requestIndex,
 		capturedAt: identity.capturedAt,
 		sessionId: sanitizeDiagnosticText(identity.sessionId, 128),
 		provider: identity.provider ? sanitizeDiagnosticText(identity.provider, 128) : null,
 		model: identity.model ? sanitizeDiagnosticText(identity.model, 256) : null,
-		planModeMarkerPresent: containsMarker(root?.instructions),
+		planModeMarkerPresent:
+			containsMarker(root?.instructions) ||
+			containsMarker(config?.systemInstruction) ||
+			containsMarker(root?.system),
 		requestBytes: jsonByteLength(payload),
-		toolDefinitionBytes: jsonByteLength(root?.tools),
-		topLevelToolNames: extractToolNames(root?.tools),
+		toolDefinitionBytes: jsonByteLength(extractProviderToolDefinitions(root)),
+		topLevelToolNames: extractProviderToolNames(root),
 		transcriptToolNames: extractTranscriptToolNames(root?.input),
+		responseTelemetry: responseTelemetryState(identity.api),
 		response: null,
 	};
 }
@@ -75,9 +84,13 @@ export function normalizeProviderRequestDiagnostic(
 ): ProviderRequestDiagnostic | undefined {
 	const record = asRecord(value);
 	if (!isProviderRequestBase(record)) return undefined;
-	if (record.version === 1) {
+	if (record.version === 1 || record.version === 2) {
+		const response =
+			record.version === 2 && isProviderResponseDiagnostic(record.response)
+				? record.response
+				: null;
 		return {
-			version: 2,
+			version: 3,
 			requestIndex: record.requestIndex as number,
 			capturedAt: record.capturedAt as number,
 			sessionId: sanitizeDiagnosticText(record.sessionId as string, 128),
@@ -85,23 +98,32 @@ export function normalizeProviderRequestDiagnostic(
 				typeof record.provider === "string" ? sanitizeDiagnosticText(record.provider, 128) : null,
 			model: typeof record.model === "string" ? sanitizeDiagnosticText(record.model, 256) : null,
 			planModeMarkerPresent: record.planModeMarkerPresent as boolean,
-			requestBytes: null,
-			toolDefinitionBytes: null,
+			requestBytes:
+				record.version === 2 && isNullableFiniteNumber(record.requestBytes)
+					? record.requestBytes
+					: null,
+			toolDefinitionBytes:
+				record.version === 2 && isNullableFiniteNumber(record.toolDefinitionBytes)
+					? record.toolDefinitionBytes
+					: null,
 			topLevelToolNames: normalizeNames(record.topLevelToolNames as string[]),
 			transcriptToolNames: normalizeNames(record.transcriptToolNames as string[]),
-			response: null,
+			responseTelemetry: response ? "received" : "pending",
+			response,
 		};
 	}
 	if (
-		record.version !== 2 ||
+		record.version !== 3 ||
 		!isNullableFiniteNumber(record.requestBytes) ||
 		!isNullableFiniteNumber(record.toolDefinitionBytes) ||
-		!(record.response === null || isProviderResponseDiagnostic(record.response))
+		!isResponseTelemetryState(record.responseTelemetry) ||
+		!(record.response === null || isProviderResponseDiagnostic(record.response)) ||
+		(record.responseTelemetry === "received") !== isProviderResponseDiagnostic(record.response)
 	) {
 		return undefined;
 	}
 	return {
-		version: 2,
+		version: 3,
 		requestIndex: record.requestIndex as number,
 		capturedAt: record.capturedAt as number,
 		sessionId: sanitizeDiagnosticText(record.sessionId as string, 128),
@@ -109,10 +131,11 @@ export function normalizeProviderRequestDiagnostic(
 			typeof record.provider === "string" ? sanitizeDiagnosticText(record.provider, 128) : null,
 		model: typeof record.model === "string" ? sanitizeDiagnosticText(record.model, 256) : null,
 		planModeMarkerPresent: record.planModeMarkerPresent as boolean,
-		requestBytes: record.requestBytes as number | null,
-		toolDefinitionBytes: record.toolDefinitionBytes as number | null,
+		requestBytes: record.requestBytes,
+		toolDefinitionBytes: record.toolDefinitionBytes,
 		topLevelToolNames: normalizeNames(record.topLevelToolNames as string[]),
 		transcriptToolNames: normalizeNames(record.transcriptToolNames as string[]),
+		responseTelemetry: record.responseTelemetry,
 		response: record.response as ProviderResponseDiagnostic | null,
 	};
 }
@@ -134,6 +157,7 @@ export function attachProviderResponse(
 	response: ProviderResponseDiagnostic,
 ): void {
 	if (request.requestIndex !== response.requestIndex) return;
+	request.responseTelemetry = "received";
 	request.response = response;
 }
 
@@ -141,7 +165,7 @@ function isProviderRequestBase(
 	record: Record<string, unknown> | undefined,
 ): record is Record<string, unknown> {
 	return (
-		(record?.version === 1 || record?.version === 2) &&
+		(record?.version === 1 || record?.version === 2 || record?.version === 3) &&
 		isNonNegativeInteger(record.requestIndex) &&
 		isFiniteNumber(record.capturedAt) &&
 		typeof record.sessionId === "string" &&
@@ -151,6 +175,35 @@ function isProviderRequestBase(
 		isStringArray(record.topLevelToolNames) &&
 		isStringArray(record.transcriptToolNames)
 	);
+}
+
+function extractProviderToolDefinitions(root: Record<string, unknown> | undefined): unknown {
+	const config = asRecord(root?.config);
+	const toolConfig = asRecord(root?.toolConfig);
+	return root?.tools ?? config?.tools ?? toolConfig?.tools;
+}
+
+function extractProviderToolNames(root: Record<string, unknown> | undefined): string[] {
+	const config = asRecord(root?.config);
+	const toolConfig = asRecord(root?.toolConfig);
+	return normalizeNames([
+		...extractToolNames(root?.tools),
+		...extractGoogleToolNames(config?.tools),
+		...extractBedrockToolNames(toolConfig?.tools),
+	]);
+}
+
+function extractGoogleToolNames(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.flatMap((group) => extractToolNames(asRecord(group)?.functionDeclarations));
+}
+
+function extractBedrockToolNames(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.flatMap((candidate) => {
+		const name = firstName(asRecord(asRecord(candidate)?.toolSpec)?.name);
+		return name ? [name] : [];
+	});
 }
 
 function extractTranscriptToolNames(input: unknown): string[] {
@@ -208,6 +261,10 @@ function normalizeNames(names: readonly string[]): string[] {
 		.slice(0, MAX_TOOL_NAMES);
 }
 
+function responseTelemetryState(api: string | undefined): ResponseTelemetryState {
+	return api === "google-generative-ai" || api === "google-vertex" ? "unsupported" : "pending";
+}
+
 function jsonByteLength(value: unknown): number | null {
 	if (value === undefined) return 0;
 	try {
@@ -215,6 +272,10 @@ function jsonByteLength(value: unknown): number | null {
 	} catch {
 		return null;
 	}
+}
+
+function isResponseTelemetryState(value: unknown): value is ResponseTelemetryState {
+	return value === "pending" || value === "received" || value === "unsupported";
 }
 
 function isStringArray(value: unknown): value is string[] {

--- a/.pi/extensions/runtime-diagnostics/provider-request.ts
+++ b/.pi/extensions/runtime-diagnostics/provider-request.ts
@@ -4,7 +4,7 @@ const PLAN_MODE_MARKER = "[CODEX-LIKE PLAN MODE ACTIVE]";
 const MAX_TOOL_NAMES = 200;
 const MAX_TOOL_NAME_LENGTH = 128;
 
-export type ResponseTelemetryState = "pending" | "received" | "unsupported";
+export type ResponseTelemetryState = "pending" | "received" | "unavailable" | "unsupported";
 
 export interface ProviderRequestDiagnostic {
 	version: 3;
@@ -45,6 +45,7 @@ export function extractProviderRequestDiagnostic(
 ): ProviderRequestDiagnostic {
 	const root = asRecord(payload);
 	const config = asRecord(root?.config);
+	const context = asRecord(root?.context);
 	return {
 		version: 3,
 		requestIndex: identity.requestIndex,
@@ -55,6 +56,7 @@ export function extractProviderRequestDiagnostic(
 		planModeMarkerPresent:
 			containsMarker(root?.instructions) ||
 			containsMarker(config?.systemInstruction) ||
+			containsMarker(context?.systemPrompt) ||
 			containsMarker(root?.system),
 		requestBytes: jsonByteLength(payload),
 		toolDefinitionBytes: jsonByteLength(extractProviderToolDefinitions(root)),
@@ -79,7 +81,7 @@ export function createProviderResponseDiagnostic(
 	};
 }
 
-export function normalizeProviderRequestDiagnostic(
+export function restoreProviderRequestDiagnostic(
 	value: unknown,
 ): ProviderRequestDiagnostic | undefined {
 	const record = asRecord(value);
@@ -108,7 +110,7 @@ export function normalizeProviderRequestDiagnostic(
 					: null,
 			topLevelToolNames: normalizeNames(record.topLevelToolNames as string[]),
 			transcriptToolNames: normalizeNames(record.transcriptToolNames as string[]),
-			responseTelemetry: response ? "received" : "pending",
+			responseTelemetry: response ? "received" : "unavailable",
 			response,
 		};
 	}
@@ -135,7 +137,8 @@ export function normalizeProviderRequestDiagnostic(
 		toolDefinitionBytes: record.toolDefinitionBytes,
 		topLevelToolNames: normalizeNames(record.topLevelToolNames as string[]),
 		transcriptToolNames: normalizeNames(record.transcriptToolNames as string[]),
-		responseTelemetry: record.responseTelemetry,
+		responseTelemetry:
+			record.responseTelemetry === "pending" ? "unavailable" : record.responseTelemetry,
 		response: record.response as ProviderResponseDiagnostic | null,
 	};
 }
@@ -180,16 +183,19 @@ function isProviderRequestBase(
 function extractProviderToolDefinitions(root: Record<string, unknown> | undefined): unknown {
 	const config = asRecord(root?.config);
 	const toolConfig = asRecord(root?.toolConfig);
-	return root?.tools ?? config?.tools ?? toolConfig?.tools;
+	const context = asRecord(root?.context);
+	return root?.tools ?? config?.tools ?? toolConfig?.tools ?? context?.tools;
 }
 
 function extractProviderToolNames(root: Record<string, unknown> | undefined): string[] {
 	const config = asRecord(root?.config);
 	const toolConfig = asRecord(root?.toolConfig);
+	const context = asRecord(root?.context);
 	return normalizeNames([
 		...extractToolNames(root?.tools),
 		...extractGoogleToolNames(config?.tools),
 		...extractBedrockToolNames(toolConfig?.tools),
+		...extractToolNames(context?.tools),
 	]);
 }
 
@@ -275,7 +281,12 @@ function jsonByteLength(value: unknown): number | null {
 }
 
 function isResponseTelemetryState(value: unknown): value is ResponseTelemetryState {
-	return value === "pending" || value === "received" || value === "unsupported";
+	return (
+		value === "pending" ||
+		value === "received" ||
+		value === "unavailable" ||
+		value === "unsupported"
+	);
 }
 
 function isStringArray(value: unknown): value is string[] {

--- a/.pi/extensions/runtime-diagnostics/report.ts
+++ b/.pi/extensions/runtime-diagnostics/report.ts
@@ -66,7 +66,18 @@ interface DiagnosticReportOptions {
 export function createDiagnosticResponse(options: DiagnosticReportOptions) {
 	const runtime = createRuntimeReport(options.pi, options.ctx, options.capturedAt);
 	const provider = createProviderReport(options.action, options.limit, options.capture);
-	const privacy = createPrivacyAudit(options.capture.records);
+	const bundleRequested = options.action === "bundle";
+	const toolCatalog = bundleRequested
+		? redactToolCatalogPaths(runtime.toolCatalog)
+		: runtime.toolCatalog;
+	const extensions = bundleRequested
+		? redactExtensionSurfacePaths(runtime.extensions)
+		: runtime.extensions;
+	const privacy = createPrivacyAudit(options.capture.records, {
+		bundleRequested,
+		bundlePathRedactionPassed:
+			!bundleRequested || bundlePathsAreRedacted(toolCatalog, extensions.surfaces),
+	});
 	const findings = createFindings(runtime, provider, options.capture, privacy);
 	const selectedSections = selectSections(options);
 	const details: Record<string, unknown> = {};
@@ -75,13 +86,11 @@ export function createDiagnosticResponse(options: DiagnosticReportOptions) {
 	if (selectedSections.has("tools")) {
 		details.tools = {
 			state: runtime.tools,
-			catalog: runtime.toolCatalog,
-			definitionBytes: sumNullable(
-				runtime.toolCatalog.map(({ definitionBytes }) => definitionBytes),
-			),
+			catalog: toolCatalog,
+			definitionBytes: sumNullable(toolCatalog.map(({ definitionBytes }) => definitionBytes)),
 		};
 	}
-	if (selectedSections.has("extensions")) details.extensions = runtime.extensions;
+	if (selectedSections.has("extensions")) details.extensions = extensions;
 	if (selectedSections.has("environment")) details.environment = runtime.environment;
 	if (selectedSections.has("timeline")) {
 		details.timeline = {
@@ -101,9 +110,11 @@ export function createDiagnosticResponse(options: DiagnosticReportOptions) {
 		export:
 			options.action === "bundle"
 				? {
-						sanitized: true,
+						sanitized: privacy.passed,
 						contentType: "application/json",
-						description: "Shareable privacy-filtered runtime diagnostic bundle.",
+						description: privacy.passed
+							? "Shareable privacy-filtered runtime diagnostic bundle."
+							: "Diagnostic bundle failed its privacy audit and should not be shared.",
 					}
 				: undefined,
 		summary: {
@@ -249,6 +260,7 @@ export function formatCommandSummary(
 	return [
 		...header,
 		`Privacy audit: ${privacy?.passed ? "passed" : "failed"}`,
+		`Bundle path redaction: ${privacy?.bundlePathRedaction ?? "unknown"}`,
 		`Checked records: ${privacy?.checkedRecordCount ?? 0}`,
 		`Unexpected fields: ${formatNameList(privacy?.unexpectedFields ?? [])}`,
 		`Not retained: ${privacy?.notRetained.join(", ") ?? "unknown"}`,
@@ -396,7 +408,10 @@ function createFindings(
 	return findings;
 }
 
-function createPrivacyAudit(records: readonly ProviderRequestDiagnostic[]) {
+function createPrivacyAudit(
+	records: readonly ProviderRequestDiagnostic[],
+	options: { bundleRequested: boolean; bundlePathRedactionPassed: boolean },
+) {
 	const allowedRequestFields = new Set([
 		"version",
 		"requestIndex",
@@ -419,6 +434,9 @@ function createPrivacyAudit(records: readonly ProviderRequestDiagnostic[]) {
 		"responseHeaderLatencyMs",
 	]);
 	const unexpectedFields = new Set<string>();
+	if (options.bundleRequested && !options.bundlePathRedactionPassed) {
+		unexpectedFields.add("bundle.source.path");
+	}
 	for (const record of records) {
 		for (const key of Object.keys(record)) {
 			if (!allowedRequestFields.has(key)) unexpectedFields.add(`request.${key}`);
@@ -432,6 +450,11 @@ function createPrivacyAudit(records: readonly ProviderRequestDiagnostic[]) {
 		passed: unexpectedFields.size === 0,
 		checkedRecordCount: records.length,
 		unexpectedFields: [...unexpectedFields].sort(),
+		bundlePathRedaction: options.bundleRequested
+			? options.bundlePathRedactionPassed
+				? "passed"
+				: "failed"
+			: "not-applicable",
 		retainedFields: [...allowedRequestFields].sort(),
 		notRetained: [
 			"prompts and instructions",
@@ -443,8 +466,52 @@ function createPrivacyAudit(records: readonly ProviderRequestDiagnostic[]) {
 		notes: [
 			"Request and tool-definition byte counts are retained as numbers, never as serialized content.",
 			"Captured display strings are stripped of terminal controls and bounded before retention.",
+			"Bundle exports replace every non-virtual tool and extension source path with a redaction marker.",
 		],
 	};
+}
+
+const REDACTED_SOURCE_PATH = "[redacted-local-path]";
+
+function redactToolCatalogPaths(
+	catalog: RuntimeDiagnosticReport["toolCatalog"],
+): RuntimeDiagnosticReport["toolCatalog"] {
+	return catalog.map((tool) => ({
+		...tool,
+		source: {
+			...tool.source,
+			path: redactSourcePath(tool.source.path),
+		},
+	}));
+}
+
+function redactExtensionSurfacePaths(
+	extensions: RuntimeDiagnosticReport["extensions"],
+): RuntimeDiagnosticReport["extensions"] {
+	return {
+		...extensions,
+		surfaces: extensions.surfaces.map((surface) => ({
+			...surface,
+			path: redactSourcePath(surface.path),
+		})),
+	};
+}
+
+function bundlePathsAreRedacted(
+	catalog: RuntimeDiagnosticReport["toolCatalog"],
+	surfaces: RuntimeDiagnosticReport["extensions"]["surfaces"],
+): boolean {
+	return [...catalog.map(({ source }) => source.path), ...surfaces.map(({ path }) => path)].every(
+		(path) => path === REDACTED_SOURCE_PATH || isVirtualSourcePath(path),
+	);
+}
+
+function redactSourcePath(path: string): string {
+	return isVirtualSourcePath(path) ? path : REDACTED_SOURCE_PATH;
+}
+
+function isVirtualSourcePath(path: string): boolean {
+	return path.startsWith("<") && path.endsWith(">");
 }
 
 function selectComparisonRecords(

--- a/.pi/extensions/runtime-diagnostics/report.ts
+++ b/.pi/extensions/runtime-diagnostics/report.ts
@@ -228,7 +228,7 @@ export function formatCommandSummary(
 			`Retained: ${provider?.retainedRecordCount ?? 0}`,
 			`Latest request: ${provider?.latest?.requestIndex ?? "none"}`,
 			`Latest status: ${formatResponseTelemetry(provider?.latest ?? null)}`,
-			`Telemetry completed/pending/unsupported: ${provider?.performance.completedRequestCount ?? 0}/${provider?.performance.pendingRequestCount ?? 0}/${provider?.performance.unsupportedRequestCount ?? 0}`,
+			`Telemetry completed/pending/unavailable/unsupported: ${provider?.performance.completedRequestCount ?? 0}/${provider?.performance.pendingRequestCount ?? 0}/${provider?.performance.unavailableRequestCount ?? 0}/${provider?.performance.unsupportedRequestCount ?? 0}`,
 			`Average header latency: ${formatMilliseconds(provider?.performance.averageResponseHeaderLatencyMs ?? null)}`,
 		].join("\n");
 	}
@@ -310,6 +310,9 @@ function createProviderReport(
 	const pending = capture.records.filter(
 		({ responseTelemetry }) => responseTelemetry === "pending",
 	);
+	const unavailable = capture.records.filter(
+		({ responseTelemetry }) => responseTelemetry === "unavailable",
+	);
 	const unsupported = capture.records.filter(
 		({ responseTelemetry }) => responseTelemetry === "unsupported",
 	);
@@ -327,6 +330,7 @@ function createProviderReport(
 		performance: {
 			completedRequestCount: completed.length,
 			pendingRequestCount: pending.length,
+			unavailableRequestCount: unavailable.length,
 			unsupportedRequestCount: unsupported.length,
 			averageResponseHeaderLatencyMs:
 				completed.length > 0
@@ -415,6 +419,15 @@ function createFindings(
 			message: `Provider-visible tools absent from the current active set: ${extra.join(", ")}.`,
 			recommendation:
 				"Check whether the active set changed after capture or whether transcript-anchored deferred tools remain visible.",
+		});
+	}
+	if (latest.responseTelemetry === "unavailable") {
+		findings.push({
+			severity: "info",
+			code: "response-telemetry-unavailable",
+			message: "The restored provider request has no retained response telemetry.",
+			recommendation:
+				"Capture a new provider request before interpreting HTTP status or response-header latency.",
 		});
 	}
 	if (latest.responseTelemetry === "unsupported") {
@@ -662,8 +675,8 @@ function formatPercent(value: number | null): string {
 
 function formatResponseTelemetry(record: ProviderRequestDiagnostic | null): string {
 	if (!record) return "none";
-	if (record.responseTelemetry === "unsupported") return "unsupported";
-	return record.response?.status === undefined ? "pending" : String(record.response.status);
+	if (record.responseTelemetry !== "received") return record.responseTelemetry;
+	return String(record.response?.status ?? "unavailable");
 }
 
 function formatMilliseconds(value: number | null): string {

--- a/.pi/extensions/runtime-diagnostics/report.ts
+++ b/.pi/extensions/runtime-diagnostics/report.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, win32 } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ProviderCaptureState } from "./capture-state.js";
 import type { ProviderRequestDiagnostic } from "./provider-request.js";
@@ -40,6 +41,7 @@ const PROVIDER_HOOK_LIMITATIONS = [
 	"before_provider_request exposes the serialized payload at this extension's position in handler load order; later extensions can still replace it.",
 	"The hook does not prove that the provider accepted or executed the exposed tools.",
 	"Response latency ends when response headers arrive and does not measure stream completion.",
+	"The installed google-generative-ai and google-vertex adapters do not emit response-header telemetry, so those requests are marked unsupported.",
 	"Provider responses are matched to requests by event order because Pi exposes no request identifier to this hook.",
 	"ExtensionAPI cannot enumerate passive event-only extensions, so extension visibility is limited to public tool and command surfaces.",
 	"Retention bounds the active reporting window; Pi session custom entries are append-only and are not erased from an existing session file.",
@@ -75,8 +77,8 @@ export function createDiagnosticResponse(options: DiagnosticReportOptions) {
 		: runtime.extensions;
 	const privacy = createPrivacyAudit(options.capture.records, {
 		bundleRequested,
-		bundlePathRedactionPassed:
-			!bundleRequested || bundlePathsAreRedacted(toolCatalog, extensions.surfaces),
+		bundleSourceRedactionPassed:
+			!bundleRequested || bundleSourcesAreRedacted(toolCatalog, extensions.surfaces),
 	});
 	const findings = createFindings(runtime, provider, options.capture, privacy);
 	const selectedSections = selectSections(options);
@@ -87,7 +89,11 @@ export function createDiagnosticResponse(options: DiagnosticReportOptions) {
 		details.tools = {
 			state: runtime.tools,
 			catalog: toolCatalog,
-			definitionBytes: sumNullable(toolCatalog.map(({ definitionBytes }) => definitionBytes)),
+			knownProviderDefinitionBytes: sumNullable(
+				toolCatalog.map(({ knownProviderDefinitionBytes }) => knownProviderDefinitionBytes),
+			),
+			definitionSizeBasis:
+				"Lower bound from name, description, and parameters. ExtensionAPI does not expose constrainedSampling; captured provider requests report actual serialized tool bytes.",
 		};
 	}
 	if (selectedSections.has("extensions")) details.extensions = extensions;
@@ -221,7 +227,8 @@ export function formatCommandSummary(
 			`Capture: ${provider?.enabled ? "enabled" : "disabled"}`,
 			`Retained: ${provider?.retainedRecordCount ?? 0}`,
 			`Latest request: ${provider?.latest?.requestIndex ?? "none"}`,
-			`Latest status: ${provider?.latest?.response?.status ?? "pending"}`,
+			`Latest status: ${formatResponseTelemetry(provider?.latest ?? null)}`,
+			`Telemetry completed/pending/unsupported: ${provider?.performance.completedRequestCount ?? 0}/${provider?.performance.pendingRequestCount ?? 0}/${provider?.performance.unsupportedRequestCount ?? 0}`,
 			`Average header latency: ${formatMilliseconds(provider?.performance.averageResponseHeaderLatencyMs ?? null)}`,
 		].join("\n");
 	}
@@ -237,12 +244,15 @@ export function formatCommandSummary(
 	}
 	if (route === "tools") {
 		const tools = detail.tools as
-			| { state: RuntimeDiagnosticReport["tools"]; definitionBytes: number | null }
+			| {
+					state: RuntimeDiagnosticReport["tools"];
+					knownProviderDefinitionBytes: number | null;
+			  }
 			| undefined;
 		return [
 			...header,
 			`Configured/active/inactive: ${tools?.state.configuredCount ?? 0}/${tools?.state.activeCount ?? 0}/${tools?.state.inactiveCount ?? 0}`,
-			`Definition bytes: ${tools?.definitionBytes ?? "unknown"}`,
+			`Known provider-definition bytes: ${tools?.knownProviderDefinitionBytes ?? "unknown"}`,
 			`Active: ${formatNameList(tools?.state.active ?? [])}`,
 			`Inactive: ${formatNameList(tools?.state.inactive ?? [])}`,
 		].join("\n");
@@ -260,7 +270,7 @@ export function formatCommandSummary(
 	return [
 		...header,
 		`Privacy audit: ${privacy?.passed ? "passed" : "failed"}`,
-		`Bundle path redaction: ${privacy?.bundlePathRedaction ?? "unknown"}`,
+		`Bundle source redaction: ${privacy?.bundleSourceRedaction ?? "unknown"}`,
 		`Checked records: ${privacy?.checkedRecordCount ?? 0}`,
 		`Unexpected fields: ${formatNameList(privacy?.unexpectedFields ?? [])}`,
 		`Not retained: ${privacy?.notRetained.join(", ") ?? "unknown"}`,
@@ -268,8 +278,9 @@ export function formatCommandSummary(
 }
 
 function selectSections(options: DiagnosticReportOptions): Set<DiagnosticSection> {
+	if (options.action === "bundle") return new Set(DIAGNOSTIC_SECTIONS);
 	if (options.sections.length > 0) return new Set(options.sections);
-	if (options.action === "bundle" || options.detail === "full") {
+	if (options.detail === "full") {
 		return new Set(DIAGNOSTIC_SECTIONS);
 	}
 	if (options.action === "latest" || options.action === "show") return new Set(["provider"]);
@@ -293,7 +304,15 @@ function createProviderReport(
 	const recent = action === "show" || action === "bundle" ? capture.records.slice(-limit) : [];
 	const latest = capture.records.at(-1) ?? null;
 	const comparisonRecords = selectComparisonRecords(action, recent, capture.records);
-	const completed = capture.records.filter(({ response }) => response !== null);
+	const completed = capture.records.filter(
+		({ responseTelemetry }) => responseTelemetry === "received",
+	);
+	const pending = capture.records.filter(
+		({ responseTelemetry }) => responseTelemetry === "pending",
+	);
+	const unsupported = capture.records.filter(
+		({ responseTelemetry }) => responseTelemetry === "unsupported",
+	);
 	return {
 		enabled: capture.enabled,
 		retainedRecordCount: capture.records.length,
@@ -307,6 +326,8 @@ function createProviderReport(
 				: null,
 		performance: {
 			completedRequestCount: completed.length,
+			pendingRequestCount: pending.length,
+			unsupportedRequestCount: unsupported.length,
 			averageResponseHeaderLatencyMs:
 				completed.length > 0
 					? completed.reduce(
@@ -339,7 +360,7 @@ function createFindings(
 		findings.push({
 			severity: "error",
 			code: "privacy-audit-failed",
-			message: `Captured records contain unexpected fields: ${privacy.unexpectedFields.join(", ")}.`,
+			message: `The diagnostic bundle privacy audit failed: ${privacy.unexpectedFields.join(", ")}.`,
 			recommendation:
 				"Disable capture and clear active records before sharing a diagnostic bundle.",
 		});
@@ -396,6 +417,15 @@ function createFindings(
 				"Check whether the active set changed after capture or whether transcript-anchored deferred tools remain visible.",
 		});
 	}
+	if (latest.responseTelemetry === "unsupported") {
+		findings.push({
+			severity: "info",
+			code: "response-telemetry-unsupported",
+			message: "The selected provider adapter does not expose response-header telemetry.",
+			recommendation:
+				"Use request-size and provider-visible-tool diagnostics without interpreting the missing HTTP status or latency as a pending response.",
+		});
+	}
 	if (latest.response && (latest.response.status < 200 || latest.response.status >= 400)) {
 		findings.push({
 			severity: "warning",
@@ -410,7 +440,7 @@ function createFindings(
 
 function createPrivacyAudit(
 	records: readonly ProviderRequestDiagnostic[],
-	options: { bundleRequested: boolean; bundlePathRedactionPassed: boolean },
+	options: { bundleRequested: boolean; bundleSourceRedactionPassed: boolean },
 ) {
 	const allowedRequestFields = new Set([
 		"version",
@@ -424,6 +454,7 @@ function createPrivacyAudit(
 		"toolDefinitionBytes",
 		"topLevelToolNames",
 		"transcriptToolNames",
+		"responseTelemetry",
 		"response",
 	]);
 	const allowedResponseFields = new Set([
@@ -434,8 +465,8 @@ function createPrivacyAudit(
 		"responseHeaderLatencyMs",
 	]);
 	const unexpectedFields = new Set<string>();
-	if (options.bundleRequested && !options.bundlePathRedactionPassed) {
-		unexpectedFields.add("bundle.source.path");
+	if (options.bundleRequested && !options.bundleSourceRedactionPassed) {
+		unexpectedFields.add("bundle.source-location");
 	}
 	for (const record of records) {
 		for (const key of Object.keys(record)) {
@@ -450,8 +481,8 @@ function createPrivacyAudit(
 		passed: unexpectedFields.size === 0,
 		checkedRecordCount: records.length,
 		unexpectedFields: [...unexpectedFields].sort(),
-		bundlePathRedaction: options.bundleRequested
-			? options.bundlePathRedactionPassed
+		bundleSourceRedaction: options.bundleRequested
+			? options.bundleSourceRedactionPassed
 				? "passed"
 				: "failed"
 			: "not-applicable",
@@ -466,7 +497,7 @@ function createPrivacyAudit(
 		notes: [
 			"Request and tool-definition byte counts are retained as numbers, never as serialized content.",
 			"Captured display strings are stripped of terminal controls and bounded before retention.",
-			"Bundle exports replace every non-virtual tool and extension source path with a redaction marker.",
+			"Bundle exports redact non-virtual source paths, package source references, and other path-like source references.",
 		],
 	};
 }
@@ -481,6 +512,7 @@ function redactToolCatalogPaths(
 		source: {
 			...tool.source,
 			path: redactSourcePath(tool.source.path),
+			source: redactSourceReference(tool.source.source, tool.source.origin),
 		},
 	}));
 }
@@ -493,21 +525,44 @@ function redactExtensionSurfacePaths(
 		surfaces: extensions.surfaces.map((surface) => ({
 			...surface,
 			path: redactSourcePath(surface.path),
+			source: redactSourceReference(surface.source, surface.origin),
 		})),
 	};
 }
 
-function bundlePathsAreRedacted(
+function bundleSourcesAreRedacted(
 	catalog: RuntimeDiagnosticReport["toolCatalog"],
 	surfaces: RuntimeDiagnosticReport["extensions"]["surfaces"],
 ): boolean {
-	return [...catalog.map(({ source }) => source.path), ...surfaces.map(({ path }) => path)].every(
-		(path) => path === REDACTED_SOURCE_PATH || isVirtualSourcePath(path),
+	const pathsAreRedacted = [
+		...catalog.map(({ source }) => source.path),
+		...surfaces.map(({ path }) => path),
+	].every((path) => path === REDACTED_SOURCE_PATH || isVirtualSourcePath(path));
+	const sourcesAreRedacted = [
+		...catalog.map(({ source }) => ({ source: source.source, origin: source.origin })),
+		...surfaces.map(({ source, origin }) => ({ source, origin })),
+	].every(
+		({ source, origin }) =>
+			source === REDACTED_SOURCE_PATH || (origin !== "package" && !isPathLikeSource(source)),
 	);
+	return pathsAreRedacted && sourcesAreRedacted;
 }
 
 function redactSourcePath(path: string): string {
 	return isVirtualSourcePath(path) ? path : REDACTED_SOURCE_PATH;
+}
+
+function redactSourceReference(source: string, origin: string): string {
+	return origin === "package" || isPathLikeSource(source) ? REDACTED_SOURCE_PATH : source;
+}
+
+function isPathLikeSource(source: string): boolean {
+	return (
+		isAbsolute(source) ||
+		win32.isAbsolute(source) ||
+		/^file:/iu.test(source) ||
+		/^(?:\.{1,2}|~)[\\/]/u.test(source)
+	);
 }
 
 function isVirtualSourcePath(path: string): boolean {
@@ -603,6 +658,12 @@ function withinOutputBounds(text: string): boolean {
 
 function formatPercent(value: number | null): string {
 	return value === null ? "n/a" : `${value.toFixed(1)}%`;
+}
+
+function formatResponseTelemetry(record: ProviderRequestDiagnostic | null): string {
+	if (!record) return "none";
+	if (record.responseTelemetry === "unsupported") return "unsupported";
+	return record.response?.status === undefined ? "pending" : String(record.response.status);
 }
 
 function formatMilliseconds(value: number | null): string {

--- a/.pi/extensions/runtime-diagnostics/report.ts
+++ b/.pi/extensions/runtime-diagnostics/report.ts
@@ -1,0 +1,549 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ProviderCaptureState } from "./capture-state.js";
+import type { ProviderRequestDiagnostic } from "./provider-request.js";
+import {
+	compareRuntimeSnapshots,
+	createRuntimeReport,
+	type RuntimeDiagnosticReport,
+	type RuntimeSnapshot,
+} from "./snapshot.js";
+
+export const DIAGNOSTIC_ACTIONS = [
+	"status",
+	"enable",
+	"disable",
+	"latest",
+	"show",
+	"compare",
+	"clear",
+	"configure",
+	"bundle",
+] as const;
+export const DIAGNOSTIC_DETAILS = ["summary", "full"] as const;
+export const DIAGNOSTIC_SECTIONS = [
+	"provider",
+	"cache",
+	"tools",
+	"extensions",
+	"environment",
+	"timeline",
+	"privacy",
+] as const;
+
+export type DiagnosticAction = (typeof DIAGNOSTIC_ACTIONS)[number];
+export type DiagnosticDetail = (typeof DIAGNOSTIC_DETAILS)[number];
+export type DiagnosticSection = (typeof DIAGNOSTIC_SECTIONS)[number];
+
+const MAX_OUTPUT_BYTES = 50 * 1024;
+const MAX_OUTPUT_LINES = 2_000;
+const PROVIDER_HOOK_LIMITATIONS = [
+	"before_provider_request exposes the serialized payload at this extension's position in handler load order; later extensions can still replace it.",
+	"The hook does not prove that the provider accepted or executed the exposed tools.",
+	"Response latency ends when response headers arrive and does not measure stream completion.",
+	"Provider responses are matched to requests by event order because Pi exposes no request identifier to this hook.",
+	"ExtensionAPI cannot enumerate passive event-only extensions, so extension visibility is limited to public tool and command surfaces.",
+	"Retention bounds the active reporting window; Pi session custom entries are append-only and are not erased from an existing session file.",
+];
+
+export interface DiagnosticFinding {
+	severity: "error" | "warning" | "info";
+	code: string;
+	message: string;
+	recommendation?: string;
+}
+
+interface DiagnosticReportOptions {
+	action: DiagnosticAction;
+	detail: DiagnosticDetail;
+	sections: readonly DiagnosticSection[];
+	limit: number;
+	pi: ExtensionAPI;
+	ctx: ExtensionContext;
+	capture: ProviderCaptureState;
+	capturedAt: number;
+}
+
+export function createDiagnosticResponse(options: DiagnosticReportOptions) {
+	const runtime = createRuntimeReport(options.pi, options.ctx, options.capturedAt);
+	const provider = createProviderReport(options.action, options.limit, options.capture);
+	const privacy = createPrivacyAudit(options.capture.records);
+	const findings = createFindings(runtime, provider, options.capture, privacy);
+	const selectedSections = selectSections(options);
+	const details: Record<string, unknown> = {};
+	if (selectedSections.has("provider")) details.providerRequestCapture = provider;
+	if (selectedSections.has("cache")) details.cache = runtime.cache;
+	if (selectedSections.has("tools")) {
+		details.tools = {
+			state: runtime.tools,
+			catalog: runtime.toolCatalog,
+			definitionBytes: sumNullable(
+				runtime.toolCatalog.map(({ definitionBytes }) => definitionBytes),
+			),
+		};
+	}
+	if (selectedSections.has("extensions")) details.extensions = runtime.extensions;
+	if (selectedSections.has("environment")) details.environment = runtime.environment;
+	if (selectedSections.has("timeline")) {
+		details.timeline = {
+			recentRuntimeRecords: runtime.recentRuntimeRecords,
+			comparison: selectRuntimeComparison(options.action, runtime.recentRuntimeRecords),
+		};
+	}
+	if (selectedSections.has("privacy")) {
+		details.privacy = privacy;
+		details.limitations = PROVIDER_HOOK_LIMITATIONS;
+	}
+
+	return {
+		format: "runtime-diagnostics/v2",
+		action: options.action,
+		generatedAt: options.capturedAt,
+		export:
+			options.action === "bundle"
+				? {
+						sanitized: true,
+						contentType: "application/json",
+						description: "Shareable privacy-filtered runtime diagnostic bundle.",
+					}
+				: undefined,
+		summary: {
+			health: findings.some(({ severity }) => severity === "error")
+				? "error"
+				: findings.some(({ severity }) => severity === "warning")
+					? "warning"
+					: "ok",
+			current: runtime.current,
+			cache: {
+				requestCount: runtime.cache.requestCount,
+				hitRatePercent: runtime.cache.hitRatePercent,
+				promptTokens: runtime.cache.promptTokens,
+			},
+			tools: {
+				configuredCount: runtime.tools.configuredCount,
+				activeCount: runtime.tools.activeCount,
+				inactiveCount: runtime.tools.inactiveCount,
+				providerVisibleCount: provider.latest ? providerVisibleNames(provider.latest).length : null,
+			},
+			capture: {
+				enabled: options.capture.enabled,
+				retainedRecordCount: options.capture.records.length,
+				prunedRecordCount: options.capture.prunedRecordCount,
+				policy: options.capture.policy,
+			},
+			visibleExtensionCount: runtime.extensions.visibleCount,
+			findingCounts: countFindings(findings),
+		},
+		findings,
+		recommendations: [
+			...new Set(
+				findings
+					.map(({ recommendation }) => recommendation)
+					.filter((value): value is string => Boolean(value)),
+			),
+		],
+		details,
+	};
+}
+
+export function boundDiagnosticResponse(value: ReturnType<typeof createDiagnosticResponse>): {
+	value: unknown;
+	text: string;
+} {
+	const text = JSON.stringify(value, null, 2);
+	if (withinOutputBounds(text)) return { value, text };
+
+	const compact = {
+		format: value.format,
+		action: value.action,
+		generatedAt: value.generatedAt,
+		export: value.export,
+		summary: value.summary,
+		findings: value.findings.slice(0, 20),
+		recommendations: value.recommendations.slice(0, 20),
+		outputNote: "Detailed sections were omitted to keep tool output below 50 KB and 2,000 lines.",
+	};
+	const compactText = JSON.stringify(compact, null, 2);
+	if (withinOutputBounds(compactText)) return { value: compact, text: compactText };
+
+	const minimal = {
+		format: value.format,
+		action: value.action,
+		generatedAt: value.generatedAt,
+		summary: value.summary,
+		outputNote:
+			"Findings and detailed sections were omitted to keep tool output below 50 KB and 2,000 lines.",
+	};
+	return { value: minimal, text: JSON.stringify(minimal, null, 2) };
+}
+
+export function formatCommandSummary(
+	response: ReturnType<typeof createDiagnosticResponse>,
+	route: string,
+): string {
+	if (route === "help") {
+		return [
+			"/runtime-diagnostics [status|provider|cache|tools|extensions|privacy|help]",
+			"Use the runtime_diagnostics tool for full JSON, comparisons, capture controls, retention configuration, and bundles.",
+		].join("\n");
+	}
+	const { summary } = response;
+	const header = [
+		`Runtime diagnostics: ${summary.health}`,
+		`Model: ${summary.current.provider ?? "none"}/${summary.current.model ?? "none"} (${summary.current.thinkingLevel})`,
+	];
+	if (route === "status") {
+		return [
+			...header,
+			`Cache: ${summary.cache.requestCount} request(s), ${formatPercent(summary.cache.hitRatePercent)} hit rate`,
+			`Tools: ${summary.tools.activeCount}/${summary.tools.configuredCount} active, ${summary.tools.providerVisibleCount ?? "no"} provider-visible`,
+			`Capture: ${summary.capture.enabled ? "enabled" : "disabled"}, ${summary.capture.retainedRecordCount} retained`,
+			`Findings: ${summary.findingCounts.error} error, ${summary.findingCounts.warning} warning, ${summary.findingCounts.info} info`,
+		].join("\n");
+	}
+	const detail = response.details as Record<string, unknown>;
+	if (route === "provider") {
+		const provider = detail.providerRequestCapture as
+			| ReturnType<typeof createProviderReport>
+			| undefined;
+		return [
+			...header,
+			`Capture: ${provider?.enabled ? "enabled" : "disabled"}`,
+			`Retained: ${provider?.retainedRecordCount ?? 0}`,
+			`Latest request: ${provider?.latest?.requestIndex ?? "none"}`,
+			`Latest status: ${provider?.latest?.response?.status ?? "pending"}`,
+			`Average header latency: ${formatMilliseconds(provider?.performance.averageResponseHeaderLatencyMs ?? null)}`,
+		].join("\n");
+	}
+	if (route === "cache") {
+		const cache = detail.cache as RuntimeDiagnosticReport["cache"] | undefined;
+		return [
+			...header,
+			`Requests: ${cache?.requestCount ?? 0}`,
+			`Prompt tokens: ${cache?.promptTokens ?? 0}`,
+			`Cache read/write: ${cache?.cacheRead ?? 0}/${cache?.cacheWrite ?? 0}`,
+			`Hit rate: ${formatPercent(cache?.hitRatePercent ?? null)}`,
+		].join("\n");
+	}
+	if (route === "tools") {
+		const tools = detail.tools as
+			| { state: RuntimeDiagnosticReport["tools"]; definitionBytes: number | null }
+			| undefined;
+		return [
+			...header,
+			`Configured/active/inactive: ${tools?.state.configuredCount ?? 0}/${tools?.state.activeCount ?? 0}/${tools?.state.inactiveCount ?? 0}`,
+			`Definition bytes: ${tools?.definitionBytes ?? "unknown"}`,
+			`Active: ${formatNameList(tools?.state.active ?? [])}`,
+			`Inactive: ${formatNameList(tools?.state.inactive ?? [])}`,
+		].join("\n");
+	}
+	if (route === "extensions") {
+		const extensions = detail.extensions as RuntimeDiagnosticReport["extensions"] | undefined;
+		return [
+			...header,
+			`Visible extension surfaces: ${extensions?.visibleCount ?? 0}`,
+			`Omitted: ${extensions?.omittedCount ?? 0}`,
+			`Sources: ${formatNameList(extensions?.surfaces.map(({ source }) => source) ?? [])}`,
+		].join("\n");
+	}
+	const privacy = detail.privacy as ReturnType<typeof createPrivacyAudit> | undefined;
+	return [
+		...header,
+		`Privacy audit: ${privacy?.passed ? "passed" : "failed"}`,
+		`Checked records: ${privacy?.checkedRecordCount ?? 0}`,
+		`Unexpected fields: ${formatNameList(privacy?.unexpectedFields ?? [])}`,
+		`Not retained: ${privacy?.notRetained.join(", ") ?? "unknown"}`,
+	].join("\n");
+}
+
+function selectSections(options: DiagnosticReportOptions): Set<DiagnosticSection> {
+	if (options.sections.length > 0) return new Set(options.sections);
+	if (options.action === "bundle" || options.detail === "full") {
+		return new Set(DIAGNOSTIC_SECTIONS);
+	}
+	if (options.action === "latest" || options.action === "show") return new Set(["provider"]);
+	if (options.action === "compare") return new Set(["provider", "timeline"]);
+	if (
+		options.action === "enable" ||
+		options.action === "disable" ||
+		options.action === "clear" ||
+		options.action === "configure"
+	) {
+		return new Set(["provider"]);
+	}
+	return new Set();
+}
+
+function createProviderReport(
+	action: DiagnosticAction,
+	limit: number,
+	capture: ProviderCaptureState,
+) {
+	const recent = action === "show" || action === "bundle" ? capture.records.slice(-limit) : [];
+	const latest = capture.records.at(-1) ?? null;
+	const comparisonRecords = selectComparisonRecords(action, recent, capture.records);
+	const completed = capture.records.filter(({ response }) => response !== null);
+	return {
+		enabled: capture.enabled,
+		retainedRecordCount: capture.records.length,
+		prunedRecordCount: capture.prunedRecordCount,
+		policy: capture.policy,
+		latest,
+		recent,
+		comparison:
+			comparisonRecords.length === 2
+				? compareProviderRequests(comparisonRecords[0], comparisonRecords[1])
+				: null,
+		performance: {
+			completedRequestCount: completed.length,
+			averageResponseHeaderLatencyMs:
+				completed.length > 0
+					? completed.reduce(
+							(total, record) => total + (record.response?.responseHeaderLatencyMs ?? 0),
+							0,
+						) / completed.length
+					: null,
+			statusCounts: countStatuses(completed),
+			requestBytes: sumNullable(capture.records.map(({ requestBytes }) => requestBytes)),
+			toolDefinitionBytes: sumNullable(
+				capture.records.map(({ toolDefinitionBytes }) => toolDefinitionBytes),
+			),
+		},
+	};
+}
+
+function createFindings(
+	runtime: RuntimeDiagnosticReport,
+	provider: ReturnType<typeof createProviderReport>,
+	capture: ProviderCaptureState,
+	privacy: ReturnType<typeof createPrivacyAudit>,
+): DiagnosticFinding[] {
+	const findings: DiagnosticFinding[] = runtime.issues.map((message) => ({
+		severity: "warning",
+		code: "runtime-state",
+		message,
+		recommendation: "Inspect the tools and environment sections for the conflicting source.",
+	}));
+	if (!privacy.passed) {
+		findings.push({
+			severity: "error",
+			code: "privacy-audit-failed",
+			message: `Captured records contain unexpected fields: ${privacy.unexpectedFields.join(", ")}.`,
+			recommendation:
+				"Disable capture and clear active records before sharing a diagnostic bundle.",
+		});
+	}
+	if (!capture.enabled) {
+		findings.push({
+			severity: "info",
+			code: "capture-disabled",
+			message: "Provider-request capture is disabled.",
+			recommendation: "Enable capture before reproducing a provider serialization issue.",
+		});
+	}
+	if (
+		runtime.cache.requestCount >= 3 &&
+		runtime.cache.promptTokens >= 1_000 &&
+		runtime.cache.cacheRead === 0
+	) {
+		findings.push({
+			severity: "info",
+			code: "cache-no-reads",
+			message: `No cache reads were reported across ${runtime.cache.requestCount} requests.`,
+			recommendation:
+				"Compare consecutive provider requests and verify that the selected provider/model supports prompt caching before treating this as a cache regression.",
+		});
+	}
+	const latest = provider.latest;
+	if (!latest) return findings;
+	if (latest.provider !== runtime.current.provider || latest.model !== runtime.current.model) {
+		findings.push({
+			severity: "warning",
+			code: "provider-model-stale",
+			message: "The latest captured provider/model does not match the current runtime selection.",
+			recommendation: "Capture one request after the model selection settles, then compare again.",
+		});
+	}
+	const visible = new Set(providerVisibleNames(latest));
+	const missing = runtime.tools.active.filter((name) => !visible.has(name));
+	const extra = [...visible].filter((name) => !runtime.tools.active.includes(name));
+	if (missing.length > 0) {
+		findings.push({
+			severity: "warning",
+			code: "active-tools-not-provider-visible",
+			message: `Active tools absent from the latest provider request: ${missing.join(", ")}.`,
+			recommendation:
+				"Inspect deferred loading and later provider hooks; the captured hook position may precede a later payload replacement.",
+		});
+	}
+	if (extra.length > 0) {
+		findings.push({
+			severity: "info",
+			code: "provider-tools-not-active",
+			message: `Provider-visible tools absent from the current active set: ${extra.join(", ")}.`,
+			recommendation:
+				"Check whether the active set changed after capture or whether transcript-anchored deferred tools remain visible.",
+		});
+	}
+	if (latest.response && (latest.response.status < 200 || latest.response.status >= 400)) {
+		findings.push({
+			severity: "warning",
+			code: "provider-http-status",
+			message: `The latest provider response reported HTTP ${latest.response.status}.`,
+			recommendation:
+				"Inspect provider availability, authentication, entitlement, and rate limits.",
+		});
+	}
+	return findings;
+}
+
+function createPrivacyAudit(records: readonly ProviderRequestDiagnostic[]) {
+	const allowedRequestFields = new Set([
+		"version",
+		"requestIndex",
+		"capturedAt",
+		"sessionId",
+		"provider",
+		"model",
+		"planModeMarkerPresent",
+		"requestBytes",
+		"toolDefinitionBytes",
+		"topLevelToolNames",
+		"transcriptToolNames",
+		"response",
+	]);
+	const allowedResponseFields = new Set([
+		"version",
+		"requestIndex",
+		"capturedAt",
+		"status",
+		"responseHeaderLatencyMs",
+	]);
+	const unexpectedFields = new Set<string>();
+	for (const record of records) {
+		for (const key of Object.keys(record)) {
+			if (!allowedRequestFields.has(key)) unexpectedFields.add(`request.${key}`);
+		}
+		if (!record.response) continue;
+		for (const key of Object.keys(record.response)) {
+			if (!allowedResponseFields.has(key)) unexpectedFields.add(`response.${key}`);
+		}
+	}
+	return {
+		passed: unexpectedFields.size === 0,
+		checkedRecordCount: records.length,
+		unexpectedFields: [...unexpectedFields].sort(),
+		retainedFields: [...allowedRequestFields].sort(),
+		notRetained: [
+			"prompts and instructions",
+			"message contents",
+			"tool schemas and arguments",
+			"HTTP headers and response bodies",
+			"credentials, API keys, and authorization values",
+		],
+		notes: [
+			"Request and tool-definition byte counts are retained as numbers, never as serialized content.",
+			"Captured display strings are stripped of terminal controls and bounded before retention.",
+		],
+	};
+}
+
+function selectComparisonRecords(
+	action: DiagnosticAction,
+	recent: readonly ProviderRequestDiagnostic[],
+	all: readonly ProviderRequestDiagnostic[],
+): readonly ProviderRequestDiagnostic[] {
+	if (all.length < 2) return [];
+	if (action === "compare" || action === "bundle") return [all[0], all[all.length - 1]];
+	if (action === "show" && recent.length >= 2) {
+		return [recent[0], recent[recent.length - 1]];
+	}
+	return all.slice(-2);
+}
+
+function compareProviderRequests(from: ProviderRequestDiagnostic, to: ProviderRequestDiagnostic) {
+	return {
+		fromRequestIndex: from.requestIndex,
+		toRequestIndex: to.requestIndex,
+		providerChanged: from.provider !== to.provider,
+		modelChanged: from.model !== to.model,
+		planModeMarkerChanged: from.planModeMarkerPresent !== to.planModeMarkerPresent,
+		requestBytesDelta: nullableDelta(from.requestBytes, to.requestBytes),
+		toolDefinitionBytesDelta: nullableDelta(from.toolDefinitionBytes, to.toolDefinitionBytes),
+		responseStatusChanged: from.response?.status !== to.response?.status,
+		responseHeaderLatencyMsDelta: nullableDelta(
+			from.response?.responseHeaderLatencyMs ?? null,
+			to.response?.responseHeaderLatencyMs ?? null,
+		),
+		topLevelTools: diffNames(from.topLevelToolNames, to.topLevelToolNames),
+		transcriptTools: diffNames(from.transcriptToolNames, to.transcriptToolNames),
+	};
+}
+
+function selectRuntimeComparison(action: DiagnosticAction, records: readonly RuntimeSnapshot[]) {
+	if (records.length < 2) return null;
+	const selected =
+		action === "compare" || action === "bundle"
+			? [records[0], records[records.length - 1]]
+			: records.slice(-2);
+	return compareRuntimeSnapshots(selected[0], selected[1]);
+}
+
+function countStatuses(records: readonly ProviderRequestDiagnostic[]): Record<string, number> {
+	const counts: Record<string, number> = {};
+	for (const record of records) {
+		const key = String(record.response?.status ?? "unknown");
+		counts[key] = (counts[key] ?? 0) + 1;
+	}
+	return counts;
+}
+
+function countFindings(findings: readonly DiagnosticFinding[]) {
+	return {
+		error: findings.filter(({ severity }) => severity === "error").length,
+		warning: findings.filter(({ severity }) => severity === "warning").length,
+		info: findings.filter(({ severity }) => severity === "info").length,
+	};
+}
+
+function providerVisibleNames(record: ProviderRequestDiagnostic): string[] {
+	return [...new Set([...record.topLevelToolNames, ...record.transcriptToolNames])].sort();
+}
+
+function sumNullable(values: readonly (number | null)[]): number | null {
+	const available = values.filter((value): value is number => value !== null);
+	return available.length > 0 ? available.reduce((total, value) => total + value, 0) : null;
+}
+
+function nullableDelta(from: number | null, to: number | null): number | null {
+	return from === null || to === null ? null : to - from;
+}
+
+function diffNames(from: readonly string[], to: readonly string[]) {
+	const previous = new Set(from);
+	const current = new Set(to);
+	return {
+		added: to.filter((name) => !previous.has(name)),
+		removed: from.filter((name) => !current.has(name)),
+	};
+}
+
+function withinOutputBounds(text: string): boolean {
+	return (
+		Buffer.byteLength(text, "utf8") <= MAX_OUTPUT_BYTES &&
+		text.split("\n").length <= MAX_OUTPUT_LINES
+	);
+}
+
+function formatPercent(value: number | null): string {
+	return value === null ? "n/a" : `${value.toFixed(1)}%`;
+}
+
+function formatMilliseconds(value: number | null): string {
+	return value === null ? "n/a" : `${value.toFixed(1)} ms`;
+}
+
+function formatNameList(values: readonly string[]): string {
+	if (values.length === 0) return "none";
+	const visible = values.slice(0, 10);
+	return `${visible.join(", ")}${values.length > visible.length ? `, +${values.length - visible.length} more` : ""}`;
+}

--- a/.pi/extensions/runtime-diagnostics/snapshot.ts
+++ b/.pi/extensions/runtime-diagnostics/snapshot.ts
@@ -10,13 +10,16 @@ const MAX_EXTENSION_SURFACES = 100;
 const MAX_CACHE_SAMPLES = 20;
 const MAX_RUNTIME_RECORDS = 20;
 
-export type RuntimeSnapshotReason =
-	| "session_start"
-	| "model_select"
-	| "before_agent_start"
-	| "tools_changed"
-	| "assistant_message"
-	| "diagnostic_tool";
+const RUNTIME_SNAPSHOT_REASONS = [
+	"session_start",
+	"model_select",
+	"before_agent_start",
+	"tools_changed",
+	"assistant_message",
+	"diagnostic_tool",
+] as const;
+
+export type RuntimeSnapshotReason = (typeof RUNTIME_SNAPSHOT_REASONS)[number];
 
 interface UsageLike {
 	input?: number;
@@ -324,8 +327,8 @@ function collectRuntimeRecords(entries: readonly SessionEntry[]): RuntimeSnapsho
 			(entry): entry is Extract<SessionEntry, { type: "custom" }> =>
 				entry.type === "custom" && entry.customType === RUNTIME_ENTRY_TYPE,
 		)
-		.map(({ data }) => data)
-		.filter(isRuntimeSnapshot)
+		.map(({ data }) => normalizeRuntimeSnapshot(data))
+		.filter((snapshot): snapshot is RuntimeSnapshot => snapshot !== undefined)
 		.slice(-MAX_RUNTIME_RECORDS);
 }
 
@@ -458,15 +461,114 @@ function diffNames(from: readonly string[], to: readonly string[]) {
 	};
 }
 
-function isRuntimeSnapshot(value: unknown): value is RuntimeSnapshot {
-	if (!isRecord(value)) return false;
-	return (
-		value.version === 1 &&
-		typeof value.capturedAt === "number" &&
-		typeof value.reason === "string" &&
-		typeof value.sessionId === "string" &&
-		isRecord(value.tools)
-	);
+function normalizeRuntimeSnapshot(value: unknown): RuntimeSnapshot | undefined {
+	if (
+		!isRecord(value) ||
+		value.version !== 1 ||
+		!isFiniteNumber(value.capturedAt) ||
+		!isRuntimeSnapshotReason(value.reason) ||
+		typeof value.sessionId !== "string" ||
+		!isNullableString(value.provider) ||
+		!isNullableString(value.model) ||
+		typeof value.thinkingLevel !== "string"
+	) {
+		return undefined;
+	}
+	const tools = normalizeToolState(value.tools);
+	const cache = value.cache === null ? null : normalizeCacheSample(value.cache);
+	if (!tools || cache === undefined) return undefined;
+	return {
+		version: 1,
+		capturedAt: value.capturedAt,
+		reason: value.reason,
+		sessionId: sanitizeDiagnosticText(value.sessionId, 128),
+		provider: value.provider ? sanitizeDiagnosticText(value.provider, 128) : null,
+		model: value.model ? sanitizeDiagnosticText(value.model, 256) : null,
+		thinkingLevel: sanitizeDiagnosticText(value.thinkingLevel, 32),
+		cache,
+		tools,
+	};
+}
+
+function normalizeToolState(value: unknown): ToolState | undefined {
+	if (
+		!isRecord(value) ||
+		!isNonNegativeInteger(value.configuredCount) ||
+		!isNonNegativeInteger(value.activeCount) ||
+		!isNonNegativeInteger(value.inactiveCount) ||
+		!isNonNegativeInteger(value.omittedCount)
+	) {
+		return undefined;
+	}
+	const active = normalizeStringArray(value.active);
+	const inactive = normalizeStringArray(value.inactive);
+	const unknownActive = normalizeStringArray(value.unknownActive);
+	if (!active || !inactive || !unknownActive) return undefined;
+	return {
+		configuredCount: value.configuredCount,
+		activeCount: value.activeCount,
+		inactiveCount: value.inactiveCount,
+		active,
+		inactive,
+		unknownActive,
+		omittedCount: value.omittedCount,
+	};
+}
+
+function normalizeCacheSample(value: unknown): ResponseCacheSample | undefined {
+	if (
+		!isRecord(value) ||
+		!isFiniteNumber(value.capturedAt) ||
+		!isNullableString(value.provider) ||
+		!isNullableString(value.model) ||
+		!isNonNegativeNumber(value.input) ||
+		!isNonNegativeNumber(value.cacheRead) ||
+		!isNonNegativeNumber(value.cacheWrite) ||
+		!isNonNegativeNumber(value.promptTokens) ||
+		!(value.hitRatePercent === null || isFiniteNumber(value.hitRatePercent))
+	) {
+		return undefined;
+	}
+	return {
+		capturedAt: value.capturedAt,
+		provider: value.provider ? sanitizeDiagnosticText(value.provider, 128) : null,
+		model: value.model ? sanitizeDiagnosticText(value.model, 256) : null,
+		input: value.input,
+		cacheRead: value.cacheRead,
+		cacheWrite: value.cacheWrite,
+		promptTokens: value.promptTokens,
+		hitRatePercent: value.hitRatePercent,
+	};
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+		return undefined;
+	}
+	return [...new Set(value.map((item) => sanitizeDiagnosticText(item, 128)))]
+		.filter(Boolean)
+		.sort((left, right) => left.localeCompare(right))
+		.slice(0, MAX_TOOL_NAMES);
+}
+
+function isRuntimeSnapshotReason(value: unknown): value is RuntimeSnapshotReason {
+	return RUNTIME_SNAPSHOT_REASONS.includes(value as RuntimeSnapshotReason);
+}
+
+function isNullableString(value: unknown): value is string | null {
+	return value === null || typeof value === "string";
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+	return isFiniteNumber(value) && Number.isInteger(value) && value >= 0;
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+	return isFiniteNumber(value) && value >= 0;
 }
 
 function jsonByteLength(value: unknown): number | null {

--- a/.pi/extensions/runtime-diagnostics/snapshot.ts
+++ b/.pi/extensions/runtime-diagnostics/snapshot.ts
@@ -12,6 +12,7 @@ const MAX_RUNTIME_RECORDS = 20;
 
 const RUNTIME_SNAPSHOT_REASONS = [
 	"session_start",
+	"session_tree",
 	"model_select",
 	"before_agent_start",
 	"tools_changed",
@@ -64,7 +65,7 @@ export interface ToolCatalogEntry {
 	name: string;
 	active: boolean;
 	inactiveReason: string | null;
-	definitionBytes: number | null;
+	knownProviderDefinitionBytes: number | null;
 	source: {
 		path: string;
 		source: string;
@@ -257,11 +258,10 @@ function collectToolCatalog(pi: ExtensionAPI): ToolCatalogEntry[] {
 				inactiveReason: isActive
 					? null
 					: "Registered but not active; Pi does not expose whether configuration, filtering, or deferred loading caused this state.",
-				definitionBytes: jsonByteLength({
+				knownProviderDefinitionBytes: jsonByteLength({
 					name: tool.name,
 					description: tool.description,
 					parameters: tool.parameters,
-					promptGuidelines: tool.promptGuidelines,
 				}),
 				source: sanitizeSourceInfo(tool.sourceInfo),
 			};

--- a/.pi/extensions/runtime-diagnostics/snapshot.ts
+++ b/.pi/extensions/runtime-diagnostics/snapshot.ts
@@ -1,4 +1,8 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, parse } from "node:path";
 import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent";
+import { sanitizeDiagnosticText } from "./text.js";
 
 export const RUNTIME_ENTRY_TYPE = "pi-debug:runtime-snapshot";
 const MAX_TOOL_NAMES = 200;
@@ -53,6 +57,29 @@ export interface ToolState {
 	omittedCount: number;
 }
 
+export interface ToolCatalogEntry {
+	name: string;
+	active: boolean;
+	inactiveReason: string | null;
+	definitionBytes: number | null;
+	source: {
+		path: string;
+		source: string;
+		scope: string;
+		origin: string;
+	};
+}
+
+export interface ExtensionSurface {
+	path: string;
+	source: string;
+	scope: string;
+	origin: string;
+	version: string | null;
+	tools: string[];
+	commands: string[];
+}
+
 export interface RuntimeDiagnosticReport {
 	capturedAt: number;
 	sessionId: string;
@@ -60,6 +87,12 @@ export interface RuntimeDiagnosticReport {
 		provider: string | null;
 		model: string | null;
 		thinkingLevel: string;
+	};
+	environment: {
+		piCodingAgentVersion: string | null;
+		nodeVersion: string;
+		platform: string;
+		architecture: string;
 	};
 	cache: {
 		requestCount: number;
@@ -72,6 +105,7 @@ export interface RuntimeDiagnosticReport {
 		recent: ResponseCacheSample[];
 	};
 	tools: ToolState;
+	toolCatalog: ToolCatalogEntry[];
 	extensions: {
 		visibility: string;
 		visibleCount: number;
@@ -80,15 +114,6 @@ export interface RuntimeDiagnosticReport {
 	};
 	issues: string[];
 	recentRuntimeRecords: RuntimeSnapshot[];
-}
-
-interface ExtensionSurface {
-	path: string;
-	source: string;
-	scope: string;
-	origin: string;
-	tools: string[];
-	commands: string[];
 }
 
 interface ResponseIdentity {
@@ -108,10 +133,10 @@ export function createRuntimeSnapshot(
 		version: 1,
 		capturedAt,
 		reason,
-		sessionId: ctx.sessionManager.getSessionId(),
-		provider: ctx.model?.provider ?? null,
-		model: ctx.model?.id ?? null,
-		thinkingLevel: pi.getThinkingLevel(),
+		sessionId: sanitizeDiagnosticText(ctx.sessionManager.getSessionId(), 128),
+		provider: ctx.model?.provider ? sanitizeDiagnosticText(ctx.model.provider, 128) : null,
+		model: ctx.model?.id ? sanitizeDiagnosticText(ctx.model.id, 256) : null,
+		thinkingLevel: sanitizeDiagnosticText(pi.getThinkingLevel(), 32),
 		cache: response
 			? createCacheSample(response.usage, capturedAt, response.provider, response.model)
 			: null,
@@ -135,6 +160,8 @@ export function createRuntimeReport(
 ): RuntimeDiagnosticReport {
 	const entries = ctx.sessionManager.getBranch();
 	const tools = collectToolState(pi);
+	const toolCatalog = collectToolCatalog(pi);
+	const extensions = collectExtensionSurfaces(pi);
 	const issues: string[] = [];
 	if (!ctx.model) issues.push("No active model is available in the extension context.");
 	if (tools.unknownActive.length > 0) {
@@ -142,20 +169,48 @@ export function createRuntimeReport(
 			`Active tools missing from the configured catalog: ${tools.unknownActive.join(", ")}.`,
 		);
 	}
+	for (const duplicate of duplicateNames(toolCatalog.map(({ name }) => name))) {
+		issues.push(`The configured tool catalog exposes the duplicate name ${duplicate}.`);
+	}
+	for (const duplicate of duplicateSurfaceNames(extensions.surfaces, "tools")) {
+		issues.push(`Multiple visible extension surfaces expose the tool ${duplicate}.`);
+	}
+	for (const duplicate of duplicateSurfaceNames(extensions.surfaces, "commands")) {
+		issues.push(`Multiple visible extension surfaces expose the command ${duplicate}.`);
+	}
 
 	return {
 		capturedAt,
-		sessionId: ctx.sessionManager.getSessionId(),
+		sessionId: sanitizeDiagnosticText(ctx.sessionManager.getSessionId(), 128),
 		current: {
-			provider: ctx.model?.provider ?? null,
-			model: ctx.model?.id ?? null,
-			thinkingLevel: pi.getThinkingLevel(),
+			provider: ctx.model?.provider ? sanitizeDiagnosticText(ctx.model.provider, 128) : null,
+			model: ctx.model?.id ? sanitizeDiagnosticText(ctx.model.id, 256) : null,
+			thinkingLevel: sanitizeDiagnosticText(pi.getThinkingLevel(), 32),
+		},
+		environment: {
+			piCodingAgentVersion: resolvePiCodingAgentVersion(),
+			nodeVersion: sanitizeDiagnosticText(process.version, 64),
+			platform: sanitizeDiagnosticText(process.platform, 32),
+			architecture: sanitizeDiagnosticText(process.arch, 32),
 		},
 		cache: collectCacheMetrics(entries),
 		tools,
-		extensions: collectExtensionSurfaces(pi),
+		toolCatalog,
+		extensions,
 		issues,
 		recentRuntimeRecords: collectRuntimeRecords(entries),
+	};
+}
+
+export function compareRuntimeSnapshots(from: RuntimeSnapshot, to: RuntimeSnapshot) {
+	return {
+		fromCapturedAt: from.capturedAt,
+		toCapturedAt: to.capturedAt,
+		providerChanged: from.provider !== to.provider,
+		modelChanged: from.model !== to.model,
+		thinkingLevelChanged: from.thinkingLevel !== to.thinkingLevel,
+		activeTools: diffNames(from.tools.active, to.tools.active),
+		inactiveTools: diffNames(from.tools.inactive, to.tools.inactive),
 	};
 }
 
@@ -163,12 +218,14 @@ function collectToolState(pi: ExtensionAPI): ToolState {
 	const configured = [...pi.getAllTools()].sort((left, right) =>
 		left.name.localeCompare(right.name),
 	);
-	const configuredNames = new Set(configured.map(({ name }) => name));
-	const activeNames = [...new Set(pi.getActiveTools())].sort((left, right) =>
-		left.localeCompare(right),
-	);
+	const configuredNames = new Set(configured.map(({ name }) => sanitizeDiagnosticText(name, 128)));
+	const activeNames = [...new Set(pi.getActiveTools())]
+		.map((name) => sanitizeDiagnosticText(name, 128))
+		.sort((left, right) => left.localeCompare(right));
 	const knownActive = activeNames.filter((name) => configuredNames.has(name));
-	const inactive = configured.map(({ name }) => name).filter((name) => !activeNames.includes(name));
+	const inactive = configured
+		.map(({ name }) => sanitizeDiagnosticText(name, 128))
+		.filter((name) => !activeNames.includes(name));
 	const unknownActive = activeNames.filter((name) => !configuredNames.has(name));
 	const visible = [...knownActive, ...inactive].slice(0, MAX_TOOL_NAMES);
 	const visibleSet = new Set(visible);
@@ -182,6 +239,30 @@ function collectToolState(pi: ExtensionAPI): ToolState {
 		unknownActive,
 		omittedCount: Math.max(0, knownActive.length + inactive.length - visible.length),
 	};
+}
+
+function collectToolCatalog(pi: ExtensionAPI): ToolCatalogEntry[] {
+	const active = new Set(pi.getActiveTools());
+	return [...pi.getAllTools()]
+		.sort((left, right) => left.name.localeCompare(right.name))
+		.slice(0, MAX_TOOL_NAMES)
+		.map((tool) => {
+			const isActive = active.has(tool.name);
+			return {
+				name: sanitizeDiagnosticText(tool.name, 128),
+				active: isActive,
+				inactiveReason: isActive
+					? null
+					: "Registered but not active; Pi does not expose whether configuration, filtering, or deferred loading caused this state.",
+				definitionBytes: jsonByteLength({
+					name: tool.name,
+					description: tool.description,
+					parameters: tool.parameters,
+					promptGuidelines: tool.promptGuidelines,
+				}),
+				source: sanitizeSourceInfo(tool.sourceInfo),
+			};
+		});
 }
 
 function collectCacheMetrics(entries: readonly SessionEntry[]): RuntimeDiagnosticReport["cache"] {
@@ -227,8 +308,8 @@ function createCacheSample(
 	const promptTokens = input + cacheRead + cacheWrite;
 	return {
 		capturedAt,
-		provider: provider ?? null,
-		model: model ?? null,
+		provider: provider ? sanitizeDiagnosticText(provider, 128) : null,
+		model: model ? sanitizeDiagnosticText(model, 256) : null,
 		input,
 		cacheRead,
 		cacheWrite,
@@ -255,16 +336,16 @@ function collectExtensionSurfaces(pi: ExtensionAPI): RuntimeDiagnosticReport["ex
 		kind: "tools" | "commands",
 		name: string,
 	) => {
-		const key = `${sourceInfo.path}\u0000${sourceInfo.source}`;
+		const sanitizedSource = sanitizeSourceInfo(sourceInfo);
+		const key = `${sanitizedSource.path}\u0000${sanitizedSource.source}`;
 		const surface = surfaces.get(key) ?? {
-			path: sourceInfo.path,
-			source: sourceInfo.source,
-			scope: sourceInfo.scope,
-			origin: sourceInfo.origin,
+			...sanitizedSource,
+			version:
+				sourceInfo.origin === "package" ? resolveOwningPackageVersion(sourceInfo.path) : null,
 			tools: [],
 			commands: [],
 		};
-		surface[kind].push(name);
+		surface[kind].push(sanitizeDiagnosticText(name, 128));
 		surfaces.set(key, surface);
 	};
 
@@ -293,6 +374,90 @@ function collectExtensionSurfaces(pi: ExtensionAPI): RuntimeDiagnosticReport["ex
 	};
 }
 
+function sanitizeSourceInfo(sourceInfo: {
+	path: string;
+	source: string;
+	scope: string;
+	origin: string;
+}) {
+	return {
+		path: sanitizeDiagnosticText(sourceInfo.path, 1024),
+		source: sanitizeDiagnosticText(sourceInfo.source, 256),
+		scope: sanitizeDiagnosticText(sourceInfo.scope, 32),
+		origin: sanitizeDiagnosticText(sourceInfo.origin, 32),
+	};
+}
+
+let cachedPiVersion: string | null | undefined;
+
+function resolvePiCodingAgentVersion(): string | null {
+	if (cachedPiVersion !== undefined) return cachedPiVersion;
+	try {
+		const entryPath = createRequire(import.meta.url).resolve("@earendil-works/pi-coding-agent");
+		cachedPiVersion = findPackageVersion(entryPath, "@earendil-works/pi-coding-agent");
+	} catch {
+		cachedPiVersion = null;
+	}
+	return cachedPiVersion;
+}
+
+const packageVersionCache = new Map<string, string | null>();
+
+function resolveOwningPackageVersion(sourcePath: string): string | null {
+	if (packageVersionCache.has(sourcePath)) return packageVersionCache.get(sourcePath) ?? null;
+	const version = findPackageVersion(sourcePath);
+	packageVersionCache.set(sourcePath, version);
+	return version;
+}
+
+function findPackageVersion(startPath: string, expectedName?: string): string | null {
+	let directory = dirname(startPath);
+	const root = parse(directory).root;
+	for (let depth = 0; depth < 8 && directory !== root; depth += 1) {
+		try {
+			const manifest = JSON.parse(readFileSync(join(directory, "package.json"), "utf8")) as {
+				name?: unknown;
+				version?: unknown;
+			};
+			if (
+				typeof manifest.version === "string" &&
+				(!expectedName || manifest.name === expectedName)
+			) {
+				return sanitizeDiagnosticText(manifest.version, 64);
+			}
+		} catch {
+			// Continue toward the filesystem root until an owning manifest is found.
+		}
+		directory = dirname(directory);
+	}
+	return null;
+}
+
+function duplicateSurfaceNames(
+	surfaces: readonly ExtensionSurface[],
+	kind: "tools" | "commands",
+): string[] {
+	return duplicateNames(surfaces.flatMap((surface) => surface[kind]));
+}
+
+function duplicateNames(names: readonly string[]): string[] {
+	const counts = new Map<string, number>();
+	for (const name of names) counts.set(name, (counts.get(name) ?? 0) + 1);
+	return [...counts.entries()]
+		.filter(([, count]) => count > 1)
+		.map(([name]) => name)
+		.sort();
+}
+
+function diffNames(from: readonly string[], to: readonly string[]) {
+	const previous = new Set(from);
+	const current = new Set(to);
+	return {
+		added: to.filter((name) => !previous.has(name)),
+		removed: from.filter((name) => !current.has(name)),
+	};
+}
+
 function isRuntimeSnapshot(value: unknown): value is RuntimeSnapshot {
 	if (!isRecord(value)) return false;
 	return (
@@ -302,6 +467,14 @@ function isRuntimeSnapshot(value: unknown): value is RuntimeSnapshot {
 		typeof value.sessionId === "string" &&
 		isRecord(value.tools)
 	);
+}
+
+function jsonByteLength(value: unknown): number | null {
+	try {
+		return Buffer.byteLength(JSON.stringify(value), "utf8");
+	} catch {
+		return null;
+	}
 }
 
 function finiteNumber(value: unknown): number {

--- a/.pi/extensions/runtime-diagnostics/text.ts
+++ b/.pi/extensions/runtime-diagnostics/text.ts
@@ -1,0 +1,22 @@
+import { stripTerminalSequences } from "@earendil-works/pi-tui";
+
+export function sanitizeDiagnosticText(value: string, maximumLength = 512): string {
+	const safeCharacters = [...stripTerminalSequences(value)].filter((character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return !isForbiddenCodePoint(codePoint);
+	});
+	const sanitized = safeCharacters.join("").split(/\s+/u).filter(Boolean).join(" ");
+	if (sanitized.length <= maximumLength) return sanitized;
+	return `${sanitized.slice(0, Math.max(0, maximumLength - 1))}…`;
+}
+
+function isForbiddenCodePoint(codePoint: number): boolean {
+	return (
+		codePoint <= 8 ||
+		(codePoint >= 11 && codePoint <= 12) ||
+		(codePoint >= 14 && codePoint <= 31) ||
+		(codePoint >= 127 && codePoint <= 159) ||
+		(codePoint >= 0x202a && codePoint <= 0x202e) ||
+		(codePoint >= 0x2066 && codePoint <= 0x2069)
+	);
+}

--- a/.pi/extensions/runtime-diagnostics/text.ts
+++ b/.pi/extensions/runtime-diagnostics/text.ts
@@ -16,6 +16,8 @@ function isForbiddenCodePoint(codePoint: number): boolean {
 		(codePoint >= 11 && codePoint <= 12) ||
 		(codePoint >= 14 && codePoint <= 31) ||
 		(codePoint >= 127 && codePoint <= 159) ||
+		codePoint === 0x061c ||
+		(codePoint >= 0x200e && codePoint <= 0x200f) ||
 		(codePoint >= 0x202a && codePoint <= 0x202e) ||
 		(codePoint >= 0x2066 && codePoint <= 0x2069)
 	);

--- a/.pi/extensions/runtime-diagnostics/tsconfig.json
+++ b/.pi/extensions/runtime-diagnostics/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["./*.ts"]
+}

--- a/.pi/extensions/runtime-diagnostics/vitest.config.ts
+++ b/.pi/extensions/runtime-diagnostics/vitest.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	root: fileURLToPath(new URL(".", import.meta.url)),
+	cacheDir: fileURLToPath(
+		new URL("../../../node_modules/.cache/runtime-diagnostics-vite", import.meta.url),
+	),
+	test: {
+		include: ["*.test.ts"],
+		testTimeout: 5_000,
+	},
+});


### PR DESCRIPTION
## Summary

- make `runtime_diagnostics` concise by default with selectable full-detail sections
- add provider/runtime comparisons, cache and tool findings, request sizing, response timing, provenance, versions, and sanitized bundles
- add session-scoped capture retention, privacy allowlist auditing, terminal-safe output, and `/runtime-diagnostics` human-readable routes
- redact local source paths and package references from bundles, clear unmatched response attribution at `agent_end`, and reject malformed restored runtime snapshots
- decode Google/Vertex and Bedrock tool payloads, distinguish unsupported Google response telemetry, and restore diagnostics after `session_tree` navigation
- make bundles include every section, strip all Unicode bidirectional controls, and report honest lower-bound catalog sizes when Pi does not expose `constrainedSampling`
- add extension-local documentation, TypeScript checks, and focused Vitest coverage

## Verification

- `npx biome check .pi/extensions/runtime-diagnostics`
- `npx tsc -p .pi/extensions/runtime-diagnostics/tsconfig.json`
- `npx vitest run --config .pi/extensions/runtime-diagnostics/vitest.config.ts` (10 tests)
- `npm run check`
- `npm test` (381 files, 3,372 tests)
- `PI_OFFLINE=1 pi --no-extensions -e ./.pi/extensions/runtime-diagnostics/index.ts --list-models`
- `PI_OFFLINE=1 pi --approve --list-models`

## Audits and limitations

- audited against `docs/extension-conventions.md` and `docs/extension-settings.md`
- audited cancellation, session replacement, tree navigation, shutdown, branch reconstruction, privacy, output bounds, and provider-prefix non-mutation
- `ExtensionAPI.getAllTools()` does not expose `constrainedSampling`, so per-tool catalog sizes are explicit lower bounds; captured provider requests report actual serialized tool-container bytes
- retention bounds the active reporting window but cannot erase append-only custom entries already stored in a session file
- interactive `/reload` was not run because it would replace the active agent runtime; explicit loading and trusted-project auto-discovery passed
- no Changeset is needed because this is a project-local extension
