### PR TITLE
docs(subagents-v3): record design principles and IPC idea

### DIFF
--- a/packages/pi-subagents-v3/docs/design-principles.md
+++ b/packages/pi-subagents-v3/docs/design-principles.md
@@ -1,0 +1,25 @@
+# Design principles
+
+These principles define the intended direction of Pi Subagents v3 rather than requirements for every Pi subagent implementation.
+
+## Context isolation is the purpose
+
+Every subagent starts as a fresh Pi process without inheriting the main agent's conversation history.
+
+A fresh context is not an empty environment: the child still receives Pi's system prompt, its agent definition, applicable project context, its allowed tools, and one explicit task.
+
+Give each subagent a self-contained task containing only the context needed to complete that task.
+
+Context isolation is the primary reason to use a subagent.
+
+If work depends on substantial history from the current conversation, continue in the current thread instead of copying that history into a new subagent.
+
+## Simplicity over feature breadth
+
+Keep the architecture explicit, bounded, and easy to understand.
+
+Do not introduce complex abstractions or orchestration merely to support more features.
+
+Prefer a small, maintainable implementation over feature completeness.
+
+Add a capability only when its value clearly justifies its implementation and ongoing maintenance cost.

--- a/packages/pi-subagents-v3/docs/design-principles.md
+++ b/packages/pi-subagents-v3/docs/design-principles.md
@@ -4,13 +4,17 @@ These principles define the intended direction of Pi Subagents v3 rather than re
 
 ## Context isolation is the purpose
 
-Every subagent starts as a fresh Pi process without inheriting the main agent's conversation history.
+A subagent starts as a fresh Pi process.
 
-A fresh context is not an empty environment: the child still receives Pi's system prompt, its agent definition, applicable project context, its allowed tools, and one explicit task.
+It does not inherit the main agent's conversation history.
+
+That isolation is not a limitation—it is the point.
+
+Fresh does not mean empty.
+
+The subagent still receives Pi's system prompt, its agent definition, applicable project context, its allowed tools, and one explicit task.
 
 Give each subagent a self-contained task containing only the context needed to complete that task.
-
-Context isolation is the primary reason to use a subagent.
 
 If work depends on substantial history from the current conversation, continue in the current thread instead of copying that history into a new subagent.
 
@@ -18,8 +22,8 @@ If work depends on substantial history from the current conversation, continue i
 
 Keep the architecture explicit, bounded, and easy to understand.
 
-Do not introduce complex abstractions or orchestration merely to support more features.
+Feature breadth alone does not justify more machinery.
 
-Prefer a small, maintainable implementation over feature completeness.
+Prefer a small system whose behavior can be understood end to end over a feature-complete system whose behavior is obscured by layers of abstraction and orchestration.
 
-Add a capability only when its value clearly justifies its implementation and ongoing maintenance cost.
+Every capability must earn its place: its value must outweigh both the complexity it introduces and the maintenance burden it leaves behind.

--- a/packages/pi-subagents-v3/docs/ipc-transport-idea.md
+++ b/packages/pi-subagents-v3/docs/ipc-transport-idea.md
@@ -1,0 +1,101 @@
+# Per-child IPC transport idea
+
+## Status
+
+This document records an unverified implementation idea for later evaluation.
+
+The current loopback TCP broker remains the implemented and authoritative transport.
+
+Do not treat this document as an approved migration plan or compatibility guarantee.
+
+## Motivation
+
+The TCP broker provides authenticated cross-process messaging but requires a server, ephemeral port, per-job tokens, socket lifecycle management, NDJSON framing, connection deadlines, and long-poll handling.
+
+A private communication channel created with each child process may preserve the messaging contract with fewer transport concepts and less lifecycle code.
+
+## Proposed direction
+
+Spawn each child with a private Node.js child-process IPC channel:
+
+```ts
+spawn(command, args, {
+	stdio: ["ignore", "pipe", "pipe", "ipc"],
+});
+```
+
+Bind the channel to the job represented by that child process rather than accepting a job identifier or authentication token from the child.
+
+Send question events from the child to the parent and reply events from the parent to the child over the same persistent channel.
+
+Keep request state in a small session-owned registry in the parent and keep child wait promises in the child bridge.
+
+A possible exchange is:
+
+```text
+child -> parent: ask(message)
+parent -> child: accepted(requestId)
+child -> parent: wait(requestId)
+main agent -> parent: reply(requestId, message)
+parent -> child: response(requestId, message)
+```
+
+The exact wire messages and ownership boundaries remain undecided.
+
+## Complexity that may be removed
+
+A successful IPC design may remove:
+
+- The loopback TCP server and ephemeral port.
+- Per-job broker tokens and broker environment variables.
+- Socket connection and connection-limit management.
+- Custom NDJSON request and response framing.
+- Connection and frame deadlines.
+- Long-poll socket ownership.
+- Cross-job token validation.
+
+## Behavior that must remain
+
+Any replacement must preserve:
+
+- A fresh child Pi process with no inherited main-agent conversation history.
+- Fixed `subagent-ask` and child `subagent-wait` tools.
+- Main-agent `subagent-reply` behavior.
+- Plain-text replies.
+- At most four outstanding requests per job.
+- The 50 KiB UTF-8 message limit and 2,000-line reply limit.
+- First-reply-wins semantics.
+- Retryable waits after timeout.
+- Caller cancellation that stops only the current wait.
+- Immediate rejection of pending waits after job cancellation, child exit, session replacement, reload, or shutdown.
+- Bounded retained state and terminal-safe cleanup.
+- Untrusted-content handling and terminal sanitization.
+- No peer messaging, retained child conversations, or nested subagents.
+
+## Compatibility spike
+
+Before selecting IPC, build the smallest possible spike that proves bidirectional messages, cancellation, child exit, and repeated cleanup through the actual Pi launch path.
+
+Exercise the spike with npm-installed Node.js Pi, Bun execution, and the Pi standalone executable where available.
+
+Include Linux and macOS, and include Windows before claiming Windows compatibility.
+
+Verify that the IPC channel does not interfere with Pi JSON output, subprocess termination, detached process-group cleanup, or extension loading.
+
+Reject the IPC design if any supported runtime cannot expose a reliable private channel without runtime-specific branches or substantial fallback code.
+
+## Fallback
+
+If child-process IPC is not portable enough, evaluate dedicated inherited file descriptors such as fd 3 and fd 4.
+
+Inherited pipes can still remove TCP addressing and authentication, but they require a bounded framing protocol and explicit stream lifecycle handling.
+
+HTTP loopback may simplify framing incrementally, but it retains the server, port, token, and network lifecycle and therefore offers a smaller reduction.
+
+Do not use filesystem polling or share Pi's normal stdin and stdout unless evidence shows that their additional coupling and cleanup remain simpler than the current transport.
+
+## Decision criteria
+
+Adopt a replacement only if it measurably reduces implementation and lifecycle complexity while preserving current behavior and supported runtime compatibility.
+
+Prefer the current TCP broker if the replacement requires runtime-specific branches, multiple transport fallbacks, or weaker isolation.


### PR DESCRIPTION
## Summary

- document fresh conversation context as the primary purpose of Pi Subagents v3
- prefer explicit, bounded, maintainable architecture over feature breadth
- record a per-child IPC transport idea, preserved behavior, compatibility spike, and rejection criteria

## Verification

- `git diff --check origin/main...HEAD`
- `npm run check`
- `npm test` (390 files, 3,468 tests)

No Changeset is included because this pull request changes documentation only.
