### PR TITLE
feat(tui-kit): add editor status widget frame

### DIFF
--- a/.changeset/calm-widgets-frame.md
+++ b/.changeset/calm-widgets-frame.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add a width-safe `EditorStatusWidget` presentation frame for passive status and progress rows near Pi's editor.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -12,7 +12,7 @@ Pi TUI Kit provides declarative screens, standalone task and confirmation flows,
 - Defines typed action, detail, settings, choice, review, multi-select, and document screens.
 - Adapts shared flows across Pi TUI and RPC modes.
 - Owns standard navigation, cancellation, disposal, lifecycle, consistent horizontal framing, and width-safe rendering.
-- Provides focused task, confirmation, live-choice, custom-interaction, terminal-text, hint, horizontal-rule, and testing helpers.
+- Provides focused task, confirmation, live-choice, custom-interaction, terminal-text, hint, editor-status-widget, horizontal-rule, and testing helpers.
 - Publishes built ESM and TypeScript declarations for independently installable extensions.
 
 ## 📦 Install
@@ -26,7 +26,7 @@ npm install @narumitw/pi-tui-kit
 The published package contains built ESM and declarations in `dist/`; consumers do not need a TypeScript loader for dependencies.
 
 The package root remains the supported entrypoint for menus and interaction runners.
-Import lightweight display helpers from `@narumitw/pi-tui-kit/terminal-text` or `@narumitw/pi-tui-kit/interaction-hints` when a startup path does not otherwise need the full Kit runtime.
+Import lightweight display helpers from `@narumitw/pi-tui-kit/editor-status-widget`, `@narumitw/pi-tui-kit/terminal-text`, or `@narumitw/pi-tui-kit/interaction-hints` when a startup path does not otherwise need the full Kit runtime.
 
 ### Compatibility floor
 
@@ -48,7 +48,7 @@ Review syntax coloring synchronously loads the Kit's complete declared highlight
 Root imports, ordinary menus, task frames, and Markdown-only reviews do not evaluate that highlighter.
 Mermaid rendering lazy-loads its declared renderer only before the first screen containing an enabled Mermaid fence.
 
-The `terminal-text` and `interaction-hints` subpaths expose only their focused ESM and declaration graphs, while the package root keeps every existing export for compatibility.
+The `editor-status-widget`, `terminal-text`, and `interaction-hints` subpaths expose only their focused ESM and declaration graphs, while the package root keeps every existing export for compatibility.
 
 Repository maintainers can measure cold root and lightweight-subpath imports plus first actions, code-review, Mermaid, and task frames in fresh serial processes:
 
@@ -111,6 +111,35 @@ export function createPreviewDivider(theme: Pick<Theme, "fg">) {
 Long and wide-character labels truncate by terminal cells on narrow renders.
 Terminal and bidirectional controls are removed from labels at the display boundary.
 When the available width cannot preserve the requested padding, the component reduces the inset to keep one rule cell visible.
+
+## 📊 Editor status widgets
+
+Use `EditorStatusWidget` as a width-safe presentation frame for passive status or progress rows near Pi's editor.
+The component renders the standard `borderMuted` top rule and truncates every extension-owned body row to the available terminal width.
+The consumer continues owning widget keys, placement, snapshots, body formatting, terminal-text sanitization, RPC publication, refresh scheduling, and session lifecycle.
+The body renderer receives a normalized non-negative integer width and runs on every render, so it can wrap or style content before the final width guard.
+
+```ts
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { EditorStatusWidget } from "@narumitw/pi-tui-kit/editor-status-widget";
+
+export function publishProgress(ctx: ExtensionContext, lines: readonly string[]) {
+  const snapshot = [...lines];
+  ctx.ui.setWidget(
+    "example:progress",
+    (_tui, theme) =>
+      new EditorStatusWidget({
+        theme,
+        renderBody: (width) => snapshot.map((line) => theme.fg("muted", line)),
+      }),
+    { placement: "aboveEditor" },
+  );
+}
+```
+
+`EditorStatusWidget` treats body rows as terminal-formatted display text and does not sanitize or wrap them.
+Sanitize untrusted values before styling or width-sensitive formatting, and perform product-specific wrapping in `renderBody()`.
+Publish plain string arrays separately when an extension supports Pi RPC widgets because RPC ignores component factories.
 
 ## 🧭 Complete menu example
 
@@ -778,6 +807,7 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `runQuestionnaire()` — adapts required choices, free-form answers, optional TUI notes, direct single-question submission, multi-question read-only review, and sequential RPC while preserving typed Submitted, Back, Close, Stale, Unsupported, and Error outcomes.
 - `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and literal shortcut keys for specialized interaction hints; the lightweight `@narumitw/pi-tui-kit/interaction-hints` subpath exports it and its public types.
 - `sanitizeTerminalText()` — removes terminal and bidirectional display controls from untrusted single-line presentation text without mutating raw payloads; the lightweight `@narumitw/pi-tui-kit/terminal-text` subpath exports it.
+- `EditorStatusWidget` — frames extension-owned passive editor status rows with the standard muted top rule and a final terminal-width guard; the lightweight `@narumitw/pi-tui-kit/editor-status-widget` subpath exports it and its public options.
 - `HorizontalRule` — renders a full-width or inset horizontal divider with an optional sanitized and aligned label plus render-time style callbacks.
 - `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending work draining, and typed results around one extension-owned custom TUI component.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
@@ -797,6 +827,7 @@ Version 12 added optional searchable `choice` fields, version 11 added Live Choi
 - `src/task.ts` — standalone and menu-shared task lifecycle orchestration
 - `src/confirmation.ts` — standalone confirmation mode adaptation and lifecycle results
 - `src/live-choice.ts` — standalone live-choice TUI/RPC adaptation and preview-work ownership
+- `src/editor-status-widget.ts` — passive editor-widget presentation framing without publication or lifecycle ownership
 - `src/questionnaire.ts` — standalone questionnaire TUI/RPC adaptation and public result contract
 - `src/interaction-hints.ts` — injected-key and literal-shortcut hint formatting, published through the lightweight `/interaction-hints` subpath
 - `src/terminal-text.ts` — terminal display sanitization published through the lightweight `/terminal-text` subpath

--- a/packages/pi-tui-kit/package.json
+++ b/packages/pi-tui-kit/package.json
@@ -25,6 +25,10 @@
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js"
 		},
+		"./editor-status-widget": {
+			"types": "./dist/editor-status-widget.d.ts",
+			"import": "./dist/editor-status-widget.js"
+		},
 		"./interaction-hints": {
 			"types": "./dist/interaction-hints.d.ts",
 			"import": "./dist/interaction-hints.js"

--- a/packages/pi-tui-kit/src/editor-status-widget.ts
+++ b/packages/pi-tui-kit/src/editor-status-widget.ts
@@ -1,0 +1,40 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { type Component, truncateToWidth } from "@earendil-works/pi-tui";
+import { HorizontalRule } from "./horizontal-rule.js";
+
+export interface EditorStatusWidgetOptions {
+	/** Active callback theme used for the standard muted editor divider. */
+	theme: Pick<Theme, "fg">;
+	/** Render extension-owned body rows for the normalized terminal width. */
+	renderBody(width: number): readonly string[];
+}
+
+/** Width-safe presentation frame for passive status widgets near Pi's editor. */
+export class EditorStatusWidget implements Component {
+	private readonly options: EditorStatusWidgetOptions;
+	private readonly rule: HorizontalRule;
+
+	constructor(options: EditorStatusWidgetOptions) {
+		this.options = options;
+		this.rule = new HorizontalRule({
+			ruleStyle: (text) => this.options.theme.fg("borderMuted", text),
+		});
+	}
+
+	invalidate() {
+		this.rule.invalidate();
+	}
+
+	render(width: number): string[] {
+		const renderWidth = normalizeWidth(width);
+		const body = this.options.renderBody(renderWidth);
+		return [
+			...this.rule.render(renderWidth),
+			...body.map((line) => truncateToWidth(line, renderWidth, "")),
+		];
+	}
+}
+
+function normalizeWidth(value: number): number {
+	return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -11,6 +11,10 @@ export {
 	runCustomInteraction,
 } from "./custom-interaction.js";
 export {
+	EditorStatusWidget,
+	type EditorStatusWidgetOptions,
+} from "./editor-status-widget.js";
+export {
 	HorizontalRule,
 	type HorizontalRuleLabelAlignment,
 	type HorizontalRuleOptions,

--- a/packages/pi-tui-kit/test/editor-status-widget.test.ts
+++ b/packages/pi-tui-kit/test/editor-status-widget.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { EditorStatusWidget } from "../src/editor-status-widget.js";
+
+test("frames extension-owned body rows with the standard muted editor divider", () => {
+	const roles: string[] = [];
+	const widths: number[] = [];
+	const theme = {
+		fg(role: string, text: string) {
+			roles.push(role);
+			return text;
+		},
+	} as Pick<Theme, "fg">;
+	const widget = new EditorStatusWidget({
+		theme,
+		renderBody(width) {
+			widths.push(width);
+			return ["Todo · 1/2 complete", "▶ Implement the shared primitive"];
+		},
+	});
+
+	assert.deepEqual(widget.render(24).map(stripVTControlCharacters), [
+		"─".repeat(24),
+		"Todo · 1/2 complete",
+		"▶ Implement the shared p",
+	]);
+	assert.deepEqual(widths, [24]);
+	assert.deepEqual(roles, ["borderMuted"]);
+});
+
+test("normalizes hostile widths and bounds every terminal-formatted body row", () => {
+	const seenWidths: number[] = [];
+	const theme = { fg: (_role: string, text: string) => text } as Pick<Theme, "fg">;
+	const widget = new EditorStatusWidget({
+		theme,
+		renderBody(width) {
+			seenWidths.push(width);
+			return ["界界界", "\u001b[31mcolored content\u001b[0m"];
+		},
+	});
+
+	for (const width of [Number.NaN, -1, 0, 5.9]) {
+		const normalized = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
+		const lines = widget.render(width);
+		assert.ok(lines.every((line) => visibleWidth(line) <= normalized));
+		if (normalized === 5) {
+			assert.deepEqual(lines.map(stripVTControlCharacters), ["─".repeat(5), "界界", "color"]);
+		}
+	}
+	assert.deepEqual(seenWidths, [0, 0, 0, 5]);
+});
+
+test("renders fresh theme and body output after invalidation without owning consumer state", () => {
+	let color = 31;
+	let value = "first";
+	const theme = {
+		fg: (_role: string, text: string) => `\u001b[${color}m${text}\u001b[0m`,
+	} as Pick<Theme, "fg">;
+	const widget = new EditorStatusWidget({ theme, renderBody: () => [value] });
+
+	assert.equal(widget.render(20)[0]?.includes("\u001b[31m"), true);
+	assert.equal(widget.render(20)[1], "first");
+
+	color = 32;
+	value = "second";
+	widget.invalidate();
+	assert.equal(widget.render(20)[0]?.includes("\u001b[32m"), true);
+	assert.equal(widget.render(20)[1], "second");
+});

--- a/packages/pi-tui-kit/test/package-exports.test.ts
+++ b/packages/pi-tui-kit/test/package-exports.test.ts
@@ -8,16 +8,19 @@ const packageRoot = path.resolve("packages/pi-tui-kit");
 
 test("built package entrypoints resolve their documented exports", async (t) => {
 	const productionSpecifier = "@narumitw/pi-tui-kit";
+	const editorStatusWidgetSpecifier = "@narumitw/pi-tui-kit/editor-status-widget";
 	const interactionHintsSpecifier = "@narumitw/pi-tui-kit/interaction-hints";
 	const terminalTextSpecifier = "@narumitw/pi-tui-kit/terminal-text";
 	const testingSpecifier = "@narumitw/pi-tui-kit/testing";
 	const production = await import(productionSpecifier);
+	const editorStatusWidget = await import(editorStatusWidgetSpecifier);
 	const interactionHints = await import(interactionHintsSpecifier);
 	const terminalText = await import(terminalTextSpecifier);
 	const testing = await import(testingSpecifier);
 	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 14);
 	assert.equal(typeof production.sanitizeTerminalText, "function");
 	assert.equal(typeof production.formatInteractionHints, "function");
+	assert.equal(typeof production.EditorStatusWidget, "function");
 	assert.equal(typeof production.HorizontalRule, "function");
 	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");
@@ -25,6 +28,7 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 	assert.equal(typeof production.runQuestionnaire, "function");
 	assert.equal("createTuiHarness" in production, false);
 	assert.equal("createRpcHarness" in production, false);
+	assert.deepEqual(Object.keys(editorStatusWidget), ["EditorStatusWidget"]);
 	assert.deepEqual(Object.keys(interactionHints), ["formatInteractionHints"]);
 	assert.deepEqual(Object.keys(terminalText), ["sanitizeTerminalText"]);
 	assert.deepEqual(Object.keys(testing).sort(), ["createRpcHarness", "createTuiHarness"]);
@@ -35,7 +39,9 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 	t.onTestFinished(() => rmSync(fixture, { recursive: true, force: true }));
 	writeFileSync(
 		path.join(fixture, "usage.ts"),
-		`import { HorizontalRule, type HorizontalRuleOptions, PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type ChoiceScreen, type LiveChoiceItem, type MenuBrowseItem, type QuestionnaireAnswer, type QuestionnaireQuestion, type ReviewFormat, type RunQuestionnaireResult } from "@narumitw/pi-tui-kit";\n` +
+		`import type { Theme } from "@earendil-works/pi-coding-agent";\n` +
+			`import { EditorStatusWidget as RootEditorStatusWidget, HorizontalRule, type HorizontalRuleOptions, PI_EXTENSION_MENU_API_VERSION, type BrowseDetailDocument, type ChoiceScreen, type EditorStatusWidgetOptions, type LiveChoiceItem, type MenuBrowseItem, type QuestionnaireAnswer, type QuestionnaireQuestion, type ReviewFormat, type RunQuestionnaireResult } from "@narumitw/pi-tui-kit";\n` +
+			`import { EditorStatusWidget } from "@narumitw/pi-tui-kit/editor-status-widget";\n` +
 			`import { formatInteractionHints, type FormatInteractionHintsOptions, type InteractionHint, type InteractionKeybindings } from "@narumitw/pi-tui-kit/interaction-hints";\n` +
 			`import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
@@ -46,6 +52,10 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 			`const formattedHints = formatInteractionHints(keybindings, hints, hintOptions);\n` +
 			`const ruleOptions: HorizontalRuleOptions = { label: "Status", labelAlignment: "left", paddingX: 1 };\n` +
 			`const rule = new HorizontalRule(ruleOptions);\n` +
+			`const theme = { fg: (_role: string, text: string) => text } as Pick<Theme, "fg">;\n` +
+			`const widgetOptions: EditorStatusWidgetOptions = { theme, renderBody: () => ["Ready"] };\n` +
+			`const widget = new EditorStatusWidget(widgetOptions);\n` +
+			`const rootWidget = new RootEditorStatusWidget(widgetOptions);\n` +
 			`const markdown: ReviewFormat = { kind: "markdown", renderLatex: false, renderMermaid: true };\n` +
 			`const document: BrowseDetailDocument = { content: "# Formula\\n\\n$x^2$", format: markdown };\n` +
 			`const item: MenuBrowseItem = { id: "one", label: "One", detailDocument: document };\n` +
@@ -54,7 +64,7 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 			`const question: QuestionnaireQuestion<"scope"> = { id: "scope", header: "Scope", prompt: "How broad?", options: [{ label: "Small" }] };\n` +
 			`const answer: QuestionnaireAnswer<"scope"> = { questionId: "scope", answer: "Small", wasCustom: false, optionIndex: 1 };\n` +
 			`const questionnaireResult: RunQuestionnaireResult<"scope"> = { kind: "submitted", answers: [answer] };\n` +
-			`void version;\nvoid formattedHints;\nvoid rule.render(80);\nvoid item;\nvoid choice;\nvoid screen;\nvoid question;\nvoid questionnaireResult;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
+			`void version;\nvoid formattedHints;\nvoid rule.render(80);\nvoid widget.render(80);\nvoid rootWidget.render(80);\nvoid item;\nvoid choice;\nvoid screen;\nvoid question;\nvoid questionnaireResult;\nvoid createTuiHarness();\nvoid createRpcHarness([]);\n`,
 	);
 	writeFileSync(
 		path.join(fixture, "tsconfig.json"),


### PR DESCRIPTION
## Summary

- add a width-safe `EditorStatusWidget` presentation primitive to Pi TUI Kit
- publish root and lightweight `@narumitw/pi-tui-kit/editor-status-widget` exports with declarations
- document the ownership boundary and add a minor Changeset
- leave `pi-tool`, `pi-plan-mode`, `pi-subagents-v3`, and `pi-todo` unchanged until the Kit API is published

## Verification

- `npm run check --workspace @narumitw/pi-tui-kit`
- `npm run check`
- `npm test` — 391 files, 3,475 tests passed
- focused Vitest run — 3 files, 9 tests passed
- README heading audit
- `npm pack --workspace @narumitw/pi-tui-kit --dry-run --json`
- `git diff --check`

## Audit

- reviewed against `docs/extension-conventions.md`, `docs/readme-conventions.md`, and `packages/pi-tui-kit/AGENTS.md`
- callback theme, terminal width safety, package exports, and release ordering are covered
- widget publication, sanitization, wrapping, RPC adaptation, refresh scheduling, and session lifecycle remain consumer-owned
