### PR TITLE
fix(runtime-diagnostics): resolve post-merge review

### DIFF
--- a/.pi/extensions/runtime-diagnostics/README.md
+++ b/.pi/extensions/runtime-diagnostics/README.md
@@ -71,9 +71,10 @@ A captured payload does not prove that the provider accepted or executed the exp
 Response latency ends when headers arrive and does not measure stream completion.
 The installed `google-generative-ai` and `google-vertex` adapters do not emit response-header telemetry, so their requests are marked `unsupported` rather than `pending`.
 Restored requests without retained response telemetry are marked `unavailable` because a future response cannot complete a historical capture.
+Retained-window byte totals are `null` when any included request has unknown legacy size data.
 Provider responses are matched to requests by event order because the hook exposes no request identifier.
 Failed HTTP attempts remain associated with the same request until a successful retry replaces them or `agent_end` ends the run.
-Unmatched request indexes are discarded at `agent_end` so a failed run cannot offset response attribution in a later run.
+Requests without response headers are marked `unavailable` at `agent_end`, and unmatched indexes are discarded so a failed run cannot offset later response attribution.
 Extension visibility includes only public tool and slash-command surfaces, so passive event-only extensions cannot be enumerated.
 Inactive tools include an honest generic explanation because Pi does not expose the configuration, filter, or deferred-loading reason.
 Per-tool definition sizes are lower bounds over the provider-visible name, description, and parameters because `ExtensionAPI.getAllTools()` does not expose `constrainedSampling`.

--- a/.pi/extensions/runtime-diagnostics/capture-state.ts
+++ b/.pi/extensions/runtime-diagnostics/capture-state.ts
@@ -61,6 +61,7 @@ export function restoreCaptureState(
 	capturedAt: number,
 ): ProviderCaptureState {
 	const state = createCaptureState();
+	const requestsByIndex = new Map<number, ProviderRequestDiagnostic>();
 	let maximumRequestIndex = 0;
 	for (const entry of entries) {
 		if (entry.type !== "custom") continue;
@@ -69,12 +70,14 @@ export function restoreCaptureState(
 			if (!record) continue;
 			maximumRequestIndex = Math.max(maximumRequestIndex, record.requestIndex);
 			state.records.push(record);
+			requestsByIndex.set(record.requestIndex, record);
+			pruneRestoredCaptureState(state, record.capturedAt, requestsByIndex);
 			continue;
 		}
 		if (entry.customType === PROVIDER_RESPONSE_ENTRY_TYPE) {
 			const response = entry.data;
 			if (!isProviderResponseDiagnostic(response)) continue;
-			const request = state.records.find((record) => record.requestIndex === response.requestIndex);
+			const request = requestsByIndex.get(response.requestIndex);
 			if (request) attachProviderResponse(request, response);
 			continue;
 		}
@@ -83,11 +86,22 @@ export function restoreCaptureState(
 		if (!control) continue;
 		const policy = "policy" in control ? control.policy : state.policy;
 		applyControlToState(state, control.action, policy);
-		pruneCaptureState(state, control.capturedAt);
+		pruneRestoredCaptureState(state, control.capturedAt, requestsByIndex);
 	}
 	state.nextRequestIndex = maximumRequestIndex + 1;
 	pruneCaptureState(state, capturedAt);
 	return state;
+}
+
+export function finalizePendingRequests(state: ProviderCaptureState): void {
+	const pendingIndexes = new Set(state.pendingRequestIndexes);
+	for (const record of state.records) {
+		if (pendingIndexes.has(record.requestIndex) && record.responseTelemetry === "pending") {
+			record.responseTelemetry = "unavailable";
+			record.response = null;
+		}
+	}
+	state.pendingRequestIndexes = [];
 }
 
 export function createControlEntry(
@@ -116,6 +130,18 @@ export function pruneCaptureState(state: ProviderCaptureState, capturedAt: numbe
 		retainedIndexes.has(requestIndex),
 	);
 	state.prunedRecordCount += previousLength - state.records.length;
+}
+
+function pruneRestoredCaptureState(
+	state: ProviderCaptureState,
+	capturedAt: number,
+	requestsByIndex: Map<number, ProviderRequestDiagnostic>,
+): void {
+	pruneCaptureState(state, capturedAt);
+	const retainedRecords = new Set(state.records);
+	for (const [requestIndex, record] of requestsByIndex) {
+		if (!retainedRecords.has(record)) requestsByIndex.delete(requestIndex);
+	}
 }
 
 function applyControlToState(

--- a/.pi/extensions/runtime-diagnostics/index.test.ts
+++ b/.pi/extensions/runtime-diagnostics/index.test.ts
@@ -238,7 +238,7 @@ test("captures only sanitized provider metadata, byte counts, status, and header
 	});
 });
 
-test("extracts provider-visible tools from Google, Bedrock, and pi-messages payloads", () => {
+test("extracts provider-visible tools from installed adapter payload shapes", () => {
 	const googleTools = [
 		{
 			functionDeclarations: [
@@ -306,6 +306,31 @@ test("extracts provider-visible tools from Google, Bedrock, and pi-messages payl
 	assert.deepEqual(piMessages.topLevelToolNames, ["read", "write"]);
 	assert.equal(piMessages.toolDefinitionBytes, Buffer.byteLength(JSON.stringify(piMessageTools)));
 	assert.equal(piMessages.planModeMarkerPresent, true);
+
+	const immediateKimiTools = [{ type: "function", function: { name: "tool_search" } }];
+	const deferredKimiTools = [{ type: "function", function: { name: "calculate" } }];
+	const kimi = extractProviderRequestDiagnostic(
+		{
+			tools: immediateKimiTools,
+			messages: [
+				{ role: "tool", content: "Found a matching tool" },
+				{ role: "system", tools: deferredKimiTools },
+			],
+		},
+		{
+			requestIndex: 4,
+			capturedAt: 400,
+			sessionId: "session",
+			api: "openai-completions",
+		},
+	);
+	assert.deepEqual(kimi.topLevelToolNames, ["tool_search"]);
+	assert.deepEqual(kimi.transcriptToolNames, ["calculate"]);
+	assert.equal(
+		kimi.toolDefinitionBytes,
+		Buffer.byteLength(JSON.stringify(immediateKimiTools)) +
+			Buffer.byteLength(JSON.stringify(deferredKimiTools)),
+	);
 });
 
 test("strips every Unicode bidirectional formatting control", () => {
@@ -356,6 +381,37 @@ test("restores fork-sensitive controls and prunes the active reporting window", 
 	assert.equal(restored.records.length, 0);
 });
 
+test("reconstructs a long append-only history within the retained window", () => {
+	const entries: SessionEntry[] = [];
+	for (let requestIndex = 1; requestIndex <= 1_000; requestIndex += 1) {
+		const request = extractProviderRequestDiagnostic(
+			{ tools: [{ name: `tool-${requestIndex}` }] },
+			{
+				requestIndex,
+				capturedAt: requestIndex,
+				sessionId: "session",
+			},
+		);
+		entries.push(
+			customEntry(PROVIDER_REQUEST_ENTRY_TYPE, request),
+			customEntry(
+				PROVIDER_RESPONSE_ENTRY_TYPE,
+				createProviderResponseDiagnostic(request, 200, requestIndex + 1),
+			),
+		);
+	}
+
+	const restored = restoreCaptureState(entries, 2_000);
+	assert.equal(restored.records.length, 100);
+	assert.equal(restored.prunedRecordCount, 900);
+	assert.equal(restored.nextRequestIndex, 1_001);
+	assert.deepEqual(
+		restored.records.map(({ requestIndex }) => requestIndex),
+		Array.from({ length: 100 }, (_, index) => index + 901),
+	);
+	assert.ok(restored.records.every(({ response }) => response?.status === 200));
+});
+
 test("marks restored response-less captures unavailable instead of pending", async () => {
 	const harness = createHarness();
 	const legacyRequest = {
@@ -399,7 +455,12 @@ test("marks restored response-less captures unavailable instead of pending", asy
 	);
 	const provider = (shown.details as Record<string, unknown>).providerRequestCapture as {
 		recent: Array<{ responseTelemetry: string }>;
-		performance: { pendingRequestCount: number; unavailableRequestCount: number };
+		performance: {
+			pendingRequestCount: number;
+			unavailableRequestCount: number;
+			requestBytes: number | null;
+			toolDefinitionBytes: number | null;
+		};
 	};
 	assert.deepEqual(
 		provider.recent.map(({ responseTelemetry }) => responseTelemetry),
@@ -407,6 +468,8 @@ test("marks restored response-less captures unavailable instead of pending", asy
 	);
 	assert.equal(provider.performance.pendingRequestCount, 0);
 	assert.equal(provider.performance.unavailableRequestCount, 2);
+	assert.equal(provider.performance.requestBytes, null);
+	assert.equal(provider.performance.toolDefinitionBytes, null);
 	assert.ok(
 		(shown.findings as Array<{ code: string }>).some(
 			({ code }) => code === "response-telemetry-unavailable",
@@ -674,12 +737,18 @@ test("clears unmatched provider requests before attributing responses in a later
 				harness.context,
 			),
 	);
-	const records = (
-		(shown.details as Record<string, unknown>).providerRequestCapture as {
-			recent: Array<{ response: null | { status: number; responseHeaderLatencyMs: number } }>;
-		}
-	).recent;
+	const provider = (shown.details as Record<string, unknown>).providerRequestCapture as {
+		recent: Array<{
+			responseTelemetry: string;
+			response: null | { status: number; responseHeaderLatencyMs: number };
+		}>;
+		performance: { pendingRequestCount: number; unavailableRequestCount: number };
+	};
+	const records = provider.recent;
+	assert.equal(records[0].responseTelemetry, "unavailable");
 	assert.equal(records[0].response, null);
+	assert.equal(provider.performance.pendingRequestCount, 0);
+	assert.equal(provider.performance.unavailableRequestCount, 1);
 	assert.deepEqual(records[1].response, {
 		version: 1,
 		requestIndex: 2,

--- a/.pi/extensions/runtime-diagnostics/index.test.ts
+++ b/.pi/extensions/runtime-diagnostics/index.test.ts
@@ -721,6 +721,27 @@ test("clears unmatched provider requests before attributing responses in a later
 	await harness.emit("before_provider_request", { payload: { tools: [{ name: "read" }] } });
 	await harness.emit("agent_end", { messages: [] });
 
+	const unavailable = parseToolResult(
+		await harness
+			.tool()
+			.execute(
+				"call-unavailable",
+				{ action: "show" },
+				new AbortController().signal,
+				undefined,
+				harness.context,
+			),
+	);
+	const unavailableFinding = (
+		unavailable.findings as Array<{ code: string; message: string }>
+	).find(({ code }) => code === "response-telemetry-unavailable");
+	assert.ok(unavailableFinding);
+	assert.equal(
+		unavailableFinding.message,
+		"No response-header telemetry is available for the latest provider request.",
+	);
+	assert.doesNotMatch(unavailableFinding.message, /restor/iu);
+
 	harness.setTime(3_000);
 	await harness.emit("before_provider_request", { payload: { tools: [{ name: "read" }] } });
 	harness.setTime(3_025);

--- a/.pi/extensions/runtime-diagnostics/index.ts
+++ b/.pi/extensions/runtime-diagnostics/index.ts
@@ -6,6 +6,7 @@ import {
 	CONTROL_ENTRY_TYPE,
 	createCaptureState,
 	createControlEntry,
+	finalizePendingRequests,
 	MAX_CAPTURE_AGE_MINUTES,
 	MAX_CAPTURE_RECORDS,
 	PROVIDER_REQUEST_ENTRY_TYPE,
@@ -208,7 +209,7 @@ export function createDebugExtension(
 		});
 
 		pi.on("agent_end", () => {
-			capture.pendingRequestIndexes = [];
+			finalizePendingRequests(capture);
 		});
 
 		pi.on("message_end", (event, ctx) => {

--- a/.pi/extensions/runtime-diagnostics/provider-request.ts
+++ b/.pi/extensions/runtime-diagnostics/provider-request.ts
@@ -59,9 +59,9 @@ export function extractProviderRequestDiagnostic(
 			containsMarker(context?.systemPrompt) ||
 			containsMarker(root?.system),
 		requestBytes: jsonByteLength(payload),
-		toolDefinitionBytes: jsonByteLength(extractProviderToolDefinitions(root)),
+		toolDefinitionBytes: providerToolDefinitionByteLength(root),
 		topLevelToolNames: extractProviderToolNames(root),
-		transcriptToolNames: extractTranscriptToolNames(root?.input),
+		transcriptToolNames: extractTranscriptToolNames(root?.input, root?.messages),
 		responseTelemetry: responseTelemetryState(identity.api),
 		response: null,
 	};
@@ -180,11 +180,34 @@ function isProviderRequestBase(
 	);
 }
 
-function extractProviderToolDefinitions(root: Record<string, unknown> | undefined): unknown {
+function extractProviderToolDefinitionContainers(
+	root: Record<string, unknown> | undefined,
+): unknown[] {
 	const config = asRecord(root?.config);
 	const toolConfig = asRecord(root?.toolConfig);
 	const context = asRecord(root?.context);
-	return root?.tools ?? config?.tools ?? toolConfig?.tools ?? context?.tools;
+	const containers = [root?.tools, config?.tools, toolConfig?.tools, context?.tools].filter(
+		(value) => value !== undefined,
+	);
+	if (!Array.isArray(root?.messages)) return containers;
+	for (const message of root.messages) {
+		const tools = asRecord(message)?.tools;
+		if (tools !== undefined) containers.push(tools);
+	}
+	return containers;
+}
+
+function providerToolDefinitionByteLength(
+	root: Record<string, unknown> | undefined,
+): number | null {
+	const containers = extractProviderToolDefinitionContainers(root);
+	let total = 0;
+	for (const container of containers) {
+		const bytes = jsonByteLength(container);
+		if (bytes === null) return null;
+		total += bytes;
+	}
+	return total;
 }
 
 function extractProviderToolNames(root: Record<string, unknown> | undefined): string[] {
@@ -212,18 +235,26 @@ function extractBedrockToolNames(value: unknown): string[] {
 	});
 }
 
-function extractTranscriptToolNames(input: unknown): string[] {
-	if (!Array.isArray(input)) return [];
+function extractTranscriptToolNames(input: unknown, messages: unknown): string[] {
 	const names: string[] = [];
-	for (const item of input) {
-		const record = asRecord(item);
-		if (record?.type !== "additional_tools" && record?.type !== "tool_search_output") {
-			continue;
+	if (Array.isArray(input)) {
+		for (const item of input) {
+			const record = asRecord(item);
+			if (record?.type !== "additional_tools" && record?.type !== "tool_search_output") {
+				continue;
+			}
+			names.push(...extractToolNames(record.tools));
+			if (record.type === "tool_search_output") {
+				const output = asRecord(record.output);
+				names.push(
+					...extractToolNames(Array.isArray(record.output) ? record.output : output?.tools),
+				);
+			}
 		}
-		names.push(...extractToolNames(record.tools));
-		if (record.type === "tool_search_output") {
-			const output = asRecord(record.output);
-			names.push(...extractToolNames(Array.isArray(record.output) ? record.output : output?.tools));
+	}
+	if (Array.isArray(messages)) {
+		for (const message of messages) {
+			names.push(...extractToolNames(asRecord(message)?.tools));
 		}
 	}
 	return normalizeNames(names);

--- a/.pi/extensions/runtime-diagnostics/report.ts
+++ b/.pi/extensions/runtime-diagnostics/report.ts
@@ -425,9 +425,9 @@ function createFindings(
 		findings.push({
 			severity: "info",
 			code: "response-telemetry-unavailable",
-			message: "The restored provider request has no retained response telemetry.",
+			message: "No response-header telemetry is available for the latest provider request.",
 			recommendation:
-				"Capture a new provider request before interpreting HTTP status or response-header latency.",
+				"Reproduce the request before interpreting HTTP status or response-header latency; if telemetry remains unavailable, inspect provider connectivity and cancellation.",
 		});
 	}
 	if (latest.responseTelemetry === "unsupported") {

--- a/.pi/extensions/runtime-diagnostics/report.ts
+++ b/.pi/extensions/runtime-diagnostics/report.ts
@@ -89,7 +89,7 @@ export function createDiagnosticResponse(options: DiagnosticReportOptions) {
 		details.tools = {
 			state: runtime.tools,
 			catalog: toolCatalog,
-			knownProviderDefinitionBytes: sumNullable(
+			knownProviderDefinitionBytes: sumComplete(
 				toolCatalog.map(({ knownProviderDefinitionBytes }) => knownProviderDefinitionBytes),
 			),
 			definitionSizeBasis:
@@ -340,8 +340,8 @@ function createProviderReport(
 						) / completed.length
 					: null,
 			statusCounts: countStatuses(completed),
-			requestBytes: sumNullable(capture.records.map(({ requestBytes }) => requestBytes)),
-			toolDefinitionBytes: sumNullable(
+			requestBytes: sumComplete(capture.records.map(({ requestBytes }) => requestBytes)),
+			toolDefinitionBytes: sumComplete(
 				capture.records.map(({ toolDefinitionBytes }) => toolDefinitionBytes),
 			),
 		},
@@ -644,9 +644,14 @@ function providerVisibleNames(record: ProviderRequestDiagnostic): string[] {
 	return [...new Set([...record.topLevelToolNames, ...record.transcriptToolNames])].sort();
 }
 
-function sumNullable(values: readonly (number | null)[]): number | null {
-	const available = values.filter((value): value is number => value !== null);
-	return available.length > 0 ? available.reduce((total, value) => total + value, 0) : null;
+function sumComplete(values: readonly (number | null)[]): number | null {
+	if (values.length === 0) return null;
+	let total = 0;
+	for (const value of values) {
+		if (value === null) return null;
+		total += value;
+	}
+	return total;
 }
 
 function nullableDelta(from: number | null, to: number | null): number | null {


### PR DESCRIPTION
## Summary

- decode Kimi deferred tool definitions from `messages[].tools`
- finalize unmatched response telemetry at `agent_end`
- mark incomplete retained-window byte aggregates as unknown
- index and bound append-only session reconstruction

## Context

This follows up on review [5019946951](https://github.com/narumiruna/pi-extensions/pull/983#pullrequestreview-5019946951), which was submitted after PR #983 had already merged.

## Verification

- `npx biome check .pi/extensions/runtime-diagnostics`
- `npx tsc -p .pi/extensions/runtime-diagnostics/tsconfig.json`
- `npx vitest run --config .pi/extensions/runtime-diagnostics/vitest.config.ts` (13 tests)
- `npm run check`
- `npm test` (381 files, 3,350 tests)
- `PI_OFFLINE=1 pi --no-extensions -e ./.pi/extensions/runtime-diagnostics/index.ts --list-models`
- `PI_OFFLINE=1 pi --approve --list-models`

## Audits

- audited against `docs/extension-conventions.md` and `docs/extension-settings.md`
- audited provider-prefix non-mutation, run-boundary telemetry, branch reconstruction, retention, privacy, and output bounds
- interactive `/reload` was not run because the execution environment prohibits opening an interactive TUI; isolated loading and trusted-project auto-discovery passed
- no Changeset is needed because this is a project-local extension
