### PR TITLE
fix(accounts): pass signal to OAuth refresh

### DIFF
--- a/.changeset/calm-accounts-refresh.md
+++ b/.changeset/calm-accounts-refresh.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-accounts": patch
+---
+
+Pass a lifecycle-cancellable signal to provider-owned OAuth refresh so expiring account credentials refresh correctly with Pi 0.84.x.

--- a/packages/pi-accounts/src/oauth.ts
+++ b/packages/pi-accounts/src/oauth.ts
@@ -2,7 +2,7 @@ import {
 	type AuthEvent,
 	type AuthPrompt,
 	cleanupSessionResources,
-	type ModelAuth,
+	type OAuthAuth,
 	type OAuthCredential,
 	type ProviderAuthInteraction,
 } from "@earendil-works/pi-ai";
@@ -16,11 +16,7 @@ export const SUPPORTED_PROVIDER_IDS = ["anthropic", "github-copilot", "openai-co
 
 export type AccountProviderId = (typeof SUPPORTED_PROVIDER_IDS)[number];
 
-export interface ProviderOwnedOAuth {
-	login(interaction: ProviderAuthInteraction): Promise<OAuthCredential>;
-	refresh(credential: OAuthCredential, signal?: AbortSignal): Promise<OAuthCredential>;
-	toAuth(credential: OAuthCredential): Promise<ModelAuth>;
-}
+export type ProviderOwnedOAuth = Pick<OAuthAuth, "login" | "refresh" | "toAuth">;
 
 export type AccountProviderAdapter = {
 	id: AccountProviderId;

--- a/packages/pi-accounts/src/runtime-auth.ts
+++ b/packages/pi-accounts/src/runtime-auth.ts
@@ -47,6 +47,7 @@ export class RuntimeAuthCoordinator {
 	private readonly controller: RuntimeApiKeyController;
 	private readonly overlay: RuntimeProviderOverlay;
 	private availableModelIds: ReadonlySet<string> | undefined;
+	private refreshController = new AbortController();
 
 	constructor(
 		pi: ExtensionAPI,
@@ -64,6 +65,7 @@ export class RuntimeAuthCoordinator {
 	): Promise<EnsureActiveProviderAuthResult> {
 		const operation = this.overlay.beginOperation();
 		const runtimeOverride = this.controller.begin(ctx);
+		const refreshSignal = this.refreshController.signal;
 		let state: ProviderAccountState;
 		try {
 			state = await store.readProviderAsync(this.provider.id);
@@ -116,7 +118,9 @@ export class RuntimeAuthCoordinator {
 					credential = latestCredential;
 					if (latestCredential.expires > now + REFRESH_SKEW_MS) return latest;
 					try {
-						const refreshed = await this.provider.oauth.refresh(latestCredential);
+						refreshSignal.throwIfAborted();
+						const refreshed = await this.provider.oauth.refresh(latestCredential, refreshSignal);
+						refreshSignal.throwIfAborted();
 						credential = refreshed;
 						return {
 							...latest,
@@ -218,6 +222,8 @@ export class RuntimeAuthCoordinator {
 	invalidate(ctx: ExtensionContext): void {
 		this.overlay.beginOperation();
 		this.controller.invalidate(ctx);
+		this.refreshController.abort(new DOMException("Account refresh invalidated", "AbortError"));
+		this.refreshController = new AbortController();
 	}
 
 	async clear(ctx: ExtensionContext): Promise<void> {

--- a/packages/pi-accounts/test/accounts.test.ts
+++ b/packages/pi-accounts/test/accounts.test.ts
@@ -1079,6 +1079,115 @@ test("unsafe provider endpoints and malformed model metadata fail closed", async
 	}
 });
 
+test("expired credentials refresh with a concrete signal and activate", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			anthropic: {
+				active: "work",
+				accounts: { work: { ...credential("expired"), expires: 1 } },
+			},
+		},
+	});
+	const provider = fakeProvider("anthropic");
+	let refreshSignal: AbortSignal | undefined;
+	provider.oauth.refresh = async (current, signal) => {
+		refreshSignal = signal;
+		if (!signal) throw new Error("Missing OAuth refresh signal");
+		return {
+			...current,
+			access: "access-refreshed",
+			expires: Date.now() + 60 * 60 * 1000,
+		};
+	};
+	const mock = createMockPi();
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, provider);
+	const { registry, keys } = runtimeHarness(mock);
+	const { ctx } = createMockContext({ modelRegistry: registry });
+
+	const result = await coordinator.ensureActive(ctx, store);
+
+	assert.deepEqual(result, {
+		status: "active",
+		providerId: "anthropic",
+		accountName: "work",
+	});
+	assert.ok(refreshSignal instanceof AbortSignal);
+	assert.equal(refreshSignal.aborted, false);
+	assert.equal(
+		(await store.readProviderAsync("anthropic")).accounts.work?.access,
+		"access-refreshed",
+	);
+	assert.equal(keys.get("anthropic"), "access-refreshed");
+});
+
+test("refresh invalidation rejects stale credentials and rotates the signal", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			anthropic: {
+				active: "work",
+				accounts: { work: { ...credential("expired"), expires: 1 } },
+			},
+		},
+	});
+	let notifyStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		notifyStarted = resolve;
+	});
+	let releaseFirst!: () => void;
+	const firstRelease = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
+	const signals: Array<AbortSignal | undefined> = [];
+	const provider = fakeProvider("anthropic");
+	provider.oauth.refresh = async (current, signal) => {
+		signals.push(signal);
+		if (signals.length === 1) {
+			notifyStarted();
+			await firstRelease;
+			return {
+				...current,
+				access: "access-stale",
+				expires: Date.now() + 60 * 60 * 1000,
+			};
+		}
+		return {
+			...current,
+			access: "access-fresh",
+			expires: Date.now() + 60 * 60 * 1000,
+		};
+	};
+	const mock = createMockPi();
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, provider);
+	const { registry, keys } = runtimeHarness(mock);
+	const { ctx } = createMockContext({ modelRegistry: registry });
+
+	const staleActivation = coordinator.ensureActive(ctx, store);
+	await started;
+	coordinator.invalidate(ctx);
+	releaseFirst();
+	const staleResult = await staleActivation;
+	const freshResult = await coordinator.ensureActive(ctx, store);
+
+	assert.equal(staleResult.status, "inactive");
+	assert.deepEqual(freshResult, {
+		status: "active",
+		providerId: "anthropic",
+		accountName: "work",
+	});
+	assert.equal(signals.length, 2);
+	assert.ok(signals[0] instanceof AbortSignal);
+	assert.equal(signals[0].aborted, true);
+	assert.ok(signals[1] instanceof AbortSignal);
+	assert.equal(signals[1].aborted, false);
+	assert.notEqual(signals[0], signals[1]);
+	assert.equal((await store.readProviderAsync("anthropic")).accounts.work?.access, "access-fresh");
+	assert.equal(keys.get("anthropic"), "access-fresh");
+});
+
 test("invalid refreshed credentials fail closed instead of escaping storage validation", async () => {
 	const store = new AccountStore(new InMemoryAccountStorageBackend());
 	await store.write({


### PR DESCRIPTION
## Summary

- Align the account OAuth adapter with Pi's required refresh signal contract.
- Pass a lifecycle-owned signal to credential refresh and reject late refresh results after invalidation.
- Add regression coverage for successful refresh, shutdown invalidation, stale-result rejection, and signal rotation.
- Add a patch Changeset for `@narumitw/pi-accounts`.

## Verification

- `npm exec -- vitest run packages/pi-accounts/test/accounts.test.ts` — 36 passed.
- `npm run check` — build, Biome, boundaries, and all workspace typechecks passed.
- `npm test` — 3,399 tests across 387 files passed.
- `just pack accounts` — 11 expected package files inspected.
- `PI_CODING_AGENT_DIR=<temporary> pi --no-extensions -e ./packages/pi-accounts --list-models` — generated entrypoint loaded and listed 68 models.
- `npm run changeset:status` — pi-accounts patch recorded; output also retains the baseline pi-btw patch and pre-existing Kit range notices.

## Risks and unverified paths

- Live OAuth refresh was not exercised because no real provider credentials were used.
- Deterministic tests cover Pi 0.84.3's required signal contract and an uncooperative provider returning after cancellation.

Closes #998
