### PR TITLE
perf(tooling): scope pre-commit typechecks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"concurrently": "^10.0.5",
 				"husky": "9.1.7",
 				"npm-check-updates": "23.1.0",
+				"semver": "7.8.5",
 				"typebox": "^1.3.18",
 				"typescript": "^7.0.2",
 				"vitest": "^4.1.11"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"concurrently": "^10.0.5",
 		"husky": "9.1.7",
 		"npm-check-updates": "23.1.0",
+		"semver": "7.8.5",
 		"typebox": "^1.3.18",
 		"typescript": "^7.0.2",
 		"vitest": "^4.1.11"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"smoke:caffeinate-dbus": "node ./packages/pi-caffeinate/test/docker/run-docker.mjs",
 		"smoke:pi-fleet:ghostty": "cd packages/pi-fleet && tsc -p tsconfig.process-smoke.json && node ../../node_modules/.cache/pi-fleet-process/scripts/ghostty-smoke.js",
 		"check": "npm run build && node ./scripts/run-checks.mjs",
-		"precommit": "biome check --staged --no-errors-on-unmatched && npm run typecheck",
+		"precommit": "biome check --staged --no-errors-on-unmatched && node ./scripts/run-typechecks.mjs --staged",
 		"prepare": "node .husky/install.mjs",
 		"changeset": "changeset",
 		"changeset:status": "changeset status --verbose",

--- a/scripts/run-typechecks.mjs
+++ b/scripts/run-typechecks.mjs
@@ -3,14 +3,57 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { selectStagedTypechecks, stagedFiles } from "./select-staged-typechecks.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const stagedOnly = process.argv.slice(2).includes("--staged");
 
-if (process.env.PI_EXTENSIONS_BUILD_READY !== "1") {
-	runNpm(["run", "build"]);
-	process.env.PI_EXTENSIONS_BUILD_READY = "1";
+if (!stagedOnly) {
+	runFullTypechecks();
+	process.exit(0);
 }
-runNpm(["--workspaces", "run", "typecheck"]);
+
+let selection;
+try {
+	selection = selectStagedTypechecks(root, stagedFiles(root));
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	console.warn(`Could not select staged typechecks (${message}); falling back to all workspaces.`);
+	runFullTypechecks();
+	process.exit(0);
+}
+
+if (selection.mode === "skip") {
+	console.log(`Skipping workspace typechecks: ${selection.reason}.`);
+	process.exit(0);
+}
+if (selection.mode === "full") {
+	console.log(`Running full workspace typechecks: ${selection.reason}.`);
+	runFullTypechecks();
+	process.exit(0);
+}
+
+console.log(
+	`Running affected workspace typechecks for ${selection.workspaceDirectories.join(", ")}: ${selection.reason}.`,
+);
+if (process.env.PI_EXTENSIONS_BUILD_READY !== "1" && selection.buildWorkspaceNames.length > 0) {
+	runWorkspaceScript("build", selection.buildWorkspaceNames, true);
+}
+runWorkspaceScript("typecheck", selection.workspaceNames);
+
+function runFullTypechecks() {
+	if (process.env.PI_EXTENSIONS_BUILD_READY !== "1") {
+		runNpm(["run", "build"]);
+		process.env.PI_EXTENSIONS_BUILD_READY = "1";
+	}
+	runNpm(["--workspaces", "run", "typecheck"]);
+}
+
+function runWorkspaceScript(script, workspaceNames, ifPresent = false) {
+	const workspaceArgs = workspaceNames.flatMap((workspaceName) => ["--workspace", workspaceName]);
+	if (ifPresent) workspaceArgs.push("--if-present");
+	runNpm([...workspaceArgs, "run", script]);
+}
 
 function runNpm(args) {
 	const command = process.env.npm_execpath

--- a/scripts/select-affected-tests.mjs
+++ b/scripts/select-affected-tests.mjs
@@ -22,7 +22,7 @@ export function changedFilesSince(root, base, head = "HEAD") {
 
 	const output = execFileSync(
 		"git",
-		["diff", "--name-only", "-z", "--diff-filter=ACDMRTUXB", `${base}...${head}`],
+		["diff", "--no-renames", "--name-only", "-z", "--diff-filter=ACDMRTUXB", `${base}...${head}`],
 		{ cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
 	);
 	return output.split("\0").filter(Boolean);

--- a/scripts/select-affected-tests.mjs
+++ b/scripts/select-affected-tests.mjs
@@ -1,13 +1,7 @@
 import { execFileSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
+import { expandReverseDependencies, readWorkspaces } from "./workspace-graph.mjs";
 
-const DEPENDENCY_FIELDS = [
-	"dependencies",
-	"devDependencies",
-	"peerDependencies",
-	"optionalDependencies",
-];
 const DOCUMENTATION_BASENAMES = new Set([
 	"CHANGELOG.md",
 	"LICENSE",
@@ -110,51 +104,6 @@ export function selectAffectedTests(root, changedFiles) {
 		workspaceDirectories,
 		reason: `${directlyAffected.size} directly changed workspace(s), ${workspaceDirectories.length} affected workspace(s)`,
 	};
-}
-
-function readWorkspaces(root) {
-	const packagesDirectory = path.join(root, "packages");
-	if (!fs.existsSync(packagesDirectory)) return [];
-
-	const workspaces = [];
-	for (const entry of fs.readdirSync(packagesDirectory, { withFileTypes: true })) {
-		if (!entry.isDirectory()) continue;
-		const manifestPath = path.join(packagesDirectory, entry.name, "package.json");
-		if (!fs.existsSync(manifestPath)) continue;
-		const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-		if (typeof manifest.name !== "string") continue;
-		workspaces.push({
-			dependencies: dependencyNames(manifest),
-			directoryName: entry.name,
-			name: manifest.name,
-		});
-	}
-	return workspaces.sort((left, right) => left.directoryName.localeCompare(right.directoryName));
-}
-
-function dependencyNames(manifest) {
-	const names = new Set();
-	for (const field of DEPENDENCY_FIELDS) {
-		const dependencies = manifest[field];
-		if (!dependencies || typeof dependencies !== "object" || Array.isArray(dependencies)) continue;
-		for (const name of Object.keys(dependencies)) names.add(name);
-	}
-	return names;
-}
-
-function expandReverseDependencies(workspaces, directlyAffected) {
-	const affected = new Set(directlyAffected);
-	let changed = true;
-	while (changed) {
-		changed = false;
-		for (const workspace of workspaces) {
-			if (affected.has(workspace.name)) continue;
-			if (![...workspace.dependencies].some((dependency) => affected.has(dependency))) continue;
-			affected.add(workspace.name);
-			changed = true;
-		}
-	}
-	return affected;
 }
 
 function isPackageTestRelevant(relativePath) {

--- a/scripts/select-staged-typechecks.mjs
+++ b/scripts/select-staged-typechecks.mjs
@@ -1,0 +1,131 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import {
+	expandDependencies,
+	expandReverseDependencies,
+	orderDependenciesFirst,
+	readWorkspaces,
+} from "./workspace-graph.mjs";
+
+const DOCUMENTATION_BASENAMES = new Set([
+	"CHANGELOG.md",
+	"LICENSE",
+	"LICENSE.md",
+	"NOTICES.md",
+	"README.md",
+]);
+const ROOT_FULL_TYPECHECK_FILES = new Set([
+	"package-lock.json",
+	"package.json",
+	"tsconfig.json",
+	"tsconfig.test.json",
+]);
+const ROOT_IGNORED_PREFIXES = [".changeset/", ".github/", "docs/"];
+
+export function stagedFiles(root) {
+	const output = execFileSync(
+		"git",
+		["diff", "--cached", "--name-only", "-z", "--diff-filter=ACDMRTUXB"],
+		{ cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+	);
+	return output.split("\0").filter(Boolean);
+}
+
+export function selectStagedTypechecks(root, changedFiles) {
+	const workspaces = readWorkspaces(root);
+	const workspaceByDirectory = new Map(
+		workspaces.map((workspace) => [workspace.directoryName, workspace]),
+	);
+	const directlyAffected = new Set();
+	let fullReason;
+
+	for (const changedFile of changedFiles) {
+		const normalized = changedFile.split(path.sep).join("/").replace(/^\.\//u, "");
+		if (!normalized || normalized.startsWith("../") || path.posix.isAbsolute(normalized)) {
+			fullReason = `unsafe staged path: ${changedFile}`;
+			break;
+		}
+
+		const packageMatch = /^packages\/([^/]+)(?:\/(.*))?$/u.exec(normalized);
+		if (packageMatch) {
+			const [, directoryName, relativePath = ""] = packageMatch;
+			if (isDocumentation(relativePath)) continue;
+
+			const workspace = workspaceByDirectory.get(directoryName);
+			if (!workspace) {
+				fullReason = `staged package is not present in the current workspace: ${directoryName}`;
+				break;
+			}
+			directlyAffected.add(workspace.name);
+			continue;
+		}
+
+		if (ROOT_FULL_TYPECHECK_FILES.has(normalized) || normalized.startsWith("scripts/")) {
+			fullReason = `shared typecheck input staged: ${normalized}`;
+			break;
+		}
+
+		if (isIgnoredRootFile(normalized)) continue;
+		if (/\.(?:[cm]?[jt]sx?|json)$/u.test(normalized)) {
+			fullReason = `unscoped code or configuration staged: ${normalized}`;
+			break;
+		}
+	}
+
+	if (fullReason) return fullSelection(workspaces, fullReason);
+
+	const affectedNames = expandReverseDependencies(workspaces, directlyAffected);
+	if (affectedNames.size === 0) {
+		return {
+			mode: "skip",
+			buildWorkspaceNames: [],
+			workspaceDirectories: [],
+			workspaceNames: [],
+			reason: "no typecheck-relevant files are staged",
+		};
+	}
+
+	const buildNames = expandDependencies(workspaces, affectedNames);
+	return {
+		mode: "affected",
+		buildWorkspaceNames: orderDependenciesFirst(
+			workspaces,
+			new Set(
+				workspaces
+					.filter(({ hasBuildScript, name }) => hasBuildScript && buildNames.has(name))
+					.map(({ name }) => name),
+			),
+		),
+		workspaceDirectories: workspaces
+			.filter(({ name }) => affectedNames.has(name))
+			.map(({ directoryName }) => directoryName),
+		workspaceNames: orderDependenciesFirst(workspaces, affectedNames),
+		reason: `${directlyAffected.size} directly staged workspace(s), ${affectedNames.size} affected workspace(s)`,
+	};
+}
+
+function fullSelection(workspaces, reason) {
+	const workspaceNames = new Set(workspaces.map(({ name }) => name));
+	return {
+		mode: "full",
+		buildWorkspaceNames: orderDependenciesFirst(
+			workspaces,
+			new Set(workspaces.filter(({ hasBuildScript }) => hasBuildScript).map(({ name }) => name)),
+		),
+		workspaceDirectories: workspaces.map(({ directoryName }) => directoryName),
+		workspaceNames: orderDependenciesFirst(workspaces, workspaceNames),
+		reason,
+	};
+}
+
+function isDocumentation(relativePath) {
+	return (
+		relativePath &&
+		(relativePath.endsWith(".md") || DOCUMENTATION_BASENAMES.has(path.posix.basename(relativePath)))
+	);
+}
+
+function isIgnoredRootFile(filePath) {
+	if (ROOT_IGNORED_PREFIXES.some((prefix) => filePath.startsWith(prefix))) return true;
+	return DOCUMENTATION_BASENAMES.has(path.posix.basename(filePath));
+}

--- a/scripts/select-staged-typechecks.mjs
+++ b/scripts/select-staged-typechecks.mjs
@@ -23,11 +23,44 @@ const ROOT_FULL_TYPECHECK_FILES = new Set([
 const ROOT_IGNORED_PREFIXES = [".changeset/", ".github/", "docs/"];
 
 export function stagedFiles(root) {
-	const output = execFileSync(
-		"git",
-		["diff", "--cached", "--name-only", "-z", "--diff-filter=ACDMRTUXB"],
-		{ cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-	);
+	const unstagedManifests = gitPaths(root, [
+		"diff",
+		"--name-only",
+		"-z",
+		"--",
+		":(glob)packages/*/package.json",
+	]);
+	const untrackedManifests = gitPaths(root, [
+		"ls-files",
+		"--others",
+		"--exclude-standard",
+		"-z",
+		"--",
+		":(glob)packages/*/package.json",
+	]);
+	const inconsistentManifests = [...new Set([...unstagedManifests, ...untrackedManifests])];
+	if (inconsistentManifests.length > 0) {
+		throw new Error(
+			`workspace manifests differ from the index: ${inconsistentManifests.join(", ")}`,
+		);
+	}
+
+	return gitPaths(root, [
+		"diff",
+		"--cached",
+		"--no-renames",
+		"--name-only",
+		"-z",
+		"--diff-filter=ACDMRTUXB",
+	]);
+}
+
+function gitPaths(root, args) {
+	const output = execFileSync("git", args, {
+		cwd: root,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
 	return output.split("\0").filter(Boolean);
 }
 

--- a/scripts/workspace-graph.mjs
+++ b/scripts/workspace-graph.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import semver from "semver";
 
 const DEPENDENCY_FIELDS = [
 	"dependencies",
@@ -12,21 +13,26 @@ export function readWorkspaces(root) {
 	const packagesDirectory = path.join(root, "packages");
 	if (!fs.existsSync(packagesDirectory)) return [];
 
-	const workspaces = [];
+	const workspaceManifests = [];
 	for (const entry of fs.readdirSync(packagesDirectory, { withFileTypes: true })) {
 		if (!entry.isDirectory()) continue;
 		const manifestPath = path.join(packagesDirectory, entry.name, "package.json");
 		if (!fs.existsSync(manifestPath)) continue;
 		const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
 		if (typeof manifest.name !== "string") continue;
-		workspaces.push({
-			dependencies: dependencyNames(manifest),
-			directoryName: entry.name,
-			hasBuildScript: typeof manifest.scripts?.build === "string",
-			name: manifest.name,
-		});
+		workspaceManifests.push({ directoryName: entry.name, manifest });
 	}
-	return workspaces.sort((left, right) => left.directoryName.localeCompare(right.directoryName));
+	workspaceManifests.sort((left, right) => left.directoryName.localeCompare(right.directoryName));
+
+	const workspaceVersions = new Map(
+		workspaceManifests.map(({ manifest }) => [manifest.name, manifest.version]),
+	);
+	return workspaceManifests.map(({ directoryName, manifest }) => ({
+		dependencies: dependencyNames(manifest, workspaceVersions),
+		directoryName,
+		hasBuildScript: typeof manifest.scripts?.build === "string",
+		name: manifest.name,
+	}));
 }
 
 export function expandReverseDependencies(workspaces, directlyAffected) {
@@ -87,12 +93,24 @@ export function orderDependenciesFirst(workspaces, workspaceNames) {
 	return ordered;
 }
 
-function dependencyNames(manifest) {
+function dependencyNames(manifest, workspaceVersions) {
 	const names = new Set();
 	for (const field of DEPENDENCY_FIELDS) {
 		const dependencies = manifest[field];
 		if (!dependencies || typeof dependencies !== "object" || Array.isArray(dependencies)) continue;
-		for (const name of Object.keys(dependencies)) names.add(name);
+		for (const [name, specifier] of Object.entries(dependencies)) {
+			if (!workspaceVersions.has(name)) continue;
+			if (!usesLocalWorkspace(specifier, workspaceVersions.get(name))) continue;
+			names.add(name);
+		}
 	}
 	return names;
+}
+
+function usesLocalWorkspace(specifier, workspaceVersion) {
+	if (typeof specifier !== "string") return false;
+	if (specifier.startsWith("workspace:")) return true;
+	if (typeof workspaceVersion !== "string" || !semver.valid(workspaceVersion)) return false;
+	const range = semver.validRange(specifier);
+	return range !== null && semver.satisfies(workspaceVersion, range, { includePrerelease: true });
 }

--- a/scripts/workspace-graph.mjs
+++ b/scripts/workspace-graph.mjs
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const DEPENDENCY_FIELDS = [
+	"dependencies",
+	"devDependencies",
+	"peerDependencies",
+	"optionalDependencies",
+];
+
+export function readWorkspaces(root) {
+	const packagesDirectory = path.join(root, "packages");
+	if (!fs.existsSync(packagesDirectory)) return [];
+
+	const workspaces = [];
+	for (const entry of fs.readdirSync(packagesDirectory, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const manifestPath = path.join(packagesDirectory, entry.name, "package.json");
+		if (!fs.existsSync(manifestPath)) continue;
+		const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+		if (typeof manifest.name !== "string") continue;
+		workspaces.push({
+			dependencies: dependencyNames(manifest),
+			directoryName: entry.name,
+			hasBuildScript: typeof manifest.scripts?.build === "string",
+			name: manifest.name,
+		});
+	}
+	return workspaces.sort((left, right) => left.directoryName.localeCompare(right.directoryName));
+}
+
+export function expandReverseDependencies(workspaces, directlyAffected) {
+	const affected = new Set(directlyAffected);
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const workspace of workspaces) {
+			if (affected.has(workspace.name)) continue;
+			if (![...workspace.dependencies].some((dependency) => affected.has(dependency))) continue;
+			affected.add(workspace.name);
+			changed = true;
+		}
+	}
+	return affected;
+}
+
+export function expandDependencies(workspaces, workspaceNames) {
+	const workspaceByName = new Map(workspaces.map((workspace) => [workspace.name, workspace]));
+	const expanded = new Set(workspaceNames);
+	const pending = [...workspaceNames];
+	while (pending.length > 0) {
+		const workspace = workspaceByName.get(pending.pop());
+		if (!workspace) continue;
+		for (const dependency of workspace.dependencies) {
+			if (!workspaceByName.has(dependency) || expanded.has(dependency)) continue;
+			expanded.add(dependency);
+			pending.push(dependency);
+		}
+	}
+	return expanded;
+}
+
+export function orderDependenciesFirst(workspaces, workspaceNames) {
+	const selected = new Set(workspaceNames);
+	const workspaceByName = new Map(workspaces.map((workspace) => [workspace.name, workspace]));
+	const visiting = new Set();
+	const visited = new Set();
+	const ordered = [];
+
+	function visit(name) {
+		if (visited.has(name) || visiting.has(name)) return;
+		visiting.add(name);
+		const workspace = workspaceByName.get(name);
+		if (workspace) {
+			for (const dependency of workspace.dependencies) {
+				if (selected.has(dependency)) visit(dependency);
+			}
+		}
+		visiting.delete(name);
+		visited.add(name);
+		ordered.push(name);
+	}
+
+	for (const workspace of workspaces) {
+		if (selected.has(workspace.name)) visit(workspace.name);
+	}
+	return ordered;
+}
+
+function dependencyNames(manifest) {
+	const names = new Set();
+	for (const field of DEPENDENCY_FIELDS) {
+		const dependencies = manifest[field];
+		if (!dependencies || typeof dependencies !== "object" || Array.isArray(dependencies)) continue;
+		for (const name of Object.keys(dependencies)) names.add(name);
+	}
+	return names;
+}

--- a/test/affected-precommit-typechecks.test.ts
+++ b/test/affected-precommit-typechecks.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, test } from "vitest";
+
+interface TypecheckSelection {
+	mode: "affected" | "full" | "skip";
+	buildWorkspaceNames: string[];
+	workspaceDirectories: string[];
+	workspaceNames: string[];
+	reason: string;
+}
+
+interface SelectorModule {
+	selectStagedTypechecks(root: string, changedFiles: string[]): TypecheckSelection;
+	stagedFiles(root: string): string[];
+}
+
+interface TestSelectorModule {
+	selectAffectedTests(
+		root: string,
+		changedFiles: string[],
+	): {
+		mode: "affected" | "full" | "skip";
+		includeRootTests: boolean;
+		workspaceDirectories: string[];
+	};
+}
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..");
+const selectorUrl = pathToFileURL(
+	path.join(repositoryRoot, "scripts", "select-staged-typechecks.mjs"),
+).href;
+const testSelectorUrl = pathToFileURL(
+	path.join(repositoryRoot, "scripts", "select-affected-tests.mjs"),
+).href;
+let fixtureRoot: string;
+let selector: SelectorModule;
+let testSelector: TestSelectorModule;
+
+beforeAll(async () => {
+	selector = (await import(selectorUrl)) as SelectorModule;
+	testSelector = (await import(testSelectorUrl)) as TestSelectorModule;
+	fixtureRoot = mkdtempSync(path.join(os.tmpdir(), "pi-precommit-selection-"));
+	writeWorkspace("library", { name: "@fixture/library", scripts: { build: "build" } });
+	writeWorkspace("feature", {
+		dependencies: { "@fixture/library": "workspace:*" },
+		name: "@fixture/feature",
+		scripts: { build: "build" },
+	});
+	writeWorkspace("app", {
+		devDependencies: { "@fixture/feature": "workspace:*" },
+		name: "@fixture/app",
+		scripts: { build: "build" },
+	});
+	writeWorkspace("unrelated", {
+		name: "@fixture/unrelated",
+		scripts: { build: "build" },
+	});
+});
+
+afterAll(() => {
+	rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+test("a staged workspace selects transitive dependents and required build dependencies", () => {
+	const selection = selector.selectStagedTypechecks(fixtureRoot, ["packages/feature/src/index.ts"]);
+
+	assert.equal(selection.mode, "affected");
+	assert.deepEqual(selection.workspaceNames, ["@fixture/feature", "@fixture/app"]);
+	assert.deepEqual(selection.workspaceDirectories, ["app", "feature"]);
+	assert.deepEqual(selection.buildWorkspaceNames, [
+		"@fixture/library",
+		"@fixture/feature",
+		"@fixture/app",
+	]);
+});
+
+test("a staged shared library selects all transitive dependents but not unrelated workspaces", () => {
+	const selection = selector.selectStagedTypechecks(fixtureRoot, ["packages/library/src/index.ts"]);
+
+	assert.equal(selection.mode, "affected");
+	assert.deepEqual(selection.workspaceNames, [
+		"@fixture/library",
+		"@fixture/feature",
+		"@fixture/app",
+	]);
+	assert.doesNotMatch(selection.workspaceNames.join(" "), /unrelated/u);
+});
+
+test("documentation-only staging skips workspace typechecks", () => {
+	const selection = selector.selectStagedTypechecks(fixtureRoot, [
+		"README.md",
+		"packages/feature/docs/usage.md",
+		"packages/feature/LICENSE",
+	]);
+
+	assert.equal(selection.mode, "skip");
+	assert.deepEqual(selection.workspaceNames, []);
+	assert.deepEqual(selection.buildWorkspaceNames, []);
+});
+
+test("shared root inputs and removed workspaces fall back to all workspaces", () => {
+	for (const changedFiles of [
+		["package-lock.json"],
+		["tsconfig.json"],
+		["biome.json"],
+		["scripts/run-typechecks.mjs"],
+		["packages/removed/src/index.ts"],
+		["../outside.ts"],
+	]) {
+		const selection = selector.selectStagedTypechecks(fixtureRoot, changedFiles);
+		assert.equal(selection.mode, "full", changedFiles.join(", "));
+		assert.deepEqual(selection.workspaceNames, [
+			"@fixture/library",
+			"@fixture/feature",
+			"@fixture/app",
+			"@fixture/unrelated",
+		]);
+	}
+});
+
+test("the existing affected-test selector retains reverse-dependent behavior", () => {
+	const selection = testSelector.selectAffectedTests(fixtureRoot, [
+		"packages/feature/src/index.ts",
+	]);
+
+	assert.equal(selection.mode, "affected");
+	assert.equal(selection.includeRootTests, true);
+	assert.deepEqual(selection.workspaceDirectories, ["app", "feature"]);
+});
+
+test("staged file discovery excludes unstaged changes", () => {
+	const gitRoot = mkdtempSync(path.join(os.tmpdir(), "pi-precommit-git-"));
+	try {
+		git(gitRoot, ["init", "-q"]);
+		writeFileSync(path.join(gitRoot, "staged.ts"), "export const staged = 1;\n");
+		writeFileSync(path.join(gitRoot, "unstaged.ts"), "export const unstaged = 1;\n");
+		git(gitRoot, ["add", "."]);
+		git(gitRoot, ["-c", "commit.gpgsign=false", "commit", "-qm", "fixture"]);
+
+		writeFileSync(path.join(gitRoot, "staged.ts"), "export const staged = 2;\n");
+		writeFileSync(path.join(gitRoot, "unstaged.ts"), "export const unstaged = 2;\n");
+		git(gitRoot, ["add", "staged.ts"]);
+
+		assert.deepEqual(selector.stagedFiles(gitRoot), ["staged.ts"]);
+	} finally {
+		rmSync(gitRoot, { recursive: true, force: true });
+	}
+});
+
+test("the pre-commit hook narrows typechecks without narrowing the repository gate", () => {
+	const manifest = JSON.parse(readFileSync(path.join(repositoryRoot, "package.json"), "utf8")) as {
+		scripts: Record<string, string>;
+	};
+	assert.match(manifest.scripts.precommit, /run-typechecks\.mjs --staged/u);
+	assert.doesNotMatch(manifest.scripts.typecheck, /--staged/u);
+});
+
+function writeWorkspace(directoryName: string, manifest: Record<string, unknown>) {
+	const workspaceRoot = path.join(fixtureRoot, "packages", directoryName);
+	mkdirSync(path.join(workspaceRoot, "src"), { recursive: true });
+	writeFileSync(path.join(workspaceRoot, "package.json"), `${JSON.stringify(manifest)}\n`);
+	writeFileSync(path.join(workspaceRoot, "src", "index.ts"), "export {};\n");
+}
+
+function git(cwd: string, args: string[]) {
+	return execFileSync("git", args, {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+}

--- a/test/affected-precommit-typechecks.test.ts
+++ b/test/affected-precommit-typechecks.test.ts
@@ -20,6 +20,7 @@ interface SelectorModule {
 }
 
 interface TestSelectorModule {
+	changedFilesSince(root: string, base: string, head?: string): string[];
 	selectAffectedTests(
 		root: string,
 		changedFiles: string[],
@@ -45,20 +46,33 @@ beforeAll(async () => {
 	selector = (await import(selectorUrl)) as SelectorModule;
 	testSelector = (await import(testSelectorUrl)) as TestSelectorModule;
 	fixtureRoot = mkdtempSync(path.join(os.tmpdir(), "pi-precommit-selection-"));
-	writeWorkspace("library", { name: "@fixture/library", scripts: { build: "build" } });
+	writeWorkspace("library", {
+		name: "@fixture/library",
+		scripts: { build: "build" },
+		version: "1.0.0",
+	});
 	writeWorkspace("feature", {
-		dependencies: { "@fixture/library": "workspace:*" },
+		dependencies: { "@fixture/library": "^1.0.0" },
 		name: "@fixture/feature",
 		scripts: { build: "build" },
+		version: "1.0.0",
 	});
 	writeWorkspace("app", {
 		devDependencies: { "@fixture/feature": "workspace:*" },
 		name: "@fixture/app",
 		scripts: { build: "build" },
+		version: "1.0.0",
+	});
+	writeWorkspace("registry-consumer", {
+		dependencies: { "@fixture/library": "^0.9.0" },
+		name: "@fixture/registry-consumer",
+		scripts: { build: "build" },
+		version: "1.0.0",
 	});
 	writeWorkspace("unrelated", {
 		name: "@fixture/unrelated",
 		scripts: { build: "build" },
+		version: "1.0.0",
 	});
 });
 
@@ -79,7 +93,7 @@ test("a staged workspace selects transitive dependents and required build depend
 	]);
 });
 
-test("a staged shared library selects all transitive dependents but not unrelated workspaces", () => {
+test("a staged shared library selects local dependents but not registry-resolved consumers", () => {
 	const selection = selector.selectStagedTypechecks(fixtureRoot, ["packages/library/src/index.ts"]);
 
 	assert.equal(selection.mode, "affected");
@@ -88,7 +102,17 @@ test("a staged shared library selects all transitive dependents but not unrelate
 		"@fixture/feature",
 		"@fixture/app",
 	]);
-	assert.doesNotMatch(selection.workspaceNames.join(" "), /unrelated/u);
+	assert.doesNotMatch(selection.workspaceNames.join(" "), /registry-consumer|unrelated/u);
+});
+
+test("an incompatible dependency range does not build the unrelated local workspace", () => {
+	const selection = selector.selectStagedTypechecks(fixtureRoot, [
+		"packages/registry-consumer/src/index.ts",
+	]);
+
+	assert.equal(selection.mode, "affected");
+	assert.deepEqual(selection.workspaceNames, ["@fixture/registry-consumer"]);
+	assert.deepEqual(selection.buildWorkspaceNames, ["@fixture/registry-consumer"]);
 });
 
 test("documentation-only staging skips workspace typechecks", () => {
@@ -118,6 +142,7 @@ test("shared root inputs and removed workspaces fall back to all workspaces", ()
 			"@fixture/library",
 			"@fixture/feature",
 			"@fixture/app",
+			"@fixture/registry-consumer",
 			"@fixture/unrelated",
 		]);
 	}
@@ -133,20 +158,42 @@ test("the existing affected-test selector retains reverse-dependent behavior", (
 	assert.deepEqual(selection.workspaceDirectories, ["app", "feature"]);
 });
 
-test("staged file discovery excludes unstaged changes", () => {
+test("staged file discovery tracks both rename paths and rejects unstaged manifests", () => {
 	const gitRoot = mkdtempSync(path.join(os.tmpdir(), "pi-precommit-git-"));
 	try {
 		git(gitRoot, ["init", "-q"]);
 		writeFileSync(path.join(gitRoot, "staged.ts"), "export const staged = 1;\n");
 		writeFileSync(path.join(gitRoot, "unstaged.ts"), "export const unstaged = 1;\n");
+		mkdirSync(path.join(gitRoot, "packages", "source", "src"), { recursive: true });
+		writeFileSync(
+			path.join(gitRoot, "packages", "source", "package.json"),
+			'{"name":"@fixture/source","version":"1.0.0"}\n',
+		);
+		writeFileSync(path.join(gitRoot, "packages", "source", "src", "moved.ts"), "export {};\n");
 		git(gitRoot, ["add", "."]);
-		git(gitRoot, ["-c", "commit.gpgsign=false", "commit", "-qm", "fixture"]);
+		commitFixture(gitRoot, "fixture");
+		const base = git(gitRoot, ["rev-parse", "HEAD"]).trim();
 
 		writeFileSync(path.join(gitRoot, "staged.ts"), "export const staged = 2;\n");
 		writeFileSync(path.join(gitRoot, "unstaged.ts"), "export const unstaged = 2;\n");
+		mkdirSync(path.join(gitRoot, "docs"), { recursive: true });
+		git(gitRoot, ["mv", "packages/source/src/moved.ts", "docs/moved.ts"]);
 		git(gitRoot, ["add", "staged.ts"]);
 
-		assert.deepEqual(selector.stagedFiles(gitRoot), ["staged.ts"]);
+		const renamedPaths = ["docs/moved.ts", "packages/source/src/moved.ts", "staged.ts"];
+		assert.deepEqual(selector.stagedFiles(gitRoot), renamedPaths);
+
+		commitFixture(gitRoot, "rename fixture");
+		assert.deepEqual(testSelector.changedFilesSince(gitRoot, base), renamedPaths);
+
+		writeFileSync(
+			path.join(gitRoot, "packages", "source", "package.json"),
+			'{"name":"@fixture/source","version":"2.0.0"}\n',
+		);
+		assert.throws(
+			() => selector.stagedFiles(gitRoot),
+			/workspace manifests differ from the index: packages\/source\/package\.json/u,
+		);
 	} finally {
 		rmSync(gitRoot, { recursive: true, force: true });
 	}
@@ -165,6 +212,20 @@ function writeWorkspace(directoryName: string, manifest: Record<string, unknown>
 	mkdirSync(path.join(workspaceRoot, "src"), { recursive: true });
 	writeFileSync(path.join(workspaceRoot, "package.json"), `${JSON.stringify(manifest)}\n`);
 	writeFileSync(path.join(workspaceRoot, "src", "index.ts"), "export {};\n");
+}
+
+function commitFixture(cwd: string, message: string) {
+	git(cwd, [
+		"-c",
+		"commit.gpgsign=false",
+		"-c",
+		"user.name=Fixture",
+		"-c",
+		"user.email=fixture@example.com",
+		"commit",
+		"-qm",
+		message,
+	]);
 }
 
 function git(cwd: string, args: string[]) {


### PR DESCRIPTION
## Summary

- Select pre-commit typechecks from staged files instead of checking every workspace.
- Include transitive workspace dependents and build required local dependencies before typechecking.
- Fall back to the full workspace gate for shared root inputs, unsafe paths, removed workspaces, or selection failures.
- Reuse the workspace graph in affected-test selection and add deterministic selector coverage.

## Verification

- `npx biome check scripts/workspace-graph.mjs scripts/select-staged-typechecks.mjs scripts/select-affected-tests.mjs scripts/run-typechecks.mjs test/affected-precommit-typechecks.test.ts package.json`
- `node node_modules/vitest/vitest.mjs run test/affected-precommit-typechecks.test.ts` (7 tests passed)
- Focused TypeScript compilation of `test/affected-precommit-typechecks.test.ts`
- Isolated-index smoke selected `pi-accounts`, built `pi-tui-kit` and `pi-accounts`, and typechecked only `pi-accounts`.
- Signed commit hook completed the full build and all workspace typechecks because `package.json` is a shared root input.

## Risks

- TypeScript checks selected workspaces rather than individual staged hunks, so unstaged edits inside a selected workspace remain visible to the compiler.
- Shared library changes can intentionally select most workspaces through reverse dependencies.

## Scope

- No Changeset is required for repository-only tooling.
