### PR TITLE
test(ci): keep publish verification in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ Run commands from the repository root unless a command says otherwise.
 - Set the Bash tool timeout to 300 seconds.
 - Run `npm run check` or `just check` for the build, Biome, boundaries, and workspace typechecks.
 - Run `npm test` or `just test` separately for active tests.
-- CI and release verification must run both gates.
+- CI must run both gates, and `publish.yml` must not rerun tests or typechecks.
 - Run `just pack <unscoped-name>` and inspect the tarball after package metadata or publishing changes.
 - After packaged extension runtime-loading changes, run `npm --workspace @narumitw/pi-<unscoped-name> run build --if-present`, then smoke with `pi -e ./packages/pi-<unscoped-name>`; record why and what remains unverified if the smoke is impractical.
 - After project-local extension changes, smoke it in isolation with `pi --no-extensions -e ./.pi/extensions/<extension>/index.ts`, then verify trusted-project auto-discovery and `/reload` when practical.

--- a/test/check-test-separation.test.ts
+++ b/test/check-test-separation.test.ts
@@ -9,7 +9,7 @@ function read(relativePath: string) {
 	return readFileSync(resolve(root, relativePath), "utf8");
 }
 
-test("check and test remain separate repository gates", () => {
+test("check and test remain separate CI gates", () => {
 	const runChecks = read("scripts/run-checks.mjs");
 	const checksMatch = /const checks = (\[[^\n]+\]);/u.exec(runChecks);
 	assert.ok(checksMatch, "run-checks must declare its task list");
@@ -24,11 +24,16 @@ test("check and test remain separate repository gates", () => {
 	assert.match(manifest.scripts?.test ?? "", /run-tests\.mjs/u);
 	assert.doesNotMatch(manifest.scripts?.check ?? "", /npm (?:run )?test/u);
 
-	for (const workflow of [".github/workflows/ci.yml", ".github/workflows/publish.yml"]) {
-		const contents = read(workflow);
-		const checkIndex = contents.indexOf("run: npm run check");
-		const testIndex = contents.indexOf("run: npm test");
-		assert.ok(checkIndex >= 0, `${workflow} must run checks`);
-		assert.ok(testIndex > checkIndex, `${workflow} must run tests after checks`);
-	}
+	const ciWorkflow = read(".github/workflows/ci.yml");
+	const checkIndex = ciWorkflow.indexOf("run: npm run check");
+	const testIndex = ciWorkflow.indexOf("run: npm test");
+	assert.ok(checkIndex >= 0, "CI must run checks");
+	assert.ok(testIndex > checkIndex, "CI must run tests after checks");
+
+	const publishWorkflow = read(".github/workflows/publish.yml");
+	assert.doesNotMatch(
+		publishWorkflow,
+		/\bnpm (?:run )?(?:check|typecheck|test)\b/u,
+		"publish must rely on CI instead of rerunning tests or typechecks",
+	);
 });


### PR DESCRIPTION
## Summary

- Keep checks and tests as separate CI gates.
- Add regression coverage preventing `publish.yml` from rerunning tests or typechecks.
- Align repository guidance with the updated release policy.

## Verification

- `npm run check`
- `npx vitest run test/check-test-separation.test.ts`

## Test note

- An earlier `npm test` run reported 3530 passing tests and one unrelated `pi-subagents-v3` broker timing failure.
- The failing test file passed when rerun in isolation.
