### PR TITLE
fix: preserve restored context across reloads

### DIFF
--- a/.changeset/restored-context-reloads.md
+++ b/.changeset/restored-context-reloads.md
@@ -1,0 +1,6 @@
+---
+"@narumitw/pi-subagents": patch
+"@narumitw/pi-todo": patch
+---
+
+Persist restored todo, subagent guidance, and required-completion context boundaries as validated branch-local session metadata so reloads and tree navigation preserve stable model-visible prefixes.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -652,6 +652,7 @@ The successful tool handoff and delivered completion messages are the ordinary m
 When a resumed session terminalizes an in-flight required run and the retained transcript still contains its pending handoff, one hidden append-only transition supersedes that stale evidence before the next model turn.
 This also covers compacted contexts that retain the handoff.
 If leading compaction or branch summaries remove the handoff, one canonical hidden fallback is restored at a fixed boundary immediately after the summaries.
+Branch-local boundary metadata preserves that exact fallback across reload and branch navigation.
 That restored fallback remains fixed for the summary epoch while later cancellation transitions or completion messages supersede it at the conversation tail.
 The runtime rejects a sixty-fifth unresolved required run before acceptance so every unresolved exact identity fits in the bounded parent context.
 The terminal completion and recipient are persisted before delivery, simultaneous root completions are batched, and the root broker allows at most one in-flight wake until that parent turn starts.
@@ -783,6 +784,7 @@ The UI explicitly states that target/trust settings are not filesystem sandboxin
 When stateful tools are enabled, their membership and provider-visible definitions stay fixed across spawn, completion, interrupt, close, mailbox, catalog, and live-policy transitions.
 Ordinary turns preserve the normalized provider-visible prefix, while a new guidance message or required-completion transition starts an explicit append-only prefix epoch.
 Compaction restoration inserts deterministic guidance and requirement fallbacks after leading summaries and retains each restored message for that summary epoch while later tail messages supersede it.
+Branch-local session metadata reconstructs those exact historical boundaries after reload and isolates them during tree navigation, including when refreshed settings require a later guidance transition.
 These rules preserve cache-eligible prefixes but do not guarantee a provider-reported cache hit.
 
 | Tool | Purpose |

--- a/packages/pi-subagents/docs/async-runtime-protocol.md
+++ b/packages/pi-subagents/docs/async-runtime-protocol.md
@@ -18,6 +18,7 @@ The successful lifecycle tool result and delivered completion message are the or
 When a resume changes a pending run to cancelled and interrupted while its stale handoff remains in model context, `before_agent_start` appends one hidden versioned transition after that handoff.
 This append-only transition also applies when leading summaries retain the stale handoff, prevents duplicate publication on later turns, and participates in fork-sensitive branch reconstruction.
 If leading compaction or branch summaries remove the handoff, the `context` hook restores one canonical hidden `pi-subagent-required-completions` fallback immediately after the summaries.
+A branch-local custom session entry records the exact restored boundary so reload and tree navigation reconstruct the correct historical fallback.
 The fallback remains at that fixed boundary for the leading-summary epoch, while a later completion or cancellation transition supersedes it at the conversation tail.
 `CompletionDeliveryBroker` owns exact completion visibility acknowledgement and asks the registry to mark the corresponding requirement visible.
 No timer, waiter, or UI object owns requirement truth.

--- a/packages/pi-subagents/src/session-guidance-contract.ts
+++ b/packages/pi-subagents/src/session-guidance-contract.ts
@@ -3,6 +3,7 @@ import {
 	type ContextEvent,
 	type ExtensionAPI,
 	type ExtensionContext,
+	type SessionEntry,
 } from "@earendil-works/pi-coding-agent";
 import type {
 	CompletionDelivery,
@@ -21,6 +22,10 @@ import type { StatefulLimits } from "./stateful-limits.js";
 
 export const SUBAGENT_GUIDANCE_CONTEXT_TYPE = "pi-subagents-session-guidance";
 export const SUBAGENT_GUIDANCE_VERSION = "pi-subagents:session-guidance:v1" as const;
+export const SUBAGENT_RESTORED_BOUNDARY_ENTRY_TYPE = "pi-subagents-restored-context-boundary";
+const SUBAGENT_RESTORED_BOUNDARY_VERSION = 1;
+type RestoredBoundary = { summaryEpoch: string; content: string };
+type RestoredBoundaryKind = "guidance" | "requirement";
 
 export interface SubagentSessionGuidanceSnapshot {
 	blockingEnabled: boolean;
@@ -45,22 +50,41 @@ export function registerSubagentSessionGuidance(
 ): SubagentSessionGuidanceController {
 	let activeSession: ExtensionContext["sessionManager"] | undefined;
 	let lastPublishedContent: string | undefined;
-	let restoredGuidanceBoundary: { summaryEpoch: string; content: string } | undefined;
-	let restoredRequirementBoundary: { summaryEpoch: string; content: string } | undefined;
+	let restoredGuidanceBoundary: RestoredBoundary | undefined;
+	let restoredRequirementBoundary: RestoredBoundary | undefined;
+	let guidanceBoundaryPersisted = false;
+	let requirementBoundaryPersisted = false;
 
-	pi.on("session_start", (_event, ctx) => {
-		activeSession = ctx.sessionManager;
-		lastPublishedContent = undefined;
-		restoredRequirementBoundary = undefined;
-		const messages = buildSessionContext(ctx.sessionManager.getBranch()).messages;
+	const restoreBranchBoundaries = (ctx: ExtensionContext): void => {
+		const branch = ctx.sessionManager.getBranch();
+		const messages = buildSessionContext(branch).messages;
 		const summaryEpoch = leadingSummaryEpoch(messages);
+		const restored = reconstructRestoredSubagentBoundaries(branch, summaryEpoch);
 		restoredGuidanceBoundary =
-			summaryEpoch && !hasSubagentSessionGuidanceHistory(messages)
+			restored.guidance ??
+			(summaryEpoch && !hasSubagentSessionGuidanceHistory(messages)
 				? {
 						summaryEpoch,
 						content: createSubagentSessionGuidance(getSnapshot()).content,
 					}
-				: undefined;
+				: undefined);
+		restoredRequirementBoundary = restored.requirement;
+		guidanceBoundaryPersisted = restored.guidance !== undefined;
+		requirementBoundaryPersisted = restored.requirement !== undefined;
+	};
+
+	const persistBoundary = (kind: RestoredBoundaryKind, boundary: RestoredBoundary): void => {
+		pi.appendEntry(SUBAGENT_RESTORED_BOUNDARY_ENTRY_TYPE, {
+			version: SUBAGENT_RESTORED_BOUNDARY_VERSION,
+			kind,
+			...boundary,
+		});
+	};
+
+	pi.on("session_start", (_event, ctx) => {
+		activeSession = ctx.sessionManager;
+		lastPublishedContent = undefined;
+		restoreBranchBoundaries(ctx);
 	});
 
 	pi.on("before_agent_start", (_event, ctx) => {
@@ -98,9 +122,11 @@ export function registerSubagentSessionGuidance(
 		const summaryEpoch = leadingSummaryEpoch(event.messages);
 		if (restoredGuidanceBoundary?.summaryEpoch !== summaryEpoch) {
 			restoredGuidanceBoundary = undefined;
+			guidanceBoundaryPersisted = false;
 		}
 		if (restoredRequirementBoundary?.summaryEpoch !== summaryEpoch) {
 			restoredRequirementBoundary = undefined;
+			requirementBoundaryPersisted = false;
 		}
 		if (
 			restoredGuidanceBoundary === undefined &&
@@ -117,6 +143,10 @@ export function registerSubagentSessionGuidance(
 			getSnapshot(),
 			restoredGuidanceBoundary?.content,
 		);
+		if (restoredGuidanceBoundary && !guidanceBoundaryPersisted) {
+			persistBoundary("guidance", restoredGuidanceBoundary);
+			guidanceBoundaryPersisted = true;
+		}
 		const messages = reconcileRequiredCompletionContext(
 			withGuidance,
 			getAgents(),
@@ -135,7 +165,17 @@ export function registerSubagentSessionGuidance(
 				};
 			}
 		}
+		if (restoredRequirementBoundary && !requirementBoundaryPersisted) {
+			persistBoundary("requirement", restoredRequirementBoundary);
+			requirementBoundaryPersisted = true;
+		}
 		if (messages !== event.messages) return { messages };
+	});
+
+	pi.on("session_tree", (_event, ctx) => {
+		if (ctx.sessionManager !== activeSession) return;
+		lastPublishedContent = undefined;
+		restoreBranchBoundaries(ctx);
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
@@ -144,6 +184,8 @@ export function registerSubagentSessionGuidance(
 		lastPublishedContent = undefined;
 		restoredGuidanceBoundary = undefined;
 		restoredRequirementBoundary = undefined;
+		guidanceBoundaryPersisted = false;
+		requirementBoundaryPersisted = false;
 	});
 
 	return {
@@ -282,6 +324,54 @@ function hasSubagentSessionGuidanceVersion(value: unknown): boolean {
 		!Array.isArray(details) &&
 		(details as Record<string, unknown>).version === SUBAGENT_GUIDANCE_VERSION
 	);
+}
+
+function reconstructRestoredSubagentBoundaries(
+	entries: readonly SessionEntry[],
+	summaryEpoch: string | undefined,
+): Partial<Record<RestoredBoundaryKind, RestoredBoundary>> {
+	const restored: Partial<Record<RestoredBoundaryKind, RestoredBoundary>> = {};
+	if (!summaryEpoch) return restored;
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (
+			entry?.type !== "custom" ||
+			entry.customType !== SUBAGENT_RESTORED_BOUNDARY_ENTRY_TYPE ||
+			!isRestoredSubagentBoundaryData(entry.data, summaryEpoch)
+		) {
+			continue;
+		}
+		if (restored[entry.data.kind] === undefined) {
+			restored[entry.data.kind] = { summaryEpoch, content: entry.data.content };
+		}
+		if (restored.guidance && restored.requirement) break;
+	}
+	return restored;
+}
+
+function isRestoredSubagentBoundaryData(
+	value: unknown,
+	summaryEpoch: string,
+): value is {
+	version: number;
+	kind: RestoredBoundaryKind;
+	summaryEpoch: string;
+	content: string;
+} {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const data = value as Record<string, unknown>;
+	if (
+		data.version !== SUBAGENT_RESTORED_BOUNDARY_VERSION ||
+		(data.kind !== "guidance" && data.kind !== "requirement") ||
+		data.summaryEpoch !== summaryEpoch ||
+		typeof data.content !== "string" ||
+		Buffer.byteLength(data.content, "utf8") > DEFAULT_MAX_CONTEXT_BYTES
+	) {
+		return false;
+	}
+	return data.kind === "guidance"
+		? data.content.startsWith(`[PI SUBAGENTS SESSION GUIDANCE ${SUBAGENT_GUIDANCE_VERSION}]\n`)
+		: data.content.startsWith("[PI SUBAGENT REQUIRED COMPLETIONS v1]\n");
 }
 
 function leadingSummaryEpoch(messages: readonly unknown[]): string | undefined {

--- a/packages/pi-subagents/test/cache-contract.test.ts
+++ b/packages/pi-subagents/test/cache-contract.test.ts
@@ -23,6 +23,7 @@ import {
 	registerSubagentSessionGuidance,
 	SUBAGENT_GUIDANCE_CONTEXT_TYPE,
 	SUBAGENT_GUIDANCE_VERSION,
+	SUBAGENT_RESTORED_BOUNDARY_ENTRY_TYPE,
 	type SubagentSessionGuidanceSnapshot,
 } from "../src/session-guidance-contract.js";
 import { resolveStatefulLimits } from "../src/stateful-limits.js";
@@ -40,6 +41,25 @@ function sessionManagerFor(branch: SessionEntry[]) {
 		getBranch: () => branch,
 		getEntries: () => branch,
 	};
+}
+
+function appendPersistedEntries(
+	mock: ReturnType<typeof createMockPi>,
+	branch: SessionEntry[],
+	parentId: string | null,
+): void {
+	for (const [index, entry] of mock.entries.entries()) {
+		const id = `persisted-boundary-${branch.length}-${index}`;
+		branch.push({
+			type: "custom",
+			id,
+			parentId,
+			timestamp: new Date(index + 1).toISOString(),
+			customType: entry.customType,
+			data: structuredClone(entry.data),
+		} as SessionEntry);
+		parentId = id;
+	}
 }
 
 function userMessage(text: string): ContextEvent["messages"][number] {
@@ -398,7 +418,7 @@ test("live policy changes retain compacted guidance at its prior provider bounda
 	await emit(mock, "session_shutdown", { reason: "quit" }, replacement.ctx);
 });
 
-test("settings changes before the first resumed context retain compacted guidance", async () => {
+test("reloaded settings append after persisted compacted guidance", async () => {
 	let snapshot = guidanceSnapshot();
 	const branch = [
 		{
@@ -411,22 +431,6 @@ test("settings changes before the first resumed context retain compacted guidanc
 			tokensBefore: 100,
 		},
 	] as SessionEntry[];
-	const mock = createMockPi();
-	const controller = registerSubagentSessionGuidance(
-		mock.pi,
-		() => snapshot,
-		() => [],
-	);
-	const context = createMockContext({ sessionManager: sessionManagerFor(branch) });
-	await emit(mock, "session_start", { reason: "resume" }, context.ctx);
-
-	const priorSnapshot = snapshot;
-	snapshot = { ...snapshot, completionDelivery: "auto-resume" };
-	controller.publish();
-	const appended = mock.sentMessages.at(-1)?.message as
-		| ContextEvent["messages"][number]
-		| undefined;
-	if (!appended) assert.fail("expected a live-policy contract");
 	const summary: ContextEvent["messages"] = [
 		{
 			role: "compactionSummary",
@@ -435,12 +439,41 @@ test("settings changes before the first resumed context retain compacted guidanc
 			timestamp: 0,
 		},
 	];
-	const baseline = reconcileSubagentSessionGuidance(
-		[...summary, userMessage("continue")],
-		priorSnapshot,
+	const priorSnapshot = snapshot;
+	const firstMock = createMockPi();
+	registerSubagentSessionGuidance(
+		firstMock.pi,
+		() => snapshot,
+		() => [],
 	);
+	const context = createMockContext({ sessionManager: sessionManagerFor(branch) });
+	await emit(firstMock, "session_start", { reason: "resume" }, context.ctx);
+	const baseline = await applyContextHooks(
+		firstMock,
+		[...summary, userMessage("continue")],
+		context.ctx,
+	);
+	assert.equal(firstMock.entries.length, 1);
+	assert.equal(firstMock.entries[0]?.customType, SUBAGENT_RESTORED_BOUNDARY_ENTRY_TYPE);
+	appendPersistedEntries(firstMock, branch, "compaction");
+	await emit(firstMock, "session_shutdown", { reason: "reload" }, context.ctx);
+
+	snapshot = { ...snapshot, completionDelivery: "auto-resume" };
+	const reloadedMock = createMockPi();
+	registerSubagentSessionGuidance(
+		reloadedMock.pi,
+		() => snapshot,
+		() => [],
+	);
+	await emit(reloadedMock, "session_start", { reason: "reload" }, context.ctx);
+	const transition = (await reloadedMock.events.get("before_agent_start")?.[0]?.(
+		{ prompt: "continue", systemPrompt: "base" },
+		context.ctx,
+	)) as { message?: ContextEvent["messages"][number] } | undefined;
+	const appended = transition?.message;
+	if (!appended) assert.fail("expected the refreshed policy to append after reload");
 	const resumed = await applyContextHooks(
-		mock,
+		reloadedMock,
 		[...summary, userMessage("continue"), appended],
 		context.ctx,
 	);
@@ -457,8 +490,12 @@ test("settings changes before the first resumed context retain compacted guidanc
 		String(appended.role === "custom" ? appended.content : ""),
 		/"completionDelivery":"auto-resume"/u,
 	);
-
-	await emit(mock, "session_shutdown", { reason: "quit" }, context.ctx);
+	assert.deepEqual(
+		baseline,
+		reconcileSubagentSessionGuidance([...summary, userMessage("continue")], priorSnapshot),
+	);
+	assert.equal(reloadedMock.entries.length, 0, "reload must reuse persisted boundary metadata");
+	await emit(reloadedMock, "session_shutdown", { reason: "quit" }, context.ctx);
 });
 
 test("restored requirement context remains fixed after completion becomes visible", async () => {
@@ -533,23 +570,69 @@ test("restored requirement context remains fixed after completion becomes visibl
 	);
 	assert.equal(secondMessages.at(-1), completion);
 
+	assert.equal(
+		mock.entries.filter((entry) => entry.customType === SUBAGENT_RESTORED_BOUNDARY_ENTRY_TYPE)
+			.length,
+		2,
+		"guidance and requirement boundary metadata must be persisted",
+	);
+	appendPersistedEntries(mock, branch, "compaction");
+	const reloadedMock = createMockPi();
+	registerSubagentSessionGuidance(reloadedMock.pi, guidanceSnapshot, () => agents);
 	const replacement = createMockContext({ sessionManager: sessionManagerFor(branch) });
-	await emit(mock, "session_start", { reason: "fork" }, replacement.ctx);
-	await emit(mock, "session_shutdown", { reason: "replace" }, context.ctx);
+	await emit(reloadedMock, "session_start", { reason: "reload" }, replacement.ctx);
 	const replacementMessages = await applyContextHooks(
-		mock,
+		reloadedMock,
 		[...firstRaw, completion],
 		replacement.ctx,
 	);
-	assert.equal(
-		replacementMessages.some(
+	assert.deepEqual(
+		replacementMessages.find(
 			(message) =>
 				message.role === "custom" && message.customType === COMPLETION_REQUIREMENT_CONTEXT_TYPE,
 		),
-		false,
-		"session replacement must clear the prior requirement boundary",
+		restored,
+		"reload must retain the requirement boundary after completion becomes visible",
 	);
-	await emit(mock, "session_shutdown", { reason: "quit" }, replacement.ctx);
+	assert.equal(reloadedMock.entries.length, 0);
+
+	const siblingGuidance = createSubagentSessionGuidance(guidanceSnapshot());
+	branch.splice(
+		0,
+		branch.length,
+		{
+			type: "compaction",
+			id: "sibling-compaction",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			summary: "Earlier work was compacted.",
+			firstKeptEntryId: "sibling-guidance",
+			tokensBefore: 100,
+		} as SessionEntry,
+		{
+			type: "message",
+			id: "sibling-guidance",
+			parentId: "sibling-compaction",
+			timestamp: new Date(1).toISOString(),
+			message: siblingGuidance,
+		} as SessionEntry,
+		{
+			type: "message",
+			id: "sibling-completion",
+			parentId: "sibling-guidance",
+			timestamp: new Date(2).toISOString(),
+			message: completion,
+		} as SessionEntry,
+	);
+	await emit(reloadedMock, "session_tree", {}, replacement.ctx);
+	const siblingMessages = [...summary, siblingGuidance, completion];
+	assert.equal(
+		await applyContextHooks(reloadedMock, siblingMessages, replacement.ctx),
+		siblingMessages,
+		"sibling navigation must not inherit restored boundaries from another branch",
+	);
+	await emit(mock, "session_shutdown", { reason: "reload" }, context.ctx);
+	await emit(reloadedMock, "session_shutdown", { reason: "quit" }, replacement.ctx);
 });
 
 test("uncompacted resume appends a restored requirement cancellation once", async () => {

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -81,6 +81,7 @@ During ordinary turns, the model reads the complete list from the persisted `upd
 If leading compaction or branch summaries remove that matching call/result pair, the extension inserts one hidden, non-persistent state-only fallback immediately after those summaries.
 
 That restored message remains fixed for the current leading-summary epoch, including after a later valid todo update or clear.
+The extension stores branch-local boundary metadata in the session so reload and branch navigation retain the established prefix without making the hidden fallback itself persistent model context.
 The later tool call and result supersede the restored state at the conversation tail without rewriting the earlier provider prefix.
 An ordinary context without a leading summary does not synthesize a fallback, and a new summary epoch restores only the then-current list when needed.
 

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -1,10 +1,11 @@
 import { StringEnum } from "@earendil-works/pi-ai";
-import type {
-	ContextEvent,
-	ExtensionAPI,
-	ExtensionContext,
-	SessionEntry,
-	Theme,
+import {
+	buildSessionContext,
+	type ContextEvent,
+	type ExtensionAPI,
+	type ExtensionContext,
+	type SessionEntry,
+	type Theme,
 } from "@earendil-works/pi-coding-agent";
 import { stripTerminalSequences, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
@@ -14,6 +15,8 @@ export const WIDGET_KEY = "todo";
 export const TODO_CONTEXT_MESSAGE_TYPE = "todo-list-status";
 export const TODO_CONTEXT_VERSION = 1;
 export const TODO_DETAILS_VERSION = 1;
+export const TODO_RESTORED_BOUNDARY_ENTRY_TYPE = "todo-restored-context-boundary";
+const TODO_RESTORED_BOUNDARY_VERSION = 1;
 export const MAX_TODO_ITEMS = 50;
 export const MAX_TODO_TEXT_LENGTH = 300;
 
@@ -126,10 +129,15 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 		},
 	});
 
+	const restoreBranchState = (ctx: ExtensionContext): void => {
+		const branch = ctx.sessionManager.getBranch();
+		items = reconstructItems(branch);
+		restoredBoundary = reconstructRestoredTodoBoundary(branch);
+	};
+
 	pi.on("session_start", (_event, ctx) => {
 		activeSession = ctx.sessionManager;
-		items = reconstructItems(ctx.sessionManager.getBranch());
-		restoredBoundary = undefined;
+		restoreBranchState(ctx);
 		publish(ctx);
 	});
 
@@ -142,6 +150,10 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 			const boundaryMessage = messages[leadingSummaryBoundary(messages)];
 			if (isTodoContextMessage(boundaryMessage)) {
 				restoredBoundary = { summaryEpoch, content: boundaryMessage.content };
+				pi.appendEntry(TODO_RESTORED_BOUNDARY_ENTRY_TYPE, {
+					version: TODO_RESTORED_BOUNDARY_VERSION,
+					...restoredBoundary,
+				});
 			}
 		}
 		if (messages !== event.messages) return { messages };
@@ -149,7 +161,7 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_tree", (_event, ctx) => {
 		if (!ownsSession(ctx)) return;
-		items = reconstructItems(ctx.sessionManager.getBranch());
+		restoreBranchState(ctx);
 		publish(ctx);
 	});
 
@@ -256,6 +268,49 @@ function todoContextContent(items: readonly TodoItem[]): string {
 	return `[PI TODO STATUS v${TODO_CONTEXT_VERSION}]
 Current todo list as JSON data:
 ${JSON.stringify(items)}`;
+}
+
+function reconstructRestoredTodoBoundary(
+	entries: readonly SessionEntry[],
+): { summaryEpoch: string; content: string } | undefined {
+	const summaryEpoch = leadingSummaryEpoch(buildSessionContext([...entries]).messages);
+	if (!summaryEpoch) return undefined;
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (entry?.type !== "custom" || entry.customType !== TODO_RESTORED_BOUNDARY_ENTRY_TYPE) {
+			continue;
+		}
+		if (!isRestoredTodoBoundaryData(entry.data, summaryEpoch)) continue;
+		return { summaryEpoch, content: entry.data.content };
+	}
+	return undefined;
+}
+
+function isRestoredTodoBoundaryData(
+	value: unknown,
+	summaryEpoch: string,
+): value is { version: number; summaryEpoch: string; content: string } {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const data = value as Record<string, unknown>;
+	if (
+		data.version !== TODO_RESTORED_BOUNDARY_VERSION ||
+		data.summaryEpoch !== summaryEpoch ||
+		typeof data.content !== "string"
+	) {
+		return false;
+	}
+	const prefix = `[PI TODO STATUS v${TODO_CONTEXT_VERSION}]\nCurrent todo list as JSON data:\n`;
+	if (!data.content.startsWith(prefix)) return false;
+	try {
+		const restoredItems: unknown = JSON.parse(data.content.slice(prefix.length));
+		return (
+			isTodoItems(restoredItems) &&
+			restoredItems.length > 0 &&
+			todoContextContent(restoredItems) === data.content
+		);
+	} catch {
+		return false;
+	}
 }
 
 function hasModelVisibleTodoState(

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -15,6 +15,7 @@ import todoWidgetExtension, {
 	TODO_CONTEXT_MESSAGE_TYPE,
 	TODO_CONTEXT_VERSION,
 	TODO_DETAILS_VERSION,
+	TODO_RESTORED_BOUNDARY_ENTRY_TYPE,
 	TOOL_NAME,
 	type TodoDetails,
 	type TodoItem,
@@ -41,6 +42,7 @@ interface RegisteredTool {
 
 function createHarness() {
 	const handlers = new Map<string, Handler[]>();
+	const entries: Array<{ customType: string; data: unknown }> = [];
 	let tool: RegisteredTool | undefined;
 	const pi = {
 		on(event: string, handler: Handler) {
@@ -49,10 +51,14 @@ function createHarness() {
 		registerTool(definition: RegisteredTool) {
 			tool = definition;
 		},
+		appendEntry(customType: string, data: unknown) {
+			entries.push({ customType, data: structuredClone(data) });
+		},
 	} as unknown as ExtensionAPI;
 	todoWidgetExtension(pi);
 
 	return {
+		entries,
 		get tool(): RegisteredTool {
 			assert.ok(tool);
 			return tool;
@@ -165,13 +171,34 @@ function todoToolCallMessage(
 	};
 }
 
-function toolResultEntry(details: TodoDetails, toolName = TOOL_NAME): SessionEntry {
+function toolResultEntry(
+	details: TodoDetails,
+	toolName = TOOL_NAME,
+	id = "tool-result",
+	parentId: string | null = null,
+): SessionEntry {
 	return {
 		type: "message",
-		id: "tool-result",
-		parentId: null,
+		id,
+		parentId,
 		timestamp: new Date(0).toISOString(),
 		message: todoToolResultMessage(details, toolName),
+	} as SessionEntry;
+}
+
+function customEntry(
+	customType: string,
+	data: unknown,
+	id: string,
+	parentId: string | null,
+): SessionEntry {
+	return {
+		type: "custom",
+		id,
+		parentId,
+		timestamp: new Date(0).toISOString(),
+		customType,
+		data,
 	} as SessionEntry;
 }
 
@@ -353,6 +380,103 @@ test("restores missing todo state and retains its summary boundary", async () =>
 		"a new summary epoch must use the current cleared state",
 	);
 	assert.deepEqual(await harness.context([...ordinary, reminder], current.ctx), ordinary);
+});
+
+test("restored todo boundaries survive reload and stay branch-local", async () => {
+	const initialItems: TodoItem[] = [{ text: "before compaction", status: "in_progress" }];
+	const initialDetails: TodoDetails = { version: TODO_DETAILS_VERSION, items: initialItems };
+	const branch: SessionEntry[] = [
+		toolResultEntry(initialDetails, TOOL_NAME, "initial", null),
+		{
+			type: "compaction",
+			id: "compaction",
+			parentId: "initial",
+			timestamp: new Date(0).toISOString(),
+			summary: "Earlier work was compacted.",
+			firstKeptEntryId: "kept",
+			tokensBefore: 100,
+		} as SessionEntry,
+	];
+	const summaries: ContextEvent["messages"] = [
+		{
+			role: "compactionSummary",
+			summary: "Earlier work was compacted.",
+			tokensBefore: 100,
+			timestamp: 0,
+		},
+	];
+	const firstHarness = createHarness();
+	const current = createContext({ branch });
+	await firstHarness.emit("session_start", current.ctx);
+	const first = await firstHarness.context(summaries, current.ctx);
+	const restored = first[1];
+	assert.equal(
+		restored?.role === "custom" ? restored.customType : undefined,
+		TODO_CONTEXT_MESSAGE_TYPE,
+	);
+	assert.equal(firstHarness.entries.length, 1);
+	const persisted = firstHarness.entries[0];
+	assert.equal(persisted?.customType, TODO_RESTORED_BOUNDARY_ENTRY_TYPE);
+	branch.push(customEntry(persisted?.customType ?? "", persisted?.data, "boundary", "compaction"));
+
+	const cleared: TodoDetails = { version: TODO_DETAILS_VERSION, items: [] };
+	const clearCall = todoToolCallMessage([]);
+	const clearResult = todoToolResultMessage(cleared);
+	branch.push(
+		{
+			type: "message",
+			id: "clear-call",
+			parentId: "boundary",
+			timestamp: new Date(1).toISOString(),
+			message: clearCall,
+		} as SessionEntry,
+		{
+			type: "message",
+			id: "clear-result",
+			parentId: "clear-call",
+			timestamp: new Date(2).toISOString(),
+			message: clearResult,
+		} as SessionEntry,
+	);
+	const reloadedHarness = createHarness();
+	await reloadedHarness.emit("session_start", current.ctx);
+	const afterReload = await reloadedHarness.context(
+		[...summaries, clearCall, clearResult],
+		current.ctx,
+	);
+	assert.deepEqual(afterReload[1], restored);
+	assert.equal(reloadedHarness.entries.length, 0, "reload must reuse persisted boundary metadata");
+
+	branch.splice(
+		0,
+		branch.length,
+		{
+			type: "compaction",
+			id: "sibling-compaction",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			summary: "Earlier work was compacted.",
+			firstKeptEntryId: "sibling-call",
+			tokensBefore: 100,
+		} as SessionEntry,
+		{
+			type: "message",
+			id: "sibling-call",
+			parentId: "sibling-compaction",
+			timestamp: new Date(1).toISOString(),
+			message: clearCall,
+		} as SessionEntry,
+		{
+			type: "message",
+			id: "sibling-result",
+			parentId: "sibling-call",
+			timestamp: new Date(2).toISOString(),
+			message: clearResult,
+		} as SessionEntry,
+	);
+	await reloadedHarness.emit("session_tree", current.ctx);
+	const sibling = [...summaries, clearCall, clearResult];
+	assert.equal(await reloadedHarness.context(sibling, current.ctx), sibling);
 });
 
 test("renders completed, current, and pending tasks with themed semantic symbols", () => {


### PR DESCRIPTION
## Summary

- Persist restored todo, subagent guidance, and required-completion boundaries as validated branch-local session entries.
- Reconstruct exact historical boundaries after extension reloads and tree navigation without rewriting established model-visible prefixes.
- Add reload, changed-settings, completion, clear, and sibling-branch regression coverage.
- Document the persistence behavior and add patch changesets for `@narumitw/pi-subagents` and `@narumitw/pi-todo`.

## Context

This is the follow-up for the four post-merge review findings on #992.
The original fix commit was pushed after #992 merged, so it required a separate pull request.

## Verification

- `npm run check`
- `npm test` — 387 test files and 3,398 tests passed
- Final semantic audit against `docs/extension-conventions.md`: prompt-prefix epochs, idempotence, reload reconstruction, branch isolation, session replacement, and shutdown paths reviewed; no asynchronous tasks or settings paths changed
