### PR TITLE
fix(tui-kit): preserve compact menu interactions

### DIFF
--- a/.changeset/fair-menu-budgets.md
+++ b/.changeset/fair-menu-budgets.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": patch
+---
+
+Keep framed choices, settings, searchable inputs, and review pagination usable within Pi's available terminal rows.

--- a/packages/pi-file-context/test/file-context-command-menu.test.ts
+++ b/packages/pi-file-context/test/file-context-command-menu.test.ts
@@ -65,8 +65,11 @@ test("makes the no-argument command a menu and advertises compatibility routes",
 		assert.match(frame, /File Context/u);
 		assert.match(frame, /Add context snippet/u);
 		assert.match(frame, /Review selected context \(0\)/u);
-		assert.match(frame, /Settings/u);
-		assert.match(frame, /Status/u);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		const laterRows = tui.render().join("\n");
+		assert.match(laterRows, /Settings/u);
+		assert.match(laterRows, /Status/u);
 		tui.press("ctrl+c");
 		await running;
 	});

--- a/packages/pi-statusline/test/commands.test.ts
+++ b/packages/pi-statusline/test/commands.test.ts
@@ -82,7 +82,7 @@ function customPalettePicker(
 	return async (factory: (...args: unknown[]) => unknown) => {
 		let result: unknown;
 		const component = (await factory(
-			{ requestRender() {} },
+			{ terminal: { rows: 24 }, requestRender() {} },
 			{
 				fg: (_color: string, text: string) => text,
 				bold: (text: string) => text,

--- a/packages/pi-tui-kit/src/components/browse.ts
+++ b/packages/pi-tui-kit/src/components/browse.ts
@@ -18,10 +18,14 @@ import {
 	RPC_DOCUMENT_LINE_WIDTH,
 	RPC_DOCUMENT_PAGE_SIZE,
 } from "./document-formatting.js";
-import { handleSearchInput, renderHorizontalRule, safeMenuText } from "./rendering.js";
+import {
+	componentRows,
+	handleSearchInput,
+	renderHorizontalRule,
+	safeMenuText,
+} from "./rendering.js";
 import { reviewDialogPages } from "./review.js";
 
-const RESERVED_HOST_ROWS = 3;
 const MAX_CONTEXT_ROWS = 2;
 const MIN_FRAMED_ROWS = 5;
 
@@ -398,11 +402,6 @@ function detailLayout(availableRows: number, contentLength: number): BrowseDetai
 	const positionRows = contentLength > contentRows && contentRows >= 2 ? 1 : 0;
 	contentRows -= positionRows;
 	return { titleRows, contentRows, positionRows, hintRows };
-}
-
-function componentRows(rows: number) {
-	const terminalRows = Number.isFinite(rows) ? Math.floor(rows) : 24;
-	return Math.max(1, terminalRows - RESERVED_HOST_ROWS);
 }
 
 function listWindowStart(selectedIndex: number, itemCount: number, viewportSize: number) {

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -292,7 +292,7 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 						...renderChoiceSearchInput(searchInput, safeWidth),
 						"",
 						...choices,
-						options.theme.fg("dim", "Type to search"),
+						...(filteredItems.length > 0 ? [options.theme.fg("dim", "Type to search")] : []),
 					]
 				: choices;
 			return renderFrame(
@@ -459,19 +459,15 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 		},
 		render(width) {
 			const safeWidth = Math.max(1, width);
-			const content = [
-				...searchInput.render(safeWidth),
-				"",
-				...renderSettingsRows(
-					filteredItems,
-					searchableItems,
-					selectedIndex,
-					displayed,
-					safeWidth,
-					options,
-				),
-				"",
-			];
+			const settingsRows = renderSettingsRows(
+				filteredItems,
+				searchableItems,
+				selectedIndex,
+				displayed,
+				safeWidth,
+				options,
+			);
+			const content = [...searchInput.render(safeWidth), "", ...settingsRows.lines, ""];
 			return renderFrame(
 				options.screen.title,
 				options.screen.lines ?? [],
@@ -479,7 +475,11 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 				"back",
 				safeWidth,
 				options,
-				{ hint: settingsHint(options.keybindings), pinnedContentRows: 1 },
+				{
+					hint: settingsHint(options.keybindings),
+					pinnedContentRows: 1,
+					priorityTailRows: settingsRows.descriptionRows,
+				},
 			);
 		},
 		invalidate() {
@@ -522,9 +522,13 @@ function renderSettingsRows<ScreenId extends string, ActionId extends string>(
 	displayed: ReadonlyMap<string, string>,
 	width: number,
 	options: SettingsOptions<ScreenId, ActionId>,
-): string[] {
-	if (allItems.length === 0) return [options.theme.fg("dim", "  No settings available")];
-	if (filteredItems.length === 0) return [options.theme.fg("dim", "  No matching settings")];
+): { lines: string[]; descriptionRows: number } {
+	if (allItems.length === 0) {
+		return { lines: [options.theme.fg("dim", "  No settings available")], descriptionRows: 0 };
+	}
+	if (filteredItems.length === 0) {
+		return { lines: [options.theme.fg("dim", "  No matching settings")], descriptionRows: 0 };
+	}
 
 	const maxVisible = Math.min(filteredItems.length, 10);
 	const startIndex = Math.max(
@@ -563,6 +567,7 @@ function renderSettingsRows<ScreenId extends string, ActionId extends string>(
 	if (startIndex > 0 || endIndex < filteredItems.length) {
 		lines.push(options.theme.fg("dim", `  (${selectedIndex + 1}/${filteredItems.length})`));
 	}
+	let descriptionRows = 0;
 	const selected = filteredItems[selectedIndex]?.item;
 	if (selected?.description) {
 		lines.push("");
@@ -571,9 +576,10 @@ function renderSettingsRows<ScreenId extends string, ActionId extends string>(
 			Math.max(1, width - 4),
 		)) {
 			lines.push(options.theme.fg("dim", `  ${line}`));
+			descriptionRows += 1;
 		}
 	}
-	return lines;
+	return { lines, descriptionRows };
 }
 
 function settingsHint(keybindings: MenuKeybindings) {

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -151,6 +151,7 @@ function createDetailComponent<ScreenId extends string, ActionId extends string>
 				options.screen.hint ?? "back",
 				width,
 				options,
+				{ confirmAction: "", navigation: false },
 			);
 		},
 		invalidate() {},
@@ -303,6 +304,10 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 				safeWidth,
 				options,
 				{
+					compactOverflowText:
+						filteredItems.length > 1
+							? `  (${selectedIndex + 1}/${filteredItems.length})`
+							: undefined,
 					confirmAction: "select",
 					pinnedContentRows: options.screen.enableSearch ? 1 : 0,
 					priorityTailRows: detailRows.length + (options.screen.enableSearch ? 1 : 0),
@@ -476,6 +481,11 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 				safeWidth,
 				options,
 				{
+					compactOverflowText:
+						filteredItems.length > 1
+							? `  (${selectedIndex + 1}/${filteredItems.length})`
+							: undefined,
+					confirmAction: "change",
 					hint: settingsHint(options.keybindings),
 					pinnedContentRows: 1,
 					priorityTailRows: settingsRows.descriptionRows,
@@ -646,6 +656,8 @@ function commonListComponent<ScreenId extends string, ActionId extends string>(
 				...(detailRows.length > 0 ? ["", ...detailRows] : []),
 			];
 			return renderFrame(options.screen.title, lines, content, destination, width, options, {
+				compactOverflowText:
+					items.length > 1 ? `  (${selectedIndex + 1}/${items.length})` : undefined,
 				priorityTailRows: detailRows.length,
 			});
 		},

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -488,7 +488,7 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 					confirmAction: "change",
 					hint: settingsHint(options.keybindings),
 					pinnedContentRows: 1,
-					priorityTailRows: settingsRows.descriptionRows,
+					priorityTailRows: settingsRows.priorityTailRows,
 				},
 			);
 		},
@@ -532,12 +532,12 @@ function renderSettingsRows<ScreenId extends string, ActionId extends string>(
 	displayed: ReadonlyMap<string, string>,
 	width: number,
 	options: SettingsOptions<ScreenId, ActionId>,
-): { lines: string[]; descriptionRows: number } {
+): { lines: string[]; priorityTailRows: number } {
 	if (allItems.length === 0) {
-		return { lines: [options.theme.fg("dim", "  No settings available")], descriptionRows: 0 };
+		return { lines: [options.theme.fg("dim", "  No settings available")], priorityTailRows: 1 };
 	}
 	if (filteredItems.length === 0) {
-		return { lines: [options.theme.fg("dim", "  No matching settings")], descriptionRows: 0 };
+		return { lines: [options.theme.fg("dim", "  No matching settings")], priorityTailRows: 1 };
 	}
 
 	const maxVisible = Math.min(filteredItems.length, 10);
@@ -577,7 +577,7 @@ function renderSettingsRows<ScreenId extends string, ActionId extends string>(
 	if (startIndex > 0 || endIndex < filteredItems.length) {
 		lines.push(options.theme.fg("dim", `  (${selectedIndex + 1}/${filteredItems.length})`));
 	}
-	let descriptionRows = 0;
+	let priorityTailRows = 0;
 	const selected = filteredItems[selectedIndex]?.item;
 	if (selected?.description) {
 		lines.push("");
@@ -586,10 +586,10 @@ function renderSettingsRows<ScreenId extends string, ActionId extends string>(
 			Math.max(1, width - 4),
 		)) {
 			lines.push(options.theme.fg("dim", `  ${line}`));
-			descriptionRows += 1;
+			priorityTailRows += 1;
 		}
 	}
-	return { lines, descriptionRows };
+	return { lines, priorityTailRows };
 }
 
 function settingsHint(keybindings: MenuKeybindings) {

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -12,7 +12,6 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { HorizontalRule } from "../horizontal-rule.js";
 import type { MenuScreen, MenuSettingItem } from "../types.js";
 import { createBrowseComponent } from "./browse.js";
 import type {
@@ -29,7 +28,6 @@ import {
 	actionMenuItemPresentation,
 	actionMenuUnavailableDescription,
 	handleSearchInput,
-	menuHint,
 	renderFrame,
 	safeMenuText,
 } from "./rendering.js";
@@ -178,9 +176,6 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 	const searchInput = new Input();
 	const restoredSearchQuery = options.searchQuery ?? "";
 	if (restoredSearchQuery) handleSearchInput(searchInput, restoredSearchQuery);
-	const border = new HorizontalRule({
-		ruleStyle: (text: string) => options.theme.fg("border", text),
-	});
 	const allItems = options.screen.items.map((item) => {
 		const current = item.id === options.screen.currentItemId ? " ✓ current" : "";
 		const unavailable = item.disabled
@@ -283,22 +278,15 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 					: []),
 				...(selectedItem?.details ?? []).map(safeMenuText),
 			];
+			const detailRows = details.flatMap((line) =>
+				wrapTextWithAnsi(options.theme.fg("muted", line), safeWidth),
+			);
 			const choices =
 				allItems.length === 0
 					? [options.theme.fg("dim", "  No choices available")]
 					: filteredItems.length === 0
 						? [options.theme.fg("dim", "  No matching choices")]
-						: [
-								...list.render(safeWidth),
-								...(details.length > 0
-									? [
-											"",
-											...details.flatMap((line) =>
-												wrapTextWithAnsi(options.theme.fg("muted", line), safeWidth),
-											),
-										]
-									: []),
-							];
+						: [...list.render(safeWidth), ...(detailRows.length > 0 ? ["", ...detailRows] : [])];
 			const search = options.screen.enableSearch
 				? [
 						...renderChoiceSearchInput(searchInput, safeWidth),
@@ -307,31 +295,21 @@ function createChoiceComponent<ScreenId extends string, ActionId extends string>
 						options.theme.fg("dim", "Type to search"),
 					]
 				: choices;
-			const result = [
-				...border.render(safeWidth),
-				...wrapTextWithAnsi(
-					options.theme.fg("accent", options.theme.bold(safeMenuText(options.screen.title))),
-					safeWidth,
-				),
-				...(options.screen.lines ?? []).flatMap((line) =>
-					wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
-				),
-				"",
-				...search,
-				...wrapTextWithAnsi(
-					options.theme.fg(
-						"dim",
-						options.interactionHint ??
-							menuHint(options.keybindings, options.screen.hint ?? "back", "select"),
-					),
-					safeWidth,
-				),
-				...border.render(safeWidth),
-			];
-			return result.map((line) => truncateToWidth(line, safeWidth, ""));
+			return renderFrame(
+				options.screen.title,
+				options.screen.lines ?? [],
+				search,
+				options.screen.hint ?? "back",
+				safeWidth,
+				options,
+				{
+					confirmAction: "select",
+					pinnedContentRows: options.screen.enableSearch ? 1 : 0,
+					priorityTailRows: detailRows.length + (options.screen.enableSearch ? 1 : 0),
+				},
+			);
 		},
 		invalidate() {
-			border.invalidate();
 			list.invalidate();
 			if (options.screen.enableSearch) searchInput.invalidate();
 		},
@@ -395,9 +373,6 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 	options: SettingsOptions<ScreenId, ActionId>,
 ): MenuScreenComponent {
 	const searchInput = new Input();
-	const border = new HorizontalRule({
-		ruleStyle: (text: string) => options.theme.fg("border", text),
-	});
 	const searchableItems = options.screen.items.map((item) => ({
 		item,
 		label: safeMenuText(item.label),
@@ -484,16 +459,7 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 		},
 		render(width) {
 			const safeWidth = Math.max(1, width);
-			const result = [
-				...border.render(safeWidth),
-				...wrapTextWithAnsi(
-					options.theme.fg("accent", options.theme.bold(safeMenuText(options.screen.title))),
-					safeWidth,
-				),
-				...(options.screen.lines ?? []).flatMap((line) =>
-					wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
-				),
-				"",
+			const content = [
 				...searchInput.render(safeWidth),
 				"",
 				...renderSettingsRows(
@@ -505,13 +471,18 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
 					options,
 				),
 				"",
-				...wrapTextWithAnsi(options.theme.fg("dim", settingsHint(options.keybindings)), safeWidth),
-				...border.render(safeWidth),
 			];
-			return result.map((line) => truncateToWidth(line, safeWidth, ""));
+			return renderFrame(
+				options.screen.title,
+				options.screen.lines ?? [],
+				content,
+				"back",
+				safeWidth,
+				options,
+				{ hint: settingsHint(options.keybindings), pinnedContentRows: 1 },
+			);
 		},
 		invalidate() {
-			border.invalidate();
 			searchInput.invalidate();
 		},
 		handleInput(data) {
@@ -661,18 +632,16 @@ function commonListComponent<ScreenId extends string, ActionId extends string>(
 			const safeWidth = Math.max(1, width);
 			const selectedId = items[selectedIndex]?.value;
 			const details = selectedId ? (selectedDetails?.(selectedId) ?? []) : [];
+			const detailRows = details.flatMap((detail) =>
+				wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(detail)), safeWidth),
+			);
 			const content = [
 				...list.render(safeWidth),
-				...(details.length > 0
-					? [
-							"",
-							...details.flatMap((detail) =>
-								wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(detail)), safeWidth),
-							),
-						]
-					: []),
+				...(detailRows.length > 0 ? ["", ...detailRows] : []),
 			];
-			return renderFrame(options.screen.title, lines, content, destination, width, options);
+			return renderFrame(options.screen.title, lines, content, destination, width, options, {
+				priorityTailRows: detailRows.length,
+			});
 		},
 		invalidate() {
 			list.invalidate();

--- a/packages/pi-tui-kit/src/components/input.ts
+++ b/packages/pi-tui-kit/src/components/input.ts
@@ -86,7 +86,7 @@ export function createInputComponent<ScreenId extends string, ActionId extends s
 				options.screen.hint ?? "back",
 				safeWidth,
 				options,
-				"submit",
+				{ confirmAction: "submit", pinnedContentRows: 1 },
 			);
 		},
 		invalidate() {

--- a/packages/pi-tui-kit/src/components/input.ts
+++ b/packages/pi-tui-kit/src/components/input.ts
@@ -86,7 +86,11 @@ export function createInputComponent<ScreenId extends string, ActionId extends s
 				options.screen.hint ?? "back",
 				safeWidth,
 				options,
-				{ confirmAction: "submit", pinnedContentRows: 1 },
+				{
+					confirmAction: "submit",
+					pinnedContentRows: 1,
+					priorityTailRows: submitting ? 1 : 0,
+				},
 			);
 		},
 		invalidate() {

--- a/packages/pi-tui-kit/src/components/multi-select.ts
+++ b/packages/pi-tui-kit/src/components/multi-select.ts
@@ -190,14 +190,10 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 								: undefined,
 						].filter((value): value is string => Boolean(value))
 				: [];
-			if (descriptions.length > 0) {
-				rowContent.push(
-					"",
-					...descriptions.flatMap((description) =>
-						wrapTextWithAnsi(options.theme.fg("dim", `  ${safeMenuText(description)}`), safeWidth),
-					),
-				);
-			}
+			const descriptionRows = descriptions.flatMap((description) =>
+				wrapTextWithAnsi(options.theme.fg("dim", `  ${safeMenuText(description)}`), safeWidth),
+			);
+			if (descriptionRows.length > 0) rowContent.push("", ...descriptionRows);
 			const content = options.screen.enableSearch
 				? [
 						...searchInput.render(safeWidth),
@@ -221,6 +217,7 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 				{
 					confirmAction: row?.kind === "action" ? "select" : "toggle",
 					pinnedContentRows: options.screen.enableSearch ? 1 : 0,
+					priorityTailRows: descriptionRows.length + (options.screen.enableSearch ? 1 : 0),
 				},
 			);
 		},

--- a/packages/pi-tui-kit/src/components/multi-select.ts
+++ b/packages/pi-tui-kit/src/components/multi-select.ts
@@ -218,7 +218,10 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 				options.screen.hint ?? "back",
 				width,
 				options,
-				row?.kind === "action" ? "select" : "toggle",
+				{
+					confirmAction: row?.kind === "action" ? "select" : "toggle",
+					pinnedContentRows: options.screen.enableSearch ? 1 : 0,
+				},
 			);
 		},
 		invalidate() {

--- a/packages/pi-tui-kit/src/components/multi-select.ts
+++ b/packages/pi-tui-kit/src/components/multi-select.ts
@@ -194,17 +194,18 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 				wrapTextWithAnsi(options.theme.fg("dim", `  ${safeMenuText(description)}`), safeWidth),
 			);
 			if (descriptionRows.length > 0) rowContent.push("", ...descriptionRows);
+			const hasMatchingItems = rows.some((candidate) => candidate.kind === "toggle");
 			const content = options.screen.enableSearch
 				? [
 						...searchInput.render(safeWidth),
 						"",
 						...(options.screen.items.length === 0
 							? [options.theme.fg("dim", "  No items available")]
-							: rows.every((candidate) => candidate.kind === "action")
+							: !hasMatchingItems
 								? [options.theme.fg("dim", "  No matching items")]
 								: []),
 						...rowContent,
-						options.theme.fg("dim", "Type to search"),
+						...(hasMatchingItems ? [options.theme.fg("dim", "Type to search")] : []),
 					]
 				: rowContent;
 			return renderFrame(
@@ -218,8 +219,9 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 					compactOverflowText:
 						rows.length > 1 ? `  (${selectedIndex + 1}/${rows.length})` : undefined,
 					confirmAction: row?.kind === "action" ? "select" : "toggle",
-					pinnedContentRows: options.screen.enableSearch ? 1 : 0,
-					priorityTailRows: descriptionRows.length + (options.screen.enableSearch ? 1 : 0),
+					pinnedContentRows: options.screen.enableSearch ? (hasMatchingItems ? 1 : 2) : 0,
+					priorityTailRows:
+						descriptionRows.length + (options.screen.enableSearch && hasMatchingItems ? 1 : 0),
 				},
 			);
 		},

--- a/packages/pi-tui-kit/src/components/multi-select.ts
+++ b/packages/pi-tui-kit/src/components/multi-select.ts
@@ -215,6 +215,8 @@ export function createMultiSelectComponent<ScreenId extends string, ActionId ext
 				width,
 				options,
 				{
+					compactOverflowText:
+						rows.length > 1 ? `  (${selectedIndex + 1}/${rows.length})` : undefined,
 					confirmAction: row?.kind === "action" ? "select" : "toggle",
 					pinnedContentRows: options.screen.enableSearch ? 1 : 0,
 					priorityTailRows: descriptionRows.length + (options.screen.enableSearch ? 1 : 0),

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -83,6 +83,7 @@ export function renderFrame<ScreenId extends string, ActionId extends string>(
 	const compactHintRow = options.theme.fg(
 		"dim",
 		compactMenuHint(
+			hintText,
 			options.keybindings,
 			destination,
 			confirmAction,
@@ -298,6 +299,7 @@ export function menuHint(
 }
 
 function compactMenuHint(
+	hintText: string,
 	keybindings: MenuKeybindings,
 	destination: "back" | "close",
 	confirmAction: string,
@@ -312,30 +314,99 @@ function compactMenuHint(
 			label: destination,
 		},
 	]);
+	const hardCancel =
+		destination === "back" || !cancel
+			? formatInteractionHints(keybindings, [{ keys: ["ctrl+c"], label: "close" }])
+			: "";
+	const confirm = confirmAction
+		? formatInteractionHints(keybindings, [
+				{ bindings: ["tui.select.confirm"], label: confirmAction },
+			])
+		: "";
+	const navigate = navigation
+		? formatInteractionHints(keybindings, [
+				{ bindings: ["tui.select.up", "tui.select.down"], label: "navigate" },
+			])
+		: "";
+	const supplied = hintSegments(hintText);
+	const groups = {
+		cancel: hintSegmentKeys(cancel),
+		confirm: hintSegmentKeys(confirm),
+		hardCancel: hintSegmentKeys(hardCancel),
+		navigate: hintSegmentKeys(navigate),
+	};
+	const classified = supplied.map((segment) => ({ segment, keys: hintSegmentKeys(segment) }));
+	const matching = (keys: ReadonlySet<string>) =>
+		classified
+			.filter((candidate) => intersects(candidate.keys, keys))
+			.map(({ segment }) => segment);
+	const cancelSegments = matching(groups.cancel);
+	const confirmSegments = matching(groups.confirm);
+	const hardCancelSegments = matching(groups.hardCancel);
+	const navigationSegments = matching(groups.navigate);
+	const claimed = new Set([
+		...cancelSegments,
+		...confirmSegments,
+		...hardCancelSegments,
+		...navigationSegments,
+	]);
+	const remaining = classified.filter(({ segment }) => !claimed.has(segment));
+	const keyedCustom = remaining.filter(({ keys }) => keys.size > 0).map(({ segment }) => segment);
+	const reminders = remaining.filter(({ keys }) => keys.size === 0).map(({ segment }) => segment);
 	return fitCompactHintSegments(
 		[
-			cancel,
+			...(cancelSegments.length > 0 ? cancelSegments : [cancel]),
 			...(compactOverflowText ? [safeMenuText(compactOverflowText).trim()] : []),
-			...(destination === "back" || !cancel
-				? [formatInteractionHints(keybindings, [{ keys: ["ctrl+c"], label: "close" }])]
-				: []),
-			...(confirmAction
-				? [
-						formatInteractionHints(keybindings, [
-							{ bindings: ["tui.select.confirm"], label: confirmAction },
-						]),
-					]
-				: []),
-			...(navigation
-				? [
-						formatInteractionHints(keybindings, [
-							{ bindings: ["tui.select.up", "tui.select.down"], label: "navigate" },
-						]),
-					]
-				: []),
+			...keyedCustom,
+			...confirmSegments,
+			...hardCancelSegments,
+			...navigationSegments,
+			...reminders,
 		],
 		width,
 	);
+}
+
+function hintSegments(hintText: string) {
+	return safeMenuText(hintText)
+		.split(/\s+[•·]\s+/u)
+		.map((segment) => segment.trim())
+		.filter(Boolean);
+}
+
+function hintSegmentKeys(segment: string) {
+	const token = safeMenuText(segment).trim().split(/\s+/u, 1)[0]?.toLowerCase() ?? "";
+	const parts = token.split("/");
+	return parts.length > 0 && parts.every(isHintKey) ? new Set(parts) : new Set<string>();
+}
+
+function isHintKey(value: string) {
+	return (
+		value.length === 1 ||
+		value.includes("+") ||
+		[
+			"esc",
+			"escape",
+			"enter",
+			"return",
+			"space",
+			"↑",
+			"↓",
+			"up",
+			"down",
+			"pageup",
+			"pagedown",
+			"home",
+			"end",
+		].includes(value)
+	);
+}
+
+function intersects(left: ReadonlySet<string>, right: ReadonlySet<string>) {
+	for (const value of left) {
+		if (right.has(value)) return true;
+	}
+	return false;
 }
 
 export function fitCompactHintSegments(segments: readonly string[], width: number) {

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -130,13 +130,12 @@ function compactInteractiveRows(
 	pinnedContentRows: number,
 	priorityTailRows: number,
 ): string[] {
+	const hintBudget = hintRows.length > 0 && availableRows > 1 ? 1 : 0;
 	const minimumContentRows = Math.min(
-		availableRows,
+		availableRows - hintBudget,
 		minimumFocusedRows(contentRows, pinnedContentRows, priorityTailRows),
 	);
-	let remainingRows = Math.max(0, availableRows - minimumContentRows);
-	const hintBudget = hintRows.length > 0 && remainingRows > 0 ? 1 : 0;
-	remainingRows -= hintBudget;
+	let remainingRows = Math.max(0, availableRows - hintBudget - minimumContentRows);
 	const titleBudget = titleRows.length > 0 && remainingRows > 0 ? 1 : 0;
 	remainingRows -= titleBudget;
 	const extraHintBudget = Math.min(Math.max(0, hintRows.length - hintBudget), remainingRows);
@@ -166,7 +165,7 @@ function compactStaticRows(
 	hintRows: readonly string[],
 	availableRows: number,
 ): string[] {
-	const titleBudget = Math.min(titleRows.length, availableRows);
+	const titleBudget = titleRows.length > 0 ? 1 : 0;
 	const hintBudget = Math.min(hintRows.length, Math.max(0, availableRows - titleBudget));
 	const contextBudget = Math.max(0, availableRows - titleBudget - hintBudget);
 	return [

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -415,9 +415,7 @@ export function fitCompactHintSegments(segments: readonly string[], width: numbe
 	let result = "";
 	for (const segment of segments.map(safeMenuText).filter(Boolean)) {
 		const candidate = result ? `${result} • ${segment}` : segment;
-		if (visibleWidth(candidate) > safeWidth) {
-			return result || truncateToWidth(segment, safeWidth, "");
-		}
+		if (visibleWidth(candidate) > safeWidth) continue;
 		result = candidate;
 	}
 	return result;

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -1,5 +1,10 @@
 import { stripVTControlCharacters } from "node:util";
-import { type Input, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import {
+	type Input,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 import { HorizontalRule } from "../horizontal-rule.js";
 import { formatInteractionHints } from "../interaction-hints.js";
 import { replaceTerminalControls, safeMenuText } from "../text.js";
@@ -33,8 +38,10 @@ export function actionMenuDialogLabel(item: ActionMenuItem<string, string>): str
 }
 
 interface FrameLayoutOptions {
+	compactOverflowText?: string;
 	confirmAction?: string;
 	hint?: string;
+	navigation?: boolean;
 	pinnedContentRows?: number;
 	priorityTailRows?: number;
 }
@@ -50,6 +57,8 @@ export function renderFrame<ScreenId extends string, ActionId extends string>(
 ): string[] {
 	const safeWidth = Math.max(1, width);
 	const rule = renderHorizontalRule(safeWidth, options.theme);
+	const confirmAction = layout.confirmAction ?? "select";
+	const navigation = layout.navigation ?? true;
 	const titleRows = wrapTextWithAnsi(
 		options.theme.fg("accent", options.theme.bold(safeMenuText(title))),
 		safeWidth,
@@ -57,14 +66,30 @@ export function renderFrame<ScreenId extends string, ActionId extends string>(
 	const contextRows = lines.flatMap((line) =>
 		wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
 	);
-	const hintRows = wrapTextWithAnsi(
+	const hintText =
+		layout.hint ??
+		options.interactionHint ??
+		menuHint(options.keybindings, destination, confirmAction, navigation);
+	const hintRows = wrapTextWithAnsi(options.theme.fg("dim", hintText), safeWidth);
+	const compactFullHintRows = wrapTextWithAnsi(
 		options.theme.fg(
 			"dim",
-			layout.hint ??
-				options.interactionHint ??
-				menuHint(options.keybindings, destination, layout.confirmAction ?? "select"),
+			layout.compactOverflowText
+				? `${hintText} • ${safeMenuText(layout.compactOverflowText).trim()}`
+				: hintText,
 		),
 		safeWidth,
+	);
+	const compactHintRow = options.theme.fg(
+		"dim",
+		compactMenuHint(
+			options.keybindings,
+			destination,
+			confirmAction,
+			navigation,
+			layout.compactOverflowText,
+			safeWidth,
+		),
 	);
 	const fullFrame = [
 		rule,
@@ -83,7 +108,8 @@ export function renderFrame<ScreenId extends string, ActionId extends string>(
 					titleRows,
 					contextRows,
 					content,
-					hintRows,
+					compactFullHintRows,
+					compactHintRow,
 					maxRows,
 					layout.pinnedContentRows ?? 0,
 					layout.priorityTailRows ?? 0,
@@ -97,6 +123,7 @@ function compactFrame(
 	contextRows: readonly string[],
 	contentRows: readonly string[],
 	hintRows: readonly string[],
+	compactHintRow: string,
 	maxRows: number,
 	pinnedContentRows: number,
 	priorityTailRows: number,
@@ -113,11 +140,12 @@ function compactFrame(
 					contextRows,
 					compactContentRows,
 					hintRows,
+					compactHintRow,
 					availableRows,
 					pinnedContentRows,
 					priorityTailRows,
 				)
-			: compactStaticRows(titleRows, contextRows, hintRows, availableRows);
+			: compactStaticRows(titleRows, contextRows, compactHintRow, availableRows);
 	return framed ? [rule, ...body, rule] : body;
 }
 
@@ -126,11 +154,12 @@ function compactInteractiveRows(
 	contextRows: readonly string[],
 	contentRows: readonly string[],
 	hintRows: readonly string[],
+	compactHintRow: string,
 	availableRows: number,
 	pinnedContentRows: number,
 	priorityTailRows: number,
 ): string[] {
-	const hintBudget = hintRows.length > 0 && availableRows > 1 ? 1 : 0;
+	const hintBudget = compactHintRow && availableRows > 1 ? 1 : 0;
 	const minimumContentRows = Math.min(
 		availableRows - hintBudget,
 		minimumFocusedRows(contentRows, pinnedContentRows, priorityTailRows),
@@ -138,8 +167,9 @@ function compactInteractiveRows(
 	let remainingRows = Math.max(0, availableRows - hintBudget - minimumContentRows);
 	const titleBudget = titleRows.length > 0 && remainingRows > 0 ? 1 : 0;
 	remainingRows -= titleBudget;
-	const extraHintBudget = Math.min(Math.max(0, hintRows.length - hintBudget), remainingRows);
-	remainingRows -= extraHintBudget;
+	const extraHintRows = Math.max(0, hintRows.length - hintBudget);
+	const useFullHints = hintBudget > 0 && extraHintRows <= remainingRows;
+	if (useFullHints) remainingRows -= extraHintRows;
 	const contentBudget = Math.min(contentRows.length, minimumContentRows + remainingRows);
 	remainingRows -= contentBudget - minimumContentRows;
 	const contextBudget = Math.min(contextRows.length, remainingRows);
@@ -149,29 +179,34 @@ function compactInteractiveRows(
 		pinnedContentRows,
 		priorityTailRows,
 	);
-	const totalHintBudget = hintBudget + extraHintBudget;
-	const boundedHints = totalHintBudget > 0 ? hintRows.slice(-totalHintBudget) : [];
 	return [
 		...titleRows.slice(0, titleBudget),
 		...contextRows.slice(0, contextBudget),
 		...boundedContent,
-		...boundedHints,
+		...(hintBudget > 0 ? (useFullHints ? hintRows : [compactHintRow]) : []),
 	];
 }
 
 function compactStaticRows(
 	titleRows: readonly string[],
 	contextRows: readonly string[],
-	hintRows: readonly string[],
+	compactHintRow: string,
 	availableRows: number,
 ): string[] {
-	const titleBudget = titleRows.length > 0 ? 1 : 0;
-	const hintBudget = Math.min(hintRows.length, Math.max(0, availableRows - titleBudget));
-	const contextBudget = Math.max(0, availableRows - titleBudget - hintBudget);
+	if (availableRows <= 0) return [];
+	if (availableRows === 1) {
+		return [contextRows[0] || compactHintRow || titleRows[0] || ""];
+	}
+	const hintBudget = compactHintRow ? 1 : 0;
+	const minimumContextRows = contextRows.length > 0 ? 1 : 0;
+	let remainingRows = Math.max(0, availableRows - hintBudget - minimumContextRows);
+	const titleBudget = titleRows.length > 0 && remainingRows > 0 ? 1 : 0;
+	remainingRows -= titleBudget;
+	const contextBudget = Math.min(contextRows.length, minimumContextRows + remainingRows);
 	return [
 		...titleRows.slice(0, titleBudget),
 		...contextRows.slice(0, contextBudget),
-		...(hintBudget > 0 ? hintRows.slice(-hintBudget) : []),
+		...(hintBudget > 0 ? [compactHintRow] : []),
 	];
 }
 
@@ -246,9 +281,12 @@ export function menuHint(
 	keybindings: MenuKeybindings,
 	destination: "back" | "close",
 	confirmAction: string,
+	navigation = true,
 ) {
 	return formatInteractionHints(keybindings, [
-		{ bindings: ["tui.select.up", "tui.select.down"], label: "navigate" },
+		...(navigation
+			? [{ bindings: ["tui.select.up", "tui.select.down"] as const, label: "navigate" }]
+			: []),
 		...(confirmAction ? [{ bindings: ["tui.select.confirm"] as const, label: confirmAction }] : []),
 		{
 			bindings: ["tui.select.cancel"],
@@ -257,6 +295,60 @@ export function menuHint(
 		},
 		...(destination === "back" ? [{ keys: ["ctrl+c"], label: "close" }] : []),
 	]);
+}
+
+function compactMenuHint(
+	keybindings: MenuKeybindings,
+	destination: "back" | "close",
+	confirmAction: string,
+	navigation: boolean,
+	compactOverflowText: string | undefined,
+	width: number,
+) {
+	const cancel = formatInteractionHints(keybindings, [
+		{
+			bindings: ["tui.select.cancel"],
+			excludeKeys: ["ctrl+c"],
+			label: destination,
+		},
+	]);
+	return fitCompactHintSegments(
+		[
+			cancel,
+			...(compactOverflowText ? [safeMenuText(compactOverflowText).trim()] : []),
+			...(destination === "back" || !cancel
+				? [formatInteractionHints(keybindings, [{ keys: ["ctrl+c"], label: "close" }])]
+				: []),
+			...(confirmAction
+				? [
+						formatInteractionHints(keybindings, [
+							{ bindings: ["tui.select.confirm"], label: confirmAction },
+						]),
+					]
+				: []),
+			...(navigation
+				? [
+						formatInteractionHints(keybindings, [
+							{ bindings: ["tui.select.up", "tui.select.down"], label: "navigate" },
+						]),
+					]
+				: []),
+		],
+		width,
+	);
+}
+
+export function fitCompactHintSegments(segments: readonly string[], width: number) {
+	const safeWidth = Math.max(1, width);
+	let result = "";
+	for (const segment of segments.map(safeMenuText).filter(Boolean)) {
+		const candidate = result ? `${result} • ${segment}` : segment;
+		if (visibleWidth(candidate) > safeWidth) {
+			return result || truncateToWidth(segment, safeWidth, "");
+		}
+		result = candidate;
+	}
+	return result;
 }
 
 export function handleSearchInput(input: Input, data: string) {

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -357,10 +357,10 @@ function compactMenuHint(
 		[
 			...(cancelSegments.length > 0 ? cancelSegments : [cancel]),
 			...(compactOverflowText ? [safeMenuText(compactOverflowText).trim()] : []),
-			...keyedCustom,
 			...confirmSegments,
 			...hardCancelSegments,
 			...navigationSegments,
+			...keyedCustom,
 			...reminders,
 		],
 		width,

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -248,9 +248,10 @@ function priorityRowIndexes(
 ) {
 	const indexes = new Set<number>();
 	const pinned = Math.max(0, Math.min(rows.length, Math.floor(pinnedRows)));
-	for (let index = 0; index < pinned && indexes.size < budget; index += 1) indexes.add(index);
+	if (pinned > 0 && indexes.size < budget) indexes.add(0);
 	const selectedIndex = selectedRowIndex(rows);
 	if (selectedIndex >= 0 && indexes.size < budget) indexes.add(selectedIndex);
+	for (let index = 1; index < pinned && indexes.size < budget; index += 1) indexes.add(index);
 	const tailStart = Math.max(pinned, rows.length - Math.max(0, Math.floor(priorityTailRows)));
 	for (let index = tailStart; index < rows.length && indexes.size < budget; index += 1) {
 		indexes.add(index);

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -32,6 +32,13 @@ export function actionMenuDialogLabel(item: ActionMenuItem<string, string>): str
 	return `[-] ${label} (unavailable: ${reason})`;
 }
 
+interface FrameLayoutOptions {
+	confirmAction?: string;
+	hint?: string;
+	pinnedContentRows?: number;
+	priorityTailRows?: number;
+}
+
 export function renderFrame<ScreenId extends string, ActionId extends string>(
 	title: string,
 	lines: readonly string[],
@@ -39,7 +46,7 @@ export function renderFrame<ScreenId extends string, ActionId extends string>(
 	destination: "back" | "close",
 	width: number,
 	options: MenuScreenComponentOptions<ScreenId, ActionId>,
-	confirmAction = "select",
+	layout: FrameLayoutOptions = {},
 ): string[] {
 	const safeWidth = Math.max(1, width);
 	const rule = renderHorizontalRule(safeWidth, options.theme);
@@ -51,7 +58,12 @@ export function renderFrame<ScreenId extends string, ActionId extends string>(
 		wrapTextWithAnsi(options.theme.fg("muted", safeMenuText(line)), safeWidth),
 	);
 	const hintRows = wrapTextWithAnsi(
-		options.theme.fg("dim", menuHint(options.keybindings, destination, confirmAction)),
+		options.theme.fg(
+			"dim",
+			layout.hint ??
+				options.interactionHint ??
+				menuHint(options.keybindings, destination, layout.confirmAction ?? "select"),
+		),
 		safeWidth,
 	);
 	const fullFrame = [
@@ -62,11 +74,20 @@ export function renderFrame<ScreenId extends string, ActionId extends string>(
 		...hintRows,
 		rule,
 	];
-	const maxRows = terminalRows(options.tui.terminal.rows);
+	const maxRows = componentRows(options.tui.terminal.rows);
 	const result =
 		fullFrame.length <= maxRows
 			? fullFrame
-			: compactFrame(rule, titleRows, contextRows, content, hintRows, maxRows);
+			: compactFrame(
+					rule,
+					titleRows,
+					contextRows,
+					content,
+					hintRows,
+					maxRows,
+					layout.pinnedContentRows ?? 0,
+					layout.priorityTailRows ?? 0,
+				);
 	return result.map((line) => truncateToWidth(line, safeWidth, ""));
 }
 
@@ -77,36 +98,138 @@ function compactFrame(
 	contentRows: readonly string[],
 	hintRows: readonly string[],
 	maxRows: number,
+	pinnedContentRows: number,
+	priorityTailRows: number,
 ): string[] {
-	if (maxRows === 1) {
-		return [titleRows[0] ?? contentRows[0] ?? hintRows.at(-1) ?? rule];
-	}
-	if (maxRows === 2) return [rule, rule];
-	if (maxRows === 3) return [rule, titleRows[0] ?? contentRows[0] ?? hintRows.at(-1) ?? "", rule];
-	const boundedTitle = titleRows.slice(0, 1);
-	const hintBudget = Math.min(hintRows.length, Math.max(0, maxRows - 2 - boundedTitle.length));
-	const boundedHints = hintBudget > 0 ? hintRows.slice(-hintBudget) : [];
-	const bodyBudget = Math.max(0, maxRows - 2 - boundedTitle.length - boundedHints.length);
-	const boundedContent = focusedRows(contentRows, Math.min(contentRows.length, bodyBudget));
-	const contextBudget = Math.max(0, bodyBudget - boundedContent.length);
-	const boundedContext = contextRows.slice(0, contextBudget);
-	return [rule, ...boundedTitle, ...boundedContext, ...boundedContent, ...boundedHints, rule].slice(
-		0,
-		maxRows,
+	const framed = maxRows >= 5;
+	const availableRows = framed ? maxRows - 2 : maxRows;
+	const compactContentRows = contentRows.filter(
+		(line) => stripVTControlCharacters(line).trim().length > 0,
 	);
+	const body =
+		compactContentRows.length > 0
+			? compactInteractiveRows(
+					titleRows,
+					contextRows,
+					compactContentRows,
+					hintRows,
+					availableRows,
+					pinnedContentRows,
+					priorityTailRows,
+				)
+			: compactStaticRows(titleRows, contextRows, hintRows, availableRows);
+	return framed ? [rule, ...body, rule] : body;
 }
 
-function focusedRows(rows: readonly string[], budget: number): readonly string[] {
+function compactInteractiveRows(
+	titleRows: readonly string[],
+	contextRows: readonly string[],
+	contentRows: readonly string[],
+	hintRows: readonly string[],
+	availableRows: number,
+	pinnedContentRows: number,
+	priorityTailRows: number,
+): string[] {
+	const minimumContentRows = Math.min(
+		availableRows,
+		minimumFocusedRows(contentRows, pinnedContentRows, priorityTailRows),
+	);
+	let remainingRows = Math.max(0, availableRows - minimumContentRows);
+	const hintBudget = hintRows.length > 0 && remainingRows > 0 ? 1 : 0;
+	remainingRows -= hintBudget;
+	const titleBudget = titleRows.length > 0 && remainingRows > 0 ? 1 : 0;
+	remainingRows -= titleBudget;
+	const extraHintBudget = Math.min(Math.max(0, hintRows.length - hintBudget), remainingRows);
+	remainingRows -= extraHintBudget;
+	const contentBudget = Math.min(contentRows.length, minimumContentRows + remainingRows);
+	remainingRows -= contentBudget - minimumContentRows;
+	const contextBudget = Math.min(contextRows.length, remainingRows);
+	const boundedContent = focusedRows(
+		contentRows,
+		contentBudget,
+		pinnedContentRows,
+		priorityTailRows,
+	);
+	const totalHintBudget = hintBudget + extraHintBudget;
+	const boundedHints = totalHintBudget > 0 ? hintRows.slice(-totalHintBudget) : [];
+	return [
+		...titleRows.slice(0, titleBudget),
+		...contextRows.slice(0, contextBudget),
+		...boundedContent,
+		...boundedHints,
+	];
+}
+
+function compactStaticRows(
+	titleRows: readonly string[],
+	contextRows: readonly string[],
+	hintRows: readonly string[],
+	availableRows: number,
+): string[] {
+	const titleBudget = Math.min(titleRows.length, availableRows);
+	const hintBudget = Math.min(hintRows.length, Math.max(0, availableRows - titleBudget));
+	const contextBudget = Math.max(0, availableRows - titleBudget - hintBudget);
+	return [
+		...titleRows.slice(0, titleBudget),
+		...contextRows.slice(0, contextBudget),
+		...(hintBudget > 0 ? hintRows.slice(-hintBudget) : []),
+	];
+}
+
+function minimumFocusedRows(rows: readonly string[], pinnedRows: number, priorityTailRows: number) {
+	const priorities = priorityRowIndexes(rows, pinnedRows, priorityTailRows);
+	return Math.max(1, priorities.size);
+}
+
+function focusedRows(
+	rows: readonly string[],
+	budget: number,
+	pinnedRows = 0,
+	priorityTailRows = 0,
+): readonly string[] {
 	if (budget <= 0) return [];
 	if (rows.length <= budget) return rows;
-	const selectedIndex = rows.findIndex((line) => /^[→›]\s/u.test(stripVTControlCharacters(line)));
-	if (selectedIndex < 0) return rows.slice(0, budget);
-	const start = Math.max(0, Math.min(selectedIndex - Math.floor(budget / 2), rows.length - budget));
-	return rows.slice(start, start + budget);
+	const indexes = priorityRowIndexes(rows, pinnedRows, priorityTailRows, budget);
+	const selectedIndex = selectedRowIndex(rows);
+	const fillOrder = Array.from({ length: rows.length }, (_, index) => index).sort((left, right) => {
+		if (selectedIndex < 0) return left - right;
+		return Math.abs(left - selectedIndex) - Math.abs(right - selectedIndex) || left - right;
+	});
+	for (const index of fillOrder) {
+		if (indexes.size >= budget) break;
+		indexes.add(index);
+	}
+	return [...indexes]
+		.sort((left, right) => left - right)
+		.map((index) => rows[index])
+		.filter((line): line is string => line !== undefined);
 }
 
-function terminalRows(rows: number) {
-	return Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : 24;
+function priorityRowIndexes(
+	rows: readonly string[],
+	pinnedRows: number,
+	priorityTailRows: number,
+	budget = Number.POSITIVE_INFINITY,
+) {
+	const indexes = new Set<number>();
+	const pinned = Math.max(0, Math.min(rows.length, Math.floor(pinnedRows)));
+	for (let index = 0; index < pinned && indexes.size < budget; index += 1) indexes.add(index);
+	const selectedIndex = selectedRowIndex(rows);
+	if (selectedIndex >= 0 && indexes.size < budget) indexes.add(selectedIndex);
+	const tailStart = Math.max(pinned, rows.length - Math.max(0, Math.floor(priorityTailRows)));
+	for (let index = tailStart; index < rows.length && indexes.size < budget; index += 1) {
+		indexes.add(index);
+	}
+	return indexes;
+}
+
+function selectedRowIndex(rows: readonly string[]) {
+	return rows.findIndex((line) => /^[→›]\s/u.test(stripVTControlCharacters(line)));
+}
+
+export function componentRows(rows: number) {
+	const terminalRows = Number.isFinite(rows) ? Math.floor(rows) : 24;
+	return Math.max(1, terminalRows - 3);
 }
 
 export function renderHorizontalRule(

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -11,10 +11,9 @@ import {
 	RPC_DOCUMENT_LINE_WIDTH,
 	RPC_DOCUMENT_PAGE_SIZE,
 } from "./document-formatting.js";
-import { menuHint, renderFrame, renderHorizontalRule, safeMenuText } from "./rendering.js";
+import { componentRows, menuHint, renderHorizontalRule, safeMenuText } from "./rendering.js";
 
 const DEFAULT_REVIEW_VIEWPORT_SIZE = 14;
-const RESERVED_HOST_ROWS = 3;
 const MIN_FRAMED_ROWS = 5;
 
 export type ReviewOptions<
@@ -46,44 +45,23 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 				options.screen.format,
 				safeWidth,
 			);
-			const terminalRows =
-				options.screen.viewportSize === "adaptive" ? options.tui.terminal.rows : undefined;
-			if (terminalRows !== undefined && Number.isFinite(terminalRows)) {
-				const frame = renderAdaptiveReviewFrame({
-					screen: options.screen,
-					allLines,
-					width: safeWidth,
-					terminalRows,
-					scrollOffset,
-					theme: options.theme,
-					keybindings: options.keybindings,
-				});
-				scrollOffset = frame.scrollOffset;
-				lastMaximumScroll = frame.maximumScroll;
-				lastViewportSize = frame.viewportSize;
-				return frame.lines;
-			}
-
-			const viewportSize = reviewViewportSize(options.screen);
-			lastMaximumScroll = Math.max(0, allLines.length - viewportSize);
-			scrollOffset = Math.max(0, Math.min(scrollOffset, lastMaximumScroll));
-			lastViewportSize = viewportSize;
-			const visible = allLines.slice(scrollOffset, scrollOffset + viewportSize);
-			const first = allLines.length === 0 ? 0 : scrollOffset + 1;
-			const last = Math.min(allLines.length, scrollOffset + viewportSize);
-			const position =
-				allLines.length > viewportSize
-					? [options.theme.fg("dim", `${first}-${last}/${allLines.length}`)]
-					: [];
-			return renderFrame(
-				options.screen.title,
-				options.screen.lines ?? [],
-				[...visible, ...position],
-				options.screen.hint ?? "back",
-				safeWidth,
-				options,
-				options.screen.confirm ? safeMenuText(options.screen.confirm.label) : "",
-			);
+			const frame = renderAdaptiveReviewFrame({
+				screen: options.screen,
+				allLines,
+				width: safeWidth,
+				terminalRows: options.tui.terminal.rows,
+				maximumViewportSize:
+					options.screen.viewportSize === "adaptive"
+						? undefined
+						: reviewViewportSize(options.screen),
+				scrollOffset,
+				theme: options.theme,
+				keybindings: options.keybindings,
+			});
+			scrollOffset = frame.scrollOffset;
+			lastMaximumScroll = frame.maximumScroll;
+			lastViewportSize = frame.viewportSize;
+			return frame.lines;
 		},
 		invalidate() {
 			documentLineCache.invalidate();
@@ -121,6 +99,7 @@ interface AdaptiveReviewFrameOptions<ActionId extends string> {
 	allLines: readonly string[];
 	width: number;
 	terminalRows: number;
+	maximumViewportSize?: number;
 	scrollOffset: number;
 	theme: MenuScreenComponentOptions<string, ActionId>["theme"];
 	keybindings: MenuKeybindings;
@@ -144,7 +123,7 @@ interface AdaptiveReviewChrome {
 function renderAdaptiveReviewFrame<ActionId extends string>(
 	options: AdaptiveReviewFrameOptions<ActionId>,
 ): AdaptiveReviewFrame {
-	const totalRows = Math.max(1, Math.floor(options.terminalRows) - RESERVED_HOST_ROWS);
+	const totalRows = componentRows(options.terminalRows);
 	const framed = totalRows >= MIN_FRAMED_ROWS;
 	const availableRows = framed ? totalRows - 2 : totalRows;
 	const destination = options.screen.hint ?? "back";
@@ -174,9 +153,17 @@ function renderAdaptiveReviewFrame<ActionId extends string>(
 		fullHint,
 		criticalHint,
 		false,
+		options.maximumViewportSize,
 	);
 	if (availableRows >= 4 && options.allLines.length > chrome.viewportSize) {
-		chrome = allocateAdaptiveReviewChrome(availableRows, fullHeader, fullHint, criticalHint, true);
+		chrome = allocateAdaptiveReviewChrome(
+			availableRows,
+			fullHeader,
+			fullHint,
+			criticalHint,
+			true,
+			options.maximumViewportSize,
+		);
 	}
 
 	const maximumScroll = Math.max(0, options.allLines.length - chrome.viewportSize);
@@ -211,6 +198,7 @@ function allocateAdaptiveReviewChrome(
 	fullHint: readonly string[],
 	criticalHint: string,
 	showPosition: boolean,
+	maximumViewportSize?: number,
 ): AdaptiveReviewChrome {
 	if (availableRows === 1) {
 		return { header: [], separator: false, hint: [], showPosition: false, viewportSize: 1 };
@@ -254,7 +242,10 @@ function allocateAdaptiveReviewChrome(
 		separator,
 		hint,
 		showPosition,
-		viewportSize: 1 + remainingRows,
+		viewportSize: Math.min(
+			1 + remainingRows,
+			maximumViewportSize === undefined ? Number.POSITIVE_INFINITY : maximumViewportSize,
+		),
 	};
 }
 

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -235,9 +235,9 @@ function allocateAdaptiveReviewChrome(
 	const compactHeader = [fullHeader[0] ?? ""];
 	if (availableRows === 2) {
 		return {
-			header: compactHeader,
+			header: [],
 			separator: false,
-			hint: [],
+			hint: [criticalHint],
 			showPosition: false,
 			viewportSize: 1,
 		};

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -224,6 +224,8 @@ function allocateAdaptiveReviewChrome(
 	}
 
 	let remainingRows = availableRows - 3 - Number(showPosition);
+	const reservedViewportRows = Math.min(remainingRows, Math.max(0, (maximumViewportSize ?? 1) - 1));
+	remainingRows -= reservedViewportRows;
 	const extraHeaderCount = Math.min(remainingRows, Math.max(0, fullHeader.length - 1));
 	const header = [...compactHeader, ...fullHeader.slice(1, 1 + extraHeaderCount)];
 	remainingRows -= extraHeaderCount;
@@ -243,7 +245,7 @@ function allocateAdaptiveReviewChrome(
 		hint,
 		showPosition,
 		viewportSize: Math.min(
-			1 + remainingRows,
+			1 + reservedViewportRows + remainingRows,
 			maximumViewportSize === undefined ? Number.POSITIVE_INFINITY : maximumViewportSize,
 		),
 	};

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import { Key, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { MenuScreen, ReviewScreen } from "../types.js";
 import type {
@@ -46,10 +47,16 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 	return {
 		render(width) {
 			const safeWidth = Math.max(1, width);
-			const allLines =
-				options.screen.content.length === 0
-					? []
-					: documentLineCache.lines(options.screen.content, options.screen.format, safeWidth);
+			const formattedLines = documentLineCache.lines(
+				options.screen.content,
+				options.screen.format,
+				safeWidth,
+			);
+			const allLines = formattedLines.some(
+				(line) => stripVTControlCharacters(line).trim().length > 0,
+			)
+				? formattedLines
+				: [];
 			const frame = renderAdaptiveReviewFrame({
 				screen: options.screen,
 				allLines,
@@ -58,7 +65,7 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 				maximumViewportSize:
 					options.screen.viewportSize === "adaptive"
 						? undefined
-						: reviewViewportSize(options.screen),
+						: Math.min(reviewViewportSize(options.screen), allLines.length),
 				scrollOffset,
 				theme: options.theme,
 				keybindings: options.keybindings,
@@ -285,9 +292,9 @@ function compactReviewHint(
 	const down = reviewBindingText(keybindings, "tui.select.down");
 	return fitCompactHintSegments(
 		[
-			...(confirm && confirmAction ? [`${confirm} ${confirmAction}`] : []),
 			...(cancel ? [`${cancel} ${destination}`] : []),
 			...(destination === "back" || !cancel ? ["ctrl+c close"] : []),
+			...(confirm && confirmAction ? [`${confirm} ${confirmAction}`] : []),
 			...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
 		],
 		width,

--- a/packages/pi-tui-kit/src/components/review.ts
+++ b/packages/pi-tui-kit/src/components/review.ts
@@ -11,7 +11,13 @@ import {
 	RPC_DOCUMENT_LINE_WIDTH,
 	RPC_DOCUMENT_PAGE_SIZE,
 } from "./document-formatting.js";
-import { componentRows, menuHint, renderHorizontalRule, safeMenuText } from "./rendering.js";
+import {
+	componentRows,
+	fitCompactHintSegments,
+	menuHint,
+	renderHorizontalRule,
+	safeMenuText,
+} from "./rendering.js";
 
 const DEFAULT_REVIEW_VIEWPORT_SIZE = 14;
 const MIN_FRAMED_ROWS = 5;
@@ -40,11 +46,10 @@ export function createReviewComponent<ScreenId extends string, ActionId extends 
 	return {
 		render(width) {
 			const safeWidth = Math.max(1, width);
-			const allLines = documentLineCache.lines(
-				options.screen.content,
-				options.screen.format,
-				safeWidth,
-			);
+			const allLines =
+				options.screen.content.length === 0
+					? []
+					: documentLineCache.lines(options.screen.content, options.screen.format, safeWidth);
 			const frame = renderAdaptiveReviewFrame({
 				screen: options.screen,
 				allLines,
@@ -141,20 +146,22 @@ function renderAdaptiveReviewFrame<ActionId extends string>(
 		options.theme.fg("dim", menuHint(options.keybindings, destination, confirmAction)),
 		options.width,
 	).map((line) => truncateToWidth(line, options.width, ""));
-	const criticalHint = truncateToWidth(
-		options.theme.fg("dim", compactReviewHint(options.keybindings, destination, confirmAction)),
-		options.width,
-		"",
+	const criticalHint = options.theme.fg(
+		"dim",
+		compactReviewHint(options.keybindings, destination, confirmAction, options.width),
 	);
 
-	let chrome = allocateAdaptiveReviewChrome(
-		availableRows,
-		fullHeader,
-		fullHint,
-		criticalHint,
-		false,
-		options.maximumViewportSize,
-	);
+	let chrome =
+		options.allLines.length === 0
+			? allocateEmptyReviewChrome(availableRows, fullHeader, fullHint, criticalHint)
+			: allocateAdaptiveReviewChrome(
+					availableRows,
+					fullHeader,
+					fullHint,
+					criticalHint,
+					false,
+					options.maximumViewportSize,
+				);
 	if (availableRows >= 4 && options.allLines.length > chrome.viewportSize) {
 		chrome = allocateAdaptiveReviewChrome(
 			availableRows,
@@ -190,6 +197,21 @@ function renderAdaptiveReviewFrame<ActionId extends string>(
 		: contentLines;
 
 	return { lines, scrollOffset, maximumScroll, viewportSize: chrome.viewportSize };
+}
+
+function allocateEmptyReviewChrome(
+	availableRows: number,
+	fullHeader: readonly string[],
+	fullHint: readonly string[],
+	criticalHint: string,
+): AdaptiveReviewChrome {
+	if (availableRows <= 0) {
+		return { header: [], separator: false, hint: [], showPosition: false, viewportSize: 0 };
+	}
+	const hint =
+		fullHint.length > 0 && fullHint.length < availableRows ? [...fullHint] : [criticalHint];
+	const header = fullHeader.slice(0, Math.max(0, availableRows - hint.length));
+	return { header, separator: false, hint, showPosition: false, viewportSize: 0 };
 }
 
 function allocateAdaptiveReviewChrome(
@@ -255,17 +277,21 @@ function compactReviewHint(
 	keybindings: MenuKeybindings,
 	destination: "back" | "close",
 	confirmAction: string,
+	width: number,
 ) {
 	const confirm = reviewBindingText(keybindings, "tui.select.confirm");
 	const cancel = reviewBindingText(keybindings, "tui.select.cancel", "ctrl+c");
 	const up = reviewBindingText(keybindings, "tui.select.up");
 	const down = reviewBindingText(keybindings, "tui.select.down");
-	return [
-		...(confirm && confirmAction ? [`${confirm} ${confirmAction}`] : []),
-		...(cancel ? [`${cancel} ${destination}`] : []),
-		...(destination === "back" || !cancel ? ["ctrl+c close"] : []),
-		...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
-	].join(" • ");
+	return fitCompactHintSegments(
+		[
+			...(confirm && confirmAction ? [`${confirm} ${confirmAction}`] : []),
+			...(cancel ? [`${cancel} ${destination}`] : []),
+			...(destination === "back" || !cancel ? ["ctrl+c close"] : []),
+			...(up || down ? [`${[up, down].filter(Boolean).join("/")} navigate`] : []),
+		],
+		width,
+	);
 }
 
 function reviewBindingText(

--- a/packages/pi-tui-kit/test/input-screen.test.ts
+++ b/packages/pi-tui-kit/test/input-screen.test.ts
@@ -67,6 +67,27 @@ test("input rejection preserves the draft and accepted submit transitions", asyn
 	assert.deepEqual(transitions, [{ kind: "close" }]);
 });
 
+test("compact input screens keep their saving indicator visible while submit is pending", async () => {
+	let release: (() => void) | undefined;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const harness = inputComponentHarness({
+		rows: 8,
+		onInputSubmit: async () => {
+			await gate;
+			return false;
+		},
+	});
+	harness.component.handleInput("x");
+	harness.component.handleInput("\r");
+	const rendered = stripVTControlCharacters(harness.component.render(32).join("\n"));
+	assert.match(rendered, /> x/u);
+	assert.match(rendered, /Saving…/u);
+	release?.();
+	await harness.component.waitForPending();
+});
+
 test("input screen drains a pending submit before Back and distinguishes Ctrl+C Close", async () => {
 	let release: (() => void) | undefined;
 	const gate = new Promise<void>((resolve) => {
@@ -250,12 +271,13 @@ function inputComponentHarness(
 			value: string;
 		}) => Promise<boolean | { accepted: boolean; transition: MenuTransition<ScreenId> }>;
 		onTransition?: (transition: MenuTransition<ScreenId>) => void;
+		rows?: number;
 	} = {},
 ) {
 	const events: Array<{ kind: "back" | "close" } | { kind: "activate"; itemId: string }> = [];
 	const component = createMenuScreenComponent<ScreenId, ActionId>({
 		screen: inputScreen,
-		tui: { terminal: { rows: 24 }, requestRender() {} },
+		tui: { terminal: { rows: overrides.rows ?? 24 }, requestRender() {} },
 		theme: {
 			fg: (_color: string, text: string) => text,
 			bold: (text: string) => text,

--- a/packages/pi-tui-kit/test/live-choice.test.ts
+++ b/packages/pi-tui-kit/test/live-choice.test.ts
@@ -91,6 +91,9 @@ test("runLiveChoice preserves supplied controls in height-compacted hints", asyn
 	assert.match(rendered, /e customize/u);
 	assert.match(rendered, /enter apply/u);
 	assert.match(rendered, /↑\/↓ inspect/u);
+	const narrow = stripVTControlCharacters(tui.resize({ width: 45 }).join("\n"));
+	assert.match(narrow, /esc back • \(1\/3\) • enter apply • ctrl\+c close/u);
+	assert.doesNotMatch(narrow, /customize|page/u);
 	tui.press("ctrl+c");
 	assert.deepEqual(await running, { kind: "closed", reason: "close" });
 });

--- a/packages/pi-tui-kit/test/live-choice.test.ts
+++ b/packages/pi-tui-kit/test/live-choice.test.ts
@@ -76,6 +76,25 @@ test("runLiveChoice blocks gated confirmation while preserving preview and short
 	});
 });
 
+test("runLiveChoice preserves supplied controls in height-compacted hints", async () => {
+	const tui = createTuiHarness({ width: 120, rows: 8 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runLiveChoice(context.ctx, {
+		title: "Preset",
+		items: choices,
+		navigationLabel: "inspect",
+		confirmLabel: "apply",
+		shortcuts: [{ id: "customize", keys: ["e"], label: "customize" }],
+	});
+	await tui.waitForOpen();
+	const rendered = stripVTControlCharacters(tui.render().join("\n"));
+	assert.match(rendered, /e customize/u);
+	assert.match(rendered, /enter apply/u);
+	assert.match(rendered, /↑\/↓ inspect/u);
+	tui.press("ctrl+c");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+});
+
 test("runLiveChoice preserves gated Back, Close, owner abort, and disposal", async () => {
 	async function drive(exit: "tui.select.cancel" | "ctrl+c") {
 		const tui = createTuiHarness();

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -139,6 +139,21 @@ test("rendered-empty fixed and default reviews preserve controls at minimum heig
 	}
 });
 
+test("two-row fixed and default reviews preserve content and cancellation", () => {
+	for (const viewportSize of [3, undefined]) {
+		const harness = reviewComponentHarness(
+			{ ...reviewScreen, content: "Important change", viewportSize },
+			false,
+			5,
+		);
+		const rendered = plainLines(harness.component, 80);
+		assert.equal(rendered.length, 2);
+		assert.match(rendered[0] ?? "", /Important change/u);
+		assert.match(rendered[1] ?? "", /q back/u);
+		assert.doesNotMatch(rendered.join("\n"), /Review changes/u);
+	}
+});
+
 test("narrow compact review hints advertise cancellation before confirmation", () => {
 	const custom = reviewComponentHarness(reviewScreen, false, 6);
 	assert.match(plainRender(custom.component, 10), /q back/u);
@@ -214,7 +229,10 @@ test("adaptive review degrades explicitly at constrained terminal heights", () =
 	assert.deepEqual(plainLines(harness.component, 80), ["row 1"]);
 
 	harness.setTerminalRows(5);
-	assert.deepEqual(plainLines(harness.component, 80), ["Review changes", "row 1"]);
+	assert.deepEqual(plainLines(harness.component, 80), [
+		"row 1",
+		"q back • ctrl+c close • l Apply • k/j navigate",
+	]);
 
 	harness.setTerminalRows(6);
 	assert.deepEqual(plainLines(harness.component, 80), [

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -23,6 +23,53 @@ const reviewScreen: ReviewScreen<ActionId> = {
 	hint: "back",
 };
 
+type ReviewKeybindings = {
+	matches(data: string, binding: string): boolean;
+	getKeys(binding: string): readonly string[];
+};
+
+const reviewTestKeybindings: ReviewKeybindings = {
+	matches(data, binding) {
+		const values: Record<string, string> = {
+			"tui.select.up": "k",
+			"tui.select.down": "j",
+			"tui.select.pageUp": "u",
+			"tui.select.pageDown": "d",
+			"tui.select.confirm": "l",
+			"tui.select.cancel": "q",
+		};
+		return data === values[binding];
+	},
+	getKeys(binding) {
+		const values: Record<string, readonly string[]> = {
+			"tui.select.up": ["k"],
+			"tui.select.down": ["j"],
+			"tui.select.pageUp": ["u"],
+			"tui.select.pageDown": ["d"],
+			"tui.select.confirm": ["l"],
+			"tui.select.cancel": ["q", "ctrl+c"],
+		};
+		return values[binding] ?? [];
+	},
+};
+
+const defaultReviewKeybindings: ReviewKeybindings = {
+	matches() {
+		return false;
+	},
+	getKeys(binding) {
+		const values: Record<string, readonly string[]> = {
+			"tui.select.up": ["up"],
+			"tui.select.down": ["down"],
+			"tui.select.pageUp": ["pageup"],
+			"tui.select.pageDown": ["pagedown"],
+			"tui.select.confirm": ["enter"],
+			"tui.select.cancel": ["escape", "ctrl+c"],
+		};
+		return values[binding] ?? [];
+	},
+};
+
 test("review preserves whitespace, sanitizes controls, and bounds exact text at every width", () => {
 	const harness = reviewComponentHarness({
 		...reviewScreen,
@@ -74,20 +121,38 @@ test("fixed and default review frames use consistent rules and preserve content"
 	]);
 });
 
-test("empty fixed and default reviews preserve controls at minimum heights", () => {
-	for (const viewportSize of [3, undefined]) {
-		for (const terminalRows of [4, 5]) {
-			const harness = reviewComponentHarness(
-				{ ...reviewScreen, content: "", viewportSize },
-				false,
-				terminalRows,
-			);
-			const lines = plainLines(harness.component, 80);
-			assert.ok(lines.length > 0);
-			assert.match(lines.join("\n"), /l Apply|q back|ctrl\+c close/u);
-			assert.ok(lines.every((line) => line.length > 0));
+test("rendered-empty fixed and default reviews preserve controls at minimum heights", () => {
+	for (const content of ["", " ", "\n", " \n\t"]) {
+		for (const viewportSize of [3, undefined]) {
+			for (const terminalRows of [4, 5]) {
+				const harness = reviewComponentHarness(
+					{ ...reviewScreen, content, viewportSize },
+					false,
+					terminalRows,
+				);
+				const lines = plainLines(harness.component, 80);
+				assert.ok(lines.length > 0);
+				assert.match(lines.join("\n"), /l Apply|q back|ctrl\+c close/u);
+				assert.ok(lines.every((line) => line.trim().length > 0));
+			}
 		}
 	}
+});
+
+test("narrow compact review hints advertise cancellation before confirmation", () => {
+	const custom = reviewComponentHarness(reviewScreen, false, 6);
+	assert.match(plainRender(custom.component, 10), /q back/u);
+	assert.doesNotMatch(plainRender(custom.component, 10), /l Apply/u);
+
+	const defaults = reviewComponentHarness(
+		reviewScreen,
+		false,
+		6,
+		undefined,
+		defaultReviewKeybindings,
+	);
+	assert.match(plainRender(defaults.component, 12), /esc back/u);
+	assert.doesNotMatch(plainRender(defaults.component, 12), /enter Apply/u);
 });
 
 test("fixed and default review pagination reaches the end after height compaction", () => {
@@ -124,6 +189,21 @@ test("fixed and default reviews reserve their requested viewport before extra he
 	}
 });
 
+test("fixed and default reviews cap reserved viewport rows at formatted content length", () => {
+	const lines = Array.from({ length: 10 }, (_, index) => `Context ${index + 1}`);
+	for (const viewportSize of [14, undefined]) {
+		const harness = reviewComponentHarness(
+			{ ...reviewScreen, content: "only row", lines, viewportSize },
+			false,
+			24,
+		);
+		const rendered = plainRender(harness.component, 80);
+		assert.match(rendered, /Context 1[\s\S]*Context 10/u);
+		assert.match(rendered, /only row/u);
+		assert.ok(harness.component.render(80).length <= 21);
+	}
+});
+
 test("adaptive review degrades explicitly at constrained terminal heights", () => {
 	const content = Array.from({ length: 10 }, (_, index) => `row ${index + 1}`).join("\n");
 	const harness = reviewComponentHarness(
@@ -140,7 +220,7 @@ test("adaptive review degrades explicitly at constrained terminal heights", () =
 	assert.deepEqual(plainLines(harness.component, 80), [
 		"Review changes",
 		"row 1",
-		"l Apply • q back • ctrl+c close • k/j navigate",
+		"q back • ctrl+c close • l Apply • k/j navigate",
 	]);
 
 	harness.setTerminalRows(7);
@@ -148,7 +228,7 @@ test("adaptive review degrades explicitly at constrained terminal heights", () =
 		"Review changes",
 		"row 1",
 		"1-1/10",
-		"l Apply • q back • ctrl+c close • k/j navigate",
+		"q back • ctrl+c close • l Apply • k/j navigate",
 	]);
 
 	harness.setTerminalRows(8);
@@ -156,7 +236,7 @@ test("adaptive review degrades explicitly at constrained terminal heights", () =
 		"─".repeat(80),
 		"Review changes",
 		"row 1",
-		"l Apply • q back • ctrl+c close • k/j navigate",
+		"q back • ctrl+c close • l Apply • k/j navigate",
 		"─".repeat(80),
 	]);
 });
@@ -698,6 +778,7 @@ function reviewComponentHarness(
 	themed = false,
 	terminalRows = 24,
 	onColor?: (color: string) => void,
+	keybindings = reviewTestKeybindings,
 ) {
 	const events: Array<{ kind: "back" | "close" } | { kind: "activate"; itemId: string }> = [];
 	const terminal = { rows: terminalRows };
@@ -711,30 +792,7 @@ function reviewComponentHarness(
 			},
 			bold: (text: string) => text,
 		},
-		keybindings: {
-			matches(data: string, binding: string) {
-				const values: Record<string, string> = {
-					"tui.select.up": "k",
-					"tui.select.down": "j",
-					"tui.select.pageUp": "u",
-					"tui.select.pageDown": "d",
-					"tui.select.confirm": "l",
-					"tui.select.cancel": "q",
-				};
-				return data === values[binding];
-			},
-			getKeys(binding: string) {
-				const values: Record<string, readonly string[]> = {
-					"tui.select.up": ["k"],
-					"tui.select.down": ["j"],
-					"tui.select.pageUp": ["u"],
-					"tui.select.pageDown": ["d"],
-					"tui.select.confirm": ["l"],
-					"tui.select.cancel": ["q", "ctrl+c"],
-				};
-				return values[binding] ?? [];
-			},
-		},
+		keybindings,
 		onEvent: (event) => events.push(event),
 	});
 	return {

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -74,6 +74,24 @@ test("fixed and default review frames use consistent rules and preserve content"
 	]);
 });
 
+test("fixed and default review pagination reaches the end after height compaction", () => {
+	const content = Array.from({ length: 20 }, (_, index) => `row ${index + 1}`).join("\n");
+	for (const viewportSize of [14, undefined]) {
+		const harness = reviewComponentHarness({ ...reviewScreen, content, viewportSize }, false, 10);
+		let rendered = plainRender(harness.component, 80);
+		assert.ok(harness.component.render(80).length <= 7);
+		assert.match(rendered, /row 1/u);
+		assert.match(rendered, /1-1\/20/u);
+
+		harness.component.handleInput("\u001b[F");
+		rendered = plainRender(harness.component, 80);
+		assert.match(rendered, /row 20/u);
+		assert.match(rendered, /20-20\/20/u);
+		harness.component.handleInput("u");
+		assert.match(plainRender(harness.component, 80), /row 19/u);
+	}
+});
+
 test("adaptive review degrades explicitly at constrained terminal heights", () => {
 	const content = Array.from({ length: 10 }, (_, index) => `row ${index + 1}`).join("\n");
 	const harness = reviewComponentHarness(

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -81,14 +81,30 @@ test("fixed and default review pagination reaches the end after height compactio
 		let rendered = plainRender(harness.component, 80);
 		assert.ok(harness.component.render(80).length <= 7);
 		assert.match(rendered, /row 1/u);
-		assert.match(rendered, /1-1\/20/u);
+		assert.match(rendered, /1-2\/20/u);
 
 		harness.component.handleInput("\u001b[F");
 		rendered = plainRender(harness.component, 80);
 		assert.match(rendered, /row 20/u);
-		assert.match(rendered, /20-20\/20/u);
+		assert.match(rendered, /19-20\/20/u);
 		harness.component.handleInput("u");
-		assert.match(plainRender(harness.component, 80), /row 19/u);
+		assert.match(plainRender(harness.component, 80), /row 17/u);
+	}
+});
+
+test("fixed and default reviews reserve their requested viewport before extra header rows", () => {
+	const content = Array.from({ length: 20 }, (_, index) => `row ${index + 1}`).join("\n");
+	const lines = Array.from({ length: 20 }, (_, index) => `Context ${index + 1}`);
+	for (const viewportSize of [14, undefined]) {
+		const harness = reviewComponentHarness(
+			{ ...reviewScreen, content, lines, viewportSize },
+			false,
+			24,
+		);
+		const rendered = plainRender(harness.component, 80);
+		assert.match(rendered, /row 1[\s\S]*row 14/u);
+		assert.match(rendered, /1-14\/20/u);
+		assert.ok(harness.component.render(80).length <= 21);
 	}
 });
 

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -70,6 +70,14 @@ const defaultReviewKeybindings: ReviewKeybindings = {
 	},
 };
 
+const longCancelReviewKeybindings: ReviewKeybindings = {
+	...defaultReviewKeybindings,
+	getKeys(binding) {
+		if (binding === "tui.select.cancel") return ["shift+escape", "ctrl+c"];
+		return defaultReviewKeybindings.getKeys(binding);
+	},
+};
+
 test("review preserves whitespace, sanitizes controls, and bounds exact text at every width", () => {
 	const harness = reviewComponentHarness({
 		...reviewScreen,
@@ -168,6 +176,19 @@ test("narrow compact review hints advertise cancellation before confirmation", (
 	);
 	assert.match(plainRender(defaults.component, 12), /esc back/u);
 	assert.doesNotMatch(plainRender(defaults.component, 12), /enter Apply/u);
+});
+
+test("compact review hints skip oversized controls and retain later controls", () => {
+	const harness = reviewComponentHarness(
+		reviewScreen,
+		false,
+		6,
+		undefined,
+		longCancelReviewKeybindings,
+	);
+	const rendered = plainRender(harness.component, 12);
+	assert.match(rendered, /ctrl\+c close/u);
+	assert.doesNotMatch(rendered, /shift\+escap/u);
 });
 
 test("fixed and default review pagination reaches the end after height compaction", () => {

--- a/packages/pi-tui-kit/test/review-screen.test.ts
+++ b/packages/pi-tui-kit/test/review-screen.test.ts
@@ -74,6 +74,22 @@ test("fixed and default review frames use consistent rules and preserve content"
 	]);
 });
 
+test("empty fixed and default reviews preserve controls at minimum heights", () => {
+	for (const viewportSize of [3, undefined]) {
+		for (const terminalRows of [4, 5]) {
+			const harness = reviewComponentHarness(
+				{ ...reviewScreen, content: "", viewportSize },
+				false,
+				terminalRows,
+			);
+			const lines = plainLines(harness.component, 80);
+			assert.ok(lines.length > 0);
+			assert.match(lines.join("\n"), /l Apply|q back|ctrl\+c close/u);
+			assert.ok(lines.every((line) => line.length > 0));
+		}
+	}
+});
+
 test("fixed and default review pagination reaches the end after height compaction", () => {
 	const content = Array.from({ length: 20 }, (_, index) => `row ${index + 1}`).join("\n");
 	for (const viewportSize of [14, undefined]) {

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -242,7 +242,50 @@ test("choice and settings screens reserve host rows and keep focused controls vi
 	assert.equal(settingsLines.at(-1), "─".repeat(40));
 	assert.ok(settingsLines.some((line) => line.startsWith("> ")));
 	assert.match(settingsLines.join("\n"), /→ Setting 11/u);
+	assert.match(settingsLines.join("\n"), /Description for setting 11/u);
 	assert.match(settingsLines.join("\n"), /Esc to go back/u);
+});
+
+test("compact searchable choices preserve empty states ahead of search reminders", () => {
+	const harness = componentHarness(
+		{ ...choiceScreen, enableSearch: true },
+		{
+			plainTheme: true,
+			rows: 9,
+			keybindings: inputFriendlyKeybindings,
+		},
+	);
+	for (const input of ["z", "z", "z"]) harness.component.handleInput(input);
+	const rendered = plainRender(harness.component, 32).join("\n");
+	assert.match(rendered, /No matching choices/u);
+	assert.doesNotMatch(rendered, /Type to search/u);
+	assert.match(rendered, /esc\s+back/u);
+});
+
+test("compact interactive frames reserve their critical interaction hint", () => {
+	const harness = componentHarness(choiceScreen, {
+		selectedItemId: "verbose",
+		plainTheme: true,
+		rows: 9,
+		keybindings: inputFriendlyKeybindings,
+	});
+	const rendered = plainRender(harness.component, 32).join("\n");
+	assert.match(rendered, /→ \[-\] Verbose/u);
+	assert.match(rendered, /esc\s+back/u);
+});
+
+test("compact static frames reserve cancellation hints before wrapped titles", () => {
+	const harness = componentHarness(
+		{
+			...detailScreen,
+			title: "A very long detail title that wraps across every available compact row",
+			lines: [],
+		},
+		{ plainTheme: true, rows: 9, keybindings: inputFriendlyKeybindings },
+	);
+	const rendered = plainRender(harness.component, 20).join("\n");
+	assert.match(rendered, /A very long detail/u);
+	assert.match(rendered, /esc\s+back|ctrl\+c\s+close/u);
 });
 
 test("action screens honor injected navigation and distinguish Back from Ctrl+C Close", () => {
@@ -982,6 +1025,7 @@ test("searchable multi-select keeps its focused query and selected row in compac
 		items: Array.from({ length: 8 }, (_, index) => ({
 			id: `tool-${index}`,
 			label: `tool_${index}`,
+			description: `Description for tool ${index}`,
 			searchText: "shared tool",
 			selected: false,
 		})),
@@ -1000,6 +1044,7 @@ test("searchable multi-select keeps its focused query and selected row in compac
 	assert.equal(lines.at(-1), "─".repeat(32));
 	assert.ok(lines.some((line) => line.startsWith("> tool")));
 	assert.match(lines.join("\n"), /› \[ \] tool_7/u);
+	assert.match(lines.join("\n"), /Description for tool 7/u);
 });
 
 test("searchable multi-select keeps actions available for no matches and distinguishes empty", async () => {

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -277,9 +277,11 @@ test("choice and settings screens reserve host rows and keep focused controls vi
 	assert.ok(settingsLines.some((line) => line.startsWith("> ")));
 	assert.match(settingsLines.join("\n"), /→ Setting 11/u);
 	assert.match(settingsLines.join("\n"), /Description for setting 11/u);
-	assert.match(settingsLines.join("\n"), /esc back/u);
+	assert.match(settingsLines.join("\n"), /Esc to go back/u);
+	const compactSettings = plainRender(settings.component, 80).join("\n");
+	assert.match(compactSettings, /Enter\/Space to change/u);
 	const narrowSettings = plainRender(settings.component, 25).join("\n");
-	assert.match(narrowSettings, /esc back/u);
+	assert.match(narrowSettings, /Esc to go back/u);
 	assert.match(narrowSettings, /\(12\/12\)/u);
 	assert.doesNotMatch(narrowSettings, /(^|\n)(?:to )?close($|\n)/u);
 });

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -1152,6 +1152,27 @@ test("compact searchable multi-select preserves empty states ahead of search rem
 	assert.doesNotMatch(emptyText, /No matching items|Type to search/u);
 });
 
+test("compact searchable multi-select keeps its selected action visible after an empty filter", () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "multiSelect",
+		title: "Searchable tools",
+		enableSearch: true,
+		items: [{ id: "read", label: "Read", selected: false }],
+		action: "toggle",
+		actions: [{ id: "save", label: "Save changes", action: "run" }],
+	};
+	const harness = componentHarness(screen, {
+		plainTheme: true,
+		rows: 8,
+		keybindings: inputFriendlyKeybindings,
+	});
+	for (const input of ["z", "z", "z"]) harness.component.handleInput(input);
+	const rendered = plainRender(harness.component, 32).join("\n");
+	assert.match(rendered, /> zzz/u);
+	assert.match(rendered, /› Save changes/u);
+	assert.doesNotMatch(rendered, /No matching items/u);
+});
+
 test("searchable multi-select keeps actions available for no matches and distinguishes empty", async () => {
 	const screen: MenuScreen<ScreenId, ActionId> = {
 		kind: "multiSelect",

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -189,7 +189,7 @@ test("action screens prioritize actionable rows when terminal height is constrai
 		keybindings: inputFriendlyKeybindings,
 	});
 	const lines = plainRender(harness.component, 32);
-	assert.ok(lines.length <= 12);
+	assert.ok(lines.length <= 9);
 	assert.equal(lines[0], "─".repeat(32));
 	assert.equal(lines.at(-1), "─".repeat(32));
 	assert.match(lines.join("\n"), /→ Restore sync access/u);
@@ -202,11 +202,47 @@ test("action screens prioritize actionable rows when terminal height is constrai
 		keybindings: inputFriendlyKeybindings,
 	});
 	const tinyLines = plainRender(tinyHarness.component, 32);
-	assert.ok(tinyLines.length <= 7);
-	assert.equal(tinyLines[0], "─".repeat(32));
-	assert.equal(tinyLines.at(-1), "─".repeat(32));
+	assert.ok(tinyLines.length <= 4);
+	assert.doesNotMatch(tinyLines.join("\n"), /─/u);
 	assert.match(tinyLines.join("\n"), /→ Help/u);
 	assert.match(tinyLines.join("\n"), /esc\s+close/u);
+
+	const minimumHarness = componentHarness(screen, {
+		selectedItemId: "help",
+		plainTheme: true,
+		rows: 4,
+		keybindings: inputFriendlyKeybindings,
+	});
+	assert.deepEqual(plainRender(minimumHarness.component, 32), ["→ Help"]);
+});
+
+test("choice and settings screens reserve host rows and keep focused controls visible", () => {
+	const choice = componentHarness(choiceScreen, {
+		selectedItemId: "balanced",
+		plainTheme: true,
+		rows: 9,
+		keybindings: inputFriendlyKeybindings,
+	});
+	const choiceLines = plainRender(choice.component, 32);
+	assert.ok(choiceLines.length <= 6);
+	assert.equal(choiceLines[0], "─".repeat(32));
+	assert.equal(choiceLines.at(-1), "─".repeat(32));
+	assert.match(choiceLines.join("\n"), /→ Balanced/u);
+	assert.match(choiceLines.join("\n"), /esc\s+back/u);
+
+	const settings = componentHarness(largeSettingsScreen(), {
+		selectedItemId: "setting-11",
+		plainTheme: true,
+		rows: 9,
+		keybindings: inputFriendlyKeybindings,
+	});
+	const settingsLines = plainRender(settings.component, 40);
+	assert.ok(settingsLines.length <= 6);
+	assert.equal(settingsLines[0], "─".repeat(40));
+	assert.equal(settingsLines.at(-1), "─".repeat(40));
+	assert.ok(settingsLines.some((line) => line.startsWith("> ")));
+	assert.match(settingsLines.join("\n"), /→ Setting 11/u);
+	assert.match(settingsLines.join("\n"), /Esc to go back/u);
 });
 
 test("action screens honor injected navigation and distinguish Back from Ctrl+C Close", () => {
@@ -936,6 +972,34 @@ test("searchable multi-select filters label and declared search text by stable r
 
 	for (const input of ["\u007f", "\u007f"]) harness.component.handleInput(input);
 	assert.match(plainRender(harness.component, 60).join("\n"), /› \[x\] 讀取 📖/);
+});
+
+test("searchable multi-select keeps its focused query and selected row in compact frames", () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "multiSelect",
+		title: "Searchable tools",
+		enableSearch: true,
+		items: Array.from({ length: 8 }, (_, index) => ({
+			id: `tool-${index}`,
+			label: `tool_${index}`,
+			searchText: "shared tool",
+			selected: false,
+		})),
+		action: "toggle",
+	};
+	const harness = componentHarness(screen, {
+		selectedItemId: "tool-7",
+		plainTheme: true,
+		rows: 10,
+		keybindings: inputFriendlyKeybindings,
+	});
+	for (const input of ["t", "o", "o", "l"]) harness.component.handleInput(input);
+	const lines = plainRender(harness.component, 32);
+	assert.ok(lines.length <= 7);
+	assert.equal(lines[0], "─".repeat(32));
+	assert.equal(lines.at(-1), "─".repeat(32));
+	assert.ok(lines.some((line) => line.startsWith("> tool")));
+	assert.match(lines.join("\n"), /› \[ \] tool_7/u);
 });
 
 test("searchable multi-select keeps actions available for no matches and distinguishes empty", async () => {

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -214,6 +214,39 @@ test("action screens prioritize actionable rows when terminal height is constrai
 		keybindings: inputFriendlyKeybindings,
 	});
 	assert.deepEqual(plainRender(minimumHarness.component, 32), ["→ Help"]);
+
+	const narrowHarness = componentHarness(screen, {
+		plainTheme: true,
+		rows: 8,
+		keybindings: inputFriendlyKeybindings,
+	});
+	assert.ok(plainRender(narrowHarness.component, 10).includes("esc close"));
+});
+
+test("compact action screens indicate options hidden by outer compaction", () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "actions",
+		title: "Actions",
+		items: Array.from({ length: 6 }, (_, index) => ({
+			id: `action-${index}`,
+			label: `Action ${index + 1}`,
+			action: "run" as const,
+		})),
+		hint: "close",
+	};
+	const harness = componentHarness(screen, {
+		plainTheme: true,
+		rows: 12,
+		keybindings: inputFriendlyKeybindings,
+	});
+	let rendered = plainRender(harness.component, 40).join("\n");
+	assert.match(rendered, /\(1\/6\)/u);
+	assert.doesNotMatch(rendered, /Action 6/u);
+
+	for (let index = 0; index < 5; index += 1) harness.component.handleInput("\u001b[B");
+	rendered = plainRender(harness.component, 40).join("\n");
+	assert.match(rendered, /→ Action 6/u);
+	assert.match(rendered, /\(6\/6\)/u);
 });
 
 test("choice and settings screens reserve host rows and keep focused controls visible", () => {
@@ -228,6 +261,7 @@ test("choice and settings screens reserve host rows and keep focused controls vi
 	assert.equal(choiceLines[0], "─".repeat(32));
 	assert.equal(choiceLines.at(-1), "─".repeat(32));
 	assert.match(choiceLines.join("\n"), /→ Balanced/u);
+	assert.match(choiceLines.join("\n"), /\(2\/3\)/u);
 	assert.match(choiceLines.join("\n"), /esc\s+back/u);
 
 	const settings = componentHarness(largeSettingsScreen(), {
@@ -243,7 +277,11 @@ test("choice and settings screens reserve host rows and keep focused controls vi
 	assert.ok(settingsLines.some((line) => line.startsWith("> ")));
 	assert.match(settingsLines.join("\n"), /→ Setting 11/u);
 	assert.match(settingsLines.join("\n"), /Description for setting 11/u);
-	assert.match(settingsLines.join("\n"), /Esc to go back/u);
+	assert.match(settingsLines.join("\n"), /esc back/u);
+	const narrowSettings = plainRender(settings.component, 25).join("\n");
+	assert.match(narrowSettings, /esc back/u);
+	assert.match(narrowSettings, /\(12\/12\)/u);
+	assert.doesNotMatch(narrowSettings, /(^|\n)(?:to )?close($|\n)/u);
 });
 
 test("compact searchable choices preserve empty states ahead of search reminders", () => {
@@ -285,7 +323,18 @@ test("compact static frames reserve cancellation hints before wrapped titles", (
 	);
 	const rendered = plainRender(harness.component, 20).join("\n");
 	assert.match(rendered, /A very long detail/u);
-	assert.match(rendered, /esc\s+back|ctrl\+c\s+close/u);
+	assert.match(rendered, /esc back/u);
+});
+
+test("compact detail frames preserve body text and advertise only supported controls", () => {
+	const harness = componentHarness(
+		{ ...detailScreen, title: "Details", lines: ["Important body"] },
+		{ plainTheme: true, rows: 8, keybindings: inputFriendlyKeybindings },
+	);
+	const rendered = plainRender(harness.component, 12).join("\n");
+	assert.match(rendered, /Important/u);
+	assert.match(rendered, /esc back/u);
+	assert.doesNotMatch(rendered, /navigate|select/u);
 });
 
 test("action screens honor injected navigation and distinguish Back from Ctrl+C Close", () => {
@@ -1045,6 +1094,7 @@ test("searchable multi-select keeps its focused query and selected row in compac
 	assert.ok(lines.some((line) => line.startsWith("> tool")));
 	assert.match(lines.join("\n"), /› \[ \] tool_7/u);
 	assert.match(lines.join("\n"), /Description for tool 7/u);
+	assert.match(lines.join("\n"), /\(8\/8\)/u);
 });
 
 test("searchable multi-select keeps actions available for no matches and distinguishes empty", async () => {

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -597,6 +597,31 @@ test("settings search reports no matches and all presentation remains width-safe
 	assert.ok(
 		plainRender(empty.component, 40).some((line) => line.includes("No settings available")),
 	);
+
+	const compactNoMatch = componentHarness(
+		{
+			kind: "settings",
+			title: "Compact settings",
+			items: [
+				{
+					id: "display",
+					label: "Display",
+					currentValue: "On",
+					values: ["On", "Off"],
+					action: "setting",
+				},
+			],
+		},
+		{ plainTheme: true, rows: 8, keybindings: inputFriendlyKeybindings },
+	);
+	compactNoMatch.component.handleInput("z");
+	assert.match(plainRender(compactNoMatch.component, 40).join("\n"), /No matching settings/u);
+	const compactEmpty = componentHarness(
+		{ kind: "settings", title: "Compact empty settings", items: [] },
+		{ plainTheme: true, rows: 8, keybindings: inputFriendlyKeybindings },
+	);
+	assert.match(plainRender(compactEmpty.component, 40).join("\n"), /No settings available/u);
+
 	for (const width of [1, 2, 8, 20, 40]) {
 		assert.ok(
 			harness.component.render(width).every((line) => visibleWidth(line) <= width),
@@ -1097,6 +1122,34 @@ test("searchable multi-select keeps its focused query and selected row in compac
 	assert.match(lines.join("\n"), /› \[ \] tool_7/u);
 	assert.match(lines.join("\n"), /Description for tool 7/u);
 	assert.match(lines.join("\n"), /\(8\/8\)/u);
+});
+
+test("compact searchable multi-select preserves empty states ahead of search reminders", () => {
+	const screen: MenuScreen<ScreenId, ActionId> = {
+		kind: "multiSelect",
+		title: "Searchable tools",
+		enableSearch: true,
+		items: [{ id: "read", label: "Read", selected: false }],
+		action: "toggle",
+		actions: [],
+	};
+	const noMatch = componentHarness(screen, {
+		plainTheme: true,
+		rows: 9,
+		keybindings: inputFriendlyKeybindings,
+	});
+	for (const input of ["z", "z", "z"]) noMatch.component.handleInput(input);
+	const noMatchText = plainRender(noMatch.component, 32).join("\n");
+	assert.match(noMatchText, /No matching items/u);
+	assert.doesNotMatch(noMatchText, /Type to search/u);
+
+	const empty = componentHarness(
+		{ ...screen, items: [] },
+		{ plainTheme: true, rows: 9, keybindings: inputFriendlyKeybindings },
+	);
+	const emptyText = plainRender(empty.component, 32).join("\n");
+	assert.match(emptyText, /No items available/u);
+	assert.doesNotMatch(emptyText, /No matching items|Type to search/u);
 });
 
 test("searchable multi-select keeps actions available for no matches and distinguishes empty", async () => {


### PR DESCRIPTION
## Summary

- bound framed choices, settings, inputs, and reviews to Pi's available terminal rows
- keep focused controls, selected rows, selected explanations, empty states, pending status, and semantic interaction hints visible during compaction
- preserve custom compact hint labels and prioritize configured standard controls before additive shortcuts
- expose compact current/total markers when outer framing hides list options
- preserve fixed/default review viewport content, rendered-empty controls, supporting context, and synchronized pagination

## Review feedback

Supersedes closed PR #1012 after restoring its accidentally reset branch.

Addresses every Codex review through `8e8ae54e`:

- fixed/default reviews reserve only available document rows before optional header context
- empty and whitespace-only compact reviews reclaim blank viewport rows for controls
- compact searchable choices, settings, and multi-select screens preserve their applicable empty states
- compact settings and multi-select screens preserve selected explanations
- compact hints keep each key with its action at narrow widths
- custom compact hints retain live-choice shortcuts and labels plus the Settings Space action
- configured standard actions precede additive shortcut and page hints
- narrow review hints advertise Back or Close before confirmation
- compact list screens expose current/total markers when options are hidden
- compact input screens keep `Saving…` visible while submission is pending
- interactive compact frames reserve critical hints and status before optional title content
- static detail frames preserve body text, cancellation hints, and only supported actions

The same starvation, custom-hint, empty-state, and outer-compaction patterns were audited across every `renderFrame()` caller and the independent browse and review allocators.

## Verification

- `npx vitest run packages/pi-starship/test/command-ux.test.ts packages/pi-tui-kit/test/screen-components.test.ts packages/pi-tui-kit/test/review-screen.test.ts packages/pi-tui-kit/test/live-choice.test.ts packages/pi-tui-kit/test/input-screen.test.ts packages/pi-tui-kit/test/searchable-choice.test.ts packages/pi-file-context/test/file-context-menu.test.ts packages/pi-file-context/test/file-context-command-menu.test.ts packages/pi-statusline/test/commands.test.ts packages/pi-subagents/test/rpc-transport.test.ts` (187 tests)
- `npm --workspace @narumitw/pi-tui-kit run check`
- `npm run check`
- `npm test` (3,441 tests)
- `npm run changeset:status`
- `npm pack --workspace @narumitw/pi-tui-kit --dry-run --json` (69 files; 33 JavaScript files; 33 declarations; no source files)

No package metadata or runtime-loading path changed, so no Pi load smoke was required.
