### PR TITLE
fix(subagents): harden benchmark and child results

### DIFF
--- a/docs/benchmarks/pi-subagents-four-arm-protocol-v3.md
+++ b/docs/benchmarks/pi-subagents-four-arm-protocol-v3.md
@@ -109,7 +109,7 @@ just benchmark-subagent-capabilities \
   --output /tmp/pi-subagents-four-arm-v3.json
 ```
 
-Resume rejects a changed protocol version, model, thinking level, repetition count, deadline, readiness deadline, or trial order.
+Resume rejects a changed protocol version, model, thinking level, repetition count, deadline, readiness deadline, trial order, or selected extension entrypoint identity.
 
 Run five repetitions only after reviewing provider budget and the diagnostic result:
 

--- a/packages/pi-subagents-v2/package.json
+++ b/packages/pi-subagents-v2/package.json
@@ -16,6 +16,7 @@
 	"files": [
 		"src",
 		"skills",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/pi-subagents-v2/src/process.ts
+++ b/packages/pi-subagents-v2/src/process.ts
@@ -109,6 +109,7 @@ async function executeProcess(
 	const timeoutMs = resolveTimeoutMs(request.timeout);
 	let latestOutput = "";
 	let terminalOutput: string | undefined;
+	let terminalStopReason: "stop" | "length" | undefined;
 	let errorMessage = "";
 	let assistantFailed = false;
 	let stderr = "";
@@ -129,6 +130,7 @@ async function executeProcess(
 				truncated ||= bounded.truncated;
 				if (event.message.stopReason === "stop" || event.message.stopReason === "length") {
 					terminalOutput = bounded.text;
+					terminalStopReason = event.message.stopReason;
 				}
 			}
 			if (event.message.stopReason === "error" || event.message.stopReason === "aborted") {
@@ -235,6 +237,9 @@ async function executeProcess(
 			? [`Ignored ${malformedEvents} malformed or oversized child event(s).`]
 			: [];
 	if (truncated) limitations.push("Child output was truncated to runtime limits.");
+	if (terminalStopReason === "length") {
+		limitations.push("Child output ended at the model output limit and may be incomplete.");
+	}
 	if (settlement.cancelled) return cancelledResult(output, limitations, truncated);
 	if (settlement.timedOut) {
 		return {
@@ -246,19 +251,23 @@ async function executeProcess(
 		};
 	}
 	const error = settlement.launchError || errorMessage || stderr.trim();
-	if (settlement.code === 0 && !assistantFailed && !errorMessage) {
+	if (settlement.code === 0 && terminalStopReason === "stop" && !assistantFailed && !errorMessage) {
 		return {
 			state: "completed",
-			result: output || "(no output)",
+			result: terminalOutput,
 			limitations,
 			truncated,
 		};
 	}
 	const failure =
 		error ||
-		(assistantFailed
-			? "Subagent model turn failed."
-			: `Subagent exited with code ${settlement.code}.`);
+		(terminalStopReason === "length"
+			? "Subagent output reached the model limit."
+			: assistantFailed
+				? "Subagent model turn failed."
+				: settlement.code === 0
+					? "Subagent exited without a terminal assistant result."
+					: `Subagent exited with code ${settlement.code}.`);
 	if (output) {
 		return {
 			state: "partial",

--- a/packages/pi-subagents-v2/test/package.test.ts
+++ b/packages/pi-subagents-v2/test/package.test.ts
@@ -19,6 +19,7 @@ test("package declares one source extension and one bundled operating skill", ()
 	assert.equal(manifest.piExtension.lifecycle, "experimental");
 	assert.ok(manifest.files.includes("src"));
 	assert.ok(manifest.files.includes("skills"));
+	assert.ok(manifest.files.includes("docs"));
 });
 
 test("bundled skill documents every minimal-runtime operating responsibility", () => {

--- a/packages/pi-subagents-v2/test/process.test.ts
+++ b/packages/pi-subagents-v2/test/process.test.ts
@@ -80,6 +80,34 @@ console.log(message("completed evidence"));
 	assert.match(partial.error ?? "", /child failed/);
 });
 
+test("runChild requires a normal terminal result and preserves incomplete evidence", async () => {
+	installFakePi(`
+const task = process.argv.at(-1) || "";
+const message = (text, stopReason) => JSON.stringify({
+  type: "message_end",
+  message: { role: "assistant", content: [{ type: "text", text }], stopReason }
+});
+if (task.includes("length")) console.log(message("cut-off evidence", "length"));
+else if (task.includes("nonterminal")) console.log(message("intermediate evidence", "toolUse"));
+else console.log("{malformed");
+`);
+	const lengthLimited = await runChild(childRequest({ task: "length" }));
+	assert.equal(lengthLimited.state, "partial");
+	assert.equal(lengthLimited.result, "cut-off evidence");
+	assert.match(lengthLimited.error ?? "", /model limit/i);
+	assert.match(lengthLimited.limitations.join("\n"), /model output limit/i);
+
+	const nonterminal = await runChild(childRequest({ task: "nonterminal" }));
+	assert.equal(nonterminal.state, "partial");
+	assert.equal(nonterminal.result, "intermediate evidence");
+	assert.match(nonterminal.error ?? "", /without a terminal assistant result/i);
+
+	const missing = await runChild(childRequest({ task: "missing" }));
+	assert.equal(missing.state, "failed");
+	assert.match(missing.error ?? "", /without a terminal assistant result/i);
+	assert.match(missing.limitations.join("\n"), /malformed/i);
+});
+
 test("runChild bounds child result text below the complete tool-output budget", async () => {
 	installFakePi(`
 const text = "x".repeat(40 * 1024);

--- a/packages/pi-subagents-v3/package.json
+++ b/packages/pi-subagents-v3/package.json
@@ -16,6 +16,7 @@
 	"files": [
 		"src",
 		"skills",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/pi-subagents-v3/src/process.ts
+++ b/packages/pi-subagents-v3/src/process.ts
@@ -109,6 +109,7 @@ async function executeProcess(
 	const timeoutMs = resolveTimeoutMs(request.timeout);
 	let latestOutput = "";
 	let terminalOutput: string | undefined;
+	let terminalStopReason: "stop" | "length" | undefined;
 	let errorMessage = "";
 	let assistantFailed = false;
 	let stderr = "";
@@ -129,6 +130,7 @@ async function executeProcess(
 				truncated ||= bounded.truncated;
 				if (event.message.stopReason === "stop" || event.message.stopReason === "length") {
 					terminalOutput = bounded.text;
+					terminalStopReason = event.message.stopReason;
 				}
 			}
 			if (event.message.stopReason === "error" || event.message.stopReason === "aborted") {
@@ -235,6 +237,9 @@ async function executeProcess(
 			? [`Ignored ${malformedEvents} malformed or oversized child event(s).`]
 			: [];
 	if (truncated) limitations.push("Child output was truncated to runtime limits.");
+	if (terminalStopReason === "length") {
+		limitations.push("Child output ended at the model output limit and may be incomplete.");
+	}
 	if (settlement.cancelled) return cancelledResult(output, limitations, truncated);
 	if (settlement.timedOut) {
 		return {
@@ -246,19 +251,23 @@ async function executeProcess(
 		};
 	}
 	const error = settlement.launchError || errorMessage || stderr.trim();
-	if (settlement.code === 0 && !assistantFailed && !errorMessage) {
+	if (settlement.code === 0 && terminalStopReason === "stop" && !assistantFailed && !errorMessage) {
 		return {
 			state: "completed",
-			result: output || "(no output)",
+			result: terminalOutput,
 			limitations,
 			truncated,
 		};
 	}
 	const failure =
 		error ||
-		(assistantFailed
-			? "Subagent model turn failed."
-			: `Subagent exited with code ${settlement.code}.`);
+		(terminalStopReason === "length"
+			? "Subagent output reached the model limit."
+			: assistantFailed
+				? "Subagent model turn failed."
+				: settlement.code === 0
+					? "Subagent exited without a terminal assistant result."
+					: `Subagent exited with code ${settlement.code}.`);
 	if (output) {
 		return {
 			state: "partial",

--- a/packages/pi-subagents-v3/test/package.test.ts
+++ b/packages/pi-subagents-v3/test/package.test.ts
@@ -23,6 +23,7 @@ test("package declares one source extension and one bundled operating skill", ()
 	assert.equal(manifest.piExtension.lifecycle, "experimental");
 	assert.ok(manifest.files.includes("src"));
 	assert.ok(manifest.files.includes("skills"));
+	assert.ok(manifest.files.includes("docs"));
 });
 
 test("bundled skill documents every minimal-runtime operating responsibility", () => {

--- a/packages/pi-subagents-v3/test/process.test.ts
+++ b/packages/pi-subagents-v3/test/process.test.ts
@@ -80,6 +80,34 @@ console.log(message("completed evidence"));
 	assert.match(partial.error ?? "", /child failed/);
 });
 
+test("runChild requires a normal terminal result and preserves incomplete evidence", async () => {
+	installFakePi(`
+const task = process.argv.at(-1) || "";
+const message = (text, stopReason) => JSON.stringify({
+  type: "message_end",
+  message: { role: "assistant", content: [{ type: "text", text }], stopReason }
+});
+if (task.includes("length")) console.log(message("cut-off evidence", "length"));
+else if (task.includes("nonterminal")) console.log(message("intermediate evidence", "toolUse"));
+else console.log("{malformed");
+`);
+	const lengthLimited = await runChild(childRequest({ task: "length" }));
+	assert.equal(lengthLimited.state, "partial");
+	assert.equal(lengthLimited.result, "cut-off evidence");
+	assert.match(lengthLimited.error ?? "", /model limit/i);
+	assert.match(lengthLimited.limitations.join("\n"), /model output limit/i);
+
+	const nonterminal = await runChild(childRequest({ task: "nonterminal" }));
+	assert.equal(nonterminal.state, "partial");
+	assert.equal(nonterminal.result, "intermediate evidence");
+	assert.match(nonterminal.error ?? "", /without a terminal assistant result/i);
+
+	const missing = await runChild(childRequest({ task: "missing" }));
+	assert.equal(missing.state, "failed");
+	assert.match(missing.error ?? "", /without a terminal assistant result/i);
+	assert.match(missing.limitations.join("\n"), /malformed/i);
+});
+
 test("runChild bounds child result text below the complete tool-output budget", async () => {
 	installFakePi(`
 const text = "x".repeat(40 * 1024);

--- a/scripts/benchmark-subagent-capabilities.ts
+++ b/scripts/benchmark-subagent-capabilities.ts
@@ -115,6 +115,14 @@ const configuration = {
 	})),
 	capabilityMatrix: capabilityMatrix(options.jobVersion),
 	order: plan,
+	resumeFingerprint: {
+		extensions: Object.fromEntries(
+			Object.entries(extensions).map(([arm, value]) => [
+				arm,
+				value ? createHash("sha256").update(path.resolve(value)).digest("hex") : null,
+			]),
+		),
+	},
 	environment: {
 		node: process.version,
 		platform: process.platform,
@@ -211,6 +219,8 @@ function loadResumeRecords(
 		timeoutMs: number;
 		readinessTimeoutMs: number;
 		order: CapabilityTrialPlan[];
+		resumeFingerprint: { extensions: Record<string, string | null> };
+		environment: { extensions: Record<string, string | null> };
 	},
 	plan: readonly CapabilityTrialPlan[],
 ): CapabilityTrialRecord[] {
@@ -236,6 +246,19 @@ function loadResumeRecords(
 		if (parsed[key] !== expected[key]) {
 			throw new Error(`Cannot resume benchmark output with different ${key}`);
 		}
+	}
+	const parsedEnvironment = isRecord(parsed.environment) ? parsed.environment : undefined;
+	const parsedExtensions = parsedEnvironment?.extensions;
+	const parsedFingerprint = isRecord(parsed.resumeFingerprint)
+		? parsed.resumeFingerprint.extensions
+		: undefined;
+	if (
+		!isRecord(parsedExtensions) ||
+		JSON.stringify(parsedExtensions) !== JSON.stringify(expected.environment.extensions) ||
+		!isRecord(parsedFingerprint) ||
+		JSON.stringify(parsedFingerprint) !== JSON.stringify(expected.resumeFingerprint.extensions)
+	) {
+		throw new Error("Cannot resume benchmark output with different extension identities");
 	}
 	if (JSON.stringify(parsed.order) !== JSON.stringify(expected.order)) {
 		throw new Error("Cannot resume benchmark output with a different trial order");

--- a/test/subagent-capability-benchmark.test.ts
+++ b/test/subagent-capability-benchmark.test.ts
@@ -39,10 +39,11 @@ function assistant(text: string): Record<string, unknown> {
 function toolResult(
 	toolName: string,
 	details: Record<string, unknown> = {},
+	isError = false,
 ): Record<string, unknown> {
 	return {
 		type: "message_end",
-		message: { role: "toolResult", toolName, isError: false, details, content: [] },
+		message: { role: "toolResult", toolName, isError, details, content: [] },
 	};
 }
 
@@ -219,6 +220,26 @@ test("event analysis enforces each arm topology and completion order", () => {
 	]);
 	assert.equal(wrongTopology.toolCompliance, false);
 	assert.equal(wrongTopology.toolCounts.unexpected, 1);
+});
+
+test("failed topology attempts make v2 and v3 trials noncompliant", () => {
+	const task = CAPABILITY_TASKS[0];
+	const final = completedSingleResearch();
+	for (const version of ["v2", "v3"] as const) {
+		const start = `subagent-${version}-start`;
+		const wait = `subagent-${version}-wait`;
+		const analysis = analyzeCapabilityEvents(`${version}-job`, task, [
+			toolResult(start, {}, true),
+			toolResult(start),
+			toolResult(wait, {}, true),
+			toolResult(wait, { state: "completed", timedOut: false }),
+			assistant(final),
+		]);
+		assert.deepEqual(analysis.toolCounts, { sync: 0, start: 1, wait: 1, unexpected: 2 });
+		assert.equal(analysis.completionObserved, true);
+		assert.equal(analysis.toolCompliance, false);
+		assert.equal(trialSucceeded(analysis, "completed", null), false);
+	}
 });
 
 test("wait timeouts and incomplete parallel joins fail topology compliance", () => {
@@ -516,4 +537,53 @@ test("manual runner selects the separately versioned v3 protocol explicitly", as
 	);
 	assert.equal(preview.environment.extensions["v3-job"], "custom-v3.ts");
 	assert.deepEqual(preview.capabilityMatrix, capabilityMatrix("v3"));
+});
+
+test("resume rejects changed v1, v2, and v3 extension identities", async () => {
+	const directory = mkdtempSync(path.join(os.tmpdir(), "subagent-capability-resume-identity-"));
+	const root = path.resolve(import.meta.dirname, "..");
+	const script = "scripts/benchmark-subagent-capabilities.ts";
+	try {
+		for (const testCase of [
+			{ protocol: [] as string[], option: "--v1-extension", name: "v1" },
+			{ protocol: [] as string[], option: "--v2-extension", name: "v2" },
+			{ protocol: ["--job-version", "v3"], option: "--v3-extension", name: "v3" },
+		]) {
+			const output = path.join(directory, `${testCase.name}.json`);
+			const initial = path.join(directory, testCase.name, "initial", "extension.ts");
+			const changed = path.join(directory, testCase.name, "changed", "extension.ts");
+			const { stdout } = await execFileAsync(
+				process.execPath,
+				[script, "--model", "provider/model", ...testCase.protocol, testCase.option, initial],
+				{ cwd: root, timeout: 3_000 },
+			);
+			writeFileSync(
+				output,
+				JSON.stringify({ ...JSON.parse(stdout), preview: false, rawRecords: [] }),
+			);
+			await assert.rejects(
+				() =>
+					execFileAsync(
+						process.execPath,
+						[
+							script,
+							"--run",
+							"--resume",
+							"--model",
+							"provider/model",
+							"--output",
+							output,
+							...testCase.protocol,
+							testCase.option,
+							changed,
+						],
+						{ cwd: root, timeout: 3_000 },
+					),
+				(error: Error & { stderr?: string }) =>
+					/different extension identities/i.test(error.stderr ?? ""),
+			);
+		}
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
 });

--- a/test/support/subagent-capability-benchmark.ts
+++ b/test/support/subagent-capability-benchmark.ts
@@ -501,8 +501,12 @@ export function analyzeCapabilityEvents(
 	for (const [index, value] of events.entries()) {
 		if (!isRecord(value) || value.type !== "message_end" || !isRecord(value.message)) continue;
 		const message = value.message;
-		if (message.role === "toolResult" && message.isError !== true) {
+		if (message.role === "toolResult") {
 			const toolName = typeof message.toolName === "string" ? message.toolName : "";
+			if (message.isError === true) {
+				if (toolName.startsWith("subagent")) unexpected++;
+				continue;
+			}
 			if (toolName === "subagent") {
 				sync++;
 				if (arm === "v1-sync") completionIndex = index;


### PR DESCRIPTION
## Summary

- Reject resumed capability benchmarks when resolved v1, v2, or v3 extension identities change.
- Count failed subagent topology attempts against benchmark compliance.
- Require normal terminal assistant results and classify model-length output as partial in both versioned runtimes.
- Include `docs/tools.md` in both versioned package tarballs.

## Verification

- `npm run check`
- `npm test` — 386 files and 3,388 tests passed
- `npx vitest run packages/pi-subagents-v2/test packages/pi-subagents-v3/test test/subagent-capability-benchmark.test.ts` — 7 files and 43 tests passed
- Both package typechecks
- Both npm dry-run pack inspections, including `docs/tools.md`
- Pi RPC package-load smokes for both versioned packages
- Fenced-code-aware package README heading audit

## Context

Follow-up to #993, which merged at `edfde83f` before this review-fix commit reached the remote branch.

No changeset is required because both versioned experimental packages are private.
