### PR TITLE
fix: retain compacted context boundaries

### DIFF
--- a/.changeset/stable-cache-prefixes.md
+++ b/.changeset/stable-cache-prefixes.md
@@ -3,6 +3,6 @@
 "@narumitw/pi-subagents": patch
 ---
 
-Restore compacted todo and required-subagent state at deterministic summary boundaries, and append restored required-run cancellations in ordinary resumed transcripts while keeping request prefixes stable.
+Restore compacted todo and required-subagent state at deterministic summary boundaries, retain each restored message for its summary epoch as later tail evidence supersedes it, and append restored required-run cancellations after stale retained handoffs while keeping request prefixes stable.
 
 Publish mutable subagent catalog and policy guidance through append-only session contracts instead of re-registering provider-visible tools.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -649,8 +649,10 @@ Required state moves from `pending` to `available` after durable terminal comple
 Interruption, close, stale restore, and shutdown terminalize unfinished requirements explicitly instead of silently dropping them.
 Tool-result details preserve fork-sensitive requirement evidence, and inspection projects bounded requirement state.
 The successful tool handoff and delivered completion messages are the ordinary model-visible source of requirement state.
-When an uncompacted resumed session terminalizes an in-flight required run, one hidden append-only transition supersedes the retained pending handoff before the next model turn.
-If leading compaction or branch summaries remove that handoff, one canonical hidden fallback is restored at a fixed boundary immediately after the summaries.
+When a resumed session terminalizes an in-flight required run and the retained transcript still contains its pending handoff, one hidden append-only transition supersedes that stale evidence before the next model turn.
+This also covers compacted contexts that retain the handoff.
+If leading compaction or branch summaries remove the handoff, one canonical hidden fallback is restored at a fixed boundary immediately after the summaries.
+That restored fallback remains fixed for the summary epoch while later cancellation transitions or completion messages supersede it at the conversation tail.
 The runtime rejects a sixty-fifth unresolved required run before acceptance so every unresolved exact identity fits in the bounded parent context.
 The terminal completion and recipient are persisted before delivery, simultaneous root completions are batched, and the root broker allows at most one in-flight wake until that parent turn starts.
 In TUI mode, completion messages show a compact task and payload summary while collapsed; use the configured tool-output expansion action (`Ctrl+O` by default) to show or hide the complete message globally.
@@ -780,7 +782,7 @@ The Settings UI applies a saved live change immediately to subsequent launches a
 The UI explicitly states that target/trust settings are not filesystem sandboxing and directs trust changes to Pi `/trust`.
 When stateful tools are enabled, their membership and provider-visible definitions stay fixed across spawn, completion, interrupt, close, mailbox, catalog, and live-policy transitions.
 Ordinary turns preserve the normalized provider-visible prefix, while a new guidance message or required-completion transition starts an explicit append-only prefix epoch.
-Compaction restoration inserts deterministic guidance and requirement fallbacks after leading summaries without moving them on later ordinary turns.
+Compaction restoration inserts deterministic guidance and requirement fallbacks after leading summaries and retains each restored message for that summary epoch while later tail messages supersede it.
 These rules preserve cache-eligible prefixes but do not guarantee a provider-reported cache hit.
 
 | Tool | Purpose |

--- a/packages/pi-subagents/docs/async-runtime-protocol.md
+++ b/packages/pi-subagents/docs/async-runtime-protocol.md
@@ -15,10 +15,10 @@ Omitting the field or using `background` preserves prior behavior and does not c
 Tool-result `details.agent.completionRequirements` provides fork-sensitive branch evidence.
 Session restoration retains exact requirements found on the active branch and treats sessions without visible subagent state as a possible compacted continuation.
 The successful lifecycle tool result and delivered completion message are the ordinary model-visible requirement handoff.
-When an uncompacted resume changes a retained pending run to cancelled and interrupted, `before_agent_start` appends one hidden versioned transition that supersedes the stale pending handoff.
-The retained transition prevents duplicate publication on later turns and participates in fork-sensitive branch reconstruction.
-If leading compaction or branch summaries remove equivalent current evidence, the `context` hook restores one canonical hidden `pi-subagent-required-completions` fallback immediately after the summaries.
-The fallback remains at that fixed boundary across ordinary turns and is removed when equivalent current evidence becomes visible or no retained requirement remains.
+When a resume changes a pending run to cancelled and interrupted while its stale handoff remains in model context, `before_agent_start` appends one hidden versioned transition after that handoff.
+This append-only transition also applies when leading summaries retain the stale handoff, prevents duplicate publication on later turns, and participates in fork-sensitive branch reconstruction.
+If leading compaction or branch summaries remove the handoff, the `context` hook restores one canonical hidden `pi-subagent-required-completions` fallback immediately after the summaries.
+The fallback remains at that fixed boundary for the leading-summary epoch, while a later completion or cancellation transition supersedes it at the conversation tail.
 `CompletionDeliveryBroker` owns exact completion visibility acknowledgement and asks the registry to mark the corresponding requirement visible.
 No timer, waiter, or UI object owns requirement truth.
 
@@ -35,7 +35,8 @@ The runtime bounds retained requirement records per agent and rejects a sixty-fi
 ## Parent behavior
 
 Pending and available requirements remain final-answer dependencies.
-Visible requirements no longer appear in the canonical fallback block.
+A newly established canonical fallback omits requirements already visible at that boundary.
+A fallback retained from an earlier request remains historical prefix context after visibility changes, and the later completion message supplies the superseding state.
 Cancelled requirements are terminal and must be reported rather than silently treated as successful evidence.
 A failed, partial, interrupted, stale, or cancelled child never satisfies mutating acceptance or independent-verification requirements merely because its turn settled.
 

--- a/packages/pi-subagents/src/completion-requirement.ts
+++ b/packages/pi-subagents/src/completion-requirement.ts
@@ -212,14 +212,15 @@ export function createRequiredCompletionTransition(
 	messages: ContextEvent["messages"],
 	agents: readonly ManagedAgent[],
 ) {
-	if (leadingSummaryBoundary(messages) > 0) return undefined;
+	const summarized = leadingSummaryBoundary(messages) > 0;
 	const state = modelRequirementState(agents);
 	const visible = completionRequirementsFromBranch(messages).records;
-	const records = state.records.filter(
-		(record) =>
-			record.state === "cancelled" &&
-			!modelRequirementStateMatches(visible.get(completionRequirementKey(record)), record),
-	);
+	const records = state.records.filter((record) => {
+		if (record.state !== "cancelled") return false;
+		const retained = visible.get(completionRequirementKey(record));
+		if (modelRequirementStateMatches(retained, record)) return false;
+		return !summarized || retained !== undefined;
+	});
 	if (records.length === 0) return undefined;
 	return {
 		role: "custom" as const,
@@ -238,18 +239,17 @@ export function reconcileRequiredCompletionContext(
 	messages: ContextEvent["messages"],
 	agents: readonly ManagedAgent[],
 	restorationPredecessors: readonly string[] = [],
+	restoredBoundaryContent?: string,
 ): ContextEvent["messages"] {
 	const existing = messages.filter(isRequiredCompletionContextMessage);
 	const withoutPrior = messages.filter((message) => !isRequiredCompletionContextMessage(message));
 	const state = modelRequirementState(agents);
-	if (state.records.length === 0) {
-		return existing.length === 0 ? messages : withoutPrior;
-	}
 	const summaryBoundary = leadingSummaryBoundary(withoutPrior);
-	const content =
-		summaryBoundary > 0 && !hasModelVisibleRequirementState(withoutPrior, state.records)
+	const currentContent =
+		state.records.length > 0 && !hasModelVisibleRequirementState(withoutPrior, state.records)
 			? requiredCompletionContextContent(state.records, state.omittedCancelled)
 			: undefined;
+	const content = summaryBoundary > 0 ? (restoredBoundaryContent ?? currentContent) : undefined;
 	let insertionBoundary = summaryBoundary;
 	while (insertionBoundary < withoutPrior.length) {
 		const predecessor = withoutPrior[insertionBoundary];

--- a/packages/pi-subagents/src/session-guidance-contract.ts
+++ b/packages/pi-subagents/src/session-guidance-contract.ts
@@ -11,6 +11,7 @@ import type {
 	DelegationCwdPolicy,
 } from "./agents/types.js";
 import {
+	COMPLETION_REQUIREMENT_CONTEXT_TYPE,
 	createRequiredCompletionTransition,
 	reconcileRequiredCompletionContext,
 } from "./completion-requirement.js";
@@ -44,12 +45,22 @@ export function registerSubagentSessionGuidance(
 ): SubagentSessionGuidanceController {
 	let activeSession: ExtensionContext["sessionManager"] | undefined;
 	let lastPublishedContent: string | undefined;
-	let restoredBoundary: { summaryEpoch: string; content: string } | undefined;
+	let restoredGuidanceBoundary: { summaryEpoch: string; content: string } | undefined;
+	let restoredRequirementBoundary: { summaryEpoch: string; content: string } | undefined;
 
 	pi.on("session_start", (_event, ctx) => {
 		activeSession = ctx.sessionManager;
 		lastPublishedContent = undefined;
-		restoredBoundary = undefined;
+		restoredRequirementBoundary = undefined;
+		const messages = buildSessionContext(ctx.sessionManager.getBranch()).messages;
+		const summaryEpoch = leadingSummaryEpoch(messages);
+		restoredGuidanceBoundary =
+			summaryEpoch && !hasSubagentSessionGuidanceHistory(messages)
+				? {
+						summaryEpoch,
+						content: createSubagentSessionGuidance(getSnapshot()).content,
+					}
+				: undefined;
 	});
 
 	pi.on("before_agent_start", (_event, ctx) => {
@@ -65,8 +76,8 @@ export function registerSubagentSessionGuidance(
 		const summaryEpoch = leadingSummaryEpoch(contextMessages);
 		if (summaryEpoch && !hasSubagentSessionGuidanceHistory(contextMessages)) {
 			if (
-				restoredBoundary?.summaryEpoch === summaryEpoch &&
-				restoredBoundary.content !== contract.content
+				restoredGuidanceBoundary?.summaryEpoch === summaryEpoch &&
+				restoredGuidanceBoundary.content !== contract.content
 			) {
 				return { message: contract };
 			}
@@ -85,13 +96,18 @@ export function registerSubagentSessionGuidance(
 	pi.on("context", (event, ctx) => {
 		if (ctx.sessionManager !== activeSession) return;
 		const summaryEpoch = leadingSummaryEpoch(event.messages);
-		if (restoredBoundary?.summaryEpoch !== summaryEpoch) restoredBoundary = undefined;
+		if (restoredGuidanceBoundary?.summaryEpoch !== summaryEpoch) {
+			restoredGuidanceBoundary = undefined;
+		}
+		if (restoredRequirementBoundary?.summaryEpoch !== summaryEpoch) {
+			restoredRequirementBoundary = undefined;
+		}
 		if (
-			restoredBoundary === undefined &&
+			restoredGuidanceBoundary === undefined &&
 			summaryEpoch &&
 			!hasSubagentSessionGuidanceHistory(event.messages)
 		) {
-			restoredBoundary = {
+			restoredGuidanceBoundary = {
 				summaryEpoch,
 				content: createSubagentSessionGuidance(getSnapshot()).content,
 			};
@@ -99,11 +115,26 @@ export function registerSubagentSessionGuidance(
 		const withGuidance = reconcileSubagentSessionGuidance(
 			event.messages,
 			getSnapshot(),
-			restoredBoundary?.content,
+			restoredGuidanceBoundary?.content,
 		);
-		const messages = reconcileRequiredCompletionContext(withGuidance, getAgents(), [
-			SUBAGENT_GUIDANCE_CONTEXT_TYPE,
-		]);
+		const messages = reconcileRequiredCompletionContext(
+			withGuidance,
+			getAgents(),
+			[SUBAGENT_GUIDANCE_CONTEXT_TYPE],
+			restoredRequirementBoundary?.content,
+		);
+		if (restoredRequirementBoundary === undefined && summaryEpoch) {
+			const boundaryMessage = messages.find(
+				(message) =>
+					message.role === "custom" && message.customType === COMPLETION_REQUIREMENT_CONTEXT_TYPE,
+			);
+			if (boundaryMessage?.role === "custom" && typeof boundaryMessage.content === "string") {
+				restoredRequirementBoundary = {
+					summaryEpoch,
+					content: boundaryMessage.content,
+				};
+			}
+		}
 		if (messages !== event.messages) return { messages };
 	});
 
@@ -111,7 +142,8 @@ export function registerSubagentSessionGuidance(
 		if (ctx.sessionManager !== activeSession) return;
 		activeSession = undefined;
 		lastPublishedContent = undefined;
-		restoredBoundary = undefined;
+		restoredGuidanceBoundary = undefined;
+		restoredRequirementBoundary = undefined;
 	});
 
 	return {

--- a/packages/pi-subagents/test/cache-contract.test.ts
+++ b/packages/pi-subagents/test/cache-contract.test.ts
@@ -13,6 +13,7 @@ import {
 	COMPLETION_REQUIREMENT_TRANSITION_TYPE,
 	completionRequirementKey,
 	completionRequirementsFromBranch,
+	createRequiredCompletionTransition,
 	reconcileRequiredCompletionContext,
 } from "../src/completion-requirement.js";
 import { AgentRegistry } from "../src/registry.js";
@@ -397,6 +398,160 @@ test("live policy changes retain compacted guidance at its prior provider bounda
 	await emit(mock, "session_shutdown", { reason: "quit" }, replacement.ctx);
 });
 
+test("settings changes before the first resumed context retain compacted guidance", async () => {
+	let snapshot = guidanceSnapshot();
+	const branch = [
+		{
+			type: "compaction",
+			id: "compaction",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			summary: "Earlier work was compacted.",
+			firstKeptEntryId: "kept",
+			tokensBefore: 100,
+		},
+	] as SessionEntry[];
+	const mock = createMockPi();
+	const controller = registerSubagentSessionGuidance(
+		mock.pi,
+		() => snapshot,
+		() => [],
+	);
+	const context = createMockContext({ sessionManager: sessionManagerFor(branch) });
+	await emit(mock, "session_start", { reason: "resume" }, context.ctx);
+
+	const priorSnapshot = snapshot;
+	snapshot = { ...snapshot, completionDelivery: "auto-resume" };
+	controller.publish();
+	const appended = mock.sentMessages.at(-1)?.message as
+		| ContextEvent["messages"][number]
+		| undefined;
+	if (!appended) assert.fail("expected a live-policy contract");
+	const summary: ContextEvent["messages"] = [
+		{
+			role: "compactionSummary",
+			summary: "Earlier work was compacted.",
+			tokensBefore: 100,
+			timestamp: 0,
+		},
+	];
+	const baseline = reconcileSubagentSessionGuidance(
+		[...summary, userMessage("continue")],
+		priorSnapshot,
+	);
+	const resumed = await applyContextHooks(
+		mock,
+		[...summary, userMessage("continue"), appended],
+		context.ctx,
+	);
+	assert.deepEqual(
+		convertToLlm(resumed).slice(0, convertToLlm(baseline).length),
+		convertToLlm(baseline),
+	);
+	assert.equal(resumed.at(-1), appended);
+	assert.match(
+		String(resumed[1]?.role === "custom" ? resumed[1].content : ""),
+		/"completionDelivery":"next-turn"/u,
+	);
+	assert.match(
+		String(appended.role === "custom" ? appended.content : ""),
+		/"completionDelivery":"auto-resume"/u,
+	);
+
+	await emit(mock, "session_shutdown", { reason: "quit" }, context.ctx);
+});
+
+test("restored requirement context remains fixed after completion becomes visible", async () => {
+	const requirement = beginCompletionRequirement(undefined, {
+		runId: "run:completed-after-restoration",
+		generation: 1,
+		createdAt: 10,
+	})[0];
+	const agent = record({ completionRequirements: [requirement] });
+	const agents = [agent];
+	const branch = [
+		{
+			type: "compaction",
+			id: "compaction",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			summary: "Earlier work was compacted.",
+			firstKeptEntryId: "kept",
+			tokensBefore: 100,
+		},
+	] as SessionEntry[];
+	const mock = createMockPi();
+	registerSubagentSessionGuidance(mock.pi, guidanceSnapshot, () => agents);
+	const context = createMockContext({ sessionManager: sessionManagerFor(branch) });
+	await emit(mock, "session_start", { reason: "resume" }, context.ctx);
+	const summary: ContextEvent["messages"] = [
+		{
+			role: "compactionSummary",
+			summary: "Earlier work was compacted.",
+			tokensBefore: 100,
+			timestamp: 0,
+		},
+	];
+	const firstRaw = [...summary, userMessage("continue")];
+	const firstMessages = await applyContextHooks(mock, firstRaw, context.ctx);
+	const restored = firstMessages.find(
+		(message) =>
+			message.role === "custom" && message.customType === COMPLETION_REQUIREMENT_CONTEXT_TYPE,
+	);
+	assert.ok(restored);
+
+	const available = {
+		...requirement,
+		state: "available" as const,
+		completionId: "completion:restored",
+		terminalState: "completed" as const,
+		updatedAt: 20,
+	};
+	agent.completionRequirements = [{ ...available, state: "visible" }];
+	const completion: ContextEvent["messages"][number] = {
+		role: "custom",
+		customType: "pi-subagent-completion",
+		content: "completed",
+		display: true,
+		details: { completionRequirement: available },
+		timestamp: 0,
+	};
+	const secondMessages = await applyContextHooks(
+		mock,
+		[...firstRaw, assistantMessage("working"), completion],
+		context.ctx,
+	);
+	const first = convertToLlm(firstMessages);
+	const second = convertToLlm(secondMessages);
+	assert.deepEqual(second.slice(0, first.length), first);
+	assert.deepEqual(
+		secondMessages.find(
+			(message) =>
+				message.role === "custom" && message.customType === COMPLETION_REQUIREMENT_CONTEXT_TYPE,
+		),
+		restored,
+	);
+	assert.equal(secondMessages.at(-1), completion);
+
+	const replacement = createMockContext({ sessionManager: sessionManagerFor(branch) });
+	await emit(mock, "session_start", { reason: "fork" }, replacement.ctx);
+	await emit(mock, "session_shutdown", { reason: "replace" }, context.ctx);
+	const replacementMessages = await applyContextHooks(
+		mock,
+		[...firstRaw, completion],
+		replacement.ctx,
+	);
+	assert.equal(
+		replacementMessages.some(
+			(message) =>
+				message.role === "custom" && message.customType === COMPLETION_REQUIREMENT_CONTEXT_TYPE,
+		),
+		false,
+		"session replacement must clear the prior requirement boundary",
+	);
+	await emit(mock, "session_shutdown", { reason: "quit" }, replacement.ctx);
+});
+
 test("uncompacted resume appends a restored requirement cancellation once", async () => {
 	const requirement = beginCompletionRequirement(undefined, {
 		runId: "run:restored",
@@ -499,6 +654,94 @@ test("uncompacted resume appends a restored requirement cancellation once", asyn
 	const first = convertToLlm(firstMessages);
 	const second = convertToLlm(secondMessages);
 	assert.deepEqual(second.slice(0, first.length), first);
+
+	await emit(mock, "session_shutdown", { reason: "quit" }, context.ctx);
+});
+
+test("compacted resume appends cancellation after a retained pending handoff", async () => {
+	const requirement = beginCompletionRequirement(undefined, {
+		runId: "run:retained-after-summary",
+		generation: 1,
+		createdAt: 10,
+	})[0];
+	const registry = new AgentRegistry(
+		{ kind: "fake", runTurn: async () => ({ output: "unused", exitCode: 0 }) },
+		{ now: () => 20 },
+	);
+	registry.restore([
+		record({
+			state: "running",
+			completionRequirements: [requirement],
+		}),
+	]);
+	const cancelled = registry.list()[0];
+	assert.equal(cancelled?.completionRequirements?.[0]?.state, "cancelled");
+
+	const pendingResult: ContextEvent["messages"][number] = {
+		role: "toolResult",
+		toolCallId: "spawn-retained",
+		toolName: "subagent_spawn",
+		content: [{ type: "text", text: "spawned required child" }],
+		details: { agent: { completionRequirements: [requirement] } },
+		isError: false,
+		timestamp: 0,
+	};
+	const branch = [
+		{
+			type: "compaction",
+			id: "compaction",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			summary: "Earlier work was compacted.",
+			firstKeptEntryId: "spawn",
+			tokensBefore: 100,
+		},
+		{
+			type: "message",
+			id: "spawn",
+			parentId: "compaction",
+			timestamp: new Date(1).toISOString(),
+			message: pendingResult,
+		},
+	] as SessionEntry[];
+	const summary: ContextEvent["messages"] = [
+		{
+			role: "compactionSummary",
+			summary: "Earlier work was compacted.",
+			tokensBefore: 100,
+			timestamp: 0,
+		},
+	];
+	assert.equal(
+		createRequiredCompletionTransition(summary, registry.list()),
+		undefined,
+		"a missing handoff must use summary-boundary restoration instead of a tail transition",
+	);
+
+	const mock = createMockPi();
+	registerSubagentSessionGuidance(mock.pi, guidanceSnapshot, () => registry.list());
+	const context = createMockContext({ sessionManager: sessionManagerFor(branch) });
+	await emit(mock, "session_start", { reason: "resume" }, context.ctx);
+	const firstMessages = await applyPromptBoundary(
+		mock,
+		[...summary, pendingResult, userMessage("continue resumed work")],
+		context.ctx,
+	);
+	const transitionIndex = firstMessages.findIndex(
+		(message) =>
+			message.role === "custom" && message.customType === COMPLETION_REQUIREMENT_TRANSITION_TYPE,
+	);
+	const handoffIndex = firstMessages.indexOf(pendingResult);
+	assert.ok(transitionIndex > handoffIndex);
+	assert.equal(transitionIndex, firstMessages.length - 1);
+	assert.equal(
+		firstMessages.some(
+			(message) =>
+				message.role === "custom" && message.customType === COMPLETION_REQUIREMENT_CONTEXT_TYPE,
+		),
+		false,
+		"the tail cancellation supersedes the retained handoff without an earlier fallback",
+	);
 
 	await emit(mock, "session_shutdown", { reason: "quit" }, context.ctx);
 });

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -80,9 +80,9 @@ During ordinary turns, the model reads the complete list from the persisted `upd
 
 If leading compaction or branch summaries remove that matching call/result pair, the extension inserts one hidden, non-persistent state-only fallback immediately after those summaries.
 
-That fixed restoration boundary keeps later ordinary requests append-only while the todo state is unchanged.
-An ordinary context without a leading summary does not synthesize a fallback.
-A later valid todo update or clear starts an explicit state-transition epoch and replaces or removes restored state.
+That restored message remains fixed for the current leading-summary epoch, including after a later valid todo update or clear.
+The later tool call and result supersede the restored state at the conversation tail without rewriting the earlier provider prefix.
+An ordinary context without a leading summary does not synthesize a fallback, and a new summary epoch restores only the then-current list when needed.
 
 In TUI mode, updates appear immediately in a widget above the editor.
 

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -56,6 +56,7 @@ const TodoParameters = Type.Object({
 export default function todoWidgetExtension(pi: ExtensionAPI): void {
 	let activeSession: ExtensionContext["sessionManager"] | undefined;
 	let items: TodoItem[] = [];
+	let restoredBoundary: { summaryEpoch: string; content: string } | undefined;
 
 	const ownsSession = (ctx: ExtensionContext): boolean => ctx.sessionManager === activeSession;
 
@@ -128,12 +129,21 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
 		activeSession = ctx.sessionManager;
 		items = reconstructItems(ctx.sessionManager.getBranch());
+		restoredBoundary = undefined;
 		publish(ctx);
 	});
 
 	pi.on("context", (event, ctx) => {
 		if (!ownsSession(ctx)) return;
-		const messages = reconcileTodoContext(event.messages, items);
+		const summaryEpoch = leadingSummaryEpoch(event.messages);
+		if (restoredBoundary?.summaryEpoch !== summaryEpoch) restoredBoundary = undefined;
+		const messages = reconcileTodoContext(event.messages, items, restoredBoundary?.content);
+		if (restoredBoundary === undefined && summaryEpoch) {
+			const boundaryMessage = messages[leadingSummaryBoundary(messages)];
+			if (isTodoContextMessage(boundaryMessage)) {
+				restoredBoundary = { summaryEpoch, content: boundaryMessage.content };
+			}
+		}
 		if (messages !== event.messages) return { messages };
 	});
 
@@ -147,6 +157,7 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 		if (!ownsSession(ctx)) return;
 		if (ctx.mode === "tui") ctx.ui.setWidget(WIDGET_KEY, undefined);
 		items = [];
+		restoredBoundary = undefined;
 		activeSession = undefined;
 	});
 }
@@ -195,14 +206,16 @@ export function renderTodoWidget(
 export function reconcileTodoContext(
 	messages: ContextEvent["messages"],
 	items: readonly TodoItem[],
+	restoredBoundaryContent?: string,
 ): ContextEvent["messages"] {
 	const existing = messages.filter(isTodoContextMessage);
 	const withoutExisting = messages.filter((message) => !isTodoContextMessage(message));
 	const summaryBoundary = leadingSummaryBoundary(withoutExisting);
-	const content =
-		items.length > 0 && summaryBoundary > 0 && !hasModelVisibleTodoState(withoutExisting, items)
+	const currentContent =
+		items.length > 0 && !hasModelVisibleTodoState(withoutExisting, items)
 			? todoContextContent(items)
 			: undefined;
+	const content = summaryBoundary > 0 ? (restoredBoundaryContent ?? currentContent) : undefined;
 	if (
 		content !== undefined &&
 		existing.length === 1 &&
@@ -298,6 +311,11 @@ function hasTodoContextVersion(message: TodoContextMessage): boolean {
 		!Array.isArray(message.details) &&
 		(message.details as Record<string, unknown>).version === TODO_CONTEXT_VERSION
 	);
+}
+
+function leadingSummaryEpoch(messages: ContextEvent["messages"]): string | undefined {
+	const boundary = leadingSummaryBoundary(messages);
+	return boundary === 0 ? undefined : JSON.stringify(messages.slice(0, boundary));
 }
 
 function leadingSummaryBoundary(messages: ContextEvent["messages"]): number {

--- a/packages/pi-todo/test/todo-cache-contract.test.ts
+++ b/packages/pi-todo/test/todo-cache-contract.test.ts
@@ -58,9 +58,30 @@ function userMessage(text: string): ContextEvent["messages"][number] {
 }
 
 function assistantMessage(text: string): ContextEvent["messages"][number] {
+	return assistantMessageWithContent([{ type: "text", text }], "stop");
+}
+
+function todoToolCallMessage(items: readonly TodoItem[]): ContextEvent["messages"][number] {
+	return assistantMessageWithContent(
+		[
+			{
+				type: "toolCall",
+				id: `todo-call-${items.length}`,
+				name: TOOL_NAME,
+				arguments: { items },
+			},
+		],
+		"toolUse",
+	);
+}
+
+function assistantMessageWithContent(
+	content: Extract<ContextEvent["messages"][number], { role: "assistant" }>["content"],
+	stopReason: "stop" | "toolUse",
+): ContextEvent["messages"][number] {
 	return {
 		role: "assistant",
-		content: [{ type: "text", text }],
+		content,
 		api: "openai-responses",
 		provider: "cache-contract",
 		model: "cache-contract",
@@ -72,7 +93,19 @@ function assistantMessage(text: string): ContextEvent["messages"][number] {
 			totalTokens: 0,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
-		stopReason: "stop",
+		stopReason,
+		timestamp: 0,
+	};
+}
+
+function todoToolResultMessage(items: readonly TodoItem[]): ContextEvent["messages"][number] {
+	return {
+		role: "toolResult",
+		toolCallId: `todo-call-${items.length}`,
+		toolName: TOOL_NAME,
+		content: [{ type: "text", text: items.length === 0 ? "cleared" : "updated" }],
+		details: { version: 1, items },
+		isError: false,
 		timestamp: 0,
 	};
 }
@@ -97,9 +130,14 @@ test("todo compaction restoration preserves normalized ordinary-request prefixes
 		},
 	];
 	const firstRaw = [...summaries, userMessage("continue")];
-	const first = normalizedRequest(reconcileTodoContext(firstRaw, items));
+	const firstMessages = reconcileTodoContext(firstRaw, items);
+	const restored = firstMessages[2];
+	if (restored?.role !== "custom" || typeof restored.content !== "string") {
+		assert.fail("expected restored todo boundary");
+	}
+	const first = normalizedRequest(firstMessages);
 	const secondRaw = [...firstRaw, assistantMessage("working"), userMessage("continue again")];
-	const second = normalizedRequest(reconcileTodoContext(secondRaw, items));
+	const second = normalizedRequest(reconcileTodoContext(secondRaw, items, restored.content));
 
 	assert.deepEqual(second.effectiveSystemGuidance, first.effectiveSystemGuidance);
 	assert.deepEqual(second.activeToolNames, [TOOL_NAME]);
@@ -107,6 +145,20 @@ test("todo compaction restoration preserves normalized ordinary-request prefixes
 	assert.deepEqual(second.toolDefinitions, first.toolDefinitions);
 	assert.deepEqual(second.messages.slice(0, first.messages.length), first.messages);
 
-	const transformed = reconcileTodoContext(firstRaw, items);
-	assert.equal(reconcileTodoContext(transformed, items), transformed);
+	const updatedItems: TodoItem[] = [{ text: "implement", status: "completed" }];
+	const updatedRaw = [
+		...secondRaw,
+		todoToolCallMessage(updatedItems),
+		todoToolResultMessage(updatedItems),
+	];
+	const updated = normalizedRequest(
+		reconcileTodoContext(updatedRaw, updatedItems, restored.content),
+	);
+	assert.deepEqual(updated.messages.slice(0, second.messages.length), second.messages);
+
+	const clearedRaw = [...updatedRaw, todoToolCallMessage([]), todoToolResultMessage([])];
+	const cleared = normalizedRequest(reconcileTodoContext(clearedRaw, [], restored.content));
+	assert.deepEqual(cleared.messages.slice(0, updated.messages.length), updated.messages);
+
+	assert.equal(reconcileTodoContext(firstMessages, items, restored.content), firstMessages);
 });

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -198,7 +198,7 @@ test("registers concise guidance for using and maintaining the todo list", () =>
 	]);
 });
 
-test("uses visible todo calls and injects only missing current state", async () => {
+test("restores missing todo state and retains its summary boundary", async () => {
 	const harness = createHarness();
 	const current = createContext();
 	await harness.emit("session_start", current.ctx);
@@ -207,6 +207,15 @@ test("uses visible todo calls and injects only missing current state", async () 
 		{ text: "implement", status: "in_progress" },
 	];
 	await setTodos(harness, current.ctx, items);
+
+	const ordinary: ContextEvent["messages"] = [
+		{
+			role: "user",
+			content: [{ type: "text", text: "ordinary context" }],
+			timestamp: 0,
+		},
+	];
+	assert.equal(await harness.context(ordinary, current.ctx), ordinary);
 
 	const base: ContextEvent["messages"] = [
 		{
@@ -227,6 +236,18 @@ test("uses visible todo calls and injects only missing current state", async () 
 			timestamp: 0,
 		},
 	];
+	const initialDetails: TodoDetails = { version: TODO_DETAILS_VERSION, items };
+	const initiallyVisible = [
+		...base,
+		todoToolCallMessage(items),
+		todoToolResultMessage(initialDetails),
+	];
+	assert.equal(
+		await harness.context(initiallyVisible, current.ctx),
+		initiallyVisible,
+		"retained matching evidence must prevent initial restoration",
+	);
+
 	const transformed = await harness.context(base, current.ctx);
 	assert.equal(transformed.length, 4);
 	const reminder = transformed[2];
@@ -266,16 +287,6 @@ test("uses visible todo calls and injects only missing current state", async () 
 		version: TODO_CONTEXT_VERSION,
 	});
 
-	const ordinary: ContextEvent["messages"] = [
-		{
-			role: "user",
-			content: [{ type: "text", text: "ordinary context" }],
-			timestamp: 0,
-		},
-	];
-	assert.equal(await harness.context(ordinary, current.ctx), ordinary);
-	assert.deepEqual(await harness.context([...ordinary, reminder], current.ctx), ordinary);
-
 	for (const toolName of [TOOL_NAME, "todo_widget"]) {
 		const details: TodoDetails = { version: TODO_DETAILS_VERSION, items };
 		const visible = [
@@ -283,7 +294,9 @@ test("uses visible todo calls and injects only missing current state", async () 
 			todoToolCallMessage(items, toolName),
 			todoToolResultMessage(details, toolName),
 		];
-		assert.equal(await harness.context(visible, current.ctx), visible);
+		const retained = await harness.context(visible, current.ctx);
+		assert.deepEqual(retained[2], reminder);
+		assert.deepEqual(retained.slice(3), visible.slice(2));
 	}
 
 	const details: TodoDetails = { version: TODO_DETAILS_VERSION, items };
@@ -317,15 +330,29 @@ test("uses visible todo calls and injects only missing current state", async () 
 		todoToolCallMessage(replacementItems),
 		todoToolResultMessage(replacementDetails),
 	];
-	assert.deepEqual(
+	assert.equal(
 		await harness.context(replacement, current.ctx),
-		replacement.filter(
-			(message) => message.role !== "custom" || message.customType !== TODO_CONTEXT_MESSAGE_TYPE,
-		),
+		replacement,
+		"a later update must supersede rather than remove the restored boundary",
 	);
 
 	await setTodos(harness, current.ctx, []);
-	assert.deepEqual(await harness.context(transformed, current.ctx), base);
+	assert.equal(
+		await harness.context(transformed, current.ctx),
+		transformed,
+		"clearing the list must not rewrite the established summary prefix",
+	);
+	const nextSummaryEpoch = base.map((message, index) =>
+		index === 0 && message.role === "compactionSummary"
+			? { ...message, summary: "Later work was compacted." }
+			: message,
+	);
+	assert.equal(
+		await harness.context(nextSummaryEpoch, current.ctx),
+		nextSummaryEpoch,
+		"a new summary epoch must use the current cleared state",
+	);
+	assert.deepEqual(await harness.context([...ordinary, reminder], current.ctx), ordinary);
 });
 
 test("renders completed, current, and pending tasks with themed semantic symbols", () => {


### PR DESCRIPTION
## Summary

- retain restored todo and required-completion messages for their leading-summary epoch while later tail evidence supersedes them
- append restored cancellations after stale retained handoffs, including compacted contexts, while keeping missing-handoff restoration at the summary boundary
- capture compacted subagent guidance at session start so a settings change before the first resumed context appends instead of rewriting the prefix
- document the corrected contracts and extend the existing pending patch Changeset

Follow-up to the post-merge review feedback on #985.

## Verification

- focused cache and lifecycle suite: 4 files, 24 tests passed
- `npm --workspace @narumitw/pi-todo run check`
- `npm --workspace @narumitw/pi-subagents run check`
- `npm run check`
- `npm test`: 383 files, 3,370 tests passed

## Audit

- reviewed against `docs/extension-conventions.md` prompt-cache and lifecycle MUST rules
- reviewed against `docs/extension-settings.md`; settings persistence ordering is unchanged, and publication remains after a successful atomic settings save
- session replacement, stale context, shutdown, summary-epoch replacement, update, clear, completion visibility, and retained/missing handoff paths have deterministic coverage
- no package metadata or runtime-loading path changed, so pack and Pi loader smokes were not required
