### PR TITLE
fix(plan-mode): support git -C inspections

### DIFF
--- a/.changeset/calm-plans-explain-tools.md
+++ b/.changeset/calm-plans-explain-tools.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-plan-mode": patch
 ---
 
-Allow reviewed Git inspections to use `git -C <path>`, and report actionable reasons when Plan mode denies an unavailable, inactive, blocked, or unselected tool.
+Allow reviewed Git inspections to use guarded `git -C <path>` forms, and report actionable reasons when Plan mode denies an unavailable, inactive, frozen, blocked, or unselected tool.

--- a/.changeset/calm-plans-explain-tools.md
+++ b/.changeset/calm-plans-explain-tools.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": patch
+---
+
+Allow reviewed Git inspections to use `git -C <path>`, and report actionable reasons when Plan mode denies an unavailable, inactive, blocked, or unselected tool.

--- a/.changeset/calm-plans-explain-tools.md
+++ b/.changeset/calm-plans-explain-tools.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-plan-mode": patch
 ---
 
-Allow reviewed Git inspections to use guarded `git -C <path>` forms, and report actionable reasons when Plan mode denies an unavailable, inactive, frozen, blocked, or unselected tool.
+Allow reviewed Git inspections to use current-working-directory `git -C <path>` forms, and report actionable reasons when Plan mode denies an unavailable, inactive, frozen, blocked, or unselected tool.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -153,8 +153,10 @@ After they become visible, the Plan-only helpers remain visible in Normal mode, 
 
 Limited `bash` uses a fail-closed Bash policy, including when an extension overrides the canonical `bash` tool name.
 It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`.
-Reviewed Git inspections may place `--no-pager` and one or more complete `-C <path>` pairs before the accepted subcommand.
-It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, incomplete `-C` pairs, other Git global options, mutating flags, dependency changes, editors, and unknown commands.
+Reviewed Git inspections may place `--no-pager` before the accepted subcommand.
+They may also place one or more complete `-C <path>` pairs before the accepted subcommand only when `-c core.fsmonitor=false` is also provided before the subcommand.
+This prevents the target repository's `core.fsmonitor` configuration from running a configured helper during inspection.
+It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, incomplete `-C` pairs, other Git global options, unsafe Git config overrides, mutating flags, dependency changes, editors, and unknown commands.
 
 Limited `powershell` uses a separate fail-closed PowerShell policy, including when an extension overrides the canonical `powershell` tool name.
 It accepts canonical inspection cmdlets such as `Get-ChildItem`, `Get-Content`, `Get-Item`, `Get-Location`, `Resolve-Path`, `Select-String`, `Test-Path`, `Measure-Object`, `Sort-Object`, `Format-List`, `Format-Table`, `Out-String`, and `Write-Output`.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -155,9 +155,9 @@ Limited `bash` uses a fail-closed Bash policy, including when an extension overr
 It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`.
 Reviewed Git inspections may place `--no-pager` before the accepted subcommand.
 They may also place one or more complete `-C <path>` pairs before the accepted subcommand only when `-c core.fsmonitor=false` is also provided before the subcommand.
-Directory-changing `git diff`, `git log`, `git show`, and `git blame` inspections must also pass `--no-ext-diff` and `--no-textconv`.
-This prevents the target repository's `core.fsmonitor`, external diff, and textconv configuration from running configured helpers during inspection.
-It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, incomplete `-C` pairs, other Git global options, unsafe Git config overrides, missing diff-helper overrides, mutating flags, dependency changes, editors, and unknown commands.
+Directory-changing `git diff`, `git log`, `git show`, and `git blame` inspections must also pass `--no-ext-diff`, `--no-textconv`, and `--submodule=short` before any `--` pathspec delimiter.
+This prevents the target repository's `core.fsmonitor`, external diff, textconv, and recursive submodule diff configuration from running configured helpers during inspection.
+It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, incomplete `-C` pairs, other Git global options, unsafe Git config overrides, missing or misplaced diff-helper overrides, recursive submodule diff modes, mutating flags, dependency changes, editors, and unknown commands.
 
 Limited `powershell` uses a separate fail-closed PowerShell policy, including when an extension overrides the canonical `powershell` tool name.
 It accepts canonical inspection cmdlets such as `Get-ChildItem`, `Get-Content`, `Get-Item`, `Get-Location`, `Resolve-Path`, `Select-String`, `Test-Path`, `Measure-Object`, `Sort-Object`, `Format-List`, `Format-Table`, `Out-String`, and `Write-Output`.
@@ -425,7 +425,7 @@ git blame -- src/plan-mode.ts
 git diff --cached
 git show --stat --oneline HEAD
 git log -p -1 HEAD -- src/plan-mode.ts
-git -c core.fsmonitor=false -C packages/pi-plan-mode diff --check --no-ext-diff --no-textconv
+git -c core.fsmonitor=false -C packages/pi-plan-mode diff --check --no-ext-diff --no-textconv --submodule=short
 gh pr view 218 --json number,title,state
 gh issue list --state open --json number,title,state
 ```
@@ -436,6 +436,8 @@ The command-specific validators still reject unsafe forms, including:
 git -C
 git -C packages/pi-plan-mode status --short
 git -c core.fsmonitor=false -C packages/pi-plan-mode diff --check
+git -c core.fsmonitor=false -C packages/pi-plan-mode diff --submodule=diff --no-ext-diff --no-textconv --submodule=short
+git -c core.fsmonitor=false -C packages/pi-plan-mode diff --submodule=short -- --no-ext-diff --no-textconv
 git -C packages/pi-plan-mode checkout main
 git blame --textconv -- src/plan-mode.ts
 git cat-file --filters HEAD

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -155,8 +155,9 @@ Limited `bash` uses a fail-closed Bash policy, including when an extension overr
 It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`.
 Reviewed Git inspections may place `--no-pager` before the accepted subcommand.
 They may also place one or more complete `-C <path>` pairs before the accepted subcommand only when `-c core.fsmonitor=false` is also provided before the subcommand.
-This prevents the target repository's `core.fsmonitor` configuration from running a configured helper during inspection.
-It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, incomplete `-C` pairs, other Git global options, unsafe Git config overrides, mutating flags, dependency changes, editors, and unknown commands.
+Directory-changing `git diff`, `git log`, `git show`, and `git blame` inspections must also pass `--no-ext-diff` and `--no-textconv`.
+This prevents the target repository's `core.fsmonitor`, external diff, and textconv configuration from running configured helpers during inspection.
+It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, incomplete `-C` pairs, other Git global options, unsafe Git config overrides, missing diff-helper overrides, mutating flags, dependency changes, editors, and unknown commands.
 
 Limited `powershell` uses a separate fail-closed PowerShell policy, including when an extension overrides the canonical `powershell` tool name.
 It accepts canonical inspection cmdlets such as `Get-ChildItem`, `Get-Content`, `Get-Item`, `Get-Location`, `Resolve-Path`, `Select-String`, `Test-Path`, `Measure-Object`, `Sort-Object`, `Format-List`, `Format-Table`, `Out-String`, and `Write-Output`.
@@ -418,12 +419,13 @@ Duplicate values are removed in first-seen order.
 With the example configuration above, commands such as these are accepted:
 
 ```bash
-git -C packages/pi-plan-mode status --short
+git -c core.fsmonitor=false -C packages/pi-plan-mode status --short
 git rev-parse --show-toplevel
 git blame -- src/plan-mode.ts
 git diff --cached
 git show --stat --oneline HEAD
 git log -p -1 HEAD -- src/plan-mode.ts
+git -c core.fsmonitor=false -C packages/pi-plan-mode diff --check --no-ext-diff --no-textconv
 gh pr view 218 --json number,title,state
 gh issue list --state open --json number,title,state
 ```
@@ -432,6 +434,8 @@ The command-specific validators still reject unsafe forms, including:
 
 ```bash
 git -C
+git -C packages/pi-plan-mode status --short
+git -c core.fsmonitor=false -C packages/pi-plan-mode diff --check
 git -C packages/pi-plan-mode checkout main
 git blame --textconv -- src/plan-mode.ts
 git cat-file --filters HEAD

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -147,11 +147,14 @@ The optional native `powershell` tool must be active when an automatic Plan poli
 Built-in `edit` and `write`, `update_plan`, tools still inactive at the first request, and deselected tools are blocked at execution time even though active schemas remain visible.
 Extension and custom tools are denied by default because Pi tools do not expose standardized mutability metadata; explicitly allow a custom-tool name before starting only when you accept the risk.
 For example, you can opt into `firecrawl_scrape`, `firecrawl_search`, or `lsp_diagnostics` when you want to use the effective active tool during planning.
+An active selectable tool omitted from the Plan policy reports that it needs explicit selection through `/plan tools` or `defaultPlanTools` before the next workflow.
+Registered but inactive, unregistered, metadata-free, and built-in blocked tools report their distinct fail-closed reasons instead of suggesting that every denial is a missing selection.
 After they become visible, the Plan-only helpers remain visible in Normal mode, but their handlers and the `tool_call` policy reject calls unless Plan mode owns the active workflow.
 
 Limited `bash` uses a fail-closed Bash policy, including when an extension overrides the canonical `bash` tool name.
 It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`.
-It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, mutating flags, dependency changes, editors, and unknown commands.
+Reviewed Git inspections may place `--no-pager` and one or more complete `-C <path>` pairs before the accepted subcommand.
+It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, incomplete `-C` pairs, other Git global options, mutating flags, dependency changes, editors, and unknown commands.
 
 Limited `powershell` uses a separate fail-closed PowerShell policy, including when an extension overrides the canonical `powershell` tool name.
 It accepts canonical inspection cmdlets such as `Get-ChildItem`, `Get-Content`, `Get-Item`, `Get-Location`, `Resolve-Path`, `Select-String`, `Test-Path`, `Measure-Object`, `Sort-Object`, `Format-List`, `Format-Table`, `Out-String`, and `Write-Output`.
@@ -413,6 +416,7 @@ Duplicate values are removed in first-seen order.
 With the example configuration above, commands such as these are accepted:
 
 ```bash
+git -C packages/pi-plan-mode status --short
 git rev-parse --show-toplevel
 git blame -- src/plan-mode.ts
 git diff --cached
@@ -425,6 +429,8 @@ gh issue list --state open --json number,title,state
 The command-specific validators still reject unsafe forms, including:
 
 ```bash
+git -C
+git -C packages/pi-plan-mode checkout main
 git blame --textconv -- src/plan-mode.ts
 git cat-file --filters HEAD
 git diff --ext-diff
@@ -446,6 +452,7 @@ GitHub CLI read paths require `--json <fields>` output so Plan mode does not rel
 Unknown `safeSubcommands` keys or values, non-array values, and non-string entries invalidate the entire settings file and trigger the normal warning/default fallback on session start.
 
 Read-only does not mean private: Git inspection can expose repository history and tracked secrets, while `gh` queries can expose remote repository, pull request, and issue data available to your authenticated account.
+A `git -C <path>` inspection can target a repository outside Pi's current working directory.
 The policy reduces accidental mutation and explicit helper execution; it is not a sandbox or a confidentiality boundary.
 
 ### Thinking level

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -149,15 +149,15 @@ Extension and custom tools are denied by default because Pi tools do not expose 
 For example, you can opt into `firecrawl_scrape`, `firecrawl_search`, or `lsp_diagnostics` when you want to use the effective active tool during planning.
 An active selectable tool omitted from the Plan policy reports that it needs explicit selection through `/plan tools` or `defaultPlanTools` before the next workflow.
 Registered but inactive, unregistered, metadata-free, and built-in blocked tools report their distinct fail-closed reasons instead of suggesting that every denial is a missing selection.
+A tool admitted before later deactivation can be reactivated and reused in the current workflow without restarting.
 After they become visible, the Plan-only helpers remain visible in Normal mode, but their handlers and the `tool_call` policy reject calls unless Plan mode owns the active workflow.
 
 Limited `bash` uses a fail-closed Bash policy, including when an extension overrides the canonical `bash` tool name.
 It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`.
 Reviewed Git inspections may place `--no-pager` before the accepted subcommand.
-They may also place one or more complete `-C <path>` pairs before the accepted subcommand only when `-c core.fsmonitor=false` is also provided before the subcommand.
-Directory-changing `git diff`, `git log`, `git show`, and `git blame` inspections must also pass `--no-ext-diff`, `--no-textconv`, and `--submodule=short` before any `--` pathspec delimiter.
-This prevents the target repository's `core.fsmonitor`, external diff, textconv, and recursive submodule diff configuration from running configured helpers during inspection.
-It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, incomplete `-C` pairs, other Git global options, unsafe Git config overrides, missing or misplaced diff-helper overrides, recursive submodule diff modes, mutating flags, dependency changes, editors, and unknown commands.
+They may also place one or more complete `-C <path>` pairs before the accepted subcommand only when every path is `.` or the exact current Pi working directory.
+Other targets are rejected so `git -C` cannot introduce executable configuration, hooks, filters, signing programs, or lazy-fetch remotes from another repository.
+It rejects output/input redirects, shell expansion, substitutions, subshells, background jobs, incomplete or directory-changing `-C` pairs, other Git global options, Git config overrides, mutating flags, dependency changes, editors, and unknown commands.
 
 Limited `powershell` uses a separate fail-closed PowerShell policy, including when an extension overrides the canonical `powershell` tool name.
 It accepts canonical inspection cmdlets such as `Get-ChildItem`, `Get-Content`, `Get-Item`, `Get-Location`, `Resolve-Path`, `Select-String`, `Test-Path`, `Measure-Object`, `Sort-Object`, `Format-List`, `Format-Table`, `Out-String`, and `Write-Output`.
@@ -419,13 +419,13 @@ Duplicate values are removed in first-seen order.
 With the example configuration above, commands such as these are accepted:
 
 ```bash
-git -c core.fsmonitor=false -C packages/pi-plan-mode status --short
+git -C . status --short
 git rev-parse --show-toplevel
 git blame -- src/plan-mode.ts
 git diff --cached
 git show --stat --oneline HEAD
 git log -p -1 HEAD -- src/plan-mode.ts
-git -c core.fsmonitor=false -C packages/pi-plan-mode diff --check --no-ext-diff --no-textconv --submodule=short
+git -C . diff --check
 gh pr view 218 --json number,title,state
 gh issue list --state open --json number,title,state
 ```
@@ -435,10 +435,9 @@ The command-specific validators still reject unsafe forms, including:
 ```bash
 git -C
 git -C packages/pi-plan-mode status --short
-git -c core.fsmonitor=false -C packages/pi-plan-mode diff --check
-git -c core.fsmonitor=false -C packages/pi-plan-mode diff --submodule=diff --no-ext-diff --no-textconv --submodule=short
-git -c core.fsmonitor=false -C packages/pi-plan-mode diff --submodule=short -- --no-ext-diff --no-textconv
-git -C packages/pi-plan-mode checkout main
+git -C packages -C .. status --short
+git -c core.fsmonitor=false -C . status --short
+git -C . checkout main
 git blame --textconv -- src/plan-mode.ts
 git cat-file --filters HEAD
 git diff --ext-diff
@@ -460,8 +459,8 @@ GitHub CLI read paths require `--json <fields>` output so Plan mode does not rel
 Unknown `safeSubcommands` keys or values, non-array values, and non-string entries invalidate the entire settings file and trigger the normal warning/default fallback on session start.
 
 Read-only does not mean private: Git inspection can expose repository history and tracked secrets, while `gh` queries can expose remote repository, pull request, and issue data available to your authenticated account.
-A `git -C <path>` inspection can target a repository outside Pi's current working directory.
-The policy reduces accidental mutation and explicit helper execution; it is not a sandbox or a confidentiality boundary.
+A `git -C <path>` inspection is accepted only when the path keeps Git in Pi's current working directory.
+The policy reduces accidental mutation and cross-repository executable configuration; it is not a sandbox or a confidentiality boundary.
 
 ### Thinking level
 

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -542,7 +542,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 	});
 
-	pi.on("tool_call", async (event) => {
+	pi.on("tool_call", async (event, ctx) => {
 		const requiredHelper =
 			event.toolName === PLAN_MODE_QUESTION_TOOL_NAME ||
 			event.toolName === PLAN_MODE_COMPLETE_TOOL_NAME;
@@ -586,13 +586,15 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				reason: `Plan mode blocks tool '${event.toolName}' because its built-in policy is blocked and settings cannot enable it.`,
 			};
 		}
+		const allowedToolNames = new Set(planModePolicyToolNames());
 		if (!activeToolNames.has(event.toolName)) {
 			return {
 				block: true,
-				reason: `Plan mode blocks tool '${event.toolName}' because it is registered but inactive. Activate it before starting the next Plan workflow.`,
+				reason: allowedToolNames.has(event.toolName)
+					? `Plan mode blocks tool '${event.toolName}' because it was admitted to the active Plan workflow but is currently inactive. Reactivate it to continue without restarting.`
+					: `Plan mode blocks tool '${event.toolName}' because it is registered but inactive. Activate it before starting the next Plan workflow.`,
 			};
 		}
-		const allowedToolNames = new Set(planModePolicyToolNames());
 		if (!allowedToolNames.has(event.toolName)) {
 			return {
 				block: true,
@@ -602,7 +604,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			};
 		}
 		if (event.toolName === "bash") {
-			const blocked = findBlockedCommandSegment(readCommand(event.input), settings.safeSubcommands);
+			const blocked = findBlockedCommandSegment(
+				readCommand(event.input),
+				settings.safeSubcommands,
+				ctx.cwd,
+			);
 			if (blocked !== undefined) {
 				return {
 					block: true,
@@ -614,6 +620,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			const blocked = findBlockedPowerShellCommandSegment(
 				readCommand(event.input),
 				settings.safeSubcommands,
+				ctx.cwd,
 			);
 			if (blocked !== undefined) {
 				return {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -596,7 +596,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!allowedToolNames.has(event.toolName)) {
 			return {
 				block: true,
-				reason: `Plan mode blocks tool '${event.toolName}' because it is not selected by the Plan policy. Exit Plan mode, then enable it with /plan tools or defaultPlanTools before starting again.`,
+				reason: workflowDesiredToolNames().has(event.toolName)
+					? `Plan mode blocks tool '${event.toolName}' because it was not available when the active Plan workflow froze its tool policy. Exit Plan mode, then start again after the tool is active.`
+					: `Plan mode blocks tool '${event.toolName}' because it is not selected by the Plan policy. Exit Plan mode, then enable it with /plan tools or defaultPlanTools before starting again.`,
 			};
 		}
 		if (event.toolName === "bash") {
@@ -1297,6 +1299,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	function planModePolicyToolNames() {
 		if (state.enabled) return workflowAllowedToolNames ?? [];
 		return computePlanModePolicyToolNames();
+	}
+
+	function workflowDesiredToolNames() {
+		const policy = state.workflowToolPolicy;
+		if (!state.enabled || policy?.kind !== "explicit") return new Set<string>();
+		return new Set(policy.desiredNames ?? []);
 	}
 
 	function beginWorkflowToolPolicy() {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -1303,8 +1303,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	function workflowDesiredToolNames() {
 		const policy = state.workflowToolPolicy;
-		if (!state.enabled || policy?.kind !== "explicit") return new Set<string>();
-		return new Set(policy.desiredNames ?? []);
+		if (!state.enabled || !policy) return new Set<string>();
+		return new Set(
+			policy.kind === "automatic" ? automaticPlanModeToolNames() : (policy.desiredNames ?? []),
+		);
 	}
 
 	function beginWorkflowToolPolicy() {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -570,18 +570,33 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 		if (requiredHelper) return;
 
+		const calledTool = toolByName(event.toolName);
+		const activeToolNames = new Set(safeGetActiveTools());
+		if (!calledTool) {
+			return {
+				block: true,
+				reason: activeToolNames.has(event.toolName)
+					? `Plan mode blocks tool '${event.toolName}' because its safe policy metadata is unavailable.`
+					: `Plan mode blocks tool '${event.toolName}' because it is not registered or active. Register and activate it before starting the next Plan workflow.`,
+			};
+		}
+		if (classifyPlanModeTool(calledTool) === "blocked") {
+			return {
+				block: true,
+				reason: `Plan mode blocks tool '${event.toolName}' because its built-in policy is blocked and settings cannot enable it.`,
+			};
+		}
+		if (!activeToolNames.has(event.toolName)) {
+			return {
+				block: true,
+				reason: `Plan mode blocks tool '${event.toolName}' because it is registered but inactive. Activate it before starting the next Plan workflow.`,
+			};
+		}
 		const allowedToolNames = new Set(planModePolicyToolNames());
 		if (!allowedToolNames.has(event.toolName)) {
 			return {
 				block: true,
-				reason: `Plan mode blocks tool '${event.toolName}' because it is unavailable or not selected by the Plan policy.`,
-			};
-		}
-		const calledTool = toolByName(event.toolName);
-		if (!calledTool || classifyPlanModeTool(calledTool) === "blocked") {
-			return {
-				block: true,
-				reason: `Plan mode blocks tool '${event.toolName}' because its safe policy metadata is unavailable.`,
+				reason: `Plan mode blocks tool '${event.toolName}' because it is not selected by the Plan policy. Exit Plan mode, then enable it with /plan tools or defaultPlanTools before starting again.`,
 			};
 		}
 		if (event.toolName === "bash") {

--- a/packages/pi-plan-mode/src/tool-policy.ts
+++ b/packages/pi-plan-mode/src/tool-policy.ts
@@ -505,6 +505,7 @@ const GH_VALIDATORS: Record<SafeGhSubcommandPath, ArgumentValidator> = {
 	"issue view": isSafeGhReadArguments,
 	"issue list": isSafeGhReadArguments,
 };
+const DIFF_HELPER_GIT_SUBCOMMANDS = new Set(["diff", "log", "show", "blame"]);
 
 function isSafeStructuredCommand(
 	command: string,
@@ -576,7 +577,7 @@ function isSafeGitCommand(args: string[], safeSubcommands: SafeSubcommands) {
 	const validator = builtinValidator ?? (configured ? configuredValidator : undefined);
 	return (
 		validator !== undefined &&
-		(!globalOptions.usesDirectoryChange || globalOptions.disablesFsmonitor) &&
+		hasSafeDirectoryChangingGitInspection(globalOptions, subcommand, subcommandArgs) &&
 		hasSafeGitArguments(subcommand, subcommandArgs) &&
 		validator(subcommandArgs)
 	);
@@ -610,6 +611,17 @@ function parseGitGlobalOptions(args: string[]) {
 
 function isSafeGitConfigOverride(config: string) {
 	return config.toLowerCase() === "core.fsmonitor=false";
+}
+
+function hasSafeDirectoryChangingGitInspection(
+	globalOptions: Exclude<ReturnType<typeof parseGitGlobalOptions>, undefined>,
+	subcommand: string,
+	args: string[],
+) {
+	if (!globalOptions.usesDirectoryChange) return true;
+	if (!globalOptions.disablesFsmonitor) return false;
+	if (!DIFF_HELPER_GIT_SUBCOMMANDS.has(subcommand)) return true;
+	return args.includes("--no-ext-diff") && args.includes("--no-textconv");
 }
 
 function hasSafeGitArguments(subcommand: string, args: string[]) {

--- a/packages/pi-plan-mode/src/tool-policy.ts
+++ b/packages/pi-plan-mode/src/tool-policy.ts
@@ -561,11 +561,11 @@ function isSafeStructuredCommand(
 }
 
 function isSafeGitCommand(args: string[], safeSubcommands: SafeSubcommands) {
-	const subcommandIndex = gitSubcommandIndex(args);
-	if (subcommandIndex === undefined) return false;
-	const subcommand = args[subcommandIndex]?.toLowerCase();
+	const globalOptions = parseGitGlobalOptions(args);
+	if (globalOptions === undefined) return false;
+	const subcommand = args[globalOptions.subcommandIndex]?.toLowerCase();
 	if (!subcommand || subcommand.startsWith("-")) return false;
-	const subcommandArgs = args.slice(subcommandIndex + 1);
+	const subcommandArgs = args.slice(globalOptions.subcommandIndex + 1);
 	const builtinValidator = (BUILTIN_GIT_VALIDATORS as Record<string, ArgumentValidator>)[
 		subcommand
 	];
@@ -576,25 +576,40 @@ function isSafeGitCommand(args: string[], safeSubcommands: SafeSubcommands) {
 	const validator = builtinValidator ?? (configured ? configuredValidator : undefined);
 	return (
 		validator !== undefined &&
+		(!globalOptions.usesDirectoryChange || globalOptions.disablesFsmonitor) &&
 		hasSafeGitArguments(subcommand, subcommandArgs) &&
 		validator(subcommandArgs)
 	);
 }
 
-function gitSubcommandIndex(args: string[]) {
+function parseGitGlobalOptions(args: string[]) {
 	let index = 0;
+	let usesDirectoryChange = false;
+	let disablesFsmonitor = false;
 	while (index < args.length) {
 		const argument = args[index];
 		if (argument === "--no-pager") {
 			index += 1;
 			continue;
 		}
+		if (argument === "-c") {
+			const config = args[index + 1];
+			if (!config || !isSafeGitConfigOverride(config)) return undefined;
+			disablesFsmonitor = true;
+			index += 2;
+			continue;
+		}
 		if (argument !== "-C") break;
 		const directory = args[index + 1];
 		if (!directory || directory.startsWith("-")) return undefined;
+		usesDirectoryChange = true;
 		index += 2;
 	}
-	return index;
+	return { subcommandIndex: index, usesDirectoryChange, disablesFsmonitor };
+}
+
+function isSafeGitConfigOverride(config: string) {
+	return config.toLowerCase() === "core.fsmonitor=false";
 }
 
 function hasSafeGitArguments(subcommand: string, args: string[]) {

--- a/packages/pi-plan-mode/src/tool-policy.ts
+++ b/packages/pi-plan-mode/src/tool-policy.ts
@@ -561,8 +561,8 @@ function isSafeStructuredCommand(
 }
 
 function isSafeGitCommand(args: string[], safeSubcommands: SafeSubcommands) {
-	let subcommandIndex = 0;
-	while (args[subcommandIndex] === "--no-pager") subcommandIndex += 1;
+	const subcommandIndex = gitSubcommandIndex(args);
+	if (subcommandIndex === undefined) return false;
 	const subcommand = args[subcommandIndex]?.toLowerCase();
 	if (!subcommand || subcommand.startsWith("-")) return false;
 	const subcommandArgs = args.slice(subcommandIndex + 1);
@@ -579,6 +579,22 @@ function isSafeGitCommand(args: string[], safeSubcommands: SafeSubcommands) {
 		hasSafeGitArguments(subcommand, subcommandArgs) &&
 		validator(subcommandArgs)
 	);
+}
+
+function gitSubcommandIndex(args: string[]) {
+	let index = 0;
+	while (index < args.length) {
+		const argument = args[index];
+		if (argument === "--no-pager") {
+			index += 1;
+			continue;
+		}
+		if (argument !== "-C") break;
+		const directory = args[index + 1];
+		if (!directory || directory.startsWith("-")) return undefined;
+		index += 2;
+	}
+	return index;
 }
 
 function hasSafeGitArguments(subcommand: string, args: string[]) {

--- a/packages/pi-plan-mode/src/tool-policy.ts
+++ b/packages/pi-plan-mode/src/tool-policy.ts
@@ -621,7 +621,19 @@ function hasSafeDirectoryChangingGitInspection(
 	if (!globalOptions.usesDirectoryChange) return true;
 	if (!globalOptions.disablesFsmonitor) return false;
 	if (!DIFF_HELPER_GIT_SUBCOMMANDS.has(subcommand)) return true;
-	return args.includes("--no-ext-diff") && args.includes("--no-textconv");
+	const optionTerminatorIndex = args.indexOf("--");
+	const optionArgs = args.slice(
+		0,
+		optionTerminatorIndex === -1 ? args.length : optionTerminatorIndex,
+	);
+	return (
+		optionArgs.includes("--no-ext-diff") &&
+		optionArgs.includes("--no-textconv") &&
+		optionArgs.includes("--submodule=short") &&
+		!optionArgs.some(
+			(argument) => argument.startsWith("--submodule") && argument !== "--submodule=short",
+		)
+	);
 }
 
 function hasSafeGitArguments(subcommand: string, args: string[]) {

--- a/packages/pi-plan-mode/src/tool-policy.ts
+++ b/packages/pi-plan-mode/src/tool-policy.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, normalize } from "node:path";
 import type { ToolInfo } from "@earendil-works/pi-coding-agent";
 
 export const BUILTIN_SAFE_GIT_SUBCOMMANDS = [
@@ -146,27 +147,41 @@ export function readCommand(input: unknown) {
 export function findBlockedCommandSegment(
 	command: string,
 	safeSubcommands: SafeSubcommands = {},
+	workingDirectory?: string,
 ): string | undefined {
 	const segments = splitShellSegments(command);
 	if (!segments || segments.length === 0) return command.trim() || "(empty command)";
-	return segments.find((segment) => !isSafeSegment(segment, safeSubcommands));
+	return segments.find((segment) => !isSafeSegment(segment, safeSubcommands, workingDirectory));
 }
 
-export function isSafeCommand(command: string, safeSubcommands: SafeSubcommands = {}) {
-	return findBlockedCommandSegment(command, safeSubcommands) === undefined;
+export function isSafeCommand(
+	command: string,
+	safeSubcommands: SafeSubcommands = {},
+	workingDirectory?: string,
+) {
+	return findBlockedCommandSegment(command, safeSubcommands, workingDirectory) === undefined;
 }
 
 export function findBlockedPowerShellCommandSegment(
 	command: string,
 	safeSubcommands: SafeSubcommands = {},
+	workingDirectory?: string,
 ): string | undefined {
 	const segments = splitPowerShellSegments(command);
 	if (!segments || segments.length === 0) return command.trim() || "(empty command)";
-	return segments.find((segment) => !isSafePowerShellSegment(segment, safeSubcommands));
+	return segments.find(
+		(segment) => !isSafePowerShellSegment(segment, safeSubcommands, workingDirectory),
+	);
 }
 
-export function isSafePowerShellCommand(command: string, safeSubcommands: SafeSubcommands = {}) {
-	return findBlockedPowerShellCommandSegment(command, safeSubcommands) === undefined;
+export function isSafePowerShellCommand(
+	command: string,
+	safeSubcommands: SafeSubcommands = {},
+	workingDirectory?: string,
+) {
+	return (
+		findBlockedPowerShellCommandSegment(command, safeSubcommands, workingDirectory) === undefined
+	);
 }
 
 function splitPowerShellSegments(command: string): string[] | undefined {
@@ -216,7 +231,11 @@ function splitPowerShellSegments(command: string): string[] | undefined {
 	return segments;
 }
 
-function isSafePowerShellSegment(segment: string, safeSubcommands: SafeSubcommands) {
+function isSafePowerShellSegment(
+	segment: string,
+	safeSubcommands: SafeSubcommands,
+	workingDirectory?: string,
+) {
 	const tokens = powerShellWords(segment);
 	if (!tokens || tokens.length === 0 || tokens.includes("--%")) return false;
 	const command = tokens[0]?.toLowerCase();
@@ -224,7 +243,7 @@ function isSafePowerShellSegment(segment: string, safeSubcommands: SafeSubcomman
 	const args = tokens.slice(1);
 	if (READ_ONLY_POWERSHELL_COMMANDS.has(command)) return true;
 	if (command !== "git" && command !== "gh") return false;
-	return isSafeStructuredCommand(command, args, safeSubcommands);
+	return isSafeStructuredCommand(command, args, safeSubcommands, workingDirectory);
 }
 
 function powerShellWords(segment: string): string[] | undefined {
@@ -322,7 +341,11 @@ function splitShellSegments(command: string): string[] | undefined {
 	return segments;
 }
 
-function isSafeSegment(segment: string, safeSubcommands: SafeSubcommands) {
+function isSafeSegment(
+	segment: string,
+	safeSubcommands: SafeSubcommands,
+	workingDirectory?: string,
+) {
 	if (hasShellExpansion(segment) || /(^|\s)[A-Za-z_][A-Za-z0-9_]*=/.test(segment)) {
 		return false;
 	}
@@ -333,7 +356,7 @@ function isSafeSegment(segment: string, safeSubcommands: SafeSubcommands) {
 	const args = tokens.slice(1);
 	if (!hasSafeArguments(command, args)) return false;
 	if (READ_ONLY_COMMANDS.has(command)) return true;
-	return isSafeStructuredCommand(command, args, safeSubcommands);
+	return isSafeStructuredCommand(command, args, safeSubcommands, workingDirectory);
 }
 
 function hasShellExpansion(segment: string) {
@@ -505,14 +528,14 @@ const GH_VALIDATORS: Record<SafeGhSubcommandPath, ArgumentValidator> = {
 	"issue view": isSafeGhReadArguments,
 	"issue list": isSafeGhReadArguments,
 };
-const DIFF_HELPER_GIT_SUBCOMMANDS = new Set(["diff", "log", "show", "blame"]);
 
 function isSafeStructuredCommand(
 	command: string,
 	args: string[],
 	safeSubcommands: SafeSubcommands,
+	workingDirectory?: string,
 ) {
-	if (command === "git") return isSafeGitCommand(args, safeSubcommands);
+	if (command === "git") return isSafeGitCommand(args, safeSubcommands, workingDirectory);
 	if (command === "gh") return isSafeGhCommand(args, safeSubcommands);
 
 	const subcommandIndex = args.findIndex((argument) => !argument.startsWith("-"));
@@ -561,12 +584,16 @@ function isSafeStructuredCommand(
 	return false;
 }
 
-function isSafeGitCommand(args: string[], safeSubcommands: SafeSubcommands) {
-	const globalOptions = parseGitGlobalOptions(args);
-	if (globalOptions === undefined) return false;
-	const subcommand = args[globalOptions.subcommandIndex]?.toLowerCase();
+function isSafeGitCommand(
+	args: string[],
+	safeSubcommands: SafeSubcommands,
+	workingDirectory?: string,
+) {
+	const subcommandIndex = parseGitGlobalOptions(args, workingDirectory);
+	if (subcommandIndex === undefined) return false;
+	const subcommand = args[subcommandIndex]?.toLowerCase();
 	if (!subcommand || subcommand.startsWith("-")) return false;
-	const subcommandArgs = args.slice(globalOptions.subcommandIndex + 1);
+	const subcommandArgs = args.slice(subcommandIndex + 1);
 	const builtinValidator = (BUILTIN_GIT_VALIDATORS as Record<string, ArgumentValidator>)[
 		subcommand
 	];
@@ -577,63 +604,31 @@ function isSafeGitCommand(args: string[], safeSubcommands: SafeSubcommands) {
 	const validator = builtinValidator ?? (configured ? configuredValidator : undefined);
 	return (
 		validator !== undefined &&
-		hasSafeDirectoryChangingGitInspection(globalOptions, subcommand, subcommandArgs) &&
 		hasSafeGitArguments(subcommand, subcommandArgs) &&
 		validator(subcommandArgs)
 	);
 }
 
-function parseGitGlobalOptions(args: string[]) {
+function parseGitGlobalOptions(args: string[], workingDirectory?: string) {
 	let index = 0;
-	let usesDirectoryChange = false;
-	let disablesFsmonitor = false;
 	while (index < args.length) {
 		const argument = args[index];
 		if (argument === "--no-pager") {
 			index += 1;
 			continue;
 		}
-		if (argument === "-c") {
-			const config = args[index + 1];
-			if (!config || !isSafeGitConfigOverride(config)) return undefined;
-			disablesFsmonitor = true;
-			index += 2;
-			continue;
-		}
 		if (argument !== "-C") break;
 		const directory = args[index + 1];
-		if (!directory || directory.startsWith("-")) return undefined;
-		usesDirectoryChange = true;
+		if (!directory || !isCurrentWorkingDirectory(directory, workingDirectory)) return undefined;
 		index += 2;
 	}
-	return { subcommandIndex: index, usesDirectoryChange, disablesFsmonitor };
+	return index;
 }
 
-function isSafeGitConfigOverride(config: string) {
-	return config.toLowerCase() === "core.fsmonitor=false";
-}
-
-function hasSafeDirectoryChangingGitInspection(
-	globalOptions: Exclude<ReturnType<typeof parseGitGlobalOptions>, undefined>,
-	subcommand: string,
-	args: string[],
-) {
-	if (!globalOptions.usesDirectoryChange) return true;
-	if (!globalOptions.disablesFsmonitor) return false;
-	if (!DIFF_HELPER_GIT_SUBCOMMANDS.has(subcommand)) return true;
-	const optionTerminatorIndex = args.indexOf("--");
-	const optionArgs = args.slice(
-		0,
-		optionTerminatorIndex === -1 ? args.length : optionTerminatorIndex,
-	);
-	return (
-		optionArgs.includes("--no-ext-diff") &&
-		optionArgs.includes("--no-textconv") &&
-		optionArgs.includes("--submodule=short") &&
-		!optionArgs.some(
-			(argument) => argument.startsWith("--submodule") && argument !== "--submodule=short",
-		)
-	);
+function isCurrentWorkingDirectory(directory: string, workingDirectory?: string) {
+	if (!workingDirectory || directory.split(/[\\/]+/u).includes("..")) return false;
+	if (normalize(directory) === ".") return true;
+	return isAbsolute(directory) && normalize(directory) === normalize(workingDirectory);
 }
 
 function hasSafeGitArguments(subcommand: string, args: string[]) {

--- a/packages/pi-plan-mode/test/issue-1039-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-1039-repro.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import planMode from "../src/plan-mode.js";
+import { isSafeCommand, isSafePowerShellCommand } from "../src/tool-policy.js";
+import { builtinTool, createMockContext, createMockPi, extensionTool } from "./support.js";
+
+const CUSTOM_TOOL = "research_tool";
+
+type ToolCallResult = { block?: boolean; reason?: string } | undefined;
+
+async function startPlan(options: {
+	configured?: string[];
+	activeTools: string[];
+	allTools: ReturnType<typeof builtinTool>[];
+}) {
+	const mock = createMockPi({ activeTools: options.activeTools, allTools: options.allTools });
+	planMode(mock.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: {
+				thinkingLevel: "inherit" as const,
+				...(options.configured === undefined ? {} : { defaultPlanTools: options.configured }),
+			},
+		}),
+	});
+	const context = createMockContext();
+	await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+	await mock.commands.get("plan")?.handler("start", context.ctx);
+	return { context, mock };
+}
+
+async function callTool(
+	fixture: Awaited<ReturnType<typeof startPlan>>,
+	toolName: string,
+	input: unknown = {},
+) {
+	return fixture.mock.events.get("tool_call")?.[0]?.(
+		{ toolName, input },
+		fixture.context.ctx,
+	) as ToolCallResult;
+}
+
+test("issue 1039: any active extension tool requires explicit Plan-policy opt-in", async () => {
+	const automatic = await startPlan({
+		activeTools: ["read", CUSTOM_TOOL],
+		allTools: [builtinTool("read"), extensionTool(CUSTOM_TOOL)],
+	});
+	assert.deepEqual(await callTool(automatic, CUSTOM_TOOL), {
+		block: true,
+		reason: `Plan mode blocks tool '${CUSTOM_TOOL}' because it is not selected by the Plan policy. Exit Plan mode, then enable it with /plan tools or defaultPlanTools before starting again.`,
+	});
+
+	const explicit = await startPlan({
+		configured: [CUSTOM_TOOL],
+		activeTools: ["read", CUSTOM_TOOL],
+		allTools: [builtinTool("read"), extensionTool(CUSTOM_TOOL)],
+	});
+	assert.equal(await callTool(explicit, CUSTOM_TOOL), undefined);
+});
+
+test("issue 1039: denied tools report inactive, unavailable, and blocked policy states", async () => {
+	const inactive = await startPlan({
+		configured: [CUSTOM_TOOL],
+		activeTools: ["read"],
+		allTools: [builtinTool("read"), extensionTool(CUSTOM_TOOL)],
+	});
+	assert.deepEqual(await callTool(inactive, CUSTOM_TOOL), {
+		block: true,
+		reason: `Plan mode blocks tool '${CUSTOM_TOOL}' because it is registered but inactive. Activate it before starting the next Plan workflow.`,
+	});
+
+	const unavailable = await startPlan({
+		configured: [CUSTOM_TOOL],
+		activeTools: ["read"],
+		allTools: [builtinTool("read")],
+	});
+	assert.deepEqual(await callTool(unavailable, CUSTOM_TOOL), {
+		block: true,
+		reason: `Plan mode blocks tool '${CUSTOM_TOOL}' because it is not registered or active. Register and activate it before starting the next Plan workflow.`,
+	});
+
+	const metadataFree = await startPlan({
+		configured: [CUSTOM_TOOL],
+		activeTools: ["read", CUSTOM_TOOL],
+		allTools: [builtinTool("read")],
+	});
+	assert.deepEqual(await callTool(metadataFree, CUSTOM_TOOL), {
+		block: true,
+		reason: `Plan mode blocks tool '${CUSTOM_TOOL}' because its safe policy metadata is unavailable.`,
+	});
+
+	const blockedBuiltin = await startPlan({
+		configured: ["danger"],
+		activeTools: ["read", "danger"],
+		allTools: [builtinTool("read"), builtinTool("danger")],
+	});
+	assert.deepEqual(await callTool(blockedBuiltin, "danger"), {
+		block: true,
+		reason:
+			"Plan mode blocks tool 'danger' because its built-in policy is blocked and settings cannot enable it.",
+	});
+});
+
+test("issue 1039: reviewed git -C inspections work in Bash and PowerShell policies", async () => {
+	for (const command of [
+		"git -C /tmp/repository status --short",
+		"git --no-pager -C /tmp/repository log -1 --oneline",
+		"git -C packages -C pi-plan-mode diff --check",
+		"git -C packages --no-pager status --short",
+	]) {
+		assert.equal(isSafeCommand(command), true, `Bash: ${command}`);
+		assert.equal(isSafePowerShellCommand(command), true, `PowerShell: ${command}`);
+	}
+	const configured = "git -C /tmp/repository rev-parse --show-toplevel";
+	assert.equal(isSafeCommand(configured), false);
+	assert.equal(isSafePowerShellCommand(configured), false);
+	assert.equal(isSafeCommand(configured, { git: ["rev-parse"] }), true);
+	assert.equal(isSafePowerShellCommand(configured, { git: ["rev-parse"] }), true);
+
+	const fixture = await startPlan({
+		activeTools: ["bash", "powershell"],
+		allTools: [builtinTool("bash"), builtinTool("powershell")],
+	});
+	assert.equal(
+		await callTool(fixture, "bash", {
+			command: "git -C /tmp/repository status --short",
+		}),
+		undefined,
+	);
+	assert.equal(
+		await callTool(fixture, "powershell", {
+			command: "git -C 'C:\\repository path' status --short",
+		}),
+		undefined,
+	);
+});
+
+test("issue 1039: git -C remains fail-closed for malformed and unsafe commands", () => {
+	for (const command of [
+		"git -C",
+		"git -C --no-pager status",
+		"git -C /tmp/repository checkout main",
+		"git -C /tmp/repository clean -fd",
+		"git -C /tmp/repository --exec-path=/tmp status",
+		"git -C /tmp/repository diff --ext-diff",
+		"git -C /tmp/repository log --show-signature -1",
+		"git --git-dir=/tmp/repository status",
+	]) {
+		assert.equal(isSafeCommand(command), false, `Bash: ${command}`);
+		assert.equal(isSafePowerShellCommand(command), false, `PowerShell: ${command}`);
+	}
+});

--- a/packages/pi-plan-mode/test/issue-1039-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-1039-repro.test.ts
@@ -58,7 +58,7 @@ test("issue 1039: any active extension tool requires explicit Plan-policy opt-in
 	assert.equal(await callTool(explicit, CUSTOM_TOOL), undefined);
 });
 
-test("issue 1039: denied tools report inactive, unavailable, and blocked policy states", async () => {
+test("issue 1039: denied tools report inactive, unavailable, frozen, and blocked policy states", async () => {
 	const inactive = await startPlan({
 		configured: [CUSTOM_TOOL],
 		activeTools: ["read"],
@@ -67,6 +67,17 @@ test("issue 1039: denied tools report inactive, unavailable, and blocked policy 
 	assert.deepEqual(await callTool(inactive, CUSTOM_TOOL), {
 		block: true,
 		reason: `Plan mode blocks tool '${CUSTOM_TOOL}' because it is registered but inactive. Activate it before starting the next Plan workflow.`,
+	});
+
+	const late = await startPlan({
+		configured: [CUSTOM_TOOL],
+		activeTools: ["read"],
+		allTools: [builtinTool("read"), extensionTool(CUSTOM_TOOL)],
+	});
+	late.mock.rawPi.setActiveTools(["read", CUSTOM_TOOL, "plan_mode_question", "plan_mode_complete"]);
+	assert.deepEqual(await callTool(late, CUSTOM_TOOL), {
+		block: true,
+		reason: `Plan mode blocks tool '${CUSTOM_TOOL}' because it was not available when the active Plan workflow froze its tool policy. Exit Plan mode, then start again after the tool is active.`,
 	});
 
 	const unavailable = await startPlan({
@@ -104,8 +115,8 @@ test("issue 1039: denied tools report inactive, unavailable, and blocked policy 
 test("issue 1039: reviewed git -C inspections work with fsmonitor disabled", async () => {
 	for (const command of [
 		"git -c core.fsmonitor=false -C /tmp/repository status --short",
-		"git --no-pager -c core.fsmonitor=false -C /tmp/repository log -1 --oneline",
-		"git -c core.fsmonitor=false -C packages -C pi-plan-mode diff --check",
+		"git --no-pager -c core.fsmonitor=false -C /tmp/repository log -1 --oneline --no-ext-diff --no-textconv",
+		"git -c core.fsmonitor=false -C packages -C pi-plan-mode diff --check --no-ext-diff --no-textconv",
 		"git -C packages --no-pager -c core.fsmonitor=false status --short",
 	]) {
 		assert.equal(isSafeCommand(command), true, `Bash: ${command}`);
@@ -140,6 +151,9 @@ test("issue 1039: git -C remains fail-closed for malformed and unsafe commands",
 		"git -C",
 		"git -C --no-pager status",
 		"git -C /tmp/repository status --short",
+		"git -c core.fsmonitor=false -C /tmp/repository diff --check",
+		"git -c core.fsmonitor=false -C /tmp/repository diff --check --no-ext-diff",
+		"git -c core.fsmonitor=false -C /tmp/repository log -p -1 --no-textconv",
 		"git -c core.fsmonitor=true -C /tmp/repository status --short",
 		"git -c alias.status=!touch -C /tmp/repository status",
 		"git -c core.fsmonitor=false -C /tmp/repository checkout main",

--- a/packages/pi-plan-mode/test/issue-1039-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-1039-repro.test.ts
@@ -69,6 +69,25 @@ test("issue 1039: denied tools report inactive, unavailable, frozen, and blocked
 		reason: `Plan mode blocks tool '${CUSTOM_TOOL}' because it is registered but inactive. Activate it before starting the next Plan workflow.`,
 	});
 
+	const deactivated = await startPlan({
+		configured: [CUSTOM_TOOL],
+		activeTools: ["read", CUSTOM_TOOL],
+		allTools: [builtinTool("read"), extensionTool(CUSTOM_TOOL)],
+	});
+	await deactivated.mock.events.get("context")?.[0]?.({ messages: [] }, deactivated.context.ctx);
+	deactivated.mock.rawPi.setActiveTools(["read", "plan_mode_question", "plan_mode_complete"]);
+	assert.deepEqual(await callTool(deactivated, CUSTOM_TOOL), {
+		block: true,
+		reason: `Plan mode blocks tool '${CUSTOM_TOOL}' because it was admitted to the active Plan workflow but is currently inactive. Reactivate it to continue without restarting.`,
+	});
+	deactivated.mock.rawPi.setActiveTools([
+		"read",
+		CUSTOM_TOOL,
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
+	assert.equal(await callTool(deactivated, CUSTOM_TOOL), undefined);
+
 	const late = await startPlan({
 		configured: [CUSTOM_TOOL],
 		activeTools: ["read"],
@@ -132,62 +151,64 @@ test("issue 1039: denied tools report inactive, unavailable, frozen, and blocked
 	});
 });
 
-test("issue 1039: reviewed git -C inspections work with fsmonitor disabled", async () => {
+test("issue 1039: reviewed git -C inspections stay in Pi's working directory", async () => {
+	const workingDirectory = process.cwd();
+	const quotedWorkingDirectory = `'${workingDirectory}'`;
 	for (const command of [
-		"git -c core.fsmonitor=false -C /tmp/repository status --short",
-		"git --no-pager -c core.fsmonitor=false -C /tmp/repository log -1 --oneline --no-ext-diff --no-textconv --submodule=short",
-		"git -c core.fsmonitor=false -C packages -C pi-plan-mode diff --check --no-ext-diff --no-textconv --submodule=short",
-		"git -C packages --no-pager -c core.fsmonitor=false status --short",
+		"git -C . status --short",
+		"git --no-pager -C . log -1 --oneline",
+		"git -C . -C . diff --check",
+		`git -C ${quotedWorkingDirectory} status --short`,
 	]) {
-		assert.equal(isSafeCommand(command), true, `Bash: ${command}`);
-		assert.equal(isSafePowerShellCommand(command), true, `PowerShell: ${command}`);
+		assert.equal(isSafeCommand(command, {}, workingDirectory), true, `Bash: ${command}`);
+		assert.equal(
+			isSafePowerShellCommand(command, {}, workingDirectory),
+			true,
+			`PowerShell: ${command}`,
+		);
 	}
-	const configured = "git -c core.fsmonitor=false -C /tmp/repository rev-parse --show-toplevel";
-	assert.equal(isSafeCommand(configured), false);
-	assert.equal(isSafePowerShellCommand(configured), false);
-	assert.equal(isSafeCommand(configured, { git: ["rev-parse"] }), true);
-	assert.equal(isSafePowerShellCommand(configured, { git: ["rev-parse"] }), true);
+	const configured = "git -C . rev-parse --show-toplevel";
+	assert.equal(isSafeCommand(configured, {}, workingDirectory), false);
+	assert.equal(isSafePowerShellCommand(configured, {}, workingDirectory), false);
+	assert.equal(isSafeCommand(configured, { git: ["rev-parse"] }, workingDirectory), true);
+	assert.equal(isSafePowerShellCommand(configured, { git: ["rev-parse"] }, workingDirectory), true);
 
 	const fixture = await startPlan({
 		activeTools: ["bash", "powershell"],
 		allTools: [builtinTool("bash"), builtinTool("powershell")],
 	});
+	assert.equal(await callTool(fixture, "bash", { command: "git -C . status --short" }), undefined);
 	assert.equal(
-		await callTool(fixture, "bash", {
-			command: "git -c core.fsmonitor=false -C /tmp/repository status --short",
-		}),
-		undefined,
-	);
-	assert.equal(
-		await callTool(fixture, "powershell", {
-			command: "git -c core.fsmonitor=false -C 'C:\\repository path' status --short",
-		}),
+		await callTool(fixture, "powershell", { command: "git -C '.' status --short" }),
 		undefined,
 	);
 });
 
-test("issue 1039: git -C remains fail-closed for malformed and unsafe commands", () => {
+test("issue 1039: git -C rejects other repositories and unsafe commands", () => {
+	const workingDirectory = process.cwd();
+	assert.equal(isSafeCommand("git -C . status --short"), false);
+	assert.equal(isSafePowerShellCommand("git -C . status --short"), false);
 	for (const command of [
 		"git -C",
 		"git -C --no-pager status",
 		"git -C /tmp/repository status --short",
-		"git -c core.fsmonitor=false -C /tmp/repository diff --check",
-		"git -c core.fsmonitor=false -C /tmp/repository diff --check --no-ext-diff",
-		"git -c core.fsmonitor=false -C /tmp/repository log -p -1 --no-textconv",
-		"git -c core.fsmonitor=false -C /tmp/repository diff --check --no-ext-diff --no-textconv",
-		"git -c core.fsmonitor=false -C /tmp/repository diff --submodule=diff --no-ext-diff --no-textconv --submodule=short",
-		"git -c core.fsmonitor=false -C /tmp/repository diff --submodule=short -- --no-ext-diff --no-textconv",
-		"git -c core.fsmonitor=false -C /tmp/repository diff --no-ext-diff --no-textconv -- --submodule=short",
-		"git -c core.fsmonitor=true -C /tmp/repository status --short",
-		"git -c alias.status=!touch -C /tmp/repository status",
-		"git -c core.fsmonitor=false -C /tmp/repository checkout main",
-		"git -c core.fsmonitor=false -C /tmp/repository clean -fd",
-		"git -c core.fsmonitor=false -C /tmp/repository --exec-path=/tmp status",
-		"git -c core.fsmonitor=false -C /tmp/repository diff --ext-diff",
-		"git -c core.fsmonitor=false -C /tmp/repository log --show-signature -1",
+		"git -C packages status --short",
+		"git -C packages -C .. status --short",
+		"git -C ./packages/.. status --short",
+		"git -c core.fsmonitor=false -C . status --short",
+		"git -c alias.status=!touch -C . status",
+		"git -C . checkout main",
+		"git -C . clean -fd",
+		"git -C . --exec-path=/tmp status",
+		"git -C . diff --ext-diff",
+		"git -C . log --show-signature -1",
 		"git --git-dir=/tmp/repository status",
 	]) {
-		assert.equal(isSafeCommand(command), false, `Bash: ${command}`);
-		assert.equal(isSafePowerShellCommand(command), false, `PowerShell: ${command}`);
+		assert.equal(isSafeCommand(command, {}, workingDirectory), false, `Bash: ${command}`);
+		assert.equal(
+			isSafePowerShellCommand(command, {}, workingDirectory),
+			false,
+			`PowerShell: ${command}`,
+		);
 	}
 });

--- a/packages/pi-plan-mode/test/issue-1039-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-1039-repro.test.ts
@@ -80,6 +80,26 @@ test("issue 1039: denied tools report inactive, unavailable, frozen, and blocked
 		reason: `Plan mode blocks tool '${CUSTOM_TOOL}' because it was not available when the active Plan workflow froze its tool policy. Exit Plan mode, then start again after the tool is active.`,
 	});
 
+	const lateAutomatic = await startPlan({
+		activeTools: ["read"],
+		allTools: [builtinTool("read"), builtinTool("powershell")],
+	});
+	await lateAutomatic.mock.events.get("context")?.[0]?.(
+		{ messages: [] },
+		lateAutomatic.context.ctx,
+	);
+	lateAutomatic.mock.rawPi.setActiveTools([
+		"read",
+		"powershell",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
+	assert.deepEqual(await callTool(lateAutomatic, "powershell"), {
+		block: true,
+		reason:
+			"Plan mode blocks tool 'powershell' because it was not available when the active Plan workflow froze its tool policy. Exit Plan mode, then start again after the tool is active.",
+	});
+
 	const unavailable = await startPlan({
 		configured: [CUSTOM_TOOL],
 		activeTools: ["read"],
@@ -115,8 +135,8 @@ test("issue 1039: denied tools report inactive, unavailable, frozen, and blocked
 test("issue 1039: reviewed git -C inspections work with fsmonitor disabled", async () => {
 	for (const command of [
 		"git -c core.fsmonitor=false -C /tmp/repository status --short",
-		"git --no-pager -c core.fsmonitor=false -C /tmp/repository log -1 --oneline --no-ext-diff --no-textconv",
-		"git -c core.fsmonitor=false -C packages -C pi-plan-mode diff --check --no-ext-diff --no-textconv",
+		"git --no-pager -c core.fsmonitor=false -C /tmp/repository log -1 --oneline --no-ext-diff --no-textconv --submodule=short",
+		"git -c core.fsmonitor=false -C packages -C pi-plan-mode diff --check --no-ext-diff --no-textconv --submodule=short",
 		"git -C packages --no-pager -c core.fsmonitor=false status --short",
 	]) {
 		assert.equal(isSafeCommand(command), true, `Bash: ${command}`);
@@ -154,6 +174,10 @@ test("issue 1039: git -C remains fail-closed for malformed and unsafe commands",
 		"git -c core.fsmonitor=false -C /tmp/repository diff --check",
 		"git -c core.fsmonitor=false -C /tmp/repository diff --check --no-ext-diff",
 		"git -c core.fsmonitor=false -C /tmp/repository log -p -1 --no-textconv",
+		"git -c core.fsmonitor=false -C /tmp/repository diff --check --no-ext-diff --no-textconv",
+		"git -c core.fsmonitor=false -C /tmp/repository diff --submodule=diff --no-ext-diff --no-textconv --submodule=short",
+		"git -c core.fsmonitor=false -C /tmp/repository diff --submodule=short -- --no-ext-diff --no-textconv",
+		"git -c core.fsmonitor=false -C /tmp/repository diff --no-ext-diff --no-textconv -- --submodule=short",
 		"git -c core.fsmonitor=true -C /tmp/repository status --short",
 		"git -c alias.status=!touch -C /tmp/repository status",
 		"git -c core.fsmonitor=false -C /tmp/repository checkout main",

--- a/packages/pi-plan-mode/test/issue-1039-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-1039-repro.test.ts
@@ -101,17 +101,17 @@ test("issue 1039: denied tools report inactive, unavailable, and blocked policy 
 	});
 });
 
-test("issue 1039: reviewed git -C inspections work in Bash and PowerShell policies", async () => {
+test("issue 1039: reviewed git -C inspections work with fsmonitor disabled", async () => {
 	for (const command of [
-		"git -C /tmp/repository status --short",
-		"git --no-pager -C /tmp/repository log -1 --oneline",
-		"git -C packages -C pi-plan-mode diff --check",
-		"git -C packages --no-pager status --short",
+		"git -c core.fsmonitor=false -C /tmp/repository status --short",
+		"git --no-pager -c core.fsmonitor=false -C /tmp/repository log -1 --oneline",
+		"git -c core.fsmonitor=false -C packages -C pi-plan-mode diff --check",
+		"git -C packages --no-pager -c core.fsmonitor=false status --short",
 	]) {
 		assert.equal(isSafeCommand(command), true, `Bash: ${command}`);
 		assert.equal(isSafePowerShellCommand(command), true, `PowerShell: ${command}`);
 	}
-	const configured = "git -C /tmp/repository rev-parse --show-toplevel";
+	const configured = "git -c core.fsmonitor=false -C /tmp/repository rev-parse --show-toplevel";
 	assert.equal(isSafeCommand(configured), false);
 	assert.equal(isSafePowerShellCommand(configured), false);
 	assert.equal(isSafeCommand(configured, { git: ["rev-parse"] }), true);
@@ -123,13 +123,13 @@ test("issue 1039: reviewed git -C inspections work in Bash and PowerShell polici
 	});
 	assert.equal(
 		await callTool(fixture, "bash", {
-			command: "git -C /tmp/repository status --short",
+			command: "git -c core.fsmonitor=false -C /tmp/repository status --short",
 		}),
 		undefined,
 	);
 	assert.equal(
 		await callTool(fixture, "powershell", {
-			command: "git -C 'C:\\repository path' status --short",
+			command: "git -c core.fsmonitor=false -C 'C:\\repository path' status --short",
 		}),
 		undefined,
 	);
@@ -139,11 +139,14 @@ test("issue 1039: git -C remains fail-closed for malformed and unsafe commands",
 	for (const command of [
 		"git -C",
 		"git -C --no-pager status",
-		"git -C /tmp/repository checkout main",
-		"git -C /tmp/repository clean -fd",
-		"git -C /tmp/repository --exec-path=/tmp status",
-		"git -C /tmp/repository diff --ext-diff",
-		"git -C /tmp/repository log --show-signature -1",
+		"git -C /tmp/repository status --short",
+		"git -c core.fsmonitor=true -C /tmp/repository status --short",
+		"git -c alias.status=!touch -C /tmp/repository status",
+		"git -c core.fsmonitor=false -C /tmp/repository checkout main",
+		"git -c core.fsmonitor=false -C /tmp/repository clean -fd",
+		"git -c core.fsmonitor=false -C /tmp/repository --exec-path=/tmp status",
+		"git -c core.fsmonitor=false -C /tmp/repository diff --ext-diff",
+		"git -c core.fsmonitor=false -C /tmp/repository log --show-signature -1",
 		"git --git-dir=/tmp/repository status",
 	]) {
 		assert.equal(isSafeCommand(command), false, `Bash: ${command}`);

--- a/packages/pi-plan-mode/test/tool-policy.test.ts
+++ b/packages/pi-plan-mode/test/tool-policy.test.ts
@@ -457,7 +457,7 @@ test("active Plan mode blocks update_plan and blocked built-ins at the tool hook
 	assert.deepEqual(blockedBuiltin, {
 		block: true,
 		reason:
-			"Plan mode blocks tool 'danger' because it is unavailable or not selected by the Plan policy.",
+			"Plan mode blocks tool 'danger' because its built-in policy is blocked and settings cannot enable it.",
 	});
 	assert.equal(allowed, undefined);
 	assert.deepEqual(optedInExtension, {


### PR DESCRIPTION
## Summary

- accept reviewed current-working-directory `git -C <path>` forms and `--no-pager` before safe Git subcommands in both limited Bash and PowerShell policies
- distinguish unselected, inactive, unavailable, metadata-free, and built-in-blocked tool denials while directing eligible tools to `/plan tools` or `defaultPlanTools`
- preserve explicit custom-tool opt-in, fixed mutating-tool blocks, stable tool schemas, settings behavior, and workflow lifecycle
- document the behavior and add a patch Changeset

Fixes #1039.

## Verification

- `npx vitest run packages/pi-plan-mode/test/issue-1039-repro.test.ts packages/pi-plan-mode/test/tool-policy.test.ts packages/pi-plan-mode/test/default-tools.test.ts` — 3 files, 26 tests passed
- `npm run check` — build, Biome, boundaries, and all workspace typechecks passed
- `npm test` — 397 files, 3,536 tests passed
- fenced-code-aware README audit — 27 active extension READMEs passed
- `npm run changeset:status` — selected only `@narumitw/pi-plan-mode` for a patch bump; existing unrelated Kit range notices remain
- `just pack plan-mode` — dry-run package contained 39 intended files
- signed pre-commit gate — staged Biome and affected Plan mode typecheck passed

## Risks and unverified paths

- `git -C <path>` is limited to `.` or the exact current Pi working directory so it cannot introduce executable configuration from another repository; trusted-current-repository helper risk remains documented.
- Malformed pairs, other repository targets, traversal forms, unknown global options, config overrides, explicit helpers, and mutating subcommands remain fail-closed in deterministic Bash and PowerShell tests.
- A Pi loader smoke was not run because package entrypoint generation and runtime loading did not change.
- Settings, asynchronous UI, cancellation, disposal, session replacement, and shutdown paths were unchanged and reviewed as not applicable to this synchronous policy hook change.

