### PR TITLE
fix(btw): settle side flow on hard cancel

### DIFF
--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -203,7 +203,18 @@ class BtwFullscreenHost<T> implements Component {
 			this.fullscreen.start();
 			// Waiting for the custom promise would leave follow-up keys bound to the side TUI.
 			this.removeHardCancelListener = this.fullscreen.addInputListener((data) => {
-				if (!isKeyRelease(data) && matchesKey(data, Key.ctrl("c"))) this.restoreParent();
+				if (!isKeyRelease(data) && matchesKey(data, Key.ctrl("c"))) {
+					const cancelActiveCustom = this.cancelActiveCustom;
+					// Let the focused component finish normally before applying the hard-cancel fallback.
+					queueMicrotask(() => {
+						try {
+							cancelActiveCustom?.();
+						} catch (error) {
+							this.cleanupError ??= error;
+						}
+					});
+					this.restoreParent();
+				}
 				return undefined;
 			});
 			outcome = { kind: "completed", value: await this.run(this.createContext()) };

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -377,6 +377,50 @@ test("Ctrl+C hands input back without closing another parent overlay", async () 
 	}
 });
 
+test("Ctrl+C cancels the side flow when transcript search owns focus", async () => {
+	const harness = createInputHandoffHarness();
+	const ctrlShiftF = "\u001b[102;6u";
+	let sideTui: TUI | undefined;
+	let closeSide: (() => void) | undefined;
+	let settled = false;
+	const running = runBtwFullscreen(harness.ctx, (ctx) =>
+		ctx.ui.custom<"closed">((tui, _theme, _keybindings, done) => {
+			sideTui = tui;
+			closeSide = () => done("closed");
+			return {
+				focused: false,
+				render: () => ["side thread"],
+				invalidate() {},
+			};
+		}),
+	);
+	const observed = running.then(
+		() => {
+			settled = true;
+		},
+		() => {
+			settled = true;
+		},
+	);
+	try {
+		await flushAsyncWork();
+		assert.ok(sideTui);
+
+		harness.terminal.send(ctrlShiftF);
+		assert.equal(sideTui.hasOverlay(), true);
+		harness.terminal.send("\u0003");
+		harness.terminal.send("x");
+		await flushAsyncWork();
+
+		assert.equal(settled, true);
+		assert.equal(harness.mainInput.text, "x");
+	} finally {
+		closeSide?.();
+		await observed;
+		harness.parent.stop();
+	}
+});
+
 test("default fullscreen enables application-owned mouse selection and restores terminal modes", async () => {
 	const writes: string[] = [];
 	let outerDone: ((value: unknown) => void) | undefined;


### PR DESCRIPTION
## Summary

- capture the active side custom when Ctrl+C starts the synchronous parent handoff
- let the focused component settle normally, then cancel the captured custom as a microtask fallback
- cover transcript search → Ctrl+C → immediate `x`, asserting that the side flow settles and `x` reaches the main editor

Follow-up to #996, addressing its hard-cancel review feedback after that PR was merged.

## Verification

Passed:

- `npm --workspace @narumitw/pi-btw run build`
- `npx vitest run packages/pi-btw/test/fullscreen-ui.test.ts` (20 tests)
- `npx biome check packages/pi-btw/src/fullscreen-ui.ts packages/pi-btw/test/fullscreen-ui.test.ts`
- `npx tsc -p packages/pi-btw/tsconfig.json --noEmit`
- `git diff --check origin/main...HEAD`

Local package-suite result on Windows:

- 180/182 tests passed in parallel.
- The symlink test hit Windows `EPERM`.
- The generated-entry test exceeded 5 seconds in the parallel suite and passed when run alone.

## Changeset

Covered by `.changeset/quick-btw-input-handoff.md`, which was merged in #996 and remains pending on `main`.
