### PR TITLE
fix(tui): preserve ctrl-c after cancel remaps

### DIFF
--- a/.changeset/strong-hard-cancel-keys.md
+++ b/.changeset/strong-hard-cancel-keys.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-tui-kit": patch
+"@narumitw/pi-sync": patch
+"@narumitw/pi-statusline": patch
+---
+
+Keep Ctrl+C available as a hard-cancel input when configurable cancellation bindings are remapped.

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -276,8 +276,10 @@ Open **Advanced → Custom layout** when the curated levels are not enough.
 | Up/Down in Move mode | Reorder the selected visible segment |
 | `Alt+Up` / `Alt+Down` | Reorder without entering Move mode |
 | `B` | Add or remove a line break after the selected segment |
-| Escape | Leave Move mode first, then close the screen |
+| Configured Back key (Escape by default) | Leave Move mode first, then close the screen |
+| Ctrl+C | Close the screen immediately, including from Move mode |
 
+The layout displays the effective Back key and keeps Ctrl+C available when Back is remapped.
 Every successful change saves and applies immediately; closing the screen does not roll it back.
 
 Available data segments:

--- a/packages/pi-statusline/src/commands.ts
+++ b/packages/pi-statusline/src/commands.ts
@@ -2,6 +2,7 @@ import {
 	DynamicBorder,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
+	type KeybindingsManager,
 } from "@earendil-works/pi-coding-agent";
 import {
 	Container,
@@ -11,6 +12,7 @@ import {
 	truncateToWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import { completeStatuslineArguments } from "./command-contract.js";
 import {
 	INFORMATION_PROFILE_NAMES,
@@ -480,7 +482,7 @@ async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineC
 			}
 
 			lines.push("");
-			const hints = segmentControlHints(safeWidth, moveMode, selected);
+			const hints = segmentControlHints(safeWidth, moveMode, selected, keybindings);
 			for (const hint of hints) {
 				lines.push(theme.fg("dim", truncateToWidth(`  ${hint}`, safeWidth)));
 			}
@@ -505,6 +507,10 @@ async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineC
 				updateThemedText();
 			},
 			handleInput(data: string) {
+				if (matchesKey(data, Key.ctrl("c"))) {
+					done(undefined);
+					return;
+				}
 				const moveModeKey = matchesKey(data, "m") || matchesKey(data, Key.shift("m"));
 				const lineBreakKey = matchesKey(data, "b") || matchesKey(data, Key.shift("b"));
 				if (matchesKey(data, Key.alt("up"))) {
@@ -656,19 +662,32 @@ function segmentControlHints(
 	width: number,
 	moveMode: boolean,
 	selected: SegmentName | undefined,
+	keybindings: Pick<KeybindingsManager, "getKeys">,
 ): string[] {
+	const configuredCancel = [
+		...new Set(
+			keybindings
+				.getKeys("tui.select.cancel")
+				.filter((key) => key !== "ctrl+c")
+				.map(displayKey)
+				.filter(Boolean),
+		),
+	];
+	const closeKeys = [...new Set([...configuredCancel, "Ctrl+C"])].join("/");
 	if (moveMode) {
+		const cancellation = [
+			...(configuredCancel.length > 0 ? [`${configuredCancel.join("/")} leave move mode`] : []),
+			"Ctrl+C close",
+		].join(" · ");
 		return width < 30
 			? [
 					`Move mode: ${selected ?? "segment"}`,
 					"↑↓ move segment",
 					"Enter/Space finish",
-					"Esc leave move mode",
+					...(configuredCancel.length > 0 ? [`${configuredCancel.join("/")} leave move mode`] : []),
+					"Ctrl+C close",
 				]
-			: [
-					`Move mode — ${selected ?? "segment"}`,
-					"↑↓ move · Enter/Space finish · Esc leave move mode",
-				];
+			: [`Move mode — ${selected ?? "segment"}`, "↑↓ move · Enter/Space finish", cancellation];
 	}
 	return width < 30
 		? [
@@ -676,12 +695,25 @@ function segmentControlHints(
 				"Enter/Space toggle",
 				"M move · B line break",
 				"Alt+↑/↓ quick move",
-				"Esc close",
+				`${closeKeys} close`,
 			]
 		: [
 				"↑↓ navigate · Enter/Space show/hide · M move mode",
-				"B add/remove line break after · Alt+↑/↓ quick move · Esc close",
+				`B add/remove line break after · Alt+↑/↓ quick move · ${closeKeys} close`,
 			];
+}
+
+function displayKey(key: string): string {
+	return sanitizeTerminalText(key)
+		.split("+")
+		.map((part) => {
+			if (part === "escape") return "Esc";
+			if (part === "ctrl") return "Ctrl";
+			if (part === "alt") return process.platform === "darwin" ? "Option" : "Alt";
+			if (part === "shift") return "Shift";
+			return part;
+		})
+		.join("+");
 }
 
 function segmentsDocument(

--- a/packages/pi-statusline/test/commands.test.ts
+++ b/packages/pi-statusline/test/commands.test.ts
@@ -5,7 +5,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { stripVTControlCharacters } from "node:util";
-import { initTheme } from "@earendil-works/pi-coding-agent";
+import { initTheme, type KeybindingsManager } from "@earendil-works/pi-coding-agent";
 import { getKeybindings, visibleWidth } from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { describe, test } from "vitest";
@@ -51,6 +51,27 @@ function selectInformationProfile(title: string, choices: string[]): string | un
 	if (screenTitle(title) === "pi-statusline") return choices[1];
 	if (title.includes("Information level")) return choices[0];
 	return undefined;
+}
+
+function remappedStatuslineKeybindings(): Pick<KeybindingsManager, "matches" | "getKeys"> {
+	return {
+		matches(data, binding) {
+			if (binding === "tui.select.cancel") return data === "q";
+			if (binding === "tui.select.confirm" || binding === "tui.input.submit") {
+				return data === "\r";
+			}
+			if (binding === "tui.select.up") return data === "\u001b[A";
+			if (binding === "tui.select.down") return data === "\u001b[B";
+			return false;
+		},
+		getKeys(binding) {
+			if (binding === "tui.select.cancel") return ["q"];
+			if (binding === "tui.select.confirm" || binding === "tui.input.submit") return ["enter"];
+			if (binding === "tui.select.up") return ["up"];
+			if (binding === "tui.select.down") return ["down"];
+			return [];
+		},
+	};
 }
 
 function customPalettePicker(
@@ -539,7 +560,7 @@ test("segment menu reorders visible segments immediately while preserving multil
 		assert.match(narrowScreen, /Enter\/Space toggle/u);
 		assert.match(narrowScreen, /M move/u);
 		assert.match(narrowScreen, /Alt\+↑\/↓ quick move/u);
-		assert.match(narrowScreen, /Esc close/u);
+		assert.match(narrowScreen, /Esc\/Ctrl\+C close/u);
 		assert.deepEqual(appliedSegments, [
 			["cwd", "line_break", "model", "branch"],
 			["model", "line_break", "cwd", "branch"],
@@ -698,6 +719,78 @@ test("segment menu offers Move mode and explains unavailable moves", async () =>
 		rmSync(root, { recursive: true, force: true });
 	}
 });
+
+test.each(["normal", "move"] as const)(
+	"segment menu keeps Ctrl+C as hard close in %s mode when cancellation is remapped",
+	async (mode) => {
+		const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));
+		const path = settingsFilePath(root);
+		writeFileSync(
+			path,
+			`${JSON.stringify({ segments: ["model", "cwd"], future: { retained: true } })}\n`,
+		);
+		try {
+			const mock = createMockPi();
+			let loaded = loadStatuslineSettings(path);
+			const appliedSegments: string[][] = [];
+			registerStatuslineCommand(mock.pi, {
+				settingsPath: path,
+				getLoaded: () => loaded,
+				apply(next) {
+					loaded = next;
+					appliedSegments.push([...next.config.segments]);
+				},
+			});
+			const tui = createTuiHarness({
+				width: 20,
+				rows: 20,
+				keybindings: remappedStatuslineKeybindings(),
+			});
+			const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+			const running = mock.commands.get("statusline")?.handler("", context.ctx);
+
+			await tui.waitForOpen();
+			tui.press("tui.select.down");
+			tui.press("tui.select.down");
+			tui.press("tui.select.confirm");
+			await tui.waitForPending();
+			await tui.waitForOpen();
+			tui.press("tui.select.confirm");
+			await tui.waitForPending();
+			await tui.waitForOpen();
+
+			const initialFrame = tui.render();
+			for (const line of initialFrame) assert.ok(visibleWidth(line) <= 20);
+			assert.match(initialFrame.join("\n"), /q\/Ctrl\+C close/u);
+			assert.equal(initialFrame.join("\n").match(/Ctrl\+C/gu)?.length, 1);
+			if (mode === "normal") {
+				tui.press("tui.select.confirm");
+				assert.deepEqual(appliedSegments, [["cwd"]]);
+			} else {
+				tui.send("m");
+				const moveFrame = tui.render();
+				for (const line of moveFrame) assert.ok(visibleWidth(line) <= 20);
+				assert.match(moveFrame.join("\n"), /q leave move mode/u);
+				assert.match(moveFrame.join("\n"), /Ctrl\+C close/u);
+				tui.send("q");
+				assert.doesNotMatch(tui.render().join("\n"), /Move mode/iu);
+				tui.send("m");
+				assert.match(tui.render().join("\n"), /Move mode/iu);
+			}
+			tui.press("ctrl+c");
+			await running;
+
+			assert.equal(tui.isOpen, false);
+			assert.deepEqual(appliedSegments, mode === "normal" ? [["cwd"]] : []);
+			assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
+				segments: mode === "normal" ? ["cwd"] : ["model", "cwd"],
+				future: { retained: true },
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	},
+);
 
 test("segment menu keeps displayed order when reordering cannot be saved", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-command-"));

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -62,6 +62,7 @@ When pi-sync has already detected a synced-content-list mismatch, the manager in
 Opening the manager still performs no new remote request.
 The standard manager also owns setup and connection lists/details plus history and recovery.
 Secondary screens provide **Back**; Escape goes back and Ctrl+C closes the flow.
+Specialized operation and masked-credential prompts show the effective cancellation bindings and retain Ctrl+C as a hard-cancel input when Back is remapped.
 Destructive, credential-bearing, and externally visible operations retain exact specialized previews and confirmations.
 
 ### Restore sync access

--- a/packages/pi-sync/src/cancellable-operation.ts
+++ b/packages/pi-sync/src/cancellable-operation.ts
@@ -3,7 +3,7 @@ import {
 	type ExtensionContext,
 	type KeybindingsManager,
 } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth } from "@earendil-works/pi-tui";
+import { Key, matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
 import { runCustomInteraction } from "@narumitw/pi-tui-kit";
 import { safeTerminalText } from "./manager-helpers.js";
 import type { SetupPullOutcome } from "./setup-switch.js";
@@ -87,7 +87,9 @@ export async function runCancellableOperation(
 				},
 				invalidate: () => loader.invalidate(),
 				handleInput(data: string) {
-					if (!keybindings.matches(data, "tui.select.cancel")) return;
+					if (!matchesKey(data, Key.ctrl("c")) && !keybindings.matches(data, "tui.select.cancel")) {
+						return;
+					}
 					if (commitStarted) {
 						ctx.ui.notify(
 							"Applying or publishing has started and cannot be cancelled safely.",
@@ -117,8 +119,7 @@ function keybindingText(
 	binding: Parameters<KeybindingsManager["getKeys"]>[0],
 	fallback: string,
 ) {
-	const keys = keybindings
-		.getKeys(binding)
+	const keys = [...new Set([...keybindings.getKeys(binding), "ctrl+c"])]
 		.map(String)
 		.map((key) => {
 			if (key === "return") return "enter";

--- a/packages/pi-sync/src/secret-input.ts
+++ b/packages/pi-sync/src/secret-input.ts
@@ -3,7 +3,9 @@ import {
 	CURSOR_MARKER,
 	decodeKittyPrintable,
 	type Focusable,
+	Key,
 	type KeybindingsManager,
+	matchesKey,
 	Text,
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
@@ -24,7 +26,7 @@ export async function promptSecret(
 			const heading = new Text("", 0, 0);
 			const hint = new Text("", 0, 0);
 			const submitKey = keybindingText(keybindings, "tui.input.submit", "enter");
-			const cancelKey = keybindingText(keybindings, "tui.select.cancel", "esc");
+			const cancelKey = keybindingText(keybindings, "tui.select.cancel", "esc", ["ctrl+c"]);
 			const applyTheme = () => {
 				heading.setText(theme.fg("accent", theme.bold(title)));
 				hint.setText(theme.fg("dim", `${submitKey} save • ${cancelKey} cancel • Input is hidden`));
@@ -58,8 +60,9 @@ export async function promptSecret(
 					hint.invalidate();
 				},
 				handleInput(data: string) {
-					if (keybindings.matches(data, "tui.select.cancel")) complete(undefined);
-					else if (keybindings.matches(data, "tui.input.submit")) complete(input.getValue());
+					if (matchesKey(data, Key.ctrl("c")) || keybindings.matches(data, "tui.select.cancel")) {
+						complete(undefined);
+					} else if (keybindings.matches(data, "tui.input.submit")) complete(input.getValue());
 					else input.handleInput(data);
 					tui.requestRender();
 				},
@@ -195,9 +198,9 @@ function keybindingText(
 	keybindings: Pick<KeybindingsManager, "getKeys">,
 	binding: Parameters<KeybindingsManager["getKeys"]>[0],
 	fallback: string,
+	additionalKeys: readonly string[] = [],
 ) {
-	const keys = keybindings
-		.getKeys(binding)
+	const keys = [...new Set([...keybindings.getKeys(binding), ...additionalKeys])]
 		.map(String)
 		.map((key) => {
 			if (key === "return") return "enter";

--- a/packages/pi-sync/test/custom-lifecycle.test.ts
+++ b/packages/pi-sync/test/custom-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { initTheme } from "@earendil-works/pi-coding-agent";
+import { initTheme, type KeybindingsManager } from "@earendil-works/pi-coding-agent";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext } from "../../../test/support.js";
@@ -101,63 +101,81 @@ test("external disposal aborts and drains an active custom operation", async () 
 	});
 });
 
-test("user cancellation aborts and drains an active custom operation", async () => {
+test.each([
+	["configured key", "q"],
+	["hard Ctrl+C", "\u0003"],
+])(
+	"user cancellation via %s aborts and drains an active custom operation",
+	async (_name, input) => {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			writeFileSync(localConfigPath(), JSON.stringify(settings()), { mode: 0o600 });
+			const tui = createTuiHarness({
+				width: 48,
+				rows: 16,
+				keybindings: remappedCancelKeybindings(),
+			});
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				custom: tui.custom,
+			});
+			let routeSignal: AbortSignal | undefined;
+			let reportRouteStarted: () => void = () => undefined;
+			const routeStarted = new Promise<void>((resolve) => {
+				reportRouteStarted = resolve;
+			});
+			let releaseRoute: () => void = () => undefined;
+			const routeGate = new Promise<void>((resolve) => {
+				releaseRoute = resolve;
+			});
+			let managerSettled = false;
+			const running = showSyncManager(ctx, async (route, signal) => {
+				if (route !== "sync") return undefined;
+				routeSignal = signal;
+				reportRouteStarted();
+				await routeGate;
+				return undefined;
+			});
+			void running.then(() => {
+				managerSettled = true;
+			});
+
+			await tui.waitForOpen();
+			tui.press("tui.select.confirm");
+			await routeStarted;
+			await waitForFrame(tui, /Checking current sync setup/u);
+			const loaderOpenCount = tui.openCount;
+			const frame = tui.render().join("\n");
+			assert.match(frame, /q\/ctrl\+c cancel/u);
+			assert.equal(frame.match(/ctrl\+c/gu)?.length, 1);
+			for (const line of frame.split("\n")) assert.ok(line.length <= 48);
+			tui.send(input);
+			await flushAsync();
+			try {
+				assert.equal(routeSignal?.aborted, true);
+				assert.equal(managerSettled, false);
+				releaseRoute();
+				await closeReturnedMenu(tui, loaderOpenCount, () => managerSettled);
+			} finally {
+				releaseRoute();
+				if (tui.isOpen) tui.dispose();
+			}
+			await running;
+			assert.match(notifications.at(-1)?.message ?? "", /cancelled/u);
+		});
+	},
+);
+
+test("commit-aware hard cancellation stays open until the active operation settles", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		writeFileSync(localConfigPath(), JSON.stringify(settings()), { mode: 0o600 });
-		const tui = createTuiHarness({ width: 48, rows: 16 });
-		const { ctx, notifications } = createMockContext({
-			hasUI: true,
-			mode: "tui",
-			custom: tui.custom,
+		const tui = createTuiHarness({
+			width: 48,
+			rows: 16,
+			keybindings: remappedCancelKeybindings(),
 		});
-		let routeSignal: AbortSignal | undefined;
-		let reportRouteStarted: () => void = () => undefined;
-		const routeStarted = new Promise<void>((resolve) => {
-			reportRouteStarted = resolve;
-		});
-		let releaseRoute: () => void = () => undefined;
-		const routeGate = new Promise<void>((resolve) => {
-			releaseRoute = resolve;
-		});
-		let managerSettled = false;
-		const running = showSyncManager(ctx, async (route, signal) => {
-			if (route !== "sync") return undefined;
-			routeSignal = signal;
-			reportRouteStarted();
-			await routeGate;
-			return undefined;
-		});
-		void running.then(() => {
-			managerSettled = true;
-		});
-
-		await tui.waitForOpen();
-		tui.press("tui.select.confirm");
-		await routeStarted;
-		await waitForFrame(tui, /Checking current sync setup/u);
-		const loaderOpenCount = tui.openCount;
-		tui.press("tui.select.cancel");
-		await flushAsync();
-		try {
-			assert.equal(routeSignal?.aborted, true);
-			assert.equal(managerSettled, false);
-			releaseRoute();
-			await closeReturnedMenu(tui, loaderOpenCount, () => managerSettled);
-		} finally {
-			releaseRoute();
-			if (tui.isOpen) tui.dispose();
-		}
-		await running;
-		assert.match(notifications.at(-1)?.message ?? "", /cancelled/u);
-	});
-});
-
-test("commit-aware cancellation stays open until the active operation settles", async () => {
-	await withTempHome(async (agentDir) => {
-		mkdirSync(agentDir, { recursive: true });
-		writeFileSync(localConfigPath(), JSON.stringify(settings()), { mode: 0o600 });
-		const tui = createTuiHarness({ width: 48, rows: 16 });
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
 			mode: "tui",
@@ -189,7 +207,8 @@ test("commit-aware cancellation stays open until the active operation settles", 
 		tui.press("tui.select.confirm");
 		await routeStarted;
 		await waitForFrame(tui, /Checking current sync setup/u);
-		tui.press("tui.select.cancel");
+		assert.match(tui.render().join("\n"), /q\/ctrl\+c cancel/u);
+		tui.press("ctrl+c");
 		try {
 			assert.equal(routeSignal?.aborted, false);
 			assert.match(notifications.at(-1)?.message ?? "", /cannot be cancelled safely/u);
@@ -203,6 +222,23 @@ test("commit-aware cancellation stays open until the active operation settles", 
 		await running;
 	});
 });
+
+function remappedCancelKeybindings(): Pick<KeybindingsManager, "matches" | "getKeys"> {
+	return {
+		matches(data, binding) {
+			if (binding === "tui.select.cancel") return data === "q";
+			if (binding === "tui.select.confirm" || binding === "tui.input.submit") {
+				return data === "\r";
+			}
+			return false;
+		},
+		getKeys(binding) {
+			if (binding === "tui.select.cancel") return ["q"];
+			if (binding === "tui.select.confirm" || binding === "tui.input.submit") return ["enter"];
+			return [];
+		},
+	};
+}
 
 function settings() {
 	return {

--- a/packages/pi-sync/test/secret-input.test.ts
+++ b/packages/pi-sync/test/secret-input.test.ts
@@ -88,9 +88,31 @@ test("masked secret input uses injected submit and cancellation keybindings", as
 	const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
 	const pending = promptSecret(ctx, "Password");
 	await tui.waitForOpen();
-	assert.match(tui.render().join("\n"), /s save • q cancel/u);
+	const frame = tui.render().join("\n");
+	assert.match(frame, /s save • q\/ctrl\+c cancel/u);
+	assert.equal(frame.match(/ctrl\+c/gu)?.length, 1);
 	tui.send("q");
 	assert.equal(await pending, undefined);
+});
+
+test("masked secret input keeps Ctrl+C when cancellation is remapped", async () => {
+	const mapping: Record<string, string> = {
+		"tui.input.submit": "s",
+		"tui.select.cancel": "q",
+	};
+	const keybindings: Pick<KeybindingsManager, "matches" | "getKeys"> = {
+		matches: (data, binding) => data === mapping[binding],
+		getKeys: (binding) => (mapping[binding] ? [mapping[binding] as never] : []),
+	};
+	const tui = createTuiHarness({ width: 40, keybindings });
+	const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+	const pending = promptSecret(ctx, "Password");
+	await tui.waitForOpen();
+	tui.type("secret");
+	assert.doesNotMatch(tui.render().join("\n"), /secret/u);
+	tui.press("ctrl+c");
+	assert.equal(await pending, undefined);
+	assert.equal(tui.isOpen, false);
 });
 
 test("a stale secret prompt never creates its masked component", async () => {

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -196,6 +196,7 @@ Owner replacement remains `stale` and takes precedence over any racing Close eve
 
 For abort-aware work outside a menu, use `runTask()`.
 TUI mode shows the Kit's Pi-styled cancellable bordered loader; RPC, print, and JSON execute the same task directly.
+The effective cancellation bindings are shown in the loader, and Ctrl+C remains a hard-cancel input when those bindings are remapped.
 User cancellation, owner replacement, external component disposal, errors, and successful completion remain distinct typed results.
 
 ```ts

--- a/packages/pi-tui-kit/src/components/task-loader.ts
+++ b/packages/pi-tui-kit/src/components/task-loader.ts
@@ -44,9 +44,10 @@ export class TaskLoader extends Container {
 		if (this.disposed || !this.cancellable) return;
 		const matches = this.keybindings.matches;
 		const cancelled =
-			typeof matches === "function"
+			matchesKey(data, Key.ctrl("c")) ||
+			(typeof matches === "function"
 				? matches.call(this.keybindings, data, "tui.select.cancel")
-				: matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"));
+				: matchesKey(data, Key.escape));
 		if (cancelled) this.onAbort?.();
 	}
 
@@ -59,10 +60,9 @@ export class TaskLoader extends Container {
 
 function cancelKeyText(keybindings: MenuKeybindings): string {
 	const getKeys = keybindings.getKeys;
-	const keys =
-		typeof getKeys === "function"
-			? getKeys.call(keybindings, "tui.select.cancel")
-			: ["escape", "ctrl+c"];
+	const configuredKeys =
+		typeof getKeys === "function" ? getKeys.call(keybindings, "tui.select.cancel") : ["escape"];
+	const keys = [...new Set([...configuredKeys, "ctrl+c"])];
 	return keys.map(displayKey).join("/");
 }
 

--- a/packages/pi-tui-kit/test/task.test.ts
+++ b/packages/pi-tui-kit/test/task.test.ts
@@ -29,7 +29,10 @@ test("runTask executes directly outside TUI without opening custom UI", async ()
 });
 
 test("runTask user cancellation aborts and drains the task before returning", async () => {
+	let ctrlCHintCount = 0;
 	let observedAbort = false;
+	let observedAbortAfterInput = false;
+	let resultBeforeDrain: unknown = "not-observed";
 	let settled = false;
 	let releaseDrain: (() => void) | undefined;
 	const drain = new Promise<void>((resolve) => {
@@ -40,10 +43,12 @@ test("runTask user cancellation aborts and drains the task before returning", as
 		hasUI: true,
 		custom: async (factory: unknown) => {
 			const harness = createCustomSelectorHarness(factory, 40);
+			const frame = harness.render().join("\n");
+			ctrlCHintCount = frame.match(/ctrl\+c/gu)?.length ?? 0;
 			harness.handleInput("tui.select.cancel");
 			await new Promise<void>((resolve) => setImmediate(resolve));
-			assert.equal(observedAbort, true);
-			assert.equal(harness.result, undefined);
+			observedAbortAfterInput = observedAbort;
+			resultBeforeDrain = harness.result;
 			releaseDrain?.();
 			return harness.resultPromise;
 		},
@@ -75,10 +80,14 @@ test("runTask user cancellation aborts and drains the task before returning", as
 
 	assert.deepEqual(result, { kind: "cancelled" });
 	assert.equal(settled, true);
+	assert.equal(ctrlCHintCount, 1);
+	assert.equal(observedAbortAfterInput, true);
+	assert.equal(resultBeforeDrain, undefined);
 });
 
 test("runTask uses callback-injected cancellation keys and renders their hint", async () => {
 	let abortedAfterInjectedKey = false;
+	let renderedFrame: readonly string[] = [];
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
@@ -87,10 +96,7 @@ test("runTask uses callback-injected cancellation keys and renders their hint", 
 				matches: (data, binding) => binding === "tui.select.cancel" && data === "x",
 				getKeys: (binding) => (binding === "tui.select.cancel" ? ["x"] : []),
 			});
-			const frame = harness.render();
-			assert.equal(frame[0], "─".repeat(40));
-			assert.equal(frame.at(-1), "─".repeat(40));
-			assert.match(frame.join("\n"), /x cancel/u);
+			renderedFrame = harness.render();
 			harness.handleInput("x");
 			await new Promise<void>((resolve) => setImmediate(resolve));
 			abortedAfterInjectedKey = taskSignal?.aborted ?? false;
@@ -117,6 +123,48 @@ test("runTask uses callback-injected cancellation keys and renders their hint", 
 
 	assert.equal(abortedAfterInjectedKey, true);
 	assert.deepEqual(result, { kind: "cancelled" });
+	assert.equal(renderedFrame[0], "─".repeat(40));
+	assert.equal(renderedFrame.at(-1), "─".repeat(40));
+	assert.match(renderedFrame.join("\n"), /x\/ctrl\+c cancel/u);
+});
+
+test("runTask keeps Ctrl+C as hard cancel when the configured key is remapped", async () => {
+	let renderedFrame = "";
+	let taskSignal: AbortSignal | undefined;
+	let taskSettled = false;
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 40, {
+				matches: (data, binding) => binding === "tui.select.cancel" && data === "x",
+				getKeys: (binding) => (binding === "tui.select.cancel" ? ["x"] : []),
+			});
+			renderedFrame = harness.render().join("\n");
+			harness.handleInput("\u0003");
+			return harness.resultPromise;
+		},
+	});
+
+	const result = await runTask(context.ctx, {
+		label: "Loading",
+		task: async ({ signal }) => {
+			taskSignal = signal;
+			await new Promise<void>((resolve) => {
+				if (signal.aborted) resolve();
+				else signal.addEventListener("abort", () => resolve(), { once: true });
+			});
+			taskSettled = true;
+			return "late";
+		},
+	});
+
+	assert.equal(taskSignal?.aborted, true);
+	assert.equal(taskSettled, true);
+	assert.deepEqual(result, { kind: "cancelled" });
+	assert.match(renderedFrame, /x\/ctrl\+c cancel/u);
+	assert.equal(renderedFrame.match(/ctrl\+c/gu)?.length, 1);
+	for (const line of renderedFrame.split("\n")) assert.ok(line.length <= 40);
 });
 
 test("runTask non-cancellable mode ignores cancel input and hides the hint", async () => {
@@ -125,15 +173,21 @@ test("runTask non-cancellable mode ignores cancel input and hides the hint", asy
 		releaseTask = resolve;
 	});
 	let taskSignal: AbortSignal | undefined;
+	let renderedFrame = "";
+	let abortedAfterConfiguredCancel: boolean | undefined;
+	let abortedAfterHardCancel: boolean | undefined;
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
 		custom: async (factory: unknown) => {
 			const harness = createCustomSelectorHarness(factory, 40);
-			assert.doesNotMatch(harness.render().join("\n"), /cancel/iu);
+			renderedFrame = harness.render().join("\n");
 			harness.handleInput("tui.select.cancel");
 			await new Promise<void>((resolve) => setImmediate(resolve));
-			assert.equal(taskSignal?.aborted, false);
+			abortedAfterConfiguredCancel = taskSignal?.aborted;
+			harness.handleInput("\u0003");
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			abortedAfterHardCancel = taskSignal?.aborted;
 			releaseTask?.();
 			return harness.resultPromise;
 		},
@@ -150,6 +204,9 @@ test("runTask non-cancellable mode ignores cancel input and hides the hint", asy
 	});
 
 	assert.deepEqual(result, { kind: "completed", value: "done" });
+	assert.doesNotMatch(renderedFrame, /cancel/iu);
+	assert.equal(abortedAfterConfiguredCancel, false);
+	assert.equal(abortedAfterHardCancel, false);
 });
 
 test("runTask owner abort is stale and drains before closing TUI", async () => {


### PR DESCRIPTION
## Summary

- keep Ctrl+C as an independent hard-cancel input for Kit tasks, pi-sync operations and secret prompts, and the pi-statusline layout editor
- preserve configured Back behavior, async drainage, post-commit refusal, masked secret handling, and immediate settings saves
- derive deduplicated cancellation hints from effective bindings and document the behavior
- add patch Changeset entries for pi-tui-kit, pi-sync, and pi-statusline

## Verification

- `npm --workspace @narumitw/pi-tui-kit run check`
- `npm --workspace @narumitw/pi-sync run check`
- `npm --workspace @narumitw/pi-statusline run check`
- focused Vitest: 4 files, 57 tests
- `npm run check`
- `npm test` (387 files, 3,408 tests)
- `npm run changeset:status`
- `git diff --check`

An earlier full-suite run had one unrelated pi-subagents RPC telemetry assertion fail; that test passed alone, the immediate full rerun passed, and the final post-hardening full run passed.

## Audit

Reviewed against `docs/extension-conventions.md`, `docs/extension-settings.md`, and the three package `AGENTS.md` files.
Cancellation/disposal, stale ownership, commit safety, secret redaction, settings persistence, failure recovery, and width-bounded rendering have focused coverage.
No package metadata or runtime-loading boundary changed, so pack and Pi-loading smokes are not applicable.
No paths remain unverified.
