### PR TITLE
fix(tui-kit): bound framed menus to terminal height

### DIFF
--- a/.changeset/bounded-menu-frames.md
+++ b/.changeset/bounded-menu-frames.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": patch
+---
+
+Keep standard menu frames within the live terminal height while preserving actionable rows and exit hints.

--- a/packages/pi-sync/test/review-feedback.test.ts
+++ b/packages/pi-sync/test/review-feedback.test.ts
@@ -121,7 +121,7 @@ test("setup switch rejects a destination changed while its review is open", asyn
 			hasUI: true,
 			mode: "tui",
 			select: async (title: string) => {
-				if (title.startsWith("Manage sync")) {
+				if (title.includes("Manage sync")) {
 					mainVisits += 1;
 					return mainVisits === 1 ? "Switch sync setup" : undefined;
 				}

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import { type Input, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { HorizontalRule } from "../horizontal-rule.js";
 import { formatInteractionHints } from "../interaction-hints.js";
@@ -42,23 +43,70 @@ export function renderFrame<ScreenId extends string, ActionId extends string>(
 ): string[] {
 	const safeWidth = Math.max(1, width);
 	const rule = renderHorizontalRule(safeWidth, options.theme);
-	const result = [
+	const titleRows = wrapTextWithAnsi(
+		options.theme.fg("accent", options.theme.bold(safeMenuText(title))),
+		safeWidth,
+	);
+	const contextRows = lines.flatMap((line) =>
+		wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
+	);
+	const hintRows = wrapTextWithAnsi(
+		options.theme.fg("dim", menuHint(options.keybindings, destination, confirmAction)),
+		safeWidth,
+	);
+	const fullFrame = [
 		rule,
-		...wrapTextWithAnsi(
-			options.theme.fg("accent", options.theme.bold(safeMenuText(title))),
-			safeWidth,
-		),
-		...lines.flatMap((line) =>
-			wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
-		),
+		...titleRows,
+		...contextRows,
 		...(content.length > 0 ? ["", ...content] : []),
-		...wrapTextWithAnsi(
-			options.theme.fg("dim", menuHint(options.keybindings, destination, confirmAction)),
-			safeWidth,
-		),
+		...hintRows,
 		rule,
 	];
+	const maxRows = terminalRows(options.tui.terminal.rows);
+	const result =
+		fullFrame.length <= maxRows
+			? fullFrame
+			: compactFrame(rule, titleRows, contextRows, content, hintRows, maxRows);
 	return result.map((line) => truncateToWidth(line, safeWidth, ""));
+}
+
+function compactFrame(
+	rule: string,
+	titleRows: readonly string[],
+	contextRows: readonly string[],
+	contentRows: readonly string[],
+	hintRows: readonly string[],
+	maxRows: number,
+): string[] {
+	if (maxRows === 1) {
+		return [titleRows[0] ?? contentRows[0] ?? hintRows.at(-1) ?? rule];
+	}
+	if (maxRows === 2) return [rule, rule];
+	if (maxRows === 3) return [rule, titleRows[0] ?? contentRows[0] ?? hintRows.at(-1) ?? "", rule];
+	const boundedTitle = titleRows.slice(0, 1);
+	const hintBudget = Math.min(hintRows.length, Math.max(0, maxRows - 2 - boundedTitle.length));
+	const boundedHints = hintBudget > 0 ? hintRows.slice(-hintBudget) : [];
+	const bodyBudget = Math.max(0, maxRows - 2 - boundedTitle.length - boundedHints.length);
+	const boundedContent = focusedRows(contentRows, Math.min(contentRows.length, bodyBudget));
+	const contextBudget = Math.max(0, bodyBudget - boundedContent.length);
+	const boundedContext = contextRows.slice(0, contextBudget);
+	return [rule, ...boundedTitle, ...boundedContext, ...boundedContent, ...boundedHints, rule].slice(
+		0,
+		maxRows,
+	);
+}
+
+function focusedRows(rows: readonly string[], budget: number): readonly string[] {
+	if (budget <= 0) return [];
+	if (rows.length <= budget) return rows;
+	const selectedIndex = rows.findIndex((line) => /^[→›]\s/u.test(stripVTControlCharacters(line)));
+	if (selectedIndex < 0) return rows.slice(0, budget);
+	const start = Math.max(0, Math.min(selectedIndex - Math.floor(budget / 2), rows.length - budget));
+	return rows.slice(start, start + budget);
+}
+
+function terminalRows(rows: number) {
+	return Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : 24;
 }
 
 export function renderHorizontalRule(

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -169,6 +169,46 @@ test("standard screens remain bounded and sanitize terminal controls", () => {
 	}
 });
 
+test("action screens prioritize actionable rows when terminal height is constrained", () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		...actionScreen,
+		lines: [
+			"Sync paused: owner unknown.",
+			"Close other Pi sessions then restore; Settings and More return.",
+		],
+		items: [
+			{ id: "restore", label: "Restore sync access… (recommended)", action: "run" },
+			{ id: "status", label: "Status & changes", action: "run" },
+			{ id: "history", label: "History & recovery…", to: "detail" },
+			{ id: "help", label: "Help", action: "run" },
+		],
+	};
+	const harness = componentHarness(screen, {
+		plainTheme: true,
+		rows: 12,
+		keybindings: inputFriendlyKeybindings,
+	});
+	const lines = plainRender(harness.component, 32);
+	assert.ok(lines.length <= 12);
+	assert.equal(lines[0], "─".repeat(32));
+	assert.equal(lines.at(-1), "─".repeat(32));
+	assert.match(lines.join("\n"), /→ Restore sync access/u);
+	assert.match(lines.join("\n"), /esc\s+close/u);
+
+	const tinyHarness = componentHarness(screen, {
+		selectedItemId: "help",
+		plainTheme: true,
+		rows: 7,
+		keybindings: inputFriendlyKeybindings,
+	});
+	const tinyLines = plainRender(tinyHarness.component, 32);
+	assert.ok(tinyLines.length <= 7);
+	assert.equal(tinyLines[0], "─".repeat(32));
+	assert.equal(tinyLines.at(-1), "─".repeat(32));
+	assert.match(tinyLines.join("\n"), /→ Help/u);
+	assert.match(tinyLines.join("\n"), /esc\s+close/u);
+});
+
 test("action screens honor injected navigation and distinguish Back from Ctrl+C Close", () => {
 	const selected = componentHarness(actionScreen, { selectedItemId: "detail" });
 	selected.component.handleInput("l");
@@ -1073,6 +1113,7 @@ function componentHarness(
 		selectedItemId?: string;
 		themePrefix?: () => string;
 		plainTheme?: boolean;
+		rows?: number;
 		keybindings?: {
 			matches(data: string, binding: string): boolean;
 			getKeys(binding: string): readonly string[];
@@ -1096,7 +1137,7 @@ function componentHarness(
 	const component = createMenuScreenComponent({
 		screen,
 		selectedItemId: options.selectedItemId,
-		tui: { terminal: { rows: 24 }, requestRender() {} },
+		tui: { terminal: { rows: options.rows ?? 24 }, requestRender() {} },
 		theme: {
 			fg(color: string, text: string) {
 				if (options.plainTheme) return text;


### PR DESCRIPTION
## Summary

- compact framed menu content against the live terminal row budget
- keep the selected action and exit hints visible in constrained layouts
- make the pi-sync stale-preview test compatible with framed menu titles
- add a patch changeset for `@narumitw/pi-tui-kit`

## Verification

- `npm run check`
- `npm test` (3,410 tests)
- release-branch reproduction with current local TUI Kit (63 focused tests)
- `npm pack --workspace @narumitw/pi-tui-kit --dry-run --json`