### PR TITLE
fix(goal): preserve completion result ordering

### DIFF
--- a/.changeset/quiet-goals-finish.md
+++ b/.changeset/quiet-goals-finish.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-goal": patch
+---
+
+Persist the real `goal_complete` result before publishing the inactive Goal contract.

--- a/packages/pi-goal/src/lifecycle.ts
+++ b/packages/pi-goal/src/lifecycle.ts
@@ -483,6 +483,11 @@ export function registerGoalLifecycle(
 
 	pi.on("turn_end", (event, ctx) => {
 		runtime.recordAutomaticTurn(ctx, event.message);
+		// goal_complete clears state synchronously, but its inactive contract must wait
+		// until Pi has persisted the real tool result at this turn boundary.
+		if (runtime.activeGoal?.status !== "active") {
+			runtime.ensureInactiveGoalContextContract(ctx);
+		}
 	});
 
 	pi.on("agent_end", (event, ctx) => {

--- a/packages/pi-goal/src/runtime.ts
+++ b/packages/pi-goal/src/runtime.ts
@@ -1234,6 +1234,15 @@ export class GoalRuntime {
 	}
 
 	clearActiveGoal(ctx: StatusContext, reason = "goal cleared", releaseWorkflow = true) {
+		this.clearActiveGoalState(ctx, reason, releaseWorkflow);
+		this.ensureInactiveGoalContextContract(ctx);
+	}
+
+	clearCompletedGoal(ctx: StatusContext) {
+		this.clearActiveGoalState(ctx, "goal cleared", true);
+	}
+
+	private clearActiveGoalState(ctx: StatusContext, reason: string, releaseWorkflow: boolean) {
 		const clearedGoal = this.activeGoal;
 		this.clearGoalWaitTimer();
 		this.cancelContinuationWork();
@@ -1243,7 +1252,6 @@ export class GoalRuntime {
 		this.activeGoal = undefined;
 		this.legacyQueueState = undefined;
 		this.clearPersistedGoal(ctx.cwd, clearedGoal, reason);
-		this.ensureInactiveGoalContextContract(ctx);
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		if (releaseWorkflow) this.releaseWorkflow();
 	}

--- a/packages/pi-goal/src/tools.ts
+++ b/packages/pi-goal/src/tools.ts
@@ -164,7 +164,7 @@ export function registerGoalTools(pi: ExtensionAPI, runtime: GoalRuntime) {
 			runtime.persistGoal(runtime.activeGoal);
 
 			ctx.ui.setStatus(STATUS_KEY, formatStatus(runtime.activeGoal));
-			runtime.clearActiveGoal(ctx);
+			runtime.clearCompletedGoal(ctx);
 			runtime.showCompletionStatus(ctx);
 			notifyTerminal(ctx.ui, `Goal complete: ${goal}`, "info");
 

--- a/packages/pi-goal/test/goal-cache-contract.test.ts
+++ b/packages/pi-goal/test/goal-cache-contract.test.ts
@@ -109,6 +109,37 @@ function assistantMessage(content: string) {
 	};
 }
 
+function assistantToolCall(toolCallId: string, goalId: string) {
+	return {
+		role: "assistant",
+		content: [
+			{ type: "text", text: "Completed with verified evidence." },
+			{
+				type: "toolCall",
+				id: toolCallId,
+				name: "goal_complete",
+				arguments: { goal_id: goalId, summary: "Completed with verified evidence." },
+			},
+		],
+		api: "openai-responses",
+		provider: "cache-contract-test",
+		model: "cache-contract-test",
+		stopReason: "toolUse",
+		timestamp: 1,
+	};
+}
+
+function goalCompleteResult(toolCallId: string) {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "goal_complete",
+		content: [{ type: "text", text: "Goal complete: Completed with verified evidence." }],
+		isError: false,
+		timestamp: 2,
+	};
+}
+
 function latestGoalContract(messages: unknown[]) {
 	const message = messages
 		.filter((candidate) => (candidate as { customType?: string }).customType === "goal-contract")
@@ -158,6 +189,107 @@ test("Goal activation appends its contract without changing the stable tool sche
 	assert.equal(kickoff.messages[retainedHistory.length + 1], contract);
 	assert.deepEqual(kickoff.activeTools, beforeGoal.activeTools);
 	assert.deepEqual(kickoffProviderRequest.tools, beforeProviderRequest.tools);
+});
+
+test("goal_complete persists one real provider output before the inactive contract", async () => {
+	const branch: Array<Record<string, unknown>> = [];
+	const allTools = [builtinTool("read"), builtinTool("bash")];
+	const mock = createMockPi({ activeTools: ["read", "bash"], allTools });
+	registerGoalWithSettingsPath(mock.pi, DEFAULT_SETTINGS_PATH);
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("goal")?.handler("complete without duplicate tool output", context.ctx);
+	const kickoffPrompt = mock.sentUserMessages.at(-1)?.text ?? "";
+	const kickoff = await captureRequest(mock, context.ctx, kickoffPrompt, [
+		userMessage(kickoffPrompt),
+	]);
+	const activeContract = latestGoalContract(kickoff.messages);
+	branch.push({
+		type: "custom_message",
+		customType: activeContract.customType,
+		content: activeContract.content,
+	});
+
+	const goal = requireLastGoal(mock);
+	const toolCallId = "goal-complete-order";
+	const toolCall = assistantToolCall(toolCallId, goal.id);
+	const toolResult = goalCompleteResult(toolCallId);
+	const sentContractsBeforeCompletion = mock.sentMessages.length;
+	const completion = await requireGoalTool(mock, "goal_complete").execute(
+		toolCallId,
+		{ goal_id: goal.id, summary: "Completed with verified evidence." },
+		new AbortController().signal,
+		() => undefined,
+		context.ctx,
+	);
+
+	assert.equal(completion.terminate, true);
+	assert.equal(mock.sentMessages.length, sentContractsBeforeCompletion);
+
+	const restartedBranch = [
+		...branch,
+		...mock.entries.map((entry) => ({ type: "custom", ...entry })),
+	];
+	const restarted = createMockPi({ activeTools: ["read", "bash"], allTools });
+	registerGoalWithSettingsPath(restarted.pi, DEFAULT_SETTINGS_PATH);
+	const restartedContext = createMockContext({
+		sessionManager: {
+			getBranch: () => restartedBranch,
+			getEntries: () => restartedBranch,
+		},
+	});
+	await restarted.events.get("session_start")?.[0]?.({ reason: "reload" }, restartedContext.ctx);
+	const restartedContract = restarted.sentMessages.at(-1)?.message as
+		| { content?: string }
+		| undefined;
+	assert.match(restartedContract?.content ?? "", /Goal mode is inactive/u);
+
+	branch.push({ type: "message", message: toolCall }, { type: "message", message: toolResult });
+	await mock.events.get("turn_end")?.[0]?.(
+		{ message: toolCall, toolResults: [toolResult] },
+		context.ctx,
+	);
+	assert.equal(mock.sentMessages.length, sentContractsBeforeCompletion + 1);
+	const inactiveContract = mock.sentMessages.at(-1)?.message as {
+		content?: string;
+		customType?: string;
+	};
+	assert.match(inactiveContract.content ?? "", /Goal mode is inactive/u);
+	branch.push({
+		type: "custom_message",
+		customType: inactiveContract.customType,
+		content: inactiveContract.content,
+	});
+	await mock.events.get("turn_end")?.[0]?.(
+		{ message: toolCall, toolResults: [toolResult] },
+		context.ctx,
+	);
+	assert.equal(mock.sentMessages.length, sentContractsBeforeCompletion + 1);
+
+	const followUpPrompt = "ordinary follow-up after Goal completion";
+	const followUp = await captureRequest(mock, context.ctx, followUpPrompt, [
+		...kickoff.messages,
+		toolCall,
+		toolResult,
+		inactiveContract,
+		userMessage(followUpPrompt),
+	]);
+	const payload = await serializeProviderRequest(followUp);
+	const providerInput = payload.input as Array<Record<string, unknown>>;
+	const outputs = providerInput.filter(
+		(item) => item.type === "function_call_output" && item.call_id === toolCallId,
+	);
+	assert.equal(outputs.length, 1);
+	assert.match(String(outputs[0]?.output), /Goal complete: Completed with verified evidence/u);
+	assert.doesNotMatch(JSON.stringify(providerInput), /No result provided/u);
+	const outputIndex = providerInput.indexOf(outputs[0] as Record<string, unknown>);
+	const inactiveIndex = providerInput.findIndex((item) =>
+		JSON.stringify(item).includes("Goal mode is inactive"),
+	);
+	assert.ok(outputIndex >= 0);
+	assert.ok(inactiveIndex > outputIndex);
 });
 
 test("token-budgeted continuation and wait resume preserve the post-activation request prefix", async () => {


### PR DESCRIPTION
## Summary

- Clear completed Goal state and release workflow ownership immediately while deferring only the inactive Goal contract until `turn_end`.
- Preserve completion status and successor Goal behavior while ensuring the real `goal_complete` result is persisted first.
- Add provider-payload regression coverage for duplicate outputs, idempotent publication, and reload recovery.
- Add a patch Changeset for `@narumitw/pi-goal`.

This supersedes #1014 with lifecycle-safe cleanup and deterministic regression coverage.

## Verification

- `npx vitest run packages/pi-goal/test/goal-cache-contract.test.ts packages/pi-goal/test/goal-contracts.test.ts packages/pi-goal/test/workflow-mutex.test.ts packages/pi-goal/test/goal-run-protocol.test.ts` — 72 passed.
- `npm --workspace @narumitw/pi-goal run check` — passed.
- `npm --workspace @narumitw/pi-goal run test:runtime` — passed.
- `npm run check` — passed.
- `npm test` — 387 files and 3,413 tests passed.

An earlier full-suite run hit one transient `pi-subagents` semantic-resource failure.
The isolated retry and the complete rerun passed.
