### PR TITLE
fix(btw): hard-cancel side flow before handoff

### DIFF
--- a/.changeset/steady-btw-hard-cancel.md
+++ b/.changeset/steady-btw-hard-cancel.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": patch
+---
+
+Close the active side flow when Ctrl+C restores the main editor while transcript search has focus.

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -13,6 +13,8 @@ import {
 	type OverlayHandle,
 	type TUI,
 	TuiAltScreen,
+	type TuiInputListener,
+	type TuiInputListenerResult,
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
 import { sanitizeSingleLine } from "./text.js";
@@ -28,6 +30,7 @@ type BtwCustomFactory<T> = (
 type BtwFullscreenTui = TUI & {
 	flash?: (message: string, durationMs?: number) => void;
 	setLayoutRoot(component: Component | undefined): void;
+	addInputListenerBeforeViewport?(listener: TuiInputListener): () => void;
 };
 
 export interface BtwFullscreenLayoutComponent extends Component {
@@ -110,6 +113,59 @@ export async function runBtwFullscreen<T>(
 	return outcome.value;
 }
 
+type BtwInputListeners = {
+	beforeViewport: Set<TuiInputListener>;
+	regular: Set<TuiInputListener>;
+};
+
+const btwInputListeners = new WeakMap<BtwTuiAltScreen, BtwInputListeners>();
+
+function dispatchBtwInput(listeners: BtwInputListeners, data: string): TuiInputListenerResult {
+	let current = data;
+	for (const group of [listeners.beforeViewport, listeners.regular]) {
+		for (const listener of group) {
+			const result = listener(current);
+			if (result?.consume) return result;
+			if (result?.data !== undefined) current = result.data;
+		}
+	}
+	return current === data ? undefined : { data: current };
+}
+
+class BtwTuiAltScreen extends TuiAltScreen {
+	override addInputListener(listener: TuiInputListener): () => void {
+		let listeners = btwInputListeners.get(this);
+		if (!listeners) {
+			const registeredListeners: BtwInputListeners = {
+				beforeViewport: new Set(),
+				regular: new Set(),
+			};
+			btwInputListeners.set(this, registeredListeners);
+			super.addInputListener((data) => dispatchBtwInput(registeredListeners, data));
+			listeners = registeredListeners;
+		}
+		listeners.regular.add(listener);
+		return () => listeners.regular.delete(listener);
+	}
+
+	addInputListenerBeforeViewport(listener: TuiInputListener): () => void {
+		const listeners = btwInputListeners.get(this);
+		if (!listeners) return super.addInputListener(listener);
+		listeners.beforeViewport.add(listener);
+		return () => listeners.beforeViewport.delete(listener);
+	}
+
+	override removeInputListener(listener: TuiInputListener): void {
+		const listeners = btwInputListeners.get(this);
+		if (!listeners) {
+			super.removeInputListener(listener);
+			return;
+		}
+		listeners.beforeViewport.delete(listener);
+		listeners.regular.delete(listener);
+	}
+}
+
 function createBtwFullscreenTui(
 	parent: TUI,
 	theme: Theme,
@@ -118,7 +174,7 @@ function createBtwFullscreenTui(
 ): BtwFullscreenTui {
 	const styleSearchMatch = (text: string) =>
 		theme.bg("searchMatchBg", theme.fg("searchMatchText", text));
-	return new TuiAltScreen(parent.terminal, parent.getShowHardwareCursor(), undefined, {
+	return new BtwTuiAltScreen(parent.terminal, parent.getShowHardwareCursor(), undefined, {
 		mouse: true,
 		searchMatchStyle: (text) => theme.underline(styleSearchMatch(text)),
 		searchCurrentMatchStyle: (text) => theme.bold(theme.inverse(styleSearchMatch(text))),
@@ -203,7 +259,10 @@ class BtwFullscreenHost<T> implements Component {
 			this.fullscreenCreated = true;
 			this.fullscreen.start();
 			// Waiting for the custom promise would leave follow-up keys bound to the side TUI.
-			this.removeHardCancelListener = this.fullscreen.addInputListener((data) => {
+			const addHardCancelListener =
+				this.fullscreen.addInputListenerBeforeViewport?.bind(this.fullscreen) ??
+				this.fullscreen.addInputListener.bind(this.fullscreen);
+			this.removeHardCancelListener = addHardCancelListener((data) => {
 				if (isKeyRelease(data) || !matchesKey(data, Key.ctrl("c"))) return undefined;
 				try {
 					this.hardCancelActiveCustom?.();

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -151,6 +151,7 @@ class BtwFullscreenHost<T> implements Component {
 	private fullscreen: BtwFullscreenTui | undefined;
 	private parentOverlay: OverlayHandle | undefined;
 	private cancelActiveCustom: (() => void) | undefined;
+	private hardCancelActiveCustom: (() => void) | undefined;
 	private removeHardCancelListener: (() => void) | undefined;
 	private started = false;
 	private disposed = false;
@@ -203,19 +204,13 @@ class BtwFullscreenHost<T> implements Component {
 			this.fullscreen.start();
 			// Waiting for the custom promise would leave follow-up keys bound to the side TUI.
 			this.removeHardCancelListener = this.fullscreen.addInputListener((data) => {
-				if (!isKeyRelease(data) && matchesKey(data, Key.ctrl("c"))) {
-					const cancelActiveCustom = this.cancelActiveCustom;
-					// Let the focused component finish normally before applying the hard-cancel fallback.
-					queueMicrotask(() => {
-						try {
-							cancelActiveCustom?.();
-						} catch (error) {
-							this.cleanupError ??= error;
-						}
-					});
+				if (isKeyRelease(data) || !matchesKey(data, Key.ctrl("c"))) return undefined;
+				try {
+					this.hardCancelActiveCustom?.();
+				} finally {
 					this.restoreParent();
 				}
-				return undefined;
+				return { consume: true };
 			});
 			outcome = { kind: "completed", value: await this.run(this.createContext()) };
 		} catch (error) {
@@ -344,6 +339,7 @@ class BtwFullscreenHost<T> implements Component {
 				if (promiseSettled || !hasPendingValue) return;
 				promiseSettled = true;
 				this.cancelActiveCustom = undefined;
+				this.hardCancelActiveCustom = undefined;
 				if (!factorySettled) {
 					resolve(pendingValue as Value);
 					return;
@@ -367,6 +363,7 @@ class BtwFullscreenHost<T> implements Component {
 				closed = true;
 				promiseSettled = true;
 				this.cancelActiveCustom = undefined;
+				this.hardCancelActiveCustom = undefined;
 				try {
 					unmount();
 					reject(error);
@@ -378,6 +375,16 @@ class BtwFullscreenHost<T> implements Component {
 				if (promiseSettled) return;
 				disposeComponent();
 				if (!promiseSettled) fail(new FullscreenUiDisposedError());
+			};
+			this.hardCancelActiveCustom = () => {
+				if (promiseSettled) return;
+				try {
+					component?.handleInput?.("\u0003");
+				} catch (error) {
+					fail(error);
+					return;
+				}
+				this.cancelActiveCustom?.();
 			};
 
 			let created: ReturnType<BtwCustomFactory<Value>>;

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -3,8 +3,12 @@ import {
 	type Component,
 	Container,
 	type Focusable,
+	getKeybindings,
+	KeybindingsManager,
+	setKeybindings,
 	type Terminal,
 	type TUI,
+	TUI_KEYBINDINGS,
 	TuiMainScreen,
 } from "@earendil-works/pi-tui";
 import { test } from "vitest";
@@ -421,7 +425,14 @@ test("Ctrl+C cancels the side flow when transcript search owns focus", async () 
 	}
 });
 
-test("Ctrl+C hard-cancels the side root while transcript search owns fullscreen focus", async () => {
+test("Ctrl+C hard-cancels the side root before a remapped search close", async (t) => {
+	const previousKeybindings = getKeybindings();
+	t.onTestFinished(() => setKeybindings(previousKeybindings));
+	setKeybindings(
+		new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.altScreen.searchClose": "ctrl+c",
+		}),
+	);
 	const harness = createInputHandoffHarness();
 	let sideTui: TUI | undefined;
 	let closeSide: (() => void) | undefined;

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -421,6 +421,50 @@ test("Ctrl+C cancels the side flow when transcript search owns focus", async () 
 	}
 });
 
+test("Ctrl+C hard-cancels the side root while transcript search owns fullscreen focus", async () => {
+	const harness = createInputHandoffHarness();
+	let sideTui: TUI | undefined;
+	let closeSide: (() => void) | undefined;
+	let sideCancelCount = 0;
+	const running = runBtwFullscreen(harness.ctx, (ctx) =>
+		ctx.ui.custom<"closed">((tui, _theme, _keybindings, done) => {
+			sideTui = tui;
+			closeSide = () => done("closed");
+			return {
+				focused: false,
+				render: () => ["side thread"],
+				handleInput(data: string) {
+					if (data !== "\u0003") return;
+					sideCancelCount += 1;
+					done("closed");
+				},
+				invalidate() {},
+			};
+		}),
+	);
+	try {
+		await flushAsyncWork();
+		assert.ok(sideTui);
+		const searchableTui = sideTui as TUI & {
+			openSearch(): void;
+			isOverlayFocused(): boolean;
+		};
+		searchableTui.openSearch();
+		assert.equal(searchableTui.isOverlayFocused(), true);
+
+		harness.terminal.send("\u0003");
+		harness.terminal.send("x");
+
+		assert.equal(sideCancelCount, 1);
+		assert.equal(await running, "closed");
+		assert.equal(harness.mainInput.text, "x");
+	} finally {
+		closeSide?.();
+		await running.catch(() => undefined);
+		harness.parent.stop();
+	}
+});
+
 test("default fullscreen enables application-owned mouse selection and restores terminal modes", async () => {
 	const writes: string[] = [];
 	let outerDone: ((value: unknown) => void) | undefined;


### PR DESCRIPTION
## Summary

- Route fullscreen `Ctrl+C` directly to the active side-flow root before restoring terminal ownership.
- Consume the original key so a focused transcript-search overlay cannot swallow cancellation.
- Preserve the disposal fallback for components that do not settle cancellation and add a patch Changeset.

## Verification

- `npx vitest run packages/pi-btw/test/fullscreen-ui.test.ts packages/pi-btw/test/fullscreen-search.test.ts` (23 tests)
- `npx vitest run packages/pi-btw/test` (183 tests)
- `npm run check`
- `npm test` (3,401 tests)
- `git diff --check`

## Context

Follow-up to #996 and #1002.
This replaces the deferred cancellation fallback with synchronous root-flow cancellation and consumes the triggering input as required by the shared-terminal handoff contract.
