### PR TITLE
fix: require native deferred tool loading

### DIFF
--- a/.changeset/native-deferred-tools.md
+++ b/.changeset/native-deferred-tools.md
@@ -1,0 +1,6 @@
+---
+"@narumitw/pi-chrome-devtools": patch
+"@narumitw/pi-firecrawl": patch
+---
+
+Use native deferred tool loading only on supported models and eagerly expose configured tools otherwise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,9 @@ Run commands from the repository root unless a command says otherwise.
 
 - Do not call Pi action methods such as `getThinkingLevel()` during extension factory load; defer them until `session_start` or later.
 - Preserve the serialized model-visible system prompt, ordered active tool definitions, and existing message prefix across ordinary turns; append new context at the conversation tail and document and test every intentional prefix transition.
-- Keep active tool names, order, and provider-visible definitions stable within each prefix epoch; use Pi's additive deferred-tool-loading path instead of replacing the active set when dynamic loading is required.
+- Lazy-load extension tools only through Pi's purely additive `pi.setActiveTools()` deferred-loading path, and never remove or replace active tools in the activation call.
+- Enable tool lazy loading only when the selected model and provider support Pi's native deferred protocol; otherwise expose the configured tools before the next model request and never use Pi's cache-invalidating fallback.
+- Keep the loader active for the session and omit `promptSnippet` and `promptGuidelines` from lazily loaded tools so activation preserves the stable system-prompt prefix.
 - Treat `agent_end` as a run boundary and `agent_settled` as the idle boundary for retries, final cleanup, and next-item activation.
 - Persist non-model state with `pi.appendEntry()` or tool-result `details`; inject a required compaction-sensitive model contract through one deterministic, deduplicated `context` hook block only after the original handoff disappears.
 - Key headless session-owned resources by `sessionManager`, not `ctx.ui`, because headless runners can share one no-op UI object.

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -120,10 +120,10 @@ These conventions preserve cache-eligible request prefixes but cannot guarantee 
   Provider-visible definitions include `name`, `description`, `parameters`, and `constrainedSampling`; runtime implementations, renderers, and labels do not.
   Remember that `promptSnippet` and `promptGuidelines` rebuild the system prompt even though they are not provider tool-definition fields.
   **Verification:** `Test` the effective system prompt, ordered active names, and normalized provider-visible definitions across consecutive ordinary requests when tool activation or metadata changes.
-- **MUST:** Use Pi's additive deferred-tool-loading path when dynamic loading is required and the selected model and provider support it.
-  Keep the loader active, add tools without removing active tools in the same transition, and normally omit `promptSnippet` and `promptGuidelines` from lazily activated tools.
-  Document fallback behavior because unsupported providers resend the complete active tool list and may invalidate the cached prefix.
-  **Verification:** `Test` additive activation at the loader tool result, `Review` fallback behavior, and run a provider `Smoke` when claiming native deferred loading for a custom model or proxy.
+- **MUST:** Lazy-load extension tools only through Pi's additive deferred-tool-loading path and only when the selected model and provider support Pi's native deferred protocol.
+  Keep the loader active, add tools without removing active tools in the same transition, and omit `promptSnippet` and `promptGuidelines` from lazily activated tools.
+  When native deferred loading is unsupported, expose the configured tools before the next model request and do not use Pi's fallback that resends the complete active tool list after a loader result.
+  **Verification:** `Test` native additive activation at the loader tool result and eager exposure for unsupported models, plus a provider `Smoke` when claiming native deferred loading for a custom model or proxy.
 - **MUST:** Do not rewrite provider message ordering or leading instructions in `before_provider_request` unless provider compatibility requires it.
   Document and test every intentional provider-prefix transition, and treat the first request after the transition as the baseline for the new prefix epoch.
   Correctness and provider compatibility take precedence over cache preservation.

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -158,7 +158,9 @@ The loader accepts a task-oriented `query`, matches it against the five capabili
 
 Loaded capability tools remain active for the rest of the session unless the user makes them unavailable through `/chrome-devtools`.
 
-Pi uses native deferred tool references on compatible Anthropic models and native additional-tools or tool-search loading on compatible OpenAI and Codex Responses models.
+Pi uses native deferred tool references on compatible Anthropic models, native additional-tools or tool-search loading on compatible OpenAI and Codex Responses models, and native Kimi loading on compatible OpenAI Chat Completions models.
+
+Kimi-compatible models declare `compat.deferredToolsMode: "kimi"` in Pi's model metadata.
 
 `azure-openai-responses` remains eager because Pi's Azure adapter does not implement native deferred tool-search serialization.
 

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -158,7 +158,7 @@ The loader accepts a task-oriented `query`, matches it against the five capabili
 
 Loaded capability tools remain active for the rest of the session unless the user makes them unavailable through `/chrome-devtools`.
 
-Pi uses native deferred tool references on compatible Anthropic models and native tool search on compatible OpenAI Responses models.
+Pi uses native deferred tool references on compatible Anthropic models and native additional-tools or tool-search loading on compatible OpenAI and Codex Responses models.
 
 `azure-openai-responses` remains eager because Pi's Azure adapter does not implement native deferred tool-search serialization.
 

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -14,7 +14,7 @@ The design is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDevTo
 - Reuses an existing CDP endpoint or lazily launches an isolated Chromium-family browser.
 - Recovers from stale page selections and reports actionable browser startup or endpoint errors.
 - Loads explicitly approved unpacked extensions only in an extension-owned Chrome for Testing or Chromium process.
-- Keeps browser tools lazy and exposes availability, setup, status, and help through `/chrome-devtools`.
+- Uses native deferred browser tools when supported and eager exposure otherwise, with availability, setup, status, and help through `/chrome-devtools`.
 - Shows compact expandable results and activity only while browser tools are running.
 - Persists reviewed tool availability while keeping browser connection settings machine-owned.
 
@@ -148,21 +148,25 @@ It never closes user-started browsers or remote endpoints.
 - `chrome_devtools_evaluate` — evaluate JavaScript in the selected page.
 - `chrome_devtools_screenshot` — capture a PNG screenshot and save it as a PNG file.
 
-### Lazy tool loading
+### Tool exposure
 
-All six tools are registered, but only `chrome_devtools_load` starts active for this extension.
+All six tools are registered.
+
+On a model/provider with native deferred-tool support, only `chrome_devtools_load` starts active for this extension.
 
 The loader accepts a task-oriented `query`, matches it against the five capability tools, and adds matching available tools without removing any active Pi tool.
 
 Loaded capability tools remain active for the rest of the session unless the user makes them unavailable through `/chrome-devtools`.
 
-Pi uses native deferred tool references on compatible Anthropic and OpenAI models.
+Pi uses native deferred tool references on compatible Anthropic models and native tool search on compatible OpenAI Responses models.
 
-Other models receive Pi's safe fallback: the newly active definitions appear in the normal tool list on the next model request.
+When the selected model/provider lacks native deferred support, the extension activates every capability allowed by settings before the next model request instead of using Pi's cache-invalidating lazy-loading fallback.
 
-The capability tools omit active-only prompt snippets so a lazy load does not rebuild the system prompt prefix.
+After a session enters eager exposure, it stays eager across later model switches to avoid removing tool definitions within that session.
 
-The saved `tools` array controls which capabilities the loader may expose.
+The capability tools omit active-only prompt snippets so native deferred loading does not rebuild the system-prompt prefix.
+
+The saved `tools` array controls which capabilities the extension may expose.
 
 An empty array leaves the loader active but makes every browser capability unavailable.
 
@@ -198,7 +202,7 @@ If the model cannot inspect the inline image, ask it to read the saved path, for
 /chrome-devtools
 ```
 
-Opens a menu that shows the lazy catalog size, whether that catalog is saved, the configured endpoint, the observed managed-browser state, and any settings or launch warning before you choose an action.
+Opens a menu that shows the tool catalog size, whether that catalog is saved, the configured endpoint, the observed managed-browser state, and any settings or launch warning before you choose an action.
 The five actions stay on one level:
 
 - **Choose available browser tools…** — stage any combination of the five capabilities, then review the exact available/unavailable result before selecting **Apply tool changes**.
@@ -235,7 +239,7 @@ Compatibility aliases remain available: `toggle` and `select` mean `tools`, `on`
 - `settings` opens the same immediate-save browser settings flow used by the menu.
 - `tools` opens the same staged, width-safe availability and review flow used by the menu.
 - `toggle` and `select` are compatibility aliases for `tools`.
-- `enable` makes all five capability tools available to the loader and saves that catalog; `on` is a compatibility alias.
+- `enable` makes all five capability tools available and follows the current native-deferred or eager exposure mode; `on` is a compatibility alias.
 - `disable` makes all five capability tools unavailable and saves the empty catalog; `off` is a compatibility alias.
   The slash command and `chrome_devtools_load` remain available.
 
@@ -258,7 +262,7 @@ Confirmed menu changes apply before the next browser connection and close only a
 Manual JSON edits and unpacked-extension changes apply after `/reload` or session replacement.
 
 When the file is missing or invalid, the extension preserves Pi's current Chrome DevTools availability policy instead of replacing it.
-A valid saved catalog is restored on Pi startup and `/reload`, while its capability definitions remain deferred.
+A valid saved catalog is restored on Pi startup and `/reload`, with capability definitions exposed natively deferred or eagerly according to model/provider support.
 A missing file is created by the first confirmed browser or tool setting.
 Within one Pi process, all browser and tool saves run in invocation order, reread the latest valid document, publish by temporary-file rename, and preserve unknown fields.
 Malformed JSON or invalid recognized fields make menu mutation unavailable and block direct saves without replacement; a failed save restores the prior displayed and effective state.

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -160,6 +160,8 @@ Loaded capability tools remain active for the rest of the session unless the use
 
 Pi uses native deferred tool references on compatible Anthropic models and native tool search on compatible OpenAI Responses models.
 
+`azure-openai-responses` remains eager because Pi's Azure adapter does not implement native deferred tool-search serialization.
+
 When the selected model/provider lacks native deferred support, the extension activates every capability allowed by settings before the next model request instead of using Pi's cache-invalidating lazy-loading fallback.
 
 After a session enters eager exposure, it stays eager across later model switches to avoid removing tool definitions within that session.

--- a/packages/pi-chrome-devtools/src/chrome-devtools.ts
+++ b/packages/pi-chrome-devtools/src/chrome-devtools.ts
@@ -2,9 +2,11 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-c
 import { shutdownManagedBrowser } from "./browser-manager.js";
 import {
 	availableChromeDevtoolsTools,
-	configureLazyChromeDevtoolsTools,
+	configureChromeDevtoolsToolExposure,
 	createChromeDevtoolsLoadTool,
 	initializeAvailableChromeDevtoolsTools,
+	requireEagerChromeDevtoolsToolExposure,
+	supportsNativeDeferredToolLoading,
 } from "./lazy-tools.js";
 import { applyRuntimeBrowserSettings, state } from "./runtime.js";
 import { loadSettings, waitForSettingsWrites } from "./settings.js";
@@ -41,7 +43,7 @@ const COMMAND_COMPLETIONS = [
 	{ value: "quickstart", label: "quickstart", description: "Show endpoint and launch help" },
 	{ value: "status", label: "status", description: "Show tool and settings status" },
 	{ value: "settings", label: "settings", description: "Edit browser connection settings" },
-	{ value: "tools", label: "tools", description: "Choose lazy-loadable Chrome DevTools tools" },
+	{ value: "tools", label: "tools", description: "Choose available Chrome DevTools tools" },
 	{ value: "toggle", label: "toggle", description: "Alias for tools" },
 	{ value: "select", label: "select", description: "Compatibility alias for tools" },
 	{ value: "enable", label: "enable", description: "Make all Chrome DevTools tools available" },
@@ -90,7 +92,13 @@ export default function chromeDevtools(pi: ExtensionAPI) {
 			settings.kind === "loaded" && settings.settings.tools
 				? settings.settings.tools
 				: availableChromeDevtoolsTools(pi);
-		configureLazyChromeDevtoolsTools(pi, availableTools);
+		configureChromeDevtoolsToolExposure(pi, availableTools, ctx.model);
+	});
+
+	pi.on("model_select", (event) => {
+		if (!supportsNativeDeferredToolLoading(event.model)) {
+			requireEagerChromeDevtoolsToolExposure(pi);
+		}
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {

--- a/packages/pi-chrome-devtools/src/lazy-tools.ts
+++ b/packages/pi-chrome-devtools/src/lazy-tools.ts
@@ -99,11 +99,7 @@ export function supportsNativeDeferredToolLoading(model: ExtensionContext["model
 		const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;
 		return major > 4 || (major === 4 && minor >= 5);
 	}
-	if (
-		model.api === "openai-responses" ||
-		model.api === "openai-codex-responses" ||
-		model.api === "azure-openai-responses"
-	) {
+	if (model.api === "openai-responses" || model.api === "openai-codex-responses") {
 		return compatBoolean(model.compat, "supportsToolSearch") === true;
 	}
 	return false;

--- a/packages/pi-chrome-devtools/src/lazy-tools.ts
+++ b/packages/pi-chrome-devtools/src/lazy-tools.ts
@@ -1,4 +1,8 @@
-import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	defineTool,
+	type ExtensionAPI,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { CHROME_DEVTOOLS_TOOL_NAMES, type ChromeDevToolsToolName } from "./tool-names.js";
 
@@ -13,6 +17,7 @@ const existingAvailableToolsStore = sharedGlobal[AVAILABLE_TOOLS_STORE];
 const availableToolsByApi =
 	existingAvailableToolsStore ?? new WeakMap<ExtensionAPI, Set<ChromeDevToolsToolName>>();
 if (!existingAvailableToolsStore) sharedGlobal[AVAILABLE_TOOLS_STORE] = availableToolsByApi;
+const lazyExposureByApi = new WeakMap<ExtensionAPI, boolean>();
 
 const SEARCH_TEXT: Record<ChromeDevToolsToolName, string> = {
 	chrome_devtools_list_pages: "list open inspectable chrome browser pages tabs targets",
@@ -31,15 +36,30 @@ export function initializeAvailableChromeDevtoolsTools(pi: ExtensionAPI) {
 	);
 }
 
-export function configureLazyChromeDevtoolsTools(
+export function configureChromeDevtoolsToolExposure(
 	pi: ExtensionAPI,
 	availableTools: readonly ChromeDevToolsToolName[],
+	model?: ExtensionContext["model"],
 ) {
-	setAvailableTools(pi, availableTools);
+	const available = setAvailableTools(pi, availableTools);
+	const lazyExposure = supportsNativeDeferredToolLoading(model);
+	lazyExposureByApi.set(pi, lazyExposure);
+	const exposedTools = lazyExposure
+		? []
+		: CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => available.has(name));
 	const nonCapabilityTools = pi
 		.getActiveTools()
 		.filter((name) => !CHROME_DEVTOOLS_TOOL_NAMES.includes(name as ChromeDevToolsToolName));
-	pi.setActiveTools(unique([...nonCapabilityTools, CHROME_DEVTOOLS_LOAD_TOOL_NAME]));
+	pi.setActiveTools(
+		unique([...nonCapabilityTools, CHROME_DEVTOOLS_LOAD_TOOL_NAME, ...exposedTools]),
+	);
+}
+
+export function requireEagerChromeDevtoolsToolExposure(pi: ExtensionAPI) {
+	lazyExposureByApi.set(pi, false);
+	const active = pi.getActiveTools();
+	const available = availableChromeDevtoolsTools(pi);
+	pi.setActiveTools(unique([...active, CHROME_DEVTOOLS_LOAD_TOOL_NAME, ...available]));
 }
 
 export function applyAvailableChromeDevtoolsTools(
@@ -47,14 +67,46 @@ export function applyAvailableChromeDevtoolsTools(
 	availableTools: readonly ChromeDevToolsToolName[],
 ) {
 	const available = setAvailableTools(pi, availableTools);
+	const lazyExposure = lazyExposureByApi.get(pi) === true;
 	const active = pi
 		.getActiveTools()
 		.filter(
 			(name) =>
 				!CHROME_DEVTOOLS_TOOL_NAMES.includes(name as ChromeDevToolsToolName) ||
-				available.has(name as ChromeDevToolsToolName),
+				(lazyExposure && available.has(name as ChromeDevToolsToolName)),
 		);
-	pi.setActiveTools(unique([...active, CHROME_DEVTOOLS_LOAD_TOOL_NAME]));
+	const eagerTools = lazyExposure
+		? []
+		: CHROME_DEVTOOLS_TOOL_NAMES.filter((name) => available.has(name));
+	pi.setActiveTools(unique([...active, CHROME_DEVTOOLS_LOAD_TOOL_NAME, ...eagerTools]));
+}
+
+export function chromeDevtoolsToolExposureMode(pi: ExtensionAPI) {
+	return lazyExposureByApi.get(pi) === true ? "native deferred" : "eager";
+}
+
+export function supportsNativeDeferredToolLoading(model: ExtensionContext["model"]): boolean {
+	if (!model) return false;
+	if (model.api === "anthropic-messages") {
+		const configured = compatBoolean(model.compat, "supportsToolReferences");
+		if (configured !== undefined) return configured;
+		if (model.provider !== "anthropic" || model.id.toLowerCase().includes("haiku")) return false;
+		const version = model.id
+			.toLowerCase()
+			.match(/^claude-(?:opus|sonnet|fable)-(\d+)(?:-(\d+))?(?:-|$)/);
+		if (!version) return false;
+		const major = Number(version[1]);
+		const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;
+		return major > 4 || (major === 4 && minor >= 5);
+	}
+	if (
+		model.api === "openai-responses" ||
+		model.api === "openai-codex-responses" ||
+		model.api === "azure-openai-responses"
+	) {
+		return compatBoolean(model.compat, "supportsToolSearch") === true;
+	}
+	return false;
 }
 
 export function availableChromeDevtoolsTools(pi: ExtensionAPI) {
@@ -136,6 +188,12 @@ function setAvailableTools(pi: ExtensionAPI, availableTools: readonly ChromeDevT
 	const available = new Set(availableTools);
 	availableToolsByApi.set(pi, available);
 	return available;
+}
+
+function compatBoolean(value: unknown, key: string) {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+	const record = value as Record<string, unknown>;
+	return typeof record[key] === "boolean" ? record[key] : undefined;
 }
 
 function unique(values: readonly string[]) {

--- a/packages/pi-chrome-devtools/src/lazy-tools.ts
+++ b/packages/pi-chrome-devtools/src/lazy-tools.ts
@@ -90,10 +90,8 @@ export function supportsNativeDeferredToolLoading(model: ExtensionContext["model
 	if (model.api === "anthropic-messages") {
 		const configured = compatBoolean(model.compat, "supportsToolReferences");
 		if (configured !== undefined) return configured;
-		if (model.provider !== "anthropic" || model.id.toLowerCase().includes("haiku")) return false;
-		const version = model.id
-			.toLowerCase()
-			.match(/^claude-(?:opus|sonnet|fable)-(\d+)(?:-(\d+))?(?:-|$)/);
+		if (model.provider !== "anthropic" || model.id.includes("haiku")) return false;
+		const version = model.id.match(/^claude-(?:opus|sonnet|fable)-(\d+)(?:-(\d+))?(?:-|$)/);
 		if (!version) return false;
 		const major = Number(version[1]);
 		const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;

--- a/packages/pi-chrome-devtools/src/lazy-tools.ts
+++ b/packages/pi-chrome-devtools/src/lazy-tools.ts
@@ -100,7 +100,10 @@ export function supportsNativeDeferredToolLoading(model: ExtensionContext["model
 		return major > 4 || (major === 4 && minor >= 5);
 	}
 	if (model.api === "openai-responses" || model.api === "openai-codex-responses") {
-		return compatBoolean(model.compat, "supportsToolSearch") === true;
+		return (
+			compatBoolean(model.compat, "supportsAdditionalTools") === true ||
+			compatBoolean(model.compat, "supportsToolSearch") === true
+		);
 	}
 	return false;
 }

--- a/packages/pi-chrome-devtools/src/lazy-tools.ts
+++ b/packages/pi-chrome-devtools/src/lazy-tools.ts
@@ -99,6 +99,9 @@ export function supportsNativeDeferredToolLoading(model: ExtensionContext["model
 		const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;
 		return major > 4 || (major === 4 && minor >= 5);
 	}
+	if (model.api === "openai-completions") {
+		return compatString(model.compat, "deferredToolsMode") === "kimi";
+	}
 	if (model.api === "openai-responses" || model.api === "openai-codex-responses") {
 		return (
 			compatBoolean(model.compat, "supportsAdditionalTools") === true ||
@@ -193,6 +196,12 @@ function compatBoolean(value: unknown, key: string) {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
 	const record = value as Record<string, unknown>;
 	return typeof record[key] === "boolean" ? record[key] : undefined;
+}
+
+function compatString(value: unknown, key: string) {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+	const record = value as Record<string, unknown>;
+	return typeof record[key] === "string" ? record[key] : undefined;
 }
 
 function unique(values: readonly string[]) {

--- a/packages/pi-chrome-devtools/src/menu.ts
+++ b/packages/pi-chrome-devtools/src/menu.ts
@@ -306,7 +306,7 @@ export async function showChromeDevtoolsToolWorkflow(
 				current.draft = new Set(selectedTools);
 				current.applied = true;
 				ctx.ui.notify(
-					`Saved: ${selectedTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} browser tools available to lazy-load.`,
+					`Saved: ${selectedTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} browser tools available.`,
 					"info",
 				);
 				return { kind: "close" };
@@ -378,7 +378,7 @@ function buildMenuSnapshot(pi: ExtensionAPI, settings: SettingsLoadResult): Menu
 
 function mainStateLines(snapshot: MenuSnapshot) {
 	return sanitizeLines([
-		`Lazy catalog: ${snapshot.activeTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} available · ${snapshot.persistenceLabel}`,
+		`Tool catalog: ${snapshot.activeTools.length} of ${CHROME_DEVTOOLS_TOOL_NAMES.length} available · ${snapshot.persistenceLabel}`,
 		`Browser: ${browserLifecycleSummary()}`,
 		`Endpoint: ${devToolsEndpoint()}`,
 		...(snapshot.settingsWarning ? [`Settings warning: ${snapshot.settingsWarning}`] : []),
@@ -421,7 +421,7 @@ function buildToolReview(current: ToolWorkflowState) {
 			`Current available browser tools: ${current.accepted.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
 			`Proposed available browser tools: ${current.draft.size}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
 			"",
-			"Available to lazy-load after apply:",
+			"Available after apply:",
 			...(available.length > 0
 				? available.map((name) => `  - ${TOOL_PRESENTATION[name].label} (${name})`)
 				: ["  - none"]),
@@ -432,7 +432,8 @@ function buildToolReview(current: ToolWorkflowState) {
 				: ["  - none"]),
 			"",
 			"Other active Pi tools remain unchanged.",
-			"Newly available tools remain deferred until chrome_devtools_load selects them.",
+			"Native-capable models defer these tools until chrome_devtools_load selects them.",
+			"Other models expose available tools eagerly before the next model request.",
 			"The accepted availability policy is saved for future sessions.",
 		].join("\n"),
 	);

--- a/packages/pi-chrome-devtools/src/tool-selector.ts
+++ b/packages/pi-chrome-devtools/src/tool-selector.ts
@@ -122,7 +122,11 @@ async function transactSelectedToolsNow(
 			const previousLoadedChromeTools = previousActiveTools.filter((name) =>
 				CHROME_DEVTOOLS_TOOL_NAMES.includes(name as ChromeDevToolsToolName),
 			);
-			pi.setActiveTools(unique([...currentNonChromeTools, ...previousLoadedChromeTools]));
+			const restoredChromeTools =
+				chromeDevtoolsToolExposureMode(pi) === "eager"
+					? previousAvailableTools
+					: previousLoadedChromeTools;
+			pi.setActiveTools(unique([...currentNonChromeTools, ...restoredChromeTools]));
 		} catch (caught) {
 			rollbackError = caught;
 		}

--- a/packages/pi-chrome-devtools/src/tool-selector.ts
+++ b/packages/pi-chrome-devtools/src/tool-selector.ts
@@ -14,6 +14,7 @@ import {
 	applyAvailableChromeDevtoolsTools,
 	availableChromeDevtoolsTools,
 	CHROME_DEVTOOLS_LOAD_TOOL_NAME,
+	chromeDevtoolsToolExposureMode,
 } from "./lazy-tools.js";
 import { state } from "./runtime.js";
 import { loadSettings, saveSettings, settingsFilePath } from "./settings.js";
@@ -49,7 +50,7 @@ export async function updateChromeDevtoolsTools(
 	if (result !== "saved" || generation !== state.sessionGeneration) return;
 	const status = await buildToolStatusMessage(pi);
 	if (generation !== state.sessionGeneration) return;
-	ctx.ui.notify(`Chrome DevTools lazy catalog ${action}.\n\n${status}`, "info");
+	ctx.ui.notify(`Chrome DevTools tool catalog ${action}.\n\n${status}`, "info");
 }
 
 export async function setSelectedChromeDevtoolsTools(
@@ -179,10 +180,11 @@ export async function buildToolStatusMessage(pi: ExtensionAPI) {
 	const persistedSetting = await persistedSettingLabel();
 	return sanitizeChromeDevtoolsDisplay(
 		[
-			`Chrome DevTools tools available to lazy-load: ${formatRuntimeStatus(summary)}`,
+			`Chrome DevTools tools available: ${formatRuntimeStatus(summary)}`,
+			`Tool exposure: ${chromeDevtoolsToolExposureMode(pi)}`,
 			`Loaded capability tools this session: ${summary.loadedChromeToolCount}/${CHROME_DEVTOOLS_TOOL_NAMES.length}`,
 			`Loader: ${pi.getActiveTools().includes(CHROME_DEVTOOLS_LOAD_TOOL_NAME) ? "active" : "inactive"}`,
-			`Persisted lazy catalog: ${persistedSetting}`,
+			`Persisted tool catalog: ${persistedSetting}`,
 			...browserSettingsStatusLines(),
 			...(state.settingsNotice ? [`Settings note: ${state.settingsNotice}`] : []),
 			`Other active tools preserved: ${summary.activeNonChromeToolCount}`,
@@ -289,9 +291,9 @@ export function buildCommandGuide() {
 		"/chrome-devtools quickstart — show endpoint and launch help",
 		"/chrome-devtools status — show tool and settings status",
 		"/chrome-devtools settings — edit browser connection settings",
-		"/chrome-devtools tools — choose tools available to lazy-load",
+		"/chrome-devtools tools — choose available Chrome DevTools tools",
 		"/chrome-devtools toggle|select — compatibility aliases for tools",
-		"/chrome-devtools enable|on — make all Chrome DevTools tools available to lazy-load",
+		"/chrome-devtools enable|on — make all Chrome DevTools tools available",
 		"/chrome-devtools disable|off — make all Chrome DevTools capability tools unavailable",
 	].join("\n");
 }

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -209,6 +209,24 @@ test("chrome-devtools keeps Azure Responses eager when compat enables tool searc
 	});
 });
 
+test("chrome-devtools keeps uppercase Anthropic model IDs eager", async () => {
+	await withTempAgentDir(async () => {
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const model = {
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "CLAUDE-SONNET-4-5",
+		};
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const { ctx } = createMockContext({ model });
+		chromeDevtoolsModule.default(mock.pi);
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, ...CAPABILITY_TOOLS]);
+	});
+});
+
 test("chrome-devtools honors native Kimi deferred-tool support", async () => {
 	await withTempAgentDir(async () => {
 		const chromeDevtoolsModule = await importFreshChromeDevtools();

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -13,8 +13,8 @@ import path from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { test, vi } from "vitest";
 import {
+	createMockContext as createBaseMockContext,
 	createCustomSelectorHarness,
-	createMockContext,
 	createMockPi,
 } from "../../../test/support.js";
 import chromeDevtools, {
@@ -33,6 +33,17 @@ import chromeDevtools, {
 	selectAllowedRoot,
 } from "../src/chrome-devtools.js";
 import { saveSettings } from "../src/settings.js";
+
+const NATIVE_DEFERRED_MODEL = {
+	api: "openai-responses",
+	provider: "openai",
+	id: "gpt-5.4",
+	compat: { supportsToolSearch: true },
+};
+
+function createMockContext(overrides: Record<string, unknown> = {}) {
+	return createBaseMockContext({ model: NATIVE_DEFERRED_MODEL, ...overrides });
+}
 
 const NEW_SETTINGS_FILE = "pi-chrome-devtools.json";
 const LEGACY_SETTINGS_FILE = "pi-chrome-devtools-settings.json";
@@ -81,7 +92,11 @@ test("chrome-devtools registers deferred CDP tools and one loader", () => {
 		assert.equal(tool.promptSnippet, undefined);
 	}
 	assert.ok(mock.commands.has("chrome-devtools"));
-	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
+	assert.deepEqual([...mock.events.keys()].sort(), [
+		"model_select",
+		"session_shutdown",
+		"session_start",
+	]);
 });
 
 test("chrome-devtools command parsing and completions cover aliases", () => {
@@ -168,6 +183,56 @@ test("chrome-devtools loader additively activates matching allowed tools", async
 	});
 });
 
+test("chrome-devtools eagerly exposes available tools without native deferred loading", async () => {
+	await withTempAgentDir(async () => {
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const unsupportedModel = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.3",
+			compat: { supportsToolSearch: false },
+		};
+		const nativeModel = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.4",
+			compat: { supportsToolSearch: true },
+		};
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const { ctx } = createMockContext({ model: unsupportedModel });
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, ...CAPABILITY_TOOLS]);
+
+		await mock.events.get("model_select")?.[0]?.({ model: nativeModel }, ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, ...CAPABILITY_TOOLS]);
+	});
+});
+
+test("chrome-devtools activates every available tool before switching to an unsupported model", async () => {
+	await withTempAgentDir(async () => {
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const nativeModel = {
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "claude-sonnet-4-5",
+		};
+		const unsupportedModel = {
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "claude-haiku-4-5",
+		};
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const { ctx } = createMockContext({ model: nativeModel });
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
+
+		await mock.events.get("model_select")?.[0]?.({ model: unsupportedModel }, ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, ...CAPABILITY_TOOLS]);
+	});
+});
+
 test("chrome-devtools keeps its missing-settings catalog across session replacement", async () => {
 	await withTempAgentDir(async () => {
 		const chromeDevtoolsModule = await importFreshChromeDevtools();
@@ -241,7 +306,7 @@ test("chrome-devtools loader does not expose tools outside the saved catalog", a
 	});
 });
 
-test("chrome-devtools loads the new settings file as the lazy catalog without a warning", async () => {
+test("chrome-devtools loads the new settings file as the tool catalog without a warning", async () => {
 	await withTempAgentDir(async (agentDir) => {
 		writeSettings(agentDir, NEW_SETTINGS_FILE, [SCREENSHOT_TOOL]);
 		const chromeDevtoolsModule = await importFreshChromeDevtools();
@@ -520,7 +585,7 @@ test("Chrome DevTools main menu dispatches declarative actions at narrow widths"
 	});
 	await mock.commands.get("chrome-devtools")?.handler("", ctx);
 	assert.ok(renders.flat().every((line) => visibleWidth(line) <= 20));
-	assert.match(renders.flat().join("\n"), /Lazy catalog: 0 of 5/);
+	assert.match(renders.flat().join("\n"), /Tool catalog: 0 of 5/);
 	assert.deepEqual(notifications, []);
 });
 

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -209,6 +209,27 @@ test("chrome-devtools keeps Azure Responses eager when compat enables tool searc
 	});
 });
 
+test("chrome-devtools honors native additional-tools support", async () => {
+	await withTempAgentDir(async () => {
+		for (const api of ["openai-responses", "openai-codex-responses"]) {
+			const chromeDevtoolsModule = await importFreshChromeDevtools();
+			const model = {
+				api,
+				provider: api === "openai-responses" ? "openai" : "openai-codex",
+				id: "gpt-5.4",
+				compat: { supportsAdditionalTools: true },
+			};
+			const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+			const { ctx } = createMockContext({ model });
+			chromeDevtoolsModule.default(mock.pi);
+
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+			assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
+		}
+	});
+});
+
 test("chrome-devtools activates every available tool before switching to an unsupported model", async () => {
 	await withTempAgentDir(async () => {
 		const chromeDevtoolsModule = await importFreshChromeDevtools();
@@ -511,6 +532,47 @@ test("chrome-devtools rejects invalid settings updates and restores active tools
 		writeSettings(agentDir, NEW_SETTINGS_FILE, [LIST_PAGES_TOOL]);
 		await mock.commands.get("chrome-devtools")?.handler("disable", ctx);
 		assert.deepEqual(readSettings(agentDir, NEW_SETTINGS_FILE).tools, []);
+	});
+});
+
+test("chrome-devtools keeps failed-save rollback eager after an unsupported model switch", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		const settingsPath = path.join(agentDir, NEW_SETTINGS_FILE);
+		writeFileSync(settingsPath, '{"tools":["invalid"]}\n');
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const { ctx, notifications } = createMockContext();
+		chromeDevtoolsModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
+
+		let markRuntimeApply: (() => void) | undefined;
+		const runtimeApplied = new Promise<void>((resolve) => {
+			markRuntimeApply = resolve;
+		});
+		const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+		mock.rawPi.setActiveTools = (names) => {
+			setActiveTools(names);
+			markRuntimeApply?.();
+			markRuntimeApply = undefined;
+		};
+
+		const command = mock.commands.get("chrome-devtools")?.handler("disable", ctx);
+		await runtimeApplied;
+		await mock.events.get("model_select")?.[0]?.(
+			{
+				model: {
+					api: "anthropic-messages",
+					provider: "anthropic",
+					id: "claude-haiku-4-5",
+				},
+			},
+			ctx,
+		);
+		await command;
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, ...CAPABILITY_TOOLS]);
+		assert.match(notifications.at(-1)?.message ?? "", /settings save failed/i);
 	});
 });
 

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -183,14 +183,14 @@ test("chrome-devtools loader additively activates matching allowed tools", async
 	});
 });
 
-test("chrome-devtools eagerly exposes available tools without native deferred loading", async () => {
+test("chrome-devtools keeps Azure Responses eager when compat enables tool search", async () => {
 	await withTempAgentDir(async () => {
 		const chromeDevtoolsModule = await importFreshChromeDevtools();
 		const unsupportedModel = {
-			api: "openai-responses",
-			provider: "openai",
-			id: "gpt-5.3",
-			compat: { supportsToolSearch: false },
+			api: "azure-openai-responses",
+			provider: "azure-openai-responses",
+			id: "gpt-5.4",
+			compat: { supportsToolSearch: true },
 		};
 		const nativeModel = {
 			api: "openai-responses",

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -209,6 +209,25 @@ test("chrome-devtools keeps Azure Responses eager when compat enables tool searc
 	});
 });
 
+test("chrome-devtools honors native Kimi deferred-tool support", async () => {
+	await withTempAgentDir(async () => {
+		const chromeDevtoolsModule = await importFreshChromeDevtools();
+		const model = {
+			api: "openai-completions",
+			provider: "moonshotai",
+			id: "kimi-k2.6",
+			compat: { deferredToolsMode: "kimi" },
+		};
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const { ctx } = createMockContext({ model });
+		chromeDevtoolsModule.default(mock.pi);
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
+	});
+});
+
 test("chrome-devtools honors native additional-tools support", async () => {
 	await withTempAgentDir(async () => {
 		for (const api of ["openai-responses", "openai-codex-responses"]) {

--- a/packages/pi-chrome-devtools/test/menu.test.ts
+++ b/packages/pi-chrome-devtools/test/menu.test.ts
@@ -43,7 +43,7 @@ test("main menu presents consequential state and five goal-oriented actions with
 
 		await mock.commands.get("chrome-devtools")?.handler("", ctx);
 
-		assert.match(rendered, /Lazy catalog: 2 of 5 available · not\s+saved/);
+		assert.match(rendered, /Tool catalog: 2 of 5 available · not\s+saved/);
 		assert.match(rendered, /Browser: not started · attaches or\s+launches on first use/);
 		assert.match(rendered, /Endpoint: http:\/\/127\.0\.0\.1:9222/);
 		assert.match(rendered, /[→›] Choose available browser tools…/);
@@ -116,7 +116,7 @@ test("main menu shows saved all-enabled state and the reversible disable preview
 
 		await mock.commands.get("chrome-devtools")?.handler("", ctx);
 
-		assert.match(rendered, /Lazy catalog: 5 of 5 available · saved/);
+		assert.match(rendered, /Tool catalog: 5 of 5 available · saved/);
 		assert.match(rendered, /Make all browser tools unavailable…/);
 		assert.match(rendered, /Preview 0 of 5; other active tools stay/);
 	});
@@ -393,8 +393,8 @@ test("apply refreshes review instead of overwriting browser tools changed while 
 		assert.match(refreshedReview, /Proposed availability: 4\/5/);
 		assert.deepEqual(mock.rawPi.getActiveTools(), [
 			"other_tool",
-			...CHROME_TOOLS.slice(0, 3),
 			"chrome_devtools_load",
+			...CHROME_TOOLS.slice(0, 3),
 		]);
 		assert.equal(existsSync(settingsFilePath()), false);
 		assert.match(notifications.at(-1)?.message ?? "", /changed while review was open/i);
@@ -524,8 +524,8 @@ test("RPC dialogs preserve staged review and confirmed apply semantics", async (
 		assert.ok(dialogTitles.some((title) => title.includes("Proposed availability: 4/5")));
 		assert.deepEqual(mock.rawPi.getActiveTools(), [
 			"other_tool",
-			...CHROME_TOOLS.slice(1),
 			"chrome_devtools_load",
+			...CHROME_TOOLS.slice(1),
 		]);
 		assert.deepEqual(
 			JSON.parse(readFileSync(settingsFilePath(), "utf8")).tools,
@@ -588,17 +588,14 @@ test("review previews the exact tool effect and one confirmed apply persists it"
 		assert.deepEqual(applicationOrder, ["wait-for-idle", "apply-runtime"]);
 		assert.deepEqual(mock.rawPi.getActiveTools(), [
 			"other_tool",
-			...CHROME_TOOLS.slice(1),
 			"chrome_devtools_load",
+			...CHROME_TOOLS.slice(1),
 		]);
 		assert.deepEqual(
 			JSON.parse(readFileSync(settingsFilePath(), "utf8")).tools,
 			CHROME_TOOLS.slice(1),
 		);
-		assert.match(
-			notifications.at(-1)?.message ?? "",
-			/Saved: 4 of 5 browser tools available to lazy-load/,
-		);
+		assert.match(notifications.at(-1)?.message ?? "", /Saved: 4 of 5 browser tools available/);
 	});
 });
 

--- a/packages/pi-firecrawl/README.md
+++ b/packages/pi-firecrawl/README.md
@@ -84,6 +84,8 @@ On reload, resume, or fork, capabilities recorded by `firecrawl_load` on the act
 
 Pi uses native deferred tool references on compatible Anthropic models and native tool search on compatible OpenAI Responses models.
 
+`azure-openai-responses` remains eager because Pi's Azure adapter does not implement native deferred tool-search serialization.
+
 When the selected model/provider lacks native deferred support, the extension activates every capability allowed by settings before the next model request instead of using Pi's cache-invalidating lazy-loading fallback.
 
 After a session enters eager exposure, it stays eager across later model switches to avoid removing tool definitions within that session.

--- a/packages/pi-firecrawl/README.md
+++ b/packages/pi-firecrawl/README.md
@@ -82,7 +82,7 @@ Loaded capability tools remain active for the session unless the user makes them
 
 On reload, resume, or fork, capabilities recorded by `firecrawl_load` on the active branch are restored when the current catalog still allows them.
 
-Pi uses native deferred tool references on compatible Anthropic models and native tool search on compatible OpenAI Responses models.
+Pi uses native deferred tool references on compatible Anthropic models and native additional-tools or tool-search loading on compatible OpenAI and Codex Responses models.
 
 `azure-openai-responses` remains eager because Pi's Azure adapter does not implement native deferred tool-search serialization.
 

--- a/packages/pi-firecrawl/README.md
+++ b/packages/pi-firecrawl/README.md
@@ -66,9 +66,11 @@ The extension never logs or displays the API key.
 - `firecrawl_map` — discover URLs for a site.
 - `firecrawl_search` — search the web through Firecrawl and optionally scrape result pages.
 
-### Lazy tool loading
+### Tool exposure
 
-All six tools are registered, but only `firecrawl_load` starts active for this extension.
+All six tools are registered.
+
+On a model/provider with native deferred-tool support, only `firecrawl_load` starts active for this extension.
 
 The loader accepts a task-oriented `query`, filters to capabilities allowed by settings, and adds up to three matching tools by default without removing any active Pi tool.
 
@@ -80,13 +82,15 @@ Loaded capability tools remain active for the session unless the user makes them
 
 On reload, resume, or fork, capabilities recorded by `firecrawl_load` on the active branch are restored when the current catalog still allows them.
 
-Pi uses native deferred tool references on compatible Anthropic and OpenAI models.
+Pi uses native deferred tool references on compatible Anthropic models and native tool search on compatible OpenAI Responses models.
 
-Other models receive Pi's safe fallback and see the newly active definitions in the normal tool list on the next model request.
+When the selected model/provider lacks native deferred support, the extension activates every capability allowed by settings before the next model request instead of using Pi's cache-invalidating lazy-loading fallback.
 
-The capability tools omit active-only prompt metadata so loading them does not rebuild the system-prompt prefix.
+After a session enters eager exposure, it stays eager across later model switches to avoid removing tool definitions within that session.
 
-The saved `tools` array controls which capabilities `firecrawl_load` may expose.
+The capability tools omit active-only prompt metadata so native deferred loading does not rebuild the system-prompt prefix.
+
+The saved `tools` array controls which capabilities the extension may expose.
 
 An empty array leaves the loader active but makes every Firecrawl API capability unavailable.
 
@@ -106,7 +110,7 @@ Oversized Firecrawl error bodies are bounded in the same way.
 /firecrawl
 ```
 
-Opens a menu with configuration quick start, command usage, lazy-catalog status, controls for making all Firecrawl capabilities available or unavailable, and a selector for choosing individual tools.
+Opens a menu with configuration quick start, command usage, tool-catalog status, controls for making all Firecrawl capabilities available or unavailable, and a selector for choosing individual tools.
 
 Direct subcommands are also available:
 
@@ -125,9 +129,9 @@ Direct subcommands are also available:
 - `config` shows API-key presence and API URL without displaying the API key value.
 - `quickstart` is an alias for `config`.
 - `status` shows available and loaded capability counts, loader state, the persisted catalog, settings file path, API-key presence, API URL, and active non-Firecrawl tool count.
-- `tools` opens a width-safe immediate-save selector for choosing capabilities available to lazy-load.
+- `tools` opens a width-safe immediate-save selector for choosing available capabilities.
 - `toggle` is an alias for `tools`.
-- `enable` makes all five API capabilities available but leaves newly available definitions deferred.
+- `enable` makes all five API capabilities available and follows the current native-deferred or eager exposure mode.
 - `disable` makes all five API capabilities unavailable and unloads affected active definitions.
   The slash command and `firecrawl_load` remain available.
 
@@ -149,7 +153,7 @@ ${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-firecrawl.json
 
 When the file is missing or invalid, the extension preserves Pi's current Firecrawl availability policy instead of replacing it.
 An unsaved catalog remains stable across runtime reloads.
-A valid saved catalog is restored on Pi startup and `/reload`, while its capability definitions remain deferred.
+A valid saved catalog is restored on Pi startup and `/reload`, with capability definitions exposed natively deferred or eagerly according to model/provider support.
 A missing file is created by the first successful availability change.
 Within one Pi process, catalog saves run in invocation order, reread the latest valid document, and preserve unknown fields.
 Malformed JSON or invalid recognized fields block the save without replacement; a failed save restores both the prior availability and loaded capability state while preserving other extensions' active tools.

--- a/packages/pi-firecrawl/README.md
+++ b/packages/pi-firecrawl/README.md
@@ -82,7 +82,9 @@ Loaded capability tools remain active for the session unless the user makes them
 
 On reload, resume, or fork, capabilities recorded by `firecrawl_load` on the active branch are restored when the current catalog still allows them.
 
-Pi uses native deferred tool references on compatible Anthropic models and native additional-tools or tool-search loading on compatible OpenAI and Codex Responses models.
+Pi uses native deferred tool references on compatible Anthropic models, native additional-tools or tool-search loading on compatible OpenAI and Codex Responses models, and native Kimi loading on compatible OpenAI Chat Completions models.
+
+Kimi-compatible models declare `compat.deferredToolsMode: "kimi"` in Pi's model metadata.
 
 `azure-openai-responses` remains eager because Pi's Azure adapter does not implement native deferred tool-search serialization.
 

--- a/packages/pi-firecrawl/src/firecrawl.ts
+++ b/packages/pi-firecrawl/src/firecrawl.ts
@@ -2,10 +2,12 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-c
 import { hasApiKey } from "./client.js";
 import {
 	availableFirecrawlTools,
-	configureLazyFirecrawlTools,
+	configureFirecrawlToolExposure,
 	createFirecrawlLoadTool,
 	initializeAvailableFirecrawlTools,
 	loadedFirecrawlToolsFromBranch,
+	requireEagerFirecrawlToolExposure,
+	supportsNativeDeferredToolLoading,
 } from "./lazy-tools.js";
 import { cleanupResponseArtifacts, openResponseArtifacts } from "./response-format.js";
 import { loadSettings } from "./settings.js";
@@ -33,8 +35,8 @@ const COMMAND_COMPLETIONS = [
 	{ value: "config", label: "config", description: "Show configuration quick start" },
 	{ value: "quickstart", label: "quickstart", description: "Show configuration quick start" },
 	{ value: "status", label: "status", description: "Show tool and settings status" },
-	{ value: "tools", label: "tools", description: "Choose lazy-loadable Firecrawl tools" },
-	{ value: "toggle", label: "toggle", description: "Choose lazy-loadable Firecrawl tools" },
+	{ value: "tools", label: "tools", description: "Choose available Firecrawl tools" },
+	{ value: "toggle", label: "toggle", description: "Choose available Firecrawl tools" },
 	{ value: "enable", label: "enable", description: "Make all Firecrawl tools available" },
 	{ value: "disable", label: "disable", description: "Make all Firecrawl tools unavailable" },
 ];
@@ -90,12 +92,18 @@ export default function firecrawl(pi: ExtensionAPI) {
 			ctx.sessionManager.getBranch(),
 			availableTools,
 		);
-		configureLazyFirecrawlTools(pi, availableTools, loadedTools, ctx.sessionManager);
+		configureFirecrawlToolExposure(pi, availableTools, loadedTools, ctx.sessionManager, ctx.model);
 		if (settings.kind === "invalid") {
 			ctx.ui.notify(
 				sanitizeFirecrawlDisplay(`Firecrawl settings ignored: ${settings.reason}`),
 				"warning",
 			);
+		}
+	});
+
+	pi.on("model_select", (event) => {
+		if (!supportsNativeDeferredToolLoading(event.model)) {
+			requireEagerFirecrawlToolExposure(pi);
 		}
 	});
 
@@ -224,7 +232,7 @@ function mainMenuLines(pi: ExtensionAPI) {
 	const capabilityNames = allFirecrawlTools();
 	const loadedCount = capabilityNames.filter((name) => active.has(name)).length;
 	return [
-		`Lazy catalog: ${availableFirecrawlTools(pi).length}/${capabilityNames.length} available`,
+		`Tool catalog: ${availableFirecrawlTools(pi).length}/${capabilityNames.length} available`,
 		`Loaded this session: ${loadedCount}/${capabilityNames.length}`,
 		`API key: ${hasApiKey() ? "present" : "missing"}`,
 	];

--- a/packages/pi-firecrawl/src/lazy-tools.ts
+++ b/packages/pi-firecrawl/src/lazy-tools.ts
@@ -126,6 +126,9 @@ export function supportsNativeDeferredToolLoading(model: ExtensionContext["model
 		const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;
 		return major > 4 || (major === 4 && minor >= 5);
 	}
+	if (model.api === "openai-completions") {
+		return compatString(model.compat, "deferredToolsMode") === "kimi";
+	}
 	if (model.api === "openai-responses" || model.api === "openai-codex-responses") {
 		return (
 			compatBoolean(model.compat, "supportsAdditionalTools") === true ||
@@ -288,6 +291,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function compatBoolean(value: unknown, key: string) {
 	if (!isRecord(value)) return undefined;
 	return typeof value[key] === "boolean" ? value[key] : undefined;
+}
+
+function compatString(value: unknown, key: string) {
+	if (!isRecord(value)) return undefined;
+	return typeof value[key] === "string" ? value[key] : undefined;
 }
 
 function unique(values: readonly string[]) {

--- a/packages/pi-firecrawl/src/lazy-tools.ts
+++ b/packages/pi-firecrawl/src/lazy-tools.ts
@@ -127,7 +127,10 @@ export function supportsNativeDeferredToolLoading(model: ExtensionContext["model
 		return major > 4 || (major === 4 && minor >= 5);
 	}
 	if (model.api === "openai-responses" || model.api === "openai-codex-responses") {
-		return compatBoolean(model.compat, "supportsToolSearch") === true;
+		return (
+			compatBoolean(model.compat, "supportsAdditionalTools") === true ||
+			compatBoolean(model.compat, "supportsToolSearch") === true
+		);
 	}
 	return false;
 }

--- a/packages/pi-firecrawl/src/lazy-tools.ts
+++ b/packages/pi-firecrawl/src/lazy-tools.ts
@@ -126,11 +126,7 @@ export function supportsNativeDeferredToolLoading(model: ExtensionContext["model
 		const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;
 		return major > 4 || (major === 4 && minor >= 5);
 	}
-	if (
-		model.api === "openai-responses" ||
-		model.api === "openai-codex-responses" ||
-		model.api === "azure-openai-responses"
-	) {
+	if (model.api === "openai-responses" || model.api === "openai-codex-responses") {
 		return compatBoolean(model.compat, "supportsToolSearch") === true;
 	}
 	return false;

--- a/packages/pi-firecrawl/src/lazy-tools.ts
+++ b/packages/pi-firecrawl/src/lazy-tools.ts
@@ -117,10 +117,8 @@ export function supportsNativeDeferredToolLoading(model: ExtensionContext["model
 	if (model.api === "anthropic-messages") {
 		const configured = compatBoolean(model.compat, "supportsToolReferences");
 		if (configured !== undefined) return configured;
-		if (model.provider !== "anthropic" || model.id.toLowerCase().includes("haiku")) return false;
-		const version = model.id
-			.toLowerCase()
-			.match(/^claude-(?:opus|sonnet|fable)-(\d+)(?:-(\d+))?(?:-|$)/);
+		if (model.provider !== "anthropic" || model.id.includes("haiku")) return false;
+		const version = model.id.match(/^claude-(?:opus|sonnet|fable)-(\d+)(?:-(\d+))?(?:-|$)/);
 		if (!version) return false;
 		const major = Number(version[1]);
 		const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;

--- a/packages/pi-firecrawl/src/lazy-tools.ts
+++ b/packages/pi-firecrawl/src/lazy-tools.ts
@@ -1,4 +1,8 @@
-import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	defineTool,
+	type ExtensionAPI,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { FIRECRAWL_TOOL_NAMES, type FirecrawlToolName } from "./tool-names.js";
 
@@ -23,6 +27,7 @@ const availableToolsBySession =
 if (!existingSessionAvailableToolsStore) {
 	sharedGlobal[SESSION_AVAILABLE_TOOLS_STORE] = availableToolsBySession;
 }
+const lazyExposureByApi = new WeakMap<ExtensionAPI, boolean>();
 
 const CRAWL_CREATION_TERMS = new Set(["begin", "create", "launch", "start"]);
 
@@ -58,21 +63,31 @@ export function initializeAvailableFirecrawlTools(pi: ExtensionAPI, sessionOwner
 	);
 }
 
-export function configureLazyFirecrawlTools(
+export function configureFirecrawlToolExposure(
 	pi: ExtensionAPI,
 	availableTools: readonly FirecrawlToolName[],
 	loadedTools: readonly FirecrawlToolName[] = [],
 	sessionOwner?: object,
+	model?: ExtensionContext["model"],
 ) {
 	const available = setAvailableTools(pi, availableTools, sessionOwner);
+	const lazyExposure = supportsNativeDeferredToolLoading(model);
+	lazyExposureByApi.set(pi, lazyExposure);
 	const loaded = new Set(loadedTools);
-	const restoredTools = FIRECRAWL_TOOL_NAMES.filter(
-		(name) => available.has(name) && loaded.has(name),
-	);
+	const exposedTools = lazyExposure
+		? FIRECRAWL_TOOL_NAMES.filter((name) => available.has(name) && loaded.has(name))
+		: FIRECRAWL_TOOL_NAMES.filter((name) => available.has(name));
 	const nonCapabilityTools = pi
 		.getActiveTools()
 		.filter((name) => !FIRECRAWL_TOOL_NAMES.includes(name as FirecrawlToolName));
-	pi.setActiveTools(unique([...nonCapabilityTools, FIRECRAWL_LOAD_TOOL_NAME, ...restoredTools]));
+	pi.setActiveTools(unique([...nonCapabilityTools, FIRECRAWL_LOAD_TOOL_NAME, ...exposedTools]));
+}
+
+export function requireEagerFirecrawlToolExposure(pi: ExtensionAPI) {
+	lazyExposureByApi.set(pi, false);
+	const active = pi.getActiveTools();
+	const available = availableFirecrawlTools(pi);
+	pi.setActiveTools(unique([...active, FIRECRAWL_LOAD_TOOL_NAME, ...available]));
 }
 
 export function applyAvailableFirecrawlTools(
@@ -81,14 +96,44 @@ export function applyAvailableFirecrawlTools(
 	sessionOwner?: object,
 ) {
 	const available = setAvailableTools(pi, availableTools, sessionOwner);
+	const lazyExposure = lazyExposureByApi.get(pi) === true;
 	const active = pi
 		.getActiveTools()
 		.filter(
 			(name) =>
 				!FIRECRAWL_TOOL_NAMES.includes(name as FirecrawlToolName) ||
-				available.has(name as FirecrawlToolName),
+				(lazyExposure && available.has(name as FirecrawlToolName)),
 		);
-	pi.setActiveTools(unique([...active, FIRECRAWL_LOAD_TOOL_NAME]));
+	const eagerTools = lazyExposure ? [] : FIRECRAWL_TOOL_NAMES.filter((name) => available.has(name));
+	pi.setActiveTools(unique([...active, FIRECRAWL_LOAD_TOOL_NAME, ...eagerTools]));
+}
+
+export function firecrawlToolExposureMode(pi: ExtensionAPI) {
+	return lazyExposureByApi.get(pi) === true ? "native deferred" : "eager";
+}
+
+export function supportsNativeDeferredToolLoading(model: ExtensionContext["model"]): boolean {
+	if (!model) return false;
+	if (model.api === "anthropic-messages") {
+		const configured = compatBoolean(model.compat, "supportsToolReferences");
+		if (configured !== undefined) return configured;
+		if (model.provider !== "anthropic" || model.id.toLowerCase().includes("haiku")) return false;
+		const version = model.id
+			.toLowerCase()
+			.match(/^claude-(?:opus|sonnet|fable)-(\d+)(?:-(\d+))?(?:-|$)/);
+		if (!version) return false;
+		const major = Number(version[1]);
+		const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;
+		return major > 4 || (major === 4 && minor >= 5);
+	}
+	if (
+		model.api === "openai-responses" ||
+		model.api === "openai-codex-responses" ||
+		model.api === "azure-openai-responses"
+	) {
+		return compatBoolean(model.compat, "supportsToolSearch") === true;
+	}
+	return false;
 }
 
 export function availableFirecrawlTools(pi: ExtensionAPI) {
@@ -239,6 +284,11 @@ function isFirecrawlToolName(value: unknown): value is FirecrawlToolName {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function compatBoolean(value: unknown, key: string) {
+	if (!isRecord(value)) return undefined;
+	return typeof value[key] === "boolean" ? value[key] : undefined;
 }
 
 function unique(values: readonly string[]) {

--- a/packages/pi-firecrawl/src/tool-selector.ts
+++ b/packages/pi-firecrawl/src/tool-selector.ts
@@ -5,6 +5,7 @@ import {
 	applyAvailableFirecrawlTools,
 	availableFirecrawlTools,
 	FIRECRAWL_LOAD_TOOL_NAME,
+	firecrawlToolExposureMode,
 } from "./lazy-tools.js";
 import {
 	loadSettings,
@@ -155,7 +156,7 @@ export async function updateFirecrawlTools(
 	const status = await buildStatusMessage(pi);
 	if (!isCurrentFirecrawlSession(generation)) return;
 	ctx.ui.notify(
-		sanitizeFirecrawlDisplay(`Firecrawl lazy catalog ${action}.\n\n${status}`),
+		sanitizeFirecrawlDisplay(`Firecrawl tool catalog ${action}.\n\n${status}`),
 		hasApiKey() ? "info" : "warning",
 	);
 }
@@ -285,10 +286,11 @@ export async function buildStatusMessage(pi: ExtensionAPI) {
 	const persistedSetting = persistedSettingLabel(settings);
 	return sanitizeFirecrawlDisplay(
 		[
-			`Firecrawl tools available to lazy-load: ${formatRuntimeStatus(summary)}`,
+			`Firecrawl tools available: ${formatRuntimeStatus(summary)}`,
+			`Tool exposure: ${firecrawlToolExposureMode(pi)}`,
 			`Loaded capability tools this session: ${summary.loadedFirecrawlToolCount}/${FIRECRAWL_TOOL_NAMES.length}`,
 			`Loader: ${pi.getActiveTools().includes(FIRECRAWL_LOAD_TOOL_NAME) ? "active" : "inactive"}`,
-			`Persisted lazy catalog: ${persistedSetting}`,
+			`Persisted tool catalog: ${persistedSetting}`,
 			`Settings file: ${settingsFilePath()}`,
 			...(settingsNotice ? [`Settings note: ${settingsNotice}`] : []),
 			`Other active tools preserved: ${summary.activeNonFirecrawlToolCount}`,
@@ -318,15 +320,15 @@ export function buildCommandGuide() {
 		"/firecrawl config — show API key presence and API URL",
 		"/firecrawl quickstart — alias for /firecrawl config",
 		"/firecrawl status — show tool and settings status",
-		"/firecrawl tools — choose tools available to lazy-load",
+		"/firecrawl tools — choose available Firecrawl tools",
 		"/firecrawl toggle — alias for /firecrawl tools",
-		"/firecrawl enable — make all Firecrawl tools available to lazy-load",
+		"/firecrawl enable — make all Firecrawl tools available",
 		"/firecrawl disable — make all Firecrawl capability tools unavailable",
 	].join("\n");
 }
 
 function toolSelectorTitle(selectedTools: ReadonlySet<FirecrawlToolName>) {
-	return `Firecrawl tools available to lazy-load (${selectedTools.size}/${FIRECRAWL_TOOL_NAMES.length}). Non-built-in tools run at user risk.`;
+	return `Available Firecrawl tools (${selectedTools.size}/${FIRECRAWL_TOOL_NAMES.length}). Non-built-in tools run at user risk.`;
 }
 
 function isFirecrawlToolName(value: string): value is FirecrawlToolName {

--- a/packages/pi-firecrawl/src/tool-selector.ts
+++ b/packages/pi-firecrawl/src/tool-selector.ts
@@ -223,7 +223,9 @@ async function transactSelectedToolsNow(
 			const previousLoadedTools = previousActiveTools.filter((name) =>
 				FIRECRAWL_TOOL_NAMES.includes(name as FirecrawlToolName),
 			);
-			pi.setActiveTools(unique([...currentNonCapabilityTools, ...previousLoadedTools]));
+			const restoredFirecrawlTools =
+				firecrawlToolExposureMode(pi) === "eager" ? previousAvailableTools : previousLoadedTools;
+			pi.setActiveTools(unique([...currentNonCapabilityTools, ...restoredFirecrawlTools]));
 		} catch (caught) {
 			rollbackError = caught;
 		}

--- a/packages/pi-firecrawl/test/firecrawl.test.ts
+++ b/packages/pi-firecrawl/test/firecrawl.test.ts
@@ -16,8 +16,8 @@ import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { test, vi } from "vitest";
 import {
+	createMockContext as createBaseMockContext,
 	createCustomSelectorHarness,
-	createMockContext,
 	createMockPi,
 	driveCustomSelector,
 } from "../../../test/support.js";
@@ -39,6 +39,17 @@ import firecrawl, {
 import { applyAvailableFirecrawlTools } from "../src/lazy-tools.js";
 import { saveSettings } from "../src/settings.js";
 import { advanceFirecrawlSessionGeneration, buildStatusMessage } from "../src/tool-selector.js";
+
+const NATIVE_DEFERRED_MODEL = {
+	api: "openai-responses",
+	provider: "openai",
+	id: "gpt-5.4",
+	compat: { supportsToolSearch: true },
+};
+
+function createMockContext(overrides: Record<string, unknown> = {}) {
+	return createBaseMockContext({ model: NATIVE_DEFERRED_MODEL, ...overrides });
+}
 
 const NEW_SETTINGS_FILE = "pi-firecrawl.json";
 const LEGACY_SETTINGS_FILE = "pi-firecrawl-settings.json";
@@ -577,7 +588,7 @@ test("Firecrawl main menu dispatches declarative actions at narrow widths", asyn
 	await mock.commands.get("firecrawl")?.handler("", ctx);
 	assert.ok(renderedLines.every((line) => visibleWidth(line) <= 20));
 	const rendered = renderedLines.join("\n");
-	assert.match(rendered, /Lazy catalog: 0\/5/);
+	assert.match(rendered, /Tool catalog: 0\/5/);
 	assert.match(rendered, /Loaded this session:\s+0\/5/);
 	assert.match(notifications.at(-1)?.message ?? "", /FIRECRAWL_API_KEY/);
 });
@@ -607,8 +618,8 @@ test("Firecrawl tool selection keeps the cursor on the toggled row", async () =>
 		assert.equal(toggledRowKeptCursor, true);
 		assert.deepEqual(mock.rawPi.getActiveTools(), [
 			"other_tool",
-			...CAPABILITY_TOOLS.filter((name) => name !== CRAWL_TOOL),
 			LOAD_TOOL,
+			...CAPABILITY_TOOLS.filter((name) => name !== CRAWL_TOOL),
 		]);
 		assert.deepEqual(
 			readSettings(agentDir, NEW_SETTINGS_FILE).tools,
@@ -818,8 +829,8 @@ test("queued selector saves reject stale availability without overwriting it", a
 
 		assert.deepEqual(mock.rawPi.getActiveTools(), [
 			"other_tool",
-			...CAPABILITY_TOOLS.slice(0, 3),
 			LOAD_TOOL,
+			...CAPABILITY_TOOLS.slice(0, 3),
 		]);
 		assert.ok(notifications.some(({ message }) => /availability changed/i.test(message)));
 	});

--- a/packages/pi-firecrawl/test/firecrawl.test.ts
+++ b/packages/pi-firecrawl/test/firecrawl.test.ts
@@ -869,6 +869,47 @@ test("firecrawl rejects invalid settings updates and restores active tools", asy
 	});
 });
 
+test("firecrawl keeps failed-save rollback eager after an unsupported model switch", async () => {
+	await withTempAgentDir(async (agentDir) => {
+		const settingsPath = path.join(agentDir, NEW_SETTINGS_FILE);
+		writeFileSync(settingsPath, '{"tools":["invalid"]}\n');
+		const firecrawlModule = await importFreshFirecrawl();
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const { ctx, notifications } = createMockContext();
+		firecrawlModule.default(mock.pi);
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
+
+		let markRuntimeApply: (() => void) | undefined;
+		const runtimeApplied = new Promise<void>((resolve) => {
+			markRuntimeApply = resolve;
+		});
+		const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+		mock.rawPi.setActiveTools = (names) => {
+			setActiveTools(names);
+			markRuntimeApply?.();
+			markRuntimeApply = undefined;
+		};
+
+		const command = mock.commands.get("firecrawl")?.handler("disable", ctx);
+		await runtimeApplied;
+		await mock.events.get("model_select")?.[0]?.(
+			{
+				model: {
+					api: "anthropic-messages",
+					provider: "anthropic",
+					id: "claude-haiku-4-5",
+				},
+			},
+			ctx,
+		);
+		await command;
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, ...CAPABILITY_TOOLS]);
+		assert.match(notifications.at(-1)?.message ?? "", /settings save failed/i);
+	});
+});
+
 test("firecrawl rolls back a failed save after shutdown invalidates its session", async () => {
 	await withTempAgentDir(async (agentDir) => {
 		mkdirSync(path.join(agentDir, NEW_SETTINGS_FILE));

--- a/packages/pi-firecrawl/test/lazy-tools.test.ts
+++ b/packages/pi-firecrawl/test/lazy-tools.test.ts
@@ -139,14 +139,14 @@ test("firecrawl loader additively loads crawl workflows without network access",
 	});
 });
 
-test("firecrawl eagerly exposes available tools when native deferred loading is unsupported", async () => {
+test("firecrawl keeps Azure Responses eager when compat enables tool search", async () => {
 	await withTempAgentDir(async () => {
 		const firecrawlModule = await importFreshFirecrawl();
 		const unsupportedModel = {
-			api: "openai-responses",
-			provider: "openai",
-			id: "gpt-5.3",
-			compat: { supportsToolSearch: false },
+			api: "azure-openai-responses",
+			provider: "azure-openai-responses",
+			id: "gpt-5.4",
+			compat: { supportsToolSearch: true },
 		};
 		const nativeModel = {
 			api: "openai-responses",

--- a/packages/pi-firecrawl/test/lazy-tools.test.ts
+++ b/packages/pi-firecrawl/test/lazy-tools.test.ts
@@ -3,8 +3,19 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test, vi } from "vitest";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import { createMockContext as createBaseMockContext, createMockPi } from "../../../test/support.js";
 import firecrawl from "../src/firecrawl.js";
+
+const NATIVE_DEFERRED_MODEL = {
+	api: "openai-responses",
+	provider: "openai",
+	id: "gpt-5.4",
+	compat: { supportsToolSearch: true },
+};
+
+function createMockContext(overrides: Record<string, unknown> = {}) {
+	return createBaseMockContext({ model: NATIVE_DEFERRED_MODEL, ...overrides });
+}
 
 const NEW_SETTINGS_FILE = "pi-firecrawl.json";
 const SCRAPE_TOOL = "firecrawl_scrape";
@@ -52,7 +63,11 @@ test("firecrawl registers deferred capability tools and one loader", () => {
 		"If FIRECRAWL_API_KEY is missing, report the configuration error instead of retrying repeatedly.",
 	]);
 	assert.ok(mock.commands.has("firecrawl"));
-	assert.deepEqual([...mock.events.keys()].sort(), ["session_shutdown", "session_start"]);
+	assert.deepEqual([...mock.events.keys()].sort(), [
+		"model_select",
+		"session_shutdown",
+		"session_start",
+	]);
 });
 
 test("firecrawl loader schema bounds task queries and result count", () => {
@@ -121,6 +136,49 @@ test("firecrawl loader additively loads crawl workflows without network access",
 		} finally {
 			globalThis.fetch = originalFetch;
 		}
+	});
+});
+
+test("firecrawl eagerly exposes available tools when native deferred loading is unsupported", async () => {
+	await withTempAgentDir(async () => {
+		const firecrawlModule = await importFreshFirecrawl();
+		const unsupportedModel = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.3",
+			compat: { supportsToolSearch: false },
+		};
+		const nativeModel = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.4",
+			compat: { supportsToolSearch: true },
+		};
+		const eager = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const eagerContext = createMockContext({ model: unsupportedModel }).ctx;
+		firecrawlModule.default(eager.pi);
+		await eager.events.get("session_start")?.[0]?.({}, eagerContext);
+		assert.deepEqual(eager.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, ...CAPABILITY_TOOLS]);
+
+		const switched = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const nativeContext = createMockContext({ model: nativeModel }).ctx;
+		firecrawlModule.default(switched.pi);
+		await switched.events.get("session_start")?.[0]?.({}, nativeContext);
+		assert.deepEqual(switched.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
+
+		await switched.events.get("model_select")?.[0]?.({ model: unsupportedModel }, nativeContext);
+		assert.deepEqual(switched.rawPi.getActiveTools(), [
+			"other_tool",
+			LOAD_TOOL,
+			...CAPABILITY_TOOLS,
+		]);
+
+		await switched.events.get("model_select")?.[0]?.({ model: nativeModel }, nativeContext);
+		assert.deepEqual(switched.rawPi.getActiveTools(), [
+			"other_tool",
+			LOAD_TOOL,
+			...CAPABILITY_TOOLS,
+		]);
 	});
 });
 

--- a/packages/pi-firecrawl/test/lazy-tools.test.ts
+++ b/packages/pi-firecrawl/test/lazy-tools.test.ts
@@ -182,6 +182,27 @@ test("firecrawl keeps Azure Responses eager when compat enables tool search", as
 	});
 });
 
+test("firecrawl honors native additional-tools support", async () => {
+	await withTempAgentDir(async () => {
+		for (const api of ["openai-responses", "openai-codex-responses"]) {
+			const firecrawlModule = await importFreshFirecrawl();
+			const model = {
+				api,
+				provider: api === "openai-responses" ? "openai" : "openai-codex",
+				id: "gpt-5.4",
+				compat: { supportsAdditionalTools: true },
+			};
+			const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+			const ctx = createMockContext({ model }).ctx;
+			firecrawlModule.default(mock.pi);
+
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+			assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
+		}
+	});
+});
+
 test("firecrawl keeps its missing-settings catalog across session replacement", async () => {
 	await withTempAgentDir(async () => {
 		const firecrawlModule = await importFreshFirecrawl();

--- a/packages/pi-firecrawl/test/lazy-tools.test.ts
+++ b/packages/pi-firecrawl/test/lazy-tools.test.ts
@@ -182,6 +182,25 @@ test("firecrawl keeps Azure Responses eager when compat enables tool search", as
 	});
 });
 
+test("firecrawl honors native Kimi deferred-tool support", async () => {
+	await withTempAgentDir(async () => {
+		const firecrawlModule = await importFreshFirecrawl();
+		const model = {
+			api: "openai-completions",
+			provider: "moonshotai",
+			id: "kimi-k2.6",
+			compat: { deferredToolsMode: "kimi" },
+		};
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const ctx = createMockContext({ model }).ctx;
+		firecrawlModule.default(mock.pi);
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL]);
+	});
+});
+
 test("firecrawl honors native additional-tools support", async () => {
 	await withTempAgentDir(async () => {
 		for (const api of ["openai-responses", "openai-codex-responses"]) {

--- a/packages/pi-firecrawl/test/lazy-tools.test.ts
+++ b/packages/pi-firecrawl/test/lazy-tools.test.ts
@@ -182,6 +182,24 @@ test("firecrawl keeps Azure Responses eager when compat enables tool search", as
 	});
 });
 
+test("firecrawl keeps uppercase Anthropic model IDs eager", async () => {
+	await withTempAgentDir(async () => {
+		const firecrawlModule = await importFreshFirecrawl();
+		const model = {
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "CLAUDE-SONNET-4-5",
+		};
+		const mock = createMockPi({ activeTools: ["other_tool", ...CAPABILITY_TOOLS] });
+		const ctx = createMockContext({ model }).ctx;
+		firecrawlModule.default(mock.pi);
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+		assert.deepEqual(mock.rawPi.getActiveTools(), ["other_tool", LOAD_TOOL, ...CAPABILITY_TOOLS]);
+	});
+});
+
 test("firecrawl honors native Kimi deferred-tool support", async () => {
 	await withTempAgentDir(async () => {
 		const firecrawlModule = await importFreshFirecrawl();


### PR DESCRIPTION
## Summary

- Require extension tool lazy loading to use Pi's additive native deferred protocol.
- Make `pi-firecrawl` and `pi-chrome-devtools` expose configured tools eagerly when the selected model or provider lacks native deferred support.
- Preserve eager exposure after an unsupported model switch, update user-facing status and documentation, and add patch Changesets.

## Verification

- `npm run check`
- `npm test` — 381 test files and 3,375 tests passed
- `npx vitest run packages/pi-firecrawl/test packages/pi-chrome-devtools/test` — 149 tests passed
- `npm pack --workspace @narumitw/pi-firecrawl --dry-run --json`
- `npm pack --workspace @narumitw/pi-chrome-devtools --dry-run --json`
- Headless RPC load smokes for both built package entrypoints

## Semantic audit

- Reviewed the Pi extension documentation, `docs/extension-conventions.md`, and `docs/extension-settings.md`.
- Audited additive activation, unsupported-model eager exposure, model switching, active-tool ordering, settings rollback, and prompt metadata.
- Settings persistence semantics and unknown-field preservation are unchanged.
- No live Anthropic or OpenAI provider request was sent; native capability selection is covered through Pi compatibility metadata and deterministic tests.
