### PR TITLE
fix(usage): use canonical OpenCode endpoint

### DIFF
--- a/.changeset/fix-opencode-go-canonical-usage-endpoint.md
+++ b/.changeset/fix-opencode-go-canonical-usage-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Use the canonical OpenCode Go usage endpoint regardless of the selected model's base URL.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -148,11 +148,11 @@ OpenRouter documents the distinction between credit and rate limits in its [API 
 
 - Provider ID: `opencode-go`
 - Semantics: OpenCode Zen plan usage windows—rolling, weekly, and monthly
-- Source: `GET {model base URL}/usage` on the configured `opencode.ai` gateway using Pi's resolved inference API key
+- Source: `GET https://opencode.ai/zen/go/v1/usage` using Pi's resolved inference API key
 - Displayed data: used percentage and reset time for each window; `rate-limited` windows remain visible at their reported usage, while unknown statuses are reported as unavailable notes
 - Statusline examples: `zen 0% r 4% w 2% m`
 
-The usage endpoint is derived from the model's base URL (`…/zen/go/v1/usage`) and is only queried when the resolved origin is `https://opencode.ai`; other origins fail before sending the credential.
+The fixed OpenCode Go usage endpoint is only queried when the resolved model origin is `https://opencode.ai`; other origins fail before sending the credential.
 
 ## 🧭 Current and configured accounts
 

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -23,6 +23,7 @@ import type {
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const GITHUB_COPILOT_USAGE_URL = "https://api.github.com/copilot_internal/user";
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
+const OPENCODE_GO_USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
 const MAX_SUCCESS_BODY_BYTES = 64 * 1024;
 const MAX_ERROR_BODY_BYTES = 4 * 1024;
 
@@ -86,7 +87,7 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 		semantics: { kind: "consumer-subscription", label: "OpenCode Zen plan usage" },
 		async query(auth, signal, timeoutMs) {
 			const payload = await fetchProviderJson(
-				opencodeUsageUrl(auth.model.baseUrl),
+				OPENCODE_GO_USAGE_URL,
 				auth,
 				signal,
 				timeoutMs,
@@ -127,6 +128,7 @@ export async function resolveUsageAuth(
 		hasOfficialOrigin(candidate, adapter.id),
 	);
 	if (!model) return undefined;
+	// SAFETY: Pi exposes the required auth methods at runtime, and checks below narrow them before use.
 	const registry = ctx.modelRegistry as unknown as UsageAuthRegistry;
 	let modelAuth: RequestAuth | undefined;
 	if (ctx.model?.provider === adapter.id && typeof registry.getApiKeyAndHeaders === "function") {
@@ -491,12 +493,6 @@ function headerValue(
 
 function hasHeader(headers: Record<string, string>, name: string): boolean {
 	return Object.keys(headers).some((key) => key.toLowerCase() === name.toLowerCase());
-}
-
-function opencodeUsageUrl(baseUrl: string | undefined): string {
-	const base = baseUrl?.trim().replace(/\/+$/u, "");
-	if (!base) throw new Error("OpenCode Go model base URL is unavailable.");
-	return `${base}/usage`;
 }
 
 function isAbortError(error: unknown): boolean {

--- a/packages/pi-usage/test/core.test.ts
+++ b/packages/pi-usage/test/core.test.ts
@@ -392,6 +392,44 @@ test("GitHub Copilot named credential selection is deterministic and reaches onl
 	);
 });
 
+test("OpenCode Go usage uses the canonical versioned endpoint", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === "opencode-go");
+	assert.ok(adapter);
+	const requestedUrls: string[] = [];
+	globalThis.fetch = async (input) => {
+		requestedUrls.push(input.toString());
+		return new Response(
+			JSON.stringify({
+				usage: {
+					rolling: { status: "ok", percent: 1 },
+				},
+			}),
+			{ status: 200 },
+		);
+	};
+
+	const report = await queryProviderUsage(
+		adapter,
+		{
+			headers: { Authorization: "Bearer secret" },
+			fingerprint: "fingerprint",
+			secrets: ["secret"],
+			model: {} as never,
+		},
+		new AbortController().signal,
+		1_000,
+	);
+
+	assert.deepEqual(requestedUrls, ["https://opencode.ai/zen/go/v1/usage"]);
+	assert.equal(report.providerId, "opencode-go");
+	assert.equal(report.buckets[0]?.used, 1);
+	assert.equal(report.buckets[0]?.remaining, 99);
+});
+
 test("provider cancellation preserves AbortError identity", async () => {
 	const abort = Object.assign(new Error("cancelled"), { name: "AbortError" });
 	const adapter = {


### PR DESCRIPTION
This pull request updates the OpenCode Go usage endpoint handling in the `@narumitw/pi-usage` package to always use the versioned endpoint. This ensures consistency and future-proofing for usage queries. The documentation and tests have been updated accordingly.

Here is the screenshot comparsion before and after the fix: 

Before the fix: (from commmit `5113b0d`)
<img width="756" height="681" alt="query failed in opencode-go" src="https://github.com/user-attachments/assets/49d349ce-fe9f-401b-89a4-e8c7df84c63c" />

After the fix: (from commit `d74a181`)
<img width="726" height="636" alt="after_fix" src="https://github.com/user-attachments/assets/83bf1738-3db7-4d39-8e7c-2ecde6470ce1" />


**Testing:**
- Added a test to verify that the canonical usage endpoint is always used for OpenCode Go.

**Code comments and safety:**
- Added a comment clarifying the runtime safety of Pi's auth methods in `resolveUsageAuth`.