### PR TITLE
fix(btw): restore main input after Ctrl+C

### DIFF
--- a/.changeset/quick-btw-input-handoff.md
+++ b/.changeset/quick-btw-input-handoff.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": patch
+---
+
+Restore main-editor input immediately after Ctrl+C exits a dedicated side thread.

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -7,6 +7,9 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import {
 	type Component,
+	isKeyRelease,
+	Key,
+	matchesKey,
 	type OverlayHandle,
 	type TUI,
 	TuiAltScreen,
@@ -69,9 +72,10 @@ export async function runBtwFullscreen<T>(
 			));
 	let liveEditorText = ctx.ui.getEditorText();
 	let restoreEditor = false;
+	let host: BtwFullscreenHost<T> | undefined;
 	const outcome = await ctx.ui.custom<FullscreenOutcome<T>>(
-		(parent, theme, keybindings, done) =>
-			new BtwFullscreenHost(
+		(parent, theme, keybindings, done) => {
+			host = new BtwFullscreenHost(
 				parent,
 				theme,
 				keybindings,
@@ -87,7 +91,13 @@ export async function runBtwFullscreen<T>(
 					done(value);
 				},
 				createTui,
-			),
+			);
+			return host;
+		},
+		{
+			overlay: true,
+			onHandle: (handle) => host?.setParentOverlay(handle),
+		},
 	);
 	if (restoreEditor) {
 		try {
@@ -139,10 +149,17 @@ function openUrlInBrowser(target: string): void {
 
 class BtwFullscreenHost<T> implements Component {
 	private fullscreen: BtwFullscreenTui | undefined;
+	private parentOverlay: OverlayHandle | undefined;
 	private cancelActiveCustom: (() => void) | undefined;
+	private removeHardCancelListener: (() => void) | undefined;
 	private started = false;
 	private disposed = false;
 	private finished = false;
+	private parentStopped = false;
+	private parentRestarted = false;
+	private fullscreenCreated = false;
+	private fullscreenStopped = false;
+	private cleanupError: unknown;
 
 	constructor(
 		private readonly parent: TUI,
@@ -154,6 +171,10 @@ class BtwFullscreenHost<T> implements Component {
 		private readonly createTui: BtwFullscreenTuiFactory,
 	) {
 		queueMicrotask(() => void this.start());
+	}
+
+	setParentOverlay(overlay: OverlayHandle): void {
+		this.parentOverlay = overlay;
 	}
 
 	render(width: number): string[] {
@@ -172,45 +193,61 @@ class BtwFullscreenHost<T> implements Component {
 		if (this.started || this.finished) return;
 		this.started = true;
 		let outcome: FullscreenOutcome<T>;
-		let parentStopped = false;
-		let fullscreenCreated = false;
 		try {
 			if (this.disposed) throw new FullscreenUiDisposedError();
 			this.parent.stop({ preserveScreen: true });
-			parentStopped = true;
+			this.parentStopped = true;
 			if (this.disposed) throw new FullscreenUiDisposedError();
 			this.fullscreen = this.createTui(this.parent, this.theme);
-			fullscreenCreated = true;
+			this.fullscreenCreated = true;
 			this.fullscreen.start();
+			// Waiting for the custom promise would leave follow-up keys bound to the side TUI.
+			this.removeHardCancelListener = this.fullscreen.addInputListener((data) => {
+				if (!isKeyRelease(data) && matchesKey(data, Key.ctrl("c"))) this.restoreParent();
+				return undefined;
+			});
 			outcome = { kind: "completed", value: await this.run(this.createContext()) };
 		} catch (error) {
 			outcome = { kind: "failed", error };
 		}
 
-		let cleanupError: unknown;
 		try {
 			this.cancelActiveCustom?.();
 		} catch (error) {
-			cleanupError = error;
+			this.cleanupError ??= error;
 		}
-		if (fullscreenCreated) {
+		this.restoreParent();
+		if (this.cleanupError !== undefined) outcome = { kind: "failed", error: this.cleanupError };
+		this.finished = true;
+		this.done(outcome);
+	}
+
+	private restoreParent(): void {
+		this.removeHardCancelListener?.();
+		this.removeHardCancelListener = undefined;
+		if (this.fullscreenCreated && !this.fullscreenStopped) {
+			this.fullscreenStopped = true;
 			try {
 				this.fullscreen?.stop({ preserveScreen: true });
 			} catch (error) {
-				cleanupError ??= error;
+				this.cleanupError ??= error;
 			}
 		}
-		if (parentStopped) {
-			try {
-				this.parent.start();
-				this.parent.renderNow(false);
-			} catch (error) {
-				cleanupError ??= error;
-			}
+		if (!this.parentStopped || this.parentRestarted) return;
+		const parentOverlay = this.parentOverlay;
+		this.parentOverlay = undefined;
+		try {
+			parentOverlay?.setHidden(true);
+		} catch (error) {
+			this.cleanupError ??= error;
 		}
-		if (cleanupError !== undefined) outcome = { kind: "failed", error: cleanupError };
-		this.finished = true;
-		this.done(outcome);
+		try {
+			this.parent.start();
+			this.parentRestarted = true;
+			this.parent.renderNow(false);
+		} catch (error) {
+			this.cleanupError ??= error;
+		}
 	}
 
 	private createContext(): ExtensionCommandContext {

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import type { Component, TUI } from "@earendil-works/pi-tui";
+import {
+	type Component,
+	Container,
+	type Focusable,
+	type Terminal,
+	type TUI,
+	TuiMainScreen,
+} from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import { type BtwFullscreenTuiFactory, runBtwFullscreen } from "../src/fullscreen-ui.js";
 
@@ -57,6 +64,9 @@ function createHarness(options: { fullscreenStopError?: Error; layoutMountError?
 		},
 		requestRender() {
 			events.push("fullscreen.render");
+		},
+		addInputListener() {
+			return () => {};
 		},
 		showOverlay() {
 			throw new Error("overlay was not expected");
@@ -123,6 +133,110 @@ function immediateComponent(done: (value: string) => void, events: string[]): Fa
 
 async function flushAsyncWork(): Promise<void> {
 	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+class InputHandoffTerminal implements Terminal {
+	readonly columns = 80;
+	readonly rows = 12;
+	readonly kittyProtocolActive = false;
+	private inputHandler: ((data: string) => void) | undefined;
+
+	start(onInput: (data: string) => void): void {
+		this.inputHandler = onInput;
+	}
+
+	stop(): void {
+		this.inputHandler = undefined;
+	}
+
+	send(data: string): void {
+		this.inputHandler?.(data);
+	}
+
+	async drainInput(): Promise<void> {}
+	write(): void {}
+	moveBy(): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(): void {}
+	setProgress(): void {}
+}
+
+class MainInput implements Component, Focusable {
+	focused = false;
+	text = "";
+
+	render(): string[] {
+		return [this.text];
+	}
+
+	handleInput(data: string): void {
+		if (data.charCodeAt(0) >= 32) this.text += data;
+	}
+
+	invalidate(): void {}
+}
+
+function createInputHandoffHarness() {
+	const terminal = new InputHandoffTerminal();
+	const parent = new TuiMainScreen(terminal, false);
+	const editorContainer = new Container();
+	const mainInput = new MainInput();
+	editorContainer.addChild(mainInput);
+	parent.addChild(editorContainer);
+	parent.setFocus(mainInput);
+	parent.start();
+
+	const ctx = {
+		ui: {
+			custom: <Value>(
+				factory: (
+					tui: TUI,
+					theme: unknown,
+					keybindings: unknown,
+					done: (value: Value) => void,
+				) => Component & { dispose?(): void },
+				options?: {
+					overlay?: boolean;
+					onHandle?: (handle: ReturnType<TUI["showOverlay"]>) => void;
+				},
+			) =>
+				new Promise<Value>((resolve) => {
+					assert.equal(options?.overlay, true);
+					let component: (Component & { dispose?(): void }) | undefined;
+					let closed = false;
+					const done = (value: Value) => {
+						if (closed) return;
+						closed = true;
+						parent.hideOverlay();
+						component?.dispose?.();
+						resolve(value);
+					};
+					component = factory(
+						parent,
+						{
+							fg: (_color: string, text: string) => text,
+							bg: (_color: string, text: string) => text,
+							underline: (text: string) => text,
+							inverse: (text: string) => text,
+							bold: (text: string) => text,
+						},
+						{},
+						done,
+					);
+					const overlay = parent.showOverlay(component);
+					options.onHandle?.(overlay);
+				}),
+			getEditorText: () => mainInput.text,
+			setEditorText: (value: string) => {
+				mainInput.text = value;
+			},
+		},
+	} as never;
+	return { ctx, mainInput, parent, terminal };
 }
 
 function createNativeFullscreenHarness() {
@@ -228,6 +342,40 @@ async function startClipboardSelection(copy: (text: string) => Promise<void>) {
 	harness.input("\u001b[<0;7;1m");
 	return { harness, running, sideTui, closeSide };
 }
+
+test("Ctrl+C hands input back without closing another parent overlay", async () => {
+	const harness = createInputHandoffHarness();
+	const existingOverlay = harness.parent.showOverlay(
+		{
+			render: () => ["existing overlay"],
+			invalidate() {},
+		},
+		{ nonCapturing: true },
+	);
+	try {
+		const running = runBtwFullscreen(harness.ctx, (ctx) =>
+			ctx.ui.custom<"closed">((_tui, _theme, _keybindings, done) => ({
+				focused: false,
+				render: () => ["side thread"],
+				handleInput(data: string) {
+					if (data === "\u0003") done("closed");
+				},
+				invalidate() {},
+			})),
+		);
+		await flushAsyncWork();
+
+		harness.terminal.send("\u0003");
+		harness.terminal.send("x");
+
+		assert.equal(await running, "closed");
+		assert.equal(harness.mainInput.text, "x");
+		assert.equal(harness.parent.hasOverlay(), true);
+	} finally {
+		existingOverlay.hide();
+		harness.parent.stop();
+	}
+});
 
 test("default fullscreen enables application-owned mouse selection and restores terminal modes", async () => {
 	const writes: string[] = [];


### PR DESCRIPTION
## Summary

- restore main-editor input as soon as Ctrl+C closes the dedicated side-thread UI
- keep the parent overlay owned by Pi until its normal close, preserving any existing overlays
- cancel the active side flow when a focused transcript-search overlay does not settle Ctrl+C
- add regression coverage for immediate input, overlay ownership, and search-focus cancellation

## Verification

Passed:

- `npm --workspace @narumitw/pi-btw run build`
- `npx vitest run packages/pi-btw/test/fullscreen-ui.test.ts` (20 tests)
- `npx biome check packages/pi-btw/src/fullscreen-ui.ts packages/pi-btw/test/fullscreen-ui.test.ts`
- `npx tsc -p packages/pi-btw/tsconfig.json --noEmit`
- `git diff --check origin/main...HEAD`

Local full-suite limitations on Windows:

- `npm run check` completed workspace typechecks and boundary checks, but root Biome rejected CRLF line endings across unchanged files.
- `npm test` stopped during the workspace build with `spawnSync ... tsc.cmd EINVAL`.
- The pi-btw package suite passed 180/182 tests; one test hit a Windows symlink `EPERM`, and the generated-entry test exceeded 5 seconds only in the parallel suite but passed alone.

Fixes #994
