### PR TITLE
chore: check only staged files with Biome

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"smoke:caffeinate-dbus": "node ./packages/pi-caffeinate/test/docker/run-docker.mjs",
 		"smoke:pi-fleet:ghostty": "cd packages/pi-fleet && tsc -p tsconfig.process-smoke.json && node ../../node_modules/.cache/pi-fleet-process/scripts/ghostty-smoke.js",
 		"check": "npm run build && node ./scripts/run-checks.mjs",
-		"precommit": "npm run biome:check && npm run typecheck",
+		"precommit": "biome check --staged --no-errors-on-unmatched && npm run typecheck",
 		"prepare": "node .husky/install.mjs",
 		"changeset": "changeset",
 		"changeset:status": "changeset status --verbose",


### PR DESCRIPTION
## Summary

- Limit the pre-commit Biome check to staged files.
- Allow commits with no Biome-supported staged files while retaining the full TypeScript typecheck.

## Verification

- `npm run precommit`
- Staged-file Biome smoke with `package.json`