### PR TITLE
feat(subagents): warn about 3.0 migration

### DIFF
--- a/.changeset/warn-subagents-v3-migration.md
+++ b/.changeset/warn-subagents-v3-migration.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": patch
+---
+
+Warn once when Pi loads the extension that version 3.0.0 will adopt the bounded-job runtime and list the major features and tool APIs that will be removed.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -8,6 +8,11 @@ Use the built-in `explorer` for read-only evidence and `worker` for a clearly ow
 
 The compatibility default exposes background and blocking methods, while **Keep Pi available (async)** is an optional smaller background-only surface.
 
+> [!WARNING]
+> `@narumitw/pi-subagents` 3.0.0 will replace this implementation with the bounded-job runtime currently developed as `pi-subagents-v3`.
+> The release will remove `/subagents`, extension settings, local usage recording, the current `subagent` and underscore-named tool APIs, custom agent catalogs and per-agent configuration, retained conversations and messaging, persisted recovery, auto-resume completion, advanced orchestration and verification, alternate transports, trust-aware cwd policy, and extension-owned worktree isolation.
+> It will instead expose `subagent-spawn`, `subagent-inspect`, `subagent-cancel`, `subagent-wait`, and `subagent-reply` for bounded background jobs.
+
 ## ✨ Features
 
 - Provides blocking batches, detached reusable agents, read-only consultation, metadata inspection, and queue-only mailboxes.

--- a/packages/pi-subagents/src/subagents-extension.ts
+++ b/packages/pi-subagents/src/subagents-extension.ts
@@ -73,6 +73,18 @@ export interface SubagentsDependencies {
 	usageRecording?: Partial<UsageRecordingDependencies>;
 }
 
+const VERSION_3_MIGRATION_WARNING = [
+	"pi-subagents 3.0.0 will replace this runtime with the bounded-job design currently developed as pi-subagents-v3.",
+	"The release will remove:",
+	"• /subagents, extension settings, and local usage recording;",
+	"• the current subagent tool and underscore-named lifecycle and consultation tools;",
+	"• custom agent catalogs, per-agent model settings, and custom agent prompts;",
+	"• retained conversations, follow-up turns, mailboxes, peer and nested messaging, persisted recovery, and auto-resume completion;",
+	"• chains, fan-in, panels, workflow DAGs, dynamic scheduling, structured result contracts, and verification orchestration;",
+	"• alternate transports, trust-aware cwd policy, and extension-owned worktree isolation.",
+	"3.0.0 will instead expose subagent-spawn, subagent-inspect, subagent-cancel, subagent-wait, and subagent-reply for bounded background jobs.",
+].join("\n");
+
 export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies = {}) {
 	pi.registerMessageRenderer(SUBAGENT_COMPLETION_MESSAGE_TYPE, renderCompletionMessage);
 	const loadBlockingExecution = cachedModuleLoader(
@@ -83,6 +95,7 @@ export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies =
 	const settings = readSubagentSettings();
 	let currentSettings: SubagentSettings | undefined = settings;
 	let currentCatalog = "";
+	let migrationWarningShown = false;
 	const blockingEnabled = settings?.blocking?.enabled !== false;
 	const statefulEnabled = settings?.stateful?.enabled !== false;
 	if (blockingEnabled) {
@@ -100,6 +113,10 @@ export default function (pi: ExtensionAPI, dependencies: SubagentsDependencies =
 			...new Set([loadNotice, refreshedNotice].filter((value) => value !== undefined)),
 		].join("\n");
 		if (notice) ctx.ui.notify(notice, "warning");
+		if (ctx.hasUI && !migrationWarningShown) {
+			migrationWarningShown = true;
+			ctx.ui.notify(VERSION_3_MIGRATION_WARNING, "warning");
+		}
 
 		currentCatalog = formatAgentCatalog(
 			discoverAgentCatalog(ctx.cwd, ctx.isProjectTrusted(), refreshedSettings),

--- a/packages/pi-subagents/test/subagents-manager-ui.test.ts
+++ b/packages/pi-subagents/test/subagents-manager-ui.test.ts
@@ -74,7 +74,8 @@ test("bare subagents opens a current-session manager and keeps direct routes pre
 		assert.match(managerText, /Diagnostics/);
 		assert.match(managerText, /Help/);
 		assert.doesNotMatch(managerText, /Consult resources:|Settings: \/|Transport:/);
-		assert.equal(managerContext.notifications.length, 0);
+		assert.equal(managerContext.notifications.length, 1);
+		assert.match(managerContext.notifications[0]?.message ?? "", /pi-subagents 3\.0\.0/i);
 
 		let nestedCall = 0;
 		const nestedRenders: string[][] = [];

--- a/packages/pi-subagents/test/subagents-registration.test.ts
+++ b/packages/pi-subagents/test/subagents-registration.test.ts
@@ -142,6 +142,50 @@ test("subagents registers consistent blocking guidance and one management comman
 	);
 });
 
+test("subagents warns once per loaded runtime about the 3.0.0 removals", async () => {
+	const mock = createMockPi();
+	subagents(mock.pi);
+	const headless = createMockContext({ mode: "print", hasUI: false });
+	for (const handler of mock.events.get("session_start") ?? []) {
+		await handler({ reason: "new" }, headless.ctx);
+	}
+	assert.deepEqual(headless.notifications, []);
+
+	const tui = createMockContext({ mode: "tui", hasUI: true });
+	for (const handler of mock.events.get("session_start") ?? []) {
+		await handler({ reason: "fork" }, tui.ctx);
+	}
+	const warnings = tui.notifications.filter((notification) =>
+		notification.message.includes("pi-subagents 3.0.0"),
+	);
+	assert.equal(warnings.length, 1);
+	assert.equal(warnings[0]?.level, "warning");
+	for (const expected of [
+		"/subagents",
+		"underscore-named",
+		"custom agent catalogs",
+		"retained conversations",
+		"workflow DAGs",
+		"trust-aware cwd policy",
+		"subagent-spawn",
+		"subagent-reply",
+	]) {
+		assert.match(warnings[0]?.message ?? "", new RegExp(expected, "i"));
+	}
+
+	for (const handler of mock.events.get("session_start") ?? []) {
+		await handler({ reason: "resume" }, tui.ctx);
+	}
+	assert.equal(
+		tui.notifications.filter((notification) => notification.message.includes("pi-subagents 3.0.0"))
+			.length,
+		1,
+	);
+	for (const handler of mock.events.get("session_shutdown") ?? []) {
+		await handler({ reason: "quit" }, tui.ctx);
+	}
+});
+
 test("deprecated blocking subagent warns once per UI session without changing execution", async () => {
 	const result = {
 		content: [{ type: "text" as const, text: "LEGACY_RESULT" }],
@@ -187,8 +231,20 @@ test("deprecated blocking subagent warns once per UI session without changing ex
 	for (const handler of mock.events.get("session_start") ?? []) {
 		await handler({ reason: "new" }, context.ctx);
 	}
+	assert.equal(
+		context.notifications.filter((notification) =>
+			notification.message.includes("pi-subagents 3.0.0"),
+		).length,
+		1,
+	);
 	assert.deepEqual(await execute(), result);
-	assert.equal(context.notifications.length, 2, "a replacement session receives one new warning");
+	assert.equal(
+		context.notifications.filter((notification) =>
+			/subagent is deprecated/i.test(notification.message),
+		).length,
+		2,
+		"a replacement session receives one new tool warning",
+	);
 	for (const handler of mock.events.get("session_shutdown") ?? []) {
 		await handler({ reason: "quit" }, context.ctx);
 	}


### PR DESCRIPTION
## Summary

- warn once per loaded `pi-subagents` runtime that version 3.0.0 will adopt the bounded-job design
- list the major tools, retained-agent features, orchestration, settings, transports, and safety policies that will be removed
- document the migration warning and the five replacement bounded-job tools
- add lifecycle and mode coverage plus a patch changeset for the pre-3.0 warning release

## Verification

- `npm run check`
- `npm test` — 398 files, 3549 tests
- `just pack subagents`
- README heading audit — 28 package READMEs
- `PI_OFFLINE=1 pi --mode rpc --no-session --no-extensions -e ./packages/pi-subagents` with `get_state` — generated runtime loaded and emitted the 3.0.0 warning

## Semantic audits

- lifecycle and session replacement: no resources or asynchronous work added
- non-interactive behavior: warning is limited to observable TUI/RPC UI contexts
- settings and prompt-cache behavior: no persistence, precedence, model-visible context, or tool-definition changes
