### PR TITLE
perf(caffeinate): lazy-load D-Bus support

### DIFF
--- a/.changeset/lazy-dbus-startup.md
+++ b/.changeset/lazy-dbus-startup.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-caffeinate": patch
+---
+
+Lazy-load Linux D-Bus support so other platforms do not load `dbus-native` during Pi startup.

--- a/packages/pi-caffeinate/scripts/build-runtime.mjs
+++ b/packages/pi-caffeinate/scripts/build-runtime.mjs
@@ -23,7 +23,7 @@ const GENERATED_BANNER = [
 	"// @ts-nocheck -- generated JavaScript uses a .ts extension for Pi's Jiti loader.",
 ].join("\n");
 const FORBIDDEN_EAGER_INPUTS = [];
-const FORBIDDEN_EAGER_EXTERNALS = ["@narumitw/pi-tui-kit"];
+const FORBIDDEN_EAGER_EXTERNALS = ["@narumitw/pi-tui-kit", "dbus-native"];
 
 export async function buildRuntime({
 	outputDirectory = distDirectory,

--- a/packages/pi-caffeinate/src/dbus-inhibit.ts
+++ b/packages/pi-caffeinate/src/dbus-inhibit.ts
@@ -1,4 +1,4 @@
-import { type Message, type MessageBus, sessionBus } from "dbus-native";
+import type { Message, MessageBus } from "dbus-native";
 
 export const SCREENSAVER_BUS_NAME = "org.freedesktop.ScreenSaver";
 export const SCREENSAVER_INTERFACE = "org.freedesktop.ScreenSaver";
@@ -20,6 +20,7 @@ export interface DbusScreenSaverClient {
 export type DbusScreenSaverFactory = () => Promise<DbusScreenSaverClient>;
 
 export async function defaultDbusScreenSaverFactory(): Promise<DbusScreenSaverClient> {
+	const { sessionBus } = await import("dbus-native");
 	return new NativeScreenSaverClient(sessionBus());
 }
 

--- a/packages/pi-caffeinate/test/build-runtime.test.ts
+++ b/packages/pi-caffeinate/test/build-runtime.test.ts
@@ -54,6 +54,7 @@ function validMetadata(): BuildMetadata {
 	const entryImports: Array<{ external?: boolean; kind?: string; path: string }> = [
 		{ path: "@earendil-works/pi-coding-agent", kind: "import-statement", external: true },
 		{ path: "@narumitw/pi-tui-kit", kind: "dynamic-import", external: true },
+		{ path: "dbus-native", kind: "dynamic-import", external: true },
 	];
 	const outputs: NonNullable<BuildMetadata["outputs"]> = {
 		"dist/index.ts": {
@@ -84,16 +85,18 @@ test("eager graph validation preserves first-use boundaries and external package
 		);
 	}
 
-	const eagerDependency = validMetadata();
-	const entry = requireOutput(eagerDependency, "dist/index.ts");
-	entry.imports = [
-		...(entry.imports ?? []),
-		{ path: "@narumitw/pi-tui-kit", kind: "import-statement", external: true },
-	];
-	assert.throws(
-		() => builder.validateEagerGraph(eagerDependency),
-		/Eager external dependency: @narumitw\/pi-tui-kit/u,
-	);
+	for (const dependency of ["@narumitw/pi-tui-kit", "dbus-native"]) {
+		const eagerDependency = validMetadata();
+		const entry = requireOutput(eagerDependency, "dist/index.ts");
+		entry.imports = [
+			...(entry.imports ?? []),
+			{ path: dependency, kind: "import-statement", external: true },
+		];
+		assert.throws(
+			() => builder.validateEagerGraph(eagerDependency),
+			new RegExp(`Eager external dependency: ${dependency.replaceAll("/", "\\/")}`, "u"),
+		);
+	}
 
 	const bundledDependency = validMetadata();
 	requireOutput(bundledDependency, "dist/index.ts").inputs = {
@@ -145,6 +148,9 @@ test("runtime builds are deterministic, mapped, external, and remove stale outpu
 		const files = await listFiles(first);
 		assert.ok(files.includes("index.ts"));
 		assert.ok(files.includes("index.ts.map"));
+		const entrySource = await readFile(join(first, "index.ts"), "utf8");
+		assert.match(entrySource, /await import\("dbus-native"\)/u);
+		assert.doesNotMatch(entrySource, /^import .* from "dbus-native";/mu);
 		assert.equal(
 			files.some((path) => path.startsWith("chunks/") && path.endsWith(".js")),
 			forbiddenEagerInputs.length > 0,


### PR DESCRIPTION
## Summary

- Lazy-load `dbus-native` only when Linux display inhibition requests a D-Bus client.
- Reject eager `dbus-native` imports in generated-runtime validation and test the emitted boundary.
- Add a patch Changeset for `@narumitw/pi-caffeinate`.

## Startup samples

Isolated `DefaultResourceLoader` samples changed from 445.0/641.1/597.3 ms to 145.7/22.4/14.6 ms.
A Pi package smoke measured the local generated entry module import at 58 ms.
Timing varies with host and filesystem cache state.

## Verification

- `npx vitest run packages/pi-caffeinate/test/build-runtime.test.ts`
- `npx vitest run packages/pi-caffeinate/test/caffeinate.test.ts`
- `npm --workspace @narumitw/pi-caffeinate run check`
- `npm run check`
- `just pack caffeinate`
- `PI_CAFFEINATE_DISABLED=1 pi -e ./packages/pi-caffeinate -p --no-session '/caffeinate status'`

The full `npm test` run was attempted separately but timed out after 300 seconds with unrelated failures in `pi-subagents` and `pi-sync`; both focused `pi-caffeinate` test files passed.
