### PR TITLE
fix(cache-hit-monitor): complete cache usage accounting

### DIFF
--- a/.pi/extensions/cache-hit-monitor/README.md
+++ b/.pi/extensions/cache-hit-monitor/README.md
@@ -29,6 +29,7 @@ The command accepts no arguments and is available in TUI and RPC modes.
 While visible, the widget updates from `message_update` as soon as the provider reports usage and finalizes on `message_end`.
 Cache comparisons reset across compaction and branch-summary boundaries because those events create a new cache prefix epoch.
 Session totals continue to include usage records visible on the active branch.
+When summary usage omits cache accounting, the session request count, tokens, and prompt cost remain included while hit rate and savings stay unavailable.
 The extension rebuilds state after session start, compaction, and tree navigation.
 It clears its widget during session shutdown and ignores events from replaced sessions.
 It does not add model-visible tools, messages, system instructions, or provider payload changes.

--- a/.pi/extensions/cache-hit-monitor/index.test.ts
+++ b/.pi/extensions/cache-hit-monitor/index.test.ts
@@ -299,6 +299,25 @@ test("renders restored totals for a summary-only branch", async () => {
 	assert.match(rendered, /Session {2}1 req.*hit 90\.0%/);
 });
 
+test("renders restored summary totals when cache accounting is unavailable", async () => {
+	const summary = assistant(1_000, 0);
+	const harness = createHarness();
+	const current = createContext("tui", [
+		{
+			type: "compaction",
+			id: "compact",
+			parentId: null,
+			usage: summary.usage,
+		} as SessionEntry,
+	]);
+	await harness.emit("session_start", {}, current.ctx);
+	await harness.command("", current.ctx);
+
+	const rendered = renderWidget(current.widgets.at(-1), 120)?.join("\n") ?? "";
+	assert.match(rendered, /summary usage only/);
+	assert.match(rendered, /Session {2}1 req.*hit n\/a.*uncached 1k.*cost \$0\.010.*saved ~n\/a/);
+});
+
 test("clears replacement UI and ignores stale replacement-session events", async () => {
 	const harness = createHarness();
 	const previous = createContext();

--- a/.pi/extensions/cache-hit-monitor/metrics.test.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.test.ts
@@ -136,6 +136,50 @@ test("requires provider cache evidence and prices a confirmed zero-read miss", (
 	assert.match(rendered, /miss premium ~\$0\.018/);
 });
 
+test("preserves input pricing for a fully cached request", () => {
+	const tieredModel: Model<Api> = {
+		...MODEL,
+		cost: {
+			...RATES,
+			tiers: [
+				{
+					inputTokensAbove: 900,
+					input: 20,
+					output: 40,
+					cacheRead: 2,
+					cacheWrite: 30,
+				},
+			],
+		},
+	};
+	const fullyCached = assistant(0, 1_000, 0);
+	fullyCached.usage.cost = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	};
+
+	const sample = createCacheSample(fullyCached, 0, tieredModel);
+	assert.ok(sample);
+	assert.deepEqual(fullyCached.usage.cost, {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	});
+	assert.ok(Math.abs((sample.inputUnitCost ?? 0) - 0.000_02) < 0.000_000_001);
+	assert.ok(Math.abs((sample.promptCost ?? 0) - 0.002) < 0.000_000_001);
+	assert.ok(Math.abs((sample.estimatedSavings ?? 0) - 0.018) < 0.000_000_001);
+	const rendered = formatMonitorLines(createCacheMonitorView([sample]))
+		.map(({ text }) => text)
+		.join("\n");
+	assert.match(rendered, /cache saved ~\$0\.018/);
+	assert.match(rendered, /Session {2}1 req.*saved ~\$0\.018/);
+});
+
 test("uses weighted session totals and excludes cross-compaction comparisons", () => {
 	const first = createCacheSample(assistant(200, 800, 0), 0, MODEL);
 	const second = createCacheSample(assistant(400, 600, 100), 0, MODEL);
@@ -211,6 +255,42 @@ test("reconstructs cache epochs and includes summarization usage in session tota
 	assert.equal(view.session.cacheRead, 2_700);
 	assert.ok(Math.abs((view.session.promptCost ?? 0) - 0.0157) < 0.000_000_1);
 	assert.ok(Math.abs((view.session.estimatedSavings ?? 0) - 0.0243) < 0.000_000_1);
+});
+
+test("retains summary usage when cache accounting is unavailable", () => {
+	const summaryMessage = assistant(1_000, 0, 0);
+	const restored = collectCacheSamples([
+		{
+			type: "compaction",
+			id: "compact",
+			parentId: null,
+			usage: summaryMessage.usage,
+		},
+		{
+			type: "branch_summary",
+			id: "branch-summary",
+			parentId: null,
+			usage: summaryMessage.usage,
+		},
+	] as SessionEntry[]);
+
+	assert.equal(restored.currentEpoch, 2);
+	assert.equal(restored.summaryRecords.length, 2);
+	assert.ok(restored.summaryRecords.every(({ hitRatePercent }) => hitRatePercent === null));
+	const view = createCacheMonitorView([], undefined, {
+		summaryRecords: restored.summaryRecords,
+	});
+	assert.equal(view.session.requestCount, 2);
+	assert.equal(view.session.input, 2_000);
+	assert.equal(view.session.promptTokens, 2_000);
+	assert.equal(view.session.hitRatePercent, null);
+	assert.ok(Math.abs((view.session.promptCost ?? 0) - 0.02) < 0.000_000_001);
+	assert.equal(view.session.estimatedSavings, null);
+	const rendered = formatMonitorLines(view)
+		.map(({ text }) => text)
+		.join("\n");
+	assert.match(rendered, /summary usage only/);
+	assert.match(rendered, /Session {2}2 req.*hit n\/a.*uncached 2k.*cost \$0\.020.*saved ~n\/a/);
 });
 
 test("does not reconstruct all-zero usage as a miss without provider evidence", () => {

--- a/.pi/extensions/cache-hit-monitor/metrics.ts
+++ b/.pi/extensions/cache-hit-monitor/metrics.ts
@@ -16,13 +16,15 @@ export interface CacheUsageRecord {
 	cacheRead: number;
 	cacheWrite: number;
 	promptTokens: number;
-	hitRatePercent: number;
-	uncachedRatePercent: number;
+	hitRatePercent: number | null;
+	uncachedRatePercent: number | null;
 	promptCost: number | null;
 	estimatedSavings: number | null;
 }
 
 export interface CacheSample extends CacheUsageRecord {
+	hitRatePercent: number;
+	uncachedRatePercent: number;
 	epoch: number;
 	timestamp: number;
 	provider: string;
@@ -98,7 +100,9 @@ export function collectCacheSamples(
 	let currentEpoch = 0;
 	for (const entry of entries) {
 		if (entry.type === "compaction" || entry.type === "branch_summary") {
-			const summaryCalculation = entry.usage ? calculateCacheUsage(entry.usage) : null;
+			const summaryCalculation = entry.usage
+				? calculateCacheUsage(entry.usage, { retainUnknownCacheAccounting: true })
+				: null;
 			if (summaryCalculation) summaryRecords.push(summaryCalculation.record);
 			currentEpoch += 1;
 			continue;
@@ -126,11 +130,22 @@ export function createCacheSample(
 	costModel?: Model<Api>,
 	cacheAccountingKnown = false,
 ): CacheSample | null {
-	const calculation = calculateCacheUsage(message.usage, costModel, cacheAccountingKnown);
-	if (!calculation) return null;
+	const calculation = calculateCacheUsage(message.usage, {
+		costModel,
+		cacheAccountingKnown,
+	});
+	if (
+		!calculation ||
+		calculation.record.hitRatePercent === null ||
+		calculation.record.uncachedRatePercent === null
+	) {
+		return null;
+	}
 
 	return {
 		...calculation.record,
+		hitRatePercent: calculation.record.hitRatePercent,
+		uncachedRatePercent: calculation.record.uncachedRatePercent,
 		epoch,
 		timestamp: finiteNumber(message.timestamp),
 		provider: message.provider,
@@ -229,6 +244,7 @@ export function aggregateCacheSamples(
 	let estimatedMissPremium = 0;
 	let hasRebilledTokens = false;
 	let missPremiumComplete = true;
+	let cacheAccountingComplete = true;
 	let bestHitRatePercent: number | null = null;
 	let worstHitRatePercent: number | null = null;
 
@@ -240,14 +256,18 @@ export function aggregateCacheSamples(
 		else promptCost += record.promptCost;
 		if (record.estimatedSavings === null) savingsKnown = false;
 		else estimatedSavings += record.estimatedSavings;
-		bestHitRatePercent = Math.max(
-			bestHitRatePercent ?? record.hitRatePercent,
-			record.hitRatePercent,
-		);
-		worstHitRatePercent = Math.min(
-			worstHitRatePercent ?? record.hitRatePercent,
-			record.hitRatePercent,
-		);
+		if (record.hitRatePercent === null) {
+			cacheAccountingComplete = false;
+		} else {
+			bestHitRatePercent = Math.max(
+				bestHitRatePercent ?? record.hitRatePercent,
+				record.hitRatePercent,
+			);
+			worstHitRatePercent = Math.min(
+				worstHitRatePercent ?? record.hitRatePercent,
+				record.hitRatePercent,
+			);
+		}
 	};
 
 	for (const sample of samples) addUsage(sample);
@@ -277,7 +297,8 @@ export function aggregateCacheSamples(
 		cacheRead,
 		cacheWrite,
 		promptTokens,
-		hitRatePercent: promptTokens > 0 ? (cacheRead / promptTokens) * 100 : null,
+		hitRatePercent:
+			promptTokens > 0 && cacheAccountingComplete ? (cacheRead / promptTokens) * 100 : null,
 		promptCost: promptCostKnown ? promptCost : null,
 		estimatedSavings: requestCount > 0 && savingsKnown ? estimatedSavings : null,
 		rebilledTokens,
@@ -414,21 +435,31 @@ interface CacheUsageCalculation {
 	paidPromptUnitCost: number | null;
 }
 
+interface CacheUsageCalculationOptions {
+	costModel?: Model<Api>;
+	cacheAccountingKnown?: boolean;
+	retainUnknownCacheAccounting?: boolean;
+}
+
 function calculateCacheUsage(
 	usage: Usage,
-	costModel?: Model<Api>,
-	cacheAccountingKnown = false,
+	options: CacheUsageCalculationOptions = {},
 ): CacheUsageCalculation | null {
 	const input = finiteNumber(usage.input);
 	const cacheRead = finiteNumber(usage.cacheRead);
 	const cacheWrite = finiteNumber(usage.cacheWrite);
 	const promptTokens = input + cacheRead + cacheWrite;
-	if (promptTokens <= 0 || (cacheRead === 0 && cacheWrite === 0 && !cacheAccountingKnown)) {
+	const cacheAccountingKnown =
+		cacheRead > 0 || cacheWrite > 0 || options.cacheAccountingKnown === true;
+	if (
+		promptTokens <= 0 ||
+		(!cacheAccountingKnown && options.retainUnknownCacheAccounting !== true)
+	) {
 		return null;
 	}
 
-	const fallbackCosts = costModel
-		? calculateCost(costModel, normalizedUsageCopy(usage, input, cacheRead, cacheWrite))
+	const fallbackCosts = options.costModel
+		? calculateCost(options.costModel, normalizedUsageCopy(usage, input, cacheRead, cacheWrite))
 		: undefined;
 	const inputCost = componentCost(input, finiteNumber(usage.cost?.input), fallbackCosts?.input);
 	const cacheReadCost = componentCost(
@@ -441,11 +472,14 @@ function calculateCacheUsage(
 		finiteNumber(usage.cost?.cacheWrite),
 		fallbackCosts?.cacheWrite,
 	);
-	const inputUnitCost = unitCost(input, inputCost);
+	const inputUnitCost =
+		input > 0
+			? unitCost(input, inputCost)
+			: effectiveInputUnitCost(options.costModel, usage, cacheRead, cacheWrite);
 	const cacheReadUnitCost =
 		cacheRead > 0
 			? unitCost(cacheRead, cacheReadCost)
-			: effectiveCacheReadUnitCost(costModel, usage, input, cacheWrite);
+			: effectiveCacheReadUnitCost(options.costModel, usage, input, cacheWrite);
 	const paidPromptUnitCost = unitCost(
 		input + cacheWrite,
 		sumKnownCosts([inputCost, cacheWriteCost]),
@@ -457,20 +491,33 @@ function calculateCacheUsage(
 			cacheRead,
 			cacheWrite,
 			promptTokens,
-			hitRatePercent: (cacheRead / promptTokens) * 100,
-			uncachedRatePercent: (input / promptTokens) * 100,
+			hitRatePercent: cacheAccountingKnown ? (cacheRead / promptTokens) * 100 : null,
+			uncachedRatePercent: cacheAccountingKnown ? (input / promptTokens) * 100 : null,
 			promptCost: sumKnownCosts([inputCost, cacheReadCost, cacheWriteCost]),
-			estimatedSavings:
-				cacheRead === 0
+			estimatedSavings: cacheAccountingKnown
+				? cacheRead === 0
 					? 0
 					: inputUnitCost !== null && cacheReadUnitCost !== null
 						? cacheRead * Math.max(0, inputUnitCost - cacheReadUnitCost)
-						: null,
+						: null
+				: null,
 		},
 		inputUnitCost,
 		cacheReadUnitCost,
 		paidPromptUnitCost,
 	};
+}
+
+function effectiveInputUnitCost(
+	costModel: Model<Api> | undefined,
+	usage: Usage,
+	cacheRead: number,
+	cacheWrite: number,
+): number | null {
+	if (!costModel || cacheRead <= 0) return null;
+	const probeTokens = Math.min(1, cacheRead);
+	const probeUsage = normalizedUsageCopy(usage, probeTokens, cacheRead - probeTokens, cacheWrite);
+	return calculateCost(costModel, probeUsage).input / probeTokens;
 }
 
 function effectiveCacheReadUnitCost(


### PR DESCRIPTION
## Summary

- Preserve effective input pricing for fully cached requests by probing Pi pricing at the same prompt size.
- Retain compaction and branch-summary usage when cache counters are absent without treating unknown accounting as a cache miss.
- Keep session request, token, and prompt-cost totals complete while showing unknown hit rate and savings as `n/a`.

## Review follow-up

This follows up on the two unresolved review threads in #982.

## Verification

- `npx tsc -p .pi/extensions/cache-hit-monitor/tsconfig.json`
- `npx vitest run --config .pi/extensions/cache-hit-monitor/vitest.config.ts` (25 tests)
- `npm run check`
- `npm test` (3,350 tests)
- `pi --no-extensions -e ./.pi/extensions/cache-hit-monitor/index.ts --list-models`
- `pi --list-models`

## Release

No Changeset is required because this is a repository-only project-local extension.
