### PR TITLE
feat(starship): add module-local theme, model color, and provider alias behaviors

### DIFF
--- a/.changeset/starship-appearance.md
+++ b/.changeset/starship-appearance.md
@@ -1,0 +1,9 @@
+---
+"@narumitw/pi-starship": minor
+---
+
+Add module-local appearance behaviors, all preserved through the existing settings document:
+
+- `thinking` now follows the current native Pi theme's per-level colors (`style_off` through `style_max` stay available as explicit overrides); the legacy `style` field remains the fallback for unknown levels.
+- `model` renders a deterministic per-model hash color (same-series models share a hue; distinct models differ) while `[model] style` has no explicit color. `[model] model_styles` maps exact ids or prefixes to explicit styles, and `[model] hash_colors = false` restores the configured style color.
+- `[provider] provider_aliases` shortens provider names.

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -265,6 +265,16 @@ An invalid root format falls back to the built-in root format; an invalid module
 The background-free direct defaults are: `brand = "bold white"`, `provider`/`model` = `"bold blue"`, `thinking`/`git_branch`/`turn` = `"bold purple"`, `directory`/`git_worktree` = `"cyan bold"`, `github_pr = "bold blue"`, `git_commit = "green bold"`, `git_state`/`activity`/`time` = `"bold yellow"`, `git_status = "red bold"`, `tokens = "bold cyan"`, `cache = "bold green"`, `extension_status = "dimmed white"`, `direnv = "bold bright-yellow"`, and `fill = "bold black"`.
 Context, cost, Git metrics, and username use the state/multi-style defaults below.
 
+### Theme-following and deterministic colors
+
+`thinking` colors follow the current native Pi theme by default: each level (`style_off`, `style_minimal`, `style_low`, `style_medium`, `style_high`, `style_xhigh`, `style_max`) maps to the theme's thinking role color, matching the built-in thinking indicator.
+Without theme colors (headless renders) the built-in dark gradient applies.
+Any configured `style_*` field overrides the theme color for that level, and the legacy `style` field is only the fallback for unknown levels.
+
+`model` renders a deterministic per-model hash color: every model in a series (the id without its `-YYYYMMDD` or `-latest` suffix) shares one hue, while the full id nudges saturation and lightness so distinct models differ slightly.
+The hash replaces only the color of the module style, keeping its modifiers: the built-in default and modifier-only styles (`bold`, `italic`) receive the hash color, while an explicit color in `style` or a matching `model_styles` entry stays fully user-controlled.
+Set `hash_colors = false` to keep the configured style color for models without a `model_styles` match.
+
 ### State-selected styles
 
 `context` and `cost` select the last entry at the highest threshold less than or equal to the current value.
@@ -440,6 +450,20 @@ When no alias matches, truncation runs after the built-in Claude/GPT shortening 
 It always changes display only—the provider model ID is untouched.
 Terminal control sequences in model IDs and truncation symbols are removed at render time.
 An empty symbol truncates without a marker.
+`model_styles` maps model ids (or shared prefixes) to explicit styles; an exact id wins, then the longest matching prefix, otherwise the deterministic hash color applies:
+
+```toml
+[model]
+model_styles = { "claude-" = "bold orange", "claude-3-7-sonnet-20250219" = "bold red" }
+```
+
+Invalid style values in `model_styles` are rejected with a warning and ignored.
+The provider module accepts exact `provider_aliases` to shorten provider names:
+
+```toml
+[provider]
+provider_aliases = { "openai-codex" = "codex" }
+```
 For example, `middle` can retain both a Hugging Face model family and its variant, while `start` is useful when a llama.cpp server reports an absolute model path.
 pi-starship treats model IDs as opaque strings and does not parse paths, repositories, GGUF suffixes, or quantization names.
 

--- a/packages/pi-starship/src/config.ts
+++ b/packages/pi-starship/src/config.ts
@@ -302,6 +302,9 @@ function normalizeModule(
 	const known = new Set(["format", "symbol", "disabled", ...Object.keys(optionSchemas)]);
 	if (definition.styleDefaults) {
 		for (const field of Object.keys(definition.styleDefaults)) known.add(field);
+		// Modules whose styles resolve through the style variable still accept the
+		// legacy style field as their fallback style.
+		if (definition.styleVariables?.includes("style")) known.add("style");
 	} else if (!definition.displayDefaults) known.add("style");
 	if (definition.displayDefaults) known.add("display");
 	if (name === "extension_status") {
@@ -336,6 +339,11 @@ function normalizeModule(
 			diagnostics.push(typeDiagnostic(`${name}.symbol`, "string"));
 		} else module.symbol = value.symbol;
 	}
+	if (definition.styleDefaults && value.style !== undefined) {
+		if (typeof value.style !== "string") {
+			diagnostics.push(typeDiagnostic(`${name}.style`, "string"));
+		} else module.style = value.style;
+	}
 	if (definition.styleDefaults) {
 		for (const field of Object.keys(definition.styleDefaults)) {
 			if (value[field] === undefined) continue;
@@ -364,7 +372,7 @@ function normalizeModule(
 	}
 	for (const [key, schema] of Object.entries(optionSchemas)) {
 		if (value[key] === undefined) continue;
-		const normalized = normalizeModuleOption(value[key], schema);
+		const normalized = normalizeModuleOption(value[key], schema, activePalette(config));
 		if (normalized.ok) module.options[key] = normalized.value;
 		else diagnostics.push(diagnostic("warning", `${name}.${key}`, normalized.message));
 	}
@@ -680,6 +688,7 @@ function validateLiteralStyles(
 function normalizeModuleOption(
 	value: unknown,
 	schema: ModuleOptionSchema,
+	palette: ColorPalette = {},
 ): { ok: true; value: ModuleOptionValue } | { ok: false; message: string } {
 	switch (schema.kind) {
 		case "string":
@@ -730,6 +739,21 @@ function normalizeModuleOption(
 			}
 			const result: Record<string, string> = {};
 			for (const [key, item] of Object.entries(value)) setOwn(result, key, item as string);
+			return { ok: true, value: result };
+		}
+		case "style-map": {
+			if (!isRecord(value) || Object.values(value).some((item) => typeof item !== "string")) {
+				return { ok: false, message: "Expected a table of style strings; using the default value" };
+			}
+			const result: Record<string, string> = {};
+			for (const [key, item] of Object.entries(value)) {
+				if (isValidStyle(item as string, palette)) setOwn(result, key, item as string);
+				else
+					return {
+						ok: false,
+						message: `Invalid style ${JSON.stringify(item)}; using the default value`,
+					};
+			}
 			return { ok: true, value: result };
 		}
 	}

--- a/packages/pi-starship/src/modules/model-color.ts
+++ b/packages/pi-starship/src/modules/model-color.ts
@@ -1,0 +1,59 @@
+/**
+ * Deterministic model colors: the model series (id without date/latest suffixes)
+ * selects a stable hue so every model in a family shares a main color, while the
+ * full id hash nudges saturation and lightness so distinct models differ slightly.
+ */
+
+const DATE_SUFFIX = /-\d{8}$/u;
+const LATEST_SUFFIX = /-latest$/u;
+
+export function seriesOf(modelId: string): string {
+	return modelId.replace(DATE_SUFFIX, "").replace(LATEST_SUFFIX, "");
+}
+
+export function fnv1a(value: string): number {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < value.length; index += 1) {
+		hash ^= value.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return hash >>> 0;
+}
+
+export function modelColorHex(modelId: string): string {
+	const idHash = fnv1a(modelId);
+	const saturation = 0.55 + ((idHash % 17) - 8) / 100;
+	const lightness = 0.5 + (((idHash >>> 8) % 13) - 6) / 100;
+	return hslToHex(modelHue(modelId), saturation, lightness);
+}
+
+export function modelHue(modelId: string): number {
+	return fnv1a(seriesOf(modelId)) % 360;
+}
+
+export function hslToHex(hue: number, saturation: number, lightness: number): string {
+	const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+	const sector = (((hue % 360) + 360) % 360) / 60;
+	const intermediate = chroma * (1 - Math.abs((sector % 2) - 1));
+	const [red, green, blue] = colorComponents(sector, chroma, intermediate);
+	const match = lightness - chroma / 2;
+	return `#${hexByte(red + match)}${hexByte(green + match)}${hexByte(blue + match)}`;
+}
+
+function colorComponents(
+	sector: number,
+	chroma: number,
+	intermediate: number,
+): [number, number, number] {
+	if (sector < 1) return [chroma, intermediate, 0];
+	if (sector < 2) return [intermediate, chroma, 0];
+	if (sector < 3) return [0, chroma, intermediate];
+	if (sector < 4) return [0, intermediate, chroma];
+	if (sector < 5) return [intermediate, 0, chroma];
+	return [chroma, 0, intermediate];
+}
+
+function hexByte(value: number): string {
+	const clamped = Math.max(0, Math.min(255, Math.round(value * 255)));
+	return clamped.toString(16).padStart(2, "0");
+}

--- a/packages/pi-starship/src/modules/model.ts
+++ b/packages/pi-starship/src/modules/model.ts
@@ -1,5 +1,7 @@
 import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
-import { defineModule } from "./types.js";
+import { parseColor } from "../format/style.js";
+import { modelColorHex } from "./model-color.js";
+import { defineModule, type ModuleOptionValue } from "./types.js";
 
 const TRUNCATION_DIRECTIONS = ["start", "middle", "end"] as const;
 type TruncationDirection = (typeof TRUNCATION_DIRECTIONS)[number];
@@ -23,6 +25,33 @@ export const modelModule = defineModule({
 			values: TRUNCATION_DIRECTIONS,
 		},
 		model_aliases: { kind: "string-map", default: {} },
+		model_styles: { kind: "style-map", default: {} },
+		hash_colors: { kind: "boolean", default: true },
+	},
+	styleVariables: ["style"],
+	resolveStyleVariables: ({ runtime, style, options }) => {
+		const id = runtime.model?.id;
+		if (!id) return { style };
+		const map = styleMapOption(options, "model_styles");
+		const exact = map[id];
+		if (exact) return { style: exact };
+		let longest: string | undefined;
+		let longestLength = 0;
+		for (const [key, value] of Object.entries(map)) {
+			if (key.length > longestLength && id.startsWith(key)) {
+				longest = value;
+				longestLength = key.length;
+			}
+		}
+		if (longest) return { style: longest };
+		if (options.hash_colors === false) return { style };
+		// Hash coloring applies when the style has no explicit color: the built-in
+		// default and modifier-only styles keep their modifiers while the hash
+		// supplies the color; an explicit color stays fully user-controlled.
+		if (style === DEFAULT_MODEL_STYLE || !hasExplicitColor(style)) {
+			return { style: hashModelStyle(id, style) };
+		}
+		return { style };
 	},
 	values: ({ runtime, options }) => {
 		if (!runtime.model) return undefined;
@@ -82,4 +111,36 @@ export function shortenModel(model: string): string {
 		.replace(/^gpt-/u, "gpt ")
 		.replace(/-20\d{6}$/u, "")
 		.replace(/-latest$/u, "");
+}
+
+const DEFAULT_MODEL_STYLE = "bold blue";
+
+function styleMapOption(
+	options: Readonly<Record<string, ModuleOptionValue>>,
+	name: string,
+): Readonly<Record<string, string>> {
+	const value = options[name];
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Readonly<Record<string, string>>)
+		: {};
+}
+
+/** Replace the color of the module style with the deterministic model hash color. */
+export function hashModelStyle(modelId: string, baseStyle: string): string {
+	const modifiers = baseStyle
+		.split(/\s+/u)
+		.filter(Boolean)
+		.filter((token) => token !== "none" && !parseColor(token));
+	return [...modifiers, modelColorHex(modelId)].join(" ");
+}
+
+function hasExplicitColor(style: string): boolean {
+	return style
+		.split(/\s+/u)
+		.filter(Boolean)
+		.some((token) => {
+			if (token === "none") return false;
+			const normalized = token.replace(/^(?:fg:|bg:)+/u, "");
+			return parseColor(normalized) !== undefined;
+		});
 }

--- a/packages/pi-starship/src/modules/provider.ts
+++ b/packages/pi-starship/src/modules/provider.ts
@@ -1,5 +1,7 @@
 import { defineModule } from "./types.js";
 
+const PROVIDER_ALIASES_KEY = "provider_aliases";
+
 export const providerModule = defineModule({
 	name: "provider",
 	variables: ["symbol", "provider"],
@@ -9,5 +11,20 @@ export const providerModule = defineModule({
 		style: "bold blue",
 		disabled: false,
 	},
-	values: ({ runtime }) => (runtime.model ? { provider: runtime.model.provider } : undefined),
+	options: {
+		[PROVIDER_ALIASES_KEY]: { kind: "string-map", default: {} },
+	},
+	values: ({ runtime, options }) => {
+		if (!runtime.model) return undefined;
+		const aliases = options[PROVIDER_ALIASES_KEY];
+		const aliasMap =
+			aliases && typeof aliases === "object" && !Array.isArray(aliases)
+				? (aliases as Readonly<Record<string, string>>)
+				: undefined;
+		const alias =
+			aliasMap && Object.hasOwn(aliasMap, runtime.model.provider)
+				? aliasMap[runtime.model.provider]
+				: undefined;
+		return { provider: alias ?? runtime.model.provider };
+	},
 });

--- a/packages/pi-starship/src/modules/render.ts
+++ b/packages/pi-starship/src/modules/render.ts
@@ -33,6 +33,7 @@ export function renderStatusline(
 					values,
 					style: module.style,
 					styles: module.styles,
+					options: module.options,
 					display: module.display,
 				})
 			: { style: module.style };

--- a/packages/pi-starship/src/modules/thinking.ts
+++ b/packages/pi-starship/src/modules/thinking.ts
@@ -1,4 +1,24 @@
+import type { ColorSpec } from "../format/style.js";
 import { defineModule } from "./types.js";
+
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+type ThinkingLevel = (typeof THINKING_LEVELS)[number];
+
+function thinkingLevelOf(value: string): ThinkingLevel | undefined {
+	return THINKING_LEVELS.find((level) => level === value);
+}
+
+/** Built-in dark-theme gradient fallback for headless or unknown-theme renders. */
+const DARK_LEVEL_STYLES: Readonly<Record<ThinkingLevel, string>> = {
+	off: "bold #505050",
+	minimal: "bold #6e6e6e",
+	low: "bold #5f87af",
+	medium: "bold #81a2be",
+	high: "bold #b294bb",
+	xhigh: "bold #d183e8",
+	max: "bold #ff5fff",
+};
 
 export const thinkingModule = defineModule({
 	name: "thinking",
@@ -9,5 +29,35 @@ export const thinkingModule = defineModule({
 		style: "bold purple",
 		disabled: false,
 	},
+	// Empty defaults mean "follow the current native TUI theme"; the built-in
+	// dark gradient remains a fallback when no theme colors are available.
+	styleDefaults: Object.fromEntries(
+		THINKING_LEVELS.map((level) => [`style_${level}`, ""]),
+	) as Record<`style_${ThinkingLevel}`, string>,
+	styleVariables: ["style"],
+	resolveStyleVariables: ({ runtime, styles, style }) => {
+		const level = thinkingLevelOf(runtime.thinkingLevel);
+		if (!level) return { style };
+		const customized = styles[`style_${level}`];
+		if (customized) return { style: customized };
+		const themed = runtime.thinkingTheme?.[level];
+		if (themed) return { style: colorSpecToStyleString(themed) };
+		return { style: DARK_LEVEL_STYLES[level] ?? style };
+	},
 	values: ({ runtime }) => ({ level: runtime.thinkingLevel }),
 });
+
+export function colorSpecToStyleString(spec: ColorSpec): string {
+	switch (spec.kind) {
+		case "named":
+			return spec.name;
+		case "fixed":
+			return `${spec.value}`;
+		case "rgb":
+			return `#${byteHex(spec.red)}${byteHex(spec.green)}${byteHex(spec.blue)}`;
+	}
+}
+
+function byteHex(value: number): string {
+	return value.toString(16).padStart(2, "0");
+}

--- a/packages/pi-starship/src/modules/types.ts
+++ b/packages/pi-starship/src/modules/types.ts
@@ -1,4 +1,4 @@
-import type { StyledChunk } from "../format/style.js";
+import type { ColorSpec, StyledChunk } from "../format/style.js";
 
 export interface GitBranchSnapshot {
 	name: string;
@@ -83,6 +83,8 @@ export interface StarshipRuntimeSnapshot {
 	gitRoot?: string;
 	model?: { provider: string; id: string };
 	thinkingLevel: string;
+	/** Native TUI thinking-role colors for the current theme, level keyed. */
+	thinkingTheme?: Readonly<Record<string, ColorSpec>>;
 	turnCount: number;
 	activeTools: ReadonlyMap<string, number>;
 	isStreaming: boolean;
@@ -140,7 +142,8 @@ export type ModuleOptionSchema =
 	| { kind: "boolean"; default: boolean }
 	| { kind: "integer"; default: number; minimum: number; maximum: number }
 	| { kind: "string-array"; default: readonly string[]; allowNegative?: boolean }
-	| { kind: "string-map"; default: Readonly<Record<string, string>> };
+	| { kind: "string-map"; default: Readonly<Record<string, string>> }
+	| { kind: "style-map"; default: Readonly<Record<string, string>> };
 
 export interface ModuleDisplayConfig {
 	threshold: number;
@@ -160,6 +163,7 @@ export interface ModuleStyleContext {
 	values: Readonly<Record<string, string>>;
 	style: string;
 	styles: Readonly<Record<string, string>>;
+	options: Readonly<Record<string, ModuleOptionValue>>;
 	display: readonly ModuleDisplayConfig[];
 }
 

--- a/packages/pi-starship/src/pi-starship.ts
+++ b/packages/pi-starship/src/pi-starship.ts
@@ -14,6 +14,7 @@ import {
 	type StarshipConfig,
 	settingsFilePath,
 } from "./config.js";
+import type { ColorSpec } from "./format/style.js";
 import { gitSnapshotEqual, readGitSnapshot } from "./modules/git/runtime.js";
 import {
 	type GithubPrSnapshot,
@@ -58,6 +59,7 @@ interface RuntimeState {
 	activeTools: Map<string, number>;
 	isStreaming: boolean;
 	thinkingLevel: string;
+	thinkingTheme?: Record<string, ColorSpec>;
 	lastCompletedTool?: string;
 	git?: GitSnapshot;
 	githubPr?: GithubPrSnapshot;
@@ -264,6 +266,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 		stopGithubPr();
 		runtime.git = undefined;
 		runtime.workspace = undefined;
+		runtime.thinkingTheme = undefined;
 		runtime.requestRender = undefined;
 		runtime.renderPreview = undefined;
 		runtime.inspect = undefined;
@@ -275,7 +278,8 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 		workspaceController.start(generation);
 		startGithubPr(target);
 
-		ctx.ui.setFooter((tui, _theme, footerData) => {
+		ctx.ui.setFooter((tui, theme, footerData) => {
+			runtime.thinkingTheme = thinkingThemeFrom(theme);
 			runtime.requestRender = () => tui.requestRender();
 			runtime.renderPreview = (preview, width) => {
 				const snapshot = runtimeSnapshot(ctx, footerData, runtime);
@@ -322,6 +326,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 						stopGithubPr();
 						runtime.git = undefined;
 						runtime.workspace = undefined;
+						runtime.thinkingTheme = undefined;
 						runtime.requestRender = undefined;
 						runtime.renderPreview = undefined;
 						runtime.inspect = undefined;
@@ -428,6 +433,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 		stopGithubPr();
 		runtime.git = undefined;
 		runtime.workspace = undefined;
+		runtime.thinkingTheme = undefined;
 		runtime.requestRender = undefined;
 		runtime.renderPreview = undefined;
 		runtime.inspect = undefined;
@@ -565,6 +571,7 @@ function runtimeSnapshot(
 		gitRoot: runtime.git?.root,
 		model: ctx.model ? { provider: ctx.model.provider, id: ctx.model.id } : undefined,
 		thinkingLevel: runtime.thinkingLevel,
+		thinkingTheme: runtime.thinkingTheme,
 		turnCount: userTurnCount(ctx),
 		activeTools: runtime.activeTools,
 		isStreaming: runtime.isStreaming,
@@ -612,6 +619,50 @@ function formatDiagnostics(loaded: LoadedStarshipConfig): string {
 export function wrapFormattedStatusline(format: string, width: number): string[] {
 	if (width <= 0) return [];
 	return wrapTextWithAnsi(format, width);
+}
+
+const THINKING_THEME_ROLES = [
+	["off", "thinkingOff"],
+	["minimal", "thinkingMinimal"],
+	["low", "thinkingLow"],
+	["medium", "thinkingMedium"],
+	["high", "thinkingHigh"],
+	["xhigh", "thinkingXhigh"],
+	["max", "thinkingMax"],
+] as const;
+
+export interface ThinkingThemeSource {
+	getFgAnsi(color: string): string;
+}
+
+/** Extract the native TUI thinking colors so the footer matches the theme. */
+export function thinkingThemeFrom(
+	source: ThinkingThemeSource | undefined,
+): Record<string, ColorSpec> | undefined {
+	if (!source || typeof source.getFgAnsi !== "function") return undefined;
+	const colors: Record<string, ColorSpec> = {};
+	for (const [level, role] of THINKING_THEME_ROLES) {
+		const spec = ansiToColorSpec(source.getFgAnsi(role));
+		if (spec) colors[level] = spec;
+	}
+	return Object.keys(colors).length > 0 ? colors : undefined;
+}
+
+export function ansiToColorSpec(prefix: string): ColorSpec | undefined {
+	const escapeCharacter = String.fromCharCode(27);
+	const fixed = new RegExp(`^${escapeCharacter}\\[38;5;(\\d{1,3})m$`, "u").exec(prefix);
+	if (fixed) {
+		const value = Number(fixed[1]);
+		return value <= 255 ? { kind: "fixed", value } : undefined;
+	}
+	const rgb = new RegExp(`^${escapeCharacter}\\[38;2;(\\d{1,3});(\\d{1,3});(\\d{1,3})m$`, "u").exec(
+		prefix,
+	);
+	if (rgb) {
+		const [red, green, blue] = [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])];
+		if (red <= 255 && green <= 255 && blue <= 255) return { kind: "rgb", red, green, blue };
+	}
+	return undefined;
 }
 
 export {

--- a/packages/pi-starship/test/command-configuration.test.ts
+++ b/packages/pi-starship/test/command-configuration.test.ts
@@ -34,7 +34,7 @@ test("Configuration exposes four focused screens under seven top-level goals", a
 			apply() {},
 			settingsPath: path,
 		});
-		const tui = createTuiHarness({ width: 64, rows: 18 });
+		const tui = createTuiHarness({ width: 64, rows: 21 });
 		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 		const running = mock.commands.get("starship")?.handler("", context.ctx);
 		await tui.waitForOpen();

--- a/packages/pi-starship/test/config.test.ts
+++ b/packages/pi-starship/test/config.test.ts
@@ -325,6 +325,8 @@ test("model truncation options normalize values and reject invalid directions in
 		truncation_symbol: "…",
 		truncation_direction: "end",
 		model_aliases: {},
+		model_styles: {},
+		hash_colors: true,
 	});
 
 	const valid = loadFromText(
@@ -335,6 +337,8 @@ test("model truncation options normalize values and reject invalid directions in
 		truncation_symbol: "",
 		truncation_direction: "middle",
 		model_aliases: { raw: "short" },
+		model_styles: {},
+		hash_colors: true,
 	});
 	assert.deepEqual(valid.diagnostics, []);
 
@@ -346,6 +350,8 @@ test("model truncation options normalize values and reject invalid directions in
 		truncation_symbol: "…",
 		truncation_direction: "end",
 		model_aliases: {},
+		model_styles: {},
+		hash_colors: true,
 	});
 	assert.deepEqual(
 		invalid.diagnostics.map((item) => item.path),

--- a/packages/pi-starship/test/model-color.test.ts
+++ b/packages/pi-starship/test/model-color.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { hashModelStyle } from "../src/modules/model.js";
+import { fnv1a, hslToHex, modelColorHex, modelHue, seriesOf } from "../src/modules/model-color.js";
+
+test("seriesOf strips date and latest suffixes", () => {
+	assert.equal(seriesOf("claude-3-7-sonnet-20250219"), "claude-3-7-sonnet");
+	assert.equal(seriesOf("gpt-5-codex-20250501"), "gpt-5-codex");
+	assert.equal(seriesOf("claude-sonnet-4-latest"), "claude-sonnet-4");
+	assert.equal(seriesOf("gemini-2.5-pro"), "gemini-2.5-pro");
+});
+
+test("fnv1a is deterministic and bounded to 32 bits", () => {
+	const first = fnv1a("claude-3-7-sonnet-20250219");
+	assert.equal(first, fnv1a("claude-3-7-sonnet-20250219"));
+	assert.ok(first >= 0 && first <= 0xffffffff);
+	assert.notEqual(first, fnv1a("claude-3-7-sonnet-20250220"));
+});
+
+test("models in the same series share the same hue", () => {
+	assert.equal(modelHue("claude-3-7-sonnet-20250219"), modelHue("claude-3-7-sonnet-20250501"));
+	assert.equal(modelHue("claude-3-5-sonnet-20241022"), modelHue("claude-3-5-sonnet-latest"));
+	assert.notEqual(modelHue("claude-3-7-sonnet-20250219"), modelHue("claude-3-5-sonnet-20241022"));
+	assert.notEqual(modelHue("claude-3-7-sonnet-20250219"), modelHue("gpt-5.6-sol"));
+});
+
+test("distinct models in a series differ in their final hex color", () => {
+	const first = modelColorHex("claude-3-5-sonnet-20241022");
+	const second = modelColorHex("claude-3-5-sonnet-20250414");
+	assert.match(first, /^#[0-9a-f]{6}$/u);
+	assert.match(second, /^#[0-9a-f]{6}$/u);
+	assert.notEqual(first, second);
+	assert.equal(modelColorHex("claude-3-5-sonnet-20241022"), first);
+});
+
+test("hslToHex converts through the valid color space", () => {
+	assert.equal(hslToHex(0, 0, 0), "#000000");
+	assert.equal(hslToHex(0, 1, 0.5), "#ff0000");
+	assert.equal(hslToHex(240, 1, 0.5), "#0000ff");
+	assert.equal(hslToHex(120, 1, 0.5), "#00ff00");
+	assert.equal(hslToHex(0, 0, 1), "#ffffff");
+	assert.equal(hslToHex(360, 0.5, 0.5), hslToHex(0, 0.5, 0.5));
+});
+
+test("hashModelStyle keeps modifiers and replaces the color", () => {
+	assert.match(hashModelStyle("claude-sonnet-4", "bold blue"), /^bold #[0-9a-f]{6}$/u);
+	assert.match(
+		hashModelStyle("gpt-5.6", "italic underline cyan"),
+		/^italic underline #[0-9a-f]{6}$/u,
+	);
+	assert.equal(hashModelStyle("x", "none"), hashModelStyle("x", ""));
+});

--- a/packages/pi-starship/test/thinking-theme.test.ts
+++ b/packages/pi-starship/test/thinking-theme.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { normalizeConfig } from "../src/config.js";
+import { renderStatusline } from "../src/modules/index.js";
+import type { StarshipRuntimeSnapshot } from "../src/modules/types.js";
+import { ansiToColorSpec } from "../src/pi-starship.js";
+
+const ESC = String.fromCharCode(27);
+
+function fixture(overrides: Partial<StarshipRuntimeSnapshot> = {}): StarshipRuntimeSnapshot {
+	return {
+		cwd: "/work/pi-extensions",
+		model: { provider: "anthropic", id: "claude-sonnet-4-20250514" },
+		thinkingLevel: "high",
+		turnCount: 0,
+		activeTools: new Map(),
+		isStreaming: false,
+		contextUsage: undefined,
+		tokenTotals: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+		usingSubscription: false,
+		gitBranch: null,
+		gitStatus: {
+			ahead: 0,
+			behind: 0,
+			stashed: 0,
+			conflicted: 0,
+			deleted: 0,
+			renamed: 0,
+			modified: 0,
+			staged: 0,
+			typechanged: 0,
+			untracked: 0,
+			worktreeAdded: 0,
+			worktreeDeleted: 0,
+			worktreeModified: 0,
+			worktreeTypechanged: 0,
+			indexAdded: 0,
+			indexDeleted: 0,
+			indexModified: 0,
+			indexTypechanged: 0,
+		},
+		extensionStatuses: new Map(),
+		now: new Date(2026, 0, 1, 9, 5),
+		...overrides,
+	};
+}
+
+test("ansiToColorSpec parses 256-color and truecolor prefixes", () => {
+	assert.deepEqual(ansiToColorSpec(`${ESC}[38;5;80m`), { kind: "fixed", value: 80 });
+	assert.deepEqual(ansiToColorSpec(`${ESC}[38;2;178;148;187m`), {
+		kind: "rgb",
+		red: 178,
+		green: 148,
+		blue: 187,
+	});
+	assert.equal(ansiToColorSpec("plain"), undefined);
+	assert.equal(ansiToColorSpec(`${ESC}[38;5;999m`), undefined);
+	assert.equal(ansiToColorSpec(`${ESC}[39m`), undefined);
+});
+
+test("thinking uses the built-in dark gradient without a theme", () => {
+	const rendered = renderStatusline(normalizeConfig({}).config, fixture());
+	// #b294bb for the high level.
+	assert.ok(rendered.ansi.includes(`38;2;178;148;187`), rendered.ansi);
+});
+
+test("thinking follows the native theme colors when provided", () => {
+	const runtime = fixture({
+		thinkingTheme: {
+			high: { kind: "rgb", red: 255, green: 0, blue: 0 },
+		},
+	});
+	const rendered = renderStatusline(normalizeConfig({}).config, runtime);
+	assert.ok(rendered.ansi.includes(`38;2;255;0;0`), rendered.ansi);
+});
+
+test("thinking level styles override the theme colors", () => {
+	const { config } = normalizeConfig({
+		thinking: { style_high: "bold red", style_off: "dimmed blue" },
+	});
+	const rendered = renderStatusline(config, fixture());
+	assert.ok(rendered.ansi.includes("31;1m"), rendered.ansi);
+	const off = renderStatusline(config, fixture({ thinkingLevel: "off" }));
+	assert.match(off.ansi, /\[34;2m|\[2;34m/u, off.ansi);
+});
+
+test("unknown thinking levels fall back to the module style", () => {
+	const rendered = renderStatusline(normalizeConfig({}).config, fixture({ thinkingLevel: "deep" }));
+	assert.ok(rendered.ansi.includes("35;1m"), rendered.ansi);
+});
+
+test("model uses a deterministic hash color by default", () => {
+	const rendered = renderStatusline(normalizeConfig({}).config, fixture());
+	assert.match(rendered.ansi, /38;2;\d{1,3};\d{1,3};\d{1,3}(?:;\d+)*m/u, rendered.ansi);
+	const other = renderStatusline(
+		normalizeConfig({}).config,
+		fixture({ model: { provider: "openai", id: "gpt-5.6-sol" } }),
+	);
+	assert.notEqual(other.ansi, rendered.ansi);
+});
+
+test("model_styles exact ids win, then longest prefixes", () => {
+	const { config } = normalizeConfig({
+		model: {
+			model_styles: {
+				"claude-": "bold green",
+				"claude-sonnet-4-20250514": "bold red",
+			},
+		},
+	});
+	const exact = renderStatusline(config, fixture());
+	assert.ok(exact.ansi.includes("31;1m"), exact.ansi);
+	const prefixed = renderStatusline(
+		config,
+		fixture({ model: { provider: "anthropic", id: "claude-3-5-sonnet-20241022" } }),
+	);
+	assert.ok(prefixed.ansi.includes("32;1m"), prefixed.ansi);
+});
+
+test("invalid model_styles values are rejected with a warning", () => {
+	const { config, diagnostics } = normalizeConfig({
+		model: { model_styles: { "gpt-": "not a style", "gemini-": "bold cyan" } },
+	});
+	assert.ok(diagnostics.some((item) => item.path === "model.model_styles"));
+	const rendered = renderStatusline(
+		config,
+		fixture({ model: { provider: "openai", id: "gpt-5.6-sol" } }),
+	);
+	// gpt- mapping was rejected; the hash color still applies.
+	assert.match(rendered.ansi, /38;2;\d{1,3};\d{1,3};\d{1,3}(?:;\d+)*m/u, rendered.ansi);
+	const gemini = renderStatusline(
+		config,
+		fixture({ model: { provider: "google", id: "gemini-2.5-pro" } }),
+	);
+	assert.ok(gemini.ansi.includes("36;1m"), gemini.ansi);
+});
+
+test("provider_aliases rename the provider value", () => {
+	const { config } = normalizeConfig({
+		format: "$provider",
+		provider: { provider_aliases: { "openai-codex": "codex" } },
+	});
+	const rendered = renderStatusline(
+		config,
+		fixture({ model: { provider: "openai-codex", id: "gpt-5.6-sol" } }),
+	);
+	assert.ok(rendered.ansi.includes("codex"));
+	assert.ok(!rendered.ansi.includes("openai-codex"));
+});
+
+test("explicit model color stays fully user-controlled", () => {
+	const { config } = normalizeConfig({ model: { style: "bold red" } });
+	const rendered = renderStatusline(config, fixture());
+	assert.match(
+		rendered.ansi,
+		new RegExp(`${ESC}\\[31;1m🤖 sonnet-4 ${ESC}\\[0m`, "u"),
+		rendered.ansi,
+	);
+});
+
+test("hash_colors false keeps the module style", () => {
+	const { config } = normalizeConfig({ model: { hash_colors: false } });
+	const rendered = renderStatusline(config, fixture());
+	// The built-in bold blue stays; no hash color is emitted.
+	assert.ok(rendered.ansi.includes("34;1m"), rendered.ansi);
+	// model_styles still override the disabled hash.
+	const { config: overridden } = normalizeConfig({
+		model: { hash_colors: false, model_styles: { "claude-": "bold red" } },
+	});
+	const styled = renderStatusline(
+		overridden,
+		fixture({ model: { provider: "a", id: "claude-x" } }),
+	);
+	assert.ok(styled.ansi.includes("31;1m"), styled.ansi);
+});
+
+test("modifier-only model style receives the hash color", () => {
+	const { config } = normalizeConfig({ model: { style: "italic" } });
+	const rendered = renderStatusline(config, fixture());
+	assert.ok(rendered.ansi.includes(";3m"), rendered.ansi);
+	assert.match(rendered.ansi, /38;2;\d{1,3};\d{1,3};\d{1,3}(?:;\d+)*m/u, rendered.ansi);
+});
+
+test("legacy thinking style falls back for unknown levels only", () => {
+	const { config } = normalizeConfig({ thinking: { style: "bold purple" } });
+	const themed = renderStatusline(config, fixture({ thinkingLevel: "high" }));
+	// The theme role color wins for known levels.
+	assert.ok(themed.ansi.includes(`38;2;178;148;187`), themed.ansi);
+	const unknown = renderStatusline(config, fixture({ thinkingLevel: "deep" }));
+	assert.ok(unknown.ansi.includes("35;1m"), unknown.ansi);
+});


### PR DESCRIPTION
## Summary

- make `thinking` follow the current native Pi theme per level (`style_off` through `style_max` stay available as explicit overrides; the legacy `style` field remains the fallback for unknown levels)
- render `model` with a deterministic per-series hash color (same-series models share a hue, distinct models differ) with `model_styles` exact/prefix overrides and a `hash_colors` switch
- accept `provider_aliases` for provider display names

Each behavior stays inside its own module's format/style surface; the root format and per-module settings semantics are unchanged.

## Changeset

`minor`: thinking and model default colors change on upgrade; both remain user-configurable through the existing settings document.

## Verification

- `npm run check` passes (build, Biome, typecheck)
- 232 package tests pass; the remaining local failures are the known Windows path-separator baselines also present on `main`
- lazy boundary and rendered-entry tests retain the split-runtime loading behavior