### PR TITLE
fix(plan-mode): support late-registered policy tools

### DIFF
--- a/.changeset/late-plan-tools.md
+++ b/.changeset/late-plan-tools.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": patch
+---
+
+Resolve explicitly selected tools registered before the first Plan request without mutating Pi's active tool schemas.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -97,7 +97,9 @@ The extension does not register a startup flag; run `/plan start` after launch f
 
 Use **Choose tools, then start…** or the `/plan tools` compatibility shortcut to choose a session-specific Plan policy override before Planning starts.
 Both routes use the same draft selector: **Done — start with this policy** stores the allowlist and starts the workflow, while cancellation leaves Plan mode off and changes nothing.
-The bounded multi-select shows 10 rows at a time, supports viewport paging, descriptions, and explicit unavailable rows for blocked or currently inactive tools.
+The bounded multi-select shows 10 rows at a time, supports viewport paging, descriptions, and explicit unavailable rows for blocked, currently inactive, or configured but not-yet-registered tools.
+Configured or previously selected names without current metadata appear as pending registration and remain selected for first-request resolution.
+Reopen the picker to refresh tools registered while it was closed because Pi exposes no live tool-registration event.
 In TUI mode, type to fuzzy-search tool names, descriptions, policy, and source metadata; RPC keeps the complete unfiltered list.
 Once Plan mode is active, tools are locked: `/plan` no longer offers tool or Settings actions, and `/plan tools` rejects the request.
 Exit and start a new workflow if a different tool set is required.
@@ -141,10 +143,10 @@ Configure persistent defaults or a one-workflow tool override before activation;
 Plan mode registers `plan_mode_question` and `plan_mode_complete` during extension load and never changes their active status itself.
 Another active-tool policy may hide them, in which case Plan start or restore fails without widening that policy.
 By default, the Plan policy allows active safe built-ins such as `read`, limited `bash`, limited `powershell`, `grep`, `find`, and `ls`.
-The optional native `powershell` tool must already be active, for example through Pi's Windows `defaultTools` setting, before Plan mode can select it.
-Built-in `edit` and `write`, `update_plan`, inactive tools, and deselected tools are blocked at execution time even though active schemas remain visible.
-Extension and custom tools are denied by default because Pi tools do not expose standardized mutability metadata; allow an already active custom tool before starting only when you accept the risk.
-For example, you can opt into an active `firecrawl_scrape`, `firecrawl_search`, or `lsp_diagnostics` tool when you want to use it during planning.
+The optional native `powershell` tool must be active when an automatic Plan policy starts, for example through Pi's Windows `defaultTools` setting, unless its name was explicitly retained for first-request resolution.
+Built-in `edit` and `write`, `update_plan`, tools still inactive at the first request, and deselected tools are blocked at execution time even though active schemas remain visible.
+Extension and custom tools are denied by default because Pi tools do not expose standardized mutability metadata; explicitly allow a custom-tool name before starting only when you accept the risk.
+For example, you can opt into `firecrawl_scrape`, `firecrawl_search`, or `lsp_diagnostics` when you want to use the effective active tool during planning.
 After they become visible, the Plan-only helpers remain visible in Normal mode, but their handlers and the `tool_call` policy reject calls unless Plan mode owns the active workflow.
 
 Limited `bash` uses a fail-closed Bash policy, including when an extension overrides the canonical `bash` tool name.
@@ -177,7 +179,8 @@ If you cancel or no interactive UI is available, the agent should ask a concise 
 
 Pi identifies tools by tool name.
 The pre-start selector stores accepted session policy names and shows each effective tool's source from Pi metadata, such as `built-in`, a user extension path, or a project extension path.
-A selected name can run in Plan mode only when that effective tool was already active at session startup.
+A selected name can run in Plan mode only when Pi has registered and activated the effective selectable tool by that workflow's first provider-bound context.
+The allowlist freezes at that boundary, so a tool registered or activated later waits for the next Plan workflow.
 If an extension overrides a built-in tool with the same name, Pi exposes the effective tool for that name and the selector shows that source.
 
 A complete Plan mode answer should appear only after the agent has resolved discoverable facts and high-impact user decisions.
@@ -342,9 +345,11 @@ An explicit empty array appears as **No optional tools** and denies every ordina
 Neither setting changes model-visible tool schemas.
 
 Tool names must be non-empty strings; duplicates are removed in first-seen order.
-Unknown, inactive, and Plan-mode-blocked names are unavailable to the policy and never become active merely by entering Plan mode.
-Settings retains configured inactive names and shows them as unavailable; resetting to automatic removes the entire override.
-An ordinary tool registered or activated after the startup baseline is outside the current workflow policy; start a later session to include it in the selectable baseline.
+Explicit configured or session-selected names remain policy intent when their tool is unknown or inactive, but Plan mode never registers or activates them.
+The inactive menu takes a fresh registered and active tool snapshot each time it opens, while an already open picker does not update in place.
+At the workflow's first provider-bound context, after every `before_agent_start` handler has settled, Plan mode resolves retained names against Pi's live registered and active tools and freezes the executable allowlist.
+Unknown, inactive, and Plan-mode-blocked names remain unavailable after that resolution, and a later registration or activation waits for the next Plan workflow rather than a new session.
+Settings shows unresolved names as pending registration; resetting to automatic removes the entire override.
 Non-built-in names in this global setting are an explicit user-risk opt-in, just like selecting them in the pre-start workflow selector.
 Plan mode does not interpret a selected custom tool's arguments or actions: allowing one trusts the whole effective tool.
 Pi resolves tools by name, so if an extension overrides a built-in name, the effective extension tool is selected instead.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -348,6 +348,8 @@ Tool names must be non-empty strings; duplicates are removed in first-seen order
 Explicit configured or session-selected names remain policy intent when their tool is unknown or inactive, but Plan mode never registers or activates them.
 The inactive menu takes a fresh registered and active tool snapshot each time it opens, while an already open picker does not update in place.
 At the workflow's first provider-bound context, after every `before_agent_start` handler has settled, Plan mode resolves retained names against Pi's live registered and active tools and freezes the executable allowlist.
+Automatic defaults recheck the effective source metadata at that boundary, so a custom override of a safe built-in name still requires explicit opt-in.
+The resolved allowlist persists with the active workflow and restores without reopening the resolution boundary after reload, resume, or tree navigation.
 Unknown, inactive, and Plan-mode-blocked names remain unavailable after that resolution, and a later registration or activation waits for the next Plan workflow rather than a new session.
 Settings shows unresolved names as pending registration; resetting to automatic removes the entire override.
 Non-built-in names in this global setting are an explicit user-risk opt-in, just like selecting them in the pre-start workflow selector.

--- a/packages/pi-plan-mode/src/plan-launch-menu.ts
+++ b/packages/pi-plan-mode/src/plan-launch-menu.ts
@@ -3,6 +3,7 @@ import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 
 export interface PlanLaunchTool {
 	name: string;
+	label?: string;
 	description: string;
 	searchText: string;
 	disabled: boolean;
@@ -47,13 +48,15 @@ export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLau
 				title: "Choose Plan policy allowlist",
 				lines: [
 					"Policy changes apply only when you start Plan mode; first use may also reveal Plan helpers.",
-					"Only tools already active in Pi can be allowed; non-built-ins run at user risk.",
+					options.toolSummary(selectedNames),
+					"Active tools can be chosen now; retained names resolve before the first request.",
+					"Plan mode never activates tools, and non-built-ins run at user risk.",
 				],
 				enableSearch: true,
 				viewportSize: 10,
 				items: options.tools.map((tool) => ({
 					id: tool.name,
-					label: tool.name,
+					label: tool.label ?? tool.name,
 					description: tool.description,
 					searchText: tool.searchText,
 					selected: selectedNames.has(tool.name),

--- a/packages/pi-plan-mode/src/plan-launch-menu.ts
+++ b/packages/pi-plan-mode/src/plan-launch-menu.ts
@@ -27,6 +27,11 @@ export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLau
 	type Screen = "main" | "tools" | "help";
 	type Action = "start" | "toggle-tool" | "start-with-tools" | "settings";
 	const selectedNames = new Set(options.getSelectedNames());
+	const toolItems = options.tools.map((tool, index) => ({
+		id: `plan-tool:${index}`,
+		tool,
+	}));
+	const toolsByItemId = new Map(toolItems.map(({ id, tool }) => [id, tool]));
 	let draftChanged = false;
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: options.initialScreen ?? "main",
@@ -54,8 +59,8 @@ export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLau
 				],
 				enableSearch: true,
 				viewportSize: 10,
-				items: options.tools.map((tool) => ({
-					id: tool.name,
+				items: toolItems.map(({ id, tool }) => ({
+					id,
 					label: tool.label ?? tool.name,
 					description: tool.description,
 					searchText: tool.searchText,
@@ -92,7 +97,7 @@ export async function showPlanLaunchMenu(ctx: ExtensionContext, options: PlanLau
 			},
 			"toggle-tool": async ({ itemId, selected, signal }) => {
 				if (signal.aborted || !options.isCurrent()) return { kind: "rejected" };
-				const tool = options.tools.find((candidate) => candidate.name === itemId);
+				const tool = itemId ? toolsByItemId.get(itemId) : undefined;
 				if (!tool || tool.disabled) return { kind: "rejected" };
 				if (selected) selectedNames.add(tool.name);
 				else selectedNames.delete(tool.name);

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -81,7 +81,12 @@ import {
 	type UpdatePlanModeSettingsOptions,
 	updatePlanModeSettings,
 } from "./settings.js";
-import { type PlanCompletionSource, type PlanModeState, restorePlanModeState } from "./state.js";
+import {
+	type PlanCompletionSource,
+	type PlanModeState,
+	type PlanModeWorkflowToolPolicy,
+	restorePlanModeState,
+} from "./state.js";
 import {
 	canSelectToolInPlanMode,
 	classifyPlanModeTool,
@@ -103,7 +108,7 @@ interface ReadyPresentationIntent {
 }
 interface PendingWorkflowToolPolicy {
 	generation: number;
-	desiredNames: string[];
+	mode: "resolve" | "revalidate";
 }
 type InteractiveUi = typeof import("./interactive-ui.js");
 
@@ -791,6 +796,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			awaitingAction: false,
 			savedPlan: undefined,
 			activeImplementation: undefined,
+			workflowToolPolicy: undefined,
 			manualThinkingLevel: undefined,
 		};
 		if (wasEnabled) {
@@ -941,6 +947,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			awaitingAction: false,
 			savedPlan: { plan, source },
 			activeImplementation: undefined,
+			workflowToolPolicy: undefined,
 			manualThinkingLevel: undefined,
 		};
 		restoreThinkingLevel();
@@ -987,8 +994,6 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 		const previousState = state;
 		const previousIntent = readyPresentationIntent;
-		const previousWorkflowAllowedToolNames = workflowAllowedToolNames;
-		const previousPendingDesiredNames = pendingWorkflowToolPolicy?.desiredNames;
 		const wasEnabled = state.enabled;
 		if (!publishModeContract("normal", ctx)) return;
 		advanceWorkflowGeneration();
@@ -1012,6 +1017,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 						startedAt: Date.now(),
 						retention,
 					},
+			workflowToolPolicy: undefined,
 			manualThinkingLevel: undefined,
 		};
 		if (wasEnabled) {
@@ -1030,11 +1036,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!sent) {
 			state = previousState;
 			readyPresentationIntent = previousIntent;
-			workflowAllowedToolNames = previousWorkflowAllowedToolNames;
-			pendingWorkflowToolPolicy = previousPendingDesiredNames
-				? { generation: workflowGeneration, desiredNames: [...previousPendingDesiredNames] }
-				: undefined;
 			if (wasEnabled) {
+				restoreWorkflowToolPolicy(state.workflowToolPolicy);
 				publishModeContract("plan", ctx);
 				applyPlanThinkingLevel();
 			}
@@ -1282,12 +1285,18 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	}
 
 	function beginWorkflowToolPolicy() {
+		const kind = toolPolicySelectionIsExplicit() ? "explicit" : "automatic";
 		const desiredNames = desiredPlanModeToolNames();
-		pendingWorkflowToolPolicy = {
-			generation: workflowGeneration,
-			desiredNames,
+		const allowedNames = resolvePlanModePolicyToolNames(desiredNames);
+		const policy: PlanModeWorkflowToolPolicy = {
+			kind,
+			...(kind === "explicit" ? { desiredNames } : {}),
+			allowedNames,
+			resolved: false,
 		};
-		workflowAllowedToolNames = resolvePlanModePolicyToolNames(desiredNames);
+		state = { ...state, workflowToolPolicy: policy };
+		pendingWorkflowToolPolicy = { generation: workflowGeneration, mode: "resolve" };
+		workflowAllowedToolNames = allowedNames;
 	}
 
 	function resolvePendingWorkflowToolPolicy(ctx: ExtensionContext) {
@@ -1301,14 +1310,103 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			pendingWorkflowToolPolicy = undefined;
 			return;
 		}
-		workflowAllowedToolNames = resolvePlanModePolicyToolNames(pending.desiredNames);
+		const policy = state.workflowToolPolicy;
+		const expectedResolved = pending.mode === "revalidate";
+		if (!policy || policy.resolved !== expectedResolved) {
+			pendingWorkflowToolPolicy = undefined;
+			return;
+		}
+		const allowedNames =
+			pending.mode === "resolve"
+				? resolveWorkflowToolPolicy(policy)
+				: revalidateFrozenWorkflowToolPolicy(policy);
+		const policyChanged = !policy.resolved || !arrayEquals(policy.allowedNames, allowedNames);
+		workflowAllowedToolNames = allowedNames;
+		state = {
+			...state,
+			workflowToolPolicy: { ...policy, allowedNames, resolved: true },
+		};
 		pendingWorkflowToolPolicy = undefined;
+		if (policyChanged) persistState();
 		updateUi(ctx);
+	}
+
+	function toolPolicySelectionIsExplicit() {
+		return (
+			state.selectedToolNames !== undefined ||
+			state.selectedToolKeys !== undefined ||
+			settings.defaultPlanTools !== undefined
+		);
 	}
 
 	function desiredPlanModeToolNames() {
 		const tools = activePlanPolicyTools();
 		return Array.from(snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot()));
+	}
+
+	function automaticPlanModeToolNames() {
+		return Array.from(snapshotPlanModeSelectedNames(activePlanPolicyTools(), {}));
+	}
+
+	function resolveWorkflowToolPolicy(policy: PlanModeWorkflowToolPolicy) {
+		return resolvePlanModePolicyToolNames(
+			policy.kind === "automatic" ? automaticPlanModeToolNames() : (policy.desiredNames ?? []),
+		);
+	}
+
+	function revalidateFrozenWorkflowToolPolicy(policy: PlanModeWorkflowToolPolicy) {
+		const currentlyAllowed = new Set(
+			policy.kind === "automatic"
+				? resolvePlanModePolicyToolNames(automaticPlanModeToolNames())
+				: resolvePlanModePolicyToolNames(policy.allowedNames),
+		);
+		return policy.allowedNames.filter((name) => currentlyAllowed.has(name));
+	}
+
+	function restoreWorkflowToolPolicy(policy: PlanModeWorkflowToolPolicy | undefined) {
+		let nextPolicy: PlanModeWorkflowToolPolicy;
+		if (!policy) {
+			const kind = toolPolicySelectionIsExplicit() ? "explicit" : "automatic";
+			const desiredNames = desiredPlanModeToolNames();
+			nextPolicy = {
+				kind,
+				...(kind === "explicit" ? { desiredNames } : {}),
+				allowedNames: resolvePlanModePolicyToolNames(desiredNames),
+				resolved: true,
+			};
+		} else if (policy.resolved) {
+			nextPolicy = policy;
+		} else {
+			nextPolicy = {
+				...policy,
+				allowedNames: resolveWorkflowToolPolicy(policy),
+			};
+		}
+		state = { ...state, workflowToolPolicy: nextPolicy };
+		workflowAllowedToolNames = nextPolicy.resolved
+			? revalidateFrozenWorkflowToolPolicy(nextPolicy)
+			: nextPolicy.allowedNames;
+		pendingWorkflowToolPolicy = {
+			generation: workflowGeneration,
+			mode: nextPolicy.resolved ? "revalidate" : "resolve",
+		};
+		return !workflowToolPoliciesEqual(policy, nextPolicy);
+	}
+
+	function workflowToolPoliciesEqual(
+		left: PlanModeWorkflowToolPolicy | undefined,
+		right: PlanModeWorkflowToolPolicy,
+	) {
+		return (
+			left?.kind === right.kind &&
+			left.resolved === right.resolved &&
+			arrayEquals(left.allowedNames, right.allowedNames) &&
+			arrayEquals(left.desiredNames ?? [], right.desiredNames ?? [])
+		);
+	}
+
+	function arrayEquals(left: readonly string[], right: readonly string[]) {
+		return left.length === right.length && left.every((value, index) => value === right[index]);
 	}
 
 	function computePlanModePolicyToolNames() {
@@ -1446,11 +1544,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				restoreThinkingLevel();
 			}
 			state = candidate;
-			if (state.enabled) beginWorkflowToolPolicy();
-			else {
+			const policyChanged = state.enabled
+				? restoreWorkflowToolPolicy(state.workflowToolPolicy)
+				: false;
+			if (!state.enabled) {
 				workflowAllowedToolNames = undefined;
 				pendingWorkflowToolPolicy = undefined;
 			}
+			if (policyChanged) persistState();
 			if (state.enabled) applyPlanThinkingLevel();
 			else if (wasEnabled) releaseWorkflowOwner();
 			return true;

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -64,7 +64,6 @@ import {
 import {
 	assertPlanModeHelperToolsAvailable,
 	planModeHelperToolsAvailable,
-	withRequiredPlanModeTools,
 } from "./required-tools.js";
 import {
 	preflightSavedPlanImplementation,
@@ -90,12 +89,7 @@ import {
 	findBlockedPowerShellCommandSegment,
 	readCommand,
 } from "./tool-policy.js";
-import {
-	compareTools,
-	filterAvailableSelectedToolNames,
-	snapshotPlanModeSelectedNames,
-	toolPolicyLabel,
-} from "./tool-selection.js";
+import { compareTools, snapshotPlanModeSelectedNames, toolPolicyLabel } from "./tool-selection.js";
 import { WorkflowMutex, type WorkflowMutexOwner } from "./workflow-mutex.js";
 
 const STATE_ENTRY_TYPE = "plan-mode-state";
@@ -106,6 +100,10 @@ interface ReadyPresentationIntent {
 	nonce: number;
 	plan: string;
 	source: PlanCompletionSource;
+}
+interface PendingWorkflowToolPolicy {
+	generation: number;
+	desiredNames: string[];
 }
 type InteractiveUi = typeof import("./interactive-ui.js");
 
@@ -142,8 +140,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let settings: PlanModeSettings = { thinkingLevel: "inherit" };
 	let toggleShortcut: ReturnType<typeof configuredPlanModeToggleShortcut>;
 	const clearPlanModeShortcutHandler = () => {};
-	let activeToolBaseline: string[] = [];
 	let workflowAllowedToolNames: string[] | undefined;
+	let pendingWorkflowToolPolicy: PendingWorkflowToolPolicy | undefined;
 	let publishedContractMode: PlanModeContract | undefined;
 	let modeContractsRelevant = false;
 	let readyPresentationIntent: ReadyPresentationIntent | undefined;
@@ -445,13 +443,13 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		currentSessionContext = ctx;
 		workflowOwner = undefined;
 		workflowMutex.bindSession(ctx.sessionManager);
-		captureToolBaseline();
 		refreshStateBeforeFirstAgentStart = event.reason === "new";
 		menuController.abort(new DOMException("Plan-mode session replaced", "AbortError"));
 		menuController = new AbortController();
 		readyPresentationIntent = undefined;
 		latestCommandContext = undefined;
 		workflowAllowedToolNames = undefined;
+		pendingWorkflowToolPolicy = undefined;
 		implementationRetention.reset();
 		settings = { thinkingLevel: "inherit" };
 		const branch = ctx.sessionManager.getBranch();
@@ -518,6 +516,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		readyPresentationIntent = undefined;
 		latestCommandContext = undefined;
 		refreshStateBeforeFirstAgentStart = false;
+		workflowAllowedToolNames = undefined;
+		pendingWorkflowToolPolicy = undefined;
 		implementationRetention.reset();
 		await awaitPlanModeSettingsWrites(dependencies.settingsPath);
 		if (currentSession !== undefined && currentSession !== shutdownSession) {
@@ -613,6 +613,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	pi.on("context", async (event, ctx) => {
+		resolvePendingWorkflowToolPolicy(ctx);
 		const result = implementationRetention.transformContext(event.messages, state);
 		if (result.clearActiveImplementationId) {
 			clearActiveImplementation(result.clearActiveImplementationId, ctx);
@@ -749,7 +750,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				selectedToolNames: candidate.selectedToolNames,
 				selectedToolKeys: candidate.selectedToolKeys,
 			};
-			workflowAllowedToolNames = computePlanModePolicyToolNames();
+			beginWorkflowToolPolicy();
 			applyPlanThinkingLevel();
 			persistState();
 			updateUi(ctx);
@@ -986,6 +987,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 		const previousState = state;
 		const previousIntent = readyPresentationIntent;
+		const previousWorkflowAllowedToolNames = workflowAllowedToolNames;
+		const previousPendingDesiredNames = pendingWorkflowToolPolicy?.desiredNames;
 		const wasEnabled = state.enabled;
 		if (!publishModeContract("normal", ctx)) return;
 		advanceWorkflowGeneration();
@@ -1027,9 +1030,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!sent) {
 			state = previousState;
 			readyPresentationIntent = previousIntent;
+			workflowAllowedToolNames = previousWorkflowAllowedToolNames;
+			pendingWorkflowToolPolicy = previousPendingDesiredNames
+				? { generation: workflowGeneration, desiredNames: [...previousPendingDesiredNames] }
+				: undefined;
 			if (wasEnabled) {
 				publishModeContract("plan", ctx);
-				workflowAllowedToolNames = computePlanModePolicyToolNames();
 				applyPlanThinkingLevel();
 			}
 			persistState();
@@ -1069,6 +1075,19 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		const ui = await loadInteractiveUi();
 		if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 		const tools = selectableTools();
+		const activeToolNames = new Set(safeGetActiveTools());
+		const initialSelectedNames = snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot());
+		const retainsInactiveSelection =
+			state.selectedToolNames !== undefined ||
+			state.selectedToolKeys !== undefined ||
+			settings.defaultPlanTools !== undefined;
+		const retainedInactiveNames = retainsInactiveSelection
+			? initialSelectedNames
+			: new Set<string>();
+		const registeredNames = new Set(tools.map((tool) => tool.name));
+		const pendingNames = Array.from(retainedInactiveNames).filter(
+			(name) => !registeredNames.has(name),
+		);
 		await ui.showPlanLaunchMenu(ctx, {
 			statusText: planModeHelperToolsAvailable(safeGetActiveTools())
 				? "Status: Off — visible Plan helpers stay inactive until /plan starts."
@@ -1079,30 +1098,65 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				const allowed = tools
 					.filter(
 						(tool) =>
-							toolIsActive(tool.name) &&
+							activeToolNames.has(tool.name) &&
 							selectedNames.has(tool.name) &&
 							canSelectToolInPlanMode(tool),
 					)
 					.map((tool) => tool.name);
-				return `Plan policy will allow: ${allowed.length > 0 ? allowed.join(", ") : "none"}.`;
+				const pending = pendingNames
+					.filter((name) => selectedNames.has(name))
+					.map(terminalToolName);
+				const visiblePending = pending.slice(0, 3);
+				const pendingSuffix =
+					pending.length > visiblePending.length
+						? `, +${pending.length - visiblePending.length} more`
+						: "";
+				return [
+					`Plan policy will allow: ${allowed.length > 0 ? allowed.join(", ") : "none"}.`,
+					...(pending.length > 0
+						? [`Pending registration: ${visiblePending.join(", ")}${pendingSuffix}.`]
+						: []),
+				].join(" ");
 			},
-			tools: tools.map((tool) => {
-				const selectable = canSelectToolInPlanMode(tool);
-				const active = toolIsActive(tool.name);
-				const policy = active ? toolPolicyLabel(tool) : "not active in this Pi session";
-				const description = tool.description ?? "No description available";
-				return {
-					name: tool.name,
-					description: `${policy} · ${description}`,
-					searchText: [policy, description].join(" "),
-					disabled: !selectable || !active,
-					disabledReason: !active
-						? "Not active in Pi; Plan mode will not activate it"
-						: selectable
-							? undefined
-							: "Blocked by Plan-mode policy",
-				};
-			}),
+			tools: [
+				...tools.map((tool) => {
+					const selectable = canSelectToolInPlanMode(tool);
+					const active = activeToolNames.has(tool.name);
+					const retained = retainedInactiveNames.has(tool.name);
+					const policy = active
+						? toolPolicyLabel(tool)
+						: retained
+							? "not active yet; retained for first-request resolution"
+							: "not active in this Pi session";
+					const description = tool.description ?? "No description available";
+					return {
+						name: tool.name,
+						description: `${policy} · ${description}`,
+						searchText: [policy, description].join(" "),
+						disabled: !selectable || !active,
+						disabledReason: !active
+							? retained
+								? "Not active yet; retained and resolved before the first request"
+								: "Not active in Pi; Plan mode will not activate it"
+							: selectable
+								? undefined
+								: "Blocked by Plan-mode policy",
+					};
+				}),
+				...pendingNames.map((name) => {
+					const label = terminalToolName(name);
+					return {
+						name,
+						label,
+						description:
+							"pending registration · Retained and resolved before the first Plan request",
+						searchText: `${label} pending registration retained first Plan request`,
+						disabled: true,
+						disabledReason:
+							"Not registered yet; Plan mode will not activate it and will resolve it before the first request",
+					};
+				}),
+			],
 			...lifecycle,
 			start: (signal) => {
 				if (signal.aborted || !lifecycle.isCurrent()) return;
@@ -1115,7 +1169,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			},
 			startWithTools: (names, signal) => {
 				if (signal.aborted || !lifecycle.isCurrent()) return;
-				const selectedToolNames = filterAvailableSelectedToolNames(names, activePlanPolicyTools());
+				const selectedToolNames = Array.from(
+					new Set(
+						names.filter((name) => activeToolNames.has(name) || retainedInactiveNames.has(name)),
+					),
+				);
 				if (enterPlanMode(ctx, { selectedToolNames, selectedToolKeys: undefined })) {
 					ctx.ui.notify("Plan mode enabled with the selected tools.", "info");
 				}
@@ -1165,7 +1223,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!isCurrent() || signal.aborted) return false;
 		const result = await ui.showPlanModeSettings(ctx, {
 			tools: selectableTools(),
-			activeToolNames: activeToolBaseline,
+			activeToolNames: safeGetActiveTools(),
 			signal,
 			isCurrent,
 			settingsPath: dependencies.settingsPath,
@@ -1192,6 +1250,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	function advanceWorkflowGeneration() {
 		workflowGeneration += 1;
+		pendingWorkflowToolPolicy = undefined;
 		finalizationRequest.reset();
 	}
 
@@ -1217,18 +1276,48 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		};
 	}
 
-	function captureToolBaseline() {
-		activeToolBaseline = withRequiredPlanModeTools(safeGetActiveTools());
+	function planModePolicyToolNames() {
+		if (state.enabled) return workflowAllowedToolNames ?? [];
+		return computePlanModePolicyToolNames();
 	}
 
-	function planModePolicyToolNames() {
-		return workflowAllowedToolNames ?? computePlanModePolicyToolNames();
+	function beginWorkflowToolPolicy() {
+		const desiredNames = desiredPlanModeToolNames();
+		pendingWorkflowToolPolicy = {
+			generation: workflowGeneration,
+			desiredNames,
+		};
+		workflowAllowedToolNames = resolvePlanModePolicyToolNames(desiredNames);
+	}
+
+	function resolvePendingWorkflowToolPolicy(ctx: ExtensionContext) {
+		const pending = pendingWorkflowToolPolicy;
+		if (!pending) return;
+		if (
+			pending.generation !== workflowGeneration ||
+			!state.enabled ||
+			!workflowMutex.isOwner(workflowOwner)
+		) {
+			pendingWorkflowToolPolicy = undefined;
+			return;
+		}
+		workflowAllowedToolNames = resolvePlanModePolicyToolNames(pending.desiredNames);
+		pendingWorkflowToolPolicy = undefined;
+		updateUi(ctx);
+	}
+
+	function desiredPlanModeToolNames() {
+		const tools = activePlanPolicyTools();
+		return Array.from(snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot()));
 	}
 
 	function computePlanModePolicyToolNames() {
-		const tools = activePlanPolicyTools();
-		const selectedNames = snapshotPlanModeSelectedNames(tools, toolSelectionSnapshot());
-		return tools
+		return resolvePlanModePolicyToolNames(desiredPlanModeToolNames());
+	}
+
+	function resolvePlanModePolicyToolNames(desiredNames: readonly string[]) {
+		const selectedNames = new Set(desiredNames);
+		return activePlanPolicyTools()
 			.filter((tool) => selectedNames.has(tool.name) && canSelectToolInPlanMode(tool))
 			.map((tool) => tool.name);
 	}
@@ -1251,12 +1340,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	}
 
 	function activePlanPolicyTools() {
-		const activeNames = new Set(activeToolBaseline);
+		const activeNames = new Set(safeGetActiveTools());
 		return selectableTools().filter((tool) => activeNames.has(tool.name));
-	}
-
-	function toolIsActive(toolName: string) {
-		return activeToolBaseline.includes(toolName);
 	}
 
 	function safeGetAllTools() {
@@ -1325,6 +1410,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	function installRestoredState(candidate: PlanModeState, ctx: ExtensionContext) {
 		const previousState = state;
 		const previousWorkflowAllowedToolNames = workflowAllowedToolNames;
+		const previousPendingWorkflowToolPolicy = pendingWorkflowToolPolicy;
 		const previousOwner = workflowOwner;
 		const wasEnabled = state.enabled;
 		if (candidate.enabled && !workflowMutex.isOwner(workflowOwner)) {
@@ -1332,6 +1418,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			if (!owner) {
 				state = { enabled: false, awaitingAction: false };
 				workflowAllowedToolNames = undefined;
+				pendingWorkflowToolPolicy = undefined;
 				reportRestoredWorkflowBusy(ctx);
 				return false;
 			}
@@ -1345,6 +1432,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				} catch {
 					state = { enabled: false, awaitingAction: false };
 					workflowAllowedToolNames = undefined;
+					pendingWorkflowToolPolicy = undefined;
 					if (workflowOwner !== previousOwner) {
 						workflowMutex.release(workflowOwner);
 						workflowOwner = previousOwner;
@@ -1358,7 +1446,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				restoreThinkingLevel();
 			}
 			state = candidate;
-			workflowAllowedToolNames = state.enabled ? computePlanModePolicyToolNames() : undefined;
+			if (state.enabled) beginWorkflowToolPolicy();
+			else {
+				workflowAllowedToolNames = undefined;
+				pendingWorkflowToolPolicy = undefined;
+			}
 			if (state.enabled) applyPlanThinkingLevel();
 			else if (wasEnabled) releaseWorkflowOwner();
 			return true;
@@ -1368,6 +1460,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			} finally {
 				state = previousState;
 				workflowAllowedToolNames = previousWorkflowAllowedToolNames;
+				pendingWorkflowToolPolicy = previousPendingWorkflowToolPolicy;
 				if (workflowOwner !== previousOwner) {
 					workflowMutex.release(workflowOwner);
 					workflowOwner = previousOwner;
@@ -1392,6 +1485,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		} finally {
 			state = previousState;
 			workflowAllowedToolNames = undefined;
+			pendingWorkflowToolPolicy = undefined;
 			try {
 				persistState();
 				updateUi(ctx);
@@ -1471,6 +1565,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	function toolByName(toolName: string) {
 		return safeGetAllTools().find((candidate) => candidate.name === toolName);
+	}
+
+	function terminalToolName(value: string) {
+		const safe = safeTerminalText(value) || "(unnamed tool)";
+		return safe.length > 120 ? `${safe.slice(0, 119)}…` : safe;
 	}
 
 	function safeTerminalText(value: string) {

--- a/packages/pi-plan-mode/src/settings-menu.ts
+++ b/packages/pi-plan-mode/src/settings-menu.ts
@@ -70,6 +70,10 @@ export async function showPlanModeSettings(
 		(tool) =>
 			tool.name !== PLAN_MODE_QUESTION_TOOL_NAME && tool.name !== PLAN_MODE_COMPLETE_TOOL_NAME,
 	);
+	const toolItemIds = new Map(
+		tools.map((tool, index) => [tool.name, `plan-settings-tool:${index}`]),
+	);
+	const toolsByItemId = new Map(tools.map((tool) => [toolItemIds.get(tool.name) as string, tool]));
 
 	const loadState = async (): Promise<SettingsMenuState> => {
 		const loaded = await readSettings(options.settingsPath);
@@ -152,7 +156,12 @@ export async function showPlanModeSettings(
 				],
 				enableSearch: true,
 				viewportSize: 10,
-				items: defaultToolItems(tools, state.settings.defaultPlanTools, activeToolNames),
+				items: defaultToolItems(
+					tools,
+					state.settings.defaultPlanTools,
+					activeToolNames,
+					toolItemIds,
+				),
 				action: "toggle-tool",
 				actions: [
 					{
@@ -253,7 +262,7 @@ export async function showPlanModeSettings(
 				return result.kind === "stay" ? { kind: "to", screen: "settings" } : result;
 			},
 			"toggle-tool": async ({ ctx: actionCtx, state, itemId, selected, signal }) => {
-				const tool = tools.find((candidate) => candidate.name === itemId);
+				const tool = itemId ? toolsByItemId.get(itemId) : undefined;
 				if (!tool || !activeToolNames.has(tool.name) || !canSelectToolInPlanMode(tool)) {
 					return { kind: "rejected" };
 				}
@@ -350,6 +359,7 @@ function defaultToolItems(
 	tools: readonly ToolInfo[],
 	configured: string[] | undefined,
 	activeToolNames: ReadonlySet<string>,
+	toolItemIds: ReadonlyMap<string, string>,
 ) {
 	const selected = new Set(explicitToolNames(tools, configured));
 	const availableNames = new Set(tools.map((tool) => tool.name));
@@ -363,7 +373,7 @@ function defaultToolItems(
 				: "not active in this Pi session";
 		const description = tool.description ?? "No description available";
 		return {
-			id: tool.name,
+			id: toolItemIds.get(tool.name) as string,
 			label: tool.name,
 			description: `${policy} · ${description}`,
 			searchText: `${policy} ${description}`,
@@ -378,11 +388,11 @@ function defaultToolItems(
 					: "Blocked by Plan-mode policy",
 		};
 	});
-	for (const name of configured ?? []) {
+	for (const [index, name] of (configured ?? []).entries()) {
 		if (availableNames.has(name)) continue;
 		const label = terminalToolName(name);
 		items.push({
-			id: name,
+			id: `plan-settings-pending:${index}`,
 			label,
 			description: "pending registration · Retained and resolved before the first request",
 			searchText: `${label} pending registration retained settings first request`,

--- a/packages/pi-plan-mode/src/settings-menu.ts
+++ b/packages/pi-plan-mode/src/settings-menu.ts
@@ -111,7 +111,7 @@ export async function showPlanModeSettings(
 									id: "defaultPlanTools",
 									label: "Plan policy tools",
 									description:
-										"Choose which already-active tools Plan mode may execute by default.",
+										"Choose active tools or retain names to resolve before the first request.",
 									currentValue: defaultToolsValue(state.settings.defaultPlanTools),
 									action: "open-tools",
 								},
@@ -147,7 +147,8 @@ export async function showPlanModeSettings(
 				title: "Default Plan policy allowlist",
 				lines: [
 					"Changes apply when a later Plan workflow starts; model-visible tools stay unchanged.",
-					"Only tools already active in Pi can be allowed; non-built-ins run at user risk.",
+					"Retained inactive names resolve before that workflow's first request.",
+					"Plan mode never activates tools, and non-built-ins run at user risk.",
 				],
 				enableSearch: true,
 				viewportSize: 10,
@@ -355,7 +356,11 @@ function defaultToolItems(
 	const items = tools.map((tool) => {
 		const active = activeToolNames.has(tool.name);
 		const selectable = active && canSelectToolInPlanMode(tool);
-		const policy = active ? toolPolicyLabel(tool) : "not active in this Pi session";
+		const policy = active
+			? toolPolicyLabel(tool)
+			: selected.has(tool.name)
+				? "not active yet; retained for first-request resolution"
+				: "not active in this Pi session";
 		const description = tool.description ?? "No description available";
 		return {
 			id: tool.name,
@@ -365,7 +370,9 @@ function defaultToolItems(
 			selected: selected.has(tool.name),
 			disabled: !selectable,
 			disabledReason: !active
-				? "Not active in Pi; Plan mode will not activate it"
+				? selected.has(tool.name)
+					? "Not active yet; retained and resolved before the first request"
+					: "Not active in Pi; Plan mode will not activate it"
 				: selectable
 					? undefined
 					: "Blocked by Plan-mode policy",
@@ -373,14 +380,15 @@ function defaultToolItems(
 	});
 	for (const name of configured ?? []) {
 		if (availableNames.has(name)) continue;
+		const label = terminalToolName(name);
 		items.push({
 			id: name,
-			label: name,
-			description: "unavailable · Retained in settings but unavailable in this session",
-			searchText: "unavailable retained settings",
+			label,
+			description: "pending registration · Retained and resolved before the first request",
+			searchText: `${label} pending registration retained settings first request`,
 			selected: true,
 			disabled: true,
-			disabledReason: "Unavailable in this session; reset defaults to remove unavailable names",
+			disabledReason: "Not registered yet; reset defaults to remove retained names",
 		});
 	}
 	return items;
@@ -390,6 +398,11 @@ function explicitToolNames(tools: readonly ToolInfo[], configured: string[] | un
 	return configured === undefined
 		? defaultPlanModeToolNames([...tools], undefined)
 		: [...configured];
+}
+
+function terminalToolName(value: string) {
+	const safe = safeTerminalText(value) || "(unnamed tool)";
+	return safe.length > 120 ? `${safe.slice(0, 119)}…` : safe;
 }
 
 function safeTerminalText(value: string) {

--- a/packages/pi-plan-mode/src/state.ts
+++ b/packages/pi-plan-mode/src/state.ts
@@ -25,6 +25,13 @@ export interface SavedPlan {
 	source: PlanCompletionSource;
 }
 
+export interface PlanModeWorkflowToolPolicy {
+	kind: "automatic" | "explicit";
+	desiredNames?: string[];
+	allowedNames: string[];
+	resolved: boolean;
+}
+
 export interface PlanModeState {
 	enabled: boolean;
 	latestPlan?: string;
@@ -34,6 +41,7 @@ export interface PlanModeState {
 	activeImplementation?: ActiveImplementationPlan;
 	selectedToolNames?: string[];
 	selectedToolKeys?: string[];
+	workflowToolPolicy?: PlanModeWorkflowToolPolicy;
 	previousThinkingLevel?: PlanModeFixedThinkingLevel;
 	appliedThinkingLevel?: PlanModeFixedThinkingLevel;
 	manualThinkingLevel?: PlanModeFixedThinkingLevel;
@@ -86,12 +94,34 @@ export function restorePlanModeState(entries: unknown[], stateEntryType: string)
 		activeImplementation,
 		selectedToolNames: stringArray(entry.data.selectedToolNames),
 		selectedToolKeys: stringArray(entry.data.selectedToolKeys),
+		workflowToolPolicy: enabled
+			? normalizeWorkflowToolPolicy(entry.data.workflowToolPolicy)
+			: undefined,
 		previousThinkingLevel: enabled
 			? fixedThinkingLevel(entry.data.previousThinkingLevel)
 			: undefined,
 		appliedThinkingLevel: enabled ? fixedThinkingLevel(entry.data.appliedThinkingLevel) : undefined,
 		manualThinkingLevel: enabled ? fixedThinkingLevel(entry.data.manualThinkingLevel) : undefined,
 	};
+}
+
+function normalizeWorkflowToolPolicy(value: unknown): PlanModeWorkflowToolPolicy | undefined {
+	if (value === undefined) return undefined;
+	const denied: PlanModeWorkflowToolPolicy = {
+		kind: "automatic",
+		allowedNames: [],
+		resolved: true,
+	};
+	if (!isRecord(value)) return denied;
+	const kind = value.kind === "automatic" || value.kind === "explicit" ? value.kind : undefined;
+	const allowedNames = stringArray(value.allowedNames);
+	if (!kind || !allowedNames || typeof value.resolved !== "boolean") return denied;
+	if (kind === "automatic") {
+		return { kind, allowedNames, resolved: value.resolved };
+	}
+	const desiredNames = stringArray(value.desiredNames);
+	if (!desiredNames) return denied;
+	return { kind, desiredNames, allowedNames, resolved: value.resolved };
 }
 
 function normalizeSavedPlan(value: unknown): SavedPlan | undefined {

--- a/packages/pi-plan-mode/src/tool-selection.ts
+++ b/packages/pi-plan-mode/src/tool-selection.ts
@@ -44,9 +44,7 @@ export function filterAvailableSelectedToolNames(names: string[], tools: ToolInf
 }
 
 export function defaultPlanModeToolNames(tools: ToolInfo[], configuredNames: string[] | undefined) {
-	if (configuredNames !== undefined) {
-		return filterAvailableSelectedToolNames(configuredNames, tools);
-	}
+	if (configuredNames !== undefined) return unique(configuredNames);
 	return tools
 		.filter((tool) => isBuiltinTool(tool) && SAFE_BUILTIN_PLAN_TOOLS.has(tool.name))
 		.map((tool) => tool.name);
@@ -70,6 +68,6 @@ export function snapshotPlanModeSelectedNames(
 	return new Set(
 		selectedToolNames === undefined
 			? defaultPlanModeToolNames(tools, selection.defaultPlanTools)
-			: filterAvailableSelectedToolNames(selectedToolNames, tools),
+			: unique(selectedToolNames),
 	);
 }

--- a/packages/pi-plan-mode/test/cache-contract.test.ts
+++ b/packages/pi-plan-mode/test/cache-contract.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import planMode from "../src/plan-mode.js";
-import { builtinTool, createMockContext, createMockPi } from "./support.js";
+import { builtinTool, createMockContext, createMockPi, extensionTool } from "./support.js";
 
 interface CapturedRequest {
 	phase: "normal" | "plan" | "implementation";
@@ -75,6 +75,43 @@ async function completePlan(mock: ReturnType<typeof createMockPi>, ctx: unknown)
 	assert.ok(complete);
 	await complete("complete", { plan: "# Cache-stable plan" }, undefined, undefined, ctx);
 }
+
+test("first-context policy resolution does not mutate late active tool schemas", async () => {
+	const allTools = [builtinTool("read")];
+	const mock = createMockPi({ activeTools: ["read"], allTools });
+	const activeToolWrites: string[][] = [];
+	const setActiveTools = mock.rawPi.setActiveTools.bind(mock.rawPi);
+	mock.rawPi.setActiveTools = (names) => {
+		activeToolWrites.push([...names]);
+		setActiveTools(names);
+	};
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: { thinkingLevel: "inherit" as const, defaultPlanTools: ["late_tool"] },
+		}),
+	});
+	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	allTools.push(extensionTool("late_tool"));
+	setActiveTools([...mock.rawPi.getActiveTools(), "late_tool"]);
+	const activeBeforeContext = mock.rawPi.getActiveTools();
+	const definitionsBeforeContext = activeBeforeContext.map((name) => {
+		const tool = [...allTools, ...mock.tools].find((candidate) => candidate.name === name) as
+			| Record<string, unknown>
+			| undefined;
+		return { name, description: tool?.description, parameters: tool?.parameters };
+	});
+
+	const request = await captureRequest("plan", mock, context.ctx, [
+		{ role: "user", content: "Inspect with the late tool" },
+	]);
+
+	assert.deepEqual(request.activeTools, activeBeforeContext);
+	assert.deepEqual(request.providerPayload.tools, definitionsBeforeContext);
+	assert.deepEqual(activeToolWrites, []);
+});
 
 test("stable Plan helper schema keeps request fields and inactive metadata safe", async () => {
 	const allTools = [

--- a/packages/pi-plan-mode/test/issue-1018-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-1018-repro.test.ts
@@ -112,6 +112,20 @@ test("unconfigured late custom tools remain denied", async () => {
 	assert.equal((await callTool(fixture, LATE_TOOL))?.block, true);
 });
 
+test("automatic defaults reject a late custom override while explicit intent allows it", async () => {
+	const automatic = await startPlan({});
+	automatic.allTools.splice(0, 1, extensionTool("read"));
+	await runBeforeAgentStart(automatic);
+	await runContext(automatic);
+	assert.equal((await callTool(automatic, "read"))?.block, true);
+
+	const explicit = await startPlan({ configured: ["read"] });
+	explicit.allTools.splice(0, 1, extensionTool("read"));
+	await runBeforeAgentStart(explicit);
+	await runContext(explicit);
+	assert.equal(await callTool(explicit, "read"), undefined);
+});
+
 test("configured inactive and metadata-free tools remain denied", async () => {
 	const inactive = await startPlan({
 		configured: [LATE_TOOL],
@@ -152,6 +166,108 @@ test("registration after first context waits for the next workflow", async () =>
 	await fixture.mock.commands.get("plan")?.handler("start", fixture.context.ctx);
 	await runContext(fixture);
 	assert.equal(await callTool(fixture, LATE_TOOL), undefined);
+});
+
+test("a resolved allowlist stays frozen when its active workflow is restored", async () => {
+	const fixture = await startPlan({ configured: [LATE_TOOL] });
+	await runContext(fixture);
+	const resolvedState = fixture.mock.entries.at(-1)?.data as
+		| {
+				workflowToolPolicy?: {
+					allowedNames?: string[];
+					resolved?: boolean;
+				};
+		  }
+		| undefined;
+	assert.equal(resolvedState?.workflowToolPolicy?.resolved, true);
+	assert.deepEqual(resolvedState?.workflowToolPolicy?.allowedNames, []);
+
+	registerLateTool(fixture);
+	const branch = fixture.mock.entries.map((entry) => ({ type: "custom", ...entry }));
+	const replacement = createMockContext({
+		sessionManager: {
+			getBranch: () => branch,
+			getEntries: () => branch,
+			getEntry: () => undefined,
+		},
+	});
+	await fixture.mock.events.get("session_start")?.[0]?.({ reason: "resume" }, replacement.ctx);
+	await fixture.mock.events.get("context")?.[0]?.({ messages: [] }, replacement.ctx);
+
+	const result = (await fixture.mock.events.get("tool_call")?.[0]?.(
+		{ toolName: LATE_TOOL, input: {} },
+		replacement.ctx,
+	)) as { block?: boolean } | undefined;
+	assert.equal(result?.block, true);
+});
+
+test("restoration revalidates a frozen allowed name after late registration", async () => {
+	const fixture = await startPlan({
+		configured: [LATE_TOOL],
+		activeTools: ["read", LATE_TOOL],
+		allTools: [builtinTool("read"), extensionTool(LATE_TOOL)],
+	});
+	await runContext(fixture);
+	const branch = fixture.mock.entries.map((entry) => ({ type: "custom", ...entry }));
+	fixture.allTools.splice(1, 1);
+	fixture.mock.rawPi.setActiveTools(["read", "plan_mode_question", "plan_mode_complete"]);
+	const replacement = createMockContext({
+		sessionManager: {
+			getBranch: () => branch,
+			getEntries: () => branch,
+			getEntry: () => undefined,
+		},
+	});
+	await fixture.mock.events.get("session_start")?.[0]?.({ reason: "resume" }, replacement.ctx);
+	fixture.allTools.push(extensionTool(LATE_TOOL));
+	fixture.mock.rawPi.setActiveTools([...fixture.mock.rawPi.getActiveTools(), LATE_TOOL]);
+	await fixture.mock.events.get("context")?.[0]?.({ messages: [] }, replacement.ctx);
+
+	assert.equal(
+		await fixture.mock.events.get("tool_call")?.[0]?.(
+			{ toolName: LATE_TOOL, input: {} },
+			replacement.ctx,
+		),
+		undefined,
+	);
+});
+
+test("malformed persisted workflow policy fails closed", async () => {
+	const stateEntry = {
+		type: "custom",
+		customType: "plan-mode-state",
+		data: {
+			enabled: true,
+			awaitingAction: false,
+			selectedToolNames: [LATE_TOOL],
+			workflowToolPolicy: {
+				kind: "explicit",
+				desiredNames: [LATE_TOOL],
+				allowedNames: [LATE_TOOL],
+				resolved: "yes",
+			},
+		},
+	};
+	const mock = createMockPi({
+		activeTools: ["read", LATE_TOOL],
+		allTools: [builtinTool("read"), extensionTool(LATE_TOOL)],
+	});
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: {
+			getBranch: () => [stateEntry],
+			getEntries: () => [stateEntry],
+			getEntry: () => undefined,
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "resume" }, context.ctx);
+	await mock.events.get("context")?.[0]?.({ messages: [] }, context.ctx);
+
+	const result = (await mock.events.get("tool_call")?.[0]?.(
+		{ toolName: LATE_TOOL, input: {} },
+		context.ctx,
+	)) as { block?: boolean } | undefined;
+	assert.equal(result?.block, true);
 });
 
 test("session replacement discards pending intent from the replaced workflow", async () => {

--- a/packages/pi-plan-mode/test/issue-1018-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-1018-repro.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import type { ToolInfo } from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import planMode from "../src/plan-mode.js";
+import {
+	filterAvailableSelectedToolNames,
+	snapshotPlanModeSelectedNames,
+} from "../src/tool-selection.js";
+import { builtinTool, createMockContext, createMockPi, extensionTool } from "./support.js";
+
+const LATE_TOOL = "late_tool";
+
+async function startPlan(options: {
+	configured?: string[];
+	activeTools?: string[];
+	allTools?: ReturnType<typeof builtinTool>[];
+}) {
+	const allTools = options.allTools ?? [builtinTool("read")];
+	const mock = createMockPi({ activeTools: options.activeTools ?? ["read"], allTools });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: {
+				thinkingLevel: "inherit" as const,
+				...(options.configured === undefined ? {} : { defaultPlanTools: [...options.configured] }),
+			},
+		}),
+	});
+	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	return { allTools, context, mock };
+}
+
+function registerLateTool(fixture: Awaited<ReturnType<typeof startPlan>>, name = LATE_TOOL) {
+	fixture.allTools.push(extensionTool(name));
+	fixture.mock.rawPi.setActiveTools([...new Set([...fixture.mock.rawPi.getActiveTools(), name])]);
+}
+
+async function runBeforeAgentStart(fixture: Awaited<ReturnType<typeof startPlan>>) {
+	for (const handler of fixture.mock.events.get("before_agent_start") ?? []) {
+		await handler({ prompt: "plan", systemPrompt: "stable" }, fixture.context.ctx);
+	}
+}
+
+async function runContext(fixture: Awaited<ReturnType<typeof startPlan>>) {
+	for (const handler of fixture.mock.events.get("context") ?? []) {
+		await handler({ messages: [] }, fixture.context.ctx);
+	}
+}
+
+async function callTool(fixture: Awaited<ReturnType<typeof startPlan>>, toolName: string) {
+	return fixture.mock.events.get("tool_call")?.[0]?.(
+		{ toolName, input: {} },
+		fixture.context.ctx,
+	) as { block?: boolean; reason?: string } | undefined;
+}
+
+test("explicit tool intent is retained until availability is resolved", () => {
+	const tools = [builtinTool("read"), builtinTool("write"), extensionTool(LATE_TOOL)] as ToolInfo[];
+	const untrustedName = "pending\u001b[31m_tool";
+	assert.deepEqual(
+		Array.from(
+			snapshotPlanModeSelectedNames(tools, {
+				defaultPlanTools: [LATE_TOOL, "missing", "write", LATE_TOOL],
+			}),
+		),
+		[LATE_TOOL, "missing", "write"],
+	);
+	assert.deepEqual(
+		filterAvailableSelectedToolNames([LATE_TOOL, "missing", "write", LATE_TOOL], tools),
+		[LATE_TOOL],
+	);
+	assert.deepEqual(
+		Array.from(
+			snapshotPlanModeSelectedNames(tools, {
+				selectedToolKeys: [`${LATE_TOOL}\u001flegacy-source`, "missing\u001flegacy-source"],
+			}),
+		),
+		[LATE_TOOL],
+	);
+	assert.deepEqual(
+		Array.from(snapshotPlanModeSelectedNames(tools, {})),
+		["read"],
+		"automatic defaults keep only safe built-ins",
+	);
+	assert.deepEqual(
+		Array.from(snapshotPlanModeSelectedNames(tools, { defaultPlanTools: [untrustedName] })),
+		[untrustedName],
+		"display sanitization must not mutate policy intent",
+	);
+});
+
+test("configured tools registered before the first Plan context join that workflow policy", async () => {
+	for (const timing of ["before-plan-handler", "after-plan-handler"] as const) {
+		const fixture = await startPlan({ configured: [LATE_TOOL] });
+		if (timing === "before-plan-handler") registerLateTool(fixture);
+		await runBeforeAgentStart(fixture);
+		if (timing === "after-plan-handler") registerLateTool(fixture);
+		await runContext(fixture);
+
+		assert.equal(await callTool(fixture, LATE_TOOL), undefined, timing);
+	}
+});
+
+test("unconfigured late custom tools remain denied", async () => {
+	const fixture = await startPlan({});
+	registerLateTool(fixture);
+	await runBeforeAgentStart(fixture);
+	await runContext(fixture);
+
+	assert.equal((await callTool(fixture, LATE_TOOL))?.block, true);
+});
+
+test("configured inactive and metadata-free tools remain denied", async () => {
+	const inactive = await startPlan({
+		configured: [LATE_TOOL],
+		allTools: [builtinTool("read"), extensionTool(LATE_TOOL)],
+	});
+	await runContext(inactive);
+	assert.equal((await callTool(inactive, LATE_TOOL))?.block, true);
+
+	const missingMetadata = await startPlan({
+		configured: [LATE_TOOL],
+		activeTools: ["read", LATE_TOOL],
+	});
+	await runContext(missingMetadata);
+	assert.equal((await callTool(missingMetadata, LATE_TOOL))?.block, true);
+});
+
+test("configured Plan-blocked built-ins remain denied", async () => {
+	const fixture = await startPlan({
+		configured: ["write"],
+		activeTools: ["read", "write"],
+		allTools: [builtinTool("read"), builtinTool("write")],
+	});
+	await runContext(fixture);
+
+	const result = await callTool(fixture, "write");
+	assert.equal(result?.block, true);
+	assert.match(result?.reason ?? "", /mutating tool/u);
+});
+
+test("registration after first context waits for the next workflow", async () => {
+	const fixture = await startPlan({ configured: [LATE_TOOL] });
+	await runContext(fixture);
+	registerLateTool(fixture);
+	await runContext(fixture);
+	assert.equal((await callTool(fixture, LATE_TOOL))?.block, true);
+
+	await fixture.mock.commands.get("plan")?.handler("exit", fixture.context.ctx);
+	await fixture.mock.commands.get("plan")?.handler("start", fixture.context.ctx);
+	await runContext(fixture);
+	assert.equal(await callTool(fixture, LATE_TOOL), undefined);
+});
+
+test("session replacement discards pending intent from the replaced workflow", async () => {
+	let configured = [LATE_TOOL];
+	const allTools = [builtinTool("read")];
+	const mock = createMockPi({ activeTools: ["read"], allTools });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: { thinkingLevel: "inherit" as const, defaultPlanTools: [...configured] },
+		}),
+	});
+	const first = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, first.ctx);
+	await mock.commands.get("plan")?.handler("start", first.ctx);
+
+	configured = [];
+	const replacement = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({ reason: "resume" }, replacement.ctx);
+	await mock.commands.get("plan")?.handler("start", replacement.ctx);
+	allTools.push(extensionTool(LATE_TOOL));
+	mock.rawPi.setActiveTools([...mock.rawPi.getActiveTools(), LATE_TOOL]);
+	await mock.events.get("context")?.[0]?.({ messages: [] }, replacement.ctx);
+
+	const result = (await mock.events.get("tool_call")?.[0]?.(
+		{ toolName: LATE_TOOL, input: {} },
+		replacement.ctx,
+	)) as { block?: boolean } | undefined;
+	assert.equal(result?.block, true);
+});
+
+test("tree restoration replaces pending intent with the restored selection", async () => {
+	let branch: unknown[] = [];
+	const allTools = [builtinTool("read")];
+	const mock = createMockPi({ activeTools: ["read"], allTools });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: { thinkingLevel: "inherit" as const, defaultPlanTools: [LATE_TOOL] },
+		}),
+	});
+	const context = createMockContext({
+		sessionManager: {
+			getBranch: () => branch,
+			getEntries: () => branch,
+			getEntry: () => undefined,
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	branch = [
+		{
+			type: "custom",
+			customType: "plan-mode-state",
+			data: { enabled: true, awaitingAction: false, selectedToolNames: ["read"] },
+		},
+	];
+	await mock.events.get("session_tree")?.[0]?.({}, context.ctx);
+	allTools.push(extensionTool(LATE_TOOL));
+	mock.rawPi.setActiveTools([...mock.rawPi.getActiveTools(), LATE_TOOL]);
+	await mock.events.get("context")?.[0]?.({ messages: [] }, context.ctx);
+
+	const lateResult = (await mock.events.get("tool_call")?.[0]?.(
+		{ toolName: LATE_TOOL, input: {} },
+		context.ctx,
+	)) as { block?: boolean } | undefined;
+	assert.equal(lateResult?.block, true);
+	assert.equal(
+		await mock.events.get("tool_call")?.[0]?.({ toolName: "read", input: {} }, context.ctx),
+		undefined,
+	);
+});

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import planMode from "../src/plan-mode.js";
@@ -184,6 +185,38 @@ test("the inactive launch menu opens Settings without starting Plan mode", async
 	await settleWithin(running, "launch Settings close");
 });
 
+test("Plan Settings uses live active tools registered after session start", async () => {
+	const allTools = [builtinTool("read")];
+	const mock = createMockPi({ activeTools: ["read"], allTools });
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	allTools.push(extensionTool("late_tool"));
+	mock.rawPi.setActiveTools([...mock.rawPi.getActiveTools(), "late_tool"]);
+
+	const running = mock.commands.get("plan")?.handler("", context.ctx) as Promise<unknown>;
+	await waitForOpenCount(tui, 1, running);
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await settleWithin(tui.waitForPending(), "the live Settings transition");
+	await waitForOpenCount(tui, 2, running);
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await settleWithin(tui.waitForPending(), "the live tool Settings transition");
+	await waitForOpenCount(tui, 3, running);
+	tui.press("tui.select.down");
+	const frame = tui.render().join("\n");
+	assert.match(frame, /late_tool/u);
+	assert.match(frame, /user opt-in/u);
+	assert.doesNotMatch(frame, /late_tool.*not active/is);
+
+	tui.press("ctrl+c");
+	await running;
+	tui.dispose();
+});
+
 test("persisted Settings become the baseline for the next Plan workflow", async () => {
 	const agentDir = await mkdtemp(join(tmpdir(), "pi-plan-mode-launch-settings-"));
 	const settingsPath = join(agentDir, "pi-plan-mode.json");
@@ -341,6 +374,85 @@ test("RPC stages tool changes until the explicit start action", async () => {
 	rpc.assertConsumed();
 	assert.deepEqual(mock.rawPi.getActiveTools(), STABLE_TOOLS);
 	assert.equal(mock.sentUserMessages.length, 0);
+});
+
+test("reopened launch picker uses live active tools registered after session start", async () => {
+	const allTools = [builtinTool("read")];
+	const mock = createMockPi({ activeTools: ["read"], allTools });
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const rpc = createRpcHarness([{ kind: "select", response: "Back" }]);
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: rpc.ui.select,
+		input: rpc.ui.input,
+		custom: rpc.ui.custom,
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	allTools.push(extensionTool("late_tool"));
+	mock.rawPi.setActiveTools([...mock.rawPi.getActiveTools(), "late_tool"]);
+	const activeBefore = mock.rawPi.getActiveTools();
+
+	await mock.commands.get("plan")?.handler("tools", context.ctx);
+
+	rpc.assertConsumed();
+	const options = rpc.dialogs[0]?.options ?? [];
+	assert.ok(options.includes("[ ] late_tool"));
+	assert.ok(
+		options.every((option) => !/late_tool.*Not active in Pi|late_tool.*unavailable/iu.test(option)),
+	);
+	assert.deepEqual(mock.rawPi.getActiveTools(), activeBefore);
+	assert.equal(mock.entries.length, 0);
+});
+
+test("launch picker retains and sanitizes configured names pending registration", async () => {
+	const pendingName = "late\u001b[31m_tool";
+	const oversizedName = "x".repeat(500);
+	const mock = createMockPi({ activeTools: ["read"], allTools: [builtinTool("read")] });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: {
+				thinkingLevel: "inherit" as const,
+				defaultPlanTools: [pendingName, oversizedName, "third", "fourth"],
+			},
+		}),
+	});
+	const rpc = createRpcHarness([{ kind: "select", response: "Back" }]);
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		select: rpc.ui.select,
+		input: rpc.ui.input,
+		custom: rpc.ui.custom,
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+
+	await mock.commands.get("plan")?.handler("tools", context.ctx);
+
+	rpc.assertConsumed();
+	const dialog = rpc.dialogs[0];
+	assert.ok(dialog);
+	assert.match(dialog.title, /Pending registration: late \[31m_tool, x+…, third, \+1 more/u);
+	assert.ok(
+		(dialog.options ?? []).some(
+			(option) =>
+				/late \[31m_tool.*Not registered yet/iu.test(option) && !option.includes("\u001b"),
+		),
+	);
+	assert.equal(JSON.stringify(dialog).includes("\u001b"), false);
+	assert.equal(JSON.stringify(dialog).includes("x".repeat(200)), false);
+	assert.equal(mock.entries.length, 0);
+
+	const tui = createTuiHarness({ width: 34, rows: 18 });
+	const tuiContext = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = mock.commands.get("plan")?.handler("tools", tuiContext.ctx) as Promise<unknown>;
+	await waitForOpenCount(tui, 1, running);
+	assert.ok(tui.render().every((line) => visibleWidth(line) <= 34));
+	tui.press("ctrl+c");
+	await running;
+	tui.dispose();
+	assert.equal(mock.entries.length, 0);
 });
 
 test("Ctrl+C and external disposal discard the inactive launch interaction", async () => {

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -414,7 +414,7 @@ test("launch picker retains and sanitizes configured names pending registration"
 			kind: "loaded" as const,
 			settings: {
 				thinkingLevel: "inherit" as const,
-				defaultPlanTools: [pendingName, oversizedName, "third", "fourth"],
+				defaultPlanTools: [pendingName, oversizedName, "start-with-tools", "fourth"],
 			},
 		}),
 	});
@@ -433,7 +433,10 @@ test("launch picker retains and sanitizes configured names pending registration"
 	rpc.assertConsumed();
 	const dialog = rpc.dialogs[0];
 	assert.ok(dialog);
-	assert.match(dialog.title, /Pending registration: late \[31m_tool, x+…, third, \+1 more/u);
+	assert.match(
+		dialog.title,
+		/Pending registration: late \[31m_tool, x+…, start-with-tools, \+1 more/u,
+	);
 	assert.ok(
 		(dialog.options ?? []).some(
 			(option) =>
@@ -442,6 +445,7 @@ test("launch picker retains and sanitizes configured names pending registration"
 	);
 	assert.equal(JSON.stringify(dialog).includes("\u001b"), false);
 	assert.equal(JSON.stringify(dialog).includes("x".repeat(200)), false);
+	assert.match(JSON.stringify(dialog), /start-with-tools/u);
 	assert.equal(mock.entries.length, 0);
 
 	const tui = createTuiHarness({ width: 34, rows: 18 });

--- a/packages/pi-plan-mode/test/settings-menu.test.ts
+++ b/packages/pi-plan-mode/test/settings-menu.test.ts
@@ -155,7 +155,7 @@ test("Default tools retain configured names that are unavailable in the current 
 		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
 		const frame = tui.render().join("\n");
 		assert.match(frame, /missing-tool.*unavailable/is);
-		assert.match(frame, /Retained in settings/i);
+		assert.match(frame, /Retained and resolved before the first request/i);
 		tui.press("ctrl+c");
 		await running;
 		assert.deepEqual(

--- a/packages/pi-plan-mode/test/settings-menu.test.ts
+++ b/packages/pi-plan-mode/test/settings-menu.test.ts
@@ -143,9 +143,9 @@ test("Default tools distinguish automatic, explicit empty, user risk, blocked ro
 	});
 });
 
-test("Default tools retain configured names that are unavailable in the current session", async () => {
+test("Default tools retain configured names without colliding with settings actions", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
-		await writeFile(settingsPath, '{"defaultPlanTools":["missing-tool"]}\n');
+		await writeFile(settingsPath, '{"defaultPlanTools":["reset-tools"]}\n');
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
 		tui.press("tui.select.down");
@@ -154,14 +154,14 @@ test("Default tools retain configured names that are unavailable in the current 
 		await tui.waitForOpen();
 		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
 		const frame = tui.render().join("\n");
-		assert.match(frame, /missing-tool.*unavailable/is);
+		assert.match(frame, /reset-tools.*pending registration/is);
 		assert.match(frame, /Retained and resolved before the first request/i);
 		tui.press("ctrl+c");
 		await running;
 		assert.deepEqual(
 			(JSON.parse(await readFile(settingsPath, "utf8")) as { defaultPlanTools: string[] })
 				.defaultPlanTools,
-			["missing-tool"],
+			["reset-tools"],
 		);
 	});
 });


### PR DESCRIPTION
## Summary

- retain explicitly configured or selected tool names until the first Plan provider-bound context
- resolve and freeze the executable policy after `before_agent_start` extensions can register tools
- refresh inactive picker and Settings snapshots without mutating Pi's active tool schemas
- document pending registration behavior and add a patch Changeset

Fixes #1018.

## Verification

- `npm run check`
- affected `npm test` gate with file-level serialization: 36 files, 316 tests passed
- Plan mode serial suite: 25 files, 253 tests passed
- focused issue, launch, default-tools, and cache tests: 4 files, 41 tests passed
- generated entry and build-runtime tests: 2 files, 6 tests passed
- Pi 0.84.3 RPC smoke: unconfigured tool omitted, configured tool pending, same-session registration enabled
- `npm run changeset:status`

## Risks and limits

- An already open picker does not update in place because Pi exposes no tool-registration event; reopening refreshes it.
- Tools registered after the first provider-bound context remain denied until the next Plan workflow.
- Default-parallel full-suite attempts hit unrelated existing 5-second timing limits locally; the official affected set passed with serial file scheduling, and the unrelated benchmark failure passed in isolation.
