### PR TITLE
fix(ci): gate publishing on successful CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,9 @@ name: Version or publish packages
 on:
   workflow_dispatch:
   workflow_run:
-     workflows: ["CI"]
-     types: [completed]
-     branches: [main]
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -19,6 +19,10 @@ concurrency:
 jobs:
   release:
     name: Create version PR or publish packages
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +30,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/test/check-test-separation.test.ts
+++ b/test/check-test-separation.test.ts
@@ -29,8 +29,25 @@ test("check and test remain separate CI gates", () => {
 	const testIndex = ciWorkflow.indexOf("run: npm test");
 	assert.ok(checkIndex >= 0, "CI must run checks");
 	assert.ok(testIndex > checkIndex, "CI must run tests after checks");
+});
 
+test("publish releases only the revision from a successful main CI push", () => {
 	const publishWorkflow = read(".github/workflows/publish.yml");
+	assert.match(
+		publishWorkflow,
+		/workflow_run:\n\s+workflows: \["CI"\]\n\s+types: \[completed\]\n\s+branches: \[main\]/u,
+		"publish must run after main-branch CI completes",
+	);
+	assert.match(
+		publishWorkflow,
+		/event_name == 'workflow_dispatch' \|\|\n\s+\(github\.event\.workflow_run\.event == 'push' &&\n\s+github\.event\.workflow_run\.conclusion == 'success'\)/u,
+		"publish must reject unsuccessful and non-push CI runs",
+	);
+	assert.match(
+		publishWorkflow,
+		/ref: \$\{\{ github\.event\.workflow_run\.head_sha \|\| github\.sha \}\}/u,
+		"publish must check out the CI-tested revision, with a manual-dispatch fallback",
+	);
 	assert.doesNotMatch(
 		publishWorkflow,
 		/\bnpm (?:run )?(?:check|typecheck|test)\b/u,


### PR DESCRIPTION
## Summary

- Run release work only after a successful main-branch push CI run.
- Check out the exact revision that CI tested while preserving manual dispatch.
- Add regression coverage for the release trigger, result gate, and checked-out SHA.

This follows up on the review finding in #1042, which merged before the fix was ready.

## Verification

- `npx vitest run test/check-test-separation.test.ts`
- `npm run check`
- `npm test`