### PR TITLE
fix(lsp): match diagnostics published under equivalent uris

### DIFF
--- a/.changeset/lsp-normalized-diagnostic-uri-keys.md
+++ b/.changeset/lsp-normalized-diagnostic-uri-keys.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-lsp": patch
 ---
 
-Key published diagnostics by a canonical file path so servers that answer with a different but equivalent URI encoding are matched. Servers such as marksman publish `file:///c%3A/dir/a.md` where Node produces `file:///C:/dir/a.md`, which previously dropped every publication and reported the file as clean.
+Key published diagnostics by a canonical file path so equivalent URI encodings are matched, and wait for each LSP process to exit before completing shutdown.

--- a/.changeset/lsp-normalized-diagnostic-uri-keys.md
+++ b/.changeset/lsp-normalized-diagnostic-uri-keys.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-lsp": patch
+---
+
+Key published diagnostics by a canonical file path so servers that answer with a different but equivalent URI encoding are matched. Servers such as marksman publish `file:///c%3A/dir/a.md` where Node produces `file:///C:/dir/a.md`, which previously dropped every publication and reported the file as clean.

--- a/packages/pi-lsp/src/lsp-client.ts
+++ b/packages/pi-lsp/src/lsp-client.ts
@@ -28,11 +28,11 @@ export function resolveSpawnCommand(
 // Quiet period (ms) after each publish before treating push diagnostics as settled.
 const PUBLISHED_DIAGNOSTICS_SETTLE_MS = 800;
 
-// Servers may answer about a file using a different but equivalent encoding of
-// the URI the client sent, so diagnostics must be keyed by a canonical form.
-// marksman, like VS Code, publishes `file:///c%3A/dir/a.md` where Node's
-// pathToFileURL produces `file:///C:/dir/a.md`; keying by the raw strings
-// silently drops every publication. Non-file URIs keep their original text.
+// Key diagnostics by a canonical path: a server may answer using a different but
+// equivalent encoding of the URI the client sent. marksman, like VS Code, sends
+// `file:///c%3A/dir/a.md` where pathToFileURL produces `file:///C:/dir/a.md`.
+// normalize() also collapses the doubled separators a URI may carry.
+// Non-file URIs such as untitled: and jdt: keep their original text.
 function documentKey(uri: string) {
 	try {
 		const filePath = path.normalize(fileURLToPath(uri));

--- a/packages/pi-lsp/src/lsp-client.ts
+++ b/packages/pi-lsp/src/lsp-client.ts
@@ -1,6 +1,7 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import { commandPathValue, mergeEnvironment, resolveCommandPath } from "./command.js";
 import { directoryUri } from "./files.js";
 import { positionAt } from "./text-edits.js";
@@ -26,6 +27,20 @@ export function resolveSpawnCommand(
 
 // Quiet period (ms) after each publish before treating push diagnostics as settled.
 const PUBLISHED_DIAGNOSTICS_SETTLE_MS = 800;
+
+// Servers may answer about a file using a different but equivalent encoding of
+// the URI the client sent, so diagnostics must be keyed by a canonical form.
+// marksman, like VS Code, publishes `file:///c%3A/dir/a.md` where Node's
+// pathToFileURL produces `file:///C:/dir/a.md`; keying by the raw strings
+// silently drops every publication. Non-file URIs keep their original text.
+function documentKey(uri: string) {
+	try {
+		const filePath = path.normalize(fileURLToPath(uri));
+		return process.platform === "win32" ? filePath.toLowerCase() : filePath;
+	} catch {
+		return uri;
+	}
+}
 
 export class LspClient {
 	#child?: ChildProcessWithoutNullStreams;
@@ -183,7 +198,7 @@ export class LspClient {
 					: undefined,
 			);
 		}
-		const published = this.#publishedDiagnostics.get(uri);
+		const published = this.#publishedDiagnostics.get(documentKey(uri));
 		// Ignore a provisional empty publish, but preserve diagnostics that arrived before the pull.
 		const afterVersion = published?.diagnostics.length
 			? published.version - 1
@@ -357,13 +372,14 @@ export class LspClient {
 		if (message.method === "textDocument/publishDiagnostics") {
 			const params = message.params as { uri?: string; diagnostics?: LspDiagnostic[] } | undefined;
 			if (params?.uri) {
-				const previousVersion = this.#publishedDiagnostics.get(params.uri)?.version ?? 0;
+				const key = documentKey(params.uri);
+				const previousVersion = this.#publishedDiagnostics.get(key)?.version ?? 0;
 				const publication = {
 					version: previousVersion + 1,
 					diagnostics: params.diagnostics ?? [],
 				};
-				this.#publishedDiagnostics.set(params.uri, publication);
-				const waiters = this.#diagnosticWaiters.get(params.uri);
+				this.#publishedDiagnostics.set(key, publication);
+				const waiters = this.#diagnosticWaiters.get(key);
 				if (waiters) {
 					for (const waiter of [...waiters]) waiter.onPublish(publication);
 				}
@@ -381,6 +397,7 @@ export class LspClient {
 		fallback?: { afterVersion: number; diagnostics: LspDiagnostic[]; waitMs: number },
 	) {
 		// See PUBLISHED_DIAGNOSTICS_SETTLE_MS. Bounded by #timeoutMs.
+		const key = documentKey(uri);
 		return new Promise<LspDiagnostic[]>((resolve, reject) => {
 			let settleTimer: NodeJS.Timeout | undefined;
 			let fallbackTimer: NodeJS.Timeout | undefined;
@@ -392,9 +409,9 @@ export class LspClient {
 				if (settleTimer) clearTimeout(settleTimer);
 				if (fallbackTimer) clearTimeout(fallbackTimer);
 				if (overallTimer) clearTimeout(overallTimer);
-				const set = this.#diagnosticWaiters.get(uri);
+				const set = this.#diagnosticWaiters.get(key);
 				set?.delete(waiter);
-				if (set && set.size === 0) this.#diagnosticWaiters.delete(uri);
+				if (set && set.size === 0) this.#diagnosticWaiters.delete(key);
 			};
 			const settleWith = (diagnostics: LspDiagnostic[]) => {
 				dispose();
@@ -411,20 +428,20 @@ export class LspClient {
 				if (fallbackTimer) clearTimeout(fallbackTimer);
 				if (settleTimer) clearTimeout(settleTimer);
 				settleTimer = setTimeout(
-					() => settleWith(this.#publishedDiagnostics.get(uri)?.diagnostics ?? []),
+					() => settleWith(this.#publishedDiagnostics.get(key)?.diagnostics ?? []),
 					this.#adapter.diagnosticsSettleMs ?? PUBLISHED_DIAGNOSTICS_SETTLE_MS,
 				);
 			};
 
 			const waiter = { onPublish, reject: fail, dispose };
-			const set = this.#diagnosticWaiters.get(uri) ?? new Set<typeof waiter>();
+			const set = this.#diagnosticWaiters.get(key) ?? new Set<typeof waiter>();
 			set.add(waiter);
-			this.#diagnosticWaiters.set(uri, set);
+			this.#diagnosticWaiters.set(key, set);
 
 			if (fallback) {
 				fallbackTimer = setTimeout(
 					() => {
-						const latest = this.#publishedDiagnostics.get(uri);
+						const latest = this.#publishedDiagnostics.get(key);
 						settleWith(
 							latest && latest.version > afterVersion ? latest.diagnostics : fallback.diagnostics,
 						);
@@ -433,7 +450,7 @@ export class LspClient {
 				);
 			}
 			overallTimer = setTimeout(() => {
-				const latest = this.#publishedDiagnostics.get(uri);
+				const latest = this.#publishedDiagnostics.get(key);
 				if (latest && latest.version > afterVersion) {
 					settleWith(latest.diagnostics);
 				} else if (fallback) {
@@ -447,7 +464,7 @@ export class LspClient {
 				}
 			}, this.#timeoutMs);
 
-			const existing = this.#publishedDiagnostics.get(uri);
+			const existing = this.#publishedDiagnostics.get(key);
 			if (existing) onPublish(existing);
 		});
 	}

--- a/packages/pi-lsp/src/lsp-client.ts
+++ b/packages/pi-lsp/src/lsp-client.ts
@@ -27,6 +27,7 @@ export function resolveSpawnCommand(
 
 // Quiet period (ms) after each publish before treating push diagnostics as settled.
 const PUBLISHED_DIAGNOSTICS_SETTLE_MS = 800;
+const PROCESS_EXIT_GRACE_MS = 500;
 
 // Key diagnostics by a canonical path: a server may answer using a different but
 // equivalent encoding of the URI the client sent. marksman, like VS Code, sends
@@ -44,6 +45,8 @@ function documentKey(uri: string) {
 
 export class LspClient {
 	#child?: ChildProcessWithoutNullStreams;
+	#process?: ChildProcessWithoutNullStreams;
+	#processExit?: Promise<void>;
 	#buffer = Buffer.alloc(0);
 	#nextId = 1;
 	#pending = new Map<
@@ -97,6 +100,16 @@ export class LspClient {
 			stdio: "pipe",
 		});
 		this.#child = child;
+		this.#process = child;
+		this.#processExit = new Promise((resolve) => {
+			const finish = () => {
+				child.off("exit", finish);
+				child.off("close", finish);
+				resolve();
+			};
+			child.once("exit", finish);
+			child.once("close", finish);
+		});
 		child.stdout.on("data", (chunk) => {
 			try {
 				this.#onData(chunk);
@@ -116,6 +129,7 @@ export class LspClient {
 		});
 		child.once("exit", (code, signal) => {
 			if (this.#child === child) this.#child = undefined;
+			if (this.#process === child) this.#process = undefined;
 			const reason = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
 			this.#rejectPending(
 				(id) =>
@@ -129,6 +143,7 @@ export class LspClient {
 				const message = `${this.#adapter.name} LSP process failed to start: ${error.message}.${this.#formatStderr()}`;
 				this.#rejectPending(message);
 				if (this.#child === child) this.#child = undefined;
+				if (this.#process === child) this.#process = undefined;
 				reject(new Error(message));
 			});
 		});
@@ -249,16 +264,24 @@ export class LspClient {
 	}
 
 	async shutdown() {
-		if (!this.#child) return;
+		const child = this.#process;
+		const processExit = this.#processExit;
+		if (!child || !processExit) return;
 
-		try {
-			await this.request("shutdown", null);
-			this.notify("exit", undefined);
-		} catch {
-			// The process may already be gone; close below still guarantees cleanup.
-		} finally {
-			this.close();
+		if (this.#child === child) {
+			try {
+				await this.request("shutdown", null);
+				this.notify("exit", undefined);
+				if (await settlesWithin(processExit, PROCESS_EXIT_GRACE_MS)) return;
+			} catch {
+				// The process may already be gone; terminate it below if needed.
+			}
 		}
+
+		this.close();
+		if (await settlesWithin(processExit, PROCESS_EXIT_GRACE_MS)) return;
+		child.kill("SIGKILL");
+		await processExit;
 	}
 
 	close() {
@@ -518,4 +541,14 @@ export class LspClient {
 
 function formatErrorMessage(error: unknown) {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function settlesWithin(promise: Promise<void>, timeoutMs: number) {
+	return new Promise<boolean>((resolve) => {
+		const timeout = setTimeout(() => resolve(false), timeoutMs);
+		void promise.then(() => {
+			clearTimeout(timeout);
+			resolve(true);
+		});
+	});
 }

--- a/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
+++ b/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
@@ -1,7 +1,18 @@
+import { writeFileSync } from "node:fs";
+
 const scenario = process.argv[2];
 const expectedFiles = Number(process.argv[3] ?? "0");
 let buffer = Buffer.alloc(0);
 const openedUris = [];
+
+if (scenario === "delayed-sigterm") process.on("SIGTERM", exitAfterDelay);
+
+function exitAfterDelay() {
+	setTimeout(() => {
+		writeFileSync(process.env.PI_LSP_TEST_EXIT_MARKER, "exited\n");
+		process.exit(0);
+	}, 100);
+}
 
 function send(message) {
 	const body = JSON.stringify(message);
@@ -172,7 +183,10 @@ function handle(message) {
 		return;
 	}
 
-	if (message.method === "exit") process.exit(0);
+	if (message.method === "exit") {
+		if (scenario === "delayed-exit") exitAfterDelay();
+		else process.exit(0);
+	}
 }
 
 process.stdin.on("data", (chunk) => {

--- a/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
+++ b/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
@@ -20,6 +20,15 @@ function diagnostic(message, line = 0) {
 	};
 }
 
+// Re-encode a file URI the way editors and some servers do: a lowercase drive
+// letter with an encoded colon on Windows, plus percent-encoded unreserved
+// characters. The result addresses the same file as the URI the client sent.
+function alternateEncoding(uri) {
+	return uri
+		.replace(/^file:\/\/\/([A-Za-z]):\//, (_match, drive) => `file:///${drive.toLowerCase()}%3A/`)
+		.replace(/-/g, "%2D");
+}
+
 function publish(uri, diagnostics) {
 	send({
 		jsonrpc: "2.0",
@@ -67,10 +76,19 @@ function handle(message) {
 	if (message.method === "textDocument/didOpen") {
 		const uri = message.params.textDocument.uri;
 		openedUris.push(uri);
-		if (scenario !== "push-silent" && scenario !== "push-silent-then-diagnostic") {
+		if (
+			scenario !== "push-silent" &&
+			scenario !== "push-silent-then-diagnostic" &&
+			scenario !== "push-alternate-uri-encoding"
+		) {
 			publish(uri, []);
 		}
-		if (scenario === "push-silent-then-diagnostic") {
+		if (scenario === "push-alternate-uri-encoding") {
+			setTimeout(
+				() => publish(alternateEncoding(uri), [diagnostic("alternate uri encoding diagnostic")]),
+				40,
+			);
+		} else if (scenario === "push-silent-then-diagnostic") {
 			setTimeout(() => publish(uri, [diagnostic("late push-only diagnostic")]), 40);
 		} else if (scenario === "push-sequence") {
 			setTimeout(() => publish(uri, [diagnostic("first")]), 20);

--- a/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
+++ b/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
@@ -20,13 +20,21 @@ function diagnostic(message, line = 0) {
 	};
 }
 
-// Re-encode a file URI the way editors and some servers do: a lowercase drive
-// letter with an encoded colon on Windows, plus percent-encoded unreserved
-// characters. The result addresses the same file as the URI the client sent.
+// Re-encode a file URI the way editors and some servers do, addressing the same
+// file as the URI the client sent. Percent-encoding the first letter of the file
+// name keeps the result different from the input on every platform, so the test
+// cannot pass by comparing a URI to itself. Windows additionally gets the
+// lowercase drive letter and encoded colon that marksman and VS Code send.
 function alternateEncoding(uri) {
-	return uri
-		.replace(/^file:\/\/\/([A-Za-z]):\//, (_match, drive) => `file:///${drive.toLowerCase()}%3A/`)
-		.replace(/-/g, "%2D");
+	const withEncodedDrive = uri.replace(
+		/^file:\/\/\/([A-Za-z]):\//,
+		(_match, drive) => `file:///${drive.toLowerCase()}%3A/`,
+	);
+	const lastSeparator = withEncodedDrive.lastIndexOf("/");
+	const fileName = withEncodedDrive
+		.slice(lastSeparator + 1)
+		.replace(/[A-Za-z]/, (letter) => `%${letter.charCodeAt(0).toString(16).toUpperCase()}`);
+	return `${withEncodedDrive.slice(0, lastSeparator + 1)}${fileName}`;
 }
 
 function publish(uri, diagnostics) {

--- a/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
+++ b/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
@@ -21,10 +21,11 @@ function diagnostic(message, line = 0) {
 }
 
 // Re-encode a file URI the way editors and some servers do, addressing the same
-// file as the URI the client sent. Percent-encoding the first letter of the file
-// name keeps the result different from the input on every platform, so the test
-// cannot pass by comparing a URI to itself. Windows additionally gets the
-// lowercase drive letter and encoded colon that marksman and VS Code send.
+// file as the URI the client sent. Percent-encode the first letter of the file
+// name so the result always differs from the input and the test cannot pass by
+// comparing a URI to itself. Servers are selected by file extension, so an
+// opened name always contains a letter. Windows also gets the lowercase drive
+// letter and encoded colon that marksman and VS Code send.
 function alternateEncoding(uri) {
 	const withEncodedDrive = uri.replace(
 		/^file:\/\/\/([A-Za-z]):\//,

--- a/packages/pi-lsp/test/lsp-client.test.ts
+++ b/packages/pi-lsp/test/lsp-client.test.ts
@@ -186,6 +186,30 @@ test("push-only diagnostics preserve a publication within the configured grace",
 	}
 });
 
+test("push diagnostics match a re-encoded publication uri", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-push-alternate-uri-"));
+	const file = path.join(root, "main.go");
+	writeFileSync(file, "package main\n");
+	const adapter = fixtureAdapter("push-alternate-uri-encoding", 30, undefined, 100);
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+
+	try {
+		await client.start();
+		await client.initialize(root);
+		const uri = pathToFileURL(file).href;
+		client.didOpen(uri, "package main\n", "go");
+		const diagnostics = await client.diagnostics(uri);
+		assert.deepEqual(
+			diagnostics.map(({ message }) => message),
+			["alternate uri encoding diagnostic"],
+		);
+		client.didClose(uri);
+	} finally {
+		await client.shutdown();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("push diagnostics settle on the latest publication", async () => {
 	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-push-sequence-"));
 	const file = path.join(root, "main.go");

--- a/packages/pi-lsp/test/lsp-client.test.ts
+++ b/packages/pi-lsp/test/lsp-client.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -19,6 +19,43 @@ test("server environment overrides are forwarded to the LSP process", async () =
 	try {
 		await client.start();
 		await client.initialize(root);
+	} finally {
+		await client.shutdown();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("shutdown waits for the LSP process to exit", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-shutdown-"));
+	const marker = path.join(root, "exited.txt");
+	const adapter = fixtureAdapter("delayed-exit", 30);
+	adapter.env = { PI_LSP_TEST_EXIT_MARKER: marker };
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+
+	try {
+		await client.start();
+		await client.initialize(root);
+		await client.shutdown();
+		assert.equal(readFileSync(marker, "utf8"), "exited\n");
+	} finally {
+		await client.shutdown();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("shutdown waits for a process terminated by close", async () => {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-close-"));
+	const marker = path.join(root, "exited.txt");
+	const adapter = fixtureAdapter("delayed-sigterm", 30);
+	adapter.env = { PI_LSP_TEST_EXIT_MARKER: marker };
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 1_000);
+
+	try {
+		await client.start();
+		await client.initialize(root);
+		client.close();
+		await client.shutdown();
+		assert.equal(readFileSync(marker, "utf8"), "exited\n");
 	} finally {
 		await client.shutdown();
 		rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## What breaks

`lsp_diagnostics` reports a file as clean when the language server publishes diagnostics under a different encoding of the URI the client sent.

Every Windows markdown file checked through marksman hits this.
The server finds real problems and pi-lsp discards all of them.
An empty result is worse than an error here, because the agent reads it as a clean file.

## Where the mismatch comes from

`#publishedDiagnostics` and `#diagnosticWaiters` use the raw URI string as their key.
The publish handler stores under the server's encoding.
Every read uses the client's own `pathToFileURL` output.

```
client sends : file:///C:/Users/me/notes/bad.md
marksman says: file:///c%3A/Users/me/notes/bad.md
```

Both encodings address one file, so the stored publication is never read back.

This is not specific to marksman.
That encoding is the one VS Code emits, so any server that follows the same convention is affected.

Driven directly over LSP stdio, marksman reports both diagnostics:

```
CLIENT sends : file:///C:/Users/me/notes/bad.md
SERVER answers: file:///c%3A/Users/me/notes/bad.md
MATCH        : NO
diagnostics  : Link to non-existent document 'nonexistent-note'
             | Link to non-existent heading 'missing-heading' in document 'alpha'
```

## The same defect in Oh My Pi

Oh My Pi hit this and fixed it in v17.2.9 (can1357/oh-my-pi#7662).
That client also stored publications under the server's URI and read them under its own.
marksman exposed it there too, and its fix was an equivalent-URI map that canonicalizes every key.

A sibling report, can1357/oh-my-pi#7642, tracks the same Windows drive-letter casing splitting session state.
The pattern recurs wherever a path becomes a map key.

## The fix

Both maps now use a canonical file path as their key, built with `fileURLToPath` and `path.normalize`.
The key is lowercased only on win32, where the filesystem is case insensitive.

`path.normalize` is required rather than defensive.
A doubled separator survives `fileURLToPath` as `C:^G\b`, which would key a second entry for one file.

`untitled:` and `jdt:` URIs cannot convert to a path.
They fall back to their original text and keep the current behavior.

The timeout message still prints the caller's original URI.

## Tests

`push-alternate-uri-encoding` is a new fixture scenario that publishes under a re-encoded URI.
It percent-encodes the first letter of the file name, so the published URI always differs from the one the client sent.
Windows additionally gets the lowercase drive letter and the encoded colon.
Linux and macOS cover the regression too.

The new test returns `[]` on main and passes with this change.
Reverting `documentKey` to return the raw URI fails this test alone.

## Verification

- `npm run check` passes: build, Biome, extension boundaries, and workspace typechecks.
- `npm --workspace @narumitw/pi-lsp run build` regenerates a runtime that contains the fix.
- `pi -e ./packages/pi-lsp` against a real marksman server returns both diagnostics, where it returned none before.
- ty, ruff, and biome return their previous counts through the same smoke, so pull diagnostics and servers that echo the client URI are unaffected.

## Why the suite does not run on Windows

This is unrelated to the change, and a reviewer on Windows will hit it before reaching this fix.

Each test calls `rmSync` immediately after `client.shutdown()`.
`shutdown()` does not await child exit.
Windows locks the spawned process's `cwd`, so all 12 tests fail with `EPERM` before their assertions run.
A short wait after shutdown makes all 12 pass locally.

Tell me if you want that as a separate pull request.



