### PR TITLE
Modify publish workflow to run on CI completion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,10 @@ name: Version or publish packages
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  workflow_run:
+     workflows: ["CI"]
+     types: [completed]
+     branches: [main]
 
 permissions:
   contents: write
@@ -34,13 +35,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
-
-      - name: Run checks
-        run: npm run check
-
-      - name: Run tests
-        run: npm test
+        run: npm install
 
       - name: Create version pull request or publish to npm
         id: changesets


### PR DESCRIPTION
Updated workflow to trigger on completion of CI workflows instead of direct pushes to main. Changed npm command from 'npm ci' to 'npm install' and removed checks and tests steps.