### PR TITLE
fix(usage): resolve active named OAuth credentials

### DIFF
--- a/.changeset/active-oauth-usage.md
+++ b/.changeset/active-oauth-usage.md
@@ -1,0 +1,6 @@
+---
+"@narumitw/pi-accounts": patch
+"@narumitw/pi-usage": patch
+---
+
+Allow current-account consumers to verify named OAuth credentials through a process-local protocol, including GitHub Copilot usage and OpenAI Codex reset flows.

--- a/docs/api/oauth-credential-source-v1.md
+++ b/docs/api/oauth-credential-source-v1.md
@@ -1,0 +1,196 @@
+# OAuth Credential Source Protocol v1
+
+- **Status:** Implemented process-local protocol.
+- **Transport:** Pi's process-local `pi.events` bus.
+- **Purpose:** Let a credential consumer verify the OAuth credential that produced the active runtime authentication without depending on a credential owner's storage.
+
+## Scope
+
+This protocol is an anonymous, synchronous request-and-offer exchange between trusted Pi extensions in one process.
+
+It does not identify credential owners, select or switch accounts, expose account labels, read another extension's files, synchronize credentials across processes, or authorize a credential without provider-specific verification.
+
+The words **MUST**, **MUST NOT**, **SHOULD**, and **MAY** are normative.
+
+## Contract
+
+The v1 channel is:
+
+```text
+oauth:credential-source:v1
+```
+
+The channel identifies the version, so the payload does not repeat it.
+
+The v1 request is:
+
+```ts
+interface OAuthCredentialSourceRequestV1 {
+	session: object;
+	provider: string;
+	offer: (credential: OAuthCredentialV1) => void;
+}
+
+interface OAuthCredentialV1 {
+	type: "oauth";
+	access: string;
+	refresh: string;
+	expires: number;
+	[key: string]: unknown;
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `session` | The current `ctx.sessionManager` object, compared by JavaScript identity. |
+| `provider` | The requested Pi provider ID, compared by exact string equality. |
+| `offer` | A synchronous callback that receives one defensive credential clone. |
+
+Unknown request properties have no protocol meaning.
+
+A conforming request MUST NOT include an extension name, account name, account label, file path, or persistence identifier.
+
+## Credential owner behavior
+
+A credential owner MUST register one listener during extension factory registration.
+
+The listener MUST be synchronous, return `void`, perform no asynchronous work, and contain no `await`.
+
+The listener MUST use guarded property reads and ignore malformed requests without throwing.
+
+A request is relevant only when all of these conditions hold:
+
+1. The payload is a non-null, non-array object.
+2. `session` is the exact object currently bound to the owner.
+3. `provider` is a non-empty string and exactly matches the retained credential's provider.
+4. `offer` is a function.
+5. The retained OAuth credential successfully produced and verified the currently active runtime authentication.
+6. No activation, replacement, invalidation, default-auth transition, or shutdown has made that retained state stale.
+
+For a relevant request, the owner MUST pass a fresh defensive clone to `offer`.
+
+The owner MUST catch an exception thrown by `offer` and MUST NOT let it interrupt sibling event listeners or runtime authentication.
+
+The owner MUST NOT emit another credential-source event, read storage, refresh OAuth, start work, persist data, show UI, log credential material, or mutate account state while answering.
+
+The owner MUST retain no credential before successful runtime verification and MUST clear retained credentials before beginning replacement, switching to default authentication, invalidation, failed-closed activation, session replacement, reload, or shutdown.
+
+A stale asynchronous task MUST NOT republish an older credential after a newer task clears or replaces it.
+
+## Credential consumer behavior
+
+A consumer MUST create a fresh request for the current `ctx.sessionManager` and exact provider ID.
+
+The consumer MUST collect offers synchronously during `pi.events.emit()` and MUST finish collection when `emit()` returns.
+
+The consumer MUST catch an `emit()` failure and fail closed.
+
+The offer callback MUST validate and defensively clone candidate objects without throwing.
+
+Candidates are ephemeral.
+
+A consumer MUST NOT cache, persist, log, format, display, or append offered credential material to a session entry.
+
+A consumer MAY add Pi's stored `auth.json` OAuth credential as a standalone fallback after event collection.
+
+The fallback has no precedence over protocol offers.
+
+The provider-specific consumer MUST freshly resolve active runtime authentication and accept only credentials whose access token and required provider metadata exactly match it.
+
+Equivalent matching candidates MAY be deduplicated.
+
+If more than one non-equivalent credential matches, selection MUST fail closed and MUST NOT depend on event-listener order.
+
+Malformed, incomplete, mismatched, unsupported-origin, or irrelevant-provider candidates MUST NOT authorize a provider request.
+
+The consumer MUST revalidate mutable session, model, provider, account, and runtime-auth state after every `await` required by its flow and immediately before an external mutation.
+
+## Lifecycle
+
+Credential state is process-local and session-bound.
+
+The owner binds the exact current `ctx.sessionManager` object on `session_start` and clears that binding on `session_shutdown` or replacement.
+
+Pi removes tracked `pi.events` listeners when an extension runtime becomes stale, but owners MUST still clear retained credentials explicitly.
+
+A replacement runtime starts with no retained credential and must verify active runtime authentication again before offering one.
+
+A consumer request for a different session object receives no conforming offer even when the underlying session data is otherwise equivalent.
+
+## Security and privacy
+
+Pi extensions run with the user's process privileges, and `pi.events` is not a security boundary between installed extensions.
+
+Users must install only trusted extensions.
+
+This protocol reduces accidental coupling and disclosure; it does not sandbox a malicious extension that can already read user files and process memory.
+
+Credential offers contain no protocol-level owner identity or account label.
+
+Provider-specific consumers MUST send secrets only to validated official origins and MUST redact secrets from errors, reports, logs, status text, UI, and test output.
+
+## Standalone and compatibility behavior
+
+A credential owner remains independently functional when no consumer is installed because unanswered protocol support has no account behavior.
+
+A consumer remains independently functional when no owner is installed by using its existing Pi `auth.json` fallback.
+
+An absent, older, or incompatible participant degrades to the consumer's existing fail-closed authentication-unavailable behavior.
+
+A participant MUST NOT import, name, detect, or require a specific extension package.
+
+Production implementations remain package-local and communicate only through this protocol and Pi's public APIs.
+
+## Guarantees
+
+When conforming participants share one characterized Pi runtime and one session:
+
+- A verified active OAuth credential can be offered without exposing credential-owner storage.
+- A stale, pending, default, failed, replaced, or shut-down owner offers nothing.
+- Exact provider and session identity isolate unrelated requests.
+- Provider-specific exact runtime-auth matching prevents an unrelated credential from authorizing usage or mutation.
+- Listener order cannot choose between conflicting matching credentials.
+- Installing either participant alone preserves its standalone behavior.
+
+## Non-guarantees
+
+The protocol does not provide:
+
+- A sandbox or security boundary between installed extensions.
+- Cross-process delivery, persistence, account synchronization, discovery, or switching.
+- Credential-owner identity, priority, fairness, precedence, or freshness beyond participant verification.
+- Support for unknown providers, proxy endpoints, or GitHub Enterprise usage.
+- Compatibility with uncharacterized Pi event-bus timing or separately loaded Pi runtimes.
+
+## Versioning
+
+The versioned channel MUST change for a breaking change.
+
+Changing field meaning, callback timing, session identity, cloning requirements, conflict handling, or lifecycle invalidation is breaking.
+
+V1 participants MUST NOT infer compatibility with an unknown channel version.
+
+A future version may coexist on a separate channel only when its specification defines deterministic multi-version offer and conflict behavior.
+
+## Required Pi behavior
+
+The deterministic characterization in [`test/oauth-credential-source-runtime.test.ts`](../../test/oauth-credential-source-runtime.test.ts) covers the repository's pinned `@earendil-works/pi-coding-agent@0.84.3` runtime through public package-root APIs.
+
+V1 depends on these Pi runtime properties:
+
+1. Loaded extensions share one process-local event bus.
+2. `pi.events.emit()` starts every registered listener synchronously before returning.
+3. All extension contexts for one active session expose the same `sessionManager` object identity.
+4. Stale extension runtimes unsubscribe their tracked event-bus listeners.
+
+Only offers made before a listener first yields are visible during synchronous collection.
+
+If a supported Pi version stops satisfying any property, participants MUST fail safe and withdraw the v1 compatibility claim until the protocol or runtime support is revised.
+
+## Product conformance
+
+A conforming credential owner must test successful publication, defensive cloning, pending and stale suppression, replacement, default authentication, failed activation, session replacement, shutdown, malformed requests, throwing callbacks, and stale asynchronous completion.
+
+A conforming consumer must test no listener, fallback, one match, duplicate equivalence, conflicts in both listener orders, malformed and mismatched candidates, listener failure, exact provider metadata, official origins, redaction, cancellation, account changes after each await, replacement, and shutdown.
+
+Cross-extension conformance must test both load orders, standalone behavior, account switching, generated entries, and absence of production imports between participants.

--- a/packages/pi-accounts/README.md
+++ b/packages/pi-accounts/README.md
@@ -12,6 +12,7 @@ Each selection overrides only the chosen provider, and selecting `default` resto
 - Keeps an independent selected account—or Pi's default login—for each provider.
 - Applies provider-specific credentials, endpoints, headers, and model availability through Pi's built-in providers.
 - Refreshes rotating credentials safely and verifies effective runtime authentication before reporting success.
+- Makes only the verified active OAuth credential available process-locally to compatible current-account consumers.
 - Stores credentials atomically in a private local file and fails closed for the affected provider on activation errors.
 - Migrates legacy `pi-codex-accounts.json` data while preserving its rollback source.
 
@@ -116,7 +117,7 @@ Choosing `default` restores Pi's built-in login for that provider.
 Removing an account lists named accounts as `Provider · account`, asks for confirmation, then removes the credential.
 Removing an active account automatically restores that provider to Pi's built-in login.
 
-## 🔐 Auth and fail-closed behavior
+## 🔒 Security and privacy
 
 Each selected account is refreshed through the provider's own OAuth `refresh()` implementation and converted through `toAuth()`.
 The extension then applies the returned API key, headers, and endpoint, verifies the effective runtime state, and reports success.
@@ -127,6 +128,18 @@ Other providers remain independent and usable.
 
 Selecting `default` removes the package-owned runtime override and restores the exact provider registration that existed before activation.
 Pi's built-in credentials are never deleted.
+
+The extension implements the versioned `oauth:credential-source:v1` protocol for compatible current-account consumers such as usage reporters.
+It offers a fresh in-memory clone only after the named OAuth credential has produced and verified the active runtime authentication for the exact Pi session.
+Pending, default, stale, failed, replaced, reloaded, and shut-down states offer nothing.
+The offer contains no account name or extension identity and is never persisted or logged by the protocol.
+A consumer must still match the offered access token and provider-specific metadata against freshly resolved runtime auth before using it.
+Installing `pi-accounts` without a compatible consumer does not change account activation behavior.
+An older or absent consumer simply does not request the credential.
+
+Pi extensions run with the user's process privileges, and the shared event bus is not a security boundary between installed extensions.
+Install only trusted extensions because any installed extension may already read user files and process memory.
+The protocol reduces accidental credential coupling; it does not sandbox malicious code.
 
 GitHub Copilot's `availableModelIds` are projected into the active provider model list.
 Switching Copilot accounts rebuilds the projection from the complete pre-overlay model catalog.
@@ -184,6 +197,7 @@ packages/pi-accounts/
 │   ├── account-store.ts
 │   ├── accounts.ts
 │   ├── oauth.ts
+│   ├── oauth-credential-source.ts
 │   ├── runtime-auth.ts
 │   └── storage.ts
 ├── dist/               # Generated source-mapped Jiti runtime

--- a/packages/pi-accounts/src/accounts.ts
+++ b/packages/pi-accounts/src/accounts.ts
@@ -20,6 +20,7 @@ import {
 	loginWithOAuthUI,
 	SUPPORTED_PROVIDER_IDS,
 } from "./oauth.js";
+import { registerOAuthCredentialSource } from "./oauth-credential-source.js";
 import {
 	type EnsureActiveProviderAuthResult,
 	RUNTIME_FAIL_CLOSED_API_KEY,
@@ -65,6 +66,7 @@ export default function accountsExtension(
 	const coordinators = new Map(
 		providers.map((provider) => [provider.id, new RuntimeAuthCoordinator(pi, provider)]),
 	);
+	registerOAuthCredentialSource(pi, [...coordinators.values()]);
 	const results = new Map<AccountProviderId, EnsureActiveProviderAuthResult>();
 	const appliedIdentities = new Map<AccountProviderId, string>();
 	const abortProviders = new Set<AccountProviderId>();
@@ -83,10 +85,11 @@ export default function accountsExtension(
 			const coordinator = coordinators.get(providerId);
 			if (!coordinator) throw new Error(`Missing runtime coordinator for ${providerId}.`);
 			let result = await coordinator.ensureActive(ctx, store);
+			let identity: string | undefined;
 			let latest = syncTasks.get(providerId);
 			if (latest && latest !== task) return latest;
 			try {
-				const identity = await authIdentity(store, result);
+				identity = await authIdentity(store, result);
 				latest = syncTasks.get(providerId);
 				if (latest && latest !== task) return latest;
 				const previousIdentity = appliedIdentities.get(providerId);
@@ -114,6 +117,7 @@ export default function accountsExtension(
 			}
 			latest = syncTasks.get(providerId);
 			if (latest && latest !== task) return latest;
+			coordinator.publishCredentialOffer(ctx, result, identity ?? "");
 			results.set(providerId, result);
 			updateStatus(ctx, results, model);
 			return result;
@@ -148,6 +152,7 @@ export default function accountsExtension(
 		sessionGeneration += 1;
 		menuController.abort(new DOMException("Accounts session replaced", "AbortError"));
 		menuController = new AbortController();
+		for (const coordinator of coordinators.values()) coordinator.invalidate(ctx);
 		if (migrationNotice) {
 			ctx.ui.notify(migrationNotice, "warning");
 			migrationNotice = undefined;

--- a/packages/pi-accounts/src/oauth-credential-source.ts
+++ b/packages/pi-accounts/src/oauth-credential-source.ts
@@ -1,0 +1,50 @@
+import type { OAuthCredential } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export const OAUTH_CREDENTIAL_SOURCE_CHANNEL = "oauth:credential-source:v1";
+
+export type OAuthCredentialSourceRequest = {
+	session: object;
+	provider: string;
+	offer: (credential: OAuthCredential) => void;
+};
+
+export type OAuthCredentialSource = {
+	offerCredential(data: unknown): void;
+};
+
+export function registerOAuthCredentialSource(
+	pi: ExtensionAPI,
+	sources: Iterable<OAuthCredentialSource>,
+): void {
+	pi.events.on(OAUTH_CREDENTIAL_SOURCE_CHANNEL, (data) => {
+		for (const source of sources) source.offerCredential(data);
+	});
+}
+
+export function parseCredentialRequest(data: unknown): OAuthCredentialSourceRequest | undefined {
+	try {
+		if (!data || typeof data !== "object" || Array.isArray(data)) return undefined;
+		const request = data as Partial<OAuthCredentialSourceRequest>;
+		if (!request.session || typeof request.session !== "object") return undefined;
+		if (typeof request.provider !== "string" || !request.provider) return undefined;
+		if (typeof request.offer !== "function") return undefined;
+		return request as OAuthCredentialSourceRequest;
+	} catch {
+		return undefined;
+	}
+}
+
+export function cloneOAuthCredential(credential: OAuthCredential): OAuthCredential | undefined {
+	try {
+		const clone = structuredClone(credential) as OAuthCredential;
+		if (!clone || typeof clone !== "object" || Array.isArray(clone)) return undefined;
+		if (clone.type !== "oauth") return undefined;
+		if (typeof clone.access !== "string" || !clone.access) return undefined;
+		if (typeof clone.refresh !== "string" || !clone.refresh) return undefined;
+		if (typeof clone.expires !== "number" || !Number.isFinite(clone.expires)) return undefined;
+		return clone;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/pi-accounts/src/runtime-auth.ts
+++ b/packages/pi-accounts/src/runtime-auth.ts
@@ -1,6 +1,7 @@
 import type { ModelAuth, OAuthCredential, ProviderHeaders } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { AccountProviderAdapter, AccountProviderId } from "./oauth.js";
+import { cloneOAuthCredential, parseCredentialRequest } from "./oauth-credential-source.js";
 
 export const RUNTIME_FAIL_CLOSED_API_KEY = "pi-accounts-auth-failed";
 const REFRESH_SKEW_MS = 5 * 60 * 1000;
@@ -30,6 +31,18 @@ type ProviderAccountState = {
 	accounts: Record<string, OAuthCredential>;
 };
 
+type PendingCredentialOffer = {
+	accountName: string;
+	credential: OAuthCredential;
+	operation: number;
+	session: object;
+};
+
+type ActiveCredentialOffer = {
+	credential: OAuthCredential;
+	session: object;
+};
+
 export type RuntimeAccountStore = {
 	readProviderAsync(providerId: AccountProviderId): Promise<ProviderAccountState>;
 	updateProviderAsync(
@@ -48,6 +61,8 @@ export class RuntimeAuthCoordinator {
 	private readonly overlay: RuntimeProviderOverlay;
 	private availableModelIds: ReadonlySet<string> | undefined;
 	private refreshController = new AbortController();
+	private pendingCredentialOffer: PendingCredentialOffer | undefined;
+	private activeCredentialOffer: ActiveCredentialOffer | undefined;
 
 	constructor(
 		pi: ExtensionAPI,
@@ -63,6 +78,7 @@ export class RuntimeAuthCoordinator {
 		store: RuntimeAccountStore,
 		now = Date.now(),
 	): Promise<EnsureActiveProviderAuthResult> {
+		this.clearCredentialOffer();
 		const operation = this.overlay.beginOperation();
 		const runtimeOverride = this.controller.begin(ctx);
 		const refreshSignal = this.refreshController.signal;
@@ -101,7 +117,12 @@ export class RuntimeAuthCoordinator {
 			} catch (error) {
 				return this.failClosed(ctx, operation, runtimeOverride, active, error);
 			}
-			if (current.active) return this.ensureActive(ctx, store, now);
+			if (current.active) {
+				if (!this.overlay.isCurrent(operation)) {
+					return { status: "inactive", providerId: this.provider.id };
+				}
+				return this.ensureActive(ctx, store, now);
+			}
 			this.availableModelIds = undefined;
 			await this.controller.clear(ctx);
 			this.overlay.remove(ctx, operation);
@@ -136,6 +157,9 @@ export class RuntimeAuthCoordinator {
 				credential = getOwnCredential(current.accounts, active) ?? credential;
 			}
 			if (current.active !== active || !getOwnCredential(current.accounts, active)) {
+				if (!this.overlay.isCurrent(operation)) {
+					return { status: "inactive", providerId: this.provider.id };
+				}
 				return this.ensureActive(ctx, store, now);
 			}
 			if (refreshError !== undefined) {
@@ -150,7 +174,12 @@ export class RuntimeAuthCoordinator {
 						credential,
 					);
 				}
-				if (!selection.matches) return this.ensureActive(ctx, store, now);
+				if (!selection.matches) {
+					if (!this.overlay.isCurrent(operation)) {
+						return { status: "inactive", providerId: this.provider.id };
+					}
+					return this.ensureActive(ctx, store, now);
+				}
 				return this.failClosed(ctx, operation, runtimeOverride, active, refreshError, credential);
 			}
 		}
@@ -171,7 +200,12 @@ export class RuntimeAuthCoordinator {
 					credential,
 				);
 			}
-			if (!selection.matches) return this.ensureActive(ctx, store, now);
+			if (!selection.matches) {
+				if (!this.overlay.isCurrent(operation)) {
+					return { status: "inactive", providerId: this.provider.id };
+				}
+				return this.ensureActive(ctx, store, now);
+			}
 			return this.failClosed(ctx, operation, runtimeOverride, active, error, credential);
 		}
 
@@ -179,7 +213,12 @@ export class RuntimeAuthCoordinator {
 		if (selection.error !== undefined) {
 			return this.failClosed(ctx, operation, runtimeOverride, active, selection.error, credential);
 		}
-		if (!selection.matches) return this.ensureActive(ctx, store, now);
+		if (!selection.matches) {
+			if (!this.overlay.isCurrent(operation)) {
+				return { status: "inactive", providerId: this.provider.id };
+			}
+			return this.ensureActive(ctx, store, now);
+		}
 
 		try {
 			const availableModelIds = readAvailableModelIds(credential);
@@ -192,7 +231,22 @@ export class RuntimeAuthCoordinator {
 				throw new Error(`Pi did not retain the runtime ${this.provider.displayName} credential.`);
 			}
 			await this.verifyOverlay(ctx, auth, availableModelIds);
+			if (!this.overlay.isCurrent(operation)) {
+				return { status: "inactive", providerId: this.provider.id };
+			}
+			const credentialClone = cloneOAuthCredential(credential);
+			if (!credentialClone) {
+				throw new Error(
+					`${this.provider.displayName} OAuth credential could not be cloned safely.`,
+				);
+			}
 			this.availableModelIds = availableModelIds ? new Set(availableModelIds) : undefined;
+			this.pendingCredentialOffer = {
+				accountName: active,
+				credential: credentialClone,
+				operation,
+				session: ctx.sessionManager,
+			};
 			return { status: "active", providerId: this.provider.id, accountName: active };
 		} catch (error) {
 			return this.failClosed(ctx, operation, runtimeOverride, active, error, credential);
@@ -201,6 +255,43 @@ export class RuntimeAuthCoordinator {
 
 	isModelAvailable(modelId: string): boolean {
 		return !this.availableModelIds || this.availableModelIds.has(modelId);
+	}
+
+	publishCredentialOffer(
+		ctx: ExtensionContext,
+		result: EnsureActiveProviderAuthResult,
+		activeIdentity: string,
+	): void {
+		this.activeCredentialOffer = undefined;
+		const pending = this.pendingCredentialOffer;
+		this.pendingCredentialOffer = undefined;
+		if (result.status !== "active" || !pending) return;
+		if (pending.session !== ctx.sessionManager || pending.accountName !== result.accountName)
+			return;
+		if (!this.overlay.isCurrent(pending.operation)) return;
+		if (activeIdentity !== `${pending.accountName}:${pending.credential.access}`) return;
+		const credential = cloneOAuthCredential(pending.credential);
+		if (!credential) return;
+		this.activeCredentialOffer = { credential, session: pending.session };
+	}
+
+	offerCredential(data: unknown): void {
+		const request = parseCredentialRequest(data);
+		const active = this.activeCredentialOffer;
+		if (!request || !active) return;
+		if (request.session !== active.session || request.provider !== this.provider.id) return;
+		const credential = cloneOAuthCredential(active.credential);
+		if (!credential) return;
+		try {
+			request.offer(credential);
+		} catch {
+			// Credential requests are advisory and must not interrupt runtime authentication.
+		}
+	}
+
+	private clearCredentialOffer(): void {
+		this.pendingCredentialOffer = undefined;
+		this.activeCredentialOffer = undefined;
 	}
 
 	async forceFailClosed(
@@ -220,6 +311,7 @@ export class RuntimeAuthCoordinator {
 	}
 
 	invalidate(ctx: ExtensionContext): void {
+		this.clearCredentialOffer();
 		this.overlay.beginOperation();
 		this.controller.invalidate(ctx);
 		this.refreshController.abort(new DOMException("Account refresh invalidated", "AbortError"));
@@ -227,6 +319,7 @@ export class RuntimeAuthCoordinator {
 	}
 
 	async clear(ctx: ExtensionContext): Promise<void> {
+		this.clearCredentialOffer();
 		const operation = this.overlay.beginOperation();
 		this.availableModelIds = undefined;
 		await this.controller.clear(ctx);
@@ -241,6 +334,10 @@ export class RuntimeAuthCoordinator {
 		error: unknown,
 		credential?: OAuthCredential,
 	): Promise<EnsureActiveProviderAuthResult> {
+		if (!this.overlay.isCurrent(operation)) {
+			return { status: "inactive", providerId: this.provider.id };
+		}
+		this.clearCredentialOffer();
 		let suffix = "";
 		try {
 			this.overlay.apply(
@@ -342,6 +439,10 @@ class RuntimeProviderOverlay {
 	beginOperation(): number {
 		this.generation += 1;
 		return this.generation;
+	}
+
+	isCurrent(generation: number): boolean {
+		return generation === this.generation;
 	}
 
 	apply(

--- a/packages/pi-accounts/test/accounts.test.ts
+++ b/packages/pi-accounts/test/accounts.test.ts
@@ -21,6 +21,7 @@ import {
 	createOAuthInteraction,
 	loginWithOAuthUI,
 } from "../src/oauth.js";
+import { OAUTH_CREDENTIAL_SOURCE_CHANNEL } from "../src/oauth-credential-source.js";
 import { RuntimeAuthCoordinator } from "../src/runtime-auth.js";
 import { InMemoryAccountStorageBackend } from "../src/storage.js";
 
@@ -115,6 +116,22 @@ function runtimeHarness(mock: ReturnType<typeof createMockPi>) {
 		},
 	};
 	return { keys, registry, runtime };
+}
+
+function collectCredentialOffers(
+	mock: ReturnType<typeof createMockPi>,
+	session: object,
+	provider: string,
+): StoredOAuthCredential[] {
+	const offers: StoredOAuthCredential[] = [];
+	mock.eventBus.emit(OAUTH_CREDENTIAL_SOURCE_CHANNEL, {
+		session,
+		provider,
+		offer(candidate: StoredOAuthCredential) {
+			offers.push(candidate);
+		},
+	});
+	return offers;
 }
 
 function createInteractiveAccountContext(
@@ -940,6 +957,218 @@ test("login selects a provider default model only when the current model is unkn
 	await mock.commands.get("accounts")?.handler("ignored", ctx);
 
 	assert.equal(mock.setModels.length, 1);
+});
+
+test("credential source offers a refreshed active credential as defensive session-bound clones", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			"github-copilot": {
+				active: "work",
+				accounts: {
+					work: {
+						...credential("expired", { availableModelIds: ["allowed"] }),
+						expires: 1,
+					},
+				},
+			},
+		},
+	});
+	const copilot = fakeProvider("github-copilot");
+	copilot.oauth.refresh = async (current) => ({
+		...current,
+		access: "access-refreshed",
+		expires: Date.now() + 60 * 60 * 1000,
+	});
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [fakeProvider("openai-codex"), fakeProvider("anthropic"), copilot],
+	});
+	const { registry } = runtimeHarness(mock);
+	const sessionManager = {};
+	const { ctx } = createMockContext({
+		model: { provider: "github-copilot", id: "allowed" },
+		modelRegistry: registry,
+		sessionManager,
+	});
+
+	assert.deepEqual(collectCredentialOffers(mock, sessionManager, "github-copilot"), []);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+
+	const first = collectCredentialOffers(mock, sessionManager, "github-copilot");
+	assert.equal(first.length, 1);
+	const firstOffer = first[0];
+	assert.ok(firstOffer);
+	assert.equal(firstOffer.access, "access-refreshed");
+	firstOffer.access = "caller-mutated";
+	(firstOffer.availableModelIds as string[]).push("caller-mutated");
+	const second = collectCredentialOffers(mock, sessionManager, "github-copilot");
+	assert.equal(second[0]?.access, "access-refreshed");
+	assert.deepEqual(second[0]?.availableModelIds, ["allowed"]);
+	assert.deepEqual(collectCredentialOffers(mock, {}, "github-copilot"), []);
+	assert.deepEqual(collectCredentialOffers(mock, sessionManager, "anthropic"), []);
+
+	assert.doesNotThrow(() => {
+		mock.eventBus.emit(OAUTH_CREDENTIAL_SOURCE_CHANNEL, {
+			session: sessionManager,
+			provider: "github-copilot",
+			offer() {
+				throw new Error("consumer rejected offer");
+			},
+		});
+	});
+	const malformed = Object.create(null) as Record<string, unknown>;
+	Object.defineProperty(malformed, "session", {
+		get() {
+			throw new Error("malformed request");
+		},
+	});
+	assert.doesNotThrow(() => mock.eventBus.emit(OAUTH_CREDENTIAL_SOURCE_CHANNEL, malformed));
+
+	await store.updateProvider("github-copilot", (state) => ({ ...state, active: undefined }));
+	await mock.events.get("model_select")?.[0]?.(
+		{ model: { provider: "github-copilot", id: "allowed" } },
+		ctx,
+	);
+	assert.deepEqual(collectCredentialOffers(mock, sessionManager, "github-copilot"), []);
+	await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.deepEqual(collectCredentialOffers(mock, sessionManager, "github-copilot"), []);
+});
+
+test("credential source suppresses pending, stale, failed-closed, and replaced activations", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			"github-copilot": {
+				active: "first",
+				accounts: {
+					first: credential("first", { availableModelIds: ["allowed"] }),
+					second: credential("second", { availableModelIds: ["allowed"] }),
+				},
+			},
+		},
+	});
+	let releaseFirst!: () => void;
+	const firstBlocked = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
+	let notifyFirst!: () => void;
+	const firstStarted = new Promise<void>((resolve) => {
+		notifyFirst = resolve;
+	});
+	const copilot = fakeProvider("github-copilot");
+	copilot.oauth.toAuth = async (current) => {
+		if (current.access === "access-first") {
+			notifyFirst();
+			await firstBlocked;
+		}
+		if (current.access === "access-failing") throw new Error("conversion failed");
+		return { apiKey: current.access };
+	};
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [fakeProvider("openai-codex"), fakeProvider("anthropic"), copilot],
+	});
+	const { registry } = runtimeHarness(mock);
+	const sessionManager = {};
+	const { ctx } = createMockContext({
+		model: { provider: "github-copilot", id: "allowed" },
+		modelRegistry: registry,
+		sessionManager,
+	});
+
+	const older = mock.events.get("session_start")?.[0]?.({}, ctx);
+	await firstStarted;
+	assert.deepEqual(collectCredentialOffers(mock, sessionManager, "github-copilot"), []);
+	await store.updateProvider("github-copilot", (state) => ({ ...state, active: "second" }));
+	await mock.events.get("before_agent_start")?.[0]?.({}, ctx);
+	assert.equal(
+		collectCredentialOffers(mock, sessionManager, "github-copilot")[0]?.access,
+		"access-second",
+	);
+	releaseFirst();
+	await older;
+	assert.equal(
+		collectCredentialOffers(mock, sessionManager, "github-copilot")[0]?.access,
+		"access-second",
+	);
+
+	await store.updateProvider("github-copilot", (state) => ({
+		...state,
+		active: "failing",
+		accounts: { ...state.accounts, failing: credential("failing") },
+	}));
+	await mock.events.get("before_agent_start")?.[0]?.({}, ctx);
+	assert.deepEqual(collectCredentialOffers(mock, sessionManager, "github-copilot"), []);
+
+	const replacement = createMockContext({
+		model: { provider: "github-copilot", id: "allowed" },
+		modelRegistry: registry,
+		sessionManager: {},
+	}).ctx;
+	await mock.events.get("session_start")?.[0]?.({}, replacement);
+	assert.deepEqual(collectCredentialOffers(mock, sessionManager, "github-copilot"), []);
+});
+
+test("session replacement invalidates a pending credential offer before old work resumes", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			"github-copilot": {
+				active: "work",
+				accounts: { work: credential("work") },
+			},
+		},
+	});
+	let releaseFirst!: () => void;
+	const firstBlocked = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
+	let notifyFirst!: () => void;
+	const firstStarted = new Promise<void>((resolve) => {
+		notifyFirst = resolve;
+	});
+	let conversions = 0;
+	const copilot = fakeProvider("github-copilot");
+	copilot.oauth.toAuth = async (current) => {
+		conversions += 1;
+		if (conversions === 1) {
+			notifyFirst();
+			await firstBlocked;
+		}
+		return { apiKey: current.access };
+	};
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [fakeProvider("openai-codex"), fakeProvider("anthropic"), copilot],
+	});
+	const { registry } = runtimeHarness(mock);
+	const oldSession = {};
+	const newSession = {};
+	const oldContext = createMockContext({ modelRegistry: registry, sessionManager: oldSession }).ctx;
+	const newContext = createMockContext({ modelRegistry: registry, sessionManager: newSession }).ctx;
+
+	const oldStart = mock.events.get("session_start")?.[0]?.({}, oldContext);
+	await firstStarted;
+	await mock.events.get("session_start")?.[0]?.({}, newContext);
+	assert.deepEqual(collectCredentialOffers(mock, oldSession, "github-copilot"), []);
+	assert.equal(
+		collectCredentialOffers(mock, newSession, "github-copilot")[0]?.access,
+		"access-work",
+	);
+	releaseFirst();
+	await oldStart;
+	assert.deepEqual(collectCredentialOffers(mock, oldSession, "github-copilot"), []);
+	assert.equal(
+		collectCredentialOffers(mock, newSession, "github-copilot")[0]?.access,
+		"access-work",
+	);
 });
 
 test("providers without account-specific overlays leave existing registrations untouched", async () => {

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -15,11 +15,12 @@ The extension reports each provider's native semantics instead of presenting unl
 - Redeems eligible Codex resets only after fresh account matching and explicit confirmation.
 - Refreshes one or all configured providers with bounded concurrency and partial-result preservation.
 - Keeps statusline and cache data scoped to the current provider and runtime account.
-- Resolves credentials through Pi and validates the effective provider endpoint before sending them.
+- Resolves credentials through Pi or the process-local OAuth credential-source protocol and validates the effective provider endpoint before sending them.
 
 ## 📦 Install
 
 Requires Pi 0.81.0 or newer so the extension can validate the effective base URL attached to resolved provider auth before sending credentials to an official usage endpoint.
+The v1 credential-source interoperability path is characterized against Pi 0.84.3; other runtimes retain standalone fallback but do not receive the protocol timing guarantee.
 
 ```bash
 pi install npm:@narumitw/pi-usage
@@ -111,7 +112,7 @@ Repair or remove an invalid file, then run `/reload` before trying the toggle ag
 The statusline selects a returned bucket that matches the current Codex model when one is available.
 Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.
 
-Reset redemption is available only when Codex is the current provider and Pi's freshly resolved access token exactly matches its stored OpenAI Codex OAuth credential.
+Reset redemption is available only when Codex is the current provider and Pi's freshly resolved access token exactly matches an OAuth credential from Pi's stored login or a compatible credential source.
 `pi-usage` forwards only the bearer authorization and matching `chatgpt-account-id` to the official ChatGPT origin.
 API-key credentials, configured-but-not-current Codex accounts, account changes during the flow, and custom/proxy origins fail before mutation.
 Backend-provided titles and descriptions are sanitized for terminal display.
@@ -126,7 +127,9 @@ Opaque credit and account IDs are never shown or persisted by the extension.
 - Statusline examples: `copilot credits 1200/1500 80%`, `copilot 245/300 82%`, or `copilot chat 40/50 80%`
 
 GitHub's quota endpoint requires the original GitHub OAuth token rather than the short-lived Copilot inference token exposed by runtime auth.
-`pi-usage` therefore supports Copilot accounts created through Pi's `/login` flow, reads that stored credential through Pi's public API, and uses it only when its short-lived access token matches the active runtime credential.
+`pi-usage` supports Copilot accounts created through Pi's `/login` flow and named accounts offered by a compatible `oauth:credential-source:v1` owner.
+It uses a candidate only when its short-lived access token exactly matches the freshly resolved active runtime credential.
+Duplicate equivalent candidates are harmless, while conflicting matches fail closed without choosing by extension load order.
 API-key credentials, account mismatches, GitHub Enterprise accounts, and proxy/custom provider origins fail closed.
 The detailed report follows the endpoint's `token_based_billing` marker so AI credits are not mislabeled as legacy premium requests, and it reports overage without treating a negative included balance as a malformed response.
 
@@ -158,6 +161,9 @@ The usage endpoint is derived from the model's base URL (`…/zen/go/v1/usage`) 
 
 The extension does not enumerate multiple accounts inside one provider and does not switch accounts.
 Account selection remains owned by Pi or an account-management extension.
+A compatible credential owner may offer the verified active named account through the versioned process-local protocol without exposing its account label or storage.
+Without such an owner, `pi-usage` retains its standalone Pi `auth.json` behavior.
+An older or incompatible owner degrades to the existing authentication-unavailable result when the stored login does not match runtime auth.
 After the active runtime credential changes, the next command, turn, or scheduled refresh resolves auth again and cannot reuse another account's cached report.
 
 ## 📊 Statusline behavior
@@ -187,11 +193,20 @@ Behavior changes:
 - Codex CLI fallback is removed to preserve active-runtime-account correctness.
 - The status key changes from `codex-usage` to `usage`.
 
+## 🔒 Security and privacy
+
+Credential candidates are collected synchronously in memory and are not cached, persisted, logged, formatted, or appended to the Pi session.
+The protocol carries no account name or extension identity.
+Only the selected provider's exact runtime match is used, and secrets are sent only to the validated official provider origin.
+Pi extensions run with the user's process privileges, so the shared event bus is not a security boundary between installed extensions.
+Install only trusted extensions because any installed extension may already read user files and process memory.
+Protocol v1 interoperability is characterized for the repository's supported Pi runtime; an absent or incompatible peer preserves standalone fallback and fail-closed mismatch behavior.
+
 ## 🚧 Limitations
 
 - Only providers with a meaningful usage source and verifiable Pi runtime auth are supported.
 - GitHub Copilot quota and OpenAI Codex reset redemption use undocumented provider endpoints that may change without notice.
-- Codex reset redemption requires a current ChatGPT OAuth login created through Pi; Codex API keys cannot redeem earned subscription resets.
+- Codex reset redemption requires a current ChatGPT OAuth credential from Pi's login or a compatible credential source; Codex API keys cannot redeem earned subscription resets.
 - Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
@@ -216,6 +231,7 @@ packages/pi-usage/
 │   ├── settings.ts    # Validated user settings and atomic persistence
 │   ├── usage-helpers.ts # Small orchestration helpers
 │   ├── query.ts       # Runtime auth resolution and bounded provider queries
+│   ├── oauth-credential-source.ts # Ephemeral OAuth candidate collection
 │   ├── codex-resets.ts # Codex reset auth, API contracts, and normalization
 │   ├── format.ts      # Provider-aware notifications and statusline text
 │   ├── core.ts        # Cache, concurrency, fingerprint, and redaction helpers

--- a/packages/pi-usage/src/codex-resets.ts
+++ b/packages/pi-usage/src/codex-resets.ts
@@ -2,6 +2,10 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { fingerprintResolvedAuth, sanitizeDisplayText } from "./core.js";
 import {
+	fallbackOAuthCredentialCandidates,
+	type OAuthCredentialCandidateReader,
+} from "./oauth-credential-source.js";
+import {
 	AUTH_FINGERPRINT_SALT,
 	adapterForProvider,
 	fetchProviderJson,
@@ -98,6 +102,7 @@ export async function resolveCodexResetAuth(
 	ctx: ExtensionContext,
 	salt: Uint8Array = AUTH_FINGERPRINT_SALT,
 	credentialReader: StoredCredentialReader = readStoredCredential,
+	candidateReader?: OAuthCredentialCandidateReader,
 ): Promise<ResolvedUsageAuth> {
 	const model = ctx.model;
 	if (model?.provider !== "openai-codex") {
@@ -112,26 +117,22 @@ export async function resolveCodexResetAuth(
 	}
 	if (!auth) throw new Error("No runtime credential is configured for OpenAI Codex.");
 
-	const credential = asObject(credentialReader("openai-codex"));
-	if (credential?.type !== "oauth") {
-		throw new Error(
-			"Usage limit resets require the OpenAI Codex OAuth account configured through Pi /login.",
-		);
-	}
-	const storedAccess = asNonemptyString(credential.access);
 	const resolvedAccess = bearerToken(headerValue(auth.headers, "Authorization")) ?? auth.apiKey;
-	if (!storedAccess || !resolvedAccess) {
-		throw new Error("OpenAI Codex OAuth credentials were incomplete.");
+	if (!resolvedAccess) throw new Error("OpenAI Codex OAuth credentials were incomplete.");
+	const resolvedAccountId = codexAccountIdFromAccessToken(resolvedAccess);
+	if (!resolvedAccountId) {
+		throw new Error("The active OpenAI Codex access token did not contain a valid account ID.");
 	}
-	if (storedAccess !== resolvedAccess) {
-		throw new Error(
-			"The active OpenAI Codex runtime account does not match Pi's stored OAuth account.",
-		);
-	}
-	const accountId = validHeaderValue(credential.accountId);
-	if (!accountId)
-		throw new Error("The OpenAI Codex OAuth credential did not include a valid account ID.");
-
+	const offered = candidateReader
+		? candidateReader(ctx, "openai-codex")
+		: fallbackOAuthCredentialCandidates("openai-codex", credentialReader);
+	if (!offered.ok) throw new Error("OpenAI Codex OAuth credential discovery failed closed.");
+	const { accountId, storedAccess } = selectCodexResetCredential(
+		offered.candidates,
+		resolvedAccess,
+		resolvedAccountId,
+		offered.offeredCount === 0,
+	);
 	const authorization = `Bearer ${resolvedAccess}`;
 	const headers = {
 		Authorization: authorization,
@@ -224,6 +225,70 @@ export function normalizeCodexResetCreditsPayload(
 		options.push(genericCodexResetOption());
 	}
 	return { availableCount, options };
+}
+
+function selectCodexResetCredential(
+	candidates: readonly unknown[],
+	resolvedAccess: string,
+	resolvedAccountId: string,
+	standaloneFallback: boolean,
+): { accountId: string; storedAccess: string } {
+	let sawOAuth = false;
+	let sawMatchingAccess = false;
+	let sawInvalidAccountId = false;
+	const matches = new Map<string, { accountId: string; storedAccess: string }>();
+	for (const candidate of candidates) {
+		try {
+			const credential = asObject(candidate);
+			if (credential?.type !== "oauth") continue;
+			sawOAuth = true;
+			const storedAccess = asNonemptyString(credential.access);
+			if (storedAccess !== resolvedAccess) continue;
+			sawMatchingAccess = true;
+			const accountId = validHeaderValue(credential.accountId);
+			const refresh = asNonemptyString(credential.refresh);
+			if (!accountId || accountId !== resolvedAccountId || !refresh) {
+				sawInvalidAccountId = true;
+				continue;
+			}
+			matches.set(refresh, { accountId, storedAccess });
+		} catch {
+			// Malformed candidates never authorize a reset request.
+		}
+	}
+	if (sawInvalidAccountId) {
+		throw new Error("The OpenAI Codex OAuth credential did not include a valid account ID.");
+	}
+	if (matches.size > 1) {
+		throw new Error("Conflicting OAuth credentials match the active OpenAI Codex runtime account.");
+	}
+	const match = matches.values().next().value;
+	if (match) return match;
+	if (!sawOAuth) {
+		throw new Error(
+			standaloneFallback
+				? "Usage limit resets require the OpenAI Codex OAuth account configured through Pi /login."
+				: "Usage limit resets require an OpenAI Codex OAuth account configured through Pi /login or a compatible credential source.",
+		);
+	}
+	if (sawMatchingAccess) throw new Error("OpenAI Codex OAuth credentials were incomplete.");
+	throw new Error(
+		standaloneFallback
+			? "The active OpenAI Codex runtime account does not match Pi's stored OAuth account."
+			: "The active OpenAI Codex runtime account does not match any available OAuth account.",
+	);
+}
+
+function codexAccountIdFromAccessToken(access: string): string | undefined {
+	try {
+		const parts = access.split(".");
+		if (parts.length !== 3 || !parts[1]) return undefined;
+		const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as unknown;
+		const claims = asObject(asObject(payload)?.["https://api.openai.com/auth"]);
+		return validHeaderValue(claims?.chatgpt_account_id);
+	} catch {
+		return undefined;
+	}
 }
 
 function normalizeResetOption(credit: Record<string, unknown>): CodexResetOption {

--- a/packages/pi-usage/src/oauth-credential-source.ts
+++ b/packages/pi-usage/src/oauth-credential-source.ts
@@ -1,0 +1,88 @@
+import type { OAuthCredential } from "@earendil-works/pi-ai";
+import {
+	type ExtensionAPI,
+	type ExtensionContext,
+	readStoredCredential,
+} from "@earendil-works/pi-coding-agent";
+
+export const OAUTH_CREDENTIAL_SOURCE_CHANNEL = "oauth:credential-source:v1";
+
+export type StoredCredentialReader = (providerId: string) => unknown;
+
+export type OAuthCredentialCandidates =
+	| { ok: true; candidates: readonly OAuthCredential[]; offeredCount?: number }
+	| { ok: false };
+
+export type OAuthCredentialCandidateReader = (
+	ctx: ExtensionContext,
+	providerId: string,
+) => OAuthCredentialCandidates;
+
+export function createOAuthCredentialCandidateReader(
+	pi: ExtensionAPI,
+	credentialReader: StoredCredentialReader = readStoredCredential,
+): OAuthCredentialCandidateReader {
+	return (ctx, providerId) =>
+		collectOAuthCredentialCandidates(pi, ctx, providerId, credentialReader);
+}
+
+export function collectOAuthCredentialCandidates(
+	pi: Pick<ExtensionAPI, "events">,
+	ctx: ExtensionContext,
+	providerId: string,
+	credentialReader: StoredCredentialReader = readStoredCredential,
+): OAuthCredentialCandidates {
+	const candidates: OAuthCredential[] = [];
+	let collecting = true;
+	const request = Object.freeze({
+		session: ctx.sessionManager,
+		provider: providerId,
+		offer(candidate: unknown) {
+			if (!collecting) return;
+			const clone = cloneOAuthCredential(candidate);
+			if (clone) candidates.push(clone);
+		},
+	});
+	try {
+		pi.events.emit(OAUTH_CREDENTIAL_SOURCE_CHANNEL, request);
+	} catch {
+		return { ok: false };
+	} finally {
+		collecting = false;
+	}
+	const offeredCount = candidates.length;
+	try {
+		const fallback = cloneOAuthCredential(credentialReader(providerId));
+		if (fallback) candidates.push(fallback);
+	} catch {
+		// A malformed or unavailable standalone credential is equivalent to no fallback.
+	}
+	return { ok: true, candidates, offeredCount };
+}
+
+export function fallbackOAuthCredentialCandidates(
+	providerId: string,
+	credentialReader: StoredCredentialReader,
+): OAuthCredentialCandidates {
+	try {
+		const credential = cloneOAuthCredential(credentialReader(providerId));
+		return { ok: true, candidates: credential ? [credential] : [], offeredCount: 0 };
+	} catch {
+		return { ok: true, candidates: [], offeredCount: 0 };
+	}
+}
+
+function cloneOAuthCredential(value: unknown): OAuthCredential | undefined {
+	try {
+		if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+		const clone = structuredClone(value) as OAuthCredential;
+		if (!clone || typeof clone !== "object" || Array.isArray(clone)) return undefined;
+		if (clone.type !== "oauth") return undefined;
+		if (typeof clone.access !== "string" || !clone.access) return undefined;
+		if (typeof clone.refresh !== "string" || !clone.refresh) return undefined;
+		if (typeof clone.expires !== "number" || !Number.isFinite(clone.expires)) return undefined;
+		return clone;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -1,6 +1,10 @@
 import { randomBytes } from "node:crypto";
 import { type ExtensionContext, readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { errorMessage, fingerprintResolvedAuth, redactUsageError } from "./core.js";
+import {
+	fallbackOAuthCredentialCandidates,
+	type OAuthCredentialCandidateReader,
+} from "./oauth-credential-source.js";
 import { normalizeCodexBackendPayload } from "./providers/codex.js";
 import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 import { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
@@ -111,6 +115,7 @@ export async function resolveUsageAuth(
 	adapter: UsageProviderAdapter,
 	salt: Uint8Array = AUTH_FINGERPRINT_SALT,
 	credentialReader: StoredCredentialReader = readStoredCredential,
+	candidateReader?: OAuthCredentialCandidateReader,
 ): Promise<ResolvedUsageAuth | undefined> {
 	if (ctx.model?.provider === adapter.id && !hasOfficialOrigin(ctx.model, adapter.id)) {
 		throw new Error(
@@ -144,7 +149,19 @@ export async function resolveUsageAuth(
 	const auth = modelAuth ?? providerResult?.auth;
 	if (!auth) return undefined;
 	if (adapter.id === "github-copilot") {
-		return resolveGitHubCopilotUsageAuth(auth, model, salt, credentialReader);
+		const offered = candidateReader
+			? candidateReader(ctx, adapter.id)
+			: fallbackOAuthCredentialCandidates(adapter.id, credentialReader);
+		if (!offered.ok) {
+			throw new Error("GitHub Copilot OAuth credential discovery failed closed.");
+		}
+		return resolveGitHubCopilotUsageAuth(
+			auth,
+			model,
+			salt,
+			offered.candidates,
+			offered.offeredCount === 0,
+		);
 	}
 	const authorization = authorizationFrom(auth);
 	if (!authorization) return undefined;
@@ -334,33 +351,73 @@ function resolveGitHubCopilotUsageAuth(
 	auth: RequestAuth,
 	model: PiModel,
 	salt: Uint8Array,
-	credentialReader: StoredCredentialReader,
+	candidates: readonly unknown[],
+	standaloneFallback: boolean,
 ): ResolvedUsageAuth {
-	const credential = asObject(credentialReader("github-copilot"));
-	if (credential?.type !== "oauth") {
-		throw new Error(
-			"GitHub Copilot usage requires the OAuth account configured through Pi /login.",
-		);
+	const resolvedAccess = bearerToken(headerValue(auth.headers, "Authorization")) ?? auth.apiKey;
+	if (!resolvedAccess) throw new Error("GitHub Copilot OAuth credentials were incomplete.");
+	let sawOAuth = false;
+	let sawMatchingAccess = false;
+	let sawIncompleteMatch = false;
+	let sawEnterpriseMatch = false;
+	const matches = new Map<string, { refresh: string; storedAccess: string }>();
+	for (const candidate of candidates) {
+		try {
+			const credential = asObject(candidate);
+			if (credential?.type !== "oauth") continue;
+			sawOAuth = true;
+			const storedAccess =
+				typeof credential.access === "string" && credential.access ? credential.access : undefined;
+			if (storedAccess !== resolvedAccess) continue;
+			sawMatchingAccess = true;
+			const enterpriseUrl = credential.enterpriseUrl;
+			if (
+				typeof enterpriseUrl === "string" &&
+				enterpriseUrl &&
+				!isPublicGitHubDomain(enterpriseUrl)
+			) {
+				sawEnterpriseMatch = true;
+				continue;
+			}
+			const refresh =
+				typeof credential.refresh === "string" && credential.refresh
+					? credential.refresh
+					: undefined;
+			if (!refresh) {
+				sawIncompleteMatch = true;
+				continue;
+			}
+			matches.set(`${storedAccess.length}:${storedAccess}${refresh}`, { refresh, storedAccess });
+		} catch {
+			// Malformed candidates never authorize a provider request.
+		}
 	}
-	if (
-		typeof credential.enterpriseUrl === "string" &&
-		credential.enterpriseUrl &&
-		!isPublicGitHubDomain(credential.enterpriseUrl)
-	) {
+	if (sawEnterpriseMatch) {
 		throw new Error("GitHub Copilot usage does not yet support GitHub Enterprise accounts.");
 	}
-	const refresh = typeof credential.refresh === "string" ? credential.refresh : undefined;
-	const storedAccess = typeof credential.access === "string" ? credential.access : undefined;
-	const resolvedAccess = bearerToken(headerValue(auth.headers, "Authorization")) ?? auth.apiKey;
-	if (!refresh || !storedAccess || !resolvedAccess) {
-		throw new Error("GitHub Copilot OAuth credentials were incomplete.");
-	}
-	if (storedAccess !== resolvedAccess) {
+	if (sawIncompleteMatch) throw new Error("GitHub Copilot OAuth credentials were incomplete.");
+	if (matches.size > 1) {
 		throw new Error(
-			"The active GitHub Copilot runtime account does not match Pi's stored OAuth account.",
+			"Conflicting OAuth credentials match the active GitHub Copilot runtime account.",
 		);
 	}
-
+	const match = matches.values().next().value;
+	if (!match) {
+		if (!sawOAuth) {
+			throw new Error(
+				standaloneFallback
+					? "GitHub Copilot usage requires the OAuth account configured through Pi /login."
+					: "GitHub Copilot usage requires an OAuth account configured through Pi /login or a compatible credential source.",
+			);
+		}
+		if (sawMatchingAccess) throw new Error("GitHub Copilot OAuth credentials were incomplete.");
+		throw new Error(
+			standaloneFallback
+				? "The active GitHub Copilot runtime account does not match Pi's stored OAuth account."
+				: "The active GitHub Copilot runtime account does not match any available OAuth account.",
+		);
+	}
+	const { refresh, storedAccess } = match;
 	const authorization = `Bearer ${refresh}`;
 	const headers = {
 		Authorization: authorization,

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -22,6 +22,7 @@ import {
 } from "./codex-resets.js";
 import { awaitWithDeadline, errorMessage, runWithConcurrency, UsageCache } from "./core.js";
 import { formatProviderStates, formatUsageStatusline } from "./format.js";
+import { createOAuthCredentialCandidateReader } from "./oauth-credential-source.js";
 import {
 	adapterForProvider,
 	isStaleExtensionContextError,
@@ -80,6 +81,7 @@ export default function usageExtension(
 	dependencies: UsageExtensionDependencies = {},
 ) {
 	const credentialReader = dependencies.credentialReader;
+	const credentialCandidates = createOAuthCredentialCandidateReader(pi, credentialReader);
 	const createRedemptionId = dependencies.createRedemptionId ?? randomUUID;
 	const settingsRuntime = dependencies.settingsRuntime ?? createUsageSettingsRuntime();
 	const cache = new UsageCache(CACHE_TTL_MS);
@@ -189,7 +191,7 @@ export default function usageExtension(
 		let auth: ResolvedUsageAuth | undefined;
 		try {
 			auth = await awaitWithDeadline(
-				resolveUsageAuth(ctx, adapter),
+				resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
 				signal,
 				DEFAULT_TIMEOUT_MS,
 				`resolving ${adapter.displayName} runtime auth`,
@@ -419,7 +421,7 @@ export default function usageExtension(
 			if (!adapter) return false;
 			try {
 				const auth = await awaitWithDeadline(
-					resolveUsageAuth(ctx, adapter),
+					resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
 					signal,
 					DEFAULT_TIMEOUT_MS,
 					`revalidating ${adapter.displayName} runtime auth`,
@@ -438,7 +440,7 @@ export default function usageExtension(
 		if (!adapter) return false;
 		try {
 			const auth = await awaitWithDeadline(
-				resolveUsageAuth(ctx, adapter),
+				resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
 				signal,
 				DEFAULT_TIMEOUT_MS,
 				`revalidating ${adapter.displayName} runtime auth`,
@@ -677,7 +679,7 @@ export default function usageExtension(
 								async (signal) => {
 									const expectedModel = modelIdentity(ctx.model);
 									const auth = await awaitWithDeadline(
-										resolveCodexResetAuth(ctx, undefined, credentialReader),
+										resolveCodexResetAuth(ctx, undefined, credentialReader, credentialCandidates),
 										signal,
 										DEFAULT_TIMEOUT_MS,
 										"resolving current Codex reset authentication",
@@ -695,7 +697,7 @@ export default function usageExtension(
 										};
 									}
 									const revalidated = await awaitWithDeadline(
-										resolveCodexResetAuth(ctx, undefined, credentialReader),
+										resolveCodexResetAuth(ctx, undefined, credentialReader, credentialCandidates),
 										signal,
 										DEFAULT_TIMEOUT_MS,
 										"revalidating current Codex reset authentication",
@@ -759,7 +761,7 @@ export default function usageExtension(
 								controller.signal,
 								async (signal) => {
 									const auth = await awaitWithDeadline(
-										resolveCodexResetAuth(ctx, undefined, credentialReader),
+										resolveCodexResetAuth(ctx, undefined, credentialReader, credentialCandidates),
 										signal,
 										DEFAULT_TIMEOUT_MS,
 										"revalidating current Codex reset authentication",

--- a/packages/pi-usage/test/codex-reset-menu.test.ts
+++ b/packages/pi-usage/test/codex-reset-menu.test.ts
@@ -17,7 +17,7 @@ const codexModel = {
 
 const credential = (access = "codex-token") => ({
 	type: "oauth",
-	access,
+	access: normalizeTestToken(access),
 	refresh: "refresh-token",
 	expires: Date.now() + 60_000,
 	accountId: "account-123",
@@ -35,13 +35,31 @@ function usageResponse(resetCount: number): Response {
 
 function codexRegistry(activeToken: () => string) {
 	return {
-		getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: activeToken() }),
-		getProviderAuth: async () => ({ auth: { apiKey: activeToken() } }),
+		getApiKeyAndHeaders: async () => ({
+			ok: true as const,
+			apiKey: normalizeTestToken(activeToken()),
+		}),
+		getProviderAuth: async () => ({ auth: { apiKey: normalizeTestToken(activeToken()) } }),
 		getAvailable: () => [codexModel],
 		getAll: () => [codexModel],
 		getProviderAuthStatus: () => ({ configured: true }),
 		getProviderDisplayName: (provider: string) => provider,
 	};
+}
+
+function normalizeTestToken(value: string): string {
+	return value.split(".").length === 3
+		? value
+		: codexAccessToken(value === "codex-token" ? "account-123" : value);
+}
+
+function codexAccessToken(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({
+			"https://api.openai.com/auth": { chatgpt_account_id: accountId },
+		}),
+	).toString("base64url");
+	return `header.${payload}.signature`;
 }
 
 test("zero Codex reset availability is visible and cannot mutate", async (t) => {

--- a/packages/pi-usage/test/codex-resets.test.ts
+++ b/packages/pi-usage/test/codex-resets.test.ts
@@ -10,6 +10,8 @@ import {
 	resolveCodexResetAuth,
 } from "../src/index.js";
 
+const activeCodexToken = codexAccessToken("account-123");
+
 const codexModel = {
 	id: "gpt-5.3-codex",
 	name: "GPT-5.3 Codex",
@@ -34,15 +36,15 @@ test("Codex reset auth requires the current matching Pi OAuth account", async ()
 	const { ctx } = createMockContext({
 		model: codexModel,
 		modelRegistry: {
-			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "active-token" }),
-			getProviderAuth: async () => ({ auth: { apiKey: "active-token" } }),
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: activeCodexToken }),
+			getProviderAuth: async () => ({ auth: { apiKey: activeCodexToken } }),
 			getAvailable: () => [codexModel],
 			getAll: () => [codexModel],
 		},
 	});
 	const credential = () => ({
-		type: "oauth",
-		access: "active-token",
+		type: "oauth" as const,
+		access: activeCodexToken,
 		refresh: "refresh-token",
 		expires: Date.now() + 60_000,
 		accountId: "account-123",
@@ -50,10 +52,68 @@ test("Codex reset auth requires the current matching Pi OAuth account", async ()
 
 	const auth = await resolveCodexResetAuth(ctx, new Uint8Array(32), credential);
 	assert.deepEqual(auth.headers, {
-		Authorization: "Bearer active-token",
+		Authorization: `Bearer ${activeCodexToken}`,
 		"chatgpt-account-id": "account-123",
 	});
 	assert.ok(auth.secrets.includes("account-123"));
+
+	const namedAuth = await resolveCodexResetAuth(
+		ctx,
+		new Uint8Array(32),
+		() => ({ ...credential(), access: "default-token" }),
+		() => ({ ok: true, candidates: [credential()] }),
+	);
+	assert.equal(namedAuth.headers["chatgpt-account-id"], "account-123");
+	const duplicate = await resolveCodexResetAuth(
+		ctx,
+		new Uint8Array(32),
+		() => undefined,
+		() => ({ ok: true, candidates: [credential(), structuredClone(credential())] }),
+	);
+	assert.equal(duplicate.fingerprint, namedAuth.fingerprint);
+	for (const candidates of [
+		[credential(), { ...credential(), refresh: "another-refresh" }],
+		[{ ...credential(), refresh: "another-refresh" }, credential()],
+	]) {
+		await assert.rejects(
+			() =>
+				resolveCodexResetAuth(
+					ctx,
+					new Uint8Array(32),
+					() => undefined,
+					() => ({
+						ok: true,
+						candidates,
+					}),
+				),
+			/conflicting/iu,
+		);
+	}
+	await assert.rejects(
+		() =>
+			resolveCodexResetAuth(
+				ctx,
+				new Uint8Array(32),
+				() => undefined,
+				() => ({
+					ok: false,
+				}),
+			),
+		/failed closed/iu,
+	);
+	await assert.rejects(
+		() =>
+			resolveCodexResetAuth(
+				ctx,
+				new Uint8Array(32),
+				() => undefined,
+				() => ({
+					ok: true,
+					candidates: [{ ...credential(), accountId: "another-account" }],
+				}),
+			),
+		/account ID/iu,
+	);
 
 	await assert.rejects(
 		() =>
@@ -85,6 +145,15 @@ test("Codex reset auth requires the current matching Pi OAuth account", async ()
 		/current.*Codex/iu,
 	);
 });
+
+function codexAccessToken(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({
+			"https://api.openai.com/auth": { chatgpt_account_id: accountId },
+		}),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
 
 test("Codex reset details normalize safe available options in expiration order", () => {
 	const availability = normalizeCodexResetCreditsPayload({

--- a/packages/pi-usage/test/core.test.ts
+++ b/packages/pi-usage/test/core.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import { createMockContext } from "../../../test/support.js";
 import type { UsageReport } from "../src/index.js";
 import {
@@ -271,6 +271,124 @@ test("GitHub Copilot usage uses the matching Pi OAuth refresh token", async () =
 				enterpriseUrl: "company.ghe.com",
 			})),
 		/Enterprise/iu,
+	);
+});
+
+test("GitHub Copilot named credential selection is deterministic and reaches only the official endpoint", async () => {
+	const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === "github-copilot");
+	assert.ok(adapter);
+	const model = {
+		id: "gpt-5.4",
+		name: "GPT-5.4",
+		provider: "github-copilot",
+		baseUrl: "https://api.individual.githubcopilot.com",
+	};
+	const { ctx } = createMockContext({
+		model,
+		modelRegistry: {
+			getProviderAuth: async () => ({
+				auth: { apiKey: "runtime-access", baseUrl: model.baseUrl },
+			}),
+			getAvailable: () => [model],
+			getAll: () => [model],
+		},
+	});
+	const matching = {
+		type: "oauth" as const,
+		access: "runtime-access",
+		refresh: "matching-github-oauth",
+		expires: Date.now() + 60_000,
+		enterpriseUrl: "github.com",
+	};
+	const candidateReader = () => ({ ok: true as const, candidates: [matching] });
+	const auth = await resolveUsageAuth(
+		ctx,
+		adapter,
+		new Uint8Array(32),
+		() => ({ ...matching, access: "default-access" }),
+		candidateReader,
+	);
+	assert.ok(auth);
+	assert.equal(auth.apiKey, "matching-github-oauth");
+
+	const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+		new Response(
+			JSON.stringify({
+				quota_snapshots: {
+					premium_interactions: { entitlement: 10, remaining: 7 },
+				},
+				login: "named-user",
+			}),
+			{ status: 200 },
+		),
+	);
+	try {
+		await queryProviderUsage(adapter, auth, new AbortController().signal, 1_000);
+		assert.equal(fetchMock.mock.calls.length, 1);
+		assert.equal(fetchMock.mock.calls[0]?.[0], "https://api.github.com/copilot_internal/user");
+		const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+		assert.deepEqual(init.headers, {
+			Authorization: "Bearer matching-github-oauth",
+			"X-GitHub-Api-Version": "2025-05-01",
+			"User-Agent": "pi-usage",
+		});
+	} finally {
+		fetchMock.mockRestore();
+	}
+
+	for (const candidates of [
+		[matching, { ...matching, refresh: "conflicting-oauth" }],
+		[{ ...matching, refresh: "conflicting-oauth" }, matching],
+	]) {
+		await assert.rejects(
+			() =>
+				resolveUsageAuth(
+					ctx,
+					adapter,
+					new Uint8Array(32),
+					() => undefined,
+					() => ({
+						ok: true,
+						candidates,
+					}),
+				),
+			/conflicting/iu,
+		);
+	}
+	const duplicate = await resolveUsageAuth(
+		ctx,
+		adapter,
+		new Uint8Array(32),
+		() => undefined,
+		() => ({ ok: true, candidates: [matching, structuredClone(matching)] }),
+	);
+	assert.equal(duplicate?.apiKey, "matching-github-oauth");
+	await assert.rejects(
+		() =>
+			resolveUsageAuth(
+				ctx,
+				adapter,
+				new Uint8Array(32),
+				() => undefined,
+				() => ({
+					ok: true,
+					candidates: [{ ...matching, enterpriseUrl: "company.ghe.test" }],
+				}),
+			),
+		/Enterprise/iu,
+	);
+	await assert.rejects(
+		() =>
+			resolveUsageAuth(
+				ctx,
+				adapter,
+				new Uint8Array(32),
+				() => undefined,
+				() => ({
+					ok: false,
+				}),
+			),
+		/failed closed/iu,
 	);
 });
 

--- a/packages/pi-usage/test/oauth-credential-source.test.ts
+++ b/packages/pi-usage/test/oauth-credential-source.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	collectOAuthCredentialCandidates,
+	createOAuthCredentialCandidateReader,
+	OAUTH_CREDENTIAL_SOURCE_CHANNEL,
+} from "../src/oauth-credential-source.js";
+
+const credential = (suffix: string) => ({
+	type: "oauth" as const,
+	access: `access-${suffix}`,
+	refresh: `refresh-${suffix}`,
+	expires: 1_000,
+	metadata: { value: suffix },
+});
+
+test("credential candidate reader preserves standalone fallback with no listener", () => {
+	const mock = createMockPi();
+	const { ctx } = createMockContext();
+	const reader = createOAuthCredentialCandidateReader(mock.pi, () => credential("fallback"));
+
+	assert.deepEqual(reader(ctx, "github-copilot"), {
+		ok: true,
+		candidates: [credential("fallback")],
+		offeredCount: 0,
+	});
+});
+
+test("credential candidate reader collects only synchronous relevant offers without caching", () => {
+	const mock = createMockPi();
+	const session = {};
+	const { ctx } = createMockContext({ sessionManager: session });
+	let requests = 0;
+	let lateOffer: ((candidate: unknown) => void) | undefined;
+	const source = credential("source");
+	mock.eventBus.on(OAUTH_CREDENTIAL_SOURCE_CHANNEL, (data) => {
+		requests += 1;
+		const request = data as {
+			session: object;
+			provider: string;
+			offer(candidate: unknown): void;
+		};
+		if (request.session !== session || request.provider !== "github-copilot") return;
+		lateOffer = request.offer;
+		request.offer(source);
+		request.offer(null);
+		request.offer({ type: "oauth", access: "incomplete" });
+	});
+	mock.eventBus.on(OAUTH_CREDENTIAL_SOURCE_CHANNEL, () => {
+		throw new Error("one listener failed");
+	});
+	const reader = createOAuthCredentialCandidateReader(mock.pi, () => undefined);
+
+	const first = reader(ctx, "github-copilot");
+	assert.equal(first.ok, true);
+	if (!first.ok) return;
+	assert.equal(first.candidates.length, 1);
+	lateOffer?.(credential("after-return"));
+	assert.equal(first.candidates.length, 1);
+	assert.equal(first.candidates[0]?.access, "access-source");
+	(first.candidates[0] as unknown as { metadata: { value: string } }).metadata.value =
+		"caller-mutated";
+	const second = reader(ctx, "github-copilot");
+	assert.equal(second.ok, true);
+	if (!second.ok) return;
+	assert.equal(
+		(second.candidates[0] as unknown as { metadata: { value: string } }).metadata.value,
+		"source",
+	);
+	assert.equal(requests, 2);
+});
+
+test("credential candidate reader includes protocol and fallback candidates for deterministic selection", () => {
+	const mock = createMockPi();
+	const { ctx } = createMockContext();
+	mock.eventBus.on(OAUTH_CREDENTIAL_SOURCE_CHANNEL, (data) => {
+		(data as { offer(candidate: unknown): void }).offer(credential("source"));
+	});
+
+	const result = collectOAuthCredentialCandidates(mock.rawPi, ctx, "openai-codex", () =>
+		credential("fallback"),
+	);
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	assert.deepEqual(
+		result.candidates.map((candidate) => candidate.access),
+		["access-source", "access-fallback"],
+	);
+});
+
+test("credential candidate reader fails closed when event emission fails", () => {
+	const { ctx } = createMockContext();
+	const result = collectOAuthCredentialCandidates(
+		{
+			events: {
+				emit() {
+					throw new Error("event bus unavailable");
+				},
+				on() {
+					return () => undefined;
+				},
+			},
+		} as never,
+		ctx,
+		"github-copilot",
+		() => credential("fallback"),
+	);
+	assert.deepEqual(result, { ok: false });
+});

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import { OAUTH_CREDENTIAL_SOURCE_CHANNEL } from "../src/oauth-credential-source.js";
 import usageExtension from "../src/usage.js";
 
 initTheme("dark", false);
@@ -12,12 +13,23 @@ const openRouterModel = {
 	provider: "openrouter",
 	baseUrl: "https://openrouter.ai/api/v1",
 };
+const codexToken = codexAccessToken("account-123");
+
 const codexModel = {
 	id: "gpt-5.3-codex",
 	name: "GPT-5.3 Codex",
 	provider: "openai-codex",
 	baseUrl: "https://chatgpt.com/backend-api",
 };
+
+function codexAccessToken(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({
+			"https://api.openai.com/auth": { chatgpt_account_id: accountId },
+		}),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
 
 async function settle(): Promise<void> {
 	await new Promise<void>((resolve) => setImmediate(resolve));
@@ -170,13 +182,27 @@ test("current Codex usage can redeem a selected reset and refresh account state"
 	const choices = ["Redeem usage limit reset…", "Weekly + 5h reset", "Yes, use reset", "Close"];
 	const titles: string[] = [];
 	const mock = createMockPi();
+	mock.eventBus.on(OAUTH_CREDENTIAL_SOURCE_CHANNEL, (data) => {
+		const request = data as {
+			provider: string;
+			offer(candidate: unknown): void;
+		};
+		if (request.provider !== "openai-codex") return;
+		request.offer({
+			type: "oauth",
+			access: codexToken,
+			refresh: "named-refresh-token",
+			expires: Date.now() + 60_000,
+			accountId: "account-123",
+		});
+	});
 	usageExtension(mock.pi, {
 		credentialReader: () => ({
 			type: "oauth",
-			access: "codex-token",
-			refresh: "refresh-token",
+			access: "default-codex-token",
+			refresh: "default-refresh-token",
 			expires: Date.now() + 60_000,
-			accountId: "account-123",
+			accountId: "default-account",
 		}),
 		createRedemptionId: () => "redeem-123",
 	});
@@ -193,8 +219,8 @@ test("current Codex usage can redeem a selected reset and refresh account state"
 			return choice;
 		},
 		modelRegistry: {
-			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "codex-token" }),
-			getProviderAuth: async () => ({ auth: { apiKey: "codex-token" } }),
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: codexToken }),
+			getProviderAuth: async () => ({ auth: { apiKey: codexToken } }),
 			getAvailable: () => [codexModel],
 			getAll: () => [codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),
@@ -248,7 +274,7 @@ test("Codex reset confirmation defaults to cancellation and sends no mutation", 
 	usageExtension(mock.pi, {
 		credentialReader: () => ({
 			type: "oauth",
-			access: "codex-token",
+			access: codexToken,
 			refresh: "refresh-token",
 			expires: Date.now() + 60_000,
 			accountId: "account-123",
@@ -266,8 +292,8 @@ test("Codex reset confirmation defaults to cancellation and sends no mutation", 
 			return choices.shift();
 		},
 		modelRegistry: {
-			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "codex-token" }),
-			getProviderAuth: async () => ({ auth: { apiKey: "codex-token" } }),
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: codexToken }),
+			getProviderAuth: async () => ({ auth: { apiKey: codexToken } }),
 			getAvailable: () => [codexModel],
 			getAll: () => [codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),

--- a/test/accounts-usage-coexistence.test.ts
+++ b/test/accounts-usage-coexistence.test.ts
@@ -1,0 +1,296 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { afterEach, test } from "vitest";
+import accountsExtension, {
+	AccountStore,
+	type StoredOAuthCredential,
+} from "../packages/pi-accounts/src/accounts.js";
+import type { AccountProviderAdapter } from "../packages/pi-accounts/src/oauth.js";
+import { OAUTH_CREDENTIAL_SOURCE_CHANNEL } from "../packages/pi-accounts/src/oauth-credential-source.js";
+import { InMemoryAccountStorageBackend } from "../packages/pi-accounts/src/storage.js";
+import usageExtension from "../packages/pi-usage/src/usage.js";
+import { createMockContext, createMockPi } from "./support.js";
+
+initTheme("dark", false);
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+const copilotModel = {
+	id: "gpt-5.4",
+	name: "GPT-5.4",
+	provider: "github-copilot",
+	baseUrl: "https://api.individual.githubcopilot.com",
+};
+
+function credential(suffix: string): StoredOAuthCredential {
+	return {
+		type: "oauth",
+		access: `runtime-${suffix}`,
+		refresh: `github-${suffix}`,
+		expires: Date.now() + 60 * 60 * 1000,
+	};
+}
+
+function provider(id: AccountProviderAdapter["id"]): AccountProviderAdapter {
+	return {
+		id,
+		displayName:
+			id === "openai-codex" ? "OpenAI Codex" : id === "anthropic" ? "Anthropic" : "GitHub Copilot",
+		requiresApiKeyBridge: id === "openai-codex",
+		oauth: {
+			async login() {
+				return credential(id);
+			},
+			async refresh(current) {
+				return current;
+			},
+			async toAuth(current) {
+				return { apiKey: current.access };
+			},
+		},
+	};
+}
+
+function runtimeRegistry(mock: ReturnType<typeof createMockPi>) {
+	const keys = new Map<string, string>();
+	const runtime = {
+		async setRuntimeApiKey(providerId: string, apiKey: string) {
+			keys.set(providerId, apiKey);
+		},
+		async removeRuntimeApiKey(providerId: string) {
+			keys.delete(providerId);
+		},
+	};
+	return {
+		keys,
+		registry: {
+			runtime,
+			getRegisteredProviderConfig: (providerId: string) => mock.providers.get(providerId),
+			getApiKeyForProvider: async (providerId: string) => keys.get(providerId),
+			getApiKeyAndHeaders: async (model: { provider: string }) => ({
+				ok: true as const,
+				apiKey: keys.get(model.provider),
+			}),
+			getProviderAuth: async (providerId: string) => {
+				const apiKey = keys.get(providerId);
+				return apiKey
+					? {
+							auth: {
+								apiKey,
+								...(providerId === "github-copilot" ? { baseUrl: copilotModel.baseUrl } : {}),
+							},
+						}
+					: undefined;
+			},
+			getAvailable: () => [copilotModel],
+			getAll: () => [copilotModel],
+			getProviderAuthStatus: (providerId: string) => ({
+				configured: keys.has(providerId),
+			}),
+			getProviderDisplayName: (providerId: string) => providerId,
+			find: (providerId: string, modelId: string) =>
+				providerId === copilotModel.provider && modelId === copilotModel.id
+					? copilotModel
+					: undefined,
+		},
+	};
+}
+
+async function createStore() {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			"github-copilot": {
+				active: "first",
+				accounts: { first: credential("first"), second: credential("second") },
+			},
+		},
+	});
+	return store;
+}
+
+function registerAccounts(mock: ReturnType<typeof createMockPi>, store: AccountStore) {
+	const sessionStartIndex = mock.events.get("session_start")?.length ?? 0;
+	const modelSelectIndex = mock.events.get("model_select")?.length ?? 0;
+	accountsExtension(mock.pi, {
+		store,
+		providers: [provider("openai-codex"), provider("anthropic"), provider("github-copilot")],
+	});
+	return {
+		sessionStart: mock.events.get("session_start")?.[sessionStartIndex],
+		modelSelect: mock.events.get("model_select")?.[modelSelectIndex],
+	};
+}
+
+function registerUsage(mock: ReturnType<typeof createMockPi>): void {
+	usageExtension(mock.pi, {
+		credentialReader: () => ({
+			...credential("default"),
+			access: "unrelated-default-runtime",
+		}),
+	});
+}
+
+function installUsageFetch(requests: Array<{ url: string; authorization: string | null }>): void {
+	globalThis.fetch = async (input, init) => {
+		const headers = new Headers(init?.headers);
+		requests.push({ url: String(input), authorization: headers.get("authorization") });
+		return new Response(
+			JSON.stringify({
+				quota_snapshots: {
+					premium_interactions: { entitlement: 10, remaining: 7 },
+				},
+				login: "named-account",
+			}),
+			{ status: 200 },
+		);
+	};
+}
+
+test.each(["accounts-first", "usage-first"] as const)(
+	"source extensions coexist in %s order across named usage and account switching",
+	async (order) => {
+		const requests: Array<{ url: string; authorization: string | null }> = [];
+		installUsageFetch(requests);
+		const store = await createStore();
+		const mock = createMockPi();
+		let accountHooks: ReturnType<typeof registerAccounts>;
+		if (order === "accounts-first") {
+			accountHooks = registerAccounts(mock, store);
+			registerUsage(mock);
+		} else {
+			registerUsage(mock);
+			accountHooks = registerAccounts(mock, store);
+		}
+		const { keys, registry } = runtimeRegistry(mock);
+		const titles: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			model: copilotModel,
+			modelRegistry: registry,
+			select: async (title: string) => {
+				titles.push(title);
+				return "Close";
+			},
+		});
+
+		await accountHooks.sessionStart?.({}, ctx);
+		await mock.commands.get("usage")?.handler("", ctx);
+		assert.equal(requests.length, 1);
+		assert.deepEqual(requests[0], {
+			url: "https://api.github.com/copilot_internal/user",
+			authorization: "Bearer github-first",
+		});
+		assert.match(titles.at(-1) ?? "", /named-account/iu);
+
+		await store.updateProvider("github-copilot", (state) => ({ ...state, active: "second" }));
+		await accountHooks.modelSelect?.({ model: copilotModel }, ctx);
+		await mock.commands.get("usage")?.handler("", ctx);
+		assert.equal(requests.length, 2);
+		assert.equal(requests[1]?.authorization, "Bearer github-second");
+
+		keys.set("github-copilot", "runtime-with-no-matching-oauth");
+		await mock.commands.get("usage")?.handler("", ctx);
+		assert.equal(requests.length, 2);
+		assert.match(titles.at(-1) ?? "", /Authentication unavailable/iu);
+	},
+);
+
+test("built generated entries complete a representative named-account usage boundary", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-accounts-usage-generated-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const previousFetch = globalThis.fetch;
+	process.env.PI_CODING_AGENT_DIR = join(root, "agent");
+	const requests: Array<{ url: string; authorization: string | null }> = [];
+	installUsageFetch(requests);
+	try {
+		const [{ default: generatedAccounts }, { default: generatedUsage }] = await Promise.all([
+			import("../packages/pi-accounts/dist/index.js"),
+			import("../packages/pi-usage/dist/index.js"),
+		]);
+		const store = await createStore();
+		const mock = createMockPi();
+		const sessionStartIndex = mock.events.get("session_start")?.length ?? 0;
+		generatedAccounts(mock.pi, {
+			store,
+			providers: [provider("openai-codex"), provider("anthropic"), provider("github-copilot")],
+		});
+		const accountSessionStart = mock.events.get("session_start")?.[sessionStartIndex];
+		generatedUsage(mock.pi, {
+			credentialReader: () => ({
+				...credential("default"),
+				access: "unrelated-default-runtime",
+			}),
+		});
+		const { registry } = runtimeRegistry(mock);
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			model: copilotModel,
+			modelRegistry: registry,
+			select: async () => "Close",
+		});
+
+		await accountSessionStart?.({}, ctx);
+		await mock.commands.get("usage")?.handler("", ctx);
+		assert.deepEqual(requests, [
+			{
+				url: "https://api.github.com/copilot_internal/user",
+				authorization: "Bearer github-first",
+			},
+		]);
+	} finally {
+		globalThis.fetch = previousFetch;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(root, { force: true, recursive: true });
+	}
+});
+
+test.each(["conflict-first", "conflict-last"] as const)(
+	"conflicting matching credential fails closed with %s listener order",
+	async (order) => {
+		let requests = 0;
+		globalThis.fetch = async () => {
+			requests += 1;
+			return new Response("{}", { status: 200 });
+		};
+		const store = await createStore();
+		const mock = createMockPi();
+		const registerConflict = () => {
+			mock.eventBus.on(OAUTH_CREDENTIAL_SOURCE_CHANNEL, (data) => {
+				const request = data as {
+					session: object;
+					provider: string;
+					offer(candidate: unknown): void;
+				};
+				if (request.provider !== "github-copilot") return;
+				request.offer({ ...credential("first"), refresh: "conflicting-refresh" });
+			});
+		};
+		if (order === "conflict-first") registerConflict();
+		registerAccounts(mock, store);
+		registerUsage(mock);
+		if (order === "conflict-last") registerConflict();
+		const { registry } = runtimeRegistry(mock);
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			model: copilotModel,
+			modelRegistry: registry,
+			select: async () => "Close",
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await mock.commands.get("usage")?.handler("", ctx);
+		assert.equal(requests, 0);
+	},
+);

--- a/test/oauth-credential-source-runtime.test.ts
+++ b/test/oauth-credential-source-runtime.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import {
+	createEventBus,
+	DefaultResourceLoader,
+	ExtensionRunner,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+
+const CHANNEL = "oauth:credential-source:v1";
+
+type Credential = {
+	type: "oauth";
+	access: string;
+	refresh: string;
+	expires: number;
+};
+
+type CredentialRequest = {
+	session: object;
+	provider: string;
+	offer: (credential: Credential) => void;
+};
+
+test("createEventBus collects every synchronous credential offer before emit returns", async () => {
+	const eventBus = createEventBus();
+	let releaseAsyncListener!: () => void;
+	let finishAsyncListener!: () => void;
+	const asyncGate = new Promise<void>((resolve) => {
+		releaseAsyncListener = resolve;
+	});
+	const asyncFinished = new Promise<void>((resolve) => {
+		finishAsyncListener = resolve;
+	});
+	const session = {};
+	const otherSession = {};
+	const offers: string[] = [];
+	const request: CredentialRequest = {
+		session,
+		provider: "github-copilot",
+		offer(credential) {
+			offers.push(credential.access);
+		},
+	};
+
+	eventBus.on(CHANNEL, (data) => {
+		const current = data as CredentialRequest;
+		if (current.session !== session || current.provider !== "github-copilot") return;
+		current.offer({ type: "oauth", access: "first", refresh: "one", expires: 1 });
+	});
+	eventBus.on(CHANNEL, (data) => {
+		const current = data as CredentialRequest;
+		if (current.session === otherSession) {
+			current.offer({ type: "oauth", access: "wrong-session", refresh: "two", expires: 2 });
+		}
+	});
+	eventBus.on(CHANNEL, async (data) => {
+		const current = data as CredentialRequest;
+		current.offer({ type: "oauth", access: "before-await", refresh: "three", expires: 3 });
+		await asyncGate;
+		current.offer({ type: "oauth", access: "after-await", refresh: "four", expires: 4 });
+		finishAsyncListener();
+	});
+
+	eventBus.emit(CHANNEL, request);
+	assert.deepEqual(offers, ["first", "before-await"]);
+
+	releaseAsyncListener();
+	await asyncFinished;
+	assert.deepEqual(offers, ["first", "before-await", "after-await"]);
+});
+
+test("inline extension factories share one bus and stale runtimes unsubscribe", async () => {
+	const eventBus = createEventBus();
+	const session = {};
+	const offers: string[] = [];
+	const loader = new DefaultResourceLoader({
+		cwd: process.cwd(),
+		agentDir: process.cwd(),
+		settingsManager: SettingsManager.inMemory({}),
+		eventBus,
+		noExtensions: true,
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+		extensionFactories: [
+			{
+				name: "credential-owner",
+				factory(pi) {
+					pi.events.on(CHANNEL, (data) => {
+						const request = data as CredentialRequest;
+						if (request.session !== session) return;
+						request.offer({ type: "oauth", access: "shared", refresh: "secret", expires: 1 });
+					});
+				},
+			},
+			{
+				name: "credential-consumer-observer",
+				factory(pi) {
+					pi.events.on(CHANNEL, (data) => {
+						assert.equal((data as CredentialRequest).session, session);
+					});
+				},
+			},
+		],
+	});
+
+	await loader.reload();
+	const loaded = loader.getExtensions();
+	assert.deepEqual(loaded.errors, []);
+	assert.equal(loaded.extensions.length, 2);
+
+	const request = (): CredentialRequest => ({
+		session,
+		provider: "github-copilot",
+		offer(credential) {
+			offers.push(credential.access);
+		},
+	});
+	eventBus.emit(CHANNEL, request());
+	assert.deepEqual(offers, ["shared"]);
+
+	loaded.runtime.invalidate("credential source runtime characterization cleanup");
+	eventBus.emit(CHANNEL, request());
+	assert.deepEqual(offers, ["shared"]);
+});
+
+test("ExtensionRunner contexts preserve exact sessionManager identity", async () => {
+	const eventBus = createEventBus();
+	const observedSessionManagers: object[] = [];
+	const loader = new DefaultResourceLoader({
+		cwd: process.cwd(),
+		agentDir: process.cwd(),
+		settingsManager: SettingsManager.inMemory({}),
+		eventBus,
+		noExtensions: true,
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+		extensionFactories: [
+			(pi) => {
+				pi.on("session_start", (_event, ctx) => {
+					observedSessionManagers.push(ctx.sessionManager);
+				});
+			},
+		],
+	});
+	const sessionManager = {};
+
+	await loader.reload();
+	const loaded = loader.getExtensions();
+	const runner = new ExtensionRunner(
+		loaded.extensions,
+		loaded.runtime,
+		process.cwd(),
+		sessionManager as never,
+		{} as never,
+	);
+
+	assert.equal(runner.createContext().sessionManager, sessionManager);
+	assert.equal(runner.createCommandContext().sessionManager, sessionManager);
+	await runner.emit({ type: "session_start", reason: "startup" });
+	assert.deepEqual(observedSessionManagers, [sessionManager]);
+});


### PR DESCRIPTION
## Summary

- add the versioned, extension-neutral `oauth:credential-source:v1` protocol over Pi's process-local event bus
- let verified named `pi-accounts` credentials authorize matching GitHub Copilot usage and OpenAI Codex reset flows without cross-extension imports or storage access
- preserve standalone Pi `auth.json` fallback, exact runtime-token and Codex JWT account-ID checks, official-origin restrictions, lifecycle invalidation, and fail-closed conflict handling
- document the trusted-extension boundary and add a patch Changeset for both packages

## Verification

- `npx vitest run ...` focused protocol/package/generated/coexistence suites: 11 files, 105 tests passed
- `npm run check`: passed
- `npm test`: 390 files, 3419 tests passed
- `just pack accounts`: 12 declared files inspected
- `just pack usage`: 21 declared files inspected
- offline non-interactive Pi generated-package load smokes: accounts, usage, and combined passed
- fenced-code-aware package README heading audit: passed
- `npm run changeset:status`: release intent correct; existing repository warnings remain for several `pi-tui-kit` dependency ranges

One intermediate full-suite run had an unrelated `pi-subagents` telemetry timing failure; its focused 13-test suite and the subsequent full 3419-test run passed.

## Risks and unverified paths

- Pi's event bus is a trusted-extension interoperability channel, not a security boundary; credentials remain ephemeral and exact-match-gated.
- Protocol timing is characterized for the pinned Pi 0.84.3 runtime.
- A live GitHub endpoint smoke was not run because no active named local Copilot credential remained; deterministic tests verify the official URL, headers, account-label response, mismatch rejection, and redaction path.
- No package publication, tag, visibility change, or release workflow was run.
