### PR TITLE
fix(worktree): cap submodule fixture setup timeout

### DIFF
--- a/packages/pi-worktree/test/git.integration.test.ts
+++ b/packages/pi-worktree/test/git.integration.test.ts
@@ -162,7 +162,7 @@ describe("initialized submodule inventory", () => {
 			"-am",
 			"add submodule",
 		]);
-	});
+	}, 5_000);
 
 	afterAll(() => {
 		if (temporary) rmSync(temporary, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- cap the submodule fixture setup hook at the repository's five-second hard limit
- address the post-merge review feedback from #1022

## Verification

- `npx vitest run packages/pi-worktree/test/git.integration.test.ts --testNamePattern='worktree inventory reports clean initialized submodules'`
- `npx vitest run packages/pi-worktree/test/git.integration.test.ts` passed 10/10 on retry
- `npm run check`
- `npm test` attempted, but this resource-constrained host timed out across unrelated process-heavy suites and the command reached the 300-second execution deadline
